### PR TITLE
Automatic generation of `ginkgo/ginkgo.hpp`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -103,6 +103,11 @@ if(DEVEL_TOOLS)
     add_dependencies(format add_license)
 endif()
 
+# Generate the global `ginkgo/ginkgo.hpp` header with every call of make
+add_custom_target(generate_ginkgo_header ALL
+        COMMAND ${CMAKE_SOURCE_DIR}/dev_tools/scripts/update_ginkgo_header.sh
+        WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
+
 if(BUILD_DOC)
 	add_subdirectory(doc)
 endif()

--- a/dev_tools/scripts/update_ginkgo_header.sh
+++ b/dev_tools/scripts/update_ginkgo_header.sh
@@ -34,6 +34,8 @@ for file in ginkgo/**/*.hpp; do
     echo "${file}" >> ${HEADER_LIST}
 done
 
+# It must be a POSIX locale in order to sort according to ASCII
+export LC_ALL=C
 # Sorting is necessary to group them according to the folders the header are in
 sort -o ${HEADER_LIST} ${HEADER_LIST}
 

--- a/dev_tools/scripts/update_ginkgo_header.sh
+++ b/dev_tools/scripts/update_ginkgo_header.sh
@@ -15,16 +15,6 @@ GINKGO_HEADER_FILE="ginkgo/ginkgo.hpp"
 GINKGO_HEADER_TEMPLATE_FILE="${GINKGO_HEADER_FILE}.in"
 
 HEADER_LIST="global_includes.hpp.tmp"
-# Make sure the file does not already exist.
-# If it does, append ".tmp" to the file name and retest it.
-while true; do
-    if [ -f "${HEADER_LIST}" ]; then
-        HEADER_LIST="${HEADER_LIST}.tmp"
-    else
-        break
-    fi
-done
-
 
 # Add every header file inside the ginkgo folder to the file ${HEADER_LIST}
 for file in ginkgo/**/*.hpp; do
@@ -39,19 +29,11 @@ export LC_ALL=C
 # Sorting is necessary to group them according to the folders the header are in
 sort -o ${HEADER_LIST} ${HEADER_LIST}
 
-
 # Generate a new, temporary ginkgo header file.
 # It will get compared at the end to the existing file in order to prevent 
 # the rebuilding of targets which depend on the global header
 # (e.g. benchmarks and examples)
 GINKGO_HEADER_TMP="${GINKGO_HEADER_FILE}.tmp"
-while true; do
-    if [ -f "${GINKGO_HEADER_TMP}" ]; then
-        GINKGO_HEADER_TMP="${GINKGO_HEADER_TMP}.tmp"
-    else
-        break
-    fi
-done
 
 PREVIOUS_FOLDER=""
 # "IFS=''" sets the word delimiters for read.

--- a/dev_tools/scripts/update_ginkgo_header.sh
+++ b/dev_tools/scripts/update_ginkgo_header.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+shopt -s globstar
+shopt -s extglob
+
+PLACE_HOLDER="#PUBLIC_HEADER_PLACE_HOLDER"
+
+THIS_DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" &>/dev/null && pwd )
+
+ROOT_DIR="${THIS_DIR}/../../"
+INCLUDE_DIR="${ROOT_DIR}/include"
+
+cd ${INCLUDE_DIR}
+
+GINKGO_HEADER_FILE="ginkgo/ginkgo.hpp"
+GINKGO_HEADER_TEMPLATE_FILE="${GINKGO_HEADER_FILE}.in"
+
+HEADER_LIST="global_includes.hpp.tmp"
+# Make sure the file does not already exist.
+# If it does, append ".tmp" to the file name and retest it.
+while true; do
+    if [ -f "${HEADER_LIST}" ]; then
+        HEADER_LIST="${HEADER_LIST}.tmp"
+    else
+        break
+    fi
+done
+
+
+# Add every header file inside the ginkgo folder to the file ${HEADER_LIST}
+for file in ginkgo/**/*.hpp; do
+    if [ "${file}" == "${GINKGO_HEADER_FILE}" ]; then
+        continue
+    fi
+    echo "${file}" >> ${HEADER_LIST}
+done
+
+# Sorting is necessary to group them according to the folders the header are in
+sort -o ${HEADER_LIST} ${HEADER_LIST}
+
+
+# Generate a new, temporary ginkgo header file.
+# It will get compared at the end to the existing file in order to prevent 
+# the rebuilding of targets which depend on the global header
+# (e.g. benchmarks and examples)
+GINKGO_HEADER_TMP="${GINKGO_HEADER_FILE}.tmp"
+while true; do
+    if [ -f "${GINKGO_HEADER_TMP}" ]; then
+        GINKGO_HEADER_TMP="${GINKGO_HEADER_TMP}.tmp"
+    else
+        break
+    fi
+done
+
+PREVIOUS_FOLDER=""
+# "IFS=''" sets the word delimiters for read.
+# An empty $IFS means the given name (after `read`) will be set to the whole line.
+while IFS='' read -r line; do
+    if [ "${line}" != ${PLACE_HOLDER} ]; then
+        echo "${line}" >> ${GINKGO_HEADER_TMP}
+    else
+        READING_FIRST_LINE=true
+        while IFS='' read -r file; do
+            CURRENT_FOLDER=$(dirname ${file})
+            # add newline between different include folder
+            if [ "${READING_FIRST_LINE}" != true ] && \
+               [ "${CURRENT_FOLDER}" != "${PREVIOUS_FOLDER}" ]
+            then
+                echo "" >> ${GINKGO_HEADER_TMP}
+            fi
+            PREVIOUS_FOLDER=${CURRENT_FOLDER}
+            echo "#include <${file}>" >> ${GINKGO_HEADER_TMP}
+            READING_FIRST_LINE=false
+        done < "${HEADER_LIST}"
+    fi
+done < ${GINKGO_HEADER_TEMPLATE_FILE}
+
+# Use the generated file ONLY when the public header does not exist yet
+# or the generated one is different to the existing one
+if [ ! -f "${GINKGO_HEADER_FILE}" ] || \
+   ! cmp -s "${GINKGO_HEADER_TMP}" "${GINKGO_HEADER_FILE}"
+then
+    mv "${GINKGO_HEADER_TMP}" "${GINKGO_HEADER_FILE}"
+else
+    rm ${GINKGO_HEADER_TMP}
+fi
+
+rm ${HEADER_LIST}

--- a/include/ginkgo/core/log/papi.hpp
+++ b/include/ginkgo/core/log/papi.hpp
@@ -34,6 +34,9 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #ifndef GKO_CORE_LOG_PAPI_HPP_
 #define GKO_CORE_LOG_PAPI_HPP_
 
+#include <ginkgo/config.hpp>
+
+#ifdef GKO_HAVE_PAPI_SDE
 
 #include <cstddef>
 #include <iostream>
@@ -305,5 +308,6 @@ private:
 }  // namespace log
 }  // namespace gko
 
+#endif  // GKO_HAVE_PAPI_SDE
 
 #endif  // GKO_CORE_LOG_OSTREAM_HPP_

--- a/include/ginkgo/core/log/papi.hpp
+++ b/include/ginkgo/core/log/papi.hpp
@@ -34,9 +34,12 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #ifndef GKO_CORE_LOG_PAPI_HPP_
 #define GKO_CORE_LOG_PAPI_HPP_
 
+
 #include <ginkgo/config.hpp>
 
+
 #ifdef GKO_HAVE_PAPI_SDE
+
 
 #include <cstddef>
 #include <iostream>
@@ -308,6 +311,6 @@ private:
 }  // namespace log
 }  // namespace gko
 
-#endif  // GKO_HAVE_PAPI_SDE
 
+#endif  // GKO_HAVE_PAPI_SDE
 #endif  // GKO_CORE_LOG_OSTREAM_HPP_

--- a/include/ginkgo/ginkgo.hpp
+++ b/include/ginkgo/ginkgo.hpp
@@ -34,7 +34,9 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #ifndef GKO_GINKGO_HPP_
 #define GKO_GINKGO_HPP_
 
+
 #include <ginkgo/config.hpp>
+
 
 #include <ginkgo/core/base/abstract_factory.hpp>
 #include <ginkgo/core/base/array.hpp>
@@ -87,5 +89,6 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <ginkgo/core/stop/time.hpp>
 
 #include <ginkgo/core/synthesizer/containers.hpp>
+
 
 #endif  // GKO_GINKGO_HPP_

--- a/include/ginkgo/ginkgo.hpp
+++ b/include/ginkgo/ginkgo.hpp
@@ -58,9 +58,8 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <ginkgo/core/base/version.hpp>
 
 #include <ginkgo/core/log/convergence.hpp>
-#ifdef GKO_HAVE_PAPI_SDE
+#include <ginkgo/core/log/logger.hpp>
 #include <ginkgo/core/log/papi.hpp>
-#endif
 #include <ginkgo/core/log/record.hpp>
 #include <ginkgo/core/log/stream.hpp>
 
@@ -81,6 +80,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <ginkgo/core/solver/gmres.hpp>
 
 #include <ginkgo/core/stop/combined.hpp>
+#include <ginkgo/core/stop/criterion.hpp>
 #include <ginkgo/core/stop/iteration.hpp>
 #include <ginkgo/core/stop/residual_norm_reduction.hpp>
 #include <ginkgo/core/stop/stopping_status.hpp>

--- a/include/ginkgo/ginkgo.hpp.in
+++ b/include/ginkgo/ginkgo.hpp.in
@@ -1,0 +1,41 @@
+/*******************************<GINKGO LICENSE>******************************
+Copyright 2017-2018
+
+Karlsruhe Institute of Technology
+Universitat Jaume I
+University of Tennessee
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice,
+   this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors
+   may be used to endorse or promote products derived from this software
+   without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+******************************<GINKGO LICENSE>*******************************/
+
+#ifndef GKO_GINKGO_HPP_
+#define GKO_GINKGO_HPP_
+
+#include <ginkgo/config.hpp>
+
+#PUBLIC_HEADER_PLACE_HOLDER
+
+#endif  // GKO_GINKGO_HPP_

--- a/include/ginkgo/ginkgo.hpp.in
+++ b/include/ginkgo/ginkgo.hpp.in
@@ -1,5 +1,5 @@
 /*******************************<GINKGO LICENSE>******************************
-Copyright 2017-2018
+Copyright 2017-2019
 
 Karlsruhe Institute of Technology
 Universitat Jaume I
@@ -34,8 +34,11 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #ifndef GKO_GINKGO_HPP_
 #define GKO_GINKGO_HPP_
 
+
 #include <ginkgo/config.hpp>
 
+
 #PUBLIC_HEADER_PLACE_HOLDER
+
 
 #endif  // GKO_GINKGO_HPP_


### PR DESCRIPTION
The script `dev_tools/scripts/update_ginkgo_header.sh` generates or updates the public header file `include/ginkgo/ginkgo.hpp`. 
It generates a temporary version of `ginkgo.hpp` which includes every header inside `include/ginkgo/`. If a version of `ginkgo.hpp` already exists, the temporary version is compared to the existing one. If they are identical, the already existing header will stay in place (therefore, the timestamps for change or modified are not changed). Otherwise, the generated, temporary file will be the new `include/ginkgo/ginkgo.hpp`.

The script is called at every `make` call to ensure changes in `include/ginkgo/` are registered without the need to run `cmake` again.

The temporary file is necessary because if `ginkgo.hpp` would be replaced at every call of the script, many binaries have to be rebuild at every `make` call (e.g. benchmarks and tests).


Tested on the CI system with both `include/ginkgo/ginkgo.hpp` already present and not (so it needs to be generated).


__TODO__

- [x] Sorting the includes needs to be identical to `make format` in order to not replace the header after every make format!