### PR TITLE
Improved solver benchmark

### DIFF
--- a/benchmark/matrix_generator/matrix_generator.cpp
+++ b/benchmark/matrix_generator/matrix_generator.cpp
@@ -34,7 +34,8 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <ginkgo/ginkgo.hpp>
 
 
-#include <cmath>
+#include <cstdlib>
+#include <exception>
 #include <fstream>
 #include <iostream>
 
@@ -77,7 +78,7 @@ void print_config_error_and_exit(int code = 1)
 {
     std::cerr << "Input has to be a JSON array of matrix configurations:\n"
               << input_format << std::endl;
-    exit(code);
+    std::exit(code);
 }
 
 

--- a/benchmark/matrix_statistics/matrix_statistics.cpp
+++ b/benchmark/matrix_statistics/matrix_statistics.cpp
@@ -35,9 +35,10 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
 #include <cmath>
+#include <cstdlib>
+#include <exception>
 #include <fstream>
 #include <iostream>
-#include <stdexcept>
 
 
 #include "benchmark/utils/general.hpp"
@@ -55,7 +56,7 @@ void print_config_error_and_exit()
               << "    { \"filename\": \"my_file.mtx\"},\n"
               << "    { \"filename\": \"my_file2.mtx\"}\n"
               << "  ]" << std::endl;
-    exit(1);
+    std::exit(1);
 }
 
 

--- a/benchmark/preconditioner/preconditioner.cpp
+++ b/benchmark/preconditioner/preconditioner.cpp
@@ -301,7 +301,7 @@ int main(int argc, char *argv[])
               << "The random seed for right hand sides is " << FLAGS_seed
               << std::endl;
 
-    auto exec = executor_factory.at(FLAGS_executor)();
+    auto exec = get_executor();
     auto &engine = get_engine();
 
     auto preconditioners = split(FLAGS_preconditioners, ',');

--- a/benchmark/preconditioner/preconditioner.cpp
+++ b/benchmark/preconditioner/preconditioner.cpp
@@ -36,8 +36,12 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <algorithm>
 #include <chrono>
+#include <cstdlib>
+#include <exception>
+#include <fstream>
 #include <iomanip>
 #include <iostream>
+
 
 #include "benchmark/utils/general.hpp"
 #include "benchmark/utils/loggers.hpp"
@@ -99,7 +103,7 @@ void print_config_error_and_exit()
               << "    { \"filename\": \"my_file.mtx\" },\n"
               << "    { \"filename\": \"my_file2.mtx\" }\n"
               << "  ]" << std::endl;
-    exit(1);
+    std::exit(1);
 }
 
 

--- a/benchmark/solver/solver.cpp
+++ b/benchmark/solver/solver.cpp
@@ -223,37 +223,40 @@ void write_precond_info(const gko::LinOp *precond,
                         rapidjson::Value &precond_info,
                         rapidjson::MemoryPoolAllocator<> &allocator)
 {
-    if (auto jacobi =
+    if (const auto jacobi =
             dynamic_cast<const gko::preconditioner::Jacobi<etype> *>(precond)) {
         // extract block sizes
-        auto bdata = jacobi->get_parameters().block_pointers.get_const_data();
+        const auto bdata =
+            jacobi->get_parameters().block_pointers.get_const_data();
         add_or_set_member(precond_info, "block_sizes",
                           rapidjson::Value(rapidjson::kArrayType), allocator);
-        for (auto i = 0u; i < jacobi->get_num_blocks(); ++i) {
+        const auto nblocks = jacobi->get_num_blocks();
+        for (auto i = decltype(nblocks){0}; i < nblocks; ++i) {
             precond_info["block_sizes"].PushBack(bdata[i + 1] - bdata[i],
                                                  allocator);
         }
 
         // extract block precisions
-        auto pdata = jacobi->get_parameters()
-                         .storage_optimization.block_wise.get_const_data();
+        const auto pdata =
+            jacobi->get_parameters()
+                .storage_optimization.block_wise.get_const_data();
         if (pdata) {
             add_or_set_member(precond_info, "block_precisions",
                               rapidjson::Value(rapidjson::kArrayType),
                               allocator);
-            for (auto i = 0u; i < jacobi->get_num_blocks(); ++i) {
+            for (auto i = decltype(nblocks){0}; i < nblocks; ++i) {
                 precond_info["block_precisions"].PushBack(
                     static_cast<int>(pdata[i]), allocator);
             }
         }
 
         // extract condition numbers
-        auto cdata = jacobi->get_conditioning();
+        const auto cdata = jacobi->get_conditioning();
         if (cdata) {
             add_or_set_member(precond_info, "block_conditioning",
                               rapidjson::Value(rapidjson::kArrayType),
                               allocator);
-            for (auto i = 0u; i < jacobi->get_num_blocks(); ++i) {
+            for (auto i = decltype(nblocks){0}; i < nblocks; ++i) {
                 precond_info["block_conditioning"].PushBack(cdata[i],
                                                             allocator);
             }

--- a/benchmark/solver/solver.cpp
+++ b/benchmark/solver/solver.cpp
@@ -36,6 +36,9 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <algorithm>
 #include <chrono>
+#include <cstdlib>
+#include <exception>
+#include <fstream>
 #include <iomanip>
 #include <iostream>
 
@@ -104,7 +107,7 @@ void print_config_error_and_exit()
               << "    { \"filename\": \"my_file2.mtx\", \"optimal\": { "
                  "\"spmv\": \"<matrix format>\" } }\n"
               << "  ]" << std::endl;
-    exit(1);
+    std::exit(1);
 }
 
 

--- a/benchmark/spmv/spmv.cpp
+++ b/benchmark/spmv/spmv.cpp
@@ -31,12 +31,12 @@ ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ******************************<GINKGO LICENSE>*******************************/
 
-
 #include <ginkgo/ginkgo.hpp>
 
 
 #include <algorithm>
 #include <chrono>
+#include <cstdlib>
 #include <exception>
 #include <fstream>
 #include <iomanip>
@@ -60,7 +60,7 @@ void print_config_error_and_exit()
               << "[\n    { \"filename\": \"my_file.mtx\"},"
               << "\n    { \"filename\": \"my_file2.mtx\"}"
               << "\n]" << std::endl;
-    exit(1);
+    std::exit(1);
 }
 
 

--- a/benchmark/utils/general.hpp
+++ b/benchmark/utils/general.hpp
@@ -35,7 +35,11 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define GKO_BENCHMARK_UTILS_GENERAL_HPP_
 
 
+#include <ginkgo/ginkgo.hpp>
+
+
 #include <array>
+#include <fstream>
 #include <functional>
 #include <map>
 #include <ostream>

--- a/benchmark/utils/general.hpp
+++ b/benchmark/utils/general.hpp
@@ -161,7 +161,7 @@ const std::map<std::string, std::function<std::shared_ptr<gko::Executor>()>>
 
 
 // returns the appropriate executor, as set by the executor flag
-std::shared_ptr<const gko::Executor> get_executor()
+std::shared_ptr<gko::Executor> get_executor()
 {
     static auto exec = executor_factory.at(FLAGS_executor)();
     return exec;

--- a/benchmark/utils/loggers.hpp
+++ b/benchmark/utils/loggers.hpp
@@ -43,7 +43,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <unordered_map>
 
 
-#include "general.hpp"
+#include "benchmark/utils/general.hpp"
 
 
 // A logger that accumulates the time of all operations
@@ -51,7 +51,7 @@ struct OperationLogger : gko::log::Logger {
     void on_operation_launched(const gko::Executor *exec,
                                const gko::Operation *op) const override
     {
-        const auto name = extract_operation_name(op);
+        const auto name = op->get_name();
         exec->synchronize();
         start[name] = std::chrono::system_clock::now();
     }
@@ -62,7 +62,7 @@ struct OperationLogger : gko::log::Logger {
         exec->synchronize();
         const auto end = std::chrono::system_clock::now();
 
-        const auto name = extract_operation_name(op);
+        const auto name = op->get_name();
         total[name] += end - start[name];
     }
 
@@ -86,17 +86,6 @@ struct OperationLogger : gko::log::Logger {
     {}
 
 private:
-    static std::string extract_operation_name(const gko::Operation *op)
-    {
-        auto full_name = gko::name_demangling::get_dynamic_type(*op);
-        std::smatch match{};
-        if (regex_match(full_name, match, std::regex(".*::(.*)_operation.*"))) {
-            return match[1];
-        } else {
-            return full_name;
-        }
-    }
-
     mutable std::map<std::string, std::chrono::system_clock::time_point> start;
     mutable std::map<std::string, std::chrono::system_clock::duration> total;
 };

--- a/benchmark/utils/loggers.hpp
+++ b/benchmark/utils/loggers.hpp
@@ -124,6 +124,7 @@ private:
     void start_operation(const gko::Executor *exec,
                          const std::string &name) const
     {
+        nested.emplace_back(0);
         exec->synchronize();
         start[name] = std::chrono::system_clock::now();
     }
@@ -132,11 +133,20 @@ private:
     {
         exec->synchronize();
         const auto end = std::chrono::system_clock::now();
-        total[name] += end - start[name];
+        const auto diff = end - start[name];
+        // make sure timings for nested operations are not counted twice
+        total[name] += diff - nested.back();
+        nested.pop_back();
+        if (nested.size() > 0) {
+            nested.back() += diff;
+        }
     }
 
     mutable std::map<std::string, std::chrono::system_clock::time_point> start;
     mutable std::map<std::string, std::chrono::system_clock::duration> total;
+    // the position i of this vector holds the total time spend on child
+    // operations on nesting level i
+    mutable std::vector<std::chrono::system_clock::duration> nested;
 };
 
 

--- a/benchmark/utils/loggers.hpp
+++ b/benchmark/utils/loggers.hpp
@@ -48,22 +48,57 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 // A logger that accumulates the time of all operations
 struct OperationLogger : gko::log::Logger {
+    void on_allocation_started(const gko::Executor *exec,
+                               const gko::size_type &) const override
+    {
+        this->start_operation(exec, "allocate");
+    }
+
+    void on_allocation_completed(const gko::Executor *exec,
+                                 const gko::size_type &,
+                                 const gko::uintptr &) const override
+    {
+        this->end_operation(exec, "allocate");
+    }
+
+    void on_free_started(const gko::Executor *exec,
+                         const gko::uintptr &) const override
+    {
+        this->start_operation(exec, "free");
+    }
+
+    void on_free_completed(const gko::Executor *exec,
+                           const gko::uintptr &) const override
+    {
+        this->end_operation(exec, "free");
+    }
+
+    void on_copy_started(const gko::Executor *from, const gko::Executor *to,
+                         const gko::uintptr &, const gko::uintptr &,
+                         const gko::size_type &) const override
+    {
+        from->synchronize();
+        this->start_operation(to, "copy");
+    }
+
+    void on_copy_completed(const gko::Executor *from, const gko::Executor *to,
+                           const gko::uintptr &, const gko::uintptr &,
+                           const gko::size_type &) const override
+    {
+        from->synchronize();
+        this->end_operation(to, "copy");
+    }
+
     void on_operation_launched(const gko::Executor *exec,
                                const gko::Operation *op) const override
     {
-        const auto name = op->get_name();
-        exec->synchronize();
-        start[name] = std::chrono::system_clock::now();
+        this->start_operation(exec, op->get_name());
     }
 
     void on_operation_completed(const gko::Executor *exec,
                                 const gko::Operation *op) const override
     {
-        exec->synchronize();
-        const auto end = std::chrono::system_clock::now();
-
-        const auto name = op->get_name();
-        total[name] += end - start[name];
+        this->end_operation(exec, op->get_name());
     }
 
     void write_data(rapidjson::Value &object,
@@ -86,6 +121,20 @@ struct OperationLogger : gko::log::Logger {
     {}
 
 private:
+    void start_operation(const gko::Executor *exec,
+                         const std::string &name) const
+    {
+        exec->synchronize();
+        start[name] = std::chrono::system_clock::now();
+    }
+
+    void end_operation(const gko::Executor *exec, const std::string &name) const
+    {
+        exec->synchronize();
+        const auto end = std::chrono::system_clock::now();
+        total[name] += end - start[name];
+    }
+
     mutable std::map<std::string, std::chrono::system_clock::time_point> start;
     mutable std::map<std::string, std::chrono::system_clock::duration> total;
 };


### PR DESCRIPTION
This PR implements the solver benchmark improvements we discussed last week:

- the _generate_ step is timed separately from the _apply_ step
- during the "slow run" that computes all the residuals, each Ginkgo kernel (more accurately: Operation) is timed separately
- in addition to kernels, memory operations (allocation, copy, free) are also timed
- the component logger is implemented in a way that correctly handles multiple nested operations (e.g. a kernel launching another kernel internally, or performing a memory allocation/free/copy) by subtracting the timing of the child operations from the parent's timing
- preconditioner metadata is collected; for (adaptive) jacobi this includes the list of block sizes, condition numbers and precisions used for each block

Here is an example output of the new benchmark runner (note that it is a small 15x15 matrix, so block Jacobi only uses 1 block):

<details><summary>Example output</summary>

```json
[
    {
        "filename": "example.mtx",
        "problem": {
            "type": "block-diagonal",
            "num_blocks": 5,
            "block_size": 3
        },
        "spmv": {
            "coo": {
                "storage": 720,
                "time": 6173.2,
                "completed": true
            }
        },
        "optimal": {
            "spmv": "coo"
        },
        "solver": {
            "bicgstab-adaptive-jacobi": {
                "recurrent_residuals": [
                    2.265183747046495,
                    0.0021703988512832936,
                    0.0021703988512832936
                ],
                "true_residuals": [
                    -1.0,
                    0.002170398851283463,
                    -1.0
                ],
                "rhs_norm": 2.265183747046495,
                "generate": {
                    "components": {
                        "allocate": 4513,
                        "copy": 882,
                        "free": 1331,
                        "jacobi::find_blocks#4": 30297,
                        "jacobi::generate#9": 314813,
                        "jacobi::initialize_precisions#2": 11341
                    },
                    "time": 207558
                },
                "apply": {
                    "components": {
                        "allocate": 10820,
                        "bicgstab::finalize#4": 14995,
                        "bicgstab::initialize#16": 62217,
                        "bicgstab::step_1#8": 41325,
                        "bicgstab::step_2#7": 33629,
                        "bicgstab::step_3#11": 32796,
                        "coo::advanced_spmv#5": 37090,
                        "coo::spmv#3": 33909,
                        "copy": 2121,
                        "dense::compute_dot#3": 21188,
                        "dense::compute_norm2#2": 28544,
                        "free": 4939,
                        "jacobi::simple_apply#8": 61203,
                        "residual_norm_reduction::residual_norm_reduction#9": 46816
                    },
                    "time": 286276
                },
                "preconditioner": {
                    "block_sizes": [
                        15
                    ],
                    "block_precisions": [
                        2
                    ],
                    "block_conditioning": [
                        12.197445138496434
                    ]
                },
                "residual_norm": 5.024181677517699e-7,
                "completed": true
            }
        }
    }
]
```

</details>

### TODO:

- [x] merge #185 
- [x] merge #186 
- [x] merge #188 
- [x] rebase this after everything else is merged
