### PR TITLE
More verbose test output on CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -59,7 +59,7 @@ stages:
   before_script: *default_before_script
   script:
     - cd ${CI_JOB_NAME/test/build}
-    - make test
+    - ctest -V
   except:
       - schedules
 


### PR DESCRIPTION
Changes the command used to run tests on the CI so the entire output of each test is preserved.