### PR TITLE
Core solver tests for all backends are moved to a common function

### DIFF
--- a/core/test/utils/batch_test_utils.hpp
+++ b/core/test/utils/batch_test_utils.hpp
@@ -132,4 +132,4 @@ void test_solve_without_scaling(
 }  // namespace gko
 
 
-#endif  // GKO_CORE_TEST_BATCH_TEST_UTILS_H_
+#endif  // GKO_CORE_TEST_UTILS_BATCH_TEST_UTILS_HPP_

--- a/core/test/utils/batch_test_utils.hpp
+++ b/core/test/utils/batch_test_utils.hpp
@@ -1,0 +1,135 @@
+/*******************************<GINKGO LICENSE>******************************
+Copyright (c) 2017-2021, the Ginkgo authors
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+******************************<GINKGO LICENSE>*******************************/
+
+#ifndef GKO_CORE_TEST_UTILS_BATCH_TEST_UTILS_HPP_
+#define GKO_CORE_TEST_UTILS_BATCH_TEST_UTILS_HPP_
+
+
+#include <ginkgo/core/log/batch_convergence.hpp>
+#include <ginkgo/core/solver/batch_richardson.hpp>
+
+
+#include "core/test/utils.hpp"
+#include "core/test/utils/batch.hpp"
+
+
+namespace gko {
+namespace test {
+
+
+template <typename SolverType>
+void test_solve_without_scaling(
+    std::shared_ptr<const Executor> exec, const size_t nbatch, const int nrows,
+    const int nrhs,
+    const remove_complex<typename SolverType::value_type> res_tol,
+    const int maxits, const typename SolverType::Factory *const factory,
+    const double true_res_norm_slack_factor = 1.0)
+{
+    using T = typename SolverType::value_type;
+    using RT = typename gko::remove_complex<T>;
+    using Dense = gko::matrix::BatchDense<T>;
+    using RDense = gko::matrix::BatchDense<RT>;
+    using Mtx = typename gko::matrix::BatchCsr<T>;
+    using factory_type = typename SolverType::Factory;
+    std::shared_ptr<gko::ReferenceExecutor> refexec =
+        gko::ReferenceExecutor::create();
+    std::shared_ptr<Mtx> ref_mtx =
+        gko::test::create_poisson1d_batch<T>(refexec, nrows, nbatch);
+    std::shared_ptr<Mtx> mtx = Mtx::create(exec);
+    mtx->copy_from(ref_mtx.get());
+    auto solver = factory->generate(mtx);
+    std::shared_ptr<const gko::log::BatchConvergence<T>> logger =
+        gko::log::BatchConvergence<T>::create(exec);
+    auto ref_b = Dense::create(
+        refexec, gko::batch_dim<>(nbatch, gko::dim<2>(nrows, nrhs)));
+    auto ref_x = Dense::create_with_config_of(ref_b.get());
+    auto ref_bnorm =
+        RDense::create(refexec, gko::batch_dim<>(nbatch, gko::dim<2>(1, nrhs)));
+    for (size_t ib = 0; ib < nbatch; ib++) {
+        for (int j = 0; j < nrhs; j++) {
+            ref_bnorm->at(ib, 0, j) = gko::zero<RT>();
+            const T val = 1.0 + std::cos(ib / 2.0 - j / 4.0);
+            for (int i = 0; i < nrows; i++) {
+                ref_b->at(ib, i, j) = val;
+                ref_x->at(ib, i, j) = 0.0;
+                ref_bnorm->at(ib, 0, j) += gko::squared_norm(val);
+            }
+            ref_bnorm->at(ib, 0, j) = std::sqrt(ref_bnorm->at(ib, 0, j));
+        }
+    }
+    auto x = Dense::create(exec);
+    x->copy_from(ref_x.get());
+    auto b = Dense::create(exec);
+    b->copy_from(ref_b.get());
+    auto alpha = gko::batch_initialize<Dense>(nbatch, {-1.0}, exec);
+    auto beta = gko::batch_initialize<Dense>(nbatch, {1.0}, exec);
+    if (exec != nullptr) {
+        ASSERT_NO_THROW(exec->synchronize());
+    }
+
+    solver->add_logger(logger);
+    solver->apply(b.get(), x.get());
+    solver->remove_logger(logger.get());
+
+    auto res = Dense::create(refexec, ref_b->get_size());
+    res->copy_from(ref_b.get());
+    ref_x->copy_from(x.get());
+    auto ref_alpha = gko::batch_initialize<Dense>(nbatch, {-1.0}, refexec);
+    auto ref_beta = gko::batch_initialize<Dense>(nbatch, {1.0}, refexec);
+    ref_mtx->apply(ref_alpha.get(), ref_x.get(), ref_beta.get(), res.get());
+    auto ref_rnorm =
+        RDense::create(refexec, gko::batch_dim<>(nbatch, gko::dim<2>(1, nrhs)));
+    res->compute_norm2(ref_rnorm.get());
+    auto r_iter_array = logger->get_num_iterations();
+    auto r_logged_res = logger->get_residual_norm();
+    for (size_t ib = 0; ib < nbatch; ib++) {
+        for (int j = 0; j < nrhs; j++) {
+            ASSERT_GT(r_iter_array.get_const_data()[ib * nrhs + j], 0);
+            ASSERT_LE(r_iter_array.get_const_data()[ib * nrhs + j], maxits - 1);
+            ASSERT_LE(r_logged_res->at(ib, 0, j) / ref_bnorm->at(ib, 0, j),
+                      res_tol);
+            ASSERT_LE(ref_rnorm->at(ib, 0, j) / ref_bnorm->at(ib, 0, j),
+                      true_res_norm_slack_factor * res_tol);
+            ASSERT_LE(
+                abs(r_logged_res->at(ib, 0, j) - ref_rnorm->at(ib, 0, j)),
+                res_tol * ref_bnorm->at(ib, 0, j) *
+                    (abs(true_res_norm_slack_factor - 1) + 10 * r<T>::value));
+        }
+    }
+}
+
+
+}  // namespace test
+}  // namespace gko
+
+
+#endif  // GKO_CORE_TEST_BATCH_TEST_UTILS_H_

--- a/cuda/test/solver/batch_bicgstab_kernels.cpp
+++ b/cuda/test/solver/batch_bicgstab_kernels.cpp
@@ -42,7 +42,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "core/solver/batch_bicgstab_kernels.hpp"
 #include "core/test/utils.hpp"
-#include "core/test/utils/batch.hpp"
+#include "core/test/utils/batch_test_utils.hpp"
 
 
 namespace {
@@ -430,15 +430,12 @@ TEST(BatchBicgstab, CanSolveWithoutScaling)
     using T = std::complex<float>;
     using RT = typename gko::remove_complex<T>;
     using Solver = gko::solver::BatchBicgstab<T>;
-    using Dense = gko::matrix::BatchDense<T>;
-    using RDense = gko::matrix::BatchDense<RT>;
-    using Mtx = typename gko::matrix::BatchCsr<T>;
-    const RT tol = 1e-3;
+    const RT tol = 1e-5;
     std::shared_ptr<gko::ReferenceExecutor> refexec =
         gko::ReferenceExecutor::create();
     std::shared_ptr<const gko::CudaExecutor> exec =
         gko::CudaExecutor::create(0, refexec);
-    const int maxits = 10000;
+    const int maxits = 5000;
     auto batchbicgstab_factory =
         Solver::build()
             .with_max_iterations(maxits)
@@ -446,69 +443,11 @@ TEST(BatchBicgstab, CanSolveWithoutScaling)
             .with_tolerance_type(gko::stop::batch::ToleranceType::relative)
             .with_preconditioner(gko::preconditioner::batch::type::jacobi)
             .on(exec);
-    const int nrows = 40;
+    const int nrows = 29;
     const size_t nbatch = 3;
-    std::shared_ptr<Mtx> ref_mtx =
-        gko::test::create_poisson1d_batch<T>(refexec, nrows, nbatch);
-    std::shared_ptr<Mtx> mtx = Mtx::create(exec);
-    mtx->copy_from(ref_mtx.get());
-    auto solver = batchbicgstab_factory->generate(mtx);
-    std::shared_ptr<const gko::log::BatchConvergence<T>> logger =
-        gko::log::BatchConvergence<T>::create(exec);
     const int nrhs = 5;
-    auto ref_b = Dense::create(
-        refexec, gko::batch_dim<>(nbatch, gko::dim<2>(nrows, nrhs)));
-    auto ref_x = Dense::create_with_config_of(ref_b.get());
-    auto ref_res = Dense::create_with_config_of(ref_b.get());
-    auto ref_bnorm =
-        RDense::create(refexec, gko::batch_dim<>(nbatch, gko::dim<2>(1, nrhs)));
-    for (size_t ib = 0; ib < nbatch; ib++) {
-        for (int j = 0; j < nrhs; j++) {
-            ref_bnorm->at(ib, 0, j) = gko::zero<RT>();
-            const T val = 1.0 + std::cos(ib / 2.0 - j / 4.0);
-            for (int i = 0; i < nrows; i++) {
-                ref_b->at(ib, i, j) = val;
-                ref_x->at(ib, i, j) = 0.0;
-                ref_res->at(ib, i, j) = val;
-                ref_bnorm->at(ib, 0, j) += gko::squared_norm(val);
-            }
-            ref_bnorm->at(ib, 0, j) = std::sqrt(ref_bnorm->at(ib, 0, j));
-        }
-    }
-    auto x = Dense::create(exec);
-    x->copy_from(ref_x.get());
-    auto res = Dense::create(exec);
-    res->copy_from(ref_res.get());
-    auto b = Dense::create(exec);
-    b->copy_from(ref_b.get());
-    auto alpha = gko::batch_initialize<Dense>(nbatch, {-1.0}, exec);
-    auto beta = gko::batch_initialize<Dense>(nbatch, {1.0}, exec);
-    if (exec != nullptr) {
-        ASSERT_NO_THROW(exec->synchronize());
-    }
-
-    solver->add_logger(logger);
-    solver->apply(b.get(), x.get());
-    solver->remove_logger(logger.get());
-
-    mtx->apply(alpha.get(), x.get(), beta.get(), res.get());
-    auto rnorm =
-        RDense::create(exec, gko::batch_dim<>(nbatch, gko::dim<2>(1, nrhs)));
-    res->compute_norm2(rnorm.get());
-    auto ref_rnorm = RDense::create(refexec);
-    ref_rnorm->copy_from(rnorm.get());
-    auto r_iter_array = logger->get_num_iterations();
-    auto r_logged_res = logger->get_residual_norm();
-    ASSERT_NO_THROW(exec->synchronize());
-    for (size_t ib = 0; ib < nbatch; ib++) {
-        for (int j = 0; j < nrhs; j++) {
-            ASSERT_LE(r_logged_res->at(ib, 0, j) / ref_bnorm->at(ib, 0, j),
-                      tol);
-            ASSERT_GT(r_iter_array.get_const_data()[ib * nrhs + j], 0);
-            ASSERT_LE(r_iter_array.get_const_data()[ib * nrhs + j], maxits);
-        }
-    }
-    GKO_ASSERT_BATCH_MTX_NEAR(r_logged_res, ref_rnorm, 100 * tol);
+    gko::test::test_solve_without_scaling<Solver>(
+        exec, nbatch, nrows, nrhs, tol, maxits, batchbicgstab_factory.get(), 5);
 }
 
 }  // namespace

--- a/cuda/test/solver/batch_bicgstab_kernels.cpp
+++ b/cuda/test/solver/batch_bicgstab_kernels.cpp
@@ -30,8 +30,8 @@ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ******************************<GINKGO LICENSE>*******************************/
 
-
 #include <ginkgo/core/solver/batch_bicgstab.hpp>
+
 
 #include <gtest/gtest.h>
 
@@ -39,6 +39,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <ginkgo/core/base/exception.hpp>
 #include <ginkgo/core/base/executor.hpp>
 #include <ginkgo/core/log/batch_convergence.hpp>
+
 
 #include "core/solver/batch_bicgstab_kernels.hpp"
 #include "core/test/utils.hpp"

--- a/cuda/test/solver/batch_cg_kernels.cpp
+++ b/cuda/test/solver/batch_cg_kernels.cpp
@@ -41,7 +41,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "core/solver/batch_cg_kernels.hpp"
 #include "core/test/utils.hpp"
-#include "core/test/utils/batch.hpp"
+#include "core/test/utils/batch_test_utils.hpp"
 
 namespace {
 
@@ -429,15 +429,12 @@ TEST(BatchCg, CanSolveWithoutScaling)
     using T = std::complex<float>;
     using RT = typename gko::remove_complex<T>;
     using Solver = gko::solver::BatchCg<T>;
-    using Dense = gko::matrix::BatchDense<T>;
-    using RDense = gko::matrix::BatchDense<RT>;
-    using Mtx = typename gko::matrix::BatchCsr<T>;
-    const RT tol = 1e-2;
+    const RT tol = 1e-5;
     std::shared_ptr<gko::ReferenceExecutor> refexec =
         gko::ReferenceExecutor::create();
     std::shared_ptr<const gko::CudaExecutor> exec =
         gko::CudaExecutor::create(0, refexec);
-    const int maxits = 10000;
+    const int maxits = 100;
     auto batchcg_factory =
         Solver::build()
             .with_max_iterations(maxits)
@@ -445,69 +442,11 @@ TEST(BatchCg, CanSolveWithoutScaling)
             .with_tolerance_type(gko::stop::batch::ToleranceType::relative)
             .with_preconditioner(gko::preconditioner::batch::type::jacobi)
             .on(exec);
-    const int nrows = 40;
+    const int nrows = 38;
     const size_t nbatch = 3;
-    std::shared_ptr<Mtx> ref_mtx =
-        gko::test::create_poisson1d_batch<T>(refexec, nrows, nbatch);
-    std::shared_ptr<Mtx> mtx = Mtx::create(exec);
-    mtx->copy_from(ref_mtx.get());
-    auto solver = batchcg_factory->generate(mtx);
-    std::shared_ptr<const gko::log::BatchConvergence<T>> logger =
-        gko::log::BatchConvergence<T>::create(exec);
     const int nrhs = 5;
-    auto ref_b = Dense::create(
-        refexec, gko::batch_dim<>(nbatch, gko::dim<2>(nrows, nrhs)));
-    auto ref_x = Dense::create_with_config_of(ref_b.get());
-    auto ref_res = Dense::create_with_config_of(ref_b.get());
-    auto ref_bnorm =
-        RDense::create(refexec, gko::batch_dim<>(nbatch, gko::dim<2>(1, nrhs)));
-    for (size_t ib = 0; ib < nbatch; ib++) {
-        for (int j = 0; j < nrhs; j++) {
-            ref_bnorm->at(ib, 0, j) = gko::zero<RT>();
-            const T val = 1.0 + std::cos(ib / 2.0 - j / 4.0);
-            for (int i = 0; i < nrows; i++) {
-                ref_b->at(ib, i, j) = val;
-                ref_x->at(ib, i, j) = 0.0;
-                ref_res->at(ib, i, j) = val;
-                ref_bnorm->at(ib, 0, j) += gko::squared_norm(val);
-            }
-            ref_bnorm->at(ib, 0, j) = std::sqrt(ref_bnorm->at(ib, 0, j));
-        }
-    }
-    auto x = Dense::create(exec);
-    x->copy_from(ref_x.get());
-    auto res = Dense::create(exec);
-    res->copy_from(ref_res.get());
-    auto b = Dense::create(exec);
-    b->copy_from(ref_b.get());
-    auto alpha = gko::batch_initialize<Dense>(nbatch, {-1.0}, exec);
-    auto beta = gko::batch_initialize<Dense>(nbatch, {1.0}, exec);
-    if (exec != nullptr) {
-        ASSERT_NO_THROW(exec->synchronize());
-    }
-
-    solver->add_logger(logger);
-    solver->apply(b.get(), x.get());
-    solver->remove_logger(logger.get());
-
-    mtx->apply(alpha.get(), x.get(), beta.get(), res.get());
-    auto rnorm =
-        RDense::create(exec, gko::batch_dim<>(nbatch, gko::dim<2>(1, nrhs)));
-    res->compute_norm2(rnorm.get());
-    auto ref_rnorm = RDense::create(refexec);
-    ref_rnorm->copy_from(rnorm.get());
-    auto r_iter_array = logger->get_num_iterations();
-    auto r_logged_res = logger->get_residual_norm();
-    ASSERT_NO_THROW(exec->synchronize());
-    for (size_t ib = 0; ib < nbatch; ib++) {
-        for (int j = 0; j < nrhs; j++) {
-            ASSERT_LE(r_logged_res->at(ib, 0, j) / ref_bnorm->at(ib, 0, j),
-                      tol);
-            ASSERT_GT(r_iter_array.get_const_data()[ib * nrhs + j], 0);
-            ASSERT_LE(r_iter_array.get_const_data()[ib * nrhs + j], maxits);
-        }
-    }
-    GKO_ASSERT_BATCH_MTX_NEAR(r_logged_res, ref_rnorm, 200 * tol);
+    gko::test::test_solve_without_scaling<Solver>(
+        exec, nbatch, nrows, nrhs, tol, maxits, batchcg_factory.get(), 10);
 }
 
 

--- a/cuda/test/solver/batch_cg_kernels.cpp
+++ b/cuda/test/solver/batch_cg_kernels.cpp
@@ -32,12 +32,14 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <ginkgo/core/solver/batch_cg.hpp>
 
+
 #include <gtest/gtest.h>
 
 
 #include <ginkgo/core/base/exception.hpp>
 #include <ginkgo/core/base/executor.hpp>
 #include <ginkgo/core/log/batch_convergence.hpp>
+
 
 #include "core/solver/batch_cg_kernels.hpp"
 #include "core/test/utils.hpp"

--- a/cuda/test/solver/batch_gmres_kernels.cpp
+++ b/cuda/test/solver/batch_gmres_kernels.cpp
@@ -32,12 +32,14 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <ginkgo/core/solver/batch_gmres.hpp>
 
+
 #include <gtest/gtest.h>
 
 
 #include <ginkgo/core/base/exception.hpp>
 #include <ginkgo/core/base/executor.hpp>
 #include <ginkgo/core/log/batch_convergence.hpp>
+
 
 #include "core/solver/batch_gmres_kernels.hpp"
 #include "core/test/utils.hpp"

--- a/cuda/test/solver/batch_gmres_kernels.cpp
+++ b/cuda/test/solver/batch_gmres_kernels.cpp
@@ -41,7 +41,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "core/solver/batch_gmres_kernels.hpp"
 #include "core/test/utils.hpp"
-#include "core/test/utils/batch.hpp"
+#include "core/test/utils/batch_test_utils.hpp"
 
 namespace {
 
@@ -431,86 +431,25 @@ TEST(BatchGmres, CanSolveWithoutScaling)
     using T = std::complex<double>;
     using RT = typename gko::remove_complex<T>;
     using Solver = gko::solver::BatchGmres<T>;
-    using Dense = gko::matrix::BatchDense<T>;
-    using RDense = gko::matrix::BatchDense<RT>;
-    using Mtx = typename gko::matrix::BatchCsr<T>;
-    const RT tol = 1e-4;
+    const RT tol = 1e-8;
     std::shared_ptr<gko::ReferenceExecutor> refexec =
         gko::ReferenceExecutor::create();
     std::shared_ptr<const gko::CudaExecutor> exec =
         gko::CudaExecutor::create(0, refexec);
-    const int maxits = 10000;
+    const int maxits = 5000;
     auto batchgmres_factory =
         Solver::build()
             .with_max_iterations(maxits)
             .with_rel_residual_tol(tol)
             .with_tolerance_type(gko::stop::batch::ToleranceType::relative)
-            .with_preconditioner(gko::preconditioner::batch::type::jacobi)
-            .with_restart(2)
+            .with_preconditioner(gko::preconditioner::batch::type::none)
+            .with_restart(5)
             .on(exec);
-    const int nrows = 40;
+    const int nrows = 23;
     const size_t nbatch = 3;
-    std::shared_ptr<Mtx> ref_mtx =
-        gko::test::create_poisson1d_batch<T>(refexec, nrows, nbatch);
-    std::shared_ptr<Mtx> mtx = Mtx::create(exec);
-    mtx->copy_from(ref_mtx.get());
-    auto solver = batchgmres_factory->generate(mtx);
-    std::shared_ptr<const gko::log::BatchConvergence<T>> logger =
-        gko::log::BatchConvergence<T>::create(exec);
     const int nrhs = 5;
-    auto ref_b = Dense::create(
-        refexec, gko::batch_dim<>(nbatch, gko::dim<2>(nrows, nrhs)));
-    auto ref_x = Dense::create_with_config_of(ref_b.get());
-    auto ref_res = Dense::create_with_config_of(ref_b.get());
-    auto ref_bnorm =
-        RDense::create(refexec, gko::batch_dim<>(nbatch, gko::dim<2>(1, nrhs)));
-    for (size_t ib = 0; ib < nbatch; ib++) {
-        for (int j = 0; j < nrhs; j++) {
-            ref_bnorm->at(ib, 0, j) = gko::zero<RT>();
-            const T val = 1.0 + std::cos(ib / 2.0 - j / 4.0);
-            for (int i = 0; i < nrows; i++) {
-                ref_b->at(ib, i, j) = val;
-                ref_x->at(ib, i, j) = 0.0;
-                ref_res->at(ib, i, j) = val;
-                ref_bnorm->at(ib, 0, j) += gko::squared_norm(val);
-            }
-            ref_bnorm->at(ib, 0, j) = std::sqrt(ref_bnorm->at(ib, 0, j));
-        }
-    }
-    auto x = Dense::create(exec);
-    x->copy_from(ref_x.get());
-    auto res = Dense::create(exec);
-    res->copy_from(ref_res.get());
-    auto b = Dense::create(exec);
-    b->copy_from(ref_b.get());
-    auto alpha = gko::batch_initialize<Dense>(nbatch, {-1.0}, exec);
-    auto beta = gko::batch_initialize<Dense>(nbatch, {1.0}, exec);
-    if (exec != nullptr) {
-        ASSERT_NO_THROW(exec->synchronize());
-    }
-
-    solver->add_logger(logger);
-    solver->apply(b.get(), x.get());
-    solver->remove_logger(logger.get());
-
-    mtx->apply(alpha.get(), x.get(), beta.get(), res.get());
-    auto rnorm =
-        RDense::create(exec, gko::batch_dim<>(nbatch, gko::dim<2>(1, nrhs)));
-    res->compute_norm2(rnorm.get());
-    auto ref_rnorm = RDense::create(refexec);
-    ref_rnorm->copy_from(rnorm.get());
-    auto r_iter_array = logger->get_num_iterations();
-    auto r_logged_res = logger->get_residual_norm();
-    ASSERT_NO_THROW(exec->synchronize());
-    for (size_t ib = 0; ib < nbatch; ib++) {
-        for (int j = 0; j < nrhs; j++) {
-            ASSERT_LE(r_logged_res->at(ib, 0, j) / ref_bnorm->at(ib, 0, j),
-                      tol);
-            ASSERT_GT(r_iter_array.get_const_data()[ib * nrhs + j], 0);
-            ASSERT_LE(r_iter_array.get_const_data()[ib * nrhs + j], maxits);
-        }
-    }
-    GKO_ASSERT_BATCH_MTX_NEAR(r_logged_res, ref_rnorm, 1e4 * tol);
+    gko::test::test_solve_without_scaling<Solver>(
+        exec, nbatch, nrows, nrhs, tol, maxits, batchgmres_factory.get(), 10);
 }
 
 }  // namespace

--- a/cuda/test/solver/batch_idr_kernels.cpp
+++ b/cuda/test/solver/batch_idr_kernels.cpp
@@ -30,14 +30,16 @@ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ******************************<GINKGO LICENSE>*******************************/
 
-
 #include <ginkgo/core/solver/batch_idr.hpp>
 
+
 #include <gtest/gtest.h>
+
 
 #include <ginkgo/core/base/exception.hpp>
 #include <ginkgo/core/base/executor.hpp>
 #include <ginkgo/core/log/batch_convergence.hpp>
+
 
 #include "core/solver/batch_idr_kernels.hpp"
 #include "core/test/utils.hpp"

--- a/cuda/test/solver/batch_idr_kernels.cpp
+++ b/cuda/test/solver/batch_idr_kernels.cpp
@@ -41,7 +41,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "core/solver/batch_idr_kernels.hpp"
 #include "core/test/utils.hpp"
-#include "core/test/utils/batch.hpp"
+#include "core/test/utils/batch_test_utils.hpp"
 
 namespace {
 
@@ -445,15 +445,12 @@ TEST(BatchIdr, CanSolveWithoutScaling)
     using T = std::complex<double>;
     using RT = typename gko::remove_complex<T>;
     using Solver = gko::solver::BatchIdr<T>;
-    using Dense = gko::matrix::BatchDense<T>;
-    using RDense = gko::matrix::BatchDense<RT>;
-    using Mtx = typename gko::matrix::BatchCsr<T>;
-    const RT tol = 1e-3;
+    const RT tol = 1e-9;
     std::shared_ptr<gko::ReferenceExecutor> refexec =
         gko::ReferenceExecutor::create();
     std::shared_ptr<const gko::CudaExecutor> exec =
         gko::CudaExecutor::create(0, refexec);
-    const int maxits = 10000;
+    const int maxits = 5000;
     auto batchidr_factory =
         Solver::build()
             .with_max_iterations(maxits)
@@ -465,69 +462,11 @@ TEST(BatchIdr, CanSolveWithoutScaling)
             .with_deterministic(true)
             .with_complex_subspace(false)
             .on(exec);
-    const int nrows = 40;
+    const int nrows = 33;
     const size_t nbatch = 3;
-    std::shared_ptr<Mtx> ref_mtx =
-        gko::test::create_poisson1d_batch<T>(refexec, nrows, nbatch);
-    std::shared_ptr<Mtx> mtx = Mtx::create(exec);
-    mtx->copy_from(ref_mtx.get());
-    auto solver = batchidr_factory->generate(mtx);
-    std::shared_ptr<const gko::log::BatchConvergence<T>> logger =
-        gko::log::BatchConvergence<T>::create(exec);
     const int nrhs = 5;
-    auto ref_b = Dense::create(
-        refexec, gko::batch_dim<>(nbatch, gko::dim<2>(nrows, nrhs)));
-    auto ref_x = Dense::create_with_config_of(ref_b.get());
-    auto ref_res = Dense::create_with_config_of(ref_b.get());
-    auto ref_bnorm =
-        RDense::create(refexec, gko::batch_dim<>(nbatch, gko::dim<2>(1, nrhs)));
-    for (size_t ib = 0; ib < nbatch; ib++) {
-        for (int j = 0; j < nrhs; j++) {
-            ref_bnorm->at(ib, 0, j) = gko::zero<RT>();
-            const T val = 1.0 + std::cos(ib / 2.0 - j / 4.0);
-            for (int i = 0; i < nrows; i++) {
-                ref_b->at(ib, i, j) = val;
-                ref_x->at(ib, i, j) = 0.0;
-                ref_res->at(ib, i, j) = val;
-                ref_bnorm->at(ib, 0, j) += gko::squared_norm(val);
-            }
-            ref_bnorm->at(ib, 0, j) = std::sqrt(ref_bnorm->at(ib, 0, j));
-        }
-    }
-    auto x = Dense::create(exec);
-    x->copy_from(ref_x.get());
-    auto res = Dense::create(exec);
-    res->copy_from(ref_res.get());
-    auto b = Dense::create(exec);
-    b->copy_from(ref_b.get());
-    auto alpha = gko::batch_initialize<Dense>(nbatch, {-1.0}, exec);
-    auto beta = gko::batch_initialize<Dense>(nbatch, {1.0}, exec);
-    if (exec != nullptr) {
-        ASSERT_NO_THROW(exec->synchronize());
-    }
-
-    solver->add_logger(logger);
-    solver->apply(b.get(), x.get());
-    solver->remove_logger(logger.get());
-
-    mtx->apply(alpha.get(), x.get(), beta.get(), res.get());
-    auto rnorm =
-        RDense::create(exec, gko::batch_dim<>(nbatch, gko::dim<2>(1, nrhs)));
-    res->compute_norm2(rnorm.get());
-    auto ref_rnorm = RDense::create(refexec);
-    ref_rnorm->copy_from(rnorm.get());
-    auto r_iter_array = logger->get_num_iterations();
-    auto r_logged_res = logger->get_residual_norm();
-    ASSERT_NO_THROW(exec->synchronize());
-    for (size_t ib = 0; ib < nbatch; ib++) {
-        for (int j = 0; j < nrhs; j++) {
-            ASSERT_LE(r_logged_res->at(ib, 0, j) / ref_bnorm->at(ib, 0, j),
-                      tol);
-            ASSERT_GT(r_iter_array.get_const_data()[ib * nrhs + j], 0);
-            ASSERT_LE(r_iter_array.get_const_data()[ib * nrhs + j], maxits);
-        }
-    }
-    GKO_ASSERT_BATCH_MTX_NEAR(r_logged_res, ref_rnorm, 1000 * tol);
+    gko::test::test_solve_without_scaling<Solver>(
+        exec, nbatch, nrows, nrhs, tol, maxits, batchidr_factory.get(), 1.1);
 }
 
 }  // namespace

--- a/cuda/test/solver/batch_richardson_kernels.cpp
+++ b/cuda/test/solver/batch_richardson_kernels.cpp
@@ -266,10 +266,10 @@ protected:
         std::vector<int> iters(2);
         if (std::is_same<real_type, float>::value) {
             iters[0] = 40;
-            iters[1] = 40;
+            iters[1] = 48;
         } else if (std::is_same<real_type, double>::value) {
             iters[0] = 98;
-            iters[1] = 98;
+            iters[1] = 106;
         } else {
             iters[0] = -1;
             iters[1] = -1;

--- a/cuda/test/solver/batch_richardson_kernels.cpp
+++ b/cuda/test/solver/batch_richardson_kernels.cpp
@@ -44,6 +44,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "core/solver/batch_richardson_kernels.hpp"
 #include "core/test/utils.hpp"
 #include "core/test/utils/batch.hpp"
+#include "core/test/utils/batch_test_utils.hpp"
 
 
 namespace {
@@ -472,82 +473,22 @@ TEST(BatchRich, CanSolveWithoutScaling)
     using T = std::complex<float>;
     using RT = typename gko::remove_complex<T>;
     using Solver = gko::solver::BatchRichardson<T>;
-    using Dense = gko::matrix::BatchDense<T>;
-    using RDense = gko::matrix::BatchDense<RT>;
-    using Mtx = typename gko::matrix::BatchCsr<T>;
-    const RT tol = std::numeric_limits<RT>::epsilon() * 1e5;
+    const RT tol = 1e-5;
     std::shared_ptr<gko::ReferenceExecutor> refexec =
         gko::ReferenceExecutor::create();
     std::shared_ptr<const gko::CudaExecutor> exec =
         gko::CudaExecutor::create(0, refexec);
     const int maxits = 10000;
+    const int nrows = 31;
+    const size_t nbatch = 3;
+    const int nrhs = 3;
     auto batchrich_factory = Solver::build()
                                  .with_max_iterations(maxits)
                                  .with_rel_residual_tol(tol)
                                  .with_relaxation_factor(RT{0.95})
                                  .on(exec);
-    const int nrows = 40;
-    const size_t nbatch = 3;
-    std::shared_ptr<Mtx> ref_mtx =
-        gko::test::create_poisson1d_batch<T>(refexec, nrows, nbatch);
-    std::shared_ptr<Mtx> mtx = Mtx::create(exec);
-    mtx->copy_from(ref_mtx.get());
-    auto solver = batchrich_factory->generate(mtx);
-    std::shared_ptr<const gko::log::BatchConvergence<T>> logger =
-        gko::log::BatchConvergence<T>::create(exec);
-    const int nrhs = 3;
-    auto ref_b = Dense::create(
-        refexec, gko::batch_dim<>(nbatch, gko::dim<2>(nrows, nrhs)));
-    auto ref_x = Dense::create_with_config_of(ref_b.get());
-    auto ref_res = Dense::create_with_config_of(ref_b.get());
-    auto ref_bnorm =
-        RDense::create(refexec, gko::batch_dim<>(nbatch, gko::dim<2>(1, nrhs)));
-    for (size_t ib = 0; ib < nbatch; ib++) {
-        for (int j = 0; j < nrhs; j++) {
-            ref_bnorm->at(ib, 0, j) = gko::zero<RT>();
-            const T val = 1.0 + std::cos(ib / 2.0 - j / 4.0);
-            for (int i = 0; i < nrows; i++) {
-                ref_b->at(ib, i, j) = val;
-                ref_x->at(ib, i, j) = 0.0;
-                ref_res->at(ib, i, j) = val;
-                ref_bnorm->at(ib, 0, j) += gko::squared_norm(val);
-            }
-            ref_bnorm->at(ib, 0, j) = std::sqrt(ref_bnorm->at(ib, 0, j));
-        }
-    }
-    auto x = Dense::create(exec);
-    x->copy_from(ref_x.get());
-    auto res = Dense::create(exec);
-    res->copy_from(ref_res.get());
-    auto b = Dense::create(exec);
-    b->copy_from(ref_b.get());
-    auto alpha = gko::batch_initialize<Dense>(nbatch, {-1.0}, exec);
-    auto beta = gko::batch_initialize<Dense>(nbatch, {1.0}, exec);
-    if (exec != nullptr) {
-        ASSERT_NO_THROW(exec->synchronize());
-    }
-
-    solver->add_logger(logger);
-    solver->apply(b.get(), x.get());
-    solver->remove_logger(logger.get());
-
-    mtx->apply(alpha.get(), x.get(), beta.get(), res.get());
-    auto rnorm =
-        RDense::create(exec, gko::batch_dim<>(nbatch, gko::dim<2>(1, nrhs)));
-    res->compute_norm2(rnorm.get());
-    auto ref_rnorm = RDense::create(refexec);
-    ref_rnorm->copy_from(rnorm.get());
-    auto r_iter_array = logger->get_num_iterations();
-    auto r_logged_res = logger->get_residual_norm();
-    ASSERT_NO_THROW(exec->synchronize());
-    for (size_t ib = 0; ib < nbatch; ib++) {
-        for (int j = 0; j < nrhs; j++) {
-            ASSERT_LE(ref_rnorm->at(ib, 0, j) / ref_bnorm->at(ib, 0, j), tol);
-            ASSERT_GT(r_iter_array.get_const_data()[ib * nrhs + j], 0);
-            ASSERT_LE(r_iter_array.get_const_data()[ib * nrhs + j], maxits);
-        }
-    }
-    GKO_ASSERT_BATCH_MTX_NEAR(r_logged_res, ref_rnorm, r<T>::value);
+    gko::test::test_solve_without_scaling<Solver>(
+        exec, nbatch, nrows, nrhs, tol, maxits, batchrich_factory.get(), 2);
 }
 
 }  // namespace

--- a/cuda/test/stop/batch_criteria.cu
+++ b/cuda/test/stop/batch_criteria.cu
@@ -154,7 +154,7 @@ protected:
                     h_r[i * nrhs + j] = 100 * tol;
                 }
                 for (size_t j = 0; j < conv_col.size(); j++) {
-                    h_r[i * nrhs + conv_col[j]] = tol / 100;
+                    h_r[i * nrhs + conv_col[j]] = tol / 10000;
                 }
             }
             resm = h_resm;

--- a/reference/test/solver/batch_bicgstab_kernels.cpp
+++ b/reference/test/solver/batch_bicgstab_kernels.cpp
@@ -38,7 +38,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "core/solver/batch_bicgstab_kernels.hpp"
 #include "core/test/utils.hpp"
-#include "core/test/utils/batch.hpp"
+#include "core/test/utils/batch_test_utils.hpp"
 
 
 namespace {
@@ -320,70 +320,23 @@ TEST(BatchBicgstab, CanSolveWithoutScaling)
     using T = std::complex<float>;
     using RT = typename gko::remove_complex<T>;
     using Solver = gko::solver::BatchBicgstab<T>;
-    using Dense = gko::matrix::BatchDense<T>;
-    using RDense = gko::matrix::BatchDense<RT>;
-    using Mtx = typename gko::matrix::BatchCsr<T>;
-    const RT tol = 1e-3;
+    const RT tol = 1e-5;
+    const int maxits = 1000;
     std::shared_ptr<gko::ReferenceExecutor> exec =
         gko::ReferenceExecutor::create();
     auto batchbicgstab_factory =
         Solver::build()
-            .with_max_iterations(10000)
+            .with_max_iterations(maxits)
             .with_rel_residual_tol(tol)
             .with_tolerance_type(gko::stop::batch::ToleranceType::relative)
             .with_preconditioner(gko::preconditioner::batch::type::jacobi)
             .on(exec);
     const int nrows = 40;
     const size_t nbatch = 3;
-    std::shared_ptr<Mtx> mtx =
-        gko::test::create_poisson1d_batch<T>(exec, nrows, nbatch);
-    auto solver = batchbicgstab_factory->generate(mtx);
-    std::shared_ptr<const gko::log::BatchConvergence<T>> logger =
-        gko::log::BatchConvergence<T>::create(exec);
-    solver->add_logger(logger);
     const int nrhs = 5;
-    auto b =
-        Dense::create(exec, gko::batch_dim<>(nbatch, gko::dim<2>(nrows, nrhs)));
-    auto x = Dense::create_with_config_of(b.get());
-    auto res = Dense::create_with_config_of(b.get());
-    auto alpha = gko::batch_initialize<Dense>(nbatch, {-1.0}, exec);
-    auto beta = gko::batch_initialize<Dense>(nbatch, {1.0}, exec);
-    auto bnorm =
-        RDense::create(exec, gko::batch_dim<>(nbatch, gko::dim<2>(1, nrhs)));
-
-    for (size_t ib = 0; ib < nbatch; ib++) {
-        for (int j = 0; j < nrhs; j++) {
-            bnorm->at(ib, 0, j) = gko::zero<RT>();
-            const T val = 1.0 + std::cos(ib / 2.0 - j / 4.0);
-            for (int i = 0; i < nrows; i++) {
-                b->at(ib, i, j) = val;
-                x->at(ib, i, j) = 0.0;
-                res->at(ib, i, j) = val;
-                bnorm->at(ib, 0, j) += gko::squared_norm(val);
-            }
-            bnorm->at(ib, 0, j) = std::sqrt(bnorm->at(ib, 0, j));
-        }
-    }
-
-    solver->apply(b.get(), x.get());
-
-    mtx->apply(alpha.get(), x.get(), beta.get(), res.get());
-
-    auto rnorm =
-        RDense::create(exec, gko::batch_dim<>(nbatch, gko::dim<2>(1, nrhs)));
-    res->compute_norm2(rnorm.get());
-    const auto iter_array = logger->get_num_iterations();
-    const auto logged_res = logger->get_residual_norm();
-
-    for (size_t ib = 0; ib < nbatch; ib++) {
-        for (int j = 0; j < nrhs; j++) {
-            ASSERT_LE(logged_res->at(ib, 0, j) / bnorm->at(ib, 0, j), tol);
-            ASSERT_GT(iter_array.get_const_data()[ib * nrhs + j], 0);
-        }
-    }
-
-
-    GKO_ASSERT_BATCH_MTX_NEAR(logged_res, rnorm, 100 * tol);
+    gko::test::test_solve_without_scaling<Solver>(
+        exec, nbatch, nrows, nrhs, tol, maxits, batchbicgstab_factory.get(),
+        10);
 }
 
 

--- a/reference/test/solver/batch_bicgstab_kernels.cpp
+++ b/reference/test/solver/batch_bicgstab_kernels.cpp
@@ -32,9 +32,12 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <ginkgo/core/solver/batch_bicgstab.hpp>
 
+
 #include <gtest/gtest.h>
 
+
 #include <ginkgo/core/log/batch_convergence.hpp>
+
 
 #include "core/solver/batch_bicgstab_kernels.hpp"
 #include "core/test/utils.hpp"

--- a/reference/test/solver/batch_cg_kernels.cpp
+++ b/reference/test/solver/batch_cg_kernels.cpp
@@ -32,9 +32,12 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <ginkgo/core/solver/batch_cg.hpp>
 
+
 #include <gtest/gtest.h>
 
+
 #include <ginkgo/core/log/batch_convergence.hpp>
+
 
 #include "core/solver/batch_cg_kernels.hpp"
 #include "core/test/utils.hpp"

--- a/reference/test/solver/batch_cg_kernels.cpp
+++ b/reference/test/solver/batch_cg_kernels.cpp
@@ -38,7 +38,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "core/solver/batch_cg_kernels.hpp"
 #include "core/test/utils.hpp"
-#include "core/test/utils/batch.hpp"
+#include "core/test/utils/batch_test_utils.hpp"
 
 
 namespace {
@@ -329,65 +329,22 @@ TEST(BatchCg, CanSolveWithoutScaling)
     using Dense = gko::matrix::BatchDense<T>;
     using RDense = gko::matrix::BatchDense<RT>;
     using Mtx = typename gko::matrix::BatchCsr<T>;
-    const RT tol = 1e-2;
+    const RT tol = 1e-9;
+    const int maxits = 1000;
     std::shared_ptr<gko::ReferenceExecutor> exec =
         gko::ReferenceExecutor::create();
     auto batchcg_factory =
         Solver::build()
-            .with_max_iterations(10000)
+            .with_max_iterations(maxits)
             .with_rel_residual_tol(tol)
             .with_tolerance_type(gko::stop::batch::ToleranceType::relative)
             .with_preconditioner(gko::preconditioner::batch::type::jacobi)
             .on(exec);
     const int nrows = 40;
     const size_t nbatch = 3;
-    std::shared_ptr<Mtx> mtx =
-        gko::test::create_poisson1d_batch<T>(exec, nrows, nbatch);
-    auto solver = batchcg_factory->generate(mtx);
-    std::shared_ptr<const gko::log::BatchConvergence<T>> logger =
-        gko::log::BatchConvergence<T>::create(exec);
-    solver->add_logger(logger);
     const int nrhs = 6;
-    auto b =
-        Dense::create(exec, gko::batch_dim<>(nbatch, gko::dim<2>(nrows, nrhs)));
-    auto x = Dense::create_with_config_of(b.get());
-    auto res = Dense::create_with_config_of(b.get());
-    auto alpha = gko::batch_initialize<Dense>(nbatch, {-1.0}, exec);
-    auto beta = gko::batch_initialize<Dense>(nbatch, {1.0}, exec);
-    auto bnorm =
-        RDense::create(exec, gko::batch_dim<>(nbatch, gko::dim<2>(1, nrhs)));
-
-    for (size_t ib = 0; ib < nbatch; ib++) {
-        for (int j = 0; j < nrhs; j++) {
-            bnorm->at(ib, 0, j) = gko::zero<RT>();
-            const T val = 1.0 + std::cos(ib / 2.0 - j / 4.0);
-            for (int i = 0; i < nrows; i++) {
-                b->at(ib, i, j) = val;
-                x->at(ib, i, j) = 0.0;
-                res->at(ib, i, j) = val;
-                bnorm->at(ib, 0, j) += gko::squared_norm(val);
-            }
-            bnorm->at(ib, 0, j) = std::sqrt(bnorm->at(ib, 0, j));
-        }
-    }
-
-    solver->apply(b.get(), x.get());
-
-    mtx->apply(alpha.get(), x.get(), beta.get(), res.get());
-    auto rnorm =
-        RDense::create(exec, gko::batch_dim<>(nbatch, gko::dim<2>(1, nrhs)));
-    res->compute_norm2(rnorm.get());
-    const auto iter_array = logger->get_num_iterations();
-    const auto logged_res = logger->get_residual_norm();
-
-    for (size_t ib = 0; ib < nbatch; ib++) {
-        for (int j = 0; j < nrhs; j++) {
-            ASSERT_LE(logged_res->at(ib, 0, j) / bnorm->at(ib, 0, j), tol);
-            ASSERT_GT(iter_array.get_const_data()[ib * nrhs + j], 0);
-        }
-    }
-
-    GKO_ASSERT_BATCH_MTX_NEAR(logged_res, rnorm, 200 * tol);
+    gko::test::test_solve_without_scaling<Solver>(
+        exec, nbatch, nrows, nrhs, tol, maxits, batchcg_factory.get(), 1.01);
 }
 
 

--- a/reference/test/solver/batch_idr_kernels.cpp
+++ b/reference/test/solver/batch_idr_kernels.cpp
@@ -32,9 +32,12 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <ginkgo/core/solver/batch_idr.hpp>
 
+
 #include <gtest/gtest.h>
 
+
 #include <ginkgo/core/log/batch_convergence.hpp>
+
 
 #include "core/solver/batch_idr_kernels.hpp"
 #include "core/test/utils.hpp"

--- a/reference/test/solver/batch_idr_kernels.cpp
+++ b/reference/test/solver/batch_idr_kernels.cpp
@@ -38,7 +38,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "core/solver/batch_idr_kernels.hpp"
 #include "core/test/utils.hpp"
-#include "core/test/utils/batch.hpp"
+#include "core/test/utils/batch_test_utils.hpp"
 
 
 namespace {
@@ -335,15 +335,13 @@ TEST(BatchIdr, CanSolveWithoutScaling)
     using T = std::complex<double>;
     using RT = typename gko::remove_complex<T>;
     using Solver = gko::solver::BatchIdr<T>;
-    using Dense = gko::matrix::BatchDense<T>;
-    using RDense = gko::matrix::BatchDense<RT>;
-    using Mtx = typename gko::matrix::BatchCsr<T>;
-    const RT tol = 1e-3;
+    const RT tol = 1e-9;
+    const int maxits = 1000;
     std::shared_ptr<gko::ReferenceExecutor> exec =
         gko::ReferenceExecutor::create();
     auto batchidr_factory =
         Solver::build()
-            .with_max_iterations(10000)
+            .with_max_iterations(maxits)
             .with_rel_residual_tol(tol)
             .with_tolerance_type(gko::stop::batch::ToleranceType::relative)
             .with_preconditioner(gko::preconditioner::batch::type::jacobi)
@@ -354,59 +352,9 @@ TEST(BatchIdr, CanSolveWithoutScaling)
             .on(exec);
     const int nrows = 40;
     const size_t nbatch = 3;
-    std::shared_ptr<Mtx> mtx =
-        gko::test::create_poisson1d_batch<T>(exec, nrows, nbatch);
-    auto solver = batchidr_factory->generate(mtx);
-    std::shared_ptr<const gko::log::BatchConvergence<T>> logger =
-        gko::log::BatchConvergence<T>::create(exec);
-    solver->add_logger(logger);
     const int nrhs = 5;
-    auto b =
-        Dense::create(exec, gko::batch_dim<>(nbatch, gko::dim<2>(nrows, nrhs)));
-    auto x = Dense::create_with_config_of(b.get());
-    auto res = Dense::create_with_config_of(b.get());
-    auto alpha = gko::batch_initialize<Dense>(nbatch, {-1.0}, exec);
-    auto beta = gko::batch_initialize<Dense>(nbatch, {1.0}, exec);
-    auto bnorm =
-        RDense::create(exec, gko::batch_dim<>(nbatch, gko::dim<2>(1, nrhs)));
-
-    for (size_t ib = 0; ib < nbatch; ib++) {
-        for (int j = 0; j < nrhs; j++) {
-            bnorm->at(ib, 0, j) = gko::zero<RT>();
-            const T val = 1.0 + std::cos(ib / 2.0 - j / 4.0);
-            for (int i = 0; i < nrows; i++) {
-                b->at(ib, i, j) = val;
-                x->at(ib, i, j) = 0.0;
-                res->at(ib, i, j) = val;
-                bnorm->at(ib, 0, j) += gko::squared_norm(val);
-            }
-            bnorm->at(ib, 0, j) = std::sqrt(bnorm->at(ib, 0, j));
-        }
-    }
-
-
-    solver->apply(b.get(), x.get());
-
-    mtx->apply(alpha.get(), x.get(), beta.get(), res.get());
-
-
-    auto rnorm =
-        RDense::create(exec, gko::batch_dim<>(nbatch, gko::dim<2>(1, nrhs)));
-    res->compute_norm2(rnorm.get());
-
-
-    const auto iter_array = logger->get_num_iterations();
-    const auto logged_res = logger->get_residual_norm();
-
-    for (size_t ib = 0; ib < nbatch; ib++) {
-        for (int j = 0; j < nrhs; j++) {
-            ASSERT_LE(logged_res->at(ib, 0, j) / bnorm->at(ib, 0, j), tol);
-            ASSERT_GT(iter_array.get_const_data()[ib * nrhs + j], 0);
-        }
-    }
-
-
-    GKO_ASSERT_BATCH_MTX_NEAR(logged_res, rnorm, 1000 * tol);
+    gko::test::test_solve_without_scaling<Solver>(
+        exec, nbatch, nrows, nrhs, tol, maxits, batchidr_factory.get(), 1.001);
 }
 
 

--- a/reference/test/solver/batch_richardson_kernels.cpp
+++ b/reference/test/solver/batch_richardson_kernels.cpp
@@ -41,7 +41,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "core/solver/batch_richardson_kernels.hpp"
 #include "core/test/utils.hpp"
-#include "core/test/utils/batch.hpp"
+#include "core/test/utils/batch_test_utils.hpp"
 
 
 namespace {
@@ -355,65 +355,20 @@ TEST(BatchRich, CanSolveWithoutScaling)
     using T = std::complex<float>;
     using RT = typename gko::remove_complex<T>;
     using Solver = gko::solver::BatchRichardson<T>;
-    using Dense = gko::matrix::BatchDense<T>;
-    using RDense = gko::matrix::BatchDense<RT>;
-    using Mtx = typename gko::matrix::BatchCsr<T>;
-    const RT tol = std::numeric_limits<RT>::epsilon();
+    const RT tol = 200 * std::numeric_limits<RT>::epsilon();
     std::shared_ptr<gko::ReferenceExecutor> exec =
         gko::ReferenceExecutor::create();
     const int maxits = 10000;
     auto batchrich_factory = Solver::build()
                                  .with_max_iterations(maxits)
-                                 .with_rel_residual_tol(tol * 200)
+                                 .with_rel_residual_tol(tol)
                                  .with_relaxation_factor(RT{0.98})
                                  .on(exec);
     const int nrows = 40;
     const size_t nbatch = 3;
-    std::shared_ptr<Mtx> mtx =
-        gko::test::create_poisson1d_batch<T>(exec, nrows, nbatch);
-    auto solver = batchrich_factory->generate(mtx);
-    std::shared_ptr<const gko::log::BatchConvergence<T>> logger =
-        gko::log::BatchConvergence<T>::create(exec);
-    solver->add_logger(logger);
     const int nrhs = 7;
-    auto b =
-        Dense::create(exec, gko::batch_dim<>(nbatch, gko::dim<2>(nrows, nrhs)));
-    auto x = Dense::create_with_config_of(b.get());
-    auto res = Dense::create_with_config_of(b.get());
-    auto alpha = gko::batch_initialize<Dense>(nbatch, {-1.0}, exec);
-    auto beta = gko::batch_initialize<Dense>(nbatch, {1.0}, exec);
-    auto bnorm =
-        RDense::create(exec, gko::batch_dim<>(nbatch, gko::dim<2>(1, nrhs)));
-    for (size_t ib = 0; ib < nbatch; ib++) {
-        for (int j = 0; j < nrhs; j++) {
-            bnorm->at(ib, 0, j) = gko::zero<RT>();
-            const T val = 1.0 + std::cos(ib / 2.0 - j / 4.0);
-            for (int i = 0; i < nrows; i++) {
-                b->at(ib, i, j) = val;
-                x->at(ib, i, j) = 0.0;
-                res->at(ib, i, j) = val;
-                bnorm->at(ib, 0, j) += gko::squared_norm(val);
-            }
-            bnorm->at(ib, 0, j) = std::sqrt(bnorm->at(ib, 0, j));
-        }
-    }
-
-    solver->apply(b.get(), x.get());
-
-    mtx->apply(alpha.get(), x.get(), beta.get(), res.get());
-    auto rnorm =
-        RDense::create(exec, gko::batch_dim<>(nbatch, gko::dim<2>(1, nrhs)));
-    res->compute_norm2(rnorm.get());
-    const auto iter_array = logger->get_num_iterations();
-    const auto logged_res = logger->get_residual_norm();
-    for (size_t ib = 0; ib < nbatch; ib++) {
-        for (int j = 0; j < nrhs; j++) {
-            ASSERT_LE(rnorm->at(ib, 0, j) / bnorm->at(ib, 0, j), tol * 200);
-            ASSERT_GT(iter_array.get_const_data()[ib * nrhs + j], 0);
-            ASSERT_LE(iter_array.get_const_data()[ib * nrhs + j], maxits);
-        }
-    }
-    GKO_ASSERT_BATCH_MTX_NEAR(logged_res, rnorm, tol);
+    gko::test::test_solve_without_scaling<Solver>(
+        exec, nbatch, nrows, nrhs, tol, maxits, batchrich_factory.get());
 }
 
 


### PR DESCRIPTION
Re-formulated the test to check whether calling the batch solvers through their public interface works. The reformulation is in terms of checking whether the logger contains reasonable values. The loose reasoning is as follows:
![img](https://user-images.githubusercontent.com/12900520/122457498-011f7f80-cfaf-11eb-80a0-dab57dfce4bb.png)
It's not as rigorous as Latex makes it look, but it should do for now.

All this is put into a common location to remove duplication.