### PR TITLE
Add triangular solvers to benchmark

### DIFF
--- a/BENCHMARKING.md
+++ b/BENCHMARKING.md
@@ -294,9 +294,9 @@ The supported environment variables are described in the following list:
     prefix) can be used as well. Multiple options can be passed. The default is
     `csr,coo,ell,hybrid,sellp`.
 * `SOLVERS={bicgstab,bicg,cg,cgs,fcg,gmres,lower_trs,upper_trs}` - the solvers
-    which should be benchmarked. Multiple options can be passed.
-    Note that `lower/upper_trs` by default don't use a preconditioner, as they
-    are exact direct solvers. The default is `cg`.
+    which should be benchmarked. Multiple options can be passed. The default
+    is `cg`. Note that `lower/upper_trs` by default don't use a preconditioner,
+    as they are by default exact direct solvers.
 * `SOLVERS_PRECISION=<precision>` - the minimal residual reduction before which
     the solver should stop. The default is `1e-6`.
 * `SOLVERS_MAX_ITERATION=<number>` - the maximum number of iterations with which

--- a/BENCHMARKING.md
+++ b/BENCHMARKING.md
@@ -293,8 +293,10 @@ The supported environment variables are described in the following list:
     library formats (cuSPARSE with `cusp_` prefix or hipSPARSE with `hipsp_`
     prefix) can be used as well. Multiple options can be passed. The default is
     `csr,coo,ell,hybrid,sellp`.
-* `SOLVERS={bicgstab,bicg,cg,cgs,fcg,gmres}` - the solvers which should be
-    benchmarked. Multiple options can be passed. The default is `cg`.
+* `SOLVERS={bicgstab,bicg,cg,cgs,fcg,gmres,lower_trs,upper_trs}` - the solvers
+    which should be benchmarked. Multiple options can be passed.
+    Note that `lower/upper_trs` by default don't use a preconditioner, as they
+    are exact direct solvers. The default is `cg`.
 * `SOLVERS_PRECISION=<precision>` - the minimal residual reduction before which
     the solver should stop. The default is `1e-6`.
 * `SOLVERS_MAX_ITERATION=<number>` - the maximum number of iterations with which

--- a/benchmark/solver/solver.cpp
+++ b/benchmark/solver/solver.cpp
@@ -65,10 +65,10 @@ DEFINE_bool(
     rel_residual, false,
     "Use relative residual instead of residual reduction stopping criterion");
 
-DEFINE_string(
-    solvers, "cg",
-    "A comma-separated list of solvers to run. "
-    "Supported values are: bicgstab, bicg, cg, cgs, fcg, gmres, overhead");
+DEFINE_string(solvers, "cg",
+              "A comma-separated list of solvers to run. "
+              "Supported values are: bicgstab, bicg, cg, cgs, fcg, gmres, "
+              "lower_trs, upper_trs, overhead");
 
 DEFINE_uint32(
     nrhs, 1,
@@ -165,6 +165,20 @@ const std::map<std::string, std::function<std::unique_ptr<gko::LinOpFactory>(
                                     .on(exec))
                             .with_krylov_dim(FLAGS_gmres_restart)
                             .with_preconditioner(give(precond))
+                            .on(exec);
+                    }},
+                   {"lower_trs",
+                    [](std::shared_ptr<const gko::Executor> exec,
+                       std::shared_ptr<const gko::LinOpFactory> precond) {
+                        return gko::solver::LowerTrs<>::build()
+                            .with_num_rhs(FLAGS_nrhs)
+                            .on(exec);
+                    }},
+                   {"upper_trs",
+                    [](std::shared_ptr<const gko::Executor> exec,
+                       std::shared_ptr<const gko::LinOpFactory> precond) {
+                        return gko::solver::UpperTrs<>::build()
+                            .with_num_rhs(FLAGS_nrhs)
                             .on(exec);
                     }},
                    {"overhead", create_solver<gko::Overhead<>>}};

--- a/benchmark/solver/solver.cpp
+++ b/benchmark/solver/solver.cpp
@@ -169,14 +169,14 @@ const std::map<std::string, std::function<std::unique_ptr<gko::LinOpFactory>(
                     }},
                    {"lower_trs",
                     [](std::shared_ptr<const gko::Executor> exec,
-                       std::shared_ptr<const gko::LinOpFactory> precond) {
+                       std::shared_ptr<const gko::LinOpFactory>) {
                         return gko::solver::LowerTrs<>::build()
                             .with_num_rhs(FLAGS_nrhs)
                             .on(exec);
                     }},
                    {"upper_trs",
                     [](std::shared_ptr<const gko::Executor> exec,
-                       std::shared_ptr<const gko::LinOpFactory> precond) {
+                       std::shared_ptr<const gko::LinOpFactory>) {
                         return gko::solver::UpperTrs<>::build()
                             .with_num_rhs(FLAGS_nrhs)
                             .on(exec);


### PR DESCRIPTION
For @lksriemer's experiments, this PR adds the triangular solvers to our benchmarks.

Usage: 
```bash
echo '[{"filename":"upper-triangular.mtx", "optimal": {"spmv":"csr"}}]' > input.json
echo '[{"filename":"upper-triangular.mtx", "rhs": "rhs.mtx", "optimal": {"spmv":"csr"}}]' > input2.json
benchmark/solver/solver -solvers upper_trs -executor cuda < input.json
benchmark/solver/solver -solvers upper_trs -executor cuda < input2.json
```
Output:
```json
[
    {
        "filename": "upper-triangular.mtx",
        "optimal": {
            "spmv": "csr"
        },
        "solver": {
            "upper_trs": {
                "recurrent_residuals": [],
                "true_residuals": [],
                "iteration_timestamps": [],
                "rhs_norm": 6.0,
                "generate": {
                    "components": {
                        "upper_trs::generate#3": 100,
                        "upper_trs::init_struct#1": 700
                    },
                    "time": 700.0
                },
                "apply": {
                    "components": {
                        "upper_trs::should_perform_transpose#1": 200,
                        "upper_trs::solve#6": 400
                    },
                    "iterations": 0,
                    "time": 700.0
                },
                "residual_norm": 7.12901703041511e-16,
                "completed": true
            }
        }
    }
]
```
By default, the right-hand side consists of all ones or the specified vector in the `rhs` json parameter, it can be set to random values using the `-random_rhs` flag

The specified runtimes are in nanoseconds.

If you want to extract the lower triangular factor of a MatrixMarket file, you can use
```bash
awk '{ if ($1 >= $2 || $1 ~ /^%/) print }' input.mtx > lower_triangular.mtx
awk '{ if ($1 <= $2 || $1 ~ /^%/) print }' input.mtx > upper_triangular.mtx
```
you only need to modify the number of non-zeros in the header line afterwards

Finally, you can specify different strategies by using different `csr` formats in `optimal`, i.e. `csrc, csrm, csri`.