### PR TITLE
Add calculation of max relative norm in spmv 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,7 +54,7 @@ if(BUILD_SHARED_LIBS AND (WIN32 OR CYGWIN) AND (GINKGO_BUILD_TESTS OR GINKGO_BUI
     option(GINKGO_CHECK_PATH "Tell Ginkgo to check if the environment variable PATH is available for this build." ON)
     set(GINKGO_WINDOWS_SHARED_LIBRARY_RELPATH "windows_shared_library" CACHE STRING
         "Set Ginkgo's shared library relative path in windows. Current default is `windows_shared_library`. \
-        This absoulte path ${PROJECT_BINARY_DIR}/GINKGO_WINDOWS_SHARED_LIBRARY_RELPATH must be in the environment variable PATH.")
+        This absolute path ${PROJECT_BINARY_DIR}/GINKGO_WINDOWS_SHARED_LIBRARY_RELPATH must be in the environment variable PATH.")
     set(GINKGO_WINDOWS_SHARED_LIBRARY_PATH ${PROJECT_BINARY_DIR}/${GINKGO_WINDOWS_SHARED_LIBRARY_RELPATH})
 else()
     set(GINKGO_CHANGED_SHARED_LIBRARY FALSE)

--- a/benchmark/solver/solver.cpp
+++ b/benchmark/solver/solver.cpp
@@ -245,7 +245,7 @@ void solve_system(const std::string &solver_name,
         add_or_set_member(solver_json, "true_residuals",
                           rapidjson::Value(rapidjson::kArrayType), allocator);
         if (FLAGS_nrhs == 1) {
-            auto rhs_norm = compute_norm(lend(b));
+            auto rhs_norm = compute_norm2(lend(b));
             add_or_set_member(solver_json, "rhs_norm", rhs_norm, allocator);
         }
         for (auto stage : {"generate", "apply"}) {

--- a/benchmark/spmv/spmv.cpp
+++ b/benchmark/spmv/spmv.cpp
@@ -61,7 +61,8 @@ DEFINE_uint32(nrhs, 1, "The number of right hand sides");
 // calling it
 void apply_spmv(const char *format_name, std::shared_ptr<gko::Executor> exec,
                 const gko::matrix_data<etype> &data, const vec<etype> *b,
-                const vec<etype> *x, rapidjson::Value &test_case,
+                const vec<etype> *x, const vec<etype> *answer,
+                rapidjson::Value &test_case,
                 rapidjson::MemoryPoolAllocator<> &allocator)
 {
     try {
@@ -73,8 +74,20 @@ void apply_spmv(const char *format_name, std::shared_ptr<gko::Executor> exec,
         exec->add_logger(storage_logger);
         auto system_matrix =
             share(formats::matrix_factory.at(format_name)(exec, data));
+
         exec->remove_logger(gko::lend(storage_logger));
         storage_logger->write_data(spmv_case[format_name], allocator);
+        // check the residual
+        if (FLAGS_detailed) {
+            auto x_clone = clone(x);
+            exec->synchronize();
+            system_matrix->apply(lend(b), lend(x_clone));
+            exec->synchronize();
+            double max_relative_norm =
+                compute_max_relative_norm(lend(x_clone), lend(answer));
+            add_or_set_member(spmv_case[format_name], "max_relative_norm",
+                              max_relative_norm, allocator);
+        }
         // warm run
         for (unsigned int i = 0; i < FLAGS_warmup; i++) {
             auto x_clone = clone(x);
@@ -172,9 +185,20 @@ int main(int argc, char *argv[])
                                     rapidjson::Value(rapidjson::kObjectType),
                                     allocator);
             }
+
+            // Compute the result from ginkgo::coo as the correct answer
+            auto answer = vec<etype>::create(exec);
+            if (FLAGS_detailed) {
+                auto system_matrix =
+                    share(formats::matrix_factory.at("coo")(exec, data));
+                answer->copy_from(lend(x));
+                exec->synchronize();
+                system_matrix->apply(lend(b), lend(answer));
+                exec->synchronize();
+            }
             for (const auto &format_name : formats) {
                 apply_spmv(format_name.c_str(), exec, data, lend(b), lend(x),
-                           test_case, allocator);
+                           lend(answer), test_case, allocator);
                 std::clog << "Current state:" << std::endl
                           << test_cases << std::endl;
                 if (spmv_case[format_name.c_str()]["completed"].GetBool()) {

--- a/benchmark/spmv/spmv.cpp
+++ b/benchmark/spmv/spmv.cpp
@@ -83,10 +83,10 @@ void apply_spmv(const char *format_name, std::shared_ptr<gko::Executor> exec,
             exec->synchronize();
             system_matrix->apply(lend(b), lend(x_clone));
             exec->synchronize();
-            double max_relative_norm =
-                compute_max_relative_norm(lend(x_clone), lend(answer));
-            add_or_set_member(spmv_case[format_name], "max_relative_norm",
-                              max_relative_norm, allocator);
+            double max_relative_norm2 =
+                compute_max_relative_norm2(lend(x_clone), lend(answer));
+            add_or_set_member(spmv_case[format_name], "max_relative_norm2",
+                              max_relative_norm2, allocator);
         }
         // warm run
         for (unsigned int i = 0; i < FLAGS_warmup; i++) {

--- a/benchmark/utils/general.hpp
+++ b/benchmark/utils/general.hpp
@@ -37,6 +37,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <ginkgo/ginkgo.hpp>
 
 
+#include <algorithm>
 #include <array>
 #include <fstream>
 #include <functional>
@@ -346,6 +347,33 @@ double compute_residual_norm(const gko::LinOp *system_matrix,
     auto res = clone(b);
     system_matrix->apply(lend(one), lend(x), lend(neg_one), lend(res));
     return compute_norm(lend(res));
+}
+
+
+template <typename ValueType>
+double compute_max_relative_norm(vec<ValueType> *result,
+                                 const vec<ValueType> *answer)
+{
+    auto exec = answer->get_executor();
+    auto answer_norm =
+        vec<ValueType>::create(exec, gko::dim<2>{1, answer->get_size()[1]});
+    answer->compute_norm2(lend(answer_norm));
+    auto neg_one = gko::initialize<vec<ValueType>>({-1.0}, exec);
+    result->add_scaled(lend(neg_one), lend(answer));
+    auto absoulte_norm =
+        vec<ValueType>::create(exec, gko::dim<2>{1, answer->get_size()[1]});
+    result->compute_norm2(lend(absoulte_norm));
+    auto host_answer_norm =
+        clone(answer_norm->get_executor()->get_master(), answer_norm);
+    auto host_absoulte_norm =
+        clone(absoulte_norm->get_executor()->get_master(), absoulte_norm);
+    double max_relative_norm = 0;
+    for (gko::size_type i = 0; i < host_answer_norm->get_size()[1]; i++) {
+        max_relative_norm =
+            std::max(host_absoulte_norm->at(0, i) / host_answer_norm->at(0, i),
+                     max_relative_norm);
+    }
+    return max_relative_norm;
 }
 
 

--- a/benchmark/utils/general.hpp
+++ b/benchmark/utils/general.hpp
@@ -328,7 +328,7 @@ double get_norm(const vec<ValueType> *norm)
 
 
 template <typename ValueType>
-double compute_norm(const vec<ValueType> *b)
+double compute_norm2(const vec<ValueType> *b)
 {
     auto exec = b->get_executor();
     auto b_norm = gko::initialize<vec<ValueType>>({0.0}, exec);
@@ -346,13 +346,13 @@ double compute_residual_norm(const gko::LinOp *system_matrix,
     auto neg_one = gko::initialize<vec<ValueType>>({-1.0}, exec);
     auto res = clone(b);
     system_matrix->apply(lend(one), lend(x), lend(neg_one), lend(res));
-    return compute_norm(lend(res));
+    return compute_norm2(lend(res));
 }
 
 
 template <typename ValueType>
-double compute_max_relative_norm(vec<ValueType> *result,
-                                 const vec<ValueType> *answer)
+double compute_max_relative_norm2(vec<ValueType> *result,
+                                  const vec<ValueType> *answer)
 {
     auto exec = answer->get_executor();
     auto answer_norm =
@@ -360,20 +360,20 @@ double compute_max_relative_norm(vec<ValueType> *result,
     answer->compute_norm2(lend(answer_norm));
     auto neg_one = gko::initialize<vec<ValueType>>({-1.0}, exec);
     result->add_scaled(lend(neg_one), lend(answer));
-    auto absoulte_norm =
+    auto absolute_norm =
         vec<ValueType>::create(exec, gko::dim<2>{1, answer->get_size()[1]});
-    result->compute_norm2(lend(absoulte_norm));
+    result->compute_norm2(lend(absolute_norm));
     auto host_answer_norm =
         clone(answer_norm->get_executor()->get_master(), answer_norm);
-    auto host_absoulte_norm =
-        clone(absoulte_norm->get_executor()->get_master(), absoulte_norm);
-    double max_relative_norm = 0;
+    auto host_absolute_norm =
+        clone(absolute_norm->get_executor()->get_master(), absolute_norm);
+    double max_relative_norm2 = 0;
     for (gko::size_type i = 0; i < host_answer_norm->get_size()[1]; i++) {
-        max_relative_norm =
-            std::max(host_absoulte_norm->at(0, i) / host_answer_norm->at(0, i),
-                     max_relative_norm);
+        max_relative_norm2 =
+            std::max(host_absolute_norm->at(0, i) / host_answer_norm->at(0, i),
+                     max_relative_norm2);
     }
-    return max_relative_norm;
+    return max_relative_norm2;
 }
 
 

--- a/benchmark/utils/loggers.hpp
+++ b/benchmark/utils/loggers.hpp
@@ -195,7 +195,7 @@ struct ResidualLogger : gko::log::Logger {
                 get_norm(gko::as<vec<ValueType>>(residual_norm)), alloc);
         } else {
             rec_res_norms.PushBack(
-                compute_norm(gko::as<vec<ValueType>>(residual)), alloc);
+                compute_norm2(gko::as<vec<ValueType>>(residual)), alloc);
         }
         if (solution) {
             true_res_norms.PushBack(


### PR DESCRIPTION
This PR add calculation of max relative norm in spmv  when detailed is true

It uses coo as the reference results. (to be same format in reference/omp/cuda/hip executors)

When `nrhs > 1`, it takes the max relative norm as result.