### PR TITLE
Ensure non-zero diagonal when generating triangular matrices

### DIFF
--- a/common/factorization/par_ilu_kernels.hpp.inc
+++ b/common/factorization/par_ilu_kernels.hpp.inc
@@ -44,13 +44,16 @@ __global__ __launch_bounds__(default_block_size) void count_nnz_per_l_u_row(
     if (row < num_rows) {
         IndexType l_row_nnz{};
         IndexType u_row_nnz{};
+        bool has_diagonal{};
         for (auto idx = row_ptrs[row]; idx < row_ptrs[row + 1]; ++idx) {
             auto col = col_idxs[idx];
             l_row_nnz += (col <= row);
             u_row_nnz += (row <= col);
+            has_diagonal |= col == row;
         }
-        l_nnz_row[row] = l_row_nnz;
-        u_nnz_row[row] = u_row_nnz;
+        // if we didn't find it, add the diagonal entry
+        l_nnz_row[row] = l_row_nnz + !has_diagonal;
+        u_nnz_row[row] = u_row_nnz + !has_diagonal;
     }
 }
 
@@ -68,21 +71,39 @@ __global__ __launch_bounds__(default_block_size) void initialize_l_u(
     const auto row = blockDim.x * blockIdx.x + threadIdx.x;
     if (row < num_rows) {
         auto l_idx = l_row_ptrs[row];
-        auto u_idx = u_row_ptrs[row];
+        auto u_idx = u_row_ptrs[row] + 1;  // we treat the diagonal separately
+        bool has_diagonal{};
+        ValueType diag_val{};
         for (size_type i = row_ptrs[row]; i < row_ptrs[row + 1]; ++i) {
             const auto col = col_idxs[i];
             const auto val = values[i];
-            if (col <= row) {
+            // save diagonal entry for later
+            if (col == row) {
+                has_diagonal = true;
+                diag_val = val;
+            }
+            if (col < row) {
                 l_col_idxs[l_idx] = col;
-                l_values[l_idx] = (col == row ? one<ValueType>() : val);
+                l_values[l_idx] = val;
                 ++l_idx;
             }
-            if (row <= col) {
+            if (row < col) {
                 u_col_idxs[u_idx] = col;
                 u_values[u_idx] = val;
                 ++u_idx;
             }
         }
+        // if there was no diagonal entry, set it to one
+        if (!has_diagonal) {
+            diag_val = one<ValueType>();
+        }
+        // store diagonal entries
+        auto l_diag_idx = l_row_ptrs[row + 1] - 1;
+        auto u_diag_idx = u_row_ptrs[row];
+        l_col_idxs[l_diag_idx] = row;
+        u_col_idxs[u_diag_idx] = row;
+        l_values[l_diag_idx] = one<ValueType>();
+        u_values[u_diag_idx] = diag_val;
     }
 }
 

--- a/core/test/utils/matrix_generator.hpp
+++ b/core/test/utils/matrix_generator.hpp
@@ -186,7 +186,7 @@ std::unique_ptr<MatrixType> generate_random_sparsity_matrix(
 
 
 /**
- * Generates a random lower triangular matrix.
+ * Generates a random triangular matrix.
  *
  * @tparam MatrixType  type of matrix to generate (matrix::Dense must implement
  *                     the interface `ConvertibleTo<MatrixType>`)
@@ -197,6 +197,10 @@ std::unique_ptr<MatrixType> generate_random_sparsity_matrix(
  *
  * @param num_rows  number of rows
  * @param num_cols  number of columns
+ * @param ones_on_diagonal  `true` generates only ones on the diagonal,
+ *                          `false` generates random values on the diagonal
+ * @param lower_triangular  `true` generates a lower triangular matrix,
+ *                          `false` an upper triangular matrix
  * @param nonzero_dist  distribution of nonzeros per row
  * @param value_dist  distribution of matrix values
  * @param engine  a random engine
@@ -205,11 +209,11 @@ std::unique_ptr<MatrixType> generate_random_sparsity_matrix(
  */
 template <typename MatrixType = matrix::Dense<>, typename NonzeroDistribution,
           typename ValueDistribution, typename Engine, typename... MatrixArgs>
-std::unique_ptr<MatrixType> generate_random_lower_triangular_matrix(
+std::unique_ptr<MatrixType> generate_random_triangular_matrix(
     size_type num_rows, size_type num_cols, bool ones_on_diagonal,
-    NonzeroDistribution &&nonzero_dist, ValueDistribution &&value_dist,
-    Engine &&engine, std::shared_ptr<const Executor> exec,
-    MatrixArgs &&... args)
+    bool lower_triangular, NonzeroDistribution &&nonzero_dist,
+    ValueDistribution &&value_dist, Engine &&engine,
+    std::shared_ptr<const Executor> exec, MatrixArgs &&... args)
 {
     using value_type = typename MatrixType::value_type;
     using index_type = typename MatrixType::index_type;
@@ -229,19 +233,34 @@ std::unique_ptr<MatrixType> generate_random_lower_triangular_matrix(
         // select a subset of `nnz_in_row` column indexes, and fill these
         // locations with random values
         std::shuffle(begin(col_idx), end(col_idx), engine);
-        std::for_each(begin(col_idx), begin(col_idx) + nnz_in_row,
-                      [&](size_type col) {
-                          if (col <= row) {
-                              if (ones_on_diagonal && col == row) {
-                                  data.nonzeros.emplace_back(row, col, one);
-                              } else {
-                                  data.nonzeros.emplace_back(
-                                      row, col,
-                                      detail::get_rand_value<value_type>(
-                                          value_dist, engine));
-                              }
-                          }
-                      });
+        // add non-zeros
+        bool has_diagonal{};
+        for (size_type nz = 0; nz < nnz_in_row; ++nz) {
+            auto col = col_idx[nz];
+            // skip non-zeros outside triangle
+            if (col > row && lower_triangular ||
+                col < row && !lower_triangular) {
+                continue;
+            }
+
+            // generate and store non-zero
+            auto val = detail::get_rand_value<value_type>(value_dist, engine);
+            if (col == row) {
+                has_diagonal = true;
+                if (ones_on_diagonal) {
+                    val = one;
+                }
+            }
+            data.nonzeros.emplace_back(row, col, val);
+        }
+
+        // add diagonal if it hasn't been added yet
+        if (!has_diagonal) {
+            auto val = ones_on_diagonal ? one
+                                        : detail::get_rand_value<value_type>(
+                                              value_dist, engine);
+            data.nonzeros.emplace_back(row, row, one);
+        }
     }
 
     data.ensure_row_major_order();
@@ -250,6 +269,40 @@ std::unique_ptr<MatrixType> generate_random_lower_triangular_matrix(
     auto result = MatrixType::create(exec, std::forward<MatrixArgs>(args)...);
     result->read(data);
     return result;
+}
+
+
+/**
+ * Generates a random lower triangular matrix.
+ *
+ * @tparam MatrixType  type of matrix to generate (matrix::Dense must implement
+ *                     the interface `ConvertibleTo<MatrixType>`)
+ * @tparam NonzeroDistribution  type of nonzero distribution
+ * @tparam ValueDistribution  type of value distribution
+ * @tparam Engine  type of random engine
+ * @tparam MatrixArgs  the arguments from the matrix to be forwarded.
+ *
+ * @param num_rows  number of rows
+ * @param num_cols  number of columns
+ * @param ones_on_diagonal  `true` generates only ones on the diagonal,
+ *                          `false` generates random values on the diagonal
+ * @param nonzero_dist  distribution of nonzeros per row
+ * @param value_dist  distribution of matrix values
+ * @param engine  a random engine
+ * @param exec  executor where the matrix should be allocated
+ * @param args  additional arguments for the matrix constructor
+ */
+template <typename MatrixType = matrix::Dense<>, typename NonzeroDistribution,
+          typename ValueDistribution, typename Engine, typename... MatrixArgs>
+std::unique_ptr<MatrixType> generate_random_lower_triangular_matrix(
+    size_type num_rows, size_type num_cols, bool ones_on_diagonal,
+    NonzeroDistribution &&nonzero_dist, ValueDistribution &&value_dist,
+    Engine &&engine, std::shared_ptr<const Executor> exec,
+    MatrixArgs &&... args)
+{
+    return generate_random_triangular_matrix(
+        num_rows, num_cols, ones_on_diagonal, true, nonzero_dist, value_dist,
+        engine, std::move(exec), std::forward<MatrixArgs>(args)...);
 }
 
 
@@ -265,6 +318,8 @@ std::unique_ptr<MatrixType> generate_random_lower_triangular_matrix(
  *
  * @param num_rows  number of rows
  * @param num_cols  number of columns
+ * @param ones_on_diagonal  `true` generates only ones on the diagonal,
+ *                          `false` generates random values on the diagonal
  * @param nonzero_dist  distribution of nonzeros per row
  * @param value_dist  distribution of matrix values
  * @param engine  a random engine
@@ -279,45 +334,9 @@ std::unique_ptr<MatrixType> generate_random_upper_triangular_matrix(
     Engine &&engine, std::shared_ptr<const Executor> exec,
     MatrixArgs &&... args)
 {
-    using value_type = typename MatrixType::value_type;
-    using index_type = typename MatrixType::index_type;
-    using std::begin;
-    using std::end;
-
-    matrix_data<value_type, index_type> data{gko::dim<2>{num_rows, num_cols},
-                                             {}};
-    value_type one = 1.0;
-    std::vector<size_type> col_idx(num_cols);
-    std::iota(begin(col_idx), end(col_idx), size_type(0));
-
-    for (size_type row = 0; row < num_rows; ++row) {
-        // randomly generate number of nonzeros in this row
-        auto nnz_in_row = static_cast<size_type>(nonzero_dist(engine));
-        nnz_in_row = std::max(size_type(0), std::min(nnz_in_row, num_cols));
-        // select a subset of `nnz_in_row` column indexes, and fill these
-        // locations with random values
-        std::shuffle(begin(col_idx), end(col_idx), engine);
-        std::for_each(begin(col_idx), begin(col_idx) + nnz_in_row,
-                      [&](size_type col) {
-                          if (col >= row) {
-                              if (ones_on_diagonal && col == row) {
-                                  data.nonzeros.emplace_back(row, col, one);
-                              } else {
-                                  data.nonzeros.emplace_back(
-                                      row, col,
-                                      detail::get_rand_value<value_type>(
-                                          value_dist, engine));
-                              }
-                          }
-                      });
-    }
-
-    data.ensure_row_major_order();
-
-    // convert to the correct matrix type
-    auto result = MatrixType::create(exec, std::forward<MatrixArgs>(args)...);
-    result->read(data);
-    return result;
+    return generate_random_triangular_matrix(
+        num_rows, num_cols, ones_on_diagonal, false, nonzero_dist, value_dist,
+        engine, std::move(exec), std::forward<MatrixArgs>(args)...);
 }
 
 

--- a/core/test/utils/matrix_generator.hpp
+++ b/core/test/utils/matrix_generator.hpp
@@ -300,7 +300,7 @@ std::unique_ptr<MatrixType> generate_random_lower_triangular_matrix(
     Engine &&engine, std::shared_ptr<const Executor> exec,
     MatrixArgs &&... args)
 {
-    return generate_random_triangular_matrix(
+    return generate_random_triangular_matrix<MatrixType>(
         num_rows, num_cols, ones_on_diagonal, true, nonzero_dist, value_dist,
         engine, std::move(exec), std::forward<MatrixArgs>(args)...);
 }
@@ -334,7 +334,7 @@ std::unique_ptr<MatrixType> generate_random_upper_triangular_matrix(
     Engine &&engine, std::shared_ptr<const Executor> exec,
     MatrixArgs &&... args)
 {
-    return generate_random_triangular_matrix(
+    return generate_random_triangular_matrix<MatrixType>(
         num_rows, num_cols, ones_on_diagonal, false, nonzero_dist, value_dist,
         engine, std::move(exec), std::forward<MatrixArgs>(args)...);
 }

--- a/core/test/utils/matrix_generator.hpp
+++ b/core/test/utils/matrix_generator.hpp
@@ -259,7 +259,7 @@ std::unique_ptr<MatrixType> generate_random_triangular_matrix(
             auto val = ones_on_diagonal ? one
                                         : detail::get_rand_value<value_type>(
                                               value_dist, engine);
-            data.nonzeros.emplace_back(row, row, one);
+            data.nonzeros.emplace_back(row, row, val);
         }
     }
 

--- a/reference/test/factorization/par_ilu_kernels.cpp
+++ b/reference/test/factorization/par_ilu_kernels.cpp
@@ -128,6 +128,27 @@ protected:
                                                  {0., 0., 0., 0., 5., -15.},
                                                  {0., 0., 0., 0., 0., 6.}},
                                                 exec)),
+          mtx_big_nodiag(gko::initialize<Csr>({{1., 1., 1., 0., 1., 3.},
+                                               {1., 2., 2., 0., 2., 0.},
+                                               {0., 2., 0., 3., 3., 5.},
+                                               {1., 0., 3., 4., 4., 4.},
+                                               {1., 2., 0., 4., 1., 6.},
+                                               {0., 2., 3., 4., 5., 8.}},
+                                         exec)),
+          big_nodiag_l_expected(gko::initialize<Dense>({{1., 0., 0., 0., 0., 0.},
+                                                        {1., 1., 0., 0., 0., 0.},
+                                                        {0., 2., 1., 0., 0., 0.},
+                                                        {2., 0., 0., 1., 0., 0.},
+                                                        {1., 1., 0., 1., 1., 0.},
+                                                        {0., 2., 1., 0.25, -0.5, 1.}},
+                                                exec)),
+          big_nodiag_u_expected(gko::initialize<Dense>({{1., 1., 1., 0., 1., 3.},
+                                                        {0., 1., 1., 0., 1., 0.},
+                                                        {0., 0., 1., 3., 1., -2.},
+                                                        {0., 0., 0., 4., 2., 0.},
+                                                        {0., 0., 0., 0., -3., 3.},
+                                                        {0., 0., 0., 0., 0., 11.5}},
+                                                exec)),
           // clang-format on
           ilu_factory_skip(
               gko::factorization::ParIlu<>::build().with_skip_sorting(true).on(
@@ -153,6 +174,9 @@ protected:
     std::shared_ptr<const Dense> mtx_big;
     std::shared_ptr<const Dense> big_l_expected;
     std::shared_ptr<const Dense> big_u_expected;
+    std::shared_ptr<const Csr> mtx_big_nodiag;
+    std::shared_ptr<const Dense> big_nodiag_l_expected;
+    std::shared_ptr<const Dense> big_nodiag_u_expected;
     std::unique_ptr<gko::factorization::ParIlu<>::Factory> ilu_factory_skip;
     std::unique_ptr<gko::factorization::ParIlu<>::Factory> ilu_factory_sort;
 };
@@ -382,6 +406,17 @@ TEST_F(ParIlu, GenerateForCsrSmall)
 
     GKO_ASSERT_MTX_NEAR(l_factor, small_l_expected, 1e-14);
     GKO_ASSERT_MTX_NEAR(u_factor, small_u_expected, 1e-14);
+}
+
+
+TEST_F(ParIlu, GenerateForCsrBigWithDiagonalZeros)
+{
+    auto factors = ilu_factory_skip->generate(mtx_big_nodiag);
+    auto l_factor = factors->get_l_factor();
+    auto u_factor = factors->get_u_factor();
+
+    GKO_ASSERT_MTX_NEAR(l_factor, big_nodiag_l_expected, 1e-14);
+    GKO_ASSERT_MTX_NEAR(u_factor, big_nodiag_u_expected, 1e-14);
 }
 
 


### PR DESCRIPTION
The generator for random triangular matrices currently does not ensure that the triangular matrix has non-zero diagonal entries, which means the resulting matrices can be singular.
In the same fashion, the generation of the ParILU factors sparsity pattern relies on the input matrix containing all diagonal entries.
This PR fixes this behavior by explicitly adding the diagonal entries if not present.