### PR TITLE
Fix warnings.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -85,6 +85,18 @@ sync:
     - schedules
 
 # Build jobs
+
+# Build job with pedantic warnings as errors.
+build/cuda100/gcc/all/debug-warnings:
+  <<: *default_build
+  image: localhost:5000/gko-cuda100-gnu7-llvm60
+  variables:
+    <<: *default_variables
+    BUILD_OMP: "ON"
+    BUILD_CUDA: "ON"
+    EXTRA_CMAKE_FLAGS: &cuda_flags
+      -DGINKGO_COMPILER_FLAGS="-Werror=pedantic"
+
 build/cuda90/gcc/all/debug:
   <<: *default_build
   image: localhost:5000/gko-cuda90-gnu5-llvm39

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -4,6 +4,7 @@ stages:
   - sync
   - build
   - test
+  - warnings
   - deploy
   - QoS_tools
   - benchmark-build
@@ -21,6 +22,7 @@ stages:
   BUILD_REFERENCE: "ON"
   BUILD_OMP: "OFF"
   BUILD_CUDA: "OFF"
+  CXX_FLAGS: ""
   EXTRA_CMAKE_FLAGS: ""
 
 .before_script_template: &default_before_script
@@ -49,6 +51,7 @@ stages:
         -DGINKGO_BUILD_REFERENCE=${BUILD_REFERENCE}
         -DGINKGO_BUILD_OMP=${BUILD_OMP} -DGINKGO_BUILD_CUDA=${BUILD_CUDA}
         -DGINKGO_BUILD_TESTS=ON -DGINKGO_BUILD_EXAMPLES=ON
+        -DCMAKE_CXX_FLAGS="${CXX_FLAGS}"
     - make -j$(grep "core id" /proc/cpuinfo | sort -u | wc -l)
   artifacts:
     paths:
@@ -85,18 +88,6 @@ sync:
     - schedules
 
 # Build jobs
-
-# Build job with pedantic warnings as errors.
-build/cuda100/gcc/all/debug-warnings:
-  <<: *default_build
-  image: localhost:5000/gko-cuda100-gnu7-llvm60
-  variables:
-    <<: *default_variables
-    BUILD_OMP: "ON"
-    BUILD_CUDA: "ON"
-    EXTRA_CMAKE_FLAGS: &cuda_flags
-      -DGINKGO_COMPILER_FLAGS="-Werror=pedantic"
-
 build/cuda90/gcc/all/debug:
   <<: *default_build
   image: localhost:5000/gko-cuda90-gnu5-llvm39
@@ -340,6 +331,20 @@ test/nocuda/clang/omp/release:
   image: localhost:5000/gko-nocuda-gnu8-llvm70
   dependencies:
     - build/nocuda/clang/omp/release
+
+
+# Job with important warnings as error
+warnings:
+  <<: *default_build
+  stage: warnings
+  image: localhost:5000/gko-cuda100-gnu7-llvm60
+  variables:
+    <<: *default_variables
+    BUILD_OMP: "ON"
+    BUILD_CUDA: "ON"
+    CXX_FLAGS: "-Werror=pedantic"
+  dependencies: []
+  allow_failure: yes
 
 
 # Deploy documentation to github-pages

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,7 +28,7 @@ option(GINKGO_EXPORT_BUILD_DIR
     OFF)
 set(GINKGO_VERBOSE_LEVEL "1" CACHE STRING
   "Verbosity level. Put 0 to turn off. 1 activates a few important messages.")
-set(GINKGO_COMPILER_FLAGS "-Werror=pedantic" CACHE STRING
+set(GINKGO_COMPILER_FLAGS "-Wpedantic" CACHE STRING
   "Set the required CXX compiler flags, mainly used for warnings. Current default is `-Wpedantic`")
 set(GINKGO_CUDA_COMPILER_FLAGS "" CACHE STRING
   "Set the required NVCC compiler flags, mainly used for warnings. Current default is an empty string")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,10 +28,10 @@ option(GINKGO_EXPORT_BUILD_DIR
     OFF)
 set(GINKGO_VERBOSE_LEVEL "1" CACHE STRING
   "Verbosity level. Put 0 to turn off. 1 activates a few important messages.")
-set(GINKGO_COMPILER_FLAGS "-Wpedantic" CACHE STRING
-  "Set the required CXX compiler flags, mainly used for warnings. Currently default is `-Wpedantic`")
+set(GINKGO_COMPILER_FLAGS "-Werror=pedantic" CACHE STRING
+  "Set the required CXX compiler flags, mainly used for warnings. Current default is `-Wpedantic`")
 set(GINKGO_CUDA_COMPILER_FLAGS "" CACHE STRING
-  "Set the required NVCC compiler flags, mainly used for warnings. Currently default is an empty string")
+  "Set the required NVCC compiler flags, mainly used for warnings. Current default is an empty string")
 set(GINKGO_CUDA_ARCHITECTURES "Auto" CACHE STRING
     "A list of target NVIDIA GPU achitectures. See README.md for more detail.")
 option(BUILD_SHARED_LIBS "Build shared (.so, .dylib, .dll) libraries" ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,7 +27,11 @@ option(GINKGO_EXPORT_BUILD_DIR
     "Make Ginkgo export its build directory to the CMake package registry."
     OFF)
 set(GINKGO_VERBOSE_LEVEL "1" CACHE STRING
-    "Verbosity level. Put 0 to turn off. 1 activates a few important messages.")
+  "Verbosity level. Put 0 to turn off. 1 activates a few important messages.")
+set(GINKGO_COMPILER_FLAGS "-Wpedantic" CACHE STRING
+  "Set the required CXX compiler flags, mainly used for warnings. Currently default is `-Wpedantic`")
+set(GINKGO_CUDA_COMPILER_FLAGS "" CACHE STRING
+  "Set the required NVCC compiler flags, mainly used for warnings. Currently default is an empty string")
 set(GINKGO_CUDA_ARCHITECTURES "Auto" CACHE STRING
     "A list of target NVIDIA GPU achitectures. See README.md for more detail.")
 option(BUILD_SHARED_LIBS "Build shared (.so, .dylib, .dll) libraries" ON)

--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -1,6 +1,6 @@
 if (NOT CMAKE_BUILD_TYPE STREQUAL "Release")
     message(WARNING
-        "Ginko is not being built in \"Release\" mode, benchmark performance "
+        "Ginkgo is not being built in \"Release\" mode, benchmark performance "
         "will be affected")
 endif()
 

--- a/benchmark/utils/general.hpp
+++ b/benchmark/utils/general.hpp
@@ -93,7 +93,7 @@ std::ranlux24 &get_engine()
 {
     static std::ranlux24 engine(FLAGS_seed);
     return engine;
-};
+}
 
 
 // helper for writing out rapidjson Values

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -38,7 +38,7 @@ endif()
 
 ginkgo_compile_features(ginkgo)
 
-target_compile_options(ginkgo PRIVATE "-Wpedantic")
+target_compile_options(ginkgo PRIVATE "${GINKGO_COMPILER_FLAGS}")
 # add a namespace alias so Ginkgo can always be included as Ginkgo::ginkgo
 # regardless of whether it is installed or added as a subdirectory
 add_library(Ginkgo::ginkgo ALIAS ginkgo)

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -38,6 +38,7 @@ endif()
 
 ginkgo_compile_features(ginkgo)
 
+target_compile_options(ginkgo PRIVATE "-Wpedantic")
 # add a namespace alias so Ginkgo can always be included as Ginkgo::ginkgo
 # regardless of whether it is installed or added as a subdirectory
 add_library(Ginkgo::ginkgo ALIAS ginkgo)

--- a/core/base/combination.cpp
+++ b/core/base/combination.cpp
@@ -87,7 +87,7 @@ void Combination<ValueType>::apply_impl(const LinOp *alpha, const LinOp *b,
 }
 
 
-#define GKO_DECLARE_COMBINATION(_type) class Combination<_type>;
+#define GKO_DECLARE_COMBINATION(_type) class Combination<_type>
 GKO_INSTANTIATE_FOR_EACH_VALUE_TYPE(GKO_DECLARE_COMBINATION);
 
 

--- a/core/base/composition.cpp
+++ b/core/base/composition.cpp
@@ -94,7 +94,7 @@ void Composition<ValueType>::apply_impl(const LinOp *alpha, const LinOp *b,
 }
 
 
-#define GKO_DECLARE_COMPOSITION(_type) class Composition<_type>;
+#define GKO_DECLARE_COMPOSITION(_type) class Composition<_type>
 GKO_INSTANTIATE_FOR_EACH_VALUE_TYPE(GKO_DECLARE_COMPOSITION);
 
 

--- a/core/base/mtx_io.cpp
+++ b/core/base/mtx_io.cpp
@@ -533,7 +533,7 @@ void write_raw(std::ostream &os, const matrix_data<ValueType, IndexType> &data,
 #define GKO_DECLARE_WRITE_RAW(ValueType, IndexType)               \
     void write_raw(std::ostream &os,                              \
                    const matrix_data<ValueType, IndexType> &data, \
-                   layout_type layout);
+                   layout_type layout)
 GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(GKO_DECLARE_READ_RAW);
 GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(GKO_DECLARE_WRITE_RAW);
 

--- a/core/log/stream.cpp
+++ b/core/log/stream.cpp
@@ -98,20 +98,22 @@ std::string location_name(const uintptr &location)
 }
 
 
-#define GKO_ENABLE_DEMANGLE_NAME(_object_type)                 \
-    std::string demangle_name(const _object_type *object)      \
-    {                                                          \
-        std::ostringstream oss;                                \
-        oss << #_object_type "[";                              \
-        if (object == nullptr) {                               \
-            oss << name_demangling::get_dynamic_type(object);  \
-        } else {                                               \
-            oss << name_demangling::get_dynamic_type(*object); \
-        }                                                      \
-        oss << "," << object << "]";                           \
-        return oss.str();                                      \
-    }                                                          \
-    void __gko_macro_terminator__()
+#define GKO_ENABLE_DEMANGLE_NAME(_object_type)                               \
+    std::string demangle_name(const _object_type *object)                    \
+    {                                                                        \
+        std::ostringstream oss;                                              \
+        oss << #_object_type "[";                                            \
+        if (object == nullptr) {                                             \
+            oss << name_demangling::get_dynamic_type(object);                \
+        } else {                                                             \
+            oss << name_demangling::get_dynamic_type(*object);               \
+        }                                                                    \
+        oss << "," << object << "]";                                         \
+        return oss.str();                                                    \
+    }                                                                        \
+    static_assert(true,                                                      \
+                  "This assert is used to counter the false positive extra " \
+                  "semi-colon warnings")
 
 GKO_ENABLE_DEMANGLE_NAME(PolymorphicObject);
 GKO_ENABLE_DEMANGLE_NAME(LinOp);

--- a/core/log/stream.cpp
+++ b/core/log/stream.cpp
@@ -61,8 +61,8 @@ std::ostream &operator<<(std::ostream &os, const matrix::Dense<ValueType> *mtx)
     auto exec = mtx->get_executor();
     auto tmp = make_temporary_clone(exec->get_master(), mtx);
     os << "[" << std::endl;
-    for (int i = 0; i < mtx->get_size()[0]; ++i) {
-        for (int j = 0; j < mtx->get_size()[1]; ++j) {
+    for (size_type i = 0; i < mtx->get_size()[0]; ++i) {
+        for (size_type j = 0; j < mtx->get_size()[1]; ++j) {
             os << '\t' << mtx->at(i, j);
         }
         os << std::endl;
@@ -110,7 +110,8 @@ std::string location_name(const uintptr &location)
         }                                                      \
         oss << "," << object << "]";                           \
         return oss.str();                                      \
-    }
+    }                                                          \
+    void __gko_macro_terminator__()
 
 GKO_ENABLE_DEMANGLE_NAME(PolymorphicObject);
 GKO_ENABLE_DEMANGLE_NAME(LinOp);

--- a/core/matrix/dense.cpp
+++ b/core/matrix/dense.cpp
@@ -564,7 +564,7 @@ std::unique_ptr<LinOp> Dense<ValueType>::conj_transpose() const
 }
 
 
-#define GKO_DECLARE_DENSE_MATRIX(_type) class Dense<_type>;
+#define GKO_DECLARE_DENSE_MATRIX(_type) class Dense<_type>
 GKO_INSTANTIATE_FOR_EACH_VALUE_TYPE(GKO_DECLARE_DENSE_MATRIX);
 
 

--- a/core/matrix/identity.cpp
+++ b/core/matrix/identity.cpp
@@ -70,9 +70,9 @@ std::unique_ptr<LinOp> IdentityFactory<ValueType>::generate_impl(
 }
 
 
-#define GKO_DECLARE_IDENTITY_MATRIX(_type) class Identity<_type>;
+#define GKO_DECLARE_IDENTITY_MATRIX(_type) class Identity<_type>
 GKO_INSTANTIATE_FOR_EACH_VALUE_TYPE(GKO_DECLARE_IDENTITY_MATRIX);
-#define GKO_DECLARE_IDENTITY_FACTORY(_type) class IdentityFactory<_type>;
+#define GKO_DECLARE_IDENTITY_FACTORY(_type) class IdentityFactory<_type>
 GKO_INSTANTIATE_FOR_EACH_VALUE_TYPE(GKO_DECLARE_IDENTITY_FACTORY);
 
 

--- a/core/solver/bicgstab_kernels.hpp
+++ b/core/solver/bicgstab_kernels.hpp
@@ -107,7 +107,7 @@ namespace bicgstab {
     template <typename ValueType>                      \
     GKO_DECLARE_BICGSTAB_STEP_3_KERNEL(ValueType);     \
     template <typename ValueType>                      \
-    GKO_DECLARE_BICGSTAB_FINALIZE_KERNEL(ValueType);
+    GKO_DECLARE_BICGSTAB_FINALIZE_KERNEL(ValueType)
 
 
 }  // namespace bicgstab

--- a/core/solver/cgs_kernels.hpp
+++ b/core/solver/cgs_kernels.hpp
@@ -93,7 +93,7 @@ namespace cgs {
     template <typename ValueType>                 \
     GKO_DECLARE_CGS_STEP_2_KERNEL(ValueType);     \
     template <typename ValueType>                 \
-    GKO_DECLARE_CGS_STEP_3_KERNEL(ValueType);
+    GKO_DECLARE_CGS_STEP_3_KERNEL(ValueType)
 
 
 }  // namespace cgs

--- a/cuda/CMakeLists.txt
+++ b/cuda/CMakeLists.txt
@@ -46,7 +46,8 @@ if(NOT CMAKE_CUDA_COMPILER_VERSION MATCHES "9.0")
         PRIVATE
             $<$<COMPILE_LANGUAGE:CUDA>:--expt-relaxed-constexpr>)
 endif()
-
+target_compile_options(ginkgo_cuda PRIVATE $<$<COMPILE_LANGUAGE:CUDA>:${GINKGO_CUDA_COMPILER_FLAGS}>)
+target_compile_options(ginkgo_cuda PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${GINKGO_COMPILER_FLAGS}>)
 ginkgo_compile_features(ginkgo_cuda)
 target_include_directories(ginkgo_cuda
     SYSTEM PRIVATE ${CUDA_INCLUDE_DIRS})

--- a/cuda/base/cublas_bindings.hpp
+++ b/cuda/base/cublas_bindings.hpp
@@ -105,17 +105,18 @@ GKO_BIND_CUBLAS_GEMM(ValueType, detail::not_implemented);
 #undef GKO_BIND_CUBLAS_GEMM
 
 
-#define GKO_BIND_CUBLAS_GEAM(ValueType, CublasName)                         \
-    inline void geam(cublasHandle_t handle, cublasOperation_t transa,       \
-                     cublasOperation_t transb, int m, int n,                \
-                     const ValueType *alpha, const ValueType *a, int lda,   \
-                     const ValueType *beta, const ValueType *b, int ldb,    \
-                     ValueType *c, int ldc)                                 \
-    {                                                                       \
-        GKO_ASSERT_NO_CUBLAS_ERRORS(                                        \
-            CublasName(handle, transa, transb, m, n, as_culibs_type(alpha), \
-                       as_culibs_type(a), lda, as_culibs_type(beta),        \
-                       as_culibs_type(b), ldb, as_culibs_type(c), ldc));    \
+#define GKO_BIND_CUBLAS_GEAM(ValueType, CublasName)                          \
+    inline void geam(cublasHandle_t handle, cublasOperation_t transa,        \
+                     cublasOperation_t transb, int m, int n,                 \
+                     const ValueType *alpha, const ValueType *a, int lda,    \
+                     const ValueType *beta, const ValueType *b, int ldb,     \
+                     ValueType *c, int ldc)                                  \
+    {                                                                        \
+        GKO_ASSERT_NO_CUBLAS_ERRORS(                                         \
+            CublasName(handle, transa, transb, m, n, as_culibs_type(alpha),  \
+                       as_culibs_type(a), lda, as_culibs_type(beta),         \
+                       as_culibs_type(b), ldb, as_culibs_type(c), ldc));     \
+    }                                                                        \
     static_assert(true,                                                      \
                   "This assert is used to counter the false positive extra " \
                   "semi-colon warnings")
@@ -130,13 +131,13 @@ GKO_BIND_CUBLAS_GEAM(ValueType, detail::not_implemented);
 #undef GKO_BIND_CUBLAS_GEAM
 
 
-#define GKO_BIND_CUBLAS_SCAL(ValueType, CublasName)                        \
-    inline void scal(cublasHandle_t handle, int n, const ValueType *alpha, \
-                     ValueType *x, int incx)                               \
-    {                                                                      \
-        GKO_ASSERT_NO_CUBLAS_ERRORS(CublasName(                            \
-            handle, n, as_culibs_type(alpha), as_culibs_type(x), incx));   \
-    }
+#define GKO_BIND_CUBLAS_SCAL(ValueType, CublasName)                          \
+    inline void scal(cublasHandle_t handle, int n, const ValueType *alpha,   \
+                     ValueType *x, int incx)                                 \
+    {                                                                        \
+        GKO_ASSERT_NO_CUBLAS_ERRORS(CublasName(                              \
+            handle, n, as_culibs_type(alpha), as_culibs_type(x), incx));     \
+    }                                                                        \
     static_assert(true,                                                      \
                   "This assert is used to counter the false positive extra " \
                   "semi-colon warnings")
@@ -151,14 +152,14 @@ GKO_BIND_CUBLAS_SCAL(ValueType, detail::not_implemented);
 #undef GKO_BIND_CUBLAS_SCAL
 
 
-#define GKO_BIND_CUBLAS_AXPY(ValueType, CublasName)                         \
-    inline void axpy(cublasHandle_t handle, int n, const ValueType *alpha,  \
-                     const ValueType *x, int incx, ValueType *y, int incy)  \
-    {                                                                       \
-        GKO_ASSERT_NO_CUBLAS_ERRORS(                                        \
-            CublasName(handle, n, as_culibs_type(alpha), as_culibs_type(x), \
-                       incx, as_culibs_type(y), incy));                     \
-    }
+#define GKO_BIND_CUBLAS_AXPY(ValueType, CublasName)                          \
+    inline void axpy(cublasHandle_t handle, int n, const ValueType *alpha,   \
+                     const ValueType *x, int incx, ValueType *y, int incy)   \
+    {                                                                        \
+        GKO_ASSERT_NO_CUBLAS_ERRORS(                                         \
+            CublasName(handle, n, as_culibs_type(alpha), as_culibs_type(x),  \
+                       incx, as_culibs_type(y), incy));                      \
+    }                                                                        \
     static_assert(true,                                                      \
                   "This assert is used to counter the false positive extra " \
                   "semi-colon warnings")
@@ -180,7 +181,7 @@ GKO_BIND_CUBLAS_AXPY(ValueType, detail::not_implemented);
         GKO_ASSERT_NO_CUBLAS_ERRORS(CublasName(handle, n, as_culibs_type(x),   \
                                                incx, as_culibs_type(y), incy,  \
                                                as_culibs_type(result)));       \
-    }
+    }                                                                          \
     static_assert(true,                                                        \
                   "This assert is used to counter the false positive extra "   \
                   "semi-colon warnings")
@@ -195,15 +196,16 @@ GKO_BIND_CUBLAS_DOT(ValueType, detail::not_implemented);
 #undef GKO_BIND_CUBLAS_DOT
 
 
-#define GKO_BIND_CUBLAS_COMPLEX_NORM2(ValueType, CublasName)            \
-    inline void norm2(cublasHandle_t handle, int n, const ValueType *x, \
-                      int incx, ValueType *result)                      \
-    {                                                                   \
-        zero_array(n, result);                                          \
-        GKO_ASSERT_NO_CUBLAS_ERRORS(                                    \
-            CublasName(handle, n, as_culibs_type(x), incx,              \
-                       reinterpret_cast<remove_complex<ValueType> *>(   \
-                           as_culibs_type(result))));                   \
+#define GKO_BIND_CUBLAS_COMPLEX_NORM2(ValueType, CublasName)                 \
+    inline void norm2(cublasHandle_t handle, int n, const ValueType *x,      \
+                      int incx, ValueType *result)                           \
+    {                                                                        \
+        zero_array(n, result);                                               \
+        GKO_ASSERT_NO_CUBLAS_ERRORS(                                         \
+            CublasName(handle, n, as_culibs_type(x), incx,                   \
+                       reinterpret_cast<remove_complex<ValueType> *>(        \
+                           as_culibs_type(result))));                        \
+    }                                                                        \
     static_assert(true,                                                      \
                   "This assert is used to counter the false positive extra " \
                   "semi-colon warnings")
@@ -215,7 +217,7 @@ GKO_BIND_CUBLAS_DOT(ValueType, detail::not_implemented);
     {                                                                          \
         GKO_ASSERT_NO_CUBLAS_ERRORS(CublasName(handle, n, as_culibs_type(x),   \
                                                incx, as_culibs_type(result))); \
-    }
+    }                                                                          \
     static_assert(true,                                                        \
                   "This assert is used to counter the false positive extra "   \
                   "semi-colon warnings")

--- a/cuda/base/cublas_bindings.hpp
+++ b/cuda/base/cublas_bindings.hpp
@@ -90,7 +90,8 @@ struct is_supported<std::complex<double>> : std::true_type {};
             CublasName(handle, transa, transb, m, n, k, as_culibs_type(alpha), \
                        as_culibs_type(a), lda, as_culibs_type(b), ldb,         \
                        as_culibs_type(beta), as_culibs_type(c), ldc));         \
-    }
+    }                                                                          \
+    void __gko_macro_terminator__()
 
 GKO_BIND_CUBLAS_GEMM(float, cublasSgemm);
 GKO_BIND_CUBLAS_GEMM(double, cublasDgemm);
@@ -113,7 +114,8 @@ GKO_BIND_CUBLAS_GEMM(ValueType, detail::not_implemented);
             CublasName(handle, transa, transb, m, n, as_culibs_type(alpha), \
                        as_culibs_type(a), lda, as_culibs_type(beta),        \
                        as_culibs_type(b), ldb, as_culibs_type(c), ldc));    \
-    }
+    }                                                                       \
+    void __gko_macro_terminator__()
 
 GKO_BIND_CUBLAS_GEAM(float, cublasSgeam);
 GKO_BIND_CUBLAS_GEAM(double, cublasDgeam);
@@ -132,6 +134,7 @@ GKO_BIND_CUBLAS_GEAM(ValueType, detail::not_implemented);
         GKO_ASSERT_NO_CUBLAS_ERRORS(CublasName(                            \
             handle, n, as_culibs_type(alpha), as_culibs_type(x), incx));   \
     }
+    void __gko_macro_terminator__()
 
 GKO_BIND_CUBLAS_SCAL(float, cublasSscal);
 GKO_BIND_CUBLAS_SCAL(double, cublasDscal);
@@ -151,6 +154,7 @@ GKO_BIND_CUBLAS_SCAL(ValueType, detail::not_implemented);
             CublasName(handle, n, as_culibs_type(alpha), as_culibs_type(x), \
                        incx, as_culibs_type(y), incy));                     \
     }
+    void __gko_macro_terminator__()
 
 GKO_BIND_CUBLAS_AXPY(float, cublasSaxpy);
 GKO_BIND_CUBLAS_AXPY(double, cublasDaxpy);
@@ -170,6 +174,7 @@ GKO_BIND_CUBLAS_AXPY(ValueType, detail::not_implemented);
                                                incx, as_culibs_type(y), incy,  \
                                                as_culibs_type(result)));       \
     }
+    void __gko_macro_terminator__()
 
 GKO_BIND_CUBLAS_DOT(float, cublasSdot);
 GKO_BIND_CUBLAS_DOT(double, cublasDdot);
@@ -190,7 +195,8 @@ GKO_BIND_CUBLAS_DOT(ValueType, detail::not_implemented);
             CublasName(handle, n, as_culibs_type(x), incx,              \
                        reinterpret_cast<remove_complex<ValueType> *>(   \
                            as_culibs_type(result))));                   \
-    }
+    }                                                                   \
+    void __gko_macro_terminator__()
 
 
 #define GKO_BIND_CUBLAS_NORM2(ValueType, CublasName)                           \
@@ -200,6 +206,7 @@ GKO_BIND_CUBLAS_DOT(ValueType, detail::not_implemented);
         GKO_ASSERT_NO_CUBLAS_ERRORS(CublasName(handle, n, as_culibs_type(x),   \
                                                incx, as_culibs_type(result))); \
     }
+    void __gko_macro_terminator__()
 
 
 GKO_BIND_CUBLAS_NORM2(float, cublasSnrm2);

--- a/cuda/base/cublas_bindings.hpp
+++ b/cuda/base/cublas_bindings.hpp
@@ -91,7 +91,9 @@ struct is_supported<std::complex<double>> : std::true_type {};
                        as_culibs_type(a), lda, as_culibs_type(b), ldb,         \
                        as_culibs_type(beta), as_culibs_type(c), ldc));         \
     }                                                                          \
-    void __gko_macro_terminator__()
+    static_assert(true,                                                        \
+                  "This assert is used to counter the false positive extra "   \
+                  "semi-colon warnings")
 
 GKO_BIND_CUBLAS_GEMM(float, cublasSgemm);
 GKO_BIND_CUBLAS_GEMM(double, cublasDgemm);
@@ -114,8 +116,9 @@ GKO_BIND_CUBLAS_GEMM(ValueType, detail::not_implemented);
             CublasName(handle, transa, transb, m, n, as_culibs_type(alpha), \
                        as_culibs_type(a), lda, as_culibs_type(beta),        \
                        as_culibs_type(b), ldb, as_culibs_type(c), ldc));    \
-    }                                                                       \
-    void __gko_macro_terminator__()
+    static_assert(true,                                                      \
+                  "This assert is used to counter the false positive extra " \
+                  "semi-colon warnings")
 
 GKO_BIND_CUBLAS_GEAM(float, cublasSgeam);
 GKO_BIND_CUBLAS_GEAM(double, cublasDgeam);
@@ -134,7 +137,9 @@ GKO_BIND_CUBLAS_GEAM(ValueType, detail::not_implemented);
         GKO_ASSERT_NO_CUBLAS_ERRORS(CublasName(                            \
             handle, n, as_culibs_type(alpha), as_culibs_type(x), incx));   \
     }
-    void __gko_macro_terminator__()
+    static_assert(true,                                                      \
+                  "This assert is used to counter the false positive extra " \
+                  "semi-colon warnings")
 
 GKO_BIND_CUBLAS_SCAL(float, cublasSscal);
 GKO_BIND_CUBLAS_SCAL(double, cublasDscal);
@@ -154,7 +159,9 @@ GKO_BIND_CUBLAS_SCAL(ValueType, detail::not_implemented);
             CublasName(handle, n, as_culibs_type(alpha), as_culibs_type(x), \
                        incx, as_culibs_type(y), incy));                     \
     }
-    void __gko_macro_terminator__()
+    static_assert(true,                                                      \
+                  "This assert is used to counter the false positive extra " \
+                  "semi-colon warnings")
 
 GKO_BIND_CUBLAS_AXPY(float, cublasSaxpy);
 GKO_BIND_CUBLAS_AXPY(double, cublasDaxpy);
@@ -174,7 +181,9 @@ GKO_BIND_CUBLAS_AXPY(ValueType, detail::not_implemented);
                                                incx, as_culibs_type(y), incy,  \
                                                as_culibs_type(result)));       \
     }
-    void __gko_macro_terminator__()
+    static_assert(true,                                                        \
+                  "This assert is used to counter the false positive extra "   \
+                  "semi-colon warnings")
 
 GKO_BIND_CUBLAS_DOT(float, cublasSdot);
 GKO_BIND_CUBLAS_DOT(double, cublasDdot);
@@ -195,8 +204,9 @@ GKO_BIND_CUBLAS_DOT(ValueType, detail::not_implemented);
             CublasName(handle, n, as_culibs_type(x), incx,              \
                        reinterpret_cast<remove_complex<ValueType> *>(   \
                            as_culibs_type(result))));                   \
-    }                                                                   \
-    void __gko_macro_terminator__()
+    static_assert(true,                                                      \
+                  "This assert is used to counter the false positive extra " \
+                  "semi-colon warnings")
 
 
 #define GKO_BIND_CUBLAS_NORM2(ValueType, CublasName)                           \
@@ -206,7 +216,9 @@ GKO_BIND_CUBLAS_DOT(ValueType, detail::not_implemented);
         GKO_ASSERT_NO_CUBLAS_ERRORS(CublasName(handle, n, as_culibs_type(x),   \
                                                incx, as_culibs_type(result))); \
     }
-    void __gko_macro_terminator__()
+    static_assert(true,                                                        \
+                  "This assert is used to counter the false positive extra "   \
+                  "semi-colon warnings")
 
 
 GKO_BIND_CUBLAS_NORM2(float, cublasSnrm2);

--- a/cuda/base/cusparse_bindings.hpp
+++ b/cuda/base/cusparse_bindings.hpp
@@ -100,7 +100,7 @@ struct is_supported<std::complex<double>, int32> : std::true_type {};
                      const ValueType *alpha, const cusparseMatDescr_t descrA, \
                      const ValueType *csrValA, const int64 *csrRowPtrA,       \
                      const int64 *csrColIndA, const ValueType *x,             \
-                     const ValueType *beta, ValueType *y) GKO_NOT_IMPLEMENTED;
+                     const ValueType *beta, ValueType *y) GKO_NOT_IMPLEMENTED
 
 GKO_BIND_CUSPARSE32_SPMV(float, cusparseScsrmv);
 GKO_BIND_CUSPARSE32_SPMV(double, cusparseDcsrmv);
@@ -143,7 +143,7 @@ GKO_BIND_CUSPARSE64_SPMV(ValueType, detail::not_implemented);
                           const int64 *OrigRowPtrA, const int64 *OrigColIndA, \
                           ValueType *TransValA, int64 *TransRowPtrA,          \
                           int64 *TransColIndA, cusparseAction_t copyValues,   \
-                          cusparseIndexBase_t idxBase) GKO_NOT_IMPLEMENTED;
+                          cusparseIndexBase_t idxBase) GKO_NOT_IMPLEMENTED
 
 GKO_BIND_CUSPARSE_TRANSPOSE32(float, cusparseScsr2csc);
 GKO_BIND_CUSPARSE_TRANSPOSE32(double, cusparseDcsr2csc);
@@ -166,7 +166,7 @@ GKO_BIND_CUSPARSE_TRANSPOSE64(ValueType, detail::not_implemented);
         const ValueType *OrigValA, const int32 *OrigRowPtrA,                 \
         const int32 *OrigColIndA, ValueType *TransValA, int32 *TransRowPtrA, \
         int32 *TransColIndA, cusparseAction_t copyValues,                    \
-        cusparseIndexBase_t idxBase) GKO_NOT_IMPLEMENTED;
+        cusparseIndexBase_t idxBase) GKO_NOT_IMPLEMENTED
 
 #define GKO_BIND_CUSPARSE_CONJ_TRANSPOSE64(ValueType, CusparseName)          \
     inline void conj_transpose(                                              \
@@ -174,7 +174,7 @@ GKO_BIND_CUSPARSE_TRANSPOSE64(ValueType, detail::not_implemented);
         const ValueType *OrigValA, const int64 *OrigRowPtrA,                 \
         const int64 *OrigColIndA, ValueType *TransValA, int64 *TransRowPtrA, \
         int64 *TransColIndA, cusparseAction_t copyValues,                    \
-        cusparseIndexBase_t idxBase) GKO_NOT_IMPLEMENTED;
+        cusparseIndexBase_t idxBase) GKO_NOT_IMPLEMENTED
 
 GKO_BIND_CUSPARSE_CONJ_TRANSPOSE32(float, cusparseScsr2csc);
 GKO_BIND_CUSPARSE_CONJ_TRANSPOSE32(double, cusparseDcsr2csc);

--- a/cuda/base/cusparse_bindings.hpp
+++ b/cuda/base/cusparse_bindings.hpp
@@ -94,13 +94,16 @@ struct is_supported<std::complex<double>, int32> : std::true_type {};
                   "This assert is used to counter the false positive extra "  \
                   "semi-colon warnings")
 
-#define GKO_BIND_CUSPARSE64_SPMV(ValueType, CusparseName)                     \
-    inline void spmv(cusparseHandle_t handle, cusparseOperation_t transA,     \
-                     size_type m, size_type n, size_type nnz,                 \
-                     const ValueType *alpha, const cusparseMatDescr_t descrA, \
-                     const ValueType *csrValA, const int64 *csrRowPtrA,       \
-                     const int64 *csrColIndA, const ValueType *x,             \
-                     const ValueType *beta, ValueType *y) GKO_NOT_IMPLEMENTED
+#define GKO_BIND_CUSPARSE64_SPMV(ValueType, CusparseName)                      \
+    inline void spmv(cusparseHandle_t handle, cusparseOperation_t transA,      \
+                     size_type m, size_type n, size_type nnz,                  \
+                     const ValueType *alpha, const cusparseMatDescr_t descrA,  \
+                     const ValueType *csrValA, const int64 *csrRowPtrA,        \
+                     const int64 *csrColIndA, const ValueType *x,              \
+                     const ValueType *beta, ValueType *y) GKO_NOT_IMPLEMENTED; \
+    static_assert(true,                                                        \
+                  "This assert is used to counter the false positive extra "   \
+                  "semi-colon warnings")
 
 GKO_BIND_CUSPARSE32_SPMV(float, cusparseScsrmv);
 GKO_BIND_CUSPARSE32_SPMV(double, cusparseDcsrmv);
@@ -143,7 +146,10 @@ GKO_BIND_CUSPARSE64_SPMV(ValueType, detail::not_implemented);
                           const int64 *OrigRowPtrA, const int64 *OrigColIndA, \
                           ValueType *TransValA, int64 *TransRowPtrA,          \
                           int64 *TransColIndA, cusparseAction_t copyValues,   \
-                          cusparseIndexBase_t idxBase) GKO_NOT_IMPLEMENTED
+                          cusparseIndexBase_t idxBase) GKO_NOT_IMPLEMENTED;   \
+    static_assert(true,                                                       \
+                  "This assert is used to counter the false positive extra "  \
+                  "semi-colon warnings")
 
 GKO_BIND_CUSPARSE_TRANSPOSE32(float, cusparseScsr2csc);
 GKO_BIND_CUSPARSE_TRANSPOSE32(double, cusparseDcsr2csc);
@@ -166,7 +172,10 @@ GKO_BIND_CUSPARSE_TRANSPOSE64(ValueType, detail::not_implemented);
         const ValueType *OrigValA, const int32 *OrigRowPtrA,                 \
         const int32 *OrigColIndA, ValueType *TransValA, int32 *TransRowPtrA, \
         int32 *TransColIndA, cusparseAction_t copyValues,                    \
-        cusparseIndexBase_t idxBase) GKO_NOT_IMPLEMENTED
+        cusparseIndexBase_t idxBase) GKO_NOT_IMPLEMENTED;                    \
+    static_assert(true,                                                      \
+                  "This assert is used to counter the false positive extra " \
+                  "semi-colon warnings")
 
 #define GKO_BIND_CUSPARSE_CONJ_TRANSPOSE64(ValueType, CusparseName)          \
     inline void conj_transpose(                                              \
@@ -174,7 +183,10 @@ GKO_BIND_CUSPARSE_TRANSPOSE64(ValueType, detail::not_implemented);
         const ValueType *OrigValA, const int64 *OrigRowPtrA,                 \
         const int64 *OrigColIndA, ValueType *TransValA, int64 *TransRowPtrA, \
         int64 *TransColIndA, cusparseAction_t copyValues,                    \
-        cusparseIndexBase_t idxBase) GKO_NOT_IMPLEMENTED
+        cusparseIndexBase_t idxBase) GKO_NOT_IMPLEMENTED;                    \
+    static_assert(true,                                                      \
+                  "This assert is used to counter the false positive extra " \
+                  "semi-colon warnings")
 
 GKO_BIND_CUSPARSE_CONJ_TRANSPOSE32(float, cusparseScsr2csc);
 GKO_BIND_CUSPARSE_CONJ_TRANSPOSE32(double, cusparseDcsr2csc);

--- a/cuda/base/cusparse_bindings.hpp
+++ b/cuda/base/cusparse_bindings.hpp
@@ -90,7 +90,9 @@ struct is_supported<std::complex<double>, int32> : std::true_type {};
             as_culibs_type(csrValA), csrRowPtrA, csrColIndA,                  \
             as_culibs_type(x), as_culibs_type(beta), as_culibs_type(y)));     \
     }                                                                         \
-    void __gko_macro_terminator__()
+    static_assert(true,                                                       \
+                  "This assert is used to counter the false positive extra "  \
+                  "semi-colon warnings")
 
 #define GKO_BIND_CUSPARSE64_SPMV(ValueType, CusparseName)                     \
     inline void spmv(cusparseHandle_t handle, cusparseOperation_t transA,     \
@@ -131,7 +133,9 @@ GKO_BIND_CUSPARSE64_SPMV(ValueType, detail::not_implemented);
                          OrigRowPtrA, OrigColIndA, as_culibs_type(TransValA), \
                          TransRowPtrA, TransColIndA, copyValues, idxBase));   \
     }                                                                         \
-    void __gko_macro_terminator__()
+    static_assert(true,                                                       \
+                  "This assert is used to counter the false positive extra "  \
+                  "semi-colon warnings")
 
 #define GKO_BIND_CUSPARSE_TRANSPOSE64(ValueType, CusparseName)                \
     inline void transpose(cusparseHandle_t handle, size_type m, size_type n,  \

--- a/cuda/base/cusparse_bindings.hpp
+++ b/cuda/base/cusparse_bindings.hpp
@@ -89,7 +89,8 @@ struct is_supported<std::complex<double>, int32> : std::true_type {};
             handle, transA, m, n, nnz, as_culibs_type(alpha), descrA,         \
             as_culibs_type(csrValA), csrRowPtrA, csrColIndA,                  \
             as_culibs_type(x), as_culibs_type(beta), as_culibs_type(y)));     \
-    }
+    }                                                                         \
+    void __gko_macro_terminator__()
 
 #define GKO_BIND_CUSPARSE64_SPMV(ValueType, CusparseName)                     \
     inline void spmv(cusparseHandle_t handle, cusparseOperation_t transA,     \
@@ -129,7 +130,8 @@ GKO_BIND_CUSPARSE64_SPMV(ValueType, detail::not_implemented);
             CusparseName(handle, m, n, nnz, as_culibs_type(OrigValA),         \
                          OrigRowPtrA, OrigColIndA, as_culibs_type(TransValA), \
                          TransRowPtrA, TransColIndA, copyValues, idxBase));   \
-    }
+    }                                                                         \
+    void __gko_macro_terminator__()
 
 #define GKO_BIND_CUSPARSE_TRANSPOSE64(ValueType, CusparseName)                \
     inline void transpose(cusparseHandle_t handle, size_type m, size_type n,  \

--- a/include/ginkgo/core/base/array.hpp
+++ b/include/ginkgo/core/base/array.hpp
@@ -90,9 +90,9 @@ public:
      * the executor of the source Array.
      */
     Array() noexcept
-        : num_elems_(0),
-          data_(nullptr, default_deleter{nullptr}),
-          exec_(nullptr)
+        : exec_(nullptr),
+          num_elems_(0),
+          data_(nullptr, default_deleter{nullptr})
     {}
 
     /**
@@ -101,9 +101,9 @@ public:
      * @param exec  the Executor where the array data is allocated
      */
     Array(std::shared_ptr<const Executor> exec) noexcept
-        : num_elems_(0),
-          data_(nullptr, default_deleter{exec}),
-          exec_(std::move(exec))
+        : exec_(std::move(exec)),
+          num_elems_(0),
+          data_(nullptr, default_deleter{exec})
     {}
 
     /**
@@ -114,9 +114,9 @@ public:
      *                   `value_type` elements) allocated on the Executor
      */
     Array(std::shared_ptr<const Executor> exec, size_type num_elems)
-        : num_elems_(num_elems),
-          data_(nullptr, default_deleter{exec}),
-          exec_(std::move(exec))
+        : exec_(std::move(exec)),
+          num_elems_(num_elems),
+          data_(nullptr, default_deleter{exec})
     {
         if (num_elems > 0) {
             data_.reset(exec_->alloc<value_type>(num_elems));
@@ -435,9 +435,9 @@ private:
     using data_manager =
         std::unique_ptr<value_type[], std::function<void(value_type[])>>;
 
+    std::shared_ptr<const Executor> exec_;
     size_type num_elems_;
     data_manager data_;
-    std::shared_ptr<const Executor> exec_;
 };
 
 

--- a/include/ginkgo/core/base/exception_helpers.hpp
+++ b/include/ginkgo/core/base/exception_helpers.hpp
@@ -66,7 +66,9 @@ namespace gko {
     {                                                              \
         throw ::gko::NotImplemented(__FILE__, __LINE__, __func__); \
     }                                                              \
-    void __gko_macro_terminator__()
+    static_assert(true,                                                      \
+                  "This assert is used to counter the false positive extra " \
+                  "semi-colon warnings")
 
 
 /**
@@ -82,7 +84,9 @@ namespace gko {
         throw ::gko::NotCompiled(__FILE__, __LINE__, __func__, \
                                  GKO_QUOTE(_module));          \
     }                                                          \
-    void __gko_macro_terminator__()
+    static_assert(true,                                                      \
+                  "This assert is used to counter the false positive extra " \
+                  "semi-colon warnings")
 
 
 /**
@@ -319,6 +323,9 @@ inline T ensure_allocated_impl(T ptr, const std::string &file, int line,
     if (_index >= _bound) {                                                \
         throw ::gko::OutOfBoundsError(__FILE__, __LINE__, _index, _bound); \
     }
+    static_assert(true,                                                      \
+                  "This assert is used to counter the false positive extra " \
+                  "semi-colon warnings")
 
 
 /**
@@ -345,6 +352,9 @@ inline T ensure_allocated_impl(T ptr, const std::string &file, int line,
     {                                                              \
         throw ::gko::KernelNotFound(__FILE__, __LINE__, __func__); \
     }
+    static_assert(true,                                                      \
+                  "This assert is used to counter the false positive extra " \
+                  "semi-colon warnings")
 
 
 }  // namespace gko

--- a/include/ginkgo/core/base/exception_helpers.hpp
+++ b/include/ginkgo/core/base/exception_helpers.hpp
@@ -62,10 +62,10 @@ namespace gko {
  * Attempts to call this function will result in a runtime error of type
  * NotImplemented.
  */
-#define GKO_NOT_IMPLEMENTED                                        \
-    {                                                              \
-        throw ::gko::NotImplemented(__FILE__, __LINE__, __func__); \
-    }                                                              \
+#define GKO_NOT_IMPLEMENTED                                                  \
+    {                                                                        \
+        throw ::gko::NotImplemented(__FILE__, __LINE__, __func__);           \
+    }                                                                        \
     static_assert(true,                                                      \
                   "This assert is used to counter the false positive extra " \
                   "semi-colon warnings")
@@ -79,11 +79,11 @@ namespace gko {
  *
  * @param _module  the module which should be compiled to enable the function
  */
-#define GKO_NOT_COMPILED(_module)                              \
-    {                                                          \
-        throw ::gko::NotCompiled(__FILE__, __LINE__, __func__, \
-                                 GKO_QUOTE(_module));          \
-    }                                                          \
+#define GKO_NOT_COMPILED(_module)                                            \
+    {                                                                        \
+        throw ::gko::NotCompiled(__FILE__, __LINE__, __func__,               \
+                                 GKO_QUOTE(_module));                        \
+    }                                                                        \
     static_assert(true,                                                      \
                   "This assert is used to counter the false positive extra " \
                   "semi-colon warnings")
@@ -319,10 +319,10 @@ inline T ensure_allocated_impl(T ptr, const std::string &file, int line,
  *
  * @throw OutOfBoundsError  if `_index >= _bound`
  */
-#define GKO_ENSURE_IN_BOUNDS(_index, _bound)                               \
-    if (_index >= _bound) {                                                \
-        throw ::gko::OutOfBoundsError(__FILE__, __LINE__, _index, _bound); \
-    }
+#define GKO_ENSURE_IN_BOUNDS(_index, _bound)                                 \
+    if (_index >= _bound) {                                                  \
+        throw ::gko::OutOfBoundsError(__FILE__, __LINE__, _index, _bound);   \
+    }                                                                        \
     static_assert(true,                                                      \
                   "This assert is used to counter the false positive extra " \
                   "semi-colon warnings")
@@ -348,10 +348,10 @@ inline T ensure_allocated_impl(T ptr, const std::string &file, int line,
  * Attempts to call this kernel will result in a runtime error of type
  * KernelNotFound.
  */
-#define GKO_KERNEL_NOT_FOUND                                       \
-    {                                                              \
-        throw ::gko::KernelNotFound(__FILE__, __LINE__, __func__); \
-    }
+#define GKO_KERNEL_NOT_FOUND                                                 \
+    {                                                                        \
+        throw ::gko::KernelNotFound(__FILE__, __LINE__, __func__);           \
+    }                                                                        \
     static_assert(true,                                                      \
                   "This assert is used to counter the false positive extra " \
                   "semi-colon warnings")

--- a/include/ginkgo/core/base/exception_helpers.hpp
+++ b/include/ginkgo/core/base/exception_helpers.hpp
@@ -65,7 +65,8 @@ namespace gko {
 #define GKO_NOT_IMPLEMENTED                                        \
     {                                                              \
         throw ::gko::NotImplemented(__FILE__, __LINE__, __func__); \
-    }
+    }                                                              \
+    void __gko_macro_terminator__()
 
 
 /**
@@ -80,7 +81,8 @@ namespace gko {
     {                                                          \
         throw ::gko::NotCompiled(__FILE__, __LINE__, __func__, \
                                  GKO_QUOTE(_module));          \
-    }
+    }                                                          \
+    void __gko_macro_terminator__()
 
 
 /**

--- a/include/ginkgo/core/base/executor.hpp
+++ b/include/ginkgo/core/base/executor.hpp
@@ -304,8 +304,10 @@ private:                                                                     \
             return name.c_str();                                               \
         }                                                                      \
                                                                                \
-        GKO_ENABLE_KERNEL_FOR_ALL_EXECUTORS(GKO_KERNEL_DEFINE_RUN_OVERLOAD, _kernel);        \
-        GKO_KERNEL_DEFINE_RUN_OVERLOAD(ReferenceExecutor, reference, _kernel);        \
+        GKO_ENABLE_KERNEL_FOR_ALL_EXECUTORS(                                   \
+            GKO_KERNEL_DETAIL_DEFINE_RUN_OVERLOAD, _kernel);                   \
+        GKO_KERNEL_DETAIL_DEFINE_RUN_OVERLOAD(ReferenceExecutor, reference,    \
+                                              _kernel);                        \
                                                                                \
     private:                                                                   \
         mutable std::tuple<Args &&...> data;                                   \

--- a/include/ginkgo/core/base/executor.hpp
+++ b/include/ginkgo/core/base/executor.hpp
@@ -291,7 +291,8 @@ private:                                                              \
     static _name##_operation<Args...> make_##_name(Args &&... args)            \
     {                                                                          \
         return _name##_operation<Args...>(std::forward<Args>(args)...);        \
-    }
+    }                                                                          \
+    void __gko_macro_terminator__()
 
 
 /**

--- a/include/ginkgo/core/base/executor.hpp
+++ b/include/ginkgo/core/base/executor.hpp
@@ -34,10 +34,6 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #ifndef GKO_CORE_EXECUTOR_HPP_
 #define GKO_CORE_EXECUTOR_HPP_
 
-#ifdef __GNUC__
-#pragma GCC system_header
-#endif  // __GNUC__
-
 #include <memory>
 #include <sstream>
 #include <tuple>

--- a/include/ginkgo/core/base/lin_op.hpp
+++ b/include/ginkgo/core/base/lin_op.hpp
@@ -34,10 +34,6 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #ifndef GKO_CORE_BASE_LIN_OP_HPP_
 #define GKO_CORE_BASE_LIN_OP_HPP_
 
-#ifdef __GNUC__
-#pragma GCC system_header
-#endif  // __GNUC__
-
 #include <ginkgo/core/base/abstract_factory.hpp>
 #include <ginkgo/core/base/dim.hpp>
 #include <ginkgo/core/base/exception_helpers.hpp>

--- a/include/ginkgo/core/base/lin_op.hpp
+++ b/include/ginkgo/core/base/lin_op.hpp
@@ -34,6 +34,9 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #ifndef GKO_CORE_BASE_LIN_OP_HPP_
 #define GKO_CORE_BASE_LIN_OP_HPP_
 
+#ifdef __GNUC__
+#pragma GCC system_header
+#endif  // __GNUC__
 
 #include <ginkgo/core/base/abstract_factory.hpp>
 #include <ginkgo/core/base/dim.hpp>
@@ -693,7 +696,9 @@ private:                                                                     \
     _parameters_name##_type _parameters_name##_;                             \
                                                                              \
 public:                                                                      \
-    void __gko_macro_terminator__()
+    static_assert(true,                                                      \
+                  "This assert is used to counter the false positive extra " \
+                  "semi-colon warnings")
 
 
 /**
@@ -702,11 +707,14 @@ public:                                                                      \
  *
  * @param _factory_name  the factory for which to define the method
  */
-#define GKO_ENABLE_BUILD_METHOD(_factory_name)       \
-    static auto build()->decltype(Factory::create()) \
-    {                                                \
-        return Factory::create();                    \
-    }
+#define GKO_ENABLE_BUILD_METHOD(_factory_name)                               \
+    static auto build()->decltype(Factory::create())                         \
+    {                                                                        \
+        return Factory::create();                                            \
+    }                                                                        \
+    static_assert(true,                                                      \
+                  "This assert is used to counter the false positive extra " \
+                  "semi-colon warnings")
 
 
 #ifndef __CUDACC__
@@ -718,17 +726,20 @@ public:                                                                      \
  *
  * @see GKO_ENABLE_LIN_OP_FACTORY for more details, and usage example
  */
-#define GKO_FACTORY_PARAMETER(_name, ...)                    \
-    mutable _name{__VA_ARGS__};                              \
-                                                             \
-    template <typename... Args>                              \
-    auto with_##_name(Args &&... _value)                     \
-        const->const ::gko::xstd::decay_t<decltype(*this)> & \
-    {                                                        \
-        using type = decltype(this->_name);                  \
-        this->_name = type{std::forward<Args>(_value)...};   \
-        return *this;                                        \
-    }
+#define GKO_FACTORY_PARAMETER(_name, ...)                                    \
+    mutable _name{__VA_ARGS__};                                              \
+                                                                             \
+    template <typename... Args>                                              \
+    auto with_##_name(Args &&... _value)                                     \
+        const->const ::gko::xstd::decay_t<decltype(*this)> &                 \
+    {                                                                        \
+        using type = decltype(this->_name);                                  \
+        this->_name = type{std::forward<Args>(_value)...};                   \
+        return *this;                                                        \
+    }                                                                        \
+    static_assert(true,                                                      \
+                  "This assert is used to counter the false positive extra " \
+                  "semi-colon warnings")
 #else  // __CUDACC__
 // A workaround for the NVCC compiler - parameter pack expansion does not work
 // properly. You won't be able to use factories in code compiled with NVCC, but

--- a/include/ginkgo/core/base/lin_op.hpp
+++ b/include/ginkgo/core/base/lin_op.hpp
@@ -692,7 +692,8 @@ public:                                                                      \
 private:                                                                     \
     _parameters_name##_type _parameters_name##_;                             \
                                                                              \
-public:
+public:                                                                      \
+    void __gko_macro_terminator__()
 
 
 /**
@@ -738,7 +739,7 @@ public:
                                           \
     template <typename... Args>           \
     auto with_##_name(Args &&... _value)  \
-        const->const ::gko::xstd::decay_t<decltype(*this)> &;
+        const->const ::gko::xstd::decay_t<decltype(*this)> &
 #endif  // __CUDACC__
 
 

--- a/include/ginkgo/core/base/matrix_data.hpp
+++ b/include/ginkgo/core/base/matrix_data.hpp
@@ -227,8 +227,8 @@ struct matrix_data {
         : size{size_ * block.size}
     {
         nonzeros.reserve(size_[0] * size_[1] * block.nonzeros.size());
-        for (int row = 0; row < size_[0]; ++row) {
-            for (int col = 0; col < size_[1]; ++col) {
+        for (size_type row = 0; row < size_[0]; ++row) {
+            for (size_type col = 0; col < size_[1]; ++col) {
                 for (const auto &elem : block.nonzeros) {
                     nonzeros.emplace_back(row * block.size[0] + elem.row,
                                           col * block.size[1] + elem.column,
@@ -273,7 +273,7 @@ struct matrix_data {
         if (value != zero<ValueType>()) {
             const auto num_nnz = std::min(size_[0], size_[1]);
             res.nonzeros.reserve(num_nnz);
-            for (int i = 0; i < num_nnz; ++i) {
+            for (size_type i = 0; i < num_nnz; ++i) {
                 res.nonzeros.emplace_back(i, i, value);
             }
         }
@@ -314,7 +314,7 @@ struct matrix_data {
         matrix_data res(size_ * block.size);
         const auto num_blocks = std::min(size_[0], size_[1]);
         res.nonzeros.reserve(num_blocks * block.nonzeros.size());
-        for (int b = 0; b < num_blocks; ++b) {
+        for (size_type b = 0; b < num_blocks; ++b) {
             for (const auto &elem : block.nonzeros) {
                 res.nonzeros.emplace_back(b * block.size[0] + elem.row,
                                           b * block.size[1] + elem.column,

--- a/include/ginkgo/core/base/range.hpp
+++ b/include/ginkgo/core/base/range.hpp
@@ -593,7 +593,8 @@ struct implement_binary_operation<operation_kind::range_by_scalar,
     {                                                               \
         return range<accessor::_operation_name<Accessor>>(          \
             operand.get_accessor());                                \
-    }
+    }                                                               \
+    void __gko_macro_terminator__()
 
 
 #define GKO_DEFINE_SIMPLE_UNARY_OPERATION(_name, ...)                  \
@@ -615,7 +616,7 @@ struct implement_binary_operation<operation_kind::range_by_scalar,
         {                                                              \
             return simple_evaluate_impl(accessor(dimensions...));      \
         }                                                              \
-    };
+    }
 
 
 namespace accessor {
@@ -785,7 +786,8 @@ GKO_BIND_UNARY_RANGE_OPERATION_TO_OPERATOR(transpose_operation, transpose);
         return range<accessor::_operation_name<                               \
             ::gko::detail::operation_kind::scalar_by_range, FirstOperand,     \
             SecondAccessor>>(first, second.get_accessor());                   \
-    }
+    }                                                                         \
+    void __gko_macro_terminator__()
 
 
 #define GKO_DEFINE_SIMPLE_BINARY_OPERATION(_name, ...)                         \
@@ -829,7 +831,7 @@ GKO_BIND_UNARY_RANGE_OPERATION_TO_OPERATOR(transpose_operation, transpose);
         {                                                                      \
             return simple_evaluate_impl(first(dims...), second);               \
         }                                                                      \
-    };
+    }
 
 
 namespace accessor {

--- a/include/ginkgo/core/base/range.hpp
+++ b/include/ginkgo/core/base/range.hpp
@@ -584,17 +584,19 @@ struct implement_binary_operation<operation_kind::range_by_scalar,
     GKO_BIND_UNARY_RANGE_OPERATION_TO_OPERATOR(_operation_name, _operator_name)
 
 
-#define GKO_BIND_UNARY_RANGE_OPERATION_TO_OPERATOR(_operation_name, \
-                                                   _operator_name)  \
-    template <typename Accessor>                                    \
-    GKO_ATTRIBUTES constexpr GKO_INLINE                             \
-        range<accessor::_operation_name<Accessor>>                  \
-        _operator_name(const range<Accessor> &operand)              \
-    {                                                               \
-        return range<accessor::_operation_name<Accessor>>(          \
-            operand.get_accessor());                                \
-    }                                                               \
-    void __gko_macro_terminator__()
+#define GKO_BIND_UNARY_RANGE_OPERATION_TO_OPERATOR(_operation_name,          \
+                                                   _operator_name)           \
+    template <typename Accessor>                                             \
+    GKO_ATTRIBUTES constexpr GKO_INLINE                                      \
+        range<accessor::_operation_name<Accessor>>                           \
+        _operator_name(const range<Accessor> &operand)                       \
+    {                                                                        \
+        return range<accessor::_operation_name<Accessor>>(                   \
+            operand.get_accessor());                                         \
+    }                                                                        \
+    static_assert(true,                                                      \
+                  "This assert is used to counter the false positive extra " \
+                  "semi-colon warnings")
 
 
 #define GKO_DEFINE_SIMPLE_UNARY_OPERATION(_name, ...)                  \
@@ -724,20 +726,23 @@ GKO_BIND_UNARY_RANGE_OPERATION_TO_OPERATOR(transpose_operation, transpose);
 #undef GKO_ENABLE_UNARY_RANGE_OPERATION
 
 
-#define GKO_ENABLE_BINARY_RANGE_OPERATION(_operation_name, _operator_name, \
-                                          _operator)                       \
-    namespace accessor {                                                   \
-    template <::gko::detail::operation_kind Kind, typename FirstOperand,   \
-              typename SecondOperand>                                      \
-    struct _operation_name                                                 \
-        : ::gko::detail::implement_binary_operation<                       \
-              Kind, FirstOperand, SecondOperand, ::gko::_operator> {       \
-        using ::gko::detail::implement_binary_operation<                   \
-            Kind, FirstOperand, SecondOperand,                             \
-            ::gko::_operator>::implement_binary_operation;                 \
-    };                                                                     \
-    }                                                                      \
-    GKO_BIND_RANGE_OPERATION_TO_OPERATOR(_operation_name, _operator_name)
+#define GKO_ENABLE_BINARY_RANGE_OPERATION(_operation_name, _operator_name,   \
+                                          _operator)                         \
+    namespace accessor {                                                     \
+    template <::gko::detail::operation_kind Kind, typename FirstOperand,     \
+              typename SecondOperand>                                        \
+    struct _operation_name                                                   \
+        : ::gko::detail::implement_binary_operation<                         \
+              Kind, FirstOperand, SecondOperand, ::gko::_operator> {         \
+        using ::gko::detail::implement_binary_operation<                     \
+            Kind, FirstOperand, SecondOperand,                               \
+            ::gko::_operator>::implement_binary_operation;                   \
+    };                                                                       \
+    }                                                                        \
+    GKO_BIND_RANGE_OPERATION_TO_OPERATOR(_operation_name, _operator_name);   \
+    static_assert(true,                                                      \
+                  "This assert is used to counter the false positive extra " \
+                  "semi-colon warnings")
 
 
 #define GKO_BIND_RANGE_OPERATION_TO_OPERATOR(_operation_name, _operator_name) \
@@ -787,7 +792,9 @@ GKO_BIND_UNARY_RANGE_OPERATION_TO_OPERATOR(transpose_operation, transpose);
             ::gko::detail::operation_kind::scalar_by_range, FirstOperand,     \
             SecondAccessor>>(first, second.get_accessor());                   \
     }                                                                         \
-    void __gko_macro_terminator__()
+    static_assert(true,                                                       \
+                  "This assert is used to counter the false positive extra "  \
+                  "semi-colon warnings")
 
 
 #define GKO_DEFINE_SIMPLE_BINARY_OPERATION(_name, ...)                         \

--- a/include/ginkgo/core/base/types.hpp
+++ b/include/ginkgo/core/base/types.hpp
@@ -371,6 +371,22 @@ GKO_ATTRIBUTES constexpr bool operator!=(precision_reduction x,
     return static_cast<st>(x) != static_cast<st>(y);
 }
 
+/**
+ * Calls a given macro for each executor type for a given kernel.
+ *
+ * The macro should take two parameters:
+ *
+ * -   the first one is replaced with the executor class name
+ * -   the second one with the name of the kernel to be bound
+ *
+ * @param _enable_macro  macro name which will be called
+ * @param _kernel  kernel which will be bound to the operation
+ *
+ * @note  the macro is not called for ReferenceExecutor
+ */
+#define GKO_ENABLE_KERNEL_FOR_ALL_EXECUTORS(_enable_macro, _kernel) \
+    _enable_macro(OmpExecutor, omp, _kernel);                       \
+    _enable_macro(CudaExecutor, cuda, _kernel)
 
 /**
  * Calls a given macro for each executor type.
@@ -398,11 +414,14 @@ GKO_ATTRIBUTES constexpr bool operator!=(precision_reduction x,
  *                Should take one argument, which is replaced by the
  *                value type.
  */
-#define GKO_INSTANTIATE_FOR_EACH_VALUE_TYPE(_macro) \
-    template _macro(float);                         \
-    template _macro(double);                        \
-    template _macro(std::complex<float>);           \
-    template _macro(std::complex<double>)
+#define GKO_INSTANTIATE_FOR_EACH_VALUE_TYPE(_macro)                          \
+    template _macro(float);                                                  \
+    template _macro(double);                                                 \
+    template _macro(std::complex<float>);                                    \
+    template _macro(std::complex<double>);                                   \
+    static_assert(true,                                                      \
+                  "This assert is used to counter the false positive extra " \
+                  "semi-colon warnings")
 
 
 /**
@@ -413,9 +432,12 @@ GKO_ATTRIBUTES constexpr bool operator!=(precision_reduction x,
  *                Should take one argument, which is replaced by the
  *                value type.
  */
-#define GKO_INSTANTIATE_FOR_EACH_INDEX_TYPE(_macro) \
-    template _macro(int32);                         \
-    template _macro(int64)
+#define GKO_INSTANTIATE_FOR_EACH_INDEX_TYPE(_macro)                          \
+    template _macro(int32);                                                  \
+    template _macro(int64);                                                  \
+    static_assert(true,                                                      \
+                  "This assert is used to counter the false positive extra " \
+                  "semi-colon warnings")
 
 
 /**
@@ -426,16 +448,18 @@ GKO_ATTRIBUTES constexpr bool operator!=(precision_reduction x,
  *                Should take two arguments, which are replaced by the
  *                value and index types.
  */
-#define GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(_macro) \
-    template _macro(float, int32);                            \
-    template _macro(double, int32);                           \
-    template _macro(std::complex<float>, int32);              \
-    template _macro(std::complex<double>, int32);             \
-    template _macro(float, int64);                            \
-    template _macro(double, int64);                           \
-    template _macro(std::complex<float>, int64);              \
-    template _macro(std::complex<double>, int64)
-
+#define GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(_macro)                \
+    template _macro(float, int32);                                           \
+    template _macro(double, int32);                                          \
+    template _macro(std::complex<float>, int32);                             \
+    template _macro(std::complex<double>, int32);                            \
+    template _macro(float, int64);                                           \
+    template _macro(double, int64);                                          \
+    template _macro(std::complex<float>, int64);                             \
+    template _macro(std::complex<double>, int64);                            \
+    static_assert(true,                                                      \
+                  "This assert is used to counter the false positive extra " \
+                  "semi-colon warnings")
 
 }  // namespace gko
 

--- a/include/ginkgo/core/base/types.hpp
+++ b/include/ginkgo/core/base/types.hpp
@@ -414,14 +414,11 @@ GKO_ATTRIBUTES constexpr bool operator!=(precision_reduction x,
  *                Should take one argument, which is replaced by the
  *                value type.
  */
-#define GKO_INSTANTIATE_FOR_EACH_VALUE_TYPE(_macro)                          \
-    template _macro(float);                                                  \
-    template _macro(double);                                                 \
-    template _macro(std::complex<float>);                                    \
-    template _macro(std::complex<double>);                                   \
-    static_assert(true,                                                      \
-                  "This assert is used to counter the false positive extra " \
-                  "semi-colon warnings")
+#define GKO_INSTANTIATE_FOR_EACH_VALUE_TYPE(_macro) \
+    template _macro(float);                         \
+    template _macro(double);                        \
+    template _macro(std::complex<float>);           \
+    template _macro(std::complex<double>)
 
 
 /**
@@ -432,12 +429,9 @@ GKO_ATTRIBUTES constexpr bool operator!=(precision_reduction x,
  *                Should take one argument, which is replaced by the
  *                value type.
  */
-#define GKO_INSTANTIATE_FOR_EACH_INDEX_TYPE(_macro)                          \
-    template _macro(int32);                                                  \
-    template _macro(int64);                                                  \
-    static_assert(true,                                                      \
-                  "This assert is used to counter the false positive extra " \
-                  "semi-colon warnings")
+#define GKO_INSTANTIATE_FOR_EACH_INDEX_TYPE(_macro) \
+    template _macro(int32);                         \
+    template _macro(int64)
 
 
 /**
@@ -448,18 +442,15 @@ GKO_ATTRIBUTES constexpr bool operator!=(precision_reduction x,
  *                Should take two arguments, which are replaced by the
  *                value and index types.
  */
-#define GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(_macro)                \
-    template _macro(float, int32);                                           \
-    template _macro(double, int32);                                          \
-    template _macro(std::complex<float>, int32);                             \
-    template _macro(std::complex<double>, int32);                            \
-    template _macro(float, int64);                                           \
-    template _macro(double, int64);                                          \
-    template _macro(std::complex<float>, int64);                             \
-    template _macro(std::complex<double>, int64);                            \
-    static_assert(true,                                                      \
-                  "This assert is used to counter the false positive extra " \
-                  "semi-colon warnings")
+#define GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(_macro) \
+    template _macro(float, int32);                            \
+    template _macro(double, int32);                           \
+    template _macro(std::complex<float>, int32);              \
+    template _macro(std::complex<double>, int32);             \
+    template _macro(float, int64);                            \
+    template _macro(double, int64);                           \
+    template _macro(std::complex<float>, int64);              \
+    template _macro(std::complex<double>, int64)
 
 }  // namespace gko
 

--- a/include/ginkgo/core/base/version.hpp
+++ b/include/ginkgo/core/base/version.hpp
@@ -82,7 +82,8 @@ struct version {
     {                                                                     \
         return std::tie(first.major, first.minor, first.patch)            \
             _operator std::tie(second.major, second.minor, second.patch); \
-    }
+    }                                                                     \
+    void __gko_macro_terminator__()
 
 GKO_ENABLE_VERSION_COMPARISON(<);
 GKO_ENABLE_VERSION_COMPARISON(<=);

--- a/include/ginkgo/core/base/version.hpp
+++ b/include/ginkgo/core/base/version.hpp
@@ -76,14 +76,16 @@ struct version {
 };
 
 
-#define GKO_ENABLE_VERSION_COMPARISON(_operator)                          \
-    inline bool operator _operator(const version &first,                  \
-                                   const version &second)                 \
-    {                                                                     \
-        return std::tie(first.major, first.minor, first.patch)            \
-            _operator std::tie(second.major, second.minor, second.patch); \
-    }                                                                     \
-    void __gko_macro_terminator__()
+#define GKO_ENABLE_VERSION_COMPARISON(_operator)                             \
+    inline bool operator _operator(const version &first,                     \
+                                   const version &second)                    \
+    {                                                                        \
+        return std::tie(first.major, first.minor, first.patch)               \
+            _operator std::tie(second.major, second.minor, second.patch);    \
+    }                                                                        \
+    static_assert(true,                                                      \
+                  "This assert is used to counter the false positive extra " \
+                  "semi-colon warnings")
 
 GKO_ENABLE_VERSION_COMPARISON(<);
 GKO_ENABLE_VERSION_COMPARISON(<=);

--- a/include/ginkgo/core/matrix/csr.hpp
+++ b/include/ginkgo/core/matrix/csr.hpp
@@ -152,7 +152,7 @@ public:
         {}
 
         load_balance(int64_t nwarps)
-            : nwarps_(nwarps), strategy_type("load_balance")
+            : strategy_type("load_balance"), nwarps_(nwarps)
         {}
 
         void process(const Array<index_type> &mtx_row_ptrs,
@@ -219,7 +219,7 @@ public:
         {}
 
         automatical(int64_t nwarps)
-            : nwarps_(nwarps), strategy_type("automatical")
+            : strategy_type("automatical"), nwarps_(nwarps)
         {}
 
         void process(const Array<index_type> &mtx_row_ptrs,
@@ -412,8 +412,8 @@ protected:
           col_idxs_(exec, num_nonzeros),
           // avoid allocation for empty matrix
           row_ptrs_(exec, size[0] + (size[0] > 0)),
-          strategy_(std::move(strategy)),
-          srow_(exec, strategy->clac_size(num_nonzeros))
+          srow_(exec, strategy->clac_size(num_nonzeros)),
+          strategy_(std::move(strategy))
     {}
 
     /**
@@ -445,8 +445,8 @@ protected:
           values_{exec, std::forward<ValuesArray>(values)},
           col_idxs_{exec, std::forward<ColIdxsArray>(col_idxs)},
           row_ptrs_{exec, std::forward<RowPtrsArray>(row_ptrs)},
-          strategy_(std::move(strategy)),
-          srow_(exec)
+          srow_(exec),
+          strategy_(std::move(strategy))
     {
         GKO_ENSURE_IN_BOUNDS(values_.get_num_elems() - 1,
                              col_idxs_.get_num_elems());

--- a/include/ginkgo/core/stop/criterion.hpp
+++ b/include/ginkgo/core/stop/criterion.hpp
@@ -296,7 +296,8 @@ public:                                                                     \
 private:                                                                    \
     _parameters_name##_type _parameters_name##_;                            \
                                                                             \
-public:
+public:                                                                     \
+    void __gko_macro_terminator__()
 
 
 }  // namespace stop

--- a/include/ginkgo/core/stop/criterion.hpp
+++ b/include/ginkgo/core/stop/criterion.hpp
@@ -271,33 +271,35 @@ using EnableDefaultCriterionFactory =
  *                          `get_<_parameters_name>()`)
  * @param _factory_name  name of the generated factory type
  */
-#define GKO_ENABLE_CRITERION_FACTORY(_criterion, _parameters_name,          \
-                                     _factory_name)                         \
-public:                                                                     \
-    const _parameters_name##_type &get_##_parameters_name() const           \
-    {                                                                       \
-        return _parameters_name##_;                                         \
-    }                                                                       \
-                                                                            \
-    class _factory_name                                                     \
-        : public ::gko::stop::EnableDefaultCriterionFactory<                \
-              _factory_name, _criterion, _parameters_name##_type> {         \
-        friend class ::gko::EnablePolymorphicObject<                        \
-            _factory_name, ::gko::stop::CriterionFactory>;                  \
-        friend class ::gko::enable_parameters_type<_parameters_name##_type, \
-                                                   _factory_name>;          \
-        using ::gko::stop::EnableDefaultCriterionFactory<                   \
-            _factory_name, _criterion,                                      \
-            _parameters_name##_type>::EnableDefaultCriterionFactory;        \
-    };                                                                      \
-    friend ::gko::stop::EnableDefaultCriterionFactory<                      \
-        _factory_name, _criterion, _parameters_name##_type>;                \
-                                                                            \
-private:                                                                    \
-    _parameters_name##_type _parameters_name##_;                            \
-                                                                            \
-public:                                                                     \
-    void __gko_macro_terminator__()
+#define GKO_ENABLE_CRITERION_FACTORY(_criterion, _parameters_name,           \
+                                     _factory_name)                          \
+public:                                                                      \
+    const _parameters_name##_type &get_##_parameters_name() const            \
+    {                                                                        \
+        return _parameters_name##_;                                          \
+    }                                                                        \
+                                                                             \
+    class _factory_name                                                      \
+        : public ::gko::stop::EnableDefaultCriterionFactory<                 \
+              _factory_name, _criterion, _parameters_name##_type> {          \
+        friend class ::gko::EnablePolymorphicObject<                         \
+            _factory_name, ::gko::stop::CriterionFactory>;                   \
+        friend class ::gko::enable_parameters_type<_parameters_name##_type,  \
+                                                   _factory_name>;           \
+        using ::gko::stop::EnableDefaultCriterionFactory<                    \
+            _factory_name, _criterion,                                       \
+            _parameters_name##_type>::EnableDefaultCriterionFactory;         \
+    };                                                                       \
+    friend ::gko::stop::EnableDefaultCriterionFactory<                       \
+        _factory_name, _criterion, _parameters_name##_type>;                 \
+                                                                             \
+private:                                                                     \
+    _parameters_name##_type _parameters_name##_;                             \
+                                                                             \
+public:                                                                      \
+    static_assert(true,                                                      \
+                  "This assert is used to counter the false positive extra " \
+                  "semi-colon warnings")
 
 
 }  // namespace stop

--- a/omp/CMakeLists.txt
+++ b/omp/CMakeLists.txt
@@ -22,6 +22,7 @@ target_sources(ginkgo_omp
 ginkgo_compile_features(ginkgo_omp)
 target_link_libraries(ginkgo_omp PRIVATE "${OpenMP_CXX_LIBRARIES}")
 target_compile_options(ginkgo_omp PRIVATE "${OpenMP_CXX_FLAGS}")
+target_compile_options(ginkgo_omp PRIVATE "-Wpedantic")
 
 # Ensures that there are no circular dependency issues
 if(NOT BUILD_SHARED_LIBS)

--- a/omp/CMakeLists.txt
+++ b/omp/CMakeLists.txt
@@ -22,7 +22,7 @@ target_sources(ginkgo_omp
 ginkgo_compile_features(ginkgo_omp)
 target_link_libraries(ginkgo_omp PRIVATE "${OpenMP_CXX_LIBRARIES}")
 target_compile_options(ginkgo_omp PRIVATE "${OpenMP_CXX_FLAGS}")
-target_compile_options(ginkgo_omp PRIVATE "-Wpedantic")
+target_compile_options(ginkgo_omp PRIVATE "${GINKGO_COMPILER_FLAGS}")
 
 # Ensures that there are no circular dependency issues
 if(NOT BUILD_SHARED_LIBS)

--- a/omp/components/format_conversion.hpp
+++ b/omp/components/format_conversion.hpp
@@ -45,7 +45,7 @@ inline void convert_idxs_to_ptrs(const IndexType *idxs, size_type num_nonzeros,
                                  IndexType *ptrs, size_type length)
 {
     std::fill(ptrs, ptrs + length, 0);
-    std::for_each(idxs, idxs + num_nonzeros, [&](IndexType v) {
+    std::for_each(idxs, idxs + num_nonzeros, [&](size_type v) {
         if (v + 1 < length) {
             ++ptrs[v + 1];
         }

--- a/reference/CMakeLists.txt
+++ b/reference/CMakeLists.txt
@@ -20,7 +20,7 @@ target_sources(ginkgo_reference
 ginkgo_compile_features(ginkgo_reference)
 ginkgo_default_includes(ginkgo_reference)
 ginkgo_install_library(ginkgo_reference reference)
-target_compile_options(ginkgo_reference PRIVATE "-Wpedantic")
+target_compile_options(ginkgo_reference PRIVATE "${GINKGO_COMPILER_FLAGS}")
 
 # Ensures that there are no circular dependency issues
 if(NOT BUILD_SHARED_LIBS)

--- a/reference/CMakeLists.txt
+++ b/reference/CMakeLists.txt
@@ -20,6 +20,7 @@ target_sources(ginkgo_reference
 ginkgo_compile_features(ginkgo_reference)
 ginkgo_default_includes(ginkgo_reference)
 ginkgo_install_library(ginkgo_reference reference)
+target_compile_options(ginkgo_reference PRIVATE "-Wpedantic")
 
 # Ensures that there are no circular dependency issues
 if(NOT BUILD_SHARED_LIBS)

--- a/reference/components/format_conversion.hpp
+++ b/reference/components/format_conversion.hpp
@@ -45,7 +45,7 @@ inline void convert_idxs_to_ptrs(const IndexType *idxs, size_type num_nonzeros,
                                  IndexType *ptrs, size_type length)
 {
     std::fill(ptrs, ptrs + length, 0);
-    std::for_each(idxs, idxs + num_nonzeros, [&](IndexType v) {
+    std::for_each(idxs, idxs + num_nonzeros, [&](size_type v) {
         if (v + 1 < length) {
             ++ptrs[v + 1];
         }


### PR DESCRIPTION
This pull request tries to fix some warnings that can be fixed mentioned in #174 . The different warnings and the solutions adopted for each are mentioned below:

+ [x] `warning: extra ; ignored` : False positive `;` warnings.
     Solution:~~(FIX) 1. To be fixed with adding an function that defines a full statement (example above).~~
           ~~(IGNORE) 2. Ones for which a full statement cannot be used due to overloading problems.~~
(FIX) By adding `static_assert(true, "message")` statements
+ [x] `warning: inheriting constructors must be inherited from a direct base class`
    Solution: (IGNORE): As it is only used for mixins.
+ [x] `warning: ISO C++11 requires at least one argument for the "..." in a variadic macro`
    Solution: ~~(IGNORE). Supposed to be [fixed](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2017/p0306r4.html) in C++2a~~
                       (FIX) by adding an additional macro that takes in `_kernel` as a parameter. 
+ [x] `warning: unused parameters [-Wunused-parameters]` 
    Solution: (FIX) 1. The ones actually unused in the function.
                   (IGNORE) 2. False positives:
                                 - The ones that are a part of variadic macros.
                                 - The ones that are a part of variadic templates and arguments.
                                 - The ones that appear due to the `NOT_IMPLEMENTED` declaration.
                                 - The ones intentionally left unused to have a uniform interface.
+ [x] `warning: comparison between signed and unsigned integers ` 
    Solution: (FIX)1. Some of the wrong types.
                   (IGNORE) 2. to prefer `auto` over explicit setting in loops.
+ [x] `warning: dereferencing type-punned pointer will break strict-aliasing rules [-Wstrict-aliasing]  ` 
    Solution: (IGNORE) 1. warnings showed mainly for `reinterpret_cast`, but this seems to actually allowed in the [standard, 5.2.10/11](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2011/n3242.pdf) and I think it is intended in Ginkgo especially for std::complex casts for the GPU and for adaptive precision support. 
+ [x] `warning: foo_ will be initialized after bar_ [-Wreorder] ` 
    Solution: (FIX) Change the ordering in the initialization or the declaration.

FIX: Implies that any code satisfying this condition should be fixed.
IGNORE: Implies either that the warning is a false-positive, is an error of the compiler or is an actual intended behaviour that the compiler interprets as a warning.

The current number of warnings are:
````
$ cat warnings | grep -e "\[-[Wp]" | wc -l 
15531

$ cat warnings | grep "inheriting constructors" | wc -l
4

$ cat warnings | grep "-Wunused-parameter" | wc -l
14109

$ cat warnings | grep "-Wstrict-aliasing" | wc -l
39

$ cat warnings | grep "warning: ISO C++11 requires at least one argument" | wc -l
1164

````

Most of the remaining warnings are the `unused parameter` warnings, which seem to be for the variadic macros and for variadic templates which the compiler does not seem to identify properly and hence I think these can be ignored.

Fixes #174 

Updated numbers:
Now, it can be run with `-pedantic-error`

````
$ cat warnings | grep -e "\[-[Wp]" | wc -l 
570

$ cat warnings | grep "inheriting constructors" | wc -l
2

$ cat warnings | grep "-Wunused-parameter" | wc -l
411

$ cat warnings | grep "-Wstrict-aliasing" | wc -l
0

$ cat warnings | grep "warning: ISO C++11 requires at least one argument" | wc -l
0
````

