### PR TITLE
Fix some overflows and windows warnings

### DIFF
--- a/core/test/matrix/hybrid.cpp
+++ b/core/test/matrix/hybrid.cpp
@@ -443,8 +443,8 @@ TYPED_TEST(Hybrid, GetCorrectImbalanceLimit)
     auto mtx_stra = gko::as<strategy>(mtx->get_strategy());
     auto mtx2_stra = gko::as<strategy2>(mtx->template get_strategy<Mtx2>());
 
-    EXPECT_EQ(mtx_stra->get_percentage(), 0.4f);
-    EXPECT_EQ(mtx2_stra->get_percentage(), 0.4f);
+    EXPECT_EQ(mtx_stra->get_percentage(), 0.4);
+    EXPECT_EQ(mtx2_stra->get_percentage(), 0.4);
 }
 
 
@@ -459,10 +459,10 @@ TYPED_TEST(Hybrid, GetCorrectImbalanceBoundedLimit)
     auto mtx_stra = gko::as<strategy>(mtx->get_strategy());
     auto mtx2_stra = gko::as<strategy2>(mtx->template get_strategy<Mtx2>());
 
-    EXPECT_EQ(mtx_stra->get_percentage(), 0.4f);
-    EXPECT_EQ(mtx_stra->get_ratio(), 0.1f);
-    EXPECT_EQ(mtx2_stra->get_percentage(), 0.4f);
-    EXPECT_EQ(mtx2_stra->get_ratio(), 0.1f);
+    EXPECT_EQ(mtx_stra->get_percentage(), 0.4);
+    EXPECT_EQ(mtx_stra->get_ratio(), 0.1);
+    EXPECT_EQ(mtx2_stra->get_percentage(), 0.4);
+    EXPECT_EQ(mtx2_stra->get_ratio(), 0.1);
 }
 
 

--- a/include/ginkgo/core/base/abstract_factory.hpp
+++ b/include/ginkgo/core/base/abstract_factory.hpp
@@ -266,7 +266,8 @@ private:
  *                  used
  */
 template <typename ConcreteParametersType, typename Factory>
-struct enable_parameters_type {
+class enable_parameters_type {
+public:
     using factory = Factory;
 
     /**

--- a/include/ginkgo/core/base/lin_op.hpp
+++ b/include/ginkgo/core/base/lin_op.hpp
@@ -916,8 +916,8 @@ public:                                                                      \
                                                   _parameters_name##_type> { \
         friend class ::gko::EnablePolymorphicObject<_factory_name,           \
                                                     ::gko::LinOpFactory>;    \
-        friend struct ::gko::enable_parameters_type<_parameters_name##_type, \
-                                                    _factory_name>;          \
+        friend class ::gko::enable_parameters_type<_parameters_name##_type,  \
+                                                   _factory_name>;           \
         explicit _factory_name(std::shared_ptr<const ::gko::Executor> exec)  \
             : ::gko::EnableDefaultLinOpFactory<_factory_name, _lin_op,       \
                                                _parameters_name##_type>(     \

--- a/include/ginkgo/core/matrix/csr.hpp
+++ b/include/ginkgo/core/matrix/csr.hpp
@@ -239,9 +239,9 @@ public:
             }
             auto num_rows = mtx_row_ptrs.get_num_elems() - 1;
             max_length_per_row_ = 0;
-            for (index_type i = 1; i < num_rows + 1; i++) {
+            for (size_type i = 0; i < num_rows; i++) {
                 max_length_per_row_ = std::max(max_length_per_row_,
-                                               row_ptrs[i] - row_ptrs[i - 1]);
+                                               row_ptrs[i + 1] - row_ptrs[i]);
             }
         }
 
@@ -461,7 +461,7 @@ public:
 #endif  // GINKGO_HIP_PLATFORM_HCC
 
                 auto nwarps = nwarps_ * multiple;
-                return min(ceildiv(nnz, warp_size_), int64_t(nwarps));
+                return min(ceildiv(nnz, warp_size_), nwarps);
             } else {
                 return 0;
             }
@@ -577,8 +577,8 @@ public:
                 this->set_name(actual_strategy.get_name());
             } else {
                 index_type maxnum = 0;
-                for (index_type i = 1; i < num_rows + 1; i++) {
-                    maxnum = std::max(maxnum, row_ptrs[i] - row_ptrs[i - 1]);
+                for (size_type i = 0; i < num_rows; i++) {
+                    maxnum = std::max(maxnum, row_ptrs[i + 1] - row_ptrs[i]);
                 }
                 if (maxnum > row_len_limit) {
                     load_balance actual_strategy(nwarps_, warp_size_,

--- a/include/ginkgo/core/matrix/hybrid.hpp
+++ b/include/ginkgo/core/matrix/hybrid.hpp
@@ -245,10 +245,10 @@ public:
          * @param percent  the row_nnz[floor(num_rows*percent)] is the number of
          *                 stored elements per row of the ell part
          */
-        explicit imbalance_limit(float percent = 0.8) : percent_(percent)
+        explicit imbalance_limit(double percent = 0.8) : percent_(percent)
         {
-            percent_ = std::min(percent_, 1.0f);
-            percent_ = std::max(percent_, 0.0f);
+            percent_ = std::min(percent_, 1.0);
+            percent_ = std::max(percent_, 0.0);
         }
 
         size_type compute_ell_num_stored_elements_per_row(
@@ -276,7 +276,7 @@ public:
         auto get_percentage() const { return percent_; }
 
     private:
-        float percent_;
+        double percent_;
     };
 
     /**
@@ -289,7 +289,7 @@ public:
         /**
          * Creates a imbalance_bounded_limit strategy.
          */
-        imbalance_bounded_limit(float percent = 0.8, float ratio = 0.0001)
+        imbalance_bounded_limit(double percent = 0.8, double ratio = 0.0001)
             : strategy_(imbalance_limit(percent)), ratio_(ratio)
         {}
 
@@ -319,7 +319,7 @@ public:
 
     private:
         imbalance_limit strategy_;
-        float ratio_;
+        double ratio_;
     };
 
 

--- a/include/ginkgo/core/preconditioner/jacobi.hpp
+++ b/include/ginkgo/core/preconditioner/jacobi.hpp
@@ -484,7 +484,8 @@ public:
          * accuracy to a value as close as possible to `dropout` will result in
          * optimal memory savings, while not degrading the quality of solution.
          */
-        remove_complex<value_type> GKO_FACTORY_PARAMETER_SCALAR(accuracy, 1e-1);
+        remove_complex<value_type> GKO_FACTORY_PARAMETER_SCALAR(
+            accuracy, static_cast<remove_complex<value_type>>(1e-1));
     };
     GKO_ENABLE_LIN_OP_FACTORY(Jacobi, parameters, Factory);
     GKO_ENABLE_BUILD_METHOD(Factory);

--- a/include/ginkgo/core/stop/criterion.hpp
+++ b/include/ginkgo/core/stop/criterion.hpp
@@ -297,8 +297,8 @@ public:                                                                      \
               _factory_name, _criterion, _parameters_name##_type> {          \
         friend class ::gko::EnablePolymorphicObject<                         \
             _factory_name, ::gko::stop::CriterionFactory>;                   \
-        friend struct ::gko::enable_parameters_type<_parameters_name##_type, \
-                                                    _factory_name>;          \
+        friend class ::gko::enable_parameters_type<_parameters_name##_type,  \
+                                                   _factory_name>;           \
         explicit _factory_name(std::shared_ptr<const ::gko::Executor> exec)  \
             : ::gko::stop::EnableDefaultCriterionFactory<                    \
                   _factory_name, _criterion, _parameters_name##_type>(       \

--- a/include/ginkgo/core/stop/residual_norm.hpp
+++ b/include/ginkgo/core/stop/residual_norm.hpp
@@ -121,8 +121,8 @@ public:
         /**
          * Factor by which the residual norm will be reduced
          */
-        remove_complex<ValueType> GKO_FACTORY_PARAMETER_SCALAR(reduction_factor,
-                                                               1e-15);
+        remove_complex<ValueType> GKO_FACTORY_PARAMETER_SCALAR(
+            reduction_factor, static_cast<remove_complex<ValueType>>(1e-15));
     };
     GKO_ENABLE_CRITERION_FACTORY(ResidualNormReduction<ValueType>, parameters,
                                  Factory);
@@ -187,8 +187,8 @@ public:
         /**
          * Relative residual norm goal
          */
-        remove_complex<ValueType> GKO_FACTORY_PARAMETER_SCALAR(tolerance,
-                                                               1e-15);
+        remove_complex<ValueType> GKO_FACTORY_PARAMETER_SCALAR(
+            tolerance, static_cast<remove_complex<ValueType>>(1e-15));
     };
     GKO_ENABLE_CRITERION_FACTORY(RelativeResidualNorm<ValueType>, parameters,
                                  Factory);
@@ -251,8 +251,8 @@ public:
         /**
          * Absolute residual norm goal
          */
-        remove_complex<ValueType> GKO_FACTORY_PARAMETER_SCALAR(tolerance,
-                                                               1e-15);
+        remove_complex<ValueType> GKO_FACTORY_PARAMETER_SCALAR(
+            tolerance, static_cast<remove_complex<ValueType>>(1e-15));
     };
     GKO_ENABLE_CRITERION_FACTORY(AbsoluteResidualNorm<ValueType>, parameters,
                                  Factory);

--- a/omp/components/prefix_sum.cpp
+++ b/omp/components/prefix_sum.cpp
@@ -44,7 +44,7 @@ void prefix_sum(std::shared_ptr<const OmpExecutor> exec, IndexType *counts,
                 size_type num_entries)
 {
     IndexType partial_sum{};
-    for (IndexType i = 0; i < num_entries; ++i) {
+    for (size_type i = 0; i < num_entries; ++i) {
         auto nnz = counts[i];
         counts[i] = partial_sum;
         partial_sum += nnz;

--- a/omp/solver/lower_trs_kernels.cpp
+++ b/omp/solver/lower_trs_kernels.cpp
@@ -107,7 +107,7 @@ void solve(std::shared_ptr<const OmpExecutor> exec,
     for (size_type j = 0; j < b->get_size()[1]; ++j) {
         for (size_type row = 0; row < matrix->get_size()[0]; ++row) {
             x->at(row, j) = b->at(row, j) / vals[row_ptrs[row + 1] - 1];
-            for (size_type k = row_ptrs[row]; k < row_ptrs[row + 1]; ++k) {
+            for (auto k = row_ptrs[row]; k < row_ptrs[row + 1]; ++k) {
                 auto col = col_idxs[k];
                 if (col < row) {
                     x->at(row, j) +=

--- a/omp/solver/upper_trs_kernels.cpp
+++ b/omp/solver/upper_trs_kernels.cpp
@@ -104,10 +104,12 @@ void solve(std::shared_ptr<const OmpExecutor> exec,
     auto vals = matrix->get_const_values();
 
 #pragma omp parallel for
-    for (int j = 0; j < b->get_size()[1]; ++j) {
-        for (int row = matrix->get_size()[0] - 1; row >= 0; --row) {
+    for (size_type j = 0; j < b->get_size()[1]; ++j) {
+        for (size_type inv_row = 0; inv_row < matrix->get_size()[0];
+             ++inv_row) {
+            auto row = matrix->get_size()[0] - 1 - inv_row;
             x->at(row, j) = b->at(row, j) / vals[row_ptrs[row]];
-            for (int k = row_ptrs[row]; k < row_ptrs[row + 1]; ++k) {
+            for (auto k = row_ptrs[row]; k < row_ptrs[row + 1]; ++k) {
                 auto col = col_idxs[k];
                 if (col > row) {
                     x->at(row, j) +=

--- a/reference/components/csr_spgeam.hpp
+++ b/reference/components/csr_spgeam.hpp
@@ -77,7 +77,7 @@ void abstract_spgeam(const matrix::Csr<ValueType, IndexType> *a,
         auto b_end = b_row_ptrs[row + 1];
         auto total_size = (a_end - a_begin) + (b_end - b_begin);
         bool skip{};
-        auto local_data = begin_cb(row);
+        auto local_data = begin_cb(static_cast<IndexType>(row));
         for (IndexType i = 0; i < total_size; ++i) {
             if (skip) {
                 skip = false;

--- a/reference/components/prefix_sum.cpp
+++ b/reference/components/prefix_sum.cpp
@@ -44,7 +44,7 @@ void prefix_sum(std::shared_ptr<const ReferenceExecutor> exec,
                 IndexType *counts, size_type num_entries)
 {
     IndexType partial_sum{};
-    for (IndexType i = 0; i < num_entries; ++i) {
+    for (size_type i = 0; i < num_entries; ++i) {
         auto nnz = counts[i];
         counts[i] = partial_sum;
         partial_sum += nnz;

--- a/reference/factorization/factorization_kernels.cpp
+++ b/reference/factorization/factorization_kernels.cpp
@@ -150,7 +150,7 @@ void add_diagonal_elements(std::shared_ptr<const ReferenceExecutor> exec,
             ++added_elements;
         }
     }
-    row_ptrs[num_rows] = new_nnz;
+    row_ptrs[num_rows] = static_cast<IndexType>(new_nnz);
 
     matrix::CsrBuilder<ValueType, IndexType> mtx_builder{mtx};
     mtx_builder.get_value_array() = std::move(new_values_array);
@@ -169,14 +169,14 @@ void initialize_row_ptrs_l_u(
 {
     auto row_ptrs = system_matrix->get_const_row_ptrs();
     auto col_idxs = system_matrix->get_const_col_idxs();
-    size_type l_nnz{};
-    size_type u_nnz{};
+    IndexType l_nnz{};
+    IndexType u_nnz{};
 
     l_row_ptrs[0] = 0;
     u_row_ptrs[0] = 0;
     for (size_type row = 0; row < system_matrix->get_size()[0]; ++row) {
-        for (size_type el = row_ptrs[row]; el < row_ptrs[row + 1]; ++el) {
-            size_type col = col_idxs[el];
+        for (auto el = row_ptrs[row]; el < row_ptrs[row + 1]; ++el) {
+            auto col = col_idxs[el];
             // don't count diagonal
             l_nnz += col < row;
             u_nnz += col > row;

--- a/reference/factorization/par_ict_kernels.cpp
+++ b/reference/factorization/par_ict_kernels.cpp
@@ -77,8 +77,7 @@ void compute_factor(std::shared_ptr<const DefaultExecutor> exec,
     auto a_vals = a->get_const_values();
 
     for (size_type row = 0; row < num_rows; ++row) {
-        for (size_type l_nz = l_row_ptrs[row]; l_nz < l_row_ptrs[row + 1];
-             ++l_nz) {
+        for (auto l_nz = l_row_ptrs[row]; l_nz < l_row_ptrs[row + 1]; ++l_nz) {
             auto col = l_col_idxs[l_nz];
             // find value from A
             auto a_begin = a_row_ptrs[row];

--- a/reference/matrix/csr_kernels.cpp
+++ b/reference/matrix/csr_kernels.cpp
@@ -218,7 +218,7 @@ void spgemm(std::shared_ptr<const ReferenceExecutor> exec,
     for (size_type a_row = 0; a_row < num_rows; ++a_row) {
         local_col_idxs.clear();
         spgemm_insert_row2(local_col_idxs, a, b, a_row);
-        c_row_ptrs[a_row] = local_col_idxs.size();
+        c_row_ptrs[a_row] = static_cast<IndexType>(local_col_idxs.size());
     }
 
     // build row pointers
@@ -272,7 +272,7 @@ void advanced_spgemm(std::shared_ptr<const ReferenceExecutor> exec,
         local_col_idxs.clear();
         spgemm_insert_row(local_col_idxs, d, a_row);
         spgemm_insert_row2(local_col_idxs, a, b, a_row);
-        c_row_ptrs[a_row] = local_col_idxs.size();
+        c_row_ptrs[a_row] = static_cast<IndexType>(local_col_idxs.size());
     }
 
     // build row pointers
@@ -429,7 +429,7 @@ void convert_to_sellp(std::shared_ptr<const ReferenceExecutor> exec,
     const auto source_col_idxs = source->get_const_col_idxs();
     const auto source_values = source->get_const_values();
 
-    int slice_num = ceildiv(num_rows, slice_size);
+    auto slice_num = ceildiv(num_rows, slice_size);
     slice_sets[0] = 0;
     for (size_type slice = 0; slice < slice_num; slice++) {
         if (slice > 0) {

--- a/reference/matrix/dense_kernels.cpp
+++ b/reference/matrix/dense_kernels.cpp
@@ -383,7 +383,7 @@ void convert_to_sellp(std::shared_ptr<const ReferenceExecutor> exec,
     auto stride_factor = (result->get_stride_factor() == 0)
                              ? matrix::default_stride_factor
                              : result->get_stride_factor();
-    int slice_num = ceildiv(num_rows, slice_size);
+    auto slice_num = ceildiv(num_rows, slice_size);
     slice_sets[0] = 0;
     for (size_type slice = 0; slice < slice_num; slice++) {
         if (slice > 0) {

--- a/reference/preconditioner/jacobi_kernels.cpp
+++ b/reference/preconditioner/jacobi_kernels.cpp
@@ -116,9 +116,9 @@ inline size_type agglomerate_supervariables(uint32 max_block_size,
         return 0;
     }
     size_type num_blocks = 1;
-    int32 current_block_size = block_ptrs[1] - block_ptrs[0];
+    auto current_block_size = block_ptrs[1] - block_ptrs[0];
     for (size_type i = 1; i < num_natural_blocks; ++i) {
-        const int32 block_size = block_ptrs[i + 1] - block_ptrs[i];
+        const auto block_size = block_ptrs[i + 1] - block_ptrs[i];
         if (current_block_size + block_size <= max_block_size) {
             current_block_size += block_size;
         } else {
@@ -170,7 +170,7 @@ inline void extract_block(const matrix::Csr<ValueType, IndexType> *mtx,
     for (int row = 0; row < block_size; ++row) {
         const auto start = row_ptrs[block_start + row];
         const auto end = row_ptrs[block_start + row + 1];
-        for (int i = start; i < end; ++i) {
+        for (auto i = start; i < end; ++i) {
             const auto col = col_idxs[i] - block_start;
             if (0 <= col && col < block_size) {
                 block[row * stride + col] = vals[i];
@@ -359,7 +359,7 @@ void generate(std::shared_ptr<const ReferenceExecutor> exec,
         vector<Array<IndexType>> perm(group_size, {}, exec);
         vector<uint32> pr_descriptors(group_size, uint32{} - 1, exec);
         // extract group of blocks, invert them, figure out storage precision
-        for (size_type b = 0; b < group_size; ++b) {
+        for (IndexType b = 0; b < group_size; ++b) {
             if (b + g >= num_blocks) {
                 break;
             }
@@ -413,7 +413,7 @@ void generate(std::shared_ptr<const ReferenceExecutor> exec,
                             [](uint32 x, uint32 y) { return x & y; }));
 
         // store the blocks
-        for (size_type b = 0; b < group_size; ++b) {
+        for (IndexType b = 0; b < group_size; ++b) {
             if (b + g >= num_blocks) {
                 break;
             }

--- a/reference/solver/lower_trs_kernels.cpp
+++ b/reference/solver/lower_trs_kernels.cpp
@@ -103,7 +103,7 @@ void solve(std::shared_ptr<const ReferenceExecutor> exec,
     for (size_type j = 0; j < b->get_size()[1]; ++j) {
         for (size_type row = 0; row < matrix->get_size()[0]; ++row) {
             x->at(row, j) = b->at(row, j) / vals[row_ptrs[row + 1] - 1];
-            for (size_type k = row_ptrs[row]; k < row_ptrs[row + 1]; ++k) {
+            for (auto k = row_ptrs[row]; k < row_ptrs[row + 1]; ++k) {
                 auto col = col_idxs[k];
                 if (col < row) {
                     x->at(row, j) +=

--- a/reference/solver/upper_trs_kernels.cpp
+++ b/reference/solver/upper_trs_kernels.cpp
@@ -100,10 +100,12 @@ void solve(std::shared_ptr<const ReferenceExecutor> exec,
     auto col_idxs = matrix->get_const_col_idxs();
     auto vals = matrix->get_const_values();
 
-    for (int j = 0; j < b->get_size()[1]; ++j) {
-        for (int row = matrix->get_size()[0] - 1; row >= 0; --row) {
+    for (size_type j = 0; j < b->get_size()[1]; ++j) {
+        for (size_type inv_row = 0; inv_row < matrix->get_size()[0];
+             ++inv_row) {
+            auto row = matrix->get_size()[0] - 1 - inv_row;
             x->at(row, j) = b->at(row, j) / vals[row_ptrs[row]];
-            for (int k = row_ptrs[row]; k < row_ptrs[row + 1]; ++k) {
+            for (auto k = row_ptrs[row]; k < row_ptrs[row + 1]; ++k) {
                 auto col = col_idxs[k];
                 if (col > row) {
                     x->at(row, j) +=


### PR DESCRIPTION
When I looked at a few of the warnings that the MSVC compiler generates, I realized that many of them point to potential overflows with 64bit indices, so I will use this PR to collect fixes for these issues.