### PR TITLE
Add gko::as for smart pointers

### DIFF
--- a/core/test/base/utils.cpp
+++ b/core/test/base/utils.cpp
@@ -50,9 +50,7 @@ struct Base {
 struct Derived : Base {};
 
 
-struct NonRelated {
-    virtual ~NonRelated() = default;
-};
+struct NonRelated : Base {};
 
 
 struct ClonableDerived : Base {
@@ -300,6 +298,42 @@ TEST(As, FailsToConvertUniquePtrIfNotRelated)
     auto expected = new Derived{};
 
     ASSERT_THROW(gko::as<NonRelated>(std::unique_ptr<Base>{expected}),
+                 gko::NotSupported);
+}
+
+
+TEST(As, ConvertsPolymorphicTypeSharedPtr)
+{
+    auto expected = new Derived{};
+
+    ASSERT_EQ(gko::as<Derived>(std::shared_ptr<Base>{expected}).get(),
+              expected);
+}
+
+
+TEST(As, FailsToConvertSharedPtrIfNotRelated)
+{
+    auto expected = new Derived{};
+
+    ASSERT_THROW(gko::as<NonRelated>(std::shared_ptr<Base>{expected}),
+                 gko::NotSupported);
+}
+
+
+TEST(As, ConvertsConstPolymorphicTypeSharedPtr)
+{
+    auto expected = new Derived{};
+
+    ASSERT_EQ(gko::as<Derived>(std::shared_ptr<const Base>{expected}).get(),
+              expected);
+}
+
+
+TEST(As, FailsToConvertConstSharedPtrIfNotRelated)
+{
+    auto expected = new Derived{};
+
+    ASSERT_THROW(gko::as<NonRelated>(std::shared_ptr<const Base>{expected}),
                  gko::NotSupported);
 }
 

--- a/core/test/base/utils.cpp
+++ b/core/test/base/utils.cpp
@@ -286,6 +286,24 @@ TEST(As, FailsToConvertConstantIfNotRelated)
 }
 
 
+TEST(As, ConvertsPolymorphicTypeUniquePtr)
+{
+    auto expected = new Derived{};
+
+    ASSERT_EQ(gko::as<Derived>(std::unique_ptr<Base>{expected}).get(),
+              expected);
+}
+
+
+TEST(As, FailsToConvertUniquePtrIfNotRelated)
+{
+    auto expected = new Derived{};
+
+    ASSERT_THROW(gko::as<NonRelated>(std::unique_ptr<Base>{expected}),
+                 gko::NotSupported);
+}
+
+
 struct DummyObject : gko::EnablePolymorphicObject<DummyObject>,
                      gko::EnablePolymorphicAssignment<DummyObject>,
                      gko::EnableCreateMethod<DummyObject> {

--- a/include/ginkgo/core/base/utils.hpp
+++ b/include/ginkgo/core/base/utils.hpp
@@ -352,6 +352,56 @@ inline std::unique_ptr<typename std::decay<T>::type> as(
 
 
 /**
+ * Performs polymorphic type conversion of a shared_ptr.
+ *
+ * @tparam T  requested result type
+ * @tparam U  static type of the passed object
+ *
+ * @param obj  the shared_ptr to the object which should be converted.
+ *
+ * @return If successful, returns a shared_ptr to the subtype, otherwise throws
+ *         NotSupported. This pointer shares ownership with the input pointer.
+ */
+template <typename T, typename U>
+inline std::shared_ptr<typename std::decay<T>::type> as(std::shared_ptr<U> obj)
+{
+    if (dynamic_cast<typename std::decay<T>::type *>(obj.get())) {
+        return std::static_pointer_cast<typename std::decay<T>::type>(obj);
+    } else {
+        throw NotSupported(__FILE__, __LINE__, __func__,
+                           name_demangling::get_type_name(typeid(obj.get())));
+    }
+}
+
+
+/**
+ * Performs polymorphic type conversion of a shared_ptr.
+ *
+ * This is the constant version of the function.
+ *
+ * @tparam T  requested result type
+ * @tparam U  static type of the passed object
+ *
+ * @param obj  the shared_ptr to the object which should be converted.
+ *
+ * @return If successful, returns a shared_ptr to the subtype, otherwise throws
+ *         NotSupported. This pointer shares ownership with the input pointer.
+ */
+template <typename T, typename U>
+inline std::shared_ptr<const typename std::decay<T>::type> as(
+    std::shared_ptr<const U> obj)
+{
+    if (dynamic_cast<const typename std::decay<T>::type *>(obj.get())) {
+        return std::static_pointer_cast<const typename std::decay<T>::type>(
+            obj);
+    } else {
+        throw NotSupported(__FILE__, __LINE__, __func__,
+                           name_demangling::get_type_name(typeid(obj.get())));
+    }
+}
+
+
+/**
  * This is a deleter that does not delete the object.
  *
  * It is useful where the object has been allocated elsewhere and will be

--- a/include/ginkgo/core/base/utils.hpp
+++ b/include/ginkgo/core/base/utils.hpp
@@ -326,6 +326,32 @@ inline const typename std::decay<T>::type *as(const U *obj)
 
 
 /**
+ * Performs polymorphic type conversion of a unique_ptr.
+ *
+ * @tparam T  requested result type
+ * @tparam U  static type of the passed object
+ *
+ * @param obj  the unique_ptr to the object which should be converted.
+ *             If successful, it will be reset to a nullptr.
+ *
+ * @return If successful, returns a unique_ptr to the subtype, otherwise throws
+ *         NotSupported.
+ */
+template <typename T, typename U>
+inline std::unique_ptr<typename std::decay<T>::type> as(
+    std::unique_ptr<U> &&obj)
+{
+    if (auto p = dynamic_cast<typename std::decay<T>::type *>(obj.get())) {
+        obj.release();
+        return std::unique_ptr<typename std::decay<T>::type>{p};
+    } else {
+        throw NotSupported(__FILE__, __LINE__, __func__,
+                           name_demangling::get_type_name(typeid(obj.get())));
+    }
+}
+
+
+/**
  * This is a deleter that does not delete the object.
  *
  * It is useful where the object has been allocated elsewhere and will be


### PR DESCRIPTION
As far as I can tell, we currently have no nice way of casting a `std::unique_ptr` to another type. There is `std::*_ptr_cast`, but that only works for `std::shared_ptr`.
Instead we need workarounds like 
```cpp
std::unique_ptr<...> ptr2{gko::as<...>(ptr.release())};
```
This PR adds an overload for `gko::as` that takes a `unique_ptr` as an rvalue, resetting it if successful.