### PR TITLE
CUDA Coo spmm implementaion

### DIFF
--- a/cuda/matrix/coo_kernels.cu
+++ b/cuda/matrix/coo_kernels.cu
@@ -48,6 +48,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "cuda/components/cooperative_groups.cuh"
 #include "cuda/components/format_conversion.cuh"
 #include "cuda/components/segment_scan.cuh"
+#include "cuda/components/zero_array.hpp"
 
 
 namespace gko {
@@ -140,57 +141,6 @@ __device__ void spmv_kernel(const size_type nnz, const size_type num_lines,
 }
 
 
-template <typename ValueType, typename IndexType, typename Closure>
-__device__ void spmm_kernel(const size_type nnz, const size_type num_lines,
-                            const ValueType *__restrict__ val,
-                            const IndexType *__restrict__ col,
-                            const IndexType *__restrict__ row,
-                            const size_type start_col, const size_type end_col,
-                            const ValueType *__restrict__ b,
-                            const size_type b_stride, ValueType *__restrict__ c,
-                            const size_type c_stride, Closure scale)
-{
-    ValueType temp = zero<ValueType>();
-    const auto coo_idx =
-        (static_cast<size_type>(blockDim.y) * blockIdx.x + threadIdx.y) *
-        num_lines;
-    const auto column_id = start_col + threadIdx.x;
-    auto coo_end = coo_idx + num_lines;
-    coo_end = (coo_end > nnz) ? nnz : coo_end;
-    if (column_id < end_col && coo_idx < nnz) {
-        auto curr_row = row[coo_idx];
-        for (auto idx = coo_idx; idx < coo_end - 1; idx++) {
-            temp += val[idx] * b[col[idx] * b_stride + column_id];
-            const auto next_row = row[idx + 1];
-            if (next_row != curr_row) {
-                atomic_add(&(c[curr_row * c_stride + column_id]), scale(temp));
-                curr_row = next_row;
-                temp = zero<ValueType>();
-            }
-        }
-        auto idx = coo_end - 1;
-        temp += val[idx] * b[col[idx] * b_stride + column_id];
-        atomic_add(&(c[row[idx] * c_stride + column_id]), scale(temp));
-    }
-}
-
-
-template <typename ValueType, typename IndexType>
-__global__ __launch_bounds__(spmv_block_size) void abstract_spmm(
-    const size_type nnz, const size_type num_lines,
-    const ValueType *__restrict__ val, const IndexType *__restrict__ col,
-    const IndexType *__restrict__ row, const size_type num_cols,
-    const ValueType *__restrict__ b, const size_type b_stride,
-    ValueType *__restrict__ c, const size_type c_stride)
-{
-    for (size_type i = 0; i < num_cols; i += 16) {
-        spmm_kernel(nnz, num_lines, val, col, row, i, min(i + 16, num_cols), b,
-                    b_stride, c, c_stride,
-                    [](const ValueType &x) { return x; });
-    }
-}
-
-
 template <typename ValueType, typename IndexType>
 __global__ __launch_bounds__(spmv_block_size) void abstract_spmv(
     const size_type nnz, const size_type num_lines,
@@ -219,15 +169,162 @@ __global__ __launch_bounds__(spmv_block_size) void abstract_spmv(
 }
 
 
-template <typename ValueType>
-__global__ __launch_bounds__(default_block_size) void set_zero(
-    const size_type nnz, ValueType *__restrict__ val)
+template <bool force, bool final, int subwarp_size = cuda_config::warp_size,
+          typename Group, typename ValueType, typename IndexType,
+          typename Closure>
+__device__ void warp_spmm(
+    const Group tile_block, const size_type nnz,
+    const ValueType *__restrict__ val, const IndexType *__restrict__ col,
+    const IndexType *__restrict__ row, const ValueType *__restrict__ b,
+    const size_type b_stride, ValueType *__restrict__ c,
+    const size_type c_stride, IndexType *__restrict__ curr_row,
+    ValueType *__restrict__ temp, const size_type offset,
+    const size_type column_id, const size_type end_col, Closure scale)
 {
-    const auto ind =
-        static_cast<size_type>(blockDim.x) * blockIdx.x + threadIdx.x;
-    if (ind < nnz) {
-        val[ind] = zero<ValueType>();
+    const auto coo_val =
+        (!final || offset < nnz) ? val[offset] : zero<ValueType>();
+    const auto col_id = (column_id < end_col) ? column_id : end_col - 1;
+    const auto coo_col = (!final || offset < nnz) ? col[offset] : col[nnz - 1];
+    int j = 0;
+    auto temp_row = tile_block.shfl(*curr_row, 0);
+
+    if (!final) {
+        constexpr int end = subwarp_size;
+#pragma unroll
+        for (; j < end - 1; j++) {
+            const auto temp_next_row = tile_block.shfl(*curr_row, j + 1);
+            *temp += tile_block.shfl(coo_val, j) *
+                     b[tile_block.shfl(coo_col, j) * b_stride + col_id];
+            if (temp_row != temp_next_row) {
+                if (column_id < end_col) {
+                    atomic_add(&(c[temp_row * c_stride + col_id]),
+                               scale(*temp));
+                }
+                *temp = zero<ValueType>();
+                temp_row = temp_next_row;
+            }
+        }
+    } else {
+        const int end =
+            min(static_cast<int>(nnz - (offset - threadIdx.x)), subwarp_size);
+#pragma unroll
+        for (; j < end - 1; j++) {
+            const auto temp_next_row = tile_block.shfl(*curr_row, j + 1);
+            *temp += tile_block.shfl(coo_val, j) *
+                     b[tile_block.shfl(coo_col, j) * b_stride + col_id];
+
+            if (temp_row != temp_next_row) {
+                if (column_id < end_col) {
+                    atomic_add(&(c[temp_row * c_stride + col_id]),
+                               scale(*temp));
+                }
+                *temp = zero<ValueType>();
+                temp_row = temp_next_row;
+            }
+        }
     }
+
+    *temp += tile_block.shfl(coo_val, j) *
+             b[tile_block.shfl(coo_col, j) * b_stride + col_id];
+    if (force) {
+        if (column_id < end_col) {
+            atomic_add(&(c[temp_row * c_stride + col_id]), scale(*temp));
+        }
+    } else {
+        const auto next_row = (!final || offset + subwarp_size < nnz)
+                                  ? row[offset + subwarp_size]
+                                  : row[nnz - 1];
+        if (tile_block.shfl(next_row, 0) != temp_row) {
+            if (column_id < end_col) {
+                atomic_add(&(c[temp_row * c_stride + col_id]), scale(*temp));
+            }
+            *temp = zero<ValueType>();
+        }
+        *curr_row = next_row;
+    }
+}
+
+template <int subwarp_size = cuda_config::warp_size, typename ValueType,
+          typename IndexType, typename Closure>
+__device__ void spmm_kernel(const size_type nnz, const size_type num_lines,
+                            const ValueType *__restrict__ val,
+                            const IndexType *__restrict__ col,
+                            const IndexType *__restrict__ row,
+                            const size_type end_col,
+                            const ValueType *__restrict__ b,
+                            const size_type b_stride, ValueType *__restrict__ c,
+                            const size_type c_stride, Closure scale)
+{
+    ValueType temp = zero<ValueType>();
+    const auto tidx = threadIdx.x;
+    auto coo_idx =
+        (static_cast<size_type>(blockDim.y) * blockIdx.x + threadIdx.y) *
+            num_lines * subwarp_size +
+        tidx;
+    const auto tile_block =
+        group::tiled_partition<subwarp_size>(group::this_thread_block());
+    const auto column_id = blockIdx.y * subwarp_size + tidx;
+    if (blockIdx.x == gridDim.x - 1) {
+        // The final block needs to check the index is valid
+        if (coo_idx - tidx < nnz) {
+            const int lines = min(
+                static_cast<int>(ceildiv(nnz - (coo_idx - tidx), subwarp_size)),
+                static_cast<int>(num_lines));
+            const auto coo_end = coo_idx + (lines - 1) * subwarp_size;
+            auto curr_row = (coo_idx < nnz) ? row[coo_idx] : row[nnz - 1];
+            for (; coo_idx < coo_end; coo_idx += subwarp_size) {
+                warp_spmm<false, true, subwarp_size>(
+                    tile_block, nnz, val, col, row, b, b_stride, c, c_stride,
+                    &curr_row, &temp, coo_idx, column_id, end_col, scale);
+            }
+            warp_spmm<true, true, subwarp_size>(
+                tile_block, nnz, val, col, row, b, b_stride, c, c_stride,
+                &curr_row, &temp, coo_end, column_id, end_col, scale);
+        }
+    } else {
+        auto curr_row = row[coo_idx];
+        const auto coo_end = coo_idx + (num_lines - 1) * subwarp_size;
+        for (; coo_idx < coo_end; coo_idx += subwarp_size) {
+            warp_spmm<false, false, subwarp_size>(
+                tile_block, nnz, val, col, row, b, b_stride, c, c_stride,
+                &curr_row, &temp, coo_idx, column_id, end_col, scale);
+        }
+        warp_spmm<true, false, subwarp_size>(
+            tile_block, nnz, val, col, row, b, b_stride, c, c_stride, &curr_row,
+            &temp, coo_end, column_id, end_col, scale);
+    }
+}
+
+
+template <int subwarp_size = cuda_config::warp_size, typename ValueType,
+          typename IndexType>
+__global__ __launch_bounds__(spmv_block_size) void abstract_spmm(
+    const size_type nnz, const size_type num_lines,
+    const ValueType *__restrict__ val, const IndexType *__restrict__ col,
+    const IndexType *__restrict__ row, const size_type num_cols,
+    const ValueType *__restrict__ b, const size_type b_stride,
+    ValueType *__restrict__ c, const size_type c_stride)
+{
+    spmm_kernel<subwarp_size>(nnz, num_lines, val, col, row, num_cols, b,
+                              b_stride, c, c_stride,
+                              [](const ValueType &x) { return x; });
+}
+
+
+template <int subwarp_size = cuda_config::warp_size, typename ValueType,
+          typename IndexType>
+__global__ __launch_bounds__(spmv_block_size) void abstract_spmm(
+    const size_type nnz, const size_type num_lines,
+    const ValueType *__restrict__ alpha, const ValueType *__restrict__ val,
+    const IndexType *__restrict__ col, const IndexType *__restrict__ row,
+    const size_type num_cols, const ValueType *__restrict__ b,
+    const size_type b_stride, ValueType *__restrict__ c,
+    const size_type c_stride)
+{
+    ValueType scale_factor = alpha[0];
+    spmm_kernel<subwarp_size>(
+        nnz, num_lines, val, col, row, num_cols, b, b_stride, c, c_stride,
+        [&scale_factor](const ValueType &x) { return scale_factor * x; });
 }
 
 
@@ -239,10 +336,7 @@ void spmv(std::shared_ptr<const CudaExecutor> exec,
           const matrix::Coo<ValueType, IndexType> *a,
           const matrix::Dense<ValueType> *b, matrix::Dense<ValueType> *c)
 {
-    auto nnz = c->get_num_stored_elements();
-    const dim3 grid(ceildiv(nnz, default_block_size));
-    const dim3 block(default_block_size);
-    set_zero<<<grid, block>>>(nnz, as_cuda_type(c->get_values()));
+    zero_array(c->get_num_stored_elements(), c->get_values());
 
     spmv2(exec, a, b, c);
 }
@@ -278,17 +372,19 @@ void spmv2(std::shared_ptr<const CudaExecutor> exec,
         if (b->get_size()[1] == 1) {
             int num_lines = ceildiv(nnz, nwarps * cuda_config::warp_size);
             const dim3 coo_block(cuda_config::warp_size, warps_in_block, 1);
-            const dim3 coo_grid(ceildiv(nwarps, warps_in_block),
-                                b->get_size()[1]);
+            const dim3 coo_grid(ceildiv(nwarps, warps_in_block));
             abstract_spmv<<<coo_grid, coo_block>>>(
                 nnz, num_lines, as_cuda_type(a->get_const_values()),
                 a->get_const_col_idxs(), as_cuda_type(a->get_const_row_idxs()),
                 as_cuda_type(b->get_const_values()), b->get_stride(),
                 as_cuda_type(c->get_values()), c->get_stride());
         } else {
-            int num_lines = ceildiv(nnz, nwarps * warps_in_block * 2);
-            const dim3 coo_block(16, warps_in_block * 2, 1);
-            const dim3 coo_grid(nwarps);
+            int num_lines = ceildiv(nnz, nwarps * cuda_config::warp_size);
+            const dim3 coo_block(cuda_config::warp_size, warps_in_block, 1);
+            const dim3 coo_grid(
+                ceildiv(nnz,
+                        num_lines * cuda_config::warp_size * warps_in_block),
+                ceildiv(b->get_size()[1], cuda_config::warp_size));
             abstract_spmm<<<coo_grid, coo_block>>>(
                 nnz, num_lines, as_cuda_type(a->get_const_values()),
                 a->get_const_col_idxs(), as_cuda_type(a->get_const_row_idxs()),
@@ -313,15 +409,30 @@ void advanced_spmv2(std::shared_ptr<const CudaExecutor> exec,
 
     auto nwarps = host_kernel::calculate_nwarps(exec, nnz);
     if (nwarps > 0) {
-        int num_lines = ceildiv(nnz, nwarps * cuda_config::warp_size);
-        const dim3 coo_block(cuda_config::warp_size, warps_in_block, 1);
-        const dim3 coo_grid(ceildiv(nwarps, warps_in_block), b->get_size()[1]);
-        abstract_spmv<<<coo_grid, coo_block>>>(
-            nnz, num_lines, as_cuda_type(alpha->get_const_values()),
-            as_cuda_type(a->get_const_values()), a->get_const_col_idxs(),
-            as_cuda_type(a->get_const_row_idxs()),
-            as_cuda_type(b->get_const_values()), b->get_stride(),
-            as_cuda_type(c->get_values()), c->get_stride());
+        if (b->get_size()[1] == 1) {
+            int num_lines = ceildiv(nnz, nwarps * cuda_config::warp_size);
+            const dim3 coo_block(cuda_config::warp_size, warps_in_block, 1);
+            const dim3 coo_grid(ceildiv(nwarps, warps_in_block));
+            abstract_spmv<<<coo_grid, coo_block>>>(
+                nnz, num_lines, as_cuda_type(alpha->get_const_values()),
+                as_cuda_type(a->get_const_values()), a->get_const_col_idxs(),
+                as_cuda_type(a->get_const_row_idxs()),
+                as_cuda_type(b->get_const_values()), b->get_stride(),
+                as_cuda_type(c->get_values()), c->get_stride());
+        } else {
+            int num_lines = ceildiv(nnz, nwarps * cuda_config::warp_size);
+            const dim3 coo_block(cuda_config::warp_size, warps_in_block, 1);
+            const dim3 coo_grid(
+                ceildiv(nnz,
+                        num_lines * cuda_config::warp_size * warps_in_block),
+                ceildiv(b->get_size()[1], cuda_config::warp_size));
+            abstract_spmm<<<coo_grid, coo_block>>>(
+                nnz, num_lines, as_cuda_type(alpha->get_const_values()),
+                as_cuda_type(a->get_const_values()), a->get_const_col_idxs(),
+                as_cuda_type(a->get_const_row_idxs()), b->get_size()[1],
+                as_cuda_type(b->get_const_values()), b->get_stride(),
+                as_cuda_type(c->get_values()), c->get_stride());
+        }
     }
 }
 

--- a/cuda/matrix/coo_kernels.cu
+++ b/cuda/matrix/coo_kernels.cu
@@ -84,7 +84,9 @@ namespace {
  * @param col  the column index array of the matrix
  * @param row  the row index array of the matrix
  * @param b  the input dense vector
+ * @param b_stride  the stride of the input dense vector
  * @param c  the output dense vector
+ * @param c_stride  the stride of the output dense vector
  * @param scale  the function on the added value
  */
 template <int subwarp_size = cuda_config::warp_size, typename ValueType,
@@ -169,154 +171,71 @@ __global__ __launch_bounds__(spmv_block_size) void abstract_spmv(
 }
 
 
-template <bool force, bool final, int subwarp_size = cuda_config::warp_size,
-          typename Group, typename ValueType, typename IndexType,
-          typename Closure>
-__device__ void warp_spmm(
-    const Group tile_block, const size_type nnz,
-    const ValueType *__restrict__ val, const IndexType *__restrict__ col,
-    const IndexType *__restrict__ row, const ValueType *__restrict__ b,
-    const size_type b_stride, ValueType *__restrict__ c,
-    const size_type c_stride, IndexType *__restrict__ curr_row,
-    ValueType *__restrict__ temp, const size_type offset,
-    const size_type column_id, const size_type end_col, Closure scale)
-{
-    const auto coo_val =
-        (!final || offset < nnz) ? val[offset] : zero<ValueType>();
-    const auto col_id = (column_id < end_col) ? column_id : end_col - 1;
-    const auto coo_col = (!final || offset < nnz) ? col[offset] : col[nnz - 1];
-    int j = 0;
-    auto temp_row = tile_block.shfl(*curr_row, 0);
-
-    if (!final) {
-        constexpr int end = subwarp_size - 1;
-#pragma unroll
-        for (; j < end; j++) {
-            const auto temp_next_row = tile_block.shfl(*curr_row, j + 1);
-            const auto tval = tile_block.shfl(coo_val, j);
-            const auto tcol = tile_block.shfl(coo_col, j);
-            *temp += tval * b[tcol * b_stride + col_id];
-            if (temp_row != temp_next_row) {
-                if (column_id < end_col) {
-                    atomic_add(&(c[temp_row * c_stride + col_id]),
-                               scale(*temp));
-                }
-                *temp = zero<ValueType>();
-                temp_row = temp_next_row;
-            }
-        }
-    } else {
-        const int end = min(nnz - (offset - threadIdx.x),
-                            static_cast<size_type>(subwarp_size)) -
-                        1;
-#pragma unroll
-        for (; j < end; j++) {
-            const auto temp_next_row = tile_block.shfl(*curr_row, j + 1);
-            const auto tval = tile_block.shfl(coo_val, j);
-            const auto tcol = tile_block.shfl(coo_col, j);
-            *temp += tval * b[tcol * b_stride + col_id];
-            if (temp_row != temp_next_row) {
-                if (column_id < end_col) {
-                    atomic_add(&(c[temp_row * c_stride + col_id]),
-                               scale(*temp));
-                }
-                *temp = zero<ValueType>();
-                temp_row = temp_next_row;
-            }
-        }
-    }
-
-    *temp += tile_block.shfl(coo_val, j) *
-             b[tile_block.shfl(coo_col, j) * b_stride + col_id];
-    if (force) {
-        if (column_id < end_col) {
-            atomic_add(&(c[temp_row * c_stride + col_id]), scale(*temp));
-        }
-    } else {
-        const auto next_row = (!final || offset + subwarp_size < nnz)
-                                  ? row[offset + subwarp_size]
-                                  : row[nnz - 1];
-        if (tile_block.shfl(next_row, 0) != temp_row) {
-            if (column_id < end_col) {
-                atomic_add(&(c[temp_row * c_stride + col_id]), scale(*temp));
-            }
-            *temp = zero<ValueType>();
-        }
-        *curr_row = next_row;
-    }
-}
-
-template <int subwarp_size = cuda_config::warp_size, typename ValueType,
-          typename IndexType, typename Closure>
-__device__ void spmm_kernel(const size_type nnz, const size_type num_lines,
+/**
+ * The device function of COO spmv
+ *
+ * @param nnz  the number of nonzeros in the matrix
+ * @param num_elems  the maximum number of nonzeros in each warp
+ * @param val  the value array of the matrix
+ * @param col  the column index array of the matrix
+ * @param row  the row index array of the matrix
+ * @param b  the input dense vector
+ * @param b_stride  the stride of the input dense vector
+ * @param c  the output dense vector
+ * @param c_stride  the stride of the output dense vector
+ * @param scale  the function on the added value
+ */
+template <typename ValueType, typename IndexType, typename Closure>
+__device__ void spmm_kernel(const size_type nnz, const size_type num_elems,
                             const ValueType *__restrict__ val,
                             const IndexType *__restrict__ col,
                             const IndexType *__restrict__ row,
-                            const size_type end_col,
+                            const size_type num_cols,
                             const ValueType *__restrict__ b,
                             const size_type b_stride, ValueType *__restrict__ c,
                             const size_type c_stride, Closure scale)
 {
     ValueType temp = zero<ValueType>();
-    const auto tidx = threadIdx.x;
-    auto coo_idx =
+    const auto coo_idx =
         (static_cast<size_type>(blockDim.y) * blockIdx.x + threadIdx.y) *
-            num_lines * subwarp_size +
-        tidx;
-    const auto tile_block =
-        group::tiled_partition<subwarp_size>(group::this_thread_block());
-    const auto column_id = blockIdx.y * subwarp_size + tidx;
-    if (blockIdx.x == gridDim.x - 1) {
-        // The final block needs to check the index is valid
-        if (coo_idx - tidx < nnz) {
-            const int lines = min(
-                static_cast<int>(ceildiv(nnz - (coo_idx - tidx), subwarp_size)),
-                static_cast<int>(num_lines));
-            const auto coo_end = coo_idx + (lines - 1) * subwarp_size;
-            auto curr_row = (coo_idx < nnz) ? row[coo_idx] : row[nnz - 1];
-            for (; coo_idx < coo_end; coo_idx += subwarp_size) {
-                warp_spmm<false, true, subwarp_size>(
-                    tile_block, nnz, val, col, row, b, b_stride, c, c_stride,
-                    &curr_row, &temp, coo_idx, column_id, end_col, scale);
-            }
-            warp_spmm<true, true, subwarp_size>(
-                tile_block, nnz, val, col, row, b, b_stride, c, c_stride,
-                &curr_row, &temp, coo_end, column_id, end_col, scale);
-        }
-    } else {
+        num_elems;
+    const auto column_id = blockIdx.y * blockDim.x + threadIdx.x;
+    const auto coo_end =
+        (coo_idx + num_elems > nnz) ? nnz : coo_idx + num_elems;
+    if (column_id < num_cols && coo_idx < nnz) {
         auto curr_row = row[coo_idx];
-        const auto coo_end = coo_idx + (num_lines - 1) * subwarp_size;
-        for (; coo_idx < coo_end; coo_idx += subwarp_size) {
-            warp_spmm<false, false, subwarp_size>(
-                tile_block, nnz, val, col, row, b, b_stride, c, c_stride,
-                &curr_row, &temp, coo_idx, column_id, end_col, scale);
+        auto idx = coo_idx;
+        for (; idx < coo_end - 1; idx++) {
+            temp += val[idx] * b[col[idx] * b_stride + column_id];
+            const auto next_row = row[idx + 1];
+            if (next_row != curr_row) {
+                atomic_add(&(c[curr_row * c_stride + column_id]), scale(temp));
+                curr_row = next_row;
+                temp = zero<ValueType>();
+            }
         }
-        warp_spmm<true, false, subwarp_size>(
-            tile_block, nnz, val, col, row, b, b_stride, c, c_stride, &curr_row,
-            &temp, coo_end, column_id, end_col, scale);
+        temp += val[idx] * b[col[idx] * b_stride + column_id];
+        atomic_add(&(c[curr_row * c_stride + column_id]), scale(temp));
     }
 }
 
 
-template <int subwarp_size = cuda_config::warp_size, typename ValueType,
-          typename IndexType>
+template <typename ValueType, typename IndexType>
 __global__ __launch_bounds__(spmv_block_size) void abstract_spmm(
-    const size_type nnz, const size_type num_lines,
+    const size_type nnz, const size_type num_elems,
     const ValueType *__restrict__ val, const IndexType *__restrict__ col,
     const IndexType *__restrict__ row, const size_type num_cols,
     const ValueType *__restrict__ b, const size_type b_stride,
     ValueType *__restrict__ c, const size_type c_stride)
 {
-    spmm_kernel<subwarp_size>(nnz, num_lines, val, col, row, num_cols, b,
-                              b_stride, c, c_stride,
-                              [](const ValueType &x) { return x; });
+    spmm_kernel(nnz, num_elems, val, col, row, num_cols, b, b_stride, c,
+                c_stride, [](const ValueType &x) { return x; });
 }
 
 
-template <int subwarp_size = cuda_config::warp_size, typename ValueType,
-          typename IndexType>
+template <typename ValueType, typename IndexType>
 __global__ __launch_bounds__(spmv_block_size) void abstract_spmm(
-    const size_type nnz, const size_type num_lines,
+    const size_type nnz, const size_type num_elems,
     const ValueType *__restrict__ alpha, const ValueType *__restrict__ val,
     const IndexType *__restrict__ col, const IndexType *__restrict__ row,
     const size_type num_cols, const ValueType *__restrict__ b,
@@ -324,8 +243,8 @@ __global__ __launch_bounds__(spmv_block_size) void abstract_spmm(
     const size_type c_stride)
 {
     ValueType scale_factor = alpha[0];
-    spmm_kernel<subwarp_size>(
-        nnz, num_lines, val, col, row, num_cols, b, b_stride, c, c_stride,
+    spmm_kernel(
+        nnz, num_elems, val, col, row, num_cols, b, b_stride, c, c_stride,
         [&scale_factor](const ValueType &x) { return scale_factor * x; });
 }
 
@@ -374,21 +293,22 @@ void spmv2(std::shared_ptr<const CudaExecutor> exec,
         if (b->get_size()[1] == 1) {
             int num_lines = ceildiv(nnz, nwarps * cuda_config::warp_size);
             const dim3 coo_block(cuda_config::warp_size, warps_in_block, 1);
-            const dim3 coo_grid(ceildiv(nwarps, warps_in_block));
+            const dim3 coo_grid(ceildiv(nwarps, warps_in_block),
+                                b->get_size()[1]);
             abstract_spmv<<<coo_grid, coo_block>>>(
                 nnz, num_lines, as_cuda_type(a->get_const_values()),
                 a->get_const_col_idxs(), as_cuda_type(a->get_const_row_idxs()),
                 as_cuda_type(b->get_const_values()), b->get_stride(),
                 as_cuda_type(c->get_values()), c->get_stride());
         } else {
-            int num_lines = ceildiv(nnz, nwarps * cuda_config::warp_size);
+            int num_elems = ceildiv(nnz, nwarps * cuda_config::warp_size) *
+                            cuda_config::warp_size;
             const dim3 coo_block(cuda_config::warp_size, warps_in_block, 1);
             const dim3 coo_grid(
-                ceildiv(nnz,
-                        num_lines * cuda_config::warp_size * warps_in_block),
+                ceildiv(nwarps, warps_in_block),
                 ceildiv(b->get_size()[1], cuda_config::warp_size));
             abstract_spmm<<<coo_grid, coo_block>>>(
-                nnz, num_lines, as_cuda_type(a->get_const_values()),
+                nnz, num_elems, as_cuda_type(a->get_const_values()),
                 a->get_const_col_idxs(), as_cuda_type(a->get_const_row_idxs()),
                 b->get_size()[1], as_cuda_type(b->get_const_values()),
                 b->get_stride(), as_cuda_type(c->get_values()),
@@ -422,14 +342,14 @@ void advanced_spmv2(std::shared_ptr<const CudaExecutor> exec,
                 as_cuda_type(b->get_const_values()), b->get_stride(),
                 as_cuda_type(c->get_values()), c->get_stride());
         } else {
-            int num_lines = ceildiv(nnz, nwarps * cuda_config::warp_size);
+            int num_elems = ceildiv(nnz, nwarps * cuda_config::warp_size) *
+                            cuda_config::warp_size;
             const dim3 coo_block(cuda_config::warp_size, warps_in_block, 1);
             const dim3 coo_grid(
-                ceildiv(nnz,
-                        num_lines * cuda_config::warp_size * warps_in_block),
+                ceildiv(nwarps, warps_in_block),
                 ceildiv(b->get_size()[1], cuda_config::warp_size));
             abstract_spmm<<<coo_grid, coo_block>>>(
-                nnz, num_lines, as_cuda_type(alpha->get_const_values()),
+                nnz, num_elems, as_cuda_type(alpha->get_const_values()),
                 as_cuda_type(a->get_const_values()), a->get_const_col_idxs(),
                 as_cuda_type(a->get_const_row_idxs()), b->get_size()[1],
                 as_cuda_type(b->get_const_values()), b->get_stride(),

--- a/cuda/matrix/coo_kernels.cu
+++ b/cuda/matrix/coo_kernels.cu
@@ -172,7 +172,7 @@ __global__ __launch_bounds__(spmv_block_size) void abstract_spmv(
 
 
 /**
- * The device function of COO spmv
+ * The device function of COO spmm
  *
  * @param nnz  the number of nonzeros in the matrix
  * @param num_elems  the maximum number of nonzeros in each warp
@@ -290,10 +290,10 @@ void spmv2(std::shared_ptr<const CudaExecutor> exec,
     auto nnz = a->get_num_stored_elements();
 
     auto nwarps = host_kernel::calculate_nwarps(exec, nnz);
+    const dim3 coo_block(cuda_config::warp_size, warps_in_block, 1);
     if (nwarps > 0) {
         if (b->get_size()[1] < 4) {
             int num_lines = ceildiv(nnz, nwarps * cuda_config::warp_size);
-            const dim3 coo_block(cuda_config::warp_size, warps_in_block, 1);
             const dim3 coo_grid(ceildiv(nwarps, warps_in_block),
                                 b->get_size()[1]);
             abstract_spmv<<<coo_grid, coo_block>>>(
@@ -304,7 +304,6 @@ void spmv2(std::shared_ptr<const CudaExecutor> exec,
         } else {
             int num_elems = ceildiv(nnz, nwarps * cuda_config::warp_size) *
                             cuda_config::warp_size;
-            const dim3 coo_block(cuda_config::warp_size, warps_in_block, 1);
             const dim3 coo_grid(
                 ceildiv(nwarps, warps_in_block),
                 ceildiv(b->get_size()[1], cuda_config::warp_size));
@@ -331,10 +330,10 @@ void advanced_spmv2(std::shared_ptr<const CudaExecutor> exec,
     auto nnz = a->get_num_stored_elements();
 
     auto nwarps = host_kernel::calculate_nwarps(exec, nnz);
+    const dim3 coo_block(cuda_config::warp_size, warps_in_block, 1);
     if (nwarps > 0) {
         if (b->get_size()[1] < 4) {
             int num_lines = ceildiv(nnz, nwarps * cuda_config::warp_size);
-            const dim3 coo_block(cuda_config::warp_size, warps_in_block, 1);
             const dim3 coo_grid(ceildiv(nwarps, warps_in_block),
                                 b->get_size()[1]);
             abstract_spmv<<<coo_grid, coo_block>>>(
@@ -346,7 +345,6 @@ void advanced_spmv2(std::shared_ptr<const CudaExecutor> exec,
         } else {
             int num_elems = ceildiv(nnz, nwarps * cuda_config::warp_size) *
                             cuda_config::warp_size;
-            const dim3 coo_block(cuda_config::warp_size, warps_in_block, 1);
             const dim3 coo_grid(
                 ceildiv(nwarps, warps_in_block),
                 ceildiv(b->get_size()[1], cuda_config::warp_size));

--- a/cuda/test/matrix/coo_kernels.cpp
+++ b/cuda/test/matrix/coo_kernels.cpp
@@ -198,12 +198,34 @@ TEST_F(Coo, SimpleApplyAddToDenseMatrixIsEquivalentToRef)
 }
 
 
+TEST_F(Coo, SimpleApplyAddToLargeDenseMatrixIsEquivalentToRef)
+{
+    set_up_apply_data(33);
+
+    mtx->apply2(y.get(), expected.get());
+    dmtx->apply2(dy.get(), dresult.get());
+
+    GKO_ASSERT_MTX_NEAR(dresult, expected, 1e-14);
+}
+
+
 TEST_F(Coo, AdvancedApplyAddToDenseMatrixIsEquivalentToRef)
 {
     set_up_apply_data(3);
 
     mtx->apply2(alpha.get(), y.get(), expected.get());
     dmtx->apply2(dalpha.get(), dy.get(), dresult.get());
+
+    GKO_ASSERT_MTX_NEAR(dresult, expected, 1e-14);
+}
+
+
+TEST_F(Coo, AdvancedApplyAddToLargeDenseMatrixIsEquivalentToRef)
+{
+    set_up_apply_data(33);
+
+    mtx->apply2(y.get(), expected.get());
+    dmtx->apply2(dy.get(), dresult.get());
 
     GKO_ASSERT_MTX_NEAR(dresult, expected, 1e-14);
 }


### PR DESCRIPTION
This PR implements the COO spmm.
The implementation is simple. Read the needed elements, compute the result, and then atomicAdd the result to the output vectors.
I have tried that using warp to read a line of nonzeros and shuffle the data in previous commit [warp_coo](https://github.com/ginkgo-project/ginkgo/blob/a644092325b61ca92640a51b6b6123caf7cf8110/cuda/matrix/coo_kernels.cu) However, in my testing cases, this warp implementation is not better than the simple one because the warp implementation needs more condition and index calculation.
The matrices set contain 100 matrices which obtained by using K-means on the whole real matrices set of SuiteSparse.

1. GFLOPS when `nrhs = 32`
![gflops](https://user-images.githubusercontent.com/19565938/64266570-168bfc80-cf35-11e9-8d33-a7f87ad51583.png)
2. simple vs warp
![simple_vs_warp](https://user-images.githubusercontent.com/19565938/64266601-24418200-cf35-11e9-9197-f994e3c4232c.png)
3. simple vs csrmm
![simple_vs_cuspcsrmm](https://user-images.githubusercontent.com/19565938/64266622-2a376300-cf35-11e9-9534-22023ec311cc.png)

