### PR TITLE
Limit CI artifacts to what is absolutely required (tests and libs).

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -54,9 +54,19 @@ stages:
     - make -j$(grep "core id" /proc/cpuinfo | sort -u | wc -l)
   artifacts:
     paths:
-      - build/
+      - "build/*/*/*/*/*/CMakeCache.txt"
+      - "build/*/*/*/*/*/core/test"
+      - "build/*/*/*/*/*/cuda/test"
+      - "build/*/*/*/*/*/omp/test"
+      - "build/*/*/*/*/*/reference/test"
+      - "build/*/*/*/*/*/core/libginkgo*"
+      - "build/*/*/*/*/*/cuda/libginkgo*"
+      - "build/*/*/*/*/*/omp/libginkgo*"
+      - "build/*/*/*/*/*/reference/libginkgo*"
   except:
       - schedules
+# build paths are of the form: build/<cuda_version>/<compiler>/<module(s)>/{debug,release}/{shared,static}/
+# see: the name of our building jobs
 
 .test_template: &default_test
   stage: test


### PR DESCRIPTION
As the title says, we seem to be reaching a problem with our artifact size for one of our compilation mode for some PRs. In order to save space in general, this PR tries to upload as artifacts only what is really required (and useful).

See https://gitlab.com/ginkgo-project/ginkgo-public-ci/-/jobs/188778903