### PR TITLE
Add logger access and clear functions

### DIFF
--- a/core/test/log/logger.cpp
+++ b/core/test/log/logger.cpp
@@ -86,6 +86,40 @@ TEST(DummyLogged, CanAddMultipleLoggers)
 }
 
 
+TEST(DummyLogged, CanAccessLoggers)
+{
+    auto exec = gko::ReferenceExecutor::create();
+    DummyLoggedClass c;
+
+    auto logger1 = gko::share(
+        gko::log::Record::create(exec, gko::log::Logger::all_events_mask));
+    auto logger2 = gko::share(gko::log::Stream<>::create(
+        exec, gko::log::Logger::all_events_mask, std::cout));
+
+    c.add_logger(logger1);
+    c.add_logger(logger2);
+
+    ASSERT_EQ(c.get_loggers()[0], logger1);
+    ASSERT_EQ(c.get_loggers()[1], logger2);
+    ASSERT_EQ(c.get_num_loggers(), 2);
+}
+
+
+TEST(DummyLogged, CanClearLoggers)
+{
+    auto exec = gko::ReferenceExecutor::create();
+    DummyLoggedClass c;
+    c.add_logger(
+        gko::log::Record::create(exec, gko::log::Logger::all_events_mask));
+    c.add_logger(gko::log::Stream<>::create(
+        exec, gko::log::Logger::all_events_mask, std::cout));
+
+    c.clear_loggers();
+
+    ASSERT_EQ(c.get_num_loggers(), 0);
+}
+
+
 TEST(DummyLogged, CanRemoveLogger)
 {
     auto exec = gko::ReferenceExecutor::create();

--- a/include/ginkgo/core/log/logger.hpp
+++ b/include/ginkgo/core/log/logger.hpp
@@ -594,6 +594,19 @@ public:
         }
     }
 
+    /**
+     * Returns the vector containing all loggers registered at this object.
+     *
+     * @return the vector containing all registered loggers.
+     */
+    const std::vector<std::shared_ptr<const Logger>> &get_loggers() const
+    {
+        return loggers_;
+    }
+
+    /** Remove all loggers registered at this object. */
+    void clear_loggers() { loggers_.clear(); }
+
 protected:
     template <size_type Event, typename... Params>
     void log(Params &&... params) const


### PR DESCRIPTION
Adds a clear_loggers() and get_loggers() function to EnableLogging to allow users to modify the set of loggers explicitly.