### PR TITLE
improve portability of warp lane masks

### DIFF
--- a/common/components/intrinsics.hpp.inc
+++ b/common/components/intrinsics.hpp.inc
@@ -30,65 +30,37 @@ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ******************************<GINKGO LICENSE>*******************************/
 
-#ifndef GKO_HIP_BASE_CONFIG_HIP_HPP_
-#define GKO_HIP_BASE_CONFIG_HIP_HPP_
+/**
+ * @internal
+ * Returns the number of set bits in the given mask.
+ */
+__device__ int popcnt(uint32 mask) { return __popc(mask); }
+
+/** @copydoc popcnt */
+__device__ int popcnt(uint64 mask) { return __popcll(mask); }
 
 
-#include <hip/device_functions.h>
+/**
+ * @internal
+ * Returns the (1-based!) index of the first set bit in the given mask,
+ * starting from the least significant bit.
+ */
+__device__ int ffs(uint32 mask) { return __ffs(mask); }
+
+/** @copydoc ffs */
+__device__ int ffs(uint64 mask)
+{
+    // the cast is necessary, as the overloads defined by HIP are ambiguous
+    return __ffsll(static_cast<unsigned long long int>(mask));
+}
 
 
-#include <ginkgo/core/base/types.hpp>
+/**
+ * @internal
+ * Returns the number of zero bits before the first set bit in the given mask,
+ * starting from the most significant bit.
+ */
+__device__ int clz(uint32 mask) { return __clz(mask); }
 
-
-#include "hip/base/math.hip.hpp"
-
-
-namespace gko {
-namespace kernels {
-namespace hip {
-
-
-struct config {
-    /**
-     * The type containing a bitmask over all lanes of a warp.
-     */
-#if GINKGO_HIP_PLATFORM_HCC
-    using lane_mask_type = uint64;
-#else  // GINKGO_HIP_PLATFORM_NVCC
-    using lane_mask_type = uint32;
-#endif
-
-    /**
-     * The number of threads within a HIP warp. Here, we use the definition from
-     * `device_functions.h`.
-     */
-#if GINKGO_HIP_PLATFORM_HCC
-    static constexpr uint32 warp_size = warpSize;
-#else  // GINKGO_HIP_PLATFORM_NVCC
-    static constexpr uint32 warp_size = 32;
-#endif
-
-    /**
-     * The bitmask of the entire warp.
-     */
-    static constexpr auto full_lane_mask = ~zero<lane_mask_type>();
-
-    /**
-     * The maximal number of threads allowed in a HIP warp.
-     */
-    static constexpr uint32 max_block_size = 1024;
-
-    /**
-     * The minimal amount of warps that need to be scheduled for each block
-     * to maximize GPU occupancy.
-     */
-    static constexpr uint32 min_warps_per_block = 4;
-};
-
-
-}  // namespace hip
-}  // namespace kernels
-}  // namespace gko
-
-
-#endif  // GKO_HIP_BASE_CONFIG_HIP_HPP_
+/** @copydoc clz */
+__device__ int clz(uint64 mask) { return __clzll(mask); }

--- a/cuda/base/config.hpp
+++ b/cuda/base/config.hpp
@@ -37,12 +37,20 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <ginkgo/core/base/types.hpp>
 
 
+#include "cuda/base/math.hpp"
+
+
 namespace gko {
 namespace kernels {
 namespace cuda {
 
 
 struct config {
+    /**
+     * The type containing a bitmask over all lanes of a warp.
+     */
+    using lane_mask_type = uint32;
+
     /**
      * The number of threads within a CUDA warp.
      */
@@ -51,7 +59,7 @@ struct config {
     /**
      * The bitmask of the entire warp.
      */
-    static constexpr uint32 full_lane_mask = (1ll << warp_size) - 1;
+    static constexpr auto full_lane_mask = ~zero<lane_mask_type>();
 
     /**
      * The maximal number of threads allowed in a CUDA warp.

--- a/cuda/components/intrinsics.cuh
+++ b/cuda/components/intrinsics.cuh
@@ -30,65 +30,24 @@ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ******************************<GINKGO LICENSE>*******************************/
 
-#ifndef GKO_HIP_BASE_CONFIG_HIP_HPP_
-#define GKO_HIP_BASE_CONFIG_HIP_HPP_
-
-
-#include <hip/device_functions.h>
+#ifndef GKO_CUDA_COMPONENTS_INTRINSICS_HIP_HPP_
+#define GKO_CUDA_COMPONENTS_INTRINSICS_HIP_HPP_
 
 
 #include <ginkgo/core/base/types.hpp>
 
 
-#include "hip/base/math.hip.hpp"
-
-
 namespace gko {
 namespace kernels {
-namespace hip {
+namespace cuda {
 
 
-struct config {
-    /**
-     * The type containing a bitmask over all lanes of a warp.
-     */
-#if GINKGO_HIP_PLATFORM_HCC
-    using lane_mask_type = uint64;
-#else  // GINKGO_HIP_PLATFORM_NVCC
-    using lane_mask_type = uint32;
-#endif
-
-    /**
-     * The number of threads within a HIP warp. Here, we use the definition from
-     * `device_functions.h`.
-     */
-#if GINKGO_HIP_PLATFORM_HCC
-    static constexpr uint32 warp_size = warpSize;
-#else  // GINKGO_HIP_PLATFORM_NVCC
-    static constexpr uint32 warp_size = 32;
-#endif
-
-    /**
-     * The bitmask of the entire warp.
-     */
-    static constexpr auto full_lane_mask = ~zero<lane_mask_type>();
-
-    /**
-     * The maximal number of threads allowed in a HIP warp.
-     */
-    static constexpr uint32 max_block_size = 1024;
-
-    /**
-     * The minimal amount of warps that need to be scheduled for each block
-     * to maximize GPU occupancy.
-     */
-    static constexpr uint32 min_warps_per_block = 4;
-};
+#include "common/components/intrinsics.hpp.inc"
 
 
-}  // namespace hip
+}  // namespace cuda
 }  // namespace kernels
 }  // namespace gko
 
 
-#endif  // GKO_HIP_BASE_CONFIG_HIP_HPP_
+#endif  // GKO_CUDA_COMPONENTS_INTRINSICS_HIP_HPP_

--- a/hip/components/cooperative_groups.hip.hpp
+++ b/hip/components/cooperative_groups.hip.hpp
@@ -232,7 +232,8 @@ public:
         return __all(predicate);
     }
 
-    __device__ __forceinline__ uint64_t ballot(int predicate) const noexcept
+    __device__ __forceinline__ config::lane_mask_type ballot(
+        int predicate) const noexcept
     {
         static_assert(Size == kernels::hip::config::warp_size,
                       "Hip does not have subwarp ballot.");

--- a/hip/components/intrinsics.hip.hpp
+++ b/hip/components/intrinsics.hip.hpp
@@ -30,17 +30,11 @@ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ******************************<GINKGO LICENSE>*******************************/
 
-#ifndef GKO_HIP_BASE_CONFIG_HIP_HPP_
-#define GKO_HIP_BASE_CONFIG_HIP_HPP_
-
-
-#include <hip/device_functions.h>
+#ifndef GKO_HIP_COMPONENTS_INTRINSICS_HIP_HPP_
+#define GKO_HIP_COMPONENTS_INTRINSICS_HIP_HPP_
 
 
 #include <ginkgo/core/base/types.hpp>
-
-
-#include "hip/base/math.hip.hpp"
 
 
 namespace gko {
@@ -48,42 +42,7 @@ namespace kernels {
 namespace hip {
 
 
-struct config {
-    /**
-     * The type containing a bitmask over all lanes of a warp.
-     */
-#if GINKGO_HIP_PLATFORM_HCC
-    using lane_mask_type = uint64;
-#else  // GINKGO_HIP_PLATFORM_NVCC
-    using lane_mask_type = uint32;
-#endif
-
-    /**
-     * The number of threads within a HIP warp. Here, we use the definition from
-     * `device_functions.h`.
-     */
-#if GINKGO_HIP_PLATFORM_HCC
-    static constexpr uint32 warp_size = warpSize;
-#else  // GINKGO_HIP_PLATFORM_NVCC
-    static constexpr uint32 warp_size = 32;
-#endif
-
-    /**
-     * The bitmask of the entire warp.
-     */
-    static constexpr auto full_lane_mask = ~zero<lane_mask_type>();
-
-    /**
-     * The maximal number of threads allowed in a HIP warp.
-     */
-    static constexpr uint32 max_block_size = 1024;
-
-    /**
-     * The minimal amount of warps that need to be scheduled for each block
-     * to maximize GPU occupancy.
-     */
-    static constexpr uint32 min_warps_per_block = 4;
-};
+#include "common/components/intrinsics.hpp.inc"
 
 
 }  // namespace hip
@@ -91,4 +50,4 @@ struct config {
 }  // namespace gko
 
 
-#endif  // GKO_HIP_BASE_CONFIG_HIP_HPP_
+#endif  // GKO_HIP_COMPONENTS_INTRINSICS_HIP_HPP_


### PR DESCRIPTION
This PR adds a `lane_mask_type` type alias to the `config` struct for CUDA and HIP kernels.
It additionally provides overloads for the `popc`, `ffs` and `clz` intrinsics that are often used in conjunction with these lane masks, so they can be called portably for all architectures.
Warp lane masks are the result of the `ballot` vote functions and can be important for warp-aggregation (with or without atomics).