### PR TITLE
Fix the (cuda|hip)DeviceReset issue.

### DIFF
--- a/benchmark/utils/general.hpp
+++ b/benchmark/utils/general.hpp
@@ -260,11 +260,11 @@ const std::map<std::string, std::function<std::shared_ptr<gko::Executor>()>>
         {"cuda",
          [] {
              return gko::CudaExecutor::create(FLAGS_device_id,
-                                              gko::OmpExecutor::create());
+                                              gko::OmpExecutor::create(), true);
          }},
         {"hip", [] {
              return gko::HipExecutor::create(FLAGS_device_id,
-                                             gko::OmpExecutor::create());
+                                             gko::OmpExecutor::create(), true);
          }}};
 
 

--- a/core/device_hooks/cuda_hooks.cpp
+++ b/core/device_hooks/cuda_hooks.cpp
@@ -50,10 +50,10 @@ version version_info::get_cuda_version() noexcept
 
 
 std::shared_ptr<CudaExecutor> CudaExecutor::create(
-    int device_id, std::shared_ptr<Executor> master)
+    int device_id, std::shared_ptr<Executor> master, bool device_reset)
 {
     return std::shared_ptr<CudaExecutor>(
-        new CudaExecutor(device_id, std::move(master)));
+        new CudaExecutor(device_id, std::move(master), device_reset));
 }
 
 

--- a/core/device_hooks/hip_hooks.cpp
+++ b/core/device_hooks/hip_hooks.cpp
@@ -47,10 +47,10 @@ version version_info::get_hip_version() noexcept
 
 
 std::shared_ptr<HipExecutor> HipExecutor::create(
-    int device_id, std::shared_ptr<Executor> master)
+    int device_id, std::shared_ptr<Executor> master, bool device_reset)
 {
     return std::shared_ptr<HipExecutor>(
-        new HipExecutor(device_id, std::move(master)));
+        new HipExecutor(device_id, std::move(master), device_reset));
 }
 
 

--- a/core/test/base/executor.cpp
+++ b/core/test/base/executor.cpp
@@ -275,7 +275,8 @@ TEST(ReferenceExecutor, IsItsOwnMaster)
 TEST(CudaExecutor, RunsCorrectOperation)
 {
     int value = 0;
-    exec_ptr cuda = gko::CudaExecutor::create(0, gko::OmpExecutor::create());
+    exec_ptr cuda =
+        gko::CudaExecutor::create(0, gko::OmpExecutor::create(), true);
 
     cuda->run(ExampleOperation(value));
     ASSERT_EQ(2, value);
@@ -288,7 +289,8 @@ TEST(CudaExecutor, RunsCorrectLambdaOperation)
     auto omp_lambda = [&value]() { value = 1; };
     auto cuda_lambda = [&value]() { value = 2; };
     auto hip_lambda = [&value]() { value = 3; };
-    exec_ptr cuda = gko::CudaExecutor::create(0, gko::OmpExecutor::create());
+    exec_ptr cuda =
+        gko::CudaExecutor::create(0, gko::OmpExecutor::create(), true);
 
     cuda->run(omp_lambda, cuda_lambda, hip_lambda);
     ASSERT_EQ(2, value);
@@ -310,6 +312,35 @@ TEST(CudaExecutor, KnowsItsDeviceId)
     auto cuda = gko::CudaExecutor::create(0, omp);
 
     ASSERT_EQ(0, cuda->get_device_id());
+}
+
+
+TEST(CudaExecutor, CanGetDeviceResetBoolean)
+{
+    auto omp = gko::OmpExecutor::create();
+    auto cuda = gko::CudaExecutor::create(0, omp);
+
+    ASSERT_EQ(false, cuda->get_device_reset());
+}
+
+
+TEST(CudaExecutor, CanSetDefaultDeviceResetBoolean)
+{
+    auto omp = gko::OmpExecutor::create();
+    auto cuda = gko::CudaExecutor::create(0, omp, true);
+
+    ASSERT_EQ(true, cuda->get_device_reset());
+}
+
+
+TEST(CudaExecutor, CanSetDeviceResetBoolean)
+{
+    auto omp = gko::OmpExecutor::create();
+    auto cuda = gko::CudaExecutor::create(0, omp);
+
+    cuda->set_device_reset(true);
+
+    ASSERT_EQ(true, cuda->get_device_reset());
 }
 
 
@@ -351,6 +382,35 @@ TEST(HipExecutor, KnowsItsDeviceId)
     auto hip = gko::HipExecutor::create(0, omp);
 
     ASSERT_EQ(0, hip->get_device_id());
+}
+
+
+TEST(HipExecutor, CanGetDeviceResetBoolean)
+{
+    auto omp = gko::OmpExecutor::create();
+    auto hip = gko::HipExecutor::create(0, omp);
+
+    ASSERT_EQ(false, hip->get_device_reset());
+}
+
+
+TEST(HipExecutor, CanSetDefaultDeviceResetBoolean)
+{
+    auto omp = gko::OmpExecutor::create();
+    auto hip = gko::HipExecutor::create(0, omp, true);
+
+    ASSERT_EQ(true, hip->get_device_reset());
+}
+
+
+TEST(HipExecutor, CanSetDeviceResetBoolean)
+{
+    auto omp = gko::OmpExecutor::create();
+    auto hip = gko::HipExecutor::create(0, omp);
+
+    hip->set_device_reset(true);
+
+    ASSERT_EQ(true, hip->get_device_reset());
 }
 
 

--- a/cuda/base/executor.cpp
+++ b/cuda/base/executor.cpp
@@ -56,13 +56,14 @@ namespace gko {
 
 
 std::shared_ptr<CudaExecutor> CudaExecutor::create(
-    int device_id, std::shared_ptr<Executor> master)
+    int device_id, std::shared_ptr<Executor> master, bool device_reset)
 {
     return std::shared_ptr<CudaExecutor>(
-        new CudaExecutor(device_id, std::move(master)),
+        new CudaExecutor(device_id, std::move(master), device_reset),
         [device_id](CudaExecutor *exec) {
             delete exec;
-            if (!CudaExecutor::get_num_execs(device_id)) {
+            if (!CudaExecutor::get_num_execs(device_id) &&
+                exec->get_device_reset()) {
                 cuda::device_guard g(device_id);
                 cudaDeviceReset();
             }

--- a/cuda/test/utils.hpp
+++ b/cuda/test/utils.hpp
@@ -45,7 +45,7 @@ namespace {
 
 // prevent device reset after each test
 auto no_reset_exec =
-    gko::CudaExecutor::create(0, gko::ReferenceExecutor::create());
+    gko::CudaExecutor::create(0, gko::ReferenceExecutor::create(), true);
 
 
 }  // namespace

--- a/examples/adaptiveprecision-blockjacobi/adaptiveprecision-blockjacobi.cpp
+++ b/examples/adaptiveprecision-blockjacobi/adaptiveprecision-blockjacobi.cpp
@@ -61,10 +61,10 @@ int main(int argc, char *argv[])
         exec = gko::OmpExecutor::create();
     } else if (argc == 2 && std::string(argv[1]) == "cuda" &&
                gko::CudaExecutor::get_num_devices() > 0) {
-        exec = gko::CudaExecutor::create(0, gko::OmpExecutor::create());
+        exec = gko::CudaExecutor::create(0, gko::OmpExecutor::create(), true);
     } else if (argc == 2 && std::string(argv[1]) == "hip" &&
                gko::HipExecutor::get_num_devices() > 0) {
-        exec = gko::HipExecutor::create(0, gko::OmpExecutor::create());
+        exec = gko::HipExecutor::create(0, gko::OmpExecutor::create(), true);
     } else {
         std::cerr << "Usage: " << argv[0] << " [executor]" << std::endl;
         std::exit(-1);

--- a/examples/custom-logger/custom-logger.cpp
+++ b/examples/custom-logger/custom-logger.cpp
@@ -221,7 +221,7 @@ int main(int argc, char *argv[])
         exec = gko::OmpExecutor::create();
     } else if (argc == 2 && std::string(argv[1]) == "cuda" &&
                gko::CudaExecutor::get_num_devices() > 0) {
-        exec = gko::CudaExecutor::create(0, gko::OmpExecutor::create());
+        exec = gko::CudaExecutor::create(0, gko::OmpExecutor::create(), true);
     } else if (argc == 2 && std::string(argv[1]) == "hip" &&
                gko::HipExecutor::get_num_devices() > 0) {
         exec = gko::HipExecutor::create(0, gko::OmpExecutor::create());

--- a/examples/custom-matrix-format/custom-matrix-format.cpp
+++ b/examples/custom-matrix-format/custom-matrix-format.cpp
@@ -255,8 +255,8 @@ int main(int argc, char *argv[])
     const auto omp = gko::OmpExecutor::create();
     std::map<std::string, std::shared_ptr<gko::Executor>> exec_map{
         {"omp", omp},
-        {"cuda", gko::CudaExecutor::create(0, omp)},
-        {"hip", gko::HipExecutor::create(0, omp)},
+        {"cuda", gko::CudaExecutor::create(0, omp, true)},
+        {"hip", gko::HipExecutor::create(0, omp, true)},
         {"reference", gko::ReferenceExecutor::create()}};
 
     // executor where Ginkgo will perform the computation

--- a/examples/custom-stopping-criterion/custom-stopping-criterion.cpp
+++ b/examples/custom-stopping-criterion/custom-stopping-criterion.cpp
@@ -148,10 +148,10 @@ int main(int argc, char *argv[])
         exec = gko::OmpExecutor::create();
     } else if (argc == 2 && std::string(argv[1]) == "cuda" &&
                gko::CudaExecutor::get_num_devices() > 0) {
-        exec = gko::CudaExecutor::create(0, gko::OmpExecutor::create());
+        exec = gko::CudaExecutor::create(0, gko::OmpExecutor::create(), true);
     } else if (argc == 2 && std::string(argv[1]) == "hip" &&
                gko::HipExecutor::get_num_devices() > 0) {
-        exec = gko::HipExecutor::create(0, gko::OmpExecutor::create());
+        exec = gko::HipExecutor::create(0, gko::OmpExecutor::create(), true);
     } else {
         std::cerr << "Usage: " << argv[0] << " [executor]" << std::endl;
         std::exit(-1);

--- a/examples/ilu-preconditioned-solver/ilu-preconditioned-solver.cpp
+++ b/examples/ilu-preconditioned-solver/ilu-preconditioned-solver.cpp
@@ -61,10 +61,10 @@ int main(int argc, char *argv[])
         exec = gko::OmpExecutor::create();
     } else if (argc == 2 && std::string(argv[1]) == "cuda" &&
                gko::CudaExecutor::get_num_devices() > 0) {
-        exec = gko::CudaExecutor::create(0, gko::OmpExecutor::create());
+        exec = gko::CudaExecutor::create(0, gko::OmpExecutor::create(), true);
     } else if (argc == 2 && std::string(argv[1]) == "hip" &&
                gko::HipExecutor::get_num_devices() > 0) {
-        exec = gko::HipExecutor::create(0, gko::OmpExecutor::create());
+        exec = gko::HipExecutor::create(0, gko::OmpExecutor::create(), true);
     } else {
         std::cerr << "Usage: " << argv[0] << " [executor]" << std::endl;
         std::exit(-1);

--- a/examples/inverse-iteration/inverse-iteration.cpp
+++ b/examples/inverse-iteration/inverse-iteration.cpp
@@ -66,10 +66,10 @@ int main(int argc, char *argv[])
         exec = gko::OmpExecutor::create();
     } else if (argc == 2 && std::string(argv[1]) == "cuda" &&
                gko::CudaExecutor::get_num_devices() > 0) {
-        exec = gko::CudaExecutor::create(0, gko::OmpExecutor::create());
+        exec = gko::CudaExecutor::create(0, gko::OmpExecutor::create(), true);
     } else if (argc == 2 && std::string(argv[1]) == "hip" &&
                gko::HipExecutor::get_num_devices() > 0) {
-        exec = gko::HipExecutor::create(0, gko::OmpExecutor::create());
+        exec = gko::HipExecutor::create(0, gko::OmpExecutor::create(), true);
     } else {
         std::cerr << "Usage: " << argv[0] << " [executor]" << std::endl;
         std::exit(-1);

--- a/examples/ir-ilu-preconditioned-solver/ir-ilu-preconditioned-solver.cpp
+++ b/examples/ir-ilu-preconditioned-solver/ir-ilu-preconditioned-solver.cpp
@@ -63,10 +63,10 @@ int main(int argc, char *argv[])
         exec = gko::OmpExecutor::create();
     } else if ((argc == 2 || argc == 3) && std::string(argv[1]) == "cuda" &&
                gko::CudaExecutor::get_num_devices() > 0) {
-        exec = gko::CudaExecutor::create(0, gko::OmpExecutor::create());
+        exec = gko::CudaExecutor::create(0, gko::OmpExecutor::create(), true);
     } else if ((argc == 2 || argc == 3) && std::string(argv[1]) == "hip" &&
                gko::HipExecutor::get_num_devices() > 0) {
-        exec = gko::HipExecutor::create(0, gko::OmpExecutor::create());
+        exec = gko::HipExecutor::create(0, gko::OmpExecutor::create(), true);
     } else {
         std::cerr << "Usage: " << argv[0] << " [executor] [sweeps]"
                   << std::endl;

--- a/examples/iterative-refinement/iterative-refinement.cpp
+++ b/examples/iterative-refinement/iterative-refinement.cpp
@@ -61,10 +61,10 @@ int main(int argc, char *argv[])
         exec = gko::OmpExecutor::create();
     } else if (argc == 2 && std::string(argv[1]) == "cuda" &&
                gko::CudaExecutor::get_num_devices() > 0) {
-        exec = gko::CudaExecutor::create(0, gko::OmpExecutor::create());
+        exec = gko::CudaExecutor::create(0, gko::OmpExecutor::create(), true);
     } else if (argc == 2 && std::string(argv[1]) == "hip" &&
                gko::HipExecutor::get_num_devices() > 0) {
-        exec = gko::HipExecutor::create(0, gko::OmpExecutor::create());
+        exec = gko::HipExecutor::create(0, gko::OmpExecutor::create(), true);
     } else {
         std::cerr << "Usage: " << argv[0] << " [executor]" << std::endl;
         std::exit(-1);
@@ -93,7 +93,7 @@ int main(int argc, char *argv[])
 
     // copy b again
     b->copy_from(host_x.get());
-    gko::size_type max_iters= 10000u; 
+    gko::size_type max_iters = 10000u;
     gko::remove_complex<ValueType> outer_reduction_factor = 1e-12;
     auto iter_stop =
         gko::stop::Iteration::build().with_max_iters(max_iters).on(exec);

--- a/examples/minimal-cuda-solver/minimal-cuda-solver.cpp
+++ b/examples/minimal-cuda-solver/minimal-cuda-solver.cpp
@@ -36,7 +36,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 int main()
 {
     // Instantiate a CUDA executor
-    auto gpu = gko::CudaExecutor::create(0, gko::OmpExecutor::create());
+    auto gpu = gko::CudaExecutor::create(0, gko::OmpExecutor::create(), true);
     // Read data
     auto A = gko::read<gko::matrix::Csr<>>(std::cin, gpu);
     auto b = gko::read<gko::matrix::Dense<>>(std::cin, gpu);

--- a/examples/mixed-precision-ir/mixed-precision-ir.cpp
+++ b/examples/mixed-precision-ir/mixed-precision-ir.cpp
@@ -68,10 +68,10 @@ int main(int argc, char *argv[])
         exec = gko::OmpExecutor::create();
     } else if (argc == 2 && std::string(argv[1]) == "cuda" &&
                gko::CudaExecutor::get_num_devices() > 0) {
-        exec = gko::CudaExecutor::create(0, gko::OmpExecutor::create());
+        exec = gko::CudaExecutor::create(0, gko::OmpExecutor::create(), true);
     } else if (argc == 2 && std::string(argv[1]) == "hip" &&
                gko::HipExecutor::get_num_devices() > 0) {
-        exec = gko::HipExecutor::create(0, gko::OmpExecutor::create());
+        exec = gko::HipExecutor::create(0, gko::OmpExecutor::create(), true);
     } else {
         std::cerr << "Usage: " << argv[0] << " [executor]" << std::endl;
         std::exit(-1);

--- a/examples/nine-pt-stencil-solver/nine-pt-stencil-solver.cpp
+++ b/examples/nine-pt-stencil-solver/nine-pt-stencil-solver.cpp
@@ -228,8 +228,8 @@ void solve_system(const std::string &executor_string,
     const auto omp = gko::OmpExecutor::create();
     std::map<std::string, std::shared_ptr<gko::Executor>> exec_map{
         {"omp", omp},
-        {"cuda", gko::CudaExecutor::create(0, omp)},
-        {"hip", gko::HipExecutor::create(0, omp)},
+        {"cuda", gko::CudaExecutor::create(0, omp, true)},
+        {"hip", gko::HipExecutor::create(0, omp, true)},
         {"reference", gko::ReferenceExecutor::create()}};
     // executor where Ginkgo will perform the computation
     const auto exec = exec_map.at(executor_string);  // throws if not valid

--- a/examples/papi-logging/papi-logging.cpp
+++ b/examples/papi-logging/papi-logging.cpp
@@ -144,10 +144,10 @@ int main(int argc, char *argv[])
         exec = gko::OmpExecutor::create();
     } else if (argc == 2 && std::string(argv[1]) == "cuda" &&
                gko::CudaExecutor::get_num_devices() > 0) {
-        exec = gko::CudaExecutor::create(0, gko::OmpExecutor::create());
+        exec = gko::CudaExecutor::create(0, gko::OmpExecutor::create(), true);
     } else if (argc == 2 && std::string(argv[1]) == "hip" &&
                gko::HipExecutor::get_num_devices() > 0) {
-        exec = gko::HipExecutor::create(0, gko::OmpExecutor::create());
+        exec = gko::HipExecutor::create(0, gko::OmpExecutor::create(), true);
     } else {
         std::cerr << "Usage: " << argv[0] << " [executor]" << std::endl;
         std::exit(-1);

--- a/examples/performance-debugging/performance-debugging.cpp
+++ b/examples/performance-debugging/performance-debugging.cpp
@@ -372,7 +372,7 @@ int main(int argc, char *argv[])
         exec = gko::OmpExecutor::create();
     } else if (argc > 1 && std::string(argv[1]) == "cuda" &&
                gko::CudaExecutor::get_num_devices() > 0) {
-        exec = gko::CudaExecutor::create(0, gko::OmpExecutor::create());
+        exec = gko::CudaExecutor::create(0, gko::OmpExecutor::create(), true);
     } else {
         print_usage(argv[0]);
     }

--- a/examples/poisson-solver/poisson-solver.cpp
+++ b/examples/poisson-solver/poisson-solver.cpp
@@ -137,8 +137,8 @@ int main(int argc, char *argv[])
     const auto omp = gko::OmpExecutor::create();
     std::map<std::string, std::shared_ptr<gko::Executor>> exec_map{
         {"omp", omp},
-        {"cuda", gko::CudaExecutor::create(0, omp)},
-        {"hip", gko::HipExecutor::create(0, omp)},
+        {"cuda", gko::CudaExecutor::create(0, omp, true)},
+        {"hip", gko::HipExecutor::create(0, omp, true)},
         {"reference", gko::ReferenceExecutor::create()}};
 
     // executor where Ginkgo will perform the computation

--- a/examples/preconditioned-solver/preconditioned-solver.cpp
+++ b/examples/preconditioned-solver/preconditioned-solver.cpp
@@ -61,10 +61,10 @@ int main(int argc, char *argv[])
         exec = gko::OmpExecutor::create();
     } else if (argc == 2 && std::string(argv[1]) == "cuda" &&
                gko::CudaExecutor::get_num_devices() > 0) {
-        exec = gko::CudaExecutor::create(0, gko::OmpExecutor::create());
+        exec = gko::CudaExecutor::create(0, gko::OmpExecutor::create(), true);
     } else if (argc == 2 && std::string(argv[1]) == "hip" &&
                gko::HipExecutor::get_num_devices() > 0) {
-        exec = gko::HipExecutor::create(0, gko::OmpExecutor::create());
+        exec = gko::HipExecutor::create(0, gko::OmpExecutor::create(), true);
     } else {
         std::cerr << "Usage: " << argv[0] << " [executor]" << std::endl;
         std::exit(-1);

--- a/examples/simple-solver-logging/simple-solver-logging.cpp
+++ b/examples/simple-solver-logging/simple-solver-logging.cpp
@@ -78,10 +78,10 @@ int main(int argc, char *argv[])
         exec = gko::OmpExecutor::create();
     } else if (argc == 2 && std::string(argv[1]) == "cuda" &&
                gko::CudaExecutor::get_num_devices() > 0) {
-        exec = gko::CudaExecutor::create(0, gko::OmpExecutor::create());
+        exec = gko::CudaExecutor::create(0, gko::OmpExecutor::create(), true);
     } else if (argc == 2 && std::string(argv[1]) == "hip" &&
                gko::HipExecutor::get_num_devices() > 0) {
-        exec = gko::HipExecutor::create(0, gko::OmpExecutor::create());
+        exec = gko::HipExecutor::create(0, gko::OmpExecutor::create(), true);
     } else {
         std::cerr << "Usage: " << argv[0] << " [executor]" << std::endl;
         std::exit(-1);

--- a/examples/simple-solver/simple-solver.cpp
+++ b/examples/simple-solver/simple-solver.cpp
@@ -80,10 +80,10 @@ int main(int argc, char *argv[])
         exec = gko::OmpExecutor::create();
     } else if (argc == 2 && std::string(argv[1]) == "cuda" &&
                gko::CudaExecutor::get_num_devices() > 0) {
-        exec = gko::CudaExecutor::create(0, gko::OmpExecutor::create());
+        exec = gko::CudaExecutor::create(0, gko::OmpExecutor::create(), true);
     } else if (argc == 2 && std::string(argv[1]) == "hip" &&
                gko::HipExecutor::get_num_devices() > 0) {
-        exec = gko::HipExecutor::create(0, gko::OmpExecutor::create());
+        exec = gko::HipExecutor::create(0, gko::OmpExecutor::create(), true);
     } else {
         std::cerr << "Usage: " << argv[0] << " [executor]" << std::endl;
         std::exit(-1);

--- a/examples/three-pt-stencil-solver/three-pt-stencil-solver.cpp
+++ b/examples/three-pt-stencil-solver/three-pt-stencil-solver.cpp
@@ -163,8 +163,8 @@ void solve_system(const std::string &executor_string,
     const auto omp = gko::OmpExecutor::create();
     std::map<std::string, std::shared_ptr<gko::Executor>> exec_map{
         {"omp", omp},
-        {"cuda", gko::CudaExecutor::create(0, omp)},
-        {"hip", gko::HipExecutor::create(0, omp)},
+        {"cuda", gko::CudaExecutor::create(0, omp, true)},
+        {"hip", gko::HipExecutor::create(0, omp, true)},
         {"reference", gko::ReferenceExecutor::create()}};
     // executor where Ginkgo will perform the computation
     const auto exec = exec_map.at(executor_string);  // throws if not valid

--- a/examples/twentyseven-pt-stencil-solver/twentyseven-pt-stencil-solver.cpp
+++ b/examples/twentyseven-pt-stencil-solver/twentyseven-pt-stencil-solver.cpp
@@ -283,8 +283,8 @@ void solve_system(const std::string &executor_string,
     const auto omp = gko::OmpExecutor::create();
     std::map<std::string, std::shared_ptr<gko::Executor>> exec_map{
         {"omp", omp},
-        {"cuda", gko::CudaExecutor::create(0, omp)},
-        {"hip", gko::HipExecutor::create(0, omp)},
+        {"cuda", gko::CudaExecutor::create(0, omp, true)},
+        {"hip", gko::HipExecutor::create(0, omp, true)},
         {"reference", gko::ReferenceExecutor::create()}};
     // executor where Ginkgo will perform the computation
     const auto exec = exec_map.at(executor_string);  // throws if not valid

--- a/hip/base/executor.hip.cpp
+++ b/hip/base/executor.hip.cpp
@@ -56,13 +56,14 @@ namespace gko {
 
 
 std::shared_ptr<HipExecutor> HipExecutor::create(
-    int device_id, std::shared_ptr<Executor> master)
+    int device_id, std::shared_ptr<Executor> master, bool device_reset)
 {
     return std::shared_ptr<HipExecutor>(
-        new HipExecutor(device_id, std::move(master)),
+        new HipExecutor(device_id, std::move(master), device_reset),
         [device_id](HipExecutor *exec) {
             delete exec;
-            if (!HipExecutor::get_num_execs(device_id)) {
+            if (!HipExecutor::get_num_execs(device_id) &&
+                exec->get_device_reset()) {
                 hip::device_guard g(device_id);
                 hipDeviceReset();
             }

--- a/hip/test/utils.hip.hpp
+++ b/hip/test/utils.hip.hpp
@@ -45,7 +45,7 @@ namespace {
 
 // prevent device reset after each test
 auto no_reset_exec =
-    gko::HipExecutor::create(0, gko::ReferenceExecutor::create());
+    gko::HipExecutor::create(0, gko::ReferenceExecutor::create(), true);
 
 
 }  // namespace

--- a/include/ginkgo/core/base/executor.hpp
+++ b/include/ginkgo/core/base/executor.hpp
@@ -785,7 +785,10 @@ private:
 
 /**
  * Controls whether the DeviceReset function should be called thanks to a
- * boolean.
+ * boolean. Note that in any case, `DeviceReset` is called only after destroying
+ * the last Ginkgo executor. Therefore, it is sufficient to set this flag to the
+ * last living executor in Ginkgo. Setting this flag to an executor which is not
+ * destroyed last has no effect.
  */
 class EnableDeviceReset {
 public:

--- a/include/ginkgo/core/base/executor.hpp
+++ b/include/ginkgo/core/base/executor.hpp
@@ -783,6 +783,40 @@ private:
 };
 
 
+/**
+ * Controls whether the DeviceReset function should be called thanks to a
+ * boolean.
+ */
+class EnableDeviceReset {
+public:
+    /**
+     * Set the device reset capability.
+     *
+     * @param device_reset  whether to allow a device reset or not
+     */
+    void set_device_reset(bool device_reset) { device_reset_ = device_reset; }
+
+    /**
+     * Returns the current status of the device reset boolean for this executor.
+     *
+     * @return the current status of the device reset boolean for this executor.
+     */
+    bool get_device_reset() { return device_reset_; }
+
+protected:
+    /**
+     * Instantiate an EnableDeviceReset class
+     *
+     * @param device_reset  the starting device_reset status. Defaults to false.
+     */
+    EnableDeviceReset(bool device_reset = false) : device_reset_{device_reset}
+    {}
+
+private:
+    bool device_reset_{};
+};
+
+
 }  // namespace detail
 
 
@@ -876,7 +910,8 @@ using DefaultExecutor = ReferenceExecutor;
  * @ingroup Executor
  */
 class CudaExecutor : public detail::ExecutorBase<CudaExecutor>,
-                     public std::enable_shared_from_this<CudaExecutor> {
+                     public std::enable_shared_from_this<CudaExecutor>,
+                     public detail::EnableDeviceReset {
     friend class detail::ExecutorBase<CudaExecutor>;
 
 public:
@@ -888,7 +923,8 @@ public:
      * kernels
      */
     static std::shared_ptr<CudaExecutor> create(
-        int device_id, std::shared_ptr<Executor> master);
+        int device_id, std::shared_ptr<Executor> master,
+        bool device_reset = false);
 
     ~CudaExecutor() { decrease_num_execs(this->device_id_); }
 
@@ -965,8 +1001,10 @@ protected:
 
     void init_handles();
 
-    CudaExecutor(int device_id, std::shared_ptr<Executor> master)
-        : device_id_(device_id),
+    CudaExecutor(int device_id, std::shared_ptr<Executor> master,
+                 bool device_reset = false)
+        : EnableDeviceReset{device_reset},
+          device_id_(device_id),
           master_(master),
           num_warps_per_sm_(0),
           num_multiprocessor_(0),
@@ -1038,7 +1076,8 @@ using DefaultExecutor = CudaExecutor;
  * @ingroup Executor
  */
 class HipExecutor : public detail::ExecutorBase<HipExecutor>,
-                    public std::enable_shared_from_this<HipExecutor> {
+                    public std::enable_shared_from_this<HipExecutor>,
+                    public detail::EnableDeviceReset {
     friend class detail::ExecutorBase<HipExecutor>;
 
 public:
@@ -1049,8 +1088,9 @@ public:
      * @param master  an executor on the host that is used to invoke the device
      *                kernels
      */
-    static std::shared_ptr<HipExecutor> create(
-        int device_id, std::shared_ptr<Executor> master);
+    static std::shared_ptr<HipExecutor> create(int device_id,
+                                               std::shared_ptr<Executor> master,
+                                               bool device_reset = false);
 
     ~HipExecutor() { decrease_num_execs(this->device_id_); }
 
@@ -1127,8 +1167,10 @@ protected:
 
     void init_handles();
 
-    HipExecutor(int device_id, std::shared_ptr<Executor> master)
-        : device_id_(device_id),
+    HipExecutor(int device_id, std::shared_ptr<Executor> master,
+                bool device_reset = false)
+        : EnableDeviceReset{device_reset},
+          device_id_(device_id),
           master_(master),
           num_multiprocessor_(0),
           num_warps_per_sm_(0),


### PR DESCRIPTION
To fix this problem, an optional boolean class is added which controls
whether to reset or not the device controlled by the executor. By 
default, the device is not reset.

All examples, benchmarks and the last executors from the tests are
modified to pass the correct value to reset the device after use. This
ensures that our CI tools and users can keep tracking memory leaks
internally.

Fixes #461