### PR TITLE
fix compile error of bitwise_not in gcc-5.5

### DIFF
--- a/core/base/range.hpp
+++ b/core/base/range.hpp
@@ -626,7 +626,7 @@ GKO_DEFINE_SIMPLE_UNARY_OPERATION(unary_minus, -operand);
 GKO_DEFINE_SIMPLE_UNARY_OPERATION(logical_not, !operand);
 
 // unary bitwise
-GKO_DEFINE_SIMPLE_UNARY_OPERATION(bitwise_not, ~operand);
+GKO_DEFINE_SIMPLE_UNARY_OPERATION(bitwise_not, ~(operand));
 
 // common functions
 GKO_DEFINE_SIMPLE_UNARY_OPERATION(zero_operation, zero(operand));


### PR DESCRIPTION
fix the compile error of bitwise_not in gcc-5.5
It close #66 