### PR TITLE
Fix GinkgoConfig.cmake. Test linking build dir.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -26,6 +26,7 @@ stages:
   CONFIG_LOG: "ON"
   CXX_FLAGS: ""
   EXTRA_CMAKE_FLAGS: ""
+  EXPORT_BUILD_DIR: "OFF"
   CI_PROJECT_DIR_SUFFIX: ""
 
 .before_script_template: &default_before_script
@@ -65,8 +66,10 @@ stages:
         -DGINKGO_BUILD_TESTS=ON -DGINKGO_BUILD_EXAMPLES=ON
         -DGINKGO_RUN_EXAMPLES=${RUN_EXAMPLES}
         -DGINKGO_CONFIG_LOG_DETAILED=${CONFIG_LOG}
+        -DGINKGO_EXPORT_BUILD_DIR=${EXPORT_BUILD_DIR}
     - ninja -j${NUM_CORES} -l${CI_LOAD_LIMIT}
     - if [ ! -z ${SYCL_DEVICE_TYPE+x} ]; then unset SYCL_DEVICE_TYPE; fi
+    - if [ "${EXPORT_BUILD_DIR}" == "ON" ]; then ninja test_exportbuild; fi
   dependencies: []
   except:
       - schedules
@@ -94,6 +97,7 @@ stages:
         -DGINKGO_BUILD_TESTS=ON -DGINKGO_BUILD_EXAMPLES=ON
         -DGINKGO_CONFIG_LOG_DETAILED=${CONFIG_LOG}
         -DGINKGO_RUN_EXAMPLES=${RUN_EXAMPLES}
+        -DGINKGO_EXPORT_BUILD_DIR=${EXPORT_BUILD_DIR}
     - ninja -j${NUM_CORES} -l${CI_LOAD_LIMIT} install
     - |
         (( $(ctest -N | tail -1 | sed 's/Total Tests: //') != 0 )) || exit 1
@@ -121,6 +125,7 @@ stages:
         fi
       fi
     - if [ ! -z ${SYCL_DEVICE_TYPE+x} ]; then unset SYCL_DEVICE_TYPE; fi
+    - if [ "${EXPORT_BUILD_DIR}" == "ON" ]; then ninja test_exportbuild; fi
   dependencies: []
   except:
       - schedules
@@ -741,6 +746,28 @@ subdir-build:
     - private_ci
     - cuda
     - gpu
+
+# Ensure Ginkgo can be used when exporting the build directory
+export-build:
+  <<: *default_build
+  stage: code_quality
+  image: localhost:5000/gko-cuda102-gnu8-llvm8-intel2019
+  variables:
+    <<: *default_variables
+    BUILD_OMP: "ON"
+    BUILD_CUDA: "ON"
+    BUILD_HIP: "ON"
+    EXPORT_BUILD_DIR: "ON"
+  only:
+    variables:
+      - $RUN_CI_TAG
+  dependencies: []
+  allow_failure: no
+  tags:
+    - private_ci
+    - cuda
+    - gpu
+
 
 # Run clang-tidy and iwyu
 clang-tidy:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -730,12 +730,10 @@ no-circular-deps:
 subdir-build:
   <<: *default_build
   stage: code_quality
-  image: localhost:5000/gko-cuda101-gnu8-llvm7-intel2019
+  image: localhost:5000/gko-nocuda-gnu9-llvm8
   variables:
     <<: *default_variables
     BUILD_OMP: "ON"
-    BUILD_CUDA: "ON"
-    BUILD_HIP: "ON"
     CI_PROJECT_PATH_SUFFIX: "/test_subdir"
   only:
     variables:
@@ -744,19 +742,16 @@ subdir-build:
   allow_failure: no
   tags:
     - private_ci
-    - cuda
-    - gpu
+    - cpu
 
 # Ensure Ginkgo can be used when exporting the build directory
 export-build:
   <<: *default_build
   stage: code_quality
-  image: localhost:5000/gko-cuda102-gnu8-llvm8-intel2019
+  image: localhost:5000/gko-nocuda-gnu9-llvm8
   variables:
     <<: *default_variables
     BUILD_OMP: "ON"
-    BUILD_CUDA: "ON"
-    BUILD_HIP: "ON"
     EXPORT_BUILD_DIR: "ON"
   only:
     variables:
@@ -765,9 +760,7 @@ export-build:
   allow_failure: no
   tags:
     - private_ci
-    - cuda
-    - gpu
-
+    - cpu
 
 # Run clang-tidy and iwyu
 clang-tidy:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -290,11 +290,13 @@ ginkgo_install()
 if(MSVC)
     # Set path/command with $<CONFIG>
     set(GINKGO_TEST_INSTALL_COMMAND "${Ginkgo_BINARY_DIR}/test_install/$<CONFIG>/test_install")
+    set(GINKGO_TEST_EXPORTBUILD_COMMAND "${Ginkgo_BINARY_DIR}/test_exportbuild/$<CONFIG>/test_exportbuild")
     if(GINKGO_BUILD_CUDA)
         set(GINKGO_TEST_INSTALL_COMMAND "${GINKGO_TEST_INSTALL_COMMAND}" "${Ginkgo_BINARY_DIR}/test_install/$<CONFIG>/test_install_cuda")
     endif()
 else()
     set(GINKGO_TEST_INSTALL_COMMAND "${Ginkgo_BINARY_DIR}/test_install/test_install")
+    set(GINKGO_TEST_EXPORTBUILD_COMMAND "${Ginkgo_BINARY_DIR}/test_exportbuild/test_exportbuild")
     if(GINKGO_BUILD_CUDA)
         set(GINKGO_TEST_INSTALL_COMMAND "${GINKGO_TEST_INSTALL_COMMAND}" "${Ginkgo_BINARY_DIR}/test_install/test_install_cuda")
     endif()
@@ -311,6 +313,20 @@ add_custom_target(test_install
     COMMAND ${CMAKE_COMMAND} --build ${Ginkgo_BINARY_DIR}/test_install --config $<CONFIG>
     COMMAND ${GINKGO_TEST_INSTALL_COMMAND}
     COMMENT "Running a test on the installed binaries. This requires running `(sudo) make install` first.")
+
+add_custom_target(test_exportbuild
+    COMMAND ${CMAKE_COMMAND} -G${CMAKE_GENERATOR} -H${Ginkgo_SOURCE_DIR}/test_exportbuild
+    -B${Ginkgo_BINARY_DIR}/test_exportbuild
+    -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER} -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
+    -DCMAKE_CUDA_COMPILER=${CMAKE_CUDA_COMPILER}
+    # `--config cfg` is ignored by single-configuration generator.
+    # `$<CONFIG>` is always be the same as `CMAKE_BUILD_TYPE` in
+    # single-configuration generator.
+    COMMAND ${CMAKE_COMMAND} --build ${Ginkgo_BINARY_DIR}/test_exportbuild --config $<CONFIG>
+    COMMAND ${GINKGO_TEST_EXPORTBUILD_COMMAND}
+    COMMENT "Running a test on Ginkgo's exported build directory. "
+    "This requires compiling Ginkgo with `-DGINKGO_EXPORT_BUILD_DIR=ON` first.")
+
 
 # Setup CPack
 set(CPACK_PACKAGE_DESCRIPTION_FILE "${Ginkgo_SOURCE_DIR}/README.md")

--- a/cmake/install_helpers.cmake
+++ b/cmake/install_helpers.cmake
@@ -67,6 +67,11 @@ function(ginkgo_install)
         "${Ginkgo_BINARY_DIR}/GinkgoConfig.cmake"
         INSTALL_DESTINATION "${GINKGO_INSTALL_CONFIG_DIR}"
         )
+    set(HELPERS "hip_helpers.cmake" "windows_helpers.cmake")
+    foreach (helper ${HELPERS})
+        configure_file(${Ginkgo_SOURCE_DIR}/cmake/${helper}
+            ${Ginkgo_BINARY_DIR}/${helper} COPYONLY)
+    endforeach()
     install(FILES
         "${Ginkgo_BINARY_DIR}/GinkgoConfig.cmake"
         "${Ginkgo_BINARY_DIR}/GinkgoConfigVersion.cmake"

--- a/test_exportbuild/CMakeLists.txt
+++ b/test_exportbuild/CMakeLists.txt
@@ -1,11 +1,7 @@
 cmake_minimum_required(VERSION 3.9)
+project(GinkgoExportBuildTest LANGUAGES CXX)
 
-project(TestInstall LANGUAGES CXX)
-
-find_package(Ginkgo REQUIRED
-            PATHS # The Path where ginkgo was installed
-            # Alternatively, use `cmake -DCMAKE_PREFIX_PATH=<ginkgo_install_dir>` to specify the install directory
-            )
+find_package(Ginkgo REQUIRED)
 
 if(MSVC)
     if(GINKGO_BUILD_SHARED_LIBS)
@@ -17,25 +13,9 @@ if(MSVC)
     endif()
 endif()
 
-include(CheckLanguage)
-check_language(CUDA)
-
-add_executable(test_install test_install.cpp)
-target_compile_features(test_install PUBLIC cxx_std_14)
-target_link_libraries(test_install PRIVATE Ginkgo::ginkgo)
-
-if(GINKGO_BUILD_CUDA)
-    enable_language(CUDA)
-    if(MSVC)
-        if(GINKGO_BUILD_SHARED_LIBS)
-            ginkgo_switch_to_windows_dynamic("CUDA")
-        else()
-            ginkgo_switch_to_windows_static("CUDA")
-        endif()
-    endif()
-    add_executable(test_install_cuda test_install_cuda.cu)
-    target_link_libraries(test_install_cuda PRIVATE Ginkgo::ginkgo)
-endif()
+add_executable(test_exportbuild ../test_install/test_install.cpp)
+target_compile_features(test_exportbuild PUBLIC cxx_std_14)
+target_link_libraries(test_exportbuild PRIVATE Ginkgo::ginkgo)
 
 if(GINKGO_BUILD_HIP AND GINKGO_HIP_PLATFORM MATCHES "hcc"
         AND GINKGO_HIP_VERSION VERSION_GREATER_EQUAL "3.5"


### PR DESCRIPTION
As previously discussed, this fixes the problem with `GinkgoConfig.cmake` from a build directory perspective, while keeping a correct installation setup.

To ensure this works, I also test linking Ginkgo after exporting the build directory so that CMake is able to use this when doing a `find_package()`. We already had an option for this, it's only a matter of actually using it.

Issue found by: https://github.com/ginkgo-project/ginkgo/pull/680