### PR TITLE
Cuda tests or implementation of multiple RHS

### DIFF
--- a/core/matrix/dense.cpp
+++ b/core/matrix/dense.cpp
@@ -113,8 +113,8 @@ inline void conversion_helper(Csr<ValueType, IndexType> *result,
 
     size_type num_stored_nonzeros = 0;
     exec->run(dense::make_count_nonzeros(source, &num_stored_nonzeros));
-    auto tmp = Csr<ValueType, IndexType>::create(exec, source->get_size(),
-                                                 num_stored_nonzeros);
+    auto tmp = Csr<ValueType, IndexType>::create(
+        exec, source->get_size(), num_stored_nonzeros, result->get_strategy());
     exec->run(op(tmp.get(), source));
     tmp->move_to(result);
 }

--- a/cuda/test/matrix/csr_kernels.cpp
+++ b/cuda/test/matrix/csr_kernels.cpp
@@ -83,12 +83,13 @@ protected:
             std::normal_distribution<>(-1.0, 1.0), rand_engine, ref);
     }
 
-    void set_up_apply_data(std::shared_ptr<Mtx::strategy_type> strategy)
+    void set_up_apply_data(std::shared_ptr<Mtx::strategy_type> strategy,
+                           int num_vectors = 1)
     {
         mtx = Mtx::create(ref, strategy);
         mtx->copy_from(gen_mtx<Vec>(532, 231, 1));
-        expected = gen_mtx<Vec>(532, 1, 1);
-        y = gen_mtx<Vec>(231, 1, 1);
+        expected = gen_mtx<Vec>(532, num_vectors, 1);
+        y = gen_mtx<Vec>(231, num_vectors, 1);
         alpha = gko::initialize<Vec>({2.0}, ref);
         beta = gko::initialize<Vec>({-1.0}, ref);
         dmtx = Mtx::create(cuda, strategy);
@@ -131,6 +132,14 @@ protected:
     std::unique_ptr<Vec> dalpha;
     std::unique_ptr<Vec> dbeta;
 };
+
+
+TEST_F(Csr, StrategyAfterCopyIsEquivalentToRef)
+{
+    set_up_apply_data(std::make_shared<Mtx::load_balance>(32));
+    ASSERT_EQ(mtx->get_strategy()->get_name(),
+              dmtx->get_strategy()->get_name());
+}
 
 
 TEST_F(Csr, SimpleApplyIsEquivalentToRefWithLoadBalance)
@@ -205,6 +214,28 @@ TEST_F(Csr, SimpleApplyIsEquivalentToRefWithAutomatical)
 
     mtx->apply(y.get(), expected.get());
     dmtx->apply(dy.get(), dresult.get());
+
+    GKO_ASSERT_MTX_NEAR(dresult, expected, 1e-14);
+}
+
+
+TEST_F(Csr, SimpleApplyToDenseMatrixIsEquivalentToRefWithLoadBalance)
+{
+    set_up_apply_data(std::make_shared<Mtx::load_balance>(32), 3);
+
+    mtx->apply(y.get(), expected.get());
+    dmtx->apply(dy.get(), dresult.get());
+
+    GKO_ASSERT_MTX_NEAR(dresult, expected, 1e-14);
+}
+
+
+TEST_F(Csr, AdvancedApplyToDenseMatrixIsEquivalentToRefWithLoadBalance)
+{
+    set_up_apply_data(std::make_shared<Mtx::load_balance>(32), 3);
+
+    mtx->apply(alpha.get(), y.get(), beta.get(), expected.get());
+    dmtx->apply(dalpha.get(), dy.get(), dbeta.get(), dresult.get());
 
     GKO_ASSERT_MTX_NEAR(dresult, expected, 1e-14);
 }

--- a/cuda/test/matrix/csr_kernels.cpp
+++ b/cuda/test/matrix/csr_kernels.cpp
@@ -197,6 +197,17 @@ TEST_F(Csr, SimpleApplyIsEquivalentToRefWithMergePath)
 }
 
 
+TEST_F(Csr, AdvancedApplyIsEquivalentToRefWithMergePath)
+{
+    set_up_apply_data(std::make_shared<Mtx::merge_path>());
+
+    mtx->apply(alpha.get(), y.get(), beta.get(), expected.get());
+    dmtx->apply(dalpha.get(), dy.get(), dbeta.get(), dresult.get());
+
+    GKO_ASSERT_MTX_NEAR(dresult, expected, 1e-14);
+}
+
+
 TEST_F(Csr, SimpleApplyIsEquivalentToRefWithClassical)
 {
     set_up_apply_data(std::make_shared<Mtx::classical>());
@@ -212,7 +223,7 @@ TEST_F(Csr, AdvancedApplyIsEquivalentToRefWithClassical)
 {
     set_up_apply_data(std::make_shared<Mtx::classical>());
 
-     mtx->apply(alpha.get(), y.get(), beta.get(), expected.get());
+    mtx->apply(alpha.get(), y.get(), beta.get(), expected.get());
     dmtx->apply(dalpha.get(), dy.get(), dbeta.get(), dresult.get());
 
     GKO_ASSERT_MTX_NEAR(dresult, expected, 1e-14);
@@ -267,7 +278,29 @@ TEST_F(Csr, AdvancedApplyToDenseMatrixIsEquivalentToRefWithClassical)
 {
     set_up_apply_data(std::make_shared<Mtx::classical>(), 3);
 
-     mtx->apply(alpha.get(), y.get(), beta.get(), expected.get());
+    mtx->apply(alpha.get(), y.get(), beta.get(), expected.get());
+    dmtx->apply(dalpha.get(), dy.get(), dbeta.get(), dresult.get());
+
+    GKO_ASSERT_MTX_NEAR(dresult, expected, 1e-14);
+}
+
+
+TEST_F(Csr, SimpleApplyToDenseMatrixIsEquivalentToRefWithMergePath)
+{
+    set_up_apply_data(std::make_shared<Mtx::merge_path>(), 3);
+
+    mtx->apply(y.get(), expected.get());
+    dmtx->apply(dy.get(), dresult.get());
+
+    GKO_ASSERT_MTX_NEAR(dresult, expected, 1e-14);
+}
+
+
+TEST_F(Csr, AdvancedApplyToDenseMatrixIsEquivalentToRefWithMergePath)
+{
+    set_up_apply_data(std::make_shared<Mtx::merge_path>(), 3);
+
+    mtx->apply(alpha.get(), y.get(), beta.get(), expected.get());
     dmtx->apply(dalpha.get(), dy.get(), dbeta.get(), dresult.get());
 
     GKO_ASSERT_MTX_NEAR(dresult, expected, 1e-14);

--- a/cuda/test/matrix/csr_kernels.cpp
+++ b/cuda/test/matrix/csr_kernels.cpp
@@ -208,6 +208,17 @@ TEST_F(Csr, SimpleApplyIsEquivalentToRefWithClassical)
 }
 
 
+TEST_F(Csr, AdvancedApplyIsEquivalentToRefWithClassical)
+{
+    set_up_apply_data(std::make_shared<Mtx::classical>());
+
+     mtx->apply(alpha.get(), y.get(), beta.get(), expected.get());
+    dmtx->apply(dalpha.get(), dy.get(), dbeta.get(), dresult.get());
+
+    GKO_ASSERT_MTX_NEAR(dresult, expected, 1e-14);
+}
+
+
 TEST_F(Csr, SimpleApplyIsEquivalentToRefWithAutomatical)
 {
     set_up_apply_data(std::make_shared<Mtx::automatical>(32));
@@ -235,6 +246,28 @@ TEST_F(Csr, AdvancedApplyToDenseMatrixIsEquivalentToRefWithLoadBalance)
     set_up_apply_data(std::make_shared<Mtx::load_balance>(32), 3);
 
     mtx->apply(alpha.get(), y.get(), beta.get(), expected.get());
+    dmtx->apply(dalpha.get(), dy.get(), dbeta.get(), dresult.get());
+
+    GKO_ASSERT_MTX_NEAR(dresult, expected, 1e-14);
+}
+
+
+TEST_F(Csr, SimpleApplyToDenseMatrixIsEquivalentToRefWithClassical)
+{
+    set_up_apply_data(std::make_shared<Mtx::classical>(), 3);
+
+    mtx->apply(y.get(), expected.get());
+    dmtx->apply(dy.get(), dresult.get());
+
+    GKO_ASSERT_MTX_NEAR(dresult, expected, 1e-14);
+}
+
+
+TEST_F(Csr, AdvancedApplyToDenseMatrixIsEquivalentToRefWithClassical)
+{
+    set_up_apply_data(std::make_shared<Mtx::classical>(), 3);
+
+     mtx->apply(alpha.get(), y.get(), beta.get(), expected.get());
     dmtx->apply(dalpha.get(), dy.get(), dbeta.get(), dresult.get());
 
     GKO_ASSERT_MTX_NEAR(dresult, expected, 1e-14);


### PR DESCRIPTION
This PR is the cuda part of #253. This closes #253.
- dense: It already has the test for mrhs, and it is a wrapper of cublas. I do not add extra test for one rhs
- hybrid: Add test for mrhs
- csr: `classical`, `load_balance` and `merge_path` has the implementation of apply and advanced_apply on mrhs.
`cusparse`: cuSparse can not allow the vector with `stride > 1`. If we still want mrhs of cuSparse, it need an extra vector to store each vector. For implementation now, I only use `GKO_NOT_IMPLEMENTED`.