### PR TITLE
Fixed gcc 6.4 `internal compiler error`

### DIFF
--- a/core/base/iterator_factory.hpp
+++ b/core/base/iterator_factory.hpp
@@ -146,7 +146,7 @@ private:
         }
 
         // Conversion operator to `element`
-        operator element() const { return element{dominant(), secondary()}; }
+        operator element() const { return {dominant(), secondary()}; }
 
         friend void swap(Reference a, Reference b)
         {
@@ -171,7 +171,7 @@ private:
 
         ToSortType &dominant() { return parent_.dominant_values_[arr_index_]; }
 
-        ToSortType dominant() const
+        const ToSortType &dominant() const
         {
             return parent_.dominant_values_[arr_index_];
         }
@@ -181,7 +181,7 @@ private:
             return parent_.secondary_values_[arr_index_];
         }
 
-        SecondaryType secondary() const
+        const SecondaryType &secondary() const
         {
             return parent_.secondary_values_[arr_index_];
         }


### PR DESCRIPTION
When compiling Ginkgo with gcc 6.4.0, there was an `internal compiler error` when compiling the `IteratorFactory`.
This is actually a problem with gcc and not with our code (since it is an __internal compiler__ error), but we can easily change our code to also compile with gcc 6.4 without changing the result.
It was fixed by changing the return type of the helper functions to `const &` instead of a value copy.

Closes #314 