### PR TITLE
Added stop_status unit tests

### DIFF
--- a/core/test/stop/CMakeLists.txt
+++ b/core/test/stop/CMakeLists.txt
@@ -1,4 +1,4 @@
 ginkgo_create_test(combined)
 ginkgo_create_test(iteration)
-ginkgo_create_test(time)
 ginkgo_create_test(stopping_status)
+ginkgo_create_test(time)

--- a/core/test/stop/CMakeLists.txt
+++ b/core/test/stop/CMakeLists.txt
@@ -1,3 +1,4 @@
 ginkgo_create_test(combined)
 ginkgo_create_test(iteration)
 ginkgo_create_test(time)
+ginkgo_create_test(stopping_status)

--- a/core/test/stop/stopping_status.cpp
+++ b/core/test/stop/stopping_status.cpp
@@ -1,0 +1,134 @@
+/*******************************<GINKGO LICENSE>******************************
+Copyright 2017-2019
+
+Karlsruhe Institute of Technology
+Universitat Jaume I
+University of Tennessee
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice,
+   this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors
+   may be used to endorse or promote products derived from this software
+   without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+******************************<GINKGO LICENSE>*******************************/
+
+#include <ginkgo/core/stop/stopping_status.hpp>
+
+
+#include <gtest/gtest.h>
+
+
+namespace {
+
+
+class stopping_status : public ::testing::Test {
+protected:
+    stopping_status()
+    {
+        stop_a.reset();
+        stop_b.reset();
+    }
+    gko::stopping_status stop_a;
+    gko::stopping_status stop_b;
+};
+
+
+TEST_F(stopping_status, CanStop)
+{
+    constexpr gko::uint8 id{1};
+
+    stop_a.stop(id, true);
+    stop_b.stop(id, false);
+
+    ASSERT_EQ(stop_a.is_finalized(), true);
+    ASSERT_EQ(stop_b.is_finalized(), false);
+    ASSERT_EQ(stop_a.has_stopped(), true);
+    ASSERT_EQ(stop_b.has_stopped(), true);
+    ASSERT_EQ(stop_a.get_id(), id);
+    ASSERT_EQ(stop_b.get_id(), id);
+}
+
+
+TEST_F(stopping_status, CanConverge)
+{
+    constexpr gko::uint8 id{5};
+
+    stop_a.converge(id, true);
+    stop_b.converge(id, false);
+
+    ASSERT_EQ(stop_a.is_finalized(), true);
+    ASSERT_EQ(stop_b.is_finalized(), false);
+    ASSERT_EQ(stop_a.has_converged(), true);
+    ASSERT_EQ(stop_b.has_converged(), true);
+    ASSERT_EQ(stop_a.has_stopped(), true);
+    ASSERT_EQ(stop_b.has_stopped(), true);
+    ASSERT_EQ(stop_a.get_id(), id);
+    ASSERT_EQ(stop_b.get_id(), id);
+}
+
+
+TEST_F(stopping_status, CanCompareEqual)
+{
+    constexpr gko::uint8 id{5};
+
+    stop_a.converge(id);
+    stop_b.converge(id);
+
+    ASSERT_EQ(stop_a == stop_b, true);
+    ASSERT_EQ(stop_a != stop_b, false);
+}
+
+
+TEST_F(stopping_status, CanCompareUnequal)
+{
+    constexpr gko::uint8 id_a{6};
+    constexpr gko::uint8 id_b{7};
+
+    stop_a.converge(id_a);
+    stop_b.converge(id_b);
+
+    ASSERT_EQ(stop_a == stop_b, false);
+    ASSERT_EQ(stop_a != stop_b, true);
+}
+
+
+TEST_F(stopping_status, CanReset)
+{
+    constexpr gko::uint8 id_a{6};
+    constexpr gko::uint8 id_b{7};
+
+    stop_a.converge(id_a, true);
+    stop_b.converge(id_b, false);
+    stop_a.reset();
+    stop_b.reset();
+
+    ASSERT_EQ(stop_a.has_stopped(), false);
+    ASSERT_EQ(stop_b.has_stopped(), false);
+    ASSERT_EQ(stop_a.has_converged(), false);
+    ASSERT_EQ(stop_b.has_converged(), false);
+    ASSERT_EQ(stop_a.is_finalized(), false);
+    ASSERT_EQ(stop_b.is_finalized(), false);
+    ASSERT_EQ(stop_a == stop_b, true);
+}
+
+
+}  // namespace

--- a/cuda/test/solver/bicgstab_kernels.cpp
+++ b/cuda/test/solver/bicgstab_kernels.cpp
@@ -260,6 +260,7 @@ TEST_F(Bicgstab, CudaBicgstabInitializeIsEquivalentToRef)
     GKO_EXPECT_MTX_NEAR(d_beta, beta, 1e-14);
     GKO_EXPECT_MTX_NEAR(d_gamma, gamma, 1e-14);
     GKO_EXPECT_MTX_NEAR(d_omega, omega, 1e-14);
+    GKO_ASSERT_ARRAY_EQ(d_stop_status, stop_status);
 }
 
 

--- a/cuda/test/solver/cg_kernels.cpp
+++ b/cuda/test/solver/cg_kernels.cpp
@@ -194,6 +194,7 @@ TEST_F(Cg, CudaCgInitializeIsEquivalentToRef)
     GKO_ASSERT_MTX_NEAR(d_q, q, 1e-14);
     GKO_ASSERT_MTX_NEAR(d_prev_rho, prev_rho, 1e-14);
     GKO_ASSERT_MTX_NEAR(d_rho, rho, 1e-14);
+    GKO_ASSERT_ARRAY_EQ(d_stop_status, stop_status);
 }
 
 

--- a/cuda/test/solver/cgs_kernels.cpp
+++ b/cuda/test/solver/cgs_kernels.cpp
@@ -250,6 +250,7 @@ TEST_F(Cgs, CudaCgsInitializeIsEquivalentToRef)
     GKO_ASSERT_MTX_NEAR(d_alpha, alpha, 1e-14);
     GKO_ASSERT_MTX_NEAR(d_beta, beta, 1e-14);
     GKO_ASSERT_MTX_NEAR(d_gamma, gamma, 1e-14);
+    GKO_ASSERT_ARRAY_EQ(d_stop_status, stop_status);
 }
 
 

--- a/cuda/test/solver/fcg_kernels.cpp
+++ b/cuda/test/solver/fcg_kernels.cpp
@@ -208,6 +208,7 @@ TEST_F(Fcg, CudaFcgInitializeIsEquivalentToRef)
     GKO_ASSERT_MTX_NEAR(d_prev_rho, prev_rho, 1e-14);
     GKO_ASSERT_MTX_NEAR(d_rho, rho, 1e-14);
     GKO_ASSERT_MTX_NEAR(d_rho_t, rho_t, 1e-14);
+    GKO_ASSERT_ARRAY_EQ(d_stop_status, stop_status);
 }
 
 

--- a/cuda/test/solver/gmres_kernels.cpp
+++ b/cuda/test/solver/gmres_kernels.cpp
@@ -204,6 +204,7 @@ TEST_F(Gmres, CudaGmresInitialize1IsEquivalentToRef)
     GKO_ASSERT_MTX_NEAR(d_residual, residual, 1e-14);
     GKO_ASSERT_MTX_NEAR(d_givens_sin, givens_sin, 1e-14);
     GKO_ASSERT_MTX_NEAR(d_givens_cos, givens_cos, 1e-14);
+    GKO_ASSERT_ARRAY_EQ(d_stop_status, stop_status);
 }
 
 
@@ -224,11 +225,7 @@ TEST_F(Gmres, CudaGmresInitialize2IsEquivalentToRef)
     GKO_ASSERT_MTX_NEAR(d_residual_norm_collection, residual_norm_collection,
                         1e-14);
     GKO_ASSERT_MTX_NEAR(d_krylov_bases, krylov_bases, 1e-14);
-    gko::Array<gko::size_type> host_iter(ref, *d_final_iter_nums);
-    for (gko::size_type i = 0; i < final_iter_nums->get_num_elems(); ++i) {
-        ASSERT_EQ(host_iter.get_const_data()[i],
-                  final_iter_nums->get_const_data()[i]);
-    }
+    GKO_ASSERT_ARRAY_EQ(d_final_iter_nums, final_iter_nums);
 }
 
 
@@ -256,11 +253,7 @@ TEST_F(Gmres, CudaGmresStep1IsEquivalentToRef)
                         1e-14);
     GKO_ASSERT_MTX_NEAR(d_hessenberg_iter, hessenberg_iter, 1e-14);
     GKO_ASSERT_MTX_NEAR(d_krylov_bases, krylov_bases, 1e-14);
-    gko::Array<gko::size_type> host_iter(ref, *d_final_iter_nums);
-    for (gko::size_type i = 0; i < final_iter_nums->get_num_elems(); ++i) {
-        ASSERT_EQ(host_iter.get_const_data()[i],
-                  final_iter_nums->get_const_data()[i]);
-    }
+    GKO_ASSERT_ARRAY_EQ(d_final_iter_nums, final_iter_nums);
 }
 
 

--- a/include/ginkgo/core/stop/stopping_status.hpp
+++ b/include/ginkgo/core/stop/stopping_status.hpp
@@ -48,6 +48,28 @@ namespace gko {
 class stopping_status {
 public:
     /**
+     * Check if two stopping_status are identical
+     * @param other  stopping_status to compare against
+     * @return true if and only if `*this == other`
+     */
+    GKO_ATTRIBUTES GKO_INLINE bool operator==(
+        const stopping_status &other) const noexcept
+    {
+        return data_ == other.data_;
+    }
+
+    /**
+     * Check if two stopping_status are different
+     * @param other  stopping_status to compare against
+     * @return true if and only if `*this != other`
+     */
+    GKO_ATTRIBUTES GKO_INLINE bool operator!=(
+        const stopping_status &other) const noexcept
+    {
+        return data_ != other.data_;
+    }
+
+    /**
      * Check if any stopping criteria was fulfilled.
      * @return Returns true if any stopping criteria was fulfilled.
      */
@@ -93,15 +115,15 @@ public:
      * Call if a stop occured due to a hard limit (and convergence was not
      * reached).
      * @param id  id of the stopping criteria.
-     * @param setFinalized  Controls if the current version should count as
+     * @param set_finalized  Controls if the current version should count as
      * finalized (set to true) or not (set to false).
      */
     GKO_ATTRIBUTES GKO_INLINE void stop(uint8 id,
-                                        bool setFinalized = true) noexcept
+                                        bool set_finalized = true) noexcept
     {
         if (!this->has_stopped()) {
             data_ |= (id & id_mask_);
-            if (setFinalized) {
+            if (set_finalized) {
                 data_ |= finalized_mask_;
             }
         }
@@ -110,15 +132,15 @@ public:
     /**
      * Call if convergence occured.
      * @param id  id of the stopping criteria.
-     * @param setFinalized  Controls if the current version should count as
+     * @param set_finalized  Controls if the current version should count as
      * finalized (set to true) or not (set to false).
      */
     GKO_ATTRIBUTES GKO_INLINE void converge(uint8 id,
-                                            bool setFinalized = true) noexcept
+                                            bool set_finalized = true) noexcept
     {
         if (!this->has_stopped()) {
             data_ |= converged_mask_ | (id & id_mask_);
-            if (setFinalized) {
+            if (set_finalized) {
                 data_ |= finalized_mask_;
             }
         }

--- a/omp/test/solver/bicgstab_kernels.cpp
+++ b/omp/test/solver/bicgstab_kernels.cpp
@@ -257,6 +257,7 @@ TEST_F(Bicgstab, OmpBicgstabInitializeIsEquivalentToRef)
     GKO_EXPECT_MTX_NEAR(d_beta, beta, 1e-14);
     GKO_EXPECT_MTX_NEAR(d_gamma, gamma, 1e-14);
     GKO_EXPECT_MTX_NEAR(d_omega, omega, 1e-14);
+    GKO_ASSERT_ARRAY_EQ(d_stop_status, stop_status);
 }
 
 

--- a/omp/test/solver/cg_kernels.cpp
+++ b/omp/test/solver/cg_kernels.cpp
@@ -193,6 +193,7 @@ TEST_F(Cg, OmpCgInitializeIsEquivalentToRef)
     GKO_ASSERT_MTX_NEAR(d_q, q, 1e-14);
     GKO_ASSERT_MTX_NEAR(d_prev_rho, prev_rho, 1e-14);
     GKO_ASSERT_MTX_NEAR(d_rho, rho, 1e-14);
+    GKO_ASSERT_ARRAY_EQ(d_stop_status, stop_status);
 }
 
 

--- a/omp/test/solver/cgs_kernels.cpp
+++ b/omp/test/solver/cgs_kernels.cpp
@@ -249,6 +249,7 @@ TEST_F(Cgs, OmpCgsInitializeIsEquivalentToRef)
     GKO_ASSERT_MTX_NEAR(d_alpha, alpha, 1e-14);
     GKO_ASSERT_MTX_NEAR(d_beta, beta, 1e-14);
     GKO_ASSERT_MTX_NEAR(d_gamma, gamma, 1e-14);
+    GKO_ASSERT_ARRAY_EQ(d_stop_status, stop_status);
 }
 
 

--- a/omp/test/solver/fcg_kernels.cpp
+++ b/omp/test/solver/fcg_kernels.cpp
@@ -207,6 +207,7 @@ TEST_F(Fcg, OmpFcgInitializeIsEquivalentToRef)
     GKO_ASSERT_MTX_NEAR(d_prev_rho, prev_rho, 1e-14);
     GKO_ASSERT_MTX_NEAR(d_rho, rho, 1e-14);
     GKO_ASSERT_MTX_NEAR(d_rho_t, rho_t, 1e-14);
+    GKO_ASSERT_ARRAY_EQ(d_stop_status, stop_status);
 }
 
 


### PR DESCRIPTION
Added unit tests for `stopping_status` and overloaded `operator==` and `operator!=`.

A helper macro `GKO_ASSERT_ARRAY_EQ` was added, which tests `gko::Array`s for equality by using the `operator==`. 
This was then used inside solver tests to compare the `stop_status` and other arrays after kernel calls (currently mostly the `initialize` kernels).

Closes #242 and closes #208.
