### PR TITLE
Fix CI tests

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -55,6 +55,7 @@ stages:
   artifacts:
     paths:
       - "build/*/*/*/*/*/CMakeCache.txt"
+      - "build/*/*/*/*/*/*.cmake"
       - "build/*/*/*/*/*/core/test"
       - "build/*/*/*/*/*/cuda/test"
       - "build/*/*/*/*/*/omp/test"
@@ -63,10 +64,17 @@ stages:
       - "build/*/*/*/*/*/cuda/libginkgo*"
       - "build/*/*/*/*/*/omp/libginkgo*"
       - "build/*/*/*/*/*/reference/libginkgo*"
+      - "build/*/*/*/*/*/core/device_hooks/libginkgo*"
+      - "build/*/*/*/*/*/*/CTestTestfile.cmake"
+      - "build/*/*/*/*/*/*/*/CTestTestfile.cmake"
   except:
       - schedules
 # build paths are of the form: build/<cuda_version>/<compiler>/<module(s)>/{debug,release}/{shared,static}/
 # see: the name of our building jobs
+#
+# All CTestTestfile.cmake files have to be added for the `ctest` command to
+# work. These tests can files are found starting from the build directory in
+# every subdirectory.
 
 .test_template: &default_test
   stage: test

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -81,6 +81,8 @@ stages:
   before_script: *default_before_script
   script:
     - cd ${CI_JOB_NAME/test/build}
+    - |
+        (( $(ctest -N | tail -1 | sed 's/Total Tests: //') != 0 )) || exit 1
     - ctest -V
   except:
       - schedules

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -73,7 +73,7 @@ stages:
 # see: the name of our building jobs
 #
 # All CTestTestfile.cmake files have to be added for the `ctest` command to
-# work. These tests can files are found starting from the build directory in
+# work. These files are found recursively starting from the build directory in
 # every subdirectory.
 
 .test_template: &default_test


### PR DESCRIPTION
Starting with commit 959f392f, tests are not properly ran.
That is due to not including several important CMake and
CTest files as artifact.