### PR TITLE
Make gko::dim conversion to bool explicit

### DIFF
--- a/include/ginkgo/core/base/dim.hpp
+++ b/include/ginkgo/core/base/dim.hpp
@@ -118,8 +118,11 @@ struct dim {
      * different than zero.
      *
      * @return true if and only if all dimensions evaluate to true
+     *
+     * @note This operator is explicit to avoid implicit dim-to-int casts.
+     *       It will still be used in contextual conversions (if, &&, ||, !)
      */
-    constexpr GKO_ATTRIBUTES operator bool() const
+    explicit constexpr GKO_ATTRIBUTES operator bool() const
     {
         return static_cast<bool>(first_) && static_cast<bool>(rest_);
     }
@@ -183,7 +186,7 @@ struct dim<1u, DimensionType> {
         return GKO_ASSERT(dimension == 0), first_;
     }
 
-    constexpr GKO_ATTRIBUTES operator bool() const
+    explicit constexpr GKO_ATTRIBUTES operator bool() const
     {
         return static_cast<bool>(first_);
     }


### PR DESCRIPTION
Follow up to #646:

Currently, gko::dim is implicitly convertible to bool. We could avoid the gko::dim -> bool -> int conversion chain by making `operator bool` explicit. C++ allows for so-called contextual conversions to also use explicit conversion operators.
`<expression>` is contextually converted to bool in the following cases:

1. `if(<expression>), while(<expression>), for(...;`<expression>; ...)`
2. `!<expression>, ... && <expression>, || <expression>`
3. `<expression> ? ... : ...`
3. `static_assert/noexcept(<expression>)`

So these are all places where gko::dim is used directly as a boolean. Any other use looks to me like a bug waiting to happen. In this sense:
![Is this interface-breaking?](https://user-images.githubusercontent.com/1693511/96260911-f8aa1b80-0fbf-11eb-8799-23de0cd25e55.png)