### PR TITLE
Report memory consumption in SpMV benchmark

### DIFF
--- a/core/device_hooks/cuda_hooks.cpp
+++ b/core/device_hooks/cuda_hooks.cpp
@@ -53,7 +53,7 @@ void OmpExecutor::raw_copy_to(const CudaExecutor *, size_type num_bytes,
     NOT_COMPILED(cuda);
 
 
-void CudaExecutor::free(void *ptr) const noexcept
+void CudaExecutor::raw_free(void *ptr) const noexcept
 {
     // Free must never fail, as it can be called in destructors.
     // If the nvidia module was not compiled, the library couldn't have

--- a/core/devices/omp/executor.cpp
+++ b/core/devices/omp/executor.cpp
@@ -45,7 +45,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 namespace gko {
 
 
-void OmpExecutor::free(void *ptr) const noexcept { std::free(ptr); }
+void OmpExecutor::raw_free(void *ptr) const noexcept { std::free(ptr); }
 
 
 std::shared_ptr<Executor> OmpExecutor::get_master() noexcept

--- a/core/test/base/executor.cpp
+++ b/core/test/base/executor.cpp
@@ -305,10 +305,10 @@ struct mock_free : T {
     mock_free(Params &&... params) : T(std::forward<Params>(params)...)
     {}
 
-    void free(void *ptr) const noexcept override
+    void raw_free(void *ptr) const noexcept override
     {
         called_free = true;
-        T::free(ptr);
+        T::raw_free(ptr);
     }
 
     mutable bool called_free{false};

--- a/cuda/base/executor.cpp
+++ b/cuda/base/executor.cpp
@@ -128,10 +128,8 @@ void OmpExecutor::raw_copy_to(const CudaExecutor *dest, size_type num_bytes,
 }
 
 
-void CudaExecutor::free(void *ptr) const noexcept
+void CudaExecutor::raw_free(void *ptr) const noexcept
 {
-    this->template log<log::Logger::free_started>(
-        this, reinterpret_cast<uintptr>(ptr));
     device_guard g(this->get_device_id());
     auto error_code = cudaFree(ptr);
     if (error_code != cudaSuccess) {
@@ -142,8 +140,6 @@ void CudaExecutor::free(void *ptr) const noexcept
                   << "Exiting program" << std::endl;
         std::exit(error_code);
     }
-    this->template log<log::Logger::free_completed>(
-        this, reinterpret_cast<uintptr>(ptr));
 }
 
 


### PR DESCRIPTION
record log the free information of each executor and add logger to record the storage(bytes) of matrix.