### PR TITLE
Improved ParIlu kernels: interface & implemtation

### DIFF
--- a/core/device_hooks/common_kernels.inc.cpp
+++ b/core/device_hooks/common_kernels.inc.cpp
@@ -575,10 +575,10 @@ namespace par_ilu_factorization {
 
 
 template <typename ValueType, typename IndexType>
-GKO_DECLARE_PAR_ILU_COMPUTE_NNZ_L_U_KERNEL(ValueType, IndexType)
+GKO_DECLARE_PAR_ILU_INITIALIZE_ROW_PTRS_L_U_KERNEL(ValueType, IndexType)
 GKO_NOT_COMPILED(GKO_HOOK_MODULE);
 GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
-    GKO_DECLARE_PAR_ILU_COMPUTE_NNZ_L_U_KERNEL);
+    GKO_DECLARE_PAR_ILU_INITIALIZE_ROW_PTRS_L_U_KERNEL);
 
 template <typename ValueType, typename IndexType>
 GKO_DECLARE_PAR_ILU_INITIALIZE_L_U_KERNEL(ValueType, IndexType)

--- a/core/factorization/par_ilu.cpp
+++ b/core/factorization/par_ilu.cpp
@@ -36,6 +36,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <memory>
 
 
+#include <ginkgo/core/base/array.hpp>
+#include <ginkgo/core/base/exception_helpers.hpp>
 #include <ginkgo/core/base/polymorphic_object.hpp>
 #include <ginkgo/core/base/types.hpp>
 #include <ginkgo/core/matrix/coo.hpp>
@@ -51,7 +53,8 @@ namespace factorization {
 namespace par_ilu_factorization {
 
 
-GKO_REGISTER_OPERATION(compute_nnz_l_u, par_ilu_factorization::compute_nnz_l_u);
+GKO_REGISTER_OPERATION(initialize_row_ptrs_l_u,
+                       par_ilu_factorization::initialize_row_ptrs_l_u);
 GKO_REGISTER_OPERATION(initialize_l_u, par_ilu_factorization::initialize_l_u);
 GKO_REGISTER_OPERATION(compute_l_u_factors,
                        par_ilu_factorization::compute_l_u_factors);
@@ -69,7 +72,11 @@ ParIlu<ValueType, IndexType>::generate_l_u(
     using CsrMatrix = matrix::Csr<ValueType, IndexType>;
     using CooMatrix = matrix::Coo<ValueType, IndexType>;
 
+    GKO_ASSERT_IS_SQUARE_MATRIX(system_matrix);
+
     const auto exec = this->get_executor();
+    const auto host_exec = exec->get_master();
+
     // Only copies the matrix if it is not on the same executor or was not in
     // the right format. Throws an exception if it is not convertable.
     std::unique_ptr<CsrMatrix> csr_system_matrix_unique_ptr{};
@@ -93,14 +100,34 @@ ParIlu<ValueType, IndexType>::generate_l_u(
     }
 
     const auto matrix_size = csr_system_matrix->get_size();
-    size_type l_nnz{};
-    size_type u_nnz{};
-    exec->run(par_ilu_factorization::make_compute_nnz_l_u(csr_system_matrix,
-                                                          &l_nnz, &u_nnz));
-    auto l_factor =
-        l_matrix_type::create(exec, matrix_size, l_nnz /* TODO set strategy */);
-    auto u_factor =
-        u_matrix_type::create(exec, matrix_size, u_nnz /* TODO set strategy */);
+    const auto number_rows = matrix_size[0];
+    Array<IndexType> l_row_ptrs{exec, number_rows + 1};
+    Array<IndexType> u_row_ptrs{exec, number_rows + 1};
+    exec->run(par_ilu_factorization::make_initialize_row_ptrs_l_u(
+        csr_system_matrix, l_row_ptrs.get_data(), u_row_ptrs.get_data()));
+
+    IndexType l_nnz_it;
+    IndexType u_nnz_it;
+    // Since nnz is always at row_ptrs[m], it can be extracted easily
+    host_exec->copy_from(exec.get(), 1, l_row_ptrs.get_data() + number_rows,
+                         &l_nnz_it);
+    host_exec->copy_from(exec.get(), 1, u_row_ptrs.get_data() + number_rows,
+                         &u_nnz_it);
+    auto l_nnz = static_cast<size_type>(l_nnz_it);
+    auto u_nnz = static_cast<size_type>(u_nnz_it);
+
+    // Since `row_ptrs` of L and U is already created, the matrix can be
+    // directly created with it
+    Array<IndexType> l_col_idxs{exec, l_nnz};
+    Array<ValueType> l_vals{exec, l_nnz};
+    auto l_factor = l_matrix_type::create(
+        exec, matrix_size, std::move(l_vals), std::move(l_col_idxs),
+        std::move(l_row_ptrs) /* TODO set strategy */);
+    Array<IndexType> u_col_idxs{exec, u_nnz};
+    Array<ValueType> u_vals{exec, u_nnz};
+    auto u_factor = u_matrix_type::create(
+        exec, matrix_size, std::move(u_vals), std::move(u_col_idxs),
+        std::move(u_row_ptrs) /* TODO set strategy */);
 
     exec->run(par_ilu_factorization::make_initialize_l_u(
         csr_system_matrix, l_factor.get(), u_factor.get()));

--- a/core/factorization/par_ilu_kernels.hpp
+++ b/core/factorization/par_ilu_kernels.hpp
@@ -49,11 +49,12 @@ namespace gko {
 namespace kernels {
 
 
-#define GKO_DECLARE_PAR_ILU_COMPUTE_NNZ_L_U_KERNEL(ValueType, IndexType) \
-    void compute_nnz_l_u(                                                \
-        std::shared_ptr<const DefaultExecutor> exec,                     \
-        const matrix::Csr<ValueType, IndexType> *system_matrix,          \
-        size_type *l_nnz, size_type *u_nnz)
+#define GKO_DECLARE_PAR_ILU_INITIALIZE_ROW_PTRS_L_U_KERNEL(ValueType, \
+                                                           IndexType) \
+    void initialize_row_ptrs_l_u(                                     \
+        std::shared_ptr<const DefaultExecutor> exec,                  \
+        const matrix::Csr<ValueType, IndexType> *system_matrix,       \
+        IndexType *l_row_ptrs, IndexType *u_row_ptrs)
 #define GKO_DECLARE_PAR_ILU_INITIALIZE_L_U_KERNEL(ValueType, IndexType) \
     void initialize_l_u(                                                \
         std::shared_ptr<const DefaultExecutor> exec,                    \
@@ -68,12 +69,12 @@ namespace kernels {
         matrix::Csr<ValueType, IndexType> *u_factor)
 
 
-#define GKO_DECLARE_ALL_AS_TEMPLATES                                  \
-    template <typename ValueType, typename IndexType>                 \
-    GKO_DECLARE_PAR_ILU_COMPUTE_NNZ_L_U_KERNEL(ValueType, IndexType); \
-    template <typename ValueType, typename IndexType>                 \
-    GKO_DECLARE_PAR_ILU_INITIALIZE_L_U_KERNEL(ValueType, IndexType);  \
-    template <typename ValueType, typename IndexType>                 \
+#define GKO_DECLARE_ALL_AS_TEMPLATES                                          \
+    template <typename ValueType, typename IndexType>                         \
+    GKO_DECLARE_PAR_ILU_INITIALIZE_ROW_PTRS_L_U_KERNEL(ValueType, IndexType); \
+    template <typename ValueType, typename IndexType>                         \
+    GKO_DECLARE_PAR_ILU_INITIALIZE_L_U_KERNEL(ValueType, IndexType);          \
+    template <typename ValueType, typename IndexType>                         \
     GKO_DECLARE_PAR_ILU_COMPUTE_L_U_FACTORS_KERNEL(ValueType, IndexType)
 
 

--- a/cuda/factorization/par_ilu_kernels.cu
+++ b/cuda/factorization/par_ilu_kernels.cu
@@ -49,16 +49,17 @@ namespace par_ilu_factorization {
 
 
 template <typename ValueType, typename IndexType>
-void compute_nnz_l_u(std::shared_ptr<const DefaultExecutor> exec,
-                     const matrix::Csr<ValueType, IndexType> *system_matrix,
-                     size_type *l_nnz, size_type *u_nnz) GKO_NOT_IMPLEMENTED;
+void initialize_row_ptrs_l_u(
+    std::shared_ptr<const CudaExecutor> exec,
+    const matrix::Csr<ValueType, IndexType> *system_matrix,
+    IndexType *l_row_ptrs, IndexType *u_row_ptrs) GKO_NOT_IMPLEMENTED;
 
 GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
-    GKO_DECLARE_PAR_ILU_COMPUTE_NNZ_L_U_KERNEL);
+    GKO_DECLARE_PAR_ILU_INITIALIZE_ROW_PTRS_L_U_KERNEL);
 
 
 template <typename ValueType, typename IndexType>
-void initialize_l_u(std::shared_ptr<const DefaultExecutor> exec,
+void initialize_l_u(std::shared_ptr<const CudaExecutor> exec,
                     const matrix::Csr<ValueType, IndexType> *system_matrix,
                     matrix::Csr<ValueType, IndexType> *csr_l,
                     matrix::Csr<ValueType, IndexType> *csr_u)
@@ -70,7 +71,7 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 
 template <typename ValueType, typename IndexType>
 void compute_l_u_factors(
-    std::shared_ptr<const DefaultExecutor> exec, size_type iterations,
+    std::shared_ptr<const CudaExecutor> exec, size_type iterations,
     const matrix::Coo<ValueType, IndexType> *system_matrix,
     matrix::Csr<ValueType, IndexType> *l_factor,
     matrix::Csr<ValueType, IndexType> *u_factor) GKO_NOT_IMPLEMENTED;

--- a/omp/factorization/par_ilu_kernels.cpp
+++ b/omp/factorization/par_ilu_kernels.cpp
@@ -50,29 +50,35 @@ namespace par_ilu_factorization {
 
 
 template <typename ValueType, typename IndexType>
-void compute_nnz_l_u(std::shared_ptr<const OmpExecutor> exec,
-                     const matrix::Csr<ValueType, IndexType> *system_matrix,
-                     size_type *l_nnz, size_type *u_nnz)
+void initialize_row_ptrs_l_u(
+    std::shared_ptr<const OmpExecutor> exec,
+    const matrix::Csr<ValueType, IndexType> *system_matrix,
+    IndexType *l_row_ptrs, IndexType *u_row_ptrs)
 {
     auto row_ptrs = system_matrix->get_const_row_ptrs();
     auto col_idxs = system_matrix->get_const_col_idxs();
-    *l_nnz = 0;
-    *u_nnz = 0;
-    for (size_type row = 0; row < system_matrix->get_size()[1]; ++row) {
+    size_type l_nnz{};
+    size_type u_nnz{};
+
+    l_row_ptrs[0] = 0;
+    u_row_ptrs[0] = 0;
+    for (size_type row = 0; row < system_matrix->get_size()[0]; ++row) {
         for (size_type el = row_ptrs[row]; el < row_ptrs[row + 1]; ++el) {
             size_type col = col_idxs[el];
             if (col <= row) {
-                ++(*l_nnz);
+                ++l_nnz;
             }
             if (col >= row) {
-                ++(*u_nnz);
+                ++u_nnz;
             }
         }
+        l_row_ptrs[row + 1] = l_nnz;
+        u_row_ptrs[row + 1] = u_nnz;
     }
 }
 
 GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
-    GKO_DECLARE_PAR_ILU_COMPUTE_NNZ_L_U_KERNEL);
+    GKO_DECLARE_PAR_ILU_INITIALIZE_ROW_PTRS_L_U_KERNEL);
 
 
 template <typename ValueType, typename IndexType>
@@ -85,19 +91,18 @@ void initialize_l_u(std::shared_ptr<const OmpExecutor> exec,
     const auto col_idxs = system_matrix->get_const_col_idxs();
     const auto vals = system_matrix->get_const_values();
 
-    auto row_ptrs_l = csr_l->get_row_ptrs();
+    const auto row_ptrs_l = csr_l->get_const_row_ptrs();
     auto col_idxs_l = csr_l->get_col_idxs();
     auto vals_l = csr_l->get_values();
 
-    auto row_ptrs_u = csr_u->get_row_ptrs();
+    const auto row_ptrs_u = csr_u->get_const_row_ptrs();
     auto col_idxs_u = csr_u->get_col_idxs();
     auto vals_u = csr_u->get_values();
 
-    size_type current_index_l{};
-    size_type current_index_u{};
-    row_ptrs_l[current_index_l] = zero<IndexType>();
-    row_ptrs_u[current_index_u] = zero<IndexType>();
+#pragma omp parallel for
     for (size_type row = 0; row < system_matrix->get_size()[0]; ++row) {
+        size_type current_index_l = row_ptrs_l[row];
+        size_type current_index_u = row_ptrs_u[row];
         for (size_type el = row_ptrs[row]; el < row_ptrs[row + 1]; ++el) {
             const auto col = col_idxs[el];
             const auto val = vals[el];
@@ -120,8 +125,6 @@ void initialize_l_u(std::shared_ptr<const OmpExecutor> exec,
                 ++current_index_u;
             }
         }
-        row_ptrs_l[row + 1] = current_index_l;
-        row_ptrs_u[row + 1] = current_index_u;
     }
 }
 
@@ -149,7 +152,7 @@ void compute_l_u_factors(std::shared_ptr<const OmpExecutor> exec,
     auto vals_l = l_factor->get_values();
     auto vals_u = u_factor->get_values();
     for (size_type iter = 0; iter < iterations; ++iter) {
-        // all elements in the incomplete factors are updated in parallel
+    // all elements in the incomplete factors are updated in parallel
 #pragma omp parallel for
         for (size_type el = 0; el < system_matrix->get_num_stored_elements();
              ++el) {

--- a/omp/test/factorization/par_ilu_kernels.cpp
+++ b/omp/test/factorization/par_ilu_kernels.cpp
@@ -33,6 +33,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "core/factorization/par_ilu_kernels.hpp"
 
 
+#include <algorithm>
 #include <fstream>
 #include <memory>
 #include <string>
@@ -41,6 +42,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <gtest/gtest.h>
 
 
+#include <ginkgo/core/base/array.hpp>
+#include <ginkgo/core/base/executor.hpp>
 #include <ginkgo/core/matrix/coo.hpp>
 #include <ginkgo/core/matrix/csr.hpp>
 #include <ginkgo/core/matrix/dense.hpp>
@@ -89,47 +92,71 @@ protected:
     std::shared_ptr<const Csr> csr_ref;
     std::shared_ptr<const Csr> csr_omp;
 
-    void compute_nnz(gko::size_type *l_nnz_ref, gko::size_type *u_nnz_ref,
-                     gko::size_type *l_nnz_omp, gko::size_type *u_nnz_omp)
+    void compute_nnz(index_type *l_row_ptrs_ref, index_type *u_row_ptrs_ref,
+                     index_type *l_row_ptrs_omp, index_type *u_row_ptrs_omp)
     {
-        gko::kernels::reference::par_ilu_factorization::compute_nnz_l_u(
-            ref, gko::lend(csr_ref), l_nnz_ref, u_nnz_ref);
-        gko::kernels::omp::par_ilu_factorization::compute_nnz_l_u(
-            ref, gko::lend(csr_omp), l_nnz_omp, u_nnz_omp);
+        gko::kernels::reference::par_ilu_factorization::initialize_row_ptrs_l_u(
+            ref, gko::lend(csr_ref), l_row_ptrs_ref, u_row_ptrs_ref);
+        gko::kernels::omp::par_ilu_factorization::initialize_row_ptrs_l_u(
+            omp, gko::lend(csr_omp), l_row_ptrs_omp, u_row_ptrs_omp);
     }
 
     void initialize_lu(std::unique_ptr<Csr> *l_ref, std::unique_ptr<Csr> *u_ref,
                        std::unique_ptr<Csr> *l_omp, std::unique_ptr<Csr> *u_omp)
     {
-        gko::size_type l_nnz_ref{};
-        gko::size_type u_nnz_ref{};
-        gko::size_type l_nnz_omp{};
-        gko::size_type u_nnz_omp{};
-        compute_nnz(&l_nnz_ref, &u_nnz_ref, &l_nnz_omp, &u_nnz_omp);
-        *l_ref = Csr::create(ref, csr_ref->get_size(), l_nnz_ref);
-        *u_ref = Csr::create(ref, csr_ref->get_size(), u_nnz_ref);
-        *l_omp = Csr::create(ref, csr_omp->get_size(), l_nnz_omp);
-        *u_omp = Csr::create(ref, csr_omp->get_size(), u_nnz_omp);
+        auto num_row_ptrs = csr_ref->get_size()[0] + 1;
+        gko::Array<index_type> l_row_ptrs_ref{ref, num_row_ptrs};
+        gko::Array<index_type> u_row_ptrs_ref{ref, num_row_ptrs};
+        gko::Array<index_type> l_row_ptrs_omp{omp, num_row_ptrs};
+        gko::Array<index_type> u_row_ptrs_omp{omp, num_row_ptrs};
+
+        compute_nnz(l_row_ptrs_ref.get_data(), u_row_ptrs_ref.get_data(),
+                    l_row_ptrs_omp.get_data(), u_row_ptrs_omp.get_data());
+        // Since `compute_nnz` was already tested, it is expected that `*_ref`
+        // and `*_omp` contain identical values
+        auto l_nnz = l_row_ptrs_ref.get_const_data()[num_row_ptrs - 1];
+        auto u_nnz = u_row_ptrs_ref.get_const_data()[num_row_ptrs - 1];
+
+        *l_ref = Csr::create(ref, csr_ref->get_size(), l_nnz);
+        *u_ref = Csr::create(ref, csr_ref->get_size(), u_nnz);
+        *l_omp = Csr::create(omp, csr_omp->get_size(), l_nnz);
+        *u_omp = Csr::create(omp, csr_omp->get_size(), u_nnz);
+        // Copy the already initialized `row_ptrs` to the new matrices
+        ref->copy_from(gko::lend(ref), num_row_ptrs, l_row_ptrs_ref.get_data(),
+                       (*l_ref)->get_row_ptrs());
+        ref->copy_from(gko::lend(ref), num_row_ptrs, u_row_ptrs_ref.get_data(),
+                       (*u_ref)->get_row_ptrs());
+        omp->copy_from(gko::lend(omp), num_row_ptrs, l_row_ptrs_omp.get_data(),
+                       (*l_omp)->get_row_ptrs());
+        omp->copy_from(gko::lend(omp), num_row_ptrs, u_row_ptrs_omp.get_data(),
+                       (*u_omp)->get_row_ptrs());
 
         gko::kernels::reference::par_ilu_factorization::initialize_l_u(
             ref, gko::lend(csr_ref), gko::lend(*l_ref), gko::lend(*u_ref));
         gko::kernels::omp::par_ilu_factorization::initialize_l_u(
-            ref, gko::lend(csr_omp), gko::lend(*l_omp), gko::lend(*u_omp));
+            omp, gko::lend(csr_omp), gko::lend(*l_omp), gko::lend(*u_omp));
     }
 };
 
 
 TEST_F(ParIlu, OmpKernelComputeNnzLUEquivalentToRef)
 {
-    gko::size_type l_nnz_ref{};
-    gko::size_type u_nnz_ref{};
-    gko::size_type l_nnz_omp{};
-    gko::size_type u_nnz_omp{};
+    auto num_row_ptrs = csr_ref->get_size()[0] + 1;
+    gko::Array<index_type> l_row_ptrs_array_ref(ref, num_row_ptrs);
+    gko::Array<index_type> u_row_ptrs_array_ref(ref, num_row_ptrs);
+    gko::Array<index_type> l_row_ptrs_array_omp(omp, num_row_ptrs);
+    gko::Array<index_type> u_row_ptrs_array_omp(omp, num_row_ptrs);
+    auto l_row_ptrs_ref = l_row_ptrs_array_ref.get_data();
+    auto u_row_ptrs_ref = u_row_ptrs_array_ref.get_data();
+    auto l_row_ptrs_omp = l_row_ptrs_array_omp.get_data();
+    auto u_row_ptrs_omp = u_row_ptrs_array_omp.get_data();
 
-    compute_nnz(&l_nnz_ref, &u_nnz_ref, &l_nnz_omp, &u_nnz_omp);
+    compute_nnz(l_row_ptrs_ref, u_row_ptrs_ref, l_row_ptrs_omp, u_row_ptrs_omp);
 
-    ASSERT_EQ(l_nnz_omp, l_nnz_ref);
-    ASSERT_EQ(u_nnz_omp, u_nnz_ref);
+    ASSERT_TRUE(std::equal(l_row_ptrs_ref, l_row_ptrs_ref + num_row_ptrs,
+                           l_row_ptrs_omp));
+    ASSERT_TRUE(std::equal(u_row_ptrs_ref, u_row_ptrs_ref + num_row_ptrs,
+                           u_row_ptrs_omp));
 }
 
 
@@ -159,18 +186,20 @@ TEST_F(ParIlu, KernelComputeParILUIsEquivalentToRef)
     auto coo_omp = Coo::create(omp);
     csr_omp->convert_to(gko::lend(coo_omp));
     initialize_lu(&l_ref, &u_ref, &l_omp, &u_omp);
-    auto u_transpose_ref = u_ref->transpose();
-    auto u_transpose_omp = u_omp->transpose();
+    auto u_transpose_lin_op_ref = u_ref->transpose();
+    auto u_transpose_ptr_ref = static_cast<Csr *>(u_transpose_lin_op_ref.get());
+    auto u_transpose_lin_op_omp = u_omp->transpose();
+    auto u_transpose_ptr_omp = static_cast<Csr *>(u_transpose_lin_op_omp.get());
 
     gko::kernels::reference::par_ilu_factorization::compute_l_u_factors(
         ref, iterations, gko::lend(coo_ref), gko::lend(l_ref),
-        gko::lend(u_ref));
+        u_transpose_ptr_ref);
     gko::kernels::omp::par_ilu_factorization::compute_l_u_factors(
         omp, iterations, gko::lend(coo_omp), gko::lend(l_omp),
-        gko::lend(u_omp));
+        u_transpose_ptr_omp);
 
-    GKO_ASSERT_MTX_NEAR(l_ref, l_omp, .3);
-    GKO_ASSERT_MTX_NEAR(u_ref, u_omp, .3);
+    GKO_ASSERT_MTX_NEAR(l_ref, l_omp, 5e-3);
+    GKO_ASSERT_MTX_NEAR(u_transpose_ptr_ref, u_transpose_ptr_omp, 5e-3);
 }
 
 

--- a/omp/test/factorization/par_ilu_kernels.cpp
+++ b/omp/test/factorization/par_ilu_kernels.cpp
@@ -92,8 +92,10 @@ protected:
     std::shared_ptr<const Csr> csr_ref;
     std::shared_ptr<const Csr> csr_omp;
 
-    void compute_nnz(index_type *l_row_ptrs_ref, index_type *u_row_ptrs_ref,
-                     index_type *l_row_ptrs_omp, index_type *u_row_ptrs_omp)
+    void initialize_row_ptrs(index_type *l_row_ptrs_ref,
+                             index_type *u_row_ptrs_ref,
+                             index_type *l_row_ptrs_omp,
+                             index_type *u_row_ptrs_omp)
     {
         gko::kernels::reference::par_ilu_factorization::initialize_row_ptrs_l_u(
             ref, gko::lend(csr_ref), l_row_ptrs_ref, u_row_ptrs_ref);
@@ -110,10 +112,11 @@ protected:
         gko::Array<index_type> l_row_ptrs_omp{omp, num_row_ptrs};
         gko::Array<index_type> u_row_ptrs_omp{omp, num_row_ptrs};
 
-        compute_nnz(l_row_ptrs_ref.get_data(), u_row_ptrs_ref.get_data(),
-                    l_row_ptrs_omp.get_data(), u_row_ptrs_omp.get_data());
-        // Since `compute_nnz` was already tested, it is expected that `*_ref`
-        // and `*_omp` contain identical values
+        initialize_row_ptrs(
+            l_row_ptrs_ref.get_data(), u_row_ptrs_ref.get_data(),
+            l_row_ptrs_omp.get_data(), u_row_ptrs_omp.get_data());
+        // Since `initialize_row_ptrs` was already tested, it is expected that
+        // `*_ref` and `*_omp` contain identical values
         auto l_nnz = l_row_ptrs_ref.get_const_data()[num_row_ptrs - 1];
         auto u_nnz = u_row_ptrs_ref.get_const_data()[num_row_ptrs - 1];
 
@@ -136,6 +139,41 @@ protected:
         gko::kernels::omp::par_ilu_factorization::initialize_l_u(
             omp, gko::lend(csr_omp), gko::lend(*l_omp), gko::lend(*u_omp));
     }
+
+    template <typename ToType, typename FromType>
+    static std::unique_ptr<ToType> static_unique_ptr_cast(
+        std::unique_ptr<FromType> &&from)
+    {
+        return std::unique_ptr<ToType>{static_cast<ToType *>(from.release())};
+    }
+
+    void compute_lu(std::unique_ptr<Csr> *l_ref, std::unique_ptr<Csr> *u_ref,
+                    std::unique_ptr<Csr> *l_omp, std::unique_ptr<Csr> *u_omp,
+                    gko::size_type iterations = 0)
+    {
+        auto coo_ref = Coo::create(ref);
+        csr_ref->convert_to(gko::lend(coo_ref));
+        auto coo_omp = Coo::create(omp);
+        csr_omp->convert_to(gko::lend(coo_omp));
+        initialize_lu(l_ref, u_ref, l_omp, u_omp);
+        auto u_transpose_lin_op_ref = (*u_ref)->transpose();
+        auto u_transpose_csr_ref =
+            static_unique_ptr_cast<Csr>(std::move(u_transpose_lin_op_ref));
+        auto u_transpose_lin_op_omp = (*u_omp)->transpose();
+        auto u_transpose_csr_omp =
+            static_unique_ptr_cast<Csr>(std::move(u_transpose_lin_op_omp));
+
+        gko::kernels::reference::par_ilu_factorization::compute_l_u_factors(
+            ref, iterations, gko::lend(coo_ref), gko::lend(*l_ref),
+            gko::lend(u_transpose_csr_ref));
+        gko::kernels::omp::par_ilu_factorization::compute_l_u_factors(
+            omp, iterations, gko::lend(coo_omp), gko::lend(*l_omp),
+            gko::lend(u_transpose_csr_omp));
+        auto u_lin_op_ref = u_transpose_csr_ref->transpose();
+        *u_ref = static_unique_ptr_cast<Csr>(std::move(u_lin_op_ref));
+        auto u_lin_op_omp = u_transpose_csr_omp->transpose();
+        *u_omp = static_unique_ptr_cast<Csr>(std::move(u_lin_op_omp));
+    }
 };
 
 
@@ -151,7 +189,8 @@ TEST_F(ParIlu, OmpKernelInitializeRowPtrsLUEquivalentToRef)
     auto l_row_ptrs_omp = l_row_ptrs_array_omp.get_data();
     auto u_row_ptrs_omp = u_row_ptrs_array_omp.get_data();
 
-    compute_nnz(l_row_ptrs_ref, u_row_ptrs_ref, l_row_ptrs_omp, u_row_ptrs_omp);
+    initialize_row_ptrs(l_row_ptrs_ref, u_row_ptrs_ref, l_row_ptrs_omp,
+                        u_row_ptrs_omp);
 
     ASSERT_TRUE(std::equal(l_row_ptrs_ref, l_row_ptrs_ref + num_row_ptrs,
                            l_row_ptrs_omp));
@@ -180,26 +219,26 @@ TEST_F(ParIlu, KernelComputeParILUIsEquivalentToRef)
     std::unique_ptr<Csr> u_ref{};
     std::unique_ptr<Csr> l_omp{};
     std::unique_ptr<Csr> u_omp{};
-    gko::size_type iterations{};
-    auto coo_ref = Coo::create(ref);
-    csr_ref->convert_to(gko::lend(coo_ref));
-    auto coo_omp = Coo::create(omp);
-    csr_omp->convert_to(gko::lend(coo_omp));
-    initialize_lu(&l_ref, &u_ref, &l_omp, &u_omp);
-    auto u_transpose_lin_op_ref = u_ref->transpose();
-    auto u_transpose_ptr_ref = static_cast<Csr *>(u_transpose_lin_op_ref.get());
-    auto u_transpose_lin_op_omp = u_omp->transpose();
-    auto u_transpose_ptr_omp = static_cast<Csr *>(u_transpose_lin_op_omp.get());
 
-    gko::kernels::reference::par_ilu_factorization::compute_l_u_factors(
-        ref, iterations, gko::lend(coo_ref), gko::lend(l_ref),
-        u_transpose_ptr_ref);
-    gko::kernels::omp::par_ilu_factorization::compute_l_u_factors(
-        omp, iterations, gko::lend(coo_omp), gko::lend(l_omp),
-        u_transpose_ptr_omp);
+    compute_lu(&l_ref, &u_ref, &l_omp, &u_omp);
 
     GKO_ASSERT_MTX_NEAR(l_ref, l_omp, 5e-3);
-    GKO_ASSERT_MTX_NEAR(u_transpose_ptr_ref, u_transpose_ptr_omp, 5e-3);
+    GKO_ASSERT_MTX_NEAR(u_ref, u_omp, 5e-3);
+}
+
+
+TEST_F(ParIlu, KernelComputeParILUWithMoreIterationsIsEquivalentToRef)
+{
+    std::unique_ptr<Csr> l_ref{};
+    std::unique_ptr<Csr> u_ref{};
+    std::unique_ptr<Csr> l_omp{};
+    std::unique_ptr<Csr> u_omp{};
+    gko::size_type iterations{20};
+
+    compute_lu(&l_ref, &u_ref, &l_omp, &u_omp, iterations);
+
+    GKO_ASSERT_MTX_NEAR(l_ref, l_omp, 1e-14);
+    GKO_ASSERT_MTX_NEAR(u_ref, u_omp, 1e-14);
 }
 
 

--- a/omp/test/factorization/par_ilu_kernels.cpp
+++ b/omp/test/factorization/par_ilu_kernels.cpp
@@ -139,7 +139,7 @@ protected:
 };
 
 
-TEST_F(ParIlu, OmpKernelComputeNnzLUEquivalentToRef)
+TEST_F(ParIlu, OmpKernelInitializeRowPtrsLUEquivalentToRef)
 {
     auto num_row_ptrs = csr_ref->get_size()[0] + 1;
     gko::Array<index_type> l_row_ptrs_array_ref(ref, num_row_ptrs);


### PR DESCRIPTION
Mostly, this PR is to allow more parallelization in the creation of the `ParIlu`. In addition, this PR fixes some errors in testing.
This is the (potentially incomplete) list what was changed:
- Instead of just computing the nnz of L and U, the CSR `row_ptrs` are computed in the first kernel, allowing for better parallelization
- Now checking if the `system_matrix` given to factory is square (including a test that checks if it is working)
- Fixed errors in omp test (leading to a lower epsilon in comparison)
- Computation of omp `initialize_row_ptrs_l_u` is now done (partially) in parallel

For the `initialize_row`, I did a brief benchmark (10 runs averaged) on my laptop with matrix [bone010.mtx](https://sparse.tamu.edu/Oberwolfach/bone010) (`47,851,783` nonzeros):
```
Duration reference: 36551145 ns
Duration OpenMP:    19150018 ns
```
So the parallel Implementation is faster.