### PR TITLE
Extract allocations from OpenMP kernels

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -437,7 +437,7 @@ build/cuda101/clang/all/release/static:
     CUDA_ARCH: 35
 
 # clang-cuda with cuda 10.1 and friends
-build/clang-cuda101/gcc/all/release/shared:
+build/clang-cuda101/gcc/cuda/release/shared:
   <<: *default_build
   extends:
     - .quick_test_condition
@@ -447,7 +447,7 @@ build/clang-cuda101/gcc/all/release/shared:
     CUDA_COMPILER: "clang++"
     BUILD_OMP: "ON"
     BUILD_CUDA: "ON"
-    BUILD_HIP: "ON"
+    BUILD_HIP: "OFF"
     BUILD_TYPE: "Release"
     CUDA_ARCH: 35
 

--- a/cmake/GinkgoConfig.cmake.in
+++ b/cmake/GinkgoConfig.cmake.in
@@ -170,8 +170,8 @@ if(GINKGO_HAVE_HWLOC)
     find_package(HWLOC REQUIRED)
 endif()
 
-# HIP depends on Threads::Threads in some circumstances, but doesn't find it
-if (GINKGO_BUILD_HIP)
+# HIP and OpenMP depend on Threads::Threads in some circumstances, but don't find it
+if (GINKGO_BUILD_HIP OR GINKGO_BUILD_OMP)
     find_package(Threads REQUIRED)
 endif()
 

--- a/omp/CMakeLists.txt
+++ b/omp/CMakeLists.txt
@@ -44,6 +44,17 @@ target_sources(ginkgo_omp
 
 ginkgo_compile_features(ginkgo_omp)
 
+# The dependency to OpenMP's potential pthread dependency needs to be public
+# because well, it's a long story:
+# std::shared_ptr decides whether we need to increment/decrement the reference
+# counters atomically by calling the pthread function __gthread_active_p, i.e.
+# checking whether there are multiple active threads. Linking against OpenMP
+# also links against pthread on Linux. Due to issues with static initialization
+# order for pthread_key_create, it may happen that ginkgo_omp assumes that a
+# piece of code is being executed sequentially, causing race conditions in the
+# reference counters.
+find_package(Threads REQUIRED)
+target_link_libraries(ginkgo_omp PUBLIC Threads::Threads)
 target_link_libraries(ginkgo_omp PRIVATE "${OpenMP_CXX_LIBRARIES}")
 target_include_directories(ginkgo_omp PRIVATE "${OpenMP_CXX_INCLUDE_DIRS}")
 # We first separate the arguments, otherwise, the target_compile_options adds it as a string

--- a/omp/matrix/csr_kernels.cpp
+++ b/omp/matrix/csr_kernels.cpp
@@ -165,7 +165,7 @@ struct col_heap_element {
 /**
  * @internal
  *
- * Entry in a heap storing a entry (value and column index) and associated
+ * Entry in a heap storing an entry (value and column index) and associated
  * non-zero index (and row end) from a matrix.
  *
  * @tparam ValueType  The value type for matrices.
@@ -247,7 +247,9 @@ void sift_down(HeapElement *heap, typename HeapElement::index_type idx,
  * @param col_cb  function that will be called once for each output column after
  *                all accumulations into it are completed. Its signature must be
  *                compatible with `col_cb(column, state)`.
- * @return the value initializaed by init_cb and updated by step_cb and col_cb
+ * @return the value initialized by init_cb and updated by step_cb and col_cb
+ * @note If the columns of B are not sorted, the output may have duplicate
+ *       column entries.
  *
  * @tparam HeapElement  the heap element type. See col_heap_element and
  *                      val_heap_element

--- a/omp/test/matrix/csr_kernels.cpp
+++ b/omp/test/matrix/csr_kernels.cpp
@@ -91,12 +91,19 @@ protected:
 
     template <typename MtxType>
     std::unique_ptr<MtxType> gen_mtx(int num_rows, int num_cols,
-                                     int min_nnz_row)
+                                     int min_nnz_row, int max_nnz_row)
     {
         return gko::test::generate_random_matrix<MtxType>(
             num_rows, num_cols,
-            std::uniform_int_distribution<>(min_nnz_row, num_cols),
+            std::uniform_int_distribution<>(min_nnz_row, max_nnz_row),
             std::normal_distribution<>(-1.0, 1.0), rand_engine, ref);
+    }
+
+    template <typename MtxType>
+    std::unique_ptr<MtxType> gen_mtx(int num_rows, int num_cols,
+                                     int min_nnz_row)
+    {
+        return gen_mtx<MtxType>(num_rows, num_cols, min_nnz_row, num_cols);
     }
 
     void set_up_apply_data(int num_vectors = 1)
@@ -253,6 +260,60 @@ TEST_F(Csr, SimpleApplyToCsrMatrixIsEquivalentToRef)
 
     GKO_ASSERT_MTX_NEAR(square_dmtx, square_mtx, 1e-14);
     GKO_ASSERT_MTX_EQ_SPARSITY(square_dmtx, square_mtx);
+    ASSERT_TRUE(square_dmtx->is_sorted_by_column_index());
+}
+
+
+TEST_F(Csr, SimpleApplyToSparseCsrMatrixIsEquivalentToRef)
+{
+    set_up_apply_data();
+    auto mtx2 =
+        gen_mtx<Mtx>(mtx->get_size()[1], square_mtx->get_size()[1], 0, 10);
+    auto dmtx2 = Mtx::create(omp, mtx2->get_size());
+    dmtx2->copy_from(mtx2.get());
+
+    mtx->apply(mtx2.get(), square_mtx.get());
+    dmtx->apply(dmtx2.get(), square_dmtx.get());
+
+    GKO_ASSERT_MTX_EQ_SPARSITY(square_dmtx, square_mtx);
+    GKO_ASSERT_MTX_NEAR(square_dmtx, square_mtx, 1e-14);
+    ASSERT_TRUE(square_dmtx->is_sorted_by_column_index());
+}
+
+
+TEST_F(Csr, SimpleApplySparseToSparseCsrMatrixIsEquivalentToRef)
+{
+    set_up_apply_data();
+    auto mtx1 = gen_mtx<Mtx>(mtx->get_size()[0], mtx->get_size()[1], 0, 10);
+    auto mtx2 =
+        gen_mtx<Mtx>(mtx->get_size()[1], square_mtx->get_size()[1], 0, 10);
+    auto dmtx1 = Mtx::create(omp, mtx1->get_size());
+    auto dmtx2 = Mtx::create(omp, mtx2->get_size());
+    dmtx1->copy_from(mtx1.get());
+    dmtx2->copy_from(mtx2.get());
+
+    mtx1->apply(mtx2.get(), square_mtx.get());
+    dmtx1->apply(dmtx2.get(), square_dmtx.get());
+
+    GKO_ASSERT_MTX_EQ_SPARSITY(square_dmtx, square_mtx);
+    GKO_ASSERT_MTX_NEAR(square_dmtx, square_mtx, 1e-14);
+    ASSERT_TRUE(square_dmtx->is_sorted_by_column_index());
+}
+
+
+TEST_F(Csr, SimpleApplyToEmptyCsrMatrixIsEquivalentToRef)
+{
+    set_up_apply_data();
+    auto mtx2 =
+        gen_mtx<Mtx>(mtx->get_size()[1], square_mtx->get_size()[1], 0, 0);
+    auto dmtx2 = Mtx::create(omp, mtx2->get_size());
+    dmtx2->copy_from(mtx2.get());
+
+    mtx->apply(mtx2.get(), square_mtx.get());
+    dmtx->apply(dmtx2.get(), square_dmtx.get());
+
+    GKO_ASSERT_MTX_EQ_SPARSITY(square_dmtx, square_mtx);
+    GKO_ASSERT_MTX_NEAR(square_dmtx, square_mtx, 1e-14);
     ASSERT_TRUE(square_dmtx->is_sorted_by_column_index());
 }
 


### PR DESCRIPTION
I'll just copy over the explanation from the source code:

The dependency on OpenMP needs to be public because well, it's a long story: 
std::shared_ptr decides whether we need to increment/decrement the reference counters atomically by calling the pthread function __gthread_active_p, i.e. checking whether there are multiple active threads. Linking against OpenMP also links against pthread on Linux. Due to issues with static initialization order for pthread_key_create, if some piece of code doesn't link against pthread, it may happen (I didn't want to dive too deep into that pit) that ginkgo_omp assumes that a piece of code is being executed sequentially, causing race conditions in the reference counters. See https://github.com/easybuilders/easybuild-easyconfigs/issues/12563

- [x] Extract allocations from Jacobi OpenMP kernels
- [x] Extract allocations from CSR SpGEMM OpenMP kernels (this means switching the algorithm to a multiway merge-based implementation with a binary heap) based on #626 
- [x] Add a bit of explanation to the SpGEMM implementation
- [x] ~~Extract allocations from RCM OpenMP kernels~~ I think this is a bit too much to ask for now
- [x] Prevent any potential problems with std::shared_ptr refcount atomics due to pthread linking
- [x] Add more tests for SpGEMM

Fixes #732