### PR TITLE
remove cuda.h includes not required

### DIFF
--- a/cuda/test/solver/lower_trs_kernels.cpp
+++ b/cuda/test/solver/lower_trs_kernels.cpp
@@ -37,7 +37,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <random>
 
 
-#include <cuda.h>
 #include <gtest/gtest.h>
 
 

--- a/cuda/test/solver/upper_trs_kernels.cpp
+++ b/cuda/test/solver/upper_trs_kernels.cpp
@@ -37,7 +37,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <random>
 
 
-#include <cuda.h>
 #include <gtest/gtest.h>
 
 


### PR DESCRIPTION
These two examples fail because the included cuda.h is not found (the rest compiles fine with CUDA enabled). However, no symbol from cuda.h seems to be used here.