### PR TITLE
Update path for HIP in GinkgoConfig.cmake.in

### DIFF
--- a/cmake/GinkgoConfig.cmake.in
+++ b/cmake/GinkgoConfig.cmake.in
@@ -134,8 +134,8 @@ set(GINKGO_OPENMP_LIBRARIES @OpenMP_CXX_LIBRARIES@)
 set(GINKGO_OPENMP_FLAGS "@OpenMP_CXX_FLAGS@")
 
 # Provide useful HIP helper functions
-include(${CMAKE_CURRENT_LIST_DIR}/hip_helpers.cmake)
-include(${CMAKE_CURRENT_LIST_DIR}/windows_helpers.cmake)
+include(${CMAKE_CURRENT_LIST_DIR}/cmake/hip_helpers.cmake)
+include(${CMAKE_CURRENT_LIST_DIR}/cmake/windows_helpers.cmake)
 
 # NOTE: we do not export benchmarks, examples, tests or devel tools
 #     so `third_party` libraries are currently unneeded.


### PR DESCRIPTION
CMakeLists will be created in ginkgo root directory, not in ginkgo root/cmake, therefore need to add "/cmake/" as path