### PR TITLE
increase the default vector size testing the GPU kernels for the solvers

### DIFF
--- a/gpu/test/solver/bicgstab_kernels.cpp
+++ b/gpu/test/solver/bicgstab_kernels.cpp
@@ -88,7 +88,7 @@ protected:
 
     void initialize_data()
     {
-        int m = 48;
+        int m = 597;
         int n = 17;
         x = gen_mtx(m, n);
         b = gen_mtx(m, n);

--- a/gpu/test/solver/cg_kernels.cpp
+++ b/gpu/test/solver/cg_kernels.cpp
@@ -78,7 +78,7 @@ protected:
 
     void initialize_data()
     {
-        int m = 97;
+        int m = 597;
         int n = 43;
         b = gen_mtx(m, n);
         r = gen_mtx(m, n);

--- a/gpu/test/solver/cgs_kernels.cpp
+++ b/gpu/test/solver/cgs_kernels.cpp
@@ -79,14 +79,14 @@ protected:
     std::unique_ptr<Mtx> gen_mtx(int num_rows, int num_cols)
     {
         return gko::test::generate_random_matrix<Mtx>(
-            ref, num_rows, num_cols,
+            num_rows, num_cols,
             std::uniform_int_distribution<>(num_cols, num_cols),
-            std::normal_distribution<>(-1.0, 1.0), rand_engine);
+            std::normal_distribution<>(0.0, 1.0), rand_engine, ref);
     }
 
     void initialize_data()
     {
-        int m = 97;
+        int m = 597;
         int n = 43;
         b = gen_mtx(m, n);
         r = gen_mtx(m, n);

--- a/gpu/test/solver/fcg_kernels.cpp
+++ b/gpu/test/solver/fcg_kernels.cpp
@@ -73,12 +73,12 @@ protected:
         return gko::test::generate_random_matrix<Mtx>(
             num_rows, num_cols,
             std::uniform_int_distribution<>(num_cols, num_cols),
-            std::normal_distribution<>(-1.0, 1.0), rand_engine, ref);
+            std::normal_distribution<>(0.0, 1.0), rand_engine, ref);
     }
 
     void initialize_data()
     {
-        int m = 97;
+        int m = 597;
         int n = 43;
         b = gen_mtx(m, n);
         r = gen_mtx(m, n);


### PR DESCRIPTION
In this bugfix I increase the default vector size to 597. This is larger than the default thread block size (512), the purpose of the size increase is to check correctness when launching multiple blocks.
With at most 43 column, this can result in a memory requirement of 20 MB. I feel this is acceptable: if people want to use the GPU back-end, they need a device featuring that amount of memory.