### PR TITLE
Allow using device memory allocations in debug mode.

### DIFF
--- a/core/device_hooks/cuda_hooks.cpp
+++ b/core/device_hooks/cuda_hooks.cpp
@@ -55,10 +55,11 @@ version version_info::get_cuda_version() noexcept
 
 
 std::shared_ptr<CudaExecutor> CudaExecutor::create(
-    int device_id, std::shared_ptr<Executor> master, bool device_reset)
+    int device_id, std::shared_ptr<Executor> master, bool device_reset,
+    bool use_unified_mem)
 {
-    return std::shared_ptr<CudaExecutor>(
-        new CudaExecutor(device_id, std::move(master), device_reset));
+    return std::shared_ptr<CudaExecutor>(new CudaExecutor(
+        device_id, std::move(master), device_reset, use_unified_mem));
 }
 
 

--- a/core/device_hooks/cuda_hooks.cpp
+++ b/core/device_hooks/cuda_hooks.cpp
@@ -56,10 +56,10 @@ version version_info::get_cuda_version() noexcept
 
 std::shared_ptr<CudaExecutor> CudaExecutor::create(
     int device_id, std::shared_ptr<Executor> master, bool device_reset,
-    bool use_unified_mem)
+    allocation_mode alloc_mode)
 {
     return std::shared_ptr<CudaExecutor>(new CudaExecutor(
-        device_id, std::move(master), device_reset, use_unified_mem));
+        device_id, std::move(master), device_reset, alloc_mode));
 }
 
 

--- a/core/device_hooks/hip_hooks.cpp
+++ b/core/device_hooks/hip_hooks.cpp
@@ -52,10 +52,11 @@ version version_info::get_hip_version() noexcept
 
 
 std::shared_ptr<HipExecutor> HipExecutor::create(
-    int device_id, std::shared_ptr<Executor> master, bool device_reset)
+    int device_id, std::shared_ptr<Executor> master, bool device_reset,
+    bool use_unified_mem)
 {
-    return std::shared_ptr<HipExecutor>(
-        new HipExecutor(device_id, std::move(master), device_reset));
+    return std::shared_ptr<HipExecutor>(new HipExecutor(
+        device_id, std::move(master), device_reset, use_unified_mem));
 }
 
 

--- a/core/device_hooks/hip_hooks.cpp
+++ b/core/device_hooks/hip_hooks.cpp
@@ -53,10 +53,10 @@ version version_info::get_hip_version() noexcept
 
 std::shared_ptr<HipExecutor> HipExecutor::create(
     int device_id, std::shared_ptr<Executor> master, bool device_reset,
-    bool use_unified_mem)
+    allocation_mode alloc_mode)
 {
     return std::shared_ptr<HipExecutor>(new HipExecutor(
-        device_id, std::move(master), device_reset, use_unified_mem));
+        device_id, std::move(master), device_reset, alloc_mode));
 }
 
 

--- a/cuda/base/executor.cpp
+++ b/cuda/base/executor.cpp
@@ -57,11 +57,11 @@ namespace gko {
 
 std::shared_ptr<CudaExecutor> CudaExecutor::create(
     int device_id, std::shared_ptr<Executor> master, bool device_reset,
-    bool use_unified_mem)
+    allocation_mode alloc_mode)
 {
     return std::shared_ptr<CudaExecutor>(
         new CudaExecutor(device_id, std::move(master), device_reset,
-                         use_unified_mem),
+                         alloc_mode),
         [device_id](CudaExecutor *exec) {
             auto device_reset = exec->get_device_reset();
             delete exec;
@@ -127,10 +127,15 @@ void *CudaExecutor::raw_alloc(size_type num_bytes) const
     void *dev_ptr = nullptr;
     cuda::device_guard g(this->get_device_id());
     int error_code = 0;
-    if (this->use_unified_memory_) {
-        error_code = cudaMallocManaged(&dev_ptr, num_bytes);
-    } else {
+    if (this->alloc_mode_ == allocation_mode::unified_host) {
+        error_code = cudaMallocManaged(&dev_ptr, num_bytes, cudaMemAttachHost);
+    } else if (this->alloc_mode_ == allocation_mode::unified_global) {
+        error_code =
+            cudaMallocManaged(&dev_ptr, num_bytes, cudaMemAttachGlobal);
+    } else if (this->alloc_mode_ == allocation_mode::device) {
         error_code = cudaMalloc(&dev_ptr, num_bytes);
+    } else {
+        GKO_NOT_SUPPORTED(this->alloc_mode_);
     }
     if (error_code != cudaErrorMemoryAllocation) {
         GKO_ASSERT_NO_CUDA_ERRORS(error_code);

--- a/cuda/base/executor.cpp
+++ b/cuda/base/executor.cpp
@@ -56,10 +56,12 @@ namespace gko {
 
 
 std::shared_ptr<CudaExecutor> CudaExecutor::create(
-    int device_id, std::shared_ptr<Executor> master, bool device_reset)
+    int device_id, std::shared_ptr<Executor> master, bool device_reset,
+    bool use_unified_mem)
 {
     return std::shared_ptr<CudaExecutor>(
-        new CudaExecutor(device_id, std::move(master), device_reset),
+        new CudaExecutor(device_id, std::move(master), device_reset,
+                         use_unified_mem),
         [device_id](CudaExecutor *exec) {
             auto device_reset = exec->get_device_reset();
             delete exec;
@@ -124,11 +126,12 @@ void *CudaExecutor::raw_alloc(size_type num_bytes) const
 {
     void *dev_ptr = nullptr;
     cuda::device_guard g(this->get_device_id());
-#ifdef NDEBUG
-    auto error_code = cudaMalloc(&dev_ptr, num_bytes);
-#else
-    auto error_code = cudaMallocManaged(&dev_ptr, num_bytes);
-#endif
+    int error_code = 0;
+    if (this->use_unified_memory_) {
+        error_code = cudaMallocManaged(&dev_ptr, num_bytes);
+    } else {
+        error_code = cudaMalloc(&dev_ptr, num_bytes);
+    }
     if (error_code != cudaErrorMemoryAllocation) {
         GKO_ASSERT_NO_CUDA_ERRORS(error_code);
     }

--- a/cuda/test/base/cuda_executor.cu
+++ b/cuda/test/base/cuda_executor.cu
@@ -98,7 +98,8 @@ protected:
         cuda = gko::CudaExecutor::create(0, omp);
         cuda2 = gko::CudaExecutor::create(
             gko::CudaExecutor::get_num_devices() - 1, omp);
-        cuda3 = gko::CudaExecutor::create(0, omp, false, true);
+        cuda3 = gko::CudaExecutor::create(0, omp, false,
+                                          gko::allocation_mode::unified_host);
     }
 
     void TearDown()

--- a/cuda/test/base/cuda_executor.cu
+++ b/cuda/test/base/cuda_executor.cu
@@ -86,7 +86,10 @@ public:
 class CudaExecutor : public ::testing::Test {
 protected:
     CudaExecutor()
-        : omp(gko::OmpExecutor::create()), cuda(nullptr), cuda2(nullptr)
+        : omp(gko::OmpExecutor::create()),
+          cuda(nullptr),
+          cuda2(nullptr),
+          cuda3(nullptr)
     {}
 
     void SetUp()
@@ -95,6 +98,7 @@ protected:
         cuda = gko::CudaExecutor::create(0, omp);
         cuda2 = gko::CudaExecutor::create(
             gko::CudaExecutor::get_num_devices() - 1, omp);
+        cuda3 = gko::CudaExecutor::create(0, omp, false, true);
     }
 
     void TearDown()
@@ -108,6 +112,7 @@ protected:
     std::shared_ptr<gko::Executor> omp;
     std::shared_ptr<gko::CudaExecutor> cuda;
     std::shared_ptr<gko::CudaExecutor> cuda2;
+    std::shared_ptr<gko::CudaExecutor> cuda3;
 };
 
 
@@ -163,6 +168,7 @@ __global__ void check_data(int *data)
     }
 }
 
+
 TEST_F(CudaExecutor, CopiesDataToCuda)
 {
     int orig[] = {3, 8};
@@ -173,6 +179,29 @@ TEST_F(CudaExecutor, CopiesDataToCuda)
     check_data<<<1, 1>>>(copy);
     ASSERT_NO_THROW(cuda->synchronize());
     cuda->free(copy);
+}
+
+
+__global__ void check_data2(int *data)
+{
+    if (data[0] != 4 || data[1] != 8) {
+        asm("trap;");
+    }
+}
+
+
+TEST_F(CudaExecutor, CanAllocateOnUnifiedMemory)
+{
+    int orig[] = {3, 8};
+    auto *copy = cuda3->alloc<int>(2);
+
+    cuda3->copy_from(omp.get(), 2, orig, copy);
+
+    check_data<<<1, 1>>>(copy);
+    ASSERT_NO_THROW(cuda3->synchronize());
+    copy[0] = 4;
+    check_data2<<<1, 1>>>(copy);
+    cuda3->free(copy);
 }
 
 

--- a/cuda/test/base/cuda_executor.cu
+++ b/cuda/test/base/cuda_executor.cu
@@ -99,7 +99,7 @@ protected:
         cuda2 = gko::CudaExecutor::create(
             gko::CudaExecutor::get_num_devices() - 1, omp);
         cuda3 = gko::CudaExecutor::create(0, omp, false,
-                                          gko::allocation_mode::unified_host);
+                                          gko::allocation_mode::unified_global);
     }
 
     void TearDown()

--- a/hip/base/executor.hip.cpp
+++ b/hip/base/executor.hip.cpp
@@ -126,12 +126,14 @@ void *HipExecutor::raw_alloc(size_type num_bytes) const
     void *dev_ptr = nullptr;
     hip::device_guard g(this->get_device_id());
     int error_code = 0;
-    if (this->alloc_mode_ == allocation_mode::unified_host) {
-        error_code = hipMallocManaged(&dev_ptr, num_bytes, hipMemAttachHost);
+    if (this->alloc_mode_ == allocation_mode::device) {
+        error_code = hipMalloc(&dev_ptr, num_bytes);
+#if !(GKO_HIP_PLATFORM_HCC == 1)
     } else if (this->alloc_mode_ == allocation_mode::unified_global) {
         error_code = hipMallocManaged(&dev_ptr, num_bytes, hipMemAttachGlobal);
-    } else if (this->alloc_mode_ == allocation_mode::device) {
-        error_code = hipMalloc(&dev_ptr, num_bytes);
+    } else if (this->alloc_mode_ == allocation_mode::unified_host) {
+        error_code = hipMallocManaged(&dev_ptr, num_bytes, hipMemAttachHost);
+#endif
     } else {
         GKO_NOT_SUPPORTED(this->alloc_mode_);
     }

--- a/hip/test/base/hip_executor.hip.cpp
+++ b/hip/test/base/hip_executor.hip.cpp
@@ -104,7 +104,8 @@ protected:
         hip = gko::HipExecutor::create(0, omp);
         hip2 = gko::HipExecutor::create(gko::HipExecutor::get_num_devices() - 1,
                                         omp);
-        hip = gko::HipExecutor::create(0, omp, false, true);
+        hip3 = gko::HipExecutor::create(0, omp, false,
+                                        gko::allocation_mode::unified_global);
     }
 
     void TearDown()
@@ -209,7 +210,7 @@ __global__ void check_data2(int *data)
 TEST_F(HipExecutor, CanAllocateOnUnifiedMemory)
 {
     int orig[] = {3, 8};
-    auto *copy = hip->alloc<int>(2);
+    auto *copy = hip3->alloc<int>(2);
 
     hip3->copy_from(omp.get(), 2, orig, copy);
 

--- a/hip/test/base/hip_executor.hip.cpp
+++ b/hip/test/base/hip_executor.hip.cpp
@@ -91,7 +91,11 @@ public:
 
 class HipExecutor : public ::testing::Test {
 protected:
-    HipExecutor() : omp(gko::OmpExecutor::create()), hip(nullptr), hip2(nullptr)
+    HipExecutor()
+        : omp(gko::OmpExecutor::create()),
+          hip(nullptr),
+          hip2(nullptr),
+          hip3(nullptr)
     {}
 
     void SetUp()
@@ -100,6 +104,7 @@ protected:
         hip = gko::HipExecutor::create(0, omp);
         hip2 = gko::HipExecutor::create(gko::HipExecutor::get_num_devices() - 1,
                                         omp);
+        hip = gko::HipExecutor::create(0, omp, false, true);
     }
 
     void TearDown()
@@ -113,6 +118,7 @@ protected:
     std::shared_ptr<gko::Executor> omp;
     std::shared_ptr<gko::HipExecutor> hip;
     std::shared_ptr<gko::HipExecutor> hip2;
+    std::shared_ptr<gko::HipExecutor> hip3;
 };
 
 
@@ -183,6 +189,39 @@ TEST_F(HipExecutor, CopiesDataToHip)
     ASSERT_NO_THROW(hip->synchronize());
     hip->free(copy);
 }
+
+
+__global__ void check_data2(int *data)
+{
+    if (data[0] != 4 || data[1] != 8) {
+#if GINKGO_HIP_PLATFORM_HCC
+        asm("s_trap 0x02;");
+#else  // GINKGO_HIP_PLATFORM_NVCC
+        asm("trap;");
+#endif
+    }
+}
+
+
+#if GINKGO_HIP_PLATFORM_NVCC
+
+
+TEST_F(HipExecutor, CanAllocateOnUnifiedMemory)
+{
+    int orig[] = {3, 8};
+    auto *copy = hip->alloc<int>(2);
+
+    hip3->copy_from(omp.get(), 2, orig, copy);
+
+    check_data<<<1, 1>>>(copy);
+    ASSERT_NO_THROW(hip3->synchronize());
+    copy[0] = 4;
+    check_data2<<<1, 1>>>(copy);
+    hip3->free(copy);
+}
+
+
+#endif
 
 
 __global__ void init_data(int *data)


### PR DESCRIPTION
Currently, we always use Unified memory for debug builds. While this helps for debugging in some cases, it can be a bit annoying because release and debug builds have different behaviours. 

This PR allows the user to specify whether or not to use the allocation using the unified memory. The default behaviour is the same as current behaviour currently controlled by pre-processor defines.