### PR TITLE
Optimized copy_from

### DIFF
--- a/core/base/polymorphic_object.hpp
+++ b/core/base/polymorphic_object.hpp
@@ -497,15 +497,9 @@ class EnablePolymorphicAssignment : public ConvertibleTo<ResultType> {
 public:
     using result_type = ResultType;
 
-    void convert_to(result_type *result) const override
-    {
-        *result = static_cast<result_type>(*self());
-    }
+    void convert_to(result_type *result) const override { *result = *self(); }
 
-    void move_to(result_type *result) override
-    {
-        *result = static_cast<result_type>(std::move(*self()));
-    }
+    void move_to(result_type *result) override { *result = std::move(*self()); }
 
 private:
     GKO_ENABLE_SELF(ConcreteType);


### PR DESCRIPTION
This PR removes the additional allocations/frees from the `copy_from` operation, as noticed in #164.

This reduces the overhead of the preconditioner in BICGSTAB. However, there is still significant idle time during preconditioner application. Highlighted on the profile is the `copy_from` initiated in the preconditioner. The "Runtime API" line shows when the copy was initiated, and the "MemCpy [DtoD]" line when the copy was actually executed. Why is there such a discrepancy between them is beyond me...

![image](https://user-images.githubusercontent.com/1261711/48302755-d1f42800-e500-11e8-9c42-4c5aeeab90ab.png)
