### PR TITLE
Fix the leftover variadic macro warnings which were forgotten.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -342,7 +342,7 @@ warnings:
     <<: *default_variables
     BUILD_OMP: "ON"
     BUILD_CUDA: "ON"
-    CXX_FLAGS: "-Werror=pedantic"
+    CXX_FLAGS: "-Werror=pedantic -pedantic-errors"
   dependencies: []
   allow_failure: yes
 

--- a/include/ginkgo/core/base/executor.hpp
+++ b/include/ginkgo/core/base/executor.hpp
@@ -34,6 +34,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #ifndef GKO_CORE_EXECUTOR_HPP_
 #define GKO_CORE_EXECUTOR_HPP_
 
+
 #include <memory>
 #include <sstream>
 #include <tuple>

--- a/include/ginkgo/core/base/executor.hpp
+++ b/include/ginkgo/core/base/executor.hpp
@@ -300,8 +300,8 @@ private:                                                                     \
             return name.c_str();                                               \
         }                                                                      \
                                                                                \
-        GKO_ENABLE_KERNEL_FOR_ALL_EXECUTORS(                                   \
-            GKO_KERNEL_DETAIL_DEFINE_RUN_OVERLOAD, _kernel);                   \
+        GKO_KERNEL_DETAIL_DEFINE_RUN_OVERLOAD(OmpExecutor, omp, _kernel);      \
+        GKO_KERNEL_DETAIL_DEFINE_RUN_OVERLOAD(CudaExecutor, cuda, _kernel);    \
         GKO_KERNEL_DETAIL_DEFINE_RUN_OVERLOAD(ReferenceExecutor, reference,    \
                                               _kernel);                        \
                                                                                \

--- a/include/ginkgo/core/base/lin_op.hpp
+++ b/include/ginkgo/core/base/lin_op.hpp
@@ -605,7 +605,7 @@ public:                                                                \
  *
  * The list of parameters for the factory should be defined in a code block
  * after the macro definition, and should contain a list of
- * GKO_FACTORY_PARMETER declarations. The class should provide a constructor
+ * GKO_FACTORY_PARAMETER declarations. The class should provide a constructor
  * with signature
  * _lin_op(const _factory_name *, std::shared_ptr<const LinOp>)
  * which the factory will use a callback to construct the object.

--- a/include/ginkgo/core/base/types.hpp
+++ b/include/ginkgo/core/base/types.hpp
@@ -435,6 +435,7 @@ GKO_ATTRIBUTES constexpr bool operator!=(precision_reduction x,
     template _macro(std::complex<float>, int64);              \
     template _macro(std::complex<double>, int64)
 
+
 }  // namespace gko
 
 

--- a/include/ginkgo/core/base/types.hpp
+++ b/include/ginkgo/core/base/types.hpp
@@ -371,6 +371,7 @@ GKO_ATTRIBUTES constexpr bool operator!=(precision_reduction x,
     return static_cast<st>(x) != static_cast<st>(y);
 }
 
+
 /**
  * Calls a given macro for each executor type for a given kernel.
  *
@@ -380,30 +381,12 @@ GKO_ATTRIBUTES constexpr bool operator!=(precision_reduction x,
  * -   the second one with the name of the kernel to be bound
  *
  * @param _enable_macro  macro name which will be called
- * @param _kernel  kernel which will be bound to the operation
  *
  * @note  the macro is not called for ReferenceExecutor
  */
-#define GKO_ENABLE_KERNEL_FOR_ALL_EXECUTORS(_enable_macro, _kernel) \
-    _enable_macro(OmpExecutor, omp, _kernel);                       \
-    _enable_macro(CudaExecutor, cuda, _kernel)
-
-/**
- * Calls a given macro for each executor type.
- *
- * The macro should take two parameters:
- *
- * -   the first one is replaced with the executor class name
- * -   the second one with the executor short name (used for namespace name)
- *
- * @param _enable_macro  macro name which will be called
- * @param ...  extra parameters passed to _enable_macro
- *
- * @note  the macro is not called for ReferenceExecutor
- */
-#define GKO_ENABLE_FOR_ALL_EXECUTORS(_enable_macro, ...) \
-    _enable_macro(OmpExecutor, omp, __VA_ARGS__);        \
-    _enable_macro(CudaExecutor, cuda, __VA_ARGS__)
+#define GKO_ENABLE_FOR_ALL_EXECUTORS(_enable_macro) \
+    _enable_macro(OmpExecutor, omp);                \
+    _enable_macro(CudaExecutor, cuda)
 
 
 /**

--- a/include/ginkgo/core/preconditioner/jacobi.hpp
+++ b/include/ginkgo/core/preconditioner/jacobi.hpp
@@ -302,7 +302,7 @@ public:
          *       has to be respected when setting this parameter. Failure to do
          *       so will lead to undefined behavior.
          */
-        gko::Array<index_type> GKO_FACTORY_PARAMETER(block_pointers);
+        gko::Array<index_type> GKO_FACTORY_PARAMETER(block_pointers, nullptr);
 
     private:
         // See documentation of storage_optimization parameter for details about

--- a/include/ginkgo/core/solver/bicgstab.hpp
+++ b/include/ginkgo/core/solver/bicgstab.hpp
@@ -98,7 +98,7 @@ public:
          * Criterion factories.
          */
         std::vector<std::shared_ptr<const stop::CriterionFactory>>
-            GKO_FACTORY_PARAMETER(criteria);
+            GKO_FACTORY_PARAMETER(criteria, nullptr);
 
         /**
          * Preconditioner factory.

--- a/include/ginkgo/core/solver/cg.hpp
+++ b/include/ginkgo/core/solver/cg.hpp
@@ -99,7 +99,7 @@ public:
          * Criterion factories.
          */
         std::vector<std::shared_ptr<const stop::CriterionFactory>>
-            GKO_FACTORY_PARAMETER(criteria);
+            GKO_FACTORY_PARAMETER(criteria, nullptr);
 
         /**
          * Preconditioner factory.

--- a/include/ginkgo/core/solver/cgs.hpp
+++ b/include/ginkgo/core/solver/cgs.hpp
@@ -96,7 +96,7 @@ public:
          * Criterion factories.
          */
         std::vector<std::shared_ptr<const stop::CriterionFactory>>
-            GKO_FACTORY_PARAMETER(criteria);
+            GKO_FACTORY_PARAMETER(criteria, nullptr);
 
         /**
          * Preconditioner factory.

--- a/include/ginkgo/core/solver/fcg.hpp
+++ b/include/ginkgo/core/solver/fcg.hpp
@@ -104,7 +104,7 @@ public:
          * Criterion factories.
          */
         std::vector<std::shared_ptr<const stop::CriterionFactory>>
-            GKO_FACTORY_PARAMETER(criteria);
+            GKO_FACTORY_PARAMETER(criteria, nullptr);
 
         /**
          * Preconditioner factory.

--- a/include/ginkgo/core/solver/gmres.hpp
+++ b/include/ginkgo/core/solver/gmres.hpp
@@ -106,7 +106,7 @@ public:
          * Criterion factories.
          */
         std::vector<std::shared_ptr<const stop::CriterionFactory>>
-            GKO_FACTORY_PARAMETER(criteria);
+            GKO_FACTORY_PARAMETER(criteria, nullptr);
 
         /**
          * Preconditioner factory.

--- a/include/ginkgo/core/stop/combined.hpp
+++ b/include/ginkgo/core/stop/combined.hpp
@@ -67,7 +67,7 @@ public:
          * too costly.
          */
         std::vector<std::shared_ptr<const CriterionFactory>>
-            GKO_FACTORY_PARAMETER(criteria);
+            GKO_FACTORY_PARAMETER(criteria, nullptr);
     };
     GKO_ENABLE_CRITERION_FACTORY(Combined, parameters, Factory);
     GKO_ENABLE_BUILD_METHOD(Factory);


### PR DESCRIPTION
The fix is to remove altogether the variadic definition of the problematic
macro (`GKO_ENABLE_FOR_ALL_EXECUTORS`) as it is required by only one other
macro call.

There should now **really** be no pedantic problem whatsoever.