### PR TITLE
Improve ell performance

### DIFF
--- a/common/matrix/ell_kernels.hpp.inc
+++ b/common/matrix/ell_kernels.hpp.inc
@@ -46,19 +46,22 @@ __device__ void spmv_kernel(const size_type num_rows, const int nwarps_per_row,
                             const size_type c_stride, Closure op)
 {
     const auto tidx =
-        static_cast<IndexType>(blockDim.x) * blockIdx.x + threadIdx.x;
-    const IndexType x = tidx / subwarp_size / nwarps_per_row;
-    const auto warp_id = tidx / subwarp_size % nwarps_per_row;
-    const auto y_start = tidx % subwarp_size +
-                         num_stored_elements_per_row * warp_id / nwarps_per_row;
-    const auto y_end =
-        num_stored_elements_per_row * (warp_id + 1) / nwarps_per_row;
-    if (x < num_rows) {
-        const auto tile_block =
-            group::tiled_partition<subwarp_size>(group::this_thread_block());
+        static_cast<size_type>(blockDim.x) * blockIdx.x + threadIdx.x;
+    const auto width = blockDim.y;
+    const auto column_id = blockIdx.y;
+    if (tidx < nwarps_per_row * num_rows) {
+        const auto idx_in_warp = threadIdx.y;
+        const auto x = tidx % num_rows;
+        const auto warp_id = tidx / num_rows;
+        const auto step_size = nwarps_per_row * width;
+        __shared__ UninitializedArray<ValueType, default_block_size> storage;
+        if (threadIdx.y == 0) {
+            storage[threadIdx.x] = 0;
+        }
+        __syncthreads();
         ValueType temp = zero<ValueType>();
-        const auto column_id = blockIdx.y;
-        for (IndexType idx = y_start; idx < y_end; idx += subwarp_size) {
+        for (auto idx = warp_id * width + idx_in_warp;
+             idx < num_stored_elements_per_row; idx += step_size) {
             const auto ind = x + idx * stride;
             const auto col_idx = col[ind];
             if (col_idx < idx) {
@@ -67,15 +70,16 @@ __device__ void spmv_kernel(const size_type num_rows, const int nwarps_per_row,
                 temp += val[ind] * b[col_idx * b_stride + column_id];
             }
         }
-        const auto answer = reduce(
-            tile_block, temp, [](ValueType x, ValueType y) { return x + y; });
-        if (tile_block.thread_rank() == 0) {
+        atomic_add(&storage[threadIdx.x], temp);
+        __syncthreads();
+        if (threadIdx.y == 0) {
             if (atomic) {
-                atomic_add(&(c[x * c_stride + column_id]),
-                           op(answer, c[x * c_stride + column_id]));
+                atomic_add(
+                    &(c[x * c_stride + column_id]),
+                    op(storage[threadIdx.x], c[x * c_stride + column_id]));
             } else {
                 c[x * c_stride + column_id] =
-                    op(answer, c[x * c_stride + column_id]);
+                    op(storage[threadIdx.x], c[x * c_stride + column_id]);
             }
         }
     }
@@ -137,10 +141,9 @@ __global__ __launch_bounds__(default_block_size) void spmv(
 
 
 template <typename ValueType>
-__global__
-    __launch_bounds__(config::max_block_size) void initialize_zero_dense(
-        size_type num_rows, size_type num_cols, size_type stride,
-        ValueType *__restrict__ result)
+__global__ __launch_bounds__(config::max_block_size) void initialize_zero_dense(
+    size_type num_rows, size_type num_cols, size_type stride,
+    ValueType *__restrict__ result)
 {
     const auto tidx_x = threadIdx.x + blockDim.x * blockIdx.x;
     const auto tidx_y = threadIdx.y + blockDim.y * blockIdx.y;

--- a/common/matrix/ell_kernels.hpp.inc
+++ b/common/matrix/ell_kernels.hpp.inc
@@ -50,35 +50,34 @@ __device__ void spmv_kernel(
         // Specialize the num_thread_per_worker = 1. It doesn't need the shared
         // memory, __syncthreads, and atomic_add
         if (tidx < num_rows) {
-            const auto x = tidx % num_rows;
-            const auto limit = x + stride * num_stored_elements_per_row;
             ValueType temp = zero<ValueType>();
-            for (size_type ind = x; ind < limit; ind += stride) {
+            for (size_type idx = 0; idx < num_stored_elements_per_row; idx++) {
+                const auto ind = tidx + idx * stride;
                 const auto col_idx = col[ind];
-                if (col_idx < ind) {
+                if (col_idx < idx) {
                     break;
                 } else {
                     temp += val[ind] * b[col_idx * b_stride + column_id];
                 }
             }
-            const auto c_ind = x * c_stride + column_id;
+            const auto c_ind = tidx * c_stride + column_id;
             c[c_ind] = op(temp, c[c_ind]);
         }
     } else {
         if (tidx < num_worker_per_row * num_rows) {
-            const auto idx_in_warp = threadIdx.y;
+            const auto idx_in_worker = threadIdx.y;
             const auto x = tidx % num_rows;
-            const auto warp_id = tidx / num_rows;
+            const auto worker_id = tidx / num_rows;
             const auto step_size = num_worker_per_row * num_thread_per_worker;
             __shared__ UninitializedArray<ValueType, default_block_size /
                                                          num_thread_per_worker>
                 storage;
-            if (threadIdx.y == 0) {
+            if (idx_in_worker == 0) {
                 storage[threadIdx.x] = 0;
             }
             __syncthreads();
             ValueType temp = zero<ValueType>();
-            for (size_type idx = warp_id * num_thread_per_worker + idx_in_warp;
+            for (size_type idx = worker_id * num_thread_per_worker + idx_in_worker;
                  idx < num_stored_elements_per_row; idx += step_size) {
                 const auto ind = x + idx * stride;
                 const auto col_idx = col[ind];
@@ -90,7 +89,7 @@ __device__ void spmv_kernel(
             }
             atomic_add(&storage[threadIdx.x], temp);
             __syncthreads();
-            if (threadIdx.y == 0) {
+            if (idx_in_worker == 0) {
                 const auto c_ind = x * c_stride + column_id;
                 if (atomic) {
                     atomic_add(&(c[c_ind]), op(storage[threadIdx.x], c[c_ind]));

--- a/common/matrix/ell_kernels.hpp.inc
+++ b/common/matrix/ell_kernels.hpp.inc
@@ -47,39 +47,58 @@ __device__ void spmv_kernel(const size_type num_rows, const int nwarps_per_row,
 {
     const auto tidx =
         static_cast<size_type>(blockDim.x) * blockIdx.x + threadIdx.x;
-    const auto width = blockDim.y;
     const auto column_id = blockIdx.y;
-    if (tidx < nwarps_per_row * num_rows) {
-        const auto idx_in_warp = threadIdx.y;
-        const auto x = tidx % num_rows;
-        const auto warp_id = tidx / num_rows;
-        const auto step_size = nwarps_per_row * width;
-        __shared__ UninitializedArray<ValueType, default_block_size> storage;
-        if (threadIdx.y == 0) {
-            storage[threadIdx.x] = 0;
-        }
-        __syncthreads();
-        ValueType temp = zero<ValueType>();
-        for (auto idx = warp_id * width + idx_in_warp;
-             idx < num_stored_elements_per_row; idx += step_size) {
-            const auto ind = x + idx * stride;
-            const auto col_idx = col[ind];
-            if (col_idx < idx) {
-                break;
-            } else {
-                temp += val[ind] * b[col_idx * b_stride + column_id];
+    if (subwarp_size == 1) {
+        // Specialize the subwarp_size = 1. It doesn't need the shared memory
+        // __syncthreads, and atomic_add
+        if (tidx < num_rows) {
+            const auto x = tidx % num_rows;
+            const auto limit = x + stride * num_stored_elements_per_row;
+            ValueType temp = zero<ValueType>();
+            for (size_type ind = x; ind < limit; ind += stride) {
+                const auto col_idx = col[ind];
+                if (col_idx < ind) {
+                    break;
+                } else {
+                    temp += val[ind] * b[col_idx * b_stride + column_id];
+                }
             }
+            const auto c_ind = x * c_stride + column_id;
+            c[c_ind] = op(temp, c[c_ind]);
         }
-        atomic_add(&storage[threadIdx.x], temp);
-        __syncthreads();
-        if (threadIdx.y == 0) {
-            if (atomic) {
-                atomic_add(
-                    &(c[x * c_stride + column_id]),
-                    op(storage[threadIdx.x], c[x * c_stride + column_id]));
-            } else {
-                c[x * c_stride + column_id] =
-                    op(storage[threadIdx.x], c[x * c_stride + column_id]);
+    } else {
+        if (tidx < nwarps_per_row * num_rows) {
+            const auto idx_in_warp = threadIdx.y;
+            const auto x = tidx % num_rows;
+            const auto warp_id = tidx / num_rows;
+            const auto step_size = nwarps_per_row * subwarp_size;
+            __shared__
+                UninitializedArray<ValueType, default_block_size / subwarp_size>
+                    storage;
+            if (threadIdx.y == 0) {
+                storage[threadIdx.x] = 0;
+            }
+            __syncthreads();
+            ValueType temp = zero<ValueType>();
+            for (size_type idx = warp_id * subwarp_size + idx_in_warp;
+                 idx < num_stored_elements_per_row; idx += step_size) {
+                const auto ind = x + idx * stride;
+                const auto col_idx = col[ind];
+                if (col_idx < idx) {
+                    break;
+                } else {
+                    temp += val[ind] * b[col_idx * b_stride + column_id];
+                }
+            }
+            atomic_add(&storage[threadIdx.x], temp);
+            __syncthreads();
+            if (threadIdx.y == 0) {
+                const auto c_ind = x * c_stride + column_id;
+                if (atomic) {
+                    atomic_add(&(c[c_ind]), op(storage[threadIdx.x], c[c_ind]));
+                } else {
+                    c[c_ind] = op(storage[threadIdx.x], c[c_ind]);
+                }
             }
         }
     }

--- a/common/matrix/ell_kernels.hpp.inc
+++ b/common/matrix/ell_kernels.hpp.inc
@@ -34,23 +34,21 @@ namespace kernel {
 namespace {
 
 
-template <int subwarp_size, bool atomic, typename ValueType, typename IndexType,
-          typename Closure>
-__device__ void spmv_kernel(const size_type num_rows, const int nwarps_per_row,
-                            const ValueType *__restrict__ val,
-                            const IndexType *__restrict__ col,
-                            const size_type stride,
-                            const size_type num_stored_elements_per_row,
-                            const ValueType *__restrict__ b,
-                            const size_type b_stride, ValueType *__restrict__ c,
-                            const size_type c_stride, Closure op)
+template <int num_thread_per_worker, bool atomic, typename ValueType,
+          typename IndexType, typename Closure>
+__device__ void spmv_kernel(
+    const size_type num_rows, const int num_worker_per_row,
+    const ValueType *__restrict__ val, const IndexType *__restrict__ col,
+    const size_type stride, const size_type num_stored_elements_per_row,
+    const ValueType *__restrict__ b, const size_type b_stride,
+    ValueType *__restrict__ c, const size_type c_stride, Closure op)
 {
     const auto tidx =
         static_cast<size_type>(blockDim.x) * blockIdx.x + threadIdx.x;
     const auto column_id = blockIdx.y;
-    if (subwarp_size == 1) {
-        // Specialize the subwarp_size = 1. It doesn't need the shared memory
-        // __syncthreads, and atomic_add
+    if (num_thread_per_worker == 1) {
+        // Specialize the num_thread_per_worker = 1. It doesn't need the shared
+        // memory, __syncthreads, and atomic_add
         if (tidx < num_rows) {
             const auto x = tidx % num_rows;
             const auto limit = x + stride * num_stored_elements_per_row;
@@ -67,20 +65,20 @@ __device__ void spmv_kernel(const size_type num_rows, const int nwarps_per_row,
             c[c_ind] = op(temp, c[c_ind]);
         }
     } else {
-        if (tidx < nwarps_per_row * num_rows) {
+        if (tidx < num_worker_per_row * num_rows) {
             const auto idx_in_warp = threadIdx.y;
             const auto x = tidx % num_rows;
             const auto warp_id = tidx / num_rows;
-            const auto step_size = nwarps_per_row * subwarp_size;
-            __shared__
-                UninitializedArray<ValueType, default_block_size / subwarp_size>
-                    storage;
+            const auto step_size = num_worker_per_row * num_thread_per_worker;
+            __shared__ UninitializedArray<ValueType, default_block_size /
+                                                         num_thread_per_worker>
+                storage;
             if (threadIdx.y == 0) {
                 storage[threadIdx.x] = 0;
             }
             __syncthreads();
             ValueType temp = zero<ValueType>();
-            for (size_type idx = warp_id * subwarp_size + idx_in_warp;
+            for (size_type idx = warp_id * num_thread_per_worker + idx_in_warp;
                  idx < num_stored_elements_per_row; idx += step_size) {
                 const auto ind = x + idx * stride;
                 const auto col_idx = col[ind];
@@ -105,26 +103,26 @@ __device__ void spmv_kernel(const size_type num_rows, const int nwarps_per_row,
 }
 
 
-template <int subwarp_size, bool atomic = false, typename ValueType,
+template <int num_thread_per_worker, bool atomic = false, typename ValueType,
           typename IndexType>
 __global__ __launch_bounds__(default_block_size) void spmv(
-    const size_type num_rows, const int nwarps_per_row,
+    const size_type num_rows, const int num_worker_per_row,
     const ValueType *__restrict__ val, const IndexType *__restrict__ col,
     const size_type stride, const size_type num_stored_elements_per_row,
     const ValueType *__restrict__ b, const size_type b_stride,
     ValueType *__restrict__ c, const size_type c_stride)
 {
-    spmv_kernel<subwarp_size, atomic>(
-        num_rows, nwarps_per_row, val, col, stride, num_stored_elements_per_row,
-        b, b_stride, c, c_stride,
+    spmv_kernel<num_thread_per_worker, atomic>(
+        num_rows, num_worker_per_row, val, col, stride,
+        num_stored_elements_per_row, b, b_stride, c, c_stride,
         [](const ValueType &x, const ValueType &y) { return x; });
 }
 
 
-template <int subwarp_size, bool atomic = false, typename ValueType,
+template <int num_thread_per_worker, bool atomic = false, typename ValueType,
           typename IndexType>
 __global__ __launch_bounds__(default_block_size) void spmv(
-    const size_type num_rows, const int nwarps_per_row,
+    const size_type num_rows, const int num_worker_per_row,
     const ValueType *__restrict__ alpha, const ValueType *__restrict__ val,
     const IndexType *__restrict__ col, const size_type stride,
     const size_type num_stored_elements_per_row,
@@ -139,15 +137,15 @@ __global__ __launch_bounds__(default_block_size) void spmv(
     // Thus, the cuda kernel only computes alpha * a * b when it uses atomic
     // operation.
     if (atomic) {
-        spmv_kernel<subwarp_size, atomic>(
-            num_rows, nwarps_per_row, val, col, stride,
+        spmv_kernel<num_thread_per_worker, atomic>(
+            num_rows, num_worker_per_row, val, col, stride,
             num_stored_elements_per_row, b, b_stride, c, c_stride,
             [&alpha_val](const ValueType &x, const ValueType &y) {
                 return alpha_val * x;
             });
     } else {
-        spmv_kernel<subwarp_size, atomic>(
-            num_rows, nwarps_per_row, val, col, stride,
+        spmv_kernel<num_thread_per_worker, atomic>(
+            num_rows, num_worker_per_row, val, col, stride,
             num_stored_elements_per_row, b, b_stride, c, c_stride,
             [&alpha_val, &beta_val](const ValueType &x, const ValueType &y) {
                 return alpha_val * x + beta_val * y;

--- a/cuda/matrix/ell_kernels.cu
+++ b/cuda/matrix/ell_kernels.cu
@@ -85,13 +85,14 @@ constexpr int num_threads_per_core = 4;
 constexpr double ratio = 1e-2;
 
 
+constexpr int upper_bound = 32;
 /**
  * A compile-time list of sub-warp sizes for which the spmv kernels should be
  * compiled.
  * 0 is a special case where it uses a sub-warp size of warp_size in
  * combination with atomic_adds.
  */
-using compiled_kernels = syn::value_list<int, 0, 1, 2, 4, 8, 16>;
+using compiled_kernels = syn::value_list<int, 0, 1, 2, 4, 8, 16, 32>;
 
 
 #include "common/matrix/ell_kernels.hpp.inc"
@@ -109,7 +110,7 @@ void abstract_spmv(syn::value_list<int, info>, int nwarps_per_row,
                    const matrix::Dense<ValueType> *beta = nullptr)
 {
     const auto nrows = a->get_size()[0];
-    constexpr int subwarp_size = (info == 0) ? config::warp_size : info;
+    constexpr int subwarp_size = (info == 0) ? upper_bound : info;
     constexpr bool atomic = (info == 0);
     const dim3 block_size(default_block_size / subwarp_size, subwarp_size, 1);
     const dim3 grid_size(ceildiv(nrows * nwarps_per_row, block_size.x),
@@ -152,7 +153,6 @@ std::array<int, 3> compute_subwarp_size_and_atomicity(
     const auto nwarps = exec->get_num_warps_per_sm() *
                         exec->get_num_multiprocessor() * num_threads_per_core;
 
-    const auto limit = default_block_size / config::warp_size;
     // Use multithreads to perform the reduction on each row when the matrix is
     // wide.
     // To make every thread have computation, so pick the value which is the
@@ -162,11 +162,11 @@ std::array<int, 3> compute_subwarp_size_and_atomicity(
     // same position. The #warps is decided according to the number of warps
     // allowed on GPU.
     if (static_cast<double>(ell_ncols) / nrows > ratio) {
-        while (subwarp_size < limit && (subwarp_size << 1) <= ell_ncols) {
+        while (subwarp_size < upper_bound && (subwarp_size << 1) <= ell_ncols) {
             subwarp_size <<= 1;
         }
-        if (subwarp_size == limit) {
-            nwarps_per_row = std::min(ell_ncols / limit, nwarps / nrows);
+        if (subwarp_size == upper_bound) {
+            nwarps_per_row = std::min(ell_ncols / upper_bound, nwarps / nrows);
             nwarps_per_row = std::max(nwarps_per_row, 1);
         }
         if (nwarps_per_row > 1) {

--- a/cuda/matrix/ell_kernels.cu
+++ b/cuda/matrix/ell_kernels.cu
@@ -91,8 +91,7 @@ constexpr double ratio = 1e-2;
  * 0 is a special case where it uses a sub-warp size of warp_size in
  * combination with atomic_adds.
  */
-using compiled_kernels =
-    syn::value_list<int, 0, 1, 2, 4, 8, 16, 32, config::warp_size>;
+using compiled_kernels = syn::value_list<int, 0, 1, 2, 4, 8, 16>;
 
 
 #include "common/matrix/ell_kernels.hpp.inc"
@@ -112,10 +111,9 @@ void abstract_spmv(syn::value_list<int, info>, int nwarps_per_row,
     const auto nrows = a->get_size()[0];
     constexpr int subwarp_size = (info == 0) ? config::warp_size : info;
     constexpr bool atomic = (info == 0);
-    const dim3 block_size(default_block_size, 1, 1);
-    const dim3 grid_size(
-        ceildiv(nrows * subwarp_size * nwarps_per_row, block_size.x),
-        b->get_size()[1], 1);
+    const dim3 block_size(default_block_size / subwarp_size, subwarp_size, 1);
+    const dim3 grid_size(ceildiv(nrows * nwarps_per_row, block_size.x),
+                         b->get_size()[1], 1);
     if (alpha == nullptr && beta == nullptr) {
         kernel::spmv<subwarp_size, atomic><<<grid_size, block_size, 0, 0>>>(
             nrows, nwarps_per_row, as_cuda_type(a->get_const_values()),
@@ -150,9 +148,11 @@ std::array<int, 3> compute_subwarp_size_and_atomicity(
 
     const auto nrows = a->get_size()[0];
     const auto ell_ncols = a->get_num_stored_elements_per_row();
+    // TODO: num_threads_per_core should be tuned for AMD gpu
     const auto nwarps = exec->get_num_warps_per_sm() *
                         exec->get_num_multiprocessor() * num_threads_per_core;
 
+    const auto limit = default_block_size / config::warp_size;
     // Use multithreads to perform the reduction on each row when the matrix is
     // wide.
     // To make every thread have computation, so pick the value which is the
@@ -162,13 +162,11 @@ std::array<int, 3> compute_subwarp_size_and_atomicity(
     // same position. The #warps is decided according to the number of warps
     // allowed on GPU.
     if (static_cast<double>(ell_ncols) / nrows > ratio) {
-        while (subwarp_size < config::warp_size &&
-               (subwarp_size << 1) <= ell_ncols) {
+        while (subwarp_size < limit && (subwarp_size << 1) <= ell_ncols) {
             subwarp_size <<= 1;
         }
-        if (subwarp_size == config::warp_size) {
-            nwarps_per_row =
-                std::min(ell_ncols / config::warp_size, nwarps / nrows);
+        if (subwarp_size == limit) {
+            nwarps_per_row = std::min(ell_ncols / limit, nwarps / nrows);
             nwarps_per_row = std::max(nwarps_per_row, 1);
         }
         if (nwarps_per_row > 1) {

--- a/cuda/matrix/ell_kernels.cu
+++ b/cuda/matrix/ell_kernels.cu
@@ -85,7 +85,13 @@ constexpr int num_threads_per_core = 4;
 constexpr double ratio = 1e-2;
 
 
-constexpr int upper_bound = 32;
+/**
+ * max_thread_per_worker is the max number of thread per worker. The
+ * `compiled_kernels` must be a list <0, 1, 2, ..., max_thread_per_worker>
+ */
+constexpr int max_thread_per_worker = 32;
+
+
 /**
  * A compile-time list of sub-warp sizes for which the spmv kernels should be
  * compiled.
@@ -102,7 +108,7 @@ namespace {
 
 
 template <int info, typename ValueType, typename IndexType>
-void abstract_spmv(syn::value_list<int, info>, int nwarps_per_row,
+void abstract_spmv(syn::value_list<int, info>, int num_worker_per_row,
                    const matrix::Ell<ValueType, IndexType> *a,
                    const matrix::Dense<ValueType> *b,
                    matrix::Dense<ValueType> *c,
@@ -110,26 +116,31 @@ void abstract_spmv(syn::value_list<int, info>, int nwarps_per_row,
                    const matrix::Dense<ValueType> *beta = nullptr)
 {
     const auto nrows = a->get_size()[0];
-    constexpr int subwarp_size = (info == 0) ? upper_bound : info;
+    constexpr int num_thread_per_worker =
+        (info == 0) ? max_thread_per_worker : info;
     constexpr bool atomic = (info == 0);
-    const dim3 block_size(default_block_size / subwarp_size, subwarp_size, 1);
-    const dim3 grid_size(ceildiv(nrows * nwarps_per_row, block_size.x),
+    const dim3 block_size(default_block_size / num_thread_per_worker,
+                          num_thread_per_worker, 1);
+    const dim3 grid_size(ceildiv(nrows * num_worker_per_row, block_size.x),
                          b->get_size()[1], 1);
     if (alpha == nullptr && beta == nullptr) {
-        kernel::spmv<subwarp_size, atomic><<<grid_size, block_size, 0, 0>>>(
-            nrows, nwarps_per_row, as_cuda_type(a->get_const_values()),
-            a->get_const_col_idxs(), a->get_stride(),
-            a->get_num_stored_elements_per_row(),
-            as_cuda_type(b->get_const_values()), b->get_stride(),
-            as_cuda_type(c->get_values()), c->get_stride());
+        kernel::spmv<num_thread_per_worker, atomic>
+            <<<grid_size, block_size, 0, 0>>>(
+                nrows, num_worker_per_row, as_cuda_type(a->get_const_values()),
+                a->get_const_col_idxs(), a->get_stride(),
+                a->get_num_stored_elements_per_row(),
+                as_cuda_type(b->get_const_values()), b->get_stride(),
+                as_cuda_type(c->get_values()), c->get_stride());
     } else if (alpha != nullptr && beta != nullptr) {
-        kernel::spmv<subwarp_size, atomic><<<grid_size, block_size, 0, 0>>>(
-            nrows, nwarps_per_row, as_cuda_type(alpha->get_const_values()),
-            as_cuda_type(a->get_const_values()), a->get_const_col_idxs(),
-            a->get_stride(), a->get_num_stored_elements_per_row(),
-            as_cuda_type(b->get_const_values()), b->get_stride(),
-            as_cuda_type(beta->get_const_values()),
-            as_cuda_type(c->get_values()), c->get_stride());
+        kernel::spmv<num_thread_per_worker, atomic>
+            <<<grid_size, block_size, 0, 0>>>(
+                nrows, num_worker_per_row,
+                as_cuda_type(alpha->get_const_values()),
+                as_cuda_type(a->get_const_values()), a->get_const_col_idxs(),
+                a->get_stride(), a->get_num_stored_elements_per_row(),
+                as_cuda_type(b->get_const_values()), b->get_stride(),
+                as_cuda_type(beta->get_const_values()),
+                as_cuda_type(c->get_values()), c->get_stride());
     } else {
         GKO_KERNEL_NOT_FOUND;
     }
@@ -139,13 +150,13 @@ GKO_ENABLE_IMPLEMENTATION_SELECTION(select_abstract_spmv, abstract_spmv);
 
 
 template <typename ValueType, typename IndexType>
-std::array<int, 3> compute_subwarp_size_and_atomicity(
+std::array<int, 3> compute_thread_worker_and_atomicity(
     std::shared_ptr<const CudaExecutor> exec,
     const matrix::Ell<ValueType, IndexType> *a)
 {
-    int subwarp_size = 1;
+    int num_thread_per_worker = 1;
     int atomic = 0;
-    int nwarps_per_row = 1;
+    int num_worker_per_row = 1;
 
     const auto nrows = a->get_size()[0];
     const auto ell_ncols = a->get_num_stored_elements_per_row();
@@ -156,24 +167,26 @@ std::array<int, 3> compute_subwarp_size_and_atomicity(
     // Use multithreads to perform the reduction on each row when the matrix is
     // wide.
     // To make every thread have computation, so pick the value which is the
-    // power of 2 less than warp_size and is less than or equal to ell_ncols. If
-    // the subwarp_size is warp_size and allow more than one warps to work on
-    // the same row, use atomic add to handle the warps write the value into the
-    // same position. The #warps is decided according to the number of warps
-    // allowed on GPU.
+    // power of 2 less than max_thread_per_worker and is less than or equal to
+    // ell_ncols. If the num_thread_per_worker is max_thread_per_worker and
+    // allow more than one worker to work on the same row, use atomic add to
+    // handle the worker write the value into the same position. The #worker is
+    // decided according to the number of worker allowed on GPU.
     if (static_cast<double>(ell_ncols) / nrows > ratio) {
-        while (subwarp_size < upper_bound && (subwarp_size << 1) <= ell_ncols) {
-            subwarp_size <<= 1;
+        while (num_thread_per_worker < max_thread_per_worker &&
+               (num_thread_per_worker << 1) <= ell_ncols) {
+            num_thread_per_worker <<= 1;
         }
-        if (subwarp_size == upper_bound) {
-            nwarps_per_row = std::min(ell_ncols / upper_bound, nwarps / nrows);
-            nwarps_per_row = std::max(nwarps_per_row, 1);
+        if (num_thread_per_worker == max_thread_per_worker) {
+            num_worker_per_row =
+                std::min(ell_ncols / max_thread_per_worker, nwarps / nrows);
+            num_worker_per_row = std::max(num_worker_per_row, 1);
         }
-        if (nwarps_per_row > 1) {
+        if (num_worker_per_row > 1) {
             atomic = 1;
         }
     }
-    return {subwarp_size, atomic, nwarps_per_row};
+    return {num_thread_per_worker, atomic, num_worker_per_row};
 }
 
 
@@ -185,24 +198,25 @@ void spmv(std::shared_ptr<const CudaExecutor> exec,
           const matrix::Ell<ValueType, IndexType> *a,
           const matrix::Dense<ValueType> *b, matrix::Dense<ValueType> *c)
 {
-    const auto data = compute_subwarp_size_and_atomicity(exec, a);
-    const int subwarp_size = std::get<0>(data);
+    const auto data = compute_thread_worker_and_atomicity(exec, a);
+    const int num_thread_per_worker = std::get<0>(data);
     const int atomic = std::get<1>(data);
-    const int nwarps_per_row = std::get<2>(data);
+    const int num_worker_per_row = std::get<2>(data);
 
     /**
      * info is the parameter for selecting the cuda kernel.
      * for info == 0, it uses the kernel by warp_size threads with atomic
      * operation for other value, it uses the kernel without atomic_add
      */
-    const int info = (!atomic) * subwarp_size;
+    const int info = (!atomic) * num_thread_per_worker;
     if (atomic) {
         zero_array(c->get_num_stored_elements(), c->get_values());
     }
     select_abstract_spmv(
         compiled_kernels(),
         [&info](int compiled_info) { return info == compiled_info; },
-        syn::value_list<int>(), syn::type_list<>(), nwarps_per_row, a, b, c);
+        syn::value_list<int>(), syn::type_list<>(), num_worker_per_row, a, b,
+        c);
 }
 
 GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(GKO_DECLARE_ELL_SPMV_KERNEL);
@@ -216,24 +230,24 @@ void advanced_spmv(std::shared_ptr<const CudaExecutor> exec,
                    const matrix::Dense<ValueType> *beta,
                    matrix::Dense<ValueType> *c)
 {
-    const auto data = compute_subwarp_size_and_atomicity(exec, a);
-    const int subwarp_size = std::get<0>(data);
+    const auto data = compute_thread_worker_and_atomicity(exec, a);
+    const int num_thread_per_worker = std::get<0>(data);
     const int atomic = std::get<1>(data);
-    const int nwarps_per_row = std::get<2>(data);
+    const int num_worker_per_row = std::get<2>(data);
 
     /**
      * info is the parameter for selecting the cuda kernel.
      * for info == 0, it uses the kernel by warp_size threads with atomic
      * operation for other value, it uses the kernel without atomic_add
      */
-    const int info = (!atomic) * subwarp_size;
+    const int info = (!atomic) * num_thread_per_worker;
     if (atomic) {
         dense::scale(exec, beta, c);
     }
     select_abstract_spmv(
         compiled_kernels(),
         [&info](int compiled_info) { return info == compiled_info; },
-        syn::value_list<int>(), syn::type_list<>(), nwarps_per_row, a, b, c,
+        syn::value_list<int>(), syn::type_list<>(), num_worker_per_row, a, b, c,
         alpha, beta);
 }
 

--- a/hip/matrix/ell_kernels.hip.cpp
+++ b/hip/matrix/ell_kernels.hip.cpp
@@ -94,7 +94,7 @@ constexpr double ratio = 1e-2;
  * 0 is a special case where it uses a sub-warp size of warp_size in
  * combination with atomic_adds.
  */
-using compiled_kernels = syn::value_list<int, 0, 1, 2, 4, 8>;
+using compiled_kernels = syn::value_list<int, 0, 1, 2, 4, 8, default_block_size/config::warp_size>;
 
 
 #include "common/matrix/ell_kernels.hpp.inc"

--- a/hip/matrix/ell_kernels.hip.cpp
+++ b/hip/matrix/ell_kernels.hip.cpp
@@ -94,8 +94,7 @@ constexpr double ratio = 1e-2;
  * 0 is a special case where it uses a sub-warp size of warp_size in
  * combination with atomic_adds.
  */
-using compiled_kernels =
-    syn::value_list<int, 0, 1, 2, 4, 8, 16, 32, config::warp_size>;
+using compiled_kernels = syn::value_list<int, 0, 1, 2, 4, 8>;
 
 
 #include "common/matrix/ell_kernels.hpp.inc"
@@ -115,10 +114,9 @@ void abstract_spmv(syn::value_list<int, info>, int nwarps_per_row,
     const auto nrows = a->get_size()[0];
     constexpr int subwarp_size = (info == 0) ? config::warp_size : info;
     constexpr bool atomic = (info == 0);
-    const dim3 block_size(default_block_size, 1, 1);
-    const dim3 grid_size(
-        ceildiv(nrows * subwarp_size * nwarps_per_row, block_size.x),
-        b->get_size()[1], 1);
+    const dim3 block_size(default_block_size / subwarp_size, subwarp_size, 1);
+    const dim3 grid_size(ceildiv(nrows * nwarps_per_row, block_size.x),
+                         b->get_size()[1], 1);
     if (alpha == nullptr && beta == nullptr) {
         hipLaunchKernelGGL(HIP_KERNEL_NAME(kernel::spmv<subwarp_size, atomic>),
                            dim3(grid_size), dim3(block_size), 0, 0, nrows,
@@ -160,6 +158,7 @@ std::array<int, 3> compute_subwarp_size_and_atomicity(
     const auto nwarps = exec->get_num_warps_per_sm() *
                         exec->get_num_multiprocessor() * num_threads_per_core;
 
+    const auto limit = default_block_size / config::warp_size;
     // Use multithreads to perform the reduction on each row when the matrix is
     // wide.
     // To make every thread have computation, so pick the value which is the
@@ -169,13 +168,11 @@ std::array<int, 3> compute_subwarp_size_and_atomicity(
     // same position. The #warps is decided according to the number of warps
     // allowed on GPU.
     if (static_cast<double>(ell_ncols) / nrows > ratio) {
-        while (subwarp_size < config::warp_size &&
-               (subwarp_size << 1) <= ell_ncols) {
+        while (subwarp_size < limit && (subwarp_size << 1) <= ell_ncols) {
             subwarp_size <<= 1;
         }
-        if (subwarp_size == config::warp_size) {
-            nwarps_per_row =
-                std::min(ell_ncols / config::warp_size, nwarps / nrows);
+        if (subwarp_size == limit) {
+            nwarps_per_row = std::min(ell_ncols / limit, nwarps / nrows);
             nwarps_per_row = std::max(nwarps_per_row, 1);
         }
         if (nwarps_per_row > 1) {


### PR DESCRIPTION
This PR improves the ell performance.

To read the memory contiguously, make the number of row in block to be the multiple of warp_size
(the warp_size is maybe not the minimal)
the block size is set to 512
In CUDA, the max number per row in one thread block is 16 (32*16)
In AMD, the max number per row in one thread block is 8 (64*8)

I do not do warp reduction. I use the shared memory to accumulate the result from different threads by `atomicAdd` in the same row because the threads in the same rows are not in the same warp.
I try non-square transpose and then do warp reduction, whose performance is similar with this PR in ND/nd12.


I test on 30 matrices. I sort the speedup of hipsp_ell/ell and take 10 in the head, 10 in the end and 10 in the middle.
i.e.
1. 10 matrices which hipsp_ell has largest speed up against original ell
2. 10 matrices which original ell has largest speed up against hipsp_ell
3. 10 matrices I pick up in the middle to check the implementation in general

- this pr ell vs original ell
![improvement](https://user-images.githubusercontent.com/19565938/70127958-5a011e80-167c-11ea-9eac-8ca2947714c1.png)
- original speedup of ell vs hipsp_ell
![original_speedup](https://user-images.githubusercontent.com/19565938/70127959-5a011e80-167c-11ea-9d0d-ea97b65c6080.png)
- this pr speedup of ell vs hipsp_ell
![thispr_speedup](https://user-images.githubusercontent.com/19565938/70127957-59688800-167c-11ea-8ced-ed2d19c89b9e.png)

Note: I still need to run this PR on the whole dataset
