### PR TITLE
Fix CSR->ELL conversion

### DIFF
--- a/benchmark/run_all_benchmarks.sh
+++ b/benchmark/run_all_benchmarks.sh
@@ -199,6 +199,7 @@ for (( i=${LOOP_START}; i < ${LOOP_END}; ++i )); do
     run_spmv_benchmarks "${RESULT_FILE}"
 
     if [ "${BENCHMARK}" == "conversions" ]; then
+        echo -e "${PREFIX}Running Conversion for ${GROUP}/${NAME}" 1>&2
         run_conversion_benchmarks "${RESULT_FILE}"
     fi
 


### PR DESCRIPTION
And accelerate benchmarks.

### Conversion details
Fix a bug in CSR `max_nnz_per_row` computation.

+ The same `grid_dim` was used for the reduction and for the
  `calculate_nnz_per_row` kernel
+ The `grid_dim` was limited to maximum `default_block_size^2` elements.
+ For bigger matrices, the extracted `max_nnz_per_row` could be wrong, due to
  omitted values.

### Benchmark details
+ Move `matrix_from` to the external loop.
+ Benchmark directly into `matrix_to`.