### PR TITLE
Improve classical csr

### DIFF
--- a/common/matrix/csr_kernels.hpp.inc
+++ b/common/matrix/csr_kernels.hpp.inc
@@ -441,24 +441,27 @@ __device__ void device_classical_spmv(const size_type num_rows,
 {
     const auto tid =
         (static_cast<size_type>(blockDim.x) * blockIdx.x + threadIdx.x);
-    const auto row = tid / subwarp_size;
+    const auto subrow =
+        static_cast<size_type>(gridDim.x) * blockDim.x / subwarp_size;
     const auto subid = tid % subwarp_size;
-    if (row >= num_rows) {
-        return;
-    }
     const auto column_id = blockIdx.y;
-    const auto ind_end = row_ptrs[row + 1];
-    ValueType temp_val = zero<ValueType>();
-    for (auto ind = row_ptrs[row] + subid; ind < ind_end; ind += subwarp_size) {
-        temp_val += val[ind] * b[col_idxs[ind] * b_stride + column_id];
+    for (auto row = tid / subwarp_size; row < num_rows; row += subrow) {
+        const auto ind_end = row_ptrs[row + 1];
+        ValueType temp_val = zero<ValueType>();
+        for (auto ind = row_ptrs[row] + subid; ind < ind_end;
+             ind += subwarp_size) {
+            temp_val += val[ind] * b[col_idxs[ind] * b_stride + column_id];
+        }
+        auto subwarp_tile =
+            group::tiled_partition<subwarp_size>(group::this_thread_block());
+        auto subwarp_result = reduce(
+            subwarp_tile, temp_val,
+            [](const ValueType &a, const ValueType &b) { return a + b; });
+        if (subid == 0) {
+            c[row * c_stride + column_id] =
+                scale(subwarp_result, c[row * c_stride + column_id]);
+        }
     }
-    auto subwarp_tile =
-        group::tiled_partition<subwarp_size>(group::this_thread_block());
-    auto subwarp_result =
-        reduce(subwarp_tile, temp_val,
-               [](const ValueType &a, const ValueType &b) { return a + b; });
-    c[row * c_stride + column_id] =
-        scale(subwarp_result, c[row * c_stride + column_id]);
 }
 
 

--- a/common/matrix/csr_kernels.hpp.inc
+++ b/common/matrix/csr_kernels.hpp.inc
@@ -222,8 +222,7 @@ template <typename ValueType>
 __global__ __launch_bounds__(default_block_size) void set_zero(
     const size_type nnz, ValueType *__restrict__ val)
 {
-    const auto ind =
-        static_cast<size_type>(blockDim.x) * blockIdx.x + threadIdx.x;
+    const auto ind = size_type(blockDim.x) * blockIdx.x + threadIdx.x;
     if (ind < nnz) {
         val[ind] = zero<ValueType>();
     }
@@ -309,7 +308,7 @@ __device__ void merge_path_spmv(
     const auto block_items = spmv_block_size * items_per_thread;
     __shared__ IndexType shared_row_ptrs[block_items];
     const IndexType diagonal =
-        min(static_cast<IndexType>(block_items * blockIdx.x), num_merge_items);
+        min(IndexType(block_items * blockIdx.x), num_merge_items);
     const IndexType diagonal_end = min(diagonal + block_items, num_merge_items);
     IndexType block_start_x;
     IndexType block_start_y;
@@ -330,9 +329,9 @@ __device__ void merge_path_spmv(
 
     IndexType start_x;
     IndexType start_y;
-    merge_path_search(static_cast<IndexType>(items_per_thread * threadIdx.x),
-                      block_num_rows, block_num_nonzeros, shared_row_ptrs,
-                      block_start_y, &start_x, &start_y);
+    merge_path_search(IndexType(items_per_thread * threadIdx.x), block_num_rows,
+                      block_num_nonzeros, shared_row_ptrs, block_start_y,
+                      &start_x, &start_y);
 
 
     IndexType ind = block_start_y + start_y;
@@ -439,10 +438,8 @@ __device__ void device_classical_spmv(const size_type num_rows,
                                       ValueType *__restrict__ c,
                                       const size_type c_stride, Closure scale)
 {
-    const auto tid =
-        (static_cast<size_type>(blockDim.x) * blockIdx.x + threadIdx.x);
-    const auto subrow =
-        static_cast<size_type>(gridDim.x) * blockDim.x / subwarp_size;
+    const auto tid = size_type(blockDim.x) * blockIdx.x + threadIdx.x;
+    const auto subrow = size_type(gridDim.x) * blockDim.x / subwarp_size;
     const auto subid = tid % subwarp_size;
     const auto column_id = blockIdx.y;
     for (auto row = tid / subwarp_size; row < num_rows; row += subrow) {
@@ -787,8 +784,7 @@ template <typename ValueType>
 __global__ __launch_bounds__(default_block_size) void conjugate_kernel(
     size_type num_nonzeros, ValueType *__restrict__ val)
 {
-    const auto tidx =
-        static_cast<size_type>(blockIdx.x) * default_block_size + threadIdx.x;
+    const auto tidx = size_type(blockIdx.x) * default_block_size + threadIdx.x;
 
     if (tidx < num_nonzeros) {
         val[tidx] = conj(val[tidx]);

--- a/common/matrix/csr_kernels.hpp.inc
+++ b/common/matrix/csr_kernels.hpp.inc
@@ -254,10 +254,10 @@ __forceinline__ __device__ void merge_path_search(
 
 template <typename ValueType, typename IndexType, typename Alpha_op>
 __device__ void merge_path_reduce(const IndexType nwarps,
-                       const ValueType *__restrict__ last_val,
-                       const IndexType *__restrict__ last_row,
-                       ValueType *__restrict__ c, const size_type c_stride,
-                       Alpha_op alpha_op)
+                                  const ValueType *__restrict__ last_val,
+                                  const IndexType *__restrict__ last_row,
+                                  ValueType *__restrict__ c,
+                                  const size_type c_stride, Alpha_op alpha_op)
 {
     const IndexType cache_lines = ceildivT<IndexType>(nwarps, spmv_block_size);
     const IndexType tid = threadIdx.x;
@@ -412,7 +412,7 @@ __global__ __launch_bounds__(spmv_block_size) void abstract_reduce(
     const size_type c_stride)
 {
     merge_path_reduce(nwarps, last_val, last_row, c, c_stride,
-           [](ValueType &x) { return x; });
+                      [](ValueType &x) { return x; });
 }
 
 
@@ -424,51 +424,60 @@ __global__ __launch_bounds__(spmv_block_size) void abstract_reduce(
 {
     const auto alpha_val = alpha[0];
     merge_path_reduce(nwarps, last_val, last_row, c, c_stride,
-           [&alpha_val](ValueType &x) { return alpha_val * x; });
+                      [&alpha_val](ValueType &x) { return alpha_val * x; });
 }
 
 
-template <typename ValueType, typename IndexType, typename Closure>
-__device__ void classical_spmv(const size_type num_rows,
-                               const ValueType *__restrict__ val,
-                               const IndexType *__restrict__ col_idxs,
-                               const IndexType *__restrict__ row_ptrs,
-                               const ValueType *__restrict__ b,
-                               const size_type b_stride,
-                               ValueType *__restrict__ c,
-                               const size_type c_stride, Closure scale)
+template <size_type subwarp_size, typename ValueType, typename IndexType,
+          typename Closure>
+__device__ void device_classical_spmv(const size_type num_rows,
+                                      const ValueType *__restrict__ val,
+                                      const IndexType *__restrict__ col_idxs,
+                                      const IndexType *__restrict__ row_ptrs,
+                                      const ValueType *__restrict__ b,
+                                      const size_type b_stride,
+                                      ValueType *__restrict__ c,
+                                      const size_type c_stride, Closure scale)
 {
     const auto tid =
-        static_cast<size_type>(blockDim.x) * blockIdx.x + threadIdx.x;
-    if (tid >= num_rows) {
+        (static_cast<size_type>(blockDim.x) * blockIdx.x + threadIdx.x);
+    const auto row = tid / subwarp_size;
+    const auto subid = tid % subwarp_size;
+    if (row >= num_rows) {
         return;
     }
     const auto column_id = blockIdx.y;
-    const auto ind_end = row_ptrs[tid + 1];
-    ValueType temp_value = zero<ValueType>();
-    for (auto ind = row_ptrs[tid]; ind < ind_end; ind++) {
-        temp_value += val[ind] * b[col_idxs[ind] * b_stride + column_id];
+    const auto ind_end = row_ptrs[row + 1];
+    ValueType temp_val = zero<ValueType>();
+    for (auto ind = row_ptrs[row] + subid; ind < ind_end; ind += subwarp_size) {
+        temp_val += val[ind] * b[col_idxs[ind] * b_stride + column_id];
     }
-    c[tid * c_stride + column_id] =
-        scale(temp_value, c[tid * c_stride + column_id]);
+    auto subwarp_tile =
+        group::tiled_partition<subwarp_size>(group::this_thread_block());
+    auto subwarp_result =
+        reduce(subwarp_tile, temp_val,
+               [](const ValueType &a, const ValueType &b) { return a + b; });
+    c[row * c_stride + column_id] =
+        scale(subwarp_result, c[row * c_stride + column_id]);
 }
 
 
-template <typename ValueType, typename IndexType>
-__global__ __launch_bounds__(classical_block_size) void abstract_classical_spmv(
+template <size_type subwarp_size, typename ValueType, typename IndexType>
+__global__ __launch_bounds__(spmv_block_size) void abstract_classical_spmv(
     const size_type num_rows, const ValueType *__restrict__ val,
     const IndexType *__restrict__ col_idxs,
     const IndexType *__restrict__ row_ptrs, const ValueType *__restrict__ b,
     const size_type b_stride, ValueType *__restrict__ c,
     const size_type c_stride)
 {
-    classical_spmv(num_rows, val, col_idxs, row_ptrs, b, b_stride, c, c_stride,
-                   [](const ValueType &x, const ValueType &y) { return x; });
+    device_classical_spmv<subwarp_size>(
+        num_rows, val, col_idxs, row_ptrs, b, b_stride, c, c_stride,
+        [](const ValueType &x, const ValueType &y) { return x; });
 }
 
 
-template <typename ValueType, typename IndexType>
-__global__ __launch_bounds__(classical_block_size) void abstract_classical_spmv(
+template <size_type subwarp_size, typename ValueType, typename IndexType>
+__global__ __launch_bounds__(spmv_block_size) void abstract_classical_spmv(
     const size_type num_rows, const ValueType *__restrict__ alpha,
     const ValueType *__restrict__ val, const IndexType *__restrict__ col_idxs,
     const IndexType *__restrict__ row_ptrs, const ValueType *__restrict__ b,
@@ -477,7 +486,7 @@ __global__ __launch_bounds__(classical_block_size) void abstract_classical_spmv(
 {
     const auto alpha_val = alpha[0];
     const auto beta_val = beta[0];
-    classical_spmv(
+    device_classical_spmv<subwarp_size>(
         num_rows, val, col_idxs, row_ptrs, b, b_stride, c, c_stride,
         [&alpha_val, &beta_val](const ValueType &x, const ValueType &y) {
             return alpha_val * x + beta_val * y;
@@ -500,10 +509,9 @@ __global__ __launch_bounds__(default_block_size) void convert_row_ptrs_to_idxs(
 
 
 template <typename ValueType>
-__global__
-    __launch_bounds__(config::max_block_size) void initialize_zero_dense(
-        size_type num_rows, size_type num_cols, size_type stride,
-        ValueType *__restrict__ result)
+__global__ __launch_bounds__(config::max_block_size) void initialize_zero_dense(
+    size_type num_rows, size_type num_cols, size_type stride,
+    ValueType *__restrict__ result)
 {
     const auto tidx_x = threadIdx.x + blockDim.x * blockIdx.x;
     const auto tidx_y = threadIdx.y + blockDim.y * blockIdx.y;
@@ -541,12 +549,10 @@ __global__ __launch_bounds__(default_block_size) void calculate_nnz_per_row(
 }
 
 
-__global__
-    __launch_bounds__(config::warp_size) void calculate_slice_lengths(
-        size_type num_rows, size_type slice_size, size_type stride_factor,
-        const size_type *__restrict__ nnz_per_row,
-        size_type *__restrict__ slice_lengths,
-        size_type *__restrict__ slice_sets)
+__global__ __launch_bounds__(config::warp_size) void calculate_slice_lengths(
+    size_type num_rows, size_type slice_size, size_type stride_factor,
+    const size_type *__restrict__ nnz_per_row,
+    size_type *__restrict__ slice_lengths, size_type *__restrict__ slice_sets)
 {
     constexpr auto warp_size = config::warp_size;
     const auto sliceid = blockIdx.x;
@@ -788,6 +794,3 @@ __global__ __launch_bounds__(default_block_size) void conjugate_kernel(
 
 
 }  //  namespace
-
-
-

--- a/cuda/matrix/csr_kernels.cu
+++ b/cuda/matrix/csr_kernels.cu
@@ -76,7 +76,6 @@ namespace csr {
 constexpr int default_block_size = 512;
 constexpr int warps_in_block = 4;
 constexpr int spmv_block_size = warps_in_block * config::warp_size;
-constexpr int classical_block_size = 64;
 constexpr int wsize = config::warp_size;
 
 
@@ -85,6 +84,9 @@ constexpr int wsize = config::warp_size;
  * should be compiled.
  */
 using compiled_kernels = syn::value_list<int, 3, 4, 6, 7, 8, 12, 14>;
+
+using classical_kernels =
+    syn::value_list<int, config::warp_size, 32, 16, 8, 4, 2, 1>;
 
 
 #include "common/matrix/csr_kernels.hpp.inc"
@@ -197,6 +199,41 @@ int compute_items_per_thread(std::shared_ptr<const CudaExecutor> exec)
 }
 
 
+template <int subwarp_size, typename ValueType, typename IndexType>
+void classical_spmv(syn::value_list<int, subwarp_size>,
+                    std::shared_ptr<const CudaExecutor> exec,
+                    const matrix::Csr<ValueType, IndexType> *a,
+                    const matrix::Dense<ValueType> *b,
+                    matrix::Dense<ValueType> *c,
+                    const matrix::Dense<ValueType> *alpha = nullptr,
+                    const matrix::Dense<ValueType> *beta = nullptr)
+{
+    const dim3 grid(ceildiv(a->get_size()[0], spmv_block_size / subwarp_size),
+                    b->get_size()[1]);
+    const dim3 block(spmv_block_size);
+    if (alpha == nullptr && beta == nullptr) {
+        kernel::abstract_classical_spmv<subwarp_size><<<grid, block, 0, 0>>>(
+            a->get_size()[0], as_cuda_type(a->get_const_values()),
+            a->get_const_col_idxs(), as_cuda_type(a->get_const_row_ptrs()),
+            as_cuda_type(b->get_const_values()), b->get_stride(),
+            as_cuda_type(c->get_values()), c->get_stride());
+
+    } else if (alpha != nullptr && beta != nullptr) {
+        kernel::abstract_classical_spmv<subwarp_size><<<grid, block, 0, 0>>>(
+            a->get_size()[0], as_cuda_type(alpha->get_const_values()),
+            as_cuda_type(a->get_const_values()), a->get_const_col_idxs(),
+            as_cuda_type(a->get_const_row_ptrs()),
+            as_cuda_type(b->get_const_values()), b->get_stride(),
+            as_cuda_type(beta->get_const_values()),
+            as_cuda_type(c->get_values()), c->get_stride());
+    } else {
+        GKO_KERNEL_NOT_FOUND;
+    }
+}
+
+GKO_ENABLE_IMPLEMENTATION_SELECTION(select_classical_spmv, classical_spmv);
+
+
 }  // namespace host_kernel
 
 
@@ -233,13 +270,24 @@ void spmv(std::shared_ptr<const CudaExecutor> exec,
             },
             syn::value_list<int>(), syn::type_list<>(), exec, a, b, c);
     } else if (a->get_strategy()->get_name() == "classical") {
-        const dim3 grid(ceildiv(a->get_size()[0], classical_block_size),
-                        b->get_size()[1]);
-        kernel::abstract_classical_spmv<<<grid, classical_block_size>>>(
-            a->get_size()[0], as_cuda_type(a->get_const_values()),
-            a->get_const_col_idxs(), as_cuda_type(a->get_const_row_ptrs()),
-            as_cuda_type(b->get_const_values()), b->get_stride(),
-            as_cuda_type(c->get_values()), c->get_stride());
+        IndexType max_length_per_row = 0;
+        using Tcsr = matrix::Csr<ValueType, IndexType>;
+        if (auto strategy =
+                std::dynamic_pointer_cast<const typename Tcsr::classical>(
+                    a->get_strategy())) {
+            max_length_per_row = strategy->get_max_length_per_row();
+        } else if (auto strategy = std::dynamic_pointer_cast<
+                       const typename Tcsr::automatical>(a->get_strategy())) {
+            max_length_per_row = strategy->get_max_length_per_row();
+        } else {
+            GKO_NOT_SUPPORTED(a->get_strategy());
+        }
+        host_kernel::select_classical_spmv(
+            classical_kernels(),
+            [&max_length_per_row](int compiled_info) {
+                return max_length_per_row >= compiled_info;
+            },
+            syn::value_list<int>(), syn::type_list<>(), exec, a, b, c);
     } else if (a->get_strategy()->get_name() == "sparselib" ||
                a->get_strategy()->get_name() == "cusparse") {
         if (cusparse::is_supported<ValueType, IndexType>::value) {
@@ -327,15 +375,25 @@ void advanced_spmv(std::shared_ptr<const CudaExecutor> exec,
             GKO_NOT_IMPLEMENTED;
         }
     } else if (a->get_strategy()->get_name() == "classical") {
-        const dim3 grid(ceildiv(a->get_size()[0], classical_block_size),
-                        b->get_size()[1]);
-        kernel::abstract_classical_spmv<<<grid, classical_block_size>>>(
-            a->get_size()[0], as_cuda_type(alpha->get_const_values()),
-            as_cuda_type(a->get_const_values()), a->get_const_col_idxs(),
-            as_cuda_type(a->get_const_row_ptrs()),
-            as_cuda_type(b->get_const_values()), b->get_stride(),
-            as_cuda_type(beta->get_const_values()),
-            as_cuda_type(c->get_values()), c->get_stride());
+        IndexType max_length_per_row = 0;
+        using Tcsr = matrix::Csr<ValueType, IndexType>;
+        if (auto strategy =
+                std::dynamic_pointer_cast<const typename Tcsr::classical>(
+                    a->get_strategy())) {
+            max_length_per_row = strategy->get_max_length_per_row();
+        } else if (auto strategy = std::dynamic_pointer_cast<
+                       const typename Tcsr::automatical>(a->get_strategy())) {
+            max_length_per_row = strategy->get_max_length_per_row();
+        } else {
+            GKO_NOT_SUPPORTED(a->get_strategy());
+        }
+        host_kernel::select_classical_spmv(
+            classical_kernels(),
+            [&max_length_per_row](int compiled_info) {
+                return max_length_per_row >= compiled_info;
+            },
+            syn::value_list<int>(), syn::type_list<>(), exec, a, b, c, alpha,
+            beta);
     } else if (a->get_strategy()->get_name() == "merge_path") {
         int items_per_thread =
             host_kernel::compute_items_per_thread<ValueType, IndexType>(exec);

--- a/cuda/matrix/csr_kernels.cu
+++ b/cuda/matrix/csr_kernels.cu
@@ -77,7 +77,7 @@ constexpr int default_block_size = 512;
 constexpr int warps_in_block = 4;
 constexpr int spmv_block_size = warps_in_block * config::warp_size;
 constexpr int wsize = config::warp_size;
-constexpr int classical_overweight = 4;
+constexpr int classical_overweight = 32;
 
 
 /**
@@ -216,6 +216,7 @@ void classical_spmv(syn::value_list<int, subwarp_size>,
                  int64(nwarps / warps_in_block));
     const dim3 grid(gridx, b->get_size()[1]);
     const dim3 block(spmv_block_size);
+
     if (alpha == nullptr && beta == nullptr) {
         kernel::abstract_classical_spmv<subwarp_size><<<grid, block, 0, 0>>>(
             a->get_size()[0], as_cuda_type(a->get_const_values()),

--- a/hip/matrix/csr_kernels.hip.cpp
+++ b/hip/matrix/csr_kernels.hip.cpp
@@ -80,7 +80,7 @@ constexpr int default_block_size = 512;
 constexpr int warps_in_block = 4;
 constexpr int spmv_block_size = warps_in_block * config::warp_size;
 constexpr int wsize = config::warp_size;
-constexpr int classical_overweight = 4;
+constexpr int classical_overweight = 32;
 
 
 /**

--- a/hip/matrix/csr_kernels.hip.cpp
+++ b/hip/matrix/csr_kernels.hip.cpp
@@ -80,6 +80,7 @@ constexpr int default_block_size = 512;
 constexpr int warps_in_block = 4;
 constexpr int spmv_block_size = warps_in_block * config::warp_size;
 constexpr int wsize = config::warp_size;
+constexpr int classical_overweight = 4;
 
 
 /**
@@ -231,9 +232,14 @@ void classical_spmv(syn::value_list<int, subwarp_size>,
                     const matrix::Dense<ValueType> *alpha = nullptr,
                     const matrix::Dense<ValueType> *beta = nullptr)
 {
-    const dim3 grid(ceildiv(a->get_size()[0], spmv_block_size / subwarp_size),
-                    b->get_size()[1]);
+    const auto nwarps = exec->get_num_warps_per_sm() *
+                        exec->get_num_multiprocessor() * classical_overweight;
+    const auto gridx =
+        std::min(ceildiv(a->get_size()[0], spmv_block_size / subwarp_size),
+                 int64(nwarps / warps_in_block));
+    const dim3 grid(gridx, b->get_size()[1]);
     const dim3 block(spmv_block_size);
+
     if (alpha == nullptr && beta == nullptr) {
         hipLaunchKernelGGL(
             HIP_KERNEL_NAME(kernel::abstract_classical_spmv<subwarp_size>),

--- a/include/ginkgo/core/matrix/csr.hpp
+++ b/include/ginkgo/core/matrix/csr.hpp
@@ -196,8 +196,8 @@ public:
             auto num_rows = mtx_row_ptrs.get_num_elems() - 1;
             max_length_per_row_ = 0;
             for (index_type i = 1; i < num_rows + 1; i++) {
-                max_length_per_row_ =
-                    std::max(maxnum, row_ptrs[i] - row_ptrs[i - 1]);
+                max_length_per_row_ = std::max(max_length_per_row_,
+                                               row_ptrs[i] - row_ptrs[i - 1]);
             }
         }
 

--- a/include/ginkgo/core/matrix/csr.hpp
+++ b/include/ginkgo/core/matrix/csr.hpp
@@ -170,7 +170,9 @@ public:
 
     /**
      * classical is a strategy_type which uses the same number of threads on
-     * each row.
+     * each row. Classical strategy uses multithreads to calculate on parts of
+     * rows and then do a reduction of these threads results. The number of
+     * threads per row depends on the max number of stored elements per row.
      */
     class classical : public strategy_type {
     public:


### PR DESCRIPTION
This PR improves the performance of the classical csr.
The idea uses multithreads per row.
Some parameters of automatical strategy selection need to be tuned for CUDA.

I set the upper limits of grid size by multiprocessor and some config because grid size has problem from HIP.
If the grid size is larger than some number (maybe 1e7), it will reduce grid size by a factor (about 27) without warning.
``` 
<<hip-api pid:18269 tid:1.477 hipModuleLaunchKernel (0x7fa81f3d1600, 17419152, 1, 1, 256, 1, 1, 0, stream:<null>, 0, 0x7ffe943172a0) @172894792082967
  hip-sync pid:18269 tid:1:ihipSyncAndResolveStream stream:<null> wait on default stream
  hip-sync pid:18269 tid:1:locking criticalData=0x256fc18 for ctx:0x256fc00.dev:0..
  hip-sync pid:18269 tid:1:syncDefaultStream
  hip-sync pid:18269 tid:1:  syncDefaultStream depOps=0
  hip-sync pid:18269 tid:1:auto-unlocking criticalData=0x256fc18 for ctx:0x256fc00.dev:0...
  hip-sync pid:18269 tid:1:locking criticalData=0x2570200 for stream:0.0..
<<hip-api pid:18269 tid:1.477 18269 1.477 hipLaunchKernel '_ZN3gko7kernels3hip3csr6kernel23abstract_classical_spmvILm32EdiEEvmPKT0_PKT1_SA_S7_mPS5_m' gridDim:{641936,1,1} groupDim:{256,1,1} sharedMem:+0 stream:0.0 @172894792205598


<<hip-api pid:17308 tid:1.477 hipModuleLaunchKernel (0x7ff8479b8600, 34838303, 1, 1, 256, 1, 1, 0, stream:<null>, 0, 0x7ffd0243f870) @172383504385077
  hip-sync pid:17308 tid:1:ihipSyncAndResolveStream stream:<null> wait on default stream
  hip-sync pid:17308 tid:1:locking criticalData=0x1466c18 for ctx:0x1466c00.dev:0..
  hip-sync pid:17308 tid:1:syncDefaultStream
  hip-sync pid:17308 tid:1:  syncDefaultStream depOps=0
  hip-sync pid:17308 tid:1:auto-unlocking criticalData=0x1466c18 for ctx:0x1466c00.dev:0...
  hip-sync pid:17308 tid:1:locking criticalData=0x1467200 for stream:0.0..
<<hip-api pid:17308 tid:1.477 17308 1.477 hipLaunchKernel '_ZN3gko7kernels3hip3csr6kernel23abstract_classical_spmvILm64EdiEEvmPKT0_PKT1_SA_S7_mPS5_m' gridDim:{1283871,1,1} groupDim:{256,1,1} sharedMem:+0 stream:0.0 @172383504415374


<<hip-api pid:25556 tid:1.477 hipModuleLaunchKernel (0x7fea8cfb5000, 8709576, 1, 1, 256, 1, 1, 0, stream:<null>, 0, 0x7fff1902b6c0) @176948076480947
  hip-sync pid:25556 tid:1:ihipSyncAndResolveStream stream:<null> wait on default stream
  hip-sync pid:25556 tid:1:locking criticalData=0x1bb0c18 for ctx:0x1bb0c00.dev:0..
  hip-sync pid:25556 tid:1:syncDefaultStream
  hip-sync pid:25556 tid:1:  syncDefaultStream depOps=0
  hip-sync pid:25556 tid:1:auto-unlocking criticalData=0x1bb0c18 for ctx:0x1bb0c00.dev:0...
  hip-sync pid:25556 tid:1:locking criticalData=0x1bb1200 for stream:0.0..
<<hip-api pid:25556 tid:1.477 25556 1.477 hipLaunchKernel '_ZN3gko7kernels3hip3csr6kernel23abstract_classical_spmvILm16EdiEEvmPKT0_PKT1_SA_S7_mPS5_m' gridDim:{8709576,1,1} groupDim:{256,1,1} sharedMem:+0 stream:0.0 @176948076619468
```


Some pictures are from redeon VII (full_opti is in develop, csrc_update is this PR)
- Csrc gflops (x is nnz)
![csrc_gflops](https://user-images.githubusercontent.com/19565938/69556880-dd987c80-0fa5-11ea-90b6-0e8ade2a6fb1.png)
- Csr(Automatical) gflops (x is nnz)
![csr_gflops](https://user-images.githubusercontent.com/19565938/69556877-dc674f80-0fa5-11ea-8462-1598f325bdc7.png)
- Csrc comparision (x is max nnz per row)
![csrc_comp](https://user-images.githubusercontent.com/19565938/69556879-dcffe600-0fa5-11ea-8b5f-dbfe143918b6.png)
- Csr(Automatical) comparision (x is max nnz per row)
![csr_comp](https://user-images.githubusercontent.com/19565938/69556878-dcffe600-0fa5-11ea-9fb4-7d64c46580e2.png)


