### PR TITLE
Add support for CUDA compute capability 7.5

### DIFF
--- a/cuda/base/executor.cpp
+++ b/cuda/base/executor.cpp
@@ -100,6 +100,7 @@ inline int convert_sm_ver_to_cores(int major, int minor)
         {0x62, 128},  // Pascal Generation (SM 6.2) GP10x class
         {0x70, 64},   // Volta Generation (SM 7.0) GV100 class
         {0x72, 64},   // Volta Generation (SM 7.2) GV11b class
+        {0x75, 64},   // Turing Generation (SM 7.5) TU1xx class
         {-1, -1}};
 
     int index = 0;


### PR DESCRIPTION
Added the number of cuda-cores per SM for compute capability 7.5 to the existing map.

Closes #266 .
__TODO:__
- [x] A test on a cc 7.5 card is __required__ before merging