### PR TITLE
Fix ForwardIterator requirements in iterator_factory

### DIFF
--- a/core/base/iterator_factory.hpp
+++ b/core/base/iterator_factory.hpp
@@ -110,7 +110,7 @@ private:
 
         ~Reference() {}
 
-        Reference(IteratorFactory &parent, array_index_type array_index)
+        Reference(IteratorFactory *parent, array_index_type array_index)
             : parent_(parent), arr_index_(array_index)
         {}
 
@@ -143,10 +143,10 @@ private:
         {
             // In C++11, it is legal for a nested class to access private
             // members of the parent class.
-            parent_.dominant_values_[arr_index_] =
-                std::move(other.parent_.dominant_values_[other.arr_index_]);
-            parent_.secondary_values_[arr_index_] =
-                std::move(other.parent_.secondary_values_[other.arr_index_]);
+            parent_->dominant_values_[arr_index_] =
+                std::move(other.parent_->dominant_values_[other.arr_index_]);
+            parent_->secondary_values_[arr_index_] =
+                std::move(other.parent_->secondary_values_[other.arr_index_]);
             return *this;
         }
 
@@ -174,25 +174,25 @@ private:
             return left.dominant < right.dominant();
         }
 
-        ToSortType &dominant() { return parent_.dominant_values_[arr_index_]; }
+        ToSortType &dominant() { return parent_->dominant_values_[arr_index_]; }
 
         const ToSortType &dominant() const
         {
-            return parent_.dominant_values_[arr_index_];
+            return parent_->dominant_values_[arr_index_];
         }
 
         SecondaryType &secondary()
         {
-            return parent_.secondary_values_[arr_index_];
+            return parent_->secondary_values_[arr_index_];
         }
 
         const SecondaryType &secondary() const
         {
-            return parent_.secondary_values_[arr_index_];
+            return parent_->secondary_values_[arr_index_];
         }
 
     private:
-        IteratorFactory &parent_;
+        IteratorFactory *parent_;
         array_index_type arr_index_;
     };
 
@@ -214,9 +214,11 @@ private:
         using reference = Reference;
         using iterator_category = std::random_access_iterator_tag;
 
+        Iterator() = default;
+
         ~Iterator() {}
 
-        Iterator(IteratorFactory &parent, difference_type array_index)
+        Iterator(IteratorFactory *parent, difference_type array_index)
             : parent_(parent), arr_index_(array_index)
         {}
 
@@ -298,12 +300,12 @@ private:
         }
 
         // Comparable operators
-        bool operator==(const Iterator &other)
+        bool operator==(const Iterator &other) const
         {
             return arr_index_ == other.arr_index_;
         }
 
-        bool operator!=(const Iterator &other)
+        bool operator!=(const Iterator &other) const
         {
             return arr_index_ != other.arr_index_;
         }
@@ -329,8 +331,8 @@ private:
         }
 
     private:
-        IteratorFactory &parent_;
-        difference_type arr_index_;
+        IteratorFactory *parent_{};
+        difference_type arr_index_{};
     };
 
 public:
@@ -363,7 +365,7 @@ public:
      * Creates an iterator pointing to the beginning of both arrays
      * @returns  an iterator pointing to the beginning of both arrays
      */
-    Iterator begin() { return {*this, 0}; }
+    Iterator begin() { return {this, 0}; }
 
     /**
      * Creates an iterator pointing to the (excluding) end of both arrays
@@ -371,7 +373,7 @@ public:
      */
     Iterator end()
     {
-        return {*this, static_cast<typename Iterator::difference_type>(size_)};
+        return {this, static_cast<typename Iterator::difference_type>(size_)};
     }
 
 private:


### PR DESCRIPTION
Our Windows builds are currently breaking, most likely because the iterator_factor `Iterator` is not *DefaultConstructible* and not *EqualityComparable* when const, which is a requirement of *LegacyForwardIterator*. This PR adds a default constructor which stores a nullptr and the necessary operator const-ness. This is most likely required for std::sort in the new version of Microsoft's std library.