### PR TITLE
Improved operation to kernel mapping

### DIFF
--- a/core/matrix/csr.cpp
+++ b/core/matrix/csr.cpp
@@ -49,32 +49,26 @@ namespace gko {
 namespace matrix {
 
 
-namespace {
+namespace csr {
 
 
-template <typename... TplArgs>
-struct TemplatedOperation {
-    GKO_REGISTER_OPERATION(spmv, csr::spmv<TplArgs...>);
-    GKO_REGISTER_OPERATION(advanced_spmv, csr::advanced_spmv<TplArgs...>);
-    GKO_REGISTER_OPERATION(convert_row_ptrs_to_idxs,
-                           csr::convert_row_ptrs_to_idxs<TplArgs...>);
-    GKO_REGISTER_OPERATION(convert_to_dense, csr::convert_to_dense<TplArgs...>);
-    GKO_REGISTER_OPERATION(move_to_dense, csr::move_to_dense<TplArgs...>);
-    GKO_REGISTER_OPERATION(transpose, csr::transpose<TplArgs...>);
-    GKO_REGISTER_OPERATION(conj_transpose, csr::conj_transpose<TplArgs...>);
-};
+GKO_REGISTER_OPERATION(spmv, csr::spmv);
+GKO_REGISTER_OPERATION(advanced_spmv, csr::advanced_spmv);
+GKO_REGISTER_OPERATION(convert_row_ptrs_to_idxs, csr::convert_row_ptrs_to_idxs);
+GKO_REGISTER_OPERATION(convert_to_dense, csr::convert_to_dense);
+GKO_REGISTER_OPERATION(move_to_dense, csr::move_to_dense);
+GKO_REGISTER_OPERATION(transpose, csr::transpose);
+GKO_REGISTER_OPERATION(conj_transpose, csr::conj_transpose);
 
 
-}  // namespace
+}  // namespace csr
 
 
 template <typename ValueType, typename IndexType>
 void Csr<ValueType, IndexType>::apply_impl(const LinOp *b, LinOp *x) const
 {
     using Dense = Dense<ValueType>;
-    this->get_executor()->run(
-        TemplatedOperation<ValueType, IndexType>::make_spmv_operation(
-            this, as<Dense>(b), as<Dense>(x)));
+    this->get_executor()->run(csr::make_spmv(this, as<Dense>(b), as<Dense>(x)));
 }
 
 
@@ -83,10 +77,8 @@ void Csr<ValueType, IndexType>::apply_impl(const LinOp *alpha, const LinOp *b,
                                            const LinOp *beta, LinOp *x) const
 {
     using Dense = Dense<ValueType>;
-    this->get_executor()->run(
-        TemplatedOperation<ValueType, IndexType>::make_advanced_spmv_operation(
-            as<Dense>(alpha), this, as<Dense>(b), as<Dense>(beta),
-            as<Dense>(x)));
+    this->get_executor()->run(csr::make_advanced_spmv(
+        as<Dense>(alpha), this, as<Dense>(b), as<Dense>(beta), as<Dense>(x)));
 }
 
 
@@ -97,10 +89,8 @@ std::unique_ptr<Coo<ValueType, IndexType>> Csr<ValueType, IndexType>::make_coo()
     auto exec = this->get_executor();
     auto tmp = Coo<ValueType, IndexType>::create(
         exec, this->get_size(), this->get_num_stored_elements());
-    exec->run(
-        TemplatedOperation<IndexType>::make_convert_row_ptrs_to_idxs_operation(
-            this->get_const_row_ptrs(), this->get_size()[0],
-            tmp->get_row_idxs()));
+    exec->run(csr::make_convert_row_ptrs_to_idxs(
+        this->get_const_row_ptrs(), this->get_size()[0], tmp->get_row_idxs()));
     return tmp;
 }
 
@@ -131,9 +121,7 @@ void Csr<ValueType, IndexType>::convert_to(Dense<ValueType> *result) const
 {
     auto exec = this->get_executor();
     auto tmp = Dense<ValueType>::create(exec, this->get_size());
-    exec->run(TemplatedOperation<
-              ValueType, IndexType>::make_convert_to_dense_operation(tmp.get(),
-                                                                     this));
+    exec->run(csr::make_convert_to_dense(tmp.get(), this));
     tmp->move_to(result);
 }
 
@@ -143,9 +131,7 @@ void Csr<ValueType, IndexType>::move_to(Dense<ValueType> *result)
 {
     auto exec = this->get_executor();
     auto tmp = Dense<ValueType>::create(exec, this->get_size());
-    exec->run(
-        TemplatedOperation<ValueType, IndexType>::make_move_to_dense_operation(
-            tmp.get(), this));
+    exec->run(csr::make_move_to_dense(tmp.get(), this));
     tmp->move_to(result);
 }
 
@@ -215,9 +201,7 @@ std::unique_ptr<LinOp> Csr<ValueType, IndexType>::transpose() const
         Csr::create(exec, gko::transpose(this->get_size()),
                     this->get_num_stored_elements(), this->get_strategy());
 
-    exec->run(
-        TemplatedOperation<ValueType, IndexType>::make_transpose_operation(
-            trans_cpy.get(), this));
+    exec->run(csr::make_transpose(trans_cpy.get(), this));
     trans_cpy->make_srow();
     return std::move(trans_cpy);
 }
@@ -231,9 +215,7 @@ std::unique_ptr<LinOp> Csr<ValueType, IndexType>::conj_transpose() const
         Csr::create(exec, gko::transpose(this->get_size()),
                     this->get_num_stored_elements(), this->get_strategy());
 
-    exec->run(
-        TemplatedOperation<ValueType, IndexType>::make_conj_transpose_operation(
-            trans_cpy.get(), this));
+    exec->run(csr::make_conj_transpose(trans_cpy.get(), this));
     trans_cpy->make_srow();
     return std::move(trans_cpy);
 }

--- a/core/matrix/dense.cpp
+++ b/core/matrix/dense.cpp
@@ -54,65 +54,38 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 namespace gko {
 namespace matrix {
+namespace dense {
+
+
+GKO_REGISTER_OPERATION(simple_apply, dense::simple_apply);
+GKO_REGISTER_OPERATION(apply, dense::apply);
+GKO_REGISTER_OPERATION(scale, dense::scale);
+GKO_REGISTER_OPERATION(add_scaled, dense::add_scaled);
+GKO_REGISTER_OPERATION(compute_dot, dense::compute_dot);
+GKO_REGISTER_OPERATION(compute_norm2, dense::compute_norm2);
+GKO_REGISTER_OPERATION(count_nonzeros, dense::count_nonzeros);
+GKO_REGISTER_OPERATION(calculate_max_nnz_per_row,
+                       dense::calculate_max_nnz_per_row);
+GKO_REGISTER_OPERATION(calculate_nonzeros_per_row,
+                       dense::calculate_nonzeros_per_row);
+GKO_REGISTER_OPERATION(calculate_total_cols, dense::calculate_total_cols);
+GKO_REGISTER_OPERATION(transpose, dense::transpose);
+GKO_REGISTER_OPERATION(conj_transpose, dense::conj_transpose);
+GKO_REGISTER_OPERATION(convert_to_coo, dense::convert_to_coo);
+GKO_REGISTER_OPERATION(convert_to_csr, dense::convert_to_csr);
+GKO_REGISTER_OPERATION(move_to_csr, dense::move_to_csr);
+GKO_REGISTER_OPERATION(convert_to_ell, dense::convert_to_ell);
+GKO_REGISTER_OPERATION(move_to_ell, dense::move_to_ell);
+GKO_REGISTER_OPERATION(convert_to_hybrid, dense::convert_to_hybrid);
+GKO_REGISTER_OPERATION(move_to_hybrid, dense::move_to_hybrid);
+GKO_REGISTER_OPERATION(convert_to_sellp, dense::convert_to_sellp);
+GKO_REGISTER_OPERATION(move_to_sellp, dense::move_to_sellp);
+
+
+}  // namespace dense
 
 
 namespace {
-
-
-template <typename ValueType>
-struct TemplatedOperation {
-    GKO_REGISTER_OPERATION(simple_apply, dense::simple_apply<ValueType>);
-    GKO_REGISTER_OPERATION(apply, dense::apply<ValueType>);
-    GKO_REGISTER_OPERATION(scale, dense::scale<ValueType>);
-    GKO_REGISTER_OPERATION(add_scaled, dense::add_scaled<ValueType>);
-    GKO_REGISTER_OPERATION(compute_dot, dense::compute_dot<ValueType>);
-    GKO_REGISTER_OPERATION(compute_norm2, dense::compute_norm2<ValueType>);
-    GKO_REGISTER_OPERATION(count_nonzeros, dense::count_nonzeros<ValueType>);
-    GKO_REGISTER_OPERATION(calculate_max_nnz_per_row,
-                           dense::calculate_max_nnz_per_row<ValueType>);
-    GKO_REGISTER_OPERATION(calculate_nonzeros_per_row,
-                           dense::calculate_nonzeros_per_row<ValueType>);
-    GKO_REGISTER_OPERATION(calculate_total_cols,
-                           dense::calculate_total_cols<ValueType>);
-    GKO_REGISTER_OPERATION(transpose, dense::transpose<ValueType>);
-    GKO_REGISTER_OPERATION(conj_transpose, dense::conj_transpose<ValueType>);
-};
-
-
-template <typename... TplArgs>
-struct TemplatedOperationCoo {
-    GKO_REGISTER_OPERATION(convert_to_coo, dense::convert_to_coo<TplArgs...>);
-};
-
-
-template <typename... TplArgs>
-struct TemplatedOperationCsr {
-    GKO_REGISTER_OPERATION(convert_to_csr, dense::convert_to_csr<TplArgs...>);
-    GKO_REGISTER_OPERATION(move_to_csr, dense::move_to_csr<TplArgs...>);
-};
-
-
-template <typename... TplArgs>
-struct TemplatedOperationEll {
-    GKO_REGISTER_OPERATION(convert_to_ell, dense::convert_to_ell<TplArgs...>);
-    GKO_REGISTER_OPERATION(move_to_ell, dense::move_to_ell<TplArgs...>);
-};
-
-
-template <typename... TplArgs>
-struct TemplatedOperationHybrid {
-    GKO_REGISTER_OPERATION(convert_to_hybrid,
-                           dense::convert_to_hybrid<TplArgs...>);
-    GKO_REGISTER_OPERATION(move_to_hybrid, dense::move_to_hybrid<TplArgs...>);
-};
-
-
-template <typename... TplArgs>
-struct TemplatedOperationSellp {
-    GKO_REGISTER_OPERATION(convert_to_sellp,
-                           dense::convert_to_sellp<TplArgs...>);
-    GKO_REGISTER_OPERATION(move_to_sellp, dense::move_to_sellp<TplArgs...>);
-};
 
 
 template <typename ValueType, typename IndexType, typename MatrixType,
@@ -123,8 +96,7 @@ inline void conversion_helper(Coo<ValueType, IndexType> *result,
     auto exec = source->get_executor();
 
     size_type num_stored_nonzeros = 0;
-    exec->run(TemplatedOperation<ValueType>::make_count_nonzeros_operation(
-        source, &num_stored_nonzeros));
+    exec->run(dense::make_count_nonzeros(source, &num_stored_nonzeros));
     auto tmp = Coo<ValueType, IndexType>::create(exec, source->get_size(),
                                                  num_stored_nonzeros);
     exec->run(op(tmp.get(), source));
@@ -140,8 +112,7 @@ inline void conversion_helper(Csr<ValueType, IndexType> *result,
     auto exec = source->get_executor();
 
     size_type num_stored_nonzeros = 0;
-    exec->run(TemplatedOperation<ValueType>::make_count_nonzeros_operation(
-        source, &num_stored_nonzeros));
+    exec->run(dense::make_count_nonzeros(source, &num_stored_nonzeros));
     auto tmp = Csr<ValueType, IndexType>::create(exec, source->get_size(),
                                                  num_stored_nonzeros);
     exec->run(op(tmp.get(), source));
@@ -156,9 +127,8 @@ inline void conversion_helper(Ell<ValueType, IndexType> *result,
 {
     auto exec = source->get_executor();
     size_type num_stored_elements_per_row = 0;
-    exec->run(
-        TemplatedOperation<ValueType>::make_calculate_max_nnz_per_row_operation(
-            source, &num_stored_elements_per_row));
+    exec->run(dense::make_calculate_max_nnz_per_row(
+        source, &num_stored_elements_per_row));
     const auto max_nnz_per_row = std::max(
         result->get_num_stored_elements_per_row(), num_stored_elements_per_row);
     const auto stride = std::max(result->get_stride(), source->get_size()[0]);
@@ -176,9 +146,7 @@ inline void conversion_helper(Hybrid<ValueType, IndexType> *result,
 {
     auto exec = source->get_executor();
     Array<size_type> row_nnz(exec, source->get_size()[0]);
-    exec->run(TemplatedOperation<
-              ValueType>::make_calculate_nonzeros_per_row_operation(source,
-                                                                    &row_nnz));
+    exec->run(dense::make_calculate_nonzeros_per_row(source, &row_nnz));
     size_type ell_lim = zero<size_type>();
     size_type coo_lim = zero<size_type>();
     result->get_strategy()->compute_hybrid_config(row_nnz, &ell_lim, &coo_lim);
@@ -206,9 +174,8 @@ inline void conversion_helper(Sellp<ValueType, IndexType> *result,
                                    ? default_stride_factor
                                    : result->get_stride_factor();
     size_type total_columns = 0;
-    exec->run(
-        TemplatedOperation<ValueType>::make_calculate_total_cols_operation(
-            source, &total_columns, stride_factor));
+    exec->run(dense::make_calculate_total_cols(source, &total_columns,
+                                               stride_factor));
     const auto total_cols = std::max(result->get_total_cols(), total_columns);
     const auto slice_size = (result->get_slice_size() == 0)
                                 ? default_slice_size
@@ -226,9 +193,8 @@ inline void conversion_helper(Sellp<ValueType, IndexType> *result,
 template <typename ValueType>
 void Dense<ValueType>::apply_impl(const LinOp *b, LinOp *x) const
 {
-    this->get_executor()->run(
-        TemplatedOperation<ValueType>::make_simple_apply_operation(
-            this, as<Dense<ValueType>>(b), as<Dense<ValueType>>(x)));
+    this->get_executor()->run(dense::make_simple_apply(
+        this, as<Dense<ValueType>>(b), as<Dense<ValueType>>(x)));
 }
 
 
@@ -236,10 +202,9 @@ template <typename ValueType>
 void Dense<ValueType>::apply_impl(const LinOp *alpha, const LinOp *b,
                                   const LinOp *beta, LinOp *x) const
 {
-    this->get_executor()->run(
-        TemplatedOperation<ValueType>::make_apply_operation(
-            as<Dense<ValueType>>(alpha), this, as<Dense<ValueType>>(b),
-            as<Dense<ValueType>>(beta), as<Dense<ValueType>>(x)));
+    this->get_executor()->run(dense::make_apply(
+        as<Dense<ValueType>>(alpha), this, as<Dense<ValueType>>(b),
+        as<Dense<ValueType>>(beta), as<Dense<ValueType>>(x)));
 }
 
 
@@ -253,8 +218,7 @@ void Dense<ValueType>::scale(const LinOp *alpha)
     }
     auto exec = this->get_executor();
     if (alpha->get_executor() != exec) NOT_IMPLEMENTED;
-    exec->run(TemplatedOperation<ValueType>::make_scale_operation(
-        as<Dense<ValueType>>(alpha), this));
+    exec->run(dense::make_scale(as<Dense<ValueType>>(alpha), this));
 }
 
 
@@ -270,8 +234,8 @@ void Dense<ValueType>::add_scaled(const LinOp *alpha, const LinOp *b)
     auto exec = this->get_executor();
     if (alpha->get_executor() != exec || b->get_executor() != exec)
         NOT_IMPLEMENTED;
-    exec->run(TemplatedOperation<ValueType>::make_add_scaled_operation(
-        as<Dense<ValueType>>(alpha), as<Dense<ValueType>>(b), this));
+    exec->run(dense::make_add_scaled(as<Dense<ValueType>>(alpha),
+                                     as<Dense<ValueType>>(b), this));
 }
 
 
@@ -283,8 +247,8 @@ void Dense<ValueType>::compute_dot(const LinOp *b, LinOp *result) const
     auto exec = this->get_executor();
     if (b->get_executor() != exec || result->get_executor() != exec)
         NOT_IMPLEMENTED;
-    exec->run(TemplatedOperation<ValueType>::make_compute_dot_operation(
-        this, as<Dense<ValueType>>(b), as<Dense<ValueType>>(result)));
+    exec->run(dense::make_compute_dot(this, as<Dense<ValueType>>(b),
+                                      as<Dense<ValueType>>(result)));
 }
 
 
@@ -294,8 +258,8 @@ void Dense<ValueType>::compute_norm2(LinOp *result) const
     ASSERT_EQUAL_DIMENSIONS(result, dim<2>(1, this->get_size()[1]));
     auto exec = this->get_executor();
     if (result->get_executor() != exec) NOT_IMPLEMENTED;
-    exec->run(TemplatedOperation<ValueType>::make_compute_norm2_operation(
-        as<Dense<ValueType>>(this), as<Dense<ValueType>>(result)));
+    exec->run(dense::make_compute_norm2(as<Dense<ValueType>>(this),
+                                        as<Dense<ValueType>>(result)));
 }
 
 
@@ -304,20 +268,17 @@ void Dense<ValueType>::convert_to(Coo<ValueType, int32> *result) const
 {
     conversion_helper(
         result, this,
-        TemplatedOperationCoo<ValueType, int32>::
-            template make_convert_to_coo_operation<decltype(result),
-                                                   const Dense<ValueType> *&>);
+        dense::template make_convert_to_coo<decltype(result),
+                                            const Dense<ValueType> *&>);
 }
 
 
 template <typename ValueType>
 void Dense<ValueType>::move_to(Coo<ValueType, int32> *result)
 {
-    conversion_helper(
-        result, this,
-        TemplatedOperationCoo<ValueType, int32>::
-            template make_convert_to_coo_operation<decltype(result),
-                                                   Dense<ValueType> *&>);
+    conversion_helper(result, this,
+                      dense::template make_convert_to_coo<decltype(result),
+                                                          Dense<ValueType> *&>);
 }
 
 
@@ -326,20 +287,17 @@ void Dense<ValueType>::convert_to(Coo<ValueType, int64> *result) const
 {
     conversion_helper(
         result, this,
-        TemplatedOperationCoo<ValueType, int64>::
-            template make_convert_to_coo_operation<decltype(result),
-                                                   const Dense<ValueType> *&>);
+        dense::template make_convert_to_coo<decltype(result),
+                                            const Dense<ValueType> *&>);
 }
 
 
 template <typename ValueType>
 void Dense<ValueType>::move_to(Coo<ValueType, int64> *result)
 {
-    conversion_helper(
-        result, this,
-        TemplatedOperationCoo<ValueType, int64>::
-            template make_convert_to_coo_operation<decltype(result),
-                                                   Dense<ValueType> *&>);
+    conversion_helper(result, this,
+                      dense::template make_convert_to_coo<decltype(result),
+                                                          Dense<ValueType> *&>);
 }
 
 
@@ -348,9 +306,8 @@ void Dense<ValueType>::convert_to(Csr<ValueType, int32> *result) const
 {
     conversion_helper(
         result, this,
-        TemplatedOperationCsr<ValueType, int32>::
-            template make_convert_to_csr_operation<decltype(result),
-                                                   const Dense<ValueType> *&>);
+        dense::template make_convert_to_csr<decltype(result),
+                                            const Dense<ValueType> *&>);
     result->make_srow();
 }
 
@@ -358,11 +315,9 @@ void Dense<ValueType>::convert_to(Csr<ValueType, int32> *result) const
 template <typename ValueType>
 void Dense<ValueType>::move_to(Csr<ValueType, int32> *result)
 {
-    conversion_helper(
-        result, this,
-        TemplatedOperationCsr<ValueType, int32>::
-            template make_move_to_csr_operation<decltype(result),
-                                                Dense<ValueType> *&>);
+    conversion_helper(result, this,
+                      dense::template make_move_to_csr<decltype(result),
+                                                       Dense<ValueType> *&>);
     result->make_srow();
 }
 
@@ -372,9 +327,8 @@ void Dense<ValueType>::convert_to(Csr<ValueType, int64> *result) const
 {
     conversion_helper(
         result, this,
-        TemplatedOperationCsr<ValueType, int64>::
-            template make_convert_to_csr_operation<decltype(result),
-                                                   const Dense<ValueType> *&>);
+        dense::template make_convert_to_csr<decltype(result),
+                                            const Dense<ValueType> *&>);
     result->make_srow();
 }
 
@@ -382,11 +336,9 @@ void Dense<ValueType>::convert_to(Csr<ValueType, int64> *result) const
 template <typename ValueType>
 void Dense<ValueType>::move_to(Csr<ValueType, int64> *result)
 {
-    conversion_helper(
-        result, this,
-        TemplatedOperationCsr<ValueType, int64>::
-            template make_move_to_csr_operation<decltype(result),
-                                                Dense<ValueType> *&>);
+    conversion_helper(result, this,
+                      dense::template make_move_to_csr<decltype(result),
+                                                       Dense<ValueType> *&>);
     result->make_srow();
 }
 
@@ -396,20 +348,17 @@ void Dense<ValueType>::convert_to(Ell<ValueType, int32> *result) const
 {
     conversion_helper(
         result, this,
-        TemplatedOperationEll<ValueType, int32>::
-            template make_convert_to_ell_operation<decltype(result),
-                                                   const Dense<ValueType> *&>);
+        dense::template make_convert_to_ell<decltype(result),
+                                            const Dense<ValueType> *&>);
 }
 
 
 template <typename ValueType>
 void Dense<ValueType>::move_to(Ell<ValueType, int32> *result)
 {
-    conversion_helper(
-        result, this,
-        TemplatedOperationEll<ValueType, int32>::
-            template make_move_to_ell_operation<decltype(result),
-                                                Dense<ValueType> *&>);
+    conversion_helper(result, this,
+                      dense::template make_move_to_ell<decltype(result),
+                                                       Dense<ValueType> *&>);
 }
 
 
@@ -418,104 +367,93 @@ void Dense<ValueType>::convert_to(Ell<ValueType, int64> *result) const
 {
     conversion_helper(
         result, this,
-        TemplatedOperationEll<ValueType, int64>::
-            template make_convert_to_ell_operation<decltype(result),
-                                                   const Dense<ValueType> *&>);
+        dense::template make_convert_to_ell<decltype(result),
+                                            const Dense<ValueType> *&>);
 }
 
 
 template <typename ValueType>
 void Dense<ValueType>::move_to(Ell<ValueType, int64> *result)
 {
-    conversion_helper(
-        result, this,
-        TemplatedOperationEll<ValueType, int64>::
-            template make_move_to_ell_operation<decltype(result),
-                                                Dense<ValueType> *&>);
+    conversion_helper(result, this,
+                      dense::template make_move_to_ell<decltype(result),
+                                                       Dense<ValueType> *&>);
 }
 
 
 template <typename ValueType>
 void Dense<ValueType>::convert_to(Hybrid<ValueType, int32> *result) const
 {
-    conversion_helper(result, this,
-                      TemplatedOperationHybrid<ValueType, int32>::
-                          template make_convert_to_hybrid_operation<
-                              decltype(result), const Dense<ValueType> *&>);
+    conversion_helper(
+        result, this,
+        dense::template make_convert_to_hybrid<decltype(result),
+                                               const Dense<ValueType> *&>);
 }
 
 
 template <typename ValueType>
 void Dense<ValueType>::move_to(Hybrid<ValueType, int32> *result)
 {
-    conversion_helper(
-        result, this,
-        TemplatedOperationHybrid<ValueType, int32>::
-            template make_move_to_hybrid_operation<decltype(result),
-                                                   Dense<ValueType> *&>);
+    conversion_helper(result, this,
+                      dense::template make_move_to_hybrid<decltype(result),
+                                                          Dense<ValueType> *&>);
 }
 
 
 template <typename ValueType>
 void Dense<ValueType>::convert_to(Hybrid<ValueType, int64> *result) const
 {
-    conversion_helper(result, this,
-                      TemplatedOperationHybrid<ValueType, int64>::
-                          template make_convert_to_hybrid_operation<
-                              decltype(result), const Dense<ValueType> *&>);
+    conversion_helper(
+        result, this,
+        dense::template make_convert_to_hybrid<decltype(result),
+                                               const Dense<ValueType> *&>);
 }
 
 
 template <typename ValueType>
 void Dense<ValueType>::move_to(Hybrid<ValueType, int64> *result)
 {
-    conversion_helper(
-        result, this,
-        TemplatedOperationHybrid<ValueType, int64>::
-            template make_move_to_hybrid_operation<decltype(result),
-                                                   Dense<ValueType> *&>);
+    conversion_helper(result, this,
+                      dense::template make_move_to_hybrid<decltype(result),
+                                                          Dense<ValueType> *&>);
 }
 
 
 template <typename ValueType>
 void Dense<ValueType>::convert_to(Sellp<ValueType, int32> *result) const
 {
-    conversion_helper(result, this,
-                      TemplatedOperationSellp<ValueType, int32>::
-                          template make_convert_to_sellp_operation<
-                              decltype(result), const Dense<ValueType> *&>);
+    conversion_helper(
+        result, this,
+        dense::template make_convert_to_sellp<decltype(result),
+                                              const Dense<ValueType> *&>);
 }
 
 
 template <typename ValueType>
 void Dense<ValueType>::move_to(Sellp<ValueType, int32> *result)
 {
-    conversion_helper(
-        result, this,
-        TemplatedOperationSellp<ValueType, int32>::
-            template make_move_to_sellp_operation<decltype(result),
-                                                  Dense<ValueType> *&>);
+    conversion_helper(result, this,
+                      dense::template make_move_to_sellp<decltype(result),
+                                                         Dense<ValueType> *&>);
 }
 
 
 template <typename ValueType>
 void Dense<ValueType>::convert_to(Sellp<ValueType, int64> *result) const
 {
-    conversion_helper(result, this,
-                      TemplatedOperationSellp<ValueType, int64>::
-                          template make_convert_to_sellp_operation<
-                              decltype(result), const Dense<ValueType> *&>);
+    conversion_helper(
+        result, this,
+        dense::template make_convert_to_sellp<decltype(result),
+                                              const Dense<ValueType> *&>);
 }
 
 
 template <typename ValueType>
 void Dense<ValueType>::move_to(Sellp<ValueType, int64> *result)
 {
-    conversion_helper(
-        result, this,
-        TemplatedOperationSellp<ValueType, int64>::
-            template make_move_to_sellp_operation<decltype(result),
-                                                  Dense<ValueType> *&>);
+    conversion_helper(result, this,
+                      dense::template make_move_to_sellp<decltype(result),
+                                                         Dense<ValueType> *&>);
 }
 
 
@@ -609,8 +547,7 @@ std::unique_ptr<LinOp> Dense<ValueType>::transpose() const
     auto exec = this->get_executor();
     auto trans_cpy = Dense::create(exec, gko::transpose(this->get_size()));
 
-    exec->run(TemplatedOperation<ValueType>::make_transpose_operation(
-        trans_cpy.get(), this));
+    exec->run(dense::make_transpose(trans_cpy.get(), this));
 
     return std::move(trans_cpy);
 }
@@ -622,8 +559,7 @@ std::unique_ptr<LinOp> Dense<ValueType>::conj_transpose() const
     auto exec = this->get_executor();
     auto trans_cpy = Dense::create(exec, gko::transpose(this->get_size()));
 
-    exec->run(TemplatedOperation<ValueType>::make_conj_transpose_operation(
-        trans_cpy.get(), this));
+    exec->run(dense::make_conj_transpose(trans_cpy.get(), this));
     return std::move(trans_cpy);
 }
 

--- a/core/matrix/hybrid.cpp
+++ b/core/matrix/hybrid.cpp
@@ -49,14 +49,16 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 namespace gko {
 namespace matrix {
+namespace hybrid {
+
+
+GKO_REGISTER_OPERATION(convert_to_dense, hybrid::convert_to_dense);
+
+
+}  // namespace hybrid
+
+
 namespace {
-
-
-template <typename... TplArgs>
-struct TemplatedOperation {
-    GKO_REGISTER_OPERATION(convert_to_dense,
-                           hybrid::convert_to_dense<TplArgs...>);
-};
 
 
 template <typename ValueType, typename IndexType>
@@ -111,9 +113,7 @@ void Hybrid<ValueType, IndexType>::convert_to(Dense<ValueType> *result) const
 {
     auto exec = this->get_executor();
     auto tmp = Dense<ValueType>::create(exec, this->get_size());
-    exec->run(TemplatedOperation<
-              ValueType, IndexType>::make_convert_to_dense_operation(tmp.get(),
-                                                                     this));
+    exec->run(hybrid::make_convert_to_dense(tmp.get(), this));
     tmp->move_to(result);
 }
 

--- a/core/preconditioner/jacobi.cpp
+++ b/core/preconditioner/jacobi.cpp
@@ -49,34 +49,28 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 namespace gko {
 namespace preconditioner {
-namespace {
+namespace jacobi {
 
 
-template <typename... TArgs>
-struct JacobiOperation {
-    GKO_REGISTER_OPERATION(simple_apply, jacobi::simple_apply<TArgs...>);
-    GKO_REGISTER_OPERATION(apply, jacobi::apply<TArgs...>);
-    GKO_REGISTER_OPERATION(find_blocks, jacobi::find_blocks<TArgs...>);
-    GKO_REGISTER_OPERATION(generate, jacobi::generate<TArgs...>);
-    GKO_REGISTER_OPERATION(convert_to_dense,
-                           jacobi::convert_to_dense<TArgs...>);
-    GKO_REGISTER_OPERATION(initialize_precisions,
-                           jacobi::initialize_precisions);
-};
+GKO_REGISTER_OPERATION(simple_apply, jacobi::simple_apply);
+GKO_REGISTER_OPERATION(apply, jacobi::apply);
+GKO_REGISTER_OPERATION(find_blocks, jacobi::find_blocks);
+GKO_REGISTER_OPERATION(generate, jacobi::generate);
+GKO_REGISTER_OPERATION(convert_to_dense, jacobi::convert_to_dense);
+GKO_REGISTER_OPERATION(initialize_precisions, jacobi::initialize_precisions);
 
 
-}  // namespace
+}  // namespace jacobi
 
 
 template <typename ValueType, typename IndexType>
 void Jacobi<ValueType, IndexType>::apply_impl(const LinOp *b, LinOp *x) const
 {
     using dense = matrix::Dense<ValueType>;
-    this->get_executor()->run(
-        JacobiOperation<ValueType, IndexType>::make_simple_apply_operation(
-            num_blocks_, parameters_.max_block_size, storage_scheme_,
-            parameters_.storage_optimization.block_wise,
-            parameters_.block_pointers, blocks_, as<dense>(b), as<dense>(x)));
+    this->get_executor()->run(jacobi::make_simple_apply(
+        num_blocks_, parameters_.max_block_size, storage_scheme_,
+        parameters_.storage_optimization.block_wise, parameters_.block_pointers,
+        blocks_, as<dense>(b), as<dense>(x)));
 }
 
 
@@ -86,12 +80,11 @@ void Jacobi<ValueType, IndexType>::apply_impl(const LinOp *alpha,
                                               LinOp *x) const
 {
     using dense = matrix::Dense<ValueType>;
-    this->get_executor()->run(
-        JacobiOperation<ValueType, IndexType>::make_apply_operation(
-            num_blocks_, parameters_.max_block_size, storage_scheme_,
-            parameters_.storage_optimization.block_wise,
-            parameters_.block_pointers, blocks_, as<dense>(alpha), as<dense>(b),
-            as<dense>(beta), as<dense>(x)));
+    this->get_executor()->run(jacobi::make_apply(
+        num_blocks_, parameters_.max_block_size, storage_scheme_,
+        parameters_.storage_optimization.block_wise, parameters_.block_pointers,
+        blocks_, as<dense>(alpha), as<dense>(b), as<dense>(beta),
+        as<dense>(x)));
 }
 
 
@@ -101,11 +94,10 @@ void Jacobi<ValueType, IndexType>::convert_to(
 {
     auto exec = this->get_executor();
     auto tmp = matrix::Dense<ValueType>::create(exec, this->get_size());
-    exec->run(
-        JacobiOperation<ValueType, IndexType>::make_convert_to_dense_operation(
-            num_blocks_, parameters_.storage_optimization.block_wise,
-            parameters_.block_pointers, blocks_, storage_scheme_,
-            tmp->get_values(), tmp->get_stride()));
+    exec->run(jacobi::make_convert_to_dense(
+        num_blocks_, parameters_.storage_optimization.block_wise,
+        parameters_.block_pointers, blocks_, storage_scheme_, tmp->get_values(),
+        tmp->get_stride()));
     tmp->move_to(result);
 }
 
@@ -158,9 +150,8 @@ void Jacobi<ValueType, IndexType>::detect_blocks(
     parameters_.block_pointers.resize_and_reset(system_matrix->get_size()[0] +
                                                 1);
     this->get_executor()->run(
-        JacobiOperation<ValueType, IndexType>::make_find_blocks_operation(
-            system_matrix, parameters_.max_block_size, num_blocks_,
-            parameters_.block_pointers));
+        jacobi::make_find_blocks(system_matrix, parameters_.max_block_size,
+                                 num_blocks_, parameters_.block_pointers));
     blocks_.resize_and_reset(
         storage_scheme_.compute_storage_space(num_blocks_));
 }
@@ -190,13 +181,12 @@ void Jacobi<ValueType, IndexType>::generate(const LinOp *system_matrix)
         }
         Array<precision_reduction> tmp(
             exec, parameters_.block_pointers.get_num_elems() - 1);
-        exec->run(JacobiOperation<ValueType, IndexType>::
-                      make_initialize_precisions_operation(precisions, tmp));
+        exec->run(jacobi::make_initialize_precisions(precisions, tmp));
         precisions = std::move(tmp);
         conditioning_.resize_and_reset(num_blocks_);
     }
 
-    exec->run(JacobiOperation<ValueType, IndexType>::make_generate_operation(
+    exec->run(jacobi::make_generate(
         csr_mtx.get(), num_blocks_, parameters_.max_block_size,
         parameters_.accuracy, storage_scheme_, conditioning_, precisions,
         parameters_.block_pointers, blocks_));

--- a/core/solver/cgs.cpp
+++ b/core/solver/cgs.cpp
@@ -48,19 +48,16 @@ namespace gko {
 namespace solver {
 
 
-namespace {
+namespace cgs {
 
 
-template <typename ValueType>
-struct TemplatedOperation {
-    GKO_REGISTER_OPERATION(initialize, cgs::initialize<ValueType>);
-    GKO_REGISTER_OPERATION(step_1, cgs::step_1<ValueType>);
-    GKO_REGISTER_OPERATION(step_2, cgs::step_2<ValueType>);
-    GKO_REGISTER_OPERATION(step_3, cgs::step_3<ValueType>);
-};
+GKO_REGISTER_OPERATION(initialize, cgs::initialize);
+GKO_REGISTER_OPERATION(step_1, cgs::step_1);
+GKO_REGISTER_OPERATION(step_2, cgs::step_2);
+GKO_REGISTER_OPERATION(step_3, cgs::step_3);
 
 
-}  // namespace
+}  // namespace cgs
 
 
 template <typename ValueType>
@@ -99,7 +96,7 @@ void Cgs<ValueType>::apply_impl(const LinOp *b, LinOp *x) const
                                        dense_b->get_size()[1]);
 
     // TODO: replace this with automatic merged kernel generator
-    exec->run(TemplatedOperation<ValueType>::make_initialize_operation(
+    exec->run(cgs::make_initialize(
         dense_b, r.get(), r_tld.get(), p.get(), q.get(), u.get(), u_hat.get(),
         v_hat.get(), t.get(), alpha.get(), beta.get(), gamma.get(),
         rho_prev.get(), rho.get(), &stop_status));
@@ -118,25 +115,25 @@ void Cgs<ValueType>::apply_impl(const LinOp *b, LinOp *x) const
     int iter = 0;
     while (true) {
         r->compute_dot(r_tld.get(), rho.get());
-        exec->run(TemplatedOperation<ValueType>::make_step_1_operation(
-            r.get(), u.get(), p.get(), q.get(), beta.get(), rho.get(),
-            rho_prev.get(), &stop_status));
+        exec->run(cgs::make_step_1(r.get(), u.get(), p.get(), q.get(),
+                                   beta.get(), rho.get(), rho_prev.get(),
+                                   &stop_status));
         // beta = rho / rho_prev
         // u = r + beta * q;
         // p = u + beta * ( q + beta * p );
         preconditioner_->apply(p.get(), t.get());
         system_matrix_->apply(t.get(), v_hat.get());
         r_tld->compute_dot(v_hat.get(), gamma.get());
-        exec->run(TemplatedOperation<ValueType>::make_step_2_operation(
-            u.get(), v_hat.get(), q.get(), t.get(), alpha.get(), rho.get(),
-            gamma.get(), &stop_status));
+        exec->run(cgs::make_step_2(u.get(), v_hat.get(), q.get(), t.get(),
+                                   alpha.get(), rho.get(), gamma.get(),
+                                   &stop_status));
         // alpha = rho / gamma
         // q = u - alpha * v_hat
         // t = u + q
         preconditioner_->apply(t.get(), u_hat.get());
         system_matrix_->apply(u_hat.get(), t.get());
-        exec->run(TemplatedOperation<ValueType>::make_step_3_operation(
-            t.get(), u_hat.get(), r.get(), dense_x, alpha.get(), &stop_status));
+        exec->run(cgs::make_step_3(t.get(), u_hat.get(), r.get(), dense_x,
+                                   alpha.get(), &stop_status));
         // r = r -alpha * t
         // x = x + alpha * u_hat
 

--- a/core/stop/criterion.cpp
+++ b/core/stop/criterion.cpp
@@ -40,22 +40,19 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 namespace gko {
 namespace stop {
-namespace {
+namespace criterion {
 
 
-struct SimpleOperation {
-    GKO_REGISTER_OPERATION(set_all_statuses,
-                           set_all_statuses::set_all_statuses);
-};
+GKO_REGISTER_OPERATION(set_all_statuses, set_all_statuses::set_all_statuses);
 
 
-}  // namespace
+}  // namespace criterion
 
 
 void Criterion::set_all_statuses(uint8 stoppingId, bool setFinalized,
                                  Array<stopping_status> *stop_status)
 {
-    this->get_executor()->run(SimpleOperation::make_set_all_statuses_operation(
+    this->get_executor()->run(criterion::make_set_all_statuses(
         stoppingId, setFinalized, stop_status));
 }
 

--- a/core/stop/residual_norm_reduction.cpp
+++ b/core/stop/residual_norm_reduction.cpp
@@ -40,18 +40,14 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 namespace gko {
 namespace stop {
-namespace {
+namespace residual_norm_reduction {
 
 
-template <typename ValueType>
-struct TemplatedOperation {
-    GKO_REGISTER_OPERATION(
-        residual_norm_reduction,
-        residual_norm_reduction::residual_norm_reduction<ValueType>);
-};
+GKO_REGISTER_OPERATION(residual_norm_reduction,
+                       residual_norm_reduction::residual_norm_reduction);
 
 
-}  // namespace
+}  // namespace residual_norm_reduction
 
 
 template <typename ValueType>
@@ -73,7 +69,7 @@ bool ResidualNormReduction<ValueType>::check_impl(
     bool all_converged = true;
 
     this->get_executor()->run(
-        TemplatedOperation<ValueType>::make_residual_norm_reduction_operation(
+        residual_norm_reduction::make_residual_norm_reduction(
             dense_tau, starting_tau_.get(), parameters_.reduction_factor,
             stoppingId, setFinalized, stop_status, &this->device_storage_,
             &all_converged, one_changed));

--- a/cuda/preconditioner/jacobi_kernels.cu
+++ b/cuda/preconditioner/jacobi_kernels.cu
@@ -58,7 +58,7 @@ namespace cuda {
  * A compile-time list of block sizes for which dedicated generate and apply
  * kernels should be compiled.
  */
-using compiled_kernels = syn::compile_int_list<1, 13, 16, 32>;
+using compiled_kernels = syn::value_list<int, 1, 13, 16, 32>;
 
 
 namespace {
@@ -334,7 +334,7 @@ constexpr int get_larger_power(int value, int guess = 1)
 
 template <int warps_per_block, int max_block_size, typename ValueType,
           typename IndexType>
-void generate(syn::compile_int_list<max_block_size>,
+void generate(syn::value_list<int, max_block_size>,
               const matrix::Csr<ValueType, IndexType> *mtx,
               remove_complex<ValueType> accuracy, ValueType *block_data,
               const preconditioner::block_interleaved_storage_scheme<IndexType>
@@ -373,7 +373,7 @@ GKO_ENABLE_IMPLEMENTATION_SELECTION(select_generate, generate);
 
 template <int warps_per_block, int max_block_size, typename ValueType,
           typename IndexType>
-void apply(syn::compile_int_list<max_block_size>, size_type num_blocks,
+void apply(syn::value_list<int, max_block_size>, size_type num_blocks,
            const precision_reduction *block_precisions,
            const IndexType *block_pointers, const ValueType *blocks,
            const preconditioner::block_interleaved_storage_scheme<IndexType>
@@ -610,8 +610,8 @@ void generate(std::shared_ptr<const CudaExecutor> exec,
                     [&](int compiled_block_size) {
                         return max_block_size <= compiled_block_size;
                     },
-                    syn::compile_int_list<cuda_config::min_warps_per_block>(),
-                    syn::compile_type_list<>(), system_matrix, accuracy,
+                    syn::value_list<int, cuda_config::min_warps_per_block>(),
+                    syn::type_list<>(), system_matrix, accuracy,
                     blocks.get_data(), storage_scheme, conditioning.get_data(),
                     block_precisions.get_data(),
                     block_pointers.get_const_data(), num_blocks);
@@ -662,8 +662,8 @@ void simple_apply(
                      [&](int compiled_block_size) {
                          return max_block_size <= compiled_block_size;
                      },
-                     syn::compile_int_list<cuda_config::min_warps_per_block>(),
-                     syn::compile_type_list<>(), num_blocks,
+                     syn::value_list<int, cuda_config::min_warps_per_block>(),
+                     syn::type_list<>(), num_blocks,
                      block_precisions.get_const_data(),
                      block_pointers.get_const_data(), blocks.get_const_data(),
                      storage_scheme, b->get_const_values() + col,

--- a/include/ginkgo/core/base/types.hpp
+++ b/include/ginkgo/core/base/types.hpp
@@ -381,12 +381,13 @@ GKO_ATTRIBUTES constexpr bool operator!=(precision_reduction x,
  * -   the second one with the executor short name (used for namespace name)
  *
  * @param _enable_macro  macro name which will be called
+ * @param ...  extra parameters passed to _enable_macro
  *
  * @note  the macro is not called for ReferenceExecutor
  */
-#define GKO_ENABLE_FOR_ALL_EXECUTORS(_enable_macro) \
-    _enable_macro(OmpExecutor, omp);                \
-    _enable_macro(CudaExecutor, cuda)
+#define GKO_ENABLE_FOR_ALL_EXECUTORS(_enable_macro, ...) \
+    _enable_macro(OmpExecutor, omp, __VA_ARGS__);        \
+    _enable_macro(CudaExecutor, cuda, __VA_ARGS__)
 
 
 /**

--- a/include/ginkgo/ginkgo.hpp
+++ b/include/ginkgo/ginkgo.hpp
@@ -83,5 +83,6 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <ginkgo/core/stop/stopping_status.hpp>
 #include <ginkgo/core/stop/time.hpp>
 
+#include <ginkgo/core/synthesizer/containers.hpp>
 
 #endif  // GKO_GINKGO_HPP_


### PR DESCRIPTION
This PR improves the implementation of `GKO_REGISTER_OPERATION`:

### Overloaded kernel and kernel template support

`GKO_REGISTER_OPERATION` now natively supports overloaded kernels and kernel templates, so there is no longer a need for workarounds such as:

```c++
template <typename... Ts>
struct Wrapper {
    GKO_REGISTER_OPERATION(foo, foo_kernel<Ts...>);
};

// usage
exec->run(Wrapper<ValueType, IndexType>::make_foo_operation(arguments...));
```

This code can now be replaced with:

```c++
GKO_REGISTER_OPERATION(foo, foo_kernel);

// usage
exec->run(make_foo(arguments...));
```

I've replaced such constructs throughout the code.

Since overloads are supported, this also means that instead of having separate names for kernels that do the same thing, but for different parameters, it's possible to register just one overloaded kernel instead. For example, the `simple_apply`, `advanced_apply` combination can be replace with an overloaded `apply`:

Old:
```c++
GKO_REGISTER_OPERATION(simple_apply, simple_apply_kernel);
GKO_REGISTER_OPERATION(advanced_apply, advanced_apply_lernel);

// usage
exec->run(make_simple_apply_operation(b, x));
exec->run(make_advanced_apply_operation(alpha, b, beta, x));
```

New:
```c++
GKO_REGISTER_OPERATION(apply, apply_kernel);

// usage
exec->run(make_apply(b, x));
exec->run(make_apply(alpha, b, beta, x));
```

I did **not** go through the entire code and change the kernel and operation names as part of this PR.

### Simpler implementation of the parameter counter

In the new implementation the kernel call is no longer nested inside a recursive implementation of the parameter counter. While these recursive calls are optimized away by the compiler when built in the release mode, they are still annoying when debugging, as the backtrace will list a whole bunch of useless stack frames on the boundary between Ginkgo core and the kernels (linear in the number of parameters of the kernel). In the new implementation, there are always only two such stack frames.

### Shorter naming scheme

The previous implementation was generating an operation called `<operation-name>_operation` and a helper function `make_<operation-name>_operation`. Since that latter was a bit long and redundant, it was now changed to simply `make_<operation-name>`.

### `get_name()` method

The `Operation` class got a new virtual method `get_name()` that can be overridden to provide a custom name to operations - which can then be used during logging to keep track of certain operations of interest. The default behavior is to use the name demangling API to return the name of the dynamic type of the operation. Operations created through `GKO_REGISTER_OPERATION` override that behavior and use the name of the kernel (2nd parameter of `GKO_REGISTER_OPERATION`) followed by a hash (`#`), followed by the number of parameters passed to the operation. I think this is a reasonable heuristic that should filter out most operations, while avoiding long names returned by name demangling.