### PR TITLE
Correctly handle CUDA builds with no GPUs

### DIFF
--- a/third_party/CudaArchitectureSelector/CMakeLists.txt
+++ b/third_party/CudaArchitectureSelector/CMakeLists.txt
@@ -1,5 +1,5 @@
 load_git_package(CudaArchitectureSelector
     "https://github.com/ginkgo-project/CudaArchitectureSelector.git"
-    "759437d2976d4bd44c94fb9d5ef9362ea9260b00")
+    "d05d51d165d154e70e348443577cce6f93c20383")
 
 set(CMAKE_MODULE_PATH "${CMAKE_MODULE_PATH}" PARENT_SCOPE)


### PR DESCRIPTION
This PR updates the version of cuda architecture selector, so it does not crash when no GPUs are detected (fixes #156).
Here is the relevant changeset from the architecture selector repository: https://github.com/ginkgo-project/CudaArchitectureSelector/commit/d05d51d165d154e70e348443577cce6f93c20383