### PR TITLE
Make codecov patch check informational

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -5,6 +5,7 @@ coverage:
         target: auto
         threshold: 5
         base: auto
+        informational: True
     project:
       default:
         target: auto


### PR DESCRIPTION
This means that the check should no longer be listed under failing checks.