### PR TITLE
Generation script improvements

### DIFF
--- a/dev_tools/scripts/create_new_algorithm.sh
+++ b/dev_tools/scripts/create_new_algorithm.sh
@@ -241,18 +241,20 @@ then
                 mv tmp $cmake_file
             elif [[ $cmake_file != "${GINKGO_ROOT_DIR}/" ]]
             then
-                list=( $(awk '/set\(SOURCES/,/.*)/ { if ($0 != "set(SOURCES"){ print $0 }}'  $cmake_file) )
-                list[-1]=$(echo ${list[-1]} | tr -d ')')
+                list=( $(awk '/set\(SOURCES/,/)/ { if ($0 != "set(SOURCES"){ print $0 }}'  $cmake_file) )
+                last_elem=$((${#list[@]}-1))
+                list[$last_elem]=$(echo ${list[$last_elem]} | tr -d ')')
                 list+=( "$source_type/${TEMPLATE_FILES[$i-1]}" )
                 IFS=$'\n' sorted=($(sort <<<"${list[*]}"))
                 unset IFS
-                sorted[-1]=$(echo ${sorted[-1]}")")
+                last_elem=$((${#sorted[@]}-1))
+                sorted[$last_elem]=$(echo ${sorted[$last_elem]}")")
 
                 ## find the correct position
                 insert_to=$(grep -n "set(SOURCES" $cmake_file | sed 's/:.*//')
 
                 ## clear up the CMakeList.txt
-                awk '/set\(SOURCES/,/    .*)/ { if ($0 == "set(SOURCES"){ print $0 }; next}1'  $cmake_file > tmp
+                awk '/set\(SOURCES/,/)/ { if ($0 == "set(SOURCES"){ print $0 }; next}1'  $cmake_file > tmp
 
                 mytmp=`mktemp`
                 head -n$insert_to tmp > $mytmp

--- a/dev_tools/scripts/create_new_algorithm.sh
+++ b/dev_tools/scripts/create_new_algorithm.sh
@@ -1,9 +1,8 @@
 #!/usr/bin/env bash
 
-set -xv
-
 # Important script variable
 execute=1
+automatic_additions=1
 TMPDIR="./tmp_$(date +%s)"
 THIS_DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" &>/dev/null && pwd )
 GINKGO_ROOT_DIR="${THIS_DIR}/../.."
@@ -14,6 +13,7 @@ function print_help {
     echo -e "\t--dry-run: does a dry run"
     echo -e "\t--help: prints this help"
     echo -e "\t--list: prints the list of possible models"
+    echo -e "\t--no-automatic-additions: do not automatically add generated files to CMakeFiles or common_kernels.inc.cpp file"
     echo -e ""
     echo -e "This script generates a new solver or preconditioner from an"
     echo -e "existing model identified thanks to the --list argument."
@@ -29,24 +29,6 @@ function list_sources {
             echo "$type "$(basename "$i" | cut -d"." -f1)
         done
     done
-}
-
-function insert_at_position {
-    insert_to="$1"
-    destination="$2"
-    text="${@:3}"
-    mytmp=`mktemp`
-
-    ## extract the lines before position
-    head -n$insert_to $destination > $mytmp
-    ## insert the list
-    for line in $text
-    do
-        echo "    $line" >> $mytmp
-    done
-    ## append the rest of the file
-    tail -n +$((insert_to+1)) $destination >> $mytmp
-    mv $mytmp $destination
 }
 
 if [ $# -lt 1 ]; then
@@ -68,6 +50,9 @@ do
         --list)
             list_sources
             exit 1
+            ;;
+        --no-automatic-additions)
+            automatic_additions=0
             ;;
         --*)
             echo -e "bad option $1"
@@ -212,7 +197,7 @@ do
 
 
     # Comment all code
-    awk '/^{$/,/^}$/ { if ($0 == "{"){ print "NOT_IMPLEMENTED;"; print "//" $0; print "// TODO: Change code imported from source"; next} else { print "//" $0; next }} 1' ${TMPDIR}/$destpath > tmp
+    awk '/^{$/,/^}$/ { if ($0 == "{"){ print "NOT_IMPLEMENTED;"; print "//" $0; print "// TODO (script): change the code imported from '${source_type}'/'${source_name}' if needed"; next} else { print "//" $0; next }} 1' ${TMPDIR}/$destpath > tmp
     mv tmp  ${TMPDIR}/$destpath
 
     ls ${TMPDIR}/$destpath
@@ -241,37 +226,86 @@ then
     rm -rf ${TMPDIR}
 
 
-    ## Try to automatically add the files to CMakeLists
-    for ((i=1; i<=${#CMAKE_FILES}; i++))
-    do
-        cmake_file="${GINKGO_ROOT_DIR}/${CMAKE_FILES[$i]}"
-        if [[ $cmake_file == *"test/"* ]]
-        then
-            insert=$(grep "$source_name" $cmake_file | sed "s/$source_name/$name/")
-            echo "$insert" >> $cmake_file
-            cat $cmake_file | sort > tmp
-            mv tmp $cmake_file
-        elif [[ $cmake_file != "${GINKGO_ROOT_DIR}/" ]]
-        then
-            list=( $(awk '/set\(SOURCES/,/.*)/ { if ($0 != "set(SOURCES"){ print $0 }}'  $cmake_file) )
-            list[-1]=$(echo ${list[-1]} | tr -d ')')
-            list+=( "$source_type/${TEMPLATE_FILES[$i]}" )
-            IFS=$'\n' sorted=($(sort <<<"${list[*]}"))
-            unset IFS
-            sorted[-1]=$(echo ${sorted[-1]}")")
+    if [ $automatic_additions -eq 1 ]
+    then
+        ## Try to automatically add the files to CMakeLists
+        echo -e "Modifiying CMakeLists.txt and common_kernels.inc.cpp"
+        for ((i=1; i<=${#CMAKE_FILES[@]}; i++))
+        do
+            cmake_file="${GINKGO_ROOT_DIR}/${CMAKE_FILES[$i-1]}"
+            if [[ $cmake_file == *"test/"* ]]
+            then
+                insert=$(grep "$source_name" $cmake_file | sed "s/$source_name/$name/")
+                echo "$insert" >> $cmake_file
+                cat $cmake_file | sort > tmp
+                mv tmp $cmake_file
+            elif [[ $cmake_file != "${GINKGO_ROOT_DIR}/" ]]
+            then
+                list=( $(awk '/set\(SOURCES/,/.*)/ { if ($0 != "set(SOURCES"){ print $0 }}'  $cmake_file) )
+                list[-1]=$(echo ${list[-1]} | tr -d ')')
+                list+=( "$source_type/${TEMPLATE_FILES[$i-1]}" )
+                IFS=$'\n' sorted=($(sort <<<"${list[*]}"))
+                unset IFS
+                sorted[-1]=$(echo ${sorted[-1]}")")
 
-            ## find the correct position
-            insert_to=$(grep -n "set(SOURCES" $cmake_file | sed 's/:.*//')
+                ## find the correct position
+                insert_to=$(grep -n "set(SOURCES" $cmake_file | sed 's/:.*//')
 
-            ## clear up the CMakeList.txt
-            awk '/set\(SOURCES/,/    .*)/ { if ($0 == "set(SOURCES"){ print $0 }; next}1'  $cmake_file > tmp
+                ## clear up the CMakeList.txt
+                awk '/set\(SOURCES/,/    .*)/ { if ($0 == "set(SOURCES"){ print $0 }; next}1'  $cmake_file > tmp
 
-            insert_at_position "${insert_to}" "tmp" "${sorted[@]}"
+                mytmp=`mktemp`
+                head -n$insert_to tmp > $mytmp
+                for line in "${sorted[@]}"
+                do
+                    echo "    $line" >> $mytmp
+                done
+                tail -n +$((insert_to+1)) tmp >> $mytmp
+                mv $mytmp tmp
+                mv tmp $cmake_file
+            fi
+        done
 
-            ## cleanup
-            mv tmp $cmake_file
-        fi
-    done
+
+        ## Automatically duplicate the entry of common_kernels.inc.cpp
+        common_kernels_file="${GINKGO_ROOT_DIR}/core/device_hooks/common_kernels.inc.cpp"
+        # add the new kernel file to headers
+        headers=( "$(grep '#include' $common_kernels_file)" )
+        headers+=( "#include \"core/${source_type}/${name}_kernels.hpp\"")
+        IFS=$'\n' headers_sorted=($(sort <<<"${headers[*]}"))
+        unset IFS
+        header_block_begin=$(grep -n "#include" $common_kernels_file | head -n1 | sed 's/:.*//')
+        grep -v '#include' $common_kernels_file > tmp
+
+        mytmp=`mktemp`
+        head -n$header_block_begin tmp > $mytmp
+        for line in "${headers_sorted[@]}"
+        do
+            echo "$line" >> $mytmp
+        done
+        tail -n +$((header_block_begin+1)) tmp >> $mytmp
+        mv $mytmp tmp
+        mv tmp $common_kernels_file
+
+        ## Automatically duplicate common_kernels.inc.cpp code block
+        IFS=$'\n'
+        GLOB_IGNORE='*'
+        old_code_block=( "$(awk '/namespace '${source_name}' {/,/}  \/\/ namespace '${source_name}'/ {print $0}' $common_kernels_file)" )
+        # code_block=( $(echo "${code_block[@]}" ) )
+        unset IFS
+        unset GLOB_IGNORE
+        old_code_block_end=$(grep -n "}  // namespace ${source_name}" $common_kernels_file | sed 's/:.*//')
+
+        mytmp=`mktemp`
+        head -n$old_code_block_end $common_kernels_file > $mytmp
+        echo -e "\n\n// TODO (script): adapt this block as needed" >> $mytmp
+        for line in "${old_code_block[@]}"
+        do
+            echo -e "$line" | sed "s/${source_name^^}/$NAME/g" | sed "s/${source_name}/$name/g" >> $mytmp
+        done
+        tail -n +$((old_code_block_end+1)) $common_kernels_file >> $mytmp
+        mv $mytmp $common_kernels_file
+    fi
 else
     echo -e "\nNo file was copied because --dry-run was used"
     echo -e "You can inspect the generated solver files in ${TMPDIR}."
@@ -295,48 +329,63 @@ do
     echo ""                                              | tee -a todo_${name}.txt
 done
 
-echo -e "In all of the previous files ${sourcename} was automatically replaced into ${name}. Ensure there is no inconsistency."    | tee -a todo_${name}.txt
-echo -e ""                                     | tee -a todo_${name}.txt
-echo -e "Caution, due to conversions you may also need to either implant all conversions in other classes similarly to ${sourcename}, or to drop the conversions alltogether."    | tee -a todo_${name}.txt
-echo -e ""                                                                         | tee -a todo_${name}.txt
+if [ $automatic_additions -eq 1 ]
+then
+    for (( i=1; i<${#CMAKE_FILES[@]}+1; i++ ))
+    do
+        if [[ "${CMAKE_FILES[$i-1]}" != "" ]]
+        then
+            echo "Modified ${CMAKE_FILES[$i-1]}"                 | tee -a todo_${name}.txt
+        fi
+    done
+    echo "Modified core/device_hooks/common_kernels.inc.cpp"     | tee -a todo_${name}.txt
+fi
 
-echo "All tests have to be modified to the specific ${source_type} characteristics."    | tee -a todo_${name}.txt
-echo ""                                                                         | tee -a todo_${name}.txt
-echo ""                                                                         | tee -a todo_${name}.txt
-echo "The following CMakeLists have to be modified manually:"                   | tee -a todo_${name}.txt
-echo "core/CMakeLists.txt"                                                      | tee -a todo_${name}.txt
-echo "core/test/${source_type}/CMakeLists.txt"                                          | tee -a todo_${name}.txt
-echo ""                                                                         | tee -a todo_${name}.txt
-echo "reference/CMakeLists.txt"                                                 | tee -a todo_${name}.txt
-echo "reference/test/${source_type}/CMakeLists.txt"                                     | tee -a todo_${name}.txt
-echo ""                                                                         | tee -a todo_${name}.txt
-echo "cpu/CMakeLists.txt"                                                       | tee -a todo_${name}.txt
-echo "cpu/test/${source_type}/CMakeLists.txt"                                           | tee -a todo_${name}.txt
-echo ""                                                                         | tee -a todo_${name}.txt
-echo "gpu/CMakeLists.txt"                                                       | tee -a todo_${name}.txt
-echo "gpu/test/${source_type}/CMakeLists.txt"                                           | tee -a todo_${name}.txt
-echo ""                                                                         | tee -a todo_${name}.txt
-echo ""                                                                         | tee -a todo_${name}.txt
-echo "The following header file has to modified:"                               | tee -a todo_${name}.txt
-echo "core/device_hooks/common_kernels.inc.cpp"                                 | tee -a todo_${name}.txt
-echo "Equivalent to the other solvers, the following part has to be appended:"  | tee -a todo_${name}.txt
-echo "##################################################" | tee -a todo_${name}.txt
-echo "#include #include \"core/solver/test_kernels.hpp\"" | tee -a todo_${name}.txt
-echo "// ..."                                             | tee -a todo_${name}.txt
-echo "namespace  ${name} {"                               | tee -a todo_${name}.txt
-echo ""                                                   | tee -a todo_${name}.txt
-echo ""                                                   | tee -a todo_${name}.txt
-echo "// template <typename ValueType>"                   | tee -a todo_${name}.txt
-echo "// GKO_DECLARE_${NAME}_INITIALIZE_KERNEL(ValueType)"| tee -a todo_${name}.txt
-echo "// NOT_COMPILED(GKO_HOOK_MODULE);"                  | tee -a todo_${name}.txt
-echo "// GKO_INSTANTIATE_FOR_EACH_VALUE_TYPE(GKO_DECLARE_${NAME}_INITIALIZE_KERNEL);" | tee -a todo_${name}.txt
-echo ""                                                   | tee -a todo_${name}.txt
-echo "// ..."                                             | tee -a todo_${name}.txt
-echo ""                                                   | tee -a todo_${name}.txt
-echo ""                                                   | tee -a todo_${name}.txt
-echo "}  // namespace ${name}"                            | tee -a todo_${name}.txt
-echo "##################################################" | tee -a todo_${name}.txt
-echo ""                                                   | tee -a todo_${name}.txt
-echo ""                                                   | tee -a todo_${name}.txt
+echo -e "In all of the previous files ${sourcename} was automatically replaced into ${name}. Ensure there is no inconsistency."                               | tee -a todo_${name}.txt
+echo -e ""                                                       | tee -a todo_${name}.txt
+echo -e "All the imported code was commented and TODO items were generated in the new files." | tee -a todo_${name}.txt
+echo -e "Check all the modified files for '// TODO (script):' items"| tee -a todo_${name}.txt
+echo -e "e.g. by using grep -HR '// TODO (script):' ${GINKGO_ROOT_DIR}"| tee -a todo_${name}.txt
+echo ""                                                          | tee -a todo_${name}.txt
+
+if [ $automatic_additions -eq 0 ]
+then
+    echo ""                                                                         | tee -a todo_${name}.txt
+    echo "The following CMakeLists have to be modified manually:"                   | tee -a todo_${name}.txt
+    echo "core/CMakeLists.txt"                                                      | tee -a todo_${name}.txt
+    echo "core/test/${source_type}/CMakeLists.txt"                                          | tee -a todo_${name}.txt
+    echo ""                                                                         | tee -a todo_${name}.txt
+    echo "reference/CMakeLists.txt"                                                 | tee -a todo_${name}.txt
+    echo "reference/test/${source_type}/CMakeLists.txt"                                     | tee -a todo_${name}.txt
+    echo ""                                                                         | tee -a todo_${name}.txt
+    echo "cpu/CMakeLists.txt"                                                       | tee -a todo_${name}.txt
+    echo "cpu/test/${source_type}/CMakeLists.txt"                                           | tee -a todo_${name}.txt
+    echo ""                                                                         | tee -a todo_${name}.txt
+    echo "gpu/CMakeLists.txt"                                                       | tee -a todo_${name}.txt
+    echo "gpu/test/${source_type}/CMakeLists.txt"                                           | tee -a todo_${name}.txt
+    echo ""                                                                         | tee -a todo_${name}.txt
+    echo ""                                                                         | tee -a todo_${name}.txt
+    echo "The following header file has to modified:"                               | tee -a todo_${name}.txt
+    echo "core/device_hooks/common_kernels.inc.cpp"                                 | tee -a todo_${name}.txt
+    echo "Equivalent to the other solvers, the following part has to be appended:"  | tee -a todo_${name}.txt
+    echo "##################################################" | tee -a todo_${name}.txt
+    echo "#include #include \"core/solver/test_kernels.hpp\"" | tee -a todo_${name}.txt
+    echo "// ..."                                             | tee -a todo_${name}.txt
+    echo "namespace  ${name} {"                               | tee -a todo_${name}.txt
+    echo ""                                                   | tee -a todo_${name}.txt
+    echo ""                                                   | tee -a todo_${name}.txt
+    echo "// template <typename ValueType>"                   | tee -a todo_${name}.txt
+    echo "// GKO_DECLARE_${NAME}_INITIALIZE_KERNEL(ValueType)"| tee -a todo_${name}.txt
+    echo "// NOT_COMPILED(GKO_HOOK_MODULE);"                  | tee -a todo_${name}.txt
+    echo "// GKO_INSTANTIATE_FOR_EACH_VALUE_TYPE(GKO_DECLARE_${NAME}_INITIALIZE_KERNEL);" | tee -a todo_${name}.txt
+    echo ""                                                   | tee -a todo_${name}.txt
+    echo "// ..."                                             | tee -a todo_${name}.txt
+    echo ""                                                   | tee -a todo_${name}.txt
+    echo ""                                                   | tee -a todo_${name}.txt
+    echo "}  // namespace ${name}"                            | tee -a todo_${name}.txt
+    echo "##################################################" | tee -a todo_${name}.txt
+    echo ""                                                   | tee -a todo_${name}.txt
+    echo ""                                                   | tee -a todo_${name}.txt
+fi
 echo "A summary of the required next steps has been written to:"
 echo "todo_${name}.txt"

--- a/dev_tools/scripts/create_new_algorithm.sh
+++ b/dev_tools/scripts/create_new_algorithm.sh
@@ -241,7 +241,7 @@ then
                 mv tmp $cmake_file
             elif [[ $cmake_file != "${GINKGO_ROOT_DIR}/" ]]
             then
-                list=( $(awk '/set\(SOURCES/,/)/ { if ($0 != "set(SOURCES"){ print $0 }}'  $cmake_file) )
+                list=( $(awk '/set\(SOURCES/,/    .*\)/ { if ($0 != "set(SOURCES"){ print $0 }}'  $cmake_file) )
                 last_elem=$((${#list[@]}-1))
                 list[$last_elem]=$(echo ${list[$last_elem]} | tr -d ')')
                 list+=( "$source_type/${TEMPLATE_FILES[$i-1]}" )
@@ -254,7 +254,7 @@ then
                 insert_to=$(grep -n "set(SOURCES" $cmake_file | sed 's/:.*//')
 
                 ## clear up the CMakeList.txt
-                awk '/set\(SOURCES/,/)/ { if ($0 == "set(SOURCES"){ print $0 }; next}1'  $cmake_file > tmp
+                awk '/set\(SOURCES/,/    .*\)/ { if ($0 == "set(SOURCES"){ print $0 }; next}1'  $cmake_file > tmp
 
                 mytmp=`mktemp`
                 head -n$insert_to tmp > $mytmp
@@ -280,12 +280,12 @@ then
         grep -v '#include' $common_kernels_file > tmp
 
         mytmp=`mktemp`
-        head -n$header_block_begin tmp > $mytmp
+        head -n$((header_block_begin-1)) tmp > $mytmp
         for line in "${headers_sorted[@]}"
         do
             echo "$line" >> $mytmp
         done
-        tail -n +$((header_block_begin+1)) tmp >> $mytmp
+        tail -n +$((header_block_begin)) tmp >> $mytmp
         mv $mytmp tmp
         mv tmp $common_kernels_file
 

--- a/gpu/matrix/csr_kernels.cu
+++ b/gpu/matrix/csr_kernels.cu
@@ -73,7 +73,7 @@ void spmv(std::shared_ptr<const GpuExecutor> exec,
 
     cusparse::destroy(descr);
     cusparse::destroy(handle);
-};
+}
 
 GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(GKO_DECLARE_CSR_SPMV_KERNEL);
 
@@ -103,7 +103,7 @@ void advanced_spmv(std::shared_ptr<const GpuExecutor> exec,
 
     cusparse::destroy(descr);
     cusparse::destroy(handle);
-};
+}
 
 GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
     GKO_DECLARE_CSR_ADVANCED_SPMV_KERNEL);
@@ -153,7 +153,7 @@ void transpose(std::shared_ptr<const GpuExecutor> exec,
                         copyValues, idxBase);
 
     cusparse::destroy(handle);
-};
+}
 
 
 GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(GKO_DECLARE_CSR_TRANSPOSE_KERNEL);
@@ -202,7 +202,7 @@ void conj_transpose(std::shared_ptr<const GpuExecutor> exec,
 
     conjugate_kernel<<<grid_size, block_size, 0, 0>>>(
         trans->get_num_stored_elements(), as_cuda_type(trans->get_values()));
-};
+}
 
 GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
     GKO_DECLARE_CSR_CONJ_TRANSPOSE_KERNEL);


### PR DESCRIPTION
I took some time today to do the changes requested to the script so that the next solver/preconditioner/matrix addition to Ginkgo are hopefully much faster. For that, I added some new fancy things:
1. Comment out all imported code, add NOT_IMPLEMENTED and TODO items
2. Automatically add the generated files to all the CMakeLists (keep everything sorted)
3. Automatically add all the required lines to common_kernels.inc.cpp for the new solver/preconditioner/matrix. Thanks to this, the code should compile without having to do anything. 
4. I added a switch to the script to disable the automatic modifications so that it's possible to do everything by hand similarly to before if there is some sort of problem.

I would like some feedback, in particular for mac users @hartwiganzt because maybe some commands are missing or without some particular arguments.

Closes #25