### PR TITLE
Emission of iteration_completed event for final iteration 

### DIFF
--- a/core/solver/bicgstab.cpp
+++ b/core/solver/bicgstab.cpp
@@ -118,6 +118,8 @@ void Bicgstab<ValueType>::apply_impl(const LinOp *b, LinOp *x) const
                 .residual(r.get())
                 .solution(dense_x)
                 .check(RelativeStoppingId, true, &stop_status, &one_changed)) {
+            this->template log<log::Logger::iteration_complete>(
+                this, iter + 1, r.get(), dense_x);
             break;
         }
 
@@ -153,6 +155,8 @@ void Bicgstab<ValueType>::apply_impl(const LinOp *b, LinOp *x) const
         }
 
         if (all_converged) {
+            this->template log<log::Logger::iteration_complete>(
+                this, iter + 1, r.get(), dense_x);
             break;
         }
 

--- a/core/solver/cg.cpp
+++ b/core/solver/cg.cpp
@@ -102,18 +102,19 @@ void Cg<ValueType>::apply_impl(const LinOp *b, LinOp *x) const
         system_matrix_, std::shared_ptr<const LinOp>(b, [](const LinOp *) {}),
         x, r.get());
 
-    int iter = 0;
+    int iter = -1;
     while (true) {
         preconditioner_->apply(r.get(), z.get());
         r->compute_dot(z.get(), rho.get());
 
+        ++iter;
+        this->template log<log::Logger::iteration_complete>(this, iter, r.get(),
+                                                            dense_x);
         if (stop_criterion->update()
                 .num_iterations(iter)
                 .residual(r.get())
                 .solution(dense_x)
                 .check(RelativeStoppingId, true, &stop_status, &one_changed)) {
-            this->template log<log::Logger::iteration_complete>(
-                this, iter + 1, r.get(), dense_x);
             break;
         }
 
@@ -129,9 +130,6 @@ void Cg<ValueType>::apply_impl(const LinOp *b, LinOp *x) const
         // x = x + tmp * p
         // r = r - tmp * q
         swap(prev_rho, rho);
-        this->template log<log::Logger::iteration_complete>(this, iter + 1,
-                                                            r.get(), dense_x);
-        iter++;
     }
 }
 

--- a/core/solver/cg.cpp
+++ b/core/solver/cg.cpp
@@ -112,6 +112,8 @@ void Cg<ValueType>::apply_impl(const LinOp *b, LinOp *x) const
                 .residual(r.get())
                 .solution(dense_x)
                 .check(RelativeStoppingId, true, &stop_status, &one_changed)) {
+            this->template log<log::Logger::iteration_complete>(
+                this, iter + 1, r.get(), dense_x);
             break;
         }
 

--- a/core/solver/cgs.cpp
+++ b/core/solver/cgs.cpp
@@ -137,20 +137,18 @@ void Cgs<ValueType>::apply_impl(const LinOp *b, LinOp *x) const
         // r = r -alpha * t
         // x = x + alpha * u_hat
 
+        iter += 2;
+        this->template log<log::Logger::iteration_complete>(this, iter, r.get(),
+                                                            dense_x);
         if (stop_criterion->update()
                 .num_iterations(iter)
                 .residual(r.get())
                 .solution(dense_x)
                 .check(RelativeStoppingId, true, &stop_status, &one_changed)) {
-            this->template log<log::Logger::iteration_complete>(
-                this, iter + 1, r.get(), dense_x);
             break;
         }
 
         swap(rho_prev, rho);
-        this->template log<log::Logger::iteration_complete>(this, iter + 1,
-                                                            r.get(), dense_x);
-        iter++;
     }
 }
 

--- a/core/solver/cgs.cpp
+++ b/core/solver/cgs.cpp
@@ -142,6 +142,8 @@ void Cgs<ValueType>::apply_impl(const LinOp *b, LinOp *x) const
                 .residual(r.get())
                 .solution(dense_x)
                 .check(RelativeStoppingId, true, &stop_status, &one_changed)) {
+            this->template log<log::Logger::iteration_complete>(
+                this, iter + 1, r.get(), dense_x);
             break;
         }
 

--- a/core/solver/fcg.cpp
+++ b/core/solver/fcg.cpp
@@ -116,6 +116,8 @@ void Fcg<ValueType>::apply_impl(const LinOp *b, LinOp *x) const
                 .residual(r.get())
                 .solution(dense_x)
                 .check(RelativeStoppingId, true, &stop_status, &one_changed)) {
+            this->template log<log::Logger::iteration_complete>(
+                this, iter + 1, r.get(), dense_x);
             break;
         }
 

--- a/core/solver/gmres.cpp
+++ b/core/solver/gmres.cpp
@@ -150,14 +150,17 @@ void Gmres<ValueType>::apply_impl(const LinOp *b, LinOp *x) const
         system_matrix_, std::shared_ptr<const LinOp>(b, [](const LinOp *) {}),
         x, residual.get());
 
-    size_type total_iter = 0, restart_iter = 0;
+    int total_iter = -1;
+    size_type restart_iter = 0;
+
     while (true) {
+        ++total_iter;
+        this->template log<log::Logger::iteration_complete>(
+            this, total_iter, residual.get(), dense_x);
         if (stop_criterion->update()
                 .num_iterations(total_iter)
                 .residual_norm(residual_norm.get())
                 .check(RelativeStoppingId, true, &stop_status, &one_changed)) {
-            this->template log<log::Logger::iteration_complete>(
-                this, total_iter + 1, residual.get(), dense_x);
             break;
         }
 
@@ -234,9 +237,6 @@ void Gmres<ValueType>::apply_impl(const LinOp *b, LinOp *x) const
         // End apply givens rotation
         // Calculate residual norm
 
-        this->template log<log::Logger::iteration_complete>(
-            this, total_iter + 1, residual.get(), dense_x);
-        total_iter++;
         restart_iter++;
     }
 

--- a/core/solver/gmres.cpp
+++ b/core/solver/gmres.cpp
@@ -156,6 +156,8 @@ void Gmres<ValueType>::apply_impl(const LinOp *b, LinOp *x) const
                 .num_iterations(total_iter)
                 .residual_norm(residual_norm.get())
                 .check(RelativeStoppingId, true, &stop_status, &one_changed)) {
+            this->template log<log::Logger::iteration_complete>(
+                this, total_iter + 1, residual.get(), dense_x);
             break;
         }
 
@@ -233,7 +235,7 @@ void Gmres<ValueType>::apply_impl(const LinOp *b, LinOp *x) const
         // Calculate residual norm
 
         this->template log<log::Logger::iteration_complete>(
-            this, restart_iter + 1, residual.get(), dense_x);
+            this, total_iter + 1, residual.get(), dense_x);
         total_iter++;
         restart_iter++;
     }


### PR DESCRIPTION
This PR fixes #187 by emitting the `iteration_completed` event after the stopping criterion decided that the iteration should stop.

Though I feel this is just a workaround, and the real problem is properly deciding what constitutes the end of an operation.
