### PR TITLE
Fixed issue with Apple's clang++ 10 compiler

### DIFF
--- a/core/base/iterator_factory.hpp
+++ b/core/base/iterator_factory.hpp
@@ -86,6 +86,11 @@ private:
     struct element {
         ToSortType dominant;
         SecondaryType secondary;
+
+        friend bool operator<(const element &left, const element &right)
+        {
+            return left.dominant < right.dominant;
+        }
     };
 
     /**

--- a/core/test/base/iterator_factory.cpp
+++ b/core/test/base/iterator_factory.cpp
@@ -79,7 +79,8 @@ protected:
 
             // Test all combinations of the `<` operator
             if (*(begin + 1) < *begin || next_ref < curr_ref ||
-                next_ref < curr_val || next_val < curr_ref) {
+                next_ref < curr_val || next_val < curr_ref ||
+                next_val < curr_val) {
                 return false;
             }
         }


### PR DESCRIPTION
Added `operator<` for the `element` helper class in the `IteratorFactory`, so `std::sort` also works with Apple's clang++ 10.

Closes #330 