### PR TITLE
Automatic precision detection in adaptive block-Jacobi preconditioning

### DIFF
--- a/core/base/extended_float.hpp
+++ b/core/base/extended_float.hpp
@@ -90,6 +90,7 @@ struct basic_float_traits<float16> {
     static constexpr int sign_bits = 1;
     static constexpr int significand_bits = 10;
     static constexpr int exponent_bits = 5;
+    static constexpr bool rounds_to_nearest = true;
 };
 
 template <>
@@ -98,6 +99,7 @@ struct basic_float_traits<float32> {
     static constexpr int sign_bits = 1;
     static constexpr int significand_bits = 23;
     static constexpr int exponent_bits = 8;
+    static constexpr bool rounds_to_nearest = true;
 };
 
 template <>
@@ -106,6 +108,7 @@ struct basic_float_traits<float64> {
     static constexpr int sign_bits = 1;
     static constexpr int significand_bits = 52;
     static constexpr int exponent_bits = 11;
+    static constexpr bool rounds_to_nearest = true;
 };
 
 template <typename FloatType, size_type NumComponents, size_type ComponentId>
@@ -117,6 +120,7 @@ struct basic_float_traits<truncated<FloatType, NumComponents, ComponentId>> {
     static constexpr int significand_bits =
         ComponentId == 0 ? sizeof(type) * byte_size - exponent_bits - 1
                          : sizeof(type) * byte_size;
+    static constexpr bool rounds_to_nearest = false;
 };
 
 
@@ -147,6 +151,11 @@ struct float_traits {
     static constexpr bits_type sign_mask =
         create_ones<bits_type>(sign_bits + significand_bits + exponent_bits) -
         exponent_mask - significand_mask;
+    static constexpr bool rounds_to_nearest =
+        basic_float_traits<T>::rounds_to_nearest;
+
+    static constexpr auto eps =
+        1.0 / (1ll << (significand_bits + rounds_to_nearest));
 
     static constexpr bool is_inf(bits_type data)
     {

--- a/core/preconditioner/jacobi.cpp
+++ b/core/preconditioner/jacobi.cpp
@@ -191,11 +191,12 @@ void Jacobi<ValueType, IndexType>::generate(const LinOp *system_matrix)
         exec->run(JacobiOperation<ValueType, IndexType>::
                       make_initialize_precisions_operation(precisions, tmp));
         precisions = std::move(tmp);
+        conditioning_.resize_and_reset(num_blocks_);
     }
 
     exec->run(JacobiOperation<ValueType, IndexType>::make_generate_operation(
         csr_mtx.get(), num_blocks_, parameters_.max_block_size, storage_scheme_,
-        precisions, parameters_.block_pointers, blocks_));
+        conditioning_, precisions, parameters_.block_pointers, blocks_));
 }
 
 

--- a/core/preconditioner/jacobi.cpp
+++ b/core/preconditioner/jacobi.cpp
@@ -195,8 +195,9 @@ void Jacobi<ValueType, IndexType>::generate(const LinOp *system_matrix)
     }
 
     exec->run(JacobiOperation<ValueType, IndexType>::make_generate_operation(
-        csr_mtx.get(), num_blocks_, parameters_.max_block_size, storage_scheme_,
-        conditioning_, precisions, parameters_.block_pointers, blocks_));
+        csr_mtx.get(), num_blocks_, parameters_.max_block_size,
+        parameters_.accuracy, storage_scheme_, conditioning_, precisions,
+        parameters_.block_pointers, blocks_));
 }
 
 

--- a/core/preconditioner/jacobi.hpp
+++ b/core/preconditioner/jacobi.hpp
@@ -241,11 +241,11 @@ public:
     /**
      * Returns an array of 1-norm condition numbers of the blocks.
      *
-     * This value is valid only if adaptive precision variant is used, and
-     * implementations of the standard non-adaptive variant are allowed to omit
-     * the calculation of condition numbers.
-     *
      * @return an array of 1-norm condition numbers of the blocks
+     *
+     * @note This value is valid only if adaptive precision variant is used, and
+     *       implementations of the standard non-adaptive variant are allowed to
+     *       omit the calculation of condition numbers.
      */
     const remove_complex<value_type> *get_conditioning() const noexcept
     {

--- a/core/preconditioner/jacobi.hpp
+++ b/core/preconditioner/jacobi.hpp
@@ -239,6 +239,20 @@ public:
     }
 
     /**
+     * Returns an array of 1-norm condition numbers of the blocks.
+     *
+     * This value is valid only if adaptive precision variant is used, and
+     * implementations of the standard non-adaptive variant are allowed to omit
+     * the calculation of condition numbers.
+     *
+     * @return an array of 1-norm condition numbers of the blocks
+     */
+    const remove_complex<value_type> *get_conditioning() const noexcept
+    {
+        return conditioning_.get_const_data();
+    }
+
+    /**
      * Returns the number of elements explicitly stored in the matrix.
      *
      * @return the number of elements explicitly stored in the matrix
@@ -398,7 +412,10 @@ protected:
      * @param exec  the executor this object is assigned to
      */
     explicit Jacobi(std::shared_ptr<const Executor> exec)
-        : EnableLinOp<Jacobi>(exec), blocks_(exec)
+        : EnableLinOp<Jacobi>(exec),
+          num_blocks_{},
+          blocks_(exec),
+          conditioning_(exec)
     {
         parameters_.block_pointers.set_executor(exec);
         parameters_.storage_optimization.block_wise.set_executor(exec);
@@ -420,7 +437,8 @@ protected:
           num_blocks_{parameters_.block_pointers.get_num_elems() - 1},
           blocks_(factory->get_executor(),
                   storage_scheme_.compute_storage_space(
-                      parameters_.block_pointers.get_num_elems() - 1))
+                      parameters_.block_pointers.get_num_elems() - 1)),
+          conditioning_(factory->get_executor())
     {
         if (parameters_.max_block_size >= 32 ||
             parameters_.max_block_size < 1) {
@@ -486,6 +504,7 @@ private:
     block_interleaved_storage_scheme<index_type> storage_scheme_{};
     size_type num_blocks_;
     Array<value_type> blocks_;
+    Array<remove_complex<value_type>> conditioning_;
 };
 
 

--- a/core/preconditioner/jacobi.hpp
+++ b/core/preconditioner/jacobi.hpp
@@ -401,6 +401,34 @@ public:
          */
         storage_optimization_type GKO_FACTORY_PARAMETER(
             storage_optimization, precision_reduction(0, 0));
+
+        /**
+         * The relative accuracy of the adaptive Jacobi variant.
+         *
+         * This parameter is only used if the adaptive version of the algorithm
+         * is selected (see storage_optimization parameter for more details).
+         * The parameter is used when detecting the optimal precisions of blocks
+         * whose precision has been set to precision_reduction::autodetect().
+         *
+         * The parameter represents the number of correct digits in the result
+         * of Jacobi::apply() operation of the adaptive variant, compared to the
+         * non-adaptive variant. In other words, the total preconditioning error
+         * will be:
+         *
+         * ```
+         * || inv(A)x - inv(M)x|| / || inv(A)x || <= c * (dropout + accuracy)
+         * ```
+         *
+         * where `c` is some constant depending on the problem size and roundoff
+         * error and `dropout` the error introduced by disregarding off-diagonal
+         * elements.
+         *
+         * Larger values reduce the volume of memory transfer, but increase
+         * the error compared to using full precision storage. Thus, tuning the
+         * accuracy to a value as close as possible to `dropout` will result in
+         * optimal memory savings, while not degrading the quality of solution.
+         */
+        remove_complex<value_type> GKO_FACTORY_PARAMETER(accuracy, 1e-1);
     };
     GKO_ENABLE_LIN_OP_FACTORY(Jacobi, parameters, Factory);
     GKO_ENABLE_BUILD_METHOD(Factory);

--- a/core/preconditioner/jacobi_kernels.hpp
+++ b/core/preconditioner/jacobi_kernels.hpp
@@ -56,6 +56,7 @@ namespace kernels {
         size_type num_blocks, uint32 max_block_size,                      \
         const preconditioner::block_interleaved_storage_scheme<IndexType> \
             &storage_scheme,                                              \
+        Array<remove_complex<ValueType>> &conditioning,                   \
         Array<precision_reduction> &block_precisions,                     \
         const Array<IndexType> &block_pointers, Array<ValueType> &blocks)
 

--- a/core/preconditioner/jacobi_kernels.hpp
+++ b/core/preconditioner/jacobi_kernels.hpp
@@ -54,6 +54,7 @@ namespace kernels {
         std::shared_ptr<const DefaultExecutor> exec,                      \
         const matrix::Csr<ValueType, IndexType> *system_matrix,           \
         size_type num_blocks, uint32 max_block_size,                      \
+        remove_complex<ValueType> accuracy,                               \
         const preconditioner::block_interleaved_storage_scheme<IndexType> \
             &storage_scheme,                                              \
         Array<remove_complex<ValueType>> &conditioning,                   \

--- a/core/test/base/matrix_data.cpp
+++ b/core/test/base/matrix_data.cpp
@@ -64,6 +64,7 @@ TEST(MatrixData, InitializesWithZeros)
 TEST(MatrixData, InitializesWithValue)
 {
     using nnz = gko::matrix_data<double, int>::nonzero_type;
+
     gko::matrix_data<double, int> m(gko::dim<2>{2, 3}, 8.3);
 
     ASSERT_EQ(m.size, gko::dim<2>(2, 3));
@@ -80,6 +81,7 @@ TEST(MatrixData, InitializesWithValue)
 TEST(MatrixData, InitializesWithRandomValues)
 {
     using nnz = gko::matrix_data<double, int>::nonzero_type;
+
     gko::matrix_data<double, int> m(
         gko::dim<2>{2, 3}, std::uniform_real_distribution<double>(-1, 1),
         std::ranlux48(19));
@@ -95,6 +97,7 @@ TEST(MatrixData, InitializesWithRandomValues)
 TEST(MatrixData, InitializesFromValueList)
 {
     using nnz = gko::matrix_data<double, int>::nonzero_type;
+
     // clang-format off
     gko::matrix_data<double, int> m{
         {2, 3, 5},
@@ -114,6 +117,7 @@ TEST(MatrixData, InitializesFromValueList)
 TEST(MatrixData, InitializesRowVectorFromValueList)
 {
     using nnz = gko::matrix_data<double, int>::nonzero_type;
+
     gko::matrix_data<double, int> m{{2, 3, 5}};
 
     ASSERT_EQ(m.size, gko::dim<2>(1, 3));
@@ -127,6 +131,7 @@ TEST(MatrixData, InitializesRowVectorFromValueList)
 TEST(MatrixData, InitializesColumnVectorFromValueList)
 {
     using nnz = gko::matrix_data<double, int>::nonzero_type;
+
     gko::matrix_data<double, int> m{{2}, {3}, {5}};
 
     ASSERT_EQ(m.size, gko::dim<2>(3, 1));
@@ -140,6 +145,7 @@ TEST(MatrixData, InitializesColumnVectorFromValueList)
 TEST(MatrixData, InitializesFromNonzeroList)
 {
     using nnz = gko::matrix_data<double, int>::nonzero_type;
+
     gko::matrix_data<double, int> m(gko::dim<2>{5, 7},
                                     {{0, 0, 2}, {1, 1, 0}, {2, 3, 5}});
 
@@ -154,6 +160,7 @@ TEST(MatrixData, InitializesFromNonzeroList)
 TEST(MatrixData, InitializesDiagonalMatrix)
 {
     using nnz = gko::matrix_data<double, int>::nonzero_type;
+
     const auto m = gko::matrix_data<double, int>::diag(gko::dim<2>{2, 3}, 5.0);
 
     ASSERT_EQ(m.size, gko::dim<2>(2, 3));
@@ -182,6 +189,7 @@ TEST(MatrixData, InitializesFromRange)
 TEST(MatrixData, InitializesDiagonalMatrixFromValueList)
 {
     using nnz = gko::matrix_data<double, int>::nonzero_type;
+
     const auto m =
         gko::matrix_data<double, int>::diag(gko::dim<2>{2, 3}, {3, 5});
 
@@ -196,6 +204,7 @@ TEST(MatrixData, InitializesBlockDiagonalMatrix)
 {
     using data = gko::matrix_data<double, int>;
     using nnz = data::nonzero_type;
+
     const auto m = data::diag(gko::dim<2>{2, 3}, {{1.0, 2.0}, {3.0, 4.0}});
 
     ASSERT_EQ(m.size, gko::dim<2>(4, 6));
@@ -214,8 +223,9 @@ TEST(MatrixData, InitializesBlockDiagonalMatrix)
 TEST(MatrixData, InitializesCheckeredMatrix)
 {
     using data = gko::matrix_data<double, int>;
-    gko::matrix_data<double, int> m{{1., 2.}, {3., 4.}};
     using nnz = data::nonzero_type;
+    gko::matrix_data<double, int> m{{1., 2.}, {3., 4.}};
+
     gko::matrix_data<double, int> mm{gko::dim<2>{3, 2}, m};
 
     ASSERT_EQ(mm.size, gko::dim<2>(6, 4));
@@ -257,6 +267,23 @@ TEST(MatrixData, InitializesDiagonalWithConditionNumber)
 
     ASSERT_EQ(m.size, gko::dim<2>(3, 3));
     ASSERT_NEAR(m.nonzeros[0].value / m.nonzeros[2].value, 100.0, 1e-16);
+}
+
+
+TEST(MatrixData, InitializesBlockDiagonalMatrixFromBlockList)
+{
+    using data = gko::matrix_data<double, int>;
+    using nnz = data::nonzero_type;
+    auto list = {data{{1.0}}, data{{2.0, 3.0}, {0.0, 4.0}}};
+
+    const auto m = data::diag(begin(list), end(list));
+
+    ASSERT_EQ(m.size, gko::dim<2>(3, 3));
+    ASSERT_EQ(m.nonzeros.size(), 4);
+    EXPECT_EQ(m.nonzeros[0], nnz(0, 0, 1.0));
+    EXPECT_EQ(m.nonzeros[1], nnz(1, 1, 2.0));
+    EXPECT_EQ(m.nonzeros[2], nnz(1, 2, 3.0));
+    EXPECT_EQ(m.nonzeros[3], nnz(2, 2, 4.0));
 }
 
 

--- a/cuda/base/types.hpp
+++ b/cuda/base/types.hpp
@@ -166,7 +166,7 @@ inline xstd::enable_if_t<
     !std::is_pointer<T>::value && !std::is_reference<T>::value, cuda_type<T>>
 as_cuda_type(T val)
 {
-    return static_cast<cuda_type<T>>(val);
+    return *reinterpret_cast<cuda_type<T> *>(&val);
 }
 
 

--- a/cuda/base/types.hpp
+++ b/cuda/base/types.hpp
@@ -150,9 +150,23 @@ using cuda_type = typename detail::cuda_type_impl<T>::type;
  * @return `val` reinterpreted to CUDA type
  */
 template <typename T>
-inline cuda_type<T> as_cuda_type(T val)
+inline xstd::enable_if_t<
+    std::is_pointer<T>::value || std::is_reference<T>::value, cuda_type<T>>
+as_cuda_type(T val)
 {
     return reinterpret_cast<cuda_type<T>>(val);
+}
+
+
+/**
+ * @copydoc as_cuda_type()
+ */
+template <typename T>
+inline xstd::enable_if_t<
+    !std::is_pointer<T>::value && !std::is_reference<T>::value, cuda_type<T>>
+as_cuda_type(T val)
+{
+    return static_cast<cuda_type<T>>(val);
 }
 
 

--- a/cuda/preconditioner/jacobi_kernels.cu
+++ b/cuda/preconditioner/jacobi_kernels.cu
@@ -105,7 +105,8 @@ __global__ void
 __launch_bounds__(warps_per_block *cuda_config::warp_size) adaptive_generate(
     size_type num_rows, const IndexType *__restrict__ row_ptrs,
     const IndexType *__restrict__ col_idxs,
-    const ValueType *__restrict__ values, ValueType *__restrict__ block_data,
+    const ValueType *__restrict__ values, remove_complex<ValueType> accuracy,
+    ValueType *__restrict__ block_data,
     preconditioner::block_interleaved_storage_scheme<IndexType> storage_scheme,
     remove_complex<ValueType> *__restrict__ conditioning,
     precision_reduction *__restrict__ block_precisions,
@@ -141,12 +142,16 @@ __launch_bounds__(warps_per_block *cuda_config::warp_size) adaptive_generate(
         prec = block_precisions[block_id];
         conditioning[block_id] = block_cond;
         if (prec == precision_reduction::autodetect()) {
-            // TODO: correctly compute the best precision
-            prec = precision_reduction();
+            using preconditioner::detail::get_optimal_storage_reduction;
+            // TODO: provide verificators to allow for reduced precision
+            auto truncate_only = [] { return false; };
+            prec = get_optimal_storage_reduction<ValueType>(
+                accuracy, block_cond, truncate_only, truncate_only);
         }
     }
 
     // make sure all blocks in the group have the same precision
+    // TODO: relax this requirement to only the same number of bits
     const auto warp = group::tiled_partition<cuda_config::warp_size>(block);
     // can only shuffle 4 byte multiples
     struct alignas(uint32) wrapper {
@@ -266,7 +271,7 @@ template <int warps_per_block, int max_block_size, typename ValueType,
           typename IndexType>
 void generate(syn::compile_int_list<max_block_size>,
               const matrix::Csr<ValueType, IndexType> *mtx,
-              ValueType *block_data,
+              remove_complex<ValueType> accuracy, ValueType *block_data,
               const preconditioner::block_interleaved_storage_scheme<IndexType>
                   &storage_scheme,
               remove_complex<ValueType> *conditioning,
@@ -284,9 +289,10 @@ void generate(syn::compile_int_list<max_block_size>,
             <<<grid_size, block_size, 0, 0>>>(
                 mtx->get_size()[0], mtx->get_const_row_ptrs(),
                 mtx->get_const_col_idxs(),
-                as_cuda_type(mtx->get_const_values()), as_cuda_type(block_data),
-                storage_scheme, as_cuda_type(conditioning), block_precisions,
-                block_ptrs, num_blocks);
+                as_cuda_type(mtx->get_const_values()), as_cuda_type(accuracy),
+                as_cuda_type(block_data), storage_scheme,
+                as_cuda_type(conditioning), block_precisions, block_ptrs,
+                num_blocks);
     } else {
         kernel::generate<max_block_size, subwarp_size, warps_per_block>
             <<<grid_size, block_size, 0, 0>>>(
@@ -528,6 +534,7 @@ template <typename ValueType, typename IndexType>
 void generate(std::shared_ptr<const CudaExecutor> exec,
               const matrix::Csr<ValueType, IndexType> *system_matrix,
               size_type num_blocks, uint32 max_block_size,
+              remove_complex<ValueType> accuracy,
               const preconditioner::block_interleaved_storage_scheme<IndexType>
                   &storage_scheme,
               Array<remove_complex<ValueType>> &conditioning,
@@ -539,7 +546,7 @@ void generate(std::shared_ptr<const CudaExecutor> exec,
                         return max_block_size <= compiled_block_size;
                     },
                     syn::compile_int_list<cuda_config::min_warps_per_block>(),
-                    syn::compile_type_list<>(), system_matrix,
+                    syn::compile_type_list<>(), system_matrix, accuracy,
                     blocks.get_data(), storage_scheme, conditioning.get_data(),
                     block_precisions.get_data(),
                     block_pointers.get_const_data(), num_blocks);

--- a/cuda/test/preconditioner/jacobi_kernels.cpp
+++ b/cuda/test/preconditioner/jacobi_kernels.cpp
@@ -397,6 +397,21 @@ TEST_F(Jacobi, CudaLinearCombinationApplyToMultipleVectorsEquivalentToRef)
 }
 
 
+TEST_F(Jacobi, ComputesTheSameConditionNumberAsRef)
+{
+    initialize_data({0, 11, 24, 33, 45, 55, 67, 70, 80, 92, 100},
+                    {dp, dp, dp, dp, dp, dp, dp, dp, dp, dp}, 13, 97, 99);
+
+    auto bj = bj_factory->generate(mtx);
+    auto d_bj = clone(ref, d_bj_factory->generate(mtx));
+
+    for (int i = 0; i < gko::as<Bj>(bj.get())->get_num_blocks(); ++i) {
+        EXPECT_NEAR(bj->get_conditioning()[i], d_bj->get_conditioning()[i],
+                    1e-11);
+    }
+}
+
+
 TEST_F(Jacobi, CudaPreconditionerEquivalentToRefWithFullPrecision)
 {
     initialize_data({0, 11, 24, 33, 45, 55, 67, 70, 80, 92, 100},

--- a/cuda/test/preconditioner/jacobi_kernels.cpp
+++ b/cuda/test/preconditioner/jacobi_kernels.cpp
@@ -53,6 +53,7 @@ protected:
     using Bj = gko::preconditioner::Jacobi<>;
     using Mtx = gko::matrix::Csr<>;
     using Vec = gko::matrix::Dense<>;
+    using mtx_data = gko::matrix_data<>;
 
     void SetUp()
     {
@@ -71,13 +72,28 @@ protected:
     void initialize_data(
         std::initializer_list<gko::int32> block_pointers,
         std::initializer_list<gko::precision_reduction> block_precisions,
-        gko::uint32 max_block_size, int min_nnz, int max_nnz, int num_rhs = 1)
+        std::initializer_list<double> condition_numbers,
+        gko::uint32 max_block_size, int min_nnz, int max_nnz, int num_rhs = 1,
+        double accuracy = 0.1)
     {
         std::ranlux48 engine(42);
         const auto dim = *(end(block_pointers) - 1);
-        mtx = gko::test::generate_random_matrix<Mtx>(
-            dim, dim, std::uniform_int_distribution<>(min_nnz, max_nnz),
-            std::normal_distribution<>(0.0, 1.0), engine, ref);
+        if (condition_numbers.size() == 0) {
+            mtx = gko::test::generate_random_matrix<Mtx>(
+                dim, dim, std::uniform_int_distribution<>(min_nnz, max_nnz),
+                std::normal_distribution<>(0.0, 1.0), engine, ref);
+        } else {
+            std::vector<mtx_data> blocks;
+            for (gko::size_type i = 0; i < block_pointers.size() - 1; ++i) {
+                const auto size =
+                    begin(block_pointers)[i + 1] - begin(block_pointers)[i];
+                const auto cond = begin(condition_numbers)[i];
+                blocks.push_back(mtx_data::cond(
+                    size, cond, std::normal_distribution<>(-1, 1), engine));
+            }
+            mtx = Mtx::create(ref);
+            mtx->read(mtx_data::diag(begin(blocks), end(blocks)));
+        }
         gko::Array<gko::int32> block_ptrs(ref, block_pointers);
         gko::Array<gko::precision_reduction> block_prec(ref, block_precisions);
         if (block_prec.get_num_elems() == 0) {
@@ -94,11 +110,13 @@ protected:
                              .with_max_block_size(max_block_size)
                              .with_block_pointers(block_ptrs)
                              .with_storage_optimization(block_prec)
+                             .with_accuracy(accuracy)
                              .on(ref);
             d_bj_factory = Bj::build()
                                .with_max_block_size(max_block_size)
                                .with_block_pointers(block_ptrs)
                                .with_storage_optimization(block_prec)
+                               .with_accuracy(accuracy)
                                .on(cuda);
         }
         b = gko::test::generate_random_matrix<Vec>(
@@ -273,7 +291,7 @@ TEST_F(Jacobi,
 
 TEST_F(Jacobi, CudaPreconditionerEquivalentToRefWithBlockSize32)
 {
-    initialize_data({0, 32, 64, 96, 128}, {}, 32, 100, 110);
+    initialize_data({0, 32, 64, 96, 128}, {}, {}, 32, 100, 110);
 
     auto bj = bj_factory->generate(mtx);
     auto d_bj = d_bj_factory->generate(mtx);
@@ -284,8 +302,8 @@ TEST_F(Jacobi, CudaPreconditionerEquivalentToRefWithBlockSize32)
 
 TEST_F(Jacobi, CudaPreconditionerEquivalentToRefWithDifferentBlockSize)
 {
-    initialize_data({0, 11, 24, 33, 45, 55, 67, 70, 80, 92, 100}, {}, 32, 97,
-                    99);
+    initialize_data({0, 11, 24, 33, 45, 55, 67, 70, 80, 92, 100}, {}, {}, 32,
+                    97, 99);
 
     auto bj = bj_factory->generate(mtx);
     auto d_bj = d_bj_factory->generate(mtx);
@@ -296,8 +314,8 @@ TEST_F(Jacobi, CudaPreconditionerEquivalentToRefWithDifferentBlockSize)
 
 TEST_F(Jacobi, CudaPreconditionerEquivalentToRefWithMPW)
 {
-    initialize_data({0, 11, 24, 33, 45, 55, 67, 70, 80, 92, 100}, {}, 13, 97,
-                    99);
+    initialize_data({0, 11, 24, 33, 45, 55, 67, 70, 80, 92, 100}, {}, {}, 13,
+                    97, 99);
 
     auto bj = bj_factory->generate(mtx);
     auto d_bj = d_bj_factory->generate(mtx);
@@ -308,7 +326,7 @@ TEST_F(Jacobi, CudaPreconditionerEquivalentToRefWithMPW)
 
 TEST_F(Jacobi, CudaApplyEquivalentToRefWithBlockSize32)
 {
-    initialize_data({0, 32, 64, 96, 128}, {}, 32, 100, 111);
+    initialize_data({0, 32, 64, 96, 128}, {}, {}, 32, 100, 111);
     auto bj = bj_factory->generate(mtx);
     auto d_bj = d_bj_factory->generate(mtx);
 
@@ -321,8 +339,8 @@ TEST_F(Jacobi, CudaApplyEquivalentToRefWithBlockSize32)
 
 TEST_F(Jacobi, CudaApplyEquivalentToRefWithDifferentBlockSize)
 {
-    initialize_data({0, 11, 24, 33, 45, 55, 67, 70, 80, 92, 100}, {}, 32, 97,
-                    99);
+    initialize_data({0, 11, 24, 33, 45, 55, 67, 70, 80, 92, 100}, {}, {}, 32,
+                    97, 99);
     auto bj = bj_factory->generate(mtx);
     auto d_bj = d_bj_factory->generate(mtx);
 
@@ -335,8 +353,8 @@ TEST_F(Jacobi, CudaApplyEquivalentToRefWithDifferentBlockSize)
 
 TEST_F(Jacobi, CudaApplyEquivalentToRef)
 {
-    initialize_data({0, 11, 24, 33, 45, 55, 67, 70, 80, 92, 100}, {}, 13, 97,
-                    99);
+    initialize_data({0, 11, 24, 33, 45, 55, 67, 70, 80, 92, 100}, {}, {}, 13,
+                    97, 99);
     auto bj = bj_factory->generate(mtx);
     auto d_bj = d_bj_factory->generate(mtx);
 
@@ -349,8 +367,8 @@ TEST_F(Jacobi, CudaApplyEquivalentToRef)
 
 TEST_F(Jacobi, CudaLinearCombinationApplyEquivalentToRef)
 {
-    initialize_data({0, 11, 24, 33, 45, 55, 67, 70, 80, 92, 100}, {}, 13, 97,
-                    99);
+    initialize_data({0, 11, 24, 33, 45, 55, 67, 70, 80, 92, 100}, {}, {}, 13,
+                    97, 99);
     auto alpha = gko::initialize<Vec>({2.0}, ref);
     auto d_alpha = gko::initialize<Vec>({2.0}, cuda);
     auto beta = gko::initialize<Vec>({-1.0}, ref);
@@ -367,8 +385,8 @@ TEST_F(Jacobi, CudaLinearCombinationApplyEquivalentToRef)
 
 TEST_F(Jacobi, CudaApplyToMultipleVectorsEquivalentToRef)
 {
-    initialize_data({0, 11, 24, 33, 45, 55, 67, 70, 80, 92, 100}, {}, 13, 97,
-                    99, 5);
+    initialize_data({0, 11, 24, 33, 45, 55, 67, 70, 80, 92, 100}, {}, {}, 13,
+                    97, 99, 5);
     auto bj = bj_factory->generate(mtx);
     auto d_bj = d_bj_factory->generate(mtx);
 
@@ -381,8 +399,8 @@ TEST_F(Jacobi, CudaApplyToMultipleVectorsEquivalentToRef)
 
 TEST_F(Jacobi, CudaLinearCombinationApplyToMultipleVectorsEquivalentToRef)
 {
-    initialize_data({0, 11, 24, 33, 45, 55, 67, 70, 80, 92, 100}, {}, 13, 97,
-                    99, 5);
+    initialize_data({0, 11, 24, 33, 45, 55, 67, 70, 80, 92, 100}, {}, {}, 13,
+                    97, 99, 5);
     auto alpha = gko::initialize<Vec>({2.0}, ref);
     auto d_alpha = gko::initialize<Vec>({2.0}, cuda);
     auto beta = gko::initialize<Vec>({-1.0}, ref);
@@ -400,7 +418,7 @@ TEST_F(Jacobi, CudaLinearCombinationApplyToMultipleVectorsEquivalentToRef)
 TEST_F(Jacobi, ComputesTheSameConditionNumberAsRef)
 {
     initialize_data({0, 11, 24, 33, 45, 55, 67, 70, 80, 92, 100},
-                    {dp, dp, dp, dp, dp, dp, dp, dp, dp, dp}, 13, 97, 99);
+                    {dp, dp, dp, dp, dp, dp, dp, dp, dp, dp}, {}, 13, 97, 99);
 
     auto bj = bj_factory->generate(mtx);
     auto d_bj = clone(ref, d_bj_factory->generate(mtx));
@@ -412,10 +430,31 @@ TEST_F(Jacobi, ComputesTheSameConditionNumberAsRef)
 }
 
 
+TEST_F(Jacobi, SelectsTheSamePrecisionsAsRef)
+{
+    initialize_data(
+        {0, 2, 14, 27, 40, 51, 61, 70, 80, 92, 100},
+        {ap, ap, ap, ap, ap, ap, ap, ap, ap, ap},
+        {1e+0, 1e+0, 1e+2, 1e+3, 1e+4, 1e+4, 1e+6, 1e+7, 1e+8, 1e+9}, 13, 97,
+        99, 1, 0.2);
+
+    auto bj = bj_factory->generate(mtx);
+    auto d_bj = gko::clone(ref, d_bj_factory->generate(mtx));
+
+    auto bj_prec =
+        bj->get_parameters().storage_optimization.block_wise.get_const_data();
+    auto d_bj_prec =
+        d_bj->get_parameters().storage_optimization.block_wise.get_const_data();
+    for (int i = 0; i < gko::as<Bj>(bj.get())->get_num_blocks(); ++i) {
+        EXPECT_EQ(bj_prec[i], d_bj_prec[i]);
+    }
+}
+
+
 TEST_F(Jacobi, CudaPreconditionerEquivalentToRefWithFullPrecision)
 {
     initialize_data({0, 11, 24, 33, 45, 55, 67, 70, 80, 92, 100},
-                    {dp, dp, dp, dp, dp, dp, dp, dp, dp, dp}, 13, 97, 99);
+                    {dp, dp, dp, dp, dp, dp, dp, dp, dp, dp}, {}, 13, 97, 99);
 
     auto bj = bj_factory->generate(mtx);
     auto d_bj = d_bj_factory->generate(mtx);
@@ -427,7 +466,8 @@ TEST_F(Jacobi, CudaPreconditionerEquivalentToRefWithFullPrecision)
 TEST_F(Jacobi, CudaPreconditionerEquivalentToRefWithReducedPrecision)
 {
     initialize_data({0, 11, 24, 33, 45, 55, 67, 70, 80, 92, 100},
-                    {sp, sp, sp, sp, sp, sp, sp, sp, sp, sp, sp}, 13, 97, 99);
+                    {sp, sp, sp, sp, sp, sp, sp, sp, sp, sp, sp}, {}, 13, 97,
+                    99);
 
     auto bj = bj_factory->generate(mtx);
     auto d_bj = d_bj_factory->generate(mtx);
@@ -439,7 +479,8 @@ TEST_F(Jacobi, CudaPreconditionerEquivalentToRefWithReducedPrecision)
 TEST_F(Jacobi, CudaPreconditionerEquivalentToRefWithCustomReducedPrecision)
 {
     initialize_data({0, 11, 24, 33, 45, 55, 67, 70, 80, 92, 100},
-                    {tp, tp, tp, tp, tp, tp, tp, tp, tp, tp, tp}, 13, 97, 99);
+                    {tp, tp, tp, tp, tp, tp, tp, tp, tp, tp, tp}, {}, 13, 97,
+                    99);
 
     auto bj = bj_factory->generate(mtx);
     auto d_bj = d_bj_factory->generate(mtx);
@@ -451,7 +492,8 @@ TEST_F(Jacobi, CudaPreconditionerEquivalentToRefWithCustomReducedPrecision)
 TEST_F(Jacobi, CudaPreconditionerEquivalentToRefWithQuarteredPrecision)
 {
     initialize_data({0, 11, 24, 33, 45, 55, 67, 70, 80, 92, 100},
-                    {hp, hp, hp, hp, hp, hp, hp, hp, hp, hp, hp}, 13, 97, 99);
+                    {hp, hp, hp, hp, hp, hp, hp, hp, hp, hp, hp}, {}, 13, 97,
+                    99);
 
     auto bj = bj_factory->generate(mtx);
     auto d_bj = d_bj_factory->generate(mtx);
@@ -463,7 +505,8 @@ TEST_F(Jacobi, CudaPreconditionerEquivalentToRefWithQuarteredPrecision)
 TEST_F(Jacobi, CudaPreconditionerEquivalentToRefWithCustomQuarteredPrecision)
 {
     initialize_data({0, 11, 24, 33, 45, 55, 67, 70, 80, 92, 100},
-                    {qp, qp, qp, qp, qp, qp, qp, qp, qp, qp, qp}, 13, 97, 99);
+                    {qp, qp, qp, qp, qp, qp, qp, qp, qp, qp, qp}, {}, 13, 97,
+                    99);
 
     auto bj = bj_factory->generate(mtx);
     auto d_bj = d_bj_factory->generate(mtx);
@@ -475,7 +518,8 @@ TEST_F(Jacobi, CudaPreconditionerEquivalentToRefWithCustomQuarteredPrecision)
 TEST_F(Jacobi, CudaPreconditionerEquivalentToRefWithAdaptivePrecision)
 {
     initialize_data({0, 11, 24, 33, 45, 55, 67, 70, 80, 92, 100},
-                    {sp, sp, dp, dp, tp, tp, qp, qp, hp, dp, up}, 13, 97, 99);
+                    {sp, sp, dp, dp, tp, tp, qp, qp, hp, dp, up}, {}, 13, 97,
+                    99);
 
     auto bj = bj_factory->generate(mtx);
     auto d_bj = d_bj_factory->generate(mtx);
@@ -487,7 +531,8 @@ TEST_F(Jacobi, CudaPreconditionerEquivalentToRefWithAdaptivePrecision)
 TEST_F(Jacobi, CudaApplyEquivalentToRefWithFullPrecision)
 {
     initialize_data({0, 11, 24, 33, 45, 55, 67, 70, 80, 92, 100},
-                    {dp, dp, dp, dp, dp, dp, dp, dp, dp, dp, dp}, 13, 97, 99);
+                    {dp, dp, dp, dp, dp, dp, dp, dp, dp, dp, dp}, {}, 13, 97,
+                    99);
     auto bj = bj_factory->generate(mtx);
     auto d_bj = d_bj_factory->generate(mtx);
 
@@ -501,7 +546,8 @@ TEST_F(Jacobi, CudaApplyEquivalentToRefWithFullPrecision)
 TEST_F(Jacobi, CudaApplyEquivalentToRefWithReducedPrecision)
 {
     initialize_data({0, 11, 24, 33, 45, 55, 67, 70, 80, 92, 100},
-                    {sp, sp, sp, sp, sp, sp, sp, sp, sp, sp, sp}, 13, 97, 99);
+                    {sp, sp, sp, sp, sp, sp, sp, sp, sp, sp, sp}, {}, 13, 97,
+                    99);
     auto bj = bj_factory->generate(mtx);
     auto d_bj = d_bj_factory->generate(mtx);
 
@@ -515,7 +561,8 @@ TEST_F(Jacobi, CudaApplyEquivalentToRefWithReducedPrecision)
 TEST_F(Jacobi, CudaApplyEquivalentToRefWithCustomReducedPrecision)
 {
     initialize_data({0, 11, 24, 33, 45, 55, 67, 70, 80, 92, 100},
-                    {tp, tp, tp, tp, tp, tp, tp, tp, tp, tp, tp}, 13, 97, 99);
+                    {tp, tp, tp, tp, tp, tp, tp, tp, tp, tp, tp}, {}, 13, 97,
+                    99);
     auto bj = bj_factory->generate(mtx);
     auto d_bj = d_bj_factory->generate(mtx);
 
@@ -529,7 +576,8 @@ TEST_F(Jacobi, CudaApplyEquivalentToRefWithCustomReducedPrecision)
 TEST_F(Jacobi, CudaApplyEquivalentToRefWithQuarteredPrecision)
 {
     initialize_data({0, 11, 24, 33, 45, 55, 67, 70, 80, 92, 100},
-                    {hp, hp, hp, hp, hp, hp, hp, hp, hp, hp, hp}, 13, 97, 99);
+                    {hp, hp, hp, hp, hp, hp, hp, hp, hp, hp, hp}, {}, 13, 97,
+                    99);
     auto bj = bj_factory->generate(mtx);
     auto d_bj = d_bj_factory->generate(mtx);
 
@@ -543,7 +591,8 @@ TEST_F(Jacobi, CudaApplyEquivalentToRefWithQuarteredPrecision)
 TEST_F(Jacobi, CudaApplyEquivalentToRefWithCustomReducedAndReducedPrecision)
 {
     initialize_data({0, 11, 24, 33, 45, 55, 67, 70, 80, 92, 100},
-                    {up, up, up, up, up, up, up, up, up, up, up}, 13, 97, 99);
+                    {up, up, up, up, up, up, up, up, up, up, up}, {}, 13, 97,
+                    99);
     auto bj = bj_factory->generate(mtx);
     auto d_bj = d_bj_factory->generate(mtx);
 
@@ -557,7 +606,8 @@ TEST_F(Jacobi, CudaApplyEquivalentToRefWithCustomReducedAndReducedPrecision)
 TEST_F(Jacobi, CudaApplyEquivalentToRefWithCustomQuarteredPrecision)
 {
     initialize_data({0, 11, 24, 33, 45, 55, 67, 70, 80, 92, 100},
-                    {qp, qp, qp, qp, qp, qp, qp, qp, qp, qp, qp}, 13, 97, 99);
+                    {qp, qp, qp, qp, qp, qp, qp, qp, qp, qp, qp}, {}, 13, 97,
+                    99);
     auto bj = bj_factory->generate(mtx);
     auto d_bj = d_bj_factory->generate(mtx);
 
@@ -571,7 +621,8 @@ TEST_F(Jacobi, CudaApplyEquivalentToRefWithCustomQuarteredPrecision)
 TEST_F(Jacobi, CudaApplyEquivalentToRefWithAdaptivePrecision)
 {
     initialize_data({0, 11, 24, 33, 45, 55, 67, 70, 80, 92, 100},
-                    {sp, sp, dp, dp, tp, tp, qp, qp, hp, dp, up}, 13, 97, 99);
+                    {sp, sp, dp, dp, tp, tp, qp, qp, hp, dp, up}, {}, 13, 97,
+                    99);
     auto bj = bj_factory->generate(mtx);
     auto d_bj = d_bj_factory->generate(mtx);
 
@@ -585,7 +636,8 @@ TEST_F(Jacobi, CudaApplyEquivalentToRefWithAdaptivePrecision)
 TEST_F(Jacobi, CudaLinearCombinationApplyEquivalentToRefWithAdaptivePrecision)
 {
     initialize_data({0, 11, 24, 33, 45, 55, 67, 70, 80, 92, 100},
-                    {sp, dp, dp, sp, sp, sp, dp, dp, sp, dp, sp}, 13, 97, 99);
+                    {sp, dp, dp, sp, sp, sp, dp, dp, sp, dp, sp}, {}, 13, 97,
+                    99);
     auto alpha = gko::initialize<Vec>({2.0}, ref);
     auto d_alpha = gko::initialize<Vec>({2.0}, cuda);
     auto beta = gko::initialize<Vec>({-1.0}, ref);
@@ -603,8 +655,8 @@ TEST_F(Jacobi, CudaLinearCombinationApplyEquivalentToRefWithAdaptivePrecision)
 TEST_F(Jacobi, CudaApplyToMultipleVectorsEquivalentToRefWithFullPrecision)
 {
     initialize_data({0, 11, 24, 33, 45, 55, 67, 70, 80, 92, 100},
-                    {dp, dp, dp, dp, dp, dp, dp, dp, dp, dp, dp}, 13, 97, 99,
-                    5);
+                    {dp, dp, dp, dp, dp, dp, dp, dp, dp, dp, dp}, {}, 13, 97,
+                    99, 5);
     auto bj = bj_factory->generate(mtx);
     auto d_bj = d_bj_factory->generate(mtx);
 
@@ -618,8 +670,8 @@ TEST_F(Jacobi, CudaApplyToMultipleVectorsEquivalentToRefWithFullPrecision)
 TEST_F(Jacobi, CudaApplyToMultipleVectorsEquivalentToRefWithReducedPrecision)
 {
     initialize_data({0, 11, 24, 33, 45, 55, 67, 70, 80, 92, 100},
-                    {sp, sp, sp, sp, sp, sp, sp, sp, sp, sp, sp}, 13, 97, 99,
-                    5);
+                    {sp, sp, sp, sp, sp, sp, sp, sp, sp, sp, sp}, {}, 13, 97,
+                    99, 5);
     auto bj = bj_factory->generate(mtx);
     auto d_bj = d_bj_factory->generate(mtx);
 
@@ -633,8 +685,8 @@ TEST_F(Jacobi, CudaApplyToMultipleVectorsEquivalentToRefWithReducedPrecision)
 TEST_F(Jacobi, CudaApplyToMultipleVectorsEquivalentToRefWithAdaptivePrecision)
 {
     initialize_data({0, 11, 24, 33, 45, 55, 67, 70, 80, 92, 100},
-                    {sp, sp, dp, dp, tp, tp, qp, qp, hp, dp, up}, 13, 97, 99,
-                    5);
+                    {sp, sp, dp, dp, tp, tp, qp, qp, hp, dp, up}, {}, 13, 97,
+                    99, 5);
     auto bj = bj_factory->generate(mtx);
     auto d_bj = d_bj_factory->generate(mtx);
 
@@ -650,8 +702,8 @@ TEST_F(
     CudaLinearCombinationApplyToMultipleVectorsEquivalentToRefWithAdaptivePrecision)
 {
     initialize_data({0, 11, 24, 33, 45, 55, 67, 70, 80, 92, 100},
-                    {sp, dp, dp, sp, sp, sp, dp, dp, sp, dp, sp}, 13, 97, 99,
-                    5);
+                    {sp, dp, dp, sp, sp, sp, dp, dp, sp, dp, sp}, {}, 13, 97,
+                    99, 5);
     auto alpha = gko::initialize<Vec>({2.0}, ref);
     auto d_alpha = gko::initialize<Vec>({2.0}, cuda);
     auto beta = gko::initialize<Vec>({-1.0}, ref);

--- a/omp/preconditioner/jacobi_kernels.cpp
+++ b/omp/preconditioner/jacobi_kernels.cpp
@@ -70,6 +70,7 @@ void generate(std::shared_ptr<const OmpExecutor> exec,
               size_type num_blocks, uint32 max_block_size,
               const preconditioner::block_interleaved_storage_scheme<IndexType>
                   &storage_scheme,
+              Array<remove_complex<ValueType>> &conditioning,
               Array<precision_reduction> &block_precisions,
               const Array<IndexType> &block_pointers,
               Array<ValueType> &blocks) NOT_IMPLEMENTED;

--- a/omp/preconditioner/jacobi_kernels.cpp
+++ b/omp/preconditioner/jacobi_kernels.cpp
@@ -68,6 +68,7 @@ template <typename ValueType, typename IndexType>
 void generate(std::shared_ptr<const OmpExecutor> exec,
               const matrix::Csr<ValueType, IndexType> *system_matrix,
               size_type num_blocks, uint32 max_block_size,
+              remove_complex<ValueType> accuracy,
               const preconditioner::block_interleaved_storage_scheme<IndexType>
                   &storage_scheme,
               Array<remove_complex<ValueType>> &conditioning,

--- a/reference/components/matrix_operations.hpp
+++ b/reference/components/matrix_operations.hpp
@@ -1,0 +1,74 @@
+/*******************************<GINKGO LICENSE>******************************
+Copyright 2017-2018
+
+Karlsruhe Institute of Technology
+Universitat Jaume I
+University of Tennessee
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice,
+   this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors
+   may be used to endorse or promote products derived from this software
+   without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+******************************<GINKGO LICENSE>*******************************/
+
+#ifndef GKO_REFERENCE_COMPONENTS_MATRIX_OPERATIONS_HPP_
+#define GKO_REFERENCE_COMPONENTS_MATRIX_OPERATIONS_HPP_
+
+
+#include "core/base/math.hpp"
+
+
+namespace gko {
+namespace kernels {
+namespace reference {
+
+
+/**
+ * @internal
+ *
+ * Computes the infinity norm of a column-major matrix.
+ */
+template <typename ValueType>
+remove_complex<ValueType> compute_inf_norm(size_type num_rows,
+                                           size_type num_cols,
+                                           const ValueType *matrix,
+                                           size_type stride)
+{
+    auto result = zero<remove_complex<ValueType>>();
+    for (size_type i = 0; i < num_rows; ++i) {
+        auto tmp = zero<remove_complex<ValueType>>();
+        for (size_type j = 0; j < num_cols; ++j) {
+            tmp += abs(matrix[i + j * stride]);
+        }
+        result = max(result, tmp);
+    }
+    return result;
+}
+
+
+}  // namespace reference
+}  // namespace kernels
+}  // namespace gko
+
+
+#endif  // GKO_REFERENCE_COMPONENTS_MATRIX_OPERATIONS_HPP_

--- a/reference/test/preconditioner/jacobi_kernels.cpp
+++ b/reference/test/preconditioner/jacobi_kernels.cpp
@@ -388,6 +388,16 @@ TEST_F(Jacobi, PivotsWhenInvertingBlocksWithiAdaptivePrecision)
 }
 
 
+TEST_F(Jacobi, ComputesConditionNumbersOfBlocks)
+{
+    auto bj = adaptive_bj_factory->generate(mtx);
+
+    auto cond = bj->get_conditioning();
+    EXPECT_NEAR(cond[0], 6.0 * 6.0 / 14.0, 1e-14);
+    ASSERT_NEAR(cond[1], 7.0 * 28.0 / 48.0, 1e-14);
+}
+
+
 TEST_F(Jacobi, AppliesToVector)
 {
     auto x = gko::initialize<Vec>({1.0, -1.0, 2.0, -2.0, 3.0}, exec);

--- a/reference/test/preconditioner/jacobi_kernels.cpp
+++ b/reference/test/preconditioner/jacobi_kernels.cpp
@@ -398,6 +398,24 @@ TEST_F(Jacobi, ComputesConditionNumbersOfBlocks)
 }
 
 
+TEST_F(Jacobi, SelectsCorrectBlockPrecisions)
+{
+    auto bj =
+        Bj::build()
+            .with_max_block_size(17u)
+            .with_block_pointers(block_pointers)
+            .with_storage_optimization(gko::precision_reduction::autodetect())
+            .with_accuracy(0.2)
+            .on(exec)
+            ->generate(give(mtx));
+
+    auto prec =
+        bj->get_parameters().storage_optimization.block_wise.get_const_data();
+    EXPECT_EQ(prec[0], gko::precision_reduction(2, 0));  // u = 0.0625
+    ASSERT_EQ(prec[1], gko::precision_reduction(1, 0));  // u = 9.53e-07
+}
+
+
 TEST_F(Jacobi, AppliesToVector)
 {
     auto x = gko::initialize<Vec>({1.0, -1.0, 2.0, -2.0, 3.0}, exec);


### PR DESCRIPTION
This PR adds automatic precision detection capabilities to adaptive variant of block Jacobi.
Currently the only precisions that can be detected are the ones that do not require modifying the range of representable values (e.g. for `ValueType = double` those are equivalents of `floatx<11, 20>` and `floatx<11, 4>`).

### TODO:

- [x] merge #169 (click [here](
https://github.com/ginkgo-project/ginkgo/compare/adaptive_block_jacobi...jacobi_auto_precision_detection?expand=1) for diff containing only the new changes)