### PR TITLE
Fix some issues with complex number types

### DIFF
--- a/common/base/math.hpp.inc
+++ b/common/base/math.hpp.inc
@@ -53,35 +53,6 @@ struct truncate_type_impl<thrust::complex<T>> {
 }  // namespace detail
 
 
-template <>
-__device__ GKO_INLINE std::complex<float> zero<std::complex<float>>()
-{
-    thrust::complex<float> z(0);
-    return reinterpret_cast<std::complex<float> &>(z);
-}
-
-template <>
-__device__ GKO_INLINE std::complex<double> zero<std::complex<double>>()
-{
-    thrust::complex<double> z(0);
-    return reinterpret_cast<std::complex<double> &>(z);
-}
-
-template <>
-__device__ GKO_INLINE std::complex<float> one<std::complex<float>>()
-{
-    thrust::complex<float> z(1);
-    return reinterpret_cast<std::complex<float> &>(z);
-}
-
-template <>
-__device__ GKO_INLINE std::complex<double> one<std::complex<double>>()
-{
-    thrust::complex<double> z(1);
-    return reinterpret_cast<std::complex<double> &>(z);
-}
-
-
 // This first part is specific for clang and intel in combination with the nvcc
 // compiler from the toolkit older than 9.2.
 // Both want to use their `__builtin_isfinite` function, which is not present

--- a/core/test/base/math.cpp
+++ b/core/test/base/math.cpp
@@ -36,12 +36,21 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <cmath>
 #include <complex>
 #include <limits>
+#include <type_traits>
 
 
 #include <gtest/gtest.h>
 
 
 namespace {
+
+
+static_assert(
+    std::is_same<double, decltype(real(std::complex<double>()))>::value,
+    "real must return a real type");
+static_assert(
+    std::is_same<double, decltype(imag(std::complex<double>()))>::value,
+    "imag must return a real type");
 
 
 template <typename T>
@@ -103,6 +112,24 @@ TEST(IsFinite, FloatComplex) { test_complex_isfinite<std::complex<float>>(); }
 
 
 TEST(IsFinite, DoubleComplex) { test_complex_isfinite<std::complex<double>>(); }
+
+
+TEST(Conjugate, FloatComplex)
+{
+    std::complex<float> a(1, 1);
+    std::complex<float> b(1, -1);
+
+    ASSERT_EQ(conj(a), b);
+}
+
+
+TEST(Conjugate, DoubleComplex)
+{
+    std::complex<double> a(1, 1);
+    std::complex<double> b(1, -1);
+
+    ASSERT_EQ(conj(a), b);
+}
 
 
 }  // namespace

--- a/cuda/components/zero_array.cu
+++ b/cuda/components/zero_array.cu
@@ -49,7 +49,7 @@ void zero_array(size_type n, ValueType *array)
 {
     const dim3 block_size(default_block_size, 1, 1);
     const dim3 grid_size(ceildiv(n, block_size.x), 1, 1);
-    kernel::zero_array<<<grid_size, block_size, 0, 0>>>(n, array);
+    kernel::zero_array<<<grid_size, block_size, 0, 0>>>(n, as_cuda_type(array));
 }
 
 

--- a/hip/components/zero_array.hip.cpp
+++ b/hip/components/zero_array.hip.cpp
@@ -53,7 +53,7 @@ void zero_array(size_type n, ValueType *array)
     const dim3 block_size(default_block_size, 1, 1);
     const dim3 grid_size(ceildiv(n, block_size.x), 1, 1);
     hipLaunchKernelGGL(kernel::zero_array, dim3(grid_size), dim3(block_size), 0,
-                       0, n, array);
+                       0, n, as_hip_type(array));
 }
 
 

--- a/hip/test/base/math.hip.cpp
+++ b/hip/test/base/math.hip.cpp
@@ -145,4 +145,12 @@ TEST_F(IsFinite, DoubleComplex)
 }
 
 
+// test that zero and one work
+void compilation_test()
+{
+    auto value1 = zero<std::complex<double>>();
+    auto value2 = one<std::complex<double>>();
+}
+
+
 }  // namespace

--- a/hip/test/base/math.hip.cpp
+++ b/hip/test/base/math.hip.cpp
@@ -146,10 +146,16 @@ TEST_F(IsFinite, DoubleComplex)
 
 
 // test that zero and one work
-void compilation_test()
+__host__ void compilation_test()
 {
-    auto value1 = zero<std::complex<double>>();
-    auto value2 = one<std::complex<double>>();
+    auto value1 = gko::zero<std::complex<double>>();
+    auto value2 = gko::one<std::complex<double>>();
+}
+
+__device__ void compilation_test2()
+{
+    auto value1 = gko::zero<std::complex<double>>();
+    auto value2 = gko::one<std::complex<double>>();
 }
 
 

--- a/hip/test/base/math.hip.cpp
+++ b/hip/test/base/math.hip.cpp
@@ -146,16 +146,16 @@ TEST_F(IsFinite, DoubleComplex)
 
 
 // test that zero and one work
-__host__ void compilation_test()
+void compilation_test()
 {
     auto value1 = gko::zero<std::complex<double>>();
     auto value2 = gko::one<std::complex<double>>();
 }
 
-__device__ void compilation_test2()
+__global__ void compilation_test2()
 {
-    auto value1 = gko::zero<std::complex<double>>();
-    auto value2 = gko::one<std::complex<double>>();
+    auto value1 = gko::zero<thrust::complex<double>>();
+    auto value2 = gko::one<thrust::complex<double>>();
 }
 
 

--- a/hip/test/base/math.hip.cpp
+++ b/hip/test/base/math.hip.cpp
@@ -145,18 +145,4 @@ TEST_F(IsFinite, DoubleComplex)
 }
 
 
-// test that zero and one work
-void compilation_test()
-{
-    auto value1 = gko::zero<std::complex<double>>();
-    auto value2 = gko::one<std::complex<double>>();
-}
-
-__global__ void compilation_test2()
-{
-    auto value1 = gko::zero<thrust::complex<double>>();
-    auto value2 = gko::one<thrust::complex<double>>();
-}
-
-
 }  // namespace

--- a/include/ginkgo/core/base/math.hpp
+++ b/include/ginkgo/core/base/math.hpp
@@ -388,15 +388,15 @@ GKO_INLINE __host__ constexpr T zero(const T &)
  * @return the multiplicative identity for T
  */
 template <typename T>
-GKO_INLINE __host__ constexpr xstd::enable_if_t<is_complex<T>(), T> one()
-{
-    return T(one<remove_complex<T>>());
-}
-
-template <typename T>
 GKO_INLINE __host__ constexpr xstd::enable_if_t<!is_complex<T>(), T> one()
 {
     return T(1);
+}
+
+template <typename T>
+GKO_INLINE __host__ constexpr xstd::enable_if_t<is_complex<T>(), T> one()
+{
+    return T(one<remove_complex<T>>());
 }
 
 
@@ -450,15 +450,15 @@ GKO_INLINE __device__ constexpr T zero(const T &)
  * @return the multiplicative identity for T
  */
 template <typename T>
-GKO_INLINE __device__ constexpr xstd::enable_if_t<is_complex<T>(), T> one()
-{
-    return T(one<remove_complex<T>>());
-}
-
-template <typename T>
 GKO_INLINE __device__ constexpr xstd::enable_if_t<!is_complex<T>(), T> one()
 {
     return T(1);
+}
+
+template <typename T>
+GKO_INLINE __device__ constexpr xstd::enable_if_t<is_complex<T>(), T> one()
+{
+    return T(one<remove_complex<T>>());
 }
 
 
@@ -609,18 +609,18 @@ GKO_INLINE GKO_ATTRIBUTES constexpr T min(const T &x, const T &y)
  * @return real part of the object (by default, the object itself)
  */
 template <typename T>
+GKO_ATTRIBUTES GKO_INLINE constexpr xstd::enable_if_t<!is_complex<T>(), T> real(
+    const T &x)
+{
+    return x;
+}
+
+template <typename T>
 GKO_ATTRIBUTES
     GKO_INLINE constexpr xstd::enable_if_t<is_complex<T>(), remove_complex<T>>
     real(const T &x)
 {
     return x.real();
-}
-
-template <typename T>
-GKO_ATTRIBUTES GKO_INLINE constexpr xstd::enable_if_t<!is_complex<T>(), T> real(
-    const T &x)
-{
-    return x;
 }
 
 
@@ -634,18 +634,18 @@ GKO_ATTRIBUTES GKO_INLINE constexpr xstd::enable_if_t<!is_complex<T>(), T> real(
  * @return imaginary part of the object (by default, zero<T>())
  */
 template <typename T>
+GKO_ATTRIBUTES GKO_INLINE constexpr xstd::enable_if_t<!is_complex<T>(), T> imag(
+    const T &)
+{
+    return zero<T>();
+}
+
+template <typename T>
 GKO_ATTRIBUTES
     GKO_INLINE constexpr xstd::enable_if_t<is_complex<T>(), remove_complex<T>>
     imag(const T &x)
 {
     return x.imag();
-}
-
-template <typename T>
-GKO_ATTRIBUTES GKO_INLINE constexpr xstd::enable_if_t<!is_complex<T>(), T> imag(
-    const T &)
-{
-    return zero<T>();
 }
 
 
@@ -657,16 +657,16 @@ GKO_ATTRIBUTES GKO_INLINE constexpr xstd::enable_if_t<!is_complex<T>(), T> imag(
  * @return  conjugate of the object (by default, the object itself)
  */
 template <typename T>
-GKO_ATTRIBUTES GKO_INLINE xstd::enable_if_t<is_complex<T>(), T> conj(const T &x)
-{
-    return T{x.real(), -x.imag()};
-}
-
-template <typename T>
 GKO_ATTRIBUTES GKO_INLINE xstd::enable_if_t<!is_complex<T>(), T> conj(
     const T &x)
 {
     return x;
+}
+
+template <typename T>
+GKO_ATTRIBUTES GKO_INLINE xstd::enable_if_t<is_complex<T>(), T> conj(const T &x)
+{
+    return T{x.real(), -x.imag()};
 }
 
 

--- a/include/ginkgo/core/base/math.hpp
+++ b/include/ginkgo/core/base/math.hpp
@@ -389,15 +389,9 @@ GKO_INLINE __host__ constexpr T zero(const T &)
  * @return the multiplicative identity for T
  */
 template <typename T>
-GKO_INLINE __host__ constexpr xstd::enable_if_t<!is_complex<T>(), T> one()
+GKO_INLINE __host__ constexpr T one()
 {
     return T(1);
-}
-
-template <typename T>
-GKO_INLINE __host__ constexpr xstd::enable_if_t<is_complex<T>(), T> one()
-{
-    return T(one<remove_complex<T>>());
 }
 
 
@@ -423,7 +417,9 @@ GKO_INLINE __host__ constexpr T one(const T &)
  * @return additive identity for T
  */
 template <typename T>
-GKO_INLINE __device__ constexpr T zero()
+GKO_INLINE __device__ constexpr xstd::enable_if_t<
+    !std::is_same<T, std::complex<remove_complex<T>>>::value, T>
+zero()
 {
     return T{};
 }
@@ -451,15 +447,11 @@ GKO_INLINE __device__ constexpr T zero(const T &)
  * @return the multiplicative identity for T
  */
 template <typename T>
-GKO_INLINE __device__ constexpr xstd::enable_if_t<!is_complex<T>(), T> one()
+GKO_INLINE __device__ constexpr xstd::enable_if_t<
+    !std::is_same<T, std::complex<remove_complex<T>>>::value, T>
+one()
 {
     return T(1);
-}
-
-template <typename T>
-GKO_INLINE __device__ constexpr xstd::enable_if_t<is_complex<T>(), T> one()
-{
-    return T(one<remove_complex<T>>());
 }
 
 

--- a/include/ginkgo/core/base/math.hpp
+++ b/include/ginkgo/core/base/math.hpp
@@ -362,7 +362,7 @@ GKO_INLINE GKO_ATTRIBUTES constexpr int64 ceildiv(int64 num, int64 den)
 template <typename T>
 GKO_INLINE __host__ constexpr T zero()
 {
-    return T{0};
+    return T{};
 }
 
 
@@ -388,13 +388,13 @@ GKO_INLINE __host__ constexpr T zero(const T &)
  * @return the multiplicative identity for T
  */
 template <typename T>
-GKO_INLINE __device__ constexpr xstd::enable_if_t<is_complex<T>(), T> one()
+GKO_INLINE __host__ constexpr xstd::enable_if_t<is_complex<T>(), T> one()
 {
     return T(one<remove_complex<T>>());
 }
 
 template <typename T>
-GKO_INLINE __device__ constexpr xstd::enable_if_t<!is_complex<T>(), T> one()
+GKO_INLINE __host__ constexpr xstd::enable_if_t<!is_complex<T>(), T> one()
 {
     return T(1);
 }
@@ -657,7 +657,7 @@ GKO_ATTRIBUTES GKO_INLINE constexpr xstd::enable_if_t<!is_complex<T>(), T> imag(
  * @return  conjugate of the object (by default, the object itself)
  */
 template <typename T>
-GKO_ATTRIBUTES GKO_INLINE xstd::enable_if_t<is_complex<T>(), remove_complex<T>>
+GKO_ATTRIBUTES GKO_INLINE xstd::enable_if_t<is_complex<T>(), T>
 conj(const T &x)
 {
     return x.conj();

--- a/include/ginkgo/core/base/math.hpp
+++ b/include/ginkgo/core/base/math.hpp
@@ -34,6 +34,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define GKO_CORE_BASE_MATH_HPP_
 
 
+#include <ginkgo/config.hpp>
 #include <ginkgo/core/base/std_extensions.hpp>
 #include <ginkgo/core/base/types.hpp>
 #include <ginkgo/core/base/utils.hpp>

--- a/include/ginkgo/core/base/math.hpp
+++ b/include/ginkgo/core/base/math.hpp
@@ -362,7 +362,7 @@ GKO_INLINE GKO_ATTRIBUTES constexpr int64 ceildiv(int64 num, int64 den)
 template <typename T>
 GKO_INLINE __host__ constexpr T zero()
 {
-    return T(0);
+    return T{0};
 }
 
 
@@ -388,7 +388,13 @@ GKO_INLINE __host__ constexpr T zero(const T &)
  * @return the multiplicative identity for T
  */
 template <typename T>
-GKO_INLINE __host__ constexpr T one()
+GKO_INLINE __device__ constexpr xstd::enable_if_t<is_complex<T>(), T> one()
+{
+    return T(one<remove_complex<T>>());
+}
+
+template <typename T>
+GKO_INLINE __device__ constexpr xstd::enable_if_t<!is_complex<T>(), T> one()
 {
     return T(1);
 }
@@ -418,7 +424,7 @@ GKO_INLINE __host__ constexpr T one(const T &)
 template <typename T>
 GKO_INLINE __device__ constexpr T zero()
 {
-    return T(0);
+    return T{};
 }
 
 
@@ -444,7 +450,13 @@ GKO_INLINE __device__ constexpr T zero(const T &)
  * @return the multiplicative identity for T
  */
 template <typename T>
-GKO_INLINE __device__ constexpr T one()
+GKO_INLINE __device__ constexpr xstd::enable_if_t<is_complex<T>(), T> one()
+{
+    return T(one<remove_complex<T>>());
+}
+
+template <typename T>
+GKO_INLINE __device__ constexpr xstd::enable_if_t<!is_complex<T>(), T> one()
 {
     return T(1);
 }
@@ -477,7 +489,7 @@ GKO_INLINE __device__ constexpr T one(const T &)
 template <typename T>
 GKO_INLINE GKO_ATTRIBUTES constexpr T zero()
 {
-    return T(0);
+    return T{};
 }
 
 
@@ -597,7 +609,16 @@ GKO_INLINE GKO_ATTRIBUTES constexpr T min(const T &x, const T &y)
  * @return real part of the object (by default, the object itself)
  */
 template <typename T>
-GKO_ATTRIBUTES GKO_INLINE constexpr T real(const T &x)
+GKO_ATTRIBUTES
+    GKO_INLINE constexpr xstd::enable_if_t<is_complex<T>(), remove_complex<T>>
+    real(const T &x)
+{
+    return x.real();
+}
+
+template <typename T>
+GKO_ATTRIBUTES GKO_INLINE constexpr xstd::enable_if_t<!is_complex<T>(), T> real(
+    const T &x)
 {
     return x;
 }
@@ -613,7 +634,16 @@ GKO_ATTRIBUTES GKO_INLINE constexpr T real(const T &x)
  * @return imaginary part of the object (by default, zero<T>())
  */
 template <typename T>
-GKO_ATTRIBUTES GKO_INLINE constexpr T imag(const T &)
+GKO_ATTRIBUTES
+    GKO_INLINE constexpr xstd::enable_if_t<is_complex<T>(), remove_complex<T>>
+    imag(const T &x)
+{
+    return x.imag();
+}
+
+template <typename T>
+GKO_ATTRIBUTES GKO_INLINE constexpr xstd::enable_if_t<!is_complex<T>(), T> imag(
+    const T &)
 {
     return zero<T>();
 }
@@ -627,7 +657,15 @@ GKO_ATTRIBUTES GKO_INLINE constexpr T imag(const T &)
  * @return  conjugate of the object (by default, the object itself)
  */
 template <typename T>
-GKO_ATTRIBUTES GKO_INLINE T conj(const T &x)
+GKO_ATTRIBUTES GKO_INLINE xstd::enable_if_t<is_complex<T>(), remove_complex<T>>
+conj(const T &x)
+{
+    return x.conj();
+}
+
+template <typename T>
+GKO_ATTRIBUTES GKO_INLINE xstd::enable_if_t<!is_complex<T>(), T> conj(
+    const T &x)
 {
     return x;
 }

--- a/include/ginkgo/core/base/math.hpp
+++ b/include/ginkgo/core/base/math.hpp
@@ -602,16 +602,17 @@ GKO_INLINE GKO_ATTRIBUTES constexpr T min(const T &x, const T &y)
  * @return real part of the object (by default, the object itself)
  */
 template <typename T>
-GKO_ATTRIBUTES GKO_INLINE constexpr xstd::enable_if_t<!is_complex<T>(), T> real(
-    const T &x)
+GKO_ATTRIBUTES
+    GKO_INLINE constexpr xstd::enable_if_t<!is_complex_s<T>::value, T>
+    real(const T &x)
 {
     return x;
 }
 
 template <typename T>
-GKO_ATTRIBUTES
-    GKO_INLINE constexpr xstd::enable_if_t<is_complex<T>(), remove_complex<T>>
-    real(const T &x)
+GKO_ATTRIBUTES GKO_INLINE constexpr xstd::enable_if_t<is_complex_s<T>::value,
+                                                      remove_complex<T>>
+real(const T &x)
 {
     return x.real();
 }
@@ -627,16 +628,17 @@ GKO_ATTRIBUTES
  * @return imaginary part of the object (by default, zero<T>())
  */
 template <typename T>
-GKO_ATTRIBUTES GKO_INLINE constexpr xstd::enable_if_t<!is_complex<T>(), T> imag(
-    const T &)
+GKO_ATTRIBUTES
+    GKO_INLINE constexpr xstd::enable_if_t<!is_complex_s<T>::value, T>
+    imag(const T &)
 {
     return zero<T>();
 }
 
 template <typename T>
-GKO_ATTRIBUTES
-    GKO_INLINE constexpr xstd::enable_if_t<is_complex<T>(), remove_complex<T>>
-    imag(const T &x)
+GKO_ATTRIBUTES GKO_INLINE constexpr xstd::enable_if_t<is_complex_s<T>::value,
+                                                      remove_complex<T>>
+imag(const T &x)
 {
     return x.imag();
 }
@@ -650,14 +652,15 @@ GKO_ATTRIBUTES
  * @return  conjugate of the object (by default, the object itself)
  */
 template <typename T>
-GKO_ATTRIBUTES GKO_INLINE xstd::enable_if_t<!is_complex<T>(), T> conj(
+GKO_ATTRIBUTES GKO_INLINE xstd::enable_if_t<!is_complex_s<T>::value, T> conj(
     const T &x)
 {
     return x;
 }
 
 template <typename T>
-GKO_ATTRIBUTES GKO_INLINE xstd::enable_if_t<is_complex<T>(), T> conj(const T &x)
+GKO_ATTRIBUTES GKO_INLINE xstd::enable_if_t<is_complex_s<T>::value, T> conj(
+    const T &x)
 {
     return T{x.real(), -x.imag()};
 }
@@ -725,8 +728,8 @@ GKO_INLINE GKO_ATTRIBUTES constexpr T get_superior_power(
 // it is put into the `gko` namespace, only enable `std::isfinite` when
 // compiling host code.
 template <typename T>
-GKO_INLINE GKO_ATTRIBUTES xstd::enable_if_t<!is_complex<T>(), bool> isfinite(
-    const T &value)
+GKO_INLINE GKO_ATTRIBUTES xstd::enable_if_t<!is_complex_s<T>::value, bool>
+isfinite(const T &value)
 {
     return std::isfinite(value);
 }
@@ -746,8 +749,8 @@ GKO_INLINE GKO_ATTRIBUTES xstd::enable_if_t<!is_complex<T>(), bool> isfinite(
  *         they are neither +/- infinity nor NaN.
  */
 template <typename T>
-GKO_INLINE GKO_ATTRIBUTES xstd::enable_if_t<is_complex<T>(), bool> isfinite(
-    const T &value)
+GKO_INLINE GKO_ATTRIBUTES xstd::enable_if_t<is_complex_s<T>::value, bool>
+isfinite(const T &value)
 {
     return isfinite(value.real()) && isfinite(value.imag());
 }

--- a/include/ginkgo/core/base/math.hpp
+++ b/include/ginkgo/core/base/math.hpp
@@ -657,10 +657,9 @@ GKO_ATTRIBUTES GKO_INLINE constexpr xstd::enable_if_t<!is_complex<T>(), T> imag(
  * @return  conjugate of the object (by default, the object itself)
  */
 template <typename T>
-GKO_ATTRIBUTES GKO_INLINE xstd::enable_if_t<is_complex<T>(), T>
-conj(const T &x)
+GKO_ATTRIBUTES GKO_INLINE xstd::enable_if_t<is_complex<T>(), T> conj(const T &x)
 {
-    return x.conj();
+    return T{x.real(), -x.imag()};
 }
 
 template <typename T>
@@ -733,8 +732,8 @@ GKO_INLINE GKO_ATTRIBUTES constexpr T get_superior_power(
 // it is put into the `gko` namespace, only enable `std::isfinite` when
 // compiling host code.
 template <typename T>
-GKO_INLINE GKO_ATTRIBUTES xstd::enable_if_t<!is_complex_s<T>::value, bool>
-isfinite(const T &value)
+GKO_INLINE GKO_ATTRIBUTES xstd::enable_if_t<!is_complex<T>(), bool> isfinite(
+    const T &value)
 {
     return std::isfinite(value);
 }
@@ -754,8 +753,8 @@ isfinite(const T &value)
  *         they are neither +/- infinity nor NaN.
  */
 template <typename T>
-GKO_INLINE GKO_ATTRIBUTES xstd::enable_if_t<is_complex_s<T>::value, bool>
-isfinite(const T &value)
+GKO_INLINE GKO_ATTRIBUTES xstd::enable_if_t<is_complex<T>(), bool> isfinite(
+    const T &value)
 {
     return isfinite(value.real()) && isfinite(value.imag());
 }


### PR DESCRIPTION
This PR fixes a few inconsistencies and issues with complex numbers and `math.hpp`:

* our real and imag now return real numbers
* our conj now works and is being tested
* HCC sometimes tried to use `__device__` functions when there was a `__host__` function available, leading to some compilation issues with zero<std::complex<...>>