### PR TITLE
Reduce compilation warnings

### DIFF
--- a/core/base/extended_float.hpp
+++ b/core/base/extended_float.hpp
@@ -307,7 +307,7 @@ private:
  */
 class half {
 public:
-    GKO_ATTRIBUTES half() noexcept = default;
+    half() noexcept = default;
 
     GKO_ATTRIBUTES half(float32 val) noexcept
     {
@@ -440,7 +440,7 @@ public:
     static_assert(component_id < num_components,
                   "This type doesn't have that many components");
 
-    GKO_ATTRIBUTES truncated() noexcept = default;
+    truncated() noexcept = default;
 
     GKO_ATTRIBUTES explicit truncated(const float_type &val) noexcept
     {

--- a/hip/CMakeLists.txt
+++ b/hip/CMakeLists.txt
@@ -128,10 +128,17 @@ if (GINKGO_HIP_PLATFORM MATCHES "nvcc")
     if (CMAKE_CUDA_HOST_COMPILER)
         set(GINKGO_HIP_CUDA_HOST_COMPILER "-ccbin=${CMAKE_CUDA_HOST_COMPILER}")
     endif()
+    
+    # Remove false positive CUDA warnings when calling one<T>() and zero<T>()
+    # This creates a compilation bug on nvcc 9.0.102 *with* the new array_deleter
+    # merged at commit ed12b3df5d26
+    if(NOT CMAKE_CUDA_COMPILER_VERSION MATCHES "9.0")
+        set(GINKGO_HIP_NVCC_ADDITIONAL_FLAGS --expt-relaxed-constexpr)
+    endif()
 endif()
 
 set(GINKGO_HIPCC_OPTIONS ${GINKGO_HIP_COMPILER_FLAGS})
-set(GINKGO_HIP_NVCC_OPTIONS ${GINKGO_HIP_NVCC_COMPILER_FLAGS})
+set(GINKGO_HIP_NVCC_OPTIONS ${GINKGO_HIP_NVCC_COMPILER_FLAGS} ${GINKGO_HIP_NVCC_ADDITIONAL_FLAGS})
 set(GINKGO_HIP_HCC_OPTIONS ${GINKGO_HIP_HCC_COMPILER_FLAGS})
 
 set_source_files_properties(${GINKGO_HIP_SOURCES} PROPERTIES HIP_SOURCE_PROPERTY_FORMAT TRUE)

--- a/include/ginkgo/core/base/range.hpp
+++ b/include/ginkgo/core/base/range.hpp
@@ -308,7 +308,7 @@ public:
     /**
      * Use the default destructor.
      */
-    GKO_ATTRIBUTES ~range() = default;
+    ~range() = default;
 
     /**
      * Creates a new range.
@@ -382,7 +382,7 @@ public:
         return *this;
     }
 
-    GKO_ATTRIBUTES range(const range &other) = default;
+    range(const range &other) = default;
 
     /**
      * Returns the length of the specified dimension of the range.


### PR DESCRIPTION
This PR gets rid our most common compilation warnings:

```
core/base/range.hpp(311): warning: __host__ annotation is ignored on a function("~range") that is explicitly defaulted on its first declaration
core/base/range.hpp(311): warning: __device__ annotation is ignored on a function("~range") that is explicitly defaulted on its first declaration
```

and extends the fix for warnings because of constexpr `__host__` calls in `__host__ __device__` functions from CUDA to HIP with NVCC