### PR TITLE
possibility to generate a checkered matrix

### DIFF
--- a/core/base/matrix_data.hpp
+++ b/core/base/matrix_data.hpp
@@ -290,6 +290,33 @@ struct matrix_data {
     }
 
     /**
+     * Initializes a checkered matrix.
+     *
+     * @param num_block_rows  number of block-rows
+     * @param num_block_cols  number of block-columns
+     * @param diag_block  matrix used to fill diagonal blocks
+     */
+    static matrix_data checkered(size_type num_block_rows,
+                                 size_type num_block_cols,
+                                 const matrix_data &block)
+    {
+        matrix_data res(num_block_rows * block.num_rows,
+                        num_block_cols * block.num_cols);
+        const auto num_blocks = num_block_rows * num_block_cols;
+        res.nonzeros.reserve(num_blocks * block.nonzeros.size());
+        for (int row = 0; row < num_block_rows; ++row) {
+            for (int col = 0; col < num_block_cols; ++col) {
+                for (const auto &elem : block.nonzeros) {
+                    res.nonzeros.emplace_back(
+                        row * block.num_rows + elem.row,
+                        col * block.num_cols + elem.column, elem.value);
+                }
+            }
+        }
+        return res;
+    }
+
+    /**
      * Total number of rows of the matrix.
      */
     size_type num_rows;

--- a/core/test/base/matrix_data.cpp
+++ b/core/test/base/matrix_data.cpp
@@ -203,4 +203,40 @@ TEST(MatrixData, InitializesBlockDiagonalMatrix)
 }
 
 
+TEST(MatrixData, InitializesCheckeredMatrix)
+{
+    using data = gko::matrix_data<double, int>;
+    using nnz = data::nonzero_type;
+    const auto m = data::checkered(3, 2, {{1.0, 2.0}, {3.0, 4.0}});
+
+    ASSERT_EQ(m.num_rows, 6);
+    ASSERT_EQ(m.num_cols, 4);
+    ASSERT_EQ(m.nonzeros.size(), 24);
+    EXPECT_EQ(m.nonzeros[0], nnz(0, 0, 1.0));
+    EXPECT_EQ(m.nonzeros[1], nnz(0, 1, 2.0));
+    EXPECT_EQ(m.nonzeros[2], nnz(1, 0, 3.0));
+    EXPECT_EQ(m.nonzeros[3], nnz(1, 1, 4.0));
+    EXPECT_EQ(m.nonzeros[4], nnz(0, 2, 1.0));
+    EXPECT_EQ(m.nonzeros[5], nnz(0, 3, 2.0));
+    EXPECT_EQ(m.nonzeros[6], nnz(1, 2, 3.0));
+    EXPECT_EQ(m.nonzeros[7], nnz(1, 3, 4.0));
+    EXPECT_EQ(m.nonzeros[8], nnz(2, 0, 1.0));
+    EXPECT_EQ(m.nonzeros[9], nnz(2, 1, 2.0));
+    EXPECT_EQ(m.nonzeros[10], nnz(3, 0, 3.0));
+    EXPECT_EQ(m.nonzeros[11], nnz(3, 1, 4.0));
+    EXPECT_EQ(m.nonzeros[12], nnz(2, 2, 1.0));
+    EXPECT_EQ(m.nonzeros[13], nnz(2, 3, 2.0));
+    EXPECT_EQ(m.nonzeros[14], nnz(3, 2, 3.0));
+    EXPECT_EQ(m.nonzeros[15], nnz(3, 3, 4.0));
+    EXPECT_EQ(m.nonzeros[16], nnz(4, 0, 1.0));
+    EXPECT_EQ(m.nonzeros[17], nnz(4, 1, 2.0));
+    EXPECT_EQ(m.nonzeros[18], nnz(5, 0, 3.0));
+    EXPECT_EQ(m.nonzeros[19], nnz(5, 1, 4.0));
+    EXPECT_EQ(m.nonzeros[20], nnz(4, 2, 1.0));
+    EXPECT_EQ(m.nonzeros[21], nnz(4, 3, 2.0));
+    EXPECT_EQ(m.nonzeros[22], nnz(5, 2, 3.0));
+    EXPECT_EQ(m.nonzeros[23], nnz(5, 3, 4.0));
+}
+
+
 }  // namespace


### PR DESCRIPTION
This merge requests adds the functionality to generate a checkered matrix out of a matrix block.

For a matrix block A, the function replicates this block in the form:
        /  A  A  A  A \
B =  |  A  A  A  A  |
        \ A  A  A  A /