### PR TITLE
Fix CI core count

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -25,8 +25,7 @@ stages:
   EXTRA_CMAKE_FLAGS: ""
 
 .before_script_template: &default_before_script
-  - export NUM_CORES=$(grep -E "^processor" /proc/cpuinfo | sort -u | wc -l)
-  - export NUM_CORES=$((NUM_CORES/10))
+  - export NUM_CORES=4
   - export OMP_NUM_THREADS=${NUM_CORES}
   - export CUDA_VISIBLE_DEVICES=0
 
@@ -788,7 +787,7 @@ fineci-benchmark-build:
                   -DGINKGO_BUILD_HIP=${BUILD_HIP} \\
                   -DGINKGO_BUILD_TESTS=OFF -DGINKGO_BUILD_EXAMPLES=OFF \\
                   -DGINKGO_BUILD_BENCHMARKS=ON
-        make -j$(grep -E "^processor" /proc/cpuinfo | sort -u | wc -l)
+        make -j4
       EOT
   dependencies: []
   only:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -25,7 +25,7 @@ stages:
   EXTRA_CMAKE_FLAGS: ""
 
 .before_script_template: &default_before_script
-  - export NUM_CORES=$(grep "core id" /proc/cpuinfo | sort -u | wc -l)
+  - export NUM_CORES=$(grep -E "^processor" /proc/cpuinfo | sort -u | wc -l)
   - export NUM_CORES=$((NUM_CORES/10))
   - export OMP_NUM_THREADS=${NUM_CORES}
   - export CUDA_VISIBLE_DEVICES=0
@@ -788,7 +788,7 @@ fineci-benchmark-build:
                   -DGINKGO_BUILD_HIP=${BUILD_HIP} \\
                   -DGINKGO_BUILD_TESTS=OFF -DGINKGO_BUILD_EXAMPLES=OFF \\
                   -DGINKGO_BUILD_BENCHMARKS=ON
-        make -j$(grep 'core id' /proc/cpuinfo | sort -u | wc -l)
+        make -j$(grep -E "^processor" /proc/cpuinfo | sort -u | wc -l)
       EOT
   dependencies: []
   only:


### PR DESCRIPTION
Currently we determine the number of (logical) cores on the CI system incorrectly:

On fineci:
```
> grep "core id" /proc/cpuinfo | sort -u
core id         : 0
core id         : 1
core id         : 10
core id         : 11
core id         : 12
core id         : 2
core id         : 3
core id         : 4
core id         : 8
core id         : 9
```

The Core IDs doesn't seem suitable to determine the number of cores, since they contain duplicates.
**As far as I can see, this also causes our builds on both machines to be executed with only a single core.**

A better choice would be
```
> grep "^processor" /proc/cpuinfo | sort -u
processor       : 0
processor       : 1
processor       : 10
processor       : 11
processor       : 12
processor       : 13
processor       : 14
processor       : 15
processor       : 16
processor       : 17
processor       : 18
processor       : 19
processor       : 2
processor       : 20
processor       : 21
processor       : 22
processor       : 23
processor       : 24
processor       : 25
processor       : 26
processor       : 27
processor       : 28
processor       : 29
processor       : 3
processor       : 30
processor       : 31
processor       : 32
processor       : 33
processor       : 34
processor       : 35
processor       : 36
processor       : 37
processor       : 38
processor       : 39
processor       : 4
processor       : 5
processor       : 6
processor       : 7
processor       : 8
processor       : 9
```