### PR TITLE
Bugfixes for reference batch functionality and improvements to testing

### DIFF
--- a/common/log/batch_logger.hpp.inc
+++ b/common/log/batch_logger.hpp.inc
@@ -80,6 +80,9 @@ public:
         const size_type batch_idx, const int iter,
         const real_type *const res_norm, const uint32 converged)
     {
+        if (iter == 0) {
+            init_converged_ = 0 - (1 << nrhs_);
+        }
         // Maybe this can/should be optimized? It might not be worth the effort.
         if (converged != init_converged_ || iter >= max_iters_ - 2) {
             for (int j = threadIdx.x; j < nrhs_; j += blockDim.x) {

--- a/common/preconditioner/batch_jacobi.hpp.inc
+++ b/common/preconditioner/batch_jacobi.hpp.inc
@@ -76,10 +76,8 @@ public:
             for (int j = mat.row_ptrs[irow] + tile.thread_rank();
                  j < mat.row_ptrs[irow + 1]; j += warp_size) {
                 const int found = (mat.col_idxs[j] == irow);
-                const uint32 foundbits = tile.ballot(found);
-                if (foundbits && tile.thread_rank() == 0) {
-                    const int posj = ffs(foundbits) - 1;
-                    work_[irow] = one<ValueType>() / mat.values[j + posj];
+                if (found) {
+                    work_[irow] = one<ValueType>() / mat.values[j];
                 }
             }
         }

--- a/common/preconditioner/batch_jacobi.hpp.inc
+++ b/common/preconditioner/batch_jacobi.hpp.inc
@@ -46,10 +46,6 @@ public:
 
     /**
      * The size of the work vector required in case of dynamic allocation.
-     *
-     * For the Jacobi preconditioner, this is unnecessary, but this function is
-     * part of a 'batch preconditioner interface' because other preconditioners
-     * may need it.
      */
     __host__ __device__ static constexpr int dynamic_work_size(
         const int num_rows, int)

--- a/reference/log/batch_logger.hpp
+++ b/reference/log/batch_logger.hpp
@@ -87,6 +87,9 @@ public:
     void log_iteration(const size_type batch_idx, const int iter,
                        const real_type *const res_norm, const uint32 converged)
     {
+        if (iter == 0) {
+            init_converged_ = 0 - (1 << nrhs_);
+        }
         if (converged != init_converged_ || iter >= max_iters_ - 1) {
             for (int j = 0; j < nrhs_; j++) {
                 const uint32 jconv = converged & (1 << j);

--- a/reference/preconditioner/batch_jacobi.hpp
+++ b/reference/preconditioner/batch_jacobi.hpp
@@ -56,15 +56,8 @@ public:
 
     /**
      * The size of the work vector required in case of dynamic allocation.
-     *
-     * For the Jacobi preconditioner, this is unnecessary, but this function is
-     * part of a 'batch preconditioner interface' because other preconditioners
-     * may need it.
      */
-    static int dynamic_work_size(int, int)
-    {
-        return batch_config<ValueType>::max_num_rows;
-    }
+    static int dynamic_work_size(const int nrows, int) { return nrows; }
 
     /**
      * Sets the input and generates the preconditioner by storing the inverse

--- a/reference/test/solver/batch_richardson_kernels.cpp
+++ b/reference/test/solver/batch_richardson_kernels.cpp
@@ -36,6 +36,9 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <gtest/gtest.h>
 
 
+#include <ginkgo/core/log/batch_convergence.hpp>
+
+
 #include "core/solver/batch_richardson_kernels.hpp"
 #include "core/test/utils.hpp"
 #include "core/test/utils/batch.hpp"
@@ -347,38 +350,44 @@ TYPED_TEST(BatchRich, GeneralScalingDoesNotChangeResult)
 }
 
 
-TYPED_TEST(BatchRich, CanSolveWithoutScaling)
+TEST(BatchRich, CanSolveWithoutScaling)
 {
-    using T = typename TestFixture::value_type;
-    using RT = typename TestFixture::real_type;
+    using T = std::complex<float>;
+    using RT = typename gko::remove_complex<T>;
     using Solver = gko::solver::BatchRichardson<T>;
     using Dense = gko::matrix::BatchDense<T>;
     using RDense = gko::matrix::BatchDense<RT>;
-    using Mtx = typename TestFixture::Mtx;
+    using Mtx = typename gko::matrix::BatchCsr<T>;
     const RT tol = std::numeric_limits<RT>::epsilon();
+    std::shared_ptr<gko::ReferenceExecutor> exec =
+        gko::ReferenceExecutor::create();
     auto batchrich_factory = Solver::build()
-                                 .with_max_iterations(500)
-                                 .with_rel_residual_tol(tol * 100)
-                                 .with_relaxation_factor(RT{0.95})
-                                 .on(this->exec);
-    std::shared_ptr<Mtx> mtx = gko::test::create_poisson1d_batch<T>(
-        this->exec, this->nrows, this->nbatch);
+                                 .with_max_iterations(10000)
+                                 .with_rel_residual_tol(tol * 200)
+                                 .with_relaxation_factor(RT{0.98})
+                                 .on(exec);
+    const int nrows = 40;
+    const size_t nbatch = 3;
+    std::shared_ptr<Mtx> mtx =
+        gko::test::create_poisson1d_batch<T>(exec, nrows, nbatch);
     auto solver = batchrich_factory->generate(mtx);
-    const int nrhs = 3;
-    auto b = Dense::create(
-        this->exec,
-        gko::batch_dim<>(this->nbatch, gko::dim<2>(this->nrows, nrhs)));
+    std::shared_ptr<const gko::log::BatchConvergence<T>> logger =
+        gko::log::BatchConvergence<T>::create(exec);
+    solver->add_logger(logger);
+    const int nrhs = 7;
+    auto b =
+        Dense::create(exec, gko::batch_dim<>(nbatch, gko::dim<2>(nrows, nrhs)));
     auto x = Dense::create_with_config_of(b.get());
     auto res = Dense::create_with_config_of(b.get());
-    auto alpha = gko::batch_initialize<Dense>(this->nbatch, {-1.0}, this->exec);
-    auto beta = gko::batch_initialize<Dense>(this->nbatch, {1.0}, this->exec);
-    auto bnorm = RDense::create(
-        this->exec, gko::batch_dim<>(this->nbatch, gko::dim<2>(1, nrhs)));
-    for (size_t ib = 0; ib < this->nbatch; ib++) {
+    auto alpha = gko::batch_initialize<Dense>(nbatch, {-1.0}, exec);
+    auto beta = gko::batch_initialize<Dense>(nbatch, {1.0}, exec);
+    auto bnorm =
+        RDense::create(exec, gko::batch_dim<>(nbatch, gko::dim<2>(1, nrhs)));
+    for (size_t ib = 0; ib < nbatch; ib++) {
         for (int j = 0; j < nrhs; j++) {
             bnorm->at(ib, 0, j) = gko::zero<RT>();
-            const T val = 1.0 + ib / 2.0 - j / 4.0;
-            for (int i = 0; i < this->nrows; i++) {
+            const T val = 1.0 + std::cos(ib / 2.0 - j / 4.0);
+            for (int i = 0; i < nrows; i++) {
                 b->at(ib, i, j) = val;
                 x->at(ib, i, j) = 0.0;
                 res->at(ib, i, j) = val;
@@ -391,14 +400,18 @@ TYPED_TEST(BatchRich, CanSolveWithoutScaling)
     solver->apply(b.get(), x.get());
 
     mtx->apply(alpha.get(), x.get(), beta.get(), res.get());
-    auto rnorm = RDense::create(
-        this->exec, gko::batch_dim<>(this->nbatch, gko::dim<2>(1, nrhs)));
+    auto rnorm =
+        RDense::create(exec, gko::batch_dim<>(nbatch, gko::dim<2>(1, nrhs)));
     res->compute_norm2(rnorm.get());
-    for (size_t ib = 0; ib < this->nbatch; ib++) {
+    const auto iter_array = logger->get_num_iterations();
+    const auto logged_res = logger->get_residual_norm();
+    for (size_t ib = 0; ib < nbatch; ib++) {
         for (int j = 0; j < nrhs; j++) {
-            ASSERT_LE(rnorm->at(ib, 0, j) / bnorm->at(ib, 0, j), tol * 100);
+            ASSERT_LE(rnorm->at(ib, 0, j) / bnorm->at(ib, 0, j), tol * 200);
+            ASSERT_GT(iter_array.get_const_data()[ib * nrhs + j], 0);
         }
     }
+    GKO_ASSERT_BATCH_MTX_NEAR(logged_res, rnorm, tol);
 }
 
 


### PR DESCRIPTION
This PR 
- [x] fixes an issue where reference batch Jacobi was reporting the wrong amount of memory it needs for the work vector
- [x] improves the integration test in `reference/test/solvers/batch_richardson_kernels` to also demonstrate the use of the batch convergence logger
- [x] Fixed batch logger has a corner case bug by resetting the stored convergence state everytime a new solve begins. The beginning of a new solve is equated with the iteration count being zero.
- [x] Simplified Cuda batch Jacobi implementation.