### PR TITLE
Simple overhead benchmarking facilities

### DIFF
--- a/benchmark/solver/solver.cpp
+++ b/benchmark/solver/solver.cpp
@@ -72,6 +72,10 @@ DEFINE_uint32(
     nrhs, 1,
     "The number of right hand sides. Record the residual only when nrhs == 1.");
 
+// This allows to benchmark the overhead of a solver by using the following
+// data: A=[1.0], x=[0.0], b=[nan]. This data can be used to benchmark normal
+// solvers or using the argument --solvers=overhead, a minimal solver will be
+// launched which contains only a few kernel calls.
 DEFINE_bool(overhead, false,
             "If set, uses dummy data to benchmark Ginkgo overhead");
 

--- a/benchmark/solver/solver.cpp
+++ b/benchmark/solver/solver.cpp
@@ -35,6 +35,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <algorithm>
 #include <chrono>
+#include <cmath>
 #include <cstdlib>
 #include <exception>
 #include <fstream>
@@ -45,6 +46,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "benchmark/utils/formats.hpp"
 #include "benchmark/utils/general.hpp"
 #include "benchmark/utils/loggers.hpp"
+#include "benchmark/utils/overhead_linop.hpp"
 
 
 // some Ginkgo shortcuts
@@ -58,21 +60,25 @@ DEFINE_uint32(max_iters, 1000,
 DEFINE_double(rel_res_goal, 1e-6, "The relative residual goal of the solver");
 
 DEFINE_string(solvers, "cg",
-              "A comma-separated list of solvers to run."
-              "Supported values are: bicgstab, cg, cgs, fcg, gmres");
+              "A comma-separated list of solvers to run. "
+              "Supported values are: bicgstab, cg, cgs, fcg, gmres, overhead");
 
-DEFINE_string(
-    preconditioners, "none",
-    "A comma-separated list of preconditioners to use."
-    "Supported values are: none, jacobi, adaptive-jacobi, parilu, ilu");
+DEFINE_string(preconditioners, "none",
+              "A comma-separated list of preconditioners to use. "
+              "Supported values are: none, jacobi, adaptive-jacobi, parilu, "
+              "ilu, overhead");
 
 DEFINE_uint32(
     nrhs, 1,
     "The number of right hand sides. Record the residual only when nrhs == 1.");
 
+DEFINE_bool(overhead, false,
+            "If set, uses dummy data to benchmark Ginkgo overhead");
+
 
 // input validation
-[[noreturn]] void print_config_error_and_exit() {
+[[noreturn]] void print_config_error_and_exit()
+{
     std::cerr << "Input has to be a JSON array of matrix configurations:\n"
               << "  [\n"
               << "    { \"filename\": \"my_file.mtx\",  \"optimal\": { "
@@ -120,7 +126,8 @@ const std::map<std::string, std::function<std::unique_ptr<gko::LinOpFactory>(
                    {"cg", create_solver<gko::solver::Cg<>>},
                    {"cgs", create_solver<gko::solver::Cgs<>>},
                    {"fcg", create_solver<gko::solver::Fcg<>>},
-                   {"gmres", create_solver<gko::solver::Gmres<>>}};
+                   {"gmres", create_solver<gko::solver::Gmres<>>},
+                   {"overhead", create_solver<gko::Overhead<>>}};
 
 
 // TODO: Workaround until GPU matrix conversions are implemented
@@ -186,13 +193,20 @@ const std::map<std::string, std::function<std::unique_ptr<gko::LinOpFactory>(
                          return std::unique_ptr<ReferenceFactoryWrapper>(
                              new ReferenceFactoryWrapper(f));
                      }},
-                    {"ilu", [](std::shared_ptr<const gko::Executor> exec) {
+                    {"ilu",
+                     [](std::shared_ptr<const gko::Executor> exec) {
                          auto fact = std::shared_ptr<gko::LinOpFactory>(
                              gko::factorization::Ilu<>::build().on(exec));
                          std::shared_ptr<const gko::LinOpFactory> f =
                              gko::preconditioner::Ilu<>::build()
                                  .with_factorization_factory(fact)
                                  .on(exec);
+                         return std::unique_ptr<ReferenceFactoryWrapper>(
+                             new ReferenceFactoryWrapper(f));
+                     }},
+                    {"overhead", [](std::shared_ptr<const gko::Executor> exec) {
+                         std::shared_ptr<const gko::LinOpFactory> f =
+                             gko::Overhead<>::build().on(exec);
                          return std::unique_ptr<ReferenceFactoryWrapper>(
                              new ReferenceFactoryWrapper(f));
                      }}};
@@ -266,7 +280,7 @@ void solve_system(const std::string &solver_name,
                           rapidjson::Value(rapidjson::kArrayType), allocator);
         add_or_set_member(solver_json, "true_residuals",
                           rapidjson::Value(rapidjson::kArrayType), allocator);
-        if (FLAGS_nrhs == 1) {
+        if (FLAGS_nrhs == 1 && !FLAGS_overhead) {
             auto rhs_norm = compute_norm2(lend(b));
             add_or_set_member(solver_json, "rhs_norm", rhs_norm, allocator);
         }
@@ -290,7 +304,7 @@ void solve_system(const std::string &solver_name,
         }
 
         // detail run
-        if (FLAGS_detailed) {
+        if (FLAGS_detailed && !FLAGS_overhead) {
             // slow run, get the time of each functions
             auto x_clone = clone(x);
 
@@ -366,7 +380,8 @@ void solve_system(const std::string &solver_name,
             apply_time += std::chrono::duration_cast<std::chrono::nanoseconds>(
                 a_tac - a_tic);
 
-            if (FLAGS_nrhs == 1 && i == FLAGS_repetitions - 1) {
+            if (FLAGS_nrhs == 1 && i == FLAGS_repetitions - 1 &&
+                !FLAGS_overhead) {
                 auto residual = compute_residual_norm(lend(system_matrix),
                                                       lend(b), lend(x_clone));
                 add_or_set_member(solver_json, "residual_norm", residual,
@@ -428,9 +443,18 @@ int main(int argc, char *argv[])
         }
     }
 
-    rapidjson::IStreamWrapper jcin(std::cin);
     rapidjson::Document test_cases;
-    test_cases.ParseStream(jcin);
+    if (!FLAGS_overhead) {
+        rapidjson::IStreamWrapper jcin(std::cin);
+        test_cases.ParseStream(jcin);
+    } else {
+        // Fake test case to run once
+        auto overhead_json = std::string() +
+                             " [{\"filename\": \"overhead.mtx\", \"optimal\": "
+                             "{ \"spmv\": \"csr\"}}]";
+        test_cases.Parse(overhead_json.c_str());
+    }
+
     if (!test_cases.IsArray()) {
         print_config_error_and_exit();
     }
@@ -457,15 +481,26 @@ int main(int argc, char *argv[])
             }
             std::clog << "Running test case: " << test_case << std::endl;
             std::ifstream mtx_fd(test_case["filename"].GetString());
-            auto data = gko::read_raw<etype>(mtx_fd);
 
-            auto system_matrix = share(formats::matrix_factory.at(
-                test_case["optimal"]["spmv"].GetString())(exec, data));
-            auto b = create_matrix<etype>(
-                exec, gko::dim<2>{system_matrix->get_size()[0], FLAGS_nrhs},
-                engine);
-            auto x = create_matrix<etype>(
-                exec, gko::dim<2>{system_matrix->get_size()[0], FLAGS_nrhs});
+            using Vec = gko::matrix::Dense<>;
+            std::shared_ptr<gko::LinOp> system_matrix;
+            std::unique_ptr<Vec> b;
+            std::unique_ptr<Vec> x;
+            if (FLAGS_overhead) {
+                system_matrix = gko::initialize<Vec>({1.0}, exec);
+                b = gko::initialize<Vec>({std::nan("")}, exec);
+                x = gko::initialize<Vec>({0.0}, exec);
+            } else {
+                auto data = gko::read_raw<etype>(mtx_fd);
+                system_matrix = share(formats::matrix_factory.at(
+                    test_case["optimal"]["spmv"].GetString())(exec, data));
+                b = create_matrix<etype>(
+                    exec, gko::dim<2>{system_matrix->get_size()[0], FLAGS_nrhs},
+                    engine);
+                x = create_matrix<etype>(
+                    exec,
+                    gko::dim<2>{system_matrix->get_size()[0], FLAGS_nrhs});
+            }
 
             std::clog << "Matrix is of size (" << system_matrix->get_size()[0]
                       << ", " << system_matrix->get_size()[1] << ")"

--- a/benchmark/utils/loggers.hpp
+++ b/benchmark/utils/loggers.hpp
@@ -229,4 +229,29 @@ private:
 };
 
 
+// Logs the number of iteration executed
+struct IterationLogger : gko::log::Logger {
+    void on_iteration_complete(const gko::LinOp *,
+                               const gko::size_type &num_iterations,
+                               const gko::LinOp *, const gko::LinOp *,
+                               const gko::LinOp *) const override
+    {
+        this->num_iters = num_iterations;
+    }
+
+    IterationLogger(std::shared_ptr<const gko::Executor> exec)
+        : gko::log::Logger(exec, gko::log::Logger::iteration_complete_mask)
+    {}
+
+    void write_data(rapidjson::Value &output,
+                    rapidjson::MemoryPoolAllocator<> &allocator)
+    {
+        add_or_set_member(output, "iterations", this->num_iters, allocator);
+    }
+
+private:
+    mutable gko::size_type num_iters{0};
+};
+
+
 #endif  // GKO_BENCHMARK_UTILS_LOGGERS_HPP_

--- a/benchmark/utils/overhead_linop.hpp
+++ b/benchmark/utils/overhead_linop.hpp
@@ -28,11 +28,14 @@ namespace overhead {
     }
 
 
-#define GKO_DECLARE_ALL                                 \
-    GKO_DECLARE_OVERHEAD_OPERATION_KERNEL(ValueType, 1) \
-    GKO_DECLARE_OVERHEAD_OPERATION_KERNEL(ValueType, 2) \
-    GKO_DECLARE_OVERHEAD_OPERATION_KERNEL(ValueType, 3) \
-    GKO_DECLARE_OVERHEAD_OPERATION_KERNEL(ValueType, 4)
+#define GKO_DECLARE_ALL                                                      \
+    GKO_DECLARE_OVERHEAD_OPERATION_KERNEL(ValueType, 1)                      \
+    GKO_DECLARE_OVERHEAD_OPERATION_KERNEL(ValueType, 2)                      \
+    GKO_DECLARE_OVERHEAD_OPERATION_KERNEL(ValueType, 3)                      \
+    GKO_DECLARE_OVERHEAD_OPERATION_KERNEL(ValueType, 4)                      \
+    static_assert(true,                                                      \
+                  "This assert is used to counter the false positive extra " \
+                  "semi-colon warnings")
 
 
 }  // namespace overhead

--- a/benchmark/utils/overhead_linop.hpp
+++ b/benchmark/utils/overhead_linop.hpp
@@ -1,5 +1,37 @@
-#ifndef GKO_BENCHMARK_UTILS_OVERHEAD_LINOP_
-#define GKO_BENCHMARK_UTILS_OVERHEAD_LINOP_
+/*******************************<GINKGO LICENSE>******************************
+Copyright (c) 2017-2020, the Ginkgo authors
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+******************************<GINKGO LICENSE>*******************************/
+
+#ifndef GKO_BENCHMARK_UTILS_OVERHEAD_LINOP_HPP_
+#define GKO_BENCHMARK_UTILS_OVERHEAD_LINOP_HPP_
 
 
 #include <cstdint>
@@ -102,8 +134,6 @@ class Overhead : public EnableLinOp<Overhead<ValueType>>,
     friend class EnablePolymorphicObject<Overhead, LinOp>;
 
 public:
-    using value_type = ValueType;
-
     GKO_CREATE_FACTORY_PARAMETERS(parameters, Factory)
     {
         /**
@@ -193,4 +223,4 @@ private:
 }  // namespace gko
 
 
-#endif  // GKO_BENCHMARK_UTILS_OVERHEAD_LINOP_
+#endif  // GKO_BENCHMARK_UTILS_OVERHEAD_LINOP_HPP_

--- a/benchmark/utils/overhead_linop.hpp
+++ b/benchmark/utils/overhead_linop.hpp
@@ -1,0 +1,193 @@
+#ifndef GKO_BENCHMARK_UTILS_OVERHEAD_LINOP_
+#define GKO_BENCHMARK_UTILS_OVERHEAD_LINOP_
+
+
+#include <cstdint>
+#include <memory>
+#include <vector>
+
+
+#include <ginkgo/core/base/lin_op.hpp>
+#include <ginkgo/core/base/types.hpp>
+#include <ginkgo/core/stop/criterion.hpp>
+
+
+namespace gko {
+namespace kernels {
+namespace overhead {
+
+
+#define GKO_DECLARE_OVERHEAD_OPERATION_KERNEL(_type, _num)            \
+    static volatile std::uintptr_t val_operation_##_num = 0;          \
+    template <typename _type>                                         \
+    void operation##_num(std::shared_ptr<const DefaultExecutor> exec, \
+                         const matrix::Dense<_type> *b,               \
+                         matrix::Dense<_type> *x)                     \
+    {                                                                 \
+        val_operation_##_num = reinterpret_cast<std::uintptr_t>(x);   \
+    }
+
+
+#define GKO_DECLARE_ALL                                 \
+    GKO_DECLARE_OVERHEAD_OPERATION_KERNEL(ValueType, 1) \
+    GKO_DECLARE_OVERHEAD_OPERATION_KERNEL(ValueType, 2) \
+    GKO_DECLARE_OVERHEAD_OPERATION_KERNEL(ValueType, 3) \
+    GKO_DECLARE_OVERHEAD_OPERATION_KERNEL(ValueType, 4)
+
+
+}  // namespace overhead
+
+
+namespace omp {
+namespace overhead {
+
+GKO_DECLARE_ALL;
+
+}  // namespace overhead
+}  // namespace omp
+
+
+namespace cuda {
+namespace overhead {
+
+GKO_DECLARE_ALL;
+
+}  // namespace overhead
+}  // namespace cuda
+
+
+namespace reference {
+namespace overhead {
+
+GKO_DECLARE_ALL;
+
+}  // namespace overhead
+}  // namespace reference
+
+
+namespace hip {
+namespace overhead {
+
+GKO_DECLARE_ALL;
+
+}  // namespace overhead
+}  // namespace hip
+
+
+#undef GKO_DECLARE_ALL
+
+
+}  // namespace kernels
+
+
+namespace overhead {
+
+
+GKO_REGISTER_OPERATION(operation1, overhead::operation1);
+GKO_REGISTER_OPERATION(operation2, overhead::operation2);
+GKO_REGISTER_OPERATION(operation3, overhead::operation3);
+GKO_REGISTER_OPERATION(operation4, overhead::operation4);
+
+
+}  // namespace overhead
+
+
+template <typename ValueType = default_precision>
+class Overhead : public EnableLinOp<Overhead<ValueType>>,
+                 public Preconditionable {
+    friend class EnableLinOp<Overhead>;
+    friend class EnablePolymorphicObject<Overhead, LinOp>;
+
+public:
+    using value_type = ValueType;
+
+    GKO_CREATE_FACTORY_PARAMETERS(parameters, Factory)
+    {
+        /**
+         * Criterion factories.
+         */
+        std::vector<std::shared_ptr<const stop::CriterionFactory>>
+            GKO_FACTORY_PARAMETER(criteria, nullptr);
+
+        /**
+         * Preconditioner factory.
+         */
+        std::shared_ptr<const LinOpFactory> GKO_FACTORY_PARAMETER(
+            preconditioner, nullptr);
+
+        /**
+         * Already generated preconditioner. If one is provided, the factory
+         * `preconditioner` will be ignored.
+         */
+        std::shared_ptr<const LinOp> GKO_FACTORY_PARAMETER(
+            generated_preconditioner, nullptr);
+    };
+
+    GKO_ENABLE_LIN_OP_FACTORY(Overhead, parameters, Factory);
+    GKO_ENABLE_BUILD_METHOD(Factory);
+
+protected:
+    void apply_impl(const LinOp *b, LinOp *x) const override
+    {
+        using Vector = matrix::Dense<ValueType>;
+
+        auto exec = this->get_executor();
+        auto dense_b = as<const Vector>(b);
+        auto dense_x = as<Vector>(x);
+
+        system_matrix_->apply(dense_b, dense_x);
+        get_preconditioner()->apply(dense_b, dense_x);
+
+        exec->run(overhead::make_operation1(dense_b, dense_x));
+        exec->run(overhead::make_operation2(dense_b, dense_x));
+        exec->run(overhead::make_operation3(dense_b, dense_x));
+        exec->run(overhead::make_operation4(dense_b, dense_x));
+    }
+
+    void apply_impl(const LinOp *alpha, const LinOp *b, const LinOp *beta,
+                    LinOp *x) const override
+    {
+        auto dense_x = as<matrix::Dense<ValueType>>(x);
+
+        auto x_clone = dense_x->clone();
+        this->apply(b, x_clone.get());
+        dense_x->scale(beta);
+        dense_x->add_scaled(alpha, x_clone.get());
+    }
+
+    explicit Overhead(std::shared_ptr<const Executor> exec)
+        : EnableLinOp<Overhead>(std::move(exec))
+    {}
+
+    explicit Overhead(const Factory *factory,
+                      std::shared_ptr<const LinOp> system_matrix)
+        : EnableLinOp<Overhead>(factory->get_executor(),
+                                transpose(system_matrix->get_size())),
+          parameters_{factory->get_parameters()},
+          system_matrix_{std::move(system_matrix)}
+    {
+        if (parameters_.generated_preconditioner) {
+            GKO_ASSERT_EQUAL_DIMENSIONS(parameters_.generated_preconditioner,
+                                        this);
+            set_preconditioner(parameters_.generated_preconditioner);
+        } else if (parameters_.preconditioner) {
+            set_preconditioner(
+                parameters_.preconditioner->generate(system_matrix_));
+        } else {
+            set_preconditioner(matrix::Identity<ValueType>::create(
+                this->get_executor(), this->get_size()[0]));
+        }
+        stop_criterion_factory_ =
+            stop::combine(std::move(parameters_.criteria));
+    }
+
+private:
+    std::shared_ptr<const LinOp> system_matrix_{};
+    std::shared_ptr<const stop::CriterionFactory> stop_criterion_factory_{};
+};
+
+
+}  // namespace gko
+
+
+#endif  // GKO_BENCHMARK_UTILS_OVERHEAD_LINOP_


### PR DESCRIPTION
This is done by modifying the `solver` benchmarks with:
+ A new `overhead` boolean parameter to ask whether or not an overhead benchmark should be done. This will use a simple matrix with a single `1.0` `value,` `0.0` as `x`, and `nan` as `b` (same setup as the `ginkgo_overhead` example). 
+ A new `Overhead` LinOP which does a normal solver setup in terms of Factory parameters and generation, except that it has an `apply_impl` method which calls four empty kernels. We have multiple runtime polymorphism calls which come into play here. I am most likely forgetting many of them: 
    + generate,
    + apply,
    + system_matrix and preconditioner's apply,
    + four kernel calls (`run()` functions), ...
+ This `Overhead` LinOp can be also be used as a preconditioner.

This allows the following:
+ Benchmark any solver/preconditioner with the dummy data.
+ Benchmark the overhead LinOp (optionally with preconditioner) with the dummy data.

We get the following results currently, benchmarked on BW Unicluster with 10.000 iterations:
+ CG with dummy data,
   + generate: `0.829 us`,
   + apply (1000 iterations): `1277.557 us`.
   + apply (2000 iterations) - apply (1000 iterations): `1200.118 us`
+ bicgstab with dummy data,
   + generate: `0.814 us`,
   + apply (1000 iterations): `1259.751 us`.
   + apply (2000 iterations) - apply (1000 iterations): `1239.370 us`
+ fcg with dummy data,
   + generate: `0.837 us`,
   + apply (1000 iterations): `1447.981 us`.
   + apply (2000 iterations) - apply (1000 iterations): `1410.630 us`
+ cgs with dummy data,
   + generate: `0.849 us`,
   + apply (1000 iterations): `1001.975 us`.
   + apply (2000 iterations) - apply (1000 iterations): `881.990 us`
+ gmres with dummy data,
   + generate: `0.836 us`,
   + apply (1000 iterations): `1510.327 us`.
   + apply (2000 iterations) - apply (1000 iterations): `1485.361 us`
+ Overhead "solver" with dummy data,
   + generate: `0.788 us`,
   + apply: `0.912 us`.
+ Overhead "solver" with overhead "preconditioner" with dummy data:
   + generate: `1.479 us`,
   + apply: `2.610 us`.