### PR TITLE
Linear combination operator

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -1,4 +1,5 @@
 set(SOURCES
+    base/combination.cpp
     base/executor.cpp
     base/mtx_io.cpp
     base/version.cpp

--- a/core/base/combination.cpp
+++ b/core/base/combination.cpp
@@ -1,0 +1,37 @@
+/*******************************<GINKGO LICENSE>******************************
+Copyright 2017-2018
+
+Karlsruhe Institute of Technology
+Universitat Jaume I
+University of Tennessee
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice,
+   this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors
+   may be used to endorse or promote products derived from this software
+   without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+******************************<GINKGO LICENSE>*******************************/
+
+#include "core/base/combination.hpp"
+
+
+namespace gko {}  // namespace gko

--- a/core/base/combination.cpp
+++ b/core/base/combination.cpp
@@ -34,4 +34,20 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "core/base/combination.hpp"
 
 
-namespace gko {}  // namespace gko
+namespace gko {
+
+
+void Combination::apply_impl(const LinOp *b, LinOp *x) const
+{
+    // TODO
+}
+
+
+void Combination::apply_impl(const LinOp *alpha, const LinOp *b,
+                             const LinOp *beta, LinOp *x) const
+{
+    // TODO
+}
+
+
+}  // namespace gko

--- a/core/base/combination.hpp
+++ b/core/base/combination.hpp
@@ -1,0 +1,54 @@
+/*******************************<GINKGO LICENSE>******************************
+Copyright 2017-2018
+
+Karlsruhe Institute of Technology
+Universitat Jaume I
+University of Tennessee
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice,
+   this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors
+   may be used to endorse or promote products derived from this software
+   without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+******************************<GINKGO LICENSE>*******************************/
+
+#ifndef GKO_CORE_BASE_COMBINATION_HPP_
+#define GKO_CORE_BASE_COMBINATION_HPP_
+
+
+#include "core/base/lin_op.hpp"
+
+
+namespace gko {
+
+
+class Combination : public gko::EnableLinOp<Combination>,
+                    public gko::EnableCreateMethod<Combination> {
+public:
+private:
+};
+
+
+}  // namespace gko
+
+
+#endif  // GKO_CORE_BASE_COMBINATION_HPP_

--- a/core/base/combination.hpp
+++ b/core/base/combination.hpp
@@ -47,11 +47,17 @@ namespace gko {
 /**
  * The Combination class can be used to construct a linear combination of
  * multiple linear operators `c1 * op1 + c2 * op2 + ... + ck * opk`.
+ *
+ * @tparam ValueType  precision of input and result vectors
  */
-class Combination : public EnableLinOp<Combination>,
-                    public EnableCreateMethod<Combination> {
+template <typename ValueType = default_precision>
+class Combination : public EnableLinOp<Combination<ValueType>>,
+                    public EnableCreateMethod<Combination<ValueType>> {
     friend class EnablePolymorphicObject<Combination, LinOp>;
     friend class EnableCreateMethod<Combination>;
+
+public:
+    using value_type = ValueType;
 
 protected:
     /**
@@ -146,6 +152,16 @@ private:
 
     std::vector<std::shared_ptr<const LinOp>> coefficients_;
     std::vector<std::shared_ptr<const LinOp>> operators_;
+
+    mutable struct cache_struct {
+        cache_struct() = default;
+        cache_struct(const cache_struct &other) {}
+        cache_struct &operator=(const cache_struct &other) { return *this; }
+
+        std::unique_ptr<LinOp> zero;
+        std::unique_ptr<LinOp> one;
+        std::unique_ptr<LinOp> intermediate_x;
+    } cache_;
 };
 
 

--- a/core/test/base/CMakeLists.txt
+++ b/core/test/base/CMakeLists.txt
@@ -1,5 +1,6 @@
 create_test(abstract_factory)
 create_test(array)
+create_test(combination)
 create_test(dim)
 create_test(exception)
 create_test(exception_helpers)

--- a/core/test/base/combination.cpp
+++ b/core/test/base/combination.cpp
@@ -1,0 +1,40 @@
+/*******************************<GINKGO LICENSE>******************************
+Copyright 2017-2018
+
+Karlsruhe Institute of Technology
+Universitat Jaume I
+University of Tennessee
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice,
+   this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors
+   may be used to endorse or promote products derived from this software
+   without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+******************************<GINKGO LICENSE>*******************************/
+
+#include <core/base/combination.hpp>
+
+
+#include <gtest/gtest.h>
+
+
+namespace {}  // namespace

--- a/core/test/base/combination.cpp
+++ b/core/test/base/combination.cpp
@@ -37,4 +37,82 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <gtest/gtest.h>
 
 
-namespace {}  // namespace
+#include <vector>
+
+
+#include <core/matrix/dense.hpp>
+
+
+namespace {
+
+
+struct DummyOperator : public gko::EnableLinOp<DummyOperator> {
+    DummyOperator(std::shared_ptr<const gko::Executor> exec, double value = 0.0)
+        : gko::EnableLinOp<DummyOperator>(exec, gko::dim<2>{1, 1}),
+          value_{value}
+    {}
+
+    void apply_impl(const LinOp *b, LinOp *x) const override
+    {
+        val(x) = val(this) * val(b);
+    }
+
+    void apply_impl(const LinOp *alpha, const LinOp *b, const LinOp *beta,
+                    LinOp *x) const override
+    {
+        val(x) = val(alpha) * val(this) * val(b) + val(beta) * val(x);
+    }
+
+    static double val(const LinOp *x)
+    {
+        return gko::as<DummyOperator>(x)->value_;
+    }
+
+    static double &val(LinOp *x) { return gko::as<DummyOperator>(x)->value_; }
+
+    double value_;
+};
+
+
+class Combination : public ::testing::Test {
+protected:
+    Combination()
+        : exec{gko::ReferenceExecutor::create()},
+          operators{std::make_shared<DummyOperator>(exec, 1),
+                    std::make_shared<DummyOperator>(exec, 2)},
+          coefficients{std::make_shared<DummyOperator>(exec, -1),
+                       std::make_shared<DummyOperator>(exec, 1)}
+    {}
+
+    std::shared_ptr<const gko::Executor> exec;
+    std::vector<std::shared_ptr<gko::LinOp>> operators;
+    std::vector<std::shared_ptr<gko::LinOp>> coefficients;
+};
+
+
+TEST_F(Combination, CanBeEmpty)
+{
+    auto cmb = gko::Combination::create(exec);
+
+    ASSERT_EQ(cmb->get_size(), gko::dim<2>(0, 0));
+}
+
+
+TEST_F(Combination, CanCreateFromIterators)
+{
+    auto cmb = gko::Combination::create(begin(coefficients), end(coefficients),
+                                        begin(operators), end(operators));
+
+    ASSERT_EQ(cmb->get_size(), gko::dim<2>(1, 1));
+}
+
+
+TEST_F(Combination, CanCreateFromList)
+{
+    auto cmb = gko::Combination::create(coefficients[0], operators[0],
+                                        coefficients[1], operators[1]);
+
+    ASSERT_EQ(cmb->get_size(), gko::dim<2>(1, 1));
+}
+
+}  // namespace

--- a/reference/test/CMakeLists.txt
+++ b/reference/test/CMakeLists.txt
@@ -1,3 +1,4 @@
+add_subdirectory(base)
 add_subdirectory(matrix)
 add_subdirectory(preconditioner)
 add_subdirectory(solver)

--- a/reference/test/base/CMakeLists.txt
+++ b/reference/test/base/CMakeLists.txt
@@ -1,0 +1,1 @@
+create_test(combination)


### PR DESCRIPTION
This PR adds a `gko::Combination` class which can be used to  construct an operator that represents a general linear combination of other operators:

```
c_1 * op_1 + c_2 * op_2 + ... c_n * op_n
```

For example, this is useful for solving shifted linear systems `(A - zI)x = b` (eg. in the context of [inverse iteration](https://en.wikipedia.org/wiki/Inverse_iteration)).

To construct the shifted matrix from an already existing matrix `mtx` in Ginkgo you could do something like:

```c++
auto mtx = /* ... */;
auto one = share(gko::initialize<gko::matrix::Dense<>>({1.0}, exec));
auto neg_z = share(gko::initialize<gko::matrix::Dense<>>({-value}, exec));
auto id_fact = gko::IdentityFactory<>::create(exec):
auto shifted_mtx = gko::Combination<>::create(one, mtx, neg_z, id_fact->generate(mtx));

// solve system with shifted_mtx
```