### PR TITLE
Add support for C++ package manager(s)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,10 @@ if (CMAKE_VERSION VERSION_GREATER_EQUAL 3.18)
 endif()
 
 project(Ginkgo LANGUAGES C CXX VERSION 1.3.0 DESCRIPTION "A numerical linear algebra library targeting many-core architectures")
+if (GINKGO_BUILD_CONAN)
+    include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+    conan_basic_setup()
+endif()
 set(Ginkgo_VERSION_TAG "develop")
 set(PROJECT_VERSION_TAG ${Ginkgo_VERSION_TAG})
 

--- a/conanfile.py
+++ b/conanfile.py
@@ -1,0 +1,42 @@
+from conans import ConanFile, CMake, tools
+
+
+class GinkgoConan(ConanFile):
+    name = "Ginkgo"
+    version = "1.3.0"
+    license = "BSD-3-Clause"
+    author = "Terry Cojean (tcojean@kit.edu)"
+    url = "https://github.com/ginkgo-project/ginkgo"
+    description = "High-performance linear algebra library for manycore systems, with a focus on sparse solution of linear systems."
+    topics = ("hpc", "linear-algebra")
+    settings = "os", "compiler", "build_type", "arch"
+    options = {"shared": [True, False], "reference": [True, False], "openmp": [
+        True, False], "cuda": [True, False], "hip": [True, False], "dpcpp": [True, False]}
+    default_options = {"shared": True, "reference": True,
+                       "openmp": False, "cuda": False, "hip": False, "dpcpp": False}
+    generators = "cmake"
+    exports_sources = "cmake/*", "common/*", "core/*", "cuda/*", "dpcpp/*", "hip/*", "include/*", "matrices/*", "omp/*", "reference/*", "third_party/*", "CMakeLists.txt", "*.cmake", "*.md", "LICENSE", "contributors.txt"
+
+    def _configure_cmake(self):
+        cmake = CMake(self)
+        cmake.definitions["GINKGO_BUILD_CONAN"] = "ON"
+        cmake.definitions["GINKGO_BUILD_BENCHMARKS"] = "OFF"
+        cmake.definitions["GINKGO_BUILD_EXAMPLES"] = "OFF"
+        cmake.definitions["GINKGO_BUILD_TESTS"] = "ON"
+        cmake.definitions["GINKGO_BUILD_REFERENCE"] = "ON" if self.options["reference"] else "OFF"
+        cmake.definitions["GINKGO_BUILD_OMP"] = "ON" if self.options["openmp"] else "OFF"
+        cmake.definitions["GINKGO_BUILD_CUDA"] = "ON" if self.options["cuda"] else "OFF"
+        cmake.definitions["GINKGO_BUILD_HIP"] = "ON" if self.options["hip"] else "OFF"
+        cmake.definitions["GINKGO_BUILD_DPCPP"] = "ON" if self.options["dpcpp"] else "OFF"
+        cmake.definitions["BUILD_SHARED_LIBS"] = "ON" if self.options["shared"] else "OFF"
+        cmake.configure()
+        return cmake
+
+    def build(self):
+        cmake = self._configure_cmake()
+        cmake.build()
+        cmake.test()
+
+    def package(self):
+        cmake = self._configure_cmake()
+        cmake.install()

--- a/test_package/CMakeLists.txt
+++ b/test_package/CMakeLists.txt
@@ -1,0 +1,59 @@
+cmake_minimum_required(VERSION 3.9)
+
+project(TestPackage LANGUAGES CXX)
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup()
+
+find_package(Ginkgo REQUIRED
+            PATHS # The Path where ginkgo was installed
+            # Alternatively, use `cmake -DCMAKE_PREFIX_PATH=<ginkgo_install_dir>` to specify the install directory
+            )
+
+if(MSVC)
+    if(GINKGO_BUILD_SHARED_LIBS)
+        ginkgo_switch_to_windows_dynamic("CXX")
+        ginkgo_switch_to_windows_dynamic("C")
+    else()
+        ginkgo_switch_to_windows_static("CXX")
+        ginkgo_switch_to_windows_static("C")
+    endif()
+endif()
+
+include(CheckLanguage)
+check_language(CUDA)
+
+add_executable(test_install ../test_install/test_install.cpp)
+target_compile_features(test_install PUBLIC cxx_std_14)
+target_link_libraries(test_install PRIVATE Ginkgo::ginkgo)
+enable_testing()
+add_test(NAME test_install COMMAND test_install)
+
+if(GINKGO_BUILD_CUDA)
+    enable_language(CUDA)
+    if(MSVC)
+        if(GINKGO_BUILD_SHARED_LIBS)
+            ginkgo_switch_to_windows_dynamic("CUDA")
+        else()
+            ginkgo_switch_to_windows_static("CUDA")
+        endif()
+    endif()
+    add_executable(test_install_cuda ../test_install/test_install_cuda.cu)
+    target_link_libraries(test_install_cuda PRIVATE Ginkgo::ginkgo)
+    add_test(NAME test_install_cuda COMMAND test_install_cuda)
+endif()
+
+if(GINKGO_BUILD_HIP
+   AND GINKGO_HIP_PLATFORM MATCHES "hcc"
+   AND GINKGO_HIP_VERSION VERSION_GREATER_EQUAL "3.5"
+   AND NOT GINKGO_BUILD_SHARED_LIBS)
+    # Compile options somehow add hip-clang specific flags. Wipe them.
+    # Currently, the flags wiped out should be:
+    # -x;hip;--hip-device-lib-path=/opt/rocm/lib;--cuda-gpu-arch=gfx900;
+    # --cuda-gpu-arch=gfx906
+    set_target_properties(hip::device PROPERTIES INTERFACE_COMPILE_OPTIONS "")
+    # In addition, link libraries have a similar problem. We only keep
+    # `hip::host`. Currently, the flags should be:
+    # hip::host;--hip-device-lib-path=/opt/rocm/lib;--hip-link;
+    # --cuda-gpu-arch=gfx900;--cuda-gpu-arch=gfx906
+    set_target_properties(hip::device PROPERTIES INTERFACE_LINK_LIBRARIES "hip::host")
+endif()

--- a/test_package/conanfile.py
+++ b/test_package/conanfile.py
@@ -1,0 +1,18 @@
+import os
+
+from conans import ConanFile, CMake, tools
+
+
+class GinkgoTestConan(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+    generators = "cmake"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.test()


### PR DESCRIPTION
This PR adds support for the Conan Package manager to Ginkgo. I also plan to add vcpkg support, but didn't completely understand their build process yet.

TODO:
- [ ] Make tests optional
- [x] Add to CI setup (unnecessary, they do their own CI)
- [x] Add vcpkg support