### PR TITLE
Fix broken bounds checks

### DIFF
--- a/core/test/base/exception_helpers.cpp
+++ b/core/test/base/exception_helpers.cpp
@@ -131,6 +131,18 @@ TEST(AssertConformant, ThrowsWhenNotConformant)
 }
 
 
+TEST(AssertEqual, DoesNotThrowWhenEqual)
+{
+    ASSERT_NO_THROW(GKO_ASSERT_EQ(1, 1));
+}
+
+
+TEST(AssertEqual, ThrowsWhenNotEqual)
+{
+    ASSERT_THROW(GKO_ASSERT_EQ(0, 1), gko::ValueMismatch);
+}
+
+
 TEST(AssertEqualRows, DoesNotThrowWhenEqualRowSize)
 {
     ASSERT_NO_THROW(

--- a/core/test/matrix/permutation.cpp
+++ b/core/test/matrix/permutation.cpp
@@ -127,7 +127,7 @@ TEST_F(Permutation, PermutationThrowsforWrongRowPermDimensions)
     ASSERT_THROW(
         gko::matrix::Permutation<>::create(
             exec, gko::dim<2>{4, 2}, gko::Array<i_type>::view(exec, 3, data)),
-        gko::OutOfBoundsError);
+        gko::ValueMismatch);
 }
 
 
@@ -139,7 +139,7 @@ TEST_F(Permutation, PermutationThrowsforWrongColPermDimensions)
         gko::matrix::Permutation<>::create(
             exec, gko::dim<2>{3, 4}, gko::Array<i_type>::view(exec, 3, data),
             gko::matrix::column_permute),
-        gko::OutOfBoundsError);
+        gko::ValueMismatch);
 }
 
 

--- a/include/ginkgo/core/matrix/coo.hpp
+++ b/include/ginkgo/core/matrix/coo.hpp
@@ -278,10 +278,8 @@ protected:
           col_idxs_{exec, std::forward<ColIdxsArray>(col_idxs)},
           row_idxs_{exec, std::forward<RowIdxsArray>(row_idxs)}
     {
-        GKO_ENSURE_IN_BOUNDS(values_.get_num_elems() - 1,
-                             col_idxs_.get_num_elems());
-        GKO_ENSURE_IN_BOUNDS(values_.get_num_elems() - 1,
-                             row_idxs_.get_num_elems());
+        GKO_ASSERT_EQ(values_.get_num_elems(), col_idxs_.get_num_elems());
+        GKO_ASSERT_EQ(values_.get_num_elems(), row_idxs_.get_num_elems());
     }
 
     void apply_impl(const LinOp *b, LinOp *x) const override;

--- a/include/ginkgo/core/matrix/csr.hpp
+++ b/include/ginkgo/core/matrix/csr.hpp
@@ -748,9 +748,8 @@ protected:
           srow_(exec),
           strategy_(std::move(strategy))
     {
-        GKO_ENSURE_IN_BOUNDS(values_.get_num_elems() - 1,
-                             col_idxs_.get_num_elems());
-        GKO_ENSURE_IN_BOUNDS(this->get_size()[0], row_ptrs_.get_num_elems());
+        GKO_ASSERT_EQ(values_.get_num_elems(), col_idxs_.get_num_elems());
+        GKO_ASSERT_EQ(this->get_size()[0] + 1, row_ptrs_.get_num_elems());
         this->make_srow();
     }
 

--- a/include/ginkgo/core/matrix/dense.hpp
+++ b/include/ginkgo/core/matrix/dense.hpp
@@ -471,8 +471,7 @@ protected:
           values_{exec, std::forward<ValuesArray>(values)},
           stride_{stride}
     {
-        GKO_ASSERT_EQ((size[0] - 1) * stride + size[1],
-                      values_.get_num_elems());
+        GKO_ASSERT_EQ(size[0] * stride, values_.get_num_elems());
     }
 
     /**

--- a/include/ginkgo/core/matrix/dense.hpp
+++ b/include/ginkgo/core/matrix/dense.hpp
@@ -471,8 +471,8 @@ protected:
           values_{exec, std::forward<ValuesArray>(values)},
           stride_{stride}
     {
-        GKO_ENSURE_IN_BOUNDS((size[0] - 1) * stride + size[1] - 1,
-                             values_.get_num_elems());
+        GKO_ASSERT_EQ((size[0] - 1) * stride + size[1],
+                      values_.get_num_elems());
     }
 
     /**

--- a/include/ginkgo/core/matrix/dense.hpp
+++ b/include/ginkgo/core/matrix/dense.hpp
@@ -471,7 +471,8 @@ protected:
           values_{exec, std::forward<ValuesArray>(values)},
           stride_{stride}
     {
-        GKO_ASSERT_EQ(size[0] * stride, values_.get_num_elems());
+        GKO_ENSURE_IN_BOUNDS((size[0] - 1) * stride + size[1] - 1,
+                             values_.get_num_elems());
     }
 
     /**

--- a/include/ginkgo/core/matrix/ell.hpp
+++ b/include/ginkgo/core/matrix/ell.hpp
@@ -287,10 +287,10 @@ protected:
           num_stored_elements_per_row_{num_stored_elements_per_row},
           stride_{stride}
     {
-        GKO_ENSURE_IN_BOUNDS(num_stored_elements_per_row_ * stride_ - 1,
-                             values_.get_num_elems());
-        GKO_ENSURE_IN_BOUNDS(num_stored_elements_per_row_ * stride_ - 1,
-                             col_idxs_.get_num_elems());
+        GKO_ASSERT_EQ(num_stored_elements_per_row_ * stride_,
+                      values_.get_num_elems());
+        GKO_ASSERT_EQ(num_stored_elements_per_row_ * stride_,
+                      col_idxs_.get_num_elems());
     }
 
     void apply_impl(const LinOp *b, LinOp *x) const override;

--- a/include/ginkgo/core/matrix/permutation.hpp
+++ b/include/ginkgo/core/matrix/permutation.hpp
@@ -164,10 +164,10 @@ protected:
           enabled_permute_(enabled_permute)
     {
         if (enabled_permute_ & row_permute) {
-            GKO_ENSURE_IN_BOUNDS(size[0] - 1, permutation_.get_num_elems());
+            GKO_ASSERT_EQ(size[0], permutation_.get_num_elems());
         }
         if (enabled_permute_ & column_permute) {
-            GKO_ENSURE_IN_BOUNDS(size[1] - 1, permutation_.get_num_elems());
+            GKO_ASSERT_EQ(size[1], permutation_.get_num_elems());
         }
     }
 

--- a/include/ginkgo/core/matrix/sparsity_csr.hpp
+++ b/include/ginkgo/core/matrix/sparsity_csr.hpp
@@ -240,9 +240,7 @@ protected:
         auto tmp = Array<value_type>{exec->get_master(), 1};
         tmp.get_data()[0] = value;
         value_ = Array<value_type>{exec, std::move(tmp)};
-        GKO_ENSURE_IN_BOUNDS(col_idxs_.get_num_elems() - 1,
-                             col_idxs_.get_num_elems());
-        GKO_ENSURE_IN_BOUNDS(this->get_size()[0], row_ptrs_.get_num_elems());
+        GKO_ASSERT_EQ(this->get_size()[0] + 1, row_ptrs_.get_num_elems());
     }
 
     /**


### PR DESCRIPTION
As #387 explains, we have some bounds checks that should rather be checks for equality, unless we want to allow our `Array`s to over-allocate memory, e.g. for SIMD purposes or similar.

This pull request replaces all `GKO_ENSURE_IN_BOUNDS` by equivalent or more strict `GKO_ASSERT_EQ`