### PR TITLE
Fix GinkgoConfig

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -273,6 +273,7 @@ add_custom_target(test_install
     -B${Ginkgo_BINARY_DIR}/test_install
     -DCMAKE_PREFIX_PATH=${CMAKE_INSTALL_PREFIX}/${GINKGO_INSTALL_CONFIG_DIR}
     -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER} -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
+    -DCMAKE_CUDA_COMPILER=${CMAKE_CUDA_COMPILER}
     # `--config cfg` is ignored by single-configuration generator.
     # `$<CONFIG>` is always be the same as `CMAKE_BUILD_TYPE` in single-configuration generator.
     COMMAND ${CMAKE_COMMAND} --build ${Ginkgo_BINARY_DIR}/test_install --config $<CONFIG>

--- a/cmake/GinkgoConfig.cmake.in
+++ b/cmake/GinkgoConfig.cmake.in
@@ -153,7 +153,7 @@ endif()
 # For details, see https://gitlab.kitware.com/cmake/cmake/issues/18614
 if((NOT GINKGO_BUILD_SHARED_LIBS) AND GINKGO_BUILD_CUDA)
     enable_language(CUDA)
-  endif()
+endif()
 
 if((NOT GINKGO_BUILD_SHARED_LIBS) AND GINKGO_BUILD_HIP)
     find_package(HIP REQUIRED)

--- a/cmake/GinkgoConfig.cmake.in
+++ b/cmake/GinkgoConfig.cmake.in
@@ -97,9 +97,8 @@ set(GINKGO_INSTALL_CONFIG_DIR "${GINKGO_INSTALL_PREFIX}/@GINKGO_INSTALL_CONFIG_D
 set(GINKGO_INSTALL_MODULE_DIR "${GINKGO_INSTALL_PREFIX}/@GINKGO_INSTALL_MODULE_DIR@")
 
 # Forward Ginkgo's MODULE PATH and the PREFIX PATH for HIP and more
-set(CMAKE_MODULE_PATH "@CMAKE_MODULE_PATH@")
-set(CMAKE_MODULE_PATH "${GINKGO_INSTALL_MODULE_DIR}" ${CMAKE_MODULE_PATH})
-set(CMAKE_PREFIX_PATH "@CMAKE_PREFIX_PATH@")
+list(APPEND CMAKE_MODULE_PATH "@CMAKE_MODULE_PATH@" "${GINKGO_INSTALL_MODULE_DIR}")
+list(APPEND CMAKE_PREFIX_PATH "@CMAKE_PREFIX_PATH@")
 
 
 set(GINKGO_INTERFACE_LINK_LIBRARIES "@GINKGO_INTERFACE_LINK_LIBRARIES@")
@@ -141,9 +140,34 @@ if (GINKGO_BUILD_CUDA AND GINKGO_CUDA_HOST_COMPILER AND NOT CMAKE_CUDA_HOST_COMP
     set(CMAKE_CUDA_HOST_COMPILER "${GINKGO_CXX_COMPILER}" CACHE STRING "" FORCE)
 endif()
 
+if(GINKGO_HAVE_PAPI_SDE)
+    find_package(PAPI REQUIRED OPTIONAL_COMPONENTS sde)
+endif()
+
 # HIP depends on Threads::Threads in some circumstances, but doesn't find it
 if (GINKGO_BUILD_HIP)
     find_package(Threads REQUIRED)
 endif()
+
+# Needed because of a known issue with CUDA while linking statically.
+# For details, see https://gitlab.kitware.com/cmake/cmake/issues/18614
+if((NOT GINKGO_BUILD_SHARED_LIBS) AND GINKGO_BUILD_CUDA)
+    enable_language(CUDA)
+  endif()
+
+if((NOT GINKGO_BUILD_SHARED_LIBS) AND GINKGO_BUILD_HIP)
+    find_package(HIP REQUIRED)
+    find_package(hipblas REQUIRED)
+    find_package(hipsparse REQUIRED)
+    if(GINKGO_HIP_PLATFORM MATCHES "hcc")
+        ginkgo_hip_ban_link_hcflag(hcc::hccrt)
+        ginkgo_hip_ban_link_hcflag(hcc::hc_am)
+        ginkgo_hip_ban_link_hcflag(hcc::mcwamp)
+        ginkgo_hip_ban_compile_hcflag(hcc::hccrt)
+        ginkgo_hip_ban_compile_hcflag(hcc::hc_am)
+        ginkgo_hip_ban_compile_hcflag(hcc::mcwamp)
+    endif()
+endif()
+
 
 include(${CMAKE_CURRENT_LIST_DIR}/GinkgoTargets.cmake)

--- a/test_install/CMakeLists.txt
+++ b/test_install/CMakeLists.txt
@@ -20,30 +20,6 @@ endif()
 include(CheckLanguage)
 check_language(CUDA)
 
-if(GINKGO_HAVE_PAPI_SDE)
-    find_package(PAPI REQUIRED OPTIONAL_COMPONENTS sde)
-endif()
-
-# Needed because of a known issue with CUDA while linking statically.
-# For details, see https://gitlab.kitware.com/cmake/cmake/issues/18614
-if((NOT GINKGO_BUILD_SHARED_LIBS) AND GINKGO_BUILD_CUDA)
-    enable_language(CUDA)
-endif()
-
-if((NOT GINKGO_BUILD_SHARED_LIBS) AND GINKGO_BUILD_HIP)
-    find_package(HIP REQUIRED)
-    find_package(hipblas REQUIRED)
-    find_package(hipsparse REQUIRED)
-    if(GINKGO_HIP_PLATFORM MATCHES "hcc")
-        ginkgo_hip_ban_link_hcflag(hcc::hccrt)
-        ginkgo_hip_ban_link_hcflag(hcc::hc_am)
-        ginkgo_hip_ban_link_hcflag(hcc::mcwamp)
-        ginkgo_hip_ban_compile_hcflag(hcc::hccrt)
-        ginkgo_hip_ban_compile_hcflag(hcc::hc_am)
-        ginkgo_hip_ban_compile_hcflag(hcc::mcwamp)
-    endif()
-endif()
-
 add_executable(test_install test_install.cpp)
 target_compile_features(test_install PUBLIC cxx_std_11)
 target_link_libraries(test_install PRIVATE Ginkgo::ginkgo)


### PR DESCRIPTION
CMake variables are appended instead of simply `set` and dependencies or corner cases (in particular with static library builds) are taken care of as part of the `GinkgoConfig.cmake`.

Thanks @nbeams for finding this issue!