### PR TITLE
Add a SONAME to shared libraries

### DIFF
--- a/cmake/build_helpers.cmake
+++ b/cmake/build_helpers.cmake
@@ -17,6 +17,9 @@ function(ginkgo_compile_features name)
     if(GINKGO_WITH_IWYU AND GINKGO_IWYU_PATH)
         set_property(TARGET "${name}" PROPERTY CXX_INCLUDE_WHAT_YOU_USE ${GINKGO_IWYU_PATH})
     endif()
+    # Set an appropriate SONAME
+    set_property(TARGET "${name}" PROPERTY
+        SOVERSION "${Ginkgo_VERSION}")
     if(GINKGO_CHANGED_SHARED_LIBRARY)
         # Put all shared libraries and corresponding imported libraries into the specified path
         set_property(TARGET "${name}" PROPERTY

--- a/contributors.txt
+++ b/contributors.txt
@@ -13,6 +13,7 @@ Grützmacher Thomas <thogru.kit@gmx.de> Karlsruhe Institute of Technology
 Heroux Mike <maherou@sandia.gov> Sandia National Laboratories
 Hoemmen Mark <mhoemme@sandia.gov> Sandia National Laboratories
 Holeksa Claudius <mail@keldu.de> Karlsruhe Institute of Technology
+Maier Matthias <matthias@43-1.org> Texas A&M University
 Nayak Pratik <pratik.nayak@kit.edu> Karlsruhe Institute of Technology
 Ribizel Tobias <mail@upsj.de> Karlsruhe Institute of Technology
 Tsai Yuhsiang <yhmtsai@gmail.com> National Taiwan University


### PR DESCRIPTION
Ginkgo is written in C++ and does not guarantee any stable ABI.
Consequently, all shared libraries should be annotated by an appropriate
SONAME (this patch simply uses the release version). This ensures
conformity with best practices and library requirements for popular
Linux distributions (e.g., Debian/Ubuntu). It also prevents silent
breakage (at dynamic link time / run time) when the library ABI changed
and user code should have been recompiled.