### PR TITLE
Fix GinkgoTargets.cmake with the correct installation paths

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -57,6 +57,25 @@ stages:
         -DGINKGO_BUILD_HIP=${BUILD_HIP}
         -DGINKGO_BUILD_TESTS=ON -DGINKGO_BUILD_EXAMPLES=ON
     - make -j${NUM_CORES}
+  dependencies: []
+  except:
+      - schedules
+
+.build_template: &default_build_with_test
+  stage: build
+  variables: *default_variables
+  before_script: *default_before_script
+  script:
+    - mkdir -p ${CI_JOB_NAME} && cd ${CI_JOB_NAME}
+    - cmake ${CI_PROJECT_DIR}
+        -DCMAKE_C_COMPILER=${C_COMPILER} -DCMAKE_CXX_COMPILER=${CXX_COMPILER}
+        -DCMAKE_BUILD_TYPE=${BUILD_TYPE} -DCMAKE_CXX_FLAGS="${CXX_FLAGS}"
+        -DBUILD_SHARED_LIBS=${BUILD_SHARED_LIBS} ${EXTRA_CMAKE_FLAGS}
+        -DGINKGO_DEVEL_TOOLS=OFF -DGINKGO_BUILD_REFERENCE=${BUILD_REFERENCE}
+        -DGINKGO_BUILD_OMP=${BUILD_OMP} -DGINKGO_BUILD_CUDA=${BUILD_CUDA}
+        -DGINKGO_BUILD_HIP=${BUILD_HIP}
+        -DGINKGO_BUILD_TESTS=ON -DGINKGO_BUILD_EXAMPLES=ON
+    - make -j${NUM_CORES}
     - |
         (( $(ctest -N | tail -1 | sed 's/Total Tests: //') != 0 )) || exit 1
     - ctest -V
@@ -88,7 +107,7 @@ sync:
 
 # Build jobs
 build/cuda90/gcc/all/debug/shared:
-  <<: *default_build
+  <<: *default_build_with_test
   image: localhost:5000/gko-cuda90-gnu5-llvm39
   variables:
     <<: *default_variables
@@ -103,7 +122,7 @@ build/cuda90/gcc/all/debug/shared:
     - gpu
 
 build/cuda90/clang/all/release/static:
-  <<: *default_build
+  <<: *default_build_with_test
   image: localhost:5000/gko-cuda90-gnu5-llvm39
   variables:
     <<: *default_variables
@@ -121,7 +140,7 @@ build/cuda90/clang/all/release/static:
 
 # cuda 9.1 and friends
 build/cuda91/gcc/all/debug/static:
-  <<: *default_build
+  <<: *default_build_with_test
   image: localhost:5000/gko-cuda91-gnu6-llvm40
   variables:
     <<: *default_variables
@@ -136,7 +155,7 @@ build/cuda91/gcc/all/debug/static:
     - gpu
 
 build/cuda91/clang/all/release/shared:
-  <<: *default_build
+  <<: *default_build_with_test
   image: localhost:5000/gko-cuda91-gnu6-llvm40
   variables:
     <<: *default_variables
@@ -152,7 +171,7 @@ build/cuda91/clang/all/release/shared:
     - gpu
 
 build/cuda91/intel/cuda/debug/shared:
-  <<: *default_build
+  <<: *default_build_with_test
   image: localhost:5000/gko-cuda91-gnu6-llvm40
   variables:
     <<: *default_variables
@@ -168,7 +187,7 @@ build/cuda91/intel/cuda/debug/shared:
 
 # cuda 9.2 and friends
 build/cuda92/gcc/all/release/shared:
-  <<: *default_build
+  <<: *default_build_with_test
   image: localhost:5000/gko-cuda92-gnu7-llvm50
   variables:
     <<: *default_variables
@@ -182,7 +201,7 @@ build/cuda92/gcc/all/release/shared:
     - gpu
 
 build/cuda92/clang/all/debug/static:
-  <<: *default_build
+  <<: *default_build_with_test
   image: localhost:5000/gko-cuda92-gnu7-llvm50
   variables:
     <<: *default_variables
@@ -199,7 +218,7 @@ build/cuda92/clang/all/debug/static:
     - gpu
 
 build/cuda92/intel/cuda/release/static:
-  <<: *default_build
+  <<: *default_build_with_test
   image: localhost:5000/gko-cuda92-gnu7-llvm50
   variables:
     <<: *default_variables
@@ -216,7 +235,7 @@ build/cuda92/intel/cuda/release/static:
 
 # cuda 10.0 and friends
 build/cuda100/gcc/all/debug/shared:
-  <<: *default_build
+  <<: *default_build_with_test
   image: localhost:5000/gko-cuda100-gnu7-llvm60
   variables:
     <<: *default_variables
@@ -230,7 +249,7 @@ build/cuda100/gcc/all/debug/shared:
     - gpu
 
 build/cuda100/clang/all/release/static:
-  <<: *default_build
+  <<: *default_build_with_test
   image: localhost:5000/gko-cuda100-gnu7-llvm60
   variables:
     <<: *default_variables
@@ -247,7 +266,7 @@ build/cuda100/clang/all/release/static:
     - gpu
 
 build/cuda100/intel/cuda/release/shared:
-  <<: *default_build
+  <<: *default_build_with_test
   image: localhost:5000/gko-cuda100-gnu7-llvm60
   variables:
     <<: *default_variables
@@ -263,7 +282,7 @@ build/cuda100/intel/cuda/release/shared:
 
 # cuda 10.1 and friends
 build/cuda101/gcc/all/debug/shared:
-  <<: *default_build
+  <<: *default_build_with_test
   image: localhost:5000/gko-cuda101-gnu8-llvm70
   variables:
     <<: *default_variables
@@ -277,7 +296,7 @@ build/cuda101/gcc/all/debug/shared:
     - gpu
 
 build/cuda101/clang/all/release/static:
-  <<: *default_build
+  <<: *default_build_with_test
   image: localhost:5000/gko-cuda101-gnu8-llvm70
   variables:
     <<: *default_variables
@@ -293,7 +312,7 @@ build/cuda101/clang/all/release/static:
     - gpu
 
 build/cuda101/intel/cuda/debug/static:
-  <<: *default_build
+  <<: *default_build_with_test
   image: localhost:5000/gko-cuda101-gnu8-llvm70
   variables:
     <<: *default_variables
@@ -309,7 +328,7 @@ build/cuda101/intel/cuda/debug/static:
 
 # HIP AMD
 build/amd/gcc/hip/debug/shared:
-  <<: *default_build
+  <<: *default_build_with_test
   image: localhost:5000/gko-amd-gnu7-llvm60
   variables:
     <<: *default_variables
@@ -321,7 +340,7 @@ build/amd/gcc/hip/debug/shared:
     - gpu
 
 build/amd/clang/hip/release/static:
-  <<: *default_build
+  <<: *default_build_with_test
   image: localhost:5000/gko-amd-gnu7-llvm60
   variables:
     <<: *default_variables
@@ -335,7 +354,7 @@ build/amd/clang/hip/release/static:
 
 # no cuda but latest gcc and clang
 build/nocuda/gcc/core/debug/static:
-  <<: *default_build
+  <<: *default_build_with_test
   image: localhost:5000/gko-nocuda-gnu9-llvm8
   variables:
     <<: *default_variables
@@ -346,7 +365,7 @@ build/nocuda/gcc/core/debug/static:
     - cpu
 
 build/nocuda/clang/core/release/shared:
-  <<: *default_build
+  <<: *default_build_with_test
   image: localhost:5000/gko-nocuda-gnu9-llvm8
   variables:
     <<: *default_variables
@@ -358,7 +377,7 @@ build/nocuda/clang/core/release/shared:
     - cpu
 
 build/nocuda/intel/core/debug/shared:
-  <<: *default_build
+  <<: *default_build_with_test
   image: localhost:5000/gko-nocuda-gnu8-llvm70
   variables:
     <<: *default_variables
@@ -370,7 +389,7 @@ build/nocuda/intel/core/debug/shared:
     - cpu
 
 build/nocuda/gcc/omp/release/shared:
-  <<: *default_build
+  <<: *default_build_with_test
   image: localhost:5000/gko-nocuda-gnu9-llvm8
   variables:
     <<: *default_variables
@@ -380,7 +399,7 @@ build/nocuda/gcc/omp/release/shared:
     - cpu
 
 build/nocuda/clang/omp/debug/static:
-  <<: *default_build
+  <<: *default_build_with_test
   image: localhost:5000/gko-nocuda-gnu9-llvm8
   variables:
     <<: *default_variables
@@ -393,7 +412,7 @@ build/nocuda/clang/omp/debug/static:
     - cpu
 
 build/nocuda/intel/omp/release/static:
-  <<: *default_build
+  <<: *default_build_with_test
   image: localhost:5000/gko-nocuda-gnu8-llvm70
   variables:
     <<: *default_variables

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -27,7 +27,9 @@ stages:
   EXTRA_CMAKE_FLAGS: ""
 
 .before_script_template: &default_before_script
-  - export OMP_NUM_THREADS=4
+  - export NUM_CORES=$(grep "core id" /proc/cpuinfo | sort -u | wc -l)
+  - export NUM_CORES=$((NUM_CORES/10))
+  - export OMP_NUM_THREADS=${NUM_CORES}
   - export CUDA_VISIBLE_DEVICES=0
 
 .before_script_git_template: &git_before_script
@@ -54,7 +56,7 @@ stages:
         -DGINKGO_BUILD_OMP=${BUILD_OMP} -DGINKGO_BUILD_CUDA=${BUILD_CUDA}
         -DGINKGO_BUILD_HIP=${BUILD_HIP}
         -DGINKGO_BUILD_TESTS=ON -DGINKGO_BUILD_EXAMPLES=ON
-    - make -j$(grep "core id" /proc/cpuinfo | sort -u | wc -l)
+    - make -j${NUM_CORES}
     - |
         (( $(ctest -N | tail -1 | sed 's/Total Tests: //') != 0 )) || exit 1
     - ctest -V

--- a/cmake/install_helpers.cmake
+++ b/cmake/install_helpers.cmake
@@ -59,10 +59,13 @@ function(ginkgo_install)
     install(FILES
         "${Ginkgo_BINARY_DIR}/GinkgoConfig.cmake"
         "${Ginkgo_BINARY_DIR}/GinkgoConfigVersion.cmake"
-        "${Ginkgo_BINARY_DIR}/GinkgoTargets.cmake"
         "${Ginkgo_SOURCE_DIR}/cmake/hip_helpers.cmake"
         DESTINATION "${GINKGO_INSTALL_CONFIG_DIR}"
         )
+      install(EXPORT Ginkgo
+        NAMESPACE Ginkgo::
+        FILE GinkgoTargets.cmake
+        DESTINATION "${GINKGO_INSTALL_CONFIG_DIR}")
 
     # Export package for use from the build tree
     if (GINKGO_EXPORT_BUILD_DIR)

--- a/dev_tools/containers/ginkgo-cuda-base.py
+++ b/dev_tools/containers/ginkgo-cuda-base.py
@@ -124,3 +124,7 @@ Stage0 += shell(commands=['cd /var/tmp',
 Stage0 += shell(commands=['cd /var/tmp/hipSPARSE', 'mkdir build', 'cd build',
                           'cmake -DBUILD_CUDA=on ..', 'make install'])
 Stage0 += shell(commands=['rm -rf /var/tmp/hipSPARSE'])
+
+# Populate the HIP environment variables
+Stage0 += environment(variables={'PATH': '$PATH:/opt/rocm/bin'})
+Stage0 += shell(commands=['echo "/opt/rocm/lib" > /etc/ld.so.conf.d/hip.conf && ldconfig'])

--- a/dev_tools/containers/ginkgo-nocuda-base.py
+++ b/dev_tools/containers/ginkgo-nocuda-base.py
@@ -68,7 +68,7 @@ if os.path.isdir('texlive/'):
                               'fancyvrb multirow hanging adjustbox xkeyval '
                               'collectbox stackengine etoolbox listofitems ulem '
                               'wasysym sectsty tocloft newunicodechar caption etoc '
-                              'pgf ec helvetic courier wasy'])
+                              'pgf ec helvetic courier wasy letltxmacro'])
 
 # Copy PAPI libs
 add_papi = USERARG.get('papi', 'False')

--- a/include/ginkgo/core/stop/criterion.hpp
+++ b/include/ginkgo/core/stop/criterion.hpp
@@ -279,7 +279,7 @@ using EnableDefaultCriterionFactory =
  * @internal For some abstract reason, nvcc compilation through HIP does not
  *           properly take into account the `using` declaration to inherit
  *           constructors. In addition, the default initialization `{}` for
- *           `_parameters_name##type $parameters` also does not work, which
+ *           `_parameters_name##type parameters` also does not work, which
  *           means the current form is probably the only correct one.
  *
  * @ingroup stop


### PR DESCRIPTION
This is a tiny PR which fixes Ginkgo's installation step as it is currently wrong.

### Description of the problem being fixed
With the current setup, on installation all paths in the target's properties populated in the `GinkgoTargets.cmake` are of the form: 
    + `INTERFACE_INCLUDE_DIRECTORIES "/path/to/build/dir/include;/path/to/source/dir/include;/path/to/source/dir"`,
    + `IMPORTED_LOCATION_RELEASE "/path/to/build/dir/cuda/libginkgo_cuda.so"`,
    + This is later copied into the installation directory, which is wrong.

After this PR, we still have the `GinkgoTargets.cmake` in the build directory with such paths, (in case we expose the CMake the build directory as a usable CMake package, this is a Ginkgo option), **but on installation a new one is generated** with the the proper paths instead. For example, we now find:
    + `INTERFACE_INCLUDE_DIRECTORIES "${_IMPORT_PREFIX}/include"`
    + `IMPORTED_LOCATION_RELEASE "${_IMPORT_PREFIX}/lib/libginkgo_cuda.so"` 

### Other non related changes
+ Minor documentation fix
+ Reduce the amount of threads used in `gitlab-ci` for parallel make.
+ Speed up tools jobs such as `iwyu` and `clang-tidy` by introducing a new build template which does not run the tests, since that was already covered by the previous jobs. 