### PR TITLE
Fix circular deps

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -46,12 +46,11 @@ stages:
     - mkdir -p ${CI_JOB_NAME} && cd ${CI_JOB_NAME}
     - cmake ${CI_PROJECT_DIR}
         -DCMAKE_C_COMPILER=${C_COMPILER} -DCMAKE_CXX_COMPILER=${CXX_COMPILER}
-        -DCMAKE_BUILD_TYPE=${BUILD_TYPE} -DBUILD_SHARED_LIBS=ON
-        ${EXTRA_CMAKE_FLAGS} -DGINKGO_DEVEL_TOOLS=OFF
-        -DGINKGO_BUILD_REFERENCE=${BUILD_REFERENCE}
+        -DCMAKE_BUILD_TYPE=${BUILD_TYPE} -DCMAKE_CXX_FLAGS="${CXX_FLAGS}"
+        -DCMAKE_CUDA_HOST_COMPILER=$(which ${CXX_COMPILER}) ${EXTRA_CMAKE_FLAGS}
+        -DGINKGO_DEVEL_TOOLS=OFF -DGINKGO_BUILD_REFERENCE=${BUILD_REFERENCE}
         -DGINKGO_BUILD_OMP=${BUILD_OMP} -DGINKGO_BUILD_CUDA=${BUILD_CUDA}
         -DGINKGO_BUILD_TESTS=ON -DGINKGO_BUILD_EXAMPLES=ON
-        -DCMAKE_CXX_FLAGS="${CXX_FLAGS}"
     - make -j$(grep "core id" /proc/cpuinfo | sort -u | wc -l)
   artifacts:
     paths:
@@ -88,17 +87,18 @@ sync:
     - schedules
 
 # Build jobs
-build/cuda90/gcc/all/debug:
+build/cuda90/gcc/all/debug/shared:
   <<: *default_build
   image: localhost:5000/gko-cuda90-gnu5-llvm39
   variables:
     <<: *default_variables
     BUILD_OMP: "ON"
     BUILD_CUDA: "ON"
-    EXTRA_CMAKE_FLAGS: &cuda_flags
-      -DCUDA_ARCHITECTURES=35
+    BUILD_TYPE: Debug
+    EXTRA_CMAKE_FLAGS: &cuda_flags_shared
+      "-DGINKGO_CUDA_ARCHITECTURES=35 -DBUILD_SHARED_LIBS=ON"
 
-build/cuda90/clang/all/debug:
+build/cuda90/clang/all/release/static:
   <<: *default_build
   image: localhost:5000/gko-cuda90-gnu5-llvm39
   variables:
@@ -107,19 +107,22 @@ build/cuda90/clang/all/debug:
     CXX_COMPILER: clang++
     BUILD_OMP: "ON"
     BUILD_CUDA: "ON"
-    EXTRA_CMAKE_FLAGS: *cuda_flags
+    BUILD_TYPE: Release
+    EXTRA_CMAKE_FLAGS: &cuda_flags_static
+      "-DGINKGO_CUDA_ARCHITECTURES=35 -DBUILD_SHARED_LIBS=OFF"
 
 # cuda 9.1 and friends
-build/cuda91/gcc/all/debug:
+build/cuda91/gcc/all/debug/static:
   <<: *default_build
   image: localhost:5000/gko-cuda91-gnu6-llvm40
   variables:
     <<: *default_variables
     BUILD_OMP: "ON"
     BUILD_CUDA: "ON"
-    EXTRA_CMAKE_FLAGS: *cuda_flags
+    BUILD_TYPE: Debug
+    EXTRA_CMAKE_FLAGS: *cuda_flags_static
 
-build/cuda91/clang/all/debug:
+build/cuda91/clang/all/release/shared:
   <<: *default_build
   image: localhost:5000/gko-cuda91-gnu6-llvm40
   variables:
@@ -128,19 +131,21 @@ build/cuda91/clang/all/debug:
     CXX_COMPILER: clang++
     BUILD_OMP: "ON"
     BUILD_CUDA: "ON"
-    EXTRA_CMAKE_FLAGS: *cuda_flags
+    BUILD_TYPE: Release
+    EXTRA_CMAKE_FLAGS: *cuda_flags_shared
 
 # cuda 9.2 and friends
-build/cuda92/gcc/all/debug:
+build/cuda92/gcc/all/release/shared:
   <<: *default_build
   image: localhost:5000/gko-cuda92-gnu7-llvm50
   variables:
     <<: *default_variables
     BUILD_OMP: "ON"
     BUILD_CUDA: "ON"
-    EXTRA_CMAKE_FLAGS: *cuda_flags
+    BUILD_TYPE: Release
+    EXTRA_CMAKE_FLAGS: *cuda_flags_shared
 
-build/cuda92/clang/all/debug:
+build/cuda92/clang/all/debug/static:
   <<: *default_build
   image: localhost:5000/gko-cuda92-gnu7-llvm50
   variables:
@@ -149,19 +154,21 @@ build/cuda92/clang/all/debug:
     CXX_COMPILER: clang++
     BUILD_OMP: "ON"
     BUILD_CUDA: "ON"
-    EXTRA_CMAKE_FLAGS: *cuda_flags
+    BUILD_TYPE: Debug
+    EXTRA_CMAKE_FLAGS: *cuda_flags_static
 
 # cuda 10.0 and friends
-build/cuda100/gcc/all/debug:
+build/cuda100/gcc/all/debug/shared:
   <<: *default_build
   image: localhost:5000/gko-cuda100-gnu7-llvm60
   variables:
     <<: *default_variables
     BUILD_OMP: "ON"
     BUILD_CUDA: "ON"
-    EXTRA_CMAKE_FLAGS: *cuda_flags
+    BUILD_TYPE: Debug
+    EXTRA_CMAKE_FLAGS: *cuda_flags_shared
 
-build/cuda100/clang/all/debug:
+build/cuda100/clang/all/release/static:
   <<: *default_build
   image: localhost:5000/gko-cuda100-gnu7-llvm60
   variables:
@@ -170,167 +177,128 @@ build/cuda100/clang/all/debug:
     CXX_COMPILER: clang++
     BUILD_OMP: "ON"
     BUILD_CUDA: "ON"
-    EXTRA_CMAKE_FLAGS: *cuda_flags
+    BUILD_TYPE: Release
+    EXTRA_CMAKE_FLAGS: *cuda_flags_static
 
 # no cuda but latest gcc and "soon" clang 7
-build/nocuda/gcc/core/debug:
+build/nocuda/gcc/core/debug/static:
   <<: *default_build
   image: localhost:5000/gko-nocuda-gnu8-llvm70
   variables:
     <<: *default_variables
-    BUILD_REFERENCE: "off"
+    BUILD_REFERENCE: "OFF"
+    BUILD_TYPE: Debug
+    EXTRA_CMAKE_FLAGS: &flags_static
+      -DBUILD_SHARED_LIBS=OFF
 
-build/nocuda/gcc/reference/debug:
-  <<: *default_build
-  image: localhost:5000/gko-nocuda-gnu8-llvm70
-  variables:
-    <<: *default_variables
-
-build/nocuda/gcc/omp/debug:
-  <<: *default_build
-  image: localhost:5000/gko-nocuda-gnu8-llvm70
-  variables:
-    <<: *default_variables
-    BUILD_OMP: "ON"
-
-# Release builds
-build/cuda91/gcc/all/release:
-  <<: *default_build
-  image: localhost:5000/gko-cuda91-gnu6-llvm40
-  variables:
-    <<: *default_variables
-    BUILD_OMP: "ON"
-    BUILD_CUDA: "ON"
-    BUILD_TYPE: Release
-    EXTRA_CMAKE_FLAGS: &cuda_flags
-      -DCUDA_ARCHITECTURES=35
-
-build/cuda91/clang/all/release:
-  <<: *default_build
-  image: localhost:5000/gko-cuda91-gnu6-llvm40
-  variables:
-    <<: *default_variables
-    C_COMPILER: clang
-    CXX_COMPILER: clang++
-    BUILD_OMP: "ON"
-    BUILD_CUDA: "ON"
-    BUILD_TYPE: Release
-    EXTRA_CMAKE_FLAGS: *cuda_flags
-
-build/nocuda/gcc/omp/release:
-  <<: *default_build
-  image: localhost:5000/gko-nocuda-gnu8-llvm70
-  variables:
-    <<: *default_variables
-    BUILD_OMP: "ON"
-    BUILD_TYPE: Release
-
-build/nocuda/clang/omp/release:
+build/nocuda/clang/core/release/shared:
   <<: *default_build
   image: localhost:5000/gko-nocuda-gnu8-llvm70
   variables:
     <<: *default_variables
     C_COMPILER: clang
     CXX_COMPILER: clang++
-    BUILD_OMP: "ON"
+    BUILD_REFERENCE: "OFF"
     BUILD_TYPE: Release
+    EXTRA_CMAKE_FLAGS: &flags_shared
+      -DBUILD_SHARED_LIBS=ON
 
+build/nocuda/gcc/omp/release/shared:
+  <<: *default_build
+  image: localhost:5000/gko-nocuda-gnu8-llvm70
+  variables:
+    <<: *default_variables
+    BUILD_OMP: "ON"
+    BUILD_REFERENCE: "ON"
+    BUILD_TYPE: Release
+    EXTRA_CMAKE_FLAGS: *flags_shared
+
+build/nocuda/clang/omp/debug/static:
+  <<: *default_build
+  image: localhost:5000/gko-nocuda-gnu8-llvm70
+  variables:
+    <<: *default_variables
+    BUILD_OMP: "ON"
+    BUILD_REFERENCE: "ON"
+    BUILD_TYPE: Debug
+    EXTRA_CMAKE_FLAGS: *flags_static
 
 # Test jobs
-test/cuda90/gcc/all/debug:
+test/cuda90/gcc/all/debug/shared:
   <<: *default_test
   image: localhost:5000/gko-cuda90-gnu5-llvm39
   dependencies:
-    - build/cuda90/gcc/all/debug
+    - build/cuda90/gcc/all/debug/shared
 
-test/cuda90/clang/all/debug:
+test/cuda90/clang/all/release/static:
   <<: *default_test
   image: localhost:5000/gko-cuda90-gnu5-llvm39
   dependencies:
-    - build/cuda90/clang/all/debug
+    - build/cuda90/clang/all/release/static
 
 # cuda 9.1 and friends
-test/cuda91/gcc/all/debug:
+test/cuda91/gcc/all/debug/static:
   <<: *default_test
   image: localhost:5000/gko-cuda91-gnu6-llvm40
   dependencies:
-    - build/cuda91/gcc/all/debug
+    - build/cuda91/gcc/all/debug/static
 
-test/cuda91/clang/all/debug:
+test/cuda91/clang/all/release/shared:
   <<: *default_test
   image: localhost:5000/gko-cuda91-gnu6-llvm40
   dependencies:
-    - build/cuda91/clang/all/debug
+    - build/cuda91/clang/all/release/shared
 
 # cuda 9.2 and friends
-test/cuda92/gcc/all/debug:
+test/cuda92/gcc/all/release/shared:
   <<: *default_test
   image: localhost:5000/gko-cuda92-gnu7-llvm50
   dependencies:
-    - build/cuda92/gcc/all/debug
+    - build/cuda92/gcc/all/release/shared
 
-test/cuda92/clang/all/debug:
+test/cuda92/clang/all/debug/static:
   <<: *default_test
   image: localhost:5000/gko-cuda92-gnu7-llvm50
   dependencies:
-    - build/cuda92/clang/all/debug
+    - build/cuda92/clang/all/debug/static
 
 # cuda 10.0 and friends
-test/cuda100/gcc/all/debug:
+test/cuda100/gcc/all/debug/shared:
   <<: *default_test
   image: localhost:5000/gko-cuda100-gnu7-llvm60
   dependencies:
-    - build/cuda100/gcc/all/debug
+    - build/cuda100/gcc/all/debug/shared
 
-test/cuda100/clang/all/debug:
+test/cuda100/clang/all/release/static:
   <<: *default_test
   image: localhost:5000/gko-cuda100-gnu7-llvm60
   dependencies:
-    - build/cuda100/clang/all/debug
+    - build/cuda100/clang/all/release/static
 
 # no cuda but latest gcc and "soon" clang 7
-test/nocuda/gcc/core/debug:
+test/nocuda/gcc/core/debug/static:
   <<: *default_test
   image: localhost:5000/gko-nocuda-gnu8-llvm70
   dependencies:
-    - build/nocuda/gcc/core/debug
+    - build/nocuda/gcc/core/debug/static
 
-test/nocuda/gcc/reference/debug:
+test/nocuda/clang/core/release/shared:
   <<: *default_test
   image: localhost:5000/gko-nocuda-gnu8-llvm70
   dependencies:
-    - build/nocuda/gcc/reference/debug
+    - build/nocuda/clang/core/release/shared
 
-test/nocuda/gcc/omp/debug:
+test/nocuda/gcc/omp/release/shared:
   <<: *default_test
   image: localhost:5000/gko-nocuda-gnu8-llvm70
   dependencies:
-    - build/nocuda/gcc/omp/debug
+    - build/nocuda/gcc/omp/release/shared
 
-# Release tests
-test/cuda91/gcc/all/release:
-  <<: *default_test
-  image: localhost:5000/gko-cuda91-gnu6-llvm40
-  dependencies:
-    - build/cuda91/gcc/all/release
-
-test/cuda91/clang/all/release:
-  <<: *default_test
-  image: localhost:5000/gko-cuda91-gnu6-llvm40
-  dependencies:
-    - build/cuda91/clang/all/release
-
-test/nocuda/gcc/omp/release:
+test/nocuda/clang/omp/debug/static:
   <<: *default_test
   image: localhost:5000/gko-nocuda-gnu8-llvm70
   dependencies:
-    - build/nocuda/gcc/omp/release
-
-test/nocuda/clang/omp/release:
-  <<: *default_test
-  image: localhost:5000/gko-nocuda-gnu8-llvm70
-  dependencies:
-    - build/nocuda/clang/omp/release
+    - build/nocuda/clang/omp/debug/static
 
 
 # Job with important warnings as error

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -4,7 +4,7 @@ stages:
   - sync
   - build
   - test
-  - warnings
+  - code_quality
   - deploy
   - QoS_tools
   - benchmark-build
@@ -336,7 +336,7 @@ test/nocuda/clang/omp/release:
 # Job with important warnings as error
 warnings:
   <<: *default_build
-  stage: warnings
+  stage: code_quality
   image: localhost:5000/gko-cuda100-gnu7-llvm60
   variables:
     <<: *default_variables
@@ -345,6 +345,20 @@ warnings:
     CXX_FLAGS: "-Werror=pedantic -pedantic-errors"
   dependencies: []
   allow_failure: yes
+
+# Ensure kernel modules do not depend on core
+no-circular-deps:
+  <<: *default_build
+  stage: code_quality
+  image: localhost:5000/gko-cuda100-gnu7-llvm60
+  variables:
+    <<: *default_variables
+    BUILD_OMP: "ON"
+    BUILD_CUDA: "ON"
+    EXTRA_CMAKE_FLAGS: '-DCMAKE_SHARED_LINKER_FLAGS="-Wl,--no-undefined"
+      -DCMAKE_EXE_LINKER_FLAGS="-Wl,--no-undefined"'
+  dependencies: []
+  allow_failure: no
 
 
 # Deploy documentation to github-pages

--- a/cmake/create_test.cmake
+++ b/cmake/create_test.cmake
@@ -6,13 +6,6 @@ function(ginkgo_create_test test_name)
     set_target_properties(${TEST_TARGET_NAME} PROPERTIES
         OUTPUT_NAME ${test_name})
     target_link_libraries(${TEST_TARGET_NAME} PRIVATE ginkgo GTest::GTest GTest::Main ${ARGN})
-    # Needed because it causes undefined reference errors on some systems.
-    # To prevent that, the library files are added to the linker again.
-    target_link_libraries(${TEST_TARGET_NAME}
-        PRIVATE $<TARGET_LINKER_FILE:ginkgo_cuda>
-                $<TARGET_LINKER_FILE:ginkgo_reference>
-                $<TARGET_LINKER_FILE:ginkgo_omp>
-                $<TARGET_LINKER_FILE:ginkgo>)
     add_test(NAME ${REL_BINARY_DIR}/${test_name} COMMAND ${TEST_TARGET_NAME})
 endfunction(ginkgo_create_test)
 
@@ -24,10 +17,5 @@ function(ginkgo_create_cuda_test test_name)
     set_target_properties(${TEST_TARGET_NAME} PROPERTIES
         OUTPUT_NAME ${test_name})
     target_link_libraries(${TEST_TARGET_NAME} PRIVATE ginkgo GTest::GTest GTest::Main ${ARGN})
-    # Needed because it causes undefined reference errors on some systems.
-    # To prevent that, the library files are added to the linker again.
-    target_link_libraries(${TEST_TARGET_NAME}
-        PRIVATE $<TARGET_LINKER_FILE:ginkgo_cuda>
-                $<TARGET_LINKER_FILE:ginkgo>)
     add_test(NAME ${REL_BINARY_DIR}/${test_name} COMMAND ${TEST_TARGET_NAME})
 endfunction(ginkgo_create_cuda_test)

--- a/core/base/executor.cpp
+++ b/core/base/executor.cpp
@@ -63,10 +63,4 @@ const char *Operation::get_name() const noexcept
 }
 
 
-int CudaExecutor::num_execs[max_devices];
-
-
-std::mutex CudaExecutor::mutex[max_devices];
-
-
 }  // namespace gko

--- a/core/devices/cuda/executor.cpp
+++ b/core/devices/cuda/executor.cpp
@@ -49,4 +49,10 @@ std::shared_ptr<const Executor> CudaExecutor::get_master() const noexcept
 }
 
 
+int CudaExecutor::num_execs[max_devices];
+
+
+std::mutex CudaExecutor::mutex[max_devices];
+
+
 }  // namespace gko

--- a/core/solver/gmres.cpp
+++ b/core/solver/gmres.cpp
@@ -152,6 +152,11 @@ void Gmres<ValueType>::apply_impl(const LinOp *b, LinOp *x) const
     int total_iter = -1;
     size_type restart_iter = 0;
 
+    auto before_preconditioner =
+        matrix::Dense<ValueType>::create_with_config_of(dense_x);
+    auto after_preconditioner =
+        matrix::Dense<ValueType>::create_with_config_of(dense_x);
+
     while (true) {
         ++total_iter;
         this->template log<log::Logger::iteration_complete>(
@@ -167,11 +172,6 @@ void Gmres<ValueType>::apply_impl(const LinOp *b, LinOp *x) const
 
         if (restart_iter == krylov_dim_) {
             // Restart
-            auto before_preconditioner =
-                matrix::Dense<ValueType>::create_with_config_of(dense_x);
-            auto after_preconditioner =
-                matrix::Dense<ValueType>::create_with_config_of(dense_x);
-
             exec->run(gmres::make_step_2(residual_norm_collection.get(),
                                          krylov_bases.get(), hessenberg.get(),
                                          y.get(), before_preconditioner.get(),
@@ -255,11 +255,6 @@ void Gmres<ValueType>::apply_impl(const LinOp *b, LinOp *x) const
     auto hessenberg_small = hessenberg->create_submatrix(
         span{0, restart_iter},
         span{0, dense_b->get_size()[1] * (restart_iter)});
-
-    auto before_preconditioner =
-        matrix::Dense<ValueType>::create_with_config_of(dense_x);
-    auto after_preconditioner =
-        matrix::Dense<ValueType>::create_with_config_of(dense_x);
 
     exec->run(gmres::make_step_2(
         residual_norm_collection.get(), krylov_bases_small.get(),

--- a/core/solver/gmres.cpp
+++ b/core/solver/gmres.cpp
@@ -172,10 +172,10 @@ void Gmres<ValueType>::apply_impl(const LinOp *b, LinOp *x) const
             auto after_preconditioner =
                 matrix::Dense<ValueType>::create_with_config_of(dense_x);
 
-            exec->run(gmres::make_step_2(
-                residual_norm_collection.get(), krylov_bases.get(),
-                hessenberg.get(), y.get(), dense_x, before_preconditioner.get(),
-                &final_iter_nums));
+            exec->run(gmres::make_step_2(residual_norm_collection.get(),
+                                         krylov_bases.get(), hessenberg.get(),
+                                         y.get(), before_preconditioner.get(),
+                                         &final_iter_nums));
             // Solve upper triangular.
             // y = hessenberg \ residual_norm_collection
 
@@ -263,7 +263,7 @@ void Gmres<ValueType>::apply_impl(const LinOp *b, LinOp *x) const
 
     exec->run(gmres::make_step_2(
         residual_norm_collection.get(), krylov_bases_small.get(),
-        hessenberg_small.get(), y.get(), dense_x, before_preconditioner.get(),
+        hessenberg_small.get(), y.get(), before_preconditioner.get(),
         &final_iter_nums));
     // Solve upper triangular.
     // y = hessenberg \ residual_norm_collection

--- a/core/solver/gmres_kernels.hpp
+++ b/core/solver/gmres_kernels.hpp
@@ -84,8 +84,8 @@ namespace gmres {
                 const matrix::Dense<_type> *krylov_bases,             \
                 const matrix::Dense<_type> *hessenberg,               \
                 matrix::Dense<_type> *y, matrix::Dense<_type> *x,     \
-                const Array<size_type> *final_iter_nums,              \
-                const LinOp *preconditioner)
+                matrix::Dense<_type> *before_preconditioner,          \
+                const Array<size_type> *final_iter_nums)
 
 
 #define GKO_DECLARE_ALL_AS_TEMPLATES                  \

--- a/core/solver/gmres_kernels.hpp
+++ b/core/solver/gmres_kernels.hpp
@@ -83,7 +83,7 @@ namespace gmres {
                 const matrix::Dense<_type> *residual_norm_collection, \
                 const matrix::Dense<_type> *krylov_bases,             \
                 const matrix::Dense<_type> *hessenberg,               \
-                matrix::Dense<_type> *y, matrix::Dense<_type> *x,     \
+                matrix::Dense<_type> *y,                              \
                 matrix::Dense<_type> *before_preconditioner,          \
                 const Array<size_type> *final_iter_nums)
 

--- a/cuda/CMakeLists.txt
+++ b/cuda/CMakeLists.txt
@@ -61,11 +61,6 @@ target_include_directories(ginkgo_cuda
     SYSTEM PRIVATE ${CUDA_INCLUDE_DIRS})
 target_link_libraries(ginkgo_cuda PRIVATE ${CUDA_RUNTIME_LIBS} ${CUBLAS} ${CUSPARSE})
 
-# Ensures that there are no circular dependency issues
-if(NOT BUILD_SHARED_LIBS)
-    target_link_libraries(ginkgo_cuda PUBLIC ginkgo)
-endif()
-
 cas_target_cuda_architectures(ginkgo_cuda
     ARCHITECTURES ${GINKGO_CUDA_ARCHITECTURES}
     UNSUPPORTED "20" "21")

--- a/cuda/preconditioner/jacobi_kernels.cu
+++ b/cuda/preconditioner/jacobi_kernels.cu
@@ -38,6 +38,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
 #include "core/base/extended_float.hpp"
+#include "core/matrix/dense_kernels.hpp"
 #include "core/preconditioner/jacobi_utils.hpp"
 #include "core/synthesizer/implementation_selection.hpp"
 #include "cuda/base/math.hpp"
@@ -280,6 +281,39 @@ __global__ void __launch_bounds__(warps_per_block *cuda_config::warp_size)
 template <int max_block_size, int subwarp_size, int warps_per_block,
           typename ValueType, typename IndexType>
 __global__ void __launch_bounds__(warps_per_block *cuda_config::warp_size)
+    advanced_apply(const ValueType *__restrict__ blocks,
+                   preconditioner::block_interleaved_storage_scheme<IndexType>
+                       storage_scheme,
+                   const IndexType *__restrict__ block_ptrs,
+                   size_type num_blocks, const ValueType *__restrict__ alpha,
+                   const ValueType *__restrict__ b, int32 b_stride,
+                   ValueType *__restrict__ x, int32 x_stride)
+{
+    const auto block_id =
+        thread::get_subwarp_id<subwarp_size, warps_per_block>();
+    const auto subwarp =
+        group::tiled_partition<subwarp_size>(group::this_thread_block());
+    if (block_id >= num_blocks) {
+        return;
+    }
+    const auto block_size = block_ptrs[block_id + 1] - block_ptrs[block_id];
+    ValueType v = zero<ValueType>();
+    if (subwarp.thread_rank() < block_size) {
+        v = alpha[0] *
+            b[(block_ptrs[block_id] + subwarp.thread_rank()) * b_stride];
+    }
+    multiply_vec_add<max_block_size>(
+        subwarp, block_size, v,
+        blocks + storage_scheme.get_global_block_offset(block_id) +
+            subwarp.thread_rank(),
+        storage_scheme.get_stride(), x + block_ptrs[block_id] * x_stride,
+        x_stride);
+}
+
+
+template <int max_block_size, int subwarp_size, int warps_per_block,
+          typename ValueType, typename IndexType>
+__global__ void __launch_bounds__(warps_per_block *cuda_config::warp_size)
     adaptive_apply(const ValueType *__restrict__ blocks,
                    preconditioner::block_interleaved_storage_scheme<IndexType>
                        storage_scheme,
@@ -303,6 +337,45 @@ __global__ void __launch_bounds__(warps_per_block *cuda_config::warp_size)
     GKO_PRECONDITIONER_JACOBI_RESOLVE_PRECISION(
         ValueType, block_precisions[block_id],
         multiply_vec<max_block_size>(
+            subwarp, block_size, v,
+            reinterpret_cast<const resolved_precision *>(
+                blocks + storage_scheme.get_group_offset(block_id)) +
+                storage_scheme.get_block_offset(block_id) +
+                subwarp.thread_rank(),
+            storage_scheme.get_stride(), x + block_ptrs[block_id] * x_stride,
+            x_stride));
+}
+
+
+template <int max_block_size, int subwarp_size, int warps_per_block,
+          typename ValueType, typename IndexType>
+__global__ void __launch_bounds__(warps_per_block *cuda_config::warp_size)
+    advanced_adaptive_apply(
+        const ValueType *__restrict__ blocks,
+        preconditioner::block_interleaved_storage_scheme<IndexType>
+            storage_scheme,
+        const precision_reduction *__restrict__ block_precisions,
+        const IndexType *__restrict__ block_ptrs, size_type num_blocks,
+        const ValueType *__restrict__ alpha, const ValueType *__restrict__ b,
+        int32 b_stride, ValueType *__restrict__ x, int32 x_stride)
+{
+    const auto block_id =
+        thread::get_subwarp_id<subwarp_size, warps_per_block>();
+    const auto subwarp =
+        group::tiled_partition<subwarp_size>(group::this_thread_block());
+    if (block_id >= num_blocks) {
+        return;
+    }
+    const auto block_size = block_ptrs[block_id + 1] - block_ptrs[block_id];
+    auto alpha_val = alpha == nullptr ? one<ValueType>() : alpha[0];
+    ValueType v = zero<ValueType>();
+    if (subwarp.thread_rank() < block_size) {
+        v = alpha[0] *
+            b[(block_ptrs[block_id] + subwarp.thread_rank()) * b_stride];
+    }
+    GKO_PRECONDITIONER_JACOBI_RESOLVE_PRECISION(
+        ValueType, block_precisions[block_id],
+        multiply_vec_add<max_block_size>(
             subwarp, block_size, v,
             reinterpret_cast<const resolved_precision *>(
                 blocks + storage_scheme.get_group_offset(block_id)) +
@@ -404,6 +477,42 @@ void apply(syn::value_list<int, max_block_size>, size_type num_blocks,
 }
 
 GKO_ENABLE_IMPLEMENTATION_SELECTION(select_apply, apply);
+
+
+template <int warps_per_block, int max_block_size, typename ValueType,
+          typename IndexType>
+void advanced_apply(
+    syn::value_list<int, max_block_size>, size_type num_blocks,
+    const precision_reduction *block_precisions,
+    const IndexType *block_pointers, const ValueType *blocks,
+    const preconditioner::block_interleaved_storage_scheme<IndexType>
+        &storage_scheme,
+    const ValueType *alpha, const ValueType *b, size_type b_stride,
+    ValueType *x, size_type x_stride)
+{
+    constexpr int subwarp_size = get_larger_power(max_block_size);
+    constexpr int blocks_per_warp = cuda_config::warp_size / subwarp_size;
+    const dim3 grid_size(ceildiv(num_blocks, warps_per_block * blocks_per_warp),
+                         1, 1);
+    const dim3 block_size(subwarp_size, blocks_per_warp, warps_per_block);
+
+    if (block_precisions) {
+        kernel::advanced_adaptive_apply<max_block_size, subwarp_size,
+                                        warps_per_block>
+            <<<grid_size, block_size, 0, 0>>>(
+                as_cuda_type(blocks), storage_scheme, block_precisions,
+                block_pointers, num_blocks, as_cuda_type(alpha),
+                as_cuda_type(b), b_stride, as_cuda_type(x), x_stride);
+    } else {
+        kernel::advanced_apply<max_block_size, subwarp_size, warps_per_block>
+            <<<grid_size, block_size, 0, 0>>>(
+                as_cuda_type(blocks), storage_scheme, block_pointers,
+                num_blocks, as_cuda_type(alpha), as_cuda_type(b), b_stride,
+                as_cuda_type(x), x_stride);
+    }
+}
+
+GKO_ENABLE_IMPLEMENTATION_SELECTION(select_advanced_apply, advanced_apply);
 
 
 template <int warps_per_block>
@@ -634,14 +743,21 @@ void apply(std::shared_ptr<const CudaExecutor> exec, size_type num_blocks,
            const matrix::Dense<ValueType> *b,
            const matrix::Dense<ValueType> *beta, matrix::Dense<ValueType> *x)
 {
-    using Vec = matrix::Dense<ValueType>;
-    // TODO: do this efficiently
-    auto tmp = x->clone();
-    simple_apply(exec, num_blocks, max_block_size, storage_scheme,
-                 block_precisions, block_pointers, blocks, b,
-                 static_cast<Vec *>(tmp.get()));
-    x->scale(beta);
-    x->add_scaled(alpha, tmp.get());
+    // TODO: write a special kernel for multiple RHS
+    dense::scale(exec, beta, x);
+    for (size_type col = 0; col < b->get_size()[1]; ++col) {
+        select_advanced_apply(
+            compiled_kernels(),
+            [&](int compiled_block_size) {
+                return max_block_size <= compiled_block_size;
+            },
+            syn::value_list<int, cuda_config::min_warps_per_block>(),
+            syn::type_list<>(), num_blocks, block_precisions.get_const_data(),
+            block_pointers.get_const_data(), blocks.get_const_data(),
+            storage_scheme, alpha->get_const_values(),
+            b->get_const_values() + col, b->get_stride(), x->get_values() + col,
+            x->get_stride());
+    }
 }
 
 GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(GKO_DECLARE_JACOBI_APPLY_KERNEL);

--- a/cuda/solver/gmres_kernels.cu
+++ b/cuda/solver/gmres_kernels.cu
@@ -688,10 +688,10 @@ void solve_upper_triangular(
 
 
 template <typename ValueType>
-void solve_x(const matrix::Dense<ValueType> *krylov_bases,
-             const matrix::Dense<ValueType> *y, matrix::Dense<ValueType> *x,
-             matrix::Dense<ValueType> *before_preconditioner,
-             const Array<size_type> *final_iter_nums)
+void calculate_qy(const matrix::Dense<ValueType> *krylov_bases,
+                  const matrix::Dense<ValueType> *y,
+                  matrix::Dense<ValueType> *before_preconditioner,
+                  const Array<size_type> *final_iter_nums)
 {
     const auto num_rows = before_preconditioner->get_size()[0];
     const auto num_cols = krylov_bases->get_size()[1];
@@ -714,6 +714,8 @@ void solve_x(const matrix::Dense<ValueType> *krylov_bases,
         y->get_stride(), as_cuda_type(before_preconditioner->get_values()),
         stride_before_preconditioner,
         as_cuda_type(final_iter_nums->get_const_data()));
+    // Calculate qy
+    // before_preconditioner = krylov_bases * y
 }
 
 
@@ -722,13 +724,13 @@ void step_2(std::shared_ptr<const CudaExecutor> exec,
             const matrix::Dense<ValueType> *residual_norm_collection,
             const matrix::Dense<ValueType> *krylov_bases,
             const matrix::Dense<ValueType> *hessenberg,
-            matrix::Dense<ValueType> *y, matrix::Dense<ValueType> *x,
+            matrix::Dense<ValueType> *y,
             matrix::Dense<ValueType> *before_preconditioner,
             const Array<size_type> *final_iter_nums)
 {
     solve_upper_triangular(residual_norm_collection, hessenberg, y,
                            final_iter_nums);
-    solve_x(krylov_bases, y, x, before_preconditioner, final_iter_nums);
+    calculate_qy(krylov_bases, y, before_preconditioner, final_iter_nums);
 }
 
 GKO_INSTANTIATE_FOR_EACH_VALUE_TYPE(GKO_DECLARE_GMRES_STEP_2_KERNEL);

--- a/cuda/test/solver/gmres_kernels.cpp
+++ b/cuda/test/solver/gmres_kernels.cpp
@@ -265,14 +265,14 @@ TEST_F(Gmres, CudaGmresStep2IsEquivalentToRef)
 {
     initialize_data();
 
-    gko::kernels::reference::gmres::step_2(
-        ref, residual_norm_collection.get(), krylov_bases.get(),
-        hessenberg.get(), y.get(), x.get(), before_preconditioner.get(),
-        final_iter_nums.get());
-    gko::kernels::cuda::gmres::step_2(
-        cuda, d_residual_norm_collection.get(), d_krylov_bases.get(),
-        d_hessenberg.get(), d_y.get(), d_x.get(), d_before_preconditioner.get(),
-        d_final_iter_nums.get());
+    gko::kernels::reference::gmres::step_2(ref, residual_norm_collection.get(),
+                                           krylov_bases.get(), hessenberg.get(),
+                                           y.get(), before_preconditioner.get(),
+                                           final_iter_nums.get());
+    gko::kernels::cuda::gmres::step_2(cuda, d_residual_norm_collection.get(),
+                                      d_krylov_bases.get(), d_hessenberg.get(),
+                                      d_y.get(), d_before_preconditioner.get(),
+                                      d_final_iter_nums.get());
 
     GKO_ASSERT_MTX_NEAR(d_y, y, 1e-14);
     GKO_ASSERT_MTX_NEAR(d_x, x, 1e-14);

--- a/dev_tools/containers/build_all_containers.sh
+++ b/dev_tools/containers/build_all_containers.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+ 
+hpccm --recipe ginkgo-nocuda-base.py --userarg gnu=8 llvm=6.0 papi=True > gko-nocuda-gnu8-llvm70.baseimage
+hpccm --recipe ginkgo-cuda-base.py --userarg cuda=10.0 gnu=7 llvm=6.0 > gko-cuda100-gnu7-llvm60.baseimage
+hpccm --recipe ginkgo-cuda-base.py --userarg cuda=9.2 gnu=7 llvm=5.0 > gko-cuda92-gnu7-llvm50.baseimage
+hpccm --recipe ginkgo-cuda-base.py --userarg cuda=9.1 gnu=6 llvm=4.0 > gko-cuda91-gnu6-llvm40.baseimage
+hpccm --recipe ginkgo-cuda-base.py --userarg cuda=9.0 gnu=5 llvm=3.9 > gko-cuda90-gnu5-llvm39.baseimage
+for i in $(ls *.baseimage)
+do
+	name=$(echo $i | cut -d"." -f1)
+	docker build -t localhost:5000/$name -f $i .
+	docker push localhost:5000/$name
+done

--- a/dev_tools/containers/ginkgo-nocuda-base.py
+++ b/dev_tools/containers/ginkgo-nocuda-base.py
@@ -13,7 +13,7 @@ Contents:
 
 import os
 
-Stage0.baseimage('ubuntu:16.04')
+Stage0.baseimage('ubuntu:18.04')
 
 
 # Setup extra tools
@@ -26,7 +26,7 @@ gnu_version = USERARG.get('gnu', '8')
 Stage0 += gnu(version=gnu_version, extra_repository=True)
 
 # Clang compilers
-llvm_version = USERARG.get('llvm', '7.0')
+llvm_version = USERARG.get('llvm', '7')
 Stage0 += llvm(version=llvm_version, extra_repository=True)
 Stage0 += apt_get(ospackages=['libomp-dev']) #required for openmp+clang
 
@@ -34,6 +34,6 @@ Stage0 += apt_get(ospackages=['libomp-dev']) #required for openmp+clang
 add_papi = USERARG.get('papi', 'False')
 if os.path.isdir('papi/') and add_papi == 'True':
 	Stage0 += apt_get(ospackages=['libpfm4'])
-	Stage0 += copy(src='papi/include/*', dest='/usr/include/') 
-	Stage0 += copy(src='papi/lib/*', dest='/usr/lib/') 
-	Stage0 += copy(src='papi/bin/*', dest='/usr/bin/') 
+	Stage0 += copy(src='papi/include/*', dest='/usr/include/')
+	Stage0 += copy(src='papi/lib/*', dest='/usr/lib/')
+	Stage0 += copy(src='papi/bin/*', dest='/usr/bin/')

--- a/dev_tools/containers/gko-nocuda-gnu8-llvm70.baseimage
+++ b/dev_tools/containers/gko-nocuda-gnu8-llvm70.baseimage
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04 AS stage0
+FROM ubuntu:18.04 AS stage0
 
 # Python
 RUN apt-get update -y && \
@@ -44,10 +44,10 @@ RUN update-alternatives --install /usr/bin/gcc gcc $(which gcc-8) 30 && \
 # LLVM compiler
 RUN apt-get update -y && \
     apt-get install -y --no-install-recommends \
-        clang-6.0 && \
+        clang-7 && \
     rm -rf /var/lib/apt/lists/*
-RUN update-alternatives --install /usr/bin/clang clang $(which clang-6.0) 30 && \
-    update-alternatives --install /usr/bin/clang++ clang++ $(which clang++-6.0) 30
+RUN update-alternatives --install /usr/bin/clang clang $(which clang-7) 30 && \
+    update-alternatives --install /usr/bin/clang++ clang++ $(which clang++-7) 30
 
 RUN apt-get update -y && \
     apt-get install -y --no-install-recommends \

--- a/omp/CMakeLists.txt
+++ b/omp/CMakeLists.txt
@@ -25,10 +25,6 @@ target_link_libraries(ginkgo_omp PRIVATE "${OpenMP_CXX_LIBRARIES}")
 target_compile_options(ginkgo_omp PRIVATE "${OpenMP_CXX_FLAGS}")
 target_compile_options(ginkgo_omp PRIVATE "${GINKGO_COMPILER_FLAGS}")
 
-# Ensures that there are no circular dependency issues
-if(NOT BUILD_SHARED_LIBS)
-    target_link_libraries(ginkgo_omp PUBLIC ginkgo)
-endif()
 # Need to link against ginkgo_cuda for the `raw_copy_to(CudaExecutor ...)` method
 target_link_libraries(ginkgo_omp PUBLIC ginkgo_cuda)
 

--- a/omp/solver/gmres_kernels.cpp
+++ b/omp/solver/gmres_kernels.cpp
@@ -102,7 +102,7 @@ void step_2(std::shared_ptr<const OmpExecutor> exec,
             const matrix::Dense<ValueType> *residual_norm_collection,
             const matrix::Dense<ValueType> *krylov_bases,
             const matrix::Dense<ValueType> *hessenberg,
-            matrix::Dense<ValueType> *y, matrix::Dense<ValueType> *x,
+            matrix::Dense<ValueType> *y,
             matrix::Dense<ValueType> *before_preconditionner,
             const Array<size_type> *final_iter_nums)
 {

--- a/omp/solver/gmres_kernels.cpp
+++ b/omp/solver/gmres_kernels.cpp
@@ -103,8 +103,8 @@ void step_2(std::shared_ptr<const OmpExecutor> exec,
             const matrix::Dense<ValueType> *krylov_bases,
             const matrix::Dense<ValueType> *hessenberg,
             matrix::Dense<ValueType> *y, matrix::Dense<ValueType> *x,
-            const Array<size_type> *final_iter_nums,
-            const LinOp *preconditioner)
+            matrix::Dense<ValueType> *before_preconditionner,
+            const Array<size_type> *final_iter_nums)
 {
     GKO_NOT_IMPLEMENTED;
 }

--- a/reference/CMakeLists.txt
+++ b/reference/CMakeLists.txt
@@ -23,11 +23,6 @@ ginkgo_default_includes(ginkgo_reference)
 ginkgo_install_library(ginkgo_reference reference)
 target_compile_options(ginkgo_reference PRIVATE "${GINKGO_COMPILER_FLAGS}")
 
-# Ensures that there are no circular dependency issues
-if(NOT BUILD_SHARED_LIBS)
-    target_link_libraries(ginkgo_reference PUBLIC ginkgo)
-endif()
-
 if(GINKGO_BUILD_TESTS)
     add_subdirectory(test)
 endif()

--- a/reference/solver/gmres_kernels.cpp
+++ b/reference/solver/gmres_kernels.cpp
@@ -207,17 +207,19 @@ void solve_upper_triangular(
 
 
 template <typename ValueType>
-void solve_x(const matrix::Dense<ValueType> *krylov_bases,
-             const matrix::Dense<ValueType> *y, matrix::Dense<ValueType> *x,
-             matrix::Dense<ValueType> *before_preconditioner,
-             const size_type *final_iter_nums)
+void calculate_qy(const matrix::Dense<ValueType> *krylov_bases,
+                  const matrix::Dense<ValueType> *y,
+                  matrix::Dense<ValueType> *before_preconditioner,
+                  const size_type *final_iter_nums)
 {
-    for (size_type k = 0; k < x->get_size()[1]; ++k) {
-        for (size_type i = 0; i < x->get_size()[0]; ++i) {
+    for (size_type k = 0; k < before_preconditioner->get_size()[1]; ++k) {
+        for (size_type i = 0; i < before_preconditioner->get_size()[0]; ++i) {
             before_preconditioner->at(i, k) = zero<ValueType>();
             for (size_type j = 0; j < final_iter_nums[k]; ++j) {
                 before_preconditioner->at(i, k) +=
-                    krylov_bases->at(i, j * x->get_size()[1] + k) * y->at(j, k);
+                    krylov_bases->at(
+                        i, j * before_preconditioner->get_size()[1] + k) *
+                    y->at(j, k);
             }
         }
     }
@@ -334,14 +336,14 @@ void step_2(std::shared_ptr<const ReferenceExecutor> exec,
             const matrix::Dense<ValueType> *residual_norm_collection,
             const matrix::Dense<ValueType> *krylov_bases,
             const matrix::Dense<ValueType> *hessenberg,
-            matrix::Dense<ValueType> *y, matrix::Dense<ValueType> *x,
+            matrix::Dense<ValueType> *y,
             matrix::Dense<ValueType> *before_preconditioner,
             const Array<size_type> *final_iter_nums)
 {
     solve_upper_triangular(residual_norm_collection, hessenberg, y,
                            final_iter_nums->get_const_data());
-    solve_x(krylov_bases, y, x, before_preconditioner,
-            final_iter_nums->get_const_data());
+    calculate_qy(krylov_bases, y, before_preconditioner,
+                 final_iter_nums->get_const_data());
 }
 
 GKO_INSTANTIATE_FOR_EACH_VALUE_TYPE(GKO_DECLARE_GMRES_STEP_2_KERNEL);

--- a/reference/solver/gmres_kernels.cpp
+++ b/reference/solver/gmres_kernels.cpp
@@ -209,13 +209,9 @@ void solve_upper_triangular(
 template <typename ValueType>
 void solve_x(const matrix::Dense<ValueType> *krylov_bases,
              const matrix::Dense<ValueType> *y, matrix::Dense<ValueType> *x,
-             const size_type *final_iter_nums, const LinOp *preconditioner)
+             matrix::Dense<ValueType> *before_preconditioner,
+             const size_type *final_iter_nums)
 {
-    auto before_preconditioner =
-        matrix::Dense<ValueType>::create_with_config_of(x);
-    auto after_preconditioner =
-        matrix::Dense<ValueType>::create_with_config_of(x);
-
     for (size_type k = 0; k < x->get_size()[1]; ++k) {
         for (size_type i = 0; i < x->get_size()[0]; ++i) {
             before_preconditioner->at(i, k) = zero<ValueType>();
@@ -223,11 +219,6 @@ void solve_x(const matrix::Dense<ValueType> *krylov_bases,
                 before_preconditioner->at(i, k) +=
                     krylov_bases->at(i, j * x->get_size()[1] + k) * y->at(j, k);
             }
-        }
-        preconditioner->apply(before_preconditioner.get(),
-                              after_preconditioner.get());
-        for (size_type i = 0; i < x->get_size()[0]; ++i) {
-            x->at(i, k) += after_preconditioner->at(i, k);
         }
     }
 }
@@ -344,13 +335,13 @@ void step_2(std::shared_ptr<const ReferenceExecutor> exec,
             const matrix::Dense<ValueType> *krylov_bases,
             const matrix::Dense<ValueType> *hessenberg,
             matrix::Dense<ValueType> *y, matrix::Dense<ValueType> *x,
-            const Array<size_type> *final_iter_nums,
-            const LinOp *preconditioner)
+            matrix::Dense<ValueType> *before_preconditioner,
+            const Array<size_type> *final_iter_nums)
 {
     solve_upper_triangular(residual_norm_collection, hessenberg, y,
                            final_iter_nums->get_const_data());
-    solve_x(krylov_bases, y, x, final_iter_nums->get_const_data(),
-            preconditioner);
+    solve_x(krylov_bases, y, x, before_preconditioner,
+            final_iter_nums->get_const_data());
 }
 
 GKO_INSTANTIATE_FOR_EACH_VALUE_TYPE(GKO_DECLARE_GMRES_STEP_2_KERNEL);


### PR DESCRIPTION
This PR fixes detected circular dependencies and improves the CI.

The approach used here is to keep the current system and enforce that no kernel module ever use any function with implementation in the core module. That was the case for two things in particular, the static variables of the `CudaExecutor` and the GMRES `solve_x` function. The `jacobi`  CUDA `advanced_apply` is borderline, I am somehow not able to make it throw an error. In fact, the CI is able to find some problem with the Jacobi (CUDA 9.2, GCC 7, Release build only), so it also requires fixing.

I really need the confirmation of @hartwiganzt here (or any mac user): does this build with `-DBUILD_SHARED_LIBS=ON`?

### Changes
+ Add a CI step to detect circular dependencies between Ginkgo modules.
+ GMRES used dense matrices and uses the preconditioner apply. These calls are
  moved to the core module
+ The static variables for the CudaExecutor were placed in the core module. They
  are moved to the Cuda module.
+ Fix the jacobi circular dependency using some code duplication.
   + All the `apply` kernels and the related kernel selector are duplicated with an
      alpha parameter in the calls
   + The advanced version scale by alpha inside the kernel themselves.
   + Use a new `multiply_vec_add` instead of `multiply_vec` which preserves the
      value in `x` by storing with addition.
+ Reduce the amount of CI jobs and integrate static builds.
  + For this, we vary more than one parameter at once. Here is the new overview:
  + core + gcc + debug + static
  + core + clang + release + shared
  + omp + gcc + release + shared
  + omp + clang + debug + static
  + all + gcc + cuda 9.0 + release + shared
  + all + clang + cuda 9.0 + debug + static
  + all + gcc + cuda 9.1 + release + static
  + all + clang + cuda 9.1 + debug + shared
  + all + gcc + cuda 9.2 + debug + shared
  + all + clang + cuda 9.2 + release + static
  + all + gcc + cuda 10.0 + debug + static
  + all + clang + cuda 10.0 + release + shared

### Closes #203.
### Closes #270.

### TODO
+ [x] Add a CI step which should fail when Ginkgo has circular dependencies
+ [x] Fix the existing circular dependencies
+ [x] Add a static library build to the CI system and try to trim the amount of configurations by varying more than one parameter per configuration
+ [x] Add a note to the contributing guideline on this circular dependency problem
+ [x] Fix Jacobi circular dependency