### PR TITLE
Fix next residual norm calculation

### DIFF
--- a/common/solver/gmres_kernels.hpp.inc
+++ b/common/solver/gmres_kernels.hpp.inc
@@ -272,8 +272,7 @@ __device__ void calculate_residual_norm_kernel(
     const ValueType &register_sin, const ValueType &register_cos,
     remove_complex<ValueType> *residual_norm,
     ValueType *residual_norm_collection,
-    size_type stride_residual_norm_collection,
-    const remove_complex<ValueType> *b_norm)
+    size_type stride_residual_norm_collection)
 {
     const auto this_rnc =
         residual_norm_collection[iter * stride_residual_norm_collection +
@@ -297,7 +296,6 @@ __global__ __launch_bounds__(block_size) void givens_rotation_kernel(
     remove_complex<ValueType> *__restrict__ residual_norm,
     ValueType *__restrict__ residual_norm_collection,
     size_type stride_residual_norm_collection,
-    const remove_complex<ValueType> *__restrict__ b_norm,
     const stopping_status *__restrict__ stop_status)
 {
     const auto col_idx = thread::get_thread_id_flat();
@@ -341,7 +339,7 @@ __global__ __launch_bounds__(block_size) void givens_rotation_kernel(
 
     calculate_residual_norm_kernel(
         col_idx, num_cols, iter, register_sin, register_cos, residual_norm,
-        residual_norm_collection, stride_residual_norm_collection, b_norm);
+        residual_norm_collection, stride_residual_norm_collection);
     // Calculate residual norm
 }
 

--- a/common/solver/gmres_kernels.hpp.inc
+++ b/common/solver/gmres_kernels.hpp.inc
@@ -281,7 +281,7 @@ __device__ void calculate_residual_norm_kernel(
     const auto next_rnc = -conj(register_sin) * this_rnc;
     residual_norm_collection[iter * stride_residual_norm_collection + col_idx] =
         register_cos * this_rnc;
-    residual_norm[col_idx] = abs(next_rnc) / b_norm[col_idx];
+    residual_norm[col_idx] = abs(next_rnc);
     residual_norm_collection[(iter + 1) * stride_residual_norm_collection +
                              col_idx] = next_rnc;
 }

--- a/core/solver/gmres_kernels.hpp
+++ b/core/solver/gmres_kernels.hpp
@@ -46,14 +46,12 @@ namespace kernels {
 namespace gmres {
 
 
-#define GKO_DECLARE_GMRES_INITIALIZE_1_KERNEL(_type)                           \
-    void initialize_1(                                                         \
-        std::shared_ptr<const DefaultExecutor> exec,                           \
-        const matrix::Dense<_type> *b,                                         \
-        matrix::Dense<remove_complex<_type>> *b_norm,                          \
-        matrix::Dense<_type> *residual, matrix::Dense<_type> *givens_sin,      \
-        matrix::Dense<_type> *givens_cos, Array<stopping_status> *stop_status, \
-        size_type krylov_dim)
+#define GKO_DECLARE_GMRES_INITIALIZE_1_KERNEL(_type)                        \
+    void initialize_1(                                                      \
+        std::shared_ptr<const DefaultExecutor> exec,                        \
+        const matrix::Dense<_type> *b, matrix::Dense<_type> *residual,      \
+        matrix::Dense<_type> *givens_sin, matrix::Dense<_type> *givens_cos, \
+        Array<stopping_status> *stop_status, size_type krylov_dim)
 
 
 #define GKO_DECLARE_GMRES_INITIALIZE_2_KERNEL(_type)                       \
@@ -65,16 +63,15 @@ namespace gmres {
                       Array<size_type> *final_iter_nums, size_type krylov_dim)
 
 
-#define GKO_DECLARE_GMRES_STEP_1_KERNEL(_type)                        \
-    void step_1(std::shared_ptr<const DefaultExecutor> exec,          \
-                size_type num_rows, matrix::Dense<_type> *givens_sin, \
-                matrix::Dense<_type> *givens_cos,                     \
-                matrix::Dense<remove_complex<_type>> *residual_norm,  \
-                matrix::Dense<_type> *residual_norm_collection,       \
-                matrix::Dense<_type> *krylov_bases,                   \
-                matrix::Dense<_type> *hessenberg_iter,                \
-                const matrix::Dense<remove_complex<_type>> *b_norm,   \
-                size_type iter, Array<size_type> *final_iter_nums,    \
+#define GKO_DECLARE_GMRES_STEP_1_KERNEL(_type)                         \
+    void step_1(std::shared_ptr<const DefaultExecutor> exec,           \
+                size_type num_rows, matrix::Dense<_type> *givens_sin,  \
+                matrix::Dense<_type> *givens_cos,                      \
+                matrix::Dense<remove_complex<_type>> *residual_norm,   \
+                matrix::Dense<_type> *residual_norm_collection,        \
+                matrix::Dense<_type> *krylov_bases,                    \
+                matrix::Dense<_type> *hessenberg_iter, size_type iter, \
+                Array<size_type> *final_iter_nums,                     \
                 const Array<stopping_status> *stop_status)
 
 

--- a/cuda/solver/gmres_kernels.cu
+++ b/cuda/solver/gmres_kernels.cu
@@ -78,7 +78,6 @@ constexpr int default_dot_size = default_dot_dim * default_dot_dim;
 template <typename ValueType>
 void initialize_1(std::shared_ptr<const CudaExecutor> exec,
                   const matrix::Dense<ValueType> *b,
-                  matrix::Dense<remove_complex<ValueType>> *b_norm,
                   matrix::Dense<ValueType> *residual,
                   matrix::Dense<ValueType> *givens_sin,
                   matrix::Dense<ValueType> *givens_cos,
@@ -90,7 +89,6 @@ void initialize_1(std::shared_ptr<const CudaExecutor> exec,
     const dim3 block_dim(default_block_size, 1, 1);
     constexpr auto block_size = default_block_size;
 
-    b->compute_norm2(b_norm);
     initialize_1_kernel<block_size><<<grid_dim, block_dim>>>(
         b->get_size()[0], b->get_size()[1], krylov_dim,
         as_cuda_type(b->get_const_values()), b->get_stride(),
@@ -214,7 +212,6 @@ void givens_rotation(std::shared_ptr<const CudaExecutor> exec,
                      matrix::Dense<ValueType> *hessenberg_iter,
                      matrix::Dense<remove_complex<ValueType>> *residual_norm,
                      matrix::Dense<ValueType> *residual_norm_collection,
-                     const matrix::Dense<remove_complex<ValueType>> *b_norm,
                      size_type iter, const Array<stopping_status> *stop_status)
 {
     // TODO: tune block_size for optimal performance
@@ -232,7 +229,6 @@ void givens_rotation(std::shared_ptr<const CudaExecutor> exec,
         givens_cos->get_stride(), as_cuda_type(residual_norm->get_values()),
         as_cuda_type(residual_norm_collection->get_values()),
         residual_norm_collection->get_stride(),
-        as_cuda_type(b_norm->get_const_values()),
         as_cuda_type(stop_status->get_const_data()));
 }
 
@@ -244,9 +240,8 @@ void step_1(std::shared_ptr<const CudaExecutor> exec, size_type num_rows,
             matrix::Dense<remove_complex<ValueType>> *residual_norm,
             matrix::Dense<ValueType> *residual_norm_collection,
             matrix::Dense<ValueType> *krylov_bases,
-            matrix::Dense<ValueType> *hessenberg_iter,
-            const matrix::Dense<remove_complex<ValueType>> *b_norm,
-            size_type iter, Array<size_type> *final_iter_nums,
+            matrix::Dense<ValueType> *hessenberg_iter, size_type iter,
+            Array<size_type> *final_iter_nums,
             const Array<stopping_status> *stop_status)
 {
     increase_final_iteration_numbers_kernel<<<
@@ -258,8 +253,7 @@ void step_1(std::shared_ptr<const CudaExecutor> exec, size_type num_rows,
     finish_arnoldi(exec, num_rows, krylov_bases, hessenberg_iter, iter,
                    stop_status->get_const_data());
     givens_rotation(exec, givens_sin, givens_cos, hessenberg_iter,
-                    residual_norm, residual_norm_collection, b_norm, iter,
-                    stop_status);
+                    residual_norm, residual_norm_collection, iter, stop_status);
 }
 
 GKO_INSTANTIATE_FOR_EACH_VALUE_TYPE(GKO_DECLARE_GMRES_STEP_1_KERNEL);

--- a/cuda/test/solver/gmres_kernels.cpp
+++ b/cuda/test/solver/gmres_kernels.cpp
@@ -97,7 +97,6 @@ protected:
         y = gen_mtx(gko::solver::default_krylov_dim, nrhs);
         before_preconditioner = Mtx::create_with_config_of(x.get());
         b = gen_mtx(m, nrhs);
-        b_norm = gen_mtx<norm_type>(1, nrhs);
         krylov_bases = gen_mtx(m * (gko::solver::default_krylov_dim + 1), nrhs);
         hessenberg = gen_mtx(gko::solver::default_krylov_dim + 1,
                              gko::solver::default_krylov_dim * nrhs);
@@ -126,8 +125,6 @@ protected:
         d_y->copy_from(y.get());
         d_b = Mtx::create(cuda);
         d_b->copy_from(b.get());
-        d_b_norm = NormVector::create(cuda);
-        d_b_norm->copy_from(b_norm.get());
         d_krylov_bases = Mtx::create(cuda);
         d_krylov_bases->copy_from(krylov_bases.get());
         d_hessenberg = Mtx::create(cuda);
@@ -161,7 +158,6 @@ protected:
     std::unique_ptr<Mtx> x;
     std::unique_ptr<Mtx> y;
     std::unique_ptr<Mtx> b;
-    std::unique_ptr<NormVector> b_norm;
     std::unique_ptr<Mtx> krylov_bases;
     std::unique_ptr<Mtx> hessenberg;
     std::unique_ptr<Mtx> hessenberg_iter;
@@ -177,7 +173,6 @@ protected:
     std::unique_ptr<Mtx> d_before_preconditioner;
     std::unique_ptr<Mtx> d_y;
     std::unique_ptr<Mtx> d_b;
-    std::unique_ptr<NormVector> d_b_norm;
     std::unique_ptr<Mtx> d_krylov_bases;
     std::unique_ptr<Mtx> d_hessenberg;
     std::unique_ptr<Mtx> d_hessenberg_iter;
@@ -196,14 +191,13 @@ TEST_F(Gmres, CudaGmresInitialize1IsEquivalentToRef)
     initialize_data();
 
     gko::kernels::reference::gmres::initialize_1(
-        ref, b.get(), b_norm.get(), residual.get(), givens_sin.get(),
-        givens_cos.get(), stop_status.get(), gko::solver::default_krylov_dim);
+        ref, b.get(), residual.get(), givens_sin.get(), givens_cos.get(),
+        stop_status.get(), gko::solver::default_krylov_dim);
     gko::kernels::cuda::gmres::initialize_1(
-        cuda, d_b.get(), d_b_norm.get(), d_residual.get(), d_givens_sin.get(),
+        cuda, d_b.get(), d_residual.get(), d_givens_sin.get(),
         d_givens_cos.get(), d_stop_status.get(),
         gko::solver::default_krylov_dim);
 
-    GKO_ASSERT_MTX_NEAR(d_b_norm, b_norm, 1e-14);
     GKO_ASSERT_MTX_NEAR(d_residual, residual, 1e-14);
     GKO_ASSERT_MTX_NEAR(d_givens_sin, givens_sin, 1e-14);
     GKO_ASSERT_MTX_NEAR(d_givens_cos, givens_cos, 1e-14);
@@ -240,12 +234,11 @@ TEST_F(Gmres, CudaGmresStep1IsEquivalentToRef)
     gko::kernels::reference::gmres::step_1(
         ref, x->get_size()[0], givens_sin.get(), givens_cos.get(),
         residual_norm.get(), residual_norm_collection.get(), krylov_bases.get(),
-        hessenberg_iter.get(), b_norm.get(), iter, final_iter_nums.get(),
-        stop_status.get());
+        hessenberg_iter.get(), iter, final_iter_nums.get(), stop_status.get());
     gko::kernels::cuda::gmres::step_1(
         cuda, d_x->get_size()[0], d_givens_sin.get(), d_givens_cos.get(),
         d_residual_norm.get(), d_residual_norm_collection.get(),
-        d_krylov_bases.get(), d_hessenberg_iter.get(), d_b_norm.get(), iter,
+        d_krylov_bases.get(), d_hessenberg_iter.get(), iter,
         d_final_iter_nums.get(), d_stop_status.get());
 
     GKO_ASSERT_MTX_NEAR(d_givens_sin, givens_sin, 1e-14);
@@ -267,12 +260,11 @@ TEST_F(Gmres, CudaGmresStep1OnSingleRHSIsEquivalentToRef)
     gko::kernels::reference::gmres::step_1(
         ref, x->get_size()[0], givens_sin.get(), givens_cos.get(),
         residual_norm.get(), residual_norm_collection.get(), krylov_bases.get(),
-        hessenberg_iter.get(), b_norm.get(), iter, final_iter_nums.get(),
-        stop_status.get());
+        hessenberg_iter.get(), iter, final_iter_nums.get(), stop_status.get());
     gko::kernels::cuda::gmres::step_1(
         cuda, d_x->get_size()[0], d_givens_sin.get(), d_givens_cos.get(),
         d_residual_norm.get(), d_residual_norm_collection.get(),
-        d_krylov_bases.get(), d_hessenberg_iter.get(), d_b_norm.get(), iter,
+        d_krylov_bases.get(), d_hessenberg_iter.get(), iter,
         d_final_iter_nums.get(), d_stop_status.get());
 
     GKO_ASSERT_MTX_NEAR(d_givens_sin, givens_sin, 1e-14);

--- a/hip/test/solver/gmres_kernels.cpp
+++ b/hip/test/solver/gmres_kernels.cpp
@@ -98,7 +98,6 @@ protected:
         y = gen_mtx(gko::solver::default_krylov_dim, nrhs);
         before_preconditioner = Mtx::create_with_config_of(x.get());
         b = gen_mtx(m, nrhs);
-        b_norm = gen_mtx<norm_type>(1, nrhs);
         krylov_bases = gen_mtx(m * (gko::solver::default_krylov_dim + 1), nrhs);
         hessenberg = gen_mtx(gko::solver::default_krylov_dim + 1,
                              gko::solver::default_krylov_dim * nrhs);
@@ -127,8 +126,6 @@ protected:
         d_y->copy_from(y.get());
         d_b = Mtx::create(hip);
         d_b->copy_from(b.get());
-        d_b_norm = NormVector::create(hip);
-        d_b_norm->copy_from(b_norm.get());
         d_krylov_bases = Mtx::create(hip);
         d_krylov_bases->copy_from(krylov_bases.get());
         d_hessenberg = Mtx::create(hip);
@@ -162,7 +159,6 @@ protected:
     std::unique_ptr<Mtx> x;
     std::unique_ptr<Mtx> y;
     std::unique_ptr<Mtx> b;
-    std::unique_ptr<Mtx> b_norm;
     std::unique_ptr<Mtx> krylov_bases;
     std::unique_ptr<Mtx> hessenberg;
     std::unique_ptr<Mtx> hessenberg_iter;
@@ -178,7 +174,6 @@ protected:
     std::unique_ptr<Mtx> d_before_preconditioner;
     std::unique_ptr<Mtx> d_y;
     std::unique_ptr<Mtx> d_b;
-    std::unique_ptr<Mtx> d_b_norm;
     std::unique_ptr<Mtx> d_krylov_bases;
     std::unique_ptr<Mtx> d_hessenberg;
     std::unique_ptr<Mtx> d_hessenberg_iter;
@@ -197,14 +192,13 @@ TEST_F(Gmres, HipGmresInitialize1IsEquivalentToRef)
     initialize_data();
 
     gko::kernels::reference::gmres::initialize_1(
-        ref, b.get(), b_norm.get(), residual.get(), givens_sin.get(),
-        givens_cos.get(), stop_status.get(), gko::solver::default_krylov_dim);
+        ref, b.get(), residual.get(), givens_sin.get(), givens_cos.get(),
+        stop_status.get(), gko::solver::default_krylov_dim);
     gko::kernels::hip::gmres::initialize_1(
-        hip, d_b.get(), d_b_norm.get(), d_residual.get(), d_givens_sin.get(),
+        hip, d_b.get(), d_residual.get(), d_givens_sin.get(),
         d_givens_cos.get(), d_stop_status.get(),
         gko::solver::default_krylov_dim);
 
-    GKO_ASSERT_MTX_NEAR(d_b_norm, b_norm, 1e-14);
     GKO_ASSERT_MTX_NEAR(d_residual, residual, 1e-14);
     GKO_ASSERT_MTX_NEAR(d_givens_sin, givens_sin, 1e-14);
     GKO_ASSERT_MTX_NEAR(d_givens_cos, givens_cos, 1e-14);
@@ -241,12 +235,11 @@ TEST_F(Gmres, HipGmresStep1IsEquivalentToRef)
     gko::kernels::reference::gmres::step_1(
         ref, x->get_size()[0], givens_sin.get(), givens_cos.get(),
         residual_norm.get(), residual_norm_collection.get(), krylov_bases.get(),
-        hessenberg_iter.get(), b_norm.get(), iter, final_iter_nums.get(),
-        stop_status.get());
+        hessenberg_iter.get(), iter, final_iter_nums.get(), stop_status.get());
     gko::kernels::hip::gmres::step_1(
         hip, d_x->get_size()[0], d_givens_sin.get(), d_givens_cos.get(),
         d_residual_norm.get(), d_residual_norm_collection.get(),
-        d_krylov_bases.get(), d_hessenberg_iter.get(), d_b_norm.get(), iter,
+        d_krylov_bases.get(), d_hessenberg_iter.get(), iter,
         d_final_iter_nums.get(), d_stop_status.get());
 
     GKO_ASSERT_MTX_NEAR(d_givens_sin, givens_sin, 1e-14);
@@ -268,12 +261,11 @@ TEST_F(Gmres, HipGmresStep1OnSingleRHSIsEquivalentToRef)
     gko::kernels::reference::gmres::step_1(
         ref, x->get_size()[0], givens_sin.get(), givens_cos.get(),
         residual_norm.get(), residual_norm_collection.get(), krylov_bases.get(),
-        hessenberg_iter.get(), b_norm.get(), iter, final_iter_nums.get(),
-        stop_status.get());
+        hessenberg_iter.get(), iter, final_iter_nums.get(), stop_status.get());
     gko::kernels::hip::gmres::step_1(
         hip, d_x->get_size()[0], d_givens_sin.get(), d_givens_cos.get(),
         d_residual_norm.get(), d_residual_norm_collection.get(),
-        d_krylov_bases.get(), d_hessenberg_iter.get(), d_b_norm.get(), iter,
+        d_krylov_bases.get(), d_hessenberg_iter.get(), iter,
         d_final_iter_nums.get(), d_stop_status.get());
 
     GKO_ASSERT_MTX_NEAR(d_givens_sin, givens_sin, 1e-14);

--- a/omp/solver/gmres_kernels.cpp
+++ b/omp/solver/gmres_kernels.cpp
@@ -191,7 +191,7 @@ void calculate_next_residual_norm(
         residual_norm_collection->at(iter, i) =
             givens_cos->at(iter, i) * residual_norm_collection->at(iter, i);
         residual_norm->at(0, i) =
-            abs(residual_norm_collection->at(iter + 1, i)) / b_norm->at(0, i);
+            abs(residual_norm_collection->at(iter + 1, i));
     }
 }
 

--- a/reference/solver/gmres_kernels.cpp
+++ b/reference/solver/gmres_kernels.cpp
@@ -179,7 +179,7 @@ void calculate_next_residual_norm(
         residual_norm_collection->at(iter, i) =
             givens_cos->at(iter, i) * residual_norm_collection->at(iter, i);
         residual_norm->at(0, i) =
-            abs(residual_norm_collection->at(iter + 1, i)) / b_norm->at(0, i);
+            abs(residual_norm_collection->at(iter + 1, i));
     }
 }
 

--- a/reference/solver/gmres_kernels.cpp
+++ b/reference/solver/gmres_kernels.cpp
@@ -165,8 +165,7 @@ template <typename ValueType>
 void calculate_next_residual_norm(
     matrix::Dense<ValueType> *givens_sin, matrix::Dense<ValueType> *givens_cos,
     matrix::Dense<remove_complex<ValueType>> *residual_norm,
-    matrix::Dense<ValueType> *residual_norm_collection,
-    const matrix::Dense<remove_complex<ValueType>> *b_norm, size_type iter,
+    matrix::Dense<ValueType> *residual_norm_collection, size_type iter,
     const stopping_status *stop_status)
 {
     for (size_type i = 0; i < residual_norm->get_size()[1]; ++i) {
@@ -233,7 +232,6 @@ void calculate_qy(const matrix::Dense<ValueType> *krylov_bases,
 template <typename ValueType>
 void initialize_1(std::shared_ptr<const ReferenceExecutor> exec,
                   const matrix::Dense<ValueType> *b,
-                  matrix::Dense<remove_complex<ValueType>> *b_norm,
                   matrix::Dense<ValueType> *residual,
                   matrix::Dense<ValueType> *givens_sin,
                   matrix::Dense<ValueType> *givens_cos,
@@ -241,13 +239,6 @@ void initialize_1(std::shared_ptr<const ReferenceExecutor> exec,
 {
     using NormValueType = remove_complex<ValueType>;
     for (size_type j = 0; j < b->get_size()[1]; ++j) {
-        // Calculate b norm
-        b_norm->at(0, j) = zero<NormValueType>();
-        for (size_type i = 0; i < b->get_size()[0]; ++i) {
-            b_norm->at(0, j) += squared_norm(b->at(i, j));
-        }
-        b_norm->at(0, j) = sqrt(b_norm->at(0, j));
-
         for (size_type i = 0; i < b->get_size()[0]; ++i) {
             residual->at(i, j) = b->at(i, j);
         }
@@ -296,9 +287,8 @@ void step_1(std::shared_ptr<const ReferenceExecutor> exec, size_type num_rows,
             matrix::Dense<remove_complex<ValueType>> *residual_norm,
             matrix::Dense<ValueType> *residual_norm_collection,
             matrix::Dense<ValueType> *krylov_bases,
-            matrix::Dense<ValueType> *hessenberg_iter,
-            const matrix::Dense<remove_complex<ValueType>> *b_norm,
-            size_type iter, Array<size_type> *final_iter_nums,
+            matrix::Dense<ValueType> *hessenberg_iter, size_type iter,
+            Array<size_type> *final_iter_nums,
             const Array<stopping_status> *stop_status)
 {
     for (size_type i = 0; i < final_iter_nums->get_num_elems(); ++i) {
@@ -311,7 +301,7 @@ void step_1(std::shared_ptr<const ReferenceExecutor> exec, size_type num_rows,
     givens_rotation(givens_sin, givens_cos, hessenberg_iter, iter,
                     stop_status->get_const_data());
     calculate_next_residual_norm(givens_sin, givens_cos, residual_norm,
-                                 residual_norm_collection, b_norm, iter,
+                                 residual_norm_collection, iter,
                                  stop_status->get_const_data());
 }
 


### PR DESCRIPTION
Dividing the residual norm by the norm of b results in us accepting an iterate where the relative residual is smaller than `norm(b) * tol` instead of `tol`. 

This is the easy fix, it gives the same iteration count and residual norm as Matlab for all matrices that I tested.

If there should be some reason for dividing the residual norm by norm(b) that I overlooked, another option is to divide the initial residual norm by norm(b) as well in `initialize_2`.