### PR TITLE
Allow Ginkgo to be build statically with CUDA

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,6 +80,11 @@ ginkgo_find_package(gflags)
 ginkgo_find_package(RapidJSON)
 add_subdirectory(third_party)    # Third-party tools and libraries
 
+# Needs to be first in order for `CMAKE_CUDA_DEVICE_LINK_EXECUTABLE` to be 
+# propagated to the other parts of Ginkgo in case of building as static libraries
+if(GINKGO_BUILD_CUDA)
+    add_subdirectory(cuda)       # High-performance kernels for NVIDIA GPUs
+endif()
 # Ginkgo core libraries
 add_subdirectory(core)           # Core Ginkgo types and top-level functions
 if (GINKGO_BUILD_REFERENCE)
@@ -87,9 +92,6 @@ if (GINKGO_BUILD_REFERENCE)
 endif()
 if (GINKGO_BUILD_OMP)
     add_subdirectory(omp)        # High-performance omp kernels
-endif()
-if(GINKGO_BUILD_CUDA)
-    add_subdirectory(cuda)       # High-performance kernels for NVIDIA GPUs
 endif()
 
 # Non core directories and targets

--- a/cuda/CMakeLists.txt
+++ b/cuda/CMakeLists.txt
@@ -1,4 +1,11 @@
 enable_language(CUDA)
+
+# Needed because of a known issue with CUDA while linking statically.
+# For details, see https://gitlab.kitware.com/cmake/cmake/issues/18614
+if (NOT BUILD_SHARED_LIBS)
+    set(CMAKE_CUDA_DEVICE_LINK_EXECUTABLE ${CMAKE_CUDA_DEVICE_LINK_EXECUTABLE} PARENT_SCOPE)
+endif()
+
 include(CudaArchitectureSelector)
 
 set(CUDA_INCLUDE_DIRS ${CMAKE_CUDA_TOOLKIT_INCLUDE_DIRECTORIES})

--- a/test_install/CMakeLists.txt
+++ b/test_install/CMakeLists.txt
@@ -7,6 +7,14 @@ find_package(Ginkgo REQUIRED
             # Alternatively, use `cmake -DCMAKE_PREFIX_PATH=<ginkgo_install_dir>` to specify the install directory
             )
 
+
+# Needed because of a known issue with CUDA while linking statically.
+# For details, see https://gitlab.kitware.com/cmake/cmake/issues/18614
+if((NOT GINKGO_BUILD_SHARED_LIBS) AND GINKGO_BUILD_CUDA)
+    enable_language(CUDA)
+endif()
+
+
 add_executable(test_install test_install.cpp)
 target_compile_features(test_install PUBLIC cxx_std_11)
 target_link_libraries(test_install PRIVATE Ginkgo::ginkgo)

--- a/test_install/test_install.cpp
+++ b/test_install/test_install.cpp
@@ -111,7 +111,7 @@ int main(int, char **)
     {
         using testType = double;
         static_assert(gko::is_complex<testType>() == false,
-                      "math.hpp nit included properly!");
+                      "math.hpp not included properly!");
     }
 
     // core/base/matrix_data.hpp
@@ -281,6 +281,16 @@ int main(int, char **)
     // core/solver/gmres.hpp
     {
         using Solver = gko::solver::Gmres<>;
+        auto test = Solver::build()
+                        .with_criteria(
+                            gko::stop::Iteration::build().with_max_iters(1u).on(
+                                refExec))
+                        .on(refExec);
+    }
+    
+    // core/solver/ir.hpp
+    {
+        using Solver = gko::solver::Ir<>;
         auto test = Solver::build()
                         .with_criteria(
                             gko::stop::Iteration::build().with_max_iters(1u).on(


### PR DESCRIPTION
Building Ginkgo as a static library with CUDA requires the variable `CMAKE_CUDA_DEVICE_LINK_EXECUTABLE` (set by `enable_language(CUDA)`) in the parent `CMakeLists.txt` (see the [official cmake issue](https://gitlab.kitware.com/cmake/cmake/issues/18614)).

Instead of using `enable_language(CUDA)` in the topmost `CMakeLists.txt`, `CMAKE_CUDA_DEVICE_LINK_EXECUTABLE` is now forwarded from the `cuda` subdirectory (which is why it is now moved in front of the others, so the mentioned variable is set everywhere).
`enable_language(CUDA)` was also added in the `test_install`, which would not work without it when Ginkgo was build as a static library with CUDA.


Also did some minor changes in the `test_install.cpp`:
- Fixed a typo
- Added the Ir solver to the test