### PR TITLE
Fix windows cuda generic

### DIFF
--- a/benchmark/conversions/conversions.cpp
+++ b/benchmark/conversions/conversions.cpp
@@ -195,5 +195,5 @@ int main(int argc, char *argv[])
         }
     }
 
-    std::cout << test_cases;
+    std::cout << test_cases << std::endl;
 }

--- a/benchmark/matrix_generator/matrix_generator.cpp
+++ b/benchmark/matrix_generator/matrix_generator.cpp
@@ -151,5 +151,5 @@ int main(int argc, char *argv[])
         }
     }
 
-    std::cout << configurations;
+    std::cout << configurations << std::endl;
 }

--- a/benchmark/matrix_statistics/matrix_statistics.cpp
+++ b/benchmark/matrix_statistics/matrix_statistics.cpp
@@ -208,5 +208,5 @@ int main(int argc, char *argv[])
         }
     }
 
-    std::cout << test_cases;
+    std::cout << test_cases << std::endl;
 }

--- a/benchmark/preconditioner/preconditioner.cpp
+++ b/benchmark/preconditioner/preconditioner.cpp
@@ -310,5 +310,5 @@ int main(int argc, char *argv[])
         }
     }
 
-    std::cout << test_cases;
+    std::cout << test_cases << std::endl;
 }

--- a/benchmark/solver/solver.cpp
+++ b/benchmark/solver/solver.cpp
@@ -467,5 +467,5 @@ int main(int argc, char *argv[])
         }
     }
 
-    std::cout << test_cases;
+    std::cout << test_cases << std::endl;
 }

--- a/benchmark/spmv/spmv.cpp
+++ b/benchmark/spmv/spmv.cpp
@@ -223,5 +223,5 @@ int main(int argc, char *argv[])
         }
     }
 
-    std::cout << test_cases;
+    std::cout << test_cases << std::endl;
 }

--- a/benchmark/utils/cuda_linops.hpp
+++ b/benchmark/utils/cuda_linops.hpp
@@ -482,7 +482,8 @@ private:
 };
 
 
-#if defined(CUDA_VERSION) && (CUDA_VERSION >= 10010)
+#if defined(CUDA_VERSION) && (CUDA_VERSION >= 10010) && \
+    !(defined(_WIN32) || defined(__CYGWIN__))
 
 
 template <typename ValueType>
@@ -677,7 +678,8 @@ private:
 };
 
 
-#endif  // defined(CUDA_VERSION) && (CUDA_VERSION >= 10010)
+#endif  // defined(CUDA_VERSION) && (CUDA_VERSION >= 10010) &&
+        // !(defined(_WIN32) || defined(__CYGWIN__))
 
 
 }  // namespace detail
@@ -690,7 +692,8 @@ using cusp_csrmp = detail::CuspCsrmp<>;
 using cusp_csrmm = detail::CuspCsrmm<>;
 
 
-#if defined(CUDA_VERSION) && (CUDA_VERSION >= 10010)
+#if defined(CUDA_VERSION) && (CUDA_VERSION >= 10010) && \
+    !(defined(_WIN32) || defined(__CYGWIN__))
 
 
 using cusp_gcsr = detail::CuspGenericCsr<>;
@@ -699,7 +702,8 @@ using cusp_gcsr2 =
 using cusp_gcoo = detail::CuspGenericCoo<>;
 
 
-#endif  // defined(CUDA_VERSION) && (CUDA_VERSION >= 10010)
+#endif  // defined(CUDA_VERSION) && (CUDA_VERSION >= 10010) &&
+        // !(defined(_WIN32) || defined(__CYGWIN__))
 
 
 using cusp_coo =

--- a/benchmark/utils/formats.hpp
+++ b/benchmark/utils/formats.hpp
@@ -97,7 +97,8 @@ std::string format_description =
     "cusp_csrex: benchmark CuSPARSE with the cusparseXcsrmvEx function.\n"
     "cusp_csrmp: benchmark CuSPARSE with the cusparseXcsrmv_mp function.\n"
     "cusp_csrmm: benchmark CuSPARSE with the cusparseXcsrmv_mm function."
-#if defined(CUDA_VERSION) && (CUDA_VERSION >= 10010)
+#if defined(CUDA_VERSION) && (CUDA_VERSION >= 10010) && \
+    !(defined(_WIN32) || defined(__CYGWIN__))
     "\n"
     "cusp_gcsr: benchmark CuSPARSE with the generic csr with default "
     "algorithm.\n"
@@ -105,7 +106,8 @@ std::string format_description =
     "CUSPARSE_CSRMV_ALG2.\n"
     "cusp_gcoo: benchmark CuSPARSE with the generic coo with default "
     "algorithm.\n"
-#endif  // defined(CUDA_VERSION) && (CUDA_VERSION >= 10010)
+#endif  // defined(CUDA_VERSION) && (CUDA_VERSION >= 10010) &&
+        // !(defined(_WIN32) || defined(__CYGWIN__))
 #endif  // HAS_CUDA
 #ifdef HAS_HIP
     "\n"
@@ -192,11 +194,13 @@ const std::map<std::string, std::function<std::unique_ptr<gko::LinOp>(
         {"cusp_hybrid", read_matrix_from_data<cusp_hybrid>},
         {"cusp_coo", read_matrix_from_data<cusp_coo>},
         {"cusp_ell", read_matrix_from_data<cusp_ell>},
-#if defined(CUDA_VERSION) && (CUDA_VERSION >= 10010)
+#if defined(CUDA_VERSION) && (CUDA_VERSION >= 10010) && \
+    !(defined(_WIN32) || defined(__CYGWIN__))
         {"cusp_gcsr", read_matrix_from_data<cusp_gcsr>},
         {"cusp_gcsr2", read_matrix_from_data<cusp_gcsr2>},
         {"cusp_gcoo", read_matrix_from_data<cusp_gcoo>},
-#endif  // defined(CUDA_VERSION) && (CUDA_VERSION >= 10010)
+#endif  // defined(CUDA_VERSION) && (CUDA_VERSION >= 10010) &&
+        // !(defined(_WIN32) || defined(__CYGWIN__))
 #endif  // HAS_CUDA
 #ifdef HAS_HIP
         {"hipsp_csr", read_matrix_from_data<hipsp_csr>},

--- a/cuda/base/types.hpp
+++ b/cuda/base/types.hpp
@@ -191,7 +191,8 @@ constexpr cudaDataType_t cuda_data_type_impl<uint8>()
 }
 
 
-#if defined(CUDA_VERSION) && (CUDA_VERSION >= 10010)
+#if defined(CUDA_VERSION) && (CUDA_VERSION >= 10010) && \
+    !(defined(_WIN32) || defined(__CYGWIN__))
 
 
 template <typename T>
@@ -213,7 +214,8 @@ constexpr cusparseIndexType_t cusparse_index_type_impl<int64>()
 }
 
 
-#endif  // defined(CUDA_VERSION) && (CUDA_VERSION >= 10010)
+#endif  // defined(CUDA_VERSION) && (CUDA_VERSION >= 10010) &&
+        // !(defined(_WIN32) || defined(__CYGWIN__))
 
 
 }  // namespace detail
@@ -234,7 +236,8 @@ constexpr cudaDataType_t cuda_data_type()
 }
 
 
-#if defined(CUDA_VERSION) && (CUDA_VERSION >= 10010)
+#if defined(CUDA_VERSION) && (CUDA_VERSION >= 10010) && \
+    !(defined(_WIN32) || defined(__CYGWIN__))
 
 
 /**
@@ -252,7 +255,8 @@ constexpr cusparseIndexType_t cusparse_index_type()
 }
 
 
-#endif  // defined(CUDA_VERSION) && (CUDA_VERSION >= 10010)
+#endif  // defined(CUDA_VERSION) && (CUDA_VERSION >= 10010) &&
+        // !(defined(_WIN32) || defined(__CYGWIN__))
 
 
 /**


### PR DESCRIPTION
This PR add the windows condition on enabling cuda generic api

In the PR #468 , adding the cuda generic api.
However, cuda generic api does not support windows https://docs.nvidia.com/cuda/cusparse/index.html#cusparse-generic-api-reference in cuda 10.2
It lead the failed compilation in windows which is caught by [gitlab-ci](https://gitlab.com/ginkgo-project/ginkgo-public-ci/pipelines/123110689) or [github action](https://github.com/ginkgo-project/ginkgo/actions/runs/49335880) in #471 

Moreover, I add the newline in the final output of benchmark.
When benchmark writes the result to standard output, it gives `]` in the head of command line, which is sometimes annoying on some terminal.
```
]mike@workstation:~$ command||
```
when moving the cursor to left, it re-render the command without `]` in the head
like
```
]mike@workstation:~$ comm||nd
```
Move all letters 1 left.
