### PR TITLE
add manual requirement of windows

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -84,11 +84,11 @@ Ginkgo adds the following additional switches to control what is being built:
     list of architectures. Supported values are:
 
     *   `Auto`
-    *   `Kepler`, `Maxwell`, `Pascal`, `Volta`
+    *   `Kepler`, `Maxwell`, `Pascal`, `Volta`, `Ampere`
     *   `CODE`, `CODE(COMPUTE)`, `(COMPUTE)`
 
     `Auto` will automatically detect the present CUDA-enabled GPU architectures
-    in the system. `Kepler`, `Maxwell`, `Pascal` and `Volta` will add flags for
+    in the system. `Kepler`, `Maxwell`, `Pascal`, `Volta` and `Ampere` will add flags for
     all architectures of that particular NVIDIA GPU generation. `COMPUTE` and
     `CODE` are placeholders that should be replaced with compute and code
     numbers (e.g.  for `compute_70` and `sm_70` `COMPUTE` and `CODE` should be
@@ -114,8 +114,56 @@ cmake  -G "Unix Makefiles" -H. -BDebug -DCMAKE_BUILD_TYPE=Debug -DGINKGO_DEVEL_T
 cmake --build Debug
 ```
 
-NOTE: Ginkgo is known to work with the `Unix Makefiles` and `Ninja` based
+NOTE: Ginkgo is known to work with the `Unix Makefiles`, `Ninja`, `MinGW Makefiles` and `Visual Studio 16 2019` based
 generators. Other CMake generators are untested.
+
+### Building Ginkgo in Windows
+Depending on the configuration settings, some manual work might be required:
+* Build Ginkgo as shared library:
+  Add `PROJECT_BINARY_DIR/GINKGO_WINDOWS_SHARED_LIBRARY_RELPATH` into the environment variable `PATH`.
+  `GINKGO_WINDOWS_SHARED_LIBRARY_RELPATH` is `windows_shared_library` by default. More Details are available in the [Installation page](./INSTALL.md).
+  * cmd: `set PATH="<PROJECT_BINARY_DIR/GINKGO_WINDOWS_SHARED_LIBRARY_RELPATH>;%PATH%"`
+  * powershell: `$env:PATH="<PROJECT_BINARY_DIR/GINKGO_WINDOWS_SHARED_LIBRARY_RELPATH>;$env:PATH"`
+
+  CMake will gives the error message if the path is not correct.
+  ```
+  Did not find this build in the environment variable PATH. Please add <path> into the environment variable PATH.
+  ```
+  the `<path>` is the needed `<PROJECT_BINARY_DIR/GINKGO_WINDOWS_SHARED_LIBRARY_RELPATH>`.
+* Build Ginkgo with Debug mode:
+  Some Debug build specific issues can appear depending on the machine and environment. The known issues are the following:
+  1. `bigobj` issue: encountering  `too many sections` needs the compilation flags `\bigobj` or `-Wa,-mbig-obj`
+  2. `ld` issue: encountering  `ld: error: export ordinal too large` needs the compilation flag `-O1`
+
+  The following are the details for different environments:
+  * _Microsoft Visual Studio_:
+    1. `bigobj` issue
+      * `cmake -DCMAKE_CXX_FLAGS=\bigobj <other parameters> <source_folder>` which might overwrite the default settings.
+      * add `\bigobj` into the environment variable `CXXFLAGS` (only availible in the first cmake configuration)
+        * cmd: `set CXXFLAGS=\bigobj`
+        * powershell: `$env:CXXFLAGS=\bigobj`
+    2. `ld` issue (_Microsoft Visual Studio_ does not have this issue)
+  * _Cygwin_:
+    1. `bigobj` issue
+      * add `-Wa,-mbig-obj -O1` into the environment variable `CXXFLAGS` (only availible in the first cmake configuration)
+        * `export CXXFLAGS="-Wa,-mbig-obj -O1"`
+      * `cmake -DCMAKE_CXX_FLAGS=-Wa,-mbig-obj <other parameters> <source_folder>`, which might overwrite the default settings.
+    2. `ld` issue (If build Ginkgo as static library, do not need this)
+      * `cmake -DGINKGO_COMPILER_FLAGS="-Wpedantic -O1" <other parameters> <source_folder>` (`GINKGO_COMPILER_FLAGS` is `-Wpedantic` by default)
+      * add `-O1` in the environement variable `CXX_FLAGS` or `CMAKE_CXX_FLAGS`
+  * _MinGW_:
+    1. `bigobj` issue
+      * add `-Wa,-mbig-obj -O1` into the environment variable `CXXFLAGS` (only availible in the first cmake configuration)
+        * cmd: `set CXXFLAGS="-Wa,-mbig-obj"`
+        * powershell: `$env:CXXFLAGS="-Wa,-mbig-obj"`
+      * `cmake -DCMAKE_CXX_FLAGS=-Wa,-mbig-obj <other parameters> <source_folder>`, which might overwrite the default settings.
+    2. `ld` issue (If build Ginkgo as static library, do not need this)
+      * `cmake -DGINKGO_COMPILER_FLAGS="-Wpedantic -O1" <other parameters> <source_folder>` (`GINKGO_COMPILER_FLAGS` is `-Wpedantic` by default)
+      * add `-O1` in the environement variable `CXX_FLAGS` or `CMAKE_CXX_FLAGS`
+* Build Ginkgo in _MinGW_:
+  If encountering the issue `cc1plus.exe: out of memory allocating 65536 bytes`, please follow the workaround in
+  [reference](https://www.intel.com/content/www/us/en/programmable/support/support-resources/knowledge-base/embedded/2016/cc1plus-exe--out-of-memory-allocating-65536-bytes.html),
+  or compile ginkgo again might work.
 
 ### Building Ginkgo with HIP support
 Ginkgo provides a [HIP](https://github.com/ROCm-Developer-Tools/HIP) backend.

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -125,11 +125,11 @@ Depending on the configuration settings, some manual work might be required:
   * cmd: `set PATH="<PROJECT_BINARY_DIR/GINKGO_WINDOWS_SHARED_LIBRARY_RELPATH>;%PATH%"`
   * powershell: `$env:PATH="<PROJECT_BINARY_DIR/GINKGO_WINDOWS_SHARED_LIBRARY_RELPATH>;$env:PATH"`
 
-  CMake will gives the error message if the path is not correct.
+  CMake will give the following error message if the path is not correct.
   ```
   Did not find this build in the environment variable PATH. Please add <path> into the environment variable PATH.
   ```
-  the `<path>` is the needed `<PROJECT_BINARY_DIR/GINKGO_WINDOWS_SHARED_LIBRARY_RELPATH>`.
+  where `<path>` is the needed `<PROJECT_BINARY_DIR/GINKGO_WINDOWS_SHARED_LIBRARY_RELPATH>`.
 * Build Ginkgo with Debug mode:
   Some Debug build specific issues can appear depending on the machine and environment. The known issues are the following:
   1. `bigobj` issue: encountering  `too many sections` needs the compilation flags `\bigobj` or `-Wa,-mbig-obj`
@@ -139,31 +139,31 @@ Depending on the configuration settings, some manual work might be required:
   * _Microsoft Visual Studio_:
     1. `bigobj` issue
       * `cmake -DCMAKE_CXX_FLAGS=\bigobj <other parameters> <source_folder>` which might overwrite the default settings.
-      * add `\bigobj` into the environment variable `CXXFLAGS` (only availible in the first cmake configuration)
+      * add `\bigobj` into the environment variable `CXXFLAGS` (only available in the first cmake configuration)
         * cmd: `set CXXFLAGS=\bigobj`
         * powershell: `$env:CXXFLAGS=\bigobj`
     2. `ld` issue (_Microsoft Visual Studio_ does not have this issue)
   * _Cygwin_:
     1. `bigobj` issue
-      * add `-Wa,-mbig-obj -O1` into the environment variable `CXXFLAGS` (only availible in the first cmake configuration)
+      * add `-Wa,-mbig-obj -O1` into the environment variable `CXXFLAGS` (only available in the first cmake configuration)
         * `export CXXFLAGS="-Wa,-mbig-obj -O1"`
       * `cmake -DCMAKE_CXX_FLAGS=-Wa,-mbig-obj <other parameters> <source_folder>`, which might overwrite the default settings.
-    2. `ld` issue (If build Ginkgo as static library, do not need this)
+    2. `ld` issue (If building Ginkgo as static library, this is not needed)
       * `cmake -DGINKGO_COMPILER_FLAGS="-Wpedantic -O1" <other parameters> <source_folder>` (`GINKGO_COMPILER_FLAGS` is `-Wpedantic` by default)
       * add `-O1` in the environement variable `CXX_FLAGS` or `CMAKE_CXX_FLAGS`
   * _MinGW_:
     1. `bigobj` issue
-      * add `-Wa,-mbig-obj -O1` into the environment variable `CXXFLAGS` (only availible in the first cmake configuration)
+      * add `-Wa,-mbig-obj -O1` into the environment variable `CXXFLAGS` (only available in the first cmake configuration)
         * cmd: `set CXXFLAGS="-Wa,-mbig-obj"`
         * powershell: `$env:CXXFLAGS="-Wa,-mbig-obj"`
       * `cmake -DCMAKE_CXX_FLAGS=-Wa,-mbig-obj <other parameters> <source_folder>`, which might overwrite the default settings.
-    2. `ld` issue (If build Ginkgo as static library, do not need this)
+    2. `ld` issue (If building Ginkgo as static library, this is not needed)
       * `cmake -DGINKGO_COMPILER_FLAGS="-Wpedantic -O1" <other parameters> <source_folder>` (`GINKGO_COMPILER_FLAGS` is `-Wpedantic` by default)
       * add `-O1` in the environement variable `CXX_FLAGS` or `CMAKE_CXX_FLAGS`
 * Build Ginkgo in _MinGW_:
   If encountering the issue `cc1plus.exe: out of memory allocating 65536 bytes`, please follow the workaround in
   [reference](https://www.intel.com/content/www/us/en/programmable/support/support-resources/knowledge-base/embedded/2016/cc1plus-exe--out-of-memory-allocating-65536-bytes.html),
-  or compile ginkgo again might work.
+  or trying to compile ginkgo again might work.
 
 ### Building Ginkgo with HIP support
 Ginkgo provides a [HIP](https://github.com/ROCm-Developer-Tools/HIP) backend.
@@ -316,4 +316,3 @@ the call with `sudo`.
 
 After the installation, CMake can find ginkgo with `find_package(Ginkgo)`.
 An example can be found in the [`test_install`](test_install/CMakeLists.txt).
-

--- a/README.md
+++ b/README.md
@@ -87,42 +87,14 @@ The Ginkgo CUDA module has the following __additional__ requirements:
 The Ginkgo OMP module has the following __additional__ requirements:
 *  _MinGW_ or _Cygwin_
 
-Need to add the following manually according to configuration settings:
+Depending on the configuration settings, some manual work might be required. More details are availble in [windows section in INSTALL.md](INSTALL.md#building-ginkgo-in-windows):
 * Build Ginkgo as shared library:
   Add `PROJECT_BINARY_DIR/GINKGO_WINDOWS_SHARED_LIBRARY_RELPATH` into the environment variable `PATH`.
-  `GINKGO_WINDOWS_SHARED_LIBRARY_RELPATH` is `windows_shared_library` by default. More Details are available in the [Installation page](./INSTALL.md).
-  * cmd: `set PATH="<PROJECT_BINARY_DIR/GINKGO_WINDOWS_SHARED_LIBRARY_RELPATH>;%PATH%"`
-  * powershell: `$env:PATH="<PROJECT_BINARY_DIR/GINKGO_WINDOWS_SHARED_LIBRARY_RELPATH>;$env:PATH"`
-
-  CMake will gives the error message including `<PROJECT_BINARY_DIR/GINKGO_WINDOWS_SHARED_LIBRARY_RELPATH>` if the path is not correct.
-  ```Did not find this build in the environment variable PATH. Please add <path> into the environment variable PATH.```
+  `GINKGO_WINDOWS_SHARED_LIBRARY_RELPATH` is `windows_shared_library` by default.
 * Build Ginkgo with Debug mode:
-  1. `bigobj` issue: encontering `too many sections` needs `\bigobj` or `-Wa,-mbig-obj`
-  2. `ld` issue: encontering `ld: error: export ordinal too large` needs `-O1`
-
-  The following are the details for different environments.
-  * _Microsoft Visual Studio_:
-    1. `bigobj` issue
-      * `cmake -DCMAKE_CXX_FLAGS=\bigobj <other parameters> <source_folder>` which might overwrite the default settings.
-      * add `\bigobj` into the environment variable `CXXFLAGS` (only availible in the first cmake configuration)
-        * cmd: `set CXXFLAGS=\bigobj`
-        * powershell: `$env:CXXFLAGS=\bigobj`
-    2. `ld` issue (_Microsoft Visual Studio_ does not have this issue)
-  * _Cygwin_:
-    1. `bigobj` issue
-      * add `-Wa,-mbig-obj -O1` into the environment variable `CXXFLAGS` (only availible in the first cmake configuration)
-        * `export CXXFLAGS="-Wa,-mbig-obj -O1"`
-      * `cmake -DCMAKE_CXX_FLAGS=-Wa,-mbig-obj <other parameters> <source_folder>`, which might overwrite the default settings.
-    2. `ld` issue (If build Ginkgo as static library, do not need this)
-      * `cmake -DGINKGO_COMPILER_FLAGS="-Wpedantic -O1" <other parameters> <source_folder>` (`GINKGO_COMPILER_FLAGS` is `-Wpedantic` by default)
-  * _MinGW_:
-    1. `bigobj` issue
-      * add `-Wa,-mbig-obj -O1` into the environment variable `CXXFLAGS` (only availible in the first cmake configuration)
-        * cmd: `set CXXFLAGS="-Wa,-mbig-obj"`
-        * powershell: `$env:CXXFLAGS="-Wa,-mbig-obj"`
-      * `cmake -DCMAKE_CXX_FLAGS=-Wa,-mbig-obj <other parameters> <source_folder>`, which might overwrite the default settings.
-    2. `ld` issue (If build Ginkgo as static library, do not need this)
-      * `cmake -DGINKGO_COMPILER_FLAGS="-Wpedantic -O1" <other parameters> <source_folder>` (`GINKGO_COMPILER_FLAGS` is `-Wpedantic` by default)
+  Some Debug build specific issues can appear depending on the machine and environment. The known issues are the following:
+  1. `bigobj` issue: encountering  `too many sections` needs the compilation flags `\bigobj` or `-Wa,-mbig-obj`
+  2. `ld` issue: encountering  `ld: error: export ordinal too large` needs the compilation flag `-O1`
 * Build Ginkgo in _MinGW_:
   If encountering the issue `cc1plus.exe: out of memory allocating 65536 bytes`, please follow the workaround in
   [reference](https://www.intel.com/content/www/us/en/programmable/support/support-resources/knowledge-base/embedded/2016/cc1plus-exe--out-of-memory-allocating-65536-bytes.html),

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ reflect the current state of the library.
 Prerequisites
 -------------
 
-### Linux and Mac OS 
+### Linux and Mac OS
 
 For Ginkgo core library:
 
@@ -87,6 +87,37 @@ The Ginkgo CUDA module has the following __additional__ requirements:
 The Ginkgo OMP module has the following __additional__ requirements:
 *  _MinGW_ or _Cygwin_
 
+Need to add the following manually according to configuration settings:
+* Build Ginkgo as shared library:
+  Add `PROJECT_BINARY_DIR/GINKGO_WINDOWS_SHARED_LIBRARY_RELPATH` into the environment variable `PATH`.
+  `GINKGO_WINDOWS_SHARED_LIBRARY_RELPATH` is `windows_shared_library` by default. More Details are available in the [Installation page](./INSTALL.md).
+  * cmd: `set PATH="<PROJECT_BINARY_DIR/GINKGO_WINDOWS_SHARED_LIBRARY_RELPATH>;%PATH%"`
+  * powershell: `$env:PATH="<PROJECT_BINARY_DIR/GINKGO_WINDOWS_SHARED_LIBRARY_RELPATH>;$env:PATH"`
+
+  CMake will gives the error message including `<PROJECT_BINARY_DIR/GINKGO_WINDOWS_SHARED_LIBRARY_RELPATH>` if the path is not correct.
+  ```Did not find this build in the environment variable PATH. Please add <path> into the environment variable PATH.```
+* Build Ginkgo with Debug mode:
+  encontering `(obj) file too big` needs `\bigobj` or `-Wa,-mbig-obj` or encontering `ld: error: export ordinal too large` needs `-O1`.
+  The following are the details for different environments.
+  * _Microsoft Visual Studio_:
+    * `cmake -DGINKGO_COMPILER_FLAGS=\bigobj <other parameters> <source_folder>`
+    * add `\bigobj` into the environment variable `CXXFLAGS` (only availible in the first cmake configuration)
+      * cmd: `set CXXFLAGS=\bigobj`
+      * powershell: `$env:CXXFLAGS=\bigobj`
+  * _Cygwin_: (If build ginkgo as static library, don't need `-O1`)
+    * `cmake -DGINKGO_COMPILER_FLAGS="-Wpedantic -Wa,-mbig-obj -O1" <other parameters> <source_folder>` (`GINKGO_COMPILER_FLAGS` is `-Wpedantic` by default)
+    * add `-Wa,-mbig-obj -O1` into the environment variable `CXXFLAGS` (only availible in the first cmake configuration)
+      * `export CXXFLAGS="-Wa,-mbig-obj -O1"`
+  * _MinGW_: (If build ginkgo as static library, don't need `-O1`)
+    * `cmake -DGINKGO_COMPILER_FLAGS="-Wpedantic -Wa,-mbig-obj -O1" <other parameters> <source_folder>` (`GINKGO_COMPILER_FLAGS` is `-Wpedantic` by default)
+    * add `-Wa,-mbig-obj -O1` into the environment variable `CXXFLAGS` (only availible in the first cmake configuration)
+      * cmd: `set CXXFLAGS="-Wa,-mbig-obj -O1"`
+      * powershell: `$env:CXXFLAGS="-Wa,-mbig-obj -O1"`
+* Build Ginkgo in _MinGW_:
+  If encountering the issue `cc1plus.exe: out of memory allocating 65536 bytes`, please follow the workaround in
+  [reference](https://www.intel.com/content/www/us/en/programmable/support/support-resources/knowledge-base/embedded/2016/cc1plus-exe--out-of-memory-allocating-65536-bytes.html),
+  or compile ginkgo again might work.
+
 __NOTE:__ _Microsoft Visual Studio_ only supports OpenMP 2.0, so it can not compile the ginkgo OMP module.
 
 __NOTE:__ Some restrictions will also apply on the version of C and C++ standard
@@ -97,7 +128,7 @@ Quick Install
 
 ### Building Ginkgo
 
-To build Ginkgo, you can use the standard CMake procedure. 
+To build Ginkgo, you can use the standard CMake procedure.
 
 ```sh
 mkdir build; cd build
@@ -122,7 +153,7 @@ Ginkgo does comprehensive unit tests using Google Tests. These tests are enabled
 ### Running the benchmarks
 
 A unique feature of Ginkgo is the ability to run benchmarks and view your results
-with the help of the [Ginkgo Performance Explorer (GPE)](https://ginkgo-project.github.io/gpe/). 
+with the help of the [Ginkgo Performance Explorer (GPE)](https://ginkgo-project.github.io/gpe/).
 
 More details about this can be found in the [BENCHMARKING.md page](./BENCHMARKING.md)
 
@@ -151,7 +182,7 @@ library design, relevant C++ information, and more.
 If you have any question, bug to report or would like to propose a new feature,
 feel free to [create an
 issue on GitHub](https://github.com/ginkgo-project/ginkgo/issues/new). Another possibility
-is to send an email to [Ginkgo's main email address](ginkgo.library@gmail.com)
+is to send an email to [Ginkgo's main email address](mailto:ginkgo.library@gmail.com)
 or to contact any of the main [contributors](contributors.txt).
 
 

--- a/README.md
+++ b/README.md
@@ -97,22 +97,32 @@ Need to add the following manually according to configuration settings:
   CMake will gives the error message including `<PROJECT_BINARY_DIR/GINKGO_WINDOWS_SHARED_LIBRARY_RELPATH>` if the path is not correct.
   ```Did not find this build in the environment variable PATH. Please add <path> into the environment variable PATH.```
 * Build Ginkgo with Debug mode:
-  encontering `(obj) file too big` needs `\bigobj` or `-Wa,-mbig-obj` or encontering `ld: error: export ordinal too large` needs `-O1`.
+  1. `bigobj` issue: encontering `too many sections` needs `\bigobj` or `-Wa,-mbig-obj`
+  2. `ld` issue: encontering `ld: error: export ordinal too large` needs `-O1`
+
   The following are the details for different environments.
   * _Microsoft Visual Studio_:
-    * `cmake -DGINKGO_COMPILER_FLAGS=\bigobj <other parameters> <source_folder>`
-    * add `\bigobj` into the environment variable `CXXFLAGS` (only availible in the first cmake configuration)
-      * cmd: `set CXXFLAGS=\bigobj`
-      * powershell: `$env:CXXFLAGS=\bigobj`
-  * _Cygwin_: (If build ginkgo as static library, don't need `-O1`)
-    * `cmake -DGINKGO_COMPILER_FLAGS="-Wpedantic -Wa,-mbig-obj -O1" <other parameters> <source_folder>` (`GINKGO_COMPILER_FLAGS` is `-Wpedantic` by default)
-    * add `-Wa,-mbig-obj -O1` into the environment variable `CXXFLAGS` (only availible in the first cmake configuration)
-      * `export CXXFLAGS="-Wa,-mbig-obj -O1"`
-  * _MinGW_: (If build ginkgo as static library, don't need `-O1`)
-    * `cmake -DGINKGO_COMPILER_FLAGS="-Wpedantic -Wa,-mbig-obj -O1" <other parameters> <source_folder>` (`GINKGO_COMPILER_FLAGS` is `-Wpedantic` by default)
-    * add `-Wa,-mbig-obj -O1` into the environment variable `CXXFLAGS` (only availible in the first cmake configuration)
-      * cmd: `set CXXFLAGS="-Wa,-mbig-obj -O1"`
-      * powershell: `$env:CXXFLAGS="-Wa,-mbig-obj -O1"`
+    1. `bigobj` issue
+      * `cmake -DCMAKE_CXX_FLAGS=\bigobj <other parameters> <source_folder>` which might overwrite the default settings.
+      * add `\bigobj` into the environment variable `CXXFLAGS` (only availible in the first cmake configuration)
+        * cmd: `set CXXFLAGS=\bigobj`
+        * powershell: `$env:CXXFLAGS=\bigobj`
+    2. `ld` issue (_Microsoft Visual Studio_ does not have this issue)
+  * _Cygwin_:
+    1. `bigobj` issue
+      * add `-Wa,-mbig-obj -O1` into the environment variable `CXXFLAGS` (only availible in the first cmake configuration)
+        * `export CXXFLAGS="-Wa,-mbig-obj -O1"`
+      * `cmake -DCMAKE_CXX_FLAGS=-Wa,-mbig-obj <other parameters> <source_folder>`, which might overwrite the default settings.
+    2. `ld` issue (If build Ginkgo as static library, do not need this)
+      * `cmake -DGINKGO_COMPILER_FLAGS="-Wpedantic -O1" <other parameters> <source_folder>` (`GINKGO_COMPILER_FLAGS` is `-Wpedantic` by default)
+  * _MinGW_:
+    1. `bigobj` issue
+      * add `-Wa,-mbig-obj -O1` into the environment variable `CXXFLAGS` (only availible in the first cmake configuration)
+        * cmd: `set CXXFLAGS="-Wa,-mbig-obj"`
+        * powershell: `$env:CXXFLAGS="-Wa,-mbig-obj"`
+      * `cmake -DCMAKE_CXX_FLAGS=-Wa,-mbig-obj <other parameters> <source_folder>`, which might overwrite the default settings.
+    2. `ld` issue (If build Ginkgo as static library, do not need this)
+      * `cmake -DGINKGO_COMPILER_FLAGS="-Wpedantic -O1" <other parameters> <source_folder>` (`GINKGO_COMPILER_FLAGS` is `-Wpedantic` by default)
 * Build Ginkgo in _MinGW_:
   If encountering the issue `cc1plus.exe: out of memory allocating 65536 bytes`, please follow the workaround in
   [reference](https://www.intel.com/content/www/us/en/programmable/support/support-resources/knowledge-base/embedded/2016/cc1plus-exe--out-of-memory-allocating-65536-bytes.html),


### PR DESCRIPTION
This pr adds the manual requirement of windows in README.md which is related to #600 .

I am checking whether the setting of Debug is only needed in shared ginkgo library.
-> Debug and Static does not need `-O1`
The description can be reviewed