### PR TITLE
Fix add_subdirectory builds for Ginkgo

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -686,7 +686,6 @@ subdir-build:
     BUILD_OMP: "ON"
     BUILD_CUDA: "ON"
     BUILD_HIP: "ON"
-    EXTRA_CMAKE_FLAGS: "-DGINKGO_BUILD_DOC=ON"
     CI_PROJECT_PATH_SUFFIX: "/test_subdir"
   only:
     variables:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -25,6 +25,7 @@ stages:
   CONFIG_LOG: "ON"
   CXX_FLAGS: ""
   EXTRA_CMAKE_FLAGS: ""
+  CI_PROJECT_DIR_SUFFIX: ""
 
 .before_script_template: &default_before_script
   - export NUM_CORES=${CI_PARALLELISM}
@@ -50,7 +51,7 @@ stages:
       CUDA_ARCH_STR=-DGINKGO_CUDA_ARCHITECTURES=${CUDA_ARCH};
       CUDA_HOST_STR=-DCMAKE_CUDA_HOST_COMPILER=$(which ${CXX_COMPILER});
       fi
-    - cmake ${CI_PROJECT_DIR}
+    - cmake ${CI_PROJECT_DIR}${CI_PROJECT_DIR_SUFFIX}
         -GNinja
         -DCMAKE_C_COMPILER=${C_COMPILER} -DCMAKE_CXX_COMPILER=${CXX_COMPILER}
         -DCMAKE_CUDA_COMPILER=${CUDA_COMPILER} -DCMAKE_BUILD_TYPE=${BUILD_TYPE}
@@ -76,7 +77,7 @@ stages:
       CUDA_ARCH_STR=-DGINKGO_CUDA_ARCHITECTURES=${CUDA_ARCH};
       CUDA_HOST_STR=-DCMAKE_CUDA_HOST_COMPILER=$(which ${CXX_COMPILER});
       fi
-    - cmake ${CI_PROJECT_DIR}
+    - cmake ${CI_PROJECT_DIR}${CI_PROJECT_DIR_SUFFIX}
         -GNinja
         -DCMAKE_C_COMPILER=${C_COMPILER} -DCMAKE_CXX_COMPILER=${CXX_COMPILER}
         -DCMAKE_CUDA_COMPILER=${CUDA_COMPILER} -DCMAKE_BUILD_TYPE=${BUILD_TYPE}
@@ -665,6 +666,28 @@ no-circular-deps:
     BUILD_CUDA: "ON"
     BUILD_HIP: "ON"
     EXTRA_CMAKE_FLAGS: '-DGINKGO_CHECK_CIRCULAR_DEPS=on'
+  only:
+    variables:
+      - $RUN_CI_TAG
+  dependencies: []
+  allow_failure: no
+  tags:
+    - private_ci
+    - cuda
+    - gpu
+
+# Ensure Ginkgo builds from a subdirectory
+subdir-build:
+  <<: *default_build
+  stage: code_quality
+  image: localhost:5000/gko-cuda101-gnu8-llvm7-intel2019
+  variables:
+    <<: *default_variables
+    BUILD_OMP: "ON"
+    BUILD_CUDA: "ON"
+    BUILD_HIP: "ON"
+    EXTRA_CMAKE_FLAGS: "-DGINKGO_BUILD_DOC=ON"
+    CI_PROJECT_PATH_SUFFIX: "/test_subdir"
   only:
     variables:
       - $RUN_CI_TAG

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -125,7 +125,7 @@ if(GINKGO_WITH_IWYU)
     find_program(GINKGO_IWYU_PATH iwyu)
 endif()
 
-list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake/Modules/")
+list(APPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake/Modules/")
 
 # Find important header files, store the definitions in include/ginkgo/config.h.in
 # For details, see https://gitlab.kitware.com/cmake/community/wikis/doc/tutorials/How-To-Write-Platform-Checks
@@ -311,8 +311,8 @@ include(CPack)
 # And finally, print the configuration to screen:
 #
 if(GINKGO_CONFIG_LOG_DETAILED)
-    FILE(READ ${CMAKE_BINARY_DIR}/detailed.log GINKGO_LOG_SUMMARY)
+    FILE(READ ${PROJECT_BINARY_DIR}/detailed.log GINKGO_LOG_SUMMARY)
 else()
-    FILE(READ ${CMAKE_BINARY_DIR}/minimal.log GINKGO_LOG_SUMMARY)
+    FILE(READ ${PROJECT_BINARY_DIR}/minimal.log GINKGO_LOG_SUMMARY)
 endif()
 MESSAGE("${GINKGO_LOG_SUMMARY}")

--- a/cmake/Modules/FindPAPI.cmake
+++ b/cmake/Modules/FindPAPI.cmake
@@ -70,7 +70,7 @@ if(PAPI_INCLUDE_DIR)
         # find the components
         enable_language(C)
         foreach(component IN LISTS PAPI_FIND_COMPONENTS)
-            file(WRITE "${CMAKE_BINARY_DIR}/papi_${component}_detect.c"
+            file(WRITE "${PROJECT_BINARY_DIR}/papi_${component}_detect.c"
                 "
                 #include <papi.h>
                 int main() {
@@ -85,8 +85,8 @@ if(PAPI_INCLUDE_DIR)
                 )
             try_run(PAPI_${component}_FOUND
                 gko_result_unused
-                "${CMAKE_BINARY_DIR}"
-                "${CMAKE_BINARY_DIR}/papi_${component}_detect.c"
+                "${PROJECT_BINARY_DIR}"
+                "${PROJECT_BINARY_DIR}/papi_${component}_detect.c"
                 LINK_LIBRARIES ${PAPI_LIBRARY}
                 )
 

--- a/cmake/get_info.cmake
+++ b/cmake/get_info.cmake
@@ -1,5 +1,5 @@
-SET(detailed_log "${CMAKE_BINARY_DIR}/detailed.log")
-SET(minimal_log  "${CMAKE_BINARY_DIR}/minimal.log")
+SET(detailed_log "${PROJECT_BINARY_DIR}/detailed.log")
+SET(minimal_log  "${PROJECT_BINARY_DIR}/minimal.log")
 FILE(REMOVE ${detailed_log} ${minimal_log})
 
 MACRO(_both)
@@ -89,7 +89,7 @@ set(log_types "detailed_log;minimal_log")
 foreach(log_type ${log_types})
     ginkgo_print_module_footer(${${log_type}} "Ginkgo configuration:")
     set(print_var
-        "CMAKE_BUILD_TYPE;BUILD_SHARED_LIBS;CMAKE_INSTALL_PREFIX;CMAKE_SOURCE_DIR;CMAKE_BINARY_DIR"
+        "CMAKE_BUILD_TYPE;BUILD_SHARED_LIBS;CMAKE_INSTALL_PREFIX;PROJECT_SOURCE_DIR;PROJECT_BINARY_DIR"
         )
     foreach(var ${print_var})
         ginkgo_print_variable(${${log_type}} ${var} )

--- a/core/test/CMakeLists.txt
+++ b/core/test/CMakeLists.txt
@@ -1,4 +1,4 @@
-include(${CMAKE_SOURCE_DIR}/cmake/create_test.cmake)
+include(${PROJECT_SOURCE_DIR}/cmake/create_test.cmake)
 
 add_subdirectory(base)
 add_subdirectory(factorization)

--- a/cuda/test/CMakeLists.txt
+++ b/cuda/test/CMakeLists.txt
@@ -1,4 +1,4 @@
-include(${CMAKE_SOURCE_DIR}/cmake/create_test.cmake)
+include(${PROJECT_SOURCE_DIR}/cmake/create_test.cmake)
 
 add_subdirectory(base)
 add_subdirectory(components)

--- a/doc/conf/Doxyfile.in
+++ b/doc/conf/Doxyfile.in
@@ -12,7 +12,7 @@ INPUT                  =
 
 INCLUDE_PATH           = @DIR_BASE@/include @DIR_BASE@
 OUTPUT_DIRECTORY       = @DIR_OUT@
-EXAMPLE_PATH           = @CMAKE_BINARY_DIR@/doc/examples
+EXAMPLE_PATH           = @PROJECT_BINARY_DIR@/doc/examples
 RECURSIVE              = YES
 EXAMPLE_RECURSIVE      = NO
 FILE_PATTERNS          = *.cpp *.cu *.hpp *.cuh *.md

--- a/doc/examples/CMakeLists.txt
+++ b/doc/examples/CMakeLists.txt
@@ -2,7 +2,7 @@
 FILE(GLOB _ginkgo_examples
     ${PROJECT_SOURCE_DIR}/examples/*
     )
-LIST(REMOVE_ITEM _ginkgo_examples "${CMAKE_CURRENT_SOURCE_DIR}/examples/CMakeLists.txt" "${PROJECT_SOURCE_DIR}/examples/build-setup.sh")
+LIST(REMOVE_ITEM _ginkgo_examples "${PROJECT_SOURCE_DIR}/examples/CMakeLists.txt" "${PROJECT_SOURCE_DIR}/examples/build-setup.sh")
 
 ADD_CUSTOM_TARGET(examples)
 

--- a/doc/examples/CMakeLists.txt
+++ b/doc/examples/CMakeLists.txt
@@ -1,32 +1,32 @@
 # Collect all of the directory names for the examples programs
 FILE(GLOB _ginkgo_examples
-    ${CMAKE_SOURCE_DIR}/examples/*
+    ${PROJECT_SOURCE_DIR}/examples/*
     )
-LIST(REMOVE_ITEM _ginkgo_examples "${CMAKE_SOURCE_DIR}/examples/CMakeLists.txt" "${CMAKE_SOURCE_DIR}/examples/build-setup.sh")
+LIST(REMOVE_ITEM _ginkgo_examples "${CMAKE_CURRENT_SOURCE_DIR}/examples/CMakeLists.txt" "${PROJECT_SOURCE_DIR}/examples/build-setup.sh")
 
 ADD_CUSTOM_TARGET(examples)
 
 file(GLOB _ginkgo_examples_tooltip
-    ${CMAKE_SOURCE_DIR}/examples/*/doc/tooltip
+    ${PROJECT_SOURCE_DIR}/examples/*/doc/tooltip
     )
 
 file(GLOB _ginkgo_examples_kind
-    ${CMAKE_SOURCE_DIR}/examples/*/doc/kind
+    ${PROJECT_SOURCE_DIR}/examples/*/doc/kind
     )
 file(GLOB _ginkgo_examples_buildson
-    ${CMAKE_SOURCE_DIR}/examples/*/doc/builds-on
+    ${PROJECT_SOURCE_DIR}/examples/*/doc/builds-on
     )
 
 ADD_CUSTOM_COMMAND(
     OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/examples.hpp
     COMMAND ${PERL_EXECUTABLE}
     ARGS
-    ${CMAKE_SOURCE_DIR}/doc/scripts/examples.pl
+    ${PROJECT_SOURCE_DIR}/doc/scripts/examples.pl
     ${CMAKE_CURRENT_SOURCE_DIR}/examples.hpp.in
     ${_ginkgo_examples}
     > ${CMAKE_CURRENT_BINARY_DIR}/examples.hpp
     DEPENDS
-    ${CMAKE_SOURCE_DIR}/doc/scripts/examples.pl
+    ${PROJECT_SOURCE_DIR}/doc/scripts/examples.pl
     ${CMAKE_CURRENT_SOURCE_DIR}/examples.hpp.in
     ${_ginkgo_examples_tooltip}
     ${_ginkgo_examples_kind}
@@ -49,12 +49,12 @@ FOREACH(example ${_ginkgo_examples})
         OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/${example}.cpp
         COMMAND ${PERL_EXECUTABLE}
         ARGS
-        ${CMAKE_SOURCE_DIR}/doc/scripts/program2plain
-        < ${CMAKE_SOURCE_DIR}/examples/${example}/${example}.cpp
+        ${PROJECT_SOURCE_DIR}/doc/scripts/program2plain
+        < ${PROJECT_SOURCE_DIR}/examples/${example}/${example}.cpp
         > ${CMAKE_CURRENT_BINARY_DIR}/${example}.cpp
         DEPENDS
-        ${CMAKE_SOURCE_DIR}/doc/scripts/program2plain
-        ${CMAKE_SOURCE_DIR}/examples/${example}/${example}.cpp
+        ${PROJECT_SOURCE_DIR}/doc/scripts/program2plain
+        ${PROJECT_SOURCE_DIR}/examples/${example}/${example}.cpp
         VERBATIM
         )
 
@@ -62,19 +62,19 @@ FOREACH(example ${_ginkgo_examples})
         OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/${example}.hpp
         COMMAND ${PERL_EXECUTABLE}
         ARGS
-        ${CMAKE_SOURCE_DIR}/doc/scripts/make_example.pl
-        ${example} ${CMAKE_SOURCE_DIR} ${CMAKE_BINARY_DIR}
+        ${PROJECT_SOURCE_DIR}/doc/scripts/make_example.pl
+        ${example} ${PROJECT_SOURCE_DIR} ${PROJECT_BINARY_DIR}
         > ${CMAKE_CURRENT_BINARY_DIR}/${example}.hpp
         WORKING_DIRECTORY
         ${CMAKE_CURRENT_BINARY_DIR}
         DEPENDS
-        ${CMAKE_SOURCE_DIR}/doc/scripts/make_example.pl
-        ${CMAKE_SOURCE_DIR}/doc/scripts/intro2toc
-        ${CMAKE_SOURCE_DIR}/doc/scripts/create_anchors
-        ${CMAKE_SOURCE_DIR}/doc/scripts/program2doxygen
-        ${CMAKE_SOURCE_DIR}/examples/${example}/${example}.cpp
-        ${CMAKE_SOURCE_DIR}/examples/${example}/doc/intro.dox
-        ${CMAKE_SOURCE_DIR}/examples/${example}/doc/results.dox
+        ${PROJECT_SOURCE_DIR}/doc/scripts/make_example.pl
+        ${PROJECT_SOURCE_DIR}/doc/scripts/intro2toc
+        ${PROJECT_SOURCE_DIR}/doc/scripts/create_anchors
+        ${PROJECT_SOURCE_DIR}/doc/scripts/program2doxygen
+        ${PROJECT_SOURCE_DIR}/examples/${example}/${example}.cpp
+        ${PROJECT_SOURCE_DIR}/examples/${example}/doc/intro.dox
+        ${PROJECT_SOURCE_DIR}/examples/${example}/doc/results.dox
         )
 
     ADD_CUSTOM_TARGET(examples_${example}

--- a/doc/examples/examples.hpp.in
+++ b/doc/examples/examples.hpp.in
@@ -127,12 +127,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *       </td></tr>
  *
  *   <tr valign="top">
- *       <td>@ref twentyseven_pt_stencil_solver</td>
- *       <td> Using a twentyseven point 3D stencil to solve the poisson equation
- *            with array views.
- *       </td></tr>
- *
- *   <tr valign="top">
  *       <td>@ref external_lib_interfacing</td>
  *       <td> Using Ginkgo's solver with the external library deal.II.
  *       </td></tr>
@@ -228,7 +222,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *     <td>@ref poisson_solver,
  *         @ref three_pt_stencil_solver,
  *         @ref nine_pt_stencil_solver,
- *         @ref twentyseven_pt_stencil_solver,
  *         @ref custom_matrix_format
  *     </td>
  *   </tr>

--- a/doc/helpers.cmake
+++ b/doc/helpers.cmake
@@ -39,7 +39,7 @@ endfunction()
 # generates the documentation named <name> with the additional
 # config file <in> in <pdf/html> format
 function(ginkgo_doc_gen name in pdf mainpage-in)
-    set(DIR_BASE "${CMAKE_SOURCE_DIR}")
+    set(DIR_BASE "${PROJECT_SOURCE_DIR}")
     set(DOC_BASE "${CMAKE_CURRENT_SOURCE_DIR}")
     set(DIR_SCRIPT "${DOC_BASE}/scripts")
     set(DIR_OUT "${CMAKE_CURRENT_BINARY_DIR}/${name}")
@@ -53,7 +53,7 @@ function(ginkgo_doc_gen name in pdf mainpage-in)
         "${DOC_BASE}/headers/"
         )
     list(APPEND doxygen_base_input
-        ${CMAKE_BINARY_DIR}/include/ginkgo/config.hpp
+        ${PROJECT_BINARY_DIR}/include/ginkgo/config.hpp
         ${DIR_BASE}/include
         ${MAINPAGE}
         )
@@ -77,7 +77,7 @@ function(ginkgo_doc_gen name in pdf mainpage-in)
         ${DIR_BASE}/include/ginkgo/**/*.hpp
         )
     list(APPEND doxygen_depend
-        ${CMAKE_BINARY_DIR}/include/ginkgo/config.hpp
+        ${PROJECT_BINARY_DIR}/include/ginkgo/config.hpp
         )
     if(GINKGO_DOC_GENERATE_EXAMPLES)
         list(APPEND doxygen_depend

--- a/hip/test/CMakeLists.txt
+++ b/hip/test/CMakeLists.txt
@@ -1,4 +1,4 @@
-include(${CMAKE_SOURCE_DIR}/cmake/create_test.cmake)
+include(${PROJECT_SOURCE_DIR}/cmake/create_test.cmake)
 
 add_subdirectory(base)
 add_subdirectory(components)

--- a/omp/test/CMakeLists.txt
+++ b/omp/test/CMakeLists.txt
@@ -1,4 +1,4 @@
-include(${CMAKE_SOURCE_DIR}/cmake/create_test.cmake)
+include(${PROJECT_SOURCE_DIR}/cmake/create_test.cmake)
 
 add_subdirectory(components)
 add_subdirectory(factorization)

--- a/reference/test/CMakeLists.txt
+++ b/reference/test/CMakeLists.txt
@@ -1,4 +1,4 @@
-include(${CMAKE_SOURCE_DIR}/cmake/create_test.cmake)
+include(${PROJECT_SOURCE_DIR}/cmake/create_test.cmake)
 
 add_subdirectory(base)
 add_subdirectory(components)

--- a/test_subdir/CMakeLists.txt
+++ b/test_subdir/CMakeLists.txt
@@ -1,0 +1,9 @@
+cmake_minimum_required(VERSION 3.14)
+project(GinkgoSubdirTest LANGUAGES CXX)
+file(CREATE_LINK "${CMAKE_CURRENT_SOURCE_DIR}/.." "${CMAKE_CURRENT_BINARY_DIR}/ginkgo" SYMBOLIC)
+
+add_subdirectory("${CMAKE_CURRENT_BINARY_DIR}/ginkgo")
+
+add_executable(test_subdir ../test_install/test_install.cpp)
+target_compile_features(test_subdir PUBLIC cxx_std_14)
+target_link_libraries(test_subdir PRIVATE Ginkgo::ginkgo)


### PR DESCRIPTION
Currently, we often use `CMAKE_SOURCE_DIR` instead of the preferred `PROJECT_SOURCE_DIR` (relative to the last project() call) or `CMAKE_CURRENT_SOURCE_DIR` (relative to the current CMakeLists.txt)

This causes issues when Ginkgo is built as a subdirectory using `add_subdirectory(...)` instead of installing it.

TODO
- [x] Add CI job for subdir build similar to test_install
- [x] ~Fix git-cmake-format interaction with ExternalProject~ (**or just ignore it?**)