### PR TITLE
Add release builds and tests to the CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -189,9 +189,9 @@ build/nocuda/gcc/omp/debug:
     BUILD_OMP: "ON"
 
 # Release builds
-build/cuda90/gcc/all/release:
+build/cuda91/gcc/all/release:
   <<: *default_build
-  image: localhost:5000/gko-cuda90-gnu5-llvm39
+  image: localhost:5000/gko-cuda91-gnu6-llvm40
   variables:
     <<: *default_variables
     BUILD_OMP: "ON"
@@ -200,9 +200,9 @@ build/cuda90/gcc/all/release:
     EXTRA_CMAKE_FLAGS: &cuda_flags
       -DCUDA_ARCHITECTURES=35
 
-build/cuda90/clang/all/release:
+build/cuda91/clang/all/release:
   <<: *default_build
-  image: localhost:5000/gko-cuda90-gnu5-llvm39
+  image: localhost:5000/gko-cuda91-gnu6-llvm40
   variables:
     <<: *default_variables
     C_COMPILER: clang
@@ -303,17 +303,17 @@ test/nocuda/gcc/omp/debug:
     - build/nocuda/gcc/omp/debug
 
 # Release tests
-test/cuda90/gcc/all/release:
+test/cuda91/gcc/all/release:
   <<: *default_test
-  image: localhost:5000/gko-cuda90-gnu5-llvm39
+  image: localhost:5000/gko-cuda91-gnu6-llvm40
   dependencies:
-    - build/cuda90/gcc/all/release
+    - build/cuda91/gcc/all/release
 
-test/cuda90/clang/all/release:
+test/cuda91/clang/all/release:
   <<: *default_test
-  image: localhost:5000/gko-cuda90-gnu5-llvm39
+  image: localhost:5000/gko-cuda91-gnu6-llvm40
   dependencies:
-    - build/cuda90/clang/all/release
+    - build/cuda91/clang/all/release
 
 test/nocuda/gcc/omp/release:
   <<: *default_test

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -188,6 +188,48 @@ build/nocuda/gcc/omp/debug:
     <<: *default_variables
     BUILD_OMP: "ON"
 
+# Release builds
+build/cuda90/gcc/all/release:
+  <<: *default_build
+  image: localhost:5000/gko-cuda90-gnu5-llvm39
+  variables:
+    <<: *default_variables
+    BUILD_OMP: "ON"
+    BUILD_CUDA: "ON"
+    BUILD_TYPE: Release
+    EXTRA_CMAKE_FLAGS: &cuda_flags
+      -DCUDA_ARCHITECTURES=35
+
+build/cuda90/clang/all/release:
+  <<: *default_build
+  image: localhost:5000/gko-cuda90-gnu5-llvm39
+  variables:
+    <<: *default_variables
+    C_COMPILER: clang
+    CXX_COMPILER: clang++
+    BUILD_OMP: "ON"
+    BUILD_CUDA: "ON"
+    BUILD_TYPE: Release
+    EXTRA_CMAKE_FLAGS: *cuda_flags
+
+build/nocuda/gcc/omp/release:
+  <<: *default_build
+  image: localhost:5000/gko-nocuda-gnu8-llvm70
+  variables:
+    <<: *default_variables
+    BUILD_OMP: "ON"
+    BUILD_TYPE: Release
+
+build/nocuda/clang/omp/release:
+  <<: *default_build
+  image: localhost:5000/gko-nocuda-gnu8-llvm70
+  variables:
+    <<: *default_variables
+    C_COMPILER: clang
+    CXX_COMPILER: clang++
+    BUILD_OMP: "ON"
+    BUILD_TYPE: Release
+
 
 # Test jobs
 test/cuda90/gcc/all/debug:
@@ -259,6 +301,31 @@ test/nocuda/gcc/omp/debug:
   image: localhost:5000/gko-nocuda-gnu8-llvm70
   dependencies:
     - build/nocuda/gcc/omp/debug
+
+# Release tests
+test/cuda90/gcc/all/release:
+  <<: *default_test
+  image: localhost:5000/gko-cuda90-gnu5-llvm39
+  dependencies:
+    - build/cuda90/gcc/all/release
+
+test/cuda90/clang/all/release:
+  <<: *default_test
+  image: localhost:5000/gko-cuda90-gnu5-llvm39
+  dependencies:
+    - build/cuda90/clang/all/release
+
+test/nocuda/gcc/omp/release:
+  <<: *default_test
+  image: localhost:5000/gko-nocuda-gnu8-llvm70
+  dependencies:
+    - build/nocuda/gcc/omp/release
+
+test/nocuda/clang/omp/release:
+  <<: *default_test
+  image: localhost:5000/gko-nocuda-gnu8-llvm70
+  dependencies:
+    - build/nocuda/clang/omp/release
 
 
 # Deploy documentation to github-pages


### PR DESCRIPTION
This PR adds a few release builds and tests to the CI system. The purpose is to ensure that Ginkgo stays compatible with release builds, without adding too many new jobs. The builds added are the following:

+ No CUDA with latest GCC an Clang
+ CUDA 9.1, GCC 6 an Clang 4.0

An example can be seen here: https://gitlab.com/ginkgo-project/ginkgo-public-ci/pipelines/43901609
This is related to https://github.com/ginkgo-project/ginkgo/pull/199