### PR TITLE
Fix for Jacobi preconditioner precision detection

### DIFF
--- a/cuda/preconditioner/jacobi_kernels.cu
+++ b/cuda/preconditioner/jacobi_kernels.cu
@@ -88,7 +88,8 @@ __device__ __forceinline__ bool validate_precision_reduction_feasibility(
     auto trans_perm = perm;
     auto block_cond = compute_infinity_norm<max_block_size>(group, block_size,
                                                             block_size, row);
-    invert_block<max_block_size>(group, block_size, row, perm, trans_perm);
+    auto succeeded =
+        invert_block<max_block_size>(group, block_size, row, perm, trans_perm);
     block_cond *= compute_infinity_norm<max_block_size>(group, block_size,
                                                         block_size, row);
 
@@ -103,7 +104,7 @@ __device__ __forceinline__ bool validate_precision_reduction_feasibility(
         }
     }
 
-    return block_cond > 0.0 &&
+    return succeeded && block_cond >= 1.0 &&
            block_cond * float_traits<remove_complex<ValueType>>::eps < 1e-3;
 }
 


### PR DESCRIPTION
This PR fixes a bug that in some cases causes the adaptive block-Jacobi preconditioner to wrongly detect the smallest eligible precision. It occurs if a block becomes singluar after trying to reduce the precision.
In that case, the inversion procedure (which is part of the condition number detection), will silently fail, resulting in a wrongly calculated inverse and condition number (meaning that the wrong precision will be selected).

The bug is fixed by propagating the information about the failure of the inversion to the precision detection method, which now correctly marks the precision as not eligible if the inversion failed.