### PR TITLE
Fix MSVC C2398

### DIFF
--- a/core/base/iterator_factory.hpp
+++ b/core/base/iterator_factory.hpp
@@ -292,7 +292,7 @@ private:
 
         Reference operator*() const { return {parent_, arr_index_}; }
 
-        Reference operator[](size_t idx) const
+        Reference operator[](difference_type idx) const
         {
             return {parent_, arr_index_ + idx};
         }


### PR DESCRIPTION
Github action update their MSVC version such that C2398 error occurs.
If this change is interface breaking, `static_cast` should also be fine.
This also fixes the error in #489 

The original MSVC: 19.24.28316.0
The current MSVC: 19.25.28610.4
c2398 log: https://github.com/ginkgo-project/ginkgo/actions/runs/64602526