### PR TITLE
avoid overloading the CI system

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -58,7 +58,7 @@ stages:
         -DGINKGO_BUILD_OMP=${BUILD_OMP} -DGINKGO_BUILD_CUDA=${BUILD_CUDA}
         -DGINKGO_BUILD_HIP=${BUILD_HIP}
         -DGINKGO_BUILD_TESTS=ON -DGINKGO_BUILD_EXAMPLES=ON
-    - ninja -j${NUM_CORES}
+    - ninja -j${NUM_CORES} -l `nproc`
   dependencies: []
   except:
       - schedules
@@ -83,7 +83,7 @@ stages:
         -DGINKGO_BUILD_OMP=${BUILD_OMP} -DGINKGO_BUILD_CUDA=${BUILD_CUDA}
         -DGINKGO_BUILD_HIP=${BUILD_HIP}
         -DGINKGO_BUILD_TESTS=ON -DGINKGO_BUILD_EXAMPLES=ON
-    - ninja -j${NUM_CORES} install
+    - ninja -j${NUM_CORES} -l `nproc` install
     - |
         (( $(ctest -N | tail -1 | sed 's/Total Tests: //') != 0 )) || exit 1
     - ctest -V


### PR DESCRIPTION
From time to time, I observed very high loads (up to 140) on the CI system, which made connecting to it almost impossible.

This PR adds the `-l` parameter to ninja, which limits it to single-core execution unless the load-average is below the number of cores.