### PR TITLE
Use separate file for add_license.sh ignored files

### DIFF
--- a/dev_tools/scripts/add_license.ignore
+++ b/dev_tools/scripts/add_license.ignore
@@ -1,0 +1,3 @@
+build
+third_party
+external-lib-interfacing.cpp

--- a/dev_tools/scripts/add_license.sh
+++ b/dev_tools/scripts/add_license.sh
@@ -53,9 +53,9 @@ echo -e "/*${GINKGO_LICENSE_BEACON}\n$(cat ${LICENSE_FILE})\n${GINKGO_LICENSE_BE
 
 # Does not work if a found file (including the path) contains a newline
 find "${GINKGO_ROOT_DIR}" \
-    ! \( -name "build" -prune -o -name "third_party" -prune -o -name "external-lib-interfacing.cpp" -prune \) \
     \( -name '*.cuh' -o -name '*.hpp' -o -name '*.hpp.in' -o -name '*.cpp' -o -name '*.cu' -o -name '*.hpp.inc' \) \
     -type f -print \
+    | grep -F -v -f "${THIS_DIR}/add_license.ignore" \
     | \
     while IFS='' read -r i; do
         # `grep -F` is important here because the characters in the beacon should be matched against


### PR DESCRIPTION
This removes the explicit filename patterns in `add_license.sh` and replaces them by a separate file.

Closes #431