### PR TITLE
Fix linking error for test cases

### DIFF
--- a/cmake/create_test.cmake
+++ b/cmake/create_test.cmake
@@ -6,6 +6,13 @@ function(create_test test_name)
     set_target_properties(${TEST_TARGET_NAME} PROPERTIES
         OUTPUT_NAME ${test_name})
     target_link_libraries(${TEST_TARGET_NAME} PRIVATE ginkgo gtest_main)
+    # Needed because it causes undefined reference errors on some systems.
+    # To prevent that, the library files are added to the linker again.
+    target_link_libraries(${TEST_TARGET_NAME} 
+        PRIVATE $<TARGET_LINKER_FILE:ginkgo_cuda>
+                $<TARGET_LINKER_FILE:ginkgo_reference>
+                $<TARGET_LINKER_FILE:ginkgo_omp>
+                $<TARGET_LINKER_FILE:ginkgo>)
     add_test(NAME ${REL_BINARY_DIR}/${test_name} COMMAND ${TEST_TARGET_NAME})
 endfunction(create_test)
 
@@ -17,5 +24,10 @@ function(create_cuda_test test_name)
     set_target_properties(${TEST_TARGET_NAME} PROPERTIES
         OUTPUT_NAME ${test_name})
     target_link_libraries(${TEST_TARGET_NAME} PRIVATE ginkgo gtest_main)
+    # Needed because it causes undefined reference errors on some systems.
+    # To prevent that, the library files are added to the linker again.
+    target_link_libraries(${TEST_TARGET_NAME} 
+        PRIVATE $<TARGET_LINKER_FILE:ginkgo_cuda>
+                $<TARGET_LINKER_FILE:ginkgo>)
     add_test(NAME ${REL_BINARY_DIR}/${test_name} COMMAND ${TEST_TARGET_NAME})
 endfunction(create_cuda_test)


### PR DESCRIPTION
This PR should fix the error happening in PR #194 and issue #138.
I am pretty sure these errors were caused by the circular dependency we have in ginkgo (for example ginkgo -> ginkgo_cuda -> ginkgo), which caused some linkers to fail for the test cases.

For some reason, the examples are always build correctly, so they do not need this fix (at least yet).

This solution should also work with various compilers and static libraries, however, ginkgo currently can not be built as a static library (I got some errors when I tried, but did not investigate further).