### PR TITLE
Fixed the `fatal: not a git repository` error

### DIFF
--- a/cmake/information_helpers.cmake
+++ b/cmake/information_helpers.cmake
@@ -17,13 +17,14 @@ macro(ginkgo_git_information)
                 WORKING_DIRECTORY ${Ginkgo_SOURCE_DIR}
                 OUTPUT_VARIABLE GINKGO_GIT_BRANCH
                 OUTPUT_STRIP_TRAILING_WHITESPACE)
-						# NOTE: There is an error here when using the `WORKING_DIRECTORY` version.
             execute_process(
                 COMMAND ${GIT_EXECUTABLE} log -1 --format=%H ${Gingko_SOURCE_DIR}
+                WORKING_DIRECTORY ${Ginkgo_SOURCE_DIR}
                 OUTPUT_VARIABLE GINKGO_GIT_REVISION
                 OUTPUT_STRIP_TRAILING_WHITESPACE)
             execute_process(
                 COMMAND ${GIT_EXECUTABLE} log -1 --format=%h ${Gingko_SOURCE_DIR}
+                WORKING_DIRECTORY ${Ginkgo_SOURCE_DIR}
                 OUTPUT_VARIABLE GINKGO_GIT_SHORTREV
                 OUTPUT_STRIP_TRAILING_WHITESPACE)
         endif()


### PR DESCRIPTION
The problem was that `WORKING_DIRECTORY` was not set when the git command was launched to retrieve the git repository information (like the commit hash) in the cmake step.

Closes #240 