### PR TITLE
Simplify executor copy interface

### DIFF
--- a/core/test/base/executor.cpp
+++ b/core/test/base/executor.cpp
@@ -133,7 +133,7 @@ TEST(OmpExecutor, CopiesData)
     int *copy = omp->alloc<int>(num_elems);
 
     // user code is run on the OMP, so local variables are in OMP memory
-    omp->copy_from(omp.get(), num_elems, orig, copy);
+    omp->copy(num_elems, orig, copy);
     EXPECT_EQ(3, copy[0]);
     EXPECT_EQ(8, copy[1]);
 
@@ -210,7 +210,7 @@ TEST(ReferenceExecutor, CopiesData)
     int *copy = ref->alloc<int>(num_elems);
 
     // ReferenceExecutor is a type of OMP executor, so this is O.K.
-    ref->copy_from(ref.get(), num_elems, orig, copy);
+    ref->copy(num_elems, orig, copy);
     EXPECT_EQ(3, copy[0]);
     EXPECT_EQ(8, copy[1]);
 

--- a/core/test/base/executor.cpp
+++ b/core/test/base/executor.cpp
@@ -218,6 +218,18 @@ TEST(ReferenceExecutor, CopiesData)
 }
 
 
+TEST(ReferenceExecutor, CopiesSingleValue)
+{
+    exec_ptr ref = gko::ReferenceExecutor::create();
+    int *el = ref->alloc<int>(1);
+    el[0] = 83683;
+
+    EXPECT_EQ(83683, ref->copy_val_to_host(el));
+
+    ref->free(el);
+}
+
+
 TEST(ReferenceExecutor, CopiesDataFromOmp)
 {
     int orig[] = {3, 8};

--- a/cuda/components/reduction.cuh
+++ b/cuda/components/reduction.cuh
@@ -89,9 +89,7 @@ __host__ ValueType reduce_add_array(std::shared_ptr<const CudaExecutor> exec,
     reduce_add_array<<<1, default_block_size>>>(
         grid_dim, as_cuda_type(block_results_val),
         as_cuda_type(d_result.get_data()));
-    ValueType answer = zero<ValueType>();
-    exec->get_master()->copy_from(exec.get(), 1, d_result.get_const_data(),
-                                  &answer);
+    auto answer = exec->copy_val_to_host(d_result.get_const_data());
     return answer;
 }
 

--- a/cuda/factorization/factorization_kernels.cu
+++ b/cuda/factorization/factorization_kernels.cu
@@ -113,9 +113,8 @@ void add_diagonal_elements(std::shared_ptr<const CudaExecutor> exec,
     prefix_sum(exec, cuda_row_ptrs_add, row_ptrs_size);
     exec->synchronize();
 
-    IndexType total_additions{};
-    exec->get_master()->copy_from(
-        exec.get(), 1, cuda_row_ptrs_add + row_ptrs_size - 1, &total_additions);
+    auto total_additions =
+        exec->copy_val_to_host(cuda_row_ptrs_add + row_ptrs_size - 1);
     size_type new_num_elems = static_cast<size_type>(total_additions) +
                               mtx->get_num_stored_elements();
 

--- a/cuda/matrix/csr_kernels.cu
+++ b/cuda/matrix/csr_kernels.cu
@@ -516,9 +516,7 @@ void advanced_spgemm(std::shared_ptr<const CudaExecutor> exec,
         auto d_descr = cusparse::create_mat_descr();
         auto info = cusparse::create_spgemm_info();
 
-        ValueType valpha{};
-        exec->get_master()->copy_from(exec.get(), 1, alpha->get_const_values(),
-                                      &valpha);
+        auto valpha = exec->copy_val_to_host(alpha->get_const_values());
         auto a_nnz = IndexType(a->get_num_stored_elements());
         auto a_vals = a->get_const_values();
         auto a_row_ptrs = a->get_const_row_ptrs();
@@ -527,9 +525,7 @@ void advanced_spgemm(std::shared_ptr<const CudaExecutor> exec,
         auto b_vals = b->get_const_values();
         auto b_row_ptrs = b->get_const_row_ptrs();
         auto b_col_idxs = b->get_const_col_idxs();
-        ValueType vbeta{};
-        exec->get_master()->copy_from(exec.get(), 1, beta->get_const_values(),
-                                      &vbeta);
+        auto vbeta = exec->copy_val_to_host(beta->get_const_values());
         auto d_nnz = IndexType(d->get_num_stored_elements());
         auto d_vals = d->get_const_values();
         auto d_row_ptrs = d->get_const_row_ptrs();
@@ -767,8 +763,7 @@ void calculate_total_cols(std::shared_ptr<const CudaExecutor> exec,
         grid_dim, as_cuda_type(block_results.get_const_data()),
         as_cuda_type(d_result.get_data()));
 
-    exec->get_master()->copy_from(exec.get(), 1, d_result.get_const_data(),
-                                  result);
+    *result = exec->copy_val_to_host(d_result.get_const_data());
 }
 
 GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
@@ -900,8 +895,7 @@ void calculate_max_nnz_per_row(std::shared_ptr<const CudaExecutor> exec,
         reduce_dim, as_cuda_type(block_results.get_const_data()),
         as_cuda_type(d_result.get_data()));
 
-    exec->get_master()->copy_from(exec.get(), 1, d_result.get_const_data(),
-                                  result);
+    *result = exec->copy_val_to_host(d_result.get_const_data());
 }
 
 GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
@@ -983,7 +977,7 @@ void sort_by_column_index(std::shared_ptr<const CudaExecutor> exec,
 
         // copy values
         Array<ValueType> tmp_vals_array(exec, nnz);
-        exec->copy_from(exec.get(), nnz, vals, tmp_vals_array.get_data());
+        exec->copy(nnz, vals, tmp_vals_array.get_data());
         auto tmp_vals = tmp_vals_array.get_const_data();
 
         // init identity permutation

--- a/cuda/matrix/dense_kernels.cu
+++ b/cuda/matrix/dense_kernels.cu
@@ -435,8 +435,7 @@ void calculate_max_nnz_per_row(std::shared_ptr<const CudaExecutor> exec,
         grid_dim, as_cuda_type(block_results.get_const_data()),
         as_cuda_type(d_result.get_data()));
 
-    exec->get_master()->copy_from(exec.get(), 1, d_result.get_const_data(),
-                                  result);
+    *result = exec->copy_val_to_host(d_result.get_const_data());
 }
 
 GKO_INSTANTIATE_FOR_EACH_VALUE_TYPE(
@@ -500,8 +499,7 @@ void calculate_total_cols(std::shared_ptr<const CudaExecutor> exec,
         grid_dim, as_cuda_type(block_results.get_const_data()),
         as_cuda_type(d_result.get_data()));
 
-    exec->get_master()->copy_from(exec.get(), 1, d_result.get_const_data(),
-                                  result);
+    *result = exec->copy_val_to_host(d_result.get_const_data());
 }
 
 GKO_INSTANTIATE_FOR_EACH_VALUE_TYPE(

--- a/cuda/preconditioner/isai_kernels.cu
+++ b/cuda/preconditioner/isai_kernels.cu
@@ -74,10 +74,9 @@ void generate_l_inverse(std::shared_ptr<const DefaultExecutor> exec,
     const auto nnz = l_csr->get_num_stored_elements();
     const auto num_rows = l_csr->get_size()[0];
 
-    exec->copy_from(exec.get(), nnz, l_csr->get_const_col_idxs(),
-                    inverse_l->get_col_idxs());
-    exec->copy_from(exec.get(), num_rows + 1, l_csr->get_const_row_ptrs(),
-                    inverse_l->get_row_ptrs());
+    exec->copy(nnz, l_csr->get_const_col_idxs(), inverse_l->get_col_idxs());
+    exec->copy(num_rows + 1, l_csr->get_const_row_ptrs(),
+               inverse_l->get_row_ptrs());
 
 
     const dim3 block(default_block_size, 1, 1);
@@ -104,10 +103,9 @@ void generate_u_inverse(std::shared_ptr<const DefaultExecutor> exec,
     const auto nnz = u_csr->get_num_stored_elements();
     const auto num_rows = u_csr->get_size()[0];
 
-    exec->copy_from(exec.get(), nnz, u_csr->get_const_col_idxs(),
-                    inverse_u->get_col_idxs());
-    exec->copy_from(exec.get(), num_rows + 1, u_csr->get_const_row_ptrs(),
-                    inverse_u->get_row_ptrs());
+    exec->copy(nnz, u_csr->get_const_col_idxs(), inverse_u->get_col_idxs());
+    exec->copy(num_rows + 1, u_csr->get_const_row_ptrs(),
+               inverse_u->get_row_ptrs());
 
 
     const dim3 block(default_block_size, 1, 1);

--- a/cuda/stop/residual_norm_reduction_kernels.cu
+++ b/cuda/stop/residual_norm_reduction_kernels.cu
@@ -112,11 +112,8 @@ void residual_norm_reduction(std::shared_ptr<const CudaExecutor> exec,
         as_cuda_type(device_storage->get_data()));
 
     /* Represents all_converged, one_changed */
-    bool tmp[2] = {true, false};
-    exec->get_master()->copy_from(exec.get(), 2,
-                                  device_storage->get_const_data(), tmp);
-    *all_converged = tmp[0];
-    *one_changed = tmp[1];
+    *all_converged = exec->copy_val_to_host(device_storage->get_const_data());
+    *one_changed = exec->copy_val_to_host(device_storage->get_const_data() + 1);
 }
 
 GKO_INSTANTIATE_FOR_EACH_VALUE_TYPE(GKO_DECLARE_RESIDUAL_NORM_REDUCTION_KERNEL);

--- a/cuda/test/factorization/par_ilu_kernels.cpp
+++ b/cuda/test/factorization/par_ilu_kernels.cpp
@@ -169,14 +169,14 @@ protected:
         *l_cuda = Csr::create(cuda, csr_cuda->get_size(), l_nnz);
         *u_cuda = Csr::create(cuda, csr_cuda->get_size(), u_nnz);
         // Copy the already initialized `row_ptrs` to the new matrices
-        ref->copy_from(gko::lend(ref), num_row_ptrs, l_row_ptrs_ref.get_data(),
-                       (*l_ref)->get_row_ptrs());
-        ref->copy_from(gko::lend(ref), num_row_ptrs, u_row_ptrs_ref.get_data(),
-                       (*u_ref)->get_row_ptrs());
-        cuda->copy_from(gko::lend(cuda), num_row_ptrs,
-                        l_row_ptrs_cuda.get_data(), (*l_cuda)->get_row_ptrs());
-        cuda->copy_from(gko::lend(cuda), num_row_ptrs,
-                        u_row_ptrs_cuda.get_data(), (*u_cuda)->get_row_ptrs());
+        ref->copy(num_row_ptrs, l_row_ptrs_ref.get_data(),
+                  (*l_ref)->get_row_ptrs());
+        ref->copy(num_row_ptrs, u_row_ptrs_ref.get_data(),
+                  (*u_ref)->get_row_ptrs());
+        cuda->copy(num_row_ptrs, l_row_ptrs_cuda.get_data(),
+                   (*l_cuda)->get_row_ptrs());
+        cuda->copy(num_row_ptrs, u_row_ptrs_cuda.get_data(),
+                   (*u_cuda)->get_row_ptrs());
 
         gko::kernels::reference::factorization::initialize_l_u(
             ref, gko::lend(csr_ref), gko::lend(*l_ref), gko::lend(*u_ref));

--- a/hip/components/reduction.hip.hpp
+++ b/hip/components/reduction.hip.hpp
@@ -92,9 +92,7 @@ __host__ ValueType reduce_add_array(std::shared_ptr<const HipExecutor> exec,
     hipLaunchKernelGGL(reduce_add_array, dim3(1), dim3(default_block_size), 0,
                        0, grid_dim, as_hip_type(block_results_val),
                        as_hip_type(d_result.get_data()));
-    ValueType answer = zero<ValueType>();
-    exec->get_master()->copy_from(exec.get(), 1, d_result.get_const_data(),
-                                  &answer);
+    auto answer = exec->copy_val_to_host(d_result.get_const_data());
     return answer;
 }
 

--- a/hip/factorization/factorization_kernels.hip.cpp
+++ b/hip/factorization/factorization_kernels.hip.cpp
@@ -117,9 +117,8 @@ void add_diagonal_elements(std::shared_ptr<const HipExecutor> exec,
     prefix_sum(exec, hip_row_ptrs_add, row_ptrs_size);
     exec->synchronize();
 
-    IndexType total_additions{};
-    exec->get_master()->copy_from(
-        exec.get(), 1, hip_row_ptrs_add + row_ptrs_size - 1, &total_additions);
+    auto total_additions =
+        exec->copy_val_to_host(hip_row_ptrs_add + row_ptrs_size - 1);
     size_type new_num_elems = static_cast<size_type>(total_additions) +
                               mtx->get_num_stored_elements();
 

--- a/hip/matrix/dense_kernels.hip.cpp
+++ b/hip/matrix/dense_kernels.hip.cpp
@@ -454,8 +454,7 @@ void calculate_max_nnz_per_row(std::shared_ptr<const HipExecutor> exec,
                        as_hip_type(block_results.get_const_data()),
                        as_hip_type(d_result.get_data()));
 
-    exec->get_master()->copy_from(exec.get(), 1, d_result.get_const_data(),
-                                  result);
+    *result = exec->copy_val_to_host(d_result.get_const_data());
 }
 
 GKO_INSTANTIATE_FOR_EACH_VALUE_TYPE(
@@ -522,8 +521,7 @@ void calculate_total_cols(std::shared_ptr<const HipExecutor> exec,
                        as_hip_type(block_results.get_const_data()),
                        as_hip_type(d_result.get_data()));
 
-    exec->get_master()->copy_from(exec.get(), 1, d_result.get_const_data(),
-                                  result);
+    *result = exec->copy_val_to_host(d_result.get_const_data());
 }
 
 GKO_INSTANTIATE_FOR_EACH_VALUE_TYPE(

--- a/hip/preconditioner/isai_kernels.hip.cpp
+++ b/hip/preconditioner/isai_kernels.hip.cpp
@@ -77,10 +77,9 @@ void generate_l_inverse(std::shared_ptr<const DefaultExecutor> exec,
     const auto nnz = l_csr->get_num_stored_elements();
     const auto num_rows = l_csr->get_size()[0];
 
-    exec->copy_from(exec.get(), nnz, l_csr->get_const_col_idxs(),
-                    inverse_l->get_col_idxs());
-    exec->copy_from(exec.get(), num_rows + 1, l_csr->get_const_row_ptrs(),
-                    inverse_l->get_row_ptrs());
+    exec->copy(nnz, l_csr->get_const_col_idxs(), inverse_l->get_col_idxs());
+    exec->copy(num_rows + 1, l_csr->get_const_row_ptrs(),
+               inverse_l->get_row_ptrs());
 
     const dim3 block(default_block_size, 1, 1);
     const dim3 grid(ceildiv(num_rows, block.x / config::warp_size), 1, 1);
@@ -107,10 +106,9 @@ void generate_u_inverse(std::shared_ptr<const DefaultExecutor> exec,
     const auto nnz = u_csr->get_num_stored_elements();
     const auto num_rows = u_csr->get_size()[0];
 
-    exec->copy_from(exec.get(), nnz, u_csr->get_const_col_idxs(),
-                    inverse_u->get_col_idxs());
-    exec->copy_from(exec.get(), num_rows + 1, u_csr->get_const_row_ptrs(),
-                    inverse_u->get_row_ptrs());
+    exec->copy(nnz, u_csr->get_const_col_idxs(), inverse_u->get_col_idxs());
+    exec->copy(num_rows + 1, u_csr->get_const_row_ptrs(),
+               inverse_u->get_row_ptrs());
 
     const dim3 block(default_block_size, 1, 1);
     const dim3 grid(ceildiv(num_rows, block.x / config::warp_size), 1, 1);

--- a/hip/stop/residual_norm_reduction_kernels.hip.cpp
+++ b/hip/stop/residual_norm_reduction_kernels.hip.cpp
@@ -116,11 +116,8 @@ void residual_norm_reduction(std::shared_ptr<const HipExecutor> exec,
                        as_hip_type(device_storage->get_data()));
 
     /* Represents all_converged, one_changed */
-    bool tmp[2] = {true, false};
-    exec->get_master()->copy_from(exec.get(), 2,
-                                  device_storage->get_const_data(), tmp);
-    *all_converged = tmp[0];
-    *one_changed = tmp[1];
+    *all_converged = exec->copy_val_to_host(device_storage->get_const_data());
+    *one_changed = exec->copy_val_to_host(device_storage->get_const_data() + 1);
 }
 
 GKO_INSTANTIATE_FOR_EACH_VALUE_TYPE(GKO_DECLARE_RESIDUAL_NORM_REDUCTION_KERNEL);

--- a/hip/test/factorization/par_ilu_kernels.hip.cpp
+++ b/hip/test/factorization/par_ilu_kernels.hip.cpp
@@ -168,14 +168,14 @@ protected:
         *l_hip = Csr::create(hip, csr_hip->get_size(), l_nnz);
         *u_hip = Csr::create(hip, csr_hip->get_size(), u_nnz);
         // Copy the already initialized `row_ptrs` to the new matrices
-        ref->copy_from(gko::lend(ref), num_row_ptrs, l_row_ptrs_ref.get_data(),
-                       (*l_ref)->get_row_ptrs());
-        ref->copy_from(gko::lend(ref), num_row_ptrs, u_row_ptrs_ref.get_data(),
-                       (*u_ref)->get_row_ptrs());
-        hip->copy_from(gko::lend(hip), num_row_ptrs, l_row_ptrs_hip.get_data(),
-                       (*l_hip)->get_row_ptrs());
-        hip->copy_from(gko::lend(hip), num_row_ptrs, u_row_ptrs_hip.get_data(),
-                       (*u_hip)->get_row_ptrs());
+        ref->copy(num_row_ptrs, l_row_ptrs_ref.get_data(),
+                  (*l_ref)->get_row_ptrs());
+        ref->copy(num_row_ptrs, u_row_ptrs_ref.get_data(),
+                  (*u_ref)->get_row_ptrs());
+        hip->copy(num_row_ptrs, l_row_ptrs_hip.get_data(),
+                  (*l_hip)->get_row_ptrs());
+        hip->copy(num_row_ptrs, u_row_ptrs_hip.get_data(),
+                  (*u_hip)->get_row_ptrs());
 
         gko::kernels::reference::factorization::initialize_l_u(
             ref, gko::lend(csr_ref), gko::lend(*l_ref), gko::lend(*u_ref));

--- a/include/ginkgo/core/base/executor.hpp
+++ b/include/ginkgo/core/base/executor.hpp
@@ -537,6 +537,40 @@ public:
     }
 
     /**
+     * Copies data within this Executor.
+     *
+     * @tparam T  datatype to copy
+     *
+     * @param num_elems  number of elements of type T to copy
+     * @param src_ptr  pointer to a block of memory containing the data to be
+     *                 copied
+     * @param dest_ptr  pointer to an allocated block of memory
+     *                  where the data will be copied to
+     */
+    template <typename T>
+    void copy(size_type num_elems, const T *src_ptr, T *dest_ptr) const
+    {
+        this->copy_from(this, num_elems, src_ptr, dest_ptr);
+    }
+
+    /**
+     * Retrieves a single element at the given location from executor memory.
+     *
+     * @tparam T  datatype to copy
+     *
+     * @param ptr  the pointer to the element to be copied
+     *
+     * @return the value stored at ptr
+     */
+    template <typename T>
+    T copy_val_to_host(const T *ptr) const
+    {
+        T out{};
+        this->get_master()->copy_from(this, 1, ptr, &out);
+        return out;
+    }
+
+    /**
      * Returns the master OmpExecutor of this Executor.
      * @return the master OmpExecutor of this Executor.
      */

--- a/omp/test/factorization/par_ilu_kernels.cpp
+++ b/omp/test/factorization/par_ilu_kernels.cpp
@@ -173,14 +173,14 @@ protected:
         *l_omp = Csr::create(omp, csr_omp->get_size(), l_nnz);
         *u_omp = Csr::create(omp, csr_omp->get_size(), u_nnz);
         // Copy the already initialized `row_ptrs` to the new matrices
-        ref->copy_from(gko::lend(ref), num_row_ptrs, l_row_ptrs_ref.get_data(),
-                       (*l_ref)->get_row_ptrs());
-        ref->copy_from(gko::lend(ref), num_row_ptrs, u_row_ptrs_ref.get_data(),
-                       (*u_ref)->get_row_ptrs());
-        omp->copy_from(gko::lend(omp), num_row_ptrs, l_row_ptrs_omp.get_data(),
-                       (*l_omp)->get_row_ptrs());
-        omp->copy_from(gko::lend(omp), num_row_ptrs, u_row_ptrs_omp.get_data(),
-                       (*u_omp)->get_row_ptrs());
+        ref->copy(num_row_ptrs, l_row_ptrs_ref.get_data(),
+                  (*l_ref)->get_row_ptrs());
+        ref->copy(num_row_ptrs, u_row_ptrs_ref.get_data(),
+                  (*u_ref)->get_row_ptrs());
+        omp->copy(num_row_ptrs, l_row_ptrs_omp.get_data(),
+                  (*l_omp)->get_row_ptrs());
+        omp->copy(num_row_ptrs, u_row_ptrs_omp.get_data(),
+                  (*u_omp)->get_row_ptrs());
 
         gko::kernels::reference::factorization::initialize_l_u(
             ref, gko::lend(csr_ref), gko::lend(*l_ref), gko::lend(*u_ref));


### PR DESCRIPTION
This PR adds an executor-local `copy` function and a single-element `copy_to_master` that simplifies the common
```cpp
Type result{};
exec->get_master()->copy_from(exec.get(), 1, data, &result);
// and
exec->copy_from(exec.get(), size, src, target);
```
patterns into
```cpp
auto result = exec->copy_val_to_master(data);
// and
exec->copy(size, src, target);
```