### PR TITLE
Add CCACHE support in CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -34,6 +34,8 @@ stages:
   - export NUM_CORES=${CI_PARALLELISM}
   - export OMP_NUM_THREADS=${NUM_CORES}
   - export CUDA_VISIBLE_DEVICES=0
+  - export CCACHE_DIR=${CCACHE_DIR}
+  - export CCACHE_MAXSIZE=${CCACHE_MAXSIZE}
 
 .before_script_git_template: &git_before_script
   - eval $(ssh-agent -s)

--- a/cmake/get_info.cmake
+++ b/cmake/get_info.cmake
@@ -77,10 +77,10 @@ function(ginkgo_print_env_variable log_type var_name)
     string(SUBSTRING
         "
 --        ${var_name}:                                                          " 0 55 upd_string)
-    if(NOT ENV{${var_name}})
-        set(str_value "<empty>")
-    else()
+    if(DEFINED ENV{${var_name}})
         set(str_value "$ENV{${var_name}}")
+    else()
+        set(str_value "<empty>")
     endif()
     string(APPEND upd_string "${str_value}")
     FILE(APPEND ${log_type} "${upd_string}")
@@ -100,7 +100,7 @@ IF("${GINKGO_GIT_SHORTREV}" STREQUAL "")
     ginkgo_print_generic_header(${detailed_log} "${to_print}")
     ginkgo_print_generic_header(${minimal_log} "${to_print}")
 ELSE()
-    set(to_print "Summary of Configuration for (Ginkgo version ${Ginkgo_VERSION} with tag ${Ginkgo_VERSION_TAG}, shortrev ${GINKGO_GIT_SHORTREV})"
+    set(to_print "Summary of Configuration for Ginkgo (version ${Ginkgo_VERSION} with tag ${Ginkgo_VERSION_TAG}, shortrev ${GINKGO_GIT_SHORTREV})"
         )
     ginkgo_print_generic_header(${detailed_log} "${to_print}")
     ginkgo_print_generic_header(${minimal_log} "${to_print}")
@@ -133,10 +133,6 @@ foreach(log_type ${log_types})
         "GINKGO_BUILD_TESTS;GINKGO_BUILD_EXAMPLES;GINKGO_EXTLIB_EXAMPLE;GINKGO_BUILD_BENCHMARKS;GINKGO_BENCHMARK_ENABLE_TUNING")
     ginkgo_print_module_footer(${${log_type}} "  Documentation:")
     ginkgo_print_foreach_variable(${${log_type}} "GINKGO_BUILD_DOC;GINKGO_VERBOSE_LEVEL")
-    ginkgo_print_module_footer(${${log_type}} "  Developer helpers:")
-    ginkgo_print_foreach_variable(${${log_type}}
-        "GINKGO_DEVEL_TOOLS;GINKGO_WITH_CLANG_TIDY;GINKGO_WITH_IWYU"
-        "GINKGO_CHECK_CIRCULAR_DEPS;GINKGO_CHECK_PATH")
     ginkgo_print_module_footer(${${log_type}} "")
 endforeach()
 
@@ -167,6 +163,23 @@ ENDIF()
 IF(GINKGO_BUILD_DPCPP)
     include(dpcpp/get_info.cmake)
 ENDIF()
+
+ginkgo_print_generic_header(${minimal_log} "  Developer Tools:")
+ginkgo_print_generic_header(${detailed_log} "  Developer Tools:")
+ginkgo_print_foreach_variable(${minimal_log}
+        "GINKGO_DEVEL_TOOLS;GINKGO_WITH_CLANG_TIDY;GINKGO_WITH_IWYU"
+        "GINKGO_CHECK_CIRCULAR_DEPS;GINKGO_CHECK_PATH;GINKGO_WITH_CCACHE")
+ginkgo_print_foreach_variable(${detailed_log}
+        "GINKGO_DEVEL_TOOLS;GINKGO_WITH_CLANG_TIDY;GINKGO_WITH_IWYU"
+        "GINKGO_CHECK_CIRCULAR_DEPS;GINKGO_CHECK_PATH;GINKGO_WITH_CCACHE")
+ginkgo_print_module_footer(${detailed_log} "  CCACHE:")
+ginkgo_print_variable(${detailed_log} "CCACHE_PROGRAM")
+ginkgo_print_env_variable(${detailed_log} "CCACHE_DIR")
+ginkgo_print_env_variable(${detailed_log} "CCACHE_MAXSIZE")
+ginkgo_print_module_footer(${detailed_log} "  PATH of other tools:")
+ginkgo_print_variable(${detailed_log} "GINKGO_CLANG_TIDY_PATH")
+ginkgo_print_variable(${detailed_log} "GINKGO_IWYU_PATH")
+ginkgo_print_module_footer(${detailed_log} "")
 
 ginkgo_print_generic_header(${minimal_log} "  Components:")
 ginkgo_print_generic_header(${detailed_log} "  Components:")


### PR DESCRIPTION
CCACHE is in fact already available, but a few cosmetic changes are required.

Most of the support is provided in the background by the gitlab-runner setup. You can see its effect on a few jobs where the cache was already built like all jobs on the AMD machine:
https://gitlab.com/ginkgo-project/ginkgo-public-ci/-/jobs/1166039002 (2 minutes to compile/test ginkgo core).

What this PR does on top of it:
+ Propagate some CCACHE environment variables set by gitlab-runner to ensure they are available/used
+ Review the way developer tools information is printed and add a bunch of CCACHE related information.