### PR TITLE
fix missing header and increase omp/parilu iter

### DIFF
--- a/cuda/components/atomic.cuh
+++ b/cuda/components/atomic.cuh
@@ -35,6 +35,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
 #include <cuda.h>
+#include <cuda_fp16.h>
 
 
 namespace gko {

--- a/hip/components/atomic.hip.hpp
+++ b/hip/components/atomic.hip.hpp
@@ -34,6 +34,9 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define GKO_HIP_COMPONENTS_ATOMIC_HIP_HPP_
 
 
+#include <hip/hip_fp16.h>
+
+
 namespace gko {
 namespace kernels {
 namespace hip {

--- a/omp/test/factorization/par_ilu_kernels.cpp
+++ b/omp/test/factorization/par_ilu_kernels.cpp
@@ -356,7 +356,7 @@ TYPED_TEST(ParIlu, KernelComputeParILUWithMoreIterationsIsEquivalentToRef)
     std::unique_ptr<Csr> u_ref{};
     std::unique_ptr<Csr> l_omp{};
     std::unique_ptr<Csr> u_omp{};
-    gko::size_type iterations{20};
+    gko::size_type iterations{30};
 
     this->compute_lu(&l_ref, &u_ref, &l_omp, &u_omp, iterations);
 


### PR DESCRIPTION
This PR fix the missing header for the `__half atomicAdd` and increase the omp/parilu iterations to  reach the residual requirement