### PR TITLE
Add support for clang-cuda

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -380,7 +380,7 @@ build/cuda101/intel/cuda/debug/static:
 # clang-cuda with cuda 10.1 and friends
 build/clang-cuda101/gcc/all/release/shared:
   <<: *default_build_with_test
-  image: localhost:5000/add_clang_cuda_69d04ab3_gko-cuda101-gnu8-llvm10-intel2019
+  image: localhost:5000/gko-cuda101-gnu8-llvm10-intel2019
   variables:
     <<: *default_variables
     CUDA_COMPILER: "clang++"
@@ -399,7 +399,7 @@ build/clang-cuda101/gcc/all/release/shared:
 
 build/clang-cuda101/clang/cuda/debug/static:
   <<: *default_build_with_test
-  image: localhost:5000/add_clang_cuda_69d04ab3_gko-cuda101-gnu8-llvm10-intel2019
+  image: localhost:5000/gko-cuda101-gnu8-llvm10-intel2019
   variables:
     <<: *default_variables
     C_COMPILER: "clang"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -15,6 +15,7 @@ stages:
   BENCHMARK_SERVER: "FINECI"
   C_COMPILER: "gcc"
   CXX_COMPILER: "g++"
+  CUDA_COMPILER: "nvcc"
   BUILD_TYPE: "Debug"
   BUILD_SHARED_LIBS: "ON"
   BUILD_REFERENCE: "ON"
@@ -51,9 +52,9 @@ stages:
     - cmake ${CI_PROJECT_DIR}
         -GNinja
         -DCMAKE_C_COMPILER=${C_COMPILER} -DCMAKE_CXX_COMPILER=${CXX_COMPILER}
-        -DCMAKE_BUILD_TYPE=${BUILD_TYPE} -DCMAKE_CXX_FLAGS="${CXX_FLAGS}"
-        -DBUILD_SHARED_LIBS=${BUILD_SHARED_LIBS} ${EXTRA_CMAKE_FLAGS}
-        ${CUDA_ARCH_STR} ${CUDA_HOST_STR}
+        -DCMAKE_CUDA_COMPILER=${CUDA_COMPILER} -DCMAKE_BUILD_TYPE=${BUILD_TYPE}
+        -DCMAKE_CXX_FLAGS="${CXX_FLAGS}" -DBUILD_SHARED_LIBS=${BUILD_SHARED_LIBS}
+        ${EXTRA_CMAKE_FLAGS} ${CUDA_ARCH_STR} ${CUDA_HOST_STR}
         -DGINKGO_DEVEL_TOOLS=OFF -DGINKGO_BUILD_REFERENCE=${BUILD_REFERENCE}
         -DGINKGO_BUILD_OMP=${BUILD_OMP} -DGINKGO_BUILD_CUDA=${BUILD_CUDA}
         -DGINKGO_BUILD_HIP=${BUILD_HIP}
@@ -76,9 +77,9 @@ stages:
     - cmake ${CI_PROJECT_DIR}
         -GNinja
         -DCMAKE_C_COMPILER=${C_COMPILER} -DCMAKE_CXX_COMPILER=${CXX_COMPILER}
-        -DCMAKE_BUILD_TYPE=${BUILD_TYPE} -DCMAKE_CXX_FLAGS="${CXX_FLAGS}"
-        -DBUILD_SHARED_LIBS=${BUILD_SHARED_LIBS} ${EXTRA_CMAKE_FLAGS}
-        ${CUDA_ARCH_STR} ${CUDA_HOST_STR}
+        -DCMAKE_CUDA_COMPILER=${CUDA_COMPILER} -DCMAKE_BUILD_TYPE=${BUILD_TYPE}
+        -DCMAKE_CXX_FLAGS="${CXX_FLAGS}" -DBUILD_SHARED_LIBS=${BUILD_SHARED_LIBS}
+        ${EXTRA_CMAKE_FLAGS} ${CUDA_ARCH_STR} ${CUDA_HOST_STR}
         -DGINKGO_DEVEL_TOOLS=OFF -DGINKGO_BUILD_REFERENCE=${BUILD_REFERENCE}
         -DGINKGO_BUILD_OMP=${BUILD_OMP} -DGINKGO_BUILD_CUDA=${BUILD_CUDA}
         -DGINKGO_BUILD_HIP=${BUILD_HIP}
@@ -345,7 +346,8 @@ build/cuda101/clang/all/release/static:
     BUILD_OMP: "ON"
     BUILD_CUDA: "ON"
     BUILD_HIP: "ON"
-    BUILD_TYPE: "Debug"
+    BUILD_TYPE: "Release"
+    BUILD_SHARED_LIBS: "OFF"
     CUDA_ARCH: 35
   only:
     variables:
@@ -365,6 +367,48 @@ build/cuda101/intel/cuda/debug/static:
     BUILD_OMP: "ON"
     BUILD_CUDA: "ON"
     BUILD_TYPE: "Debug"
+    BUILD_SHARED_LIBS: "OFF"
+    CUDA_ARCH: 35
+  only:
+    variables:
+      - $RUN_CI_TAG
+  tags:
+    - private_ci
+    - cuda
+    - gpu
+
+# clang-cuda with cuda 10.1 and friends
+build/clang-cuda101/gcc/all/release/shared:
+  <<: *default_build_with_test
+  image: localhost:5000/add_clang_cuda_69d04ab3_gko-cuda101-gnu8-llvm10-intel2019
+  variables:
+    <<: *default_variables
+    CUDA_COMPILER: "clang++"
+    BUILD_OMP: "ON"
+    BUILD_CUDA: "ON"
+    BUILD_HIP: "ON"
+    BUILD_TYPE: "Release"
+    CUDA_ARCH: 35
+  only:
+    variables:
+      - $RUN_CI_TAG
+  tags:
+    - private_ci
+    - cuda
+    - gpu
+
+build/clang-cuda101/clang/cuda/debug/static:
+  <<: *default_build_with_test
+  image: localhost:5000/add_clang_cuda_69d04ab3_gko-cuda101-gnu8-llvm10-intel2019
+  variables:
+    <<: *default_variables
+    C_COMPILER: "clang"
+    CXX_COMPILER: "clang++"
+    CUDA_COMPILER: "clang++"
+    BUILD_OMP: "ON"
+    BUILD_CUDA: "ON"
+    BUILD_TYPE: "Debug"
+    BUILD_SHARED_LIBS: "OFF"
     CUDA_ARCH: 35
   only:
     variables:
@@ -674,10 +718,10 @@ gh-pages:
     - mkdir -p ${CI_JOB_NAME} && pushd ${CI_JOB_NAME}
     - cmake ${CI_PROJECT_DIR}
         -DCMAKE_C_COMPILER=${C_COMPILER} -DCMAKE_CXX_COMPILER=${CXX_COMPILER}
-        -DCMAKE_BUILD_TYPE=${BUILD_TYPE} -DBUILD_SHARED_LIBS=ON
-        ${EXTRA_CMAKE_FLAGS} -DGINKGO_DEVEL_TOOLS=OFF -DGINKGO_BUILD_REFERENCE=OFF
-        -DGINKGO_BUILD_OMP=OFF -DGINKGO_BUILD_CUDA=OFF -DGINKGO_BUILD_HIP=OFF
-        -DGINKGO_BUILD_TESTS=OFF -DGINKGO_BUILD_EXAMPLES=OFF
+        -DCMAKE_CUDA_COMPILER=${CUDA_COMPILER} -DCMAKE_BUILD_TYPE=${BUILD_TYPE}
+        -DBUILD_SHARED_LIBS=ON ${EXTRA_CMAKE_FLAGS} -DGINKGO_DEVEL_TOOLS=OFF
+        -DGINKGO_BUILD_REFERENCE=OFF -DGINKGO_BUILD_OMP=OFF -DGINKGO_BUILD_CUDA=OFF
+        -DGINKGO_BUILD_HIP=OFF -DGINKGO_BUILD_TESTS=OFF -DGINKGO_BUILD_EXAMPLES=OFF
         -DGINKGO_BUILD_DOC=ON -DGINKGO_DOC_GENERATE_PDF=ON
     - make usr
     - make pdf

--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -25,6 +25,8 @@ function(ginkgo_benchmark_hipsp_linops name)
     target_compile_definitions("${name}" PRIVATE HAS_HIP=1)
     EXECUTE_PROCESS(COMMAND ${HIP_PATH}/bin/hipconfig --cpp_config OUTPUT_VARIABLE HIP_CXX_FLAGS)
     set_target_properties("${name}" PROPERTIES COMPILE_FLAGS ${HIP_CXX_FLAGS})
+    # for some reason, HIP creates a dependency on Threads::Threads here, so we need to find it
+    find_package(Threads REQUIRED)
     find_package(HIP REQUIRED)
     find_package(hipblas REQUIRED)
     find_package(hipsparse REQUIRED)

--- a/cmake/GinkgoConfig.cmake.in
+++ b/cmake/GinkgoConfig.cmake.in
@@ -135,10 +135,15 @@ include(${CMAKE_CURRENT_LIST_DIR}/windows_helpers.cmake)
 # NOTE: we do not export benchmarks, examples, tests or devel tools
 #     so `third_party` libraries are currently unneeded.
 
-# populate CUDA_HOST_COMPILER if Ginkgo was built with CUDA
+# propagate CUDA_HOST_COMPILER if Ginkgo was built with CUDA
 if (GINKGO_BUILD_CUDA AND GINKGO_CUDA_HOST_COMPILER AND NOT CMAKE_CUDA_HOST_COMPILER)
     message(STATUS "Ginkgo: Setting CUDA host compiler to ${GINKGO_CXX_COMPILER}")
     set(CMAKE_CUDA_HOST_COMPILER "${GINKGO_CXX_COMPILER}" CACHE STRING "" FORCE)
+endif()
+
+# HIP depends on Threads::Threads in some circumstances, but doesn't find it
+if (GINKGO_BUILD_HIP)
+    find_package(Threads REQUIRED)
 endif()
 
 include(${CMAKE_CURRENT_LIST_DIR}/GinkgoTargets.cmake)

--- a/cuda/CMakeLists.txt
+++ b/cuda/CMakeLists.txt
@@ -95,8 +95,9 @@ target_sources(ginkgo_cuda
         stop/residual_norm_reduction_kernels.cu)
 
 # This creates a compilation bug on nvcc 9.0.102 *with* the new array_deleter
-# merged at commit ed12b3df5d26
-if(NOT CMAKE_CUDA_COMPILER_VERSION MATCHES "9.0")
+# merged at commit ed12b3df5d26, and the parameter is not recognized by clang-cuda
+if(CMAKE_CUDA_COMPILER_ID STREQUAL "NVIDIA" AND
+   NOT CMAKE_CUDA_COMPILER_VERSION MATCHES "9.0")
     # remove false positive CUDA warnings when calling one<T>() and zero<T>()
     target_compile_options(ginkgo_cuda
         PRIVATE

--- a/examples/custom-matrix-format/CMakeLists.txt
+++ b/examples/custom-matrix-format/CMakeLists.txt
@@ -8,4 +8,6 @@ if (GINKGO_BUILD_CUDA AND GINKGO_BUILD_OMP)
     target_link_libraries(custom-matrix-format ginkgo)
     target_include_directories(custom-matrix-format PRIVATE
         ${PROJECT_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR})
+    # workaround for clang-cuda/g++ interaction
+    set_target_properties(custom-matrix-format PROPERTIES POSITION_INDEPENDENT_CODE ON)
 endif()

--- a/third_party/CudaArchitectureSelector/CMakeLists.txt
+++ b/third_party/CudaArchitectureSelector/CMakeLists.txt
@@ -1,6 +1,6 @@
 ginkgo_load_git_package(CudaArchitectureSelector
     "https://github.com/ginkgo-project/CudaArchitectureSelector.git"
-    "7cbe43dd33df7db709f3ee9d2c33acabfdc536ba")
+    "f6e024cc2000eb870dc52166d4cdce9fe7f9a7a4")
 add_subdirectory(${CMAKE_CURRENT_BINARY_DIR}/src
     ${CMAKE_CURRENT_BINARY_DIR}/build EXCLUDE_FROM_ALL)
 set(CMAKE_MODULE_PATH "${CMAKE_MODULE_PATH}" PARENT_SCOPE)

--- a/third_party/CudaArchitectureSelector/CMakeLists.txt
+++ b/third_party/CudaArchitectureSelector/CMakeLists.txt
@@ -1,6 +1,6 @@
 ginkgo_load_git_package(CudaArchitectureSelector
     "https://github.com/ginkgo-project/CudaArchitectureSelector.git"
-    "51e6fc3590bfadded3bcf56f739c90066b2b8071")
+    "7cbe43dd33df7db709f3ee9d2c33acabfdc536ba")
 add_subdirectory(${CMAKE_CURRENT_BINARY_DIR}/src
     ${CMAKE_CURRENT_BINARY_DIR}/build EXCLUDE_FROM_ALL)
 set(CMAKE_MODULE_PATH "${CMAKE_MODULE_PATH}" PARENT_SCOPE)


### PR DESCRIPTION
This PR takes the first steps to full clang-cuda support in Ginkgo. It works with the current CMake master version and (slightly patched) clang-10 (https://github.com/llvm/llvm-project/commit/8e20516540444618ad32dd11e835c05804053697)