### PR TITLE
Preconditioned solver example

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,2 +1,3 @@
 add_subdirectory(ginkgo_overhead)
+add_subdirectory(preconditioned_solver)
 add_subdirectory(simple_solver)

--- a/examples/preconditioned_solver/CMakeLists.txt
+++ b/examples/preconditioned_solver/CMakeLists.txt
@@ -1,0 +1,6 @@
+add_executable(preconditioned_solver preconditioned_solver.cpp)
+target_link_libraries(preconditioned_solver ginkgo)
+target_include_directories(preconditioned_solver PRIVATE ${PROJECT_SOURCE_DIR})
+configure_file(data/A.mtx data/A.mtx COPYONLY)
+configure_file(data/b.mtx data/b.mtx COPYONLY)
+configure_file(data/x0.mtx data/x0.mtx COPYONLY)

--- a/examples/preconditioned_solver/build.sh
+++ b/examples/preconditioned_solver/build.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+# set up script
+if [ $# -ne 1 ]; then
+    echo -e "Usage: $0 GINKGO_BUILD_DIRECTORY"
+    exit 1
+fi
+BUILD_DIR=$1
+THIS_DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" &>/dev/null && pwd )
+
+# copy libraries
+LIBRARY_DIRS="core core/device_hooks reference cpu gpu"
+LIBRARY_NAMES="ginkgo ginkgo_reference ginkgo_cpu ginkgo_gpu"
+SUFFIXES=".so .dylib .dll d.so d.dylib d.dll"
+for prefix in ${LIBRARY_DIRS}; do
+    for name in ${LIBRARY_NAMES}; do
+        for suffix in ${SUFFIXES}; do
+            cp ${BUILD_DIR}/${prefix}/lib${name}${suffix} \
+                ${THIS_DIR}/lib${name}${suffix} 2>/dev/null
+        done
+    done
+done
+
+# figure out correct compiler flags
+if ls ${THIS_DIR} | grep -F "libginkgo." >/dev/null; then
+    LINK_FLAGS="-lginkgo -lginkgo_cpu -lginkgo_gpu -lginkgo_reference"
+else
+    LINK_FLAGS="-lginkgod -lginkgo_cpud -lginkgo_gpud -lginkgo_referenced"
+fi
+if [ -z "${CXX}" ]; then
+    CXX="c++"
+fi
+
+# build
+${CXX} -std=c++11 -o ${THIS_DIR}/preconditioned_solver \
+    ${THIS_DIR}/preconditioned_solver.cpp \
+    -I${THIS_DIR}/../.. -L${THIS_DIR} ${LINK_FLAGS}

--- a/examples/preconditioned_solver/data/A.mtx
+++ b/examples/preconditioned_solver/data/A.mtx
@@ -1,0 +1,114 @@
+%%MatrixMarket matrix coordinate integer symmetric
+%-------------------------------------------------------------------------------
+% UF Sparse Matrix Collection, Tim Davis
+% http://www.cise.ufl.edu/research/sparse/matrices/JGD_Trefethen/Trefethen_20b
+% name: JGD_Trefethen/Trefethen_20b
+% [Diagonal matrices with primes, Nick Trefethen, Oxford Univ.]
+% id: 2203
+% date: 2008
+% author: N. Trefethen
+% ed: J.-G. Dumas
+% fields: name title A id date author ed kind notes
+% kind: combinatorial problem
+%-------------------------------------------------------------------------------
+% notes:
+% Diagonal matrices with primes, Nick Trefethen, Oxford Univ.          
+% From Jean-Guillaume Dumas' Sparse Integer Matrix Collection,         
+% http://ljk.imag.fr/membres/Jean-Guillaume.Dumas/simc.html            
+%                                                                      
+% Problem 7 of the Hundred-dollar, Hundred-digit Challenge Problems,   
+% SIAM News, vol 35, no. 1.                                            
+%                                                                      
+% 7. Let A be the 20,000 x 20,000 matrix whose entries are zero        
+% everywhere except for the primes 2, 3, 5, 7, . . . , 224737 along the
+% main diagonal and the number 1 in all the positions A(i,j) with      
+% |i-j| = 1,2,4,8, . . . ,16384.  What is the (1,1) entry of inv(A)?   
+%                                                                      
+% http://www.siam.org/news/news.php?id=388                             
+%                                                                      
+% Filename in JGD collection: Trefethen/trefethen_20__19_minor.sms     
+%-------------------------------------------------------------------------------
+19 19 83
+1 1 3
+2 1 1
+3 1 1
+5 1 1
+9 1 1
+17 1 1
+2 2 5
+3 2 1
+4 2 1
+6 2 1
+10 2 1
+18 2 1
+3 3 7
+4 3 1
+5 3 1
+7 3 1
+11 3 1
+19 3 1
+4 4 11
+5 4 1
+6 4 1
+8 4 1
+12 4 1
+5 5 13
+6 5 1
+7 5 1
+9 5 1
+13 5 1
+6 6 17
+7 6 1
+8 6 1
+10 6 1
+14 6 1
+7 7 19
+8 7 1
+9 7 1
+11 7 1
+15 7 1
+8 8 23
+9 8 1
+10 8 1
+12 8 1
+16 8 1
+9 9 29
+10 9 1
+11 9 1
+13 9 1
+17 9 1
+10 10 31
+11 10 1
+12 10 1
+14 10 1
+18 10 1
+11 11 37
+12 11 1
+13 11 1
+15 11 1
+19 11 1
+12 12 41
+13 12 1
+14 12 1
+16 12 1
+13 13 43
+14 13 1
+15 13 1
+17 13 1
+14 14 47
+15 14 1
+16 14 1
+18 14 1
+15 15 53
+16 15 1
+17 15 1
+19 15 1
+16 16 59
+17 16 1
+18 16 1
+17 17 61
+18 17 1
+19 17 1
+18 18 67
+19 18 1
+19 19 71

--- a/examples/preconditioned_solver/data/b.mtx
+++ b/examples/preconditioned_solver/data/b.mtx
@@ -1,0 +1,21 @@
+%%MatrixMarket matrix array real general
+19 1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1

--- a/examples/preconditioned_solver/data/x0.mtx
+++ b/examples/preconditioned_solver/data/x0.mtx
@@ -1,0 +1,21 @@
+%%MatrixMarket matrix array real general
+19 1
+0
+0
+0
+0
+0
+0
+0
+0
+0
+0
+0
+0
+0
+0
+0
+0
+0
+0
+0

--- a/examples/preconditioned_solver/preconditioned_solver.cpp
+++ b/examples/preconditioned_solver/preconditioned_solver.cpp
@@ -1,0 +1,130 @@
+/*******************************<GINKGO LICENSE>******************************
+Copyright 2017-2018
+
+Karlsruhe Institute of Technology
+Universitat Jaume I
+University of Tennessee
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice,
+   this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors
+   may be used to endorse or promote products derived from this software
+   without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+******************************<GINKGO LICENSE>*******************************/
+
+/*****************************<COMPILATION>***********************************
+The easiest way to build the example solver is to use the script provided:
+./build.sh <PATH_TO_GINKGO_BUILD_DIR>
+
+Ginkgo should be compiled with `-DBUILD_REFERENCE=on` option.
+
+Alternatively, you can setup the configuration manually:
+
+Go to the <PATH_TO_GINKGO_BUILD_DIR> directory and copy the shared
+libraries located in the following subdirectories:
+
+    + core/
+    + core/device_hooks/
+    + reference/
+    + cpu/
+    + gpu/
+
+to this directory.
+
+Then compile the file with the following command line:
+
+c++ -std=c++11 -o preconditioned_solver preconditioned_solver.cpp -I../.. \
+    -L. -lginkgo -lginkgo_reference -lginkgo_cpu -lginkgo_gpu
+
+(if ginkgo was built in debug mode, append 'd' to every library name)
+
+Now you should be able to run the program using:
+
+env LD_LIBRARY_PATH=.:${LD_LIBRARY_PATH} ./preconditioned_solver
+
+*****************************<COMPILATION>**********************************/
+
+#include <include/ginkgo.hpp>
+#include <iostream>
+#include <string>
+
+int main(int argc, char *argv[])
+{
+    // Some shortcuts
+    using vec = gko::matrix::Dense<>;
+    using mtx = gko::matrix::Csr<>;
+    using cg = gko::solver::CgFactory<>;
+
+    // Figure out where to run the code
+    std::shared_ptr<gko::Executor> exec;
+    if (argc == 1 || std::string(argv[1]) == "reference") {
+        exec = gko::ReferenceExecutor::create();
+    } else if (argc == 2 && std::string(argv[1]) == "cpu") {
+        exec = gko::CpuExecutor::create();
+    } else if (argc == 2 && std::string(argv[1]) == "gpu" &&
+               gko::GpuExecutor::get_num_devices() > 0) {
+        exec = gko::GpuExecutor::create(0, gko::CpuExecutor::create());
+    } else {
+        std::cerr << "Usage: " << argv[0] << " [executor]" << std::endl;
+        std::exit(-1);
+    }
+
+    // Read data
+    std::shared_ptr<mtx> A = mtx::create(exec);
+    A->read_from_mtx("data/A.mtx");
+    auto b = vec::create(exec);
+    b->read_from_mtx("data/b.mtx");
+    auto x = vec::create(exec);
+    x->read_from_mtx("data/x0.mtx");
+
+    // Create solver factory
+    auto solver_gen = cg::create(exec, 20, 1e-20);
+    // Add preconditioner, these 2 lines are the only difference from the
+    // simple solver example
+    using bj = gko::preconditioner::BlockJacobiFactory<>;
+    solver_gen->set_preconditioner(bj::create(exec, 8));
+    // Create solver
+    auto solver = solver_gen->generate(A);
+
+    // Solve system
+    solver->apply(b.get(), x.get());
+
+    // Print result
+    auto h_x = vec::create(exec->get_master());
+    h_x->copy_from(x.get());
+    std::cout << "x = [" << std::endl;
+    for (int i = 0; i < h_x->get_num_rows(); ++i) {
+        std::cout << "    " << h_x->at(i, 0) << std::endl;
+    }
+    std::cout << "];" << std::endl;
+
+    // Calculate residual
+    auto one = gko::initialize<vec>({1.0}, exec);
+    auto neg_one = gko::initialize<vec>({-1.0}, exec);
+    auto res = gko::initialize<vec>({0.0}, exec);
+    A->apply(one.get(), x.get(), neg_one.get(), b.get());
+    b->compute_dot(b.get(), res.get());
+
+    auto h_res = vec::create(exec->get_master());
+    h_res->copy_from(std::move(res));
+    std::cout << "res = " << std::sqrt(h_res->at(0, 0)) << ";" << std::endl;
+}

--- a/include/ginkgo.hpp
+++ b/include/ginkgo.hpp
@@ -37,6 +37,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "core/matrix/csr.hpp"
 #include "core/matrix/dense.hpp"
+#include "core/preconditioner/block_jacobi.hpp"
 #include "core/solver/cg.hpp"
 
 


### PR DESCRIPTION
This is something @hartwiganzt has been asking me to add for a while, and since today even @venovako requested it, I finally took some time and added the example of a solver which also uses a preconditioner. It needed 2 extra lines of code (103 and 104) compared to the simple solver example (I could have made it 1 slightly longer line :smile:).

Note that it doesn't work on GPU, since we don't have diagonal block detection for GPUs yet. And I don't have to tell you why it doesn't work on the CPU. So for now, you can run it with the reference implementation.

@hartwiganzt maybe you should add the block detection algorithm as soon as possible, so we have a complete implementation of at least one preconditioner.
