### PR TITLE
pragma unroll warning in hip

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -58,7 +58,7 @@ stages:
         -DGINKGO_BUILD_OMP=${BUILD_OMP} -DGINKGO_BUILD_CUDA=${BUILD_CUDA}
         -DGINKGO_BUILD_HIP=${BUILD_HIP}
         -DGINKGO_BUILD_TESTS=ON -DGINKGO_BUILD_EXAMPLES=ON
-    - make -j${NUM_CORES} 2>&1 | grep -v -e "loop not unrolled"
+    - make -j${NUM_CORES} 2>&1
   dependencies: []
   except:
       - schedules
@@ -82,7 +82,7 @@ stages:
         -DGINKGO_BUILD_OMP=${BUILD_OMP} -DGINKGO_BUILD_CUDA=${BUILD_CUDA}
         -DGINKGO_BUILD_HIP=${BUILD_HIP}
         -DGINKGO_BUILD_TESTS=ON -DGINKGO_BUILD_EXAMPLES=ON
-    - make -j${NUM_CORES} install 2>&1 | grep -v -e "loop not unrolled"
+    - make -j${NUM_CORES} install 2>&1
     - |
         (( $(ctest -N | tail -1 | sed 's/Total Tests: //') != 0 )) || exit 1
     - ctest -V

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -58,7 +58,7 @@ stages:
         -DGINKGO_BUILD_OMP=${BUILD_OMP} -DGINKGO_BUILD_CUDA=${BUILD_CUDA}
         -DGINKGO_BUILD_HIP=${BUILD_HIP}
         -DGINKGO_BUILD_TESTS=ON -DGINKGO_BUILD_EXAMPLES=ON
-    - make -j${NUM_CORES} 2>&1
+    - make -j${NUM_CORES}
   dependencies: []
   except:
       - schedules
@@ -82,7 +82,7 @@ stages:
         -DGINKGO_BUILD_OMP=${BUILD_OMP} -DGINKGO_BUILD_CUDA=${BUILD_CUDA}
         -DGINKGO_BUILD_HIP=${BUILD_HIP}
         -DGINKGO_BUILD_TESTS=ON -DGINKGO_BUILD_EXAMPLES=ON
-    - make -j${NUM_CORES} install 2>&1
+    - make -j${NUM_CORES} install
     - |
         (( $(ctest -N | tail -1 | sed 's/Total Tests: //') != 0 )) || exit 1
     - ctest -V
@@ -337,7 +337,7 @@ build/cuda101/intel/cuda/debug/static:
 # HIP AMD
 build/amd/gcc/hip/debug/shared:
   <<: *default_build_with_test
-  image: localhost:5000/hip_updated
+  image: localhost:5000/gko-amd-gnu7-llvm60
   variables:
     <<: *default_variables
     BUILD_OMP: "ON"
@@ -350,7 +350,7 @@ build/amd/gcc/hip/debug/shared:
 
 build/amd/clang/hip/release/static:
   <<: *default_build_with_test
-  image: localhost:5000/hip_updated
+  image: localhost:5000/gko-amd-gnu7-llvm60
   variables:
     <<: *default_variables
     C_COMPILER: "clang"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -337,7 +337,7 @@ build/cuda101/intel/cuda/debug/static:
 # HIP AMD
 build/amd/gcc/hip/debug/shared:
   <<: *default_build_with_test
-  image: localhost:5000/gko-amd-gnu7-llvm60
+  image: localhost:5000/hip_updated
   variables:
     <<: *default_variables
     BUILD_OMP: "ON"
@@ -350,7 +350,7 @@ build/amd/gcc/hip/debug/shared:
 
 build/amd/clang/hip/release/static:
   <<: *default_build_with_test
-  image: localhost:5000/gko-amd-gnu7-llvm60
+  image: localhost:5000/hip_updated
   variables:
     <<: *default_variables
     C_COMPILER: "clang"

--- a/common/components/diagonal_block_manipulation.hpp.inc
+++ b/common/components/diagonal_block_manipulation.hpp.inc
@@ -58,38 +58,36 @@ __device__ __forceinline__ void extract_transposed_diag_blocks(
     IndexType bsize = 0;
 #pragma unroll
     for (int b = 0; b < processed_blocks; ++b, ++bid) {
-        if (bid >= num_blocks) {
-            break;
-        }
-        bstart += bsize;
-        bsize = block_ptrs[bid + 1] - bstart;
+        if (bid < num_blocks) {
+            bstart += bsize;
+            bsize = block_ptrs[bid + 1] - bstart;
 #pragma unroll
-        for (int i = 0; i < max_block_size; ++i) {
-            if (i >= bsize) {
-                break;
-            }
-            if (threadIdx.y == b && threadIdx.x < max_block_size) {
-                workspace[threadIdx.x] = zero<ValueType>();
-            }
-            warp.sync();
-            const auto row = bstart + i;
-            const auto rstart = row_ptrs[row] + tid;
-            const auto rend = row_ptrs[row + 1];
-            // use the entire warp to ensure coalesced memory access
-            for (auto j = rstart; j < rend; j += config::warp_size) {
-                const auto col = col_idxs[j] - bstart;
-                if (col >= bsize) {
-                    break;
+            for (int i = 0; i < max_block_size; ++i) {
+                if (i < bsize) {
+                    if (threadIdx.y == b && threadIdx.x < max_block_size) {
+                        workspace[threadIdx.x] = zero<ValueType>();
+                    }
+                    warp.sync();
+                    const auto row = bstart + i;
+                    const auto rstart = row_ptrs[row] + tid;
+                    const auto rend = row_ptrs[row + 1];
+                    // use the entire warp to ensure coalesced memory access
+                    for (auto j = rstart; j < rend; j += config::warp_size) {
+                        const auto col = col_idxs[j] - bstart;
+                        if (col >= bsize) {
+                            break;
+                        }
+                        if (col >= 0) {
+                            workspace[col] = values[j];
+                        }
+                    }
+                    warp.sync();
+                    if (threadIdx.y == b && threadIdx.x < bsize) {
+                        block_row[i * increment] = workspace[threadIdx.x];
+                    }
+                    warp.sync();
                 }
-                if (col >= 0) {
-                    workspace[col] = values[j];
-                }
             }
-            warp.sync();
-            if (threadIdx.y == b && threadIdx.x < bsize) {
-                block_row[i * increment] = workspace[threadIdx.x];
-            }
-            warp.sync();
         }
     }
 }

--- a/common/components/reduction.hpp.inc
+++ b/common/components/reduction.hpp.inc
@@ -109,7 +109,6 @@ __device__ void reduce(const Group &__restrict__ group,
 {
     const auto local_id = group.thread_rank();
 
-#pragma unroll
     for (int k = group.size() / 2; k >= config::warp_size; k /= 2) {
         group.sync();
         if (local_id < k) {

--- a/common/components/warp_blas.hpp.inc
+++ b/common/components/warp_blas.hpp.inc
@@ -215,7 +215,11 @@ __device__ __forceinline__ void copy_matrix(
     size_type stride)
 {
     GKO_ASSERT(problem_size <= max_problem_size);
+#if !defined(__NVCC__)
+#pragma unroll 1
+#else
 #pragma unroll
+#endif  // !defined(__NVCC__)
     for (int32 i = 0; i < max_problem_size; ++i) {
         if (i < problem_size) {
             const auto idx = group.shfl(col_perm, i);

--- a/common/components/warp_blas.hpp.inc
+++ b/common/components/warp_blas.hpp.inc
@@ -215,17 +215,16 @@ __device__ __forceinline__ void copy_matrix(
     size_type stride)
 {
     GKO_ASSERT(problem_size <= max_problem_size);
-#if !defined(__NVCC__)
-#pragma unroll 1
-#else
 #pragma unroll
-#endif  // !defined(__NVCC__)
     for (int32 i = 0; i < max_problem_size; ++i) {
         if (i < problem_size) {
             const auto idx = group.shfl(col_perm, i);
             if (group.thread_rank() < problem_size) {
+                // Need to assign a variable for the source_row, or hip
+                // will use a lot of VGPRs in unroll. This might lead a problem.
+                const auto val = source_row[i * increment];
                 destination[get_row_major_index<mod>(idx, row_perm, stride)] =
-                    static_cast<ResultValueType>(source_row[i * increment]);
+                    static_cast<ResultValueType>(val);
             }
         }
     }

--- a/common/components/warp_blas.hpp.inc
+++ b/common/components/warp_blas.hpp.inc
@@ -132,19 +132,18 @@ __device__ __forceinline__ bool invert_block(const Group &__restrict__ group,
 #pragma unroll 1
 #endif
     for (int32 i = 0; i < max_problem_size; ++i) {
-        if (i >= problem_size) {
-            break;
+        if (i < problem_size) {
+            const auto piv = choose_pivot(group, row[i], pivoted);
+            if (group.thread_rank() == piv) {
+                perm = i;
+                pivoted = true;
+            }
+            if (group.thread_rank() == i) {
+                trans_perm = piv;
+            }
+            apply_gauss_jordan_transform<max_problem_size>(group, piv, i, row,
+                                                           status);
         }
-        const auto piv = choose_pivot(group, row[i], pivoted);
-        if (group.thread_rank() == piv) {
-            perm = i;
-            pivoted = true;
-        }
-        if (group.thread_rank() == i) {
-            trans_perm = piv;
-        }
-        apply_gauss_jordan_transform<max_problem_size>(group, piv, i, row,
-                                                       status);
     }
     return status;
 }
@@ -218,13 +217,12 @@ __device__ __forceinline__ void copy_matrix(
     GKO_ASSERT(problem_size <= max_problem_size);
 #pragma unroll
     for (int32 i = 0; i < max_problem_size; ++i) {
-        if (i >= problem_size) {
-            break;
-        }
-        const auto idx = group.shfl(col_perm, i);
-        if (group.thread_rank() < problem_size) {
-            destination[get_row_major_index<mod>(idx, row_perm, stride)] =
-                static_cast<ResultValueType>(source_row[i * increment]);
+        if (i < problem_size) {
+            const auto idx = group.shfl(col_perm, i);
+            if (group.thread_rank() < problem_size) {
+                destination[get_row_major_index<mod>(idx, row_perm, stride)] =
+                    static_cast<ResultValueType>(source_row[i * increment]);
+            }
         }
     }
 }
@@ -269,17 +267,17 @@ __device__ __forceinline__ void multiply_transposed_vec(
     auto mtx_elem = zero<VectorValueType>();
 #pragma unroll
     for (int32 i = 0; i < max_problem_size; ++i) {
-        if (i >= problem_size) {
-            break;
-        }
-        if (group.thread_rank() < problem_size) {
-            mtx_elem = static_cast<VectorValueType>(mtx_row[i * mtx_increment]);
-        }
-        const auto out =
-            reduce(group, mtx_elem * vec,
-                   [](VectorValueType x, VectorValueType y) { return x + y; });
-        if (group.thread_rank() == 0) {
-            res[i * res_increment] = out;
+        if (i < problem_size) {
+            if (group.thread_rank() < problem_size) {
+                mtx_elem =
+                    static_cast<VectorValueType>(mtx_row[i * mtx_increment]);
+            }
+            const auto out = reduce(
+                group, mtx_elem * vec,
+                [](VectorValueType x, VectorValueType y) { return x + y; });
+            if (group.thread_rank() == 0) {
+                res[i * res_increment] = out;
+            }
         }
     }
 }
@@ -330,13 +328,13 @@ __device__ __forceinline__ void multiply_vec(
     auto out = zero<VectorValueType>();
 #pragma unroll
     for (int32 i = 0; i < max_problem_size; ++i) {
-        if (i >= problem_size) {
-            break;
+        if (i < problem_size) {
+            if (group.thread_rank() < problem_size) {
+                mtx_elem =
+                    static_cast<VectorValueType>(mtx_row[i * mtx_increment]);
+            }
+            out += mtx_elem * group.shfl(vec, i);
         }
-        if (group.thread_rank() < problem_size) {
-            mtx_elem = static_cast<VectorValueType>(mtx_row[i * mtx_increment]);
-        }
-        out += mtx_elem * group.shfl(vec, i);
     }
     if (group.thread_rank() < problem_size) {
         closure_op(res[group.thread_rank() * res_increment], out);
@@ -379,10 +377,9 @@ __device__ __forceinline__ remove_complex<ValueType> compute_infinity_norm(
 #pragma unroll 1
 #endif
         for (uint32 i = 0; i < max_problem_size; ++i) {
-            if (i >= num_cols) {
-                break;
+            if (i < num_cols) {
+                sum += abs(row[i]);
             }
-            sum += abs(row[i]);
         }
     }
     return reduce(group, sum,

--- a/common/components/warp_blas.hpp.inc
+++ b/common/components/warp_blas.hpp.inc
@@ -221,7 +221,8 @@ __device__ __forceinline__ void copy_matrix(
             const auto idx = group.shfl(col_perm, i);
             if (group.thread_rank() < problem_size) {
                 // Need to assign a variable for the source_row, or hip
-                // will use a lot of VGPRs in unroll. This might lead a problem.
+                // will use a lot of VGPRs in unroll. This might lead to
+                // problems.
                 const auto val = source_row[i * increment];
                 destination[get_row_major_index<mod>(idx, row_perm, stride)] =
                     static_cast<ResultValueType>(val);

--- a/common/preconditioner/jacobi_generate_kernel.hpp.inc
+++ b/common/preconditioner/jacobi_generate_kernel.hpp.inc
@@ -44,11 +44,11 @@ __device__ __forceinline__ bool validate_precision_reduction_feasibility(
     if (group.thread_rank() < block_size) {
 #pragma unroll
         for (auto i = 0u; i < max_block_size; ++i) {
-            if (i >= block_size) {
-                break;
+            if (i < block_size) {
+                work[i * stride + group.thread_rank()] = row[i];
+                row[i] =
+                    static_cast<ValueType>(static_cast<ReducedType>(row[i]));
             }
-            work[i * stride + group.thread_rank()] = row[i];
-            row[i] = static_cast<ValueType>(static_cast<ReducedType>(row[i]));
         }
     }
 
@@ -66,10 +66,9 @@ __device__ __forceinline__ bool validate_precision_reduction_feasibility(
     if (group.thread_rank() < block_size) {
 #pragma unroll
         for (auto i = 0u; i < max_block_size; ++i) {
-            if (i >= block_size) {
-                break;
+            if (i < block_size) {
+                row[i] = work[i * stride + group.thread_rank()];
             }
-            row[i] = work[i * stride + group.thread_rank()];
         }
     }
 

--- a/hip/components/cooperative_groups.hip.hpp
+++ b/hip/components/cooperative_groups.hip.hpp
@@ -169,7 +169,7 @@ namespace detail {
  * `any` and `all` are only supported when the size is config::warp_size
  *
  */
-template <size_type Size>
+template <unsigned Size>
 class thread_block_tile {
     /**
      * Mask with Size consecutive ones starting at the least significant bit.
@@ -193,10 +193,7 @@ public:
         return data_.rank;
     }
 
-    __device__ __forceinline__ unsigned size() const noexcept
-    {
-        return data_.size;
-    }
+    __device__ __forceinline__ unsigned size() const noexcept { return Size; }
 
     __device__ __forceinline__ void sync() const noexcept
     {


### PR DESCRIPTION
This PR removes the pragma unroll warning in hip.
In general, the warning in ginkgo is caused by using break in the loop.
```
for () {
  if (condition) break;
  // other commands
}
```
->
```
for () {
  if (!condition) {
    // other commands
  }
}
```
to make pragma unroll work. ( I am not sure whether it affect the performance.)

copy_matrix unroll problem:
~~When using clang and hip to compile, copy_matrix gives the wrong result on custom precision.
I need to use `#pragma unroll 1` to disable it.~~
I add local one variable to store `source_row` value to make everything work as expected.
I only go through some different part of fix_13.isa and unfix_13.isa. The assembly looks similar except the number of VGPR.
For some reasons, hip use many VGPR (registers) in the original version (without using the local variable)
unfix_13.isa contains NumSpilledVGPRs and use full VGPR (256), but fix_13.isa does not need to use full VGPR.
[unroll_isa.zip](https://github.com/ginkgo-project/ginkgo/files/4481892/unroll_isa.zip)
If someone is interested in the assembly code, I use `# main - start` and `# main - end` around 

```
const auto val = source_row[i * increment];
destination[get_row_major_index<mod>(idx, row_perm, stride)] = static_cast<ResultValueType>(val);
```
or `destination[get_row_major_index<mod>(idx, row_perm, stride)] = static_cast<ResultValueType>(source_row[i * increment]);`
This issue https://github.com/ROCm-Developer-Tools/aomp/issues/24 also mentions some weird things about `NumSpilledVGPRs` although the reason might be different from this PR.

Note. The original version gives wrong answer when casting to custom precision format and the wrong result are stable.