### PR TITLE
Fix criterion check logger

### DIFF
--- a/core/log/record.cpp
+++ b/core/log/record.cpp
@@ -244,7 +244,8 @@ void Record::on_criterion_check_started(
 
 void Record::on_criterion_check_completed(
     const stop::Criterion *criterion, const size_type &num_iterations,
-    const LinOp *residual, const LinOp *residual_norm, const LinOp *solution,
+    const LinOp *residual, const LinOp *residual_norm,
+    const LinOp *implicit_residual_norm_sq, const LinOp *solution,
     const uint8 &stopping_id, const bool &set_finalized,
     const Array<stopping_status> *status, const bool &oneChanged,
     const bool &converged) const
@@ -254,6 +255,19 @@ void Record::on_criterion_check_completed(
         (std::unique_ptr<criterion_data>(new criterion_data{
             criterion, num_iterations, residual, residual_norm, solution,
             stopping_id, set_finalized, status, oneChanged, converged})));
+}
+
+
+void Record::on_criterion_check_completed(
+    const stop::Criterion *criterion, const size_type &num_iterations,
+    const LinOp *residual, const LinOp *residual_norm, const LinOp *solution,
+    const uint8 &stopping_id, const bool &set_finalized,
+    const Array<stopping_status> *status, const bool &oneChanged,
+    const bool &converged) const
+{
+    this->on_criterion_check_completed(
+        criterion, num_iterations, residual, residual_norm, nullptr, solution,
+        stopping_id, set_finalized, status, oneChanged, converged);
 }
 
 

--- a/include/ginkgo/core/log/logger.hpp
+++ b/include/ginkgo/core/log/logger.hpp
@@ -417,7 +417,7 @@ protected:
         const Array<stopping_status> *status, const bool &one_changed,
         const bool &all_converged) const
     {
-        this->on_criterion_check_completed(criterion, it, r, x, tau, x,
+        this->on_criterion_check_completed(criterion, it, r, tau, x,
                                            stopping_id, set_finalized, status,
                                            one_changed, all_converged);
     }

--- a/include/ginkgo/core/log/record.hpp
+++ b/include/ginkgo/core/log/record.hpp
@@ -366,6 +366,14 @@ public:
     void on_criterion_check_completed(
         const stop::Criterion *criterion, const size_type &num_iterations,
         const LinOp *residual, const LinOp *residual_norm,
+        const LinOp *implicit_residual_norm_sq, const LinOp *solution,
+        const uint8 &stopping_id, const bool &set_finalized,
+        const Array<stopping_status> *status, const bool &one_changed,
+        const bool &all_converged) const override;
+
+    void on_criterion_check_completed(
+        const stop::Criterion *criterion, const size_type &num_iterations,
+        const LinOp *residual, const LinOp *residual_norm,
         const LinOp *solution, const uint8 &stopping_id,
         const bool &set_finalized, const Array<stopping_status> *status,
         const bool &one_changed, const bool &all_converged) const override;


### PR DESCRIPTION
The logger::on_criterion_check_complete function accidentally calls itself recursively. This PR adds a test to detect that behavior and fixes it together with a `partially overridden` warning in record.hpp