### PR TITLE
fix sellp read

### DIFF
--- a/core/matrix/sellp.cpp
+++ b/core/matrix/sellp.cpp
@@ -76,18 +76,18 @@ size_type calculate_total_cols(const matrix_data<ValueType, IndexType> &data,
     IndexType current_slice = 0;
     size_type total_cols = 0;
     for (const auto &elem : data.nonzeros) {
+        if (elem.row != current_row) {
+            current_row = elem.row;
+            slice_lengths[current_slice] =
+                max(slice_lengths[current_slice], nonzeros_per_row);
+            nonzeros_per_row = 0;
+        }
         if (elem.row / slice_size != current_slice) {
             slice_lengths[current_slice] =
                 stride_factor *
                 ceildiv(slice_lengths[current_slice], stride_factor);
             total_cols += slice_lengths[current_slice];
             current_slice = elem.row / slice_size;
-        }
-        if (elem.row != current_row) {
-            current_row = elem.row;
-            slice_lengths[current_slice] =
-                max(slice_lengths[current_slice], nonzeros_per_row);
-            nonzeros_per_row = 0;
         }
         nonzeros_per_row += (elem.value != zero<ValueType>());
     }


### PR DESCRIPTION
This PR fixes the read function of Sellp

The original implementation might update the next `slice_length`