### PR TITLE
Warn when CXX and CUDA host compiler do not match.

### DIFF
--- a/cuda/CMakeLists.txt
+++ b/cuda/CMakeLists.txt
@@ -122,6 +122,15 @@ if (NOT CMAKE_CUDA_HOST_COMPILER AND NOT GINKGO_CUDA_DEFAULT_HOST_COMPILER)
 elseif(GINKGO_CUDA_DEFAULT_HOST_COMPILER)
     unset(CMAKE_CUDA_HOST_COMPILER CACHE)
 endif()
+
+if(CMAKE_CUDA_HOST_COMPILER AND NOT CMAKE_CXX_COMPILER STREQUAL CMAKE_CUDA_HOST_COMPILER)
+    message(WARNING "The CMake CXX compiler and CUDA host compiler do not match. "
+        "If you encounter any build error, especially while linking, try to use "
+        "the same compiler for both.\n"
+        "The CXX compiler is ${CMAKE_CXX_COMPILER} with version ${CMAKE_CXX_COMPILER_VERSION}.\n"
+        "The CUDA host compiler is ${CMAKE_CUDA_HOST_COMPILER}.")
+endif()
+
 target_compile_options(ginkgo_cuda PRIVATE $<$<COMPILE_LANGUAGE:CUDA>:${GINKGO_CUDA_COMPILER_FLAGS}>)
 target_compile_options(ginkgo_cuda PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${GINKGO_COMPILER_FLAGS}>)
 ginkgo_compile_features(ginkgo_cuda)


### PR DESCRIPTION
On some systems, this can cause problems if the two compilers are tied
to different glib versions. At linking time (esp. for examples or
tests), it is then possible that some symbols are not found.

Closes #605 