### PR TITLE
Fixed slow COO SpMV for the OpenMP executor

### DIFF
--- a/omp/matrix/coo_kernels.cpp
+++ b/omp/matrix/coo_kernels.cpp
@@ -109,8 +109,8 @@ void spmv2(std::shared_ptr<const OmpExecutor> exec,
     auto num_cols = b->get_size()[1];
 
 #pragma omp parallel for
-    for (size_type i = 0; i < a->get_num_stored_elements(); i++) {
-        for (size_type j = 0; j < num_cols; j++) {
+    for (size_type j = 0; j < num_cols; j++) {
+        for (size_type i = 0; i < a->get_num_stored_elements(); i++) {
             c->at(coo_row[i], j) += coo_val[i] * b->at(coo_col[i], j);
         }
     }
@@ -133,8 +133,8 @@ void advanced_spmv2(std::shared_ptr<const OmpExecutor> exec,
     auto num_cols = b->get_size()[1];
 
 #pragma omp parallel for
-    for (size_type i = 0; i < a->get_num_stored_elements(); i++) {
-        for (size_type j = 0; j < num_cols; j++) {
+    for (size_type j = 0; j < num_cols; j++) {
+        for (size_type i = 0; i < a->get_num_stored_elements(); i++) {
             c->at(coo_row[i], j) +=
                 alpha_val * coo_val[i] * b->at(coo_col[i], j);
         }

--- a/omp/matrix/coo_kernels.cpp
+++ b/omp/matrix/coo_kernels.cpp
@@ -108,8 +108,8 @@ void spmv2(std::shared_ptr<const OmpExecutor> exec,
     auto coo_row = a->get_const_row_idxs();
     auto num_cols = b->get_size()[1];
 
-    for (size_type i = 0; i < a->get_num_stored_elements(); i++) {
 #pragma omp parallel for
+    for (size_type i = 0; i < a->get_num_stored_elements(); i++) {
         for (size_type j = 0; j < num_cols; j++) {
             c->at(coo_row[i], j) += coo_val[i] * b->at(coo_col[i], j);
         }
@@ -132,8 +132,8 @@ void advanced_spmv2(std::shared_ptr<const OmpExecutor> exec,
     auto alpha_val = alpha->at(0, 0);
     auto num_cols = b->get_size()[1];
 
-    for (size_type i = 0; i < a->get_num_stored_elements(); i++) {
 #pragma omp parallel for
+    for (size_type i = 0; i < a->get_num_stored_elements(); i++) {
         for (size_type j = 0; j < num_cols; j++) {
             c->at(coo_row[i], j) +=
                 alpha_val * coo_val[i] * b->at(coo_col[i], j);


### PR DESCRIPTION
Changed the order of the loops in the OpenMP COO SpMV, so the `pragma` is in the outer loop.

I ran some tests on my laptop (matrix: `5320 x 2310`, 100 right hand sides), 5 consecutive `apply`s for each executor (not averaged, time shown is the sum over all 5 passes):
```
Before this PR (current develop):
Duration ref [us]: 1464703
Duration omp [us]: 76439644

With this PR:
Duration ref [us]: 1421583
Duration omp [us]: 3172356
```

I was able to run it on the CI system (`OMP_NUM_THREADS=10`), and I get these results (same settings as on my laptop, listed above):
```
Before this PR:
Duration ref [us]: 3134603
Duration omp [us]: 70496128

With this PR:
Duration ref [us]: 3246514
Duration omp [us]: 1227014
```
Now, same test with `OMP_NUM_THREADS=40`:
```
Before this PR:
Duration ref [us]: 3132254
Duration omp [us]: 315196010

With this PR:
Duration ref [us]: 3129671
Duration omp [us]: 881428
```


So, I would say we keep the `pragma`s for the number of right hand sides.

Closes #339