### PR TITLE
Add HIP bindings for SpGeMM

### DIFF
--- a/common/base/math.hpp.inc
+++ b/common/base/math.hpp.inc
@@ -173,3 +173,13 @@ using ::isfinite;
 
 
 #endif  // defined(__CUDA_ARCH__) || __HIP_DEVICE_COMPILE__
+
+
+// We need this struct, because otherwise we would call a __host__ function in a
+// __device__ function (even though it is constexpr)
+template <typename T>
+struct device_numeric_limits {
+    static constexpr auto inf = std::numeric_limits<T>::infinity();
+    static constexpr auto max = std::numeric_limits<T>::max();
+    static constexpr auto min = std::numeric_limits<T>::min();
+};

--- a/common/matrix/csr_kernels.hpp.inc
+++ b/common/matrix/csr_kernels.hpp.inc
@@ -495,6 +495,98 @@ __global__ __launch_bounds__(spmv_block_size) void abstract_classical_spmv(
 
 
 template <typename IndexType>
+__global__ __launch_bounds__(default_block_size) void spgeam_nnz(
+    const IndexType *a_row_ptrs, const IndexType *a_col_idxs,
+    const IndexType *b_row_ptrs, const IndexType *b_col_idxs,
+    IndexType num_rows, IndexType *nnz)
+{
+    constexpr auto sentinel = device_numeric_limits<IndexType>::max;
+    auto row = threadIdx.x + blockDim.x * blockIdx.x;
+    if (row >= num_rows) {
+        return;
+    }
+
+    auto a_begin = a_row_ptrs[row];
+    auto b_begin = b_row_ptrs[row];
+    auto a_end = a_row_ptrs[row + 1];
+    auto b_end = b_row_ptrs[row + 1];
+    auto a_size = a_end - a_begin;
+    auto b_size = b_end - b_begin;
+    auto a_ptr = a_begin;
+    auto b_ptr = b_begin;
+    auto a_col = a_ptr < a_end ? a_col_idxs[a_ptr] : sentinel;
+    auto b_col = b_ptr < b_end ? b_col_idxs[b_ptr] : sentinel;
+    IndexType count{};
+    IndexType i{};
+    while (i < a_size + b_size) {
+        auto advance_a = (a_col <= b_col);
+        auto advance_b = (b_col <= a_col);
+        i += advance_a + advance_b;
+        a_ptr += advance_a;
+        b_ptr += advance_b;
+        if (advance_a) {
+            a_col = a_ptr < a_end ? a_col_idxs[a_ptr] : sentinel;
+        }
+        if (advance_b) {
+            b_col = b_ptr < b_end ? b_col_idxs[b_ptr] : sentinel;
+        }
+        ++count;
+    }
+    nnz[row] = count;
+}
+
+
+template <typename IndexType, typename ValueType>
+__global__ __launch_bounds__(default_block_size) void spgeam(
+    ValueType alpha, const IndexType *a_row_ptrs, const IndexType *a_col_idxs,
+    const ValueType *a_vals, ValueType beta, const IndexType *b_row_ptrs,
+    const IndexType *b_col_idxs, const ValueType *b_vals, IndexType num_rows,
+    const IndexType *c_row_ptrs, IndexType *c_col_idxs, ValueType *c_vals)
+{
+    constexpr auto sentinel = device_numeric_limits<IndexType>::max;
+    auto row = threadIdx.x + blockDim.x * blockIdx.x;
+    if (row >= num_rows) {
+        return;
+    }
+
+    auto a_begin = a_row_ptrs[row];
+    auto b_begin = b_row_ptrs[row];
+    auto c_begin = c_row_ptrs[row];
+    auto a_end = a_row_ptrs[row + 1];
+    auto b_end = b_row_ptrs[row + 1];
+    auto a_size = a_end - a_begin;
+    auto b_size = b_end - b_begin;
+    auto a_ptr = a_begin;
+    auto b_ptr = b_begin;
+    auto a_col = a_ptr < a_end ? a_col_idxs[a_ptr] : sentinel;
+    auto b_col = b_ptr < b_end ? b_col_idxs[b_ptr] : sentinel;
+    IndexType count{};
+    IndexType i{};
+    IndexType c_col{};
+    while (i < a_size + b_size) {
+        auto advance_a = (a_col <= b_col);
+        auto advance_b = (b_col <= a_col);
+        c_col = advance_a ? a_col : b_col;
+        i += advance_a + advance_b;
+        a_ptr += advance_a;
+        b_ptr += advance_b;
+        ValueType c_val{};
+        if (advance_a) {
+            a_col = a_ptr < a_end ? a_col_idxs[a_ptr] : sentinel;
+            c_val += alpha * a_vals[a_ptr - 1];
+        }
+        if (advance_b) {
+            b_col = b_ptr < b_end ? b_col_idxs[b_ptr] : sentinel;
+            c_val += beta * b_vals[b_ptr - 1];
+        }
+        c_col_idxs[c_begin + count] = c_col;
+        c_vals[c_begin + count] = c_val;
+        ++count;
+    }
+}
+
+
+template <typename IndexType>
 __global__ __launch_bounds__(default_block_size) void convert_row_ptrs_to_idxs(
     size_type num_rows, const IndexType *__restrict__ ptrs,
     IndexType *__restrict__ idxs)

--- a/common/matrix/csr_kernels.hpp.inc
+++ b/common/matrix/csr_kernels.hpp.inc
@@ -501,7 +501,7 @@ __global__ __launch_bounds__(default_block_size) void spgeam_nnz(
     IndexType num_rows, IndexType *nnz)
 {
     constexpr auto sentinel = device_numeric_limits<IndexType>::max;
-    auto row = threadIdx.x + blockDim.x * blockIdx.x;
+    auto row = threadIdx.x + blockDim.x * static_cast<size_type>(blockIdx.x);
     if (row >= num_rows) {
         return;
     }
@@ -544,7 +544,7 @@ __global__ __launch_bounds__(default_block_size) void spgeam(
     const IndexType *c_row_ptrs, IndexType *c_col_idxs, ValueType *c_vals)
 {
     constexpr auto sentinel = device_numeric_limits<IndexType>::max;
-    auto row = threadIdx.x + blockDim.x * blockIdx.x;
+    auto row = threadIdx.x + blockDim.x * static_cast<size_type>(blockIdx.x);
     if (row >= num_rows) {
         return;
     }

--- a/core/matrix/csr_kernels.hpp
+++ b/core/matrix/csr_kernels.hpp
@@ -75,7 +75,7 @@ namespace kernels {
                          const matrix::Csr<ValueType, IndexType> *a,  \
                          const matrix::Csr<ValueType, IndexType> *b,  \
                          const matrix::Dense<ValueType> *beta,        \
-                         const matrix::Csr<ValueType, IndexType> *c,  \
+                         const matrix::Csr<ValueType, IndexType> *d,  \
                          Array<IndexType> &c_row_ptrs,                \
                          Array<IndexType> &c_col_idxs,                \
                          Array<ValueType> &c_vals)

--- a/cuda/matrix/csr_kernels.cu
+++ b/cuda/matrix/csr_kernels.cu
@@ -498,7 +498,7 @@ void advanced_spgemm(std::shared_ptr<const CudaExecutor> exec,
                      const matrix::Csr<ValueType, IndexType> *a,
                      const matrix::Csr<ValueType, IndexType> *b,
                      const matrix::Dense<ValueType> *beta,
-                     const matrix::Csr<ValueType, IndexType> *c,
+                     const matrix::Csr<ValueType, IndexType> *d,
                      Array<IndexType> &c_row_ptrs_array,
                      Array<IndexType> &c_col_idxs_array,
                      Array<ValueType> &c_vals_array)
@@ -509,7 +509,7 @@ void advanced_spgemm(std::shared_ptr<const CudaExecutor> exec,
         auto a_descr = cusparse::create_mat_descr();
         auto b_descr = cusparse::create_mat_descr();
         auto c_descr = cusparse::create_mat_descr();
-        auto c_old_descr = cusparse::create_mat_descr();
+        auto d_descr = cusparse::create_mat_descr();
         auto info = cusparse::create_spgemm_info();
 
         ValueType valpha{};
@@ -526,10 +526,10 @@ void advanced_spgemm(std::shared_ptr<const CudaExecutor> exec,
         ValueType vbeta{};
         exec->get_master()->copy_from(exec.get(), 1, beta->get_const_values(),
                                       &vbeta);
-        auto c_old_nnz = IndexType(c->get_num_stored_elements());
-        auto c_old_vals = c->get_const_values();
-        auto c_old_row_ptrs = c->get_const_row_ptrs();
-        auto c_old_col_idxs = c->get_const_col_idxs();
+        auto d_nnz = IndexType(d->get_num_stored_elements());
+        auto d_vals = d->get_const_values();
+        auto d_row_ptrs = d->get_const_row_ptrs();
+        auto d_col_idxs = d->get_const_col_idxs();
         auto m = IndexType(a->get_size()[0]);
         auto n = IndexType(b->get_size()[1]);
         auto k = IndexType(a->get_size()[1]);
@@ -538,8 +538,8 @@ void advanced_spgemm(std::shared_ptr<const CudaExecutor> exec,
         size_type buffer_size{};
         cusparse::spgemm_buffer_size(
             handle, m, n, k, &valpha, a_descr, a_nnz, a_row_ptrs, a_col_idxs,
-            b_descr, b_nnz, b_row_ptrs, b_col_idxs, &vbeta, c_old_descr,
-            c_old_nnz, c_old_row_ptrs, c_old_col_idxs, info, buffer_size);
+            b_descr, b_nnz, b_row_ptrs, b_col_idxs, &vbeta, d_descr, d_nnz,
+            d_row_ptrs, d_col_idxs, info, buffer_size);
         Array<char> buffer_array(exec, buffer_size);
         auto buffer = buffer_array.get_data();
 
@@ -549,9 +549,8 @@ void advanced_spgemm(std::shared_ptr<const CudaExecutor> exec,
         IndexType c_nnz{};
         cusparse::spgemm_nnz(handle, m, n, k, a_descr, a_nnz, a_row_ptrs,
                              a_col_idxs, b_descr, b_nnz, b_row_ptrs, b_col_idxs,
-                             c_old_descr, c_old_nnz, c_old_row_ptrs,
-                             c_old_col_idxs, c_descr, c_row_ptrs, &c_nnz, info,
-                             buffer);
+                             d_descr, d_nnz, d_row_ptrs, d_col_idxs, c_descr,
+                             c_row_ptrs, &c_nnz, info, buffer);
 
         // accumulate non-zeros
         c_col_idxs_array.resize_and_reset(c_nnz);
@@ -560,12 +559,12 @@ void advanced_spgemm(std::shared_ptr<const CudaExecutor> exec,
         auto c_vals = c_vals_array.get_data();
         cusparse::spgemm(handle, m, n, k, &valpha, a_descr, a_nnz, a_vals,
                          a_row_ptrs, a_col_idxs, b_descr, b_nnz, b_vals,
-                         b_row_ptrs, b_col_idxs, &vbeta, c_old_descr, c_old_nnz,
-                         c_old_vals, c_old_row_ptrs, c_old_col_idxs, c_descr,
-                         c_vals, c_row_ptrs, c_col_idxs, info, buffer);
+                         b_row_ptrs, b_col_idxs, &vbeta, d_descr, d_nnz, d_vals,
+                         d_row_ptrs, d_col_idxs, c_descr, c_vals, c_row_ptrs,
+                         c_col_idxs, info, buffer);
 
         cusparse::destroy(info);
-        cusparse::destroy(c_old_descr);
+        cusparse::destroy(d_descr);
         cusparse::destroy(c_descr);
         cusparse::destroy(b_descr);
         cusparse::destroy(a_descr);

--- a/hip/base/hipsparse_bindings.hip.hpp
+++ b/hip/base/hipsparse_bindings.hip.hpp
@@ -223,11 +223,14 @@ void spgemm_buffer_size(
 
 GKO_BIND_HIPSPARSE_SPGEMM_BUFFER_SIZE(float, hipsparseScsrgemm2_bufferSizeExt);
 GKO_BIND_HIPSPARSE_SPGEMM_BUFFER_SIZE(double, hipsparseDcsrgemm2_bufferSizeExt);
-// TODO: uncomment when the shipped hipSparse gets updated
-// GKO_BIND_HIPSPARSE_SPGEMM_BUFFER_SIZE(std::complex<float>,
-//                                       hipsparseCcsrgemm2_bufferSizeExt);
-// GKO_BIND_HIPSPARSE_SPGEMM_BUFFER_SIZE(std::complex<double>,
-//                                       hipsparseZcsrgemm2_bufferSizeExt);*/
+#if defined(hipsparseVersionMajor) && defined(hipsparseVersionMinor) && \
+    ((hipsparseVersionMajor > 1) ||                                     \
+     (hipsparseVersionMajor == 1 && hipsparseVersionMinor >= 4))
+GKO_BIND_HIPSPARSE_SPGEMM_BUFFER_SIZE(std::complex<float>,
+                                      hipsparseCcsrgemm2_bufferSizeExt);
+GKO_BIND_HIPSPARSE_SPGEMM_BUFFER_SIZE(std::complex<double>,
+                                      hipsparseZcsrgemm2_bufferSizeExt);
+#endif  // hipsparse version >= 1.4
 
 
 #undef GKO_BIND_HIPSPARSE_SPGEMM_BUFFER_SIZE
@@ -306,9 +309,12 @@ void spgemm(hipsparseHandle_t handle, IndexType m, IndexType n, IndexType k,
 
 GKO_BIND_HIPSPARSE_SPGEMM(float, hipsparseScsrgemm2);
 GKO_BIND_HIPSPARSE_SPGEMM(double, hipsparseDcsrgemm2);
-// TODO: uncomment when the shipped hipSparse gets updated
-// GKO_BIND_HIPSPARSE_SPGEMM(std::complex<float>, hipsparseCcsrgemm2);
-// GKO_BIND_HIPSPARSE_SPGEMM(std::complex<double>, hipsparseZcsrgemm2);
+#if defined(hipsparseVersionMajor) && defined(hipsparseVersionMinor) && \
+    ((hipsparseVersionMajor > 1) ||                                     \
+     (hipsparseVersionMajor == 1 && hipsparseVersionMinor >= 4))
+GKO_BIND_HIPSPARSE_SPGEMM(std::complex<float>, hipsparseCcsrgemm2);
+GKO_BIND_HIPSPARSE_SPGEMM(std::complex<double>, hipsparseZcsrgemm2);
+#endif  // hipsparse version >= 1.4
 
 
 #undef GKO_BIND_HIPSPARSE_SPGEMM

--- a/hip/base/hipsparse_bindings.hip.hpp
+++ b/hip/base/hipsparse_bindings.hip.hpp
@@ -595,14 +595,11 @@ inline csrgemm2Info_t create_spgemm_info()
     return info;
 }
 
-// on HIP, hipsparseMatDescr_t and csrgemm2Info_t are both void*, so this would
-// be a redefinition
-#ifndef __HIP_PLATFORM_HCC__
-inline void destroy(csrgemm2Info_t info)
+
+inline void destroy_spgemm_info(csrgemm2Info_t info)
 {
     GKO_ASSERT_NO_HIPSPARSE_ERRORS(hipsparseDestroyCsrgemm2Info(info));
 }
-#endif
 
 
 }  // namespace hipsparse

--- a/hip/base/hipsparse_bindings.hip.hpp
+++ b/hip/base/hipsparse_bindings.hip.hpp
@@ -189,6 +189,131 @@ GKO_BIND_HIPSPARSE32_SPMV(ValueType, detail::not_implemented);
 #undef GKO_BIND_HIPSPARSE32_SPMV
 
 
+template <typename IndexType, typename ValueType>
+void spgemm_buffer_size(
+    hipsparseHandle_t handle, IndexType m, IndexType n, IndexType k,
+    const ValueType *alpha, const hipsparseMatDescr_t descrA, IndexType nnzA,
+    const IndexType *csrRowPtrA, const IndexType *csrColIndA,
+    const hipsparseMatDescr_t descrB, IndexType nnzB,
+    const IndexType *csrRowPtrB, const IndexType *csrColIndB,
+    const ValueType *beta, const hipsparseMatDescr_t descrD, IndexType nnzD,
+    const IndexType *csrRowPtrD, const IndexType *csrColIndD,
+    csrgemm2Info_t info, size_type &result) GKO_NOT_IMPLEMENTED;
+
+#define GKO_BIND_HIPSPARSE_SPGEMM_BUFFER_SIZE(ValueType, HipsparseName)        \
+    template <>                                                                \
+    inline void spgemm_buffer_size<int32, ValueType>(                          \
+        hipsparseHandle_t handle, int32 m, int32 n, int32 k,                   \
+        const ValueType *alpha, const hipsparseMatDescr_t descrA, int32 nnzA,  \
+        const int32 *csrRowPtrA, const int32 *csrColIndA,                      \
+        const hipsparseMatDescr_t descrB, int32 nnzB, const int32 *csrRowPtrB, \
+        const int32 *csrColIndB, const ValueType *beta,                        \
+        const hipsparseMatDescr_t descrD, int32 nnzD, const int32 *csrRowPtrD, \
+        const int32 *csrColIndD, csrgemm2Info_t info, size_type &result)       \
+    {                                                                          \
+        GKO_ASSERT_NO_HIPSPARSE_ERRORS(HipsparseName(                          \
+            handle, m, n, k, as_hiplibs_type(alpha), descrA, nnzA, csrRowPtrA, \
+            csrColIndA, descrB, nnzB, csrRowPtrB, csrColIndB,                  \
+            as_hiplibs_type(beta), descrD, nnzD, csrRowPtrD, csrColIndD, info, \
+            &result));                                                         \
+    }                                                                          \
+    static_assert(true,                                                        \
+                  "This assert is used to counter the false positive extra "   \
+                  "semi-colon warnings")
+
+GKO_BIND_HIPSPARSE_SPGEMM_BUFFER_SIZE(float, hipsparseScsrgemm2_bufferSizeExt);
+GKO_BIND_HIPSPARSE_SPGEMM_BUFFER_SIZE(double, hipsparseDcsrgemm2_bufferSizeExt);
+// TODO: uncomment when the shipped hipSparse gets updated
+// GKO_BIND_HIPSPARSE_SPGEMM_BUFFER_SIZE(std::complex<float>,
+//                                       hipsparseCcsrgemm2_bufferSizeExt);
+// GKO_BIND_HIPSPARSE_SPGEMM_BUFFER_SIZE(std::complex<double>,
+//                                       hipsparseZcsrgemm2_bufferSizeExt);*/
+
+
+#undef GKO_BIND_HIPSPARSE_SPGEMM_BUFFER_SIZE
+
+
+template <typename IndexType>
+void spgemm_nnz(hipsparseHandle_t handle, IndexType m, IndexType n, IndexType k,
+                const hipsparseMatDescr_t descrA, IndexType nnzA,
+                const IndexType *csrRowPtrA, const IndexType *csrColIndA,
+                const hipsparseMatDescr_t descrB, IndexType nnzB,
+                const IndexType *csrRowPtrB, const IndexType *csrColIndB,
+                const hipsparseMatDescr_t descrD, IndexType nnzD,
+                const IndexType *csrRowPtrD, const IndexType *csrColIndD,
+                const hipsparseMatDescr_t descrC, IndexType *csrRowPtrC,
+                IndexType *nnzC, csrgemm2Info_t info,
+                void *buffer) GKO_NOT_IMPLEMENTED;
+
+template <>
+inline void spgemm_nnz<int32>(
+    hipsparseHandle_t handle, int32 m, int32 n, int32 k,
+    const hipsparseMatDescr_t descrA, int32 nnzA, const int32 *csrRowPtrA,
+    const int32 *csrColIndA, const hipsparseMatDescr_t descrB, int32 nnzB,
+    const int32 *csrRowPtrB, const int32 *csrColIndB,
+    const hipsparseMatDescr_t descrD, int32 nnzD, const int32 *csrRowPtrD,
+    const int32 *csrColIndD, const hipsparseMatDescr_t descrC,
+    int32 *csrRowPtrC, int32 *nnzC, csrgemm2Info_t info, void *buffer)
+{
+    GKO_ASSERT_NO_HIPSPARSE_ERRORS(hipsparseXcsrgemm2Nnz(
+        handle, m, n, k, descrA, nnzA, csrRowPtrA, csrColIndA, descrB, nnzB,
+        csrRowPtrB, csrColIndB, descrD, nnzD, csrRowPtrD, csrColIndD, descrC,
+        csrRowPtrC, nnzC, info, buffer));
+}
+
+
+template <typename IndexType, typename ValueType>
+void spgemm(hipsparseHandle_t handle, IndexType m, IndexType n, IndexType k,
+            const ValueType *alpha, const hipsparseMatDescr_t descrA,
+            IndexType nnzA, const ValueType *csrValA,
+            const IndexType *csrRowPtrA, const IndexType *csrColIndA,
+            const hipsparseMatDescr_t descrB, IndexType nnzB,
+            const ValueType *csrValB, const IndexType *csrRowPtrB,
+            const IndexType *csrColIndB, const ValueType *beta,
+            const hipsparseMatDescr_t descrD, IndexType nnzD,
+            const ValueType *csrValD, const IndexType *csrRowPtrD,
+            const IndexType *csrColIndD, const hipsparseMatDescr_t descrC,
+            ValueType *csrValC, const IndexType *csrRowPtrC,
+            IndexType *csrColIndC, csrgemm2Info_t info,
+            void *buffer) GKO_NOT_IMPLEMENTED;
+
+#define GKO_BIND_HIPSPARSE_SPGEMM(ValueType, HipsparseName)                    \
+    template <>                                                                \
+    inline void spgemm<int32, ValueType>(                                      \
+        hipsparseHandle_t handle, int32 m, int32 n, int32 k,                   \
+        const ValueType *alpha, const hipsparseMatDescr_t descrA, int32 nnzA,  \
+        const ValueType *csrValA, const int32 *csrRowPtrA,                     \
+        const int32 *csrColIndA, const hipsparseMatDescr_t descrB, int32 nnzB, \
+        const ValueType *csrValB, const int32 *csrRowPtrB,                     \
+        const int32 *csrColIndB, const ValueType *beta,                        \
+        const hipsparseMatDescr_t descrD, int32 nnzD,                          \
+        const ValueType *csrValD, const int32 *csrRowPtrD,                     \
+        const int32 *csrColIndD, const hipsparseMatDescr_t descrC,             \
+        ValueType *csrValC, const int32 *csrRowPtrC, int32 *csrColIndC,        \
+        csrgemm2Info_t info, void *buffer)                                     \
+    {                                                                          \
+        GKO_ASSERT_NO_HIPSPARSE_ERRORS(HipsparseName(                          \
+            handle, m, n, k, as_hiplibs_type(alpha), descrA, nnzA,             \
+            as_hiplibs_type(csrValA), csrRowPtrA, csrColIndA, descrB, nnzB,    \
+            as_hiplibs_type(csrValB), csrRowPtrB, csrColIndB,                  \
+            as_hiplibs_type(beta), descrD, nnzD, as_hiplibs_type(csrValD),     \
+            csrRowPtrD, csrColIndD, descrC, as_hiplibs_type(csrValC),          \
+            csrRowPtrC, csrColIndC, info, buffer));                            \
+    }                                                                          \
+    static_assert(true,                                                        \
+                  "This assert is used to counter the false positive extra "   \
+                  "semi-colon warnings")
+
+GKO_BIND_HIPSPARSE_SPGEMM(float, hipsparseScsrgemm2);
+GKO_BIND_HIPSPARSE_SPGEMM(double, hipsparseDcsrgemm2);
+// TODO: uncomment when the shipped hipSparse gets updated
+// GKO_BIND_HIPSPARSE_SPGEMM(std::complex<float>, hipsparseCcsrgemm2);
+// GKO_BIND_HIPSPARSE_SPGEMM(std::complex<double>, hipsparseZcsrgemm2);
+
+
+#undef GKO_BIND_HIPSPARSE_SPGEMM
+
+
 #define GKO_BIND_HIPSPARSE32_CSR2HYB(ValueType, HipsparseName)               \
     inline void csr2hyb(hipsparseHandle_t handle, int32 m, int32 n,          \
                         const hipsparseMatDescr_t descrA,                    \
@@ -455,6 +580,23 @@ inline void destroy(hipsparseMatDescr_t descr)
 {
     GKO_ASSERT_NO_HIPSPARSE_ERRORS(hipsparseDestroyMatDescr(descr));
 }
+
+
+inline csrgemm2Info_t create_spgemm_info()
+{
+    csrgemm2Info_t info{};
+    GKO_ASSERT_NO_HIPSPARSE_ERRORS(hipsparseCreateCsrgemm2Info(&info));
+    return info;
+}
+
+// on HIP, hipsparseMatDescr_t and csrgemm2Info_t are both void*, so this would
+// be a redefinition
+#ifndef __HIP_PLATFORM_HCC__
+inline void destroy(csrgemm2Info_t info)
+{
+    GKO_ASSERT_NO_HIPSPARSE_ERRORS(hipsparseDestroyCsrgemm2Info(info));
+}
+#endif
 
 
 }  // namespace hipsparse

--- a/hip/matrix/csr_kernels.hip.cpp
+++ b/hip/matrix/csr_kernels.hip.cpp
@@ -527,10 +527,119 @@ void advanced_spgemm(std::shared_ptr<const HipExecutor> exec,
                      const matrix::Csr<ValueType, IndexType> *a,
                      const matrix::Csr<ValueType, IndexType> *b,
                      const matrix::Dense<ValueType> *beta,
-                     const matrix::Csr<ValueType, IndexType> *c,
+                     const matrix::Csr<ValueType, IndexType> *d,
                      Array<IndexType> &c_row_ptrs_array,
                      Array<IndexType> &c_col_idxs_array,
-                     Array<ValueType> &c_vals_array) GKO_NOT_IMPLEMENTED;
+                     Array<ValueType> &c_vals_array)
+{
+    if (hipsparse::is_supported<ValueType, IndexType>::value) {
+        auto handle = exec->get_hipsparse_handle();
+        hipsparse::pointer_mode_guard pm_guard(handle);
+        auto a_descr = hipsparse::create_mat_descr();
+        auto b_descr = hipsparse::create_mat_descr();
+        auto c_descr = hipsparse::create_mat_descr();
+        auto d_descr = hipsparse::create_mat_descr();
+        auto info = hipsparse::create_spgemm_info();
+
+        ValueType valpha{};
+        exec->get_master()->copy_from(exec.get(), 1, alpha->get_const_values(),
+                                      &valpha);
+        auto a_nnz = IndexType(a->get_num_stored_elements());
+        auto a_vals = a->get_const_values();
+        auto a_row_ptrs = a->get_const_row_ptrs();
+        auto a_col_idxs = a->get_const_col_idxs();
+        auto b_nnz = IndexType(b->get_num_stored_elements());
+        auto b_vals = b->get_const_values();
+        auto b_row_ptrs = b->get_const_row_ptrs();
+        auto b_col_idxs = b->get_const_col_idxs();
+        auto d_vals = d->get_const_values();
+        auto d_row_ptrs = d->get_const_row_ptrs();
+        auto d_col_idxs = d->get_const_col_idxs();
+        auto null_value = static_cast<ValueType *>(nullptr);
+        auto null_index = static_cast<IndexType *>(nullptr);
+        auto m = IndexType(a->get_size()[0]);
+        auto n = IndexType(b->get_size()[1]);
+        auto k = IndexType(a->get_size()[1]);
+
+        // allocate buffer
+        size_type buffer_size{};
+        hipsparse::spgemm_buffer_size(
+            handle, m, n, k, &valpha, a_descr, a_nnz, a_row_ptrs, a_col_idxs,
+            b_descr, b_nnz, b_row_ptrs, b_col_idxs, null_value, d_descr,
+            IndexType(0), null_index, null_index, info, buffer_size);
+        Array<char> buffer_array(exec, buffer_size);
+        auto buffer = buffer_array.get_data();
+
+        // count nnz
+        Array<IndexType> c_tmp_row_ptrs_array(exec, m + 1);
+        auto c_tmp_row_ptrs = c_tmp_row_ptrs_array.get_data();
+        IndexType c_nnz{};
+        hipsparse::spgemm_nnz(
+            handle, m, n, k, a_descr, a_nnz, a_row_ptrs, a_col_idxs, b_descr,
+            b_nnz, b_row_ptrs, b_col_idxs, d_descr, IndexType(0), null_index,
+            null_index, c_descr, c_tmp_row_ptrs, &c_nnz, info, buffer);
+
+        // accumulate non-zeros for alpha * A * B
+        Array<IndexType> c_tmp_col_idxs_array(exec, c_nnz);
+        Array<ValueType> c_tmp_vals_array(exec, c_nnz);
+        auto c_tmp_col_idxs = c_tmp_col_idxs_array.get_data();
+        auto c_tmp_vals = c_tmp_vals_array.get_data();
+        hipsparse::spgemm(handle, m, n, k, &valpha, a_descr, a_nnz, a_vals,
+                          a_row_ptrs, a_col_idxs, b_descr, b_nnz, b_vals,
+                          b_row_ptrs, b_col_idxs, null_value, d_descr,
+                          IndexType(0), null_value, null_index, null_index,
+                          c_descr, c_tmp_vals, c_tmp_row_ptrs, c_tmp_col_idxs,
+                          info, buffer);
+
+        // destroy hipsparse context
+        hipsparse::destroy(info);
+        hipsparse::destroy(d_descr);
+        hipsparse::destroy(c_descr);
+        hipsparse::destroy(b_descr);
+        hipsparse::destroy(a_descr);
+
+        // count nnz for alpha * A * B + beta * D
+        c_row_ptrs_array.resize_and_reset(m + 1);
+        auto c_row_ptrs = c_row_ptrs_array.get_data();
+        auto num_blocks = ceildiv(m, default_block_size);
+        hipLaunchKernelGGL(HIP_KERNEL_NAME(kernel::spgeam_nnz),
+                           dim3(num_blocks), dim3(default_block_size), 0, 0,
+                           c_tmp_row_ptrs, c_tmp_col_idxs, d_row_ptrs,
+                           d_col_idxs, m, c_row_ptrs);
+
+        // build row pointers
+        auto num_row_ptrs = m + 1;
+        auto num_blocks_prefixsum = ceildiv(num_row_ptrs, default_block_size);
+        Array<IndexType> block_sums_array(exec, num_blocks_prefixsum);
+        auto block_sums = block_sums_array.get_data();
+        hipLaunchKernelGGL(
+            HIP_KERNEL_NAME(start_prefix_sum<default_block_size>),
+            dim3(num_blocks_prefixsum), dim3(default_block_size), 0, 0,
+            num_row_ptrs, c_row_ptrs, block_sums);
+        hipLaunchKernelGGL(
+            HIP_KERNEL_NAME(finalize_prefix_sum<default_block_size>),
+            dim3(num_blocks_prefixsum), dim3(default_block_size), 0, 0,
+            num_row_ptrs, c_row_ptrs, block_sums);
+
+        // accumulate non-zeros for alpha * A * B + beta * D
+        ValueType vbeta{};
+        exec->get_master()->copy_from(exec.get(), 1, beta->get_const_values(),
+                                      &vbeta);
+        exec->get_master()->copy_from(exec.get(), 1, c_row_ptrs + m, &c_nnz);
+        c_col_idxs_array.resize_and_reset(c_nnz);
+        c_vals_array.resize_and_reset(c_nnz);
+        auto c_col_idxs = c_col_idxs_array.get_data();
+        auto c_vals = c_vals_array.get_data();
+        hipLaunchKernelGGL(
+            HIP_KERNEL_NAME(kernel::spgeam), dim3(num_blocks),
+            dim3(default_block_size), 0, 0, as_hip_type(one<ValueType>()),
+            c_tmp_row_ptrs, c_tmp_col_idxs, as_hip_type(c_tmp_vals),
+            as_hip_type(vbeta), d_row_ptrs, d_col_idxs, as_hip_type(d_vals), m,
+            c_row_ptrs, c_col_idxs, as_hip_type(c_vals));
+    } else {
+        GKO_NOT_IMPLEMENTED;
+    }
+}
 
 GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
     GKO_DECLARE_CSR_ADVANCED_SPGEMM_KERNEL);

--- a/hip/matrix/csr_kernels.hip.cpp
+++ b/hip/matrix/csr_kernels.hip.cpp
@@ -452,8 +452,71 @@ template <typename ValueType, typename IndexType>
 void spgemm(std::shared_ptr<const HipExecutor> exec,
             const matrix::Csr<ValueType, IndexType> *a,
             const matrix::Csr<ValueType, IndexType> *b,
-            Array<IndexType> &c_row_ptrs, Array<IndexType> &c_col_idxs,
-            Array<ValueType> &c_vals) GKO_NOT_IMPLEMENTED;
+            Array<IndexType> &c_row_ptrs_array,
+            Array<IndexType> &c_col_idxs_array, Array<ValueType> &c_vals_array)
+{
+    if (hipsparse::is_supported<ValueType, IndexType>::value) {
+        auto handle = exec->get_hipsparse_handle();
+        hipsparse::pointer_mode_guard pm_guard(handle);
+        auto a_descr = hipsparse::create_mat_descr();
+        auto b_descr = hipsparse::create_mat_descr();
+        auto c_descr = hipsparse::create_mat_descr();
+        auto d_descr = hipsparse::create_mat_descr();
+        auto info = hipsparse::create_spgemm_info();
+
+        auto alpha = one<ValueType>();
+        auto a_nnz = IndexType(a->get_num_stored_elements());
+        auto a_vals = a->get_const_values();
+        auto a_row_ptrs = a->get_const_row_ptrs();
+        auto a_col_idxs = a->get_const_col_idxs();
+        auto b_nnz = IndexType(b->get_num_stored_elements());
+        auto b_vals = b->get_const_values();
+        auto b_row_ptrs = b->get_const_row_ptrs();
+        auto b_col_idxs = b->get_const_col_idxs();
+        auto null_value = static_cast<ValueType *>(nullptr);
+        auto null_index = static_cast<IndexType *>(nullptr);
+        auto m = IndexType(a->get_size()[0]);
+        auto n = IndexType(b->get_size()[1]);
+        auto k = IndexType(a->get_size()[1]);
+
+        // allocate buffer
+        size_type buffer_size{};
+        hipsparse::spgemm_buffer_size(
+            handle, m, n, k, &alpha, a_descr, a_nnz, a_row_ptrs, a_col_idxs,
+            b_descr, b_nnz, b_row_ptrs, b_col_idxs, null_value, d_descr,
+            IndexType(0), null_index, null_index, info, buffer_size);
+        Array<char> buffer_array(exec, buffer_size);
+        auto buffer = buffer_array.get_data();
+
+        // count nnz
+        c_row_ptrs_array.resize_and_reset(m + 1);
+        auto c_row_ptrs = c_row_ptrs_array.get_data();
+        IndexType c_nnz{};
+        hipsparse::spgemm_nnz(
+            handle, m, n, k, a_descr, a_nnz, a_row_ptrs, a_col_idxs, b_descr,
+            b_nnz, b_row_ptrs, b_col_idxs, d_descr, IndexType(0), null_index,
+            null_index, c_descr, c_row_ptrs, &c_nnz, info, buffer);
+
+        // accumulate non-zeros
+        c_col_idxs_array.resize_and_reset(c_nnz);
+        c_vals_array.resize_and_reset(c_nnz);
+        auto c_col_idxs = c_col_idxs_array.get_data();
+        auto c_vals = c_vals_array.get_data();
+        hipsparse::spgemm(
+            handle, m, n, k, &alpha, a_descr, a_nnz, a_vals, a_row_ptrs,
+            a_col_idxs, b_descr, b_nnz, b_vals, b_row_ptrs, b_col_idxs,
+            null_value, d_descr, IndexType(0), null_value, null_index,
+            null_index, c_descr, c_vals, c_row_ptrs, c_col_idxs, info, buffer);
+
+        hipsparse::destroy(info);
+        hipsparse::destroy(d_descr);
+        hipsparse::destroy(c_descr);
+        hipsparse::destroy(b_descr);
+        hipsparse::destroy(a_descr);
+    } else {
+        GKO_NOT_IMPLEMENTED;
+    }
+}
 
 GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(GKO_DECLARE_CSR_SPGEMM_KERNEL);
 
@@ -465,8 +528,9 @@ void advanced_spgemm(std::shared_ptr<const HipExecutor> exec,
                      const matrix::Csr<ValueType, IndexType> *b,
                      const matrix::Dense<ValueType> *beta,
                      const matrix::Csr<ValueType, IndexType> *c,
-                     Array<IndexType> &c_row_ptrs, Array<IndexType> &c_col_idxs,
-                     Array<ValueType> &c_vals) GKO_NOT_IMPLEMENTED;
+                     Array<IndexType> &c_row_ptrs_array,
+                     Array<IndexType> &c_col_idxs_array,
+                     Array<ValueType> &c_vals_array) GKO_NOT_IMPLEMENTED;
 
 GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
     GKO_DECLARE_CSR_ADVANCED_SPGEMM_KERNEL);

--- a/hip/matrix/csr_kernels.hip.cpp
+++ b/hip/matrix/csr_kernels.hip.cpp
@@ -508,7 +508,7 @@ void spgemm(std::shared_ptr<const HipExecutor> exec,
             null_value, d_descr, IndexType(0), null_value, null_index,
             null_index, c_descr, c_vals, c_row_ptrs, c_col_idxs, info, buffer);
 
-        hipsparse::destroy(info);
+        hipsparse::destroy_spgemm_info(info);
         hipsparse::destroy(d_descr);
         hipsparse::destroy(c_descr);
         hipsparse::destroy(b_descr);
@@ -592,7 +592,7 @@ void advanced_spgemm(std::shared_ptr<const HipExecutor> exec,
                           info, buffer);
 
         // destroy hipsparse context
-        hipsparse::destroy(info);
+        hipsparse::destroy_spgemm_info(info);
         hipsparse::destroy(d_descr);
         hipsparse::destroy(c_descr);
         hipsparse::destroy(b_descr);

--- a/hip/test/matrix/csr_kernels.hip.cpp
+++ b/hip/test/matrix/csr_kernels.hip.cpp
@@ -308,6 +308,19 @@ TEST_F(Csr, AdvancedApplyToDenseMatrixIsEquivalentToRefWithMergePath)
 }
 
 
+TEST_F(Csr, AdvancedApplyToCsrMatrixIsEquivalentToRef)
+{
+    set_up_apply_data(std::make_shared<Mtx::automatical>());
+    auto trans = mtx->transpose();
+    auto d_trans = dmtx->transpose();
+
+    mtx->apply(alpha.get(), trans.get(), beta.get(), square_mtx.get());
+    dmtx->apply(dalpha.get(), d_trans.get(), dbeta.get(), square_dmtx.get());
+
+    GKO_ASSERT_MTX_NEAR(square_dmtx, square_mtx, 1e-14);
+}
+
+
 TEST_F(Csr, SimpleApplyToCsrMatrixIsEquivalentToRef)
 {
     set_up_apply_data(std::make_shared<Mtx::automatical>());

--- a/hip/test/matrix/csr_kernels.hip.cpp
+++ b/hip/test/matrix/csr_kernels.hip.cpp
@@ -310,7 +310,7 @@ TEST_F(Csr, AdvancedApplyToDenseMatrixIsEquivalentToRefWithMergePath)
 
 TEST_F(Csr, AdvancedApplyToCsrMatrixIsEquivalentToRef)
 {
-    set_up_apply_data(std::make_shared<Mtx::automatical>());
+    set_up_apply_data(std::make_shared<Mtx::automatical>(hip));
     auto trans = mtx->transpose();
     auto d_trans = dmtx->transpose();
 
@@ -323,7 +323,7 @@ TEST_F(Csr, AdvancedApplyToCsrMatrixIsEquivalentToRef)
 
 TEST_F(Csr, SimpleApplyToCsrMatrixIsEquivalentToRef)
 {
-    set_up_apply_data(std::make_shared<Mtx::automatical>());
+    set_up_apply_data(std::make_shared<Mtx::automatical>(hip));
     auto trans = mtx->transpose();
     auto d_trans = dmtx->transpose();
 

--- a/hip/test/matrix/csr_kernels.hip.cpp
+++ b/hip/test/matrix/csr_kernels.hip.cpp
@@ -61,7 +61,7 @@ protected:
     using Mtx = gko::matrix::Csr<>;
     using Vec = gko::matrix::Dense<>;
 
-    Csr() : rand_engine(42) {}
+    Csr() : mtx_size(532, 231), rand_engine(42) {}
 
     void SetUp()
     {
@@ -91,13 +91,17 @@ protected:
                            int num_vectors = 1)
     {
         mtx = Mtx::create(ref, strategy);
-        mtx->copy_from(gen_mtx<Vec>(532, 231, 1));
-        expected = gen_mtx<Vec>(532, num_vectors, 1);
-        y = gen_mtx<Vec>(231, num_vectors, 1);
+        mtx->copy_from(gen_mtx<Vec>(mtx_size[0], mtx_size[1], 1));
+        square_mtx = Mtx::create(ref, strategy);
+        square_mtx->copy_from(gen_mtx<Vec>(mtx_size[0], mtx_size[0], 1));
+        expected = gen_mtx<Vec>(mtx_size[0], num_vectors, 1);
+        y = gen_mtx<Vec>(mtx_size[1], num_vectors, 1);
         alpha = gko::initialize<Vec>({2.0}, ref);
         beta = gko::initialize<Vec>({-1.0}, ref);
         dmtx = Mtx::create(hip, strategy);
         dmtx->copy_from(mtx.get());
+        square_dmtx = Mtx::create(hip, strategy);
+        square_dmtx->copy_from(square_mtx.get());
         dresult = Vec::create(hip);
         dresult->copy_from(expected.get());
         dy = Vec::create(hip);
@@ -111,15 +115,18 @@ protected:
     std::shared_ptr<gko::ReferenceExecutor> ref;
     std::shared_ptr<const gko::HipExecutor> hip;
 
+    const gko::dim<2> mtx_size;
     std::ranlux48 rand_engine;
 
     std::unique_ptr<Mtx> mtx;
+    std::unique_ptr<Mtx> square_mtx;
     std::unique_ptr<Vec> expected;
     std::unique_ptr<Vec> y;
     std::unique_ptr<Vec> alpha;
     std::unique_ptr<Vec> beta;
 
     std::unique_ptr<Mtx> dmtx;
+    std::unique_ptr<Mtx> square_dmtx;
     std::unique_ptr<Vec> dresult;
     std::unique_ptr<Vec> dy;
     std::unique_ptr<Vec> dalpha;
@@ -298,6 +305,19 @@ TEST_F(Csr, AdvancedApplyToDenseMatrixIsEquivalentToRefWithMergePath)
     dmtx->apply(dalpha.get(), dy.get(), dbeta.get(), dresult.get());
 
     GKO_ASSERT_MTX_NEAR(dresult, expected, 1e-14);
+}
+
+
+TEST_F(Csr, SimpleApplyToCsrMatrixIsEquivalentToRef)
+{
+    set_up_apply_data(std::make_shared<Mtx::automatical>());
+    auto trans = mtx->transpose();
+    auto d_trans = dmtx->transpose();
+
+    mtx->apply(trans.get(), square_mtx.get());
+    dmtx->apply(d_trans.get(), square_dmtx.get());
+
+    GKO_ASSERT_MTX_NEAR(square_dmtx, square_mtx, 1e-14);
 }
 
 

--- a/include/ginkgo/core/base/types.hpp
+++ b/include/ginkgo/core/base/types.hpp
@@ -39,6 +39,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <complex>
 #include <cstddef>
 #include <cstdint>
+#include <limits>
 #include <type_traits>
 
 

--- a/omp/matrix/csr_kernels.cpp
+++ b/omp/matrix/csr_kernels.cpp
@@ -260,7 +260,7 @@ void advanced_spgemm(std::shared_ptr<const OmpExecutor> exec,
                      const matrix::Csr<ValueType, IndexType> *a,
                      const matrix::Csr<ValueType, IndexType> *b,
                      const matrix::Dense<ValueType> *beta,
-                     const matrix::Csr<ValueType, IndexType> *c,
+                     const matrix::Csr<ValueType, IndexType> *d,
                      Array<IndexType> &c_row_ptrs_array,
                      Array<IndexType> &c_col_idxs_array,
                      Array<ValueType> &c_vals_array)
@@ -278,7 +278,7 @@ void advanced_spgemm(std::shared_ptr<const OmpExecutor> exec,
     for (size_type a_row = 0; a_row < num_rows; ++a_row) {
         local_col_idxs.clear();
         if (vbeta != zero(vbeta)) {
-            spgemm_insert_row(local_col_idxs, c, a_row);
+            spgemm_insert_row(local_col_idxs, d, a_row);
         }
         if (valpha != zero(valpha)) {
             spgemm_insert_row2(local_col_idxs, a, b, a_row);
@@ -302,7 +302,7 @@ void advanced_spgemm(std::shared_ptr<const OmpExecutor> exec,
     for (size_type a_row = 0; a_row < num_rows; ++a_row) {
         local_row_nzs.clear();
         if (vbeta != zero(vbeta)) {
-            spgemm_accumulate_row(local_row_nzs, c, vbeta, a_row);
+            spgemm_accumulate_row(local_row_nzs, d, vbeta, a_row);
         }
         if (valpha != zero(valpha)) {
             spgemm_accumulate_row2(local_row_nzs, a, b, valpha, a_row);

--- a/reference/matrix/csr_kernels.cpp
+++ b/reference/matrix/csr_kernels.cpp
@@ -257,7 +257,7 @@ void advanced_spgemm(std::shared_ptr<const ReferenceExecutor> exec,
                      const matrix::Csr<ValueType, IndexType> *a,
                      const matrix::Csr<ValueType, IndexType> *b,
                      const matrix::Dense<ValueType> *beta,
-                     const matrix::Csr<ValueType, IndexType> *c,
+                     const matrix::Csr<ValueType, IndexType> *d,
                      Array<IndexType> &c_row_ptrs_array,
                      Array<IndexType> &c_col_idxs_array,
                      Array<ValueType> &c_vals_array)
@@ -274,7 +274,7 @@ void advanced_spgemm(std::shared_ptr<const ReferenceExecutor> exec,
     for (size_type a_row = 0; a_row < num_rows; ++a_row) {
         local_col_idxs.clear();
         if (vbeta != zero(vbeta)) {
-            spgemm_insert_row(local_col_idxs, c, a_row);
+            spgemm_insert_row(local_col_idxs, d, a_row);
         }
         if (valpha != zero(valpha)) {
             spgemm_insert_row2(local_col_idxs, a, b, a_row);
@@ -297,7 +297,7 @@ void advanced_spgemm(std::shared_ptr<const ReferenceExecutor> exec,
     for (size_type a_row = 0; a_row < num_rows; ++a_row) {
         local_row_nzs.clear();
         if (vbeta != zero(vbeta)) {
-            spgemm_accumulate_row(local_row_nzs, c, vbeta, a_row);
+            spgemm_accumulate_row(local_row_nzs, d, vbeta, a_row);
         }
         if (valpha != zero(valpha)) {
             spgemm_accumulate_row2(local_row_nzs, a, b, valpha, a_row);


### PR DESCRIPTION
This PR adds HIP bindings for simple SpGeMM (`C = alpha * A * B`).
The full SpGeMM (`C = alpha * A * B + beta * D`) is not yet implemented in rocSPARSE, so I re-implemented it using a very naive SpGeAM kernel. Note that it assumes that the input matrices are sorted!