### PR TITLE
Data Validation

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -10,6 +10,7 @@ target_sources(ginkgo
     base/mtx_io.cpp
     base/perturbation.cpp
     base/version.cpp
+    components/validation_helpers.cpp
     factorization/ic.cpp
     factorization/ilu.cpp
     factorization/par_ic.cpp

--- a/core/components/validation_helpers.cpp
+++ b/core/components/validation_helpers.cpp
@@ -98,6 +98,22 @@ bool has_non_zero_diagonal(const LinOp *matrix)
 #undef GKO_CALL_AND_RETURN_IF_CASTABLE
 
 template <typename IndexType>
+bool has_unique_idxs(const IndexType *idxs, const size_type num_entries)
+{
+    for (size_type i = 1; i < num_entries; ++i) {
+        if (idxs[i - 1] == idxs[i]) {
+            return false;
+        }
+    }
+    return true;
+};
+
+#define GKO_DECLARE_HAS_UNIQUE_IDXS(IndexType) \
+    bool has_unique_idxs(const IndexType *idxs, const size_type num_entries)
+
+GKO_INSTANTIATE_FOR_EACH_INDEX_TYPE(GKO_DECLARE_HAS_UNIQUE_IDXS);
+
+template <typename IndexType>
 bool is_row_ordered(const IndexType *row_ptrs, const size_type num_entries)
 {
     for (size_type i = 1; i < num_entries; ++i) {

--- a/core/components/validation_helpers.cpp
+++ b/core/components/validation_helpers.cpp
@@ -165,6 +165,25 @@ bool is_finite(const ValueType *values, const size_type num_entries)
 GKO_INSTANTIATE_FOR_EACH_VALUE_TYPE(GKO_DECLARE_IS_FINITE);
 
 
+template <typename IndexType>
+bool is_consecutive(const IndexType *idxs, const size_type num_entries,
+                    const IndexType max_gap)
+{
+    for (size_type i = 1; i < num_entries; ++i) {
+        const IndexType gap = idxs[i] - idxs[i - 1];
+        if (gap > max_gap) {
+            return false;
+        }
+    }
+    return true;
+}
+
+#define GKO_DECLARE_IS_CONSECUTIVE(IndexType)                               \
+    bool is_consecutive(const IndexType *idxs, const size_type num_entries, \
+                        const IndexType max_gap)
+
+GKO_INSTANTIATE_FOR_EACH_INDEX_TYPE(GKO_DECLARE_IS_CONSECUTIVE);
+
 }  // namespace validate
 
 }  // namespace gko

--- a/core/components/validation_helpers.cpp
+++ b/core/components/validation_helpers.cpp
@@ -63,29 +63,29 @@ bool is_symmetric_impl(const LinOp *matrix, const float tolerance)
 }
 
 
-#define GKO_CALL_FOR_EACH_NON_COMPLEX_VALUE_AND_INDEX_TYPE(_macro) \
-    _macro(float, int32);                                          \
-    _macro(double, int32);                                         \
-    _macro(float, int64);                                          \
-    _macro(double, int64);
+#define GKO_CALL_FOR_EACH_NON_COMPLEX_VALUE_AND_INDEX_TYPE(_macro, ...) \
+    _macro(float, int32, ##__VA_ARGS__);                                \
+    _macro(double, int32, ##__VA_ARGS__);                               \
+    _macro(float, int64, ##__VA_ARGS__);                                \
+    _macro(double, int64, ##__VA_ARGS__)
 
 
-#define GKO_CALL_FOR_EACH_VALUE_AND_INDEX_TYPE(_macro)          \
-    GKO_CALL_FOR_EACH_NON_COMPLEX_VALUE_AND_INDEX_TYPE(_macro); \
-    _macro(std::complex<float>, int32);                         \
-    _macro(std::complex<double>, int32);                        \
-    _macro(std::complex<float>, int64);                         \
-    _macro(std::complex<double>, int64);
+#define GKO_CALL_FOR_EACH_VALUE_AND_INDEX_TYPE(_macro, ...)                    \
+    GKO_CALL_FOR_EACH_NON_COMPLEX_VALUE_AND_INDEX_TYPE(_macro, ##__VA_ARGS__); \
+    _macro(std::complex<float>, int32, ##__VA_ARGS__);                         \
+    _macro(std::complex<double>, int32, ##__VA_ARGS__);                        \
+    _macro(std::complex<float>, int64, ##__VA_ARGS__);                         \
+    _macro(std::complex<double>, int64, ##__VA_ARGS__)
 
+#define CALL_AND_RETURN_IF_CASTABLE(T1, T2, func, matrix, ...)        \
+    if (dynamic_cast<const WritableToMatrixData<T1, T2> *>(matrix)) { \
+        return func<T1, T2>(matrix, ##__VA_ARGS__);                   \
+    }
 
 bool is_symmetric(const LinOp *matrix, const float tolerance)
 {
-#define CALL_AND_RETURN_IF_CASTABLE(T1, T2)                           \
-    if (dynamic_cast<const WritableToMatrixData<T1, T2> *>(matrix)) { \
-        return is_symmetric_impl<T1, T2>(matrix, tolerance);          \
-    }
-    GKO_CALL_FOR_EACH_VALUE_AND_INDEX_TYPE(CALL_AND_RETURN_IF_CASTABLE);
-#undef CALL_AND_RETURN_IF_CASTABLE
+    GKO_CALL_FOR_EACH_VALUE_AND_INDEX_TYPE(CALL_AND_RETURN_IF_CASTABLE,
+                                           is_symmetric_impl, matrix, tolerance)
     return false;
 }
 
@@ -106,14 +106,11 @@ bool has_non_zero_diagonal_impl(const LinOp *matrix)
 
 bool has_non_zero_diagonal(const LinOp *matrix)
 {
-#define CALL_AND_RETURN_IF_CASTABLE(T1, T2)                           \
-    if (dynamic_cast<const WritableToMatrixData<T1, T2> *>(matrix)) { \
-        return has_non_zero_diagonal_impl<T1, T2>(matrix);            \
-    }
-    GKO_CALL_FOR_EACH_VALUE_AND_INDEX_TYPE(CALL_AND_RETURN_IF_CASTABLE);
-#undef CALL_AND_RETURN_IF_CASTABLE
+    GKO_CALL_FOR_EACH_VALUE_AND_INDEX_TYPE(CALL_AND_RETURN_IF_CASTABLE,
+                                           has_non_zero_diagonal_impl, matrix)
     return false;
 }
+#undef CALL_AND_RETURN_IF_CASTABLE
 
 template <typename IndexType>
 bool is_row_ordered(const IndexType *row_ptrs, const size_type num_entries)
@@ -146,7 +143,7 @@ bool is_within_bounds(const IndexType *idxs, const size_type num_entries,
 #define GKO_DECLARE_IS_WITHIN_BOUNDS(IndexType)                               \
     bool is_within_bounds(const IndexType *idxs, const size_type num_entries, \
                           const IndexType lower_bound,                        \
-                          const IndexType upper_bound);
+                          const IndexType upper_bound)
 
 GKO_INSTANTIATE_FOR_EACH_INDEX_TYPE(GKO_DECLARE_IS_WITHIN_BOUNDS);
 

--- a/core/components/validation_helpers.cpp
+++ b/core/components/validation_helpers.cpp
@@ -33,6 +33,24 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "core/components/validation_helpers.hpp"
 
 namespace gko {
-namespace validate {}
+namespace validate {
+
+template <typename IndexType>
+bool is_row_ordered(const IndexType *row_ptrs, const size_type num_entries)
+{
+    for (size_type i = 1; i < num_entries; ++i) {
+        if (row_ptrs[i - 1] > row_ptrs[i]) {
+            return false;
+        }
+    }
+    return true;
+}
+
+#define GKO_DECLARE_IS_ROW_ORDERED(IndexType) \
+    bool is_row_ordered(const IndexType *row_ptrs, const size_type num_entries)
+
+GKO_INSTANTIATE_FOR_EACH_INDEX_TYPE(GKO_DECLARE_IS_ROW_ORDERED);
+
+}  // namespace validate
 
 }  // namespace gko

--- a/core/components/validation_helpers.cpp
+++ b/core/components/validation_helpers.cpp
@@ -95,6 +95,40 @@ bool has_non_zero_diagonal(const LinOp *matrix)
                                            has_non_zero_diagonal_impl, matrix)
     return false;
 }
+
+template <class ValueType, class IndexType>
+bool is_triangular_impl(const LinOp *matrix, const bool upper)
+{
+    matrix_data<ValueType, IndexType> data{};
+    dynamic_cast<const WritableToMatrixData<ValueType, IndexType> *>(matrix)
+        ->write(data);
+
+    auto predicate = [upper](const IndexType i1, const IndexType i2) {
+        return upper ? i1 > i2 : i2 > i1;
+    };
+
+    for (auto &nonzero : data.nonzeros) {
+        if (predicate(nonzero.row, nonzero.column)) {
+            return false;
+        }
+    }
+    return true;
+}
+
+
+bool is_lower_triangular(const LinOp *matrix)
+{
+    GKO_CALL_FOR_EACH_VALUE_AND_INDEX_TYPE(GKO_CALL_AND_RETURN_IF_CASTABLE,
+                                           is_diagonal_impl, matrix, false)
+    return false;
+}
+
+bool is_upper_triangular(const LinOp *matrix)
+{
+    GKO_CALL_FOR_EACH_VALUE_AND_INDEX_TYPE(GKO_CALL_AND_RETURN_IF_CASTABLE,
+                                           is_diagonal_impl, matrix, true)
+    return false;
+}
 #undef GKO_CALL_AND_RETURN_IF_CASTABLE
 
 template <typename IndexType>
@@ -106,7 +140,7 @@ bool has_unique_idxs(const IndexType *idxs, const size_type num_entries)
         }
     }
     return true;
-};
+}
 
 #define GKO_DECLARE_HAS_UNIQUE_IDXS(IndexType) \
     bool has_unique_idxs(const IndexType *idxs, const size_type num_entries)

--- a/core/components/validation_helpers.cpp
+++ b/core/components/validation_helpers.cpp
@@ -169,7 +169,6 @@ bool is_upper_triangular(const LinOp *matrix)
                                            is_triangular_impl, matrix, true)
     return false;
 }
-#undef GKO_CALL_AND_RETURN_IF_CASTABLE
 
 
 template <typename IndexType>
@@ -227,6 +226,28 @@ bool is_finite(const ValueType *values, const size_type num_entries)
 
 GKO_INSTANTIATE_FOR_EACH_VALUE_TYPE(GKO_DECLARE_IS_FINITE);
 
+template <class ValueType, class IndexType>
+bool is_finite_impl(const LinOp *matrix)
+{
+    matrix_data<ValueType, IndexType> data{};
+    dynamic_cast<const WritableToMatrixData<ValueType, IndexType> *>(matrix)
+        ->write(data);
+
+    size_type num_elems = data.nonzeros.size();
+
+    return all_of(num_elems, [&data, num_elems](const size_type i) {
+        return std::isfinite(std::abs(data.nonzeros[i].value));
+    });
+}
+
+bool is_finite(const LinOp *matrix)
+{
+    GKO_CALL_FOR_EACH_VALUE_AND_INDEX_TYPE(GKO_CALL_AND_RETURN_IF_CASTABLE,
+                                           is_finite_impl, matrix)
+    return false;
+}
+
+#undef GKO_CALL_AND_RETURN_IF_CASTABLE
 
 template <typename IndexType>
 bool is_consecutive(const IndexType *idxs, const size_type num_entries,

--- a/core/components/validation_helpers.cpp
+++ b/core/components/validation_helpers.cpp
@@ -131,6 +131,24 @@ bool is_row_ordered(const IndexType *row_ptrs, const size_type num_entries)
 
 GKO_INSTANTIATE_FOR_EACH_INDEX_TYPE(GKO_DECLARE_IS_ROW_ORDERED);
 
+template <typename IndexType>
+bool is_within_bounds(const IndexType *idxs, const size_type num_entries,
+                      const IndexType lower_bound, const IndexType upper_bound)
+{
+    for (size_type i = 0; i < num_entries; ++i) {
+        if (lower_bound > idxs[i] || idxs[i] >= upper_bound) {
+            return false;
+        }
+    }
+    return true;
+}
+
+#define GKO_DECLARE_IS_WITHIN_BOUNDS(IndexType)                               \
+    bool is_within_bounds(const IndexType *idxs, const size_type num_entries, \
+                          const IndexType lower_bound,                        \
+                          const IndexType upper_bound);
+
+GKO_INSTANTIATE_FOR_EACH_INDEX_TYPE(GKO_DECLARE_IS_WITHIN_BOUNDS);
 
 template <typename ValueType>
 bool is_finite(const ValueType *values, const size_type num_entries)

--- a/core/components/validation_helpers.cpp
+++ b/core/components/validation_helpers.cpp
@@ -111,12 +111,17 @@ template <typename ValueType>
 bool is_finite(const ValueType *values, const size_type num_entries)
 {
     for (size_type i = 0; i < num_entries; ++i) {
-        if (!std::isfinite(values[i])) {
+        if (!std::isfinite(std::abs(values[i]))) {
             return false;
         }
     }
     return true;
 }
+
+#define GKO_DECLARE_IS_FINITE(ValueType) \
+    bool is_finite(const ValueType *values, const size_type num_entries)
+
+GKO_INSTANTIATE_FOR_EACH_VALUE_TYPE(GKO_DECLARE_IS_FINITE);
 
 
 }  // namespace validate

--- a/core/components/validation_helpers.cpp
+++ b/core/components/validation_helpers.cpp
@@ -1,0 +1,38 @@
+/*******************************<GINKGO LICENSE>******************************
+Copyright (c) 2017-2021, the Ginkgo authors
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+******************************<GINKGO LICENSE>*******************************/
+
+#include "core/components/validation_helpers.hpp"
+
+namespace gko {
+namespace validate {}
+
+}  // namespace gko

--- a/core/components/validation_helpers.cpp
+++ b/core/components/validation_helpers.cpp
@@ -77,14 +77,15 @@ bool is_symmetric_impl(const LinOp *matrix, const float tolerance)
     _macro(std::complex<float>, int64);                         \
     _macro(std::complex<double>, int64);
 
+
+bool is_symmetric(const LinOp *matrix, const float tolerance)
+{
 #define CALL_AND_RETURN_IF_CASTABLE(T1, T2)                           \
     if (dynamic_cast<const WritableToMatrixData<T1, T2> *>(matrix)) { \
         return is_symmetric_impl<T1, T2>(matrix, tolerance);          \
     }
-
-bool is_symmetric(const LinOp *matrix, const float tolerance)
-{
     GKO_CALL_FOR_EACH_VALUE_AND_INDEX_TYPE(CALL_AND_RETURN_IF_CASTABLE);
+#undef CALL_AND_RETURN_IF_CASTABLE
     return false;
 }
 

--- a/core/components/validation_helpers.cpp
+++ b/core/components/validation_helpers.cpp
@@ -62,29 +62,14 @@ bool is_symmetric_impl(const LinOp *matrix, const float tolerance)
         });
 }
 
-
-#define GKO_CALL_FOR_EACH_NON_COMPLEX_VALUE_AND_INDEX_TYPE(_macro, ...) \
-    _macro(float, int32, ##__VA_ARGS__);                                \
-    _macro(double, int32, ##__VA_ARGS__);                               \
-    _macro(float, int64, ##__VA_ARGS__);                                \
-    _macro(double, int64, ##__VA_ARGS__)
-
-
-#define GKO_CALL_FOR_EACH_VALUE_AND_INDEX_TYPE(_macro, ...)                    \
-    GKO_CALL_FOR_EACH_NON_COMPLEX_VALUE_AND_INDEX_TYPE(_macro, ##__VA_ARGS__); \
-    _macro(std::complex<float>, int32, ##__VA_ARGS__);                         \
-    _macro(std::complex<double>, int32, ##__VA_ARGS__);                        \
-    _macro(std::complex<float>, int64, ##__VA_ARGS__);                         \
-    _macro(std::complex<double>, int64, ##__VA_ARGS__)
-
-#define CALL_AND_RETURN_IF_CASTABLE(T1, T2, func, matrix, ...)        \
+#define GKO_CALL_AND_RETURN_IF_CASTABLE(T1, T2, func, matrix, ...)    \
     if (dynamic_cast<const WritableToMatrixData<T1, T2> *>(matrix)) { \
         return func<T1, T2>(matrix, ##__VA_ARGS__);                   \
     }
 
 bool is_symmetric(const LinOp *matrix, const float tolerance)
 {
-    GKO_CALL_FOR_EACH_VALUE_AND_INDEX_TYPE(CALL_AND_RETURN_IF_CASTABLE,
+    GKO_CALL_FOR_EACH_VALUE_AND_INDEX_TYPE(GKO_CALL_AND_RETURN_IF_CASTABLE,
                                            is_symmetric_impl, matrix, tolerance)
     return false;
 }
@@ -106,11 +91,11 @@ bool has_non_zero_diagonal_impl(const LinOp *matrix)
 
 bool has_non_zero_diagonal(const LinOp *matrix)
 {
-    GKO_CALL_FOR_EACH_VALUE_AND_INDEX_TYPE(CALL_AND_RETURN_IF_CASTABLE,
+    GKO_CALL_FOR_EACH_VALUE_AND_INDEX_TYPE(GKO_CALL_AND_RETURN_IF_CASTABLE,
                                            has_non_zero_diagonal_impl, matrix)
     return false;
 }
-#undef CALL_AND_RETURN_IF_CASTABLE
+#undef GKO_CALL_AND_RETURN_IF_CASTABLE
 
 template <typename IndexType>
 bool is_row_ordered(const IndexType *row_ptrs, const size_type num_entries)

--- a/core/components/validation_helpers.hpp
+++ b/core/components/validation_helpers.hpp
@@ -56,7 +56,7 @@ bool has_non_zero_diagonal(const LinOp *A);
 /**
  * Tests whether the given row_ptrs are in an ascending order
  *
- * @param row_ptrs the array which is to be tested
+ * @param row_ptrs the sorted array which is to be tested
  * @param num_entries length of the array which is to be tested
  */
 template <typename IndexType>
@@ -95,6 +95,15 @@ template <typename ValueType>
 bool is_finite(const ValueType *values, const size_type num_entries);
 
 
+/**
+ * Tests whether the difference between adjacent elements is below a threshold
+ *
+ * @param idxs the sorted array which is to be tested
+ * @param num_entries length of the array which is to be tested
+ */
+template <typename IndexType>
+bool is_consecutive(const IndexType *idxs, const size_type num_entries,
+                    const IndexType max_gap);
 }  // namespace validate
 }  // namespace gko
 

--- a/core/components/validation_helpers.hpp
+++ b/core/components/validation_helpers.hpp
@@ -74,9 +74,9 @@ bool is_within_bounds(const IndexType *idxs, const IndexType lower_bound,
 
 
 /**
- * Tests whether the elements of the given array are within specified bounds
+ * Tests whether all elements of the given array are finite
  *
- * @param row_ptrs the array which is to be tested
+ * @param values the array which is to be tested
  * @param num_entries length of the array which is to be tested
  */
 template <typename ValueType>

--- a/core/components/validation_helpers.hpp
+++ b/core/components/validation_helpers.hpp
@@ -52,10 +52,7 @@ bool is_symmetric(const LinOp *A) { return false; }
  * @param row_ptrs the array which is to be tested
  */
 template <typename IndexType>
-bool is_row_ordered(const IndexType *row_ptrs, const size_type num_entries)
-{
-    return false;
-}
+bool is_row_ordered(const IndexType *row_ptrs, const size_type num_entries);
 
 }  // namespace validate
 }  // namespace gko

--- a/core/components/validation_helpers.hpp
+++ b/core/components/validation_helpers.hpp
@@ -44,15 +44,44 @@ namespace validate {
  *
  * @param A the input matrix which is tested
  */
-bool is_symmetric(const LinOp *A) { return false; }
+bool is_symmetric(const LinOp *A, const float tolerance = 0.0);
+
+/**
+ * Tests whether a given matrix is symmetric
+ *
+ * @param A the input matrix which is tested
+ */
+bool has_non_zero_diagonal(const LinOp *A) { return false; }
 
 /**
  * Tests whether the given row_ptrs are in an ascending order
  *
  * @param row_ptrs the array which is to be tested
+ * @param num_entries length of the array which is to be tested
  */
 template <typename IndexType>
 bool is_row_ordered(const IndexType *row_ptrs, const size_type num_entries);
+
+/**
+ * Tests whether the elements of the given array are within specified bounds
+ *
+ * @param row_ptrs the array which is to be tested
+ * @param num_entries length of the array which is to be tested
+ */
+template <typename IndexType>
+bool is_within_bounds(const IndexType *idxs, const IndexType lower_bound,
+                      const IndexType upper_bound);
+
+
+/**
+ * Tests whether the elements of the given array are within specified bounds
+ *
+ * @param row_ptrs the array which is to be tested
+ * @param num_entries length of the array which is to be tested
+ */
+template <typename ValueType>
+bool is_finite(const ValueType *values, const size_type num_entries);
+
 
 }  // namespace validate
 }  // namespace gko

--- a/core/components/validation_helpers.hpp
+++ b/core/components/validation_helpers.hpp
@@ -63,6 +63,15 @@ template <typename IndexType>
 bool is_row_ordered(const IndexType *row_ptrs, const size_type num_entries);
 
 /**
+ * Tests whether the elements of the given index array are within unique
+ *
+ * @param idxs the sorted array which is to be tested
+ * @param num_entries length of the array which is to be tested
+ */
+template <typename IndexType>
+bool has_unique_idxs(const IndexType *idxs, const size_type num_entries);
+
+/**
  * Tests whether the elements of the given array are within [lower_bound,
  * upper_bound)
  *

--- a/core/components/validation_helpers.hpp
+++ b/core/components/validation_helpers.hpp
@@ -1,0 +1,40 @@
+/*******************************<GINKGO LICENSE>******************************
+Copyright (c) 2017-2021, the Ginkgo authors
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+******************************<GINKGO LICENSE>*******************************/
+
+#ifndef GKO_CORE_COMPONENTS_VALIDATION_HELPERS_HPP_
+#define GKO_CORE_COMPONENTS_VALIDATION_HELPERS_HPP_
+
+namespace gko {
+namespace validate {}
+}  // namespace gko
+
+#endif  // GKO_CORE_COMPONENTS_VALIDATION_HELPERS_HPP_

--- a/core/components/validation_helpers.hpp
+++ b/core/components/validation_helpers.hpp
@@ -44,14 +44,28 @@ namespace validate {
  *
  * @param A the input matrix which is tested
  */
-bool is_symmetric(const LinOp *A, const float tolerance = 0.0);
+bool is_symmetric(const LinOp *matrix, const float tolerance = 0.0);
 
 /**
  * Tests whether a given matrix has zero elements on the diagonal
  *
  * @param A the input matrix which is tested
  */
-bool has_non_zero_diagonal(const LinOp *A);
+bool has_non_zero_diagonal(const LinOp *matrix);
+
+/**
+ * Tests whether a given matrix is a lower triangular matrix
+ *
+ * @param A the input matrix which is tested
+ */
+bool is_lower_triangular(const LinOp *matrix);
+
+/**
+ * Tests whether a given matrix is an upper triangular matrix
+ *
+ * @param A the input matrix which is tested
+ */
+bool is_upper_triangular(const LinOp *matrix);
 
 /**
  * Tests whether the given row_ptrs are in an ascending order

--- a/core/components/validation_helpers.hpp
+++ b/core/components/validation_helpers.hpp
@@ -31,7 +31,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ******************************<GINKGO LICENSE>*******************************/
 
 #ifndef GKO_CORE_COMPONENTS_VALIDATION_HELPERS_HPP_
-#define GKO_CORE_COMponents_VALIDATION_HELPERS_HPP_
+#define GKO_CORE_COMPONENTS_VALIDATION_HELPERS_HPP_
 
 #include <ginkgo/core/base/array.hpp>
 #include <ginkgo/core/base/lin_op.hpp>
@@ -51,7 +51,7 @@ bool is_symmetric(const LinOp *A, const float tolerance = 0.0);
  *
  * @param A the input matrix which is tested
  */
-bool has_non_zero_diagonal(const LinOp *A) { return false; }
+bool has_non_zero_diagonal(const LinOp *A);
 
 /**
  * Tests whether the given row_ptrs are in an ascending order

--- a/core/components/validation_helpers.hpp
+++ b/core/components/validation_helpers.hpp
@@ -63,14 +63,17 @@ template <typename IndexType>
 bool is_row_ordered(const IndexType *row_ptrs, const size_type num_entries);
 
 /**
- * Tests whether the elements of the given array are within specified bounds
+ * Tests whether the elements of the given array are within [lower_bound,
+ * upper_bound)
  *
  * @param row_ptrs the array which is to be tested
  * @param num_entries length of the array which is to be tested
+ * @param lower_bound the lower bound
+ * @param upper_bound the upper bound
  */
 template <typename IndexType>
-bool is_within_bounds(const IndexType *idxs, const IndexType lower_bound,
-                      const IndexType upper_bound);
+bool is_within_bounds(const IndexType *idxs, const size_type num_entries,
+                      const IndexType lower_bound, const IndexType upper_bound);
 
 
 /**

--- a/core/components/validation_helpers.hpp
+++ b/core/components/validation_helpers.hpp
@@ -109,6 +109,8 @@ template <typename ValueType>
 bool is_finite(const ValueType *values, const size_type num_entries);
 
 
+bool is_finite(const LinOp *matrix);
+
 /**
  * Tests whether the difference between adjacent elements is below a threshold
  *

--- a/core/components/validation_helpers.hpp
+++ b/core/components/validation_helpers.hpp
@@ -47,7 +47,7 @@ namespace validate {
 bool is_symmetric(const LinOp *A, const float tolerance = 0.0);
 
 /**
- * Tests whether a given matrix is symmetric
+ * Tests whether a given matrix has zero elements on the diagonal
  *
  * @param A the input matrix which is tested
  */

--- a/core/factorization/ilu.cpp
+++ b/core/factorization/ilu.cpp
@@ -33,6 +33,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <ginkgo/core/factorization/ilu.hpp>
 
 
+#include <map>
 #include <memory>
 
 
@@ -40,6 +41,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <ginkgo/core/base/exception_helpers.hpp>
 
 
+#include "core/components/validation_helpers.hpp"
 #include "core/factorization/factorization_kernels.hpp"
 #include "core/factorization/ilu_kernels.hpp"
 #include "core/factorization/par_ilu_kernels.hpp"
@@ -47,8 +49,28 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 namespace gko {
 namespace factorization {
-namespace ilu_factorization {
 
+template <typename ValueType, typename IndexType>
+void Ilu<ValueType, IndexType>::validate_impl() const
+{
+    std::map<std::string, std::function<bool()>> constraints_map{
+        {"l_factor_is_finite",
+         [this] { return ::gko::validate::is_finite(get_l_factor().get()); }},
+        {"u_factor_is_finite",
+         [this] { return ::gko::validate::is_finite(get_u_factor().get()); }},
+        {"has_non_zero_diagonal", [this] {
+             return ::gko::validate::has_non_zero_diagonal(
+                 get_l_factor().get());
+         }}};
+
+    for (auto const &x : constraints_map) {
+        if (!x.second()) {
+            throw gko::Invalid(__FILE__, __LINE__, "Ilu", x.first);
+        };
+    }
+};
+
+namespace ilu_factorization {
 
 GKO_REGISTER_OPERATION(compute_ilu, ilu_factorization::compute_lu);
 GKO_REGISTER_OPERATION(add_diagonal_elements,

--- a/core/factorization/par_ict.cpp
+++ b/core/factorization/par_ict.cpp
@@ -33,6 +33,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <ginkgo/core/factorization/par_ict.hpp>
 
 
+#include <map>
 #include <memory>
 
 
@@ -45,6 +46,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
 #include "core/base/utils.hpp"
+#include "core/components/validation_helpers.hpp"
 #include "core/factorization/factorization_kernels.hpp"
 #include "core/factorization/par_ict_kernels.hpp"
 #include "core/factorization/par_ilu_kernels.hpp"
@@ -56,6 +58,30 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 namespace gko {
 namespace factorization {
+
+template <typename ValueType, typename IndexType>
+void ParIct<ValueType, IndexType>::validate_impl() const
+{
+    std::map<std::string, std::function<bool()>> constraints_map{
+        {"is_finite",
+         [this] {
+             return ::gko::validate::is_finite(get_l_factor().get()) &&
+                    ::gko::validate::is_finite(get_lt_factor().get());
+         }},
+        {"has_non_zero_diagonal", [this] {
+             return ::gko::validate::has_non_zero_diagonal(
+                        get_l_factor().get()) &&
+                    ::gko::validate::has_non_zero_diagonal(
+                        get_lt_factor().get());
+         }}};
+
+    for (auto const &x : constraints_map) {
+        if (!x.second()) {
+            throw gko::Invalid(__FILE__, __LINE__, "ParIc", x.first);
+        };
+    }
+}
+
 namespace par_ict_factorization {
 
 

--- a/core/factorization/par_ilut.cpp
+++ b/core/factorization/par_ilut.cpp
@@ -33,6 +33,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <ginkgo/core/factorization/par_ilut.hpp>
 
 
+#include <map>
 #include <memory>
 
 
@@ -45,6 +46,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
 #include "core/base/utils.hpp"
+#include "core/components/validation_helpers.hpp"
 #include "core/factorization/factorization_kernels.hpp"
 #include "core/factorization/par_ilu_kernels.hpp"
 #include "core/factorization/par_ilut_kernels.hpp"
@@ -55,6 +57,28 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 namespace gko {
 namespace factorization {
+
+template <typename ValueType, typename IndexType>
+void ParIlut<ValueType, IndexType>::validate_impl() const
+{
+    std::map<std::string, std::function<bool()>> constraints_map{
+        {"is_finite",
+         [this] {
+             return ::gko::validate::is_finite(get_l_factor().get()) &&
+                    ::gko::validate::is_finite(get_u_factor().get());
+         }},
+        {"has_non_zero_diagonal", [this] {
+             return ::gko::validate::has_non_zero_diagonal(
+                 get_l_factor().get());
+         }}};
+
+    for (auto const &x : constraints_map) {
+        if (!x.second()) {
+            throw gko::Invalid(__FILE__, __LINE__, "ParIc", x.first);
+        };
+    }
+}
+
 namespace par_ilut_factorization {
 
 

--- a/core/matrix/csr.cpp
+++ b/core/matrix/csr.cpp
@@ -344,18 +344,23 @@ void Csr<ValueType, IndexType>::read(const mat_data &data)
 template <typename ValueType, typename IndexType>
 void Csr<ValueType, IndexType>::validate_impl() const
 {
-    bool valid = false;
     std::map<std::string, std::function<bool()>> constraints_map{
         {"is_finite",
          [this] {
              return ::gko::validate::is_finite<ValueType>(
                  values_.get_const_data(), values_.get_num_elems());
          }},
-        {"is_within_bounds",
+        {"column index is_within_bounds",
          [this] {
              return ::gko::validate::is_within_bounds<IndexType>(
                  col_idxs_.get_const_data(), col_idxs_.get_num_elems(), 0,
                  this->get_size()[1]);
+         }},
+        {"row pointer is_within_bounds",
+         [this] {
+             return ::gko::validate::is_within_bounds<IndexType>(
+                 row_ptrs_.get_const_data(), row_ptrs_.get_num_elems(), 0,
+                 values_.get_num_elems());
          }},
         {"is_row_ordered", [this] {
              return ::gko::validate::is_row_ordered<IndexType>(

--- a/core/matrix/csr.cpp
+++ b/core/matrix/csr.cpp
@@ -360,11 +360,16 @@ void Csr<ValueType, IndexType>::validate_impl() const
          [this] {
              return ::gko::validate::is_within_bounds<IndexType>(
                  row_ptrs_.get_const_data(), row_ptrs_.get_num_elems(), 0,
-                 values_.get_num_elems());
+                 values_.get_num_elems() + 1);
          }},
-        {"is_row_ordered", [this] {
+        {"is_row_ordered",
+         [this] {
              return ::gko::validate::is_row_ordered<IndexType>(
                  row_ptrs_.get_const_data(), row_ptrs_.get_num_elems());
+         }},
+        {"row pointer has_unique_idxs", [this] {
+             return ::gko::validate::has_unique_idxs(row_ptrs_.get_const_data(),
+                                                     row_ptrs_.get_num_elems());
          }}};
 
     for (auto const &x : constraints_map) {

--- a/core/matrix/dense.cpp
+++ b/core/matrix/dense.cpp
@@ -34,6 +34,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
 #include <algorithm>
+#include <map>
 #include <type_traits>
 
 
@@ -53,6 +54,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <ginkgo/core/matrix/sparsity_csr.hpp>
 
 
+#include "core/components/validation_helpers.hpp"
 #include "core/matrix/dense_kernels.hpp"
 
 
@@ -619,7 +621,6 @@ inline void write_impl(const MatrixType *mtx, MatrixData &data)
 
 }  // namespace
 
-
 template <typename ValueType>
 void Dense<ValueType>::write(mat_data &data) const
 {
@@ -633,6 +634,21 @@ void Dense<ValueType>::write(mat_data32 &data) const
     write_impl(this, data);
 }
 
+template <typename ValueType>
+void Dense<ValueType>::validate_impl() const
+{
+    std::map<std::string, std::function<bool()>> constraints_map{
+        {"is_finite", [this] {
+             return ::gko::validate::is_finite<ValueType>(
+                 values_.get_const_data(), values_.get_num_elems());
+         }}};
+
+    for (auto const &x : constraints_map) {
+        if (!x.second()) {
+            throw gko::Invalid(__FILE__, __LINE__, "Dense", x.first);
+        };
+    }
+}
 
 template <typename ValueType>
 std::unique_ptr<LinOp> Dense<ValueType>::transpose() const

--- a/core/matrix/diagonal.cpp
+++ b/core/matrix/diagonal.cpp
@@ -32,6 +32,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <ginkgo/core/matrix/diagonal.hpp>
 
+#include <map>
 
 #include <ginkgo/core/base/exception_helpers.hpp>
 #include <ginkgo/core/base/precision_dispatch.hpp>
@@ -40,6 +41,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
 #include "core/components/absolute_array.hpp"
+#include "core/components/validation_helpers.hpp"
 #include "core/matrix/diagonal_kernels.hpp"
 
 
@@ -268,6 +270,22 @@ template <typename ValueType>
 void Diagonal<ValueType>::write(mat_data32 &data) const
 {
     write_impl(this, data);
+}
+
+template <typename ValueType>
+void Diagonal<ValueType>::validate_impl() const
+{
+    std::map<std::string, std::function<bool()>> constraints_map{
+        {"is_finite", [this] {
+             return ::gko::validate::is_finite<ValueType>(
+                 values_.get_const_data(), values_.get_num_elems());
+         }}};
+
+    for (auto const &x : constraints_map) {
+        if (!x.second()) {
+            throw gko::Invalid(__FILE__, __LINE__, "Diagonal", x.first);
+        };
+    }
 }
 
 

--- a/core/matrix/fbcsr.cpp
+++ b/core/matrix/fbcsr.cpp
@@ -51,6 +51,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "accessor/range.hpp"
 #include "core/components/absolute_array.hpp"
 #include "core/components/fill_array.hpp"
+#include "core/components/validation_helpers.hpp"
 #include "core/matrix/fbcsr_kernels.hpp"
 
 
@@ -418,6 +419,44 @@ void Fbcsr<ValueType, IndexType>::write(mat_data &data) const
     }
 }
 
+template <typename ValueType, typename IndexType>
+void Fbcsr<ValueType, IndexType>::validate_impl() const
+{
+    std::map<std::string, std::function<bool()>> constraints_map{
+        {"is_finite",
+         [this] {
+             return ::gko::validate::is_finite<ValueType>(
+                 values_.get_const_data(), values_.get_num_elems());
+         }},
+        {"column index is_within_bounds",
+         [this] {
+             return ::gko::validate::is_within_bounds<IndexType>(
+                 col_idxs_.get_const_data(), col_idxs_.get_num_elems(), 0,
+                 nbcols_);
+         }},
+        {"row pointer is_within_bounds",
+         [this] {
+             return ::gko::validate::is_within_bounds<IndexType>(
+                 row_ptrs_.get_const_data(), row_ptrs_.get_num_elems(), 0,
+                 nbcols_ + 1);
+         }},
+        {"is_row_ordered",
+         [this] {
+             return ::gko::validate::is_row_ordered<IndexType>(
+                 row_ptrs_.get_const_data(), row_ptrs_.get_num_elems());
+         }},
+        {"row pointer has_unique_idxs", [this] {
+             return ::gko::validate::has_unique_idxs(row_ptrs_.get_const_data(),
+                                                     row_ptrs_.get_num_elems());
+         }}};
+
+
+    for (auto const &x : constraints_map) {
+        if (!x.second()) {
+            throw gko::Invalid(__FILE__, __LINE__, "Fbcsr", x.first);
+        };
+    }
+}
 
 template <typename ValueType, typename IndexType>
 std::unique_ptr<LinOp> Fbcsr<ValueType, IndexType>::transpose() const

--- a/core/matrix/hybrid.cpp
+++ b/core/matrix/hybrid.cpp
@@ -283,6 +283,12 @@ void Hybrid<ValueType, IndexType>::write(mat_data &data) const
     }
 }
 
+template <typename ValueType, typename IndexType>
+void Hybrid<ValueType, IndexType>::validate_impl() const
+{
+    ell_->validate_impl();
+    coo_->validate_impl();
+}
 
 template <typename ValueType, typename IndexType>
 std::unique_ptr<Diagonal<ValueType>>

--- a/core/matrix/sellp.cpp
+++ b/core/matrix/sellp.cpp
@@ -305,10 +305,7 @@ template <typename ValueType, typename IndexType>
 void Sellp<ValueType, IndexType>::validate_impl() const
 {
     std::map<std::string, std::function<bool()>> constraints_map{
-        {"is_finite", [this] {
-             return ::gko::validate::is_finite<ValueType>(
-                 values_.get_const_data(), values_.get_num_elems());
-         }}};
+        {"is_finite", [this] { return ::gko::validate::is_finite(this); }}};
 
     for (auto const &x : constraints_map) {
         if (!x.second()) {

--- a/core/matrix/sellp.cpp
+++ b/core/matrix/sellp.cpp
@@ -299,6 +299,20 @@ void Sellp<ValueType, IndexType>::write(mat_data &data) const
     }
 }
 
+void validate_impl() const
+{
+    std::map<std::string, std::function<bool()>> constraints_map{
+        {"is_finite", [this] {
+             return ::gko::validate::is_finite<ValueType>(
+                 values_.get_const_data(), values_.get_num_elems());
+         }}};
+
+    for (auto const &x : constraints_map) {
+        if (!x.second()) {
+            throw gko::Invalid(__FILE__, __LINE__, "Sellp", x.first);
+        };
+    }
+}
 
 template <typename ValueType, typename IndexType>
 std::unique_ptr<Diagonal<ValueType>>

--- a/core/matrix/sellp.cpp
+++ b/core/matrix/sellp.cpp
@@ -45,6 +45,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "core/base/allocator.hpp"
 #include "core/components/absolute_array.hpp"
 #include "core/components/fill_array.hpp"
+#include "core/components/validation_helpers.hpp"
 #include "core/matrix/sellp_kernels.hpp"
 
 
@@ -299,7 +300,9 @@ void Sellp<ValueType, IndexType>::write(mat_data &data) const
     }
 }
 
-void validate_impl() const
+// TODO check if strided/padded
+template <typename ValueType, typename IndexType>
+void Sellp<ValueType, IndexType>::validate_impl() const
 {
     std::map<std::string, std::function<bool()>> constraints_map{
         {"is_finite", [this] {

--- a/core/test/CMakeLists.txt
+++ b/core/test/CMakeLists.txt
@@ -2,6 +2,7 @@ include(${PROJECT_SOURCE_DIR}/cmake/create_test.cmake)
 
 add_subdirectory(accessor)
 add_subdirectory(base)
+add_subdirectory(components)
 add_subdirectory(factorization)
 add_subdirectory(log)
 add_subdirectory(matrix)

--- a/core/test/components/CMakeLists.txt
+++ b/core/test/components/CMakeLists.txt
@@ -1,0 +1,1 @@
+ginkgo_create_test(validation_helpers)

--- a/core/test/components/validation_helpers.cpp
+++ b/core/test/components/validation_helpers.cpp
@@ -42,7 +42,7 @@ namespace {
 
 #define GKO_DEFINE_ISSYMMETRIC(MATRIX_TYPE)                                   \
     template <typename ValueIndexType>                                        \
-    class IsSymmetric##MATRIX_TYPE : public ::testing::Test {                 \
+    class MatrixTest##MATRIX_TYPE : public ::testing::Test {                  \
     protected:                                                                \
         using value_type =                                                    \
             typename std::tuple_element<0, decltype(ValueIndexType())>::type; \
@@ -50,7 +50,7 @@ namespace {
             typename std::tuple_element<1, decltype(ValueIndexType())>::type; \
         using Mtx = gko::matrix::Coo<value_type, index_type>;                 \
                                                                               \
-        IsSymmetric##MATRIX_TYPE()                                            \
+        MatrixTest##MATRIX_TYPE()                                             \
             : exec(gko::ReferenceExecutor::create()),                         \
               mtx(gko::matrix::Coo<value_type, index_type>::create(           \
                   exec, gko::dim<2>{3, 3}, 9))                                \
@@ -98,18 +98,32 @@ namespace {
 #define GKO_TYPED_TEST_SUITE_FOR_MATRIX_TYPE(MATRIX_TYPE)                     \
     GKO_DEFINE_ISSYMMETRIC(MATRIX_TYPE);                                      \
                                                                               \
-    TYPED_TEST_SUITE(IsSymmetric##MATRIX_TYPE, gko::test::ValueIndexTypes);   \
+    TYPED_TEST_SUITE(MatrixTest##MATRIX_TYPE, gko::test::ValueIndexTypes);    \
                                                                               \
-    TYPED_TEST(IsSymmetric##MATRIX_TYPE, ReturnsTrueOnSymmetric)              \
+    TYPED_TEST(MatrixTest##MATRIX_TYPE, ReturnsTrueOnSymmetric)               \
     {                                                                         \
         ASSERT_EQ(gko::validate::is_symmetric(this->mtx.get(), 1e-32), true); \
     }                                                                         \
                                                                               \
-    TYPED_TEST(IsSymmetric##MATRIX_TYPE, ReturnsFalseOnAsymmetric)            \
+    TYPED_TEST(MatrixTest##MATRIX_TYPE, ReturnsFalseOnAsymmetric)             \
     {                                                                         \
         auto asym_mtx = this->mtx->clone();                                   \
         asym_mtx->get_values()[2] = 0;                                        \
         ASSERT_EQ(gko::validate::is_symmetric(asym_mtx.get(), 1e-32), false); \
+    }                                                                         \
+                                                                              \
+    TYPED_TEST(MatrixTest##MATRIX_TYPE, ReturnsTrueOnNonZeroDiagonal)         \
+    {                                                                         \
+        auto asym_mtx = this->mtx->clone();                                   \
+        ASSERT_EQ(gko::validate::has_non_zero_diagonal(this->mtx.get()),      \
+                  true);                                                      \
+    }                                                                         \
+    TYPED_TEST(MatrixTest##MATRIX_TYPE, ReturnsFalseOnZeroDiagonal)           \
+    {                                                                         \
+        auto asym_mtx = this->mtx->clone();                                   \
+        asym_mtx->get_values()[0] = 0;                                        \
+        ASSERT_EQ(gko::validate::has_non_zero_diagonal(asym_mtx.get()),       \
+                  false);                                                     \
     }
 
 GKO_TYPED_TEST_SUITE_FOR_MATRIX_TYPE(Coo)

--- a/core/test/components/validation_helpers.cpp
+++ b/core/test/components/validation_helpers.cpp
@@ -138,6 +138,8 @@ protected:
     std::shared_ptr<const gko::Executor> exec;
 };
 
+// IndexType Tests
+
 TYPED_TEST_SUITE(IndexTypeTest, gko::test::IndexTypes);
 
 TYPED_TEST(IndexTypeTest, IsRowOrderedReturnsFalseOnUnordered)
@@ -158,6 +160,35 @@ TYPED_TEST(IndexTypeTest, IsRowOrderedeturnsTrueOnOrdered)
         gko::validate::is_row_ordered(a.get_const_data(), a.get_num_elems()),
         false);
 }
+
+TYPED_TEST(IndexTypeTest, IsWithinBoundsReturnsTrueBounded)
+{
+    gko::Array<TypeParam> a{this->exec, {3, 2, 1}};
+
+    ASSERT_EQ(gko::validate::is_within_bounds<TypeParam>(
+                  a.get_const_data(), a.get_num_elems(), 0, 4),
+              true);
+}
+
+TYPED_TEST(IndexTypeTest, IsWithinBoundsReturnsFalseLowerBound)
+{
+    gko::Array<TypeParam> a{this->exec, {3, 2, 1}};
+
+    ASSERT_EQ(gko::validate::is_within_bounds<TypeParam>(
+                  a.get_const_data(), a.get_num_elems(), 2, 4),
+              false);
+}
+
+TYPED_TEST(IndexTypeTest, IsWithinBoundsReturnsFalseUpperBound)
+{
+    gko::Array<TypeParam> a{this->exec, {3, 2, 1}};
+
+    ASSERT_EQ(gko::validate::is_within_bounds<TypeParam>(
+                  a.get_const_data(), a.get_num_elems(), 0, 3),
+              false);
+}
+
+// ValueType Tests
 
 template <typename T>
 class ValueTypeTest : public ::testing::Test {

--- a/core/test/components/validation_helpers.cpp
+++ b/core/test/components/validation_helpers.cpp
@@ -34,6 +34,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <ginkgo/core/base/array.hpp>
 #include <ginkgo/core/base/executor.hpp>
 #include <ginkgo/core/matrix/coo.hpp>
+#include <ginkgo/core/matrix/csr.hpp>
 
 #include "core/components/validation_helpers.hpp"
 #include "core/test/utils.hpp"
@@ -55,6 +56,7 @@ using RealValueTypes =
 
 namespace {
 
+/* clang-format off */
 #define GKO_DEFINE_ISSYMMETRIC(MATRIX_TYPE)                                   \
     template <typename ValueIndexType>                                        \
     class MatrixTest##MATRIX_TYPE : public ::testing::Test {                  \
@@ -63,52 +65,82 @@ namespace {
             typename std::tuple_element<0, decltype(ValueIndexType())>::type; \
         using index_type =                                                    \
             typename std::tuple_element<1, decltype(ValueIndexType())>::type; \
-        using Mtx = gko::matrix::Coo<value_type, index_type>;                 \
+        using Mtx = gko::matrix::MATRIX_TYPE<value_type, index_type>;         \
                                                                               \
         MatrixTest##MATRIX_TYPE()                                             \
             : exec(gko::ReferenceExecutor::create()),                         \
-              mtx(gko::matrix::Coo<value_type, index_type>::create(           \
-                  exec, gko::dim<2>{3, 3}, 9))                                \
+            sym_mtx(                                                          \
+                gko::matrix::MATRIX_TYPE<value_type, index_type>::create(     \
+                  exec, gko::dim<2>{3, 3}, 7)),                               \
+            l_triangular_mtx(                                                 \
+                gko::matrix::MATRIX_TYPE<value_type, index_type>::create(     \
+                  exec, gko::dim<2>{3, 3}, 5)),                                \
+            u_triangular_mtx(                                                 \
+                gko::matrix::MATRIX_TYPE<value_type, index_type>::create(     \
+                  exec, gko::dim<2>{3, 3}, 5))                                \
         {                                                                     \
-            value_type *v = mtx->get_values();                                \
                                                                               \
-            index_type *c = mtx->get_col_idxs();                              \
-            index_type *r = mtx->get_row_idxs();                              \
+            auto coo_sym_mtx(                                                 \
+                gko::matrix::Coo<value_type, index_type>::create(             \
+                  exec, gko::dim<2>{3, 3}, 7));                               \
                                                                               \
+            value_type *v = coo_sym_mtx->get_values();                        \
+            index_type *c = coo_sym_mtx->get_col_idxs();                      \
+            index_type *r = coo_sym_mtx->get_row_idxs();                      \
+            /* set values of symmetric matrix */                              \
+            r[0] = 0; r[1] = 0;                                               \
+            r[2] = 1; r[3] = 1; r[4] = 1;                                     \
+                      r[5] = 2; r[6] = 2;                                     \
+                                                                              \
+            c[0] = 0; c[1] = 1;                                               \
+            c[2] = 0; c[3] = 1; c[4] = 2;                                     \
+                      c[5] = 1; c[6] = 2;                                     \
+                                                                              \
+            v[0] = 1; v[1] = 2;                                               \
+            v[2] = 2; v[3] = 1; v[4] = 4;                                     \
+                      v[5] = 4; v[6] = 1;                                     \
+                                                                              \
+            coo_sym_mtx->convert_to(sym_mtx.get());                           \
+                                                                              \
+            auto coo_triangular_mtx(                                          \
+                gko::matrix::Coo<value_type, index_type>::create(             \
+                  exec, gko::dim<2>{3, 3}, 5));                               \
+                                                                              \
+            v = coo_triangular_mtx->get_values();                             \
+            c = coo_triangular_mtx->get_col_idxs();                           \
+            r = coo_triangular_mtx->get_row_idxs();                           \
+            /* set values of lower triangular matrix */                       \
             r[0] = 0;                                                         \
-            r[3] = 1;                                                         \
-            r[6] = 2;                                                         \
-            r[1] = 0;                                                         \
-            r[4] = 1;                                                         \
-            r[7] = 2;                                                         \
-            r[2] = 0;                                                         \
-            r[5] = 1;                                                         \
-            r[8] = 2;                                                         \
+            r[1] = 1; r[2] = 1;                                               \
+                      r[3] = 2; r[4] = 2;                                     \
                                                                               \
             c[0] = 0;                                                         \
-            c[3] = 0;                                                         \
-            c[6] = 0;                                                         \
-            c[1] = 1;                                                         \
-            c[4] = 1;                                                         \
-            c[7] = 1;                                                         \
-            c[2] = 2;                                                         \
-            c[5] = 2;                                                         \
-            c[8] = 2;                                                         \
+            c[1] = 0; c[2] = 1;                                               \
+                      c[3] = 1; c[4] = 2;                                     \
                                                                               \
             v[0] = 1;                                                         \
-            v[3] = 2;                                                         \
-            v[6] = 3;                                                         \
-            v[1] = 2;                                                         \
-            v[4] = 1;                                                         \
-            v[7] = 4;                                                         \
-            v[2] = 3;                                                         \
-            v[5] = 4;                                                         \
-            v[8] = 1;                                                         \
+            v[1] = 2; v[2] = 1;                                               \
+                      v[3] = 4; v[4] = 1;                                     \
+                                                                              \
+            coo_triangular_mtx->convert_to(l_triangular_mtx.get());           \
+            /* set values of upper triangular matrix */                       \
+            c[0] = 0;                                                         \
+            c[1] = 1; c[2] = 1;                                               \
+                      c[3] = 2; c[4] = 2;                                     \
+                                                                              \
+            r[0] = 0;                                                         \
+            r[1] = 0; r[2] = 1;                                               \
+                      r[3] = 1; r[4] = 2;                                     \
+                                                                              \
+            coo_triangular_mtx->convert_to(u_triangular_mtx.get());           \
         }                                                                     \
                                                                               \
         std::shared_ptr<const gko::Executor> exec;                            \
-        std::unique_ptr<Mtx> mtx;                                             \
+        std::unique_ptr<Mtx> sym_mtx;                                         \
+        std::unique_ptr<Mtx> l_triangular_mtx;                                \
+        std::unique_ptr<Mtx> u_triangular_mtx;                                \
     }
+/* clang-format on */
 
 #define GKO_TYPED_TEST_SUITE_FOR_MATRIX_TYPE(MATRIX_TYPE)                     \
     GKO_DEFINE_ISSYMMETRIC(MATRIX_TYPE);                                      \
@@ -117,33 +149,51 @@ namespace {
                                                                               \
     TYPED_TEST(MatrixTest##MATRIX_TYPE, ReturnsTrueOnSymmetric)               \
     {                                                                         \
-        ASSERT_EQ(gko::validate::is_symmetric(this->mtx.get(), 1e-32), true); \
+        ASSERT_EQ(gko::validate::is_symmetric(this->sym_mtx.get(), 1e-32),    \
+                  true);                                                      \
     }                                                                         \
                                                                               \
     TYPED_TEST(MatrixTest##MATRIX_TYPE, ReturnsFalseOnAsymmetric)             \
     {                                                                         \
-        auto asym_mtx = this->mtx->clone();                                   \
+        auto asym_mtx = this->sym_mtx->clone();                               \
         asym_mtx->get_values()[2] = 0;                                        \
         ASSERT_EQ(gko::validate::is_symmetric(asym_mtx.get(), 1e-32), false); \
     }                                                                         \
                                                                               \
     TYPED_TEST(MatrixTest##MATRIX_TYPE, ReturnsTrueOnNonZeroDiagonal)         \
     {                                                                         \
-        auto asym_mtx = this->mtx->clone();                                   \
-        ASSERT_EQ(gko::validate::has_non_zero_diagonal(this->mtx.get()),      \
+        auto asym_mtx = this->sym_mtx->clone();                               \
+        ASSERT_EQ(gko::validate::has_non_zero_diagonal(this->sym_mtx.get()),  \
                   true);                                                      \
     }                                                                         \
     TYPED_TEST(MatrixTest##MATRIX_TYPE, ReturnsFalseOnZeroDiagonal)           \
     {                                                                         \
-        auto asym_mtx = this->mtx->clone();                                   \
+        auto asym_mtx = this->sym_mtx->clone();                               \
         asym_mtx->get_values()[0] = 0;                                        \
         ASSERT_EQ(gko::validate::has_non_zero_diagonal(asym_mtx.get()),       \
                   false);                                                     \
+    }                                                                         \
+    TYPED_TEST(MatrixTest##MATRIX_TYPE, ReturnsTrueOnCorrectTriangular)       \
+    {                                                                         \
+        ASSERT_EQ(                                                            \
+            gko::validate::is_lower_triangular(this->l_triangular_mtx.get()), \
+            true);                                                            \
+        ASSERT_EQ(                                                            \
+            gko::validate::is_upper_triangular(this->u_triangular_mtx.get()), \
+            true);                                                            \
+    }                                                                         \
+    TYPED_TEST(MatrixTest##MATRIX_TYPE, ReturnsFalesOnFalseTriangular)        \
+    {                                                                         \
+        ASSERT_EQ(                                                            \
+            gko::validate::is_lower_triangular(this->u_triangular_mtx.get()), \
+            false);                                                           \
+        ASSERT_EQ(                                                            \
+            gko::validate::is_upper_triangular(this->l_triangular_mtx.get()), \
+            false);                                                           \
     }
 
 GKO_TYPED_TEST_SUITE_FOR_MATRIX_TYPE(Coo)
 GKO_TYPED_TEST_SUITE_FOR_MATRIX_TYPE(Csr)
-GKO_TYPED_TEST_SUITE_FOR_MATRIX_TYPE(Ell)
 
 template <typename T>
 class IndexTypeTest : public ::testing::Test {

--- a/core/test/components/validation_helpers.cpp
+++ b/core/test/components/validation_helpers.cpp
@@ -117,16 +117,16 @@ GKO_TYPED_TEST_SUITE_FOR_MATRIX_TYPE(Csr)
 GKO_TYPED_TEST_SUITE_FOR_MATRIX_TYPE(Ell)
 
 template <typename T>
-class IsRowOrdered : public ::testing::Test {
+class IndexTypeTest : public ::testing::Test {
 protected:
-    IsRowOrdered() : exec(gko::ReferenceExecutor::create()) {}
+    IndexTypeTest() : exec(gko::ReferenceExecutor::create()) {}
 
     std::shared_ptr<const gko::Executor> exec;
 };
 
-TYPED_TEST_SUITE(IsRowOrdered, gko::test::IndexTypes);
+TYPED_TEST_SUITE(IndexTypeTest, gko::test::IndexTypes);
 
-TYPED_TEST(IsRowOrdered, ReturnsFalseOnUnordered)
+TYPED_TEST(IndexTypeTest, IsRowOrderedReturnsFalseOnUnordered)
 {
     gko::Array<TypeParam> a{this->exec, {1, 2, 3}};
 
@@ -136,7 +136,7 @@ TYPED_TEST(IsRowOrdered, ReturnsFalseOnUnordered)
 }
 
 
-TYPED_TEST(IsRowOrdered, ReturnsTrueOnOrdered)
+TYPED_TEST(IndexTypeTest, IsRowOrderedeturnsTrueOnOrdered)
 {
     gko::Array<TypeParam> a{this->exec, {3, 2, 1}};
 
@@ -144,4 +144,23 @@ TYPED_TEST(IsRowOrdered, ReturnsTrueOnOrdered)
         gko::validate::is_row_ordered(a.get_const_data(), a.get_num_elems()),
         false);
 }
+
+template <typename T>
+class ValueTypeTest : public ::testing::Test {
+protected:
+    ValueTypeTest() : exec(gko::ReferenceExecutor::create()) {}
+
+    std::shared_ptr<const gko::Executor> exec;
+};
+
+TYPED_TEST_SUITE(ValueTypeTest, gko::test::ValueTypes);
+
+TYPED_TEST(ValueTypeTest, IsFiniteReturnsFalseOnInf)
+{
+    gko::Array<TypeParam> a{this->exec, {0., 1., 1.0 / 0.0}};
+
+    ASSERT_EQ(gko::validate::is_finite(a.get_const_data(), a.get_num_elems()),
+              false);
+}
+
 }  // namespace

--- a/core/test/components/validation_helpers.cpp
+++ b/core/test/components/validation_helpers.cpp
@@ -166,8 +166,25 @@ TYPED_TEST(IndexTypeTest, IsRowOrderedReturnsFalseOnUnordered)
         true);
 }
 
+TYPED_TEST(IndexTypeTest, IsUniqueReturnsTrueOnUniqueIndices)
+{
+    gko::Array<TypeParam> a{this->exec, {1, 2, 3}};
 
-TYPED_TEST(IndexTypeTest, IsRowOrderedeturnsTrueOnOrdered)
+    ASSERT_EQ(
+        gko::validate::has_unique_idxs(a.get_const_data(), a.get_num_elems()),
+        true);
+}
+
+TYPED_TEST(IndexTypeTest, IsUniqueReturnsFalseOnNonUniqueIndices)
+{
+    gko::Array<TypeParam> a{this->exec, {1, 1, 3}};
+
+    ASSERT_EQ(
+        gko::validate::has_unique_idxs(a.get_const_data(), a.get_num_elems()),
+        false);
+}
+
+TYPED_TEST(IndexTypeTest, IsRowOrderedReturnsTrueOnOrdered)
 {
     gko::Array<TypeParam> a{this->exec, {3, 2, 1}};
 

--- a/core/test/components/validation_helpers.cpp
+++ b/core/test/components/validation_helpers.cpp
@@ -40,51 +40,81 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 namespace {
 
-template <typename ValueIndexType>
-class IsSymmetric : public ::testing::Test {
-protected:
-    using value_type =
-        typename std::tuple_element<0, decltype(ValueIndexType())>::type;
-    using index_type =
-        typename std::tuple_element<1, decltype(ValueIndexType())>::type;
-    using Mtx = gko::matrix::Coo<value_type, index_type>;
-
-    IsSymmetric()
-        : exec(gko::ReferenceExecutor::create()),
-          mtx(gko::matrix::Coo<value_type, index_type>::create(
-              exec, gko::dim<2>{3, 3}, 9))
-    {
-        value_type *v = mtx->get_values();
-        index_type *c = mtx->get_col_idxs();
-        index_type *r = mtx->get_row_idxs();
-
-        // clang-format off
-        r[0] = 0; r[3] = 1; r[6] = 2;
-        r[1] = 0; r[4] = 1; r[7] = 2;
-        r[2] = 0; r[5] = 1; r[8] = 2;
-
-        c[0] = 0; c[3] = 0; c[6] = 0;
-        c[1] = 1; c[4] = 1; c[7] = 1;
-        c[2] = 2; c[5] = 2; c[8] = 2;
-
-        v[0] = 1; v[3] = 2; v[6] = 3;
-        v[1] = 2; v[4] = 1; v[7] = 4;
-        v[2] = 3; v[5] = 4; v[8] = 1;
-        // clang-format on
+#define GKO_DEFINE_ISSYMMETRIC(MATRIX_TYPE)                                   \
+    template <typename ValueIndexType>                                        \
+    class IsSymmetric##MATRIX_TYPE : public ::testing::Test {                 \
+    protected:                                                                \
+        using value_type =                                                    \
+            typename std::tuple_element<0, decltype(ValueIndexType())>::type; \
+        using index_type =                                                    \
+            typename std::tuple_element<1, decltype(ValueIndexType())>::type; \
+        using Mtx = gko::matrix::Coo<value_type, index_type>;                 \
+                                                                              \
+        IsSymmetric##MATRIX_TYPE()                                            \
+            : exec(gko::ReferenceExecutor::create()),                         \
+              mtx(gko::matrix::Coo<value_type, index_type>::create(           \
+                  exec, gko::dim<2>{3, 3}, 9))                                \
+        {                                                                     \
+            value_type *v = mtx->get_values();                                \
+                                                                              \
+            index_type *c = mtx->get_col_idxs();                              \
+            index_type *r = mtx->get_row_idxs();                              \
+                                                                              \
+            r[0] = 0;                                                         \
+            r[3] = 1;                                                         \
+            r[6] = 2;                                                         \
+            r[1] = 0;                                                         \
+            r[4] = 1;                                                         \
+            r[7] = 2;                                                         \
+            r[2] = 0;                                                         \
+            r[5] = 1;                                                         \
+            r[8] = 2;                                                         \
+                                                                              \
+            c[0] = 0;                                                         \
+            c[3] = 0;                                                         \
+            c[6] = 0;                                                         \
+            c[1] = 1;                                                         \
+            c[4] = 1;                                                         \
+            c[7] = 1;                                                         \
+            c[2] = 2;                                                         \
+            c[5] = 2;                                                         \
+            c[8] = 2;                                                         \
+                                                                              \
+            v[0] = 1;                                                         \
+            v[3] = 2;                                                         \
+            v[6] = 3;                                                         \
+            v[1] = 2;                                                         \
+            v[4] = 1;                                                         \
+            v[7] = 4;                                                         \
+            v[2] = 3;                                                         \
+            v[5] = 4;                                                         \
+            v[8] = 1;                                                         \
+        }                                                                     \
+                                                                              \
+        std::shared_ptr<const gko::Executor> exec;                            \
+        std::unique_ptr<Mtx> mtx;                                             \
     }
 
-    std::shared_ptr<const gko::Executor> exec;
-    std::unique_ptr<Mtx> mtx;
-};
+#define GKO_TYPED_TEST_SUITE_FOR_MATRIX_TYPE(MATRIX_TYPE)                     \
+    GKO_DEFINE_ISSYMMETRIC(MATRIX_TYPE);                                      \
+                                                                              \
+    TYPED_TEST_SUITE(IsSymmetric##MATRIX_TYPE, gko::test::ValueIndexTypes);   \
+                                                                              \
+    TYPED_TEST(IsSymmetric##MATRIX_TYPE, ReturnsTrueOnSymmetric)              \
+    {                                                                         \
+        ASSERT_EQ(gko::validate::is_symmetric(this->mtx.get(), 1e-32), true); \
+    }                                                                         \
+                                                                              \
+    TYPED_TEST(IsSymmetric##MATRIX_TYPE, ReturnsFalseOnAsymmetric)            \
+    {                                                                         \
+        auto asym_mtx = this->mtx->clone();                                   \
+        asym_mtx->get_values()[2] = 0;                                        \
+        ASSERT_EQ(gko::validate::is_symmetric(asym_mtx.get(), 1e-32), false); \
+    }
 
-TYPED_TEST_SUITE(IsSymmetric, gko::test::ValueIndexTypes);
-
-// TODO expand to other matrix formats
-TYPED_TEST(IsSymmetric, ReturnsTrueOnSymmetric)
-{
-    ASSERT_EQ(gko::validate::is_symmetric(this->mtx.get(), 1e-32), true);
-}
-
+GKO_TYPED_TEST_SUITE_FOR_MATRIX_TYPE(Coo)
+GKO_TYPED_TEST_SUITE_FOR_MATRIX_TYPE(Csr)
+GKO_TYPED_TEST_SUITE_FOR_MATRIX_TYPE(Ell)
 
 template <typename T>
 class IsRowOrdered : public ::testing::Test {

--- a/core/test/components/validation_helpers.cpp
+++ b/core/test/components/validation_helpers.cpp
@@ -65,6 +65,6 @@ TYPED_TEST(IsRowOrdered, ReturnsTrueOnOrdered)
 
     ASSERT_EQ(
         gko::validate::is_row_ordered(a.get_const_data(), a.get_num_elems()),
-        true);
+        false);
 }
 }  // namespace

--- a/core/test/components/validation_helpers.cpp
+++ b/core/test/components/validation_helpers.cpp
@@ -30,34 +30,41 @@ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ******************************<GINKGO LICENSE>*******************************/
 
-#ifndef GKO_CORE_COMPONENTS_VALIDATION_HELPERS_HPP_
-#define GKO_CORE_COMponents_VALIDATION_HELPERS_HPP_
-
+#include <gtest/gtest.h>
 #include <ginkgo/core/base/array.hpp>
-#include <ginkgo/core/base/lin_op.hpp>
+#include <ginkgo/core/base/executor.hpp>
 
-namespace gko {
-namespace validate {
+#include "core/components/validation_helpers.hpp"
+#include "core/test/utils.hpp"
 
-/**
- * Tests whether a given matrix is symmetric
- *
- * @param A the input matrix which is tested
- */
-bool is_symmetric(const LinOp *A) { return false; }
+namespace {
 
-/**
- * Tests whether the given row_ptrs are in an ascending order
- *
- * @param row_ptrs the array which is to be tested
- */
-template <typename IndexType>
-bool is_row_ordered(const IndexType *row_ptrs, const size_type num_entries)
+template <typename T>
+class IsRowOrdered : public ::testing::Test {
+protected:
+    IsRowOrdered() : exec(gko::ReferenceExecutor::create()) {}
+
+    std::shared_ptr<const gko::Executor> exec;
+};
+
+TYPED_TEST_SUITE(IsRowOrdered, gko::test::IndexTypes);
+
+TYPED_TEST(IsRowOrdered, ReturnsFalseOnUnordered)
 {
-    return false;
+    gko::Array<TypeParam> a{this->exec, {1, 2, 3}};
+
+    ASSERT_EQ(
+        gko::validate::is_row_ordered(a.get_const_data(), a.get_num_elems()),
+        true);
 }
 
-}  // namespace validate
-}  // namespace gko
 
-#endif  // GKO_CORE_COMPONENTS_VALIDATION_HELPERS_HPP_
+TYPED_TEST(IsRowOrdered, ReturnsTrueOnOrdered)
+{
+    gko::Array<TypeParam> a{this->exec, {3, 2, 1}};
+
+    ASSERT_EQ(
+        gko::validate::is_row_ordered(a.get_const_data(), a.get_num_elems()),
+        true);
+}
+}  // namespace

--- a/core/test/components/validation_helpers.cpp
+++ b/core/test/components/validation_helpers.cpp
@@ -220,6 +220,23 @@ TYPED_TEST(IndexTypeTest, IsWithinBoundsReturnsFalseUpperBound)
               false);
 }
 
+TYPED_TEST(IndexTypeTest, IsConsecutiveReturnsTrueConsecutive)
+{
+    gko::Array<TypeParam> a{this->exec, {1, 3, 5}};
+
+    ASSERT_EQ(gko::validate::is_consecutive<TypeParam>(a.get_const_data(),
+                                                       a.get_num_elems(), 2),
+              true);
+}
+
+TYPED_TEST(IndexTypeTest, IsConsecutiveReturnsFalseNonConesecutive)
+{
+    gko::Array<TypeParam> a{this->exec, {1, 4, 8}};
+
+    ASSERT_EQ(gko::validate::is_consecutive<TypeParam>(a.get_const_data(),
+                                                       a.get_num_elems(), 2),
+              false);
+}
 // ValueType Tests
 
 template <typename T>
@@ -242,6 +259,7 @@ TYPED_TEST(RealValueTypeTest, IsFiniteReturnsFalseOnInf)
     ASSERT_EQ(gko::validate::is_finite(a.get_const_data(), a.get_num_elems()),
               false);
 }
+
 template <typename T>
 class ComplexValueTypeTest : public ::testing::Test {
 protected:

--- a/include/ginkgo/core/base/exception.hpp
+++ b/include/ginkgo/core/base/exception.hpp
@@ -148,6 +148,29 @@ public:
     {}
 };
 
+/**
+ * Invalid is thrown in case it a LinOp does not satisfy
+ * its set of constraints, eg. when the system matrix of
+ * the Cg solver is not symmetric.
+ */
+class Invalid : public Error {
+public:
+    /**
+     * Initializes an Invalid error.
+     *
+     * @param file  The name of the offending source file
+     * @param line  The source code line number where the error occurred
+     * @param func  The name of the function where the error occured
+     * @param obj_type  The object type on which the requested operation
+                       cannot be performed.
+     */
+    Invalid(const std::string &file, int line, const std::string &lin_op,
+            const std::string &constraint)
+        : Error(file, line,
+                "LinOp " + lin_op + " is not valid, the " + constraint +
+                    " constraint is not satisfied.")
+    {}
+};
 
 /**
  * NotSupported is thrown in case it is not possible to

--- a/include/ginkgo/core/base/lin_op.hpp
+++ b/include/ginkgo/core/base/lin_op.hpp
@@ -318,6 +318,8 @@ protected:
         GKO_ASSERT_EQUAL_DIMENSIONS(beta, dim<2>(1, 1));
     }
 
+    // TODO copy data to host
+    // TODO check if in debug mode
     void validate() const
     {
         if (true) validate_impl();

--- a/include/ginkgo/core/base/lin_op.hpp
+++ b/include/ginkgo/core/base/lin_op.hpp
@@ -158,6 +158,7 @@ public:
     {
         this->template log<log::Logger::linop_apply_started>(this, b, x);
         this->validate_application_parameters(b, x);
+        this->validate();
         auto exec = this->get_executor();
         this->apply_impl(make_temporary_clone(exec, b).get(),
                          make_temporary_clone(exec, x).get());
@@ -172,6 +173,7 @@ public:
     {
         this->template log<log::Logger::linop_apply_started>(this, b, x);
         this->validate_application_parameters(b, x);
+        this->validate();
         auto exec = this->get_executor();
         this->apply_impl(make_temporary_clone(exec, b).get(),
                          make_temporary_clone(exec, x).get());
@@ -195,6 +197,7 @@ public:
         this->template log<log::Logger::linop_advanced_apply_started>(
             this, alpha, b, beta, x);
         this->validate_application_parameters(alpha, b, beta, x);
+        this->validate();
         auto exec = this->get_executor();
         this->apply_impl(make_temporary_clone(exec, alpha).get(),
                          make_temporary_clone(exec, b).get(),
@@ -214,6 +217,7 @@ public:
         this->template log<log::Logger::linop_advanced_apply_started>(
             this, alpha, b, beta, x);
         this->validate_application_parameters(alpha, b, beta, x);
+        this->validate();
         auto exec = this->get_executor();
         this->apply_impl(make_temporary_clone(exec, alpha).get(),
                          make_temporary_clone(exec, b).get(),
@@ -313,6 +317,14 @@ protected:
         GKO_ASSERT_EQUAL_DIMENSIONS(alpha, dim<2>(1, 1));
         GKO_ASSERT_EQUAL_DIMENSIONS(beta, dim<2>(1, 1));
     }
+
+    void validate() const
+    {
+        if (true) validate_impl();
+
+    };  // const = 0;
+
+    virtual void validate_impl() const {};  // const = 0;
 
 private:
     dim<2> size_{};
@@ -1021,7 +1033,7 @@ public:                                                                      \
     mutable _name{__VA_ARGS__};                                              \
                                                                              \
     template <typename... Args>                                              \
-    auto with_##_name(Args &&... _value)                                     \
+    auto with_##_name(Args &&..._value)                                      \
         const->const std::decay_t<decltype(*this)> &                         \
     {                                                                        \
         using type = decltype(this->_name);                                  \
@@ -1072,7 +1084,7 @@ public:                                                                      \
     mutable _name{__VA_ARGS__};                                              \
                                                                              \
     template <typename... Args>                                              \
-    auto with_##_name(Args &&... _value)                                     \
+    auto with_##_name(Args &&..._value)                                      \
         const->const std::decay_t<decltype(*this)> &                         \
     {                                                                        \
         GKO_NOT_IMPLEMENTED;                                                 \
@@ -1101,7 +1113,7 @@ public:                                                                      \
     mutable _name{__VA_ARGS__};                                              \
                                                                              \
     template <typename... Args>                                              \
-    auto with_##_name(Args &&... _value)                                     \
+    auto with_##_name(Args &&..._value)                                      \
         const->const std::decay_t<decltype(*this)> &                         \
     {                                                                        \
         using type = decltype(this->_name);                                  \

--- a/include/ginkgo/core/base/types.hpp
+++ b/include/ginkgo/core/base/types.hpp
@@ -415,6 +415,68 @@ GKO_ATTRIBUTES constexpr bool operator!=(precision_reduction x,
     _enable_macro(DpcppExecutor, dpcpp);            \
     _enable_macro(CudaExecutor, cuda)
 
+/**
+ * This helper macro handles consistent expansion of __VA_ARGS__ for MSVC and
+ * other compilers.
+ *
+ * Consider the following example given on https://bit.ly/3wp8PqT
+ *
+ * #define MACRO_WITH_3_PARAMS(p1, p2, p3) P1 = p1 | P2 = p2 | P3 = p3
+ * #define MACRO_VA_ARGS(...) MACRO_WITH_3_PARAMS( __VA_ARGS__)
+ * MACRO_VA_ARGS(foo, bar, baz)
+ *
+ * On MSVC this is expanded into
+ * P1 = foo, bar, baz | P2 =  | P3 =
+ *
+ * In order to expand the macro consitently PASS_ON can be applied
+ * #define MACRO_VA_ARGS(...) PASS_ON(PASS_ON(MACRO_WITH_3_PARAMS)(
+ * __VA_ARGS__))
+ */
+#define PASS_ON(...) __VA_ARGS__
+
+/**
+ * Calls a macro with variable number of arguments.
+ *
+ * The macro uses PASS_ON to expand __VA_ARGS__. This is needed to have
+ * consistent behaviour among MSVC and other compilers.
+ *
+ * @param _macro  The macro which is to be expanded.
+ */
+#define GKO_APPLY_MACRO(_macro, ...) PASS_ON(PASS_ON(_macro)(__VA_ARGS__))
+
+/**
+ * Expands a macro for each  non_complex value and index type compiled by
+ * Ginkgo.
+ *
+ * @param _macro  A macro which expands the template instantiation
+ *                (not including the leading `template` specifier).
+ *                Should take two arguments, which are replaced by the
+ *                value and index types.
+ * @param ...     Optional parameters which are passed to _macro
+ * @param ...     Optional parameters which are passed to _macro
+ */
+#define GKO_CALL_FOR_EACH_NON_COMPLEX_VALUE_AND_INDEX_TYPE(_macro, ...) \
+    GKO_APPLY_MACRO(_macro, float, int32, ##__VA_ARGS__);               \
+    GKO_APPLY_MACRO(_macro, double, int32, ##__VA_ARGS__);              \
+    GKO_APPLY_MACRO(_macro, float, int64, ##__VA_ARGS__);               \
+    GKO_APPLY_MACRO(_macro, double, int64, ##__VA_ARGS__)
+
+
+/**
+ * Expands a macro for each value and index type compiled by Ginkgo.
+ *
+ * @param _macro  A macro which expands the template instantiation
+ *                (not including the leading `template` specifier).
+ *                Should take two arguments, which are replaced by the
+ *                value and index types.
+ * @param ...     Optional parameters which are passed to _macro
+ */
+#define GKO_CALL_FOR_EACH_VALUE_AND_INDEX_TYPE(_macro, ...)                    \
+    GKO_CALL_FOR_EACH_NON_COMPLEX_VALUE_AND_INDEX_TYPE(_macro, ##__VA_ARGS__); \
+    GKO_APPLY_MACRO(_macro, std::complex<float>, int32, ##__VA_ARGS__);        \
+    GKO_APPLY_MACRO(_macro, std::complex<float>, int64, ##__VA_ARGS__);        \
+    GKO_APPLY_MACRO(_macro, std::complex<double>, int32, ##__VA_ARGS__);       \
+    GKO_APPLY_MACRO(_macro, std::complex<double>, int64, ##__VA_ARGS__)
 
 /**
  * Instantiates a template for each non-complex value type compiled by Ginkgo.
@@ -490,10 +552,7 @@ GKO_ATTRIBUTES constexpr bool operator!=(precision_reduction x,
     _macro(double, int64) GKO_NOT_IMPLEMENTED
 #else
 #define GKO_INSTANTIATE_FOR_EACH_NON_COMPLEX_VALUE_AND_INDEX_TYPE(_macro) \
-    template _macro(float, int32);                                        \
-    template _macro(double, int32);                                       \
-    template _macro(float, int64);                                        \
-    template _macro(double, int64)
+    GKO_CALL_FOR_EACH_NON_COMPLEX_VALUE_AND_INDEX_TYPE(template _macro)
 #endif
 
 
@@ -515,12 +574,8 @@ GKO_ATTRIBUTES constexpr bool operator!=(precision_reduction x,
     template <>                                                        \
     _macro(std::complex<double>, int64) GKO_NOT_IMPLEMENTED
 #else
-#define GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(_macro)          \
-    GKO_INSTANTIATE_FOR_EACH_NON_COMPLEX_VALUE_AND_INDEX_TYPE(_macro); \
-    template _macro(std::complex<float>, int32);                       \
-    template _macro(std::complex<double>, int32);                      \
-    template _macro(std::complex<float>, int64);                       \
-    template _macro(std::complex<double>, int64)
+#define GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(_macro) \
+    GKO_CALL_FOR_EACH_VALUE_AND_INDEX_TYPE(template _macro)
 #endif
 
 
@@ -567,6 +622,5 @@ GKO_ATTRIBUTES constexpr bool operator!=(precision_reduction x,
 
 
 }  // namespace gko
-
 
 #endif  // GKO_PUBLIC_CORE_BASE_TYPES_HPP_

--- a/include/ginkgo/core/factorization/ic.hpp
+++ b/include/ginkgo/core/factorization/ic.hpp
@@ -109,8 +109,14 @@ public:
                             : l_factor_is_finite;
              }},
             {"has_non_zero_diagonal", [this] {
-                 return ::gko::validate::has_non_zero_diagonal(
-                     get_l_factor().get());
+                 bool l_factor_has_non_zero_diagonal =
+                     ::gko::validate::has_non_zero_diagonal(
+                         get_l_factor().get());
+                 return this->parameters_.both_factors
+                            ? ::gko::validate::has_non_zero_diagonal(
+                                  get_lt_factor().get()) &&
+                                  l_factor_has_non_zero_diagonal
+                            : l_factor_has_non_zero_diagonal;
              }}};
 
         for (auto const &x : constraints_map) {

--- a/include/ginkgo/core/factorization/ic.hpp
+++ b/include/ginkgo/core/factorization/ic.hpp
@@ -100,7 +100,13 @@ public:
         std::map<std::string, std::function<bool()>> constraints_map{
             {"is_finite",
              [this] {
-                 return ::gko::validate::is_finite(get_l_factor().get());
+                 bool l_factor_is_finite =
+                     ::gko::validate::is_finite(get_l_factor().get());
+                 return this->parameters_.both_factors
+                            ? ::gko::validate::is_finite(
+                                  get_lt_factor().get()) &&
+                                  l_factor_is_finite
+                            : l_factor_is_finite;
              }},
             {"has_non_zero_diagonal", [this] {
                  return ::gko::validate::has_non_zero_diagonal(

--- a/include/ginkgo/core/factorization/ic.hpp
+++ b/include/ginkgo/core/factorization/ic.hpp
@@ -109,7 +109,7 @@ public:
 
         for (auto const &x : constraints_map) {
             if (!x.second()) {
-                throw gko::Invalid(__FILE__, __LINE__, "Sellp", x.first);
+                throw gko::Invalid(__FILE__, __LINE__, "Ic", x.first);
             };
         }
     };

--- a/include/ginkgo/core/factorization/ic.hpp
+++ b/include/ginkgo/core/factorization/ic.hpp
@@ -34,7 +34,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define GKO_PUBLIC_CORE_FACTORIZATION_IC_HPP_
 
 
-#include <map>
 #include <memory>
 
 
@@ -43,7 +42,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <ginkgo/core/base/types.hpp>
 #include <ginkgo/core/matrix/csr.hpp>
 
-#include "core/components/validation_helpers.hpp"
 
 namespace gko {
 /**
@@ -95,41 +93,12 @@ public:
         }
     }
 
-    void validate_impl() const
-    {
-        std::map<std::string, std::function<bool()>> constraints_map{
-            {"is_finite",
-             [this] {
-                 bool l_factor_is_finite =
-                     ::gko::validate::is_finite(get_l_factor().get());
-                 return this->parameters_.both_factors
-                            ? ::gko::validate::is_finite(
-                                  get_lt_factor().get()) &&
-                                  l_factor_is_finite
-                            : l_factor_is_finite;
-             }},
-            {"has_non_zero_diagonal", [this] {
-                 bool l_factor_has_non_zero_diagonal =
-                     ::gko::validate::has_non_zero_diagonal(
-                         get_l_factor().get());
-                 return this->parameters_.both_factors
-                            ? ::gko::validate::has_non_zero_diagonal(
-                                  get_lt_factor().get()) &&
-                                  l_factor_has_non_zero_diagonal
-                            : l_factor_has_non_zero_diagonal;
-             }}};
-
-        for (auto const &x : constraints_map) {
-            if (!x.second()) {
-                throw gko::Invalid(__FILE__, __LINE__, "Ic", x.first);
-            };
-        }
-    };
+    void validate_impl() const override;
 
     // Remove the possibility of calling `create`, which was enabled by
     // `Composition`
     template <typename... Args>
-    static std::unique_ptr<Composition<ValueType>> create(Args &&...args) =
+    static std::unique_ptr<Composition<ValueType>> create(Args &&... args) =
         delete;
 
     GKO_CREATE_FACTORY_PARAMETERS(parameters, Factory)

--- a/include/ginkgo/core/factorization/ilu.hpp
+++ b/include/ginkgo/core/factorization/ilu.hpp
@@ -34,6 +34,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define GKO_PUBLIC_CORE_FACTORIZATION_ILU_HPP_
 
 
+#include <map>
 #include <memory>
 
 
@@ -42,6 +43,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <ginkgo/core/base/types.hpp>
 #include <ginkgo/core/matrix/csr.hpp>
 
+#include "core/components/validation_helpers.hpp"
 
 namespace gko {
 /**
@@ -88,10 +90,33 @@ public:
             this->get_operators()[1]);
     }
 
+    void validate_impl() const
+    {
+        std::map<std::string, std::function<bool()>> constraints_map{
+            {"l_factor_is_finite",
+             [this] {
+                 return ::gko::validate::is_finite(get_l_factor().get());
+             }},
+            {"u_factor_is_finite",
+             [this] {
+                 return ::gko::validate::is_finite(get_u_factor().get());
+             }},
+            {"has_non_zero_diagonal", [this] {
+                 return ::gko::validate::has_non_zero_diagonal(
+                     get_l_factor().get());
+             }}};
+
+        for (auto const &x : constraints_map) {
+            if (!x.second()) {
+                throw gko::Invalid(__FILE__, __LINE__, "Ilu", x.first);
+            };
+        }
+    };
+
     // Remove the possibility of calling `create`, which was enabled by
     // `Composition`
     template <typename... Args>
-    static std::unique_ptr<Composition<ValueType>> create(Args &&... args) =
+    static std::unique_ptr<Composition<ValueType>> create(Args &&...args) =
         delete;
 
     GKO_CREATE_FACTORY_PARAMETERS(parameters, Factory)

--- a/include/ginkgo/core/factorization/ilu.hpp
+++ b/include/ginkgo/core/factorization/ilu.hpp
@@ -34,7 +34,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define GKO_PUBLIC_CORE_FACTORIZATION_ILU_HPP_
 
 
-#include <map>
 #include <memory>
 
 
@@ -43,7 +42,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <ginkgo/core/base/types.hpp>
 #include <ginkgo/core/matrix/csr.hpp>
 
-#include "core/components/validation_helpers.hpp"
 
 namespace gko {
 /**
@@ -90,33 +88,12 @@ public:
             this->get_operators()[1]);
     }
 
-    void validate_impl() const
-    {
-        std::map<std::string, std::function<bool()>> constraints_map{
-            {"l_factor_is_finite",
-             [this] {
-                 return ::gko::validate::is_finite(get_l_factor().get());
-             }},
-            {"u_factor_is_finite",
-             [this] {
-                 return ::gko::validate::is_finite(get_u_factor().get());
-             }},
-            {"has_non_zero_diagonal", [this] {
-                 return ::gko::validate::has_non_zero_diagonal(
-                     get_l_factor().get());
-             }}};
-
-        for (auto const &x : constraints_map) {
-            if (!x.second()) {
-                throw gko::Invalid(__FILE__, __LINE__, "Ilu", x.first);
-            };
-        }
-    };
+    void validate_impl() const override;
 
     // Remove the possibility of calling `create`, which was enabled by
     // `Composition`
     template <typename... Args>
-    static std::unique_ptr<Composition<ValueType>> create(Args &&...args) =
+    static std::unique_ptr<Composition<ValueType>> create(Args &&... args) =
         delete;
 
     GKO_CREATE_FACTORY_PARAMETERS(parameters, Factory)

--- a/include/ginkgo/core/factorization/par_ic.hpp
+++ b/include/ginkgo/core/factorization/par_ic.hpp
@@ -34,6 +34,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define GKO_PUBLIC_CORE_FACTORIZATION_PAR_IC_HPP_
 
 
+#include <map>
 #include <memory>
 
 
@@ -42,6 +43,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <ginkgo/core/base/types.hpp>
 #include <ginkgo/core/matrix/csr.hpp>
 
+#include "core/components/validation_helpers.hpp"
 
 namespace gko {
 /**
@@ -118,10 +120,30 @@ public:
         }
     }
 
+    std::map<std::string, std::function<bool()>> constraints_map{
+        {"is_finite",
+         [this] {
+             bool l_factor_is_finite =
+                 ::gko::validate::is_finite(get_l_factor().get());
+             return this->parameters_.both_factors
+                        ? ::gko::validate::is_finite(get_lt_factor().get()) &&
+                              l_factor_is_finite
+                        : l_factor_is_finite;
+         }},
+        {"has_non_zero_diagonal", [this] {
+             bool l_factor_has_non_zero_diagonal =
+                 ::gko::validate::has_non_zero_diagonal(get_l_factor().get());
+             return this->parameters_.both_factors
+                        ? ::gko::validate::has_non_zero_diagonal(
+                              get_lt_factor().get()) &&
+                              l_factor_has_non_zero_diagonal
+                        : l_factor_has_non_zero_diagonal;
+         }}};
+
     // Remove the possibility of calling `create`, which was enabled by
     // `Composition`
     template <typename... Args>
-    static std::unique_ptr<Composition<ValueType>> create(Args &&... args) =
+    static std::unique_ptr<Composition<ValueType>> create(Args &&...args) =
         delete;
 
     GKO_CREATE_FACTORY_PARAMETERS(parameters, Factory)

--- a/include/ginkgo/core/factorization/par_ic.hpp
+++ b/include/ginkgo/core/factorization/par_ic.hpp
@@ -34,7 +34,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define GKO_PUBLIC_CORE_FACTORIZATION_PAR_IC_HPP_
 
 
-#include <map>
 #include <memory>
 
 
@@ -43,7 +42,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <ginkgo/core/base/types.hpp>
 #include <ginkgo/core/matrix/csr.hpp>
 
-#include "core/components/validation_helpers.hpp"
 
 namespace gko {
 /**
@@ -120,30 +118,12 @@ public:
         }
     }
 
-    std::map<std::string, std::function<bool()>> constraints_map{
-        {"is_finite",
-         [this] {
-             bool l_factor_is_finite =
-                 ::gko::validate::is_finite(get_l_factor().get());
-             return this->parameters_.both_factors
-                        ? ::gko::validate::is_finite(get_lt_factor().get()) &&
-                              l_factor_is_finite
-                        : l_factor_is_finite;
-         }},
-        {"has_non_zero_diagonal", [this] {
-             bool l_factor_has_non_zero_diagonal =
-                 ::gko::validate::has_non_zero_diagonal(get_l_factor().get());
-             return this->parameters_.both_factors
-                        ? ::gko::validate::has_non_zero_diagonal(
-                              get_lt_factor().get()) &&
-                              l_factor_has_non_zero_diagonal
-                        : l_factor_has_non_zero_diagonal;
-         }}};
+    void validate_impl() const override;
 
     // Remove the possibility of calling `create`, which was enabled by
     // `Composition`
     template <typename... Args>
-    static std::unique_ptr<Composition<ValueType>> create(Args &&...args) =
+    static std::unique_ptr<Composition<ValueType>> create(Args &&... args) =
         delete;
 
     GKO_CREATE_FACTORY_PARAMETERS(parameters, Factory)

--- a/include/ginkgo/core/factorization/par_ict.hpp
+++ b/include/ginkgo/core/factorization/par_ict.hpp
@@ -113,6 +113,8 @@ public:
             this->get_operators()[1]);
     }
 
+    void validate_impl() const override;
+
     // Remove the possibility of calling `create`, which was enabled by
     // `Composition`
     template <typename... Args>

--- a/include/ginkgo/core/factorization/par_ilu.hpp
+++ b/include/ginkgo/core/factorization/par_ilu.hpp
@@ -34,6 +34,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define GKO_PUBLIC_CORE_FACTORIZATION_PAR_ILU_HPP_
 
 
+#include <map>
 #include <memory>
 
 
@@ -42,6 +43,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <ginkgo/core/base/types.hpp>
 #include <ginkgo/core/matrix/csr.hpp>
 
+#include "core/components/validation_helpers.hpp"
 
 namespace gko {
 /**
@@ -116,10 +118,33 @@ public:
             this->get_operators()[1]);
     }
 
+    void validate_impl() const
+    {
+        std::map<std::string, std::function<bool()>> constraints_map{
+            {"l_factor_is_finite",
+             [this] {
+                 return ::gko::validate::is_finite(get_l_factor().get());
+             }},
+            {"u_factor_is_finite",
+             [this] {
+                 return ::gko::validate::is_finite(get_u_factor().get());
+             }},
+            {"has_non_zero_diagonal", [this] {
+                 return ::gko::validate::has_non_zero_diagonal(
+                     get_l_factor().get());
+             }}};
+
+        for (auto const &x : constraints_map) {
+            if (!x.second()) {
+                throw gko::Invalid(__FILE__, __LINE__, "Ilu", x.first);
+            };
+        }
+    };
+
     // Remove the possibility of calling `create`, which was enabled by
     // `Composition`
     template <typename... Args>
-    static std::unique_ptr<Composition<ValueType>> create(Args &&... args) =
+    static std::unique_ptr<Composition<ValueType>> create(Args &&...args) =
         delete;
 
     GKO_CREATE_FACTORY_PARAMETERS(parameters, Factory)

--- a/include/ginkgo/core/factorization/par_ilu.hpp
+++ b/include/ginkgo/core/factorization/par_ilu.hpp
@@ -34,7 +34,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define GKO_PUBLIC_CORE_FACTORIZATION_PAR_ILU_HPP_
 
 
-#include <map>
 #include <memory>
 
 
@@ -43,7 +42,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <ginkgo/core/base/types.hpp>
 #include <ginkgo/core/matrix/csr.hpp>
 
-#include "core/components/validation_helpers.hpp"
 
 namespace gko {
 /**
@@ -118,33 +116,12 @@ public:
             this->get_operators()[1]);
     }
 
-    void validate_impl() const
-    {
-        std::map<std::string, std::function<bool()>> constraints_map{
-            {"l_factor_is_finite",
-             [this] {
-                 return ::gko::validate::is_finite(get_l_factor().get());
-             }},
-            {"u_factor_is_finite",
-             [this] {
-                 return ::gko::validate::is_finite(get_u_factor().get());
-             }},
-            {"has_non_zero_diagonal", [this] {
-                 return ::gko::validate::has_non_zero_diagonal(
-                     get_l_factor().get());
-             }}};
-
-        for (auto const &x : constraints_map) {
-            if (!x.second()) {
-                throw gko::Invalid(__FILE__, __LINE__, "Ilu", x.first);
-            };
-        }
-    };
+    void validate_impl() const override;
 
     // Remove the possibility of calling `create`, which was enabled by
     // `Composition`
     template <typename... Args>
-    static std::unique_ptr<Composition<ValueType>> create(Args &&...args) =
+    static std::unique_ptr<Composition<ValueType>> create(Args &&... args) =
         delete;
 
     GKO_CREATE_FACTORY_PARAMETERS(parameters, Factory)

--- a/include/ginkgo/core/factorization/par_ilut.hpp
+++ b/include/ginkgo/core/factorization/par_ilut.hpp
@@ -118,6 +118,8 @@ public:
             this->get_operators()[1]);
     }
 
+    void validate_impl() const override;
+
     // Remove the possibility of calling `create`, which was enabled by
     // `Composition`
     template <typename... Args>

--- a/include/ginkgo/core/matrix/coo.hpp
+++ b/include/ginkgo/core/matrix/coo.hpp
@@ -120,6 +120,8 @@ public:
 
     void write(mat_data &data) const override;
 
+    void validate_impl() const override;
+
     std::unique_ptr<Diagonal<ValueType>> extract_diagonal() const override;
 
     std::unique_ptr<absolute_type> compute_absolute() const override;

--- a/include/ginkgo/core/matrix/csr.hpp
+++ b/include/ginkgo/core/matrix/csr.hpp
@@ -691,6 +691,8 @@ public:
 
     void write(mat_data &data) const override;
 
+    void validate_impl() const override;
+
     std::unique_ptr<LinOp> transpose() const override;
 
     std::unique_ptr<LinOp> conj_transpose() const override;

--- a/include/ginkgo/core/matrix/dense.hpp
+++ b/include/ginkgo/core/matrix/dense.hpp
@@ -258,6 +258,8 @@ public:
 
     void write(mat_data32 &data) const override;
 
+    void validate_impl() const override;
+
     std::unique_ptr<LinOp> transpose() const override;
 
     std::unique_ptr<LinOp> conj_transpose() const override;

--- a/include/ginkgo/core/matrix/dense.hpp
+++ b/include/ginkgo/core/matrix/dense.hpp
@@ -818,7 +818,7 @@ private:
 template <typename Matrix, typename... TArgs>
 std::unique_ptr<Matrix> initialize(
     size_type stride, std::initializer_list<typename Matrix::value_type> vals,
-    std::shared_ptr<const Executor> exec, TArgs &&... create_args)
+    std::shared_ptr<const Executor> exec, TArgs &&...create_args)
 {
     using dense = matrix::Dense<typename Matrix::value_type>;
     size_type num_rows = vals.size();
@@ -857,7 +857,7 @@ std::unique_ptr<Matrix> initialize(
 template <typename Matrix, typename... TArgs>
 std::unique_ptr<Matrix> initialize(
     std::initializer_list<typename Matrix::value_type> vals,
-    std::shared_ptr<const Executor> exec, TArgs &&... create_args)
+    std::shared_ptr<const Executor> exec, TArgs &&...create_args)
 {
     return initialize<Matrix>(1, vals, std::move(exec),
                               std::forward<TArgs>(create_args)...);
@@ -890,7 +890,7 @@ std::unique_ptr<Matrix> initialize(
     size_type stride,
     std::initializer_list<std::initializer_list<typename Matrix::value_type>>
         vals,
-    std::shared_ptr<const Executor> exec, TArgs &&... create_args)
+    std::shared_ptr<const Executor> exec, TArgs &&...create_args)
 {
     using dense = matrix::Dense<typename Matrix::value_type>;
     size_type num_rows = vals.size();
@@ -938,7 +938,7 @@ template <typename Matrix, typename... TArgs>
 std::unique_ptr<Matrix> initialize(
     std::initializer_list<std::initializer_list<typename Matrix::value_type>>
         vals,
-    std::shared_ptr<const Executor> exec, TArgs &&... create_args)
+    std::shared_ptr<const Executor> exec, TArgs &&...create_args)
 {
     return initialize<Matrix>(vals.size() > 0 ? begin(vals)->size() : 0, vals,
                               std::move(exec),

--- a/include/ginkgo/core/matrix/diagonal.hpp
+++ b/include/ginkgo/core/matrix/diagonal.hpp
@@ -151,6 +151,7 @@ public:
 
     void write(mat_data32 &data) const override;
 
+    void validate_impl() const override;
 
 protected:
     /**

--- a/include/ginkgo/core/matrix/ell.hpp
+++ b/include/ginkgo/core/matrix/ell.hpp
@@ -113,6 +113,8 @@ public:
 
     void write(mat_data &data) const override;
 
+    void validate_impl() const override;
+
     std::unique_ptr<Diagonal<ValueType>> extract_diagonal() const override;
 
     std::unique_ptr<absolute_type> compute_absolute() const override;

--- a/include/ginkgo/core/matrix/fbcsr.hpp
+++ b/include/ginkgo/core/matrix/fbcsr.hpp
@@ -204,6 +204,8 @@ public:
 
     void write(mat_data &data) const override;
 
+    void validate_impl() const override;
+
     std::unique_ptr<LinOp> transpose() const override;
 
     std::unique_ptr<LinOp> conj_transpose() const override;

--- a/include/ginkgo/core/matrix/hybrid.hpp
+++ b/include/ginkgo/core/matrix/hybrid.hpp
@@ -397,6 +397,8 @@ public:
 
     void write(mat_data &data) const override;
 
+    void validate_impl() const override;
+
     std::unique_ptr<Diagonal<ValueType>> extract_diagonal() const override;
 
     std::unique_ptr<absolute_type> compute_absolute() const override;

--- a/include/ginkgo/core/matrix/permutation.hpp
+++ b/include/ginkgo/core/matrix/permutation.hpp
@@ -1,5 +1,6 @@
 /*******************************<GINKGO LICENSE>******************************
-Copyright (c) 2017-2021, the Ginkgo authors All rights reserved.
+Copyright (c) 2017-2021, the Ginkgo authors
+All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions

--- a/include/ginkgo/core/matrix/permutation.hpp
+++ b/include/ginkgo/core/matrix/permutation.hpp
@@ -34,6 +34,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
 #include <algorithm>
+#include <map>
 #include <memory>
 #include <numeric>
 #include <vector>
@@ -47,6 +48,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <ginkgo/core/base/types.hpp>
 #include <ginkgo/core/base/utils.hpp>
 
+#include "core/components/validation_helpers.hpp"
 
 namespace gko {
 namespace matrix {
@@ -135,10 +137,7 @@ public:
     void validate_impl() const
     {
         std::map<std::string, std::function<bool()>> constraints_map{
-            {"is_finite", [this] {
-                 return ::gko::validate::is_finite<ValueType>(
-                     values_.get_const_data(), values_.get_num_elems());
-             }}};
+            {"is_finite", [this] { return ::gko::validate::is_finite(this); }}};
 
         for (auto const &x : constraints_map) {
             if (!x.second()) {

--- a/include/ginkgo/core/matrix/permutation.hpp
+++ b/include/ginkgo/core/matrix/permutation.hpp
@@ -1,6 +1,5 @@
 /*******************************<GINKGO LICENSE>******************************
-Copyright (c) 2017-2021, the Ginkgo authors
-All rights reserved.
+Copyright (c) 2017-2021, the Ginkgo authors All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions
@@ -132,6 +131,21 @@ public:
         enabled_permute_ = permute_mask;
     }
 
+    // TODO add has_unique_idxs test
+    void validate_impl() const
+    {
+        std::map<std::string, std::function<bool()>> constraints_map{
+            {"is_finite", [this] {
+                 return ::gko::validate::is_finite<ValueType>(
+                     values_.get_const_data(), values_.get_num_elems());
+             }}};
+
+        for (auto const &x : constraints_map) {
+            if (!x.second()) {
+                throw gko::Invalid(__FILE__, __LINE__, "Permutation", x.first);
+            };
+        }
+    }
 
 protected:
     /**

--- a/include/ginkgo/core/matrix/sellp.hpp
+++ b/include/ginkgo/core/matrix/sellp.hpp
@@ -110,6 +110,8 @@ public:
 
     void write(mat_data &data) const override;
 
+    void validate_impl() const override;
+
     std::unique_ptr<Diagonal<ValueType>> extract_diagonal() const override;
 
     std::unique_ptr<absolute_type> compute_absolute() const override;
@@ -247,8 +249,8 @@ public:
     /**
      * @copydoc Sellp::val_at(size_type, size_type, size_type)
      */
-    value_type val_at(size_type row, size_type slice_set, size_type idx) const
-        noexcept
+    value_type val_at(size_type row, size_type slice_set,
+                      size_type idx) const noexcept
     {
         return values_
             .get_const_data()[this->linearize_index(row, slice_set, idx)];
@@ -275,8 +277,8 @@ public:
     /**
      * @copydoc Sellp::col_at(size_type, size_type, size_type)
      */
-    index_type col_at(size_type row, size_type slice_set, size_type idx) const
-        noexcept
+    index_type col_at(size_type row, size_type slice_set,
+                      size_type idx) const noexcept
     {
         return this
             ->get_const_col_idxs()[this->linearize_index(row, slice_set, idx)];


### PR DESCRIPTION
This PR implements data validation strategies as outlined in #746. The aim is to provide a set of validation functions, to evaluate the validity of matrices for debug builds.

The implementation is done in several stages: 

- [x] Free functions checking:
  - [x] If a given matrix is symmetric.
  - [x] If a given matrix has a non-zero diagonal.
  - [x] If given indices are ordered.
  - [x] If given indices are within given bounds.
  - [x] If given indices are unique.
  - [x] If given values are finite.
  - [x] If differences in indices are below given value.
  - [x] If matrix is triangular.

- [ ] Matrices:
   - [x] Coo:  Values are finite, bounded indices (row,column), row pointers are ordered.
   - [x] Csr: Values are finite,  indices are within bounds, row_ptr are sorted and unique.
   - [x] Ell:  Values are  finite, column index is within bounds
   - [x] Diagonal: Values are  finite.
   - [x] Dense: Values are  finite.
   - [x] Fbcsr:  Values are finite,  indices are within bounds, row_ptr are sorted and unique.
   - [x] Hybrid: The underlying Coo and Ell matrix are valid.
   - [ ] Permutation: indices are unique wrt the permutation.
   - [ ] Sellp:  Slice offsets are non-descending, slice lengths are consistent with slice offsets.

   
- [x] Factorizations: 
   - [x] Check if output is valid and has non-zero diagonal
   - [ ] IC: check if diagonal entries are >0 and if input matrix is symmetric
   
- [ ] Preconditioners:
    - [ ] Jacobi: The block pointers need to be ascending with gaps smaller than max_block_size
    - [ ] Jacobi: The blocks must be invertible/inverted blocks must contain finite values
    - [ ] Ic: The system matrix must be symmetric
    - [ ] Ilu:
    - [ ] Isai: The output must be a valid Csr matrix

- [ ] Solvers:
   - [ ] All solvers: system matrix is valid
   - [ ] Iterative solvers: preconditioner is valid
   - [ ] CG: system matrix is symmetric.
   - [ ] Upper/LowerTrs: system matrix needs to be triangular with non-zero diagonal entries.