### PR TITLE
Specialize HIP cooperative groups for HCC and NVCC

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -56,7 +56,7 @@ stages:
         -DGINKGO_BUILD_OMP=${BUILD_OMP} -DGINKGO_BUILD_CUDA=${BUILD_CUDA}
         -DGINKGO_BUILD_HIP=${BUILD_HIP}
         -DGINKGO_BUILD_TESTS=ON -DGINKGO_BUILD_EXAMPLES=ON
-    - make -j${NUM_CORES} 2>&1 | grep -v -e "without '\.sync' is deprecated" -e "loop not unrolled"
+    - make -j${NUM_CORES} 2>&1 | grep -v -e "loop not unrolled"
   dependencies: []
   except:
       - schedules
@@ -75,7 +75,7 @@ stages:
         -DGINKGO_BUILD_OMP=${BUILD_OMP} -DGINKGO_BUILD_CUDA=${BUILD_CUDA}
         -DGINKGO_BUILD_HIP=${BUILD_HIP}
         -DGINKGO_BUILD_TESTS=ON -DGINKGO_BUILD_EXAMPLES=ON
-    - make -j${NUM_CORES} install 2>&1 | grep -v -e "without '\.sync' is deprecated" -e "loop not unrolled"
+    - make -j${NUM_CORES} install 2>&1 | grep -v -e "loop not unrolled"
     - |
         (( $(ctest -N | tail -1 | sed 's/Total Tests: //') != 0 )) || exit 1
     - ctest -V

--- a/cuda/test/components/CMakeLists.txt
+++ b/cuda/test/components/CMakeLists.txt
@@ -1,2 +1,3 @@
+ginkgo_create_cuda_test(cooperative_groups)
 ginkgo_create_cuda_test(prefix_sum)
 ginkgo_create_cuda_test(sorting)

--- a/cuda/test/components/cooperative_groups.cu
+++ b/cuda/test/components/cooperative_groups.cu
@@ -43,6 +43,9 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <ginkgo/core/base/executor.hpp>
 
 
+#include "cuda/base/config.hpp"
+
+
 namespace {
 
 

--- a/cuda/test/components/cooperative_groups.cu
+++ b/cuda/test/components/cooperative_groups.cu
@@ -1,0 +1,207 @@
+/*******************************<GINKGO LICENSE>******************************
+Copyright (c) 2017-2020, the Ginkgo authors
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+******************************<GINKGO LICENSE>*******************************/
+
+#include "cuda/components/cooperative_groups.cuh"
+
+
+#include <memory>
+
+
+#include <gtest/gtest.h>
+
+
+#include <ginkgo/core/base/array.hpp>
+#include <ginkgo/core/base/executor.hpp>
+
+
+namespace {
+
+
+using namespace gko::kernels::cuda;
+
+
+class CooperativeGroups : public ::testing::Test {
+protected:
+    CooperativeGroups()
+        : ref(gko::ReferenceExecutor::create()),
+          cuda(gko::CudaExecutor::create(0, ref)),
+          result(ref, 1),
+          dresult(cuda)
+    {
+        *result.get_data() = true;
+        dresult = result;
+    }
+
+    template <typename Kernel>
+    void test(Kernel kernel)
+    {
+        kernel<<<1, config::warp_size>>>(dresult.get_data());
+        result = dresult;
+        auto success = *result.get_const_data();
+
+        ASSERT_TRUE(success);
+    }
+
+    std::shared_ptr<gko::ReferenceExecutor> ref;
+    std::shared_ptr<gko::CudaExecutor> cuda;
+    gko::Array<bool> result;
+    gko::Array<bool> dresult;
+};
+
+
+constexpr static int subwarp_size = config::warp_size / 4;
+
+
+__device__ void test_assert(bool *success, bool partial)
+{
+    auto warp =
+        group::tiled_partition<config::warp_size>(group::this_thread_block());
+    auto full = warp.all(partial);
+    if (threadIdx.x == 0) {
+        *success &= full;
+    }
+}
+
+
+__global__ void cg_shuffle(bool *s)
+{
+    auto group =
+        group::tiled_partition<config::warp_size>(group::this_thread_block());
+    auto i = int(group.thread_rank());
+    test_assert(s, group.shfl_up(i, 1) == max(0, i - 1));
+    test_assert(s, group.shfl_down(i, 1) == min(i + 1, config::warp_size - 1));
+    test_assert(s, group.shfl(i, 0) == 0);
+}
+
+TEST_F(CooperativeGroups, Shuffle) { test(cg_shuffle); }
+
+
+__global__ void cg_all(bool *s)
+{
+    auto group =
+        group::tiled_partition<config::warp_size>(group::this_thread_block());
+    test_assert(s, group.all(true));
+    test_assert(s, !group.all(false));
+    test_assert(s, !group.all(threadIdx.x < 13));
+}
+
+TEST_F(CooperativeGroups, All) { test(cg_all); }
+
+
+__global__ void cg_any(bool *s)
+{
+    auto group =
+        group::tiled_partition<config::warp_size>(group::this_thread_block());
+    test_assert(s, group.any(true));
+    test_assert(s, group.any(threadIdx.x == 0));
+    test_assert(s, !group.any(false));
+}
+
+TEST_F(CooperativeGroups, Any) { test(cg_any); }
+
+
+__global__ void cg_ballot(bool *s)
+{
+    auto group =
+        group::tiled_partition<config::warp_size>(group::this_thread_block());
+    test_assert(s, group.ballot(false) == 0);
+    test_assert(s, group.ballot(true) == ~config::lane_mask_type{});
+    test_assert(s, group.ballot(threadIdx.x < 4) == 0xf);
+}
+
+TEST_F(CooperativeGroups, Ballot) { test(cg_ballot); }
+
+
+__global__ void cg_subwarp_shuffle(bool *s)
+{
+    auto group =
+        group::tiled_partition<subwarp_size>(group::this_thread_block());
+    auto i = int(group.thread_rank());
+    test_assert(s, group.shfl_up(i, 1) == max(i - 1, 0));
+    test_assert(s, group.shfl_down(i, 1) == min(i + 1, subwarp_size - 1));
+    auto group_base = threadIdx.x / subwarp_size * subwarp_size;
+    test_assert(s, group.shfl(int(threadIdx.x), 0) == group_base);
+}
+
+TEST_F(CooperativeGroups, SubwarpShuffle) { test(cg_subwarp_shuffle); }
+
+
+__global__ void cg_subwarp_all(bool *s)
+{
+    auto grp = threadIdx.x / subwarp_size;
+    bool test_grp = grp == 1;
+    auto i = threadIdx.x % subwarp_size;
+    // only test with test_grp, the other threads run 'interference'
+    auto group =
+        group::tiled_partition<subwarp_size>(group::this_thread_block());
+    test_assert(s, !test_grp || group.all(test_grp));
+    test_assert(s, !test_grp || !group.all(!test_grp));
+    test_assert(s, !test_grp || !group.all(i < subwarp_size - 3 || !test_grp));
+}
+
+TEST_F(CooperativeGroups, SubwarpAll) { test(cg_subwarp_all); }
+
+
+__global__ void cg_subwarp_any(bool *s)
+{
+    auto grp = threadIdx.x / subwarp_size;
+    bool test_grp = grp == 1;
+    // only test with test_grp, the other threads run 'interference'
+    auto group =
+        group::tiled_partition<subwarp_size>(group::this_thread_block());
+    auto i = group.thread_rank();
+    test_assert(s, !test_grp || group.any(test_grp));
+    test_assert(s, !test_grp || group.any(test_grp && i == 1));
+    test_assert(s, !test_grp || !group.any(!test_grp));
+}
+
+TEST_F(CooperativeGroups, SubwarpAny) { test(cg_subwarp_any); }
+
+
+__global__ void cg_subwarp_ballot(bool *s)
+{
+    auto grp = threadIdx.x / subwarp_size;
+    bool test_grp = grp == 1;
+    auto full_mask = (config::lane_mask_type{1} << subwarp_size) - 1;
+    // only test with test_grp, the other threads run 'interference'
+    auto group =
+        group::tiled_partition<subwarp_size>(group::this_thread_block());
+    auto i = group.thread_rank();
+    test_assert(s, !test_grp || group.ballot(!test_grp) == 0);
+    test_assert(s, !test_grp || group.ballot(test_grp) == full_mask);
+    test_assert(s, !test_grp || group.ballot(i < 4 || !test_grp) == 0xf);
+}
+
+TEST_F(CooperativeGroups, SubwarpBallot) { test(cg_subwarp_ballot); }
+
+
+}  // namespace

--- a/hip/components/cooperative_groups.hip.hpp
+++ b/hip/components/cooperative_groups.hip.hpp
@@ -247,6 +247,10 @@ public:
     GKO_BIND_SHFL(shfl_xor, uint32, int32);
     GKO_BIND_SHFL(shfl_xor, double, int32);
 
+    /**
+     * Returns true iff the predicate is true for at least one threads in the
+     * group. Note that the whole group needs to execute the same operation.
+     */
     __device__ __forceinline__ int any(int predicate) const noexcept
     {
 #if GINKGO_HIP_PLATFORM_HCC
@@ -260,6 +264,10 @@ public:
 #endif
     }
 
+    /**
+     * Returns true iff the predicate is true for all threads in the group.
+     * Note that the whole group needs to execute the same operation.
+     */
     __device__ __forceinline__ int all(int predicate) const noexcept
     {
 #if GINKGO_HIP_PLATFORM_HCC
@@ -273,6 +281,13 @@ public:
 #endif
     }
 
+    /**
+     * Returns a bitmask containing the value of the given predicate
+     * for all threads in the group.
+     * This means that the ith bit is equal to the predicate of the
+     * thread with thread_rank() == i in the group.
+     * Note that the whole group needs to execute the same operation.
+     */
     __device__ __forceinline__ config::lane_mask_type ballot(
         int predicate) const noexcept
     {

--- a/hip/components/cooperative_groups.hip.hpp
+++ b/hip/components/cooperative_groups.hip.hpp
@@ -250,7 +250,11 @@ public:
     __device__ __forceinline__ int any(int predicate) const noexcept
     {
 #if GINKGO_HIP_PLATFORM_HCC
-        return (__ballot(predicate) & data_.mask) != 0;
+        if (Size == config::warp_size) {
+            return __any(predicate);
+        } else {
+            return (__ballot(predicate) & data_.mask) != 0;
+        }
 #else
         return __any_sync(data_.mask, predicate);
 #endif
@@ -259,7 +263,11 @@ public:
     __device__ __forceinline__ int all(int predicate) const noexcept
     {
 #if GINKGO_HIP_PLATFORM_HCC
-        return (__ballot(predicate) & data_.mask) == data_.mask;
+        if (Size == config::warp_size) {
+            return __all(predicate);
+        } else {
+            return (__ballot(predicate) & data_.mask) == data_.mask;
+        }
 #else
         return __all_sync(data_.mask, predicate);
 #endif
@@ -269,9 +277,17 @@ public:
         int predicate) const noexcept
     {
 #if GINKGO_HIP_PLATFORM_HCC
-        return (__ballot(predicate) & data_.mask) >> data_.lane_offset;
+        if (Size == config::warp_size) {
+            return __ballot(predicate);
+        } else {
+            return (__ballot(predicate) & data_.mask) >> data_.lane_offset;
+        }
 #else
-        return __ballot_sync(data_.mask, predicate) >> data_.lane_offset;
+        if (Size == config::warp_size) {
+            return __ballot_sync(data_.mask, predicate);
+        } else {
+            return __ballot_sync(data_.mask, predicate) >> data_.lane_offset;
+        }
 #endif
     }
 

--- a/hip/test/components/CMakeLists.txt
+++ b/hip/test/components/CMakeLists.txt
@@ -1,2 +1,3 @@
+ginkgo_create_hip_test(cooperative_groups)
 ginkgo_create_hip_test(prefix_sum)
 ginkgo_create_hip_test(sorting)

--- a/hip/test/components/cooperative_groups.hip.cpp
+++ b/hip/test/components/cooperative_groups.hip.cpp
@@ -1,0 +1,204 @@
+/*******************************<GINKGO LICENSE>******************************
+Copyright (c) 2017-2020, the Ginkgo authors
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+******************************<GINKGO LICENSE>*******************************/
+
+// TODO remove when the HIP includes are fixed
+#include <hip/hip_runtime.h>
+
+
+#include "hip/components/cooperative_groups.hip.hpp"
+
+
+#include <memory>
+
+
+#include <gtest/gtest.h>
+
+
+#include <ginkgo/core/base/array.hpp>
+#include <ginkgo/core/base/executor.hpp>
+
+
+namespace {
+
+
+using namespace gko::kernels::hip;
+using namespace gko::kernels::hip::group;
+
+
+class CooperativeGroups : public ::testing::Test {
+protected:
+    CooperativeGroups()
+        : ref(gko::ReferenceExecutor::create()),
+          hip(gko::HipExecutor::create(0, ref)),
+          result(ref, 1),
+          dresult(hip)
+    {
+        *result.get_data() = true;
+        dresult = result;
+    }
+
+    template <typename Kernel>
+    void test(Kernel kernel)
+    {
+        hipLaunchKernelGGL(HIP_KERNEL_NAME(kernel), dim3(1),
+                           dim3(config::warp_size), 0, 0, dresult.get_data());
+        result = dresult;
+        auto success = *result.get_const_data();
+
+        ASSERT_TRUE(success);
+    }
+
+    std::shared_ptr<gko::ReferenceExecutor> ref;
+    std::shared_ptr<gko::HipExecutor> hip;
+    gko::Array<bool> result;
+    gko::Array<bool> dresult;
+};
+
+
+constexpr static int subwarp_size = config::warp_size / 4;
+
+
+__device__ void test_assert(bool *success, bool partial)
+{
+    auto warp = tiled_partition<config::warp_size>(this_thread_block());
+    auto full = warp.all(partial);
+    if (threadIdx.x == 0) {
+        *success &= full;
+    }
+}
+
+
+__global__ void cg_shuffle(bool *s)
+{
+    auto group = tiled_partition<config::warp_size>(this_thread_block());
+    auto i = int(group.thread_rank());
+    test_assert(s, group.shfl_up(i, 1) == max(0, i - 1));
+    test_assert(s, group.shfl_down(i, 1) == min(i + 1, config::warp_size - 1));
+    test_assert(s, group.shfl(i, 0) == 0);
+}
+
+TEST_F(CooperativeGroups, Shuffle) { test(cg_shuffle); }
+
+
+__global__ void cg_all(bool *s)
+{
+    auto group = tiled_partition<config::warp_size>(this_thread_block());
+    test_assert(s, group.all(true));
+    test_assert(s, !group.all(false));
+    test_assert(s, !group.all(threadIdx.x < 13));
+}
+
+TEST_F(CooperativeGroups, All) { test(cg_all); }
+
+
+__global__ void cg_any(bool *s)
+{
+    auto group = tiled_partition<config::warp_size>(this_thread_block());
+    test_assert(s, group.any(true));
+    test_assert(s, group.any(threadIdx.x == 0));
+    test_assert(s, !group.any(false));
+}
+
+TEST_F(CooperativeGroups, Any) { test(cg_any); }
+
+
+__global__ void cg_ballot(bool *s)
+{
+    auto group = tiled_partition<config::warp_size>(this_thread_block());
+    test_assert(s, group.ballot(false) == 0);
+    test_assert(s, group.ballot(true) == ~config::lane_mask_type{});
+    test_assert(s, group.ballot(threadIdx.x < 4) == 0xf);
+}
+
+TEST_F(CooperativeGroups, Ballot) { test(cg_ballot); }
+
+
+__global__ void cg_subwarp_shuffle(bool *s)
+{
+    auto group = tiled_partition<subwarp_size>(this_thread_block());
+    auto i = int(group.thread_rank());
+    test_assert(s, group.shfl_up(i, 1) == max(i - 1, 0));
+    test_assert(s, group.shfl_down(i, 1) == min(i + 1, subwarp_size - 1));
+    auto group_base = threadIdx.x / subwarp_size * subwarp_size;
+    test_assert(s, group.shfl(int(threadIdx.x), 0) == group_base);
+}
+
+TEST_F(CooperativeGroups, SubwarpShuffle) { test(cg_subwarp_shuffle); }
+
+
+__global__ void cg_subwarp_all(bool *s)
+{
+    auto grp = threadIdx.x / subwarp_size;
+    bool test_grp = grp == 1;
+    auto i = threadIdx.x % subwarp_size;
+    // only test with test_grp, the other threads run 'interference'
+    auto group = tiled_partition<subwarp_size>(this_thread_block());
+    test_assert(s, !test_grp || group.all(test_grp));
+    test_assert(s, !test_grp || !group.all(!test_grp));
+    test_assert(s, !test_grp || !group.all(i < subwarp_size - 3 || !test_grp));
+}
+
+TEST_F(CooperativeGroups, SubwarpAll) { test(cg_subwarp_all); }
+
+
+__global__ void cg_subwarp_any(bool *s)
+{
+    auto grp = threadIdx.x / subwarp_size;
+    bool test_grp = grp == 1;
+    // only test with test_grp, the other threads run 'interference'
+    auto group = tiled_partition<subwarp_size>(this_thread_block());
+    auto i = group.thread_rank();
+    test_assert(s, !test_grp || group.any(test_grp));
+    test_assert(s, !test_grp || group.any(test_grp && i == 1));
+    test_assert(s, !test_grp || !group.any(!test_grp));
+}
+
+TEST_F(CooperativeGroups, SubwarpAny) { test(cg_subwarp_any); }
+
+
+__global__ void cg_subwarp_ballot(bool *s)
+{
+    auto grp = threadIdx.x / subwarp_size;
+    bool test_grp = grp == 1;
+    auto full_mask = (config::lane_mask_type{1} << subwarp_size) - 1;
+    // only test with test_grp, the other threads run 'interference'
+    auto group = tiled_partition<subwarp_size>(this_thread_block());
+    auto i = group.thread_rank();
+    test_assert(s, !test_grp || group.ballot(!test_grp) == 0);
+    test_assert(s, !test_grp || group.ballot(test_grp) == full_mask);
+    test_assert(s, !test_grp || group.ballot(i < 4 || !test_grp) == 0xf);
+}
+
+TEST_F(CooperativeGroups, SubwarpBallot) { test(cg_subwarp_ballot); }
+
+
+}  // namespace

--- a/hip/test/components/cooperative_groups.hip.cpp
+++ b/hip/test/components/cooperative_groups.hip.cpp
@@ -51,7 +51,6 @@ namespace {
 
 
 using namespace gko::kernels::hip;
-using namespace gko::kernels::hip::group;
 
 
 class CooperativeGroups : public ::testing::Test {
@@ -77,6 +76,18 @@ protected:
         ASSERT_TRUE(success);
     }
 
+    template <typename Kernel>
+    void test_subwarp(Kernel kernel)
+    {
+        hipLaunchKernelGGL(HIP_KERNEL_NAME(kernel), dim3(1),
+                           dim3(config::warp_size / 2), 0, 0,
+                           dresult.get_data());
+        result = dresult;
+        auto success = *result.get_const_data();
+
+        ASSERT_TRUE(success);
+    }
+
     std::shared_ptr<gko::ReferenceExecutor> ref;
     std::shared_ptr<gko::HipExecutor> hip;
     gko::Array<bool> result;
@@ -89,17 +100,16 @@ constexpr static int subwarp_size = config::warp_size / 4;
 
 __device__ void test_assert(bool *success, bool partial)
 {
-    auto warp = tiled_partition<config::warp_size>(this_thread_block());
-    auto full = warp.all(partial);
-    if (threadIdx.x == 0) {
-        *success &= full;
+    if (!partial) {
+        *success = false;
     }
 }
 
 
 __global__ void cg_shuffle(bool *s)
 {
-    auto group = tiled_partition<config::warp_size>(this_thread_block());
+    auto group =
+        group::tiled_partition<config::warp_size>(group::this_thread_block());
     auto i = int(group.thread_rank());
     test_assert(s, group.shfl_up(i, 1) == max(0, i - 1));
     test_assert(s, group.shfl_down(i, 1) == min(i + 1, config::warp_size - 1));
@@ -111,7 +121,8 @@ TEST_F(CooperativeGroups, Shuffle) { test(cg_shuffle); }
 
 __global__ void cg_all(bool *s)
 {
-    auto group = tiled_partition<config::warp_size>(this_thread_block());
+    auto group =
+        group::tiled_partition<config::warp_size>(group::this_thread_block());
     test_assert(s, group.all(true));
     test_assert(s, !group.all(false));
     test_assert(s, !group.all(threadIdx.x < 13));
@@ -122,7 +133,8 @@ TEST_F(CooperativeGroups, All) { test(cg_all); }
 
 __global__ void cg_any(bool *s)
 {
-    auto group = tiled_partition<config::warp_size>(this_thread_block());
+    auto group =
+        group::tiled_partition<config::warp_size>(group::this_thread_block());
     test_assert(s, group.any(true));
     test_assert(s, group.any(threadIdx.x == 0));
     test_assert(s, !group.any(false));
@@ -133,7 +145,8 @@ TEST_F(CooperativeGroups, Any) { test(cg_any); }
 
 __global__ void cg_ballot(bool *s)
 {
-    auto group = tiled_partition<config::warp_size>(this_thread_block());
+    auto group =
+        group::tiled_partition<config::warp_size>(group::this_thread_block());
     test_assert(s, group.ballot(false) == 0);
     test_assert(s, group.ballot(true) == ~config::lane_mask_type{});
     test_assert(s, group.ballot(threadIdx.x < 4) == 0xf);
@@ -144,15 +157,27 @@ TEST_F(CooperativeGroups, Ballot) { test(cg_ballot); }
 
 __global__ void cg_subwarp_shuffle(bool *s)
 {
-    auto group = tiled_partition<subwarp_size>(this_thread_block());
+    auto group =
+        group::tiled_partition<subwarp_size>(group::this_thread_block());
     auto i = int(group.thread_rank());
     test_assert(s, group.shfl_up(i, 1) == max(i - 1, 0));
     test_assert(s, group.shfl_down(i, 1) == min(i + 1, subwarp_size - 1));
     auto group_base = threadIdx.x / subwarp_size * subwarp_size;
     test_assert(s, group.shfl(int(threadIdx.x), 0) == group_base);
+    if (threadIdx.x / subwarp_size == 1) {
+        test_assert(s, group.shfl_up(i, 1) == max(i - 1, 0));
+        test_assert(s, group.shfl_down(i, 1) == min(i + 1, subwarp_size - 1));
+        test_assert(s, group.shfl(int(threadIdx.x), 0) == group_base);
+    } else {
+        test_assert(s, group.shfl_down(i, 1) == min(i + 1, subwarp_size - 1));
+        test_assert(s, group.shfl(int(threadIdx.x), 0) == group_base);
+        test_assert(s, group.shfl_up(i, 1) == max(i - 1, 0));
+    }
 }
 
 TEST_F(CooperativeGroups, SubwarpShuffle) { test(cg_subwarp_shuffle); }
+
+TEST_F(CooperativeGroups, SubwarpShuffle2) { test_subwarp(cg_subwarp_shuffle); }
 
 
 __global__ void cg_subwarp_all(bool *s)
@@ -161,13 +186,25 @@ __global__ void cg_subwarp_all(bool *s)
     bool test_grp = grp == 1;
     auto i = threadIdx.x % subwarp_size;
     // only test with test_grp, the other threads run 'interference'
-    auto group = tiled_partition<subwarp_size>(this_thread_block());
+    auto group =
+        group::tiled_partition<subwarp_size>(group::this_thread_block());
     test_assert(s, !test_grp || group.all(test_grp));
     test_assert(s, !test_grp || !group.all(!test_grp));
     test_assert(s, !test_grp || !group.all(i < subwarp_size - 3 || !test_grp));
+    if (test_grp) {
+        test_assert(s, group.all(true));
+        test_assert(s, !group.all(false));
+        test_assert(s, !group.all(i < subwarp_size - 3));
+    } else {
+        test_assert(s, !group.all(false));
+        test_assert(s, !group.all(i < subwarp_size - 3));
+        test_assert(s, group.all(true));
+    }
 }
 
 TEST_F(CooperativeGroups, SubwarpAll) { test(cg_subwarp_all); }
+
+TEST_F(CooperativeGroups, SubwarpAll2) { test_subwarp(cg_subwarp_all); }
 
 
 __global__ void cg_subwarp_any(bool *s)
@@ -175,14 +212,26 @@ __global__ void cg_subwarp_any(bool *s)
     auto grp = threadIdx.x / subwarp_size;
     bool test_grp = grp == 1;
     // only test with test_grp, the other threads run 'interference'
-    auto group = tiled_partition<subwarp_size>(this_thread_block());
+    auto group =
+        group::tiled_partition<subwarp_size>(group::this_thread_block());
     auto i = group.thread_rank();
     test_assert(s, !test_grp || group.any(test_grp));
     test_assert(s, !test_grp || group.any(test_grp && i == 1));
     test_assert(s, !test_grp || !group.any(!test_grp));
+    if (test_grp) {
+        test_assert(s, group.any(true));
+        test_assert(s, group.any(i == 1));
+        test_assert(s, !group.any(false));
+    } else {
+        test_assert(s, !group.any(false));
+        test_assert(s, group.any(true));
+        test_assert(s, group.any(i == 1));
+    }
 }
 
 TEST_F(CooperativeGroups, SubwarpAny) { test(cg_subwarp_any); }
+
+TEST_F(CooperativeGroups, SubwarpAny2) { test_subwarp(cg_subwarp_any); }
 
 
 __global__ void cg_subwarp_ballot(bool *s)
@@ -191,14 +240,26 @@ __global__ void cg_subwarp_ballot(bool *s)
     bool test_grp = grp == 1;
     auto full_mask = (config::lane_mask_type{1} << subwarp_size) - 1;
     // only test with test_grp, the other threads run 'interference'
-    auto group = tiled_partition<subwarp_size>(this_thread_block());
+    auto group =
+        group::tiled_partition<subwarp_size>(group::this_thread_block());
     auto i = group.thread_rank();
     test_assert(s, !test_grp || group.ballot(!test_grp) == 0);
     test_assert(s, !test_grp || group.ballot(test_grp) == full_mask);
     test_assert(s, !test_grp || group.ballot(i < 4 || !test_grp) == 0xf);
+    if (test_grp) {
+        test_assert(s, group.ballot(false) == 0);
+        test_assert(s, group.ballot(true) == full_mask);
+        test_assert(s, group.ballot(i < 4) == 0xf);
+    } else {
+        test_assert(s, group.ballot(true) == full_mask);
+        test_assert(s, group.ballot(i < 4) == 0xf);
+        test_assert(s, group.ballot(false) == 0);
+    }
 }
 
 TEST_F(CooperativeGroups, SubwarpBallot) { test(cg_subwarp_ballot); }
+
+TEST_F(CooperativeGroups, SubwarpBallot2) { test_subwarp(cg_subwarp_ballot); }
 
 
 }  // namespace


### PR DESCRIPTION
This adds a lane mask to the thread_block_tile class and uses it to
implement CUDA and HCC-specific versions of register shuffles, ballot,
all and any.

Nice side-effect: All the deprecation warnings from NVCC should disappear.

TODO:

- [x] Figure out how to test this
- [x] Remove grep for `.sync` from CI config
- [x] ~~Check if this significantly impacts the performance of warp sorting on NVIDIA GPUs~~
(We are actually now almost executing the same code for HIP and CUDA, and I could not observe any runtime issues there. In case there were any, we could just set the tiled partition size to `config::warp_size`. In the long run, it might be interesting to specialize this to independent subwarps, but not for now.)