### PR TITLE
Fix find_library(cublas) issue on the machine installing multiple cuda

### DIFF
--- a/cuda/CMakeLists.txt
+++ b/cuda/CMakeLists.txt
@@ -53,8 +53,14 @@ else()
     set(CUDA_RUNTIME_LIBS "${CUDA_RUNTIME_LIBS_DYNAMIC}" CACHE STRING "Path to a library" FORCE)
 endif()
 
+# CUDA 10.1/10.2 put cublas, cublasLt, cudnn in /usr/lib/<arch>-linux-gnu/, but
+# others (<= 10.0 or >= 11) put them in cuda own directory
+# If the environment installs several cuda including 10.1/10.2, cmake will find
+# the 10.1/10.2 .so files when searching others cuda in the default path.
+# CMake already puts /usr/lib/<arch>-linux-gnu/ after cuda own directory in the
+# `CMAKE_CUDA_IMPLICIT_LINK_DIRECTORIES`, so we always put NO_DEFAULT_PATH here.
 find_library(CUBLAS cublas
-    HINT ${CMAKE_CUDA_IMPLICIT_LINK_DIRECTORIES})
+    HINT ${CMAKE_CUDA_IMPLICIT_LINK_DIRECTORIES} NO_DEFAULT_PATH)
 find_library(CUSPARSE cusparse
     HINT ${CMAKE_CUDA_IMPLICIT_LINK_DIRECTORIES})
 


### PR DESCRIPTION
This PR forces`find_library(cublas)` on the given path not default path.

Cuda 10.1/10.2 put `cublas/cublasLt/cudnn` in `/usr/lib/<arch>-linux-gnu/`, but other versions put them in cuda own directory.
Thus, if the machine installs multiple cuda including 10.1/10.2, cmake always find the 10.1/10.2 .so files in default path.
CMake already puts the `/usr/lib/<arch>-linux-gnu/` in `CMAKE_CUDA_IMPLICIT_LINK_DIRECTORIES`, so we can always search cublas on this variable without default path.
Besides the ci test (cmake 3.14.7 on cuda9.2/10.1), cmake 3.9 on cuda9.2/10.1 which is ginkgo's minimal requirement includes `/usr/lib/<arch>-linux-gnu/` in `CMAKE_CUDA_IMPLICIT_LINK_DIRECTORIES`

Related page:
https://docs.nvidia.com/cuda/archive/10.1/cuda-toolkit-release-notes/index.html#cublas-new-features
https://docs.nvidia.com/cuda/cuda-toolkit-release-notes/index.html#cublas-new-features