### PR TITLE
Use parallel merge in HIP advanced spgemm

### DIFF
--- a/common/components/merging.hpp.inc
+++ b/common/components/merging.hpp.inc
@@ -153,7 +153,7 @@ __device__ void group_merge(const ValueType *a, IndexType a_size,
     IndexType c_begin{};
     auto lane = IndexType(group.thread_rank());
     auto a_cur = detail::checked_load(a, a_begin + lane, a_size);
-    auto b_cur = detail::checked_load(b, b_begin + lane, a_size);
+    auto b_cur = detail::checked_load(b, b_begin + lane, b_size);
     while (c_begin < c_size) {
         auto merge_result = group_merge_step<group_size>(a_cur, b_cur, group);
         merge_fn(merge_result.a_idx + a_begin, merge_result.a_val,

--- a/common/matrix/csr_kernels.hpp.inc
+++ b/common/matrix/csr_kernels.hpp.inc
@@ -494,95 +494,95 @@ __global__ __launch_bounds__(spmv_block_size) void abstract_classical_spmv(
 }
 
 
-template <typename IndexType>
+template <int subwarp_size, typename IndexType>
 __global__ __launch_bounds__(default_block_size) void spgeam_nnz(
     const IndexType *a_row_ptrs, const IndexType *a_col_idxs,
     const IndexType *b_row_ptrs, const IndexType *b_col_idxs,
     IndexType num_rows, IndexType *nnz)
 {
-    constexpr auto sentinel = device_numeric_limits<IndexType>::max;
-    auto row = threadIdx.x + blockDim.x * static_cast<size_type>(blockIdx.x);
+    auto row =
+        (threadIdx.x + blockDim.x * size_type(blockIdx.x)) / subwarp_size;
+    auto subwarp =
+        group::tiled_partition<subwarp_size>(group::this_thread_block());
     if (row >= num_rows) {
         return;
     }
 
     auto a_begin = a_row_ptrs[row];
     auto b_begin = b_row_ptrs[row];
-    auto a_end = a_row_ptrs[row + 1];
-    auto b_end = b_row_ptrs[row + 1];
-    auto a_size = a_end - a_begin;
-    auto b_size = b_end - b_begin;
-    auto a_ptr = a_begin;
-    auto b_ptr = b_begin;
-    auto a_col = a_ptr < a_end ? a_col_idxs[a_ptr] : sentinel;
-    auto b_col = b_ptr < b_end ? b_col_idxs[b_ptr] : sentinel;
+    auto a_size = a_row_ptrs[row + 1] - a_begin;
+    auto b_size = b_row_ptrs[row + 1] - b_begin;
     IndexType count{};
-    IndexType i{};
-    while (i < a_size + b_size) {
-        auto advance_a = (a_col <= b_col);
-        auto advance_b = (b_col <= a_col);
-        i += advance_a + advance_b;
-        a_ptr += advance_a;
-        b_ptr += advance_b;
-        if (advance_a) {
-            a_col = a_ptr < a_end ? a_col_idxs[a_ptr] : sentinel;
-        }
-        if (advance_b) {
-            b_col = b_ptr < b_end ? b_col_idxs[b_ptr] : sentinel;
-        }
-        ++count;
+    group_merge<subwarp_size>(
+        a_col_idxs + a_begin, a_size, b_col_idxs + b_begin, b_size, subwarp,
+        [&](IndexType, IndexType a_col, IndexType, IndexType b_col, IndexType,
+            bool valid) {
+            count += popcnt(subwarp.ballot(a_col != b_col && valid));
+        });
+
+    if (subwarp.thread_rank() == 0) {
+        nnz[row] = count;
     }
-    nnz[row] = count;
 }
 
 
-template <typename IndexType, typename ValueType>
+template <int subwarp_size, typename IndexType, typename ValueType>
 __global__ __launch_bounds__(default_block_size) void spgeam(
     ValueType alpha, const IndexType *a_row_ptrs, const IndexType *a_col_idxs,
     const ValueType *a_vals, ValueType beta, const IndexType *b_row_ptrs,
     const IndexType *b_col_idxs, const ValueType *b_vals, IndexType num_rows,
     const IndexType *c_row_ptrs, IndexType *c_col_idxs, ValueType *c_vals)
 {
-    constexpr auto sentinel = device_numeric_limits<IndexType>::max;
-    auto row = threadIdx.x + blockDim.x * static_cast<size_type>(blockIdx.x);
+    auto row =
+        (threadIdx.x + blockDim.x * size_type(blockIdx.x)) / subwarp_size;
+    auto subwarp =
+        group::tiled_partition<subwarp_size>(group::this_thread_block());
     if (row >= num_rows) {
         return;
     }
 
+    auto lane = IndexType(subwarp.thread_rank());
+    constexpr auto lanemask_full =
+        ~config::lane_mask_type{} >> (config::warp_size - subwarp_size);
+    auto lanemask_eq = config::lane_mask_type{1} << lane;
+    auto lanemask_lt = lanemask_eq - 1;
+
     auto a_begin = a_row_ptrs[row];
     auto b_begin = b_row_ptrs[row];
+    auto a_size = a_row_ptrs[row + 1] - a_begin;
+    auto b_size = b_row_ptrs[row + 1] - b_begin;
     auto c_begin = c_row_ptrs[row];
-    auto a_end = a_row_ptrs[row + 1];
-    auto b_end = b_row_ptrs[row + 1];
-    auto a_size = a_end - a_begin;
-    auto b_size = b_end - b_begin;
-    auto a_ptr = a_begin;
-    auto b_ptr = b_begin;
-    auto a_col = a_ptr < a_end ? a_col_idxs[a_ptr] : sentinel;
-    auto b_col = b_ptr < b_end ? b_col_idxs[b_ptr] : sentinel;
-    IndexType count{};
-    IndexType i{};
-    IndexType c_col{};
-    while (i < a_size + b_size) {
-        auto advance_a = (a_col <= b_col);
-        auto advance_b = (b_col <= a_col);
-        c_col = advance_a ? a_col : b_col;
-        i += advance_a + advance_b;
-        a_ptr += advance_a;
-        b_ptr += advance_b;
-        ValueType c_val{};
-        if (advance_a) {
-            a_col = a_ptr < a_end ? a_col_idxs[a_ptr] : sentinel;
-            c_val += alpha * a_vals[a_ptr - 1];
-        }
-        if (advance_b) {
-            b_col = b_ptr < b_end ? b_col_idxs[b_ptr] : sentinel;
-            c_val += beta * b_vals[b_ptr - 1];
-        }
-        c_col_idxs[c_begin + count] = c_col;
-        c_vals[c_begin + count] = c_val;
-        ++count;
-    }
+    bool skip_first{};
+    group_merge<subwarp_size>(
+        a_col_idxs + a_begin, a_size, b_col_idxs + b_begin, b_size, subwarp,
+        [&](IndexType a_nz, IndexType a_col, IndexType b_nz, IndexType b_col,
+            IndexType, bool valid) {
+            auto c_col = min(a_col, b_col);
+            auto equal_mask = subwarp.ballot(a_col == b_col && valid);
+            // check if the elements in the previous merge step are
+            // equal
+            auto prev_equal_mask = equal_mask << 1 | skip_first;
+            // store the highest bit for the next group_merge_step
+            skip_first = bool(equal_mask >> (subwarp_size - 1));
+            auto prev_equal = bool(prev_equal_mask & lanemask_eq);
+            // only output an entry if the previous cols weren't equal.
+            // if they were equal, they were both handled in the
+            // previous step
+            if (valid && !prev_equal) {
+                auto c_ofs = popcnt(~prev_equal_mask & lanemask_lt);
+                c_col_idxs[c_begin + c_ofs] = c_col;
+                auto a_val =
+                    a_col <= b_col ? a_vals[a_nz + a_begin] : zero<ValueType>();
+                auto b_val =
+                    b_col <= a_col ? b_vals[b_nz + b_begin] : zero<ValueType>();
+                c_vals[c_begin + c_ofs] = alpha * a_val + beta * b_val;
+            }
+            // advance by the number of merged elements
+            // in theory, we would need to mask by `valid`, but this
+            // would only be false somwhere in the last iteration, where
+            // we don't need the value of c_begin afterwards, anyways.
+            c_begin += popcnt(~prev_equal_mask & lanemask_full);
+        });
 }
 
 

--- a/common/matrix/csr_kernels.hpp.inc
+++ b/common/matrix/csr_kernels.hpp.inc
@@ -500,8 +500,8 @@ __global__ __launch_bounds__(default_block_size) void spgeam_nnz(
     const IndexType *b_row_ptrs, const IndexType *b_col_idxs,
     IndexType num_rows, IndexType *nnz)
 {
-    auto row =
-        (threadIdx.x + blockDim.x * size_type(blockIdx.x)) / subwarp_size;
+    auto row = (threadIdx.x + blockDim.x * static_cast<size_type>(blockIdx.x)) /
+               subwarp_size;
     auto subwarp =
         group::tiled_partition<subwarp_size>(group::this_thread_block());
     if (row >= num_rows) {
@@ -533,15 +533,15 @@ __global__ __launch_bounds__(default_block_size) void spgeam(
     const IndexType *b_col_idxs, const ValueType *b_vals, IndexType num_rows,
     const IndexType *c_row_ptrs, IndexType *c_col_idxs, ValueType *c_vals)
 {
-    auto row =
-        (threadIdx.x + blockDim.x * size_type(blockIdx.x)) / subwarp_size;
+    auto row = (threadIdx.x + blockDim.x * static_cast<size_type>(blockIdx.x)) /
+               subwarp_size;
     auto subwarp =
         group::tiled_partition<subwarp_size>(group::this_thread_block());
     if (row >= num_rows) {
         return;
     }
 
-    auto lane = IndexType(subwarp.thread_rank());
+    auto lane = static_cast<IndexType>(subwarp.thread_rank());
     constexpr auto lanemask_full =
         ~config::lane_mask_type{} >> (config::warp_size - subwarp_size);
     auto lanemask_eq = config::lane_mask_type{1} << lane;

--- a/core/test/utils/assertions.hpp
+++ b/core/test/utils/assertions.hpp
@@ -215,10 +215,12 @@ template <typename MatrixData1, typename MatrixData2>
             !std::equal(fst_row_begin, fst_row_end, snd_row_begin, col_eq)) {
             auto fail = ::testing::AssertionFailure();
             fail << "Sparsity pattern differs between " << first_expression
-                 << " and " << second_expression << "\n\tIn row " << row << " "
-                 << first_expression << " has columns:\n";
+                 << " and " << second_expression << "\nIn row " << row << " "
+                 << first_expression << " has " << (fst_row_end - fst_row_begin)
+                 << " columns:\n";
             detail::print_columns(fail, fst_row_begin, fst_row_end);
-            fail << " and " << second_expression << " has columns:\n";
+            fail << "and " << second_expression << " has "
+                 << (snd_row_end - snd_row_begin) << " columns:\n";
             detail::print_columns(fail, snd_row_begin, snd_row_end);
             return fail;
         }

--- a/core/test/utils/matrix_generator.hpp
+++ b/core/test/utils/matrix_generator.hpp
@@ -238,8 +238,8 @@ std::unique_ptr<MatrixType> generate_random_triangular_matrix(
         for (size_type nz = 0; nz < nnz_in_row; ++nz) {
             auto col = col_idx[nz];
             // skip non-zeros outside triangle
-            if (col > row && lower_triangular ||
-                col < row && !lower_triangular) {
+            if ((col > row && lower_triangular) ||
+                (col < row && !lower_triangular)) {
                 continue;
             }
 

--- a/cuda/matrix/csr_kernels.cu
+++ b/cuda/matrix/csr_kernels.cu
@@ -57,6 +57,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "cuda/base/types.hpp"
 #include "cuda/components/atomic.cuh"
 #include "cuda/components/cooperative_groups.cuh"
+#include "cuda/components/intrinsics.cuh"
+#include "cuda/components/merging.cuh"
 #include "cuda/components/reduction.cuh"
 #include "cuda/components/segment_scan.cuh"
 #include "cuda/components/uninitialized_array.hpp"

--- a/hip/matrix/csr_kernels.hip.cpp
+++ b/hip/matrix/csr_kernels.hip.cpp
@@ -470,20 +470,20 @@ void spgemm(std::shared_ptr<const HipExecutor> exec,
         auto info = hipsparse::create_spgemm_info();
 
         auto alpha = one<ValueType>();
-        auto a_nnz = IndexType(a->get_num_stored_elements());
+        auto a_nnz = static_cast<IndexType>(a->get_num_stored_elements());
         auto a_vals = a->get_const_values();
         auto a_row_ptrs = a->get_const_row_ptrs();
         auto a_col_idxs = a->get_const_col_idxs();
-        auto b_nnz = IndexType(b->get_num_stored_elements());
+        auto b_nnz = static_cast<IndexType>(b->get_num_stored_elements());
         auto b_vals = b->get_const_values();
         auto b_row_ptrs = b->get_const_row_ptrs();
         auto b_col_idxs = b->get_const_col_idxs();
         auto null_value = static_cast<ValueType *>(nullptr);
         auto null_index = static_cast<IndexType *>(nullptr);
         auto zero_nnz = IndexType{};
-        auto m = IndexType(a->get_size()[0]);
-        auto n = IndexType(b->get_size()[1]);
-        auto k = IndexType(a->get_size()[1]);
+        auto m = static_cast<IndexType>(a->get_size()[0]);
+        auto n = static_cast<IndexType>(b->get_size()[1]);
+        auto k = static_cast<IndexType>(a->get_size()[1]);
         auto c_row_ptrs = c->get_row_ptrs();
         matrix::CsrBuilder<ValueType, IndexType> c_builder{c};
         auto &c_col_idxs_array = c_builder.get_col_idx_array();
@@ -540,7 +540,7 @@ void spgeam(syn::value_list<int, subwarp_size>,
             const IndexType *b_row_ptrs, const IndexType *b_col_idxs,
             const ValueType *b_vals, matrix::Csr<ValueType, IndexType> *c)
 {
-    auto m = IndexType(c->get_size()[0]);
+    auto m = static_cast<IndexType>(c->get_size()[0]);
     auto c_row_ptrs = c->get_row_ptrs();
     // count nnz for alpha * A + beta * B
     auto subwarps_per_block = default_block_size / subwarp_size;
@@ -594,11 +594,11 @@ void advanced_spgemm(std::shared_ptr<const HipExecutor> exec,
         auto d_descr = hipsparse::create_mat_descr();
         auto info = hipsparse::create_spgemm_info();
 
-        auto a_nnz = IndexType(a->get_num_stored_elements());
+        auto a_nnz = static_cast<IndexType>(a->get_num_stored_elements());
         auto a_vals = a->get_const_values();
         auto a_row_ptrs = a->get_const_row_ptrs();
         auto a_col_idxs = a->get_const_col_idxs();
-        auto b_nnz = IndexType(b->get_num_stored_elements());
+        auto b_nnz = static_cast<IndexType>(b->get_num_stored_elements());
         auto b_vals = b->get_const_values();
         auto b_row_ptrs = b->get_const_row_ptrs();
         auto b_col_idxs = b->get_const_col_idxs();
@@ -608,16 +608,16 @@ void advanced_spgemm(std::shared_ptr<const HipExecutor> exec,
         auto null_value = static_cast<ValueType *>(nullptr);
         auto null_index = static_cast<IndexType *>(nullptr);
         auto one_value = one<ValueType>();
-        auto m = IndexType(a->get_size()[0]);
-        auto n = IndexType(b->get_size()[1]);
-        auto k = IndexType(a->get_size()[1]);
+        auto m = static_cast<IndexType>(a->get_size()[0]);
+        auto n = static_cast<IndexType>(b->get_size()[1]);
+        auto k = static_cast<IndexType>(a->get_size()[1]);
 
         // allocate buffer
         size_type buffer_size{};
         hipsparse::spgemm_buffer_size(
             handle, m, n, k, &one_value, a_descr, a_nnz, a_row_ptrs, a_col_idxs,
             b_descr, b_nnz, b_row_ptrs, b_col_idxs, null_value, d_descr,
-            IndexType(0), null_index, null_index, info, buffer_size);
+            IndexType{}, null_index, null_index, info, buffer_size);
         Array<char> buffer_array(exec, buffer_size);
         auto buffer = buffer_array.get_data();
 
@@ -627,7 +627,7 @@ void advanced_spgemm(std::shared_ptr<const HipExecutor> exec,
         IndexType c_nnz{};
         hipsparse::spgemm_nnz(
             handle, m, n, k, a_descr, a_nnz, a_row_ptrs, a_col_idxs, b_descr,
-            b_nnz, b_row_ptrs, b_col_idxs, d_descr, IndexType(0), null_index,
+            b_nnz, b_row_ptrs, b_col_idxs, d_descr, IndexType{}, null_index,
             null_index, c_descr, c_tmp_row_ptrs, &c_nnz, info, buffer);
 
         // accumulate non-zeros for A * B
@@ -638,7 +638,7 @@ void advanced_spgemm(std::shared_ptr<const HipExecutor> exec,
         hipsparse::spgemm(handle, m, n, k, &one_value, a_descr, a_nnz, a_vals,
                           a_row_ptrs, a_col_idxs, b_descr, b_nnz, b_vals,
                           b_row_ptrs, b_col_idxs, null_value, d_descr,
-                          IndexType(0), null_value, null_index, null_index,
+                          IndexType{}, null_value, null_index, null_index,
                           c_descr, c_tmp_vals, c_tmp_row_ptrs, c_tmp_col_idxs,
                           info, buffer);
 


### PR DESCRIPTION
Lo and behold, the `group_merge` implementation has a tiny but nasty Guttenbug, which this PR fixes.
I found it when testing the HIP spgeam for advanced spgemm, which this PR also adds.
Finally, this PR improves the test reporting for mismatching sparsity patterns and fixes a small compiler warning in the test utils.