### PR TITLE
Fix handle location and some warnings

### DIFF
--- a/cuda/base/executor.cpp
+++ b/cuda/base/executor.cpp
@@ -172,6 +172,7 @@ void CudaExecutor::raw_copy_to(const OmpExecutor *, size_type num_bytes,
 void CudaExecutor::raw_copy_to(const CudaExecutor *src, size_type num_bytes,
                                const void *src_ptr, void *dest_ptr) const
 {
+    device_guard g(this->get_device_id());
     ASSERT_NO_CUDA_ERRORS(cudaMemcpyPeer(dest_ptr, this->device_id_, src_ptr,
                                          src->get_device_id(), num_bytes));
 }
@@ -223,12 +224,20 @@ void CudaExecutor::set_gpu_property()
 
 void CudaExecutor::init_handles()
 {
-    this->cublas_handle_ = handle_manager<cublasContext>(
-        kernels::cuda::cublas::init(), kernels::cuda::cublas::destroy);
-    typedef void (*func_ptr)(cusparseHandle_t);
-    this->cusparse_handle_ = handle_manager<cusparseContext>(
-        kernels::cuda::cusparse::init(),
-        static_cast<func_ptr>(kernels::cuda::cusparse::destroy));
+    if (device_id_ < this->get_num_devices() && device_id_ >= 0) {
+        const auto id = this->get_device_id();
+        device_guard g(id);
+        this->cublas_handle_ = handle_manager<cublasContext>(
+            kernels::cuda::cublas::init(), [id](cublasHandle_t handle) {
+                device_guard g(id);
+                kernels::cuda::cublas::destroy(handle);
+            });
+        this->cusparse_handle_ = handle_manager<cusparseContext>(
+            kernels::cuda::cusparse::init(), [id](cusparseHandle_t handle) {
+                device_guard g(id);
+                kernels::cuda::cusparse::destroy(handle);
+            });
+    }
 }
 
 

--- a/cuda/matrix/coo_kernels.cu
+++ b/cuda/matrix/coo_kernels.cu
@@ -44,7 +44,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "cuda/base/math.hpp"
 #include "cuda/base/types.hpp"
 #include "cuda/components/atomic.cuh"
-#include "cuda/components/shuffle.cuh"
+#include "cuda/components/cooperative_groups.cuh"
 #include "cuda/components/synchronization.cuh"
 
 
@@ -62,13 +62,15 @@ constexpr int spmv_block_size = warps_in_block * cuda_config::warp_size;
 namespace {
 
 
-template <typename ValueType, typename IndexType>
-__device__ __forceinline__ void segment_scan(IndexType ind, ValueType *val,
-                                             bool *head)
+template <int subwarp_size = cuda_config::warp_size, typename ValueType,
+          typename IndexType>
+__device__ __forceinline__ void segment_scan(
+    const group::thread_block_tile<subwarp_size> &group, IndexType ind, ValueType *val,
+    bool *head)
 {
 #pragma unroll
-    for (int i = 1; i < cuda_config::warp_size; i <<= 1) {
-        const IndexType add_ind = warp::shuffle_up(ind, i);
+    for (int i = 1; i < subwarp_size; i <<= 1) {
+        const IndexType add_ind = group.shfl_up(ind, i);
         ValueType add_val = zero<ValueType>();
         if (threadIdx.x >= i && add_ind == ind) {
             add_val = *val;
@@ -76,8 +78,8 @@ __device__ __forceinline__ void segment_scan(IndexType ind, ValueType *val,
                 *head = false;
             }
         }
-        add_val = warp::shuffle_down(add_val, i);
-        if (threadIdx.x < cuda_config::warp_size - i) {
+        add_val = group.shfl_down(add_val, i);
+        if (threadIdx.x < subwarp_size - i) {
             *val += add_val;
         }
     }
@@ -96,7 +98,8 @@ __device__ __forceinline__ void segment_scan(IndexType ind, ValueType *val,
  * @param c  the output dense vector
  * @param scale  the function on the added value
  */
-template <typename ValueType, typename IndexType, typename Closure>
+template <int subwarp_size = cuda_config::warp_size, typename ValueType,
+          typename IndexType, typename Closure>
 __device__ void spmv_kernel(const size_type nnz, const size_type num_lines,
                             const ValueType *__restrict__ val,
                             const IndexType *__restrict__ col,
@@ -110,24 +113,25 @@ __device__ void spmv_kernel(const size_type nnz, const size_type num_lines,
                            blockDim.y * num_lines +
                        threadIdx.y * blockDim.x * num_lines;
     const auto column_id = blockIdx.y;
-    size_type num =
-        (nnz > start) * ceildiv(nnz - start, cuda_config::warp_size);
+    size_type num = (nnz > start) * ceildiv(nnz - start, subwarp_size);
     num = min(num, num_lines);
     const IndexType ind_start = start + threadIdx.x;
-    const IndexType ind_end = ind_start + (num - 1) * cuda_config::warp_size;
+    const IndexType ind_end = ind_start + (num - 1) * subwarp_size;
     IndexType ind = ind_start;
     bool is_first_in_segment = true;
     IndexType curr_row = (ind < nnz) ? row[ind] : 0;
-    for (; ind < ind_end; ind += cuda_config::warp_size) {
+    const auto tile_block =
+        group::tiled_partition<subwarp_size>(group::this_thread_block());
+    for (; ind < ind_end; ind += subwarp_size) {
         temp_val += (ind < nnz) ? val[ind] * b[col[ind] * b_stride + column_id]
                                 : zero<ValueType>();
-        auto next_row = (ind + cuda_config::warp_size < nnz)
-                            ? row[ind + cuda_config::warp_size]
-                            : row[nnz - 1];
+        auto next_row =
+            (ind + subwarp_size < nnz) ? row[ind + subwarp_size] : row[nnz - 1];
         // segmented scan
-        if (warp::any(curr_row != next_row)) {
+        if (tile_block.any(curr_row != next_row)) {
             is_first_in_segment = true;
-            segment_scan(curr_row, &temp_val, &is_first_in_segment);
+            segment_scan<subwarp_size>(tile_block, curr_row, &temp_val,
+                                       &is_first_in_segment);
             if (is_first_in_segment) {
                 atomic_add(&(c[curr_row * c_stride + column_id]),
                            scale(temp_val));
@@ -137,12 +141,13 @@ __device__ void spmv_kernel(const size_type nnz, const size_type num_lines,
         curr_row = next_row;
     }
     if (num > 0) {
-        ind = ind_start + (num - 1) * cuda_config::warp_size;
+        ind = ind_start + (num - 1) * subwarp_size;
         temp_val += (ind < nnz) ? val[ind] * b[col[ind] * b_stride + column_id]
                                 : zero<ValueType>();
         // segmented scan
         is_first_in_segment = true;
-        segment_scan(curr_row, &temp_val, &is_first_in_segment);
+        segment_scan<subwarp_size>(tile_block, curr_row, &temp_val,
+                                   &is_first_in_segment);
         if (is_first_in_segment) {
             atomic_add(&(c[curr_row * c_stride + column_id]), scale(temp_val));
         }

--- a/include/ginkgo/core/base/lin_op.hpp
+++ b/include/ginkgo/core/base/lin_op.hpp
@@ -547,9 +547,9 @@ public:
                          make_temporary_clone(exec, b).get(),
                          make_temporary_clone(exec, beta).get(),
                          make_temporary_clone(exec, x).get());
-        return self();
         this->template log<log::Logger::linop_advanced_apply_completed>(
             this, alpha, b, beta, x);
+        return self();
     }
 
 protected:


### PR DESCRIPTION
This PR fix handle location and some warnings
1. the cuda handle is allocated on the specified device.
2. cudaMemcpyPeer needs to run on src or dest device, or CUDA uses some additional memory until the program finished.
3. use cooperative_group in csr/coo cuda kernel to reduce warning from warp function.
4. fix the unreachable statement in include/ginkgo/core/base/lin_op.hpp