### PR TITLE
Add assertion for sparsity pattern equality

### DIFF
--- a/core/test/utils/assertions.hpp
+++ b/core/test/utils/assertions.hpp
@@ -106,11 +106,10 @@ void print_componentwise_error(Ostream &os, const MatrixData1 &first,
 template <typename Ostream, typename Iterator>
 void print_columns(Ostream &os, const Iterator &begin, const Iterator &end)
 {
-    os << "\t";
     for (auto it = begin; it != end; ++it) {
-        os << it->column << "\t";
+        os << '\t' << it->column;
     }
-    os << "\n";
+    os << '\n';
 }
 
 

--- a/core/test/utils/assertions_test.cpp
+++ b/core/test/utils/assertions_test.cpp
@@ -47,24 +47,48 @@ class MatricesNear : public ::testing::Test {
 protected:
     using Mtx = gko::matrix::Dense<>;
     using Sparse = gko::matrix::Csr<>;
+
+    template <typename Type, std::size_t size>
+    gko::Array<Type> make_view(std::array<Type, size> &array)
+    {
+        return gko::Array<Type>::view(exec, size, array.data());
+    }
+
     MatricesNear()
         : exec(gko::ReferenceExecutor::create()),
           mtx1(gko::initialize<Mtx>({{1.0, 2.0, 3.0}, {0.0, 4.0, 0.0}}, exec)),
           mtx2(gko::initialize<Mtx>({{1.0, 2.0, 3.0}, {4.0, 0.0, 4.0}}, exec)),
           mtx3(gko::initialize<Mtx>({{1.0, 2.0, 3.0}, {0.0, 4.1, 0.0}}, exec)),
-          mtx1_sp(gko::initialize<Sparse>({{1.0, 2.0, 3.0}, {0.0, 4.0, 0.0}},
-                                          exec)),
-          mtx2_sp(gko::initialize<Sparse>({{1.0, 2.0, 3.0}, {4.0, 0.0, 4.0}},
-                                          exec)),
-          mtx3_sp(
-              gko::initialize<Sparse>({{1.0, 2.0, 3.0}, {0.0, 4.1, 0.0}}, exec))
-
-    {}
+          mtx13_row_ptrs{0, 3, 4},
+          mtx2_row_ptrs{0, 3, 5},
+          mtx13_col_idxs{0, 1, 2, 1},
+          mtx2_col_idxs{0, 1, 2, 0, 2},
+          mtx1_vals{1.0, 2.0, 3.0, 4.0},
+          mtx2_vals{1.0, 2.0, 3.0, 4.0, 4.0},
+          mtx3_vals{1.0, 2.0, 3.0, 4.1}
+    {
+        mtx1_sp = Sparse::create(exec, mtx1->get_size(), make_view(mtx1_vals),
+                                 make_view(mtx13_col_idxs),
+                                 make_view(mtx13_row_ptrs));
+        mtx2_sp =
+            Sparse::create(exec, mtx2->get_size(), make_view(mtx2_vals),
+                           make_view(mtx2_col_idxs), make_view(mtx2_row_ptrs));
+        mtx3_sp = Sparse::create(exec, mtx3->get_size(), make_view(mtx3_vals),
+                                 make_view(mtx13_col_idxs),
+                                 make_view(mtx13_row_ptrs));
+    }
 
     std::shared_ptr<const gko::Executor> exec;
     std::unique_ptr<Mtx> mtx1;
     std::unique_ptr<Mtx> mtx2;
     std::unique_ptr<Mtx> mtx3;
+    std::array<Sparse::index_type, 3> mtx13_row_ptrs;
+    std::array<Sparse::index_type, 3> mtx2_row_ptrs;
+    std::array<Sparse::index_type, 4> mtx13_col_idxs;
+    std::array<Sparse::index_type, 5> mtx2_col_idxs;
+    std::array<Sparse::value_type, 4> mtx1_vals;
+    std::array<Sparse::value_type, 5> mtx2_vals;
+    std::array<Sparse::value_type, 4> mtx3_vals;
     std::unique_ptr<Sparse> mtx1_sp;
     std::unique_ptr<Sparse> mtx2_sp;
     std::unique_ptr<Sparse> mtx3_sp;
@@ -107,7 +131,7 @@ TEST_F(MatricesNear, CanUseShortNotation)
     GKO_EXPECT_MTX_NEAR(mtx1, mtx1, 0.0);
     GKO_ASSERT_MTX_NEAR(mtx1, mtx3, 0.1);
     GKO_EXPECT_MTX_NEAR_SPARSITY(mtx1_sp, mtx1_sp, 0.0);
-    GKO_ASSERT_MTX_NEAR_SPARSITY(mtx1_sp, mtx2_sp, 0.0);
+    GKO_ASSERT_MTX_NEAR_SPARSITY(mtx1_sp, mtx1_sp, 0.0);
 }
 
 

--- a/core/test/utils/assertions_test.cpp
+++ b/core/test/utils/assertions_test.cpp
@@ -99,8 +99,8 @@ TEST_F(MatricesNear, SuceedsIfSame)
 {
     ASSERT_PRED_FORMAT3(gko::test::assertions::matrices_near, mtx1.get(),
                         mtx1.get(), 0.0);
-    ASSERT_PRED_FORMAT3(gko::test::assertions::matrices_near_sparsity,
-                        mtx1_sp.get(), mtx1_sp.get(), 0.0);
+    ASSERT_PRED_FORMAT2(gko::test::assertions::matrices_equal_sparsity,
+                        mtx1_sp.get(), mtx1_sp.get());
 }
 
 
@@ -108,8 +108,8 @@ TEST_F(MatricesNear, FailsIfDifferent)
 {
     ASSERT_PRED_FORMAT3(!gko::test::assertions::matrices_near, mtx1.get(),
                         mtx2.get(), 0.0);
-    ASSERT_PRED_FORMAT3(!gko::test::assertions::matrices_near_sparsity,
-                        mtx1_sp.get(), mtx2_sp.get(), 0.0);
+    ASSERT_PRED_FORMAT2(!gko::test::assertions::matrices_equal_sparsity,
+                        mtx1_sp.get(), mtx2_sp.get());
 }
 
 
@@ -119,10 +119,8 @@ TEST_F(MatricesNear, SucceedsIfClose)
                         mtx3.get(), 0.0);
     ASSERT_PRED_FORMAT3(gko::test::assertions::matrices_near, mtx1.get(),
                         mtx3.get(), 0.1);
-    ASSERT_PRED_FORMAT3(!gko::test::assertions::matrices_near_sparsity,
-                        mtx1_sp.get(), mtx3_sp.get(), 0.0);
-    ASSERT_PRED_FORMAT3(gko::test::assertions::matrices_near_sparsity,
-                        mtx1_sp.get(), mtx3_sp.get(), 0.1);
+    ASSERT_PRED_FORMAT2(gko::test::assertions::matrices_equal_sparsity,
+                        mtx1_sp.get(), mtx3_sp.get());
 }
 
 
@@ -130,8 +128,8 @@ TEST_F(MatricesNear, CanUseShortNotation)
 {
     GKO_EXPECT_MTX_NEAR(mtx1, mtx1, 0.0);
     GKO_ASSERT_MTX_NEAR(mtx1, mtx3, 0.1);
-    GKO_EXPECT_MTX_NEAR_SPARSITY(mtx1_sp, mtx1_sp, 0.0);
-    GKO_ASSERT_MTX_NEAR_SPARSITY(mtx1_sp, mtx1_sp, 0.0);
+    GKO_EXPECT_MTX_EQ_SPARSITY(mtx1_sp, mtx3_sp);
+    GKO_ASSERT_MTX_EQ_SPARSITY(mtx1_sp, mtx3_sp);
 }
 
 

--- a/cuda/test/factorization/par_ilu_kernels.cpp
+++ b/cuda/test/factorization/par_ilu_kernels.cpp
@@ -202,8 +202,8 @@ TEST_F(ParIlu, KernelInitializeParILUIsEquivalentToRef)
 
     initialize_lu(&l_ref, &u_ref, &l_cuda, &u_cuda);
 
-    GKO_ASSERT_MTX_NEAR(l_ref, l_cuda, 1e-14);
-    GKO_ASSERT_MTX_NEAR(u_ref, u_cuda, 1e-14);
+    GKO_ASSERT_MTX_NEAR_SPARSITY(l_ref, l_cuda, 1e-14);
+    GKO_ASSERT_MTX_NEAR_SPARSITY(u_ref, u_cuda, 1e-14);
 }
 
 
@@ -216,8 +216,8 @@ TEST_F(ParIlu, KernelComputeParILUIsEquivalentToRef)
 
     compute_lu(&l_ref, &u_ref, &l_cuda, &u_cuda);
 
-    GKO_ASSERT_MTX_NEAR(l_ref, l_cuda, 5e-2);
-    GKO_ASSERT_MTX_NEAR(u_ref, u_cuda, 5e-2);
+    GKO_ASSERT_MTX_NEAR_SPARSITY(l_ref, l_cuda, 5e-2);
+    GKO_ASSERT_MTX_NEAR_SPARSITY(u_ref, u_cuda, 5e-2);
 }
 
 
@@ -231,8 +231,8 @@ TEST_F(ParIlu, KernelComputeParILUWithMoreIterationsIsEquivalentToRef)
 
     compute_lu(&l_ref, &u_ref, &l_cuda, &u_cuda, iterations);
 
-    GKO_ASSERT_MTX_NEAR(l_ref, l_cuda, 1e-14);
-    GKO_ASSERT_MTX_NEAR(u_ref, u_cuda, 1e-14);
+    GKO_ASSERT_MTX_NEAR_SPARSITY(l_ref, l_cuda, 1e-14);
+    GKO_ASSERT_MTX_NEAR_SPARSITY(u_ref, u_cuda, 1e-14);
 }
 
 

--- a/cuda/test/factorization/par_ilu_kernels.cpp
+++ b/cuda/test/factorization/par_ilu_kernels.cpp
@@ -202,8 +202,10 @@ TEST_F(ParIlu, KernelInitializeParILUIsEquivalentToRef)
 
     initialize_lu(&l_ref, &u_ref, &l_cuda, &u_cuda);
 
-    GKO_ASSERT_MTX_NEAR_SPARSITY(l_ref, l_cuda, 1e-14);
-    GKO_ASSERT_MTX_NEAR_SPARSITY(u_ref, u_cuda, 1e-14);
+    GKO_ASSERT_MTX_NEAR(l_ref, l_cuda, 1e-14);
+    GKO_ASSERT_MTX_NEAR(u_ref, u_cuda, 1e-14);
+    GKO_ASSERT_MTX_EQ_SPARSITY(l_ref, l_cuda);
+    GKO_ASSERT_MTX_EQ_SPARSITY(u_ref, u_cuda);
 }
 
 
@@ -216,8 +218,10 @@ TEST_F(ParIlu, KernelComputeParILUIsEquivalentToRef)
 
     compute_lu(&l_ref, &u_ref, &l_cuda, &u_cuda);
 
-    GKO_ASSERT_MTX_NEAR_SPARSITY(l_ref, l_cuda, 5e-2);
-    GKO_ASSERT_MTX_NEAR_SPARSITY(u_ref, u_cuda, 5e-2);
+    GKO_ASSERT_MTX_NEAR(l_ref, l_cuda, 5e-2);
+    GKO_ASSERT_MTX_NEAR(u_ref, u_cuda, 5e-2);
+    GKO_ASSERT_MTX_EQ_SPARSITY(l_ref, l_cuda);
+    GKO_ASSERT_MTX_EQ_SPARSITY(u_ref, u_cuda);
 }
 
 
@@ -231,8 +235,10 @@ TEST_F(ParIlu, KernelComputeParILUWithMoreIterationsIsEquivalentToRef)
 
     compute_lu(&l_ref, &u_ref, &l_cuda, &u_cuda, iterations);
 
-    GKO_ASSERT_MTX_NEAR_SPARSITY(l_ref, l_cuda, 1e-14);
-    GKO_ASSERT_MTX_NEAR_SPARSITY(u_ref, u_cuda, 1e-14);
+    GKO_ASSERT_MTX_NEAR(l_ref, l_cuda, 1e-14);
+    GKO_ASSERT_MTX_NEAR(u_ref, u_cuda, 1e-14);
+    GKO_ASSERT_MTX_EQ_SPARSITY(l_ref, l_cuda);
+    GKO_ASSERT_MTX_EQ_SPARSITY(u_ref, u_cuda);
 }
 
 

--- a/cuda/test/matrix/csr_kernels.cpp
+++ b/cuda/test/matrix/csr_kernels.cpp
@@ -363,7 +363,8 @@ TEST_F(Csr, AdvancedApplyToCsrMatrixIsEquivalentToRef)
     mtx->apply(alpha.get(), trans.get(), beta.get(), square_mtx.get());
     dmtx->apply(dalpha.get(), d_trans.get(), dbeta.get(), square_dmtx.get());
 
-    GKO_ASSERT_MTX_NEAR_SPARSITY(square_dmtx, square_mtx, 1e-14);
+    GKO_ASSERT_MTX_NEAR(square_dmtx, square_mtx, 1e-14);
+    GKO_ASSERT_MTX_EQ_SPARSITY(square_dmtx, square_mtx);
 }
 
 
@@ -376,7 +377,8 @@ TEST_F(Csr, SimpleApplyToCsrMatrixIsEquivalentToRef)
     mtx->apply(trans.get(), square_mtx.get());
     dmtx->apply(d_trans.get(), square_dmtx.get());
 
-    GKO_ASSERT_MTX_NEAR_SPARSITY(square_dmtx, square_mtx, 1e-14);
+    GKO_ASSERT_MTX_NEAR(square_dmtx, square_mtx, 1e-14);
+    GKO_ASSERT_MTX_EQ_SPARSITY(square_dmtx, square_mtx);
 }
 
 

--- a/cuda/test/matrix/csr_kernels.cpp
+++ b/cuda/test/matrix/csr_kernels.cpp
@@ -363,7 +363,7 @@ TEST_F(Csr, AdvancedApplyToCsrMatrixIsEquivalentToRef)
     mtx->apply(alpha.get(), trans.get(), beta.get(), square_mtx.get());
     dmtx->apply(dalpha.get(), d_trans.get(), dbeta.get(), square_dmtx.get());
 
-    GKO_ASSERT_MTX_NEAR(square_dmtx, square_mtx, 1e-14);
+    GKO_ASSERT_MTX_NEAR_SPARSITY(square_dmtx, square_mtx, 1e-14);
 }
 
 
@@ -376,7 +376,7 @@ TEST_F(Csr, SimpleApplyToCsrMatrixIsEquivalentToRef)
     mtx->apply(trans.get(), square_mtx.get());
     dmtx->apply(d_trans.get(), square_dmtx.get());
 
-    GKO_ASSERT_MTX_NEAR(square_dmtx, square_mtx, 1e-14);
+    GKO_ASSERT_MTX_NEAR_SPARSITY(square_dmtx, square_mtx, 1e-14);
 }
 
 

--- a/hip/test/factorization/par_ilu_kernels.hip.cpp
+++ b/hip/test/factorization/par_ilu_kernels.hip.cpp
@@ -201,8 +201,10 @@ TEST_F(ParIlu, KernelInitializeParILUIsEquivalentToRef)
 
     initialize_lu(&l_ref, &u_ref, &l_hip, &u_hip);
 
-    GKO_ASSERT_MTX_NEAR_SPARSITY(l_ref, l_hip, 1e-14);
-    GKO_ASSERT_MTX_NEAR_SPARSITY(u_ref, u_hip, 1e-14);
+    GKO_ASSERT_MTX_NEAR(l_ref, l_hip, 1e-14);
+    GKO_ASSERT_MTX_NEAR(u_ref, u_hip, 1e-14);
+    GKO_ASSERT_MTX_EQ_SPARSITY(l_ref, l_hip);
+    GKO_ASSERT_MTX_EQ_SPARSITY(u_ref, u_hip);
 }
 
 
@@ -215,8 +217,10 @@ TEST_F(ParIlu, KernelComputeParILUIsEquivalentToRef)
 
     compute_lu(&l_ref, &u_ref, &l_hip, &u_hip);
 
-    GKO_ASSERT_MTX_NEAR_SPARSITY(l_ref, l_hip, 5e-2);
-    GKO_ASSERT_MTX_NEAR_SPARSITY(u_ref, u_hip, 5e-2);
+    GKO_ASSERT_MTX_NEAR(l_ref, l_hip, 5e-2);
+    GKO_ASSERT_MTX_NEAR(u_ref, u_hip, 5e-2);
+    GKO_ASSERT_MTX_EQ_SPARSITY(l_ref, l_hip);
+    GKO_ASSERT_MTX_EQ_SPARSITY(u_ref, u_hip);
 }
 
 
@@ -230,8 +234,10 @@ TEST_F(ParIlu, KernelComputeParILUWithMoreIterationsIsEquivalentToRef)
 
     compute_lu(&l_ref, &u_ref, &l_hip, &u_hip, iterations);
 
-    GKO_ASSERT_MTX_NEAR_SPARSITY(l_ref, l_hip, 1e-14);
-    GKO_ASSERT_MTX_NEAR_SPARSITY(u_ref, u_hip, 1e-14);
+    GKO_ASSERT_MTX_NEAR(l_ref, l_hip, 1e-14);
+    GKO_ASSERT_MTX_NEAR(u_ref, u_hip, 1e-14);
+    GKO_ASSERT_MTX_EQ_SPARSITY(l_ref, l_hip);
+    GKO_ASSERT_MTX_EQ_SPARSITY(u_ref, u_hip);
 }
 
 

--- a/hip/test/factorization/par_ilu_kernels.hip.cpp
+++ b/hip/test/factorization/par_ilu_kernels.hip.cpp
@@ -201,8 +201,8 @@ TEST_F(ParIlu, KernelInitializeParILUIsEquivalentToRef)
 
     initialize_lu(&l_ref, &u_ref, &l_hip, &u_hip);
 
-    GKO_ASSERT_MTX_NEAR(l_ref, l_hip, 1e-14);
-    GKO_ASSERT_MTX_NEAR(u_ref, u_hip, 1e-14);
+    GKO_ASSERT_MTX_NEAR_SPARSITY(l_ref, l_hip, 1e-14);
+    GKO_ASSERT_MTX_NEAR_SPARSITY(u_ref, u_hip, 1e-14);
 }
 
 
@@ -215,8 +215,8 @@ TEST_F(ParIlu, KernelComputeParILUIsEquivalentToRef)
 
     compute_lu(&l_ref, &u_ref, &l_hip, &u_hip);
 
-    GKO_ASSERT_MTX_NEAR(l_ref, l_hip, 5e-2);
-    GKO_ASSERT_MTX_NEAR(u_ref, u_hip, 5e-2);
+    GKO_ASSERT_MTX_NEAR_SPARSITY(l_ref, l_hip, 5e-2);
+    GKO_ASSERT_MTX_NEAR_SPARSITY(u_ref, u_hip, 5e-2);
 }
 
 
@@ -230,8 +230,8 @@ TEST_F(ParIlu, KernelComputeParILUWithMoreIterationsIsEquivalentToRef)
 
     compute_lu(&l_ref, &u_ref, &l_hip, &u_hip, iterations);
 
-    GKO_ASSERT_MTX_NEAR(l_ref, l_hip, 1e-14);
-    GKO_ASSERT_MTX_NEAR(u_ref, u_hip, 1e-14);
+    GKO_ASSERT_MTX_NEAR_SPARSITY(l_ref, l_hip, 1e-14);
+    GKO_ASSERT_MTX_NEAR_SPARSITY(u_ref, u_hip, 1e-14);
 }
 
 

--- a/omp/test/factorization/par_ilu_kernels.cpp
+++ b/omp/test/factorization/par_ilu_kernels.cpp
@@ -206,8 +206,8 @@ TEST_F(ParIlu, KernelInitializeParILUIsEquivalentToRef)
 
     initialize_lu(&l_ref, &u_ref, &l_omp, &u_omp);
 
-    GKO_ASSERT_MTX_NEAR(l_ref, l_omp, 1e-14);
-    GKO_ASSERT_MTX_NEAR(u_ref, u_omp, 1e-14);
+    GKO_ASSERT_MTX_NEAR_SPARSITY(l_ref, l_omp, 1e-14);
+    GKO_ASSERT_MTX_NEAR_SPARSITY(u_ref, u_omp, 1e-14);
 }
 
 
@@ -220,8 +220,8 @@ TEST_F(ParIlu, KernelComputeParILUIsEquivalentToRef)
 
     compute_lu(&l_ref, &u_ref, &l_omp, &u_omp);
 
-    GKO_ASSERT_MTX_NEAR(l_ref, l_omp, 5e-2);
-    GKO_ASSERT_MTX_NEAR(u_ref, u_omp, 5e-2);
+    GKO_ASSERT_MTX_NEAR_SPARSITY(l_ref, l_omp, 5e-2);
+    GKO_ASSERT_MTX_NEAR_SPARSITY(u_ref, u_omp, 5e-2);
 }
 
 
@@ -235,8 +235,8 @@ TEST_F(ParIlu, KernelComputeParILUWithMoreIterationsIsEquivalentToRef)
 
     compute_lu(&l_ref, &u_ref, &l_omp, &u_omp, iterations);
 
-    GKO_ASSERT_MTX_NEAR(l_ref, l_omp, 1e-14);
-    GKO_ASSERT_MTX_NEAR(u_ref, u_omp, 1e-14);
+    GKO_ASSERT_MTX_NEAR_SPARSITY(l_ref, l_omp, 1e-14);
+    GKO_ASSERT_MTX_NEAR_SPARSITY(u_ref, u_omp, 1e-14);
 }
 
 

--- a/omp/test/factorization/par_ilu_kernels.cpp
+++ b/omp/test/factorization/par_ilu_kernels.cpp
@@ -206,8 +206,10 @@ TEST_F(ParIlu, KernelInitializeParILUIsEquivalentToRef)
 
     initialize_lu(&l_ref, &u_ref, &l_omp, &u_omp);
 
-    GKO_ASSERT_MTX_NEAR_SPARSITY(l_ref, l_omp, 1e-14);
-    GKO_ASSERT_MTX_NEAR_SPARSITY(u_ref, u_omp, 1e-14);
+    GKO_ASSERT_MTX_NEAR(l_ref, l_omp, 1e-14);
+    GKO_ASSERT_MTX_NEAR(u_ref, u_omp, 1e-14);
+    GKO_ASSERT_MTX_EQ_SPARSITY(l_ref, l_omp);
+    GKO_ASSERT_MTX_EQ_SPARSITY(u_ref, u_omp);
 }
 
 
@@ -220,8 +222,10 @@ TEST_F(ParIlu, KernelComputeParILUIsEquivalentToRef)
 
     compute_lu(&l_ref, &u_ref, &l_omp, &u_omp);
 
-    GKO_ASSERT_MTX_NEAR_SPARSITY(l_ref, l_omp, 5e-2);
-    GKO_ASSERT_MTX_NEAR_SPARSITY(u_ref, u_omp, 5e-2);
+    GKO_ASSERT_MTX_NEAR(l_ref, l_omp, 5e-2);
+    GKO_ASSERT_MTX_NEAR(u_ref, u_omp, 5e-2);
+    GKO_ASSERT_MTX_EQ_SPARSITY(l_ref, l_omp);
+    GKO_ASSERT_MTX_EQ_SPARSITY(u_ref, u_omp);
 }
 
 
@@ -235,8 +239,10 @@ TEST_F(ParIlu, KernelComputeParILUWithMoreIterationsIsEquivalentToRef)
 
     compute_lu(&l_ref, &u_ref, &l_omp, &u_omp, iterations);
 
-    GKO_ASSERT_MTX_NEAR_SPARSITY(l_ref, l_omp, 1e-14);
-    GKO_ASSERT_MTX_NEAR_SPARSITY(u_ref, u_omp, 1e-14);
+    GKO_ASSERT_MTX_NEAR(l_ref, l_omp, 1e-14);
+    GKO_ASSERT_MTX_NEAR(u_ref, u_omp, 1e-14);
+    GKO_ASSERT_MTX_EQ_SPARSITY(l_ref, l_omp);
+    GKO_ASSERT_MTX_EQ_SPARSITY(u_ref, u_omp);
 }
 
 

--- a/omp/test/matrix/csr_kernels.cpp
+++ b/omp/test/matrix/csr_kernels.cpp
@@ -236,7 +236,7 @@ TEST_F(Csr, AdvancedApplyToCsrMatrixIsEquivalentToRef)
     mtx->apply(alpha.get(), trans.get(), beta.get(), square_mtx.get());
     dmtx->apply(dalpha.get(), d_trans.get(), dbeta.get(), square_dmtx.get());
 
-    GKO_ASSERT_MTX_NEAR(square_dmtx, square_mtx, 1e-14);
+    GKO_ASSERT_MTX_NEAR_SPARSITY(square_dmtx, square_mtx, 1e-14);
 }
 
 
@@ -249,7 +249,7 @@ TEST_F(Csr, SimpleApplyToCsrMatrixIsEquivalentToRef)
     mtx->apply(trans.get(), square_mtx.get());
     dmtx->apply(d_trans.get(), square_dmtx.get());
 
-    GKO_ASSERT_MTX_NEAR(square_dmtx, square_mtx, 1e-14);
+    GKO_ASSERT_MTX_NEAR_SPARSITY(square_dmtx, square_mtx, 1e-14);
 }
 
 

--- a/omp/test/matrix/csr_kernels.cpp
+++ b/omp/test/matrix/csr_kernels.cpp
@@ -236,7 +236,8 @@ TEST_F(Csr, AdvancedApplyToCsrMatrixIsEquivalentToRef)
     mtx->apply(alpha.get(), trans.get(), beta.get(), square_mtx.get());
     dmtx->apply(dalpha.get(), d_trans.get(), dbeta.get(), square_dmtx.get());
 
-    GKO_ASSERT_MTX_NEAR_SPARSITY(square_dmtx, square_mtx, 1e-14);
+    GKO_ASSERT_MTX_NEAR(square_dmtx, square_mtx, 1e-14);
+    GKO_ASSERT_MTX_EQ_SPARSITY(square_dmtx, square_mtx);
 }
 
 
@@ -249,7 +250,8 @@ TEST_F(Csr, SimpleApplyToCsrMatrixIsEquivalentToRef)
     mtx->apply(trans.get(), square_mtx.get());
     dmtx->apply(d_trans.get(), square_dmtx.get());
 
-    GKO_ASSERT_MTX_NEAR_SPARSITY(square_dmtx, square_mtx, 1e-14);
+    GKO_ASSERT_MTX_NEAR(square_dmtx, square_mtx, 1e-14);
+    GKO_ASSERT_MTX_EQ_SPARSITY(square_dmtx, square_mtx);
 }
 
 


### PR DESCRIPTION
This PR adds the `GKO_ASSERT_MATRIX_NEAR_SPARSITY` test assertion, which first checks if the sparsity patterns of the two input matrices match, and then proceeds like `GKO_ASSERT_MATRIX_NEAR`

This kind of assertion becomes interesting when we add more kernels that modify the sparsity pattern, like SpGeMM or the ParILUT kernels in general.