### PR TITLE
Use another toolset of msvc in cuda job

### DIFF
--- a/.github/workflows/windows-msvc-cuda.yml
+++ b/.github/workflows/windows-msvc-cuda.yml
@@ -45,5 +45,5 @@ jobs:
         refreshenv
         mkdir build
         cd build
-        cmake -DGINKGO_BUILD_CUDA=ON -DGINKGO_BUILD_OMP=OFF -DGINKGO_MIXED_PRECISION=${{ matrix.config.mixed }} -DGINKGO_CUDA_ARCHITECTURES=60 ..
+        cmake -T version=14.25 -DGINKGO_BUILD_CUDA=ON -DGINKGO_BUILD_OMP=OFF -DGINKGO_MIXED_PRECISION=${{ matrix.config.mixed }} -DGINKGO_CUDA_ARCHITECTURES=60 ..
         cmake --build . -j4 --config Release

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -352,8 +352,12 @@ else()
 endif()
 
 file(MAKE_DIRECTORY ${Ginkgo_BINARY_DIR}/test_install)
+set(TOOLSET "")
+if (NOT "${CMAKE_GENERATOR_TOOLSET}" STREQUAL "")
+    set(TOOLSET "-T ${CMAKE_GENERATOR_TOOLSET}")
+endif()
 add_custom_target(test_install
-    COMMAND ${CMAKE_COMMAND} -G${CMAKE_GENERATOR} -H${Ginkgo_SOURCE_DIR}/test_install
+    COMMAND ${CMAKE_COMMAND} -G${CMAKE_GENERATOR} ${TOOLSET} -H${Ginkgo_SOURCE_DIR}/test_install
     -B${Ginkgo_BINARY_DIR}/test_install
     -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
     -DCMAKE_PREFIX_PATH=${CMAKE_INSTALL_PREFIX}/${GINKGO_INSTALL_CONFIG_DIR}
@@ -370,7 +374,7 @@ add_custom_target(test_install
     COMMENT "Running a test on the installed binaries. This requires running `(sudo) make install` first.")
 
 add_custom_target(test_exportbuild
-    COMMAND ${CMAKE_COMMAND} -G${CMAKE_GENERATOR} -H${Ginkgo_SOURCE_DIR}/test_exportbuild
+    COMMAND ${CMAKE_COMMAND} -G${CMAKE_GENERATOR} ${TOOLSET} -H${Ginkgo_SOURCE_DIR}/test_exportbuild
     -B${Ginkgo_BINARY_DIR}/test_exportbuild
     -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER} -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
     -DCMAKE_CUDA_COMPILER=${CMAKE_CUDA_COMPILER}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -354,7 +354,7 @@ endif()
 file(MAKE_DIRECTORY ${Ginkgo_BINARY_DIR}/test_install)
 set(TOOLSET "")
 if (NOT "${CMAKE_GENERATOR_TOOLSET}" STREQUAL "")
-    set(TOOLSET "-T ${CMAKE_GENERATOR_TOOLSET}")
+    set(TOOLSET "-T${CMAKE_GENERATOR_TOOLSET}")
 endif()
 add_custom_target(test_install
     COMMAND ${CMAKE_COMMAND} -G${CMAKE_GENERATOR} ${TOOLSET} -H${Ginkgo_SOURCE_DIR}/test_install

--- a/cmake/package_helpers.cmake
+++ b/cmake/package_helpers.cmake
@@ -20,7 +20,7 @@ function(ginkgo_load_git_package package_name package_url package_tag)
         download/CMakeLists.txt)
     set(TOOLSET "")
     if (NOT "${CMAKE_GENERATOR_TOOLSET}" STREQUAL "")
-        set(TOOLSET "-T ${CMAKE_GENERATOR_TOOLSET}")
+        set(TOOLSET "-T${CMAKE_GENERATOR_TOOLSET}")
     endif()
     execute_process(COMMAND ${CMAKE_COMMAND} -G "${CMAKE_GENERATOR}" "${TOOLSET}" .
         RESULT_VARIABLE result
@@ -73,7 +73,7 @@ function(ginkgo_load_and_configure_package package_name package_url package_hash
         download/CMakeLists.txt)
     set(TOOLSET "")
     if (NOT "${CMAKE_GENERATOR_TOOLSET}" STREQUAL "")
-        set(TOOLSET "-T ${CMAKE_GENERATOR_TOOLSET}")
+        set(TOOLSET "-T${CMAKE_GENERATOR_TOOLSET}")
     endif()
     execute_process(COMMAND ${CMAKE_COMMAND} -G "${CMAKE_GENERATOR}" "${TOOLSET}" .
         RESULT_VARIABLE result

--- a/cmake/package_helpers.cmake
+++ b/cmake/package_helpers.cmake
@@ -18,7 +18,11 @@ function(ginkgo_load_git_package package_name package_url package_tag)
     endif()
     configure_file(${PACKAGE_DOWNLOADER_SCRIPT}
         download/CMakeLists.txt)
-    execute_process(COMMAND ${CMAKE_COMMAND} -G "${CMAKE_GENERATOR}" .
+    set(TOOLSET "")
+    if (NOT "${CMAKE_GENERATOR_TOOLSET}" STREQUAL "")
+        set(TOOLSET "-T ${CMAKE_GENERATOR_TOOLSET}")
+    endif()
+    execute_process(COMMAND ${CMAKE_COMMAND} -G "${CMAKE_GENERATOR}" "${TOOLSET}" .
         RESULT_VARIABLE result
         WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/download)
     if(result)
@@ -67,7 +71,11 @@ function(ginkgo_load_and_configure_package package_name package_url package_hash
     endif()
     configure_file(${NON_CMAKE_PACKAGE_DOWNLOADER_SCRIPT}
         download/CMakeLists.txt)
-    execute_process(COMMAND ${CMAKE_COMMAND} -G "${CMAKE_GENERATOR}" .
+    set(TOOLSET "")
+    if (NOT "${CMAKE_GENERATOR_TOOLSET}" STREQUAL "")
+        set(TOOLSET "-T ${CMAKE_GENERATOR_TOOLSET}")
+    endif()
+    execute_process(COMMAND ${CMAKE_COMMAND} -G "${CMAKE_GENERATOR}" "${TOOLSET}" .
         RESULT_VARIABLE result
         WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/download)
     if(result)


### PR DESCRIPTION
This PR uses `-T version=14.25` to use another one toolset in github action.
Also, pass the toolset selection into other cmake command if it exists.
It avoid the error from the latest compiler from 16.10 with cuda 11. [ref](https://github.com/actions/virtual-environments/issues/3485) 
Github action install the toolset 14.25 from this [issue](https://github.com/actions/virtual-environments/issues/1076)  
Another workaround is to use standard 17 not 14.