### PR TITLE
Update git-cmake-format source repository

### DIFF
--- a/third_party/git-cmake-format/CMakeLists.txt
+++ b/third_party/git-cmake-format/CMakeLists.txt
@@ -1,5 +1,5 @@
 ginkgo_load_git_package(git-cmake-format
-    "https://github.com/gflegar/git-cmake-format.git"
-    "9fdc1553c525b3d7ce758892fe666078903a1b21")
+    "https://github.com/ginkgo-project/git-cmake-format.git"
+    "e19ab13e640d58abd3bfdbff5f77b499b2ec4169")
 add_subdirectory(${CMAKE_CURRENT_BINARY_DIR}/src
     ${CMAKE_CURRENT_BINARY_DIR}/build EXCLUDE_FROM_ALL)


### PR DESCRIPTION
We need to make some changes to the `git-cmake-format.py` script, so we [forked the repository](https://github.com/ginkgo-project/git-cmake-format) and need to update the corresponding paths and commit hash.

The changes are
* Add `.hpp.inc` files to the list of formatted files
* Don't unstage files when they need to be formatted. This is especially annoying when you only staged some of your files or even only parts of these files (`git add -p`). The behavior of the pre-commit hook should not change, since it only checks the staged files (without unstaged changes!) for formatting purposes.