### PR TITLE
Fix Sonarqube warnings in examples/benchmarks

### DIFF
--- a/benchmark/matrix_statistics/matrix_statistics.cpp
+++ b/benchmark/matrix_statistics/matrix_statistics.cpp
@@ -72,18 +72,21 @@ void compute_summary(const std::vector<gko::size_type> &dist,
     // clang-format on
 
     add_or_set_member(out, "min", dist[0], allocator);
-    add_or_set_member(out, "q1",
-                      coefs[r][0] * dist[positions[r][0]] +
-                          coefs[r][1] * dist[positions[r][1]],
-                      allocator);
-    add_or_set_member(out, "median",
-                      coefs[r][2] * dist[positions[r][2]] +
-                          coefs[r][3] * dist[positions[r][3]],
-                      allocator);
-    add_or_set_member(out, "q3",
-                      coefs[r][4] * dist[positions[r][4]] +
-                          coefs[r][5] * dist[positions[r][5]],
-                      allocator);
+    add_or_set_member(
+        out, "q1",
+        coefs[r][0] * static_cast<double>(dist[positions[r][0]]) +
+            coefs[r][1] * static_cast<double>(dist[positions[r][1]]),
+        allocator);
+    add_or_set_member(
+        out, "median",
+        coefs[r][2] * static_cast<double>(dist[positions[r][2]]) +
+            coefs[r][3] * static_cast<double>(dist[positions[r][3]]),
+        allocator);
+    add_or_set_member(
+        out, "q3",
+        coefs[r][4] * static_cast<double>(dist[positions[r][4]]) +
+            coefs[r][5] * static_cast<double>(dist[positions[r][5]]),
+        allocator);
     add_or_set_member(out, "max", dist[dist.size() - 1], allocator);
 }
 
@@ -94,11 +97,12 @@ double compute_moment(int degree, const std::vector<gko::size_type> &dist,
     if (normalization == 0.0) {
         return 0.0;
     }
-    auto moment = 0.0;
+    double moment = 0.0;
     for (const auto &x : dist) {
-        moment += std::pow(x - center, degree);
+        moment += std::pow(static_cast<double>(x) - center, degree);
     }
-    return moment / dist.size() / std::pow(normalization, degree);
+    return moment / static_cast<double>(dist.size()) /
+           std::pow(normalization, static_cast<double>(degree));
 }
 
 

--- a/examples/ginkgo-overhead/ginkgo-overhead.cpp
+++ b/examples/ginkgo-overhead/ginkgo-overhead.cpp
@@ -89,8 +89,11 @@ int main(int argc, char *argv[])
     auto time = std::chrono::duration_cast<std::chrono::nanoseconds>(tac - tic);
     std::cout << "Running " << num_iters
               << " iterations of the CG solver took a total of "
-              << 1.0 * time.count() / std::nano::den << " seconds." << std::endl
+              << static_cast<double>(time.count()) /
+                     static_cast<double>(std::nano::den)
+              << " seconds." << std::endl
               << "\tAverage library overhead:     "
-              << 1.0 * time.count() / num_iters << " [nanoseconds / iteration]"
-              << std::endl;
+              << static_cast<double>(time.count()) /
+                     static_cast<double>(num_iters)
+              << " [nanoseconds / iteration]" << std::endl;
 }

--- a/examples/nine-pt-stencil-solver/nine-pt-stencil-solver.cpp
+++ b/examples/nine-pt-stencil-solver/nine-pt-stencil-solver.cpp
@@ -339,14 +339,17 @@ int main(int argc, char *argv[])
                  values.data(), rhs.data(), u.data(), reduction_factor);
     auto stop_time = std::chrono::steady_clock::now();
     auto runtime_duration =
-        std::chrono::duration_cast<std::chrono::nanoseconds>(stop_time -
-                                                             start_time)
-            .count() *
+        static_cast<double>(
+            std::chrono::duration_cast<std::chrono::nanoseconds>(stop_time -
+                                                                 start_time)
+                .count()) *
         1e-6;
 
     print_solution(dp, u.data());
     std::cout << "The average relative error is "
-              << calculate_error(dp, u.data(), correct_u) / dp_2 << std::endl;
+              << calculate_error(dp, u.data(), correct_u) /
+                     static_cast<gko::remove_complex<ValueType>>(dp_2)
+              << std::endl;
     std::cout << "The runtime is " << std::to_string(runtime_duration) << " ms"
               << std::endl;
 }

--- a/examples/poisson-solver/poisson-solver.cpp
+++ b/examples/poisson-solver/poisson-solver.cpp
@@ -69,9 +69,9 @@ void generate_rhs(Closure f, ValueType u0, ValueType u1,
 {
     const auto discretization_points = rhs->get_size()[0];
     auto values = rhs->get_values();
-    const ValueType h = 1.0 / (discretization_points + 1);
+    const ValueType h = 1.0 / static_cast<ValueType>(discretization_points + 1);
     for (gko::size_type i = 0; i < discretization_points; ++i) {
-        const auto xi = ValueType(i + 1) * h;
+        const auto xi = static_cast<ValueType>(i + 1) * h;
         values[i] = -f(xi) * h * h;
     }
     values[0] += u0;
@@ -99,11 +99,11 @@ gko::remove_complex<ValueType> calculate_error(
     int discretization_points, const gko::matrix::Dense<ValueType> *u,
     Closure correct_u)
 {
-    const ValueType h = 1.0 / (discretization_points + 1);
+    const ValueType h = 1.0 / static_cast<ValueType>(discretization_points + 1);
     auto error = 0.0;
     for (int i = 0; i < discretization_points; ++i) {
         using std::abs;
-        const auto xi = ValueType(i + 1) * h;
+        const auto xi = static_cast<ValueType>(i + 1) * h;
         error +=
             abs(u->get_const_values()[i] - correct_u(xi)) / abs(correct_u(xi));
     }
@@ -180,6 +180,7 @@ int main(int argc, char *argv[])
     print_solution<ValueType>(u0, u1, lend(u));
     std::cout << "The average relative error is "
               << calculate_error(discretization_points, lend(u), correct_u) /
-                     discretization_points
+                     static_cast<gko::remove_complex<ValueType>>(
+                         discretization_points)
               << std::endl;
 }

--- a/examples/twentyseven-pt-stencil-solver/twentyseven-pt-stencil-solver.cpp
+++ b/examples/twentyseven-pt-stencil-solver/twentyseven-pt-stencil-solver.cpp
@@ -410,14 +410,17 @@ int main(int argc, char *argv[])
     auto stop_time = std::chrono::steady_clock::now();
 
     const auto runtime_duration =
-        std::chrono::duration_cast<std::chrono::nanoseconds>(stop_time -
-                                                             start_time)
-            .count() *
+        static_cast<double>(
+            std::chrono::duration_cast<std::chrono::nanoseconds>(stop_time -
+                                                                 start_time)
+                .count()) *
         1e-6;
 
     print_solution<ValueType, IndexType>(dp, u.data());
     std::cout << "The average relative error is "
-              << calculate_error(dp, u.data(), correct_u) / dp_3 << std::endl;
+              << calculate_error(dp, u.data(), correct_u) /
+                     static_cast<gko::remove_complex<ValueType>>(dp_3)
+              << std::endl;
 
     std::cout << "The runtime is " << std::to_string(runtime_duration) << " ms"
               << std::endl;


### PR DESCRIPTION
We currently have a rather bad reliability rating again, probably due to some upstream changes in Sonarqube. This PR fixes [the reported "bugs"](https://sonarcloud.io/project/issues?id=ginkgo-project_ginkgo&resolved=false&types=BUG).