### PR TITLE
Block-interleaved block storage in block-Jacobi

### DIFF
--- a/core/preconditioner/block_jacobi.hpp
+++ b/core/preconditioner/block_jacobi.hpp
@@ -295,7 +295,7 @@ protected:
      *
      * Should be a multiple of cache line size for best performance.
      */
-    static constexpr size_type block_stride_ = 32;
+    static constexpr size_type max_block_stride_ = 32;
 
     /**
      * Returns the smallest power of 2 at least as larger as the input.
@@ -304,7 +304,7 @@ protected:
      *
      * @return a power of two at least as large as `n`
      */
-    static inline size_type get_larger_power(size_type n) noexcept
+    static size_type get_larger_power(size_type n) noexcept
     {
         size_type res = 1;
         while (res < n) res *= 2;
@@ -319,13 +319,14 @@ protected:
      *
      * @return a suitable storage scheme
      */
-    static inline block_interleaved_storage_scheme compute_storage_scheme(
+    static block_interleaved_storage_scheme compute_storage_scheme(
         uint32 max_block_size) noexcept
     {
         const auto group_size = static_cast<uint32>(
-            block_stride_ / get_larger_power(max_block_size));
-        const auto block_offset = block_stride_ / group_size;
-        const auto group_offset = max_block_size * block_stride_;
+            max_block_stride_ / get_larger_power(max_block_size));
+        const auto block_offset = max_block_size;
+        const auto block_stride = group_size * block_offset;
+        const auto group_offset = max_block_size * block_stride;
         return {block_offset, group_offset, group_size};
     }
 };

--- a/core/preconditioner/block_jacobi.hpp
+++ b/core/preconditioner/block_jacobi.hpp
@@ -78,6 +78,88 @@ struct index_type<Op<ValueType, IndexType>> {
 };  // namespace detail
 
 
+// TODO: replace this with a custom accessor
+/**
+ * Defines the parameters of the interleaved block storage scheme used by
+ * block-Jacobi blocks.
+ */
+struct block_interleaved_storage_scheme {
+    /**
+     * The offset between consecutive blocks within the group.
+     */
+    size_type block_offset;
+    /**
+     * The offset between two block groups.
+     */
+    size_type group_offset;
+    /**
+     * Then number of blocks within the group.
+     */
+    uint32 group_size;
+
+    /**
+     * Computes the storage space required for the requested number of blocks.
+     *
+     * @param num_blocks  the total number of blocks that needs to be stored
+     *
+     * @return the total memory (as the number of elements) that need to be
+     *         allocated for the scheme
+     */
+    size_type compute_storage_space(size_type num_blocks) const
+    {
+        return (num_blocks + 1 == size_type{0})
+                   ? size_type{0}
+                   : ceildiv(num_blocks, group_size) * group_offset;
+    }
+
+    /**
+     * Returns the offset of the group belonging to the block with the given ID.
+     *
+     * @param block_id  the ID of the block
+     *
+     * @return the offset of the group belonging to block with ID `block_id`
+     */
+    GKO_ATTRIBUTES size_type get_group_offset(size_type block_id) const
+    {
+        return group_offset * (block_id / group_size);
+    }
+
+    /**
+     * Returns the offset of the block with the given ID within its group.
+     *
+     * @param block_id  the ID of the block
+     *
+     * @return the offset of the block with ID `block_id` within its group
+     */
+    GKO_ATTRIBUTES size_type get_block_offset(size_type block_id) const
+    {
+        return block_offset * (block_id % group_size);
+    }
+
+    /**
+     * Returns the offset of the block with the given ID.
+     *
+     * @param block_id  the ID of the block
+     *
+     * @return the offset of the block with ID `block_id`
+     */
+    GKO_ATTRIBUTES size_type get_global_block_offset(size_type block_id) const
+    {
+        return this->get_group_offset(block_id) +
+               this->get_block_offset(block_id);
+    }
+
+    /**
+     * Returns the stride between columns of the block.
+     *
+     * @return stride between columns of the block
+     */
+    GKO_ATTRIBUTES size_type get_stride() const
+    {
+        return block_offset * group_size;
+    }
+};
+
 /**
  * This is an intermediate class which implements common methods of block-Jacobi
  * preconditioners.
@@ -92,7 +174,6 @@ class BasicBlockJacobi : public EnableLinOp<ConcreteBlockJacobi> {
 public:
     using EnableLinOp<ConcreteBlockJacobi>::convert_to;
     using EnableLinOp<ConcreteBlockJacobi>::move_to;
-
     using value_type = typename detail::value_type<ConcreteBlockJacobi>::type;
     using index_type = typename detail::index_type<ConcreteBlockJacobi>::type;
 
@@ -135,11 +216,14 @@ public:
     }
 
     /**
-     * Returns the stride used for storing the blocks.
+     * Returns the storage scheme used for storing Jacobi blocks.
      *
-     * @return the stride used for storing the blocks
+     * @return the storage scheme used for storing Jacobi blocks
      */
-    size_type get_stride() const noexcept { return max_block_size_; }
+    const block_interleaved_storage_scheme &get_storage_scheme() const noexcept
+    {
+        return storage_scheme_;
+    }
 
     /**
      * Returns the pointer to the memory used for storing the block data.
@@ -192,17 +276,58 @@ protected:
               exec, transpose(system_matrix->get_size())),
           num_blocks_(block_pointers.get_num_elems() - 1),
           max_block_size_(max_block_size),
+          storage_scheme_{compute_storage_scheme(max_block_size)},
           block_pointers_(block_pointers),
-          blocks_(exec, this->get_size()[1] * max_block_size)
+          blocks_(exec, storage_scheme_.compute_storage_space(
+                            block_pointers.get_num_elems() - 1))
     {
         block_pointers_.set_executor(this->get_executor());
     }
 
-protected:
     size_type num_blocks_{};
     uint32 max_block_size_{};
+    block_interleaved_storage_scheme storage_scheme_;
     Array<index_type> block_pointers_;
     Array<value_type> blocks_;
+
+    /**
+     * Stride between two columns of a block (as number of elements).
+     *
+     * Should be a multiple of cache line size for best performance.
+     */
+    static constexpr size_type block_stride_ = 32;
+
+    /**
+     * Returns the smallest power of 2 at least as larger as the input.
+     *
+     * @param n  a number
+     *
+     * @return a power of two at least as large as `n`
+     */
+    static inline size_type get_larger_power(size_type n) noexcept
+    {
+        size_type res = 1;
+        while (res < n) res *= 2;
+        return res;
+    }
+
+    /**
+     * Computes the storage scheme suitable for storing blocks of a given
+     * maximum size.
+     *
+     * @param max_block_size  the maximum size of the blocks
+     *
+     * @return a suitable storage scheme
+     */
+    static inline block_interleaved_storage_scheme compute_storage_scheme(
+        uint32 max_block_size) noexcept
+    {
+        const auto group_size = static_cast<uint32>(
+            block_stride_ / get_larger_power(max_block_size));
+        const auto block_offset = block_stride_ / group_size;
+        const auto group_offset = max_block_size * block_stride_;
+        return {block_offset, group_offset, group_size};
+    }
 };
 
 

--- a/core/preconditioner/block_jacobi_kernels.hpp
+++ b/core/preconditioner/block_jacobi_kernels.hpp
@@ -49,35 +49,43 @@ namespace kernels {
                      uint32 max_block_size, size_type &num_blocks,           \
                      Array<IndexType> &block_pointers)
 
-#define GKO_DECLARE_BLOCK_JACOBI_GENERATE_KERNEL(ValueType, IndexType)      \
-    void generate(std::shared_ptr<const DefaultExecutor> exec,              \
-                  const matrix::Csr<ValueType, IndexType> *system_matrix,   \
-                  size_type num_blocks, uint32 max_block_size,              \
-                  size_type stride, const Array<IndexType> &block_pointers, \
+#define GKO_DECLARE_BLOCK_JACOBI_GENERATE_KERNEL(ValueType, IndexType)    \
+    void generate(std::shared_ptr<const DefaultExecutor> exec,            \
+                  const matrix::Csr<ValueType, IndexType> *system_matrix, \
+                  size_type num_blocks, uint32 max_block_size,            \
+                  const preconditioner::block_interleaved_storage_scheme  \
+                      &storage_scheme,                                    \
+                  const Array<IndexType> &block_pointers,                 \
                   Array<ValueType> &blocks)
 
 #define GKO_DECLARE_BLOCK_JACOBI_APPLY_KERNEL(ValueType, IndexType)            \
     void apply(                                                                \
         std::shared_ptr<const DefaultExecutor> exec, size_type num_blocks,     \
-        uint32 max_block_size, size_type stride,                               \
+        uint32 max_block_size,                                                 \
+        const preconditioner::block_interleaved_storage_scheme                 \
+            &storage_scheme,                                                   \
         const Array<IndexType> &block_pointers,                                \
         const Array<ValueType> &blocks, const matrix::Dense<ValueType> *alpha, \
         const matrix::Dense<ValueType> *b,                                     \
         const matrix::Dense<ValueType> *beta, matrix::Dense<ValueType> *x)
 
-#define GKO_DECLARE_BLOCK_JACOBI_SIMPLE_APPLY_KERNEL(ValueType, IndexType) \
-    void simple_apply(                                                     \
-        std::shared_ptr<const DefaultExecutor> exec, size_type num_blocks, \
-        uint32 max_block_size, size_type stride,                           \
-        const Array<IndexType> &block_pointers,                            \
-        const Array<ValueType> &blocks, const matrix::Dense<ValueType> *b, \
-        matrix::Dense<ValueType> *x)
+#define GKO_DECLARE_BLOCK_JACOBI_SIMPLE_APPLY_KERNEL(ValueType, IndexType)   \
+    void simple_apply(std::shared_ptr<const DefaultExecutor> exec,           \
+                      size_type num_blocks, uint32 max_block_size,           \
+                      const preconditioner::block_interleaved_storage_scheme \
+                          &storage_scheme,                                   \
+                      const Array<IndexType> &block_pointers,                \
+                      const Array<ValueType> &blocks,                        \
+                      const matrix::Dense<ValueType> *b,                     \
+                      matrix::Dense<ValueType> *x)
 
 #define GKO_DECLARE_BLOCK_JACOBI_CONVERT_TO_DENSE_KERNEL(ValueType, IndexType) \
     void convert_to_dense(                                                     \
         std::shared_ptr<const DefaultExecutor> exec, size_type num_blocks,     \
         const Array<IndexType> &block_pointers,                                \
-        const Array<ValueType> &blocks, size_type block_stride,                \
+        const Array<ValueType> &blocks,                                        \
+        const preconditioner::block_interleaved_storage_scheme                 \
+            &storage_scheme,                                                   \
         ValueType *result_values, size_type result_stride)
 
 #define DECLARE_ALL_AS_TEMPLATES                                        \
@@ -123,19 +131,23 @@ DECLARE_ALL_AS_TEMPLATES;
 #undef DECLARE_ALL_AS_TEMPLATES
 
 
-#define GKO_DECLARE_ADAPTIVE_BLOCK_JACOBI_GENERATE_KERNEL(ValueType,   \
-                                                          IndexType)   \
-    void generate(                                                     \
-        std::shared_ptr<const DefaultExecutor> exec,                   \
-        const matrix::Csr<ValueType, IndexType> *system_matrix,        \
-        size_type num_blocks, uint32 max_block_size, size_type stride, \
-        Array<precision<ValueType, IndexType>> &block_precisions,      \
-        const Array<IndexType> &block_pointers, Array<ValueType> &blocks)
+#define GKO_DECLARE_ADAPTIVE_BLOCK_JACOBI_GENERATE_KERNEL(ValueType,        \
+                                                          IndexType)        \
+    void generate(std::shared_ptr<const DefaultExecutor> exec,              \
+                  const matrix::Csr<ValueType, IndexType> *system_matrix,   \
+                  size_type num_blocks, uint32 max_block_size,              \
+                  const preconditioner::block_interleaved_storage_scheme    \
+                      &storage_scheme,                                      \
+                  Array<precision<ValueType, IndexType>> &block_precisions, \
+                  const Array<IndexType> &block_pointers,                   \
+                  Array<ValueType> &blocks)
 
 #define GKO_DECLARE_ADAPTIVE_BLOCK_JACOBI_APPLY_KERNEL(ValueType, IndexType)   \
     void apply(                                                                \
         std::shared_ptr<const DefaultExecutor> exec, size_type num_blocks,     \
-        uint32 max_block_size, size_type stride,                               \
+        uint32 max_block_size,                                                 \
+        const preconditioner::block_interleaved_storage_scheme                 \
+            &storage_scheme,                                                   \
         const Array<precision<ValueType, IndexType>> &block_precisions,        \
         const Array<IndexType> &block_pointers,                                \
         const Array<ValueType> &blocks, const matrix::Dense<ValueType> *alpha, \
@@ -146,7 +158,9 @@ DECLARE_ALL_AS_TEMPLATES;
                                                               IndexType)   \
     void simple_apply(                                                     \
         std::shared_ptr<const DefaultExecutor> exec, size_type num_blocks, \
-        uint32 max_block_size, size_type stride,                           \
+        uint32 max_block_size,                                             \
+        const preconditioner::block_interleaved_storage_scheme             \
+            &storage_scheme,                                               \
         const Array<precision<ValueType, IndexType>> &block_precisions,    \
         const Array<IndexType> &block_pointers,                            \
         const Array<ValueType> &blocks, const matrix::Dense<ValueType> *b, \
@@ -158,7 +172,9 @@ DECLARE_ALL_AS_TEMPLATES;
         std::shared_ptr<const DefaultExecutor> exec, size_type num_blocks,   \
         const Array<precision<ValueType, IndexType>> &block_precisions,      \
         const Array<IndexType> &block_pointers,                              \
-        const Array<ValueType> &blocks, size_type block_stride,              \
+        const Array<ValueType> &blocks,                                      \
+        const preconditioner::block_interleaved_storage_scheme               \
+            &storage_scheme,                                                 \
         ValueType *result_values, size_type result_stride)
 
 #define DECLARE_ALL_AS_TEMPLATES                                             \

--- a/core/preconditioner/block_jacobi_kernels.hpp
+++ b/core/preconditioner/block_jacobi_kernels.hpp
@@ -50,41 +50,41 @@ namespace kernels {
                      Array<IndexType> &block_pointers)
 
 #define GKO_DECLARE_BLOCK_JACOBI_GENERATE_KERNEL(ValueType, IndexType)    \
-    void generate(std::shared_ptr<const DefaultExecutor> exec,            \
-                  const matrix::Csr<ValueType, IndexType> *system_matrix, \
-                  size_type num_blocks, uint32 max_block_size,            \
-                  const preconditioner::block_interleaved_storage_scheme  \
-                      &storage_scheme,                                    \
-                  const Array<IndexType> &block_pointers,                 \
-                  Array<ValueType> &blocks)
+    void generate(                                                        \
+        std::shared_ptr<const DefaultExecutor> exec,                      \
+        const matrix::Csr<ValueType, IndexType> *system_matrix,           \
+        size_type num_blocks, uint32 max_block_size,                      \
+        const preconditioner::block_interleaved_storage_scheme<IndexType> \
+            &storage_scheme,                                              \
+        const Array<IndexType> &block_pointers, Array<ValueType> &blocks)
 
 #define GKO_DECLARE_BLOCK_JACOBI_APPLY_KERNEL(ValueType, IndexType)            \
     void apply(                                                                \
         std::shared_ptr<const DefaultExecutor> exec, size_type num_blocks,     \
         uint32 max_block_size,                                                 \
-        const preconditioner::block_interleaved_storage_scheme                 \
+        const preconditioner::block_interleaved_storage_scheme<IndexType>      \
             &storage_scheme,                                                   \
         const Array<IndexType> &block_pointers,                                \
         const Array<ValueType> &blocks, const matrix::Dense<ValueType> *alpha, \
         const matrix::Dense<ValueType> *b,                                     \
         const matrix::Dense<ValueType> *beta, matrix::Dense<ValueType> *x)
 
-#define GKO_DECLARE_BLOCK_JACOBI_SIMPLE_APPLY_KERNEL(ValueType, IndexType)   \
-    void simple_apply(std::shared_ptr<const DefaultExecutor> exec,           \
-                      size_type num_blocks, uint32 max_block_size,           \
-                      const preconditioner::block_interleaved_storage_scheme \
-                          &storage_scheme,                                   \
-                      const Array<IndexType> &block_pointers,                \
-                      const Array<ValueType> &blocks,                        \
-                      const matrix::Dense<ValueType> *b,                     \
-                      matrix::Dense<ValueType> *x)
+#define GKO_DECLARE_BLOCK_JACOBI_SIMPLE_APPLY_KERNEL(ValueType, IndexType) \
+    void simple_apply(                                                     \
+        std::shared_ptr<const DefaultExecutor> exec, size_type num_blocks, \
+        uint32 max_block_size,                                             \
+        const preconditioner::block_interleaved_storage_scheme<IndexType>  \
+            &storage_scheme,                                               \
+        const Array<IndexType> &block_pointers,                            \
+        const Array<ValueType> &blocks, const matrix::Dense<ValueType> *b, \
+        matrix::Dense<ValueType> *x)
 
 #define GKO_DECLARE_BLOCK_JACOBI_CONVERT_TO_DENSE_KERNEL(ValueType, IndexType) \
     void convert_to_dense(                                                     \
         std::shared_ptr<const DefaultExecutor> exec, size_type num_blocks,     \
         const Array<IndexType> &block_pointers,                                \
         const Array<ValueType> &blocks,                                        \
-        const preconditioner::block_interleaved_storage_scheme                 \
+        const preconditioner::block_interleaved_storage_scheme<IndexType>      \
             &storage_scheme,                                                   \
         ValueType *result_values, size_type result_stride)
 
@@ -131,22 +131,22 @@ DECLARE_ALL_AS_TEMPLATES;
 #undef DECLARE_ALL_AS_TEMPLATES
 
 
-#define GKO_DECLARE_ADAPTIVE_BLOCK_JACOBI_GENERATE_KERNEL(ValueType,        \
-                                                          IndexType)        \
-    void generate(std::shared_ptr<const DefaultExecutor> exec,              \
-                  const matrix::Csr<ValueType, IndexType> *system_matrix,   \
-                  size_type num_blocks, uint32 max_block_size,              \
-                  const preconditioner::block_interleaved_storage_scheme    \
-                      &storage_scheme,                                      \
-                  Array<precision<ValueType, IndexType>> &block_precisions, \
-                  const Array<IndexType> &block_pointers,                   \
-                  Array<ValueType> &blocks)
+#define GKO_DECLARE_ADAPTIVE_BLOCK_JACOBI_GENERATE_KERNEL(ValueType,      \
+                                                          IndexType)      \
+    void generate(                                                        \
+        std::shared_ptr<const DefaultExecutor> exec,                      \
+        const matrix::Csr<ValueType, IndexType> *system_matrix,           \
+        size_type num_blocks, uint32 max_block_size,                      \
+        const preconditioner::block_interleaved_storage_scheme<IndexType> \
+            &storage_scheme,                                              \
+        Array<precision<ValueType, IndexType>> &block_precisions,         \
+        const Array<IndexType> &block_pointers, Array<ValueType> &blocks)
 
 #define GKO_DECLARE_ADAPTIVE_BLOCK_JACOBI_APPLY_KERNEL(ValueType, IndexType)   \
     void apply(                                                                \
         std::shared_ptr<const DefaultExecutor> exec, size_type num_blocks,     \
         uint32 max_block_size,                                                 \
-        const preconditioner::block_interleaved_storage_scheme                 \
+        const preconditioner::block_interleaved_storage_scheme<IndexType>      \
             &storage_scheme,                                                   \
         const Array<precision<ValueType, IndexType>> &block_precisions,        \
         const Array<IndexType> &block_pointers,                                \
@@ -159,7 +159,7 @@ DECLARE_ALL_AS_TEMPLATES;
     void simple_apply(                                                     \
         std::shared_ptr<const DefaultExecutor> exec, size_type num_blocks, \
         uint32 max_block_size,                                             \
-        const preconditioner::block_interleaved_storage_scheme             \
+        const preconditioner::block_interleaved_storage_scheme<IndexType>  \
             &storage_scheme,                                               \
         const Array<precision<ValueType, IndexType>> &block_precisions,    \
         const Array<IndexType> &block_pointers,                            \
@@ -173,7 +173,7 @@ DECLARE_ALL_AS_TEMPLATES;
         const Array<precision<ValueType, IndexType>> &block_precisions,      \
         const Array<IndexType> &block_pointers,                              \
         const Array<ValueType> &blocks,                                      \
-        const preconditioner::block_interleaved_storage_scheme               \
+        const preconditioner::block_interleaved_storage_scheme<IndexType>    \
             &storage_scheme,                                                 \
         ValueType *result_values, size_type result_stride)
 

--- a/core/test/preconditioner/block_jacobi.cpp
+++ b/core/test/preconditioner/block_jacobi.cpp
@@ -178,7 +178,8 @@ TEST_F(AdaptiveBlockJacobiFactory, CanMoveBlockPrecisions)
 class BlockInterleavedStorageScheme : public ::testing::Test {
 protected:
     // groups of 4 blocks, offset of 3 within the group and 16 between groups
-    gko::preconditioner::block_interleaved_storage_scheme s{3, 16, 4};
+    gko::preconditioner::block_interleaved_storage_scheme<gko::int32> s{3, 16,
+                                                                        2};
 };
 
 

--- a/core/test/preconditioner/block_jacobi.cpp
+++ b/core/test/preconditioner/block_jacobi.cpp
@@ -175,4 +175,41 @@ TEST_F(AdaptiveBlockJacobiFactory, CanMoveBlockPrecisions)
 }
 
 
+class BlockInterleavedStorageScheme : public ::testing::Test {
+protected:
+    // groups of 4 blocks, offset of 3 within the group and 16 between groups
+    gko::preconditioner::block_interleaved_storage_scheme s{3, 16, 4};
+};
+
+
+TEST_F(BlockInterleavedStorageScheme, ComputesStorageSpace)
+{
+    ASSERT_EQ(s.compute_storage_space(10), 16 * 3);  // 3 groups of 16 elements
+}
+
+
+TEST_F(BlockInterleavedStorageScheme, ComputesGroupOffset)
+{
+    ASSERT_EQ(s.get_group_offset(17), 16 * 4);  // 5th group
+}
+
+
+TEST_F(BlockInterleavedStorageScheme, ComputesBlockOffset)
+{
+    ASSERT_EQ(s.get_block_offset(17), 1 * 3);  // 2nd in group
+}
+
+
+TEST_F(BlockInterleavedStorageScheme, ComputesGlobalBlockOffset)
+{
+    ASSERT_EQ(s.get_global_block_offset(17), 16 * 4 + 1 * 3);
+}
+
+
+TEST_F(BlockInterleavedStorageScheme, ComputesStride)
+{
+    ASSERT_EQ(s.get_stride(), 4 * 3);  // 4 offsets of 3
+}
+
+
 }  // namespace

--- a/omp/preconditioner/block_jacobi_kernels.cpp
+++ b/omp/preconditioner/block_jacobi_kernels.cpp
@@ -54,49 +54,51 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 
 
 template <typename ValueType, typename IndexType>
-void generate(std::shared_ptr<const OmpExecutor> exec,
-              const matrix::Csr<ValueType, IndexType> *system_matrix,
-              size_type num_blocks, uint32 max_block_size, size_type stride,
-              const Array<IndexType> &block_pointers,
-              Array<ValueType> &blocks) NOT_IMPLEMENTED;
+void generate(
+    std::shared_ptr<const OmpExecutor> exec,
+    const matrix::Csr<ValueType, IndexType> *system_matrix,
+    size_type num_blocks, uint32 max_block_size,
+    const preconditioner::block_interleaved_storage_scheme &storage_scheme,
+    const Array<IndexType> &block_pointers,
+    Array<ValueType> &blocks) NOT_IMPLEMENTED;
 
 GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
     GKO_DECLARE_BLOCK_JACOBI_GENERATE_KERNEL);
 
 
 template <typename ValueType, typename IndexType>
-void apply(std::shared_ptr<const OmpExecutor> exec, size_type num_blocks,
-           uint32 max_block_size, size_type stride,
-           const Array<IndexType> &block_pointers,
-           const Array<ValueType> &blocks,
-           const matrix::Dense<ValueType> *alpha,
-           const matrix::Dense<ValueType> *b,
-           const matrix::Dense<ValueType> *beta,
-           matrix::Dense<ValueType> *x) NOT_IMPLEMENTED;
+void apply(
+    std::shared_ptr<const OmpExecutor> exec, size_type num_blocks,
+    uint32 max_block_size,
+    const preconditioner::block_interleaved_storage_scheme &storage_scheme,
+    const Array<IndexType> &block_pointers, const Array<ValueType> &blocks,
+    const matrix::Dense<ValueType> *alpha, const matrix::Dense<ValueType> *b,
+    const matrix::Dense<ValueType> *beta,
+    matrix::Dense<ValueType> *x) NOT_IMPLEMENTED;
 
 GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
     GKO_DECLARE_BLOCK_JACOBI_APPLY_KERNEL);
 
 
 template <typename ValueType, typename IndexType>
-void simple_apply(std::shared_ptr<const OmpExecutor> exec, size_type num_blocks,
-                  uint32 max_block_size, size_type stride,
-                  const Array<IndexType> &block_pointers,
-                  const Array<ValueType> &blocks,
-                  const matrix::Dense<ValueType> *b,
-                  matrix::Dense<ValueType> *x) NOT_IMPLEMENTED;
+void simple_apply(
+    std::shared_ptr<const OmpExecutor> exec, size_type num_blocks,
+    uint32 max_block_size,
+    const preconditioner::block_interleaved_storage_scheme &storage_scheme,
+    const Array<IndexType> &block_pointers, const Array<ValueType> &blocks,
+    const matrix::Dense<ValueType> *b,
+    matrix::Dense<ValueType> *x) NOT_IMPLEMENTED;
 
 GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
     GKO_DECLARE_BLOCK_JACOBI_SIMPLE_APPLY_KERNEL);
 
 
 template <typename ValueType, typename IndexType>
-void convert_to_dense(std::shared_ptr<const OmpExecutor> exec,
-                      size_type num_blocks,
-                      const Array<IndexType> &block_pointers,
-                      const Array<ValueType> &blocks, size_type block_stride,
-                      ValueType *result_values,
-                      size_type result_stride) NOT_IMPLEMENTED;
+void convert_to_dense(
+    std::shared_ptr<const OmpExecutor> exec, size_type num_blocks,
+    const Array<IndexType> &block_pointers, const Array<ValueType> &blocks,
+    const preconditioner::block_interleaved_storage_scheme &storage_scheme,
+    ValueType *result_values, size_type result_stride) NOT_IMPLEMENTED;
 
 GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
     GKO_DECLARE_BLOCK_JACOBI_CONVERT_TO_DENSE_KERNEL);
@@ -109,27 +111,29 @@ namespace adaptive_block_jacobi {
 
 
 template <typename ValueType, typename IndexType>
-void generate(std::shared_ptr<const OmpExecutor> exec,
-              const matrix::Csr<ValueType, IndexType> *system_matrix,
-              size_type num_blocks, uint32 max_block_size, size_type stride,
-              Array<precision<ValueType, IndexType>> &block_precisions,
-              const Array<IndexType> &block_pointers,
-              Array<ValueType> &blocks) NOT_IMPLEMENTED;
+void generate(
+    std::shared_ptr<const OmpExecutor> exec,
+    const matrix::Csr<ValueType, IndexType> *system_matrix,
+    size_type num_blocks, uint32 max_block_size,
+    const preconditioner::block_interleaved_storage_scheme &storage_scheme,
+    Array<precision<ValueType, IndexType>> &block_precisions,
+    const Array<IndexType> &block_pointers,
+    Array<ValueType> &blocks) NOT_IMPLEMENTED;
 
 GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
     GKO_DECLARE_ADAPTIVE_BLOCK_JACOBI_GENERATE_KERNEL);
 
 
 template <typename ValueType, typename IndexType>
-void apply(std::shared_ptr<const OmpExecutor> exec, size_type num_blocks,
-           uint32 max_block_size, size_type stride,
-           const Array<precision<ValueType, IndexType>> &block_precisions,
-           const Array<IndexType> &block_pointers,
-           const Array<ValueType> &blocks,
-           const matrix::Dense<ValueType> *alpha,
-           const matrix::Dense<ValueType> *b,
-           const matrix::Dense<ValueType> *beta,
-           matrix::Dense<ValueType> *x) NOT_IMPLEMENTED;
+void apply(
+    std::shared_ptr<const OmpExecutor> exec, size_type num_blocks,
+    uint32 max_block_size,
+    const preconditioner::block_interleaved_storage_scheme &storage_scheme,
+    const Array<precision<ValueType, IndexType>> &block_precisions,
+    const Array<IndexType> &block_pointers, const Array<ValueType> &blocks,
+    const matrix::Dense<ValueType> *alpha, const matrix::Dense<ValueType> *b,
+    const matrix::Dense<ValueType> *beta,
+    matrix::Dense<ValueType> *x) NOT_IMPLEMENTED;
 
 GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
     GKO_DECLARE_ADAPTIVE_BLOCK_JACOBI_APPLY_KERNEL);
@@ -138,7 +142,8 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 template <typename ValueType, typename IndexType>
 void simple_apply(
     std::shared_ptr<const OmpExecutor> exec, size_type num_blocks,
-    uint32 max_block_size, size_type stride,
+    uint32 max_block_size,
+    const preconditioner::block_interleaved_storage_scheme &storage_scheme,
     const Array<precision<ValueType, IndexType>> &block_precisions,
     const Array<IndexType> &block_pointers, const Array<ValueType> &blocks,
     const matrix::Dense<ValueType> *b,
@@ -153,8 +158,8 @@ void convert_to_dense(
     std::shared_ptr<const OmpExecutor> exec, size_type num_blocks,
     const Array<precision<ValueType, IndexType>> &block_precisions,
     const Array<IndexType> &block_pointers, const Array<ValueType> &blocks,
-    size_type block_stride, ValueType *result_values,
-    size_type result_stride) NOT_IMPLEMENTED;
+    const preconditioner::block_interleaved_storage_scheme &storage_scheme,
+    ValueType *result_values, size_type result_stride) NOT_IMPLEMENTED;
 
 GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
     GKO_DECLARE_ADAPTIVE_BLOCK_JACOBI_CONVERT_TO_DENSE_KERNEL);

--- a/omp/preconditioner/block_jacobi_kernels.cpp
+++ b/omp/preconditioner/block_jacobi_kernels.cpp
@@ -54,27 +54,29 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 
 
 template <typename ValueType, typename IndexType>
-void generate(
-    std::shared_ptr<const OmpExecutor> exec,
-    const matrix::Csr<ValueType, IndexType> *system_matrix,
-    size_type num_blocks, uint32 max_block_size,
-    const preconditioner::block_interleaved_storage_scheme &storage_scheme,
-    const Array<IndexType> &block_pointers,
-    Array<ValueType> &blocks) NOT_IMPLEMENTED;
+void generate(std::shared_ptr<const OmpExecutor> exec,
+              const matrix::Csr<ValueType, IndexType> *system_matrix,
+              size_type num_blocks, uint32 max_block_size,
+              const preconditioner::block_interleaved_storage_scheme<IndexType>
+                  &storage_scheme,
+              const Array<IndexType> &block_pointers,
+              Array<ValueType> &blocks) NOT_IMPLEMENTED;
 
 GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
     GKO_DECLARE_BLOCK_JACOBI_GENERATE_KERNEL);
 
 
 template <typename ValueType, typename IndexType>
-void apply(
-    std::shared_ptr<const OmpExecutor> exec, size_type num_blocks,
-    uint32 max_block_size,
-    const preconditioner::block_interleaved_storage_scheme &storage_scheme,
-    const Array<IndexType> &block_pointers, const Array<ValueType> &blocks,
-    const matrix::Dense<ValueType> *alpha, const matrix::Dense<ValueType> *b,
-    const matrix::Dense<ValueType> *beta,
-    matrix::Dense<ValueType> *x) NOT_IMPLEMENTED;
+void apply(std::shared_ptr<const OmpExecutor> exec, size_type num_blocks,
+           uint32 max_block_size,
+           const preconditioner::block_interleaved_storage_scheme<IndexType>
+               &storage_scheme,
+           const Array<IndexType> &block_pointers,
+           const Array<ValueType> &blocks,
+           const matrix::Dense<ValueType> *alpha,
+           const matrix::Dense<ValueType> *b,
+           const matrix::Dense<ValueType> *beta,
+           matrix::Dense<ValueType> *x) NOT_IMPLEMENTED;
 
 GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
     GKO_DECLARE_BLOCK_JACOBI_APPLY_KERNEL);
@@ -84,7 +86,8 @@ template <typename ValueType, typename IndexType>
 void simple_apply(
     std::shared_ptr<const OmpExecutor> exec, size_type num_blocks,
     uint32 max_block_size,
-    const preconditioner::block_interleaved_storage_scheme &storage_scheme,
+    const preconditioner::block_interleaved_storage_scheme<IndexType>
+        &storage_scheme,
     const Array<IndexType> &block_pointers, const Array<ValueType> &blocks,
     const matrix::Dense<ValueType> *b,
     matrix::Dense<ValueType> *x) NOT_IMPLEMENTED;
@@ -97,7 +100,8 @@ template <typename ValueType, typename IndexType>
 void convert_to_dense(
     std::shared_ptr<const OmpExecutor> exec, size_type num_blocks,
     const Array<IndexType> &block_pointers, const Array<ValueType> &blocks,
-    const preconditioner::block_interleaved_storage_scheme &storage_scheme,
+    const preconditioner::block_interleaved_storage_scheme<IndexType>
+        &storage_scheme,
     ValueType *result_values, size_type result_stride) NOT_IMPLEMENTED;
 
 GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
@@ -111,29 +115,31 @@ namespace adaptive_block_jacobi {
 
 
 template <typename ValueType, typename IndexType>
-void generate(
-    std::shared_ptr<const OmpExecutor> exec,
-    const matrix::Csr<ValueType, IndexType> *system_matrix,
-    size_type num_blocks, uint32 max_block_size,
-    const preconditioner::block_interleaved_storage_scheme &storage_scheme,
-    Array<precision<ValueType, IndexType>> &block_precisions,
-    const Array<IndexType> &block_pointers,
-    Array<ValueType> &blocks) NOT_IMPLEMENTED;
+void generate(std::shared_ptr<const OmpExecutor> exec,
+              const matrix::Csr<ValueType, IndexType> *system_matrix,
+              size_type num_blocks, uint32 max_block_size,
+              const preconditioner::block_interleaved_storage_scheme<IndexType>
+                  &storage_scheme,
+              Array<precision<ValueType, IndexType>> &block_precisions,
+              const Array<IndexType> &block_pointers,
+              Array<ValueType> &blocks) NOT_IMPLEMENTED;
 
 GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
     GKO_DECLARE_ADAPTIVE_BLOCK_JACOBI_GENERATE_KERNEL);
 
 
 template <typename ValueType, typename IndexType>
-void apply(
-    std::shared_ptr<const OmpExecutor> exec, size_type num_blocks,
-    uint32 max_block_size,
-    const preconditioner::block_interleaved_storage_scheme &storage_scheme,
-    const Array<precision<ValueType, IndexType>> &block_precisions,
-    const Array<IndexType> &block_pointers, const Array<ValueType> &blocks,
-    const matrix::Dense<ValueType> *alpha, const matrix::Dense<ValueType> *b,
-    const matrix::Dense<ValueType> *beta,
-    matrix::Dense<ValueType> *x) NOT_IMPLEMENTED;
+void apply(std::shared_ptr<const OmpExecutor> exec, size_type num_blocks,
+           uint32 max_block_size,
+           const preconditioner::block_interleaved_storage_scheme<IndexType>
+               &storage_scheme,
+           const Array<precision<ValueType, IndexType>> &block_precisions,
+           const Array<IndexType> &block_pointers,
+           const Array<ValueType> &blocks,
+           const matrix::Dense<ValueType> *alpha,
+           const matrix::Dense<ValueType> *b,
+           const matrix::Dense<ValueType> *beta,
+           matrix::Dense<ValueType> *x) NOT_IMPLEMENTED;
 
 GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
     GKO_DECLARE_ADAPTIVE_BLOCK_JACOBI_APPLY_KERNEL);
@@ -143,7 +149,8 @@ template <typename ValueType, typename IndexType>
 void simple_apply(
     std::shared_ptr<const OmpExecutor> exec, size_type num_blocks,
     uint32 max_block_size,
-    const preconditioner::block_interleaved_storage_scheme &storage_scheme,
+    const preconditioner::block_interleaved_storage_scheme<IndexType>
+        &storage_scheme,
     const Array<precision<ValueType, IndexType>> &block_precisions,
     const Array<IndexType> &block_pointers, const Array<ValueType> &blocks,
     const matrix::Dense<ValueType> *b,
@@ -158,7 +165,8 @@ void convert_to_dense(
     std::shared_ptr<const OmpExecutor> exec, size_type num_blocks,
     const Array<precision<ValueType, IndexType>> &block_precisions,
     const Array<IndexType> &block_pointers, const Array<ValueType> &blocks,
-    const preconditioner::block_interleaved_storage_scheme &storage_scheme,
+    const preconditioner::block_interleaved_storage_scheme<IndexType>
+        &storage_scheme,
     ValueType *result_values, size_type result_stride) NOT_IMPLEMENTED;
 
 GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(

--- a/reference/preconditioner/block_jacobi_kernels.cpp
+++ b/reference/preconditioner/block_jacobi_kernels.cpp
@@ -281,12 +281,12 @@ inline void invert_block(IndexType block_size, IndexType *perm,
 
 
 template <typename ValueType, typename IndexType>
-void generate(
-    std::shared_ptr<const ReferenceExecutor> exec,
-    const matrix::Csr<ValueType, IndexType> *system_matrix,
-    size_type num_blocks, uint32 max_block_size,
-    const preconditioner::block_interleaved_storage_scheme &storage_scheme,
-    const Array<IndexType> &block_pointers, Array<ValueType> &blocks)
+void generate(std::shared_ptr<const ReferenceExecutor> exec,
+              const matrix::Csr<ValueType, IndexType> *system_matrix,
+              size_type num_blocks, uint32 max_block_size,
+              const preconditioner::block_interleaved_storage_scheme<IndexType>
+                  &storage_scheme,
+              const Array<IndexType> &block_pointers, Array<ValueType> &blocks)
 {
     const auto ptrs = block_pointers.get_const_data();
     for (size_type b = 0; b < num_blocks; ++b) {
@@ -350,13 +350,15 @@ inline void apply_block(size_type block_size, size_type num_rhs,
 
 
 template <typename ValueType, typename IndexType>
-void apply(
-    std::shared_ptr<const ReferenceExecutor> exec, size_type num_blocks,
-    uint32 max_block_size,
-    const preconditioner::block_interleaved_storage_scheme &storage_scheme,
-    const Array<IndexType> &block_pointers, const Array<ValueType> &blocks,
-    const matrix::Dense<ValueType> *alpha, const matrix::Dense<ValueType> *b,
-    const matrix::Dense<ValueType> *beta, matrix::Dense<ValueType> *x)
+void apply(std::shared_ptr<const ReferenceExecutor> exec, size_type num_blocks,
+           uint32 max_block_size,
+           const preconditioner::block_interleaved_storage_scheme<IndexType>
+               &storage_scheme,
+           const Array<IndexType> &block_pointers,
+           const Array<ValueType> &blocks,
+           const matrix::Dense<ValueType> *alpha,
+           const matrix::Dense<ValueType> *b,
+           const matrix::Dense<ValueType> *beta, matrix::Dense<ValueType> *x)
 {
     const auto ptrs = block_pointers.get_const_data();
     for (size_type i = 0; i < num_blocks; ++i) {
@@ -379,7 +381,8 @@ template <typename ValueType, typename IndexType>
 void simple_apply(
     std::shared_ptr<const ReferenceExecutor> exec, size_type num_blocks,
     uint32 max_block_size,
-    const preconditioner::block_interleaved_storage_scheme &storage_scheme,
+    const preconditioner::block_interleaved_storage_scheme<IndexType>
+        &storage_scheme,
     const Array<IndexType> &block_pointers, const Array<ValueType> &blocks,
     const matrix::Dense<ValueType> *b, matrix::Dense<ValueType> *x)
 {
@@ -405,7 +408,8 @@ template <typename ValueType, typename IndexType>
 void convert_to_dense(
     std::shared_ptr<const ReferenceExecutor> exec, size_type num_blocks,
     const Array<IndexType> &block_pointers, const Array<ValueType> &blocks,
-    const preconditioner::block_interleaved_storage_scheme &storage_scheme,
+    const preconditioner::block_interleaved_storage_scheme<IndexType>
+        &storage_scheme,
     ValueType *result_values, size_type result_stride)
 {
     const auto ptrs = block_pointers.get_const_data();
@@ -454,14 +458,16 @@ namespace adaptive_block_jacobi {
 
 
 template <typename ValueType, typename IndexType>
-void apply(
-    std::shared_ptr<const ReferenceExecutor> exec, size_type num_blocks,
-    uint32 max_block_size,
-    const preconditioner::block_interleaved_storage_scheme &storage_scheme,
-    const Array<precision<ValueType, IndexType>> &block_precisions,
-    const Array<IndexType> &block_pointers, const Array<ValueType> &blocks,
-    const matrix::Dense<ValueType> *alpha, const matrix::Dense<ValueType> *b,
-    const matrix::Dense<ValueType> *beta, matrix::Dense<ValueType> *x)
+void apply(std::shared_ptr<const ReferenceExecutor> exec, size_type num_blocks,
+           uint32 max_block_size,
+           const preconditioner::block_interleaved_storage_scheme<IndexType>
+               &storage_scheme,
+           const Array<precision<ValueType, IndexType>> &block_precisions,
+           const Array<IndexType> &block_pointers,
+           const Array<ValueType> &blocks,
+           const matrix::Dense<ValueType> *alpha,
+           const matrix::Dense<ValueType> *b,
+           const matrix::Dense<ValueType> *beta, matrix::Dense<ValueType> *x)
 {
     const auto ptrs = block_pointers.get_const_data();
     const auto prec = block_precisions.get_const_data();
@@ -491,7 +497,8 @@ template <typename ValueType, typename IndexType>
 void simple_apply(
     std::shared_ptr<const ReferenceExecutor> exec, size_type num_blocks,
     uint32 max_block_size,
-    const preconditioner::block_interleaved_storage_scheme &storage_scheme,
+    const preconditioner::block_interleaved_storage_scheme<IndexType>
+        &storage_scheme,
     const Array<precision<ValueType, IndexType>> &block_precisions,
     const Array<IndexType> &block_pointers, const Array<ValueType> &blocks,
     const matrix::Dense<ValueType> *b, matrix::Dense<ValueType> *x)
@@ -525,7 +532,8 @@ void convert_to_dense(
     std::shared_ptr<const ReferenceExecutor> exec, size_type num_blocks,
     const Array<precision<ValueType, IndexType>> &block_precisions,
     const Array<IndexType> &block_pointers, const Array<ValueType> &blocks,
-    const preconditioner::block_interleaved_storage_scheme &storage_scheme,
+    const preconditioner::block_interleaved_storage_scheme<IndexType>
+        &storage_scheme,
     ValueType *result_values, size_type result_stride)
 {
     const auto ptrs = block_pointers.get_const_data();
@@ -558,13 +566,13 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 
 
 template <typename ValueType, typename IndexType>
-void generate(
-    std::shared_ptr<const ReferenceExecutor> exec,
-    const matrix::Csr<ValueType, IndexType> *system_matrix,
-    size_type num_blocks, uint32 max_block_size,
-    const preconditioner::block_interleaved_storage_scheme &storage_scheme,
-    Array<precision<ValueType, IndexType>> &block_precisions,
-    const Array<IndexType> &block_pointers, Array<ValueType> &blocks)
+void generate(std::shared_ptr<const ReferenceExecutor> exec,
+              const matrix::Csr<ValueType, IndexType> *system_matrix,
+              size_type num_blocks, uint32 max_block_size,
+              const preconditioner::block_interleaved_storage_scheme<IndexType>
+                  &storage_scheme,
+              Array<precision<ValueType, IndexType>> &block_precisions,
+              const Array<IndexType> &block_pointers, Array<ValueType> &blocks)
 {
     const auto ptrs = block_pointers.get_const_data();
     const auto prec = block_precisions.get_data();

--- a/reference/preconditioner/block_jacobi_kernels.cpp
+++ b/reference/preconditioner/block_jacobi_kernels.cpp
@@ -281,10 +281,12 @@ inline void invert_block(IndexType block_size, IndexType *perm,
 
 
 template <typename ValueType, typename IndexType>
-void generate(std::shared_ptr<const ReferenceExecutor> exec,
-              const matrix::Csr<ValueType, IndexType> *system_matrix,
-              size_type num_blocks, uint32 max_block_size, size_type stride,
-              const Array<IndexType> &block_pointers, Array<ValueType> &blocks)
+void generate(
+    std::shared_ptr<const ReferenceExecutor> exec,
+    const matrix::Csr<ValueType, IndexType> *system_matrix,
+    size_type num_blocks, uint32 max_block_size,
+    const preconditioner::block_interleaved_storage_scheme &storage_scheme,
+    const Array<IndexType> &block_pointers, Array<ValueType> &blocks)
 {
     const auto ptrs = block_pointers.get_const_data();
     for (size_type b = 0; b < num_blocks; ++b) {
@@ -297,7 +299,8 @@ void generate(std::shared_ptr<const ReferenceExecutor> exec,
         invert_block(block_size, perm.get_data(), block.get_data(), block_size);
         permute_and_transpose_block(
             block_size, perm.get_data(), block.get_data(), block_size,
-            blocks.get_data() + stride * ptrs[b], stride);
+            blocks.get_data() + storage_scheme.get_global_block_offset(b),
+            storage_scheme.get_stride());
     }
 }
 
@@ -347,23 +350,24 @@ inline void apply_block(size_type block_size, size_type num_rhs,
 
 
 template <typename ValueType, typename IndexType>
-void apply(std::shared_ptr<const ReferenceExecutor> exec, size_type num_blocks,
-           uint32 max_block_size, size_type stride,
-           const Array<IndexType> &block_pointers,
-           const Array<ValueType> &blocks,
-           const matrix::Dense<ValueType> *alpha,
-           const matrix::Dense<ValueType> *b,
-           const matrix::Dense<ValueType> *beta, matrix::Dense<ValueType> *x)
+void apply(
+    std::shared_ptr<const ReferenceExecutor> exec, size_type num_blocks,
+    uint32 max_block_size,
+    const preconditioner::block_interleaved_storage_scheme &storage_scheme,
+    const Array<IndexType> &block_pointers, const Array<ValueType> &blocks,
+    const matrix::Dense<ValueType> *alpha, const matrix::Dense<ValueType> *b,
+    const matrix::Dense<ValueType> *beta, matrix::Dense<ValueType> *x)
 {
     const auto ptrs = block_pointers.get_const_data();
     for (size_type i = 0; i < num_blocks; ++i) {
-        const auto block = blocks.get_const_data() + stride * ptrs[i];
+        const auto block =
+            blocks.get_const_data() + storage_scheme.get_global_block_offset(i);
         const auto block_b = b->get_const_values() + b->get_stride() * ptrs[i];
         const auto block_x = x->get_values() + x->get_stride() * ptrs[i];
         const auto block_size = ptrs[i + 1] - ptrs[i];
-        apply_block(block_size, b->get_size()[1], block, stride,
-                    alpha->at(0, 0), block_b, b->get_stride(), beta->at(0, 0),
-                    block_x, x->get_stride());
+        apply_block(block_size, b->get_size()[1], block,
+                    storage_scheme.get_stride(), alpha->at(0, 0), block_b,
+                    b->get_stride(), beta->at(0, 0), block_x, x->get_stride());
     }
 }
 
@@ -372,22 +376,24 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 
 
 template <typename ValueType, typename IndexType>
-void simple_apply(std::shared_ptr<const ReferenceExecutor> exec,
-                  size_type num_blocks, uint32 max_block_size, size_type stride,
-                  const Array<IndexType> &block_pointers,
-                  const Array<ValueType> &blocks,
-                  const matrix::Dense<ValueType> *b,
-                  matrix::Dense<ValueType> *x)
+void simple_apply(
+    std::shared_ptr<const ReferenceExecutor> exec, size_type num_blocks,
+    uint32 max_block_size,
+    const preconditioner::block_interleaved_storage_scheme &storage_scheme,
+    const Array<IndexType> &block_pointers, const Array<ValueType> &blocks,
+    const matrix::Dense<ValueType> *b, matrix::Dense<ValueType> *x)
 {
     const auto ptrs = block_pointers.get_const_data();
     for (size_type i = 0; i < num_blocks; ++i) {
-        const auto block = blocks.get_const_data() + stride * ptrs[i];
+        const auto block =
+            blocks.get_const_data() + storage_scheme.get_global_block_offset(i);
         const auto block_b = b->get_const_values() + b->get_stride() * ptrs[i];
         const auto block_x = x->get_values() + x->get_stride() * ptrs[i];
         const auto block_size = ptrs[i + 1] - ptrs[i];
-        apply_block(block_size, b->get_size()[1], block, stride,
-                    one<ValueType>(), block_b, b->get_stride(),
-                    zero<ValueType>(), block_x, x->get_stride());
+        apply_block(block_size, b->get_size()[1], block,
+                    storage_scheme.get_stride(), one<ValueType>(), block_b,
+                    b->get_stride(), zero<ValueType>(), block_x,
+                    x->get_stride());
     }
 }
 
@@ -396,11 +402,11 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 
 
 template <typename ValueType, typename IndexType>
-void convert_to_dense(std::shared_ptr<const ReferenceExecutor> exec,
-                      size_type num_blocks,
-                      const Array<IndexType> &block_pointers,
-                      const Array<ValueType> &blocks, size_type block_stride,
-                      ValueType *result_values, size_type result_stride)
+void convert_to_dense(
+    std::shared_ptr<const ReferenceExecutor> exec, size_type num_blocks,
+    const Array<IndexType> &block_pointers, const Array<ValueType> &blocks,
+    const preconditioner::block_interleaved_storage_scheme &storage_scheme,
+    ValueType *result_values, size_type result_stride)
 {
     const auto ptrs = block_pointers.get_const_data();
     const size_type matrix_size = ptrs[num_blocks];
@@ -411,9 +417,10 @@ void convert_to_dense(std::shared_ptr<const ReferenceExecutor> exec,
     }
 
     for (size_type i = 0; i < num_blocks; ++i) {
-        const auto block = blocks.get_const_data() + block_stride * ptrs[i];
+        const auto block =
+            blocks.get_const_data() + storage_scheme.get_global_block_offset(i);
         const auto block_size = ptrs[i + 1] - ptrs[i];
-        transpose_block(block_size, block, block_stride,
+        transpose_block(block_size, block, storage_scheme.get_stride(),
                         result_values + ptrs[i] * result_stride + ptrs[i],
                         result_stride);
     }
@@ -447,28 +454,32 @@ namespace adaptive_block_jacobi {
 
 
 template <typename ValueType, typename IndexType>
-void apply(std::shared_ptr<const ReferenceExecutor> exec, size_type num_blocks,
-           uint32 max_block_size, size_type stride,
-           const Array<precision<ValueType, IndexType>> &block_precisions,
-           const Array<IndexType> &block_pointers,
-           const Array<ValueType> &blocks,
-           const matrix::Dense<ValueType> *alpha,
-           const matrix::Dense<ValueType> *b,
-           const matrix::Dense<ValueType> *beta, matrix::Dense<ValueType> *x)
+void apply(
+    std::shared_ptr<const ReferenceExecutor> exec, size_type num_blocks,
+    uint32 max_block_size,
+    const preconditioner::block_interleaved_storage_scheme &storage_scheme,
+    const Array<precision<ValueType, IndexType>> &block_precisions,
+    const Array<IndexType> &block_pointers, const Array<ValueType> &blocks,
+    const matrix::Dense<ValueType> *alpha, const matrix::Dense<ValueType> *b,
+    const matrix::Dense<ValueType> *beta, matrix::Dense<ValueType> *x)
 {
     const auto ptrs = block_pointers.get_const_data();
     const auto prec = block_precisions.get_const_data();
     for (size_type i = 0; i < num_blocks; ++i) {
-        const auto block = blocks.get_const_data() + stride * ptrs[i];
+        // TODO: use the same precision for the block group and optimize the
+        // storage scheme for it
+        const auto block =
+            blocks.get_const_data() + storage_scheme.get_global_block_offset(i);
         const auto block_b = b->get_const_values() + b->get_stride() * ptrs[i];
         const auto block_x = x->get_values() + x->get_stride() * ptrs[i];
         const auto block_size = ptrs[i + 1] - ptrs[i];
         RESOLVE_PRECISION(
-            prec[i], block_jacobi::apply_block(
-                         block_size, b->get_size()[1],
-                         reinterpret_cast<const resolved_precision *>(block),
-                         stride, alpha->at(0, 0), block_b, b->get_stride(),
-                         beta->at(0, 0), block_x, x->get_stride()));
+            prec[i],
+            block_jacobi::apply_block(
+                block_size, b->get_size()[1],
+                reinterpret_cast<const resolved_precision *>(block),
+                storage_scheme.get_stride(), alpha->at(0, 0), block_b,
+                b->get_stride(), beta->at(0, 0), block_x, x->get_stride()));
     }
 }
 
@@ -479,7 +490,8 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 template <typename ValueType, typename IndexType>
 void simple_apply(
     std::shared_ptr<const ReferenceExecutor> exec, size_type num_blocks,
-    uint32 max_block_size, size_type stride,
+    uint32 max_block_size,
+    const preconditioner::block_interleaved_storage_scheme &storage_scheme,
     const Array<precision<ValueType, IndexType>> &block_precisions,
     const Array<IndexType> &block_pointers, const Array<ValueType> &blocks,
     const matrix::Dense<ValueType> *b, matrix::Dense<ValueType> *x)
@@ -487,16 +499,20 @@ void simple_apply(
     const auto ptrs = block_pointers.get_const_data();
     const auto prec = block_precisions.get_const_data();
     for (size_type i = 0; i < num_blocks; ++i) {
-        const auto block = blocks.get_const_data() + stride * ptrs[i];
+        // TODO: use the same precision for the block group and optimize the
+        // storage scheme for it
+        const auto block =
+            blocks.get_const_data() + storage_scheme.get_global_block_offset(i);
         const auto block_b = b->get_const_values() + b->get_stride() * ptrs[i];
         const auto block_x = x->get_values() + x->get_stride() * ptrs[i];
         const auto block_size = ptrs[i + 1] - ptrs[i];
         RESOLVE_PRECISION(
-            prec[i], block_jacobi::apply_block(
-                         block_size, b->get_size()[1],
-                         reinterpret_cast<const resolved_precision *>(block),
-                         stride, one<ValueType>(), block_b, b->get_stride(),
-                         zero<ValueType>(), block_x, x->get_stride()));
+            prec[i],
+            block_jacobi::apply_block(
+                block_size, b->get_size()[1],
+                reinterpret_cast<const resolved_precision *>(block),
+                storage_scheme.get_stride(), one<ValueType>(), block_b,
+                b->get_stride(), zero<ValueType>(), block_x, x->get_stride()));
     }
 }
 
@@ -509,7 +525,8 @@ void convert_to_dense(
     std::shared_ptr<const ReferenceExecutor> exec, size_type num_blocks,
     const Array<precision<ValueType, IndexType>> &block_precisions,
     const Array<IndexType> &block_pointers, const Array<ValueType> &blocks,
-    size_type block_stride, ValueType *result_values, size_type result_stride)
+    const preconditioner::block_interleaved_storage_scheme &storage_scheme,
+    ValueType *result_values, size_type result_stride)
 {
     const auto ptrs = block_pointers.get_const_data();
     const auto prec = block_precisions.get_const_data();
@@ -521,13 +538,17 @@ void convert_to_dense(
     }
 
     for (size_type i = 0; i < num_blocks; ++i) {
-        const auto block = blocks.get_const_data() + block_stride * ptrs[i];
+        // TODO: use the same precision for the block group and optimize the
+        // storage scheme for it
+        const auto block =
+            blocks.get_const_data() + storage_scheme.get_global_block_offset(i);
         const auto block_size = ptrs[i + 1] - ptrs[i];
         RESOLVE_PRECISION(
             prec[i],
             block_jacobi::transpose_block(
                 block_size, reinterpret_cast<const resolved_precision *>(block),
-                block_stride, result_values + ptrs[i] * result_stride + ptrs[i],
+                storage_scheme.get_stride(),
+                result_values + ptrs[i] * result_stride + ptrs[i],
                 result_stride));
     }
 }
@@ -537,11 +558,13 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 
 
 template <typename ValueType, typename IndexType>
-void generate(std::shared_ptr<const ReferenceExecutor> exec,
-              const matrix::Csr<ValueType, IndexType> *system_matrix,
-              size_type num_blocks, uint32 max_block_size, size_type stride,
-              Array<precision<ValueType, IndexType>> &block_precisions,
-              const Array<IndexType> &block_pointers, Array<ValueType> &blocks)
+void generate(
+    std::shared_ptr<const ReferenceExecutor> exec,
+    const matrix::Csr<ValueType, IndexType> *system_matrix,
+    size_type num_blocks, uint32 max_block_size,
+    const preconditioner::block_interleaved_storage_scheme &storage_scheme,
+    Array<precision<ValueType, IndexType>> &block_precisions,
+    const Array<IndexType> &block_pointers, Array<ValueType> &blocks)
 {
     const auto ptrs = block_pointers.get_const_data();
     const auto prec = block_precisions.get_data();
@@ -558,13 +581,16 @@ void generate(std::shared_ptr<const ReferenceExecutor> exec,
             // TODO: properly compute best precision
             prec[b] = precision<ValueType, IndexType>::double_precision;
         }
+        // TODO: use the same precision for the block group and optimize the
+        // storage scheme for it
         RESOLVE_PRECISION(
             prec[b],
             block_jacobi::permute_and_transpose_block(
                 block_size, perm.get_data(), block.get_data(), block_size,
-                reinterpret_cast<resolved_precision *>(blocks.get_data() +
-                                                       stride * ptrs[b]),
-                stride));
+                reinterpret_cast<resolved_precision *>(
+                    blocks.get_data() +
+                    storage_scheme.get_global_block_offset(b)),
+                storage_scheme.get_stride()));
     }
 }
 

--- a/reference/test/preconditioner/block_jacobi.cpp
+++ b/reference/test/preconditioner/block_jacobi.cpp
@@ -146,8 +146,8 @@ TEST_F(BlockJacobi, GeneratesCorrectStorageScheme)
     auto scheme = bj->get_storage_scheme();
 
     ASSERT_EQ(scheme.group_size, 8);  // 8 3-b-3 blocks fit into 32-wide group
-    ASSERT_EQ(scheme.block_offset, 4);
-    ASSERT_EQ(scheme.group_offset, 8 * 4 * 3);
+    ASSERT_EQ(scheme.block_offset, 3);
+    ASSERT_EQ(scheme.group_offset, 8 * 3 * 3);
 }
 
 

--- a/reference/test/preconditioner/block_jacobi.cpp
+++ b/reference/test/preconditioner/block_jacobi.cpp
@@ -145,7 +145,7 @@ TEST_F(BlockJacobi, GeneratesCorrectStorageScheme)
 {
     auto scheme = bj->get_storage_scheme();
 
-    ASSERT_EQ(scheme.group_size, 8);  // 8 3-b-3 blocks fit into 32-wide group
+    ASSERT_EQ(scheme.group_power, 3);  // 8 3-by-3 blocks fit into 32-wide group
     ASSERT_EQ(scheme.block_offset, 3);
     ASSERT_EQ(scheme.group_offset, 8 * 3 * 3);
 }

--- a/reference/test/preconditioner/block_jacobi.cpp
+++ b/reference/test/preconditioner/block_jacobi.cpp
@@ -118,12 +118,13 @@ protected:
         ASSERT_EQ(b_ptr_a[0], b_ptr_b[0]);
         for (int i = 0; i < a->get_num_blocks(); ++i) {
             ASSERT_EQ(b_ptr_a[i + 1], b_ptr_b[i + 1]);
+            auto scheme = a->get_storage_scheme();
             assert_same_block(
                 b_ptr_a[i + 1] - b_ptr_a[i],
-                a->get_const_blocks() + b_ptr_a[i] * a->get_stride(),
-                a->get_stride(),
-                b->get_const_blocks() + b_ptr_b[i] * b->get_stride(),
-                b->get_stride());
+                a->get_const_blocks() + scheme.get_global_block_offset(i),
+                scheme.get_stride(),
+                b->get_const_blocks() + scheme.get_global_block_offset(i),
+                scheme.get_stride());
         }
     }
 
@@ -138,6 +139,16 @@ protected:
 
 class BlockJacobi
     : public BasicBlockJacobiTest<gko::preconditioner::BlockJacobiFactory<>> {};
+
+
+TEST_F(BlockJacobi, GeneratesCorrectStorageScheme)
+{
+    auto scheme = bj->get_storage_scheme();
+
+    ASSERT_EQ(scheme.group_size, 8);  // 8 3-b-3 blocks fit into 32-wide group
+    ASSERT_EQ(scheme.block_offset, 4);
+    ASSERT_EQ(scheme.group_offset, 8 * 4 * 3);
+}
 
 
 TEST_F(BlockJacobi, CanBeCloned)
@@ -182,7 +193,6 @@ TEST_F(BlockJacobi, CanBeCleared)
     ASSERT_EQ(bj->get_size(), gko::dim<2>(0, 0));
     ASSERT_EQ(bj->get_num_stored_elements(), 0);
     ASSERT_EQ(bj->get_max_block_size(), 0);
-    ASSERT_EQ(bj->get_stride(), 0);
     ASSERT_EQ(bj->get_const_block_pointers(), nullptr);
     ASSERT_EQ(bj->get_const_blocks(), nullptr);
 }
@@ -251,22 +261,24 @@ protected:
         for (int i = 0; i < a->get_num_blocks(); ++i) {
             ASSERT_EQ(b_prec_a[i], b_prec_b[i]);
             ASSERT_EQ(b_ptr_a[i + 1], b_ptr_b[i + 1]);
+            auto scheme = a->get_storage_scheme();
             if (b_prec_a[i] == Bj::single_precision) {
-                assert_same_block(
-                    b_ptr_a[i + 1] - b_ptr_a[i],
-                    reinterpret_cast<const float *>(
-                        a->get_const_blocks() + b_ptr_a[i] * a->get_stride()),
-                    a->get_stride(),
-                    reinterpret_cast<const float *>(
-                        b->get_const_blocks() + b_ptr_b[i] * b->get_stride()),
-                    b->get_stride());
+                assert_same_block(b_ptr_a[i + 1] - b_ptr_a[i],
+                                  reinterpret_cast<const float *>(
+                                      a->get_const_blocks() +
+                                      scheme.get_global_block_offset(i)),
+                                  scheme.get_stride(),
+                                  reinterpret_cast<const float *>(
+                                      b->get_const_blocks() +
+                                      scheme.get_global_block_offset(i)),
+                                  scheme.get_stride());
             } else {
                 assert_same_block(
                     b_ptr_a[i + 1] - b_ptr_a[i],
-                    a->get_const_blocks() + b_ptr_a[i] * a->get_stride(),
-                    a->get_stride(),
-                    b->get_const_blocks() + b_ptr_b[i] * b->get_stride(),
-                    b->get_stride());
+                    a->get_const_blocks() + scheme.get_global_block_offset(i),
+                    scheme.get_stride(),
+                    b->get_const_blocks() + scheme.get_global_block_offset(i),
+                    scheme.get_stride());
             }
         }
     }
@@ -320,7 +332,6 @@ TEST_F(AdaptiveBlockJacobi, CanBeCleared)
     ASSERT_EQ(bj->get_size(), gko::dim<2>(0, 0));
     ASSERT_EQ(bj->get_num_stored_elements(), 0);
     ASSERT_EQ(bj->get_max_block_size(), 0);
-    ASSERT_EQ(bj->get_stride(), 0);
     ASSERT_EQ(bj->get_const_block_pointers(), nullptr);
     ASSERT_EQ(bj->get_const_block_precisions(), nullptr);
     ASSERT_EQ(bj->get_const_blocks(), nullptr);

--- a/reference/test/preconditioner/block_jacobi_kernels.cpp
+++ b/reference/test/preconditioner/block_jacobi_kernels.cpp
@@ -221,14 +221,15 @@ TEST_F(BlockJacobi, InvertsDiagonalBlocks)
     bj_lin_op = bj_factory->generate(mtx);
 
     bj = static_cast<Bj *>(bj_lin_op.get());
-    auto p = bj->get_stride();
-    auto b1 = bj->get_blocks();
+    auto scheme = bj->get_storage_scheme();
+    auto p = scheme.get_stride();
+    auto b1 = bj->get_blocks() + scheme.get_global_block_offset(0);
     EXPECT_NEAR(b1[0 + 0 * p], 4.0 / 14.0, 1e-14);
     EXPECT_NEAR(b1[0 + 1 * p], 2.0 / 14.0, 1e-14);
     EXPECT_NEAR(b1[1 + 0 * p], 1.0 / 14.0, 1e-14);
     EXPECT_NEAR(b1[1 + 1 * p], 4.0 / 14.0, 1e-14);
 
-    auto b2 = bj->get_blocks() + 2 * p;
+    auto b2 = bj->get_blocks() + scheme.get_global_block_offset(1);
     EXPECT_NEAR(b2[0 + 0 * p], 14.0 / 48.0, 1e-14);
     EXPECT_NEAR(b2[0 + 1 * p], 8.0 / 48.0, 1e-14);
     EXPECT_NEAR(b2[0 + 2 * p], 4.0 / 48.0, 1e-14);
@@ -260,8 +261,9 @@ TEST_F(BlockJacobi, PivotsWhenInvertingBlock)
     bj_lin_op = bj_factory->generate(std::move(mtx));
 
     bj = static_cast<Bj *>(bj_lin_op.get());
-    auto p = bj->get_stride();
-    auto b1 = bj->get_blocks();
+    auto scheme = bj->get_storage_scheme();
+    auto p = scheme.get_stride();
+    auto b1 = bj->get_blocks() + scheme.get_global_block_offset(0);
     EXPECT_NEAR(b1[0 + 0 * p], 0.0 / 4.0, 1e-14);
     EXPECT_NEAR(b1[0 + 1 * p], 0.0 / 4.0, 1e-14);
     EXPECT_NEAR(b1[0 + 2 * p], 4.0 / 4.0, 1e-14);
@@ -407,14 +409,16 @@ TEST_F(AdaptiveBlockJacobi, InvertsDiagonalBlocks)
     bj_lin_op = bj_factory->generate(mtx);
 
     bj = static_cast<Bj *>(bj_lin_op.get());
-    auto p = bj->get_stride();
-    auto b1 = reinterpret_cast<const float *>(bj->get_const_blocks());
+    auto scheme = bj->get_storage_scheme();
+    auto p = scheme.get_stride();
+    auto b1 = reinterpret_cast<const float *>(
+        bj->get_blocks() + scheme.get_global_block_offset(0));
     EXPECT_NEAR(b1[0 + 0 * p], 4.0 / 14.0, 1e-7);
     EXPECT_NEAR(b1[0 + 1 * p], 2.0 / 14.0, 1e-7);
     EXPECT_NEAR(b1[1 + 0 * p], 1.0 / 14.0, 1e-7);
     EXPECT_NEAR(b1[1 + 1 * p], 4.0 / 14.0, 1e-7);
 
-    auto b2 = bj->get_blocks() + 2 * p;
+    auto b2 = bj->get_blocks() + scheme.get_global_block_offset(1);
     EXPECT_NEAR(b2[0 + 0 * p], 14.0 / 48.0, 1e-14);
     EXPECT_NEAR(b2[0 + 1 * p], 8.0 / 48.0, 1e-14);
     EXPECT_NEAR(b2[0 + 2 * p], 4.0 / 48.0, 1e-14);
@@ -445,10 +449,12 @@ TEST_F(AdaptiveBlockJacobi, PivotsWhenInvertingBlock)
                {0.0, 2.0, 0.0, 0.0, 0.0, 4.0, 1.0, 0.0, 0.0});
 
     bj_lin_op = bj_factory->generate(std::move(mtx));
-
     bj = static_cast<Bj *>(bj_lin_op.get());
-    auto p = bj->get_stride();
-    auto b1 = reinterpret_cast<const float *>(bj->get_const_blocks());
+
+    auto scheme = bj->get_storage_scheme();
+    auto p = scheme.get_stride();
+    auto b1 = reinterpret_cast<const float *>(
+        bj->get_blocks() + scheme.get_global_block_offset(0));
     EXPECT_NEAR(b1[0 + 0 * p], 0.0 / 4.0, 1e-7);
     EXPECT_NEAR(b1[0 + 1 * p], 0.0 / 4.0, 1e-7);
     EXPECT_NEAR(b1[0 + 2 * p], 4.0 / 4.0, 1e-7);


### PR DESCRIPTION
This PR further improves the performance of the block-Jacobi preconditioner for smaller block sizes by redesigning the way blocks are stored in memory. In addition to column-major storage introduced in #158, this PR interleaves the blocks to maximize coalescence when a single warp handles multiple problems.
The idea is shown in the following figure, where the maximum block size allows to interleave 2 blocks to fill the cache line:


![jacobi_storage](https://user-images.githubusercontent.com/1261711/47814893-34a23280-dd4f-11e8-8891-27a168a4b0d9.png)

There's trade-off in both approaches depicted in the figure. Option 1 always results in aligned data access, but consumes more memory in total. Option 2 consumes less memory, but data accesses are not always aligned.

I'm currently running benchmarks for both options on PizDaint, but the results on an initial implementation of this I got before suggest that option 2 is faster.

TODO:
----------

- [x] merge #158 
- [x] get benchmark results