### PR TITLE
Add virtual method apply_uses_initial_guess to LinOp

### DIFF
--- a/core/solver/ir.cpp
+++ b/core/solver/ir.cpp
@@ -96,7 +96,7 @@ void Ir<ValueType>::apply_impl(const LinOp *b, LinOp *x) const
             // Use the inner solver to solve
             // A * inner_solution = residual
             // with residual as initial guess.
-            inner_solution->copy_from(residual.get());
+            inner_solution->copy_from(lend(residual));
             solver_->apply(lend(residual), lend(inner_solution));
 
             // x = x + inner_solution

--- a/core/solver/ir.cpp
+++ b/core/solver/ir.cpp
@@ -92,19 +92,29 @@ void Ir<ValueType>::apply_impl(const LinOp *b, LinOp *x) const
             break;
         }
 
-        // Use the inner solver to solve
-        // A * inner_solution = residual
-        // with residual as initial guess.
-        inner_solution->copy_from(residual.get());
-        solver_->apply(lend(residual), lend(inner_solution));
+        if (solver_->apply_uses_initial_guess()) {
+            // Use the inner solver to solve
+            // A * inner_solution = residual
+            // with residual as initial guess.
+            inner_solution->copy_from(residual.get());
+            solver_->apply(lend(residual), lend(inner_solution));
 
-        // x = x + inner_solution
-        dense_x->add_scaled(lend(one_op), lend(inner_solution));
+            // x = x + inner_solution
+            dense_x->add_scaled(lend(one_op), lend(inner_solution));
 
-        // residual = b - A * x
-        residual->copy_from(dense_b);
-        system_matrix_->apply(lend(neg_one_op), dense_x, lend(one_op),
-                              lend(residual));
+            // residual = b - A * x
+            residual->copy_from(dense_b);
+            system_matrix_->apply(lend(neg_one_op), dense_x, lend(one_op),
+                                  lend(residual));
+        } else {
+            // x = x + A \ residual
+            solver_->apply(lend(one_op), lend(residual), lend(one_op), dense_x);
+
+            // residual = b - A * x
+            residual->copy_from(dense_b);
+            system_matrix_->apply(lend(neg_one_op), dense_x, lend(one_op),
+                                  lend(residual));
+        }
     }
 }
 

--- a/core/test/base/lin_op.cpp
+++ b/core/test/base/lin_op.cpp
@@ -236,6 +236,12 @@ TEST_F(EnableLinOp, ExtendedApplyCopiesBackOnlyX)
 }
 
 
+TEST_F(EnableLinOp, ApplyUsesInitialGuessReturnsFalse)
+{
+    ASSERT_FALSE(op->apply_uses_initial_guess());
+}
+
+
 template <typename T = int>
 class DummyLinOpWithFactory
     : public gko::EnableLinOp<DummyLinOpWithFactory<T>> {

--- a/core/test/solver/bicg.cpp
+++ b/core/test/solver/bicg.cpp
@@ -146,6 +146,12 @@ TEST_F(Bicg, CanBeCleared)
 }
 
 
+TEST_F(Bicg, ApplyUsesInitialGuessReturnsTrue)
+{
+    ASSERT_TRUE(solver->apply_uses_initial_guess());
+}
+
+
 TEST_F(Bicg, CanSetPreconditionerGenerator)
 {
     auto bicg_factory =

--- a/core/test/solver/bicgstab.cpp
+++ b/core/test/solver/bicgstab.cpp
@@ -163,6 +163,12 @@ TYPED_TEST(Bicgstab, CanBeCleared)
 }
 
 
+TYPED_TEST(Bicgstab, ApplyUsesInitialGuessReturnsTrue)
+{
+    ASSERT_TRUE(this->solver->apply_uses_initial_guess());
+}
+
+
 TYPED_TEST(Bicgstab, CanSetPreconditionerGenerator)
 {
     using Solver = typename TestFixture::Solver;

--- a/core/test/solver/cg.cpp
+++ b/core/test/solver/cg.cpp
@@ -166,6 +166,12 @@ TYPED_TEST(Cg, CanBeCleared)
 }
 
 
+TYPED_TEST(Cg, ApplyUsesInitialGuessReturnsTrue)
+{
+    ASSERT_TRUE(this->solver->apply_uses_initial_guess());
+}
+
+
 TYPED_TEST(Cg, CanSetPreconditionerGenerator)
 {
     using Solver = typename TestFixture::Solver;

--- a/core/test/solver/cgs.cpp
+++ b/core/test/solver/cgs.cpp
@@ -165,6 +165,12 @@ TYPED_TEST(Cgs, CanBeCleared)
 }
 
 
+TYPED_TEST(Cgs, ApplyUsesInitialGuessReturnsTrue)
+{
+    ASSERT_TRUE(this->solver->apply_uses_initial_guess());
+}
+
+
 TYPED_TEST(Cgs, CanSetPreconditionerGenerator)
 {
     using Mtx = typename TestFixture::Mtx;

--- a/core/test/solver/fcg.cpp
+++ b/core/test/solver/fcg.cpp
@@ -151,6 +151,12 @@ TYPED_TEST(Fcg, CanBeCleared)
 }
 
 
+TYPED_TEST(Fcg, ApplyUsesInitialGuessReturnsTrue)
+{
+    ASSERT_TRUE(this->solver->apply_uses_initial_guess());
+}
+
+
 TYPED_TEST(Fcg, CanSetPreconditionerGenerator)
 {
     using Solver = typename TestFixture::Solver;

--- a/core/test/solver/gmres.cpp
+++ b/core/test/solver/gmres.cpp
@@ -184,6 +184,12 @@ TYPED_TEST(Gmres, CanBeCleared)
 }
 
 
+TYPED_TEST(Gmres, ApplyUsesInitialGuessReturnsTrue)
+{
+    ASSERT_TRUE(this->solver->apply_uses_initial_guess());
+}
+
+
 TYPED_TEST(Gmres, CanSetPreconditionerGenerator)
 {
     using Solver = typename TestFixture::Solver;

--- a/core/test/solver/ir.cpp
+++ b/core/test/solver/ir.cpp
@@ -165,6 +165,12 @@ TYPED_TEST(Ir, CanBeCleared)
 }
 
 
+TYPED_TEST(Ir, ApplyUsesInitialGuessReturnsTrue)
+{
+    ASSERT_TRUE(this->solver->apply_uses_initial_guess());
+}
+
+
 TYPED_TEST(Ir, CanSetInnerSolverInFactory)
 {
     using Solver = typename TestFixture::Solver;

--- a/cuda/test/solver/ir_kernels.cpp
+++ b/cuda/test/solver/ir_kernels.cpp
@@ -175,7 +175,7 @@ TEST_F(Ir, ApplyWithIterativeInnerSolverIsEquivalentToRef)
 
     // Note: 1e-13 instead of 1e-14, as the difference in the inner gmres
     // iteration gets amplified by the difference in IR.
-    GKO_ASSERT_MTX_NEAR(d_x, x, 1e-13);
+    GKO_ASSERT_MTX_NEAR(d_x, x, 1e-12);
 }
 
 

--- a/cuda/test/solver/ir_kernels.cpp
+++ b/cuda/test/solver/ir_kernels.cpp
@@ -42,6 +42,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <ginkgo/core/base/exception.hpp>
 #include <ginkgo/core/base/executor.hpp>
 #include <ginkgo/core/matrix/dense.hpp>
+#include <ginkgo/core/solver/gmres.hpp>
 #include <ginkgo/core/stop/combined.hpp>
 #include <ginkgo/core/stop/iteration.hpp>
 
@@ -132,6 +133,49 @@ TEST_F(Ir, ApplyIsEquivalentToRef)
     d_solver->apply(lend(d_b), lend(d_x));
 
     GKO_ASSERT_MTX_NEAR(d_x, x, 1e-14);
+}
+
+
+TEST_F(Ir, ApplyWithIterativeInnerSolverIsEquivalentToRef)
+{
+    auto mtx = gen_mtx(50, 50);
+    auto x = gen_mtx(50, 3);
+    auto b = gen_mtx(50, 3);
+    auto d_mtx = clone(cuda, mtx);
+    auto d_x = clone(cuda, x);
+    auto d_b = clone(cuda, b);
+
+    auto ir_factory =
+        gko::solver::Ir<>::build()
+            .with_solver(
+                gko::solver::Gmres<>::build()
+                    .with_criteria(
+                        gko::stop::Iteration::build().with_max_iters(1u).on(
+                            ref))
+                    .on(ref))
+            .with_criteria(
+                gko::stop::Iteration::build().with_max_iters(2u).on(ref))
+            .on(ref);
+    auto d_ir_factory =
+        gko::solver::Ir<>::build()
+            .with_solver(
+                gko::solver::Gmres<>::build()
+                    .with_criteria(
+                        gko::stop::Iteration::build().with_max_iters(1u).on(
+                            cuda))
+                    .on(cuda))
+            .with_criteria(
+                gko::stop::Iteration::build().with_max_iters(2u).on(cuda))
+            .on(cuda);
+    auto solver = ir_factory->generate(std::move(mtx));
+    auto d_solver = d_ir_factory->generate(std::move(d_mtx));
+
+    solver->apply(lend(b), lend(x));
+    d_solver->apply(lend(d_b), lend(d_x));
+
+    // Note: 1e-13 instead of 1e-14, as the difference in the inner gmres
+    // iteration gets amplified by the difference in IR.
+    GKO_ASSERT_MTX_NEAR(d_x, x, 1e-13);
 }
 
 

--- a/cuda/test/solver/ir_kernels.cpp
+++ b/cuda/test/solver/ir_kernels.cpp
@@ -173,7 +173,7 @@ TEST_F(Ir, ApplyWithIterativeInnerSolverIsEquivalentToRef)
     solver->apply(lend(b), lend(x));
     d_solver->apply(lend(d_b), lend(d_x));
 
-    // Note: 1e-13 instead of 1e-14, as the difference in the inner gmres
+    // Note: 1e-12 instead of 1e-14, as the difference in the inner gmres
     // iteration gets amplified by the difference in IR.
     GKO_ASSERT_MTX_NEAR(d_x, x, 1e-12);
 }

--- a/hip/test/solver/ir_kernels.cpp
+++ b/hip/test/solver/ir_kernels.cpp
@@ -42,6 +42,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <ginkgo/core/base/exception.hpp>
 #include <ginkgo/core/base/executor.hpp>
 #include <ginkgo/core/matrix/dense.hpp>
+#include <ginkgo/core/solver/gmres.hpp>
 #include <ginkgo/core/stop/combined.hpp>
 #include <ginkgo/core/stop/iteration.hpp>
 
@@ -132,6 +133,49 @@ TEST_F(Ir, ApplyIsEquivalentToRef)
     d_solver->apply(lend(d_b), lend(d_x));
 
     GKO_ASSERT_MTX_NEAR(d_x, x, 1e-14);
+}
+
+
+TEST_F(Ir, ApplyWithIterativeInnerSolverIsEquivalentToRef)
+{
+    auto mtx = gen_mtx(50, 50);
+    auto x = gen_mtx(50, 3);
+    auto b = gen_mtx(50, 3);
+    auto d_mtx = clone(hip, mtx);
+    auto d_x = clone(hip, x);
+    auto d_b = clone(hip, b);
+
+    auto ir_factory =
+        gko::solver::Ir<>::build()
+            .with_solver(
+                gko::solver::Gmres<>::build()
+                    .with_criteria(
+                        gko::stop::Iteration::build().with_max_iters(1u).on(
+                            ref))
+                    .on(ref))
+            .with_criteria(
+                gko::stop::Iteration::build().with_max_iters(2u).on(ref))
+            .on(ref);
+    auto d_ir_factory =
+        gko::solver::Ir<>::build()
+            .with_solver(
+                gko::solver::Gmres<>::build()
+                    .with_criteria(
+                        gko::stop::Iteration::build().with_max_iters(1u).on(
+                            hip))
+                    .on(hip))
+            .with_criteria(
+                gko::stop::Iteration::build().with_max_iters(2u).on(hip))
+            .on(hip);
+    auto solver = ir_factory->generate(std::move(mtx));
+    auto d_solver = d_ir_factory->generate(std::move(d_mtx));
+
+    solver->apply(lend(b), lend(x));
+    d_solver->apply(lend(d_b), lend(d_x));
+
+    // Note: 1e-13 instead of 1e-14, as the difference in the inner gmres
+    // iteration gets amplified by the difference in IR.
+    GKO_ASSERT_MTX_NEAR(d_x, x, 1e-13);
 }
 
 

--- a/hip/test/solver/ir_kernels.cpp
+++ b/hip/test/solver/ir_kernels.cpp
@@ -175,7 +175,7 @@ TEST_F(Ir, ApplyWithIterativeInnerSolverIsEquivalentToRef)
 
     // Note: 1e-13 instead of 1e-14, as the difference in the inner gmres
     // iteration gets amplified by the difference in IR.
-    GKO_ASSERT_MTX_NEAR(d_x, x, 1e-13);
+    GKO_ASSERT_MTX_NEAR(d_x, x, 1e-12);
 }
 
 

--- a/hip/test/solver/ir_kernels.cpp
+++ b/hip/test/solver/ir_kernels.cpp
@@ -173,7 +173,7 @@ TEST_F(Ir, ApplyWithIterativeInnerSolverIsEquivalentToRef)
     solver->apply(lend(b), lend(x));
     d_solver->apply(lend(d_b), lend(d_x));
 
-    // Note: 1e-13 instead of 1e-14, as the difference in the inner gmres
+    // Note: 1e-12 instead of 1e-14, as the difference in the inner gmres
     // iteration gets amplified by the difference in IR.
     GKO_ASSERT_MTX_NEAR(d_x, x, 1e-12);
 }

--- a/include/ginkgo/core/base/lin_op.hpp
+++ b/include/ginkgo/core/base/lin_op.hpp
@@ -224,6 +224,9 @@ public:
     /**
      * Returns true if the linear operator uses the data given in x as
      * an initial guess. Returns false otherwise.
+     *
+     * @return true if the linear operator uses the data given in x as
+     *         an initial guess. Returns false otherwise.
      */
     virtual bool apply_uses_initial_guess() const { return false; }
 

--- a/include/ginkgo/core/base/lin_op.hpp
+++ b/include/ginkgo/core/base/lin_op.hpp
@@ -221,6 +221,12 @@ public:
      */
     const dim<2> &get_size() const noexcept { return size_; }
 
+    /**
+     * Returns true if the linear operator uses the data given in x as
+     * an initial guess. Returns false otherwise.
+     */
+    virtual bool apply_uses_initial_guess() const { return false; }
+
 protected:
     /**
      * Creates a linear operator.

--- a/include/ginkgo/core/solver/bicg.hpp
+++ b/include/ginkgo/core/solver/bicg.hpp
@@ -88,7 +88,7 @@ public:
     /**
      * Return true as iterative solvers use the data in x as an initial guess.
      */
-    virtual bool apply_uses_initial_guess() const { return true; }
+    bool apply_uses_initial_guess() const override { return true; }
 
     GKO_CREATE_FACTORY_PARAMETERS(parameters, Factory)
     {

--- a/include/ginkgo/core/solver/bicg.hpp
+++ b/include/ginkgo/core/solver/bicg.hpp
@@ -87,6 +87,8 @@ public:
 
     /**
      * Return true as iterative solvers use the data in x as an initial guess.
+     *
+     * @return true as iterative solvers use the data in x as an initial guess.
      */
     bool apply_uses_initial_guess() const override { return true; }
 

--- a/include/ginkgo/core/solver/bicg.hpp
+++ b/include/ginkgo/core/solver/bicg.hpp
@@ -85,6 +85,11 @@ public:
         return system_matrix_;
     }
 
+    /**
+     * Return true as iterative solvers use the data in x as an initial guess.
+     */
+    virtual bool apply_uses_initial_guess() const { return true; }
+
     GKO_CREATE_FACTORY_PARAMETERS(parameters, Factory)
     {
         /**

--- a/include/ginkgo/core/solver/bicgstab.hpp
+++ b/include/ginkgo/core/solver/bicgstab.hpp
@@ -93,6 +93,8 @@ public:
 
     /**
      * Return true as iterative solvers use the data in x as an initial guess.
+     *
+     * @return true as iterative solvers use the data in x as an initial guess.
      */
     bool apply_uses_initial_guess() const override { return true; }
 

--- a/include/ginkgo/core/solver/bicgstab.hpp
+++ b/include/ginkgo/core/solver/bicgstab.hpp
@@ -91,6 +91,11 @@ public:
         return system_matrix_;
     }
 
+    /**
+     * Return true as iterative solvers use the data in x as an initial guess.
+     */
+    bool apply_uses_initial_guess() const { return true; }
+
     GKO_CREATE_FACTORY_PARAMETERS(parameters, Factory)
     {
         /**

--- a/include/ginkgo/core/solver/bicgstab.hpp
+++ b/include/ginkgo/core/solver/bicgstab.hpp
@@ -94,7 +94,7 @@ public:
     /**
      * Return true as iterative solvers use the data in x as an initial guess.
      */
-    bool apply_uses_initial_guess() const { return true; }
+    bool apply_uses_initial_guess() const override { return true; }
 
     GKO_CREATE_FACTORY_PARAMETERS(parameters, Factory)
     {

--- a/include/ginkgo/core/solver/cg.hpp
+++ b/include/ginkgo/core/solver/cg.hpp
@@ -88,6 +88,8 @@ public:
 
     /**
      * Return true as iterative solvers use the data in x as an initial guess.
+     *
+     * @return true as iterative solvers use the data in x as an initial guess.
      */
     bool apply_uses_initial_guess() const override { return true; }
 

--- a/include/ginkgo/core/solver/cg.hpp
+++ b/include/ginkgo/core/solver/cg.hpp
@@ -86,6 +86,11 @@ public:
         return system_matrix_;
     }
 
+    /**
+     * Return true as iterative solvers use the data in x as an initial guess.
+     */
+    virtual bool apply_uses_initial_guess() const { return true; }
+
     GKO_CREATE_FACTORY_PARAMETERS(parameters, Factory)
     {
         /**

--- a/include/ginkgo/core/solver/cg.hpp
+++ b/include/ginkgo/core/solver/cg.hpp
@@ -89,7 +89,7 @@ public:
     /**
      * Return true as iterative solvers use the data in x as an initial guess.
      */
-    virtual bool apply_uses_initial_guess() const { return true; }
+    bool apply_uses_initial_guess() const override { return true; }
 
     GKO_CREATE_FACTORY_PARAMETERS(parameters, Factory)
     {

--- a/include/ginkgo/core/solver/cgs.hpp
+++ b/include/ginkgo/core/solver/cgs.hpp
@@ -85,6 +85,8 @@ public:
 
     /**
      * Return true as iterative solvers use the data in x as an initial guess.
+     *
+     * @return true as iterative solvers use the data in x as an initial guess.
      */
     bool apply_uses_initial_guess() const override { return true; }
 

--- a/include/ginkgo/core/solver/cgs.hpp
+++ b/include/ginkgo/core/solver/cgs.hpp
@@ -86,7 +86,7 @@ public:
     /**
      * Return true as iterative solvers use the data in x as an initial guess.
      */
-    virtual bool apply_uses_initial_guess() const { return true; }
+    bool apply_uses_initial_guess() const override { return true; }
 
     GKO_CREATE_FACTORY_PARAMETERS(parameters, Factory)
     {

--- a/include/ginkgo/core/solver/cgs.hpp
+++ b/include/ginkgo/core/solver/cgs.hpp
@@ -83,6 +83,11 @@ public:
         return system_matrix_;
     }
 
+    /**
+     * Return true as iterative solvers use the data in x as an initial guess.
+     */
+    virtual bool apply_uses_initial_guess() const { return true; }
+
     GKO_CREATE_FACTORY_PARAMETERS(parameters, Factory)
     {
         /**

--- a/include/ginkgo/core/solver/fcg.hpp
+++ b/include/ginkgo/core/solver/fcg.hpp
@@ -93,6 +93,8 @@ public:
 
     /**
      * Return true as iterative solvers use the data in x as an initial guess.
+     *
+     * @return true as iterative solvers use the data in x as an initial guess.
      */
     bool apply_uses_initial_guess() const override { return true; }
 

--- a/include/ginkgo/core/solver/fcg.hpp
+++ b/include/ginkgo/core/solver/fcg.hpp
@@ -94,7 +94,7 @@ public:
     /**
      * Return true as iterative solvers use the data in x as an initial guess.
      */
-    virtual bool apply_uses_initial_guess() const { return true; }
+    bool apply_uses_initial_guess() const override { return true; }
 
     GKO_CREATE_FACTORY_PARAMETERS(parameters, Factory)
     {

--- a/include/ginkgo/core/solver/fcg.hpp
+++ b/include/ginkgo/core/solver/fcg.hpp
@@ -91,6 +91,11 @@ public:
         return system_matrix_;
     }
 
+    /**
+     * Return true as iterative solvers use the data in x as an initial guess.
+     */
+    virtual bool apply_uses_initial_guess() const { return true; }
+
     GKO_CREATE_FACTORY_PARAMETERS(parameters, Factory)
     {
         /**

--- a/include/ginkgo/core/solver/gmres.hpp
+++ b/include/ginkgo/core/solver/gmres.hpp
@@ -88,6 +88,8 @@ public:
 
     /**
      * Return true as iterative solvers use the data in x as an initial guess.
+     *
+     * @return true as iterative solvers use the data in x as an initial guess.
      */
     bool apply_uses_initial_guess() const override { return true; }
 

--- a/include/ginkgo/core/solver/gmres.hpp
+++ b/include/ginkgo/core/solver/gmres.hpp
@@ -89,7 +89,7 @@ public:
     /**
      * Return true as iterative solvers use the data in x as an initial guess.
      */
-    virtual bool apply_uses_initial_guess() const { return true; }
+    bool apply_uses_initial_guess() const override { return true; }
 
     /**
      * Returns the krylov dimension.

--- a/include/ginkgo/core/solver/gmres.hpp
+++ b/include/ginkgo/core/solver/gmres.hpp
@@ -87,6 +87,11 @@ public:
     }
 
     /**
+     * Return true as iterative solvers use the data in x as an initial guess.
+     */
+    virtual bool apply_uses_initial_guess() const { return true; }
+
+    /**
      * Returns the krylov dimension.
      *
      * @return the krylov dimension

--- a/include/ginkgo/core/solver/ir.hpp
+++ b/include/ginkgo/core/solver/ir.hpp
@@ -114,7 +114,7 @@ public:
     /**
      * Return true as iterative solvers use the data in x as an initial guess.
      */
-    virtual bool apply_uses_initial_guess() const { return true; }
+    bool apply_uses_initial_guess() const override { return true; }
 
     /**
      * Returns the solver operator used as the inner solver.

--- a/include/ginkgo/core/solver/ir.hpp
+++ b/include/ginkgo/core/solver/ir.hpp
@@ -111,6 +111,10 @@ public:
         return system_matrix_;
     }
 
+    /**
+     * Return true as iterative solvers use the data in x as an initial guess.
+     */
+    virtual bool apply_uses_initial_guess() const { return true; }
 
     /**
      * Returns the solver operator used as the inner solver.

--- a/include/ginkgo/core/solver/ir.hpp
+++ b/include/ginkgo/core/solver/ir.hpp
@@ -113,6 +113,8 @@ public:
 
     /**
      * Return true as iterative solvers use the data in x as an initial guess.
+     *
+     * @return true as iterative solvers use the data in x as an initial guess.
      */
     bool apply_uses_initial_guess() const override { return true; }
 

--- a/omp/test/solver/ir_kernels.cpp
+++ b/omp/test/solver/ir_kernels.cpp
@@ -168,7 +168,7 @@ TEST_F(Ir, ApplyWithIterativeInnerSolverIsEquivalentToRef)
 
     // Note: 1e-13 instead of 1e-14, as the difference in the inner gmres
     // iteration gets amplified by the difference in IR.
-    GKO_ASSERT_MTX_NEAR(d_x, x, 1e-13);
+    GKO_ASSERT_MTX_NEAR(d_x, x, 1e-12);
 }
 
 

--- a/omp/test/solver/ir_kernels.cpp
+++ b/omp/test/solver/ir_kernels.cpp
@@ -42,6 +42,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <ginkgo/core/base/exception.hpp>
 #include <ginkgo/core/base/executor.hpp>
 #include <ginkgo/core/matrix/dense.hpp>
+#include <ginkgo/core/solver/gmres.hpp>
 #include <ginkgo/core/stop/combined.hpp>
 #include <ginkgo/core/stop/iteration.hpp>
 
@@ -125,6 +126,49 @@ TEST_F(Ir, ApplyIsEquivalentToRef)
     d_solver->apply(lend(d_b), lend(d_x));
 
     GKO_ASSERT_MTX_NEAR(d_x, x, 1e-14);
+}
+
+
+TEST_F(Ir, ApplyWithIterativeInnerSolverIsEquivalentToRef)
+{
+    auto mtx = gen_mtx(50, 50);
+    auto x = gen_mtx(50, 3);
+    auto b = gen_mtx(50, 3);
+    auto d_mtx = clone(omp, mtx);
+    auto d_x = clone(omp, x);
+    auto d_b = clone(omp, b);
+
+    auto ir_factory =
+        gko::solver::Ir<>::build()
+            .with_solver(
+                gko::solver::Gmres<>::build()
+                    .with_criteria(
+                        gko::stop::Iteration::build().with_max_iters(1u).on(
+                            ref))
+                    .on(ref))
+            .with_criteria(
+                gko::stop::Iteration::build().with_max_iters(2u).on(ref))
+            .on(ref);
+    auto d_ir_factory =
+        gko::solver::Ir<>::build()
+            .with_solver(
+                gko::solver::Gmres<>::build()
+                    .with_criteria(
+                        gko::stop::Iteration::build().with_max_iters(1u).on(
+                            omp))
+                    .on(omp))
+            .with_criteria(
+                gko::stop::Iteration::build().with_max_iters(2u).on(omp))
+            .on(omp);
+    auto solver = ir_factory->generate(std::move(mtx));
+    auto d_solver = d_ir_factory->generate(std::move(d_mtx));
+
+    solver->apply(lend(b), lend(x));
+    d_solver->apply(lend(d_b), lend(d_x));
+
+    // Note: 1e-13 instead of 1e-14, as the difference in the inner gmres
+    // iteration gets amplified by the difference in IR.
+    GKO_ASSERT_MTX_NEAR(d_x, x, 1e-13);
 }
 
 

--- a/omp/test/solver/ir_kernels.cpp
+++ b/omp/test/solver/ir_kernels.cpp
@@ -166,7 +166,7 @@ TEST_F(Ir, ApplyWithIterativeInnerSolverIsEquivalentToRef)
     solver->apply(lend(b), lend(x));
     d_solver->apply(lend(d_b), lend(d_x));
 
-    // Note: 1e-13 instead of 1e-14, as the difference in the inner gmres
+    // Note: 1e-12 instead of 1e-14, as the difference in the inner gmres
     // iteration gets amplified by the difference in IR.
     GKO_ASSERT_MTX_NEAR(d_x, x, 1e-12);
 }

--- a/reference/test/solver/ir_kernels.cpp
+++ b/reference/test/solver/ir_kernels.cpp
@@ -101,10 +101,11 @@ TYPED_TEST(Ir, SolvesTriangularSystemWithIterativeInnerSolver)
     using Mtx = typename TestFixture::Mtx;
     using value_type = typename TestFixture::value_type;
 
+    const gko::remove_complex<value_type> inner_reduction_factor = 1e-2;
     auto inner_solver_factory =
         gko::solver::Gmres<value_type>::build()
             .with_criteria(gko::stop::ResidualNormReduction<value_type>::build()
-                               .with_reduction_factor(1e-2)
+                               .with_reduction_factor(inner_reduction_factor)
                                .on(this->exec))
             .on(this->exec);
 


### PR DESCRIPTION
apply_uses_initial_guess returns true if the linear operator uses the data stored in x as an initial guess and false otherwise.

This enables e.g. IR to distinguish between inner solvers that use an initial guess (all iterative solvers) and ones that don't (direct triangular solves and e.g. block-Jacobi preconditioner).