### PR TITLE
Add ExecutorAllocator

### DIFF
--- a/benchmark/preconditioner/preconditioner.cpp
+++ b/benchmark/preconditioner/preconditioner.cpp
@@ -215,7 +215,8 @@ void run_preconditioner(const char *precond_name,
             auto x_clone = clone(x);
             auto precond = precond_factory.at(precond_name)(exec);
 
-            auto gen_logger = std::make_shared<OperationLogger>(exec);
+            auto gen_logger =
+                std::make_shared<OperationLogger>(exec, FLAGS_nested_names);
             exec->add_logger(gen_logger);
             std::unique_ptr<gko::LinOp> precond_op;
             for (auto i = 0u; i < FLAGS_repetitions; ++i) {
@@ -226,7 +227,8 @@ void run_preconditioner(const char *precond_name,
             gen_logger->write_data(this_precond_data["generate"]["components"],
                                    allocator, FLAGS_repetitions);
 
-            auto apply_logger = std::make_shared<OperationLogger>(exec);
+            auto apply_logger =
+                std::make_shared<OperationLogger>(exec, FLAGS_nested_names);
             exec->add_logger(apply_logger);
             for (auto i = 0u; i < FLAGS_repetitions; ++i) {
                 precond_op->apply(lend(b), lend(x_clone));

--- a/benchmark/solver/solver.cpp
+++ b/benchmark/solver/solver.cpp
@@ -81,8 +81,7 @@ DEFINE_bool(overhead, false,
 
 
 // input validation
-[[noreturn]] void print_config_error_and_exit()
-{
+[[noreturn]] void print_config_error_and_exit() {
     std::cerr << "Input has to be a JSON array of matrix configurations:\n"
               << "  [\n"
               << "    { \"filename\": \"my_file.mtx\",  \"optimal\": { "
@@ -318,7 +317,8 @@ void solve_system(const std::string &solver_name,
             // slow run, get the time of each functions
             auto x_clone = clone(x);
 
-            auto gen_logger = std::make_shared<OperationLogger>(exec);
+            auto gen_logger =
+                std::make_shared<OperationLogger>(exec, FLAGS_nested_names);
             exec->add_logger(gen_logger);
 
             auto precond = precond_factory.at(precond_name)(exec);
@@ -339,7 +339,8 @@ void solve_system(const std::string &solver_name,
                                    solver_json["preconditioner"], allocator);
             }
 
-            auto apply_logger = std::make_shared<OperationLogger>(exec);
+            auto apply_logger =
+                std::make_shared<OperationLogger>(exec, FLAGS_nested_names);
             exec->add_logger(apply_logger);
 
             solver->apply(lend(b), lend(x_clone));

--- a/benchmark/utils/general.hpp
+++ b/benchmark/utils/general.hpp
@@ -80,6 +80,8 @@ DEFINE_string(double_buffer, "",
 DEFINE_bool(detailed, true,
             "If set, performs several runs to obtain more detailed results");
 
+DEFINE_bool(nested_names, false, "If set, separately logs nested operations");
+
 DEFINE_uint32(seed, 42, "Seed used for the random number generator");
 
 DEFINE_uint32(warmup, 2, "Warm-up repetitions");

--- a/benchmark/utils/loggers.hpp
+++ b/benchmark/utils/loggers.hpp
@@ -127,7 +127,7 @@ private:
         auto nested_name = nested.empty() || !use_nested_name
                                ? name
                                : nested.back().first + "::" + name;
-        nested.emplace_back(nested_name, 0);
+        nested.emplace_back(nested_name, std::chrono::steady_clock::duration{});
         start[nested_name] = std::chrono::steady_clock::now();
     }
 

--- a/core/base/allocator.hpp
+++ b/core/base/allocator.hpp
@@ -34,10 +34,16 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define GKO_CORE_BASE_ALLOCATOR_HPP_
 
 
-#include <ginkgo/core/base/executor.hpp>
+#include <map>
 #include <memory>
+#include <set>
 #include <type_traits>
+#include <unordered_map>
+#include <unordered_set>
 #include <vector>
+
+
+#include <ginkgo/core/base/executor.hpp>
 
 
 namespace gko {
@@ -137,9 +143,31 @@ private:
 };
 
 
-// Convenience type alias
+// Convenience type aliases
+/** std::vector using an ExecutorAllocator. */
 template <typename T>
 using vector = std::vector<T, ExecutorAllocator<T>>;
+
+/** std::set using an ExecutorAllocator. */
+template <typename Key>
+using set = std::set<Key, std::less<Key>, gko::ExecutorAllocator<Key>>;
+
+/** std::map using an ExecutorAllocator. */
+template <typename Key, typename Value>
+using map = std::map<Key, Value, std::less<Key>,
+                     gko::ExecutorAllocator<std::pair<const Key, Value>>>;
+
+/** std::unordered_set using an ExecutorAllocator. */
+template <typename Key>
+using unordered_set =
+    std::unordered_set<Key, std::hash<Key>, std::equal_to<Key>,
+                       gko::ExecutorAllocator<Key>>;
+
+/** std::unordered_map using an ExecutorAllocator. */
+template <typename Key, typename Value>
+using unordered_map =
+    std::unordered_map<Key, Value, std::hash<Key>, std::equal_to<Key>,
+                       gko::ExecutorAllocator<std::pair<const Key, Value>>>;
 
 
 }  // namespace gko

--- a/core/base/allocator.hpp
+++ b/core/base/allocator.hpp
@@ -1,0 +1,147 @@
+/*******************************<GINKGO LICENSE>******************************
+Copyright (c) 2017-2020, the Ginkgo authors
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+******************************<GINKGO LICENSE>*******************************/
+
+#ifndef GKO_CORE_BASE_ALLOCATOR_HPP_
+#define GKO_CORE_BASE_ALLOCATOR_HPP_
+
+
+#include <ginkgo/core/base/executor.hpp>
+#include <memory>
+#include <type_traits>
+#include <vector>
+
+
+namespace gko {
+
+/**
+ * @internal
+ *
+ * C++ standard library-compatible allocator that uses an executor for
+ * allocations.
+ *
+ * @tparam T  the type of the allocated elements.
+ */
+template <typename T>
+class ExecutorAllocator {
+public:
+    using value_type = T;
+    using propagate_on_container_copy_assignment = std::true_type;
+    using propagate_on_container_move_assignment = std::true_type;
+    using propagate_on_container_swap = std::true_type;
+
+    /**
+     * Constructs an allocator from a given executor.
+     *
+     * This function works with both const and non-const ExecType,
+     * as long as it is derived from gko::Executor.
+     * @param exec  the executor
+     * @tparam ExecType  the static type of the executor
+     */
+    template <typename ExecType>
+    ExecutorAllocator(std::shared_ptr<ExecType> exec) : exec_{std::move(exec)}
+    {}
+
+    /**
+     * Constructs an allocator for another element type from a given executor.
+     *
+     * This is related to `std::allocator_traits::template rebind<U>` and its
+     * use in more advanced data structures.
+     *
+     * @param other  the other executor
+     * @tparam U  the element type of the allocator to be constructed.
+     */
+    template <typename U>
+    explicit ExecutorAllocator(const ExecutorAllocator<U> &other)
+        : exec_{other.get_executor()}
+    {}
+
+    /** Returns the executor used by this allocator.  */
+    std::shared_ptr<const Executor> get_executor() const { return exec_; }
+
+    /**
+     * Allocates a memory area of the given size.
+     *
+     * @param n  the number of elements to allocate
+     * @return  the pointer to a newly allocated memory area of `n` elements.
+     */
+    T *allocate(std::size_t n) const { return exec_->alloc<T>(n); }
+
+    /**
+     * Frees a memory area that was allocated by this allocator.
+     *
+     * @param ptr  The memory area to free, previously returned by `allocate`.
+     *
+     * @note  The second parameter is unused.
+     */
+    void deallocate(T *ptr, std::size_t) const { exec_->free(ptr); }
+
+    /**
+     * Compares two ExecutorAllocators for equality
+     *
+     * @param l  the first allocator
+     * @param r  the second allocator
+     * @return true iff the two allocators use the same executor
+     */
+    template <typename T2>
+    friend bool operator==(const ExecutorAllocator<T> &l,
+                           const ExecutorAllocator<T2> &r)
+    {
+        return l.get_executor() == r.get_executor();
+    }
+
+    /**
+     * Compares two ExecutorAllocators for inequality
+     *
+     * @param l  the first allocator
+     * @param r  the second allocator
+     * @return true iff the two allocators use different executors
+     */
+    template <typename T2>
+    friend bool operator!=(const ExecutorAllocator<T> &l,
+                           const ExecutorAllocator<T2> &r)
+    {
+        return !(l == r);
+    }
+
+private:
+    std::shared_ptr<const Executor> exec_;
+};
+
+
+// Convenience type alias
+template <typename T>
+using vector = std::vector<T, ExecutorAllocator<T>>;
+
+
+}  // namespace gko
+
+#endif  // GKO_CORE_BASE_ALLOCATOR_HPP_

--- a/core/matrix/sellp.cpp
+++ b/core/matrix/sellp.cpp
@@ -33,9 +33,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <ginkgo/core/matrix/sellp.hpp>
 
 
-#include <vector>
-
-
 #include <ginkgo/core/base/exception_helpers.hpp>
 #include <ginkgo/core/base/executor.hpp>
 #include <ginkgo/core/base/math.hpp>
@@ -44,6 +41,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <ginkgo/core/matrix/dense.hpp>
 
 
+#include "core/base/allocator.hpp"
 #include "core/matrix/sellp_kernels.hpp"
 
 
@@ -69,7 +67,7 @@ template <typename ValueType, typename IndexType>
 size_type calculate_total_cols(const matrix_data<ValueType, IndexType> &data,
                                const size_type slice_size,
                                const size_type stride_factor,
-                               std::vector<size_type> &slice_lengths)
+                               vector<size_type> &slice_lengths)
 {
     size_type nonzeros_per_row = 0;
     IndexType current_row = 0;
@@ -175,7 +173,7 @@ void Sellp<ValueType, IndexType>::read(const mat_data &data)
     // Allocate space for slice_cols.
     size_type slice_num =
         static_cast<index_type>((data.size[0] + slice_size - 1) / slice_size);
-    std::vector<size_type> slice_lengths(slice_num, 0);
+    vector<size_type> slice_lengths(slice_num, 0, {this->get_executor()});
 
     // Get the number of maximum columns for every slice.
     auto total_cols =

--- a/core/test/base/CMakeLists.txt
+++ b/core/test/base/CMakeLists.txt
@@ -1,4 +1,5 @@
 ginkgo_create_test(abstract_factory)
+ginkgo_create_test(allocator)
 ginkgo_create_test(array)
 ginkgo_create_test(combination)
 ginkgo_create_test(composition)

--- a/core/test/base/allocator.cpp
+++ b/core/test/base/allocator.cpp
@@ -1,0 +1,93 @@
+/*******************************<GINKGO LICENSE>******************************
+Copyright (c) 2017-2020, the Ginkgo authors
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+******************************<GINKGO LICENSE>*******************************/
+
+#include "core/base/allocator.hpp"
+
+
+#include <vector>
+
+
+#include <gtest/gtest.h>
+
+
+namespace {
+
+
+TEST(ExecutorAllocator, Works)
+{
+    auto exec = gko::ReferenceExecutor::create();
+    auto alloc = gko::ExecutorAllocator<int>(exec);
+
+    int *ptr{};
+    ASSERT_NO_THROW(ptr = alloc.allocate(10));
+    // This test can only fail with sanitizers
+    ptr[0] = 0;
+    ptr[9] = 0;
+
+    ASSERT_NO_THROW(alloc.deallocate(ptr, 10));
+}
+
+
+TEST(ExecutorAllocator, WorksWithStdlib)
+{
+    auto exec = gko::ReferenceExecutor::create();
+    auto alloc = gko::ExecutorAllocator<int>(exec);
+    auto vec = std::vector<int, gko::ExecutorAllocator<int>>(10, {exec});
+
+    // This test can only fail with sanitizers
+    vec[0] = 0;
+    vec[9] = 0;
+}
+
+
+TEST(ExecutorAllocator, ComparesEqual)
+{
+    auto exec = gko::ReferenceExecutor::create();
+    auto alloc1 = gko::ExecutorAllocator<int>(exec);
+    auto alloc2 = gko::ExecutorAllocator<float>(exec);
+
+    ASSERT_TRUE(alloc1 == alloc2);
+}
+
+
+TEST(ExecutorAllocator, ComparesNotEqual)
+{
+    auto exec1 = gko::ReferenceExecutor::create();
+    auto exec2 = gko::OmpExecutor::create();
+    auto alloc1 = gko::ExecutorAllocator<int>(exec1);
+    auto alloc2 = gko::ExecutorAllocator<float>(exec2);
+
+    ASSERT_TRUE(alloc1 != alloc2);
+}
+
+
+}  // namespace

--- a/core/test/base/allocator.cpp
+++ b/core/test/base/allocator.cpp
@@ -61,7 +61,7 @@ TEST(ExecutorAllocator, WorksWithStdlib)
 {
     auto exec = gko::ReferenceExecutor::create();
     auto alloc = gko::ExecutorAllocator<int>(exec);
-    auto vec = std::vector<int, gko::ExecutorAllocator<int>>(10, {exec});
+    auto vec = std::vector<int, gko::ExecutorAllocator<int>>(10, 0, exec);
 
     // This test can only fail with sanitizers
     vec[0] = 0;

--- a/reference/matrix/csr_kernels.cpp
+++ b/reference/matrix/csr_kernels.cpp
@@ -35,11 +35,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <algorithm>
 #include <iterator>
-#include <map>
 #include <numeric>
-#include <unordered_set>
 #include <utility>
-#include <vector>
 
 
 #include <ginkgo/core/base/array.hpp>
@@ -52,6 +49,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <ginkgo/core/matrix/sellp.hpp>
 
 
+#include "core/base/allocator.hpp"
 #include "core/base/iterator_factory.hpp"
 #include "core/components/prefix_sum.hpp"
 #include "core/matrix/csr_builder.hpp"
@@ -130,7 +128,7 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 
 
 template <typename ValueType, typename IndexType>
-void spgemm_insert_row(std::unordered_set<IndexType> &cols,
+void spgemm_insert_row(unordered_set<IndexType> &cols,
                        const matrix::Csr<ValueType, IndexType> *c,
                        size_type row)
 {
@@ -141,7 +139,7 @@ void spgemm_insert_row(std::unordered_set<IndexType> &cols,
 
 
 template <typename ValueType, typename IndexType>
-void spgemm_insert_row2(std::unordered_set<IndexType> &cols,
+void spgemm_insert_row2(unordered_set<IndexType> &cols,
                         const matrix::Csr<ValueType, IndexType> *a,
                         const matrix::Csr<ValueType, IndexType> *b,
                         size_type row)
@@ -161,7 +159,7 @@ void spgemm_insert_row2(std::unordered_set<IndexType> &cols,
 
 
 template <typename ValueType, typename IndexType>
-void spgemm_accumulate_row(std::map<IndexType, ValueType> &cols,
+void spgemm_accumulate_row(map<IndexType, ValueType> &cols,
                            const matrix::Csr<ValueType, IndexType> *c,
                            ValueType scale, size_type row)
 {
@@ -178,7 +176,7 @@ void spgemm_accumulate_row(std::map<IndexType, ValueType> &cols,
 
 
 template <typename ValueType, typename IndexType>
-void spgemm_accumulate_row2(std::map<IndexType, ValueType> &cols,
+void spgemm_accumulate_row2(map<IndexType, ValueType> &cols,
                             const matrix::Csr<ValueType, IndexType> *a,
                             const matrix::Csr<ValueType, IndexType> *b,
                             ValueType scale, size_type row)
@@ -215,7 +213,7 @@ void spgemm(std::shared_ptr<const ReferenceExecutor> exec,
     // first sweep: count nnz for each row
     auto c_row_ptrs = c->get_row_ptrs();
 
-    std::unordered_set<IndexType> local_col_idxs;
+    unordered_set<IndexType> local_col_idxs(exec);
     for (size_type a_row = 0; a_row < num_rows; ++a_row) {
         local_col_idxs.clear();
         spgemm_insert_row2(local_col_idxs, a, b, a_row);
@@ -235,7 +233,7 @@ void spgemm(std::shared_ptr<const ReferenceExecutor> exec,
     auto c_col_idxs = c_col_idxs_array.get_data();
     auto c_vals = c_vals_array.get_data();
 
-    std::map<IndexType, ValueType> local_row_nzs;
+    map<IndexType, ValueType> local_row_nzs(exec);
     for (size_type a_row = 0; a_row < num_rows; ++a_row) {
         local_row_nzs.clear();
         spgemm_accumulate_row2(local_row_nzs, a, b, one<ValueType>(), a_row);
@@ -268,7 +266,7 @@ void advanced_spgemm(std::shared_ptr<const ReferenceExecutor> exec,
     // first sweep: count nnz for each row
     auto c_row_ptrs = c->get_row_ptrs();
 
-    std::unordered_set<IndexType> local_col_idxs;
+    unordered_set<IndexType> local_col_idxs(exec);
     for (size_type a_row = 0; a_row < num_rows; ++a_row) {
         local_col_idxs.clear();
         if (vbeta != zero(vbeta)) {
@@ -293,7 +291,7 @@ void advanced_spgemm(std::shared_ptr<const ReferenceExecutor> exec,
     auto c_col_idxs = c_col_idxs_array.get_data();
     auto c_vals = c_vals_array.get_data();
 
-    std::map<IndexType, ValueType> local_row_nzs;
+    map<IndexType, ValueType> local_row_nzs(exec);
     for (size_type a_row = 0; a_row < num_rows; ++a_row) {
         local_row_nzs.clear();
         if (vbeta != zero(vbeta)) {
@@ -648,7 +646,8 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 
 
 template <typename ValueType, typename IndexType>
-void row_permute_impl(const Array<IndexType> *permutation_indices,
+void row_permute_impl(std::shared_ptr<const ReferenceExecutor> exec,
+                      const Array<IndexType> *permutation_indices,
                       const matrix::Csr<ValueType, IndexType> *orig,
                       matrix::Csr<ValueType, IndexType> *row_permuted)
 {
@@ -664,7 +663,7 @@ void row_permute_impl(const Array<IndexType> *permutation_indices,
 
     size_type cur_ptr = 0;
     rp_row_ptrs[0] = cur_ptr;
-    std::vector<size_type> orig_num_nnz_per_row(num_rows, 0);
+    vector<size_type> orig_num_nnz_per_row(num_rows, 0, exec);
     for (size_type row = 0; row < num_rows; ++row) {
         orig_num_nnz_per_row[row] = orig_row_ptrs[row + 1] - orig_row_ptrs[row];
     }
@@ -692,7 +691,7 @@ void row_permute(std::shared_ptr<const ReferenceExecutor> exec,
                  const matrix::Csr<ValueType, IndexType> *orig,
                  matrix::Csr<ValueType, IndexType> *row_permuted)
 {
-    row_permute_impl(permutation_indices, orig, row_permuted);
+    row_permute_impl(exec, permutation_indices, orig, row_permuted);
 }
 
 GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
@@ -712,7 +711,7 @@ void inverse_row_permute(std::shared_ptr<const ReferenceExecutor> exec,
         iperm[perm[ind]] = ind;
     }
 
-    row_permute_impl(&inv_perm, orig, row_permuted);
+    row_permute_impl(exec, &inv_perm, orig, row_permuted);
 }
 
 GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(

--- a/reference/preconditioner/jacobi_kernels.cpp
+++ b/reference/preconditioner/jacobi_kernels.cpp
@@ -37,7 +37,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <cmath>
 #include <iterator>
 #include <numeric>
-#include <vector>
 
 
 #include <ginkgo/core/base/exception_helpers.hpp>
@@ -46,6 +45,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <ginkgo/core/matrix/dense.hpp>
 
 
+#include "core/base/allocator.hpp"
 #include "core/base/extended_float.hpp"
 #include "core/preconditioner/jacobi_utils.hpp"
 #include "reference/components/matrix_operations.hpp"
@@ -291,13 +291,13 @@ inline bool invert_block(IndexType block_size, IndexType *perm,
 
 
 template <typename ReducedType, typename ValueType, typename IndexType>
-inline bool validate_precision_reduction_feasibility(IndexType block_size,
-                                                     const ValueType *block,
-                                                     size_type stride)
+inline bool validate_precision_reduction_feasibility(
+    std::shared_ptr<const ReferenceExecutor> exec, IndexType block_size,
+    const ValueType *block, size_type stride)
 {
     using gko::detail::float_traits;
-    std::vector<ValueType> tmp(block_size * block_size);
-    std::vector<IndexType> perm(block_size);
+    vector<ValueType> tmp(block_size * block_size, {}, exec);
+    vector<IndexType> perm(block_size, {}, exec);
     std::iota(begin(perm), end(perm), IndexType{0});
     for (IndexType i = 0; i < block_size; ++i) {
         for (IndexType j = 0; j < block_size; ++j) {
@@ -337,9 +337,9 @@ void generate(std::shared_ptr<const ReferenceExecutor> exec,
     const auto group_size = storage_scheme.get_group_size();
     const auto cond = conditioning.get_data();
     for (size_type g = 0; g < num_blocks; g += group_size) {
-        std::vector<Array<ValueType>> block(group_size);
-        std::vector<Array<IndexType>> perm(group_size);
-        std::vector<uint32> pr_descriptors(group_size, uint32{} - 1);
+        vector<Array<ValueType>> block(group_size, {}, exec);
+        vector<Array<IndexType>> perm(group_size, {}, exec);
+        vector<uint32> pr_descriptors(group_size, uint32{} - 1, exec);
         // extract group of blocks, invert them, figure out storage precision
         for (size_type b = 0; b < group_size; ++b) {
             if (b + g >= num_blocks) {
@@ -369,16 +369,18 @@ void generate(std::shared_ptr<const ReferenceExecutor> exec,
                 using preconditioner::detail::get_supported_storage_reductions;
                 pr_descriptors[b] = get_supported_storage_reductions<ValueType>(
                     accuracy, cond[g + b],
-                    [&block_size, &block, &b] {
+                    [&exec, &block_size, &block, &b] {
                         using target = reduce_precision<ValueType>;
                         return validate_precision_reduction_feasibility<target>(
-                            block_size, block[b].get_const_data(), block_size);
+                            exec, block_size, block[b].get_const_data(),
+                            block_size);
                     },
-                    [&block_size, &block, &b] {
+                    [&exec, &block_size, &block, &b] {
                         using target =
                             reduce_precision<reduce_precision<ValueType>>;
                         return validate_precision_reduction_feasibility<target>(
-                            block_size, block[b].get_const_data(), block_size);
+                            exec, block_size, block[b].get_const_data(),
+                            block_size);
                     });
             } else {
                 pr_descriptors[b] = preconditioner::detail::


### PR DESCRIPTION
This PR adds a C++ standard-library compatible allocator and uses it in all places where we use standard-library containers.

Additionally, it improves the operation logging for benchmarks by allowing the separate recording of nested operations (kernels -> allocate/free), which this PR will introduce in many additional places.

This was based on a discussion we had on #500 