### PR TITLE
fix benchmark/spmv CI failed

### DIFF
--- a/benchmark/spmv/spmv.cpp
+++ b/benchmark/spmv/spmv.cpp
@@ -35,8 +35,6 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <include/ginkgo.hpp>
 
 
-#include <cuda_runtime.h>
-#include <cusparse.h>
 #include <algorithm>
 #include <array>
 #include <chrono>


### PR DESCRIPTION
Sorry, I keep the cuda header in the spmv file.
Thus, the CI is failed because the compiler does not find them.