### PR TITLE
Add codecov

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -393,6 +393,7 @@ coverage:
   before_script: *default_before_script
   script:
     - ctest -S cmake/CTestScript.cmake -DCTEST_BUILD_CONFIGURATION=COVERAGE
+    - bash <(curl -s https://codecov.io/bash)
   dependencies: []
   only:
     refs:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 ![Ginkgo](/assets/logo.png)
 
+[![Build status](https://gitlab.com/ginkgo-project/ginkgo-public-ci/badges/develop/build.svg)](https://github.com/ginkgo-project/ginkgo/commits/develop)
+[![Coverage](https://codecov.io/gh/ginkgo-project/ginkgo/branch/develop/graph/badge.svg)](https://codecov.io/gh/ginkgo-project/ginkgo)
+[![CDash dashboard](https://img.shields.io/badge/CDash-Access-blue.svg)](http://my.cdash.org/index.php?project=Ginkgo+Project)
+[![Documentation](https://img.shields.io/badge/Documentation-latest-blue.svg)](https://ginkgo-project.github.io/ginkgo/doc/develop/)
+
+
 Ginkgo is a high-performance linear algebra library for manycore systems, with a
 focus on sparse solution of linear systems. It is implemented using modern C++
 (you will need at least C++11 compliant compiler to build it), with GPU kernels

--- a/dev_tools/containers/ginkgo-cuda-base.py
+++ b/dev_tools/containers/ginkgo-cuda-base.py
@@ -7,7 +7,7 @@ Contents:
 	OpenMP latest apt version for Clang+OpenMP
 	Python 2 and 3 (upstream)
 	cmake (upstream)
-	git, openssh, doxygen, curl latest apt version
+	git, openssh, doxygen, curl, valgrind, graphviz latest apt version
 """
 # pylint: disable=invalid-name, undefined-variable, used-before-assignment
 
@@ -20,7 +20,7 @@ Stage0.baseimage(image)
 # Setup extra tools
 Stage0 += python()
 Stage0 += cmake(eula=True)
-Stage0 += apt_get(ospackages=['git', 'openssh-client', 'doxygen', 'curl', 'valgrind'])
+Stage0 += apt_get(ospackages=['git', 'openssh-client', 'doxygen', 'curl', 'valgrind', 'graphviz'])
 
 # GNU compilers
 gnu_version = USERARG.get('gnu', '7')

--- a/dev_tools/containers/ginkgo-nocuda-base.py
+++ b/dev_tools/containers/ginkgo-nocuda-base.py
@@ -6,7 +6,7 @@ Contents:
 	OpenMP latest apt version for Clang+OpenMP
 	Python 2 and 3 (upstream)
 	cmake (upstream)
-	build-essential, git, openssh, doxygen, curl latest apt version
+	build-essential, git, openssh, doxygen, curl, valgrind, graphviz latest apt version
 	papi: adds package libpfm4, and copy precompiled papi headers and files from a directory called 'papi'
 """
 # pylint: disable=invalid-name, undefined-variable, used-before-assignment
@@ -19,7 +19,7 @@ Stage0.baseimage('ubuntu:16.04')
 # Setup extra tools
 Stage0 += python()
 Stage0 += cmake(eula=True)
-Stage0 += apt_get(ospackages=['build-essential', 'git', 'openssh-client', 'doxygen', 'curl', 'valgrind'])
+Stage0 += apt_get(ospackages=['build-essential', 'git', 'openssh-client', 'doxygen', 'curl', 'valgrind', 'graphviz'])
 
 # GNU compilers
 gnu_version = USERARG.get('gnu', '8')

--- a/dev_tools/containers/gko-cuda100-gnu7-llvm60.baseimage
+++ b/dev_tools/containers/gko-cuda100-gnu7-llvm60.baseimage
@@ -22,7 +22,8 @@ RUN apt-get update -y && \
         openssh-client \
         doxygen \
         curl \
-        valgrind && \
+        valgrind \
+        graphviz && \
     rm -rf /var/lib/apt/lists/*
 
 # GNU compiler

--- a/dev_tools/containers/gko-cuda90-gnu5-llvm39.baseimage
+++ b/dev_tools/containers/gko-cuda90-gnu5-llvm39.baseimage
@@ -22,7 +22,8 @@ RUN apt-get update -y && \
         openssh-client \
         doxygen \
         curl \
-        valgrind && \
+        valgrind \
+        graphviz && \
     rm -rf /var/lib/apt/lists/*
 
 # GNU compiler

--- a/dev_tools/containers/gko-cuda91-gnu6-llvm40.baseimage
+++ b/dev_tools/containers/gko-cuda91-gnu6-llvm40.baseimage
@@ -22,7 +22,8 @@ RUN apt-get update -y && \
         openssh-client \
         doxygen \
         curl \
-        valgrind && \
+        valgrind \
+        graphviz && \
     rm -rf /var/lib/apt/lists/*
 
 # GNU compiler

--- a/dev_tools/containers/gko-cuda92-gnu7-llvm50.baseimage
+++ b/dev_tools/containers/gko-cuda92-gnu7-llvm50.baseimage
@@ -22,7 +22,8 @@ RUN apt-get update -y && \
         openssh-client \
         doxygen \
         curl \
-        valgrind && \
+        valgrind \
+        graphviz && \
     rm -rf /var/lib/apt/lists/*
 
 # GNU compiler

--- a/dev_tools/containers/gko-nocuda-gnu8-llvm70.baseimage
+++ b/dev_tools/containers/gko-nocuda-gnu8-llvm70.baseimage
@@ -23,7 +23,8 @@ RUN apt-get update -y && \
         openssh-client \
         doxygen \
         curl \
-        valgrind && \
+        valgrind \
+        graphviz && \
     rm -rf /var/lib/apt/lists/*
 
 # GNU compiler


### PR DESCRIPTION
This is a small PR with the purpose of adding a new tool, [codecov](https://codecov.io/gh/ginkgo-project/ginkgo/branch/add_codecov).

This provides the ability to add a coverage banner in our Readme. I also add some other convenience banners at the same time. The codecov tool itself provides a different view of code coverage which is fairly intuitive. See the link above for an example.
Here is a sample from the branch:  ![Coverage](https://codecov.io/gh/ginkgo-project/ginkgo/branch/add_codecov/graph/badge.svg)

Finally, it is unrelated but the containers are updated at the same time to also add the `graphviz` tool which is required for PR #258.