### PR TITLE
Remove unused preconditioner parameter in LowerTrs

### DIFF
--- a/include/ginkgo/core/solver/lower_trs.hpp
+++ b/include/ginkgo/core/solver/lower_trs.hpp
@@ -109,12 +109,6 @@ public:
     GKO_CREATE_FACTORY_PARAMETERS(parameters, Factory)
     {
         /**
-         * Preconditioner factory.
-         */
-        std::shared_ptr<const LinOpFactory> GKO_FACTORY_PARAMETER(
-            preconditioner, nullptr);
-
-        /**
          * Number of right hand sides.
          *
          * @note This value is currently a dummy value which is not used by the


### PR DESCRIPTION
When going through the factory parameters in Ginkgo, I noticed that the LowerTrs factory has a preconditioner parameter that is never used anywhere. This PR removes the unused parameter. Is this considered interface-breaking?