### PR TITLE
Fix Intel Compilation issues on ForHLR2

### DIFF
--- a/benchmark/solver/solver.cpp
+++ b/benchmark/solver/solver.cpp
@@ -205,17 +205,19 @@ const std::map<std::string, std::function<std::unique_ptr<gko::LinOpFactory>(
          }},
         {"jacobi",
          [](std::shared_ptr<const gko::Executor> exec) {
+             std::shared_ptr<const gko::LinOpFactory> f =
+                 gko::preconditioner::Jacobi<>::build().on(exec);
              return std::unique_ptr<ReferenceFactoryWrapper>(
-                 new ReferenceFactoryWrapper(
-                     gko::preconditioner::Jacobi<>::build().on(exec)));
+                 new ReferenceFactoryWrapper(f));
          }},
         {"adaptive-jacobi", [](std::shared_ptr<const gko::Executor> exec) {
+             std::shared_ptr<const gko::LinOpFactory> f =
+                 gko::preconditioner::Jacobi<>::build()
+                     .with_storage_optimization(
+                         gko::precision_reduction::autodetect())
+                     .on(exec);
              return std::unique_ptr<ReferenceFactoryWrapper>(
-                 new ReferenceFactoryWrapper(
-                     gko::preconditioner::Jacobi<>::build()
-                         .with_storage_optimization(
-                             gko::precision_reduction::autodetect())
-                         .on(exec)));
+                 new ReferenceFactoryWrapper(f));
          }}};
 
 

--- a/omp/matrix/dense_kernels.cpp
+++ b/omp/matrix/dense_kernels.cpp
@@ -186,9 +186,11 @@ void compute_norm2(std::shared_ptr<const OmpExecutor> exec,
                    matrix::Dense<ValueType> *result)
 {
     compute_dot(exec, x, x, result);
+    const size_type dim_0 = result->get_size()[0];
+    const size_type dim_1 = result->get_size()[1];
 #pragma omp parallel for collapse(2)
-    for (size_type i = 0; i < result->get_size()[0]; ++i) {
-        for (size_type j = 0; j < result->get_size()[1]; ++j) {
+    for (size_type i = 0; i < dim_0; ++i) {
+        for (size_type j = 0; j < dim_1; ++j) {
             result->at(i, j) = sqrt(abs(result->at(i, j)));
         }
     }


### PR DESCRIPTION
This fix is required for ICC >= 18 on the ForHLR2 platform.

The problems are the following:
+ The pragma omp for with `collapse` does not work because the end boundaries were not explicitly `const`.
+ The usage of the temporary `ReferenceFactoryWrapper` class required an implicit conversion from `std::unique_ptr<gko::LinOpFactory>` to `std::shared_ptr<const gko::LinOpFactory>`, which seemed to fail. This is now done explicitly.

Closes Issue #209 (for now).