### PR TITLE
Fix solver kernel documentation and add memory estimates

### DIFF
--- a/core/solver/bicg.cpp
+++ b/core/solver/bicg.cpp
@@ -201,21 +201,21 @@ void Bicg<ValueType>::apply_impl(const LinOp *b, LinOp *x) const
             break;
         }
 
-        exec->run(bicg::make_step_1(p.get(), z.get(), p2.get(), z2.get(),
-                                    rho.get(), prev_rho.get(), &stop_status));
         // tmp = rho / prev_rho
         // p = z + tmp * p
         // p2 = z2 + tmp * p2
+        exec->run(bicg::make_step_1(p.get(), z.get(), p2.get(), z2.get(),
+                                    rho.get(), prev_rho.get(), &stop_status));
         system_matrix_->apply(p.get(), q.get());
         conj_trans_A->apply(p2.get(), q2.get());
         p2->compute_dot(q.get(), beta.get());
-        exec->run(bicg::make_step_2(dense_x, r.get(), r2.get(), p.get(),
-                                    q.get(), q2.get(), beta.get(), rho.get(),
-                                    &stop_status));
         // tmp = rho / beta
         // x = x + tmp * p
         // r = r - tmp * q
         // r2 = r2 - tmp * q2
+        exec->run(bicg::make_step_2(dense_x, r.get(), r2.get(), p.get(),
+                                    q.get(), q2.get(), beta.get(), rho.get(),
+                                    &stop_status));
         swap(prev_rho, rho);
     }
 }

--- a/core/solver/bicg.cpp
+++ b/core/solver/bicg.cpp
@@ -186,14 +186,15 @@ void Bicg<ValueType>::apply_impl(const LinOp *b, LinOp *x) const
 
     /* Memory movement summary:
      * Per iteration:
-     * 13.5n * values + matrix/preconditioner storage
+     * 14n * values + matrix/preconditioner storage
      * Two iterations:
-     * 27n * values + matrix/preconditioner storage + conj storage
+     * 28n * values + matrix/preconditioner storage + conj storage
      * 2x SpMV:                4n * values + storage + conj storage
      * 2x Preconditioner:      4n * values + storage + conj storage
      * 2x dot                  4n
      * 1x step 1 (axpys)       6n
      * 1x step 2 (axpys)       9n
+     * 1x norm2 residual        n
      */
     while (true) {
         get_preconditioner()->apply(r.get(), z.get());

--- a/core/solver/bicg.cpp
+++ b/core/solver/bicg.cpp
@@ -185,9 +185,6 @@ void Bicg<ValueType>::apply_impl(const LinOp *b, LinOp *x) const
     int iter = -1;
 
     /* Memory movement summary:
-     * Per iteration:
-     * 14n * values + matrix/preconditioner storage
-     * Two iterations:
      * 28n * values + matrix/preconditioner storage + conj storage
      * 2x SpMV:                4n * values + storage + conj storage
      * 2x Preconditioner:      4n * values + storage + conj storage

--- a/core/solver/bicg.cpp
+++ b/core/solver/bicg.cpp
@@ -184,6 +184,14 @@ void Bicg<ValueType>::apply_impl(const LinOp *b, LinOp *x) const
 
     int iter = -1;
 
+    /* Memory movement summary:
+     * 27n * values + 2 * matrix/preconditioner storage
+     * 2x SpMV:                4n * values + 2 * storage
+     * 2x Preconditioner:      4n * values + 2 * storage
+     * 2x dot                  4n
+     * 1x step 1 (axpys)       6n
+     * 1x step 2 (axpys)       9n
+     */
     while (true) {
         get_preconditioner()->apply(r.get(), z.get());
         conj_trans_preconditioner->apply(r2.get(), z2.get());

--- a/core/solver/bicg.cpp
+++ b/core/solver/bicg.cpp
@@ -185,9 +185,12 @@ void Bicg<ValueType>::apply_impl(const LinOp *b, LinOp *x) const
     int iter = -1;
 
     /* Memory movement summary:
-     * 27n * values + 2 * matrix/preconditioner storage
-     * 2x SpMV:                4n * values + 2 * storage
-     * 2x Preconditioner:      4n * values + 2 * storage
+     * Per iteration:
+     * 13.5n * values + matrix/preconditioner storage
+     * Two iterations:
+     * 27n * values + matrix/preconditioner storage + conj storage
+     * 2x SpMV:                4n * values + storage + conj storage
+     * 2x Preconditioner:      4n * values + storage + conj storage
      * 2x dot                  4n
      * 1x step 1 (axpys)       6n
      * 1x step 2 (axpys)       9n

--- a/core/solver/bicgstab.cpp
+++ b/core/solver/bicgstab.cpp
@@ -139,6 +139,9 @@ void Bicgstab<ValueType>::apply_impl(const LinOp *b, LinOp *x) const
     int iter = -1;
 
     /* Memory movement summary:
+     * Per iteration:
+     * 14.5n * values + matrix/preconditioner storage
+     * Two iterations:
      * 29n * values + 2 * matrix/preconditioner storage
      * 2x SpMV:                4n * values + 2 * storage
      * 2x Preconditioner:      4n * values + 2 * storage

--- a/core/solver/bicgstab.cpp
+++ b/core/solver/bicgstab.cpp
@@ -139,9 +139,6 @@ void Bicgstab<ValueType>::apply_impl(const LinOp *b, LinOp *x) const
     int iter = -1;
 
     /* Memory movement summary:
-     * Per iteration:
-     * 15.5n * values + matrix/preconditioner storage
-     * Two iterations:
      * 31n * values + 2 * matrix/preconditioner storage
      * 2x SpMV:                4n * values + 2 * storage
      * 2x Preconditioner:      4n * values + 2 * storage
@@ -181,7 +178,6 @@ void Bicgstab<ValueType>::apply_impl(const LinOp *b, LinOp *x) const
         exec->run(bicgstab::make_step_2(r.get(), s.get(), v.get(), rho.get(),
                                         alpha.get(), beta.get(), &stop_status));
 
-        ++iter;
         auto all_converged =
             stop_criterion->update()
                 .num_iterations(iter)
@@ -193,8 +189,6 @@ void Bicgstab<ValueType>::apply_impl(const LinOp *b, LinOp *x) const
             exec->run(bicgstab::make_finalize(dense_x, y.get(), alpha.get(),
                                               &stop_status));
         }
-        this->template log<log::Logger::iteration_complete>(this, iter,
-                                                            s.get());
         if (all_converged) {
             break;
         }

--- a/core/solver/bicgstab.cpp
+++ b/core/solver/bicgstab.cpp
@@ -152,19 +152,19 @@ void Bicgstab<ValueType>::apply_impl(const LinOp *b, LinOp *x) const
             break;
         }
 
+        // tmp = rho / prev_rho * alpha / omega
+        // p = r + tmp * (p - omega * v)
         exec->run(bicgstab::make_step_1(r.get(), p.get(), v.get(), rho.get(),
                                         prev_rho.get(), alpha.get(),
                                         omega.get(), &stop_status));
-        // tmp = rho / prev_rho * alpha / omega
-        // p = r + tmp * (p - omega * v)
 
         get_preconditioner()->apply(p.get(), y.get());
         system_matrix_->apply(y.get(), v.get());
         rr->compute_dot(v.get(), beta.get());
-        exec->run(bicgstab::make_step_2(r.get(), s.get(), v.get(), rho.get(),
-                                        alpha.get(), beta.get(), &stop_status));
         // alpha = rho / beta
         // s = r - alpha * v
+        exec->run(bicgstab::make_step_2(r.get(), s.get(), v.get(), rho.get(),
+                                        alpha.get(), beta.get(), &stop_status));
 
         ++iter;
         auto all_converged =
@@ -188,12 +188,12 @@ void Bicgstab<ValueType>::apply_impl(const LinOp *b, LinOp *x) const
         system_matrix_->apply(z.get(), t.get());
         s->compute_dot(t.get(), gamma.get());
         t->compute_dot(t.get(), beta.get());
-        exec->run(bicgstab::make_step_3(
-            dense_x, r.get(), s.get(), t.get(), y.get(), z.get(), alpha.get(),
-            beta.get(), gamma.get(), omega.get(), &stop_status));
         // omega = gamma / beta
         // x = x + alpha * y + omega * z
         // r = s - omega * t
+        exec->run(bicgstab::make_step_3(
+            dense_x, r.get(), s.get(), t.get(), y.get(), z.get(), alpha.get(),
+            beta.get(), gamma.get(), omega.get(), &stop_status));
         swap(prev_rho, rho);
     }
 }  // namespace solver

--- a/core/solver/bicgstab.cpp
+++ b/core/solver/bicgstab.cpp
@@ -137,6 +137,17 @@ void Bicgstab<ValueType>::apply_impl(const LinOp *b, LinOp *x) const
     rr->copy_from(r.get());
 
     int iter = -1;
+
+    /* Memory movement summary:
+     * 29n * values + 2 * matrix/preconditioner storage
+     * 2x SpMV:                4n * values + 2 * storage
+     * 2x Preconditioner:      4n * values + 2 * storage
+     * 3x dot                  6n
+     * 1x norm2                 n
+     * 1x step 1 (fused axpys) 4n
+     * 1x step 2 (axpy)        3n
+     * 1x step 3 (fused axpys) 7n
+     */
     while (true) {
         ++iter;
         this->template log<log::Logger::iteration_complete>(this, iter, r.get(),

--- a/core/solver/bicgstab.cpp
+++ b/core/solver/bicgstab.cpp
@@ -140,9 +140,9 @@ void Bicgstab<ValueType>::apply_impl(const LinOp *b, LinOp *x) const
 
     /* Memory movement summary:
      * Per iteration:
-     * 14.5n * values + matrix/preconditioner storage
+     * 15.5n * values + matrix/preconditioner storage
      * Two iterations:
-     * 29n * values + 2 * matrix/preconditioner storage
+     * 31n * values + 2 * matrix/preconditioner storage
      * 2x SpMV:                4n * values + 2 * storage
      * 2x Preconditioner:      4n * values + 2 * storage
      * 3x dot                  6n
@@ -150,6 +150,7 @@ void Bicgstab<ValueType>::apply_impl(const LinOp *b, LinOp *x) const
      * 1x step 1 (fused axpys) 4n
      * 1x step 2 (axpy)        3n
      * 1x step 3 (fused axpys) 7n
+     * 2x norm2 residual       2n
      */
     while (true) {
         ++iter;

--- a/core/solver/bicgstab.cpp
+++ b/core/solver/bicgstab.cpp
@@ -194,7 +194,7 @@ void Bicgstab<ValueType>::apply_impl(const LinOp *b, LinOp *x) const
                                               &stop_status));
         }
         this->template log<log::Logger::iteration_complete>(this, iter,
-                                                            r.get());
+                                                            s.get());
         if (all_converged) {
             break;
         }

--- a/core/solver/cg.cpp
+++ b/core/solver/cg.cpp
@@ -128,6 +128,14 @@ void Cg<ValueType>::apply_impl(const LinOp *b, LinOp *x) const
         x, r.get());
 
     int iter = -1;
+    /* Memory movement summary:
+     * 17n * values + matrix/preconditioner storage
+     * 1x SpMV:           2n * values + storage
+     * 1x Preconditioner: 2n * values + storage
+     * 2x dot             4n
+     * 1x step 1 (axpy)   3n
+     * 1x step 2 (axpys)  6n
+     */
     while (true) {
         get_preconditioner()->apply(r.get(), z.get());
         r->compute_dot(z.get(), rho.get());

--- a/core/solver/cg.cpp
+++ b/core/solver/cg.cpp
@@ -129,12 +129,13 @@ void Cg<ValueType>::apply_impl(const LinOp *b, LinOp *x) const
 
     int iter = -1;
     /* Memory movement summary:
-     * 17n * values + matrix/preconditioner storage
+     * 18n * values + matrix/preconditioner storage
      * 1x SpMV:           2n * values + storage
      * 1x Preconditioner: 2n * values + storage
      * 2x dot             4n
      * 1x step 1 (axpy)   3n
      * 1x step 2 (axpys)  6n
+     * 1x norm2 residual   n
      */
     while (true) {
         get_preconditioner()->apply(r.get(), z.get());

--- a/core/solver/cg.cpp
+++ b/core/solver/cg.cpp
@@ -144,17 +144,17 @@ void Cg<ValueType>::apply_impl(const LinOp *b, LinOp *x) const
             break;
         }
 
-        exec->run(cg::make_step_1(p.get(), z.get(), rho.get(), prev_rho.get(),
-                                  &stop_status));
         // tmp = rho / prev_rho
         // p = z + tmp * p
+        exec->run(cg::make_step_1(p.get(), z.get(), rho.get(), prev_rho.get(),
+                                  &stop_status));
         system_matrix_->apply(p.get(), q.get());
         p->compute_dot(q.get(), beta.get());
-        exec->run(cg::make_step_2(dense_x, r.get(), p.get(), q.get(),
-                                  beta.get(), rho.get(), &stop_status));
         // tmp = rho / beta
         // x = x + tmp * p
         // r = r - tmp * q
+        exec->run(cg::make_step_2(dense_x, r.get(), p.get(), q.get(),
+                                  beta.get(), rho.get(), &stop_status));
         swap(prev_rho, rho);
     }
 }

--- a/core/solver/cgs.cpp
+++ b/core/solver/cgs.cpp
@@ -139,6 +139,9 @@ void Cgs<ValueType>::apply_impl(const LinOp *b, LinOp *x) const
 
     int iter = 0;
     /* Memory movement summary:
+     * Per iteration:
+     * 13.5n * values + matrix/preconditioner storage
+     * Two iterations:
      * 27n * values + 2 * matrix/preconditioner storage
      * 2x SpMV:                4n * values + 2 * storage
      * 2x Preconditioner:      4n * values + 2 * storage

--- a/core/solver/cgs.cpp
+++ b/core/solver/cgs.cpp
@@ -140,15 +140,16 @@ void Cgs<ValueType>::apply_impl(const LinOp *b, LinOp *x) const
     int iter = 0;
     /* Memory movement summary:
      * Per iteration:
-     * 13.5n * values + matrix/preconditioner storage
+     * 14n * values + matrix/preconditioner storage
      * Two iterations:
-     * 27n * values + 2 * matrix/preconditioner storage
+     * 28n * values + 2 * matrix/preconditioner storage
      * 2x SpMV:                4n * values + 2 * storage
      * 2x Preconditioner:      4n * values + 2 * storage
      * 2x dot                  4n
      * 1x step 1 (fused axpys) 5n
      * 1x step 2 (fused axpys) 4n
      * 1x step 3 (axpys)       6n
+     * 1x norm2 residual        n
      */
     while (true) {
         r->compute_dot(r_tld.get(), rho.get());

--- a/core/solver/cgs.cpp
+++ b/core/solver/cgs.cpp
@@ -138,6 +138,15 @@ void Cgs<ValueType>::apply_impl(const LinOp *b, LinOp *x) const
     r_tld->copy_from(r.get());
 
     int iter = 0;
+    /* Memory movement summary:
+     * 27n * values + 2 * matrix/preconditioner storage
+     * 2x SpMV:                4n * values + 2 * storage
+     * 2x Preconditioner:      4n * values + 2 * storage
+     * 2x dot                  4n
+     * 1x step 1 (fused axpys) 5n
+     * 1x step 2 (fused axpys) 4n
+     * 1x step 3 (axpys)       6n
+     */
     while (true) {
         r->compute_dot(r_tld.get(), rho.get());
         // beta = rho / rho_prev

--- a/core/solver/cgs.cpp
+++ b/core/solver/cgs.cpp
@@ -139,9 +139,6 @@ void Cgs<ValueType>::apply_impl(const LinOp *b, LinOp *x) const
 
     int iter = 0;
     /* Memory movement summary:
-     * Per iteration:
-     * 14n * values + matrix/preconditioner storage
-     * Two iterations:
      * 28n * values + 2 * matrix/preconditioner storage
      * 2x SpMV:                4n * values + 2 * storage
      * 2x Preconditioner:      4n * values + 2 * storage
@@ -169,9 +166,6 @@ void Cgs<ValueType>::apply_impl(const LinOp *b, LinOp *x) const
                                    alpha.get(), rho.get(), gamma.get(),
                                    &stop_status));
 
-        ++iter;
-        this->template log<log::Logger::iteration_complete>(this, iter, r.get(),
-                                                            dense_x);
         get_preconditioner()->apply(t.get(), u_hat.get());
         system_matrix_->apply(u_hat.get(), t.get());
         // r = r - alpha * t

--- a/core/solver/fcg.cpp
+++ b/core/solver/fcg.cpp
@@ -131,12 +131,13 @@ void Fcg<ValueType>::apply_impl(const LinOp *b, LinOp *x) const
 
     int iter = -1;
     /* Memory movement summary:
-     * 20n * values + matrix/preconditioner storage
+     * 21n * values + matrix/preconditioner storage
      * 1x SpMV:                2n * values + storage
      * 1x Preconditioner:      2n * values + storage
      * 3x dot                  6n
      * 1x step 1 (axpy)        3n
      * 1x step 2 (fused axpys) 7n
+     * 1x norm2 residual        n
      */
     while (true) {
         get_preconditioner()->apply(r.get(), z.get());

--- a/core/solver/fcg.cpp
+++ b/core/solver/fcg.cpp
@@ -130,6 +130,14 @@ void Fcg<ValueType>::apply_impl(const LinOp *b, LinOp *x) const
         x, r.get());
 
     int iter = -1;
+    /* Memory movement summary:
+     * 20n * values + matrix/preconditioner storage
+     * 1x SpMV:                2n * values + storage
+     * 1x Preconditioner:      2n * values + storage
+     * 3x dot                  6n
+     * 1x step 1 (axpy)        3n
+     * 1x step 2 (fused axpys) 7n
+     */
     while (true) {
         get_preconditioner()->apply(r.get(), z.get());
         r->compute_dot(z.get(), rho.get());

--- a/core/solver/fcg.cpp
+++ b/core/solver/fcg.cpp
@@ -147,19 +147,19 @@ void Fcg<ValueType>::apply_impl(const LinOp *b, LinOp *x) const
             break;
         }
 
-        exec->run(fcg::make_step_1(p.get(), z.get(), rho_t.get(),
-                                   prev_rho.get(), &stop_status));
         // tmp = rho_t / prev_rho
         // p = z + tmp * p
+        exec->run(fcg::make_step_1(p.get(), z.get(), rho_t.get(),
+                                   prev_rho.get(), &stop_status));
         system_matrix_->apply(p.get(), q.get());
         p->compute_dot(q.get(), beta.get());
-        exec->run(fcg::make_step_2(dense_x, r.get(), t.get(), p.get(), q.get(),
-                                   beta.get(), rho.get(), &stop_status));
         // tmp = rho / beta
         // [prev_r = r] in registers
         // x = x + tmp * p
         // r = r - tmp * q
         // t = r - [prev_r]
+        exec->run(fcg::make_step_2(dense_x, r.get(), t.get(), p.get(), q.get(),
+                                   beta.get(), rho.get(), &stop_status));
         swap(prev_rho, rho);
     }
 }

--- a/core/solver/gmres.cpp
+++ b/core/solver/gmres.cpp
@@ -159,6 +159,17 @@ void Gmres<ValueType>::apply_impl(const LinOp *b, LinOp *x) const
     auto after_preconditioner =
         matrix::Dense<ValueType>::create_with_config_of(dense_x);
 
+    /* Memory movement summary for iteration in Krylov subspace of dimension d
+     * (== krylov_dim / 2 on average), ignoring restarts:
+     * (5d+7)n * values + matrix/preconditioner storage
+     * 1x SpMV:                2n * values + storage
+     * 1x Preconditioner:      2n * values + storage
+     * MGS:               (5d+3)n
+     *   dx dot               2dn
+     *   dx axpys             3dn
+     *   1x norm2               n
+     *   1x scal               2n
+     */
     while (true) {
         ++total_iter;
         this->template log<log::Logger::iteration_complete>(

--- a/core/solver/gmres.cpp
+++ b/core/solver/gmres.cpp
@@ -169,7 +169,7 @@ void Gmres<ValueType>::apply_impl(const LinOp *b, LinOp *x) const
      *       1x norm2               n
      *       1x scal               2n
      * Restart:         (1+14/d)n  (every dth iteration)
-     *       1x gemm           (d+1)n
+     *       1x gemv           (d+1)n
      *       1x Preconditioner     2n * values + storage
      *       1x axpy               3n
      *       1x copy               2n

--- a/core/solver/gmres.cpp
+++ b/core/solver/gmres.cpp
@@ -160,7 +160,7 @@ void Gmres<ValueType>::apply_impl(const LinOp *b, LinOp *x) const
         matrix::Dense<ValueType>::create_with_config_of(dense_x);
 
     /* Memory movement summary for average iteration with krylov_dim d:
-     * (5/2d+15/2)n * values + matrix/preconditioner storage
+     * (5/2d+15/2+12/d)n * values + (1+1/d) * matrix/preconditioner storage
      * 1x SpMV:                2n * values + storage
      * 1x Preconditioner:      2n * values + storage
      * MGS:           (5/2d+5/2)n = sum k=0 to d-1 of (5k+5)n/d
@@ -168,9 +168,13 @@ void Gmres<ValueType>::apply_impl(const LinOp *b, LinOp *x) const
      *       1x axpys          3(k+1)n in iteration k (0-based)
      *       1x norm2               n
      *       1x scal               2n
-     * Restart (average):       n = approx (d+1)n/d
+     * Restart:         (1+12/d)n  (every dth iteration)
      *       1x gemm           (d+1)n
-     *       plus some O(n) terms we can ignore for larger d
+     *       1x Preconditioner     2n * values + storage
+     *       1x axpy               3n
+     *       1x Advanced SpMV      3n * values + storage
+     *       1x norm2               n
+     *       2x scal               2n
      */
     while (true) {
         ++total_iter;

--- a/core/solver/gmres.cpp
+++ b/core/solver/gmres.cpp
@@ -160,21 +160,22 @@ void Gmres<ValueType>::apply_impl(const LinOp *b, LinOp *x) const
         matrix::Dense<ValueType>::create_with_config_of(dense_x);
 
     /* Memory movement summary for average iteration with krylov_dim d:
-     * (5/2d+15/2+12/d)n * values + (1+1/d) * matrix/preconditioner storage
+     * (5/2d+21/2+14/d)n * values + (1+1/d) * matrix/preconditioner storage
      * 1x SpMV:                2n * values + storage
      * 1x Preconditioner:      2n * values + storage
-     * MGS:           (5/2d+5/2)n = sum k=0 to d-1 of (5k+5)n/d
+     * MGS:          (5/2d+11/2)n = sum k=0 to d-1 of (5k+8)n/d
      *       1x dots           2(k+1)n in iteration k (0-based)
      *       1x axpys          3(k+1)n in iteration k (0-based)
      *       1x norm2               n
      *       1x scal               2n
-     * Restart:         (1+12/d)n  (every dth iteration)
+     * Restart:         (1+14/d)n  (every dth iteration)
      *       1x gemm           (d+1)n
      *       1x Preconditioner     2n * values + storage
      *       1x axpy               3n
+     *       1x copy               2n
      *       1x Advanced SpMV      3n * values + storage
      *       1x norm2               n
-     *       2x scal               2n
+     *       1x scal               2n
      */
     while (true) {
         ++total_iter;

--- a/core/solver/idr.cpp
+++ b/core/solver/idr.cpp
@@ -205,6 +205,10 @@ void Idr<ValueType>::iterate(const LinOp *b, LinOp *x) const
         subspace_vectors->apply(residual.get(), f.get());
 
         for (size_type k = 0; k < subspace_dim_; k++) {
+            ++total_iter;
+            this->template log<log::Logger::iteration_complete>(
+                this, total_iter, residual.get(), dense_x);
+
             // c = M \ f = (c_1, ..., c_s)^T
             // v = residual - c_k * g_k - ... - c_s * g_s
             exec->run(idr::make_step_1(nrhs, k, m.get(), f.get(),

--- a/core/solver/idr.cpp
+++ b/core/solver/idr.cpp
@@ -172,14 +172,17 @@ void Idr<ValueType>::iterate(const LinOp *b, LinOp *x) const
     int total_iter = -1;
 
     /* Memory movement summary for iteration with subspace dimension s
-     * (11/2s^2+27/2d+...)n * values + (s+1) * matrix/preconditioner storage
+     * Per iteration:
+     * (11/2s+10+5/(s+1))n * values + matrix/preconditioner storage
+     * For (s+1) iterations:
+     * (11/2s^2+31/2s+15)n * values + (s+1) * matrix/preconditioner storage
      * dx SpMV:                    2(s+1)n * values + (s+1) * storage
      * dx Preconditioner:          2(s+1)n * values + (s+1) * storage
      * 1x multidot (gemm)           (s+1)n
      * dx step 1 (fused axpys) s(s/2+5/2)n = approx 1 + sum k=[0,s) of (s-k+1)n
      * dx step 2 (fused axpys) s(s/2+5/2)n = approx 1 + sum k=[0,s) of (s-k+1)n
-     * dx step 3:             s(9/2s+7/2)n = sum k=[0,s) of (8k+s-k+1+6)n
-     *       1x orthogonalize g+u          8kn in iteration k (0-based)
+     * dx step 3:            s(9/2s+11/2)n = sum k=[0,s) of (8k+2+s-k+1+6)n
+     *       1x orthogonalize g+u      (8k+2)n in iteration k (0-based)
      *       1x multidot (gemm)       (s-k+1)n in iteration k (0-based)
      *       2x axpy                        6n
      * 1x dot                           2n
@@ -232,6 +235,7 @@ void Idr<ValueType>::iterate(const LinOp *b, LinOp *x) const
             //     g_k -= alpha * g_i
             //     u_k -= alpha * u_i
             // end for
+            // store g_k to g
             // for i = [k,s)
             //     m_i,k = p^H_i * g_k
             // end for

--- a/core/solver/idr.cpp
+++ b/core/solver/idr.cpp
@@ -173,9 +173,7 @@ void Idr<ValueType>::iterate(const LinOp *b, LinOp *x) const
 
     /* Memory movement summary for iteration with subspace dimension s
      * Per iteration:
-     * (11/2s+10+7/(s+1))n * values + matrix/preconditioner storage
-     * For (s+1) iterations:
-     * (11/2s^2+31/2s+17)n * values + (s+1) * matrix/preconditioner storage
+     * (11/2s^2+31/2s+18)n * values + (s+1) * matrix/preconditioner storage
      * (s+1)x SpMV:                2(s+1)n * values + (s+1) * storage
      * (s+1)x Preconditioner:      2(s+1)n * values + (s+1) * storage
      * 1x multidot (gemv)           (s+1)n
@@ -189,6 +187,7 @@ void Idr<ValueType>::iterate(const LinOp *b, LinOp *x) const
      * 2x norm2                         2n
      * 1x scale                         2n
      * 2x axpy                          6n
+     * 1x norm2 residual                 n
      */
     while (true) {
         ++total_iter;
@@ -208,10 +207,6 @@ void Idr<ValueType>::iterate(const LinOp *b, LinOp *x) const
         subspace_vectors->apply(residual.get(), f.get());
 
         for (size_type k = 0; k < subspace_dim_; k++) {
-            ++total_iter;
-            this->template log<log::Logger::iteration_complete>(
-                this, total_iter, residual.get(), dense_x);
-
             // c = M \ f = (c_1, ..., c_s)^T
             // v = residual - sum i=[k,s) of (c_i * g_i)
             exec->run(idr::make_step_1(nrhs, k, m.get(), f.get(),

--- a/core/solver/idr.cpp
+++ b/core/solver/idr.cpp
@@ -173,22 +173,22 @@ void Idr<ValueType>::iterate(const LinOp *b, LinOp *x) const
 
     /* Memory movement summary for iteration with subspace dimension s
      * Per iteration:
-     * (11/2s+10+5/(s+1))n * values + matrix/preconditioner storage
+     * (11/2s+10+7/(s+1))n * values + matrix/preconditioner storage
      * For (s+1) iterations:
-     * (11/2s^2+31/2s+15)n * values + (s+1) * matrix/preconditioner storage
-     * dx SpMV:                    2(s+1)n * values + (s+1) * storage
-     * dx Preconditioner:          2(s+1)n * values + (s+1) * storage
-     * 1x multidot (gemm)           (s+1)n
-     * dx step 1 (fused axpys) s(s/2+5/2)n = approx 1 + sum k=[0,s) of (s-k+1)n
-     * dx step 2 (fused axpys) s(s/2+5/2)n = approx 1 + sum k=[0,s) of (s-k+1)n
-     * dx step 3:            s(9/2s+11/2)n = sum k=[0,s) of (8k+2+s-k+1+6)n
+     * (11/2s^2+31/2s+17)n * values + (s+1) * matrix/preconditioner storage
+     * (s+1)x SpMV:                2(s+1)n * values + (s+1) * storage
+     * (s+1)x Preconditioner:      2(s+1)n * values + (s+1) * storage
+     * 1x multidot (gemv)           (s+1)n
+     * sx step 1 (fused axpys) s(s/2+5/2)n = sum k=[0,s) of (s-k+2)n
+     * sx step 2 (fused axpys) s(s/2+5/2)n = sum k=[0,s) of (s-k+2)n
+     * sx step 3:            s(9/2s+11/2)n = sum k=[0,s) of (8k+2+s-k+1+6)n
      *       1x orthogonalize g+u      (8k+2)n in iteration k (0-based)
-     *       1x multidot (gemm)       (s-k+1)n in iteration k (0-based)
+     *       1x multidot (gemv)       (s-k+1)n in iteration k (0-based)
      *       2x axpy                        6n
      * 1x dot                           2n
      * 2x norm2                         2n
      * 1x scale                         2n
-     * 2x axpy                          4n
+     * 2x axpy                          6n
      */
     while (true) {
         ++total_iter;

--- a/cuda/solver/idr_kernels.cu
+++ b/cuda/solver/idr_kernels.cu
@@ -33,8 +33,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "core/solver/idr_kernels.hpp"
 
 
+#include <ctime>
 #include <random>
-#include <time.h>
 
 
 #include <ginkgo/core/base/exception_helpers.hpp>

--- a/hip/solver/idr_kernels.hip.cpp
+++ b/hip/solver/idr_kernels.hip.cpp
@@ -33,8 +33,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "core/solver/idr_kernels.hpp"
 
 
+#include <ctime>
 #include <random>
-#include <time.h>
 
 
 #include <hip/hip_runtime.h>

--- a/omp/solver/idr_kernels.cpp
+++ b/omp/solver/idr_kernels.cpp
@@ -34,6 +34,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
 #include <algorithm>
+#include <ctime>
 #include <random>
 
 

--- a/reference/solver/idr_kernels.cpp
+++ b/reference/solver/idr_kernels.cpp
@@ -34,6 +34,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
 #include <algorithm>
+#include <ctime>
 #include <random>
 
 


### PR DESCRIPTION
The CGS documentation for step_2 was in the wrong line.

EDIT by Tobias: We decided to repurpose this PR to include memory estimates based on the solver kernel implementations. If you have some time, please check our computations - especially GMRES and IDR are challenging.

- [x] BiCG
- [x] BiCGSTAB
- [x] CG
- [x] CGS
- [x] FCG
- [x] GMRES
- [x] IDR