### PR TITLE
Removed redundant operator overloading in `stopping_status` (caused by automatic merging)

### DIFF
--- a/include/ginkgo/core/solver/ir.hpp
+++ b/include/ginkgo/core/solver/ir.hpp
@@ -122,7 +122,7 @@ public:
          * Criterion factories.
          */
         std::vector<std::shared_ptr<const stop::CriterionFactory>>
-            GKO_FACTORY_PARAMETER(criteria);
+            GKO_FACTORY_PARAMETER(criteria, nullptr);
 
         /**
          * Inner solver factory.

--- a/include/ginkgo/core/stop/stopping_status.hpp
+++ b/include/ginkgo/core/stop/stopping_status.hpp
@@ -53,28 +53,6 @@ class stopping_status {
 
 public:
     /**
-     * Check if two stopping_status are identical
-     * @param other  stopping_status to compare against
-     * @return true if and only if `*this == other`
-     */
-    GKO_ATTRIBUTES GKO_INLINE bool operator==(
-        const stopping_status &other) const noexcept
-    {
-        return data_ == other.data_;
-    }
-
-    /**
-     * Check if two stopping_status are different
-     * @param other  stopping_status to compare against
-     * @return true if and only if `*this != other`
-     */
-    GKO_ATTRIBUTES GKO_INLINE bool operator!=(
-        const stopping_status &other) const noexcept
-    {
-        return data_ != other.data_;
-    }
-
-    /**
      * Check if any stopping criteria was fulfilled.
      * @return Returns true if any stopping criteria was fulfilled.
      */


### PR DESCRIPTION
Removed redundant member functions `operator==` and `operator!=` in class `stopping_status`, which were also present as `friend` functions.

Additionally, I fixed the [C++ standard warning we were getting](https://gitlab.com/ginkgo-project/ginkgo-public-ci/-/jobs/174127692) (caused by `GKO_FACTORY_PARAMETER(criteria);`) by providing a `nullptr` as the default value.
This was found and pointed out by @pratikvn .