### PR TITLE
Extract thread ID computation from GPU kernels

### DIFF
--- a/common/components/prefix_sum.hpp.inc
+++ b/common/components/prefix_sum.hpp.inc
@@ -50,7 +50,7 @@ __global__ __launch_bounds__(block_size) void start_prefix_sum(
     size_type num_elements, ValueType *__restrict__ elements,
     ValueType *__restrict__ block_sum)
 {
-    const auto tidx = threadIdx.x + blockDim.x * blockIdx.x;
+    const auto tidx = thread::get_thread_id_flat();
     const auto element_id = threadIdx.x;
     __shared__ size_type prefix_helper[block_size];
     prefix_helper[element_id] =
@@ -113,7 +113,7 @@ __global__ __launch_bounds__(block_size) void finalize_prefix_sum(
     size_type num_elements, ValueType *__restrict__ elements,
     const ValueType *__restrict__ block_sum)
 {
-    const auto tidx = threadIdx.x + blockIdx.x * blockDim.x;
+    const auto tidx = thread::get_thread_id_flat();
 
     if (tidx < num_elements) {
         ValueType prefix_block_sum = zero<ValueType>();

--- a/common/components/reduction.hpp.inc
+++ b/common/components/reduction.hpp.inc
@@ -142,7 +142,7 @@ __device__ void reduce_array(size_type size,
                              ValueType *__restrict__ result,
                              Operator reduce_op = Operator{})
 {
-    const auto tidx = threadIdx.x + blockIdx.x * blockDim.x;
+    const auto tidx = thread::get_thread_id_flat<size_type>();
     auto thread_result = zero<ValueType>();
     for (auto i = tidx; i < size; i += blockDim.x * gridDim.x) {
         thread_result = reduce_op(thread_result, source[i]);

--- a/common/components/reduction.hpp.inc
+++ b/common/components/reduction.hpp.inc
@@ -142,7 +142,7 @@ __device__ void reduce_array(size_type size,
                              ValueType *__restrict__ result,
                              Operator reduce_op = Operator{})
 {
-    const auto tidx = thread::get_thread_id_flat<size_type>();
+    const auto tidx = thread::get_thread_id_flat();
     auto thread_result = zero<ValueType>();
     for (auto i = tidx; i < size; i += blockDim.x * gridDim.x) {
         thread_result = reduce_op(thread_result, source[i]);

--- a/common/components/thread_ids.hpp.inc
+++ b/common/components/thread_ids.hpp.inc
@@ -193,3 +193,80 @@ __device__ __forceinline__ size_type get_thread_id()
     return get_subwarp_id<subwarp_size, warps_per_block>() * subwarp_size +
            threadIdx.x;
 }
+
+
+/**
+ * @internal
+ *
+ * Returns the global ID of the thread in the given index type.
+ * This function assumes one-dimensional thread and block indexing.
+ *
+ * @return the global ID of the thread in the given index type.
+ *
+ * @tparam IndexType  the index type
+ */
+template <typename IndexType = size_type>
+__device__ __forceinline__ IndexType get_thread_id_flat()
+{
+    return threadIdx.x + static_cast<IndexType>(blockDim.x) * blockIdx.x;
+}
+
+
+/**
+ * @internal
+ *
+ * Returns the total number of threads in the given index type.
+ * This function assumes one-dimensional thread and block indexing.
+ *
+ * @return the total number of threads in the given index type.
+ *
+ * @tparam IndexType  the index type
+ */
+template <typename IndexType = size_type>
+__device__ __forceinline__ IndexType get_thread_num_flat()
+{
+    return blockDim.x * static_cast<IndexType>(gridDim.x);
+}
+
+
+/**
+ * @internal
+ *
+ * Returns the global ID of the subwarp in the given index type.
+ * This function assumes one-dimensional thread and block indexing
+ * with a power of two block size of at least subwarp_size.
+ *
+ * @return the global ID of the subwarp in the given index type.
+ *
+ * @tparam subwarp_size  the size of the subwarp. Must be a power of two!
+ * @tparam IndexType  the index type
+ */
+template <int subwarp_size, typename IndexType = size_type>
+__device__ __forceinline__ IndexType get_subwarp_id_flat()
+{
+    static_assert(!(subwarp_size & (subwarp_size - 1)),
+                  "subwarp_size must be a power of two");
+    return threadIdx.x / subwarp_size +
+           static_cast<IndexType>(blockDim.x / subwarp_size) * blockIdx.x;
+}
+
+
+/**
+ * @internal
+ *
+ * Returns the total number of subwarps in the given index type.
+ * This function assumes one-dimensional thread and block indexing
+ * with a power of two block size of at least subwarp_size.
+ *
+ * @return the total number of subwarps in the given index type.
+ *
+ * @tparam subwarp_size  the size of the subwarp. Must be a power of two!
+ * @tparam IndexType  the index type
+ */
+template <int subwarp_size, typename IndexType = size_type>
+__device__ __forceinline__ IndexType get_subwarp_num_flat()
+{
+    static_assert(!(subwarp_size & (subwarp_size - 1)),
+                  "subwarp_size must be a power of two");
+    return blockDim.x / subwarp_size * static_cast<IndexType>(gridDim.x);
+}

--- a/common/components/zero_array.hpp.inc
+++ b/common/components/zero_array.hpp.inc
@@ -38,8 +38,7 @@ template <typename ValueType>
 __global__ __launch_bounds__(default_block_size) void zero_array(
     size_type n, ValueType *__restrict__ array)
 {
-    const auto tidx =
-        static_cast<size_type>(blockDim.x) * blockIdx.x + threadIdx.x;
+    const auto tidx = thread::get_thread_id_flat();
     if (tidx < n) {
         array[tidx] = zero<ValueType>();
     }

--- a/common/factorization/par_ilu_kernels.hpp.inc
+++ b/common/factorization/par_ilu_kernels.hpp.inc
@@ -93,18 +93,17 @@ __global__
         IndexType *__restrict__ elements_to_add_per_row,
         bool *__restrict__ changes_required)
 {
-    const auto total_thread_count =
-        static_cast<size_type>(blockDim.x) * gridDim.x / SubwarpSize;
-    const auto tidx =
-        threadIdx.x + static_cast<size_type>(blockIdx.x) * blockDim.x;
-    const auto begin_row = static_cast<IndexType>(tidx / SubwarpSize);
+    const auto total_subwarp_count =
+        thread::get_subwarp_num_flat<SubwarpSize, IndexType>();
+    const auto begin_row =
+        thread::get_subwarp_id_flat<SubwarpSize, IndexType>();
 
     auto thread_block = group::this_thread_block();
     auto subwarp_grp = group::tiled_partition<SubwarpSize>(thread_block);
     const auto subwarp_idx = subwarp_grp.thread_rank();
 
     bool local_change{false};
-    for (IndexType row = begin_row; row < num_rows; row += total_thread_count) {
+    for (auto row = begin_row; row < num_rows; row += total_subwarp_count) {
         if (row >= num_cols) {
             if (subwarp_idx == 0) {
                 elements_to_add_per_row[row] = 0;
@@ -145,17 +144,16 @@ __global__
         const IndexType *__restrict__ row_ptrs_addition)
 {
     // Precaution in case not enough threads were created
-    const auto total_thread_count =
-        static_cast<size_type>(blockDim.x) * gridDim.x / SubwarpSize;
-    const auto tidx =
-        threadIdx.x + static_cast<size_type>(blockIdx.x) * blockDim.x;
-    const auto begin_row = static_cast<IndexType>(tidx / SubwarpSize);
+    const auto total_subwarp_count =
+        thread::get_subwarp_num_flat<SubwarpSize, IndexType>();
+    const auto begin_row =
+        thread::get_subwarp_id_flat<SubwarpSize, IndexType>();
 
     auto thread_block = group::this_thread_block();
     auto subwarp_grp = group::tiled_partition<SubwarpSize>(thread_block);
     const auto subwarp_idx = subwarp_grp.thread_rank();
 
-    for (IndexType row = begin_row; row < num_rows; row += total_thread_count) {
+    for (auto row = begin_row; row < num_rows; row += total_subwarp_count) {
         const IndexType old_row_start{old_row_ptrs[row]};
         const IndexType old_row_end{old_row_ptrs[row + 1]};
         const IndexType new_row_start{old_row_start + row_ptrs_addition[row]};
@@ -223,12 +221,10 @@ __global__ __launch_bounds__(default_block_size) void update_row_ptrs(
     IndexType num_rows, IndexType *__restrict__ row_ptrs,
     IndexType *__restrict__ row_ptr_addition)
 {
-    const auto total_thread_count =
-        static_cast<size_type>(blockDim.x) * gridDim.x;
-    const auto begin_row =
-        threadIdx.x + static_cast<size_type>(blockIdx.x) * blockDim.x;
+    const auto total_thread_count = thread::get_thread_num_flat<IndexType>();
+    const auto begin_row = thread::get_thread_id_flat<IndexType>();
 
-    for (IndexType row = begin_row; row < num_rows; row += total_thread_count) {
+    for (auto row = begin_row; row < num_rows; row += total_thread_count) {
         row_ptrs[row] += row_ptr_addition[row];
     }
 }
@@ -241,7 +237,7 @@ __global__ __launch_bounds__(default_block_size) void count_nnz_per_l_u_row(
     const ValueType *__restrict__ values, IndexType *__restrict__ l_nnz_row,
     IndexType *__restrict__ u_nnz_row)
 {
-    const auto row = blockDim.x * blockIdx.x + threadIdx.x;
+    const auto row = thread::get_thread_id_flat<IndexType>();
     if (row < num_rows) {
         IndexType l_row_nnz{};
         IndexType u_row_nnz{};
@@ -266,7 +262,7 @@ __global__ __launch_bounds__(default_block_size) void initialize_l_u(
     const IndexType *__restrict__ u_row_ptrs,
     IndexType *__restrict__ u_col_idxs, ValueType *__restrict__ u_values)
 {
-    const auto row = blockDim.x * blockIdx.x + threadIdx.x;
+    const auto row = thread::get_thread_id_flat<IndexType>();
     if (row < num_rows) {
         auto l_idx = l_row_ptrs[row];
         auto u_idx = u_row_ptrs[row];
@@ -298,7 +294,7 @@ __global__ __launch_bounds__(default_block_size) void compute_l_u_factors(
     const IndexType *__restrict__ u_row_ptrs,
     const IndexType *__restrict__ u_col_idxs, ValueType *__restrict__ u_values)
 {
-    const auto elem_id = blockDim.x * blockIdx.x + threadIdx.x;
+    const auto elem_id = thread::get_thread_id_flat<IndexType>();
     if (elem_id < num_elements) {
         const auto row = row_idxs[elem_id];
         const auto col = col_idxs[elem_id];

--- a/common/matrix/coo_kernels.hpp.inc
+++ b/common/matrix/coo_kernels.hpp.inc
@@ -228,7 +228,7 @@ __global__ __launch_bounds__(default_block_size) void convert_row_idxs_to_ptrs(
     const IndexType *__restrict__ idxs, size_type num_nonzeros,
     IndexType *__restrict__ ptrs, size_type length)
 {
-    const auto tidx = threadIdx.x + blockIdx.x * blockDim.x;
+    const auto tidx = thread::get_thread_id_flat();
 
     if (tidx == 0) {
         ptrs[0] = 0;
@@ -265,7 +265,7 @@ __global__ __launch_bounds__(default_block_size) void fill_in_dense(
     const ValueType *__restrict__ values, size_type stride,
     ValueType *__restrict__ result)
 {
-    const auto tidx = threadIdx.x + blockDim.x * blockIdx.x;
+    const auto tidx = thread::get_thread_id_flat();
     if (tidx < nnz) {
         result[stride * row_idxs[tidx] + col_idxs[tidx]] = values[tidx];
     }

--- a/common/matrix/csr_kernels.hpp.inc
+++ b/common/matrix/csr_kernels.hpp.inc
@@ -222,7 +222,7 @@ template <typename ValueType>
 __global__ __launch_bounds__(default_block_size) void set_zero(
     const size_type nnz, ValueType *__restrict__ val)
 {
-    const auto ind = size_type(blockDim.x) * blockIdx.x + threadIdx.x;
+    const auto ind = thread::get_thread_id_flat();
     if (ind < nnz) {
         val[ind] = zero<ValueType>();
     }
@@ -438,19 +438,19 @@ __device__ void device_classical_spmv(const size_type num_rows,
                                       ValueType *__restrict__ c,
                                       const size_type c_stride, Closure scale)
 {
-    const auto tid = size_type(blockDim.x) * blockIdx.x + threadIdx.x;
-    const auto subrow = size_type(gridDim.x) * blockDim.x / subwarp_size;
-    const auto subid = tid % subwarp_size;
+    auto subwarp_tile =
+        group::tiled_partition<subwarp_size>(group::this_thread_block());
+    const auto subrow = thread::get_subwarp_num_flat<subwarp_size>();
+    const auto subid = subwarp_tile.thread_rank();
     const auto column_id = blockIdx.y;
-    for (auto row = tid / subwarp_size; row < num_rows; row += subrow) {
+    auto row = thread::get_subwarp_id_flat<subwarp_size>();
+    for (; row < num_rows; row += subrow) {
         const auto ind_end = row_ptrs[row + 1];
         ValueType temp_val = zero<ValueType>();
         for (auto ind = row_ptrs[row] + subid; ind < ind_end;
              ind += subwarp_size) {
             temp_val += val[ind] * b[col_idxs[ind] * b_stride + column_id];
         }
-        auto subwarp_tile =
-            group::tiled_partition<subwarp_size>(group::this_thread_block());
         auto subwarp_result = reduce(
             subwarp_tile, temp_val,
             [](const ValueType &a, const ValueType &b) { return a + b; });
@@ -500,8 +500,7 @@ __global__ __launch_bounds__(default_block_size) void spgeam_nnz(
     const IndexType *b_row_ptrs, const IndexType *b_col_idxs,
     IndexType num_rows, IndexType *nnz)
 {
-    auto row = (threadIdx.x + blockDim.x * static_cast<size_type>(blockIdx.x)) /
-               subwarp_size;
+    auto row = thread::get_subwarp_id_flat<subwarp_size, IndexType>();
     auto subwarp =
         group::tiled_partition<subwarp_size>(group::this_thread_block());
     if (row >= num_rows) {
@@ -533,8 +532,7 @@ __global__ __launch_bounds__(default_block_size) void spgeam(
     const IndexType *b_col_idxs, const ValueType *b_vals, IndexType num_rows,
     const IndexType *c_row_ptrs, IndexType *c_col_idxs, ValueType *c_vals)
 {
-    auto row = (threadIdx.x + blockDim.x * static_cast<size_type>(blockIdx.x)) /
-               subwarp_size;
+    auto row = thread::get_subwarp_id_flat<subwarp_size, IndexType>();
     auto subwarp =
         group::tiled_partition<subwarp_size>(group::this_thread_block());
     if (row >= num_rows) {
@@ -591,7 +589,7 @@ __global__ __launch_bounds__(default_block_size) void convert_row_ptrs_to_idxs(
     size_type num_rows, const IndexType *__restrict__ ptrs,
     IndexType *__restrict__ idxs)
 {
-    const auto tidx = threadIdx.x + blockDim.x * blockIdx.x;
+    const auto tidx = thread::get_thread_id_flat();
     if (tidx < num_rows) {
         for (auto i = ptrs[tidx]; i < ptrs[tidx + 1]; i++) {
             idxs[i] = tidx;
@@ -620,7 +618,7 @@ __global__ __launch_bounds__(default_block_size) void fill_in_dense(
     const ValueType *__restrict__ values, size_type stride,
     ValueType *__restrict__ result)
 {
-    const auto tidx = threadIdx.x + blockDim.x * blockIdx.x;
+    const auto tidx = thread::get_thread_id_flat();
     if (tidx < num_rows) {
         for (auto i = row_ptrs[tidx]; i < row_ptrs[tidx + 1]; i++) {
             result[stride * tidx + col_idxs[i]] = values[i];
@@ -634,7 +632,7 @@ __global__ __launch_bounds__(default_block_size) void calculate_nnz_per_row(
     size_type num_rows, const IndexType *__restrict__ row_ptrs,
     size_type *__restrict__ nnz_per_row)
 {
-    const auto tidx = threadIdx.x + blockIdx.x * blockDim.x;
+    const auto tidx = thread::get_thread_id_flat();
     if (tidx < num_rows) {
         nnz_per_row[tidx] = row_ptrs[tidx + 1] - row_ptrs[tidx];
     }
@@ -685,7 +683,7 @@ __global__ __launch_bounds__(default_block_size) void fill_in_sellp(
     IndexType *__restrict__ result_col_idxs,
     ValueType *__restrict__ result_values)
 {
-    const auto global_row = threadIdx.x + blockIdx.x * blockDim.x;
+    const auto global_row = thread::get_thread_id_flat();
     const auto row = global_row % slice_size;
     const auto sliceid = global_row / slice_size;
 
@@ -714,7 +712,7 @@ __global__ __launch_bounds__(default_block_size) void initialize_zero_ell(
     size_type max_nnz_per_row, size_type stride, ValueType *__restrict__ values,
     IndexType *__restrict__ col_idxs)
 {
-    const auto tidx = threadIdx.x + blockIdx.x * blockDim.x;
+    const auto tidx = thread::get_thread_id_flat();
 
     if (tidx < stride * max_nnz_per_row) {
         values[tidx] = zero<ValueType>();
@@ -732,10 +730,9 @@ __global__ __launch_bounds__(default_block_size) void fill_in_ell(
     ValueType *__restrict__ result_values,
     IndexType *__restrict__ result_col_idxs)
 {
-    const auto tidx = threadIdx.x + blockIdx.x * blockDim.x;
     constexpr auto warp_size = config::warp_size;
-    const auto row = tidx / warp_size;
-    const auto local_tidx = tidx % warp_size;
+    const auto row = thread::get_subwarp_id_flat<warp_size>();
+    const auto local_tidx = threadIdx.x % warp_size;
 
     if (row < num_rows) {
         for (size_type i = local_tidx;
@@ -754,10 +751,11 @@ __global__ __launch_bounds__(default_block_size) void reduce_max_nnz_per_slice(
     size_type num_rows, size_type slice_size, size_type stride_factor,
     const size_type *__restrict__ nnz_per_row, size_type *__restrict__ result)
 {
-    const auto tidx = threadIdx.x + blockIdx.x * blockDim.x;
     constexpr auto warp_size = config::warp_size;
-    const auto warpid = tidx / warp_size;
-    const auto tid_in_warp = tidx % warp_size;
+    auto warp_tile =
+        group::tiled_partition<warp_size>(group::this_thread_block());
+    const auto warpid = thread::get_subwarp_id_flat<warp_size>();
+    const auto tid_in_warp = warp_tile.thread_rank();
     const auto slice_num = ceildiv(num_rows, slice_size);
 
     size_type thread_result = 0;
@@ -767,9 +765,6 @@ __global__ __launch_bounds__(default_block_size) void reduce_max_nnz_per_slice(
                 max(thread_result, nnz_per_row[warpid * slice_size + i]);
         }
     }
-
-    auto warp_tile =
-        group::tiled_partition<warp_size>(group::this_thread_block());
     auto warp_result = reduce(
         warp_tile, thread_result,
         [](const size_type &a, const size_type &b) { return max(a, b); });
@@ -818,7 +813,7 @@ __global__
         IndexType *__restrict__ csr_row_idxs,
         size_type *__restrict__ coo_row_nnz)
 {
-    const auto tidx = threadIdx.x + blockIdx.x * blockDim.x;
+    const auto tidx = thread::get_thread_id_flat();
     if (tidx < num_rows) {
         const size_type csr_nnz = csr_row_idxs[tidx + 1] - csr_row_idxs[tidx];
         coo_row_nnz[tidx] =
@@ -840,10 +835,9 @@ __global__ __launch_bounds__(default_block_size) void fill_in_hybrid(
     IndexType *__restrict__ result_coo_col,
     IndexType *__restrict__ result_coo_row)
 {
-    const auto tidx = threadIdx.x + blockIdx.x * blockDim.x;
     constexpr auto warp_size = config::warp_size;
-    const auto row = tidx / warp_size;
-    const auto local_tidx = tidx % warp_size;
+    const auto row = thread::get_subwarp_id_flat<warp_size>();
+    const auto local_tidx = threadIdx.x % warp_size;
 
     if (row < num_rows) {
         for (size_type i = local_tidx;
@@ -876,7 +870,7 @@ template <typename ValueType>
 __global__ __launch_bounds__(default_block_size) void conjugate_kernel(
     size_type num_nonzeros, ValueType *__restrict__ val)
 {
-    const auto tidx = size_type(blockIdx.x) * default_block_size + threadIdx.x;
+    const auto tidx = thread::get_thread_id_flat();
 
     if (tidx < num_nonzeros) {
         val[tidx] = conj(val[tidx]);

--- a/common/matrix/dense_kernels.hpp.inc
+++ b/common/matrix/dense_kernels.hpp.inc
@@ -128,8 +128,7 @@ template <typename ValueType>
 __global__ __launch_bounds__(default_block_size) void compute_sqrt(
     size_type num_cols, ValueType *__restrict__ work)
 {
-    const auto tidx =
-        static_cast<size_type>(blockDim.x) * blockIdx.x + threadIdx.x;
+    const auto tidx = thread::get_thread_id_flat();
     if (tidx < num_cols) {
         work[tidx] = sqrt(abs(work[tidx]));
     }
@@ -143,7 +142,7 @@ __global__ __launch_bounds__(default_block_size) void fill_in_coo(
     const ValueType *__restrict__ source, IndexType *__restrict__ row_idxs,
     IndexType *__restrict__ col_idxs, ValueType *__restrict__ values)
 {
-    const auto tidx = threadIdx.x + blockDim.x * blockIdx.x;
+    const auto tidx = thread::get_thread_id_flat();
     if (tidx < num_rows) {
         size_type write_to = row_ptrs[tidx];
 
@@ -165,19 +164,17 @@ __global__ __launch_bounds__(default_block_size) void count_nnz_per_row(
     const ValueType *__restrict__ work, IndexType *__restrict__ result)
 {
     constexpr auto warp_size = config::warp_size;
-    const auto tidx = threadIdx.x + blockIdx.x * blockDim.x;
-    const auto row_idx = tidx / warp_size;
+    const auto row_idx = thread::get_subwarp_id_flat<warp_size>();
+    auto warp_tile =
+        group::tiled_partition<warp_size>(group::this_thread_block());
 
     if (row_idx < num_rows) {
         IndexType part_result{};
-        for (auto i = threadIdx.x % warp_size; i < num_cols; i += warp_size) {
+        for (auto i = warp_tile.thread_rank(); i < num_cols; i += warp_size) {
             if (work[stride * row_idx + i] != zero<ValueType>()) {
                 part_result += 1;
             }
         }
-
-        auto warp_tile =
-            group::tiled_partition<warp_size>(group::this_thread_block());
         result[row_idx] = reduce(
             warp_tile, part_result,
             [](const size_type &a, const size_type &b) { return a + b; });
@@ -191,7 +188,7 @@ __global__ __launch_bounds__(default_block_size) void fill_in_csr(
     const ValueType *__restrict__ source, IndexType *__restrict__ row_ptrs,
     IndexType *__restrict__ col_idxs, ValueType *__restrict__ values)
 {
-    const auto tidx = threadIdx.x + blockDim.x * blockIdx.x;
+    const auto tidx = thread::get_thread_id_flat();
 
     if (tidx < num_rows) {
         auto write_to = row_ptrs[tidx];
@@ -213,7 +210,7 @@ __global__ __launch_bounds__(default_block_size) void fill_in_ell(
     size_type result_stride, IndexType *__restrict__ col_ptrs,
     ValueType *__restrict__ values)
 {
-    const auto tidx = threadIdx.x + blockDim.x * blockIdx.x;
+    const auto tidx = thread::get_thread_id_flat();
     if (tidx < num_rows) {
         IndexType col_idx = 0;
         for (size_type col = 0; col < num_cols; col++) {
@@ -278,7 +275,7 @@ __global__ __launch_bounds__(default_block_size) void fill_in_sellp(
     size_type *__restrict__ slice_lengths, size_type *__restrict__ slice_sets,
     IndexType *__restrict__ col_idxs, ValueType *__restrict__ vals)
 {
-    const auto global_row = threadIdx.x + blockIdx.x * blockDim.x;
+    const auto global_row = thread::get_thread_id_flat();
     const auto row = global_row % slice_size;
     const auto sliceid = global_row / slice_size;
 
@@ -324,10 +321,11 @@ __global__ __launch_bounds__(default_block_size) void reduce_max_nnz_per_slice(
     size_type num_rows, size_type slice_size, size_type stride_factor,
     const size_type *__restrict__ nnz_per_row, size_type *__restrict__ result)
 {
-    const auto tidx = threadIdx.x + blockIdx.x * blockDim.x;
     constexpr auto warp_size = config::warp_size;
-    const auto warpid = tidx / warp_size;
-    const auto tid_in_warp = tidx % warp_size;
+    auto warp_tile =
+        group::tiled_partition<warp_size>(group::this_thread_block());
+    const auto warpid = thread::get_subwarp_id_flat<warp_size>();
+    const auto tid_in_warp = warp_tile.thread_rank();
     const auto slice_num = ceildiv(num_rows, slice_size);
 
     size_type thread_result = 0;
@@ -338,8 +336,6 @@ __global__ __launch_bounds__(default_block_size) void reduce_max_nnz_per_slice(
         }
     }
 
-    auto warp_tile =
-        group::tiled_partition<warp_size>(group::this_thread_block());
     auto warp_result = reduce(
         warp_tile, thread_result,
         [](const size_type &a, const size_type &b) { return max(a, b); });

--- a/common/matrix/ell_kernels.hpp.inc
+++ b/common/matrix/ell_kernels.hpp.inc
@@ -43,8 +43,7 @@ __device__ void spmv_kernel(
     const ValueType *__restrict__ b, const size_type b_stride,
     ValueType *__restrict__ c, const size_type c_stride, Closure op)
 {
-    const auto tidx =
-        static_cast<size_type>(blockDim.x) * blockIdx.x + threadIdx.x;
+    const auto tidx = thread::get_thread_id_flat();
     const auto column_id = blockIdx.y;
     if (num_thread_per_worker == 1) {
         // Specialize the num_thread_per_worker = 1. It doesn't need the shared
@@ -77,7 +76,8 @@ __device__ void spmv_kernel(
             }
             __syncthreads();
             ValueType temp = zero<ValueType>();
-            for (size_type idx = worker_id * num_thread_per_worker + idx_in_worker;
+            for (size_type idx =
+                     worker_id * num_thread_per_worker + idx_in_worker;
                  idx < num_stored_elements_per_row; idx += step_size) {
                 const auto ind = x + idx * stride;
                 const auto col_idx = col[ind];
@@ -176,7 +176,7 @@ __global__ __launch_bounds__(default_block_size) void fill_in_dense(
     const ValueType *__restrict__ values, size_type result_stride,
     ValueType *__restrict__ result)
 {
-    const auto tidx = threadIdx.x + blockIdx.x * blockDim.x;
+    const auto tidx = thread::get_thread_id_flat();
     if (tidx < num_rows) {
         for (auto col = 0; col < nnz; col++) {
             result[tidx * result_stride +
@@ -193,20 +193,18 @@ __global__ __launch_bounds__(default_block_size) void count_nnz_per_row(
     const ValueType *__restrict__ values, IndexType *__restrict__ result)
 {
     constexpr auto warp_size = config::warp_size;
-    const auto tidx = threadIdx.x + blockIdx.x * blockDim.x;
-    const auto row_idx = tidx / warp_size;
+    const auto row_idx = thread::get_subwarp_id_flat<warp_size>();
+    auto warp_tile =
+        group::tiled_partition<warp_size>(group::this_thread_block());
 
     if (row_idx < num_rows) {
         IndexType part_result{};
-        for (auto i = threadIdx.x % warp_size; i < max_nnz_per_row;
+        for (auto i = warp_tile.thread_rank(); i < max_nnz_per_row;
              i += warp_size) {
             if (values[stride * i + row_idx] != zero<ValueType>()) {
                 part_result += 1;
             }
         }
-
-        auto warp_tile =
-            group::tiled_partition<warp_size>(group::this_thread_block());
         result[row_idx] = reduce(
             warp_tile, part_result,
             [](const size_type &a, const size_type &b) { return a + b; });
@@ -223,7 +221,7 @@ __global__ __launch_bounds__(default_block_size) void fill_in_csr(
     IndexType *__restrict__ result_col_idxs,
     ValueType *__restrict__ result_values)
 {
-    const auto tidx = threadIdx.x + blockDim.x * blockIdx.x;
+    const auto tidx = thread::get_thread_id_flat();
 
     if (tidx < num_rows) {
         auto write_to = result_row_ptrs[tidx];

--- a/common/matrix/hybrid_kernels.hpp.inc
+++ b/common/matrix/hybrid_kernels.hpp.inc
@@ -104,7 +104,7 @@ __global__ __launch_bounds__(default_block_size) void fill_in_csr(
     IndexType *__restrict__ result_col_idxs,
     ValueType *__restrict__ result_values)
 {
-    const auto tidx = threadIdx.x + blockDim.x * blockIdx.x;
+    const auto tidx = thread::get_thread_id_flat();
 
     if (tidx < num_rows) {
         auto write_to = result_row_ptrs[tidx];
@@ -132,7 +132,7 @@ __global__ __launch_bounds__(default_block_size) void add(
     size_type num, ValueType1 *__restrict__ val1,
     const ValueType2 *__restrict__ val2)
 {
-    const auto tidx = threadIdx.x + blockDim.x * blockIdx.x;
+    const auto tidx = thread::get_thread_id_flat();
     if (tidx < num) {
         val1[tidx] += val2[tidx];
     }

--- a/common/matrix/sellp_kernels.hpp.inc
+++ b/common/matrix/sellp_kernels.hpp.inc
@@ -115,8 +115,7 @@ __global__ __launch_bounds__(default_block_size) void fill_in_dense(
     const IndexType *__restrict__ col_idxs,
     const ValueType *__restrict__ values, ValueType *__restrict__ result)
 {
-    const auto global_row =
-        (blockDim.x * blockIdx.x + threadIdx.x) / threads_per_row;
+    const auto global_row = thread::get_subwarp_id_flat<threads_per_row>();
     const auto row = global_row % slice_size;
     const auto slice = global_row / slice_size;
     const auto start_index = threadIdx.x % threads_per_row;
@@ -142,10 +141,11 @@ __global__ __launch_bounds__(default_block_size) void count_nnz_per_row(
     const ValueType *__restrict__ values, IndexType *__restrict__ result)
 {
     constexpr auto warp_size = config::warp_size;
-    const auto tidx = threadIdx.x + blockIdx.x * blockDim.x;
-    const auto row_idx = tidx / warp_size;
+    auto warp_tile =
+        group::tiled_partition<warp_size>(group::this_thread_block());
+    const auto row_idx = thread::get_subwarp_id_flat<warp_size>();
     const auto slice_id = row_idx / slice_size;
-    const auto tid_in_warp = tidx % warp_size;
+    const auto tid_in_warp = warp_tile.thread_rank();
     const auto row_in_slice = row_idx % slice_size;
 
     if (row_idx < num_rows) {
@@ -159,9 +159,6 @@ __global__ __launch_bounds__(default_block_size) void count_nnz_per_row(
                 part_result += 1;
             }
         }
-
-        auto warp_tile =
-            group::tiled_partition<warp_size>(group::this_thread_block());
         result[row_idx] = reduce(
             warp_tile, part_result,
             [](const size_type &a, const size_type &b) { return a + b; });
@@ -179,7 +176,7 @@ __global__ __launch_bounds__(default_block_size) void fill_in_csr(
     IndexType *__restrict__ result_col_idxs,
     ValueType *__restrict__ result_values)
 {
-    const auto row = threadIdx.x + blockIdx.x * blockDim.x;
+    const auto row = thread::get_thread_id_flat();
     const auto slice_id = row / slice_size;
     const auto row_in_slice = row % slice_size;
 

--- a/common/preconditioner/jacobi_kernels.hpp.inc
+++ b/common/preconditioner/jacobi_kernels.hpp.inc
@@ -52,11 +52,10 @@ __global__ void compare_adjacent_rows(size_type num_rows, int32 max_block_size,
                                       const IndexType *__restrict__ col_idx,
                                       bool *__restrict__ matching_next_row)
 {
-    const auto global_tid = blockDim.x * blockIdx.x + threadIdx.x;
-    const auto local_tid = threadIdx.x % config::warp_size;
-    const auto warp_id = global_tid / config::warp_size;
     const auto warp =
         group::tiled_partition<config::warp_size>(group::this_thread_block());
+    const auto local_tid = warp.thread_rank();
+    const auto warp_id = thread::get_subwarp_id_flat<config::warp_size>();
 
     if (warp_id >= num_rows - 1) {
         return;

--- a/common/solver/bicg_kernels.hpp.inc
+++ b/common/solver/bicg_kernels.hpp.inc
@@ -40,8 +40,7 @@ __global__ __launch_bounds__(default_block_size) void initialize_kernel(
     ValueType *__restrict__ q2, ValueType *__restrict__ prev_rho,
     ValueType *__restrict__ rho, stopping_status *__restrict__ stop_status)
 {
-    const auto tidx =
-        static_cast<size_type>(blockDim.x) * blockIdx.x + threadIdx.x;
+    const auto tidx = thread::get_thread_id_flat();
 
     if (tidx < num_cols) {
         rho[tidx] = zero<ValueType>();
@@ -70,8 +69,7 @@ __global__ __launch_bounds__(default_block_size) void step_1_kernel(
     const ValueType *__restrict__ rho, const ValueType *__restrict__ prev_rho,
     const stopping_status *__restrict__ stop_status)
 {
-    const auto tidx =
-        static_cast<size_type>(blockDim.x) * blockIdx.x + threadIdx.x;
+    const auto tidx = thread::get_thread_id_flat();
     const auto col = tidx % stride;
     if (col >= num_cols || tidx >= num_rows * stride ||
         stop_status[col].has_stopped()) {
@@ -96,8 +94,7 @@ __global__ __launch_bounds__(default_block_size) void step_2_kernel(
     const ValueType *__restrict__ beta, const ValueType *__restrict__ rho,
     const stopping_status *__restrict__ stop_status)
 {
-    const auto tidx =
-        static_cast<size_type>(blockDim.x) * blockIdx.x + threadIdx.x;
+    const auto tidx = thread::get_thread_id_flat();
     const auto row = tidx / stride;
     const auto col = tidx % stride;
 

--- a/common/solver/bicgstab_kernels.hpp.inc
+++ b/common/solver/bicgstab_kernels.hpp.inc
@@ -42,8 +42,7 @@ __global__ __launch_bounds__(default_block_size) void initialize_kernel(
     ValueType *__restrict__ beta, ValueType *__restrict__ gamma,
     ValueType *__restrict__ omega, stopping_status *__restrict__ stop_status)
 {
-    const auto tidx =
-        static_cast<size_type>(blockDim.x) * blockIdx.x + threadIdx.x;
+    const auto tidx = thread::get_thread_id_flat();
 
     if (tidx < num_cols) {
         prev_rho[tidx] = one<ValueType>();
@@ -77,8 +76,7 @@ __global__ __launch_bounds__(default_block_size) void step_1_kernel(
     const ValueType *__restrict__ omega,
     const stopping_status *__restrict__ stop_status)
 {
-    const auto tidx =
-        static_cast<size_type>(blockDim.x) * blockIdx.x + threadIdx.x;
+    const auto tidx = thread::get_thread_id_flat();
     const auto col = tidx % stride;
     if (col >= num_cols || tidx >= num_rows * stride ||
         stop_status[col].has_stopped()) {
@@ -101,8 +99,7 @@ __global__ __launch_bounds__(default_block_size) void step_2_kernel(
     ValueType *__restrict__ alpha, const ValueType *__restrict__ beta,
     const stopping_status *__restrict__ stop_status)
 {
-    const size_type tidx =
-        static_cast<size_type>(blockDim.x) * blockIdx.x + threadIdx.x;
+    const size_type tidx = thread::get_thread_id_flat();
     const size_type col = tidx % stride;
     if (col >= num_cols || tidx >= num_rows * stride ||
         stop_status[col].has_stopped()) {
@@ -129,8 +126,7 @@ __global__ __launch_bounds__(default_block_size) void step_3_kernel(
     const ValueType *__restrict__ gamma, ValueType *__restrict__ omega,
     const stopping_status *__restrict__ stop_status)
 {
-    const auto tidx =
-        static_cast<size_type>(blockDim.x) * blockIdx.x + threadIdx.x;
+    const auto tidx = thread::get_thread_id_flat();
     const auto row = tidx / stride;
     const auto col = tidx % stride;
     if (col >= num_cols || tidx >= num_rows * stride ||
@@ -159,8 +155,7 @@ __global__ __launch_bounds__(default_block_size) void finalize_kernel(
     const ValueType *__restrict__ y, const ValueType *__restrict__ alpha,
     stopping_status *__restrict__ stop_status)
 {
-    const auto tidx =
-        static_cast<size_type>(blockDim.x) * blockIdx.x + threadIdx.x;
+    const auto tidx = thread::get_thread_id_flat();
     const auto row = tidx / stride;
     const auto col = tidx % stride;
     if (col >= num_cols || tidx >= num_rows * stride ||

--- a/common/solver/cg_kernels.hpp.inc
+++ b/common/solver/cg_kernels.hpp.inc
@@ -38,8 +38,7 @@ __global__ __launch_bounds__(default_block_size) void initialize_kernel(
     ValueType *__restrict__ q, ValueType *__restrict__ prev_rho,
     ValueType *__restrict__ rho, stopping_status *__restrict__ stop_status)
 {
-    const auto tidx =
-        static_cast<size_type>(blockDim.x) * blockIdx.x + threadIdx.x;
+    const auto tidx = thread::get_thread_id_flat();
 
     if (tidx < num_cols) {
         rho[tidx] = zero<ValueType>();
@@ -63,8 +62,7 @@ __global__ __launch_bounds__(default_block_size) void step_1_kernel(
     const ValueType *__restrict__ rho, const ValueType *__restrict__ prev_rho,
     const stopping_status *__restrict__ stop_status)
 {
-    const auto tidx =
-        static_cast<size_type>(blockDim.x) * blockIdx.x + threadIdx.x;
+    const auto tidx = thread::get_thread_id_flat();
     const auto col = tidx % stride;
     if (col >= num_cols || tidx >= num_rows * stride ||
         stop_status[col].has_stopped()) {
@@ -84,8 +82,7 @@ __global__ __launch_bounds__(default_block_size) void step_2_kernel(
     const ValueType *__restrict__ beta, const ValueType *__restrict__ rho,
     const stopping_status *__restrict__ stop_status)
 {
-    const auto tidx =
-        static_cast<size_type>(blockDim.x) * blockIdx.x + threadIdx.x;
+    const auto tidx = thread::get_thread_id_flat();
     const auto row = tidx / stride;
     const auto col = tidx % stride;
 

--- a/common/solver/cgs_kernels.hpp.inc
+++ b/common/solver/cgs_kernels.hpp.inc
@@ -42,8 +42,7 @@ __global__ __launch_bounds__(default_block_size) void initialize_kernel(
     ValueType *__restrict__ rho_prev, ValueType *__restrict__ rho,
     stopping_status *__restrict__ stop_status)
 {
-    const auto tidx =
-        static_cast<size_type>(blockDim.x) * blockIdx.x + threadIdx.x;
+    const auto tidx = thread::get_thread_id_flat();
 
     if (tidx < num_cols) {
         rho[tidx] = zero<ValueType>();
@@ -76,8 +75,7 @@ __global__ __launch_bounds__(default_block_size) void step_1_kernel(
     const ValueType *__restrict__ rho_prev,
     const stopping_status *__restrict__ stop_status)
 {
-    const auto tidx =
-        static_cast<size_type>(blockDim.x) * blockIdx.x + threadIdx.x;
+    const auto tidx = thread::get_thread_id_flat();
     const auto col = tidx % stride;
 
     if (col >= num_cols || tidx >= num_rows * stride ||
@@ -101,8 +99,7 @@ __global__ __launch_bounds__(default_block_size) void step_2_kernel(
     const ValueType *__restrict__ gamma,
     const stopping_status *__restrict__ stop_status)
 {
-    const auto tidx =
-        static_cast<size_type>(blockDim.x) * blockIdx.x + threadIdx.x;
+    const auto tidx = thread::get_thread_id_flat();
     const auto col = tidx % stride;
 
     if (col >= num_cols || tidx >= num_rows * stride ||
@@ -125,8 +122,7 @@ __global__ __launch_bounds__(default_block_size) void step_3_kernel(
     ValueType *__restrict__ x, const ValueType *__restrict__ alpha,
     const stopping_status *__restrict__ stop_status)
 {
-    const auto tidx =
-        static_cast<size_type>(blockDim.x) * blockIdx.x + threadIdx.x;
+    const auto tidx = thread::get_thread_id_flat();
     const auto row = tidx / stride;
     const auto col = tidx % stride;
     if (col >= num_cols || tidx >= num_rows * stride ||

--- a/common/solver/fcg_kernels.hpp.inc
+++ b/common/solver/fcg_kernels.hpp.inc
@@ -39,8 +39,7 @@ __global__ __launch_bounds__(default_block_size) void initialize_kernel(
     ValueType *__restrict__ prev_rho, ValueType *__restrict__ rho,
     ValueType *__restrict__ rho_t, stopping_status *__restrict__ stop_status)
 {
-    const auto tidx =
-        static_cast<size_type>(blockDim.x) * blockIdx.x + threadIdx.x;
+    const auto tidx = thread::get_thread_id_flat();
 
     if (tidx < num_cols) {
         rho[tidx] = zero<ValueType>();
@@ -66,8 +65,7 @@ __global__ __launch_bounds__(default_block_size) void step_1_kernel(
     const ValueType *__restrict__ rho, const ValueType *__restrict__ prev_rho,
     const stopping_status *__restrict__ stop_status)
 {
-    const auto tidx =
-        static_cast<size_type>(blockDim.x) * blockIdx.x + threadIdx.x;
+    const auto tidx = thread::get_thread_id_flat();
     const auto col = tidx % stride;
     if (col >= num_cols || tidx >= num_rows * stride ||
         stop_status[col].has_stopped()) {
@@ -88,8 +86,7 @@ __global__ __launch_bounds__(default_block_size) void step_2_kernel(
     const ValueType *__restrict__ rho,
     const stopping_status *__restrict__ stop_status)
 {
-    const auto tidx =
-        static_cast<size_type>(blockDim.x) * blockIdx.x + threadIdx.x;
+    const auto tidx = thread::get_thread_id_flat();
     const auto row = tidx / stride;
     const auto col = tidx % stride;
 

--- a/common/solver/gmres_kernels.hpp.inc
+++ b/common/solver/gmres_kernels.hpp.inc
@@ -41,7 +41,7 @@ __global__ __launch_bounds__(block_size) void initialize_1_kernel(
     ValueType *__restrict__ givens_cos, size_type stride_cos,
     stopping_status *__restrict__ stop_status)
 {
-    const auto global_id = blockIdx.x * blockDim.x + threadIdx.x;
+    const auto global_id = thread::get_thread_id_flat();
 
     const auto row_idx = global_id / stride_b;
     const auto col_idx = global_id % stride_b;
@@ -73,7 +73,7 @@ __global__ __launch_bounds__(block_size) void initialize_2_1_kernel(
     ValueType *__restrict__ residual_norm_collection,
     size_type stride_residual_nc)
 {
-    const auto global_id = blockIdx.x * blockDim.x + threadIdx.x;
+    const auto global_id = thread::get_thread_id_flat();
     const auto row_idx = global_id / stride_krylov;
     const auto col_idx = global_id % stride_krylov;
 
@@ -98,7 +98,7 @@ __global__ __launch_bounds__(block_size) void initialize_2_2_kernel(
     ValueType *__restrict__ krylov_bases, size_type stride_krylov,
     size_type *__restrict__ final_iter_nums)
 {
-    const auto global_id = blockIdx.x * blockDim.x + threadIdx.x;
+    const auto global_id = thread::get_thread_id_flat();
     const auto row_idx = global_id / num_rhs;
     const auto col_idx = global_id % num_rhs;
 
@@ -120,10 +120,9 @@ __global__
         size_type *__restrict__ final_iter_nums,
         const stopping_status *__restrict__ stop_status, size_type total_number)
 {
-    const auto global_id = threadIdx.x + blockIdx.x * blockDim.x;
+    const auto global_id = thread::get_thread_id_flat();
     if (global_id < total_number) {
-        final_iter_nums[global_id] +=
-            (1 - stop_status[global_id].has_stopped());
+        final_iter_nums[global_id] += !stop_status[global_id].has_stopped();
     }
 }
 
@@ -189,7 +188,7 @@ __global__ __launch_bounds__(block_size) void update_next_krylov_kernel(
     const ValueType *__restrict__ hessenberg_iter, size_type stride_hessenberg,
     const stopping_status *__restrict__ stop_status)
 {
-    const auto global_id = blockIdx.x * blockDim.x + threadIdx.x;
+    const auto global_id = thread::get_thread_id_flat();
     const auto row_idx = global_id / stride_next_krylov;
     const auto col_idx = global_id % stride_next_krylov;
 
@@ -257,7 +256,7 @@ __global__ __launch_bounds__(block_size) void update_krylov_next_krylov_kernel(
     const ValueType *__restrict__ hessenberg_iter, size_type stride_hessenberg,
     const stopping_status *__restrict__ stop_status)
 {
-    const auto global_id = threadIdx.x + blockIdx.x * blockDim.x;
+    const auto global_id = thread::get_thread_id_flat();
     const auto row_idx = global_id / stride_next_krylov;
     const auto col_idx = global_id % stride_next_krylov;
     const auto hessenberg =
@@ -344,7 +343,7 @@ __global__ __launch_bounds__(block_size) void givens_rotation_kernel(
     const ValueType *__restrict__ b_norm,
     const stopping_status *__restrict__ stop_status)
 {
-    const auto col_idx = blockIdx.x * blockDim.x + threadIdx.x;
+    const auto col_idx = thread::get_thread_id_flat();
 
     if (col_idx >= num_cols || stop_status[col_idx].has_stopped()) {
         return;
@@ -409,7 +408,7 @@ __global__ __launch_bounds__(block_size) void solve_upper_triangular_kernel(
     ValueType *__restrict__ y, size_type stride_y,
     const size_type *__restrict__ final_iter_nums)
 {
-    const auto col_idx = blockIdx.x * blockDim.x + threadIdx.x;
+    const auto col_idx = thread::get_thread_id_flat();
 
     if (col_idx >= num_rhs) {
         return;
@@ -443,7 +442,7 @@ __global__ __launch_bounds__(block_size) void calculate_Qy_kernel(
     size_type stride_preconditioner,
     const size_type *__restrict__ final_iter_nums)
 {
-    const auto global_id = blockIdx.x * blockDim.x + threadIdx.x;
+    const auto global_id = thread::get_thread_id_flat();
     const auto row_id = global_id / stride_preconditioner;
     const auto col_id = global_id % stride_preconditioner;
 

--- a/common/solver/ir_kernels.hpp.inc
+++ b/common/solver/ir_kernels.hpp.inc
@@ -33,8 +33,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 __global__ __launch_bounds__(default_block_size) void initialize_kernel(
     size_type num_cols, stopping_status *stop_status)
 {
-    const auto tidx =
-        static_cast<size_type>(blockDim.x) * blockIdx.x + threadIdx.x;
+    const auto tidx = thread::get_thread_id_flat();
 
     if (tidx < num_cols) {
         stop_status[tidx].reset();

--- a/cuda/components/zero_array.cu
+++ b/cuda/components/zero_array.cu
@@ -33,6 +33,9 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "cuda/components/zero_array.hpp"
 
 
+#include "cuda/components/thread_ids.cuh"
+
+
 namespace gko {
 namespace kernels {
 namespace cuda {

--- a/cuda/factorization/par_ilu_kernels.cu
+++ b/cuda/factorization/par_ilu_kernels.cu
@@ -46,6 +46,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "cuda/components/cooperative_groups.cuh"
 #include "cuda/components/intrinsics.cuh"
 #include "cuda/components/searching.cuh"
+#include "cuda/components/thread_ids.cuh"
 
 
 namespace gko {

--- a/cuda/matrix/coo_kernels.cu
+++ b/cuda/matrix/coo_kernels.cu
@@ -49,6 +49,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "cuda/components/cooperative_groups.cuh"
 #include "cuda/components/format_conversion.cuh"
 #include "cuda/components/segment_scan.cuh"
+#include "cuda/components/thread_ids.cuh"
 #include "cuda/components/zero_array.hpp"
 
 

--- a/cuda/matrix/csr_kernels.cu
+++ b/cuda/matrix/csr_kernels.cu
@@ -61,6 +61,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "cuda/components/merging.cuh"
 #include "cuda/components/reduction.cuh"
 #include "cuda/components/segment_scan.cuh"
+#include "cuda/components/thread_ids.cuh"
 #include "cuda/components/uninitialized_array.hpp"
 #include "cuda/components/zero_array.hpp"
 

--- a/cuda/matrix/dense_kernels.cu
+++ b/cuda/matrix/dense_kernels.cu
@@ -48,6 +48,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "cuda/base/pointer_mode_guard.hpp"
 #include "cuda/components/cooperative_groups.cuh"
 #include "cuda/components/reduction.cuh"
+#include "cuda/components/thread_ids.cuh"
 #include "cuda/components/uninitialized_array.hpp"
 
 

--- a/cuda/matrix/ell_kernels.cu
+++ b/cuda/matrix/ell_kernels.cu
@@ -53,6 +53,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "cuda/components/cooperative_groups.cuh"
 #include "cuda/components/format_conversion.cuh"
 #include "cuda/components/reduction.cuh"
+#include "cuda/components/thread_ids.cuh"
 #include "cuda/components/zero_array.hpp"
 
 

--- a/cuda/matrix/hybrid_kernels.cu
+++ b/cuda/matrix/hybrid_kernels.cu
@@ -47,6 +47,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "cuda/components/format_conversion.cuh"
 #include "cuda/components/reduction.cuh"
 #include "cuda/components/segment_scan.cuh"
+#include "cuda/components/thread_ids.cuh"
 #include "cuda/components/zero_array.hpp"
 
 

--- a/cuda/matrix/sellp_kernels.cu
+++ b/cuda/matrix/sellp_kernels.cu
@@ -45,6 +45,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "cuda/base/cusparse_bindings.hpp"
 #include "cuda/base/types.hpp"
 #include "cuda/components/reduction.cuh"
+#include "cuda/components/thread_ids.cuh"
 
 
 namespace gko {

--- a/cuda/preconditioner/jacobi_kernels.cu
+++ b/cuda/preconditioner/jacobi_kernels.cu
@@ -57,7 +57,7 @@ namespace {
 
 
 // a total of 32 warps (1024 threads)
-constexpr int default_block_size = 32;
+constexpr int default_num_warps = 32;
 // with current architectures, at most 32 warps can be scheduled per SM (and
 // current GPUs have at most 84 SMs)
 constexpr int default_grid_size = 32 * 32 * 128;
@@ -112,11 +112,11 @@ void initialize_precisions(std::shared_ptr<const CudaExecutor> exec,
                            const Array<precision_reduction> &source,
                            Array<precision_reduction> &precisions)
 {
-    const auto block_size = default_block_size * config::warp_size;
+    const auto block_size = default_num_warps * config::warp_size;
     const auto grid_size = min(
         default_grid_size,
         static_cast<int32>(ceildiv(precisions.get_num_elems(), block_size)));
-    duplicate_array<default_block_size><<<grid_size, block_size>>>(
+    duplicate_array<default_num_warps><<<grid_size, block_size>>>(
         source.get_const_data(), source.get_num_elems(), precisions.get_data(),
         precisions.get_num_elems());
 }

--- a/cuda/preconditioner/jacobi_kernels.cu
+++ b/cuda/preconditioner/jacobi_kernels.cu
@@ -41,6 +41,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "cuda/base/math.hpp"
 #include "cuda/base/types.hpp"
 #include "cuda/components/cooperative_groups.cuh"
+#include "cuda/components/thread_ids.cuh"
 
 
 namespace gko {

--- a/cuda/preconditioner/jacobi_kernels.cu
+++ b/cuda/preconditioner/jacobi_kernels.cu
@@ -76,7 +76,7 @@ size_type find_natural_blocks(std::shared_ptr<const CudaExecutor> exec,
 
     Array<bool> matching_next_row(exec, mtx->get_size()[0] - 1);
 
-    const dim3 block_size(default_block_size, 1, 1);
+    const dim3 block_size(config::warp_size, 1, 1);
     const dim3 grid_size(
         ceildiv(mtx->get_size()[0] * config::warp_size, block_size.x), 1, 1);
     compare_adjacent_rows<<<grid_size, block_size, 0, 0>>>(

--- a/cuda/solver/bicg_kernels.cu
+++ b/cuda/solver/bicg_kernels.cu
@@ -39,6 +39,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "cuda/base/math.hpp"
 #include "cuda/base/types.hpp"
+#include "cuda/components/thread_ids.cuh"
 
 
 namespace gko {

--- a/cuda/solver/bicgstab_kernels.cu
+++ b/cuda/solver/bicgstab_kernels.cu
@@ -39,6 +39,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "cuda/base/math.hpp"
 #include "cuda/base/types.hpp"
+#include "cuda/components/thread_ids.cuh"
 
 
 namespace gko {

--- a/cuda/solver/cg_kernels.cu
+++ b/cuda/solver/cg_kernels.cu
@@ -39,6 +39,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "cuda/base/math.hpp"
 #include "cuda/base/types.hpp"
+#include "cuda/components/thread_ids.cuh"
 
 
 namespace gko {

--- a/cuda/solver/cgs_kernels.cu
+++ b/cuda/solver/cgs_kernels.cu
@@ -39,6 +39,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "cuda/base/math.hpp"
 #include "cuda/base/types.hpp"
+#include "cuda/components/thread_ids.cuh"
 
 
 namespace gko {

--- a/cuda/solver/fcg_kernels.cu
+++ b/cuda/solver/fcg_kernels.cu
@@ -39,6 +39,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "cuda/base/math.hpp"
 #include "cuda/base/types.hpp"
+#include "cuda/components/thread_ids.cuh"
 
 
 namespace gko {

--- a/cuda/solver/gmres_kernels.cu
+++ b/cuda/solver/gmres_kernels.cu
@@ -49,6 +49,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "cuda/components/atomic.cuh"
 #include "cuda/components/cooperative_groups.cuh"
 #include "cuda/components/reduction.cuh"
+#include "cuda/components/thread_ids.cuh"
 #include "cuda/components/uninitialized_array.hpp"
 
 

--- a/cuda/solver/ir_kernels.cu
+++ b/cuda/solver/ir_kernels.cu
@@ -36,6 +36,9 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <ginkgo/core/base/math.hpp>
 
 
+#include "cuda/components/thread_ids.cuh"
+
+
 namespace gko {
 namespace kernels {
 namespace cuda {

--- a/cuda/stop/criterion_kernels.cu
+++ b/cuda/stop/criterion_kernels.cu
@@ -40,6 +40,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "cuda/base/math.hpp"
 #include "cuda/base/types.hpp"
+#include "cuda/components/thread_ids.cuh"
 
 
 namespace gko {
@@ -60,8 +61,7 @@ __global__ __launch_bounds__(default_block_size) void set_all_statuses(
     size_type num_elems, uint8 stoppingId, bool setFinalized,
     stopping_status *stop_status)
 {
-    const auto tidx =
-        static_cast<size_type>(blockDim.x) * blockIdx.x + threadIdx.x;
+    const auto tidx = thread::get_thread_id_flat();
     if (tidx < num_elems) {
         stop_status[tidx].stop(stoppingId, setFinalized);
     }

--- a/cuda/stop/residual_norm_reduction_kernels.cu
+++ b/cuda/stop/residual_norm_reduction_kernels.cu
@@ -40,6 +40,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "cuda/base/math.hpp"
 #include "cuda/base/types.hpp"
+#include "cuda/components/thread_ids.cuh"
+
 
 namespace gko {
 namespace kernels {
@@ -64,8 +66,7 @@ __global__
         bool setFinalized, stopping_status *__restrict__ stop_status,
         bool *__restrict__ device_storage)
 {
-    const auto tidx =
-        static_cast<size_type>(blockDim.x) * blockIdx.x + threadIdx.x;
+    const auto tidx = thread::get_thread_id_flat();
     if (tidx < num_cols) {
         if (abs(tau[tidx]) < rel_residual_goal * abs(orig_tau[tidx])) {
             stop_status[tidx].converge(stoppingId, setFinalized);

--- a/hip/components/zero_array.hip.hpp
+++ b/hip/components/zero_array.hip.hpp
@@ -36,6 +36,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "hip/base/math.hip.hpp"
 #include "hip/base/types.hip.hpp"
+#include "hip/components/thread_ids.hip.hpp"
 
 
 namespace gko {

--- a/hip/factorization/par_ilu_kernels.hip.cpp
+++ b/hip/factorization/par_ilu_kernels.hip.cpp
@@ -48,6 +48,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "hip/components/cooperative_groups.hip.hpp"
 #include "hip/components/intrinsics.hip.hpp"
 #include "hip/components/searching.hip.hpp"
+#include "hip/components/thread_ids.hip.hpp"
 
 
 namespace gko {

--- a/hip/matrix/coo_kernels.hip.cpp
+++ b/hip/matrix/coo_kernels.hip.cpp
@@ -52,6 +52,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "hip/components/cooperative_groups.hip.hpp"
 #include "hip/components/format_conversion.hip.hpp"
 #include "hip/components/segment_scan.hip.hpp"
+#include "hip/components/thread_ids.hip.hpp"
 #include "hip/components/zero_array.hip.hpp"
 
 

--- a/hip/matrix/csr_kernels.hip.cpp
+++ b/hip/matrix/csr_kernels.hip.cpp
@@ -64,6 +64,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "hip/components/merging.hip.hpp"
 #include "hip/components/reduction.hip.hpp"
 #include "hip/components/segment_scan.hip.hpp"
+#include "hip/components/thread_ids.hip.hpp"
 #include "hip/components/uninitialized_array.hip.hpp"
 #include "hip/components/zero_array.hip.hpp"
 

--- a/hip/matrix/dense_kernels.hip.cpp
+++ b/hip/matrix/dense_kernels.hip.cpp
@@ -51,6 +51,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "hip/base/pointer_mode_guard.hip.hpp"
 #include "hip/components/cooperative_groups.hip.hpp"
 #include "hip/components/reduction.hip.hpp"
+#include "hip/components/thread_ids.hip.hpp"
 #include "hip/components/uninitialized_array.hip.hpp"
 
 

--- a/hip/matrix/ell_kernels.hip.cpp
+++ b/hip/matrix/ell_kernels.hip.cpp
@@ -56,6 +56,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "hip/components/cooperative_groups.hip.hpp"
 #include "hip/components/format_conversion.hip.hpp"
 #include "hip/components/reduction.hip.hpp"
+#include "hip/components/thread_ids.hip.hpp"
 #include "hip/components/zero_array.hip.hpp"
 
 

--- a/hip/matrix/hybrid_kernels.hip.cpp
+++ b/hip/matrix/hybrid_kernels.hip.cpp
@@ -50,6 +50,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "hip/components/format_conversion.hip.hpp"
 #include "hip/components/reduction.hip.hpp"
 #include "hip/components/segment_scan.hip.hpp"
+#include "hip/components/thread_ids.hip.hpp"
 #include "hip/components/zero_array.hip.hpp"
 
 

--- a/hip/matrix/sellp_kernels.hip.cpp
+++ b/hip/matrix/sellp_kernels.hip.cpp
@@ -48,6 +48,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "hip/base/hipsparse_bindings.hip.hpp"
 #include "hip/base/types.hip.hpp"
 #include "hip/components/reduction.hip.hpp"
+#include "hip/components/thread_ids.hip.hpp"
 
 
 namespace gko {

--- a/hip/preconditioner/jacobi_kernels.hip.cpp
+++ b/hip/preconditioner/jacobi_kernels.hip.cpp
@@ -44,6 +44,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "hip/base/math.hip.hpp"
 #include "hip/base/types.hip.hpp"
 #include "hip/components/cooperative_groups.hip.hpp"
+#include "hip/components/thread_ids.hip.hpp"
 
 
 namespace gko {

--- a/hip/preconditioner/jacobi_kernels.hip.cpp
+++ b/hip/preconditioner/jacobi_kernels.hip.cpp
@@ -61,9 +61,9 @@ namespace {
 
 // a total of 32/16 warps (1024 threads)
 #if GINKGO_HIP_PLATFORM_HCC
-constexpr int default_block_size = 16;
+constexpr int default_num_warps = 16;
 #else  // GINKGO_HIP_PLATFORM_NVCC
-constexpr int default_block_size = 32;
+constexpr int default_num_warps = 32;
 #endif
 // with current architectures, at most 32 warps can be scheduled per SM (and
 // current GPUs have at most 84 SMs)
@@ -122,11 +122,11 @@ void initialize_precisions(std::shared_ptr<const HipExecutor> exec,
                            const Array<precision_reduction> &source,
                            Array<precision_reduction> &precisions)
 {
-    const auto block_size = default_block_size * config::warp_size;
+    const auto block_size = default_num_warps * config::warp_size;
     const auto grid_size = min(
         default_grid_size,
         static_cast<int32>(ceildiv(precisions.get_num_elems(), block_size)));
-    hipLaunchKernelGGL(HIP_KERNEL_NAME(duplicate_array<default_block_size>),
+    hipLaunchKernelGGL(HIP_KERNEL_NAME(duplicate_array<default_num_warps>),
                        dim3(grid_size), dim3(block_size), 0, 0,
                        source.get_const_data(), source.get_num_elems(),
                        precisions.get_data(), precisions.get_num_elems());

--- a/hip/preconditioner/jacobi_kernels.hip.cpp
+++ b/hip/preconditioner/jacobi_kernels.hip.cpp
@@ -83,7 +83,7 @@ size_type find_natural_blocks(std::shared_ptr<const HipExecutor> exec,
 
     Array<bool> matching_next_row(exec, mtx->get_size()[0] - 1);
 
-    const dim3 block_size(default_block_size, 1, 1);
+    const dim3 block_size(config::warp_size, 1, 1);
     const dim3 grid_size(
         ceildiv(mtx->get_size()[0] * config::warp_size, block_size.x), 1, 1);
     hipLaunchKernelGGL(compare_adjacent_rows, dim3(grid_size), dim3(block_size),

--- a/hip/solver/bicg_kernels.hip.cpp
+++ b/hip/solver/bicg_kernels.hip.cpp
@@ -42,6 +42,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "hip/base/math.hip.hpp"
 #include "hip/base/types.hip.hpp"
+#include "hip/components/thread_ids.hip.hpp"
 
 
 namespace gko {

--- a/hip/solver/bicgstab_kernels.hip.cpp
+++ b/hip/solver/bicgstab_kernels.hip.cpp
@@ -42,6 +42,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "hip/base/math.hip.hpp"
 #include "hip/base/types.hip.hpp"
+#include "hip/components/thread_ids.hip.hpp"
 
 
 namespace gko {

--- a/hip/solver/cg_kernels.hip.cpp
+++ b/hip/solver/cg_kernels.hip.cpp
@@ -42,6 +42,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "hip/base/math.hip.hpp"
 #include "hip/base/types.hip.hpp"
+#include "hip/components/thread_ids.hip.hpp"
 
 
 namespace gko {

--- a/hip/solver/cgs_kernels.hip.cpp
+++ b/hip/solver/cgs_kernels.hip.cpp
@@ -42,6 +42,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "hip/base/math.hip.hpp"
 #include "hip/base/types.hip.hpp"
+#include "hip/components/thread_ids.hip.hpp"
 
 
 namespace gko {

--- a/hip/solver/fcg_kernels.hip.cpp
+++ b/hip/solver/fcg_kernels.hip.cpp
@@ -42,6 +42,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "hip/base/math.hip.hpp"
 #include "hip/base/types.hip.hpp"
+#include "hip/components/thread_ids.hip.hpp"
 
 
 namespace gko {

--- a/hip/solver/gmres_kernels.hip.cpp
+++ b/hip/solver/gmres_kernels.hip.cpp
@@ -52,6 +52,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "hip/components/atomic.hip.hpp"
 #include "hip/components/cooperative_groups.hip.hpp"
 #include "hip/components/reduction.hip.hpp"
+#include "hip/components/thread_ids.hip.hpp"
 #include "hip/components/uninitialized_array.hip.hpp"
 
 

--- a/hip/solver/ir_kernels.hip.cpp
+++ b/hip/solver/ir_kernels.hip.cpp
@@ -39,6 +39,9 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <ginkgo/core/base/math.hpp>
 
 
+#include "hip/components/thread_ids.hip.hpp"
+
+
 namespace gko {
 namespace kernels {
 namespace hip {

--- a/hip/stop/criterion_kernels.hip.cpp
+++ b/hip/stop/criterion_kernels.hip.cpp
@@ -40,6 +40,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "hip/base/math.hip.hpp"
 #include "hip/base/types.hip.hpp"
+#include "hip/components/thread_ids.hip.hpp"
 
 
 namespace gko {
@@ -60,8 +61,7 @@ __global__ __launch_bounds__(default_block_size) void set_all_statuses(
     size_type num_elems, uint8 stoppingId, bool setFinalized,
     stopping_status *stop_status)
 {
-    const auto tidx =
-        static_cast<size_type>(blockDim.x) * blockIdx.x + threadIdx.x;
+    const auto tidx = thread::get_thread_id_flat();
     if (tidx < num_elems) {
         stop_status[tidx].stop(stoppingId, setFinalized);
     }

--- a/hip/stop/residual_norm_reduction_kernels.hip.cpp
+++ b/hip/stop/residual_norm_reduction_kernels.hip.cpp
@@ -43,6 +43,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "hip/base/math.hip.hpp"
 #include "hip/base/types.hip.hpp"
+#include "hip/components/thread_ids.hip.hpp"
+
 
 namespace gko {
 namespace kernels {
@@ -67,8 +69,7 @@ __global__
         bool setFinalized, stopping_status *__restrict__ stop_status,
         bool *__restrict__ device_storage)
 {
-    const auto tidx =
-        static_cast<size_type>(blockDim.x) * blockIdx.x + threadIdx.x;
+    const auto tidx = thread::get_thread_id_flat();
     if (tidx < num_cols) {
         if (abs(tau[tidx]) < rel_residual_goal * abs(orig_tau[tidx])) {
             stop_status[tidx].converge(stoppingId, setFinalized);


### PR DESCRIPTION
At the moment most of our code is filled with `threadIdx.x + blockDim.x * blockIdx.x` and similar expressions. There are some issues with this approach:

1. The product can overflow since the calculation is executed using unsigned 32 bit values. This is even true if the matrix dimensions are below MAX_INT, since we sometimes use multiple threads per row.
2. The resulting type of this statement is `unsigned` by default. It would instead be better if we could have a robust method to determine the thread or subwarp ID expressed in a given type.

This PR adds `get_thread_id_flat` and `get_subwarp_id_flat` functions that work for one-dimensional thread indexing (using only `*Idx.x`) and uses them where possible, which at the same time fixes some potential overflow bugs.

This is a first attempt to solve some of the issues listed in #430. But there might be some discussion warranted, especially in terms of the interaction with `cooperative_groups`, which always use 3D indexing.

Also feel free to add more locations where we could use these functions, as I only grepped for the most common patterns.