### PR TITLE
Cuda11 support

### DIFF
--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -4,16 +4,27 @@ on: [push]
 
 jobs:
   windows_cuda:
-    name: cuda102/release/shared (only compile)
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+        - {version: "10.2.89.20191206", name: "cuda102/release/shared"}
+        - {version: "latest", name: "cuda-latest/release/shared"}
+    name: msvc/${{ matrix.config.name }} (only compile)
     runs-on: [windows-latest]
     steps:
     - uses: actions/checkout@v2
-    - name: setup
+    - name: setup (versioned)
+      if: matrix.config.version != 'latest'
       run: |
-        choco install cuda --version=10.2.89.20191206 -y
+        choco install cuda --version=${{ matrix.config.version }} -y
+    - name: setup (latest)
+      if: matrix.config.version == 'latest'
+      run: |
+        choco install cuda -y
     - name: configure
       run: |
-        $env:ChocolateyInstall = Convert-Path "$((Get-Command choco).Path)\..\.."   
+        $env:ChocolateyInstall = Convert-Path "$((Get-Command choco).Path)\..\.."
         Import-Module "$env:ChocolateyInstall\helpers\chocolateyProfile.psm1"
         refreshenv
         mkdir build
@@ -21,7 +32,7 @@ jobs:
         $env:PATH="$pwd\windows_shared_library;$env:PATH"
         cmake -DGINKGO_BUILD_CUDA=ON -DGINKGO_BUILD_OMP=OFF ..
         cmake --build . -j4 --config Release
-        
+
   windows_ref:
     strategy:
       fail-fast: false

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -400,6 +400,126 @@ build/clang-cuda101/clang/cuda/debug/static:
     - cuda
     - gpu
 
+# cuda 10.2 and friends
+build/cuda102/gcc/all/debug/shared:
+  <<: *default_build_with_test
+  image: localhost:5000/gko-cuda102-gnu8-llvm8-intel2019
+  variables:
+    <<: *default_variables
+    BUILD_OMP: "ON"
+    BUILD_CUDA: "ON"
+    BUILD_HIP: "ON"
+    BUILD_TYPE: "Debug"
+    CUDA_ARCH: 35
+  only:
+    variables:
+      - $RUN_CI_TAG
+  tags:
+    - private_ci
+    - cuda
+    - gpu
+
+build/cuda102/clang/all/release/static:
+  <<: *default_build_with_test
+  image: localhost:5000/gko-cuda102-gnu8-llvm8-intel2019
+  variables:
+    <<: *default_variables
+    C_COMPILER: "clang"
+    CXX_COMPILER: "clang++"
+    BUILD_OMP: "ON"
+    BUILD_CUDA: "ON"
+    BUILD_HIP: "ON"
+    BUILD_TYPE: "Release"
+    BUILD_SHARED_LIBS: "OFF"
+    CUDA_ARCH: 35
+  only:
+    variables:
+      - $RUN_CI_TAG
+  tags:
+    - private_ci
+    - cuda
+    - gpu
+
+build/cuda102/intel/cuda/debug/static:
+  <<: *default_build_with_test
+  image: localhost:5000/gko-cuda102-gnu8-llvm8-intel2019
+  variables:
+    <<: *default_variables
+    C_COMPILER: "icc"
+    CXX_COMPILER: "icpc"
+    BUILD_OMP: "ON"
+    BUILD_CUDA: "ON"
+    BUILD_TYPE: "Debug"
+    BUILD_SHARED_LIBS: "OFF"
+    CUDA_ARCH: 35
+  only:
+    variables:
+      - $RUN_CI_TAG
+  tags:
+    - private_ci
+    - cuda
+    - gpu
+
+# cuda 11.0 and friends
+build/cuda110/gcc/all/debug/shared:
+  <<: *default_build_with_test
+  image: localhost:5000/gko-cuda110-gnu9-llvm9-intel2020
+  variables:
+    <<: *default_variables
+    BUILD_OMP: "ON"
+    BUILD_CUDA: "ON"
+    BUILD_HIP: "OFF"
+    BUILD_TYPE: "Debug"
+    CUDA_ARCH: 35
+  only:
+    variables:
+      - $RUN_CI_TAG
+  tags:
+    - private_ci
+    - cuda
+    - gpu
+
+build/cuda110/clang/all/release/static:
+  <<: *default_build_with_test
+  image: localhost:5000/gko-cuda110-gnu9-llvm9-intel2020
+  variables:
+    <<: *default_variables
+    C_COMPILER: "clang"
+    CXX_COMPILER: "clang++"
+    BUILD_OMP: "ON"
+    BUILD_CUDA: "ON"
+    BUILD_HIP: "OFF"
+    BUILD_TYPE: "Release"
+    BUILD_SHARED_LIBS: "OFF"
+    CUDA_ARCH: 35
+  only:
+    variables:
+      - $RUN_CI_TAG
+  tags:
+    - private_ci
+    - cuda
+    - gpu
+
+build/cuda110/intel/cuda/debug/static:
+  <<: *default_build_with_test
+  image: localhost:5000/gko-cuda110-gnu9-llvm9-intel2020
+  variables:
+    <<: *default_variables
+    C_COMPILER: "icc"
+    CXX_COMPILER: "icpc"
+    BUILD_OMP: "ON"
+    BUILD_CUDA: "ON"
+    BUILD_TYPE: "Debug"
+    BUILD_SHARED_LIBS: "OFF"
+    CUDA_ARCH: 35
+  only:
+    variables:
+      - $RUN_CI_TAG
+  tags:
+    - private_ci
+    - cuda
+    - gpu
+
 # HIP AMD
 build/amd/gcc/hip/debug/shared:
   <<: *default_build_with_test

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -339,26 +339,6 @@ build/cuda101/clang/all/release/static:
     - cuda
     - gpu
 
-build/cuda101/intel/cuda/debug/static:
-  <<: *default_build_with_test
-  image: localhost:5000/gko-cuda101-gnu8-llvm7-intel2019
-  variables:
-    <<: *default_variables
-    C_COMPILER: "icc"
-    CXX_COMPILER: "icpc"
-    BUILD_OMP: "ON"
-    BUILD_CUDA: "ON"
-    BUILD_TYPE: "Debug"
-    BUILD_SHARED_LIBS: "OFF"
-    CUDA_ARCH: 35
-  only:
-    variables:
-      - $RUN_CI_TAG
-  tags:
-    - private_ci
-    - cuda
-    - gpu
-
 # clang-cuda with cuda 10.1 and friends
 build/clang-cuda101/gcc/all/release/shared:
   <<: *default_build_with_test
@@ -461,14 +441,13 @@ build/cuda102/intel/cuda/debug/static:
     - gpu
 
 # cuda 11.0 and friends
-build/cuda110/gcc/all/debug/shared:
+build/cuda110/gcc/cuda/debug/shared:
   <<: *default_build_with_test
   image: localhost:5000/gko-cuda110-gnu9-llvm9-intel2020
   variables:
     <<: *default_variables
     BUILD_OMP: "ON"
     BUILD_CUDA: "ON"
-    BUILD_HIP: "OFF"
     BUILD_TYPE: "Debug"
     CUDA_ARCH: 35
   only:
@@ -479,7 +458,7 @@ build/cuda110/gcc/all/debug/shared:
     - cuda
     - gpu
 
-build/cuda110/clang/all/release/static:
+build/cuda110/clang/cuda/release/static:
   <<: *default_build_with_test
   image: localhost:5000/gko-cuda110-gnu9-llvm9-intel2020
   variables:
@@ -488,7 +467,6 @@ build/cuda110/clang/all/release/static:
     CXX_COMPILER: "clang++"
     BUILD_OMP: "ON"
     BUILD_CUDA: "ON"
-    BUILD_HIP: "OFF"
     BUILD_TYPE: "Release"
     BUILD_SHARED_LIBS: "OFF"
     CUDA_ARCH: 35

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,12 @@ if (CMAKE_VERSION VERSION_GREATER_EQUAL 3.12)
     cmake_policy(SET CMP0074 NEW)
 endif()
 
+# Let CAS handle the CUDA architecture flags (for now)
+# Windows still gives CMP0104 warning if putting it in cuda.
+if (CMAKE_VERSION VERSION_GREATER_EQUAL 3.18)
+    cmake_policy(SET CMP0104 OLD)
+endif()
+
 project(Ginkgo LANGUAGES C CXX VERSION 1.2.0 DESCRIPTION "A numerical linear algebra library targeting many-core architectures")
 set(Ginkgo_VERSION_TAG "develop")
 set(PROJECT_VERSION_TAG ${Ginkgo_VERSION_TAG})

--- a/benchmark/utils/cuda_linops.hpp
+++ b/benchmark/utils/cuda_linops.hpp
@@ -116,6 +116,8 @@ private:
     handle_manager<cusparseMatDescr> descr_;
 };
 
+#if defined(CUDA_VERSION) && (CUDA_VERSION < 11000)
+
 
 template <typename ValueType = gko::default_precision,
           typename IndexType = gko::int32>
@@ -297,6 +299,8 @@ private:
     cusparseOperation_t trans_;
 };
 
+#endif
+
 
 template <typename ValueType = gko::default_precision,
           typename IndexType = gko::int32>
@@ -400,6 +404,8 @@ private:
 };
 
 
+#if defined(CUDA_VERSION) && (CUDA_VERSION < 11000)
+
 template <typename ValueType = gko::default_precision,
           typename IndexType = gko::int32,
           cusparseHybPartition_t Partition = CUSPARSE_HYB_PARTITION_AUTO,
@@ -482,6 +488,9 @@ private:
     cusparseOperation_t trans_;
     cusparseHybMat_t hyb_;
 };
+
+
+#endif
 
 
 #if defined(CUDA_VERSION) && (CUDA_VERSION >= 10010) && \
@@ -688,10 +697,12 @@ private:
 
 
 // Some shortcuts
-using cusp_csr = detail::CuspCsr<>;
 using cusp_csrex = detail::CuspCsrEx<>;
+#if defined(CUDA_VERSION) && (CUDA_VERSION < 11000)
+using cusp_csr = detail::CuspCsr<>;
 using cusp_csrmp = detail::CuspCsrmp<>;
 using cusp_csrmm = detail::CuspCsrmm<>;
+#endif
 
 
 #if defined(CUDA_VERSION) && (CUDA_VERSION >= 10010) && \
@@ -708,10 +719,12 @@ using cusp_gcoo = detail::CuspGenericCoo<>;
         // !(defined(_WIN32) || defined(__CYGWIN__))
 
 
+#if defined(CUDA_VERSION) && (CUDA_VERSION < 11000)
 using cusp_coo =
     detail::CuspHybrid<double, gko::int32, CUSPARSE_HYB_PARTITION_USER, 0>;
 using cusp_ell =
     detail::CuspHybrid<double, gko::int32, CUSPARSE_HYB_PARTITION_MAX, 0>;
 using cusp_hybrid = detail::CuspHybrid<>;
+#endif
 
 #endif  // GKO_BENCHMARK_UTILS_CUDA_LINOPS_HPP_

--- a/benchmark/utils/cuda_linops.hpp
+++ b/benchmark/utils/cuda_linops.hpp
@@ -494,8 +494,9 @@ private:
 #endif
 
 
-#if defined(CUDA_VERSION) && (CUDA_VERSION >= 10010) && \
-    !(defined(_WIN32) || defined(__CYGWIN__))
+#if defined(CUDA_VERSION) &&  \
+    (CUDA_VERSION >= 11000 || \
+     ((CUDA_VERSION >= 10010) && !(defined(_WIN32) || defined(__CYGWIN__))))
 
 
 template <typename ValueType>
@@ -690,8 +691,8 @@ private:
 };
 
 
-#endif  // defined(CUDA_VERSION) && (CUDA_VERSION >= 10010) &&
-        // !(defined(_WIN32) || defined(__CYGWIN__))
+#endif  // defined(CUDA_VERSION) && (CUDA_VERSION >= 11000 || ((CUDA_VERSION >=
+        // 10010) && !(defined(_WIN32) || defined(__CYGWIN__))))
 
 
 }  // namespace detail
@@ -706,8 +707,9 @@ using cusp_csrmm = detail::CuspCsrmm<>;
 #endif
 
 
-#if defined(CUDA_VERSION) && (CUDA_VERSION >= 10010) && \
-    !(defined(_WIN32) || defined(__CYGWIN__))
+#if defined(CUDA_VERSION) &&  \
+    (CUDA_VERSION >= 11000 || \
+     ((CUDA_VERSION >= 10010) && !(defined(_WIN32) || defined(__CYGWIN__))))
 
 
 using cusp_gcsr = detail::CuspGenericCsr<>;
@@ -716,8 +718,8 @@ using cusp_gcsr2 =
 using cusp_gcoo = detail::CuspGenericCoo<>;
 
 
-#endif  // defined(CUDA_VERSION) && (CUDA_VERSION >= 10010) &&
-        // !(defined(_WIN32) || defined(__CYGWIN__))
+#endif  // defined(CUDA_VERSION) && (CUDA_VERSION >= 11000 || ((CUDA_VERSION >=
+        // 10010) && !(defined(_WIN32) || defined(__CYGWIN__))))
 
 
 #if defined(CUDA_VERSION) && (CUDA_VERSION < 11000)

--- a/benchmark/utils/cuda_linops.hpp
+++ b/benchmark/utils/cuda_linops.hpp
@@ -300,7 +300,8 @@ private:
     cusparseOperation_t trans_;
 };
 
-#endif
+
+#endif  // defined(CUDA_VERSION) && (CUDA_VERSION < 11000)
 
 
 template <typename ValueType = gko::default_precision,
@@ -393,7 +394,7 @@ protected:
     {
 #ifdef ALLOWMP
         algmode_ = CUSPARSE_ALG_MERGE_PATH;
-#endif
+#endif  // ALLOWMP
     }
 
 private:
@@ -406,6 +407,7 @@ private:
 
 
 #if defined(CUDA_VERSION) && (CUDA_VERSION < 11000)
+
 
 template <typename ValueType = gko::default_precision,
           typename IndexType = gko::int32,
@@ -491,7 +493,7 @@ private:
 };
 
 
-#endif
+#endif  // defined(CUDA_VERSION) && (CUDA_VERSION < 11000)
 
 
 #if defined(CUDA_VERSION) &&  \
@@ -523,7 +525,7 @@ void cusp_generic_spmv(std::shared_ptr<const gko::CudaExecutor> gpu_exec,
         &vecb, dense_b->get_num_stored_elements(),
         as_culibs_type(const_cast<ValueType *>(db)), cu_value));
 
-    size_t buffer_size = 0;
+    gko::size_type buffer_size = 0;
     GKO_ASSERT_NO_CUSPARSE_ERRORS(cusparseSpMV_bufferSize(
         gpu_exec->get_cusparse_handle(), trans, &scalars.get_const_data()[0],
         mat, vecb, &scalars.get_const_data()[1], vecx, cu_value, alg,
@@ -704,7 +706,7 @@ using cusp_csrex = detail::CuspCsrEx<>;
 using cusp_csr = detail::CuspCsr<>;
 using cusp_csrmp = detail::CuspCsrmp<>;
 using cusp_csrmm = detail::CuspCsrmm<>;
-#endif
+#endif  // defined(CUDA_VERSION) && (CUDA_VERSION < 11000)
 
 
 #if defined(CUDA_VERSION) &&  \
@@ -728,6 +730,7 @@ using cusp_coo =
 using cusp_ell =
     detail::CuspHybrid<double, gko::int32, CUSPARSE_HYB_PARTITION_MAX, 0>;
 using cusp_hybrid = detail::CuspHybrid<>;
-#endif
+#endif  // defined(CUDA_VERSION) && (CUDA_VERSION < 11000)
+
 
 #endif  // GKO_BENCHMARK_UTILS_CUDA_LINOPS_HPP_

--- a/benchmark/utils/cuda_linops.hpp
+++ b/benchmark/utils/cuda_linops.hpp
@@ -116,6 +116,7 @@ private:
     handle_manager<cusparseMatDescr> descr_;
 };
 
+
 #if defined(CUDA_VERSION) && (CUDA_VERSION < 11000)
 
 

--- a/benchmark/utils/formats.hpp
+++ b/benchmark/utils/formats.hpp
@@ -187,13 +187,15 @@ const std::map<std::string, std::function<std::unique_ptr<gko::LinOp>(
         {"coo", read_matrix_from_data<gko::matrix::Coo<>>},
         {"ell", read_matrix_from_data<gko::matrix::Ell<>>},
 #ifdef HAS_CUDA
+#if defined(CUDA_VERSION) && (CUDA_VERSION < 11000)
         {"cusp_csr", read_matrix_from_data<cusp_csr>},
         {"cusp_csrmp", read_matrix_from_data<cusp_csrmp>},
-        {"cusp_csrex", read_matrix_from_data<cusp_csrex>},
         {"cusp_csrmm", read_matrix_from_data<cusp_csrmm>},
         {"cusp_hybrid", read_matrix_from_data<cusp_hybrid>},
         {"cusp_coo", read_matrix_from_data<cusp_coo>},
         {"cusp_ell", read_matrix_from_data<cusp_ell>},
+#endif
+        {"cusp_csrex", read_matrix_from_data<cusp_csrex>},
 #if defined(CUDA_VERSION) && (CUDA_VERSION >= 10010) && \
     !(defined(_WIN32) || defined(__CYGWIN__))
         {"cusp_gcsr", read_matrix_from_data<cusp_gcsr>},

--- a/benchmark/utils/formats.hpp
+++ b/benchmark/utils/formats.hpp
@@ -60,8 +60,15 @@ std::string available_format =
     "hybrid60, hybrid80, hybridlimit0, hybridlimit25, hybridlimit33, "
     "hybridminstorage"
 #ifdef HAS_CUDA
-    ", cusp_csr, cusp_csrex, cusp_csrmp, cusp_csrmm, cusp_coo, cusp_ell, "
-    "cusp_hybrid"
+    ", cusp_csr, cusp_csrex, cusp_coo"
+#if defined(CUDA_VERSION) && (CUDA_VERSION < 11000)
+    ", cusp_csrmp, cusp_csrmm, cusp_ell, cusp_hybrid"
+#endif
+#if defined(CUDA_VERSION) &&  \
+    (CUDA_VERSION >= 11000 || \
+     ((CUDA_VERSION >= 10010) && !(defined(_WIN32) || defined(__CYGWIN__))))
+    ", cusp_gcsr, cusp_gcsr2, cusp_gcoo"
+#endif
 #endif  // HAS_CUDA
 #ifdef HAS_HIP
     ", hipsp_csr, hipsp_csrmm, hipsp_coo, hipsp_ell, hipsp_hybrid"
@@ -88,15 +95,20 @@ std::string format_description =
     "hybridminstorage: Hybrid uses the minimal storage to store the matrix."
 #ifdef HAS_CUDA
     "\n"
-    "cusp_hybrid: benchmark CuSPARSE spmv with cusparseXhybmv and an automatic "
-    "partition.\n"
+#if defined(CUDA_VERSION) && (CUDA_VERSION < 11000)
     "cusp_coo: use cusparseXhybmv with a CUSPARSE_HYB_PARTITION_USER "
     "partition.\n"
-    "cusp_ell: use cusparseXhybmv with CUSPARSE_HYB_PARTITION_MAX partition.\n"
     "cusp_csr: benchmark CuSPARSE with the cusparseXcsrmv function.\n"
-    "cusp_csrex: benchmark CuSPARSE with the cusparseXcsrmvEx function.\n"
+    "cusp_ell: use cusparseXhybmv with CUSPARSE_HYB_PARTITION_MAX partition.\n"
     "cusp_csrmp: benchmark CuSPARSE with the cusparseXcsrmv_mp function.\n"
-    "cusp_csrmm: benchmark CuSPARSE with the cusparseXcsrmv_mm function."
+    "cusp_csrmm: benchmark CuSPARSE with the cusparseXcsrmv_mm function.\n"
+    "cusp_hybrid: benchmark CuSPARSE spmv with cusparseXhybmv and an automatic "
+    "partition.\n"
+#else
+    "cusp_csr: is an alias of cusp_gcsr.\n"
+    "cusp_coo: is an alias of cusp_gcoo.\n"
+#endif
+    "cusp_csrex: benchmark CuSPARSE with the cusparseXcsrmvEx function."
 #if defined(CUDA_VERSION) && (CUDA_VERSION >= 10010) && \
     !(defined(_WIN32) || defined(__CYGWIN__))
     "\n"

--- a/benchmark/utils/formats.hpp
+++ b/benchmark/utils/formats.hpp
@@ -109,8 +109,9 @@ std::string format_description =
     "cusp_coo: is an alias of cusp_gcoo.\n"
 #endif
     "cusp_csrex: benchmark CuSPARSE with the cusparseXcsrmvEx function."
-#if defined(CUDA_VERSION) && (CUDA_VERSION >= 10010) && \
-    !(defined(_WIN32) || defined(__CYGWIN__))
+#if defined(CUDA_VERSION) &&  \
+    (CUDA_VERSION >= 11000 || \
+     ((CUDA_VERSION >= 10010) && !(defined(_WIN32) || defined(__CYGWIN__))))
     "\n"
     "cusp_gcsr: benchmark CuSPARSE with the generic csr with default "
     "algorithm.\n"
@@ -118,8 +119,8 @@ std::string format_description =
     "CUSPARSE_CSRMV_ALG2.\n"
     "cusp_gcoo: benchmark CuSPARSE with the generic coo with default "
     "algorithm.\n"
-#endif  // defined(CUDA_VERSION) && (CUDA_VERSION >= 10010) &&
-        // !(defined(_WIN32) || defined(__CYGWIN__))
+#endif  // defined(CUDA_VERSION) && (CUDA_VERSION >= 11000 || ((CUDA_VERSION >=
+        // 10010) && !(defined(_WIN32) || defined(__CYGWIN__))))
 #endif  // HAS_CUDA
 #ifdef HAS_HIP
     "\n"
@@ -212,13 +213,14 @@ const std::map<std::string, std::function<std::unique_ptr<gko::LinOp>(
         {"cusp_coo", read_matrix_from_data<cusp_gcoo>},
 #endif
         {"cusp_csrex", read_matrix_from_data<cusp_csrex>},
-#if defined(CUDA_VERSION) && (CUDA_VERSION >= 10010) && \
-    !(defined(_WIN32) || defined(__CYGWIN__))
+#if defined(CUDA_VERSION) &&  \
+    (CUDA_VERSION >= 11000 || \
+     ((CUDA_VERSION >= 10010) && !(defined(_WIN32) || defined(__CYGWIN__))))
         {"cusp_gcsr", read_matrix_from_data<cusp_gcsr>},
         {"cusp_gcsr2", read_matrix_from_data<cusp_gcsr2>},
         {"cusp_gcoo", read_matrix_from_data<cusp_gcoo>},
-#endif  // defined(CUDA_VERSION) && (CUDA_VERSION >= 10010) &&
-        // !(defined(_WIN32) || defined(__CYGWIN__))
+#endif  // defined(CUDA_VERSION) && (CUDA_VERSION >= 11000 || ((CUDA_VERSION >=
+        // 10010) && !(defined(_WIN32) || defined(__CYGWIN__))))
 #endif  // HAS_CUDA
 #ifdef HAS_HIP
         {"hipsp_csr", read_matrix_from_data<hipsp_csr>},

--- a/benchmark/utils/formats.hpp
+++ b/benchmark/utils/formats.hpp
@@ -194,6 +194,10 @@ const std::map<std::string, std::function<std::unique_ptr<gko::LinOp>(
         {"cusp_hybrid", read_matrix_from_data<cusp_hybrid>},
         {"cusp_coo", read_matrix_from_data<cusp_coo>},
         {"cusp_ell", read_matrix_from_data<cusp_ell>},
+#else
+        // cusp_csr, cusp_coo use the generic ones from CUDA 11
+        {"cusp_csr", read_matrix_from_data<cusp_gcsr>},
+        {"cusp_coo", read_matrix_from_data<cusp_gcoo>},
 #endif
         {"cusp_csrex", read_matrix_from_data<cusp_csrex>},
 #if defined(CUDA_VERSION) && (CUDA_VERSION >= 10010) && \

--- a/benchmark/utils/formats.hpp
+++ b/benchmark/utils/formats.hpp
@@ -63,12 +63,13 @@ std::string available_format =
     ", cusp_csr, cusp_csrex, cusp_coo"
 #if defined(CUDA_VERSION) && (CUDA_VERSION < 11000)
     ", cusp_csrmp, cusp_csrmm, cusp_ell, cusp_hybrid"
-#endif
+#endif  // defined(CUDA_VERSION) && (CUDA_VERSION < 11000)
 #if defined(CUDA_VERSION) &&  \
     (CUDA_VERSION >= 11000 || \
      ((CUDA_VERSION >= 10010) && !(defined(_WIN32) || defined(__CYGWIN__))))
     ", cusp_gcsr, cusp_gcsr2, cusp_gcoo"
-#endif
+#endif  // defined(CUDA_VERSION) && (CUDA_VERSION >= 11000 || ((CUDA_VERSION >=
+        // 10010) && !(defined(_WIN32) || defined(__CYGWIN__))))
 #endif  // HAS_CUDA
 #ifdef HAS_HIP
     ", hipsp_csr, hipsp_csrmm, hipsp_coo, hipsp_ell, hipsp_hybrid"
@@ -104,7 +105,7 @@ std::string format_description =
     "cusp_csrmm: benchmark CuSPARSE with the cusparseXcsrmv_mm function.\n"
     "cusp_hybrid: benchmark CuSPARSE spmv with cusparseXhybmv and an automatic "
     "partition.\n"
-#else
+#else  // CUDA_VERSION >= 11000
     "cusp_csr: is an alias of cusp_gcsr.\n"
     "cusp_coo: is an alias of cusp_gcoo.\n"
 #endif
@@ -207,7 +208,7 @@ const std::map<std::string, std::function<std::unique_ptr<gko::LinOp>(
         {"cusp_hybrid", read_matrix_from_data<cusp_hybrid>},
         {"cusp_coo", read_matrix_from_data<cusp_coo>},
         {"cusp_ell", read_matrix_from_data<cusp_ell>},
-#else
+#else // CUDA_VERSION >= 11000
         // cusp_csr, cusp_coo use the generic ones from CUDA 11
         {"cusp_csr", read_matrix_from_data<cusp_gcsr>},
         {"cusp_coo", read_matrix_from_data<cusp_gcoo>},

--- a/cmake/create_test.cmake
+++ b/cmake/create_test.cmake
@@ -68,6 +68,9 @@ function(ginkgo_create_cuda_test test_name)
         PRIVATE
         "$<BUILD_INTERFACE:${Ginkgo_BINARY_DIR}>"
         )
+    cas_target_cuda_architectures(${TEST_TARGET_NAME}
+        ARCHITECTURES ${GINKGO_CUDA_ARCHITECTURES}
+        UNSUPPORTED "20" "21")
     set_target_properties(${TEST_TARGET_NAME} PROPERTIES
         OUTPUT_NAME ${test_name})
 

--- a/common/base/executor.hpp.inc
+++ b/common/base/executor.hpp.inc
@@ -78,7 +78,7 @@ inline int convert_sm_ver_to_cores(int major, int minor)
               << "is undefined. The default value of "
               << nGpuArchCoresPerSM[index - 1].Cores << " Cores/SM is used."
               << std::endl;
-#endif
+#endif  // GKO_VERBOSE_LEVEL >= 1
     return nGpuArchCoresPerSM[index - 1].Cores;
 }
 

--- a/common/components/atomic.hpp.inc
+++ b/common/components/atomic.hpp.inc
@@ -88,7 +88,7 @@ GKO_BIND_ATOMIC_HELPER_STRUCTURE(unsigned int);
 #if !(defined(CUDA_VERSION) && (CUDA_VERSION < 10010))
 // CUDA 10.1 starts supporting 16-bit unsigned short int atomicCAS
 GKO_BIND_ATOMIC_HELPER_STRUCTURE(unsigned short int);
-#endif
+#endif  // !(defined(CUDA_VERSION) && (CUDA_VERSION < 10010))
 
 #undef GKO_BIND_ATOMIC_HELPER_STRUCTURE
 
@@ -125,14 +125,16 @@ GKO_BIND_ATOMIC_ADD(float);
 // CUDA 8.0 starts suppoting 64-bit double atomicAdd on devices of compute
 // capability 6.x and higher
 GKO_BIND_ATOMIC_ADD(double);
-#endif
+#endif  // !((defined(CUDA_VERSION) && (CUDA_VERSION < 8000)) ||
+        // (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ < 600)))
 
 #if !((defined(CUDA_VERSION) && (CUDA_VERSION < 10000)) || \
       (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ < 700)))
 // CUDA 10.0 starts supporting 16-bit __half floating-point atomicAdd on devices
 // of compute capability 7.x and higher.
 GKO_BIND_ATOMIC_ADD(__half);
-#endif
+#endif  // !((defined(CUDA_VERSION) && (CUDA_VERSION < 10000)) ||
+        // (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ < 700)))
 
 #if !((defined(CUDA_VERSION) && (CUDA_VERSION < 10000)) || \
       (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ < 600)))
@@ -142,7 +144,8 @@ GKO_BIND_ATOMIC_ADD(__half);
 // elements; the entire __half2 is not guaranteed to be atomic as a single
 // 32-bit access.
 GKO_BIND_ATOMIC_ADD(__half2);
-#endif
+#endif  // !((defined(CUDA_VERSION) && (CUDA_VERSION < 10000)) ||
+        // (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ < 600)))
 
 
 #endif  // !defined(__HIPCC__) || (defined(__HIP_DEVICE_COMPILE__) &&

--- a/common/components/segment_scan.hpp.inc
+++ b/common/components/segment_scan.hpp.inc
@@ -38,7 +38,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  * performs suffix sum. Works on the source array and returns whether the thread
  * is the first element of its segment with same `ind`.
  */
-template <size_type subwarp_size, typename ValueType, typename IndexType>
+template <unsigned subwarp_size, typename ValueType, typename IndexType>
 __device__ __forceinline__ bool segment_scan(
     const group::thread_block_tile<subwarp_size> &group, const IndexType ind,
     ValueType *__restrict__ val)

--- a/common/components/sorting.hpp.inc
+++ b/common/components/sorting.hpp.inc
@@ -128,7 +128,8 @@ struct bitonic_warp {
 
     __forceinline__ __device__ static void merge(ValueType *els, bool reverse)
     {
-        auto tile = group::thread_block_tile<num_threads>{};
+        auto tile =
+            group::tiled_partition<num_threads>(group::this_thread_block());
         auto new_reverse = reverse != upper_half();
         for (auto i = 0; i < num_local; ++i) {
             auto other = tile.shfl_xor(els[i], num_threads / 2);

--- a/common/factorization/par_ilut_filter_kernels.hpp.inc
+++ b/common/factorization/par_ilut_filter_kernels.hpp.inc
@@ -42,7 +42,8 @@ __device__ void abstract_filter_impl(const IndexType *row_ptrs,
                                      StepCallback step_cb,
                                      FinishCallback finish_cb)
 {
-    auto subwarp = group::thread_block_tile<subwarp_size>();
+    auto subwarp =
+        group::tiled_partition<subwarp_size>(group::this_thread_block());
     auto row = thread::get_subwarp_id_flat<subwarp_size, IndexType>();
     auto lane = subwarp.thread_rank();
     auto lane_prefix_mask = (config::lane_mask_type(1) << lane) - 1;

--- a/common/matrix/csr_kernels.hpp.inc
+++ b/common/matrix/csr_kernels.hpp.inc
@@ -87,7 +87,7 @@ __device__ __forceinline__ void find_next_row(
 }
 
 
-template <size_type subwarp_size, typename ValueType, typename IndexType,
+template <unsigned subwarp_size, typename ValueType, typename IndexType,
           typename Closure>
 __device__ __forceinline__ void warp_atomic_add(
     const group::thread_block_tile<subwarp_size> &group, bool force_write,
@@ -105,7 +105,7 @@ __device__ __forceinline__ void warp_atomic_add(
 }
 
 
-template <bool last, size_type subwarp_size, typename ValueType,
+template <bool last, unsigned subwarp_size, typename ValueType,
           typename IndexType, typename Closure>
 __device__ __forceinline__ void process_window(
     const group::thread_block_tile<subwarp_size> &group,

--- a/common/preconditioner/jacobi_generate_kernel.hpp.inc
+++ b/common/preconditioner/jacobi_generate_kernel.hpp.inc
@@ -53,12 +53,12 @@ __device__ __forceinline__ bool validate_precision_reduction_feasibility(
     }
 
     // compute the condition number
-    auto perm = group.thread_rank();
-    auto trans_perm = perm;
+    uint32 perm = group.thread_rank();
+    uint32 trans_perm = perm;
     auto block_cond = compute_infinity_norm<max_block_size>(group, block_size,
                                                             block_size, row);
-    auto succeeded =
-        invert_block<max_block_size>(group, block_size, row, perm, trans_perm);
+    auto succeeded = invert_block<max_block_size>(
+        group, static_cast<uint32>(block_size), row, perm, trans_perm);
     block_cond *= compute_infinity_norm<max_block_size>(group, block_size,
                                                         block_size, row);
 
@@ -99,10 +99,10 @@ __global__ void __launch_bounds__(warps_per_block *config::warp_size) generate(
     const auto subwarp = group::tiled_partition<subwarp_size>(block);
     if (block_id < num_blocks) {
         const auto block_size = block_ptrs[block_id + 1] - block_ptrs[block_id];
-        auto perm = subwarp.thread_rank();
-        auto trans_perm = subwarp.thread_rank();
-        invert_block<max_block_size>(subwarp, block_size, row, perm,
-                                     trans_perm);
+        uint32 perm = subwarp.thread_rank();
+        uint32 trans_perm = subwarp.thread_rank();
+        invert_block<max_block_size>(subwarp, static_cast<uint32>(block_size),
+                                     row, perm, trans_perm);
         copy_matrix<max_block_size, and_transpose>(
             subwarp, block_size, row, 1, perm, trans_perm,
             block_data + storage_scheme.get_global_block_offset(block_id),
@@ -138,11 +138,11 @@ __launch_bounds__(warps_per_block *config::warp_size) adaptive_generate(
 
     // compute inverse and figure out the correct precision
     const auto subwarp = group::tiled_partition<subwarp_size>(block);
-    const auto block_size =
+    const uint32 block_size =
         block_id < num_blocks ? block_ptrs[block_id + 1] - block_ptrs[block_id]
                               : 0;
-    auto perm = subwarp.thread_rank();
-    auto trans_perm = subwarp.thread_rank();
+    uint32 perm = subwarp.thread_rank();
+    uint32 trans_perm = subwarp.thread_rank();
     auto prec_descriptor = ~uint32{};
     if (block_id < num_blocks) {
         auto block_cond = compute_infinity_norm<max_block_size>(

--- a/cuda/CMakeLists.txt
+++ b/cuda/CMakeLists.txt
@@ -151,11 +151,6 @@ target_link_libraries(ginkgo_cuda PRIVATE ${CUDA_RUNTIME_LIBS} ${CUBLAS} ${CUSPA
 # Need to link against ginkgo_hip for the `raw_copy_to(HipExecutor ...)` method
 target_link_libraries(ginkgo_cuda PUBLIC ginkgo_hip)
 
-# Let CAS handle the CUDA architecture flags (for now)
-if (CMAKE_VERSION VERSION_GREATER_EQUAL 3.18)
-    cmake_policy(SET CMP0104 OLD)
-endif()
-
 cas_target_cuda_architectures(ginkgo_cuda
     ARCHITECTURES ${GINKGO_CUDA_ARCHITECTURES}
     UNSUPPORTED "20" "21")

--- a/cuda/base/cusparse_bindings.hpp
+++ b/cuda/base/cusparse_bindings.hpp
@@ -561,6 +561,8 @@ inline void transpose(cusparseHandle_t handle, size_type m, size_type n,
                       cusparseAction_t copyValues,
                       cusparseIndexBase_t idxBase) GKO_NOT_IMPLEMENTED;
 
+// Cusparse csr2csc use the order (row_inx, col_ptr) for csc, so we need to
+// switch row_ptr and col_idx of transposed csr here
 #define GKO_BIND_CUSPARSE_TRANSPOSE32(ValueType, CusparseName)                \
     template <>                                                               \
     inline void transpose<ValueType, int32>(                                  \
@@ -573,7 +575,7 @@ inline void transpose(cusparseHandle_t handle, size_type m, size_type n,
         GKO_ASSERT_NO_CUSPARSE_ERRORS(                                        \
             CusparseName(handle, m, n, nnz, as_culibs_type(OrigValA),         \
                          OrigRowPtrA, OrigColIndA, as_culibs_type(TransValA), \
-                         TransRowPtrA, TransColIndA, copyValues, idxBase));   \
+                         TransColIndA, TransRowPtrA, copyValues, idxBase));   \
     }                                                                         \
     static_assert(true,                                                       \
                   "This assert is used to counter the false positive extra "  \

--- a/cuda/base/cusparse_bindings.hpp
+++ b/cuda/base/cusparse_bindings.hpp
@@ -751,6 +751,9 @@ inline void destroy(cusparseMatDescr_t descr)
 }
 
 
+#if defined(CUDA_VERSION) && (CUDA_VERSION < 11000)
+
+
 inline csrgemm2Info_t create_spgemm_info()
 {
     csrgemm2Info_t info{};
@@ -765,7 +768,7 @@ inline void destroy(csrgemm2Info_t info)
 }
 
 
-#if defined(CUDA_VERSION) && (CUDA_VERSION >= 11000)
+#else
 
 
 inline cusparseSpGEMMDescr_t create_spgemm_descr()

--- a/cuda/base/cusparse_handle.hpp
+++ b/cuda/base/cusparse_handle.hpp
@@ -1,0 +1,77 @@
+/*******************************<GINKGO LICENSE>******************************
+Copyright (c) 2017-2020, the Ginkgo authors
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+******************************<GINKGO LICENSE>*******************************/
+
+#ifndef GKO_CUDA_BASE_CUSPARSE_HANDLE_HPP_
+#define GKO_CUDA_BASE_CUSPARSE_HANDLE_HPP_
+
+
+#include <cuda.h>
+#include <cusparse.h>
+
+
+#include <ginkgo/core/base/exception_helpers.hpp>
+
+
+namespace gko {
+namespace kernels {
+namespace cuda {
+/**
+ * @brief The CUSPARSE namespace.
+ *
+ * @ingroup cusparse
+ */
+namespace cusparse {
+
+
+inline cusparseHandle_t init()
+{
+    cusparseHandle_t handle{};
+    GKO_ASSERT_NO_CUSPARSE_ERRORS(cusparseCreate(&handle));
+    GKO_ASSERT_NO_CUSPARSE_ERRORS(
+        cusparseSetPointerMode(handle, CUSPARSE_POINTER_MODE_DEVICE));
+    return handle;
+}
+
+
+inline void destroy(cusparseHandle_t handle)
+{
+    GKO_ASSERT_NO_CUSPARSE_ERRORS(cusparseDestroy(handle));
+}
+
+
+}  // namespace cusparse
+}  // namespace cuda
+}  // namespace kernels
+}  // namespace gko
+
+
+#endif  // GKO_CUDA_BASE_CUSPARSE_HANDLE_HPP_

--- a/cuda/base/executor.cpp
+++ b/cuda/base/executor.cpp
@@ -93,7 +93,7 @@ void CudaExecutor::raw_free(void *ptr) const noexcept
                   << " in " << __func__ << ": " << cudaGetErrorName(error_code)
                   << ": " << cudaGetErrorString(error_code) << std::endl
                   << "Exiting program" << std::endl;
-#endif
+#endif  // GKO_VERBOSE_LEVEL >= 1
         std::exit(error_code);
     }
 }

--- a/cuda/base/executor.cpp
+++ b/cuda/base/executor.cpp
@@ -45,7 +45,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "cuda/base/config.hpp"
 #include "cuda/base/cublas_bindings.hpp"
-#include "cuda/base/cusparse_bindings.hpp"
+#include "cuda/base/cusparse_handle.hpp"
 #include "cuda/base/device_guard.hpp"
 
 

--- a/cuda/base/types.hpp
+++ b/cuda/base/types.hpp
@@ -198,8 +198,9 @@ constexpr cudaDataType_t cuda_data_type_impl<uint8>()
 }
 
 
-#if defined(CUDA_VERSION) && (CUDA_VERSION >= 10010) && \
-    !(defined(_WIN32) || defined(__CYGWIN__))
+#if defined(CUDA_VERSION) &&  \
+    (CUDA_VERSION >= 11000 || \
+     ((CUDA_VERSION >= 10010) && !(defined(_WIN32) || defined(__CYGWIN__))))
 
 
 template <typename T>
@@ -221,8 +222,8 @@ constexpr cusparseIndexType_t cusparse_index_type_impl<int64>()
 }
 
 
-#endif  // defined(CUDA_VERSION) && (CUDA_VERSION >= 10010) &&
-        // !(defined(_WIN32) || defined(__CYGWIN__))
+#endif  // defined(CUDA_VERSION) && (CUDA_VERSION >= 11000 || ((CUDA_VERSION >=
+        // 10010) && !(defined(_WIN32) || defined(__CYGWIN__))))
 
 
 }  // namespace detail
@@ -243,8 +244,9 @@ constexpr cudaDataType_t cuda_data_type()
 }
 
 
-#if defined(CUDA_VERSION) && (CUDA_VERSION >= 10010) && \
-    !(defined(_WIN32) || defined(__CYGWIN__))
+#if defined(CUDA_VERSION) &&  \
+    (CUDA_VERSION >= 11000 || \
+     ((CUDA_VERSION >= 10010) && !(defined(_WIN32) || defined(__CYGWIN__))))
 
 
 /**
@@ -262,8 +264,8 @@ constexpr cusparseIndexType_t cusparse_index_type()
 }
 
 
-#endif  // defined(CUDA_VERSION) && (CUDA_VERSION >= 10010) &&
-        // !(defined(_WIN32) || defined(__CYGWIN__))
+#endif  // defined(CUDA_VERSION) && (CUDA_VERSION >= 11000 || ((CUDA_VERSION >=
+        // 10010) && !(defined(_WIN32) || defined(__CYGWIN__))))
 
 
 /**

--- a/cuda/components/cooperative_groups.cuh
+++ b/cuda/components/cooperative_groups.cuh
@@ -368,6 +368,21 @@ private:
 
 // Implementing this as a using directive messes up with SFINAE for some reason,
 // probably a bug in NVCC. If it is a complete type, everything works fine.
+#if defined(CUDA_VERSION) && (CUDA_VERSION < 11000)
+
+
+template <size_type Size>
+struct thread_block_tile : detail::enable_extended_shuffle<
+                               cooperative_groups::thread_block_tile<Size>> {
+    using detail::enable_extended_shuffle<
+        cooperative_groups::thread_block_tile<Size>>::enable_extended_shuffle;
+};
+
+
+#else
+
+
+// Cuda cooperative groups must need parent group type from cuda 11
 template <size_type Size>
 struct thread_block_tile
     : detail::enable_extended_shuffle<cooperative_groups::thread_block_tile<
@@ -375,6 +390,9 @@ struct thread_block_tile
     using detail::enable_extended_shuffle<cooperative_groups::thread_block_tile<
         Size, cooperative_groups::thread_block>>::enable_extended_shuffle;
 };
+
+
+#endif
 // inherits thread_group
 //
 // public API:

--- a/cuda/components/cooperative_groups.cuh
+++ b/cuda/components/cooperative_groups.cuh
@@ -317,10 +317,10 @@ template <typename Group>
 class enable_extended_shuffle : public Group {
 public:
     using Group::Group;
-    using Group::shfl;
-    using Group::shfl_down;
-    using Group::shfl_up;
-    using Group::shfl_xor;
+    // using Group::shfl;
+    // using Group::shfl_down;
+    // using Group::shfl_up;
+    // using Group::shfl_xor;
 
 #define GKO_ENABLE_SHUFFLE_OPERATION(_name, SelectorType)                   \
     template <typename ValueType>                                           \
@@ -369,10 +369,11 @@ private:
 // Implementing this as a using directive messes up with SFINAE for some reason,
 // probably a bug in NVCC. If it is a complete type, everything works fine.
 template <size_type Size>
-struct thread_block_tile : detail::enable_extended_shuffle<
-                               cooperative_groups::thread_block_tile<Size>> {
-    using detail::enable_extended_shuffle<
-        cooperative_groups::thread_block_tile<Size>>::enable_extended_shuffle;
+struct thread_block_tile
+    : detail::enable_extended_shuffle<cooperative_groups::thread_block_tile<
+          Size, cooperative_groups::thread_block>> {
+    using detail::enable_extended_shuffle<cooperative_groups::thread_block_tile<
+        Size, cooperative_groups::thread_block>>::enable_extended_shuffle;
 };
 // inherits thread_group
 //

--- a/cuda/components/cooperative_groups.cuh
+++ b/cuda/components/cooperative_groups.cuh
@@ -38,6 +38,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
 #include <cooperative_groups.h>
+#include <cuda.h>
 
 
 #include "cuda/base/config.hpp"

--- a/cuda/components/cooperative_groups.cuh
+++ b/cuda/components/cooperative_groups.cuh
@@ -318,6 +318,35 @@ template <typename Group>
 class enable_extended_shuffle : public Group {
 public:
     using Group::Group;
+#define GKO_BIND_SHFL(ShflOp, ValueType, SelectorType)                       \
+    __device__ __forceinline__ ValueType ShflOp(                             \
+        ValueType var, SelectorType selector) const noexcept                 \
+    {                                                                        \
+        return __##ShflOp##_sync(this->build_mask(), var, selector,          \
+                                 this->size());                              \
+    }                                                                        \
+    static_assert(true,                                                      \
+                  "This assert is used to counter the false positive extra " \
+                  "semi-colon warnings")
+    GKO_BIND_SHFL(shfl, int32, int32);
+    GKO_BIND_SHFL(shfl, float, int32);
+    GKO_BIND_SHFL(shfl, uint32, int32);
+    GKO_BIND_SHFL(shfl, double, int32);
+
+    GKO_BIND_SHFL(shfl_up, int32, uint32);
+    GKO_BIND_SHFL(shfl_up, uint32, uint32);
+    GKO_BIND_SHFL(shfl_up, float, uint32);
+    GKO_BIND_SHFL(shfl_up, double, uint32);
+
+    GKO_BIND_SHFL(shfl_down, int32, uint32);
+    GKO_BIND_SHFL(shfl_down, uint32, uint32);
+    GKO_BIND_SHFL(shfl_down, float, uint32);
+    GKO_BIND_SHFL(shfl_down, double, uint32);
+
+    GKO_BIND_SHFL(shfl_xor, int32, int32);
+    GKO_BIND_SHFL(shfl_xor, float, int32);
+    GKO_BIND_SHFL(shfl_xor, uint32, int32);
+    GKO_BIND_SHFL(shfl_xor, double, int32);
     // using Group::shfl;
     // using Group::shfl_down;
     // using Group::shfl_up;

--- a/cuda/components/cooperative_groups.cuh
+++ b/cuda/components/cooperative_groups.cuh
@@ -367,25 +367,17 @@ private:
 };
 
 
-#else
-
-
-// cuda11 put the default consturctor in protected function.
-template <typename Group>
-class enable_default_constructor : public Group {};
-
-
 #endif  // defined(CUDA_VERSION) && (CUDA_VERSION < 11000)
 
 
 }  // namespace detail
 
 
-// Implementing this as a using directive messes up with SFINAE for some reason,
-// probably a bug in NVCC. If it is a complete type, everything works fine.
 #if defined(CUDA_VERSION) && (CUDA_VERSION < 11000)
 
 
+// Implementing this as a using directive messes up with SFINAE for some reason,
+// probably a bug in NVCC. If it is a complete type, everything works fine.
 template <unsigned Size>
 struct thread_block_tile : detail::enable_extended_shuffle<
                                cooperative_groups::thread_block_tile<Size>> {
@@ -394,7 +386,7 @@ struct thread_block_tile : detail::enable_extended_shuffle<
 };
 
 
-#else
+#else  // CUDA_VERSION >= 11000
 
 
 // Cuda11 cooperative group's shuffle supports complex
@@ -442,7 +434,7 @@ struct is_synchronizable_group_impl<cooperative_groups::thread_block_tile<Size>>
     : std::true_type {};
 
 
-#else
+#else  // CUDA_VERSION >= 11000
 
 
 // thread_block_tile is same as cuda11's
@@ -524,7 +516,7 @@ __device__ __forceinline__
 }
 
 
-#else
+#else  // CUDA_VERSION >= 11000
 
 
 // cooperative group after cuda11 contain parent group in template.

--- a/cuda/components/format_conversion.cuh
+++ b/cuda/components/format_conversion.cuh
@@ -100,7 +100,11 @@ __host__ size_type calculate_nwarps(std::shared_ptr<const CudaExecutor> exec,
         exec->get_num_warps_per_sm() * config::warp_size / subwarp_size;
     size_type nwarps_in_cuda = exec->get_num_multiprocessor() * warps_per_sm;
     size_type multiple = 8;
-    if (nnz >= 2e6) {
+    if (nnz >= 2e8) {
+        multiple = 2048;
+    } else if (nnz >= 2e7) {
+        multiple = 512;
+    } else if (nnz >= 2e6) {
         multiple = 128;
     } else if (nnz >= 2e5) {
         multiple = 32;

--- a/cuda/matrix/csr_kernels.cu
+++ b/cuda/matrix/csr_kernels.cu
@@ -443,12 +443,14 @@ void advanced_spmv(std::shared_ptr<const CudaExecutor> exec,
             auto vecc = cusparse::create_dnvec(c->get_num_stored_elements(),
                                                c_val, cu_value);
             size_t buffer_size = 0;
-            cusparse::spmv_buffersize(handle, trans, alpha->get_const_values(),
-                                      mat, vecb, beta->get_const_values(), vecc,
-                                      cu_value, alg, &buffer_size);
+            cusparse::spmv_buffersize(exec->get_cusparse_handle(), trans,
+                                      alpha->get_const_values(), mat, vecb,
+                                      beta->get_const_values(), vecc, cu_value,
+                                      alg, &buffer_size);
             gko::Array<char> buffer_array(exec, buffer_size);
             auto buffer = buffer_array.get_data();
-            cusparse::spmv(handle, trans, alpha->get_const_values(), mat, vecb,
+            cusparse::spmv(exec->get_cusparse_handle(), trans,
+                           alpha->get_const_values(), mat, vecb,
                            beta->get_const_values(), vecc, cu_value, alg,
                            buffer);
             cusparse::destroy(vecb);
@@ -939,20 +941,20 @@ void transpose(std::shared_ptr<const CudaExecutor> exec,
             orig->get_size()[1], orig->get_num_stored_elements(),
             orig->get_const_values(), orig->get_const_row_ptrs(),
             orig->get_const_col_idxs(), trans->get_values(),
-            trans->get_col_idxs(), trans->get_row_ptrs(), copyValues, idxBase);
+            trans->get_row_ptrs(), trans->get_col_idxs(), copyValues, idxBase);
 #else  // CUDA_VERSION >= 11000
         cudaDataType_t cu_value =
             gko::kernels::cuda::cuda_data_type<ValueType>();
         cusparseAction_t copyValues = CUSPARSE_ACTION_NUMERIC;
         cusparseIndexBase_t idxBase = CUSPARSE_INDEX_BASE_ZERO;
-        cusparseCsr2CscAlg_t alg = CUSPARSE_CSR2CSC_ALG2;
+        cusparseCsr2CscAlg_t alg = CUSPARSE_CSR2CSC_ALG1;
         size_type buffer_size = 0;
         cusparse::transpose_buffersize(
             exec->get_cusparse_handle(), orig->get_size()[0],
             orig->get_size()[1], orig->get_num_stored_elements(),
             orig->get_const_values(), orig->get_const_row_ptrs(),
             orig->get_const_col_idxs(), trans->get_values(),
-            trans->get_col_idxs(), trans->get_row_ptrs(), cu_value, copyValues,
+            trans->get_row_ptrs(), trans->get_col_idxs(), cu_value, copyValues,
             idxBase, alg, &buffer_size);
         Array<char> buffer_array(exec, buffer_size);
         auto buffer = buffer_array.get_data();
@@ -961,7 +963,7 @@ void transpose(std::shared_ptr<const CudaExecutor> exec,
             orig->get_size()[1], orig->get_num_stored_elements(),
             orig->get_const_values(), orig->get_const_row_ptrs(),
             orig->get_const_col_idxs(), trans->get_values(),
-            trans->get_col_idxs(), trans->get_row_ptrs(), cu_value, copyValues,
+            trans->get_row_ptrs(), trans->get_col_idxs(), cu_value, copyValues,
             idxBase, alg, buffer);
 #endif
     } else {
@@ -991,7 +993,7 @@ void conj_transpose(std::shared_ptr<const CudaExecutor> exec,
             orig->get_size()[1], orig->get_num_stored_elements(),
             orig->get_const_values(), orig->get_const_row_ptrs(),
             orig->get_const_col_idxs(), trans->get_values(),
-            trans->get_col_idxs(), trans->get_row_ptrs(), copyValues, idxBase);
+            trans->get_row_ptrs(), trans->get_col_idxs(), copyValues, idxBase);
 #else  // CUDA_VERSION >= 11000
         cudaDataType_t cu_value =
             gko::kernels::cuda::cuda_data_type<ValueType>();
@@ -1004,7 +1006,7 @@ void conj_transpose(std::shared_ptr<const CudaExecutor> exec,
             orig->get_size()[1], orig->get_num_stored_elements(),
             orig->get_const_values(), orig->get_const_row_ptrs(),
             orig->get_const_col_idxs(), trans->get_values(),
-            trans->get_col_idxs(), trans->get_row_ptrs(), cu_value, copyValues,
+            trans->get_row_ptrs(), trans->get_col_idxs(), cu_value, copyValues,
             idxBase, alg, &buffer_size);
         Array<char> buffer_array(exec, buffer_size);
         auto buffer = buffer_array.get_data();
@@ -1013,7 +1015,7 @@ void conj_transpose(std::shared_ptr<const CudaExecutor> exec,
             orig->get_size()[1], orig->get_num_stored_elements(),
             orig->get_const_values(), orig->get_const_row_ptrs(),
             orig->get_const_col_idxs(), trans->get_values(),
-            trans->get_col_idxs(), trans->get_row_ptrs(), cu_value, copyValues,
+            trans->get_row_ptrs(), trans->get_col_idxs(), cu_value, copyValues,
             idxBase, alg, buffer);
 #endif
 

--- a/cuda/matrix/csr_kernels.cu
+++ b/cuda/matrix/csr_kernels.cu
@@ -343,7 +343,7 @@ void spmv(std::shared_ptr<const CudaExecutor> exec,
                     cusparse::create_dnvec(b->get_num_stored_elements(), b_val);
                 auto vecc =
                     cusparse::create_dnvec(c->get_num_stored_elements(), c_val);
-                size_t buffer_size = 0;
+                size_type buffer_size = 0;
                 cusparse::spmv_buffersize<ValueType>(handle, trans, &alpha, mat,
                                                      vecb, &beta, vecc, alg,
                                                      &buffer_size);
@@ -432,7 +432,7 @@ void advanced_spmv(std::shared_ptr<const CudaExecutor> exec,
                 cusparse::create_dnvec(b->get_num_stored_elements(), b_val);
             auto vecc =
                 cusparse::create_dnvec(c->get_num_stored_elements(), c_val);
-            size_t buffer_size = 0;
+            size_type buffer_size = 0;
             cusparse::spmv_buffersize<ValueType>(
                 exec->get_cusparse_handle(), trans, alpha->get_const_values(),
                 mat, vecb, beta->get_const_values(), vecc, alg, &buffer_size);
@@ -1111,7 +1111,7 @@ void conj_transpose(std::shared_ptr<const CudaExecutor> exec,
             gko::kernels::cuda::cuda_data_type<ValueType>();
         cusparseAction_t copyValues = CUSPARSE_ACTION_NUMERIC;
         cusparseIndexBase_t idxBase = CUSPARSE_INDEX_BASE_ZERO;
-        cusparseCsr2CscAlg_t alg = CUSPARSE_CSR2CSC_ALG2;
+        cusparseCsr2CscAlg_t alg = CUSPARSE_CSR2CSC_ALG1;
         size_type buffer_size = 0;
         cusparse::transpose_buffersize(
             exec->get_cusparse_handle(), orig->get_size()[0],

--- a/cuda/test/matrix/csr_kernels.cpp
+++ b/cuda/test/matrix/csr_kernels.cpp
@@ -416,6 +416,7 @@ TEST_F(Csr, TransposeIsEquivalentToRef)
 
     GKO_ASSERT_MTX_NEAR(static_cast<Mtx *>(d_trans.get()),
                         static_cast<Mtx *>(trans.get()), 0.0);
+    ASSERT_TRUE(static_cast<Mtx *>(d_trans.get())->is_sorted_by_column_index());
 }
 
 
@@ -428,6 +429,8 @@ TEST_F(Csr, ConjugateTransposeIsEquivalentToRef)
 
     GKO_ASSERT_MTX_NEAR(static_cast<ComplexMtx *>(d_trans.get()),
                         static_cast<ComplexMtx *>(trans.get()), 0.0);
+    ASSERT_TRUE(
+        static_cast<ComplexMtx *>(d_trans.get())->is_sorted_by_column_index());
 }
 
 

--- a/cuda/test/solver/lower_trs_kernels.cpp
+++ b/cuda/test/solver/lower_trs_kernels.cpp
@@ -131,7 +131,7 @@ TEST_F(LowerTrs, CudaLowerTrsFlagCheckIsCorrect)
     bool expected_flag = false;
 #if (defined(CUDA_VERSION) && (CUDA_VERSION < 9020))
     expected_flag = true;
-#endif
+#endif  // (defined(CUDA_VERSION) && (CUDA_VERSION < 9020))
     gko::kernels::cuda::lower_trs::should_perform_transpose(cuda, trans_flag);
 
     ASSERT_EQ(expected_flag, trans_flag);

--- a/cuda/test/solver/upper_trs_kernels.cpp
+++ b/cuda/test/solver/upper_trs_kernels.cpp
@@ -132,7 +132,7 @@ TEST_F(UpperTrs, CudaUpperTrsFlagCheckIsCorrect)
 
 #if (defined(CUDA_VERSION) && (CUDA_VERSION < 9020))
     expected_flag = true;
-#endif
+#endif  // (defined(CUDA_VERSION) && (CUDA_VERSION < 9020))
     gko::kernels::cuda::upper_trs::should_perform_transpose(cuda, trans_flag);
 
     ASSERT_EQ(expected_flag, trans_flag);

--- a/hip/base/executor.hip.cpp
+++ b/hip/base/executor.hip.cpp
@@ -93,7 +93,7 @@ void HipExecutor::raw_free(void *ptr) const noexcept
                   << " in " << __func__ << ": " << hipGetErrorName(error_code)
                   << ": " << hipGetErrorString(error_code) << std::endl
                   << "Exiting program" << std::endl;
-#endif
+#endif  // GKO_VERBOSE_LEVEL >= 1
         std::exit(error_code);
     }
 }

--- a/hip/base/hipsparse_bindings.hip.hpp
+++ b/hip/base/hipsparse_bindings.hip.hpp
@@ -372,8 +372,8 @@ GKO_BIND_HIPSPARSE64_CSR2HYB(ValueType, detail::not_implemented);
     {                                                                         \
         GKO_ASSERT_NO_HIPSPARSE_ERRORS(HipsparseName(                         \
             handle, m, n, nnz, as_hiplibs_type(OrigValA), OrigRowPtrA,        \
-            OrigColIndA, as_hiplibs_type(TransValA), TransRowPtrA,            \
-            TransColIndA, copyValues, idxBase));                              \
+            OrigColIndA, as_hiplibs_type(TransValA), TransColIndA,            \
+            TransRowPtrA, copyValues, idxBase));                              \
     }                                                                         \
     static_assert(true,                                                       \
                   "This assert is used to counter the false positive extra "  \

--- a/hip/components/cooperative_groups.hip.hpp
+++ b/hip/components/cooperative_groups.hip.hpp
@@ -199,7 +199,7 @@ public:
     {
 #if GINKGO_HIP_PLATFORM_NVCC
         __syncwarp(data_.mask);
-#endif
+#endif  // GINKGO_HIP_PLATFORM_NVCC
     }
 
 #if GINKGO_HIP_PLATFORM_HCC

--- a/hip/components/cooperative_groups.hip.hpp
+++ b/hip/components/cooperative_groups.hip.hpp
@@ -375,7 +375,7 @@ private:
 
 // Implementing this as a using directive messes up with SFINAE for some reason,
 // probably a bug in NVCC. If it is a complete type, everything works fine.
-template <size_type Size>
+template <unsigned Size>
 struct thread_block_tile
     : detail::enable_extended_shuffle<detail::thread_block_tile<Size>> {
     using detail::enable_extended_shuffle<
@@ -398,12 +398,12 @@ __device__ __forceinline__
 namespace detail {
 
 
-template <size_type Size>
+template <unsigned Size>
 struct is_group_impl<thread_block_tile<Size>> : std::true_type {};
-template <size_type Size>
+template <unsigned Size>
 struct is_synchronizable_group_impl<thread_block_tile<Size>> : std::true_type {
 };
-template <size_type Size>
+template <unsigned Size>
 struct is_communicator_group_impl<thread_block_tile<Size>> : std::true_type {};
 
 
@@ -485,7 +485,7 @@ private:
                     (threadIdx.y + blockDim.y *
                         (threadIdx.z + blockDim.z *
                             (blockIdx.x + gridDim.x *
-                                (blockIdx.y + gridDim.y * blockIdx.z))))}                      
+                                (blockIdx.y + gridDim.y * blockIdx.z))))}
     {}
     // clang-format on
 

--- a/hip/components/format_conversion.hip.hpp
+++ b/hip/components/format_conversion.hip.hpp
@@ -104,7 +104,11 @@ __host__ size_type calculate_nwarps(std::shared_ptr<const HipExecutor> exec,
                               subwarp_size;
 #if GINKGO_HIP_PLATFORM_NVCC
     size_type multiple = 8;
-    if (nnz >= 2e6) {
+    if (nnz >= 2e8) {
+        multiple = 2048;
+    } else if (nnz >= 2e7) {
+        multiple = 512;
+    } else if (nnz >= 2e6) {
         multiple = 128;
     } else if (nnz >= 2e5) {
         multiple = 32;

--- a/hip/matrix/csr_kernels.hip.cpp
+++ b/hip/matrix/csr_kernels.hip.cpp
@@ -926,7 +926,7 @@ void transpose(std::shared_ptr<const HipExecutor> exec,
             orig->get_size()[1], orig->get_num_stored_elements(),
             orig->get_const_values(), orig->get_const_row_ptrs(),
             orig->get_const_col_idxs(), trans->get_values(),
-            trans->get_col_idxs(), trans->get_row_ptrs(), copyValues, idxBase);
+            trans->get_row_ptrs(), trans->get_col_idxs(), copyValues, idxBase);
     } else {
         GKO_NOT_IMPLEMENTED;
     }

--- a/hip/test/matrix/csr_kernels.hip.cpp
+++ b/hip/test/matrix/csr_kernels.hip.cpp
@@ -401,6 +401,7 @@ TEST_F(Csr, TransposeIsEquivalentToRef)
 
     GKO_ASSERT_MTX_NEAR(static_cast<Mtx *>(d_trans.get()),
                         static_cast<Mtx *>(trans.get()), 0.0);
+    ASSERT_TRUE(static_cast<Mtx *>(d_trans.get())->is_sorted_by_column_index());
 }
 
 
@@ -482,18 +483,6 @@ TEST_F(Csr, MoveToSparsityCsrIsEquivalentToRef)
 }
 
 
-TEST_F(Csr, ConvertsEmptyToSellp)
-{
-    auto dempty_mtx = Mtx::create(hip);
-    auto dsellp_mtx = gko::matrix::Sellp<>::create(hip);
-
-    dempty_mtx->convert_to(dsellp_mtx.get());
-
-    ASSERT_EQ(hip->copy_val_to_host(dsellp_mtx->get_const_slice_sets()), 0);
-    ASSERT_FALSE(dsellp_mtx->get_size());
-}
-
-
 TEST_F(Csr, CalculateMaxNnzPerRowIsEquivalentToRef)
 {
     set_up_apply_data(std::make_shared<Mtx::sparselib>());
@@ -561,6 +550,18 @@ TEST_F(Csr, MoveToSellpIsEquivalentToRef)
 }
 
 
+TEST_F(Csr, ConvertsEmptyToSellp)
+{
+    auto dempty_mtx = Mtx::create(hip);
+    auto dsellp_mtx = gko::matrix::Sellp<>::create(hip);
+
+    dempty_mtx->convert_to(dsellp_mtx.get());
+
+    ASSERT_EQ(hip->copy_val_to_host(dsellp_mtx->get_const_slice_sets()), 0);
+    ASSERT_FALSE(dsellp_mtx->get_size());
+}
+
+
 TEST_F(Csr, CalculateTotalColsIsEquivalentToRef)
 {
     set_up_apply_data(std::make_shared<Mtx::sparselib>());
@@ -625,7 +626,7 @@ TEST_F(Csr, MoveToHybridIsEquivalentToRef)
 
 TEST_F(Csr, RecognizeSortedMatrixIsEquivalentToRef)
 {
-    set_up_apply_data(std::make_shared<Mtx::sparselib>());
+    set_up_apply_data(std::make_shared<Mtx::automatical>(hip));
     bool is_sorted_hip{};
     bool is_sorted_ref{};
 

--- a/hip/test/preconditioner/jacobi_kernels.cpp
+++ b/hip/test/preconditioner/jacobi_kernels.cpp
@@ -315,7 +315,7 @@ TEST_F(Jacobi, HipPreconditionerEquivalentToRefWithBlockSize64)
 
     GKO_ASSERT_MTX_NEAR(gko::as<Bj>(d_bj.get()), gko::as<Bj>(bj.get()), 1e-13);
 }
-#endif
+#endif  // GINKGO_HIP_PLATFORM_HCC
 
 
 TEST_F(Jacobi, HipPreconditionerEquivalentToRefWithDifferentBlockSize)
@@ -395,7 +395,7 @@ TEST_F(Jacobi, HipApplyEquivalentToRefWithBlockSize64)
 
     GKO_ASSERT_MTX_NEAR(d_x, x, 1e-12);
 }
-#endif
+#endif  // GINKGO_HIP_PLATFORM_HCC
 
 
 TEST_F(Jacobi, HipApplyEquivalentToRefWithDifferentBlockSize)

--- a/include/ginkgo/core/base/types.hpp
+++ b/include/ginkgo/core/base/types.hpp
@@ -45,7 +45,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #ifdef __HIPCC__
 #include <hip/hip_runtime.h>
-#endif
+#endif  // __HIPCC__
 
 
 // Macros for handling different compilers / architectures uniformly

--- a/include/ginkgo/core/matrix/csr.hpp
+++ b/include/ginkgo/core/matrix/csr.hpp
@@ -431,7 +431,11 @@ public:
         {
             if (warp_size_ > 0) {
                 int multiple = 8;
-                if (nnz >= 2e6) {
+                if (nnz >= 2e8) {
+                    multiple = 2048;
+                } else if (nnz >= 2e7) {
+                    multiple = 512;
+                } else if (nnz >= 2e6) {
                     multiple = 128;
                 } else if (nnz >= 2e5) {
                     multiple = 32;

--- a/omp/test/matrix/csr_kernels.cpp
+++ b/omp/test/matrix/csr_kernels.cpp
@@ -299,6 +299,7 @@ TEST_F(Csr, TransposeIsEquivalentToRef)
 
     GKO_ASSERT_MTX_NEAR(static_cast<Mtx *>(d_trans.get()),
                         static_cast<Mtx *>(trans.get()), 0.0);
+    ASSERT_TRUE(static_cast<Mtx *>(d_trans.get())->is_sorted_by_column_index());
 }
 
 
@@ -311,6 +312,8 @@ TEST_F(Csr, ConjugateTransposeIsEquivalentToRef)
 
     GKO_ASSERT_MTX_NEAR(static_cast<ComplexMtx *>(d_trans.get()),
                         static_cast<ComplexMtx *>(trans.get()), 0.0);
+    ASSERT_TRUE(
+        static_cast<ComplexMtx *>(d_trans.get())->is_sorted_by_column_index());
 }
 
 

--- a/reference/test/stop/combined.cpp
+++ b/reference/test/stop/combined.cpp
@@ -37,7 +37,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <thread>
 #if defined(_WIN32) || defined(__CYGWIN__)
 #include <windows.h>
-#endif
+#endif  // defined(_WIN32) || defined(__CYGWIN__)
 
 
 #include <gtest/gtest.h>

--- a/reference/test/stop/time.cpp
+++ b/reference/test/stop/time.cpp
@@ -37,7 +37,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <thread>
 #if defined(_WIN32) || defined(__CYGWIN__)
 #include <windows.h>
-#endif
+#endif  // defined(_WIN32) || defined(__CYGWIN__)
 
 
 #include <gtest/gtest.h>


### PR DESCRIPTION
this PR add cuda11 support.

Summary:
1. add generic spmv/spmm into cusparse spmv/spmm
2. use cusp_coo/cusp_csr as cusp_gcoo/cusp_gcsr in benchmark/spmv 
3. use correct architecture flag in cuda/test
4. use cuda11's cooperative group because it support complex shuffle, but we remove the parent type in `tiled_partition`
5. add cuda 10.2/11 gitlab ci (linux) and cuda11 github action (windows)
6. replace deprecated spgemm2 and gthr by new cusparse generic interface.

Fixes #613 