### PR TITLE
Use unified memory in CUDA debug builds

### DIFF
--- a/dev_tools/scripts/gdb-ginkgo.py
+++ b/dev_tools/scripts/gdb-ginkgo.py
@@ -106,14 +106,11 @@ class GkoArrayPrinter:
         self.val = val
         self.execname = str(self.val['exec_']['_M_ptr'].dereference().dynamic_type)
         self.pointer = get_unique_ptr_data_ptr(self.val['data_']);
-        self.is_cpu = re.match('gko::(Reference|Omp)Executor', str(self.execname)) is not None
 
     def children(self):
-        if self.is_cpu:
-            return self._iterator(self.pointer, self.val['num_elems_'])
-        return []
+        return self._iterator(self.pointer, self.val['num_elems_'])
 
-    def to_string(self):     
+    def to_string(self):
         return ('%s of length %d on %s (%s)' % (str(self.val.type), int(self.val['num_elems_']), self.execname, self.pointer))
 
     def display_hint(self):

--- a/dev_tools/scripts/gdb-ginkgo.py
+++ b/dev_tools/scripts/gdb-ginkgo.py
@@ -106,9 +106,13 @@ class GkoArrayPrinter:
         self.val = val
         self.execname = str(self.val['exec_']['_M_ptr'].dereference().dynamic_type)
         self.pointer = get_unique_ptr_data_ptr(self.val['data_']);
+        # Cuda allows access via unified memory in Debug builds
+        self.is_cpu = re.match('gko::(Reference|Omp|Cuda)Executor', str(self.execname)) is not None
 
     def children(self):
-        return self._iterator(self.pointer, self.val['num_elems_'])
+        if self.is_cpu:
+            return self._iterator(self.pointer, self.val['num_elems_'])
+        return []
 
     def to_string(self):
         return ('%s of length %d on %s (%s)' % (str(self.val.type), int(self.val['num_elems_']), self.execname, self.pointer))

--- a/hip/base/executor.hip.cpp
+++ b/hip/base/executor.hip.cpp
@@ -103,7 +103,7 @@ void *HipExecutor::raw_alloc(size_type num_bytes) const
 {
     void *dev_ptr = nullptr;
     hip::device_guard g(this->get_device_id());
-#ifdef NDEBUG
+#if defined(NDEBUG) || (GINKGO_HIP_PLATFORM_HCC == 1)
     auto error_code = hipMalloc(&dev_ptr, num_bytes);
 #else
     auto error_code = hipMallocManaged(&dev_ptr, num_bytes);

--- a/hip/base/executor.hip.cpp
+++ b/hip/base/executor.hip.cpp
@@ -103,7 +103,11 @@ void *HipExecutor::raw_alloc(size_type num_bytes) const
 {
     void *dev_ptr = nullptr;
     hip::device_guard g(this->get_device_id());
+#ifdef NDEBUG
     auto error_code = hipMalloc(&dev_ptr, num_bytes);
+#else
+    auto error_code = hipMallocManaged(&dev_ptr, num_bytes);
+#endif
     if (error_code != hipErrorMemoryAllocation) {
         GKO_ASSERT_NO_HIP_ERRORS(error_code);
     }
@@ -123,14 +127,14 @@ void HipExecutor::raw_copy_to(const OmpExecutor *, size_type num_bytes,
 }
 
 
-void HipExecutor::raw_copy_to(const CudaExecutor *src, size_type num_bytes,
+void HipExecutor::raw_copy_to(const CudaExecutor *dest, size_type num_bytes,
                               const void *src_ptr, void *dest_ptr) const
 {
 #if GINKGO_HIP_PLATFORM_NVCC == 1
     if (num_bytes > 0) {
         hip::device_guard g(this->get_device_id());
-        GKO_ASSERT_NO_HIP_ERRORS(hipMemcpyPeer(dest_ptr, this->device_id_,
-                                               src_ptr, src->get_device_id(),
+        GKO_ASSERT_NO_HIP_ERRORS(hipMemcpyPeer(dest_ptr, dest->get_device_id(),
+                                               src_ptr, this->get_device_id(),
                                                num_bytes));
     }
 #else
@@ -139,13 +143,13 @@ void HipExecutor::raw_copy_to(const CudaExecutor *src, size_type num_bytes,
 }
 
 
-void HipExecutor::raw_copy_to(const HipExecutor *src, size_type num_bytes,
+void HipExecutor::raw_copy_to(const HipExecutor *dest, size_type num_bytes,
                               const void *src_ptr, void *dest_ptr) const
 {
     if (num_bytes > 0) {
         hip::device_guard g(this->get_device_id());
-        GKO_ASSERT_NO_HIP_ERRORS(hipMemcpyPeer(dest_ptr, this->device_id_,
-                                               src_ptr, src->get_device_id(),
+        GKO_ASSERT_NO_HIP_ERRORS(hipMemcpyPeer(dest_ptr, dest->get_device_id(),
+                                               src_ptr, this->get_device_id(),
                                                num_bytes));
     }
 }


### PR DESCRIPTION
This PR uses unified memory instead of device memory in CUDA debug builds, allowing you to directly access device memory in `cuda-gdb`.

It additionally fixes a bug in multi-GPU raw_copy_to, which used the wrong device ordinals due to a wrongly named parameter (src -> dest)