### PR TITLE
Add sonarqube capacities to Ginkgo.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -381,14 +381,25 @@ sonarqube_cov:
   image: localhost:5000/gko-cuda100-gnu7-llvm60
   before_script: *default_before_script
   script:
+    - PR_ID=$(curl "https://api.github.com/search/issues?q=sha:${CI_COMMIT_SHA}"
+      | jq '.items[0].number')
+    - if [[ "${PR_ID}" != "null" ]]; then
+        target_branch=$(curl
+          "https://api.github.com/repos/ginkgo-project/ginkgo/pulls/${PR_ID}" | jq
+          '.base.ref' | sed 's/"//g');
+        sonar_branching="-Dsonar.pullrequest.branch=${CI_COMMIT_REF_NAME}
+          -Dsonar.pullrequest.base=${target_branch}
+          -Dsonar.pullrequest.key=${PR_ID}";
+      else
+        sonar_branching="-Dsonar.branch.name=${CI_COMMIT_REF_NAME}
+        -Dsonar.branch.target=develop";
+      fi
     - ctest -S cmake/CTestScript.cmake -DCTEST_BUILD_CONFIGURATION=COVERAGE
       -DGINKGO_SONARQUBE_TEST=ON
     - sonar-scanner -Dsonar.login=${SONARQUBE_LOGIN}
       -Dsonar.cfamily.build-wrapper-output=build/bw-output
-      -Dsonar.branch.name=${CI_COMMIT_REF_NAME} -Dsonar.branch.target=develop
       -Dsonar.cfamily.gcov.reportsPath=build/Testing/CoverageInfo
-      -Dsonar.pullrequest.branch=${CI_COMMIT_REF_NAME}
-      -Dsonar.pullrequest.base=develop
+      ${sonar_branching}
     - bash <(curl -s https://codecov.io/bash)
   dependencies: []
   only:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -87,6 +87,7 @@ stages:
   except:
       - schedules
 
+
 sync:
   stage: sync
   variables:
@@ -105,6 +106,7 @@ sync:
     - develop
   except:
     - schedules
+
 
 # Build jobs
 build/cuda90/gcc/all/debug/shared:
@@ -373,6 +375,27 @@ iwyu:
   dependencies: []
   allow_failure: yes
 
+# Code analysis, coverage and reporting tool
+sonarqube_cov:
+  stage: code_quality
+  image: localhost:5000/gko-cuda100-gnu7-llvm60
+  before_script: *default_before_script
+  script:
+    - ctest -S cmake/CTestScript.cmake -DCTEST_BUILD_CONFIGURATION=COVERAGE
+      -DGINKGO_SONARQUBE_TEST=ON
+    - sonar-scanner -Dsonar.login=${SONARQUBE_LOGIN}
+      -Dsonar.cfamily.build-wrapper-output=build/bw-output
+      -Dsonar.branch.name=${CI_COMMIT_REF_NAME} -Dsonar.branch.target=develop
+      -Dsonar.cfamily.gcov.reportsPath=build/Testing/CoverageInfo
+      -Dsonar.pullrequest.branch=${CI_COMMIT_REF_NAME}
+      -Dsonar.pullrequest.base=develop
+    - bash <(curl -s https://codecov.io/bash)
+  dependencies: []
+  only:
+    variables:
+      - $PUBLIC_CI_TAG
+
+
 # Deploy documentation to github-pages
 gh-pages:
   stage: deploy
@@ -416,21 +439,6 @@ gh-pages:
   except:
       - schedules
 
-
-coverage:
-  stage: QoS_tools
-  image: localhost:5000/gko-cuda100-gnu7-llvm60
-  before_script: *default_before_script
-  script:
-    - ctest -S cmake/CTestScript.cmake -DCTEST_BUILD_CONFIGURATION=COVERAGE
-    - bash <(curl -s https://codecov.io/bash)
-  dependencies: []
-  only:
-    refs:
-      - master
-      - develop
-    variables:
-      - $PUBLIC_CI_TAG
 
 threadsanitizer:
   stage: QoS_tools

--- a/cmake/CTestScript.cmake
+++ b/cmake/CTestScript.cmake
@@ -132,6 +132,9 @@ ctest_submit(PARTS Configure)
 
 ctest_read_custom_files( ${CTEST_BINARY_DIRECTORY} )
 
+if (DEFINED GINKGO_SONARQUBE_TEST)
+    set(CTEST_BUILD_COMMAND "build-wrapper-linux-x86-64 --out-dir bw-output make -j${PROC_COUNT}")
+endif()
 ctest_build(BUILD "${CTEST_BINARY_DIRECTORY}" APPEND)
 ctest_submit(PARTS Build)
 

--- a/dev_tools/containers/ginkgo-cuda-base.py
+++ b/dev_tools/containers/ginkgo-cuda-base.py
@@ -45,6 +45,8 @@ Stage0 += shell(commands=clangtidyln)
 if os.path.isdir('bin/'):
         Stage0 += copy(src='bin/*', dest='/usr/bin/')
 
+if os.path.isdir('sonar-scanner/'):
+        Stage0 += copy(src='sonar-scanner/', dest='/')
 
 # Correctly set the LIBRARY_PATH
 Stage0 += environment(variables={'LIBRARY_PATH': '/usr/local/cuda/lib64/stubs'})

--- a/dev_tools/containers/ginkgo-cuda-base.py
+++ b/dev_tools/containers/ginkgo-cuda-base.py
@@ -7,7 +7,7 @@ Contents:
 	OpenMP latest apt version for Clang+OpenMP
 	Python 2 and 3 (upstream)
 	cmake (upstream)
-	git, openssh, doxygen, curl, valgrind, graphviz latest apt version
+	git, openssh, doxygen, curl, valgrind, graphviz, jq latest apt version
 	iwyu precompiled version 6.0
 """
 # pylint: disable=invalid-name, undefined-variable, used-before-assignment
@@ -24,7 +24,7 @@ Stage0.baseimage(image)
 Stage0 += python()
 Stage0 += cmake(eula=True)
 Stage0 += apt_get(ospackages=['git', 'openssh-client', 'doxygen', 'curl', 'valgrind', 'graphviz'])
-Stage0 += apt_get(ospackages=['iwyu'])
+Stage0 += apt_get(ospackages=['jq', 'iwyu'])
 
 # GNU compilers
 gnu_version = USERARG.get('gnu', '7')

--- a/dev_tools/containers/ginkgo-nocuda-base.py
+++ b/dev_tools/containers/ginkgo-nocuda-base.py
@@ -7,7 +7,7 @@ Contents:
 	Python 2 and 3 (upstream)
 	cmake (upstream)
 	build-essential, git, openssh, doxygen, curl, valgrind latest apt version
-	graphviz, ghostscript, texlive, texlive-latex-extra, latest apt version
+	jq, graphviz, ghostscript, texlive, texlive-latex-extra, latest apt version
 	texlive-science, texlive-fonts-extra, texlive-publishers latest apt version
 	clang-tidy, iwyu: latest apt version
 	papi: adds package libpfm4, and copy precompiled papi headers and files
@@ -24,7 +24,7 @@ Stage0.baseimage('ubuntu:18.04')
 Stage0 += python()
 Stage0 += cmake(eula=True)
 Stage0 += apt_get(ospackages=['build-essential', 'git', 'openssh-client', 'doxygen', 'curl', 'valgrind'])
-Stage0 += apt_get(ospackages=['graphviz', 'ghostscript', 'texlive', 'texlive-latex-extra'])
+Stage0 += apt_get(ospackages=['jq', 'graphviz', 'ghostscript', 'texlive', 'texlive-latex-extra'])
 Stage0 += apt_get(ospackages=['texlive-science', 'texlive-fonts-extra', 'texlive-publishers'])
 Stage0 += apt_get(ospackages=['clang-tidy', 'iwyu'])
 

--- a/dev_tools/containers/gko-cuda100-gnu7-llvm60.baseimage
+++ b/dev_tools/containers/gko-cuda100-gnu7-llvm60.baseimage
@@ -28,6 +28,7 @@ RUN apt-get update -y && \
 
 RUN apt-get update -y && \
     apt-get install -y --no-install-recommends \
+        jq \
         iwyu && \
     rm -rf /var/lib/apt/lists/*
 

--- a/dev_tools/containers/gko-cuda100-gnu7-llvm60.baseimage
+++ b/dev_tools/containers/gko-cuda100-gnu7-llvm60.baseimage
@@ -70,6 +70,8 @@ RUN ln -s /usr/bin/clang-tidy-6.0 /usr/bin/clang-tidy
 
 COPY bin/* /usr/bin/
 
+COPY sonar-scanner/ /
+
 ENV LIBRARY_PATH=/usr/local/cuda/lib64/stubs
 
 ENV LD_LIBRARY_PATH=/usr/local/cuda/lib64/stubs

--- a/dev_tools/containers/gko-cuda90-gnu5-llvm39.baseimage
+++ b/dev_tools/containers/gko-cuda90-gnu5-llvm39.baseimage
@@ -28,6 +28,7 @@ RUN apt-get update -y && \
 
 RUN apt-get update -y && \
     apt-get install -y --no-install-recommends \
+        jq \
         iwyu && \
     rm -rf /var/lib/apt/lists/*
 

--- a/dev_tools/containers/gko-cuda90-gnu5-llvm39.baseimage
+++ b/dev_tools/containers/gko-cuda90-gnu5-llvm39.baseimage
@@ -70,6 +70,8 @@ RUN ln -s /usr/bin/clang-tidy-3.9 /usr/bin/clang-tidy
 
 COPY bin/* /usr/bin/
 
+COPY sonar-scanner/ /
+
 ENV LIBRARY_PATH=/usr/local/cuda/lib64/stubs
 
 ENV LD_LIBRARY_PATH=/usr/local/cuda/lib64/stubs

--- a/dev_tools/containers/gko-cuda91-gnu6-llvm40.baseimage
+++ b/dev_tools/containers/gko-cuda91-gnu6-llvm40.baseimage
@@ -28,6 +28,7 @@ RUN apt-get update -y && \
 
 RUN apt-get update -y && \
     apt-get install -y --no-install-recommends \
+        jq \
         iwyu && \
     rm -rf /var/lib/apt/lists/*
 

--- a/dev_tools/containers/gko-cuda91-gnu6-llvm40.baseimage
+++ b/dev_tools/containers/gko-cuda91-gnu6-llvm40.baseimage
@@ -70,6 +70,8 @@ RUN ln -s /usr/bin/clang-tidy-4.0 /usr/bin/clang-tidy
 
 COPY bin/* /usr/bin/
 
+COPY sonar-scanner/ /
+
 ENV LIBRARY_PATH=/usr/local/cuda/lib64/stubs
 
 ENV LD_LIBRARY_PATH=/usr/local/cuda/lib64/stubs

--- a/dev_tools/containers/gko-cuda92-gnu7-llvm50.baseimage
+++ b/dev_tools/containers/gko-cuda92-gnu7-llvm50.baseimage
@@ -28,6 +28,7 @@ RUN apt-get update -y && \
 
 RUN apt-get update -y && \
     apt-get install -y --no-install-recommends \
+        jq \
         iwyu && \
     rm -rf /var/lib/apt/lists/*
 

--- a/dev_tools/containers/gko-cuda92-gnu7-llvm50.baseimage
+++ b/dev_tools/containers/gko-cuda92-gnu7-llvm50.baseimage
@@ -70,6 +70,8 @@ RUN ln -s /usr/bin/clang-tidy-5.0 /usr/bin/clang-tidy
 
 COPY bin/* /usr/bin/
 
+COPY sonar-scanner/ /
+
 ENV LIBRARY_PATH=/usr/local/cuda/lib64/stubs
 
 ENV LD_LIBRARY_PATH=/usr/local/cuda/lib64/stubs

--- a/dev_tools/containers/gko-nocuda-gnu8-llvm70.baseimage
+++ b/dev_tools/containers/gko-nocuda-gnu8-llvm70.baseimage
@@ -28,6 +28,7 @@ RUN apt-get update -y && \
 
 RUN apt-get update -y && \
     apt-get install -y --no-install-recommends \
+        jq \
         graphviz \
         ghostscript \
         texlive \

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,10 @@
+sonar.projectKey=ginkgo-project_ginkgo
+sonar.organization=ginkgo-project
+sonar.pullrequest.github.repository=ginkgo-project/ginkgo
+
+sonar.cfamily.threads=10
+
+sonar.sources=.
+sonar.tests=.
+sonar.exclusions="third_party/**, build/**"
+sonar.test.inclusions=*/test/**


### PR DESCRIPTION
A long time ago, I tried out using [sonarqube with Ginkgo](https://sonarcloud.io/dashboard?id=ginkgo-project_ginkgo) and we got some really
nice code analysis out of it. This small PR adds this capacity to Ginkgo as part of
the CI system. The main goal is to have statistics (coverage, new bugs, etc) for
each pull request *before* merging into develop. This would allow to take care of
many coding problems as part of the PR process rather than after merging.

After this, I believe Ginkgo is fairly well covered in terms of tools for code static
and dynamic analysis. This is the last tool I wanted to add to Ginkgo.

+ Adapt the containers to bundle the sonar-scanner tool when found.
+ Add a CUDA job which launches the build-wrapper and sonar-scanner tools to
   scan the code and update all data online.
+ Put all coverage analysis on a per branch basis instead of only for the long
   living branches. This provides change metrics for branches before they are
   merged to develop.