### PR TITLE
Add document with more details about licensing

### DIFF
--- a/ABOUT-LICENSING.md
+++ b/ABOUT-LICENSING.md
@@ -1,0 +1,110 @@
+About Licensing
+===============
+
+Ginkgo is available under the [3-clause BSD license](LICENSE):
+
+> Copyright 2017-2018
+> 
+> Karlsruhe Institute of Technology  
+> Universitat Jaume I  
+> University of Tennessee  
+> 
+> Redistribution and use in source and binary forms, with or without
+> modification, are permitted provided that the following conditions are met:
+> 
+> 1. Redistributions of source code must retain the above copyright notice, this
+>    list of conditions and the following disclaimer.
+> 
+> 2. Redistributions in binary form must reproduce the above copyright notice,
+>    this list of conditions and the following disclaimer in the documentation
+>    and/or other materials provided with the distribution.
+> 
+> 3. Neither the name of the copyright holder nor the names of its contributors
+>    may be used to endorse or promote products derived from this software
+>    without specific prior written permission.
+> 
+> THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+> AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+> IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+> DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+> FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+> DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+> SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+> CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+> OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+> OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+If you want to use Ginkgo, but need a different license, please
+[contact us](https://github.com/ginkgo-project/ginkgo/wiki#contact-us).
+
+Ginkgo source distribution does not bundle any third-party software. However,
+the licensing conditions of Ginkgo's dependencies still apply, depending on the
+modules used with Ginkgo. Please refer to the documentation of the dependencies
+for license conditions. Additionally, depending on the options used to compile
+Ginkgo, the build system will pull additional dependencies which have their own
+licensing conditions (note that all of these are extra utilities, and it is
+possible to obtain a fully functional installation of Ginkgo without any of
+them). They include the following:
+
+When compiling Ginkgo with `-DBUILT_TEST=ON`, the build system will download and
+build [Google Test](https://github.com/google/googletest), and link the binary
+with Ginkgo's unit tests. Google Test is available under the following license:
+
+> Copyright 2008, Google Inc.
+> All rights reserved.
+> 
+> Redistribution and use in source and binary forms, with or without
+> modification, are permitted provided that the following conditions are
+> met:
+> 
+> * Redistributions of source code must retain the above copyright notice, this
+>   list of conditions and the following disclaimer.
+> * Redistributions in binary form must reproduce the above copyright notice,
+>   this list of conditions and the following disclaimer in the documentation
+>   and/or other materials provided with the distribution.
+> * Neither the name of Google Inc. nor the names of its contributors may be
+>   used to endorse or promote products derived from this software without
+>   specific prior written permission.
+> 
+> THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+> "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+> LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+> A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+> OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+> SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+> LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+> DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+> THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+> (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+> OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+When compiling Ginkgo with `-DDEVEL_TOOLS=ON` the build system will download
+[git-cmake-format](https://github.com/kbenzie/git-cmake-format), available under
+the following license:
+
+> This is free and unencumbered software released into the public domain.
+> 
+> Anyone is free to copy, modify, publish, use, compile, sell, or distribute
+> this software, either in source code form or as a compiled binary, for any
+> purpose, commercial or non-commercial, and by any means.
+> 
+> In jurisdictions that recognize copyright laws, the author or authors of this
+> software dedicate any and all copyright interest in the software to the public
+> domain.  We make this dedication for the benefit of the public at large and to
+> the detriment of our heirs and successors.  We intend this dedication to be an
+> overt act of relinquishment in perpetuity of all present and future rights to
+> this software under copyright law.
+> 
+> THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+> IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTBILITY,
+> FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT, IN NO EVENT SHALL THE
+> AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES, OR OTHER LIABILITY, WHETHER IN AN
+> ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+> WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+> 
+> For more information, please refer to <http://unlicense.org/>
+
+__NOTE:__ Some of the options that pull additional software when compiling
+Ginkgo are ON by default, and have to be disabled manually to prevent
+third-party licensing. Refer to the [Installation section in
+README.md](README.md#installation) for more details.

--- a/README.md
+++ b/README.md
@@ -1,10 +1,14 @@
 ![Ginkgo](/assets/logo.png)
 
-Ginkgo is a numerical linear algebra library targeting manycore architectures.
+Ginkgo is a high-performance linear algebra library for manycore systems, with a
+focus on sparse solution of linear systems. It is implemented using modern C++
+(you will need at least C++11 compliant compiler to build it), with GPU kernels
+implemented in CUDA.
 
 
 Prerequisites
 -------------
+
 
 ### Linux
 
@@ -27,11 +31,6 @@ In addition, if you want to contribute code to Ginkgo, you will also need the
 following:
 
 *   _clang-format 5.0.1+_ (ships as part of _clang_)
-*   __NOTE:__ If you want to use _clang_ as your compiler and develop Ginkgo,
-    you'll currently need two versions _clang_: _clang 4.0.0_ or older, as this
-    is this version supporetd by the CUDA 9.1 toolkit, and _clang 5.0.1_ or
-    newer, which will not be used for compilation, but only provide the
-    _clang-format_ utility
 
 
 ### Mac OS
@@ -118,10 +117,10 @@ Ginkgo adds the following additional switches to control what is being built:
     `Auto` will automatically detect the present CUDA-enabled GPU 
     architectures in the system.
     `Kepler`, `Maxwell`, `Pascal` and `Volta` will add flags for all
-    architectures of that particular NVIDIA GPU generation. `COMPUTE` and `CODE` are
-    placeholders that should be replaced with compute and code numbers (e.g.
-    for `compute_70` and `code_70` `COMPUTE` and `CODE` should be replaced
-    with `70`. `MaxPTX` will select the latest architecture supported by the
+    architectures of that particular NVIDIA GPU generation. `COMPUTE` and `CODE`
+    are placeholders that should be replaced with compute and code numbers (e.g.
+    for `compute_70` and `code_70` `COMPUTE` and `CODE` should be replaced with
+    `70`. `MaxPTX` will select the latest architecture supported by the
     compiler. `Off` will not select any architectures and compile with NVCC's
     default settings. Default is `Auto`.
 
@@ -175,3 +174,7 @@ make install
 If the installation prefix (see `CMAKE_INSTALL_PREFIX`) is not writable for your
 user, e.g. when installing Ginkgo system-wide, it might be necessary to prefix
 the call with `sudo`.
+
+### Licensing
+
+Refer to [ABOUT-LICENSING.md](ABOUT-LICENSING.md) for details.


### PR DESCRIPTION
This document clarifies which additional software Ginkgo may use, and includes its licenses.

It also updates some outdated information in README.md.