### PR TITLE
Fix benchmarking issue with JSON and non-finite numbers

### DIFF
--- a/benchmark/utils/general.hpp
+++ b/benchmark/utils/general.hpp
@@ -168,7 +168,10 @@ std::ranlux24 &get_engine()
 std::ostream &operator<<(std::ostream &os, const rapidjson::Value &value)
 {
     rapidjson::OStreamWrapper jos(os);
-    rapidjson::PrettyWriter<rapidjson::OStreamWrapper> writer(jos);
+    rapidjson::PrettyWriter<rapidjson::OStreamWrapper, rapidjson::UTF8<>,
+                            rapidjson::UTF8<>, rapidjson::CrtAllocator,
+                            rapidjson::kWriteNanAndInfFlag>
+        writer(jos);
     value.Accept(writer);
     return os;
 }


### PR DESCRIPTION
Since the JSON standard does not allow for NaN and Inf values, rapidJSON "silently" fails when writing these values (meaning it returns `false`). This PR enables a flag that will cause all of these values to be output in benchmarks anyways.