### PR TITLE
Improve update hessenberg of gmres

### DIFF
--- a/benchmark/solver/solver.cpp
+++ b/benchmark/solver/solver.cpp
@@ -123,7 +123,8 @@ const std::map<std::string, std::function<std::unique_ptr<gko::LinOpFactory>(
     solver_factory{{"cg", create_solver<gko::solver::Cg<>>},
                    {"bicgstab", create_solver<gko::solver::Bicgstab<>>},
                    {"cgs", create_solver<gko::solver::Cgs<>>},
-                   {"fcg", create_solver<gko::solver::Fcg<>>}};
+                   {"fcg", create_solver<gko::solver::Fcg<>>},
+                   {"gmres", create_solver<gko::solver::Gmres<>>}};
 
 
 // TODO: Workaround until GPU matrix conversions are implemented

--- a/cuda/solver/gmres_kernels.cu
+++ b/cuda/solver/gmres_kernels.cu
@@ -286,7 +286,7 @@ __global__ __launch_bounds__(default_dot_size) void multidot_kernel(
     const auto tidx = threadIdx.x;
     const auto tidy = threadIdx.y;
     const auto col_idx = blockIdx.x * default_dot_dim + tidx;
-    const auto num = ceildiv(num_rows, default_dot_dim);
+    const auto num = ceildiv(num_rows, gridDim.y);
     const auto start_row = blockIdx.y * num;
     const auto end_row =
         ((blockIdx.y + 1) * num > num_rows) ? num_rows : (blockIdx.y + 1) * num;

--- a/cuda/solver/gmres_kernels.cu
+++ b/cuda/solver/gmres_kernels.cu
@@ -440,6 +440,8 @@ void finish_arnoldi(std::shared_ptr<const CudaExecutor> exec,
                          exec->get_num_multiprocessor() * 2);
     const dim3 block_size(default_dot_dim, default_dot_dim);
     for (size_type k = 0; k < iter + 1; ++k) {
+        zero_array(dim_size[1],
+                   hessenberg_iter->get_values() + k * stride_hessenberg);
         if (dim_size[1] == 1) {
             cublas::dot(cublas_handle, dim_size[0],
                         next_krylov_basis->get_const_values(),
@@ -448,8 +450,6 @@ void finish_arnoldi(std::shared_ptr<const CudaExecutor> exec,
                         stride_krylov,
                         hessenberg_iter->get_values() + k * stride_hessenberg);
         } else {
-            zero_array(dim_size[1],
-                       hessenberg_iter->get_values() + k * stride_hessenberg);
             multidot_kernel<<<grid_size, block_size>>>(
                 k, dim_size[0], dim_size[1],
                 as_cuda_type(next_krylov_basis->get_const_values()),


### PR DESCRIPTION
This PR improves the kernel `update_hessenberg` and remove the unneeded copy when preconditioner is identity. 
It closes #364 

This part focus on the `update_hessenberg` improvement.
Take step 1 of gmres as the target.
It uses our implementation not cublas according to profiling.

Profiling results of step 1 in gmres
The left column of table is the number of right hand side.

P100

| parabolic_fem | cublas | implementation |
| --- | ---: | ---: |
| 4 | 28,874,986,570 | **18,591,212,314** |
| 2 | 17,228,621,978 | **16,034,896,559** |
| 1 | **11,732,775,039** | 14,406,294,158 |

| cz20468 | cublas | implementation |
| --- | ---: | ---: |
| 4 | 3,265,137,834 | **1,057,310,522** |
| 2 | 1,950,870,235 | **978,492,002** |
| 1 | 1,324,164,163 | **887,645,474** |

V100

| parabolic_fem | cublas | implementation |
| --- | ---: | ---: |
| 4 | 27,439,138,382 | **12,768,940,580** |
| 2 | 16,620,131,622 | **12,468,852,824** |
| 1 | **10,211,400,108** | 10,739,503,389|

| cz20468 | cublas | implementation |
| --- | ---: | ---: |
| 4 | 2,037,349,176 | **737,828,231** |
| 2 | 1,222,426,279 | **647,972,789** |
| 1 | 800,424,903 | **608,971,884** |

edited: cherry-pick @thoasm branch [fix_copy_gmres](https://github.com/ginkgo-project/ginkgo/tree/fix_copy_gmres)
