### PR TITLE
Fix a few cmake warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,8 @@
 cmake_minimum_required(VERSION 3.9)
 
+# Use *_ROOT environment variables for find_package calls
+cmake_policy(SET CMP0074 NEW)
+
 project(Ginkgo LANGUAGES C CXX VERSION 1.2.0 DESCRIPTION "A numerical linear algebra library targeting many-core architectures")
 set(Ginkgo_VERSION_TAG "develop")
 set(PROJECT_VERSION_TAG ${Ginkgo_VERSION_TAG})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,9 @@
 cmake_minimum_required(VERSION 3.9)
 
 # Use *_ROOT environment variables for find_package calls
-cmake_policy(SET CMP0074 NEW)
+if (CMAKE_VERSION VERSION_GREATER_EQUAL 3.12)
+    cmake_policy(SET CMP0074 NEW)
+endif()
 
 project(Ginkgo LANGUAGES C CXX VERSION 1.2.0 DESCRIPTION "A numerical linear algebra library targeting many-core architectures")
 set(Ginkgo_VERSION_TAG "develop")

--- a/cmake/DownloadCMakeLists.txt.in
+++ b/cmake/DownloadCMakeLists.txt.in
@@ -1,5 +1,5 @@
-cmake_minimum_required(VERSION 2.8)
-
+cmake_minimum_required(VERSION 3.9)
+project(${package_name})
 
 include(ExternalProject)
 ExternalProject_Add(${package_name}
@@ -17,8 +17,6 @@ ExternalProject_Add(${package_name}
                "-DCMAKE_AR=${CMAKE_AR}"
                "-DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}"
                "-DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}"
-               "-DCMAKE_RC_COMPILER=${CMAKE_RC_COMPILER}"
-               "-DCMAKE_COMPILER_PREFIX=${CMAKE_COMPILER_PREFIX}"
                "-DCMAKE_FIND_ROOT_PATH=${CMAKE_FIND_ROOT_PATH}"
                "${ARGN}"
     INSTALL_COMMAND   ""

--- a/cuda/CMakeLists.txt
+++ b/cuda/CMakeLists.txt
@@ -141,6 +141,9 @@ target_link_libraries(ginkgo_cuda PRIVATE ${CUDA_RUNTIME_LIBS} ${CUBLAS} ${CUSPA
 # Need to link against ginkgo_hip for the `raw_copy_to(HipExecutor ...)` method
 target_link_libraries(ginkgo_cuda PUBLIC ginkgo_hip)
 
+# Let CAS handle the CUDA architecture flags (for now)
+cmake_policy(SET CMP0104 OLD)
+
 cas_target_cuda_architectures(ginkgo_cuda
     ARCHITECTURES ${GINKGO_CUDA_ARCHITECTURES}
     UNSUPPORTED "20" "21")

--- a/cuda/CMakeLists.txt
+++ b/cuda/CMakeLists.txt
@@ -142,7 +142,9 @@ target_link_libraries(ginkgo_cuda PRIVATE ${CUDA_RUNTIME_LIBS} ${CUBLAS} ${CUSPA
 target_link_libraries(ginkgo_cuda PUBLIC ginkgo_hip)
 
 # Let CAS handle the CUDA architecture flags (for now)
-cmake_policy(SET CMP0104 OLD)
+if (CMAKE_VERSION VERSION_GREATER_EQUAL 3.18)
+    cmake_policy(SET CMP0104 OLD)
+endif()
 
 cas_target_cuda_architectures(ginkgo_cuda
     ARCHITECTURES ${GINKGO_CUDA_ARCHITECTURES}

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.9)
 include(helpers.cmake)
 find_package(Doxygen REQUIRED)
 find_package(Perl REQUIRED)

--- a/examples/external-lib-interfacing/CMakeLists.txt
+++ b/examples/external-lib-interfacing/CMakeLists.txt
@@ -1,7 +1,7 @@
 if(GINKGO_BUILD_EXTLIB_EXAMPLE)
     # This is just an example of the CMakeLists.txt file that can be used after the
     # correct version of deal.ii has been installed.
-    cmake_minimum_required(VERSION 3.8)
+    cmake_minimum_required(VERSION 3.9)
     project(DEAL_II_EXAMPLE LANGUAGES CXX)
 
     find_package(MPI REQUIRED)


### PR DESCRIPTION
This PR fixes a few warning that the latest CMake versions output:
* move cmake_minimum_required from CMake 2.8 to more recent versions
* add project(...) to external projects
* set a few CMake policies

The [CMP0104](https://cmake.org/cmake/help/v3.18/policy/CMP0104.html) policy concerns CUDA architectures, we may want to move this to CAS, but I wasn't sure whether this is worth the effort.