### PR TITLE
Add precision conversion functions

### DIFF
--- a/common/components/precision_conversion.hpp.inc
+++ b/common/components/precision_conversion.hpp.inc
@@ -1,0 +1,41 @@
+/*******************************<GINKGO LICENSE>******************************
+Copyright (c) 2017-2020, the Ginkgo authors
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+******************************<GINKGO LICENSE>*******************************/
+
+template <typename SourceType, typename TargetType>
+__global__ void convert_precision(size_type size, const SourceType *in,
+                                  TargetType *out)
+{
+    auto tnum = thread::get_thread_num_flat();
+    for (auto i = thread::get_thread_id_flat(); i < size; i += tnum) {
+        out[i] = in[i];
+    }
+}

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -4,6 +4,7 @@ add_subdirectory(device_hooks)  # placeholders for disabled modules
 add_library(ginkgo "")
 target_sources(ginkgo
     PRIVATE
+        base/array.cpp
         base/combination.cpp
         base/composition.cpp
         base/executor.cpp

--- a/core/base/array.cpp
+++ b/core/base/array.cpp
@@ -43,7 +43,7 @@ namespace gko {
 namespace conversion {
 
 
-GKO_REGISTER_OPERATION(convert, convert_precision);
+GKO_REGISTER_OPERATION(convert, components::convert_precision);
 
 
 }  // namespace conversion

--- a/core/base/array.cpp
+++ b/core/base/array.cpp
@@ -1,0 +1,71 @@
+/*******************************<GINKGO LICENSE>******************************
+Copyright (c) 2017-2020, the Ginkgo authors
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+******************************<GINKGO LICENSE>*******************************/
+
+#include <ginkgo/core/base/array.hpp>
+
+
+#include <ginkgo/core/base/math.hpp>
+
+
+#include "core/components/precision_conversion.hpp"
+
+
+namespace gko {
+namespace conversion {
+
+
+GKO_REGISTER_OPERATION(convert, convert_precision);
+
+
+}  // namespace conversion
+
+
+namespace detail {
+
+
+template <typename SourceType, typename TargetType>
+void convert_data(std::shared_ptr<const Executor> exec, size_type size,
+                  const SourceType *src, TargetType *dst)
+{
+    exec->run(conversion::make_convert(size, src, dst));
+}
+
+
+#define GKO_DECLARE_ARRAY_CONVERSION(From, To)                              \
+    void convert_data<From, To>(std::shared_ptr<const Executor>, size_type, \
+                                const From *, To *)
+
+GKO_INSTANTIATE_FOR_EACH_VALUE_CONVERSION(GKO_DECLARE_ARRAY_CONVERSION);
+
+
+}  // namespace detail
+}  // namespace gko

--- a/core/components/precision_conversion.hpp
+++ b/core/components/precision_conversion.hpp
@@ -58,30 +58,38 @@ namespace kernels {
 
 
 namespace omp {
+namespace components {
 
 GKO_DECLARE_ALL_AS_TEMPLATES;
 
+}  // namespace components
 }  // namespace omp
 
 
 namespace cuda {
+namespace components {
 
 GKO_DECLARE_ALL_AS_TEMPLATES;
 
+}  // namespace components
 }  // namespace cuda
 
 
 namespace reference {
+namespace components {
 
 GKO_DECLARE_ALL_AS_TEMPLATES;
 
+}  // namespace components
 }  // namespace reference
 
 
 namespace hip {
+namespace components {
 
 GKO_DECLARE_ALL_AS_TEMPLATES;
 
+}  // namespace components
 }  // namespace hip
 
 

--- a/core/components/precision_conversion.hpp
+++ b/core/components/precision_conversion.hpp
@@ -1,0 +1,94 @@
+/*******************************<GINKGO LICENSE>******************************
+Copyright (c) 2017-2020, the Ginkgo authors
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+******************************<GINKGO LICENSE>*******************************/
+
+#ifndef GKO_CORE_COMPONENTS_PRECISION_CONVERSION_HPP_
+#define GKO_CORE_COMPONENTS_PRECISION_CONVERSION_HPP_
+
+
+#include <memory>
+
+
+#include <ginkgo/core/base/executor.hpp>
+#include <ginkgo/core/base/math.hpp>
+#include <ginkgo/core/base/types.hpp>
+
+
+namespace gko {
+namespace kernels {
+
+
+#define GKO_DECLARE_CONVERT_PRECISION_KERNEL(SourceType, TargetType)    \
+    void convert_precision(std::shared_ptr<const DefaultExecutor> exec, \
+                           size_type size, const SourceType *in,        \
+                           TargetType *out)
+
+
+#define GKO_DECLARE_ALL_AS_TEMPLATES                    \
+    template <typename SourceType, typename TargetType> \
+    GKO_DECLARE_CONVERT_PRECISION_KERNEL(SourceType, TargetType)
+
+
+namespace omp {
+
+GKO_DECLARE_ALL_AS_TEMPLATES;
+
+}  // namespace omp
+
+
+namespace cuda {
+
+GKO_DECLARE_ALL_AS_TEMPLATES;
+
+}  // namespace cuda
+
+
+namespace reference {
+
+GKO_DECLARE_ALL_AS_TEMPLATES;
+
+}  // namespace reference
+
+
+namespace hip {
+
+GKO_DECLARE_ALL_AS_TEMPLATES;
+
+}  // namespace hip
+
+
+#undef GKO_DECLARE_ALL_AS_TEMPLATES
+
+
+}  // namespace kernels
+}  // namespace gko
+
+#endif  // GKO_CORE_COMPONENTS_PRECISION_CONVERSION_HPP_

--- a/core/components/prefix_sum.hpp
+++ b/core/components/prefix_sum.hpp
@@ -56,30 +56,38 @@ namespace kernels {
 
 
 namespace omp {
+namespace components {
 
 GKO_DECLARE_ALL_AS_TEMPLATES;
 
+}  // namespace components
 }  // namespace omp
 
 
 namespace cuda {
+namespace components {
 
 GKO_DECLARE_ALL_AS_TEMPLATES;
 
+}  // namespace components
 }  // namespace cuda
 
 
 namespace reference {
+namespace components {
 
 GKO_DECLARE_ALL_AS_TEMPLATES;
 
+}  // namespace components
 }  // namespace reference
 
 
 namespace hip {
+namespace components {
 
 GKO_DECLARE_ALL_AS_TEMPLATES;
 
+}  // namespace components
 }  // namespace hip
 
 

--- a/core/device_hooks/common_kernels.inc.cpp
+++ b/core/device_hooks/common_kernels.inc.cpp
@@ -68,6 +68,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 namespace gko {
 namespace kernels {
 namespace GKO_HOOK_MODULE {
+namespace components {
 
 
 template <typename SourceType, typename TargetType>
@@ -75,13 +76,15 @@ GKO_DECLARE_CONVERT_PRECISION_KERNEL(SourceType, TargetType)
 GKO_NOT_COMPILED(GKO_HOOK_MODULE);
 GKO_INSTANTIATE_FOR_EACH_VALUE_CONVERSION(GKO_DECLARE_CONVERT_PRECISION_KERNEL);
 
-
 template <typename IndexType>
 GKO_DECLARE_PREFIX_SUM_KERNEL(IndexType)
 GKO_NOT_COMPILED(GKO_HOOK_MODULE);
 GKO_INSTANTIATE_FOR_EACH_INDEX_TYPE(GKO_DECLARE_PREFIX_SUM_KERNEL);
 // explicitly instantiate for size_type, as this is used in the SellP format
 template GKO_DECLARE_PREFIX_SUM_KERNEL(size_type);
+
+
+}  // namespace components
 
 
 namespace dense {

--- a/core/device_hooks/common_kernels.inc.cpp
+++ b/core/device_hooks/common_kernels.inc.cpp
@@ -33,6 +33,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <ginkgo/core/base/exception_helpers.hpp>
 
 
+#include "core/components/precision_conversion.hpp"
+#include "core/components/prefix_sum.hpp"
 #include "core/factorization/factorization_kernels.hpp"
 #include "core/factorization/ilu_kernels.hpp"
 #include "core/factorization/par_ilu_kernels.hpp"
@@ -66,6 +68,22 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 namespace gko {
 namespace kernels {
 namespace GKO_HOOK_MODULE {
+
+
+template <typename SourceType, typename TargetType>
+GKO_DECLARE_CONVERT_PRECISION_KERNEL(SourceType, TargetType)
+GKO_NOT_COMPILED(GKO_HOOK_MODULE);
+GKO_INSTANTIATE_FOR_EACH_VALUE_CONVERSION(GKO_DECLARE_CONVERT_PRECISION_KERNEL);
+
+
+template <typename IndexType>
+GKO_DECLARE_PREFIX_SUM_KERNEL(IndexType)
+GKO_NOT_COMPILED(GKO_HOOK_MODULE);
+GKO_INSTANTIATE_FOR_EACH_INDEX_TYPE(GKO_DECLARE_PREFIX_SUM_KERNEL);
+// explicitly instantiate for size_type, as this is used in the SellP format
+template GKO_DECLARE_PREFIX_SUM_KERNEL(size_type);
+
+
 namespace dense {
 
 

--- a/core/matrix/coo.cpp
+++ b/core/matrix/coo.cpp
@@ -105,6 +105,25 @@ void Coo<ValueType, IndexType>::apply2_impl(const LinOp *alpha, const LinOp *b,
 
 template <typename ValueType, typename IndexType>
 void Coo<ValueType, IndexType>::convert_to(
+    Coo<next_precision<ValueType>, IndexType> *result) const
+{
+    result->values_ = this->values_;
+    result->row_idxs_ = this->row_idxs_;
+    result->col_idxs_ = this->col_idxs_;
+    result->set_size(this->get_size());
+}
+
+
+template <typename ValueType, typename IndexType>
+void Coo<ValueType, IndexType>::move_to(
+    Coo<next_precision<ValueType>, IndexType> *result)
+{
+    this->convert_to(result);
+}
+
+
+template <typename ValueType, typename IndexType>
+void Coo<ValueType, IndexType>::convert_to(
     Csr<ValueType, IndexType> *result) const
 {
     auto exec = this->get_executor();

--- a/core/matrix/csr.cpp
+++ b/core/matrix/csr.cpp
@@ -122,6 +122,68 @@ void Csr<ValueType, IndexType>::apply_impl(const LinOp *alpha, const LinOp *b,
 
 template <typename ValueType, typename IndexType>
 void Csr<ValueType, IndexType>::convert_to(
+    Csr<next_precision<ValueType>, IndexType> *result) const
+{
+    result->values_ = this->values_;
+    result->col_idxs_ = this->col_idxs_;
+    result->row_ptrs_ = this->row_ptrs_;
+    result->set_size(this->get_size());
+    auto strat = this->get_strategy().get();
+    using Other = Csr<next_precision<ValueType>, IndexType>;
+    std::shared_ptr<typename Other::strategy_type> new_strat;
+    // TODO clean this up as soon as we improve strategy_type
+    if (dynamic_cast<classical *>(strat)) {
+        new_strat = std::make_shared<typename Other::classical>();
+    } else if (dynamic_cast<merge_path *>(strat)) {
+        new_strat = std::make_shared<typename Other::merge_path>();
+    } else if (dynamic_cast<cusparse *>(strat)) {
+        new_strat = std::make_shared<typename Other::cusparse>();
+    } else if (dynamic_cast<sparselib *>(strat)) {
+        new_strat = std::make_shared<typename Other::sparselib>();
+    } else {
+        auto rexec = result->get_executor();
+        auto cuda_exec = std::dynamic_pointer_cast<const CudaExecutor>(rexec);
+        auto hip_exec = std::dynamic_pointer_cast<const HipExecutor>(rexec);
+        auto lb = dynamic_cast<load_balance *>(strat);
+        if (cuda_exec) {
+            if (lb) {
+                new_strat =
+                    std::make_shared<typename Other::load_balance>(cuda_exec);
+            } else {
+                new_strat =
+                    std::make_shared<typename Other::automatical>(cuda_exec);
+            }
+        } else if (hip_exec) {
+            if (lb) {
+                new_strat =
+                    std::make_shared<typename Other::load_balance>(hip_exec);
+            } else {
+                new_strat =
+                    std::make_shared<typename Other::automatical>(hip_exec);
+            }
+        } else {
+            // FIXME this creates a long delay
+            if (lb) {
+                new_strat = std::make_shared<typename Other::load_balance>();
+            } else {
+                new_strat = std::make_shared<typename Other::automatical>();
+            }
+        }
+    }
+    result->set_strategy(new_strat);
+}
+
+
+template <typename ValueType, typename IndexType>
+void Csr<ValueType, IndexType>::move_to(
+    Csr<next_precision<ValueType>, IndexType> *result)
+{
+    this->convert_to(result);
+}
+
+
+template <typename ValueType, typename IndexType>
+void Csr<ValueType, IndexType>::convert_to(
     Coo<ValueType, IndexType> *result) const
 {
     auto exec = this->get_executor();

--- a/core/matrix/dense.cpp
+++ b/core/matrix/dense.cpp
@@ -284,6 +284,23 @@ void Dense<ValueType>::compute_norm2_impl(LinOp *result) const
 
 
 template <typename ValueType>
+void Dense<ValueType>::convert_to(
+    Dense<next_precision<ValueType>> *result) const
+{
+    result->values_ = this->values_;
+    result->stride_ = this->stride_;
+    result->set_size(this->get_size());
+}
+
+
+template <typename ValueType>
+void Dense<ValueType>::move_to(Dense<next_precision<ValueType>> *result)
+{
+    this->convert_to(result);
+}
+
+
+template <typename ValueType>
 void Dense<ValueType>::convert_to(Coo<ValueType, int32> *result) const
 {
     conversion_helper(

--- a/core/matrix/ell.cpp
+++ b/core/matrix/ell.cpp
@@ -109,6 +109,26 @@ void Ell<ValueType, IndexType>::apply_impl(const LinOp *alpha, const LinOp *b,
 
 
 template <typename ValueType, typename IndexType>
+void Ell<ValueType, IndexType>::convert_to(
+    Ell<next_precision<ValueType>, IndexType> *result) const
+{
+    result->values_ = this->values_;
+    result->col_idxs_ = this->col_idxs_;
+    result->num_stored_elements_per_row_ = this->num_stored_elements_per_row_;
+    result->stride_ = this->stride_;
+    result->set_size(this->get_size());
+}
+
+
+template <typename ValueType, typename IndexType>
+void Ell<ValueType, IndexType>::move_to(
+    Ell<next_precision<ValueType>, IndexType> *result)
+{
+    this->convert_to(result);
+}
+
+
+template <typename ValueType, typename IndexType>
 void Ell<ValueType, IndexType>::convert_to(Dense<ValueType> *result) const
 {
     auto exec = this->get_executor();

--- a/core/matrix/hybrid.cpp
+++ b/core/matrix/hybrid.cpp
@@ -110,6 +110,26 @@ void Hybrid<ValueType, IndexType>::apply_impl(const LinOp *alpha,
 
 
 template <typename ValueType, typename IndexType>
+void Hybrid<ValueType, IndexType>::convert_to(
+    Hybrid<next_precision<ValueType>, IndexType> *result) const
+{
+    this->ell_->convert_to(result->ell_.get());
+    this->coo_->convert_to(result->coo_.get());
+    // TODO set strategy correctly
+    // There is no way to correctly clone the strategy like in Csr::convert_to
+    result->set_size(this->get_size());
+}
+
+
+template <typename ValueType, typename IndexType>
+void Hybrid<ValueType, IndexType>::move_to(
+    Hybrid<next_precision<ValueType>, IndexType> *result)
+{
+    this->convert_to(result);
+}
+
+
+template <typename ValueType, typename IndexType>
 void Hybrid<ValueType, IndexType>::convert_to(Dense<ValueType> *result) const
 {
     auto exec = this->get_executor();

--- a/core/matrix/sellp.cpp
+++ b/core/matrix/sellp.cpp
@@ -121,6 +121,29 @@ void Sellp<ValueType, IndexType>::apply_impl(const LinOp *alpha, const LinOp *b,
 
 
 template <typename ValueType, typename IndexType>
+void Sellp<ValueType, IndexType>::convert_to(
+    Sellp<next_precision<ValueType>, IndexType> *result) const
+{
+    result->values_ = this->values_;
+    result->col_idxs_ = this->col_idxs_;
+    result->slice_lengths_ = this->slice_lengths_;
+    result->slice_sets_ = this->slice_sets_;
+    result->slice_size_ = this->slice_size_;
+    result->stride_factor_ = this->stride_factor_;
+    result->total_cols_ = this->total_cols_;
+    result->set_size(this->get_size());
+}
+
+
+template <typename ValueType, typename IndexType>
+void Sellp<ValueType, IndexType>::move_to(
+    Sellp<next_precision<ValueType>, IndexType> *result)
+{
+    this->convert_to(result);
+}
+
+
+template <typename ValueType, typename IndexType>
 void Sellp<ValueType, IndexType>::convert_to(Dense<ValueType> *result) const
 {
     auto exec = this->get_executor();

--- a/cuda/CMakeLists.txt
+++ b/cuda/CMakeLists.txt
@@ -64,6 +64,7 @@ target_sources(ginkgo_cuda
         base/exception.cpp
         base/executor.cpp
         base/version.cpp
+        components/precision_conversion.cu
         components/prefix_sum.cu
         components/zero_array_kernels.cu
         factorization/ilu_kernels.cu

--- a/cuda/components/precision_conversion.cu
+++ b/cuda/components/precision_conversion.cu
@@ -40,6 +40,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 namespace gko {
 namespace kernels {
 namespace cuda {
+namespace components {
 
 
 #include "common/components/precision_conversion.hpp.inc"
@@ -60,6 +61,7 @@ void convert_precision(std::shared_ptr<const DefaultExecutor> exec,
 GKO_INSTANTIATE_FOR_EACH_VALUE_CONVERSION(GKO_DECLARE_CONVERT_PRECISION_KERNEL);
 
 
+}  // namespace components
 }  // namespace cuda
 }  // namespace kernels
 }  // namespace gko

--- a/cuda/components/precision_conversion.cu
+++ b/cuda/components/precision_conversion.cu
@@ -1,0 +1,65 @@
+/*******************************<GINKGO LICENSE>******************************
+Copyright (c) 2017-2020, the Ginkgo authors
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+******************************<GINKGO LICENSE>*******************************/
+
+#include "core/components/precision_conversion.hpp"
+
+
+#include "cuda/base/types.hpp"
+#include "cuda/components/thread_ids.cuh"
+
+
+namespace gko {
+namespace kernels {
+namespace cuda {
+
+
+#include "common/components/precision_conversion.hpp.inc"
+
+
+constexpr int default_block_size = 512;
+
+
+template <typename SourceType, typename TargetType>
+void convert_precision(std::shared_ptr<const DefaultExecutor> exec,
+                       size_type size, const SourceType *in, TargetType *out)
+{
+    auto num_blocks = ceildiv(size, default_block_size);
+    convert_precision<<<num_blocks, default_block_size>>>(
+        size, as_cuda_type(in), as_cuda_type(out));
+}
+
+GKO_INSTANTIATE_FOR_EACH_VALUE_CONVERSION(GKO_DECLARE_CONVERT_PRECISION_KERNEL);
+
+
+}  // namespace cuda
+}  // namespace kernels
+}  // namespace gko

--- a/cuda/components/precision_conversion.cu
+++ b/cuda/components/precision_conversion.cu
@@ -43,10 +43,10 @@ namespace cuda {
 namespace components {
 
 
-#include "common/components/precision_conversion.hpp.inc"
-
-
 constexpr int default_block_size = 512;
+
+
+#include "common/components/precision_conversion.hpp.inc"
 
 
 template <typename SourceType, typename TargetType>

--- a/cuda/components/prefix_sum.cu
+++ b/cuda/components/prefix_sum.cu
@@ -39,6 +39,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 namespace gko {
 namespace kernels {
 namespace cuda {
+namespace components {
 
 
 constexpr int prefix_sum_block_size = 512;
@@ -61,12 +62,11 @@ void prefix_sum(std::shared_ptr<const CudaExecutor> exec, IndexType *counts,
 
 GKO_INSTANTIATE_FOR_EACH_INDEX_TYPE(GKO_DECLARE_PREFIX_SUM_KERNEL);
 
-// explicitly instantiate for size_type as well, as this is used in the SellP
-// format
-template void prefix_sum<size_type>(std::shared_ptr<const CudaExecutor> exec,
-                                    size_type *counts, size_type num_entries);
+// instantiate for size_type as well, as this is used in the Sellp format
+template GKO_DECLARE_PREFIX_SUM_KERNEL(size_type);
 
 
+}  // namespace components
 }  // namespace cuda
 }  // namespace kernels
 }  // namespace gko

--- a/cuda/factorization/factorization_kernels.cu
+++ b/cuda/factorization/factorization_kernels.cu
@@ -110,7 +110,7 @@ void add_diagonal_elements(std::shared_ptr<const CudaExecutor> exec,
         return;
     }
 
-    prefix_sum(exec, cuda_row_ptrs_add, row_ptrs_size);
+    components::prefix_sum(exec, cuda_row_ptrs_add, row_ptrs_size);
     exec->synchronize();
 
     auto total_additions =
@@ -162,8 +162,8 @@ void initialize_row_ptrs_l_u(
         as_cuda_type(system_matrix->get_const_values()),
         as_cuda_type(l_row_ptrs), as_cuda_type(u_row_ptrs));
 
-    prefix_sum(exec, l_row_ptrs, num_rows + 1);
-    prefix_sum(exec, u_row_ptrs, num_rows + 1);
+    components::prefix_sum(exec, l_row_ptrs, num_rows + 1);
+    components::prefix_sum(exec, u_row_ptrs, num_rows + 1);
 }
 
 GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(

--- a/cuda/matrix/csr_kernels.cu
+++ b/cuda/matrix/csr_kernels.cu
@@ -676,7 +676,7 @@ void convert_to_sellp(std::shared_ptr<const CudaExecutor> exec,
         as_cuda_type(nnz_per_row.get_const_data()), as_cuda_type(slice_lengths),
         as_cuda_type(slice_sets));
 
-    prefix_sum(exec, slice_sets, slice_num + 1);
+    components::prefix_sum(exec, slice_sets, slice_num + 1);
 
     grid_dim = ceildiv(num_rows, default_block_size);
     kernel::fill_in_sellp<<<grid_dim, default_block_size>>>(
@@ -927,7 +927,7 @@ void convert_to_hybrid(std::shared_ptr<const CudaExecutor> exec,
         num_rows, max_nnz_per_row, as_cuda_type(source->get_const_row_ptrs()),
         as_cuda_type(coo_offset.get_data()));
 
-    prefix_sum(exec, coo_offset.get_data(), num_rows);
+    components::prefix_sum(exec, coo_offset.get_data(), num_rows);
 
     grid_dim = ceildiv(num_rows * config::warp_size, default_block_size);
     kernel::fill_in_hybrid<<<grid_dim, default_block_size>>>(

--- a/cuda/matrix/dense_kernels.cu
+++ b/cuda/matrix/dense_kernels.cu
@@ -252,7 +252,7 @@ void convert_to_coo(std::shared_ptr<const CudaExecutor> exec,
     auto nnz_prefix_sum = Array<size_type>(exec, num_rows);
     calculate_nonzeros_per_row(exec, source, &nnz_prefix_sum);
 
-    prefix_sum(exec, nnz_prefix_sum.get_data(), num_rows);
+    components::prefix_sum(exec, nnz_prefix_sum.get_data(), num_rows);
 
     size_type grid_dim = ceildiv(num_rows, default_block_size);
 
@@ -288,7 +288,7 @@ void convert_to_csr(std::shared_ptr<const CudaExecutor> exec,
         num_rows, num_cols, stride, as_cuda_type(source->get_const_values()),
         as_cuda_type(row_ptrs));
 
-    prefix_sum(exec, row_ptrs, num_rows + 1);
+    components::prefix_sum(exec, row_ptrs, num_rows + 1);
 
     size_type grid_dim = ceildiv(num_rows, default_block_size);
 
@@ -369,7 +369,7 @@ void convert_to_sellp(std::shared_ptr<const CudaExecutor> exec,
         as_cuda_type(nnz_per_row.get_const_data()), as_cuda_type(slice_lengths),
         as_cuda_type(slice_sets));
 
-    prefix_sum(exec, slice_sets, slice_num + 1);
+    components::prefix_sum(exec, slice_sets, slice_num + 1);
 
     grid_dim = ceildiv(num_rows, default_block_size);
     kernel::fill_in_sellp<<<grid_dim, default_block_size>>>(

--- a/cuda/matrix/ell_kernels.cu
+++ b/cuda/matrix/ell_kernels.cu
@@ -308,7 +308,7 @@ void convert_to_csr(std::shared_ptr<const CudaExecutor> exec,
         num_rows, max_nnz_per_row, stride,
         as_cuda_type(source->get_const_values()), as_cuda_type(row_ptrs));
 
-    prefix_sum(exec, row_ptrs, num_rows + 1);
+    components::prefix_sum(exec, row_ptrs, num_rows + 1);
 
     size_type grid_dim = ceildiv(num_rows, default_block_size);
 

--- a/cuda/matrix/hybrid_kernels.cu
+++ b/cuda/matrix/hybrid_kernels.cu
@@ -129,7 +129,7 @@ void convert_to_csr(std::shared_ptr<const CudaExecutor> exec,
         num_rows, as_cuda_type(row_ptrs),
         as_cuda_type(coo_row_ptrs.get_const_data()));
 
-    prefix_sum(exec, row_ptrs, num_rows + 1);
+    components::prefix_sum(exec, row_ptrs, num_rows + 1);
 
     // Fill the value
     grid_num = ceildiv(num_rows, default_block_size);

--- a/cuda/matrix/sellp_kernels.cu
+++ b/cuda/matrix/sellp_kernels.cu
@@ -176,7 +176,7 @@ void convert_to_csr(std::shared_ptr<const CudaExecutor> exec,
     grid_dim = ceildiv(num_rows + 1, default_block_size);
     auto add_values = Array<IndexType>(exec, grid_dim);
 
-    prefix_sum(exec, result_row_ptrs, num_rows + 1);
+    components::prefix_sum(exec, result_row_ptrs, num_rows + 1);
 
     grid_dim = ceildiv(num_rows, default_block_size);
 

--- a/cuda/test/components/CMakeLists.txt
+++ b/cuda/test/components/CMakeLists.txt
@@ -1,5 +1,6 @@
 ginkgo_create_cuda_test(cooperative_groups_kernels)
 ginkgo_create_cuda_test(merging_kernels)
+ginkgo_create_cuda_test(precision_conversion)
 ginkgo_create_cuda_test(prefix_sum)
 ginkgo_create_cuda_test(searching_kernels)
 ginkgo_create_cuda_test(sorting_kernels)

--- a/cuda/test/components/precision_conversion.cu
+++ b/cuda/test/components/precision_conversion.cu
@@ -30,9 +30,7 @@ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ******************************<GINKGO LICENSE>*******************************/
 
-#include "core/components/prefix_sum.hpp"
-
-
+#include <cstring>
 #include <limits>
 #include <memory>
 #include <random>
@@ -60,8 +58,12 @@ protected:
           total_size(42793),
           vals(ref, total_size),
           cvals(ref, total_size),
+          vals2(ref, 1),
+          expected_float(ref, 1),
+          expected_double(ref, 1),
           dvals(exec),
-          dcvals(exec)
+          dcvals(exec),
+          dvals2(exec)
     {
         auto maxval = 1e10f;
         std::uniform_real_distribution<float> dist(-maxval, maxval);
@@ -71,6 +73,13 @@ protected:
         }
         dvals = vals;
         dcvals = cvals;
+        gko::uint64 rawdouble = 0x4218888000889111ULL;
+        gko::uint32 rawfloat = 0x50c44400ULL;
+        gko::uint64 rawrounded = 0x4218888000000000ULL;
+        std::memcpy(vals2.get_data(), &rawdouble, sizeof(double));
+        std::memcpy(expected_float.get_data(), &rawfloat, sizeof(float));
+        std::memcpy(expected_double.get_data(), &rawrounded, sizeof(double));
+        dvals2 = vals2;
     }
 
     std::shared_ptr<gko::ReferenceExecutor> ref;
@@ -79,6 +88,10 @@ protected:
     gko::size_type total_size;
     gko::Array<float> vals;
     gko::Array<float> dvals;
+    gko::Array<double> vals2;
+    gko::Array<double> dvals2;
+    gko::Array<float> expected_float;
+    gko::Array<double> expected_double;
     gko::Array<std::complex<float>> cvals;
     gko::Array<std::complex<float>> dcvals;
 };
@@ -96,6 +109,18 @@ TEST_F(PrecisionConversion, ConvertsReal)
 }
 
 
+TEST_F(PrecisionConversion, ConvertsRealViaRef)
+{
+    gko::Array<double> tmp{ref};
+    gko::Array<float> dout;
+
+    tmp = dvals;
+    dout = tmp;
+
+    GKO_ASSERT_ARRAY_EQ(&dvals, &dout);
+}
+
+
 TEST_F(PrecisionConversion, ConvertsComplex)
 {
     gko::Array<std::complex<double>> dtmp;
@@ -105,6 +130,19 @@ TEST_F(PrecisionConversion, ConvertsComplex)
     dout = dtmp;
 
     GKO_ASSERT_ARRAY_EQ(&dcvals, &dout);
+}
+
+
+TEST_F(PrecisionConversion, ConversionRounds)
+{
+    gko::Array<float> dtmp;
+    gko::Array<double> dout;
+
+    dtmp = dvals2;
+    dout = dtmp;
+
+    GKO_ASSERT_ARRAY_EQ(&dtmp, &expected_float);
+    GKO_ASSERT_ARRAY_EQ(&dout, &expected_double);
 }
 
 

--- a/cuda/test/components/precision_conversion.cu
+++ b/cuda/test/components/precision_conversion.cu
@@ -1,0 +1,135 @@
+/*******************************<GINKGO LICENSE>******************************
+Copyright (c) 2017-2020, the Ginkgo authors
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+******************************<GINKGO LICENSE>*******************************/
+
+#include "core/components/prefix_sum.hpp"
+
+
+#include <limits>
+#include <memory>
+#include <random>
+#include <vector>
+
+
+#include <gtest/gtest.h>
+
+
+#include <ginkgo/core/base/array.hpp>
+
+
+#include "cuda/test/utils.hpp"
+
+
+namespace {
+
+
+class PrecisionConversion : public ::testing::Test {
+protected:
+    PrecisionConversion()
+        : ref(gko::ReferenceExecutor::create()),
+          exec(gko::CudaExecutor::create(0, ref)),
+          rand(293),
+          total_size(42793),
+          vals(ref, total_size),
+          cvals(ref, total_size),
+          dvals(exec),
+          dcvals(exec)
+    {
+        auto maxval = std::numeric_limits<float>::max();
+        std::uniform_real_distribution<float> dist(-maxval, maxval);
+        for (gko::size_type i = 0; i < total_size; ++i) {
+            vals.get_data()[i] = dist(rand);
+            cvals.get_data()[i] = {dist(rand), dist(rand)};
+        }
+        dvals = vals;
+        dcvals = cvals;
+    }
+
+    std::shared_ptr<gko::ReferenceExecutor> ref;
+    std::shared_ptr<gko::CudaExecutor> exec;
+    std::default_random_engine rand;
+    gko::size_type total_size;
+    gko::Array<float> vals;
+    gko::Array<float> dvals;
+    gko::Array<std::complex<float>> cvals;
+    gko::Array<std::complex<float>> dcvals;
+};
+
+
+TEST_F(PrecisionConversion, ConvertsReal)
+{
+    gko::Array<double> dtmp;
+    gko::Array<float> dout;
+
+    dtmp = dvals;
+    dout = dtmp;
+
+    GKO_ASSERT_ARRAY_EQ(&dvals, &dout);
+}
+
+
+TEST_F(PrecisionConversion, ConvertsComplex)
+{
+    gko::Array<std::complex<double>> dtmp;
+    gko::Array<std::complex<float>> dout;
+
+    dtmp = dcvals;
+    dout = dtmp;
+
+    GKO_ASSERT_ARRAY_EQ(&dcvals, &dout);
+}
+
+
+TEST_F(PrecisionConversion, ConvertsRealFromRef)
+{
+    gko::Array<double> dtmp;
+    gko::Array<float> dout;
+
+    dtmp = vals;
+    dout = dtmp;
+
+    GKO_ASSERT_ARRAY_EQ(&dvals, &dout);
+}
+
+
+TEST_F(PrecisionConversion, ConvertsComplexFromRef)
+{
+    gko::Array<std::complex<double>> dtmp;
+    gko::Array<std::complex<float>> dout;
+
+    dtmp = cvals;
+    dout = dtmp;
+
+    GKO_ASSERT_ARRAY_EQ(&dcvals, &dout);
+}
+
+
+}  // namespace

--- a/cuda/test/components/precision_conversion.cu
+++ b/cuda/test/components/precision_conversion.cu
@@ -73,9 +73,9 @@ protected:
         }
         dvals = vals;
         dcvals = cvals;
-        gko::uint64 rawdouble = 0x4218888000889111ULL;
-        gko::uint32 rawfloat = 0x50c44400ULL;
-        gko::uint64 rawrounded = 0x4218888000000000ULL;
+        gko::uint64 rawdouble{0x4218888000889111ULL};
+        gko::uint32 rawfloat{0x50c44400UL};
+        gko::uint64 rawrounded{0x4218888000000000ULL};
         std::memcpy(vals2.get_data(), &rawdouble, sizeof(double));
         std::memcpy(expected_float.get_data(), &rawfloat, sizeof(float));
         std::memcpy(expected_double.get_data(), &rawrounded, sizeof(double));

--- a/cuda/test/components/precision_conversion.cu
+++ b/cuda/test/components/precision_conversion.cu
@@ -63,7 +63,7 @@ protected:
           dvals(exec),
           dcvals(exec)
     {
-        auto maxval = std::numeric_limits<float>::max();
+        auto maxval = 1e10f;
         std::uniform_real_distribution<float> dist(-maxval, maxval);
         for (gko::size_type i = 0; i < total_size; ++i) {
             vals.get_data()[i] = dist(rand);

--- a/cuda/test/components/prefix_sum.cu
+++ b/cuda/test/components/prefix_sum.cu
@@ -70,8 +70,10 @@ protected:
 
     void test(gko::size_type size)
     {
-        gko::kernels::reference::prefix_sum(ref, vals.get_data(), size);
-        gko::kernels::cuda::prefix_sum(exec, dvals.get_data(), size);
+        gko::kernels::reference::components::prefix_sum(ref, vals.get_data(),
+                                                        size);
+        gko::kernels::cuda::components::prefix_sum(exec, dvals.get_data(),
+                                                   size);
 
         gko::Array<index_type> dresult(ref, dvals);
         auto dptr = dresult.get_const_data();

--- a/hip/CMakeLists.txt
+++ b/hip/CMakeLists.txt
@@ -101,6 +101,7 @@ set(GINKGO_HIP_SOURCES
     base/exception.hip.cpp
     base/executor.hip.cpp
     base/version.hip.cpp
+    components/precision_conversion.hip.cpp
     components/prefix_sum.hip.cpp
     components/zero_array_kernels.hip.cpp
     factorization/ilu_kernels.hip.cpp

--- a/hip/components/precision_conversion.hip.cpp
+++ b/hip/components/precision_conversion.hip.cpp
@@ -40,6 +40,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 namespace gko {
 namespace kernels {
 namespace hip {
+namespace components {
 
 
 #include "common/components/precision_conversion.hpp.inc"
@@ -61,6 +62,7 @@ void convert_precision(std::shared_ptr<const DefaultExecutor> exec,
 GKO_INSTANTIATE_FOR_EACH_VALUE_CONVERSION(GKO_DECLARE_CONVERT_PRECISION_KERNEL);
 
 
+}  // namespace components
 }  // namespace hip
 }  // namespace kernels
 }  // namespace gko

--- a/hip/components/precision_conversion.hip.cpp
+++ b/hip/components/precision_conversion.hip.cpp
@@ -1,0 +1,66 @@
+/*******************************<GINKGO LICENSE>******************************
+Copyright (c) 2017-2020, the Ginkgo authors
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+******************************<GINKGO LICENSE>*******************************/
+
+#include "core/components/precision_conversion.hpp"
+
+
+#include "hip/base/types.hip.hpp"
+#include "hip/components/thread_ids.hip.hpp"
+
+
+namespace gko {
+namespace kernels {
+namespace hip {
+
+
+#include "common/components/precision_conversion.hpp.inc"
+
+
+constexpr int default_block_size = 512;
+
+
+template <typename SourceType, typename TargetType>
+void convert_precision(std::shared_ptr<const DefaultExecutor> exec,
+                       size_type size, const SourceType *in, TargetType *out)
+{
+    auto num_blocks = ceildiv(size, default_block_size);
+    hipLaunchKernelGGL(HIP_KERNEL_NAME(convert_precision), num_blocks,
+                       default_block_size, 0, 0, size, as_hip_type(in),
+                       as_hip_type(out));
+}
+
+GKO_INSTANTIATE_FOR_EACH_VALUE_CONVERSION(GKO_DECLARE_CONVERT_PRECISION_KERNEL);
+
+
+}  // namespace hip
+}  // namespace kernels
+}  // namespace gko

--- a/hip/components/precision_conversion.hip.cpp
+++ b/hip/components/precision_conversion.hip.cpp
@@ -43,10 +43,10 @@ namespace hip {
 namespace components {
 
 
-#include "common/components/precision_conversion.hpp.inc"
-
-
 constexpr int default_block_size = 512;
+
+
+#include "common/components/precision_conversion.hpp.inc"
 
 
 template <typename SourceType, typename TargetType>

--- a/hip/components/prefix_sum.hip.cpp
+++ b/hip/components/prefix_sum.hip.cpp
@@ -39,6 +39,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 namespace gko {
 namespace kernels {
 namespace hip {
+namespace components {
 
 
 constexpr int prefix_sum_block_size = 512;
@@ -62,12 +63,11 @@ void prefix_sum(std::shared_ptr<const HipExecutor> exec, IndexType *counts,
 
 GKO_INSTANTIATE_FOR_EACH_INDEX_TYPE(GKO_DECLARE_PREFIX_SUM_KERNEL);
 
-// explicitly instantiate for size_type as well, as this is used in the SellP
-// format
-template void prefix_sum<size_type>(std::shared_ptr<const HipExecutor> exec,
-                                    size_type *counts, size_type num_entries);
+// instantiate for size_type as well, as this is used in the Sellp format
+template GKO_DECLARE_PREFIX_SUM_KERNEL(size_type);
 
 
+}  // namespace components
 }  // namespace hip
 }  // namespace kernels
 }  // namespace gko

--- a/hip/factorization/factorization_kernels.hip.cpp
+++ b/hip/factorization/factorization_kernels.hip.cpp
@@ -114,7 +114,7 @@ void add_diagonal_elements(std::shared_ptr<const HipExecutor> exec,
         return;
     }
 
-    prefix_sum(exec, hip_row_ptrs_add, row_ptrs_size);
+    components::prefix_sum(exec, hip_row_ptrs_add, row_ptrs_size);
     exec->synchronize();
 
     auto total_additions =
@@ -168,8 +168,8 @@ void initialize_row_ptrs_l_u(
                        as_hip_type(system_matrix->get_const_values()),
                        as_hip_type(l_row_ptrs), as_hip_type(u_row_ptrs));
 
-    prefix_sum(exec, l_row_ptrs, num_rows + 1);
-    prefix_sum(exec, u_row_ptrs, num_rows + 1);
+    components::prefix_sum(exec, l_row_ptrs, num_rows + 1);
+    components::prefix_sum(exec, u_row_ptrs, num_rows + 1);
 }
 
 GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(

--- a/hip/matrix/csr_kernels.hip.cpp
+++ b/hip/matrix/csr_kernels.hip.cpp
@@ -552,7 +552,7 @@ void spgeam(syn::value_list<int, subwarp_size>,
                        c_row_ptrs);
 
     // build row pointers
-    prefix_sum(exec, c_row_ptrs, m + 1);
+    components::prefix_sum(exec, c_row_ptrs, m + 1);
 
     // accumulate non-zeros for alpha * A + beta * B
     matrix::CsrBuilder<ValueType, IndexType> c_builder{c};
@@ -771,7 +771,7 @@ void convert_to_sellp(std::shared_ptr<const HipExecutor> exec,
                        stride_factor, as_hip_type(nnz_per_row.get_const_data()),
                        as_hip_type(slice_lengths), as_hip_type(slice_sets));
 
-    prefix_sum(exec, slice_sets, slice_num + 1);
+    components::prefix_sum(exec, slice_sets, slice_num + 1);
 
     grid_dim = ceildiv(num_rows, default_block_size);
     hipLaunchKernelGGL(kernel::fill_in_sellp, dim3(grid_dim),
@@ -1035,7 +1035,7 @@ void convert_to_hybrid(std::shared_ptr<const HipExecutor> exec,
                        as_hip_type(source->get_const_row_ptrs()),
                        as_hip_type(coo_offset.get_data()));
 
-    prefix_sum(exec, coo_offset.get_data(), num_rows);
+    components::prefix_sum(exec, coo_offset.get_data(), num_rows);
 
     grid_dim = ceildiv(num_rows * config::warp_size, default_block_size);
     hipLaunchKernelGGL(kernel::fill_in_hybrid, dim3(grid_dim),

--- a/hip/matrix/dense_kernels.hip.cpp
+++ b/hip/matrix/dense_kernels.hip.cpp
@@ -265,7 +265,7 @@ void convert_to_coo(std::shared_ptr<const HipExecutor> exec,
     const size_type grid_dim = ceildiv(num_rows, default_block_size);
     auto add_values = Array<size_type>(exec, grid_dim);
 
-    prefix_sum(exec, nnz_prefix_sum.get_data(), num_rows);
+    components::prefix_sum(exec, nnz_prefix_sum.get_data(), num_rows);
 
     hipLaunchKernelGGL(kernel::fill_in_coo, dim3(grid_dim),
                        dim3(default_block_size), 0, 0, num_rows, num_cols,
@@ -301,7 +301,7 @@ void convert_to_csr(std::shared_ptr<const HipExecutor> exec,
                        stride, as_hip_type(source->get_const_values()),
                        as_hip_type(row_ptrs));
 
-    prefix_sum(exec, row_ptrs, num_rows + 1);
+    components::prefix_sum(exec, row_ptrs, num_rows + 1);
 
     size_type grid_dim = ceildiv(num_rows, default_block_size);
 
@@ -385,7 +385,7 @@ void convert_to_sellp(std::shared_ptr<const HipExecutor> exec,
                        as_hip_type(nnz_per_row.get_const_data()),
                        as_hip_type(slice_lengths), as_hip_type(slice_sets));
 
-    prefix_sum(exec, slice_sets, slice_num + 1);
+    components::prefix_sum(exec, slice_sets, slice_num + 1);
 
     grid_dim = ceildiv(num_rows, default_block_size);
     hipLaunchKernelGGL(

--- a/hip/matrix/ell_kernels.hip.cpp
+++ b/hip/matrix/ell_kernels.hip.cpp
@@ -317,7 +317,7 @@ void convert_to_csr(std::shared_ptr<const HipExecutor> exec,
     size_type grid_dim = ceildiv(num_rows + 1, default_block_size);
     auto add_values = Array<IndexType>(exec, grid_dim);
 
-    prefix_sum(exec, row_ptrs, num_rows + 1);
+    components::prefix_sum(exec, row_ptrs, num_rows + 1);
 
     hipLaunchKernelGGL(
         kernel::fill_in_csr, dim3(grid_dim), dim3(default_block_size), 0, 0,

--- a/hip/matrix/hybrid_kernels.hip.cpp
+++ b/hip/matrix/hybrid_kernels.hip.cpp
@@ -135,7 +135,7 @@ void convert_to_csr(std::shared_ptr<const HipExecutor> exec,
                        0, num_rows, as_hip_type(row_ptrs),
                        as_hip_type(coo_row_ptrs.get_const_data()));
 
-    prefix_sum(exec, row_ptrs, num_rows + 1);
+    components::prefix_sum(exec, row_ptrs, num_rows + 1);
 
     // Fill the value
     grid_num = ceildiv(num_rows, default_block_size);

--- a/hip/matrix/sellp_kernels.hip.cpp
+++ b/hip/matrix/sellp_kernels.hip.cpp
@@ -180,7 +180,7 @@ void convert_to_csr(std::shared_ptr<const HipExecutor> exec,
         0, num_rows, slice_size, as_hip_type(source_slice_sets),
         as_hip_type(source_values), as_hip_type(result_row_ptrs));
 
-    prefix_sum(exec, result_row_ptrs, num_rows + 1);
+    components::prefix_sum(exec, result_row_ptrs, num_rows + 1);
 
     grid_dim = ceildiv(num_rows, default_block_size);
 

--- a/hip/test/components/CMakeLists.txt
+++ b/hip/test/components/CMakeLists.txt
@@ -1,5 +1,6 @@
 ginkgo_create_hip_test(cooperative_groups_kernels)
 ginkgo_create_hip_test(merging_kernels)
+ginkgo_create_hip_test(precision_conversion)
 ginkgo_create_hip_test(prefix_sum)
 ginkgo_create_hip_test(searching_kernels)
 ginkgo_create_hip_test(sorting_kernels)

--- a/hip/test/components/precision_conversion.hip.cpp
+++ b/hip/test/components/precision_conversion.hip.cpp
@@ -30,9 +30,7 @@ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ******************************<GINKGO LICENSE>*******************************/
 
-#include "core/components/prefix_sum.hpp"
-
-
+#include <cstring>
 #include <limits>
 #include <memory>
 #include <random>
@@ -60,8 +58,12 @@ protected:
           total_size(42793),
           vals(ref, total_size),
           cvals(ref, total_size),
+          vals2(ref, 1),
+          expected_float(ref, 1),
+          expected_double(ref, 1),
           dvals(exec),
-          dcvals(exec)
+          dcvals(exec),
+          dvals2(exec)
     {
         auto maxval = 1e10f;
         std::uniform_real_distribution<float> dist(-maxval, maxval);
@@ -71,6 +73,13 @@ protected:
         }
         dvals = vals;
         dcvals = cvals;
+        gko::uint64 rawdouble = 0x4218888000889111ULL;
+        gko::uint32 rawfloat = 0x50c44400ULL;
+        gko::uint64 rawrounded = 0x4218888000000000ULL;
+        std::memcpy(vals2.get_data(), &rawdouble, sizeof(double));
+        std::memcpy(expected_float.get_data(), &rawfloat, sizeof(float));
+        std::memcpy(expected_double.get_data(), &rawrounded, sizeof(double));
+        dvals2 = vals2;
     }
 
     std::shared_ptr<gko::ReferenceExecutor> ref;
@@ -79,6 +88,10 @@ protected:
     gko::size_type total_size;
     gko::Array<float> vals;
     gko::Array<float> dvals;
+    gko::Array<double> vals2;
+    gko::Array<double> dvals2;
+    gko::Array<float> expected_float;
+    gko::Array<double> expected_double;
     gko::Array<std::complex<float>> cvals;
     gko::Array<std::complex<float>> dcvals;
 };
@@ -96,6 +109,18 @@ TEST_F(PrecisionConversion, ConvertsReal)
 }
 
 
+TEST_F(PrecisionConversion, ConvertsRealViaRef)
+{
+    gko::Array<double> tmp{ref};
+    gko::Array<float> dout;
+
+    tmp = dvals;
+    dout = tmp;
+
+    GKO_ASSERT_ARRAY_EQ(&dvals, &dout);
+}
+
+
 TEST_F(PrecisionConversion, ConvertsComplex)
 {
     gko::Array<std::complex<double>> dtmp;
@@ -105,6 +130,19 @@ TEST_F(PrecisionConversion, ConvertsComplex)
     dout = dtmp;
 
     GKO_ASSERT_ARRAY_EQ(&dcvals, &dout);
+}
+
+
+TEST_F(PrecisionConversion, ConversionRounds)
+{
+    gko::Array<float> dtmp;
+    gko::Array<double> dout;
+
+    dtmp = dvals2;
+    dout = dtmp;
+
+    GKO_ASSERT_ARRAY_EQ(&dtmp, &expected_float);
+    GKO_ASSERT_ARRAY_EQ(&dout, &expected_double);
 }
 
 

--- a/hip/test/components/precision_conversion.hip.cpp
+++ b/hip/test/components/precision_conversion.hip.cpp
@@ -1,0 +1,135 @@
+/*******************************<GINKGO LICENSE>******************************
+Copyright (c) 2017-2020, the Ginkgo authors
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+******************************<GINKGO LICENSE>*******************************/
+
+#include "core/components/prefix_sum.hpp"
+
+
+#include <limits>
+#include <memory>
+#include <random>
+#include <vector>
+
+
+#include <gtest/gtest.h>
+
+
+#include <ginkgo/core/base/array.hpp>
+
+
+#include "hip/test/utils.hip.hpp"
+
+
+namespace {
+
+
+class PrecisionConversion : public ::testing::Test {
+protected:
+    PrecisionConversion()
+        : ref(gko::ReferenceExecutor::create()),
+          exec(gko::HipExecutor::create(0, ref)),
+          rand(293),
+          total_size(42793),
+          vals(ref, total_size),
+          cvals(ref, total_size),
+          dvals(exec),
+          dcvals(exec)
+    {
+        auto maxval = std::numeric_limits<float>::max();
+        std::uniform_real_distribution<float> dist(-maxval, maxval);
+        for (gko::size_type i = 0; i < total_size; ++i) {
+            vals.get_data()[i] = dist(rand);
+            cvals.get_data()[i] = {dist(rand), dist(rand)};
+        }
+        dvals = vals;
+        dcvals = cvals;
+    }
+
+    std::shared_ptr<gko::ReferenceExecutor> ref;
+    std::shared_ptr<gko::HipExecutor> exec;
+    std::default_random_engine rand;
+    gko::size_type total_size;
+    gko::Array<float> vals;
+    gko::Array<float> dvals;
+    gko::Array<std::complex<float>> cvals;
+    gko::Array<std::complex<float>> dcvals;
+};
+
+
+TEST_F(PrecisionConversion, ConvertsReal)
+{
+    gko::Array<double> dtmp;
+    gko::Array<float> dout;
+
+    dtmp = dvals;
+    dout = dtmp;
+
+    GKO_ASSERT_ARRAY_EQ(&dvals, &dout);
+}
+
+
+TEST_F(PrecisionConversion, ConvertsComplex)
+{
+    gko::Array<std::complex<double>> dtmp;
+    gko::Array<std::complex<float>> dout;
+
+    dtmp = dcvals;
+    dout = dtmp;
+
+    GKO_ASSERT_ARRAY_EQ(&dcvals, &dout);
+}
+
+
+TEST_F(PrecisionConversion, ConvertsRealFromRef)
+{
+    gko::Array<double> dtmp;
+    gko::Array<float> dout;
+
+    dtmp = vals;
+    dout = dtmp;
+
+    GKO_ASSERT_ARRAY_EQ(&dvals, &dout);
+}
+
+
+TEST_F(PrecisionConversion, ConvertsComplexFromRef)
+{
+    gko::Array<std::complex<double>> dtmp;
+    gko::Array<std::complex<float>> dout;
+
+    dtmp = cvals;
+    dout = dtmp;
+
+    GKO_ASSERT_ARRAY_EQ(&dcvals, &dout);
+}
+
+
+}  // namespace

--- a/hip/test/components/precision_conversion.hip.cpp
+++ b/hip/test/components/precision_conversion.hip.cpp
@@ -73,9 +73,9 @@ protected:
         }
         dvals = vals;
         dcvals = cvals;
-        gko::uint64 rawdouble = 0x4218888000889111ULL;
-        gko::uint32 rawfloat = 0x50c44400ULL;
-        gko::uint64 rawrounded = 0x4218888000000000ULL;
+        gko::uint64 rawdouble{0x4218888000889111ULL};
+        gko::uint32 rawfloat{0x50c44400UL};
+        gko::uint64 rawrounded{0x4218888000000000ULL};
         std::memcpy(vals2.get_data(), &rawdouble, sizeof(double));
         std::memcpy(expected_float.get_data(), &rawfloat, sizeof(float));
         std::memcpy(expected_double.get_data(), &rawrounded, sizeof(double));

--- a/hip/test/components/precision_conversion.hip.cpp
+++ b/hip/test/components/precision_conversion.hip.cpp
@@ -63,7 +63,7 @@ protected:
           dvals(exec),
           dcvals(exec)
     {
-        auto maxval = std::numeric_limits<float>::max();
+        auto maxval = 1e10f;
         std::uniform_real_distribution<float> dist(-maxval, maxval);
         for (gko::size_type i = 0; i < total_size; ++i) {
             vals.get_data()[i] = dist(rand);

--- a/hip/test/components/prefix_sum.hip.cpp
+++ b/hip/test/components/prefix_sum.hip.cpp
@@ -70,8 +70,9 @@ protected:
 
     void test(gko::size_type size)
     {
-        gko::kernels::reference::prefix_sum(ref, vals.get_data(), size);
-        gko::kernels::hip::prefix_sum(exec, dvals.get_data(), size);
+        gko::kernels::reference::components::prefix_sum(ref, vals.get_data(),
+                                                        size);
+        gko::kernels::hip::components::prefix_sum(exec, dvals.get_data(), size);
 
         gko::Array<index_type> dresult(ref, dvals);
         auto dptr = dresult.get_const_data();

--- a/include/ginkgo/core/base/array.hpp
+++ b/include/ginkgo/core/base/array.hpp
@@ -419,7 +419,7 @@ public:
             GKO_ENSURE_COMPATIBLE_BOUNDS(other.get_num_elems(),
                                          this->num_elems_);
         }
-        Array<OtherValueType> tmp;
+        Array<OtherValueType> tmp{this->exec_};
         const OtherValueType *source = other.get_const_data();
         // if we are on different executors: copy, then convert
         if (this->exec_ != other.get_executor()) {

--- a/include/ginkgo/core/base/math.hpp
+++ b/include/ginkgo/core/base/math.hpp
@@ -202,6 +202,26 @@ GKO_INLINE GKO_ATTRIBUTES constexpr bool is_complex()
 namespace detail {
 
 
+// singly linked list of all our supported precisions
+template <typename T>
+struct next_precision_impl {};
+
+template <>
+struct next_precision_impl<float> {
+    using type = double;
+};
+
+template <>
+struct next_precision_impl<double> {
+    using type = float;
+};
+
+template <typename T>
+struct next_precision_impl<std::complex<T>> {
+    using type = std::complex<typename next_precision_impl<T>::type>;
+};
+
+
 template <typename T>
 struct reduce_precision_impl {
     using type = T;
@@ -245,6 +265,13 @@ struct increase_precision_impl<half> {
 
 
 }  // namespace detail
+
+
+/**
+ * Obtains the next type in the singly-linked precision list.
+ */
+template <typename T>
+using next_precision = typename detail::next_precision_impl<T>::type;
 
 
 /**

--- a/include/ginkgo/core/base/types.hpp
+++ b/include/ginkgo/core/base/types.hpp
@@ -442,6 +442,22 @@ GKO_ATTRIBUTES constexpr bool operator!=(precision_reduction x,
     template _macro(std::complex<double>, int64)
 
 
+/**
+ * Instantiates a template for each value type conversion pair compiled by
+ * Ginkgo.
+ *
+ * @param _macro  A macro which expands the template instantiation
+ *                (not including the leading `template` specifier).
+ *                Should take two arguments `src` and `dst`, which
+ *                are replaced by the source and destination value type.
+ */
+#define GKO_INSTANTIATE_FOR_EACH_VALUE_CONVERSION(_macro)       \
+    template _macro(float, double);                             \
+    template _macro(double, float);                             \
+    template _macro(std::complex<float>, std::complex<double>); \
+    template _macro(std::complex<double>, std::complex<float>)
+
+
 }  // namespace gko
 
 

--- a/include/ginkgo/core/matrix/coo.hpp
+++ b/include/ginkgo/core/matrix/coo.hpp
@@ -76,6 +76,7 @@ class CooBuilder;
 template <typename ValueType = default_precision, typename IndexType = int32>
 class Coo : public EnableLinOp<Coo<ValueType, IndexType>>,
             public EnableCreateMethod<Coo<ValueType, IndexType>>,
+            public ConvertibleTo<Coo<next_precision<ValueType>, IndexType>>,
             public ConvertibleTo<Csr<ValueType, IndexType>>,
             public ConvertibleTo<Dense<ValueType>>,
             public ReadableFromMatrixData<ValueType, IndexType>,
@@ -93,6 +94,13 @@ public:
     using value_type = ValueType;
     using index_type = IndexType;
     using mat_data = matrix_data<ValueType, IndexType>;
+
+    friend class Coo<next_precision<ValueType>, IndexType>;
+
+    void convert_to(
+        Coo<next_precision<ValueType>, IndexType> *result) const override;
+
+    void move_to(Coo<next_precision<ValueType>, IndexType> *result) override;
 
     void convert_to(Csr<ValueType, IndexType> *other) const override;
 

--- a/include/ginkgo/core/matrix/csr.hpp
+++ b/include/ginkgo/core/matrix/csr.hpp
@@ -96,6 +96,7 @@ void strategy_rebuild_helper(Csr<ValueType, IndexType> *result);
 template <typename ValueType = default_precision, typename IndexType = int32>
 class Csr : public EnableLinOp<Csr<ValueType, IndexType>>,
             public EnableCreateMethod<Csr<ValueType, IndexType>>,
+            public ConvertibleTo<Csr<next_precision<ValueType>, IndexType>>,
             public ConvertibleTo<Dense<ValueType>>,
             public ConvertibleTo<Coo<ValueType, IndexType>>,
             public ConvertibleTo<Ell<ValueType, IndexType>>,
@@ -562,6 +563,12 @@ public:
             detail::strategy_rebuild_helper(result);
         }
     }
+    friend class Csr<next_precision<ValueType>, IndexType>;
+
+    void convert_to(
+        Csr<next_precision<ValueType>, IndexType> *result) const override;
+
+    void move_to(Csr<next_precision<ValueType>, IndexType> *result) override;
 
     void convert_to(Dense<ValueType> *other) const override;
 

--- a/include/ginkgo/core/matrix/dense.hpp
+++ b/include/ginkgo/core/matrix/dense.hpp
@@ -35,7 +35,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
 #include <initializer_list>
-#include <type_traits>
 
 
 #include <ginkgo/core/base/array.hpp>

--- a/include/ginkgo/core/matrix/dense.hpp
+++ b/include/ginkgo/core/matrix/dense.hpp
@@ -35,6 +35,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
 #include <initializer_list>
+#include <type_traits>
 
 
 #include <ginkgo/core/base/array.hpp>
@@ -87,6 +88,7 @@ class SparsityCsr;
 template <typename ValueType = default_precision>
 class Dense : public EnableLinOp<Dense<ValueType>>,
               public EnableCreateMethod<Dense<ValueType>>,
+              public ConvertibleTo<Dense<next_precision<ValueType>>>,
               public ConvertibleTo<Coo<ValueType, int32>>,
               public ConvertibleTo<Coo<ValueType, int64>>,
               public ConvertibleTo<Csr<ValueType, int32>>,
@@ -145,6 +147,12 @@ public:
         // Otherwise, it results in a compile error.
         return (*other).create_with_same_config();
     }
+
+    friend class Dense<next_precision<ValueType>>;
+
+    void convert_to(Dense<next_precision<ValueType>> *result) const override;
+
+    void move_to(Dense<next_precision<ValueType>> *result) override;
 
     void convert_to(Coo<ValueType, int32> *result) const override;
 

--- a/include/ginkgo/core/matrix/ell.hpp
+++ b/include/ginkgo/core/matrix/ell.hpp
@@ -70,6 +70,7 @@ class Csr;
 template <typename ValueType = default_precision, typename IndexType = int32>
 class Ell : public EnableLinOp<Ell<ValueType, IndexType>>,
             public EnableCreateMethod<Ell<ValueType, IndexType>>,
+            public ConvertibleTo<Ell<next_precision<ValueType>, IndexType>>,
             public ConvertibleTo<Dense<ValueType>>,
             public ConvertibleTo<Csr<ValueType, IndexType>>,
             public ReadableFromMatrixData<ValueType, IndexType>,
@@ -86,6 +87,13 @@ public:
     using value_type = ValueType;
     using index_type = IndexType;
     using mat_data = matrix_data<ValueType, IndexType>;
+
+    friend class Ell<next_precision<ValueType>, IndexType>;
+
+    void convert_to(
+        Ell<next_precision<ValueType>, IndexType> *result) const override;
+
+    void move_to(Ell<next_precision<ValueType>, IndexType> *result) override;
 
     void convert_to(Dense<ValueType> *other) const override;
 

--- a/include/ginkgo/core/matrix/hybrid.hpp
+++ b/include/ginkgo/core/matrix/hybrid.hpp
@@ -68,12 +68,14 @@ class Csr;
  * @ingroup LinOp
  */
 template <typename ValueType = default_precision, typename IndexType = int32>
-class Hybrid : public EnableLinOp<Hybrid<ValueType, IndexType>>,
-               public EnableCreateMethod<Hybrid<ValueType, IndexType>>,
-               public ConvertibleTo<Dense<ValueType>>,
-               public ConvertibleTo<Csr<ValueType, IndexType>>,
-               public ReadableFromMatrixData<ValueType, IndexType>,
-               public WritableToMatrixData<ValueType, IndexType> {
+class Hybrid
+    : public EnableLinOp<Hybrid<ValueType, IndexType>>,
+      public EnableCreateMethod<Hybrid<ValueType, IndexType>>,
+      public ConvertibleTo<Hybrid<next_precision<ValueType>, IndexType>>,
+      public ConvertibleTo<Dense<ValueType>>,
+      public ConvertibleTo<Csr<ValueType, IndexType>>,
+      public ReadableFromMatrixData<ValueType, IndexType>,
+      public WritableToMatrixData<ValueType, IndexType> {
     friend class EnableCreateMethod<Hybrid>;
     friend class EnablePolymorphicObject<Hybrid, LinOp>;
     friend class Dense<ValueType>;
@@ -329,6 +331,13 @@ public:
     private:
         imbalance_bounded_limit strategy_;
     };
+
+    friend class Hybrid<next_precision<ValueType>, IndexType>;
+
+    void convert_to(
+        Hybrid<next_precision<ValueType>, IndexType> *result) const override;
+
+    void move_to(Hybrid<next_precision<ValueType>, IndexType> *result) override;
 
     void convert_to(Dense<ValueType> *other) const override;
 

--- a/include/ginkgo/core/matrix/sellp.hpp
+++ b/include/ginkgo/core/matrix/sellp.hpp
@@ -67,6 +67,7 @@ class Csr;
 template <typename ValueType = default_precision, typename IndexType = int32>
 class Sellp : public EnableLinOp<Sellp<ValueType, IndexType>>,
               public EnableCreateMethod<Sellp<ValueType, IndexType>>,
+              public ConvertibleTo<Sellp<next_precision<ValueType>, IndexType>>,
               public ConvertibleTo<Dense<ValueType>>,
               public ConvertibleTo<Csr<ValueType, IndexType>>,
               public ReadableFromMatrixData<ValueType, IndexType>,
@@ -83,6 +84,13 @@ public:
     using value_type = ValueType;
     using index_type = IndexType;
     using mat_data = matrix_data<ValueType, IndexType>;
+
+    friend class Sellp<next_precision<ValueType>, IndexType>;
+
+    void convert_to(
+        Sellp<next_precision<ValueType>, IndexType> *result) const override;
+
+    void move_to(Sellp<next_precision<ValueType>, IndexType> *result) override;
 
     void convert_to(Dense<ValueType> *other) const override;
 

--- a/omp/CMakeLists.txt
+++ b/omp/CMakeLists.txt
@@ -4,6 +4,7 @@ add_library(ginkgo_omp $<TARGET_OBJECTS:ginkgo_omp_device> "")
 target_sources(ginkgo_omp
     PRIVATE
         base/version.cpp
+        components/precision_conversion.cpp
         components/prefix_sum.cpp
         factorization/ilu_kernels.cpp
         factorization/factorization_kernels.cpp

--- a/omp/components/precision_conversion.cpp
+++ b/omp/components/precision_conversion.cpp
@@ -1,0 +1,56 @@
+/*******************************<GINKGO LICENSE>******************************
+Copyright (c) 2017-2020, the Ginkgo authors
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+******************************<GINKGO LICENSE>*******************************/
+
+#include "core/components/precision_conversion.hpp"
+
+
+namespace gko {
+namespace kernels {
+namespace omp {
+
+
+template <typename SourceType, typename TargetType>
+void convert_precision(std::shared_ptr<const DefaultExecutor> exec,
+                       size_type size, const SourceType *in, TargetType *out)
+{
+#pragma omp parallel for
+    for (size_type i = 0; i < size; ++i) {
+        out[i] = in[i];
+    }
+}
+
+GKO_INSTANTIATE_FOR_EACH_VALUE_CONVERSION(GKO_DECLARE_CONVERT_PRECISION_KERNEL);
+
+
+}  // namespace omp
+}  // namespace kernels
+}  // namespace gko

--- a/omp/components/precision_conversion.cpp
+++ b/omp/components/precision_conversion.cpp
@@ -36,6 +36,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 namespace gko {
 namespace kernels {
 namespace omp {
+namespace components {
 
 
 template <typename SourceType, typename TargetType>
@@ -51,6 +52,7 @@ void convert_precision(std::shared_ptr<const DefaultExecutor> exec,
 GKO_INSTANTIATE_FOR_EACH_VALUE_CONVERSION(GKO_DECLARE_CONVERT_PRECISION_KERNEL);
 
 
+}  // namespace components
 }  // namespace omp
 }  // namespace kernels
 }  // namespace gko

--- a/omp/components/prefix_sum.cpp
+++ b/omp/components/prefix_sum.cpp
@@ -36,6 +36,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 namespace gko {
 namespace kernels {
 namespace omp {
+namespace components {
 
 
 template <typename IndexType>
@@ -52,12 +53,11 @@ void prefix_sum(std::shared_ptr<const OmpExecutor> exec, IndexType *counts,
 
 GKO_INSTANTIATE_FOR_EACH_INDEX_TYPE(GKO_DECLARE_PREFIX_SUM_KERNEL);
 
-// explicitly instantiate for size_type as well, as this is used in the SellP
-// format
-template void prefix_sum<size_type>(std::shared_ptr<const OmpExecutor> exec,
-                                    size_type *counts, size_type num_entries);
+// instantiate for size_type as well, as this is used in the Sellp format
+template GKO_DECLARE_PREFIX_SUM_KERNEL(size_type);
 
 
+}  // namespace components
 }  // namespace omp
 }  // namespace kernels
 }  // namespace gko

--- a/omp/factorization/factorization_kernels.cpp
+++ b/omp/factorization/factorization_kernels.cpp
@@ -187,7 +187,7 @@ void add_diagonal_elements(std::shared_ptr<const OmpExecutor> exec,
     }
 
     row_ptrs_addition.get_data()[row_ptrs_size - 1] = 0;
-    prefix_sum(exec, row_ptrs_addition.get_data(), row_ptrs_size);
+    components::prefix_sum(exec, row_ptrs_addition.get_data(), row_ptrs_size);
 
     size_type new_num_elems = mtx->get_num_stored_elements() +
                               row_ptrs_addition.get_data()[row_ptrs_size - 1];
@@ -242,8 +242,8 @@ void initialize_row_ptrs_l_u(
     }
 
     // Now, compute the prefix-sum, to get proper row_ptrs for L and U
-    prefix_sum(exec, l_row_ptrs, num_rows + 1);
-    prefix_sum(exec, u_row_ptrs, num_rows + 1);
+    components::prefix_sum(exec, l_row_ptrs, num_rows + 1);
+    components::prefix_sum(exec, u_row_ptrs, num_rows + 1);
 }
 
 GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(

--- a/omp/matrix/csr_kernels.cpp
+++ b/omp/matrix/csr_kernels.cpp
@@ -224,7 +224,7 @@ void spgemm(std::shared_ptr<const OmpExecutor> exec,
     }
 
     // build row pointers
-    prefix_sum(exec, c_row_ptrs, num_rows + 1);
+    components::prefix_sum(exec, c_row_ptrs, num_rows + 1);
 
     // second sweep: accumulate non-zeros
     auto new_nnz = c_row_ptrs[num_rows];
@@ -284,7 +284,7 @@ void advanced_spgemm(std::shared_ptr<const OmpExecutor> exec,
     }
 
     // build row pointers
-    prefix_sum(exec, c_row_ptrs, num_rows + 1);
+    components::prefix_sum(exec, c_row_ptrs, num_rows + 1);
 
     // second sweep: accumulate non-zeros
     auto new_nnz = c_row_ptrs[num_rows];

--- a/omp/matrix/dense_kernels.cpp
+++ b/omp/matrix/dense_kernels.cpp
@@ -240,7 +240,7 @@ void convert_to_coo(std::shared_ptr<const OmpExecutor> exec,
         row_ptrs[row] = row_count;
     }
 
-    prefix_sum(exec, row_ptrs, num_rows);
+    components::prefix_sum(exec, row_ptrs, num_rows);
 
 #pragma omp parallel for
     for (size_type row = 0; row < num_rows; ++row) {
@@ -284,7 +284,7 @@ void convert_to_csr(std::shared_ptr<const OmpExecutor> exec,
         row_ptrs[row] = row_nnz;
     }
 
-    prefix_sum(exec, row_ptrs, num_rows + 1);
+    components::prefix_sum(exec, row_ptrs, num_rows + 1);
 
 #pragma omp parallel for
     for (size_type row = 0; row < num_rows; ++row) {
@@ -377,7 +377,7 @@ void convert_to_hybrid(std::shared_ptr<const OmpExecutor> exec,
         coo_row_ptrs[row] = std::max(ell_lim, total_row_nnz) - ell_lim;
     }
 
-    prefix_sum(exec, coo_row_ptrs, num_rows);
+    components::prefix_sum(exec, coo_row_ptrs, num_rows);
 
 #pragma omp parallel for
     for (size_type row = 0; row < num_rows; row++) {
@@ -503,7 +503,7 @@ void convert_to_sparsity_csr(std::shared_ptr<const OmpExecutor> exec,
         row_ptrs[row] = row_nnz;
     }
 
-    prefix_sum(exec, row_ptrs, num_rows + 1);
+    components::prefix_sum(exec, row_ptrs, num_rows + 1);
 
 #pragma omp parallel for
     for (size_type row = 0; row < num_rows; ++row) {

--- a/omp/test/components/CMakeLists.txt
+++ b/omp/test/components/CMakeLists.txt
@@ -1,1 +1,2 @@
+ginkgo_create_test(precision_conversion)
 ginkgo_create_test(prefix_sum)

--- a/omp/test/components/precision_conversion.cpp
+++ b/omp/test/components/precision_conversion.cpp
@@ -1,0 +1,147 @@
+/*******************************<GINKGO LICENSE>******************************
+Copyright (c) 2017-2020, the Ginkgo authors
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+******************************<GINKGO LICENSE>*******************************/
+
+#include "core/components/prefix_sum.hpp"
+
+
+#include <limits>
+#include <memory>
+#include <random>
+#include <vector>
+
+
+#include <gtest/gtest.h>
+
+
+#include <ginkgo/core/base/array.hpp>
+
+
+#include "core/test/utils.hpp"
+
+
+namespace {
+
+
+class PrecisionConversion : public ::testing::Test {
+protected:
+    PrecisionConversion()
+        : ref(gko::ReferenceExecutor::create()),
+          exec(gko::OmpExecutor::create()),
+          rand(293),
+          total_size(42793),
+          vals(ref, total_size),
+          cvals(ref, total_size),
+          dvals(exec),
+          dcvals(exec)
+    {
+        auto maxval = std::numeric_limits<float>::max();
+        std::uniform_real_distribution<float> dist(-maxval, maxval);
+        for (gko::size_type i = 0; i < total_size; ++i) {
+            vals.get_data()[i] = dist(rand);
+            cvals.get_data()[i] = {dist(rand), dist(rand)};
+        }
+        dvals = vals;
+        dcvals = cvals;
+    }
+
+    std::shared_ptr<gko::ReferenceExecutor> ref;
+    std::shared_ptr<gko::OmpExecutor> exec;
+    std::default_random_engine rand;
+    gko::size_type total_size;
+    gko::Array<float> vals;
+    gko::Array<float> dvals;
+    gko::Array<std::complex<float>> cvals;
+    gko::Array<std::complex<float>> dcvals;
+};
+
+
+TEST_F(PrecisionConversion, ConvertsReal)
+{
+    gko::Array<double> dtmp;
+    gko::Array<float> dout;
+
+    dtmp = dvals;
+    dout = dtmp;
+
+    GKO_ASSERT_ARRAY_EQ(&dvals, &dout);
+}
+
+
+TEST_F(PrecisionConversion, ConvertsRealViaRef)
+{
+    gko::Array<double> dtmp{ref};
+    gko::Array<float> dout;
+
+    dtmp = dvals;
+    dout = dtmp;
+
+    GKO_ASSERT_ARRAY_EQ(&dvals, &dout);
+}
+
+
+TEST_F(PrecisionConversion, ConvertsComplex)
+{
+    gko::Array<std::complex<double>> dtmp;
+    gko::Array<std::complex<float>> dout;
+
+    dtmp = dcvals;
+    dout = dtmp;
+
+    GKO_ASSERT_ARRAY_EQ(&dcvals, &dout);
+}
+
+
+TEST_F(PrecisionConversion, ConvertsRealFromRef)
+{
+    gko::Array<double> dtmp;
+    gko::Array<float> dout;
+
+    dtmp = vals;
+    dout = dtmp;
+
+    GKO_ASSERT_ARRAY_EQ(&dvals, &dout);
+}
+
+
+TEST_F(PrecisionConversion, ConvertsComplexFromRef)
+{
+    gko::Array<std::complex<double>> dtmp;
+    gko::Array<std::complex<float>> dout;
+
+    dtmp = cvals;
+    dout = dtmp;
+
+    GKO_ASSERT_ARRAY_EQ(&dcvals, &dout);
+}
+
+
+}  // namespace

--- a/omp/test/components/precision_conversion.cpp
+++ b/omp/test/components/precision_conversion.cpp
@@ -73,9 +73,9 @@ protected:
         }
         dvals = vals;
         dcvals = cvals;
-        gko::uint64 rawdouble = 0x4218888000889111ULL;
-        gko::uint32 rawfloat = 0x50c44400ULL;
-        gko::uint64 rawrounded = 0x4218888000000000ULL;
+        gko::uint64 rawdouble{0x4218888000889111ULL};
+        gko::uint32 rawfloat{0x50c44400UL};
+        gko::uint64 rawrounded{0x4218888000000000ULL};
         std::memcpy(vals2.get_data(), &rawdouble, sizeof(double));
         std::memcpy(expected_float.get_data(), &rawfloat, sizeof(float));
         std::memcpy(expected_double.get_data(), &rawrounded, sizeof(double));

--- a/omp/test/components/precision_conversion.cpp
+++ b/omp/test/components/precision_conversion.cpp
@@ -63,7 +63,7 @@ protected:
           dvals(exec),
           dcvals(exec)
     {
-        auto maxval = std::numeric_limits<float>::max();
+        auto maxval = 1e10f;
         std::uniform_real_distribution<float> dist(-maxval, maxval);
         for (gko::size_type i = 0; i < total_size; ++i) {
             vals.get_data()[i] = dist(rand);

--- a/omp/test/components/prefix_sum.cpp
+++ b/omp/test/components/prefix_sum.cpp
@@ -71,8 +71,9 @@ protected:
 
     void test(gko::size_type size)
     {
-        gko::kernels::reference::prefix_sum(ref, vals.get_data(), size);
-        gko::kernels::omp::prefix_sum(exec, dvals.get_data(), size);
+        gko::kernels::reference::components::prefix_sum(ref, vals.get_data(),
+                                                        size);
+        gko::kernels::omp::components::prefix_sum(exec, dvals.get_data(), size);
 
         auto dptr = dvals.get_const_data();
         auto ptr = vals.get_const_data();

--- a/reference/CMakeLists.txt
+++ b/reference/CMakeLists.txt
@@ -2,6 +2,7 @@ add_library(ginkgo_reference $<TARGET_OBJECTS:ginkgo_reference_device> "")
 target_sources(ginkgo_reference
     PRIVATE
         base/version.cpp
+        components/precision_conversion.cpp
         components/prefix_sum.cpp
         factorization/ilu_kernels.cpp
         factorization/factorization_kernels.cpp

--- a/reference/components/precision_conversion.cpp
+++ b/reference/components/precision_conversion.cpp
@@ -1,0 +1,56 @@
+/*******************************<GINKGO LICENSE>******************************
+Copyright (c) 2017-2020, the Ginkgo authors
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+******************************<GINKGO LICENSE>*******************************/
+
+#include "core/components/precision_conversion.hpp"
+
+
+#include <algorithm>
+
+
+namespace gko {
+namespace kernels {
+namespace reference {
+
+
+template <typename SourceType, typename TargetType>
+void convert_precision(std::shared_ptr<const DefaultExecutor> exec,
+                       size_type size, const SourceType *in, TargetType *out)
+{
+    std::copy_n(in, size, out);
+}
+
+GKO_INSTANTIATE_FOR_EACH_VALUE_CONVERSION(GKO_DECLARE_CONVERT_PRECISION_KERNEL);
+
+
+}  // namespace reference
+}  // namespace kernels
+}  // namespace gko

--- a/reference/components/precision_conversion.cpp
+++ b/reference/components/precision_conversion.cpp
@@ -39,6 +39,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 namespace gko {
 namespace kernels {
 namespace reference {
+namespace components {
 
 
 template <typename SourceType, typename TargetType>
@@ -51,6 +52,7 @@ void convert_precision(std::shared_ptr<const DefaultExecutor> exec,
 GKO_INSTANTIATE_FOR_EACH_VALUE_CONVERSION(GKO_DECLARE_CONVERT_PRECISION_KERNEL);
 
 
+}  // namespace components
 }  // namespace reference
 }  // namespace kernels
 }  // namespace gko

--- a/reference/components/prefix_sum.cpp
+++ b/reference/components/prefix_sum.cpp
@@ -36,6 +36,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 namespace gko {
 namespace kernels {
 namespace reference {
+namespace components {
 
 
 template <typename IndexType>
@@ -52,13 +53,11 @@ void prefix_sum(std::shared_ptr<const ReferenceExecutor> exec,
 
 GKO_INSTANTIATE_FOR_EACH_INDEX_TYPE(GKO_DECLARE_PREFIX_SUM_KERNEL);
 
-// explicitly instantiate for size_type as well, as this is used in the SellP
-// format
-template void prefix_sum<size_type>(
-    std::shared_ptr<const ReferenceExecutor> exec, size_type *counts,
-    size_type num_entries);
+// instantiate for size_type as well, as this is used in the Sellp format
+template GKO_DECLARE_PREFIX_SUM_KERNEL(size_type);
 
 
+}  // namespace components
 }  // namespace reference
 }  // namespace kernels
 }  // namespace gko

--- a/reference/matrix/csr_kernels.cpp
+++ b/reference/matrix/csr_kernels.cpp
@@ -221,7 +221,7 @@ void spgemm(std::shared_ptr<const ReferenceExecutor> exec,
     }
 
     // build row pointers
-    prefix_sum(exec, c_row_ptrs, num_rows + 1);
+    components::prefix_sum(exec, c_row_ptrs, num_rows + 1);
 
     // second sweep: accumulate non-zeros
     auto new_nnz = c_row_ptrs[num_rows];
@@ -279,7 +279,7 @@ void advanced_spgemm(std::shared_ptr<const ReferenceExecutor> exec,
     }
 
     // build row pointers
-    prefix_sum(exec, c_row_ptrs, num_rows + 1);
+    components::prefix_sum(exec, c_row_ptrs, num_rows + 1);
 
     // second sweep: accumulate non-zeros
     auto new_nnz = c_row_ptrs[num_rows];

--- a/reference/test/components/CMakeLists.txt
+++ b/reference/test/components/CMakeLists.txt
@@ -1,1 +1,2 @@
+ginkgo_create_test(precision_conversion)
 ginkgo_create_test(prefix_sum)

--- a/reference/test/components/precision_conversion.cpp
+++ b/reference/test/components/precision_conversion.cpp
@@ -1,0 +1,127 @@
+/*******************************<GINKGO LICENSE>******************************
+Copyright (c) 2017-2020, the Ginkgo authors
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+******************************<GINKGO LICENSE>*******************************/
+
+#include "core/components/prefix_sum.hpp"
+
+
+#include <limits>
+#include <memory>
+#include <random>
+#include <vector>
+
+
+#include <gtest/gtest.h>
+
+
+#include <ginkgo/core/base/array.hpp>
+
+
+#include "core/test/utils.hpp"
+
+
+namespace {
+
+
+class PrecisionConversion : public ::testing::Test {
+protected:
+    PrecisionConversion()
+        : ref(gko::ReferenceExecutor::create()),
+          rand(293),
+          total_size(42793),
+          vals(ref, total_size),
+          cvals(ref, total_size)
+    {
+        auto maxval = std::numeric_limits<float>::max();
+        std::uniform_real_distribution<float> dist(-maxval, maxval);
+        for (gko::size_type i = 0; i < total_size; ++i) {
+            vals.get_data()[i] = dist(rand);
+            cvals.get_data()[i] = {dist(rand), dist(rand)};
+        }
+    }
+
+    std::shared_ptr<gko::ReferenceExecutor> ref;
+    std::default_random_engine rand;
+    gko::size_type total_size;
+    gko::Array<float> vals;
+    gko::Array<std::complex<float>> cvals;
+};
+
+
+TEST_F(PrecisionConversion, ConvertsReal)
+{
+    gko::Array<double> tmp;
+    gko::Array<float> out;
+
+    tmp = vals;
+    out = tmp;
+
+    GKO_ASSERT_ARRAY_EQ(&vals, &out);
+}
+
+
+TEST_F(PrecisionConversion, ConvertsRealWithSetExecutor)
+{
+    gko::Array<double> tmp{ref};
+    gko::Array<float> out{ref};
+
+    tmp = vals;
+    out = tmp;
+
+    GKO_ASSERT_ARRAY_EQ(&vals, &out);
+}
+
+
+TEST_F(PrecisionConversion, ConvertsRealFromView)
+{
+    gko::Array<double> tmp{ref};
+    gko::Array<float> out{ref};
+
+    tmp = gko::Array<float>::view(ref, vals.get_num_elems(), vals.get_data());
+    out = tmp;
+
+    GKO_ASSERT_ARRAY_EQ(&vals, &out);
+}
+
+
+TEST_F(PrecisionConversion, ConvertsComplex)
+{
+    gko::Array<std::complex<double>> tmp;
+    gko::Array<std::complex<float>> out;
+
+    tmp = cvals;
+    out = tmp;
+
+    GKO_ASSERT_ARRAY_EQ(&cvals, &out);
+}
+
+
+}  // namespace

--- a/reference/test/components/precision_conversion.cpp
+++ b/reference/test/components/precision_conversion.cpp
@@ -60,7 +60,7 @@ protected:
           vals(ref, total_size),
           cvals(ref, total_size)
     {
-        auto maxval = std::numeric_limits<float>::max();
+        auto maxval = 1e10f;
         std::uniform_real_distribution<float> dist(-maxval, maxval);
         for (gko::size_type i = 0; i < total_size; ++i) {
             vals.get_data()[i] = dist(rand);

--- a/reference/test/components/precision_conversion.cpp
+++ b/reference/test/components/precision_conversion.cpp
@@ -67,9 +67,9 @@ protected:
             vals.get_data()[i] = dist(rand);
             cvals.get_data()[i] = {dist(rand), dist(rand)};
         }
-        gko::uint64 rawdouble = 0x4218888000889111ULL;
-        gko::uint32 rawfloat = 0x50c44400ULL;
-        gko::uint64 rawrounded = 0x4218888000000000ULL;
+        gko::uint64 rawdouble{0x4218888000889111ULL};
+        gko::uint32 rawfloat{0x50c44400UL};
+        gko::uint64 rawrounded{0x4218888000000000ULL};
         std::memcpy(vals2.get_data(), &rawdouble, sizeof(double));
         std::memcpy(expected_float.get_data(), &rawfloat, sizeof(float));
         std::memcpy(expected_double.get_data(), &rawrounded, sizeof(double));

--- a/reference/test/components/prefix_sum.cpp
+++ b/reference/test/components/prefix_sum.cpp
@@ -67,8 +67,8 @@ TYPED_TEST_CASE(PrefixSum, gko::test::IndexTypes);
 
 TYPED_TEST(PrefixSum, Works)
 {
-    gko::kernels::reference::prefix_sum(this->exec, this->vals.data(),
-                                        this->vals.size());
+    gko::kernels::reference::components::prefix_sum(
+        this->exec, this->vals.data(), this->vals.size());
 
     ASSERT_EQ(this->vals, this->expected);
 }

--- a/reference/test/matrix/coo_kernels.cpp
+++ b/reference/test/matrix/coo_kernels.cpp
@@ -98,6 +98,48 @@ protected:
 TYPED_TEST_CASE(Coo, gko::test::ValueIndexTypes);
 
 
+TYPED_TEST(Coo, ConvertsToPrecision)
+{
+    using ValueType = typename TestFixture::value_type;
+    using IndexType = typename TestFixture::index_type;
+    using OtherType = typename gko::next_precision<ValueType>;
+    using Coo = typename TestFixture::Mtx;
+    using OtherCoo = gko::matrix::Coo<OtherType, IndexType>;
+    auto tmp = OtherCoo::create(this->exec);
+    auto res = Coo::create(this->exec);
+    // If OtherType is more precise: 0, otherwise r
+    auto residual = r<OtherType>::value < r<ValueType>::value
+                        ? gko::remove_complex<ValueType>{0}
+                        : gko::remove_complex<OtherType>{r<OtherType>::value};
+
+    this->mtx->convert_to(tmp.get());
+    tmp->convert_to(res.get());
+
+    GKO_ASSERT_MTX_NEAR(this->mtx, res, residual);
+}
+
+
+TYPED_TEST(Coo, MovesToPrecision)
+{
+    using ValueType = typename TestFixture::value_type;
+    using IndexType = typename TestFixture::index_type;
+    using OtherType = typename gko::next_precision<ValueType>;
+    using Coo = typename TestFixture::Mtx;
+    using OtherCoo = gko::matrix::Coo<OtherType, IndexType>;
+    auto tmp = OtherCoo::create(this->exec);
+    auto res = Coo::create(this->exec);
+    // If OtherType is more precise: 0, otherwise r
+    auto residual = r<OtherType>::value < r<ValueType>::value
+                        ? gko::remove_complex<ValueType>{0}
+                        : gko::remove_complex<OtherType>{r<OtherType>::value};
+
+    this->mtx->move_to(tmp.get());
+    tmp->move_to(res.get());
+
+    GKO_ASSERT_MTX_NEAR(this->mtx, res, residual);
+}
+
+
 TYPED_TEST(Coo, ConvertsToCsr)
 {
     using value_type = typename TestFixture::value_type;

--- a/reference/test/matrix/coo_kernels.cpp
+++ b/reference/test/matrix/coo_kernels.cpp
@@ -110,7 +110,7 @@ TYPED_TEST(Coo, ConvertsToPrecision)
     // If OtherType is more precise: 0, otherwise r
     auto residual = r<OtherType>::value < r<ValueType>::value
                         ? gko::remove_complex<ValueType>{0}
-                        : gko::remove_complex<OtherType>{r<OtherType>::value};
+                        : gko::remove_complex<ValueType>{r<OtherType>::value};
 
     this->mtx->convert_to(tmp.get());
     tmp->convert_to(res.get());
@@ -131,7 +131,7 @@ TYPED_TEST(Coo, MovesToPrecision)
     // If OtherType is more precise: 0, otherwise r
     auto residual = r<OtherType>::value < r<ValueType>::value
                         ? gko::remove_complex<ValueType>{0}
-                        : gko::remove_complex<OtherType>{r<OtherType>::value};
+                        : gko::remove_complex<ValueType>{r<OtherType>::value};
 
     this->mtx->move_to(tmp.get());
     tmp->move_to(res.get());

--- a/reference/test/matrix/csr_kernels.cpp
+++ b/reference/test/matrix/csr_kernels.cpp
@@ -613,7 +613,7 @@ TYPED_TEST(Csr, ConvertsToPrecision)
     // If OtherType is more precise: 0, otherwise r
     auto residual = r<OtherType>::value < r<ValueType>::value
                         ? gko::remove_complex<ValueType>{0}
-                        : gko::remove_complex<OtherType>{r<OtherType>::value};
+                        : gko::remove_complex<ValueType>{r<OtherType>::value};
 
     // use mtx2 as mtx's strategy would involve creating a CudaExecutor
     this->mtx2->convert_to(tmp.get());
@@ -637,7 +637,7 @@ TYPED_TEST(Csr, MovesToPrecision)
     // If OtherType is more precise: 0, otherwise r
     auto residual = r<OtherType>::value < r<ValueType>::value
                         ? gko::remove_complex<ValueType>{0}
-                        : gko::remove_complex<OtherType>{r<OtherType>::value};
+                        : gko::remove_complex<ValueType>{r<OtherType>::value};
 
     // use mtx2 as mtx's strategy would involve creating a CudaExecutor
     this->mtx2->move_to(tmp.get());

--- a/reference/test/matrix/csr_kernels.cpp
+++ b/reference/test/matrix/csr_kernels.cpp
@@ -601,6 +601,54 @@ TYPED_TEST(Csr, ApplyFailsOnWrongNumberOfCols)
 }
 
 
+TYPED_TEST(Csr, ConvertsToPrecision)
+{
+    using ValueType = typename TestFixture::value_type;
+    using IndexType = typename TestFixture::index_type;
+    using OtherType = typename gko::next_precision<ValueType>;
+    using Csr = typename TestFixture::Mtx;
+    using OtherCsr = gko::matrix::Csr<OtherType, IndexType>;
+    auto tmp = OtherCsr::create(this->exec);
+    auto res = Csr::create(this->exec);
+    // If OtherType is more precise: 0, otherwise r
+    auto residual = r<OtherType>::value < r<ValueType>::value
+                        ? gko::remove_complex<ValueType>{0}
+                        : gko::remove_complex<OtherType>{r<OtherType>::value};
+
+    // use mtx2 as mtx's strategy would involve creating a CudaExecutor
+    this->mtx2->convert_to(tmp.get());
+    tmp->convert_to(res.get());
+
+    GKO_ASSERT_MTX_NEAR(this->mtx2, res, residual);
+    ASSERT_EQ(typeid(*this->mtx2->get_strategy()),
+              typeid(*res->get_strategy()));
+}
+
+
+TYPED_TEST(Csr, MovesToPrecision)
+{
+    using ValueType = typename TestFixture::value_type;
+    using IndexType = typename TestFixture::index_type;
+    using OtherType = typename gko::next_precision<ValueType>;
+    using Csr = typename TestFixture::Mtx;
+    using OtherCsr = gko::matrix::Csr<OtherType, IndexType>;
+    auto tmp = OtherCsr::create(this->exec);
+    auto res = Csr::create(this->exec);
+    // If OtherType is more precise: 0, otherwise r
+    auto residual = r<OtherType>::value < r<ValueType>::value
+                        ? gko::remove_complex<ValueType>{0}
+                        : gko::remove_complex<OtherType>{r<OtherType>::value};
+
+    // use mtx2 as mtx's strategy would involve creating a CudaExecutor
+    this->mtx2->move_to(tmp.get());
+    tmp->move_to(res.get());
+
+    GKO_ASSERT_MTX_NEAR(this->mtx2, res, residual);
+    ASSERT_EQ(typeid(*this->mtx2->get_strategy()),
+              typeid(*res->get_strategy()));
+}
+
+
 TYPED_TEST(Csr, ConvertsToDense)
 {
     using Dense = typename TestFixture::Vec;

--- a/reference/test/matrix/dense_kernels.cpp
+++ b/reference/test/matrix/dense_kernels.cpp
@@ -308,6 +308,46 @@ TYPED_TEST(Dense, ComputDotFailsOnWrongResultSize)
 }
 
 
+TYPED_TEST(Dense, ConvertsToPrecision)
+{
+    using Dense = typename TestFixture::Mtx;
+    using T = typename TestFixture::value_type;
+    using OtherT = typename gko::next_precision<T>;
+    using OtherDense = typename gko::matrix::Dense<OtherT>;
+    auto tmp = OtherDense::create(this->exec);
+    auto res = Dense::create(this->exec);
+    // If OtherT is more precise: 0, otherwise r
+    auto residual = r<OtherT>::value < r<T>::value
+                        ? gko::remove_complex<T>{0}
+                        : gko::remove_complex<T>{r<OtherT>::value};
+
+    this->mtx1->convert_to(tmp.get());
+    tmp->convert_to(res.get());
+
+    GKO_ASSERT_MTX_NEAR(this->mtx1, res, residual);
+}
+
+
+TYPED_TEST(Dense, MovesToPrecision)
+{
+    using Dense = typename TestFixture::Mtx;
+    using T = typename TestFixture::value_type;
+    using OtherT = typename gko::next_precision<T>;
+    using OtherDense = typename gko::matrix::Dense<OtherT>;
+    auto tmp = OtherDense::create(this->exec);
+    auto res = Dense::create(this->exec);
+    // If OtherT is more precise: 0, otherwise r
+    auto residual = r<OtherT>::value < r<T>::value
+                        ? gko::remove_complex<T>{0}
+                        : gko::remove_complex<T>{r<OtherT>::value};
+
+    this->mtx1->move_to(tmp.get());
+    tmp->move_to(res.get());
+
+    GKO_ASSERT_MTX_NEAR(this->mtx1, res, residual);
+}
+
+
 TYPED_TEST(Dense, ConvertsToCoo32)
 {
     using T = typename TestFixture::value_type;

--- a/reference/test/matrix/ell_kernels.cpp
+++ b/reference/test/matrix/ell_kernels.cpp
@@ -211,6 +211,48 @@ TYPED_TEST(Ell, ApplyFailsOnWrongNumberOfCols)
 }
 
 
+TYPED_TEST(Ell, ConvertsToPrecision)
+{
+    using ValueType = typename TestFixture::value_type;
+    using IndexType = typename TestFixture::index_type;
+    using OtherType = typename gko::next_precision<ValueType>;
+    using Ell = typename TestFixture::Mtx;
+    using OtherEll = gko::matrix::Ell<OtherType, IndexType>;
+    auto tmp = OtherEll::create(this->exec);
+    auto res = Ell::create(this->exec);
+    // If OtherType is more precise: 0, otherwise r
+    auto residual = r<OtherType>::value < r<ValueType>::value
+                        ? gko::remove_complex<ValueType>{0}
+                        : gko::remove_complex<OtherType>{r<OtherType>::value};
+
+    this->mtx1->convert_to(tmp.get());
+    tmp->convert_to(res.get());
+
+    GKO_ASSERT_MTX_NEAR(this->mtx1, res, residual);
+}
+
+
+TYPED_TEST(Ell, MovesToPrecision)
+{
+    using ValueType = typename TestFixture::value_type;
+    using IndexType = typename TestFixture::index_type;
+    using OtherType = typename gko::next_precision<ValueType>;
+    using Ell = typename TestFixture::Mtx;
+    using OtherEll = gko::matrix::Ell<OtherType, IndexType>;
+    auto tmp = OtherEll::create(this->exec);
+    auto res = Ell::create(this->exec);
+    // If OtherType is more precise: 0, otherwise r
+    auto residual = r<OtherType>::value < r<ValueType>::value
+                        ? gko::remove_complex<ValueType>{0}
+                        : gko::remove_complex<OtherType>{r<OtherType>::value};
+
+    this->mtx1->move_to(tmp.get());
+    tmp->move_to(res.get());
+
+    GKO_ASSERT_MTX_NEAR(this->mtx1, res, residual);
+}
+
+
 TYPED_TEST(Ell, ConvertsToDense)
 {
     using Vec = typename TestFixture::Vec;

--- a/reference/test/matrix/ell_kernels.cpp
+++ b/reference/test/matrix/ell_kernels.cpp
@@ -223,7 +223,7 @@ TYPED_TEST(Ell, ConvertsToPrecision)
     // If OtherType is more precise: 0, otherwise r
     auto residual = r<OtherType>::value < r<ValueType>::value
                         ? gko::remove_complex<ValueType>{0}
-                        : gko::remove_complex<OtherType>{r<OtherType>::value};
+                        : gko::remove_complex<ValueType>{r<OtherType>::value};
 
     this->mtx1->convert_to(tmp.get());
     tmp->convert_to(res.get());
@@ -244,7 +244,7 @@ TYPED_TEST(Ell, MovesToPrecision)
     // If OtherType is more precise: 0, otherwise r
     auto residual = r<OtherType>::value < r<ValueType>::value
                         ? gko::remove_complex<ValueType>{0}
-                        : gko::remove_complex<OtherType>{r<OtherType>::value};
+                        : gko::remove_complex<ValueType>{r<OtherType>::value};
 
     this->mtx1->move_to(tmp.get());
     tmp->move_to(res.get());

--- a/reference/test/matrix/hybrid_kernels.cpp
+++ b/reference/test/matrix/hybrid_kernels.cpp
@@ -249,7 +249,7 @@ TYPED_TEST(Hybrid, ConvertsToPrecision)
     // If OtherType is more precise: 0, otherwise r
     auto residual = r<OtherType>::value < r<ValueType>::value
                         ? gko::remove_complex<ValueType>{0}
-                        : gko::remove_complex<OtherType>{r<OtherType>::value};
+                        : gko::remove_complex<ValueType>{r<OtherType>::value};
 
     this->mtx1->convert_to(tmp.get());
     tmp->convert_to(res.get());
@@ -270,7 +270,7 @@ TYPED_TEST(Hybrid, MovesToPrecision)
     // If OtherType is more precise: 0, otherwise r
     auto residual = r<OtherType>::value < r<ValueType>::value
                         ? gko::remove_complex<ValueType>{0}
-                        : gko::remove_complex<OtherType>{r<OtherType>::value};
+                        : gko::remove_complex<ValueType>{r<OtherType>::value};
 
     this->mtx1->move_to(tmp.get());
     tmp->move_to(res.get());

--- a/reference/test/matrix/hybrid_kernels.cpp
+++ b/reference/test/matrix/hybrid_kernels.cpp
@@ -237,6 +237,48 @@ TYPED_TEST(Hybrid, ApplyFailsOnWrongNumberOfCols)
 }
 
 
+TYPED_TEST(Hybrid, ConvertsToPrecision)
+{
+    using ValueType = typename TestFixture::value_type;
+    using IndexType = typename TestFixture::index_type;
+    using OtherType = typename gko::next_precision<ValueType>;
+    using Hybrid = typename TestFixture::Mtx;
+    using OtherHybrid = gko::matrix::Hybrid<OtherType, IndexType>;
+    auto tmp = OtherHybrid::create(this->exec);
+    auto res = Hybrid::create(this->exec);
+    // If OtherType is more precise: 0, otherwise r
+    auto residual = r<OtherType>::value < r<ValueType>::value
+                        ? gko::remove_complex<ValueType>{0}
+                        : gko::remove_complex<OtherType>{r<OtherType>::value};
+
+    this->mtx1->convert_to(tmp.get());
+    tmp->convert_to(res.get());
+
+    GKO_ASSERT_MTX_NEAR(this->mtx1, res, residual);
+}
+
+
+TYPED_TEST(Hybrid, MovesToPrecision)
+{
+    using ValueType = typename TestFixture::value_type;
+    using IndexType = typename TestFixture::index_type;
+    using OtherType = typename gko::next_precision<ValueType>;
+    using Hybrid = typename TestFixture::Mtx;
+    using OtherHybrid = gko::matrix::Hybrid<OtherType, IndexType>;
+    auto tmp = OtherHybrid::create(this->exec);
+    auto res = Hybrid::create(this->exec);
+    // If OtherType is more precise: 0, otherwise r
+    auto residual = r<OtherType>::value < r<ValueType>::value
+                        ? gko::remove_complex<ValueType>{0}
+                        : gko::remove_complex<OtherType>{r<OtherType>::value};
+
+    this->mtx1->move_to(tmp.get());
+    tmp->move_to(res.get());
+
+    GKO_ASSERT_MTX_NEAR(this->mtx1, res, residual);
+}
+
+
 TYPED_TEST(Hybrid, ConvertsToDense)
 {
     using Vec = typename TestFixture::Vec;

--- a/reference/test/matrix/sellp_kernels.cpp
+++ b/reference/test/matrix/sellp_kernels.cpp
@@ -199,7 +199,7 @@ TYPED_TEST(Sellp, ConvertsToPrecision)
     // If OtherType is more precise: 0, otherwise r
     auto residual = r<OtherType>::value < r<ValueType>::value
                         ? gko::remove_complex<ValueType>{0}
-                        : gko::remove_complex<OtherType>{r<OtherType>::value};
+                        : gko::remove_complex<ValueType>{r<OtherType>::value};
 
     this->mtx1->convert_to(tmp.get());
     tmp->convert_to(res.get());
@@ -220,7 +220,7 @@ TYPED_TEST(Sellp, MovesToPrecision)
     // If OtherType is more precise: 0, otherwise r
     auto residual = r<OtherType>::value < r<ValueType>::value
                         ? gko::remove_complex<ValueType>{0}
-                        : gko::remove_complex<OtherType>{r<OtherType>::value};
+                        : gko::remove_complex<ValueType>{r<OtherType>::value};
 
     this->mtx1->move_to(tmp.get());
     tmp->move_to(res.get());

--- a/reference/test/matrix/sellp_kernels.cpp
+++ b/reference/test/matrix/sellp_kernels.cpp
@@ -187,6 +187,48 @@ TYPED_TEST(Sellp, ApplyFailsOnWrongNumberOfCols)
 }
 
 
+TYPED_TEST(Sellp, ConvertsToPrecision)
+{
+    using ValueType = typename TestFixture::value_type;
+    using IndexType = typename TestFixture::index_type;
+    using OtherType = typename gko::next_precision<ValueType>;
+    using Sellp = typename TestFixture::Mtx;
+    using OtherSellp = gko::matrix::Sellp<OtherType, IndexType>;
+    auto tmp = OtherSellp::create(this->exec);
+    auto res = Sellp::create(this->exec);
+    // If OtherType is more precise: 0, otherwise r
+    auto residual = r<OtherType>::value < r<ValueType>::value
+                        ? gko::remove_complex<ValueType>{0}
+                        : gko::remove_complex<OtherType>{r<OtherType>::value};
+
+    this->mtx1->convert_to(tmp.get());
+    tmp->convert_to(res.get());
+
+    GKO_ASSERT_MTX_NEAR(this->mtx1, res, residual);
+}
+
+
+TYPED_TEST(Sellp, MovesToPrecision)
+{
+    using ValueType = typename TestFixture::value_type;
+    using IndexType = typename TestFixture::index_type;
+    using OtherType = typename gko::next_precision<ValueType>;
+    using Sellp = typename TestFixture::Mtx;
+    using OtherSellp = gko::matrix::Sellp<OtherType, IndexType>;
+    auto tmp = OtherSellp::create(this->exec);
+    auto res = Sellp::create(this->exec);
+    // If OtherType is more precise: 0, otherwise r
+    auto residual = r<OtherType>::value < r<ValueType>::value
+                        ? gko::remove_complex<ValueType>{0}
+                        : gko::remove_complex<OtherType>{r<OtherType>::value};
+
+    this->mtx1->move_to(tmp.get());
+    tmp->move_to(res.get());
+
+    GKO_ASSERT_MTX_NEAR(this->mtx1, res, residual);
+}
+
+
 TYPED_TEST(Sellp, ConvertsToDense)
 {
     using Vec = typename TestFixture::Vec;


### PR DESCRIPTION
This PR adds precision conversion support to the Ginkgo matrix formats

TODO:
- [x] Implement array conversions
- [x] Implement matrix conversions