### PR TITLE
Fix the OpenMP module creation problem due to missing link.

### DIFF
--- a/omp/CMakeLists.txt
+++ b/omp/CMakeLists.txt
@@ -28,6 +28,8 @@ target_compile_options(ginkgo_omp PRIVATE "${OpenMP_CXX_FLAGS}")
 if(NOT BUILD_SHARED_LIBS)
     target_link_libraries(ginkgo_omp PUBLIC ginkgo)
 endif()
+# Need to link against ginkgo_cuda for the `raw_copy_to(CudaExecutor ...)` method
+target_link_libraries(ginkgo_omp PRIVATE ginkgo_cuda)
 
 ginkgo_default_includes(ginkgo_omp)
 ginkgo_install_library(ginkgo_omp omp)


### PR DESCRIPTION
This is a small PR which fixes one of the problems arising on MacOS due to a missing link libraries.

**It is still required for MacOS users or anyone with a link error to build the library in static mode, through `-DBUILD_SHARED_LIBS=OFF`**.