### PR TITLE
Add a GINKGO_VERBOSE_LEVEL option to CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,8 +19,12 @@ option(BUILD_DOC "Generate documentation" OFF)
 option(BUILD_SHARED_LIBS "Build shared (.so, .dylib, .dll) libraries" ON)
 option(SKIP_DEPENDENCY_UPDATE
        "Do not update dependencies each time the project is rebuilt" ON)
+set(Ginkgo_VERBOSE_LEVEL "1" CACHE STRING
+       "Verbosity level. Put 0 to turn off. 1 activates a few important messages.")
 set(CUDA_ARCHITECTURES "Auto" CACHE STRING
     "A list of target NVIDIA GPU achitectures. See README.md for more detail.")
+
+set(GKO_VERBOSE_LEVEL ${Ginkgo_VERBOSE_LEVEL})
 
 include(cmake/create_test.cmake)
 include(cmake/install_helpers.cmake)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,12 +19,10 @@ option(BUILD_DOC "Generate documentation" OFF)
 option(BUILD_SHARED_LIBS "Build shared (.so, .dylib, .dll) libraries" ON)
 option(SKIP_DEPENDENCY_UPDATE
        "Do not update dependencies each time the project is rebuilt" ON)
-set(Ginkgo_VERBOSE_LEVEL "1" CACHE STRING
+set(GINKGO_VERBOSE_LEVEL "1" CACHE STRING
        "Verbosity level. Put 0 to turn off. 1 activates a few important messages.")
 set(CUDA_ARCHITECTURES "Auto" CACHE STRING
     "A list of target NVIDIA GPU achitectures. See README.md for more detail.")
-
-set(GKO_VERBOSE_LEVEL ${Ginkgo_VERBOSE_LEVEL})
 
 include(cmake/create_test.cmake)
 include(cmake/install_helpers.cmake)

--- a/README.md
+++ b/README.md
@@ -90,6 +90,9 @@ Ginkgo adds the following additional switches to control what is being built:
     errors due to ABI incompatibilities. The default is `OFF`.
 *   `-DCMAKE_INSTALL_PREFIX=path` sets the installation path for `make install`.
     The default value is usually something like `/usr/local`
+*   `-DGINKGO_VERBOSE_LEVEL=integer` sets the verbosity of Ginkgo.
+    * `0` disables all output in the main libraries,
+    * `1` enables a few important messages related to unexpected behavior (default).
 *   `-DCUDA_ARCHITECTURES=<list>` where `<list>` is a semicolon (`;`) separated
     list of architectures. Supported values are:
 

--- a/cuda/base/executor.cpp
+++ b/cuda/base/executor.cpp
@@ -40,6 +40,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <cuda_runtime.h>
 
 
+#include <ginkgo/config.hpp>
 #include <ginkgo/core/base/exception_helpers.hpp>
 
 
@@ -110,12 +111,14 @@ inline int convert_sm_ver_to_cores(int major, int minor)
         index++;
     }
 
-    // If we don't find the values, we use the last valid value by default to
-    // allow proper execution
+#if GKO_VERBOSE_LEVEL >= 1
+    // If we don't find the values, we use the last valid value by default
+    // to allow proper execution
     std::cerr << "MapSMtoCores for SM " << major << "." << minor
               << "is undefined. The default value of "
               << nGpuArchCoresPerSM[index - 1].Cores << " Cores/SM is used."
               << std::endl;
+#endif
     return nGpuArchCoresPerSM[index - 1].Cores;
 }
 
@@ -137,11 +140,13 @@ void CudaExecutor::raw_free(void *ptr) const noexcept
     device_guard g(this->get_device_id());
     auto error_code = cudaFree(ptr);
     if (error_code != cudaSuccess) {
+#if GKO_VERBOSE_LEVEL >= 1
         // Unfortunately, if memory free fails, there's not much we can do
         std::cerr << "Unrecoverable CUDA error on device " << this->device_id_
                   << " in " << __func__ << ": " << cudaGetErrorName(error_code)
                   << ": " << cudaGetErrorString(error_code) << std::endl
                   << "Exiting program" << std::endl;
+#endif
         std::exit(error_code);
     }
 }

--- a/include/ginkgo/config.hpp.in
+++ b/include/ginkgo/config.hpp.in
@@ -41,6 +41,14 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define GKO_VERSION_TAG "${Ginkgo_VERSION_TAG}"
 
 
+/*
+ * Controls the amount of messages output by Ginkgo.
+ * 0 disables all output (except for test, benchmarks and examples).
+ * 1 activates important messages.
+*/
+#define GKO_VERBOSE_LEVEL ${GKO_VERBOSE_LEVEL}
+
+
 /* Is Itanium ABI available? */
 #cmakedefine GKO_HAVE_CXXABI_H
 

--- a/include/ginkgo/config.hpp.in
+++ b/include/ginkgo/config.hpp.in
@@ -46,7 +46,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  * 0 disables all output (except for test, benchmarks and examples).
  * 1 activates important messages.
 */
-#define GKO_VERBOSE_LEVEL ${GKO_VERBOSE_LEVEL}
+#define GKO_VERBOSE_LEVEL ${GINKGO_VERBOSE_LEVEL}
 
 
 /* Is Itanium ABI available? */


### PR DESCRIPTION
Add a GINKGO_VERBOSE_LEVEL option to CMake. This allows picking the amount of messages Ginkgo should print.

This is required to ensure full compatibility with xSDK policy M11 [[1]].  Exceptions can be turned off with the `-fno-exceptions` compiler option.
```
M11. Have no hardwired print or IO statements that cannot be turned off.
```

Outputs from examples and benchmarks have not been guarded. There are two reasons for this:
1. Benchmarks and examples are accessory and can be removed,
2. The very purpose of these pieces of code is to produce some output, and tell the user what it is.

### Description of the option
+ 0 disables all messages
+ 1 only allows some very important messages (failure or unexpected behavior)
+ Can be extended in the future with more levels to allow for better user interaction.

[1]: https://github.com/ginkgo-project/xsdk-policy-compatibility/blob/master/ginkgo-policy-compatibility.md

### Topics to discuss: 
+ VERBOSE level `0` means that Ginkgo can have a weird behavior without an user output, is that fine? I would say yes because that is a killswitch the user activates himself, and the default level is `1`. 
+ I already added a prefix to this CMAKE option, which I set to `Ginkgo`. Is that fine? Later on, this prefix has to be added to all options which would mean options such as `Ginkgo_BUILD_CUDA`.

### Requirements and TODOs
Before merging:
+ [x] Merge PR #205 

After merging:
+ [ ] Update [our xsdk compatibliity list](https://github.com/ginkgo-project/xsdk-policy-compatibility)