### PR TITLE
Fix sonarqube_cov job for long living branches

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -390,6 +390,8 @@ sonarqube_cov:
         sonar_branching="-Dsonar.pullrequest.branch=${CI_COMMIT_REF_NAME}
           -Dsonar.pullrequest.base=${target_branch}
           -Dsonar.pullrequest.key=${PR_ID}";
+      elif [[ "${CI_COMMIT_REF_NAME}" == "master" ]] || [[ "${CI_COMMIT_REF_NAME}" == "develop" ]] || [[ "${CI_COMMIT_REF_NAME}" =~ ^v[0-9\.]+$ ]]; then
+        sonar_branching="-Dsonar.branch.name=${CI_COMMIT_REF_NAME}";
       else
         sonar_branching="-Dsonar.branch.name=${CI_COMMIT_REF_NAME}
         -Dsonar.branch.target=develop";


### PR DESCRIPTION
For long living branches there should be no `target` set. This applies to develop, master and version tags.