### PR TITLE
Use version of CAS with workarounds for CMake bugs

### DIFF
--- a/third_party/CudaArchitectureSelector/CMakeLists.txt
+++ b/third_party/CudaArchitectureSelector/CMakeLists.txt
@@ -1,4 +1,5 @@
 load_git_package(CudaArchitectureSelector
     "https://github.com/ginkgo-project/CudaArchitectureSelector.git"
-    "a4c3c1e97e862ca0c0f1c5d6b096cbfcc1b96fcb")
+    "a0871e31f16837f02324259d8829bac0fa02dcab")
+
 set(CMAKE_MODULE_PATH "${CMAKE_MODULE_PATH}" PARENT_SCOPE)


### PR DESCRIPTION
This should fix #143 by using a newer version of CAS that includes a workaround for the bug (not setting `CMAKE_CUDA_COMPILER_LOADED`) in older CMake versions.