### PR TITLE
Improved benchmark runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,93 @@ run the following from the build folder:
 
 where `path/to/test` is the path returned by `make test`.
 
+### Running the benchmarks
+
+In addition to the unit tests designed to verify correctness, Ginkgo also
+includes a benchmark suite for checking its performance on the system. To
+compile the benchmarks, the flag `-DBUILD_BENCHMARKS=ON` has to be set during
+the `cmake` step. In addition, the [`ssget` command-line
+utility](https://github.com/ginkgo-project/ssget) has to be installed on the
+system.
+
+The benchmark suite tests Ginkgo's performance using the [SuiteSparse matrix
+collection](https://sparse.tamu.edu/) and artificially generated matrices. The
+suite sparse collection will be downloaded automatically when the benchmarks are
+run. Please note that the entire collection requires roughly 100GB of disk
+storage in its compressed format, and roughly 25GB of additional disk space for
+intermediate data (such us uncompressing the archive). Additionally, the
+benchmark runs usually take a long time (SpMV benchmarks on the complete
+collection take roughly 24h using the K20 GPU), and will stress the system.
+
+The benchmark suite is invoked using the `make benchmark` command in the build
+directory. The behavior of the suite can be modified using environment
+variables. Assuming the `bash` shell is used, these can either be specified via
+the `export` command to persist between multiple runs:
+
+```sh
+export VARIABLE="value"
+...
+make benchmark
+```
+
+or specified on the fly, on the same line as the `make benchmark` command:
+
+```sh
+env VARIABLE="value" ... make benchmark
+```
+
+Since `make` sets any variables passed to it as temporary environment variables,
+the following shorthand can also be used:
+
+```sh
+make benchmark VARIABLE="value" ...
+```
+
+A combinaion of the above approaches is also possible (e.g. it may be useful to
+`export` the `SYSTEM_NAME` variable, and specify the others at every benchmark
+run).
+
+Supported environment variables are described in the following list:
+
+*   `BENCHMARK={spmv, solver, preconditioner}` - The benchmark set to run.
+    Default is `spmv`.
+    *   `spmv` - Runs the sparse matrix-vector product benchmarks on the
+                 SuiteSparse collection.
+    *   `solver` - Runs the solver benchmarks on the SuiteSparse collection.
+                The matrix format is determined by running the `spmv` benchmarks
+                first, and using the fastest format determined by that
+                benchmark.
+    *   `preconditioner` - Runs the preconditioner benchmarks on artificially
+                generated block-diagonal matrices.
+*   `DRY_RUN={true, false}` - If set to `true`, prepares the system for the
+    benchmark runs (downloads the collections, creates the result structure,
+    etc.) and outputs the list of commands that would normally be run, but does
+    not run the benchmarks themselves. Default is `false`.
+*   `EXECUTOR={reference,cuda,omp}` - The executor used for running the
+    benchmarks. Default is `cuda`.
+*   `SEGMENTS=<N>` - Splits the benchmark suite into `<N>` segments. This option
+    is usefull for running the benchmarks on an HPC system with a batch
+    scheduler, as it enables partitioning of the benchmark suite and runing it
+    concurrently on multiple nodes of the system. If specified, `SEGMENT_ID`
+    also has to be set. Default is `1`.
+*   `SEGMENT_ID=<I>` - used in combination with the `SEGMENTS` variable. `<I>`
+    should be an integer between 1 and `<N>`. If specified, only the `<I>`-th
+    segment of the benchmark suite will be run. Default is `1`.
+*   `SYSTEM_NAME=<name>` - the name of the system where the benchmarks are being
+    run. This option only changes the directory where the benchmark results are
+    stored. It can be used to avoid overwritting the benchmarks if multiple
+    systems share the same filesystem, or when copying the results between
+    systems. Default is `unknown`.
+
+Once `make benchmark` completes, the results can be found in
+`<Ginkgo build directory>/benchmark/results/${SYSTEM_NAME}/`. The files are
+written in the JSON format, and can be analyzed using any of the data
+analysis tools that support JSON. Alternatively, they can be uploaded to an
+online repository, and analyzed using Ginkgo's free web tool
+[Ginkgo Performance Explorer (GPE)](https://ginkgo-project.github.io/gpe/).
+(Make sure to change the "Performance data URL" to your repository if using
+GPE.)
+
 ### Installing Ginkgo
 
 To install Ginkgo into the specified folder, execute the following command in

--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ the following shorthand can also be used:
 make benchmark VARIABLE="value" ...
 ```
 
-A combinaion of the above approaches is also possible (e.g. it may be useful to
+A combination of the above approaches is also possible (e.g. it may be useful to
 `export` the `SYSTEM_NAME` variable, and specify the others at every benchmark
 run).
 
@@ -228,7 +228,9 @@ Supported environment variables are described in the following list:
     *   `solver` - Runs the solver benchmarks on the SuiteSparse collection.
                 The matrix format is determined by running the `spmv` benchmarks
                 first, and using the fastest format determined by that
-                benchmark.
+                benchmark. The maximum number of iterations for the iterative
+                solvers is set to 10,000 and the requested residual reduction
+                factor to 1e-6.
     *   `preconditioner` - Runs the preconditioner benchmarks on artificially
                 generated block-diagonal matrices.
 *   `DRY_RUN={true, false}` - If set to `true`, prepares the system for the
@@ -238,8 +240,8 @@ Supported environment variables are described in the following list:
 *   `EXECUTOR={reference,cuda,omp}` - The executor used for running the
     benchmarks. Default is `cuda`.
 *   `SEGMENTS=<N>` - Splits the benchmark suite into `<N>` segments. This option
-    is usefull for running the benchmarks on an HPC system with a batch
-    scheduler, as it enables partitioning of the benchmark suite and runing it
+    is useful for running the benchmarks on an HPC system with a batch
+    scheduler, as it enables partitioning of the benchmark suite and running it
     concurrently on multiple nodes of the system. If specified, `SEGMENT_ID`
     also has to be set. Default is `1`.
 *   `SEGMENT_ID=<I>` - used in combination with the `SEGMENTS` variable. `<I>`
@@ -247,7 +249,7 @@ Supported environment variables are described in the following list:
     segment of the benchmark suite will be run. Default is `1`.
 *   `SYSTEM_NAME=<name>` - the name of the system where the benchmarks are being
     run. This option only changes the directory where the benchmark results are
-    stored. It can be used to avoid overwritting the benchmarks if multiple
+    stored. It can be used to avoid overwriting the benchmarks if multiple
     systems share the same filesystem, or when copying the results between
     systems. Default is `unknown`.
 

--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -18,15 +18,9 @@ add_custom_command(
             ${CMAKE_CURRENT_SOURCE_DIR}/run_all_benchmarks.sh
             ${CMAKE_CURRENT_BINARY_DIR}/run_all_benchmarks.sh)
 
-function (add_benchmark_target executor)
-    add_custom_target(${executor}_benchmark)
-    add_custom_command(
-        TARGET ${executor}_benchmark POST_BUILD
-        COMMAND bash run_all_benchmarks.sh ${executor} >/dev/null
-        DEPENDS make_run_all_benchmarks
-        WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
-endfunction()
-
-add_benchmark_target(reference)
-add_benchmark_target(omp)
-add_benchmark_target(cuda)
+add_custom_target(benchmark)
+add_custom_command(
+    TARGET benchmark POST_BUILD
+    COMMAND bash run_all_benchmarks.sh >/dev/null
+    DEPENDS make_run_all_benchmarks
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})

--- a/benchmark/matrix_statistics/matrix_statistics.cpp
+++ b/benchmark/matrix_statistics/matrix_statistics.cpp
@@ -37,6 +37,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <cmath>
 #include <fstream>
 #include <iostream>
+#include <stdexcept>
 #include <vector>
 
 
@@ -56,7 +57,9 @@ std::ostream &operator<<(std::ostream &os, const rapidjson::Value &value)
 {
     rapidjson::OStreamWrapper jos(os);
     rapidjson::PrettyWriter<rapidjson::OStreamWrapper> writer(jos);
-    value.Accept(writer);
+    if (!value.Accept(writer)) {
+        throw std::runtime_error("Error writing data");
+    }
     return os;
 }
 
@@ -211,6 +214,9 @@ void compute_summary(const std::vector<gko::size_type> &dist,
 double compute_moment(int degree, const std::vector<gko::size_type> &dist,
                       double center = 0.0, double normalization = 1.0)
 {
+    if (normalization == 0.0) {
+        return 0.0;
+    }
     auto moment = 0.0;
     for (const auto &x : dist) {
         moment += std::pow(x - center, degree);

--- a/benchmark/run_all_benchmarks.sh
+++ b/benchmark/run_all_benchmarks.sh
@@ -1,55 +1,55 @@
-EXECUTOR=$1
+################################################################################
+# Environment variable detection
+
+if [ ! "${BENCHMARK}" ]; then
+    echo "BENCHMARK   environment variable not set - assuming \"spmv\"" 1>&2
+    BENCHMARK="spmv"
+fi
+
+if [ ! "${DRY_RUN}" ]; then
+    echo "DRY_RUN     environment variable not set - assuming \"false\"" 1>&2
+    DRY_RUN="false"
+fi
+
+if [ ! "${EXECUTOR}" ]; then
+    echo "EXECUTOR    environment variable not set - assuming \"cuda\"" 1>&2
+    EXECUTOR="cuda"
+fi
+
+if [ ! "${SEGMENTS}" ]; then
+    echo "SEGMENTS    environment variable not set - running entire suite" 1>&2
+    SEGMENTS=1
+    SEGMENT_ID=1
+elif [ ! "${SEGMENT_ID}" ]; then
+    echo "SEGMENT_ID  environment variable not set - exiting" 1>&2
+    exit 1
+fi
+
+if [ ! "${SYSTEM_NAME}" ]; then
+    echo "SYSTEM_MANE environment variable not set - assuming \"unknown\"" 1>&2
+    SYSTEM_NAME="unknown"
+fi
 
 
-SSGET=ssget
-NUM_PROBLEMS=$(${SSGET} -n)
-NUM_PROBLEMS=10
-
+################################################################################
+# Utilities
 
 # Checks the creation dates of a set of files $@, replaces file $1
 # with the newest file from the set, and deletes the other
 # files.
 keep_latest() {
-    RESULT=$1
+    RESULT="$1"
     for file in $@; do
-        if [ ${file} -nt ${RESULT} ]; then
-            RESULT=${file}
+        if [ "${file}" -nt "${RESULT}" ]; then
+            RESULT="${file}"
         fi
     done
     if [ "${RESULT}" != "$1" ]; then
-        cp ${RESULT} $1
+        cp "${RESULT}" "$1"
     fi
     for file in ${@:2}; do
-        rm -f ${file}
+        rm -f "${file}"
     done
-}
-
-
-# Creates an input file for $1-th problem in the SuiteSparse collection
-generate_suite_sparse_input() {
-    INPUT=$(${SSGET} -i $i -e)
-    cat << EOT
-[{
-    "filename": "${INPUT}",
-    "problem": $(${SSGET} -i $i -j)
-}]
-EOT
-}
-
-
-# Creates an input file for a block diagonal matrix with block size $1 and
-# number of blocks $2. The location of the matrix is given by $3.
-generate_block_diagonal_input() {
-    cat << EOT
-[{
-    "filename": "$3",
-    "problem": {
-        "type": "block-diagonal",
-        "num_blocks": $2,
-        "block_size": $1
-    }
-}]
-EOT
 }
 
 
@@ -59,11 +59,12 @@ EOT
 # backups and the results are combined, and the newest file is taken as the
 # final result.
 compute_matrix_statistics() {
-    cp $1 "$1.imd" # make sure we're not loosing the original input
+    [ "${DRY_RUN}" == "true" ] && return
+    cp "$1" "$1.imd" # make sure we're not loosing the original input
     ./matrix_statistics/matrix_statistics \
         --backup="$1.bkp" --double_buffer="$1.bkp2" \
-        <"$1.imd" 2>&1 >$1
-    keep_latest $1 "$1.bkp" "$1.bkp2" "$1.imd"
+        <"$1.imd" 2>&1 >"$1"
+    keep_latest "$1" "$1.bkp" "$1.bkp2" "$1.imd"
 }
 
 
@@ -73,11 +74,12 @@ compute_matrix_statistics() {
 # is completed, the backups and the results are combined, and the newest file is
 # taken as the final result.
 run_spmv_benchmarks() {
-    cp $1 "$1.imd" # make sure we're not loosing the original input
+    [ "${DRY_RUN}" == "true" ] && return
+    cp "$1" "$1.imd" # make sure we're not loosing the original input
     ./spmv/spmv --backup="$1.bkp" --double_buffer="$1.bkp2" \
-                --executor=${EXECUTOR} --formats="csr,coo,hybrid,sellp,ell" \
-                <"$1.imd" 2>&1 >$1
-    keep_latest $1 "$1.bkp" "$1.bkp2" "$1.imd"
+                --executor="${EXECUTOR}" --formats="csr,coo,hybrid,sellp,ell" \
+                <"$1.imd" 2>&1 >"$1"
+    keep_latest "$1" "$1.bkp" "$1.bkp2" "$1.imd"
 }
 
 
@@ -87,12 +89,13 @@ run_spmv_benchmarks() {
 # is completed, the backups and the results are combined, and the newest file is
 # taken as the final result.
 run_solver_benchmarks() {
-    cp $1 "$1.imd" # make sure we're not loosing the original input
+    [ "${DRY_RUN}" == "true" ] && return
+    cp "$1" "$1.imd" # make sure we're not loosing the original input
     ./solver/solver --backup="$1.bkp" --double_buffer="$1.bkp2" \
-                    --executor=${EXECUTOR} --solvers="cg,bicgstab,cgs,fcg" \
+                    --executor="${EXECUTOR}" --solvers="cg,bicgstab,cgs,fcg" \
                     --max_iters=10000 --rel_res_goal=1e-6 \
-                    <"$1.imd" 2>&1 >$1
-    keep_latest $1 "$1.bkp" "$1.bkp2" "$1.imd"
+                    <"$1.imd" 2>&1 >"$1"
+    keep_latest "$1" "$1.bkp" "$1.bkp2" "$1.imd"
 }
 
 
@@ -102,54 +105,73 @@ run_solver_benchmarks() {
 # benchmarking is completed, the backups and the results are combined, and the
 # newest file is taken as the final result.
 run_preconditioner_benchmarks() {
+    [ "${DRY_RUN}" == "true" ] && return
     local bsize
     for bsize in {1..32}; do
         echo -e "\t\t running jacobi for block size ${bsize}/32" 1>&2
-        cp $1 "$1.imd" # make sure we're not loosing the original input
+        cp "$1" "$1.imd" # make sure we're not loosing the original input
         ./preconditioner/preconditioner \
             --backup="$1.bkp" --double_buffer="$1.bkp2" \
-            --executor=${EXECUTOR} --preconditioners=jacobi \
-            --max_block_size=${bsize} \
-            <"$1.imd" 2>&1 >$1
-        keep_latest $1 "$1.bkp" "$1.bkp2" "$1.imd"
+            --executor="${EXECUTOR}" --preconditioners="jacobi" \
+            --max_block_size="${bsize}" \
+            <"$1.imd" 2>&1 >"$1"
+        keep_latest "$1" "$1.bkp" "$1.bkp2" "$1.imd"
     done
 }
 
 
-# SuiteSparse matrices
-for (( i=1; i <= ${NUM_PROBLEMS}; ++i )); do
+################################################################################
+# SuiteSparse collection
+
+SSGET=ssget
+NUM_PROBLEMS="$(${SSGET} -n)"
+
+# Creates an input file for $1-th problem in the SuiteSparse collection
+generate_suite_sparse_input() {
+    INPUT=$(${SSGET} -i "$1" -e)
+    cat << EOT
+[{
+    "filename": "${INPUT}",
+    "problem": $(${SSGET} -i "$1" -j)
+}]
+EOT
+}
+
+LOOP_START=$((1 + (${NUM_PROBLEMS}) * (${SEGMENT_ID} - 1) / ${SEGMENTS}))
+LOOP_END=$((1 + (${NUM_PROBLEMS}) * (${SEGMENT_ID}) / ${SEGMENTS}))
+for (( i=${LOOP_START}; i < ${LOOP_END}; ++i )); do
     if [ "${BENCHMARK}" == "preconditioner" ]; then
         break
     fi
-    if [ $(${SSGET} -i $i -preal) = "0" ]; then
-        ${SSGET} -i $i -c >/dev/null
+    if [ "$(${SSGET} -i "$i" -preal)" = "0" ]; then
+        [ "${DRY_RUN}" != "true" ] && ${SSGET} -i "$i" -c >/dev/null
         continue
     fi
     RESULT_DIR="results/${SYSTEM_NAME}/${EXECUTOR}/SuiteSparse"
-    GROUP=$(${SSGET} -i $i -pgroup)
-    NAME=$(${SSGET} -i $i -pname)
+    GROUP=$(${SSGET} -i "$i" -pgroup)
+    NAME=$(${SSGET} -i "$i" -pname)
     RESULT_FILE="${RESULT_DIR}/${GROUP}/${NAME}.json"
     PREFIX="($i/${NUM_PROBLEMS}):\t"
-    mkdir -p $(dirname ${RESULT_FILE})
-    generate_suite_sparse_input $i >${RESULT_FILE}
+    mkdir -p "$(dirname "${RESULT_FILE}")"
+    generate_suite_sparse_input "$i" >"${RESULT_FILE}"
 
     echo -e "${PREFIX}Extracting statistics for ${GROUP}/${NAME}" 1>&2
-    compute_matrix_statistics ${RESULT_FILE}
+    compute_matrix_statistics "${RESULT_FILE}"
 
     echo -e "${PREFIX}Running SpMV for ${GROUP}/${NAME}" 1>&2
-    run_spmv_benchmarks ${RESULT_FILE}
+    run_spmv_benchmarks "${RESULT_FILE}"
 
     if [ "${BENCHMARK}" != "solver" -o \
-         "$(${SSGET} -i $i -prows)" != "$(${SSGET} -i $i -pcols)" ]; then
-        ${SSGET} -i $i -c >/dev/null
+         "$(${SSGET} -i "$i" -prows)" != "$(${SSGET} -i "$i" -pcols)" ]; then
+        [ "${DRY_RUN}" != "true" ] && ${SSGET} -i "$i" -c >/dev/null
         continue
     fi
 
     echo -e "${PREFIX}Running solvers for ${GROUP}/${NAME}" 1>&2
-    run_solver_benchmarks ${RESULT_FILE}
+    run_solver_benchmarks "${RESULT_FILE}"
 
     echo -e "${PREFIX}Cleaning up problem ${GROUP}/${NAME}" 1>&2
-    ${SSGET} -i $i -c >/dev/null
+    [ "${DRY_RUN}" != "true" ] && ${SSGET} -i "$i" -c >/dev/null
 done
 
 
@@ -158,41 +180,88 @@ if [ "${BENCHMARK}" != "preconditioner" ]; then
 fi
 
 
-# block diagonal matrices
+################################################################################
+# Generated collection
+
+count_tokens() { echo "$#"; }
+
 BLOCK_SIZES="$(seq 1 32)"
 NUM_BLOCKS="$(seq 10000 2000 50000)"
-
-count_tokens() { echo $#; }
 NUM_PROBLEMS=$((
     $(count_tokens ${BLOCK_SIZES}) * $(count_tokens ${NUM_BLOCKS}) ))
-ID=1
+ID=0
 
+
+# Creates an input file for a block diagonal matrix with block size $1 and
+# number of blocks $2. The location of the matrix is given by $3.
+generate_block_diagonal_input() {
+    cat << EOT
+[{
+    "filename": "$3",
+    "problem": {
+        "collection": "generated",
+        "group": "block-diagonal",
+        "name": "$2-$1",
+        "type": "block-diagonal",
+        "real": true,
+        "binary": false,
+        "2d3d": false,
+        "posdef": false,
+        "psym": 1,
+        "nsym": 0,
+        "kind": "artificially generated problem",
+        "num_blocks": $2,
+        "block_size": $1
+    }
+}]
+EOT
+}
+
+
+# Generates the problem data using the input file $1
+generate_problem() {
+    [ "${DRY_RUN}" == "true" ] && return
+    cp "$1" "$1.tmp"
+    ./matrix_generator/matrix_generator <"$1.tmp" 2>&1 >"$1"
+    keep_latest "$1" "$1.tmp"
+}
+
+
+LOOP_START=$((1 + (${NUM_PROBLEMS}) * (${SEGMENT_ID} - 1) / ${SEGMENTS}))
+LOOP_END=$((1 + (${NUM_PROBLEMS}) * (${SEGMENT_ID}) / ${SEGMENTS}))
 for bsize in ${BLOCK_SIZES}; do
     for nblocks in ${NUM_BLOCKS}; do
+        ID=$((${ID} + 1))
+        if [ "${ID}" -ge "${LOOP_END}" ]; then
+            break
+        fi
+        if [ "${ID}" -lt "${LOOP_START}" ]; then
+            continue
+        fi
         RESULT_DIR="results/${SYSTEM_NAME}/${EXECUTOR}/Generated"
         GROUP="block-diagonal"
         NAME="${nblocks}-${bsize}"
         RESULT_FILE="${RESULT_DIR}/${GROUP}/${NAME}.json"
         PREFIX="(${ID}/${NUM_PROBLEMS}):\t"
-        mkdir -p $(dirname ${RESULT_FILE})
+        mkdir -p "$(dirname "${RESULT_FILE}")"
         mkdir -p "/tmp/${GROUP}"
         generate_block_diagonal_input \
-            ${bsize} ${nblocks} "/tmp/${GROUP}/${NAME}.mtx" >${RESULT_FILE}
+            "${bsize}" "${nblocks}" "/tmp/${GROUP}/${NAME}.mtx" \
+                >"${RESULT_FILE}"
 
         echo -e "${PREFIX}Generating problem ${GROUP}/${NAME}" 1>&2
-        cp "${RESULT_FILE}" "${RESULT_FILE}.tmp"
-        ./matrix_generator/matrix_generator <"${RESULT_FILE}.tmp" 2>&1 \
-            >${RESULT_FILE}
-        rm "${RESULT_FILE}.tmp"
+        generate_problem "${RESULT_FILE}"
 
         echo -e "${PREFIX}Extracting statistics for ${GROUP}/${NAME}" 1>&2
-        compute_matrix_statistics ${RESULT_FILE}
+        compute_matrix_statistics "${RESULT_FILE}"
 
         echo -e "${PREFIX}Running preconditioners for ${GROUP}/${NAME}" 1>&2
-        run_preconditioner_benchmarks ${RESULT_FILE}
+        run_preconditioner_benchmarks "${RESULT_FILE}"
 
         echo -e "${PREFIX}Cleaning up problem ${GROUP}/${NAME}" 1>&2
-        rm -r "/tmp/${GROUP}/${NAME}.mtx"
-        ID=$(( ${ID} + 1 ))
+        [ "${DRY_RUN}" != "true" ] && rm -r "/tmp/${GROUP}/${NAME}.mtx"
     done
+    if [ "${ID}" -ge "${LOOP_END}" ]; then
+        break
+    fi
 done

--- a/benchmark/run_all_benchmarks.sh
+++ b/benchmark/run_all_benchmarks.sh
@@ -3,6 +3,7 @@ EXECUTOR=$1
 
 SSGET=ssget
 NUM_PROBLEMS=$(${SSGET} -n)
+NUM_PROBLEMS=10
 
 
 # Checks the creation dates of a set of files $@, replaces file $1
@@ -24,13 +25,29 @@ keep_latest() {
 }
 
 
-# Creates an input file for SpMV benchmark for $1-th problem in the collection
-generate_benchmark_input() {
+# Creates an input file for $1-th problem in the SuiteSparse collection
+generate_suite_sparse_input() {
     INPUT=$(${SSGET} -i $i -e)
     cat << EOT
 [{
     "filename": "${INPUT}",
     "problem": $(${SSGET} -i $i -j)
+}]
+EOT
+}
+
+
+# Creates an input file for a block diagonal matrix with block size $1 and
+# number of blocks $2. The location of the matrix is given by $3.
+generate_block_diagonal_input() {
+    cat << EOT
+[{
+    "filename": "$3",
+    "problem": {
+        "type": "block-diagonal",
+        "num_blocks": $2,
+        "block_size": $1
+    }
 }]
 EOT
 }
@@ -79,7 +96,31 @@ run_solver_benchmarks() {
 }
 
 
+# Runs the preconditioner benchmarks for all supported preconditioners by using
+# file $1 as the input, and updating it with the results. Backups are created
+# after each benchmark run, to prevent data loss in case of a crash. Once the
+# benchmarking is completed, the backups and the results are combined, and the
+# newest file is taken as the final result.
+run_preconditioner_benchmarks() {
+    local bsize
+    for bsize in {1..32}; do
+        echo -e "\t\t running jacobi for block size ${bsize}/32" 1>&2
+        cp $1 "$1.imd" # make sure we're not loosing the original input
+        ./preconditioner/preconditioner \
+            --backup="$1.bkp" --double_buffer="$1.bkp2" \
+            --executor=${EXECUTOR} --preconditioners=jacobi \
+            --max_block_size=${bsize} \
+            <"$1.imd" 2>&1 >$1
+        keep_latest $1 "$1.bkp" "$1.bkp2" "$1.imd"
+    done
+}
+
+
+# SuiteSparse matrices
 for (( i=1; i <= ${NUM_PROBLEMS}; ++i )); do
+    if [ "${BENCHMARK}" == "preconditioner" ]; then
+        break
+    fi
     if [ $(${SSGET} -i $i -preal) = "0" ]; then
         ${SSGET} -i $i -c >/dev/null
         continue
@@ -88,14 +129,14 @@ for (( i=1; i <= ${NUM_PROBLEMS}; ++i )); do
     GROUP=$(${SSGET} -i $i -pgroup)
     NAME=$(${SSGET} -i $i -pname)
     RESULT_FILE="${RESULT_DIR}/${GROUP}/${NAME}.json"
+    PREFIX="($i/${NUM_PROBLEMS}):\t"
     mkdir -p $(dirname ${RESULT_FILE})
-    generate_benchmark_input $i >${RESULT_FILE}
+    generate_suite_sparse_input $i >${RESULT_FILE}
 
-    echo -e \
-        "($i/${NUM_PROBLEMS}):\tExtracting statistics for ${GROUP}/${NAME}" 1>&2
+    echo -e "${PREFIX}Extracting statistics for ${GROUP}/${NAME}" 1>&2
     compute_matrix_statistics ${RESULT_FILE}
 
-    echo -e "($i/${NUM_PROBLEMS}):\tRunning SpMV for ${GROUP}/${NAME}" 1>&2
+    echo -e "${PREFIX}Running SpMV for ${GROUP}/${NAME}" 1>&2
     run_spmv_benchmarks ${RESULT_FILE}
 
     if [ "${BENCHMARK}" != "solver" -o \
@@ -104,8 +145,54 @@ for (( i=1; i <= ${NUM_PROBLEMS}; ++i )); do
         continue
     fi
 
-    echo -e "($i/${NUM_PROBLEMS}):\tRunning Solvers for ${GROUP}/${NAME}" 1>&2
+    echo -e "${PREFIX}Running solvers for ${GROUP}/${NAME}" 1>&2
     run_solver_benchmarks ${RESULT_FILE}
 
+    echo -e "${PREFIX}Cleaning up problem ${GROUP}/${NAME}" 1>&2
     ${SSGET} -i $i -c >/dev/null
+done
+
+
+if [ "${BENCHMARK}" != "preconditioner" ]; then
+    exit
+fi
+
+
+# block diagonal matrices
+BLOCK_SIZES="$(seq 1 32)"
+NUM_BLOCKS="$(seq 10000 2000 50000)"
+
+count_tokens() { echo $#; }
+NUM_PROBLEMS=$((
+    $(count_tokens ${BLOCK_SIZES}) * $(count_tokens ${NUM_BLOCKS}) ))
+ID=1
+
+for bsize in ${BLOCK_SIZES}; do
+    for nblocks in ${NUM_BLOCKS}; do
+        RESULT_DIR="results/${SYSTEM_NAME}/${EXECUTOR}/Generated"
+        GROUP="block-diagonal"
+        NAME="${nblocks}-${bsize}"
+        RESULT_FILE="${RESULT_DIR}/${GROUP}/${NAME}.json"
+        PREFIX="(${ID}/${NUM_PROBLEMS}):\t"
+        mkdir -p $(dirname ${RESULT_FILE})
+        mkdir -p "/tmp/${GROUP}"
+        generate_block_diagonal_input \
+            ${bsize} ${nblocks} "/tmp/${GROUP}/${NAME}.mtx" >${RESULT_FILE}
+
+        echo -e "${PREFIX}Generating problem ${GROUP}/${NAME}" 1>&2
+        cp "${RESULT_FILE}" "${RESULT_FILE}.tmp"
+        ./matrix_generator/matrix_generator <"${RESULT_FILE}.tmp" 2>&1 \
+            >${RESULT_FILE}
+        rm "${RESULT_FILE}.tmp"
+
+        echo -e "${PREFIX}Extracting statistics for ${GROUP}/${NAME}" 1>&2
+        compute_matrix_statistics ${RESULT_FILE}
+
+        echo -e "${PREFIX}Running preconditioners for ${GROUP}/${NAME}" 1>&2
+        run_preconditioner_benchmarks ${RESULT_FILE}
+
+        echo -e "${PREFIX}Cleaning up problem ${GROUP}/${NAME}" 1>&2
+        rm -r "/tmp/${GROUP}/${NAME}.mtx"
+        ID=$(( ${ID} + 1 ))
+    done
 done


### PR DESCRIPTION
This PR adds the preconditioner benchmark to the benchmark runner script and generally improves the structure of the script.

Benchmark configuration is done entirely using environment variables and the make target is changed to simply `make benchmark`. It is explained in more detail in the README.

@tcojean I guess we would also need to modify the CI configurations a bit to accommodate these changes?

## TODO:

- [x] merge #151 first