### PR TITLE
Fixed GKO_ENABLE_BUILD_METHOD macro

### DIFF
--- a/include/ginkgo/core/base/lin_op.hpp
+++ b/include/ginkgo/core/base/lin_op.hpp
@@ -728,9 +728,9 @@ public:                                                                      \
  * @ingroup LinOp
  */
 #define GKO_ENABLE_BUILD_METHOD(_factory_name)                               \
-    static auto build()->decltype(Factory::create())                         \
+    static auto build()->decltype(_factory_name::create())                   \
     {                                                                        \
-        return Factory::create();                                            \
+        return _factory_name::create();                                      \
     }                                                                        \
     static_assert(true,                                                      \
                   "This assert is used to counter the false positive extra " \


### PR DESCRIPTION
`GKO_ENABLE_BUILD_METHOD` takes an argument, which is supposed to be the name of the factory class. However, this parameter was never used.
Instead, the name `Factory` was hard-coded, which worked because we always use this name. However, it failed to compile when using a different name.
Now, the argument is used properly, so names other than `Factory` will also work.