### PR TITLE
Improve identity constructor and treatment of rectangular matrices

### DIFF
--- a/benchmark/utils/overhead_linop.hpp
+++ b/benchmark/utils/overhead_linop.hpp
@@ -208,7 +208,7 @@ protected:
                 parameters_.preconditioner->generate(system_matrix_));
         } else {
             set_preconditioner(matrix::Identity<ValueType>::create(
-                this->get_executor(), this->get_size()[0]));
+                this->get_executor(), this->get_size()));
         }
         stop_criterion_factory_ =
             stop::combine(std::move(parameters_.criteria));

--- a/core/solver/gmres.cpp
+++ b/core/solver/gmres.cpp
@@ -94,8 +94,6 @@ std::unique_ptr<LinOp> Gmres<ValueType>::conj_transpose() const
 template <typename ValueType>
 void Gmres<ValueType>::apply_impl(const LinOp *b, LinOp *x) const
 {
-    GKO_ASSERT_IS_SQUARE_MATRIX(system_matrix_);
-
     using Vector = matrix::Dense<ValueType>;
     using NormVector = matrix::Dense<remove_complex<ValueType>>;
 

--- a/core/test/matrix/identity.cpp
+++ b/core/test/matrix/identity.cpp
@@ -36,6 +36,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <gtest/gtest.h>
 
 
+#include <ginkgo/core/base/exception.hpp>
 #include <ginkgo/core/matrix/dense.hpp>
 
 
@@ -72,7 +73,26 @@ TYPED_TEST(Identity, CanBeConstructedWithSize)
 {
     using Id = typename TestFixture::Id;
     auto identity = Id::create(this->exec, 5);
+
     ASSERT_EQ(identity->get_size(), gko::dim<2>(5, 5));
+}
+
+
+TYPED_TEST(Identity, CanBeConstructedWithSquareSize)
+{
+    using Id = typename TestFixture::Id;
+    auto identity = Id::create(this->exec, gko::dim<2>(5, 5));
+
+    ASSERT_EQ(identity->get_size(), gko::dim<2>(5, 5));
+}
+
+
+TYPED_TEST(Identity, FailsConstructionWithRectangularSize)
+{
+    using Id = typename TestFixture::Id;
+
+    ASSERT_THROW(Id::create(this->exec, gko::dim<2>(5, 4)),
+                 gko::DimensionMismatch);
 }
 
 
@@ -124,6 +144,16 @@ TYPED_TEST(IdentityFactory, CanGenerateIdentityMatrix)
     auto id = id_factory->generate(std::move(mtx));
 
     ASSERT_EQ(id->get_size(), gko::dim<2>(5, 5));
+}
+
+
+TYPED_TEST(IdentityFactory, FailsToGenerateRectangularIdentityMatrix)
+{
+    auto exec = gko::ReferenceExecutor::create();
+    auto id_factory = gko::matrix::IdentityFactory<TypeParam>::create(exec);
+    auto mtx = gko::matrix::Dense<TypeParam>::create(exec, gko::dim<2>{5, 4});
+
+    ASSERT_THROW(id_factory->generate(std::move(mtx)), gko::DimensionMismatch);
 }
 
 

--- a/core/test/solver/bicg.cpp
+++ b/core/test/solver/bicg.cpp
@@ -257,7 +257,7 @@ TYPED_TEST(Bicg, ThrowsOnWrongPreconditionerInFactory)
     using Mtx = typename TestFixture::Mtx;
     using Solver = typename TestFixture::Solver;
     std::shared_ptr<Mtx> wrong_sized_mtx =
-        Mtx::create(this->exec, gko::dim<2>{1, 3});
+        Mtx::create(this->exec, gko::dim<2>{2, 2});
     std::shared_ptr<Solver> bicg_precond =
         Solver::build()
             .with_criteria(

--- a/core/test/solver/bicg.cpp
+++ b/core/test/solver/bicg.cpp
@@ -276,6 +276,18 @@ TYPED_TEST(Bicg, ThrowsOnWrongPreconditionerInFactory)
 }
 
 
+TYPED_TEST(Bicg, ThrowsOnRectangularMatrixInFactory)
+{
+    using Mtx = typename TestFixture::Mtx;
+    using Solver = typename TestFixture::Solver;
+    std::shared_ptr<Mtx> rectangular_mtx =
+        Mtx::create(this->exec, gko::dim<2>{1, 2});
+
+    ASSERT_THROW(this->bicg_factory->generate(rectangular_mtx),
+                 gko::DimensionMismatch);
+}
+
+
 TYPED_TEST(Bicg, CanSetPreconditioner)
 {
     using Solver = typename TestFixture::Solver;

--- a/core/test/solver/bicgstab.cpp
+++ b/core/test/solver/bicgstab.cpp
@@ -268,6 +268,18 @@ TYPED_TEST(Bicgstab, ThrowsOnWrongPreconditionerInFactory)
 }
 
 
+TYPED_TEST(Bicgstab, ThrowsOnRectangularMatrixInFactory)
+{
+    using Mtx = typename TestFixture::Mtx;
+    using Solver = typename TestFixture::Solver;
+    std::shared_ptr<Mtx> rectangular_mtx =
+        Mtx::create(this->exec, gko::dim<2>{1, 2});
+
+    ASSERT_THROW(this->bicgstab_factory->generate(rectangular_mtx),
+                 gko::DimensionMismatch);
+}
+
+
 TYPED_TEST(Bicgstab, CanSetPreconditioner)
 {
     using Solver = typename TestFixture::Solver;

--- a/core/test/solver/bicgstab.cpp
+++ b/core/test/solver/bicgstab.cpp
@@ -249,7 +249,7 @@ TYPED_TEST(Bicgstab, ThrowsOnWrongPreconditionerInFactory)
     using Mtx = typename TestFixture::Mtx;
     using Solver = typename TestFixture::Solver;
     std::shared_ptr<Mtx> wrong_sized_mtx =
-        Mtx::create(this->exec, gko::dim<2>{1, 3});
+        Mtx::create(this->exec, gko::dim<2>{2, 2});
     std::shared_ptr<Solver> bicgstab_precond =
         Solver::build()
             .with_criteria(

--- a/core/test/solver/cg.cpp
+++ b/core/test/solver/cg.cpp
@@ -256,7 +256,7 @@ TYPED_TEST(Cg, ThrowsOnWrongPreconditionerInFactory)
     using Mtx = typename TestFixture::Mtx;
     using Solver = typename TestFixture::Solver;
     std::shared_ptr<Mtx> wrong_sized_mtx =
-        Mtx::create(this->exec, gko::dim<2>{1, 3});
+        Mtx::create(this->exec, gko::dim<2>{2, 2});
     std::shared_ptr<Solver> cg_precond =
         Solver::build()
             .with_criteria(

--- a/core/test/solver/cg.cpp
+++ b/core/test/solver/cg.cpp
@@ -275,6 +275,18 @@ TYPED_TEST(Cg, ThrowsOnWrongPreconditionerInFactory)
 }
 
 
+TYPED_TEST(Cg, ThrowsOnRectangularMatrixInFactory)
+{
+    using Mtx = typename TestFixture::Mtx;
+    using Solver = typename TestFixture::Solver;
+    std::shared_ptr<Mtx> rectangular_mtx =
+        Mtx::create(this->exec, gko::dim<2>{1, 2});
+
+    ASSERT_THROW(this->cg_factory->generate(rectangular_mtx),
+                 gko::DimensionMismatch);
+}
+
+
 TYPED_TEST(Cg, CanSetPreconditioner)
 {
     using Solver = typename TestFixture::Solver;

--- a/core/test/solver/cgs.cpp
+++ b/core/test/solver/cgs.cpp
@@ -275,6 +275,18 @@ TYPED_TEST(Cgs, ThrowsOnWrongPreconditionerInFactory)
 }
 
 
+TYPED_TEST(Cgs, ThrowsOnRectangularMatrixInFactory)
+{
+    using Mtx = typename TestFixture::Mtx;
+    using Solver = typename TestFixture::Solver;
+    std::shared_ptr<Mtx> rectangular_mtx =
+        Mtx::create(this->exec, gko::dim<2>{1, 2});
+
+    ASSERT_THROW(this->cgs_factory->generate(rectangular_mtx),
+                 gko::DimensionMismatch);
+}
+
+
 TYPED_TEST(Cgs, CanSetPreconditioner)
 {
     using Solver = typename TestFixture::Solver;

--- a/core/test/solver/cgs.cpp
+++ b/core/test/solver/cgs.cpp
@@ -256,7 +256,7 @@ TYPED_TEST(Cgs, ThrowsOnWrongPreconditionerInFactory)
     using Mtx = typename TestFixture::Mtx;
     using Solver = typename TestFixture::Solver;
     std::shared_ptr<Mtx> wrong_sized_mtx =
-        Mtx::create(this->exec, gko::dim<2>{1, 3});
+        Mtx::create(this->exec, gko::dim<2>{2, 2});
     std::shared_ptr<Solver> cgs_precond =
         Solver::build()
             .with_criteria(

--- a/core/test/solver/fcg.cpp
+++ b/core/test/solver/fcg.cpp
@@ -241,7 +241,7 @@ TYPED_TEST(Fcg, ThrowsOnWrongPreconditionerInFactory)
     using Mtx = typename TestFixture::Mtx;
     using Solver = typename TestFixture::Solver;
     std::shared_ptr<Mtx> wrong_sized_mtx =
-        Mtx::create(this->exec, gko::dim<2>{1, 3});
+        Mtx::create(this->exec, gko::dim<2>{2, 2});
     std::shared_ptr<Solver> fcg_precond =
         Solver::build()
             .with_criteria(

--- a/core/test/solver/fcg.cpp
+++ b/core/test/solver/fcg.cpp
@@ -260,6 +260,18 @@ TYPED_TEST(Fcg, ThrowsOnWrongPreconditionerInFactory)
 }
 
 
+TYPED_TEST(Fcg, ThrowsOnRectangularMatrixInFactory)
+{
+    using Mtx = typename TestFixture::Mtx;
+    using Solver = typename TestFixture::Solver;
+    std::shared_ptr<Mtx> rectangular_mtx =
+        Mtx::create(this->exec, gko::dim<2>{1, 2});
+
+    ASSERT_THROW(this->fcg_factory->generate(rectangular_mtx),
+                 gko::DimensionMismatch);
+}
+
+
 TYPED_TEST(Fcg, CanSetPreconditioner)
 {
     using Solver = typename TestFixture::Solver;

--- a/core/test/solver/gmres.cpp
+++ b/core/test/solver/gmres.cpp
@@ -332,6 +332,18 @@ TYPED_TEST(Gmres, ThrowsOnWrongPreconditionerInFactory)
 }
 
 
+TYPED_TEST(Gmres, ThrowsOnRectangularMatrixInFactory)
+{
+    using Mtx = typename TestFixture::Mtx;
+    using Solver = typename TestFixture::Solver;
+    std::shared_ptr<Mtx> rectangular_mtx =
+        Mtx::create(this->exec, gko::dim<2>{1, 2});
+
+    ASSERT_THROW(this->gmres_factory->generate(rectangular_mtx),
+                 gko::DimensionMismatch);
+}
+
+
 TYPED_TEST(Gmres, CanSetPreconditioner)
 {
     using Solver = typename TestFixture::Solver;

--- a/core/test/solver/gmres.cpp
+++ b/core/test/solver/gmres.cpp
@@ -313,7 +313,7 @@ TYPED_TEST(Gmres, ThrowsOnWrongPreconditionerInFactory)
     using Mtx = typename TestFixture::Mtx;
     using Solver = typename TestFixture::Solver;
     std::shared_ptr<Mtx> wrong_sized_mtx =
-        Mtx::create(this->exec, gko::dim<2>{1, 3});
+        Mtx::create(this->exec, gko::dim<2>{2, 2});
     std::shared_ptr<Solver> gmres_precond =
         Solver::build()
             .with_criteria(

--- a/core/test/solver/ir.cpp
+++ b/core/test/solver/ir.cpp
@@ -252,7 +252,7 @@ TYPED_TEST(Ir, ThrowsOnWrongInnerSolverInFactory)
     using Mtx = typename TestFixture::Mtx;
     using Solver = typename TestFixture::Solver;
     std::shared_ptr<Mtx> wrong_sized_mtx =
-        Mtx::create(this->exec, gko::dim<2>{1, 3});
+        Mtx::create(this->exec, gko::dim<2>{2, 2});
     std::shared_ptr<Solver> ir_solver =
         Solver::build()
             .with_criteria(
@@ -300,7 +300,7 @@ TYPED_TEST(Ir, ThrowOnWrongInnerSolverSet)
     using Mtx = typename TestFixture::Mtx;
     using Solver = typename TestFixture::Solver;
     std::shared_ptr<Mtx> wrong_sized_mtx =
-        Mtx::create(this->exec, gko::dim<2>{1, 3});
+        Mtx::create(this->exec, gko::dim<2>{2, 2});
     std::shared_ptr<Solver> ir_solver =
         Solver::build()
             .with_criteria(

--- a/core/test/solver/ir.cpp
+++ b/core/test/solver/ir.cpp
@@ -319,6 +319,18 @@ TYPED_TEST(Ir, ThrowOnWrongInnerSolverSet)
 }
 
 
+TYPED_TEST(Ir, ThrowsOnRectangularMatrixInFactory)
+{
+    using Mtx = typename TestFixture::Mtx;
+    using Solver = typename TestFixture::Solver;
+    std::shared_ptr<Mtx> rectangular_mtx =
+        Mtx::create(this->exec, gko::dim<2>{1, 2});
+
+    ASSERT_THROW(this->ir_factory->generate(rectangular_mtx),
+                 gko::DimensionMismatch);
+}
+
+
 TYPED_TEST(Ir, DefaultRelaxationFactor)
 {
     using value_type = typename TestFixture::value_type;

--- a/core/test/solver/lower_trs.cpp
+++ b/core/test/solver/lower_trs.cpp
@@ -75,4 +75,15 @@ TYPED_TEST(LowerTrs, LowerTrsFactoryKnowsItsExecutor)
 }
 
 
+TYPED_TEST(LowerTrs, ThrowsOnRectangularMatrixInFactory)
+{
+    using Mtx = gko::matrix::Dense<typename TestFixture::value_type>;
+    std::shared_ptr<Mtx> rectangular_matrix =
+        Mtx::create(this->exec, gko::dim<2>{1, 2});
+
+    ASSERT_THROW(this->lower_trs_factory->generate(rectangular_matrix),
+                 gko::DimensionMismatch);
+}
+
+
 }  // namespace

--- a/core/test/solver/upper_trs.cpp
+++ b/core/test/solver/upper_trs.cpp
@@ -75,4 +75,15 @@ TYPED_TEST(UpperTrs, UpperTrsFactoryKnowsItsExecutor)
 }
 
 
+TYPED_TEST(UpperTrs, ThrowsOnRectangularMatrixInFactory)
+{
+    using Mtx = gko::matrix::Dense<typename TestFixture::value_type>;
+    std::shared_ptr<Mtx> rectangular_matrix =
+        Mtx::create(this->exec, gko::dim<2>{1, 2});
+
+    ASSERT_THROW(this->upper_trs_factory->generate(rectangular_matrix),
+                 gko::DimensionMismatch);
+}
+
+
 }  // namespace

--- a/include/ginkgo/core/matrix/identity.hpp
+++ b/include/ginkgo/core/matrix/identity.hpp
@@ -91,6 +91,17 @@ protected:
     /**
      * Creates an Identity matrix of the specified size.
      *
+     * @param size  size of the matrix (must be square)
+     */
+    Identity(std::shared_ptr<const Executor> exec, dim<2> size)
+        : EnableLinOp<Identity>(exec, size)
+    {
+        GKO_ASSERT_IS_SQUARE_MATRIX(this);
+    }
+
+    /**
+     * Creates an Identity matrix of the specified size.
+     *
      * @param size  size of the matrix
      */
     Identity(std::shared_ptr<const Executor> exec, size_type size)

--- a/include/ginkgo/core/solver/bicg.hpp
+++ b/include/ginkgo/core/solver/bicg.hpp
@@ -171,7 +171,7 @@ protected:
                 parameters_.preconditioner->generate(system_matrix_));
         } else {
             set_preconditioner(matrix::Identity<ValueType>::create(
-                this->get_executor(), this->get_size()[0]));
+                this->get_executor(), this->get_size()));
         }
         stop_criterion_factory_ =
             stop::combine(std::move(parameters_.criteria));

--- a/include/ginkgo/core/solver/bicg.hpp
+++ b/include/ginkgo/core/solver/bicg.hpp
@@ -162,6 +162,7 @@ protected:
           parameters_{factory->get_parameters()},
           system_matrix_{std::move(system_matrix)}
     {
+        GKO_ASSERT_IS_SQUARE_MATRIX(system_matrix_);
         if (parameters_.generated_preconditioner) {
             GKO_ASSERT_EQUAL_DIMENSIONS(parameters_.generated_preconditioner,
                                         this);

--- a/include/ginkgo/core/solver/bicgstab.hpp
+++ b/include/ginkgo/core/solver/bicgstab.hpp
@@ -167,6 +167,7 @@ protected:
           parameters_{factory->get_parameters()},
           system_matrix_{std::move(system_matrix)}
     {
+        GKO_ASSERT_IS_SQUARE_MATRIX(system_matrix_);
         if (parameters_.generated_preconditioner) {
             GKO_ASSERT_EQUAL_DIMENSIONS(parameters_.generated_preconditioner,
                                         this);

--- a/include/ginkgo/core/solver/bicgstab.hpp
+++ b/include/ginkgo/core/solver/bicgstab.hpp
@@ -176,7 +176,7 @@ protected:
                 parameters_.preconditioner->generate(system_matrix_));
         } else {
             set_preconditioner(matrix::Identity<ValueType>::create(
-                this->get_executor(), this->get_size()[0]));
+                this->get_executor(), this->get_size()));
         }
         stop_criterion_factory_ =
             stop::combine(std::move(parameters_.criteria));

--- a/include/ginkgo/core/solver/cg.hpp
+++ b/include/ginkgo/core/solver/cg.hpp
@@ -172,7 +172,7 @@ protected:
                 parameters_.preconditioner->generate(system_matrix_));
         } else {
             set_preconditioner(matrix::Identity<ValueType>::create(
-                this->get_executor(), this->get_size()[0]));
+                this->get_executor(), this->get_size()));
         }
         stop_criterion_factory_ =
             stop::combine(std::move(parameters_.criteria));

--- a/include/ginkgo/core/solver/cg.hpp
+++ b/include/ginkgo/core/solver/cg.hpp
@@ -163,6 +163,7 @@ protected:
           parameters_{factory->get_parameters()},
           system_matrix_{std::move(system_matrix)}
     {
+        GKO_ASSERT_IS_SQUARE_MATRIX(system_matrix_);
         if (parameters_.generated_preconditioner) {
             GKO_ASSERT_EQUAL_DIMENSIONS(parameters_.generated_preconditioner,
                                         this);

--- a/include/ginkgo/core/solver/cgs.hpp
+++ b/include/ginkgo/core/solver/cgs.hpp
@@ -160,6 +160,7 @@ protected:
           parameters_{factory->get_parameters()},
           system_matrix_{std::move(system_matrix)}
     {
+        GKO_ASSERT_IS_SQUARE_MATRIX(system_matrix_);
         if (parameters_.generated_preconditioner) {
             GKO_ASSERT_EQUAL_DIMENSIONS(parameters_.generated_preconditioner,
                                         this);

--- a/include/ginkgo/core/solver/cgs.hpp
+++ b/include/ginkgo/core/solver/cgs.hpp
@@ -169,7 +169,7 @@ protected:
                 parameters_.preconditioner->generate(system_matrix_));
         } else {
             set_preconditioner(matrix::Identity<ValueType>::create(
-                this->get_executor(), this->get_size()[0]));
+                this->get_executor(), this->get_size()));
         }
         stop_criterion_factory_ =
             stop::combine(std::move(parameters_.criteria));

--- a/include/ginkgo/core/solver/fcg.hpp
+++ b/include/ginkgo/core/solver/fcg.hpp
@@ -177,7 +177,7 @@ protected:
                 parameters_.preconditioner->generate(system_matrix_));
         } else {
             set_preconditioner(matrix::Identity<ValueType>::create(
-                this->get_executor(), this->get_size()[0]));
+                this->get_executor(), this->get_size()));
         }
         stop_criterion_factory_ =
             stop::combine(std::move(parameters_.criteria));

--- a/include/ginkgo/core/solver/fcg.hpp
+++ b/include/ginkgo/core/solver/fcg.hpp
@@ -168,6 +168,7 @@ protected:
           parameters_{factory->get_parameters()},
           system_matrix_{std::move(system_matrix)}
     {
+        GKO_ASSERT_IS_SQUARE_MATRIX(system_matrix_);
         if (parameters_.generated_preconditioner) {
             GKO_ASSERT_EQUAL_DIMENSIONS(parameters_.generated_preconditioner,
                                         this);

--- a/include/ginkgo/core/solver/gmres.hpp
+++ b/include/ginkgo/core/solver/gmres.hpp
@@ -182,6 +182,7 @@ protected:
           parameters_{factory->get_parameters()},
           system_matrix_{std::move(system_matrix)}
     {
+        GKO_ASSERT_IS_SQUARE_MATRIX(system_matrix_);
         if (parameters_.generated_preconditioner) {
             GKO_ASSERT_EQUAL_DIMENSIONS(parameters_.generated_preconditioner,
                                         this);

--- a/include/ginkgo/core/solver/gmres.hpp
+++ b/include/ginkgo/core/solver/gmres.hpp
@@ -191,7 +191,7 @@ protected:
                 parameters_.preconditioner->generate(system_matrix_));
         } else {
             set_preconditioner(matrix::Identity<ValueType>::create(
-                this->get_executor(), this->get_size()[0]));
+                this->get_executor(), this->get_size()));
         }
         if (parameters_.krylov_dim) {
             krylov_dim_ = parameters_.krylov_dim;

--- a/include/ginkgo/core/solver/ir.hpp
+++ b/include/ginkgo/core/solver/ir.hpp
@@ -226,7 +226,7 @@ protected:
             solver_ = parameters_.solver->generate(system_matrix_);
         } else {
             solver_ = matrix::Identity<ValueType>::create(this->get_executor(),
-                                                          this->get_size()[0]);
+                                                          this->get_size());
         }
         relaxation_factor_ = gko::initialize<matrix::Dense<ValueType>>(
             {parameters_.relaxation_factor}, this->get_executor());

--- a/include/ginkgo/core/solver/ir.hpp
+++ b/include/ginkgo/core/solver/ir.hpp
@@ -219,6 +219,7 @@ protected:
           parameters_{factory->get_parameters()},
           system_matrix_{std::move(system_matrix)}
     {
+        GKO_ASSERT_IS_SQUARE_MATRIX(system_matrix_);
         if (parameters_.generated_solver) {
             solver_ = parameters_.generated_solver;
             GKO_ASSERT_EQUAL_DIMENSIONS(solver_, this);


### PR DESCRIPTION
This PR adds a gko::dim<2> constructor for Identity and adds checks for square matrices into all solver constructors, which avoids opaque errors from within Solver::apply_impl by failing early.

Fixes #645 