### PR TITLE
Fix memory leaks detected by Valgrind in Ginkgo.

### DIFF
--- a/core/device_hooks/cuda_hooks.cpp
+++ b/core/device_hooks/cuda_hooks.cpp
@@ -50,6 +50,14 @@ version version_info::get_cuda_version() noexcept
 }
 
 
+std::shared_ptr<CudaExecutor> CudaExecutor::create(
+    int device_id, std::shared_ptr<Executor> master)
+{
+    return std::shared_ptr<CudaExecutor>(
+        new CudaExecutor(device_id, std::move(master)));
+}
+
+
 void OmpExecutor::raw_copy_to(const CudaExecutor *, size_type num_bytes,
                               const void *src_ptr, void *dest_ptr) const
     NOT_COMPILED(cuda);

--- a/core/test/base/executor.cpp
+++ b/core/test/base/executor.cpp
@@ -289,9 +289,9 @@ TEST(CudaExecutor, KnowsItsMaster)
 TEST(CudaExecutor, KnowsItsDeviceId)
 {
     auto omp = gko::OmpExecutor::create();
-    auto cuda = gko::CudaExecutor::create(5, omp);
+    auto cuda = gko::CudaExecutor::create(0, omp);
 
-    ASSERT_EQ(5, cuda->get_device_id());
+    ASSERT_EQ(0, cuda->get_device_id());
 }
 
 

--- a/cuda/base/executor.cpp
+++ b/cuda/base/executor.cpp
@@ -126,6 +126,19 @@ inline int convert_sm_ver_to_cores(int major, int minor)
 }  // namespace
 
 
+std::shared_ptr<CudaExecutor> CudaExecutor::create(
+    int device_id, std::shared_ptr<Executor> master)
+{
+    return std::shared_ptr<CudaExecutor>(
+        new CudaExecutor(device_id, std::move(master)),
+        [device_id](CudaExecutor *exec) {
+            delete exec;
+            device_guard g(device_id);
+            cudaDeviceReset();
+        });
+}
+
+
 void OmpExecutor::raw_copy_to(const CudaExecutor *dest, size_type num_bytes,
                               const void *src_ptr, void *dest_ptr) const
 {

--- a/dev_tools/valgrind/suppressions.supp
+++ b/dev_tools/valgrind/suppressions.supp
@@ -4,7 +4,7 @@
    match-leak-kinds: reachable
    fun:malloc
    ...
-   obj:/opt/cuda/lib64/libcublas.so.*
+   obj:libcublas.so.*
    ...
    fun:call_init.part.0
    fun:_dl_init
@@ -16,5 +16,38 @@
    match-leak-kinds: reachable,possible
    ...
    fun:cuda*
+   ...
+}
+{
+   CUDA Init
+   Memcheck:Leak
+   match-leak-kinds: reachable,possible
+   fun:*alloc
+   ...
+   obj:*libcuda.so*
+   ...
+   fun:cuInit
+   ...
+}
+{
+   CUDA DevicePrimaryCtxRetain
+   Memcheck:Leak
+   match-leak-kinds: reachable,possible
+   fun:*alloc
+   ...
+   obj:*libcuda.so*
+   ...
+   fun:cuDevicePrimaryCtxRetain
+   ...
+}
+{
+   Allocate Thread Local Storage
+   Memcheck:Leak
+   match-leak-kinds: reachable,possible
+   fun:*alloc
+   ...
+   fun:_dl_allocate_tls
+   ...
+   fun:pthread_create*
    ...
 }

--- a/include/ginkgo/core/base/array.hpp
+++ b/include/ginkgo/core/base/array.hpp
@@ -288,6 +288,7 @@ public:
         }
         if (exec_ == nullptr) {
             exec_ = other.get_executor();
+            data_ = data_manager{nullptr, other.data_.get_deleter()};
         }
         if (other.get_executor() == nullptr) {
             this->resize_and_reset(0);

--- a/include/ginkgo/core/base/executor.hpp
+++ b/include/ginkgo/core/base/executor.hpp
@@ -771,11 +771,7 @@ public:
      * kernels
      */
     static std::shared_ptr<CudaExecutor> create(
-        int device_id, std::shared_ptr<Executor> master)
-    {
-        return std::shared_ptr<CudaExecutor>(
-            new CudaExecutor(device_id, std::move(master)));
-    }
+        int device_id, std::shared_ptr<Executor> master);
 
     std::shared_ptr<Executor> get_master() noexcept override;
 


### PR DESCRIPTION
Overall, there was one real memory leak, multiple leftover CUDA memory which go away when using `cudaDeviceReset` and a few problems which should be suppressed.

Overall, all that's left are 5 memory whenever using CUDA which are really hard to track down as there is no information at all. I am also unsure whether they are related to us. `cuda-memcheck` does not seem to find anything.

### Changes
+ When array has no executor and is copied to, also inherit the deleter from the
	other array.
+ Add three new suppressions for `cuInit`, `cuDevicePrimaryCtxRetain` and
	`_dl_allocate_tls` (thread local storage allocation) in `pthread_create`.
+ Call `cudaDeviceReset()` when deleting a CudaExecutor.
+ Do not create a CudaExecutor with an invalid `id`. While the code is correct,
	it generates a lot of memory leaks due to CUDA failures.


### Fixes #152.

### Extra information
Previous state: https://my.cdash.org/viewDynamicAnalysis.php?buildid=1611562
Current state: https://my.cdash.org/viewDynamicAnalysis.php?buildid=1611561

All of the OpenMP warning should go away after a new check. These were thread local storage allocation related problems which are not related to us.

After the OpenMP improvements: https://my.cdash.org/viewDynamicAnalysis.php?buildid=1611586