### PR TITLE
fix omp local header and reorder_factory

### DIFF
--- a/include/ginkgo/core/reorder/reordering_base.hpp
+++ b/include/ginkgo/core/reorder/reordering_base.hpp
@@ -144,9 +144,17 @@ public:                                                                        \
             _factory_name, ::gko::reorder::ReorderingBaseFactory>;             \
         friend class ::gko::enable_parameters_type<_parameters_name##_type,    \
                                                    _factory_name>;             \
-        using ::gko::reorder::EnableDefaultReorderingBaseFactory<              \
-            _factory_name, _reordering_base,                                   \
-            _parameters_name##_type>::EnableDefaultReorderingBaseFactory;      \
+        explicit _factory_name(std::shared_ptr<const ::gko::Executor> exec)    \
+            : ::gko::reorder::EnableDefaultReorderingBaseFactory<              \
+                  _factory_name, _reordering_base, _parameters_name##_type>(   \
+                  std::move(exec))                                             \
+        {}                                                                     \
+        explicit _factory_name(std::shared_ptr<const ::gko::Executor> exec,    \
+                               const _parameters_name##_type &parameters)      \
+            : ::gko::reorder::EnableDefaultReorderingBaseFactory<              \
+                  _factory_name, _reordering_base, _parameters_name##_type>(   \
+                  std::move(exec), parameters)                                 \
+        {}                                                                     \
     };                                                                         \
     friend ::gko::reorder::EnableDefaultReorderingBaseFactory<                 \
         _factory_name, _reordering_base, _parameters_name##_type>;             \

--- a/omp/reorder/rcm_kernels.cpp
+++ b/omp/reorder/rcm_kernels.cpp
@@ -54,10 +54,10 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <ginkgo/core/matrix/sparsity_csr.hpp>
 
 
-#include "components/omp_mutex.hpp"
-#include "components/sort_small.hpp"
 #include "core/base/allocator.hpp"
 #include "core/components/prefix_sum.hpp"
+#include "omp/components/omp_mutex.hpp"
+#include "omp/components/sort_small.hpp"
 
 
 namespace gko {


### PR DESCRIPTION
This PR fixes the compile issue in Windows and MacOS
1. can not find the local header in MacOS
2. error inheriting constructors must be inherited from a direct base class in Windows (only cuda)