### PR TITLE
Fix dim

### DIFF
--- a/core/test/base/dim.cpp
+++ b/core/test/base/dim.cpp
@@ -33,6 +33,9 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <ginkgo/core/base/dim.hpp>
 
 
+#include <memory>
+
+
 #include <gtest/gtest.h>
 
 
@@ -45,6 +48,16 @@ TEST(Dim, ConstructsCorrectObject)
 
     ASSERT_EQ(d[0], 4);
     ASSERT_EQ(d[1], 5);
+}
+
+
+TEST(Dim, ConstructsCorrectConstexprObject)
+{
+    constexpr gko::dim<3> d{4, 5, 6};
+
+    ASSERT_EQ(d[0], 4);
+    ASSERT_EQ(d[1], 5);
+    ASSERT_EQ(d[2], 6);
 }
 
 
@@ -63,6 +76,34 @@ TEST(Dim, ConstructsNullObject)
 
     ASSERT_EQ(d[0], 0);
     ASSERT_EQ(d[1], 0);
+}
+
+
+class dim_manager {
+public:
+    using dim = gko::dim<3>;
+    const dim &get_size() const { return size_; }
+
+    static std::unique_ptr<dim_manager> create(const dim &size)
+    {
+        return std::unique_ptr<dim_manager>{new dim_manager{size}};
+    }
+
+private:
+    dim_manager(const dim &size) : size_{size} {}
+    dim size_;
+};
+
+
+TEST(Dim, CopiesProperlyOnHeap)
+{
+    auto manager = dim_manager::create(gko::dim<3>{1, 2, 3});
+
+    const auto copy = manager->get_size();
+
+    ASSERT_EQ(copy[0], 1);
+    ASSERT_EQ(copy[1], 2);
+    ASSERT_EQ(copy[2], 3);
 }
 
 

--- a/include/ginkgo/core/base/dim.hpp
+++ b/include/ginkgo/core/base/dim.hpp
@@ -97,7 +97,8 @@ struct dim {
     constexpr GKO_ATTRIBUTES const dimension_type &operator[](
         const size_type &dimension) const noexcept
     {
-        return GKO_ASSERT(dimension < dimensionality), *(&first_ + dimension);
+        return GKO_ASSERT(dimension < dimensionality),
+               dimension == 0 ? first_ : rest_[dimension - 1];
     }
 
     /**
@@ -106,7 +107,8 @@ struct dim {
     GKO_ATTRIBUTES dimension_type &operator[](
         const size_type &dimension) noexcept
     {
-        return GKO_ASSERT(dimension < dimensionality), *(&first_ + dimension);
+        return GKO_ASSERT(dimension < dimensionality),
+               dimension == 0 ? first_ : rest_[dimension - 1];
     }
 
     /**
@@ -173,12 +175,12 @@ struct dim<1u, DimensionType> {
     constexpr GKO_ATTRIBUTES const dimension_type &operator[](
         const size_type &dimension) const noexcept
     {
-        return *(&first_ + dimension);
+        return GKO_ASSERT(dimension == 0), first_;
     }
 
     GKO_ATTRIBUTES dimension_type &operator[](const size_type &dimension)
     {
-        return *(&first_ + dimension);
+        return GKO_ASSERT(dimension == 0), first_;
     }
 
     constexpr GKO_ATTRIBUTES operator bool() const


### PR DESCRIPTION
This is a simple fix to `gko::dim`.
Previously, it relied on the binary representation to work properly, and the intel compiler also sometimes optimized away the copying of some non-first dimensions.
Now, it should properly comply with the C++ standard (without relying on a specific binary representation). Additionally, two tests were added.