### PR TITLE
update Ampere sm information

### DIFF
--- a/common/base/executor.hpp.inc
+++ b/common/base/executor.hpp.inc
@@ -34,7 +34,7 @@ namespace {
 
 
 // The function is copied from _ConvertSMVer2Cores of
-// cuda-9.2/samples/common/inc/helper_cuda.h
+// cuda-11.0/samples/common/inc/helper_cuda.h
 inline int convert_sm_ver_to_cores(int major, int minor)
 {
     // Defines for GPU Architecture types (using the SM version to determine
@@ -59,6 +59,7 @@ inline int convert_sm_ver_to_cores(int major, int minor)
         {0x70, 64},   // Volta Generation (SM 7.0) GV100 class
         {0x72, 64},   // Volta Generation (SM 7.2) GV11b class
         {0x75, 64},   // Turing Generation (SM 7.5) TU1xx class
+        {0x80, 64},   // Ampere Generation (SM 8.0) GA100 class
         {-1, -1}};
 
     int index = 0;

--- a/hip/CMakeLists.txt
+++ b/hip/CMakeLists.txt
@@ -199,7 +199,7 @@ if (GINKGO_HIP_PLATFORM MATCHES "nvcc")
     endif()
     # add gpu architecture flags
     include(CudaArchitectureSelector)
-    cas_target_cuda_architectures_plain(GINKGO_HIP_NVCC_ARCH
+    cas_variable_cuda_architectures(GINKGO_HIP_NVCC_ARCH
         ARCHITECTURES ${GINKGO_CUDA_ARCHITECTURES}
         UNSUPPORTED "20" "21")
 endif()

--- a/third_party/CudaArchitectureSelector/CMakeLists.txt
+++ b/third_party/CudaArchitectureSelector/CMakeLists.txt
@@ -1,6 +1,6 @@
 ginkgo_load_git_package(CudaArchitectureSelector
     "https://github.com/ginkgo-project/CudaArchitectureSelector.git"
-    "f6e024cc2000eb870dc52166d4cdce9fe7f9a7a4")
+    "cba91d58e9bb847e572fedf8cc18f701ae035410")
 add_subdirectory(${CMAKE_CURRENT_BINARY_DIR}/src
     ${CMAKE_CURRENT_BINARY_DIR}/build EXCLUDE_FROM_ALL)
 set(CMAKE_MODULE_PATH "${CMAKE_MODULE_PATH}" PARENT_SCOPE)


### PR DESCRIPTION
This PR updates ampere sm information from `cuda-11.0/samples/common/inc/helper_cuda.h`
Also, update the `CudaArchitectureSelector` commit to support Ampere binding.

Todo:
- [x] Merge https://github.com/ginkgo-project/CudaArchitectureSelector/pull/6