### PR TITLE
Disable GINKGO_DEVEL_TOOLS by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@ include(cmake/hip_path.cmake)
 include(cmake/autodetect_executors.cmake)
 
 # Ginkgo configuration options
-option(GINKGO_DEVEL_TOOLS "Add development tools to the build system" ON)
+option(GINKGO_DEVEL_TOOLS "Add development tools to the build system" OFF)
 option(GINKGO_BUILD_TESTS "Generate build files for unit tests" ON)
 option(GINKGO_BUILD_EXAMPLES "Build Ginkgo's examples" ON)
 option(GINKGO_BUILD_BENCHMARKS "Build Ginkgo's benchmarks" ON)

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -17,7 +17,7 @@ Ginkgo adds the following additional switches to control what is being built:
 
 *   `-DGINKGO_DEVEL_TOOLS={ON, OFF}` sets up the build system for development
     (requires clang-format, will also download git-cmake-format),
-    default is `ON`.
+    default is `OFF`.
 *   `-DGINKGO_BUILD_TESTS={ON, OFF}` builds Ginkgo's tests
     (will download googletest), default is `ON`.
 *   `-DGINKGO_BUILD_BENCHMARKS={ON, OFF}` builds Ginkgo's benchmarks

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -16,6 +16,8 @@ endif()
 if(GINKGO_DEVEL_TOOLS)
     set(GCF_IGNORE_LIST "third_party" CACHE STRING "Ignore directories for GCF")
     add_subdirectory(git-cmake-format)
+else()
+    add_subdirectory(dummy-hook)
 endif()
 
 if(GINKGO_BUILD_BENCHMARKS)

--- a/third_party/dummy-hook/CMakeLists.txt
+++ b/third_party/dummy-hook/CMakeLists.txt
@@ -1,0 +1,18 @@
+if(EXISTS "${Ginkgo_SOURCE_DIR}/.git")
+    set(ADD_HOOK FALSE)
+    set(HOOK_LOCATION "${Ginkgo_SOURCE_DIR}/.git/hooks/pre-commit")
+    if(NOT EXISTS "${HOOK_LOCATION}")
+        set(ADD_HOOK TRUE)
+    else()
+        # check if the correct hook is installed
+        execute_process(COMMAND grep git-cmake-format.py "${HOOK_LOCATION}"
+                        RESULT_VARIABLE res OUTPUT_QUIET)
+        # return value =/= 0 means the pattern was not found
+        if(NOT res EQUAL 0)
+            set(ADD_HOOK TRUE)
+        endif()
+    endif()
+    if(ADD_HOOK)
+        configure_file(dummy_hook "${HOOK_LOCATION}" COPYONLY)
+    endif()
+endif()

--- a/third_party/dummy-hook/dummy_hook
+++ b/third_party/dummy-hook/dummy_hook
@@ -1,0 +1,5 @@
+#!/bin/bash
+echo "Please only commit to Ginkgo when GINKGO_DEVEL_TOOLS is enabled in CMake."
+echo "This can be set in your initial invocation of CMake by using"
+echo " -DGINKGO_DEVEL_TOOLS=ON or by editing the CMakeCache.txt file."
+exit 1


### PR DESCRIPTION
This PR sets the default for `GINKGO_DEVEL_TOOLS` to `OFF` to make it easier for users to use our library even though they don't have the necessary tools (especially `clang-format`) installed.

To not break our workflow, it adds a dummy pre-commit hook that is installed when `DEVEL_TOOLS` is off and rejects every commit with a reminder message. The hook is not installed when the `git-cmake-format` hook is already present.

Closes #440 