### PR TITLE
Optimize Composition intermediate storage

### DIFF
--- a/core/base/composition.cpp
+++ b/core/base/composition.cpp
@@ -89,7 +89,7 @@ std::unique_ptr<LinOp> apply_inner_operators(
         operators[i]->apply(lend(in), lend(out));
     }
 
-    return std::move(out);
+    return out;
 }
 
 

--- a/core/base/composition.cpp
+++ b/core/base/composition.cpp
@@ -89,7 +89,7 @@ std::unique_ptr<LinOp> apply_inner_operators(
         operators[i]->apply(lend(in), lend(out));
     }
 
-    return out;
+    return std::move(out);
 }
 
 

--- a/core/base/composition.cpp
+++ b/core/base/composition.cpp
@@ -33,50 +33,75 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <ginkgo/core/base/composition.hpp>
 
 
+#include <algorithm>
+
+
 #include <ginkgo/core/matrix/dense.hpp>
 
 
 namespace gko {
-namespace {
 
 
-template <typename ValueType, typename OpIterator, typename VecIterator>
-inline void allocate_vectors(OpIterator begin, OpIterator end, VecIterator res)
-{
-    for (auto it = begin; it != end; ++it) {
-        if (*res == nullptr || (*res)->get_size()[0] != (*it)->get_size()[0]) {
-            *res = matrix::Dense<ValueType>::create(
-                (*it)->get_executor(), gko::dim<2>{(*it)->get_size()[0], 1});
-        }
-        ++res;
-    }
-}
-
-
-inline const LinOp *apply_inner_operators(
+template <typename ValueType>
+std::unique_ptr<LinOp> apply_inner_operators(
     const std::vector<std::shared_ptr<const LinOp>> &operators,
-    const std::vector<std::unique_ptr<LinOp>> &intermediate, const LinOp *rhs)
+    Array<ValueType> &storage, const LinOp *rhs)
 {
-    for (auto i = operators.size() - 1; i > 0u; --i) {
-        auto solution = lend(intermediate[i - 1]);
-        operators[i]->apply(rhs, solution);
-        rhs = solution;
+    using Dense = matrix::Dense<ValueType>;
+    // determine amount of necessary storage:
+    // maximum sum of two subsequent intermediate vectors
+    // (and the out dimension of the last op if we only have one operator)
+    auto num_rhs = rhs->get_size()[1];
+    auto max_intermediate_size = std::accumulate(
+        begin(operators) + 1, end(operators) - 1,
+        operators.back()->get_size()[0],
+        [](size_type acc, std::shared_ptr<const LinOp> op) {
+            return std::max(acc, op->get_size()[0] + op->get_size()[1]);
+        });
+    auto storage_size = max_intermediate_size * num_rhs;
+    storage.resize_and_reset(storage_size);
+
+    // apply inner vectors
+    auto exec = rhs->get_executor();
+    auto data = storage.get_data();
+    // apply last operator
+    auto out_dim = gko::dim<2>{operators.back()->get_size()[0], num_rhs};
+    auto out = Dense::create(
+        exec, out_dim, Array<ValueType>::view(exec, out_dim[0] * num_rhs, data),
+        num_rhs);
+    operators.back()->apply(rhs, lend(out));
+    // apply following operators
+    // alternate intermediate vectors between beginning/end of storage
+    auto reversed_storage = true;
+    for (auto i = operators.size() - 2; i > 0; --i) {
+        // swap in and out
+        auto in = std::move(out);
+        // build new intermediate vector
+        out_dim[0] = operators[i]->get_size()[0];
+        auto out_size = out_dim[0] * num_rhs;
+        auto out_data =
+            data + (reversed_storage ? storage_size - out_size : size_type{});
+        reversed_storage = !reversed_storage;
+        out = Dense::create(exec, out_dim,
+                            Array<ValueType>::view(exec, out_size, out_data),
+                            num_rhs);
+        // apply operator
+        operators[i]->apply(lend(in), lend(out));
     }
-    return rhs;
+
+    return std::move(out);
 }
-
-
-}  // namespace
 
 
 template <typename ValueType>
 void Composition<ValueType>::apply_impl(const LinOp *b, LinOp *x) const
 {
-    cache_.intermediate.resize(operators_.size() - 1);
-    allocate_vectors<ValueType>(begin(operators_) + 1, end(operators_),
-                                begin(cache_.intermediate));
-    operators_[0]->apply(
-        apply_inner_operators(operators_, cache_.intermediate, b), x);
+    if (operators_.size() > 1) {
+        operators_[0]->apply(
+            lend(apply_inner_operators(operators_, storage_, b)), x);
+    } else {
+        operators_[0]->apply(b, x);
+    }
 }
 
 
@@ -84,12 +109,13 @@ template <typename ValueType>
 void Composition<ValueType>::apply_impl(const LinOp *alpha, const LinOp *b,
                                         const LinOp *beta, LinOp *x) const
 {
-    cache_.intermediate.resize(operators_.size() - 1);
-    allocate_vectors<ValueType>(begin(operators_) + 1, end(operators_),
-                                begin(cache_.intermediate));
-    operators_[0]->apply(
-        alpha, apply_inner_operators(operators_, cache_.intermediate, b), beta,
-        x);
+    if (operators_.size() > 1) {
+        operators_[0]->apply(
+            alpha, lend(apply_inner_operators(operators_, storage_, b)), beta,
+            x);
+    } else {
+        operators_[0]->apply(alpha, b, beta, x);
+    }
 }
 
 

--- a/reference/test/base/composition.cpp
+++ b/reference/test/base/composition.cpp
@@ -80,6 +80,42 @@ protected:
 TYPED_TEST_CASE(Composition, gko::test::ValueTypes);
 
 
+TYPED_TEST(Composition, AppliesSingleToVector)
+{
+    /*
+        cmp = [ -9 -2 ]
+              [ 27 26 ]
+    */
+    using Mtx = typename TestFixture::Mtx;
+    auto cmp = gko::Composition<TypeParam>::create(this->product);
+    auto x = gko::initialize<Mtx>({1.0, 2.0}, this->exec);
+    auto res = clone(x);
+
+    cmp->apply(lend(x), lend(res));
+
+    GKO_ASSERT_MTX_NEAR(res, l({-13.0, 79.0}), r<TypeParam>::value);
+}
+
+
+TYPED_TEST(Composition, AppliesSingleLinearCombinationToVector)
+{
+    /*
+        cmp = [ -9 -2 ]
+              [ 27 26 ]
+    */
+    using Mtx = typename TestFixture::Mtx;
+    auto cmp = gko::Composition<TypeParam>::create(this->product);
+    auto alpha = gko::initialize<Mtx>({3.0}, this->exec);
+    auto beta = gko::initialize<Mtx>({-1.0}, this->exec);
+    auto x = gko::initialize<Mtx>({1.0, 2.0}, this->exec);
+    auto res = clone(x);
+
+    cmp->apply(lend(alpha), lend(x), lend(beta), lend(res));
+
+    GKO_ASSERT_MTX_NEAR(res, l({-40.0, 235.0}), r<TypeParam>::value);
+}
+
+
 TYPED_TEST(Composition, AppliesToVector)
 {
     /*

--- a/reference/test/base/composition.cpp
+++ b/reference/test/base/composition.cpp
@@ -55,13 +55,25 @@ protected:
 
     Composition()
         : exec{gko::ReferenceExecutor::create()},
-          operators{gko::initialize<Mtx>(I<T>({2.0, 1.0}), exec),
-                    gko::initialize<Mtx>({I<T>({3.0, 2.0})}, exec)}
+          operators{
+              gko::initialize<Mtx>(I<T>({2.0, 1.0}), exec),
+              gko::initialize<Mtx>({I<T>({3.0, 2.0})}, exec),
+              gko::initialize<Mtx>({I<T>{-1.0, 1.0, 2.0}, I<T>{5.0, -3.0, 0.0}},
+                                   exec),
+              gko::initialize<Mtx>(
+                  {I<T>{9.0, 4.0}, I<T>{6.0, -2.0}, I<T>{-3.0, 2.0}}, exec),
+              gko::initialize<Mtx>({I<T>{1.0, 0.0}, I<T>{0.0, 1.0}}, exec)},
+          identity{
+              gko::initialize<Mtx>({I<T>{1.0, 0.0}, I<T>{0.0, 1.0}}, exec)},
+          product{
+              gko::initialize<Mtx>({I<T>{-9.0, -2.0}, I<T>{27.0, 26.0}}, exec)}
     {}
 
     std::shared_ptr<const gko::Executor> exec;
     std::vector<std::shared_ptr<gko::LinOp>> coefficients;
     std::vector<std::shared_ptr<gko::LinOp>> operators;
+    std::shared_ptr<Mtx> identity;
+    std::shared_ptr<Mtx> product;
 };
 
 TYPED_TEST_CASE(Composition, gko::test::ValueTypes);
@@ -102,6 +114,126 @@ TYPED_TEST(Composition, AppliesLinearCombinationToVector)
     cmp->apply(lend(alpha), lend(x), lend(beta), lend(res));
 
     GKO_ASSERT_MTX_NEAR(res, l({41.0, 19.0}), r<TypeParam>::value);
+}
+
+
+TYPED_TEST(Composition, AppliesLongerToVector)
+{
+    /*
+        cmp = [ 2 ] * [ 3 2 ] * [ -9  -2 ]
+              [ 1 ]             [ 27  26 ]
+    */
+    using Mtx = typename TestFixture::Mtx;
+    auto cmp = gko::Composition<TypeParam>::create(
+        this->operators[0], this->operators[1], this->product);
+    auto x = gko::initialize<Mtx>({1.0, 2.0}, this->exec);
+    auto res = clone(x);
+
+    cmp->apply(lend(x), lend(res));
+
+    GKO_ASSERT_MTX_NEAR(res, l({238.0, 119.0}), r<TypeParam>::value);
+}
+
+
+TYPED_TEST(Composition, AppliesLongerLinearCombinationToVector)
+{
+    /*
+        cmp = [ 2 ] * [ 3 2 ] * [ -9  -2 ]
+              [ 1 ]             [ 27  26 ]
+    */
+    using Mtx = typename TestFixture::Mtx;
+    auto cmp = gko::Composition<TypeParam>::create(
+        this->operators[0], this->operators[1], this->product);
+    auto alpha = gko::initialize<Mtx>({3.0}, this->exec);
+    auto beta = gko::initialize<Mtx>({-1.0}, this->exec);
+    auto x = gko::initialize<Mtx>({1.0, 2.0}, this->exec);
+    auto res = clone(x);
+
+    cmp->apply(lend(alpha), lend(x), lend(beta), lend(res));
+
+    GKO_ASSERT_MTX_NEAR(res, l({713.0, 355.0}), r<TypeParam>::value);
+}
+
+
+TYPED_TEST(Composition, AppliesLongestToVector)
+{
+    /*
+        cmp = [ 2 ] * [ 3 2 ] * [ -1  1  2 ] * [  9  4 ] * [ 1 0 ]
+              [ 1 ]             [  5 -3  0 ]   [  6 -2 ]   [ 0 1 ]
+                                               [ -3  2 ]
+    */
+    using Mtx = typename TestFixture::Mtx;
+    auto cmp = gko::Composition<TypeParam>::create(this->operators.begin(),
+                                                   this->operators.end());
+    auto x = gko::initialize<Mtx>({1.0, 2.0}, this->exec);
+    auto res = clone(x);
+
+    cmp->apply(lend(x), lend(res));
+
+    GKO_ASSERT_MTX_NEAR(res, l({238.0, 119.0}), r<TypeParam>::value);
+}
+
+
+TYPED_TEST(Composition, AppliesLongestLinearCombinationToVector)
+{
+    /*
+        cmp = [ 2 ] * [ 3 2 ] * [ -1  1  2 ] * [  9  4 ] * [ 1 0 ]
+              [ 1 ]             [  5 -3  0 ]   [  6 -2 ]   [ 0 1 ]
+                                               [ -3  2 ]
+    */
+    using Mtx = typename TestFixture::Mtx;
+    auto cmp = gko::Composition<TypeParam>::create(this->operators.begin(),
+                                                   this->operators.end());
+    auto alpha = gko::initialize<Mtx>({3.0}, this->exec);
+    auto beta = gko::initialize<Mtx>({-1.0}, this->exec);
+    auto x = gko::initialize<Mtx>({1.0, 2.0}, this->exec);
+    auto res = clone(x);
+
+    cmp->apply(lend(alpha), lend(x), lend(beta), lend(res));
+
+    GKO_ASSERT_MTX_NEAR(res, l({713.0, 355.0}), r<TypeParam>::value);
+}
+
+
+TYPED_TEST(Composition, AppliesLongestToVectorMultipleRhs)
+{
+    /*
+        cmp = [ 2 ] * [ 3 2 ] * [ -1  1  2 ] * [  9  4 ] * [ 1 0 ]
+              [ 1 ]             [  5 -3  0 ]   [  6 -2 ]   [ 0 1 ]
+                                               [ -3  2 ]
+    */
+    using Mtx = typename TestFixture::Mtx;
+    auto cmp = gko::Composition<TypeParam>::create(this->operators.begin(),
+                                                   this->operators.end());
+    auto x = clone(this->identity);
+    auto res = clone(x);
+
+    cmp->apply(lend(x), lend(res));
+
+    GKO_ASSERT_MTX_NEAR(res, l({{54.0, 92.0}, {27.0, 46.0}}),
+                        r<TypeParam>::value);
+}
+
+
+TYPED_TEST(Composition, AppliesLongestLinearCombinationToVectorMultipleRhs)
+{
+    /*
+        cmp = [ 2 ] * [ 3 2 ] * [ -1  1  2 ] * [  9  4 ] * [ 1 0 ]
+              [ 1 ]             [  5 -3  0 ]   [  6 -2 ]   [ 0 1 ]
+                                               [ -3  2 ]
+    */
+    using Mtx = typename TestFixture::Mtx;
+    auto cmp = gko::Composition<TypeParam>::create(this->operators.begin(),
+                                                   this->operators.end());
+    auto alpha = gko::initialize<Mtx>({3.0}, this->exec);
+    auto beta = gko::initialize<Mtx>({-1.0}, this->exec);
+    auto x = clone(this->identity);
+    auto res = clone(x);
+
+    cmp->apply(lend(alpha), lend(x), lend(beta), lend(res));
+
+    GKO_ASSERT_MTX_NEAR(res, l({{161.0, 276.0}, {81.0, 137.0}}),
+                        r<TypeParam>::value);
 }
 
 

--- a/reference/test/base/composition.cpp
+++ b/reference/test/base/composition.cpp
@@ -58,15 +58,16 @@ protected:
           operators{
               gko::initialize<Mtx>(I<T>({2.0, 1.0}), exec),
               gko::initialize<Mtx>({I<T>({3.0, 2.0})}, exec),
-              gko::initialize<Mtx>({I<T>{-1.0, 1.0, 2.0}, I<T>{5.0, -3.0, 0.0}},
-                                   exec),
               gko::initialize<Mtx>(
-                  {I<T>{9.0, 4.0}, I<T>{6.0, -2.0}, I<T>{-3.0, 2.0}}, exec),
-              gko::initialize<Mtx>({I<T>{1.0, 0.0}, I<T>{0.0, 1.0}}, exec)},
+                  {I<T>({-1.0, 1.0, 2.0}), I<T>({5.0, -3.0, 0.0})}, exec),
+              gko::initialize<Mtx>(
+                  {I<T>({9.0, 4.0}), I<T>({6.0, -2.0}), I<T>({-3.0, 2.0})},
+                  exec),
+              gko::initialize<Mtx>({I<T>({1.0, 0.0}), I<T>({0.0, 1.0})}, exec)},
           identity{
-              gko::initialize<Mtx>({I<T>{1.0, 0.0}, I<T>{0.0, 1.0}}, exec)},
-          product{
-              gko::initialize<Mtx>({I<T>{-9.0, -2.0}, I<T>{27.0, 26.0}}, exec)}
+              gko::initialize<Mtx>({I<T>({1.0, 0.0}), I<T>({0.0, 1.0})}, exec)},
+          product{gko::initialize<Mtx>({I<T>({-9.0, -2.0}), I<T>({27.0, 26.0})},
+                                       exec)}
     {}
 
     std::shared_ptr<const gko::Executor> exec;

--- a/reference/test/base/composition.cpp
+++ b/reference/test/base/composition.cpp
@@ -63,6 +63,7 @@ protected:
               gko::initialize<Mtx>(
                   {I<T>({9.0, 4.0}), I<T>({6.0, -2.0}), I<T>({-3.0, 2.0})},
                   exec),
+              gko::initialize<Mtx>({I<T>({1.0, 0.0}), I<T>({0.0, 1.0})}, exec),
               gko::initialize<Mtx>({I<T>({1.0, 0.0}), I<T>({0.0, 1.0})}, exec)},
           identity{
               gko::initialize<Mtx>({I<T>({1.0, 0.0}), I<T>({0.0, 1.0})}, exec)},
@@ -195,7 +196,7 @@ TYPED_TEST(Composition, AppliesLongerLinearCombinationToVector)
 TYPED_TEST(Composition, AppliesLongestToVector)
 {
     /*
-        cmp = [ 2 ] * [ 3 2 ] * [ -1  1  2 ] * [  9  4 ] * [ 1 0 ]
+        cmp = [ 2 ] * [ 3 2 ] * [ -1  1  2 ] * [  9  4 ] * [ 1 0 ]^2
               [ 1 ]             [  5 -3  0 ]   [  6 -2 ]   [ 0 1 ]
                                                [ -3  2 ]
     */
@@ -214,7 +215,7 @@ TYPED_TEST(Composition, AppliesLongestToVector)
 TYPED_TEST(Composition, AppliesLongestLinearCombinationToVector)
 {
     /*
-        cmp = [ 2 ] * [ 3 2 ] * [ -1  1  2 ] * [  9  4 ] * [ 1 0 ]
+        cmp = [ 2 ] * [ 3 2 ] * [ -1  1  2 ] * [  9  4 ] * [ 1 0 ]^2
               [ 1 ]             [  5 -3  0 ]   [  6 -2 ]   [ 0 1 ]
                                                [ -3  2 ]
     */
@@ -235,7 +236,7 @@ TYPED_TEST(Composition, AppliesLongestLinearCombinationToVector)
 TYPED_TEST(Composition, AppliesLongestToVectorMultipleRhs)
 {
     /*
-        cmp = [ 2 ] * [ 3 2 ] * [ -1  1  2 ] * [  9  4 ] * [ 1 0 ]
+        cmp = [ 2 ] * [ 3 2 ] * [ -1  1  2 ] * [  9  4 ] * [ 1 0 ]^2
               [ 1 ]             [  5 -3  0 ]   [  6 -2 ]   [ 0 1 ]
                                                [ -3  2 ]
     */
@@ -255,7 +256,7 @@ TYPED_TEST(Composition, AppliesLongestToVectorMultipleRhs)
 TYPED_TEST(Composition, AppliesLongestLinearCombinationToVectorMultipleRhs)
 {
     /*
-        cmp = [ 2 ] * [ 3 2 ] * [ -1  1  2 ] * [  9  4 ] * [ 1 0 ]
+        cmp = [ 2 ] * [ 3 2 ] * [ -1  1  2 ] * [  9  4 ] * [ 1 0 ]^2
               [ 1 ]             [  5 -3  0 ]   [  6 -2 ]   [ 0 1 ]
                                                [ -3  2 ]
     */


### PR DESCRIPTION
Only store the minimal amount of memory necessary for Composition. This is either the maximum sum of input and output dimension for all but the last intermediate operator, or the output dimension
of the last intermediate operator if there is only one operator.