### PR TITLE
Create executor in exec_map only if requested.

### DIFF
--- a/contributors.txt
+++ b/contributors.txt
@@ -17,3 +17,4 @@ Maier Matthias <matthias@43-1.org> Texas A&M University
 Nayak Pratik <pratik.nayak@kit.edu> Karlsruhe Institute of Technology
 Ribizel Tobias <mail@upsj.de> Karlsruhe Institute of Technology
 Tsai Yuhsiang <yhmtsai@gmail.com> National Taiwan University
+Gregor Olenik <go@hpsim.de> HPSim

--- a/contributors.txt
+++ b/contributors.txt
@@ -15,6 +15,6 @@ Hoemmen Mark <mhoemme@sandia.gov> Sandia National Laboratories
 Holeksa Claudius <mail@keldu.de> Karlsruhe Institute of Technology
 Maier Matthias <matthias@43-1.org> Texas A&M University
 Nayak Pratik <pratik.nayak@kit.edu> Karlsruhe Institute of Technology
+Olenik Gregor <go@hpsim.de> HPSim
 Ribizel Tobias <mail@upsj.de> Karlsruhe Institute of Technology
 Tsai Yuhsiang <yhmtsai@gmail.com> National Taiwan University
-Gregor Olenik <go@hpsim.de> HPSim

--- a/examples/custom-matrix-format/custom-matrix-format.cpp
+++ b/examples/custom-matrix-format/custom-matrix-format.cpp
@@ -270,7 +270,7 @@ int main(int argc, char *argv[])
     // executor where Ginkgo will perform the computation
     const auto exec = exec_map.at(executor_string)();  // throws if not valid
     // executor used by the application
-    const auto app_exec = exec_map["omp"]();
+    const auto app_exec = exec->get_master();
 
     // problem:
     auto correct_u = [](ValueType x) { return x * x * x; };

--- a/examples/custom-matrix-format/custom-matrix-format.cpp
+++ b/examples/custom-matrix-format/custom-matrix-format.cpp
@@ -252,17 +252,25 @@ int main(int argc, char *argv[])
     const auto executor_string = argc >= 3 ? argv[2] : "reference";
 
     // Figure out where to run the code
-    const auto omp = gko::OmpExecutor::create();
-    std::map<std::string, std::shared_ptr<gko::Executor>> exec_map{
-        {"omp", omp},
-        {"cuda", gko::CudaExecutor::create(0, omp, true)},
-        {"hip", gko::HipExecutor::create(0, omp, true)},
-        {"reference", gko::ReferenceExecutor::create()}};
+    std::map<std::string, std::function<std::shared_ptr<gko::Executor>()>>
+        exec_map{
+            {"omp", [] { return gko::OmpExecutor::create(); }},
+            {"cuda",
+             [] {
+                 return gko::CudaExecutor::create(0, gko::OmpExecutor::create(),
+                                                  true);
+             }},
+            {"hip",
+             [] {
+                 return gko::HipExecutor::create(0, gko::OmpExecutor::create(),
+                                                 true);
+             }},
+            {"reference", [] { return gko::ReferenceExecutor::create(); }}};
 
     // executor where Ginkgo will perform the computation
-    const auto exec = exec_map.at(executor_string);  // throws if not valid
+    const auto exec = exec_map.at(executor_string)();  // throws if not valid
     // executor used by the application
-    const auto app_exec = exec_map["omp"];
+    const auto app_exec = exec_map["omp"]();
 
     // problem:
     auto correct_u = [](ValueType x) { return x * x * x; };

--- a/examples/nine-pt-stencil-solver/nine-pt-stencil-solver.cpp
+++ b/examples/nine-pt-stencil-solver/nine-pt-stencil-solver.cpp
@@ -243,7 +243,7 @@ void solve_system(const std::string &executor_string,
     // executor where Ginkgo will perform the computation
     const auto exec = exec_map.at(executor_string)();  // throws if not valid
     // executor where the application initialized the data
-    const auto app_exec = exec_map["omp"]();
+    const auto app_exec = exec->get_master();
 
     // Tell Ginkgo to use the data in our application
 

--- a/examples/nine-pt-stencil-solver/nine-pt-stencil-solver.cpp
+++ b/examples/nine-pt-stencil-solver/nine-pt-stencil-solver.cpp
@@ -225,16 +225,25 @@ void solve_system(const std::string &executor_string,
     const gko::size_type dp_2 = dp * dp;
 
     // Figure out where to run the code
-    const auto omp = gko::OmpExecutor::create();
-    std::map<std::string, std::shared_ptr<gko::Executor>> exec_map{
-        {"omp", omp},
-        {"cuda", gko::CudaExecutor::create(0, omp, true)},
-        {"hip", gko::HipExecutor::create(0, omp, true)},
-        {"reference", gko::ReferenceExecutor::create()}};
+    std::map<std::string, std::function<std::shared_ptr<gko::Executor>()>>
+        exec_map{
+            {"omp", [] { return gko::OmpExecutor::create(); }},
+            {"cuda",
+             [] {
+                 return gko::CudaExecutor::create(0, gko::OmpExecutor::create(),
+                                                  true);
+             }},
+            {"hip",
+             [] {
+                 return gko::HipExecutor::create(0, gko::OmpExecutor::create(),
+                                                 true);
+             }},
+            {"reference", [] { return gko::ReferenceExecutor::create(); }}};
+
     // executor where Ginkgo will perform the computation
-    const auto exec = exec_map.at(executor_string);  // throws if not valid
+    const auto exec = exec_map.at(executor_string)();  // throws if not valid
     // executor where the application initialized the data
-    const auto app_exec = exec_map["omp"];
+    const auto app_exec = exec_map["omp"]();
 
     // Tell Ginkgo to use the data in our application
 

--- a/examples/poisson-solver/poisson-solver.cpp
+++ b/examples/poisson-solver/poisson-solver.cpp
@@ -134,17 +134,25 @@ int main(int argc, char *argv[])
     const auto executor_string = argc >= 3 ? argv[2] : "reference";
 
     // Figure out where to run the code
-    const auto omp = gko::OmpExecutor::create();
-    std::map<std::string, std::shared_ptr<gko::Executor>> exec_map{
-        {"omp", omp},
-        {"cuda", gko::CudaExecutor::create(0, omp, true)},
-        {"hip", gko::HipExecutor::create(0, omp, true)},
-        {"reference", gko::ReferenceExecutor::create()}};
+    std::map<std::string, std::function<std::shared_ptr<gko::Executor>()>>
+        exec_map{
+            {"omp", [] { return gko::OmpExecutor::create(); }},
+            {"cuda",
+             [] {
+                 return gko::CudaExecutor::create(0, gko::OmpExecutor::create(),
+                                                  true);
+             }},
+            {"hip",
+             [] {
+                 return gko::HipExecutor::create(0, gko::OmpExecutor::create(),
+                                                 true);
+             }},
+            {"reference", [] { return gko::ReferenceExecutor::create(); }}};
 
     // executor where Ginkgo will perform the computation
-    const auto exec = exec_map.at(executor_string);  // throws if not valid
+    const auto exec = exec_map.at(executor_string)();  // throws if not valid
     // executor used by the application
-    const auto app_exec = exec_map["omp"];
+    const auto app_exec = exec_map["omp"]();
 
     // problem:
     auto correct_u = [](ValueType x) { return x * x * x; };

--- a/examples/poisson-solver/poisson-solver.cpp
+++ b/examples/poisson-solver/poisson-solver.cpp
@@ -152,7 +152,7 @@ int main(int argc, char *argv[])
     // executor where Ginkgo will perform the computation
     const auto exec = exec_map.at(executor_string)();  // throws if not valid
     // executor used by the application
-    const auto app_exec = exec_map["omp"]();
+    const auto app_exec = exec->get_master();
 
     // problem:
     auto correct_u = [](ValueType x) { return x * x * x; };

--- a/examples/three-pt-stencil-solver/three-pt-stencil-solver.cpp
+++ b/examples/three-pt-stencil-solver/three-pt-stencil-solver.cpp
@@ -178,7 +178,7 @@ void solve_system(const std::string &executor_string,
     // executor where Ginkgo will perform the computation
     const auto exec = exec_map.at(executor_string)();  // throws if not valid
     // executor where the application initialized the data
-    const auto app_exec = exec_map["omp"]();
+    const auto app_exec = exec->get_master();
 
     // Tell Ginkgo to use the data in our application
 

--- a/examples/twentyseven-pt-stencil-solver/twentyseven-pt-stencil-solver.cpp
+++ b/examples/twentyseven-pt-stencil-solver/twentyseven-pt-stencil-solver.cpp
@@ -298,7 +298,7 @@ void solve_system(const std::string &executor_string,
     // executor where Ginkgo will perform the computation
     const auto exec = exec_map.at(executor_string)();  // throws if not valid
     // executor where the application initialized the data
-    const auto app_exec = exec_map["omp"]();
+    const auto app_exec = exec->get_master();
 
     // Tell Ginkgo to use the data in our application
 

--- a/examples/twentyseven-pt-stencil-solver/twentyseven-pt-stencil-solver.cpp
+++ b/examples/twentyseven-pt-stencil-solver/twentyseven-pt-stencil-solver.cpp
@@ -280,16 +280,25 @@ void solve_system(const std::string &executor_string,
     const size_t dp_3 = dp * dp * dp;
 
     // Figure out where to run the code
-    const auto omp = gko::OmpExecutor::create();
-    std::map<std::string, std::shared_ptr<gko::Executor>> exec_map{
-        {"omp", omp},
-        {"cuda", gko::CudaExecutor::create(0, omp, true)},
-        {"hip", gko::HipExecutor::create(0, omp, true)},
-        {"reference", gko::ReferenceExecutor::create()}};
+    std::map<std::string, std::function<std::shared_ptr<gko::Executor>()>>
+        exec_map{
+            {"omp", [] { return gko::OmpExecutor::create(); }},
+            {"cuda",
+             [] {
+                 return gko::CudaExecutor::create(0, gko::OmpExecutor::create(),
+                                                  true);
+             }},
+            {"hip",
+             [] {
+                 return gko::HipExecutor::create(0, gko::OmpExecutor::create(),
+                                                 true);
+             }},
+            {"reference", [] { return gko::ReferenceExecutor::create(); }}};
+
     // executor where Ginkgo will perform the computation
-    const auto exec = exec_map.at(executor_string);  // throws if not valid
+    const auto exec = exec_map.at(executor_string)();  // throws if not valid
     // executor where the application initialized the data
-    const auto app_exec = exec_map["omp"];
+    const auto app_exec = exec_map["omp"]();
 
     // Tell Ginkgo to use the data in our application
 


### PR DESCRIPTION
Fixes #594 Create executor only if requested using lambda functions inside the `exec_map`.