### PR TITLE
fix the CGS tester by modifying the call to the matrix generator

### DIFF
--- a/gpu/test/solver/cgs_kernels.cpp
+++ b/gpu/test/solver/cgs_kernels.cpp
@@ -79,9 +79,9 @@ protected:
     std::unique_ptr<Mtx> gen_mtx(int num_rows, int num_cols)
     {
         return gko::test::generate_random_matrix<Mtx>(
-            ref, num_rows, num_cols,
+            num_rows, num_cols,
             std::uniform_int_distribution<>(num_cols, num_cols),
-            std::normal_distribution<>(-1.0, 1.0), rand_engine);
+            std::normal_distribution<>(0.0, 1.0), rand_engine, ref);
     }
 
     void initialize_data()


### PR DESCRIPTION
The executor (in this case "ref") has to go to the end of the matrix generator call. I am not sure how this got into the develop branch without anybody noticing. this should fix the bug.