### PR TITLE
Add a publications dropdown in doxygen documentation page

### DIFF
--- a/doc/DoxygenLayout.xml
+++ b/doc/DoxygenLayout.xml
@@ -5,7 +5,11 @@
     <tab type="mainpage" visible="yes" title=""/>
     <tab type="user" visible="yes" title="Tutorial" url="https://github.com/ginkgo-project/ginkgo/wiki/Tutorial:-Building-a-Poisson-Solver" />
     <tab type="user" visible="yes" title="Examples" url="@ref Examples" />
-    <tab type="user" visible="yes" title="Citing Ginkgo" url="@ref citing_ginkgo" />
+    <tab type="user" visible="yes" title="Publications" url="@ref citing_ginkgo" >
+      <tab type="user" visible="yes" title="Citing Ginkgo" url="@ref citing_ginkgo" />
+      <tab type="user" visible="yes" title="Ginkgo White Paper" url="https://www.arxiv-vanity.com/papers/2006.16852/" />
+      <tab type="user" visible="yes" title="Slides and Outreach" url="https://github.com/ginkgo-project/outreach" />
+    </tab>
     <tab type="user" visible="yes" title="Contributing To Ginkgo" url="@ref contributing_guidelines" />
     <tab type="user" visible="yes" title="Using Ginkgo" url="@ref install_ginkgo">
       <tab type="user" visible="yes" title="Installing Ginkgo" url="@ref install_ginkgo" />


### PR DESCRIPTION
This PR adds a dropdown for Ginkgo's publications, which can showcase the item that is the [white paper of Ginkgo rendered nicely.](https://www.arxiv-vanity.com/papers/2006.16852/) 

![A screenshot](https://user-images.githubusercontent.com/10301328/112115137-2459af00-8bb9-11eb-9e04-39f0fcc1f9dd.png)