### PR TITLE
Support Mixed precision SpMV and BLAS operations

### DIFF
--- a/common/solver/cb_gmres_kernels.hpp.inc
+++ b/common/solver/cb_gmres_kernels.hpp.inc
@@ -326,8 +326,8 @@ __global__ __launch_bounds__(dot_dim *dot_dim) void multidot_kernel(
     if (col_idx < num_cols && !stop_status[col_idx].has_stopped()) {
         for (size_type i = start_row; i < end_row; i += blockDim.y) {
             const auto next_krylov_idx = i * stride_next_krylov + col_idx;
-            local_res += next_krylov_basis[next_krylov_idx] *
-                         krylov_bases(k, i, col_idx);
+            ValueType other_basis = krylov_bases(k, i, col_idx);
+            local_res += next_krylov_basis[next_krylov_idx] * conj(other_basis);
         }
     }
     // Transpose local_res, so each warp contains a local_res from the same
@@ -380,8 +380,8 @@ __global__ __launch_bounds__(block_size) void singledot_kernel(
     if (!stop_status[col_idx].has_stopped()) {
         for (size_type i = start_row; i < end_row; i += block_size) {
             const auto next_krylov_idx = i * stride_next_krylov + col_idx;
-            local_res += next_krylov_basis[next_krylov_idx] *
-                         krylov_bases(k, i, col_idx);
+            ValueType other_basis = krylov_bases(k, i, col_idx);
+            local_res += next_krylov_basis[next_krylov_idx] * conj(other_basis);
         }
     }
     // Transpose local_res, so each warp contains a local_res from the same

--- a/core/matrix/coo.cpp
+++ b/core/matrix/coo.cpp
@@ -40,6 +40,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <ginkgo/core/base/exception_helpers.hpp>
 #include <ginkgo/core/base/executor.hpp>
 #include <ginkgo/core/base/math.hpp>
+#include <ginkgo/core/base/precision_dispatch.hpp>
 #include <ginkgo/core/base/utils.hpp>
 #include <ginkgo/core/matrix/csr.hpp>
 #include <ginkgo/core/matrix/dense.hpp>
@@ -77,17 +78,11 @@ GKO_REGISTER_OPERATION(outplace_absolute_array,
 template <typename ValueType, typename IndexType>
 void Coo<ValueType, IndexType>::apply_impl(const LinOp *b, LinOp *x) const
 {
-    using ComplexDense = Dense<to_complex<ValueType>>;
-
-    if (dynamic_cast<const Dense<ValueType> *>(b)) {
-        this->get_executor()->run(coo::make_spmv(this, as<Dense<ValueType>>(b),
-                                                 as<Dense<ValueType>>(x)));
-    } else {
-        auto dense_b = as<ComplexDense>(b);
-        auto dense_x = as<ComplexDense>(x);
-        this->apply(dense_b->create_real_view().get(),
-                    dense_x->create_real_view().get());
-    }
+    precision_dispatch_real_complex<ValueType>(
+        [this](auto dense_b, auto dense_x) {
+            this->get_executor()->run(coo::make_spmv(this, dense_b, dense_x));
+        },
+        b, x);
 }
 
 
@@ -95,38 +90,23 @@ template <typename ValueType, typename IndexType>
 void Coo<ValueType, IndexType>::apply_impl(const LinOp *alpha, const LinOp *b,
                                            const LinOp *beta, LinOp *x) const
 {
-    using ComplexDense = Dense<to_complex<ValueType>>;
-    using RealDense = Dense<remove_complex<ValueType>>;
-
-    if (dynamic_cast<const Dense<ValueType> *>(b)) {
-        this->get_executor()->run(coo::make_advanced_spmv(
-            as<Dense<ValueType>>(alpha), this, as<Dense<ValueType>>(b),
-            as<Dense<ValueType>>(beta), as<Dense<ValueType>>(x)));
-    } else {
-        auto dense_b = as<ComplexDense>(b);
-        auto dense_x = as<ComplexDense>(x);
-        auto dense_alpha = as<RealDense>(alpha);
-        auto dense_beta = as<RealDense>(beta);
-        this->apply(dense_alpha, dense_b->create_real_view().get(), dense_beta,
-                    dense_x->create_real_view().get());
-    }
+    precision_dispatch_real_complex<ValueType>(
+        [this](auto dense_alpha, auto dense_b, auto dense_beta, auto dense_x) {
+            this->get_executor()->run(coo::make_advanced_spmv(
+                dense_alpha, this, dense_b, dense_beta, dense_x));
+        },
+        alpha, b, beta, x);
 }
 
 
 template <typename ValueType, typename IndexType>
 void Coo<ValueType, IndexType>::apply2_impl(const LinOp *b, LinOp *x) const
 {
-    using ComplexDense = Dense<to_complex<ValueType>>;
-
-    if (dynamic_cast<const Dense<ValueType> *>(b)) {
-        this->get_executor()->run(coo::make_spmv2(this, as<Dense<ValueType>>(b),
-                                                  as<Dense<ValueType>>(x)));
-    } else {
-        auto dense_b = as<ComplexDense>(b);
-        auto dense_x = as<ComplexDense>(x);
-        this->apply2(dense_b->create_real_view().get(),
-                     dense_x->create_real_view().get());
-    }
+    precision_dispatch_real_complex<ValueType>(
+        [this](auto dense_b, auto dense_x) {
+            this->get_executor()->run(coo::make_spmv2(this, dense_b, dense_x));
+        },
+        b, x);
 }
 
 
@@ -134,20 +114,12 @@ template <typename ValueType, typename IndexType>
 void Coo<ValueType, IndexType>::apply2_impl(const LinOp *alpha, const LinOp *b,
                                             LinOp *x) const
 {
-    using ComplexDense = Dense<to_complex<ValueType>>;
-    using RealDense = Dense<remove_complex<ValueType>>;
-
-    if (dynamic_cast<const Dense<ValueType> *>(b)) {
-        this->get_executor()->run(coo::make_advanced_spmv2(
-            as<Dense<ValueType>>(alpha), this, as<Dense<ValueType>>(b),
-            as<Dense<ValueType>>(x)));
-    } else {
-        auto dense_b = as<ComplexDense>(b);
-        auto dense_x = as<ComplexDense>(x);
-        auto dense_alpha = as<RealDense>(alpha);
-        this->apply2(dense_alpha, dense_b->create_real_view().get(),
-                     dense_x->create_real_view().get());
-    }
+    precision_dispatch_real_complex<ValueType>(
+        [this](auto dense_alpha, auto dense_b, auto dense_x) {
+            this->get_executor()->run(
+                coo::make_advanced_spmv2(dense_alpha, this, dense_b, dense_x));
+        },
+        alpha, b, x);
 }
 
 

--- a/core/matrix/diagonal.cpp
+++ b/core/matrix/diagonal.cpp
@@ -34,6 +34,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
 #include <ginkgo/core/base/exception_helpers.hpp>
+#include <ginkgo/core/base/precision_dispatch.hpp>
 #include <ginkgo/core/base/utils.hpp>
 #include <ginkgo/core/matrix/dense.hpp>
 
@@ -67,12 +68,8 @@ void Diagonal<ValueType>::apply_impl(const LinOp *b, LinOp *x) const
 {
     auto exec = this->get_executor();
 
-    if (dynamic_cast<const Dense<ValueType> *>(b) &&
-        dynamic_cast<Dense<ValueType> *>(x)) {
-        exec->run(diagonal::make_apply_to_dense(this, as<Dense<ValueType>>(b),
-                                                as<Dense<ValueType>>(x)));
-    } else if (dynamic_cast<const Csr<ValueType, int32> *>(b) &&
-               dynamic_cast<Csr<ValueType, int32> *>(x)) {
+    if (dynamic_cast<const Csr<ValueType, int32> *>(b) &&
+        dynamic_cast<Csr<ValueType, int32> *>(x)) {
         exec->run(diagonal::make_apply_to_csr(
             this, as<Csr<ValueType, int32>>(b), as<Csr<ValueType, int32>>(x)));
     } else if (dynamic_cast<const Csr<ValueType, int64> *>(b) &&
@@ -80,7 +77,12 @@ void Diagonal<ValueType>::apply_impl(const LinOp *b, LinOp *x) const
         exec->run(diagonal::make_apply_to_csr(
             this, as<Csr<ValueType, int64>>(b), as<Csr<ValueType, int64>>(x)));
     } else {
-        GKO_NOT_IMPLEMENTED;
+        precision_dispatch_real_complex<ValueType>(
+            [this, &exec](auto dense_b, auto dense_x) {
+                exec->run(
+                    diagonal::make_apply_to_dense(this, dense_b, dense_x));
+            },
+            b, x);
     }
 }
 
@@ -90,12 +92,8 @@ void Diagonal<ValueType>::rapply_impl(const LinOp *b, LinOp *x) const
 {
     auto exec = this->get_executor();
 
-    if (dynamic_cast<const Dense<ValueType> *>(b) &&
-        dynamic_cast<Dense<ValueType> *>(x)) {
-        exec->run(diagonal::make_right_apply_to_dense(
-            this, as<Dense<ValueType>>(b), as<Dense<ValueType>>(x)));
-    } else if (dynamic_cast<const Csr<ValueType, int32> *>(b) &&
-               dynamic_cast<Csr<ValueType, int32> *>(x)) {
+    if (dynamic_cast<const Csr<ValueType, int32> *>(b) &&
+        dynamic_cast<Csr<ValueType, int32> *>(x)) {
         exec->run(diagonal::make_right_apply_to_csr(
             this, as<Csr<ValueType, int32>>(b), as<Csr<ValueType, int32>>(x)));
     } else if (dynamic_cast<const Csr<ValueType, int64> *>(b) &&
@@ -103,7 +101,14 @@ void Diagonal<ValueType>::rapply_impl(const LinOp *b, LinOp *x) const
         exec->run(diagonal::make_right_apply_to_csr(
             this, as<Csr<ValueType, int64>>(b), as<Csr<ValueType, int64>>(x)));
     } else {
-        GKO_NOT_IMPLEMENTED;
+        // no real-to-complex conversion, as this would require doubling the
+        // diagonal entries for the complex-to-real columns
+        precision_dispatch<ValueType>(
+            [this, &exec](auto dense_b, auto dense_x) {
+                exec->run(diagonal::make_right_apply_to_dense(this, dense_b,
+                                                              dense_x));
+            },
+            b, x);
     }
 }
 
@@ -112,14 +117,14 @@ template <typename ValueType>
 void Diagonal<ValueType>::apply_impl(const LinOp *alpha, const LinOp *b,
                                      const LinOp *beta, LinOp *x) const
 {
-    if (dynamic_cast<const Dense<ValueType> *>(b) &&
-        dynamic_cast<Dense<ValueType> *>(x)) {
-        auto dense_x = as<Dense<ValueType>>(x);
-        dense_x->scale(beta);
-        dense_x->add_scaled(alpha, b);
-    } else {
-        GKO_NOT_IMPLEMENTED;
-    }
+    precision_dispatch_real_complex<ValueType>(
+        [this](auto dense_alpha, auto dense_b, auto dense_beta, auto dense_x) {
+            auto x_clone = dense_x->clone();
+            this->apply(dense_b, x_clone.get());
+            dense_x->scale(dense_beta);
+            dense_x->add_scaled(dense_alpha, x_clone.get());
+        },
+        alpha, b, beta, x);
 }
 
 

--- a/core/matrix/diagonal.cpp
+++ b/core/matrix/diagonal.cpp
@@ -120,7 +120,7 @@ void Diagonal<ValueType>::apply_impl(const LinOp *alpha, const LinOp *b,
     precision_dispatch_real_complex<ValueType>(
         [this](auto dense_alpha, auto dense_b, auto dense_beta, auto dense_x) {
             auto x_clone = dense_x->clone();
-            this->apply(dense_b, x_clone.get());
+            this->apply_impl(dense_b, x_clone.get());
             dense_x->scale(dense_beta);
             dense_x->add_scaled(dense_alpha, x_clone.get());
         },

--- a/core/matrix/ell.cpp
+++ b/core/matrix/ell.cpp
@@ -39,6 +39,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <ginkgo/core/base/exception_helpers.hpp>
 #include <ginkgo/core/base/executor.hpp>
 #include <ginkgo/core/base/math.hpp>
+#include <ginkgo/core/base/precision_dispatch.hpp>
 #include <ginkgo/core/base/utils.hpp>
 #include <ginkgo/core/matrix/csr.hpp>
 #include <ginkgo/core/matrix/dense.hpp>
@@ -101,17 +102,11 @@ size_type calculate_max_nnz_per_row(
 template <typename ValueType, typename IndexType>
 void Ell<ValueType, IndexType>::apply_impl(const LinOp *b, LinOp *x) const
 {
-    using ComplexDense = Dense<to_complex<ValueType>>;
-
-    if (dynamic_cast<const Dense<ValueType> *>(b)) {
-        this->get_executor()->run(ell::make_spmv(this, as<Dense<ValueType>>(b),
-                                                 as<Dense<ValueType>>(x)));
-    } else {
-        auto dense_b = as<ComplexDense>(b);
-        auto dense_x = as<ComplexDense>(x);
-        this->apply(dense_b->create_real_view().get(),
-                    dense_x->create_real_view().get());
-    }
+    precision_dispatch_real_complex<ValueType>(
+        [this](auto dense_b, auto dense_x) {
+            this->get_executor()->run(ell::make_spmv(this, dense_b, dense_x));
+        },
+        b, x);
 }
 
 
@@ -119,21 +114,12 @@ template <typename ValueType, typename IndexType>
 void Ell<ValueType, IndexType>::apply_impl(const LinOp *alpha, const LinOp *b,
                                            const LinOp *beta, LinOp *x) const
 {
-    using ComplexDense = Dense<to_complex<ValueType>>;
-    using RealDense = Dense<remove_complex<ValueType>>;
-
-    if (dynamic_cast<const Dense<ValueType> *>(b)) {
-        this->get_executor()->run(ell::make_advanced_spmv(
-            as<Dense<ValueType>>(alpha), this, as<Dense<ValueType>>(b),
-            as<Dense<ValueType>>(beta), as<Dense<ValueType>>(x)));
-    } else {
-        auto dense_b = as<ComplexDense>(b);
-        auto dense_x = as<ComplexDense>(x);
-        auto dense_alpha = as<RealDense>(alpha);
-        auto dense_beta = as<RealDense>(beta);
-        this->apply(dense_alpha, dense_b->create_real_view().get(), dense_beta,
-                    dense_x->create_real_view().get());
-    }
+    precision_dispatch_real_complex<ValueType>(
+        [this](auto dense_alpha, auto dense_b, auto dense_beta, auto dense_x) {
+            this->get_executor()->run(ell::make_advanced_spmv(
+                dense_alpha, this, dense_b, dense_beta, dense_x));
+        },
+        alpha, b, beta, x);
 }
 
 

--- a/core/matrix/identity.cpp
+++ b/core/matrix/identity.cpp
@@ -34,6 +34,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
 #include <ginkgo/core/base/exception_helpers.hpp>
+#include <ginkgo/core/base/precision_dispatch.hpp>
 #include <ginkgo/core/base/utils.hpp>
 #include <ginkgo/core/matrix/dense.hpp>
 
@@ -53,9 +54,12 @@ template <typename ValueType>
 void Identity<ValueType>::apply_impl(const LinOp *alpha, const LinOp *b,
                                      const LinOp *beta, LinOp *x) const
 {
-    auto dense_x = as<Dense<ValueType>>(x);
-    dense_x->scale(beta);
-    dense_x->add_scaled(alpha, b);
+    precision_dispatch_real_complex<ValueType>(
+        [this](auto dense_alpha, auto dense_b, auto dense_beta, auto dense_x) {
+            dense_x->scale(dense_beta);
+            dense_x->add_scaled(dense_alpha, dense_b);
+        },
+        alpha, b, beta, x);
 }
 
 

--- a/core/preconditioner/jacobi.cpp
+++ b/core/preconditioner/jacobi.cpp
@@ -39,6 +39,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <ginkgo/core/base/exception_helpers.hpp>
 #include <ginkgo/core/base/executor.hpp>
 #include <ginkgo/core/base/math.hpp>
+#include <ginkgo/core/base/precision_dispatch.hpp>
 #include <ginkgo/core/base/utils.hpp>
 #include <ginkgo/core/matrix/csr.hpp>
 #include <ginkgo/core/matrix/dense.hpp>
@@ -71,11 +72,14 @@ GKO_REGISTER_OPERATION(initialize_precisions, jacobi::initialize_precisions);
 template <typename ValueType, typename IndexType>
 void Jacobi<ValueType, IndexType>::apply_impl(const LinOp *b, LinOp *x) const
 {
-    using dense = matrix::Dense<ValueType>;
-    this->get_executor()->run(jacobi::make_simple_apply(
-        num_blocks_, parameters_.max_block_size, storage_scheme_,
-        parameters_.storage_optimization.block_wise, parameters_.block_pointers,
-        blocks_, as<dense>(b), as<dense>(x)));
+    precision_dispatch_real_complex<ValueType>(
+        [this](auto dense_b, auto dense_x) {
+            this->get_executor()->run(jacobi::make_simple_apply(
+                num_blocks_, parameters_.max_block_size, storage_scheme_,
+                parameters_.storage_optimization.block_wise,
+                parameters_.block_pointers, blocks_, dense_b, dense_x));
+        },
+        b, x);
 }
 
 
@@ -84,12 +88,15 @@ void Jacobi<ValueType, IndexType>::apply_impl(const LinOp *alpha,
                                               const LinOp *b, const LinOp *beta,
                                               LinOp *x) const
 {
-    using dense = matrix::Dense<ValueType>;
-    this->get_executor()->run(jacobi::make_apply(
-        num_blocks_, parameters_.max_block_size, storage_scheme_,
-        parameters_.storage_optimization.block_wise, parameters_.block_pointers,
-        blocks_, as<dense>(alpha), as<dense>(b), as<dense>(beta),
-        as<dense>(x)));
+    precision_dispatch_real_complex<ValueType>(
+        [this](auto dense_alpha, auto dense_b, auto dense_beta, auto dense_x) {
+            this->get_executor()->run(jacobi::make_apply(
+                num_blocks_, parameters_.max_block_size, storage_scheme_,
+                parameters_.storage_optimization.block_wise,
+                parameters_.block_pointers, blocks_, dense_alpha, dense_b,
+                dense_beta, dense_x));
+        },
+        alpha, b, beta, x);
 }
 
 
@@ -220,8 +227,8 @@ void Jacobi<ValueType, IndexType>::generate(const LinOp *system_matrix,
 
     const auto all_block_opt = parameters_.storage_optimization.of_all_blocks;
     auto &precisions = parameters_.storage_optimization.block_wise;
-    // if adaptive version is used, make sure that the precision array is of the
-    // correct size by replicating it multiple times if needed
+    // if adaptive version is used, make sure that the precision array is of
+    // the correct size by replicating it multiple times if needed
     if (parameters_.storage_optimization.is_block_wise ||
         all_block_opt != precision_reduction(0, 0)) {
         if (!parameters_.storage_optimization.is_block_wise) {

--- a/core/solver/bicg.cpp
+++ b/core/solver/bicg.cpp
@@ -38,6 +38,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <ginkgo/core/base/executor.hpp>
 #include <ginkgo/core/base/math.hpp>
 #include <ginkgo/core/base/name_demangling.hpp>
+#include <ginkgo/core/base/precision_dispatch.hpp>
 #include <ginkgo/core/base/utils.hpp>
 
 
@@ -110,6 +111,18 @@ std::unique_ptr<LinOp> conj_transpose_with_csr(const LinOp *mtx)
 template <typename ValueType>
 void Bicg<ValueType>::apply_impl(const LinOp *b, LinOp *x) const
 {
+    precision_dispatch_real_complex<ValueType>(
+        [this](auto dense_b, auto dense_x) {
+            this->apply_dense_impl(dense_b, dense_x);
+        },
+        b, x);
+}
+
+
+template <typename ValueType>
+void Bicg<ValueType>::apply_dense_impl(const matrix::Dense<ValueType> *dense_b,
+                                       matrix::Dense<ValueType> *dense_x) const
+{
     using std::swap;
     using Vector = matrix::Dense<ValueType>;
     constexpr uint8 RelativeStoppingId{1};
@@ -119,8 +132,6 @@ void Bicg<ValueType>::apply_impl(const LinOp *b, LinOp *x) const
     auto one_op = initialize<Vector>({one<ValueType>()}, exec);
     auto neg_one_op = initialize<Vector>({-one<ValueType>()}, exec);
 
-    auto dense_b = as<const Vector>(b);
-    auto dense_x = as<Vector>(x);
     auto r = Vector::create_with_config_of(dense_b);
     auto r2 = Vector::create_with_config_of(dense_b);
     auto z = Vector::create_with_config_of(dense_b);
@@ -179,8 +190,9 @@ void Bicg<ValueType>::apply_impl(const LinOp *b, LinOp *x) const
     r2->copy_from(r.get());
     // r2 = r
     auto stop_criterion = stop_criterion_factory_->generate(
-        system_matrix_, std::shared_ptr<const LinOp>(b, [](const LinOp *) {}),
-        x, r.get());
+        system_matrix_,
+        std::shared_ptr<const LinOp>(dense_b, [](const LinOp *) {}), dense_x,
+        r.get());
 
     int iter = -1;
 
@@ -234,12 +246,14 @@ template <typename ValueType>
 void Bicg<ValueType>::apply_impl(const LinOp *alpha, const LinOp *b,
                                  const LinOp *beta, LinOp *x) const
 {
-    auto dense_x = as<matrix::Dense<ValueType>>(x);
-
-    auto x_clone = dense_x->clone();
-    this->apply(b, x_clone.get());
-    dense_x->scale(beta);
-    dense_x->add_scaled(alpha, x_clone.get());
+    precision_dispatch_real_complex<ValueType>(
+        [this](auto dense_alpha, auto dense_b, auto dense_beta, auto dense_x) {
+            auto x_clone = dense_x->clone();
+            this->apply(dense_b, x_clone.get());
+            dense_x->scale(dense_beta);
+            dense_x->add_scaled(dense_alpha, x_clone.get());
+        },
+        alpha, b, beta, x);
 }
 
 

--- a/core/solver/bicg.cpp
+++ b/core/solver/bicg.cpp
@@ -249,7 +249,7 @@ void Bicg<ValueType>::apply_impl(const LinOp *alpha, const LinOp *b,
     precision_dispatch_real_complex<ValueType>(
         [this](auto dense_alpha, auto dense_b, auto dense_beta, auto dense_x) {
             auto x_clone = dense_x->clone();
-            this->apply(dense_b, x_clone.get());
+            this->apply_dense_impl(dense_b, x_clone.get());
             dense_x->scale(dense_beta);
             dense_x->add_scaled(dense_alpha, x_clone.get());
         },

--- a/core/solver/bicgstab.cpp
+++ b/core/solver/bicgstab.cpp
@@ -228,7 +228,7 @@ void Bicgstab<ValueType>::apply_impl(const LinOp *alpha, const LinOp *b,
     precision_dispatch_real_complex<ValueType>(
         [this](auto dense_alpha, auto dense_b, auto dense_beta, auto dense_x) {
             auto x_clone = dense_x->clone();
-            this->apply(dense_b, x_clone.get());
+            this->apply_dense_impl(dense_b, x_clone.get());
             dense_x->scale(dense_beta);
             dense_x->add_scaled(dense_alpha, x_clone.get());
         },

--- a/core/solver/bicgstab.cpp
+++ b/core/solver/bicgstab.cpp
@@ -37,6 +37,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <ginkgo/core/base/exception_helpers.hpp>
 #include <ginkgo/core/base/executor.hpp>
 #include <ginkgo/core/base/math.hpp>
+#include <ginkgo/core/base/precision_dispatch.hpp>
 #include <ginkgo/core/base/utils.hpp>
 
 
@@ -87,6 +88,19 @@ std::unique_ptr<LinOp> Bicgstab<ValueType>::conj_transpose() const
 template <typename ValueType>
 void Bicgstab<ValueType>::apply_impl(const LinOp *b, LinOp *x) const
 {
+    precision_dispatch_real_complex<ValueType>(
+        [this](auto dense_b, auto dense_x) {
+            this->apply_dense_impl(dense_b, dense_x);
+        },
+        b, x);
+}
+
+
+template <typename ValueType>
+void Bicgstab<ValueType>::apply_dense_impl(
+    const matrix::Dense<ValueType> *dense_b,
+    matrix::Dense<ValueType> *dense_x) const
+{
     using std::swap;
     using Vector = matrix::Dense<ValueType>;
     using AbsVector = matrix::Dense<remove_complex<ValueType>>;
@@ -98,8 +112,6 @@ void Bicgstab<ValueType>::apply_impl(const LinOp *b, LinOp *x) const
     auto one_op = initialize<Vector>({one<ValueType>()}, exec);
     auto neg_one_op = initialize<Vector>({-one<ValueType>()}, exec);
 
-    auto dense_b = as<Vector>(b);
-    auto dense_x = as<Vector>(x);
     auto r = Vector::create_with_config_of(dense_b);
     auto z = Vector::create_with_config_of(dense_b);
     auto y = Vector::create_with_config_of(dense_b);
@@ -132,8 +144,9 @@ void Bicgstab<ValueType>::apply_impl(const LinOp *b, LinOp *x) const
 
     system_matrix_->apply(neg_one_op.get(), dense_x, one_op.get(), r.get());
     auto stop_criterion = stop_criterion_factory_->generate(
-        system_matrix_, std::shared_ptr<const LinOp>(b, [](const LinOp *) {}),
-        x, r.get());
+        system_matrix_,
+        std::shared_ptr<const LinOp>(dense_b, [](const LinOp *) {}), dense_x,
+        r.get());
     rr->copy_from(r.get());
 
     int iter = -1;
@@ -205,18 +218,21 @@ void Bicgstab<ValueType>::apply_impl(const LinOp *b, LinOp *x) const
             beta.get(), gamma.get(), omega.get(), &stop_status));
         swap(prev_rho, rho);
     }
-}  // namespace solver
+}
 
 
 template <typename ValueType>
 void Bicgstab<ValueType>::apply_impl(const LinOp *alpha, const LinOp *b,
                                      const LinOp *beta, LinOp *x) const
 {
-    auto dense_x = as<matrix::Dense<ValueType>>(x);
-    auto x_clone = dense_x->clone();
-    this->apply(b, x_clone.get());
-    dense_x->scale(beta);
-    dense_x->add_scaled(alpha, x_clone.get());
+    precision_dispatch_real_complex<ValueType>(
+        [this](auto dense_alpha, auto dense_b, auto dense_beta, auto dense_x) {
+            auto x_clone = dense_x->clone();
+            this->apply(dense_b, x_clone.get());
+            dense_x->scale(dense_beta);
+            dense_x->add_scaled(dense_alpha, x_clone.get());
+        },
+        alpha, b, beta, x);
 }
 
 

--- a/core/solver/cb_gmres.cpp
+++ b/core/solver/cb_gmres.cpp
@@ -41,6 +41,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <ginkgo/core/base/exception_helpers.hpp>
 #include <ginkgo/core/base/executor.hpp>
 #include <ginkgo/core/base/math.hpp>
+#include <ginkgo/core/base/precision_dispatch.hpp>
 #include <ginkgo/core/base/utils_helper.hpp>
 #include <ginkgo/core/log/logger.hpp>
 #include <ginkgo/core/matrix/dense.hpp>
@@ -188,8 +189,21 @@ struct helper<std::complex<T>> {
 template <typename ValueType>
 void CbGmres<ValueType>::apply_impl(const LinOp *b, LinOp *x) const
 {
-    // Current workaround to get a lambda with a template argument (only the
-    // type of `value` matters, the content does not)
+    precision_dispatch_real_complex<ValueType>(
+        [this](auto dense_b, auto dense_x) {
+            this->apply_dense_impl(dense_b, dense_x);
+        },
+        b, x);
+}
+
+
+template <typename ValueType>
+void CbGmres<ValueType>::apply_dense_impl(
+    const matrix::Dense<ValueType> *dense_b,
+    matrix::Dense<ValueType> *dense_x) const
+{
+    // Current workaround to get a lambda with a template argument (only
+    // the type of `value` matters, the content does not)
     auto apply_templated = [&](auto value) {
         using storage_type = decltype(value);
         GKO_ASSERT_IS_SQUARE_MATRIX(system_matrix_);
@@ -207,8 +221,6 @@ void CbGmres<ValueType>::apply_impl(const LinOp *b, LinOp *x) const
         auto one_op = initialize<Vector>({one<ValueType>()}, exec);
         auto neg_one_op = initialize<Vector>({-one<ValueType>()}, exec);
 
-        auto dense_b = as<const Vector>(b);
-        auto dense_x = as<Vector>(x);
         auto residual = Vector::create_with_config_of(dense_b);
         /* The dimensions {x, y, z} explained for the krylov_bases:
          * - x: selects the krylov vector (which has krylov_dim + 1 vectors)
@@ -287,8 +299,8 @@ void CbGmres<ValueType>::apply_impl(const LinOp *b, LinOp *x) const
 
         auto stop_criterion = stop_criterion_factory_->generate(
             system_matrix_,
-            std::shared_ptr<const LinOp>(b, [](const LinOp *) {}), x,
-            residual.get());
+            std::shared_ptr<const LinOp>(dense_b, [](const LinOp *) {}),
+            dense_x, residual.get());
 
         int total_iter = -1;
         size_type restart_iter = 0;
@@ -493,15 +505,16 @@ void CbGmres<ValueType>::apply_impl(const LinOp *b, LinOp *x) const
 
 template <typename ValueType>
 void CbGmres<ValueType>::apply_impl(const LinOp *alpha, const LinOp *b,
-                                    const LinOp *residual_norm_collection,
-                                    LinOp *x) const
+                                    const LinOp *beta, LinOp *x) const
 {
-    auto dense_x = as<matrix::Dense<ValueType>>(x);
-
-    auto x_clone = dense_x->clone();
-    this->apply(b, x_clone.get());
-    dense_x->scale(residual_norm_collection);
-    dense_x->add_scaled(alpha, x_clone.get());
+    precision_dispatch_real_complex<ValueType>(
+        [this](auto dense_alpha, auto dense_b, auto dense_beta, auto dense_x) {
+            auto x_clone = dense_x->clone();
+            this->apply(dense_b, x_clone.get());
+            dense_x->scale(dense_beta);
+            dense_x->add_scaled(dense_alpha, x_clone.get());
+        },
+        alpha, b, beta, x);
 }
 
 #define GKO_DECLARE_CB_GMRES(_type1) class CbGmres<_type1>

--- a/core/solver/cb_gmres.cpp
+++ b/core/solver/cb_gmres.cpp
@@ -510,7 +510,7 @@ void CbGmres<ValueType>::apply_impl(const LinOp *alpha, const LinOp *b,
     precision_dispatch_real_complex<ValueType>(
         [this](auto dense_alpha, auto dense_b, auto dense_beta, auto dense_x) {
             auto x_clone = dense_x->clone();
-            this->apply(dense_b, x_clone.get());
+            this->apply_dense_impl(dense_b, x_clone.get());
             dense_x->scale(dense_beta);
             dense_x->add_scaled(dense_alpha, x_clone.get());
         },

--- a/core/solver/cg.cpp
+++ b/core/solver/cg.cpp
@@ -188,7 +188,7 @@ void Cg<ValueType>::apply_impl(const LinOp *alpha, const LinOp *b,
     precision_dispatch_real_complex<ValueType>(
         [this](auto dense_alpha, auto dense_b, auto dense_beta, auto dense_x) {
             auto x_clone = dense_x->clone();
-            this->apply(dense_b, x_clone.get());
+            this->apply_dense_impl(dense_b, x_clone.get());
             dense_x->scale(dense_beta);
             dense_x->add_scaled(dense_alpha, x_clone.get());
         },

--- a/core/solver/cg.cpp
+++ b/core/solver/cg.cpp
@@ -38,6 +38,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <ginkgo/core/base/executor.hpp>
 #include <ginkgo/core/base/math.hpp>
 #include <ginkgo/core/base/name_demangling.hpp>
+#include <ginkgo/core/base/precision_dispatch.hpp>
 #include <ginkgo/core/base/utils.hpp>
 
 
@@ -88,6 +89,18 @@ std::unique_ptr<LinOp> Cg<ValueType>::conj_transpose() const
 template <typename ValueType>
 void Cg<ValueType>::apply_impl(const LinOp *b, LinOp *x) const
 {
+    precision_dispatch_real_complex<ValueType>(
+        [this](auto dense_b, auto dense_x) {
+            this->apply_dense_impl(dense_b, dense_x);
+        },
+        b, x);
+}
+
+
+template <typename ValueType>
+void Cg<ValueType>::apply_dense_impl(const matrix::Dense<ValueType> *dense_b,
+                                     matrix::Dense<ValueType> *dense_x) const
+{
     using std::swap;
     using Vector = matrix::Dense<ValueType>;
 
@@ -98,8 +111,6 @@ void Cg<ValueType>::apply_impl(const LinOp *b, LinOp *x) const
     auto one_op = initialize<Vector>({one<ValueType>()}, exec);
     auto neg_one_op = initialize<Vector>({-one<ValueType>()}, exec);
 
-    auto dense_b = as<const Vector>(b);
-    auto dense_x = as<Vector>(x);
     auto r = Vector::create_with_config_of(dense_b);
     auto z = Vector::create_with_config_of(dense_b);
     auto p = Vector::create_with_config_of(dense_b);
@@ -124,8 +135,9 @@ void Cg<ValueType>::apply_impl(const LinOp *b, LinOp *x) const
 
     system_matrix_->apply(neg_one_op.get(), dense_x, one_op.get(), r.get());
     auto stop_criterion = stop_criterion_factory_->generate(
-        system_matrix_, std::shared_ptr<const LinOp>(b, [](const LinOp *) {}),
-        x, r.get());
+        system_matrix_,
+        std::shared_ptr<const LinOp>(dense_b, [](const LinOp *) {}), dense_x,
+        r.get());
 
     int iter = -1;
     /* Memory movement summary:
@@ -173,12 +185,14 @@ template <typename ValueType>
 void Cg<ValueType>::apply_impl(const LinOp *alpha, const LinOp *b,
                                const LinOp *beta, LinOp *x) const
 {
-    auto dense_x = as<matrix::Dense<ValueType>>(x);
-
-    auto x_clone = dense_x->clone();
-    this->apply(b, x_clone.get());
-    dense_x->scale(beta);
-    dense_x->add_scaled(alpha, x_clone.get());
+    precision_dispatch_real_complex<ValueType>(
+        [this](auto dense_alpha, auto dense_b, auto dense_beta, auto dense_x) {
+            auto x_clone = dense_x->clone();
+            this->apply(dense_b, x_clone.get());
+            dense_x->scale(dense_beta);
+            dense_x->add_scaled(dense_alpha, x_clone.get());
+        },
+        alpha, b, beta, x);
 }
 
 

--- a/core/solver/cgs.cpp
+++ b/core/solver/cgs.cpp
@@ -209,7 +209,7 @@ void Cgs<ValueType>::apply_impl(const LinOp *alpha, const LinOp *b,
     precision_dispatch_real_complex<ValueType>(
         [this](auto dense_alpha, auto dense_b, auto dense_beta, auto dense_x) {
             auto x_clone = dense_x->clone();
-            this->apply(dense_b, x_clone.get());
+            this->apply_dense_impl(dense_b, x_clone.get());
             dense_x->scale(dense_beta);
             dense_x->add_scaled(dense_alpha, x_clone.get());
         },

--- a/core/solver/cgs.cpp
+++ b/core/solver/cgs.cpp
@@ -37,6 +37,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <ginkgo/core/base/exception_helpers.hpp>
 #include <ginkgo/core/base/executor.hpp>
 #include <ginkgo/core/base/math.hpp>
+#include <ginkgo/core/base/precision_dispatch.hpp>
 #include <ginkgo/core/base/utils.hpp>
 
 
@@ -88,10 +89,20 @@ std::unique_ptr<LinOp> Cgs<ValueType>::conj_transpose() const
 template <typename ValueType>
 void Cgs<ValueType>::apply_impl(const LinOp *b, LinOp *x) const
 {
+    precision_dispatch_real_complex<ValueType>(
+        [this](auto dense_b, auto dense_x) {
+            this->apply_dense_impl(dense_b, dense_x);
+        },
+        b, x);
+}
+
+
+template <typename ValueType>
+void Cgs<ValueType>::apply_dense_impl(const matrix::Dense<ValueType> *dense_b,
+                                      matrix::Dense<ValueType> *dense_x) const
+{
     using std::swap;
     using Vector = matrix::Dense<ValueType>;
-    auto dense_b = as<const Vector>(b);
-    auto dense_x = as<Vector>(x);
 
     constexpr uint8 RelativeStoppingId{1};
 
@@ -133,8 +144,9 @@ void Cgs<ValueType>::apply_impl(const LinOp *b, LinOp *x) const
 
     system_matrix_->apply(neg_one_op.get(), dense_x, one_op.get(), r.get());
     auto stop_criterion = stop_criterion_factory_->generate(
-        system_matrix_, std::shared_ptr<const LinOp>(b, [](const LinOp *) {}),
-        x, r.get());
+        system_matrix_,
+        std::shared_ptr<const LinOp>(dense_b, [](const LinOp *) {}), dense_x,
+        r.get());
     r_tld->copy_from(r.get());
 
     int iter = 0;
@@ -194,12 +206,14 @@ template <typename ValueType>
 void Cgs<ValueType>::apply_impl(const LinOp *alpha, const LinOp *b,
                                 const LinOp *beta, LinOp *x) const
 {
-    auto dense_x = as<matrix::Dense<ValueType>>(x);
-
-    auto x_clone = dense_x->clone();
-    this->apply(b, x_clone.get());
-    dense_x->scale(beta);
-    dense_x->add_scaled(alpha, x_clone.get());
+    precision_dispatch_real_complex<ValueType>(
+        [this](auto dense_alpha, auto dense_b, auto dense_beta, auto dense_x) {
+            auto x_clone = dense_x->clone();
+            this->apply(dense_b, x_clone.get());
+            dense_x->scale(dense_beta);
+            dense_x->add_scaled(dense_alpha, x_clone.get());
+        },
+        alpha, b, beta, x);
 }
 
 

--- a/core/solver/fcg.cpp
+++ b/core/solver/fcg.cpp
@@ -193,7 +193,7 @@ void Fcg<ValueType>::apply_impl(const LinOp *alpha, const LinOp *b,
     precision_dispatch_real_complex<ValueType>(
         [this](auto dense_alpha, auto dense_b, auto dense_beta, auto dense_x) {
             auto x_clone = dense_x->clone();
-            this->apply(dense_b, x_clone.get());
+            this->apply_dense_impl(dense_b, x_clone.get());
             dense_x->scale(dense_beta);
             dense_x->add_scaled(dense_alpha, x_clone.get());
         },

--- a/core/solver/fcg.cpp
+++ b/core/solver/fcg.cpp
@@ -37,6 +37,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <ginkgo/core/base/exception_helpers.hpp>
 #include <ginkgo/core/base/executor.hpp>
 #include <ginkgo/core/base/math.hpp>
+#include <ginkgo/core/base/precision_dispatch.hpp>
 #include <ginkgo/core/base/utils.hpp>
 
 
@@ -85,10 +86,20 @@ std::unique_ptr<LinOp> Fcg<ValueType>::conj_transpose() const
 template <typename ValueType>
 void Fcg<ValueType>::apply_impl(const LinOp *b, LinOp *x) const
 {
+    precision_dispatch_real_complex<ValueType>(
+        [this](auto dense_b, auto dense_x) {
+            this->apply_dense_impl(dense_b, dense_x);
+        },
+        b, x);
+}
+
+
+template <typename ValueType>
+void Fcg<ValueType>::apply_dense_impl(const matrix::Dense<ValueType> *dense_b,
+                                      matrix::Dense<ValueType> *dense_x) const
+{
     using std::swap;
     using Vector = matrix::Dense<ValueType>;
-    auto dense_b = as<const Vector>(b);
-    auto dense_x = as<Vector>(x);
 
     constexpr uint8 RelativeStoppingId{1};
 
@@ -126,8 +137,9 @@ void Fcg<ValueType>::apply_impl(const LinOp *b, LinOp *x) const
 
     system_matrix_->apply(neg_one_op.get(), dense_x, one_op.get(), r.get());
     auto stop_criterion = stop_criterion_factory_->generate(
-        system_matrix_, std::shared_ptr<const LinOp>(b, [](const LinOp *) {}),
-        x, r.get());
+        system_matrix_,
+        std::shared_ptr<const LinOp>(dense_b, [](const LinOp *) {}), dense_x,
+        r.get());
 
     int iter = -1;
     /* Memory movement summary:
@@ -178,11 +190,14 @@ template <typename ValueType>
 void Fcg<ValueType>::apply_impl(const LinOp *alpha, const LinOp *b,
                                 const LinOp *beta, LinOp *x) const
 {
-    auto dense_x = as<matrix::Dense<ValueType>>(x);
-    auto x_clone = dense_x->clone();
-    this->apply(b, x_clone.get());
-    dense_x->scale(beta);
-    dense_x->add_scaled(alpha, x_clone.get());
+    precision_dispatch_real_complex<ValueType>(
+        [this](auto dense_alpha, auto dense_b, auto dense_beta, auto dense_x) {
+            auto x_clone = dense_x->clone();
+            this->apply(dense_b, x_clone.get());
+            dense_x->scale(dense_beta);
+            dense_x->add_scaled(dense_alpha, x_clone.get());
+        },
+        alpha, b, beta, x);
 }
 
 

--- a/core/solver/gmres.cpp
+++ b/core/solver/gmres.cpp
@@ -330,7 +330,7 @@ void Gmres<ValueType>::apply_impl(const LinOp *alpha, const LinOp *b,
     precision_dispatch_real_complex<ValueType>(
         [this](auto dense_alpha, auto dense_b, auto dense_beta, auto dense_x) {
             auto x_clone = dense_x->clone();
-            this->apply(dense_b, x_clone.get());
+            this->apply_dense_impl(dense_b, x_clone.get());
             dense_x->scale(dense_beta);
             dense_x->add_scaled(dense_alpha, x_clone.get());
         },

--- a/core/solver/gmres.cpp
+++ b/core/solver/gmres.cpp
@@ -39,6 +39,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <ginkgo/core/base/executor.hpp>
 #include <ginkgo/core/base/math.hpp>
 #include <ginkgo/core/base/name_demangling.hpp>
+#include <ginkgo/core/base/precision_dispatch.hpp>
 #include <ginkgo/core/base/utils.hpp>
 #include <ginkgo/core/matrix/dense.hpp>
 #include <ginkgo/core/matrix/identity.hpp>
@@ -94,6 +95,18 @@ std::unique_ptr<LinOp> Gmres<ValueType>::conj_transpose() const
 template <typename ValueType>
 void Gmres<ValueType>::apply_impl(const LinOp *b, LinOp *x) const
 {
+    precision_dispatch_real_complex<ValueType>(
+        [this](auto dense_b, auto dense_x) {
+            this->apply_dense_impl(dense_b, dense_x);
+        },
+        b, x);
+}
+
+
+template <typename ValueType>
+void Gmres<ValueType>::apply_dense_impl(const matrix::Dense<ValueType> *dense_b,
+                                        matrix::Dense<ValueType> *dense_x) const
+{
     using Vector = matrix::Dense<ValueType>;
     using NormVector = matrix::Dense<remove_complex<ValueType>>;
 
@@ -104,8 +117,6 @@ void Gmres<ValueType>::apply_impl(const LinOp *b, LinOp *x) const
     auto one_op = initialize<Vector>({one<ValueType>()}, exec);
     auto neg_one_op = initialize<Vector>({-one<ValueType>()}, exec);
 
-    auto dense_b = as<const Vector>(b);
-    auto dense_x = as<Vector>(x);
     auto residual = Vector::create_with_config_of(dense_b);
     auto krylov_bases = Vector::create_with_type_of(
         dense_b, exec,
@@ -149,8 +160,9 @@ void Gmres<ValueType>::apply_impl(const LinOp *b, LinOp *x) const
     // final_iter_nums = {0, ..., 0}
 
     auto stop_criterion = stop_criterion_factory_->generate(
-        system_matrix_, std::shared_ptr<const LinOp>(b, [](const LinOp *) {}),
-        x, residual.get());
+        system_matrix_,
+        std::shared_ptr<const LinOp>(dense_b, [](const LinOp *) {}), dense_x,
+        residual.get());
 
     int total_iter = -1;
     size_type restart_iter = 0;
@@ -313,15 +325,16 @@ void Gmres<ValueType>::apply_impl(const LinOp *b, LinOp *x) const
 
 template <typename ValueType>
 void Gmres<ValueType>::apply_impl(const LinOp *alpha, const LinOp *b,
-                                  const LinOp *residual_norm_collection,
-                                  LinOp *x) const
+                                  const LinOp *beta, LinOp *x) const
 {
-    auto dense_x = as<matrix::Dense<ValueType>>(x);
-
-    auto x_clone = dense_x->clone();
-    this->apply(b, x_clone.get());
-    dense_x->scale(residual_norm_collection);
-    dense_x->add_scaled(alpha, x_clone.get());
+    precision_dispatch_real_complex<ValueType>(
+        [this](auto dense_alpha, auto dense_b, auto dense_beta, auto dense_x) {
+            auto x_clone = dense_x->clone();
+            this->apply(dense_b, x_clone.get());
+            dense_x->scale(dense_beta);
+            dense_x->add_scaled(dense_alpha, x_clone.get());
+        },
+        alpha, b, beta, x);
 }
 
 

--- a/core/solver/idr.cpp
+++ b/core/solver/idr.cpp
@@ -297,7 +297,7 @@ void Idr<ValueType>::apply_impl(const LinOp *alpha, const LinOp *b,
     precision_dispatch_real_complex<ValueType>(
         [this](auto dense_alpha, auto dense_b, auto dense_beta, auto dense_x) {
             auto x_clone = dense_x->clone();
-            this->apply(dense_b, x_clone.get());
+            this->apply_impl(dense_b, x_clone.get());
             dense_x->scale(dense_beta);
             dense_x->add_scaled(dense_alpha, x_clone.get());
         },

--- a/core/solver/idr.cpp
+++ b/core/solver/idr.cpp
@@ -37,6 +37,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <ginkgo/core/base/exception_helpers.hpp>
 #include <ginkgo/core/base/executor.hpp>
 #include <ginkgo/core/base/math.hpp>
+#include <ginkgo/core/base/precision_dispatch.hpp>
 #include <ginkgo/core/base/utils.hpp>
 
 
@@ -88,7 +89,8 @@ std::unique_ptr<LinOp> Idr<ValueType>::conj_transpose() const
 
 template <typename ValueType>
 template <typename SubspaceType>
-void Idr<ValueType>::iterate(const LinOp *b, LinOp *x) const
+void Idr<ValueType>::iterate(const matrix::Dense<SubspaceType> *dense_b,
+                             matrix::Dense<SubspaceType> *dense_x) const
 {
     using std::swap;
     using Vector = matrix::Dense<SubspaceType>;
@@ -101,9 +103,6 @@ void Idr<ValueType>::iterate(const LinOp *b, LinOp *x) const
     auto neg_one_op =
         initialize<matrix::Dense<ValueType>>({-one<ValueType>()}, exec);
     auto subspace_neg_one_op = initialize<Vector>({-one<SubspaceType>()}, exec);
-
-    auto dense_b = as<Vector>(b);
-    auto dense_x = as<Vector>(x);
 
     constexpr uint8 RelativeStoppingId{1};
 
@@ -272,18 +271,22 @@ void Idr<ValueType>::iterate(const LinOp *b, LinOp *x) const
 template <typename ValueType>
 void Idr<ValueType>::apply_impl(const LinOp *b, LinOp *x) const
 {
-    // If ValueType is complex, the subspace matrix P will be complex anyway.
-    if (!is_complex<ValueType>() && complex_subspace_) {
-        auto dense_b = as<matrix::Dense<ValueType>>(b);
-        auto dense_x = as<matrix::Dense<ValueType>>(x);
-        auto complex_b = dense_b->make_complex();
-        auto complex_x = dense_x->make_complex();
-        this->iterate<to_complex<ValueType>>(complex_b.get(), complex_x.get());
-        complex_x->get_real(
-            dynamic_cast<matrix::Dense<remove_complex<ValueType>> *>(dense_x));
-    } else {
-        this->iterate<ValueType>(b, x);
-    }
+    precision_dispatch_real_complex<ValueType>(
+        [this](auto dense_b, auto dense_x) {
+            // If ValueType is complex, the subspace matrix P will be complex
+            // anyway.
+            if (!is_complex<ValueType>() && complex_subspace_) {
+                auto complex_b = dense_b->make_complex();
+                auto complex_x = dense_x->make_complex();
+                this->iterate(complex_b.get(), complex_x.get());
+                complex_x->get_real(
+                    dynamic_cast<matrix::Dense<remove_complex<ValueType>> *>(
+                        dense_x));
+            } else {
+                this->iterate(dense_b, dense_x);
+            }
+        },
+        b, x);
 }
 
 
@@ -291,12 +294,14 @@ template <typename ValueType>
 void Idr<ValueType>::apply_impl(const LinOp *alpha, const LinOp *b,
                                 const LinOp *beta, LinOp *x) const
 {
-    auto dense_x = as<matrix::Dense<ValueType>>(x);
-
-    auto x_clone = dense_x->clone();
-    this->apply(b, x_clone.get());
-    dense_x->scale(beta);
-    dense_x->add_scaled(alpha, x_clone.get());
+    precision_dispatch_real_complex<ValueType>(
+        [this](auto dense_alpha, auto dense_b, auto dense_beta, auto dense_x) {
+            auto x_clone = dense_x->clone();
+            this->apply(dense_b, x_clone.get());
+            dense_x->scale(dense_beta);
+            dense_x->add_scaled(dense_alpha, x_clone.get());
+        },
+        alpha, b, beta, x);
 }
 
 

--- a/core/solver/ir.cpp
+++ b/core/solver/ir.cpp
@@ -33,6 +33,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <ginkgo/core/solver/ir.hpp>
 
 
+#include <ginkgo/core/base/precision_dispatch.hpp>
 #include <ginkgo/core/matrix/dense.hpp>
 
 
@@ -81,6 +82,18 @@ std::unique_ptr<LinOp> Ir<ValueType>::conj_transpose() const
 template <typename ValueType>
 void Ir<ValueType>::apply_impl(const LinOp *b, LinOp *x) const
 {
+    precision_dispatch_real_complex<ValueType>(
+        [this](auto dense_b, auto dense_x) {
+            this->apply_dense_impl(dense_b, dense_x);
+        },
+        b, x);
+}
+
+
+template <typename ValueType>
+void Ir<ValueType>::apply_dense_impl(const matrix::Dense<ValueType> *dense_b,
+                                     matrix::Dense<ValueType> *dense_x) const
+{
     using Vector = matrix::Dense<ValueType>;
     constexpr uint8 relative_stopping_id{1};
 
@@ -88,8 +101,6 @@ void Ir<ValueType>::apply_impl(const LinOp *b, LinOp *x) const
     auto one_op = initialize<Vector>({one<ValueType>()}, exec);
     auto neg_one_op = initialize<Vector>({-one<ValueType>()}, exec);
 
-    auto dense_b = as<const Vector>(b);
-    auto dense_x = as<Vector>(x);
     auto residual = Vector::create_with_config_of(dense_b);
     auto inner_solution = Vector::create_with_config_of(dense_b);
 
@@ -102,8 +113,9 @@ void Ir<ValueType>::apply_impl(const LinOp *b, LinOp *x) const
                           lend(residual));
 
     auto stop_criterion = stop_criterion_factory_->generate(
-        system_matrix_, std::shared_ptr<const LinOp>(b, [](const LinOp *) {}),
-        x, lend(residual));
+        system_matrix_,
+        std::shared_ptr<const LinOp>(dense_b, [](const LinOp *) {}), dense_x,
+        lend(residual));
 
     int iter = -1;
     while (true) {
@@ -152,12 +164,14 @@ template <typename ValueType>
 void Ir<ValueType>::apply_impl(const LinOp *alpha, const LinOp *b,
                                const LinOp *beta, LinOp *x) const
 {
-    auto dense_x = as<matrix::Dense<ValueType>>(x);
-
-    auto x_clone = dense_x->clone();
-    this->apply(b, x_clone.get());
-    dense_x->scale(beta);
-    dense_x->add_scaled(alpha, x_clone.get());
+    precision_dispatch_real_complex<ValueType>(
+        [this](auto dense_alpha, auto dense_b, auto dense_beta, auto dense_x) {
+            auto x_clone = dense_x->clone();
+            this->apply(dense_b, x_clone.get());
+            dense_x->scale(dense_beta);
+            dense_x->add_scaled(dense_alpha, x_clone.get());
+        },
+        alpha, b, beta, x);
 }
 
 

--- a/core/solver/ir.cpp
+++ b/core/solver/ir.cpp
@@ -167,7 +167,7 @@ void Ir<ValueType>::apply_impl(const LinOp *alpha, const LinOp *b,
     precision_dispatch_real_complex<ValueType>(
         [this](auto dense_alpha, auto dense_b, auto dense_beta, auto dense_x) {
             auto x_clone = dense_x->clone();
-            this->apply(dense_b, x_clone.get());
+            this->apply_dense_impl(dense_b, x_clone.get());
             dense_x->scale(dense_beta);
             dense_x->add_scaled(dense_alpha, x_clone.get());
         },

--- a/core/solver/lower_trs.cpp
+++ b/core/solver/lower_trs.cpp
@@ -144,7 +144,7 @@ void LowerTrs<ValueType, IndexType>::apply_impl(const LinOp *alpha,
     precision_dispatch_real_complex<ValueType>(
         [this](auto dense_alpha, auto dense_b, auto dense_beta, auto dense_x) {
             auto x_clone = dense_x->clone();
-            this->apply(dense_b, x_clone.get());
+            this->apply_impl(dense_b, x_clone.get());
             dense_x->scale(dense_beta);
             dense_x->add_scaled(dense_alpha, x_clone.get());
         },

--- a/core/solver/lower_trs.cpp
+++ b/core/solver/lower_trs.cpp
@@ -37,6 +37,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <ginkgo/core/base/exception_helpers.hpp>
 #include <ginkgo/core/base/executor.hpp>
 #include <ginkgo/core/base/polymorphic_object.hpp>
+#include <ginkgo/core/base/precision_dispatch.hpp>
 #include <ginkgo/core/base/types.hpp>
 #include <ginkgo/core/base/utils.hpp>
 #include <ginkgo/core/matrix/csr.hpp>
@@ -101,32 +102,36 @@ void LowerTrs<ValueType, IndexType>::generate()
 template <typename ValueType, typename IndexType>
 void LowerTrs<ValueType, IndexType>::apply_impl(const LinOp *b, LinOp *x) const
 {
-    using Vector = matrix::Dense<ValueType>;
-    const auto exec = this->get_executor();
+    precision_dispatch_real_complex<ValueType>(
+        [this](auto dense_b, auto dense_x) {
+            using Vector = matrix::Dense<ValueType>;
+            const auto exec = this->get_executor();
 
-    auto dense_b = as<const Vector>(b);
-    auto dense_x = as<Vector>(x);
-
-    // This kernel checks if a transpose is needed for the multiple rhs case.
-    // Currently only the algorithm for CUDA version <=9.1 needs this
-    // transposition due to the limitation in the cusparse algorithm. The other
-    // executors (omp and reference) do not use the transpose (trans_x and
-    // trans_b) and hence are passed in empty pointers.
-    bool do_transpose = false;
-    std::shared_ptr<Vector> trans_b;
-    std::shared_ptr<Vector> trans_x;
-    this->get_executor()->run(
-        lower_trs::make_should_perform_transpose(do_transpose));
-    if (do_transpose) {
-        trans_b = Vector::create(exec, gko::transpose(dense_b->get_size()));
-        trans_x = Vector::create(exec, gko::transpose(dense_x->get_size()));
-    } else {
-        trans_b = Vector::create(exec);
-        trans_x = Vector::create(exec);
-    }
-    exec->run(lower_trs::make_solve(
-        gko::lend(system_matrix_), gko::lend(this->solve_struct_),
-        gko::lend(trans_b), gko::lend(trans_x), dense_b, dense_x));
+            // This kernel checks if a transpose is needed for the multiple rhs
+            // case. Currently only the algorithm for CUDA version <=9.1 needs
+            // this transposition due to the limitation in the cusparse
+            // algorithm. The other executors (omp and reference) do not use the
+            // transpose (trans_x and trans_b) and hence are passed in empty
+            // pointers.
+            bool do_transpose = false;
+            std::shared_ptr<Vector> trans_b;
+            std::shared_ptr<Vector> trans_x;
+            this->get_executor()->run(
+                lower_trs::make_should_perform_transpose(do_transpose));
+            if (do_transpose) {
+                trans_b =
+                    Vector::create(exec, gko::transpose(dense_b->get_size()));
+                trans_x =
+                    Vector::create(exec, gko::transpose(dense_x->get_size()));
+            } else {
+                trans_b = Vector::create(exec);
+                trans_x = Vector::create(exec);
+            }
+            exec->run(lower_trs::make_solve(
+                gko::lend(system_matrix_), gko::lend(this->solve_struct_),
+                gko::lend(trans_b), gko::lend(trans_x), dense_b, dense_x));
+        },
+        b, x);
 }
 
 
@@ -136,12 +141,14 @@ void LowerTrs<ValueType, IndexType>::apply_impl(const LinOp *alpha,
                                                 const LinOp *beta,
                                                 LinOp *x) const
 {
-    auto dense_x = as<matrix::Dense<ValueType>>(x);
-
-    auto x_clone = dense_x->clone();
-    this->apply(b, x_clone.get());
-    dense_x->scale(beta);
-    dense_x->add_scaled(alpha, gko::lend(x_clone));
+    precision_dispatch_real_complex<ValueType>(
+        [this](auto dense_alpha, auto dense_b, auto dense_beta, auto dense_x) {
+            auto x_clone = dense_x->clone();
+            this->apply(dense_b, x_clone.get());
+            dense_x->scale(dense_beta);
+            dense_x->add_scaled(dense_alpha, x_clone.get());
+        },
+        alpha, b, beta, x);
 }
 
 

--- a/core/solver/upper_trs.cpp
+++ b/core/solver/upper_trs.cpp
@@ -37,6 +37,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <ginkgo/core/base/exception_helpers.hpp>
 #include <ginkgo/core/base/executor.hpp>
 #include <ginkgo/core/base/polymorphic_object.hpp>
+#include <ginkgo/core/base/precision_dispatch.hpp>
 #include <ginkgo/core/base/types.hpp>
 #include <ginkgo/core/base/utils.hpp>
 #include <ginkgo/core/matrix/csr.hpp>
@@ -101,32 +102,36 @@ void UpperTrs<ValueType, IndexType>::generate()
 template <typename ValueType, typename IndexType>
 void UpperTrs<ValueType, IndexType>::apply_impl(const LinOp *b, LinOp *x) const
 {
-    using Vector = matrix::Dense<ValueType>;
-    const auto exec = this->get_executor();
+    precision_dispatch_real_complex<ValueType>(
+        [this](auto dense_b, auto dense_x) {
+            using Vector = matrix::Dense<ValueType>;
+            const auto exec = this->get_executor();
 
-    auto dense_b = as<const Vector>(b);
-    auto dense_x = as<Vector>(x);
-
-    // This kernel checks if a transpose is needed for the multiple rhs case.
-    // Currently only the algorithm for CUDA version <=9.1 needs this
-    // transposition due to the limitation in the cusparse algorithm. The other
-    // executors (omp and reference) do not use the transpose (trans_x and
-    // trans_b) and hence are passed in empty pointers.
-    bool do_transpose = false;
-    std::shared_ptr<Vector> trans_b;
-    std::shared_ptr<Vector> trans_x;
-    this->get_executor()->run(
-        upper_trs::make_should_perform_transpose(do_transpose));
-    if (do_transpose) {
-        trans_b = Vector::create(exec, gko::transpose(dense_b->get_size()));
-        trans_x = Vector::create(exec, gko::transpose(dense_x->get_size()));
-    } else {
-        trans_b = Vector::create(exec);
-        trans_x = Vector::create(exec);
-    }
-    exec->run(upper_trs::make_solve(
-        gko::lend(system_matrix_), gko::lend(this->solve_struct_),
-        gko::lend(trans_b), gko::lend(trans_x), dense_b, dense_x));
+            // This kernel checks if a transpose is needed for the multiple rhs
+            // case. Currently only the algorithm for CUDA version <=9.1 needs
+            // this transposition due to the limitation in the cusparse
+            // algorithm. The other executors (omp and reference) do not use the
+            // transpose (trans_x and trans_b) and hence are passed in empty
+            // pointers.
+            bool do_transpose = false;
+            std::shared_ptr<Vector> trans_b;
+            std::shared_ptr<Vector> trans_x;
+            this->get_executor()->run(
+                upper_trs::make_should_perform_transpose(do_transpose));
+            if (do_transpose) {
+                trans_b =
+                    Vector::create(exec, gko::transpose(dense_b->get_size()));
+                trans_x =
+                    Vector::create(exec, gko::transpose(dense_x->get_size()));
+            } else {
+                trans_b = Vector::create(exec);
+                trans_x = Vector::create(exec);
+            }
+            exec->run(upper_trs::make_solve(
+                gko::lend(system_matrix_), gko::lend(this->solve_struct_),
+                gko::lend(trans_b), gko::lend(trans_x), dense_b, dense_x));
+        },
+        b, x);
 }
 
 
@@ -136,12 +141,14 @@ void UpperTrs<ValueType, IndexType>::apply_impl(const LinOp *alpha,
                                                 const LinOp *beta,
                                                 LinOp *x) const
 {
-    auto dense_x = as<matrix::Dense<ValueType>>(x);
-
-    auto x_clone = dense_x->clone();
-    this->apply(b, x_clone.get());
-    dense_x->scale(beta);
-    dense_x->add_scaled(alpha, gko::lend(x_clone));
+    precision_dispatch_real_complex<ValueType>(
+        [this](auto dense_alpha, auto dense_b, auto dense_beta, auto dense_x) {
+            auto x_clone = dense_x->clone();
+            this->apply(dense_b, x_clone.get());
+            dense_x->scale(dense_beta);
+            dense_x->add_scaled(dense_alpha, x_clone.get());
+        },
+        alpha, b, beta, x);
 }
 
 

--- a/core/solver/upper_trs.cpp
+++ b/core/solver/upper_trs.cpp
@@ -144,7 +144,7 @@ void UpperTrs<ValueType, IndexType>::apply_impl(const LinOp *alpha,
     precision_dispatch_real_complex<ValueType>(
         [this](auto dense_alpha, auto dense_b, auto dense_beta, auto dense_x) {
             auto x_clone = dense_x->clone();
-            this->apply(dense_b, x_clone.get());
+            this->apply_impl(dense_b, x_clone.get());
             dense_x->scale(dense_beta);
             dense_x->add_scaled(dense_alpha, x_clone.get());
         },

--- a/core/test/base/utils.cpp
+++ b/core/test/base/utils.cpp
@@ -422,6 +422,19 @@ TEST_F(TemporaryClone, CopiesBackAfterLeavingScope)
 }
 
 
+TEST_F(TemporaryClone, DoesntCopyBackConstAfterLeavingScope)
+{
+    {
+        auto clone = make_temporary_clone(
+            omp, static_cast<const DummyObject *>(gko::lend(obj)));
+        obj->data = 7;
+    }
+
+    ASSERT_EQ(obj->get_executor(), ref);
+    ASSERT_EQ(obj->data, 7);
+}
+
+
 TEST_F(TemporaryClone, AvoidsCopyOnSameExecutor)
 {
     auto clone = make_temporary_clone(ref, gko::lend(obj));

--- a/core/test/utils.hpp
+++ b/core/test/utils.hpp
@@ -116,6 +116,13 @@ template <typename Precision, typename OutputType = Precision>
 using r = typename gko::test::reduction_factor<Precision, OutputType>;
 
 
+template <typename Precision1, typename Precision2>
+constexpr double r_mixed()
+{
+    return std::max<double>(r<Precision1>::value, r<Precision2>::value);
+}
+
+
 template <typename T>
 using I = std::initializer_list<T>;
 

--- a/cuda/test/matrix/dense_kernels.cpp
+++ b/cuda/test/matrix/dense_kernels.cpp
@@ -61,9 +61,12 @@ protected:
     using itype = int;
     using vtype = double;
     using Mtx = gko::matrix::Dense<vtype>;
+    using MixedMtx = gko::matrix::Dense<gko::next_precision<vtype>>;
     using NormVector = gko::matrix::Dense<gko::remove_complex<vtype>>;
     using Arr = gko::Array<itype>;
     using ComplexMtx = gko::matrix::Dense<std::complex<vtype>>;
+    using MixedComplexMtx =
+        gko::matrix::Dense<gko::next_precision<std::complex<vtype>>>;
 
     Dense() : rand_engine(15) {}
 
@@ -152,6 +155,14 @@ protected:
             std::unique_ptr<Arr>(new Arr{ref, tmp2.begin(), tmp2.end()});
         rgather_idxs =
             std::unique_ptr<Arr>(new Arr{ref, tmp3.begin(), tmp3.end()});
+    }
+
+    template <typename ConvertedType, typename InputType>
+    std::unique_ptr<ConvertedType> convert(InputType &&input)
+    {
+        auto result = ConvertedType::create(input->get_executor());
+        input->convert_to(result.get());
+        return result;
     }
 
     std::shared_ptr<gko::ReferenceExecutor> ref;
@@ -347,6 +358,17 @@ TEST_F(Dense, SimpleApplyIsEquivalentToRef)
 }
 
 
+TEST_F(Dense, SimpleApplyMixedIsEquivalentToRef)
+{
+    set_up_apply_data();
+
+    x->apply(convert<MixedMtx>(y).get(), convert<MixedMtx>(expected).get());
+    dx->apply(convert<MixedMtx>(dy).get(), convert<MixedMtx>(dresult).get());
+
+    GKO_ASSERT_MTX_NEAR(dresult, expected, 1e-7);
+}
+
+
 TEST_F(Dense, AdvancedApplyIsEquivalentToRef)
 {
     set_up_apply_data();
@@ -355,6 +377,19 @@ TEST_F(Dense, AdvancedApplyIsEquivalentToRef)
     dx->apply(dalpha.get(), dy.get(), dbeta.get(), dresult.get());
 
     GKO_ASSERT_MTX_NEAR(dresult, expected, 1e-14);
+}
+
+
+TEST_F(Dense, AdvancedApplyMixedIsEquivalentToRef)
+{
+    set_up_apply_data();
+
+    x->apply(convert<MixedMtx>(alpha).get(), convert<MixedMtx>(y).get(),
+             convert<MixedMtx>(beta).get(), convert<MixedMtx>(expected).get());
+    dx->apply(convert<MixedMtx>(dalpha).get(), convert<MixedMtx>(dy).get(),
+              convert<MixedMtx>(dbeta).get(), convert<MixedMtx>(dresult).get());
+
+    GKO_ASSERT_MTX_NEAR(dresult, expected, 1e-7);
 }
 
 
@@ -375,6 +410,23 @@ TEST_F(Dense, ApplyToComplexIsEquivalentToRef)
 }
 
 
+TEST_F(Dense, ApplyToMixedComplexIsEquivalentToRef)
+{
+    set_up_apply_data();
+    auto complex_b = gen_mtx<MixedComplexMtx>(25, 1);
+    auto dcomplex_b = MixedComplexMtx::create(cuda);
+    dcomplex_b->copy_from(complex_b.get());
+    auto complex_x = gen_mtx<MixedComplexMtx>(65, 1);
+    auto dcomplex_x = MixedComplexMtx::create(cuda);
+    dcomplex_x->copy_from(complex_x.get());
+
+    x->apply(complex_b.get(), complex_x.get());
+    dx->apply(dcomplex_b.get(), dcomplex_x.get());
+
+    GKO_ASSERT_MTX_NEAR(dcomplex_x, complex_x, 1e-7);
+}
+
+
 TEST_F(Dense, AdvancedApplyToComplexIsEquivalentToRef)
 {
     set_up_apply_data();
@@ -389,6 +441,25 @@ TEST_F(Dense, AdvancedApplyToComplexIsEquivalentToRef)
     dx->apply(dalpha.get(), dcomplex_b.get(), dbeta.get(), dcomplex_x.get());
 
     GKO_ASSERT_MTX_NEAR(dcomplex_x, complex_x, 1e-14);
+}
+
+
+TEST_F(Dense, AdvancedApplyToMixedComplexIsEquivalentToRef)
+{
+    set_up_apply_data();
+    auto complex_b = gen_mtx<MixedComplexMtx>(25, 1);
+    auto dcomplex_b = MixedComplexMtx::create(cuda);
+    dcomplex_b->copy_from(complex_b.get());
+    auto complex_x = gen_mtx<MixedComplexMtx>(65, 1);
+    auto dcomplex_x = MixedComplexMtx::create(cuda);
+    dcomplex_x->copy_from(complex_x.get());
+
+    x->apply(convert<MixedMtx>(alpha).get(), complex_b.get(),
+             convert<MixedMtx>(beta).get(), complex_x.get());
+    dx->apply(convert<MixedMtx>(dalpha).get(), dcomplex_b.get(),
+              convert<MixedMtx>(dbeta).get(), dcomplex_x.get());
+
+    GKO_ASSERT_MTX_NEAR(dcomplex_x, complex_x, 1e-7);
 }
 
 

--- a/hip/test/matrix/dense_kernels.hip.cpp
+++ b/hip/test/matrix/dense_kernels.hip.cpp
@@ -61,9 +61,12 @@ protected:
     using itype = int;
     using vtype = double;
     using Mtx = gko::matrix::Dense<vtype>;
+    using MixedMtx = gko::matrix::Dense<gko::next_precision<vtype>>;
     using NormVector = gko::matrix::Dense<gko::remove_complex<vtype>>;
     using Arr = gko::Array<itype>;
     using ComplexMtx = gko::matrix::Dense<std::complex<vtype>>;
+    using MixedComplexMtx =
+        gko::matrix::Dense<gko::next_precision<std::complex<vtype>>>;
 
     Dense() : rand_engine(15) {}
 
@@ -149,6 +152,14 @@ protected:
             std::unique_ptr<Arr>(new Arr{ref, tmp2.begin(), tmp2.end()});
         rgather_idxs =
             std::unique_ptr<Arr>(new Arr{ref, tmp3.begin(), tmp3.end()});
+    }
+
+    template <typename ConvertedType, typename InputType>
+    std::unique_ptr<ConvertedType> convert(InputType &&input)
+    {
+        auto result = ConvertedType::create(input->get_executor());
+        input->convert_to(result.get());
+        return result;
     }
 
     std::shared_ptr<gko::ReferenceExecutor> ref;
@@ -342,6 +353,17 @@ TEST_F(Dense, SimpleApplyIsEquivalentToRef)
 }
 
 
+TEST_F(Dense, SimpleApplyMixedIsEquivalentToRef)
+{
+    set_up_apply_data();
+
+    x->apply(convert<MixedMtx>(y).get(), convert<MixedMtx>(expected).get());
+    dx->apply(convert<MixedMtx>(dy).get(), convert<MixedMtx>(dresult).get());
+
+    GKO_ASSERT_MTX_NEAR(dresult, expected, 1e-7);
+}
+
+
 TEST_F(Dense, AdvancedApplyIsEquivalentToRef)
 {
     set_up_apply_data();
@@ -350,6 +372,19 @@ TEST_F(Dense, AdvancedApplyIsEquivalentToRef)
     dx->apply(dalpha.get(), dy.get(), dbeta.get(), dresult.get());
 
     GKO_ASSERT_MTX_NEAR(dresult, expected, 1e-14);
+}
+
+
+TEST_F(Dense, AdvancedApplyMixedIsEquivalentToRef)
+{
+    set_up_apply_data();
+
+    x->apply(convert<MixedMtx>(alpha).get(), convert<MixedMtx>(y).get(),
+             convert<MixedMtx>(beta).get(), convert<MixedMtx>(expected).get());
+    dx->apply(convert<MixedMtx>(dalpha).get(), convert<MixedMtx>(dy).get(),
+              convert<MixedMtx>(dbeta).get(), convert<MixedMtx>(dresult).get());
+
+    GKO_ASSERT_MTX_NEAR(dresult, expected, 1e-7);
 }
 
 
@@ -370,6 +405,23 @@ TEST_F(Dense, ApplyToComplexIsEquivalentToRef)
 }
 
 
+TEST_F(Dense, ApplyToMixedComplexIsEquivalentToRef)
+{
+    set_up_apply_data();
+    auto complex_b = gen_mtx<MixedComplexMtx>(25, 1);
+    auto dcomplex_b = MixedComplexMtx::create(hip);
+    dcomplex_b->copy_from(complex_b.get());
+    auto complex_x = gen_mtx<MixedComplexMtx>(65, 1);
+    auto dcomplex_x = MixedComplexMtx::create(hip);
+    dcomplex_x->copy_from(complex_x.get());
+
+    x->apply(complex_b.get(), complex_x.get());
+    dx->apply(dcomplex_b.get(), dcomplex_x.get());
+
+    GKO_ASSERT_MTX_NEAR(dcomplex_x, complex_x, 1e-7);
+}
+
+
 TEST_F(Dense, AdvancedApplyToComplexIsEquivalentToRef)
 {
     set_up_apply_data();
@@ -384,6 +436,25 @@ TEST_F(Dense, AdvancedApplyToComplexIsEquivalentToRef)
     dx->apply(dalpha.get(), dcomplex_b.get(), dbeta.get(), dcomplex_x.get());
 
     GKO_ASSERT_MTX_NEAR(dcomplex_x, complex_x, 1e-14);
+}
+
+
+TEST_F(Dense, AdvancedApplyToMixedComplexIsEquivalentToRef)
+{
+    set_up_apply_data();
+    auto complex_b = gen_mtx<MixedComplexMtx>(25, 1);
+    auto dcomplex_b = MixedComplexMtx::create(hip);
+    dcomplex_b->copy_from(complex_b.get());
+    auto complex_x = gen_mtx<MixedComplexMtx>(65, 1);
+    auto dcomplex_x = MixedComplexMtx::create(hip);
+    dcomplex_x->copy_from(complex_x.get());
+
+    x->apply(convert<MixedMtx>(alpha).get(), complex_b.get(),
+             convert<MixedMtx>(beta).get(), complex_x.get());
+    dx->apply(convert<MixedMtx>(dalpha).get(), dcomplex_b.get(),
+              convert<MixedMtx>(dbeta).get(), dcomplex_x.get());
+
+    GKO_ASSERT_MTX_NEAR(dcomplex_x, complex_x, 1e-7);
 }
 
 

--- a/include/ginkgo/core/base/precision_dispatch.hpp
+++ b/include/ginkgo/core/base/precision_dispatch.hpp
@@ -1,0 +1,232 @@
+/*******************************<GINKGO LICENSE>******************************
+Copyright (c) 2017-2021, the Ginkgo authors
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+******************************<GINKGO LICENSE>*******************************/
+
+#ifndef GKO_PUBLIC_CORE_BASE_PRECISION_DISPATCH_HPP_
+#define GKO_PUBLIC_CORE_BASE_PRECISION_DISPATCH_HPP_
+
+
+#include <ginkgo/core/base/math.hpp>
+#include <ginkgo/core/base/temporary_conversion.hpp>
+#include <ginkgo/core/matrix/dense.hpp>
+
+
+namespace gko {
+
+
+/**
+ * Convert the given LinOp from matrix::Dense<...> to matrix::Dense<ValueType>.
+ * The conversion tries to convert the input LinOp to all Dense types with value
+ * type recursively reachable by next_precision<...> starting from the ValueType
+ * template parameter. This means that all real-to-real and complex-to-complex
+ * conversions for default precisions are being considered.
+ * If the input matrix is non-const, the contents of the modified converted
+ * object will be converted back to the input matrix when the returned object is
+ * destroyed. This may lead to a loss of precision!
+ *
+ * @param matrix  the input matrix which is supposed to be converted. It is
+ *                wrapped unchanged if it is already of type
+ *                matrix::Dense<ValueType>, otherwise it will be converted to
+ *                this type if possible.
+ *
+ * @returns  a detail::temporary_conversion pointing to the (potentially
+ *           converted) object.
+ *
+ * @throws NotSupported  if the input matrix cannot be converted to
+ *                       matrix::Dense<ValueType>
+ *
+ * @tparam ValueType  the value type into whose associated matrix::Dense type to
+ *                    convert the input LinOp.
+ */
+template <typename ValueType>
+detail::temporary_conversion<matrix::Dense<ValueType>>
+make_temporary_conversion(LinOp *matrix)
+{
+    auto result =
+        detail::temporary_conversion<matrix::Dense<ValueType>>::template create<
+            matrix::Dense<next_precision<ValueType>>>(matrix);
+    if (!result) {
+        GKO_NOT_SUPPORTED(matrix);
+    }
+    return result;
+}
+
+
+/** @copydoc make_temporary_conversion(LinOp*) */
+template <typename ValueType>
+detail::temporary_conversion<const matrix::Dense<ValueType>>
+make_temporary_conversion(const LinOp *matrix)
+{
+    auto result = detail::temporary_conversion<const matrix::Dense<ValueType>>::
+        template create<matrix::Dense<next_precision<ValueType>>>(matrix);
+    if (!result) {
+        GKO_NOT_SUPPORTED(matrix);
+    }
+    return result;
+}
+
+
+/**
+ * Calls the given function with each given argument LinOp temporarily
+ * converted into matrix::Dense<ValueType> as parameters.
+ *
+ * @param fn  the given function. It will be passed one (potentially const)
+ *            matrix::Dense<ValueType>* parameter per parameter in the parameter
+ *            pack `linops`.
+ * @param linops  the given arguments to be converted and passed on to fn.
+ *
+ * @tparam ValueType  the value type to use for the parameters of `fn`.
+ * @tparam Function  the function pointer, lambda or other functor type to call
+ *                   with the converted arguments.
+ * @tparam Args  the argument type list.
+ * */
+template <typename ValueType, typename Function, typename... Args>
+void precision_dispatch(Function fn, Args *... linops)
+{
+    fn(make_temporary_conversion<ValueType>(linops).get()...);
+}
+
+
+/**
+ * Calls the given function with the given LinOps temporarily converted to
+ * matrix::Dense<ValueType>* as parameters.
+ * If ValueType is real and both input vectors are complex, uses
+ * matrix::Dense::get_real_view() to convert them into real matrices after
+ * precision conversion.
+ *
+ * @see precision_dispatch()
+ */
+template <typename ValueType, typename Function>
+void precision_dispatch_real_complex(Function fn, const LinOp *in, LinOp *out)
+{
+    // do we need to convert complex Dense to real Dense?
+    // all real dense vectors are intra-convertible, thus by casting to
+    // ConvertibleTo<matrix::Dense<>>, we can check whether a LinOp is a real
+    // dense matrix:
+    auto complex_to_real =
+        !(is_complex<ValueType>() ||
+          dynamic_cast<const ConvertibleTo<matrix::Dense<>> *>(in));
+    if (complex_to_real) {
+        auto dense_in = make_temporary_conversion<to_complex<ValueType>>(in);
+        auto dense_out = make_temporary_conversion<to_complex<ValueType>>(out);
+        using Dense = matrix::Dense<ValueType>;
+        // These dynamic_casts are only needed to make the code compile
+        // If ValueType is complex, this branch will never be taken
+        // If ValueType is real, the cast is a no-op
+        fn(dynamic_cast<const Dense *>(dense_in->create_real_view().get()),
+           dynamic_cast<Dense *>(dense_out->create_real_view().get()));
+    } else {
+        precision_dispatch<ValueType>(fn, in, out);
+    }
+}
+
+
+/**
+ * Calls the given function with the given LinOps temporarily converted to
+ * matrix::Dense<ValueType>* as parameters.
+ * If ValueType is real and both `in` and `out` are complex, uses
+ * matrix::Dense::get_real_view() to convert them into real matrices after
+ * precision conversion.
+ *
+ * @see precision_dispatch()
+ */
+template <typename ValueType, typename Function>
+void precision_dispatch_real_complex(Function fn, const LinOp *alpha,
+                                     const LinOp *in, LinOp *out)
+{
+    // do we need to convert complex Dense to real Dense?
+    // all real dense vectors are intra-convertible, thus by casting to
+    // ConvertibleTo<matrix::Dense<>>, we can check whether a LinOp is a real
+    // dense matrix:
+    auto complex_to_real =
+        !(is_complex<ValueType>() ||
+          dynamic_cast<const ConvertibleTo<matrix::Dense<>> *>(in));
+    if (complex_to_real) {
+        auto dense_in = make_temporary_conversion<to_complex<ValueType>>(in);
+        auto dense_out = make_temporary_conversion<to_complex<ValueType>>(out);
+        auto dense_alpha = make_temporary_conversion<ValueType>(alpha);
+        using Dense = matrix::Dense<ValueType>;
+        // These dynamic_casts are only needed to make the code compile
+        // If ValueType is complex, this branch will never be taken
+        // If ValueType is real, the cast is a no-op
+        fn(dense_alpha.get(),
+           dynamic_cast<const Dense *>(dense_in->create_real_view().get()),
+           dynamic_cast<Dense *>(dense_out->create_real_view().get()));
+    } else {
+        precision_dispatch<ValueType>(fn, alpha, in, out);
+    }
+}
+
+
+/**
+ * Calls the given function with the given LinOps temporarily converted to
+ * matrix::Dense<ValueType>* as parameters.
+ * If ValueType is real and both `in` and `out` are complex, uses
+ * matrix::Dense::get_real_view() to convert them into real matrices after
+ * precision conversion.
+ *
+ * @see precision_dispatch()
+ */
+template <typename ValueType, typename Function>
+void precision_dispatch_real_complex(Function fn, const LinOp *alpha,
+                                     const LinOp *in, const LinOp *beta,
+                                     LinOp *out)
+{
+    // do we need to convert complex Dense to real Dense?
+    // all real dense vectors are intra-convertible, thus by casting to
+    // ConvertibleTo<matrix::Dense<>>, we can check whether a LinOp is a real
+    // dense matrix:
+    auto complex_to_real =
+        !(is_complex<ValueType>() ||
+          dynamic_cast<const ConvertibleTo<matrix::Dense<>> *>(in));
+    if (complex_to_real) {
+        auto dense_in = make_temporary_conversion<to_complex<ValueType>>(in);
+        auto dense_out = make_temporary_conversion<to_complex<ValueType>>(out);
+        auto dense_alpha = make_temporary_conversion<ValueType>(alpha);
+        auto dense_beta = make_temporary_conversion<ValueType>(beta);
+        using Dense = matrix::Dense<ValueType>;
+        // These dynamic_casts are only needed to make the code compile
+        // If ValueType is complex, this branch will never be taken
+        // If ValueType is real, the cast is a no-op
+        fn(dense_alpha.get(),
+           dynamic_cast<const Dense *>(dense_in->create_real_view().get()),
+           dense_beta.get(),
+           dynamic_cast<Dense *>(dense_out->create_real_view().get()));
+    } else {
+        precision_dispatch<ValueType>(fn, alpha, in, beta, out);
+    }
+}
+
+
+}  // namespace gko
+
+
+#endif  // GKO_PUBLIC_CORE_BASE_PRECISION_DISPATCH_HPP_

--- a/include/ginkgo/core/base/temporary_conversion.hpp
+++ b/include/ginkgo/core/base/temporary_conversion.hpp
@@ -112,7 +112,7 @@ public:
  *
  * Helper type that attempts to statically find the dynamic type of a given
  * LinOp from a list of ConversionCandidates and, on the first match, converts
- * it to TargetType with an appropriate .
+ * it to TargetType with an appropriate convert_back_deleter.
  *
  * @tparam ConversionCandidates  list of potential dynamic types of the input
  *                               object to be checked.

--- a/include/ginkgo/core/base/temporary_conversion.hpp
+++ b/include/ginkgo/core/base/temporary_conversion.hpp
@@ -1,0 +1,253 @@
+/*******************************<GINKGO LICENSE>******************************
+Copyright (c) 2017-2021, the Ginkgo authors
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+******************************<GINKGO LICENSE>*******************************/
+
+#ifndef GKO_PUBLIC_CORE_BASE_TEMPORARY_CONVERSION_HPP_
+#define GKO_PUBLIC_CORE_BASE_TEMPORARY_CONVERSION_HPP_
+
+
+#include <memory>
+#include <tuple>
+#include <type_traits>
+
+
+#include <ginkgo/core/base/lin_op.hpp>
+#include <ginkgo/core/base/utils.hpp>
+
+
+namespace gko {
+namespace detail {
+
+
+/**
+ * @internal
+ *
+ * A convert_back_deleter is a type of deleter that converts and copies the data
+ * to an internally referenced object before performing the deletion.
+ *
+ * The deleter will use the `convert_to` method to perform the conversion, and
+ * then delete the passed object using the `delete` keyword. This kind of
+ * deleter is useful when temporarily converting an object with the intent of
+ * converting it back once it goes out of scope.
+ *
+ * There is also a specialization for constant objects that does not perform the
+ * conversion, since a constant object couldn't have been changed.
+ *
+ * @tparam CopyType  the type of converted object being deleted
+ * @tparam OrigType  the type of converted object to which the data will be
+ *                   converted back
+ */
+template <typename CopyType, typename OrigType>
+class convert_back_deleter {
+public:
+    using pointer = CopyType *;
+    using original_pointer = OrigType *;
+
+    /**
+     * Creates a new deleter object.
+     *
+     * @param original  the origin object to which the data will be converted
+     *                  back before deletion
+     */
+    convert_back_deleter(original_pointer original) : original_{original} {}
+
+    /**
+     * Deletes the object.
+     *
+     * @param ptr  pointer to the object being deleted
+     */
+    void operator()(pointer ptr) const
+    {
+        ptr->convert_to(original_);
+        delete ptr;
+    }
+
+private:
+    original_pointer original_;
+};
+
+// specialization for constant objects, no need to convert back something that
+// cannot change
+template <typename CopyType, typename OrigType>
+class convert_back_deleter<const CopyType, const OrigType> {
+public:
+    using pointer = const CopyType *;
+    using original_pointer = const OrigType *;
+    convert_back_deleter(original_pointer) {}
+
+    void operator()(pointer ptr) const { delete ptr; }
+};
+
+
+/**
+ * @internal
+ *
+ * Helper type that attempts to statically find the dynamic type of a given
+ * LinOp from a list of ConversionCandidates and, on the first match, converts
+ * it to TargetType with an appropriate .
+ *
+ * @tparam ConversionCandidates  list of potential dynamic types of the input
+ *                               object to be checked.
+ */
+template <typename... ConversionCandidates>
+struct conversion_helper {
+    /** Dispatch convert_impl with the ConversionCandidates list */
+    template <typename TargetType, typename MaybeConstLinOp>
+    static std::unique_ptr<TargetType, std::function<void(TargetType *)>>
+    convert(MaybeConstLinOp *obj)
+    {
+        return convert_impl<TargetType, MaybeConstLinOp,
+                            ConversionCandidates...>(obj);
+    }
+
+    /**
+     * Attempts to cast obj from the first ConversionCandidate and convert it to
+     * TargetType with a matching convert_back_deleter. If the cast fails,
+     * recursively tries the remaining conversion candidates.
+     */
+    template <typename TargetType, typename MaybeConstLinOp,
+              typename FirstCandidate, typename... TrailingCandidates>
+    static std::unique_ptr<TargetType, std::function<void(TargetType *)>>
+    convert_impl(MaybeConstLinOp *obj)
+    {
+        // make candidate_type conditionally const based on whether obj is const
+        using candidate_type =
+            std::conditional_t<std::is_const<MaybeConstLinOp>::value,
+                               const FirstCandidate, FirstCandidate>;
+        candidate_type *cast_obj{};
+        if ((cast_obj = dynamic_cast<candidate_type *>(obj))) {
+            // if the cast is successful, obj is of dynamic type candidate_type
+            // so we can convert from this type to TargetType
+            auto converted = TargetType::create(obj->get_executor());
+            cast_obj->convert_to(converted.get());
+            // Make sure ConvertibleTo<TargetType> is available and symmetric
+            static_assert(
+                std::is_base_of<ConvertibleTo<std::remove_cv_t<TargetType>>,
+                                FirstCandidate>::value,
+                "ConvertibleTo not implemented");
+            static_assert(std::is_base_of<ConvertibleTo<FirstCandidate>,
+                                          TargetType>::value,
+                          "ConvertibleTo not symmetric");
+            return {converted.release(),
+                    convert_back_deleter<TargetType, candidate_type>{cast_obj}};
+        } else {
+            // else try the remaining candidates
+            return conversion_helper<TrailingCandidates...>::template convert<
+                TargetType>(obj);
+        }
+    }
+};
+
+template <>
+struct conversion_helper<> {
+    template <typename T, typename MaybeConstLinOp>
+    static std::unique_ptr<T, std::function<void(T *)>> convert(
+        MaybeConstLinOp *obj)
+    {
+        // return nullptr if no previous candidates matched
+        return {nullptr, null_deleter<T>{}};
+    }
+};
+
+
+/**
+ * A temporary_conversion is a special smart pointer-like object that is
+ * designed to hold an object temporarily converted to another format.
+ *
+ * After the temporary_conversion goes out of scope, the stored object will
+ * be converted back to its original format. This class is optimized to
+ * avoid copies if the object is already in the correct format, in which
+ * case it will just hold a reference to that object, without performing the
+ * conversion.
+ *
+ * @tparam T  the type of object held in the temporary_conversion
+ */
+template <typename T>
+class temporary_conversion {
+public:
+    using value_type = T;
+    using pointer = T *;
+    using lin_op_type =
+        std::conditional_t<std::is_const<T>::value, const LinOp, LinOp>;
+
+    /**
+     * Create a temporary conversion for a non-temporary LinOp.
+     *
+     * @tparam ConversionCandidates  list of potential dynamic types of ptr to
+     *                               try out for converting ptr to type T.
+     */
+    template <typename... ConversionCandidates>
+    static temporary_conversion create(lin_op_type *ptr)
+    {
+        T *cast_ptr{};
+        if ((cast_ptr = dynamic_cast<T *>(ptr))) {
+            return handle_type{cast_ptr, null_deleter<T>{}};
+        } else {
+            return conversion_helper<ConversionCandidates...>::template convert<
+                T>(ptr);
+        }
+    }
+
+    /**
+     * Returns the object held by temporary_conversion.
+     *
+     * @return the object held by temporary_conversion
+     */
+    T *get() const { return handle_.get(); }
+
+    /**
+     * Calls a method on the underlying object.
+     *
+     * @return the underlying object
+     */
+    T *operator->() const { return handle_.get(); }
+
+    /**
+     * Returns if the conversion was successful.
+     */
+    explicit operator bool() { return static_cast<bool>(handle_); }
+
+private:
+    // std::function deleter allows to decide the (type of) deleter at
+    // runtime
+    using handle_type = std::unique_ptr<T, std::function<void(T *)>>;
+
+    temporary_conversion(handle_type handle) : handle_{std::move(handle)} {}
+
+    handle_type handle_;
+};
+
+
+}  // namespace detail
+}  // namespace gko
+
+
+#endif  // GKO_PUBLIC_CORE_BASE_TEMPORARY_CONVERSION_HPP_

--- a/include/ginkgo/core/preconditioner/ic.hpp
+++ b/include/ginkgo/core/preconditioner/ic.hpp
@@ -43,6 +43,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <ginkgo/core/base/exception.hpp>
 #include <ginkgo/core/base/exception_helpers.hpp>
 #include <ginkgo/core/base/lin_op.hpp>
+#include <ginkgo/core/base/precision_dispatch.hpp>
 #include <ginkgo/core/base/std_extensions.hpp>
 #include <ginkgo/core/factorization/par_ic.hpp>
 #include <ginkgo/core/matrix/dense.hpp>
@@ -190,20 +191,30 @@ public:
 protected:
     void apply_impl(const LinOp *b, LinOp *x) const override
     {
-        set_cache_to(b);
-        l_solver_->apply(b, cache_.intermediate.get());
-        if (lh_solver_->apply_uses_initial_guess()) {
-            x->copy_from(cache_.intermediate.get());
-        }
-        lh_solver_->apply(cache_.intermediate.get(), x);
+        // take care of real-to-complex apply
+        precision_dispatch_real_complex<value_type>(
+            [&](auto dense_b, auto dense_x) {
+                this->set_cache_to(dense_b);
+                l_solver_->apply(dense_b, cache_.intermediate.get());
+                if (lh_solver_->apply_uses_initial_guess()) {
+                    dense_x->copy_from(cache_.intermediate.get());
+                }
+                lh_solver_->apply(cache_.intermediate.get(), dense_x);
+            },
+            b, x);
     }
 
     void apply_impl(const LinOp *alpha, const LinOp *b, const LinOp *beta,
                     LinOp *x) const override
     {
-        set_cache_to(b);
-        l_solver_->apply(b, cache_.intermediate.get());
-        lh_solver_->apply(alpha, cache_.intermediate.get(), beta, x);
+        precision_dispatch_real_complex<value_type>(
+            [&](auto dense_alpha, auto dense_b, auto dense_beta, auto dense_x) {
+                this->set_cache_to(dense_b);
+                l_solver_->apply(dense_b, cache_.intermediate.get());
+                lh_solver_->apply(dense_alpha, cache_.intermediate.get(),
+                                  dense_beta, dense_x);
+            },
+            alpha, b, beta, x);
     }
 
     explicit Ic(std::shared_ptr<const Executor> exec)

--- a/include/ginkgo/core/solver/bicg.hpp
+++ b/include/ginkgo/core/solver/bicg.hpp
@@ -44,6 +44,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <ginkgo/core/base/types.hpp>
 #include <ginkgo/core/log/logger.hpp>
 #include <ginkgo/core/matrix/csr.hpp>
+#include <ginkgo/core/matrix/dense.hpp>
 #include <ginkgo/core/matrix/identity.hpp>
 #include <ginkgo/core/stop/combined.hpp>
 #include <ginkgo/core/stop/criterion.hpp>
@@ -154,6 +155,9 @@ public:
 
 protected:
     void apply_impl(const LinOp *b, LinOp *x) const override;
+
+    void apply_dense_impl(const matrix::Dense<ValueType> *b,
+                          matrix::Dense<ValueType> *x) const;
 
     void apply_impl(const LinOp *alpha, const LinOp *b, const LinOp *beta,
                     LinOp *x) const override;

--- a/include/ginkgo/core/solver/bicgstab.hpp
+++ b/include/ginkgo/core/solver/bicgstab.hpp
@@ -43,6 +43,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <ginkgo/core/base/math.hpp>
 #include <ginkgo/core/base/types.hpp>
 #include <ginkgo/core/log/logger.hpp>
+#include <ginkgo/core/matrix/dense.hpp>
 #include <ginkgo/core/matrix/identity.hpp>
 #include <ginkgo/core/stop/combined.hpp>
 #include <ginkgo/core/stop/criterion.hpp>
@@ -152,6 +153,9 @@ public:
 
 protected:
     void apply_impl(const LinOp *b, LinOp *x) const override;
+
+    void apply_dense_impl(const matrix::Dense<ValueType> *b,
+                          matrix::Dense<ValueType> *x) const;
 
     void apply_impl(const LinOp *alpha, const LinOp *b, const LinOp *beta,
                     LinOp *x) const override;

--- a/include/ginkgo/core/solver/cb_gmres.hpp
+++ b/include/ginkgo/core/solver/cb_gmres.hpp
@@ -44,6 +44,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <ginkgo/core/base/math.hpp>
 #include <ginkgo/core/base/types.hpp>
 #include <ginkgo/core/log/logger.hpp>
+#include <ginkgo/core/matrix/dense.hpp>
 #include <ginkgo/core/matrix/identity.hpp>
 #include <ginkgo/core/stop/combined.hpp>
 #include <ginkgo/core/stop/criterion.hpp>
@@ -190,6 +191,9 @@ public:
 
 protected:
     void apply_impl(const LinOp *b, LinOp *x) const override;
+
+    void apply_dense_impl(const matrix::Dense<ValueType> *b,
+                          matrix::Dense<ValueType> *x) const;
 
     void apply_impl(const LinOp *alpha, const LinOp *b, const LinOp *beta,
                     LinOp *x) const override;

--- a/include/ginkgo/core/solver/cg.hpp
+++ b/include/ginkgo/core/solver/cg.hpp
@@ -43,6 +43,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <ginkgo/core/base/math.hpp>
 #include <ginkgo/core/base/types.hpp>
 #include <ginkgo/core/log/logger.hpp>
+#include <ginkgo/core/matrix/dense.hpp>
 #include <ginkgo/core/matrix/identity.hpp>
 #include <ginkgo/core/stop/combined.hpp>
 #include <ginkgo/core/stop/criterion.hpp>
@@ -148,6 +149,9 @@ public:
 
 protected:
     void apply_impl(const LinOp *b, LinOp *x) const override;
+
+    void apply_dense_impl(const matrix::Dense<ValueType> *b,
+                          matrix::Dense<ValueType> *x) const;
 
     void apply_impl(const LinOp *alpha, const LinOp *b, const LinOp *beta,
                     LinOp *x) const override;

--- a/include/ginkgo/core/solver/cgs.hpp
+++ b/include/ginkgo/core/solver/cgs.hpp
@@ -43,6 +43,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <ginkgo/core/base/math.hpp>
 #include <ginkgo/core/base/types.hpp>
 #include <ginkgo/core/log/logger.hpp>
+#include <ginkgo/core/matrix/dense.hpp>
 #include <ginkgo/core/matrix/identity.hpp>
 #include <ginkgo/core/stop/combined.hpp>
 #include <ginkgo/core/stop/criterion.hpp>
@@ -145,6 +146,9 @@ public:
 
 protected:
     void apply_impl(const LinOp *b, LinOp *x) const override;
+
+    void apply_dense_impl(const matrix::Dense<ValueType> *b,
+                          matrix::Dense<ValueType> *x) const;
 
     void apply_impl(const LinOp *alpha, const LinOp *b, const LinOp *beta,
                     LinOp *x) const override;

--- a/include/ginkgo/core/solver/fcg.hpp
+++ b/include/ginkgo/core/solver/fcg.hpp
@@ -43,6 +43,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <ginkgo/core/base/math.hpp>
 #include <ginkgo/core/base/types.hpp>
 #include <ginkgo/core/log/logger.hpp>
+#include <ginkgo/core/matrix/dense.hpp>
 #include <ginkgo/core/matrix/identity.hpp>
 #include <ginkgo/core/stop/combined.hpp>
 #include <ginkgo/core/stop/criterion.hpp>
@@ -153,6 +154,9 @@ public:
 
 protected:
     void apply_impl(const LinOp *b, LinOp *x) const override;
+
+    void apply_dense_impl(const matrix::Dense<ValueType> *b,
+                          matrix::Dense<ValueType> *x) const;
 
     void apply_impl(const LinOp *alpha, const LinOp *b, const LinOp *beta,
                     LinOp *x) const override;

--- a/include/ginkgo/core/solver/gmres.hpp
+++ b/include/ginkgo/core/solver/gmres.hpp
@@ -43,6 +43,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <ginkgo/core/base/math.hpp>
 #include <ginkgo/core/base/types.hpp>
 #include <ginkgo/core/log/logger.hpp>
+#include <ginkgo/core/matrix/dense.hpp>
 #include <ginkgo/core/matrix/identity.hpp>
 #include <ginkgo/core/stop/combined.hpp>
 #include <ginkgo/core/stop/criterion.hpp>
@@ -167,6 +168,9 @@ public:
 
 protected:
     void apply_impl(const LinOp *b, LinOp *x) const override;
+
+    void apply_dense_impl(const matrix::Dense<ValueType> *b,
+                          matrix::Dense<ValueType> *x) const;
 
     void apply_impl(const LinOp *alpha, const LinOp *b, const LinOp *beta,
                     LinOp *x) const override;

--- a/include/ginkgo/core/solver/idr.hpp
+++ b/include/ginkgo/core/solver/idr.hpp
@@ -251,7 +251,8 @@ protected:
                     LinOp *x) const override;
 
     template <typename SubspaceType>
-    void iterate(const LinOp *b, LinOp *x) const;
+    void iterate(const matrix::Dense<SubspaceType> *dense_b,
+                 matrix::Dense<SubspaceType> *dense_x) const;
 
     explicit Idr(std::shared_ptr<const Executor> exec)
         : EnableLinOp<Idr>(std::move(exec))

--- a/include/ginkgo/core/solver/ir.hpp
+++ b/include/ginkgo/core/solver/ir.hpp
@@ -205,6 +205,9 @@ public:
 protected:
     void apply_impl(const LinOp *b, LinOp *x) const override;
 
+    void apply_dense_impl(const matrix::Dense<ValueType> *b,
+                          matrix::Dense<ValueType> *x) const;
+
     void apply_impl(const LinOp *alpha, const LinOp *b, const LinOp *beta,
                     LinOp *x) const override;
 

--- a/include/ginkgo/ginkgo.hpp
+++ b/include/ginkgo/ginkgo.hpp
@@ -54,10 +54,12 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <ginkgo/core/base/name_demangling.hpp>
 #include <ginkgo/core/base/perturbation.hpp>
 #include <ginkgo/core/base/polymorphic_object.hpp>
+#include <ginkgo/core/base/precision_dispatch.hpp>
 #include <ginkgo/core/base/range.hpp>
 #include <ginkgo/core/base/range_accessors.hpp>
 #include <ginkgo/core/base/std_extensions.hpp>
 #include <ginkgo/core/base/temporary_clone.hpp>
+#include <ginkgo/core/base/temporary_conversion.hpp>
 #include <ginkgo/core/base/types.hpp>
 #include <ginkgo/core/base/utils.hpp>
 #include <ginkgo/core/base/utils_helper.hpp>

--- a/omp/solver/cb_gmres_kernels.cpp
+++ b/omp/solver/cb_gmres_kernels.cpp
@@ -93,8 +93,8 @@ void finish_arnoldi_CGS(matrix::Dense<ValueType> *next_krylov_basis,
         for (size_type k = 0; k < iter + 1; ++k) {
             ValueType hessenberg_iter_entry = zero<ValueType>();
             for (size_type j = 0; j < next_krylov_basis->get_size()[0]; ++j) {
-                hessenberg_iter_entry +=
-                    next_krylov_basis->at(j, i) * krylov_bases(k, j, i);
+                hessenberg_iter_entry += next_krylov_basis->at(j, i) *
+                                         conj(ValueType{krylov_bases(k, j, i)});
             }
             hessenberg_iter->at(k, i) = hessenberg_iter_entry;
         }
@@ -136,7 +136,8 @@ void finish_arnoldi_CGS(matrix::Dense<ValueType> *next_krylov_basis,
                 for (size_type j = 0; j < next_krylov_basis->get_size()[0];
                      ++j) {
                     hessenberg_iter_entry +=
-                        next_krylov_basis->at(j, i) * krylov_bases(k, j, i);
+                        next_krylov_basis->at(j, i) *
+                        conj(ValueType{krylov_bases(k, j, i)});
                 }
                 buffer_iter->at(k, i) = hessenberg_iter_entry;
             }
@@ -148,7 +149,8 @@ void finish_arnoldi_CGS(matrix::Dense<ValueType> *next_krylov_basis,
                 for (size_type j = 0; j < next_krylov_basis->get_size()[0];
                      ++j) {
                     next_krylov_basis->at(j, i) -=
-                        buffer_iter->at(k, i) * krylov_bases(k, j, i);
+                        buffer_iter->at(k, i) *
+                        conj(ValueType{krylov_bases(k, j, i)});
                 }
             }
             // for i in 1:iter

--- a/reference/solver/cb_gmres_kernels.cpp
+++ b/reference/solver/cb_gmres_kernels.cpp
@@ -89,7 +89,8 @@ void finish_arnoldi_CGS(matrix::Dense<ValueType> *next_krylov_basis,
             hessenberg_iter->at(k, i) = zero<ValueType>();
             for (size_type j = 0; j < next_krylov_basis->get_size()[0]; ++j) {
                 hessenberg_iter->at(k, i) +=
-                    next_krylov_basis->at(j, i) * krylov_bases(k, j, i);
+                    next_krylov_basis->at(j, i) *
+                    conj(ValueType{krylov_bases(k, j, i)});
             }
         }
         // for i in 1:iter
@@ -128,7 +129,8 @@ void finish_arnoldi_CGS(matrix::Dense<ValueType> *next_krylov_basis,
                 for (size_type j = 0; j < next_krylov_basis->get_size()[0];
                      ++j) {
                     buffer_iter->at(k, i) +=
-                        next_krylov_basis->at(j, i) * krylov_bases(k, j, i);
+                        next_krylov_basis->at(j, i) *
+                        conj(ValueType{krylov_bases(k, j, i)});
                 }
             }
             // for i in 1:iter
@@ -138,7 +140,8 @@ void finish_arnoldi_CGS(matrix::Dense<ValueType> *next_krylov_basis,
                 for (size_type j = 0; j < next_krylov_basis->get_size()[0];
                      ++j) {
                     next_krylov_basis->at(j, i) -=
-                        buffer_iter->at(k, i) * krylov_bases(k, j, i);
+                        buffer_iter->at(k, i) *
+                        conj(ValueType{krylov_bases(k, j, i)});
                 }
                 hessenberg_iter->at(k, i) += buffer_iter->at(k, i);
             }

--- a/reference/test/base/combination.cpp
+++ b/reference/test/base/combination.cpp
@@ -89,6 +89,71 @@ TYPED_TEST(Combination, AppliesToVector)
 }
 
 
+TYPED_TEST(Combination, AppliesToMixedVector)
+{
+    /*
+        cmb = [ 8 7 ]
+              [ 5 4 ]
+    */
+    using value_type = gko::next_precision<TypeParam>;
+    using Mtx = typename TestFixture::Mtx;
+    auto cmb = gko::Combination<TypeParam>::create(
+        this->coefficients[0], this->operators[0], this->coefficients[1],
+        this->operators[1]);
+    auto x = gko::initialize<Mtx>({1.0, 2.0}, this->exec);
+    auto res = clone(x);
+
+    cmb->apply(lend(x), lend(res));
+
+    GKO_ASSERT_MTX_NEAR(res, l({22.0, 13.0}),
+                        (r_mixed<value_type, TypeParam>()));
+}
+
+
+TYPED_TEST(Combination, AppliesToComplexVector)
+{
+    /*
+        cmb = [ 8 7 ]
+              [ 5 4 ]
+    */
+    using Mtx = gko::to_complex<typename TestFixture::Mtx>;
+    using T = typename Mtx::value_type;
+    auto cmb = gko::Combination<TypeParam>::create(
+        this->coefficients[0], this->operators[0], this->coefficients[1],
+        this->operators[1]);
+    auto x = gko::initialize<Mtx>({T{1.0, -2.0}, T{2.0, -4.0}}, this->exec);
+    auto res = clone(x);
+
+    cmb->apply(lend(x), lend(res));
+
+    GKO_ASSERT_MTX_NEAR(res, l({T{22.0, -44.0}, T{13.0, -26.0}}),
+                        r<TypeParam>::value);
+}
+
+
+TYPED_TEST(Combination, AppliesToMixedComplexVector)
+{
+    /*
+        cmb = [ 8 7 ]
+              [ 5 4 ]
+    */
+    using value_type = gko::to_complex<gko::next_precision<TypeParam>>;
+    using Mtx = gko::matrix::Dense<value_type>;
+    auto cmb = gko::Combination<TypeParam>::create(
+        this->coefficients[0], this->operators[0], this->coefficients[1],
+        this->operators[1]);
+    auto x = gko::initialize<Mtx>(
+        {value_type{1.0, -2.0}, value_type{2.0, -4.0}}, this->exec);
+    auto res = clone(x);
+
+    cmb->apply(lend(x), lend(res));
+
+    GKO_ASSERT_MTX_NEAR(res,
+                        l({value_type{22.0, -44.0}, value_type{13.0, -26.0}}),
+                        (r_mixed<value_type, TypeParam>()));
+}
+
+
 TYPED_TEST(Combination, AppliesLinearCombinationToVector)
 {
     /*
@@ -107,6 +172,80 @@ TYPED_TEST(Combination, AppliesLinearCombinationToVector)
     cmb->apply(lend(alpha), lend(x), lend(beta), lend(res));
 
     GKO_ASSERT_MTX_NEAR(res, l({65.0, 37.0}), r<TypeParam>::value);
+}
+
+
+TYPED_TEST(Combination, AppliesLinearCombinationToMixedVector)
+{
+    /*
+        cmb = [ 8 7 ]
+              [ 5 4 ]
+    */
+    using value_type = gko::next_precision<TypeParam>;
+    using Mtx = typename TestFixture::Mtx;
+    auto cmb = gko::Combination<TypeParam>::create(
+        this->coefficients[0], this->operators[0], this->coefficients[1],
+        this->operators[1]);
+    auto alpha = gko::initialize<Mtx>({3.0}, this->exec);
+    auto beta = gko::initialize<Mtx>({-1.0}, this->exec);
+    auto x = gko::initialize<Mtx>({1.0, 2.0}, this->exec);
+    auto res = clone(x);
+
+    cmb->apply(lend(alpha), lend(x), lend(beta), lend(res));
+
+    GKO_ASSERT_MTX_NEAR(res, l({65.0, 37.0}),
+                        (r_mixed<value_type, TypeParam>()));
+}
+
+
+TYPED_TEST(Combination, AppliesLinearCombinationToComplexVector)
+{
+    /*
+        cmb = [ 8 7 ]
+              [ 5 4 ]
+    */
+    using Dense = typename TestFixture::Mtx;
+    using DenseComplex = gko::to_complex<Dense>;
+    using T = typename DenseComplex::value_type;
+    auto cmb = gko::Combination<TypeParam>::create(
+        this->coefficients[0], this->operators[0], this->coefficients[1],
+        this->operators[1]);
+    auto alpha = gko::initialize<Dense>({3.0}, this->exec);
+    auto beta = gko::initialize<Dense>({-1.0}, this->exec);
+    auto x =
+        gko::initialize<DenseComplex>({T{1.0, -2.0}, T{2.0, -4.0}}, this->exec);
+    auto res = clone(x);
+
+    cmb->apply(lend(alpha), lend(x), lend(beta), lend(res));
+
+    GKO_ASSERT_MTX_NEAR(res, l({T{65.0, -130.0}, T{37.0, -74.0}}),
+                        r<TypeParam>::value);
+}
+
+
+TYPED_TEST(Combination, AppliesLinearCombinationToMixedComplexVector)
+{
+    /*
+        cmb = [ 8 7 ]
+              [ 5 4 ]
+    */
+    using MixedDense = gko::matrix::Dense<gko::next_precision<TypeParam>>;
+    using MixedDenseComplex = gko::to_complex<MixedDense>;
+    using value_type = typename MixedDenseComplex::value_type;
+    auto cmb = gko::Combination<TypeParam>::create(
+        this->coefficients[0], this->operators[0], this->coefficients[1],
+        this->operators[1]);
+    auto alpha = gko::initialize<MixedDense>({3.0}, this->exec);
+    auto beta = gko::initialize<MixedDense>({-1.0}, this->exec);
+    auto x = gko::initialize<MixedDenseComplex>(
+        {value_type{1.0, -2.0}, value_type{2.0, -4.0}}, this->exec);
+    auto res = clone(x);
+
+    cmb->apply(lend(alpha), lend(x), lend(beta), lend(res));
+
+    GKO_ASSERT_MTX_NEAR(res,
+                        l({value_type{65.0, -130.0}, value_type{37.0, -74.0}}),
+                        (r_mixed<value_type, TypeParam>()));
 }
 
 

--- a/reference/test/base/combination.cpp
+++ b/reference/test/base/combination.cpp
@@ -96,7 +96,7 @@ TYPED_TEST(Combination, AppliesToMixedVector)
               [ 5 4 ]
     */
     using value_type = gko::next_precision<TypeParam>;
-    using Mtx = typename TestFixture::Mtx;
+    using Mtx = gko::matrix::Dense<value_type>;
     auto cmb = gko::Combination<TypeParam>::create(
         this->coefficients[0], this->operators[0], this->coefficients[1],
         this->operators[1]);
@@ -182,7 +182,7 @@ TYPED_TEST(Combination, AppliesLinearCombinationToMixedVector)
               [ 5 4 ]
     */
     using value_type = gko::next_precision<TypeParam>;
-    using Mtx = typename TestFixture::Mtx;
+    using Mtx = gko::matrix::Dense<value_type>;
     auto cmb = gko::Combination<TypeParam>::create(
         this->coefficients[0], this->operators[0], this->coefficients[1],
         this->operators[1]);

--- a/reference/test/base/composition.cpp
+++ b/reference/test/base/composition.cpp
@@ -128,6 +128,67 @@ TYPED_TEST(Composition, AppliesSingleToVector)
 }
 
 
+TYPED_TEST(Composition, AppliesSingleToMixedVector)
+{
+    /*
+        cmp = [ -9 -2 ]
+              [ 27 26 ]
+    */
+    using Mtx = gko::matrix::Dense<gko::next_precision<TypeParam>>;
+    using value_type = typename Mtx::value_type;
+    auto cmp = gko::Composition<TypeParam>::create(this->product);
+    auto x = gko::initialize<Mtx>({1.0, 2.0}, this->exec);
+    auto res = clone(x);
+
+    cmp->apply(lend(x), lend(res));
+
+    GKO_ASSERT_MTX_NEAR(res, l({-13.0, 79.0}),
+                        (r_mixed<value_type, TypeParam>()));
+}
+
+
+TYPED_TEST(Composition, AppliesSingleToComplexVector)
+{
+    /*
+        cmp = [ -9 -2 ]
+              [ 27 26 ]
+    */
+    using value_type = gko::to_complex<TypeParam>;
+    using Mtx = gko::matrix::Dense<value_type>;
+    auto cmp = gko::Composition<TypeParam>::create(this->product);
+    auto x = gko::initialize<Mtx>(
+        {value_type{1.0, -2.0}, value_type{2.0, -4.0}}, this->exec);
+    auto res = clone(x);
+
+    cmp->apply(lend(x), lend(res));
+
+    GKO_ASSERT_MTX_NEAR(res,
+                        l({value_type{-13.0, 26.0}, value_type{79.0, -158.0}}),
+                        r<TypeParam>::value);
+}
+
+
+TYPED_TEST(Composition, AppliesSingleToMixedComplexVector)
+{
+    /*
+        cmp = [ -9 -2 ]
+              [ 27 26 ]
+    */
+    using value_type = gko::next_precision<gko::to_complex<TypeParam>>;
+    using Mtx = gko::matrix::Dense<value_type>;
+    auto cmp = gko::Composition<TypeParam>::create(this->product);
+    auto x = gko::initialize<Mtx>(
+        {value_type{1.0, -2.0}, value_type{2.0, -4.0}}, this->exec);
+    auto res = clone(x);
+
+    cmp->apply(lend(x), lend(res));
+
+    GKO_ASSERT_MTX_NEAR(res,
+                        l({value_type{-13.0, 26.0}, value_type{79.0, -158.0}}),
+                        (r_mixed<value_type, TypeParam>()));
+}
+
+
 TYPED_TEST(Composition, AppliesSingleLinearCombinationToVector)
 {
     /*
@@ -144,6 +205,75 @@ TYPED_TEST(Composition, AppliesSingleLinearCombinationToVector)
     cmp->apply(lend(alpha), lend(x), lend(beta), lend(res));
 
     GKO_ASSERT_MTX_NEAR(res, l({-40.0, 235.0}), r<TypeParam>::value);
+}
+
+
+TYPED_TEST(Composition, AppliesSingleLinearCombinationToMixedVector)
+{
+    /*
+        cmp = [ -9 -2 ]
+              [ 27 26 ]
+    */
+    using value_type = gko::next_precision<TypeParam>;
+    using Mtx = gko::matrix::Dense<value_type>;
+    auto cmp = gko::Composition<TypeParam>::create(this->product);
+    auto alpha = gko::initialize<Mtx>({3.0}, this->exec);
+    auto beta = gko::initialize<Mtx>({-1.0}, this->exec);
+    auto x = gko::initialize<Mtx>({1.0, 2.0}, this->exec);
+    auto res = clone(x);
+
+    cmp->apply(lend(alpha), lend(x), lend(beta), lend(res));
+
+    GKO_ASSERT_MTX_NEAR(res, l({-40.0, 235.0}),
+                        (r_mixed<value_type, TypeParam>()));
+}
+
+
+TYPED_TEST(Composition, AppliesSingleLinearCombinationToComplexVector)
+{
+    /*
+        cmp = [ -9 -2 ]
+              [ 27 26 ]
+    */
+    using Dense = typename TestFixture::Mtx;
+    using DenseComplex = gko::to_complex<Dense>;
+    using value_type = typename DenseComplex::value_type;
+    auto cmp = gko::Composition<TypeParam>::create(this->product);
+    auto alpha = gko::initialize<Dense>({3.0}, this->exec);
+    auto beta = gko::initialize<Dense>({-1.0}, this->exec);
+    auto x = gko::initialize<DenseComplex>(
+        {value_type{1.0, -2.0}, value_type{2.0, -4.0}}, this->exec);
+    auto res = clone(x);
+
+    cmp->apply(lend(alpha), lend(x), lend(beta), lend(res));
+
+    GKO_ASSERT_MTX_NEAR(res,
+                        l({value_type{-40.0, 80.0}, value_type{235.0, -470.0}}),
+                        r<TypeParam>::value);
+}
+
+
+TYPED_TEST(Composition, AppliesSingleLinearCombinationToMixedComplexVector)
+{
+    /*
+        cmp = [ -9 -2 ]
+              [ 27 26 ]
+    */
+    using MixedDense = gko::matrix::Dense<gko::next_precision<TypeParam>>;
+    using MixedDenseComplex = gko::to_complex<MixedDense>;
+    using value_type = typename MixedDenseComplex::value_type;
+    auto cmp = gko::Composition<TypeParam>::create(this->product);
+    auto alpha = gko::initialize<MixedDense>({3.0}, this->exec);
+    auto beta = gko::initialize<MixedDense>({-1.0}, this->exec);
+    auto x = gko::initialize<MixedDenseComplex>(
+        {value_type{1.0, -2.0}, value_type{2.0, -4.0}}, this->exec);
+    auto res = clone(x);
+
+    cmp->apply(lend(alpha), lend(x), lend(beta), lend(res));
+
+    GKO_ASSERT_MTX_NEAR(res,
+                        l({value_type{-40.0, 80.0}, value_type{235.0, -470.0}}),
+                        (r_mixed<value_type, TypeParam>()));
 }
 
 

--- a/reference/test/base/perturbation.cpp
+++ b/reference/test/base/perturbation.cpp
@@ -87,6 +87,70 @@ TYPED_TEST(Perturbation, AppliesToVector)
 }
 
 
+TYPED_TEST(Perturbation, AppliesToMixedVector)
+{
+    /*
+        cmp = I + 2 * [ 2 ] * [ 3 2 ]
+                      [ 1 ]
+    */
+    using Mtx = gko::matrix::Dense<gko::next_precision<TypeParam>>;
+    using value_type = typename Mtx::value_type;
+    auto cmp = gko::Perturbation<TypeParam>::create(this->scalar, this->basis,
+                                                    this->projector);
+    auto x = gko::initialize<Mtx>({1.0, 2.0}, this->exec);
+    auto res = Mtx::create_with_config_of(gko::lend(x));
+
+    cmp->apply(gko::lend(x), gko::lend(res));
+
+    GKO_ASSERT_MTX_NEAR(res, l({29.0, 16.0}),
+                        (r_mixed<value_type, TypeParam>()));
+}
+
+
+TYPED_TEST(Perturbation, AppliesToComplexVector)
+{
+    /*
+        cmp = I + 2 * [ 2 ] * [ 3 2 ]
+                      [ 1 ]
+    */
+    using value_type = gko::to_complex<TypeParam>;
+    using Mtx = gko::matrix::Dense<value_type>;
+    auto cmp = gko::Perturbation<TypeParam>::create(this->scalar, this->basis,
+                                                    this->projector);
+    auto x = gko::initialize<Mtx>(
+        {value_type{1.0, -2.0}, value_type{2.0, -4.0}}, this->exec);
+    auto res = Mtx::create_with_config_of(gko::lend(x));
+
+    cmp->apply(gko::lend(x), gko::lend(res));
+
+    GKO_ASSERT_MTX_NEAR(res,
+                        l({value_type{29.0, -58.0}, value_type{16.0, -32.0}}),
+                        r<TypeParam>::value);
+}
+
+
+TYPED_TEST(Perturbation, AppliesToMixedComplexVector)
+{
+    /*
+        cmp = I + 2 * [ 2 ] * [ 3 2 ]
+                      [ 1 ]
+    */
+    using value_type = gko::to_complex<gko::next_precision<TypeParam>>;
+    using Mtx = gko::matrix::Dense<value_type>;
+    auto cmp = gko::Perturbation<TypeParam>::create(this->scalar, this->basis,
+                                                    this->projector);
+    auto x = gko::initialize<Mtx>(
+        {value_type{1.0, -2.0}, value_type{2.0, -4.0}}, this->exec);
+    auto res = Mtx::create_with_config_of(gko::lend(x));
+
+    cmp->apply(gko::lend(x), gko::lend(res));
+
+    GKO_ASSERT_MTX_NEAR(res,
+                        l({value_type{29.0, -58.0}, value_type{16.0, -32.0}}),
+                        (r_mixed<value_type, TypeParam>()));
+}
+
+
 TYPED_TEST(Perturbation, AppliesLinearCombinationToVector)
 {
     /*
@@ -104,6 +168,78 @@ TYPED_TEST(Perturbation, AppliesLinearCombinationToVector)
     cmp->apply(gko::lend(alpha), gko::lend(x), gko::lend(beta), gko::lend(res));
 
     GKO_ASSERT_MTX_NEAR(res, l({86.0, 46.0}), r<TypeParam>::value);
+}
+
+
+TYPED_TEST(Perturbation, AppliesLinearCombinationToMixedVector)
+{
+    /*
+        cmp = I + 2 * [ 2 ] * [ 3 2 ]
+                      [ 1 ]
+    */
+    using value_type = gko::next_precision<TypeParam>;
+    using Mtx = gko::matrix::Dense<value_type>;
+    auto cmp = gko::Perturbation<TypeParam>::create(this->scalar, this->basis,
+                                                    this->projector);
+    auto alpha = gko::initialize<Mtx>({3.0}, this->exec);
+    auto beta = gko::initialize<Mtx>({-1.0}, this->exec);
+    auto x = gko::initialize<Mtx>({1.0, 2.0}, this->exec);
+    auto res = gko::clone(x);
+
+    cmp->apply(gko::lend(alpha), gko::lend(x), gko::lend(beta), gko::lend(res));
+
+    GKO_ASSERT_MTX_NEAR(res, l({86.0, 46.0}),
+                        (r_mixed<value_type, TypeParam>()));
+}
+
+
+TYPED_TEST(Perturbation, AppliesLinearCombinationToComplexVector)
+{
+    /*
+        cmp = I + 2 * [ 2 ] * [ 3 2 ]
+                      [ 1 ]
+    */
+    using Dense = typename TestFixture::Mtx;
+    using DenseComplex = gko::to_complex<Dense>;
+    using value_type = typename DenseComplex::value_type;
+    auto cmp = gko::Perturbation<TypeParam>::create(this->scalar, this->basis,
+                                                    this->projector);
+    auto alpha = gko::initialize<Dense>({3.0}, this->exec);
+    auto beta = gko::initialize<Dense>({-1.0}, this->exec);
+    auto x = gko::initialize<DenseComplex>(
+        {value_type{1.0, -2.0}, value_type{2.0, -4.0}}, this->exec);
+    auto res = gko::clone(x);
+
+    cmp->apply(gko::lend(alpha), gko::lend(x), gko::lend(beta), gko::lend(res));
+
+    GKO_ASSERT_MTX_NEAR(res,
+                        l({value_type{86.0, -172.0}, value_type{46.0, -92.0}}),
+                        r<TypeParam>::value);
+}
+
+
+TYPED_TEST(Perturbation, AppliesLinearCombinationToMixedComplexVector)
+{
+    /*
+        cmp = I + 2 * [ 2 ] * [ 3 2 ]
+                      [ 1 ]
+    */
+    using MixedDense = gko::matrix::Dense<gko::next_precision<TypeParam>>;
+    using MixedDenseComplex = gko::to_complex<MixedDense>;
+    using value_type = typename MixedDenseComplex::value_type;
+    auto cmp = gko::Perturbation<TypeParam>::create(this->scalar, this->basis,
+                                                    this->projector);
+    auto alpha = gko::initialize<MixedDense>({3.0}, this->exec);
+    auto beta = gko::initialize<MixedDense>({-1.0}, this->exec);
+    auto x = gko::initialize<MixedDenseComplex>(
+        {value_type{1.0, -2.0}, value_type{2.0, -4.0}}, this->exec);
+    auto res = gko::clone(x);
+
+    cmp->apply(gko::lend(alpha), gko::lend(x), gko::lend(beta), gko::lend(res));
+
+    GKO_ASSERT_MTX_NEAR(res,
+                        l({value_type{86.0, -172.0}, value_type{46.0, -92.0}}),
+                        (r_mixed<value_type, TypeParam>()));
 }
 
 

--- a/reference/test/matrix/dense_kernels.cpp
+++ b/reference/test/matrix/dense_kernels.cpp
@@ -65,7 +65,9 @@ class Dense : public ::testing::Test {
 protected:
     using value_type = T;
     using Mtx = gko::matrix::Dense<value_type>;
+    using MixedMtx = gko::matrix::Dense<gko::next_precision<value_type>>;
     using ComplexMtx = gko::to_complex<Mtx>;
+    using MixedComplexMtx = gko::to_complex<MixedMtx>;
     using RealMtx = gko::remove_complex<Mtx>;
     Dense()
         : exec(gko::ReferenceExecutor::create()),
@@ -168,6 +170,26 @@ TYPED_TEST(Dense, AppliesToDense)
 }
 
 
+TYPED_TEST(Dense, AppliesToMixedDense)
+{
+    using MixedMtx = typename TestFixture::MixedMtx;
+    using MixedT = typename MixedMtx::value_type;
+    auto mmtx1 = MixedMtx::create(this->exec);
+    auto mmtx3 = MixedMtx::create(this->exec);
+    this->mtx1->convert_to(mmtx1.get());
+    this->mtx3->convert_to(mmtx3.get());
+
+    this->mtx2->apply(mmtx1.get(), mmtx3.get());
+
+    EXPECT_EQ(mmtx3->at(0, 0), MixedT{-0.5});
+    EXPECT_EQ(mmtx3->at(0, 1), MixedT{-0.5});
+    EXPECT_EQ(mmtx3->at(0, 2), MixedT{-0.5});
+    EXPECT_EQ(mmtx3->at(1, 0), MixedT{1.0});
+    EXPECT_EQ(mmtx3->at(1, 1), MixedT{1.0});
+    ASSERT_EQ(mmtx3->at(1, 2), MixedT{1.0});
+}
+
+
 TYPED_TEST(Dense, AppliesLinearCombinationToDense)
 {
     using Mtx = typename TestFixture::Mtx;
@@ -184,6 +206,28 @@ TYPED_TEST(Dense, AppliesLinearCombinationToDense)
     EXPECT_EQ(this->mtx3->at(1, 0), T{0.0});
     EXPECT_EQ(this->mtx3->at(1, 1), T{2.0});
     ASSERT_EQ(this->mtx3->at(1, 2), T{4.0});
+}
+
+
+TYPED_TEST(Dense, AppliesLinearCombinationToMixedDense)
+{
+    using MixedMtx = typename TestFixture::MixedMtx;
+    using MixedT = typename MixedMtx::value_type;
+    auto mmtx1 = MixedMtx::create(this->exec);
+    auto mmtx3 = MixedMtx::create(this->exec);
+    this->mtx1->convert_to(mmtx1.get());
+    this->mtx3->convert_to(mmtx3.get());
+    auto alpha = gko::initialize<MixedMtx>({-1.0}, this->exec);
+    auto beta = gko::initialize<MixedMtx>({2.0}, this->exec);
+
+    this->mtx2->apply(alpha.get(), mmtx1.get(), beta.get(), mmtx3.get());
+
+    EXPECT_EQ(mmtx3->at(0, 0), MixedT{2.5});
+    EXPECT_EQ(mmtx3->at(0, 1), MixedT{4.5});
+    EXPECT_EQ(mmtx3->at(0, 2), MixedT{6.5});
+    EXPECT_EQ(mmtx3->at(1, 0), MixedT{0.0});
+    EXPECT_EQ(mmtx3->at(1, 1), MixedT{2.0});
+    ASSERT_EQ(mmtx3->at(1, 2), MixedT{4.0});
 }
 
 
@@ -232,6 +276,22 @@ TYPED_TEST(Dense, ScalesData)
 }
 
 
+TYPED_TEST(Dense, ScalesDataMixed)
+{
+    using MixedMtx = typename TestFixture::MixedMtx;
+    using MixedT = typename MixedMtx::value_type;
+    using T = typename TestFixture::value_type;
+    auto alpha = gko::initialize<MixedMtx>({I<MixedT>{2.0, -2.0}}, this->exec);
+
+    this->mtx2->scale(alpha.get());
+
+    EXPECT_EQ(this->mtx2->at(0, 0), T{2.0});
+    EXPECT_EQ(this->mtx2->at(0, 1), T{2.0});
+    EXPECT_EQ(this->mtx2->at(1, 0), T{-4.0});
+    EXPECT_EQ(this->mtx2->at(1, 1), T{-4.0});
+}
+
+
 TYPED_TEST(Dense, ScalesDataWithScalar)
 {
     using Mtx = typename TestFixture::Mtx;
@@ -269,6 +329,25 @@ TYPED_TEST(Dense, AddsScaled)
     using Mtx = typename TestFixture::Mtx;
     using T = typename TestFixture::value_type;
     auto alpha = gko::initialize<Mtx>({{2.0, 1.0, -2.0}}, this->exec);
+
+    this->mtx1->add_scaled(alpha.get(), this->mtx3.get());
+
+    EXPECT_EQ(this->mtx1->at(0, 0), T{3.0});
+    EXPECT_EQ(this->mtx1->at(0, 1), T{4.0});
+    EXPECT_EQ(this->mtx1->at(0, 2), T{-3.0});
+    EXPECT_EQ(this->mtx1->at(1, 0), T{2.5});
+    EXPECT_EQ(this->mtx1->at(1, 1), T{4.0});
+    ASSERT_EQ(this->mtx1->at(1, 2), T{-1.5});
+}
+
+
+TYPED_TEST(Dense, AddsScaledMixed)
+{
+    using MixedMtx = typename TestFixture::MixedMtx;
+    using T = typename TestFixture::value_type;
+    auto mmtx3 = MixedMtx::create(this->exec);
+    this->mtx3->convert_to(mmtx3.get());
+    auto alpha = gko::initialize<MixedMtx>({{2.0, 1.0, -2.0}}, this->exec);
 
     this->mtx1->add_scaled(alpha.get(), this->mtx3.get());
 
@@ -338,6 +417,22 @@ TYPED_TEST(Dense, ComputesDot)
 }
 
 
+TYPED_TEST(Dense, ComputesDotMixed)
+{
+    using MixedMtx = typename TestFixture::MixedMtx;
+    using MixedT = typename MixedMtx::value_type;
+    auto mmtx3 = MixedMtx::create(this->exec);
+    this->mtx3->convert_to(mmtx3.get());
+    auto result = MixedMtx::create(this->exec, gko::dim<2>{1, 3});
+
+    this->mtx1->compute_dot(this->mtx3.get(), result.get());
+
+    EXPECT_EQ(result->at(0, 0), MixedT{1.75});
+    EXPECT_EQ(result->at(0, 1), MixedT{7.75});
+    ASSERT_EQ(result->at(0, 2), MixedT{17.75});
+}
+
+
 TYPED_TEST(Dense, ComputesNorm2)
 {
     using Mtx = typename TestFixture::Mtx;
@@ -352,6 +447,24 @@ TYPED_TEST(Dense, ComputesNorm2)
 
     EXPECT_EQ(result->at(0, 0), T_nc{3.0});
     EXPECT_EQ(result->at(0, 1), T_nc{5.0});
+}
+
+
+TYPED_TEST(Dense, ComputesNorm2Mixed)
+{
+    using MixedMtx = typename TestFixture::MixedMtx;
+    using MixedT = typename MixedMtx::value_type;
+    using MixedT_nc = gko::remove_complex<MixedT>;
+    using MixedNormVector = gko::matrix::Dense<MixedT_nc>;
+    auto mtx(gko::initialize<MixedMtx>(
+        {I<MixedT>{1.0, 0.0}, I<MixedT>{2.0, 3.0}, I<MixedT>{2.0, 4.0}},
+        this->exec));
+    auto result = MixedNormVector::create(this->exec, gko::dim<2>{1, 2});
+
+    mtx->compute_norm2(result.get());
+
+    EXPECT_EQ(result->at(0, 0), MixedT_nc{3.0});
+    EXPECT_EQ(result->at(0, 1), MixedT_nc{5.0});
 }
 
 
@@ -2312,8 +2425,7 @@ TYPED_TEST(Dense, AppliesToComplex)
 {
     using value_type = typename TestFixture::value_type;
     using complex_type = gko::to_complex<value_type>;
-    using Mtx = typename TestFixture::Mtx;
-    using Vec = typename gko::matrix::Dense<complex_type>;
+    using Vec = gko::matrix::Dense<complex_type>;
     auto exec = gko::ReferenceExecutor::create();
 
     // clang-format off
@@ -2334,24 +2446,50 @@ TYPED_TEST(Dense, AppliesToComplex)
 }
 
 
-TYPED_TEST(Dense, AdvancedAppliesToComplex)
+TYPED_TEST(Dense, AppliesToMixedComplex)
 {
-    using value_type = typename TestFixture::value_type;
-    using complex_type = gko::to_complex<value_type>;
-    using Mtx = typename TestFixture::Mtx;
-    using Vec = typename gko::matrix::Dense<complex_type>;
+    using mixed_value_type =
+        gko::next_precision<typename TestFixture::value_type>;
+    using mixed_complex_type = gko::to_complex<mixed_value_type>;
+    using Vec = gko::matrix::Dense<mixed_complex_type>;
     auto exec = gko::ReferenceExecutor::create();
 
     // clang-format off
     auto b = gko::initialize<Vec>(
+        {{mixed_complex_type{1.0, 0.0}, mixed_complex_type{2.0, 1.0}},
+         {mixed_complex_type{2.0, 2.0}, mixed_complex_type{3.0, 3.0}},
+         {mixed_complex_type{3.0, 4.0}, mixed_complex_type{4.0, 5.0}}}, exec);
+    auto x = Vec::create(exec, gko::dim<2>{2,2});
+    // clang-format on
+
+    this->mtx1->apply(b.get(), x.get());
+
+    GKO_ASSERT_MTX_NEAR(
+        x,
+        l({{mixed_complex_type{14.0, 16.0}, mixed_complex_type{20.0, 22.0}},
+           {mixed_complex_type{17.0, 19.0}, mixed_complex_type{24.5, 26.5}}}),
+        0.0);
+}
+
+
+TYPED_TEST(Dense, AdvancedAppliesToComplex)
+{
+    using value_type = typename TestFixture::value_type;
+    using complex_type = gko::to_complex<value_type>;
+    using Dense = gko::matrix::Dense<value_type>;
+    using DenseComplex = gko::matrix::Dense<complex_type>;
+    auto exec = gko::ReferenceExecutor::create();
+
+    // clang-format off
+    auto b = gko::initialize<DenseComplex>(
         {{complex_type{1.0, 0.0}, complex_type{2.0, 1.0}},
          {complex_type{2.0, 2.0}, complex_type{3.0, 3.0}},
          {complex_type{3.0, 4.0}, complex_type{4.0, 5.0}}}, exec);
-    auto x = gko::initialize<Vec>(
+    auto x = gko::initialize<DenseComplex>(
         {{complex_type{1.0, 0.0}, complex_type{2.0, 1.0}},
          {complex_type{2.0, 2.0}, complex_type{3.0, 3.0}}}, exec);
-    auto alpha = gko::initialize<Mtx>({-1.0}, this->exec);
-    auto beta = gko::initialize<Mtx>({2.0}, this->exec);
+    auto alpha = gko::initialize<Dense>({-1.0}, this->exec);
+    auto beta = gko::initialize<Dense>({2.0}, this->exec);
     // clang-format on
 
     this->mtx1->apply(alpha.get(), b.get(), beta.get(), x.get());
@@ -2360,6 +2498,38 @@ TYPED_TEST(Dense, AdvancedAppliesToComplex)
         x,
         l({{complex_type{-12.0, -16.0}, complex_type{-16.0, -20.0}},
            {complex_type{-13.0, -15.0}, complex_type{-18.5, -20.5}}}),
+        0.0);
+}
+
+
+TYPED_TEST(Dense, AdvancedAppliesToMixedComplex)
+{
+    using mixed_value_type =
+        gko::next_precision<typename TestFixture::value_type>;
+    using mixed_complex_type = gko::to_complex<mixed_value_type>;
+    using MixedDense = gko::matrix::Dense<mixed_value_type>;
+    using MixedDenseComplex = gko::matrix::Dense<mixed_complex_type>;
+    auto exec = gko::ReferenceExecutor::create();
+
+    // clang-format off
+    auto b = gko::initialize<MixedDenseComplex>(
+        {{mixed_complex_type{1.0, 0.0}, mixed_complex_type{2.0, 1.0}},
+         {mixed_complex_type{2.0, 2.0}, mixed_complex_type{3.0, 3.0}},
+         {mixed_complex_type{3.0, 4.0}, mixed_complex_type{4.0, 5.0}}}, exec);
+    auto x = gko::initialize<MixedDenseComplex>(
+        {{mixed_complex_type{1.0, 0.0}, mixed_complex_type{2.0, 1.0}},
+         {mixed_complex_type{2.0, 2.0}, mixed_complex_type{3.0, 3.0}}}, exec);
+    auto alpha = gko::initialize<MixedDense>({-1.0}, this->exec);
+    auto beta = gko::initialize<MixedDense>({2.0}, this->exec);
+    // clang-format on
+
+    this->mtx1->apply(alpha.get(), b.get(), beta.get(), x.get());
+
+    GKO_ASSERT_MTX_NEAR(
+        x,
+        l({{mixed_complex_type{-12.0, -16.0}, mixed_complex_type{-16.0, -20.0}},
+           {mixed_complex_type{-13.0, -15.0},
+            mixed_complex_type{-18.5, -20.5}}}),
         0.0);
 }
 

--- a/reference/test/matrix/hybrid_kernels.cpp
+++ b/reference/test/matrix/hybrid_kernels.cpp
@@ -64,6 +64,7 @@ protected:
     using Mtx = gko::matrix::Hybrid<value_type, index_type>;
     using Vec = gko::matrix::Dense<value_type>;
     using Csr = gko::matrix::Csr<value_type, index_type>;
+    using MixedVec = gko::matrix::Dense<gko::next_precision<value_type>>;
 
     Hybrid()
         : exec(gko::ReferenceExecutor::create()),
@@ -145,6 +146,18 @@ TYPED_TEST(Hybrid, AppliesToDenseVector)
 }
 
 
+TYPED_TEST(Hybrid, AppliesToMixedDenseVector)
+{
+    using MixedVec = typename TestFixture::MixedVec;
+    auto x = gko::initialize<MixedVec>({2.0, 1.0, 4.0}, this->exec);
+    auto y = MixedVec::create(this->exec, gko::dim<2>{2, 1});
+
+    this->mtx1->apply(x.get(), y.get());
+
+    GKO_ASSERT_MTX_NEAR(y, l({13.0, 5.0}), 0.0);
+}
+
+
 TYPED_TEST(Hybrid, AppliesToDenseMatrix)
 {
     using Vec = typename TestFixture::Vec;
@@ -174,6 +187,20 @@ TYPED_TEST(Hybrid, AppliesLinearCombinationToDenseVector)
     auto beta = gko::initialize<Vec>({2.0}, this->exec);
     auto x = gko::initialize<Vec>({2.0, 1.0, 4.0}, this->exec);
     auto y = gko::initialize<Vec>({1.0, 2.0}, this->exec);
+
+    this->mtx1->apply(alpha.get(), x.get(), beta.get(), y.get());
+
+    GKO_ASSERT_MTX_NEAR(y, l({-11.0, -1.0}), 0.0);
+}
+
+
+TYPED_TEST(Hybrid, AppliesLinearCombinationToMixedDenseVector)
+{
+    using MixedVec = typename TestFixture::MixedVec;
+    auto alpha = gko::initialize<MixedVec>({-1.0}, this->exec);
+    auto beta = gko::initialize<MixedVec>({2.0}, this->exec);
+    auto x = gko::initialize<MixedVec>({2.0, 1.0, 4.0}, this->exec);
+    auto y = gko::initialize<MixedVec>({1.0, 2.0}, this->exec);
 
     this->mtx1->apply(alpha.get(), x.get(), beta.get(), y.get());
 
@@ -691,7 +718,7 @@ TYPED_TEST(Hybrid, AppliesToComplex)
     using value_type = typename TestFixture::value_type;
     using complex_type = gko::to_complex<value_type>;
     using Mtx = typename TestFixture::Mtx;
-    using Vec = typename gko::matrix::Dense<complex_type>;
+    using Vec = gko::matrix::Dense<complex_type>;
     auto exec = gko::ReferenceExecutor::create();
 
     // clang-format off
@@ -712,25 +739,51 @@ TYPED_TEST(Hybrid, AppliesToComplex)
 }
 
 
+TYPED_TEST(Hybrid, AppliesToMixedComplex)
+{
+    using mixed_value_type =
+        gko::next_precision<typename TestFixture::value_type>;
+    using mixed_complex_type = gko::to_complex<mixed_value_type>;
+    using Vec = gko::matrix::Dense<mixed_complex_type>;
+    auto exec = gko::ReferenceExecutor::create();
+
+    // clang-format off
+    auto b = gko::initialize<Vec>(
+        {{mixed_complex_type{1.0, 0.0}, mixed_complex_type{2.0, 1.0}},
+         {mixed_complex_type{2.0, 2.0}, mixed_complex_type{3.0, 3.0}},
+         {mixed_complex_type{3.0, 4.0}, mixed_complex_type{4.0, 5.0}}}, exec);
+    auto x = Vec::create(exec, gko::dim<2>{2,2});
+    // clang-format on
+
+    this->mtx1->apply(b.get(), x.get());
+
+    GKO_ASSERT_MTX_NEAR(
+        x,
+        l({{mixed_complex_type{13.0, 14.0}, mixed_complex_type{19.0, 20.0}},
+           {mixed_complex_type{10.0, 10.0}, mixed_complex_type{15.0, 15.0}}}),
+        0.0);
+}
+
+
 TYPED_TEST(Hybrid, AdvancedAppliesToComplex)
 {
     using value_type = typename TestFixture::value_type;
     using complex_type = gko::to_complex<value_type>;
     using Mtx = typename TestFixture::Mtx;
-    using Scal = typename gko::matrix::Dense<value_type>;
-    using Vec = typename gko::matrix::Dense<complex_type>;
+    using Dense = gko::matrix::Dense<value_type>;
+    using DenseComplex = gko::matrix::Dense<complex_type>;
     auto exec = gko::ReferenceExecutor::create();
 
     // clang-format off
-    auto b = gko::initialize<Vec>(
+    auto b = gko::initialize<DenseComplex>(
         {{complex_type{1.0, 0.0}, complex_type{2.0, 1.0}},
          {complex_type{2.0, 2.0}, complex_type{3.0, 3.0}},
          {complex_type{3.0, 4.0}, complex_type{4.0, 5.0}}}, exec);
-    auto x = gko::initialize<Vec>(
+    auto x = gko::initialize<DenseComplex>(
         {{complex_type{1.0, 0.0}, complex_type{2.0, 1.0}},
          {complex_type{2.0, 2.0}, complex_type{3.0, 3.0}}}, exec);
-    auto alpha = gko::initialize<Scal>({-1.0}, this->exec);
-    auto beta = gko::initialize<Scal>({2.0}, this->exec);
+    auto alpha = gko::initialize<Dense>({-1.0}, this->exec);
+    auto beta = gko::initialize<Dense>({2.0}, this->exec);
     // clang-format on
 
     this->mtx1->apply(alpha.get(), b.get(), beta.get(), x.get());
@@ -739,6 +792,38 @@ TYPED_TEST(Hybrid, AdvancedAppliesToComplex)
         x,
         l({{complex_type{-11.0, -14.0}, complex_type{-15.0, -18.0}},
            {complex_type{-6.0, -6.0}, complex_type{-9.0, -9.0}}}),
+        0.0);
+}
+
+
+TYPED_TEST(Hybrid, AdvancedAppliesToMixedComplex)
+{
+    using mixed_value_type =
+        gko::next_precision<typename TestFixture::value_type>;
+    using mixed_complex_type = gko::to_complex<mixed_value_type>;
+    using MixedDense = gko::matrix::Dense<mixed_value_type>;
+    using MixedDenseComplex = gko::matrix::Dense<mixed_complex_type>;
+
+    // clang-format off
+    auto b = gko::initialize<MixedDenseComplex>(
+        {{mixed_complex_type{1.0, 0.0}, mixed_complex_type{2.0, 1.0}},
+         {mixed_complex_type{2.0, 2.0}, mixed_complex_type{3.0, 3.0}},
+         {mixed_complex_type{3.0, 4.0}, mixed_complex_type{4.0, 5.0}}},
+         this->exec);
+    auto x = gko::initialize<MixedDenseComplex>(
+        {{mixed_complex_type{1.0, 0.0}, mixed_complex_type{2.0, 1.0}},
+         {mixed_complex_type{2.0, 2.0}, mixed_complex_type{3.0, 3.0}}},
+         this->exec);
+    auto alpha = gko::initialize<MixedDense>({-1.0}, this->exec);
+    auto beta = gko::initialize<MixedDense>({2.0}, this->exec);
+    // clang-format on
+
+    this->mtx1->apply(alpha.get(), b.get(), beta.get(), x.get());
+
+    GKO_ASSERT_MTX_NEAR(
+        x,
+        l({{mixed_complex_type{-11.0, -14.0}, mixed_complex_type{-15.0, -18.0}},
+           {mixed_complex_type{-6.0, -6.0}, mixed_complex_type{-9.0, -9.0}}}),
         0.0);
 }
 

--- a/reference/test/matrix/identity.cpp
+++ b/reference/test/matrix/identity.cpp
@@ -51,6 +51,9 @@ protected:
     using value_type = T;
     using Id = gko::matrix::Identity<value_type>;
     using Vec = gko::matrix::Dense<value_type>;
+    using MixedVec = gko::matrix::Dense<gko::next_precision<value_type>>;
+    using ComplexVec = gko::to_complex<Vec>;
+    using MixedComplexVec = gko::to_complex<MixedVec>;
 
     Identity() : exec(gko::ReferenceExecutor::create()) {}
 
@@ -59,6 +62,34 @@ protected:
 
 
 TYPED_TEST_SUITE(Identity, gko::test::ValueTypes);
+
+
+TYPED_TEST(Identity, AppliesToVector)
+{
+    using Id = typename TestFixture::Id;
+    using Vec = typename TestFixture::Vec;
+    auto identity = Id::create(this->exec, 3);
+    auto x = gko::initialize<Vec>({3.0, -1.0, 2.0}, this->exec);
+    auto b = gko::initialize<Vec>({2.0, 1.0, 5.0}, this->exec);
+
+    identity->apply(b.get(), x.get());
+
+    GKO_ASSERT_MTX_NEAR(x, l({2.0, 1.0, 5.0}), 0.0);
+}
+
+
+TYPED_TEST(Identity, AppliesToMixedVector)
+{
+    using Id = typename TestFixture::Id;
+    using MixedVec = typename TestFixture::MixedVec;
+    auto identity = Id::create(this->exec, 3);
+    auto x = gko::initialize<MixedVec>({3.0, -1.0, 2.0}, this->exec);
+    auto b = gko::initialize<MixedVec>({2.0, 1.0, 5.0}, this->exec);
+
+    identity->apply(b.get(), x.get());
+
+    GKO_ASSERT_MTX_NEAR(x, l({2.0, 1.0, 5.0}), 0.0);
+}
 
 
 TYPED_TEST(Identity, AppliesLinearCombinationToVector)
@@ -70,6 +101,22 @@ TYPED_TEST(Identity, AppliesLinearCombinationToVector)
     auto beta = gko::initialize<Vec>({1.0}, this->exec);
     auto x = gko::initialize<Vec>({3.0, -1.0, 2.0}, this->exec);
     auto b = gko::initialize<Vec>({2.0, 1.0, 5.0}, this->exec);
+
+    identity->apply(alpha.get(), b.get(), beta.get(), x.get());
+
+    GKO_ASSERT_MTX_NEAR(x, l({7.0, 1.0, 12.0}), 0.0);
+}
+
+
+TYPED_TEST(Identity, AppliesLinearCombinationToMixedVector)
+{
+    using Id = typename TestFixture::Id;
+    using MixedVec = typename TestFixture::MixedVec;
+    auto identity = Id::create(this->exec, 3);
+    auto alpha = gko::initialize<MixedVec>({2.0}, this->exec);
+    auto beta = gko::initialize<MixedVec>({1.0}, this->exec);
+    auto x = gko::initialize<MixedVec>({3.0, -1.0, 2.0}, this->exec);
+    auto b = gko::initialize<MixedVec>({2.0, 1.0, 5.0}, this->exec);
 
     identity->apply(alpha.get(), b.get(), beta.get(), x.get());
 
@@ -93,6 +140,68 @@ TYPED_TEST(Identity, AppliesLinearCombinationToMultipleVectors)
     identity->apply(alpha.get(), b.get(), beta.get(), x.get());
 
     GKO_ASSERT_MTX_NEAR(x, l({{7.0, 6.5}, {1.0, 6.5}, {12.0, 1.5}}), 0.0);
+}
+
+
+TYPED_TEST(Identity, AppliesToComplex)
+{
+    using Id = typename TestFixture::Id;
+    using ComplexVec = typename TestFixture::ComplexVec;
+    auto identity = Id::create(this->exec, 3);
+    auto x = gko::initialize<ComplexVec>({3.0, -1.0, 2.0}, this->exec);
+    auto b = gko::initialize<ComplexVec>({2.0, 1.0, 5.0}, this->exec);
+
+    identity->apply(b.get(), x.get());
+
+    GKO_ASSERT_MTX_NEAR(x, l({2.0, 1.0, 5.0}), 0.0);
+}
+
+
+TYPED_TEST(Identity, AppliesToMixedComplex)
+{
+    using Id = typename TestFixture::Id;
+    using MixedComplexVec = typename TestFixture::MixedComplexVec;
+    auto identity = Id::create(this->exec, 3);
+    auto x = gko::initialize<MixedComplexVec>({3.0, -1.0, 2.0}, this->exec);
+    auto b = gko::initialize<MixedComplexVec>({2.0, 1.0, 5.0}, this->exec);
+
+    identity->apply(b.get(), x.get());
+
+    GKO_ASSERT_MTX_NEAR(x, l({2.0, 1.0, 5.0}), 0.0);
+}
+
+
+TYPED_TEST(Identity, AppliesLinearCombinationToComplex)
+{
+    using Id = typename TestFixture::Id;
+    using Vec = typename TestFixture::Vec;
+    using ComplexVec = typename TestFixture::ComplexVec;
+    auto identity = Id::create(this->exec, 3);
+    auto alpha = gko::initialize<Vec>({2.0}, this->exec);
+    auto beta = gko::initialize<Vec>({1.0}, this->exec);
+    auto x = gko::initialize<ComplexVec>({3.0, -1.0, 2.0}, this->exec);
+    auto b = gko::initialize<ComplexVec>({2.0, 1.0, 5.0}, this->exec);
+
+    identity->apply(alpha.get(), b.get(), beta.get(), x.get());
+
+    GKO_ASSERT_MTX_NEAR(x, l({7.0, 1.0, 12.0}), 0.0);
+}
+
+
+TYPED_TEST(Identity, AppliesLinearCombinationToMixedComplex)
+{
+    using Id = typename TestFixture::Id;
+    using MixedVec = typename TestFixture::MixedVec;
+    using MixedComplexVec = typename TestFixture::MixedComplexVec;
+    auto identity = Id::create(this->exec, 3);
+    auto alpha = gko::initialize<MixedVec>({2.0}, this->exec);
+    auto beta = gko::initialize<MixedVec>({1.0}, this->exec);
+    auto x = gko::initialize<MixedComplexVec>({3.0, -1.0, 2.0}, this->exec);
+    auto b = gko::initialize<MixedComplexVec>({2.0, 1.0, 5.0}, this->exec);
+
+    identity->apply(alpha.get(), b.get(), beta.get(), x.get());
+
+    GKO_ASSERT_MTX_NEAR(x, l({7.0, 1.0, 12.0}), 0.0);
 }
 
 

--- a/reference/test/matrix/sellp_kernels.cpp
+++ b/reference/test/matrix/sellp_kernels.cpp
@@ -96,6 +96,18 @@ TYPED_TEST(Sellp, AppliesToDenseVector)
 }
 
 
+TYPED_TEST(Sellp, AppliesToMixedDenseVector)
+{
+    using Vec = typename TestFixture::Vec;
+    auto x = gko::initialize<Vec>({2.0, 1.0, 4.0}, this->exec);
+    auto y = Vec::create(this->exec, gko::dim<2>{2, 1});
+
+    this->mtx1->apply(x.get(), y.get());
+
+    GKO_ASSERT_MTX_NEAR(y, l({13.0, 5.0}), 0.0);
+}
+
+
 TYPED_TEST(Sellp, AppliesToDenseMatrix)
 {
     using Vec = typename TestFixture::Vec;
@@ -119,6 +131,20 @@ TYPED_TEST(Sellp, AppliesToDenseMatrix)
 
 
 TYPED_TEST(Sellp, AppliesLinearCombinationToDenseVector)
+{
+    using Vec = typename TestFixture::Vec;
+    auto alpha = gko::initialize<Vec>({-1.0}, this->exec);
+    auto beta = gko::initialize<Vec>({2.0}, this->exec);
+    auto x = gko::initialize<Vec>({2.0, 1.0, 4.0}, this->exec);
+    auto y = gko::initialize<Vec>({1.0, 2.0}, this->exec);
+
+    this->mtx1->apply(alpha.get(), x.get(), beta.get(), y.get());
+
+    GKO_ASSERT_MTX_NEAR(y, l({-11.0, -1.0}), 0.0);
+}
+
+
+TYPED_TEST(Sellp, AppliesLinearCombinationToMixedDenseVector)
 {
     using Vec = typename TestFixture::Vec;
     auto alpha = gko::initialize<Vec>({-1.0}, this->exec);
@@ -645,8 +671,32 @@ TYPED_TEST(Sellp, AppliesToComplex)
 {
     using value_type = typename TestFixture::value_type;
     using complex_type = gko::to_complex<value_type>;
-    using Mtx = typename TestFixture::Mtx;
-    using Vec = typename gko::matrix::Dense<complex_type>;
+    using Vec = gko::matrix::Dense<complex_type>;
+    auto exec = gko::ReferenceExecutor::create();
+
+    // clang-format off
+    auto b = gko::initialize<Vec>(
+        {{complex_type{1.0, 0.0}, complex_type{2.0, 1.0}},
+         {complex_type{2.0, 2.0}, complex_type{3.0, 3.0}},
+         {complex_type{3.0, 4.0}, complex_type{4.0, 5.0}}}, exec);
+    auto x = Vec::create(exec, gko::dim<2>{2,2});
+    // clang-format on
+
+    this->mtx1->apply(b.get(), x.get());
+
+    GKO_ASSERT_MTX_NEAR(
+        x,
+        l({{complex_type{13.0, 14.0}, complex_type{19.0, 20.0}},
+           {complex_type{10.0, 10.0}, complex_type{15.0, 15.0}}}),
+        0.0);
+}
+
+
+TYPED_TEST(Sellp, AppliesToMixedComplex)
+{
+    using value_type = typename TestFixture::value_type;
+    using complex_type = gko::to_complex<value_type>;
+    using Vec = gko::matrix::Dense<complex_type>;
     auto exec = gko::ReferenceExecutor::create();
 
     // clang-format off
@@ -671,21 +721,50 @@ TYPED_TEST(Sellp, AdvancedAppliesToComplex)
 {
     using value_type = typename TestFixture::value_type;
     using complex_type = gko::to_complex<value_type>;
-    using Mtx = typename TestFixture::Mtx;
-    using Scal = typename gko::matrix::Dense<value_type>;
-    using Vec = typename gko::matrix::Dense<complex_type>;
+    using Dense = gko::matrix::Dense<value_type>;
+    using DenseComplex = gko::matrix::Dense<complex_type>;
     auto exec = gko::ReferenceExecutor::create();
 
     // clang-format off
-    auto b = gko::initialize<Vec>(
+    auto b = gko::initialize<DenseComplex>(
         {{complex_type{1.0, 0.0}, complex_type{2.0, 1.0}},
          {complex_type{2.0, 2.0}, complex_type{3.0, 3.0}},
          {complex_type{3.0, 4.0}, complex_type{4.0, 5.0}}}, exec);
-    auto x = gko::initialize<Vec>(
+    auto x = gko::initialize<DenseComplex>(
         {{complex_type{1.0, 0.0}, complex_type{2.0, 1.0}},
          {complex_type{2.0, 2.0}, complex_type{3.0, 3.0}}}, exec);
-    auto alpha = gko::initialize<Scal>({-1.0}, this->exec);
-    auto beta = gko::initialize<Scal>({2.0}, this->exec);
+    auto alpha = gko::initialize<Dense>({-1.0}, this->exec);
+    auto beta = gko::initialize<Dense>({2.0}, this->exec);
+    // clang-format on
+
+    this->mtx1->apply(alpha.get(), b.get(), beta.get(), x.get());
+
+    GKO_ASSERT_MTX_NEAR(
+        x,
+        l({{complex_type{-11.0, -14.0}, complex_type{-15.0, -18.0}},
+           {complex_type{-6.0, -6.0}, complex_type{-9.0, -9.0}}}),
+        0.0);
+}
+
+
+TYPED_TEST(Sellp, AdvancedAppliesToMixedComplex)
+{
+    using value_type = typename TestFixture::value_type;
+    using complex_type = gko::to_complex<value_type>;
+    using MixedDense = gko::matrix::Dense<value_type>;
+    using MixedDenseComplex = gko::matrix::Dense<complex_type>;
+    auto exec = gko::ReferenceExecutor::create();
+
+    // clang-format off
+    auto b = gko::initialize<MixedDenseComplex>(
+        {{complex_type{1.0, 0.0}, complex_type{2.0, 1.0}},
+         {complex_type{2.0, 2.0}, complex_type{3.0, 3.0}},
+         {complex_type{3.0, 4.0}, complex_type{4.0, 5.0}}}, exec);
+    auto x = gko::initialize<MixedDenseComplex>(
+        {{complex_type{1.0, 0.0}, complex_type{2.0, 1.0}},
+         {complex_type{2.0, 2.0}, complex_type{3.0, 3.0}}}, exec);
+    auto alpha = gko::initialize<MixedDense>({-1.0}, this->exec);
+    auto beta = gko::initialize<MixedDense>({2.0}, this->exec);
     // clang-format on
 
     this->mtx1->apply(alpha.get(), b.get(), beta.get(), x.get());

--- a/reference/test/matrix/sellp_kernels.cpp
+++ b/reference/test/matrix/sellp_kernels.cpp
@@ -98,7 +98,8 @@ TYPED_TEST(Sellp, AppliesToDenseVector)
 
 TYPED_TEST(Sellp, AppliesToMixedDenseVector)
 {
-    using Vec = typename TestFixture::Vec;
+    using value_type = gko::next_precision<typename TestFixture::value_type>;
+    using Vec = gko::matrix::Dense<value_type>;
     auto x = gko::initialize<Vec>({2.0, 1.0, 4.0}, this->exec);
     auto y = Vec::create(this->exec, gko::dim<2>{2, 1});
 
@@ -146,7 +147,8 @@ TYPED_TEST(Sellp, AppliesLinearCombinationToDenseVector)
 
 TYPED_TEST(Sellp, AppliesLinearCombinationToMixedDenseVector)
 {
-    using Vec = typename TestFixture::Vec;
+    using value_type = gko::next_precision<typename TestFixture::value_type>;
+    using Vec = gko::matrix::Dense<value_type>;
     auto alpha = gko::initialize<Vec>({-1.0}, this->exec);
     auto beta = gko::initialize<Vec>({2.0}, this->exec);
     auto x = gko::initialize<Vec>({2.0, 1.0, 4.0}, this->exec);

--- a/reference/test/matrix/sparsity_csr_kernels.cpp
+++ b/reference/test/matrix/sparsity_csr_kernels.cpp
@@ -174,6 +174,20 @@ TYPED_TEST(SparsityCsr, AppliesToDenseVector)
 }
 
 
+TYPED_TEST(SparsityCsr, AppliesToMixedDenseVector)
+{
+    using Vec = typename TestFixture::Vec;
+    using T = typename TestFixture::value_type;
+    auto x = gko::initialize<Vec>({2.0, 1.0, 4.0}, this->exec);
+    auto y = Vec::create(this->exec, gko::dim<2>{2, 1});
+
+    this->mtx->apply(x.get(), y.get());
+
+    EXPECT_EQ(y->at(0), T{7.0});
+    EXPECT_EQ(y->at(1), T{1.0});
+}
+
+
 TYPED_TEST(SparsityCsr, AppliesToDenseMatrix)
 {
     using Vec = typename TestFixture::Vec;
@@ -207,6 +221,22 @@ TYPED_TEST(SparsityCsr, AppliesLinearCombinationToDenseVector)
 }
 
 
+TYPED_TEST(SparsityCsr, AppliesLinearCombinationToMixedDenseVector)
+{
+    using Vec = typename TestFixture::Vec;
+    using T = typename TestFixture::value_type;
+    auto alpha = gko::initialize<Vec>({-1.0}, this->exec);
+    auto beta = gko::initialize<Vec>({2.0}, this->exec);
+    auto x = gko::initialize<Vec>({2.0, 1.0, 4.0}, this->exec);
+    auto y = gko::initialize<Vec>({1.0, 2.0}, this->exec);
+
+    this->mtx->apply(alpha.get(), x.get(), beta.get(), y.get());
+
+    EXPECT_EQ(y->at(0), T{-5.0});
+    EXPECT_EQ(y->at(1), T{3.0});
+}
+
+
 TYPED_TEST(SparsityCsr, AppliesLinearCombinationToDenseMatrix)
 {
     using Vec = typename TestFixture::Vec;
@@ -224,6 +254,76 @@ TYPED_TEST(SparsityCsr, AppliesLinearCombinationToDenseMatrix)
     EXPECT_EQ(y->at(1, 0), T{3.0});
     EXPECT_EQ(y->at(0, 1), T{-3.0});
     EXPECT_EQ(y->at(1, 1), T{-1.5});
+}
+
+
+TYPED_TEST(SparsityCsr, AppliesToComplex)
+{
+    using Vec = gko::to_complex<typename TestFixture::Vec>;
+    using T = gko::to_complex<typename TestFixture::value_type>;
+    auto x = gko::initialize<Vec>({T{2.0, 4.0}, T{1.0, 2.0}, T{4.0, 8.0}},
+                                  this->exec);
+    auto y = Vec::create(this->exec, gko::dim<2>{2, 1});
+
+    this->mtx->apply(x.get(), y.get());
+
+    EXPECT_EQ(y->at(0), T(7.0, 14.0));
+    EXPECT_EQ(y->at(1), T(1.0, 2.0));
+}
+
+
+TYPED_TEST(SparsityCsr, AppliesToMixedComplex)
+{
+    using T =
+        gko::next_precision<gko::to_complex<typename TestFixture::value_type>>;
+    using Vec = gko::matrix::Dense<T>;
+    auto x = gko::initialize<Vec>({T{2.0, 4.0}, T{1.0, 2.0}, T{4.0, 8.0}},
+                                  this->exec);
+    auto y = Vec::create(this->exec, gko::dim<2>{2, 1});
+
+    this->mtx->apply(x.get(), y.get());
+
+    EXPECT_EQ(y->at(0), T(7.0, 14.0));
+    EXPECT_EQ(y->at(1), T(1.0, 2.0));
+}
+
+
+TYPED_TEST(SparsityCsr, AppliesLinearCombinationToComplex)
+{
+    using Vec = typename TestFixture::Vec;
+    using ComplexVec = gko::to_complex<Vec>;
+    using T = gko::to_complex<typename TestFixture::value_type>;
+    auto alpha = gko::initialize<Vec>({-1.0}, this->exec);
+    auto beta = gko::initialize<Vec>({2.0}, this->exec);
+    auto x = gko::initialize<ComplexVec>(
+        {T{2.0, 4.0}, T{1.0, 2.0}, T{4.0, 8.0}}, this->exec);
+    auto y =
+        gko::initialize<ComplexVec>({T{1.0, 2.0}, T{2.0, 4.0}}, this->exec);
+
+    this->mtx->apply(alpha.get(), x.get(), beta.get(), y.get());
+
+    EXPECT_EQ(y->at(0), T(-5.0, -10.0));
+    EXPECT_EQ(y->at(1), T(3.0, 6.0));
+}
+
+
+TYPED_TEST(SparsityCsr, AppliesLinearCombinationToMixedComplex)
+{
+    using Vec = gko::matrix::Dense<
+        gko::next_precision<typename TestFixture::value_type>>;
+    using ComplexVec = gko::to_complex<Vec>;
+    using T = typename ComplexVec::value_type;
+    auto alpha = gko::initialize<Vec>({-1.0}, this->exec);
+    auto beta = gko::initialize<Vec>({2.0}, this->exec);
+    auto x = gko::initialize<ComplexVec>(
+        {T{2.0, 4.0}, T{1.0, 2.0}, T{4.0, 8.0}}, this->exec);
+    auto y =
+        gko::initialize<ComplexVec>({T{1.0, 2.0}, T{2.0, 4.0}}, this->exec);
+
+    this->mtx->apply(alpha.get(), x.get(), beta.get(), y.get());
+
+    EXPECT_EQ(y->at(0), T(-5.0, -10.0));
+    EXPECT_EQ(y->at(1), T(3.0, 6.0));
 }
 
 

--- a/reference/test/matrix/sparsity_csr_kernels.cpp
+++ b/reference/test/matrix/sparsity_csr_kernels.cpp
@@ -176,8 +176,8 @@ TYPED_TEST(SparsityCsr, AppliesToDenseVector)
 
 TYPED_TEST(SparsityCsr, AppliesToMixedDenseVector)
 {
-    using Vec = typename TestFixture::Vec;
-    using T = typename TestFixture::value_type;
+    using T = gko::next_precision<typename TestFixture::value_type>;
+    using Vec = gko::matrix::Dense<T>;
     auto x = gko::initialize<Vec>({2.0, 1.0, 4.0}, this->exec);
     auto y = Vec::create(this->exec, gko::dim<2>{2, 1});
 
@@ -223,8 +223,8 @@ TYPED_TEST(SparsityCsr, AppliesLinearCombinationToDenseVector)
 
 TYPED_TEST(SparsityCsr, AppliesLinearCombinationToMixedDenseVector)
 {
-    using Vec = typename TestFixture::Vec;
-    using T = typename TestFixture::value_type;
+    using T = gko::next_precision<typename TestFixture::value_type>;
+    using Vec = gko::matrix::Dense<T>;
     auto alpha = gko::initialize<Vec>({-1.0}, this->exec);
     auto beta = gko::initialize<Vec>({2.0}, this->exec);
     auto x = gko::initialize<Vec>({2.0, 1.0, 4.0}, this->exec);

--- a/reference/test/preconditioner/ic.cpp
+++ b/reference/test/preconditioner/ic.cpp
@@ -276,6 +276,139 @@ TYPED_TEST(Ic, SolvesSingleRhs)
 }
 
 
+TYPED_TEST(Ic, SolvesSingleRhsMixed)
+{
+    using ic_prec_type = typename TestFixture::ic_prec_type;
+    using T = typename TestFixture::value_type;
+    using Vec = gko::matrix::Dense<gko::next_precision<T>>;
+    const auto b = gko::initialize<Vec>({1.0, 3.0, 6.0}, this->exec);
+    auto x = Vec::create(this->exec, gko::dim<2>{3, 1});
+    auto preconditioner =
+        ic_prec_type::build().on(this->exec)->generate(this->mtx);
+
+    preconditioner->apply(b.get(), x.get());
+
+    GKO_ASSERT_MTX_NEAR(x, l({3.0, -2.0, 4.0}), this->tol);
+}
+
+
+TYPED_TEST(Ic, SolvesSingleRhsComplex)
+{
+    using ic_prec_type = typename TestFixture::ic_prec_type;
+    using Vec = gko::to_complex<typename TestFixture::Vec>;
+    using T = typename Vec::value_type;
+    const auto b = gko::initialize<Vec>(
+        {T{1.0, 2.0}, T{3.0, 6.0}, T{6.0, 12.0}}, this->exec);
+    auto x = Vec::create(this->exec, gko::dim<2>{3, 1});
+    auto preconditioner =
+        ic_prec_type::build().on(this->exec)->generate(this->mtx);
+
+    preconditioner->apply(b.get(), x.get());
+
+    GKO_ASSERT_MTX_NEAR(x, l({T{3.0, 6.0}, T{-2.0, -4.0}, T{4.0, 8.0}}),
+                        this->tol);
+}
+
+
+TYPED_TEST(Ic, SolvesSingleRhsComplexMixed)
+{
+    using ic_prec_type = typename TestFixture::ic_prec_type;
+    using Vec = gko::matrix::Dense<
+        gko::next_precision<gko::to_complex<typename TestFixture::value_type>>>;
+    using T = typename Vec::value_type;
+    const auto b = gko::initialize<Vec>(
+        {T{1.0, 2.0}, T{3.0, 6.0}, T{6.0, 12.0}}, this->exec);
+    auto x = Vec::create(this->exec, gko::dim<2>{3, 1});
+    auto preconditioner =
+        ic_prec_type::build().on(this->exec)->generate(this->mtx);
+
+    preconditioner->apply(b.get(), x.get());
+
+    GKO_ASSERT_MTX_NEAR(x, l({T{3.0, 6.0}, T{-2.0, -4.0}, T{4.0, 8.0}}),
+                        this->tol);
+}
+
+
+TYPED_TEST(Ic, AdvancedSolvesSingleRhs)
+{
+    using ic_prec_type = typename TestFixture::ic_prec_type;
+    using Vec = typename TestFixture::Vec;
+    const auto b = gko::initialize<Vec>({1.0, 3.0, 6.0}, this->exec);
+    const auto alpha = gko::initialize<Vec>({2.0}, this->exec);
+    const auto beta = gko::initialize<Vec>({-1.0}, this->exec);
+    auto x = gko::initialize<Vec>({1.0, 2.0, 3.0}, this->exec);
+    auto preconditioner =
+        ic_prec_type::build().on(this->exec)->generate(this->mtx);
+
+    preconditioner->apply(alpha.get(), b.get(), beta.get(), x.get());
+
+    GKO_ASSERT_MTX_NEAR(x, l({5.0, -6.0, 5.0}), this->tol);
+}
+
+
+TYPED_TEST(Ic, AdvancedSolvesSingleRhsMixed)
+{
+    using ic_prec_type = typename TestFixture::ic_prec_type;
+    using T = typename TestFixture::value_type;
+    using Vec = gko::matrix::Dense<gko::next_precision<T>>;
+    const auto b = gko::initialize<Vec>({1.0, 3.0, 6.0}, this->exec);
+    const auto alpha = gko::initialize<Vec>({2.0}, this->exec);
+    const auto beta = gko::initialize<Vec>({-1.0}, this->exec);
+    auto x = gko::initialize<Vec>({1.0, 2.0, 3.0}, this->exec);
+    auto preconditioner =
+        ic_prec_type::build().on(this->exec)->generate(this->mtx);
+
+    preconditioner->apply(alpha.get(), b.get(), beta.get(), x.get());
+
+    GKO_ASSERT_MTX_NEAR(x, l({5.0, -6.0, 5.0}), this->tol);
+}
+
+
+TYPED_TEST(Ic, AdvancedSolvesSingleRhsComplex)
+{
+    using ic_prec_type = typename TestFixture::ic_prec_type;
+    using Dense = typename TestFixture::Vec;
+    using DenseComplex = gko::to_complex<Dense>;
+    using T = typename DenseComplex::value_type;
+    const auto b = gko::initialize<DenseComplex>(
+        {T{1.0, 2.0}, T{3.0, 6.0}, T{6.0, 12.0}}, this->exec);
+    const auto alpha = gko::initialize<Dense>({2.0}, this->exec);
+    const auto beta = gko::initialize<Dense>({-1.0}, this->exec);
+    auto x = gko::initialize<DenseComplex>(
+        {T{1.0, 2.0}, T{2.0, 4.0}, T{3.0, 6.0}}, this->exec);
+    auto preconditioner =
+        ic_prec_type::build().on(this->exec)->generate(this->mtx);
+
+    preconditioner->apply(alpha.get(), b.get(), beta.get(), x.get());
+
+    GKO_ASSERT_MTX_NEAR(x, l({T{5.0, 10.0}, T{-6.0, -12.0}, T{5.0, 10.0}}),
+                        this->tol);
+}
+
+
+TYPED_TEST(Ic, AdvancedSolvesSingleRhsComplexMixed)
+{
+    using ic_prec_type = typename TestFixture::ic_prec_type;
+    using MixedDense = gko::matrix::Dense<
+        gko::next_precision<typename TestFixture::value_type>>;
+    using MixedDenseComplex = gko::to_complex<MixedDense>;
+    using T = typename MixedDenseComplex::value_type;
+    const auto b = gko::initialize<MixedDenseComplex>(
+        {T{1.0, 2.0}, T{3.0, 6.0}, T{6.0, 12.0}}, this->exec);
+    const auto alpha = gko::initialize<MixedDense>({2.0}, this->exec);
+    const auto beta = gko::initialize<MixedDense>({-1.0}, this->exec);
+    auto x = gko::initialize<MixedDenseComplex>(
+        {T{1.0, 2.0}, T{2.0, 4.0}, T{3.0, 6.0}}, this->exec);
+    auto preconditioner =
+        ic_prec_type::build().on(this->exec)->generate(this->mtx);
+
+    preconditioner->apply(alpha.get(), b.get(), beta.get(), x.get());
+
+    GKO_ASSERT_MTX_NEAR(x, l({T{5.0, 10.0}, T{-6.0, -12.0}, T{5.0, 10.0}}),
+                        this->tol);
+}
+
+
 TYPED_TEST(Ic, SolvesMultipleRhs)
 {
     using ic_prec_type = typename TestFixture::ic_prec_type;

--- a/reference/test/solver/bicg_kernels.cpp
+++ b/reference/test/solver/bicg_kernels.cpp
@@ -131,6 +131,64 @@ TYPED_TEST(Bicg, SolvesStencilSystem)
 }
 
 
+TYPED_TEST(Bicg, SolvesStencilSystemMixed)
+{
+    using value_type = gko::next_precision<typename TestFixture::value_type>;
+    using Mtx = gko::matrix::Dense<value_type>;
+    auto solver = this->bicg_factory->generate(this->mtx);
+    auto b = gko::initialize<Mtx>({-1.0, 3.0, 1.0}, this->exec);
+    auto x = gko::initialize<Mtx>({0.0, 0.0, 0.0}, this->exec);
+
+    solver->apply(b.get(), x.get());
+
+    GKO_ASSERT_MTX_NEAR(x, l({1.0, 3.0, 2.0}),
+                        (r_mixed<value_type, TypeParam>()));
+}
+
+
+TYPED_TEST(Bicg, SolvesStencilSystemComplex)
+{
+    using Mtx = gko::to_complex<typename TestFixture::Mtx>;
+    using value_type = typename Mtx::value_type;
+    auto solver = this->bicg_factory->generate(this->mtx);
+    auto b = gko::initialize<Mtx>(
+        {value_type{-1.0, 2.0}, value_type{3.0, -6.0}, value_type{1.0, -2.0}},
+        this->exec);
+    auto x = gko::initialize<Mtx>(
+        {value_type{0.0, 0.0}, value_type{0.0, 0.0}, value_type{0.0, 0.0}},
+        this->exec);
+
+    solver->apply(b.get(), x.get());
+
+    GKO_ASSERT_MTX_NEAR(x,
+                        l({value_type{1.0, -2.0}, value_type{3.0, -6.0},
+                           value_type{2.0, -4.0}}),
+                        r<value_type>::value);
+}
+
+
+TYPED_TEST(Bicg, SolvesStencilSystemMixedComplex)
+{
+    using value_type =
+        gko::to_complex<gko::next_precision<typename TestFixture::value_type>>;
+    using Mtx = gko::matrix::Dense<value_type>;
+    auto solver = this->bicg_factory->generate(this->mtx);
+    auto b = gko::initialize<Mtx>(
+        {value_type{-1.0, 2.0}, value_type{3.0, -6.0}, value_type{1.0, -2.0}},
+        this->exec);
+    auto x = gko::initialize<Mtx>(
+        {value_type{0.0, 0.0}, value_type{0.0, 0.0}, value_type{0.0, 0.0}},
+        this->exec);
+
+    solver->apply(b.get(), x.get());
+
+    GKO_ASSERT_MTX_NEAR(x,
+                        l({value_type{1.0, -2.0}, value_type{3.0, -6.0},
+                           value_type{2.0, -4.0}}),
+                        (r_mixed<value_type, TypeParam>()));
+}
+
+
 TYPED_TEST(Bicg, SolvesMultipleStencilSystems)
 {
     using Mtx = typename TestFixture::Mtx;
@@ -162,6 +220,72 @@ TYPED_TEST(Bicg, SolvesStencilSystemUsingAdvancedApply)
     solver->apply(alpha.get(), b.get(), beta.get(), x.get());
 
     GKO_ASSERT_MTX_NEAR(x, l({1.5, 5.0, 2.0}), r<value_type>::value);
+}
+
+
+TYPED_TEST(Bicg, SolvesStencilSystemUsingAdvancedApplyMixed)
+{
+    using value_type = gko::next_precision<typename TestFixture::value_type>;
+    using Mtx = gko::matrix::Dense<value_type>;
+    auto solver = this->bicg_factory->generate(this->mtx);
+    auto alpha = gko::initialize<Mtx>({2.0}, this->exec);
+    auto beta = gko::initialize<Mtx>({-1.0}, this->exec);
+    auto b = gko::initialize<Mtx>({-1.0, 3.0, 1.0}, this->exec);
+    auto x = gko::initialize<Mtx>({0.5, 1.0, 2.0}, this->exec);
+
+    solver->apply(alpha.get(), b.get(), beta.get(), x.get());
+
+    GKO_ASSERT_MTX_NEAR(x, l({1.5, 5.0, 2.0}),
+                        (r_mixed<value_type, TypeParam>()));
+}
+
+
+TYPED_TEST(Bicg, SolvesStencilSystemUsingAdvancedApplyComplex)
+{
+    using Scalar = typename TestFixture::Mtx;
+    using Mtx = gko::to_complex<typename TestFixture::Mtx>;
+    using value_type = typename Mtx::value_type;
+    auto solver = this->bicg_factory->generate(this->mtx);
+    auto alpha = gko::initialize<Scalar>({2.0}, this->exec);
+    auto beta = gko::initialize<Scalar>({-1.0}, this->exec);
+    auto b = gko::initialize<Mtx>(
+        {value_type{-1.0, 2.0}, value_type{3.0, -6.0}, value_type{1.0, -2.0}},
+        this->exec);
+    auto x = gko::initialize<Mtx>(
+        {value_type{0.5, -1.0}, value_type{1.0, -2.0}, value_type{2.0, -4.0}},
+        this->exec);
+
+    solver->apply(alpha.get(), b.get(), beta.get(), x.get());
+
+    GKO_ASSERT_MTX_NEAR(x,
+                        l({value_type{1.5, -3.0}, value_type{5.0, -10.0},
+                           value_type{2.0, -4.0}}),
+                        r<value_type>::value);
+}
+
+
+TYPED_TEST(Bicg, SolvesStencilSystemUsingAdvancedApplyMixedComplex)
+{
+    using Scalar = gko::matrix::Dense<
+        gko::next_precision<typename TestFixture::value_type>>;
+    using Mtx = gko::to_complex<typename TestFixture::Mtx>;
+    using value_type = typename Mtx::value_type;
+    auto solver = this->bicg_factory->generate(this->mtx);
+    auto alpha = gko::initialize<Scalar>({2.0}, this->exec);
+    auto beta = gko::initialize<Scalar>({-1.0}, this->exec);
+    auto b = gko::initialize<Mtx>(
+        {value_type{-1.0, 2.0}, value_type{3.0, -6.0}, value_type{1.0, -2.0}},
+        this->exec);
+    auto x = gko::initialize<Mtx>(
+        {value_type{0.5, -1.0}, value_type{1.0, -2.0}, value_type{2.0, -4.0}},
+        this->exec);
+
+    solver->apply(alpha.get(), b.get(), beta.get(), x.get());
+
+    GKO_ASSERT_MTX_NEAR(x,
+                        l({value_type{1.5, -3.0}, value_type{5.0, -10.0},
+                           value_type{2.0, -4.0}}),
+                        (r_mixed<value_type, TypeParam>()));
 }
 
 
@@ -326,8 +450,8 @@ TYPED_TEST(Bicg, SolvesMultipleDenseSystemForDivergenceCheck)
     ASSERT_LE(normC1 / normB1, normS1 / normB1 + r<value_type>::value);
     ASSERT_LE(normC2 / normB2, normS2 / normB2 + r<value_type>::value);
 
-    // Not sure if this is necessary, the assertions above should cover what is
-    // needed.
+    // Not sure if this is necessary, the assertions above should cover what
+    // is needed.
     GKO_ASSERT_MTX_NEAR(xc, mergedRes, r<value_type>::value);
 }
 

--- a/reference/test/solver/bicgstab_kernels.cpp
+++ b/reference/test/solver/bicgstab_kernels.cpp
@@ -112,14 +112,71 @@ TYPED_TEST(Bicgstab, SolvesDenseSystem)
 {
     using Mtx = typename TestFixture::Mtx;
     using value_type = typename TestFixture::value_type;
-    auto half_tol = std::sqrt(r<value_type>::value);
     auto solver = this->bicgstab_factory->generate(this->mtx);
     auto b = gko::initialize<Mtx>({-1.0, 3.0, 1.0}, this->exec);
     auto x = gko::initialize<Mtx>({0.0, 0.0, 0.0}, this->exec);
 
     solver->apply(b.get(), x.get());
 
-    GKO_ASSERT_MTX_NEAR(x, l({-4.0, -1.0, 4.0}), half_tol);
+    GKO_ASSERT_MTX_NEAR(x, l({-4.0, -1.0, 4.0}), r<value_type>::value);
+}
+
+
+TYPED_TEST(Bicgstab, SolvesDenseSystemMixed)
+{
+    using value_type = gko::next_precision<typename TestFixture::value_type>;
+    using Mtx = gko::matrix::Dense<value_type>;
+    auto solver = this->bicgstab_factory->generate(this->mtx);
+    auto b = gko::initialize<Mtx>({-1.0, 3.0, 1.0}, this->exec);
+    auto x = gko::initialize<Mtx>({0.0, 0.0, 0.0}, this->exec);
+
+    solver->apply(b.get(), x.get());
+
+    GKO_ASSERT_MTX_NEAR(x, l({-4.0, -1.0, 4.0}),
+                        (r_mixed<value_type, TypeParam>()));
+}
+
+
+TYPED_TEST(Bicgstab, SolvesDenseSystemComplex)
+{
+    using Mtx = gko::to_complex<typename TestFixture::Mtx>;
+    using value_type = typename Mtx::value_type;
+    auto solver = this->bicgstab_factory->generate(this->mtx);
+    auto b = gko::initialize<Mtx>(
+        {value_type{-1.0, 2.0}, value_type{3.0, -6.0}, value_type{1.0, -2.0}},
+        this->exec);
+    auto x = gko::initialize<Mtx>(
+        {value_type{0.0, 0.0}, value_type{0.0, 0.0}, value_type{0.0, 0.0}},
+        this->exec);
+
+    solver->apply(b.get(), x.get());
+
+    GKO_ASSERT_MTX_NEAR(x,
+                        l({value_type{-4.0, 8.0}, value_type{-1.0, 2.0},
+                           value_type{4.0, -8.0}}),
+                        r<value_type>::value);
+}
+
+
+TYPED_TEST(Bicgstab, SolvesDenseSystemMixedComplex)
+{
+    using value_type =
+        gko::to_complex<gko::next_precision<typename TestFixture::value_type>>;
+    using Mtx = gko::matrix::Dense<value_type>;
+    auto solver = this->bicgstab_factory->generate(this->mtx);
+    auto b = gko::initialize<Mtx>(
+        {value_type{-1.0, 2.0}, value_type{3.0, -6.0}, value_type{1.0, -2.0}},
+        this->exec);
+    auto x = gko::initialize<Mtx>(
+        {value_type{0.0, 0.0}, value_type{0.0, 0.0}, value_type{0.0, 0.0}},
+        this->exec);
+
+    solver->apply(b.get(), x.get());
+
+    GKO_ASSERT_MTX_NEAR(x,
+                        l({value_type{-4.0, 8.0}, value_type{-1.0, 2.0},
+                           value_type{4.0, -8.0}}),
+                        (r_mixed<value_type, TypeParam>()));
 }
 
 
@@ -165,7 +222,6 @@ TYPED_TEST(Bicgstab, SolvesDenseSystemUsingAdvancedApply)
 {
     using Mtx = typename TestFixture::Mtx;
     using value_type = typename TestFixture::value_type;
-    auto half_tol = std::sqrt(r<value_type>::value);
     auto solver = this->bicgstab_factory->generate(this->mtx);
     auto alpha = gko::initialize<Mtx>({2.0}, this->exec);
     auto beta = gko::initialize<Mtx>({-1.0}, this->exec);
@@ -174,8 +230,73 @@ TYPED_TEST(Bicgstab, SolvesDenseSystemUsingAdvancedApply)
 
     solver->apply(alpha.get(), b.get(), beta.get(), x.get());
 
+    GKO_ASSERT_MTX_NEAR(x, l({-8.5, -3.0, 6.0}), r<value_type>::value);
+}
 
-    GKO_ASSERT_MTX_NEAR(x, l({-8.5, -3.0, 6.0}), half_tol);
+
+TYPED_TEST(Bicgstab, SolvesDenseSystemUsingAdvancedApplyMixed)
+{
+    using value_type = gko::next_precision<typename TestFixture::value_type>;
+    using Mtx = gko::matrix::Dense<value_type>;
+    auto solver = this->bicgstab_factory->generate(this->mtx);
+    auto alpha = gko::initialize<Mtx>({2.0}, this->exec);
+    auto beta = gko::initialize<Mtx>({-1.0}, this->exec);
+    auto b = gko::initialize<Mtx>({-1.0, 3.0, 1.0}, this->exec);
+    auto x = gko::initialize<Mtx>({0.5, 1.0, 2.0}, this->exec);
+
+    solver->apply(alpha.get(), b.get(), beta.get(), x.get());
+
+    GKO_ASSERT_MTX_NEAR(x, l({-8.5, -3.0, 6.0}),
+                        (r_mixed<value_type, TypeParam>()));
+}
+
+
+TYPED_TEST(Bicgstab, SolvesDenseSystemUsingAdvancedApplyComplex)
+{
+    using Scalar = typename TestFixture::Mtx;
+    using Mtx = gko::to_complex<typename TestFixture::Mtx>;
+    using value_type = typename Mtx::value_type;
+    auto solver = this->bicgstab_factory->generate(this->mtx);
+    auto alpha = gko::initialize<Scalar>({2.0}, this->exec);
+    auto beta = gko::initialize<Scalar>({-1.0}, this->exec);
+    auto b = gko::initialize<Mtx>(
+        {value_type{-1.0, 2.0}, value_type{3.0, -6.0}, value_type{1.0, -2.0}},
+        this->exec);
+    auto x = gko::initialize<Mtx>(
+        {value_type{0.5, -1.0}, value_type{1.0, -2.0}, value_type{2.0, -4.0}},
+        this->exec);
+
+    solver->apply(alpha.get(), b.get(), beta.get(), x.get());
+
+    GKO_ASSERT_MTX_NEAR(x,
+                        l({value_type{-8.5, 17.0}, value_type{-3.0, 6.0},
+                           value_type{6.0, -12.0}}),
+                        r<value_type>::value);
+}
+
+
+TYPED_TEST(Bicgstab, SolvesDenseSystemUsingAdvancedApplyMixedComplex)
+{
+    using Scalar = gko::matrix::Dense<
+        gko::next_precision<typename TestFixture::value_type>>;
+    using Mtx = gko::to_complex<typename TestFixture::Mtx>;
+    using value_type = typename Mtx::value_type;
+    auto solver = this->bicgstab_factory->generate(this->mtx);
+    auto alpha = gko::initialize<Scalar>({2.0}, this->exec);
+    auto beta = gko::initialize<Scalar>({-1.0}, this->exec);
+    auto b = gko::initialize<Mtx>(
+        {value_type{-1.0, 2.0}, value_type{3.0, -6.0}, value_type{1.0, -2.0}},
+        this->exec);
+    auto x = gko::initialize<Mtx>(
+        {value_type{0.5, -1.0}, value_type{1.0, -2.0}, value_type{2.0, -4.0}},
+        this->exec);
+
+    solver->apply(alpha.get(), b.get(), beta.get(), x.get());
+
+    GKO_ASSERT_MTX_NEAR(x,
+                        l({value_type{-8.5, 17.0}, value_type{-3.0, 6.0},
+                           value_type{6.0, -12.0}}),
+                        (r_mixed<value_type, TypeParam>()));
 }
 
 
@@ -194,7 +315,6 @@ TYPED_TEST(Bicgstab, SolvesMultipleDenseSystemsUsingAdvancedApply)
         {I<T>{0.5, 1.0}, I<T>{1.0, 2.0}, I<T>{2.0, 3.0}}, this->exec);
 
     solver->apply(alpha.get(), b.get(), beta.get(), x.get());
-
 
     GKO_ASSERT_MTX_NEAR(x, l({{-8.5, 1.0}, {-3.0, 2.0}, {6.0, -5.0}}),
                         half_tol);

--- a/reference/test/solver/cb_gmres_kernels.cpp
+++ b/reference/test/solver/cb_gmres_kernels.cpp
@@ -199,6 +199,68 @@ TYPED_TEST(CbGmres, SolvesStencilSystem)
 }
 
 
+TYPED_TEST(CbGmres, SolvesStencilSystemMixed)
+{
+    using value_type = gko::next_precision<typename TestFixture::value_type>;
+    using Mtx = gko::matrix::Dense<value_type>;
+    auto solver = this->cb_gmres_factory->generate(this->mtx);
+    auto b = gko::initialize<Mtx>({13.0, 7.0, 1.0}, this->exec);
+    auto x = gko::initialize<Mtx>({0.0, 0.0, 0.0}, this->exec);
+
+    solver->apply(b.get(), x.get());
+
+    GKO_ASSERT_MTX_NEAR(
+        x, l({1.0, 3.0, 2.0}),
+        std::max<double>(this->assert_precision(), r<value_type>::value));
+}
+
+
+TYPED_TEST(CbGmres, SolvesStencilSystemComplex)
+{
+    using Mtx = gko::to_complex<typename TestFixture::Mtx>;
+    using value_type = typename Mtx::value_type;
+    auto solver = this->cb_gmres_factory->generate(this->mtx);
+    auto b =
+        gko::initialize<Mtx>({value_type{13.0, -26.0}, value_type{7.0, -14.0},
+                              value_type{1.0, -2.0}},
+                             this->exec);
+    auto x = gko::initialize<Mtx>(
+        {value_type{0.0, 0.0}, value_type{0.0, 0.0}, value_type{0.0, 0.0}},
+        this->exec);
+
+    solver->apply(b.get(), x.get());
+
+    GKO_ASSERT_MTX_NEAR(x,
+                        l({value_type{1.0, -2.0}, value_type{3.0, -6.0},
+                           value_type{2.0, -4.0}}),
+                        this->assert_precision());
+}
+
+
+TYPED_TEST(CbGmres, SolvesStencilSystemMixedComplex)
+{
+    using value_type =
+        gko::to_complex<gko::next_precision<typename TestFixture::value_type>>;
+    using Mtx = gko::matrix::Dense<value_type>;
+    auto solver = this->cb_gmres_factory->generate(this->mtx);
+    auto b =
+        gko::initialize<Mtx>({value_type{13.0, -26.0}, value_type{7.0, -14.0},
+                              value_type{1.0, -2.0}},
+                             this->exec);
+    auto x = gko::initialize<Mtx>(
+        {value_type{0.0, 0.0}, value_type{0.0, 0.0}, value_type{0.0, 0.0}},
+        this->exec);
+
+    solver->apply(b.get(), x.get());
+
+    GKO_ASSERT_MTX_NEAR(
+        x,
+        l({value_type{1.0, -2.0}, value_type{3.0, -6.0},
+           value_type{2.0, -4.0}}),
+        std::max<double>(this->assert_precision(), r<value_type>::value));
+}
+
+
 TYPED_TEST(CbGmres, SolvesStencilSystem2)
 {
     using Mtx = typename TestFixture::Mtx;
@@ -257,6 +319,76 @@ TYPED_TEST(CbGmres, SolvesStencilSystemUsingAdvancedApply)
     solver->apply(alpha.get(), b.get(), beta.get(), x.get());
 
     GKO_ASSERT_MTX_NEAR(x, l({1.5, 5.0, 2.0}), this->assert_precision());
+}
+
+
+TYPED_TEST(CbGmres, SolvesStencilSystemUsingAdvancedApplyMixed)
+{
+    using value_type = gko::next_precision<typename TestFixture::value_type>;
+    using Mtx = gko::matrix::Dense<value_type>;
+    auto solver = this->cb_gmres_factory->generate(this->mtx);
+    auto alpha = gko::initialize<Mtx>({2.0}, this->exec);
+    auto beta = gko::initialize<Mtx>({-1.0}, this->exec);
+    auto b = gko::initialize<Mtx>({13.0, 7.0, 1.0}, this->exec);
+    auto x = gko::initialize<Mtx>({0.5, 1.0, 2.0}, this->exec);
+
+    solver->apply(alpha.get(), b.get(), beta.get(), x.get());
+
+    GKO_ASSERT_MTX_NEAR(
+        x, l({1.5, 5.0, 2.0}),
+        std::max<double>(this->assert_precision(), r<value_type>::value));
+}
+
+
+TYPED_TEST(CbGmres, SolvesStencilSystemUsingAdvancedApplyComplex)
+{
+    using Scalar = typename TestFixture::Mtx;
+    using Mtx = gko::to_complex<typename TestFixture::Mtx>;
+    using value_type = typename Mtx::value_type;
+    auto solver = this->cb_gmres_factory->generate(this->mtx);
+    auto alpha = gko::initialize<Scalar>({2.0}, this->exec);
+    auto beta = gko::initialize<Scalar>({-1.0}, this->exec);
+    auto b =
+        gko::initialize<Mtx>({value_type{13.0, -26.0}, value_type{7.0, -14.0},
+                              value_type{1.0, -2.0}},
+                             this->exec);
+    auto x = gko::initialize<Mtx>(
+        {value_type{0.5, -1.0}, value_type{1.0, -2.0}, value_type{2.0, -4.0}},
+        this->exec);
+
+    solver->apply(alpha.get(), b.get(), beta.get(), x.get());
+
+    GKO_ASSERT_MTX_NEAR(x,
+                        l({value_type{1.5, -3.0}, value_type{5.0, -10.0},
+                           value_type{2.0, -4.0}}),
+                        this->assert_precision());
+}
+
+
+TYPED_TEST(CbGmres, SolvesStencilSystemUsingAdvancedApplyMixedComplex)
+{
+    using Scalar = gko::matrix::Dense<
+        gko::next_precision<typename TestFixture::value_type>>;
+    using Mtx = gko::to_complex<typename TestFixture::Mtx>;
+    using value_type = typename Mtx::value_type;
+    auto solver = this->cb_gmres_factory->generate(this->mtx);
+    auto alpha = gko::initialize<Scalar>({2.0}, this->exec);
+    auto beta = gko::initialize<Scalar>({-1.0}, this->exec);
+    auto b =
+        gko::initialize<Mtx>({value_type{13.0, -26.0}, value_type{7.0, -14.0},
+                              value_type{1.0, -2.0}},
+                             this->exec);
+    auto x = gko::initialize<Mtx>(
+        {value_type{0.5, -1.0}, value_type{1.0, -2.0}, value_type{2.0, -4.0}},
+        this->exec);
+
+    solver->apply(alpha.get(), b.get(), beta.get(), x.get());
+
+    GKO_ASSERT_MTX_NEAR(
+        x,
+        l({value_type{1.5, -3.0}, value_type{5.0, -10.0},
+           value_type{2.0, -4.0}}),
+        std::max<double>(this->assert_precision(), r<value_type>::value));
 }
 
 
@@ -390,8 +522,8 @@ TYPED_TEST(CbGmres, SolvesMultipleDenseSystemForDivergenceCheck)
     ASSERT_LE(normC1 / normB1, normS1 / normB1 + this->assert_precision());
     ASSERT_LE(normC2 / normB2, normS2 / normB2 + this->assert_precision());
 
-    // Not sure if this is necessary, the assertions above should cover what is
-    // needed.
+    // Not sure if this is necessary, the assertions above should cover what
+    // is needed.
     GKO_ASSERT_MTX_NEAR(xc, mergedRes, this->assert_precision());
 }
 

--- a/reference/test/solver/cg_kernels.cpp
+++ b/reference/test/solver/cg_kernels.cpp
@@ -126,6 +126,64 @@ TYPED_TEST(Cg, SolvesStencilSystem)
 }
 
 
+TYPED_TEST(Cg, SolvesStencilSystemMixed)
+{
+    using value_type = gko::next_precision<typename TestFixture::value_type>;
+    using Mtx = gko::matrix::Dense<value_type>;
+    auto solver = this->cg_factory->generate(this->mtx);
+    auto b = gko::initialize<Mtx>({-1.0, 3.0, 1.0}, this->exec);
+    auto x = gko::initialize<Mtx>({0.0, 0.0, 0.0}, this->exec);
+
+    solver->apply(b.get(), x.get());
+
+    GKO_ASSERT_MTX_NEAR(x, l({1.0, 3.0, 2.0}),
+                        (r_mixed<value_type, TypeParam>()));
+}
+
+
+TYPED_TEST(Cg, SolvesStencilSystemComplex)
+{
+    using Mtx = gko::to_complex<typename TestFixture::Mtx>;
+    using value_type = typename Mtx::value_type;
+    auto solver = this->cg_factory->generate(this->mtx);
+    auto b = gko::initialize<Mtx>(
+        {value_type{-1.0, 2.0}, value_type{3.0, -6.0}, value_type{1.0, -2.0}},
+        this->exec);
+    auto x = gko::initialize<Mtx>(
+        {value_type{0.0, 0.0}, value_type{0.0, 0.0}, value_type{0.0, 0.0}},
+        this->exec);
+
+    solver->apply(b.get(), x.get());
+
+    GKO_ASSERT_MTX_NEAR(x,
+                        l({value_type{1.0, -2.0}, value_type{3.0, -6.0},
+                           value_type{2.0, -4.0}}),
+                        r<value_type>::value);
+}
+
+
+TYPED_TEST(Cg, SolvesStencilSystemMixedComplex)
+{
+    using value_type =
+        gko::to_complex<gko::next_precision<typename TestFixture::value_type>>;
+    using Mtx = gko::matrix::Dense<value_type>;
+    auto solver = this->cg_factory->generate(this->mtx);
+    auto b = gko::initialize<Mtx>(
+        {value_type{-1.0, 2.0}, value_type{3.0, -6.0}, value_type{1.0, -2.0}},
+        this->exec);
+    auto x = gko::initialize<Mtx>(
+        {value_type{0.0, 0.0}, value_type{0.0, 0.0}, value_type{0.0, 0.0}},
+        this->exec);
+
+    solver->apply(b.get(), x.get());
+
+    GKO_ASSERT_MTX_NEAR(x,
+                        l({value_type{1.0, -2.0}, value_type{3.0, -6.0},
+                           value_type{2.0, -4.0}}),
+                        (r_mixed<value_type, TypeParam>()));
+}
+
+
 TYPED_TEST(Cg, SolvesMultipleStencilSystems)
 {
     using Mtx = typename TestFixture::Mtx;
@@ -157,6 +215,72 @@ TYPED_TEST(Cg, SolvesStencilSystemUsingAdvancedApply)
     solver->apply(alpha.get(), b.get(), beta.get(), x.get());
 
     GKO_ASSERT_MTX_NEAR(x, l({1.5, 5.0, 2.0}), r<value_type>::value);
+}
+
+
+TYPED_TEST(Cg, SolvesStencilSystemUsingAdvancedApplyMixed)
+{
+    using value_type = gko::next_precision<typename TestFixture::value_type>;
+    using Mtx = gko::matrix::Dense<value_type>;
+    auto solver = this->cg_factory->generate(this->mtx);
+    auto alpha = gko::initialize<Mtx>({2.0}, this->exec);
+    auto beta = gko::initialize<Mtx>({-1.0}, this->exec);
+    auto b = gko::initialize<Mtx>({-1.0, 3.0, 1.0}, this->exec);
+    auto x = gko::initialize<Mtx>({0.5, 1.0, 2.0}, this->exec);
+
+    solver->apply(alpha.get(), b.get(), beta.get(), x.get());
+
+    GKO_ASSERT_MTX_NEAR(x, l({1.5, 5.0, 2.0}),
+                        (r_mixed<value_type, TypeParam>()));
+}
+
+
+TYPED_TEST(Cg, SolvesStencilSystemUsingAdvancedApplyComplex)
+{
+    using Scalar = typename TestFixture::Mtx;
+    using Mtx = gko::to_complex<typename TestFixture::Mtx>;
+    using value_type = typename Mtx::value_type;
+    auto solver = this->cg_factory->generate(this->mtx);
+    auto alpha = gko::initialize<Scalar>({2.0}, this->exec);
+    auto beta = gko::initialize<Scalar>({-1.0}, this->exec);
+    auto b = gko::initialize<Mtx>(
+        {value_type{-1.0, 2.0}, value_type{3.0, -6.0}, value_type{1.0, -2.0}},
+        this->exec);
+    auto x = gko::initialize<Mtx>(
+        {value_type{0.5, -1.0}, value_type{1.0, -2.0}, value_type{2.0, -4.0}},
+        this->exec);
+
+    solver->apply(alpha.get(), b.get(), beta.get(), x.get());
+
+    GKO_ASSERT_MTX_NEAR(x,
+                        l({value_type{1.5, -3.0}, value_type{5.0, -10.0},
+                           value_type{2.0, -4.0}}),
+                        r<value_type>::value);
+}
+
+
+TYPED_TEST(Cg, SolvesStencilSystemUsingAdvancedApplyMixedComplex)
+{
+    using Scalar = gko::matrix::Dense<
+        gko::next_precision<typename TestFixture::value_type>>;
+    using Mtx = gko::to_complex<typename TestFixture::Mtx>;
+    using value_type = typename Mtx::value_type;
+    auto solver = this->cg_factory->generate(this->mtx);
+    auto alpha = gko::initialize<Scalar>({2.0}, this->exec);
+    auto beta = gko::initialize<Scalar>({-1.0}, this->exec);
+    auto b = gko::initialize<Mtx>(
+        {value_type{-1.0, 2.0}, value_type{3.0, -6.0}, value_type{1.0, -2.0}},
+        this->exec);
+    auto x = gko::initialize<Mtx>(
+        {value_type{0.5, -1.0}, value_type{1.0, -2.0}, value_type{2.0, -4.0}},
+        this->exec);
+
+    solver->apply(alpha.get(), b.get(), beta.get(), x.get());
+
+    GKO_ASSERT_MTX_NEAR(x,
+                        l({value_type{1.5, -3.0}, value_type{5.0, -10.0},
+                           value_type{2.0, -4.0}}),
+                        (r_mixed<value_type, TypeParam>()));
 }
 
 

--- a/reference/test/solver/fcg_kernels.cpp
+++ b/reference/test/solver/fcg_kernels.cpp
@@ -126,6 +126,64 @@ TYPED_TEST(Fcg, SolvesStencilSystem)
 }
 
 
+TYPED_TEST(Fcg, SolvesStencilSystemMixed)
+{
+    using value_type = gko::next_precision<typename TestFixture::value_type>;
+    using Mtx = gko::matrix::Dense<value_type>;
+    auto solver = this->fcg_factory->generate(this->mtx);
+    auto b = gko::initialize<Mtx>({-1.0, 3.0, 1.0}, this->exec);
+    auto x = gko::initialize<Mtx>({0.0, 0.0, 0.0}, this->exec);
+
+    solver->apply(b.get(), x.get());
+
+    GKO_ASSERT_MTX_NEAR(x, l({1.0, 3.0, 2.0}),
+                        (r_mixed<value_type, TypeParam>()));
+}
+
+
+TYPED_TEST(Fcg, SolvesStencilSystemComplex)
+{
+    using Mtx = gko::to_complex<typename TestFixture::Mtx>;
+    using value_type = typename Mtx::value_type;
+    auto solver = this->fcg_factory->generate(this->mtx);
+    auto b = gko::initialize<Mtx>(
+        {value_type{-1.0, 2.0}, value_type{3.0, -6.0}, value_type{1.0, -2.0}},
+        this->exec);
+    auto x = gko::initialize<Mtx>(
+        {value_type{0.0, 0.0}, value_type{0.0, 0.0}, value_type{0.0, 0.0}},
+        this->exec);
+
+    solver->apply(b.get(), x.get());
+
+    GKO_ASSERT_MTX_NEAR(x,
+                        l({value_type{1.0, -2.0}, value_type{3.0, -6.0},
+                           value_type{2.0, -4.0}}),
+                        r<value_type>::value);
+}
+
+
+TYPED_TEST(Fcg, SolvesStencilSystemMixedComplex)
+{
+    using value_type =
+        gko::to_complex<gko::next_precision<typename TestFixture::value_type>>;
+    using Mtx = gko::matrix::Dense<value_type>;
+    auto solver = this->fcg_factory->generate(this->mtx);
+    auto b = gko::initialize<Mtx>(
+        {value_type{-1.0, 2.0}, value_type{3.0, -6.0}, value_type{1.0, -2.0}},
+        this->exec);
+    auto x = gko::initialize<Mtx>(
+        {value_type{0.0, 0.0}, value_type{0.0, 0.0}, value_type{0.0, 0.0}},
+        this->exec);
+
+    solver->apply(b.get(), x.get());
+
+    GKO_ASSERT_MTX_NEAR(x,
+                        l({value_type{1.0, -2.0}, value_type{3.0, -6.0},
+                           value_type{2.0, -4.0}}),
+                        (r_mixed<value_type, TypeParam>()));
+}
+
+
 TYPED_TEST(Fcg, SolvesMultipleStencilSystems)
 {
     using Mtx = typename TestFixture::Mtx;
@@ -156,7 +214,73 @@ TYPED_TEST(Fcg, SolvesStencilSystemUsingAdvancedApply)
 
     solver->apply(alpha.get(), b.get(), beta.get(), x.get());
 
-    GKO_ASSERT_MTX_NEAR(x, l({1.5, 5.0, 2.0}), r<value_type>::value * 1e1);
+    GKO_ASSERT_MTX_NEAR(x, l({1.5, 5.0, 2.0}), r<value_type>::value);
+}
+
+
+TYPED_TEST(Fcg, SolvesStencilSystemUsingAdvancedApplyMixed)
+{
+    using value_type = gko::next_precision<typename TestFixture::value_type>;
+    using Mtx = gko::matrix::Dense<value_type>;
+    auto solver = this->fcg_factory->generate(this->mtx);
+    auto alpha = gko::initialize<Mtx>({2.0}, this->exec);
+    auto beta = gko::initialize<Mtx>({-1.0}, this->exec);
+    auto b = gko::initialize<Mtx>({-1.0, 3.0, 1.0}, this->exec);
+    auto x = gko::initialize<Mtx>({0.5, 1.0, 2.0}, this->exec);
+
+    solver->apply(alpha.get(), b.get(), beta.get(), x.get());
+
+    GKO_ASSERT_MTX_NEAR(x, l({1.5, 5.0, 2.0}),
+                        (r_mixed<value_type, TypeParam>()));
+}
+
+
+TYPED_TEST(Fcg, SolvesStencilSystemUsingAdvancedApplyComplex)
+{
+    using Scalar = typename TestFixture::Mtx;
+    using Mtx = gko::to_complex<typename TestFixture::Mtx>;
+    using value_type = typename Mtx::value_type;
+    auto solver = this->fcg_factory->generate(this->mtx);
+    auto alpha = gko::initialize<Scalar>({2.0}, this->exec);
+    auto beta = gko::initialize<Scalar>({-1.0}, this->exec);
+    auto b = gko::initialize<Mtx>(
+        {value_type{-1.0, 2.0}, value_type{3.0, -6.0}, value_type{1.0, -2.0}},
+        this->exec);
+    auto x = gko::initialize<Mtx>(
+        {value_type{0.5, -1.0}, value_type{1.0, -2.0}, value_type{2.0, -4.0}},
+        this->exec);
+
+    solver->apply(alpha.get(), b.get(), beta.get(), x.get());
+
+    GKO_ASSERT_MTX_NEAR(x,
+                        l({value_type{1.5, -3.0}, value_type{5.0, -10.0},
+                           value_type{2.0, -4.0}}),
+                        r<value_type>::value);
+}
+
+
+TYPED_TEST(Fcg, SolvesStencilSystemUsingAdvancedApplyMixedComplex)
+{
+    using Scalar = gko::matrix::Dense<
+        gko::next_precision<typename TestFixture::value_type>>;
+    using Mtx = gko::to_complex<typename TestFixture::Mtx>;
+    using value_type = typename Mtx::value_type;
+    auto solver = this->fcg_factory->generate(this->mtx);
+    auto alpha = gko::initialize<Scalar>({2.0}, this->exec);
+    auto beta = gko::initialize<Scalar>({-1.0}, this->exec);
+    auto b = gko::initialize<Mtx>(
+        {value_type{-1.0, 2.0}, value_type{3.0, -6.0}, value_type{1.0, -2.0}},
+        this->exec);
+    auto x = gko::initialize<Mtx>(
+        {value_type{0.5, -1.0}, value_type{1.0, -2.0}, value_type{2.0, -4.0}},
+        this->exec);
+
+    solver->apply(alpha.get(), b.get(), beta.get(), x.get());
+
+    GKO_ASSERT_MTX_NEAR(x,
+                        l({value_type{1.5, -3.0}, value_type{5.0, -10.0},
+                           value_type{2.0, -4.0}}),
+                        (r_mixed<value_type, TypeParam>()));
 }
 
 

--- a/reference/test/solver/gmres_kernels.cpp
+++ b/reference/test/solver/gmres_kernels.cpp
@@ -135,6 +135,66 @@ TYPED_TEST(Gmres, SolvesStencilSystem)
 }
 
 
+TYPED_TEST(Gmres, SolvesStencilSystemMixed)
+{
+    using value_type = gko::next_precision<typename TestFixture::value_type>;
+    using Mtx = gko::matrix::Dense<value_type>;
+    auto solver = this->gmres_factory->generate(this->mtx);
+    auto b = gko::initialize<Mtx>({13.0, 7.0, 1.0}, this->exec);
+    auto x = gko::initialize<Mtx>({0.0, 0.0, 0.0}, this->exec);
+
+    solver->apply(b.get(), x.get());
+
+    GKO_ASSERT_MTX_NEAR(x, l({1.0, 3.0, 2.0}),
+                        (r_mixed<value_type, TypeParam>()));
+}
+
+
+TYPED_TEST(Gmres, SolvesStencilSystemComplex)
+{
+    using Mtx = gko::to_complex<typename TestFixture::Mtx>;
+    using value_type = typename Mtx::value_type;
+    auto solver = this->gmres_factory->generate(this->mtx);
+    auto b =
+        gko::initialize<Mtx>({value_type{13.0, -26.0}, value_type{7.0, -14.0},
+                              value_type{1.0, -2.0}},
+                             this->exec);
+    auto x = gko::initialize<Mtx>(
+        {value_type{0.0, 0.0}, value_type{0.0, 0.0}, value_type{0.0, 0.0}},
+        this->exec);
+
+    solver->apply(b.get(), x.get());
+
+    GKO_ASSERT_MTX_NEAR(x,
+                        l({value_type{1.0, -2.0}, value_type{3.0, -6.0},
+                           value_type{2.0, -4.0}}),
+                        r<value_type>::value * 1e1);
+}
+
+
+TYPED_TEST(Gmres, SolvesStencilSystemMixedComplex)
+{
+    using value_type =
+        gko::to_complex<gko::next_precision<typename TestFixture::value_type>>;
+    using Mtx = gko::matrix::Dense<value_type>;
+    auto solver = this->gmres_factory->generate(this->mtx);
+    auto b =
+        gko::initialize<Mtx>({value_type{13.0, -26.0}, value_type{7.0, -14.0},
+                              value_type{1.0, -2.0}},
+                             this->exec);
+    auto x = gko::initialize<Mtx>(
+        {value_type{0.0, 0.0}, value_type{0.0, 0.0}, value_type{0.0, 0.0}},
+        this->exec);
+
+    solver->apply(b.get(), x.get());
+
+    GKO_ASSERT_MTX_NEAR(x,
+                        l({value_type{1.0, -2.0}, value_type{3.0, -6.0},
+                           value_type{2.0, -4.0}}),
+                        (r_mixed<value_type, TypeParam>()));
+}
+
+
 TYPED_TEST(Gmres, SolvesMultipleStencilSystems)
 {
     using Mtx = typename TestFixture::Mtx;
@@ -166,6 +226,74 @@ TYPED_TEST(Gmres, SolvesStencilSystemUsingAdvancedApply)
     solver->apply(alpha.get(), b.get(), beta.get(), x.get());
 
     GKO_ASSERT_MTX_NEAR(x, l({1.5, 5.0, 2.0}), r<value_type>::value * 1e1);
+}
+
+
+TYPED_TEST(Gmres, SolvesStencilSystemUsingAdvancedApplyMixed)
+{
+    using value_type = gko::next_precision<typename TestFixture::value_type>;
+    using Mtx = gko::matrix::Dense<value_type>;
+    auto solver = this->gmres_factory->generate(this->mtx);
+    auto alpha = gko::initialize<Mtx>({2.0}, this->exec);
+    auto beta = gko::initialize<Mtx>({-1.0}, this->exec);
+    auto b = gko::initialize<Mtx>({13.0, 7.0, 1.0}, this->exec);
+    auto x = gko::initialize<Mtx>({0.5, 1.0, 2.0}, this->exec);
+
+    solver->apply(alpha.get(), b.get(), beta.get(), x.get());
+
+    GKO_ASSERT_MTX_NEAR(x, l({1.5, 5.0, 2.0}),
+                        (r_mixed<value_type, TypeParam>()));
+}
+
+
+TYPED_TEST(Gmres, SolvesStencilSystemUsingAdvancedApplyComplex)
+{
+    using Scalar = typename TestFixture::Mtx;
+    using Mtx = gko::to_complex<typename TestFixture::Mtx>;
+    using value_type = typename Mtx::value_type;
+    auto solver = this->gmres_factory->generate(this->mtx);
+    auto alpha = gko::initialize<Scalar>({2.0}, this->exec);
+    auto beta = gko::initialize<Scalar>({-1.0}, this->exec);
+    auto b =
+        gko::initialize<Mtx>({value_type{13.0, -26.0}, value_type{7.0, -14.0},
+                              value_type{1.0, -2.0}},
+                             this->exec);
+    auto x = gko::initialize<Mtx>(
+        {value_type{0.5, -1.0}, value_type{1.0, -2.0}, value_type{2.0, -4.0}},
+        this->exec);
+
+    solver->apply(alpha.get(), b.get(), beta.get(), x.get());
+
+    GKO_ASSERT_MTX_NEAR(x,
+                        l({value_type{1.5, -3.0}, value_type{5.0, -10.0},
+                           value_type{2.0, -4.0}}),
+                        r<value_type>::value * 1e1);
+}
+
+
+TYPED_TEST(Gmres, SolvesStencilSystemUsingAdvancedApplyMixedComplex)
+{
+    using Scalar = gko::matrix::Dense<
+        gko::next_precision<typename TestFixture::value_type>>;
+    using Mtx = gko::to_complex<typename TestFixture::Mtx>;
+    using value_type = typename Mtx::value_type;
+    auto solver = this->gmres_factory->generate(this->mtx);
+    auto alpha = gko::initialize<Scalar>({2.0}, this->exec);
+    auto beta = gko::initialize<Scalar>({-1.0}, this->exec);
+    auto b =
+        gko::initialize<Mtx>({value_type{13.0, -26.0}, value_type{7.0, -14.0},
+                              value_type{1.0, -2.0}},
+                             this->exec);
+    auto x = gko::initialize<Mtx>(
+        {value_type{0.5, -1.0}, value_type{1.0, -2.0}, value_type{2.0, -4.0}},
+        this->exec);
+
+    solver->apply(alpha.get(), b.get(), beta.get(), x.get());
+
+    GKO_ASSERT_MTX_NEAR(x,
+                        l({value_type{1.5, -3.0}, value_type{5.0, -10.0},
+                           value_type{2.0, -4.0}}),
+                        (r_mixed<value_type, TypeParam>()));
 }
 
 

--- a/reference/test/solver/idr_kernels.cpp
+++ b/reference/test/solver/idr_kernels.cpp
@@ -102,14 +102,71 @@ TYPED_TEST(Idr, SolvesDenseSystem)
 {
     using Mtx = typename TestFixture::Mtx;
     using value_type = typename TestFixture::value_type;
-    auto half_tol = std::sqrt(r<value_type>::value);
     auto solver = this->idr_factory->generate(this->mtx);
     auto b = gko::initialize<Mtx>({-1.0, 3.0, 1.0}, this->exec);
     auto x = gko::initialize<Mtx>({0.0, 0.0, 0.0}, this->exec);
 
     solver->apply(b.get(), x.get());
 
-    GKO_ASSERT_MTX_NEAR(x, l({-4.0, -1.0, 4.0}), half_tol);
+    GKO_ASSERT_MTX_NEAR(x, l({-4.0, -1.0, 4.0}), r<value_type>::value * 1e1);
+}
+
+
+TYPED_TEST(Idr, SolvesDenseSystemMixed)
+{
+    using value_type = gko::next_precision<typename TestFixture::value_type>;
+    using Mtx = gko::matrix::Dense<value_type>;
+    auto solver = this->idr_factory->generate(this->mtx);
+    auto b = gko::initialize<Mtx>({-1.0, 3.0, 1.0}, this->exec);
+    auto x = gko::initialize<Mtx>({0.0, 0.0, 0.0}, this->exec);
+
+    solver->apply(b.get(), x.get());
+
+    GKO_ASSERT_MTX_NEAR(x, l({-4.0, -1.0, 4.0}),
+                        (r_mixed<value_type, TypeParam>()) * 1e1);
+}
+
+
+TYPED_TEST(Idr, SolvesDenseSystemComplex)
+{
+    using Mtx = gko::to_complex<typename TestFixture::Mtx>;
+    using value_type = typename Mtx::value_type;
+    auto solver = this->idr_factory->generate(this->mtx);
+    auto b = gko::initialize<Mtx>(
+        {value_type{-1.0, 2.0}, value_type{3.0, -6.0}, value_type{1.0, -2.0}},
+        this->exec);
+    auto x = gko::initialize<Mtx>(
+        {value_type{0.0, 0.0}, value_type{0.0, 0.0}, value_type{0.0, 0.0}},
+        this->exec);
+
+    solver->apply(b.get(), x.get());
+
+    GKO_ASSERT_MTX_NEAR(x,
+                        l({value_type{-4.0, 8.0}, value_type{-1.0, 2.0},
+                           value_type{4.0, -8.0}}),
+                        r<value_type>::value * 1e1);
+}
+
+
+TYPED_TEST(Idr, SolvesDenseSystemMixedComplex)
+{
+    using value_type =
+        gko::to_complex<gko::next_precision<typename TestFixture::value_type>>;
+    using Mtx = gko::matrix::Dense<value_type>;
+    auto solver = this->idr_factory->generate(this->mtx);
+    auto b = gko::initialize<Mtx>(
+        {value_type{-1.0, 2.0}, value_type{3.0, -6.0}, value_type{1.0, -2.0}},
+        this->exec);
+    auto x = gko::initialize<Mtx>(
+        {value_type{0.0, 0.0}, value_type{0.0, 0.0}, value_type{0.0, 0.0}},
+        this->exec);
+
+    solver->apply(b.get(), x.get());
+
+    GKO_ASSERT_MTX_NEAR(x,
+                        l({value_type{-4.0, 8.0}, value_type{-1.0, 2.0},
+                           value_type{4.0, -8.0}}),
+                        (r_mixed<value_type, TypeParam>()) * 1e1);
 }
 
 
@@ -198,7 +255,6 @@ TYPED_TEST(Idr, SolvesDenseSystemUsingAdvancedApply)
 {
     using Mtx = typename TestFixture::Mtx;
     using value_type = typename TestFixture::value_type;
-    auto half_tol = std::sqrt(r<value_type>::value);
     auto solver = this->idr_factory->generate(this->mtx);
     auto alpha = gko::initialize<Mtx>({2.0}, this->exec);
     auto beta = gko::initialize<Mtx>({-1.0}, this->exec);
@@ -207,7 +263,73 @@ TYPED_TEST(Idr, SolvesDenseSystemUsingAdvancedApply)
 
     solver->apply(alpha.get(), b.get(), beta.get(), x.get());
 
-    GKO_ASSERT_MTX_NEAR(x, l({-8.5, -3.0, 6.0}), half_tol);
+    GKO_ASSERT_MTX_NEAR(x, l({-8.5, -3.0, 6.0}), r<value_type>::value * 1e1);
+}
+
+
+TYPED_TEST(Idr, SolvesDenseSystemUsingAdvancedApplyMixed)
+{
+    using value_type = gko::next_precision<typename TestFixture::value_type>;
+    using Mtx = gko::matrix::Dense<value_type>;
+    auto solver = this->idr_factory->generate(this->mtx);
+    auto alpha = gko::initialize<Mtx>({2.0}, this->exec);
+    auto beta = gko::initialize<Mtx>({-1.0}, this->exec);
+    auto b = gko::initialize<Mtx>({-1.0, 3.0, 1.0}, this->exec);
+    auto x = gko::initialize<Mtx>({0.5, 1.0, 2.0}, this->exec);
+
+    solver->apply(alpha.get(), b.get(), beta.get(), x.get());
+
+    GKO_ASSERT_MTX_NEAR(x, l({-8.5, -3.0, 6.0}),
+                        (r_mixed<value_type, TypeParam>()) * 1e1);
+}
+
+
+TYPED_TEST(Idr, SolvesDenseSystemUsingAdvancedApplyComplex)
+{
+    using Scalar = typename TestFixture::Mtx;
+    using Mtx = gko::to_complex<typename TestFixture::Mtx>;
+    using value_type = typename Mtx::value_type;
+    auto solver = this->idr_factory->generate(this->mtx);
+    auto alpha = gko::initialize<Scalar>({2.0}, this->exec);
+    auto beta = gko::initialize<Scalar>({-1.0}, this->exec);
+    auto b = gko::initialize<Mtx>(
+        {value_type{-1.0, 2.0}, value_type{3.0, -6.0}, value_type{1.0, -2.0}},
+        this->exec);
+    auto x = gko::initialize<Mtx>(
+        {value_type{0.5, -1.0}, value_type{1.0, -2.0}, value_type{2.0, -4.0}},
+        this->exec);
+
+    solver->apply(alpha.get(), b.get(), beta.get(), x.get());
+
+    GKO_ASSERT_MTX_NEAR(x,
+                        l({value_type{-8.5, 17.0}, value_type{-3.0, 6.0},
+                           value_type{6.0, -12.0}}),
+                        r<value_type>::value * 1e1);
+}
+
+
+TYPED_TEST(Idr, SolvesDenseSystemUsingAdvancedApplyMixedComplex)
+{
+    using Scalar = gko::matrix::Dense<
+        gko::next_precision<typename TestFixture::value_type>>;
+    using Mtx = gko::to_complex<typename TestFixture::Mtx>;
+    using value_type = typename Mtx::value_type;
+    auto solver = this->idr_factory->generate(this->mtx);
+    auto alpha = gko::initialize<Scalar>({2.0}, this->exec);
+    auto beta = gko::initialize<Scalar>({-1.0}, this->exec);
+    auto b = gko::initialize<Mtx>(
+        {value_type{-1.0, 2.0}, value_type{3.0, -6.0}, value_type{1.0, -2.0}},
+        this->exec);
+    auto x = gko::initialize<Mtx>(
+        {value_type{0.5, -1.0}, value_type{1.0, -2.0}, value_type{2.0, -4.0}},
+        this->exec);
+
+    solver->apply(alpha.get(), b.get(), beta.get(), x.get());
+
+    GKO_ASSERT_MTX_NEAR(x,
+                        l({value_type{-8.5, 17.0}, value_type{-3.0, 6.0},
+                           value_type{6.0, -12.0}}),
+                        (r_mixed<value_type, TypeParam>()) * 1e1);
 }
 
 

--- a/reference/test/solver/ir_kernels.cpp
+++ b/reference/test/solver/ir_kernels.cpp
@@ -97,6 +97,64 @@ TYPED_TEST(Ir, SolvesTriangularSystem)
 }
 
 
+TYPED_TEST(Ir, SolvesTriangularSystemMixed)
+{
+    using value_type = gko::next_precision<typename TestFixture::value_type>;
+    using Mtx = gko::matrix::Dense<value_type>;
+    auto solver = this->ir_factory->generate(this->mtx);
+    auto b = gko::initialize<Mtx>({3.9, 9.0, 2.2}, this->exec);
+    auto x = gko::initialize<Mtx>({0.0, 0.0, 0.0}, this->exec);
+
+    solver->apply(b.get(), x.get());
+
+    GKO_ASSERT_MTX_NEAR(x, l({1.0, 3.0, 2.0}),
+                        (r_mixed<value_type, TypeParam>()) * 1e1);
+}
+
+
+TYPED_TEST(Ir, SolvesTriangularSystemComplex)
+{
+    using Mtx = gko::to_complex<typename TestFixture::Mtx>;
+    using value_type = typename Mtx::value_type;
+    auto solver = this->ir_factory->generate(this->mtx);
+    auto b = gko::initialize<Mtx>(
+        {value_type{3.9, -7.8}, value_type{9.0, -18.0}, value_type{2.2, -4.4}},
+        this->exec);
+    auto x = gko::initialize<Mtx>(
+        {value_type{0.0, 0.0}, value_type{0.0, 0.0}, value_type{0.0, 0.0}},
+        this->exec);
+
+    solver->apply(b.get(), x.get());
+
+    GKO_ASSERT_MTX_NEAR(x,
+                        l({value_type{1.0, -2.0}, value_type{3.0, -6.0},
+                           value_type{2.0, -4.0}}),
+                        r<value_type>::value * 1e1);
+}
+
+
+TYPED_TEST(Ir, SolvesTriangularSystemMixedComplex)
+{
+    using value_type =
+        gko::to_complex<gko::next_precision<typename TestFixture::value_type>>;
+    using Mtx = gko::matrix::Dense<value_type>;
+    auto solver = this->ir_factory->generate(this->mtx);
+    auto b = gko::initialize<Mtx>(
+        {value_type{3.9, -7.8}, value_type{9.0, -18.0}, value_type{2.2, -4.4}},
+        this->exec);
+    auto x = gko::initialize<Mtx>(
+        {value_type{0.0, 0.0}, value_type{0.0, 0.0}, value_type{0.0, 0.0}},
+        this->exec);
+
+    solver->apply(b.get(), x.get());
+
+    GKO_ASSERT_MTX_NEAR(x,
+                        l({value_type{1.0, -2.0}, value_type{3.0, -6.0},
+                           value_type{2.0, -4.0}}),
+                        (r_mixed<value_type, TypeParam>()) * 1e1);
+}
+
+
 TYPED_TEST(Ir, SolvesTriangularSystemWithIterativeInnerSolver)
 {
     using Mtx = typename TestFixture::Mtx;
@@ -159,6 +217,71 @@ TYPED_TEST(Ir, SolvesTriangularSystemUsingAdvancedApply)
     solver->apply(alpha.get(), b.get(), beta.get(), x.get());
 
     GKO_ASSERT_MTX_NEAR(x, l({1.5, 5.0, 2.0}), r<value_type>::value * 1e1);
+}
+
+
+TYPED_TEST(Ir, SolvesTriangularSystemUsingAdvancedApplyMixed)
+{
+    using Mtx = typename TestFixture::Mtx;
+    using value_type = typename TestFixture::value_type;
+    auto solver = this->ir_factory->generate(this->mtx);
+    auto alpha = gko::initialize<Mtx>({2.0}, this->exec);
+    auto beta = gko::initialize<Mtx>({-1.0}, this->exec);
+    auto b = gko::initialize<Mtx>({3.9, 9.0, 2.2}, this->exec);
+    auto x = gko::initialize<Mtx>({0.5, 1.0, 2.0}, this->exec);
+
+    solver->apply(alpha.get(), b.get(), beta.get(), x.get());
+
+    GKO_ASSERT_MTX_NEAR(x, l({1.5, 5.0, 2.0}), r<value_type>::value * 1e1);
+}
+
+
+TYPED_TEST(Ir, SolvesTriangularSystemUsingAdvancedApplyComplex)
+{
+    using Scalar = typename TestFixture::Mtx;
+    using Mtx = gko::to_complex<typename TestFixture::Mtx>;
+    using value_type = typename Mtx::value_type;
+    auto solver = this->ir_factory->generate(this->mtx);
+    auto alpha = gko::initialize<Scalar>({2.0}, this->exec);
+    auto beta = gko::initialize<Scalar>({-1.0}, this->exec);
+    auto b = gko::initialize<Mtx>(
+        {value_type{3.9, -7.8}, value_type{9.0, -18.0}, value_type{2.2, -4.4}},
+        this->exec);
+    auto x = gko::initialize<Mtx>(
+        {value_type{0.5, -1.0}, value_type{1.0, -2.0}, value_type{2.0, -4.0}},
+        this->exec);
+
+    solver->apply(alpha.get(), b.get(), beta.get(), x.get());
+
+    GKO_ASSERT_MTX_NEAR(x,
+                        l({value_type{1.5, -3.0}, value_type{5.0, -10.0},
+                           value_type{2.0, -4.0}}),
+                        (r_mixed<value_type, TypeParam>()) * 1e1);
+}
+
+
+TYPED_TEST(Ir, SolvesTriangularSystemUsingAdvancedApplyMixedComplex)
+{
+    using Scalar = gko::matrix::Dense<
+        gko::next_precision<typename TestFixture::value_type>>;
+    using Mtx = gko::to_complex<typename TestFixture::Mtx>;
+    using value_type = typename Mtx::value_type;
+    auto solver = this->ir_factory->generate(this->mtx);
+    auto alpha = gko::initialize<Scalar>({2.0}, this->exec);
+    auto beta = gko::initialize<Scalar>({-1.0}, this->exec);
+    auto b = gko::initialize<Mtx>(
+        {value_type{3.9, -7.8}, value_type{9.0, -18.0}, value_type{2.2, -4.4}},
+        this->exec);
+    auto x = gko::initialize<Mtx>(
+        {value_type{0.5, -1.0}, value_type{1.0, -2.0}, value_type{2.0, -4.0}},
+        this->exec);
+
+    solver->apply(alpha.get(), b.get(), beta.get(), x.get());
+
+    GKO_ASSERT_MTX_NEAR(x,
+                        l({value_type{1.5, -3.0}, value_type{5.0, -10.0},
+                           value_type{2.0, -4.0}}),
+                        r<value_type>::value * 1e1);
 }
 
 

--- a/reference/test/solver/lower_trs_kernels.cpp
+++ b/reference/test/solver/lower_trs_kernels.cpp
@@ -122,6 +122,67 @@ TYPED_TEST(LowerTrs, SolvesTriangularSystem)
 }
 
 
+TYPED_TEST(LowerTrs, SolvesTriangularSystemMixed)
+{
+    using other_value_type = typename TestFixture::value_type;
+    using value_type = gko::next_precision<other_value_type>;
+    using Mtx = gko::matrix::Dense<value_type>;
+    std::shared_ptr<Mtx> b = gko::initialize<Mtx>({1.0, 2.0, 1.0}, this->exec);
+    auto x = gko::initialize<Mtx>({0.0, 0.0, 0.0}, this->exec);
+    auto solver = this->lower_trs_factory->generate(this->mtx);
+
+    solver->apply(b.get(), x.get());
+
+    GKO_ASSERT_MTX_NEAR(x, l({1.0, -1.0, 2.0}),
+                        (r_mixed<value_type, other_value_type>()));
+}
+
+
+TYPED_TEST(LowerTrs, SolvesTriangularSystemComplex)
+{
+    using Scalar = typename TestFixture::Mtx;
+    using Mtx = gko::to_complex<typename TestFixture::Mtx>;
+    using value_type = typename Mtx::value_type;
+    std::shared_ptr<Mtx> b = gko::initialize<Mtx>(
+        {value_type{1.0, -2.0}, value_type{2.0, -4.0}, value_type{1.0, -2.0}},
+        this->exec);
+    auto x = gko::initialize<Mtx>(
+        {value_type{0.0, 0.0}, value_type{0.0, 0.0}, value_type{0.0, 0.0}},
+        this->exec);
+    auto solver = this->lower_trs_factory->generate(this->mtx);
+
+    solver->apply(b.get(), x.get());
+
+    GKO_ASSERT_MTX_NEAR(x,
+                        l({value_type{1.0, -2.0}, value_type{-1.0, 2.0},
+                           value_type{2.0, -4.0}}),
+                        r<value_type>::value);
+}
+
+
+TYPED_TEST(LowerTrs, SolvesTriangularSystemMixedComplex)
+{
+    using other_value_type = typename TestFixture::value_type;
+    using Scalar = gko::matrix::Dense<gko::next_precision<other_value_type>>;
+    using Mtx = gko::to_complex<typename TestFixture::Mtx>;
+    using value_type = typename Mtx::value_type;
+    std::shared_ptr<Mtx> b = gko::initialize<Mtx>(
+        {value_type{1.0, -2.0}, value_type{2.0, -4.0}, value_type{1.0, -2.0}},
+        this->exec);
+    auto x = gko::initialize<Mtx>(
+        {value_type{0.0, 0.0}, value_type{0.0, 0.0}, value_type{0.0, 0.0}},
+        this->exec);
+    auto solver = this->lower_trs_factory->generate(this->mtx);
+
+    solver->apply(b.get(), x.get());
+
+    GKO_ASSERT_MTX_NEAR(x,
+                        l({value_type{1.0, -2.0}, value_type{-1.0, 2.0},
+                           value_type{2.0, -4.0}}),
+                        (r_mixed<value_type, other_value_type>()));
+}
+
+
 TYPED_TEST(LowerTrs, SolvesMultipleTriangularSystems)
 {
     using Mtx = typename TestFixture::Mtx;
@@ -167,6 +228,73 @@ TYPED_TEST(LowerTrs, SolvesTriangularSystemUsingAdvancedApply)
     solver->apply(alpha.get(), b.get(), beta.get(), x.get());
 
     GKO_ASSERT_MTX_NEAR(x, l({1.0, -1.0, 3.0}), r<value_type>::value);
+}
+
+
+TYPED_TEST(LowerTrs, SolvesTriangularSystemUsingAdvancedApplyMixed)
+{
+    using other_value_type = typename TestFixture::value_type;
+    using value_type = gko::next_precision<other_value_type>;
+    using Mtx = gko::matrix::Dense<value_type>;
+    auto alpha = gko::initialize<Mtx>({2.0}, this->exec);
+    auto beta = gko::initialize<Mtx>({-1.0}, this->exec);
+    std::shared_ptr<Mtx> b = gko::initialize<Mtx>({1.0, 2.0, 1.0}, this->exec);
+    auto x = gko::initialize<Mtx>({1.0, -1.0, 1.0}, this->exec);
+    auto solver = this->lower_trs_factory->generate(this->mtx);
+
+    solver->apply(alpha.get(), b.get(), beta.get(), x.get());
+
+    GKO_ASSERT_MTX_NEAR(x, l({1.0, -1.0, 3.0}),
+                        (r_mixed<value_type, other_value_type>()));
+}
+
+
+TYPED_TEST(LowerTrs, SolvesTriangularSystemUsingAdvancedApplyComplex)
+{
+    using Scalar = typename TestFixture::Mtx;
+    using Mtx = gko::to_complex<typename TestFixture::Mtx>;
+    using value_type = typename Mtx::value_type;
+    auto alpha = gko::initialize<Scalar>({2.0}, this->exec);
+    auto beta = gko::initialize<Scalar>({-1.0}, this->exec);
+    std::shared_ptr<Mtx> b = gko::initialize<Mtx>(
+        {value_type{1.0, -2.0}, value_type{2.0, -4.0}, value_type{1.0, -2.0}},
+        this->exec);
+    auto x = gko::initialize<Mtx>(
+        {value_type{1.0, -2.0}, value_type{-1.0, 2.0}, value_type{1.0, -2.0}},
+        this->exec);
+    auto solver = this->lower_trs_factory->generate(this->mtx);
+
+    solver->apply(alpha.get(), b.get(), beta.get(), x.get());
+
+    GKO_ASSERT_MTX_NEAR(x,
+                        l({value_type{1.0, -2.0}, value_type{-1.0, 2.0},
+                           value_type{3.0, -6.0}}),
+                        r<value_type>::value);
+}
+
+
+TYPED_TEST(LowerTrs, SolvesTriangularSystemUsingAdvancedApplyMixedComplex)
+{
+    using other_value_type = typename TestFixture::value_type;
+    using Scalar = gko::matrix::Dense<gko::next_precision<other_value_type>>;
+    using Mtx = gko::to_complex<typename TestFixture::Mtx>;
+    using value_type = typename Mtx::value_type;
+    auto alpha = gko::initialize<Scalar>({2.0}, this->exec);
+    auto beta = gko::initialize<Scalar>({-1.0}, this->exec);
+    std::shared_ptr<Mtx> b = gko::initialize<Mtx>(
+        {value_type{1.0, -2.0}, value_type{2.0, -4.0}, value_type{1.0, -2.0}},
+        this->exec);
+    auto x = gko::initialize<Mtx>(
+        {value_type{1.0, -2.0}, value_type{-1.0, 2.0}, value_type{1.0, -2.0}},
+        this->exec);
+    auto solver = this->lower_trs_factory->generate(this->mtx);
+
+    solver->apply(alpha.get(), b.get(), beta.get(), x.get());
+
+    GKO_ASSERT_MTX_NEAR(x,
+                        l({value_type{1.0, -2.0}, value_type{-1.0, 2.0},
+                           value_type{3.0, -6.0}}),
+                        (r_mixed<value_type, other_value_type>()));
 }
 
 

--- a/reference/test/solver/upper_trs_kernels.cpp
+++ b/reference/test/solver/upper_trs_kernels.cpp
@@ -120,6 +120,67 @@ TYPED_TEST(UpperTrs, SolvesTriangularSystem)
 }
 
 
+TYPED_TEST(UpperTrs, SolvesTriangularSystemMixed)
+{
+    using other_value_type = typename TestFixture::value_type;
+    using value_type = gko::next_precision<other_value_type>;
+    using Mtx = gko::matrix::Dense<value_type>;
+    std::shared_ptr<Mtx> b = gko::initialize<Mtx>({4.0, 2.0, 3.0}, this->exec);
+    auto x = gko::initialize<Mtx>({0.0, 0.0, 0.0}, this->exec);
+    auto solver = this->upper_trs_factory->generate(this->mtx);
+
+    solver->apply(b.get(), x.get());
+
+    GKO_ASSERT_MTX_NEAR(x, l({13.0, -4.0, 3.0}),
+                        (r_mixed<value_type, other_value_type>()));
+}
+
+
+TYPED_TEST(UpperTrs, SolvesTriangularSystemComplex)
+{
+    using Scalar = typename TestFixture::Mtx;
+    using Mtx = gko::to_complex<typename TestFixture::Mtx>;
+    using value_type = typename Mtx::value_type;
+    std::shared_ptr<Mtx> b = gko::initialize<Mtx>(
+        {value_type{4.0, -8.0}, value_type{2.0, -4.0}, value_type{3.0, -6.0}},
+        this->exec);
+    auto x = gko::initialize<Mtx>(
+        {value_type{0.0, 0.0}, value_type{0.0, 0.0}, value_type{0.0, 0.0}},
+        this->exec);
+    auto solver = this->upper_trs_factory->generate(this->mtx);
+
+    solver->apply(b.get(), x.get());
+
+    GKO_ASSERT_MTX_NEAR(x,
+                        l({value_type{13.0, -26.0}, value_type{-4.0, 8.0},
+                           value_type{3.0, -6.0}}),
+                        r<value_type>::value);
+}
+
+
+TYPED_TEST(UpperTrs, SolvesTriangularSystemMixedComplex)
+{
+    using other_value_type = typename TestFixture::value_type;
+    using Scalar = gko::matrix::Dense<gko::next_precision<other_value_type>>;
+    using Mtx = gko::to_complex<typename TestFixture::Mtx>;
+    using value_type = typename Mtx::value_type;
+    std::shared_ptr<Mtx> b = gko::initialize<Mtx>(
+        {value_type{4.0, -8.0}, value_type{2.0, -4.0}, value_type{3.0, -6.0}},
+        this->exec);
+    auto x = gko::initialize<Mtx>(
+        {value_type{0.0, 0.0}, value_type{0.0, 0.0}, value_type{0.0, 0.0}},
+        this->exec);
+    auto solver = this->upper_trs_factory->generate(this->mtx);
+
+    solver->apply(b.get(), x.get());
+
+    GKO_ASSERT_MTX_NEAR(x,
+                        l({value_type{13.0, -26.0}, value_type{-4.0, 8.0},
+                           value_type{3.0, -6.0}}),
+                        (r_mixed<value_type, other_value_type>()));
+}
+
+
 TYPED_TEST(UpperTrs, SolvesMultipleTriangularSystems)
 {
     using Mtx = typename TestFixture::Mtx;
@@ -166,6 +227,73 @@ TYPED_TEST(UpperTrs, SolvesTriangularSystemUsingAdvancedApply)
     solver->apply(alpha.get(), b.get(), beta.get(), x.get());
 
     GKO_ASSERT_MTX_NEAR(x, l({25.0, -7.0, 5.0}), r<value_type>::value);
+}
+
+
+TYPED_TEST(UpperTrs, SolvesTriangularSystemUsingAdvancedApplyMixed)
+{
+    using other_value_type = typename TestFixture::value_type;
+    using value_type = gko::next_precision<other_value_type>;
+    using Mtx = gko::matrix::Dense<value_type>;
+    auto alpha = gko::initialize<Mtx>({2.0}, this->exec);
+    auto beta = gko::initialize<Mtx>({-1.0}, this->exec);
+    std::shared_ptr<Mtx> b = gko::initialize<Mtx>({4.0, 2.0, 3.0}, this->exec);
+    auto x = gko::initialize<Mtx>({1.0, -1.0, 1.0}, this->exec);
+    auto solver = this->upper_trs_factory->generate(this->mtx);
+
+    solver->apply(alpha.get(), b.get(), beta.get(), x.get());
+
+    GKO_ASSERT_MTX_NEAR(x, l({25.0, -7.0, 5.0}),
+                        (r_mixed<value_type, other_value_type>()));
+}
+
+
+TYPED_TEST(UpperTrs, SolvesTriangularSystemUsingAdvancedApplyComplex)
+{
+    using Scalar = typename TestFixture::Mtx;
+    using Mtx = gko::to_complex<typename TestFixture::Mtx>;
+    using value_type = typename Mtx::value_type;
+    auto alpha = gko::initialize<Scalar>({2.0}, this->exec);
+    auto beta = gko::initialize<Scalar>({-1.0}, this->exec);
+    std::shared_ptr<Mtx> b = gko::initialize<Mtx>(
+        {value_type{4.0, -8.0}, value_type{2.0, -4.0}, value_type{3.0, -6.0}},
+        this->exec);
+    auto x = gko::initialize<Mtx>(
+        {value_type{1.0, -2.0}, value_type{-1.0, 2.0}, value_type{1.0, -2.0}},
+        this->exec);
+    auto solver = this->upper_trs_factory->generate(this->mtx);
+
+    solver->apply(alpha.get(), b.get(), beta.get(), x.get());
+
+    GKO_ASSERT_MTX_NEAR(x,
+                        l({value_type{25.0, -50.0}, value_type{-7.0, 14.0},
+                           value_type{5.0, -10.0}}),
+                        r<value_type>::value);
+}
+
+
+TYPED_TEST(UpperTrs, SolvesTriangularSystemUsingAdvancedApplyMixedComplex)
+{
+    using other_value_type = typename TestFixture::value_type;
+    using Scalar = gko::matrix::Dense<gko::next_precision<other_value_type>>;
+    using Mtx = gko::to_complex<typename TestFixture::Mtx>;
+    using value_type = typename Mtx::value_type;
+    auto alpha = gko::initialize<Scalar>({2.0}, this->exec);
+    auto beta = gko::initialize<Scalar>({-1.0}, this->exec);
+    std::shared_ptr<Mtx> b = gko::initialize<Mtx>(
+        {value_type{4.0, -8.0}, value_type{2.0, -4.0}, value_type{3.0, -6.0}},
+        this->exec);
+    auto x = gko::initialize<Mtx>(
+        {value_type{1.0, -2.0}, value_type{-1.0, 2.0}, value_type{1.0, -2.0}},
+        this->exec);
+    auto solver = this->upper_trs_factory->generate(this->mtx);
+
+    solver->apply(alpha.get(), b.get(), beta.get(), x.get());
+
+    GKO_ASSERT_MTX_NEAR(x,
+                        l({value_type{25.0, -50.0}, value_type{-7.0, 14.0},
+                           value_type{5.0, -10.0}}),
+                        (r_mixed<value_type, other_value_type>()));
 }
 
 


### PR DESCRIPTION
This PR adds full mixed precision support to Ginkgo, at least in terms of LinOp compatibility.
By default, this happens with the new `make_temporary_conversion` helper that works similarly to `make_temporary_clone` and is wrapped in the `precision_dispatch` function, which applies the correct precision and complex-to-real conversions for SpMV and preconditioner applications. For solvers, a more explicit conversion is necessary.

The temporary conversion wrapper won't give ideal performance, since it requires additional conversions from and to the input/output vectors as well as associated allocations of temporary memory for each apply operation. For solvers, this might still pay off due to the long runtime of a single `apply`. Mixed Precision IR is then almost equivalent to the following
```cpp
auto solver =
    gko::solver::Ir<double>::build()
        .with_solver(
            gko::solver::Gmres<float>::build()
                .with_criteria(
                    gko::stop::ResidualNormReduction<SolverType>::build()
                        .with_reduction_factor(inner_reduction_factor)
                        .on(exec),
                    gko::stop::Iteration::build()
                        .with_max_iters(max_inner_iters)
                        .on(exec))
                .on(exec))
        .with_criteria(gko::stop::ResidualNormReduction<ValueType>::build()
                            .with_reduction_factor(outer_reduction_factor)
                            .on(exec),
                        gko::stop::Iteration::build()
                            .with_max_iters(max_outer_iters)
                            .on(exec))
        .on(exec)
        ->generate(give(A));
```
except for the fact that A is always stored and computed on in double precision.

TODO: 
- [x] Comprehensive Reference Tests
- [x] ~~No need to convert `x` to ValueType for LinOps where `apply_uses_initial_guess() == false`~~ This would be way too complex and probably be overkill, since this is not meant to provide good performance
- [x] ~~Modify MPIR example~~