### PR TITLE
Using next_krylov_basis instead of krylov_bases to save unnecessary p…

### DIFF
--- a/common/solver/gmres_kernels.hpp.inc
+++ b/common/solver/gmres_kernels.hpp.inc
@@ -96,6 +96,7 @@ __global__ __launch_bounds__(block_size) void initialize_2_2_kernel(
     const ValueType *__restrict__ residual_norm,
     ValueType *__restrict__ residual_norm_collection,
     ValueType *__restrict__ krylov_bases, size_type stride_krylov,
+    ValueType *__restrict__ next_krylov_basis, size_type stride_next_krylov,
     size_type *__restrict__ final_iter_nums)
 {
     const auto global_id = thread::get_thread_id_flat();
@@ -108,9 +109,10 @@ __global__ __launch_bounds__(block_size) void initialize_2_2_kernel(
     }
 
     if (row_idx < num_rows && col_idx < num_rhs) {
-        krylov_bases[row_idx * stride_krylov + col_idx] =
-            residual[row_idx * stride_residual + col_idx] /
-            residual_norm[col_idx];
+        auto value = residual[row_idx * stride_residual + col_idx] /
+                     residual_norm[col_idx];
+        krylov_bases[row_idx * stride_krylov + col_idx] = value;
+        next_krylov_basis[row_idx * stride_next_krylov + col_idx] = value;
     }
 }
 

--- a/core/solver/gmres.cpp
+++ b/core/solver/gmres.cpp
@@ -123,7 +123,7 @@ void Gmres<ValueType>::apply_impl(const LinOp *b, LinOp *x) const
     // residual_norm = norm(residual)
     // residual_norm_collection = {residual_norm, 0, ..., 0}
     // krylov_bases(:, 1) = residual / residual_norm
-    //
+    // next_krylov_basis = residual / residual_norm
     // final_iter_nums = {0, ..., 0}
 
     auto stop_criterion = stop_criterion_factory_->generate(
@@ -177,14 +177,14 @@ void Gmres<ValueType>::apply_impl(const LinOp *b, LinOp *x) const
             // residual_norm = norm(residual)
             // residual_norm_collection = {residual_norm, 0, ..., 0}
             // krylov_bases(:, 1) = residual / residual_norm
+            // next_krylov_basis = residual / residual_norm
             // final_iter_nums = {0, ..., 0}
             restart_iter = 0;
         }
 
         get_preconditioner()->apply(next_krylov_basis.get(),
                                     preconditioned_vector.get());
-        // preconditioned_vector = get_preconditioner() *
-        //                         krylov_bases(:, restart_iter)
+        // preconditioned_vector = get_preconditioner() * next_krylov_basis
 
         // Do Arnoldi and givens rotation
         auto hessenberg_iter = hessenberg->create_submatrix(

--- a/core/solver/gmres_kernels.hpp
+++ b/core/solver/gmres_kernels.hpp
@@ -60,6 +60,7 @@ namespace gmres {
                       matrix::Dense<_type> *residual_norm,            \
                       matrix::Dense<_type> *residual_norm_collection, \
                       matrix::Dense<_type> *krylov_bases,             \
+                      matrix::Dense<_type> *next_krylov_basis,        \
                       Array<size_type> *final_iter_nums, size_type krylov_dim)
 
 

--- a/cuda/solver/gmres_kernels.cu
+++ b/cuda/solver/gmres_kernels.cu
@@ -108,6 +108,7 @@ void initialize_2(std::shared_ptr<const CudaExecutor> exec,
                   matrix::Dense<ValueType> *residual_norm,
                   matrix::Dense<ValueType> *residual_norm_collection,
                   matrix::Dense<ValueType> *krylov_bases,
+                  matrix::Dense<ValueType> *next_krylov_basis,
                   Array<size_type> *final_iter_nums, size_type krylov_dim)
 {
     const auto num_rows = residual->get_size()[0];
@@ -133,6 +134,8 @@ void initialize_2(std::shared_ptr<const CudaExecutor> exec,
         as_cuda_type(residual_norm->get_const_values()),
         as_cuda_type(residual_norm_collection->get_values()),
         as_cuda_type(krylov_bases->get_values()), krylov_bases->get_stride(),
+        as_cuda_type(next_krylov_basis->get_values()),
+        next_krylov_basis->get_stride(),
         as_cuda_type(final_iter_nums->get_data()));
 }
 

--- a/cuda/test/solver/gmres_kernels.cpp
+++ b/cuda/test/solver/gmres_kernels.cpp
@@ -215,16 +215,19 @@ TEST_F(Gmres, CudaGmresInitialize2IsEquivalentToRef)
     gko::kernels::reference::gmres::initialize_2(
         ref, residual.get(), residual_norm.get(),
         residual_norm_collection.get(), krylov_bases.get(),
-        final_iter_nums.get(), gko::solver::default_krylov_dim);
+        next_krylov_basis.get(), final_iter_nums.get(),
+        gko::solver::default_krylov_dim);
     gko::kernels::cuda::gmres::initialize_2(
         cuda, d_residual.get(), d_residual_norm.get(),
         d_residual_norm_collection.get(), d_krylov_bases.get(),
-        d_final_iter_nums.get(), gko::solver::default_krylov_dim);
+        d_next_krylov_basis.get(), d_final_iter_nums.get(),
+        gko::solver::default_krylov_dim);
 
     GKO_ASSERT_MTX_NEAR(d_residual_norm, residual_norm, 1e-14);
     GKO_ASSERT_MTX_NEAR(d_residual_norm_collection, residual_norm_collection,
                         1e-14);
     GKO_ASSERT_MTX_NEAR(d_krylov_bases, krylov_bases, 1e-14);
+    GKO_ASSERT_MTX_NEAR(d_next_krylov_basis, next_krylov_basis, 1e-14);
     GKO_ASSERT_ARRAY_EQ(d_final_iter_nums, final_iter_nums);
 }
 

--- a/hip/solver/gmres_kernels.hip.cpp
+++ b/hip/solver/gmres_kernels.hip.cpp
@@ -112,6 +112,7 @@ void initialize_2(std::shared_ptr<const HipExecutor> exec,
                   matrix::Dense<ValueType> *residual_norm,
                   matrix::Dense<ValueType> *residual_norm_collection,
                   matrix::Dense<ValueType> *krylov_bases,
+                  matrix::Dense<ValueType> *next_krylov_basis,
                   Array<size_type> *final_iter_nums, size_type krylov_dim)
 {
     const auto num_rows = residual->get_size()[0];
@@ -140,6 +141,8 @@ void initialize_2(std::shared_ptr<const HipExecutor> exec,
         as_hip_type(residual_norm->get_const_values()),
         as_hip_type(residual_norm_collection->get_values()),
         as_hip_type(krylov_bases->get_values()), krylov_bases->get_stride(),
+        as_hip_type(next_krylov_basis->get_values()),
+        next_krylov_basis->get_stride(),
         as_hip_type(final_iter_nums->get_data()));
 }
 

--- a/hip/test/solver/gmres_kernels.cpp
+++ b/hip/test/solver/gmres_kernels.cpp
@@ -215,16 +215,19 @@ TEST_F(Gmres, HipGmresInitialize2IsEquivalentToRef)
     gko::kernels::reference::gmres::initialize_2(
         ref, residual.get(), residual_norm.get(),
         residual_norm_collection.get(), krylov_bases.get(),
-        final_iter_nums.get(), gko::solver::default_krylov_dim);
+        next_krylov_basis.get(), final_iter_nums.get(),
+        gko::solver::default_krylov_dim);
     gko::kernels::hip::gmres::initialize_2(
         hip, d_residual.get(), d_residual_norm.get(),
         d_residual_norm_collection.get(), d_krylov_bases.get(),
-        d_final_iter_nums.get(), gko::solver::default_krylov_dim);
+        next_krylov_basis.get(), d_final_iter_nums.get(),
+        gko::solver::default_krylov_dim);
 
     GKO_ASSERT_MTX_NEAR(d_residual_norm, residual_norm, 1e-14);
     GKO_ASSERT_MTX_NEAR(d_residual_norm_collection, residual_norm_collection,
                         1e-14);
     GKO_ASSERT_MTX_NEAR(d_krylov_bases, krylov_bases, 1e-14);
+    GKO_ASSERT_MTX_NEAR(d_next_krylov_basis, next_krylov_basis, 1e-14);
     GKO_ASSERT_ARRAY_EQ(d_final_iter_nums, final_iter_nums);
 }
 

--- a/omp/solver/gmres_kernels.cpp
+++ b/omp/solver/gmres_kernels.cpp
@@ -293,6 +293,7 @@ void initialize_2(std::shared_ptr<const OmpExecutor> exec,
                   matrix::Dense<ValueType> *residual_norm,
                   matrix::Dense<ValueType> *residual_norm_collection,
                   matrix::Dense<ValueType> *krylov_bases,
+                  matrix::Dense<ValueType> *next_krylov_basis,
                   Array<size_type> *final_iter_nums, size_type krylov_dim)
 {
     for (size_type j = 0; j < residual->get_size()[1]; ++j) {
@@ -318,8 +319,9 @@ void initialize_2(std::shared_ptr<const OmpExecutor> exec,
 
 #pragma omp parallel for
         for (size_type i = 0; i < residual->get_size()[0]; ++i) {
-            krylov_bases->at(i, j) =
-                residual->at(i, j) / residual_norm->at(0, j);
+            auto value = residual->at(i, j) / residual_norm->at(0, j);
+            krylov_bases->at(i, j) = value;
+            next_krylov_basis->at(i, j) = value;
         }
         final_iter_nums->get_data()[j] = 0;
     }

--- a/omp/test/solver/gmres_kernels.cpp
+++ b/omp/test/solver/gmres_kernels.cpp
@@ -214,16 +214,19 @@ TEST_F(Gmres, OmpGmresInitialize2IsEquivalentToRef)
     gko::kernels::reference::gmres::initialize_2(
         ref, residual.get(), residual_norm.get(),
         residual_norm_collection.get(), krylov_bases.get(),
-        final_iter_nums.get(), gko::solver::default_krylov_dim);
+        next_krylov_basis.get(), final_iter_nums.get(),
+        gko::solver::default_krylov_dim);
     gko::kernels::omp::gmres::initialize_2(
         omp, d_residual.get(), d_residual_norm.get(),
         d_residual_norm_collection.get(), d_krylov_bases.get(),
-        d_final_iter_nums.get(), gko::solver::default_krylov_dim);
+        d_next_krylov_basis.get(), d_final_iter_nums.get(),
+        gko::solver::default_krylov_dim);
 
     GKO_ASSERT_MTX_NEAR(d_residual_norm, residual_norm, 1e-14);
     GKO_ASSERT_MTX_NEAR(d_residual_norm_collection, residual_norm_collection,
                         1e-14);
     GKO_ASSERT_MTX_NEAR(d_krylov_bases, krylov_bases, 1e-14);
+    GKO_ASSERT_MTX_NEAR(d_next_krylov_basis, next_krylov_basis, 1e-14);
     GKO_ASSERT_ARRAY_EQ(d_final_iter_nums, final_iter_nums);
 }
 

--- a/reference/solver/gmres_kernels.cpp
+++ b/reference/solver/gmres_kernels.cpp
@@ -270,6 +270,7 @@ void initialize_2(std::shared_ptr<const ReferenceExecutor> exec,
                   matrix::Dense<ValueType> *residual_norm,
                   matrix::Dense<ValueType> *residual_norm_collection,
                   matrix::Dense<ValueType> *krylov_bases,
+                  matrix::Dense<ValueType> *next_krylov_basis,
                   Array<size_type> *final_iter_nums, size_type krylov_dim)
 {
     for (size_type j = 0; j < residual->get_size()[1]; ++j) {
@@ -289,6 +290,8 @@ void initialize_2(std::shared_ptr<const ReferenceExecutor> exec,
         }
         for (size_type i = 0; i < residual->get_size()[0]; ++i) {
             krylov_bases->at(i, j) =
+                residual->at(i, j) / residual_norm->at(0, j);
+            next_krylov_basis->at(i, j) =
                 residual->at(i, j) / residual_norm->at(0, j);
         }
         final_iter_nums->get_data()[j] = 0;


### PR DESCRIPTION
…adding in the preconditioned vector. This made it necessary to choose a different spmv strategy when using plain GMRES or with ilu preconditioner, since the default choice doesn't support multiple vectors. 