### PR TITLE
Fix the recent problem in the CUDA test.

### DIFF
--- a/core/base/executor.cpp
+++ b/core/base/executor.cpp
@@ -63,4 +63,10 @@ const char *Operation::get_name() const noexcept
 }
 
 
+int CudaExecutor::num_execs[max_devices];
+
+
+std::mutex CudaExecutor::mutex[max_devices];
+
+
 }  // namespace gko

--- a/cuda/base/executor.cpp
+++ b/cuda/base/executor.cpp
@@ -133,8 +133,10 @@ std::shared_ptr<CudaExecutor> CudaExecutor::create(
         new CudaExecutor(device_id, std::move(master)),
         [device_id](CudaExecutor *exec) {
             delete exec;
-            device_guard g(device_id);
-            cudaDeviceReset();
+            if (!CudaExecutor::get_num_execs(device_id)) {
+                device_guard g(device_id);
+                cudaDeviceReset();
+            }
         });
 }
 
@@ -191,8 +193,8 @@ void CudaExecutor::raw_copy_to(const CudaExecutor *src, size_type num_bytes,
                                const void *src_ptr, void *dest_ptr) const
 {
     device_guard g(this->get_device_id());
-    GKO_ASSERT_NO_CUDA_ERRORS(cudaMemcpyPeer(dest_ptr, this->device_id_, src_ptr,
-                                         src->get_device_id(), num_bytes));
+    GKO_ASSERT_NO_CUDA_ERRORS(cudaMemcpyPeer(
+        dest_ptr, this->device_id_, src_ptr, src->get_device_id(), num_bytes));
 }
 
 

--- a/cuda/test/base/cuda_executor.cu
+++ b/cuda/test/base/cuda_executor.cu
@@ -95,6 +95,15 @@ protected:
 };
 
 
+TEST_F(CudaExecutor, CanInstantiateTwoExecutorsOnOneDevice)
+{
+    auto cuda = gko::CudaExecutor::create(0, omp);
+    auto cuda2 = gko::CudaExecutor::create(0, omp);
+
+    // We want automatic deinitialization to not create any error
+}
+
+
 TEST_F(CudaExecutor, MasterKnowsNumberOfDevices)
 {
     int count = 0;


### PR DESCRIPTION
This is done by using `cudaDeviceReset()` only when the last executor on
the device is being deleted.

Closes #241.