### PR TITLE
Fix CUDA ISAI test by adding cuda include files during build

### DIFF
--- a/cuda/test/preconditioner/CMakeLists.txt
+++ b/cuda/test/preconditioner/CMakeLists.txt
@@ -1,2 +1,2 @@
 ginkgo_create_test(jacobi_kernels)
-ginkgo_create_test(isai_kernels)
+ginkgo_create_test_cpp_cuda_header(isai_kernels)


### PR DESCRIPTION
I forgot that `cuda/base/config.hpp` internally includes `thrust/complex.h`, which requires the CUDA headers to be present. This PR simply changes the create function of the test to one which forwards these headers to the compiler.