### PR TITLE
Fix the residual norm reduction criterion for CUDA devices

### DIFF
--- a/core/stop/residual_norm_reduction.cpp
+++ b/core/stop/residual_norm_reduction.cpp
@@ -62,20 +62,19 @@ bool ResidualNormReduction<ValueType>::check_impl(
     if (updater.residual_norm_ != nullptr) {
         dense_tau = as<Vector>(updater.residual_norm_);
     } else if (updater.residual_ != nullptr) {
-        u_dense_tau = Vector::create_with_config_of(starting_tau_.get());
-        auto dense_r = as<Vector>(updater.residual_);
-        dense_r->compute_norm2(u_dense_tau.get());
-        dense_tau = u_dense_tau.get();
+        auto *dense_r = as<Vector>(updater.residual_);
+        dense_r->compute_norm2(u_dense_tau_.get());
+        dense_tau = u_dense_tau_.get();
     } else {
         NOT_SUPPORTED(nullptr);
     }
+    bool all_converged = true;
 
-    bool all_converged{};
     this->get_executor()->run(
         TemplatedOperation<ValueType>::make_residual_norm_reduction_operation(
             dense_tau, starting_tau_.get(), parameters_.reduction_factor,
-            stoppingId, setFinalized, stop_status, &all_converged,
-            one_changed));
+            stoppingId, setFinalized, stop_status, &this->device_storage_,
+            &all_converged, one_changed));
     return all_converged;
 }
 

--- a/core/stop/residual_norm_reduction.hpp
+++ b/core/stop/residual_norm_reduction.hpp
@@ -35,6 +35,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define GKO_CORE_STOP_RESIDUAL_NORM_REDUCTION_HPP_
 
 
+#include "core/base/array.hpp"
 #include "core/base/utils.hpp"
 #include "core/matrix/dense.hpp"
 #include "core/stop/criterion.hpp"
@@ -68,16 +69,14 @@ class ResidualNormReduction
 public:
     using Vector = matrix::Dense<ValueType>;
 
-    GKO_CREATE_FACTORY_PARAMETERS(parameters, Factory)
-    {
+    GKO_CREATE_FACTORY_PARAMETERS(parameters, Factory){
         /**
          * Relative residual norm goal
          */
         remove_complex<ValueType> GKO_FACTORY_PARAMETER(reduction_factor,
-                                                        1e-15);
-    };
+                                                        1e-15)};
     GKO_ENABLE_CRITERION_FACTORY(ResidualNormReduction<ValueType>, parameters,
-                                 Factory);
+                                 Factory)
     GKO_ENABLE_BUILD_METHOD(Factory);
 
 protected:
@@ -86,29 +85,35 @@ protected:
                     const Criterion::Updater &) override;
 
     explicit ResidualNormReduction(std::shared_ptr<const gko::Executor> exec)
-        : EnablePolymorphicObject<ResidualNormReduction<ValueType>, Criterion>(
-              std::move(exec))
+        : EnablePolymorphicObject<ResidualNormReduction, Criterion>(exec),
+          device_storage_{exec, 2}
     {}
 
     explicit ResidualNormReduction(const Factory *factory,
                                    const CriterionArgs &args)
-        : EnablePolymorphicObject<ResidualNormReduction<ValueType>, Criterion>(
+        : EnablePolymorphicObject<ResidualNormReduction, Criterion>(
               factory->get_executor()),
-          parameters_{factory->get_parameters()}
+          parameters_{factory->get_parameters()},
+          device_storage_{factory->get_executor(), 2}
     {
         if (args.initial_residual == nullptr) {
             NOT_SUPPORTED(nullptr);
         }
 
+        auto exec = factory->get_executor();
+
         auto dense_r = as<Vector>(args.initial_residual);
-        starting_tau_ =
-            Vector::create(factory->get_executor(),
-                           dim<2>{1, args.initial_residual->get_size()[1]});
+        starting_tau_ = Vector::create(
+            exec, dim<2>{1, args.initial_residual->get_size()[1]});
+        u_dense_tau_ = Vector::create_with_config_of(starting_tau_.get());
         dense_r->compute_norm2(starting_tau_.get());
     }
 
 private:
     std::unique_ptr<Vector> starting_tau_{};
+    std::unique_ptr<Vector> u_dense_tau_{};
+    /* Contains device side: all_converged and one_changed booleans */
+    Array<bool> device_storage_;
 };
 
 

--- a/core/stop/residual_norm_reduction_kernels.hpp
+++ b/core/stop/residual_norm_reduction_kernels.hpp
@@ -53,7 +53,7 @@ namespace residual_norm_reduction {
         const matrix::Dense<_type> *tau, const matrix::Dense<_type> *orig_tau, \
         remove_complex<_type> rel_residual_goal, uint8 stoppingId,             \
         bool setFinalized, Array<stopping_status> *stop_status,                \
-        bool *all_converged, bool *one_changed)
+        Array<bool> *device_storage, bool *all_converged, bool *one_changed)
 
 
 #define DECLARE_ALL_AS_TEMPLATES  \

--- a/cuda/stop/residual_norm_reduction_kernels.cu
+++ b/cuda/stop/residual_norm_reduction_kernels.cu
@@ -36,6 +36,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "core/base/exception_helpers.hpp"
 #include "core/base/math.hpp"
+#include "core/stop/residual_norm_reduction.hpp"
 #include "cuda/base/math.hpp"
 #include "cuda/base/types.hpp"
 
@@ -55,19 +56,19 @@ __global__
         const ValueType *__restrict__ tau,
         const ValueType *__restrict__ orig_tau, uint8 stoppingId,
         bool setFinalized, stopping_status *__restrict__ stop_status,
-        bool *__restrict__ all_converged, bool *__restrict__ one_changed)
+        bool *__restrict__ device_storage)
 {
     const auto tidx =
         static_cast<size_type>(blockDim.x) * blockIdx.x + threadIdx.x;
     if (tidx < num_cols) {
         if (abs(tau[tidx]) < rel_residual_goal * abs(orig_tau[tidx])) {
             stop_status[tidx].converge(stoppingId, setFinalized);
-            *one_changed = true;
+            device_storage[1] = true;
         }
         // because only false is written to all_converged, write conflicts
         // should not cause any problem
         else if (!stop_status[tidx].has_stopped()) {
-            *all_converged = false;
+            device_storage[0] = false;
         }
     }
 }
@@ -80,17 +81,13 @@ void residual_norm_reduction(std::shared_ptr<const CudaExecutor> exec,
                              remove_complex<ValueType> rel_residual_goal,
                              uint8 stoppingId, bool setFinalized,
                              Array<stopping_status> *stop_status,
-                             bool *all_converged, bool *one_changed)
+                             Array<bool> *device_storage, bool *all_converged,
+                             bool *one_changed)
 {
-    *all_converged = true;
-    auto all_converged_array =
-        Array<bool>::view(exec->get_master(), 1, all_converged);
-    Array<bool> d_all_converged(exec, all_converged_array);
-
-    *one_changed = false;
-    auto one_changed_array =
-        Array<bool>::view(exec->get_master(), 1, one_changed);
-    Array<bool> d_one_changed(exec, one_changed_array);
+    /* Represents all_converged, one_changed */
+    bool tmp[2] = {true, false};
+    exec->copy_from(exec->get_master().get(), 2, tmp,
+                    device_storage->get_data());
 
     const dim3 block_size(default_block_size, 1, 1);
     const dim3 grid_size(ceildiv(tau->get_size()[1], block_size.x), 1, 1);
@@ -100,11 +97,12 @@ void residual_norm_reduction(std::shared_ptr<const CudaExecutor> exec,
         as_cuda_type(tau->get_const_values()),
         as_cuda_type(orig_tau->get_const_values()), stoppingId, setFinalized,
         as_cuda_type(stop_status->get_data()),
-        as_cuda_type(d_all_converged.get_data()),
-        as_cuda_type(d_one_changed.get_data()));
+        as_cuda_type(device_storage->get_data()));
 
-    all_converged_array = d_all_converged;
-    one_changed_array = d_one_changed;
+    exec->get_master()->copy_from(exec.get(), 2,
+                                  device_storage->get_const_data(), tmp);
+    *all_converged = tmp[0];
+    *one_changed = tmp[1];
 }
 
 GKO_INSTANTIATE_FOR_EACH_VALUE_TYPE(GKO_DECLARE_RESIDUAL_NORM_REDUCTION_KERNEL);

--- a/omp/stop/residual_norm_reduction_kernels.cpp
+++ b/omp/stop/residual_norm_reduction_kernels.cpp
@@ -53,9 +53,11 @@ void residual_norm_reduction(std::shared_ptr<const OmpExecutor> exec,
                              remove_complex<ValueType> rel_residual_goal,
                              uint8 stoppingId, bool setFinalized,
                              Array<stopping_status> *stop_status,
-                             bool *all_converged, bool *one_changed)
+                             Array<bool> *device_storage, bool *all_converged,
+                             bool *one_changed)
 {
     *all_converged = true;
+    *one_changed = false;
 #pragma omp parallel for
     for (size_type i = 0; i < tau->get_size()[1]; ++i) {
         if (abs(tau->at(i)) < rel_residual_goal * abs(orig_tau->at(i))) {

--- a/reference/stop/residual_norm_reduction_kernels.cpp
+++ b/reference/stop/residual_norm_reduction_kernels.cpp
@@ -55,9 +55,11 @@ void residual_norm_reduction(std::shared_ptr<const ReferenceExecutor> exec,
                              remove_complex<ValueType> rel_residual_goal,
                              uint8 stoppingId, bool setFinalized,
                              Array<stopping_status> *stop_status,
-                             bool *all_converged, bool *one_changed)
+                             Array<bool> *device_storage, bool *all_converged,
+                             bool *one_changed)
 {
     *all_converged = true;
+    *one_changed = false;
     for (size_type i = 0; i < tau->get_size()[1]; ++i) {
         if (abs(tau->at(i)) < rel_residual_goal * abs(orig_tau->at(i))) {
             stop_status->get_data()[i].converge(stoppingId, setFinalized);


### PR DESCRIPTION
This MR does everything that can be done to accelerate the Residual Norm Reduction Stopping Criterion for GPUs. Multiple optimizations are done to ensure no temporary data are allocated on the GPU, and therefore no cudaFree (and related) are called.
	1. An array to store the residual norms is always created to accelerate the norm computation (it is used only in the case we have a GPU executor AND the solver doesn't provide residual norms, which is currently all of Ginkgo).
	2. A small temporary array of two bytes is always created (used on the GPU) to represent the following booleans: `all_converged`, `one_changed`. There, I directly call `executor->copy_from()` as I found that was the most fitting function for that purpose.


Currently, results show on a P100 that the total criterion check takes 130 us, roughly 60us of that is the norm computation. A SpMV (with CSR and thermal 2 matrix) is 367 us by comparison. On the P100, the total criterion check time was divided by two. When looking at the BiCGSTAB solver time, it got down to `0.75289 s` from `0.81687 s` with thermal2 in CSR format (roughly 8% speedup).


I think that it would be possible to accelerate this further (make it almost perfect, i.e. divide the time by two again) but the only way to do it would be to migrate all of our copies towards using the "Async" modes for CUDA and/or using different streams.

The traces are available there:
[before fix](https://drive.google.com/open?id=1F0v-uw-3BANulesJKaV5Rxsw91ncsa3k)
[after fix](https://drive.google.com/open?id=1qJiwVFzHiYQGwGVso9sFAiYzPTa1MI1y)