### PR TITLE
Fix the automatical strategy when shared.

### DIFF
--- a/core/test/matrix/csr_builder.cpp
+++ b/core/test/matrix/csr_builder.cpp
@@ -90,11 +90,15 @@ TYPED_TEST(CsrBuilder, UpdatesSrowOnDestruction)
     using index_type = typename TestFixture::index_type;
     struct mock_strategy : public Mtx::strategy_type {
         virtual void process(const gko::Array<index_type> &,
-                             gko::Array<index_type> *)
+                             gko::Array<index_type> *) override
         {
             *was_called = true;
         }
-        virtual int64_t clac_size(const int64_t nnz) { return 0; }
+        virtual int64_t clac_size(const int64_t nnz) override { return 0; }
+        virtual std::shared_ptr<typename Mtx::strategy_type> copy() override
+        {
+            return std::make_shared<mock_strategy>(*was_called);
+        }
 
         mock_strategy(bool &flag) : Mtx::strategy_type(""), was_called(&flag) {}
 

--- a/core/test/matrix/csr_builder.cpp
+++ b/core/test/matrix/csr_builder.cpp
@@ -94,7 +94,9 @@ TYPED_TEST(CsrBuilder, UpdatesSrowOnDestruction)
         {
             *was_called = true;
         }
+
         virtual int64_t clac_size(const int64_t nnz) override { return 0; }
+
         virtual std::shared_ptr<typename Mtx::strategy_type> copy() override
         {
             return std::make_shared<mock_strategy>(*was_called);

--- a/cuda/test/matrix/csr_kernels.cpp
+++ b/cuda/test/matrix/csr_kernels.cpp
@@ -676,4 +676,29 @@ TEST_F(Csr, SortUnsortedMatrixIsEquivalentToRef)
 }
 
 
+TEST_F(Csr, OneAutomaticalWorksWithDifferentMatrices)
+{
+    auto automatical = std::make_shared<Mtx::automatical>();
+    auto row_len_limit = std::max(automatical->nvidia_row_len_limit,
+                                  automatical->amd_row_len_limit);
+    auto load_balance_mtx = Mtx::create(ref);
+    auto classical_mtx = Mtx::create(ref);
+    load_balance_mtx->copy_from(
+        gen_mtx<Vec>(1, row_len_limit + 1000, row_len_limit + 1));
+    classical_mtx->copy_from(gen_mtx<Vec>(50, 50, 1));
+    auto load_balance_mtx_d = Mtx::create(cuda);
+    auto classical_mtx_d = Mtx::create(cuda);
+    load_balance_mtx_d->copy_from(load_balance_mtx.get());
+    classical_mtx_d->copy_from(classical_mtx.get());
+
+    load_balance_mtx_d->set_strategy(automatical);
+    classical_mtx_d->set_strategy(automatical);
+
+    EXPECT_EQ("load_balance", load_balance_mtx_d->get_strategy()->get_name());
+    EXPECT_EQ("classical", classical_mtx_d->get_strategy()->get_name());
+    ASSERT_NE(load_balance_mtx_d->get_strategy().get(),
+              classical_mtx_d->get_strategy().get());
+}
+
+
 }  // namespace

--- a/doc/helpers.cmake
+++ b/doc/helpers.cmake
@@ -101,7 +101,7 @@ function(ginkgo_doc_gen name in pdf mainpage-in)
         ${doxygen_base_input}
         )
     # pick some markdown files we want as pages
-    set(doxygen_markdown_files "../../INSTALL.md ../../TESTING.md ../../BENCHMARKING.md")
+    set(doxygen_markdown_files "../../INSTALL.md ../../TESTING.md ../../BENCHMARKING.md ../../CONTRIBUTING.md")
     ginkgo_to_string(doxygen_base_input_str ${doxygen_base_input} )
     ginkgo_to_string(doxygen_dev_input_str ${doxygen_dev_input} )
     ginkgo_to_string(doxygen_image_path_str ${doxygen_image_path} )

--- a/hip/test/matrix/csr_kernels.hip.cpp
+++ b/hip/test/matrix/csr_kernels.hip.cpp
@@ -652,7 +652,7 @@ TEST_F(Csr, SortUnsortedMatrixIsEquivalentToRef)
 
 TEST_F(Csr, OneAutomaticalWorksWithDifferentMatrices)
 {
-    auto automatical = std::make_shared<Mtx::automatical>();
+    auto automatical = std::make_shared<Mtx::automatical>(hip);
     auto row_len_limit = std::max(automatical->nvidia_row_len_limit,
                                   automatical->amd_row_len_limit);
     auto load_balance_mtx = Mtx::create(ref);

--- a/hip/test/matrix/csr_kernels.hip.cpp
+++ b/hip/test/matrix/csr_kernels.hip.cpp
@@ -650,4 +650,29 @@ TEST_F(Csr, SortUnsortedMatrixIsEquivalentToRef)
 }
 
 
+TEST_F(Csr, OneAutomaticalWorksWithDifferentMatrices)
+{
+    auto automatical = std::make_shared<Mtx::automatical>();
+    auto row_len_limit = std::max(automatical->nvidia_row_len_limit,
+                                  automatical->amd_row_len_limit);
+    auto load_balance_mtx = Mtx::create(ref);
+    auto classical_mtx = Mtx::create(ref);
+    load_balance_mtx->copy_from(
+        gen_mtx<Vec>(1, row_len_limit + 1000, row_len_limit + 1));
+    classical_mtx->copy_from(gen_mtx<Vec>(50, 50, 1));
+    auto load_balance_mtx_d = Mtx::create(hip);
+    auto classical_mtx_d = Mtx::create(hip);
+    load_balance_mtx_d->copy_from(load_balance_mtx.get());
+    classical_mtx_d->copy_from(classical_mtx.get());
+
+    load_balance_mtx_d->set_strategy(automatical);
+    classical_mtx_d->set_strategy(automatical);
+
+    EXPECT_EQ("load_balance", load_balance_mtx_d->get_strategy()->get_name());
+    EXPECT_EQ("classical", classical_mtx_d->get_strategy()->get_name());
+    ASSERT_NE(load_balance_mtx_d->get_strategy().get(),
+              classical_mtx_d->get_strategy().get());
+}
+
+
 }  // namespace

--- a/include/ginkgo/core/matrix/csr.hpp
+++ b/include/ginkgo/core/matrix/csr.hpp
@@ -602,6 +602,7 @@ public:
         result->col_idxs_ = this->col_idxs_;
         result->row_ptrs_ = this->row_ptrs_;
         result->srow_ = this->srow_;
+        result->set_size(this->get_size());
         result->set_strategy(std::move(this->get_strategy()->copy()));
         // END NOTE
     }
@@ -822,7 +823,7 @@ protected:
           col_idxs_(exec, num_nonzeros),
           row_ptrs_(exec, size[0] + 1),
           srow_(exec, strategy->clac_size(num_nonzeros)),
-          strategy_(std::move(strategy->copy()))
+          strategy_(strategy->copy())
     {}
 
     /**
@@ -855,7 +856,7 @@ protected:
           col_idxs_{exec, std::forward<ColIdxsArray>(col_idxs)},
           row_ptrs_{exec, std::forward<RowPtrsArray>(row_ptrs)},
           srow_(exec),
-          strategy_(std::move(strategy->copy()))
+          strategy_(strategy->copy())
     {
         GKO_ASSERT_EQ(values_.get_num_elems(), col_idxs_.get_num_elems());
         GKO_ASSERT_EQ(this->get_size()[0] + 1, row_ptrs_.get_num_elems());

--- a/reference/test/factorization/par_ict_kernels.cpp
+++ b/reference/test/factorization/par_ict_kernels.cpp
@@ -270,9 +270,11 @@ TYPED_TEST(ParIct, SetStrategies)
     auto fact = factory->generate(this->mtx_system);
 
     ASSERT_EQ(factory->get_parameters().l_strategy, l_strategy);
-    ASSERT_EQ(fact->get_l_factor()->get_strategy(), l_strategy);
+    ASSERT_EQ(fact->get_l_factor()->get_strategy()->get_name(),
+              l_strategy->get_name());
     ASSERT_EQ(factory->get_parameters().lt_strategy, lt_strategy);
-    ASSERT_EQ(fact->get_lt_factor()->get_strategy(), lt_strategy);
+    ASSERT_EQ(fact->get_lt_factor()->get_strategy()->get_name(),
+              lt_strategy->get_name());
 }
 
 

--- a/reference/test/factorization/par_ilu_kernels.cpp
+++ b/reference/test/factorization/par_ilu_kernels.cpp
@@ -477,14 +477,15 @@ TYPED_TEST(ParIlu, SetLStrategy)
 {
     using Csr = typename TestFixture::Csr;
     using par_ilu_type = typename TestFixture::par_ilu_type;
-    auto l_strategy = std::make_shared<typename Csr::automatical>(0, 0);
+    auto l_strategy = std::make_shared<typename Csr::classical>();
 
     auto factory =
         par_ilu_type::build().with_l_strategy(l_strategy).on(this->ref);
     auto par_ilu = factory->generate(this->mtx_small);
 
     ASSERT_EQ(factory->get_parameters().l_strategy, l_strategy);
-    ASSERT_EQ(par_ilu->get_l_factor()->get_strategy(), l_strategy);
+    ASSERT_EQ(par_ilu->get_l_factor()->get_strategy()->get_name(),
+              l_strategy->get_name());
 }
 
 
@@ -499,7 +500,8 @@ TYPED_TEST(ParIlu, SetUStrategy)
     auto par_ilu = factory->generate(this->mtx_small);
 
     ASSERT_EQ(factory->get_parameters().u_strategy, u_strategy);
-    ASSERT_EQ(par_ilu->get_u_factor()->get_strategy(), u_strategy);
+    ASSERT_EQ(par_ilu->get_u_factor()->get_strategy()->get_name(),
+              u_strategy->get_name());
 }
 
 

--- a/reference/test/factorization/par_ilut_kernels.cpp
+++ b/reference/test/factorization/par_ilut_kernels.cpp
@@ -545,9 +545,11 @@ TYPED_TEST(ParIlut, SetStrategies)
     auto fact = factory->generate(this->mtx_system);
 
     ASSERT_EQ(factory->get_parameters().l_strategy, l_strategy);
-    ASSERT_EQ(fact->get_l_factor()->get_strategy(), l_strategy);
+    ASSERT_EQ(fact->get_l_factor()->get_strategy()->get_name(),
+              l_strategy->get_name());
     ASSERT_EQ(factory->get_parameters().u_strategy, u_strategy);
-    ASSERT_EQ(fact->get_u_factor()->get_strategy(), u_strategy);
+    ASSERT_EQ(fact->get_u_factor()->get_strategy()->get_name(),
+              u_strategy->get_name());
 }
 
 

--- a/reference/test/matrix/coo_kernels.cpp
+++ b/reference/test/matrix/coo_kernels.cpp
@@ -155,8 +155,8 @@ TYPED_TEST(Coo, ConvertsToCsr)
 
     this->assert_equal_to_mtx_in_csr_format(csr_mtx_c.get());
     this->assert_equal_to_mtx_in_csr_format(csr_mtx_m.get());
-    ASSERT_EQ(csr_mtx_c->get_strategy(), csr_s_classical);
-    ASSERT_EQ(csr_mtx_m->get_strategy(), csr_s_merge);
+    ASSERT_EQ(csr_mtx_c->get_strategy()->get_name(), "classical");
+    ASSERT_EQ(csr_mtx_m->get_strategy()->get_name(), "merge_path");
 }
 
 
@@ -176,8 +176,8 @@ TYPED_TEST(Coo, MovesToCsr)
 
     this->assert_equal_to_mtx_in_csr_format(csr_mtx_c.get());
     this->assert_equal_to_mtx_in_csr_format(csr_mtx_m.get());
-    ASSERT_EQ(csr_mtx_c->get_strategy(), csr_s_classical);
-    ASSERT_EQ(csr_mtx_m->get_strategy(), csr_s_merge);
+    ASSERT_EQ(csr_mtx_c->get_strategy()->get_name(), "classical");
+    ASSERT_EQ(csr_mtx_m->get_strategy()->get_name(), "merge_path");
 }
 
 

--- a/reference/test/matrix/dense_kernels.cpp
+++ b/reference/test/matrix/dense_kernels.cpp
@@ -487,9 +487,9 @@ TYPED_TEST(Dense, ConvertsToCsr32)
     EXPECT_EQ(v[1], T{3.0});
     EXPECT_EQ(v[2], T{2.0});
     EXPECT_EQ(v[3], T{5.0});
-    ASSERT_EQ(csr_mtx_c->get_strategy(), csr_s_classical);
+    ASSERT_EQ(csr_mtx_c->get_strategy()->get_name(), "classical");
     GKO_ASSERT_MTX_NEAR(csr_mtx_c.get(), csr_mtx_m.get(), 0.0);
-    ASSERT_EQ(csr_mtx_m->get_strategy(), csr_s_merge);
+    ASSERT_EQ(csr_mtx_m->get_strategy()->get_name(), "merge_path");
 }
 
 
@@ -522,9 +522,9 @@ TYPED_TEST(Dense, MovesToCsr32)
     EXPECT_EQ(v[1], T{3.0});
     EXPECT_EQ(v[2], T{2.0});
     EXPECT_EQ(v[3], T{5.0});
-    ASSERT_EQ(csr_mtx_c->get_strategy(), csr_s_classical);
+    ASSERT_EQ(csr_mtx_c->get_strategy()->get_name(), "classical");
     GKO_ASSERT_MTX_NEAR(csr_mtx_c.get(), csr_mtx_m.get(), 0.0);
-    ASSERT_EQ(csr_mtx_m->get_strategy(), csr_s_merge);
+    ASSERT_EQ(csr_mtx_m->get_strategy()->get_name(), "merge_path");
 }
 
 
@@ -556,9 +556,9 @@ TYPED_TEST(Dense, ConvertsToCsr64)
     EXPECT_EQ(v[1], T{3.0});
     EXPECT_EQ(v[2], T{2.0});
     EXPECT_EQ(v[3], T{5.0});
-    ASSERT_EQ(csr_mtx_c->get_strategy(), csr_s_classical);
+    ASSERT_EQ(csr_mtx_c->get_strategy()->get_name(), "classical");
     GKO_ASSERT_MTX_NEAR(csr_mtx_c.get(), csr_mtx_m.get(), 0.0);
-    ASSERT_EQ(csr_mtx_m->get_strategy(), csr_s_merge);
+    ASSERT_EQ(csr_mtx_m->get_strategy()->get_name(), "merge_path");
 }
 
 
@@ -591,9 +591,9 @@ TYPED_TEST(Dense, MovesToCsr64)
     EXPECT_EQ(v[1], T{3.0});
     EXPECT_EQ(v[2], T{2.0});
     EXPECT_EQ(v[3], T{5.0});
-    ASSERT_EQ(csr_mtx_c->get_strategy(), csr_s_classical);
+    ASSERT_EQ(csr_mtx_c->get_strategy()->get_name(), "classical");
     GKO_ASSERT_MTX_NEAR(csr_mtx_c.get(), csr_mtx_m.get(), 0.0);
-    ASSERT_EQ(csr_mtx_m->get_strategy(), csr_s_merge);
+    ASSERT_EQ(csr_mtx_m->get_strategy()->get_name(), "merge_path");
 }
 
 

--- a/reference/test/matrix/ell_kernels.cpp
+++ b/reference/test/matrix/ell_kernels.cpp
@@ -436,8 +436,8 @@ TYPED_TEST(Ell, ConvertsToCsr)
 
     this->assert_equal_to_mtx(csr_mtx_c.get());
     this->assert_equal_to_mtx(csr_mtx_m.get());
-    ASSERT_EQ(csr_mtx_c->get_strategy(), csr_s_classical);
-    ASSERT_EQ(csr_mtx_m->get_strategy(), csr_s_merge);
+    ASSERT_EQ(csr_mtx_c->get_strategy()->get_name(), "classical");
+    ASSERT_EQ(csr_mtx_m->get_strategy()->get_name(), "merge_path");
 }
 
 
@@ -455,8 +455,8 @@ TYPED_TEST(Ell, MovesToCsr)
 
     this->assert_equal_to_mtx(csr_mtx_c.get());
     this->assert_equal_to_mtx(csr_mtx_m.get());
-    ASSERT_EQ(csr_mtx_c->get_strategy(), csr_s_classical);
-    ASSERT_EQ(csr_mtx_m->get_strategy(), csr_s_merge);
+    ASSERT_EQ(csr_mtx_c->get_strategy()->get_name(), "classical");
+    ASSERT_EQ(csr_mtx_m->get_strategy()->get_name(), "merge_path");
 }
 
 
@@ -475,8 +475,8 @@ TYPED_TEST(Ell, ConvertsWithStrideToCsr)
 
     this->assert_equal_to_mtx(csr_mtx_c.get());
     this->assert_equal_to_mtx(csr_mtx_m.get());
-    ASSERT_EQ(csr_mtx_c->get_strategy(), csr_s_classical);
-    ASSERT_EQ(csr_mtx_m->get_strategy(), csr_s_merge);
+    ASSERT_EQ(csr_mtx_c->get_strategy()->get_name(), "classical");
+    ASSERT_EQ(csr_mtx_m->get_strategy()->get_name(), "merge_path");
 }
 
 
@@ -495,8 +495,8 @@ TYPED_TEST(Ell, MovesWithStrideToCsr)
 
     this->assert_equal_to_mtx(csr_mtx_c.get());
     this->assert_equal_to_mtx(csr_mtx_m.get());
-    ASSERT_EQ(csr_mtx_c->get_strategy(), csr_s_classical);
-    ASSERT_EQ(csr_mtx_m->get_strategy(), csr_s_merge);
+    ASSERT_EQ(csr_mtx_c->get_strategy()->get_name(), "classical");
+    ASSERT_EQ(csr_mtx_m->get_strategy()->get_name(), "merge_path");
 }
 
 

--- a/reference/test/matrix/hybrid_kernels.cpp
+++ b/reference/test/matrix/hybrid_kernels.cpp
@@ -322,8 +322,8 @@ TYPED_TEST(Hybrid, ConvertsToCsr)
 
     this->assert_equal_to_mtx(csr_mtx_c.get());
     this->assert_equal_to_mtx(csr_mtx_m.get());
-    ASSERT_EQ(csr_mtx_c->get_strategy(), csr_s_classical);
-    ASSERT_EQ(csr_mtx_m->get_strategy(), csr_s_merge);
+    ASSERT_EQ(csr_mtx_c->get_strategy()->get_name(), "classical");
+    ASSERT_EQ(csr_mtx_m->get_strategy()->get_name(), "merge_path");
 }
 
 
@@ -341,8 +341,8 @@ TYPED_TEST(Hybrid, MovesToCsr)
 
     this->assert_equal_to_mtx(csr_mtx_c.get());
     this->assert_equal_to_mtx(csr_mtx_m.get());
-    ASSERT_EQ(csr_mtx_c->get_strategy(), csr_s_classical);
-    ASSERT_EQ(csr_mtx_m->get_strategy(), csr_s_merge);
+    ASSERT_EQ(csr_mtx_c->get_strategy()->get_name(), "classical");
+    ASSERT_EQ(csr_mtx_m->get_strategy()->get_name(), "merge_path");
 }
 
 

--- a/reference/test/matrix/sellp_kernels.cpp
+++ b/reference/test/matrix/sellp_kernels.cpp
@@ -276,8 +276,8 @@ TYPED_TEST(Sellp, ConvertsToCsr)
                            {0.0, 5.0, 0.0}}), 0.0);
     // clang-format on
     GKO_ASSERT_MTX_NEAR(csr_mtx_c.get(), csr_mtx_m.get(), 0.0);
-    ASSERT_EQ(csr_mtx_c->get_strategy(), csr_s_classical);
-    ASSERT_EQ(csr_mtx_m->get_strategy(), csr_s_merge);
+    ASSERT_EQ(csr_mtx_c->get_strategy()->get_name(), "classical");
+    ASSERT_EQ(csr_mtx_m->get_strategy()->get_name(), "merge_path");
 }
 
 
@@ -299,8 +299,8 @@ TYPED_TEST(Sellp, MovesToCsr)
                            {0.0, 5.0, 0.0}}), 0.0);
     // clang-format on
     GKO_ASSERT_MTX_NEAR(csr_mtx_c.get(), csr_mtx_m.get(), 0.0);
-    ASSERT_EQ(csr_mtx_c->get_strategy(), csr_s_classical);
-    ASSERT_EQ(csr_mtx_m->get_strategy(), csr_s_merge);
+    ASSERT_EQ(csr_mtx_c->get_strategy()->get_name(), "classical");
+    ASSERT_EQ(csr_mtx_m->get_strategy()->get_name(), "merge_path");
 }
 
 


### PR DESCRIPTION
The automatical strategy has an issue when shared, it behaves as the
wrong strategy if the matrices using it have different properties.
This fixes this issue only by extending the current interface, and not
changing any existing function. All other (more elegant) approaches
I thought of would break the current interface. In effect:
+ Add a new virtual `copy` function to the strategies in order to create
  a new shared pointer polymorphically.
+ The approach used is to always copy the strategy, whenever a CSR
  matrix is instantiated or copied. Thankfully, the strategies are
  currently light objects so this should create few overhead.
+ Add tests which ensure that matrices with difference properties work
  correctly with the automatical strategy.

Fixes https://github.com/ginkgo-project/ginkgo/issues/426