### PR TITLE
Preconditionable interface

### DIFF
--- a/include/ginkgo/core/base/lin_op.hpp
+++ b/include/ginkgo/core/base/lin_op.hpp
@@ -447,6 +447,22 @@ public:
 
 
 /**
+ * A LinOp implementing this interface can be preconditioned.
+ */
+class Preconditionable {
+public:
+    virtual ~Preconditionable() = default;
+
+    /**
+     * Returns the preconditioner operator used by the Preconditionable.
+     *
+     * @return the preconditioner operator used by the Preconditionable
+     */
+    virtual std::shared_ptr<const LinOp> get_preconditioner() const = 0;
+};
+
+
+/**
  * The EnableLinOp mixin can be used to provide sensible default implementations
  * of the majority of the LinOp and PolymorphicObject interface.
  *

--- a/include/ginkgo/core/solver/bicgstab.hpp
+++ b/include/ginkgo/core/solver/bicgstab.hpp
@@ -64,7 +64,8 @@ namespace solver {
  * @tparam ValueType precision of the elements of the system matrix.
  */
 template <typename ValueType = default_precision>
-class Bicgstab : public EnableLinOp<Bicgstab<ValueType>> {
+class Bicgstab : public EnableLinOp<Bicgstab<ValueType>>,
+                 public Preconditionable {
     friend class EnableLinOp<Bicgstab>;
     friend class EnablePolymorphicObject<Bicgstab, LinOp>;
 
@@ -86,7 +87,7 @@ public:
      *
      * @return the preconditioner operator used by the solver
      */
-    std::shared_ptr<const LinOp> get_preconditioner() const
+    std::shared_ptr<const LinOp> get_preconditioner() const override
     {
         return preconditioner_;
     }

--- a/include/ginkgo/core/solver/cg.hpp
+++ b/include/ginkgo/core/solver/cg.hpp
@@ -66,7 +66,7 @@ namespace solver {
  * @tparam ValueType  precision of matrix elements
  */
 template <typename ValueType = default_precision>
-class Cg : public EnableLinOp<Cg<ValueType>> {
+class Cg : public EnableLinOp<Cg<ValueType>>, public Preconditionable {
     friend class EnableLinOp<Cg>;
     friend class EnablePolymorphicObject<Cg, LinOp>;
 
@@ -88,7 +88,7 @@ public:
      *
      * @return the preconditioner operator used by the solver
      */
-    std::shared_ptr<const LinOp> get_preconditioner() const
+    std::shared_ptr<const LinOp> get_preconditioner() const override
     {
         return preconditioner_;
     }

--- a/include/ginkgo/core/solver/cgs.hpp
+++ b/include/ginkgo/core/solver/cgs.hpp
@@ -63,7 +63,7 @@ namespace solver {
  * @tparam ValueType precision of matrix elements
  */
 template <typename ValueType = default_precision>
-class Cgs : public EnableLinOp<Cgs<ValueType>> {
+class Cgs : public EnableLinOp<Cgs<ValueType>>, public Preconditionable {
     friend class EnableLinOp<Cgs>;
     friend class EnablePolymorphicObject<Cgs, LinOp>;
 
@@ -85,7 +85,7 @@ public:
      *
      * @return the preconditioner operator used by the solver
      */
-    std::shared_ptr<const LinOp> get_preconditioner() const
+    std::shared_ptr<const LinOp> get_preconditioner() const override
     {
         return preconditioner_;
     }

--- a/include/ginkgo/core/solver/fcg.hpp
+++ b/include/ginkgo/core/solver/fcg.hpp
@@ -71,7 +71,7 @@ namespace solver {
  * @tparam ValueType precision of matrix elements
  */
 template <typename ValueType = default_precision>
-class Fcg : public EnableLinOp<Fcg<ValueType>> {
+class Fcg : public EnableLinOp<Fcg<ValueType>>, public Preconditionable {
     friend class EnableLinOp<Fcg>;
     friend class EnablePolymorphicObject<Fcg, LinOp>;
 
@@ -93,7 +93,7 @@ public:
      *
      * @return the preconditioner operator used by the solver
      */
-    std::shared_ptr<const LinOp> get_preconditioner() const
+    std::shared_ptr<const LinOp> get_preconditioner() const override
     {
         return preconditioner_;
     }

--- a/include/ginkgo/core/solver/gmres.hpp
+++ b/include/ginkgo/core/solver/gmres.hpp
@@ -66,14 +66,11 @@ constexpr size_type default_krylov_dim = 100u;
  * @tparam ValueType  precision of matrix elements
  */
 template <typename ValueType = default_precision>
-class Gmres : public EnableLinOp<Gmres<ValueType>>,
-              public log::EnableLogging<Gmres<ValueType>> {
+class Gmres : public EnableLinOp<Gmres<ValueType>>, public Preconditionable {
     friend class EnableLinOp<Gmres>;
     friend class EnablePolymorphicObject<Gmres, LinOp>;
 
 public:
-    using log::EnableLogging<Gmres<ValueType>>::log;
-    using log::EnableLogging<Gmres<ValueType>>::add_logger;
     using value_type = ValueType;
 
     /**
@@ -91,7 +88,7 @@ public:
      *
      * @return the preconditioner operator used by the solver
      */
-    std::shared_ptr<const LinOp> get_preconditioner() const
+    std::shared_ptr<const LinOp> get_preconditioner() const override
     {
         return preconditioner_;
     }


### PR DESCRIPTION
This PR adds a `Preconditionable` interface which allows querying if a `LinOp` is something that can be preconditioned, and if it is, the preconditioner can be obtained via the `get_preconditioner()` method.

This allows us to get the preconditioner of a solver without knowing its concrete class by trying to cast in to `Preconditionable`, instead of having to try all the solvers (with all template parameters) in the library - something that will be useful for extended solver benchmark which needs to extract information about preconditioners.

I also fixed a small bug in GMRES, so it no longer includes 2 instances of `EnableLogging` (one explicitly, and one through `EnableLinOp`).