### PR TITLE
Add missing clang parameter in AMD CI config

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -343,6 +343,8 @@ build/amd/clang/hip/release/static:
   image: localhost:5000/gko-amd-gnu7-llvm60
   variables:
     <<: *default_variables
+    C_COMPILER: clang
+    CXX_COMPILER: clang++
     BUILD_OMP: "ON"
     BUILD_HIP: "ON"
     BUILD_TYPE: Release


### PR DESCRIPTION
Currently, the `build/amd/clang/hip/release/static` CI job is missing the parameters to use `clang` insted of `gcc`. This PR adds the missing parameters.