### PR TITLE
Fix hip atomic add on complex in updated hip

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -344,7 +344,7 @@ build/cuda101/intel/cuda/debug/static:
 # HIP AMD
 build/amd/gcc/hip/debug/shared:
   <<: *default_build_with_test
-  image: localhost:5000/gko-amd-gnu7-llvm60
+  image: localhost:5000/hip_updated
   variables:
     <<: *default_variables
     BUILD_OMP: "ON"
@@ -357,7 +357,7 @@ build/amd/gcc/hip/debug/shared:
 
 build/amd/clang/hip/release/static:
   <<: *default_build_with_test
-  image: localhost:5000/gko-amd-gnu7-llvm60
+  image: localhost:5000/hip_updated
   variables:
     <<: *default_variables
     C_COMPILER: clang

--- a/hip/components/atomic.hip.hpp
+++ b/hip/components/atomic.hip.hpp
@@ -52,8 +52,8 @@ __forceinline__ __device__ thrust::complex<float> atomic_add(
 {
     hipComplex *addr = reinterpret_cast<hipComplex *>(address);
     // Separate to real part and imag part
-    auto real = atomic_add(&(addr->x), val.real());
-    auto imag = atomic_add(&(addr->y), val.imag());
+    auto real = atomic_add(static_cast<float *>(&(addr->x)), val.real());
+    auto imag = atomic_add(static_cast<float *>(&(addr->y)), val.imag());
     return {real, imag};
 }
 
@@ -68,8 +68,8 @@ __forceinline__ __device__ thrust::complex<double> atomic_add(
 {
     hipDoubleComplex *addr = reinterpret_cast<hipDoubleComplex *>(address);
     // Separate to real part and imag part
-    auto real = atomic_add(&(addr->x), val.real());
-    auto imag = atomic_add(&(addr->y), val.imag());
+    auto real = atomic_add(static_cast<double *>(&(addr->x)), val.real());
+    auto imag = atomic_add(static_cast<double *>(&(addr->y)), val.imag());
     return {real, imag};
 }
 


### PR DESCRIPTION
hcc fixed the printf problem in https://github.com/RadeonOpenCompute/hcc/pull/1290 and https://github.com/RadeonOpenCompute/hcc/pull/1354

I rerun the script (`dev_tools/container/gko-amd-gnu7-llvm60.baseimage`) to build the image `localhost:5000/hip_update` with the updated hip.

They handle complex in more general way.
`&(addr->x)` gets `hip_impl::Scalar_accessor<double, double __attribute__((ext_vector_type(2))), 1>::Address` not `double *`, so compiler can not find a proper `atomic_add`. The failed log in https://gitlab.com/ginkgo-project/ginkgo-public-ci/-/jobs/500647667
[The related code](https://github.com/ROCm-Developer-Tools/HIP/blob/5f1420a229b41662f1f3f178de56daa10028d39c/include/hip/hcc_detail/hip_vector_types.h#L62-L86)

I use `static_cast<double *>` to make the conversion work. Another way is to get the address first `double *addrx = &(addr->x)` and then call the `atomic_add`.

If someone would like to try the printf in `localhost:5000/hip_update`, you need to define `HIP_ENABLE_PRINTF` and `export HCC_ENABLE_PRINTF=1` to enable printf.

sample.cpp
```
#include "hip/hip_runtime.h"

__global__ void run_printf() {
    int idx = threadIdx.x;
    printf("Hello World, tid = %d\n", idx);
}

int main() {
    hipSetDevice(0);
    hipLaunchKernelGGL(HIP_KERNEL_NAME(run_printf), dim3(1), dim3(7), 0, 0);
    hipDeviceSynchronize();
    return 0;
}
```
```
export HCC_ENABLE_PRINTF=1
hipcc -DHIP_ENABLE_PRINTF sample.cpp
```

Todo:
- [ ] Finish the review
- [x] Update docker image (#499)
- [ ] Revert the `.gitlab-ci.yml`