### PR TITLE
Add bitonic sorting kernels

### DIFF
--- a/common/components/sorting.hpp.inc
+++ b/common/components/sorting.hpp.inc
@@ -1,0 +1,245 @@
+/*******************************<GINKGO LICENSE>******************************
+Copyright (c) 2017-2019, the Ginkgo authors
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+******************************<GINKGO LICENSE>*******************************/
+
+namespace detail {
+
+
+template <typename ValueType>
+__device__ void bitonic_cas(ValueType &a, ValueType &b, bool reverse)
+{
+    auto tmp = a;
+    bool cmp = (a < b) != reverse;
+    a = cmp ? a : b;
+    b = cmp ? b : tmp;
+}
+
+template <typename ValueType, int num_elements>
+struct bitonic_local {
+    // # local elements
+    using half = bitonic_local<ValueType, num_elements / 2>;
+
+    // merges two bitonic sequences els[0, n / 2), els[n / 2, n)
+    __host__ __device__ static void merge(ValueType *els, bool odd)
+    {
+        auto els_mid = els + (num_elements / 2);
+        for (auto i = 0; i < num_elements / 2; ++i) {
+            bitonic_cas(els[i], els_mid[i], odd);
+        }
+        half::merge(els, odd);
+        half::merge(els_mid, odd);
+    }
+
+    // sorts an unsorted sequence els [0, n)
+    __device__ static void sort(ValueType *els, bool reverse)
+    {
+        auto els_mid = els + (num_elements / 2);
+        // sort first half normally
+        half::sort(els, reverse);
+        // sort second half reversed
+        half::sort(els_mid, !reverse);
+        // merge two halves
+        merge(els, reverse);
+    }
+};
+
+template <typename ValueType>
+struct bitonic_local<ValueType, 1> {
+    // nothing to do for a single element
+    __device__ static void merge(ValueType *, bool) {}
+    __device__ static void sort(ValueType *, bool) {}
+};
+
+
+template <typename ValueType, int num_local, int num_threads>
+struct bitonic_warp {
+    constexpr static auto num_elements = num_local * num_threads;
+    using half = bitonic_warp<ValueType, num_local, num_threads / 2>;
+    static_assert(
+        config::warp_size % num_threads == 0 &&
+            num_threads <= config::warp_size,
+        "number of threads must be a power of two smaller than warp_size");
+
+    // check if we are in the upper half of all threads in this group
+    // this is important as
+    // 1. for sorting, we have to reverse the sort order in the upper half
+    // 2. for merging, we have to determine for the XOR shuffle if we are
+    //    the "smaller" thread, as this thread gets the "smaller" element.
+    __device__ static bool upper_half()
+    {
+        return bool(threadIdx.x & (num_threads / 2));
+    }
+
+    __device__ static void merge(ValueType *els, bool reverse)
+    {
+        auto tile = group::thread_block_tile<num_threads>{};
+        auto new_reverse = reverse != upper_half();
+        for (auto i = 0; i < num_local; ++i) {
+            auto other = tile.shfl_xor(els[i], num_threads / 2);
+            bitonic_cas(els[i], other, new_reverse);
+        }
+        half::merge(els, reverse);
+    }
+
+    __device__ static void sort(ValueType *els, bool reverse)
+    {
+        auto new_reverse = reverse != upper_half();
+        half::sort(els, new_reverse);
+        merge(els, reverse);
+    }
+};
+
+template <typename ValueType, int NumLocalElements>
+struct bitonic_warp<ValueType, NumLocalElements, 1> {
+    using local = bitonic_local<ValueType, NumLocalElements>;
+    __device__ static void merge(ValueType *els, bool reverse)
+    {
+        local::merge(els, reverse);
+    }
+    __device__ static void sort(ValueType *els, bool reverse)
+    {
+        local::sort(els, reverse);
+    }
+};
+
+
+template <typename ValueType, int num_local, int num_threads, int num_groups,
+          int num_total_threads>
+struct bitonic_global {
+    constexpr static auto num_elements = num_local * num_threads * num_groups;
+    using half = bitonic_global<ValueType, num_local, num_threads,
+                                num_groups / 2, num_total_threads>;
+    static_assert(32 % num_groups == 0,
+                  "num_groups must be a power of two <= 32");
+
+    __device__ static int shared_idx(int local)
+    {
+        auto rank = group::this_thread_block().thread_rank();
+        // use the same memory-bank to avoid bank conflicts
+        return rank + local * num_total_threads;
+    }
+
+    // check if we are in the upper half of all groups in this block
+    // this is important as for sorting, we have to reverse the sort order in
+    // the upper half
+    __device__ static bool upper_half()
+    {
+        auto rank = group::this_thread_block().thread_rank();
+        return bool(rank & (num_groups * num_threads / 2));
+    }
+
+    __device__ static void merge(ValueType *local_els, ValueType *shared_els,
+                                 bool reverse)
+    {
+        group::this_thread_block().sync();
+        auto upper_shared_els = shared_els + (num_groups * num_threads / 2);
+        // only the lower group executes the CAS
+        if (!upper_half()) {
+            for (auto i = 0; i < num_local; ++i) {
+                auto j = shared_idx(i);
+                bitonic_cas(shared_els[j], upper_shared_els[j], reverse);
+            }
+        }
+        half::merge(local_els, shared_els, reverse);
+    }
+
+    __device__ static void sort(ValueType *local_els, ValueType *shared_els,
+                                bool reverse)
+    {
+        auto new_reverse = reverse != upper_half();
+        half::sort(local_els, shared_els, new_reverse);
+        merge(local_els, shared_els, reverse);
+    }
+};
+
+template <typename ValueType, int num_local, int num_threads,
+          int num_total_threads>
+struct bitonic_global<ValueType, num_local, num_threads, 1, num_total_threads> {
+    using warp = bitonic_warp<ValueType, num_local, num_threads>;
+
+    __device__ static int shared_idx(int local)
+    {
+        // use the indexing from the general struct
+        return bitonic_global<ValueType, num_local, num_threads, 2,
+                              num_total_threads>::shared_idx(local);
+    }
+
+    __device__ static void merge(ValueType *local_els, ValueType *shared_els,
+                                 bool reverse)
+    {
+        group::this_thread_block().sync();
+        for (auto i = 0; i < num_local; ++i) {
+            local_els[i] = shared_els[shared_idx(i)];
+        }
+        warp::merge(local_els, reverse);
+        for (auto i = 0; i < num_local; ++i) {
+            shared_els[shared_idx(i)] = local_els[i];
+        }
+    }
+
+    __device__ static void sort(ValueType *local_els, ValueType *shared_els,
+                                bool reverse)
+    {
+        auto rank = group::this_thread_block().thread_rank();
+        // This is the first step, so we don't need to load from shared memory
+        warp::sort(local_els, reverse);
+        // store the sorted elements in shared memory
+        for (auto i = 0; i < num_local; ++i) {
+            shared_els[shared_idx(i)] = local_els[i];
+        }
+    }
+};
+
+
+}  // namespace detail
+
+
+template <int num_elements, int num_local, typename ValueType>
+__device__ void bitonic_sort(ValueType *local_elements,
+                             ValueType *shared_elements)
+{
+    constexpr auto num_threads = num_elements / num_local;
+    constexpr auto num_warps = num_threads / config::warp_size;
+    static_assert(num_threads <= config::max_block_size,
+                  "bitonic_sort exceeds thread block");
+    if (num_warps > 1) {
+        detail::bitonic_global<ValueType, num_local, config::warp_size,
+                               num_warps, num_threads>::sort(local_elements,
+                                                             shared_elements,
+                                                             false);
+    } else {
+        constexpr auto _num_threads =
+            num_warps > 1 ? 1 : num_threads;  // sentinel value to make sure we
+                                              // don't break anything
+        detail::bitonic_warp<ValueType, num_local, _num_threads>::sort(
+            local_elements, false);
+    }
+}

--- a/common/components/sorting.hpp.inc
+++ b/common/components/sorting.hpp.inc
@@ -221,6 +221,32 @@ struct bitonic_global<ValueType, num_local, num_threads, 1, num_total_threads> {
 }  // namespace detail
 
 
+/**
+ * @internal
+ *
+ * This function sorts elements within a thread block.
+ *
+ * It takes a local array of elements and the pointer to a shared buffer of size
+ * `num_elements` as input. After the execution, the thread with rank `i` in the
+ * thread block (determined by `group::this_thread_block().thread_rank()`) has
+ * the elements at index `num_local * i` up to `num_local * i + (num_local - 1)`
+ * in the sorted sequence stored in its `local_elements` at index 0 up to
+ * `num_local - 1`.
+ *
+ * @note The shared-memory buffer uses a striped layout to limit bank
+ *       collisions, so it should not directly be used to access elements from
+ *       the sorted sequence. If `num_elements <= num_local * warp_size`, the
+ *       algorithm doesn't use/need the shared-memory buffer, so it can be null.
+ *
+ * @param local_elements  the `num_local` input/output elements from this
+ *                        thread.
+ * @param shared_elements  the shared-memory buffer of size `num_elements`
+ * @tparam num_elements  the number of elements - it must be a power of two!
+ * @tparam num_local  the number of elements stored per thread - it must be a
+ *                    power of two!
+ * @tparam ValueType  the type of the elements to be sorted - it must implement
+ *                    the less-than operator!
+ */
 template <int num_elements, int num_local, typename ValueType>
 __device__ void bitonic_sort(ValueType *local_elements,
                              ValueType *shared_elements)
@@ -230,14 +256,18 @@ __device__ void bitonic_sort(ValueType *local_elements,
     static_assert(num_threads <= config::max_block_size,
                   "bitonic_sort exceeds thread block");
     if (num_warps > 1) {
-        detail::bitonic_global<ValueType, num_local, config::warp_size,
-                               num_warps, num_threads>::sort(local_elements,
-                                                             shared_elements,
-                                                             false);
-    } else {
+        // these checks are necessary since the `if` is not evaluated at
+        // compile-time so even though the branch is never taken, it still gets
+        // instantiated and must thus compile.
+        constexpr auto _num_warps = num_warps <= 1 ? 1 : num_warps;
         constexpr auto _num_threads =
-            num_warps > 1 ? 1 : num_threads;  // sentinel value to make sure we
-                                              // don't break anything
+            num_threads <= config::warp_size ? config::warp_size : num_threads;
+        detail::bitonic_global<ValueType, num_local, config::warp_size,
+                               _num_warps, _num_threads>::sort(local_elements,
+                                                               shared_elements,
+                                                               false);
+    } else {
+        constexpr auto _num_threads = num_warps > 1 ? 1 : num_threads;
         detail::bitonic_warp<ValueType, num_local, _num_threads>::sort(
             local_elements, false);
     }

--- a/common/components/sorting.hpp.inc
+++ b/common/components/sorting.hpp.inc
@@ -44,18 +44,17 @@ __device__ void bitonic_cas(ValueType &a, ValueType &b, bool reverse)
 
 template <typename ValueType, int num_elements>
 struct bitonic_local {
-    // # local elements
     using half = bitonic_local<ValueType, num_elements / 2>;
 
     // merges two bitonic sequences els[0, n / 2), els[n / 2, n)
-    __host__ __device__ static void merge(ValueType *els, bool odd)
+    __host__ __device__ static void merge(ValueType *els, bool reverse)
     {
         auto els_mid = els + (num_elements / 2);
         for (auto i = 0; i < num_elements / 2; ++i) {
-            bitonic_cas(els[i], els_mid[i], odd);
+            bitonic_cas(els[i], els_mid[i], reverse);
         }
-        half::merge(els, odd);
-        half::merge(els_mid, odd);
+        half::merge(els, reverse);
+        half::merge(els_mid, reverse);
     }
 
     // sorts an unsorted sequence els [0, n)

--- a/common/components/sorting.hpp.inc
+++ b/common/components/sorting.hpp.inc
@@ -33,6 +33,13 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 namespace detail {
 
 
+/**
+ * @internal
+ * Bitonic sorting operation for two elements.
+ *
+ * @param reverse  sorts in ascending order if `false` and
+ *                 descending order if `true`.
+ */
 template <typename ValueType>
 __device__ void bitonic_cas(ValueType &a, ValueType &b, bool reverse)
 {
@@ -42,6 +49,14 @@ __device__ void bitonic_cas(ValueType &a, ValueType &b, bool reverse)
     b = cmp ? b : tmp;
 }
 
+
+/**
+ * @internal
+ * This is a recursive implementation of a bitonic sorting network,
+ * executed sequentially on locally stored data.
+ *
+ * Based on Batcher, "Sorting Networks and Their Applications", 1968.
+ */
 template <typename ValueType, int num_elements>
 struct bitonic_local {
     using half = bitonic_local<ValueType, num_elements / 2>;
@@ -81,6 +96,13 @@ struct bitonic_local<ValueType, 1> {
 };
 
 
+/**
+ * @internal
+ * This is a recursive implementation of a bitonic sorting network,
+ * executed in parallel within a warp using lane shuffle instructions.
+ *
+ * Based on Hou et al., "Fast Segmented Sort on GPUs", 2017.
+ */
 template <typename ValueType, int num_local, int num_threads>
 struct bitonic_warp {
     constexpr static auto num_elements = num_local * num_threads;
@@ -135,6 +157,14 @@ struct bitonic_warp<ValueType, NumLocalElements, 1> {
 };
 
 
+/**
+ * @internal
+ * This is a recursive implementation of a bitonic sorting network,
+ * executed in parallel in a thread block using shared memory.
+ *
+ * We use a tiled storage pattern to avoid memory bank collisions on shared
+ * memory accesses, see @ref shared_idx.
+ */
 template <typename ValueType, int num_local, int num_threads, int num_groups,
           int num_total_threads>
 struct bitonic_global {

--- a/common/components/sorting.hpp.inc
+++ b/common/components/sorting.hpp.inc
@@ -45,6 +45,9 @@ __device__ void bitonic_cas(ValueType &a, ValueType &b, bool reverse)
 template <typename ValueType, int num_elements>
 struct bitonic_local {
     using half = bitonic_local<ValueType, num_elements / 2>;
+    static_assert(num_elements > 0, "number of elements must be positive");
+    static_assert((num_elements & (num_elements - 1)) == 0,
+                  "number of elements must be a power of two");
 
     // merges two bitonic sequences els[0, n / 2), els[n / 2, n)
     __host__ __device__ static void merge(ValueType *els, bool reverse)
@@ -82,6 +85,8 @@ template <typename ValueType, int num_local, int num_threads>
 struct bitonic_warp {
     constexpr static auto num_elements = num_local * num_threads;
     using half = bitonic_warp<ValueType, num_local, num_threads / 2>;
+    static_assert(num_threads > 0, "number of threads must be positive");
+    static_assert(num_local > 0, "number of local elements must be positive");
     static_assert(
         config::warp_size % num_threads == 0 &&
             num_threads <= config::warp_size,
@@ -136,6 +141,11 @@ struct bitonic_global {
     constexpr static auto num_elements = num_local * num_threads * num_groups;
     using half = bitonic_global<ValueType, num_local, num_threads,
                                 num_groups / 2, num_total_threads>;
+    static_assert(num_groups > 0, "number of groups must be positive");
+    static_assert(num_threads > 0,
+                  "number of threads per group must be positive");
+    static_assert(num_local > 0, "number of local elements must be positive");
+    static_assert(num_total_threads > 0, "number of threads must be positive");
     static_assert(32 % num_groups == 0,
                   "num_groups must be a power of two <= 32");
 

--- a/cuda/base/config.hpp
+++ b/cuda/base/config.hpp
@@ -34,6 +34,9 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define GKO_CUDA_BASE_CONFIG_HPP_
 
 
+#include <ginkgo/core/base/types.hpp>
+
+
 namespace gko {
 namespace kernels {
 namespace cuda {

--- a/cuda/components/sorting.cuh
+++ b/cuda/components/sorting.cuh
@@ -1,0 +1,54 @@
+/*******************************<GINKGO LICENSE>******************************
+Copyright (c) 2017-2019, the Ginkgo authors
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+******************************<GINKGO LICENSE>*******************************/
+
+#ifndef GKO_CUDA_COMPONENTS_SORTING_CUH_
+#define GKO_CUDA_COMPONENTS_SORTING_CUH_
+
+
+#include "cuda/base/config.hpp"
+#include "cuda/components/cooperative_groups.cuh"
+
+
+namespace gko {
+namespace kernels {
+namespace cuda {
+
+
+#include "common/components/sorting.hpp.inc"
+
+
+}  // namespace cuda
+}  // namespace kernels
+}  // namespace gko
+
+
+#endif  // GKO_CUDA_COMPONENTS_SORTING_CUH_

--- a/cuda/test/CMakeLists.txt
+++ b/cuda/test/CMakeLists.txt
@@ -1,6 +1,7 @@
 include(${CMAKE_SOURCE_DIR}/cmake/create_test.cmake)
 
 add_subdirectory(base)
+add_subdirectory(components)
 add_subdirectory(factorization)
 add_subdirectory(matrix)
 add_subdirectory(preconditioner)

--- a/cuda/test/components/CMakeLists.txt
+++ b/cuda/test/components/CMakeLists.txt
@@ -1,0 +1,1 @@
+ginkgo_create_cuda_test(sorting)

--- a/cuda/test/components/sorting.cu
+++ b/cuda/test/components/sorting.cu
@@ -30,6 +30,9 @@ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ******************************<GINKGO LICENSE>*******************************/
 
+#include "cuda/components/sorting.cuh"
+
+
 #include <memory>
 #include <random>
 
@@ -39,9 +42,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <ginkgo/core/base/array.hpp>
 #include <ginkgo/core/base/executor.hpp>
-
-
-#include "cuda/components/sorting.cuh"
 
 
 namespace {

--- a/cuda/test/components/sorting.cu
+++ b/cuda/test/components/sorting.cu
@@ -1,0 +1,141 @@
+/*******************************<GINKGO LICENSE>******************************
+Copyright (c) 2017-2019, the Ginkgo authors
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+******************************<GINKGO LICENSE>*******************************/
+
+#include <memory>
+#include <random>
+
+
+#include <gtest/gtest.h>
+
+
+#include <ginkgo/core/base/array.hpp>
+#include <ginkgo/core/base/executor.hpp>
+
+
+#include "cuda/components/sorting.cuh"
+
+
+namespace {
+
+
+using gko::kernels::cuda::bitonic_sort;
+using gko::kernels::cuda::config;
+
+
+constexpr auto num_elements = 2048;
+constexpr auto num_local = 4;
+constexpr auto num_threads = num_elements / num_local;
+
+
+__global__ void test_sort_shared(gko::int32 *data)
+{
+    gko::int32 local[num_local];
+    __shared__ gko::int32 sh_local[num_elements];
+    for (int i = 0; i < num_local; ++i) {
+        local[i] = data[threadIdx.x * num_local + i];
+    }
+    bitonic_sort<num_elements, num_local>(local, sh_local);
+    for (int i = 0; i < num_local; ++i) {
+        data[threadIdx.x * num_local + i] = local[i];
+    }
+}
+
+
+__global__ void test_sort_warp(gko::int32 *data)
+{
+    gko::int32 local[num_local];
+    for (int i = 0; i < num_local; ++i) {
+        local[i] = data[threadIdx.x * num_local + i];
+    }
+    bitonic_sort<config::warp_size * num_local, num_local>(
+        local, static_cast<gko::int32 *>(nullptr));
+    for (int i = 0; i < num_local; ++i) {
+        data[threadIdx.x * num_local + i] = local[i];
+    }
+}
+
+
+class Sorting : public ::testing::Test {
+protected:
+    Sorting()
+        : ref(gko::ReferenceExecutor::create()),
+          cuda(gko::CudaExecutor::create(0, ref)),
+          rng(123456),
+          ref_shared(ref, num_elements),
+          ref_warp(ref),
+          ddata(cuda)
+    {
+        // we want some duplicate elements
+        std::uniform_int_distribution<gko::int32> dist(0, num_elements / 2);
+        for (auto i = 0; i < num_elements; ++i) {
+            ref_shared.get_data()[i] = dist(rng);
+        }
+        ddata = gko::Array<gko::int32>{cuda, ref_shared};
+        ref_warp = ref_shared;
+        std::sort(ref_shared.get_data(), ref_shared.get_data() + num_elements);
+        std::sort(ref_warp.get_data(),
+                  ref_warp.get_data() + (config::warp_size * num_local));
+    }
+
+    std::shared_ptr<gko::ReferenceExecutor> ref;
+    std::shared_ptr<gko::CudaExecutor> cuda;
+    std::default_random_engine rng;
+    gko::Array<gko::int32> ref_shared;
+    gko::Array<gko::int32> ref_warp;
+    gko::Array<gko::int32> ddata;
+};
+
+
+TEST_F(Sorting, CudaBitonicSortWarp)
+{
+    test_sort_warp<<<1, config::warp_size>>>(ddata.get_data());
+    ddata.set_executor(ref);
+    auto data_ptr = ddata.get_const_data();
+    auto ref_ptr = ref_warp.get_const_data();
+
+    ASSERT_TRUE(std::equal(data_ptr, data_ptr + (num_local * config::warp_size),
+                           ref_ptr));
+}
+
+
+TEST_F(Sorting, CudaBitonicSortShared)
+{
+    test_sort_shared<<<1, num_threads>>>(ddata.get_data());
+    ddata.set_executor(ref);
+    auto data_ptr = ddata.get_const_data();
+    auto ref_ptr = ref_shared.get_const_data();
+
+    ASSERT_TRUE(std::equal(data_ptr, data_ptr + num_elements, ref_ptr));
+}
+
+
+}  // namespace

--- a/hip/base/config.hip.hpp
+++ b/hip/base/config.hip.hpp
@@ -37,6 +37,9 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <hip/device_functions.h>
 
 
+#include <ginkgo/core/base/types.hpp>
+
+
 #include "hip/base/math.hip.hpp"
 
 

--- a/hip/components/sorting.hip.hpp
+++ b/hip/components/sorting.hip.hpp
@@ -1,0 +1,54 @@
+/*******************************<GINKGO LICENSE>******************************
+Copyright (c) 2017-2019, the Ginkgo authors
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+******************************<GINKGO LICENSE>*******************************/
+
+#ifndef GKO_HIP_COMPONENTS_SORTING_CUH_
+#define GKO_HIP_COMPONENTS_SORTING_CUH_
+
+
+#include "hip/base/config.hip.hpp"
+#include "hip/components/cooperative_groups.hip.hpp"
+
+
+namespace gko {
+namespace kernels {
+namespace hip {
+
+
+#include "common/components/sorting.hpp.inc"
+
+
+}  // namespace hip
+}  // namespace kernels
+}  // namespace gko
+
+
+#endif  // GKO_HIP_COMPONENTS_SORTING_CUH_

--- a/hip/test/CMakeLists.txt
+++ b/hip/test/CMakeLists.txt
@@ -1,6 +1,7 @@
 include(${CMAKE_SOURCE_DIR}/cmake/create_test.cmake)
 
 add_subdirectory(base)
+add_subdirectory(components)
 add_subdirectory(factorization)
 add_subdirectory(matrix)
 add_subdirectory(solver)

--- a/hip/test/components/CMakeLists.txt
+++ b/hip/test/components/CMakeLists.txt
@@ -1,0 +1,1 @@
+ginkgo_create_hip_test(sorting)

--- a/hip/test/components/sorting.hip.cpp
+++ b/hip/test/components/sorting.hip.cpp
@@ -30,6 +30,9 @@ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ******************************<GINKGO LICENSE>*******************************/
 
+#include "hip/components/sorting.hip.hpp"
+
+
 #include <memory>
 #include <random>
 
@@ -39,9 +42,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <ginkgo/core/base/array.hpp>
 #include <ginkgo/core/base/executor.hpp>
-
-
-#include "hip/components/sorting.hip.hpp"
 
 
 namespace {

--- a/hip/test/components/sorting.hip.cpp
+++ b/hip/test/components/sorting.hip.cpp
@@ -30,6 +30,10 @@ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ******************************<GINKGO LICENSE>*******************************/
 
+// TODO remove when the HIP includes are fixed
+#include <hip/hip_runtime.h>
+
+
 #include "hip/components/sorting.hip.hpp"
 
 

--- a/hip/test/components/sorting.hip.cpp
+++ b/hip/test/components/sorting.hip.cpp
@@ -1,0 +1,143 @@
+/*******************************<GINKGO LICENSE>******************************
+Copyright (c) 2017-2019, the Ginkgo authors
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+******************************<GINKGO LICENSE>*******************************/
+
+#include <memory>
+#include <random>
+
+
+#include <gtest/gtest.h>
+
+
+#include <ginkgo/core/base/array.hpp>
+#include <ginkgo/core/base/executor.hpp>
+
+
+#include "hip/components/sorting.hip.hpp"
+
+
+namespace {
+
+
+using gko::kernels::hip::bitonic_sort;
+using gko::kernels::hip::config;
+
+
+constexpr auto num_elements = 2048;
+constexpr auto num_local = 4;
+constexpr auto num_threads = num_elements / num_local;
+
+
+__global__ void test_sort_shared(gko::int32 *data)
+{
+    gko::int32 local[num_local];
+    __shared__ gko::int32 sh_local[num_elements];
+    for (int i = 0; i < num_local; ++i) {
+        local[i] = data[threadIdx.x * num_local + i];
+    }
+    bitonic_sort<num_elements, num_local>(local, sh_local);
+    for (int i = 0; i < num_local; ++i) {
+        data[threadIdx.x * num_local + i] = local[i];
+    }
+}
+
+
+__global__ void test_sort_warp(gko::int32 *data)
+{
+    gko::int32 local[num_local];
+    for (int i = 0; i < num_local; ++i) {
+        local[i] = data[threadIdx.x * num_local + i];
+    }
+    bitonic_sort<config::warp_size * num_local, num_local>(
+        local, static_cast<gko::int32 *>(nullptr));
+    for (int i = 0; i < num_local; ++i) {
+        data[threadIdx.x * num_local + i] = local[i];
+    }
+}
+
+
+class Sorting : public ::testing::Test {
+protected:
+    Sorting()
+        : ref(gko::ReferenceExecutor::create()),
+          hip(gko::HipExecutor::create(0, ref)),
+          rng(123456),
+          ref_shared(ref, num_elements),
+          ref_warp(ref),
+          ddata(hip)
+    {
+        // we want some duplicate elements
+        std::uniform_int_distribution<gko::int32> dist(0, num_elements / 2);
+        for (auto i = 0; i < num_elements; ++i) {
+            ref_shared.get_data()[i] = dist(rng);
+        }
+        ddata = gko::Array<gko::int32>{hip, ref_shared};
+        ref_warp = ref_shared;
+        std::sort(ref_shared.get_data(), ref_shared.get_data() + num_elements);
+        std::sort(ref_warp.get_data(),
+                  ref_warp.get_data() + (config::warp_size * num_local));
+    }
+
+    std::shared_ptr<gko::ReferenceExecutor> ref;
+    std::shared_ptr<gko::HipExecutor> hip;
+    std::default_random_engine rng;
+    gko::Array<gko::int32> ref_shared;
+    gko::Array<gko::int32> ref_warp;
+    gko::Array<gko::int32> ddata;
+};
+
+
+TEST_F(Sorting, HipBitonicSortWarp)
+{
+    hipLaunchKernelGGL(HIP_KERNEL_NAME(test_sort_warp), dim3(1),
+                       dim3(config::warp_size), 0, 0, ddata.get_data());
+    ddata.set_executor(ref);
+    auto data_ptr = ddata.get_const_data();
+    auto ref_ptr = ref_warp.get_const_data();
+
+    ASSERT_TRUE(std::equal(data_ptr, data_ptr + (num_local * config::warp_size),
+                           ref_ptr));
+}
+
+
+TEST_F(Sorting, HipBitonicSortShared)
+{
+    hipLaunchKernelGGL(HIP_KERNEL_NAME(test_sort_shared), dim3(1),
+                       dim3(num_threads), 0, 0, ddata.get_data());
+    ddata.set_executor(ref);
+    auto data_ptr = ddata.get_const_data();
+    auto ref_ptr = ref_shared.get_const_data();
+
+    ASSERT_TRUE(std::equal(data_ptr, data_ptr + num_elements, ref_ptr));
+}
+
+
+}  // namespace


### PR DESCRIPTION
This PR adds a three-stage bitonic sorting implementation for GPUs:

* In the first stage, a power-of-two number of elements are being sorted locally within each thread
* In the second stage, these local elements are being sorted within a warp/wavefront using butterfly shuffles
* In the third stage, these elements from a power-of-two number of warps/wavefronts are being sorted using shared memory. Here I took additional care to avoid shared memory collisions.

Note that in a bitonic sorting network, we first recursively sort two halves of the input, with the second half reversed, and then merge the result by first merging corresponding elements from the two blocks and then recursively merging the elements inside the two halves.

TODO:
- [x] Add documentation describing how to invoke the helper functions