### PR TITLE
An OSX build with Github actions

### DIFF
--- a/.github/workflows/osx.yml
+++ b/.github/workflows/osx.yml
@@ -3,13 +3,18 @@ name: OSX-build
 on: [push]
 
 jobs:
-  osx-clang-shared:
-
-    name: OSX build shared libs
+  osx-clang-omp:
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+        - {shared: "ON", build_type: "Debug", name: "omp/debug/shared"}
+        - {shared: "OFF", build_type: "Release", name: "omp/release/static"}
+    name: ${{ matrix.config.name }}
     runs-on: [macos-latest]
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     - name: setup
       run: brew install libomp
     - name: info
@@ -20,27 +25,8 @@ jobs:
       run: |
         mkdir build
         cd build
-        cmake ..
-        make -j 10
-        ctest -j 10
-
-  osx-clang-static:
-
-    name: OSX build static libs
-    runs-on: [macos-latest]
-
-    steps:
-    - uses: actions/checkout@v1
-    - name: setup
-      run: brew install libomp
-    - name: info
-      run: |
-        g++ -v
-        cmake  --version
-    - name: configure
-      run: |
-        mkdir build
-        cd build
-        cmake -DBUILD_SHARED_LIBS=off ..
-        make -j 10
-        ctest -j 10
+        cmake .. -DBUILD_SHARED_LIBS=${{ matrix.config.shared }} -DCMAKE_BUILD_TYPE=${{ matrix.config.build_type }}
+        make -j8 
+        ctest -j10
+        make install
+        make test_install

--- a/.github/workflows/osx.yml
+++ b/.github/workflows/osx.yml
@@ -1,0 +1,46 @@
+name: OSX-build
+
+on: [push]
+
+jobs:
+  osx-clang-shared:
+
+    name: OSX build shared libs
+    runs-on: [macos-latest]
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: setup
+      run: brew install libomp
+    - name: info
+      run: |
+        g++ -v
+        cmake --version
+    - name: configure
+      run: |
+        mkdir build
+        cd build
+        cmake ..
+        make -j 10
+        ctest -j 10
+
+  osx-clang-static:
+
+    name: OSX build static libs
+    runs-on: [macos-latest]
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: setup
+      run: brew install libomp
+    - name: info
+      run: |
+        g++ -v
+        cmake  --version
+    - name: configure
+      run: |
+        mkdir build
+        cd build
+        cmake -DBUILD_SHARED_LIBS=off ..
+        make -j 10
+        ctest -j 10

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,8 @@
-cmake_minimum_required(VERSION 3.9)
+if(APPLE)
+  cmake_minimum_required(VERSION 3.12)
+else()
+  cmake_minimum_required(VERSION 3.9)
+endif()
 
 project(Ginkgo LANGUAGES C CXX VERSION 1.1.1 DESCRIPTION "A numerical linear algebra library targeting many-core architectures")
 set(Ginkgo_VERSION_TAG "develop")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,4 @@
-if(APPLE)
-  cmake_minimum_required(VERSION 3.12)
-else()
-  cmake_minimum_required(VERSION 3.9)
-endif()
+cmake_minimum_required(VERSION 3.9)
 
 project(Ginkgo LANGUAGES C CXX VERSION 1.1.1 DESCRIPTION "A numerical linear algebra library targeting many-core architectures")
 set(Ginkgo_VERSION_TAG "develop")

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ![Ginkgo](/assets/logo.png)
 
 [![Build status](https://gitlab.com/ginkgo-project/ginkgo-public-ci/badges/develop/pipeline.svg)](https://github.com/ginkgo-project/ginkgo/commits/develop)
-![OSX-build](https://github.com/ginkgo-project/ginkgo/workflows/OSX-build/badge.svg)
+[![OSX-build](https://github.com/ginkgo-project/ginkgo/workflows/OSX-build/badge.svg)](https://github.com/ginkgo-project/ginkgo/actions?query=workflow%3AOSX-build)
 [![Maintainability Rating](https://sonarcloud.io/api/project_badges/measure?project=ginkgo-project_ginkgo&metric=sqale_rating)](https://sonarcloud.io/dashboard?id=ginkgo-project_ginkgo)
 [![Reliability Rating](https://sonarcloud.io/api/project_badges/measure?project=ginkgo-project_ginkgo&metric=reliability_rating)](https://sonarcloud.io/dashboard?id=ginkgo-project_ginkgo)
 [![CDash dashboard](https://img.shields.io/badge/CDash-Access-blue.svg)](http://my.cdash.org/index.php?project=Ginkgo+Project)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 ![Ginkgo](/assets/logo.png)
 
 [![Build status](https://gitlab.com/ginkgo-project/ginkgo-public-ci/badges/develop/pipeline.svg)](https://github.com/ginkgo-project/ginkgo/commits/develop)
+![OSX-build](https://github.com/ginkgo-project/ginkgo/workflows/OSX-build/badge.svg)
 [![Maintainability Rating](https://sonarcloud.io/api/project_badges/measure?project=ginkgo-project_ginkgo&metric=sqale_rating)](https://sonarcloud.io/dashboard?id=ginkgo-project_ginkgo)
 [![Reliability Rating](https://sonarcloud.io/api/project_badges/measure?project=ginkgo-project_ginkgo&metric=reliability_rating)](https://sonarcloud.io/dashboard?id=ginkgo-project_ginkgo)
 [![CDash dashboard](https://img.shields.io/badge/CDash-Access-blue.svg)](http://my.cdash.org/index.php?project=Ginkgo+Project)

--- a/omp/CMakeLists.txt
+++ b/omp/CMakeLists.txt
@@ -27,8 +27,13 @@ target_sources(ginkgo_omp
         stop/residual_norm_reduction_kernels.cpp)
 
 ginkgo_compile_features(ginkgo_omp)
-target_link_libraries(ginkgo_omp PRIVATE OpenMP::OpenMP_CXX)
-target_compile_options(ginkgo_omp PRIVATE "${OpenMP_CXX_FLAGS}")
+
+target_link_libraries(ginkgo_omp PRIVATE "${OpenMP_CXX_LIBRARIES}")
+target_include_directories(ginkgo_omp PRIVATE "${OpenMP_CXX_INCLUDE_DIRS}")
+# We first separate the arguments, otherwise, the target_compile_options adds it as a string
+# and the compiler is unhappy with the quotation marks.
+separate_arguments(OpenMP_SEP_FLAGS NATIVE_COMMAND "${OpenMP_CXX_FLAGS}")
+target_compile_options(ginkgo_omp PRIVATE "${OpenMP_SEP_FLAGS}")
 target_compile_options(ginkgo_omp PRIVATE "${GINKGO_COMPILER_FLAGS}")
 
 # Need to link against ginkgo_cuda for the `raw_copy_to(CudaExecutor ...)` method

--- a/omp/CMakeLists.txt
+++ b/omp/CMakeLists.txt
@@ -27,7 +27,7 @@ target_sources(ginkgo_omp
         stop/residual_norm_reduction_kernels.cpp)
 
 ginkgo_compile_features(ginkgo_omp)
-target_link_libraries(ginkgo_omp PRIVATE "${OpenMP_CXX_LIBRARIES}")
+target_link_libraries(ginkgo_omp PRIVATE OpenMP::OpenMP_CXX)
 target_compile_options(ginkgo_omp PRIVATE "${OpenMP_CXX_FLAGS}")
 target_compile_options(ginkgo_omp PRIVATE "${GINKGO_COMPILER_FLAGS}")
 

--- a/test_install/CMakeLists.txt
+++ b/test_install/CMakeLists.txt
@@ -34,6 +34,10 @@ if((NOT GINKGO_BUILD_SHARED_LIBS) AND GINKGO_BUILD_HIP)
     endif()
 endif()
 
+if(GINKGO_BUILD_OMP)
+  find_package(OpenMP REQUIRED)
+endif()
+
 add_executable(test_install test_install.cpp)
 target_compile_features(test_install PUBLIC cxx_std_11)
 target_link_libraries(test_install PRIVATE Ginkgo::ginkgo)

--- a/test_install/CMakeLists.txt
+++ b/test_install/CMakeLists.txt
@@ -34,10 +34,6 @@ if((NOT GINKGO_BUILD_SHARED_LIBS) AND GINKGO_BUILD_HIP)
     endif()
 endif()
 
-if(GINKGO_BUILD_OMP)
-  find_package(OpenMP REQUIRED)
-endif()
-
 add_executable(test_install test_install.cpp)
 target_compile_features(test_install PUBLIC cxx_std_11)
 target_link_libraries(test_install PRIVATE Ginkgo::ginkgo)


### PR DESCRIPTION
This PR adds an OSX build with github-actions. You can access it either by clicking on the Actions tab on top, or at the bottom, where it is run.

It runs our basic configure step without CUDA and HIP on the Apple Clang compiler.

We can additionally add a badge to say that we compile and test on Apple as well. 

Also modifies our OpenMP linking to use the modern CMake Targets.