### PR TITLE
Memory utilities

### DIFF
--- a/core/test/base/utils.cpp
+++ b/core/test/base/utils.cpp
@@ -40,25 +40,157 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 namespace {
 
 
-class Base {
-public:
+struct Base {
     virtual ~Base() = default;
 };
 
 
-class Derived : public Base {
+struct Derived : Base {
 };
 
 
-class NonRelated {
+struct NonRelated {
     virtual ~NonRelated() = default;
 };
+
+
+struct Clonable {
+    virtual ~Clonable() = default;
+    virtual std::unique_ptr<Base> clone() = 0;
+};
+
+
+struct ClonableDerived : Base, Clonable {
+    std::unique_ptr<Base> clone() override
+    {
+        return std::unique_ptr<Base>(new ClonableDerived());
+    }
+};
+
+
+TEST(Clone, ClonesUniquePointer)
+{
+    std::unique_ptr<ClonableDerived> p(new ClonableDerived());
+
+    auto clone = gko::clone(p);
+
+    ::testing::StaticAssertTypeEq<decltype(clone),
+                                  std::unique_ptr<ClonableDerived>>();
+    ASSERT_NE(p.get(), clone.get());
+}
+
+
+TEST(Clone, ClonesSharedPointer)
+{
+    std::shared_ptr<ClonableDerived> p(new ClonableDerived());
+
+    auto clone = gko::clone(p);
+
+    ::testing::StaticAssertTypeEq<decltype(clone),
+                                  std::unique_ptr<ClonableDerived>>();
+    ASSERT_NE(p.get(), clone.get());
+}
+
+
+TEST(Clone, ClonesPlainPointer)
+{
+    std::unique_ptr<ClonableDerived> p(new ClonableDerived());
+
+    auto clone = gko::clone(p.get());
+
+    ::testing::StaticAssertTypeEq<decltype(clone),
+                                  std::unique_ptr<ClonableDerived>>();
+    ASSERT_NE(p.get(), clone.get());
+}
+
+
+TEST(Share, SharesSharedPointer)
+{
+    std::shared_ptr<Derived> p(new Derived());
+    auto plain = p.get();
+
+    auto shared = gko::share(p);
+
+    ::testing::StaticAssertTypeEq<decltype(shared), std::shared_ptr<Derived>>();
+    ASSERT_EQ(plain, shared.get());
+}
+
+
+TEST(Share, SharesUniquePointer)
+{
+    std::unique_ptr<Derived> p(new Derived());
+    auto plain = p.get();
+
+    auto shared = gko::share(p);
+
+    ::testing::StaticAssertTypeEq<decltype(shared), std::shared_ptr<Derived>>();
+    ASSERT_EQ(plain, shared.get());
+}
+
+
+TEST(Give, GivesSharedPointer)
+{
+    std::shared_ptr<Derived> p(new Derived());
+    auto plain = p.get();
+
+    auto given = gko::give(p);
+
+    ::testing::StaticAssertTypeEq<decltype(given), std::shared_ptr<Derived>>();
+    ASSERT_EQ(plain, given.get());
+}
+
+
+TEST(Give, GivesUniquePointer)
+{
+    std::unique_ptr<Derived> p(new Derived());
+    auto plain = p.get();
+
+    auto given = gko::give(p);
+
+    ::testing::StaticAssertTypeEq<decltype(given), std::unique_ptr<Derived>>();
+    ASSERT_EQ(plain, given.get());
+}
+
+
+TEST(Lend, LendsUniquePointer)
+{
+    std::unique_ptr<Derived> p(new Derived());
+
+    auto lent = gko::lend(p);
+
+    ::testing::StaticAssertTypeEq<decltype(lent), Derived *>();
+    ASSERT_EQ(p.get(), lent);
+}
+
+
+TEST(Lend, LendsSharedPointer)
+{
+    std::shared_ptr<Derived> p(new Derived());
+
+    auto lent = gko::lend(p);
+
+    ::testing::StaticAssertTypeEq<decltype(lent), Derived *>();
+    ASSERT_EQ(p.get(), lent);
+}
+
+
+TEST(Lend, LendsPlainPointer)
+{
+    std::unique_ptr<Derived> p(new Derived());
+
+    auto lent = gko::lend(p.get());
+
+    ::testing::StaticAssertTypeEq<decltype(lent), Derived *>();
+    ASSERT_EQ(p.get(), lent);
+}
 
 
 TEST(As, ConvertsPolymorphicType)
 {
     Derived d;
+
     Base *b = &d;
+
     ASSERT_EQ(gko::as<Derived>(b), &d);
 }
 
@@ -67,6 +199,7 @@ TEST(As, FailsToConvertIfNotRelated)
 {
     Derived d;
     Base *b = &d;
+
     ASSERT_THROW(gko::as<NonRelated>(b), gko::NotSupported);
 }
 
@@ -75,6 +208,7 @@ TEST(As, ConvertsConstantPolymorphicType)
 {
     Derived d;
     const Base *b = &d;
+
     ASSERT_EQ(gko::as<Derived>(b), &d);
 }
 
@@ -83,6 +217,7 @@ TEST(As, FailsToConvertConstantIfNotRelated)
 {
     Derived d;
     const Base *b = &d;
+
     ASSERT_THROW(gko::as<NonRelated>(b), gko::NotSupported);
 }
 

--- a/examples/ginkgo_overhead/ginkgo_overhead.cpp
+++ b/examples/ginkgo_overhead/ginkgo_overhead.cpp
@@ -105,8 +105,8 @@ int main(int argc, char *argv[])
 
     auto tic = std::chrono::system_clock::now();
 
-    auto solver = cg_factory->generate(std::move(A));
-    solver->apply(x.get(), b.get());
+    auto solver = cg_factory->generate(gko::give(A));
+    solver->apply(gko::lend(x), gko::lend(b));
     exec->synchronize();
 
     auto tac = std::chrono::system_clock::now();

--- a/examples/preconditioned_solver/preconditioned_solver.cpp
+++ b/examples/preconditioned_solver/preconditioned_solver.cpp
@@ -89,7 +89,7 @@ int main(int argc, char *argv[])
     }
 
     // Read data
-    std::shared_ptr<mtx> A = gko::read<mtx>("data/A.mtx", exec);
+    auto A = gko::share(gko::read<mtx>("data/A.mtx", exec));
     auto b = gko::read<vec>("data/b.mtx", exec);
     auto x = gko::read<vec>("data/x0.mtx", exec);
 
@@ -103,11 +103,11 @@ int main(int argc, char *argv[])
     auto solver = solver_gen->generate(A);
 
     // Solve system
-    solver->apply(b.get(), x.get());
+    solver->apply(gko::lend(b), gko::lend(x));
 
     // Print result
     auto h_x = vec::create(exec->get_master());
-    h_x->copy_from(x.get());
+    h_x->copy_from(gko::lend(x));
     std::cout << "x = [" << std::endl;
     for (int i = 0; i < h_x->get_num_rows(); ++i) {
         std::cout << "    " << h_x->at(i, 0) << std::endl;
@@ -118,8 +118,8 @@ int main(int argc, char *argv[])
     auto one = gko::initialize<vec>({1.0}, exec);
     auto neg_one = gko::initialize<vec>({-1.0}, exec);
     auto res = gko::initialize<vec>({0.0}, exec);
-    A->apply(one.get(), x.get(), neg_one.get(), b.get());
-    b->compute_dot(b.get(), res.get());
+    A->apply(gko::lend(one), gko::lend(x), gko::lend(neg_one), gko::lend(b));
+    b->compute_dot(gko::lend(b), gko::lend(res));
 
     auto h_res = vec::create(exec->get_master());
     h_res->copy_from(std::move(res));

--- a/examples/preconditioned_solver/preconditioned_solver.cpp
+++ b/examples/preconditioned_solver/preconditioned_solver.cpp
@@ -106,8 +106,7 @@ int main(int argc, char *argv[])
     solver->apply(gko::lend(b), gko::lend(x));
 
     // Print result
-    auto h_x = vec::create(exec->get_master());
-    h_x->copy_from(gko::lend(x));
+    auto h_x = gko::clone_to(exec->get_master(), x);
     std::cout << "x = [" << std::endl;
     for (int i = 0; i < h_x->get_num_rows(); ++i) {
         std::cout << "    " << h_x->at(i, 0) << std::endl;
@@ -121,7 +120,6 @@ int main(int argc, char *argv[])
     A->apply(gko::lend(one), gko::lend(x), gko::lend(neg_one), gko::lend(b));
     b->compute_dot(gko::lend(b), gko::lend(res));
 
-    auto h_res = vec::create(exec->get_master());
-    h_res->copy_from(std::move(res));
+    auto h_res = gko::clone_to(exec->get_master(), res);
     std::cout << "res = " << std::sqrt(h_res->at(0, 0)) << ";" << std::endl;
 }

--- a/examples/simple_solver/simple_solver.cpp
+++ b/examples/simple_solver/simple_solver.cpp
@@ -89,7 +89,7 @@ int main(int argc, char *argv[])
     }
 
     // Read data
-    std::shared_ptr<mtx> A = gko::read<mtx>("data/A.mtx", exec);
+    auto A = gko::share(gko::read<mtx>("data/A.mtx", exec));
     auto b = gko::read<vec>("data/b.mtx", exec);
     auto x = gko::read<vec>("data/x0.mtx", exec);
 
@@ -98,11 +98,11 @@ int main(int argc, char *argv[])
     auto solver = solver_gen->generate(A);
 
     // Solve system
-    solver->apply(b.get(), x.get());
+    solver->apply(gko::lend(b), gko::lend(x));
 
     // Print result
     auto h_x = vec::create(exec->get_master());
-    h_x->copy_from(x.get());
+    h_x->copy_from(gko::lend(x));
     std::cout << "x = [" << std::endl;
     for (int i = 0; i < h_x->get_num_rows(); ++i) {
         std::cout << "    " << h_x->at(i, 0) << std::endl;
@@ -113,8 +113,8 @@ int main(int argc, char *argv[])
     auto one = gko::initialize<vec>({1.0}, exec);
     auto neg_one = gko::initialize<vec>({-1.0}, exec);
     auto res = gko::initialize<vec>({0.0}, exec);
-    A->apply(one.get(), x.get(), neg_one.get(), b.get());
-    b->compute_dot(b.get(), res.get());
+    A->apply(gko::lend(one), gko::lend(x), gko::lend(neg_one), gko::lend(b));
+    b->compute_dot(gko::lend(b), gko::lend(res));
 
     auto h_res = vec::create(exec->get_master());
     h_res->copy_from(std::move(res));

--- a/examples/simple_solver/simple_solver.cpp
+++ b/examples/simple_solver/simple_solver.cpp
@@ -101,8 +101,7 @@ int main(int argc, char *argv[])
     solver->apply(gko::lend(b), gko::lend(x));
 
     // Print result
-    auto h_x = vec::create(exec->get_master());
-    h_x->copy_from(gko::lend(x));
+    auto h_x = gko::clone_to(exec->get_master(), x);
     std::cout << "x = [" << std::endl;
     for (int i = 0; i < h_x->get_num_rows(); ++i) {
         std::cout << "    " << h_x->at(i, 0) << std::endl;
@@ -116,7 +115,6 @@ int main(int argc, char *argv[])
     A->apply(gko::lend(one), gko::lend(x), gko::lend(neg_one), gko::lend(b));
     b->compute_dot(gko::lend(b), gko::lend(res));
 
-    auto h_res = vec::create(exec->get_master());
-    h_res->copy_from(std::move(res));
+    auto h_res = gko::clone_to(exec->get_master(), res);
     std::cout << "res = " << std::sqrt(h_res->at(0, 0)) << ";" << std::endl;
 }


### PR DESCRIPTION
This implements #30.

It also updates the examples to use the new features.
If this is accepted, we'll have to do the same for the rest of the code, but this can happen gradually.

EDIT: Also implemented a related `gko::clone_to` wrapper around `LinOp::clone_to` which wasn't discussed in #30, but is related.
