### PR TITLE
Quiet OpenCV find_package

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -36,7 +36,7 @@ if(GINKGO_BUILD_EXTLIB_EXAMPLE)
     list(APPEND EXAMPLES_LIST external-lib-interfacing)
 endif()
 
-find_package(OpenCV)
+find_package(OpenCV QUIET)
 if(OpenCV_FOUND)
     list(APPEND EXAMPLES_LIST heat-equation)
 endif()

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -39,6 +39,8 @@ endif()
 find_package(OpenCV QUIET)
 if(OpenCV_FOUND)
     list(APPEND EXAMPLES_LIST heat-equation)
+else()
+    message(STATUS "No OpenCV found, disabling heat-equation example")
 endif()
 
 if(GINKGO_HAVE_PAPI_SDE)


### PR DESCRIPTION
We use OpenCV to generate the `heat-equation` video, but there is no FindOpenCV module available in CMake by default, so it attempts to find a `OpenCVConfig.cmake` instead.
This change avoids printing a lengthy and maybe surprising error message:
```
CMake Warning at examples/CMakeLists.txt:39 (find_package):
  By not providing "FindOpenCV.cmake" in CMAKE_MODULE_PATH this project has
  asked CMake to find a package configuration file provided by "OpenCV", but
  CMake did not find one.

  Could not find a package configuration file provided by "OpenCV" with any
  of the following names:

    OpenCVConfig.cmake
    opencv-config.cmake

  Add the installation prefix of "OpenCV" to CMAKE_PREFIX_PATH or set
  "OpenCV_DIR" to a directory containing one of the above files.  If "OpenCV"
  provides a separate development package or SDK, be sure it has been
  installed.
  ```