### PR TITLE
Extract common utilities from benchmarks

### DIFF
--- a/benchmark/matrix_generator/matrix_generator.cpp
+++ b/benchmark/matrix_generator/matrix_generator.cpp
@@ -37,42 +37,13 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <cmath>
 #include <fstream>
 #include <iostream>
-#include <map>
-#include <random>
-#include <vector>
 
 
-#include <gflags/gflags.h>
-#include <rapidjson/document.h>
-#include <rapidjson/istreamwrapper.h>
-#include <rapidjson/ostreamwrapper.h>
-#include <rapidjson/prettywriter.h>
+#include "benchmark/utils/general.hpp"
 
 
 // some Ginkgo shortcuts
-using vector = gko::matrix::Dense<>;
-
-
-// helper for writing out rapidjson Values
-std::ostream &operator<<(std::ostream &os, const rapidjson::Value &value)
-{
-    rapidjson::OStreamWrapper jos(os);
-    rapidjson::PrettyWriter<rapidjson::OStreamWrapper> writer(jos);
-    value.Accept(writer);
-    return os;
-}
-
-
-// helper for splitting a comma-separated list into vector of strings
-std::vector<std::string> split(const std::string &s, char delimiter)
-{
-    std::istringstream iss(s);
-    std::vector<std::string> tokens;
-    for (std::string token; std::getline(iss, token, delimiter);
-         tokens.push_back(token))
-        ;
-    return tokens;
-}
+using etype = double;
 
 
 namespace {
@@ -121,10 +92,6 @@ void validate_option_object(const rapidjson::Value &value)
 }
 
 
-// Command-line arguments
-DEFINE_uint32(seed, 42, "Seed used to generate the values of random matrices");
-
-
 void initialize_argument_parsing(int *argc, char **argv[])
 {
     std::ostringstream doc;
@@ -143,12 +110,12 @@ void initialize_argument_parsing(int *argc, char **argv[])
 
 
 using generator_function =
-    std::function<gko::matrix_data<>(rapidjson::Value &, std::ranlux24 &)>;
+    std::function<gko::matrix_data<etype>(rapidjson::Value &, std::ranlux24 &)>;
 
 
 // matrix generators
-gko::matrix_data<> generate_block_diagonal(rapidjson::Value &config,
-                                           std::ranlux24 &engine)
+gko::matrix_data<etype> generate_block_diagonal(rapidjson::Value &config,
+                                                std::ranlux24 &engine)
 {
     if (!config.HasMember("num_blocks") || !config["num_blocks"].IsUint() ||
         !config.HasMember("block_size") || !config["block_size"].IsUint()) {
@@ -156,10 +123,10 @@ gko::matrix_data<> generate_block_diagonal(rapidjson::Value &config,
     }
     auto num_blocks = config["num_blocks"].GetUint();
     auto block_size = config["block_size"].GetUint();
-    auto block =
-        gko::matrix_data<>(gko::dim<2>(block_size),
-                           std::uniform_real_distribution<>(-1.0, 1.0), engine);
-    return gko::matrix_data<>::diag(num_blocks, block);
+    auto block = gko::matrix_data<etype>(
+        gko::dim<2>(block_size), std::uniform_real_distribution<>(-1.0, 1.0),
+        engine);
+    return gko::matrix_data<etype>::diag(num_blocks, block);
 }
 
 
@@ -174,7 +141,7 @@ int main(int argc, char *argv[])
 
     std::clog << gko::version_info::get() << std::endl;
 
-    std::ranlux24 engine(FLAGS_seed);
+    auto engine = get_engine();
     rapidjson::IStreamWrapper jcin(std::cin);
     rapidjson::Document configurations;
     configurations.ParseStream(jcin);

--- a/benchmark/matrix_statistics/matrix_statistics.cpp
+++ b/benchmark/matrix_statistics/matrix_statistics.cpp
@@ -38,57 +38,13 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <fstream>
 #include <iostream>
 #include <stdexcept>
-#include <vector>
 
 
-#include <gflags/gflags.h>
-#include <rapidjson/document.h>
-#include <rapidjson/istreamwrapper.h>
-#include <rapidjson/ostreamwrapper.h>
-#include <rapidjson/prettywriter.h>
+#include "benchmark/utils/general.hpp"
 
 
 // some Ginkgo shortcuts
-using vector = gko::matrix::Dense<>;
-
-
-// helper for writing out rapidjson Values
-std::ostream &operator<<(std::ostream &os, const rapidjson::Value &value)
-{
-    rapidjson::OStreamWrapper jos(os);
-    rapidjson::PrettyWriter<rapidjson::OStreamWrapper> writer(jos);
-    if (!value.Accept(writer)) {
-        throw std::runtime_error("Error writing data");
-    }
-    return os;
-}
-
-
-// helper for setting rapidjson object members
-template <typename T, typename NameType, typename Allocator>
-void add_or_set_member(rapidjson::Value &object, NameType &&name, T &&value,
-                       Allocator &&allocator)
-{
-    if (object.HasMember(name)) {
-        object[name] = std::forward<T>(value);
-    } else {
-        object.AddMember(rapidjson::Value::StringRefType(name),
-                         std::forward<T>(value),
-                         std::forward<Allocator>(allocator));
-    }
-}
-
-
-// helper for splitting a comma-separated list into vector of strings
-std::vector<std::string> split(const std::string &s, char delimiter)
-{
-    std::istringstream iss(s);
-    std::vector<std::string> tokens;
-    for (std::string token; std::getline(iss, token, delimiter);
-         tokens.push_back(token))
-        ;
-    return tokens;
-}
+using etype = double;
 
 
 // input validation
@@ -111,18 +67,6 @@ void validate_option_object(const rapidjson::Value &value)
     }
 }
 
-
-// Command-line arguments
-
-DEFINE_string(backup, "",
-              "If set, the value is used as a file path of a backup"
-              " file where results are written after each test");
-
-DEFINE_string(double_buffer, "",
-              "If --backup is set, this variable can be set"
-              " to nonempty string to enable double"
-              " buffering of backup files, in case of a"
-              " crash when overwriting the backup");
 
 void initialize_argument_parsing(int *argc, char **argv[])
 {
@@ -152,30 +96,11 @@ void initialize_argument_parsing(int *argc, char **argv[])
 }
 
 
-// backup generation
-void backup_results(rapidjson::Document &results)
-{
-    static int next = 0;
-    static auto filenames = []() -> std::array<std::string, 2> {
-        if (FLAGS_double_buffer.size() > 0) {
-            return {FLAGS_backup, FLAGS_double_buffer};
-        } else {
-            return {FLAGS_backup, FLAGS_backup};
-        }
-    }();
-    if (FLAGS_backup.size() == 0) {
-        return;
-    }
-    std::ofstream ofs(filenames[next]);
-    ofs << results;
-    next = 1 - next;
-}
-
 // See en.wikipedia.org/wiki/Five-number_summary
 // Quartile computation uses Method 3 from en.wikipedia.org/wiki/Quartile
-template <typename Allocator>
 void compute_summary(const std::vector<gko::size_type> &dist,
-                     rapidjson::Value &out, Allocator &allocator)
+                     rapidjson::Value &out,
+                     rapidjson::MemoryPoolAllocator<> &allocator)
 {
     const auto q = dist.size() / 4;
     const auto r = dist.size() % 4;
@@ -226,9 +151,9 @@ double compute_moment(int degree, const std::vector<gko::size_type> &dist,
 
 
 // See en.wikipedia.org/wiki/Moment_(mathematics)
-template <typename Allocator>
 void compute_moments(const std::vector<gko::size_type> &dist,
-                     rapidjson::Value &out, Allocator &allocator)
+                     rapidjson::Value &out,
+                     rapidjson::MemoryPoolAllocator<> &allocator)
 {
     const auto mean = compute_moment(1, dist);
     add_or_set_member(out, "mean", mean, allocator);
@@ -257,7 +182,7 @@ void compute_distribution_properties(const std::vector<gko::size_type> &dist,
 
 
 template <typename Allocator>
-void extract_matrix_statistics(gko::matrix_data<double, gko::int64> &data,
+void extract_matrix_statistics(gko::matrix_data<etype, gko::int64> &data,
                                rapidjson::Value &problem, Allocator &allocator)
 {
     std::vector<gko::size_type> row_dist(data.size[0]);
@@ -309,7 +234,7 @@ int main(int argc, char *argv[])
             std::clog << "Running test case: " << test_case << std::endl;
 
             std::ifstream ifs(test_case["filename"].GetString());
-            auto matrix = gko::read_raw<double, gko::int64>(ifs);
+            auto matrix = gko::read_raw<etype, gko::int64>(ifs);
             ifs.close();
 
             std::clog << "Matrix is of size (" << matrix.size[0] << ", "

--- a/benchmark/utils/general.hpp
+++ b/benchmark/utils/general.hpp
@@ -1,0 +1,240 @@
+/*******************************<GINKGO LICENSE>******************************
+Copyright 2017-2018
+
+Karlsruhe Institute of Technology
+Universitat Jaume I
+University of Tennessee
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice,
+   this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors
+   may be used to endorse or promote products derived from this software
+   without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+******************************<GINKGO LICENSE>*******************************/
+
+#ifndef GKO_BENCHMARK_UTILS_GENERAL_HPP_
+#define GKO_BENCHMARK_UTILS_GENERAL_HPP_
+
+
+#include <array>
+#include <functional>
+#include <map>
+#include <ostream>
+#include <random>
+#include <sstream>
+#include <string>
+#include <utility>
+#include <vector>
+
+
+#include <gflags/gflags.h>
+#include <rapidjson/document.h>
+#include <rapidjson/istreamwrapper.h>
+#include <rapidjson/ostreamwrapper.h>
+#include <rapidjson/prettywriter.h>
+
+
+// Global command-line arguments
+DEFINE_string(
+    executor, "reference",
+    "The executor used to run the benchmarks, one of: reference, omp, cuda");
+
+DEFINE_uint32(device_id, 0, "ID of the device where to run the code");
+
+DEFINE_bool(overwrite, false,
+            "If true, overwrites existing results with new ones");
+
+DEFINE_string(backup, "",
+              "If set, the value is used as a file path of a backup"
+              " file where results are written after each test");
+
+DEFINE_string(double_buffer, "",
+              "If --backup is set, this variable can be set"
+              " to a nonempty string to enable double"
+              " buffering of backup files, in case of a"
+              " crash when overwriting the backup");
+
+DEFINE_bool(detailed, true,
+            "If set, performs several runs to obtain more detailed results");
+
+DEFINE_uint32(seed, 42, "Seed used for the random number generator");
+
+DEFINE_uint32(warmup, 2, "Warm-up repetitions");
+
+DEFINE_uint32(repetitions, 10,
+              "Number of runs used to obtain an averaged result.");
+
+
+// Returns a random number engine
+std::ranlux24 &get_engine()
+{
+    static std::ranlux24 engine(FLAGS_seed);
+    return engine;
+};
+
+
+// helper for writing out rapidjson Values
+std::ostream &operator<<(std::ostream &os, const rapidjson::Value &value)
+{
+    rapidjson::OStreamWrapper jos(os);
+    rapidjson::PrettyWriter<rapidjson::OStreamWrapper> writer(jos);
+    value.Accept(writer);
+    return os;
+}
+
+
+// helper for setting rapidjson object members
+template <typename T, typename NameType, typename Allocator>
+void add_or_set_member(rapidjson::Value &object, NameType &&name, T &&value,
+                       Allocator &&allocator)
+{
+    if (object.HasMember(name)) {
+        object[name] = std::forward<T>(value);
+    } else {
+        auto n = rapidjson::Value(name, allocator);
+        object.AddMember(n, std::forward<T>(value), allocator);
+    }
+}
+
+
+// helper for splitting a comma-separated list into vector of strings
+std::vector<std::string> split(const std::string &s, char delimiter)
+{
+    std::istringstream iss(s);
+    std::vector<std::string> tokens;
+    for (std::string token; std::getline(iss, token, delimiter);
+         tokens.push_back(token))
+        ;
+    return tokens;
+}
+
+
+// backup generation
+void backup_results(rapidjson::Document &results)
+{
+    static int next = 0;
+    static auto filenames = []() -> std::array<std::string, 2> {
+        if (FLAGS_double_buffer.size() > 0) {
+            return {FLAGS_backup, FLAGS_double_buffer};
+        } else {
+            return {FLAGS_backup, FLAGS_backup};
+        }
+    }();
+    if (FLAGS_backup.size() == 0) {
+        return;
+    }
+    std::ofstream ofs(filenames[next]);
+    ofs << results;
+    next = 1 - next;
+}
+
+
+// executor mapping
+const std::map<std::string, std::function<std::shared_ptr<gko::Executor>()>>
+    executor_factory{
+        {"reference", [] { return gko::ReferenceExecutor::create(); }},
+        {"omp", [] { return gko::OmpExecutor::create(); }},
+        {"cuda", [] {
+             return gko::CudaExecutor::create(FLAGS_device_id,
+                                              gko::OmpExecutor::create());
+         }}};
+
+
+// returns the appropriate executor, as set by the executor flag
+std::shared_ptr<const gko::Executor> get_executor()
+{
+    static auto exec = executor_factory.at(FLAGS_executor)();
+    return exec;
+}
+
+
+// ginkgo shortcuts
+template <typename ValueType>
+using vec = gko::matrix::Dense<ValueType>;
+
+
+// creates a zero vector
+template <typename ValueType>
+std::unique_ptr<vec<ValueType>> create_vector(
+    std::shared_ptr<const gko::Executor> exec, gko::size_type size)
+{
+    auto res = vec<ValueType>::create(exec);
+    res->read(gko::matrix_data<ValueType>(gko::dim<2>{size, 1}));
+    return res;
+}
+
+
+// creates a random matrix
+template <typename ValueType, typename RandomEngine>
+std::unique_ptr<vec<ValueType>> create_matrix(
+    std::shared_ptr<const gko::Executor> exec, gko::dim<2> size,
+    RandomEngine &engine)
+{
+    auto res = vec<ValueType>::create(exec);
+    res->read(gko::matrix_data<ValueType>(
+        size, std::uniform_real_distribution<>(-1.0, 1.0), engine));
+    return res;
+}
+
+
+// creates a random vector
+template <typename ValueType, typename RandomEngine>
+std::unique_ptr<vec<ValueType>> create_vector(
+    std::shared_ptr<const gko::Executor> exec, gko::size_type size,
+    RandomEngine &engine)
+{
+    return create_matrix<ValueType>(exec, gko::dim<2>{size, 1}, engine);
+}
+
+
+// utilities for computing norms and residuals
+template <typename ValueType>
+double get_norm(const vec<ValueType> *norm)
+{
+    return clone(norm->get_executor()->get_master(), norm)->at(0, 0);
+}
+
+
+template <typename ValueType>
+double compute_norm(const vec<ValueType> *b)
+{
+    auto exec = b->get_executor();
+    auto b_norm = gko::initialize<vec<ValueType>>({0.0}, exec);
+    b->compute_norm2(lend(b_norm));
+    return get_norm(lend(b_norm));
+}
+
+
+template <typename ValueType>
+double compute_residual_norm(const gko::LinOp *system_matrix,
+                             const vec<ValueType> *b, const vec<ValueType> *x)
+{
+    auto exec = system_matrix->get_executor();
+    auto one = gko::initialize<vec<ValueType>>({1.0}, exec);
+    auto neg_one = gko::initialize<vec<ValueType>>({-1.0}, exec);
+    auto res = clone(b);
+    system_matrix->apply(lend(one), lend(x), lend(neg_one), lend(res));
+    return compute_norm(lend(res));
+}
+
+
+#endif  // GKO_BENCHMARK_UTILS_HPP_

--- a/benchmark/utils/general.hpp
+++ b/benchmark/utils/general.hpp
@@ -116,14 +116,15 @@ void add_or_set_member(rapidjson::Value &object, NameType &&name, T &&value,
 }
 
 
-// helper for splitting a comma-separated list into vector of strings
-std::vector<std::string> split(const std::string &s, char delimiter)
+// helper for splitting a delimiter-separated list into vector of strings
+std::vector<std::string> split(const std::string &s, char delimiter = ',')
 {
     std::istringstream iss(s);
     std::vector<std::string> tokens;
-    for (std::string token; std::getline(iss, token, delimiter);
-         tokens.push_back(token))
-        ;
+    std::string token;
+    while (std::getline(iss, token, delimiter)) {
+        tokens.push_back(token);
+    }
     return tokens;
 }
 

--- a/benchmark/utils/loggers.hpp
+++ b/benchmark/utils/loggers.hpp
@@ -1,0 +1,185 @@
+/*******************************<GINKGO LICENSE>******************************
+Copyright 2017-2018
+
+Karlsruhe Institute of Technology
+Universitat Jaume I
+University of Tennessee
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice,
+   this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors
+   may be used to endorse or promote products derived from this software
+   without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+******************************<GINKGO LICENSE>*******************************/
+
+#ifndef GKO_BENCHMARK_UTILS_LOGGERS_HPP_
+#define GKO_BENCHMARK_UTILS_LOGGERS_HPP_
+
+
+#include <ginkgo/ginkgo.hpp>
+
+
+#include <chrono>
+#include <regex>
+#include <unordered_map>
+
+
+#include "general.hpp"
+
+
+// A logger that accumulates the time of all operations
+struct OperationLogger : gko::log::Logger {
+    void on_operation_launched(const gko::Executor *exec,
+                               const gko::Operation *op) const override
+    {
+        const auto name = extract_operation_name(op);
+        exec->synchronize();
+        start[name] = std::chrono::system_clock::now();
+    }
+
+    void on_operation_completed(const gko::Executor *exec,
+                                const gko::Operation *op) const override
+    {
+        exec->synchronize();
+        const auto end = std::chrono::system_clock::now();
+
+        const auto name = extract_operation_name(op);
+        total[name] += end - start[name];
+    }
+
+    void write_data(rapidjson::Value &object,
+                    rapidjson::MemoryPoolAllocator<> &alloc,
+                    gko::uint32 repetitions)
+    {
+        for (const auto &entry : total) {
+            add_or_set_member(
+                object, entry.first.c_str(),
+                std::chrono::duration_cast<std::chrono::nanoseconds>(
+                    entry.second)
+                        .count() /
+                    repetitions,
+                alloc);
+        }
+    }
+
+    OperationLogger(std::shared_ptr<const gko::Executor> exec)
+        : gko::log::Logger(exec)
+    {}
+
+private:
+    static std::string extract_operation_name(const gko::Operation *op)
+    {
+        auto full_name = gko::name_demangling::get_dynamic_type(*op);
+        std::smatch match{};
+        if (regex_match(full_name, match, std::regex(".*::(.*)_operation.*"))) {
+            return match[1];
+        } else {
+            return full_name;
+        }
+    }
+
+    mutable std::map<std::string, std::chrono::system_clock::time_point> start;
+    mutable std::map<std::string, std::chrono::system_clock::duration> total;
+};
+
+
+struct StorageLogger : gko::log::Logger {
+    void on_allocation_completed(const gko::Executor *,
+                                 const gko::size_type &num_bytes,
+                                 const gko::uintptr &location) const override
+    {
+        storage[location] = num_bytes;
+    }
+
+    void on_free_completed(const gko::Executor *,
+                           const gko::uintptr &location) const override
+    {
+        storage[location] = 0;
+    }
+
+    void write_data(rapidjson::Value &output,
+                    rapidjson::MemoryPoolAllocator<> &allocator)
+    {
+        gko::size_type total{};
+        for (const auto &e : storage) {
+            total += e.second;
+        }
+        add_or_set_member(output, "storage", total, allocator);
+    }
+
+    StorageLogger(std::shared_ptr<const gko::Executor> exec)
+        : gko::log::Logger(exec)
+    {}
+
+private:
+    mutable std::unordered_map<gko::uintptr, gko::size_type> storage;
+};
+
+
+// Logs true and recurrent residuals of the solver
+template <typename ValueType>
+struct ResidualLogger : gko::log::Logger {
+    void on_iteration_complete(const gko::LinOp *, const gko::size_type &,
+                               const gko::LinOp *residual,
+                               const gko::LinOp *solution,
+                               const gko::LinOp *residual_norm) const override
+    {
+        if (residual_norm) {
+            rec_res_norms.PushBack(
+                get_norm(gko::as<vec<ValueType>>(residual_norm)), alloc);
+        } else {
+            rec_res_norms.PushBack(
+                compute_norm(gko::as<vec<ValueType>>(residual)), alloc);
+        }
+        if (solution) {
+            true_res_norms.PushBack(
+                compute_residual_norm(matrix, b,
+                                      gko::as<vec<ValueType>>(solution)),
+                alloc);
+        } else {
+            true_res_norms.PushBack(-1.0, alloc);
+        }
+    }
+
+    ResidualLogger(std::shared_ptr<const gko::Executor> exec,
+                   const gko::LinOp *matrix, const vec<ValueType> *b,
+                   rapidjson::Value &rec_res_norms,
+                   rapidjson::Value &true_res_norms,
+                   rapidjson::MemoryPoolAllocator<> &alloc)
+        : gko::log::Logger(exec, gko::log::Logger::iteration_complete_mask),
+          matrix{matrix},
+          b{b},
+          rec_res_norms{rec_res_norms},
+          true_res_norms{true_res_norms},
+          alloc{alloc}
+    {}
+
+private:
+    const gko::LinOp *matrix;
+    const vec<ValueType> *b;
+    rapidjson::Value &rec_res_norms;
+    rapidjson::Value &true_res_norms;
+    rapidjson::MemoryPoolAllocator<> &alloc;
+};
+
+
+#endif  // GKO_BENCHMARK_UTILS_LOGGERS_HPP_


### PR DESCRIPTION
This PR extract the reusable parts of benchmarks into utility headers to remove the amount of code that has to be duplicated.