### PR TITLE
Add some micro-benchmarking support to Ginkgo

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,6 +59,9 @@ option(GINKGO_CONFIG_LOG_DETAILED
 option(GINKGO_BENCHMARK_ENABLE_TUNING
     "Enable tuning variables in the benchmarks. For specific use cases, manual code changes could be required."
     OFF)
+option(GINKGO_BUILD_MICRO_BENCHMARKS
+    "Build Ginkgo's micro-benchmarks. This benchmarks the smaller functionalities to ensure their performance."
+    OFF)
 set(GINKGO_VERBOSE_LEVEL "1" CACHE STRING
     "Verbosity level. Put 0 to turn off. 1 activates a few important messages.")
 if(MSVC)
@@ -224,6 +227,9 @@ endif()
 if(GINKGO_BUILD_BENCHMARKS)
     find_package(gflags 2.2.2 QUIET)
     find_package(RapidJSON 1.1.0 QUIET)
+endif()
+if(GINKGO_BUILD_MICRO_BENCHMARKS)
+    find_package(gbench QUIET)
 endif()
 if(GINKGO_BUILD_HWLOC)
     find_package(HWLOC 2.1) # No need for QUIET as we ship FindHWLOC

--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -119,9 +119,9 @@ add_custom_command(
             ${CMAKE_CURRENT_SOURCE_DIR}/run_all_benchmarks.sh
             ${CMAKE_CURRENT_BINARY_DIR}/run_all_benchmarks.sh)
 
-add_custom_target(benchmark)
+add_custom_target(gko-benchmark)
 add_custom_command(
-    TARGET benchmark POST_BUILD
+    TARGET gko-benchmark POST_BUILD
     COMMAND bash run_all_benchmarks.sh >/dev/null
     DEPENDS make_run_all_benchmarks
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})

--- a/cmake/create_mbench.cmake
+++ b/cmake/create_mbench.cmake
@@ -1,0 +1,21 @@
+function(ginkgo_create_mbench mbench_name)
+    set(THREADS_PREFER_PTHREAD_FLAG ON)
+    find_package(Threads REQUIRED)
+    file(RELATIVE_PATH REL_BINARY_DIR
+        ${PROJECT_BINARY_DIR} ${CMAKE_CURRENT_BINARY_DIR})
+    string(REPLACE "/" "_" MBENCH_TARGET_NAME "${REL_BINARY_DIR}/${mbench_name}")
+    add_executable(${MBENCH_TARGET_NAME} ${mbench_name}.cpp)
+    target_compile_features("${MBENCH_TARGET_NAME}" PUBLIC cxx_std_14)
+    target_include_directories("${MBENCH_TARGET_NAME}"
+        PRIVATE
+        "$<BUILD_INTERFACE:${Ginkgo_BINARY_DIR}>"
+        )
+    set_target_properties(${MBENCH_TARGET_NAME} PROPERTIES
+        OUTPUT_NAME ${mbench_name})
+    if (GINKGO_CHECK_CIRCULAR_DEPS)
+        target_link_libraries(${MBENCH_TARGET_NAME} PRIVATE "${GINKGO_CIRCULAR_DEPS_FLAGS}")
+    endif()
+    target_link_libraries(${MBENCH_TARGET_NAME} PRIVATE ginkgo GBench::GBench GBench::Main
+        Threads::Threads ${ARGN})
+    add_test(NAME ${REL_BINARY_DIR}/${mbench_name} COMMAND ${MBENCH_TARGET_NAME})
+endfunction(ginkgo_create_mbench)

--- a/cmake/create_mbench.cmake
+++ b/cmake/create_mbench.cmake
@@ -17,5 +17,28 @@ function(ginkgo_create_mbench mbench_name)
     endif()
     target_link_libraries(${MBENCH_TARGET_NAME} PRIVATE ginkgo GBench::GBench GBench::Main
         Threads::Threads ${ARGN})
-    add_test(NAME ${REL_BINARY_DIR}/${mbench_name} COMMAND ${MBENCH_TARGET_NAME})
 endfunction(ginkgo_create_mbench)
+
+function(ginkgo_create_cuda_mbench mbench_name)
+    set(THREADS_PREFER_PTHREAD_FLAG ON)
+    find_package(Threads REQUIRED)
+    file(RELATIVE_PATH REL_BINARY_DIR
+        ${PROJECT_BINARY_DIR} ${CMAKE_CURRENT_BINARY_DIR})
+    string(REPLACE "/" "_" MBENCH_TARGET_NAME "${REL_BINARY_DIR}/${mbench_name}")
+    add_executable(${MBENCH_TARGET_NAME} ${mbench_name}.cu)
+    target_compile_features("${MBENCH_TARGET_NAME}" PUBLIC cxx_std_14)
+    target_include_directories("${MBENCH_TARGET_NAME}"
+        PRIVATE
+        "$<BUILD_INTERFACE:${Ginkgo_BINARY_DIR}>"
+        )
+    cas_target_cuda_architectures(${MBENCH_TARGET_NAME}
+        ARCHITECTURES ${GINKGO_CUDA_ARCHITECTURES}
+        UNSUPPORTED "20" "21")
+    set_target_properties(${MBENCH_TARGET_NAME} PROPERTIES
+        OUTPUT_NAME ${mbench_name})
+
+    if (GINKGO_CHECK_CIRCULAR_DEPS)
+        target_link_libraries(${MBENCH_TARGET_NAME} PRIVATE "${GINKGO_CIRCULAR_DEPS_FLAGS}")
+    endif()
+    target_link_libraries(${MBENCH_TARGET_NAME} PRIVATE ginkgo GBench::Main GBench::GBench ${ARGN})
+endfunction(ginkgo_create_cuda_mbench)

--- a/cmake/get_info.cmake
+++ b/cmake/get_info.cmake
@@ -133,7 +133,7 @@ foreach(log_type ${log_types})
         "GINKGO_MIXED_PRECISION")
     ginkgo_print_module_footer(${${log_type}} "  Tests, benchmarks and examples:")
     ginkgo_print_foreach_variable(${${log_type}}
-        "GINKGO_BUILD_TESTS;GINKGO_FAST_TESTS;GINKGO_BUILD_EXAMPLES;GINKGO_EXTLIB_EXAMPLE;GINKGO_BUILD_BENCHMARKS;GINKGO_BENCHMARK_ENABLE_TUNING")
+        "GINKGO_BUILD_TESTS;GINKGO_FAST_TESTS;GINKGO_BUILD_EXAMPLES;GINKGO_EXTLIB_EXAMPLE;GINKGO_BUILD_BENCHMARKS;GINKGO_BUILD_MICRO_BENCHMARKS;GINKGO_BENCHMARK_ENABLE_TUNING")
     ginkgo_print_module_footer(${${log_type}} "  Documentation:")
     ginkgo_print_foreach_variable(${${log_type}} "GINKGO_BUILD_DOC;GINKGO_VERBOSE_LEVEL")
     ginkgo_print_module_footer(${${log_type}} "")

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -91,3 +91,7 @@ endif()
 if(GINKGO_BUILD_TESTS)
     add_subdirectory(test)
 endif()
+
+if(GINKGO_BUILD_MICRO_BENCHMARKS)
+    add_subdirectory(micro-benchmarks)
+endif()

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -93,5 +93,5 @@ if(GINKGO_BUILD_TESTS)
 endif()
 
 if(GINKGO_BUILD_MICRO_BENCHMARKS)
-    add_subdirectory(micro-benchmarks)
+    add_subdirectory(micro_bench)
 endif()

--- a/core/micro_bench/CMakeLists.txt
+++ b/core/micro_bench/CMakeLists.txt
@@ -1,0 +1,3 @@
+include(${PROJECT_SOURCE_DIR}/cmake/create_mbench.cmake)
+
+add_subdirectory(base)

--- a/core/micro_bench/base/CMakeLists.txt
+++ b/core/micro_bench/base/CMakeLists.txt
@@ -1,0 +1,2 @@
+ginkgo_create_mbench(array)
+ginkgo_create_mbench(executor)

--- a/core/micro_bench/base/array.cpp
+++ b/core/micro_bench/base/array.cpp
@@ -1,0 +1,252 @@
+/*******************************<GINKGO LICENSE>******************************
+Copyright (c) 2017-2021, the Ginkgo authors
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+******************************<GINKGO LICENSE>*******************************/
+
+#include <ginkgo/core/base/array.hpp>
+
+
+#include <cmath>
+#include <random>
+#include <type_traits>
+
+
+#include <benchmark/benchmark.h>
+
+
+#include <ginkgo/core/base/exception.hpp>
+
+
+using exec_ptr = std::shared_ptr<gko::Executor>;
+
+
+class Array : public benchmark::Fixture {
+public:
+    void SetUp(const ::benchmark::State &state)
+    {
+        gen();
+        exec = gko::ReferenceExecutor::create();
+    }
+
+    void TearDown(const ::benchmark::State &state) {}
+
+    exec_ptr exec;
+    std::uniform_int_distribution<> dis{1, 100};
+    std::mt19937 gen;
+};
+
+
+BENCHMARK_F(Array, CreateWithoutExecutor)(benchmark::State &state)
+{
+    for (auto _ : state) {
+        gko::Array<int> a;
+    }
+}
+
+
+BENCHMARK_F(Array, CreateWithExecutor)(benchmark::State &state)
+{
+    for (auto _ : state) {
+        gko::Array<int> a(this->exec);
+    }
+}
+
+
+BENCHMARK_DEFINE_F(Array, CreateFromExistingData)(benchmark::State &state)
+{
+    for (auto _ : state) {
+        gko::Array<int> a(this->exec, state.range(0), new int[state.range(0)],
+                          std::default_delete<int[]>{});
+    }
+}
+
+BENCHMARK_REGISTER_F(Array, CreateFromExistingData)
+    ->RangeMultiplier(8)
+    ->Range(64, 64 << 12);
+
+
+BENCHMARK_DEFINE_F(Array, CreateView)(benchmark::State &state)
+{
+    auto data = new int[state.range(0)];
+    for (auto _ : state) {
+        auto view = gko::Array<int>::view(this->exec, state.range(0), data);
+    }
+    delete data;
+}
+
+BENCHMARK_REGISTER_F(Array, CreateView)
+    ->RangeMultiplier(8)
+    ->Range(64, 64 << 12);
+
+
+BENCHMARK_DEFINE_F(Array, CreateFromDataOnExecutor)(benchmark::State &state)
+{
+    for (auto _ : state) {
+        gko::Array<int> a{this->exec, state.range(0),
+                          this->exec->template alloc<int>(state.range(0))};
+    }
+}
+
+BENCHMARK_REGISTER_F(Array, CreateFromDataOnExecutor)
+    ->RangeMultiplier(8)
+    ->Range(64, 64 << 12);
+
+
+BENCHMARK_DEFINE_F(Array, CreateFromRange)(benchmark::State &state)
+{
+    using std::begin;
+    auto data = std::vector<int>{state.range(0), state.range(0) * 7};
+    for (auto _ : state) {
+        gko::Array<int> a{this->exec, begin(data), end(data)};
+    }
+}
+
+BENCHMARK_REGISTER_F(Array, CreateFromRange)
+    ->RangeMultiplier(8)
+    ->Range(64, 64 << 12);
+
+
+BENCHMARK_DEFINE_F(Array, CopyConstruct)(benchmark::State &state)
+{
+    auto x = gko::Array<int>{this->exec, state.range(0)};
+    for (auto _ : state) {
+        gko::Array<int> a(x);
+    }
+}
+
+BENCHMARK_REGISTER_F(Array, CopyConstruct)
+    ->RangeMultiplier(8)
+    ->Range(64, 64 << 12);
+
+
+BENCHMARK_DEFINE_F(Array, MoveConstruct)(benchmark::State &state)
+{
+    auto x = gko::Array<int>{this->exec, state.range(0)};
+    for (auto _ : state) {
+        gko::Array<int> a(std::move(x));
+    }
+}
+
+BENCHMARK_REGISTER_F(Array, MoveConstruct)
+    ->RangeMultiplier(8)
+    ->Range(64, 64 << 12);
+
+
+BENCHMARK_DEFINE_F(Array, CopyAssign)(benchmark::State &state)
+{
+    auto x1 = gko::Array<int>{this->exec, state.range(0)};
+    auto x2 = gko::Array<int>{this->exec, state.range(0) + 2};
+    for (auto _ : state) {
+        x1 = x2;
+    }
+}
+
+BENCHMARK_REGISTER_F(Array, CopyAssign)
+    ->RangeMultiplier(8)
+    ->Range(64, 64 << 12);
+
+
+BENCHMARK_DEFINE_F(Array, MoveAssign)(benchmark::State &state)
+{
+    auto x1 = gko::Array<int>{this->exec, state.range(0)};
+    auto x2 = gko::Array<int>{this->exec, state.range(0) + 3};
+    for (auto _ : state) {
+        x1 = std::move(x2);
+    }
+}
+
+BENCHMARK_REGISTER_F(Array, MoveAssign)
+    ->RangeMultiplier(8)
+    ->Range(64, 64 << 12);
+
+
+BENCHMARK_DEFINE_F(Array, CopyViews)(benchmark::State &state)
+{
+    auto data = new int[state.range(0)];
+    auto data2 = new int[state.range(0)];
+    auto view1 = gko::Array<int>::view(this->exec, state.range(0), data);
+    auto view2 = gko::Array<int>::view(this->exec, state.range(0), data2);
+    for (auto _ : state) {
+        view1 = view2;
+    }
+    delete data, data2;
+}
+
+BENCHMARK_REGISTER_F(Array, CopyViews)->RangeMultiplier(8)->Range(64, 64 << 12);
+
+
+BENCHMARK_DEFINE_F(Array, MoveViews)(benchmark::State &state)
+{
+    auto data = new int[state.range(0)];
+    auto data2 = new int[state.range(0)];
+    auto view1 = gko::Array<int>::view(this->exec, state.range(0), data);
+    auto view2 = gko::Array<int>::view(this->exec, state.range(0), data2);
+    for (auto _ : state) {
+        view1 = std::move(view2);
+    }
+    delete data, data2;
+}
+
+BENCHMARK_REGISTER_F(Array, MoveViews)->RangeMultiplier(8)->Range(64, 64 << 12);
+
+
+BENCHMARK_DEFINE_F(Array, TempClone)(benchmark::State &state)
+{
+    auto x = gko::Array<int>{this->exec, state.range(0)};
+    for (auto _ : state) {
+        auto tmp_clone = make_temporary_clone(this->exec, &x);
+    }
+}
+
+BENCHMARK_REGISTER_F(Array, TempClone)->RangeMultiplier(8)->Range(64, 64 << 12);
+
+
+BENCHMARK_DEFINE_F(Array, Clear)(benchmark::State &state)
+{
+    auto x = gko::Array<int>{this->exec, state.range(0)};
+    for (auto _ : state) {
+        x.clear();
+    }
+}
+
+BENCHMARK_REGISTER_F(Array, Clear)->RangeMultiplier(8)->Range(64, 64 << 12);
+
+
+BENCHMARK_DEFINE_F(Array, ResizeAndReset)(benchmark::State &state)
+{
+    auto x = gko::Array<int>{this->exec, state.range(0)};
+    for (auto _ : state) {
+        x.resize_and_reset(state.range(0) + this->dis(this->gen));
+    }
+}
+
+BENCHMARK_REGISTER_F(Array, ResizeAndReset)
+    ->RangeMultiplier(8)
+    ->Range(64, 64 << 12);

--- a/core/micro_bench/base/executor.cpp
+++ b/core/micro_bench/base/executor.cpp
@@ -1,0 +1,153 @@
+/*******************************<GINKGO LICENSE>******************************
+Copyright (c) 2017-2021, the Ginkgo authors
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+******************************<GINKGO LICENSE>*******************************/
+
+#include <ginkgo/core/base/executor.hpp>
+
+
+#include <cmath>
+#include <random>
+#include <thread>
+#include <type_traits>
+
+
+#include <benchmark/benchmark.h>
+
+
+#include <ginkgo/core/base/exception.hpp>
+
+
+using exec_ptr = std::shared_ptr<gko::Executor>;
+
+
+class ExampleOperation : public gko::Operation {
+public:
+    explicit ExampleOperation(int &val) : value(val) {}
+    void run(std::shared_ptr<const gko::OmpExecutor>) const override
+    {
+        value = 1;
+    }
+    void run(std::shared_ptr<const gko::CudaExecutor>) const override
+    {
+        value = 2;
+    }
+    void run(std::shared_ptr<const gko::HipExecutor>) const override
+    {
+        value = 3;
+    }
+    void run(std::shared_ptr<const gko::DpcppExecutor>) const override
+    {
+        value = 4;
+    }
+    void run(std::shared_ptr<const gko::ReferenceExecutor>) const override
+    {
+        value = 5;
+    }
+
+    int &value;
+};
+
+
+template <typename ExecCreate>
+static void executor_create(benchmark::State &st, ExecCreate &&exec_create)
+{
+    for (auto _ : st) {
+        exec_create();
+    }
+}
+
+BENCHMARK_CAPTURE(executor_create, Ref,
+                  []() { auto exec = gko::ReferenceExecutor::create(); });
+BENCHMARK_CAPTURE(executor_create, Omp,
+                  []() { auto exec = gko::ReferenceExecutor::create(); });
+BENCHMARK_CAPTURE(executor_create, Cuda, []() {
+    auto exec = gko::CudaExecutor::create(0, gko::OmpExecutor::create());
+});
+BENCHMARK_CAPTURE(executor_create, Hip, []() {
+    auto exec = gko::HipExecutor::create(0, gko::OmpExecutor::create());
+});
+BENCHMARK_CAPTURE(executor_create, Dpcpp, []() {
+    auto exec = gko::DpcppExecutor::create(0, gko::OmpExecutor::create());
+});
+
+
+template <typename ExecCreate, typename ExecRun>
+static void executor_run(benchmark::State &st, ExecCreate &&create,
+                         ExecRun &&run)
+{
+    exec_ptr exec;
+    create(exec);
+    for (auto _ : st) {
+        run(exec);
+    }
+}
+
+BENCHMARK_CAPTURE(
+    executor_run, Ref,
+    [](exec_ptr &exec) { exec = gko::ReferenceExecutor::create(); },
+    [](exec_ptr &exec) {
+        int value = 0;
+        exec->run(ExampleOperation(value));
+    });
+BENCHMARK_CAPTURE(
+    executor_run, Omp,
+    [](exec_ptr &exec) { exec = gko::OmpExecutor::create(); },
+    [](exec_ptr &exec) {
+        int value = 0;
+        exec->run(ExampleOperation(value));
+    });
+BENCHMARK_CAPTURE(
+    executor_run, Cuda,
+    [](exec_ptr &exec) {
+        exec = gko::CudaExecutor::create(0, gko::OmpExecutor::create());
+    },
+    [](exec_ptr &exec) {
+        int value = 0;
+        exec->run(ExampleOperation(value));
+    });
+BENCHMARK_CAPTURE(
+    executor_run, Hip,
+    [](exec_ptr &exec) {
+        exec = gko::HipExecutor::create(0, gko::OmpExecutor::create());
+    },
+    [](exec_ptr &exec) {
+        int value = 0;
+        exec->run(ExampleOperation(value));
+    });
+BENCHMARK_CAPTURE(
+    executor_run, Dpcpp,
+    [](exec_ptr &exec) {
+        exec = gko::DpcppExecutor::create(0, gko::OmpExecutor::create());
+    },
+    [](exec_ptr &exec) {
+        int value = 0;
+        exec->run(ExampleOperation(value));
+    });

--- a/cuda/CMakeLists.txt
+++ b/cuda/CMakeLists.txt
@@ -233,6 +233,10 @@ if(GINKGO_BUILD_TESTS)
     add_subdirectory(test)
 endif()
 
+if(GINKGO_BUILD_MICRO_BENCHMARKS)
+    add_subdirectory(micro_bench)
+endif()
+
 # Propagate some useful CUDA informations not propagated by default
 set(CMAKE_CUDA_COMPILER_VERSION "${CMAKE_CUDA_COMPILER_VERSION}" PARENT_SCOPE)
 set(CMAKE_CUDA_HOST_LINK_LAUNCHER "${CMAKE_CUDA_HOST_LINK_LAUNCHER}" PARENT_SCOPE)

--- a/cuda/micro_bench/CMakeLists.txt
+++ b/cuda/micro_bench/CMakeLists.txt
@@ -1,0 +1,3 @@
+include(${PROJECT_SOURCE_DIR}/cmake/create_mbench.cmake)
+
+add_subdirectory(base)

--- a/cuda/micro_bench/base/CMakeLists.txt
+++ b/cuda/micro_bench/base/CMakeLists.txt
@@ -1,0 +1,2 @@
+ginkgo_create_cuda_mbench(array)
+ginkgo_create_cuda_mbench(executor)

--- a/cuda/micro_bench/base/array.cu
+++ b/cuda/micro_bench/base/array.cu
@@ -1,0 +1,280 @@
+/*******************************<GINKGO LICENSE>******************************
+Copyright (c) 2017-2021, the Ginkgo authors
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+******************************<GINKGO LICENSE>*******************************/
+
+#include <ginkgo/core/base/array.hpp>
+
+
+#include <cmath>
+#include <random>
+#include <type_traits>
+
+
+#include <benchmark/benchmark.h>
+
+
+#include <ginkgo/core/base/exception.hpp>
+
+
+using exec_ptr = std::shared_ptr<gko::Executor>;
+
+
+class Array : public benchmark::Fixture {
+public:
+    void SetUp(const ::benchmark::State &state)
+    {
+        exec = gko::OmpExecutor::create();
+    }
+
+    void TearDown(const ::benchmark::State &state)
+    {
+        if (exec != nullptr) {
+            // ensure that previous calls finished and didn't throw an error
+            exec->synchronize();
+        }
+    }
+
+    exec_ptr exec;
+    std::uniform_int_distribution<> dis{1, 100};
+    std::mt19937 gen{};
+};
+
+
+BENCHMARK_F(Array, CreateWithoutExecutor)(benchmark::State &state)
+{
+    for (auto _ : state) {
+        gko::Array<int> a;
+    }
+}
+
+
+BENCHMARK_F(Array, CreateWithExecutor)(benchmark::State &state)
+{
+    auto cuda = gko::CudaExecutor::create(0, this->exec);
+    for (auto _ : state) {
+        gko::Array<int> a(cuda);
+    }
+}
+
+
+BENCHMARK_DEFINE_F(Array, CreateFromDataOnExecutor)(benchmark::State &state)
+{
+    auto cuda = gko::CudaExecutor::create(0, this->exec);
+    gko::size_type size = state.range(0);
+    for (auto _ : state) {
+        gko::Array<int> a{cuda, size, cuda->template alloc<int>(size)};
+    }
+}
+
+BENCHMARK_REGISTER_F(Array, CreateFromDataOnExecutor)
+    ->RangeMultiplier(8)
+    ->Range(64, 64 << 10);
+
+
+BENCHMARK_DEFINE_F(Array, CreateFromRange)(benchmark::State &state)
+{
+    using std::begin;
+    auto cuda = gko::CudaExecutor::create(0, this->exec);
+    auto size = static_cast<long>(state.range(0));
+    auto data = std::vector<long>{size, size + 7};
+    for (auto _ : state) {
+        gko::Array<long> a{cuda, begin(data), end(data)};
+    }
+}
+
+BENCHMARK_REGISTER_F(Array, CreateFromRange)
+    ->RangeMultiplier(8)
+    ->Range(64, 64 << 10);
+
+
+BENCHMARK_DEFINE_F(Array, CopyConstructFromHost)(benchmark::State &state)
+{
+    gko::size_type size = state.range(0);
+    auto cuda = gko::CudaExecutor::create(0, this->exec);
+    auto x = gko::Array<int>{cuda->get_master(), size};
+    for (auto _ : state) {
+        gko::Array<int> a(cuda, x);
+    }
+}
+
+BENCHMARK_REGISTER_F(Array, CopyConstructFromHost)
+    ->RangeMultiplier(8)
+    ->Range(64, 64 << 10);
+
+
+BENCHMARK_DEFINE_F(Array, CopyConstructFromDevice)(benchmark::State &state)
+{
+    gko::size_type size = state.range(0);
+    auto cuda = gko::CudaExecutor::create(0, this->exec);
+    auto x = gko::Array<int>{cuda, size};
+    for (auto _ : state) {
+        gko::Array<int> a(x);
+    }
+}
+
+BENCHMARK_REGISTER_F(Array, CopyConstructFromDevice)
+    ->RangeMultiplier(8)
+    ->Range(64, 64 << 10);
+
+
+BENCHMARK_DEFINE_F(Array, MoveConstructFromHost)(benchmark::State &state)
+{
+    gko::size_type size = state.range(0);
+    auto cuda = gko::CudaExecutor::create(0, this->exec);
+    auto x = gko::Array<int>{cuda->get_master(), size};
+    for (auto _ : state) {
+        gko::Array<int> a(cuda, std::move(x));
+    }
+}
+
+BENCHMARK_REGISTER_F(Array, MoveConstructFromHost)
+    ->RangeMultiplier(8)
+    ->Range(64, 64 << 10);
+
+
+BENCHMARK_DEFINE_F(Array, MoveConstructFromDevice)(benchmark::State &state)
+{
+    gko::size_type size = state.range(0);
+    auto cuda = gko::CudaExecutor::create(0, this->exec);
+    auto x = gko::Array<int>{cuda, size};
+    for (auto _ : state) {
+        gko::Array<int> a(std::move(x));
+    }
+}
+
+BENCHMARK_REGISTER_F(Array, MoveConstructFromDevice)
+    ->RangeMultiplier(8)
+    ->Range(64, 64 << 10);
+
+
+BENCHMARK_DEFINE_F(Array, CopyAssignFromHost)(benchmark::State &state)
+{
+    gko::size_type size = state.range(0);
+    auto cuda = gko::CudaExecutor::create(0, this->exec);
+    auto x1 = gko::Array<int>{cuda, size};
+    auto x2 = gko::Array<int>{cuda->get_master(), size + 2};
+    for (auto _ : state) {
+        x1 = x2;
+    }
+}
+
+BENCHMARK_REGISTER_F(Array, CopyAssignFromHost)
+    ->RangeMultiplier(8)
+    ->Range(64, 64 << 10);
+
+
+BENCHMARK_DEFINE_F(Array, CopyAssignFromDevice)(benchmark::State &state)
+{
+    gko::size_type size = state.range(0);
+    auto cuda = gko::CudaExecutor::create(0, this->exec);
+    auto x1 = gko::Array<int>{cuda, size};
+    auto x2 = gko::Array<int>{cuda, size + 2};
+    for (auto _ : state) {
+        x1 = x2;
+    }
+}
+
+BENCHMARK_REGISTER_F(Array, CopyAssignFromDevice)
+    ->RangeMultiplier(8)
+    ->Range(64, 64 << 10);
+
+
+BENCHMARK_DEFINE_F(Array, MoveAssignFromHost)(benchmark::State &state)
+{
+    gko::size_type size = state.range(0);
+    auto cuda = gko::CudaExecutor::create(0, this->exec);
+    auto x1 = gko::Array<int>{cuda, size};
+    auto x2 = gko::Array<int>{cuda->get_master(), size + 3};
+    for (auto _ : state) {
+        x1 = std::move(x2);
+    }
+}
+
+BENCHMARK_REGISTER_F(Array, MoveAssignFromHost)
+    ->RangeMultiplier(8)
+    ->Range(64, 64 << 10);
+
+
+BENCHMARK_DEFINE_F(Array, MoveAssignFromDevice)(benchmark::State &state)
+{
+    gko::size_type size = state.range(0);
+    auto cuda = gko::CudaExecutor::create(0, this->exec);
+    auto x1 = gko::Array<int>{cuda, size};
+    auto x2 = gko::Array<int>{cuda, size + 3};
+    for (auto _ : state) {
+        x1 = std::move(x2);
+    }
+}
+
+BENCHMARK_REGISTER_F(Array, MoveAssignFromDevice)
+    ->RangeMultiplier(8)
+    ->Range(64, 64 << 10);
+
+
+BENCHMARK_DEFINE_F(Array, TempClone)(benchmark::State &state)
+{
+    gko::size_type size = state.range(0);
+    auto cuda = gko::CudaExecutor::create(0, this->exec);
+    auto x = gko::Array<int>{cuda->get_master(), size};
+    for (auto _ : state) {
+        auto tmp_clone = make_temporary_clone(cuda, &x);
+    }
+}
+
+BENCHMARK_REGISTER_F(Array, TempClone)->RangeMultiplier(8)->Range(64, 64 << 10);
+
+
+BENCHMARK_DEFINE_F(Array, Clear)(benchmark::State &state)
+{
+    gko::size_type size = state.range(0);
+    auto cuda = gko::CudaExecutor::create(0, this->exec);
+    auto x = gko::Array<int>{cuda, size};
+    for (auto _ : state) {
+        x.clear();
+    }
+}
+
+BENCHMARK_REGISTER_F(Array, Clear)->RangeMultiplier(8)->Range(64, 64 << 10);
+
+
+BENCHMARK_DEFINE_F(Array, ResizeAndReset)(benchmark::State &state)
+{
+    gko::size_type size = state.range(0);
+    auto cuda = gko::CudaExecutor::create(0, this->exec);
+    auto x = gko::Array<int>{cuda, size};
+    for (auto _ : state) {
+        x.resize_and_reset(size + this->dis(this->gen));
+    }
+}
+
+BENCHMARK_REGISTER_F(Array, ResizeAndReset)
+    ->RangeMultiplier(8)
+    ->Range(64, 64 << 10);

--- a/cuda/micro_bench/base/executor.cu
+++ b/cuda/micro_bench/base/executor.cu
@@ -1,0 +1,111 @@
+/*******************************<GINKGO LICENSE>******************************
+Copyright (c) 2017-2021, the Ginkgo authors
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+******************************<GINKGO LICENSE>*******************************/
+
+#include <ginkgo/core/base/executor.hpp>
+
+
+#include <cmath>
+#include <random>
+#include <thread>
+#include <type_traits>
+
+
+#include <benchmark/benchmark.h>
+
+
+#include <ginkgo/core/base/exception.hpp>
+
+
+using exec_ptr = std::shared_ptr<gko::Executor>;
+
+
+class ExampleOperation : public gko::Operation {
+public:
+    explicit ExampleOperation(int &val) : value(val) {}
+    void run(std::shared_ptr<const gko::OmpExecutor>) const override
+    {
+        value = 1;
+    }
+    void run(std::shared_ptr<const gko::CudaExecutor>) const override
+    {
+        value = 2;
+    }
+    void run(std::shared_ptr<const gko::HipExecutor>) const override
+    {
+        value = 3;
+    }
+    void run(std::shared_ptr<const gko::DpcppExecutor>) const override
+    {
+        value = 4;
+    }
+    void run(std::shared_ptr<const gko::ReferenceExecutor>) const override
+    {
+        value = 5;
+    }
+
+    int &value;
+};
+
+
+template <typename ExecCreate>
+static void executor_create(benchmark::State &st, ExecCreate &&exec_create)
+{
+    for (auto _ : st) {
+        exec_create();
+    }
+}
+
+BENCHMARK_CAPTURE(executor_create, Cuda, []() {
+    auto exec = gko::CudaExecutor::create(0, gko::OmpExecutor::create());
+});
+
+
+template <typename ExecCreate, typename ExecRun>
+static void executor_run(benchmark::State &st, ExecCreate &&create,
+                         ExecRun &&run)
+{
+    exec_ptr exec;
+    create(exec);
+    for (auto _ : st) {
+        run(exec);
+    }
+}
+
+BENCHMARK_CAPTURE(
+    executor_run, Cuda,
+    [](exec_ptr &exec) {
+        exec = gko::CudaExecutor::create(0, gko::OmpExecutor::create());
+    },
+    [](exec_ptr &exec) {
+        int value = 0;
+        exec->run(ExampleOperation(value));
+    });

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -25,6 +25,12 @@ else()
     add_subdirectory(dummy-hook)
 endif()
 
+if(GINKGO_BUILD_MICRO_BENCHMARKS)
+    if (NOT gbench_FOUND)
+        add_subdirectory(gbench)
+    endif()
+endif()
+
 if(GINKGO_BUILD_BENCHMARKS)
     if (NOT gflags_FOUND)
         add_subdirectory(gflags)

--- a/third_party/gbench/CMakeLists.txt
+++ b/third_party/gbench/CMakeLists.txt
@@ -1,0 +1,35 @@
+# ginkgo_load_git_package(gbench_external
+#         "https://github.com/google/benchmark.git"
+#         "73d4d5e8d6d449fc8663765a42aa8aeeee844489"
+#         "-DCMAKE_CXX_FLAGS=-fPIC"
+#         "-DBENCHMARK_ENABLE_TESTING=OFF"
+#         "-DCMAKE_CXX_FLAGS_DEBUG=${CMAKE_CXX_FLAGS_DEBUG}"
+#         "-DCMAKE_CXX_FLAGS_RELEASE=${CMAKE_CXX_FLAGS_RELEASE}"
+#         "-DCMAKE_C_FLAGS_DEBUG=${CMAKE_C_FLAGS_DEBUG}"
+#         "-DCMAKE_C_FLAGS_RELEASE=${CMAKE_C_FLAGS_RELEASE}")
+
+# ginkgo_add_external_target(GBench::GBench benchmark src/include build/src
+#    STATIC "d" gbench_external FALSE)
+# ginkgo_add_external_target(GBench::Main benchmark_main src/include build/src
+#     STATIC "d" gbench_external FALSE)
+
+message(STATUS "Fetching external GBench")
+include(FetchContent)
+FetchContent_Declare(
+    googlebenchmark
+    GIT_REPOSITORY https://github.com/google/benchmark.git
+    GIT_TAG        73d4d5e8d6d449fc8663765a42aa8aeeee844489
+)
+FetchContent_GetProperties(googlebenchmark)
+if(NOT googlebenchmark_POPULATED)
+    FetchContent_Populate(googlebenchmark)
+    add_subdirectory(${googlebenchmark_SOURCE_DIR} ${googlebenchmark_BINARY_DIR} EXCLUDE_FROM_ALL)
+endif()
+# make sure the tests DLLs are placed in the working path for CTest
+set_target_properties(benchmark benchmark_main PROPERTIES
+    RUNTIME_OUTPUT_DIRECTORY "${GINKGO_LIBRARY_PATH}"
+    ARCHIVE_OUTPUT_DIRECTORY "${GINKGO_LIBRARY_PATH}"
+    LIBRARY_OUTPUT_DIRECTORY "${GINKGO_LIBRARY_PATH}")
+# by default, the outdated targets are not being exported
+add_library(GBench::Main ALIAS benchmark_main)
+add_library(GBench::GBench ALIAS benchmark)


### PR DESCRIPTION
This PR adds some micro-benchmarking support to benchmark all the small functionalities of Ginkgo. For example, you can get information like the following:

1. Executor creation and run timings and overheads.
![mbench](https://user-images.githubusercontent.com/10301328/121667847-fd6d9380-caaa-11eb-8ed9-f463c400528e.png)

2. Array creation, copy, move timings and differences.
![array-mbench](https://user-images.githubusercontent.com/10301328/121668001-21c97000-caab-11eb-8ed4-84ee323e26aa.png)

3. More specific backend-specific timings as well are possible, example for arrays with CUDA:
![cuda-array-mbench](https://user-images.githubusercontent.com/10301328/121668099-3c034e00-caab-11eb-933b-21031d0c6d05.png)

Of course there are a few things that we need to discuss:

1. Timings for GPUs is from the host side, but that may be okay.
2. The repetitions for the function calls is not something that can be clearly controlled through google benchmark, which as discussed before is a downside of this.

I think this type of micro-benchmarking information can be really useful in detecting performance degradations and can atleast give us a hint if some commit/change regressed the performance.
