### PR TITLE
Example for GPU kernel operations

### DIFF
--- a/cuda/base/executor.cuh
+++ b/cuda/base/executor.cuh
@@ -1,0 +1,60 @@
+/*******************************<GINKGO LICENSE>******************************
+Copyright (c) 2017-2020, the Ginkgo authors
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+******************************<GINKGO LICENSE>*******************************/
+
+#ifndef GKO_CUDA_BASE_EXECUTOR_CUH_
+#define GKO_CUDA_BASE_EXECUTOR_CUH_
+
+#include <ginkgo/core/base/executor.hpp>
+
+
+#include "cuda/base/types.hpp"
+
+
+namespace gko {
+
+
+template <typename Kernel, typename... Args>
+void CudaExecutor::run_gpu(const char *kernel_name, Kernel kernel,
+                           size_type num_blocks, size_type block_size,
+                           Args... args) const
+{
+    this->template log<log::Logger::gpu_kernel_launch>(this, kernel_name,
+                                                       num_blocks, block_size);
+    kernel<<<num_blocks, block_size>>>(kernels::cuda::as_cuda_type(args)...);
+    this->template log<log::Logger::gpu_kernel_finish>(this, kernel_name,
+                                                       num_blocks, block_size);
+}
+
+
+}  // namespace gko
+
+#endif  // GKO_CUDA_BASE_EXECUTOR_CUH_

--- a/hip/base/executor.hip.hpp
+++ b/hip/base/executor.hip.hpp
@@ -1,0 +1,64 @@
+/*******************************<GINKGO LICENSE>******************************
+Copyright (c) 2017-2020, the Ginkgo authors
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+******************************<GINKGO LICENSE>*******************************/
+
+#ifndef GKO_HIP_BASE_EXECUTOR_HIP_HPP_
+#define GKO_HIP_BASE_EXECUTOR_HIP_HPP_
+
+#include <ginkgo/core/base/executor.hpp>
+
+
+#include <hip/hip_runtime.h>
+
+
+#include "hip/base/types.hip.hpp"
+
+
+namespace gko {
+
+
+template <typename Kernel, typename... Args>
+void HipExecutor::run_gpu(const char *kernel_name, Kernel kernel,
+                          size_type num_blocks, size_type block_size,
+                          Args... args) const
+{
+    this->template log<log::Logger::gpu_kernel_launch>(this, kernel_name,
+                                                       num_blocks, block_size);
+    hipLaunchKernelGGL(HIP_KERNEL_NAME(kernel), num_blocks, block_size, 0, 0,
+                       kernels::hip::as_hip_type(args)...);
+    this->template log<log::Logger::gpu_kernel_finish>(this, kernel_name,
+                                                       num_blocks, block_size);
+}
+
+
+}  // namespace gko
+
+#endif  // GKO_HIP_BASE_EXECUTOR_HIP_HPP_

--- a/include/ginkgo/core/base/executor.hpp
+++ b/include/ginkgo/core/base/executor.hpp
@@ -867,6 +867,13 @@ public:
     void run(const Operation &op) const override;
 
     /**
+     * Executes the given GPU kernel with the given arguments on this executor.
+     */
+    template <typename Kernel, typename... Args>
+    void run_gpu(const char *kernel_name, Kernel kernel, size_type num_blocks,
+                 size_type block_size, Args... args) const;
+
+    /**
      * Get the CUDA device id of the device associated to this executor.
      */
     int get_device_id() const noexcept { return device_id_; }
@@ -1027,6 +1034,13 @@ public:
     void synchronize() const override;
 
     void run(const Operation &op) const override;
+
+    /**
+     * Executes the given GPU kernel with the given arguments on this executor.
+     */
+    template <typename Kernel, typename... Args>
+    void run_gpu(const char *kernel_name, Kernel kernel, size_type num_blocks,
+                 size_type block_size, Args... args) const;
 
     /**
      * Get the HIP device id of the device associated to this executor.

--- a/include/ginkgo/core/log/logger.hpp
+++ b/include/ginkgo/core/log/logger.hpp
@@ -403,6 +403,32 @@ public:                                                              \
                               const LinOp *x = nullptr,
                               const LinOp *tau = nullptr)
 
+    /**
+     * Register the `gpu_kernel_launch` event which logs every launched GPU
+     * kernel.
+     *
+     * @param exec  the executor
+     * @param name  the kernel name
+     * @param num_blocks  the number of blocks
+     * @param block_size  the block size
+     */
+    GKO_LOGGER_REGISTER_EVENT(22, gpu_kernel_launch, const Executor *exec,
+                              const char *name, size_type num_blocks,
+                              size_type block_size)
+
+    /**
+     * Register the `gpu_kernel_finish` event which logs every finished GPU
+     * kernel.
+     *
+     * @param exec  the executor
+     * @param name  the kernel name
+     * @param num_blocks  the number of blocks
+     * @param block_size  the block size
+     */
+    GKO_LOGGER_REGISTER_EVENT(23, gpu_kernel_finish, const Executor *exec,
+                              const char *name, size_type num_blocks,
+                              size_type block_size)
+
 
 #undef GKO_LOGGER_REGISTER_EVENT
 


### PR DESCRIPTION
This PR is an example for how we could unify the kernel launch process between CUDA and HIP, and improve the portability (multi-stream!) and profilability (benchmarking) of individual GPU kernels.
If there are no major problems, this could allow us to merge most CUDA and HIP files outside `*/base` and `*/components`. The current syntax is of course only a simple example with much improvement potential.
@tcojean rightly mentioned that there might be a certain overhead associated with the logger invocations, so in case we launch a huge number of small kernels, this overhead might become noticable.

So Pros:
* Unifies the code base
* More portability (multiple CUDA/HIP streams)
* More logging potential
* No more need to use `as_cuda_type`/`as_hip_type` for complex types

Cons:
* Performance penalty?
* More verbose? (explicit template parameters, kernel name) We might be able to hide this in a macro.