### PR TITLE
Solver benchmark

### DIFF
--- a/ABOUT-LICENSING.md
+++ b/ABOUT-LICENSING.md
@@ -104,6 +104,152 @@ the following license:
 > 
 > For more information, please refer to <http://unlicense.org/>
 
+When compiling Ginkgo with `-DBUILD_BENCHMARKS=ON` the build system will
+download, build, and link [gflags](https://github.com/gflags/gflags) and 
+[RapidJSON](https://github.com/Tencent/rapidjson) with the
+benchmark suites. gtest is available under the following license:
+
+> Copyright (c) 2006, Google Inc.
+> All rights reserved.
+> 
+> Redistribution and use in source and binary forms, with or without
+> modification, are permitted provided that the following conditions are
+> met:
+> 
+> * Redistributions of source code must retain the above copyright
+> notice, this list of conditions and the following disclaimer.
+> * Redistributions in binary form must reproduce the above
+> copyright notice, this list of conditions and the following disclaimer
+> in the documentation and/or other materials provided with the
+> distribution.
+> * Neither the name of Google Inc. nor the names of its
+> contributors may be used to endorse or promote products derived from
+> this software without specific prior written permission.
+> 
+> THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+> "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+> LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+> A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+> OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+> SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+> LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+> DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+> THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+> (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+> OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+RapidJSON is available under the following license (note that Ginkgo's build
+system automatically removes the `bin/jsonchecker/` directory which is licensed
+under the problematic JSON license):
+
+> Tencent is pleased to support the open source community by making RapidJSON
+> available. 
+>  
+> Copyright (C) 2015 THL A29 Limited, a Tencent company, and Milo Yip.  All
+> rights reserved.
+> 
+> If you have downloaded a copy of the RapidJSON binary from Tencent, please
+> note that the RapidJSON binary is licensed under the MIT License.  If you have
+> downloaded a copy of the RapidJSON source code from Tencent, please note that
+> RapidJSON source code is licensed under the MIT License, except for the
+> third-party components listed below which are subject to different license
+> terms.  Your integration of RapidJSON into your own projects may require
+> compliance with the MIT License, as well as the other licenses applicable to
+> the third-party components included within RapidJSON. To avoid the problematic
+> JSON license in your own projects, it's sufficient to exclude the
+> bin/jsonchecker/ directory, as it's the only code under the JSON license.  A
+> copy of the MIT License is included in this file.
+> 
+> Other dependencies and licenses:
+> 
+> Open Source Software Licensed Under the BSD License:
+> --------------------------------------------------------------------
+> 
+> The msinttypes r29 
+>
+> Copyright (c) 2006-2013 Alexander Chemeris  
+> All rights reserved.
+> 
+> Redistribution and use in source and binary forms, with or without
+> modification, are permitted provided that the following conditions are met:
+> 
+> * Redistributions of source code must retain the above copyright notice, this
+>   list of conditions and the following disclaimer. 
+> * Redistributions in binary form must reproduce the above copyright notice,
+>   this list of conditions and the following disclaimer in the documentation
+>   and/or other materials provided with the distribution.
+> * Neither the name of  copyright holder nor the names of its contributors may
+>   be used to endorse or promote products derived from this software without
+>   specific prior written permission.
+> 
+> THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND ANY
+> EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+> WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+> DISCLAIMED. IN NO EVENT SHALL THE REGENTS AND CONTRIBUTORS BE LIABLE FOR ANY
+> DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+> (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+> LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+> ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+> (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+> SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+> 
+> Open Source Software Licensed Under the JSON License:
+> --------------------------------------------------------------------
+> 
+> json.org  
+> Copyright (c) 2002  
+> JSON.org All Rights Reserved.
+> 
+> JSON_checker  
+> Copyright (c) 2002 JSON.org  
+> All Rights Reserved.
+> 
+> 	
+> Terms of the JSON License:
+> ---------------------------------------------------
+> 
+> Permission is hereby granted, free of charge, to any person obtaining a copy
+> of this software and associated documentation files (the "Software"), to deal
+> in the Software without restriction, including without limitation the rights
+> to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+> copies of the Software, and to permit persons to whom the Software is
+> furnished to do so, subject to the following conditions:
+> 
+> The above copyright notice and this permission notice shall be included in all
+> copies or substantial portions of the Software.
+> 
+> The Software shall be used for Good, not Evil.
+> 
+> THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+> IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+> FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+> AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+> LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+> OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+> SOFTWARE.
+> 
+> 
+> Terms of the MIT License:
+> --------------------------------------------------------------------
+> 
+> Permission is hereby granted, free of charge, to any person obtaining a copy
+> of this software and associated documentation files (the "Software"), to deal
+> in the Software without restriction, including without limitation the rights
+> to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+> copies of the Software, and to permit persons to whom the Software is
+> furnished to do so, subject to the following conditions:
+> 
+> The above copyright notice and this permission notice shall be included in all
+> copies or substantial portions of the Software.
+> 
+> THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+> IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+> FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+> AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+> LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+> OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+> SOFTWARE.
+
 __NOTE:__ Some of the options that pull additional software when compiling
 Ginkgo are ON by default, and have to be disabled manually to prevent
 third-party licensing. Refer to the [Installation section in

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,7 @@ if(WIN32)
 else()
     cmake_minimum_required(VERSION 3.8)
 endif()
+
 project(Ginkgo LANGUAGES CXX VERSION 0.0.0)
 set(Ginkgo_VERSION_TAG "develop")
 set(PROJECT_VERSION_TAG ${Ginkgo_VERSION_TAG})

--- a/README.md
+++ b/README.md
@@ -90,6 +90,8 @@ Ginkgo adds the following additional switches to control what is being built:
     default is `ON`
 *   `-DBUILD_TESTS={ON, OFF}` builds Ginkgo's tests
     (will download googletest), default is `ON`
+*   `-DBUILD_BENCHMARKS={ON, OFF}` builds Ginkgo's benchmarks
+    (will download gflags and rapidjson), default is `ON`
 *   `-DBUILD_EXAMPLES={ON, OFF}` builds Ginkgo's examples, default is `ON`
 *   `-DBUILD_REFERENCE={ON, OFF}` build reference implementations of the
     kernels, usefull for testing, default os `OFF`

--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -1,1 +1,2 @@
 add_subdirectory(spmv_comparison_cuda)
+add_subdirectory(solver)

--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -1,2 +1,7 @@
+if (NOT CMAKE_BUILD_TYPE STREQUAL "Release")
+    message(WARNING
+        "Ginko is not being built in \"Release\" mode, benchmark performance "
+        "will be affected")
+endif()
 add_subdirectory(spmv_comparison_cuda)
 add_subdirectory(solver)

--- a/benchmark/solver/CMakeLists.txt
+++ b/benchmark/solver/CMakeLists.txt
@@ -1,2 +1,4 @@
 add_executable(solver solver.cpp)
 target_link_libraries(solver ginkgo gflags)
+target_include_directories(solver PRIVATE
+    ${Ginkgo_BINARY_DIR}/third_party/rapidjson/src/include)

--- a/benchmark/solver/CMakeLists.txt
+++ b/benchmark/solver/CMakeLists.txt
@@ -1,0 +1,2 @@
+add_executable(solver solver.cpp)
+target_link_libraries(solver ginkgo gflags)

--- a/benchmark/solver/solver.cpp
+++ b/benchmark/solver/solver.cpp
@@ -1,0 +1,90 @@
+/*******************************<GINKGO LICENSE>******************************
+Copyright 2017-2018
+
+Karlsruhe Institute of Technology
+Universitat Jaume I
+University of Tennessee
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice,
+   this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors
+   may be used to endorse or promote products derived from this software
+   without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+******************************<GINKGO LICENSE>*******************************/
+
+#include <include/ginkgo.hpp>
+
+
+#include <functional>
+#include <iostream>
+#include <map>
+
+
+#include <gflags/gflags.h>
+
+
+// Command-line arguments
+DEFINE_uint32(device_id, 0, "ID of the device where to run the code");
+
+DEFINE_uint32(max_iters, 1000,
+              "Maximal number of iterations the solver will be run for");
+
+DEFINE_double(rel_res_goal, 1e-6, "The relative residual goal of the solver");
+
+const std::map<std::string, std::function<std::shared_ptr<gko::Executor>()>>
+    executor_factory{
+        {"reference", [] { return gko::ReferenceExecutor::create(); }},
+        {"omp", [] { return gko::OmpExecutor::create(); }},
+        {"cuda", [] {
+             return gko::CudaExecutor::create(FLAGS_device_id,
+                                              gko::OmpExecutor::create());
+         }}};
+
+DEFINE_string(
+    executor, "reference",
+    "The executor used to run the solver, one of: reference, omp, cuda");
+bool validate_executor(const char *flag_name, const std::string &value)
+{
+    if (executor_factory.count(value) == 0) {
+        std::cout << "Wrong argument for flag --" << flag_name << ": " << value
+                  << "\nHas to be one of: reference, omp, cuda" << std::endl;
+        return false;
+    }
+    return true;
+};
+DEFINE_validator(executor, validate_executor);
+
+
+int main(int argc, char *argv[])
+{
+    gflags::SetUsageMessage("Usage: " + std::string(argv[0]) + " [options]");
+    gflags::ParseCommandLineFlags(&argc, &argv, true);
+
+    std::cerr << gko::version_info::get() << std::endl
+              << "Running on " << FLAGS_executor << "(" << FLAGS_device_id
+              << ")" << std::endl
+              << "Running CG with " << FLAGS_max_iters
+              << " iterations and residual goal of " << FLAGS_rel_res_goal
+              << std::endl;
+
+    auto exec = executor_factory.at(FLAGS_executor)();
+}

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -9,6 +9,7 @@ if(DEVEL_TOOLS)
     add_subdirectory(git-cmake-format)
 endif()
 
-if(BUILD_EXAMPLES OR BUILD_BENCHMARK)
+if(BUILD_BENCHMARK)
     add_subdirectory(gflags)
+    add_subdirectory(rapidjson)
 endif()

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -8,3 +8,7 @@ if(DEVEL_TOOLS)
     set(GCF_IGNORE_LIST "third_party" CACHE STRING "Ignore directories for GCF")
     add_subdirectory(git-cmake-format)
 endif()
+
+if(BUILD_EXAMPLES OR BUILD_BENCHMARK)
+    add_subdirectory(gflags)
+endif()

--- a/third_party/gflags/CMakeLists.txt
+++ b/third_party/gflags/CMakeLists.txt
@@ -1,0 +1,3 @@
+load_git_package(gflags
+    "https://github.com/gflags/gflags.git"
+    "660603a3df1c400437260b51c55490a046a12e8a")

--- a/third_party/git-cmake-format/CMakeLists.txt
+++ b/third_party/git-cmake-format/CMakeLists.txt
@@ -1,4 +1,3 @@
 load_git_package(git-cmake-format
     "https://github.com/gflegar/git-cmake-format.git"
-    "master")
-
+    "9fdc1553c525b3d7ce758892fe666078903a1b21")

--- a/third_party/rapidjson/CMakeLists.txt
+++ b/third_party/rapidjson/CMakeLists.txt
@@ -1,0 +1,8 @@
+set(RAPIDJSON_BUILD_DOC OFF CACHE BOOL "" FORCE)
+set(RAPIDJSON_BUILD_EXAMPLES OFF CACHE BOOL "" FORCE)
+set(RAPIDJSON_BUILD_TESTS OFF CACHE BOOL "" FORCE)
+load_git_package(rapidjson
+    "https://github.com/Tencent/rapidjson.git"
+    "73063f5002612c6bf64fe24f851cd5cc0d83eef9")
+# Remove directory with questionable licensing
+file(REMOVE_RECURSE ${CMAKE_CURRENT_BINARY_DIR}/src/bin/jsonchecker)


### PR DESCRIPTION
This PR adds a benchmark suite for testing Ginkgo's solvers.

It can solve a list of linear systems on any executor, using multiple solvers. The matrices (test cases) are read from standard input as an array of JSON objects, where each object contains the filename and the best matrix format which will be used to store the matrix. The initial guess is set to 0, and the right hand side is a vector of random numbers, uniformly distributed in range [-1, 1].

The result is written to standard output, in the same format as the input, but each test case has an additional member object for each solver run. This object contains the timing, the final residual, information if the solver completed or resulted in an exception, and optionally the recurrent and true residuals of each iteration. Per-iteration residuals are obtained from a separate run, so their computation does not interfere with the timings. Note that the number of iterations can be inferred from the number of entries in per-iteration residuals.

A lot of progress information is also being written to standard error throughout the solver run.

Optionally, the intermediate results can be written to a backup file after each solution of a linear system, to prevent loss of data in case the system terminates the benchmark suite.  Such intermediate result file can be given as input to the benchmark suite, and computation will continue from where it stopped (optionally, all computations can also be redone).

To see usage information and a list of all available options, run `./solver --help`.  Note that some of the options are related to the option parsing and information reporting. To get only the options related to the benchmark suite itself, run `./solver --helpshort`.

TODO
--------

- [x] This PR includes the content of PR #111 to correctly report a list of residuals.  That should be merged before this.