### PR TITLE
Tune OpenMP SellP, COO and ELL SpMV kernels for small number of rhs

### DIFF
--- a/include/ginkgo/core/base/math.hpp
+++ b/include/ginkgo/core/base/math.hpp
@@ -459,6 +459,31 @@ struct infinity_impl {
 };
 
 
+/**
+ * Computes the highest-precision type from a list of types
+ */
+template <typename T1, typename T2>
+struct highest_precision_impl {
+    using type = decltype(T1{} + T2{});
+};
+
+template <typename T1, typename T2>
+struct highest_precision_impl<std::complex<T1>, std::complex<T2>> {
+    using type = std::complex<typename highest_precision_impl<T1, T2>::type>;
+};
+
+template <typename Head, typename... Tail>
+struct highest_precision_variadic {
+    using type = typename highest_precision_impl<
+        Head, typename highest_precision_variadic<Tail...>::type>::type;
+};
+
+template <typename Head>
+struct highest_precision_variadic<Head> {
+    using type = Head;
+};
+
+
 }  // namespace detail
 
 
@@ -481,6 +506,11 @@ using reduce_precision = typename detail::reduce_precision_impl<T>::type;
  */
 template <typename T>
 using increase_precision = typename detail::increase_precision_impl<T>::type;
+
+
+template <typename... Ts>
+using highest_precision =
+    typename detail::highest_precision_variadic<Ts...>::type;
 
 
 /**

--- a/include/ginkgo/core/base/math.hpp
+++ b/include/ginkgo/core/base/math.hpp
@@ -508,6 +508,17 @@ template <typename T>
 using increase_precision = typename detail::increase_precision_impl<T>::type;
 
 
+/**
+ * Obtains the smallest arithmetic type that is able to store elements of all
+ * template parameter types exactly. All template type parameters need to be
+ * either real or complex types, mixing them is not possible.
+ *
+ * Formally, it computes a right-fold over the type list, with the highest
+ * precision of a pair of real arithmetic types T1, T2 computed as
+ * `decltype(T1{} + T2{})`, or
+ * `std::complex<highest_precision<remove_complex<T1>, remove_complex<T2>>>` for
+ * complex types.
+ */
 template <typename... Ts>
 using highest_precision =
     typename detail::highest_precision_variadic<Ts...>::type;

--- a/omp/matrix/coo_kernels.cpp
+++ b/omp/matrix/coo_kernels.cpp
@@ -33,6 +33,9 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "core/matrix/coo_kernels.hpp"
 
 
+#include <array>
+
+
 #include <omp.h>
 
 
@@ -91,15 +94,18 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
     GKO_DECLARE_COO_ADVANCED_SPMV_KERNEL);
 
 
-template <typename ValueType, typename IndexType>
-void spmv2(std::shared_ptr<const OmpExecutor> exec,
-           const matrix::Coo<ValueType, IndexType>* a,
-           const matrix::Dense<ValueType>* b, matrix::Dense<ValueType>* c)
+template <int block_size, typename ValueType, typename IndexType>
+void spmv2_blocked(std::shared_ptr<const OmpExecutor> exec,
+                   const matrix::Coo<ValueType, IndexType>* a,
+                   const matrix::Dense<ValueType>* b,
+                   matrix::Dense<ValueType>* c, ValueType scale)
 {
+    GKO_ASSERT(b->get_size()[1] > block_size);
     const auto coo_val = a->get_const_values();
     const auto coo_col = a->get_const_col_idxs();
     const auto coo_row = a->get_const_row_idxs();
     const auto num_rhs = b->get_size()[1];
+    const auto rounded_rhs = num_rhs / block_size * block_size;
     const auto sentinel_row = a->get_size()[0] + 1;
     const auto nnz = a->get_num_stored_elements();
 
@@ -115,29 +121,228 @@ void spmv2(std::shared_ptr<const OmpExecutor> exec,
             const auto first = begin > 0 ? coo_row[begin - 1] : sentinel_row;
             const auto last = end < nnz ? coo_row[end] : sentinel_row;
             auto nz = begin;
-            for (; nz < end && coo_row[nz] == first; nz++) {
-                const auto row = first;
-                const auto col = coo_col[nz];
-                for (size_type rhs = 0; rhs < num_rhs; rhs++) {
-                    atomic_add(c->at(row, rhs), coo_val[nz] * b->at(col, rhs));
+            std::array<ValueType, block_size> partial_sum;
+            if (first != sentinel_row) {
+                for (size_type rhs_base = 0; rhs_base < rounded_rhs;
+                     rhs_base += block_size) {
+                    // handle row overlap with previous thread: block partial
+                    // sums
+                    partial_sum.fill(zero<ValueType>());
+                    for (auto local_nz = nz;
+                         local_nz < end && coo_row[local_nz] == first;
+                         local_nz++) {
+                        const auto row = first;
+                        const auto col = coo_col[local_nz];
+#pragma unroll
+                        for (size_type i = 0; i < block_size; i++) {
+                            const auto rhs = i + rhs_base;
+                            partial_sum[i] +=
+                                scale * coo_val[local_nz] * b->at(col, rhs);
+                        }
+                    }
+                    // handle row overlap with previous thread: block add to
+                    // memory
+#pragma unroll
+                    for (size_type i = 0; i < block_size; i++) {
+                        const auto rhs = i + rhs_base;
+                        atomic_add(c->at(first, rhs), partial_sum[i]);
+                    }
+                }
+                // handle row overlap with previous thread: remainder partial
+                // sums
+                partial_sum.fill(zero<ValueType>());
+                for (; nz < end && coo_row[nz] == first; nz++) {
+                    const auto row = first;
+                    const auto col = coo_col[nz];
+                    for (size_type rhs = rounded_rhs; rhs < num_rhs; rhs++) {
+                        partial_sum[rhs - rounded_rhs] +=
+                            scale * coo_val[nz] * b->at(col, rhs);
+                    }
+                }
+                // handle row overlap with previous thread: remainder add to
+                // memory
+                for (size_type rhs = rounded_rhs; rhs < num_rhs; rhs++) {
+                    atomic_add(c->at(first, rhs),
+                               partial_sum[rhs - rounded_rhs]);
                 }
             }
+            // handle non-overlapping rows
             for (; nz < end && coo_row[nz] != last; nz++) {
                 const auto row = coo_row[nz];
                 const auto col = coo_col[nz];
-                for (size_type rhs = 0; rhs < num_rhs; rhs++) {
-                    c->at(row, rhs) += coo_val[nz] * b->at(col, rhs);
+                for (size_type rhs_base = 0; rhs_base < rounded_rhs;
+                     rhs_base += block_size) {
+#pragma unroll
+                    for (size_type i = 0; i < block_size; i++) {
+                        const auto rhs = i + rhs_base;
+                        c->at(row, rhs) +=
+                            scale * coo_val[nz] * b->at(col, rhs);
+                    }
+                }
+                for (size_type rhs = rounded_rhs; rhs < num_rhs; rhs++) {
+                    c->at(row, rhs) += scale * coo_val[nz] * b->at(col, rhs);
                 }
             }
-            for (; nz < end; nz++) {
-                const auto row = last;
-                const auto col = coo_col[nz];
-                for (size_type rhs = 0; rhs < num_rhs; rhs++) {
-                    atomic_add(c->at(row, rhs), coo_val[nz] * b->at(col, rhs));
+            if (last != sentinel_row) {
+                for (size_type rhs_base = 0; rhs_base < rounded_rhs;
+                     rhs_base += block_size) {
+                    // handle row overlap with following thread: block partial
+                    // sums
+                    partial_sum.fill(zero<ValueType>());
+                    for (auto local_nz = nz; local_nz < end; local_nz++) {
+                        const auto row = last;
+                        const auto col = coo_col[local_nz];
+#pragma unroll
+                        for (size_type i = 0; i < block_size; i++) {
+                            const auto rhs = i + rhs_base;
+                            partial_sum[i] +=
+                                scale * coo_val[local_nz] * b->at(col, rhs);
+                        }
+                    }
+                    // handle row overlap with following thread: block add to
+                    // memory
+#pragma unroll
+                    for (size_type i = 0; i < block_size; i++) {
+                        const auto rhs = i + rhs_base;
+                        const auto row = last;
+                        atomic_add(c->at(last, rhs), partial_sum[i]);
+                    }
+                }
+                // handle row overlap with following thread: block partial sums
+                partial_sum.fill(zero<ValueType>());
+                for (; nz < end; nz++) {
+                    const auto row = last;
+                    const auto col = coo_col[nz];
+                    for (size_type rhs = rounded_rhs; rhs < num_rhs; rhs++) {
+                        partial_sum[rhs - rounded_rhs] +=
+                            scale * coo_val[nz] * b->at(col, rhs);
+                    }
+                }
+                // handle row overlap with following thread: block add to memory
+                for (size_type rhs = rounded_rhs; rhs < num_rhs; rhs++) {
+                    const auto row = last;
+                    atomic_add(c->at(last, rhs),
+                               partial_sum[rhs - rounded_rhs]);
                 }
             }
         }
     }
+}
+
+
+template <int num_rhs, typename ValueType, typename IndexType>
+void spmv2_small_rhs(std::shared_ptr<const OmpExecutor> exec,
+                     const matrix::Coo<ValueType, IndexType>* a,
+                     const matrix::Dense<ValueType>* b,
+                     matrix::Dense<ValueType>* c, ValueType scale)
+{
+    GKO_ASSERT(b->get_size()[1] == num_rhs);
+    const auto coo_val = a->get_const_values();
+    const auto coo_col = a->get_const_col_idxs();
+    const auto coo_row = a->get_const_row_idxs();
+    const auto sentinel_row = a->get_size()[0] + 1;
+    const auto nnz = a->get_num_stored_elements();
+
+#pragma omp parallel
+    {
+        const auto num_threads = omp_get_num_threads();
+        const auto work_per_thread =
+            static_cast<size_type>(ceildiv(nnz, num_threads));
+        const auto thread_id = static_cast<size_type>(omp_get_thread_num());
+        const auto begin = work_per_thread * thread_id;
+        const auto end = std::min(begin + work_per_thread, nnz);
+        if (begin < end) {
+            const auto first = begin > 0 ? coo_row[begin - 1] : sentinel_row;
+            const auto last = end < nnz ? coo_row[end] : sentinel_row;
+            auto nz = begin;
+            std::array<ValueType, num_rhs> partial_sum;
+            if (first != sentinel_row) {
+                // handle row overlap with previous thread: partial sums
+                partial_sum.fill(zero<ValueType>());
+                for (; nz < end && coo_row[nz] == first; nz++) {
+                    const auto row = first;
+                    const auto col = coo_col[nz];
+#pragma unroll
+                    for (size_type rhs = 0; rhs < num_rhs; rhs++) {
+                        partial_sum[rhs] +=
+                            scale * coo_val[nz] * b->at(col, rhs);
+                    }
+                }
+                // handle row overlap with previous thread: add to memory
+#pragma unroll
+                for (size_type rhs = 0; rhs < num_rhs; rhs++) {
+                    atomic_add(c->at(first, rhs), partial_sum[rhs]);
+                }
+            }
+            // handle non-overlapping rows
+            for (; nz < end && coo_row[nz] != last; nz++) {
+                const auto row = coo_row[nz];
+                const auto col = coo_col[nz];
+#pragma unroll
+                for (size_type rhs = 0; rhs < num_rhs; rhs++) {
+                    c->at(row, rhs) += scale * coo_val[nz] * b->at(col, rhs);
+                }
+            }
+            if (last != sentinel_row) {
+                // handle row overlap with following thread: partial sums
+                partial_sum.fill(zero<ValueType>());
+                for (; nz < end; nz++) {
+                    const auto row = last;
+                    const auto col = coo_col[nz];
+#pragma unroll
+                    for (size_type rhs = 0; rhs < num_rhs; rhs++) {
+                        partial_sum[rhs] +=
+                            scale * coo_val[nz] * b->at(col, rhs);
+                    }
+                }
+                // handle row overlap with following thread: add to memory
+#pragma unroll
+                for (size_type rhs = 0; rhs < num_rhs; rhs++) {
+                    const auto row = last;
+                    atomic_add(c->at(last, rhs), partial_sum[rhs]);
+                }
+            }
+        }
+    }
+}
+
+
+template <typename ValueType, typename IndexType>
+void generic_spmv2(std::shared_ptr<const OmpExecutor> exec,
+                   const matrix::Coo<ValueType, IndexType>* a,
+                   const matrix::Dense<ValueType>* b,
+                   matrix::Dense<ValueType>* c, ValueType scale)
+{
+    const auto num_rhs = b->get_size()[1];
+    if (num_rhs <= 0) {
+        return;
+    }
+    if (num_rhs == 1) {
+        spmv2_small_rhs<1>(exec, a, b, c, scale);
+        return;
+    }
+    if (num_rhs == 2) {
+        spmv2_small_rhs<2>(exec, a, b, c, scale);
+        return;
+    }
+    if (num_rhs == 3) {
+        spmv2_small_rhs<3>(exec, a, b, c, scale);
+        return;
+    }
+    if (num_rhs == 4) {
+        spmv2_small_rhs<4>(exec, a, b, c, scale);
+        return;
+    }
+    spmv2_blocked<4>(exec, a, b, c, scale);
+}
+
+
+template <typename ValueType, typename IndexType>
+void spmv2(std::shared_ptr<const OmpExecutor> exec,
+           const matrix::Coo<ValueType, IndexType>* a,
+           const matrix::Dense<ValueType>* b, matrix::Dense<ValueType>* c)
+{
+    generic_spmv2(exec, a, b, c, one<ValueType>());
 }
 
 GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(GKO_DECLARE_COO_SPMV2_KERNEL);
@@ -150,51 +355,7 @@ void advanced_spmv2(std::shared_ptr<const OmpExecutor> exec,
                     const matrix::Dense<ValueType>* b,
                     matrix::Dense<ValueType>* c)
 {
-    const auto coo_val = a->get_const_values();
-    const auto coo_col = a->get_const_col_idxs();
-    const auto coo_row = a->get_const_row_idxs();
-    const auto num_rhs = b->get_size()[1];
-    const auto sentinel_row = a->get_size()[0] + 1;
-    const auto nnz = a->get_num_stored_elements();
-    const auto scale = alpha->at(0, 0);
-
-#pragma omp parallel
-    {
-        const auto num_threads = omp_get_num_threads();
-        const auto work_per_thread =
-            static_cast<size_type>(ceildiv(nnz, num_threads));
-        const auto thread_id = static_cast<size_type>(omp_get_thread_num());
-        const auto begin = work_per_thread * thread_id;
-        const auto end = std::min(begin + work_per_thread, nnz);
-        if (begin < end) {
-            const auto first = begin > 0 ? coo_row[begin - 1] : sentinel_row;
-            const auto last = end < nnz ? coo_row[end] : sentinel_row;
-            auto nz = begin;
-            for (; nz < end && coo_row[nz] == first; nz++) {
-                const auto row = first;
-                const auto col = coo_col[nz];
-                for (size_type rhs = 0; rhs < num_rhs; rhs++) {
-                    atomic_add(c->at(row, rhs),
-                               scale * coo_val[nz] * b->at(col, rhs));
-                }
-            }
-            for (; nz < end && coo_row[nz] != last; nz++) {
-                const auto row = coo_row[nz];
-                const auto col = coo_col[nz];
-                for (size_type rhs = 0; rhs < num_rhs; rhs++) {
-                    c->at(row, rhs) += scale * coo_val[nz] * b->at(col, rhs);
-                }
-            }
-            for (; nz < end; nz++) {
-                const auto row = last;
-                const auto col = coo_col[nz];
-                for (size_type rhs = 0; rhs < num_rhs; rhs++) {
-                    atomic_add(c->at(row, rhs),
-                               scale * coo_val[nz] * b->at(col, rhs));
-                }
-            }
-        }
-    }
+    generic_spmv2(exec, a, b, c, alpha->at(0, 0));
 }
 
 GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(

--- a/omp/matrix/ell_kernels.cpp
+++ b/omp/matrix/ell_kernels.cpp
@@ -33,6 +33,9 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "core/matrix/ell_kernels.hpp"
 
 
+#include <array>
+
+
 #include <omp.h>
 
 
@@ -58,13 +61,16 @@ namespace omp {
 namespace ell {
 
 
-template <typename InputValueType, typename MatrixValueType,
-          typename OutputValueType, typename IndexType>
-void spmv(std::shared_ptr<const OmpExecutor> exec,
-          const matrix::Ell<MatrixValueType, IndexType>* a,
-          const matrix::Dense<InputValueType>* b,
-          matrix::Dense<OutputValueType>* c)
+template <int num_rhs, typename InputValueType, typename MatrixValueType,
+          typename OutputValueType, typename IndexType, typename OutFn>
+void spmv_small_rhs(std::shared_ptr<const OmpExecutor> exec,
+                    const matrix::Ell<MatrixValueType, IndexType>* a,
+                    const matrix::Dense<InputValueType>* b,
+                    matrix::Dense<OutputValueType>* c, OutFn out)
 {
+    GKO_ASSERT(b->get_size()[1] == num_rhs);
+    using arithmetic_type =
+        decltype(InputValueType{} + OutputValueType{} + MatrixValueType{});
     using a_accessor =
         gko::acc::reduced_row_major<1, OutputValueType, const MatrixValueType>;
     using b_accessor =
@@ -82,17 +88,116 @@ void spmv(std::shared_ptr<const OmpExecutor> exec,
 
 #pragma omp parallel for
     for (size_type row = 0; row < a->get_size()[0]; row++) {
-        for (size_type j = 0; j < c->get_size()[1]; j++) {
-            c->at(row, j) = zero<OutputValueType>();
-        }
+        std::array<arithmetic_type, num_rhs> partial_sum;
+        partial_sum.fill(zero<arithmetic_type>());
         for (size_type i = 0; i < num_stored_elements_per_row; i++) {
             auto val = a_vals(row + i * stride);
             auto col = a->col_at(row, i);
-            for (size_type j = 0; j < c->get_size()[1]; j++) {
-                c->at(row, j) += val * b_vals(col, j);
+#pragma unroll
+            for (size_type j = 0; j < num_rhs; j++) {
+                partial_sum[j] += val * b_vals(col, j);
             }
         }
+#pragma unroll
+        for (size_type j = 0; j < num_rhs; j++) {
+            c->at(row, j) = out(row, j, partial_sum[j]);
+        }
     }
+}
+
+
+template <int block_size, typename InputValueType, typename MatrixValueType,
+          typename OutputValueType, typename IndexType, typename OutFn>
+void spmv_blocked(std::shared_ptr<const OmpExecutor> exec,
+                  const matrix::Ell<MatrixValueType, IndexType>* a,
+                  const matrix::Dense<InputValueType>* b,
+                  matrix::Dense<OutputValueType>* c, OutFn out)
+{
+    GKO_ASSERT(b->get_size()[1] > block_size);
+    using arithmetic_type =
+        decltype(InputValueType{} + OutputValueType{} + MatrixValueType{});
+    using a_accessor =
+        gko::acc::reduced_row_major<1, OutputValueType, const MatrixValueType>;
+    using b_accessor =
+        gko::acc::reduced_row_major<2, OutputValueType, const InputValueType>;
+
+    const auto num_stored_elements_per_row =
+        a->get_num_stored_elements_per_row();
+    const auto stride = a->get_stride();
+    const auto a_vals = gko::acc::range<a_accessor>(
+        std::array<size_type, 1>{num_stored_elements_per_row * stride},
+        a->get_const_values());
+    const auto b_vals = gko::acc::range<b_accessor>(
+        std::array<size_type, 2>{{b->get_size()[0], b->get_size()[1]}},
+        b->get_const_values(), std::array<size_type, 1>{{b->get_stride()}});
+
+    const auto num_rhs = b->get_size()[1];
+    const auto rounded_rhs = num_rhs / block_size * block_size;
+
+#pragma omp parallel for
+    for (size_type row = 0; row < a->get_size()[0]; row++) {
+        std::array<arithmetic_type, block_size> partial_sum;
+        for (size_type rhs_base = 0; rhs_base < rounded_rhs;
+             rhs_base += block_size) {
+            partial_sum.fill(zero<arithmetic_type>());
+            for (size_type i = 0; i < num_stored_elements_per_row; i++) {
+                auto val = a_vals(row + i * stride);
+                auto col = a->col_at(row, i);
+#pragma unroll
+                for (size_type j = 0; j < block_size; j++) {
+                    partial_sum[j] += val * b_vals(col, j + rhs_base);
+                }
+            }
+#pragma unroll
+            for (size_type j = 0; j < block_size; j++) {
+                const auto col = j + rhs_base;
+                c->at(row, col) = out(row, col, partial_sum[j]);
+            }
+        }
+        partial_sum.fill(zero<arithmetic_type>());
+        for (size_type i = 0; i < num_stored_elements_per_row; i++) {
+            auto val = a_vals(row + i * stride);
+            auto col = a->col_at(row, i);
+            for (size_type j = rounded_rhs; j < num_rhs; j++) {
+                partial_sum[j - rounded_rhs] += val * b_vals(col, j);
+            }
+        }
+        for (size_type j = rounded_rhs; j < num_rhs; j++) {
+            c->at(row, j) = out(row, j, partial_sum[j - rounded_rhs]);
+        }
+    }
+}
+
+
+template <typename InputValueType, typename MatrixValueType,
+          typename OutputValueType, typename IndexType>
+void spmv(std::shared_ptr<const OmpExecutor> exec,
+          const matrix::Ell<MatrixValueType, IndexType>* a,
+          const matrix::Dense<InputValueType>* b,
+          matrix::Dense<OutputValueType>* c)
+{
+    const auto num_rhs = b->get_size()[1];
+    if (num_rhs <= 0) {
+        return;
+    }
+    auto out = [](auto, auto, auto value) { return value; };
+    if (num_rhs == 1) {
+        spmv_small_rhs<1>(exec, a, b, c, out);
+        return;
+    }
+    if (num_rhs == 2) {
+        spmv_small_rhs<2>(exec, a, b, c, out);
+        return;
+    }
+    if (num_rhs == 3) {
+        spmv_small_rhs<3>(exec, a, b, c, out);
+        return;
+    }
+    if (num_rhs == 4) {
+        spmv_small_rhs<4>(exec, a, b, c, out);
+        return;
+    }
+    spmv_blocked<4>(exec, a, b, c, out);
 }
 
 GKO_INSTANTIATE_FOR_EACH_MIXED_VALUE_AND_INDEX_TYPE(
@@ -108,36 +213,32 @@ void advanced_spmv(std::shared_ptr<const OmpExecutor> exec,
                    const matrix::Dense<OutputValueType>* beta,
                    matrix::Dense<OutputValueType>* c)
 {
-    using a_accessor =
-        gko::acc::reduced_row_major<1, OutputValueType, const MatrixValueType>;
-    using b_accessor =
-        gko::acc::reduced_row_major<2, OutputValueType, const InputValueType>;
-
-    const auto num_stored_elements_per_row =
-        a->get_num_stored_elements_per_row();
-    const auto stride = a->get_stride();
-    const auto a_vals = gko::acc::range<a_accessor>(
-        std::array<size_type, 1>{num_stored_elements_per_row * stride},
-        a->get_const_values());
-    const auto b_vals = gko::acc::range<b_accessor>(
-        std::array<size_type, 2>{{b->get_size()[0], b->get_size()[1]}},
-        b->get_const_values(), std::array<size_type, 1>{{b->get_stride()}});
-    const auto alpha_val = OutputValueType(alpha->at(0, 0));
-    const auto beta_val = beta->at(0, 0);
-
-#pragma omp parallel for
-    for (size_type row = 0; row < a->get_size()[0]; row++) {
-        for (size_type j = 0; j < c->get_size()[1]; j++) {
-            c->at(row, j) *= beta_val;
-        }
-        for (size_type i = 0; i < num_stored_elements_per_row; i++) {
-            auto val = a_vals(row + i * stride);
-            auto col = a->col_at(row, i);
-            for (size_type j = 0; j < c->get_size()[1]; j++) {
-                c->at(row, j) += alpha_val * val * b_vals(col, j);
-            }
-        }
+    const auto num_rhs = b->get_size()[1];
+    if (num_rhs <= 0) {
+        return;
     }
+    const auto alpha_val = alpha->at(0, 0);
+    const auto beta_val = beta->at(0, 0);
+    auto out = [&](auto i, auto j, auto value) {
+        return alpha_val * value + beta_val * c->at(i, j);
+    };
+    if (num_rhs == 1) {
+        spmv_small_rhs<1>(exec, a, b, c, out);
+        return;
+    }
+    if (num_rhs == 2) {
+        spmv_small_rhs<2>(exec, a, b, c, out);
+        return;
+    }
+    if (num_rhs == 3) {
+        spmv_small_rhs<3>(exec, a, b, c, out);
+        return;
+    }
+    if (num_rhs == 4) {
+        spmv_small_rhs<4>(exec, a, b, c, out);
+        return;
+    }
+    spmv_blocked<4>(exec, a, b, c, out);
 }
 
 GKO_INSTANTIATE_FOR_EACH_MIXED_VALUE_AND_INDEX_TYPE(

--- a/omp/matrix/ell_kernels.cpp
+++ b/omp/matrix/ell_kernels.cpp
@@ -100,7 +100,7 @@ void spmv_small_rhs(std::shared_ptr<const OmpExecutor> exec,
         }
 #pragma unroll
         for (size_type j = 0; j < num_rhs; j++) {
-            c->at(row, j) = out(row, j, partial_sum[j]);
+            [&] { c->at(row, j) = out(row, j, partial_sum[j]); }();
         }
     }
 }
@@ -151,7 +151,7 @@ void spmv_blocked(std::shared_ptr<const OmpExecutor> exec,
 #pragma unroll
             for (size_type j = 0; j < block_size; j++) {
                 const auto col = j + rhs_base;
-                c->at(row, col) = out(row, col, partial_sum[j]);
+                [&] { c->at(row, col) = out(row, col, partial_sum[j]); }();
             }
         }
         partial_sum.fill(zero<arithmetic_type>());
@@ -163,7 +163,9 @@ void spmv_blocked(std::shared_ptr<const OmpExecutor> exec,
             }
         }
         for (size_type j = rounded_rhs; j < num_rhs; j++) {
-            c->at(row, j) = out(row, j, partial_sum[j - rounded_rhs]);
+            [&] {
+                c->at(row, j) = out(row, j, partial_sum[j - rounded_rhs]);
+            }();
         }
     }
 }

--- a/omp/matrix/sellp_kernels.cpp
+++ b/omp/matrix/sellp_kernels.cpp
@@ -82,7 +82,10 @@ void spmv_small_rhs(std::shared_ptr<const OmpExecutor> exec,
                 }
 #pragma unroll
                 for (size_type j = 0; j < num_rhs; j++) {
-                    c->at(global_row, j) = out(global_row, j, partial_sum[j]);
+                    [&] {
+                        c->at(global_row, j) =
+                            out(global_row, j, partial_sum[j]);
+                    }();
                 }
             }
         }
@@ -123,8 +126,10 @@ void spmv_blocked(std::shared_ptr<const OmpExecutor> exec,
                     }
 #pragma unroll
                     for (size_type j = 0; j < block_size; j++) {
-                        c->at(global_row, j + rhs_base) =
-                            out(global_row, j + rhs_base, partial_sum[j]);
+                        [&] {
+                            c->at(global_row, j + rhs_base) =
+                                out(global_row, j + rhs_base, partial_sum[j]);
+                        }();
                     }
                 }
                 partial_sum.fill(zero<ValueType>());
@@ -136,8 +141,10 @@ void spmv_blocked(std::shared_ptr<const OmpExecutor> exec,
                     }
                 }
                 for (size_type j = rounded_rhs; j < num_rhs; j++) {
-                    c->at(global_row, j) =
-                        out(global_row, j, partial_sum[j - rounded_rhs]);
+                    [&] {
+                        c->at(global_row, j) =
+                            out(global_row, j, partial_sum[j - rounded_rhs]);
+                    }();
                 }
             }
         }

--- a/omp/matrix/sellp_kernels.cpp
+++ b/omp/matrix/sellp_kernels.cpp
@@ -33,6 +33,9 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "core/matrix/sellp_kernels.hpp"
 
 
+#include <array>
+
+
 #include <omp.h>
 
 
@@ -50,11 +53,13 @@ namespace omp {
 namespace sellp {
 
 
-template <typename ValueType, typename IndexType>
-void spmv(std::shared_ptr<const OmpExecutor> exec,
-          const matrix::Sellp<ValueType, IndexType>* a,
-          const matrix::Dense<ValueType>* b, matrix::Dense<ValueType>* c)
+template <int num_rhs, typename ValueType, typename IndexType, typename OutFn>
+void spmv_small_rhs(std::shared_ptr<const OmpExecutor> exec,
+                    const matrix::Sellp<ValueType, IndexType>* a,
+                    const matrix::Dense<ValueType>* b,
+                    matrix::Dense<ValueType>* c, OutFn out)
 {
+    GKO_ASSERT(b->get_size()[1] == num_rhs);
     auto col_idxs = a->get_const_col_idxs();
     auto slice_lengths = a->get_const_slice_lengths();
     auto slice_sets = a->get_const_slice_sets();
@@ -65,19 +70,108 @@ void spmv(std::shared_ptr<const OmpExecutor> exec,
         for (size_type row = 0; row < slice_size; row++) {
             size_type global_row = slice * slice_size + row;
             if (global_row < a->get_size()[0]) {
-                for (size_type j = 0; j < c->get_size()[1]; j++) {
-                    c->at(global_row, j) = zero<ValueType>();
-                }
+                std::array<ValueType, num_rhs> partial_sum;
+                partial_sum.fill(zero<ValueType>());
                 for (size_type i = 0; i < slice_lengths[slice]; i++) {
                     auto val = a->val_at(row, slice_sets[slice], i);
                     auto col = a->col_at(row, slice_sets[slice], i);
-                    for (size_type j = 0; j < c->get_size()[1]; j++) {
-                        c->at(global_row, j) += val * b->at(col, j);
+#pragma unroll
+                    for (size_type j = 0; j < num_rhs; j++) {
+                        partial_sum[j] += val * b->at(col, j);
                     }
+                }
+#pragma unroll
+                for (size_type j = 0; j < num_rhs; j++) {
+                    c->at(global_row, j) = out(global_row, j, partial_sum[j]);
                 }
             }
         }
     }
+}
+
+
+template <int block_size, typename ValueType, typename IndexType,
+          typename OutFn>
+void spmv_blocked(std::shared_ptr<const OmpExecutor> exec,
+                  const matrix::Sellp<ValueType, IndexType>* a,
+                  const matrix::Dense<ValueType>* b,
+                  matrix::Dense<ValueType>* c, OutFn out)
+{
+    auto col_idxs = a->get_const_col_idxs();
+    auto slice_lengths = a->get_const_slice_lengths();
+    auto slice_sets = a->get_const_slice_sets();
+    auto slice_size = a->get_slice_size();
+    auto slice_num = ceildiv(a->get_size()[0] + slice_size - 1, slice_size);
+    const auto num_rhs = b->get_size()[1];
+    const auto rounded_rhs = num_rhs / block_size * block_size;
+#pragma omp parallel for collapse(2)
+    for (size_type slice = 0; slice < slice_num; slice++) {
+        for (size_type row = 0; row < slice_size; row++) {
+            size_type global_row = slice * slice_size + row;
+            if (global_row < a->get_size()[0]) {
+                std::array<ValueType, block_size> partial_sum;
+                for (size_type rhs_base = 0; rhs_base < rounded_rhs;
+                     rhs_base += block_size) {
+                    partial_sum.fill(zero<ValueType>());
+                    for (size_type i = 0; i < slice_lengths[slice]; i++) {
+                        auto val = a->val_at(row, slice_sets[slice], i);
+                        auto col = a->col_at(row, slice_sets[slice], i);
+#pragma unroll
+                        for (size_type j = 0; j < block_size; j++) {
+                            partial_sum[j] += val * b->at(col, j + rhs_base);
+                        }
+                    }
+#pragma unroll
+                    for (size_type j = 0; j < block_size; j++) {
+                        c->at(global_row, j + rhs_base) =
+                            out(global_row, j + rhs_base, partial_sum[j]);
+                    }
+                }
+                partial_sum.fill(zero<ValueType>());
+                for (size_type i = 0; i < slice_lengths[slice]; i++) {
+                    auto val = a->val_at(row, slice_sets[slice], i);
+                    auto col = a->col_at(row, slice_sets[slice], i);
+                    for (size_type j = rounded_rhs; j < num_rhs; j++) {
+                        partial_sum[j - rounded_rhs] += val * b->at(col, j);
+                    }
+                }
+                for (size_type j = rounded_rhs; j < num_rhs; j++) {
+                    c->at(global_row, j) =
+                        out(global_row, j, partial_sum[j - rounded_rhs]);
+                }
+            }
+        }
+    }
+}
+
+
+template <typename ValueType, typename IndexType>
+void spmv(std::shared_ptr<const OmpExecutor> exec,
+          const matrix::Sellp<ValueType, IndexType>* a,
+          const matrix::Dense<ValueType>* b, matrix::Dense<ValueType>* c)
+{
+    const auto num_rhs = b->get_size()[1];
+    if (num_rhs <= 0) {
+        return;
+    }
+    auto out = [](auto, auto, auto value) { return value; };
+    if (num_rhs == 1) {
+        spmv_small_rhs<1>(exec, a, b, c, out);
+        return;
+    }
+    if (num_rhs == 2) {
+        spmv_small_rhs<2>(exec, a, b, c, out);
+        return;
+    }
+    if (num_rhs == 3) {
+        spmv_small_rhs<3>(exec, a, b, c, out);
+        return;
+    }
+    if (num_rhs == 4) {
+        spmv_small_rhs<4>(exec, a, b, c, out);
+        return;
+    }
+    spmv_blocked<4>(exec, a, b, c, out);
 }
 
 GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(GKO_DECLARE_SELLP_SPMV_KERNEL);
@@ -91,32 +185,32 @@ void advanced_spmv(std::shared_ptr<const OmpExecutor> exec,
                    const matrix::Dense<ValueType>* beta,
                    matrix::Dense<ValueType>* c)
 {
-    auto vals = a->get_const_values();
-    auto col_idxs = a->get_const_col_idxs();
-    auto slice_lengths = a->get_const_slice_lengths();
-    auto slice_sets = a->get_const_slice_sets();
-    auto slice_size = a->get_slice_size();
-    auto slice_num = ceildiv(a->get_size()[0] + slice_size - 1, slice_size);
-    auto valpha = alpha->at(0, 0);
-    auto vbeta = beta->at(0, 0);
-#pragma omp parallel for collapse(2)
-    for (size_type slice = 0; slice < slice_num; slice++) {
-        for (size_type row = 0; row < slice_size; row++) {
-            size_type global_row = slice * slice_size + row;
-            if (global_row < a->get_size()[0]) {
-                for (size_type j = 0; j < c->get_size()[1]; j++) {
-                    c->at(global_row, j) *= vbeta;
-                }
-                for (size_type i = 0; i < slice_lengths[slice]; i++) {
-                    auto val = a->val_at(row, slice_sets[slice], i);
-                    auto col = a->col_at(row, slice_sets[slice], i);
-                    for (size_type j = 0; j < c->get_size()[1]; j++) {
-                        c->at(global_row, j) += valpha * val * b->at(col, j);
-                    }
-                }
-            }
-        }
+    const auto num_rhs = b->get_size()[1];
+    if (num_rhs <= 0) {
+        return;
     }
+    const auto alpha_val = alpha->at(0, 0);
+    const auto beta_val = beta->at(0, 0);
+    auto out = [&](auto i, auto j, auto value) {
+        return alpha_val * value + beta_val * c->at(i, j);
+    };
+    if (num_rhs == 1) {
+        spmv_small_rhs<1>(exec, a, b, c, out);
+        return;
+    }
+    if (num_rhs == 2) {
+        spmv_small_rhs<2>(exec, a, b, c, out);
+        return;
+    }
+    if (num_rhs == 3) {
+        spmv_small_rhs<3>(exec, a, b, c, out);
+        return;
+    }
+    if (num_rhs == 4) {
+        spmv_small_rhs<4>(exec, a, b, c, out);
+        return;
+    }
+    spmv_blocked<4>(exec, a, b, c, out);
 }
 
 GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(

--- a/omp/matrix/sellp_kernels.cpp
+++ b/omp/matrix/sellp_kernels.cpp
@@ -60,7 +60,6 @@ void spmv_small_rhs(std::shared_ptr<const OmpExecutor> exec,
                     matrix::Dense<ValueType>* c, OutFn out)
 {
     GKO_ASSERT(b->get_size()[1] == num_rhs);
-    auto col_idxs = a->get_const_col_idxs();
     auto slice_lengths = a->get_const_slice_lengths();
     auto slice_sets = a->get_const_slice_sets();
     auto slice_size = a->get_slice_size();
@@ -100,7 +99,6 @@ void spmv_blocked(std::shared_ptr<const OmpExecutor> exec,
                   const matrix::Dense<ValueType>* b,
                   matrix::Dense<ValueType>* c, OutFn out)
 {
-    auto col_idxs = a->get_const_col_idxs();
     auto slice_lengths = a->get_const_slice_lengths();
     auto slice_sets = a->get_const_slice_sets();
     auto slice_size = a->get_slice_size();

--- a/omp/test/matrix/coo_kernels.cpp
+++ b/omp/test/matrix/coo_kernels.cpp
@@ -228,7 +228,7 @@ TEST_F(Coo, SimpleApplyToDenseMatrixIsEquivalentToRef)
 
 TEST_F(Coo, AdvancedApplyToDenseMatrixIsEquivalentToRef)
 {
-    set_up_apply_data(3);
+    set_up_apply_data(4);
 
     mtx->apply(alpha.get(), y.get(), beta.get(), expected.get());
     dmtx->apply(dalpha.get(), dy.get(), dbeta.get(), dresult.get());
@@ -239,7 +239,7 @@ TEST_F(Coo, AdvancedApplyToDenseMatrixIsEquivalentToRef)
 
 TEST_F(Coo, SimpleApplyAddToDenseMatrixIsEquivalentToRef)
 {
-    set_up_apply_data(3);
+    set_up_apply_data(5);
 
     mtx->apply2(y.get(), expected.get());
     dmtx->apply2(dy.get(), dresult.get());
@@ -250,7 +250,7 @@ TEST_F(Coo, SimpleApplyAddToDenseMatrixIsEquivalentToRef)
 
 TEST_F(Coo, SimpleApplyAddToDenseMatrixIsEquivalentToRefUnsorted)
 {
-    set_up_apply_data(3);
+    set_up_apply_data(6);
     auto pair = gen_unsorted_mtx();
 
     pair.ref->apply2(y.get(), expected.get());
@@ -262,7 +262,7 @@ TEST_F(Coo, SimpleApplyAddToDenseMatrixIsEquivalentToRefUnsorted)
 
 TEST_F(Coo, AdvancedApplyAddToDenseMatrixIsEquivalentToRef)
 {
-    set_up_apply_data(3);
+    set_up_apply_data(7);
 
     mtx->apply2(alpha.get(), y.get(), expected.get());
     dmtx->apply2(dalpha.get(), dy.get(), dresult.get());

--- a/omp/test/matrix/ell_kernels.cpp
+++ b/omp/test/matrix/ell_kernels.cpp
@@ -326,7 +326,7 @@ TEST_F(Ell, SimpleApplyToDenseMatrixIsEquivalentToRef)
 
 TEST_F(Ell, MixedSimpleApplyToDenseMatrixIsEquivalentToRef1)
 {
-    set_up_apply_data(0, 0, 3);
+    set_up_apply_data(0, 0, 4);
 
     mtx->apply(y2.get(), expected2.get());
     dmtx->apply(dy2.get(), dresult2.get());
@@ -337,7 +337,7 @@ TEST_F(Ell, MixedSimpleApplyToDenseMatrixIsEquivalentToRef1)
 
 TEST_F(Ell, MixedSimpleApplyToDenseMatrixIsEquivalentToRef2)
 {
-    set_up_apply_data(0, 0, 3);
+    set_up_apply_data(0, 0, 5);
 
     mtx->apply(y2.get(), expected.get());
     dmtx->apply(dy2.get(), dresult.get());
@@ -348,7 +348,7 @@ TEST_F(Ell, MixedSimpleApplyToDenseMatrixIsEquivalentToRef2)
 
 TEST_F(Ell, MixedSimpleApplyToDenseMatrixIsEquivalentToRef3)
 {
-    set_up_apply_data(0, 0, 3);
+    set_up_apply_data(0, 0, 6);
 
     mtx->apply(y.get(), expected2.get());
     dmtx->apply(dy.get(), dresult2.get());
@@ -370,7 +370,7 @@ TEST_F(Ell, AdvancedApplyToDenseMatrixIsEquivalentToRef)
 
 TEST_F(Ell, MixedAdvancedApplyToDenseMatrixIsEquivalentToRef1)
 {
-    set_up_apply_data(0, 0, 3);
+    set_up_apply_data(0, 0, 4);
 
     mtx->apply(alpha2.get(), y2.get(), beta2.get(), expected2.get());
     dmtx->apply(dalpha2.get(), dy2.get(), dbeta2.get(), dresult2.get());
@@ -381,7 +381,7 @@ TEST_F(Ell, MixedAdvancedApplyToDenseMatrixIsEquivalentToRef1)
 
 TEST_F(Ell, MixedAdvancedApplyToDenseMatrixIsEquivalentToRef2)
 {
-    set_up_apply_data(0, 0, 3);
+    set_up_apply_data(0, 0, 5);
 
     mtx->apply(alpha2.get(), y2.get(), beta.get(), expected.get());
     dmtx->apply(dalpha2.get(), dy2.get(), dbeta.get(), dresult.get());
@@ -392,7 +392,7 @@ TEST_F(Ell, MixedAdvancedApplyToDenseMatrixIsEquivalentToRef2)
 
 TEST_F(Ell, MixedAdvancedApplyToDenseMatrixIsEquivalentToRef3)
 {
-    set_up_apply_data(0, 0, 3);
+    set_up_apply_data(0, 0, 6);
 
     mtx->apply(alpha.get(), y.get(), beta2.get(), expected2.get());
     dmtx->apply(dalpha.get(), dy.get(), dbeta2.get(), dresult2.get());

--- a/omp/test/matrix/sellp_kernels.cpp
+++ b/omp/test/matrix/sellp_kernels.cpp
@@ -168,7 +168,7 @@ TEST_F(Sellp, AdvancedApplyWithSliceSizeAndStrideFactorIsEquivalentToRef)
 
 TEST_F(Sellp, SimpleApplyMultipleRHSIsEquivalentToRef)
 {
-    set_up_apply_matrix(64);
+    set_up_apply_matrix(3);
 
     mtx->apply(y.get(), expected.get());
     dmtx->apply(dy.get(), dresult.get());
@@ -179,7 +179,7 @@ TEST_F(Sellp, SimpleApplyMultipleRHSIsEquivalentToRef)
 
 TEST_F(Sellp, AdvancedApplyMultipleRHSIsEquivalentToRef)
 {
-    set_up_apply_matrix(64);
+    set_up_apply_matrix(4);
 
     mtx->apply(alpha.get(), y.get(), beta.get(), expected.get());
     dmtx->apply(dalpha.get(), dy.get(), dbeta.get(), dresult.get());
@@ -191,7 +191,7 @@ TEST_F(Sellp, AdvancedApplyMultipleRHSIsEquivalentToRef)
 TEST_F(Sellp,
        SimpleApplyMultipleRHSWithSliceSizeAndStrideFactorIsEquivalentToRef)
 {
-    set_up_apply_matrix(32, 2);
+    set_up_apply_matrix(5, 2);
 
     mtx->apply(y.get(), expected.get());
     dmtx->apply(dy.get(), dresult.get());
@@ -203,7 +203,7 @@ TEST_F(Sellp,
 TEST_F(Sellp,
        AdvancedApplyMultipleRHSWithSliceSizeAndStrideFActorIsEquivalentToRef)
 {
-    set_up_apply_matrix(32, 2);
+    set_up_apply_matrix(6, 2);
 
     mtx->apply(alpha.get(), y.get(), beta.get(), expected.get());
     dmtx->apply(dalpha.get(), dy.get(), dbeta.get(), dresult.get());


### PR DESCRIPTION
This PR adds special-cases for small numbers of rhs and uses blocked operations for larger numbers of rhs.

As a side-effect, this also makes ELL mixed-precision SpMV more precise, since it uses the highest available precision.

- [x] Benchmark SpMV