### PR TITLE
Adaptive block-Jacobi CUDA kernels

### DIFF
--- a/core/preconditioner/jacobi.cpp
+++ b/core/preconditioner/jacobi.cpp
@@ -132,12 +132,10 @@ void Jacobi<ValueType, IndexType>::write(mat_data &data) const
                                     .block_wise.get_const_data();
         const auto prec =
             precisions ? precisions[block] : precision_reduction();
-        // TODO: use the same precision for the block group and optimize the
-        // storage scheme for it
         GKO_PRECONDITIONER_JACOBI_RESOLVE_PRECISION(ValueType, prec, {
             const auto block_data =
-                reinterpret_cast<const resolved_precision *>(
-                    group_data + scheme.get_block_offset(block));
+                reinterpret_cast<const resolved_precision *>(group_data) +
+                scheme.get_block_offset(block);
             for (IndexType row = 0; row < block_size; ++row) {
                 for (IndexType col = 0; col < block_size; ++col) {
                     data.nonzeros.emplace_back(

--- a/core/preconditioner/jacobi.hpp
+++ b/core/preconditioner/jacobi.hpp
@@ -300,12 +300,14 @@ public:
 
             storage_optimization_type(
                 const Array<precision_reduction> &block_wise_opt)
-                : is_block_wise{true}, block_wise{block_wise_opt}
+                : is_block_wise{block_wise_opt.get_num_elems() > 0},
+                  block_wise{block_wise_opt}
             {}
 
             storage_optimization_type(
                 Array<precision_reduction> &&block_wise_opt)
-                : is_block_wise{true}, block_wise{std::move(block_wise_opt)}
+                : is_block_wise{block_wise_opt.get_num_elems() > 0},
+                  block_wise{std::move(block_wise_opt)}
             {}
 
             operator precision_reduction() { return of_all_blocks; }

--- a/core/preconditioner/jacobi_utils.hpp
+++ b/core/preconditioner/jacobi_utils.hpp
@@ -43,6 +43,17 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
         using resolved_precision =                                     \
             ::gko::reduce_precision<::gko::reduce_precision<_type>>;   \
         __VA_ARGS__;                                                   \
+    } else if (_prec == ::gko::precision_reduction(1, 0)) {            \
+        using resolved_precision = ::gko::truncate_type<_type>;        \
+        __VA_ARGS__;                                                   \
+    } else if (_prec == ::gko::precision_reduction(1, 1)) {            \
+        using resolved_precision =                                     \
+            ::gko::truncate_type<::gko::reduce_precision<_type>>;      \
+        __VA_ARGS__;                                                   \
+    } else if (_prec == ::gko::precision_reduction(2, 0)) {            \
+        using resolved_precision =                                     \
+            ::gko::truncate_type<::gko::truncate_type<_type>>;         \
+        __VA_ARGS__;                                                   \
     } else {                                                           \
         using resolved_precision = _type;                              \
         __VA_ARGS__;                                                   \

--- a/cuda/components/reduction.cuh
+++ b/cuda/components/reduction.cuh
@@ -118,7 +118,8 @@ __device__ __forceinline__ int choose_pivot(const Group &group,
 template <
     typename Group, typename ValueType, typename Operator,
     typename = xstd::enable_if_t<group::is_synchronizable_group<Group>::value>>
-__device__ void reduce(const Group &group, ValueType *data,
+__device__ void reduce(const Group &__restrict__ group,
+                       ValueType *__restrict__ data,
                        Operator reduce_op = Operator{})
 {
     const auto local_id = group.thread_rank();

--- a/cuda/components/warp_blas.cuh
+++ b/cuda/components/warp_blas.cuh
@@ -197,7 +197,8 @@ __host__ __device__ __forceinline__ auto get_row_major_index(T1 row, T2 col,
  * @tparam max_problem_size  maximum problem size passed to the routine
  * @tparam mod  the transformation to perform on the return data
  * @tparam Group  type of the group of threads
- * @tparam ValueType  type of values stored in the matrix
+ * @tparam SourceValueType  type of values stored in the source matrix
+ * @tparam ResultValueType  type of values stored in the result matrix
  *
  * @param group  group of threads participating in the copy
  * @param problem_size  actual size of the matrix
@@ -216,12 +217,13 @@ __host__ __device__ __forceinline__ auto get_row_major_index(T1 row, T2 col,
  */
 template <
     int max_problem_size, postprocess_transformation mod = and_return,
-    typename Group, typename ValueType,
+    typename Group, typename SourceValueType, typename ResultValueType,
     typename = xstd::enable_if_t<group::is_communicator_group<Group>::value>>
 __device__ __forceinline__ void copy_matrix(
     const Group &group, uint32 problem_size,
-    const ValueType *__restrict__ source_row, uint32 increment, uint32 row_perm,
-    uint32 col_perm, ValueType *__restrict__ destination, size_type stride)
+    const SourceValueType *__restrict__ source_row, uint32 increment,
+    uint32 row_perm, uint32 col_perm, ResultValueType *__restrict__ destination,
+    size_type stride)
 {
     GKO_ASSERT(problem_size <= max_problem_size);
 #pragma unroll
@@ -232,7 +234,7 @@ __device__ __forceinline__ void copy_matrix(
         const auto idx = group.shfl(col_perm, i);
         if (group.thread_rank() < problem_size) {
             destination[get_row_major_index<mod>(idx, row_perm, stride)] =
-                source_row[i * increment];
+                static_cast<ResultValueType>(source_row[i * increment]);
         }
     }
 }
@@ -247,7 +249,8 @@ __device__ __forceinline__ void copy_matrix(
  *
  * @tparam max_problem_size  maximum problem size passed to the routine
  * @tparam Group  type of the group of threads
- * @tparam ValueType  type of values stored in matrix and vectors
+ * @tparam MatrixValueType  type of values stored in the matrix
+ * @tparam VectorValueType  type of values stored in the vectors
  *
  * @param group  group of threads participating in the operation
  * @param problem_size  actual size of the matrix
@@ -263,25 +266,28 @@ __device__ __forceinline__ void copy_matrix(
  * @param mtx_increment  offset between two consecutive elements of the result
  */
 template <
-    int max_problem_size, typename Group, typename ValueType,
+    int max_problem_size, typename Group, typename MatrixValueType,
+    typename VectorValueType,
     typename = xstd::enable_if_t<group::is_communicator_group<Group>::value>>
 __device__ __forceinline__ void multiply_transposed_vec(
-    const Group &group, uint32 problem_size, const ValueType &__restrict__ vec,
-    const ValueType *__restrict__ mtx_row, uint32 mtx_increment,
-    ValueType *__restrict__ res, uint32 res_increment)
+    const Group &group, uint32 problem_size,
+    const VectorValueType &__restrict__ vec,
+    const MatrixValueType *__restrict__ mtx_row, uint32 mtx_increment,
+    VectorValueType *__restrict__ res, uint32 res_increment)
 {
     GKO_ASSERT(problem_size <= max_problem_size);
-    auto mtx_elem = zero<ValueType>();
+    auto mtx_elem = zero<VectorValueType>();
 #pragma unroll
     for (int32 i = 0; i < max_problem_size; ++i) {
         if (i >= problem_size) {
             break;
         }
         if (group.thread_rank() < problem_size) {
-            mtx_elem = mtx_row[i * mtx_increment];
+            mtx_elem = static_cast<VectorValueType>(mtx_row[i * mtx_increment]);
         }
-        const auto out = reduce(group, mtx_elem * vec,
-                                [](ValueType x, ValueType y) { return x + y; });
+        const auto out =
+            reduce(group, mtx_elem * vec,
+                   [](VectorValueType x, VectorValueType y) { return x + y; });
         if (group.thread_rank() == 0) {
             res[i * res_increment] = out;
         }
@@ -298,7 +304,8 @@ __device__ __forceinline__ void multiply_transposed_vec(
  *
  * @tparam max_problem_size  maximum problem size passed to the routine
  * @tparam Group  type of the group of threads
- * @tparam ValueType  type of values stored in matrix and vectors
+ * @tparam MatrixValueType  type of values stored in the matrix
+ * @tparam VectorValueType  type of values stored in the vectors
  *
  * @param group  group of threads participating in the operation
  * @param problem_size  actual size of the matrix
@@ -314,23 +321,25 @@ __device__ __forceinline__ void multiply_transposed_vec(
  * @param mtx_increment  offset between two consecutive elements of the result
  */
 template <
-    int max_problem_size, typename Group, typename ValueType,
+    int max_problem_size, typename Group, typename MatrixValueType,
+    typename VectorValueType,
     typename = xstd::enable_if_t<group::is_communicator_group<Group>::value>>
 __device__ __forceinline__ void multiply_vec(
-    const Group &group, uint32 problem_size, const ValueType &__restrict__ vec,
-    const ValueType *__restrict__ mtx_row, uint32 mtx_increment,
-    ValueType *__restrict__ res, uint32 res_increment)
+    const Group &group, uint32 problem_size,
+    const VectorValueType &__restrict__ vec,
+    const MatrixValueType *__restrict__ mtx_row, uint32 mtx_increment,
+    VectorValueType *__restrict__ res, uint32 res_increment)
 {
     GKO_ASSERT(problem_size <= max_problem_size);
-    auto mtx_elem = zero<ValueType>();
-    auto out = zero<ValueType>();
+    auto mtx_elem = zero<VectorValueType>();
+    auto out = zero<VectorValueType>();
 #pragma unroll
     for (int32 i = 0; i < max_problem_size; ++i) {
         if (i >= problem_size) {
             break;
         }
         if (group.thread_rank() < problem_size) {
-            mtx_elem = mtx_row[i * mtx_increment];
+            mtx_elem = static_cast<VectorValueType>(mtx_row[i * mtx_increment]);
         }
         out += mtx_elem * group.shfl(vec, i);
     }

--- a/cuda/components/warp_blas.cuh
+++ b/cuda/components/warp_blas.cuh
@@ -72,10 +72,9 @@ enum postprocess_transformation { and_return, and_transpose };
 template <
     int max_problem_size, typename Group, typename ValueType,
     typename = xstd::enable_if_t<group::is_communicator_group<Group>::value>>
-__device__ __forceinline__ void apply_gauss_jordan_transform(const Group &group,
-                                                             int32 key_row,
-                                                             int32 key_col,
-                                                             ValueType *row)
+__device__ __forceinline__ void apply_gauss_jordan_transform(
+    const Group &__restrict__ group, int32 key_row, int32 key_col,
+    ValueType *__restrict__ row)
 {
     auto key_col_elem = group.shfl(row[key_col], key_row);
     if (key_col_elem == zero<ValueType>()) {
@@ -133,7 +132,7 @@ __device__ __forceinline__ void apply_gauss_jordan_transform(const Group &group,
 template <
     int max_problem_size, typename Group, typename ValueType,
     typename = xstd::enable_if_t<group::is_communicator_group<Group>::value>>
-__device__ __forceinline__ void invert_block(const Group &group,
+__device__ __forceinline__ void invert_block(const Group &__restrict__ group,
                                              uint32 problem_size,
                                              ValueType *__restrict__ row,
                                              uint32 &__restrict__ perm,
@@ -220,7 +219,7 @@ template <
     typename Group, typename SourceValueType, typename ResultValueType,
     typename = xstd::enable_if_t<group::is_communicator_group<Group>::value>>
 __device__ __forceinline__ void copy_matrix(
-    const Group &group, uint32 problem_size,
+    const Group &__restrict__ group, uint32 problem_size,
     const SourceValueType *__restrict__ source_row, uint32 increment,
     uint32 row_perm, uint32 col_perm, ResultValueType *__restrict__ destination,
     size_type stride)
@@ -270,7 +269,7 @@ template <
     typename VectorValueType,
     typename = xstd::enable_if_t<group::is_communicator_group<Group>::value>>
 __device__ __forceinline__ void multiply_transposed_vec(
-    const Group &group, uint32 problem_size,
+    const Group &__restrict__ group, uint32 problem_size,
     const VectorValueType &__restrict__ vec,
     const MatrixValueType *__restrict__ mtx_row, uint32 mtx_increment,
     VectorValueType *__restrict__ res, uint32 res_increment)
@@ -325,7 +324,7 @@ template <
     typename VectorValueType,
     typename = xstd::enable_if_t<group::is_communicator_group<Group>::value>>
 __device__ __forceinline__ void multiply_vec(
-    const Group &group, uint32 problem_size,
+    const Group &__restrict__ group, uint32 problem_size,
     const VectorValueType &__restrict__ vec,
     const MatrixValueType *__restrict__ mtx_row, uint32 mtx_increment,
     VectorValueType *__restrict__ res, uint32 res_increment)

--- a/cuda/preconditioner/jacobi_kernels.cu
+++ b/cuda/preconditioner/jacobi_kernels.cu
@@ -107,7 +107,7 @@ __launch_bounds__(warps_per_block *cuda_config::warp_size) adaptive_generate(
     const IndexType *__restrict__ col_idxs,
     const ValueType *__restrict__ values, ValueType *__restrict__ block_data,
     preconditioner::block_interleaved_storage_scheme<IndexType> storage_scheme,
-    precision_reduction *block_precisions,
+    precision_reduction *__restrict__ block_precisions,
     const IndexType *__restrict__ block_ptrs, size_type num_blocks)
 {
     // extract blocks
@@ -206,7 +206,7 @@ __global__ void __launch_bounds__(warps_per_block *cuda_config::warp_size)
     adaptive_apply(const ValueType *__restrict__ blocks,
                    preconditioner::block_interleaved_storage_scheme<IndexType>
                        storage_scheme,
-                   const precision_reduction *block_precisions,
+                   const precision_reduction *__restrict__ block_precisions,
                    const IndexType *__restrict__ block_ptrs,
                    size_type num_blocks, const ValueType *__restrict__ b,
                    int32 b_stride, ValueType *__restrict__ x, int32 x_stride)

--- a/reference/test/preconditioner/jacobi.cpp
+++ b/reference/test/preconditioner/jacobi.cpp
@@ -40,6 +40,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <gtest/gtest.h>
 
 
+#include <core/base/extended_float.hpp>
 #include <core/matrix/csr.hpp>
 #include <core/matrix/dense.hpp>
 #include <core/preconditioner/jacobi_utils.hpp>

--- a/reference/test/preconditioner/jacobi.cpp
+++ b/reference/test/preconditioner/jacobi.cpp
@@ -110,7 +110,8 @@ protected:
     {
         for (int i = 0; i < block_size; ++i) {
             for (int j = 0; j < block_size; ++j) {
-                EXPECT_EQ(ptr_a[i * stride_a + j], ptr_b[i * stride_b + j])
+                EXPECT_EQ(static_cast<double>(ptr_a[i * stride_a + j]),
+                          static_cast<double>(ptr_b[i * stride_b + j]))
                     << "Mismatch at position (" << i << ", " << j << ")";
             }
         }
@@ -146,9 +147,13 @@ protected:
                 Bj::value_type, prec_a,
                 assert_same_block(
                     b_ptr_a[i + 1] - b_ptr_a[i],
-                    a->get_blocks() + scheme.get_global_block_offset(i),
+                    reinterpret_cast<const resolved_precision *>(
+                        a->get_blocks() + scheme.get_group_offset(i)) +
+                        scheme.get_block_offset(i),
                     scheme.get_stride(),
-                    b->get_blocks() + scheme.get_global_block_offset(i),
+                    reinterpret_cast<const resolved_precision *>(
+                        a->get_blocks() + scheme.get_group_offset(i)) +
+                        scheme.get_block_offset(i),
                     scheme.get_stride()));
         }
     }

--- a/reference/test/preconditioner/jacobi.cpp
+++ b/reference/test/preconditioner/jacobi.cpp
@@ -85,7 +85,8 @@ protected:
                          .with_block_pointers(block_pointers)
                          .on(exec);
         adaptive_bj_factory = Bj::build()
-                                  .with_max_block_size(3u)
+                                  .with_max_block_size(17u)
+                                  // make sure group size is 1
                                   .with_block_pointers(block_pointers)
                                   .with_storage_optimization(block_precisions)
                                   .on(exec);

--- a/reference/test/preconditioner/jacobi_kernels.cpp
+++ b/reference/test/preconditioner/jacobi_kernels.cpp
@@ -412,6 +412,24 @@ TEST_F(Jacobi, AppliesToVectorWithAdaptivePrecision)
 }
 
 
+TEST_F(Jacobi, AppliesToVectorWithAdaptivePrecisionAndSmallBlocks)
+{
+    auto x = gko::initialize<Vec>({1.0, -1.0, 2.0, -2.0, 3.0}, exec);
+    auto b = gko::initialize<Vec>({4.0, -1.0, -2.0, 4.0, -1.0}, exec);
+    auto bj = Bj::build()
+                  .with_max_block_size(3u)
+                  // group size will be > 1
+                  .with_block_pointers(block_pointers)
+                  .with_storage_optimization(block_precisions)
+                  .on(exec)
+                  ->generate(mtx);
+
+    bj->apply(b.get(), x.get());
+
+    ASSERT_MTX_NEAR(x, l({1.0, 0.0, 0.0, 1.0, 0.0}), 1e-7);
+}
+
+
 TEST_F(Jacobi, AppliesToMultipleVectors)
 {
     auto x = gko::initialize<Vec>(
@@ -439,6 +457,30 @@ TEST_F(Jacobi, AppliesToMultipleVectorsWithAdaptivePrecision)
         3, {{4.0, -2.0}, {-1.0, 4.0}, {-2.0, 0.0}, {4.0, -2.0}, {-1.0, 4.0}},
         exec);
     auto bj = adaptive_bj_factory->generate(mtx);
+
+    bj->apply(b.get(), x.get());
+
+    ASSERT_MTX_NEAR(
+        x, l({{1.0, 0.0}, {0.0, 1.0}, {0.0, 0.0}, {1.0, 0.0}, {0.0, 1.0}}),
+        1e-7);
+}
+
+
+TEST_F(Jacobi, AppliesToMultipleVectorsWithAdaptivePrecisionAndSmallBlocks)
+{
+    auto x = gko::initialize<Vec>(
+        3, {{1.0, 0.5}, {-1.0, -0.5}, {2.0, 1.0}, {-2.0, -1.0}, {3.0, 1.5}},
+        exec);
+    auto b = gko::initialize<Vec>(
+        3, {{4.0, -2.0}, {-1.0, 4.0}, {-2.0, 0.0}, {4.0, -2.0}, {-1.0, 4.0}},
+        exec);
+    auto bj = Bj::build()
+                  .with_max_block_size(3u)
+                  // group size will be > 1
+                  .with_block_pointers(block_pointers)
+                  .with_storage_optimization(block_precisions)
+                  .on(exec)
+                  ->generate(mtx);
 
     bj->apply(b.get(), x.get());
 


### PR DESCRIPTION
This PR adds implementations of CUDA kernels for adaptive block-Jacobi and related unit tests.
The reference implementation of adaptive block-Jacobi is also fixed to store the preconditioner data in correct format: all blocks belonging to the same block group are stored using the same precision and there are no "gaps" in memory between blocks of the same group.

Automatic precision detection is still not implemented, both in reference and CUDA kernels (and blocks whose precision is set to adaptive will just use full precision for now).

### TODO:

- [x] merge #167 (If you want to see the new changes inside this PR click [here](https://github.com/ginkgo-project/ginkgo/compare/unified_jacobi_implementation...adaptive_block_jacobi?expand=1))
- [ ] get performance results for low precision block-Jacobi (all blocks set to the same value)