### PR TITLE
Fix machine_topology overflow

### DIFF
--- a/core/devices/machine_topology.cpp
+++ b/core/devices/machine_topology.cpp
@@ -249,7 +249,7 @@ void MachineTopology::load_objects(
         hwloc_obj_type_snprintf(ances_type, sizeof(ances_type), ancestor, 0);
         vector.back().ancestor_type = std::string(ances_type);
         // Write the PCI Bus ID from the object info.
-        char pci_bus_id[13];
+        char pci_bus_id[14];
         snprintf(pci_bus_id, sizeof(pci_bus_id), "%04x:%02x:%02x.%01x",
                  obj->attr->pcidev.domain, obj->attr->pcidev.bus,
                  obj->attr->pcidev.dev, obj->attr->pcidev.func);


### PR DESCRIPTION
A compiler warning for snprintf pointed to a buffer overflow in the PCI bus ID formatting in machine_topology.cpp
snprintf writes a `\0`-terminated string, so we need one more entry than the format string outputs.