### PR TITLE
Fix for issue with corner case of reading empty Fbcsr matrix

### DIFF
--- a/core/matrix/fbcsr.cpp
+++ b/core/matrix/fbcsr.cpp
@@ -336,6 +336,11 @@ void Fbcsr<ValueType, IndexType>::read(const mat_data &data)
                              blocks.size() * bs * bs, bs);
 
     tmp->row_ptrs_.get_data()[0] = 0;
+    if (data.nonzeros.size() == 0) {
+        tmp->move_to(this);
+        return;
+    }
+
     index_type cur_brow = 0;
     index_type cur_bnz = 0;
     index_type cur_bcol = blocks.begin()->first.block_column;

--- a/core/test/matrix/fbcsr.cpp
+++ b/core/test/matrix/fbcsr.cpp
@@ -460,6 +460,24 @@ TYPED_TEST(Fbcsr, CanBeReadFromMatrixData)
 }
 
 
+TYPED_TEST(Fbcsr, CanBeReadFromEmptyMatrixData)
+{
+    using Mtx = typename TestFixture::Mtx;
+    using MtxData = typename TestFixture::MtxData;
+    auto m = Mtx::create(this->exec);
+    m->set_block_size(this->fbsample.bs);
+    MtxData mdata;
+    mdata.size = gko::dim<2>{0, 0};
+
+    m->read(mdata);
+
+    ASSERT_EQ(m->get_size(), (gko::dim<2>{0, 0}));
+    ASSERT_EQ(m->get_const_row_ptrs()[0], 0);
+    ASSERT_EQ(m->get_const_col_idxs(), nullptr);
+    ASSERT_EQ(m->get_const_values(), nullptr);
+}
+
+
 TYPED_TEST(Fbcsr, GeneratesCorrectMatrixData)
 {
     using value_type = typename TestFixture::value_type;


### PR DESCRIPTION
This is part of an attempt to understand an issue flagged by SonarCloud related to a null reference in the Fbcsr read function. One possibility is that it's catching the case where the input is empty, because that was causing issues which this PR fixes. Before SonarCloud is run on this PR, it is unclear whether the null reference issue will be fixed. Regardless, this small fix is good to have.

The tests related to the read functions (and all core Fbcsr tests) are Valgrind-clean.