### PR TITLE
allow bot for all changed files and update label regex

### DIFF
--- a/.github/bot-pr-format-base.sh
+++ b/.github/bot-pr-format-base.sh
@@ -7,23 +7,7 @@ FORMAT_HEADER_REGEX='^(benchmark|core|cuda|hip|include/ginkgo/core|omp|reference
 FORMAT_REGEX='^(common|examples|test_install)/'
 
 echo "Retrieving PR file list"
-PR_FILES=""
-PAGE="1"
-while true; do
-  # this api allows 100 items per page
-  # github action uses `bash -e`. The last empty page will leads jq error, use `|| :` to ignore the error.
-  PR_PAGE_FILES=$(api_get "$PR_URL/files?&per_page=100&page=${PAGE}" | jq -er '.[] | .filename' || :)
-  if [ "${PR_PAGE_FILES}" = "" ]; then
-    break
-  fi
-  echo "Retrieving PR file list - ${PAGE} pages"
-  if [ ! "${PR_FILES}" = "" ]; then
-    # add the same new line format as jq output
-    PR_FILES="${PR_FILES}"$'\n'
-  fi
-  PR_FILES="${PR_FILES}${PR_PAGE_FILES}"
-  PAGE=$(( PAGE + 1 ))
-done
+PR_FILES=$(bot_get_all_changed_files ${PR_URL})
 NUM=$(echo "${PR_FILES}" | wc -l)
 echo "PR has ${NUM} changed files"
 

--- a/.github/bot-pr-format-base.sh
+++ b/.github/bot-pr-format-base.sh
@@ -7,7 +7,26 @@ FORMAT_HEADER_REGEX='^(benchmark|core|cuda|hip|include/ginkgo/core|omp|reference
 FORMAT_REGEX='^(common|examples|test_install)/'
 
 echo "Retrieving PR file list"
-PR_FILES="$(api_get "$PR_URL/files?&per_page=1000" | jq -er '.[] | .filename')"
+PR_FILES=""
+PAGE="1"
+while true; do
+  # this api allows 100 items per page
+  # github action uses `bash -e`. The last empty page will leads jq error, use `|| :` to ignore the error.
+  PR_PAGE_FILES=$(api_get "$PR_URL/files?&per_page=100&page=${PAGE}" | jq -er '.[] | .filename' || :)
+  if [ "${PR_PAGE_FILES}" = "" ]; then
+    break
+  fi
+  echo "Retrieving PR file list - ${PAGE} pages"
+  if [ ! "${PR_FILES}" = "" ]; then
+    # add the same new line format as jq output
+    PR_FILES="${PR_FILES}"$'\n'
+  fi
+  PR_FILES="${PR_FILES}${PR_PAGE_FILES}"
+  PAGE=$(( PAGE + 1 ))
+done
+NUM=$(echo "${PR_FILES}" | wc -l)
+echo "PR has ${NUM} changed files"
+
 TO_FORMAT="$(echo "$PR_FILES" | grep -E $EXTENSION_REGEX || true)"
 
 git remote add fork "$HEAD_URL"

--- a/.github/label.sh
+++ b/.github/label.sh
@@ -3,23 +3,7 @@
 source .github/bot-pr-base.sh
 
 echo "Retrieving PR file list"
-PR_FILES=""
-PAGE="1"
-while true; do
-  # this api allows 100 items per page
-  # github action uses `bash -e`. The last empty page will leads jq error, use `|| :` to ignore the error.
-  PR_PAGE_FILES=$(api_get "$PR_URL/files?&per_page=100&page=${PAGE}" | jq -er '.[] | .filename' || :)
-  if [ "${PR_PAGE_FILES}" = "" ]; then
-    break
-  fi
-  echo "Retrieving PR file list - ${PAGE} pages"
-  if [ ! "${PR_FILES}" = "" ]; then
-    # add the same new line format as jq output
-    PR_FILES="${PR_FILES}"$'\n'
-  fi
-  PR_FILES="${PR_FILES}${PR_PAGE_FILES}"
-  PAGE=$(( PAGE + 1 ))
-done
+PR_FILES=$(bot_get_all_changed_files ${PR_URL})
 NUM=$(echo "${PR_FILES}" | wc -l)
 echo "PR has ${NUM} changed files"
 


### PR DESCRIPTION
This PR makes bot (label and format) get all changed files when the number of files is larger than 100, and update label regex.

if the regex use some special character like `\.`, `|`, or `$`, I will put the quote.
Also, add `.github` match into `reg:ci-cd` 

The log of this bot:
https://github.com/yhmtsai/ginkgo/pull/4/checks?check_run_id=1646511807
The result:
https://github.com/yhmtsai/ginkgo/pull/4
The file used in that repo:
https://github.com/yhmtsai/ginkgo/blob/a0d711041c159483025e66b0e1ee83186f0e653e/.github/label.sh#L5