### PR TITLE
Fix the view memory leak and array/view copy/move.

### DIFF
--- a/core/test/base/array.cpp
+++ b/core/test/base/array.cpp
@@ -33,6 +33,9 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <ginkgo/core/base/array.hpp>
 
 
+#include <algorithm>
+
+
 #include <gtest/gtest.h>
 
 
@@ -284,14 +287,43 @@ TYPED_TEST(Array, CanBeResized)
 }
 
 
-TYPED_TEST(Array, VewCanBeResetNotResized)
+TYPED_TEST(Array, ViewCannotBeResized)
 {
     TypeParam data[] = {1, 2, 3};
     auto view = gko::Array<TypeParam>::view(this->exec, 3, data);
-    view.resize_and_reset(1);
 
-    EXPECT_EQ(view.get_const_data(), nullptr);
-    ASSERT_EQ(view.get_num_elems(), 1);
+    EXPECT_THROW(view.resize_and_reset(1), gko::NotSupported);
+    EXPECT_EQ(view.get_num_elems(), 3);
+    ASSERT_EQ(view.get_data()[0], TypeParam{1});
+}
+
+
+template <typename T>
+class my_null_deleter {
+public:
+    using pointer = T *;
+
+    void operator()(pointer) const noexcept {}
+};
+
+template <typename T>
+class my_null_deleter<T[]> {
+public:
+    using pointer = T[];
+
+    void operator()(pointer) const noexcept {}
+};
+
+
+TYPED_TEST(Array, CustomDeleterCannotBeResized)
+{
+    TypeParam data[] = {1, 2, 3};
+    auto view_custom_deleter = gko::Array<TypeParam>(
+        this->exec, 3, data, my_null_deleter<TypeParam[]>{});
+
+    EXPECT_THROW(view_custom_deleter.resize_and_reset(1), gko::NotSupported);
+    EXPECT_EQ(view_custom_deleter.get_num_elems(), 3);
+    ASSERT_EQ(view_custom_deleter.get_data()[0], TypeParam{1});
 }
 
 
@@ -342,6 +374,7 @@ TYPED_TEST(Array, CopyArrayToArray)
     EXPECT_EQ(array.get_data()[2], TypeParam{2});
     EXPECT_EQ(array.get_data()[3], TypeParam{1});
     EXPECT_EQ(array.get_num_elems(), 4);
+    EXPECT_NE(array.get_data(), array2.get_data());
     ASSERT_EQ(array2.get_num_elems(), 4);
 }
 
@@ -363,6 +396,7 @@ TYPED_TEST(Array, CopyViewToView)
     EXPECT_EQ(data[2], TypeParam{2});
     EXPECT_EQ(view.get_num_elems(), 3);
     EXPECT_EQ(view2.get_num_elems(), 3);
+    EXPECT_EQ(view2.get_data()[0], TypeParam{2});
     ASSERT_THROW(view2 = view_size4, gko::OutOfBoundsError);
 }
 
@@ -407,9 +441,11 @@ TYPED_TEST(Array, MoveArrayToArray)
 {
     gko::Array<TypeParam> array(this->exec, {1, 2, 3});
     gko::Array<TypeParam> array2(this->exec, {5, 4, 2, 1});
+    auto data2 = array2.get_data();
 
     array = std::move(array2);
 
+    EXPECT_EQ(array.get_data(), data2);
     EXPECT_EQ(array.get_data()[0], TypeParam{5});
     EXPECT_EQ(array.get_data()[1], TypeParam{4});
     EXPECT_EQ(array.get_data()[2], TypeParam{2});
@@ -435,7 +471,12 @@ TYPED_TEST(Array, MoveViewToView)
     EXPECT_EQ(view.get_data()[2], TypeParam{2});
     EXPECT_EQ(view.get_num_elems(), 3);
     EXPECT_EQ(view2.get_data(), nullptr);
-    ASSERT_EQ(view2.get_num_elems(), 0);
+    EXPECT_EQ(view2.get_num_elems(), 0);
+    EXPECT_NE(data, nullptr);
+    EXPECT_EQ(data[0], TypeParam{1});
+    EXPECT_EQ(data[1], TypeParam{2});
+    EXPECT_EQ(data[2], TypeParam{3});
+    ASSERT_EQ(data[3], TypeParam{4});
 }
 
 
@@ -468,13 +509,18 @@ TYPED_TEST(Array, MoveArrayToView)
     auto view = gko::Array<TypeParam>::view(this->exec, 3, data);
     gko::Array<TypeParam> array_size2(this->exec, {5, 4});
     gko::Array<TypeParam> array_size4(this->exec, {5, 4, 2, 1});
+    auto size2_ptr = array_size2.get_data();
+    auto size4_ptr = array_size4.get_data();
 
     view = std::move(array_size2);
 
     EXPECT_EQ(view.get_data()[0], TypeParam{5});
     EXPECT_EQ(view.get_data()[1], TypeParam{4});
     EXPECT_EQ(view.get_num_elems(), 2);
-    EXPECT_NO_THROW(view = array_size4);
+    EXPECT_NE(view.get_data(), data);
+    EXPECT_EQ(view.get_data(), size2_ptr);
+    EXPECT_NO_THROW(view = std::move(array_size4));
+    EXPECT_EQ(view.get_data(), size4_ptr);
     EXPECT_EQ(array_size2.get_data(), nullptr);
     ASSERT_EQ(array_size2.get_num_elems(), 0);
 }

--- a/include/ginkgo/core/base/exception_helpers.hpp
+++ b/include/ginkgo/core/base/exception_helpers.hpp
@@ -455,6 +455,25 @@ inline T ensure_allocated_impl(T ptr, const std::string &file, int line,
 
 
 /**
+ * Ensures that two dimensions have compatible bounds, in particular before a
+ * copy operation. This means the target should have at least as much elements
+ * as the source.
+ *
+ * @param _source  the source of the expected copy operation
+ * @param _target  the destination of the expected copy operation
+ *
+ * @throw OutOfBoundsError  if `_source > _target`
+ */
+#define GKO_ENSURE_COMPATIBLE_BOUNDS(_source, _target)                       \
+    if (_source > _target) {                                                 \
+        throw ::gko::OutOfBoundsError(__FILE__, __LINE__, _source, _target); \
+    }                                                                        \
+    static_assert(true,                                                      \
+                  "This assert is used to counter the false positive extra " \
+                  "semi-colon warnings")
+
+
+/**
  * Creates a StreamError exception.
  * This macro sets the correct information about the location of the error
  * and fills the exception with data about the stream, and the reason for the


### PR DESCRIPTION
This fixes some of the discussed issues with arrays. The changes are noted in the list below. Some of these points should still be discussed.

+ Add tests for copy/move of all combinations of array/view.
+ Add a new exception helper macro for testing array dimensions.
+ When copying something into a view, do bound checking and ensure what is
  copied has a compatible amount of data.
+ When copying into an array, the proper amount of data is allocated and copied
   over.
+ When moving a into b, b becomes a and a is invalid afterwards.
+ Resize and reset for views throws an error.