### PR TITLE
Custom logger example

### DIFF
--- a/doc/examples/examples.hpp.in
+++ b/doc/examples/examples.hpp.in
@@ -35,47 +35,30 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  * @page Examples Example programs
  *
  * Here you can find example programs that demonstrate the usage of Ginkgo.
- * Some examples are built on one another and some are stand-alone and demonstrate a concept of
+ * Some examples are built on one another and some are stand-alone and
+ * demonstrate a concept of
  * Ginkgo, which can be used in your own code.
  *
  * You can browse the available example programs
  * <ol>
- *   <li> as <b><a href="#graph">a graph</a></b> that shows how example programs build upon each other.
+ *   <li> as <b><a href="#graph">a graph</a></b> that shows how example programs
+ *     build upon each other.
  *   <li> as <b><a href="#list">a list</a></b> that provides a short
  *     synopsis of each program.
  *   <li> or <b><a href="#topic">grouped by topic</a></b>.
  * </ol>
  *
- * The easiest way to build the example that you want is to use the script provided:
+ * By default, all Ginkgo examples are built using CMake.
+ *
+ * An example for building the examples and using Ginkgo as an external library
+ * without CMake can be found in the script provided for each example, which
+ * should be called with the form:
  * <code>./build.sh PATH_TO_GINKGO_BUILD_DIR </code>
  *
- * By default, Ginkgo is compiled with atleast <code>-DGINKGO_BUILD_REFERENCE=on</code>.
+ * By default, Ginkgo is compiled with at least
+ * <code>-DGINKGO_BUILD_REFERENCE=on</code>.
  * To execute on a GPU, you need to have a GPU on the system and must have
  * compiled Ginkgo with the <code>-DGINKGO_BUILD_CUDA=ON</code> option.
- *
- * Alternatively, you can setup the configuration manually:
- *
- * Go to the <code> PATH_TO_GINKGO_BUILD_DIR </code> directory and copy the shared
- * libraries located in the following subdirectories:
- * <ol>
- *   <li> <code>core/</code>
- *   <li> <code>core/device_hooks/</code>
- *   <li> <code>reference/</code>
- *   <li> <code>omp/</code>
- *   <li> <code>cuda/</code>
- * </ol>
- * to this directory.
- *
- * Then compile the file with the following command line:
- * @code{.cpp}
- * c++ -std=c++11 -o <example-name> <example-name>.cpp -I../.. \
- * -L. -lginkgo -lginkgo_reference -lginkgo_omp -lginkgo_cuda
- * @endcode
- * (if ginkgo was built in debug mode, append 'd' to every library name)
- *
- * Now you should be able to run the program using:
- *
- * @code{.cpp}env LD_LIBRARY_PATH=.:\$\{LD_LIBRARY_PATH\} ./<example-name>@endcode
  *
  * <a name="graph"></a>
  * @anchor ExampleConnectionGraph
@@ -106,13 +89,14 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *
  *   <tr valign="top">
  *       <td>@ref minimal_cuda_solver</td>
- *       <td> A minimal solver on the CUDA executor than can be run on NVIDIA GPU's.
+ *       <td> A minimal solver on the CUDA executor than can be run on NVIDIA
+ *            GPU's.
  *       </td></tr>
  *
  *   <tr valign="top">
  *       <td>@ref poisson_solver</td>
  *       <td> Solve an actual physically relevant problem, the poisson problem.
- *           The matrix is generated within Ginkgo.
+ *            The matrix is generated within Ginkgo.
  *       </td></tr>
  *
  *   <tr valign="top">
@@ -122,7 +106,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *
  *   <tr valign="top">
  *       <td>@ref three_pt_stencil_solver</td>
- *       <td> Using a three point stencil to solve the poisson equation with array views.
+ *       <td> Using a three point stencil to solve the poisson equation with
+ *            array views.
  *       </td></tr>
  *
  *   <tr valign="top">
@@ -131,24 +116,33 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *       </td></tr>
  *
  *   <tr valign="top">
+ *       <td width="260px">@ref custom_logger</td>
+ *       <td> Creating a custom logger specifically for comparing the recurrent
+ *            and the real residual norms.
+ *       </td></tr>
+ *
+ *   <tr valign="top">
  *       <td>@ref custom_matrix_format</td>
- *       <td> Creating a matrix-free stencil solver by using Ginkgo's advanced methods to build your own custom matrix format.
+ *       <td> Creating a matrix-free stencil solver by using Ginkgo's advanced
+ *            methods to build your own custom matrix format.
  *       </td></tr>
  *
  *   <tr valign="top">
  *       <td>@ref inverse_iteration</td>
- *       <td> Using Ginkgo to compute eigenvalues of a matrix with the inverse iteration method.
+ *       <td> Using Ginkgo to compute eigenvalues of a matrix with the inverse
+ *            iteration method.
  *       </td></tr>
  *
  *   <tr valign="top">
  *       <td>@ref simple_solver_logging</td>
- *       <td> Using the logging functionality in Ginkgo to get solver and other information to
- *        diagnose and debug your code.
+ *       <td> Using the logging functionality in Ginkgo to get solver and other
+ *            information to diagnose and debug your code.
  *       </td></tr>
  *
  *   <tr valign="top">
  *       <td>@ref papi_logging</td>
- *       <td> Using the PAPI logging library in Ginkgo to get advanced information about your code
+ *       <td> Using the PAPI logging library in Ginkgo to get advanced
+ *            information about your code
  *        and its behaviour.
  *       </td></tr>
  *
@@ -159,12 +153,14 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *
  *   <tr valign="top">
  *       <td>@ref custom_stopping_criterion</td>
- *       <td> Creating a custom stopping criterion for the iterative solution process.
+ *       <td> Creating a custom stopping criterion for the iterative solution
+ *            process.
  *       </td></tr>
  *
  *   <tr valign="top">
  *       <td>@ref ginkgo_ranges</td>
- *       <td> Using the ranges concept to factorize a matrix with the LU factorization.
+ *       <td> Using the ranges concept to factorize a matrix with the LU
+ *            factorization.
  *       </td></tr>
  *
  * </table>
@@ -214,7 +210,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *         @ref inverse_iteration,
  *         @ref simple_solver_logging,
  *         @ref papi_logging,
- *         @ref custom_stopping_criterion
+ *         @ref custom_stopping_criterion,
+ *         @ref custom_logger
  *     </td>
  *   </tr>
  *
@@ -224,14 +221,23 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  * <table align="center" width="90%">
  *
  *   <tr valign="top">
- *     <td> Using Ginkgo with external libraries. 
+ *     <td> Using Ginkgo with external libraries.
  *     </td>
  *     <td>@ref external_lib_interfacing
  *     </td>
  *   </tr>
  *
  *   <tr valign="top">
- *     <td width="400px"> Writing your own matrix format 
+ *     <td width="400px"> Customizing Ginkgo
+ *     </td>
+ *     <td>@ref custom_logger,
+ *         @ref custom_stopping_criterion,
+ *         @ref custom_matrix_format
+ *     </td>
+ *   </tr>
+ *
+ *   <tr valign="top">
+ *     <td width="400px"> Writing your own matrix format
  *     </td>
  *     <td>@ref custom_matrix_format
  *     </td>
@@ -248,7 +254,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *     <td> Logging within Ginkgo.
  *     </td>
  *     <td> @ref simple_solver_logging,
- *          @ref papi_logging
+ *          @ref papi_logging,
+ *          @ref custom_logger
  *     </td>
  *   </tr>
  *

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,4 +1,5 @@
 option(GINKGO_BUILD_EXTLIB_EXAMPLE "Build the external-lib-interfacing with deal.II, you need to link the deal.II library." OFF)
+add_subdirectory(custom-logger)
 add_subdirectory(custom-matrix-format)
 add_subdirectory(custom-stopping-criterion)
 if(GINKGO_BUILD_EXTLIB_EXAMPLE)

--- a/examples/custom-logger/CMakeLists.txt
+++ b/examples/custom-logger/CMakeLists.txt
@@ -1,0 +1,6 @@
+add_executable(custom-logger custom-logger.cpp)
+target_link_libraries(custom-logger ginkgo)
+target_include_directories(custom-logger PRIVATE ${PROJECT_SOURCE_DIR})
+configure_file(data/A.mtx data/A.mtx COPYONLY)
+configure_file(data/b.mtx data/b.mtx COPYONLY)
+configure_file(data/x0.mtx data/x0.mtx COPYONLY)

--- a/examples/custom-logger/build.sh
+++ b/examples/custom-logger/build.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+# set up script
+if [ $# -ne 1 ]; then
+    echo -e "Usage: $0 GINKGO_BUILD_DIRECTORY"
+    exit 1
+fi
+BUILD_DIR=$1
+THIS_DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" &>/dev/null && pwd )
+
+# copy libraries
+LIBRARY_DIRS="core core/device_hooks reference omp cuda"
+LIBRARY_NAMES="ginkgo ginkgo_reference ginkgo_omp ginkgo_cuda"
+SUFFIXES=".so .dylib .dll d.so d.dylib d.dll"
+for prefix in ${LIBRARY_DIRS}; do
+    for name in ${LIBRARY_NAMES}; do
+        for suffix in ${SUFFIXES}; do
+            cp ${BUILD_DIR}/${prefix}/lib${name}${suffix} \
+                ${THIS_DIR}/lib${name}${suffix} 2>/dev/null
+        done
+    done
+done
+
+# figure out correct compiler flags
+if ls ${THIS_DIR} | grep -F "libginkgo." >/dev/null; then
+    LINK_FLAGS="-lginkgo -lginkgo_omp -lginkgo_cuda -lginkgo_reference"
+else
+    LINK_FLAGS="-lginkgod -lginkgo_ompd -lginkgo_cudad -lginkgo_referenced"
+fi
+if [ -z "${CXX}" ]; then
+    CXX="c++"
+fi
+
+# build
+${CXX} -std=c++11 -o ${THIS_DIR}/custom-logger ${THIS_DIR}/custom-logger.cpp \
+       -I${THIS_DIR}/../../include -I${BUILD_DIR}/include -L${THIS_DIR} \
+       ${LINK_FLAGS}

--- a/examples/custom-logger/custom-logger.cpp
+++ b/examples/custom-logger/custom-logger.cpp
@@ -85,7 +85,7 @@ struct ResidualLogger : gko::log::Logger {
         std::cout << '|' << std::setw(10) << "Iteration" << '|' << std::setw(25)
                   << "Recurrent Residual Norm" << '|' << std::setw(25)
                   << "Real Residual Norm" << '|' << std::endl;
-        // Print a separation line. Note that for creating `10` caracters
+        // Print a separation line. Note that for creating `10` characters
         // `std::setw()` should be set to `11`.
         std::cout << '|' << std::setfill('-') << std::setw(11) << '|'
                   << std::setw(26) << '|' << std::setw(26) << '|'

--- a/examples/custom-logger/custom-logger.cpp
+++ b/examples/custom-logger/custom-logger.cpp
@@ -37,10 +37,144 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 // Add the fstream header to read from data from files.
 #include <fstream>
+// Add the C++ iomanip header to prettify the output.
+#include <iomanip>
 // Add the C++ iostream header to output information to the console.
 #include <iostream>
 // Add the string manipulation header to handle strings.
 #include <string>
+// Add the vector header for storing the logger's data
+#include <vector>
+
+// Utility function which gets the scalar value of a Ginkgo gko::matrix::Dense
+// matrix representing the norm of a vector.
+template <typename ValueType>
+double get_norm(const gko::matrix::Dense<ValueType> *norm)
+{
+    // Put the value on CPU thanks to the master executor
+    auto cpu_norm = clone(norm->get_executor()->get_master(), norm);
+    // Return the scalar value contained at position (0, 0)
+    return cpu_norm->at(0, 0);
+}
+
+// Utility function which computes the norm of a Ginkgo gko::matrix::Dense
+// vector.
+template <typename ValueType>
+double compute_norm(const gko::matrix::Dense<ValueType> *b)
+{
+    // Get the executor of the vector
+    auto exec = b->get_executor();
+    // Initialize a result scalar containing the value 0.0.
+    auto b_norm = gko::initialize<gko::matrix::Dense<ValueType>>({0.0}, exec);
+    // Use the dense `compute_norm2` function to compute the norm.
+    b->compute_norm2(lend(b_norm));
+    // Use the other utility function to return the norm contained in `b_norm``
+    return get_norm(lend(b_norm));
+}
+
+// Custom logger class which intercepts the residual norm scalar and solution
+// vector in order to print a table of real vs recurrent (internal to the
+// solvers) residual norms.
+template <typename ValueType>
+struct ResidualLogger : gko::log::Logger {
+    // Output the logger's data in a table format
+    void write() const
+    {
+        // Print a header for the table
+        std::cout << "Recurrent vs real residual norm:" << std::endl;
+        std::cout << '|' << std::setw(10) << "Iteration" << '|' << std::setw(25)
+                  << "Recurrent Residual Norm" << '|' << std::setw(25)
+                  << "Real Residual Norm" << '|' << std::endl;
+        // Print a separation line. Note that for creating `10` caracters
+        // `std::setw()` should be set to `11`.
+        std::cout << '|' << std::setfill('-') << std::setw(11) << '|'
+                  << std::setw(26) << '|' << std::setw(26) << '|'
+                  << std::setfill(' ') << std::endl;
+        // Print the data one by one in the form
+        for (std::size_t i = 0; i < iterations.size(); i++) {
+            std::cout << std::scientific << '|' << std::setw(10)
+                      << iterations[i] << '|' << std::setw(25)
+                      << recurrent_norms[i] << '|' << std::setw(25)
+                      << real_norms[i] << '|' << std::defaultfloat << std::endl;
+        }
+        // Print a separation line
+        std::cout << '|' << std::setfill('-') << std::setw(11) << '|'
+                  << std::setw(26) << '|' << std::setw(26) << '|'
+                  << std::setfill(' ') << std::endl;
+    }
+
+    using gko_dense = gko::matrix::Dense<ValueType>;
+
+    // Customize the logging hook which is called everytime an iteration is
+    // completed
+    void on_iteration_complete(const gko::LinOp *,
+                               const gko::size_type &iteration,
+                               const gko::LinOp *residual,
+                               const gko::LinOp *solution,
+                               const gko::LinOp *residual_norm) const override
+    {
+        // If the solver shares a residual norm, log its value
+        if (residual_norm) {
+            auto dense_norm = gko::as<gko_dense>(residual_norm);
+            // Add the norm to the `recurrent_norms` vector
+            recurrent_norms.push_back(get_norm(dense_norm));
+            // Otherwise, use the recurrent residual vector
+        } else {
+            auto dense_residual = gko::as<gko_dense>(residual);
+            // Compute the residual vector's norm
+            auto norm = compute_norm(gko::lend(dense_residual));
+            // Add the computed norm to the `recurrent_norms` vector
+            recurrent_norms.push_back(norm);
+        }
+
+        // If the solver shares the current solution vector
+        if (solution) {
+            // Store the matrix's executor
+            auto exec = matrix->get_executor();
+            // Create a scalar containing the value 1.0
+            auto one = gko::initialize<gko_dense>({1.0}, exec);
+            // Create a scalar containing the value -1.0
+            auto neg_one = gko::initialize<gko_dense>({-1.0}, exec);
+            // Instantiate a temporary result variable
+            auto res = gko::clone(b);
+            // Compute the real residual vector by calling apply on the system
+            // matrix
+            matrix->apply(gko::lend(one), gko::lend(solution),
+                          gko::lend(neg_one), gko::lend(res));
+
+            // Compute the norm of the residual vector and add it to the
+            // `real_norms` vector
+            real_norms.push_back(compute_norm(gko::lend(res)));
+        } else {
+            // Add to the `real_norms` vector the value -1.0 if it could not be
+            // computed
+            real_norms.push_back(-1.0);
+        }
+
+        // Add the current iteration number to the `iterations` vector
+        iterations.push_back(iteration);
+    }
+
+    // Construct the logger and store the system matrix and b vectors
+    ResidualLogger(std::shared_ptr<const gko::Executor> exec,
+                   const gko::LinOp *matrix, const gko_dense *b)
+        : gko::log::Logger(exec, gko::log::Logger::iteration_complete_mask),
+          matrix{matrix},
+          b{b}
+    {}
+
+private:
+    // Pointer to the system matrix
+    const gko::LinOp *matrix;
+    // Pointer to the right hand sides
+    const gko_dense *b;
+    // Vector which stores all the recurrent residual norms
+    mutable std::vector<ValueType> recurrent_norms{};
+    // Vector which stores all the real residual norms
+    mutable std::vector<ValueType> real_norms{};
+    // Vector which stores all the iteration numbers
+    mutable std::vector<std::size_t> iterations{};
+};
 
 
 int main(int argc, char *argv[])
@@ -113,15 +247,25 @@ int main(int argc, char *argv[])
                     .with_reduction_factor(1e-15)
                     .on(exec))
             .on(exec);
+
+    // Instantiate a ResidualLogger logger.
+    auto logger = std::make_shared<ResidualLogger<double>>(exec, gko::lend(A),
+                                                           gko::lend(b));
+
+    // Add the previously created logger to the solver factory. The logger will
+    // be automatically propagated to all solvers created from this factory.
+    solver_gen->add_logger(logger);
+
     // Generate the solver from the matrix. The solver factory built in the
     // previous step takes a "matrix"(a gko::LinOp to be more general) as an
-    // input. In this case we provide it with a full matrix that we previously
-    // read, but as the solver only effectively uses the apply() method within
-    // the provided "matrix" object, you can effectively create a gko::LinOp
-    // class with your own apply implementation to accomplish more tasks. We
-    // will see an example of how this can be done in the custom-matrix-format
-    // example
+    // input. In this case we provide it with a full matrix that we
+    // previously read, but as the solver only effectively uses the apply()
+    // method within the provided "matrix" object, you can effectively
+    // create a gko::LinOp class with your own apply implementation to
+    // accomplish more tasks. We will see an example of how this can be done
+    // in the custom-matrix-format example
     auto solver = solver_gen->generate(A);
+
 
     // Finally, solve the system. The solver, being a gko::LinOp, can be applied
     // to a right hand side, b to
@@ -131,6 +275,9 @@ int main(int argc, char *argv[])
     // Print the solution to the command line.
     std::cout << "Solution (x): \n";
     write(std::cout, lend(x));
+
+    // Print the table of the residuals obtained from the logger
+    logger->write();
 
     // To measure if your solution has actually converged, you can measure the
     // error of the solution.

--- a/examples/custom-logger/data/A.mtx
+++ b/examples/custom-logger/data/A.mtx
@@ -1,0 +1,114 @@
+%%MatrixMarket matrix coordinate integer symmetric
+%-------------------------------------------------------------------------------
+% UF Sparse Matrix Collection, Tim Davis
+% http://www.cise.ufl.edu/research/sparse/matrices/JGD_Trefethen/Trefethen_20b
+% name: JGD_Trefethen/Trefethen_20b
+% [Diagonal matrices with primes, Nick Trefethen, Oxford Univ.]
+% id: 2203
+% date: 2008
+% author: N. Trefethen
+% ed: J.-G. Dumas
+% fields: name title A id date author ed kind notes
+% kind: combinatorial problem
+%-------------------------------------------------------------------------------
+% notes:
+% Diagonal matrices with primes, Nick Trefethen, Oxford Univ.          
+% From Jean-Guillaume Dumas' Sparse Integer Matrix Collection,         
+% http://ljk.imag.fr/membres/Jean-Guillaume.Dumas/simc.html            
+%                                                                      
+% Problem 7 of the Hundred-dollar, Hundred-digit Challenge Problems,   
+% SIAM News, vol 35, no. 1.                                            
+%                                                                      
+% 7. Let A be the 20,000 x 20,000 matrix whose entries are zero        
+% everywhere except for the primes 2, 3, 5, 7, . . . , 224737 along the
+% main diagonal and the number 1 in all the positions A(i,j) with      
+% |i-j| = 1,2,4,8, . . . ,16384.  What is the (1,1) entry of inv(A)?   
+%                                                                      
+% http://www.siam.org/news/news.php?id=388                             
+%                                                                      
+% Filename in JGD collection: Trefethen/trefethen_20__19_minor.sms     
+%-------------------------------------------------------------------------------
+19 19 83
+1 1 3
+2 1 1
+3 1 1
+5 1 1
+9 1 1
+17 1 1
+2 2 5
+3 2 1
+4 2 1
+6 2 1
+10 2 1
+18 2 1
+3 3 7
+4 3 1
+5 3 1
+7 3 1
+11 3 1
+19 3 1
+4 4 11
+5 4 1
+6 4 1
+8 4 1
+12 4 1
+5 5 13
+6 5 1
+7 5 1
+9 5 1
+13 5 1
+6 6 17
+7 6 1
+8 6 1
+10 6 1
+14 6 1
+7 7 19
+8 7 1
+9 7 1
+11 7 1
+15 7 1
+8 8 23
+9 8 1
+10 8 1
+12 8 1
+16 8 1
+9 9 29
+10 9 1
+11 9 1
+13 9 1
+17 9 1
+10 10 31
+11 10 1
+12 10 1
+14 10 1
+18 10 1
+11 11 37
+12 11 1
+13 11 1
+15 11 1
+19 11 1
+12 12 41
+13 12 1
+14 12 1
+16 12 1
+13 13 43
+14 13 1
+15 13 1
+17 13 1
+14 14 47
+15 14 1
+16 14 1
+18 14 1
+15 15 53
+16 15 1
+17 15 1
+19 15 1
+16 16 59
+17 16 1
+18 16 1
+17 17 61
+18 17 1
+19 17 1
+18 18 67
+19 18 1
+19 19 71

--- a/examples/custom-logger/data/b.mtx
+++ b/examples/custom-logger/data/b.mtx
@@ -1,0 +1,21 @@
+%%MatrixMarket matrix array real general
+19 1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1

--- a/examples/custom-logger/data/x0.mtx
+++ b/examples/custom-logger/data/x0.mtx
@@ -1,0 +1,21 @@
+%%MatrixMarket matrix array real general
+19 1
+0
+0
+0
+0
+0
+0
+0
+0
+0
+0
+0
+0
+0
+0
+0
+0
+0
+0
+0

--- a/examples/custom-logger/doc/builds-on
+++ b/examples/custom-logger/doc/builds-on
@@ -1,0 +1,1 @@
+simple-solver simple-solver-logging minimal-cuda-solver

--- a/examples/custom-logger/doc/intro.dox
+++ b/examples/custom-logger/doc/intro.dox
@@ -1,0 +1,21 @@
+<a name="Intro"></a>
+<h1>Introduction</h1>
+The custom-logger example shows how Ginkgo's API can be leveraged to implement application-specific callbacks for Ginkgo's events. This is the most basic way of extending Ginkgo and a good first step for any application developer who wants to adapt Ginkgo to his specific needs.
+
+Ginkgo's gko::log::Logger abstraction provides hooks to the events that happen during the library execution. These hooks concern any low-level event such as memory allocations, deallocations, copies and kernel launches up to high-level events such as linear operator applications and completion of solver iterations.
+
+In this example, a simple logger is implemented to track the solver's recurrent residual norm and compute the true residual norm. At the end of the solver execution, a comparison table is shown on-screen.
+
+<h3> About the example </h3>
+Each example has the following sections:
+<ol>
+  <li> <b>Introduction:</b>This gives an overview of the example and mentions
+  any interesting aspects in the example that might help the reader.
+  <li> <b>The commented program:</b> This section is intended for you to
+  understand the details of the example so that you can play with it and understand
+  Ginkgo and its features better.
+  <li> <b>Results:</b> This section shows the results of the code when run. Though the
+  results may not be completely the same, you can expect the behaviour to be similar. 
+  <li> <b>The plain program:</b> This is the complete code without any comments to have
+  an complete overview of the code.
+  </ol>

--- a/examples/custom-logger/doc/kind
+++ b/examples/custom-logger/doc/kind
@@ -1,0 +1,1 @@
+logging

--- a/examples/custom-logger/doc/results.dox
+++ b/examples/custom-logger/doc/results.dox
@@ -1,0 +1,63 @@
+<h1>Results</h1>
+The following is the expected result:
+
+@code{.cpp}
+This is Ginkgo 0.0.0 (develop)
+    running with core module 0.0.0 (develop)
+    the reference module is  0.0.0 (develop)
+    the OpenMP    module is  not compiled
+    the CUDA      module is  not compiled
+Solution (x):
+%%MatrixMarket matrix array real general
+19 1
+0.252218
+0.108645
+0.0662811
+0.0630433
+0.0384088
+0.0396536
+0.0402648
+0.0338935
+0.0193098
+0.0234653
+0.0211499
+0.0196413
+0.0199151
+0.0181674
+0.0162722
+0.0150714
+0.0107016
+0.0121141
+0.0123025
+Recurrent vs real residual norm:
+| Iteration|  Recurrent Residual Norm|       Real Residual Norm|
+|----------|-------------------------|-------------------------|
+|         0|             4.358899e+00|             4.358899e+00|
+|         1|             2.304548e+00|             2.304548e+00|
+|         2|             1.467706e+00|             1.467706e+00|
+|         3|             9.848751e-01|             9.848751e-01|
+|         4|             7.418330e-01|             7.418330e-01|
+|         5|             5.136231e-01|             5.136231e-01|
+|         6|             3.841650e-01|             3.841650e-01|
+|         7|             3.164394e-01|             3.164394e-01|
+|         8|             2.277088e-01|             2.277088e-01|
+|         9|             1.703121e-01|             1.703121e-01|
+|        10|             9.737220e-02|             9.737220e-02|
+|        11|             6.168306e-02|             6.168306e-02|
+|        12|             4.541231e-02|             4.541231e-02|
+|        13|             3.195304e-02|             3.195304e-02|
+|        14|             1.616058e-02|             1.616058e-02|
+|        15|             6.570152e-03|             6.570152e-03|
+|        16|             2.643669e-03|             2.643669e-03|
+|        17|             8.588089e-04|             8.588089e-04|
+|        18|             2.864613e-04|             2.864613e-04|
+|        19|             1.641952e-15|             2.107881e-15|
+|----------|-------------------------|-------------------------|
+Residual norm sqrt(r^T r):
+%%MatrixMarket matrix array real general
+1 1
+2.10788e-15
+@endcode
+
+<h4> Comments about programming and debugging </h4>
+

--- a/examples/custom-logger/doc/short-intro
+++ b/examples/custom-logger/doc/short-intro
@@ -1,0 +1,1 @@
+The simple solver with a custom logger example.

--- a/examples/custom-logger/doc/tooltip
+++ b/examples/custom-logger/doc/tooltip
@@ -1,0 +1,1 @@
+Creating a custom logger with Ginkgo.

--- a/examples/custom-matrix-format/build.sh
+++ b/examples/custom-matrix-format/build.sh
@@ -27,11 +27,11 @@ if ls ${THIS_DIR} | grep -F "libginkgo." >/dev/null; then
 else
     LINK_FLAGS="-lginkgod -lginkgo_ompd -lginkgo_cudad -lginkgo_referenced"
 fi
-if [ -z "${CXX}" ]; then
-    CXX="c++"
-fi
+
+CXX="nvcc"
 
 # build
-${CXX} -std=c++11 -o ${THIS_DIR}/custom_matrix_format \
-    ${THIS_DIR}/custom_matrix_format.cpp \
-    -I${THIS_DIR}/../.. -L${THIS_DIR} ${LINK_FLAGS}
+${CXX} -std=c++11 -o ${THIS_DIR}/custom-matrix-format \
+       ${THIS_DIR}/custom-matrix-format.cpp ${THIS_DIR}/stencil_kernel.cu \
+       -I${THIS_DIR}/../../include -I${BUILD_DIR}/include \
+       -L${THIS_DIR} ${LINK_FLAGS}

--- a/examples/custom-stopping-criterion/build.sh
+++ b/examples/custom-stopping-criterion/build.sh
@@ -23,15 +23,16 @@ done
 
 # figure out correct compiler flags
 if ls ${THIS_DIR} | grep -F "libginkgo." >/dev/null; then
-    LINK_FLAGS="-lginkgo -lginkgo_omp -lginkgo_cuda -lginkgo_reference"
+    LINK_FLAGS="-lpthread -lginkgo -lginkgo_omp -lginkgo_cuda -lginkgo_reference"
 else
-    LINK_FLAGS="-lginkgod -lginkgo_ompd -lginkgo_cudad -lginkgo_referenced"
+    LINK_FLAGS="-lpthread -lginkgod -lginkgo_ompd -lginkgo_cudad -lginkgo_referenced"
 fi
 if [ -z "${CXX}" ]; then
     CXX="c++"
 fi
 
 # build
-${CXX} -std=c++11 -o ${THIS_DIR}/asynchronous_stopping_criterion \
-    ${THIS_DIR}/asynchronous_stopping_criterion.cpp \
-    -I${THIS_DIR}/../.. -L${THIS_DIR} ${LINK_FLAGS}
+${CXX} -std=c++11 -o ${THIS_DIR}/custom-stopping-criterion \
+       ${THIS_DIR}/custom-stopping-criterion.cpp \
+       -I${THIS_DIR}/../../include -I${BUILD_DIR}/include \
+       -L${THIS_DIR} ${LINK_FLAGS}

--- a/examples/ginkgo-overhead/build.sh
+++ b/examples/ginkgo-overhead/build.sh
@@ -32,6 +32,7 @@ if [ -z "${CXX}" ]; then
 fi
 
 # build
-${CXX} -std=c++11 -O3 -o ${THIS_DIR}/ginkgo_overhead \
-    ${THIS_DIR}/ginkgo_overhead.cpp \
-    -I${THIS_DIR}/../.. -L${THIS_DIR} ${LINK_FLAGS}
+${CXX} -std=c++11 -O3 -o ${THIS_DIR}/ginkgo-overhead \
+       ${THIS_DIR}/ginkgo-overhead.cpp \
+       -I${THIS_DIR}/../../include -I${BUILD_DIR}/include \
+       -L${THIS_DIR} ${LINK_FLAGS}

--- a/examples/ginkgo-ranges/build.sh
+++ b/examples/ginkgo-ranges/build.sh
@@ -32,5 +32,6 @@ if [ -z "${CXX}" ]; then
 fi
 
 # build
-${CXX} -std=c++11 -o ${THIS_DIR}/ranges ${THIS_DIR}/ranges.cpp \
-    -I${THIS_DIR}/../.. -L${THIS_DIR} ${LINK_FLAGS}
+${CXX} -std=c++11 -o ${THIS_DIR}/ginkgo-ranges ${THIS_DIR}/ginkgo-ranges.cpp \
+       -I${THIS_DIR}/../../include -I${BUILD_DIR}/include \
+       -L${THIS_DIR} ${LINK_FLAGS}

--- a/examples/inverse-iteration/build.sh
+++ b/examples/inverse-iteration/build.sh
@@ -33,5 +33,6 @@ fi
 
 # build
 ${CXX} -std=c++11 -o \
-    ${THIS_DIR}/inverse_iteration ${THIS_DIR}/inverse_iteration.cpp \
-    -I${THIS_DIR}/../.. -L${THIS_DIR} ${LINK_FLAGS}
+    ${THIS_DIR}/inverse-iteration ${THIS_DIR}/inverse-iteration.cpp \
+    -I${THIS_DIR}/../../include -I${BUILD_DIR}/include \
+    -L${THIS_DIR} ${LINK_FLAGS}

--- a/examples/minimal-cuda-solver/build.sh
+++ b/examples/minimal-cuda-solver/build.sh
@@ -32,6 +32,7 @@ if [ -z "${CXX}" ]; then
 fi
 
 # build
-${CXX} -std=c++11 -o ${THIS_DIR}/minimal_solver_cuda \
-    ${THIS_DIR}/minimal_solver_cuda.cpp \
-    -I${THIS_DIR}/../.. -L${THIS_DIR} ${LINK_FLAGS}
+${CXX} -std=c++11 -o ${THIS_DIR}/minimal-cuda-solver \
+    ${THIS_DIR}/minimal-cuda-solver.cpp \
+    -I${THIS_DIR}/../../include -I${BUILD_DIR}/include \
+    -L${THIS_DIR} ${LINK_FLAGS}

--- a/examples/papi-logging/build.sh
+++ b/examples/papi-logging/build.sh
@@ -23,14 +23,15 @@ done
 
 # figure out correct compiler flags
 if ls ${THIS_DIR} | grep -F "libginkgo." >/dev/null; then
-    LINK_FLAGS="-lginkgo -lginkgo_omp -lginkgo_cuda -lginkgo_reference"
+    LINK_FLAGS="-lpapi -lginkgo -lginkgo_omp -lginkgo_cuda -lginkgo_reference"
 else
-    LINK_FLAGS="-lginkgod -lginkgo_ompd -lginkgo_cudad -lginkgo_referenced"
+    LINK_FLAGS="-lpapi -lginkgod -lginkgo_ompd -lginkgo_cudad -lginkgo_referenced"
 fi
 if [ -z "${CXX}" ]; then
     CXX="c++"
 fi
 
 # build
-${CXX} -std=c++11 -o ${THIS_DIR}/papi_logging ${THIS_DIR}/papi_logging.cpp \
-    -I${THIS_DIR}/../.. -L${THIS_DIR} ${LINK_FLAGS}
+${CXX} -std=c++11 -o ${THIS_DIR}/papi-logging ${THIS_DIR}/papi-logging.cpp \
+       -I${THIS_DIR}/../../include -I${BUILD_DIR}/include \
+       -L${THIS_DIR} ${LINK_FLAGS}

--- a/examples/papi-logging/papi-logging.cpp
+++ b/examples/papi-logging/papi-logging.cpp
@@ -30,7 +30,7 @@ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ******************************<GINKGO LICENSE>*******************************/
 
-#include <include/ginkgo/ginkgo.hpp>
+#include <ginkgo/ginkgo.hpp>
 
 
 #include <papi.h>

--- a/examples/poisson-solver/build.sh
+++ b/examples/poisson-solver/build.sh
@@ -32,6 +32,7 @@ if [ -z "${CXX}" ]; then
 fi
 
 # build
-${CXX} -std=c++11 -o ${THIS_DIR}/poisson_solver \
-    ${THIS_DIR}/poisson_solver.cpp \
-    -I${THIS_DIR}/../.. -L${THIS_DIR} ${LINK_FLAGS}
+${CXX} -std=c++11 -o ${THIS_DIR}/poisson-solver \
+    ${THIS_DIR}/poisson-solver.cpp \
+    -I${THIS_DIR}/../../include -I${BUILD_DIR}/include \
+    -L${THIS_DIR} ${LINK_FLAGS}

--- a/examples/preconditioned-solver/build.sh
+++ b/examples/preconditioned-solver/build.sh
@@ -32,6 +32,7 @@ if [ -z "${CXX}" ]; then
 fi
 
 # build
-${CXX} -std=c++11 -o ${THIS_DIR}/preconditioned_solver \
-    ${THIS_DIR}/preconditioned_solver.cpp \
-    -I${THIS_DIR}/../.. -L${THIS_DIR} ${LINK_FLAGS}
+${CXX} -std=c++11 -o ${THIS_DIR}/preconditioned-solver \
+    ${THIS_DIR}/preconditioned-solver.cpp \
+    -I${THIS_DIR}/../../include -I${BUILD_DIR}/include \
+    -L${THIS_DIR} ${LINK_FLAGS}

--- a/examples/simple-solver-logging/build.sh
+++ b/examples/simple-solver-logging/build.sh
@@ -32,6 +32,7 @@ if [ -z "${CXX}" ]; then
 fi
 
 # build
-${CXX} -std=c++11 -o ${THIS_DIR}/simple_solver_logging \
-       ${THIS_DIR}/simple_solver_logging.cpp \
-       -I${THIS_DIR}/../.. -L${THIS_DIR} ${LINK_FLAGS}
+${CXX} -std=c++11 -o ${THIS_DIR}/simple-solver-logging \
+       ${THIS_DIR}/simple-solver-logging.cpp \
+       -I${THIS_DIR}/../../include -I${BUILD_DIR}/include \
+       -L${THIS_DIR} ${LINK_FLAGS}

--- a/examples/simple-solver/build.sh
+++ b/examples/simple-solver/build.sh
@@ -32,5 +32,6 @@ if [ -z "${CXX}" ]; then
 fi
 
 # build
-${CXX} -std=c++11 -o ${THIS_DIR}/simple_solver ${THIS_DIR}/simple_solver.cpp \
-    -I${THIS_DIR}/../.. -L${THIS_DIR} ${LINK_FLAGS}
+${CXX} -std=c++11 -o ${THIS_DIR}/simple-solver ${THIS_DIR}/simple-solver.cpp \
+       -I${THIS_DIR}/../../include -I${BUILD_DIR}/include \
+       -L${THIS_DIR} ${LINK_FLAGS}

--- a/examples/three-pt-stencil-solver/build.sh
+++ b/examples/three-pt-stencil-solver/build.sh
@@ -32,5 +32,7 @@ if [ -z "${CXX}" ]; then
 fi
 
 # build
-${CXX} -std=c++11 -o ${THIS_DIR}/3pt_stencil ${THIS_DIR}/3pt_stencil.cpp \
-    -I${THIS_DIR}/../.. -L${THIS_DIR} ${LINK_FLAGS}
+${CXX} -std=c++11 -o ${THIS_DIR}/three-pt-stencil-solver \
+       ${THIS_DIR}/three-pt-stencil-solver.cpp \
+       -I${THIS_DIR}/../../include -I${BUILD_DIR}/include \
+       -L${THIS_DIR} ${LINK_FLAGS}


### PR DESCRIPTION
This PR takes care of one of the TODOs noted in the release notes, stating we
were missing a custom logger example.

The purpose of this example is to show the users how to customize Ginkgo by
adding a new logger, which is useful and more efficient for application specific
problems. This is also one of the most basic (and simple) ways of customizing
Ginkgo, therefore this is a good entry level example for customization.

This example simply prints a table of the recurrent residual norm against the
real residual norm. This example is documented as much as the`simple-solver`
example for the user's convenience.

This PR also fixes all `build.sh` scripts which were seriously outdated and non
working. 