### PR TITLE
Fix the windows cuda of GitHub action

### DIFF
--- a/cuda/CMakeLists.txt
+++ b/cuda/CMakeLists.txt
@@ -9,9 +9,11 @@ endif()
 if(MSVC)
     # MSVC can not find CUDA automatically
     # Use CUDA_COMPILER PATH to define the CUDA TOOLKIT ROOT DIR
+    string(REPLACE "/bin/nvcc.exe" "" CMAKE_CUDA_ROOT_DIR ${CMAKE_CUDA_COMPILER})
     if("${CMAKE_CUDA_TOOLKIT_INCLUDE_DIRECTORIES}" STREQUAL "")
-        string(REPLACE "/bin/nvcc.exe" "" CMAKE_CUDA_ROOT_DIR ${CMAKE_CUDA_COMPILER})
         set(CMAKE_CUDA_TOOLKIT_INCLUDE_DIRECTORIES "${CMAKE_CUDA_ROOT_DIR}/include")
+    endif()
+    if("${CMAKE_CUDA_IMPLICIT_LINK_DIRECTORIES}" STREQUAL "")
         set(CMAKE_CUDA_IMPLICIT_LINK_DIRECTORIES "${CMAKE_CUDA_ROOT_DIR}/lib/x64")
     endif()
 


### PR DESCRIPTION
The updated CMake (>= 3.17.0) can find the location of `CMAKE_CUDA_TOOLKIT_INCLUDE_DIRECTORIES` which is not found in the older CMake version (< 3.17.0)

This PR handles `CMAKE_CUDA_TOOLKIT_INCLUDE_DIRECTORIES` and `CMAKE_CUDA_IMPLICIT_LINK_DIRECTORIES` individually to fix this problem.