### PR TITLE
Update the third party packages to the latest releases

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,9 +75,9 @@ configure_file(${Ginkgo_SOURCE_DIR}/include/ginkgo/config.hpp.in
 
 # Try to find the third party packages before using our subdirectories
 include(cmake/package_helpers.cmake)
-ginkgo_find_package(GTest)
-ginkgo_find_package(gflags)
-ginkgo_find_package(RapidJSON)
+ginkgo_find_package(GTest 1.8.1)
+ginkgo_find_package(gflags 2.2.2)
+ginkgo_find_package(RapidJSON 1.1.0)
 add_subdirectory(third_party)    # Third-party tools and libraries
 
 # Needs to be first in order for `CMAKE_CUDA_DEVICE_LINK_EXECUTABLE` to be 

--- a/third_party/gflags/CMakeLists.txt
+++ b/third_party/gflags/CMakeLists.txt
@@ -1,5 +1,7 @@
 ginkgo_load_git_package(gflags_external
     "https://github.com/gflags/gflags.git"
-    "660603a3df1c400437260b51c55490a046a12e8a"
-    "-DBUILD_TESTING=OFF" "-DBUILD_gflags_LIB=OFF" "-DBUILD_gflags_nothreads_LIB=ON" "-DBUILD_STATIC_LIBS=ON")
-ginkgo_add_external_target(gflags gflags_nothreads build/include build/lib STATIC "" gflags_external FALSE)
+    "e171aa2d15ed9eb17054558e0b3a6a413bb01067"
+    "-DGFLAGS_BUILD_TESTING=OFF" "-DGFLAGS_BUILD_gflags_LIB=OFF"
+    "-DGFLAGS_BUILD_gflags_nothreads_LIB=ON" "-DGFLAGS_BUILD_STATIC_LIBS=ON"
+    "-DGFLAGS_BUILD_PACKAGING=OFF")
+ginkgo_add_external_target(gflags gflags_nothreads build/include build/lib STATIC "_debug" gflags_external FALSE)

--- a/third_party/gtest/CMakeLists.txt
+++ b/third_party/gtest/CMakeLists.txt
@@ -1,6 +1,6 @@
 ginkgo_load_git_package(gtest_external
     "https://github.com/google/googletest.git"
-    "d5266326752f0a1dadbd310932d8f4fd8c3c5e7d"
+    "2fe3bd994b3189899d93f1d5a881e725e046fdc2"
     # Work around the linking errors when compiling gtest with CUDA
     "-Dgtest_disable_pthreads=ON")
 ginkgo_add_external_target(GTest::GTest gtest src/googletest/include build/googlemock/gtest

--- a/third_party/rapidjson/CMakeLists.txt
+++ b/third_party/rapidjson/CMakeLists.txt
@@ -1,8 +1,9 @@
 ginkgo_load_git_package(rapidjson_external
     "https://github.com/Tencent/rapidjson.git"
-    "73063f5002612c6bf64fe24f851cd5cc0d83eef9"
+    "8d272e53a4d1dc405e08ce2dd50159c58f4451e9"
     "-DRAPIDJSON_BUILD_DOC=OFF" "-DRAPIDJSON_BUILD_EXAMPLES=OFF"
-    "-DRAPIDJSON_BUILD_TESTS=OFF" "-DRAPIDJSON_BUILD_THIRDPARTY_GTEST=OFF")
+    "-DRAPIDJSON_BUILD_TESTS=OFF" "-DRAPIDJSON_BUILD_THIRDPARTY_GTEST=OFF"
+    "-DRAPIDJSON_BUILD_CXX11=ON")
 # Remove directory with questionable licensing
 file(REMOVE_RECURSE ${CMAKE_CURRENT_BINARY_DIR}/src/bin/jsonchecker)
 ginkgo_add_external_target(rapidjson rapidjson src/include "" STATIC "" rapidjson_external TRUE)


### PR DESCRIPTION
`gtest` and `gflags` are updated to their latest release. For `RapidJSON`, try to find a correct version as the last release is over two years old and there is a lot of recent pipeline failures.

This PR also ensures for our usage RapidJSON that there is no problem with some compilers when building benchmarks (i.e., building Ginkgo with `-DGINKGO_BUILD_BENCHMARKS=ON`). The problem was that on some compilers, no constructor can be recognized for the RapidJSON `GenericValue` object with a parameter of type `std::size_t`. The fix used is to add an explicit version of our main function `add_or_set_member` for `std::size_t` which uses a `static_cast` to `std::uint64_t`.

This is related to #270.