### PR TITLE
Improved version of CAS

### DIFF
--- a/third_party/CudaArchitectureSelector/CMakeLists.txt
+++ b/third_party/CudaArchitectureSelector/CMakeLists.txt
@@ -1,5 +1,5 @@
 load_git_package(CudaArchitectureSelector
     "https://github.com/ginkgo-project/CudaArchitectureSelector.git"
-    "d05d51d165d154e70e348443577cce6f93c20383")
+    "0b46fb7d653404db312cbc1fc702cb528fd1c1b0")
 
 set(CMAKE_MODULE_PATH "${CMAKE_MODULE_PATH}" PARENT_SCOPE)


### PR DESCRIPTION
Updates the version of CudaArchitectureSelector used by Ginkgo. The updated version supports pre-C++11 compilers and passes correct compiler flags when compiling the architecture detector executable.
