### PR TITLE
Change matrix location from SOURCE to BINARY

### DIFF
--- a/matrices/config.hpp.in
+++ b/matrices/config.hpp.in
@@ -38,8 +38,8 @@ namespace gko {
 namespace matrices {
 
 
-const char *location_ani1_mtx = "@Ginkgo_SOURCE_DIR@/matrices/test/ani1.mtx";
-const char *location_ani4_mtx = "@Ginkgo_SOURCE_DIR@/matrices/test/ani4.mtx";
+const char *location_ani1_mtx = "@Ginkgo_BINARY_DIR@/matrices/test/ani1.mtx";
+const char *location_ani4_mtx = "@Ginkgo_BINARY_DIR@/matrices/test/ani4.mtx";
 
 
 } // namespace matrices


### PR DESCRIPTION
@pratikvn noticed that we copy matrices from SOURCE to BINARY, while the `matrices/config.hpp.in` pointed towards the SOURCE directory. That is actually a bug:
The matrix location is supposed to be in the binary location, to ensure it can be accessed and read. The source directory might not be readable (or even mounted) on some cluster configurations, which is why they are copied to the binary directory. This change makes the tests to use the matrices in the BINARY directory instead of the SOURCE directory.