### PR TITLE
Fix segmentation fault in block-Jacobi

### DIFF
--- a/core/preconditioner/block_jacobi.cpp
+++ b/core/preconditioner/block_jacobi.cpp
@@ -174,7 +174,7 @@ void BlockJacobi<ValueType, IndexType>::generate(const LinOp *system_matrix)
         csr_mtx = csr_mtx_handle.get();
     }
     if (this->block_pointers_.get_data() == nullptr) {
-        this->block_pointers_.resize_and_reset(csr_mtx->get_size()[0]);
+        this->block_pointers_.resize_and_reset(csr_mtx->get_size()[0] + 1);
         exec->run(BlockJacobiOperation<ValueType, IndexType>::
                       make_find_blocks_operation(csr_mtx, this->max_block_size_,
                                                  this->num_blocks_,


### PR DESCRIPTION
This PR fixes a segmentation fault which can happen when generating the diagonal blocks for block-Jacobi.

The problem was the size of the `block_pointers_` array in the block-Jacobi class which was allocated to equal the number of rows of the matrix. In the worst case scenario, each row is assigned to a separate block in the first stage of block detection, which makes the number of entries in `block_pointers_` equal number of rows + 1, longer than the allocated array by 1 element. Increasing the size of the array by 1 fixes the problem.