### PR TITLE
Fix for unnecessary copies in stopping criteria

### DIFF
--- a/core/stop/combined.hpp
+++ b/core/stop/combined.hpp
@@ -80,7 +80,7 @@ protected:
         : EnablePolymorphicObject<Combined, Criterion>(std::move(exec))
     {}
 
-    explicit Combined(const Factory *factory, const CriterionArgs args)
+    explicit Combined(const Factory *factory, const CriterionArgs &args)
         : EnablePolymorphicObject<Combined, Criterion>(factory->get_executor()),
           parameters_{factory->get_parameters()}
     {

--- a/core/stop/iteration.hpp
+++ b/core/stop/iteration.hpp
@@ -70,7 +70,7 @@ protected:
         : EnablePolymorphicObject<Iteration, Criterion>(std::move(exec))
     {}
 
-    explicit Iteration(const Factory *factory, const CriterionArgs args)
+    explicit Iteration(const Factory *factory, const CriterionArgs &args)
         : EnablePolymorphicObject<Iteration, Criterion>(
               factory->get_executor()),
           parameters_{factory->get_parameters()}

--- a/core/stop/residual_norm_reduction.hpp
+++ b/core/stop/residual_norm_reduction.hpp
@@ -90,7 +90,7 @@ protected:
     {}
 
     explicit ResidualNormReduction(const Factory *factory,
-                                   const CriterionArgs args)
+                                   const CriterionArgs &args)
         : EnablePolymorphicObject<ResidualNormReduction<ValueType>, Criterion>(
               factory->get_executor()),
           parameters_{factory->get_parameters()}

--- a/examples/asynchronous_stopping_criterion/asynchronous_stopping_criterion.cpp
+++ b/examples/asynchronous_stopping_criterion/asynchronous_stopping_criterion.cpp
@@ -113,7 +113,7 @@ protected:
     {}
 
     explicit ByInteraction(const Factory *factory,
-                           const gko::stop::CriterionArgs args)
+                           const gko::stop::CriterionArgs &args)
 
         : EnablePolymorphicObject<ByInteraction, Criterion>(
               factory->get_executor()),


### PR DESCRIPTION
There was a reference missing in constructors of stopping criteria, which caused some unnecessary copies.