### PR TITLE
Clean up CMake installation step

### DIFF
--- a/cmake/GinkgoConfig.cmake.in
+++ b/cmake/GinkgoConfig.cmake.in
@@ -140,8 +140,12 @@ set(GINKGO_OPENMP_LIBRARIES @OpenMP_CXX_LIBRARIES@)
 set(GINKGO_OPENMP_FLAGS "@OpenMP_CXX_FLAGS@")
 
 # Provide useful HIP helper functions
-include(${CMAKE_CURRENT_LIST_DIR}/hip_helpers.cmake)
-include(${CMAKE_CURRENT_LIST_DIR}/windows_helpers.cmake)
+if(GINKGO_BUILD_HIP)
+    include(${CMAKE_CURRENT_LIST_DIR}/hip_helpers.cmake)
+endif()
+if (WIN32 OR CYGWIN)
+    include(${CMAKE_CURRENT_LIST_DIR}/windows_helpers.cmake)
+endif()
 
 # NOTE: we do not export benchmarks, examples, tests or devel tools
 #     so `third_party` libraries are currently unneeded.

--- a/cmake/install_helpers.cmake
+++ b/cmake/install_helpers.cmake
@@ -2,28 +2,28 @@ include(CMakePackageConfigHelpers)
 include(GNUInstallDirs)
 
 
-set(GINKGO_INSTALL_INCLUDE_DIR "include")
-set(GINKGO_INSTALL_LIBRARY_DIR "lib")
-set(GINKGO_INSTALL_PKGCONFIG_DIR "lib/pkgconfig")
-set(GINKGO_INSTALL_CONFIG_DIR "lib/cmake/Ginkgo")
-set(GINKGO_INSTALL_MODULE_DIR "lib/cmake/Ginkgo/Modules")
+set(GINKGO_INSTALL_INCLUDE_DIR "${CMAKE_INSTALL_INCLUDEDIR}")
+set(GINKGO_INSTALL_LIBRARY_DIR "${CMAKE_INSTALL_LIBDIR}")
+set(GINKGO_INSTALL_PKGCONFIG_DIR "${CMAKE_INSTALL_LIBDIR}/pkgconfig")
+set(GINKGO_INSTALL_CONFIG_DIR "${CMAKE_INSTALL_LIBDIR}/cmake/Ginkgo")
+set(GINKGO_INSTALL_MODULE_DIR "${CMAKE_INSTALL_LIBDIR}/cmake/Ginkgo/Modules")
 
 function(ginkgo_install_library name subdir)
-    
+
     if (WIN32 OR CYGWIN)
         # dll is considered as runtime
         install(TARGETS "${name}"
             EXPORT Ginkgo
-            LIBRARY DESTINATION ${GINKGO_INSTALL_LIBRARY_DIR}
-            ARCHIVE DESTINATION ${GINKGO_INSTALL_LIBRARY_DIR}
-            RUNTIME DESTINATION ${GINKGO_INSTALL_LIBRARY_DIR}
+            LIBRARY DESTINATION "${GINKGO_INSTALL_LIBRARY_DIR}"
+            ARCHIVE DESTINATION "${GINKGO_INSTALL_LIBRARY_DIR}"
+            RUNTIME DESTINATION "${GINKGO_INSTALL_LIBRARY_DIR}"
             )
     else ()
         # install .so and .a files
         install(TARGETS "${name}"
             EXPORT Ginkgo
-            LIBRARY DESTINATION ${GINKGO_INSTALL_LIBRARY_DIR}
-            ARCHIVE DESTINATION ${GINKGO_INSTALL_LIBRARY_DIR}
+            LIBRARY DESTINATION "${GINKGO_INSTALL_LIBRARY_DIR}"
+            ARCHIVE DESTINATION "${GINKGO_INSTALL_LIBRARY_DIR}"
         )
     endif ()
 endfunction()
@@ -37,9 +37,8 @@ function(ginkgo_install)
         DESTINATION "${GINKGO_INSTALL_INCLUDE_DIR}"
         FILES_MATCHING PATTERN "*.hpp"
         )
-    install(DIRECTORY "${Ginkgo_BINARY_DIR}/include/"
-        DESTINATION "${GINKGO_INSTALL_INCLUDE_DIR}"
-        FILES_MATCHING PATTERN "*.hpp"
+    install(FILES "${Ginkgo_BINARY_DIR}/include/ginkgo/config.hpp"
+        DESTINATION "${GINKGO_INSTALL_INCLUDE_DIR}/ginkgo"
         )
     if (GINKGO_HAVE_PAPI_SDE)
         install(FILES "${Ginkgo_SOURCE_DIR}/third_party/papi_sde/papi_sde_interface.h"
@@ -60,7 +59,7 @@ function(ginkgo_install)
     write_basic_package_version_file(
         "${Ginkgo_BINARY_DIR}/GinkgoConfigVersion.cmake"
         VERSION "${PROJECT_VERSION}"
-        COMPATIBILITY AnyNewerVersion
+        COMPATIBILITY SameMajorVersion
         )
     configure_package_config_file(
         "${Ginkgo_SOURCE_DIR}/cmake/GinkgoConfig.cmake.in"
@@ -75,11 +74,21 @@ function(ginkgo_install)
     install(FILES
         "${Ginkgo_BINARY_DIR}/GinkgoConfig.cmake"
         "${Ginkgo_BINARY_DIR}/GinkgoConfigVersion.cmake"
-        "${Ginkgo_SOURCE_DIR}/cmake/hip_helpers.cmake"
-        "${Ginkgo_SOURCE_DIR}/cmake/windows_helpers.cmake"
         DESTINATION "${GINKGO_INSTALL_CONFIG_DIR}"
         )
-      install(EXPORT Ginkgo
+    if (WIN32 OR CYGWIN)
+        install(FILES
+            "${Ginkgo_SOURCE_DIR}/cmake/windows_helpers.cmake"
+            DESTINATION "${GINKGO_INSTALL_CONFIG_DIR}"
+            )
+    endif()
+    if (GINKGO_BUILD_HIP)
+        install(FILES
+            "${Ginkgo_SOURCE_DIR}/cmake/hip_helpers.cmake"
+            DESTINATION "${GINKGO_INSTALL_CONFIG_DIR}"
+            )
+    endif()
+    install(EXPORT Ginkgo
         NAMESPACE Ginkgo::
         FILE GinkgoTargets.cmake
         DESTINATION "${GINKGO_INSTALL_CONFIG_DIR}")


### PR DESCRIPTION
I was building a [vcpkg port for Ginkgo](https://github.com/upsj/vcpkg) (see #686) where I stumbled across a few issues with the current build setup, which this PR fixes:

* install and use windows and HIP helpers only when necessary
* use GNUInstallDirs provided values instead of hard-coded paths
* correctly quote paths (even though they are most likely relative)
* Avoid creating `include/CMakeFiles` by manually installing `ginkgo/config.hpp`
* Use SameMajorVersion instead of AnyNewerVersion to find potential interface breaks at configure time already