### PR TITLE
Add hipSPARSE csrsort

### DIFF
--- a/cuda/test/matrix/csr_kernels.cpp
+++ b/cuda/test/matrix/csr_kernels.cpp
@@ -131,7 +131,7 @@ protected:
 
     matrix_pair gen_unsorted_mtx()
     {
-        constexpr int min_nnz_per_row = 2;  // Must be larger/equal than 2
+        constexpr int min_nnz_per_row = 2;  // Must be at least 2
         auto local_mtx_ref =
             gen_mtx<Mtx>(mtx_size[0], mtx_size[1], min_nnz_per_row);
         for (size_t row = 0; row < mtx_size[0]; ++row) {

--- a/hip/matrix/csr_kernels.hip.cpp
+++ b/hip/matrix/csr_kernels.hip.cpp
@@ -1086,7 +1086,46 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 template <typename ValueType, typename IndexType>
 void sort_by_column_index(std::shared_ptr<const HipExecutor> exec,
                           matrix::Csr<ValueType, IndexType> *to_sort)
-    GKO_NOT_IMPLEMENTED;
+{
+    if (hipsparse::is_supported<ValueType, IndexType>::value) {
+        auto handle = exec->get_hipsparse_handle();
+        auto descr = hipsparse::create_mat_descr();
+        auto m = IndexType(to_sort->get_size()[0]);
+        auto n = IndexType(to_sort->get_size()[1]);
+        auto nnz = IndexType(to_sort->get_num_stored_elements());
+        auto row_ptrs = to_sort->get_const_row_ptrs();
+        auto col_idxs = to_sort->get_col_idxs();
+        auto vals = to_sort->get_values();
+
+        // copy values
+        Array<ValueType> tmp_vals_array(exec, nnz);
+        exec->copy_from(exec.get(), nnz, vals, tmp_vals_array.get_data());
+        auto tmp_vals = tmp_vals_array.get_const_data();
+
+        // init identity permutation
+        Array<IndexType> permutation_array(exec, nnz);
+        auto permutation = permutation_array.get_data();
+        hipsparse::create_identity_permutation(handle, nnz, permutation);
+
+        // allocate buffer
+        size_type buffer_size{};
+        hipsparse::csrsort_buffer_size(handle, m, n, nnz, row_ptrs, col_idxs,
+                                       buffer_size);
+        Array<char> buffer_array{exec, buffer_size};
+        auto buffer = buffer_array.get_data();
+
+        // sort column indices
+        hipsparse::csrsort(handle, m, n, nnz, descr, row_ptrs, col_idxs,
+                           permutation, buffer);
+
+        // sort values
+        hipsparse::gather(handle, nnz, tmp_vals, vals, permutation);
+
+        hipsparse::destroy(descr);
+    } else {
+        GKO_NOT_IMPLEMENTED;
+    }
+}
 
 GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
     GKO_DECLARE_CSR_SORT_BY_COLUMN_INDEX);

--- a/hip/test/matrix/csr_kernels.hip.cpp
+++ b/hip/test/matrix/csr_kernels.hip.cpp
@@ -138,10 +138,10 @@ protected:
                 std::swap(vals[idx1], vals[idx2]);
             }
         }
-        auto local_mtx_cuda = Mtx::create(hip);
-        local_mtx_cuda->copy_from(local_mtx_ref.get());
+        auto local_mtx_hip = Mtx::create(hip);
+        local_mtx_hip->copy_from(local_mtx_ref.get());
 
-        return {std::move(local_mtx_ref), std::move(local_mtx_cuda)};
+        return {std::move(local_mtx_ref), std::move(local_mtx_hip)};
     }
 
     std::shared_ptr<gko::ReferenceExecutor> ref;

--- a/hip/test/matrix/csr_kernels.hip.cpp
+++ b/hip/test/matrix/csr_kernels.hip.cpp
@@ -119,7 +119,7 @@ protected:
 
     matrix_pair gen_unsorted_mtx()
     {
-        constexpr int min_nnz_per_row = 2;  // Must be larger/equal than 2
+        constexpr int min_nnz_per_row = 2;  // Must be at least 2
         auto local_mtx_ref =
             gen_mtx<Mtx>(mtx_size[0], mtx_size[1], min_nnz_per_row);
         for (size_t row = 0; row < mtx_size[0]; ++row) {

--- a/omp/test/matrix/csr_kernels.cpp
+++ b/omp/test/matrix/csr_kernels.cpp
@@ -141,7 +141,7 @@ protected:
 
     matrix_pair gen_unsorted_mtx()
     {
-        constexpr int min_nnz_per_row = 2;  // Must be larger/equal than 2
+        constexpr int min_nnz_per_row = 2;  // Must be at least 2
         auto local_mtx_ref =
             gen_mtx<Mtx>(mtx_size[0], mtx_size[1], min_nnz_per_row);
         for (size_t row = 0; row < mtx_size[0]; ++row) {

--- a/omp/test/matrix/sparsity_csr_kernels.cpp
+++ b/omp/test/matrix/sparsity_csr_kernels.cpp
@@ -117,7 +117,7 @@ protected:
 
     matrix_pair gen_unsorted_mtx()
     {
-        constexpr int min_nnz_per_row = 2;  // Must be larger/equal than 2
+        constexpr int min_nnz_per_row = 2;  // Must be at least 2
         auto local_mtx_ref =
             gen_mtx<Mtx>(mtx_size[0], mtx_size[1], min_nnz_per_row);
         for (size_t row = 0; row < mtx_size[0]; ++row) {


### PR DESCRIPTION
This PR adds hipSPARSE bindings for the *csrsort functions and the corresponding HIP kernels and tests.