### PR TITLE
Improve RTTI use for error messages

### DIFF
--- a/core/test/base/exception_helpers.cpp
+++ b/core/test/base/exception_helpers.cpp
@@ -55,11 +55,48 @@ TEST(NotCompiled, ThrowsWhenUsed)
 }
 
 
-void does_not_support_int() { GKO_NOT_SUPPORTED(int{}); }
-
-TEST(NotSupported, ReturnsNotSupportedException)
+template <typename Expected, typename T>
+void test_not_supported_impl(const T &obj)
 {
-    ASSERT_THROW(does_not_support_int(), gko::NotSupported);
+    try {
+        GKO_NOT_SUPPORTED(obj);
+        FAIL();
+    } catch (gko::NotSupported &m) {
+        // check for equal suffix
+        std::string msg{m.what()};
+        auto expected = gko::name_demangling::get_type_name(typeid(Expected));
+        ASSERT_TRUE(
+            std::equal(expected.rbegin(), expected.rend(), msg.rbegin()));
+    }
+}
+
+
+TEST(NotSupported, ReturnsIntNotSupportedException)
+{
+    test_not_supported_impl<int>(int{});
+}
+
+
+struct Base {
+    virtual ~Base() = default;
+};
+
+struct Derived : Base {};
+
+
+TEST(NotSupported, ReturnsPtrNotSupportedException)
+{
+    Derived d;
+    Base *b = &d;
+    test_not_supported_impl<Derived>(b);
+}
+
+
+TEST(NotSupported, ReturnsRefNotSupportedException)
+{
+    Derived d;
+    Base &b = d;
+    test_not_supported_impl<Derived>(b);
 }
 
 

--- a/core/test/base/exception_helpers.cpp
+++ b/core/test/base/exception_helpers.cpp
@@ -55,7 +55,7 @@ TEST(NotCompiled, ThrowsWhenUsed)
 }
 
 
-void does_not_support_int() { GKO_NOT_SUPPORTED(int); }
+void does_not_support_int() { GKO_NOT_SUPPORTED(int{}); }
 
 TEST(NotSupported, ReturnsNotSupportedException)
 {

--- a/core/test/base/utils.cpp
+++ b/core/test/base/utils.cpp
@@ -248,7 +248,15 @@ TEST(As, FailsToConvertIfNotRelated)
     Derived d;
     Base *b = &d;
 
-    ASSERT_THROW(gko::as<NonRelated>(b), gko::NotSupported);
+    try {
+        gko::as<NonRelated>(b);
+        FAIL();
+    } catch (gko::NotSupported &m) {
+        std::string msg{m.what()};
+        auto expected = gko::name_demangling::get_type_name(typeid(Derived));
+        ASSERT_TRUE(
+            std::equal(expected.rbegin(), expected.rend(), msg.rbegin()));
+    }
 }
 
 
@@ -266,7 +274,15 @@ TEST(As, FailsToConvertConstantIfNotRelated)
     Derived d;
     const Base *b = &d;
 
-    ASSERT_THROW(gko::as<NonRelated>(b), gko::NotSupported);
+    try {
+        gko::as<NonRelated>(b);
+        FAIL();
+    } catch (gko::NotSupported &m) {
+        std::string msg{m.what()};
+        auto expected = gko::name_demangling::get_type_name(typeid(Derived));
+        ASSERT_TRUE(
+            std::equal(expected.rbegin(), expected.rend(), msg.rbegin()));
+    }
 }
 
 

--- a/cuda/base/executor.cpp
+++ b/cuda/base/executor.cpp
@@ -135,7 +135,7 @@ void CudaExecutor::raw_copy_to(const HipExecutor *src, size_type num_bytes,
     GKO_ASSERT_NO_CUDA_ERRORS(cudaMemcpyPeer(
         dest_ptr, this->device_id_, src_ptr, src->get_device_id(), num_bytes));
 #else
-    GKO_NOT_SUPPORTED(CudaExecutor);
+    GKO_NOT_SUPPORTED(this);
 #endif
 }
 

--- a/hip/base/executor.hip.cpp
+++ b/hip/base/executor.hip.cpp
@@ -126,7 +126,7 @@ void HipExecutor::raw_copy_to(const CudaExecutor *src, size_type num_bytes,
     GKO_ASSERT_NO_HIP_ERRORS(hipMemcpyPeer(dest_ptr, this->device_id_, src_ptr,
                                            src->get_device_id(), num_bytes));
 #else
-    GKO_NOT_SUPPORTED(HipExecutor);
+    GKO_NOT_SUPPORTED(this);
 #endif
 }
 

--- a/include/ginkgo/core/base/utils.hpp
+++ b/include/ginkgo/core/base/utils.hpp
@@ -291,8 +291,10 @@ inline typename std::decay<T>::type *as(U *obj)
     if (auto p = dynamic_cast<typename std::decay<T>::type *>(obj)) {
         return p;
     } else {
-        throw NotSupported(__FILE__, __LINE__, __func__,
-                           name_demangling::get_type_name(typeid(obj)));
+        throw NotSupported(__FILE__, __LINE__,
+                           std::string{"gko::as<"} +
+                               name_demangling::get_type_name(typeid(T)) + ">",
+                           name_demangling::get_type_name(typeid(*obj)));
     }
 }
 
@@ -315,8 +317,10 @@ inline const typename std::decay<T>::type *as(const U *obj)
     if (auto p = dynamic_cast<const typename std::decay<T>::type *>(obj)) {
         return p;
     } else {
-        throw NotSupported(__FILE__, __LINE__, __func__,
-                           name_demangling::get_type_name(typeid(obj)));
+        throw NotSupported(__FILE__, __LINE__,
+                           std::string{"gko::as<"} +
+                               name_demangling::get_type_name(typeid(T)) + ">",
+                           name_demangling::get_type_name(typeid(*obj)));
     }
 }
 


### PR DESCRIPTION
Currently in all of our error messages that use RTTI, we print the static type of a pointer instead of the dynamic type of the pointee. This PR fixes that behavior.

Before:

```
Operation as does not support parameters of type const gko::LinOp *
```

After:

```
Operation gko::as<gko::matrix::Ell> does not support parameters of type gko::matrix::Coo
```