### PR TITLE
Run cuda-memcheck with CUDA 10.1 on amdci

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -976,7 +976,10 @@ cudamemcheck:
   stage: QoS_tools
   extends:
     - .deploy_condition
-    - .use_gko-cuda110-gnu9-llvm9-intel2020
+  image: ginkgohub/cuda:101-gnu8-llvm10-intel2019
+  tags:
+    - private_ci
+    - nvidia-gpu
   before_script: *default_before_script
   script:
     - ctest -V -S cmake/CTestScript.cmake -DCTEST_BUILD_CONFIGURATION=RelWithDebInfo


### PR DESCRIPTION
HIP doesn't support CUDA 11.*, so the fix in #793 was incomplete