### PR TITLE
Add benchmarking support for Batch matrix formats

### DIFF
--- a/benchmark/run_all_benchmarks.sh
+++ b/benchmark/run_all_benchmarks.sh
@@ -35,9 +35,9 @@ if [ ! "${FORMATS}" ]; then
     FORMATS="batch_csr"
 fi
 
-if [ ! "${NUM_BATCHES}" ]; then
-    NUM_BATCHES="1"
-    echo "NUM_BATCHES environment variable not set - assuming \"${NUM_BATCHES}\"" 1>&2
+if [ ! "${NUM_BATCH_DUP}" ]; then
+    NUM_BATCH_DUP="1"
+    echo "NUM_BATCH_DUP environment variable not set - assuming \"${NUM_BATCH_DUP}\"" 1>&2
 fi
 
 if [ ! "${SOLVERS}" ]; then
@@ -72,7 +72,7 @@ fi
 
 if [ ! "${SOLVERS_JACOBI_MAX_BS}" ]; then
     SOLVERS_JACOBI_MAX_BS="32"
-    "SOLVERS_JACOBI_MAX_BS environment variable not set - assuming \"${SOLVERS_JACOBI_MAX_BS}\"" 1>&2
+    echo "SOLVERS_JACOBI_MAX_BS environment variable not set - assuming \"${SOLVERS_JACOBI_MAX_BS}\"" 1>&2
 fi
 
 if [ ! "${BENCHMARK_PRECISION}" ]; then
@@ -141,6 +141,20 @@ else
     DETAILED_STR="--detailed=true"
 fi
 
+if  [ ! "${BATCH_SCALING}" ] || [ "${BATCH_SCALING}" -eq 0 ]; then
+    BATCH_SCALING_STR="--batch_scaling=false"
+else
+    BATCH_SCALING_STR="--batch_scaling=true"
+fi
+
+if  [ ! "${USE_SUITE_SPARSE}" ] || [ "${USE_SUITE_SPARSE}" -eq 1 ]; then
+    SS_STR="--using_suite_sparse=true"
+    echo "Using matrices from SuiteSparse"
+else
+    SS_STR="--using_suite_sparse=false"
+    echo "Not using matrices from SuiteSparse"
+fi
+
 # This allows using a matrix list file for benchmarking.
 # The file should contains a suitesparse matrix on each line.
 # The allowed formats to target suitesparse matrix is:
@@ -155,6 +169,42 @@ elif [ -f "${MATRIX_LIST_FILE}" ]; then
     use_matrix_list_file=1
 else
     echo -e "A matrix list file was set to ${MATRIX_LIST_FILE} but it cannot be found."
+    exit 1
+fi
+
+if [ ! "${BATCH_MATRIX_LIST_FILE}" ]; then
+    use_batch_matrix_list_file=0
+elif [ -f "${BATCH_MATRIX_LIST_FILE}" ]; then
+    use_batch_matrix_list_file=1
+    echo "A batch matrix list file was set to ${BATCH_MATRIX_LIST_FILE}"
+else
+    echo -e "A batch matrix list file was set to ${BATCH_MATRIX_LIST_FILE} but it cannot be found."
+    exit 1
+fi
+
+# This allows using a folder to automatically read the files in the folder into a matrix.
+# The folder structure for a matrix class with two batch entries could look like this:
+#
+# matrix_class
+# \__1
+#     \__A.mtx
+#     \__b.mtx
+#     \__x0.mtx
+# \__2
+#     \__A.mtx
+#     \__b.mtx
+#     \__x0.mtx
+if [ ! "${BATCH_MATRIX_FOLDER}" ]; then
+    use_batch_matrix=0
+elif [ -d "${BATCH_MATRIX_FOLDER}" ]; then
+    use_batch_matrix=1
+    echo "A batch matrix folder was set to ${BATCH_MATRIX_FOLDER}"
+    if [ -f "${MATRIX_LIST_FILE}" ]; then
+        echo "Cannot use both matrix file list and batch matrix folder. The matrix file list will be ignored."
+        use_matrix_list_file=0
+    fi
+else
+    echo -e "A matrix folder was set to ${BATCH_MATRIX_FOLDER} but it cannot be found."
     exit 1
 fi
 
@@ -238,7 +288,8 @@ run_batch_spmv_benchmarks() {
     cp "$1" "$1.imd" # make sure we're not loosing the original input
     ./spmv/batch_spmv${BENCH_SUFFIX} --backup="$1.bkp" --double_buffer="$1.bkp2" \
                 --executor="${EXECUTOR}" --formats="${FORMATS}" \
-                --num_batches="${NUM_BATCHES}" \
+                --num_duplications="${NUM_BATCH_DUP}" "${BATCH_SCALING_STR}" \
+                --num_batches="${NUM_BATCH_ENTRIES}" "${SS_STR}" \
                 --device_id="${DEVICE_ID}" --gpu_timer=${GPU_TIMER} \
                 <"$1.imd" 2>&1 >"$1"
     keep_latest "$1" "$1.bkp" "$1.bkp2" "$1.imd"
@@ -295,9 +346,63 @@ run_preconditioner_benchmarks() {
 
 
 ################################################################################
+# Batch matrix functionality
+
+count_num_batch_entries() {
+    echo $(($(ls -la $1 | wc -l) - 3))
+}
+
+parse_batch_matrix_list() {
+    local source_list_file=$1
+    local benchmark_list=""
+    for mtx in $(cat ${source_list_file}); do
+        benchmark_list="$benchmark_list $mtx"
+    done
+    echo "$benchmark_list"
+}
+
+if [ $use_batch_matrix -eq 1 ]; then
+    BATCH_MATRIX_LIST=$(parse_batch_matrix_list $BATCH_MATRIX_LIST_FILE)
+    NUM_BATCH_MATS=${#BATCH_MATRIX_LIST[@]}
+    echo "Number of matrices: ${NUM_BATCH_MATS} and the matrices are: ${BATCH_MATRIX_LIST}"
+fi
+
+# Creates an input file for the batch matrix
+generate_batch_input() {
+    BASE_DIR=$1 #${$(dirname $1)}
+    INPUT=$2
+    cat << EOT
+[{
+    "problem": "${BASE_DIR}/${INPUT}"
+}]
+EOT
+}
+
+
+if [ $use_batch_matrix -eq 1 ]; then
+    for (( p=0; p < ${NUM_BATCH_MATS}; ++p )); do
+        i=${BATCH_MATRIX_LIST[$((p))]}
+        lmat=$(echo "$i" | sed 's/^[[:space:]]*//')
+        echo -e "Processing matrix: $lmat"
+        RESULT_DIR="results/${SYSTEM_NAME}/${EXECUTOR}"
+        RESULT_FILE="${RESULT_DIR}/${lmat}.json"
+        mkdir -p "$(dirname "${RESULT_FILE}")"
+        generate_batch_input "$BATCH_MATRIX_FOLDER" "$lmat" > "${RESULT_FILE}"
+        NUM_BATCH_ENTRIES=$(count_num_batch_entries "${BATCH_MATRIX_FOLDER}/${lmat}")
+
+        if [ "${BENCHMARK}" == "batch_spmv" ]; then
+            echo -e "(${p}/${NUM_BATCH_MATS}) Running Batch SpMV for ${lmat} class" 1>&2
+            run_batch_spmv_benchmarks "${RESULT_FILE}"
+        fi
+    done
+fi
+
+################################################################################
 # SuiteSparse collection
 
-SSGET=ssget
+if [ $USE_SUITE_SPARSE -eq 1 ]; then
+
+    SSGET=ssget
 NUM_PROBLEMS="$(${SSGET} -n)"
 
 # Creates an input file for $1-th problem in the SuiteSparse collection
@@ -369,6 +474,7 @@ for (( p=${LOOP_START}; p < ${LOOP_END}; ++p )); do
         run_spmv_benchmarks "${RESULT_FILE}"
     elif [ "${BENCHMARK}" == "batch_spmv" ]; then
         echo -e "${PREFIX}Running Batch SpMV for ${GROUP}/${NAME}" 1>&2
+        NUM_BATCH_ENTRIES=${NUM_BATCH_DUP}
         run_batch_spmv_benchmarks "${RESULT_FILE}"
     fi
 
@@ -482,3 +588,5 @@ for bsize in ${BLOCK_SIZES}; do
         break
     fi
 done
+
+fi

--- a/benchmark/run_all_benchmarks.sh
+++ b/benchmark/run_all_benchmarks.sh
@@ -185,40 +185,18 @@ else
     exit 1
 fi
 
-# This allows using a matrix list file for benchmarking.
-#
-# Each matrix on each line is duplicated NUM_BATCH_DUP times
-# if USE_SUITE_SPARSE is on
-#
-# The file should contains a suitesparse matrix on each line.
-# The allowed formats to target suitesparse matrix is:
-#   id or group/name or name.
-# Example:
-# 1903
-# Freescale/circuit5M
-# thermal2
-if [ ! "${BATCH_MATRIX_LIST_FILE}" ]; then
-    use_batch_matrix_list_file=0
-elif [ -f "${BATCH_MATRIX_LIST_FILE}" ]; then
-    use_batch_matrix_list_file=1
-    echo "A batch matrix list file was set to ${BATCH_MATRIX_LIST_FILE}"
-else
-    echo -e "A batch matrix list file was set to ${BATCH_MATRIX_LIST_FILE} but it cannot be found."
-    exit 1
-fi
-
 # This allows using a folder to automatically read the files in the folder into a matrix.
 # The folder structure for a matrix class with two batch entries should look like this:
 #
 # matrix_class
-# \__1
-#     \__A.mtx
-#     \__b.mtx
-#     \__x0.mtx
-# \__2
-#     \__A.mtx
-#     \__b.mtx
-#     \__x0.mtx
+#    \__1
+#        \__A.mtx
+#        \__b.mtx
+#        \__x0.mtx
+#    \__2
+#        \__A.mtx
+#        \__b.mtx
+#        \__x0.mtx
 if [ ! "${BATCH_MATRIX_FOLDER}" ]; then
     use_batch_matrix=0
 elif [ -d "${BATCH_MATRIX_FOLDER}" ]; then
@@ -230,6 +208,26 @@ elif [ -d "${BATCH_MATRIX_FOLDER}" ]; then
     fi
 else
     echo -e "A matrix folder was set to ${BATCH_MATRIX_FOLDER} but it cannot be found."
+    exit 1
+fi
+
+# This allows using a batch matrix list file for benchmarking.
+#
+# Each list must contain the batch matrix files in a hierarchy, as shown above and
+# each matrix class must be in a separate line.
+#
+# Example:
+# dodecane_lu
+# gri30
+if [ ! "${BATCH_MATRIX_LIST_FILE}" ] && [ -d "${BATCH_MATRIX_FOLDER}" ]; then
+    echo -e "A batch matrix folder was set to ${BATCH_MATRIX_FOLDER} , but no BATCH_MATRIX_LIST_FILE was set."
+    exit 1
+elif [ ! "${BATCH_MATRIX_LIST_FILE}" ] && [ ! "${BATCH_MATRIX_FOLDER}" ]; then
+    use_batch_matrix=0
+elif [ -f "${BATCH_MATRIX_LIST_FILE}" ]; then
+    echo "A batch matrix list file was set to ${BATCH_MATRIX_LIST_FILE}"
+else
+    echo -e "A batch matrix list file was set to ${BATCH_MATRIX_LIST_FILE} but it cannot be found."
     exit 1
 fi
 

--- a/benchmark/run_all_benchmarks.sh
+++ b/benchmark/run_all_benchmarks.sh
@@ -143,10 +143,17 @@ else
     DETAILED_STR="--detailed=true"
 fi
 
-if  [ ! "${BATCH_SCALING}" ] || [ "${BATCH_SCALING}" -eq 0 ]; then
-    BATCH_SCALING_STR="--batch_scaling=false"
-else
-    BATCH_SCALING_STR="--batch_scaling=true"
+if  [ ! "${BATCH_SCALING}" ] ; then
+    BATCH_SCALING_STR="none"
+    echo "BATCH_SCALING_STRING environment variable not set - assuming \"${BATCH_SCALING_STR}\"" 1>&2
+fi
+
+if  [ "${BATCH_SCALING}" == "none" ] ; then
+    BATCH_SCALING_STR="--batch_scaling=none"
+elif  [ "${BATCH_SCALING}" == "implicit" ] ; then
+    BATCH_SCALING_STR="--batch_scaling=implicit"
+elif  [ "${BATCH_SCALING}" == "explicit" ] ; then
+    BATCH_SCALING_STR="--batch_scaling=explicit"
 fi
 
 if [ ! "${USE_SUITE_SPARSE}" ]; then

--- a/benchmark/run_all_benchmarks.sh
+++ b/benchmark/run_all_benchmarks.sh
@@ -388,9 +388,9 @@ parse_batch_matrix_list() {
 }
 
 if [ $use_batch_matrix -eq 1 ]; then
-    BATCH_MATRIX_LIST=$(parse_batch_matrix_list $BATCH_MATRIX_LIST_FILE)
-    NUM_BATCH_MATS=${#BATCH_MATRIX_LIST[@]}
-    echo "Number of matrices: ${NUM_BATCH_MATS} and the matrices are: ${BATCH_MATRIX_LIST}"
+    BATCH_MATRIX_TYPES_LIST=$(parse_batch_matrix_list $BATCH_MATRIX_LIST_FILE)
+    NUM_BATCH_MAT_TYPES=${#BATCH_MATRIX_TYPES_LIST[@]}
+    echo "Number of matrices: ${NUM_BATCH_MAT_TYPES} and the matrices are: ${BATCH_MATRIX_TYPES_LIST}"
 fi
 
 # Creates an input file for the batch matrix
@@ -405,8 +405,8 @@ EOT
 }
 
 if [ $use_batch_matrix -eq 1 ]; then
-    for (( p=0; p < ${NUM_BATCH_MATS}; ++p )); do
-        i=${BATCH_MATRIX_LIST[$((p))]}
+    for (( p=0; p < ${NUM_BATCH_MAT_TYPES}; ++p )); do
+        i=${BATCH_MATRIX_TYPES_LIST[$((p))]}
         lmat=$(echo "$i" | sed 's/^[[:space:]]*//')
         echo -e "Processing matrix: $lmat"
         RESULT_DIR="results/${SYSTEM_NAME}/${EXECUTOR}"
@@ -416,7 +416,7 @@ if [ $use_batch_matrix -eq 1 ]; then
         NUM_BATCH_ENTRIES=$(count_num_batch_entries "${BATCH_MATRIX_FOLDER}/${lmat}")
 
         if [ "${BENCHMARK}" == "batch_spmv" ]; then
-            echo -e "(${p}/${NUM_BATCH_MATS}) Running Batch SpMV for ${lmat} class" 1>&2
+            echo -e "(${p}/${NUM_BATCH_MAT_TYPES}) Running Batch SpMV for ${lmat} class" 1>&2
             run_batch_spmv_benchmarks "${RESULT_FILE}"
         fi
     done

--- a/benchmark/run_all_benchmarks.sh
+++ b/benchmark/run_all_benchmarks.sh
@@ -147,12 +147,16 @@ else
     BATCH_SCALING_STR="--batch_scaling=true"
 fi
 
-if  [ ! "${USE_SUITE_SPARSE}" ] || [ "${USE_SUITE_SPARSE}" -eq 1 ]; then
-    SS_STR="--using_suite_sparse=true"
-    echo "Using matrices from SuiteSparse"
-else
+if [ ! "${USE_SUITE_SPARSE}" ]; then
+    USE_SUITE_SPARSE=1
+fi
+
+if [ "${USE_SUITE_SPARSE}" -eq 0 ]; then
     SS_STR="--using_suite_sparse=false"
     echo "Not using matrices from SuiteSparse"
+else
+    SS_STR="--using_suite_sparse=true"
+    echo "Using matrices from SuiteSparse"
 fi
 
 # This allows using a matrix list file for benchmarking.
@@ -172,6 +176,18 @@ else
     exit 1
 fi
 
+# This allows using a matrix list file for benchmarking.
+#
+# Each matrix on each line is duplicated NUM_BATCH_DUP times
+# if USE_SUITE_SPARSE is on
+#
+# The file should contains a suitesparse matrix on each line.
+# The allowed formats to target suitesparse matrix is:
+#   id or group/name or name.
+# Example:
+# 1903
+# Freescale/circuit5M
+# thermal2
 if [ ! "${BATCH_MATRIX_LIST_FILE}" ]; then
     use_batch_matrix_list_file=0
 elif [ -f "${BATCH_MATRIX_LIST_FILE}" ]; then
@@ -183,7 +199,7 @@ else
 fi
 
 # This allows using a folder to automatically read the files in the folder into a matrix.
-# The folder structure for a matrix class with two batch entries could look like this:
+# The folder structure for a matrix class with two batch entries should look like this:
 #
 # matrix_class
 # \__1
@@ -278,7 +294,7 @@ run_spmv_benchmarks() {
 }
 
 
-# Runs the SpMV benchmarks for all SpMV formats by using file $1 as the input,
+# Runs the batch SpMV benchmarks for all batch formats by using file $1 as the input,
 # and updating it with the results. Backups are created after each
 # benchmark run, to prevent data loss in case of a crash. Once the benchmarking
 # is completed, the backups and the results are combined, and the newest file is
@@ -348,10 +364,12 @@ run_preconditioner_benchmarks() {
 ################################################################################
 # Batch matrix functionality
 
+# Because ls -la always shows first 3 non-essential (for our purposes) lines
 count_num_batch_entries() {
     echo $(($(ls -la $1 | wc -l) - 3))
 }
 
+# Read the list of the batch_mat file and prepare the batch matrix class list.
 parse_batch_matrix_list() {
     local source_list_file=$1
     local benchmark_list=""
@@ -378,7 +396,6 @@ generate_batch_input() {
 EOT
 }
 
-
 if [ $use_batch_matrix -eq 1 ]; then
     for (( p=0; p < ${NUM_BATCH_MATS}; ++p )); do
         i=${BATCH_MATRIX_LIST[$((p))]}
@@ -397,127 +414,128 @@ if [ $use_batch_matrix -eq 1 ]; then
     done
 fi
 
+
 ################################################################################
 # SuiteSparse collection
 
 if [ $USE_SUITE_SPARSE -eq 1 ]; then
 
     SSGET=ssget
-NUM_PROBLEMS="$(${SSGET} -n)"
+    NUM_PROBLEMS="$(${SSGET} -n)"
 
-# Creates an input file for $1-th problem in the SuiteSparse collection
-generate_suite_sparse_input() {
-    INPUT=$(${SSGET} -i "$1" -e)
-    cat << EOT
+    # Creates an input file for $1-th problem in the SuiteSparse collection
+    generate_suite_sparse_input() {
+        INPUT=$(${SSGET} -i "$1" -e)
+        cat << EOT
 [{
     "filename": "${INPUT}",
     "problem": $(${SSGET} -i "$1" -j)
 }]
 EOT
-}
+    }
 
-parse_matrix_list() {
-    local source_list_file=$1
-    local benchmark_list=""
-    local id=0
-    for mtx in $(cat ${source_list_file}); do
-        if [[ ! "$mtx" =~ ^[0-9]+$ ]]; then
-            if [[ "$mtx" =~ ^[a-zA-Z0-9_-]+$ ]]; then
-                id=$(${SSGET} -s "[ @name == $mtx ]")
-            elif [[ "$mtx" =~ ^([a-zA-Z0-9_-]+)\/([a-zA-Z0-9_-]+)$ ]]; then
-                local group="${BASH_REMATCH[1]}"
-                local name="${BASH_REMATCH[2]}"
-                id=$(${SSGET} -s "[ @name == $name ] && [ @group == $group ]")
+    parse_matrix_list() {
+        local source_list_file=$1
+        local benchmark_list=""
+        local id=0
+        for mtx in $(cat ${source_list_file}); do
+            if [[ ! "$mtx" =~ ^[0-9]+$ ]]; then
+                if [[ "$mtx" =~ ^[a-zA-Z0-9_-]+$ ]]; then
+                    id=$(${SSGET} -s "[ @name == $mtx ]")
+                elif [[ "$mtx" =~ ^([a-zA-Z0-9_-]+)\/([a-zA-Z0-9_-]+)$ ]]; then
+                    local group="${BASH_REMATCH[1]}"
+                    local name="${BASH_REMATCH[2]}"
+                    id=$(${SSGET} -s "[ @name == $name ] && [ @group == $group ]")
+                else
+                    >&2 echo -e "Could not recognize entry $mtx."
+                fi
             else
-                >&2 echo -e "Could not recognize entry $mtx."
+                id=$mtx
             fi
-        else
-            id=$mtx
-        fi
-        benchmark_list="$benchmark_list $id"
-    done
-    echo "$benchmark_list"
-}
+            benchmark_list="$benchmark_list $id"
+        done
+        echo "$benchmark_list"
+    }
 
-if [ $use_matrix_list_file -eq 1 ]; then
-    MATRIX_LIST=($(parse_matrix_list $MATRIX_LIST_FILE))
-    NUM_PROBLEMS=${#MATRIX_LIST[@]}
-fi
-
-LOOP_START=$((1 + (${NUM_PROBLEMS}) * (${SEGMENT_ID} - 1) / ${SEGMENTS}))
-LOOP_END=$((1 + (${NUM_PROBLEMS}) * (${SEGMENT_ID}) / ${SEGMENTS}))
-for (( p=${LOOP_START}; p < ${LOOP_END}; ++p )); do
     if [ $use_matrix_list_file -eq 1 ]; then
-        i=${MATRIX_LIST[$((p-1))]}
-    else
-        i=$p
+        MATRIX_LIST=($(parse_matrix_list $MATRIX_LIST_FILE))
+        NUM_PROBLEMS=${#MATRIX_LIST[@]}
     fi
-    if [ "${BENCHMARK}" == "preconditioner" ]; then
-        break
-    fi
-    if [ "$(${SSGET} -i "$i" -preal)" = "0" ]; then
+
+    LOOP_START=$((1 + (${NUM_PROBLEMS}) * (${SEGMENT_ID} - 1) / ${SEGMENTS}))
+    LOOP_END=$((1 + (${NUM_PROBLEMS}) * (${SEGMENT_ID}) / ${SEGMENTS}))
+    for (( p=${LOOP_START}; p < ${LOOP_END}; ++p )); do
+        if [ $use_matrix_list_file -eq 1 ]; then
+            i=${MATRIX_LIST[$((p-1))]}
+        else
+            i=$p
+        fi
+        if [ "${BENCHMARK}" == "preconditioner" ]; then
+            break
+        fi
+        if [ "$(${SSGET} -i "$i" -preal)" = "0" ]; then
+            [ "${DRY_RUN}" != "true" ] && ${SSGET} -i "$i" -c >/dev/null
+            continue
+        fi
+        RESULT_DIR="results/${SYSTEM_NAME}/${EXECUTOR}/SuiteSparse"
+        GROUP=$(${SSGET} -i "$i" -pgroup)
+        NAME=$(${SSGET} -i "$i" -pname)
+        RESULT_FILE="${RESULT_DIR}/${GROUP}/${NAME}.json"
+        PREFIX="($i/${NUM_PROBLEMS}):\t"
+        mkdir -p "$(dirname "${RESULT_FILE}")"
+        generate_suite_sparse_input "$i" >"${RESULT_FILE}"
+
+        echo -e "${PREFIX}Extracting statistics for ${GROUP}/${NAME}" 1>&2
+        compute_matrix_statistics "${RESULT_FILE}"
+        if [ "${BENCHMARK}" == "spmv" ]; then
+            echo -e "${PREFIX}Running SpMV for ${GROUP}/${NAME}" 1>&2
+            run_spmv_benchmarks "${RESULT_FILE}"
+        elif [ "${BENCHMARK}" == "batch_spmv" ]; then
+            echo -e "${PREFIX}Running Batch SpMV for ${GROUP}/${NAME}" 1>&2
+            NUM_BATCH_ENTRIES=${NUM_BATCH_DUP}
+            run_batch_spmv_benchmarks "${RESULT_FILE}"
+        fi
+
+        if [ "${BENCHMARK}" == "conversions" ]; then
+            echo -e "${PREFIX}Running Conversion for ${GROUP}/${NAME}" 1>&2
+            run_conversion_benchmarks "${RESULT_FILE}"
+        fi
+
+        if [ "${BENCHMARK}" != "solver" -o \
+            "$(${SSGET} -i "$i" -prows)" != "$(${SSGET} -i "$i" -pcols)" ]; then
+            [ "${DRY_RUN}" != "true" ] && ${SSGET} -i "$i" -c >/dev/null
+            continue
+        fi
+
+        echo -e "${PREFIX}Running solvers for ${GROUP}/${NAME}" 1>&2
+        run_solver_benchmarks "${RESULT_FILE}"
+
+        echo -e "${PREFIX}Cleaning up problem ${GROUP}/${NAME}" 1>&2
         [ "${DRY_RUN}" != "true" ] && ${SSGET} -i "$i" -c >/dev/null
-        continue
-    fi
-    RESULT_DIR="results/${SYSTEM_NAME}/${EXECUTOR}/SuiteSparse"
-    GROUP=$(${SSGET} -i "$i" -pgroup)
-    NAME=$(${SSGET} -i "$i" -pname)
-    RESULT_FILE="${RESULT_DIR}/${GROUP}/${NAME}.json"
-    PREFIX="($i/${NUM_PROBLEMS}):\t"
-    mkdir -p "$(dirname "${RESULT_FILE}")"
-    generate_suite_sparse_input "$i" >"${RESULT_FILE}"
+    done
 
-    echo -e "${PREFIX}Extracting statistics for ${GROUP}/${NAME}" 1>&2
-    compute_matrix_statistics "${RESULT_FILE}"
-    if [ "${BENCHMARK}" == "spmv" ]; then
-        echo -e "${PREFIX}Running SpMV for ${GROUP}/${NAME}" 1>&2
-        run_spmv_benchmarks "${RESULT_FILE}"
-    elif [ "${BENCHMARK}" == "batch_spmv" ]; then
-        echo -e "${PREFIX}Running Batch SpMV for ${GROUP}/${NAME}" 1>&2
-        NUM_BATCH_ENTRIES=${NUM_BATCH_DUP}
-        run_batch_spmv_benchmarks "${RESULT_FILE}"
+
+    if [ "${BENCHMARK}" != "preconditioner" ]; then
+        exit
     fi
 
-    if [ "${BENCHMARK}" == "conversions" ]; then
-        echo -e "${PREFIX}Running Conversion for ${GROUP}/${NAME}" 1>&2
-        run_conversion_benchmarks "${RESULT_FILE}"
-    fi
 
-    if [ "${BENCHMARK}" != "solver" -o \
-         "$(${SSGET} -i "$i" -prows)" != "$(${SSGET} -i "$i" -pcols)" ]; then
-        [ "${DRY_RUN}" != "true" ] && ${SSGET} -i "$i" -c >/dev/null
-        continue
-    fi
+    ################################################################################
+    # Generated collection
 
-    echo -e "${PREFIX}Running solvers for ${GROUP}/${NAME}" 1>&2
-    run_solver_benchmarks "${RESULT_FILE}"
+    count_tokens() { echo "$#"; }
 
-    echo -e "${PREFIX}Cleaning up problem ${GROUP}/${NAME}" 1>&2
-    [ "${DRY_RUN}" != "true" ] && ${SSGET} -i "$i" -c >/dev/null
-done
+    BLOCK_SIZES="$(seq 1 32)"
+    NUM_BLOCKS="$(seq 10000 2000 50000)"
+    NUM_PROBLEMS=$((
+                      $(count_tokens ${BLOCK_SIZES}) * $(count_tokens ${NUM_BLOCKS}) ))
+    ID=0
 
 
-if [ "${BENCHMARK}" != "preconditioner" ]; then
-    exit
-fi
-
-
-################################################################################
-# Generated collection
-
-count_tokens() { echo "$#"; }
-
-BLOCK_SIZES="$(seq 1 32)"
-NUM_BLOCKS="$(seq 10000 2000 50000)"
-NUM_PROBLEMS=$((
-    $(count_tokens ${BLOCK_SIZES}) * $(count_tokens ${NUM_BLOCKS}) ))
-ID=0
-
-
-# Creates an input file for a block diagonal matrix with block size $1 and
-# number of blocks $2. The location of the matrix is given by $3.
-generate_block_diagonal_input() {
-    cat << EOT
+    # Creates an input file for a block diagonal matrix with block size $1 and
+    # number of blocks $2. The location of the matrix is given by $3.
+    generate_block_diagonal_input() {
+        cat << EOT
 [{
     "filename": "$3",
     "problem": {
@@ -537,56 +555,56 @@ generate_block_diagonal_input() {
     }
 }]
 EOT
-}
+    }
 
 
-# Generates the problem data using the input file $1
-generate_problem() {
-    [ "${DRY_RUN}" == "true" ] && return
-    cp "$1" "$1.tmp"
-    ./matrix_generator/matrix_generator${BENCH_SUFFIX} <"$1.tmp" 2>&1 >"$1"
-    keep_latest "$1" "$1.tmp"
-}
+    # Generates the problem data using the input file $1
+    generate_problem() {
+        [ "${DRY_RUN}" == "true" ] && return
+        cp "$1" "$1.tmp"
+        ./matrix_generator/matrix_generator${BENCH_SUFFIX} <"$1.tmp" 2>&1 >"$1"
+        keep_latest "$1" "$1.tmp"
+    }
 
 
-LOOP_START=$((1 + (${NUM_PROBLEMS}) * (${SEGMENT_ID} - 1) / ${SEGMENTS}))
-LOOP_END=$((1 + (${NUM_PROBLEMS}) * (${SEGMENT_ID}) / ${SEGMENTS}))
-for bsize in ${BLOCK_SIZES}; do
-    for nblocks in ${NUM_BLOCKS}; do
-        ID=$((${ID} + 1))
+    LOOP_START=$((1 + (${NUM_PROBLEMS}) * (${SEGMENT_ID} - 1) / ${SEGMENTS}))
+    LOOP_END=$((1 + (${NUM_PROBLEMS}) * (${SEGMENT_ID}) / ${SEGMENTS}))
+    for bsize in ${BLOCK_SIZES}; do
+        for nblocks in ${NUM_BLOCKS}; do
+            ID=$((${ID} + 1))
+            if [ "${ID}" -ge "${LOOP_END}" ]; then
+                break
+            fi
+            if [ "${ID}" -lt "${LOOP_START}" ]; then
+                continue
+            fi
+            RESULT_DIR="results/${SYSTEM_NAME}/${EXECUTOR}/Generated"
+            GROUP="block-diagonal"
+            NAME="${nblocks}-${bsize}"
+            RESULT_FILE="${RESULT_DIR}/${GROUP}/${NAME}.json"
+            PREFIX="(${ID}/${NUM_PROBLEMS}):\t"
+            mkdir -p "$(dirname "${RESULT_FILE}")"
+            mkdir -p "/tmp/${GROUP}"
+            generate_block_diagonal_input \
+                "${bsize}" "${nblocks}" "/tmp/${GROUP}/${NAME}.mtx" \
+                >"${RESULT_FILE}"
+
+            echo -e "${PREFIX}Generating problem ${GROUP}/${NAME}" 1>&2
+            generate_problem "${RESULT_FILE}"
+
+            echo -e "${PREFIX}Extracting statistics for ${GROUP}/${NAME}" 1>&2
+            compute_matrix_statistics "${RESULT_FILE}"
+
+            echo -e "${PREFIX}Running preconditioners for ${GROUP}/${NAME}" 1>&2
+            BLOCK_SIZES="${bsize}"
+            run_preconditioner_benchmarks "${RESULT_FILE}"
+
+            echo -e "${PREFIX}Cleaning up problem ${GROUP}/${NAME}" 1>&2
+            [ "${DRY_RUN}" != "true" ] && rm -r "/tmp/${GROUP}/${NAME}.mtx"
+        done
         if [ "${ID}" -ge "${LOOP_END}" ]; then
             break
         fi
-        if [ "${ID}" -lt "${LOOP_START}" ]; then
-            continue
-        fi
-        RESULT_DIR="results/${SYSTEM_NAME}/${EXECUTOR}/Generated"
-        GROUP="block-diagonal"
-        NAME="${nblocks}-${bsize}"
-        RESULT_FILE="${RESULT_DIR}/${GROUP}/${NAME}.json"
-        PREFIX="(${ID}/${NUM_PROBLEMS}):\t"
-        mkdir -p "$(dirname "${RESULT_FILE}")"
-        mkdir -p "/tmp/${GROUP}"
-        generate_block_diagonal_input \
-            "${bsize}" "${nblocks}" "/tmp/${GROUP}/${NAME}.mtx" \
-                >"${RESULT_FILE}"
-
-        echo -e "${PREFIX}Generating problem ${GROUP}/${NAME}" 1>&2
-        generate_problem "${RESULT_FILE}"
-
-        echo -e "${PREFIX}Extracting statistics for ${GROUP}/${NAME}" 1>&2
-        compute_matrix_statistics "${RESULT_FILE}"
-
-        echo -e "${PREFIX}Running preconditioners for ${GROUP}/${NAME}" 1>&2
-        BLOCK_SIZES="${bsize}"
-        run_preconditioner_benchmarks "${RESULT_FILE}"
-
-        echo -e "${PREFIX}Cleaning up problem ${GROUP}/${NAME}" 1>&2
-        [ "${DRY_RUN}" != "true" ] && rm -r "/tmp/${GROUP}/${NAME}.mtx"
     done
-    if [ "${ID}" -ge "${LOOP_END}" ]; then
-        break
-    fi
-done
 
 fi

--- a/benchmark/run_all_benchmarks.sh
+++ b/benchmark/run_all_benchmarks.sh
@@ -105,9 +105,11 @@ elif [ "${SOLVERS_RHS}" == "1" ]; then
     SOLVERS_RHS_FLAG="--rhs_generation=1"
 elif [ "${SOLVERS_RHS}" == "sinus" ]; then
     SOLVERS_RHS_FLAG="--rhs_generation=sinus"
+elif [ "${SOLVERS_RHS}" == "file" ]; then
+    SOLVERS_RHS_FLAG="--rhs_generation=file"
 else
     echo "SOLVERS_RHS does not support the value \"${SOLVERS_RHS}\"." 1>&2
-    echo "The following values are supported: \"1\", \"random\" and \"sinus\"" 1>&2
+    echo "The following values are supported: \"1\", \"random\", \"sinus\" and \"file\" " 1>&2
     exit 1
 fi
 
@@ -306,6 +308,7 @@ run_batch_spmv_benchmarks() {
                 --executor="${EXECUTOR}" --formats="${FORMATS}" \
                 --num_duplications="${NUM_BATCH_DUP}" "${BATCH_SCALING_STR}" \
                 --num_batches="${NUM_BATCH_ENTRIES}" "${SS_STR}" \
+                "${SOLVERS_RHS_FLAG}" \
                 --device_id="${DEVICE_ID}" --gpu_timer=${GPU_TIMER} \
                 <"$1.imd" 2>&1 >"$1"
     keep_latest "$1" "$1.bkp" "$1.bkp2" "$1.imd"

--- a/benchmark/spmv/CMakeLists.txt
+++ b/benchmark/spmv/CMakeLists.txt
@@ -1,1 +1,2 @@
 ginkgo_add_typed_benchmark_executables(spmv "YES" spmv.cpp)
+ginkgo_add_typed_benchmark_executables(batch_spmv "YES" batch_spmv.cpp)

--- a/benchmark/spmv/batch_spmv.cpp
+++ b/benchmark/spmv/batch_spmv.cpp
@@ -66,11 +66,13 @@ DEFINE_bool(using_suite_sparse, true,
 DEFINE_string(
     rhs_generation, "none",
     "Method used to generate the right hand side. Supported values are:"
-    "`1`, `random`, `sinus`. `1` sets all values of the right hand side to 1, "
+    "`1`, `random`, `sinus`, `file` . `1` sets all values of the right hand "
+    "side to 1, "
     "`random` assigns the values to a uniformly distributed random number "
-    "in [-1, 1), and `sinus` assigns b = A * (s / |s|) with A := system matrix,"
+    "in [-1, 1), `sinus` assigns b = A * (s / |s|) with A := system matrix,"
     " s := vector with s(idx) = sin(idx) for non-complex types, and "
-    "s(idx) = sin(2*idx) + i * sin(2*idx+1).");
+    "s(idx) = sin(2*idx) + i * sin(2*idx+1) and `file` read the rhs from a "
+    "file.");
 
 
 template <typename ValueType>

--- a/benchmark/spmv/batch_spmv.cpp
+++ b/benchmark/spmv/batch_spmv.cpp
@@ -72,6 +72,8 @@ using size_type = gko::size_type;
 
 // This function supposes that management of `FLAGS_overwrite` is done before
 // calling it
+//
+// Overload for the Suitesparse matrices
 void apply_spmv(const char *format_name, std::shared_ptr<gko::Executor> exec,
                 const gko::matrix_data<etype> &data, const batch_vec<etype> *b,
                 const batch_vec<etype> *x, const batch_vec<etype> *answer,
@@ -186,6 +188,8 @@ void apply_spmv(const char *format_name, std::shared_ptr<gko::Executor> exec,
 
 // This function supposes that management of `FLAGS_overwrite` is done before
 // calling it
+//
+// Overload with the reading a batch matrix with std::vector<matrix_data>
 void apply_spmv(const char *format_name, std::shared_ptr<gko::Executor> exec,
                 const std::vector<gko::matrix_data<etype>> &data,
                 const batch_vec<etype> *b, const batch_vec<etype> *x,

--- a/benchmark/spmv/batch_spmv.cpp
+++ b/benchmark/spmv/batch_spmv.cpp
@@ -1,0 +1,270 @@
+/*******************************<GINKGO LICENSE>******************************
+Copyright (c) 2017-2021, the Ginkgo authors
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+******************************<GINKGO LICENSE>*******************************/
+
+#include <ginkgo/ginkgo.hpp>
+
+
+#include <algorithm>
+#include <chrono>
+#include <cstdlib>
+#include <exception>
+#include <fstream>
+#include <iomanip>
+#include <iostream>
+#include <typeinfo>
+
+
+#include "benchmark/utils/formats.hpp"
+#include "benchmark/utils/general.hpp"
+#include "benchmark/utils/loggers.hpp"
+#include "benchmark/utils/spmv_common.hpp"
+#include "benchmark/utils/timer.hpp"
+#include "benchmark/utils/types.hpp"
+
+
+#ifdef GINKGO_BENCHMARK_ENABLE_TUNING
+#include "benchmark/utils/tuning_variables.hpp"
+#endif  // GINKGO_BENCHMARK_ENABLE_TUNING
+
+
+// Command-line arguments
+DEFINE_uint32(nrhs, 1, "The number of right hand sides");
+DEFINE_uint32(num_batches, 1, "The number of batch entries");
+
+
+template <typename ValueType>
+using batch_vec = gko::matrix::BatchDense<ValueType>;
+
+// This function supposes that management of `FLAGS_overwrite` is done before
+// calling it
+void apply_spmv(const char *format_name, std::shared_ptr<gko::Executor> exec,
+                const gko::matrix_data<etype> &data, const batch_vec<etype> *b,
+                const batch_vec<etype> *x, const batch_vec<etype> *answer,
+                rapidjson::Value &test_case,
+                rapidjson::MemoryPoolAllocator<> &allocator)
+{
+    try {
+        auto &spmv_case = test_case["spmv"];
+        add_or_set_member(spmv_case, format_name,
+                          rapidjson::Value(rapidjson::kObjectType), allocator);
+
+        auto nbatch = FLAGS_num_batches;
+        auto storage_logger = std::make_shared<StorageLogger>(exec);
+        exec->add_logger(storage_logger);
+        auto system_matrix = share(
+            formats::batch_matrix_factory.at(format_name)(exec, nbatch, data));
+
+        std::clog << "Batch Matrix has: "
+                  << system_matrix->get_num_batch_entries()
+                  << " batches, each of size ("
+                  << system_matrix->get_size().at(0)[0] << ", "
+                  << system_matrix->get_size().at(0)[1] << ") , with total nnz "
+                  << gko::as<gko::matrix::BatchCsr<etype>>(system_matrix.get())
+                         ->get_num_stored_elements()
+                  << std::endl;
+
+        exec->remove_logger(gko::lend(storage_logger));
+        storage_logger->write_data(spmv_case[format_name], allocator);
+        // check the residual
+        if (FLAGS_detailed) {
+            auto x_clone = clone(x);
+            exec->synchronize();
+            system_matrix->apply(lend(b), lend(x_clone));
+            exec->synchronize();
+            auto max_relative_norm2 =
+                compute_batch_max_relative_norm2(lend(x_clone), lend(answer));
+            // FIXME
+            // add_or_set_member(spmv_case[format_name], "max_relative_norm2",
+            //                   max_relative_norm2, allocator);
+        }
+        // warm run
+        for (unsigned int i = 0; i < FLAGS_warmup; i++) {
+            auto x_clone = clone(x);
+            exec->synchronize();
+            system_matrix->apply(lend(b), lend(x_clone));
+            exec->synchronize();
+        }
+
+        // tuning run
+#ifdef GINKGO_BENCHMARK_ENABLE_TUNING
+        auto &format_case = spmv_case[format_name];
+        if (!format_case.HasMember("tuning")) {
+            format_case.AddMember(
+                "tuning", rapidjson::Value(rapidjson::kObjectType), allocator);
+        }
+        auto &tuning_case = format_case["tuning"];
+        add_or_set_member(tuning_case, "time",
+                          rapidjson::Value(rapidjson::kArrayType), allocator);
+        add_or_set_member(tuning_case, "values",
+                          rapidjson::Value(rapidjson::kArrayType), allocator);
+
+        // Enable tuning for this portion of code
+        gko::_tuning_flag = true;
+        // Select some values we want to tune.
+        std::vector<gko::size_type> tuning_values{
+            1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096};
+        for (auto val : tuning_values) {
+            // Actually set the value that will be tuned. See
+            // cuda/components/format_conversion.cuh for an example of how this
+            // variable is used.
+            gko::_tuned_value = val;
+            auto tuning_timer = get_timer(exec, FLAGS_gpu_timer);
+            for (unsigned int i = 0; i < FLAGS_repetitions; i++) {
+                auto x_clone = clone(x);
+                exec->synchronize();
+                tuning_timer->tic();
+                system_matrix->apply(lend(b), lend(x_clone));
+                tuning_timer->toc();
+            }
+            tuning_case["time"].PushBack(tuning_timer->compute_average_time(),
+                                         allocator);
+            tuning_case["values"].PushBack(val, allocator);
+        }
+        // We put back the flag to false to use the default (non-tuned) values
+        // for the following
+        gko::_tuning_flag = false;
+#endif  // GINKGO_BENCHMARK_ENABLE_TUNING
+
+        // timed run
+        auto timer = get_timer(exec, FLAGS_gpu_timer);
+        for (unsigned int i = 0; i < FLAGS_repetitions; i++) {
+            auto x_clone = clone(x);
+            exec->synchronize();
+            timer->tic();
+            system_matrix->apply(lend(b), lend(x_clone));
+            timer->toc();
+        }
+        add_or_set_member(spmv_case[format_name], "time",
+                          timer->compute_average_time(), allocator);
+
+        // compute and write benchmark data
+        add_or_set_member(spmv_case[format_name], "completed", true, allocator);
+    } catch (const std::exception &e) {
+        add_or_set_member(test_case["spmv"][format_name], "completed", false,
+                          allocator);
+        std::cerr << "Error when processing test case " << test_case << "\n"
+                  << "what(): " << e.what() << std::endl;
+    }
+}
+
+
+int main(int argc, char *argv[])
+{
+    std::string header =
+        "A benchmark for measuring performance of Ginkgo's spmv.\n";
+    std::string format = std::string() + "  [\n" +
+                         "    { \"filename\": \"my_file.mtx\"},\n" +
+                         "    { \"filename\": \"my_file2.mtx\"}\n" + "  ]\n\n";
+    initialize_argument_parsing(&argc, &argv, header, format);
+
+    std::string extra_information = "The formats are " + FLAGS_formats +
+                                    "\nThe number of right hand sides is " +
+                                    std::to_string(FLAGS_nrhs) + "\n";
+    print_general_information(extra_information);
+
+    auto exec = executor_factory.at(FLAGS_executor)();
+    auto engine = get_engine();
+    auto formats = split(FLAGS_formats, ',');
+
+    rapidjson::IStreamWrapper jcin(std::cin);
+    rapidjson::Document test_cases;
+    test_cases.ParseStream(jcin);
+    if (!test_cases.IsArray()) {
+        print_config_error_and_exit();
+    }
+
+    auto &allocator = test_cases.GetAllocator();
+
+    for (auto &test_case : test_cases.GetArray()) {
+        try {
+            // set up benchmark
+            validate_option_object(test_case);
+            if (!test_case.HasMember("spmv")) {
+                test_case.AddMember("spmv",
+                                    rapidjson::Value(rapidjson::kObjectType),
+                                    allocator);
+            }
+            auto &spmv_case = test_case["spmv"];
+            if (!FLAGS_overwrite &&
+                all_of(begin(formats), end(formats),
+                       [&spmv_case](const std::string &s) {
+                           return spmv_case.HasMember(s.c_str());
+                       })) {
+                continue;
+            }
+            std::clog << "Running test case: " << test_case << std::endl;
+            std::ifstream mtx_fd(test_case["filename"].GetString());
+            auto data = gko::read_raw<etype>(mtx_fd);
+
+            auto nrhs = FLAGS_nrhs;
+            auto nbatch = FLAGS_num_batches;
+            auto b = create_batch_matrix<etype>(
+                exec,
+                gko::batch_dim<2>(nbatch, gko::dim<2>{data.size[0], nrhs}),
+                engine);
+            auto x = create_batch_matrix<etype>(
+                exec,
+                gko::batch_dim<2>(nbatch, gko::dim<2>{data.size[0], nrhs}),
+                engine);
+            // std::clog << "Batch Matrix has: " << nbatch
+            //           << " batches, each of size (" << data.size[0] << ", "
+            //           << data.size[1] << ")" << std::endl;
+
+            // Compute the result from ginkgo::coo as the correct answer
+            auto answer = batch_vec<etype>::create(exec);
+            if (FLAGS_detailed) {
+                auto system_matrix = share(formats::batch_matrix_factory.at(
+                    "batch_csr")(exec, nbatch, data));
+                answer->copy_from(lend(x));
+                exec->synchronize();
+                system_matrix->apply(lend(b), lend(answer));
+                exec->synchronize();
+            }
+            for (const auto &format_name : formats) {
+                apply_spmv(format_name.c_str(), exec, data, lend(b), lend(x),
+                           lend(answer), test_case, allocator);
+                std::clog << "Current state:" << std::endl
+                          << test_cases << std::endl;
+                if (spmv_case[format_name.c_str()]["completed"].GetBool()) {
+                    auto performance =
+                        spmv_case[format_name.c_str()]["time"].GetDouble();
+                }
+                backup_results(test_cases);
+            }
+        } catch (const std::exception &e) {
+            std::cerr << "Error setting up matrix data, what(): " << e.what()
+                      << std::endl;
+        }
+    }
+
+    std::cout << test_cases << std::endl;
+}

--- a/benchmark/utils/formats.hpp
+++ b/benchmark/utils/formats.hpp
@@ -198,7 +198,7 @@ std::unique_ptr<MatrixType> read_batch_matrix_from_data(
  * @return a `unique_pointer` to the created matrix
  */
 template <typename MatrixType>
-std::unique_ptr<MatrixType> read_batch_matrix_from_data2(
+std::unique_ptr<MatrixType> read_batch_matrix_from_batch_data(
     std::shared_ptr<const gko::Executor> exec, const int num_duplications,
     const std::vector<gko::matrix_data<etype>> &data)
 {
@@ -249,7 +249,7 @@ const std::map<std::string, std::function<std::unique_ptr<gko::BatchLinOp>(
                                 const std::vector<gko::matrix_data<etype>> &)>>
     batch_matrix_factory2{
         {"batch_csr",
-         read_batch_matrix_from_data2<gko::matrix::BatchCsr<etype>>}};
+         read_batch_matrix_from_batch_data<gko::matrix::BatchCsr<etype>>}};
 
 
 const std::map<std::string, std::function<std::unique_ptr<gko::BatchLinOp>(

--- a/benchmark/utils/formats.hpp
+++ b/benchmark/utils/formats.hpp
@@ -198,6 +198,28 @@ std::unique_ptr<MatrixType> read_batch_matrix_from_data(
  * @return a `unique_pointer` to the created matrix
  */
 template <typename MatrixType>
+std::unique_ptr<MatrixType> read_batch_matrix_from_data2(
+    std::shared_ptr<const gko::Executor> exec, const int num_duplications,
+    const std::vector<gko::matrix_data<etype>> &data)
+{
+    auto single_batch = MatrixType::create(exec);
+    single_batch->read(data);
+    auto mat = MatrixType::create(exec, num_duplications, single_batch.get());
+    return mat;
+}
+
+/**
+ * Creates a Ginkgo matrix from the intermediate data representation format
+ * gko::matrix_data.
+ *
+ * @param exec  the executor where the matrix will be put
+ * @param data  the data represented in the intermediate representation format
+ *
+ * @tparam MatrixType  the Ginkgo matrix type (such as `gko::matrix::Csr<>`)
+ *
+ * @return a `unique_pointer` to the created matrix
+ */
+template <typename MatrixType>
 std::unique_ptr<MatrixType> read_matrix_from_data(
     std::shared_ptr<const gko::Executor> exec,
     const gko::matrix_data<etype> &data)
@@ -220,6 +242,14 @@ std::unique_ptr<MatrixType> read_matrix_from_data(
         mat->read(data);                                                      \
         return mat;                                                           \
     }
+
+
+const std::map<std::string, std::function<std::unique_ptr<gko::BatchLinOp>(
+                                std::shared_ptr<const gko::Executor>, const int,
+                                const std::vector<gko::matrix_data<etype>> &)>>
+    batch_matrix_factory2{
+        {"batch_csr",
+         read_batch_matrix_from_data2<gko::matrix::BatchCsr<etype>>}};
 
 
 const std::map<std::string, std::function<std::unique_ptr<gko::BatchLinOp>(

--- a/benchmark/utils/general.hpp
+++ b/benchmark/utils/general.hpp
@@ -286,6 +286,9 @@ std::shared_ptr<gko::Executor> get_executor()
 template <typename ValueType>
 using vec = gko::matrix::Dense<ValueType>;
 
+template <typename ValueType>
+using batch_vec = gko::matrix::BatchDense<ValueType>;
+
 
 // Create a matrix with value indices s[i, j] = sin(i)
 template <typename ValueType>
@@ -321,6 +324,44 @@ create_matrix_sin(std::shared_ptr<const gko::Executor> exec, gko::dim<2> size)
     }
     auto res = vec<ValueType>::create(exec);
     h_res->move_to(res.get());
+    return res;
+}
+
+
+template <typename ValueType, typename RandomEngine>
+std::unique_ptr<batch_vec<ValueType>> create_batch_matrix(
+    std::shared_ptr<const gko::Executor> exec, const gko::batch_dim<2> &size,
+    RandomEngine &engine)
+{
+    GKO_ASSERT(size.stores_equal_sizes());
+    auto res = batch_vec<ValueType>::create(exec);
+    auto num_batch_entries = size.get_num_batch_entries();
+    std::vector<gko::matrix_data<ValueType>> data{};
+    for (gko::size_type i = 0; i < num_batch_entries; ++i) {
+        data.emplace_back(gko::matrix_data<ValueType>(
+            size.at(0),
+            std::uniform_real_distribution<gko::remove_complex<ValueType>>(-1.0,
+                                                                           1.0),
+            engine));
+    }
+    res->read(data);
+    return res;
+}
+
+
+template <typename ValueType>
+std::unique_ptr<batch_vec<ValueType>> create_batch_matrix(
+    std::shared_ptr<const gko::Executor> exec, const gko::batch_dim<2> &size,
+    ValueType value)
+{
+    GKO_ASSERT(size.stores_equal_sizes());
+    auto res = batch_vec<ValueType>::create(exec);
+    auto num_batch_entries = size.get_num_batch_entries();
+    std::vector<gko::matrix_data<ValueType>> data{};
+    for (gko::size_type i = 0; i < num_batch_entries; ++i) {
+        data.emplace_back(gko::matrix_data<ValueType>(size.at(0), value));
+    }
+    res->read(data);
     return res;
 }
 
@@ -403,6 +444,42 @@ gko::remove_complex<ValueType> compute_residual_norm(
     auto res = clone(b);
     system_matrix->apply(lend(one), lend(x), lend(neg_one), lend(res));
     return compute_norm2(lend(res));
+}
+
+
+template <typename ValueType>
+std::vector<gko::remove_complex<ValueType>> compute_batch_max_relative_norm2(
+    batch_vec<ValueType> *result, const batch_vec<ValueType> *answer)
+{
+    using rc_vtype = gko::remove_complex<ValueType>;
+    auto exec = answer->get_executor();
+    auto nbatch = result->get_num_batch_entries();
+    auto answer_norm = batch_vec<rc_vtype>::create(
+        exec,
+        gko::batch_dim<2>(nbatch, gko::dim<2>(1, answer->get_size().at(0)[1])));
+    answer->compute_norm2(lend(answer_norm));
+    auto neg_one =
+        gko::batch_initialize<batch_vec<ValueType>>(nbatch, {-1.0}, exec);
+    result->add_scaled(lend(neg_one), lend(answer));
+    auto absolute_norm = batch_vec<rc_vtype>::create(
+        exec,
+        gko::batch_dim<2>(nbatch, gko::dim<2>(1, result->get_size().at(0)[1])));
+    result->compute_norm2(lend(absolute_norm));
+    auto host_answer_norm =
+        clone(answer_norm->get_executor()->get_master(), answer_norm);
+    auto host_absolute_norm =
+        clone(absolute_norm->get_executor()->get_master(), absolute_norm);
+    std::vector<rc_vtype> max_relative_norm2(nbatch, rc_vtype(0.0));
+    for (gko::size_type b = 0; b < host_answer_norm->get_num_batch_entries();
+         b++) {
+        for (gko::size_type i = 0; i < host_answer_norm->get_size().at(0)[1];
+             i++) {
+            max_relative_norm2[b] = std::max(
+                host_absolute_norm->at(b, 0, i) / host_answer_norm->at(b, 0, i),
+                max_relative_norm2[b]);
+        }
+    }
+    return max_relative_norm2;
 }
 
 

--- a/benchmark/utils/spmv_common.hpp
+++ b/benchmark/utils/spmv_common.hpp
@@ -59,6 +59,35 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
 /**
+ * Function which outputs the input format for benchmarks similar to the spmv.
+ */
+[[noreturn]] void print_batch_config_error_and_exit()
+{
+    std::cerr << "Input has to be a JSON array of matrix configuration folder "
+                 "locations:\n"
+              << "  [\n"
+              << "    { \"problem\": \"my_folder\" },\n"
+              << "    { \"problem\": \"my_folder2\" }\n"
+              << "  ]" << std::endl;
+    std::exit(1);
+}
+
+
+/**
+ * Validates whether the input format is correct for spmv-like benchmarks.
+ *
+ * @param value  the JSON value to test.
+ */
+void validate_batch_option_object(const rapidjson::Value &value)
+{
+    if (!value.IsObject() || !value.HasMember("problem") ||
+        !value["problem"].IsString()) {
+        print_batch_config_error_and_exit();
+    }
+}
+
+
+/**
  * Validates whether the input format is correct for spmv-like benchmarks.
  *
  * @param value  the JSON value to test.

--- a/core/test/matrix/batch_csr.cpp
+++ b/core/test/matrix/batch_csr.cpp
@@ -183,6 +183,7 @@ TYPED_TEST(BatchCsr, CanBeDuplicatedFromOneCsrMatrix)
     auto mtx = gko::matrix::BatchCsr<value_type, index_type>::create(
         this->exec, 3, csr_mat.get());
 
+    ASSERT_EQ(mtx->get_size(), gko::batch_dim<2>(3, gko::dim<2>{3, 2}));
     this->assert_equal_data_array(12, batch_values, mtx->get_values());
     this->assert_equal_data_array(4, col_idxs, mtx->get_col_idxs());
     this->assert_equal_data_array(4, row_ptrs, mtx->get_row_ptrs());
@@ -210,6 +211,7 @@ TYPED_TEST(BatchCsr, CanBeDuplicatedFromBatchMatrices)
     auto mtx = gko::matrix::BatchCsr<value_type, index_type>::create(
         this->exec, 3, batch_mtx.get());
 
+    ASSERT_EQ(mtx->get_size(), gko::batch_dim<2>(6, gko::dim<2>{3, 2}));
     this->assert_equal_data_array(24, bvalues, mtx->get_values());
     this->assert_equal_data_array(4, col_idxs, mtx->get_col_idxs());
     this->assert_equal_data_array(4, row_ptrs, mtx->get_row_ptrs());

--- a/core/test/matrix/batch_dense.cpp
+++ b/core/test/matrix/batch_dense.cpp
@@ -172,6 +172,29 @@ TYPED_TEST(BatchDense, CanBeConstructedFromExistingData)
 }
 
 
+TYPED_TEST(BatchDense, CanBeConstructedFromBatchDenseMatrices)
+{
+    using value_type = typename TestFixture::value_type;
+    using DenseMtx = typename TestFixture::DenseMtx;
+    using size_type = gko::size_type;
+    auto mat1 = gko::initialize<DenseMtx>(
+        3, {{-1.0, 2.0, 3.0}, {-1.5, 2.5, 3.5}}, this->exec);
+    auto mat2 = gko::initialize<DenseMtx>({{1.0, 2.5, 3.0}, {1.0, 2.0, 3.0}},
+                                          this->exec);
+
+    auto m = gko::matrix::BatchDense<TypeParam>::create(
+        this->exec, std::vector<DenseMtx *>{mat1.get(), mat2.get()});
+    auto m_ref = gko::matrix::BatchDense<TypeParam>::create(
+        this->exec,
+        std::vector<DenseMtx *>{mat1.get(), mat2.get(), mat1.get(), mat2.get(),
+                                mat1.get(), mat2.get()});
+    auto m2 =
+        gko::matrix::BatchDense<TypeParam>::create(this->exec, 3, m.get());
+
+    GKO_ASSERT_BATCH_MTX_NEAR(m2.get(), m_ref.get(), 1e-14);
+}
+
+
 TYPED_TEST(BatchDense, CanBeConstructedFromDenseMatrices)
 {
     using value_type = typename TestFixture::value_type;

--- a/include/ginkgo/core/matrix/batch_csr.hpp
+++ b/include/ginkgo/core/matrix/batch_csr.hpp
@@ -249,31 +249,6 @@ protected:
     {}
 
 
-    template <typename MatrixType>
-    void batch_duplicator(std::shared_ptr<const Executor> exec,
-                          const size_type num_batch_entries,
-                          const size_type col_idxs_size,
-                          const MatrixType *input,
-                          BatchCsr<value_type, index_type> *output)
-    {
-        auto row_ptrs = output->get_row_ptrs();
-        auto col_idxs = output->get_col_idxs();
-        auto values = output->get_values();
-        size_type offset = 0;
-        size_type num_nnz = input->get_num_stored_elements();
-        for (size_type i = 0; i < num_batch_entries; ++i) {
-            exec->copy_from(input->get_executor().get(), num_nnz,
-                            input->get_const_values(), values + offset);
-            offset += num_nnz;
-        }
-        exec->copy_from(input->get_executor().get(), col_idxs_size,
-                        input->get_const_col_idxs(), col_idxs);
-        exec->copy_from(input->get_executor().get(),
-                        output->get_size().at(0)[0] + 1,
-                        input->get_const_row_ptrs(), row_ptrs);
-    }
-
-
     /**
      * Creates an BatchCsr matrix by duplicating a CSR matrix
      *
@@ -367,6 +342,30 @@ protected:
                     const BatchLinOp *beta, BatchLinOp *x) const override;
 
 private:
+    template <typename MatrixType>
+    void batch_duplicator(std::shared_ptr<const Executor> exec,
+                          const size_type num_batch_entries,
+                          const size_type col_idxs_size,
+                          const MatrixType *input,
+                          BatchCsr<value_type, index_type> *output)
+    {
+        auto row_ptrs = output->get_row_ptrs();
+        auto col_idxs = output->get_col_idxs();
+        auto values = output->get_values();
+        size_type offset = 0;
+        size_type num_nnz = input->get_num_stored_elements();
+        for (size_type i = 0; i < num_batch_entries; ++i) {
+            exec->copy_from(input->get_executor().get(), num_nnz,
+                            input->get_const_values(), values + offset);
+            offset += num_nnz;
+        }
+        exec->copy_from(input->get_executor().get(), col_idxs_size,
+                        input->get_const_col_idxs(), col_idxs);
+        exec->copy_from(input->get_executor().get(),
+                        output->get_size().at(0)[0] + 1,
+                        input->get_const_row_ptrs(), row_ptrs);
+    }
+
     Array<value_type> values_;
     Array<index_type> col_idxs_;
     Array<index_type> row_ptrs_;

--- a/include/ginkgo/core/matrix/batch_csr.hpp
+++ b/include/ginkgo/core/matrix/batch_csr.hpp
@@ -249,6 +249,31 @@ protected:
     {}
 
 
+    template <typename MatrixType>
+    void batch_duplicator(std::shared_ptr<const Executor> exec,
+                          const size_type num_batch_entries,
+                          const size_type col_idxs_size,
+                          const MatrixType *input,
+                          BatchCsr<value_type, index_type> *output)
+    {
+        auto row_ptrs = output->get_row_ptrs();
+        auto col_idxs = output->get_col_idxs();
+        auto values = output->get_values();
+        size_type offset = 0;
+        size_type num_nnz = input->get_num_stored_elements();
+        for (size_type i = 0; i < num_batch_entries; ++i) {
+            exec->copy_from(input->get_executor().get(), num_nnz,
+                            input->get_const_values(), values + offset);
+            offset += num_nnz;
+        }
+        exec->copy_from(input->get_executor().get(), col_idxs_size,
+                        input->get_const_col_idxs(), col_idxs);
+        exec->copy_from(input->get_executor().get(),
+                        output->get_size().at(0)[0] + 1,
+                        input->get_const_row_ptrs(), row_ptrs);
+    }
+
+
     /**
      * Creates an BatchCsr matrix by duplicating a CSR matrix
      *
@@ -265,21 +290,9 @@ protected:
           col_idxs_(exec, csr_mat->get_num_stored_elements()),
           row_ptrs_(exec, (csr_mat->get_size()[0]) + 1)
     {
-        size_type offset = 0;
-        size_type num_nnz = csr_mat->get_num_stored_elements();
-        for (size_type i = 0; i < num_batch_entries; ++i) {
-            exec->copy_from(csr_mat->get_executor().get(), num_nnz,
-                            csr_mat->get_const_values(),
-                            values_.get_data() + offset);
-            offset += num_nnz;
-        }
-        exec->copy_from(csr_mat->get_executor().get(), num_nnz,
-                        csr_mat->get_const_col_idxs(), col_idxs_.get_data());
-        exec->copy_from(csr_mat->get_executor().get(),
-                        (csr_mat->get_size()[0]) + 1,
-                        csr_mat->get_const_row_ptrs(), row_ptrs_.get_data());
+        batch_duplicator(exec, num_batch_entries,
+                         csr_mat->get_num_stored_elements(), csr_mat, this);
     }
-
 
     /**
      * Creates an BatchCsr matrix by duplicating a BatchCsr matrix
@@ -302,20 +315,8 @@ protected:
                               batch_mat->get_num_batch_entries()),
           row_ptrs_(exec, (batch_mat->get_size().at(0)[0]) + 1)
     {
-        size_type offset = 0;
-        size_type num_nnz = batch_mat->get_num_stored_elements();
-        for (size_type i = 0; i < num_duplications; ++i) {
-            exec->copy_from(batch_mat->get_executor().get(), num_nnz,
-                            batch_mat->get_const_values(),
-                            values_.get_data() + offset);
-            offset += num_nnz;
-        }
-        exec->copy_from(batch_mat->get_executor().get(),
-                        col_idxs_.get_num_elems(),
-                        batch_mat->get_const_col_idxs(), col_idxs_.get_data());
-        exec->copy_from(batch_mat->get_executor().get(),
-                        row_ptrs_.get_num_elems(),
-                        batch_mat->get_const_row_ptrs(), row_ptrs_.get_data());
+        batch_duplicator(exec, num_duplications, col_idxs_.get_num_elems(),
+                         batch_mat, this);
     }
 
 

--- a/reference/test/preconditioner/batch_jacobi_kernels.cpp
+++ b/reference/test/preconditioner/batch_jacobi_kernels.cpp
@@ -64,7 +64,6 @@ protected:
     const size_t nbatch = 2;
     const int nrows = 3;
     std::shared_ptr<const Mtx> mtx;
-    static constexpr real_type eps = std::numeric_limits<real_type>::epsilon();
 
     std::unique_ptr<Mtx> get_matrix()
     {
@@ -90,6 +89,7 @@ TYPED_TEST_SUITE(BatchJacobi, gko::test::ValueTypes);
 
 TYPED_TEST(BatchJacobi, AppliesToSingleVector)
 {
+    using value_type = typename TestFixture::value_type;
     using BDense = typename TestFixture::BDense;
     auto xex = gko::batch_initialize<BDense>(
         {{-1.0, -3.0, 20.0}, {2.0, 1.25, -12.0}}, this->exec);
@@ -101,7 +101,8 @@ TYPED_TEST(BatchJacobi, AppliesToSingleVector)
     gko::kernels::reference::batch_jacobi::batch_jacobi_apply(
         this->exec, this->mtx.get(), b.get(), x.get());
 
-    GKO_ASSERT_BATCH_MTX_NEAR(x, xex, this->eps);
+    const auto eps = r<value_type>::value;
+    GKO_ASSERT_BATCH_MTX_NEAR(x, xex, eps);
 }
 
 TYPED_TEST(BatchJacobi, AppliesToMultipleVectors)
@@ -122,7 +123,8 @@ TYPED_TEST(BatchJacobi, AppliesToMultipleVectors)
     gko::kernels::reference::batch_jacobi::batch_jacobi_apply(
         this->exec, this->mtx.get(), b.get(), x.get());
 
-    GKO_ASSERT_BATCH_MTX_NEAR(x, xex, this->eps);
+    const auto eps = r<T>::value;
+    GKO_ASSERT_BATCH_MTX_NEAR(x, xex, eps);
 }
 
 }  // namespace


### PR DESCRIPTION
This PR adds benchmarking functionality to BatchCsr and possibly any other future batch matrix formats. 

To allow for easy benchmarking, two new constructors were added to `BatchCsr` allowing duplication of CSR matrices or duplication of `BatchCsr` matrices. 

To facilitate benchmarking with the Suitesparse matrix collection, a new `NUM_BATCHES` environment variable can be set, which reads the input matrix ( in CSR ) and duplicates `NUM_BATCHES` of it and stores it in the `BatchCsr` format. 

### TODO

+ [x] Read different matrices for different batch entries. 
+ [x] Allow reading of scaled matrices and right hand sides.
+ [x] Allow reading of scaling vectors.  