### PR TITLE
fix claculate_max_nonzeros_per_row

### DIFF
--- a/core/matrix/ell.cpp
+++ b/core/matrix/ell.cpp
@@ -75,7 +75,7 @@ size_type calculate_max_nonzeros_per_row(
         }
         nnz += (elem.value != zero<ValueType>());
     }
-    return max_nonzeros_per_row;
+    return std::max(max_nonzeros_per_row, nnz);
 }
 
 


### PR DESCRIPTION
This is a pull request to fix the `claculate_max_nonzeros_per_row` function bug.