### PR TITLE
Update Permutation class and kernels.

### DIFF
--- a/common/matrix/dense_kernels.hpp.inc
+++ b/common/matrix/dense_kernels.hpp.inc
@@ -361,4 +361,80 @@ __global__ __launch_bounds__(default_block_size) void reduce_total_cols(
 }
 
 
+template <size_type block_size, typename IndexType, typename ValueType>
+__global__ __launch_bounds__(block_size) void row_permute(
+    size_type num_rows, size_type num_cols,
+    const IndexType *__restrict__ perm_idxs, const ValueType *__restrict__ orig,
+    size_type stride_orig, ValueType *__restrict__ result,
+    size_type stride_result)
+{
+    constexpr auto warps_per_block = block_size / config::warp_size;
+    const auto global_id =
+        thread::get_thread_id<config::warp_size, warps_per_block>();
+    const auto row_id = global_id / num_cols;
+    const auto col_id = global_id % num_cols;
+    if (row_id < num_rows) {
+        result[row_id * stride_result + col_id] =
+            orig[perm_idxs[row_id] * stride_orig + col_id];
+    }
+}
+
+
+template <size_type block_size, typename IndexType, typename ValueType>
+__global__ __launch_bounds__(block_size) void column_permute(
+    size_type num_rows, size_type num_cols,
+    const IndexType *__restrict__ perm_idxs, const ValueType *__restrict__ orig,
+    size_type stride_orig, ValueType *__restrict__ result,
+    size_type stride_result)
+{
+    constexpr auto warps_per_block = block_size / config::warp_size;
+    const auto global_id =
+        thread::get_thread_id<config::warp_size, warps_per_block>();
+    const auto row_id = global_id / num_cols;
+    const auto col_id = global_id % num_cols;
+    if (row_id < num_rows) {
+        result[row_id * stride_result + col_id] =
+            orig[row_id * stride_orig + perm_idxs[col_id]];
+    }
+}
+
+
+template <size_type block_size, typename IndexType, typename ValueType>
+__global__ __launch_bounds__(block_size) void inverse_row_permute(
+    size_type num_rows, size_type num_cols,
+    const IndexType *__restrict__ perm_idxs, const ValueType *__restrict__ orig,
+    size_type stride_orig, ValueType *__restrict__ result,
+    size_type stride_result)
+{
+    constexpr auto warps_per_block = block_size / config::warp_size;
+    const auto global_id =
+        thread::get_thread_id<config::warp_size, warps_per_block>();
+    const auto row_id = global_id / num_cols;
+    const auto col_id = global_id % num_cols;
+    if (row_id < num_rows) {
+        result[perm_idxs[row_id] * stride_result + col_id] =
+            orig[row_id * stride_orig + col_id];
+    }
+}
+
+
+template <size_type block_size, typename IndexType, typename ValueType>
+__global__ __launch_bounds__(block_size) void inverse_column_permute(
+    size_type num_rows, size_type num_cols,
+    const IndexType *__restrict__ perm_idxs, const ValueType *__restrict__ orig,
+    size_type stride_orig, ValueType *__restrict__ result,
+    size_type stride_result)
+{
+    constexpr auto warps_per_block = block_size / config::warp_size;
+    const auto global_id =
+        thread::get_thread_id<config::warp_size, warps_per_block>();
+    const auto row_id = global_id / num_cols;
+    const auto col_id = global_id % num_cols;
+    if (row_id < num_rows) {
+        result[row_id * stride_result + perm_idxs[col_id]] =
+            orig[row_id * stride_orig + col_id];
+    }
+}
+
+
 }  // namespace kernel

--- a/core/test/matrix/permutation.cpp
+++ b/core/test/matrix/permutation.cpp
@@ -120,7 +120,8 @@ TYPED_TEST(Permutation, CanBeConstructedWithSize)
 
 TYPED_TEST(Permutation, FactorySetsCorrectPermuteMask)
 {
-    auto m = gko::matrix::Permutation<i_type>::create(exec);
+    using i_type = typename TestFixture::i_type;
+    auto m = gko::matrix::Permutation<i_type>::create(this->exec);
     auto mask = m->get_permute_mask();
 
     ASSERT_EQ(mask, gko::matrix::row_permute);
@@ -129,6 +130,7 @@ TYPED_TEST(Permutation, FactorySetsCorrectPermuteMask)
 
 TYPED_TEST(Permutation, PermutationCanBeConstructedFromExistingData)
 {
+    using i_type = typename TestFixture::i_type;
     using i_type = typename TestFixture::i_type;
     i_type data[] = {1, 0, 2};
 
@@ -142,8 +144,9 @@ TYPED_TEST(Permutation, PermutationCanBeConstructedFromExistingData)
 
 TYPED_TEST(Permutation, CanBeConstructedWithSizeAndMask)
 {
+    using i_type = typename TestFixture::i_type;
     auto m = gko::matrix::Permutation<i_type>::create(
-        exec, gko::dim<2>{2, 3}, gko::matrix::column_permute);
+        this->exec, gko::dim<2>{2, 3}, gko::matrix::column_permute);
 
     ASSERT_EQ(m->get_size(), gko::dim<2>(2, 3));
     ASSERT_EQ(m->get_permutation_size(), 2);
@@ -153,8 +156,9 @@ TYPED_TEST(Permutation, CanBeConstructedWithSizeAndMask)
 
 TYPED_TEST(Permutation, CanExplicitlyOverrideSetPermuteMask)
 {
+    using i_type = typename TestFixture::i_type;
     auto m = gko::matrix::Permutation<i_type>::create(
-        exec, gko::dim<2>{2, 3}, gko::matrix::column_permute);
+        this->exec, gko::dim<2>{2, 3}, gko::matrix::column_permute);
 
     auto mask = m->get_permute_mask();
     ASSERT_EQ(mask, gko::matrix::column_permute);
@@ -181,10 +185,12 @@ TYPED_TEST(Permutation, PermutationThrowsforWrongRowPermDimensions)
 
 TYPED_TEST(Permutation, SettingMaskDoesNotModifyData)
 {
+    using i_type = typename TestFixture::i_type;
     i_type data[] = {1, 0, 2};
 
     auto m = gko::matrix::Permutation<i_type>::create(
-        exec, gko::dim<2>{3, 5}, gko::Array<i_type>::view(exec, 3, data));
+        this->exec, gko::dim<2>{3, 5},
+        gko::Array<i_type>::view(this->exec, 3, data));
 
     auto mask = m->get_permute_mask();
     ASSERT_EQ(m->get_const_permutation(), data);
@@ -244,23 +250,24 @@ TYPED_TEST(Permutation, CanBeMoved)
 
 TYPED_TEST(Permutation, CopyingPreservesMask)
 {
-    auto mtx_copy = gko::matrix::Permutation<i_type>::create(exec);
+    using i_type = typename TestFixture::i_type;
+    auto mtx_copy = gko::matrix::Permutation<i_type>::create(this->exec);
 
-    mtx_copy->copy_from(mtx.get());
+    mtx_copy->copy_from(this->mtx.get());
 
-    auto o_mask = mtx->get_permute_mask();
+    auto o_mask = this->mtx->get_permute_mask();
     auto n_mask = mtx_copy->get_permute_mask();
     ASSERT_EQ(o_mask, gko::matrix::row_permute);
     ASSERT_EQ(o_mask, n_mask);
 
-    mtx->set_permute_mask(gko::matrix::column_permute);
+    this->mtx->set_permute_mask(gko::matrix::column_permute);
 
-    o_mask = mtx->get_permute_mask();
+    o_mask = this->mtx->get_permute_mask();
     n_mask = mtx_copy->get_permute_mask();
     ASSERT_EQ(o_mask, gko::matrix::column_permute);
     ASSERT_NE(o_mask, n_mask);
 
-    mtx_copy->copy_from(mtx.get());
+    mtx_copy->copy_from(this->mtx.get());
 
     n_mask = mtx_copy->get_permute_mask();
     ASSERT_EQ(o_mask, n_mask);

--- a/cuda/matrix/dense_kernels.cu
+++ b/cuda/matrix/dense_kernels.cu
@@ -562,7 +562,18 @@ template <typename ValueType, typename IndexType>
 void row_permute(std::shared_ptr<const CudaExecutor> exec,
                  const Array<IndexType> *permutation_indices,
                  matrix::Dense<ValueType> *row_permuted,
-                 const matrix::Dense<ValueType> *orig) GKO_NOT_IMPLEMENTED;
+                 const matrix::Dense<ValueType> *orig)
+{
+    constexpr auto block_size = default_block_size;
+    const dim3 grid_dim =
+        ceildiv(orig->get_size()[0] * orig->get_size()[1], block_size);
+    const dim3 block_dim{config::warp_size, 1, block_size / config::warp_size};
+    kernel::row_permute<block_size><<<grid_dim, block_dim>>>(
+        orig->get_size()[0], orig->get_size()[1],
+        as_cuda_type(permutation_indices->get_const_data()),
+        as_cuda_type(orig->get_const_values()), orig->get_stride(),
+        as_cuda_type(row_permuted->get_values()), row_permuted->get_stride());
+}
 
 GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(GKO_DECLARE_ROW_PERMUTE_KERNEL);
 
@@ -571,7 +582,19 @@ template <typename ValueType, typename IndexType>
 void column_permute(std::shared_ptr<const CudaExecutor> exec,
                     const Array<IndexType> *permutation_indices,
                     matrix::Dense<ValueType> *column_permuted,
-                    const matrix::Dense<ValueType> *orig) GKO_NOT_IMPLEMENTED;
+                    const matrix::Dense<ValueType> *orig)
+{
+    constexpr auto block_size = default_block_size;
+    const dim3 grid_dim =
+        ceildiv(orig->get_size()[0] * orig->get_size()[1], block_size);
+    const dim3 block_dim{config::warp_size, 1, block_size / config::warp_size};
+    kernel::column_permute<block_size><<<grid_dim, block_dim>>>(
+        orig->get_size()[0], orig->get_size()[1],
+        as_cuda_type(permutation_indices->get_const_data()),
+        as_cuda_type(orig->get_const_values()), orig->get_stride(),
+        as_cuda_type(column_permuted->get_values()),
+        column_permuted->get_stride());
+}
 
 GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
     GKO_DECLARE_COLUMN_PERMUTE_KERNEL);
@@ -582,7 +605,17 @@ void inverse_row_permute(std::shared_ptr<const CudaExecutor> exec,
                          const Array<IndexType> *permutation_indices,
                          matrix::Dense<ValueType> *row_permuted,
                          const matrix::Dense<ValueType> *orig)
-    GKO_NOT_IMPLEMENTED;
+{
+    constexpr auto block_size = default_block_size;
+    const dim3 grid_dim =
+        ceildiv(orig->get_size()[0] * orig->get_size()[1], block_size);
+    const dim3 block_dim{config::warp_size, 1, block_size / config::warp_size};
+    kernel::inverse_row_permute<block_size><<<grid_dim, block_dim>>>(
+        orig->get_size()[0], orig->get_size()[1],
+        as_cuda_type(permutation_indices->get_const_data()),
+        as_cuda_type(orig->get_const_values()), orig->get_stride(),
+        as_cuda_type(row_permuted->get_values()), row_permuted->get_stride());
+}
 
 GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
     GKO_DECLARE_INVERSE_ROW_PERMUTE_KERNEL);
@@ -593,7 +626,18 @@ void inverse_column_permute(std::shared_ptr<const CudaExecutor> exec,
                             const Array<IndexType> *permutation_indices,
                             matrix::Dense<ValueType> *column_permuted,
                             const matrix::Dense<ValueType> *orig)
-    GKO_NOT_IMPLEMENTED;
+{
+    constexpr auto block_size = default_block_size;
+    const dim3 grid_dim =
+        ceildiv(orig->get_size()[0] * orig->get_size()[1], block_size);
+    const dim3 block_dim{config::warp_size, 1, block_size / config::warp_size};
+    kernel::inverse_column_permute<block_size><<<grid_dim, block_dim>>>(
+        orig->get_size()[0], orig->get_size()[1],
+        as_cuda_type(permutation_indices->get_const_data()),
+        as_cuda_type(orig->get_const_values()), orig->get_stride(),
+        as_cuda_type(column_permuted->get_values()),
+        column_permuted->get_stride());
+}
 
 GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
     GKO_DECLARE_INVERSE_COLUMN_PERMUTE_KERNEL);

--- a/cuda/test/matrix/dense_kernels.cpp
+++ b/cuda/test/matrix/dense_kernels.cpp
@@ -487,6 +487,7 @@ TEST_F(Dense, CalculateTotalColsIsEquivalentToRef)
 TEST_F(Dense, IsRowPermutable)
 {
     set_up_apply_data();
+
     auto r_permute = x->row_permute(rpermute_idxs.get());
     auto dr_permute = dx->row_permute(drpermute_idxs.get());
 
@@ -498,6 +499,7 @@ TEST_F(Dense, IsRowPermutable)
 TEST_F(Dense, IsColPermutable)
 {
     set_up_apply_data();
+
     auto c_permute = x->column_permute(cpermute_idxs.get());
     auto dc_permute = dx->column_permute(dcpermute_idxs.get());
 
@@ -509,6 +511,7 @@ TEST_F(Dense, IsColPermutable)
 TEST_F(Dense, IsInverseRowPermutable)
 {
     set_up_apply_data();
+
     auto inverse_r_permute = x->inverse_row_permute(rpermute_idxs.get());
     auto d_inverse_r_permute = dx->inverse_row_permute(drpermute_idxs.get());
 
@@ -520,6 +523,7 @@ TEST_F(Dense, IsInverseRowPermutable)
 TEST_F(Dense, IsInverseColPermutable)
 {
     set_up_apply_data();
+
     auto inverse_c_permute = x->inverse_column_permute(cpermute_idxs.get());
     auto d_inverse_c_permute = dx->inverse_column_permute(dcpermute_idxs.get());
 

--- a/cuda/test/matrix/dense_kernels.cpp
+++ b/cuda/test/matrix/dense_kernels.cpp
@@ -55,9 +55,11 @@ namespace {
 
 class Dense : public ::testing::Test {
 protected:
-    using Mtx = gko::matrix::Dense<>;
-    using Arr = gko::Array<int>;
-    using ComplexMtx = gko::matrix::Dense<std::complex<double>>;
+    using itype = int;
+    using vtype = double;
+    using Mtx = gko::matrix::Dense<vtype>;
+    using Arr = gko::Array<itype>;
+    using ComplexMtx = gko::matrix::Dense<std::complex<vtype>>;
 
     Dense() : rand_engine(15) {}
 
@@ -125,11 +127,11 @@ protected:
         dbeta = Mtx::create(cuda);
         dbeta->copy_from(beta.get());
 
-        std::vector<int> tmp(x->get_size()[0], 0);
+        std::vector<itype> tmp(x->get_size()[0], 0);
         auto rng = std::default_random_engine{};
         std::iota(tmp.begin(), tmp.end(), 0);
         std::shuffle(tmp.begin(), tmp.end(), rng);
-        std::vector<int> tmp2(x->get_size()[1], 0);
+        std::vector<itype> tmp2(x->get_size()[1], 0);
         std::iota(tmp2.begin(), tmp2.end(), 0);
         std::shuffle(tmp2.begin(), tmp2.end(), rng);
         rpermute_idxs =

--- a/cuda/test/matrix/dense_kernels.cpp
+++ b/cuda/test/matrix/dense_kernels.cpp
@@ -56,6 +56,7 @@ namespace {
 class Dense : public ::testing::Test {
 protected:
     using Mtx = gko::matrix::Dense<>;
+    using Arr = gko::Array<int>;
     using ComplexMtx = gko::matrix::Dense<std::complex<double>>;
 
     Dense() : rand_engine(15) {}
@@ -123,6 +124,22 @@ protected:
         dalpha->copy_from(alpha.get());
         dbeta = Mtx::create(cuda);
         dbeta->copy_from(beta.get());
+
+        std::vector<int> tmp(x->get_size()[0], 0);
+        auto rng = std::default_random_engine{};
+        std::iota(tmp.begin(), tmp.end(), 0);
+        std::shuffle(tmp.begin(), tmp.end(), rng);
+        std::vector<int> tmp2(x->get_size()[1], 0);
+        std::iota(tmp2.begin(), tmp2.end(), 0);
+        std::shuffle(tmp2.begin(), tmp2.end(), rng);
+        rpermute_idxs =
+            std::unique_ptr<Arr>(new Arr{ref, tmp.begin(), tmp.end()});
+        drpermute_idxs =
+            std::unique_ptr<Arr>(new Arr{cuda, tmp.begin(), tmp.end()});
+        cpermute_idxs =
+            std::unique_ptr<Arr>(new Arr{ref, tmp2.begin(), tmp2.end()});
+        dcpermute_idxs =
+            std::unique_ptr<Arr>(new Arr{cuda, tmp2.begin(), tmp2.end()});
     }
 
     std::shared_ptr<gko::ReferenceExecutor> ref;
@@ -142,6 +159,10 @@ protected:
     std::unique_ptr<Mtx> dy;
     std::unique_ptr<Mtx> dalpha;
     std::unique_ptr<Mtx> dbeta;
+    std::unique_ptr<Arr> rpermute_idxs;
+    std::unique_ptr<Arr> drpermute_idxs;
+    std::unique_ptr<Arr> cpermute_idxs;
+    std::unique_ptr<Arr> dcpermute_idxs;
 };
 
 
@@ -460,6 +481,50 @@ TEST_F(Dense, CalculateTotalColsIsEquivalentToRef)
         cuda, dx.get(), &dtotal_cols, 2, gko::matrix::default_slice_size);
 
     ASSERT_EQ(total_cols, dtotal_cols);
+}
+
+
+TEST_F(Dense, IsRowPermutable)
+{
+    set_up_apply_data();
+    auto r_permute = x->row_permute(rpermute_idxs.get());
+    auto dr_permute = dx->row_permute(drpermute_idxs.get());
+
+    GKO_ASSERT_MTX_NEAR(static_cast<Mtx *>(r_permute.get()),
+                        static_cast<Mtx *>(dr_permute.get()), 0);
+}
+
+
+TEST_F(Dense, IsColPermutable)
+{
+    set_up_apply_data();
+    auto c_permute = x->column_permute(cpermute_idxs.get());
+    auto dc_permute = dx->column_permute(dcpermute_idxs.get());
+
+    GKO_ASSERT_MTX_NEAR(static_cast<Mtx *>(c_permute.get()),
+                        static_cast<Mtx *>(dc_permute.get()), 0);
+}
+
+
+TEST_F(Dense, IsInverseRowPermutable)
+{
+    set_up_apply_data();
+    auto inverse_r_permute = x->inverse_row_permute(rpermute_idxs.get());
+    auto d_inverse_r_permute = dx->inverse_row_permute(drpermute_idxs.get());
+
+    GKO_ASSERT_MTX_NEAR(static_cast<Mtx *>(inverse_r_permute.get()),
+                        static_cast<Mtx *>(d_inverse_r_permute.get()), 0);
+}
+
+
+TEST_F(Dense, IsInverseColPermutable)
+{
+    set_up_apply_data();
+    auto inverse_c_permute = x->inverse_column_permute(cpermute_idxs.get());
+    auto d_inverse_c_permute = dx->inverse_column_permute(dcpermute_idxs.get());
+
+    GKO_ASSERT_MTX_NEAR(static_cast<Mtx *>(inverse_c_permute.get()),
+                        static_cast<Mtx *>(d_inverse_c_permute.get()), 0);
 }
 
 

--- a/hip/matrix/dense_kernels.hip.cpp
+++ b/hip/matrix/dense_kernels.hip.cpp
@@ -584,7 +584,19 @@ template <typename ValueType, typename IndexType>
 void row_permute(std::shared_ptr<const HipExecutor> exec,
                  const Array<IndexType> *permutation_indices,
                  matrix::Dense<ValueType> *row_permuted,
-                 const matrix::Dense<ValueType> *orig) GKO_NOT_IMPLEMENTED;
+                 const matrix::Dense<ValueType> *orig)
+{
+    constexpr auto block_size = default_block_size;
+    const dim3 grid_dim =
+        ceildiv(orig->get_size()[0] * orig->get_size()[1], block_size);
+    const dim3 block_dim{config::warp_size, 1, block_size / config::warp_size};
+    hipLaunchKernelGGL(
+        kernel::row_permute<block_size>, dim3(grid_dim), dim3(block_dim), 0, 0,
+        orig->get_size()[0], orig->get_size()[1],
+        as_hip_type(permutation_indices->get_const_data()),
+        as_hip_type(orig->get_const_values()), orig->get_stride(),
+        as_hip_type(row_permuted->get_values()), row_permuted->get_stride());
+}
 
 GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(GKO_DECLARE_ROW_PERMUTE_KERNEL);
 
@@ -593,7 +605,20 @@ template <typename ValueType, typename IndexType>
 void column_permute(std::shared_ptr<const HipExecutor> exec,
                     const Array<IndexType> *permutation_indices,
                     matrix::Dense<ValueType> *column_permuted,
-                    const matrix::Dense<ValueType> *orig) GKO_NOT_IMPLEMENTED;
+                    const matrix::Dense<ValueType> *orig)
+{
+    constexpr auto block_size = default_block_size;
+    const dim3 grid_dim =
+        ceildiv(orig->get_size()[0] * orig->get_size()[1], block_size);
+    const dim3 block_dim{config::warp_size, 1, block_size / config::warp_size};
+    hipLaunchKernelGGL(
+        kernel::column_permute<block_size>, dim3(grid_dim), dim3(block_dim), 0,
+        0, orig->get_size()[0], orig->get_size()[1],
+        as_hip_type(permutation_indices->get_const_data()),
+        as_hip_type(orig->get_const_values()), orig->get_stride(),
+        as_hip_type(column_permuted->get_values()),
+        column_permuted->get_stride());
+}
 
 GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
     GKO_DECLARE_COLUMN_PERMUTE_KERNEL);
@@ -604,7 +629,18 @@ void inverse_row_permute(std::shared_ptr<const HipExecutor> exec,
                          const Array<IndexType> *permutation_indices,
                          matrix::Dense<ValueType> *row_permuted,
                          const matrix::Dense<ValueType> *orig)
-    GKO_NOT_IMPLEMENTED;
+{
+    constexpr auto block_size = default_block_size;
+    const dim3 grid_dim =
+        ceildiv(orig->get_size()[0] * orig->get_size()[1], block_size);
+    const dim3 block_dim{config::warp_size, 1, block_size / config::warp_size};
+    hipLaunchKernelGGL(
+        kernel::inverse_row_permute<block_size>, dim3(grid_dim),
+        dim3(block_dim), 0, 0, orig->get_size()[0], orig->get_size()[1],
+        as_hip_type(permutation_indices->get_const_data()),
+        as_hip_type(orig->get_const_values()), orig->get_stride(),
+        as_hip_type(row_permuted->get_values()), row_permuted->get_stride());
+}
 
 GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
     GKO_DECLARE_INVERSE_ROW_PERMUTE_KERNEL);
@@ -615,7 +651,19 @@ void inverse_column_permute(std::shared_ptr<const HipExecutor> exec,
                             const Array<IndexType> *permutation_indices,
                             matrix::Dense<ValueType> *column_permuted,
                             const matrix::Dense<ValueType> *orig)
-    GKO_NOT_IMPLEMENTED;
+{
+    constexpr auto block_size = default_block_size;
+    const dim3 grid_dim =
+        ceildiv(orig->get_size()[0] * orig->get_size()[1], block_size);
+    const dim3 block_dim{config::warp_size, 1, block_size / config::warp_size};
+    hipLaunchKernelGGL(
+        kernel::inverse_column_permute<block_size>, dim3(grid_dim),
+        dim3(block_dim), 0, 0, orig->get_size()[0], orig->get_size()[1],
+        as_hip_type(permutation_indices->get_const_data()),
+        as_hip_type(orig->get_const_values()), orig->get_stride(),
+        as_hip_type(column_permuted->get_values()),
+        column_permuted->get_stride());
+}
 
 GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
     GKO_DECLARE_INVERSE_COLUMN_PERMUTE_KERNEL);

--- a/hip/test/matrix/dense_kernels.hip.cpp
+++ b/hip/test/matrix/dense_kernels.hip.cpp
@@ -55,7 +55,10 @@ namespace {
 
 class Dense : public ::testing::Test {
 protected:
-    using Mtx = gko::matrix::Dense<>;
+    using itype = int;
+    using vtype = double;
+    using Mtx = gko::matrix::Dense<vtype>;
+    using Arr = gko::Array<itype>;
 
     Dense() : rand_engine(15) {}
 
@@ -119,6 +122,22 @@ protected:
         dalpha->copy_from(alpha.get());
         dbeta = Mtx::create(hip);
         dbeta->copy_from(beta.get());
+
+        std::vector<itype> tmp(x->get_size()[0], 0);
+        auto rng = std::default_random_engine{};
+        std::iota(tmp.begin(), tmp.end(), 0);
+        std::shuffle(tmp.begin(), tmp.end(), rng);
+        std::vector<itype> tmp2(x->get_size()[1], 0);
+        std::iota(tmp2.begin(), tmp2.end(), 0);
+        std::shuffle(tmp2.begin(), tmp2.end(), rng);
+        rpermute_idxs =
+            std::unique_ptr<Arr>(new Arr{ref, tmp.begin(), tmp.end()});
+        drpermute_idxs =
+            std::unique_ptr<Arr>(new Arr{hip, tmp.begin(), tmp.end()});
+        cpermute_idxs =
+            std::unique_ptr<Arr>(new Arr{ref, tmp2.begin(), tmp2.end()});
+        dcpermute_idxs =
+            std::unique_ptr<Arr>(new Arr{hip, tmp2.begin(), tmp2.end()});
     }
 
     std::shared_ptr<gko::ReferenceExecutor> ref;
@@ -136,6 +155,10 @@ protected:
     std::unique_ptr<Mtx> dy;
     std::unique_ptr<Mtx> dalpha;
     std::unique_ptr<Mtx> dbeta;
+    std::unique_ptr<Arr> rpermute_idxs;
+    std::unique_ptr<Arr> drpermute_idxs;
+    std::unique_ptr<Arr> cpermute_idxs;
+    std::unique_ptr<Arr> dcpermute_idxs;
 };
 
 
@@ -442,6 +465,54 @@ TEST_F(Dense, CalculateTotalColsIsEquivalentToRef)
         hip, dx.get(), &dtotal_cols, 2, gko::matrix::default_slice_size);
 
     ASSERT_EQ(total_cols, dtotal_cols);
+}
+
+
+TEST_F(Dense, IsRowPermutable)
+{
+    set_up_apply_data();
+
+    auto r_permute = x->row_permute(rpermute_idxs.get());
+    auto dr_permute = dx->row_permute(drpermute_idxs.get());
+
+    GKO_ASSERT_MTX_NEAR(static_cast<Mtx *>(r_permute.get()),
+                        static_cast<Mtx *>(dr_permute.get()), 0);
+}
+
+
+TEST_F(Dense, IsColPermutable)
+{
+    set_up_apply_data();
+
+    auto c_permute = x->column_permute(cpermute_idxs.get());
+    auto dc_permute = dx->column_permute(dcpermute_idxs.get());
+
+    GKO_ASSERT_MTX_NEAR(static_cast<Mtx *>(c_permute.get()),
+                        static_cast<Mtx *>(dc_permute.get()), 0);
+}
+
+
+TEST_F(Dense, IsInverseRowPermutable)
+{
+    set_up_apply_data();
+
+    auto inverse_r_permute = x->inverse_row_permute(rpermute_idxs.get());
+    auto d_inverse_r_permute = dx->inverse_row_permute(drpermute_idxs.get());
+
+    GKO_ASSERT_MTX_NEAR(static_cast<Mtx *>(inverse_r_permute.get()),
+                        static_cast<Mtx *>(d_inverse_r_permute.get()), 0);
+}
+
+
+TEST_F(Dense, IsInverseColPermutable)
+{
+    set_up_apply_data();
+
+    auto inverse_c_permute = x->inverse_column_permute(cpermute_idxs.get());
+    auto d_inverse_c_permute = dx->inverse_column_permute(dcpermute_idxs.get());
+
+    GKO_ASSERT_MTX_NEAR(static_cast<Mtx *>(inverse_c_permute.get()),
+                        static_cast<Mtx *>(d_inverse_c_permute.get()), 0);
 }
 
 

--- a/include/ginkgo/core/matrix/permutation.hpp
+++ b/include/ginkgo/core/matrix/permutation.hpp
@@ -114,6 +114,23 @@ public:
         return permutation_.get_num_elems();
     }
 
+    /**
+     * Get the permute masks
+     *
+     * @param permute_mask the permute masks
+     */
+    mask_type get_permute_mask() { return enabled_permute_; }
+
+    /**
+     * Set the permute masks
+     *
+     * @param permute_mask the permute masks
+     */
+    void set_permute_mask(mask_type permute_mask)
+    {
+        enabled_permute_ = permute_mask;
+    }
+
 
 protected:
     /**
@@ -122,7 +139,7 @@ protected:
      * @param exec  Executor associated to the LinOp
      */
     Permutation(std::shared_ptr<const Executor> exec)
-        : Permutation(std::move(exec), dim<2>{})
+        : Permutation(std::move(exec), dim<2>{}, row_permute)
     {}
 
     /**

--- a/include/ginkgo/core/matrix/permutation.hpp
+++ b/include/ginkgo/core/matrix/permutation.hpp
@@ -60,7 +60,7 @@ static constexpr mask_type column_permute = mask_type{1 << 2};
 static constexpr mask_type inverse_permute = mask_type{1 << 3};
 
 /**
- * Permutation is a matrix format which stores the row and column permutation
+ * Permutation is a matrix "format" which stores the row and column permutation
  * arrays which can be used for re-ordering the rows and columns a matrix.
  *
  * @tparam IndexType  precision of permutation array indices.
@@ -68,7 +68,8 @@ static constexpr mask_type inverse_permute = mask_type{1 << 3};
  * @note This format is used mainly to allow for an abstraction of the
  * permutation/re-ordering and provides the user with an apply method which
  * calls the respective LinOp's permute operation if the respective LinOp
- * implements the Permutable interface.
+ * implements the Permutable interface. As such it only stores an array of the
+ * permutation indices.
  *
  * @ingroup permutation
  * @ingroup mat_formats
@@ -117,9 +118,9 @@ public:
     /**
      * Get the permute masks
      *
-     * @param permute_mask the permute masks
+     * @return  permute_mask the permute masks
      */
-    mask_type get_permute_mask() { return enabled_permute_; }
+    mask_type get_permute_mask() const { return enabled_permute_; }
 
     /**
      * Set the permute masks
@@ -139,7 +140,7 @@ protected:
      * @param exec  Executor associated to the LinOp
      */
     Permutation(std::shared_ptr<const Executor> exec)
-        : Permutation(std::move(exec), dim<2>{}, row_permute)
+        : Permutation(std::move(exec), dim<2>{})
     {}
 
     /**

--- a/include/ginkgo/core/matrix/permutation.hpp
+++ b/include/ginkgo/core/matrix/permutation.hpp
@@ -130,13 +130,15 @@ protected:
      *
      * @param exec  Executor associated to the matrix
      * @param size  size of the permutable matrix
+     * @param enabled_permute  mask for the type of permutation to apply.
      */
-    Permutation(std::shared_ptr<const Executor> exec, const dim<2> &size)
+    Permutation(std::shared_ptr<const Executor> exec, const dim<2> &size,
+                const mask_type &enabled_permute = row_permute)
         : EnableLinOp<Permutation>(exec, size),
           permutation_(exec, size[0]),
           row_size_(size[0]),
           col_size_(size[1]),
-          enabled_permute_(row_permute)
+          enabled_permute_(enabled_permute)
     {}
 
     /**
@@ -148,6 +150,7 @@ protected:
      * @param exec  Executor associated to the matrix
      * @param size  size of the permutation array.
      * @param permutation_indices array of permutation array
+     * @param enabled_permute  mask for the type of permutation to apply.
      *
      * @note If `permutation_indices` is not an rvalue, not an array of
      * IndexType, or is on the wrong executor, an internal copy will be created,


### PR DESCRIPTION
This PR updates the permutation class and the kernels.

+ The constructor is updated to take in the type of permutation with the sizes.
+ Similar to the strategies, the permutation masks can be get and set to allow for some flexibility.
+ The CUDA and HIP permutation kernels for row, column and their inverses are added.

### TODO
+ [x] Add HIP kernels and tests.
