### PR TITLE
Update Ginkgo badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 ![Ginkgo](/assets/logo.png)
 
-[![Build status](https://gitlab.com/ginkgo-project/ginkgo-public-ci/badges/develop/build.svg)](https://github.com/ginkgo-project/ginkgo/commits/develop)
+[![Build status](https://gitlab.com/ginkgo-project/ginkgo-public-ci/badges/develop/pipeline.svg)](https://github.com/ginkgo-project/ginkgo/commits/develop)
+[![Maintainability Rating](https://sonarcloud.io/api/project_badges/measure?project=ginkgo-project_ginkgo&metric=sqale_rating)](https://sonarcloud.io/dashboard?id=ginkgo-project_ginkgo)
+[![Reliability Rating](https://sonarcloud.io/api/project_badges/measure?project=ginkgo-project_ginkgo&metric=reliability_rating)](https://sonarcloud.io/dashboard?id=ginkgo-project_ginkgo)
 [![CDash dashboard](https://img.shields.io/badge/CDash-Access-blue.svg)](http://my.cdash.org/index.php?project=Ginkgo+Project)
 [![Documentation](https://img.shields.io/badge/Documentation-latest-blue.svg)](https://ginkgo-project.github.io/ginkgo/doc/develop/)
 [![License](https://img.shields.io/github/license/ginkgo-project/ginkgo.svg)](./LICENSE)


### PR DESCRIPTION
This is a tiny PR to update the badges in our main `README.md`.

+ Fix the pipeline badge (see https://gitlab.com/gitlab-org/gitlab-foss/issues/35307),
+ Add sonarcloud maintainability badge,
+ Add sonarcloud reliability rating.

Reliability should soon go up to A as all the major issues pointed by sonarcloud which could be fixed should now be.