### PR TITLE
Preconditioner benchmark

### DIFF
--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -6,6 +6,7 @@ endif()
 
 add_subdirectory(matrix_generator)
 add_subdirectory(matrix_statistics)
+add_subdirectory(preconditioner)
 add_subdirectory(solver)
 add_subdirectory(spmv)
 add_subdirectory(spmv_comparison_cuda)

--- a/benchmark/preconditioner/CMakeLists.txt
+++ b/benchmark/preconditioner/CMakeLists.txt
@@ -1,0 +1,4 @@
+add_executable(preconditioner preconditioner.cpp)
+target_link_libraries(preconditioner ginkgo gflags)
+target_include_directories(preconditioner PRIVATE
+    ${Ginkgo_BINARY_DIR}/third_party/rapidjson/src/include)

--- a/benchmark/preconditioner/preconditioner.cpp
+++ b/benchmark/preconditioner/preconditioner.cpp
@@ -1,0 +1,456 @@
+/*******************************<GINKGO LICENSE>******************************
+Copyright 2017-2018
+
+Karlsruhe Institute of Technology
+Universitat Jaume I
+University of Tennessee
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice,
+   this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors
+   may be used to endorse or promote products derived from this software
+   without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+******************************<GINKGO LICENSE>*******************************/
+
+#include <include/ginkgo.hpp>
+
+
+#include <algorithm>
+#include <array>
+#include <functional>
+#include <iomanip>
+#include <iostream>
+#include <map>
+#include <random>
+#include <sstream>
+#include <string>
+
+
+#include <gflags/gflags.h>
+#include <rapidjson/document.h>
+#include <rapidjson/istreamwrapper.h>
+#include <rapidjson/ostreamwrapper.h>
+#include <rapidjson/prettywriter.h>
+
+
+// some Ginkgo shortcuts
+using vector = gko::matrix::Dense<>;
+
+
+// helper for writing out rapidjson Values
+std::ostream &operator<<(std::ostream &os, const rapidjson::Value &value)
+{
+    rapidjson::OStreamWrapper jos(os);
+    rapidjson::PrettyWriter<rapidjson::OStreamWrapper> writer(jos);
+    value.Accept(writer);
+    return os;
+}
+
+
+// helper for setting rapidjson object members
+template <typename T, typename NameType, typename Allocator>
+void add_or_set_member(rapidjson::Value &object, NameType &&name, T &&value,
+                       Allocator &&allocator)
+{
+    if (object.HasMember(name)) {
+        object[name] = std::forward<T>(value);
+    } else {
+        object.AddMember(rapidjson::Value::StringRefType(name),
+                         std::forward<T>(value),
+                         std::forward<Allocator>(allocator));
+    }
+}
+
+
+// helper for splitting a comma-separated list into vector of strings
+std::vector<std::string> split(const std::string &s, char delimiter)
+{
+    std::istringstream iss(s);
+    std::vector<std::string> tokens;
+    for (std::string token; std::getline(iss, token, delimiter);
+         tokens.push_back(token))
+        ;
+    return tokens;
+}
+
+
+// input validation
+void print_config_error_and_exit()
+{
+    std::cerr << "Input has to be a JSON array of matrix configurations:\n"
+              << "  [\n"
+              << "    { \"filename\": \"my_file.mtx\" },\n"
+              << "    { \"filename\": \"my_file2.mtx\" }\n"
+              << "  ]" << std::endl;
+    exit(1);
+}
+
+
+void validate_option_object(const rapidjson::Value &value)
+{
+    if (!value.IsObject() || !value.HasMember("filename") ||
+        !value["filename"].IsString()) {
+        print_config_error_and_exit();
+    }
+}
+
+
+// Command-line arguments
+DEFINE_uint32(device_id, 0, "ID of the device where to run the code");
+
+DEFINE_uint32(max_iters, 1000,
+              "Maximal number of iterations the solver will be run for");
+
+DEFINE_uint32(max_block_size, 32,
+              "Maximal block size of the block-Jacobi preconditioner");
+
+DEFINE_string(
+    executor, "reference",
+    "The executor used to run the solver, one of: reference, omp, cuda");
+
+DEFINE_string(matrix_format, "csr", "The format in which to read the matrix");
+
+DEFINE_string(preconditioners, "jacobi",
+              "A comma-separated list of solvers to run."
+              "Supported values are: jacobi");
+
+DEFINE_uint32(rhs_seed, 1234, "Seed used to generate the right hand side");
+
+DEFINE_bool(overwrite, false,
+            "If true, overwrites existing results with new ones");
+
+DEFINE_string(backup, "",
+              "If set, the value is used as a file path of a backup"
+              " file where results are written after each test");
+
+DEFINE_string(double_buffer, "",
+              "If --backup is set, this variable can be set"
+              " to nonempty string to enable double"
+              " buffering of backup files, in case of a"
+              " crash when overwriting the backup");
+
+DEFINE_bool(detailed, true,
+            "If set, runs the preconditioner a second time, timing the "
+            "intermediate kernels and synchronizing between kernel launches");
+
+void initialize_argument_parsing(int *argc, char **argv[])
+{
+    std::ostringstream doc;
+    doc << "A benchmark for measuring preconditioner performance.\n"
+        << "Usage: " << (*argv)[0] << " [options]\n"
+        << "  The standard input should contain a list of test cases as a JSON "
+        << "array of objects:\n"
+        << "  [\n"
+        << "    { \"filename\": \"my_file.mtx\" },\n"
+        << "    { \"filename\": \"my_file2.mtx\" }\n"
+        << "  ]\n\n"
+        << "  The results are written to standard output, in the same format,\n"
+        << "  but with test cases extended to include an additional member \n"
+        << "  object for each preconditioner run in the benchmark.\n"
+        << "  If run with a --backup flag, an intermediate result is written \n"
+        << "  to a file in the same format. The backup file can be used as \n"
+        << "  input \n to this test suite, and the benchmarking will \n"
+        << "  continue from the point where the backup file was created.";
+
+    gflags::SetUsageMessage(doc.str());
+    std::ostringstream ver;
+    ver << gko::version_info::get();
+    gflags::SetVersionString(ver.str());
+    gflags::ParseCommandLineFlags(argc, argv, true);
+}
+
+
+// backup generation
+void backup_results(rapidjson::Document &results)
+{
+    static int next = 0;
+    static auto filenames = []() -> std::array<std::string, 2> {
+        if (FLAGS_double_buffer.size() > 0) {
+            return {FLAGS_backup, FLAGS_double_buffer};
+        } else {
+            return {FLAGS_backup, FLAGS_backup};
+        }
+    }();
+    if (FLAGS_backup.size() == 0) {
+        return;
+    }
+    std::ofstream ofs(filenames[next]);
+    ofs << results;
+    next = 1 - next;
+}
+
+
+// matrix format mapping
+template <typename MatrixType>
+std::unique_ptr<gko::LinOp> read_matrix(
+    std::shared_ptr<const gko::Executor> exec, const rapidjson::Value &options)
+{
+    return gko::read<MatrixType>(std::ifstream(options["filename"].GetString()),
+                                 std::move(exec));
+}
+
+const std::map<std::string, std::function<std::unique_ptr<gko::LinOp>(
+                                std::shared_ptr<const gko::Executor>,
+                                const rapidjson::Value &)>>
+    matrix_factory{{"csr", read_matrix<gko::matrix::Csr<>>},
+                   {"coo", read_matrix<gko::matrix::Coo<>>},
+                   {"ell", read_matrix<gko::matrix::Ell<>>},
+                   {"hybrid", read_matrix<gko::matrix::Hybrid<>>},
+                   {"sellp", read_matrix<gko::matrix::Sellp<>>}};
+
+
+// preconditioner mapping
+const std::map<std::string, std::function<std::unique_ptr<gko::LinOpFactory>(
+                                std::shared_ptr<const gko::Executor> exec)>>
+    precond_factory{
+        {"jacobi",
+         [](std::shared_ptr<const gko::Executor> exec) {
+             return gko::preconditioner::BlockJacobiFactory<>::create(
+                 exec, FLAGS_max_block_size);
+         }},
+        {"adaptive-jacobi", [](std::shared_ptr<const gko::Executor> exec) {
+             return gko::preconditioner::AdaptiveBlockJacobiFactory<>::create(
+                 exec, FLAGS_max_block_size);
+         }}};
+
+
+// executor mapping
+const std::map<std::string, std::function<std::shared_ptr<gko::Executor>()>>
+    executor_factory{
+        {"reference", [] { return gko::ReferenceExecutor::create(); }},
+        {"omp", [] { return gko::OmpExecutor::create(); }},
+        {"cuda", [] {
+             return gko::CudaExecutor::create(FLAGS_device_id,
+                                              gko::OmpExecutor::create());
+         }}};
+
+
+// preconditioner generation and application
+template <typename RandomEngine>
+std::unique_ptr<vector> create_rhs(std::shared_ptr<const gko::Executor> exec,
+                                   RandomEngine &engine, gko::size_type size)
+{
+    auto rhs = vector::create(exec);
+    rhs->read(gko::matrix_data<>(gko::dim<2>{size, 1},
+                                 std::uniform_real_distribution<>(-1.0, 1.0),
+                                 engine));
+    return rhs;
+}
+
+
+std::unique_ptr<vector> create_initial_guess(
+    std::shared_ptr<const gko::Executor> exec, gko::size_type size)
+{
+    auto rhs = vector::create(exec);
+    rhs->read(gko::matrix_data<>(gko::dim<2>{size, 1}));
+    return rhs;
+}
+
+
+template <typename Allocator>
+void run_preconditioner(const char *precond_name,
+                        std::shared_ptr<const gko::Executor> exec,
+                        std::shared_ptr<const gko::LinOp> system_matrix,
+                        const vector *b, const vector *x,
+                        rapidjson::Value &test_case, Allocator &allocator) try {
+    auto &precond_object = test_case["preconditioner"];
+    if (!FLAGS_overwrite && precond_object.HasMember(precond_name)) {
+        return;
+    }
+
+    add_or_set_member(precond_object, precond_name,
+                      rapidjson::Value(rapidjson::kObjectType), allocator);
+    add_or_set_member(precond_object[precond_name], "generate",
+                      rapidjson::Value(rapidjson::kObjectType), allocator);
+    add_or_set_member(precond_object[precond_name], "apply",
+                      rapidjson::Value(rapidjson::kObjectType), allocator);
+    for (auto stage : {"generate", "apply"}) {
+        add_or_set_member(precond_object[precond_name][stage], "components",
+                          rapidjson::Value(rapidjson::kObjectType), allocator);
+    }
+
+    /*
+    struct logger : gko::log::Logger {
+        void on_iteration_complete(
+            const gko::LinOp *, const gko::size_type &,
+            const gko::LinOp *residual, const gko::LinOp *solution,
+            const gko::LinOp *residual_norm) const override
+        {
+            if (residual_norm) {
+                rec_res_norms.PushBack(get_norm(gko::as<vector>(residual_norm)),
+                                       alloc);
+            } else {
+                rec_res_norms.PushBack(compute_norm(gko::as<vector>(residual)),
+                                       alloc);
+            }
+            if (solution) {
+                true_res_norms.PushBack(
+                    compute_residual_norm(matrix, b, gko::as<vector>(solution)),
+                    alloc);
+            } else {
+                true_res_norms.PushBack(-1.0, alloc);
+            }
+        }
+
+        logger(std::shared_ptr<const gko::Executor> exec,
+               const gko::LinOp *matrix, const vector *b,
+               rapidjson::Value &rec_res_norms,
+               rapidjson::Value &true_res_norms, Allocator &alloc)
+            : gko::log::Logger(exec),
+              matrix{matrix},
+              b{b},
+              rec_res_norms{rec_res_norms},
+              true_res_norms{true_res_norms},
+              alloc{alloc}
+        {}
+
+    private:
+        const gko::LinOp *matrix;
+        const vector *b;
+        rapidjson::Value &rec_res_norms;
+        rapidjson::Value &true_res_norms;
+        Allocator &alloc;
+    };*/
+
+    if (FLAGS_detailed) {
+        // slow run, times each component separately
+        /*
+        auto x_clone = clone(x);
+
+        auto solver =
+            solver_factory.at(solver_name)(exec)->generate(system_matrix);
+        solver->add_logger(std::make_shared<logger>(
+            exec, lend(system_matrix), b,
+            solver_case[solver_name]["recurrent_residuals"],
+            solver_case[solver_name]["true_residuals"], allocator));
+        solver->apply(lend(b), lend(x_clone));
+        */
+    }
+
+    // timed run
+    {
+        auto x_clone = clone(x);
+
+        auto precond = precond_factory.at(precond_name)(exec);
+
+        exec->synchronize();
+        auto g_tic = std::chrono::system_clock::now();
+
+        auto precond_op = precond->generate(system_matrix);
+
+        exec->synchronize();
+        auto g_tac = std::chrono::system_clock::now();
+
+        auto generate_time =
+            std::chrono::duration_cast<std::chrono::nanoseconds>(g_tac - g_tic);
+        add_or_set_member(precond_object[precond_name]["generate"], "time",
+                          generate_time.count(), allocator);
+
+        exec->synchronize();
+        auto a_tic = std::chrono::system_clock::now();
+
+        precond_op->apply(lend(b), lend(x_clone));
+
+        exec->synchronize();
+        auto a_tac = std::chrono::system_clock::now();
+
+        auto apply_time =
+            std::chrono::duration_cast<std::chrono::nanoseconds>(a_tac - a_tic);
+        add_or_set_member(precond_object[precond_name]["apply"], "time",
+                          apply_time.count(), allocator);
+    }
+
+    add_or_set_member(precond_object[precond_name], "completed", true,
+                      allocator);
+} catch (std::exception e) {
+    add_or_set_member(test_case["preconditioner"][precond_name], "completed",
+                      false, allocator);
+    std::cerr << "Error when processing test case " << test_case << "\n"
+              << "what(): " << e.what() << std::endl;
+}
+
+
+int main(int argc, char *argv[])
+{
+    initialize_argument_parsing(&argc, &argv);
+
+    std::clog << gko::version_info::get() << std::endl
+              << "Running on " << FLAGS_executor << "(" << FLAGS_device_id
+              << ")" << std::endl
+              << "Running preconditioners " << FLAGS_preconditioners
+              << std::endl
+              << "The random seed for right hand sides is " << FLAGS_rhs_seed
+              << std::endl;
+
+    auto exec = executor_factory.at(FLAGS_executor)();
+    auto preconditioners = split(FLAGS_preconditioners, ',');
+
+    rapidjson::IStreamWrapper jcin(std::cin);
+    rapidjson::Document test_cases;
+    test_cases.ParseStream(jcin);
+    if (!test_cases.IsArray()) {
+        print_config_error_and_exit();
+    }
+
+    std::ranlux24 rhs_engine(FLAGS_rhs_seed);
+    auto &allocator = test_cases.GetAllocator();
+
+    for (auto &test_case : test_cases.GetArray()) try {
+            // set up benchmark
+            validate_option_object(test_case);
+            if (!test_case.HasMember("preconditioner")) {
+                test_case.AddMember("preconditioner",
+                                    rapidjson::Value(rapidjson::kObjectType),
+                                    allocator);
+            }
+            auto &precond_object = test_case["preconditioner"];
+            if (!FLAGS_overwrite &&
+                all_of(begin(preconditioners), end(preconditioners),
+                       [&precond_object](const std::string &s) {
+                           return precond_object.HasMember(s.c_str());
+                       })) {
+                continue;
+            }
+            std::clog << "Running test case: " << test_case << std::endl;
+
+            auto system_matrix =
+                share(matrix_factory.at(FLAGS_matrix_format)(exec, test_case));
+            auto b = create_rhs(exec, rhs_engine, system_matrix->get_size()[0]);
+            auto x = create_initial_guess(exec, system_matrix->get_size()[0]);
+
+            std::clog << "Matrix is of size (" << system_matrix->get_size()[0]
+                      << ", " << system_matrix->get_size()[1] << ")"
+                      << std::endl;
+            for (const auto &precond_name : preconditioners) {
+                run_preconditioner(precond_name.c_str(), exec, system_matrix,
+                                   lend(b), lend(x), test_case, allocator);
+                std::clog << "Current state:" << std::endl
+                          << test_cases << std::endl;
+                backup_results(test_cases);
+            }
+        } catch (std::exception &e) {
+            std::cerr << "Error setting up preconditioner, what(): " << e.what()
+                      << std::endl;
+        }
+
+    std::cout << test_cases;
+}

--- a/core/base/name_demangling.hpp
+++ b/core/base/name_demangling.hpp
@@ -128,7 +128,7 @@ std::string get_enclosing_scope(const T &)
  * @see C++11 documentation [type.info] and [expr.typeid]
  * @see https://itanium-cxx-abi.github.io/cxx-abi/abi.html#demangler
  */
-#define GKO_FUNCTION_NAME gko::name_demangling::get_enclosing_scope_name([] {})
+#define GKO_FUNCTION_NAME gko::name_demangling::get_enclosing_scope([] {})
 
 
 }  // namespace name_demangling


### PR DESCRIPTION
This PR adds a benchmark runner for benchmarking preconditioners (for now block-Jacobi).

It runs both the generate and apply steps, can be set up to do multiple runs and report the results as average, and, using executor logging, can automatically detect the kernels (not CUDA kernels, but Ginkgo's kernels - the boundaries between Ginkgo core and the kernel modules) and report separate timings for each of them.

TODO:

- [x] merge #150 first, as this PR relies on that