### PR TITLE
Fix valgrind warning and errors

### DIFF
--- a/core/matrix/sellp.cpp
+++ b/core/matrix/sellp.cpp
@@ -220,14 +220,17 @@ void Sellp<ValueType, IndexType>::write(mat_data &data) const
         for (size_type row_in_slice = 0; row_in_slice < slice_size;
              row_in_slice++) {
             auto row = slice * slice_size + row_in_slice;
-            for (size_type i = 0; i < tmp->get_const_slice_lengths()[slice];
-                 i++) {
-                const auto val = tmp->val_at(
-                    row_in_slice, tmp->get_const_slice_sets()[slice], i);
-                if (val != zero<ValueType>() && row < tmp->get_size()[0]) {
-                    const auto col = tmp->col_at(
+            if (row < tmp->get_size()[0]) {
+                for (size_type i = 0; i < tmp->get_const_slice_lengths()[slice];
+                     i++) {
+                    const auto val = tmp->val_at(
                         row_in_slice, tmp->get_const_slice_sets()[slice], i);
-                    data.nonzeros.emplace_back(row, col, val);
+                    if (val != zero<ValueType>()) {
+                        const auto col =
+                            tmp->col_at(row_in_slice,
+                                        tmp->get_const_slice_sets()[slice], i);
+                        data.nonzeros.emplace_back(row, col, val);
+                    }
                 }
             }
         }

--- a/include/ginkgo/core/matrix/csr.hpp
+++ b/include/ginkgo/core/matrix/csr.hpp
@@ -224,21 +224,21 @@ public:
         void process(const Array<index_type> &mtx_row_ptrs,
                      Array<index_type> *mtx_srow)
         {
-            // if the number of stored elements per row is larger than 1e6 or
+            // if the number of stored elements is larger than 1e6 or
             // the maximum number of stored elements per row is larger than
             // 64, use load_balance otherwise use classical
-            const auto num = mtx_row_ptrs.get_num_elems();
+            const auto num_rows = mtx_row_ptrs.get_num_elems() - 1;
             Array<index_type> host_row_ptrs(
                 mtx_row_ptrs.get_executor()->get_master());
             host_row_ptrs = mtx_row_ptrs;
             const auto row_val = host_row_ptrs.get_const_data();
-            if (row_val[num] > 1e6) {
+            if (row_val[num_rows] > static_cast<index_type>(1e6)) {
                 std::make_shared<load_balance>(nwarps_)->process(host_row_ptrs,
                                                                  mtx_srow);
                 this->set_name("load_balance");
             } else {
                 index_type maxnum = 0;
-                for (index_type i = 1; i < num; i++) {
+                for (index_type i = 1; i < num_rows + 1; i++) {
                     maxnum = max(maxnum, row_val[i] - row_val[i - 1]);
                 }
                 if (maxnum > 64) {


### PR DESCRIPTION
Fixed two issues, which were detected from valgrind: One in `Sellp::write()` and one in `Csr::automatical::process()`.
### `Sellp::write()`
It was only a warning, and it should have no effect on the runtime behavior. The issue was that `val` was read and tested against zero before it was tested if it is a part of the matrix, or just padding after the matrix. This memory is always allocated and present, so we would not have read any invalid memory area, it was just skipped when initializing the values.
The fix was basically to add a test if we are at a row which is still in the matrix before reading / testing the value.

### `Csr::automatical::process()`
Here, it was actually an error. We were doing something similar to this:
```c++
Array<index_type> host_row_ptrs(mtx_row_ptrs.get_executor()->get_master());
host_row_ptrs = mtx_row_ptrs;
auto error_access = host_row_ptrs->get_const_data()[host_row_ptrs->get_num_elems()];
```
Where the last line leads to memory access which is out of bound.
The fix was basically to read only the `size - 1` element, which should also be the one which stores the number of non-zeros in the CSR format.

Closes #273
