### PR TITLE
Improved storage scheme for block-Jacobi

### DIFF
--- a/core/preconditioner/block_jacobi.cpp
+++ b/core/preconditioner/block_jacobi.cpp
@@ -147,7 +147,7 @@ void BlockJacobi<ValueType, IndexType>::write(mat_data &data) const
             for (IndexType col = 0; col < block_size; ++col) {
                 data.nonzeros.emplace_back(
                     ptrs[block] + row, ptrs[block] + col,
-                    block_data[row * tmp->get_stride() + col]);
+                    block_data[row + col * tmp->get_stride()]);
             }
         }
     }
@@ -295,7 +295,7 @@ void AdaptiveBlockJacobi<ValueType, IndexType>::write(mat_data &data) const
                     data.nonzeros.emplace_back(
                         ptrs[block] + row, ptrs[block] + col,
                         static_cast<ValueType>(
-                            block_data[row * tmp->get_stride() + col]));
+                            block_data[row + col * tmp->get_stride()]));
                 }
             }
         });

--- a/cuda/preconditioner/block_jacobi_kernels.cu
+++ b/cuda/preconditioner/block_jacobi_kernels.cu
@@ -77,7 +77,7 @@ __global__ void __launch_bounds__(warps_per_block *cuda_config::warp_size)
         auto trans_perm = subwarp.thread_rank();
         invert_block<max_block_size>(subwarp, block_size, row, perm,
                                      trans_perm);
-        copy_matrix<max_block_size>(
+        copy_matrix<max_block_size, and_transpose>(
             subwarp, block_size, row, 1, perm, trans_perm,
             block_data + (block_ptrs[block_id] * stride), stride);
     }
@@ -104,7 +104,7 @@ __global__ void __launch_bounds__(warps_per_block *cuda_config::warp_size)
     if (subwarp.thread_rank() < block_size) {
         v = b[(block_ptrs[block_id] + subwarp.thread_rank()) * b_stride];
     }
-    multiply_transposed_vec<max_block_size>(
+    multiply_vec<max_block_size>(
         subwarp, block_size, v,
         blocks + block_ptrs[block_id] * stride + subwarp.thread_rank(), stride,
         x + block_ptrs[block_id] * x_stride, x_stride);

--- a/reference/test/preconditioner/block_jacobi_kernels.cpp
+++ b/reference/test/preconditioner/block_jacobi_kernels.cpp
@@ -223,21 +223,21 @@ TEST_F(BlockJacobi, InvertsDiagonalBlocks)
     bj = static_cast<Bj *>(bj_lin_op.get());
     auto p = bj->get_stride();
     auto b1 = bj->get_blocks();
-    EXPECT_NEAR(b1[0 * p + 0], 4.0 / 14.0, 1e-14);
-    EXPECT_NEAR(b1[0 * p + 1], 2.0 / 14.0, 1e-14);
-    EXPECT_NEAR(b1[1 * p + 0], 1.0 / 14.0, 1e-14);
-    EXPECT_NEAR(b1[1 * p + 1], 4.0 / 14.0, 1e-14);
+    EXPECT_NEAR(b1[0 + 0 * p], 4.0 / 14.0, 1e-14);
+    EXPECT_NEAR(b1[0 + 1 * p], 2.0 / 14.0, 1e-14);
+    EXPECT_NEAR(b1[1 + 0 * p], 1.0 / 14.0, 1e-14);
+    EXPECT_NEAR(b1[1 + 1 * p], 4.0 / 14.0, 1e-14);
 
     auto b2 = bj->get_blocks() + 2 * p;
-    EXPECT_NEAR(b2[0 * p + 0], 14.0 / 48.0, 1e-14);
-    EXPECT_NEAR(b2[0 * p + 1], 8.0 / 48.0, 1e-14);
-    EXPECT_NEAR(b2[0 * p + 2], 4.0 / 48.0, 1e-14);
-    EXPECT_NEAR(b2[1 * p + 0], 4.0 / 48.0, 1e-14);
-    EXPECT_NEAR(b2[1 * p + 1], 16.0 / 48.0, 1e-14);
-    EXPECT_NEAR(b2[1 * p + 2], 8.0 / 48.0, 1e-14);
-    EXPECT_NEAR(b2[2 * p + 0], 1.0 / 48.0, 1e-14);
-    EXPECT_NEAR(b2[2 * p + 1], 4.0 / 48.0, 1e-14);
-    EXPECT_NEAR(b2[2 * p + 2], 14.0 / 48.0, 1e-14);
+    EXPECT_NEAR(b2[0 + 0 * p], 14.0 / 48.0, 1e-14);
+    EXPECT_NEAR(b2[0 + 1 * p], 8.0 / 48.0, 1e-14);
+    EXPECT_NEAR(b2[0 + 2 * p], 4.0 / 48.0, 1e-14);
+    EXPECT_NEAR(b2[1 + 0 * p], 4.0 / 48.0, 1e-14);
+    EXPECT_NEAR(b2[1 + 1 * p], 16.0 / 48.0, 1e-14);
+    EXPECT_NEAR(b2[1 + 2 * p], 8.0 / 48.0, 1e-14);
+    EXPECT_NEAR(b2[2 + 0 * p], 1.0 / 48.0, 1e-14);
+    EXPECT_NEAR(b2[2 + 1 * p], 4.0 / 48.0, 1e-14);
+    EXPECT_NEAR(b2[2 + 2 * p], 14.0 / 48.0, 1e-14);
 }
 
 
@@ -262,15 +262,15 @@ TEST_F(BlockJacobi, PivotsWhenInvertingBlock)
     bj = static_cast<Bj *>(bj_lin_op.get());
     auto p = bj->get_stride();
     auto b1 = bj->get_blocks();
-    EXPECT_NEAR(b1[0 * p + 0], 0.0 / 4.0, 1e-14);
-    EXPECT_NEAR(b1[0 * p + 1], 0.0 / 4.0, 1e-14);
-    EXPECT_NEAR(b1[0 * p + 2], 4.0 / 4.0, 1e-14);
-    EXPECT_NEAR(b1[1 * p + 0], 2.0 / 4.0, 1e-14);
-    EXPECT_NEAR(b1[1 * p + 1], 0.0 / 4.0, 1e-14);
-    EXPECT_NEAR(b1[1 * p + 2], 0.0 / 4.0, 1e-14);
-    EXPECT_NEAR(b1[2 * p + 0], 0.0 / 4.0, 1e-14);
-    EXPECT_NEAR(b1[2 * p + 1], 1.0 / 4.0, 1e-14);
-    EXPECT_NEAR(b1[2 * p + 2], 0.0 / 4.0, 1e-14);
+    EXPECT_NEAR(b1[0 + 0 * p], 0.0 / 4.0, 1e-14);
+    EXPECT_NEAR(b1[0 + 1 * p], 0.0 / 4.0, 1e-14);
+    EXPECT_NEAR(b1[0 + 2 * p], 4.0 / 4.0, 1e-14);
+    EXPECT_NEAR(b1[1 + 0 * p], 2.0 / 4.0, 1e-14);
+    EXPECT_NEAR(b1[1 + 1 * p], 0.0 / 4.0, 1e-14);
+    EXPECT_NEAR(b1[1 + 2 * p], 0.0 / 4.0, 1e-14);
+    EXPECT_NEAR(b1[2 + 0 * p], 0.0 / 4.0, 1e-14);
+    EXPECT_NEAR(b1[2 + 1 * p], 1.0 / 4.0, 1e-14);
+    EXPECT_NEAR(b1[2 + 2 * p], 0.0 / 4.0, 1e-14);
 }
 
 
@@ -409,21 +409,21 @@ TEST_F(AdaptiveBlockJacobi, InvertsDiagonalBlocks)
     bj = static_cast<Bj *>(bj_lin_op.get());
     auto p = bj->get_stride();
     auto b1 = reinterpret_cast<const float *>(bj->get_const_blocks());
-    EXPECT_NEAR(b1[0 * p + 0], 4.0 / 14.0, 1e-7);
-    EXPECT_NEAR(b1[0 * p + 1], 2.0 / 14.0, 1e-7);
-    EXPECT_NEAR(b1[1 * p + 0], 1.0 / 14.0, 1e-7);
-    EXPECT_NEAR(b1[1 * p + 1], 4.0 / 14.0, 1e-7);
+    EXPECT_NEAR(b1[0 + 0 * p], 4.0 / 14.0, 1e-7);
+    EXPECT_NEAR(b1[0 + 1 * p], 2.0 / 14.0, 1e-7);
+    EXPECT_NEAR(b1[1 + 0 * p], 1.0 / 14.0, 1e-7);
+    EXPECT_NEAR(b1[1 + 1 * p], 4.0 / 14.0, 1e-7);
 
     auto b2 = bj->get_blocks() + 2 * p;
-    EXPECT_NEAR(b2[0 * p + 0], 14.0 / 48.0, 1e-14);
-    EXPECT_NEAR(b2[0 * p + 1], 8.0 / 48.0, 1e-14);
-    EXPECT_NEAR(b2[0 * p + 2], 4.0 / 48.0, 1e-14);
-    EXPECT_NEAR(b2[1 * p + 0], 4.0 / 48.0, 1e-14);
-    EXPECT_NEAR(b2[1 * p + 1], 16.0 / 48.0, 1e-14);
-    EXPECT_NEAR(b2[1 * p + 2], 8.0 / 48.0, 1e-14);
-    EXPECT_NEAR(b2[2 * p + 0], 1.0 / 48.0, 1e-14);
-    EXPECT_NEAR(b2[2 * p + 1], 4.0 / 48.0, 1e-14);
-    EXPECT_NEAR(b2[2 * p + 2], 14.0 / 48.0, 1e-14);
+    EXPECT_NEAR(b2[0 + 0 * p], 14.0 / 48.0, 1e-14);
+    EXPECT_NEAR(b2[0 + 1 * p], 8.0 / 48.0, 1e-14);
+    EXPECT_NEAR(b2[0 + 2 * p], 4.0 / 48.0, 1e-14);
+    EXPECT_NEAR(b2[1 + 0 * p], 4.0 / 48.0, 1e-14);
+    EXPECT_NEAR(b2[1 + 1 * p], 16.0 / 48.0, 1e-14);
+    EXPECT_NEAR(b2[1 + 2 * p], 8.0 / 48.0, 1e-14);
+    EXPECT_NEAR(b2[2 + 0 * p], 1.0 / 48.0, 1e-14);
+    EXPECT_NEAR(b2[2 + 1 * p], 4.0 / 48.0, 1e-14);
+    EXPECT_NEAR(b2[2 + 2 * p], 14.0 / 48.0, 1e-14);
 }
 
 
@@ -449,15 +449,15 @@ TEST_F(AdaptiveBlockJacobi, PivotsWhenInvertingBlock)
     bj = static_cast<Bj *>(bj_lin_op.get());
     auto p = bj->get_stride();
     auto b1 = reinterpret_cast<const float *>(bj->get_const_blocks());
-    EXPECT_NEAR(b1[0 * p + 0], 0.0 / 4.0, 1e-7);
-    EXPECT_NEAR(b1[0 * p + 1], 0.0 / 4.0, 1e-7);
-    EXPECT_NEAR(b1[0 * p + 2], 4.0 / 4.0, 1e-7);
-    EXPECT_NEAR(b1[1 * p + 0], 2.0 / 4.0, 1e-7);
-    EXPECT_NEAR(b1[1 * p + 1], 0.0 / 4.0, 1e-7);
-    EXPECT_NEAR(b1[1 * p + 2], 0.0 / 4.0, 1e-7);
-    EXPECT_NEAR(b1[2 * p + 0], 0.0 / 4.0, 1e-7);
-    EXPECT_NEAR(b1[2 * p + 1], 1.0 / 4.0, 1e-7);
-    EXPECT_NEAR(b1[2 * p + 2], 0.0 / 4.0, 1e-7);
+    EXPECT_NEAR(b1[0 + 0 * p], 0.0 / 4.0, 1e-7);
+    EXPECT_NEAR(b1[0 + 1 * p], 0.0 / 4.0, 1e-7);
+    EXPECT_NEAR(b1[0 + 2 * p], 4.0 / 4.0, 1e-7);
+    EXPECT_NEAR(b1[1 + 0 * p], 2.0 / 4.0, 1e-7);
+    EXPECT_NEAR(b1[1 + 1 * p], 0.0 / 4.0, 1e-7);
+    EXPECT_NEAR(b1[1 + 2 * p], 0.0 / 4.0, 1e-7);
+    EXPECT_NEAR(b1[2 + 0 * p], 0.0 / 4.0, 1e-7);
+    EXPECT_NEAR(b1[2 + 1 * p], 1.0 / 4.0, 1e-7);
+    EXPECT_NEAR(b1[2 + 2 * p], 0.0 / 4.0, 1e-7);
 }
 
 


### PR DESCRIPTION
This PR changes the block-Jacobi preconditioner storage scheme to use column-major instead of row-major order for the blocks. Benchmarks using a preliminary implementation of this storage scheme show that this slightly reduces the performance of the generate step (since now there is a non-coalesced data write due to the transposition), but the apply step becomes faster since now the matrix-vector product can be expressed in terms of a series of parallel AXPYs, instead of parallel dot-products which appear in the row-major version of the kernel.

Benchmark results
-------------------------

### Only `generate`
![image](https://user-images.githubusercontent.com/1261711/47725412-cf6c1580-dc58-11e8-9e9f-8fc915921c0e.png)

### `find_blocks` + `generate`
![image](https://user-images.githubusercontent.com/1261711/47737405-2978d500-dc71-11e8-9b13-a676361ce26a.png)

### `apply`
![image](https://user-images.githubusercontent.com/1261711/47725245-80be7b80-dc58-11e8-956b-78fd204ca0af.png)

TODO
--------

- [x] merge #155 
- [x] get benchmark results for this (will take a couple of days - I still have other things running on the P100 in UJI)
