### PR TITLE
Print error for incompatible HIP and CUDA settings

### DIFF
--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -8,7 +8,7 @@ if (GINKGO_BUILD_CUDA AND GINKGO_BUILD_HIP AND GINKGO_HIP_PLATFORM MATCHES "hcc"
   message(FATAL_ERROR "Building the benchmarks for both HIP AMD and CUDA "
           "at the same time is currently not supported. "
 	  "Disable the benchmark build using `-DGINKGO_BUILD_BENCHMARKS=OFF` "
-	  "or use `export HIP_PLATFORM=nvcc` in your build environment, instead.")
+	  "or use `export HIP_PLATFORM=nvcc` in your build environment instead.")
 endif()
 
 function(ginkgo_benchmark_cusp_linops name)

--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -5,8 +5,10 @@ if (NOT CMAKE_BUILD_TYPE STREQUAL "Release")
 endif()
 
 if (GINKGO_BUILD_CUDA AND GINKGO_BUILD_HIP AND GINKGO_HIP_PLATFORM MATCHES "hcc")
-  message(FATAL_ERROR "Building the benchmarks with both HIP AMD and CUDA support "
-      "at the same time is currently not supported. Use `export HIP_PLATFORM=nvcc` instead.")
+  message(FATAL_ERROR "Building the benchmarks for both HIP AMD and CUDA "
+          "at the same time is currently not supported. "
+	  "Disable the benchmark build using `-DGINKGO_BUILD_BENCHMARKS=OFF` "
+	  "or use `export HIP_PLATFORM=nvcc` in your build environment, instead.")
 endif()
 
 function(ginkgo_benchmark_cusp_linops name)

--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -4,6 +4,11 @@ if (NOT CMAKE_BUILD_TYPE STREQUAL "Release")
         "will be affected")
 endif()
 
+if (GINKGO_BUILD_CUDA AND GINKGO_BUILD_HIP AND GINKGO_HIP_PLATFORM MATCHES "hcc")
+  message(FATAL_ERROR "Building the benchmarks with both HIP AMD and CUDA support "
+      "at the same time is currently not supported. Use `export HIP_PLATFORM=nvcc` instead.")
+endif()
+
 function(ginkgo_benchmark_cusp_linops name)
     target_compile_definitions("${name}" PRIVATE HAS_CUDA=1)
     target_link_libraries("${name}" ginkgo ${CUDA_RUNTIME_LIBS}


### PR DESCRIPTION
This PR is meant to avoid other people making the same mistake as I did with configuring HIP and CUDA: When trying to compile the benchmarks using HCC and NVCC simultaneously, instead of getting confusing compiler errors, we fail early.

Closes https://github.com/ginkgo-project/ginkgo/issues/392