### PR TITLE
Building ginkgo as a static library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,6 +36,14 @@ endif()
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
+
+# Needed because of a known issue with CUDA while linking statically.
+# For details, see https://gitlab.kitware.com/cmake/cmake/issues/18614
+if((NOT BUILD_SHARED_LIBS) AND BUILD_CUDA)
+    enable_language(CUDA)
+endif()
+
+
 if(BUILD_TESTS)
     set(MEMORYCHECK_SUPPRESSIONS_FILE
         "${PROJECT_SOURCE_DIR}/dev_tools/valgrind/suppressions.supp"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,4 @@
-if(WIN32)
-    cmake_minimum_required(VERSION 3.9)
-else()
-    cmake_minimum_required(VERSION 3.8)
-endif()
+cmake_minimum_required(VERSION 3.9)
 
 project(Ginkgo LANGUAGES C CXX VERSION 0.0.0)
 set(Ginkgo_VERSION_TAG "develop")

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Prerequisites
 
 For Ginkgo core library:
 
-*   _cmake 3.8+_
+*   _cmake 3.9+_
 *   C++11 compliant compiler, one of:
     *   _gcc 5.3+, 6.3+, 7.3+, 8.1+_
     *   _clang 3.9+_

--- a/README.md
+++ b/README.md
@@ -93,6 +93,8 @@ Ginkgo adds the following additional switches to control what is being built:
 *   `-DGINKGO_VERBOSE_LEVEL=integer` sets the verbosity of Ginkgo.
     * `0` disables all output in the main libraries,
     * `1` enables a few important messages related to unexpected behavior (default).
+*   `-DBUILD_SHARED_LIBS={ON, OFF}` builds ginkgo as shared libraries (`OFF`)
+    or as dynamic libraries (`ON`), default is `ON`
 *   `-DCUDA_ARCHITECTURES=<list>` where `<list>` is a semicolon (`;`) separated
     list of architectures. Supported values are:
 
@@ -248,6 +250,13 @@ make install
 If the installation prefix (see `CMAKE_INSTALL_PREFIX`) is not writable for your
 user, e.g. when installing Ginkgo system-wide, it might be necessary to prefix
 the call with `sudo`.
+
+After the installation, CMake can find ginkgo with `find_package(Ginkgo)`.
+An example can be found in the [`install_test`](install_test/CMakeLists.txt).
+
+
+__Note:__ If the installed ginkgo was built statically and with CUDA, 
+`CUDA` needs to be specified as a language in order for CMake to work properly.
 
 ### Licensing
 

--- a/core/base/version.cpp
+++ b/core/base/version.cpp
@@ -36,6 +36,29 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 namespace gko {
 
+#define GKO_DEFINE_VERSION_COMPARISON(_operator)                          \
+    bool operator _operator(const version &first, const version &second)  \
+    {                                                                     \
+        return std::tie(first.major, first.minor, first.patch)            \
+            _operator std::tie(second.major, second.minor, second.patch); \
+    }
+
+GKO_DEFINE_VERSION_COMPARISON(<)
+GKO_DEFINE_VERSION_COMPARISON(<=)
+GKO_DEFINE_VERSION_COMPARISON(==)
+GKO_DEFINE_VERSION_COMPARISON(!=)
+GKO_DEFINE_VERSION_COMPARISON(>=)
+GKO_DEFINE_VERSION_COMPARISON(>)
+
+
+std::ostream &operator<<(std::ostream &os, const version &ver)
+{
+    os << ver.major << "." << ver.minor << "." << ver.patch;
+    if (ver.tag) {
+        os << " (" << ver.tag << ")";
+    }
+    return os;
+}
 
 version version_info::get_core_version() noexcept
 {

--- a/core/base/version.cpp
+++ b/core/base/version.cpp
@@ -36,29 +36,6 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 namespace gko {
 
-#define GKO_DEFINE_VERSION_COMPARISON(_operator)                          \
-    bool operator _operator(const version &first, const version &second)  \
-    {                                                                     \
-        return std::tie(first.major, first.minor, first.patch)            \
-            _operator std::tie(second.major, second.minor, second.patch); \
-    }
-
-GKO_DEFINE_VERSION_COMPARISON(<)
-GKO_DEFINE_VERSION_COMPARISON(<=)
-GKO_DEFINE_VERSION_COMPARISON(==)
-GKO_DEFINE_VERSION_COMPARISON(!=)
-GKO_DEFINE_VERSION_COMPARISON(>=)
-GKO_DEFINE_VERSION_COMPARISON(>)
-
-
-std::ostream &operator<<(std::ostream &os, const version &ver)
-{
-    os << ver.major << "." << ver.minor << "." << ver.patch;
-    if (ver.tag) {
-        os << " (" << ver.tag << ")";
-    }
-    return os;
-}
 
 version version_info::get_core_version() noexcept
 {

--- a/cuda/CMakeLists.txt
+++ b/cuda/CMakeLists.txt
@@ -57,8 +57,7 @@ set_property(TARGET ginkgo_cuda PROPERTY BUILD_PATH ${CMAKE_CUDA_IMPLICIT_LINK_D
 
 target_include_directories(ginkgo_cuda
     SYSTEM PRIVATE ${CUDA_INCLUDE_DIRS})
-target_link_libraries(ginkgo_cuda PRIVATE ${CUDA_LIBRARIES} ${CUDA_RUNTIME_LIBS} ${CUBLAS}
-    ${CUSPARSE})
+target_link_libraries(ginkgo_cuda PRIVATE ${CUDA_RUNTIME_LIBS} ${CUBLAS} ${CUSPARSE})
 
 # Ensures that there are no circular dependency issues
 if(NOT BUILD_SHARED_LIBS)

--- a/cuda/CMakeLists.txt
+++ b/cuda/CMakeLists.txt
@@ -51,10 +51,20 @@ find_library(CUSPARSE cusparse
 add_library(ginkgo_cuda
     $<TARGET_OBJECTS:ginkgo_cuda_device>
     ${SOURCES})
+
+set_target_properties(ginkgo_cuda PROPERTIES CUDA_SEPARABLE_COMPILATION ON)
+set_property(TARGET ginkgo_cuda PROPERTY BUILD_PATH ${CMAKE_CUDA_IMPLICIT_LINK_DIRIECTORY})
+
 target_include_directories(ginkgo_cuda
     SYSTEM PRIVATE ${CUDA_INCLUDE_DIRS})
-target_link_libraries(ginkgo_cuda PRIVATE ${CUDA_RUNTIME_LIBS} ${CUBLAS}
+target_link_libraries(ginkgo_cuda PRIVATE ${CUDA_LIBRARIES} ${CUDA_RUNTIME_LIBS} ${CUBLAS}
     ${CUSPARSE})
+
+# Problem described here: https://gitlab.kitware.com/cmake/cmake/issues/18614
+if(NOT BUILD_SHARED_LIBS)
+    target_link_libraries(ginkgo_cuda PUBLIC ginkgo)
+endif()
+
 cas_target_cuda_architectures(ginkgo_cuda
     ARCHITECTURES ${CUDA_ARCHITECTURES}
     UNSUPPORTED "20" "21")

--- a/cuda/CMakeLists.txt
+++ b/cuda/CMakeLists.txt
@@ -60,7 +60,7 @@ target_include_directories(ginkgo_cuda
 target_link_libraries(ginkgo_cuda PRIVATE ${CUDA_LIBRARIES} ${CUDA_RUNTIME_LIBS} ${CUBLAS}
     ${CUSPARSE})
 
-# Problem described here: https://gitlab.kitware.com/cmake/cmake/issues/18614
+# Ensures that there are no circular dependency issues
 if(NOT BUILD_SHARED_LIBS)
     target_link_libraries(ginkgo_cuda PUBLIC ginkgo)
 endif()

--- a/cuda/CMakeLists.txt
+++ b/cuda/CMakeLists.txt
@@ -52,9 +52,6 @@ add_library(ginkgo_cuda
     $<TARGET_OBJECTS:ginkgo_cuda_device>
     ${SOURCES})
 
-set_target_properties(ginkgo_cuda PROPERTIES CUDA_SEPARABLE_COMPILATION ON)
-set_property(TARGET ginkgo_cuda PROPERTY BUILD_PATH ${CMAKE_CUDA_IMPLICIT_LINK_DIRIECTORY})
-
 target_include_directories(ginkgo_cuda
     SYSTEM PRIVATE ${CUDA_INCLUDE_DIRS})
 target_link_libraries(ginkgo_cuda PRIVATE ${CUDA_RUNTIME_LIBS} ${CUBLAS} ${CUSPARSE})

--- a/include/ginkgo/core/base/version.hpp
+++ b/include/ginkgo/core/base/version.hpp
@@ -76,21 +76,17 @@ struct version {
 };
 
 
-#define GKO_ENABLE_VERSION_COMPARISON(_operator)                          \
-    bool operator _operator(const version &first, const version &second)  \
-    {                                                                     \
-        return std::tie(first.major, first.minor, first.patch)            \
-            _operator std::tie(second.major, second.minor, second.patch); \
-    }
+#define GKO_DECLARE_VERSION_COMPARISON(_operator) \
+    bool operator _operator(const version &first, const version &second);
 
-GKO_ENABLE_VERSION_COMPARISON(<);
-GKO_ENABLE_VERSION_COMPARISON(<=);
-GKO_ENABLE_VERSION_COMPARISON(==);
-GKO_ENABLE_VERSION_COMPARISON(!=);
-GKO_ENABLE_VERSION_COMPARISON(>=);
-GKO_ENABLE_VERSION_COMPARISON(>);
+GKO_DECLARE_VERSION_COMPARISON(<)
+GKO_DECLARE_VERSION_COMPARISON(<=)
+GKO_DECLARE_VERSION_COMPARISON(==)
+GKO_DECLARE_VERSION_COMPARISON(!=)
+GKO_DECLARE_VERSION_COMPARISON(>=)
+GKO_DECLARE_VERSION_COMPARISON(>)
 
-#undef GKO_ENABLE_VERSION_COMPARISON
+#undef GKO_DECLARE_VERSION_COMPARISON
 
 
 /**
@@ -101,14 +97,7 @@ GKO_ENABLE_VERSION_COMPARISON(>);
  *
  * @return os
  */
-std::ostream &operator<<(std::ostream &os, const version &ver)
-{
-    os << ver.major << "." << ver.minor << "." << ver.patch;
-    if (ver.tag) {
-        os << " (" << ver.tag << ")";
-    }
-    return os;
-}
+std::ostream &operator<<(std::ostream &os, const version &ver);
 
 
 /**

--- a/include/ginkgo/core/base/version.hpp
+++ b/include/ginkgo/core/base/version.hpp
@@ -76,17 +76,22 @@ struct version {
 };
 
 
-#define GKO_DECLARE_VERSION_COMPARISON(_operator) \
-    bool operator _operator(const version &first, const version &second);
+#define GKO_ENABLE_VERSION_COMPARISON(_operator)                          \
+    inline bool operator _operator(const version &first,                  \
+                                   const version &second)                 \
+    {                                                                     \
+        return std::tie(first.major, first.minor, first.patch)            \
+            _operator std::tie(second.major, second.minor, second.patch); \
+    }
 
-GKO_DECLARE_VERSION_COMPARISON(<)
-GKO_DECLARE_VERSION_COMPARISON(<=)
-GKO_DECLARE_VERSION_COMPARISON(==)
-GKO_DECLARE_VERSION_COMPARISON(!=)
-GKO_DECLARE_VERSION_COMPARISON(>=)
-GKO_DECLARE_VERSION_COMPARISON(>)
+GKO_ENABLE_VERSION_COMPARISON(<);
+GKO_ENABLE_VERSION_COMPARISON(<=);
+GKO_ENABLE_VERSION_COMPARISON(==);
+GKO_ENABLE_VERSION_COMPARISON(!=);
+GKO_ENABLE_VERSION_COMPARISON(>=);
+GKO_ENABLE_VERSION_COMPARISON(>);
 
-#undef GKO_DECLARE_VERSION_COMPARISON
+#undef GKO_ENABLE_VERSION_COMPARISON
 
 
 /**
@@ -97,7 +102,14 @@ GKO_DECLARE_VERSION_COMPARISON(>)
  *
  * @return os
  */
-std::ostream &operator<<(std::ostream &os, const version &ver);
+inline std::ostream &operator<<(std::ostream &os, const version &ver)
+{
+    os << ver.major << "." << ver.minor << "." << ver.patch;
+    if (ver.tag) {
+        os << " (" << ver.tag << ")";
+    }
+    return os;
+}
 
 
 /**

--- a/install_test/CMakeLists.txt
+++ b/install_test/CMakeLists.txt
@@ -1,7 +1,9 @@
-
 cmake_minimum_required(VERSION 3.8)
 
 project(InstallTest LANGUAGES CXX)
+
+# The `enable_language` is needed when the library is build static with CUDA
+#enable_language(CUDA)
 
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)

--- a/install_test/CMakeLists.txt
+++ b/install_test/CMakeLists.txt
@@ -2,8 +2,7 @@ cmake_minimum_required(VERSION 3.8)
 
 project(InstallTest LANGUAGES CXX)
 
-# The `enable_language` is needed when the library is build static with CUDA
-#enable_language(CUDA)
+# `enable_language(CUDA)` is needed when ginkgo was statically build with CUDA
 
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)

--- a/omp/CMakeLists.txt
+++ b/omp/CMakeLists.txt
@@ -15,24 +15,19 @@ set(SOURCES
     stop/criterion_kernels.cpp
     stop/residual_norm_reduction_kernels.cpp)
 
-find_package(OpenMP)
+find_package(OpenMP REQUIRED)
 
 add_library(ginkgo_omp
     $<TARGET_OBJECTS:ginkgo_omp_device>
     ${SOURCES})
 
-if(OPENMP_FOUND)
-    #set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
-    # TODO: find alternative when CMAKE is version 3.8 (this ONLY works with 3.9+)
-    target_link_libraries(ginkgo_omp PRIVATE OpenMP::OpenMP_CXX)
-else()
-    set(BUILD_OMP OFF CACHE BOOL "Compile OpenMP kernels for CPU" FORCE)
-endif()
+target_link_libraries(ginkgo_omp PRIVATE "${OpenMP_CXX_FLAGS}")
+target_compile_options(ginkgo_omp PRIVATE "${OpenMP_CXX_FLAGS}")
 
+# Ensures that there are no circular dependency issues
 if(NOT BUILD_SHARED_LIBS)
     target_link_libraries(ginkgo_omp PUBLIC ginkgo)
 endif()
-#target_link_libraries(ginkgo_omp PRIVATE ginkgo_cuda)
 
 ginkgo_default_includes(ginkgo_omp)
 ginkgo_install_library(ginkgo_omp omp)

--- a/omp/CMakeLists.txt
+++ b/omp/CMakeLists.txt
@@ -16,16 +16,24 @@ set(SOURCES
     stop/residual_norm_reduction_kernels.cpp)
 
 find_package(OpenMP)
-if(OPENMP_FOUND)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
-else()
-    set(BUILD_OMP OFF CACHE BOOL "Compile OpenMP kernels for CPU" FORCE)
-endif()
 
 add_library(ginkgo_omp
     $<TARGET_OBJECTS:ginkgo_omp_device>
     ${SOURCES})
-target_link_libraries(ginkgo_omp PUBLIC ginkgo_cuda)
+
+if(OPENMP_FOUND)
+    #set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
+    # TODO: find alternative when CMAKE is version 3.8 (this ONLY works with 3.9+)
+    target_link_libraries(ginkgo_omp PRIVATE OpenMP::OpenMP_CXX)
+else()
+    set(BUILD_OMP OFF CACHE BOOL "Compile OpenMP kernels for CPU" FORCE)
+endif()
+
+if(NOT BUILD_SHARED_LIBS)
+    target_link_libraries(ginkgo_omp PUBLIC ginkgo)
+endif()
+#target_link_libraries(ginkgo_omp PRIVATE ginkgo_cuda)
+
 ginkgo_default_includes(ginkgo_omp)
 ginkgo_install_library(ginkgo_omp omp)
 

--- a/omp/CMakeLists.txt
+++ b/omp/CMakeLists.txt
@@ -21,7 +21,7 @@ add_library(ginkgo_omp
     $<TARGET_OBJECTS:ginkgo_omp_device>
     ${SOURCES})
 
-target_link_libraries(ginkgo_omp PRIVATE "${OpenMP_CXX_FLAGS}")
+target_link_libraries(ginkgo_omp PRIVATE "${OpenMP_CXX_LIBRARIES}")
 target_compile_options(ginkgo_omp PRIVATE "${OpenMP_CXX_FLAGS}")
 
 # Ensures that there are no circular dependency issues

--- a/reference/CMakeLists.txt
+++ b/reference/CMakeLists.txt
@@ -21,6 +21,13 @@ add_library(ginkgo_reference
 ginkgo_default_includes(ginkgo_reference)
 ginkgo_install_library(ginkgo_reference reference)
 
+if(NOT BUILD_SHARED_LIBS)
+    target_link_libraries(ginkgo_reference PUBLIC ginkgo)
+    message("From reference! NOT build with variable = ${BUILD_SHARED_LIBS}")
+else()
+    message("From reference! SET with var = ${BUILD_SHARED_LIBS}")
+endif()
+
 if(BUILD_TESTS)
     add_subdirectory(test)
 endif()

--- a/reference/CMakeLists.txt
+++ b/reference/CMakeLists.txt
@@ -21,11 +21,9 @@ add_library(ginkgo_reference
 ginkgo_default_includes(ginkgo_reference)
 ginkgo_install_library(ginkgo_reference reference)
 
+# Ensures that there are no circular dependency issues
 if(NOT BUILD_SHARED_LIBS)
     target_link_libraries(ginkgo_reference PUBLIC ginkgo)
-    message("From reference! NOT build with variable = ${BUILD_SHARED_LIBS}")
-else()
-    message("From reference! SET with var = ${BUILD_SHARED_LIBS}")
 endif()
 
 if(BUILD_TESTS)


### PR DESCRIPTION
In order to build ginkgo as a static library, the version files had to be modified because the operators `<`, `>`, ... were defined in the header, and therefore defined in all build static libraries, which leads to linker error.

The linking to OpenMP was also changed to both fit the modern CMake and work properly with a installed version of ginkgo.

For CUDA, it is a bit more complicated. For some reason, the varialbe `CMAKE_CUDA_DEVICE_LINK_EXECUTABLE` needs to be set (see [the currently open issue from CMake](https://gitlab.kitware.com/cmake/cmake/issues/18614)). This can be bypassed by using `enable_language(CUDA)` where ginkgo is used (also needs to be done at the top level of ginkgo, which is done in this PR). However, this also has to be done whenever ginkgo itself is used, which is why it is also added as a comment of the `install_test` CMake file.

Unfortunately, I haven't found any way around the `enable_language(CUDA)`. 
The suggested fix on the CMake issue only prevents the CMake error, however, building fails in that case because it does not find the symbols related to CUDA for some reason.

I also added some instructions on how to build ginkgo statically in the `README.md`.

When #220 is merged, the `enable_language(CUDA)` in the `install_test` can be done inside an if that tests if ginkgo was build statically.