### PR TITLE
Add return value to atomic operations

### DIFF
--- a/common/components/atomic.hpp.inc
+++ b/common/components/atomic.hpp.inc
@@ -65,13 +65,13 @@ __forceinline__ __device__ ResultType reinterpret(ValueType val)
         __forceinline__ __device__ static ValueType atomic_add(              \
             ValueType *__restrict__ addr, ValueType val)                     \
         {                                                                    \
-            CONVERTER_TYPE *address_as_ull =                                 \
+            CONVERTER_TYPE *address_as_converter =                           \
                 reinterpret_cast<CONVERTER_TYPE *>(addr);                    \
-            CONVERTER_TYPE old = *address_as_ull;                            \
+            CONVERTER_TYPE old = *address_as_converter;                      \
             CONVERTER_TYPE assumed;                                          \
             do {                                                             \
                 assumed = old;                                               \
-                old = atomicCAS(address_as_ull, assumed,                     \
+                old = atomicCAS(address_as_converter, assumed,               \
                                 reinterpret<CONVERTER_TYPE>(                 \
                                     val + reinterpret<ValueType>(assumed))); \
             } while (assumed != old);                                        \

--- a/common/components/atomic.hpp.inc
+++ b/common/components/atomic.hpp.inc
@@ -36,7 +36,8 @@ namespace detail {
 
 template <typename ValueType, typename = void>
 struct atomic_helper {
-    __forceinline__ __device__ static void atomic_add(ValueType *, ValueType)
+    __forceinline__ __device__ static ValueType atomic_add(ValueType *,
+                                                           ValueType)
     {
         static_assert(sizeof(ValueType) == 0,
                       "This default function is not implemented, only the "
@@ -61,7 +62,7 @@ __forceinline__ __device__ ResultType reinterpret(ValueType val)
     struct atomic_helper<ValueType,                                          \
                          gko::xstd::enable_if_t<(sizeof(ValueType) ==        \
                                                  sizeof(CONVERTER_TYPE))>> { \
-        __forceinline__ __device__ static void atomic_add(                   \
+        __forceinline__ __device__ static ValueType atomic_add(              \
             ValueType *__restrict__ addr, ValueType val)                     \
         {                                                                    \
             CONVERTER_TYPE *address_as_ull =                                 \
@@ -74,6 +75,7 @@ __forceinline__ __device__ ResultType reinterpret(ValueType val)
                                 reinterpret<CONVERTER_TYPE>(                 \
                                     val + reinterpret<ValueType>(assumed))); \
             } while (assumed != old);                                        \
+            return reinterpret<ValueType>(old);                              \
         }                                                                    \
     };
 
@@ -95,17 +97,17 @@ GKO_BIND_ATOMIC_HELPER_STRUCTURE(unsigned short int);
 
 
 template <typename T>
-__forceinline__ __device__ void atomic_add(T *__restrict__ addr, T val)
+__forceinline__ __device__ T atomic_add(T *__restrict__ addr, T val)
 {
-    detail::atomic_helper<T>::atomic_add(addr, val);
+    return detail::atomic_helper<T>::atomic_add(addr, val);
 }
 
 
-#define GKO_BIND_ATOMIC_ADD(ValueType)                                       \
-    __forceinline__ __device__ void atomic_add(ValueType *__restrict__ addr, \
-                                               ValueType val)                \
-    {                                                                        \
-        atomicAdd(addr, val);                                                \
+#define GKO_BIND_ATOMIC_ADD(ValueType)               \
+    __forceinline__ __device__ ValueType atomic_add( \
+        ValueType *__restrict__ addr, ValueType val) \
+    {                                                \
+        return atomicAdd(addr, val);                 \
     }
 
 GKO_BIND_ATOMIC_ADD(int);

--- a/cuda/components/atomic.cuh
+++ b/cuda/components/atomic.cuh
@@ -50,10 +50,10 @@ namespace cuda {
 __forceinline__ __device__ thrust::complex<float> atomic_add(
     thrust::complex<float> *__restrict__ address, thrust::complex<float> val)
 {
-    cuComplex *cuaddr = reinterpret_cast<cuComplex *>(address);
+    cuComplex *addr = reinterpret_cast<cuComplex *>(address);
     // Separate to real part and imag part
-    auto real = atomic_add(&(cuaddr->x), val.real());
-    auto imag = atomic_add(&(cuaddr->y), val.imag());
+    auto real = atomic_add(&(addr->x), val.real());
+    auto imag = atomic_add(&(addr->y), val.imag());
     return {real, imag};
 }
 
@@ -66,10 +66,10 @@ __forceinline__ __device__ thrust::complex<float> atomic_add(
 __forceinline__ __device__ thrust::complex<double> atomic_add(
     thrust::complex<double> *__restrict__ address, thrust::complex<double> val)
 {
-    cuDoubleComplex *cuaddr = reinterpret_cast<cuDoubleComplex *>(address);
+    cuDoubleComplex *addr = reinterpret_cast<cuDoubleComplex *>(address);
     // Separate to real part and imag part
-    auto real = atomic_add(&(cuaddr->x), val.real());
-    auto imag = atomic_add(&(cuaddr->y), val.imag());
+    auto real = atomic_add(&(addr->x), val.real());
+    auto imag = atomic_add(&(addr->y), val.imag());
     return {real, imag};
 }
 

--- a/cuda/components/atomic.cuh
+++ b/cuda/components/atomic.cuh
@@ -47,13 +47,14 @@ namespace cuda {
  *
  * @note It is not 'real' complex<float> atomic add operation
  */
-__forceinline__ __device__ void atomic_add(
+__forceinline__ __device__ thrust::complex<float> atomic_add(
     thrust::complex<float> *__restrict__ address, thrust::complex<float> val)
 {
     cuComplex *cuaddr = reinterpret_cast<cuComplex *>(address);
     // Separate to real part and imag part
-    atomic_add(&(cuaddr->x), val.real());
-    atomic_add(&(cuaddr->y), val.imag());
+    auto real = atomic_add(&(cuaddr->x), val.real());
+    auto imag = atomic_add(&(cuaddr->y), val.imag());
+    return {real, imag};
 }
 
 
@@ -62,13 +63,14 @@ __forceinline__ __device__ void atomic_add(
  *
  * @note It is not 'real' complex<double> atomic add operation
  */
-__forceinline__ __device__ void atomic_add(
+__forceinline__ __device__ thrust::complex<float> atomic_add(
     thrust::complex<double> *__restrict__ address, thrust::complex<double> val)
 {
     cuDoubleComplex *cuaddr = reinterpret_cast<cuDoubleComplex *>(address);
     // Separate to real part and imag part
-    atomic_add(&(cuaddr->x), val.real());
-    atomic_add(&(cuaddr->y), val.imag());
+    auto real = atomic_add(&(cuaddr->x), val.real());
+    auto imag = atomic_add(&(cuaddr->y), val.imag());
+    return {real, imag};
 }
 
 

--- a/cuda/components/atomic.cuh
+++ b/cuda/components/atomic.cuh
@@ -63,7 +63,7 @@ __forceinline__ __device__ thrust::complex<float> atomic_add(
  *
  * @note It is not 'real' complex<double> atomic add operation
  */
-__forceinline__ __device__ thrust::complex<float> atomic_add(
+__forceinline__ __device__ thrust::complex<double> atomic_add(
     thrust::complex<double> *__restrict__ address, thrust::complex<double> val)
 {
     cuDoubleComplex *cuaddr = reinterpret_cast<cuDoubleComplex *>(address);

--- a/hip/components/atomic.hip.hpp
+++ b/hip/components/atomic.hip.hpp
@@ -50,10 +50,10 @@ namespace hip {
 __forceinline__ __device__ thrust::complex<float> atomic_add(
     thrust::complex<float> *__restrict__ address, thrust::complex<float> val)
 {
-    hipComplex *cuaddr = reinterpret_cast<hipComplex *>(address);
+    hipComplex *addr = reinterpret_cast<hipComplex *>(address);
     // Separate to real part and imag part
-    auto real = atomic_add(&(cuaddr->x), val.real());
-    auto imag = atomic_add(&(cuaddr->y), val.imag());
+    auto real = atomic_add(&(addr->x), val.real());
+    auto imag = atomic_add(&(addr->y), val.imag());
     return {real, imag};
 }
 
@@ -66,10 +66,10 @@ __forceinline__ __device__ thrust::complex<float> atomic_add(
 __forceinline__ __device__ thrust::complex<double> atomic_add(
     thrust::complex<double> *__restrict__ address, thrust::complex<double> val)
 {
-    hipDoubleComplex *cuaddr = reinterpret_cast<hipDoubleComplex *>(address);
+    hipDoubleComplex *addr = reinterpret_cast<hipDoubleComplex *>(address);
     // Separate to real part and imag part
-    auto real = atomic_add(&(cuaddr->x), val.real());
-    auto imag = atomic_add(&(cuaddr->y), val.imag());
+    auto real = atomic_add(&(addr->x), val.real());
+    auto imag = atomic_add(&(addr->y), val.imag());
     return {real, imag};
 }
 

--- a/hip/components/atomic.hip.hpp
+++ b/hip/components/atomic.hip.hpp
@@ -47,13 +47,14 @@ namespace hip {
  *
  * @note It is not 'real' complex<float> atomic add operation
  */
-__forceinline__ __device__ void atomic_add(
+__forceinline__ __device__ thrust::complex<float> atomic_add(
     thrust::complex<float> *__restrict__ address, thrust::complex<float> val)
 {
     hipComplex *cuaddr = reinterpret_cast<hipComplex *>(address);
     // Separate to real part and imag part
-    atomic_add(&(cuaddr->x), val.real());
-    atomic_add(&(cuaddr->y), val.imag());
+    auto real = atomic_add(&(cuaddr->x), val.real());
+    auto imag = atomic_add(&(cuaddr->y), val.imag());
+    return {real, imag};
 }
 
 
@@ -62,13 +63,14 @@ __forceinline__ __device__ void atomic_add(
  *
  * @note It is not 'real' complex<double> atomic add operation
  */
-__forceinline__ __device__ void atomic_add(
+__forceinline__ __device__ thrust::complex<float> atomic_add(
     thrust::complex<double> *__restrict__ address, thrust::complex<double> val)
 {
     hipDoubleComplex *cuaddr = reinterpret_cast<hipDoubleComplex *>(address);
     // Separate to real part and imag part
-    atomic_add(&(cuaddr->x), val.real());
-    atomic_add(&(cuaddr->y), val.imag());
+    auto real = atomic_add(&(cuaddr->x), val.real());
+    auto imag = atomic_add(&(cuaddr->y), val.imag());
+    return {real, imag};
 }
 
 

--- a/hip/components/atomic.hip.hpp
+++ b/hip/components/atomic.hip.hpp
@@ -63,7 +63,7 @@ __forceinline__ __device__ thrust::complex<float> atomic_add(
  *
  * @note It is not 'real' complex<double> atomic add operation
  */
-__forceinline__ __device__ thrust::complex<float> atomic_add(
+__forceinline__ __device__ thrust::complex<double> atomic_add(
     thrust::complex<double> *__restrict__ address, thrust::complex<double> val)
 {
     hipDoubleComplex *cuaddr = reinterpret_cast<hipDoubleComplex *>(address);


### PR DESCRIPTION
Our `atomic_add` wrappers don't use the return value of the atomic operations.

This PR adds the return value to all wrappers.