### PR TITLE
Cooperative groups

### DIFF
--- a/core/base/utils.hpp
+++ b/core/base/utils.hpp
@@ -495,6 +495,14 @@ temporary_clone<T> make_temporary_clone(std::shared_ptr<const Executor> exec,
 #endif  // defined(__CUDA_ARCH__) && defined(__APPLE__)
 
 
+// handled deprecated notices correctly on different systems
+#if defined(_WIN32)
+#define GKO_DEPRECATED(msg) __declspec(deprecated(msg))
+#else
+#define GKO_DEPRECATED(msg) __attribute__((deprecated(msg)))
+#endif  // defined(_WIN32)
+
+
 }  // namespace gko
 
 

--- a/cuda/components/cooperative_groups.cuh
+++ b/cuda/components/cooperative_groups.cuh
@@ -106,6 +106,15 @@ namespace gko {
  * To check if a group T satisfies one of the concepts, one can use the
  * metafunctions is_group<T>::value, is_synchronizable_group<T>::value and
  * is_communicator_group<T>::value.
+ *
+ * @note If you were referred to this file by the deprecation notices on
+ *       Ginkgo's synchronization or shuffle API, please note that the current
+ *       implementation of cooperative groups contains only a subset of
+ *       functionalities provided by those APIs. If you need more functionality,
+ *       please add the appropriate implementations to existing cooperative
+ *       groups, or create new groups if the existing groups do not cover your
+ *       use-case. For an example, see the enable_extended_shuffle mixin, which
+ *       adds extended shuffles support to built-in CUDA cooperative groups.
  */
 namespace group {
 

--- a/cuda/components/cooperative_groups.cuh
+++ b/cuda/components/cooperative_groups.cuh
@@ -1,0 +1,234 @@
+/*******************************<GINKGO LICENSE>******************************
+Copyright 2017-2018
+
+Karlsruhe Institute of Technology
+Universitat Jaume I
+University of Tennessee
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice,
+   this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors
+   may be used to endorse or promote products derived from this software
+   without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+******************************<GINKGO LICENSE>*******************************/
+
+#ifndef GKO_CUDA_COMPONENTS_COOPERATIVE_GROUPS_CUH_
+#define GKO_CUDA_COMPONENTS_COOPERATIVE_GROUPS_CUH_
+
+
+#include <cooperative_groups.h>
+
+
+namespace gko {
+namespace group {
+
+
+// See <CUDA directory>/include/cooperative_groups.h for documentation and
+// implementation.
+
+
+// define new or modify existing groups here
+
+
+// types
+
+
+using cooperative_groups::thread_group;
+// public API:
+// void sync() const
+// unsigned size() const
+// unsigned thread_rank() const
+//
+// protected API:
+// _data (union) {
+//   unsigned type;
+//   coalesced {
+//     unsigned type;
+//     unsigned size;
+//     unsigned mask
+//   };
+//   buffer {
+//     void *ptr[2];
+//   }
+// }
+// operator=
+// thread_group(__internal::groupType type)
+
+
+// using cooperative_groups::grid_group;
+// Do not use this. Need to launch kernels with cuLaunchCooperativeKernel for
+// this to work, and the device has to support it. It's not available on some
+// older hardware we're trying to support.
+// public API:
+// grid_group()
+// bool is_valid() const
+// void sync() const
+// unsigned size() const
+// unsigned thread_rank() const
+// dim3 group_dim() const
+
+
+using cooperative_groups::thread_block;
+// inherits thread_group
+//
+// public API:
+// void sync() const
+// unsigned size() const
+// unsigned thread_rank() const
+// dim3 group_index() const
+// dim3 thread_index() const
+// dim3 group_dim() const
+
+
+// Probably don't use it, implementation is incomplete
+using cooperative_groups::coalesced_group;
+// inherits thread_group
+//
+// public API:
+// unsigned size() const
+// unsigned thread_rank() const
+// unsigned sync() const
+// T shfl(T, unsigned) const   // bug - should be int
+// T shfl_up(T, int) const     // bug - should be unsigned
+// T shfl_down(T, int) const   // bug - should be unsigned
+// int any(int) const
+// int all(int) const
+// unsigned ballot(int) const
+//
+// c.c. 7.0 and higher
+// unsigned match_any(T) const
+// unsigned match_all(T) const
+
+
+namespace detail {
+
+// Adds generalized shuffles that support any type to the group.
+template <typename Group>
+class enable_extended_shuffle : public Group {
+public:
+    using Group::Group;
+    using Group::shfl;
+    using Group::shfl_down;
+    using Group::shfl_up;
+    using Group::shfl_xor;
+
+#define GKO_ENABLE_SHUFFLE_OPERATION(_name, SelectorType)                  \
+    template <typename ValueType>                                          \
+    __device__ __forceinline__ ValueType _name(const ValueType &var,       \
+                                               SelectorType selector)      \
+    {                                                                      \
+        return shuffle_impl(                                               \
+            [this](int32 v, SelectorType s) { return this->_name(v, s); }, \
+            var, selector);                                                \
+    }
+
+    GKO_ENABLE_SHUFFLE_OPERATION(shfl, int32)
+    GKO_ENABLE_SHUFFLE_OPERATION(shfl_up, uint32)
+    GKO_ENABLE_SHUFFLE_OPERATION(shfl_down, uint32)
+    GKO_ENABLE_SHUFFLE_OPERATION(shfl_xor, int32)
+
+#undef GKO_ENABLE_SHUFFLE_OPERATION
+
+private:
+    template <typename ShuffleOperator, typename ValueType,
+              typename SelectorType>
+    static __device__ __forceinline__ ValueType shuffle_impl(
+        ShuffleOperator shufle, const ValueType &var, SelectorType selector)
+    {
+        static_assert(sizeof(ValueType) % sizeof(int32) == 0,
+                      "Unable to shuffle sizes which are not 4-byte multiples");
+        constexpr auto value_size = sizeof(ValueType) / sizeof(int32);
+        ValueType result;
+        auto var_array = reinterpret_cast<const int32 *>(&var);
+        auto result_array = reinterpret_cast<int32 *>(&result);
+#pragma unroll
+        for (std::size_t i = 0; i < value_size; ++i) {
+            result_array[i] = shuffle(var_array[i], selector);
+        }
+        return result;
+    }
+};
+
+
+}  // namespace detail
+
+
+template <size_type Size>
+using thread_block_tile = detail::enable_extended_shuffle<
+    cooperative_groups::thread_block_tile<Size>>;
+// inherits thread_group
+//
+// public API:
+// void sync() const
+// unsigned thread_rank() const
+// usigned size() const
+// T shfl(T, int)
+// T shfl_up(T, unsigned)
+// T shfl_down(T, unsigned)
+// T shfl_xor(T, unsigned)
+// int any(int) const
+// int all(int) const
+// unsigned ballot(int) const
+//
+// c.c. 7.0 and higher
+// unsigned match_any(T) const
+// unsigned match_all(T) const
+
+
+// top-level functions
+// thread_group this_thread()
+using cooperative_groups::this_thread;
+// grid_group this_grid()
+// using cooperative_groups::this_grid;
+// thread_block this_thread_block()
+using cooperative_groups::this_thread_block;
+// coalesced_group coalesced_threads()
+using cooperative_groups::coalesced_threads;
+// void sync(group)
+using cooperative_groups::sync;
+// unsigned thread_rank(group)
+using cooperative_groups::thread_rank;
+// unsigned group_size(group)
+using cooperative_groups::group_size;
+
+
+template <typename Group>
+__device__ __forceinline__ auto tiled_partition(const Group &g)
+    -> decltype(cooperative_groups::tiled_partition(g))
+{
+    return cooperative_groups::tiled_partition(g);
+}
+
+
+template <size_type Size, typename Group>
+__device__ __forceinline__ thread_block_tile<Size> tiled_partition(
+    const Group &)
+{
+    return thread_block_tile<Size>();
+}
+
+
+}  // namespace group
+}  // namespace gko
+
+
+#endif  // GKO_CUDA_COMPONENTS_COOPERATIVE_GROUPS_CUH_

--- a/cuda/components/cooperative_groups.cuh
+++ b/cuda/components/cooperative_groups.cuh
@@ -319,8 +319,6 @@ struct thread_block_tile : detail::enable_extended_shuffle<
     using detail::enable_extended_shuffle<
         cooperative_groups::thread_block_tile<Size>>::enable_extended_shuffle;
 };
-
-
 // inherits thread_group
 //
 // public API:
@@ -338,6 +336,7 @@ struct thread_block_tile : detail::enable_extended_shuffle<
 // c.c. 7.0 and higher
 // unsigned match_any(T) const
 // unsigned match_all(T) const
+
 namespace detail {
 // struct is_group_impl<thread_block_tile<16>> : std::true_type {};
 template <size_type Size>

--- a/cuda/components/reduction.cuh
+++ b/cuda/components/reduction.cuh
@@ -60,9 +60,9 @@ namespace cuda {
  *       Otherwise, the correct value is returned only to the thread with
  *       subwarp index 0.
  */
-template <typename Group, typename ValueType, typename Operator,
-          typename = xstd::void_t<decltype(std::declval<Group>().shfl_xor(
-              std::declval<ValueType>(), std::declval<int32>()))>>
+template <
+    typename Group, typename ValueType, typename Operator,
+    typename = xstd::enable_if_t<group::is_communicator_group<Group>::value>>
 __device__ __forceinline__ ValueType reduce(const Group &group,
                                             ValueType local_data,
                                             Operator reduce_op = Operator{})
@@ -85,9 +85,9 @@ __device__ __forceinline__ ValueType reduce(const Group &group,
  * Only the values from threads which set `is_pivoted` to `false` will be
  * considered.
  */
-template <typename Group, typename ValueType,
-          typename = xstd::void_t<decltype(std::declval<Group>().shfl(
-              std::declval<ValueType>(), std::declval<int32>()))>>
+template <
+    typename Group, typename ValueType,
+    typename = xstd::enable_if_t<group::is_communicator_group<Group>::value>>
 __device__ __forceinline__ int choose_pivot(const Group &group,
                                             ValueType local_data,
                                             bool is_pivoted)

--- a/cuda/components/reduction.cuh
+++ b/cuda/components/reduction.cuh
@@ -35,6 +35,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define GKO_CUDA_COMPONENTS_REDUCTION_CUH_
 
 
+#include "cuda/components/cooperative_groups.cuh"
 #include "cuda/components/shuffle.cuh"
 #include "cuda/components/synchronization.cuh"
 #include "cuda/components/thread_ids.cuh"

--- a/cuda/components/reduction.cuh
+++ b/cuda/components/reduction.cuh
@@ -78,8 +78,7 @@ __device__ __forceinline__ ValueType reduce(const Group &group,
  * @internal
  *
  * Returns the index of the thread that has the element with the largest
- * magnitude among all the threads in the sub-warp of `subwarp_size` threads.
- * Restrictions on subwarp_size from warp::reduce apply.
+ * magnitude among all the threads in the group.
  * Only the values from threads which set `is_pivoted` to `false` will be
  * considered.
  */

--- a/cuda/components/synchronization.cuh
+++ b/cuda/components/synchronization.cuh
@@ -47,9 +47,18 @@ namespace cuda {
 namespace warp {
 
 
+#define GKO_DEPRECATION_NOTICE                                               \
+    GKO_DEPRECATED(                                                          \
+        "The synchronization API is deprecated as it may trigger incorrect " \
+        "behavior on the Volta and later architectures. Please use the "     \
+        "cooperative groups API available in "                               \
+        "cuda/components/cooperative_groups.cuh")
+
+
 #if __CUDACC_VER_MAJOR__ < 9
 
 
+GKO_DEPRECATION_NOTICE
 __device__ __forceinline__ uint32 active_mask()
 {
     // all threads are always active in CUDA < 9
@@ -57,6 +66,7 @@ __device__ __forceinline__ uint32 active_mask()
 }
 
 
+GKO_DEPRECATION_NOTICE
 __device__ __forceinline__ void synchronize(
     uint32 mask = cuda_config::full_lane_mask)
 {
@@ -65,6 +75,7 @@ __device__ __forceinline__ void synchronize(
 }
 
 
+GKO_DEPRECATION_NOTICE
 __device__ __forceinline__ bool any(bool predicate,
                                     uint32 mask = cuda_config::full_lane_mask)
 {
@@ -73,6 +84,7 @@ __device__ __forceinline__ bool any(bool predicate,
 }
 
 
+GKO_DEPRECATION_NOTICE
 __device__ __forceinline__ bool all(bool predicate,
                                     uint32 mask = cuda_config::full_lane_mask)
 {
@@ -81,6 +93,7 @@ __device__ __forceinline__ bool all(bool predicate,
 }
 
 
+GKO_DEPRECATION_NOTICE
 __device__ __forceinline__ int32
 count(bool predicate, uint32 mask = cuda_config::full_lane_mask)
 {
@@ -89,6 +102,7 @@ count(bool predicate, uint32 mask = cuda_config::full_lane_mask)
 }
 
 
+GKO_DEPRECATION_NOTICE
 __device__ __forceinline__ uint32
 ballot(bool predicate, uint32 mask = cuda_config::full_lane_mask)
 {
@@ -100,9 +114,11 @@ ballot(bool predicate, uint32 mask = cuda_config::full_lane_mask)
 #else  // __CUDACC_VER_MAJOR__ < 9
 
 
+GKO_DEPRECATION_NOTICE
 __device__ __forceinline__ bool active_mask() { return __activemask(); }
 
 
+GKO_DEPRECATION_NOTICE
 __device__ __forceinline__ void synchronize(
     uint32 mask = cuda_config::full_lane_mask)
 {
@@ -110,6 +126,7 @@ __device__ __forceinline__ void synchronize(
 }
 
 
+GKO_DEPRECATION_NOTICE
 __device__ __forceinline__ bool any(bool predicate,
                                     uint32 mask = cuda_config::full_lane_mask)
 {
@@ -117,6 +134,7 @@ __device__ __forceinline__ bool any(bool predicate,
 }
 
 
+GKO_DEPRECATION_NOTICE
 __device__ __forceinline__ bool all(bool predicate,
                                     uint32 mask = cuda_config::full_lane_mask)
 {
@@ -124,6 +142,7 @@ __device__ __forceinline__ bool all(bool predicate,
 }
 
 
+GKO_DEPRECATION_NOTICE
 __device__ __forceinline__ int32
 count(bool predicate, uint32 mask = cuda_config::full_lane_mask)
 {
@@ -131,6 +150,7 @@ count(bool predicate, uint32 mask = cuda_config::full_lane_mask)
 }
 
 
+GKO_DEPRECATION_NOTICE
 __device__ __forceinline__ uint32
 ballot(bool predicate, uint32 mask = cuda_config::full_lane_mask)
 {
@@ -147,24 +167,29 @@ ballot(bool predicate, uint32 mask = cuda_config::full_lane_mask)
 namespace block {
 
 
+GKO_DEPRECATION_NOTICE
 __device__ __forceinline__ void fence() { __threadfence_block(); }
 
 
+GKO_DEPRECATION_NOTICE
 __device__ __forceinline__ void synchronize() { __syncthreads(); }
 
 
+GKO_DEPRECATION_NOTICE
 __device__ __forceinline__ bool any(bool predicate)
 {
     return __syncthreads_or(predicate);
 }
 
 
+GKO_DEPRECATION_NOTICE
 __device__ __forceinline__ bool all(bool predicate)
 {
     return __syncthreads_and(predicate);
 }
 
 
+GKO_DEPRECATION_NOTICE
 __device__ __forceinline__ int32 count(bool predicate)
 {
     return __syncthreads_count(predicate);
@@ -177,6 +202,7 @@ __device__ __forceinline__ int32 count(bool predicate)
 namespace device {
 
 
+GKO_DEPRECATION_NOTICE
 __device__ __forceinline__ void fence() { __threadfence(); }
 
 
@@ -186,6 +212,7 @@ __device__ __forceinline__ void fence() { __threadfence(); }
 namespace system {
 
 
+GKO_DEPRECATION_NOTICE
 __device__ __forceinline__ void fence() { __threadfence_system(); }
 
 
@@ -193,6 +220,9 @@ __device__ __forceinline__ void fence() { __threadfence_system(); }
 }  // namespace cuda
 }  // namespace kernels
 }  // namespace gko
+
+
+#undef GKO_DEPRECATION_NOTICE
 
 
 #endif  // GKO_CUDA_COMPONENTS_SYNCHRONIZATION_CUH_

--- a/cuda/components/warp_blas.cuh
+++ b/cuda/components/warp_blas.cuh
@@ -62,14 +62,14 @@ namespace warp {
  * @note assumes that block dimensions are in "standard format":
  *       (subwarp_size, cuda_config::warp_size / subwarp_size, z)
  */
-template <int max_problem_size, typename Group, typename ValueType>
+template <
+    int max_problem_size, typename Group, typename ValueType,
+    typename = xstd::enable_if_t<group::is_communicator_group<Group>::value>>
 __device__ __forceinline__ void apply_gauss_jordan_transform(const Group &group,
                                                              int32 key_row,
                                                              int32 key_col,
                                                              ValueType *row)
 {
-    // static_assert(max_problem_size <= subwarp_size,
-    //              "max_problem_size cannot be larger than subwarp_size");
     auto key_col_elem = group.shfl(row[key_col], key_row);
     if (key_col_elem == zero<ValueType>()) {
         // TODO: implement error handling for GPUs to be able to properly
@@ -126,15 +126,15 @@ __device__ __forceinline__ void apply_gauss_jordan_transform(const Group &group,
  * @note assumes that block dimensions are in "standard format":
  *       (subwarp_size, cuda_config::warp_size / subwarp_size, z)
  */
-template <int max_problem_size, typename Group, typename ValueType>
+template <
+    int max_problem_size, typename Group, typename ValueType,
+    typename = xstd::enable_if_t<group::is_communicator_group<Group>::value>>
 __device__ __forceinline__ void invert_block(const Group &group,
                                              uint32 problem_size,
                                              ValueType *__restrict__ row,
                                              uint32 &__restrict__ perm,
                                              uint32 &__restrict__ trans_perm)
 {
-    // static_assert(max_problem_size <= subwarp_size,
-    //               "max_problem_size cannot be larger than subwarp_size");
     GKO_ASSERT(problem_size <= max_problem_size);
     // prevent rows after problem_size to become pivots
     auto pivoted = group.thread_rank() >= problem_size;
@@ -185,14 +185,14 @@ __device__ __forceinline__ void invert_block(const Group &group,
  * @note assumes that block dimensions are in "standard format":
  *       (subwarp_size, cuda_config::warp_size / subwarp_size, z)
  */
-template <int max_problem_size, typename Group, typename ValueType>
+template <
+    int max_problem_size, typename Group, typename ValueType,
+    typename = xstd::enable_if_t<group::is_communicator_group<Group>::value>>
 __device__ __forceinline__ void copy_matrix(
     const Group &group, uint32 problem_size,
     const ValueType *__restrict__ source_row, uint32 increment, uint32 row_perm,
     uint32 col_perm, ValueType *__restrict__ destination, size_type stride)
 {
-    // static_assert(max_problem_size <= subwarp_size,
-    //              "max_problem_size cannot be larger than subwarp_size");
     GKO_ASSERT(problem_size <= max_problem_size);
 #pragma unroll
     for (int32 i = 0; i < max_problem_size; ++i) {
@@ -234,14 +234,14 @@ __device__ __forceinline__ void copy_matrix(
  * @note assumes that block dimensions are in "standard format":
  *       (subwarp_size, cuda_config::warp_size / subwarp_size, z)
  */
-template <int max_problem_size, typename Group, typename ValueType>
+template <
+    int max_problem_size, typename Group, typename ValueType,
+    typename = xstd::enable_if_t<group::is_communicator_group<Group>::value>>
 __device__ __forceinline__ void multiply_transposed_vec(
     const Group &group, uint32 problem_size, const ValueType &__restrict__ vec,
     const ValueType *__restrict__ mtx_row, uint32 mtx_increment,
     ValueType *__restrict__ res, uint32 res_increment)
 {
-    // static_assert(max_problem_size <= subwarp_size,
-    //               "max_problem_size cannot be larger than subwarp_size");
     GKO_ASSERT(problem_size <= max_problem_size);
     auto mtx_elem = zero<ValueType>();
 #pragma unroll

--- a/cuda/matrix/dense_kernels.cu
+++ b/cuda/matrix/dense_kernels.cu
@@ -229,9 +229,8 @@ __global__ __launch_bounds__(block_size) void compute_partial_dot(
     __shared__ UninitializedArray<ValueType, block_size> tmp_work;
     tmp_work[local_id] = tmp;
 
-    block::reduce<block_size, cuda_config::warp_size>(
-        static_cast<ValueType *>(tmp_work),
-        [](const ValueType &x, const ValueType &y) { return x + y; });
+    reduce(group::this_thread_block(), static_cast<ValueType *>(tmp_work),
+           [](const ValueType &x, const ValueType &y) { return x + y; });
 
     if (local_id == 0) {
         work[thread::get_block_id()] = tmp_work[0];
@@ -252,9 +251,8 @@ __global__ __launch_bounds__(block_size) void finalize_dot_computation(
     __shared__ UninitializedArray<ValueType, block_size> tmp_work;
     tmp_work[local_id] = tmp;
 
-    block::reduce<block_size, cuda_config::warp_size>(
-        static_cast<ValueType *>(tmp_work),
-        [](const ValueType &x, const ValueType &y) { return x + y; });
+    reduce(group::this_thread_block(), static_cast<ValueType *>(tmp_work),
+           [](const ValueType &x, const ValueType &y) { return x + y; });
 
     if (local_id == 0) {
         *result = tmp_work[0];


### PR DESCRIPTION
This PR adds the cooperative groups support to Ginkgo and changes the reduction, block-Jacobi, and dense matrix related implementation to use it. The old synchronization and shuffle interfaces are still there as some parts of the library still use the (CSR and COO SpMV format), but the old API now emits a warning that it is deprecated, and should be replaced by cooperative groups (so if you try to compile the library now, you'll get a bunch of warnings coming from CSR and COO kernels).

This resolves #54. Block-Jacobi now successfully runs on V100.

(The only remaining question is if the performance on older devices will be affected by the new API).