### PR TITLE
Fix Coo out of bounds access for strided vectors

### DIFF
--- a/cuda/matrix/coo_kernels.cu
+++ b/cuda/matrix/coo_kernels.cu
@@ -40,7 +40,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <ginkgo/core/matrix/dense.hpp>
 
 
-#include "core/components/fill_array.hpp"
 #include "core/matrix/dense_kernels.hpp"
 #include "cuda/base/config.hpp"
 #include "cuda/base/cusparse_bindings.hpp"
@@ -82,9 +81,7 @@ void spmv(std::shared_ptr<const CudaExecutor> exec,
           const matrix::Coo<ValueType, IndexType> *a,
           const matrix::Dense<ValueType> *b, matrix::Dense<ValueType> *c)
 {
-    components::fill_array(exec, c->get_values(), c->get_num_stored_elements(),
-                           zero<ValueType>());
-
+    dense::fill(exec, c, zero<ValueType>());
     spmv2(exec, a, b, c);
 }
 

--- a/cuda/test/matrix/coo_kernels.cpp
+++ b/cuda/test/matrix/coo_kernels.cpp
@@ -141,6 +141,24 @@ TEST_F(Coo, SimpleApplyIsEquivalentToRef)
 }
 
 
+TEST_F(Coo, SimpleApplyDoesntOverwritePadding)
+{
+    set_up_apply_data();
+    auto dresult_padded =
+        Vec::create(cuda, dresult->get_size(), dresult->get_stride() + 1);
+    dresult_padded->copy_from(dresult.get());
+    double padding_val{1234.0};
+    cuda->copy_from(cuda->get_master().get(), 1, &padding_val,
+                    dresult_padded->get_values() + 1);
+
+    mtx->apply(y.get(), expected.get());
+    dmtx->apply(dy.get(), dresult.get());
+
+    GKO_ASSERT_MTX_NEAR(dresult, expected, 1e-14);
+    ASSERT_EQ(cuda->copy_val_to_host(dresult_padded->get_values() + 1), 1234.0);
+}
+
+
 TEST_F(Coo, SimpleApplyIsEquivalentToRefUnsorted)
 {
     set_up_apply_data();
@@ -161,6 +179,24 @@ TEST_F(Coo, AdvancedApplyIsEquivalentToRef)
     dmtx->apply(dalpha.get(), dy.get(), dbeta.get(), dresult.get());
 
     GKO_ASSERT_MTX_NEAR(dresult, expected, 1e-14);
+}
+
+
+TEST_F(Coo, AdvancedApplyDoesntOverwritePadding)
+{
+    set_up_apply_data();
+    auto dresult_padded =
+        Vec::create(cuda, dresult->get_size(), dresult->get_stride() + 1);
+    dresult_padded->copy_from(dresult.get());
+    double padding_val{1234.0};
+    cuda->copy_from(cuda->get_master().get(), 1, &padding_val,
+                    dresult_padded->get_values() + 1);
+
+    mtx->apply(alpha.get(), y.get(), beta.get(), expected.get());
+    dmtx->apply(dalpha.get(), dy.get(), dbeta.get(), dresult.get());
+
+    GKO_ASSERT_MTX_NEAR(dresult, expected, 1e-14);
+    ASSERT_EQ(cuda->copy_val_to_host(dresult_padded->get_values() + 1), 1234.0);
 }
 
 

--- a/cuda/test/matrix/coo_kernels.cpp
+++ b/cuda/test/matrix/coo_kernels.cpp
@@ -152,9 +152,9 @@ TEST_F(Coo, SimpleApplyDoesntOverwritePadding)
                     dresult_padded->get_values() + 1);
 
     mtx->apply(y.get(), expected.get());
-    dmtx->apply(dy.get(), dresult.get());
+    dmtx->apply(dy.get(), dresult_padded.get());
 
-    GKO_ASSERT_MTX_NEAR(dresult, expected, 1e-14);
+    GKO_ASSERT_MTX_NEAR(dresult_padded, expected, 1e-14);
     ASSERT_EQ(cuda->copy_val_to_host(dresult_padded->get_values() + 1), 1234.0);
 }
 
@@ -193,9 +193,9 @@ TEST_F(Coo, AdvancedApplyDoesntOverwritePadding)
                     dresult_padded->get_values() + 1);
 
     mtx->apply(alpha.get(), y.get(), beta.get(), expected.get());
-    dmtx->apply(dalpha.get(), dy.get(), dbeta.get(), dresult.get());
+    dmtx->apply(dalpha.get(), dy.get(), dbeta.get(), dresult_padded.get());
 
-    GKO_ASSERT_MTX_NEAR(dresult, expected, 1e-14);
+    GKO_ASSERT_MTX_NEAR(dresult_padded, expected, 1e-14);
     ASSERT_EQ(cuda->copy_val_to_host(dresult_padded->get_values() + 1), 1234.0);
 }
 

--- a/hip/matrix/coo_kernels.hip.cpp
+++ b/hip/matrix/coo_kernels.hip.cpp
@@ -43,7 +43,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <ginkgo/core/matrix/dense.hpp>
 
 
-#include "core/components/fill_array.hpp"
 #include "core/matrix/dense_kernels.hpp"
 #include "hip/base/config.hip.hpp"
 #include "hip/base/hipsparse_bindings.hip.hpp"
@@ -85,9 +84,7 @@ void spmv(std::shared_ptr<const HipExecutor> exec,
           const matrix::Coo<ValueType, IndexType> *a,
           const matrix::Dense<ValueType> *b, matrix::Dense<ValueType> *c)
 {
-    components::fill_array(exec, c->get_values(), c->get_num_stored_elements(),
-                           zero<ValueType>());
-
+    dense::fill(exec, c, zero<ValueType>());
     spmv2(exec, a, b, c);
 }
 

--- a/hip/test/matrix/coo_kernels.hip.cpp
+++ b/hip/test/matrix/coo_kernels.hip.cpp
@@ -153,9 +153,9 @@ TEST_F(Coo, SimpleApplyDoesntOverwritePadding)
                    dresult_padded->get_values() + 1);
 
     mtx->apply(y.get(), expected.get());
-    dmtx->apply(dy.get(), dresult.get());
+    dmtx->apply(dy.get(), dresult_padded.get());
 
-    GKO_ASSERT_MTX_NEAR(dresult, expected, 1e-14);
+    GKO_ASSERT_MTX_NEAR(dresult_padded, expected, 1e-14);
     ASSERT_EQ(hip->copy_val_to_host(dresult_padded->get_values() + 1), 1234.0);
 }
 
@@ -194,9 +194,9 @@ TEST_F(Coo, AdvancedApplyDoesntOverwritePadding)
                    dresult_padded->get_values() + 1);
 
     mtx->apply(alpha.get(), y.get(), beta.get(), expected.get());
-    dmtx->apply(dalpha.get(), dy.get(), dbeta.get(), dresult.get());
+    dmtx->apply(dalpha.get(), dy.get(), dbeta.get(), dresult_padded.get());
 
-    GKO_ASSERT_MTX_NEAR(dresult, expected, 1e-14);
+    GKO_ASSERT_MTX_NEAR(dresult_padded, expected, 1e-14);
     ASSERT_EQ(hip->copy_val_to_host(dresult_padded->get_values() + 1), 1234.0);
 }
 

--- a/hip/test/matrix/coo_kernels.hip.cpp
+++ b/hip/test/matrix/coo_kernels.hip.cpp
@@ -142,6 +142,24 @@ TEST_F(Coo, SimpleApplyIsEquivalentToRef)
 }
 
 
+TEST_F(Coo, SimpleApplyDoesntOverwritePadding)
+{
+    set_up_apply_data();
+    auto dresult_padded =
+        Vec::create(hip, dresult->get_size(), dresult->get_stride() + 1);
+    dresult_padded->copy_from(dresult.get());
+    double padding_val{1234.0};
+    hip->copy_from(hip->get_master().get(), 1, &padding_val,
+                   dresult_padded->get_values() + 1);
+
+    mtx->apply(y.get(), expected.get());
+    dmtx->apply(dy.get(), dresult.get());
+
+    GKO_ASSERT_MTX_NEAR(dresult, expected, 1e-14);
+    ASSERT_EQ(hip->copy_val_to_host(dresult_padded->get_values() + 1), 1234.0);
+}
+
+
 TEST_F(Coo, SimpleApplyIsEquivalentToRefUnsorted)
 {
     set_up_apply_data();
@@ -162,6 +180,24 @@ TEST_F(Coo, AdvancedApplyIsEquivalentToRef)
     dmtx->apply(dalpha.get(), dy.get(), dbeta.get(), dresult.get());
 
     GKO_ASSERT_MTX_NEAR(dresult, expected, 1e-14);
+}
+
+
+TEST_F(Coo, AdvancedApplyDoesntOverwritePadding)
+{
+    set_up_apply_data();
+    auto dresult_padded =
+        Vec::create(hip, dresult->get_size(), dresult->get_stride() + 1);
+    dresult_padded->copy_from(dresult.get());
+    double padding_val{1234.0};
+    hip->copy_from(hip->get_master().get(), 1, &padding_val,
+                   dresult_padded->get_values() + 1);
+
+    mtx->apply(alpha.get(), y.get(), beta.get(), expected.get());
+    dmtx->apply(dalpha.get(), dy.get(), dbeta.get(), dresult.get());
+
+    GKO_ASSERT_MTX_NEAR(dresult, expected, 1e-14);
+    ASSERT_EQ(hip->copy_val_to_host(dresult_padded->get_values() + 1), 1234.0);
 }
 
 

--- a/omp/matrix/coo_kernels.cpp
+++ b/omp/matrix/coo_kernels.cpp
@@ -67,11 +67,12 @@ void spmv(std::shared_ptr<const OmpExecutor> exec,
           const matrix::Coo<ValueType, IndexType> *a,
           const matrix::Dense<ValueType> *b, matrix::Dense<ValueType> *c)
 {
-#pragma omp parallel for
-    for (size_type i = 0; i < c->get_num_stored_elements(); i++) {
-        c->at(i) = zero<ValueType>();
+#pragma omp parallel for collapse(2)
+    for (size_type i = 0; i < c->get_size()[0]; i++) {
+        for (size_type j = 0; j < c->get_size()[1]; j++) {
+            c->at(i, j) = zero<ValueType>();
+        }
     }
-
     spmv2(exec, a, b, c);
 }
 
@@ -87,9 +88,11 @@ void advanced_spmv(std::shared_ptr<const OmpExecutor> exec,
                    matrix::Dense<ValueType> *c)
 {
     auto beta_val = beta->at(0, 0);
-#pragma omp parallel for
-    for (size_type i = 0; i < c->get_num_stored_elements(); i++) {
-        c->at(i) *= beta_val;
+#pragma omp parallel for collapse(2)
+    for (size_type i = 0; i < c->get_size()[0]; i++) {
+        for (size_type j = 0; j < c->get_size()[1]; j++) {
+            c->at(i, j) *= beta_val;
+        }
     }
 
     advanced_spmv2(exec, alpha, a, b, c);

--- a/omp/matrix/coo_kernels.cpp
+++ b/omp/matrix/coo_kernels.cpp
@@ -42,6 +42,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <ginkgo/core/matrix/dense.hpp>
 
 
+#include "core/matrix/dense_kernels.hpp"
 #include "omp/components/atomic.hpp"
 #include "omp/components/format_conversion.hpp"
 
@@ -67,12 +68,7 @@ void spmv(std::shared_ptr<const OmpExecutor> exec,
           const matrix::Coo<ValueType, IndexType> *a,
           const matrix::Dense<ValueType> *b, matrix::Dense<ValueType> *c)
 {
-#pragma omp parallel for collapse(2)
-    for (size_type i = 0; i < c->get_size()[0]; i++) {
-        for (size_type j = 0; j < c->get_size()[1]; j++) {
-            c->at(i, j) = zero<ValueType>();
-        }
-    }
+    dense::fill(exec, c, zero<ValueType>());
     spmv2(exec, a, b, c);
 }
 
@@ -87,14 +83,7 @@ void advanced_spmv(std::shared_ptr<const OmpExecutor> exec,
                    const matrix::Dense<ValueType> *beta,
                    matrix::Dense<ValueType> *c)
 {
-    auto beta_val = beta->at(0, 0);
-#pragma omp parallel for collapse(2)
-    for (size_type i = 0; i < c->get_size()[0]; i++) {
-        for (size_type j = 0; j < c->get_size()[1]; j++) {
-            c->at(i, j) *= beta_val;
-        }
-    }
-
+    dense::scale(exec, beta, c);
     advanced_spmv2(exec, alpha, a, b, c);
 }
 

--- a/omp/test/matrix/coo_kernels.cpp
+++ b/omp/test/matrix/coo_kernels.cpp
@@ -166,9 +166,9 @@ TEST_F(Coo, SimpleApplyDoesntOverwritePadding)
     dresult_padded->get_values()[1] = 1234.0;
 
     mtx->apply(y.get(), expected.get());
-    dmtx->apply(dy.get(), dresult.get());
+    dmtx->apply(dy.get(), dresult_padded.get());
 
-    GKO_ASSERT_MTX_NEAR(dresult, expected, 1e-14);
+    GKO_ASSERT_MTX_NEAR(dresult_padded, expected, 1e-14);
     ASSERT_EQ(dresult_padded->get_values()[1], 1234.0);
 }
 
@@ -193,9 +193,9 @@ TEST_F(Coo, AdvancedApplyDoesntOverwritePadding)
     dresult_padded->get_values()[1] = 1234.0;
 
     mtx->apply(alpha.get(), y.get(), beta.get(), expected.get());
-    dmtx->apply(dalpha.get(), dy.get(), dbeta.get(), dresult.get());
+    dmtx->apply(dalpha.get(), dy.get(), dbeta.get(), dresult_padded.get());
 
-    GKO_ASSERT_MTX_NEAR(dresult, expected, 1e-14);
+    GKO_ASSERT_MTX_NEAR(dresult_padded, expected, 1e-14);
     ASSERT_EQ(dresult_padded->get_values()[1], 1234.0);
 }
 

--- a/omp/test/matrix/coo_kernels.cpp
+++ b/omp/test/matrix/coo_kernels.cpp
@@ -157,6 +157,22 @@ TEST_F(Coo, SimpleApplyIsEquivalentToRef)
 }
 
 
+TEST_F(Coo, SimpleApplyDoesntOverwritePadding)
+{
+    set_up_apply_data();
+    auto dresult_padded =
+        Vec::create(omp, dresult->get_size(), dresult->get_stride() + 1);
+    dresult_padded->copy_from(dresult.get());
+    dresult_padded->get_values()[1] = 1234.0;
+
+    mtx->apply(y.get(), expected.get());
+    dmtx->apply(dy.get(), dresult.get());
+
+    GKO_ASSERT_MTX_NEAR(dresult, expected, 1e-14);
+    ASSERT_EQ(dresult_padded->get_values()[1], 1234.0);
+}
+
+
 TEST_F(Coo, AdvancedApplyIsEquivalentToRef)
 {
     set_up_apply_data();
@@ -165,6 +181,22 @@ TEST_F(Coo, AdvancedApplyIsEquivalentToRef)
     dmtx->apply(dalpha.get(), dy.get(), dbeta.get(), dresult.get());
 
     GKO_ASSERT_MTX_NEAR(dresult, expected, 1e-14);
+}
+
+
+TEST_F(Coo, AdvancedApplyDoesntOverwritePadding)
+{
+    set_up_apply_data();
+    auto dresult_padded =
+        Vec::create(omp, dresult->get_size(), dresult->get_stride() + 1);
+    dresult_padded->copy_from(dresult.get());
+    dresult_padded->get_values()[1] = 1234.0;
+
+    mtx->apply(alpha.get(), y.get(), beta.get(), expected.get());
+    dmtx->apply(dalpha.get(), dy.get(), dbeta.get(), dresult.get());
+
+    GKO_ASSERT_MTX_NEAR(dresult, expected, 1e-14);
+    ASSERT_EQ(dresult_padded->get_values()[1], 1234.0);
 }
 
 

--- a/reference/matrix/coo_kernels.cpp
+++ b/reference/matrix/coo_kernels.cpp
@@ -63,8 +63,10 @@ void spmv(std::shared_ptr<const ReferenceExecutor> exec,
           const matrix::Coo<ValueType, IndexType> *a,
           const matrix::Dense<ValueType> *b, matrix::Dense<ValueType> *c)
 {
-    for (size_type i = 0; i < c->get_num_stored_elements(); i++) {
-        c->at(i) = zero<ValueType>();
+    for (size_type i = 0; i < c->get_size()[0]; i++) {
+        for (size_type j = 0; j < c->get_size()[1]; j++) {
+            c->at(i, j) = zero<ValueType>();
+        }
     }
     spmv2(exec, a, b, c);
 }
@@ -81,8 +83,10 @@ void advanced_spmv(std::shared_ptr<const ReferenceExecutor> exec,
                    matrix::Dense<ValueType> *c)
 {
     auto beta_val = beta->at(0, 0);
-    for (size_type i = 0; i < c->get_num_stored_elements(); i++) {
-        c->at(i) *= beta_val;
+    for (size_type i = 0; i < c->get_size()[0]; i++) {
+        for (size_type j = 0; j < c->get_size()[1]; j++) {
+            c->at(i, j) *= beta_val;
+        }
     }
     advanced_spmv2(exec, alpha, a, b, c);
 }

--- a/reference/matrix/coo_kernels.cpp
+++ b/reference/matrix/coo_kernels.cpp
@@ -39,6 +39,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <ginkgo/core/matrix/dense.hpp>
 
 
+#include "core/matrix/dense_kernels.hpp"
 #include "reference/components/format_conversion.hpp"
 
 
@@ -63,11 +64,7 @@ void spmv(std::shared_ptr<const ReferenceExecutor> exec,
           const matrix::Coo<ValueType, IndexType> *a,
           const matrix::Dense<ValueType> *b, matrix::Dense<ValueType> *c)
 {
-    for (size_type i = 0; i < c->get_size()[0]; i++) {
-        for (size_type j = 0; j < c->get_size()[1]; j++) {
-            c->at(i, j) = zero<ValueType>();
-        }
-    }
+    dense::fill(exec, c, zero<ValueType>());
     spmv2(exec, a, b, c);
 }
 
@@ -82,12 +79,7 @@ void advanced_spmv(std::shared_ptr<const ReferenceExecutor> exec,
                    const matrix::Dense<ValueType> *beta,
                    matrix::Dense<ValueType> *c)
 {
-    auto beta_val = beta->at(0, 0);
-    for (size_type i = 0; i < c->get_size()[0]; i++) {
-        for (size_type j = 0; j < c->get_size()[1]; j++) {
-            c->at(i, j) *= beta_val;
-        }
-    }
+    dense::scale(exec, beta, c);
     advanced_spmv2(exec, alpha, a, b, c);
 }
 

--- a/reference/test/matrix/coo_kernels.cpp
+++ b/reference/test/matrix/coo_kernels.cpp
@@ -350,6 +350,21 @@ TYPED_TEST(Coo, AppliesToDenseVector)
 }
 
 
+TYPED_TEST(Coo, ApplyToStridedVectorKeepsPadding)
+{
+    using Vec = typename TestFixture::Vec;
+    using T = typename TestFixture::value_type;
+    auto x = gko::initialize<Vec>({2.0, 1.0, 4.0}, this->exec);
+    auto y = Vec::create(this->exec, gko::dim<2>{2, 1}, 2);
+    y->get_values()[1] = 1234;
+
+    this->mtx->apply(x.get(), y.get());
+
+    GKO_ASSERT_MTX_NEAR(y, l({13.0, 5.0}), 0.0);
+    ASSERT_EQ(y->get_values()[1], T{1234});
+}
+
+
 TYPED_TEST(Coo, AppliesToMixedDenseVector)
 {
     using MixedVec = typename TestFixture::MixedVec;
@@ -429,6 +444,25 @@ TYPED_TEST(Coo, AppliesLinearCombinationToDenseVector)
     this->mtx->apply(alpha.get(), x.get(), beta.get(), y.get());
 
     GKO_ASSERT_MTX_NEAR(y, l({-11.0, -1.0}), 0.0);
+}
+
+
+TYPED_TEST(Coo, ApplyLinearCombinationToStridedVectorKeepsPadding)
+{
+    using Vec = typename TestFixture::Vec;
+    using T = typename TestFixture::value_type;
+    auto alpha = gko::initialize<Vec>({-1.0}, this->exec);
+    auto beta = gko::initialize<Vec>({2.0}, this->exec);
+    auto x = gko::initialize<Vec>({2.0, 1.0, 4.0}, this->exec);
+    auto y = Vec::create(this->exec, gko::dim<2>{2, 1}, 2);
+    y->get_values()[1] = 1234;
+    y->at(0, 0) = 1.0;
+    y->at(1, 0) = 2.0;
+
+    this->mtx->apply(alpha.get(), x.get(), beta.get(), y.get());
+
+    GKO_ASSERT_MTX_NEAR(y, l({-11.0, -1.0}), 0.0);
+    ASSERT_EQ(y->get_values()[1], T{1234});
 }
 
 


### PR DESCRIPTION
This PR prevents the Coo CPU kernels from overwriting data past the end of the vector, since they took the amount of storage, not the actual number of elements into account.
The commit message is actually slightly inaccurate, since the linearized index skips padding, but may write past the end of the vector.