### PR TITLE
Fix the error size of extract_diagonal

### DIFF
--- a/cuda/matrix/dense_kernels.cu
+++ b/cuda/matrix/dense_kernels.cu
@@ -785,7 +785,7 @@ void extract_diagonal(std::shared_ptr<const CudaExecutor> exec,
 {
     const dim3 grid_dim = ceildiv(diag->get_size()[0], default_block_size);
     kernel::extract_diagonal<<<grid_dim, default_block_size>>>(
-        orig->get_size()[0], as_cuda_type(orig->get_const_values()),
+        diag->get_size()[0], as_cuda_type(orig->get_const_values()),
         orig->get_stride(), as_cuda_type(diag->get_values()));
 }
 

--- a/cuda/test/matrix/dense_kernels.cpp
+++ b/cuda/test/matrix/dense_kernels.cpp
@@ -829,12 +829,23 @@ TEST_F(Dense, IsInverseColPermutable)
 }
 
 
-TEST_F(Dense, ExtractDiagonalIsEquivalentToRef)
+TEST_F(Dense, ExtractDiagonalOnTallSkinnyIsEquivalentToRef)
 {
     set_up_apply_data();
 
     auto diag = x->extract_diagonal();
     auto ddiag = dx->extract_diagonal();
+
+    GKO_ASSERT_MTX_NEAR(diag.get(), ddiag.get(), 0);
+}
+
+
+TEST_F(Dense, ExtractDiagonalOnShortFatIsEquivalentToRef)
+{
+    set_up_apply_data();
+
+    auto diag = y->extract_diagonal();
+    auto ddiag = dy->extract_diagonal();
 
     GKO_ASSERT_MTX_NEAR(diag.get(), ddiag.get(), 0);
 }

--- a/hip/matrix/dense_kernels.hip.cpp
+++ b/hip/matrix/dense_kernels.hip.cpp
@@ -824,7 +824,7 @@ void extract_diagonal(std::shared_ptr<const HipExecutor> exec,
 {
     const dim3 grid_dim = ceildiv(diag->get_size()[0], default_block_size);
     hipLaunchKernelGGL(kernel::extract_diagonal, dim3(grid_dim),
-                       dim3(default_block_size), 0, 0, orig->get_size()[0],
+                       dim3(default_block_size), 0, 0, diag->get_size()[0],
                        as_hip_type(orig->get_const_values()),
                        orig->get_stride(), as_hip_type(diag->get_values()));
 }

--- a/hip/test/matrix/dense_kernels.hip.cpp
+++ b/hip/test/matrix/dense_kernels.hip.cpp
@@ -812,12 +812,23 @@ TEST_F(Dense, IsInverseColPermutable)
 }
 
 
-TEST_F(Dense, ExtractDiagonalIsEquivalentToRef)
+TEST_F(Dense, ExtractDiagonalOnTallSkinnyIsEquivalentToRef)
 {
     set_up_apply_data();
 
     auto diag = x->extract_diagonal();
     auto ddiag = dx->extract_diagonal();
+
+    GKO_ASSERT_MTX_NEAR(diag.get(), ddiag.get(), 0);
+}
+
+
+TEST_F(Dense, ExtractDiagonalOnShortFatIsEquivalentToRef)
+{
+    set_up_apply_data();
+
+    auto diag = y->extract_diagonal();
+    auto ddiag = dy->extract_diagonal();
 
     GKO_ASSERT_MTX_NEAR(diag.get(), ddiag.get(), 0);
 }

--- a/omp/test/matrix/dense_kernels.cpp
+++ b/omp/test/matrix/dense_kernels.cpp
@@ -950,12 +950,23 @@ TEST_F(Dense, IsInverseColPermutable)
 }
 
 
-TEST_F(Dense, ExtractDiagonalIsEquivalentToRef)
+TEST_F(Dense, ExtractDiagonalOnTallSkinnyIsEquivalentToRef)
 {
     set_up_apply_data();
 
     auto diag = x->extract_diagonal();
     auto ddiag = dx->extract_diagonal();
+
+    GKO_ASSERT_MTX_NEAR(diag.get(), ddiag.get(), 0);
+}
+
+
+TEST_F(Dense, ExtractDiagonalOnShortFatIsEquivalentToRef)
+{
+    set_up_apply_data();
+
+    auto diag = y->extract_diagonal();
+    auto ddiag = dy->extract_diagonal();
 
     GKO_ASSERT_MTX_NEAR(diag.get(), ddiag.get(), 0);
 }

--- a/reference/test/matrix/dense_kernels.cpp
+++ b/reference/test/matrix/dense_kernels.cpp
@@ -83,7 +83,9 @@ protected:
           mtx5(gko::initialize<Mtx>(
               {{1.0, -1.0, -0.5}, {-2.0, 2.0, 4.5}, {2.1, 3.4, 1.2}}, exec)),
           mtx6(gko::initialize<Mtx>({{1.0, 2.0, 0.0}, {0.0, 1.5, 0.0}}, exec)),
-          mtx7(gko::initialize<Mtx>({{1.0, 2.0, 3.0}, {0.0, 1.5, 0.0}}, exec))
+          mtx7(gko::initialize<Mtx>({{1.0, 2.0, 3.0}, {0.0, 1.5, 0.0}}, exec)),
+          mtx8(gko::initialize<Mtx>(
+              {I<T>({1.0, -1.0}), I<T>({-2.0, 2.0}), I<T>({-3.0, 3.0})}, exec))
     {}
 
     std::shared_ptr<const gko::Executor> exec;
@@ -94,6 +96,7 @@ protected:
     std::unique_ptr<Mtx> mtx5;
     std::unique_ptr<Mtx> mtx6;
     std::unique_ptr<Mtx> mtx7;
+    std::unique_ptr<Mtx> mtx8;
 
     std::ranlux48 rand_engine;
 
@@ -2383,7 +2386,7 @@ TYPED_TEST(Dense, ExtractsDiagonalFromSquareMatrix)
 }
 
 
-TYPED_TEST(Dense, ExtractsDiagonalFromNonSquareMatrix)
+TYPED_TEST(Dense, ExtractsDiagonalFromTallSkinnyMatrix)
 {
     using T = typename TestFixture::value_type;
 
@@ -2397,6 +2400,24 @@ TYPED_TEST(Dense, ExtractsDiagonalFromNonSquareMatrix)
     ASSERT_EQ(diag->get_size()[1], 2);
     ASSERT_EQ(diag->get_values()[0], T{1.});
     ASSERT_EQ(diag->get_values()[1], T{5.});
+}
+
+
+TYPED_TEST(Dense, ExtractsDiagonalFromShortFatMatrix)
+{
+    using T = typename TestFixture::value_type;
+
+    // clang-format off
+    // { 1.0, -1.0},
+    // {-2.0,  2.0},
+    // {-3.0,  3.0}
+    // clang-format on
+    auto diag = this->mtx8->extract_diagonal();
+
+    ASSERT_EQ(diag->get_size()[0], 2);
+    ASSERT_EQ(diag->get_size()[1], 2);
+    ASSERT_EQ(diag->get_values()[0], T{1.});
+    ASSERT_EQ(diag->get_values()[1], T{2.});
 }
 
 


### PR DESCRIPTION
This PR uses the diag size not matrix size for extract_diagonal to avoid the segmentation fault when `#rows > #cols`.

TODO:
- [x] also add test case `#cols > #rows`