### PR TITLE
Make array constructor explicit

### DIFF
--- a/include/ginkgo/core/base/array.hpp
+++ b/include/ginkgo/core/base/array.hpp
@@ -122,7 +122,7 @@ public:
      *
      * @param exec  the Executor where the array data is allocated
      */
-    Array(std::shared_ptr<const Executor> exec) noexcept
+    explicit Array(std::shared_ptr<const Executor> exec) noexcept
         : num_elems_(0),
           data_(nullptr, default_deleter{exec}),
           exec_(std::move(exec))


### PR DESCRIPTION
This PR prevents Executors from being accidentally converted to empty Arrays. It is technically interface breaking, but like the explicit bool conversion previously, I think it only prevents accidental misuse