### PR TITLE
Use same matrix list in benchmark and warmup/repetitions in solver

### DIFF
--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -4,6 +4,16 @@ if (NOT CMAKE_BUILD_TYPE STREQUAL "Release")
         "will be affected")
 endif()
 
+function(ginkgo_benchmark_cusp_linops name)
+    target_compile_definitions("${name}" PRIVATE HAS_CUDA=1)
+    target_link_libraries("${name}" ginkgo ${CUDA_RUNTIME_LIBS}
+        ${CUBLAS} ${CUSPARSE})
+    target_include_directories("${name}" SYSTEM PRIVATE ${CUDA_INCLUDE_DIRS})
+    if(CMAKE_CUDA_COMPILER_VERSION GREATER_EQUAL "9.2")
+        target_compile_definitions("${name}" PRIVATE ALLOWMP=1)
+    endif()
+endfunction()
+
 add_subdirectory(conversions)
 add_subdirectory(matrix_generator)
 add_subdirectory(matrix_statistics)

--- a/benchmark/conversions/conversions.cpp
+++ b/benchmark/conversions/conversions.cpp
@@ -43,7 +43,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <typeinfo>
 
 
-#include "benchmark/utils/common.hpp"
+#include "benchmark/utils/formats.hpp"
 #include "benchmark/utils/general.hpp"
 #include "benchmark/utils/loggers.hpp"
 #include "benchmark/utils/spmv_common.hpp"
@@ -66,7 +66,8 @@ void convert_matrix(const gko::LinOp *matrix_from, const char *format_to,
                           rapidjson::Value(rapidjson::kObjectType), allocator);
 
         gko::matrix_data<> data{gko::dim<2>{1, 1}, 1};
-        auto matrix_to = share(matrix_factory.at(format_to)(exec, data));
+        auto matrix_to =
+            share(formats::matrix_factory.at(format_to)(exec, data));
         // warm run
         for (unsigned int i = 0; i < FLAGS_warmup; i++) {
             exec->synchronize();
@@ -153,8 +154,8 @@ int main(int argc, char *argv[])
         for (const auto &format_from : formats) {
             try {
                 auto matrix_from =
-                    share(matrix_factory.at(format_from)(exec, data));
-                for (const auto &format : matrix_factory) {
+                    share(formats::matrix_factory.at(format_from)(exec, data));
+                for (const auto &format : formats::matrix_factory) {
                     const auto format_to = std::get<0>(format);
                     if (format_from == format_to) {
                         continue;
@@ -175,7 +176,7 @@ int main(int argc, char *argv[])
                 }
                 backup_results(test_cases);
             } catch (const gko::AllocationError &e) {
-                for (const auto &format : matrix_factory) {
+                for (const auto &format : formats::matrix_factory) {
                     const auto format_to = std::get<0>(format);
                     auto conversion_name =
                         std::string(format_from) + "-" + format_to;

--- a/benchmark/conversions/conversions.cpp
+++ b/benchmark/conversions/conversions.cpp
@@ -51,19 +51,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 using etype = double;
 
-// Command-line arguments
-DEFINE_string(
-    formats, "coo",
-    "A comma-separated list of formats to benchmark. All conversions from the "
-    "formats given as argument to existing Ginkgo formats are benchmarked.\n"
-    "Supported values are: coo, csr, ell, hybrid, sellp"
-    "coo: Coordinate storage.\n"
-    "csr: Compressed Sparse Row storage.\n"
-    "ell: Ellpack format according to Bell and Garland: Efficient Sparse "
-    "Matrix-Vector Multiplication on CUDA.\n"
-    "hybrid: Hybrid uses ell and coo to represent the matrix.\n"
-    "sellp: Sliced Ellpack format.\n");
-
 
 // This function supposes that management of `FLAGS_overwrite` is done before
 // calling it

--- a/benchmark/conversions/conversions.cpp
+++ b/benchmark/conversions/conversions.cpp
@@ -43,6 +43,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <typeinfo>
 
 
+#include "benchmark/utils/common.hpp"
 #include "benchmark/utils/general.hpp"
 #include "benchmark/utils/loggers.hpp"
 #include "benchmark/utils/spmv_common.hpp"
@@ -62,17 +63,6 @@ DEFINE_string(
     "Matrix-Vector Multiplication on CUDA.\n"
     "hybrid: Hybrid uses ell and coo to represent the matrix.\n"
     "sellp: Sliced Ellpack format.\n");
-
-
-const std::map<std::string, std::function<std::unique_ptr<gko::LinOp>(
-                                std::shared_ptr<const gko::Executor>,
-                                const gko::matrix_data<> &)>>
-    matrix_factory{
-        {"csr", READ_MATRIX(csr, std::make_shared<csr::automatical>())},
-        {"coo", read_matrix_from_data<gko::matrix::Coo<>>},
-        {"ell", read_matrix_from_data<gko::matrix::Ell<>>},
-        {"hybrid", read_matrix_from_data<hybrid>},
-        {"sellp", read_matrix_from_data<gko::matrix::Sellp<>>}};
 
 
 // This function supposes that management of `FLAGS_overwrite` is done before

--- a/benchmark/preconditioner/preconditioner.cpp
+++ b/benchmark/preconditioner/preconditioner.cpp
@@ -42,7 +42,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <iostream>
 
 
-#include "benchmark/utils/common.hpp"
+#include "benchmark/utils/formats.hpp"
 #include "benchmark/utils/general.hpp"
 #include "benchmark/utils/loggers.hpp"
 #include "benchmark/utils/spmv_common.hpp"
@@ -289,7 +289,7 @@ int main(int argc, char *argv[])
             auto data = gko::read_raw<etype>(mtx_fd);
 
             auto system_matrix =
-                share(matrix_factory.at(FLAGS_formats)(exec, data));
+                share(formats::matrix_factory.at(FLAGS_formats)(exec, data));
             auto b = create_vector<etype>(exec, system_matrix->get_size()[0],
                                           engine);
             auto x = create_vector<etype>(exec, system_matrix->get_size()[0]);

--- a/benchmark/preconditioner/preconditioner.cpp
+++ b/benchmark/preconditioner/preconditioner.cpp
@@ -66,8 +66,6 @@ DEFINE_double(accuracy, 1e-1,
               "This value is used as the accuracy flag of the adaptive Jacobi "
               "preconditioner.");
 
-DECLARE_string(formats);
-
 
 // some shortcuts
 using etype = double;

--- a/benchmark/preconditioner/preconditioner.cpp
+++ b/benchmark/preconditioner/preconditioner.cpp
@@ -42,6 +42,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <iostream>
 
 
+#include "benchmark/utils/common.hpp"
 #include "benchmark/utils/general.hpp"
 #include "benchmark/utils/loggers.hpp"
 #include "benchmark/utils/spmv_common.hpp"
@@ -50,8 +51,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 // Command-line arguments
 DEFINE_uint32(max_block_size, 32,
               "Maximal block size of the block-Jacobi preconditioner");
-
-DEFINE_string(matrix_format, "csr", "The format in which to read the matrix");
 
 DEFINE_string(preconditioners, "jacobi",
               "A comma-separated list of solvers to run."
@@ -66,6 +65,8 @@ DEFINE_string(storage_optimization, "0,0",
 DEFINE_double(accuracy, 1e-1,
               "This value is used as the accuracy flag of the adaptive Jacobi "
               "preconditioner.");
+
+DECLARE_string(formats);
 
 
 // some shortcuts
@@ -85,16 +86,6 @@ gko::precision_reduction parse_storage_optimization(const std::string &flag)
     }
     return gko::precision_reduction(std::stoi(parts[0]), std::stoi(parts[1]));
 }
-
-
-const std::map<std::string, std::function<std::unique_ptr<gko::LinOp>(
-                                std::shared_ptr<const gko::Executor>,
-                                const rapidjson::Value &)>>
-    matrix_factory{{"csr", read_matrix<gko::matrix::Csr<etype>>},
-                   {"coo", read_matrix<gko::matrix::Coo<etype>>},
-                   {"ell", read_matrix<gko::matrix::Ell<etype>>},
-                   {"hybrid", read_matrix<gko::matrix::Hybrid<etype>>},
-                   {"sellp", read_matrix<gko::matrix::Sellp<etype>>}};
 
 
 // preconditioner mapping
@@ -244,6 +235,8 @@ void run_preconditioner(const char *precond_name,
 
 int main(int argc, char *argv[])
 {
+    // Use csr as the default format
+    FLAGS_formats = "csr";
     std::string header =
         "A benchmark for measuring preconditioner performance.\n";
     std::string format = std::string() + "  [\n" +
@@ -259,6 +252,12 @@ int main(int argc, char *argv[])
     auto &engine = get_engine();
 
     auto preconditioners = split(FLAGS_preconditioners, ',');
+
+    auto formats = split(FLAGS_formats, ',');
+    if (formats.size() != 1) {
+        std::cerr << "Preconditioner only supports one format" << std::endl;
+        std::exit(1);
+    }
 
     rapidjson::IStreamWrapper jcin(std::cin);
     rapidjson::Document test_cases;
@@ -288,8 +287,11 @@ int main(int argc, char *argv[])
             }
             std::clog << "Running test case: " << test_case << std::endl;
 
+            std::ifstream mtx_fd(test_case["filename"].GetString());
+            auto data = gko::read_raw<etype>(mtx_fd);
+
             auto system_matrix =
-                share(matrix_factory.at(FLAGS_matrix_format)(exec, test_case));
+                share(matrix_factory.at(FLAGS_formats)(exec, data));
             auto b = create_vector<etype>(exec, system_matrix->get_size()[0],
                                           engine);
             auto x = create_vector<etype>(exec, system_matrix->get_size()[0]);

--- a/benchmark/solver/CMakeLists.txt
+++ b/benchmark/solver/CMakeLists.txt
@@ -1,11 +1,5 @@
 add_executable(solver solver.cpp)
 target_link_libraries(solver ginkgo gflags rapidjson)
 if (GINKGO_BUILD_CUDA)
-    target_compile_definitions(solver PRIVATE HAS_CUDA=1)
-    target_link_libraries(solver ginkgo ${CUDA_RUNTIME_LIBS}
-        ${CUBLAS} ${CUSPARSE})
-    target_include_directories(solver SYSTEM PRIVATE ${CUDA_INCLUDE_DIRS})
-    if(CMAKE_CUDA_COMPILER_VERSION GREATER_EQUAL "9.2")
-        target_compile_definitions(solver PRIVATE ALLOWMP=1)
-    endif()
+    ginkgo_benchmark_cusp_linops(solver)
 endif()

--- a/benchmark/solver/CMakeLists.txt
+++ b/benchmark/solver/CMakeLists.txt
@@ -1,2 +1,11 @@
 add_executable(solver solver.cpp)
 target_link_libraries(solver ginkgo gflags rapidjson)
+if (GINKGO_BUILD_CUDA)
+    target_compile_definitions(solver PRIVATE HAS_CUDA=1)
+    target_link_libraries(solver ginkgo ${CUDA_RUNTIME_LIBS}
+        ${CUBLAS} ${CUSPARSE})
+    target_include_directories(solver SYSTEM PRIVATE ${CUDA_INCLUDE_DIRS})
+    if(CMAKE_CUDA_COMPILER_VERSION GREATER_EQUAL "9.2")
+        target_compile_definitions(solver PRIVATE ALLOWMP=1)
+    endif()
+endif()

--- a/benchmark/solver/solver.cpp
+++ b/benchmark/solver/solver.cpp
@@ -42,9 +42,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <iostream>
 
 
-#define DISABLE_FORMATS_COMMAND
 #include "benchmark/utils/formats.hpp"
-#undef DISABLE_FORMATS_COMMAND
 #include "benchmark/utils/general.hpp"
 #include "benchmark/utils/loggers.hpp"
 

--- a/benchmark/solver/solver.cpp
+++ b/benchmark/solver/solver.cpp
@@ -42,6 +42,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <iostream>
 
 
+#include "benchmark/utils/common.hpp"
 #include "benchmark/utils/general.hpp"
 #include "benchmark/utils/loggers.hpp"
 
@@ -58,8 +59,7 @@ DEFINE_double(rel_res_goal, 1e-6, "The relative residual goal of the solver");
 
 DEFINE_string(solvers, "cg",
               "A comma-separated list of solvers to run."
-              "Supported values are: bicgstab, cg, cgs, fcg, gmres, ir, "
-              "lower_trs, upper_trs");
+              "Supported values are: bicgstab, cg, cgs, fcg, gmres");
 
 DEFINE_string(preconditioners, "none",
               "A comma-separated list of preconditioners to use."
@@ -88,16 +88,6 @@ void validate_option_object(const rapidjson::Value &value)
         print_config_error_and_exit();
     }
 }
-
-
-const std::map<std::string, std::function<std::unique_ptr<gko::LinOp>(
-                                std::shared_ptr<const gko::Executor>,
-                                const rapidjson::Value &)>>
-    matrix_factory{{"csr", read_matrix<gko::matrix::Csr<>>},
-                   {"coo", read_matrix<gko::matrix::Coo<>>},
-                   {"ell", read_matrix<gko::matrix::Ell<>>},
-                   {"hybrid", read_matrix<gko::matrix::Hybrid<>>},
-                   {"sellp", read_matrix<gko::matrix::Sellp<>>}};
 
 
 // solver mapping

--- a/benchmark/solver/solver.cpp
+++ b/benchmark/solver/solver.cpp
@@ -42,7 +42,9 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <iostream>
 
 
+#define DISABLE_FORMATS_COMMAND
 #include "benchmark/utils/common.hpp"
+#undef DISABLE_FORMATS_COMMAND
 #include "benchmark/utils/general.hpp"
 #include "benchmark/utils/loggers.hpp"
 

--- a/benchmark/solver/solver.cpp
+++ b/benchmark/solver/solver.cpp
@@ -71,7 +71,6 @@ DEFINE_uint32(
     nrhs, 1,
     "The number of right hand sides. Record the residual only when nrhs == 1.");
 
-DECLARE_uint32(repetitions);
 
 // input validation
 [[noreturn]] void print_config_error_and_exit() {

--- a/benchmark/solver/solver.cpp
+++ b/benchmark/solver/solver.cpp
@@ -43,7 +43,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
 #define DISABLE_FORMATS_COMMAND
-#include "benchmark/utils/common.hpp"
+#include "benchmark/utils/formats.hpp"
 #undef DISABLE_FORMATS_COMMAND
 #include "benchmark/utils/general.hpp"
 #include "benchmark/utils/loggers.hpp"
@@ -439,7 +439,7 @@ int main(int argc, char *argv[])
             std::ifstream mtx_fd(test_case["filename"].GetString());
             auto data = gko::read_raw<etype>(mtx_fd);
 
-            auto system_matrix = share(matrix_factory.at(
+            auto system_matrix = share(formats::matrix_factory.at(
                 test_case["optimal"]["spmv"].GetString())(exec, data));
             auto b = create_matrix<etype>(
                 exec, gko::dim<2>{system_matrix->get_size()[0], FLAGS_nrhs},

--- a/benchmark/spmv/CMakeLists.txt
+++ b/benchmark/spmv/CMakeLists.txt
@@ -1,11 +1,5 @@
 add_executable(spmv spmv.cpp)
 target_link_libraries(spmv ginkgo gflags rapidjson)
 if (GINKGO_BUILD_CUDA)
-    target_compile_definitions(spmv PRIVATE HAS_CUDA=1)
-    target_link_libraries(spmv ginkgo ${CUDA_RUNTIME_LIBS}
-        ${CUBLAS} ${CUSPARSE})
-    target_include_directories(spmv SYSTEM PRIVATE ${CUDA_INCLUDE_DIRS})
-    if(CMAKE_CUDA_COMPILER_VERSION GREATER_EQUAL "9.2")
-        target_compile_definitions(spmv PRIVATE ALLOWMP=1)
-    endif()
+    ginkgo_benchmark_cusp_linops(spmv)
 endif()

--- a/benchmark/spmv/spmv.cpp
+++ b/benchmark/spmv/spmv.cpp
@@ -43,14 +43,10 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <typeinfo>
 
 
+#include "benchmark/utils/common.hpp"
 #include "benchmark/utils/general.hpp"
 #include "benchmark/utils/loggers.hpp"
 #include "benchmark/utils/spmv_common.hpp"
-
-
-#ifdef HAS_CUDA
-#include "cuda_linops.hpp"
-#endif  // HAS_CUDA
 
 
 using etype = double;
@@ -92,54 +88,6 @@ DEFINE_string(
     "cusp_csrmm: benchmark CuSPARSE with the cusparseXcsrmv_mm function.\n");
 
 DEFINE_uint32(nrhs, 1, "The number of right hand sides");
-
-
-const std::map<std::string, std::function<std::unique_ptr<gko::LinOp>(
-                                std::shared_ptr<const gko::Executor>,
-                                const gko::matrix_data<> &)>>
-    matrix_factory{
-        {"csr", READ_MATRIX(csr, std::make_shared<csr::automatical>())},
-        {"csri", READ_MATRIX(csr, std::make_shared<csr::load_balance>())},
-        {"csrm", READ_MATRIX(csr, std::make_shared<csr::merge_path>())},
-        {"csrc", READ_MATRIX(csr, std::make_shared<csr::classical>())},
-        {"coo", read_matrix_from_data<gko::matrix::Coo<>>},
-        {"ell", read_matrix_from_data<gko::matrix::Ell<>>},
-#ifdef HAS_CUDA
-        {"cusp_csr", read_matrix_from_data<cusp_csr>},
-        {"cusp_csrmp", read_matrix_from_data<cusp_csrmp>},
-        {"cusp_csrex", read_matrix_from_data<cusp_csrex>},
-        {"cusp_csrmm", read_matrix_from_data<cusp_csrmm>},
-        {"cusp_hybrid", read_matrix_from_data<cusp_hybrid>},
-        {"cusp_coo", read_matrix_from_data<cusp_coo>},
-        {"cusp_ell", read_matrix_from_data<cusp_ell>},
-#endif  // HAS_CUDA
-        {"hybrid", read_matrix_from_data<hybrid>},
-        {"hybrid0",
-         READ_MATRIX(hybrid, std::make_shared<hybrid::imbalance_limit>(0))},
-        {"hybrid25",
-         READ_MATRIX(hybrid, std::make_shared<hybrid::imbalance_limit>(0.25))},
-        {"hybrid33",
-         READ_MATRIX(hybrid,
-                     std::make_shared<hybrid::imbalance_limit>(1.0 / 3.0))},
-        {"hybrid40",
-         READ_MATRIX(hybrid, std::make_shared<hybrid::imbalance_limit>(0.4))},
-        {"hybrid60",
-         READ_MATRIX(hybrid, std::make_shared<hybrid::imbalance_limit>(0.6))},
-        {"hybrid80",
-         READ_MATRIX(hybrid, std::make_shared<hybrid::imbalance_limit>(0.8))},
-        {"hybridlimit0",
-         READ_MATRIX(hybrid,
-                     std::make_shared<hybrid::imbalance_bounded_limit>(0))},
-        {"hybridlimit25",
-         READ_MATRIX(hybrid,
-                     std::make_shared<hybrid::imbalance_bounded_limit>(0.25))},
-        {"hybridlimit33",
-         READ_MATRIX(hybrid, std::make_shared<hybrid::imbalance_bounded_limit>(
-                                 1.0 / 3.0))},
-        {"hybridminstorage",
-         READ_MATRIX(hybrid,
-                     std::make_shared<hybrid::minimal_storage_limit>())},
-        {"sellp", read_matrix_from_data<gko::matrix::Sellp<>>}};
 
 
 // This function supposes that management of `FLAGS_overwrite` is done before

--- a/benchmark/spmv/spmv.cpp
+++ b/benchmark/spmv/spmv.cpp
@@ -43,7 +43,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <typeinfo>
 
 
-#include "benchmark/utils/common.hpp"
+#include "benchmark/utils/formats.hpp"
 #include "benchmark/utils/general.hpp"
 #include "benchmark/utils/loggers.hpp"
 #include "benchmark/utils/spmv_common.hpp"
@@ -71,7 +71,8 @@ void apply_spmv(const char *format_name, std::shared_ptr<gko::Executor> exec,
 
         auto storage_logger = std::make_shared<StorageLogger>(exec);
         exec->add_logger(storage_logger);
-        auto system_matrix = share(matrix_factory.at(format_name)(exec, data));
+        auto system_matrix =
+            share(formats::matrix_factory.at(format_name)(exec, data));
         exec->remove_logger(gko::lend(storage_logger));
         storage_logger->write_data(spmv_case[format_name], allocator);
         // warm run

--- a/benchmark/spmv/spmv.cpp
+++ b/benchmark/spmv/spmv.cpp
@@ -53,39 +53,6 @@ using etype = double;
 
 
 // Command-line arguments
-DEFINE_string(
-    formats, "coo",
-    "A comma-separated list of formats to run."
-    "Supported values are: coo, csr, ell, sellp, hybrid, hybrid0, "
-    "hybrid25, hybrid33, hybrid40, hybrid60, hybrid80, hybridlimit0, "
-    "hybridlimit25, hybridlimit33, hybridminstorage, cusp_csr, cusp_csrex, "
-    "cusp_csrmp, cusp_csrmm, cusp_coo, cusp_ell, cusp_hybrid.\n"
-    "coo: Coordinate storage. The CUDA kernel uses the load-balancing approach "
-    "suggested in Flegar et al.: Overcoming Load Imbalance for Irregular "
-    "Sparse Matrices.\n"
-    "csr: Compressed Sparse Row storage. Ginkgo implementation with automatic "
-    "strategy.\n"
-    "csrc: Ginkgo's CSR implementation with automatic stategy.\n"
-    "csri: Ginkgo's CSR implementation with inbalance strategy.\n"
-    "csrm: Ginkgo's CSR implementation with merge_path strategy.\n"
-    "ell: Ellpack format according to Bell and Garland: Efficient Sparse "
-    "Matrix-Vector Multiplication on CUDA.\n"
-    "sellp: Sliced Ellpack uses a default block size of 32.\n"
-    "hybrid: Hybrid uses ell and coo to represent the matrix.\n"
-    "hybrid0, hybrid25, hybrid33, hybrid40, hybrid60, hybrid80: Hybrid uses "
-    "the row distribution to decide the partition.\n"
-    "hybridlimit0, hybridlimit25, hybrid33: Add the upper bound on the ell "
-    "part of hybrid0, hybrid25, hybrid33.\n"
-    "hybridminstorage: Hybrid uses the minimal storage to store the matrix.\n"
-    "cusp_hybrid: benchmark CuSPARSE spmv with cusparseXhybmv and an automatic "
-    "partition.\n"
-    "cusp_coo: use cusparseXhybmv with a CUSPARSE_HYB_PARTITION_USER "
-    "partition.\n"
-    "cusp_ell: use cusparseXhybmv with CUSPARSE_HYB_PARTITION_MAX partition.\n"
-    "cusp_csr: benchmark CuSPARSE with the cusparseXcsrmv function.\n"
-    "cusp_csrex: benchmark CuSPARSE with the cusparseXcsrmvEx function.\n"
-    "cusp_csrmp: benchmark CuSPARSE with the cusparseXcsrmv_mp function.\n"
-    "cusp_csrmm: benchmark CuSPARSE with the cusparseXcsrmv_mm function.\n");
 
 DEFINE_uint32(nrhs, 1, "The number of right hand sides");
 

--- a/benchmark/utils/common.hpp
+++ b/benchmark/utils/common.hpp
@@ -1,0 +1,136 @@
+/*******************************<GINKGO LICENSE>******************************
+Copyright (c) 2017-2019, the Ginkgo authors
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+******************************<GINKGO LICENSE>*******************************/
+
+#ifndef GKO_BENCHMARK_UTILS_COMMON_HPP_
+#define GKO_BENCHMARK_UTILS_COMMON_HPP_
+
+
+#include <ginkgo/ginkgo.hpp>
+
+
+#include <map>
+
+
+#ifdef HAS_CUDA
+#include "cuda_linops.hpp"
+#endif  // HAS_CUDA
+
+
+// some shortcuts
+using hybrid = gko::matrix::Hybrid<>;
+using csr = gko::matrix::Csr<>;
+
+
+/**
+ * Creates a Ginkgo matrix from the intermediate data representation format
+ * gko::matrix_data.
+ *
+ * @param exec  the executor where the matrix will be put
+ * @param data  the data represented in the intermediate representation format
+ *
+ * @tparam MatrixType  the Ginkgo matrix type (such as `gko::matrix::Csr<>`)
+ *
+ * @return a `unique_pointer` to the created matrix
+ */
+template <typename MatrixType>
+std::unique_ptr<MatrixType> read_matrix_from_data(
+    std::shared_ptr<const gko::Executor> exec, const gko::matrix_data<> &data)
+{
+    auto mat = MatrixType::create(std::move(exec));
+    mat->read(data);
+    return mat;
+}
+
+/**
+ * Creates a Ginkgo matrix from the intermediate data representation format
+ * gko::matrix_data with support for variable arguments.
+ *
+ * @param MATRIX_TYPE  the Ginkgo matrix type (such as `gko::matrix::Csr<>`)
+ */
+#define READ_MATRIX(MATRIX_TYPE, ...)                                    \
+    [](std::shared_ptr<const gko::Executor> exec,                        \
+       const gko::matrix_data<> &data) -> std::unique_ptr<MATRIX_TYPE> { \
+        auto mat = MATRIX_TYPE::create(std::move(exec), __VA_ARGS__);    \
+        mat->read(data);                                                 \
+        return mat;                                                      \
+    }
+
+
+const std::map<std::string, std::function<std::unique_ptr<gko::LinOp>(
+                                std::shared_ptr<const gko::Executor>,
+                                const gko::matrix_data<> &)>>
+    matrix_factory{
+        {"csr", READ_MATRIX(csr, std::make_shared<csr::automatical>())},
+        {"csri", READ_MATRIX(csr, std::make_shared<csr::load_balance>())},
+        {"csrm", READ_MATRIX(csr, std::make_shared<csr::merge_path>())},
+        {"csrc", READ_MATRIX(csr, std::make_shared<csr::classical>())},
+        {"coo", read_matrix_from_data<gko::matrix::Coo<>>},
+        {"ell", read_matrix_from_data<gko::matrix::Ell<>>},
+#ifdef HAS_CUDA
+        {"cusp_csr", read_matrix_from_data<cusp_csr>},
+        {"cusp_csrmp", read_matrix_from_data<cusp_csrmp>},
+        {"cusp_csrex", read_matrix_from_data<cusp_csrex>},
+        {"cusp_csrmm", read_matrix_from_data<cusp_csrmm>},
+        {"cusp_hybrid", read_matrix_from_data<cusp_hybrid>},
+        {"cusp_coo", read_matrix_from_data<cusp_coo>},
+        {"cusp_ell", read_matrix_from_data<cusp_ell>},
+#endif  // HAS_CUDA
+        {"hybrid", read_matrix_from_data<hybrid>},
+        {"hybrid0",
+         READ_MATRIX(hybrid, std::make_shared<hybrid::imbalance_limit>(0))},
+        {"hybrid25",
+         READ_MATRIX(hybrid, std::make_shared<hybrid::imbalance_limit>(0.25))},
+        {"hybrid33",
+         READ_MATRIX(hybrid,
+                     std::make_shared<hybrid::imbalance_limit>(1.0 / 3.0))},
+        {"hybrid40",
+         READ_MATRIX(hybrid, std::make_shared<hybrid::imbalance_limit>(0.4))},
+        {"hybrid60",
+         READ_MATRIX(hybrid, std::make_shared<hybrid::imbalance_limit>(0.6))},
+        {"hybrid80",
+         READ_MATRIX(hybrid, std::make_shared<hybrid::imbalance_limit>(0.8))},
+        {"hybridlimit0",
+         READ_MATRIX(hybrid,
+                     std::make_shared<hybrid::imbalance_bounded_limit>(0))},
+        {"hybridlimit25",
+         READ_MATRIX(hybrid,
+                     std::make_shared<hybrid::imbalance_bounded_limit>(0.25))},
+        {"hybridlimit33",
+         READ_MATRIX(hybrid, std::make_shared<hybrid::imbalance_bounded_limit>(
+                                 1.0 / 3.0))},
+        {"hybridminstorage",
+         READ_MATRIX(hybrid,
+                     std::make_shared<hybrid::minimal_storage_limit>())},
+        {"sellp", read_matrix_from_data<gko::matrix::Sellp<>>}};
+
+
+#endif  // GKO_BENCHMARK_UTILS_COMMON_HPP_

--- a/benchmark/utils/common.hpp
+++ b/benchmark/utils/common.hpp
@@ -40,6 +40,9 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <map>
 
 
+#include <gflags/gflags.h>
+
+
 #ifdef HAS_CUDA
 #include "cuda_linops.hpp"
 #endif  // HAS_CUDA
@@ -48,6 +51,52 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 // some shortcuts
 using hybrid = gko::matrix::Hybrid<>;
 using csr = gko::matrix::Csr<>;
+
+// the formats command-line argument
+// If define DISABLE_FORMATS_COMMAND, do not define this argument.
+#ifndef DISABLE_FORMATS_COMMAND
+DEFINE_string(
+    formats, "coo",
+    "A comma-separated list of formats to run."
+    "Supported values are: coo, csr, ell, sellp, hybrid, hybrid0, "
+    "hybrid25, hybrid33, hybrid40, hybrid60, hybrid80, hybridlimit0, "
+    "hybridlimit25, hybridlimit33, hybridminstorage"
+#ifdef HAS_CUDA
+    ", cusp_csr, cusp_csrex, cusp_csrmp, cusp_csrmm, cusp_coo, cusp_ell, "
+    "cusp_hybrid"
+#endif  // HAS_CUDA
+    ".\n"
+    "coo: Coordinate storage. The CUDA kernel uses the load-balancing approach "
+    "suggested in Flegar et al.: Overcoming Load Imbalance for Irregular "
+    "Sparse Matrices.\n"
+    "csr: Compressed Sparse Row storage. Ginkgo implementation with automatic "
+    "strategy.\n"
+    "csrc: Ginkgo's CSR implementation with automatic stategy.\n"
+    "csri: Ginkgo's CSR implementation with inbalance strategy.\n"
+    "csrm: Ginkgo's CSR implementation with merge_path strategy.\n"
+    "ell: Ellpack format according to Bell and Garland: Efficient Sparse "
+    "Matrix-Vector Multiplication on CUDA.\n"
+    "sellp: Sliced Ellpack uses a default block size of 32.\n"
+    "hybrid: Hybrid uses ell and coo to represent the matrix.\n"
+    "hybrid0, hybrid25, hybrid33, hybrid40, hybrid60, hybrid80: Hybrid uses "
+    "the row distribution to decide the partition.\n"
+    "hybridlimit0, hybridlimit25, hybrid33: Add the upper bound on the ell "
+    "part of hybrid0, hybrid25, hybrid33.\n"
+    "hybridminstorage: Hybrid uses the minimal storage to store the matrix."
+#ifdef HAS_CUDA
+    "\n"
+    "cusp_hybrid: benchmark CuSPARSE spmv with cusparseXhybmv and an automatic "
+    "partition.\n"
+    "cusp_coo: use cusparseXhybmv with a CUSPARSE_HYB_PARTITION_USER "
+    "partition.\n"
+    "cusp_ell: use cusparseXhybmv with CUSPARSE_HYB_PARTITION_MAX partition.\n"
+    "cusp_csr: benchmark CuSPARSE with the cusparseXcsrmv function.\n"
+    "cusp_csrex: benchmark CuSPARSE with the cusparseXcsrmvEx function.\n"
+    "cusp_csrmp: benchmark CuSPARSE with the cusparseXcsrmv_mp function.\n"
+    "cusp_csrmm: benchmark CuSPARSE with the cusparseXcsrmv_mm function."
+#endif  // HAS_CUDA
+);
+#endif  // DISABLE_FORMATS_COMMAND
 
 
 /**

--- a/benchmark/utils/cuda_linops.hpp
+++ b/benchmark/utils/cuda_linops.hpp
@@ -74,11 +74,17 @@ protected:
         this->initialize_descr();
     }
 
+    ~CuspBase() = default;
+
+    CuspBase(const CuspBase &other) = delete;
+
     CuspBase &operator=(const CuspBase &other)
     {
-        gko::LinOp::operator=(other);
-        this->gpu_exec_ = other.gpu_exec_;
-        this->initialize_descr();
+        if (this != &other) {
+            gko::LinOp::operator=(other);
+            this->gpu_exec_ = other.gpu_exec_;
+            this->initialize_descr();
+        }
         return *this;
     }
 
@@ -312,15 +318,13 @@ public:
         const auto id = this->get_gpu_exec()->get_device_id();
         gko::device_guard g{id};
         if (set_buffer_) {
-            try {
-                GKO_ASSERT_NO_CUDA_ERRORS(cudaFree(buffer_));
-            } catch (const std::exception &e) {
-                std::cerr
-                    << "Error when unallocating CuspCsrEx temporary buffer: "
-                    << e.what() << std::endl;
-            }
+            GKO_ASSERT_NO_CUDA_ERRORS(cudaFree(buffer_));
         }
     }
+
+    CuspCsrEx(const CuspCsrEx &other) = delete;
+
+    CuspCsrEx &operator=(const CuspCsrEx &other) = default;
 
 protected:
     void apply_impl(const gko::LinOp *b, gko::LinOp *x) const override
@@ -418,13 +422,12 @@ public:
     {
         const auto id = this->get_gpu_exec()->get_device_id();
         gko::device_guard g{id};
-        try {
-            GKO_ASSERT_NO_CUSPARSE_ERRORS(cusparseDestroyHybMat(hyb_));
-        } catch (const std::exception &e) {
-            std::cerr << "Error when unallocating CuspHybrid hyb_ matrix: "
-                      << e.what() << std::endl;
-        }
+        GKO_ASSERT_NO_CUSPARSE_ERRORS(cusparseDestroyHybMat(hyb_));
     }
+
+    CuspHybrid(const CuspHybrid &other) = delete;
+
+    CuspHybrid &operator=(const CuspHybrid &other) = default;
 
 protected:
     void apply_impl(const gko::LinOp *b, gko::LinOp *x) const override

--- a/benchmark/utils/cuda_linops.hpp
+++ b/benchmark/utils/cuda_linops.hpp
@@ -30,8 +30,8 @@ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ******************************<GINKGO LICENSE>*******************************/
 
-#ifndef GKO_BENCHMARK_SPMV_CUDA_LINOPS_HPP_
-#define GKO_BENCHMARK_SPMV_CUDA_LINOPS_HPP_
+#ifndef GKO_BENCHMARK_UTILS_CUDA_LINOPS_HPP_
+#define GKO_BENCHMARK_UTILS_CUDA_LINOPS_HPP_
 
 
 #include <ginkgo/ginkgo.hpp>
@@ -477,4 +477,4 @@ using cusp_ell =
     detail::CuspHybrid<double, gko::int32, CUSPARSE_HYB_PARTITION_MAX, 0>;
 using cusp_hybrid = detail::CuspHybrid<>;
 
-#endif  // GKO_BENCHMARK_SPMV_CUDA_LINOPS_HPP_
+#endif  // GKO_BENCHMARK_UTILS_CUDA_LINOPS_HPP_

--- a/benchmark/utils/formats.hpp
+++ b/benchmark/utils/formats.hpp
@@ -30,14 +30,15 @@ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ******************************<GINKGO LICENSE>*******************************/
 
-#ifndef GKO_BENCHMARK_UTILS_COMMON_HPP_
-#define GKO_BENCHMARK_UTILS_COMMON_HPP_
+#ifndef GKO_BENCHMARK_UTILS_FORMATS_HPP_
+#define GKO_BENCHMARK_UTILS_FORMATS_HPP_
 
 
 #include <ginkgo/ginkgo.hpp>
 
 
 #include <map>
+#include <string>
 
 
 #include <gflags/gflags.h>
@@ -48,24 +49,20 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #endif  // HAS_CUDA
 
 
-// some shortcuts
-using hybrid = gko::matrix::Hybrid<>;
-using csr = gko::matrix::Csr<>;
+namespace {
 
-// the formats command-line argument
-// If define DISABLE_FORMATS_COMMAND, do not define this argument.
-#ifndef DISABLE_FORMATS_COMMAND
-DEFINE_string(
-    formats, "coo",
-    "A comma-separated list of formats to run."
-    "Supported values are: coo, csr, ell, sellp, hybrid, hybrid0, "
-    "hybrid25, hybrid33, hybrid40, hybrid60, hybrid80, hybridlimit0, "
-    "hybridlimit25, hybridlimit33, hybridminstorage"
+
+std::string available_format =
+    "coo, csr, ell, sellp, hybrid, hybrid0, hybrid25, hybrid33, hybrid40, "
+    "hybrid60, hybrid80, hybridlimit0, hybridlimit25, hybridlimit33, "
+    "hybridminstorage"
 #ifdef HAS_CUDA
     ", cusp_csr, cusp_csrex, cusp_csrmp, cusp_csrmm, cusp_coo, cusp_ell, "
     "cusp_hybrid"
 #endif  // HAS_CUDA
-    ".\n"
+    ".\n";
+
+std::string format_description =
     "coo: Coordinate storage. The CUDA kernel uses the load-balancing approach "
     "suggested in Flegar et al.: Overcoming Load Imbalance for Irregular "
     "Sparse Matrices.\n"
@@ -95,9 +92,29 @@ DEFINE_string(
     "cusp_csrmp: benchmark CuSPARSE with the cusparseXcsrmv_mp function.\n"
     "cusp_csrmm: benchmark CuSPARSE with the cusparseXcsrmv_mm function."
 #endif  // HAS_CUDA
-);
+    ;
+
+std::string format_command =
+    "A comma-separated list of formats to run. Supported values are: " +
+    available_format + format_description;
+
+
+}  // namespace
+
+
+// the formats command-line argument
+// If define DISABLE_FORMATS_COMMAND, do not define this argument.
+#ifndef DISABLE_FORMATS_COMMAND
+DEFINE_string(formats, "coo", format_command.c_str());
 #endif  // DISABLE_FORMATS_COMMAND
 
+
+namespace formats {
+
+
+// some shortcuts
+using hybrid = gko::matrix::Hybrid<>;
+using csr = gko::matrix::Csr<>;
 
 /**
  * Creates a Ginkgo matrix from the intermediate data representation format
@@ -182,4 +199,6 @@ const std::map<std::string, std::function<std::unique_ptr<gko::LinOp>(
         {"sellp", read_matrix_from_data<gko::matrix::Sellp<>>}};
 
 
-#endif  // GKO_BENCHMARK_UTILS_COMMON_HPP_
+}  // namespace formats
+
+#endif  // GKO_BENCHMARK_UTILS_FORMATS_HPP_

--- a/benchmark/utils/formats.hpp
+++ b/benchmark/utils/formats.hpp
@@ -49,7 +49,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #endif  // HAS_CUDA
 
 
-namespace {
+namespace formats {
 
 
 std::string available_format =
@@ -99,11 +99,11 @@ std::string format_command =
     available_format + format_description;
 
 
-}  // namespace
+}  // namespace formats
 
 
 // the formats command-line argument
-DEFINE_string(formats, "coo", format_command.c_str());
+DEFINE_string(formats, "coo", formats::format_command.c_str());
 
 
 namespace formats {

--- a/benchmark/utils/formats.hpp
+++ b/benchmark/utils/formats.hpp
@@ -103,10 +103,7 @@ std::string format_command =
 
 
 // the formats command-line argument
-// If define DISABLE_FORMATS_COMMAND, do not define this argument.
-#ifndef DISABLE_FORMATS_COMMAND
 DEFINE_string(formats, "coo", format_command.c_str());
-#endif  // DISABLE_FORMATS_COMMAND
 
 
 namespace formats {

--- a/benchmark/utils/general.hpp
+++ b/benchmark/utils/general.hpp
@@ -280,6 +280,15 @@ std::unique_ptr<vec<ValueType>> create_vector(
     return res;
 }
 
+template <typename ValueType>
+std::unique_ptr<vec<ValueType>> create_matrix(
+    std::shared_ptr<const gko::Executor> exec, gko::dim<2> size)
+{
+    auto res = vec<ValueType>::create(exec);
+    res->read(gko::matrix_data<ValueType>(size));
+    return res;
+}
+
 
 // creates a random matrix
 template <typename ValueType, typename RandomEngine>
@@ -335,4 +344,4 @@ double compute_residual_norm(const gko::LinOp *system_matrix,
 }
 
 
-#endif  // GKO_BENCHMARK_UTILS_HPP_
+#endif  // GKO_BENCHMARK_UTILS_GENERAL_HPP_

--- a/benchmark/utils/spmv_common.hpp
+++ b/benchmark/utils/spmv_common.hpp
@@ -30,6 +30,9 @@ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ******************************<GINKGO LICENSE>*******************************/
 
+#ifndef GKO_BENCHMARK_UTILS_SPMV_COMMON_HPP_
+#define GKO_BENCHMARK_UTILS_SPMV_COMMON_HPP_
+
 #include <ginkgo/ginkgo.hpp>
 
 
@@ -47,8 +50,7 @@ using csr = gko::matrix::Csr<>;
 /**
  * Function which outputs the input format for benchmarks similar to the spmv.
  */
-[[noreturn]] void print_config_error_and_exit()
-{
+[[noreturn]] void print_config_error_and_exit() {
     std::cerr << "Input has to be a JSON array of matrix configurations:\n"
               << "  [\n"
               << "    { \"filename\": \"my_file.mtx\" },\n"
@@ -72,36 +74,4 @@ void validate_option_object(const rapidjson::Value &value)
 }
 
 
-/**
- * Creates a Ginkgo matrix from the intermediate data representation format
- * gko::matrix_data.
- *
- * @param exec  the executor where the matrix will be put
- * @param data  the data represented in the intermediate representation format
- *
- * @tparam MatrixType  the Ginkgo matrix type (such as `gko::matrix::Csr<>`)
- *
- * @return a `unique_pointer` to the created matrix
- */
-template <typename MatrixType>
-std::unique_ptr<MatrixType> read_matrix_from_data(
-    std::shared_ptr<const gko::Executor> exec, const gko::matrix_data<> &data)
-{
-    auto mat = MatrixType::create(std::move(exec));
-    mat->read(data);
-    return mat;
-}
-
-/**
- * Creates a Ginkgo matrix from the intermediate data representation format
- * gko::matrix_data with support for variable arguments.
- *
- * @param MATRIX_TYPE  the Ginkgo matrix type (such as `gko::matrix::Csr<>`)
- */
-#define READ_MATRIX(MATRIX_TYPE, ...)                                    \
-    [](std::shared_ptr<const gko::Executor> exec,                        \
-       const gko::matrix_data<> &data) -> std::unique_ptr<MATRIX_TYPE> { \
-        auto mat = MATRIX_TYPE::create(std::move(exec), __VA_ARGS__);    \
-        mat->read(data);                                                 \
-        return mat;                                                      \
-    }
+#endif  // GKO_BENCHMARK_UTILS_SPMV_COMMON_HPP_


### PR DESCRIPTION
1. Move the creations and comand-line arguments of matrix format into `utils/common.hpp`
every program under benchmark uses the same matrix format list.
2. Split timing detailed components and computing residuals in solver.
3. Solver will use warmup and repetitions argument. 
(solver has two extra apply for timing detailed components and computing residuals, so the total number is warmup + 2 + repetitions)

preconditioner uses csr as default matrix format which is same as previous setting, and others use coo.
solver uses 1 as repetitions, and others use 10
