### PR TITLE
Supporting CUDA Toolkit 10.1 combined with GCC

### DIFF
--- a/cuda/solver/gmres_kernels.cu
+++ b/cuda/solver/gmres_kernels.cu
@@ -694,10 +694,13 @@ void solve_x(std::shared_ptr<const CudaExecutor> exec,
              const Array<size_type> *final_iter_nums,
              const LinOp *preconditioner)
 {
-    auto before_preconditioner =
-        matrix::Dense<ValueType>::create_with_config_of(x);
-    auto after_preconditioner =
-        matrix::Dense<ValueType>::create_with_config_of(x);
+    // The CUDA 10.1 compiler does not compile
+    // `matrix::Dense<ValueType>::create_with_config_of(x)`,
+    // therefore, the `create` method is directly called.
+    auto before_preconditioner = matrix::Dense<ValueType>::create(
+        x->get_executor(), x->get_size(), x->get_stride());
+    auto after_preconditioner = matrix::Dense<ValueType>::create(
+        x->get_executor(), x->get_size(), x->get_stride());
 
     const auto num_rows = before_preconditioner->get_size()[0];
     const auto num_cols = krylov_bases->get_size()[1];

--- a/cuda/solver/gmres_kernels.cu
+++ b/cuda/solver/gmres_kernels.cu
@@ -694,13 +694,10 @@ void solve_x(std::shared_ptr<const CudaExecutor> exec,
              const Array<size_type> *final_iter_nums,
              const LinOp *preconditioner)
 {
-    // The CUDA 10.1 compiler does not compile
-    // `matrix::Dense<ValueType>::create_with_config_of(x)`,
-    // therefore, the `create` method is directly called.
-    auto before_preconditioner = matrix::Dense<ValueType>::create(
-        x->get_executor(), x->get_size(), x->get_stride());
-    auto after_preconditioner = matrix::Dense<ValueType>::create(
-        x->get_executor(), x->get_size(), x->get_stride());
+    auto before_preconditioner =
+        matrix::Dense<ValueType>::create_with_config_of(x);
+    auto after_preconditioner =
+        matrix::Dense<ValueType>::create_with_config_of(x);
 
     const auto num_rows = before_preconditioner->get_size()[0];
     const auto num_cols = krylov_bases->get_size()[1];

--- a/include/ginkgo/core/matrix/dense.hpp
+++ b/include/ginkgo/core/matrix/dense.hpp
@@ -128,8 +128,13 @@ public:
      */
     static std::unique_ptr<Dense> create_with_config_of(const Dense *other)
     {
-        return Dense::create(other->get_executor(), other->get_size(),
-                             other->get_stride());
+        // De-referencing `other` before calling the functions (instead of
+        // using operator `->`) is currently required to be compatible with
+        // CUDA 10.1.
+        // Otherwise, it results in a compile error.
+        // TODO Check if the compiler error is fixed and revert to `operator->`.
+        return Dense::create((*other).get_executor(), (*other).get_size(),
+                             (*other).get_stride());
     }
 
     void convert_to(Coo<ValueType, int32> *result) const override;


### PR DESCRIPTION
CUDA Toolkit 10.1, for some reason, does not allow a call to our current version of `Dense::create_with_config_of` (it does not compile) inside a `.cu` file. In order to fix that, there are two options:
1. To call `Dense::create` directly in the CUDA gmres solver
2. de-referencing the `other` pointer first instead of relying on the operator `->` (credit to @rongou and @trivialfis for finding that, I came across their solution [from this comment](https://github.com/dmlc/xgboost/pull/4223#issuecomment-470476672))

I think the second option is nicer since it allows us to use `Dense::create_with_config_of` everywhere, which is why it is now the current proposed solution.

Closes #263.

__TODO:__
- [x] Compile and test with CUDA 10.1