### PR TITLE
Removed optional behavior (`shopt`) from scripts

### DIFF
--- a/dev_tools/scripts/add_license.sh
+++ b/dev_tools/scripts/add_license.sh
@@ -58,12 +58,14 @@ find "${GINKGO_ROOT_DIR}" \
     -type f -print \
     | \
     while IFS='' read -r i; do
-        if ! grep -q "${GINKGO_LICENSE_BEACON}" "${i}"
+        # `grep -F` is important here because the characters in the beacon should be matched against
+        # and not interpreted as an expression.
+        if ! grep -F -q -e "${GINKGO_LICENSE_BEACON}" "${i}"
         then
             cat "${COMMENTED_LICENSE_FILE}" "${i}" >"${i}.new" && mv "${i}.new" "${i}"
         else
-            beginning=$(grep -n "/\*${GINKGO_LICENSE_BEACON}" "${i}" | cut -d":" -f1)
-            end=$(grep -n "${GINKGO_LICENSE_BEACON}.*/" "${i}" | cut -d":" -f1)
+            beginning=$(grep -F -n -e "/*${GINKGO_LICENSE_BEACON}" "${i}" | cut -d":" -f1)
+            end=$(grep -F -n -e "${GINKGO_LICENSE_BEACON}*/" "${i}" | cut -d":" -f1)
             end=$((end+1))
             diff -u <(sed -n "${beginning},${end}p" "${i}") "${COMMENTED_LICENSE_FILE}" > "${DIFF_FILE}"
             if [ "$(cat "${DIFF_FILE}")" != "" ]

--- a/dev_tools/scripts/add_license.sh
+++ b/dev_tools/scripts/add_license.sh
@@ -1,32 +1,77 @@
 #!/usr/bin/env bash
-shopt -s globstar
-shopt -s extglob
 
 THIS_DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" &>/dev/null && pwd )
-GINKGO_ROOT_DIR="${THIS_DIR}/../.."
+# ${THIS_DIR} is expected to be: ${GINKGO_ROOT_DIR}/dev_tools/scripts
+
+# Use local paths, so there is less chance of a newline being in a path of a found file
+cd "${THIS_DIR}/../.."
+GINKGO_ROOT_DIR="."
+
+
 LICENSE_FILE="${GINKGO_ROOT_DIR}/LICENSE"
-PATTERNS="cpp|hpp|cuh|cu|hpp.in"
-EXCLUDED_DIRECTORIES="build|third_party"
 GINKGO_LICENSE_BEACON="******************************<GINKGO LICENSE>******************************"
 
-echo -e "/*${GINKGO_LICENSE_BEACON}\n$(cat ${LICENSE_FILE})\n${GINKGO_LICENSE_BEACON}*/\n" > commented_license.tmp
+# These two files are temporary files which will be created (and deleted).
+# Therefore, the files should not already exist.
+COMMENTED_LICENSE_FILE="${THIS_DIR}/commented_license.tmp"
+DIFF_FILE="${THIS_DIR}/diff.patch.tmp"
 
-for i in ${GINKGO_ROOT_DIR}/!(${EXCLUDED_DIRECTORIES})/**/*.@(${PATTERNS})
-do
-    if ! grep -q "${GINKGO_LICENSE_BEACON}" $i
-    then
-        cat commented_license.tmp $i >$i.new && mv $i.new $i
-    else
-        beginning=$(grep -n "/\*${GINKGO_LICENSE_BEACON}" $i | cut -d":" -f1)
-        end=$(grep -n "${GINKGO_LICENSE_BEACON}.*/" $i | cut -d":" -f1)
-        end=$((end+1))
-        diff -u <(sed -n "${beginning},${end}p" $i) commented_license.tmp > diff.patch
-        if [ "$(cat diff.patch)" != "" ]
+# Test if required commands are present on the system:
+command -v find &> /dev/null
+if [ ${?} -ne 0 ]; then
+    echo 'The command `find` is required for this script to work, but not supported by your system.' 1>&2
+    exit 1
+fi
+command -v diff &> /dev/null
+if [ ${?} -ne 0 ]; then
+    echo 'The command `diff` is required for this script to work, but not supported by your system.' 1>&2
+    exit 1
+fi
+command -v patch &> /dev/null
+if [ ${?} -ne 0 ]; then
+    echo 'The command `patch` is required for this script to work, but not supported by your system.' 1>&2
+    exit 1
+fi
+command -v grep &> /dev/null
+if [ ${?} -ne 0 ]; then
+    echo 'The command `grep` is required for this script to work, but not supported by your system.' 1>&2
+    exit 1
+fi
+command -v sed &> /dev/null
+if [ ${?} -ne 0 ]; then
+    echo 'The command `sed` is required for this script to work, but not supported by your system.' 1>&2
+    exit 1
+fi
+command -v cut &> /dev/null
+if [ ${?} -ne 0 ]; then
+    echo 'The command `cut` is required for this script to work, but not supported by your system.' 1>&2
+    exit 1
+fi
+
+
+echo -e "/*${GINKGO_LICENSE_BEACON}\n$(cat ${LICENSE_FILE})\n${GINKGO_LICENSE_BEACON}*/\n" > "${COMMENTED_LICENSE_FILE}"
+
+# Does not work if a found file (including the path) contains a newline
+find "${GINKGO_ROOT_DIR}" \
+    ! \( -name "build" -prune -o -name "third_party" -prune \) \
+    \( -name '*.cuh' -o -name '*.hpp' -o -name '*.hpp.in' -o -name '*.cpp' -o -name '*.cu' \) \
+    -type f -print \
+    | \
+    while IFS='' read -r i; do
+        if ! grep -q "${GINKGO_LICENSE_BEACON}" "${i}"
         then
-            patch $i diff.patch
+            cat "${COMMENTED_LICENSE_FILE}" "${i}" >"${i}.new" && mv "${i}.new" "${i}"
+        else
+            beginning=$(grep -n "/\*${GINKGO_LICENSE_BEACON}" "${i}" | cut -d":" -f1)
+            end=$(grep -n "${GINKGO_LICENSE_BEACON}.*/" "${i}" | cut -d":" -f1)
+            end=$((end+1))
+            diff -u <(sed -n "${beginning},${end}p" "${i}") "${COMMENTED_LICENSE_FILE}" > "${DIFF_FILE}"
+            if [ "$(cat "${DIFF_FILE}")" != "" ]
+            then
+                patch "${i}" "${DIFF_FILE}"
+            fi
+            rm "${DIFF_FILE}"
         fi
-        rm diff.patch
-    fi
-done
+    done
 
-rm commented_license.tmp
+rm "${COMMENTED_LICENSE_FILE}"

--- a/dev_tools/scripts/update_ginkgo_header.sh
+++ b/dev_tools/scripts/update_ginkgo_header.sh
@@ -35,7 +35,7 @@ fi
 
 # Put all header files as a list (separated by newlines) in the file ${HEADER_LIST}
 # Requires detected files (including the path) to not contain newlines
-find "${TOP_HEADER_FOLDER}" -name '*.hpp' -type f -fprint "${HEADER_LIST}"
+find "${TOP_HEADER_FOLDER}" -name '*.hpp' -type f -print > "${HEADER_LIST}"
 
 if [ ${?} -ne 0 ]; then
     echo 'Exiting due to an error being returned by `find`!' 1>&2

--- a/dev_tools/scripts/update_ginkgo_header.sh
+++ b/dev_tools/scripts/update_ginkgo_header.sh
@@ -1,6 +1,4 @@
 #!/usr/bin/env bash
-shopt -s globstar
-shopt -s extglob
 
 PLACE_HOLDER="#PUBLIC_HEADER_PLACE_HOLDER"
 
@@ -9,25 +7,52 @@ THIS_DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" &>/dev/null && pwd )
 ROOT_DIR="${THIS_DIR}/../../"
 INCLUDE_DIR="${ROOT_DIR}/include"
 
+# Use local paths, so there is less chance of a newline being in a path of a found file
 cd ${INCLUDE_DIR}
+TOP_HEADER_FOLDER="."
 
 GINKGO_HEADER_FILE="ginkgo/ginkgo.hpp"
 GINKGO_HEADER_TEMPLATE_FILE="${GINKGO_HEADER_FILE}.in"
 
 HEADER_LIST="global_includes.hpp.tmp"
 
-# Add every header file inside the ginkgo folder to the file ${HEADER_LIST}
-for file in ginkgo/**/*.hpp; do
-    if [ "${file}" == "${GINKGO_HEADER_FILE}" ]; then
-        continue
-    fi
-    echo "${file}" >> ${HEADER_LIST}
-done
+# Test if required commands are present on the system:
+command -v find &> /dev/null
+if [ ${?} -ne 0 ]; then
+    echo 'The command `find` is required for this script to work, but not supported by your system.' 1>&2
+    exit 1
+fi
+command -v sort &> /dev/null
+if [ ${?} -ne 0 ]; then
+    echo 'The command `sort` is required for this script to work, but not supported by your system.' 1>&2
+    exit 1
+fi
+command -v cmp &> /dev/null
+if [ ${?} -ne 0 ]; then
+    echo 'The command `cmp` is required for this script to work, but not supported by your system.' 1>&2
+    exit 1
+fi
+
+# Put all header files as a list (separated by newlines) in the file ${HEADER_LIST}
+# Requires detected files (including the path) to not contain newlines
+find "${TOP_HEADER_FOLDER}" -name '*.hpp' -type f -fprint "${HEADER_LIST}"
+
+if [ ${?} -ne 0 ]; then
+    echo 'Exiting due to an error being returned by `find`!' 1>&2
+    rm "${HEADER_LIST}"
+    exit 1
+fi
 
 # It must be a POSIX locale in order to sort according to ASCII
 export LC_ALL=C
 # Sorting is necessary to group them according to the folders the header are in
-sort -o ${HEADER_LIST} ${HEADER_LIST}
+sort -o "${HEADER_LIST}" "${HEADER_LIST}"
+
+if [ ${?} -ne 0 ]; then
+    echo 'Exiting due to an error being returned by `sort`!' 1>&2
+    rm "${HEADER_LIST}"
+    exit 1
+fi
 
 # Generate a new, temporary ginkgo header file.
 # It will get compared at the end to the existing file in order to prevent 
@@ -37,26 +62,35 @@ GINKGO_HEADER_TMP="${GINKGO_HEADER_FILE}.tmp"
 
 PREVIOUS_FOLDER=""
 # "IFS=''" sets the word delimiters for read.
-# An empty $IFS means the given name (after `read`) will be set to the whole line.
+# An empty ${IFS} means the given name (after `read`) will be set to the whole line,
+# and in this case it means it will not ignore leading and trailing whitespaces.
 while IFS='' read -r line; do
-    if [ "${line}" != ${PLACE_HOLDER} ]; then
-        echo "${line}" >> ${GINKGO_HEADER_TMP}
+    if [ "${line}" != "${PLACE_HOLDER}" ]; then
+        echo "${line}" >> "${GINKGO_HEADER_TMP}"
     else
         READING_FIRST_LINE=true
-        while IFS='' read -r file; do
-            CURRENT_FOLDER=$(dirname ${file})
+        while IFS='' read -r prefixed_file; do
+            # Remove the include directory from the file name
+            file="${prefixed_file#${TOP_HEADER_FOLDER}/}"
+            
+            # Do not include yourself
+            if [ "${file}" == "${GINKGO_HEADER_FILE}" ]; then
+                continue
+            fi
+            
+            CURRENT_FOLDER="$(dirname ${file})"
             # add newline between different include folder
             if [ "${READING_FIRST_LINE}" != true ] && \
                [ "${CURRENT_FOLDER}" != "${PREVIOUS_FOLDER}" ]
             then
-                echo "" >> ${GINKGO_HEADER_TMP}
+                echo "" >> "${GINKGO_HEADER_TMP}"
             fi
-            PREVIOUS_FOLDER=${CURRENT_FOLDER}
-            echo "#include <${file}>" >> ${GINKGO_HEADER_TMP}
+            PREVIOUS_FOLDER="${CURRENT_FOLDER}"
+            echo "#include <${file}>" >> "${GINKGO_HEADER_TMP}"
             READING_FIRST_LINE=false
         done < "${HEADER_LIST}"
     fi
-done < ${GINKGO_HEADER_TEMPLATE_FILE}
+done < "${GINKGO_HEADER_TEMPLATE_FILE}"
 
 # Use the generated file ONLY when the public header does not exist yet
 # or the generated one is different to the existing one
@@ -65,7 +99,7 @@ if [ ! -f "${GINKGO_HEADER_FILE}" ] || \
 then
     mv "${GINKGO_HEADER_TMP}" "${GINKGO_HEADER_FILE}"
 else
-    rm ${GINKGO_HEADER_TMP}
+    rm "${GINKGO_HEADER_TMP}"
 fi
 
-rm ${HEADER_LIST}
+rm "${HEADER_LIST}"

--- a/dev_tools/scripts/update_ginkgo_header.sh
+++ b/dev_tools/scripts/update_ginkgo_header.sh
@@ -3,12 +3,10 @@
 PLACE_HOLDER="#PUBLIC_HEADER_PLACE_HOLDER"
 
 THIS_DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" &>/dev/null && pwd )
-
-ROOT_DIR="${THIS_DIR}/../../"
-INCLUDE_DIR="${ROOT_DIR}/include"
+INCLUDE_DIR="${THIS_DIR}/../../include"
 
 # Use local paths, so there is less chance of a newline being in a path of a found file
-cd ${INCLUDE_DIR}
+cd "${INCLUDE_DIR}"
 TOP_HEADER_FOLDER="."
 
 GINKGO_HEADER_FILE="ginkgo/ginkgo.hpp"


### PR DESCRIPTION
Removed the need for the following requested features in the scripts `dev_tools/scripts/update_ginkgo_header.sh` and `dev_tools/scripts/add_license.sh`:
- `extglob` (`**`) by using `find` instead
- `globstar` with appropriate arguments for `find`

Additionally, made sure that commands that are used (like `find`, `sort`, ...) are present and do not return an error.
I am not 100% sure if this check is necessary (or if I should also include `cat`, `rm`, `mv` and so on), but I don't think it hurts.

A big difference for `add_license.sh` is that the working directory is changed to the root ginkgo directory, and the temporary files will be created in `dev_tools/scripts` instead of inside the build directory. However, we should not have any name-clashes (and the temporary file names are now variables which can be easily altered).

Additionally, now all folders named `build` and `third_party` are ignored by `add_license.sh`, not just these folders inside the top level of the ginkgo folder (I changed that when I saw that it previously affected files in `test_install/build` on my system).

Performance wise, I ran `time ./dev_tools/scripts/add_license.sh` with the current status:
```
real	0m2,927s
user	0m2,957s
sys	0m1,046s
```

Before the changes (current `develop` status), it is:
```
real	0m3,007s
user	0m2,990s
sys	0m1,060s
```
So, we don't lose performance here.
Results for `time ./dev_tools/scripts/update_ginkgo_header.sh` with the current status:
```
real	0m0,055s
user	0m0,048s
sys	0m0,009s
```
Before:
```
real	0m0,055s
user	0m0,041s
sys	0m0,017s
```
So we don't lose performance here either.


__TODO:__
- [x] Confirm that it works on Mac

Closes #272.