### PR TITLE
Fix some doxygen issues.

### DIFF
--- a/doc/conf/Doxyfile.in
+++ b/doc/conf/Doxyfile.in
@@ -80,7 +80,6 @@ VERBATIM_HEADERS       = YES
 # External references
 ALLEXTERNALS           = NO
 EXTERNAL_GROUPS        = YES
-PERL_PATH              = @PERL_EXECUTABLE@
 
 # Graph generation
 CLASS_DIAGRAMS         = YES

--- a/doc/examples/examples.hpp.in
+++ b/doc/examples/examples.hpp.in
@@ -105,6 +105,16 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *       </td></tr>
  *
  *   <tr valign="top">
+ *       <td>@ref ilu_preconditioned_solver</td>
+ *       <td> Using an ILU preconditioner to solve a linear system.
+ *       </td></tr>
+ *
+ *   <tr valign="top">
+ *       <td>@ref performance_debugging</td>
+ *       <td> Using Loggers to debug the performance within Ginkgo.
+ *       </td></tr>
+ *
+ *   <tr valign="top">
  *       <td>@ref three_pt_stencil_solver</td>
  *       <td> Using a three point stencil to solve the poisson equation with
  *            array views.
@@ -191,6 +201,13 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *   </tr>
  *
  *   <tr valign="top">
+ *     <td> Debug the performance of a solver using loggers.
+ *     </td>
+ *     <td>@ref performance_debugging
+ *     </td>
+ *   </tr>
+ *
+ *   <tr valign="top">
  *     <td> Using the CUDA executor
  *     </td>
  *     <td>@ref minimal_cuda_solver
@@ -200,7 +217,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *   <tr valign="top">
  *     <td width="400px"> Using preconditioners
  *     </td>
- *     <td>@ref preconditioned_solver
+ *     <td>@ref preconditioned_solver,
+ *         @ref ilu_preconditioned_solver
  *     </td>
  *   </tr>
  *
@@ -221,6 +239,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *     <td>@ref simple_solver,
  *         @ref minimal_cuda_solver,
  *         @ref preconditioned_solver,
+ *         @ref ilu_preconditioned_solver,
  *         @ref inverse_iteration,
  *         @ref simple_solver_logging,
  *         @ref papi_logging,

--- a/doc/scripts/make_example.pl
+++ b/doc/scripts/make_example.pl
@@ -28,8 +28,7 @@ $cmake_source_dir=$ARGV[1];
 $cmake_build_dir=$ARGV[2];
 
 print
-"/**
-  * \@page $example_underscore The $example program
+"/** \@page $example_underscore The $example program
 ";
 
 open intro, "$cmake_source_dir/examples/$example/doc/short-intro"

--- a/examples/nine-pt-stencil-solver/doc/builds-on
+++ b/examples/nine-pt-stencil-solver/doc/builds-on
@@ -1,1 +1,1 @@
-simple-solver poisson-solver three-pt-stencil-solver
+simple-solver three-pt-stencil-solver poisson-solver 

--- a/examples/twentyseven-pt-stencil-solver/doc/builds-on
+++ b/examples/twentyseven-pt-stencil-solver/doc/builds-on
@@ -1,1 +1,1 @@
-simple-solver poisson-solver three-pt-stencil-solver nine-pt-stencil-solver
+simple-solver poisson-solver nine-pt-stencil-solver three-pt-stencil-solver 


### PR DESCRIPTION
This fixes some doxygen issues.

+ Remove PERL_PATH.
+ Add perf_debug and ilu_prec to the list.
+ Correct the graph rendering by the appropriate spacing at the end.
+ Fix the linking issue by generating the header of the example.hpp correctly.