### PR TITLE
fix idr and criterion in solver benchmark

### DIFF
--- a/benchmark/solver/solver.cpp
+++ b/benchmark/solver/solver.cpp
@@ -151,6 +151,7 @@ const std::map<std::string, std::function<std::unique_ptr<gko::LinOpFactory>(
                    {"cg", create_solver<gko::solver::Cg<>>},
                    {"cgs", create_solver<gko::solver::Cgs<>>},
                    {"fcg", create_solver<gko::solver::Fcg<>>},
+                   {"idr", create_solver<gko::solver::Idr<>>},
                    {"gmres",
                     [](std::shared_ptr<const gko::Executor> exec,
                        std::shared_ptr<const gko::LinOpFactory> precond) {

--- a/benchmark/solver/solver.cpp
+++ b/benchmark/solver/solver.cpp
@@ -43,6 +43,9 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <iostream>
 
 
+#include <ginkgo/core/preconditioner/isai.hpp>
+
+
 #include "benchmark/utils/formats.hpp"
 #include "benchmark/utils/general.hpp"
 #include "benchmark/utils/loggers.hpp"


### PR DESCRIPTION
Small fix - add idr in solver_factory of benchmark.
is any parameter left for user input? I can also add it in this pr.

Add create_criterion to keep the consistent stopping criteria.