### PR TITLE
Add exact forward error computation for trisolve benchmark

### DIFF
--- a/benchmark/utils/general.hpp
+++ b/benchmark/utils/general.hpp
@@ -429,6 +429,21 @@ gko::remove_complex<ValueType> compute_norm2(const vec<ValueType>* b)
 
 
 template <typename ValueType>
+gko::remove_complex<ValueType> compute_direct_error(const gko::LinOp *solver,
+                                                    const vec<ValueType> *b,
+                                                    const vec<ValueType> *x)
+{
+    auto exec = solver->get_executor();
+    auto ref_solver = gko::clone(gko::ReferenceExecutor::create(), solver);
+    auto one = gko::initialize<vec<ValueType>>({1.0}, exec);
+    auto neg_one = gko::initialize<vec<ValueType>>({-1.0}, exec);
+    auto res = clone(x);
+    ref_solver->apply(lend(one), lend(b), lend(neg_one), lend(res));
+    return compute_norm2(lend(res));
+}
+
+
+template <typename ValueType>
 gko::remove_complex<ValueType> compute_residual_norm(
     const gko::LinOp* system_matrix, const vec<ValueType>* b,
     const vec<ValueType>* x)


### PR DESCRIPTION
Checking the triangular solvers for correctness is a bit annoying, since some of the triangular systems we are checking are very ill-conditioned. Thus this PR adds a direct forward error calculation for these solvers based on the reference executor, which should give bitwise identical results for all straightforward trisolve implementations (not including blocked and warp-parallel solves here)

- [x] Merge #753 