### PR TITLE
Make criterion factory parameters work with CUDA

### DIFF
--- a/benchmark/utils/overhead_linop.hpp
+++ b/benchmark/utils/overhead_linop.hpp
@@ -140,19 +140,19 @@ public:
          * Criterion factories.
          */
         std::vector<std::shared_ptr<const stop::CriterionFactory>>
-            GKO_FACTORY_PARAMETER(criteria, nullptr);
+            GKO_FACTORY_PARAMETER_VECTOR(criteria, nullptr);
 
         /**
          * Preconditioner factory.
          */
-        std::shared_ptr<const LinOpFactory> GKO_FACTORY_PARAMETER(
+        std::shared_ptr<const LinOpFactory> GKO_FACTORY_PARAMETER_SCALAR(
             preconditioner, nullptr);
 
         /**
          * Already generated preconditioner. If one is provided, the factory
          * `preconditioner` will be ignored.
          */
-        std::shared_ptr<const LinOp> GKO_FACTORY_PARAMETER(
+        std::shared_ptr<const LinOp> GKO_FACTORY_PARAMETER_SCALAR(
             generated_preconditioner, nullptr);
     };
 

--- a/core/test/base/lin_op.cpp
+++ b/core/test/base/lin_op.cpp
@@ -252,7 +252,7 @@ public:
 
     GKO_CREATE_FACTORY_PARAMETERS(parameters, Factory)
     {
-        T GKO_FACTORY_PARAMETER(value, T{5});
+        T GKO_FACTORY_PARAMETER_SCALAR(value, T{5});
     };
     GKO_ENABLE_LIN_OP_FACTORY(DummyLinOpWithFactory, parameters, Factory);
     GKO_ENABLE_BUILD_METHOD(Factory);

--- a/cuda/test/base/CMakeLists.txt
+++ b/cuda/test/base/CMakeLists.txt
@@ -1,3 +1,4 @@
 ginkgo_create_cuda_test(cuda_executor)
 ginkgo_create_cuda_test(exception_helpers)
+ginkgo_create_cuda_test(lin_op)
 ginkgo_create_cuda_test(math)

--- a/cuda/test/base/lin_op.cu
+++ b/cuda/test/base/lin_op.cu
@@ -44,8 +44,8 @@ protected:
     FactoryParameter() {}
 
 public:
-    std::vector<int> GKO_FACTORY_PARAMETER_VECTOR(parameter, 10, 11);
-    int GKO_FACTORY_PARAMETER_SCALAR(parameter2, -4);
+    std::vector<int> GKO_FACTORY_PARAMETER_VECTOR(vector_parameter, 10, 11);
+    int GKO_FACTORY_PARAMETER_SCALAR(scalar_parameter, -4);
 };
 
 
@@ -53,8 +53,8 @@ TEST_F(FactoryParameter, WorksOnCudaDefault)
 {
     std::vector<int> expected{10, 11};
 
-    ASSERT_EQ(parameter, expected);
-    ASSERT_EQ(parameter2, -4);
+    ASSERT_EQ(vector_parameter, expected);
+    ASSERT_EQ(scalar_parameter, -4);
 }
 
 
@@ -62,9 +62,9 @@ TEST_F(FactoryParameter, WorksOnCuda0)
 {
     std::vector<int> expected{};
 
-    auto result = &this->with_parameter();
+    auto result = &this->with_vector_parameter();
 
-    ASSERT_EQ(parameter, expected);
+    ASSERT_EQ(vector_parameter, expected);
     ASSERT_EQ(result, this);
 }
 
@@ -73,10 +73,10 @@ TEST_F(FactoryParameter, WorksOnCuda1)
 {
     std::vector<int> expected{2};
 
-    this->with_parameter(2).with_parameter2(3);
+    this->with_vector_parameter(2).with_scalar_parameter(3);
 
-    ASSERT_EQ(parameter, expected);
-    ASSERT_EQ(parameter2, 3);
+    ASSERT_EQ(vector_parameter, expected);
+    ASSERT_EQ(scalar_parameter, 3);
 }
 
 
@@ -84,9 +84,9 @@ TEST_F(FactoryParameter, WorksOnCuda2)
 {
     std::vector<int> expected{8, 3};
 
-    this->with_parameter(8, 3);
+    this->with_vector_parameter(8, 3);
 
-    ASSERT_EQ(parameter, expected);
+    ASSERT_EQ(vector_parameter, expected);
 }
 
 
@@ -94,9 +94,9 @@ TEST_F(FactoryParameter, WorksOnCuda3)
 {
     std::vector<int> expected{1, 7, 2};
 
-    this->with_parameter(1, 7, 2);
+    this->with_vector_parameter(1, 7, 2);
 
-    ASSERT_EQ(parameter, expected);
+    ASSERT_EQ(vector_parameter, expected);
 }
 
 
@@ -104,9 +104,9 @@ TEST_F(FactoryParameter, WorksOnCuda4)
 {
     std::vector<int> expected{4, 5, 4, 2};
 
-    this->with_parameter(4, 5, 4, 2);
+    this->with_vector_parameter(4, 5, 4, 2);
 
-    ASSERT_EQ(parameter, expected);
+    ASSERT_EQ(vector_parameter, expected);
 }
 
 
@@ -114,9 +114,9 @@ TEST_F(FactoryParameter, WorksOnCuda5)
 {
     std::vector<int> expected{9, 3, 4, 2, 7};
 
-    this->with_parameter(9, 3, 4, 2, 7);
+    this->with_vector_parameter(9, 3, 4, 2, 7);
 
-    ASSERT_EQ(parameter, expected);
+    ASSERT_EQ(vector_parameter, expected);
 }
 
 

--- a/cuda/test/base/lin_op.cu
+++ b/cuda/test/base/lin_op.cu
@@ -30,58 +30,94 @@ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ******************************<GINKGO LICENSE>*******************************/
 
-#ifndef GKO_CORE_STOP_ITERATION_HPP_
-#define GKO_CORE_STOP_ITERATION_HPP_
+#include <ginkgo/core/base/lin_op.hpp>
 
 
-#include <ginkgo/core/stop/criterion.hpp>
+#include <gtest/gtest.h>
 
 
-namespace gko {
-namespace stop {
+namespace {
 
-/**
- * The Iteration class is a stopping criterion which stops the iteration process
- * after a preset number of iterations.
- *
- * @note to use this stopping criterion, it is required to update the iteration
- * count for the ::check() method.
- *
- * @ingroup stop
- */
-class Iteration : public EnablePolymorphicObject<Iteration, Criterion> {
-    friend class EnablePolymorphicObject<Iteration, Criterion>;
+
+class FactoryParameter : public ::testing::Test {
+protected:
+    FactoryParameter() {}
 
 public:
-    GKO_CREATE_FACTORY_PARAMETERS(parameters, Factory)
-    {
-        /**
-         * Maximum number of iterations
-         */
-        size_type GKO_FACTORY_PARAMETER_SCALAR(max_iters, 0);
-    };
-    GKO_ENABLE_CRITERION_FACTORY(Iteration, parameters, Factory);
-    GKO_ENABLE_BUILD_METHOD(Factory);
-
-protected:
-    bool check_impl(uint8 stoppingId, bool setFinalized,
-                    Array<stopping_status> *stop_status, bool *one_changed,
-                    const Updater &updater) override;
-
-    explicit Iteration(std::shared_ptr<const gko::Executor> exec)
-        : EnablePolymorphicObject<Iteration, Criterion>(std::move(exec))
-    {}
-
-    explicit Iteration(const Factory *factory, const CriterionArgs &args)
-        : EnablePolymorphicObject<Iteration, Criterion>(
-              factory->get_executor()),
-          parameters_{factory->get_parameters()}
-    {}
+    std::vector<int> GKO_FACTORY_PARAMETER_VECTOR(parameter, 10, 11);
+    int GKO_FACTORY_PARAMETER_SCALAR(parameter2, -4);
 };
 
 
-}  // namespace stop
-}  // namespace gko
+TEST_F(FactoryParameter, WorksOnCudaDefault)
+{
+    std::vector<int> expected{10, 11};
+
+    ASSERT_EQ(parameter, expected);
+    ASSERT_EQ(parameter2, -4);
+}
 
 
-#endif  // GKO_CORE_STOP_ITERATION_HPP_
+TEST_F(FactoryParameter, WorksOnCuda0)
+{
+    std::vector<int> expected{};
+
+    auto result = &this->with_parameter();
+
+    ASSERT_EQ(parameter, expected);
+    ASSERT_EQ(result, this);
+}
+
+
+TEST_F(FactoryParameter, WorksOnCuda1)
+{
+    std::vector<int> expected{2};
+
+    this->with_parameter(2).with_parameter2(3);
+
+    ASSERT_EQ(parameter, expected);
+    ASSERT_EQ(parameter2, 3);
+}
+
+
+TEST_F(FactoryParameter, WorksOnCuda2)
+{
+    std::vector<int> expected{8, 3};
+
+    this->with_parameter(8, 3);
+
+    ASSERT_EQ(parameter, expected);
+}
+
+
+TEST_F(FactoryParameter, WorksOnCuda3)
+{
+    std::vector<int> expected{1, 7, 2};
+
+    this->with_parameter(1, 7, 2);
+
+    ASSERT_EQ(parameter, expected);
+}
+
+
+TEST_F(FactoryParameter, WorksOnCuda4)
+{
+    std::vector<int> expected{4, 5, 4, 2};
+
+    this->with_parameter(4, 5, 4, 2);
+
+    ASSERT_EQ(parameter, expected);
+}
+
+
+TEST_F(FactoryParameter, WorksOnCuda5)
+{
+    std::vector<int> expected{9, 3, 4, 2, 7};
+
+    this->with_parameter(9, 3, 4, 2, 7);
+
+    ASSERT_EQ(parameter, expected);
+}
+
+
+}  // namespace

--- a/examples/custom-stopping-criterion/custom-stopping-criterion.cpp
+++ b/examples/custom-stopping-criterion/custom-stopping-criterion.cpp
@@ -56,7 +56,7 @@ public:
         /**
          * Boolean set by the user to stop the iteration process
          */
-        std::add_pointer<volatile bool>::type GKO_FACTORY_PARAMETER(
+        std::add_pointer<volatile bool>::type GKO_FACTORY_PARAMETER_SCALAR(
             stop_iteration_process, nullptr);
     };
     GKO_ENABLE_CRITERION_FACTORY(ByInteraction, parameters, Factory);

--- a/hip/test/base/CMakeLists.txt
+++ b/hip/test/base/CMakeLists.txt
@@ -1,4 +1,5 @@
 ginkgo_create_hip_test(hip_executor)
+ginkgo_create_hip_test(lin_op)
 ginkgo_create_hip_test(math)
 # Only hcc needs the libraries. nvcc only requires the headers.
 if (GINKGO_HIP_PLATFORM MATCHES "hcc")

--- a/hip/test/base/lin_op.hip.cpp
+++ b/hip/test/base/lin_op.hip.cpp
@@ -30,58 +30,94 @@ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ******************************<GINKGO LICENSE>*******************************/
 
-#ifndef GKO_CORE_STOP_ITERATION_HPP_
-#define GKO_CORE_STOP_ITERATION_HPP_
+#include <ginkgo/core/base/lin_op.hpp>
 
 
-#include <ginkgo/core/stop/criterion.hpp>
+#include <gtest/gtest.h>
 
 
-namespace gko {
-namespace stop {
+namespace {
 
-/**
- * The Iteration class is a stopping criterion which stops the iteration process
- * after a preset number of iterations.
- *
- * @note to use this stopping criterion, it is required to update the iteration
- * count for the ::check() method.
- *
- * @ingroup stop
- */
-class Iteration : public EnablePolymorphicObject<Iteration, Criterion> {
-    friend class EnablePolymorphicObject<Iteration, Criterion>;
+
+class FactoryParameter : public ::testing::Test {
+protected:
+    FactoryParameter() {}
 
 public:
-    GKO_CREATE_FACTORY_PARAMETERS(parameters, Factory)
-    {
-        /**
-         * Maximum number of iterations
-         */
-        size_type GKO_FACTORY_PARAMETER_SCALAR(max_iters, 0);
-    };
-    GKO_ENABLE_CRITERION_FACTORY(Iteration, parameters, Factory);
-    GKO_ENABLE_BUILD_METHOD(Factory);
-
-protected:
-    bool check_impl(uint8 stoppingId, bool setFinalized,
-                    Array<stopping_status> *stop_status, bool *one_changed,
-                    const Updater &updater) override;
-
-    explicit Iteration(std::shared_ptr<const gko::Executor> exec)
-        : EnablePolymorphicObject<Iteration, Criterion>(std::move(exec))
-    {}
-
-    explicit Iteration(const Factory *factory, const CriterionArgs &args)
-        : EnablePolymorphicObject<Iteration, Criterion>(
-              factory->get_executor()),
-          parameters_{factory->get_parameters()}
-    {}
+    std::vector<int> GKO_FACTORY_PARAMETER_VECTOR(parameter, 10, 11);
+    int GKO_FACTORY_PARAMETER_SCALAR(parameter2, -4);
 };
 
 
-}  // namespace stop
-}  // namespace gko
+TEST_F(FactoryParameter, WorksOnHipDefault)
+{
+    std::vector<int> expected{10, 11};
+
+    ASSERT_EQ(parameter, expected);
+    ASSERT_EQ(parameter2, -4);
+}
 
 
-#endif  // GKO_CORE_STOP_ITERATION_HPP_
+TEST_F(FactoryParameter, WorksOnHip0)
+{
+    std::vector<int> expected{};
+
+    auto result = &this->with_parameter();
+
+    ASSERT_EQ(parameter, expected);
+    ASSERT_EQ(result, this);
+}
+
+
+TEST_F(FactoryParameter, WorksOnHip1)
+{
+    std::vector<int> expected{2};
+
+    this->with_parameter(2).with_parameter2(3);
+
+    ASSERT_EQ(parameter, expected);
+    ASSERT_EQ(parameter2, 3);
+}
+
+
+TEST_F(FactoryParameter, WorksOnHip2)
+{
+    std::vector<int> expected{8, 3};
+
+    this->with_parameter(8, 3);
+
+    ASSERT_EQ(parameter, expected);
+}
+
+
+TEST_F(FactoryParameter, WorksOnHip3)
+{
+    std::vector<int> expected{1, 7, 2};
+
+    this->with_parameter(1, 7, 2);
+
+    ASSERT_EQ(parameter, expected);
+}
+
+
+TEST_F(FactoryParameter, WorksOnHip4)
+{
+    std::vector<int> expected{4, 5, 4, 2};
+
+    this->with_parameter(4, 5, 4, 2);
+
+    ASSERT_EQ(parameter, expected);
+}
+
+
+TEST_F(FactoryParameter, WorksOnHip5)
+{
+    std::vector<int> expected{9, 3, 4, 2, 7};
+
+    this->with_parameter(9, 3, 4, 2, 7);
+
+    ASSERT_EQ(parameter, expected);
+}
+
+
+}  // namespace

--- a/hip/test/base/lin_op.hip.cpp
+++ b/hip/test/base/lin_op.hip.cpp
@@ -44,8 +44,8 @@ protected:
     FactoryParameter() {}
 
 public:
-    std::vector<int> GKO_FACTORY_PARAMETER_VECTOR(parameter, 10, 11);
-    int GKO_FACTORY_PARAMETER_SCALAR(parameter2, -4);
+    std::vector<int> GKO_FACTORY_PARAMETER_VECTOR(vector_parameter, 10, 11);
+    int GKO_FACTORY_PARAMETER_SCALAR(scalar_parameter, -4);
 };
 
 
@@ -53,8 +53,8 @@ TEST_F(FactoryParameter, WorksOnHipDefault)
 {
     std::vector<int> expected{10, 11};
 
-    ASSERT_EQ(parameter, expected);
-    ASSERT_EQ(parameter2, -4);
+    ASSERT_EQ(vector_parameter, expected);
+    ASSERT_EQ(scalar_parameter, -4);
 }
 
 
@@ -62,9 +62,9 @@ TEST_F(FactoryParameter, WorksOnHip0)
 {
     std::vector<int> expected{};
 
-    auto result = &this->with_parameter();
+    auto result = &this->with_vector_parameter();
 
-    ASSERT_EQ(parameter, expected);
+    ASSERT_EQ(vector_parameter, expected);
     ASSERT_EQ(result, this);
 }
 
@@ -73,10 +73,10 @@ TEST_F(FactoryParameter, WorksOnHip1)
 {
     std::vector<int> expected{2};
 
-    this->with_parameter(2).with_parameter2(3);
+    this->with_vector_parameter(2).with_scalar_parameter(3);
 
-    ASSERT_EQ(parameter, expected);
-    ASSERT_EQ(parameter2, 3);
+    ASSERT_EQ(vector_parameter, expected);
+    ASSERT_EQ(scalar_parameter, 3);
 }
 
 
@@ -84,9 +84,9 @@ TEST_F(FactoryParameter, WorksOnHip2)
 {
     std::vector<int> expected{8, 3};
 
-    this->with_parameter(8, 3);
+    this->with_vector_parameter(8, 3);
 
-    ASSERT_EQ(parameter, expected);
+    ASSERT_EQ(vector_parameter, expected);
 }
 
 
@@ -94,9 +94,9 @@ TEST_F(FactoryParameter, WorksOnHip3)
 {
     std::vector<int> expected{1, 7, 2};
 
-    this->with_parameter(1, 7, 2);
+    this->with_vector_parameter(1, 7, 2);
 
-    ASSERT_EQ(parameter, expected);
+    ASSERT_EQ(vector_parameter, expected);
 }
 
 
@@ -104,9 +104,9 @@ TEST_F(FactoryParameter, WorksOnHip4)
 {
     std::vector<int> expected{4, 5, 4, 2};
 
-    this->with_parameter(4, 5, 4, 2);
+    this->with_vector_parameter(4, 5, 4, 2);
 
-    ASSERT_EQ(parameter, expected);
+    ASSERT_EQ(vector_parameter, expected);
 }
 
 
@@ -114,9 +114,9 @@ TEST_F(FactoryParameter, WorksOnHip5)
 {
     std::vector<int> expected{9, 3, 4, 2, 7};
 
-    this->with_parameter(9, 3, 4, 2, 7);
+    this->with_vector_parameter(9, 3, 4, 2, 7);
 
-    ASSERT_EQ(parameter, expected);
+    ASSERT_EQ(vector_parameter, expected);
 }
 
 

--- a/include/ginkgo/core/base/lin_op.hpp
+++ b/include/ginkgo/core/base/lin_op.hpp
@@ -741,7 +741,7 @@ public:                                                                \
  *
  * The list of parameters for the factory should be defined in a code block
  * after the macro definition, and should contain a list of
- * GKO_FACTORY_PARAMETER declarations. The class should provide a constructor
+ * GKO_FACTORY_PARAMETER_* declarations. The class should provide a constructor
  * with signature
  * _lin_op(const _factory_name *, std::shared_ptr<const LinOp>)
  * which the factory will use a callback to construct the object.
@@ -753,7 +753,7 @@ public:                                                                \
  *     GKO_ENABLE_LIN_OP_FACTORY(MyLinOp, my_parameters, Factory) {
  *         // a factory parameter named "my_value", of type int and default
  *         // value of 5
- *         int GKO_FACTORY_PARAMETER(my_value, 5);
+ *         int GKO_FACTORY_PARAMETER_SCALAR(my_value, 5);
  *     };
  *     // constructor needed by EnableLinOp
  *     explicit MyLinOp(std::shared_ptr<const Executor> exec) {
@@ -787,8 +787,8 @@ public:                                                                \
  * std::cout << my_op->get_my_parameters().my_value;  // prints 0
  * ```
  *
- * @note It is possible to combine both the #GKO_CREATE_FACTORY_PARAMETER()
- * macro with this one in a unique macro for class __templates__ (not with
+ * @note It is possible to combine both the #GKO_CREATE_FACTORY_PARAMETER_*()
+ * macros with this one in a unique macro for class __templates__ (not with
  * regular classes). Splitting this into two distinct macros allows to use them
  * in all contexts. See <https://stackoverflow.com/q/50202718/9385966> for more
  * details.
@@ -870,6 +870,8 @@ public:                                                                      \
  *
  * @see GKO_ENABLE_LIN_OP_FACTORY for more details, and usage example
  *
+ * @deprecated Use GKO_FACTORY_PARAMETER_SCALAR or GKO_FACTORY_PARAMETER_VECTOR
+ *
  * @ingroup LinOp
  */
 #define GKO_FACTORY_PARAMETER(_name, ...)                                    \
@@ -886,11 +888,40 @@ public:                                                                      \
     static_assert(true,                                                      \
                   "This assert is used to counter the false positive extra " \
                   "semi-colon warnings")
+/**
+ * Creates a scalar factory parameter in the factory parameters structure.
+ *
+ * Scalar in this context means that the constructor for this type only takes
+ * a single parameter.
+ *
+ * @param _name  name of the parameter
+ * @param _default  default value of the parameter
+ *
+ * @see GKO_ENABLE_LIN_OP_FACTORY for more details, and usage example
+ *
+ * @ingroup LinOp
+ */
+#define GKO_FACTORY_PARAMETER_SCALAR(_name, _default) \
+    GKO_FACTORY_PARAMETER(_name, _default)
+/**
+ * Creates a vector factory parameter in the factory parameters structure.
+ *
+ * Vector in this context means that the constructor for this type takes
+ * multiple parameters.
+ *
+ * @param _name  name of the parameter
+ * @param _default  default value of the parameter
+ *
+ * @see GKO_ENABLE_LIN_OP_FACTORY for more details, and usage example
+ *
+ * @ingroup LinOp
+ */
+#define GKO_FACTORY_PARAMETER_VECTOR(_name, ...) \
+    GKO_FACTORY_PARAMETER(_name, __VA_ARGS__)
 #else  // defined(__CUDACC__) || defined(__HIPCC__)
 // A workaround for the NVCC compiler - parameter pack expansion does not work
-// properly. You won't be able to use factories in code compiled with NVCC, but
-// at least this won't trigger a compiler error as soon as a header using it is
-// included. To not get a linker error, we provide a dummy body.
+// properly, because while the assignment to a scalar value is translated by
+// cudafe without parameter pack expansion, the corresponding parameter is not.
 #define GKO_FACTORY_PARAMETER(_name, ...)                                    \
     mutable _name{__VA_ARGS__};                                              \
                                                                              \
@@ -898,6 +929,35 @@ public:                                                                      \
     auto with_##_name(Args &&... _value)                                     \
         const->const std::decay_t<decltype(*this)> &                         \
     {                                                                        \
+        GKO_NOT_IMPLEMENTED;                                                 \
+        return *this;                                                        \
+    }                                                                        \
+    static_assert(true,                                                      \
+                  "This assert is used to counter the false positive extra " \
+                  "semi-colon warnings")
+#define GKO_FACTORY_PARAMETER_SCALAR(_name, _default)                        \
+    mutable _name{_default};                                                 \
+                                                                             \
+    template <typename Arg>                                                  \
+    auto with_##_name(Arg &&_value)                                          \
+        const->const ::gko::xstd::decay_t<decltype(*this)> &                 \
+    {                                                                        \
+        using type = decltype(this->_name);                                  \
+        this->_name = type{std::forward<Arg>(_value)};                       \
+        return *this;                                                        \
+    }                                                                        \
+    static_assert(true,                                                      \
+                  "This assert is used to counter the false positive extra " \
+                  "semi-colon warnings")
+#define GKO_FACTORY_PARAMETER_VECTOR(_name, ...)                             \
+    mutable _name{__VA_ARGS__};                                              \
+                                                                             \
+    template <typename... Args>                                              \
+    auto with_##_name(Args &&... _value)                                     \
+        const->const ::gko::xstd::decay_t<decltype(*this)> &                 \
+    {                                                                        \
+        using type = decltype(this->_name);                                  \
+        this->_name = type{std::forward<Args>(_value)...};                   \
         return *this;                                                        \
     }                                                                        \
     static_assert(true,                                                      \

--- a/include/ginkgo/core/factorization/ilu.hpp
+++ b/include/ginkgo/core/factorization/ilu.hpp
@@ -101,14 +101,14 @@ public:
          * `nullptr` will result in the strategy `classical`.
          */
         std::shared_ptr<typename matrix_type::strategy_type>
-            GKO_FACTORY_PARAMETER(l_strategy, nullptr);
+            GKO_FACTORY_PARAMETER_SCALAR(l_strategy, nullptr);
 
         /**
          * Strategy which will be used by the U matrix. The default value
          * `nullptr` will result in the strategy `classical`.
          */
         std::shared_ptr<typename matrix_type::strategy_type>
-            GKO_FACTORY_PARAMETER(u_strategy, nullptr);
+            GKO_FACTORY_PARAMETER_SCALAR(u_strategy, nullptr);
     };
     GKO_ENABLE_LIN_OP_FACTORY(Ilu, parameters, Factory);
     GKO_ENABLE_BUILD_METHOD(Factory);

--- a/include/ginkgo/core/factorization/par_ict.hpp
+++ b/include/ginkgo/core/factorization/par_ict.hpp
@@ -125,7 +125,7 @@ public:
          * The number of total iterations of ParICT that will be executed.
          * The default value is 5.
          */
-        size_type GKO_FACTORY_PARAMETER(iterations, 5);
+        size_type GKO_FACTORY_PARAMETER_SCALAR(iterations, 5);
 
         /**
          * @brief `true` means it is known that the matrix given to this
@@ -144,7 +144,7 @@ public:
          * it must remain `false`, otherwise, the factorization might be
          * incorrect.
          */
-        bool GKO_FACTORY_PARAMETER(skip_sorting, false);
+        bool GKO_FACTORY_PARAMETER_SCALAR(skip_sorting, false);
 
         /**
          * @brief `true` means the candidate selection will use an inexact
@@ -160,7 +160,7 @@ public:
          *
          * The default behavior is to use approximate selection.
          */
-        bool GKO_FACTORY_PARAMETER(approximate_select, true);
+        bool GKO_FACTORY_PARAMETER_SCALAR(approximate_select, true);
 
         /**
          * @brief `true` means the sample used for the selection algorithm will
@@ -179,7 +179,7 @@ public:
          *
          * The default behavior is to use a random sample.
          */
-        bool GKO_FACTORY_PARAMETER(deterministic_sample, false);
+        bool GKO_FACTORY_PARAMETER_SCALAR(deterministic_sample, false);
 
         /**
          * @brief the amount of fill-in that is allowed in L compared to
@@ -193,21 +193,21 @@ public:
          * The default value `2.0` allows twice the number of non-zeros in
          * L compared to the lower triangle of A.
          */
-        double GKO_FACTORY_PARAMETER(fill_in_limit, 2.0);
+        double GKO_FACTORY_PARAMETER_SCALAR(fill_in_limit, 2.0);
 
         /**
          * Strategy which will be used by the L matrix. The default value
          * `nullptr` will result in the strategy `classical`.
          */
         std::shared_ptr<typename matrix_type::strategy_type>
-            GKO_FACTORY_PARAMETER(l_strategy, nullptr);
+            GKO_FACTORY_PARAMETER_SCALAR(l_strategy, nullptr);
 
         /**
          * Strategy which will be used by the L^T matrix. The default value
          * `nullptr` will result in the strategy `classical`.
          */
         std::shared_ptr<typename matrix_type::strategy_type>
-            GKO_FACTORY_PARAMETER(lt_strategy, nullptr);
+            GKO_FACTORY_PARAMETER_SCALAR(lt_strategy, nullptr);
     };
     GKO_ENABLE_LIN_OP_FACTORY(ParIct, parameters, Factory);
     GKO_ENABLE_BUILD_METHOD(Factory);

--- a/include/ginkgo/core/factorization/par_ilu.hpp
+++ b/include/ginkgo/core/factorization/par_ilu.hpp
@@ -127,7 +127,7 @@ public:
          * implementation decides on the actual value depending on the
          * ressources that are available.
          */
-        size_type GKO_FACTORY_PARAMETER(iterations, 0);
+        size_type GKO_FACTORY_PARAMETER_SCALAR(iterations, 0);
 
         /**
          * @brief `true` means it is known that the matrix given to this
@@ -146,21 +146,21 @@ public:
          * it must remain `false`, otherwise, the factorization might be
          * incorrect.
          */
-        bool GKO_FACTORY_PARAMETER(skip_sorting, false);
+        bool GKO_FACTORY_PARAMETER_SCALAR(skip_sorting, false);
 
         /**
          * Strategy which will be used by the L matrix. The default value
          * `nullptr` will result in the strategy `classical`.
          */
         std::shared_ptr<typename l_matrix_type::strategy_type>
-            GKO_FACTORY_PARAMETER(l_strategy, nullptr);
+            GKO_FACTORY_PARAMETER_SCALAR(l_strategy, nullptr);
 
         /**
          * Strategy which will be used by the U matrix. The default value
          * `nullptr` will result in the strategy `classical`.
          */
         std::shared_ptr<typename u_matrix_type::strategy_type>
-            GKO_FACTORY_PARAMETER(u_strategy, nullptr);
+            GKO_FACTORY_PARAMETER_SCALAR(u_strategy, nullptr);
     };
     GKO_ENABLE_LIN_OP_FACTORY(ParIlu, parameters, Factory);
     GKO_ENABLE_BUILD_METHOD(Factory);

--- a/include/ginkgo/core/factorization/par_ilut.hpp
+++ b/include/ginkgo/core/factorization/par_ilut.hpp
@@ -129,7 +129,7 @@ public:
          * The number of total iterations of ParILUT that will be executed.
          * The default value is 5.
          */
-        size_type GKO_FACTORY_PARAMETER(iterations, 5);
+        size_type GKO_FACTORY_PARAMETER_SCALAR(iterations, 5);
 
         /**
          * @brief `true` means it is known that the matrix given to this
@@ -148,7 +148,7 @@ public:
          * it must remain `false`, otherwise, the factorization might be
          * incorrect.
          */
-        bool GKO_FACTORY_PARAMETER(skip_sorting, false);
+        bool GKO_FACTORY_PARAMETER_SCALAR(skip_sorting, false);
 
         /**
          * @brief `true` means the candidate selection will use an inexact
@@ -164,7 +164,7 @@ public:
          *
          * The default behavior is to use approximate selection.
          */
-        bool GKO_FACTORY_PARAMETER(approximate_select, true);
+        bool GKO_FACTORY_PARAMETER_SCALAR(approximate_select, true);
 
         /**
          * @brief `true` means the sample used for the selection algorithm will
@@ -183,7 +183,7 @@ public:
          *
          * The default behavior is to use a random sample.
          */
-        bool GKO_FACTORY_PARAMETER(deterministic_sample, false);
+        bool GKO_FACTORY_PARAMETER_SCALAR(deterministic_sample, false);
 
         /**
          * @brief the amount of fill-in that is allowed in L and U compared to
@@ -198,21 +198,21 @@ public:
          * The default value `2.0` allows twice the number of non-zeros in
          * L and U compared to ILU(0).
          */
-        double GKO_FACTORY_PARAMETER(fill_in_limit, 2.0);
+        double GKO_FACTORY_PARAMETER_SCALAR(fill_in_limit, 2.0);
 
         /**
          * Strategy which will be used by the L matrix. The default value
          * `nullptr` will result in the strategy `classical`.
          */
         std::shared_ptr<typename l_matrix_type::strategy_type>
-            GKO_FACTORY_PARAMETER(l_strategy, nullptr);
+            GKO_FACTORY_PARAMETER_SCALAR(l_strategy, nullptr);
 
         /**
          * Strategy which will be used by the U matrix. The default value
          * `nullptr` will result in the strategy `classical`.
          */
         std::shared_ptr<typename u_matrix_type::strategy_type>
-            GKO_FACTORY_PARAMETER(u_strategy, nullptr);
+            GKO_FACTORY_PARAMETER_SCALAR(u_strategy, nullptr);
     };
     GKO_ENABLE_LIN_OP_FACTORY(ParIlut, parameters, Factory);
     GKO_ENABLE_BUILD_METHOD(Factory);

--- a/include/ginkgo/core/preconditioner/ilu.hpp
+++ b/include/ginkgo/core/preconditioner/ilu.hpp
@@ -135,19 +135,19 @@ public:
         /**
          * Factory for the L solver
          */
-        std::shared_ptr<typename l_solver_type::Factory> GKO_FACTORY_PARAMETER(
-            l_solver_factory, nullptr);
+        std::shared_ptr<typename l_solver_type::Factory>
+            GKO_FACTORY_PARAMETER_SCALAR(l_solver_factory, nullptr);
 
         /**
          * Factory for the U solver
          */
-        std::shared_ptr<typename u_solver_type::Factory> GKO_FACTORY_PARAMETER(
-            u_solver_factory, nullptr);
+        std::shared_ptr<typename u_solver_type::Factory>
+            GKO_FACTORY_PARAMETER_SCALAR(u_solver_factory, nullptr);
 
         /**
          * Factory for the factorization
          */
-        std::shared_ptr<LinOpFactory> GKO_FACTORY_PARAMETER(
+        std::shared_ptr<LinOpFactory> GKO_FACTORY_PARAMETER_SCALAR(
             factorization_factory, nullptr);
     };
 

--- a/include/ginkgo/core/preconditioner/isai.hpp
+++ b/include/ginkgo/core/preconditioner/isai.hpp
@@ -132,7 +132,7 @@ public:
          * input matrix to be sorted. If it is, this parameter can be set to
          * `true` to skip the sorting for better performance.
          */
-        bool GKO_FACTORY_PARAMETER(skip_sorting, false);
+        bool GKO_FACTORY_PARAMETER_SCALAR(skip_sorting, false);
 
         /**
          * @brief Which power of the input matrix should be used for the
@@ -142,7 +142,7 @@ public:
          * pattern for the sparse inverse.
          * Must be at least 1, default value 1.
          */
-        int GKO_FACTORY_PARAMETER(sparsity_power, 1);
+        int GKO_FACTORY_PARAMETER_SCALAR(sparsity_power, 1);
     };
 
     GKO_ENABLE_LIN_OP_FACTORY(Isai, parameters, Factory);

--- a/include/ginkgo/core/preconditioner/jacobi.hpp
+++ b/include/ginkgo/core/preconditioner/jacobi.hpp
@@ -300,7 +300,7 @@ public:
          *
          * @note This value has to be between 1 and 32 (NVIDIA)/64 (AMD).
          */
-        uint32 GKO_FACTORY_PARAMETER(max_block_size, 32u);
+        uint32 GKO_FACTORY_PARAMETER_SCALAR(max_block_size, 32u);
 
         /**
          * Stride between two columns of a block (as number of elements).
@@ -311,7 +311,7 @@ public:
          *       reference executor. The allowed value: 0, 64 for AMD and 0, 32
          *       for NVIDIA
          */
-        uint32 GKO_FACTORY_PARAMETER(max_block_stride, 0u);
+        uint32 GKO_FACTORY_PARAMETER_SCALAR(max_block_stride, 0u);
 
         /**
          * Starting (row / column) indexes of individual blocks.
@@ -338,7 +338,8 @@ public:
          *       has to be respected when setting this parameter. Failure to do
          *       so will lead to undefined behavior.
          */
-        gko::Array<index_type> GKO_FACTORY_PARAMETER(block_pointers, nullptr);
+        gko::Array<index_type> GKO_FACTORY_PARAMETER_SCALAR(block_pointers,
+                                                            nullptr);
 
     private:
         // See documentation of storage_optimization parameter for details about
@@ -435,7 +436,7 @@ public:
          * If the non-adaptive version of Jacobi is used, the
          * `storage_optimization.block_wise` Array will be empty.
          */
-        storage_optimization_type GKO_FACTORY_PARAMETER(
+        storage_optimization_type GKO_FACTORY_PARAMETER_SCALAR(
             storage_optimization, precision_reduction(0, 0));
 
         /**
@@ -464,7 +465,7 @@ public:
          * accuracy to a value as close as possible to `dropout` will result in
          * optimal memory savings, while not degrading the quality of solution.
          */
-        remove_complex<value_type> GKO_FACTORY_PARAMETER(accuracy, 1e-1);
+        remove_complex<value_type> GKO_FACTORY_PARAMETER_SCALAR(accuracy, 1e-1);
     };
     GKO_ENABLE_LIN_OP_FACTORY(Jacobi, parameters, Factory);
     GKO_ENABLE_BUILD_METHOD(Factory);

--- a/include/ginkgo/core/preconditioner/jacobi.hpp
+++ b/include/ginkgo/core/preconditioner/jacobi.hpp
@@ -338,7 +338,7 @@ public:
          *       has to be respected when setting this parameter. Failure to do
          *       so will lead to undefined behavior.
          */
-        gko::Array<index_type> GKO_FACTORY_PARAMETER_SCALAR(block_pointers,
+        gko::Array<index_type> GKO_FACTORY_PARAMETER_VECTOR(block_pointers,
                                                             nullptr);
 
     private:
@@ -436,7 +436,7 @@ public:
          * If the non-adaptive version of Jacobi is used, the
          * `storage_optimization.block_wise` Array will be empty.
          */
-        storage_optimization_type GKO_FACTORY_PARAMETER_SCALAR(
+        storage_optimization_type GKO_FACTORY_PARAMETER_VECTOR(
             storage_optimization, precision_reduction(0, 0));
 
         /**

--- a/include/ginkgo/core/solver/bicg.hpp
+++ b/include/ginkgo/core/solver/bicg.hpp
@@ -127,19 +127,19 @@ public:
          * Criterion factories.
          */
         std::vector<std::shared_ptr<const stop::CriterionFactory>>
-            GKO_FACTORY_PARAMETER(criteria, nullptr);
+            GKO_FACTORY_PARAMETER_VECTOR(criteria, nullptr);
 
         /**
          * Preconditioner factory.
          */
-        std::shared_ptr<const LinOpFactory> GKO_FACTORY_PARAMETER(
+        std::shared_ptr<const LinOpFactory> GKO_FACTORY_PARAMETER_SCALAR(
             preconditioner, nullptr);
 
         /**
          * Already generated preconditioner. If one is provided, the factory
          * `preconditioner` will be ignored.
          */
-        std::shared_ptr<const LinOp> GKO_FACTORY_PARAMETER(
+        std::shared_ptr<const LinOp> GKO_FACTORY_PARAMETER_SCALAR(
             generated_preconditioner, nullptr);
     };
     GKO_ENABLE_LIN_OP_FACTORY(Bicg, parameters, Factory);

--- a/include/ginkgo/core/solver/bicgstab.hpp
+++ b/include/ginkgo/core/solver/bicgstab.hpp
@@ -132,19 +132,19 @@ public:
          * Criterion factories.
          */
         std::vector<std::shared_ptr<const stop::CriterionFactory>>
-            GKO_FACTORY_PARAMETER(criteria, nullptr);
+            GKO_FACTORY_PARAMETER_VECTOR(criteria, nullptr);
 
         /**
          * Preconditioner factory.
          */
-        std::shared_ptr<const LinOpFactory> GKO_FACTORY_PARAMETER(
+        std::shared_ptr<const LinOpFactory> GKO_FACTORY_PARAMETER_SCALAR(
             preconditioner, nullptr);
 
         /**
          * Already generated preconditioner. If one is provided, the factory
          * `preconditioner` will be ignored.
          */
-        std::shared_ptr<const LinOp> GKO_FACTORY_PARAMETER(
+        std::shared_ptr<const LinOp> GKO_FACTORY_PARAMETER_SCALAR(
             generated_preconditioner, nullptr);
     };
     GKO_ENABLE_LIN_OP_FACTORY(Bicgstab, parameters, Factory);

--- a/include/ginkgo/core/solver/cg.hpp
+++ b/include/ginkgo/core/solver/cg.hpp
@@ -128,19 +128,19 @@ public:
          * Criterion factories.
          */
         std::vector<std::shared_ptr<const stop::CriterionFactory>>
-            GKO_FACTORY_PARAMETER(criteria, nullptr);
+            GKO_FACTORY_PARAMETER_VECTOR(criteria, nullptr);
 
         /**
          * Preconditioner factory.
          */
-        std::shared_ptr<const LinOpFactory> GKO_FACTORY_PARAMETER(
+        std::shared_ptr<const LinOpFactory> GKO_FACTORY_PARAMETER_SCALAR(
             preconditioner, nullptr);
 
         /**
          * Already generated preconditioner. If one is provided, the factory
          * `preconditioner` will be ignored.
          */
-        std::shared_ptr<const LinOp> GKO_FACTORY_PARAMETER(
+        std::shared_ptr<const LinOp> GKO_FACTORY_PARAMETER_SCALAR(
             generated_preconditioner, nullptr);
     };
     GKO_ENABLE_LIN_OP_FACTORY(Cg, parameters, Factory);

--- a/include/ginkgo/core/solver/cgs.hpp
+++ b/include/ginkgo/core/solver/cgs.hpp
@@ -125,19 +125,19 @@ public:
          * Criterion factories.
          */
         std::vector<std::shared_ptr<const stop::CriterionFactory>>
-            GKO_FACTORY_PARAMETER(criteria, nullptr);
+            GKO_FACTORY_PARAMETER_VECTOR(criteria, nullptr);
 
         /**
          * Preconditioner factory.
          */
-        std::shared_ptr<const LinOpFactory> GKO_FACTORY_PARAMETER(
+        std::shared_ptr<const LinOpFactory> GKO_FACTORY_PARAMETER_SCALAR(
             preconditioner, nullptr);
 
         /**
          * Already generated preconditioner. If one is provided, the factory
          * `preconditioner` will be ignored.
          */
-        std::shared_ptr<const LinOp> GKO_FACTORY_PARAMETER(
+        std::shared_ptr<const LinOp> GKO_FACTORY_PARAMETER_SCALAR(
             generated_preconditioner, nullptr);
     };
     GKO_ENABLE_LIN_OP_FACTORY(Cgs, parameters, Factory);

--- a/include/ginkgo/core/solver/fcg.hpp
+++ b/include/ginkgo/core/solver/fcg.hpp
@@ -133,19 +133,19 @@ public:
          * Criterion factories.
          */
         std::vector<std::shared_ptr<const stop::CriterionFactory>>
-            GKO_FACTORY_PARAMETER(criteria, nullptr);
+            GKO_FACTORY_PARAMETER_VECTOR(criteria, nullptr);
 
         /**
          * Preconditioner factory.
          */
-        std::shared_ptr<const LinOpFactory> GKO_FACTORY_PARAMETER(
+        std::shared_ptr<const LinOpFactory> GKO_FACTORY_PARAMETER_SCALAR(
             preconditioner, nullptr);
 
         /**
          * Already generated preconditioner. If one is provided, the factory
          * `preconditioner` will be ignored.
          */
-        std::shared_ptr<const LinOp> GKO_FACTORY_PARAMETER(
+        std::shared_ptr<const LinOp> GKO_FACTORY_PARAMETER_SCALAR(
             generated_preconditioner, nullptr);
     };
     GKO_ENABLE_LIN_OP_FACTORY(Fcg, parameters, Factory);

--- a/include/ginkgo/core/solver/gmres.hpp
+++ b/include/ginkgo/core/solver/gmres.hpp
@@ -142,25 +142,25 @@ public:
          * Criterion factories.
          */
         std::vector<std::shared_ptr<const stop::CriterionFactory>>
-            GKO_FACTORY_PARAMETER(criteria, nullptr);
+            GKO_FACTORY_PARAMETER_VECTOR(criteria, nullptr);
 
         /**
          * Preconditioner factory.
          */
-        std::shared_ptr<const LinOpFactory> GKO_FACTORY_PARAMETER(
+        std::shared_ptr<const LinOpFactory> GKO_FACTORY_PARAMETER_SCALAR(
             preconditioner, nullptr);
 
         /**
          * Already generated preconditioner. If one is provided, the factory
          * `preconditioner` will be ignored.
          */
-        std::shared_ptr<const LinOp> GKO_FACTORY_PARAMETER(
+        std::shared_ptr<const LinOp> GKO_FACTORY_PARAMETER_SCALAR(
             generated_preconditioner, nullptr);
 
         /**
          * krylov dimension factory.
          */
-        size_type GKO_FACTORY_PARAMETER(krylov_dim, 0u);
+        size_type GKO_FACTORY_PARAMETER_SCALAR(krylov_dim, 0u);
     };
     GKO_ENABLE_LIN_OP_FACTORY(Gmres, parameters, Factory);
     GKO_ENABLE_BUILD_METHOD(Factory);

--- a/include/ginkgo/core/solver/ir.hpp
+++ b/include/ginkgo/core/solver/ir.hpp
@@ -178,25 +178,26 @@ public:
          * Criterion factories.
          */
         std::vector<std::shared_ptr<const stop::CriterionFactory>>
-            GKO_FACTORY_PARAMETER(criteria, nullptr);
+            GKO_FACTORY_PARAMETER_VECTOR(criteria, nullptr);
 
         /**
          * Inner solver factory.
          */
-        std::shared_ptr<const LinOpFactory> GKO_FACTORY_PARAMETER(solver,
-                                                                  nullptr);
+        std::shared_ptr<const LinOpFactory> GKO_FACTORY_PARAMETER_SCALAR(
+            solver, nullptr);
 
         /**
          * Already generated solver. If one is provided, the factory `solver`
          * will be ignored.
          */
-        std::shared_ptr<const LinOp> GKO_FACTORY_PARAMETER(generated_solver,
-                                                           nullptr);
+        std::shared_ptr<const LinOp> GKO_FACTORY_PARAMETER_SCALAR(
+            generated_solver, nullptr);
 
         /**
          * Relaxation factor for Richardson iteration
          */
-        ValueType GKO_FACTORY_PARAMETER(relaxation_factor, value_type{1});
+        ValueType GKO_FACTORY_PARAMETER_SCALAR(relaxation_factor,
+                                               value_type{1});
     };
     GKO_ENABLE_LIN_OP_FACTORY(Ir, parameters, Factory);
     GKO_ENABLE_BUILD_METHOD(Factory);

--- a/include/ginkgo/core/solver/lower_trs.hpp
+++ b/include/ginkgo/core/solver/lower_trs.hpp
@@ -117,7 +117,7 @@ public:
          *       sophisticated implementation. Hence this parameter is left
          *       here. But currently, there is no need to use it.
          */
-        gko::size_type GKO_FACTORY_PARAMETER(num_rhs, 1u);
+        gko::size_type GKO_FACTORY_PARAMETER_SCALAR(num_rhs, 1u);
     };
     GKO_ENABLE_LIN_OP_FACTORY(LowerTrs, parameters, Factory);
     GKO_ENABLE_BUILD_METHOD(Factory);

--- a/include/ginkgo/core/solver/upper_trs.hpp
+++ b/include/ginkgo/core/solver/upper_trs.hpp
@@ -117,7 +117,7 @@ public:
          *       sophisticated implementation. Hence this parameter is left
          *       here. But currently, there is no need to use it.
          */
-        gko::size_type GKO_FACTORY_PARAMETER(num_rhs, 1u);
+        gko::size_type GKO_FACTORY_PARAMETER_SCALAR(num_rhs, 1u);
     };
     GKO_ENABLE_LIN_OP_FACTORY(UpperTrs, parameters, Factory);
     GKO_ENABLE_BUILD_METHOD(Factory);

--- a/include/ginkgo/core/stop/combined.hpp
+++ b/include/ginkgo/core/stop/combined.hpp
@@ -68,7 +68,7 @@ public:
          * too costly.
          */
         std::vector<std::shared_ptr<const CriterionFactory>>
-            GKO_FACTORY_PARAMETER(criteria, nullptr);
+            GKO_FACTORY_PARAMETER_VECTOR(criteria, nullptr);
     };
     GKO_ENABLE_CRITERION_FACTORY(Combined, parameters, Factory);
     GKO_ENABLE_BUILD_METHOD(Factory);

--- a/include/ginkgo/core/stop/residual_norm.hpp
+++ b/include/ginkgo/core/stop/residual_norm.hpp
@@ -119,8 +119,8 @@ public:
         /**
          * Factor by which the residual norm will be reduced
          */
-        remove_complex<ValueType> GKO_FACTORY_PARAMETER(reduction_factor,
-                                                        1e-15);
+        remove_complex<ValueType> GKO_FACTORY_PARAMETER_SCALAR(reduction_factor,
+                                                               1e-15);
     };
     GKO_ENABLE_CRITERION_FACTORY(ResidualNormReduction<ValueType>, parameters,
                                  Factory);
@@ -179,7 +179,8 @@ public:
         /**
          * Relative residual norm goal
          */
-        remove_complex<ValueType> GKO_FACTORY_PARAMETER(tolerance, 1e-15);
+        remove_complex<ValueType> GKO_FACTORY_PARAMETER_SCALAR(tolerance,
+                                                               1e-15);
     };
     GKO_ENABLE_CRITERION_FACTORY(RelativeResidualNorm<ValueType>, parameters,
                                  Factory);
@@ -237,7 +238,8 @@ public:
         /**
          * Absolute residual norm goal
          */
-        remove_complex<ValueType> GKO_FACTORY_PARAMETER(tolerance, 1e-15);
+        remove_complex<ValueType> GKO_FACTORY_PARAMETER_SCALAR(tolerance,
+                                                               1e-15);
     };
     GKO_ENABLE_CRITERION_FACTORY(AbsoluteResidualNorm<ValueType>, parameters,
                                  Factory);

--- a/include/ginkgo/core/stop/time.hpp
+++ b/include/ginkgo/core/stop/time.hpp
@@ -60,8 +60,8 @@ public:
         /**
          * Amount of seconds to wait (default value: 10 seconds)
          */
-        std::chrono::nanoseconds GKO_FACTORY_PARAMETER(time_limit,
-                                                       10000000000LL);
+        std::chrono::nanoseconds GKO_FACTORY_PARAMETER_SCALAR(time_limit,
+                                                              10000000000LL);
     };
     GKO_ENABLE_CRITERION_FACTORY(Time, parameters, Factory);
     GKO_ENABLE_BUILD_METHOD(Factory);


### PR DESCRIPTION
This PR adds new "overloads" `GKO_FACTORY_PARAMETER_SCALAR`/`_VECTOR` for types which can be initialized with a single value/multiple values which are aliased to by `GKO_FACTORY_PARAMETER` in C++ compilers.
It also adds a NotImplemented exception for nvcc using `GKO_FACTORY_PARAMETER`.

Fixes #491