### PR TITLE
Fix matrix market reader on pattern mtx

### DIFF
--- a/core/base/mtx_reader.cpp
+++ b/core/base/mtx_reader.cpp
@@ -121,6 +121,9 @@ public:
                     "MMIO: unable to read value for matrix position " +
                         to_string(row) + ", " + to_string(col));
             }
+        } else {
+            // pattern: the value is 1 (True)
+            rp = 1.0;
         }
         data.nonzeros.emplace_back(row, col, combine<ValueType>(rp, ip));
         if (mm_is_symmetric(t_) && row != col) {

--- a/core/test/base/mtx_reader.cpp
+++ b/core/test/base/mtx_reader.cpp
@@ -152,10 +152,10 @@ TEST(MtxReader, ReadsSparsePatternMtx)
 
     ASSERT_EQ(data.size, gko::dim(2, 3));
     auto &v = data.nonzeros;
-    ASSERT_EQ(v[0], tpl(0, 0, 0.0));
-    ASSERT_EQ(v[1], tpl(0, 1, 0.0));
-    ASSERT_EQ(v[2], tpl(0, 2, 0.0));
-    ASSERT_EQ(v[3], tpl(1, 1, 0.0));
+    ASSERT_EQ(v[0], tpl(0, 0, 1.0));
+    ASSERT_EQ(v[1], tpl(0, 1, 1.0));
+    ASSERT_EQ(v[2], tpl(0, 2, 1.0));
+    ASSERT_EQ(v[3], tpl(1, 1, 1.0));
 }
 
 

--- a/cuda/CMakeLists.txt
+++ b/cuda/CMakeLists.txt
@@ -35,7 +35,8 @@ if(NOT CMAKE_CUDA_COMPILER_VERSION MATCHES "9.0")
     set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} --expt-relaxed-constexpr")
 endif()
 
-# make the CMAKE_CUDA_FLAGS in parent scope
+# This is required by some examples such as cmake_matrix_format
+# which need the correct CMAKE_CUDA_FLAGS to be set
 set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS}" PARENT_SCOPE)
 
 set(CUDA_INCLUDE_DIRS ${CMAKE_CUDA_TOOLKIT_INCLUDE_DIRECTORIES})

--- a/cuda/matrix/coo_kernels.cu
+++ b/cuda/matrix/coo_kernels.cu
@@ -94,14 +94,14 @@ __device__ __forceinline__ void segment_scan(IndexType ind, ValueType *val,
  * @param c  the output dense vector
  * @param scale  the function on the added value
  */
-template <typename ValueType, typename IndexType, typename Clousure>
+template <typename ValueType, typename IndexType, typename Closure>
 __device__ void spmv_kernel(const size_type nnz, const size_type num_lines,
                             const ValueType *__restrict__ val,
                             const IndexType *__restrict__ col,
                             const IndexType *__restrict__ row,
                             const ValueType *__restrict__ b,
                             const size_type b_stride, ValueType *__restrict__ c,
-                            const size_type c_stride, Clousure scale)
+                            const size_type c_stride, Closure scale)
 {
     ValueType temp_val = zero<ValueType>();
     const auto start = static_cast<size_type>(blockDim.x) * blockIdx.x *


### PR DESCRIPTION
Fix the problem:
When reading the pattern mtx and then converting it to the matrix (Coo ...), the matrix can not store any information from the pattern mtx because all elements are zero.
Change the elements to be one.
