### PR TITLE
Clarifies the documentation for dense norm computation

### DIFF
--- a/contributors.txt
+++ b/contributors.txt
@@ -15,6 +15,7 @@ Heroux Mike <maherou@sandia.gov> Sandia National Laboratories
 Hoemmen Mark <mhoemme@sandia.gov> Sandia National Laboratories
 Holeksa Claudius <mail@keldu.de> Karlsruhe Institute of Technology
 Kashi Aditya <aditya.kashi@kit.edu> Karlsruhe Institute of Technology
+Koch Marcel <marcel.koch@kit.edu> Karlsruhe Institute of Technology
 Maier Matthias <matthias@43-1.org> Texas A&M University
 Nayak Pratik <pratik.nayak@kit.edu> Karlsruhe Institute of Technology
 Olenik Gregor <go@hpsim.de> HPSim

--- a/include/ginkgo/core/matrix/dense.hpp
+++ b/include/ginkgo/core/matrix/dense.hpp
@@ -680,7 +680,7 @@ public:
     }
 
     /**
-     * Computes the Euclidian (L^2) norm of this matrix.
+     * Computes the column-wise Euclidian (L^2) norm of this matrix.
      *
      * @param result  a Dense row vector, used to store the norm
      *                (the number of columns in the vector must match the number


### PR DESCRIPTION
The updated documentation explicitly mentions that the norm is computed for each column vector. This is similar to the documentation for `compute_dot` and `compute_conj_dot`, which behave in the same way.