### PR TITLE
Fix windows GitHub action

### DIFF
--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -10,7 +10,7 @@ jobs:
     - uses: actions/checkout@v2
     - name: setup
       run: |
-        choco install cuda -y
+        choco install cuda --version=10.2.89.20191206 -y
     - name: configure
       run: |
         $env:ChocolateyInstall = Convert-Path "$((Get-Command choco).Path)\..\.."   

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -20,7 +20,7 @@ jobs:
         cd build
         $env:PATH="$pwd\windows_shared_library;$env:PATH"
         cmake -DGINKGO_BUILD_CUDA=ON -DGINKGO_BUILD_OMP=OFF ..
-        cmake --build . -j8 --config Release
+        cmake --build . -j4 --config Release
         
   windows_ref:
     strategy:
@@ -49,7 +49,7 @@ jobs:
         mkdir build
         cd build
         cmake -DBUILD_SHARED_LIBS=${{ matrix.config.shared }} -DGINKGO_BUILD_CUDA=OFF -DGINKGO_BUILD_OMP=OFF ..
-        cmake --build . -j8 --config ${{ matrix.config.build_type }}
+        cmake --build . -j4 --config ${{ matrix.config.build_type }}
         ctest . -C ${{ matrix.config.build_type }} --output-on-failure
     - name: install_shared_env
       if: matrix.config.shared == 'ON'
@@ -85,10 +85,12 @@ jobs:
       run: |
         set PATH=%PATH:C:\Program Files\Git\bin;=%
         set PATH=%PATH:C:\Program Files\Git\usr\bin;=%
+        bcdedit /set IncreaseUserVa 3072
+        editbin /LARGEADDRESSAWARE "C:\Program Files\Git\mingw64\bin\cc1plus.exe"
         mkdir build
         cd build
         cmake -G "MinGW Makefiles" -DBUILD_SHARED_LIBS=${{ matrix.config.shared }} -DCMAKE_BUILD_TYPE=${{ matrix.config.build_type }} -DGINKGO_COMPILER_FLAGS=${{ matrix.config.cflags }} ..
-        cmake --build . -j8
+        cmake --build . -j4
         ctest . --output-on-failure
       shell: cmd
     - name: install_shared_env
@@ -135,7 +137,7 @@ jobs:
         mkdir build
         cd build
         bash -c "cmake -DBUILD_SHARED_LIBS=${{ matrix.config.shared }} -DCMAKE_BUILD_TYPE=${{ matrix.config.build_type }} -DGINKGO_COMPILER_FLAGS=${{ matrix.config.cflags }} .."
-        bash -c "make -j8"
+        bash -c "make -j4"
         bash -c "ctest . --output-on-failure"
       shell: cmd
     - name: install_shared


### PR DESCRIPTION
This PR fixes the issue of windows GitHub action

1. fix cuda version 10.2 in `Windows-build: cuda102/release/shared (only compile)`
2. enable cc1plus to use larger address space [reference](https://www.intel.com/content/www/us/en/programmable/support/support-resources/knowledge-base/embedded/2016/cc1plus-exe--out-of-memory-allocating-65536-bytes.html)
3. reduce the number of jobs

To be honest, I am not sure whether 2, 3 really help or not. 
I will rerun the workflow 2-3 times to check whether all are passed.