### PR TITLE
Benchmarks auto repetitions

### DIFF
--- a/benchmark/blas/blas.cpp
+++ b/benchmark/blas/blas.cpp
@@ -464,6 +464,8 @@ void apply_blas(const char *operation_name, std::shared_ptr<gko::Executor> exec,
                           allocator);
         add_or_set_member(blas_case[operation_name], "bandwidth", mem / runtime,
                           allocator);
+        add_or_set_member(blas_case[operation_name], "repetitions", repetitions,
+                          allocator);
 
         // compute and write benchmark data
         add_or_set_member(blas_case[operation_name], "completed", true,

--- a/benchmark/blas/blas.cpp
+++ b/benchmark/blas/blas.cpp
@@ -451,15 +451,12 @@ void apply_blas(const char *operation_name, std::shared_ptr<gko::Executor> exec,
         // timed run
         op->prepare();
         for (auto _ : ic.run()) {
-            exec->synchronize();
-            timer->tic();
             op->run();
-            timer->toc();
         }
-        const auto runtime = timer->compute_average_time();
+        const auto runtime = ic.compute_average_time();
         const auto flops = static_cast<double>(op->get_flops());
         const auto mem = static_cast<double>(op->get_memory());
-        const auto repetitions = timer->get_num_repetitions();
+        const auto repetitions = ic.get_num_repetitions();
         add_or_set_member(blas_case[operation_name], "time", runtime,
                           allocator);
         add_or_set_member(blas_case[operation_name], "flops", flops / runtime,

--- a/benchmark/blas/blas.cpp
+++ b/benchmark/blas/blas.cpp
@@ -437,8 +437,11 @@ void apply_blas(const char *operation_name, std::shared_ptr<gko::Executor> exec,
 
         auto op = operation_map[operation_name](exec, parse_dims(test_case));
 
+        auto timer = get_timer(exec, FLAGS_gpu_timer);
+        IterationControl ic(timer);
+
         // warm run
-        for (unsigned int i = 0; i < FLAGS_warmup; i++) {
+        for (auto _ : ic.warmup_run()) {
             op->prepare();
             exec->synchronize();
             op->run();
@@ -446,18 +449,17 @@ void apply_blas(const char *operation_name, std::shared_ptr<gko::Executor> exec,
         }
 
         // timed run
-        auto timer = get_timer(exec, FLAGS_gpu_timer);
-        const auto repetitions = get_repetitions();
-        for (unsigned int i = 0; i < repetitions; i++) {
-            op->prepare();
+        op->prepare();
+        for (auto _ : ic.run()) {
             exec->synchronize();
             timer->tic();
             op->run();
             timer->toc();
         }
-        auto runtime = timer->compute_average_time();
-        auto flops = static_cast<double>(op->get_flops());
-        auto mem = static_cast<double>(op->get_memory());
+        const auto runtime = timer->compute_average_time();
+        const auto flops = static_cast<double>(op->get_flops());
+        const auto mem = static_cast<double>(op->get_memory());
+        const auto repetitions = timer->get_num_repetitions();
         add_or_set_member(blas_case[operation_name], "time", runtime,
                           allocator);
         add_or_set_member(blas_case[operation_name], "flops", flops / runtime,

--- a/benchmark/blas/blas.cpp
+++ b/benchmark/blas/blas.cpp
@@ -447,7 +447,8 @@ void apply_blas(const char *operation_name, std::shared_ptr<gko::Executor> exec,
 
         // timed run
         auto timer = get_timer(exec, FLAGS_gpu_timer);
-        for (unsigned int i = 0; i < FLAGS_repetitions; i++) {
+        const auto repetitions = get_repetitions();
+        for (unsigned int i = 0; i < repetitions; i++) {
             op->prepare();
             exec->synchronize();
             timer->tic();

--- a/benchmark/conversions/conversions.cpp
+++ b/benchmark/conversions/conversions.cpp
@@ -80,8 +80,9 @@ void convert_matrix(const gko::LinOp *matrix_from, const char *format_to,
             matrix_to->clear();
         }
         auto timer = get_timer(exec, FLAGS_gpu_timer);
+        const auto repetitions = get_repetitions();
         // timed run
-        for (unsigned int i = 0; i < FLAGS_repetitions; i++) {
+        for (unsigned int i = 0; i < repetitions; i++) {
             exec->synchronize();
             timer->tic();
             matrix_to->copy_from(matrix_from);

--- a/benchmark/conversions/conversions.cpp
+++ b/benchmark/conversions/conversions.cpp
@@ -85,11 +85,7 @@ void convert_matrix(const gko::LinOp *matrix_from, const char *format_to,
         }
         // timed run
         for (auto _ : ic.run()) {
-            exec->synchronize();
-            timer->tic();
             matrix_to->copy_from(matrix_from);
-            timer->toc();
-            matrix_to->clear();
         }
         add_or_set_member(conversion_case[conversion_name], "time",
                           timer->compute_average_time(), allocator);

--- a/benchmark/conversions/conversions.cpp
+++ b/benchmark/conversions/conversions.cpp
@@ -72,17 +72,19 @@ void convert_matrix(const gko::LinOp *matrix_from, const char *format_to,
         gko::matrix_data<etype> data{gko::dim<2>{1, 1}, 1};
         auto matrix_to =
             share(formats::matrix_factory.at(format_to)(exec, data));
+
+        auto timer = get_timer(exec, FLAGS_gpu_timer);
+        IterationControl ic{timer};
+
         // warm run
-        for (unsigned int i = 0; i < FLAGS_warmup; i++) {
+        for (auto _ : ic.warmup_run()) {
             exec->synchronize();
             matrix_to->copy_from(matrix_from);
             exec->synchronize();
             matrix_to->clear();
         }
-        auto timer = get_timer(exec, FLAGS_gpu_timer);
-        const auto repetitions = get_repetitions();
         // timed run
-        for (unsigned int i = 0; i < repetitions; i++) {
+        for (auto _ : ic.run()) {
             exec->synchronize();
             timer->tic();
             matrix_to->copy_from(matrix_from);
@@ -92,7 +94,7 @@ void convert_matrix(const gko::LinOp *matrix_from, const char *format_to,
         add_or_set_member(conversion_case[conversion_name], "time",
                           timer->compute_average_time(), allocator);
         add_or_set_member(conversion_case[conversion_name], "repetitions",
-                          repetitions, allocator);
+                          timer->get_num_repetitions(), allocator);
 
         // compute and write benchmark data
         add_or_set_member(conversion_case[conversion_name], "completed", true,

--- a/benchmark/conversions/conversions.cpp
+++ b/benchmark/conversions/conversions.cpp
@@ -91,6 +91,8 @@ void convert_matrix(const gko::LinOp *matrix_from, const char *format_to,
         }
         add_or_set_member(conversion_case[conversion_name], "time",
                           timer->compute_average_time(), allocator);
+        add_or_set_member(conversion_case[conversion_name], "repetitions",
+                          repetitions, allocator);
 
         // compute and write benchmark data
         add_or_set_member(conversion_case[conversion_name], "completed", true,

--- a/benchmark/preconditioner/preconditioner.cpp
+++ b/benchmark/preconditioner/preconditioner.cpp
@@ -159,6 +159,7 @@ void run_preconditioner(const char *precond_name,
                               allocator);
         }
 
+        const auto repetitions = get_repetitions();
         {
             // fast run, gets total time
             auto x_clone = clone(x);
@@ -174,28 +175,27 @@ void run_preconditioner(const char *precond_name,
             exec->synchronize();
             generate_timer->tic();
             std::unique_ptr<gko::LinOp> precond_op;
-            for (auto i = 0u; i < FLAGS_repetitions; ++i) {
+            for (auto i = 0u; i < repetitions; ++i) {
                 precond_op = precond->generate(system_matrix);
             }
             generate_timer->toc();
 
             // the timer is out of the loops to reduce calling synchronize
             // overhead, so the timer does not know the number of repetitions.
-            auto generate_time =
-                generate_timer->get_total_time() / FLAGS_repetitions;
+            auto generate_time = generate_timer->get_total_time() / repetitions;
             add_or_set_member(this_precond_data["generate"], "time",
                               generate_time, allocator);
 
             exec->synchronize();
             apply_timer->tic();
-            for (auto i = 0u; i < FLAGS_repetitions; ++i) {
+            for (auto i = 0u; i < repetitions; ++i) {
                 precond_op->apply(lend(b), lend(x_clone));
             }
             apply_timer->toc();
 
             // the timer is out of the loops to reduce calling synchronize
             // overhead, so the timer does not know the number of repetitions.
-            auto apply_time = apply_timer->get_total_time() / FLAGS_repetitions;
+            auto apply_time = apply_timer->get_total_time() / repetitions;
             add_or_set_member(this_precond_data["apply"], "time", apply_time,
                               allocator);
         }
@@ -209,24 +209,24 @@ void run_preconditioner(const char *precond_name,
                 std::make_shared<OperationLogger>(exec, FLAGS_nested_names);
             exec->add_logger(gen_logger);
             std::unique_ptr<gko::LinOp> precond_op;
-            for (auto i = 0u; i < FLAGS_repetitions; ++i) {
+            for (auto i = 0u; i < repetitions; ++i) {
                 precond_op = precond->generate(system_matrix);
             }
             exec->remove_logger(gko::lend(gen_logger));
 
             gen_logger->write_data(this_precond_data["generate"]["components"],
-                                   allocator, FLAGS_repetitions);
+                                   allocator, repetitions);
 
             auto apply_logger =
                 std::make_shared<OperationLogger>(exec, FLAGS_nested_names);
             exec->add_logger(apply_logger);
-            for (auto i = 0u; i < FLAGS_repetitions; ++i) {
+            for (auto i = 0u; i < repetitions; ++i) {
                 precond_op->apply(lend(b), lend(x_clone));
             }
             exec->remove_logger(gko::lend(apply_logger));
 
             apply_logger->write_data(this_precond_data["apply"]["components"],
-                                     allocator, FLAGS_repetitions);
+                                     allocator, repetitions);
         }
 
         add_or_set_member(this_precond_data, "completed", true, allocator);

--- a/benchmark/preconditioner/preconditioner.cpp
+++ b/benchmark/preconditioner/preconditioner.cpp
@@ -159,7 +159,8 @@ void run_preconditioner(const char *precond_name,
                               allocator);
         }
 
-        const auto repetitions = get_repetitions();
+        const auto repetitions =
+            static_cast<unsigned int>(std::stoi(FLAGS_repetitions));
         {
             // fast run, gets total time
             auto x_clone = clone(x);
@@ -255,6 +256,12 @@ int main(int argc, char *argv[])
 
     std::string extra_information =
         "Running with preconditioners: " + FLAGS_preconditioners + "\n";
+    if (FLAGS_repetitions == "auto") {
+        FLAGS_repetitions = "10";
+        extra_information +=
+            "Warning: 'repetitions = auto' is not supported.\n"
+            "          Using the fallback value of 10 repetitions.\n";
+    }
     print_general_information(extra_information);
 
     auto exec = get_executor();

--- a/benchmark/solver/solver.cpp
+++ b/benchmark/solver/solver.cpp
@@ -473,7 +473,8 @@ void solve_system(const std::string &solver_name,
         // timed run
         auto generate_timer = get_timer(exec, FLAGS_gpu_timer);
         auto apply_timer = get_timer(exec, FLAGS_gpu_timer);
-        for (unsigned int i = 0; i < FLAGS_repetitions; i++) {
+        const auto repetitions = get_repetitions();
+        for (unsigned int i = 0; i < repetitions; i++) {
             auto x_clone = clone(x);
 
             exec->synchronize();
@@ -488,7 +489,7 @@ void solve_system(const std::string &solver_name,
             solver->apply(lend(b), lend(x_clone));
             apply_timer->toc();
 
-            if (b->get_size()[1] == 1 && i == FLAGS_repetitions - 1 &&
+            if (b->get_size()[1] == 1 && i == repetitions - 1 &&
                 !FLAGS_overhead) {
                 auto residual = compute_residual_norm(lend(system_matrix),
                                                       lend(b), lend(x_clone));

--- a/benchmark/solver/solver.cpp
+++ b/benchmark/solver/solver.cpp
@@ -501,6 +501,7 @@ void solve_system(const std::string &solver_name,
                           generate_timer->compute_average_time(), allocator);
         add_or_set_member(solver_json["apply"], "time",
                           apply_timer->compute_average_time(), allocator);
+        add_or_set_member(solver_json, "repetitions", repetitions, allocator);
 
         // compute and write benchmark data
         add_or_set_member(solver_json, "completed", true, allocator);

--- a/benchmark/solver/solver.cpp
+++ b/benchmark/solver/solver.cpp
@@ -399,8 +399,7 @@ void solve_system(const std::string &solver_name,
                               allocator);
         }
 
-        auto apply_timer = get_timer(exec, FLAGS_gpu_timer);
-        IterationControl ic{apply_timer};
+        IterationControl ic{get_timer(exec, FLAGS_gpu_timer)};
 
         // warm run
         auto it_logger = std::make_shared<IterationLogger>(exec);
@@ -475,6 +474,7 @@ void solve_system(const std::string &solver_name,
 
         // timed run
         auto generate_timer = get_timer(exec, FLAGS_gpu_timer);
+        auto apply_timer = ic.get_timer();
         auto x_clone = clone(x);
         for (auto status : ic.run(false)) {
             x_clone = clone(x);

--- a/benchmark/spmv/spmv.cpp
+++ b/benchmark/spmv/spmv.cpp
@@ -151,6 +151,8 @@ void apply_spmv(const char *format_name, std::shared_ptr<gko::Executor> exec,
         }
         add_or_set_member(spmv_case[format_name], "time",
                           timer->compute_average_time(), allocator);
+        add_or_set_member(spmv_case[format_name], "repetitions", repetitions,
+                          allocator);
 
         // compute and write benchmark data
         add_or_set_member(spmv_case[format_name], "completed", true, allocator);

--- a/benchmark/spmv/spmv.cpp
+++ b/benchmark/spmv/spmv.cpp
@@ -92,8 +92,7 @@ void apply_spmv(const char *format_name, std::shared_ptr<gko::Executor> exec,
                               max_relative_norm2, allocator);
         }
 
-        auto timer = get_timer(exec, FLAGS_gpu_timer);
-        IterationControl ic{timer};
+        IterationControl ic{get_timer(exec, FLAGS_gpu_timer)};
         // warm run
         for (auto _ : ic.warmup_run()) {
             auto x_clone = clone(x);
@@ -102,9 +101,7 @@ void apply_spmv(const char *format_name, std::shared_ptr<gko::Executor> exec,
             exec->synchronize();
         }
 
-        auto x_clone = clone(x);  // TODO: assure that cloning once is enough
-                                  // for guessing repetitions
-                                  // tuning run
+        // tuning run
 #ifdef GINKGO_BENCHMARK_ENABLE_TUNING
         auto &format_case = spmv_case[format_name];
         if (!format_case.HasMember("tuning")) {
@@ -129,12 +126,9 @@ void apply_spmv(const char *format_name, std::shared_ptr<gko::Executor> exec,
             gko::_tuned_value = val;
             auto tuning_timer = get_timer(exec, FLAGS_gpu_timer);
             IterationControl ic_tuning{tuning_timer};
+            auto x_clone = clone(x);
             for (auto _ : ic_tuning.run()) {
-                auto x_clone = clone(x);
-                exec->synchronize();
-                tuning_timer->tic();
                 system_matrix->apply(lend(b), lend(x_clone));
-                tuning_timer->toc();
             }
             tuning_case["time"].PushBack(tuning_timer->compute_average_time(),
                                          allocator);
@@ -146,17 +140,14 @@ void apply_spmv(const char *format_name, std::shared_ptr<gko::Executor> exec,
 #endif  // GINKGO_BENCHMARK_ENABLE_TUNING
 
         // timed run
+        auto x_clone = clone(x);
         for (auto _ : ic.run()) {
-            x_clone = clone(x);
-            exec->synchronize();
-            timer->tic();
             system_matrix->apply(lend(b), lend(x_clone));
-            timer->toc();
         }
         add_or_set_member(spmv_case[format_name], "time",
-                          timer->compute_average_time(), allocator);
+                          ic.compute_average_time(), allocator);
         add_or_set_member(spmv_case[format_name], "repetitions",
-                          timer->get_num_repetitions(), allocator);
+                          ic.get_num_repetitions(), allocator);
 
         // compute and write benchmark data
         add_or_set_member(spmv_case[format_name], "completed", true, allocator);

--- a/benchmark/spmv/spmv.cpp
+++ b/benchmark/spmv/spmv.cpp
@@ -99,6 +99,7 @@ void apply_spmv(const char *format_name, std::shared_ptr<gko::Executor> exec,
             exec->synchronize();
         }
 
+        const auto repetitions = get_repetitions();
         // tuning run
 #ifdef GINKGO_BENCHMARK_ENABLE_TUNING
         auto &format_case = spmv_case[format_name];
@@ -123,7 +124,7 @@ void apply_spmv(const char *format_name, std::shared_ptr<gko::Executor> exec,
             // variable is used.
             gko::_tuned_value = val;
             auto tuning_timer = get_timer(exec, FLAGS_gpu_timer);
-            for (unsigned int i = 0; i < FLAGS_repetitions; i++) {
+            for (unsigned int i = 0; i < repetitions; i++) {
                 auto x_clone = clone(x);
                 exec->synchronize();
                 tuning_timer->tic();
@@ -141,7 +142,7 @@ void apply_spmv(const char *format_name, std::shared_ptr<gko::Executor> exec,
 
         // timed run
         auto timer = get_timer(exec, FLAGS_gpu_timer);
-        for (unsigned int i = 0; i < FLAGS_repetitions; i++) {
+        for (unsigned int i = 0; i < repetitions; i++) {
             auto x_clone = clone(x);
             exec->synchronize();
             timer->tic();

--- a/benchmark/utils/general.hpp
+++ b/benchmark/utils/general.hpp
@@ -87,7 +87,7 @@ DEFINE_uint32(seed, 42, "Seed used for the random number generator");
 
 DEFINE_uint32(warmup, 2, "Warm-up repetitions");
 
-DEFINE_uint32(repetitions, 10,
+DEFINE_string(repetitions, "10",
               "Number of runs used to obtain an averaged result.");
 
 
@@ -433,5 +433,12 @@ gko::remove_complex<ValueType> compute_max_relative_norm2(
     return max_relative_norm2;
 }
 
+
+// parses the repetitions flag
+unsigned int get_repetitions()
+{
+    const std::string reps_str = FLAGS_repetitions;
+    return static_cast<unsigned int>(std::stoi(reps_str));
+}
 
 #endif  // GKO_BENCHMARK_UTILS_GENERAL_HPP_

--- a/benchmark/utils/timer.hpp
+++ b/benchmark/utils/timer.hpp
@@ -264,6 +264,7 @@ public:
 protected:
     void tic_impl() override
     {
+        exec_->synchronize();
         gko::cuda::device_guard g{id_};
         // Currently, gko::CudaExecutor always use default stream.
         GKO_ASSERT_NO_CUDA_ERRORS(cudaEventRecord(start_));
@@ -271,6 +272,7 @@ protected:
 
     double toc_impl() override
     {
+        exec_->synchronize();
         gko::cuda::device_guard g{id_};
         // Currently, gko::CudaExecutor always use default stream.
         GKO_ASSERT_NO_CUDA_ERRORS(cudaEventRecord(stop_));
@@ -330,6 +332,7 @@ public:
 protected:
     void tic_impl() override
     {
+        exec_->synchronize();
         gko::hip::device_guard g{id_};
         // Currently, gko::HipExecutor always use default stream.
         GKO_ASSERT_NO_HIP_ERRORS(hipEventRecord(start_));
@@ -337,6 +340,7 @@ protected:
 
     double toc_impl() override
     {
+        exec_->synchronize();
         gko::hip::device_guard g{id_};
         // Currently, gko::HipExecutor always use default stream.
         GKO_ASSERT_NO_HIP_ERRORS(hipEventRecord(stop_));

--- a/benchmark/utils/timer.hpp
+++ b/benchmark/utils/timer.hpp
@@ -272,7 +272,6 @@ protected:
 
     double toc_impl() override
     {
-        exec_->synchronize();
         gko::cuda::device_guard g{id_};
         // Currently, gko::CudaExecutor always use default stream.
         GKO_ASSERT_NO_CUDA_ERRORS(cudaEventRecord(stop_));
@@ -340,7 +339,6 @@ protected:
 
     double toc_impl() override
     {
-        exec_->synchronize();
         gko::hip::device_guard g{id_};
         // Currently, gko::HipExecutor always use default stream.
         GKO_ASSERT_NO_HIP_ERRORS(hipEventRecord(stop_));

--- a/benchmark/utils/timer.hpp
+++ b/benchmark/utils/timer.hpp
@@ -30,6 +30,10 @@ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ******************************<GINKGO LICENSE>*******************************/
 
+#ifndef GKO_BENCHMARK_UTILS_TIMER_HPP_
+#define GKO_BENCHMARK_UTILS_TIMER_HPP_
+
+
 #include <ginkgo/ginkgo.hpp>
 
 
@@ -385,3 +389,5 @@ std::shared_ptr<Timer> get_timer(std::shared_ptr<const gko::Executor> exec,
     // No cuda/hip executor available or no gpu_timer used
     return std::make_shared<CpuTimer>(exec);
 }
+
+#endif  // GKO_BENCHMARK_UTILS_TIMER_HPP_


### PR DESCRIPTION
This PR enables the automatic deduction of repetition number for the benchmarks. 

For small working sets, the benchmark timings may be too sensitive regarding outliers. With this PR the number of repetitions for the benchmark run is estimated such that the whole benchmark takes >=0.5s. This should result in more stable benchmarks for small problems.

If the repetitions are set to `auto` the warm-up step is skipped.

WIP: The PR enables the new behavior only for the **blas, conversion, spmv** benchmarks. 
Todo:
- [x] enable for solver, preconditioner bencharks
- [x] handle large benchmarks (one repetition takes >0.5s) gracefully
