### PR TITLE
Multidimensional row-major and column-major accessors

### DIFF
--- a/core/test/base/range_accessors.cpp
+++ b/core/test/base/range_accessors.cpp
@@ -275,13 +275,13 @@ TEST_F(RowMajorAccessor3d, CanAssignSubranges)
 }
 
 
-class ColMajorAccessor3d : public ::testing::Test {
+class BlockColMajorAccessor3d : public ::testing::Test {
 protected:
     using span = gko::span;
     static constexpr gko::size_type dimensionality{3};
 
-    using col_major_range =
-        gko::range<gko::accessor::col_major<int, dimensionality>>;
+    using blk_col_major_range =
+        gko::range<gko::accessor::block_col_major<int, dimensionality>>;
 
     // clang-format off
     int data[2 * 3 * 4]{
@@ -308,14 +308,14 @@ protected:
     // clang-format on
     const gko::dim<dimensionality> dim1{2, 3, 4};
     const gko::dim<dimensionality> dim2{2, 2, 3};
-    col_major_range default_r{data, dim1};
-    col_major_range custom_r{
+    blk_col_major_range default_r{data, dim1};
+    blk_col_major_range custom_r{
         data, dim2,
         std::array<const gko::size_type, dimensionality - 1>{12, 3}};
 };
 
 
-TEST_F(ColMajorAccessor3d, ComputesCorrectStride)
+TEST_F(BlockColMajorAccessor3d, ComputesCorrectStride)
 {
     auto range_stride = default_r.get_accessor().stride;
     auto check_stride = std::array<const gko::size_type, 2>{12, 3};
@@ -324,7 +324,7 @@ TEST_F(ColMajorAccessor3d, ComputesCorrectStride)
 }
 
 
-TEST_F(ColMajorAccessor3d, CanAccessData)
+TEST_F(BlockColMajorAccessor3d, CanAccessData)
 {
     EXPECT_EQ(default_r(0, 0, 0), 1);
     EXPECT_EQ(custom_r(0, 0, 0), 1);
@@ -339,7 +339,7 @@ TEST_F(ColMajorAccessor3d, CanAccessData)
 }
 
 
-TEST_F(ColMajorAccessor3d, CanWriteData)
+TEST_F(BlockColMajorAccessor3d, CanWriteData)
 {
     default_r(0, 0, 0) = 4;
     custom_r(1, 1, 1) = 100;
@@ -351,7 +351,7 @@ TEST_F(ColMajorAccessor3d, CanWriteData)
 }
 
 
-TEST_F(ColMajorAccessor3d, CanCreateSubrange)
+TEST_F(BlockColMajorAccessor3d, CanCreateSubrange)
 {
     auto subr = custom_r(span{0, 2}, span{1, 2}, span{1, 3});
 
@@ -362,7 +362,7 @@ TEST_F(ColMajorAccessor3d, CanCreateSubrange)
 }
 
 
-TEST_F(ColMajorAccessor3d, CanCreateRowVector)
+TEST_F(BlockColMajorAccessor3d, CanCreateRowVector)
 {
     auto subr = default_r(1u, 2u, span{0, 2});
 
@@ -371,7 +371,7 @@ TEST_F(ColMajorAccessor3d, CanCreateRowVector)
 }
 
 
-TEST_F(ColMajorAccessor3d, CanCreateColumnVector)
+TEST_F(BlockColMajorAccessor3d, CanCreateColumnVector)
 {
     auto subr = default_r(span{0u, 2u}, 1u, 3u);
 
@@ -380,7 +380,7 @@ TEST_F(ColMajorAccessor3d, CanCreateColumnVector)
 }
 
 
-TEST_F(ColMajorAccessor3d, CanAssignValues)
+TEST_F(BlockColMajorAccessor3d, CanAssignValues)
 {
     default_r(1, 1, 1) = default_r(0, 0, 0);
 
@@ -388,7 +388,7 @@ TEST_F(ColMajorAccessor3d, CanAssignValues)
 }
 
 
-TEST_F(ColMajorAccessor3d, CanAssignSubranges)
+TEST_F(BlockColMajorAccessor3d, CanAssignSubranges)
 {
     default_r(1u, span{0, 2}, span{0, 3}) =
         custom_r(0u, span{0, 2}, span{0, 3});

--- a/core/test/base/range_accessors.cpp
+++ b/core/test/base/range_accessors.cpp
@@ -287,15 +287,15 @@ protected:
     int data[2 * 3 * 4]{
          1, 3, 5,
          2, 4, 6,
-		-1,-2,-3,
-		11,12,13,
+        -1,-2,-3,
+        11,12,13,
 
-		21,25,29,
-		22,26,30,
-		23,27,31,
-		24,28,32
+        21,25,29,
+        22,26,30,
+        23,27,31,
+        24,28,32
 
-		/* This matrix actually looks like
+        /* This matrix actually looks like
         1, 2, -1, 11,
         3, 4, -2, 12,
         5, 6, -3, 13,
@@ -303,7 +303,7 @@ protected:
         21, 22, 23, 24,
         25, 26, 27, 28,
         29, 30, 31, 32
-	    */
+        */
     };
     // clang-format on
     const gko::dim<dimensionality> dim1{2, 3, 4};

--- a/core/test/base/range_accessors.cpp
+++ b/core/test/base/range_accessors.cpp
@@ -62,6 +62,35 @@ protected:
 };
 
 
+TEST_F(RowMajorAccessor, CanCreateWithDim)
+{
+    row_major_int_range r2{data, gko::dim<2>{3, 2}, 3u};
+
+    EXPECT_EQ(r2(0, 0), 1);
+    EXPECT_EQ(r2(0, 1), 2);
+    EXPECT_EQ(r2(1, 0), 3);
+    EXPECT_EQ(r2(1, 1), 4);
+    EXPECT_EQ(r2(2, 0), 5);
+    EXPECT_EQ(r2(2, 1), 6);
+}
+
+
+TEST_F(RowMajorAccessor, CanCreateDefaultStride)
+{
+    row_major_int_range r2{data, gko::dim<2>{3, 3}};
+
+    EXPECT_EQ(r2(0, 0), 1);
+    EXPECT_EQ(r2(0, 1), 2);
+    EXPECT_EQ(r2(0, 2), -1);
+    EXPECT_EQ(r2(1, 0), 3);
+    EXPECT_EQ(r2(1, 1), 4);
+    EXPECT_EQ(r2(1, 2), -2);
+    EXPECT_EQ(r2(2, 0), 5);
+    EXPECT_EQ(r2(2, 1), 6);
+    EXPECT_EQ(r2(2, 2), -3);
+}
+
+
 TEST_F(RowMajorAccessor, CanAccessData)
 {
     EXPECT_EQ(r(0, 0), 1);
@@ -132,6 +161,117 @@ TEST_F(RowMajorAccessor, CanAssignSubranges)
     EXPECT_EQ(data[6], 5);
     EXPECT_EQ(data[7], 6);
     EXPECT_EQ(data[8], -3);
+}
+
+
+class RowMajorAccessor3d : public ::testing::Test {
+protected:
+    using span = gko::span;
+    static constexpr gko::size_type dimensionality{3};
+
+    using row_major_int_range =
+        gko::range<gko::accessor::row_major<int, dimensionality>>;
+
+    // clang-format off
+    int data[2 * 3 * 4]{
+        1, 2, -1, 11,
+        3, 4, -2, 12,
+        5, 6, -3, 13,
+
+        21, 22, 23, 24,
+        25, 26, 27, 28,
+        29, 30, 31, 32
+    };
+    // clang-format on
+    const gko::dim<dimensionality> dim1{2, 3, 4};
+    const gko::dim<dimensionality> dim2{2, 2, 3};
+    row_major_int_range default_r{data, dim1};
+    row_major_int_range custom_r{
+        data, dim2,
+        std::array<const gko::size_type, dimensionality - 1>{12, 4}};
+};
+
+
+TEST_F(RowMajorAccessor3d, CanAccessData)
+{
+    EXPECT_EQ(default_r(0, 0, 0), 1);
+    EXPECT_EQ(custom_r(0, 0, 0), 1);
+    EXPECT_EQ(default_r(0, 1, 0), 3);
+    EXPECT_EQ(custom_r(0, 1, 0), 3);
+    EXPECT_EQ(default_r(0, 1, 3), 12);
+    EXPECT_EQ(default_r(0, 2, 2), -3);
+    EXPECT_EQ(default_r(1, 2, 1), 30);
+    EXPECT_EQ(default_r(1, 2, 2), 31);
+    EXPECT_EQ(default_r(1, 2, 3), 32);
+}
+
+
+TEST_F(RowMajorAccessor3d, CanWriteData)
+{
+    default_r(0, 0, 0) = 4;
+    custom_r(1, 1, 1) = 100;
+
+    EXPECT_EQ(default_r(0, 0, 0), 4);
+    EXPECT_EQ(custom_r(0, 0, 0), 4);
+    EXPECT_EQ(default_r(1, 1, 1), 100);
+    EXPECT_EQ(custom_r(1, 1, 1), 100);
+}
+
+
+TEST_F(RowMajorAccessor3d, CanCreateSubrange)
+{
+    auto subr = custom_r(span{0, 2}, span{1, 2}, span{1, 3});
+
+    EXPECT_EQ(subr(0, 0, 0), 4);
+    EXPECT_EQ(subr(0, 0, 1), -2);
+    EXPECT_EQ(subr(1, 0, 0), 26);
+    EXPECT_EQ(subr(1, 0, 1), 27);
+}
+
+
+TEST_F(RowMajorAccessor3d, CanCreateRowVector)
+{
+    auto subr = default_r(1u, 2u, span{0, 2});
+
+    EXPECT_EQ(subr(0, 0, 0), 29);
+    EXPECT_EQ(subr(0, 0, 1), 30);
+}
+
+
+TEST_F(RowMajorAccessor3d, CanCreateColumnVector)
+{
+    auto subr = default_r(span{0u, 2u}, 1u, 3u);
+
+    EXPECT_EQ(subr(0, 0, 0), 12);
+    EXPECT_EQ(subr(1, 0, 0), 28);
+}
+
+
+TEST_F(RowMajorAccessor3d, CanAssignValues)
+{
+    default_r(1, 1, 1) = default_r(0, 0, 0);
+
+    EXPECT_EQ(data[17], 1);
+}
+
+
+TEST_F(RowMajorAccessor3d, CanAssignSubranges)
+{
+    default_r(1u, span{0, 2}, span{0, 3}) =
+        custom_r(0u, span{0, 2}, span{0, 3});
+
+    EXPECT_EQ(data[12], 1);
+    EXPECT_EQ(data[13], 2);
+    EXPECT_EQ(data[14], -1);
+    EXPECT_EQ(data[15], 24);
+    EXPECT_EQ(data[16], 3);
+    EXPECT_EQ(data[17], 4);
+    EXPECT_EQ(data[18], -2);
+    EXPECT_EQ(data[19], 28);
+    EXPECT_EQ(data[20], 29);
+    EXPECT_EQ(data[21], 30);
+    EXPECT_EQ(data[22], 31);
+    EXPECT_EQ(data[23], 32);
 }
 
 

--- a/include/ginkgo/core/base/range_accessors.hpp
+++ b/include/ginkgo/core/base/range_accessors.hpp
@@ -73,7 +73,7 @@ struct row_major_helper_s {
     compute(const std::array<ValueType, total_dim> &size,
             const std::array<ValueType, (total_dim > 1 ? total_dim - 1 : 0)>
                 &stride,
-            FirstType first, Indices &&...idxs)
+            FirstType first, Indices &&... idxs)
     {
         return GKO_ASSERT(first < size[dim_idx]),
                first * stride[dim_idx] +
@@ -103,7 +103,7 @@ template <typename ValueType, size_type total_dim, typename... Indices>
 constexpr GKO_ATTRIBUTES ValueType compute_storage_index(
     const std::array<ValueType, total_dim> &size,
     const std::array<ValueType, (total_dim > 1 ? total_dim - 1 : 0)> &stride,
-    Indices &&...idxs)
+    Indices &&... idxs)
 {
     return row_major_helper_s<ValueType, total_dim>::compute(
         size, stride, std::forward<Indices>(idxs)...);
@@ -120,7 +120,8 @@ constexpr GKO_ATTRIBUTES std::enable_if_t<iter == N, int> spans_in_size(
 template <size_type iter, typename ValueType, size_type N, typename First,
           typename... Remaining>
 constexpr GKO_ATTRIBUTES std::enable_if_t<(iter < N), int> spans_in_size(
-    const std::array<ValueType, N> &size, First first, Remaining &&...remaining)
+    const std::array<ValueType, N> &size, First first,
+    Remaining &&... remaining)
 {
     static_assert(sizeof...(Remaining) + 1 == N - iter,
                   "Number of remaining spans must be equal to N - iter");
@@ -132,7 +133,7 @@ constexpr GKO_ATTRIBUTES std::enable_if_t<(iter < N), int> spans_in_size(
 
 template <typename ValueType, size_type N, typename... Spans>
 constexpr GKO_ATTRIBUTES int validate_spans(
-    const std::array<ValueType, N> &size, Spans &&...spans)
+    const std::array<ValueType, N> &size, Spans &&... spans)
 {
     return detail::spans_in_size<0>(size, std::forward<Spans>(spans)...);
 }
@@ -164,7 +165,7 @@ using are_span_compatible = are_span_compatible_impl<false, Args...>;
 template <typename ValueType, size_type N, size_type current, typename... Dims>
 constexpr GKO_ATTRIBUTES
     std::enable_if_t<(current == N), std::array<ValueType, N>>
-    to_array_impl(const dim<N> &size, Dims &&...dims)
+    to_array_impl(const dim<N> &size, Dims &&... dims)
 {
     static_assert(sizeof...(Dims) == N,
                   "Number of arguments must match dimensionality!");
@@ -175,7 +176,7 @@ constexpr GKO_ATTRIBUTES
 template <typename ValueType, size_type N, size_type current, typename... Dims>
 constexpr GKO_ATTRIBUTES
     std::enable_if_t<(current < N), std::array<ValueType, N>>
-    to_array_impl(const dim<N> &size, Dims &&...dims)
+    to_array_impl(const dim<N> &size, Dims &&... dims)
 {
     return to_array_impl<ValueType, N, current + 1>(
         size, std::forward<Dims>(dims)..., size[current]);
@@ -209,7 +210,7 @@ constexpr GKO_ATTRIBUTES
     std::enable_if_t<N == 0 || (iter == N && iter == sizeof...(Args) + 1),
                      std::array<ValueType, N == 0 ? 0 : N - 1>>
     compute_default_stride_array_impl(const std::array<ValueType, N> &,
-                                      Args &&...args)
+                                      Args &&... args)
 {
     return {{std::forward<Args>(args)...}};
 }
@@ -218,7 +219,7 @@ template <size_type iter = 1, typename ValueType, size_type N, typename... Args>
 constexpr GKO_ATTRIBUTES std::enable_if_t<
     (iter < N) && (iter == sizeof...(Args) + 1), std::array<ValueType, N - 1>>
 compute_default_stride_array_impl(const std::array<ValueType, N> &size,
-                                  Args &&...args)
+                                  Args &&... args)
 {
     return compute_default_stride_array_impl<iter + 1>(
         size, std::forward<Args>(args)..., mult_dim_upwards_impl<iter>(size));
@@ -237,7 +238,7 @@ constexpr GKO_ATTRIBUTES
 template <size_type iter, typename ValueType, size_type N, typename Callable,
           typename... Indices>
 GKO_ATTRIBUTES std::enable_if_t<iter == N> multidim_for_each_impl(
-    const std::array<ValueType, N> &, Callable callable, Indices &&...indices)
+    const std::array<ValueType, N> &, Callable callable, Indices &&... indices)
 {
     static_assert(iter == sizeof...(Indices),
                   "Number arguments must match current iteration!");
@@ -248,7 +249,7 @@ template <size_type iter, typename ValueType, size_type N, typename Callable,
           typename... Indices>
 GKO_ATTRIBUTES std::enable_if_t<(iter < N)> multidim_for_each_impl(
     const std::array<ValueType, N> &size, Callable &&callable,
-    Indices &&...indices)
+    Indices &&... indices)
 {
     static_assert(iter == sizeof...(Indices),
                   "Number arguments must match current iteration!");
@@ -372,7 +373,7 @@ public:
     template <typename... Indices>
     constexpr GKO_ATTRIBUTES
         std::enable_if_t<are_all_integral<Indices...>::value, value_type &>
-        operator()(Indices &&...indices) const
+        operator()(Indices &&... indices) const
     {
         return data[detail::compute_storage_index(
             lengths, stride, std::forward<Indices>(indices)...)];
@@ -627,6 +628,303 @@ public:
      * Distance between consecutive rows.
      */
     const size_type stride;
+};
+
+
+namespace detail_colmajor {
+
+
+/**
+ * This helper runs from first to last dimension in order to compute the index.
+ * The index is computed like this:
+ * indices: x1, x2, x3, ..., xn
+ * compute(stride, x1, x2, x3, ..., x(n-1), xn) ->
+ *  x1 * stride[0] + x2 * stride[1] + ...
+ *    + x(n-2) * stride[n-3] + x(n-1) + xn * stride[n-2]
+ * Note that swap of the last two strides, making this 'column major'.
+ */
+template <typename ValueType, size_type total_dim, size_type current_iter = 1>
+struct index_helper_s {
+    static_assert(total_dim >= 1, "Dimensionality must be >= 1");
+    static_assert(current_iter <= total_dim, "Iteration must be <= total_dim!");
+
+    static constexpr size_type dim_idx{current_iter - 1};
+
+    template <typename FirstType, typename... Indices>
+    static constexpr GKO_ATTRIBUTES ValueType
+    compute(const std::array<ValueType, total_dim> &size,
+            const std::array<ValueType, (total_dim > 0 ? total_dim - 1 : 0)>
+                &stride,
+            FirstType first, Indices &&... idxs)
+    {
+        if (current_iter == total_dim - 1) {
+            return first +
+                   index_helper_s<ValueType, total_dim, current_iter + 1>::
+                       compute(size, stride, std::forward<Indices>(idxs)...);
+        }
+
+        return GKO_ASSERT(first < size[dim_idx]),
+               first * stride[dim_idx] +
+                   index_helper_s<ValueType, total_dim, current_iter + 1>::
+                       compute(size, stride, std::forward<Indices>(idxs)...);
+    }
+};
+
+template <typename ValueType, size_type total_dim>
+struct index_helper_s<ValueType, total_dim, total_dim> {
+    static_assert(total_dim >= 2, "Dimensionality must be >= 2");
+
+    // static constexpr size_type current_iter = total_dim;
+    static constexpr size_type dim_idx{total_dim - 1};
+
+    template <typename FirstType, typename... Indices>
+    static constexpr GKO_ATTRIBUTES ValueType
+    compute(const std::array<ValueType, total_dim> &size,
+            const std::array<ValueType, (total_dim > 1 ? total_dim - 1 : 0)>
+                &stride,
+            FirstType first, Indices &&... idxs)
+    {
+        return GKO_ASSERT(first < size[total_dim - 1]),
+               first * stride[dim_idx - 1];
+    }
+};
+
+/**
+ * Computes the storage index for the given indices with respect to the given
+ * stride array
+ */
+template <typename ValueType, size_type total_dim, typename... Indices>
+constexpr GKO_ATTRIBUTES ValueType compute_index(
+    const std::array<ValueType, total_dim> &size,
+    const std::array<ValueType, (total_dim > 0 ? total_dim - 1 : 0)> &stride,
+    Indices &&... idxs)
+{
+    return index_helper_s<ValueType, total_dim>::compute(
+        size, stride, std::forward<Indices>(idxs)...);
+}
+
+
+template <size_type iter, typename ValueType, size_type N>
+constexpr GKO_ATTRIBUTES std::enable_if_t<iter == N, ValueType>
+mult_dim_upwards_impl(const std::array<ValueType, N> &size)
+{
+    return 1;
+}
+
+template <size_type iter, typename ValueType, size_type N>
+constexpr GKO_ATTRIBUTES std::enable_if_t<(iter < N), ValueType>
+mult_dim_upwards_impl(const std::array<ValueType, N> &size)
+{
+    return size[iter] * mult_dim_upwards_impl<iter + 1>(size);
+}
+
+template <size_type iter = 1, typename ValueType, size_type N, typename... Args>
+constexpr GKO_ATTRIBUTES
+    std::enable_if_t<(iter == N - 1) && (iter == sizeof...(Args) + 1),
+                     std::array<ValueType, N - 1>>
+    default_stride_array_impl(const std::array<ValueType, N> &size,
+                              Args &&... args)
+{
+    return {{std::forward<Args>(args)..., size[N - 2]}};
+}
+
+template <size_type iter = 1, typename ValueType, size_type N, typename... Args>
+constexpr GKO_ATTRIBUTES std::enable_if_t<(iter < N - 1 || iter == N) &&
+                                              (iter == sizeof...(Args) + 1),
+                                          std::array<ValueType, N - 1>>
+default_stride_array_impl(const std::array<ValueType, N> &size, Args &&... args)
+{
+    return default_stride_array_impl<iter + 1>(
+        size, std::forward<Args>(args)..., mult_dim_upwards_impl<iter>(size));
+}
+
+template <typename ValueType, size_type dimensions>
+constexpr GKO_ATTRIBUTES
+    std::array<ValueType, (dimensions > 0 ? dimensions - 1 : 0)>
+    default_stride_array(const std::array<ValueType, dimensions> &size)
+{
+    return default_stride_array_impl(size);
+}
+
+
+}  // namespace detail_colmajor
+
+
+/**
+ * A bridge between a range and a column-major memory layout.
+ *
+ * Note that this is not completely a 'layout right'. Only the innermost
+ * two dimensions are regarded as defining a column-major matrix, and
+ * the rest of the dimensions are treated identically to \ref row_major.
+ *
+ * You should not try to explicitly create an instance of this accessor.
+ * Instead, supply it as a template parameter to a range, and pass the
+ * constructor parameters for this class to the range (it will forward it to
+ * this class).
+ *
+ * @tparam ValueType  type of values this accessor returns
+ * @tparam Dimensionality  number of dimensions of this accessor
+ */
+template <typename ValueType, size_type Dimensionality>
+class col_major {
+public:
+    friend class range<col_major>;
+
+    static_assert(Dimensionality != 0,
+                  "This accessor does not support a dimensionality of 0!");
+    static_assert(Dimensionality != 1,
+                  "Please use row_major accessor for 1D ranges.");
+    static constexpr size_type dimensionality = Dimensionality;
+
+    /**
+     * Type of values returned by the accessor.
+     */
+    using value_type = ValueType;
+
+    /**
+     * Type of underlying data storage.
+     */
+    using data_type = value_type *;
+
+    /**
+     * Number of dimensions of the accessor.
+     */
+
+    using const_accessor = col_major<const ValueType, Dimensionality>;
+    using stride_type = std::array<const size_type, dimensionality - 1>;
+    using length_type = std::array<const size_type, dimensionality>;
+
+protected:
+    /**
+     * Creates a col_major accessor.
+     *
+     * @param data  pointer to the block of memory containing the data
+     * @param lengths size / length of the accesses of each dimension
+     * @param stride  distance (in elements) between starting positions of
+     *                the dimensions (i.e.
+     *   `x_1 * stride_1 + x_2 * stride_2 * ... + x_(n-1) + x_n * stride_(n-1)`
+     *                points to the element at (x_1, x_2, ..., x_n))
+     */
+    constexpr GKO_ATTRIBUTES explicit col_major(data_type data,
+                                                dim<dimensionality> size,
+                                                stride_type stride)
+        : data{data},
+          lengths{detail::to_array<const size_type>(size)},
+          stride{stride}
+    {}
+
+    /**
+     * Creates a col_major accessor with a default stride (assumes no padding)
+     *
+     * @param data  pointer to the block of memory containing the data
+     * @param lengths size / length of the accesses of each dimension
+     */
+    constexpr GKO_ATTRIBUTES explicit col_major(data_type data,
+                                                dim<dimensionality> size)
+        : data{data},
+          lengths{detail::to_array<const size_type>(size)},
+          stride{detail_colmajor::default_stride_array(lengths)}
+    {}
+
+public:
+    /**
+     * Creates a col_major range which contains a read-only version of the
+     * current accessor.
+     *
+     * @returns  a col major range which is read-only.
+     */
+    constexpr GKO_ATTRIBUTES range<const_accessor> to_const() const
+    {
+        // TODO Remove this functionality all together (if requested)
+        return range<const_accessor>(data, lengths, stride);
+    }
+
+    /**
+     * Returns the data element at the specified indices
+     *
+     * @param row  row index
+     * @param col  column index
+     *
+     * @return data element at (indices...)
+     */
+    template <typename... Indices>
+    constexpr GKO_ATTRIBUTES
+        std::enable_if_t<are_all_integral<Indices...>::value, value_type &>
+        operator()(Indices &&... indices) const
+    {
+        return data[detail_colmajor::compute_index(
+            lengths, stride, std::forward<Indices>(indices)...)];
+    }
+
+    /**
+     * Returns the sub-range spanning the range (x1_span, x2_span, ...)
+     *
+     * @param rows  row span
+     * @param cols  column span
+     *
+     * @return sub-range spanning the given spans
+     */
+    template <typename... SpanTypes>
+    constexpr GKO_ATTRIBUTES std::enable_if_t<
+        detail::are_span_compatible<SpanTypes...>::value, range<col_major>>
+    operator()(SpanTypes... spans) const
+    {
+        return detail::validate_spans(lengths, spans...),
+               range<col_major>{
+                   data + detail_colmajor::compute_index(
+                              lengths, stride, (span{spans}.begin)...),
+                   dim<dimensionality>{
+                       (span{spans}.end - span{spans}.begin)...},
+                   stride};
+    }
+
+    /**
+     * Returns the length in dimension `dimension`.
+     *
+     * @param dimension  a dimension index
+     *
+     * @return length in dimension `dimension`
+     */
+    constexpr GKO_ATTRIBUTES size_type length(size_type dimension) const
+    {
+        return lengths[dimension];
+    }
+
+    /**
+     * Copies data from another accessor
+     *
+     * @warning Do not use this function since it is not optimized for a
+     *          specific executor. It will always be performed sequentially.
+     *          Please write an optimized version (adjusted to the architecture)
+     *          by iterating through the values yourself.
+     *
+     * @tparam OtherAccessor  type of the other accessor
+     *
+     * @param other  other accessor
+     */
+    template <typename OtherAccessor>
+    GKO_ATTRIBUTES void copy_from(const OtherAccessor &other) const
+    {
+        detail::multidim_for_each(lengths, [this, &other](auto... indices) {
+            (*this)(indices...) = other(indices...);
+        });
+    }
+
+    /**
+     * Reference to the underlying data.
+     */
+    const data_type data;
+
+    /**
+     * An array of dimension sizes.
+     */
+    const length_type lengths;
+
+    /**
+     * Distance between consecutive 'layers' for each dimension
+     * (except the second, for which it is 1).
+     */
+    const stride_type stride;
 };
 
 

--- a/include/ginkgo/core/base/range_accessors.hpp
+++ b/include/ginkgo/core/base/range_accessors.hpp
@@ -97,7 +97,11 @@ struct row_major_helper_s<ValueType, total_dim, total_dim> {
 
 /**
  * Computes the storage index for the given indices with respect to the given
- * stride array
+ * stride array for row-major access
+ *
+ * @param size  the multi-dimensional sizes of the range of values
+ * @param stride  the stride array
+ * @param idxs  the multi-dimensional indices of the desired entry
  */
 template <typename ValueType, size_type total_dim, typename... Indices>
 constexpr GKO_ATTRIBUTES ValueType compute_storage_index(
@@ -639,13 +643,14 @@ namespace detail_block_col_major {
 
 
 /**
- * This helper runs from first to last dimension in order to compute the index.
+ * Runs from first to last dimension in order to compute the index.
+ *
  * The index is computed like this:
  * indices: x1, x2, x3, ..., xn
  * compute(stride, x1, x2, x3, ..., x(n-1), xn) ->
  *  x1 * stride[0] + x2 * stride[1] + ...
  *    + x(n-2) * stride[n-3] + x(n-1) + xn * stride[n-2]
- * Note that swap of the last two strides, making this 'column major'.
+ * Note that swap of the last two strides, making this 'block column major'.
  */
 template <typename ValueType, size_type total_dim, size_type current_iter = 1>
 struct index_helper_s {
@@ -695,8 +700,11 @@ struct index_helper_s<ValueType, total_dim, total_dim> {
 };
 
 /**
- * Computes the storage index for the given indices with respect to the given
- * stride array
+ * Computes the flat storage index for block-column-major access.
+ *
+ * @param size  the multi-dimensional sizes of the range of values
+ * @param stride  the stride array
+ * @param idxs  the multi-dimensional indices of the desired entry
  */
 template <typename ValueType, size_type total_dim, typename... Indices>
 constexpr GKO_ATTRIBUTES ValueType compute_index(

--- a/include/ginkgo/core/base/range_accessors.hpp
+++ b/include/ginkgo/core/base/range_accessors.hpp
@@ -332,8 +332,8 @@ protected:
                                                 dim<dimensionality> size,
                                                 stride_type stride)
         : data{data},
-          lengths{detail::to_array<const size_type>(size)},
-          stride{stride}
+          lengths(detail::to_array<const size_type>(size)),
+          stride(stride)
     {}
 
     /**
@@ -345,8 +345,8 @@ protected:
     constexpr GKO_ATTRIBUTES explicit row_major(data_type data,
                                                 dim<dimensionality> size)
         : data{data},
-          lengths{detail::to_array<const size_type>(size)},
-          stride{detail::compute_default_stride_array(lengths)}
+          lengths(detail::to_array<const size_type>(size)),
+          stride(detail::compute_default_stride_array(lengths))
     {}
 
 public:
@@ -517,8 +517,8 @@ protected:
                                                 dim<dimensionality> size,
                                                 size_type stride)
         : data{data},
-          lengths{detail::to_array<const size_type>(size)},
-          stride{stride}
+          lengths(detail::to_array<const size_type>(size)),
+          stride(stride)
     {}
 
     /**
@@ -530,7 +530,7 @@ protected:
     constexpr GKO_ATTRIBUTES explicit row_major(data_type data,
                                                 dim<dimensionality> size)
         : data{data},
-          lengths{detail::to_array<const size_type>(size)},
+          lengths(detail::to_array<const size_type>(size)),
           stride{size[1]}
     {}
 
@@ -809,8 +809,8 @@ protected:
                                                 dim<dimensionality> size,
                                                 stride_type stride)
         : data{data},
-          lengths{detail::to_array<const size_type>(size)},
-          stride{stride}
+          lengths(detail::to_array<const size_type>(size)),
+          stride(stride)
     {}
 
     /**
@@ -822,8 +822,8 @@ protected:
     constexpr GKO_ATTRIBUTES explicit col_major(data_type data,
                                                 dim<dimensionality> size)
         : data{data},
-          lengths{detail::to_array<const size_type>(size)},
-          stride{detail_colmajor::default_stride_array(lengths)}
+          lengths(detail::to_array<const size_type>(size)),
+          stride(detail_colmajor::default_stride_array(lengths))
     {}
 
 public:

--- a/include/ginkgo/core/base/range_accessors.hpp
+++ b/include/ginkgo/core/base/range_accessors.hpp
@@ -635,11 +635,12 @@ public:
 };
 
 
+namespace detail {
 /**
  * Namespace for helper functions and structs for
  * the block column major accessor.
  */
-namespace detail_block_col_major {
+namespace blk_col_major {
 
 
 /**
@@ -747,7 +748,8 @@ constexpr GKO_ATTRIBUTES
 }
 
 
-}  // namespace detail_block_col_major
+}  // namespace blk_col_major
+}  // namespace detail
 
 
 /**
@@ -824,7 +826,7 @@ protected:
                                                       dim<dimensionality> size)
         : data{data},
           lengths(detail::to_array<const size_type>(size)),
-          stride(detail_block_col_major::default_stride_array(lengths))
+          stride(detail::blk_col_major::default_stride_array(lengths))
     {}
 
 public:
@@ -853,7 +855,7 @@ public:
         std::enable_if_t<are_all_integral<Indices...>::value, value_type &>
         operator()(Indices &&... indices) const
     {
-        return data[detail_block_col_major::compute_index(
+        return data[detail::blk_col_major::compute_index(
             lengths, stride, std::forward<Indices>(indices)...)];
     }
 
@@ -873,7 +875,7 @@ public:
     {
         return detail::validate_spans(lengths, spans...),
                range<block_col_major>{
-                   data + detail_block_col_major::compute_index(
+                   data + detail::blk_col_major::compute_index(
                               lengths, stride, (span{spans}.begin)...),
                    dim<dimensionality>{
                        (span{spans}.end - span{spans}.begin)...},


### PR DESCRIPTION
This PR adds a multidimensional generalization of the existing 2D row-major accessor. The old one is preserved as a template specialization to not break interface.

There is also a new multidimensional 'column-major' accessor. It is very similar to the row-major accessor except that the innermost two dimensions are flipped. So eg., a 4D column-major accessor would be a set of column-major blocks arranged in a block-row-major fashion with respect to each other.