### PR TITLE
Fix CGS logging and update containers

### DIFF
--- a/core/solver/cgs.cpp
+++ b/core/solver/cgs.cpp
@@ -126,6 +126,11 @@ void Cgs<ValueType>::apply_impl(const LinOp *b, LinOp *x) const
         exec->run(cgs::make_step_2(u.get(), v_hat.get(), q.get(), t.get(),
                                    alpha.get(), rho.get(), gamma.get(),
                                    &stop_status));
+
+        ++iter;
+        this->template log<log::Logger::iteration_complete>(this, iter, r.get(),
+                                                            dense_x);
+
         // alpha = rho / gamma
         // q = u - alpha * v_hat
         // t = u + q
@@ -136,7 +141,7 @@ void Cgs<ValueType>::apply_impl(const LinOp *b, LinOp *x) const
         // r = r -alpha * t
         // x = x + alpha * u_hat
 
-        iter += 2;
+        ++iter;
         this->template log<log::Logger::iteration_complete>(this, iter, r.get(),
                                                             dense_x);
         if (stop_criterion->update()

--- a/dev_tools/containers/ginkgo-cuda-base.py
+++ b/dev_tools/containers/ginkgo-cuda-base.py
@@ -1,14 +1,15 @@
 """
 Ginkgo Base image
 Contents:
-	CUDA version set by the user
-	GNU compilers version set by the user
-	LLVM/Clang clang-tidy version set by the user
-	OpenMP latest apt version for Clang+OpenMP
-	Python 2 and 3 (upstream)
-	cmake (upstream)
-	git, openssh, doxygen, curl, valgrind, graphviz, jq latest apt version
-	iwyu precompiled version 6.0
+    CUDA version set by the user
+    GNU compilers version set by the user
+    LLVM/Clang clang-tidy version set by the user
+    OpenMP latest apt version for Clang+OpenMP
+    Python 2 and 3 (upstream)
+    cmake (upstream)
+    git, openssh, doxygen, curl, valgrind, graphviz, jq latest apt version
+    build-essential, automake, pkg-config, libtool, latest apt version
+    iwyu precompiled version 6.0
 """
 # pylint: disable=invalid-name, undefined-variable, used-before-assignment
 
@@ -16,8 +17,27 @@ import os
 
 cuda_version = USERARG.get('cuda', '10.0')
 
-image = 'nvidia/cuda:{}-devel-ubuntu16.04'.format(cuda_version)
-Stage0.baseimage(image)
+if float(cuda_version) < float(9.2):
+    image = 'nvidia/cuda:{}-devel-ubuntu16.04'.format(cuda_version)
+    Stage0.baseimage(image)
+else:
+    image = 'nvidia/cuda:{}-devel-ubuntu18.04'.format(cuda_version)
+    Stage0.baseimage(image)
+
+
+# Correctly set the LIBRARY_PATH
+Stage0 += environment(variables={'CUDA_INSTALL_PATH': '/usr/local/cuda/'})
+Stage0 += environment(variables={'CUDA_PATH': '/usr/local/cuda/'})
+Stage0 += environment(variables={'CUDA_ROOT': '/usr/local/cuda/'})
+Stage0 += environment(variables={'CUDA_SDK': '/usr/local/cuda/'})
+Stage0 += environment(variables={'CUDA_INC_PATH': '/usr/local/cuda/include'})
+Stage0 += environment(variables={'PATH': '$PATH:/usr/local/cuda/bin'})
+Stage0 += environment(variables={'LIBRARY_PATH': '$LIBRARY_PATH:/usr/local/cuda/lib64/stubs'})
+Stage0 += environment(variables={'LD_LIBRARY_PATH': '$LD_LIBRARY_PATH:/usr/local/cuda/lib64/stubs'})
+Stage0 += environment(variables={'LD_RUN_PATH': 'usr/local/cuda/lib64/stubs'})
+Stage0 += environment(variables={'INCLUDEPATH': '/usr/local/cuda/include'})
+Stage0 += environment(variables={'CPATH': '/usr/local/cuda/include'})
+Stage0 += environment(variables={'MANPATH': '/usr/local/cuda/doc/man'})
 
 
 # Setup extra tools
@@ -25,6 +45,8 @@ Stage0 += python()
 Stage0 += cmake(eula=True)
 Stage0 += apt_get(ospackages=['git', 'openssh-client', 'doxygen', 'curl', 'valgrind', 'graphviz'])
 Stage0 += apt_get(ospackages=['jq', 'iwyu'])
+Stage0 += apt_get(ospackages=['build-essential', 'automake', 'pkg-config', 'libtool'])
+
 
 # GNU compilers
 gnu_version = USERARG.get('gnu', '7')
@@ -43,12 +65,20 @@ Stage0 += shell(commands=clangtidyln)
 
 # IWYU
 if os.path.isdir('bin/'):
-        Stage0 += copy(src='bin/*', dest='/usr/bin/')
+    Stage0 += copy(src='bin/*', dest='/usr/bin/')
 
 if os.path.isdir('sonar-scanner/'):
-        Stage0 += copy(src='sonar-scanner/', dest='/')
+    Stage0 += copy(src='sonar-scanner/', dest='/')
 
-# Correctly set the LIBRARY_PATH
-Stage0 += environment(variables={'LIBRARY_PATH': '/usr/local/cuda/lib64/stubs'})
-Stage0 += environment(variables={'LD_LIBRARY_PATH': '/usr/local/cuda/lib64/stubs'})
+# hwloc
+if float(cuda_version) >= float(9.2):
+    Stage0 += shell(commands=['cd /var/tmp',
+                              'git clone https://github.com/open-mpi/hwloc.git hwloc'])
+    Stage0 += shell(commands=['cd /var/tmp/hwloc', './autogen.sh',
+                              './configure --prefix=/usr --disable-nvml', 'make -j10', 'make install'])
 
+    # upload valid FineCI topology and set it for hwloc
+    if os.path.isfile('topology/fineci.xml'):
+        Stage0 += copy(src='topology/fineci.xml', dest='/')
+        Stage0 += environment(variables={'HWLOC_XMLFILE': '/fineci.xml'})
+        Stage0 += environment(variables={'HWLOC_THISSYSTEM': '1'})

--- a/dev_tools/containers/ginkgo-nocuda-base.py
+++ b/dev_tools/containers/ginkgo-nocuda-base.py
@@ -1,17 +1,18 @@
 """
 Ginkgo Base image
 Contents:
-	GNU compilers version set by the user
-	LLVM/Clang version set by the user
-	OpenMP latest apt version for Clang+OpenMP
-	Python 2 and 3 (upstream)
-	cmake (upstream)
-	build-essential, git, openssh, doxygen, curl, valgrind latest apt version
-	jq, graphviz, ghostscript, texlive, texlive-latex-extra, latest apt version
-	texlive-science, texlive-fonts-extra, texlive-publishers latest apt version
-	clang-tidy, iwyu: latest apt version
-	papi: adds package libpfm4, and copy precompiled papi headers and files
-            from a directory called 'papi'
+    GNU compilers version set by the user
+    LLVM/Clang version set by the user
+    OpenMP latest apt version for Clang+OpenMP
+    Python 2 and 3 (upstream)
+    cmake (upstream)
+    build-essential, git, openssh, doxygen, curl, valgrind latest apt version
+    jq, graphviz, ghostscript, texlive, texlive-latex-extra, latest apt version
+    texlive-science, texlive-fonts-extra, texlive-publishers latest apt version
+    clang-tidy, iwyu: latest apt version
+    hwloc, libhwloc-dev, pkg-config latest apt version
+    papi: adds package libpfm4, and copy precompiled papi headers and files
+          from a directory called 'papi'
 """
 # pylint: disable=invalid-name, undefined-variable, used-before-assignment
 
@@ -27,6 +28,7 @@ Stage0 += apt_get(ospackages=['build-essential', 'git', 'openssh-client', 'doxyg
 Stage0 += apt_get(ospackages=['jq', 'graphviz', 'ghostscript', 'texlive', 'texlive-latex-extra'])
 Stage0 += apt_get(ospackages=['texlive-science', 'texlive-fonts-extra', 'texlive-publishers'])
 Stage0 += apt_get(ospackages=['clang-tidy', 'iwyu'])
+Stage0 += apt_get(ospackages=['hwloc', 'libhwloc-dev', 'pkg-config'])
 
 # GNU compilers
 gnu_version = USERARG.get('gnu', '8')

--- a/dev_tools/containers/gko-cuda100-gnu7-llvm60.baseimage
+++ b/dev_tools/containers/gko-cuda100-gnu7-llvm60.baseimage
@@ -1,4 +1,28 @@
-FROM nvidia/cuda:10.0-devel-ubuntu16.04 AS stage0
+FROM nvidia/cuda:10.0-devel-ubuntu18.04 AS stage0
+
+ENV CUDA_INSTALL_PATH=/usr/local/cuda/
+
+ENV CUDA_PATH=/usr/local/cuda/
+
+ENV CUDA_ROOT=/usr/local/cuda/
+
+ENV CUDA_SDK=/usr/local/cuda/
+
+ENV CUDA_INC_PATH=/usr/local/cuda/include
+
+ENV PATH=$PATH:/usr/local/cuda/bin
+
+ENV LIBRARY_PATH=$LIBRARY_PATH:/usr/local/cuda/lib64/stubs
+
+ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/cuda/lib64/stubs
+
+ENV LD_RUN_PATH=usr/local/cuda/lib64/stubs
+
+ENV INCLUDEPATH=/usr/local/cuda/include
+
+ENV CPATH=/usr/local/cuda/include
+
+ENV MANPATH=/usr/local/cuda/doc/man
 
 # Python
 RUN apt-get update -y && \
@@ -30,6 +54,14 @@ RUN apt-get update -y && \
     apt-get install -y --no-install-recommends \
         jq \
         iwyu && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN apt-get update -y && \
+    apt-get install -y --no-install-recommends \
+        build-essential \
+        automake \
+        pkg-config \
+        libtool && \
     rm -rf /var/lib/apt/lists/*
 
 # GNU compiler
@@ -73,8 +105,19 @@ COPY bin/* /usr/bin/
 
 COPY sonar-scanner/ /
 
-ENV LIBRARY_PATH=/usr/local/cuda/lib64/stubs
+RUN cd /var/tmp && \
+    git clone https://github.com/open-mpi/hwloc.git hwloc
 
-ENV LD_LIBRARY_PATH=/usr/local/cuda/lib64/stubs
+RUN cd /var/tmp/hwloc && \
+    ./autogen.sh && \
+    ./configure --prefix=/usr --disable-nvml && \
+    make -j10 && \
+    make install
+
+COPY topology/fineci.xml /
+
+ENV HWLOC_XMLFILE=/fineci.xml
+
+ENV HWLOC_THISSYSTEM=1
 
 

--- a/dev_tools/containers/gko-cuda90-gnu5-llvm39.baseimage
+++ b/dev_tools/containers/gko-cuda90-gnu5-llvm39.baseimage
@@ -1,5 +1,29 @@
 FROM nvidia/cuda:9.0-devel-ubuntu16.04 AS stage0
 
+ENV CUDA_INSTALL_PATH=/usr/local/cuda/
+
+ENV CUDA_PATH=/usr/local/cuda/
+
+ENV CUDA_ROOT=/usr/local/cuda/
+
+ENV CUDA_SDK=/usr/local/cuda/
+
+ENV CUDA_INC_PATH=/usr/local/cuda/include
+
+ENV PATH=$PATH:/usr/local/cuda/bin
+
+ENV LIBRARY_PATH=$LIBRARY_PATH:/usr/local/cuda/lib64/stubs
+
+ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/cuda/lib64/stubs
+
+ENV LD_RUN_PATH=usr/local/cuda/lib64/stubs
+
+ENV INCLUDEPATH=/usr/local/cuda/include
+
+ENV CPATH=/usr/local/cuda/include
+
+ENV MANPATH=/usr/local/cuda/doc/man
+
 # Python
 RUN apt-get update -y && \
     apt-get install -y --no-install-recommends \
@@ -30,6 +54,14 @@ RUN apt-get update -y && \
     apt-get install -y --no-install-recommends \
         jq \
         iwyu && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN apt-get update -y && \
+    apt-get install -y --no-install-recommends \
+        build-essential \
+        automake \
+        pkg-config \
+        libtool && \
     rm -rf /var/lib/apt/lists/*
 
 # GNU compiler
@@ -72,9 +104,5 @@ RUN ln -s /usr/bin/clang-tidy-3.9 /usr/bin/clang-tidy
 COPY bin/* /usr/bin/
 
 COPY sonar-scanner/ /
-
-ENV LIBRARY_PATH=/usr/local/cuda/lib64/stubs
-
-ENV LD_LIBRARY_PATH=/usr/local/cuda/lib64/stubs
 
 

--- a/dev_tools/containers/gko-cuda91-gnu6-llvm40.baseimage
+++ b/dev_tools/containers/gko-cuda91-gnu6-llvm40.baseimage
@@ -1,5 +1,29 @@
 FROM nvidia/cuda:9.1-devel-ubuntu16.04 AS stage0
 
+ENV CUDA_INSTALL_PATH=/usr/local/cuda/
+
+ENV CUDA_PATH=/usr/local/cuda/
+
+ENV CUDA_ROOT=/usr/local/cuda/
+
+ENV CUDA_SDK=/usr/local/cuda/
+
+ENV CUDA_INC_PATH=/usr/local/cuda/include
+
+ENV PATH=$PATH:/usr/local/cuda/bin
+
+ENV LIBRARY_PATH=$LIBRARY_PATH:/usr/local/cuda/lib64/stubs
+
+ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/cuda/lib64/stubs
+
+ENV LD_RUN_PATH=usr/local/cuda/lib64/stubs
+
+ENV INCLUDEPATH=/usr/local/cuda/include
+
+ENV CPATH=/usr/local/cuda/include
+
+ENV MANPATH=/usr/local/cuda/doc/man
+
 # Python
 RUN apt-get update -y && \
     apt-get install -y --no-install-recommends \
@@ -30,6 +54,14 @@ RUN apt-get update -y && \
     apt-get install -y --no-install-recommends \
         jq \
         iwyu && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN apt-get update -y && \
+    apt-get install -y --no-install-recommends \
+        build-essential \
+        automake \
+        pkg-config \
+        libtool && \
     rm -rf /var/lib/apt/lists/*
 
 # GNU compiler
@@ -72,9 +104,5 @@ RUN ln -s /usr/bin/clang-tidy-4.0 /usr/bin/clang-tidy
 COPY bin/* /usr/bin/
 
 COPY sonar-scanner/ /
-
-ENV LIBRARY_PATH=/usr/local/cuda/lib64/stubs
-
-ENV LD_LIBRARY_PATH=/usr/local/cuda/lib64/stubs
 
 

--- a/dev_tools/containers/gko-cuda92-gnu7-llvm50.baseimage
+++ b/dev_tools/containers/gko-cuda92-gnu7-llvm50.baseimage
@@ -1,4 +1,28 @@
-FROM nvidia/cuda:9.2-devel-ubuntu16.04 AS stage0
+FROM nvidia/cuda:9.2-devel-ubuntu18.04 AS stage0
+
+ENV CUDA_INSTALL_PATH=/usr/local/cuda/
+
+ENV CUDA_PATH=/usr/local/cuda/
+
+ENV CUDA_ROOT=/usr/local/cuda/
+
+ENV CUDA_SDK=/usr/local/cuda/
+
+ENV CUDA_INC_PATH=/usr/local/cuda/include
+
+ENV PATH=$PATH:/usr/local/cuda/bin
+
+ENV LIBRARY_PATH=$LIBRARY_PATH:/usr/local/cuda/lib64/stubs
+
+ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/cuda/lib64/stubs
+
+ENV LD_RUN_PATH=usr/local/cuda/lib64/stubs
+
+ENV INCLUDEPATH=/usr/local/cuda/include
+
+ENV CPATH=/usr/local/cuda/include
+
+ENV MANPATH=/usr/local/cuda/doc/man
 
 # Python
 RUN apt-get update -y && \
@@ -30,6 +54,14 @@ RUN apt-get update -y && \
     apt-get install -y --no-install-recommends \
         jq \
         iwyu && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN apt-get update -y && \
+    apt-get install -y --no-install-recommends \
+        build-essential \
+        automake \
+        pkg-config \
+        libtool && \
     rm -rf /var/lib/apt/lists/*
 
 # GNU compiler
@@ -73,8 +105,19 @@ COPY bin/* /usr/bin/
 
 COPY sonar-scanner/ /
 
-ENV LIBRARY_PATH=/usr/local/cuda/lib64/stubs
+RUN cd /var/tmp && \
+    git clone https://github.com/open-mpi/hwloc.git hwloc
 
-ENV LD_LIBRARY_PATH=/usr/local/cuda/lib64/stubs
+RUN cd /var/tmp/hwloc && \
+    ./autogen.sh && \
+    ./configure --prefix=/usr --disable-nvml && \
+    make -j10 && \
+    make install
+
+COPY topology/fineci.xml /
+
+ENV HWLOC_XMLFILE=/fineci.xml
+
+ENV HWLOC_THISSYSTEM=1
 
 

--- a/dev_tools/containers/gko-nocuda-gnu8-llvm70.baseimage
+++ b/dev_tools/containers/gko-nocuda-gnu8-llvm70.baseimage
@@ -48,6 +48,13 @@ RUN apt-get update -y && \
         iwyu && \
     rm -rf /var/lib/apt/lists/*
 
+RUN apt-get update -y && \
+    apt-get install -y --no-install-recommends \
+        hwloc \
+        libhwloc-dev \
+        pkg-config && \
+    rm -rf /var/lib/apt/lists/*
+
 # GNU compiler
 RUN apt-get update -y && \
     apt-get install -y --no-install-recommends software-properties-common && \


### PR DESCRIPTION
This is a small PR which fixes a small problem with the way CGS is logged and updates the containers. Here are the description of the two commits:

### CGS logging
Report subiteration residuals through `iteration_complete` for CGS.

+ Previously, when running the CGS solver for 100 iterations only 50 residuals
would be reported because one loop does two iterations.
+ Currently, the same residual and solution vectors are reported twice as
these are computed only every two iterations (once per loop run).

### Container update
Update the containers with new functionalities.

+ Add Ubuntu 18.04 support for CUDA containers (cuda 9.2 and more supported only).
+ Correctly set the environment variables with CUDA paths
+ Add support for automake, pkg-config and libtool.
+ Add hwloc support and integrate a topology file of the machine. This has to be
done since hwloc has trouble finding CUDA devices inside the container.
