### PR TITLE
Decrease test size for a few OpenMP tests

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -23,6 +23,7 @@ stages:
   BUILD_CUDA: "OFF"
   BUILD_HIP: "OFF"
   BUILD_HWLOC: "ON"
+  FAST_TESTS: "OFF"
   RUN_EXAMPLES: "OFF"
   CONFIG_LOG: "ON"
   CXX_FLAGS: ""
@@ -68,6 +69,7 @@ stages:
         -DGINKGO_BUILD_HIP=${BUILD_HIP}
         -DGINKGO_BUILD_HWLOC=${BUILD_HWLOC}
         -DGINKGO_BUILD_TESTS=ON -DGINKGO_BUILD_EXAMPLES=ON
+        -DGINKGO_FAST_TESTS=${FAST_TESTS}
         -DGINKGO_RUN_EXAMPLES=${RUN_EXAMPLES}
         -DGINKGO_CONFIG_LOG_DETAILED=${CONFIG_LOG}
         -DGINKGO_EXPORT_BUILD_DIR=${EXPORT_BUILD_DIR}
@@ -100,6 +102,7 @@ stages:
         -DGINKGO_BUILD_HIP=${BUILD_HIP}
         -DGINKGO_BUILD_HWLOC=${BUILD_HWLOC}
         -DGINKGO_BUILD_TESTS=ON -DGINKGO_BUILD_EXAMPLES=ON
+        -DGINKGO_FAST_TESTS=${FAST_TESTS}
         -DGINKGO_CONFIG_LOG_DETAILED=${CONFIG_LOG}
         -DGINKGO_RUN_EXAMPLES=${RUN_EXAMPLES}
         -DGINKGO_EXPORT_BUILD_DIR=${EXPORT_BUILD_DIR}
@@ -172,6 +175,7 @@ build/cuda90/gcc/all/debug/shared:
     BUILD_OMP: "ON"
     BUILD_CUDA: "ON"
     BUILD_TYPE: "Debug"
+    FAST_TESTS: "ON"
     RUN_EXAMPLES: "ON"
     CUDA_ARCH: 35
   only:
@@ -211,6 +215,7 @@ build/cuda91/gcc/all/debug/static:
     BUILD_OMP: "ON"
     BUILD_CUDA: "ON"
     BUILD_TYPE: "Debug"
+    FAST_TESTS: "ON"
     BUILD_SHARED_LIBS: "OFF"
     CUDA_ARCH: 35
   only:
@@ -295,6 +300,7 @@ build/cuda100/gcc/all/debug/shared:
     BUILD_CUDA: "ON"
     BUILD_HIP: "ON"
     BUILD_TYPE: "Debug"
+    FAST_TESTS: "ON"
     CUDA_ARCH: 35
   only:
     variables:
@@ -354,6 +360,7 @@ build/cuda101/gcc/all/debug/shared:
     BUILD_CUDA: "ON"
     BUILD_HIP: "ON"
     BUILD_TYPE: "Debug"
+    FAST_TESTS: "ON"
     CUDA_ARCH: 35
   only:
     variables:
@@ -415,6 +422,7 @@ build/clang-cuda101/clang/cuda/debug/static:
     BUILD_OMP: "ON"
     BUILD_CUDA: "ON"
     BUILD_TYPE: "Debug"
+    FAST_TESTS: "ON"
     BUILD_SHARED_LIBS: "OFF"
     CUDA_ARCH: 35
   only:
@@ -437,6 +445,7 @@ build/cuda102/gcc/all/debug/shared:
     BUILD_CUDA: "ON"
     BUILD_HIP: "ON"
     BUILD_TYPE: "Debug"
+    FAST_TESTS: "ON"
     BUILD_HWLOC: "OFF"
     CUDA_ARCH: 35
   only:
@@ -479,6 +488,7 @@ build/cuda102/intel/cuda/debug/static:
     BUILD_OMP: "ON"
     BUILD_CUDA: "ON"
     BUILD_TYPE: "Debug"
+    FAST_TESTS: "ON"
     BUILD_SHARED_LIBS: "OFF"
     CUDA_ARCH: 35
   only:
@@ -498,6 +508,7 @@ build/cuda110/gcc/cuda/debug/shared:
     BUILD_OMP: "ON"
     BUILD_CUDA: "ON"
     BUILD_TYPE: "Debug"
+    FAST_TESTS: "ON"
     CUDA_ARCH: 35
   only:
     variables:
@@ -537,6 +548,7 @@ build/cuda110/intel/cuda/debug/static:
     BUILD_OMP: "ON"
     BUILD_CUDA: "ON"
     BUILD_TYPE: "Debug"
+    FAST_TESTS: "ON"
     BUILD_SHARED_LIBS: "OFF"
     CUDA_ARCH: 35
   only:
@@ -557,6 +569,7 @@ build/amd/gcc/hip/debug/shared:
     BUILD_HIP: "ON"
     RUN_EXAMPLES: "ON"
     BUILD_TYPE: "Debug"
+    FAST_TESTS: "ON"
   only:
     variables:
       - $RUN_CI_TAG
@@ -592,6 +605,7 @@ build/nocuda/gcc/core/debug/static:
     <<: *default_variables
     BUILD_REFERENCE: "OFF"
     BUILD_TYPE: "Debug"
+    FAST_TESTS: "ON"
     BUILD_SHARED_LIBS: "OFF"
     BUILD_HWLOC: "OFF"
   only:
@@ -626,6 +640,7 @@ build/nocuda/intel/core/debug/shared:
     CXX_COMPILER: "icpc"
     BUILD_REFERENCE: "OFF"
     BUILD_TYPE: "Debug"
+    FAST_TESTS: "ON"
   only:
     variables:
       - $RUN_CI_TAG
@@ -657,6 +672,7 @@ build/nocuda/clang/omp/debug/static:
     CXX_COMPILER: "clang++"
     BUILD_OMP: "ON"
     BUILD_TYPE: "Debug"
+    FAST_TESTS: "ON"
     BUILD_SHARED_LIBS: "OFF"
   only:
     variables:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -34,7 +34,7 @@ stages:
 .before_script_template: &default_before_script
   - export NUM_CORES=${CI_PARALLELISM}
   - export OMP_NUM_THREADS=${NUM_CORES}
-  - export CUDA_VISIBLE_DEVICES=0
+  - export CUDA_VISIBLE_DEVICES=$((RANDOM % 2))
   - export CCACHE_DIR=${CCACHE_DIR}
   - export CCACHE_MAXSIZE=${CCACHE_MAXSIZE}
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,6 +32,7 @@ option(GINKGO_BUILD_DPCPP
 option(GINKGO_BUILD_CUDA "Compile kernels for NVIDIA GPUs" ${GINKGO_HAS_CUDA})
 option(GINKGO_BUILD_HIP "Compile kernels for AMD or NVIDIA GPUs" ${GINKGO_HAS_HIP})
 option(GINKGO_BUILD_DOC "Generate documentation" OFF)
+option(GINKGO_FAST_TESTS "Reduces the input size for a few tests known to be time-intensive" OFF)
 option(GINKGO_SKIP_DEPENDENCY_UPDATE
     "Do not update dependencies each time the project is rebuilt" ON)
 option(GINKGO_EXPORT_BUILD_DIR

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -143,6 +143,7 @@ if(GINKGO_BUILD_TESTS)
 
     enable_testing()
     include(CTest)
+    add_custom_target(quick_test "${CMAKE_CTEST_COMMAND}" -R 'core|reference')
 endif()
 
 if(GINKGO_WITH_CLANG_TIDY)

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -20,6 +20,8 @@ Ginkgo adds the following additional switches to control what is being built:
     default is `OFF`.
 *   `-DGINKGO_BUILD_TESTS={ON, OFF}` builds Ginkgo's tests
     (will download googletest), default is `ON`.
+*   `-DGINKGO_FAST_TESTS={ON, OFF}` reduces the input sizes for a few slow tests
+    to speed them up, default is `OFF`.
 *   `-DGINKGO_BUILD_BENCHMARKS={ON, OFF}` builds Ginkgo's benchmarks
     (will download gflags and rapidjson), default is `ON`.
 *   `-DGINKGO_BUILD_EXAMPLES={ON, OFF}` builds Ginkgo's examples, default is `ON`

--- a/TESTING.md
+++ b/TESTING.md
@@ -27,6 +27,17 @@ run the following from the build folder:
 
 where `path/to/test` is the path returned by `make test`.
 
+#### Using make quick_test
+After compiling Ginkgo, use the following command inside the build folder to run
+a small subset of tests that should execute quickly:
+
+```sh
+make quick_test
+```
+
+These tests do not use GPU features except for a few device property queries, so
+they may still fail if Ginkgo was compiled with GPU support, but no such GPU is
+available. The output is equivalent to `make test`.
 
 #### Using CTest 
 The tests can also be ran through CTest from the command line, for example when

--- a/cmake/create_test.cmake
+++ b/cmake/create_test.cmake
@@ -10,6 +10,9 @@ function(ginkgo_create_test test_name)
         )
     set_target_properties(${TEST_TARGET_NAME} PROPERTIES
         OUTPUT_NAME ${test_name})
+    if (GINKGO_FAST_TESTS)
+        target_compile_definitions(${TEST_TARGET_NAME} PRIVATE GINKGO_FAST_TESTS)
+    endif()
     if (GINKGO_CHECK_CIRCULAR_DEPS)
         target_link_libraries(${TEST_TARGET_NAME} PRIVATE "${GINKGO_CIRCULAR_DEPS_FLAGS}")
     endif()
@@ -30,6 +33,9 @@ function(ginkgo_create_dpcpp_test test_name)
         )
     set_target_properties(${TEST_TARGET_NAME} PROPERTIES
         OUTPUT_NAME ${test_name})
+    if (GINKGO_FAST_TESTS)
+        target_compile_definitions(${TEST_TARGET_NAME} PRIVATE GINKGO_FAST_TESTS)
+    endif()
     if (GINKGO_CHECK_CIRCULAR_DEPS)
         target_link_libraries(${TEST_TARGET_NAME} PRIVATE "${GINKGO_CIRCULAR_DEPS_FLAGS}")
     endif()
@@ -51,6 +57,9 @@ function(ginkgo_create_thread_test test_name)
         )
     set_target_properties(${TEST_TARGET_NAME} PROPERTIES
         OUTPUT_NAME ${test_name})
+    if (GINKGO_FAST_TESTS)
+        target_compile_definitions(${TEST_TARGET_NAME} PRIVATE GINKGO_FAST_TESTS)
+    endif()
     if (GINKGO_CHECK_CIRCULAR_DEPS)
         target_link_libraries(${TEST_TARGET_NAME} PRIVATE "${GINKGO_CIRCULAR_DEPS_FLAGS}")
     endif()
@@ -72,6 +81,9 @@ function(ginkgo_create_test_cpp_cuda_header test_name)
         )
     set_target_properties(${TEST_TARGET_NAME} PROPERTIES
         OUTPUT_NAME ${test_name})
+    if (GINKGO_FAST_TESTS)
+        target_compile_definitions(${TEST_TARGET_NAME} PRIVATE GINKGO_FAST_TESTS)
+    endif()
     if (GINKGO_CHECK_CIRCULAR_DEPS)
         target_link_libraries(${TEST_TARGET_NAME} PRIVATE "${GINKGO_CIRCULAR_DEPS_FLAGS}")
     endif()
@@ -93,7 +105,9 @@ function(ginkgo_create_cuda_test test_name)
         PRIVATE "$<$<COMPILE_LANGUAGE:CUDA>:${GINKGO_CUDA_ARCH_FLAGS}>")
     set_target_properties(${TEST_TARGET_NAME} PROPERTIES
         OUTPUT_NAME ${test_name})
-
+    if (GINKGO_FAST_TESTS)
+        target_compile_definitions(${TEST_TARGET_NAME} PRIVATE GINKGO_FAST_TESTS)
+    endif()
     if (GINKGO_CHECK_CIRCULAR_DEPS)
         target_link_libraries(${TEST_TARGET_NAME} PRIVATE "${GINKGO_CIRCULAR_DEPS_FLAGS}")
     endif()
@@ -108,6 +122,10 @@ function(ginkgo_create_hip_test test_name)
     string(REPLACE "/" "_" TEST_TARGET_NAME "${REL_BINARY_DIR}/${test_name}")
 
     set_source_files_properties(${test_name}.hip.cpp PROPERTIES HIP_SOURCE_PROPERTY_FORMAT TRUE)
+    set(GINKGO_TEST_HIP_DEFINES)
+    if (GINKGO_FAST_TESTS)
+        set(GINKGO_TEST_HIP_DEFINES -DGINKGO_FAST_TESTS)
+    endif()
 
     # NOTE: With how HIP works, passing the flags `HIPCC_OPTIONS` etc. here
     # creates a redefinition of all flags. This creates some issues with `nvcc`,
@@ -116,13 +134,13 @@ function(ginkgo_create_hip_test test_name)
         hip_add_executable(${TEST_TARGET_NAME} ${test_name}.hip.cpp
             # If `FindHIP.cmake`, namely `HIP_PARSE_HIPCC_OPTIONS` macro and
             # call gets fixed, uncomment this.
-            # HIPCC_OPTIONS ${GINKGO_HIPCC_OPTIONS}
-            # NVCC_OPTIONS  ${GINKGO_HIP_NVCC_OPTIONS}
-            # CLANG_OPTIONS ${GINKGO_HIP_CLANG_OPTIONS}
+            HIPCC_OPTIONS ${GINKGO_TEST_HIP_DEFINES} # ${GINKGO_HIPCC_OPTIONS}
+            # NVCC_OPTIONS  ${GINKGO_TEST_HIP_DEFINES} ${GINKGO_HIP_NVCC_OPTIONS}
+            # CLANG_OPTIONS ${GINKGO_TEST_HIP_DEFINES} ${GINKGO_HIP_CLANG_OPTIONS}
             )
     else() # hcc/clang
         hip_add_executable(${TEST_TARGET_NAME} ${test_name}.hip.cpp
-            HIPCC_OPTIONS ${GINKGO_HIPCC_OPTIONS}
+            HIPCC_OPTIONS ${GINKGO_HIPCC_OPTIONS} ${GINKGO_TEST_HIP_DEFINES}
             NVCC_OPTIONS  ${GINKGO_HIP_NVCC_OPTIONS}
             CLANG_OPTIONS ${GINKGO_HIP_CLANG_OPTIONS}
             )

--- a/cmake/get_info.cmake
+++ b/cmake/get_info.cmake
@@ -130,7 +130,7 @@ foreach(log_type ${log_types})
         "GINKGO_BUILD_OMP;GINKGO_BUILD_REFERENCE;GINKGO_BUILD_CUDA;GINKGO_BUILD_HIP;GINKGO_BUILD_DPCPP")
     ginkgo_print_module_footer(${${log_type}} "  Tests, benchmarks and examples:")
     ginkgo_print_foreach_variable(${${log_type}}
-        "GINKGO_BUILD_TESTS;GINKGO_BUILD_EXAMPLES;GINKGO_EXTLIB_EXAMPLE;GINKGO_BUILD_BENCHMARKS;GINKGO_BENCHMARK_ENABLE_TUNING")
+        "GINKGO_BUILD_TESTS;GINKGO_FAST_TESTS;GINKGO_BUILD_EXAMPLES;GINKGO_EXTLIB_EXAMPLE;GINKGO_BUILD_BENCHMARKS;GINKGO_BENCHMARK_ENABLE_TUNING")
     ginkgo_print_module_footer(${${log_type}} "  Documentation:")
     ginkgo_print_foreach_variable(${${log_type}} "GINKGO_BUILD_DOC;GINKGO_VERBOSE_LEVEL")
     ginkgo_print_module_footer(${${log_type}} "")

--- a/cuda/test/factorization/par_ilut_kernels.cpp
+++ b/cuda/test/factorization/par_ilut_kernels.cpp
@@ -71,7 +71,11 @@ protected:
     using ComplexCsr = gko::matrix::Csr<std::complex<value_type>, index_type>;
 
     ParIlut()
+#ifdef GINKGO_FAST_TESTS
+        : mtx_size(152, 231),
+#else
         : mtx_size(532, 423),
+#endif
           rand_engine(1337),
           ref(gko::ReferenceExecutor::create()),
           cuda(gko::CudaExecutor::create(0, ref))

--- a/cuda/test/matrix/csr_kernels.cpp
+++ b/cuda/test/matrix/csr_kernels.cpp
@@ -67,7 +67,14 @@ protected:
     using ComplexVec = gko::matrix::Dense<std::complex<double>>;
     using ComplexMtx = gko::matrix::Csr<std::complex<double>>;
 
-    Csr() : mtx_size(532, 231), rand_engine(42) {}
+    Csr()
+#ifdef GINKGO_FAST_TESTS
+        : mtx_size(152, 231),
+#else
+        : mtx_size(532, 231),
+#endif
+          rand_engine(42)
+    {}
 
     void SetUp()
     {
@@ -464,10 +471,10 @@ TEST_F(Csr, AdvancedApplyToIdentityMatrixIsEquivalentToRef)
 TEST_F(Csr, ApplyToComplexIsEquivalentToRef)
 {
     set_up_apply_data(std::make_shared<Mtx::automatical>());
-    auto complex_b = gen_mtx<ComplexVec>(231, 3, 1);
+    auto complex_b = gen_mtx<ComplexVec>(this->mtx_size[1], 3, 1);
     auto dcomplex_b = ComplexVec::create(cuda);
     dcomplex_b->copy_from(complex_b.get());
-    auto complex_x = gen_mtx<ComplexVec>(532, 3, 1);
+    auto complex_x = gen_mtx<ComplexVec>(this->mtx_size[0], 3, 1);
     auto dcomplex_x = ComplexVec::create(cuda);
     dcomplex_x->copy_from(complex_x.get());
 
@@ -481,10 +488,10 @@ TEST_F(Csr, ApplyToComplexIsEquivalentToRef)
 TEST_F(Csr, AdvancedApplyToComplexIsEquivalentToRef)
 {
     set_up_apply_data(std::make_shared<Mtx::automatical>());
-    auto complex_b = gen_mtx<ComplexVec>(231, 3, 1);
+    auto complex_b = gen_mtx<ComplexVec>(this->mtx_size[1], 3, 1);
     auto dcomplex_b = ComplexVec::create(cuda);
     dcomplex_b->copy_from(complex_b.get());
-    auto complex_x = gen_mtx<ComplexVec>(532, 3, 1);
+    auto complex_x = gen_mtx<ComplexVec>(this->mtx_size[0], 3, 1);
     auto dcomplex_x = ComplexVec::create(cuda);
     dcomplex_x->copy_from(complex_x.get());
 

--- a/cuda/test/matrix/diagonal_kernels.cpp
+++ b/cuda/test/matrix/diagonal_kernels.cpp
@@ -62,7 +62,14 @@ protected:
     using Dense = gko::matrix::Dense<ValueType>;
     using ComplexDiag = gko::matrix::Diagonal<ComplexValueType>;
 
-    Diagonal() : mtx_size(532, 231), rand_engine(42) {}
+    Diagonal()
+#ifdef GINKGO_FAST_TESTS
+        : mtx_size(152, 231),
+#else
+        : mtx_size(532, 231),
+#endif
+          rand_engine(42)
+    {}
 
     void SetUp()
     {

--- a/cuda/test/solver/cb_gmres_kernels.cpp
+++ b/cuda/test/solver/cb_gmres_kernels.cpp
@@ -119,7 +119,11 @@ protected:
 
     void initialize_data()
     {
+#ifdef GINKGO_FAST_TESTS
+        int m = 123;
+#else
         int m = 597;
+#endif
         int n = 43;
         x = gen_mtx(m, n);
         y = gen_mtx(default_krylov_dim_mixed, n);

--- a/cuda/test/solver/gmres_kernels.cpp
+++ b/cuda/test/solver/gmres_kernels.cpp
@@ -92,7 +92,11 @@ protected:
 
     void initialize_data(int nrhs = 43)
     {
+#ifdef GINKGO_FAST_TESTS
+        int m = 123;
+#else
         int m = 597;
+#endif
         x = gen_mtx(m, nrhs);
         y = gen_mtx(gko::solver::default_krylov_dim, nrhs);
         before_preconditioner = Mtx::create_with_config_of(x.get());

--- a/hip/test/factorization/par_ilut_kernels.hip.cpp
+++ b/hip/test/factorization/par_ilut_kernels.hip.cpp
@@ -72,7 +72,11 @@ protected:
     using ComplexCsr = gko::matrix::Csr<std::complex<value_type>, index_type>;
 
     ParIlut()
+#ifdef GINKGO_FAST_TESTS
+        : mtx_size(152, 231),
+#else
         : mtx_size(500, 700),
+#endif
           rand_engine(1337),
           ref(gko::ReferenceExecutor::create()),
           hip(gko::HipExecutor::create(0, ref))

--- a/hip/test/matrix/csr_kernels.hip.cpp
+++ b/hip/test/matrix/csr_kernels.hip.cpp
@@ -67,7 +67,14 @@ protected:
     using ComplexVec = gko::matrix::Dense<std::complex<double>>;
     using ComplexMtx = gko::matrix::Csr<std::complex<double>>;
 
-    Csr() : mtx_size(532, 231), rand_engine(42) {}
+    Csr()
+#ifdef GINKGO_FAST_TESTS
+        : mtx_size(152, 231),
+#else
+        : mtx_size(532, 231),
+#endif
+          rand_engine(42)
+    {}
 
     void SetUp()
     {
@@ -458,10 +465,10 @@ TEST_F(Csr, AdvancedApplyToIdentityMatrixIsEquivalentToRef)
 TEST_F(Csr, ApplyToComplexIsEquivalentToRef)
 {
     set_up_apply_data(std::make_shared<Mtx::automatical>(hip));
-    auto complex_b = gen_mtx<ComplexVec>(231, 3, 1);
+    auto complex_b = gen_mtx<ComplexVec>(this->mtx_size[1], 3, 1);
     auto dcomplex_b = ComplexVec::create(hip);
     dcomplex_b->copy_from(complex_b.get());
-    auto complex_x = gen_mtx<ComplexVec>(532, 3, 1);
+    auto complex_x = gen_mtx<ComplexVec>(this->mtx_size[0], 3, 1);
     auto dcomplex_x = ComplexVec::create(hip);
     dcomplex_x->copy_from(complex_x.get());
 
@@ -475,10 +482,10 @@ TEST_F(Csr, ApplyToComplexIsEquivalentToRef)
 TEST_F(Csr, AdvancedApplyToComplexIsEquivalentToRef)
 {
     set_up_apply_data(std::make_shared<Mtx::automatical>(hip));
-    auto complex_b = gen_mtx<ComplexVec>(231, 3, 1);
+    auto complex_b = gen_mtx<ComplexVec>(this->mtx_size[1], 3, 1);
     auto dcomplex_b = ComplexVec::create(hip);
     dcomplex_b->copy_from(complex_b.get());
-    auto complex_x = gen_mtx<ComplexVec>(532, 3, 1);
+    auto complex_x = gen_mtx<ComplexVec>(this->mtx_size[0], 3, 1);
     auto dcomplex_x = ComplexVec::create(hip);
     dcomplex_x->copy_from(complex_x.get());
 

--- a/hip/test/matrix/diagonal_kernels.hip.cpp
+++ b/hip/test/matrix/diagonal_kernels.hip.cpp
@@ -62,7 +62,14 @@ protected:
     using Dense = gko::matrix::Dense<ValueType>;
     using ComplexDiag = gko::matrix::Diagonal<ComplexValueType>;
 
-    Diagonal() : mtx_size(532, 231), rand_engine(42) {}
+    Diagonal()
+#ifdef GINKGO_FAST_TESTS
+        : mtx_size(152, 231),
+#else
+        : mtx_size(532, 231),
+#endif
+          rand_engine(42)
+    {}
 
     void SetUp()
     {

--- a/hip/test/solver/cb_gmres_kernels.cpp
+++ b/hip/test/solver/cb_gmres_kernels.cpp
@@ -119,7 +119,11 @@ protected:
 
     void initialize_data()
     {
+#ifdef GINKGO_FAST_TESTS
+        int m = 123;
+#else
         int m = 597;
+#endif
         int n = 43;
         x = gen_mtx(m, n);
         y = gen_mtx(default_krylov_dim_mixed, n);

--- a/hip/test/solver/gmres_kernels.cpp
+++ b/hip/test/solver/gmres_kernels.cpp
@@ -93,7 +93,11 @@ protected:
 
     void initialize_data(int nrhs = 43)
     {
+#ifdef GINKGO_FAST_TESTS
+        int m = 123;
+#else
         int m = 597;
+#endif
         x = gen_mtx(m, nrhs);
         y = gen_mtx(gko::solver::default_krylov_dim, nrhs);
         before_preconditioner = Mtx::create_with_config_of(x.get());

--- a/omp/test/factorization/par_ict_kernels.cpp
+++ b/omp/test/factorization/par_ict_kernels.cpp
@@ -71,7 +71,11 @@ protected:
     using Csr = gko::matrix::Csr<value_type, index_type>;
 
     ParIct()
+#ifdef GINKGO_FAST_TESTS
+        : mtx_size(152, 152),
+#else
         : mtx_size(532, 532),
+#endif
           rand_engine(567321),
           ref(gko::ReferenceExecutor::create()),
           omp(gko::OmpExecutor::create())

--- a/omp/test/factorization/par_ilut_kernels.cpp
+++ b/omp/test/factorization/par_ilut_kernels.cpp
@@ -72,7 +72,11 @@ protected:
     using Csr = gko::matrix::Csr<value_type, index_type>;
 
     ParIlut()
+#ifdef GINKGO_FAST_TESTS
+        : mtx_size(152, 231),
+#else
         : mtx_size(532, 423),
+#endif
           rand_engine(1337),
           ref(gko::ReferenceExecutor::create()),
           omp(gko::OmpExecutor::create())

--- a/omp/test/matrix/csr_kernels.cpp
+++ b/omp/test/matrix/csr_kernels.cpp
@@ -67,7 +67,14 @@ protected:
     using ComplexVec = gko::matrix::Dense<std::complex<double>>;
     using ComplexMtx = gko::matrix::Csr<std::complex<double>>;
 
-    Csr() : mtx_size(532, 231), rand_engine(42) {}
+    Csr()
+#ifdef GINKGO_FAST_TESTS
+        : mtx_size(152, 185),
+#else
+        : mtx_size(532, 231),
+#endif
+          rand_engine(42)
+    {}
 
     void SetUp()
     {
@@ -285,10 +292,10 @@ TEST_F(Csr, AdvancedApplyToDenseMatrixIsEquivalentToRef)
 TEST_F(Csr, ApplyToComplexIsEquivalentToRef)
 {
     set_up_apply_data(3);
-    auto complex_b = gen_mtx<ComplexVec>(231, 3, 1);
+    auto complex_b = gen_mtx<ComplexVec>(this->mtx_size[1], 3, 1);
     auto dcomplex_b = ComplexVec::create(omp);
     dcomplex_b->copy_from(complex_b.get());
-    auto complex_x = gen_mtx<ComplexVec>(532, 3, 1);
+    auto complex_x = gen_mtx<ComplexVec>(this->mtx_size[0], 3, 1);
     auto dcomplex_x = ComplexVec::create(omp);
     dcomplex_x->copy_from(complex_x.get());
 
@@ -302,10 +309,10 @@ TEST_F(Csr, ApplyToComplexIsEquivalentToRef)
 TEST_F(Csr, AdvancedApplyToComplexIsEquivalentToRef)
 {
     set_up_apply_data(3);
-    auto complex_b = gen_mtx<ComplexVec>(231, 3, 1);
+    auto complex_b = gen_mtx<ComplexVec>(this->mtx_size[1], 3, 1);
     auto dcomplex_b = ComplexVec::create(omp);
     dcomplex_b->copy_from(complex_b.get());
-    auto complex_x = gen_mtx<ComplexVec>(532, 3, 1);
+    auto complex_x = gen_mtx<ComplexVec>(this->mtx_size[0], 3, 1);
     auto dcomplex_x = ComplexVec::create(omp);
     dcomplex_x->copy_from(complex_x.get());
 

--- a/omp/test/matrix/diagonal_kernels.cpp
+++ b/omp/test/matrix/diagonal_kernels.cpp
@@ -62,7 +62,14 @@ protected:
     using Dense = gko::matrix::Dense<ValueType>;
     using ComplexDiag = gko::matrix::Diagonal<ComplexValueType>;
 
-    Diagonal() : mtx_size(532, 231), rand_engine(42) {}
+    Diagonal()
+#ifdef GINKGO_FAST_TESTS
+        : mtx_size(152, 185),
+#else
+        : mtx_size(532, 231),
+#endif
+          rand_engine(42)
+    {}
 
     void SetUp()
     {

--- a/omp/test/solver/cb_gmres_kernels.cpp
+++ b/omp/test/solver/cb_gmres_kernels.cpp
@@ -121,7 +121,11 @@ protected:
 
     void initialize_data()
     {
+#ifdef GINKGO_FAST_TESTS
+        int m = 123;
+#else
         int m = 597;
+#endif
         int n = 43;
         x = gen_mtx(m, n);
         y = gen_mtx(default_krylov_dim_mixed, n);

--- a/omp/test/solver/gmres_kernels.cpp
+++ b/omp/test/solver/gmres_kernels.cpp
@@ -125,7 +125,11 @@ protected:
 
     void initialize_data()
     {
+#ifdef GINKGO_FAST_TESTS
+        int m = 123;
+#else
         int m = 597;
+#endif
         int n = 43;
         x = gen_mtx(m, n);
         y = gen_mtx(gko::solver::default_krylov_dim, n);


### PR DESCRIPTION
Now that the builds are blazingly fast thanks to #739 the tests are starting to dominate our runtime, and there are a few outliers that IMO don't justify their long runtime.

This PR adds the (off-by-default) CMake flag GINKGO_FAST_TESTS that reduces the input size for a few tests known to be slow and uses it in Debug CI jobs. An example why I would consider this necessary is https://gitlab.com/ginkgo-project/ginkgo-public-ci/-/jobs/1169715092 which takes more than 2 hours to complete.

The tests in question are:

GPU
* ParILUT
* CSR
* Diagonal
* (CB)GMRES

OpenMP
* ParICT
* ParILUT
* CSR
* Dense
* Diagonal
* (CB)GMRES

The reason I would not consider this an issue is that

1. CUDA compiles the kernels in Release mode independent of the CMake build type, so we would catch failures with Release builds, too
2. OpenMP doesn't have any parameters like block sizes we need to exceed to cover all possible scenarios.