### PR TITLE
Fix for linking errors with CMake 3.12

### DIFF
--- a/third_party/gtest/CMakeLists.txt
+++ b/third_party/gtest/CMakeLists.txt
@@ -5,6 +5,9 @@ set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
 set(INSTALL_GMOCK OFF CACHE BOOL "" FORCE)
 set(INSTALL_GTEST OFF CACHE BOOL "" FORCE)
 
+# Work around the linking errors when compiling gtest with CUDA
+set(gtest_disable_pthreads ON CACHE BOOL "" FORCE)
+
 load_git_package(gtest
     "https://github.com/google/googletest.git"
     "d5266326752f0a1dadbd310932d8f4fd8c3c5e7d")


### PR DESCRIPTION
Linking executables that use googletest and CUDA causes pthread-related problems starting from CMake 3.12. This resolves the issue by adding the workaround suggested by @venovako in #86.