### PR TITLE
Reference sellp conversion

### DIFF
--- a/core/matrix/dense.cpp
+++ b/core/matrix/dense.cpp
@@ -173,13 +173,13 @@ inline void conversion_helper(Sellp<ValueType, IndexType> *result,
     const auto stride_factor = (result->get_stride_factor() == 0)
                                    ? default_stride_factor
                                    : result->get_stride_factor();
-    size_type total_columns = 0;
-    exec->run(dense::make_calculate_total_cols(source, &total_columns,
-                                               stride_factor));
-    const auto total_cols = std::max(result->get_total_cols(), total_columns);
     const auto slice_size = (result->get_slice_size() == 0)
                                 ? default_slice_size
                                 : result->get_slice_size();
+    size_type total_columns = 0;
+    exec->run(dense::make_calculate_total_cols(source, &total_columns,
+                                               stride_factor, slice_size));
+    const auto total_cols = std::max(result->get_total_cols(), total_columns);
     auto tmp = Sellp<ValueType, IndexType>::create(
         exec, source->get_size(), slice_size, stride_factor, total_cols);
     exec->run(op(tmp.get(), source));

--- a/core/matrix/dense_kernels.hpp
+++ b/core/matrix/dense_kernels.hpp
@@ -136,7 +136,8 @@ namespace kernels {
 #define GKO_DECLARE_DENSE_CALCULATE_TOTAL_COLS_KERNEL(_type)               \
     void calculate_total_cols(std::shared_ptr<const DefaultExecutor> exec, \
                               const matrix::Dense<_type> *source,          \
-                              size_type *result, size_type stride_factor)
+                              size_type *result, size_type stride_factor,  \
+                              size_type slice_size)
 
 #define GKO_DECLARE_TRANSPOSE_KERNEL(_type)                     \
     void transpose(std::shared_ptr<const DefaultExecutor> exec, \

--- a/cuda/matrix/dense_kernels.cu
+++ b/cuda/matrix/dense_kernels.cu
@@ -457,8 +457,8 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_TYPE(
 template <typename ValueType>
 void calculate_total_cols(std::shared_ptr<const CudaExecutor> exec,
                           const matrix::Dense<ValueType> *source,
-                          size_type *result,
-                          size_type stride_factor) NOT_IMPLEMENTED;
+                          size_type *result, size_type stride_factor,
+                          size_type slice_size) NOT_IMPLEMENTED;
 
 GKO_INSTANTIATE_FOR_EACH_VALUE_TYPE(
     GKO_DECLARE_DENSE_CALCULATE_TOTAL_COLS_KERNEL);

--- a/omp/matrix/dense_kernels.cpp
+++ b/omp/matrix/dense_kernels.cpp
@@ -282,7 +282,8 @@ void convert_to_sellp(std::shared_ptr<const OmpExecutor> exec,
 
     for (size_type slice = 0; slice < slice_num; slice++) {
         if (slice > 0) {
-            slice_sets[slice] = slice_lengths[slice - 1];
+            slice_sets[slice] =
+                slice_sets[slice - 1] + slice_lengths[slice - 1];
         }
         size_type current_slice_length = 0;
 #pragma omp parallel for reduction(max : current_slice_length)
@@ -325,7 +326,8 @@ void convert_to_sellp(std::shared_ptr<const OmpExecutor> exec,
         }
     }
 
-    slice_sets[slice_num] = slice_lengths[slice_num - 1];
+    slice_sets[slice_num] =
+        slice_sets[slice_num - 1] + slice_lengths[slice_num - 1];
 }
 
 GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(

--- a/omp/matrix/dense_kernels.cpp
+++ b/omp/matrix/dense_kernels.cpp
@@ -402,11 +402,11 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_TYPE(
 template <typename ValueType>
 void calculate_total_cols(std::shared_ptr<const OmpExecutor> exec,
                           const matrix::Dense<ValueType> *source,
-                          size_type *result, size_type stride_factor)
+                          size_type *result, size_type stride_factor,
+                          size_type slice_size)
 {
     auto num_rows = source->get_size()[0];
     auto num_cols = source->get_size()[1];
-    auto slice_size = matrix::default_slice_size;
     auto slice_num = ceildiv(num_rows, slice_size);
     size_type total_cols = 0;
 #pragma omp parallel for reduction(+ : total_cols)

--- a/omp/test/matrix/dense_kernels.cpp
+++ b/omp/test/matrix/dense_kernels.cpp
@@ -344,10 +344,10 @@ TEST_F(Dense, CalculateTotalColsIsEquivalentToRef)
     auto omtx = Mtx::create(omp);
     omtx->copy_from(rmtx.get());
 
-    gko::kernels::reference::dense::calculate_total_cols(ref, rmtx.get(),
-                                                         &ref_total_cols, 1);
-    gko::kernels::omp::dense::calculate_total_cols(omp, omtx.get(),
-                                                   &omp_total_cols, 1);
+    gko::kernels::reference::dense::calculate_total_cols(
+        ref, rmtx.get(), &ref_total_cols, 1, gko::matrix::default_slice_size);
+    gko::kernels::omp::dense::calculate_total_cols(
+        omp, omtx.get(), &omp_total_cols, 1, gko::matrix::default_slice_size);
 
     ASSERT_EQ(ref_total_cols, omp_total_cols);
 }

--- a/reference/matrix/dense_kernels.cpp
+++ b/reference/matrix/dense_kernels.cpp
@@ -527,11 +527,11 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_TYPE(
 template <typename ValueType>
 void calculate_total_cols(std::shared_ptr<const ReferenceExecutor> exec,
                           const matrix::Dense<ValueType> *source,
-                          size_type *result, size_type stride_factor)
+                          size_type *result, size_type stride_factor,
+                          size_type slice_size)
 {
     auto num_rows = source->get_size()[0];
     auto num_cols = source->get_size()[1];
-    auto slice_size = matrix::default_slice_size;
     auto slice_num = ceildiv(num_rows, slice_size);
     auto total_cols = 0;
     auto temp = 0, slice_temp = 0;

--- a/reference/matrix/dense_kernels.cpp
+++ b/reference/matrix/dense_kernels.cpp
@@ -396,7 +396,7 @@ void convert_to_sellp(std::shared_ptr<const ReferenceExecutor> exec,
     slice_sets[0] = 0;
     for (size_type slice = 0; slice < slice_num; slice++) {
         if (slice > 0) {
-            slice_sets[slice] = slice_lengths[slice - 1];
+            slice_sets[slice] = slice_sets[slice - 1] + slice_lengths[slice - 1];
         }
         slice_lengths[slice] = 0;
         for (size_type row = 0; row < slice_size; row++) {
@@ -437,7 +437,7 @@ void convert_to_sellp(std::shared_ptr<const ReferenceExecutor> exec,
             }
         }
     }
-    slice_sets[slice_num] = slice_lengths[slice_num - 1];
+    slice_sets[slice_num] = slice_sets[slice_num - 1] + slice_lengths[slice_num - 1];
 }
 
 GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(

--- a/reference/matrix/dense_kernels.cpp
+++ b/reference/matrix/dense_kernels.cpp
@@ -396,7 +396,8 @@ void convert_to_sellp(std::shared_ptr<const ReferenceExecutor> exec,
     slice_sets[0] = 0;
     for (size_type slice = 0; slice < slice_num; slice++) {
         if (slice > 0) {
-            slice_sets[slice] = slice_sets[slice - 1] + slice_lengths[slice - 1];
+            slice_sets[slice] =
+                slice_sets[slice - 1] + slice_lengths[slice - 1];
         }
         slice_lengths[slice] = 0;
         for (size_type row = 0; row < slice_size; row++) {
@@ -437,7 +438,8 @@ void convert_to_sellp(std::shared_ptr<const ReferenceExecutor> exec,
             }
         }
     }
-    slice_sets[slice_num] = slice_sets[slice_num - 1] + slice_lengths[slice_num - 1];
+    slice_sets[slice_num] =
+        slice_sets[slice_num - 1] + slice_lengths[slice_num - 1];
 }
 
 GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(

--- a/reference/test/matrix/dense_kernels.cpp
+++ b/reference/test/matrix/dense_kernels.cpp
@@ -40,6 +40,12 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <gtest/gtest.h>
 
 
+#include <random>
+
+
+#include <core/test/utils.hpp>
+
+
 #include <core/test/utils/assertions.hpp>
 #include <ginkgo/core/base/exception.hpp>
 #include <ginkgo/core/base/executor.hpp>
@@ -86,6 +92,17 @@ protected:
     std::unique_ptr<gko::matrix::Dense<std::complex<double>>> mtx6;
     std::unique_ptr<gko::matrix::Dense<>> mtx7;
     std::unique_ptr<gko::matrix::Dense<>> mtx8;
+
+    std::ranlux48 rand_engine;
+
+    template <typename MtxType>
+    std::unique_ptr<MtxType> gen_mtx(int num_rows, int num_cols)
+    {
+        return gko::test::generate_random_matrix<MtxType>(
+            num_rows, num_cols,
+            std::uniform_int_distribution<>(num_cols, num_cols),
+            std::normal_distribution<>(0.0, 1.0), rand_engine, exec);
+    }
 };
 
 
@@ -945,6 +962,19 @@ TEST_F(Dense, NonSquareMatrixIsConjugateTransposable)
                     l({{1.0 - 2.0 * i, -2.0 - 1.5 * i, 1.0 + 0.0 * i},
                        {-1.0 - 2.1 * i, 4.5 + 0.0 * i, -i}}),
                     0.0);
+}
+
+TEST_F(Dense, ConvertsToAndFromSellpWithMoreThanOneSlice)
+{
+    auto x = gen_mtx<Mtx>(65, 25);
+
+    auto sellp_mtx = gko::matrix::Sellp<>::create(exec);
+    auto dense_mtx = gko::matrix::Dense<>::create(exec);
+
+    x->convert_to(sellp_mtx.get());
+    sellp_mtx->convert_to(dense_mtx.get());
+
+    ASSERT_MTX_NEAR(dense_mtx.get(), x.get(), 1e-14);
 }
 
 


### PR DESCRIPTION
Fixed a mistake in calculating the slice offsets in the conversion from dense to sellp.
The offset of slice n was previously just set to the length of slice n-1 but should be set to the sum over the lengths of all previous slices.