### PR TITLE
Pull in git-cmake-format fix

### DIFF
--- a/third_party/git-cmake-format/CMakeLists.txt
+++ b/third_party/git-cmake-format/CMakeLists.txt
@@ -1,6 +1,6 @@
 ginkgo_load_git_package(git-cmake-format
     "https://github.com/ginkgo-project/git-cmake-format.git"
-    "2e7ebcdd65ecb507599b25b93b82d2985a8888c5"
+    "46d2b43b24fa3aea366be9cce21abfdfffcf0090"
     "-DGCF_CLANGFORMAT_MINIMAL_VERSION=5.0.1")
 add_subdirectory(${CMAKE_CURRENT_BINARY_DIR}/src
     ${CMAKE_CURRENT_BINARY_DIR}/build EXCLUDE_FROM_ALL)


### PR DESCRIPTION
We had a small issue with the previous changes to git-cmake-format. This PR pulls in the fix from https://github.com/ginkgo-project/git-cmake-format/pull/2