### PR TITLE
Fix a few test warnings

### DIFF
--- a/core/test/log/stream.cpp
+++ b/core/test/log/stream.cpp
@@ -35,6 +35,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <iomanip>
 #include <sstream>
+#include <string>
 
 
 #include <gtest/gtest.h>
@@ -715,7 +716,8 @@ TYPED_TEST(Stream, CatchesIterations)
     logger->template on<gko::log::Logger::iteration_complete>(
         solver.get(), num_iters, residual.get());
 
-    GKO_ASSERT_STR_CONTAINS(out.str(), "iteration " + num_iters);
+    GKO_ASSERT_STR_CONTAINS(out.str(),
+                            "iteration " + std::to_string(num_iters));
     GKO_ASSERT_STR_CONTAINS(out.str(), ptrstream_solver.str());
     GKO_ASSERT_STR_CONTAINS(out.str(), ptrstream_residual.str());
 }

--- a/cuda/test/base/cuda_executor.cu
+++ b/cuda/test/base/cuda_executor.cu
@@ -53,17 +53,25 @@ namespace {
 class ExampleOperation : public gko::Operation {
 public:
     explicit ExampleOperation(int &val) : value(val) {}
+
     void run(std::shared_ptr<const gko::OmpExecutor>) const override
     {
         value = -1;
     }
-    void run(std::shared_ptr<const gko::CudaExecutor>) const override
-    {
-        cudaGetDevice(&value);
-    }
+
     void run(std::shared_ptr<const gko::ReferenceExecutor>) const override
     {
         value = -2;
+    }
+
+    void run(std::shared_ptr<const gko::HipExecutor>) const override
+    {
+        value = -3;
+    }
+
+    void run(std::shared_ptr<const gko::CudaExecutor>) const override
+    {
+        cudaGetDevice(&value);
     }
 
     int &value;

--- a/hip/test/base/hip_executor.hip.cpp
+++ b/hip/test/base/hip_executor.hip.cpp
@@ -59,17 +59,25 @@ namespace {
 class ExampleOperation : public gko::Operation {
 public:
     explicit ExampleOperation(int &val) : value(val) {}
+
     void run(std::shared_ptr<const gko::OmpExecutor>) const override
     {
         value = -1;
     }
-    void run(std::shared_ptr<const gko::HipExecutor>) const override
-    {
-        hipGetDevice(&value);
-    }
+
     void run(std::shared_ptr<const gko::ReferenceExecutor>) const override
     {
         value = -2;
+    }
+
+    void run(std::shared_ptr<const gko::CudaExecutor>) const override
+    {
+        value = -3;
+    }
+
+    void run(std::shared_ptr<const gko::HipExecutor>) const override
+    {
+        hipGetDevice(&value);
     }
 
     int &value;


### PR DESCRIPTION
A test from our stream logger doesn't actually test the expected behavior, but by pure chance it succeeds anyways (since the empty string is contained in every string).

A [clang warning](https://gitlab.com/ginkgo-project/ginkgo-public-ci/-/jobs/551075280) pointed me to this issue.

Additionally, there are some tests that only partially override Operation::run, which gets fixed by this PR as well.