### PR TITLE
update clang-format requirement and commit

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ The Ginkgo CUDA module has the following __additional__ requirements:
 In addition, if you want to contribute code to Ginkgo, you will also need the
 following:
 
-*   _clang-format 5.0.1+_ (ships as part of _clang_)
+*   _clang-format 5.0.0+_ (ships as part of _clang_)
 *   _clang-tidy_ (optional, when setting the flag `-DGINKGO_WITH_CLANG_TIDY=ON`)
 *   _iwyu_ (Include What You Use, optional, when setting the flag `-DGINKGO_WITH_IWYU=ON`)
 

--- a/third_party/git-cmake-format/CMakeLists.txt
+++ b/third_party/git-cmake-format/CMakeLists.txt
@@ -1,6 +1,6 @@
 ginkgo_load_git_package(git-cmake-format
     "https://github.com/ginkgo-project/git-cmake-format.git"
-    "46d2b43b24fa3aea366be9cce21abfdfffcf0090"
-    "-DGCF_CLANGFORMAT_MINIMAL_VERSION=5.0.1")
+    "29c23665d624e1cae1308bec651706fdaa8fe38b"
+    "-DGCF_CLANGFORMAT_MINIMAL_VERSION=5.0.0")
 add_subdirectory(${CMAKE_CURRENT_BINARY_DIR}/src
     ${CMAKE_CURRENT_BINARY_DIR}/build EXCLUDE_FROM_ALL)


### PR DESCRIPTION
This PR update clang-format related changes.

1. the minimal requirement `5.0.1+` -> `5.0.0+`
2. update the commit `git-cmake-format`

Although clang-format with different version leads slight difference, I keep the lowest version which allows the current clang-format config.

