### PR TITLE
add relaxation in IR to represent Richardson iteration

### DIFF
--- a/core/solver/ir.cpp
+++ b/core/solver/ir.cpp
@@ -57,7 +57,7 @@ std::unique_ptr<LinOp> Ir<ValueType>::transpose() const
         .with_generated_solver(
             share(as<Transposable>(this->get_solver())->transpose()))
         .with_criteria(this->stop_criterion_factory_)
-        .with_relaxation(parameters_.relaxation)
+        .with_relaxation_factor(parameters_.relaxation_factor)
         .on(this->get_executor())
         ->generate(
             share(as<Transposable>(this->get_system_matrix())->transpose()));
@@ -71,7 +71,7 @@ std::unique_ptr<LinOp> Ir<ValueType>::conj_transpose() const
         .with_generated_solver(
             share(as<Transposable>(this->get_solver())->conj_transpose()))
         .with_criteria(this->stop_criterion_factory_)
-        .with_relaxation(conj(parameters_.relaxation))
+        .with_relaxation_factor(conj(parameters_.relaxation_factor))
         .on(this->get_executor())
         ->generate(share(
             as<Transposable>(this->get_system_matrix())->conj_transpose()));
@@ -127,17 +127,17 @@ void Ir<ValueType>::apply_impl(const LinOp *b, LinOp *x) const
             inner_solution->copy_from(lend(residual));
             solver_->apply(lend(residual), lend(inner_solution));
 
-            // x = x + relaxtion * inner_solution
-            dense_x->add_scaled(lend(relaxation_), lend(inner_solution));
+            // x = x + relaxation_factor * inner_solution
+            dense_x->add_scaled(lend(relaxation_factor_), lend(inner_solution));
 
             // residual = b - A * x
             residual->copy_from(dense_b);
             system_matrix_->apply(lend(neg_one_op), dense_x, lend(one_op),
                                   lend(residual));
         } else {
-            // x = x + relaxation * A \ residual
-            solver_->apply(lend(relaxation_), lend(residual), lend(one_op),
-                           dense_x);
+            // x = x + relaxation_factor * A \ residual
+            solver_->apply(lend(relaxation_factor_), lend(residual),
+                           lend(one_op), dense_x);
 
             // residual = b - A * x
             residual->copy_from(dense_b);

--- a/core/test/solver/ir.cpp
+++ b/core/test/solver/ir.cpp
@@ -319,10 +319,10 @@ TYPED_TEST(Ir, ThrowOnWrongInnerSolverSet)
 }
 
 
-TYPED_TEST(Ir, UseAsRichardson)
+TYPED_TEST(Ir, DefaultRelaxationFactor)
 {
     using value_type = typename TestFixture::value_type;
-    const value_type relaxation{0.5};
+    const value_type relaxation_factor{0.5};
 
     auto richardson =
         gko::solver::Richardson<value_type>::build()
@@ -331,11 +331,30 @@ TYPED_TEST(Ir, UseAsRichardson)
                 gko::stop::ResidualNormReduction<value_type>::build()
                     .with_reduction_factor(r<value_type>::value)
                     .on(this->exec))
-            .with_relaxation(relaxation)
             .on(this->exec)
             ->generate(this->mtx);
 
-    ASSERT_EQ(richardson->get_parameters().relaxation, value_type{0.5});
+    ASSERT_EQ(richardson->get_parameters().relaxation_factor, value_type{1});
+}
+
+
+TYPED_TEST(Ir, UseAsRichardson)
+{
+    using value_type = typename TestFixture::value_type;
+    const value_type relaxation_factor{0.5};
+
+    auto richardson =
+        gko::solver::Richardson<value_type>::build()
+            .with_criteria(
+                gko::stop::Iteration::build().with_max_iters(3u).on(this->exec),
+                gko::stop::ResidualNormReduction<value_type>::build()
+                    .with_reduction_factor(r<value_type>::value)
+                    .on(this->exec))
+            .with_relaxation_factor(relaxation_factor)
+            .on(this->exec)
+            ->generate(this->mtx);
+
+    ASSERT_EQ(richardson->get_parameters().relaxation_factor, value_type{0.5});
 }
 
 

--- a/core/test/solver/ir.cpp
+++ b/core/test/solver/ir.cpp
@@ -319,4 +319,24 @@ TYPED_TEST(Ir, ThrowOnWrongInnerSolverSet)
 }
 
 
+TYPED_TEST(Ir, UseAsRichardson)
+{
+    using value_type = typename TestFixture::value_type;
+    const value_type relaxation{0.5};
+
+    auto richardson =
+        gko::solver::Richardson<value_type>::build()
+            .with_criteria(
+                gko::stop::Iteration::build().with_max_iters(3u).on(this->exec),
+                gko::stop::ResidualNormReduction<value_type>::build()
+                    .with_reduction_factor(r<value_type>::value)
+                    .on(this->exec))
+            .with_relaxation(relaxation)
+            .on(this->exec)
+            ->generate(this->mtx);
+
+    ASSERT_EQ(richardson->get_parameters().relaxation, value_type{0.5});
+}
+
+
 }  // namespace

--- a/cuda/test/solver/ir_kernels.cpp
+++ b/cuda/test/solver/ir_kernels.cpp
@@ -179,4 +179,81 @@ TEST_F(Ir, ApplyWithIterativeInnerSolverIsEquivalentToRef)
 }
 
 
+TEST_F(Ir, RichardsonApplyIsEquivalentToRef)
+{
+    auto mtx = gen_mtx(50, 50);
+    auto x = gen_mtx(50, 3);
+    auto b = gen_mtx(50, 3);
+    auto d_mtx = clone(cuda, mtx);
+    auto d_x = clone(cuda, x);
+    auto d_b = clone(cuda, b);
+    // Forget about accuracy - Richardson is not going to converge for a random
+    // matrix, just check that a couple of iterations gives the same result on
+    // both executors
+    auto ir_factory =
+        gko::solver::Ir<>::build()
+            .with_criteria(
+                gko::stop::Iteration::build().with_max_iters(2u).on(ref))
+            .with_relaxation(0.9)
+            .on(ref);
+    auto d_ir_factory =
+        gko::solver::Ir<>::build()
+            .with_criteria(
+                gko::stop::Iteration::build().with_max_iters(2u).on(cuda))
+            .with_relaxation(0.9)
+            .on(cuda);
+    auto solver = ir_factory->generate(std::move(mtx));
+    auto d_solver = d_ir_factory->generate(std::move(d_mtx));
+
+    solver->apply(lend(b), lend(x));
+    d_solver->apply(lend(d_b), lend(d_x));
+
+    GKO_ASSERT_MTX_NEAR(d_x, x, 1e-14);
+}
+
+
+TEST_F(Ir, RichardsonApplyWithIterativeInnerSolverIsEquivalentToRef)
+{
+    auto mtx = gen_mtx(50, 50);
+    auto x = gen_mtx(50, 3);
+    auto b = gen_mtx(50, 3);
+    auto d_mtx = clone(cuda, mtx);
+    auto d_x = clone(cuda, x);
+    auto d_b = clone(cuda, b);
+    auto ir_factory =
+        gko::solver::Ir<>::build()
+            .with_solver(
+                gko::solver::Gmres<>::build()
+                    .with_criteria(
+                        gko::stop::Iteration::build().with_max_iters(1u).on(
+                            ref))
+                    .on(ref))
+            .with_criteria(
+                gko::stop::Iteration::build().with_max_iters(2u).on(ref))
+            .with_relaxation(0.9)
+            .on(ref);
+    auto d_ir_factory =
+        gko::solver::Ir<>::build()
+            .with_solver(
+                gko::solver::Gmres<>::build()
+                    .with_criteria(
+                        gko::stop::Iteration::build().with_max_iters(1u).on(
+                            cuda))
+                    .on(cuda))
+            .with_criteria(
+                gko::stop::Iteration::build().with_max_iters(2u).on(cuda))
+            .with_relaxation(0.9)
+            .on(cuda);
+    auto solver = ir_factory->generate(std::move(mtx));
+    auto d_solver = d_ir_factory->generate(std::move(d_mtx));
+
+    solver->apply(lend(b), lend(x));
+    d_solver->apply(lend(d_b), lend(d_x));
+
+    // Note: 1e-12 instead of 1e-14, as the difference in the inner gmres
+    // iteration gets amplified by the difference in IR.
+    GKO_ASSERT_MTX_NEAR(d_x, x, 1e-12);
+}
+
+
 }  // namespace

--- a/cuda/test/solver/ir_kernels.cpp
+++ b/cuda/test/solver/ir_kernels.cpp
@@ -194,13 +194,13 @@ TEST_F(Ir, RichardsonApplyIsEquivalentToRef)
         gko::solver::Ir<>::build()
             .with_criteria(
                 gko::stop::Iteration::build().with_max_iters(2u).on(ref))
-            .with_relaxation(0.9)
+            .with_relaxation_factor(0.9)
             .on(ref);
     auto d_ir_factory =
         gko::solver::Ir<>::build()
             .with_criteria(
                 gko::stop::Iteration::build().with_max_iters(2u).on(cuda))
-            .with_relaxation(0.9)
+            .with_relaxation_factor(0.9)
             .on(cuda);
     auto solver = ir_factory->generate(std::move(mtx));
     auto d_solver = d_ir_factory->generate(std::move(d_mtx));
@@ -230,7 +230,7 @@ TEST_F(Ir, RichardsonApplyWithIterativeInnerSolverIsEquivalentToRef)
                     .on(ref))
             .with_criteria(
                 gko::stop::Iteration::build().with_max_iters(2u).on(ref))
-            .with_relaxation(0.9)
+            .with_relaxation_factor(0.9)
             .on(ref);
     auto d_ir_factory =
         gko::solver::Ir<>::build()
@@ -242,7 +242,7 @@ TEST_F(Ir, RichardsonApplyWithIterativeInnerSolverIsEquivalentToRef)
                     .on(cuda))
             .with_criteria(
                 gko::stop::Iteration::build().with_max_iters(2u).on(cuda))
-            .with_relaxation(0.9)
+            .with_relaxation_factor(0.9)
             .on(cuda);
     auto solver = ir_factory->generate(std::move(mtx));
     auto d_solver = d_ir_factory->generate(std::move(d_mtx));

--- a/hip/test/solver/ir_kernels.cpp
+++ b/hip/test/solver/ir_kernels.cpp
@@ -194,13 +194,13 @@ TEST_F(Ir, RichardsonApplyIsEquivalentToRef)
         gko::solver::Ir<>::build()
             .with_criteria(
                 gko::stop::Iteration::build().with_max_iters(2u).on(ref))
-            .with_relaxation(0.9)
+            .with_relaxation_factor(0.9)
             .on(ref);
     auto d_ir_factory =
         gko::solver::Ir<>::build()
             .with_criteria(
                 gko::stop::Iteration::build().with_max_iters(2u).on(hip))
-            .with_relaxation(0.9)
+            .with_relaxation_factor(0.9)
             .on(hip);
     auto solver = ir_factory->generate(std::move(mtx));
     auto d_solver = d_ir_factory->generate(std::move(d_mtx));
@@ -230,7 +230,7 @@ TEST_F(Ir, RichardsonApplyWithIterativeInnerSolverIsEquivalentToRef)
                     .on(ref))
             .with_criteria(
                 gko::stop::Iteration::build().with_max_iters(2u).on(ref))
-            .with_relaxation(0.9)
+            .with_relaxation_factor(0.9)
             .on(ref);
     auto d_ir_factory =
         gko::solver::Ir<>::build()
@@ -242,7 +242,7 @@ TEST_F(Ir, RichardsonApplyWithIterativeInnerSolverIsEquivalentToRef)
                     .on(hip))
             .with_criteria(
                 gko::stop::Iteration::build().with_max_iters(2u).on(hip))
-            .with_relaxation(0.9)
+            .with_relaxation_factor(0.9)
             .on(hip);
     auto solver = ir_factory->generate(std::move(mtx));
     auto d_solver = d_ir_factory->generate(std::move(d_mtx));

--- a/hip/test/solver/ir_kernels.cpp
+++ b/hip/test/solver/ir_kernels.cpp
@@ -179,4 +179,81 @@ TEST_F(Ir, ApplyWithIterativeInnerSolverIsEquivalentToRef)
 }
 
 
+TEST_F(Ir, RichardsonApplyIsEquivalentToRef)
+{
+    auto mtx = gen_mtx(50, 50);
+    auto x = gen_mtx(50, 3);
+    auto b = gen_mtx(50, 3);
+    auto d_mtx = clone(hip, mtx);
+    auto d_x = clone(hip, x);
+    auto d_b = clone(hip, b);
+    // Forget about accuracy - Richardson is not going to converge for a random
+    // matrix, just check that a couple of iterations gives the same result on
+    // both executors
+    auto ir_factory =
+        gko::solver::Ir<>::build()
+            .with_criteria(
+                gko::stop::Iteration::build().with_max_iters(2u).on(ref))
+            .with_relaxation(0.9)
+            .on(ref);
+    auto d_ir_factory =
+        gko::solver::Ir<>::build()
+            .with_criteria(
+                gko::stop::Iteration::build().with_max_iters(2u).on(hip))
+            .with_relaxation(0.9)
+            .on(hip);
+    auto solver = ir_factory->generate(std::move(mtx));
+    auto d_solver = d_ir_factory->generate(std::move(d_mtx));
+
+    solver->apply(lend(b), lend(x));
+    d_solver->apply(lend(d_b), lend(d_x));
+
+    GKO_ASSERT_MTX_NEAR(d_x, x, 1e-14);
+}
+
+
+TEST_F(Ir, RichardsonApplyWithIterativeInnerSolverIsEquivalentToRef)
+{
+    auto mtx = gen_mtx(50, 50);
+    auto x = gen_mtx(50, 3);
+    auto b = gen_mtx(50, 3);
+    auto d_mtx = clone(hip, mtx);
+    auto d_x = clone(hip, x);
+    auto d_b = clone(hip, b);
+    auto ir_factory =
+        gko::solver::Ir<>::build()
+            .with_solver(
+                gko::solver::Gmres<>::build()
+                    .with_criteria(
+                        gko::stop::Iteration::build().with_max_iters(1u).on(
+                            ref))
+                    .on(ref))
+            .with_criteria(
+                gko::stop::Iteration::build().with_max_iters(2u).on(ref))
+            .with_relaxation(0.9)
+            .on(ref);
+    auto d_ir_factory =
+        gko::solver::Ir<>::build()
+            .with_solver(
+                gko::solver::Gmres<>::build()
+                    .with_criteria(
+                        gko::stop::Iteration::build().with_max_iters(1u).on(
+                            hip))
+                    .on(hip))
+            .with_criteria(
+                gko::stop::Iteration::build().with_max_iters(2u).on(hip))
+            .with_relaxation(0.9)
+            .on(hip);
+    auto solver = ir_factory->generate(std::move(mtx));
+    auto d_solver = d_ir_factory->generate(std::move(d_mtx));
+
+    solver->apply(lend(b), lend(x));
+    d_solver->apply(lend(d_b), lend(d_x));
+
+    // Note: 1e-12 instead of 1e-14, as the difference in the inner gmres
+    // iteration gets amplified by the difference in IR.
+    GKO_ASSERT_MTX_NEAR(d_x, x, 1e-12);
+}
+
+
 }  // namespace

--- a/omp/test/solver/ir_kernels.cpp
+++ b/omp/test/solver/ir_kernels.cpp
@@ -187,13 +187,13 @@ TEST_F(Ir, RichardsonApplyIsEquivalentToRef)
         gko::solver::Ir<>::build()
             .with_criteria(
                 gko::stop::Iteration::build().with_max_iters(2u).on(ref))
-            .with_relaxation(0.9)
+            .with_relaxation_factor(0.9)
             .on(ref);
     auto d_ir_factory =
         gko::solver::Ir<>::build()
             .with_criteria(
                 gko::stop::Iteration::build().with_max_iters(2u).on(omp))
-            .with_relaxation(0.9)
+            .with_relaxation_factor(0.9)
             .on(omp);
     auto solver = ir_factory->generate(std::move(mtx));
     auto d_solver = d_ir_factory->generate(std::move(d_mtx));
@@ -223,7 +223,7 @@ TEST_F(Ir, RichardsonApplyWithIterativeInnerSolverIsEquivalentToRef)
                     .on(ref))
             .with_criteria(
                 gko::stop::Iteration::build().with_max_iters(2u).on(ref))
-            .with_relaxation(0.9)
+            .with_relaxation_factor(0.9)
             .on(ref);
     auto d_ir_factory =
         gko::solver::Ir<>::build()
@@ -235,7 +235,7 @@ TEST_F(Ir, RichardsonApplyWithIterativeInnerSolverIsEquivalentToRef)
                     .on(omp))
             .with_criteria(
                 gko::stop::Iteration::build().with_max_iters(2u).on(omp))
-            .with_relaxation(0.9)
+            .with_relaxation_factor(0.9)
             .on(omp);
     auto solver = ir_factory->generate(std::move(mtx));
     auto d_solver = d_ir_factory->generate(std::move(d_mtx));

--- a/omp/test/solver/ir_kernels.cpp
+++ b/omp/test/solver/ir_kernels.cpp
@@ -172,4 +172,81 @@ TEST_F(Ir, ApplyWithIterativeInnerSolverIsEquivalentToRef)
 }
 
 
+TEST_F(Ir, RichardsonApplyIsEquivalentToRef)
+{
+    auto mtx = gen_mtx(50, 50);
+    auto x = gen_mtx(50, 3);
+    auto b = gen_mtx(50, 3);
+    auto d_mtx = clone(omp, mtx);
+    auto d_x = clone(omp, x);
+    auto d_b = clone(omp, b);
+    // Forget about accuracy - Richardson is not going to converge for a random
+    // matrix, just check that a couple of iterations gives the same result on
+    // both executors
+    auto ir_factory =
+        gko::solver::Ir<>::build()
+            .with_criteria(
+                gko::stop::Iteration::build().with_max_iters(2u).on(ref))
+            .with_relaxation(0.9)
+            .on(ref);
+    auto d_ir_factory =
+        gko::solver::Ir<>::build()
+            .with_criteria(
+                gko::stop::Iteration::build().with_max_iters(2u).on(omp))
+            .with_relaxation(0.9)
+            .on(omp);
+    auto solver = ir_factory->generate(std::move(mtx));
+    auto d_solver = d_ir_factory->generate(std::move(d_mtx));
+
+    solver->apply(lend(b), lend(x));
+    d_solver->apply(lend(d_b), lend(d_x));
+
+    GKO_ASSERT_MTX_NEAR(d_x, x, 1e-14);
+}
+
+
+TEST_F(Ir, RichardsonApplyWithIterativeInnerSolverIsEquivalentToRef)
+{
+    auto mtx = gen_mtx(50, 50);
+    auto x = gen_mtx(50, 3);
+    auto b = gen_mtx(50, 3);
+    auto d_mtx = clone(omp, mtx);
+    auto d_x = clone(omp, x);
+    auto d_b = clone(omp, b);
+    auto ir_factory =
+        gko::solver::Ir<>::build()
+            .with_solver(
+                gko::solver::Gmres<>::build()
+                    .with_criteria(
+                        gko::stop::Iteration::build().with_max_iters(1u).on(
+                            ref))
+                    .on(ref))
+            .with_criteria(
+                gko::stop::Iteration::build().with_max_iters(2u).on(ref))
+            .with_relaxation(0.9)
+            .on(ref);
+    auto d_ir_factory =
+        gko::solver::Ir<>::build()
+            .with_solver(
+                gko::solver::Gmres<>::build()
+                    .with_criteria(
+                        gko::stop::Iteration::build().with_max_iters(1u).on(
+                            omp))
+                    .on(omp))
+            .with_criteria(
+                gko::stop::Iteration::build().with_max_iters(2u).on(omp))
+            .with_relaxation(0.9)
+            .on(omp);
+    auto solver = ir_factory->generate(std::move(mtx));
+    auto d_solver = d_ir_factory->generate(std::move(d_mtx));
+
+    solver->apply(lend(b), lend(x));
+    d_solver->apply(lend(d_b), lend(d_x));
+
+    // Note: 1e-12 instead of 1e-14, as the difference in the inner gmres
+    // iteration gets amplified by the difference in IR.
+    GKO_ASSERT_MTX_NEAR(d_x, x, 1e-12);
+}
+
+
 }  // namespace

--- a/reference/test/solver/ir_kernels.cpp
+++ b/reference/test/solver/ir_kernels.cpp
@@ -62,7 +62,8 @@ protected:
           mtx(gko::initialize<Mtx>(
               {{0.9, -1.0, 3.0}, {0.0, 1.0, 3.0}, {0.0, 0.0, 1.1}}, exec)),
           // Eigenvalues of mtx are 0.9, 1.0 and 1.1
-          // Richardson iteration, converges since | lambda - 1 | < 1
+          // Richardson iteration, converges since
+          // | relaxation_factor * lambda - 1 | < 1
           ir_factory(
               Solver::build()
                   .with_criteria(
@@ -220,7 +221,7 @@ TYPED_TEST(Ir, RichardsonSolvesTriangularSystem)
                           gko::stop::ResidualNormReduction<value_type>::build()
                               .with_reduction_factor(r<value_type>::value)
                               .on(this->exec))
-                      .with_relaxation(value_type{1})
+                      .with_relaxation_factor(value_type{0.9})
                       .on(this->exec)
                       ->generate(this->mtx);
     auto b = gko::initialize<Mtx>({3.9, 9.0, 2.2}, this->exec);
@@ -251,7 +252,7 @@ TYPED_TEST(Ir, RichardsonSolvesTriangularSystemWithIterativeInnerSolver)
                 gko::stop::ResidualNormReduction<value_type>::build()
                     .with_reduction_factor(r<value_type>::value)
                     .on(this->exec))
-            .with_relaxation(value_type{1})
+            .with_relaxation_factor(value_type{0.9})
             .with_solver(gko::share(inner_solver_factory))
             .on(this->exec);
     auto b = gko::initialize<Mtx>({3.9, 9.0, 2.2}, this->exec);
@@ -274,7 +275,7 @@ TYPED_TEST(Ir, RichardsonTransposedSolvesTriangularSystem)
                            gko::stop::ResidualNormReduction<value_type>::build()
                                .with_reduction_factor(r<value_type>::value)
                                .on(this->exec))
-            .with_relaxation(value_type{0.9})
+            .with_relaxation_factor(value_type{0.9})
             .on(this->exec)
             ->generate(this->mtx->transpose());
     auto b = gko::initialize<Mtx>({3.9, 9.0, 2.2}, this->exec);
@@ -297,7 +298,7 @@ TYPED_TEST(Ir, RichardsonConjTransposedSolvesTriangularSystem)
                            gko::stop::ResidualNormReduction<value_type>::build()
                                .with_reduction_factor(r<value_type>::value)
                                .on(this->exec))
-            .with_relaxation(value_type{0.9})
+            .with_relaxation_factor(value_type{0.9})
             .on(this->exec)
             ->generate(this->mtx->conj_transpose());
     auto b = gko::initialize<Mtx>({3.9, 9.0, 2.2}, this->exec);

--- a/reference/test/solver/ir_kernels.cpp
+++ b/reference/test/solver/ir_kernels.cpp
@@ -209,4 +209,104 @@ TYPED_TEST(Ir, SolvesConjTransposedTriangularSystem)
 }
 
 
+TYPED_TEST(Ir, RichardsonSolvesTriangularSystem)
+{
+    using Mtx = typename TestFixture::Mtx;
+    using value_type = typename TestFixture::value_type;
+    auto solver = gko::solver::Ir<value_type>::build()
+                      .with_criteria(
+                          gko::stop::Iteration::build().with_max_iters(100u).on(
+                              this->exec),
+                          gko::stop::ResidualNormReduction<value_type>::build()
+                              .with_reduction_factor(r<value_type>::value)
+                              .on(this->exec))
+                      .with_relaxation(value_type{1})
+                      .on(this->exec)
+                      ->generate(this->mtx);
+    auto b = gko::initialize<Mtx>({3.9, 9.0, 2.2}, this->exec);
+    auto x = gko::initialize<Mtx>({0.0, 0.0, 0.0}, this->exec);
+
+    solver->apply(b.get(), x.get());
+
+    GKO_ASSERT_MTX_NEAR(x, l({1.0, 3.0, 2.0}), r<value_type>::value * 1e1);
+}
+
+
+TYPED_TEST(Ir, RichardsonSolvesTriangularSystemWithIterativeInnerSolver)
+{
+    using Mtx = typename TestFixture::Mtx;
+    using value_type = typename TestFixture::value_type;
+    const gko::remove_complex<value_type> inner_reduction_factor = 1e-2;
+    auto inner_solver_factory =
+        gko::solver::Gmres<value_type>::build()
+            .with_criteria(gko::stop::ResidualNormReduction<value_type>::build()
+                               .with_reduction_factor(inner_reduction_factor)
+                               .on(this->exec))
+            .on(this->exec);
+    auto solver_factory =
+        gko::solver::Ir<value_type>::build()
+            .with_criteria(
+                gko::stop::Iteration::build().with_max_iters(100u).on(
+                    this->exec),
+                gko::stop::ResidualNormReduction<value_type>::build()
+                    .with_reduction_factor(r<value_type>::value)
+                    .on(this->exec))
+            .with_relaxation(value_type{1})
+            .with_solver(gko::share(inner_solver_factory))
+            .on(this->exec);
+    auto b = gko::initialize<Mtx>({3.9, 9.0, 2.2}, this->exec);
+    auto x = gko::initialize<Mtx>({0.0, 0.0, 0.0}, this->exec);
+
+    solver_factory->generate(this->mtx)->apply(b.get(), x.get());
+
+    GKO_ASSERT_MTX_NEAR(x, l({1.0, 3.0, 2.0}), r<value_type>::value * 1e1);
+}
+
+
+TYPED_TEST(Ir, RichardsonTransposedSolvesTriangularSystem)
+{
+    using Mtx = typename TestFixture::Mtx;
+    using value_type = typename TestFixture::value_type;
+    auto solver =
+        gko::solver::Ir<value_type>::build()
+            .with_criteria(gko::stop::Iteration::build().with_max_iters(30u).on(
+                               this->exec),
+                           gko::stop::ResidualNormReduction<value_type>::build()
+                               .with_reduction_factor(r<value_type>::value)
+                               .on(this->exec))
+            .with_relaxation(value_type{0.9})
+            .on(this->exec)
+            ->generate(this->mtx->transpose());
+    auto b = gko::initialize<Mtx>({3.9, 9.0, 2.2}, this->exec);
+    auto x = gko::initialize<Mtx>({0.0, 0.0, 0.0}, this->exec);
+
+    solver->transpose()->apply(b.get(), x.get());
+
+    GKO_ASSERT_MTX_NEAR(x, l({1.0, 3.0, 2.0}), r<value_type>::value * 1e1);
+}
+
+
+TYPED_TEST(Ir, RichardsonConjTransposedSolvesTriangularSystem)
+{
+    using Mtx = typename TestFixture::Mtx;
+    using value_type = typename TestFixture::value_type;
+    auto solver =
+        gko::solver::Ir<value_type>::build()
+            .with_criteria(gko::stop::Iteration::build().with_max_iters(30u).on(
+                               this->exec),
+                           gko::stop::ResidualNormReduction<value_type>::build()
+                               .with_reduction_factor(r<value_type>::value)
+                               .on(this->exec))
+            .with_relaxation(value_type{0.9})
+            .on(this->exec)
+            ->generate(this->mtx->conj_transpose());
+    auto b = gko::initialize<Mtx>({3.9, 9.0, 2.2}, this->exec);
+    auto x = gko::initialize<Mtx>({0.0, 0.0, 0.0}, this->exec);
+
+    solver->conj_transpose()->apply(b.get(), x.get());
+
+    GKO_ASSERT_MTX_NEAR(x, l({1.0, 3.0, 2.0}), r<value_type>::value * 1e1);
+}
+
+
 }  // namespace


### PR DESCRIPTION
This PR adds relaxation factor into IR such that it can be considered as preconditioned Richardson iteration.

```
solution = initial_guess
while not converged:
    residual = b - A solution
    error = solver(A, residual)
    // solution = solution + error
    solution = solution + relaxation * error

