### PR TITLE
Release 1.3.0 for develop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,68 @@ commits. For a comprehensive list, use the following command:
 git log --first-parent
 ```
 
+## Version 1.3.0
+
+The Ginkgo team is proud to announce the new minor release of Ginkgo version
+1.3.0. This release brings CUDA 11 support, changes the default C++ standard to
+be C++14 instead of C++11, adds a new Diagonal matrix format and capacity for
+diagonal extraction, significantly improves the CMake configuration output
+format, adds the Ginkgo paper which got accepted into the Journal of Open Source
+Software (JOSS), and fixes multiple issues.
+
+Supported systems and requirements:
++ For all platforms, cmake 3.9+
++ Linux and MacOS
+  + gcc: 5.3+, 6.3+, 7.3+, all versions after 8.1+
+  + clang: 3.9+
+  + Intel compiler: 2017+
+  + Apple LLVM: 8.0+
+  + CUDA module: CUDA 9.0+
+  + HIP module: ROCm 2.8+
++ Windows
+  + MinGW and CygWin: gcc 5.3+, 6.3+, 7.3+, all versions after 8.1+
+  + Microsoft Visual Studio: VS 2017 15.7+
+  + CUDA module: CUDA 9.0+, Microsoft Visual Studio
+  + OpenMP module: MinGW or CygWin.
+
+
+The current known issues can be found in the [known issues page](https://github.com/ginkgo-project/ginkgo/wiki/Known-Issues).
+
+
+### Additions
++ Add paper for Journal of Open Source Software (JOSS). [#479](https://github.com/ginkgo-project/ginkgo/pull/479)
++ Add a DiagonalExtractable interface. [#563](https://github.com/ginkgo-project/ginkgo/pull/563)
++ Add a new diagonal Matrix Format. [#580](https://github.com/ginkgo-project/ginkgo/pull/580)
++ Add Cuda11 support. [#603](https://github.com/ginkgo-project/ginkgo/pull/603)
++ Add information output after CMake configuration. [#610](https://github.com/ginkgo-project/ginkgo/pull/610)
++ Add a new preconditioner export example. [#595](https://github.com/ginkgo-project/ginkgo/pull/595)
++ Add a new cuda-memcheck CI job. [#592](https://github.com/ginkgo-project/ginkgo/pull/592)
+
+### Changes
++ Use unified memory in CUDA debug builds. [#621](https://github.com/ginkgo-project/ginkgo/pull/621)
++ Improve `BENCHMARKING.md` with more detailed info. [#619](https://github.com/ginkgo-project/ginkgo/pull/619)
++ Use C++14 standard instead of C++11. [#611](https://github.com/ginkgo-project/ginkgo/pull/611)
++ Update the Ampere sm information and CudaArchitectureSelector. [#588](https://github.com/ginkgo-project/ginkgo/pull/588)
+
+### Fixes
++ Fix documentation warnings and errors. [#624](https://github.com/ginkgo-project/ginkgo/pull/624)
++ Fix warnings for diagonal matrix format. [#622](https://github.com/ginkgo-project/ginkgo/pull/622)
++ Fix criterion factory parameters in CUDA. [#586](https://github.com/ginkgo-project/ginkgo/pull/586)
++ Fix the norm-type in the examples. [#612](https://github.com/ginkgo-project/ginkgo/pull/612)
++ Fix the WAW race in OpenMP is_sorted_by_column_index. [#617](https://github.com/ginkgo-project/ginkgo/pull/617)
++ Fix the example's exec_map by creating the executor only if requested. [#602](https://github.com/ginkgo-project/ginkgo/pull/602)
++ Fix some CMake warnings. [#614](https://github.com/ginkgo-project/ginkgo/pull/614)
++ Fix Windows building documentation. [#601](https://github.com/ginkgo-project/ginkgo/pull/601)
++ Warn when CXX and CUDA host compiler do not match. [#607](https://github.com/ginkgo-project/ginkgo/pull/607)
++ Fix reduce_add, prefix_sum, and doc-build. [#593](https://github.com/ginkgo-project/ginkgo/pull/593)
++ Fix find_library(cublas) issue on machines installing multiple cuda. [#591](https://github.com/ginkgo-project/ginkgo/pull/591)
++ Fix allocator in sellp read. [#589](https://github.com/ginkgo-project/ginkgo/pull/589)
++ Fix the CAS with HIP and NVIDIA backends. [#585](https://github.com/ginkgo-project/ginkgo/pull/585)
+
+### Deletions
++ Remove unused preconditioner parameter in LowerTrs. [#587](https://github.com/ginkgo-project/ginkgo/pull/587)
+
+
 ## Version 1.2.0
 
 The Ginkgo team is proud to announce the new minor release of Ginkgo version

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,10 +25,10 @@ Supported systems and requirements:
   + CUDA module: CUDA 9.0+
   + HIP module: ROCm 2.8+
 + Windows
-  + MinGW and CygWin: gcc 5.3+, 6.3+, 7.3+, all versions after 8.1+
+  + MinGW and Cygwin: gcc 5.3+, 6.3+, 7.3+, all versions after 8.1+
   + Microsoft Visual Studio: VS 2017 15.7+
   + CUDA module: CUDA 9.0+, Microsoft Visual Studio
-  + OpenMP module: MinGW or CygWin.
+  + OpenMP module: MinGW or Cygwin.
 
 
 The current known issues can be found in the [known issues page](https://github.com/ginkgo-project/ginkgo/wiki/Known-Issues).
@@ -85,10 +85,10 @@ Supported systems and requirements:
   + CUDA module: CUDA 9.0+
   + HIP module: ROCm 2.8+
 + Windows
-  + MinGW and CygWin: gcc 5.3+, 6.3+, 7.3+, all versions after 8.1+
+  + MinGW and Cygwin: gcc 5.3+, 6.3+, 7.3+, all versions after 8.1+
   + Microsoft Visual Studio: VS 2017 15.7+
   + CUDA module: CUDA 9.0+, Microsoft Visual Studio
-  + OpenMP module: MinGW or CygWin.
+  + OpenMP module: MinGW or Cygwin.
 
 
 The current known issues can be found in the [known issues page](https://github.com/ginkgo-project/ginkgo/wiki/Known-Issues).

--- a/CITING.md
+++ b/CITING.md
@@ -17,6 +17,23 @@ available through the following reference:
 Multiple topical papers exist on Ginkgo and its algorithms. The following papers
 can be used to cite specific aspects of the Ginkgo project.
 
+### The Ginkgo Software
+
+The Ginkgo software itself was reviewed and has a paper published in the Journal
+of Open Source Software, which can be cited with the following reference:
+
+```bibtex
+@article{Joss2020,
+  doi = {10.21105.joss.02260},
+  url = {https://doi.org/10.21105/joss.02260},
+  year = {2020},
+  publisher = {The Open Journal},
+  author = {Hartwig Anzt and Terry Cojean and Yen-Chen Chen and Goran Flegar and Fritz G\"{o}bel and Thomas Gr\"{u}tzmacher and Pratik Nayak and Tobias Ribizel and Yu-Hsiang Tsai},
+  title = {Ginkgo: A high performance numerical linear algebra library},
+  journal = {Journal of Open Source Software}
+}
+```
+
 ### On Portability
 
 ``` bibtex

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@ if (CMAKE_VERSION VERSION_GREATER_EQUAL 3.18)
     cmake_policy(SET CMP0104 OLD)
 endif()
 
-project(Ginkgo LANGUAGES C CXX VERSION 1.2.0 DESCRIPTION "A numerical linear algebra library targeting many-core architectures")
+project(Ginkgo LANGUAGES C CXX VERSION 1.3.0 DESCRIPTION "A numerical linear algebra library targeting many-core architectures")
 set(Ginkgo_VERSION_TAG "develop")
 set(PROJECT_VERSION_TAG ${Ginkgo_VERSION_TAG})
 

--- a/examples/build-setup.sh
+++ b/examples/build-setup.sh
@@ -4,7 +4,7 @@
 LIBRARY_DIRS="core core/device_hooks reference omp cuda hip"
 LIBRARY_NAMES="ginkgo ginkgo_reference ginkgo_omp ginkgo_cuda ginkgo_hip"
 SUFFIXES=".so .dylib .dll d.so d.dylib d.dll"
-VERSION="1.2.0"
+VERSION="1.3.0"
 for prefix in ${LIBRARY_DIRS}; do
     for name in ${LIBRARY_NAMES}; do
         for suffix in ${SUFFIXES}; do


### PR DESCRIPTION
This PR pushes the Ginkgo 1.3.0 release for develop. You can find in `CHANGELOG.md` the summary of the additions.

If this is accepted, I will later create a similar PR for the `master` branch.

The documentation will be generated for this branch and will be available on a successful build at:
https://ginkgo-project.github.io/ginkgo/doc/release/1.3.0/index.html