### PR TITLE
Add a memory space abstraction

### DIFF
--- a/benchmark/utils/loggers.hpp
+++ b/benchmark/utils/loggers.hpp
@@ -48,41 +48,43 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 // A logger that accumulates the time of all operations
 struct OperationLogger : gko::log::Logger {
-    void on_allocation_started(const gko::Executor *exec,
+    void on_allocation_started(const gko::MemorySpace *mem_space,
                                const gko::size_type &) const override
     {
-        this->start_operation(exec, "allocate");
+        this->start_operation(mem_space, "allocate");
     }
 
-    void on_allocation_completed(const gko::Executor *exec,
+    void on_allocation_completed(const gko::MemorySpace *mem_space,
                                  const gko::size_type &,
                                  const gko::uintptr &) const override
     {
-        this->end_operation(exec, "allocate");
+        this->end_operation(mem_space, "allocate");
     }
 
-    void on_free_started(const gko::Executor *exec,
+    void on_free_started(const gko::MemorySpace *mem_space,
                          const gko::uintptr &) const override
     {
-        this->start_operation(exec, "free");
+        this->start_operation(mem_space, "free");
     }
 
-    void on_free_completed(const gko::Executor *exec,
+    void on_free_completed(const gko::MemorySpace *mem_space,
                            const gko::uintptr &) const override
     {
-        this->end_operation(exec, "free");
+        this->end_operation(mem_space, "free");
     }
 
-    void on_copy_started(const gko::Executor *from, const gko::Executor *to,
-                         const gko::uintptr &, const gko::uintptr &,
+    void on_copy_started(const gko::MemorySpace *from,
+                         const gko::MemorySpace *to, const gko::uintptr &,
+                         const gko::uintptr &,
                          const gko::size_type &) const override
     {
         from->synchronize();
         this->start_operation(to, "copy");
     }
 
-    void on_copy_completed(const gko::Executor *from, const gko::Executor *to,
-                           const gko::uintptr &, const gko::uintptr &,
+    void on_copy_completed(const gko::MemorySpace *from,
+                           const gko::MemorySpace *to, const gko::uintptr &,
+                           const gko::uintptr &,
                            const gko::size_type &) const override
     {
         from->synchronize();
@@ -118,14 +120,15 @@ struct OperationLogger : gko::log::Logger {
     }
 
     OperationLogger(std::shared_ptr<const gko::Executor> exec, bool nested_name)
-        : gko::log::Logger(exec), use_nested_name{nested_name}
+        : gko::log::Logger(exec, exec->get_mem_space()),
+          use_nested_name{nested_name}
     {}
 
 private:
-    void start_operation(const gko::Executor *exec,
-                         const std::string &name) const
+    template <typename LogObject>
+    void start_operation(const LogObject *obj, const std::string &name) const
     {
-        exec->synchronize();
+        obj->synchronize();
         const std::lock_guard<std::mutex> lock(mutex);
         auto nested_name = nested.empty() || !use_nested_name
                                ? name
@@ -134,9 +137,12 @@ private:
         start[nested_name] = std::chrono::steady_clock::now();
     }
 
-    void end_operation(const gko::Executor *exec, const std::string &name) const
+    // Helper to compute the end time and store the operation's time at its
+    // end. Also time nested operations.
+    template <typename LogObject>
+    void end_operation(const LogObject *obj, const std::string &name) const
     {
-        exec->synchronize();
+        obj->synchronize();
         const std::lock_guard<std::mutex> lock(mutex);
         // if operations are properly nested, nested_name now ends with name
         auto nested_name = nested.back().first;
@@ -163,7 +169,7 @@ private:
 
 
 struct StorageLogger : gko::log::Logger {
-    void on_allocation_completed(const gko::Executor *,
+    void on_allocation_completed(const gko::MemorySpace *,
                                  const gko::size_type &num_bytes,
                                  const gko::uintptr &location) const override
     {
@@ -171,7 +177,7 @@ struct StorageLogger : gko::log::Logger {
         storage[location] = num_bytes;
     }
 
-    void on_free_completed(const gko::Executor *,
+    void on_free_completed(const gko::MemorySpace *,
                            const gko::uintptr &location) const override
     {
         const std::lock_guard<std::mutex> lock(mutex);
@@ -190,7 +196,7 @@ struct StorageLogger : gko::log::Logger {
     }
 
     StorageLogger(std::shared_ptr<const gko::Executor> exec)
-        : gko::log::Logger(exec)
+        : gko::log::Logger(exec, exec->get_mem_space())
     {}
 
 private:
@@ -235,7 +241,8 @@ struct ResidualLogger : gko::log::Logger {
                    rapidjson::Value &true_res_norms,
                    rapidjson::Value &timestamps,
                    rapidjson::MemoryPoolAllocator<> &alloc)
-        : gko::log::Logger(exec, gko::log::Logger::iteration_complete_mask),
+        : gko::log::Logger(exec, exec->get_mem_space(),
+                           gko::log::Logger::iteration_complete_mask),
           matrix{matrix},
           b{b},
           start{std::chrono::steady_clock::now()},
@@ -267,7 +274,8 @@ struct IterationLogger : gko::log::Logger {
     }
 
     IterationLogger(std::shared_ptr<const gko::Executor> exec)
-        : gko::log::Logger(exec, gko::log::Logger::iteration_complete_mask)
+        : gko::log::Logger(exec, exec->get_mem_space(),
+                           gko::log::Logger::iteration_complete_mask)
     {}
 
     void write_data(rapidjson::Value &output,

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -8,6 +8,7 @@ target_sources(ginkgo
     base/combination.cpp
     base/composition.cpp
     base/executor.cpp
+    base/memory_space.cpp
     base/mtx_io.cpp
     base/perturbation.cpp
     base/version.cpp

--- a/core/base/allocator.hpp
+++ b/core/base/allocator.hpp
@@ -101,7 +101,7 @@ public:
      */
     T *allocate(std::size_t n) const
     {
-        return exec_->get_mem_space()->alloc<T>(n);
+        return exec_->get_mem_space()->template alloc<T>(n);
     }
 
     /**

--- a/core/base/allocator.hpp
+++ b/core/base/allocator.hpp
@@ -99,7 +99,10 @@ public:
      * @param n  the number of elements to allocate
      * @return  the pointer to a newly allocated memory area of `n` elements.
      */
-    T *allocate(std::size_t n) const { return exec_->alloc<T>(n); }
+    T *allocate(std::size_t n) const
+    {
+        return exec_->get_mem_space()->alloc<T>(n);
+    }
 
     /**
      * Frees a memory area that was allocated by this allocator.
@@ -108,7 +111,10 @@ public:
      *
      * @note  The second parameter is unused.
      */
-    void deallocate(T *ptr, std::size_t) const { exec_->free(ptr); }
+    void deallocate(T *ptr, std::size_t) const
+    {
+        exec_->get_mem_space()->free(ptr);
+    }
 
     /**
      * Compares two ExecutorAllocators for equality

--- a/core/base/memory_space.cpp
+++ b/core/base/memory_space.cpp
@@ -30,38 +30,40 @@ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ******************************<GINKGO LICENSE>*******************************/
 
-#include <ginkgo/core/base/executor.hpp>
 #include <ginkgo/core/base/memory_space.hpp>
+
+
+#include <cstdlib>
+#include <cstring>
+
+
+#include <ginkgo/core/base/exception.hpp>
+#include <ginkgo/core/base/exception_helpers.hpp>
 
 
 namespace gko {
 
 
-std::shared_ptr<Executor> HipExecutor::get_master() noexcept { return master_; }
+void HostMemorySpace::raw_free(void *ptr) const noexcept { std::free(ptr); }
 
 
-std::shared_ptr<const Executor> HipExecutor::get_master() const noexcept
+void HostMemorySpace::synchronize() const
 {
-    return master_;
+    // Currently a no-op
 }
 
 
-std::shared_ptr<MemorySpace> HipExecutor::get_mem_space() noexcept
+void *HostMemorySpace::raw_alloc(size_type num_bytes) const
 {
-    return this->mem_space_instance_;
+    return GKO_ENSURE_ALLOCATED(std::malloc(num_bytes), "Host", num_bytes);
 }
 
 
-std::shared_ptr<const MemorySpace> HipExecutor::get_mem_space() const noexcept
+void HostMemorySpace::raw_copy_to(const HostMemorySpace *, size_type num_bytes,
+                                  const void *src_ptr, void *dest_ptr) const
 {
-    return this->mem_space_instance_;
+    std::memcpy(dest_ptr, src_ptr, num_bytes);
 }
-
-
-int HipExecutor::num_execs[max_devices];
-
-
-std::mutex HipExecutor::mutex[max_devices];
 
 
 }  // namespace gko

--- a/core/device_hooks/cuda_hooks.cpp
+++ b/core/device_hooks/cuda_hooks.cpp
@@ -67,9 +67,8 @@ std::shared_ptr<CudaExecutor> CudaExecutor::create(
     int device_id, std::shared_ptr<MemorySpace> mem_space,
     std::shared_ptr<Executor> master, bool device_reset)
 {
-    return std::shared_ptr<CudaExecutor>(
-        new CudaExecutor(device_id, mem_space, std::move(master)),
-        device_reset);
+    return std::shared_ptr<CudaExecutor>(new CudaExecutor(
+        device_id, mem_space, std::move(master), device_reset));
 }
 
 
@@ -150,6 +149,12 @@ void CudaUVMSpace::raw_copy_to(const HostMemorySpace *dest_mem_space,
 void CudaExecutor::synchronize() const GKO_NOT_COMPILED(cuda);
 
 
+void CudaMemorySpace::synchronize() const GKO_NOT_COMPILED(cuda);
+
+
+void CudaUVMSpace::synchronize() const GKO_NOT_COMPILED(cuda);
+
+
 void CudaExecutor::run(const Operation &op) const
 {
     op.run(
@@ -176,6 +181,12 @@ std::string CusparseError::get_error(int64)
 
 
 int CudaExecutor::get_num_devices() { return 0; }
+
+
+int CudaMemorySpace::get_num_devices() { return 0; }
+
+
+int CudaUVMSpace::get_num_devices() { return 0; }
 
 
 void CudaExecutor::set_gpu_property() {}

--- a/core/device_hooks/hip_hooks.cpp
+++ b/core/device_hooks/hip_hooks.cpp
@@ -36,6 +36,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <ginkgo/core/base/exception_helpers.hpp>
 #include <ginkgo/core/base/executor.hpp>
+#include <ginkgo/core/base/memory_space.hpp>
 #include <ginkgo/core/base/types.hpp>
 #include <ginkgo/core/base/version.hpp>
 
@@ -59,12 +60,21 @@ std::shared_ptr<HipExecutor> HipExecutor::create(
 }
 
 
-void OmpExecutor::raw_copy_to(const HipExecutor *, size_type num_bytes,
-                              const void *src_ptr, void *dest_ptr) const
+std::shared_ptr<HipExecutor> HipExecutor::create(
+    int device_id, std::shared_ptr<MemorySpace> memory_space,
+    std::shared_ptr<Executor> master, bool device_reset)
+{
+    return std::shared_ptr<HipExecutor>(
+        new HipExecutor(device_id, memory_space, std::move(master)),
+        device_reset);
+}
+
+void HostMemorySpace::raw_copy_to(const HipMemorySpace *, size_type num_bytes,
+                                  const void *src_ptr, void *dest_ptr) const
     GKO_NOT_COMPILED(hip);
 
 
-void HipExecutor::raw_free(void *ptr) const noexcept
+void HipMemorySpace::raw_free(void *ptr) const noexcept
 {
     // Free must never fail, as it can be called in destructors.
     // If the nvidia module was not compiled, the library couldn't have
@@ -72,21 +82,27 @@ void HipExecutor::raw_free(void *ptr) const noexcept
 }
 
 
-void *HipExecutor::raw_alloc(size_type num_bytes) const GKO_NOT_COMPILED(hip);
-
-
-void HipExecutor::raw_copy_to(const OmpExecutor *, size_type num_bytes,
-                              const void *src_ptr, void *dest_ptr) const
+void *HipMemorySpace::raw_alloc(size_type num_bytes) const
     GKO_NOT_COMPILED(hip);
 
 
-void HipExecutor::raw_copy_to(const CudaExecutor *, size_type num_bytes,
-                              const void *src_ptr, void *dest_ptr) const
+void HipMemorySpace::raw_copy_to(const HostMemorySpace *, size_type num_bytes,
+                                 const void *src_ptr, void *dest_ptr) const
     GKO_NOT_COMPILED(hip);
 
 
-void HipExecutor::raw_copy_to(const HipExecutor *, size_type num_bytes,
-                              const void *src_ptr, void *dest_ptr) const
+void HipMemorySpace::raw_copy_to(const CudaMemorySpace *, size_type num_bytes,
+                                 const void *src_ptr, void *dest_ptr) const
+    GKO_NOT_COMPILED(hip);
+
+
+void HipMemorySpace::raw_copy_to(const CudaUVMSpace *, size_type num_bytes,
+                                 const void *src_ptr, void *dest_ptr) const
+    GKO_NOT_COMPILED(hip);
+
+
+void HipMemorySpace::raw_copy_to(const HipMemorySpace *, size_type num_bytes,
+                                 const void *src_ptr, void *dest_ptr) const
     GKO_NOT_COMPILED(hip);
 
 

--- a/core/device_hooks/hip_hooks.cpp
+++ b/core/device_hooks/hip_hooks.cpp
@@ -64,9 +64,8 @@ std::shared_ptr<HipExecutor> HipExecutor::create(
     int device_id, std::shared_ptr<MemorySpace> memory_space,
     std::shared_ptr<Executor> master, bool device_reset)
 {
-    return std::shared_ptr<HipExecutor>(
-        new HipExecutor(device_id, memory_space, std::move(master)),
-        device_reset);
+    return std::shared_ptr<HipExecutor>(new HipExecutor(
+        device_id, memory_space, std::move(master), device_reset));
 }
 
 void HostMemorySpace::raw_copy_to(const HipMemorySpace *, size_type num_bytes,
@@ -109,6 +108,9 @@ void HipMemorySpace::raw_copy_to(const HipMemorySpace *, size_type num_bytes,
 void HipExecutor::synchronize() const GKO_NOT_COMPILED(hip);
 
 
+void HipMemorySpace::synchronize() const GKO_NOT_COMPILED(hip);
+
+
 void HipExecutor::run(const Operation &op) const
 {
     op.run(
@@ -135,6 +137,9 @@ std::string HipsparseError::get_error(int64)
 
 
 int HipExecutor::get_num_devices() { return 0; }
+
+
+int HipMemorySpace::get_num_devices() { return 0; }
 
 
 void HipExecutor::set_gpu_property() {}

--- a/core/devices/cuda/executor.cpp
+++ b/core/devices/cuda/executor.cpp
@@ -31,6 +31,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ******************************<GINKGO LICENSE>*******************************/
 
 #include <ginkgo/core/base/executor.hpp>
+#include <ginkgo/core/base/memory_space.hpp>
 
 
 namespace gko {
@@ -45,6 +46,18 @@ std::shared_ptr<Executor> CudaExecutor::get_master() noexcept
 std::shared_ptr<const Executor> CudaExecutor::get_master() const noexcept
 {
     return master_;
+}
+
+
+std::shared_ptr<MemorySpace> CudaExecutor::get_mem_space() noexcept
+{
+    return this->mem_space_instance_;
+}
+
+
+std::shared_ptr<const MemorySpace> CudaExecutor::get_mem_space() const noexcept
+{
+    return this->mem_space_instance_;
 }
 
 

--- a/core/devices/omp/executor.cpp
+++ b/core/devices/omp/executor.cpp
@@ -31,6 +31,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ******************************<GINKGO LICENSE>*******************************/
 
 #include <ginkgo/core/base/executor.hpp>
+#include <ginkgo/core/base/memory_space.hpp>
 
 
 #include <cstdlib>
@@ -42,9 +43,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
 namespace gko {
-
-
-void OmpExecutor::raw_free(void *ptr) const noexcept { std::free(ptr); }
 
 
 std::shared_ptr<Executor> OmpExecutor::get_master() noexcept
@@ -59,18 +57,15 @@ std::shared_ptr<const Executor> OmpExecutor::get_master() const noexcept
 }
 
 
-void *OmpExecutor::raw_alloc(size_type num_bytes) const
+std::shared_ptr<MemorySpace> OmpExecutor::get_mem_space() noexcept
 {
-    return GKO_ENSURE_ALLOCATED(std::malloc(num_bytes), "OMP", num_bytes);
+    return this->mem_space_instance_;
 }
 
 
-void OmpExecutor::raw_copy_to(const OmpExecutor *, size_type num_bytes,
-                              const void *src_ptr, void *dest_ptr) const
+std::shared_ptr<const MemorySpace> OmpExecutor::get_mem_space() const noexcept
 {
-    if (num_bytes > 0) {
-        std::memcpy(dest_ptr, src_ptr, num_bytes);
-    }
+    return this->mem_space_instance_;
 }
 
 

--- a/core/log/logger.cpp
+++ b/core/log/logger.cpp
@@ -38,7 +38,7 @@ namespace log {
 
 
 constexpr Logger::mask_type Logger::all_events_mask;
-constexpr Logger::mask_type Logger::executor_events_mask;
+constexpr Logger::mask_type Logger::memory_space_events_mask;
 constexpr Logger::mask_type Logger::operation_events_mask;
 constexpr Logger::mask_type Logger::polymorphic_object_events_mask;
 constexpr Logger::mask_type Logger::linop_events_mask;

--- a/core/log/papi.cpp
+++ b/core/log/papi.cpp
@@ -42,40 +42,41 @@ namespace log {
 
 
 template <typename ValueType>
-void Papi<ValueType>::on_allocation_started(const Executor *exec,
+void Papi<ValueType>::on_allocation_started(const MemorySpace *mem_space,
                                             const size_type &num_bytes) const
 {
-    allocation_started.get_counter(exec) += num_bytes;
+    allocation_started.get_counter(mem_space) += num_bytes;
 }
 
 
 template <typename ValueType>
-void Papi<ValueType>::on_allocation_completed(const Executor *exec,
+void Papi<ValueType>::on_allocation_completed(const MemorySpace *mem_space,
                                               const size_type &num_bytes,
                                               const uintptr &location) const
 {
-    allocation_completed.get_counter(exec) += num_bytes;
+    allocation_completed.get_counter(mem_space) += num_bytes;
 }
 
 
 template <typename ValueType>
-void Papi<ValueType>::on_free_started(const Executor *exec,
+void Papi<ValueType>::on_free_started(const MemorySpace *mem_space,
                                       const uintptr &location) const
 {
-    free_started.get_counter(exec) += 1;
+    free_started.get_counter(mem_space) += 1;
 }
 
 
 template <typename ValueType>
-void Papi<ValueType>::on_free_completed(const Executor *exec,
+void Papi<ValueType>::on_free_completed(const MemorySpace *mem_space,
                                         const uintptr &location) const
 {
-    free_completed.get_counter(exec) += 1;
+    free_completed.get_counter(mem_space) += 1;
 }
 
 
 template <typename ValueType>
-void Papi<ValueType>::on_copy_started(const Executor *from, const Executor *to,
+void Papi<ValueType>::on_copy_started(const MemorySpace *from,
+                                      const MemorySpace *to,
                                       const uintptr &location_from,
                                       const uintptr &location_to,
                                       const size_type &num_bytes) const
@@ -86,8 +87,8 @@ void Papi<ValueType>::on_copy_started(const Executor *from, const Executor *to,
 
 
 template <typename ValueType>
-void Papi<ValueType>::on_copy_completed(const Executor *from,
-                                        const Executor *to,
+void Papi<ValueType>::on_copy_completed(const MemorySpace *from,
+                                        const MemorySpace *to,
                                         const uintptr &location_from,
                                         const uintptr &location_to,
                                         const size_type &num_bytes) const

--- a/core/log/record.cpp
+++ b/core/log/record.cpp
@@ -42,49 +42,49 @@ namespace gko {
 namespace log {
 
 
-void Record::on_allocation_started(const Executor *exec,
+void Record::on_allocation_started(const MemorySpace *mem_space,
                                    const size_type &num_bytes) const
 {
     append_deque(data_.allocation_started,
-                 (std::unique_ptr<executor_data>(
-                     new executor_data{exec, num_bytes, 0})));
+                 (std::unique_ptr<memory_space_data>(
+                     new memory_space_data{mem_space, num_bytes, 0})));
 }
 
 
-void Record::on_allocation_completed(const Executor *exec,
+void Record::on_allocation_completed(const MemorySpace *mem_space,
                                      const size_type &num_bytes,
                                      const uintptr &location) const
 {
     append_deque(data_.allocation_completed,
-                 (std::unique_ptr<executor_data>(
-                     new executor_data{exec, num_bytes, location})));
+                 (std::unique_ptr<memory_space_data>(
+                     new memory_space_data{mem_space, num_bytes, location})));
 }
 
 
-void Record::on_free_started(const Executor *exec,
+void Record::on_free_started(const MemorySpace *mem_space,
                              const uintptr &location) const
 {
-    append_deque(
-        data_.free_started,
-        (std::unique_ptr<executor_data>(new executor_data{exec, 0, location})));
+    append_deque(data_.free_started,
+                 (std::unique_ptr<memory_space_data>(
+                     new memory_space_data{mem_space, 0, location})));
 }
 
 
-void Record::on_free_completed(const Executor *exec,
+void Record::on_free_completed(const MemorySpace *mem_space,
                                const uintptr &location) const
 {
-    append_deque(
-        data_.free_completed,
-        (std::unique_ptr<executor_data>(new executor_data{exec, 0, location})));
+    append_deque(data_.free_completed,
+                 (std::unique_ptr<memory_space_data>(
+                     new memory_space_data{mem_space, 0, location})));
 }
 
 
-void Record::on_copy_started(const Executor *from, const Executor *to,
+void Record::on_copy_started(const MemorySpace *from, const MemorySpace *to,
                              const uintptr &location_from,
                              const uintptr &location_to,
                              const size_type &num_bytes) const
 {
-    using tuple = std::tuple<executor_data, executor_data>;
+    using tuple = std::tuple<memory_space_data, memory_space_data>;
     append_deque(
         data_.copy_started,
         (std::unique_ptr<tuple>(new tuple{{from, num_bytes, location_from},
@@ -92,12 +92,12 @@ void Record::on_copy_started(const Executor *from, const Executor *to,
 }
 
 
-void Record::on_copy_completed(const Executor *from, const Executor *to,
+void Record::on_copy_completed(const MemorySpace *from, const MemorySpace *to,
                                const uintptr &location_from,
                                const uintptr &location_to,
                                const size_type &num_bytes) const
 {
-    using tuple = std::tuple<executor_data, executor_data>;
+    using tuple = std::tuple<memory_space_data, memory_space_data>;
     append_deque(
         data_.copy_completed,
         (std::unique_ptr<tuple>(new tuple{{from, num_bytes, location_from},

--- a/core/log/stream.cpp
+++ b/core/log/stream.cpp
@@ -116,6 +116,7 @@ GKO_ENABLE_DEMANGLE_NAME(LinOp);
 GKO_ENABLE_DEMANGLE_NAME(LinOpFactory);
 GKO_ENABLE_DEMANGLE_NAME(stop::Criterion);
 GKO_ENABLE_DEMANGLE_NAME(Executor);
+GKO_ENABLE_DEMANGLE_NAME(MemorySpace);
 GKO_ENABLE_DEMANGLE_NAME(Operation);
 
 
@@ -123,46 +124,46 @@ GKO_ENABLE_DEMANGLE_NAME(Operation);
 
 
 template <typename ValueType>
-void Stream<ValueType>::on_allocation_started(const Executor *exec,
+void Stream<ValueType>::on_allocation_started(const MemorySpace *mem_space,
                                               const size_type &num_bytes) const
 {
-    os_ << prefix_ << "allocation started on " << demangle_name(exec)
+    os_ << prefix_ << "allocation started on " << demangle_name(mem_space)
         << " with " << bytes_name(num_bytes) << std::endl;
 }
 
 
 template <typename ValueType>
-void Stream<ValueType>::on_allocation_completed(const Executor *exec,
+void Stream<ValueType>::on_allocation_completed(const MemorySpace *mem_space,
                                                 const size_type &num_bytes,
                                                 const uintptr &location) const
 {
-    os_ << prefix_ << "allocation completed on " << demangle_name(exec)
+    os_ << prefix_ << "allocation completed on " << demangle_name(mem_space)
         << " at " << location_name(location) << " with "
         << bytes_name(num_bytes) << std::endl;
 }
 
 
 template <typename ValueType>
-void Stream<ValueType>::on_free_started(const Executor *exec,
+void Stream<ValueType>::on_free_started(const MemorySpace *mem_space,
                                         const uintptr &location) const
 {
-    os_ << prefix_ << "free started on " << demangle_name(exec) << " at "
+    os_ << prefix_ << "free started on " << demangle_name(mem_space) << " at "
         << location_name(location) << std::endl;
 }
 
 
 template <typename ValueType>
-void Stream<ValueType>::on_free_completed(const Executor *exec,
+void Stream<ValueType>::on_free_completed(const MemorySpace *mem_space,
                                           const uintptr &location) const
 {
-    os_ << prefix_ << "free completed on " << demangle_name(exec) << " at "
+    os_ << prefix_ << "free completed on " << demangle_name(mem_space) << " at "
         << location_name(location) << std::endl;
 }
 
 
 template <typename ValueType>
-void Stream<ValueType>::on_copy_started(const Executor *from,
-                                        const Executor *to,
+void Stream<ValueType>::on_copy_started(const MemorySpace *from,
+                                        const MemorySpace *to,
                                         const uintptr &location_from,
                                         const uintptr &location_to,
                                         const size_type &num_bytes) const
@@ -175,8 +176,8 @@ void Stream<ValueType>::on_copy_started(const Executor *from,
 
 
 template <typename ValueType>
-void Stream<ValueType>::on_copy_completed(const Executor *from,
-                                          const Executor *to,
+void Stream<ValueType>::on_copy_completed(const MemorySpace *from,
+                                          const MemorySpace *to,
                                           const uintptr &location_from,
                                           const uintptr &location_to,
                                           const size_type &num_bytes) const

--- a/core/test/base/array.cpp
+++ b/core/test/base/array.cpp
@@ -110,8 +110,9 @@ TYPED_TEST(Array, CanBeCreatedFromExistingData)
 
 TYPED_TEST(Array, CanBeCreatedFromDataOnExecutor)
 {
-    gko::Array<TypeParam> a{this->exec, 3,
-                            this->exec->template alloc<TypeParam>(3)};
+    gko::Array<TypeParam> a{
+        this->exec, 3,
+        this->exec->get_mem_space()->template alloc<TypeParam>(3)};
 
     EXPECT_EQ(a.get_num_elems(), 3);
 }

--- a/core/test/base/executor.cpp
+++ b/core/test/base/executor.cpp
@@ -95,52 +95,6 @@ TEST(OmpExecutor, RunsCorrectLambdaOperation)
 }
 
 
-TEST(OmpExecutor, AllocatesAndFreesMemory)
-{
-    const int num_elems = 10;
-    exec_ptr omp = gko::OmpExecutor::create();
-    int *ptr = nullptr;
-
-    ASSERT_NO_THROW(ptr = omp->alloc<int>(num_elems));
-    ASSERT_NO_THROW(omp->free(ptr));
-}
-
-
-TEST(OmpExecutor, FreeAcceptsNullptr)
-{
-    exec_ptr omp = gko::OmpExecutor::create();
-    ASSERT_NO_THROW(omp->free(nullptr));
-}
-
-
-TEST(OmpExecutor, FailsWhenOverallocating)
-{
-    const gko::size_type num_elems = 1ll << 50;  // 4PB of integers
-    exec_ptr omp = gko::OmpExecutor::create();
-    int *ptr = nullptr;
-
-    ASSERT_THROW(ptr = omp->alloc<int>(num_elems), gko::AllocationError);
-
-    omp->free(ptr);
-}
-
-
-TEST(OmpExecutor, CopiesData)
-{
-    int orig[] = {3, 8};
-    const int num_elems = std::extent<decltype(orig)>::value;
-    exec_ptr omp = gko::OmpExecutor::create();
-    int *copy = omp->alloc<int>(num_elems);
-
-    // user code is run on the OMP, so local variables are in OMP memory
-    omp->copy(num_elems, orig, copy);
-    EXPECT_EQ(3, copy[0]);
-    EXPECT_EQ(8, copy[1]);
-
-    omp->free(copy);
-}
-
-
 TEST(OmpExecutor, IsItsOwnMaster)
 {
     exec_ptr omp = gko::OmpExecutor::create();
@@ -172,95 +126,15 @@ TEST(ReferenceExecutor, RunsCorrectLambdaOperation)
 }
 
 
-TEST(ReferenceExecutor, AllocatesAndFreesMemory)
-{
-    const int num_elems = 10;
-    exec_ptr ref = gko::ReferenceExecutor::create();
-    int *ptr = nullptr;
-
-    ASSERT_NO_THROW(ptr = ref->alloc<int>(num_elems));
-    ASSERT_NO_THROW(ref->free(ptr));
-}
-
-
-TEST(ReferenceExecutor, FreeAcceptsNullptr)
-{
-    exec_ptr omp = gko::ReferenceExecutor::create();
-    ASSERT_NO_THROW(omp->free(nullptr));
-}
-
-
-TEST(ReferenceExecutor, FailsWhenOverallocating)
-{
-    const gko::size_type num_elems = 1ll << 50;  // 4PB of integers
-    exec_ptr ref = gko::ReferenceExecutor::create();
-    int *ptr = nullptr;
-
-    ASSERT_THROW(ptr = ref->alloc<int>(num_elems), gko::AllocationError);
-
-    ref->free(ptr);
-}
-
-
-TEST(ReferenceExecutor, CopiesData)
-{
-    int orig[] = {3, 8};
-    const int num_elems = std::extent<decltype(orig)>::value;
-    exec_ptr ref = gko::ReferenceExecutor::create();
-    int *copy = ref->alloc<int>(num_elems);
-
-    // ReferenceExecutor is a type of OMP executor, so this is O.K.
-    ref->copy(num_elems, orig, copy);
-    EXPECT_EQ(3, copy[0]);
-    EXPECT_EQ(8, copy[1]);
-
-    ref->free(copy);
-}
-
-
 TEST(ReferenceExecutor, CopiesSingleValue)
 {
     exec_ptr ref = gko::ReferenceExecutor::create();
-    int *el = ref->alloc<int>(1);
+    int *el = ref->get_mem_space()->alloc<int>(1);
     el[0] = 83683;
 
     EXPECT_EQ(83683, ref->copy_val_to_host(el));
 
-    ref->free(el);
-}
-
-
-TEST(ReferenceExecutor, CopiesDataFromOmp)
-{
-    int orig[] = {3, 8};
-    const int num_elems = std::extent<decltype(orig)>::value;
-    exec_ptr omp = gko::OmpExecutor::create();
-    exec_ptr ref = gko::ReferenceExecutor::create();
-    int *copy = ref->alloc<int>(num_elems);
-
-    // ReferenceExecutor is a type of OMP executor, so this is O.K.
-    ref->copy_from(omp.get(), num_elems, orig, copy);
-    EXPECT_EQ(3, copy[0]);
-    EXPECT_EQ(8, copy[1]);
-
-    ref->free(copy);
-}
-
-
-TEST(ReferenceExecutor, CopiesDataToOmp)
-{
-    int orig[] = {3, 8};
-    const int num_elems = std::extent<decltype(orig)>::value;
-    exec_ptr omp = gko::OmpExecutor::create();
-    exec_ptr ref = gko::ReferenceExecutor::create();
-    int *copy = omp->alloc<int>(num_elems);
-
-    // ReferenceExecutor is a type of OMP executor, so this is O.K.
-    omp->copy_from(ref.get(), num_elems, orig, copy);
-    EXPECT_EQ(3, copy[0]);
-    EXPECT_EQ(8, copy[1]);
-
-    ref->free(copy);
+    ref->get_mem_space()->free(el);
 }
 
 
@@ -411,44 +285,6 @@ TEST(HipExecutor, CanSetDeviceResetBoolean)
     hip->set_device_reset(true);
 
     ASSERT_EQ(true, hip->get_device_reset());
-}
-
-
-template <typename T>
-struct mock_free : T {
-    /**
-     * @internal Due to a bug with gcc 5.3, the constructor needs to be called
-     * with `()` operator instead of `{}`.
-     */
-    template <typename... Params>
-    mock_free(Params &&... params) : T(std::forward<Params>(params)...)
-    {}
-
-    void raw_free(void *ptr) const noexcept override
-    {
-        called_free = true;
-        T::raw_free(ptr);
-    }
-
-    mutable bool called_free{false};
-};
-
-
-TEST(ExecutorDeleter, DeletesObject)
-{
-    auto ref = std::make_shared<mock_free<gko::ReferenceExecutor>>();
-    auto x = ref->alloc<int>(5);
-
-    gko::executor_deleter<int>{ref}(x);
-
-    ASSERT_TRUE(ref->called_free);
-}
-
-
-TEST(ExecutorDeleter, AvoidsDeletionForNullExecutor)
-{
-    int x[5];
-    ASSERT_NO_THROW(gko::executor_deleter<int>{nullptr}(x));
 }
 
 

--- a/core/test/base/memory_space.cpp
+++ b/core/test/base/memory_space.cpp
@@ -1,0 +1,159 @@
+/*******************************<GINKGO LICENSE>******************************
+Copyright (c) 2017-2020, the Ginkgo authors
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+******************************<GINKGO LICENSE>*******************************/
+
+#include <ginkgo/core/base/memory_space.hpp>
+
+
+#include <type_traits>
+
+
+#include <gtest/gtest.h>
+
+
+#include <ginkgo/core/base/exception.hpp>
+
+
+namespace {
+
+
+using mem_space_ptr = std::shared_ptr<gko::MemorySpace>;
+
+
+TEST(HostMemorySpace, AllocatesAndFreesMemory)
+{
+    const int num_elems = 10;
+    mem_space_ptr host = gko::HostMemorySpace::create();
+    int *ptr = nullptr;
+
+    ASSERT_NO_THROW(ptr = host->alloc<int>(num_elems));
+    ASSERT_NO_THROW(host->free(ptr));
+}
+
+
+TEST(HostMemorySpace, FreeAcceptsNullptr)
+{
+    mem_space_ptr host = gko::HostMemorySpace::create();
+    ASSERT_NO_THROW(host->free(nullptr));
+}
+
+
+TEST(HostMemorySpace, FailsWhenOverallocating)
+{
+    const gko::size_type num_elems = 1ll << 50;  // 4PB of integers
+    mem_space_ptr host = gko::HostMemorySpace::create();
+    int *ptr = nullptr;
+
+    ASSERT_THROW(ptr = host->alloc<int>(num_elems), gko::AllocationError);
+
+    host->free(ptr);
+}
+
+
+TEST(HostMemorySpace, CopiesData)
+{
+    int orig[] = {3, 8};
+    const int num_elems = std::extent<decltype(orig)>::value;
+    mem_space_ptr host = gko::HostMemorySpace::create();
+    int *copy = host->alloc<int>(num_elems);
+
+    // user code is run on the HOST, so local variables are in HOST memory
+    host->copy_from(host.get(), num_elems, orig, copy);
+    EXPECT_EQ(3, copy[0]);
+    EXPECT_EQ(8, copy[1]);
+
+    host->free(copy);
+}
+
+
+TEST(CudaMemorySpace, KnowsItsDeviceId)
+{
+    auto cuda = gko::CudaMemorySpace::create(0);
+
+    ASSERT_EQ(0, cuda->get_device_id());
+}
+
+
+TEST(CudaUVMSpace, KnowsItsDeviceId)
+{
+    auto cuda_uvm = gko::CudaUVMSpace::create(0);
+
+    ASSERT_EQ(0, cuda_uvm->get_device_id());
+}
+
+
+TEST(HipMemorySpace, KnowsItsDeviceId)
+{
+    auto hip = gko::HipMemorySpace::create(0);
+
+    ASSERT_EQ(0, hip->get_device_id());
+}
+
+
+template <typename T>
+struct mock_free : T {
+    /**
+     * @internal Due to a bug with gcc 5.3, the constructor needs to be called
+     * with `()` operator instead of `{}`.
+     */
+    template <typename... Params>
+    mock_free(Params &&... params) : T(std::forward<Params>(params)...)
+    {}
+
+    void raw_free(void *ptr) const noexcept override
+    {
+        called_free = true;
+        T::raw_free(ptr);
+    }
+
+    mutable bool called_free{false};
+};
+
+
+TEST(MemorySpaceDeleter, DeletesObject)
+{
+    auto host = std::make_shared<mock_free<gko::HostMemorySpace>>();
+    auto x = host->alloc<int>(5);
+
+    gko::memory_space_deleter<int>{host}(x);
+
+    ASSERT_TRUE(host->called_free);
+}
+
+
+TEST(MemorySpaceDeleter, AvoidsDeletionForNullMemorySpace)
+{
+    int x[5];
+    ASSERT_NO_THROW(gko::memory_space_deleter<int>{nullptr}(x));
+}
+
+
+}  // namespace

--- a/core/test/log/convergence.cpp
+++ b/core/test/log/convergence.cpp
@@ -37,6 +37,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
 #include <ginkgo/core/base/executor.hpp>
+#include <ginkgo/core/base/memory_space.hpp>
 
 
 #include "core/test/utils.hpp"
@@ -54,7 +55,7 @@ TYPED_TEST(Convergence, CanGetData)
 {
     auto exec = gko::ReferenceExecutor::create();
     auto logger = gko::log::Convergence<TypeParam>::create(
-        exec, gko::log::Logger::iteration_complete_mask);
+        exec, exec->get_mem_space(), gko::log::Logger::iteration_complete_mask);
 
     ASSERT_EQ(logger->get_num_iterations(), 0);
     ASSERT_EQ(logger->get_residual(), nullptr);

--- a/core/test/log/logger.cpp
+++ b/core/test/log/logger.cpp
@@ -65,8 +65,8 @@ TEST(DummyLogged, CanAddLogger)
     auto exec = gko::ReferenceExecutor::create();
     DummyLoggedClass c;
 
-    c.add_logger(
-        gko::log::Record::create(exec, gko::log::Logger::all_events_mask));
+    c.add_logger(gko::log::Record::create(exec, exec->get_mem_space(),
+                                          gko::log::Logger::all_events_mask));
 
     ASSERT_EQ(c.get_num_loggers(), 1);
 }
@@ -77,10 +77,11 @@ TEST(DummyLogged, CanAddMultipleLoggers)
     auto exec = gko::ReferenceExecutor::create();
     DummyLoggedClass c;
 
-    c.add_logger(
-        gko::log::Record::create(exec, gko::log::Logger::all_events_mask));
-    c.add_logger(gko::log::Stream<>::create(
-        exec, gko::log::Logger::all_events_mask, std::cout));
+    c.add_logger(gko::log::Record::create(exec, exec->get_mem_space(),
+                                          gko::log::Logger::all_events_mask));
+    c.add_logger(gko::log::Stream<>::create(exec, exec->get_mem_space(),
+                                            gko::log::Logger::all_events_mask,
+                                            std::cout));
 
     ASSERT_EQ(c.get_num_loggers(), 2);
 }
@@ -90,11 +91,12 @@ TEST(DummyLogged, CanRemoveLogger)
 {
     auto exec = gko::ReferenceExecutor::create();
     DummyLoggedClass c;
-    auto r = gko::share(
-        gko::log::Record::create(exec, gko::log::Logger::all_events_mask));
+    auto r = gko::share(gko::log::Record::create(
+        exec, exec->get_mem_space(), gko::log::Logger::all_events_mask));
     c.add_logger(r);
-    c.add_logger(gko::log::Stream<>::create(
-        exec, gko::log::Logger::all_events_mask, std::cout));
+    c.add_logger(gko::log::Stream<>::create(exec, exec->get_mem_space(),
+                                            gko::log::Logger::all_events_mask,
+                                            std::cout));
 
     c.remove_logger(gko::lend(r));
 
@@ -107,7 +109,7 @@ struct DummyLogger : gko::log::Logger {
     explicit DummyLogger(
         std::shared_ptr<const gko::Executor> exec,
         const mask_type &enabled_events = Logger::all_events_mask)
-        : Logger(exec, enabled_events)
+        : Logger(exec, exec->get_mem_space(), enabled_events)
     {}
 
     void on_iteration_complete(

--- a/core/test/log/record.cpp
+++ b/core/test/log/record.cpp
@@ -37,6 +37,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
 #include <ginkgo/core/base/executor.hpp>
+#include <ginkgo/core/base/memory_space.hpp>
 #include <ginkgo/core/base/utils.hpp>
 #include <ginkgo/core/solver/bicgstab.hpp>
 #include <ginkgo/core/stop/iteration.hpp>
@@ -56,7 +57,7 @@ TEST(Record, CanGetData)
 {
     auto exec = gko::ReferenceExecutor::create();
     auto logger = gko::log::Record::create(
-        exec, gko::log::Logger::iteration_complete_mask);
+        exec, exec->get_mem_space(), gko::log::Logger::iteration_complete_mask);
 
     ASSERT_EQ(logger->get().allocation_started.size(), 0);
 }
@@ -66,12 +67,13 @@ TEST(Record, CatchesAllocationStarted)
 {
     auto exec = gko::ReferenceExecutor::create();
     auto logger = gko::log::Record::create(
-        exec, gko::log::Logger::allocation_started_mask);
+        exec, exec->get_mem_space(), gko::log::Logger::allocation_started_mask);
 
-    logger->on<gko::log::Logger::allocation_started>(exec.get(), 42);
+    logger->on<gko::log::Logger::allocation_started>(
+        exec->get_mem_space().get(), 42);
 
     auto &data = logger->get().allocation_started.back();
-    ASSERT_EQ(data->exec, exec.get());
+    ASSERT_EQ(data->mem_space, exec->get_mem_space().get());
     ASSERT_EQ(data->num_bytes, 42);
     ASSERT_EQ(data->location, 0);
 }
@@ -80,15 +82,17 @@ TEST(Record, CatchesAllocationStarted)
 TEST(Record, CatchesAllocationCompleted)
 {
     auto exec = gko::ReferenceExecutor::create();
-    auto logger = gko::log::Record::create(
-        exec, gko::log::Logger::allocation_completed_mask);
+    auto logger =
+        gko::log::Record::create(exec, exec->get_mem_space(),
+                                 gko::log::Logger::allocation_completed_mask);
     int dummy = 1;
     auto ptr = reinterpret_cast<gko::uintptr>(&dummy);
 
-    logger->on<gko::log::Logger::allocation_completed>(exec.get(), 42, ptr);
+    logger->on<gko::log::Logger::allocation_completed>(
+        exec->get_mem_space().get(), 42, ptr);
 
     auto &data = logger->get().allocation_completed.back();
-    ASSERT_EQ(data->exec, exec.get());
+    ASSERT_EQ(data->mem_space, exec->get_mem_space().get());
     ASSERT_EQ(data->num_bytes, 42);
     ASSERT_EQ(data->location, ptr);
 }
@@ -97,15 +101,16 @@ TEST(Record, CatchesAllocationCompleted)
 TEST(Record, CatchesFreeStarted)
 {
     auto exec = gko::ReferenceExecutor::create();
-    auto logger =
-        gko::log::Record::create(exec, gko::log::Logger::free_started_mask);
+    auto logger = gko::log::Record::create(exec, exec->get_mem_space(),
+                                           gko::log::Logger::free_started_mask);
     int dummy = 1;
     auto ptr = reinterpret_cast<gko::uintptr>(&dummy);
 
-    logger->on<gko::log::Logger::free_started>(exec.get(), ptr);
+    logger->on<gko::log::Logger::free_started>(exec->get_mem_space().get(),
+                                               ptr);
 
     auto &data = logger->get().free_started.back();
-    ASSERT_EQ(data->exec, exec.get());
+    ASSERT_EQ(data->mem_space, exec->get_mem_space().get());
     ASSERT_EQ(data->num_bytes, 0);
     ASSERT_EQ(data->location, ptr);
 }
@@ -114,15 +119,16 @@ TEST(Record, CatchesFreeStarted)
 TEST(Record, CatchesFreeCompleted)
 {
     auto exec = gko::ReferenceExecutor::create();
-    auto logger =
-        gko::log::Record::create(exec, gko::log::Logger::free_completed_mask);
+    auto logger = gko::log::Record::create(
+        exec, exec->get_mem_space(), gko::log::Logger::free_completed_mask);
     int dummy = 1;
     auto ptr = reinterpret_cast<gko::uintptr>(&dummy);
 
-    logger->on<gko::log::Logger::free_completed>(exec.get(), ptr);
+    logger->on<gko::log::Logger::free_completed>(exec->get_mem_space().get(),
+                                                 ptr);
 
     auto &data = logger->get().free_completed.back();
-    ASSERT_EQ(data->exec, exec.get());
+    ASSERT_EQ(data->mem_space, exec->get_mem_space().get());
     ASSERT_EQ(data->num_bytes, 0);
     ASSERT_EQ(data->location, ptr);
 }
@@ -131,23 +137,24 @@ TEST(Record, CatchesFreeCompleted)
 TEST(Record, CatchesCopyStarted)
 {
     auto exec = gko::ReferenceExecutor::create();
-    auto logger =
-        gko::log::Record::create(exec, gko::log::Logger::copy_started_mask);
+    auto logger = gko::log::Record::create(exec, exec->get_mem_space(),
+                                           gko::log::Logger::copy_started_mask);
     int dummy_from = 1;
     int dummy_to = 1;
     auto ptr_from = reinterpret_cast<gko::uintptr>(&dummy_from);
     auto ptr_to = reinterpret_cast<gko::uintptr>(&dummy_to);
 
-    logger->on<gko::log::Logger::copy_started>(exec.get(), exec.get(), ptr_from,
-                                               ptr_to, 42);
+    logger->on<gko::log::Logger::copy_started>(exec->get_mem_space().get(),
+                                               exec->get_mem_space().get(),
+                                               ptr_from, ptr_to, 42);
 
     auto &data = logger->get().copy_started.back();
     auto data_from = std::get<0>(*data);
     auto data_to = std::get<1>(*data);
-    ASSERT_EQ(data_from.exec, exec.get());
+    ASSERT_EQ(data_from.mem_space, exec->get_mem_space().get());
     ASSERT_EQ(data_from.num_bytes, 42);
     ASSERT_EQ(data_from.location, ptr_from);
-    ASSERT_EQ(data_to.exec, exec.get());
+    ASSERT_EQ(data_to.mem_space, exec->get_mem_space().get());
     ASSERT_EQ(data_to.num_bytes, 42);
     ASSERT_EQ(data_to.location, ptr_to);
 }
@@ -156,23 +163,24 @@ TEST(Record, CatchesCopyStarted)
 TEST(Record, CatchesCopyCompleted)
 {
     auto exec = gko::ReferenceExecutor::create();
-    auto logger =
-        gko::log::Record::create(exec, gko::log::Logger::copy_completed_mask);
+    auto logger = gko::log::Record::create(
+        exec, exec->get_mem_space(), gko::log::Logger::copy_completed_mask);
     int dummy_from = 1;
     int dummy_to = 1;
     auto ptr_from = reinterpret_cast<gko::uintptr>(&dummy_from);
     auto ptr_to = reinterpret_cast<gko::uintptr>(&dummy_to);
 
-    logger->on<gko::log::Logger::copy_completed>(exec.get(), exec.get(),
+    logger->on<gko::log::Logger::copy_completed>(exec->get_mem_space().get(),
+                                                 exec->get_mem_space().get(),
                                                  ptr_from, ptr_to, 42);
 
     auto &data = logger->get().copy_completed.back();
     auto data_from = std::get<0>(*data);
     auto data_to = std::get<1>(*data);
-    ASSERT_EQ(data_from.exec, exec.get());
+    ASSERT_EQ(data_from.mem_space, exec->get_mem_space().get());
     ASSERT_EQ(data_from.num_bytes, 42);
     ASSERT_EQ(data_from.location, ptr_from);
-    ASSERT_EQ(data_to.exec, exec.get());
+    ASSERT_EQ(data_to.mem_space, exec->get_mem_space().get());
     ASSERT_EQ(data_to.num_bytes, 42);
     ASSERT_EQ(data_to.location, ptr_to);
 }
@@ -182,7 +190,7 @@ TEST(Record, CatchesOperationLaunched)
 {
     auto exec = gko::ReferenceExecutor::create();
     auto logger = gko::log::Record::create(
-        exec, gko::log::Logger::operation_launched_mask);
+        exec, exec->get_mem_space(), gko::log::Logger::operation_launched_mask);
     gko::Operation op;
 
     logger->on<gko::log::Logger::operation_launched>(exec.get(), &op);
@@ -196,8 +204,9 @@ TEST(Record, CatchesOperationLaunched)
 TEST(Record, CatchesOperationCompleted)
 {
     auto exec = gko::ReferenceExecutor::create();
-    auto logger = gko::log::Record::create(
-        exec, gko::log::Logger::operation_completed_mask);
+    auto logger =
+        gko::log::Record::create(exec, exec->get_mem_space(),
+                                 gko::log::Logger::operation_completed_mask);
     gko::Operation op;
 
     logger->on<gko::log::Logger::operation_completed>(exec.get(), &op);
@@ -213,7 +222,8 @@ TEST(Record, CatchesPolymorphicObjectCreateStarted)
     using Dense = gko::matrix::Dense<>;
     auto exec = gko::ReferenceExecutor::create();
     auto logger = gko::log::Record::create(
-        exec, gko::log::Logger::polymorphic_object_create_started_mask);
+        exec, exec->get_mem_space(),
+        gko::log::Logger::polymorphic_object_create_started_mask);
     auto po = gko::matrix::Dense<>::create(exec);
 
     logger->on<gko::log::Logger::polymorphic_object_create_started>(exec.get(),
@@ -232,7 +242,8 @@ TEST(Record, CatchesPolymorphicObjectCreateCompleted)
     using Dense = gko::matrix::Dense<>;
     auto exec = gko::ReferenceExecutor::create();
     auto logger = gko::log::Record::create(
-        exec, gko::log::Logger::polymorphic_object_create_completed_mask);
+        exec, exec->get_mem_space(),
+        gko::log::Logger::polymorphic_object_create_completed_mask);
     auto po = gko::matrix::Dense<>::create(exec);
     auto output = gko::matrix::Dense<>::create(exec);
 
@@ -251,7 +262,8 @@ TEST(Record, CatchesPolymorphicObjectCopyStarted)
     using Dense = gko::matrix::Dense<>;
     auto exec = gko::ReferenceExecutor::create();
     auto logger = gko::log::Record::create(
-        exec, gko::log::Logger::polymorphic_object_copy_started_mask);
+        exec, exec->get_mem_space(),
+        gko::log::Logger::polymorphic_object_copy_started_mask);
     auto from = gko::matrix::Dense<>::create(exec);
     auto to = gko::matrix::Dense<>::create(exec);
 
@@ -270,7 +282,8 @@ TEST(Record, CatchesPolymorphicObjectCopyCompleted)
     using Dense = gko::matrix::Dense<>;
     auto exec = gko::ReferenceExecutor::create();
     auto logger = gko::log::Record::create(
-        exec, gko::log::Logger::polymorphic_object_copy_completed_mask);
+        exec, exec->get_mem_space(),
+        gko::log::Logger::polymorphic_object_copy_completed_mask);
     auto from = gko::matrix::Dense<>::create(exec);
     auto to = gko::matrix::Dense<>::create(exec);
 
@@ -290,7 +303,8 @@ TEST(Record, CatchesPolymorphicObjectDeleted)
     using Dense = gko::matrix::Dense<>;
     auto exec = gko::ReferenceExecutor::create();
     auto logger = gko::log::Record::create(
-        exec, gko::log::Logger::polymorphic_object_deleted_mask);
+        exec, exec->get_mem_space(),
+        gko::log::Logger::polymorphic_object_deleted_mask);
     auto po = gko::matrix::Dense<>::create(exec);
 
     logger->on<gko::log::Logger::polymorphic_object_deleted>(exec.get(),
@@ -308,8 +322,9 @@ TEST(Record, CatchesLinOpApplyStarted)
 {
     using Dense = gko::matrix::Dense<>;
     auto exec = gko::ReferenceExecutor::create();
-    auto logger = gko::log::Record::create(
-        exec, gko::log::Logger::linop_apply_started_mask);
+    auto logger =
+        gko::log::Record::create(exec, exec->get_mem_space(),
+                                 gko::log::Logger::linop_apply_started_mask);
     auto A = gko::initialize<Dense>({1.1}, exec);
     auto b = gko::initialize<Dense>({-2.2}, exec);
     auto x = gko::initialize<Dense>({3.3}, exec);
@@ -330,8 +345,9 @@ TEST(Record, CatchesLinOpApplyCompleted)
 {
     using Dense = gko::matrix::Dense<>;
     auto exec = gko::ReferenceExecutor::create();
-    auto logger = gko::log::Record::create(
-        exec, gko::log::Logger::linop_apply_completed_mask);
+    auto logger =
+        gko::log::Record::create(exec, exec->get_mem_space(),
+                                 gko::log::Logger::linop_apply_completed_mask);
     auto A = gko::initialize<Dense>({1.1}, exec);
     auto b = gko::initialize<Dense>({-2.2}, exec);
     auto x = gko::initialize<Dense>({3.3}, exec);
@@ -353,7 +369,8 @@ TEST(Record, CatchesLinOpAdvancedApplyStarted)
     using Dense = gko::matrix::Dense<>;
     auto exec = gko::ReferenceExecutor::create();
     auto logger = gko::log::Record::create(
-        exec, gko::log::Logger::linop_advanced_apply_started_mask);
+        exec, exec->get_mem_space(),
+        gko::log::Logger::linop_advanced_apply_started_mask);
     auto A = gko::initialize<Dense>({1.1}, exec);
     auto alpha = gko::initialize<Dense>({-4.4}, exec);
     auto b = gko::initialize<Dense>({-2.2}, exec);
@@ -377,7 +394,8 @@ TEST(Record, CatchesLinOpAdvancedApplyCompleted)
     using Dense = gko::matrix::Dense<>;
     auto exec = gko::ReferenceExecutor::create();
     auto logger = gko::log::Record::create(
-        exec, gko::log::Logger::linop_advanced_apply_completed_mask);
+        exec, exec->get_mem_space(),
+        gko::log::Logger::linop_advanced_apply_completed_mask);
     auto A = gko::initialize<Dense>({1.1}, exec);
     auto alpha = gko::initialize<Dense>({-4.4}, exec);
     auto b = gko::initialize<Dense>({-2.2}, exec);
@@ -400,7 +418,8 @@ TEST(Record, CatchesLinopFactoryGenerateStarted)
 {
     auto exec = gko::ReferenceExecutor::create();
     auto logger = gko::log::Record::create(
-        exec, gko::log::Logger::linop_factory_generate_started_mask);
+        exec, exec->get_mem_space(),
+        gko::log::Logger::linop_factory_generate_started_mask);
     auto factory =
         gko::solver::Bicgstab<>::build()
             .with_criteria(
@@ -422,7 +441,8 @@ TEST(Record, CatchesLinopFactoryGenerateCompleted)
 {
     auto exec = gko::ReferenceExecutor::create();
     auto logger = gko::log::Record::create(
-        exec, gko::log::Logger::linop_factory_generate_completed_mask);
+        exec, exec->get_mem_space(),
+        gko::log::Logger::linop_factory_generate_completed_mask);
     auto factory =
         gko::solver::Bicgstab<>::build()
             .with_criteria(
@@ -445,7 +465,8 @@ TEST(Record, CatchesCriterionCheckStarted)
 {
     auto exec = gko::ReferenceExecutor::create();
     auto logger = gko::log::Record::create(
-        exec, gko::log::Logger::criterion_check_started_mask);
+        exec, exec->get_mem_space(),
+        gko::log::Logger::criterion_check_started_mask);
     auto criterion =
         gko::stop::Iteration::build().with_max_iters(3u).on(exec)->generate(
             nullptr, nullptr, nullptr);
@@ -468,7 +489,8 @@ TEST(Record, CatchesCriterionCheckCompleted)
 {
     auto exec = gko::ReferenceExecutor::create();
     auto logger = gko::log::Record::create(
-        exec, gko::log::Logger::criterion_check_completed_mask);
+        exec, exec->get_mem_space(),
+        gko::log::Logger::criterion_check_completed_mask);
     auto criterion =
         gko::stop::Iteration::build().with_max_iters(3u).on(exec)->generate(
             nullptr, nullptr, nullptr);
@@ -499,7 +521,7 @@ TEST(Record, CatchesIterations)
     using Dense = gko::matrix::Dense<>;
     auto exec = gko::ReferenceExecutor::create();
     auto logger = gko::log::Record::create(
-        exec, gko::log::Logger::iteration_complete_mask);
+        exec, exec->get_mem_space(), gko::log::Logger::iteration_complete_mask);
     auto factory =
         gko::solver::Bicgstab<>::build()
             .with_criteria(

--- a/core/test/log/stream.cpp
+++ b/core/test/log/stream.cpp
@@ -42,6 +42,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
 #include <ginkgo/core/base/executor.hpp>
+#include <ginkgo/core/base/memory_space.hpp>
 #include <ginkgo/core/matrix/dense.hpp>
 #include <ginkgo/core/solver/bicgstab.hpp>
 #include <ginkgo/core/stop/iteration.hpp>
@@ -67,9 +68,11 @@ TYPED_TEST(Stream, CatchesAllocationStarted)
     auto exec = gko::ReferenceExecutor::create();
     std::stringstream out;
     auto logger = gko::log::Stream<TypeParam>::create(
-        exec, gko::log::Logger::allocation_started_mask, out);
+        exec, exec->get_mem_space(), gko::log::Logger::allocation_started_mask,
+        out);
 
-    logger->template on<gko::log::Logger::allocation_started>(exec.get(), 42);
+    logger->template on<gko::log::Logger::allocation_started>(
+        exec->get_mem_space().get(), 42);
 
     auto os = out.str();
     GKO_ASSERT_STR_CONTAINS(os, "allocation started on");
@@ -82,13 +85,15 @@ TYPED_TEST(Stream, CatchesAllocationCompleted)
     auto exec = gko::ReferenceExecutor::create();
     std::stringstream out;
     auto logger = gko::log::Stream<TypeParam>::create(
-        exec, gko::log::Logger::allocation_completed_mask, out);
+        exec, exec->get_mem_space(),
+        gko::log::Logger::allocation_completed_mask, out);
     int dummy = 1;
     std::stringstream ptrstream;
     ptrstream << std::hex << "0x" << reinterpret_cast<gko::uintptr>(&dummy);
 
     logger->template on<gko::log::Logger::allocation_completed>(
-        exec.get(), 42, reinterpret_cast<gko::uintptr>(&dummy));
+        exec->get_mem_space().get(), 42,
+        reinterpret_cast<gko::uintptr>(&dummy));
 
     auto os = out.str();
     GKO_ASSERT_STR_CONTAINS(os, "allocation completed on");
@@ -102,13 +107,13 @@ TYPED_TEST(Stream, CatchesFreeStarted)
     auto exec = gko::ReferenceExecutor::create();
     std::stringstream out;
     auto logger = gko::log::Stream<TypeParam>::create(
-        exec, gko::log::Logger::free_started_mask, out);
+        exec, exec->get_mem_space(), gko::log::Logger::free_started_mask, out);
     int dummy = 1;
     std::stringstream ptrstream;
     ptrstream << std::hex << "0x" << reinterpret_cast<gko::uintptr>(&dummy);
 
     logger->template on<gko::log::Logger::free_started>(
-        exec.get(), reinterpret_cast<gko::uintptr>(&dummy));
+        exec->get_mem_space().get(), reinterpret_cast<gko::uintptr>(&dummy));
 
     auto os = out.str();
     GKO_ASSERT_STR_CONTAINS(os, "free started on");
@@ -121,13 +126,14 @@ TYPED_TEST(Stream, CatchesFreeCompleted)
     auto exec = gko::ReferenceExecutor::create();
     std::stringstream out;
     auto logger = gko::log::Stream<TypeParam>::create(
-        exec, gko::log::Logger::free_completed_mask, out);
+        exec, exec->get_mem_space(), gko::log::Logger::free_completed_mask,
+        out);
     int dummy = 1;
     std::stringstream ptrstream;
     ptrstream << std::hex << "0x" << reinterpret_cast<gko::uintptr>(&dummy);
 
     logger->template on<gko::log::Logger::free_completed>(
-        exec.get(), reinterpret_cast<gko::uintptr>(&dummy));
+        exec->get_mem_space().get(), reinterpret_cast<gko::uintptr>(&dummy));
 
     auto os = out.str();
     GKO_ASSERT_STR_CONTAINS(os, "free completed on");
@@ -140,7 +146,7 @@ TYPED_TEST(Stream, CatchesCopyStarted)
     auto exec = gko::ReferenceExecutor::create();
     std::stringstream out;
     auto logger = gko::log::Stream<TypeParam>::create(
-        exec, gko::log::Logger::copy_started_mask, out);
+        exec, exec->get_mem_space(), gko::log::Logger::copy_started_mask, out);
     int dummy_in = 1;
     int dummy_out = 1;
     std::stringstream ptrstream_in;
@@ -151,7 +157,8 @@ TYPED_TEST(Stream, CatchesCopyStarted)
                   << reinterpret_cast<gko::uintptr>(&dummy_out);
 
     logger->template on<gko::log::Logger::copy_started>(
-        exec.get(), exec.get(), reinterpret_cast<gko::uintptr>(&dummy_in),
+        exec->get_mem_space().get(), exec->get_mem_space().get(),
+        reinterpret_cast<gko::uintptr>(&dummy_in),
         reinterpret_cast<gko::uintptr>(&dummy_out), 42);
 
     auto os = out.str();
@@ -167,7 +174,8 @@ TYPED_TEST(Stream, CatchesCopyCompleted)
     auto exec = gko::ReferenceExecutor::create();
     std::stringstream out;
     auto logger = gko::log::Stream<TypeParam>::create(
-        exec, gko::log::Logger::copy_completed_mask, out);
+        exec, exec->get_mem_space(), gko::log::Logger::copy_completed_mask,
+        out);
     int dummy_in = 1;
     int dummy_out = 1;
     std::stringstream ptrstream_in;
@@ -178,7 +186,8 @@ TYPED_TEST(Stream, CatchesCopyCompleted)
                   << reinterpret_cast<gko::uintptr>(&dummy_out);
 
     logger->template on<gko::log::Logger::copy_completed>(
-        exec.get(), exec.get(), reinterpret_cast<gko::uintptr>(&dummy_in),
+        exec->get_mem_space().get(), exec->get_mem_space().get(),
+        reinterpret_cast<gko::uintptr>(&dummy_in),
         reinterpret_cast<gko::uintptr>(&dummy_out), 42);
 
     auto os = out.str();
@@ -194,7 +203,8 @@ TYPED_TEST(Stream, CatchesOperationLaunched)
     auto exec = gko::ReferenceExecutor::create();
     std::stringstream out;
     auto logger = gko::log::Stream<TypeParam>::create(
-        exec, gko::log::Logger::operation_launched_mask, out);
+        exec, exec->get_mem_space(), gko::log::Logger::operation_launched_mask,
+        out);
     gko::Operation op;
     std::stringstream ptrstream;
     ptrstream << &op;
@@ -212,7 +222,8 @@ TYPED_TEST(Stream, CatchesOperationCompleted)
     auto exec = gko::ReferenceExecutor::create();
     std::stringstream out;
     auto logger = gko::log::Stream<TypeParam>::create(
-        exec, gko::log::Logger::operation_completed_mask, out);
+        exec, exec->get_mem_space(), gko::log::Logger::operation_completed_mask,
+        out);
     gko::Operation op;
     std::stringstream ptrstream;
     ptrstream << &op;
@@ -230,7 +241,8 @@ TYPED_TEST(Stream, CatchesPolymorphicObjectCreateStarted)
     auto exec = gko::ReferenceExecutor::create();
     std::stringstream out;
     auto logger = gko::log::Stream<TypeParam>::create(
-        exec, gko::log::Logger::polymorphic_object_create_started_mask, out);
+        exec, exec->get_mem_space(),
+        gko::log::Logger::polymorphic_object_create_started_mask, out);
     auto po = gko::matrix::Dense<TypeParam>::create(exec);
     std::stringstream ptrstream;
     ptrstream << po.get();
@@ -249,7 +261,8 @@ TYPED_TEST(Stream, CatchesPolymorphicObjectCreateCompleted)
     auto exec = gko::ReferenceExecutor::create();
     std::stringstream out;
     auto logger = gko::log::Stream<TypeParam>::create(
-        exec, gko::log::Logger::polymorphic_object_create_completed_mask, out);
+        exec, exec->get_mem_space(),
+        gko::log::Logger::polymorphic_object_create_completed_mask, out);
     auto po = gko::matrix::Dense<TypeParam>::create(exec);
     auto output = gko::matrix::Dense<TypeParam>::create(exec);
     std::stringstream ptrstream_in;
@@ -272,7 +285,8 @@ TYPED_TEST(Stream, CatchesPolymorphicObjectCopyStarted)
     auto exec = gko::ReferenceExecutor::create();
     std::stringstream out;
     auto logger = gko::log::Stream<TypeParam>::create(
-        exec, gko::log::Logger::polymorphic_object_copy_started_mask, out);
+        exec, exec->get_mem_space(),
+        gko::log::Logger::polymorphic_object_copy_started_mask, out);
     auto from = gko::matrix::Dense<TypeParam>::create(exec);
     auto to = gko::matrix::Dense<TypeParam>::create(exec);
     std::stringstream ptrstream_from;
@@ -295,7 +309,8 @@ TYPED_TEST(Stream, CatchesPolymorphicObjectCopyCompleted)
     auto exec = gko::ReferenceExecutor::create();
     std::stringstream out;
     auto logger = gko::log::Stream<TypeParam>::create(
-        exec, gko::log::Logger::polymorphic_object_copy_completed_mask, out);
+        exec, exec->get_mem_space(),
+        gko::log::Logger::polymorphic_object_copy_completed_mask, out);
     auto from = gko::matrix::Dense<TypeParam>::create(exec);
     auto to = gko::matrix::Dense<TypeParam>::create(exec);
     std::stringstream ptrstream_from;
@@ -318,7 +333,8 @@ TYPED_TEST(Stream, CatchesPolymorphicObjectDeleted)
     auto exec = gko::ReferenceExecutor::create();
     std::stringstream out;
     auto logger = gko::log::Stream<TypeParam>::create(
-        exec, gko::log::Logger::polymorphic_object_deleted_mask, out);
+        exec, exec->get_mem_space(),
+        gko::log::Logger::polymorphic_object_deleted_mask, out);
     auto po = gko::matrix::Dense<TypeParam>::create(exec);
     std::stringstream ptrstream;
     ptrstream << po.get();
@@ -338,7 +354,8 @@ TYPED_TEST(Stream, CatchesLinOpApplyStarted)
     auto exec = gko::ReferenceExecutor::create();
     std::stringstream out;
     auto logger = gko::log::Stream<TypeParam>::create(
-        exec, gko::log::Logger::linop_apply_started_mask, out);
+        exec, exec->get_mem_space(), gko::log::Logger::linop_apply_started_mask,
+        out);
     auto A = Dense::create(exec);
     auto b = Dense::create(exec);
     auto x = Dense::create(exec);
@@ -366,7 +383,8 @@ TYPED_TEST(Stream, CatchesLinOpApplyStartedWithVerbose)
     auto exec = gko::ReferenceExecutor::create();
     std::stringstream out;
     auto logger = gko::log::Stream<TypeParam>::create(
-        exec, gko::log::Logger::linop_apply_started_mask, out, true);
+        exec, exec->get_mem_space(), gko::log::Logger::linop_apply_started_mask,
+        out, true);
     auto A = gko::initialize<Dense>({1.1}, exec);
     auto b = gko::initialize<Dense>({-2.2}, exec);
     auto x = gko::initialize<Dense>({3.3}, exec);
@@ -387,7 +405,8 @@ TYPED_TEST(Stream, CatchesLinOpApplyCompleted)
     auto exec = gko::ReferenceExecutor::create();
     std::stringstream out;
     auto logger = gko::log::Stream<TypeParam>::create(
-        exec, gko::log::Logger::linop_apply_completed_mask, out);
+        exec, exec->get_mem_space(),
+        gko::log::Logger::linop_apply_completed_mask, out);
     auto A = Dense::create(exec);
     auto b = Dense::create(exec);
     auto x = Dense::create(exec);
@@ -415,7 +434,8 @@ TYPED_TEST(Stream, CatchesLinOpApplyCompletedWithVerbose)
     auto exec = gko::ReferenceExecutor::create();
     std::stringstream out;
     auto logger = gko::log::Stream<TypeParam>::create(
-        exec, gko::log::Logger::linop_apply_completed_mask, out, true);
+        exec, exec->get_mem_space(),
+        gko::log::Logger::linop_apply_completed_mask, out, true);
     auto A = gko::initialize<Dense>({1.1}, exec);
     auto b = gko::initialize<Dense>({-2.2}, exec);
     auto x = gko::initialize<Dense>({3.3}, exec);
@@ -436,7 +456,8 @@ TYPED_TEST(Stream, CatchesLinOpAdvancedApplyStarted)
     auto exec = gko::ReferenceExecutor::create();
     std::stringstream out;
     auto logger = gko::log::Stream<TypeParam>::create(
-        exec, gko::log::Logger::linop_advanced_apply_started_mask, out);
+        exec, exec->get_mem_space(),
+        gko::log::Logger::linop_advanced_apply_started_mask, out);
     auto A = Dense::create(exec);
     auto alpha = Dense::create(exec);
     auto b = Dense::create(exec);
@@ -472,7 +493,8 @@ TYPED_TEST(Stream, CatchesLinOpAdvancedApplyStartedWithVerbose)
     auto exec = gko::ReferenceExecutor::create();
     std::stringstream out;
     auto logger = gko::log::Stream<TypeParam>::create(
-        exec, gko::log::Logger::linop_advanced_apply_started_mask, out, true);
+        exec, exec->get_mem_space(),
+        gko::log::Logger::linop_advanced_apply_started_mask, out, true);
     auto A = gko::initialize<Dense>({1.1}, exec);
     auto alpha = gko::initialize<Dense>({-4.4}, exec);
     auto b = gko::initialize<Dense>({-2.2}, exec);
@@ -497,7 +519,8 @@ TYPED_TEST(Stream, CatchesLinOpAdvancedApplyCompleted)
     auto exec = gko::ReferenceExecutor::create();
     std::stringstream out;
     auto logger = gko::log::Stream<TypeParam>::create(
-        exec, gko::log::Logger::linop_advanced_apply_completed_mask, out);
+        exec, exec->get_mem_space(),
+        gko::log::Logger::linop_advanced_apply_completed_mask, out);
     auto A = Dense::create(exec);
     auto alpha = Dense::create(exec);
     auto b = Dense::create(exec);
@@ -533,7 +556,8 @@ TYPED_TEST(Stream, CatchesLinOpAdvancedApplyCompletedWithVerbose)
     auto exec = gko::ReferenceExecutor::create();
     std::stringstream out;
     auto logger = gko::log::Stream<TypeParam>::create(
-        exec, gko::log::Logger::linop_advanced_apply_completed_mask, out, true);
+        exec, exec->get_mem_space(),
+        gko::log::Logger::linop_advanced_apply_completed_mask, out, true);
     auto A = gko::initialize<Dense>({1.1}, exec);
     auto alpha = gko::initialize<Dense>({-4.4}, exec);
     auto b = gko::initialize<Dense>({-2.2}, exec);
@@ -557,7 +581,8 @@ TYPED_TEST(Stream, CatchesLinopFactoryGenerateStarted)
     auto exec = gko::ReferenceExecutor::create();
     std::stringstream out;
     auto logger = gko::log::Stream<TypeParam>::create(
-        exec, gko::log::Logger::linop_factory_generate_started_mask, out);
+        exec, exec->get_mem_space(),
+        gko::log::Logger::linop_factory_generate_started_mask, out);
     auto factory =
         gko::solver::Bicgstab<TypeParam>::build()
             .with_criteria(
@@ -584,7 +609,8 @@ TYPED_TEST(Stream, CatchesLinopFactoryGenerateCompleted)
     auto exec = gko::ReferenceExecutor::create();
     std::stringstream out;
     auto logger = gko::log::Stream<TypeParam>::create(
-        exec, gko::log::Logger::linop_factory_generate_completed_mask, out);
+        exec, exec->get_mem_space(),
+        gko::log::Logger::linop_factory_generate_completed_mask, out);
     auto factory =
         gko::solver::Bicgstab<TypeParam>::build()
             .with_criteria(
@@ -616,7 +642,8 @@ TYPED_TEST(Stream, CatchesCriterionCheckStarted)
     auto exec = gko::ReferenceExecutor::create();
     std::stringstream out;
     auto logger = gko::log::Stream<TypeParam>::create(
-        exec, gko::log::Logger::criterion_check_started_mask, out);
+        exec, exec->get_mem_space(),
+        gko::log::Logger::criterion_check_started_mask, out);
     auto criterion =
         gko::stop::Iteration::build().with_max_iters(3u).on(exec)->generate(
             nullptr, nullptr, nullptr);
@@ -643,7 +670,8 @@ TYPED_TEST(Stream, CatchesCriterionCheckCompleted)
     auto exec = gko::ReferenceExecutor::create();
     std::stringstream out;
     auto logger = gko::log::Stream<TypeParam>::create(
-        exec, gko::log::Logger::criterion_check_completed_mask, out);
+        exec, exec->get_mem_space(),
+        gko::log::Logger::criterion_check_completed_mask, out);
     auto criterion =
         gko::stop::Iteration::build().with_max_iters(3u).on(exec)->generate(
             nullptr, nullptr, nullptr);
@@ -674,7 +702,8 @@ TYPED_TEST(Stream, CatchesCriterionCheckCompletedWithVerbose)
     auto exec = gko::ReferenceExecutor::create();
     std::stringstream out;
     auto logger = gko::log::Stream<TypeParam>::create(
-        exec, gko::log::Logger::criterion_check_completed_mask, out, true);
+        exec, exec->get_mem_space(),
+        gko::log::Logger::criterion_check_completed_mask, out, true);
     auto criterion =
         gko::stop::Iteration::build().with_max_iters(3u).on(exec)->generate(
             nullptr, nullptr, nullptr);
@@ -703,7 +732,8 @@ TYPED_TEST(Stream, CatchesIterations)
     auto exec = gko::ReferenceExecutor::create();
     std::stringstream out;
     auto logger = gko::log::Stream<TypeParam>::create(
-        exec, gko::log::Logger::iteration_complete_mask, out);
+        exec, exec->get_mem_space(), gko::log::Logger::iteration_complete_mask,
+        out);
     auto solver = Dense::create(exec);
     auto residual = Dense::create(exec);
     auto solution = Dense::create(exec);
@@ -729,7 +759,8 @@ TYPED_TEST(Stream, CatchesIterationsWithVerbose)
     auto exec = gko::ReferenceExecutor::create();
     std::stringstream out;
     auto logger = gko::log::Stream<TypeParam>::create(
-        exec, gko::log::Logger::iteration_complete_mask, out, true);
+        exec, exec->get_mem_space(), gko::log::Logger::iteration_complete_mask,
+        out, true);
 
     auto factory =
         gko::solver::Bicgstab<TypeParam>::build()

--- a/cuda/CMakeLists.txt
+++ b/cuda/CMakeLists.txt
@@ -69,6 +69,7 @@ target_sources(ginkgo_cuda
     PRIVATE
     base/exception.cpp
     base/executor.cpp
+    base/memory_space.cpp
     base/version.cpp
     components/absolute_array.cu
     components/fill_array.cu

--- a/cuda/base/executor.cpp
+++ b/cuda/base/executor.cpp
@@ -71,87 +71,20 @@ std::shared_ptr<CudaExecutor> CudaExecutor::create(
 }
 
 
-void OmpExecutor::raw_copy_to(const CudaExecutor *dest, size_type num_bytes,
-                              const void *src_ptr, void *dest_ptr) const
+std::shared_ptr<CudaExecutor> CudaExecutor::create(
+    int device_id, std::shared_ptr<MemorySpace> mem_space,
+    std::shared_ptr<Executor> master, bool device_reset)
 {
-    if (num_bytes > 0) {
-        cuda::device_guard g(dest->get_device_id());
-        GKO_ASSERT_NO_CUDA_ERRORS(
-            cudaMemcpy(dest_ptr, src_ptr, num_bytes, cudaMemcpyHostToDevice));
-    }
-}
-
-
-void CudaExecutor::raw_free(void *ptr) const noexcept
-{
-    cuda::device_guard g(this->get_device_id());
-    auto error_code = cudaFree(ptr);
-    if (error_code != cudaSuccess) {
-#if GKO_VERBOSE_LEVEL >= 1
-        // Unfortunately, if memory free fails, there's not much we can do
-        std::cerr << "Unrecoverable CUDA error on device " << this->device_id_
-                  << " in " << __func__ << ": " << cudaGetErrorName(error_code)
-                  << ": " << cudaGetErrorString(error_code) << std::endl
-                  << "Exiting program" << std::endl;
-#endif  // GKO_VERBOSE_LEVEL >= 1
-        std::exit(error_code);
-    }
-}
-
-
-void *CudaExecutor::raw_alloc(size_type num_bytes) const
-{
-    void *dev_ptr = nullptr;
-    cuda::device_guard g(this->get_device_id());
-#ifdef NDEBUG
-    auto error_code = cudaMalloc(&dev_ptr, num_bytes);
-#else
-    auto error_code = cudaMallocManaged(&dev_ptr, num_bytes);
-#endif
-    if (error_code != cudaErrorMemoryAllocation) {
-        GKO_ASSERT_NO_CUDA_ERRORS(error_code);
-    }
-    GKO_ENSURE_ALLOCATED(dev_ptr, "cuda", num_bytes);
-    return dev_ptr;
-}
-
-
-void CudaExecutor::raw_copy_to(const OmpExecutor *, size_type num_bytes,
-                               const void *src_ptr, void *dest_ptr) const
-{
-    if (num_bytes > 0) {
-        cuda::device_guard g(this->get_device_id());
-        GKO_ASSERT_NO_CUDA_ERRORS(
-            cudaMemcpy(dest_ptr, src_ptr, num_bytes, cudaMemcpyDeviceToHost));
-    }
-}
-
-
-void CudaExecutor::raw_copy_to(const CudaExecutor *dest, size_type num_bytes,
-                               const void *src_ptr, void *dest_ptr) const
-{
-    if (num_bytes > 0) {
-        cuda::device_guard g(this->get_device_id());
-        GKO_ASSERT_NO_CUDA_ERRORS(
-            cudaMemcpyPeer(dest_ptr, dest->get_device_id(), src_ptr,
-                           this->get_device_id(), num_bytes));
-    }
-}
-
-
-void CudaExecutor::raw_copy_to(const HipExecutor *dest, size_type num_bytes,
-                               const void *src_ptr, void *dest_ptr) const
-{
-#if GINKGO_HIP_PLATFORM_NVCC == 1
-    if (num_bytes > 0) {
-        cuda::device_guard g(this->get_device_id());
-        GKO_ASSERT_NO_CUDA_ERRORS(
-            cudaMemcpyPeer(dest_ptr, dest->get_device_id(), src_ptr,
-                           this->get_device_id(), num_bytes));
-    }
-#else
-    GKO_NOT_SUPPORTED(this);
-#endif
+    return std::shared_ptr<CudaExecutor>(
+        new CudaExecutor(device_id, mem_space, std::move(master), device_reset),
+        [device_id](CudaExecutor *exec) {
+            delete exec;
+            if (!CudaExecutor::get_num_execs(device_id) &&
+                exec->get_device_reset()) {
+                cuda::device_guard g(device_id);
+                cudaDeviceReset();
+            }
+        });
 }
 
 

--- a/cuda/base/memory_space.cpp
+++ b/cuda/base/memory_space.cpp
@@ -1,0 +1,277 @@
+/*******************************<GINKGO LICENSE>******************************
+Copyright (c) 2017-2020, the Ginkgo authors
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+******************************<GINKGO LICENSE>*******************************/
+
+#include <ginkgo/core/base/memory_space.hpp>
+
+
+#include <iostream>
+
+
+#include <cuda_runtime.h>
+
+
+#include <ginkgo/config.hpp>
+#include <ginkgo/core/base/exception_helpers.hpp>
+
+
+#include "cuda/base/device_guard.hpp"
+
+
+namespace gko {
+
+
+void CudaMemorySpace::synchronize() const
+{
+    cuda::device_guard g(this->get_device_id());
+    GKO_ASSERT_NO_CUDA_ERRORS(cudaDeviceSynchronize());
+}
+
+
+void CudaUVMSpace::synchronize() const
+{
+    cuda::device_guard g(this->get_device_id());
+    GKO_ASSERT_NO_CUDA_ERRORS(cudaDeviceSynchronize());
+}
+
+
+int CudaMemorySpace::get_num_devices()
+{
+    int deviceCount = 0;
+    auto error_code = cudaGetDeviceCount(&deviceCount);
+    if (error_code == cudaErrorNoDevice) {
+        return 0;
+    }
+    GKO_ASSERT_NO_CUDA_ERRORS(error_code);
+    return deviceCount;
+}
+
+
+int CudaUVMSpace::get_num_devices()
+{
+    int deviceCount = 0;
+    auto error_code = cudaGetDeviceCount(&deviceCount);
+    if (error_code == cudaErrorNoDevice) {
+        return 0;
+    }
+    GKO_ASSERT_NO_CUDA_ERRORS(error_code);
+    return deviceCount;
+}
+
+
+void HostMemorySpace::raw_copy_to(const CudaMemorySpace *dest,
+                                  size_type num_bytes, const void *src_ptr,
+                                  void *dest_ptr) const
+{
+    if (num_bytes > 0) {
+        cuda::device_guard g(dest->get_device_id());
+        GKO_ASSERT_NO_CUDA_ERRORS(
+            cudaMemcpy(dest_ptr, src_ptr, num_bytes, cudaMemcpyHostToDevice));
+    }
+}
+
+
+void CudaMemorySpace::raw_free(void *ptr) const noexcept
+{
+    cuda::device_guard g(this->get_device_id());
+    auto error_code = cudaFree(ptr);
+    if (error_code != cudaSuccess) {
+#if GKO_VERBOSE_LEVEL >= 1
+        // Unfortunately, if memory free fails, there's not much we can do
+        std::cerr << "Unrecoverable CUDA error on device " << this->device_id_
+                  << " in " << __func__ << ": " << cudaGetErrorName(error_code)
+                  << ": " << cudaGetErrorString(error_code) << std::endl
+                  << "Exiting program" << std::endl;
+#endif
+        std::exit(error_code);
+    }
+}
+
+
+void CudaUVMSpace::raw_free(void *ptr) const noexcept
+{
+    cuda::device_guard g(this->get_device_id());
+    auto error_code = cudaFree(ptr);
+    if (error_code != cudaSuccess) {
+#if GKO_VERBOSE_LEVEL >= 1
+        // Unfortunately, if memory free fails, there's not much we can do
+        std::cerr << "Unrecoverable CUDA error on device " << this->device_id_
+                  << " in " << __func__ << ": " << cudaGetErrorName(error_code)
+                  << ": " << cudaGetErrorString(error_code) << std::endl
+                  << "Exiting program" << std::endl;
+#endif
+        std::exit(error_code);
+    }
+}
+
+
+void *CudaMemorySpace::raw_alloc(size_type num_bytes) const
+{
+    void *dev_ptr = nullptr;
+    cuda::device_guard g(this->get_device_id());
+    auto error_code = cudaMalloc(&dev_ptr, num_bytes);
+    if (error_code != cudaErrorMemoryAllocation) {
+        GKO_ASSERT_NO_CUDA_ERRORS(error_code);
+    }
+    GKO_ENSURE_ALLOCATED(dev_ptr, "cuda", num_bytes);
+    return dev_ptr;
+}
+
+
+void CudaMemorySpace::raw_copy_to(const HostMemorySpace *, size_type num_bytes,
+                                  const void *src_ptr, void *dest_ptr) const
+{
+    if (num_bytes > 0) {
+        cuda::device_guard g(this->get_device_id());
+        GKO_ASSERT_NO_CUDA_ERRORS(
+            cudaMemcpy(dest_ptr, src_ptr, num_bytes, cudaMemcpyDeviceToHost));
+    }
+}
+
+
+void CudaMemorySpace::raw_copy_to(const CudaMemorySpace *dest,
+                                  size_type num_bytes, const void *src_ptr,
+                                  void *dest_ptr) const
+{
+    if (num_bytes > 0) {
+        cuda::device_guard g(this->get_device_id());
+        GKO_ASSERT_NO_CUDA_ERRORS(
+            cudaMemcpyPeer(dest_ptr, dest->get_device_id(), src_ptr,
+                           this->get_device_id(), num_bytes));
+    }
+}
+
+
+void CudaUVMSpace::raw_copy_to(const HipMemorySpace *dest, size_type num_bytes,
+                               const void *src_ptr, void *dest_ptr) const
+{
+#if GINKGO_HIP_PLATFORM_NVCC == 1
+    if (num_bytes > 0) {
+        cuda::device_guard g(this->get_device_id());
+        GKO_ASSERT_NO_CUDA_ERRORS(
+            cudaMemcpyPeer(dest_ptr, dest->get_device_id(), src_ptr,
+                           this->get_device_id(), num_bytes));
+    }
+#else
+    GKO_NOT_SUPPORTED(this);
+#endif
+}
+
+
+void CudaMemorySpace::raw_copy_to(const HipMemorySpace *dest,
+                                  size_type num_bytes, const void *src_ptr,
+                                  void *dest_ptr) const
+{
+#if GINKGO_HIP_PLATFORM_NVCC == 1
+    if (num_bytes > 0) {
+        cuda::device_guard g(this->get_device_id());
+        GKO_ASSERT_NO_CUDA_ERRORS(
+            cudaMemcpyPeer(dest_ptr, dest->get_device_id(), src_ptr,
+                           this->get_device_id(), num_bytes));
+    }
+#else
+    GKO_NOT_SUPPORTED(this);
+#endif
+}
+
+
+void CudaMemorySpace::raw_copy_to(const CudaUVMSpace *dest, size_type num_bytes,
+                                  const void *src_ptr, void *dest_ptr) const
+{
+    if (num_bytes > 0) {
+        cuda::device_guard g(this->get_device_id());
+        GKO_ASSERT_NO_CUDA_ERRORS(
+            cudaMemcpyPeer(dest_ptr, dest->get_device_id(), src_ptr,
+                           this->get_device_id(), num_bytes));
+    }
+}
+
+
+void CudaUVMSpace::raw_copy_to(const CudaMemorySpace *dest, size_type num_bytes,
+                               const void *src_ptr, void *dest_ptr) const
+{
+    if (num_bytes > 0) {
+        cuda::device_guard g(this->get_device_id());
+        GKO_ASSERT_NO_CUDA_ERRORS(
+            cudaMemcpyPeer(dest_ptr, dest->get_device_id(), src_ptr,
+                           this->get_device_id(), num_bytes));
+    }
+}
+
+
+void CudaUVMSpace::raw_copy_to(const CudaUVMSpace *dest, size_type num_bytes,
+                               const void *src_ptr, void *dest_ptr) const
+{
+    if (num_bytes > 0) {
+        cuda::device_guard g(this->get_device_id());
+        GKO_ASSERT_NO_CUDA_ERRORS(
+            cudaMemcpyPeer(dest_ptr, dest->get_device_id(), src_ptr,
+                           this->get_device_id(), num_bytes));
+    }
+}
+
+
+void HostMemorySpace::raw_copy_to(const CudaUVMSpace *dest, size_type num_bytes,
+                                  const void *src_ptr, void *dest_ptr) const
+{
+    if (num_bytes > 0) {
+        cuda::device_guard g(dest->get_device_id());
+        GKO_ASSERT_NO_CUDA_ERRORS(
+            cudaMemcpy(dest_ptr, src_ptr, num_bytes, cudaMemcpyHostToDevice));
+    }
+}
+
+
+void *CudaUVMSpace::raw_alloc(size_type num_bytes) const
+{
+    void *dev_ptr = nullptr;
+    cuda::device_guard g(this->get_device_id());
+    auto error_code = cudaMallocManaged(&dev_ptr, num_bytes);
+    if (error_code != cudaErrorMemoryAllocation) {
+        GKO_ASSERT_NO_CUDA_ERRORS(error_code);
+    }
+    GKO_ENSURE_ALLOCATED(dev_ptr, "cuda", num_bytes);
+    return dev_ptr;
+}
+
+
+void CudaUVMSpace::raw_copy_to(const HostMemorySpace *, size_type num_bytes,
+                               const void *src_ptr, void *dest_ptr) const
+{
+    if (num_bytes > 0) {
+        cuda::device_guard g(this->get_device_id());
+        GKO_ASSERT_NO_CUDA_ERRORS(
+            cudaMemcpy(dest_ptr, src_ptr, num_bytes, cudaMemcpyDeviceToHost));
+    }
+}
+
+
+}  // namespace gko

--- a/cuda/factorization/par_ilut_select_common.cu
+++ b/cuda/factorization/par_ilut_select_common.cu
@@ -100,7 +100,8 @@ sampleselect_bucket<IndexType> sampleselect_find_bucket(
 {
     kernel::find_bucket<<<1, config::warp_size>>>(prefix_sum, rank);
     IndexType values[3]{};
-    exec->get_master()->copy_from(exec.get(), 3, prefix_sum, values);
+    exec->get_master()->get_mem_space()->copy_from(exec->get_mem_space().get(),
+                                                   3, prefix_sum, values);
     return {values[0], values[1], values[2]};
 }
 

--- a/cuda/solver/common_trs_kernels.cuh
+++ b/cuda/solver/common_trs_kernels.cuh
@@ -222,10 +222,12 @@ void generate_kernel(std::shared_ptr<const CudaExecutor> exec,
 
                 // allocate workspace
                 if (cuda_solve_struct->factor_work_vec != nullptr) {
-                    exec->free(cuda_solve_struct->factor_work_vec);
+                    exec->get_mem_space()->free(
+                        cuda_solve_struct->factor_work_vec);
                 }
                 cuda_solve_struct->factor_work_vec =
-                    exec->alloc<void *>(cuda_solve_struct->factor_work_size);
+                    exec->get_mem_space()->alloc<void *>(
+                        cuda_solve_struct->factor_work_size);
 
                 cusparse::csrsm2_analysis(
                     handle, cuda_solve_struct->algorithm,

--- a/cuda/test/base/CMakeLists.txt
+++ b/cuda/test/base/CMakeLists.txt
@@ -1,4 +1,5 @@
 ginkgo_create_cuda_test(cuda_executor)
+ginkgo_create_cuda_test(cuda_memory_space)
 ginkgo_create_cuda_test(exception_helpers)
 ginkgo_create_cuda_test(lin_op)
 ginkgo_create_cuda_test(math)

--- a/cuda/test/base/cuda_executor.cu
+++ b/cuda/test/base/cuda_executor.cu
@@ -131,12 +131,12 @@ TEST_F(CudaExecutor, PreservesDeviceSettings)
 {
     auto previous_device = gko::CudaExecutor::get_num_devices() - 1;
     GKO_ASSERT_NO_CUDA_ERRORS(cudaSetDevice(previous_device));
-    auto orig = cuda->alloc<int>(2);
+    auto orig = cuda->get_mem_space()->alloc<int>(2);
     int current_device;
     GKO_ASSERT_NO_CUDA_ERRORS(cudaGetDevice(&current_device));
     ASSERT_EQ(current_device, previous_device);
 
-    cuda->free(orig);
+    cuda->get_mem_space()->free(orig);
     GKO_ASSERT_NO_CUDA_ERRORS(cudaGetDevice(&current_device));
     ASSERT_EQ(current_device, previous_device);
 }

--- a/cuda/test/base/cuda_executor.cu
+++ b/cuda/test/base/cuda_executor.cu
@@ -126,71 +126,6 @@ TEST_F(CudaExecutor, MasterKnowsNumberOfDevices)
 }
 
 
-TEST_F(CudaExecutor, AllocatesAndFreesMemory)
-{
-    int *ptr = nullptr;
-
-    ASSERT_NO_THROW(ptr = cuda->alloc<int>(2));
-    ASSERT_NO_THROW(cuda->free(ptr));
-}
-
-
-TEST_F(CudaExecutor, FailsWhenOverallocating)
-{
-    const gko::size_type num_elems = 1ll << 50;  // 4PB of integers
-    int *ptr = nullptr;
-
-    ASSERT_THROW(
-        {
-            ptr = cuda->alloc<int>(num_elems);
-            cuda->synchronize();
-        },
-        gko::AllocationError);
-
-    cuda->free(ptr);
-}
-
-
-__global__ void check_data(int *data)
-{
-    if (data[0] != 3 || data[1] != 8) {
-        asm("trap;");
-    }
-}
-
-TEST_F(CudaExecutor, CopiesDataToCuda)
-{
-    int orig[] = {3, 8};
-    auto *copy = cuda->alloc<int>(2);
-
-    cuda->copy_from(omp.get(), 2, orig, copy);
-
-    check_data<<<1, 1>>>(copy);
-    ASSERT_NO_THROW(cuda->synchronize());
-    cuda->free(copy);
-}
-
-
-__global__ void init_data(int *data)
-{
-    data[0] = 3;
-    data[1] = 8;
-}
-
-TEST_F(CudaExecutor, CopiesDataFromCuda)
-{
-    int copy[2];
-    auto orig = cuda->alloc<int>(2);
-    init_data<<<1, 1>>>(orig);
-
-    omp->copy_from(cuda.get(), 2, orig, copy);
-
-    EXPECT_EQ(3, copy[0]);
-    ASSERT_EQ(8, copy[1]);
-    cuda->free(orig);
-}
-
-
 /* Properly checks if it works only when multiple GPUs exist */
 TEST_F(CudaExecutor, PreservesDeviceSettings)
 {
@@ -215,32 +150,6 @@ TEST_F(CudaExecutor, RunsOnProperDevice)
     cuda2->run(ExampleOperation(value));
 
     ASSERT_EQ(value, cuda2->get_device_id());
-}
-
-
-TEST_F(CudaExecutor, CopiesDataFromCudaToCuda)
-{
-    int copy[2];
-    auto orig = cuda->alloc<int>(2);
-    GKO_ASSERT_NO_CUDA_ERRORS(cudaSetDevice(0));
-    init_data<<<1, 1>>>(orig);
-
-    auto copy_cuda2 = cuda2->alloc<int>(2);
-    cuda2->copy_from(cuda.get(), 2, orig, copy_cuda2);
-
-    // Check that the data is really on GPU2 and ensure we did not cheat
-    int value = -1;
-    GKO_ASSERT_NO_CUDA_ERRORS(cudaSetDevice(cuda2->get_device_id()));
-    check_data<<<1, 1>>>(copy_cuda2);
-    GKO_ASSERT_NO_CUDA_ERRORS(cudaSetDevice(0));
-    cuda2->run(ExampleOperation(value));
-    ASSERT_EQ(value, cuda2->get_device_id());
-    // Put the results on OpenMP and run CPU side assertions
-    omp->copy_from(cuda2.get(), 2, copy_cuda2, copy);
-    EXPECT_EQ(3, copy[0]);
-    ASSERT_EQ(8, copy[1]);
-    cuda->free(copy_cuda2);
-    cuda->free(orig);
 }
 
 

--- a/cuda/test/base/cuda_memory_space.cu
+++ b/cuda/test/base/cuda_memory_space.cu
@@ -1,0 +1,238 @@
+/*******************************<GINKGO LICENSE>******************************
+Copyright (c) 2017-2020, the Ginkgo authors
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+******************************<GINKGO LICENSE>*******************************/
+
+#include <ginkgo/core/base/executor.hpp>
+#include <ginkgo/core/base/memory_space.hpp>
+
+
+#include <type_traits>
+
+
+#include <gtest/gtest.h>
+
+
+#include <ginkgo/core/base/exception.hpp>
+#include <ginkgo/core/base/exception_helpers.hpp>
+
+
+namespace {
+
+
+class CudaMemorySpace : public ::testing::Test {
+protected:
+    CudaMemorySpace() : cuda(nullptr), cuda2(nullptr) {}
+
+    void SetUp()
+    {
+        omp = gko::HostMemorySpace::create();
+        cuda = gko::CudaMemorySpace::create(0);
+        cuda2 = gko::CudaMemorySpace::create(
+            gko::CudaMemorySpace::get_num_devices() - 1);
+    }
+
+    void TearDown()
+    {
+        if (cuda != nullptr) {
+            // ensure that previous calls finished and didn't throw an error
+            ASSERT_NO_THROW(cuda->synchronize());
+        }
+        if (cuda2 != nullptr) {
+            // ensure that previous calls finished and didn't throw an error
+            ASSERT_NO_THROW(cuda2->synchronize());
+        }
+    }
+
+    std::shared_ptr<gko::HostMemorySpace> omp;
+    std::shared_ptr<gko::CudaMemorySpace> cuda;
+    std::shared_ptr<gko::CudaMemorySpace> cuda2;
+};
+
+
+TEST_F(CudaMemorySpace, AllocatesAndFreesMemory)
+{
+    int *ptr = nullptr;
+
+    ASSERT_NO_THROW(ptr = cuda->alloc<int>(2));
+    ASSERT_NO_THROW(cuda->free(ptr));
+}
+
+
+TEST_F(CudaMemorySpace, FailsWhenOverallocating)
+{
+    const gko::size_type num_elems = 1ll << 50;  // 4PB of integers
+    int *ptr = nullptr;
+
+    ASSERT_THROW(
+        {
+            ptr = cuda->alloc<int>(num_elems);
+            cuda->synchronize();
+        },
+        gko::AllocationError);
+
+    cuda->free(ptr);
+}
+
+
+__global__ void check_data(int *data)
+{
+    if (data[0] != 3 || data[1] != 8) {
+        asm("trap;");
+    }
+}
+
+
+TEST_F(CudaMemorySpace, CopiesDataToCuda)
+{
+    int orig[] = {3, 8};
+    auto *copy = cuda->alloc<int>(2);
+
+    cuda->copy_from(omp.get(), 2, orig, copy);
+
+    check_data<<<1, 1>>>(copy);
+    ASSERT_NO_THROW(cuda->synchronize());
+    cuda->free(copy);
+}
+
+
+__global__ void init_data(int *data)
+{
+    data[0] = 3;
+    data[1] = 8;
+}
+
+TEST_F(CudaMemorySpace, CopiesDataFromCuda)
+{
+    int copy[2];
+    auto orig = cuda->alloc<int>(2);
+    init_data<<<1, 1>>>(orig);
+
+    omp->copy_from(cuda.get(), 2, orig, copy);
+
+    EXPECT_EQ(3, copy[0]);
+    ASSERT_EQ(8, copy[1]);
+    cuda->free(orig);
+}
+
+
+TEST_F(CudaMemorySpace, CopiesDataFromCudaToCuda)
+{
+    int copy[2];
+    auto orig = cuda->alloc<int>(2);
+    GKO_ASSERT_NO_CUDA_ERRORS(cudaSetDevice(0));
+    init_data<<<1, 1>>>(orig);
+
+    auto copy_cuda2 = cuda2->alloc<int>(2);
+    cuda2->copy_from(cuda.get(), 2, orig, copy_cuda2);
+
+    // Check that the data is really on GPU2 and ensure we did not cheat
+    GKO_ASSERT_NO_CUDA_ERRORS(cudaSetDevice(cuda2->get_device_id()));
+    check_data<<<1, 1>>>(copy_cuda2);
+    GKO_ASSERT_NO_CUDA_ERRORS(cudaSetDevice(0));
+
+    omp->copy_from(cuda2.get(), 2, copy_cuda2, copy);
+
+    EXPECT_EQ(3, copy[0]);
+    ASSERT_EQ(8, copy[1]);
+    cuda2->free(copy_cuda2);
+    cuda->free(orig);
+}
+
+
+class CudaUVMSpace : public ::testing::Test {
+protected:
+    CudaUVMSpace() : cuda_uvm(nullptr) {}
+
+    void SetUp() { cuda_uvm = gko::CudaUVMSpace::create(0); }
+
+    void TearDown()
+    {
+        if (cuda_uvm != nullptr) {
+            // ensure that previous calls finished and didn't throw an error
+            // ASSERT_NO_THROW(cuda_uvm->synchronize());
+            cuda_uvm->synchronize();
+        }
+    }
+
+    std::shared_ptr<gko::CudaUVMSpace> cuda_uvm;
+};
+
+
+TEST_F(CudaUVMSpace, UVMAllocatesAndFreesMemory)
+{
+    int *ptr = nullptr;
+
+    ASSERT_NO_THROW(ptr = cuda_uvm->alloc<int>(2));
+    cuda_uvm->synchronize();
+    ASSERT_NO_THROW(cuda_uvm->free(ptr));
+}
+
+
+// TEST_F(CudaUVMSpace, UVMFailsWhenOverallocating)
+// {
+//     const gko::size_type num_elems = 1ll << 50;  // 4PB of integers
+//     int *ptr = nullptr;
+
+//     ASSERT_THROW(
+//         {
+//             ptr = cuda_uvm->alloc<int>(num_elems);
+//             cuda_uvm->synchronize();
+//         },
+//         gko::AllocationError);
+
+//     cuda_uvm->free(ptr);
+// }
+
+
+TEST_F(CudaUVMSpace, CanBeAccessedFromHost)
+{
+    int *orig = cuda_uvm->alloc<int>(2);
+    orig[0] = 1;
+    orig[1] = 2;
+    ASSERT_EQ(orig[0], 1);
+    ASSERT_EQ(orig[1], 2);
+    cuda_uvm->synchronize();
+    cuda_uvm->free(orig);
+}
+
+
+TEST_F(CudaUVMSpace, CanBeAccessedFromDevice)
+{
+    int *orig = cuda_uvm->alloc<int>(2);
+    orig[0] = 3;
+    orig[1] = 8;
+    check_data<<<1, 1>>>(orig);
+    cuda_uvm->synchronize();
+    cuda_uvm->free(orig);
+}
+
+
+}  // namespace

--- a/examples/adaptiveprecision-blockjacobi/adaptiveprecision-blockjacobi.cpp
+++ b/examples/adaptiveprecision-blockjacobi/adaptiveprecision-blockjacobi.cpp
@@ -111,7 +111,7 @@ int main(int argc, char *argv[])
                         .on(exec);
 
     std::shared_ptr<const gko::log::Convergence<ValueType>> logger =
-        gko::log::Convergence<ValueType>::create(exec);
+        gko::log::Convergence<ValueType>::create(exec, exec->get_mem_space());
     iter_stop->add_logger(logger);
     tol_stop->add_logger(logger);
 

--- a/examples/custom-logger/custom-logger.cpp
+++ b/examples/custom-logger/custom-logger.cpp
@@ -171,7 +171,8 @@ struct ResidualLogger : gko::log::Logger {
     // Construct the logger and store the system matrix and b vectors
     ResidualLogger(std::shared_ptr<const gko::Executor> exec,
                    const gko::LinOp *matrix, const gko_dense *b)
-        : gko::log::Logger(exec, gko::log::Logger::iteration_complete_mask),
+        : gko::log::Logger(exec, exec->get_mem_space(),
+                           gko::log::Logger::iteration_complete_mask),
           matrix{matrix},
           b{b}
     {}

--- a/examples/custom-stopping-criterion/custom-stopping-criterion.cpp
+++ b/examples/custom-stopping-criterion/custom-stopping-criterion.cpp
@@ -117,7 +117,8 @@ void run_solver(volatile bool *stop_iteration_process,
                       .on(exec)
                       ->generate(A);
     solver->add_logger(gko::log::Stream<ValueType>::create(
-        exec, gko::log::Logger::iteration_complete_mask, std::cout, true));
+        exec, exec->get_mem_space(), gko::log::Logger::iteration_complete_mask,
+        std::cout, true));
     solver->apply(lend(b), lend(x));
 
     std::cout << "Solver stopped" << std::endl;

--- a/examples/ir-ilu-preconditioned-solver/ir-ilu-preconditioned-solver.cpp
+++ b/examples/ir-ilu-preconditioned-solver/ir-ilu-preconditioned-solver.cpp
@@ -143,7 +143,7 @@ int main(int argc, char *argv[])
                         .on(exec);
 
     std::shared_ptr<const gko::log::Convergence<ValueType>> logger =
-        gko::log::Convergence<ValueType>::create(exec);
+        gko::log::Convergence<ValueType>::create(exec, exec->get_mem_space());
     iter_stop->add_logger(logger);
     tol_stop->add_logger(logger);
 

--- a/examples/iterative-refinement/iterative-refinement.cpp
+++ b/examples/iterative-refinement/iterative-refinement.cpp
@@ -113,7 +113,7 @@ int main(int argc, char *argv[])
                         .on(exec);
 
     std::shared_ptr<const gko::log::Convergence<ValueType>> logger =
-        gko::log::Convergence<ValueType>::create(exec);
+        gko::log::Convergence<ValueType>::create(exec, exec->get_mem_space());
     iter_stop->add_logger(logger);
     tol_stop->add_logger(logger);
 

--- a/examples/papi-logging/papi-logging.cpp
+++ b/examples/papi-logging/papi-logging.cpp
@@ -140,8 +140,7 @@ int main(int argc, char *argv[])
     std::cout << gko::version_info::get() << std::endl;
 
     if (argc == 2 && (std::string(argv[1]) == "--help")) {
-        std::cerr << "Usage: " << argv[0] << " [executor]"
-                  << std::endl;
+        std::cerr << "Usage: " << argv[0] << " [executor]" << std::endl;
         std::exit(-1);
     }
 
@@ -192,8 +191,9 @@ int main(int argc, char *argv[])
 
     // Create a PAPI logger and add it to relevant LinOps
     auto logger = gko::log::Papi<ValueType>::create(
-        exec, gko::log::Logger::linop_apply_completed_mask |
-                  gko::log::Logger::linop_advanced_apply_completed_mask);
+        exec, exec->get_mem_space(),
+        gko::log::Logger::linop_apply_completed_mask |
+            gko::log::Logger::linop_advanced_apply_completed_mask);
     solver->add_logger(logger);
     A->add_logger(logger);
 

--- a/examples/performance-debugging/performance-debugging.cpp
+++ b/examples/performance-debugging/performance-debugging.cpp
@@ -116,41 +116,43 @@ namespace loggers {
 // taken before and after. This can create significant overhead since to ensure
 // proper timings, calls to `synchronize` are required.
 struct OperationLogger : gko::log::Logger {
-    void on_allocation_started(const gko::Executor *exec,
+    void on_allocation_started(const gko::MemorySpace *mem_space,
                                const gko::size_type &) const override
     {
-        this->start_operation(exec, "allocate");
+        this->start_operation(mem_space, "allocate");
     }
 
-    void on_allocation_completed(const gko::Executor *exec,
+    void on_allocation_completed(const gko::MemorySpace *mem_space,
                                  const gko::size_type &,
                                  const gko::uintptr &) const override
     {
-        this->end_operation(exec, "allocate");
+        this->end_operation(mem_space, "allocate");
     }
 
-    void on_free_started(const gko::Executor *exec,
+    void on_free_started(const gko::MemorySpace *mem_space,
                          const gko::uintptr &) const override
     {
-        this->start_operation(exec, "free");
+        this->start_operation(mem_space, "free");
     }
 
-    void on_free_completed(const gko::Executor *exec,
+    void on_free_completed(const gko::MemorySpace *mem_space,
                            const gko::uintptr &) const override
     {
-        this->end_operation(exec, "free");
+        this->end_operation(mem_space, "free");
     }
 
-    void on_copy_started(const gko::Executor *from, const gko::Executor *to,
-                         const gko::uintptr &, const gko::uintptr &,
+    void on_copy_started(const gko::MemorySpace *from,
+                         const gko::MemorySpace *to, const gko::uintptr &,
+                         const gko::uintptr &,
                          const gko::size_type &) const override
     {
         from->synchronize();
         this->start_operation(to, "copy");
     }
 
-    void on_copy_completed(const gko::Executor *from, const gko::Executor *to,
-                           const gko::uintptr &, const gko::uintptr &,
+    void on_copy_completed(const gko::MemorySpace *from,
+                           const gko::MemorySpace *to, const gko::uintptr &,
+                           const gko::uintptr &,
                            const gko::size_type &) const override
     {
         from->synchronize();
@@ -181,24 +183,25 @@ struct OperationLogger : gko::log::Logger {
     }
 
     OperationLogger(std::shared_ptr<const gko::Executor> exec)
-        : gko::log::Logger(exec)
+        : gko::log::Logger(exec, exec->get_mem_space())
     {}
 
 private:
     // Helper which synchronizes and starts the time before every operation.
-    void start_operation(const gko::Executor *exec,
-                         const std::string &name) const
+    template <typename Event>
+    void start_operation(const Event *event, const std::string &name) const
     {
         nested.emplace_back(0);
-        exec->synchronize();
+        event->synchronize();
         start[name] = std::chrono::steady_clock::now();
     }
 
     // Helper to compute the end time and store the operation's time at its
     // end. Also time nested operations.
-    void end_operation(const gko::Executor *exec, const std::string &name) const
+    template <typename Event>
+    void end_operation(const Event *event, const std::string &name) const
     {
-        exec->synchronize();
+        event->synchronize();
         const auto end = std::chrono::steady_clock::now();
         const auto diff = end - start[name];
         // make sure timings for nested operations are not counted twice
@@ -220,7 +223,7 @@ private:
 // This logger tracks the persistently allocated data
 struct StorageLogger : gko::log::Logger {
     // Store amount of bytes allocated on every allocation
-    void on_allocation_completed(const gko::Executor *,
+    void on_allocation_completed(const gko::MemorySpace *,
                                  const gko::size_type &num_bytes,
                                  const gko::uintptr &location) const override
     {
@@ -228,7 +231,7 @@ struct StorageLogger : gko::log::Logger {
     }
 
     // Reset the amount of bytes on every free
-    void on_free_completed(const gko::Executor *,
+    void on_free_completed(const gko::MemorySpace *,
                            const gko::uintptr &location) const override
     {
         storage[location] = 0;
@@ -245,7 +248,7 @@ struct StorageLogger : gko::log::Logger {
     }
 
     StorageLogger(std::shared_ptr<const gko::Executor> exec)
-        : gko::log::Logger(exec)
+        : gko::log::Logger(exec, exec->get_mem_space())
     {}
 
 private:
@@ -281,7 +284,8 @@ struct ResidualLogger : gko::log::Logger {
 
     ResidualLogger(std::shared_ptr<const gko::Executor> exec,
                    const gko::LinOp *matrix, const vec<ValueType> *b)
-        : gko::log::Logger(exec, gko::log::Logger::iteration_complete_mask),
+        : gko::log::Logger(exec, exec->get_mem_space(),
+                           gko::log::Logger::iteration_complete_mask),
           matrix{matrix},
           b{b}
     {}
@@ -370,8 +374,7 @@ int main(int argc, char *argv[])
 
     // Figure out where to run the code
     if (argc == 2 && (std::string(argv[1]) == "--help")) {
-        std::cerr << "Usage: " << argv[0] << " [executor]"
-                  << std::endl;
+        std::cerr << "Usage: " << argv[0] << " [executor]" << std::endl;
         std::exit(-1);
     }
 

--- a/examples/simple-solver-logging/simple-solver-logging.cpp
+++ b/examples/simple-solver-logging/simple-solver-logging.cpp
@@ -109,7 +109,7 @@ int main(int argc, char *argv[])
     // for convenience.
     std::shared_ptr<gko::log::Stream<ValueType>> stream_logger =
         gko::log::Stream<ValueType>::create(
-            exec,
+            exec, exec->get_mem_space(),
             gko::log::Logger::all_events_mask ^
                 gko::log::Logger::linop_factory_events_mask ^
                 gko::log::Logger::polymorphic_object_events_mask,
@@ -146,15 +146,17 @@ int main(int argc, char *argv[])
     // Logger class for more information.
     std::ofstream filestream("my_file.txt");
     solver->add_logger(gko::log::Stream<ValueType>::create(
-        exec, gko::log::Logger::all_events_mask, filestream));
+        exec, exec->get_mem_space(), gko::log::Logger::all_events_mask,
+        filestream));
     solver->add_logger(stream_logger);
 
     // Add another logger which puts all the data in an object, we can later
     // retrieve this object in our code. Here we only have want Executor
     // and criterion check completed events.
     std::shared_ptr<gko::log::Record> record_logger = gko::log::Record::create(
-        exec, gko::log::Logger::executor_events_mask |
-                  gko::log::Logger::criterion_check_completed_mask);
+        exec, exec->get_mem_space(),
+        gko::log::Logger::memory_space_events_mask |
+            gko::log::Logger::criterion_check_completed_mask);
     exec->add_logger(record_logger);
     residual_criterion->add_logger(record_logger);
 
@@ -165,10 +167,10 @@ int main(int argc, char *argv[])
     // location copied
     auto &last_copy = record_logger->get().copy_completed.back();
     std::cout << "Last memory copied was of size " << std::hex
-              << std::get<0>(*last_copy).num_bytes << " FROM executor "
-              << std::get<0>(*last_copy).exec << " pointer "
-              << std::get<0>(*last_copy).location << " TO executor "
-              << std::get<1>(*last_copy).exec << " pointer "
+              << std::get<0>(*last_copy).num_bytes << " FROM Memory Space"
+              << std::get<0>(*last_copy).mem_space << " pointer "
+              << std::get<0>(*last_copy).location << " TO Memory Space "
+              << std::get<1>(*last_copy).mem_space << " pointer "
               << std::get<1>(*last_copy).location << std::dec << std::endl;
     // Also print the residual of the last criterion check event (where
     // convergence happened)

--- a/hip/CMakeLists.txt
+++ b/hip/CMakeLists.txt
@@ -142,6 +142,7 @@ endif()
 set(GINKGO_HIP_SOURCES
     base/exception.hip.cpp
     base/executor.hip.cpp
+    base/memory_space.hip.cpp
     base/version.hip.cpp
     components/absolute_array.hip.cpp
     components/fill_array.hip.cpp

--- a/hip/base/memory_space.hip.cpp
+++ b/hip/base/memory_space.hip.cpp
@@ -1,0 +1,170 @@
+/*******************************<GINKGO LICENSE>******************************
+Copyright (c) 2017-2020, the Ginkgo authors
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+******************************<GINKGO LICENSE>*******************************/
+
+#include <ginkgo/core/base/memory_space.hpp>
+
+
+#include <iostream>
+
+
+#include <hip/hip_runtime.h>
+
+
+#include <ginkgo/config.hpp>
+#include <ginkgo/core/base/exception_helpers.hpp>
+
+
+#include "hip/base/device_guard.hip.hpp"
+
+
+namespace gko {
+
+
+void HostMemorySpace::raw_copy_to(const HipMemorySpace *dest,
+                                  size_type num_bytes, const void *src_ptr,
+                                  void *dest_ptr) const
+{
+    if (num_bytes > 0) {
+        hip::device_guard g(dest->get_device_id());
+        GKO_ASSERT_NO_HIP_ERRORS(
+            hipMemcpy(dest_ptr, src_ptr, num_bytes, hipMemcpyHostToDevice));
+    }
+}
+
+
+void HipMemorySpace::raw_free(void *ptr) const noexcept
+{
+    hip::device_guard g(this->get_device_id());
+    auto error_code = hipFree(ptr);
+    if (error_code != hipSuccess) {
+#if GKO_VERBOSE_LEVEL >= 1
+        // Unfortunately, if memory free fails, there's not much we can do
+        std::cerr << "Unrecoverable HIP error on device " << this->device_id_
+                  << " in " << __func__ << ": " << hipGetErrorName(error_code)
+                  << ": " << hipGetErrorString(error_code) << std::endl
+                  << "Exiting program" << std::endl;
+#endif
+        std::exit(error_code);
+    }
+}
+
+
+void *HipMemorySpace::raw_alloc(size_type num_bytes) const
+{
+    void *dev_ptr = nullptr;
+    hip::device_guard g(this->get_device_id());
+    auto error_code = hipMalloc(&dev_ptr, num_bytes);
+    if (error_code != hipErrorMemoryAllocation) {
+        GKO_ASSERT_NO_HIP_ERRORS(error_code);
+    }
+    GKO_ENSURE_ALLOCATED(dev_ptr, "hip", num_bytes);
+    return dev_ptr;
+}
+
+
+void HipMemorySpace::raw_copy_to(const HostMemorySpace *, size_type num_bytes,
+                                 const void *src_ptr, void *dest_ptr) const
+{
+    if (num_bytes > 0) {
+        hip::device_guard g(this->get_device_id());
+        GKO_ASSERT_NO_HIP_ERRORS(
+            hipMemcpy(dest_ptr, src_ptr, num_bytes, hipMemcpyDeviceToHost));
+    }
+}
+
+
+void HipMemorySpace::raw_copy_to(const CudaMemorySpace *dest,
+                                 size_type num_bytes, const void *src_ptr,
+                                 void *dest_ptr) const
+{
+#if GINKGO_HIP_PLATFORM_NVCC == 1
+    if (num_bytes > 0) {
+        hip::device_guard g(this->get_device_id());
+        GKO_ASSERT_NO_HIP_ERRORS(hipMemcpyPeer(dest_ptr, dest->get_device_id(),
+                                               src_ptr, this->get_device_id(),
+                                               num_bytes));
+    }
+#else
+    GKO_NOT_SUPPORTED(this);
+#endif
+}
+
+
+void HipMemorySpace::raw_copy_to(const CudaUVMSpace *dest, size_type num_bytes,
+                                 const void *src_ptr, void *dest_ptr) const
+{
+#if GINKGO_HIP_PLATFORM_NVCC == 1
+    if (num_bytes > 0) {
+        hip::device_guard g(this->get_device_id());
+        GKO_ASSERT_NO_HIP_ERRORS(hipMemcpyPeer(dest_ptr, dest->get_device_id(),
+                                               src_ptr, this->get_device_id(),
+                                               num_bytes));
+    }
+#else
+    GKO_NOT_SUPPORTED(this);
+#endif
+}
+
+
+void HipMemorySpace::raw_copy_to(const HipMemorySpace *dest,
+                                 size_type num_bytes, const void *src_ptr,
+                                 void *dest_ptr) const
+{
+    if (num_bytes > 0) {
+        hip::device_guard g(this->get_device_id());
+        GKO_ASSERT_NO_HIP_ERRORS(hipMemcpyPeer(dest_ptr, dest->get_device_id(),
+                                               src_ptr, this->get_device_id(),
+                                               num_bytes));
+    }
+}
+
+
+void HipMemorySpace::synchronize() const
+{
+    hip::device_guard g(this->get_device_id());
+    GKO_ASSERT_NO_HIP_ERRORS(hipDeviceSynchronize());
+}
+
+
+int HipMemorySpace::get_num_devices()
+{
+    int deviceCount = 0;
+    auto error_code = hipGetDeviceCount(&deviceCount);
+    if (error_code == hipErrorNoDevice) {
+        return 0;
+    }
+    GKO_ASSERT_NO_HIP_ERRORS(error_code);
+    return deviceCount;
+}
+
+
+}  // namespace gko

--- a/hip/factorization/par_ilut_select_common.hip.cpp
+++ b/hip/factorization/par_ilut_select_common.hip.cpp
@@ -109,7 +109,8 @@ sampleselect_bucket<IndexType> sampleselect_find_bucket(
     hipLaunchKernelGGL(HIP_KERNEL_NAME(kernel::find_bucket), dim3(1),
                        dim3(config::warp_size), 0, 0, prefix_sum, rank);
     IndexType values[3]{};
-    exec->get_master()->copy_from(exec.get(), 3, prefix_sum, values);
+    exec->get_master()->get_mem_space()->copy_from(exec->get_mem_space().get(),
+                                                   3, prefix_sum, values);
     return {values[0], values[1], values[2]};
 }
 

--- a/hip/solver/common_trs_kernels.hip.hpp
+++ b/hip/solver/common_trs_kernels.hip.hpp
@@ -159,10 +159,10 @@ void generate_kernel(std::shared_ptr<const HipExecutor> exec,
 
                 // allocate workspace
                 if (hip_solve_struct->factor_work_vec != nullptr) {
-                    exec->free(hip_solve_struct->factor_work_vec);
+                    exec->get_mem_space()->free(hip_solve_struct->factor_work_vec);
                 }
                 hip_solve_struct->factor_work_vec =
-                    exec->alloc<void *>(hip_solve_struct->factor_work_size);
+                    exec->get_mem_space()->alloc<void *>(hip_solve_struct->factor_work_size);
 
                 hipsparse::csrsv2_analysis(
                     handle, HIPSPARSE_OPERATION_NON_TRANSPOSE,

--- a/hip/test/base/CMakeLists.txt
+++ b/hip/test/base/CMakeLists.txt
@@ -1,4 +1,5 @@
 ginkgo_create_hip_test(hip_executor)
+ginkgo_create_hip_test(hip_memory_space)
 ginkgo_create_hip_test(lin_op)
 ginkgo_create_hip_test(math)
 # Only hcc needs the libraries. nvcc only requires the headers.

--- a/hip/test/base/hip_executor.hip.cpp
+++ b/hip/test/base/hip_executor.hip.cpp
@@ -131,75 +131,6 @@ TEST_F(HipExecutor, MasterKnowsNumberOfDevices)
 }
 
 
-TEST_F(HipExecutor, AllocatesAndFreesMemory)
-{
-    int *ptr = nullptr;
-
-    ASSERT_NO_THROW(ptr = hip->alloc<int>(2));
-    ASSERT_NO_THROW(hip->free(ptr));
-}
-
-
-TEST_F(HipExecutor, FailsWhenOverallocating)
-{
-    const gko::size_type num_elems = 1ll << 50;  // 4PB of integers
-    int *ptr = nullptr;
-
-    ASSERT_THROW(
-        {
-            ptr = hip->alloc<int>(num_elems);
-            hip->synchronize();
-        },
-        gko::AllocationError);
-
-    hip->free(ptr);
-}
-
-
-__global__ void check_data(int *data)
-{
-    if (data[0] != 3 || data[1] != 8) {
-#if GINKGO_HIP_PLATFORM_HCC
-        asm("s_trap 0x02;");
-#else  // GINKGO_HIP_PLATFORM_NVCC
-        asm("trap;");
-#endif
-    }
-}
-
-TEST_F(HipExecutor, CopiesDataToHip)
-{
-    int orig[] = {3, 8};
-    auto *copy = hip->alloc<int>(2);
-
-    hip->copy_from(omp.get(), 2, orig, copy);
-
-    hipLaunchKernelGGL((check_data), dim3(1), dim3(1), 0, 0, copy);
-    ASSERT_NO_THROW(hip->synchronize());
-    hip->free(copy);
-}
-
-
-__global__ void init_data(int *data)
-{
-    data[0] = 3;
-    data[1] = 8;
-}
-
-TEST_F(HipExecutor, CopiesDataFromHip)
-{
-    int copy[2];
-    auto orig = hip->alloc<int>(2);
-    hipLaunchKernelGGL((init_data), dim3(1), dim3(1), 0, 0, orig);
-
-    omp->copy_from(hip.get(), 2, orig, copy);
-
-    EXPECT_EQ(3, copy[0]);
-    ASSERT_EQ(8, copy[1]);
-    hip->free(orig);
-}
-
-
 /* Properly checks if it works only when multiple GPUs exist */
 TEST_F(HipExecutor, PreservesDeviceSettings)
 {
@@ -224,32 +155,6 @@ TEST_F(HipExecutor, RunsOnProperDevice)
     hip2->run(ExampleOperation(value));
 
     ASSERT_EQ(value, hip2->get_device_id());
-}
-
-
-TEST_F(HipExecutor, CopiesDataFromHipToHip)
-{
-    int copy[2];
-    auto orig = hip->alloc<int>(2);
-    GKO_ASSERT_NO_HIP_ERRORS(hipSetDevice(0));
-    hipLaunchKernelGGL((init_data), dim3(1), dim3(1), 0, 0, orig);
-
-    auto copy_hip2 = hip2->alloc<int>(2);
-    hip2->copy_from(hip.get(), 2, orig, copy_hip2);
-
-    // Check that the data is really on GPU2 and ensure we did not cheat
-    int value = -1;
-    GKO_ASSERT_NO_HIP_ERRORS(hipSetDevice(hip2->get_device_id()));
-    hipLaunchKernelGGL((check_data), dim3(1), dim3(1), 0, 0, copy_hip2);
-    GKO_ASSERT_NO_HIP_ERRORS(hipSetDevice(0));
-    hip2->run(ExampleOperation(value));
-    ASSERT_EQ(value, hip2->get_device_id());
-    // Put the results on OpenMP and run CPU side assertions
-    omp->copy_from(hip2.get(), 2, copy_hip2, copy);
-    EXPECT_EQ(3, copy[0]);
-    ASSERT_EQ(8, copy[1]);
-    hip->free(copy_hip2);
-    hip->free(orig);
 }
 
 

--- a/hip/test/base/hip_executor.hip.cpp
+++ b/hip/test/base/hip_executor.hip.cpp
@@ -136,12 +136,12 @@ TEST_F(HipExecutor, PreservesDeviceSettings)
 {
     auto previous_device = gko::HipExecutor::get_num_devices() - 1;
     GKO_ASSERT_NO_HIP_ERRORS(hipSetDevice(previous_device));
-    auto orig = hip->alloc<int>(2);
+    auto orig = hip->get_mem_space()->alloc<int>(2);
     int current_device;
     GKO_ASSERT_NO_HIP_ERRORS(hipGetDevice(&current_device));
     ASSERT_EQ(current_device, previous_device);
 
-    hip->free(orig);
+    hip->get_mem_space()->free(orig);
     GKO_ASSERT_NO_HIP_ERRORS(hipGetDevice(&current_device));
     ASSERT_EQ(current_device, previous_device);
 }

--- a/hip/test/base/hip_memory_space.hip.cpp
+++ b/hip/test/base/hip_memory_space.hip.cpp
@@ -1,0 +1,178 @@
+/*******************************<GINKGO LICENSE>******************************
+Copyright (c) 2017-2020, the Ginkgo authors
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+******************************<GINKGO LICENSE>*******************************/
+
+#include <ginkgo/core/base/memory_space.hpp>
+
+
+#include <memory>
+#include <type_traits>
+
+
+#include <gtest/gtest.h>
+#include <hip/hip_runtime.h>
+
+
+#include <ginkgo/core/base/exception.hpp>
+#include <ginkgo/core/base/exception_helpers.hpp>
+
+
+namespace {
+
+
+class HipMemorySpace : public ::testing::Test {
+protected:
+    HipMemorySpace()
+        : omp(gko::HostMemorySpace::create()), hip(nullptr), hip2(nullptr)
+    {}
+
+    void SetUp()
+    {
+        ASSERT_GT(gko::HipMemorySpace::get_num_devices(), 0);
+        hip = gko::HipMemorySpace::create(0);
+        hip2 = gko::HipMemorySpace::create(
+            gko::HipMemorySpace::get_num_devices() - 1);
+    }
+
+    void TearDown()
+    {
+        if (hip != nullptr) {
+            // ensure that previous calls finished and didn't throw an error
+            ASSERT_NO_THROW(hip->synchronize());
+        }
+    }
+
+    std::shared_ptr<gko::MemorySpace> omp;
+    std::shared_ptr<gko::HipMemorySpace> hip;
+    std::shared_ptr<gko::HipMemorySpace> hip2;
+};
+
+
+TEST_F(HipMemorySpace, AllocatesAndFreesMemory)
+{
+    int *ptr = nullptr;
+
+    ASSERT_NO_THROW(ptr = hip->alloc<int>(2));
+    ASSERT_NO_THROW(hip->free(ptr));
+}
+
+
+TEST_F(HipMemorySpace, FailsWhenOverallocating)
+{
+    const gko::size_type num_elems = 1ll << 50;  // 4PB of integers
+    int *ptr = nullptr;
+
+    ASSERT_THROW(
+        {
+            ptr = hip->alloc<int>(num_elems);
+            hip->synchronize();
+        },
+        gko::AllocationError);
+
+    hip->free(ptr);
+}
+
+
+__global__ void check_data(int *data)
+{
+    if (data[0] != 3 || data[1] != 8) {
+#if GINKGO_HIP_PLATFORM_HCC
+        asm("s_trap 0x02;");
+#else  // GINKGO_HIP_PLATFORM_NVCC
+        asm("trap;");
+#endif
+    }
+}
+
+TEST_F(HipMemorySpace, CopiesDataToHip)
+{
+    int orig[] = {3, 8};
+    auto *copy = hip->alloc<int>(2);
+
+    hip->copy_from(omp.get(), 2, orig, copy);
+
+    hipLaunchKernelGGL((check_data), dim3(1), dim3(1), 0, 0, copy);
+    ASSERT_NO_THROW(hip->synchronize());
+    hip->free(copy);
+}
+
+
+__global__ void init_data(int *data)
+{
+    data[0] = 3;
+    data[1] = 8;
+}
+
+TEST_F(HipMemorySpace, CopiesDataFromHip)
+{
+    int copy[2];
+    auto orig = hip->alloc<int>(2);
+    hipLaunchKernelGGL((init_data), dim3(1), dim3(1), 0, 0, orig);
+
+    omp->copy_from(hip.get(), 2, orig, copy);
+
+    EXPECT_EQ(3, copy[0]);
+    ASSERT_EQ(8, copy[1]);
+    hip->free(orig);
+}
+
+
+TEST_F(HipMemorySpace, CopiesDataFromHipToHip)
+{
+    int copy[2];
+    auto orig = hip->alloc<int>(2);
+    GKO_ASSERT_NO_HIP_ERRORS(hipSetDevice(0));
+    hipLaunchKernelGGL((init_data), dim3(1), dim3(1), 0, 0, orig);
+
+    auto copy_hip2 = hip2->alloc<int>(2);
+    hip2->copy_from(hip.get(), 2, orig, copy_hip2);
+
+    // Check that the data is really on GPU2 and ensure we did not cheat
+    GKO_ASSERT_NO_HIP_ERRORS(hipSetDevice(hip2->get_device_id()));
+    hipLaunchKernelGGL((check_data), dim3(1), dim3(1), 0, 0, copy_hip2);
+    GKO_ASSERT_NO_HIP_ERRORS(hipSetDevice(0));
+    // Put the results on OpenMP and run CPU side assertions
+    omp->copy_from(hip2.get(), 2, copy_hip2, copy);
+    EXPECT_EQ(3, copy[0]);
+    ASSERT_EQ(8, copy[1]);
+    hip->free(copy_hip2);
+    hip->free(orig);
+}
+
+
+TEST_F(HipMemorySpace, Synchronizes)
+{
+    // Todo design a proper unit test once we support streams
+    ASSERT_NO_THROW(hip->synchronize());
+}
+
+
+}  // namespace

--- a/include/ginkgo/core/base/exception.hpp
+++ b/include/ginkgo/core/base/exception.hpp
@@ -174,6 +174,30 @@ public:
 
 
 /**
+ * MemSpaceMismatch is thrown in case it is not possible to
+ * perform the requested operation on the given object type.
+ */
+class MemSpaceMismatch : public Error {
+public:
+    /**
+     * Initializes a MemSpaceMismatch error.
+     *
+     * @param file The name of the offending source file
+     * @param line The source code line number where the error occurred
+     * @param func The name of the function where the error occured
+     * @param obj_type The object type on which the requested operation
+     cannot be performed.
+    */
+    MemSpaceMismatch(const std::string &file, int line, const std::string &func,
+                     const std::string &obj_type)
+        : Error(file, line,
+                "This executor" + func +
+                    " does not support Memory space of type " + obj_type)
+    {}
+};
+
+
+/**
  * CudaError is thrown when a CUDA routine throws a non-zero error code.
  */
 class CudaError : public Error {

--- a/include/ginkgo/core/base/exception_helpers.hpp
+++ b/include/ginkgo/core/base/exception_helpers.hpp
@@ -88,6 +88,19 @@ namespace gko {
                   "semi-colon warnings")
 
 
+/**
+ * Creates a MemSpaceMismatch exception.
+ * This macro sets the correct information about the location of the error
+ * and fills the exception with data about _obj.
+ *
+ * @param _obj  the object referenced by MemSpaceMismatch exception
+ *
+ * @return MemSpaceMismatch
+ */
+#define GKO_MEMSPACE_MISMATCH(_obj) \
+    throw ::gko::MemSpaceMismatch(__FILE__, __LINE__, __func__, GKO_QUOTE(_obj))
+
+
 namespace detail {
 
 

--- a/include/ginkgo/core/base/executor.hpp
+++ b/include/ginkgo/core/base/executor.hpp
@@ -490,7 +490,8 @@ public:
     template <typename T>
     void copy(size_type num_elems, const T *src_ptr, T *dest_ptr) const
     {
-        this->get_mem_space()->copy_from(this, num_elems, src_ptr, dest_ptr);
+        this->get_mem_space()->copy_from(this->get_mem_space().get(), num_elems,
+                                         src_ptr, dest_ptr);
     }
 
     /**
@@ -506,7 +507,8 @@ public:
     T copy_val_to_host(const T *ptr) const
     {
         T out{};
-        this->get_master()->get_mem_space()->copy_from(this, 1, ptr, &out);
+        this->get_master()->get_mem_space()->copy_from(this->get_mem_space().get(), 1,
+                                                       ptr, &out);
         return out;
     }
 

--- a/include/ginkgo/core/base/executor.hpp
+++ b/include/ginkgo/core/base/executor.hpp
@@ -41,6 +41,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <type_traits>
 
 
+#include <ginkgo/core/base/exception.hpp>
+#include <ginkgo/core/base/exception_helpers.hpp>
 #include <ginkgo/core/base/memory_space.hpp>
 #include <ginkgo/core/base/types.hpp>
 #include <ginkgo/core/log/logger.hpp>
@@ -488,7 +490,7 @@ public:
     template <typename T>
     void copy(size_type num_elems, const T *src_ptr, T *dest_ptr) const
     {
-        this->copy_from(this, num_elems, src_ptr, dest_ptr);
+        this->get_mem_space()->copy_from(this, num_elems, src_ptr, dest_ptr);
     }
 
     /**
@@ -504,7 +506,7 @@ public:
     T copy_val_to_host(const T *ptr) const
     {
         T out{};
-        this->get_master()->copy_from(this, 1, ptr, &out);
+        this->get_master()->get_mem_space()->copy_from(this, 1, ptr, &out);
         return out;
     }
 
@@ -689,14 +691,6 @@ public:
 
 protected:
     OmpExecutor() { mem_space_instance_ = HostMemorySpace::create(); }
-
-    OmpExecutor(std::shared_ptr<MemorySpace> mem_space)
-        : mem_space_instance_(mem_space)
-    {
-        if (!check_mem_space_validity(mem_space_instance_)) {
-            GKO_MEMSPACE_MISMATCH(NOT_HOST);
-        }
-    }
 
     OmpExecutor(std::shared_ptr<MemorySpace> mem_space)
         : mem_space_instance_(mem_space)

--- a/include/ginkgo/core/base/memory_space.hpp
+++ b/include/ginkgo/core/base/memory_space.hpp
@@ -1,0 +1,468 @@
+/*******************************<GINKGO LICENSE>******************************
+Copyright (c) 2017-2020, the Ginkgo authors
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+******************************<GINKGO LICENSE>*******************************/
+
+#ifndef GKO_CORE_MEMORY_SPACE_HPP_
+#define GKO_CORE_MEMORY_SPACE_HPP_
+
+
+#include <memory>
+#include <mutex>
+#include <sstream>
+#include <tuple>
+#include <type_traits>
+
+
+#include <ginkgo/core/base/types.hpp>
+#include <ginkgo/core/log/logger.hpp>
+#include <ginkgo/core/synthesizer/containers.hpp>
+
+
+namespace gko {
+
+
+#define GKO_FORWARD_DECLARE(_type, ...) class _type
+
+GKO_ENABLE_FOR_ALL_MEMORY_SPACES(GKO_FORWARD_DECLARE);
+
+#undef GKO_FORWARD_DECLARE
+
+
+namespace detail {
+
+
+template <typename>
+class MemorySpaceBase;
+
+
+}  // namespace detail
+
+
+class MemorySpace : public log::EnableLogging<MemorySpace> {
+    template <typename T>
+    friend class detail::MemorySpaceBase;
+
+public:
+    virtual ~MemorySpace() = default;
+
+    MemorySpace() = default;
+    MemorySpace(MemorySpace &) = delete;
+    MemorySpace(MemorySpace &&) = default;
+    MemorySpace &operator=(MemorySpace &) = delete;
+    MemorySpace &operator=(MemorySpace &&) = default;
+
+    /**
+     * Allocates memory in this MemorySpace.
+     *
+     * @tparam T  datatype to allocate
+     *
+     * @param num_elems  number of elements of type T to allocate
+     *
+     * @throw AllocationError  if the allocation failed
+     *
+     * @return pointer to allocated memory
+     */
+    template <typename T>
+    T *alloc(size_type num_elems) const
+    {
+        this->template log<log::Logger::allocation_started>(
+            this, num_elems * sizeof(T));
+        T *allocated = static_cast<T *>(this->raw_alloc(num_elems * sizeof(T)));
+        this->template log<log::Logger::allocation_completed>(
+            this, num_elems * sizeof(T), reinterpret_cast<uintptr>(allocated));
+        return allocated;
+    }
+
+    /**
+     * Frees memory previously allocated with MemorySpace::alloc().
+     *
+     * If `ptr` is a `nullptr`, the function has no effect.
+     *
+     * @param ptr  pointer to the allocated memory block
+     */
+    void free(void *ptr) const noexcept
+    {
+        this->template log<log::Logger::free_started>(
+            this, reinterpret_cast<uintptr>(ptr));
+        this->raw_free(ptr);
+        this->template log<log::Logger::free_completed>(
+            this, reinterpret_cast<uintptr>(ptr));
+    }
+
+    /**
+     * Copies data from another MemorySpace.
+     *
+     * @tparam T  datatype to copy
+     *
+     * @param src_mem_space  MemorySpace from which the memory will be copied
+     * @param num_elems  number of elements of type T to copy
+     * @param src_ptr  pointer to a block of memory containing the data to be
+     *                 copied
+     * @param dest_ptr  pointer to an allocated block of memory
+     *                  where the data will be copied to
+     */
+    template <typename T>
+    void copy_from(const MemorySpace *src_mem_space, size_type num_elems,
+                   const T *src_ptr, T *dest_ptr) const
+    {
+        this->template log<log::Logger::copy_started>(
+            src_mem_space, this, reinterpret_cast<uintptr>(src_ptr),
+            reinterpret_cast<uintptr>(dest_ptr), num_elems * sizeof(T));
+        this->raw_copy_from(src_mem_space, num_elems * sizeof(T), src_ptr,
+                            dest_ptr);
+        this->template log<log::Logger::copy_completed>(
+            src_mem_space, this, reinterpret_cast<uintptr>(src_ptr),
+            reinterpret_cast<uintptr>(dest_ptr), num_elems * sizeof(T));
+    }
+
+    /**
+     * Synchronize the operations launched on the executor with its master.
+     */
+    virtual void synchronize() const = 0;
+
+protected:
+    /**
+     * Allocates raw memory in this MemorySpace.
+     *
+     * @param size  number of bytes to allocate
+     *
+     * @throw AllocationError  if the allocation failed
+     *
+     * @return raw pointer to allocated memory
+     */
+    virtual void *raw_alloc(size_type size) const = 0;
+
+    /**
+     * Frees memory previously allocated with MemorySpace::alloc().
+     *
+     * If `ptr` is a `nullptr`, the function has no effect.
+     *
+     * @param ptr  pointer to the allocated memory block
+     */
+    virtual void raw_free(void *ptr) const noexcept = 0;
+
+    /**
+     * Copies raw data from another MemorySpace.
+     *
+     * @param src_mem_space  MemorySpace from which the memory will be copied
+     * @param n_bytes  number of bytes to copy
+     * @param src_ptr  pointer to a block of memory containing the data to be
+     *                 copied
+     * @param dest_ptr  pointer to an allocated block of memory where the data
+     *                  will be copied to
+     */
+    virtual void raw_copy_from(const MemorySpace *src_mem_space,
+                               size_type n_bytes, const void *src_ptr,
+                               void *dest_ptr) const = 0;
+
+/**
+ * @internal
+ * Declares a raw_copy_to() overload for a specified MemorySpace subclass.
+ *
+ * This is the second stage of the double dispatch emulation required to
+ * implement raw_copy_from().
+ *
+ * @param _mem_space_type  the MemorySpace subclass
+ */
+#define GKO_ENABLE_RAW_COPY_TO(_mem_space_type, ...)                 \
+    virtual void raw_copy_to(const _mem_space_type *dest_mem_space,  \
+                             size_type n_bytes, const void *src_ptr, \
+                             void *dest_ptr) const = 0
+
+    GKO_ENABLE_FOR_ALL_MEMORY_SPACES(GKO_ENABLE_RAW_COPY_TO);
+
+#undef GKO_ENABLE_RAW_COPY_TO
+};
+
+
+/**
+ * This is a deleter that uses an mem_space's `free` method to deallocate
+ * the data.
+ *
+ * @tparam T  the type of object being deleted
+ *
+ * @ingroup MemorySpace
+ */
+template <typename T>
+class memory_space_deleter {
+public:
+    using pointer = T *;
+
+    /**
+     * Creates a new deleter.
+     *
+     * @param mem_space  the mem_spaceutor used to free the data
+     */
+    explicit memory_space_deleter(std::shared_ptr<const MemorySpace> mem_space)
+        : mem_space_{mem_space}
+    {}
+
+    /**
+     * Deletes the object.
+     *
+     * @param ptr  pointer to the object being deleted
+     */
+    void operator()(pointer ptr) const
+    {
+        if (mem_space_) {
+            mem_space_->free(ptr);
+        }
+    }
+
+private:
+    std::shared_ptr<const MemorySpace> mem_space_;
+};
+
+// a specialization for arrays
+template <typename T>
+class memory_space_deleter<T[]> {
+public:
+    using pointer = T[];
+
+    explicit memory_space_deleter(std::shared_ptr<const MemorySpace> mem_space)
+        : mem_space_{mem_space}
+    {}
+
+    void operator()(pointer ptr) const
+    {
+        if (mem_space_) {
+            mem_space_->free(ptr);
+        }
+    }
+
+private:
+    std::shared_ptr<const MemorySpace> mem_space_;
+};
+
+
+namespace detail {
+
+
+template <typename ConcreteMemorySpace>
+class MemorySpaceBase : public MemorySpace {
+public:
+    void raw_copy_from(const MemorySpace *src_mem_space, size_type n_bytes,
+                       const void *src_ptr, void *dest_ptr) const override
+    {
+        src_mem_space->raw_copy_to(self(), n_bytes, src_ptr, dest_ptr);
+    }
+
+private:
+    ConcreteMemorySpace *self() noexcept
+    {
+        return static_cast<ConcreteMemorySpace *>(this);
+    }
+
+    const ConcreteMemorySpace *self() const noexcept
+    {
+        return static_cast<const ConcreteMemorySpace *>(this);
+    }
+};
+
+
+}  // namespace detail
+
+
+#define GKO_OVERRIDE_RAW_COPY_TO(_memory_space_type, ...)                    \
+    void raw_copy_to(const _memory_space_type *dest_mem_space,               \
+                     size_type n_bytes, const void *src_ptr, void *dest_ptr) \
+        const override
+
+
+class HostMemorySpace : public detail::MemorySpaceBase<HostMemorySpace> {
+    friend class detail::MemorySpaceBase<HostMemorySpace>;
+
+public:
+    /**
+     * Creates a new HostMemorySpace.
+     */
+    static std::shared_ptr<HostMemorySpace> create()
+    {
+        return std::shared_ptr<HostMemorySpace>(new HostMemorySpace());
+    }
+
+    void synchronize() const override;
+
+protected:
+    HostMemorySpace() = default;
+
+    void *raw_alloc(size_type size) const override;
+
+    void raw_free(void *ptr) const noexcept override;
+
+    GKO_ENABLE_FOR_ALL_MEMORY_SPACES(GKO_OVERRIDE_RAW_COPY_TO);
+};
+
+
+class CudaMemorySpace : public detail::MemorySpaceBase<CudaMemorySpace> {
+    friend class detail::MemorySpaceBase<CudaMemorySpace>;
+
+public:
+    /**
+     * Creates a new CudaMemorySpace.
+     *
+     * @param device_id  the CUDA device id of this device
+     */
+    static std::shared_ptr<CudaMemorySpace> create(int device_id)
+    {
+        return std::shared_ptr<CudaMemorySpace>(new CudaMemorySpace(device_id));
+    }
+
+    /**
+     * Get the CUDA device id of the device associated to this memory_space.
+     */
+    int get_device_id() const noexcept { return this->device_id_; }
+
+    /**
+     * Get the number of devices present on the system.
+     */
+    static int get_num_devices();
+
+    void synchronize() const override;
+
+protected:
+    CudaMemorySpace() = default;
+
+    CudaMemorySpace(int device_id) : device_id_(device_id)
+    {
+        assert(device_id < max_devices);
+    }
+
+    void *raw_alloc(size_type size) const override;
+
+    void raw_free(void *ptr) const noexcept override;
+
+    GKO_ENABLE_FOR_ALL_MEMORY_SPACES(GKO_OVERRIDE_RAW_COPY_TO);
+
+private:
+    int device_id_;
+    static constexpr int max_devices = 64;
+};
+
+
+class CudaUVMSpace : public detail::MemorySpaceBase<CudaUVMSpace> {
+    friend class detail::MemorySpaceBase<CudaUVMSpace>;
+
+public:
+    /**
+     * Creates a new CudaUVMSpace.
+     *
+     * @param device_id  the CUDA device id of this device
+     */
+    static std::shared_ptr<CudaUVMSpace> create(int device_id)
+    {
+        return std::shared_ptr<CudaUVMSpace>(new CudaUVMSpace(device_id));
+    }
+
+    /**
+     * Get the CUDA device id of the device associated to this memory_space.
+     */
+    int get_device_id() const noexcept { return this->device_id_; }
+
+    /**
+     * Get the number of devices present on the system.
+     */
+    static int get_num_devices();
+
+    void synchronize() const override;
+
+protected:
+    CudaUVMSpace() = default;
+
+    CudaUVMSpace(int device_id) : device_id_(device_id)
+    {
+        assert(device_id < max_devices);
+    }
+
+    void *raw_alloc(size_type size) const override;
+
+    void raw_free(void *ptr) const noexcept override;
+
+    GKO_ENABLE_FOR_ALL_MEMORY_SPACES(GKO_OVERRIDE_RAW_COPY_TO);
+
+private:
+    int device_id_;
+    static constexpr int max_devices = 64;
+};
+
+
+class HipMemorySpace : public detail::MemorySpaceBase<HipMemorySpace> {
+    friend class detail::MemorySpaceBase<HipMemorySpace>;
+
+public:
+    /**
+     * Creates a new HipMemorySpace.
+     *
+     * @param device_id  the HIP device id of this device
+     */
+    static std::shared_ptr<HipMemorySpace> create(int device_id)
+    {
+        return std::shared_ptr<HipMemorySpace>(new HipMemorySpace(device_id));
+    }
+
+    /**
+     * Get the HIP device id of the device associated to this memory_space.
+     */
+    int get_device_id() const noexcept { return this->device_id_; }
+
+    /**
+     * Get the number of devices present on the system.
+     */
+    static int get_num_devices();
+
+    void synchronize() const override;
+
+protected:
+    HipMemorySpace() = default;
+
+    HipMemorySpace(int device_id) : device_id_(device_id)
+    {
+        assert(device_id < max_devices);
+    }
+
+    void *raw_alloc(size_type size) const override;
+
+    void raw_free(void *ptr) const noexcept override;
+
+    GKO_ENABLE_FOR_ALL_MEMORY_SPACES(GKO_OVERRIDE_RAW_COPY_TO);
+
+private:
+    int device_id_;
+    static constexpr int max_devices = 64;
+};
+
+#undef GKO_OVERRIDE_RAW_COPY_TO
+
+
+}  // namespace gko
+
+
+#endif  // GKO_CORE_MEMORY_SPACE_HPP_

--- a/include/ginkgo/core/base/types.hpp
+++ b/include/ginkgo/core/base/types.hpp
@@ -396,6 +396,23 @@ GKO_ATTRIBUTES constexpr bool operator!=(precision_reduction x,
 
 
 /**
+ * Calls a given macro for each memory space type for a given kernel.
+ *
+ * The macro should take two parameters:
+ *
+ * -   the first one is replaced with the memory space class name
+ * -   the second one with the name of the kernel to be bound
+ *
+ * @param _enable_macro  macro name which will be called
+ */
+#define GKO_ENABLE_FOR_ALL_MEMORY_SPACES(_enable_macro) \
+    _enable_macro(HostMemorySpace, host);               \
+    _enable_macro(HipMemorySpace, hip);                 \
+    _enable_macro(CudaMemorySpace, cuda);               \
+    _enable_macro(CudaUVMSpace, cuda_uvm)
+
+
+/**
  * Instantiates a template for each non-complex value type compiled by Ginkgo.
  *
  * @param _macro  A macro which expands the template instantiation

--- a/include/ginkgo/core/log/convergence.hpp
+++ b/include/ginkgo/core/log/convergence.hpp
@@ -88,10 +88,11 @@ public:
      */
     static std::unique_ptr<Convergence> create(
         std::shared_ptr<const Executor> exec,
+        std::shared_ptr<const MemorySpace> mem_space,
         const mask_type &enabled_events = Logger::all_events_mask)
     {
         return std::unique_ptr<Convergence>(
-            new Convergence(exec, enabled_events));
+            new Convergence(exec, mem_space, enabled_events));
     }
 
     /**
@@ -131,8 +132,9 @@ protected:
      */
     explicit Convergence(
         std::shared_ptr<const gko::Executor> exec,
+        std::shared_ptr<const gko::MemorySpace> mem_space,
         const mask_type &enabled_events = Logger::all_events_mask)
-        : Logger(exec, enabled_events)
+        : Logger(exec, mem_space, enabled_events)
     {}
 
 private:

--- a/include/ginkgo/core/log/logger.hpp
+++ b/include/ginkgo/core/log/logger.hpp
@@ -52,6 +52,7 @@ namespace gko {
 template <typename ValueType>
 class Array;
 class Executor;
+class MemorySpace;
 class LinOp;
 class LinOpFactory;
 class PolymorphicObject;
@@ -140,68 +141,74 @@ public:                                                              \
     static constexpr mask_type _event_name##_mask{mask_type{1} << _id};
 
     /**
-     * Executor's allocation started event.
+     * Memory Space's allocation started event.
      *
-     * @param exec  the executor used
+     * @param mem_space  the memory space used
      * @param num_bytes  the number of bytes to allocate
      */
-    GKO_LOGGER_REGISTER_EVENT(0, allocation_started, const Executor *exec,
+    GKO_LOGGER_REGISTER_EVENT(0, allocation_started,
+                              const MemorySpace *mem_space,
                               const size_type &num_bytes)
 
     /**
-     * Executor's allocation completed event.
+     * Memory Space's allocation completed event.
      *
-     * @param exec  the executor used
+     * @param mem_space  the memory space used
      * @param num_bytes  the number of bytes allocated
      * @param location  the address at which the data was allocated
      */
-    GKO_LOGGER_REGISTER_EVENT(1, allocation_completed, const Executor *exec,
+    GKO_LOGGER_REGISTER_EVENT(1, allocation_completed,
+                              const MemorySpace *mem_space,
                               const size_type &num_bytes,
                               const uintptr &location)
 
     /**
-     * Executor's free started event.
+     * Memory Space's free started event.
      *
-     * @param exec  the executor used
+     * @param mem_space  the memory space used
      * @param location  the address at which the data will be freed
      */
-    GKO_LOGGER_REGISTER_EVENT(2, free_started, const Executor *exec,
+    GKO_LOGGER_REGISTER_EVENT(2, free_started, const MemorySpace *mem_space,
                               const uintptr &location)
 
     /**
-     * Executor's free completed event.
+     * Memory Space's free completed event.
      *
-     * @param exec  the executor used
+     * @param mem_space  the memory space used
      * @param location  the address at which the data was freed
      */
-    GKO_LOGGER_REGISTER_EVENT(3, free_completed, const Executor *exec,
+    GKO_LOGGER_REGISTER_EVENT(3, free_completed, const MemorySpace *mem_space,
                               const uintptr &location)
 
     /**
-     * Executor's copy started event.
+     * Memory Space's copy started event.
 
-     * @param exec_from  the executor to be copied from
-     * @param exec_to  the executor to be copied to
+     * @param mem_space_from  the memory space to be copied from
+     * @param mem_space_to  the memory space to be copied to
      * @param loc_from  the address at which the data will be copied from
      * @param loc_to  the address at which the data will be copied to
      * @param num_bytes  the number of bytes to be copied
      */
-    GKO_LOGGER_REGISTER_EVENT(4, copy_started, const Executor *exec_from,
-                              const Executor *exec_to, const uintptr &loc_from,
-                              const uintptr &loc_to, const size_type &num_bytes)
+    GKO_LOGGER_REGISTER_EVENT(4, copy_started,
+                              const MemorySpace *mem_space_from,
+                              const MemorySpace *mem_space_to,
+                              const uintptr &loc_from, const uintptr &loc_to,
+                              const size_type &num_bytes)
 
     /**
-     * Executor's copy completed event.
+     * Memory Space's copy completed event.
      *
-     * @param exec_from  the executor copied from
-     * @param exec_to  the executor copied to
+     * @param mem_space_from  the memory space copied from
+     * @param mem_space_to  the memory space copied to
      * @param loc_from  the address at which the data was copied from
      * @param loc_to  the address at which the data was copied to
      * @param num_bytes  the number of bytes copied
      */
-    GKO_LOGGER_REGISTER_EVENT(5, copy_completed, const Executor *exec_from,
-                              const Executor *exec_to, const uintptr &loc_from,
-                              const uintptr &loc_to, const size_type &num_bytes)
+    GKO_LOGGER_REGISTER_EVENT(5, copy_completed,
+                              const MemorySpace *mem_space_from,
+                              const MemorySpace *mem_space_to,
+                              const uintptr &loc_from, const uintptr &loc_to,
+                              const size_type &num_bytes)
 
     /**
      * Executor's operation launched event (method run).
@@ -407,9 +414,9 @@ public:                                                              \
 #undef GKO_LOGGER_REGISTER_EVENT
 
     /**
-     * Bitset Mask which activates all executor events
+     * Bitset Mask which activates all memory space events
      */
-    static constexpr mask_type executor_events_mask =
+    static constexpr mask_type memory_space_events_mask =
         allocation_started_mask | allocation_completed_mask |
         free_started_mask | free_completed_mask | copy_started_mask |
         copy_completed_mask;
@@ -466,12 +473,14 @@ protected:
      *                           event.
      */
     explicit Logger(std::shared_ptr<const gko::Executor> exec,
+                    std::shared_ptr<const gko::MemorySpace> mem_space,
                     const mask_type &enabled_events = all_events_mask)
-        : exec_{exec}, enabled_events_{enabled_events}
+        : exec_{exec}, mem_space_{mem_space}, enabled_events_{enabled_events}
     {}
 
 private:
     std::shared_ptr<const Executor> exec_;
+    std::shared_ptr<const MemorySpace> mem_space_;
     mask_type enabled_events_;
 };
 

--- a/include/ginkgo/core/log/papi.hpp
+++ b/include/ginkgo/core/log/papi.hpp
@@ -91,26 +91,26 @@ static std::mutex papi_count_mutex;
 template <typename ValueType = default_precision>
 class Papi : public Logger {
 public:
-    /* Executor events */
-    void on_allocation_started(const Executor *exec,
+    /* Memory space events */
+    void on_allocation_started(const MemorySpace *mem_space,
                                const size_type &num_bytes) const override;
 
-    void on_allocation_completed(const Executor *exec,
+    void on_allocation_completed(const MemorySpace *mem_space,
                                  const size_type &num_bytes,
                                  const uintptr &location) const override;
 
-    void on_free_started(const Executor *exec,
+    void on_free_started(const MemorySpace *mem_space,
                          const uintptr &location) const override;
 
-    void on_free_completed(const Executor *exec,
+    void on_free_completed(const MemorySpace *mem_space,
                            const uintptr &location) const override;
 
-    void on_copy_started(const Executor *from, const Executor *to,
+    void on_copy_started(const MemorySpace *from, const MemorySpace *to,
                          const uintptr &location_from,
                          const uintptr &location_to,
                          const size_type &num_bytes) const override;
 
-    void on_copy_completed(const Executor *from, const Executor *to,
+    void on_copy_completed(const MemorySpace *from, const MemorySpace *to,
                            const uintptr &location_from,
                            const uintptr &location_to,
                            const size_type &num_bytes) const override;
@@ -185,9 +185,10 @@ public:
      */
     static std::shared_ptr<Papi> create(
         std::shared_ptr<const gko::Executor> exec,
+        std::shared_ptr<const gko::MemorySpace> mem_space,
         const Logger::mask_type &enabled_events = Logger::all_events_mask)
     {
-        return std::shared_ptr<Papi>(new Papi(exec, enabled_events));
+        return std::shared_ptr<Papi>(new Papi(exec, mem_space, enabled_events));
     }
 
     /**
@@ -201,8 +202,9 @@ public:
 protected:
     explicit Papi(
         std::shared_ptr<const gko::Executor> exec,
+        std::shared_ptr<const gko::MemorySpace> mem_space,
         const Logger::mask_type &enabled_events = Logger::all_events_mask)
-        : Logger(exec, enabled_events)
+        : Logger(exec, mem_space, enabled_events)
     {
         std::ostringstream os;
 
@@ -257,20 +259,21 @@ private:
     };
 
 
-    mutable papi_queue<Executor> allocation_started{&papi_handle,
-                                                    "allocation_started"};
-    mutable papi_queue<Executor> allocation_completed{&papi_handle,
-                                                      "allocation_completed"};
-    mutable papi_queue<Executor> free_started{&papi_handle, "free_started"};
-    mutable papi_queue<Executor> free_completed{&papi_handle, "free_completed"};
-    mutable papi_queue<Executor> copy_started_from{&papi_handle,
-                                                   "copy_started_from"};
-    mutable papi_queue<Executor> copy_started_to{&papi_handle,
-                                                 "copy_started_to"};
-    mutable papi_queue<Executor> copy_completed_from{&papi_handle,
-                                                     "copy_completed_from"};
-    mutable papi_queue<Executor> copy_completed_to{&papi_handle,
-                                                   "copy_completed_to"};
+    mutable papi_queue<MemorySpace> allocation_started{&papi_handle,
+                                                       "allocation_started"};
+    mutable papi_queue<MemorySpace> allocation_completed{
+        &papi_handle, "allocation_completed"};
+    mutable papi_queue<MemorySpace> free_started{&papi_handle, "free_started"};
+    mutable papi_queue<MemorySpace> free_completed{&papi_handle,
+                                                   "free_completed"};
+    mutable papi_queue<MemorySpace> copy_started_from{&papi_handle,
+                                                      "copy_started_from"};
+    mutable papi_queue<MemorySpace> copy_started_to{&papi_handle,
+                                                    "copy_started_to"};
+    mutable papi_queue<MemorySpace> copy_completed_from{&papi_handle,
+                                                        "copy_completed_from"};
+    mutable papi_queue<MemorySpace> copy_completed_to{&papi_handle,
+                                                      "copy_completed_to"};
 
     mutable papi_queue<Executor> operation_launched{&papi_handle,
                                                     "operation_launched"};

--- a/include/ginkgo/core/log/record.hpp
+++ b/include/ginkgo/core/log/record.hpp
@@ -90,8 +90,8 @@ struct iteration_complete_data {
 /**
  * Struct representing Executor related data
  */
-struct executor_data {
-    const Executor *exec;
+struct memory_space_data {
+    const MemorySpace *mem_space;
     const size_type num_bytes;
     const uintptr location;
 };
@@ -235,13 +235,15 @@ public:
      * Struct storing the actually logged data
      */
     struct logged_data {
-        std::deque<std::unique_ptr<executor_data>> allocation_started;
-        std::deque<std::unique_ptr<executor_data>> allocation_completed;
-        std::deque<std::unique_ptr<executor_data>> free_started;
-        std::deque<std::unique_ptr<executor_data>> free_completed;
-        std::deque<std::unique_ptr<std::tuple<executor_data, executor_data>>>
+        std::deque<std::unique_ptr<memory_space_data>> allocation_started;
+        std::deque<std::unique_ptr<memory_space_data>> allocation_completed;
+        std::deque<std::unique_ptr<memory_space_data>> free_started;
+        std::deque<std::unique_ptr<memory_space_data>> free_completed;
+        std::deque<
+            std::unique_ptr<std::tuple<memory_space_data, memory_space_data>>>
             copy_started;
-        std::deque<std::unique_ptr<std::tuple<executor_data, executor_data>>>
+        std::deque<
+            std::unique_ptr<std::tuple<memory_space_data, memory_space_data>>>
             copy_completed;
 
         std::deque<std::unique_ptr<operation_data>> operation_launched;
@@ -275,25 +277,25 @@ public:
     };
 
     /* Executor events */
-    void on_allocation_started(const Executor *exec,
+    void on_allocation_started(const MemorySpace *mem_space,
                                const size_type &num_bytes) const override;
 
-    void on_allocation_completed(const Executor *exec,
+    void on_allocation_completed(const MemorySpace *mem_space,
                                  const size_type &num_bytes,
                                  const uintptr &location) const override;
 
-    void on_free_started(const Executor *exec,
+    void on_free_started(const MemorySpace *mem_space,
                          const uintptr &location) const override;
 
-    void on_free_completed(const Executor *exec,
+    void on_free_completed(const MemorySpace *mem_space,
                            const uintptr &location) const override;
 
-    void on_copy_started(const Executor *from, const Executor *to,
+    void on_copy_started(const MemorySpace *from, const MemorySpace *to,
                          const uintptr &location_from,
                          const uintptr &location_to,
                          const size_type &num_bytes) const override;
 
-    void on_copy_completed(const Executor *from, const Executor *to,
+    void on_copy_completed(const MemorySpace *from, const MemorySpace *to,
                            const uintptr &location_from,
                            const uintptr &location_to,
                            const size_type &num_bytes) const override;
@@ -390,11 +392,12 @@ public:
      */
     static std::unique_ptr<Record> create(
         std::shared_ptr<const Executor> exec,
+        std::shared_ptr<const MemorySpace> mem_space,
         const mask_type &enabled_events = Logger::all_events_mask,
         size_type max_storage = 1)
     {
         return std::unique_ptr<Record>(
-            new Record(exec, enabled_events, max_storage));
+            new Record(exec, mem_space, enabled_events, max_storage));
     }
 
     /**
@@ -422,9 +425,10 @@ protected:
      *                     memory overhead of this logger.
      */
     explicit Record(std::shared_ptr<const gko::Executor> exec,
+                    std::shared_ptr<const gko::MemorySpace> mem_space,
                     const mask_type &enabled_events = Logger::all_events_mask,
                     size_type max_storage = 0)
-        : Logger(exec, enabled_events), max_storage_{max_storage}
+        : Logger(exec, mem_space, enabled_events), max_storage_{max_storage}
     {}
 
     /**

--- a/include/ginkgo/core/log/stream.hpp
+++ b/include/ginkgo/core/log/stream.hpp
@@ -59,25 +59,25 @@ template <typename ValueType = default_precision>
 class Stream : public Logger {
 public:
     /* Executor events */
-    void on_allocation_started(const Executor *exec,
+    void on_allocation_started(const MemorySpace *mem_space,
                                const size_type &num_bytes) const override;
 
-    void on_allocation_completed(const Executor *exec,
+    void on_allocation_completed(const MemorySpace *mem_space,
                                  const size_type &num_bytes,
                                  const uintptr &location) const override;
 
-    void on_free_started(const Executor *exec,
+    void on_free_started(const MemorySpace *mem_space,
                          const uintptr &location) const override;
 
-    void on_free_completed(const Executor *exec,
+    void on_free_completed(const MemorySpace *mem_space,
                            const uintptr &location) const override;
 
-    void on_copy_started(const Executor *from, const Executor *to,
+    void on_copy_started(const MemorySpace *from, const MemorySpace *to,
                          const uintptr &location_from,
                          const uintptr &location_to,
                          const size_type &num_bytes) const override;
 
-    void on_copy_completed(const Executor *from, const Executor *to,
+    void on_copy_completed(const MemorySpace *from, const MemorySpace *to,
                            const uintptr &location_from,
                            const uintptr &location_to,
                            const size_type &num_bytes) const override;
@@ -173,11 +173,12 @@ public:
      */
     static std::unique_ptr<Stream> create(
         std::shared_ptr<const Executor> exec,
+        std::shared_ptr<const MemorySpace> mem_space,
         const Logger::mask_type &enabled_events = Logger::all_events_mask,
         std::ostream &os = std::cout, bool verbose = false)
     {
         return std::unique_ptr<Stream>(
-            new Stream(exec, enabled_events, os, verbose));
+            new Stream(exec, mem_space, enabled_events, os, verbose));
     }
 
 protected:
@@ -194,9 +195,10 @@ protected:
      */
     explicit Stream(
         std::shared_ptr<const gko::Executor> exec,
+        std::shared_ptr<const gko::MemorySpace> mem_space,
         const Logger::mask_type &enabled_events = Logger::all_events_mask,
         std::ostream &os = std::cout, bool verbose = false)
-        : Logger(exec, enabled_events), os_(os), verbose_(verbose)
+        : Logger(exec, mem_space, enabled_events), os_(os), verbose_(verbose)
     {}
 
 

--- a/reference/test/log/convergence.cpp
+++ b/reference/test/log/convergence.cpp
@@ -58,7 +58,8 @@ TYPED_TEST(Convergence, CatchesCriterionCheckCompleted)
 {
     auto exec = gko::ReferenceExecutor::create();
     auto logger = gko::log::Convergence<TypeParam>::create(
-        exec, gko::log::Logger::criterion_check_completed_mask);
+        exec, exec->get_mem_space(),
+        gko::log::Logger::criterion_check_completed_mask);
     auto criterion =
         gko::stop::Iteration::build().with_max_iters(3u).on(exec)->generate(
             nullptr, nullptr, nullptr);

--- a/reference/test/log/papi.cpp
+++ b/reference/test/log/papi.cpp
@@ -73,7 +73,7 @@ protected:
     const std::string init(const gko::log::Logger::mask_type &event,
                            const std::string &event_name, U *ptr)
     {
-        logger = gko::log::Papi<T>::create(exec, event);
+        logger = gko::log::Papi<T>::create(exec, exec->get_mem_space(), event);
         std::ostringstream os;
         os << "sde:::" << logger->get_handle_name() << "::" << event_name << "_"
            << reinterpret_cast<gko::uintptr>(ptr);

--- a/test_install/test_install.cpp
+++ b/test_install/test_install.cpp
@@ -183,23 +183,25 @@ int main(int, char **)
 
     // core/log/convergence.hpp
     {
-        auto test = gko::log::Convergence<>::create(refExec);
+        auto test =
+            gko::log::Convergence<>::create(refExec, refExec->get_mem_space());
     }
 
     // core/log/record.hpp
     {
-        auto test = gko::log::executor_data{};
+        auto test = gko::log::memory_space_data{};
     }
 
     // core/log/stream.hpp
     {
-        auto test = gko::log::Stream<>::create(refExec);
+        auto test =
+            gko::log::Stream<>::create(refExec, refExec->get_mem_space());
     }
 
 #if GKO_HAVE_PAPI_SDE
     // core/log/papi.hpp
     {
-        auto test = gko::log::Papi<>::create(refExec);
+        auto test = gko::log::Papi<>::create(refExec, refExec->get_mem_space());
     }
 #endif  // GKO_HAVE_PAPI_SDE
 
@@ -357,13 +359,13 @@ int main(int, char **)
                            .with_reduction_factor(1e-10)
                            .on(refExec);
 
-        auto rel_res = gko::stop::RelativeResidualNorm<>::build()
-                           .with_tolerance(1e-10)
-                           .on(refExec);
+        auto rel_res =
+            gko::stop::RelativeResidualNorm<>::build().with_tolerance(1e-10).on(
+                refExec);
 
-        auto abs_res = gko::stop::AbsoluteResidualNorm<>::build()
-                           .with_tolerance(1e-10)
-                           .on(refExec);
+        auto abs_res =
+            gko::stop::AbsoluteResidualNorm<>::build().with_tolerance(1e-10).on(
+                refExec);
 
         // stopping_status.hpp
         auto stop_status = gko::stopping_status{};

--- a/test_install/test_install_cuda.cu
+++ b/test_install/test_install_cuda.cu
@@ -187,23 +187,23 @@ int main(int, char **)
 
     // core/log/convergence.hpp
     {
-        gko::log::Convergence<>::create(cudaExec);
+        gko::log::Convergence<>::create(cudaExec, cudaExec->get_mem_space());
     }
 
     // core/log/record.hpp
     {
-        gko::log::executor_data{};
+        gko::log::memory_space_data{};
     }
 
     // core/log/stream.hpp
     {
-        gko::log::Stream<>::create(cudaExec);
+        gko::log::Stream<>::create(cudaExec, cudaExec->get_mem_space());
     }
 
 #if GKO_HAVE_PAPI_SDE
     // core/log/papi.hpp
     {
-        gko::log::Papi<>::create(cudaExec);
+        gko::log::Papi<>::create(cudaExec, cudaExec->get_mem_space());
     }
 #endif  // GKO_HAVE_PAPI_SDE
 
@@ -349,13 +349,11 @@ int main(int, char **)
             .with_reduction_factor(1e-10)
             .on(cudaExec);
 
-        gko::stop::RelativeResidualNorm<>::build()
-            .with_tolerance(1e-10)
-            .on(cudaExec);
+        gko::stop::RelativeResidualNorm<>::build().with_tolerance(1e-10).on(
+            cudaExec);
 
-        gko::stop::AbsoluteResidualNorm<>::build()
-            .with_tolerance(1e-10)
-            .on(cudaExec);
+        gko::stop::AbsoluteResidualNorm<>::build().with_tolerance(1e-10).on(
+            cudaExec);
 
         // stopping_status.hpp
         gko::stopping_status{};


### PR DESCRIPTION
This PR is a draft PR which showcases how a memory space abstraction would look like in Ginkgo. All the memory operations such as `alloc`, `free`  and `raw_copy_to`'s are move from the Executor to the MemorySpace class.

By default, Executors are created with separate new memory space objects thereby trying to maintain the same behaviour as before this PR. Executors can also be created with an associated memory space. In that case, with matching memory spaces, the data would not be copied. 

This PR is experimental and is available for anyone who wants to discuss and play around with the code. 

Please feel free to point out problems and issues with the current implementation and suggestions for improvements are welcome.

### TODO

+ [x] Add documentation.
+ [ ] Check whether polymorphic_object can also be completely abstracted.

Update: 
Interface breaking change, See #402 
