### PR TITLE
Add missing Combination and Composition getters

### DIFF
--- a/core/test/base/combination.cpp
+++ b/core/test/base/combination.cpp
@@ -77,6 +77,8 @@ TEST_F(Combination, CanBeEmpty)
     auto cmb = gko::Combination<>::create(exec);
 
     ASSERT_EQ(cmb->get_size(), gko::dim<2>(0, 0));
+    ASSERT_EQ(cmb->get_coefficients().size(), 0);
+    ASSERT_EQ(cmb->get_operators().size(), 0);
 }
 
 
@@ -87,6 +89,12 @@ TEST_F(Combination, CanCreateFromIterators)
                                    begin(operators), end(operators));
 
     ASSERT_EQ(cmb->get_size(), gko::dim<2>(1, 1));
+    ASSERT_EQ(cmb->get_coefficients().size(), 2);
+    ASSERT_EQ(cmb->get_operators().size(), 2);
+    ASSERT_EQ(cmb->get_coefficients()[0], coefficients[0]);
+    ASSERT_EQ(cmb->get_operators()[0], operators[0]);
+    ASSERT_EQ(cmb->get_coefficients()[1], coefficients[1]);
+    ASSERT_EQ(cmb->get_operators()[1], operators[1]);
 }
 
 
@@ -96,6 +104,12 @@ TEST_F(Combination, CanCreateFromList)
                                           coefficients[1], operators[1]);
 
     ASSERT_EQ(cmb->get_size(), gko::dim<2>(1, 1));
+    ASSERT_EQ(cmb->get_coefficients().size(), 2);
+    ASSERT_EQ(cmb->get_operators().size(), 2);
+    ASSERT_EQ(cmb->get_coefficients()[0], coefficients[0]);
+    ASSERT_EQ(cmb->get_operators()[0], operators[0]);
+    ASSERT_EQ(cmb->get_coefficients()[1], coefficients[1]);
+    ASSERT_EQ(cmb->get_operators()[1], operators[1]);
 }
 
 

--- a/core/test/base/composition.cpp
+++ b/core/test/base/composition.cpp
@@ -75,6 +75,7 @@ TEST_F(Composition, CanBeEmpty)
     auto cmp = gko::Composition<>::create(exec);
 
     ASSERT_EQ(cmp->get_size(), gko::dim<2>(0, 0));
+    ASSERT_EQ(cmp->get_operators().size(), 0);
 }
 
 
@@ -83,6 +84,9 @@ TEST_F(Composition, CanCreateFromIterators)
     auto cmp = gko::Composition<>::create(begin(operators), end(operators));
 
     ASSERT_EQ(cmp->get_size(), gko::dim<2>(2, 3));
+    ASSERT_EQ(cmp->get_operators().size(), 2);
+    ASSERT_EQ(cmp->get_operators()[0], operators[0]);
+    ASSERT_EQ(cmp->get_operators()[1], operators[1]);
 }
 
 
@@ -91,6 +95,9 @@ TEST_F(Composition, CanCreateFromList)
     auto cmp = gko::Composition<>::create(operators[0], operators[1]);
 
     ASSERT_EQ(cmp->get_size(), gko::dim<2>(2, 3));
+    ASSERT_EQ(cmp->get_operators().size(), 2);
+    ASSERT_EQ(cmp->get_operators()[0], operators[0]);
+    ASSERT_EQ(cmp->get_operators()[1], operators[1]);
 }
 
 


### PR DESCRIPTION
This PR adds the missing getters to `gko::Combination` and `gko::Composition` that can be used to retrieve the operators they are composed of.

This will come in handy when working with factorizations, factorization-based preconditioners, and possibly eigensolvers.

I also managed to use lambdas to solve the issue of throwing exceptions from member initializer lists.