### PR TITLE
Remove anonymous namespaces in header files.

### DIFF
--- a/cuda/base/cublas_bindings.hpp
+++ b/cuda/base/cublas_bindings.hpp
@@ -51,7 +51,6 @@ namespace kernels {
 namespace cuda {
 namespace cublas {
 namespace detail {
-namespace {
 
 
 template <typename... Args>
@@ -61,11 +60,7 @@ inline int64 not_implemented(Args &&...)
 }
 
 
-}  // namespace
 }  // namespace detail
-
-
-namespace {
 
 
 template <typename ValueType>
@@ -233,7 +228,6 @@ inline void destroy(cublasHandle_t handle)
 }
 
 
-}  // namespace
 }  // namespace cublas
 }  // namespace cuda
 }  // namespace kernels

--- a/cuda/base/cusparse_bindings.hpp
+++ b/cuda/base/cusparse_bindings.hpp
@@ -49,7 +49,6 @@ namespace kernels {
 namespace cuda {
 namespace cusparse {
 namespace detail {
-namespace {
 
 
 template <typename... Args>
@@ -59,11 +58,7 @@ inline int64 not_implemented(Args...)
 }
 
 
-}  // namespace
 }  // namespace detail
-
-
-namespace {
 
 
 template <typename ValueType, typename IndexType>
@@ -221,7 +216,6 @@ inline void destroy(cusparseMatDescr_t descr)
 }
 
 
-}  // namespace
 }  // namespace cusparse
 }  // namespace cuda
 }  // namespace kernels


### PR DESCRIPTION
There were some anonymous namespaces in header files which I removed. The problem was identified by [sonarqube](https://sonarcloud.io/project/issues?id=ginkgo-project_ginkgo&resolved=false&types=BUG).

Anonymous namespaces means in each translation unit (source file and its `#include`d headers) there is a new instance of these functions. This is a bad practice and unneeded in this case.

References:
+ https://en.cppreference.com/w/cpp/language/namespace
+ https://stackoverflow.com/questions/357564/uses-for-anonymous-namespaces-in-header-files