### PR TITLE
ResidualNorm stop can compute the needed info in gen/check

### DIFF
--- a/core/stop/residual_norm.cpp
+++ b/core/stop/residual_norm.cpp
@@ -75,6 +75,27 @@ bool ResidualNormBase<ValueType>::check_impl(
             dense_r->compute_norm2(u_dense_tau_.get());
         }
         dense_tau = u_dense_tau_.get();
+    } else if (updater.solution_ != nullptr && system_matrix_ != nullptr &&
+               b_ != nullptr) {
+        auto exec = this->get_executor();
+        if (auto vec_b = std::dynamic_pointer_cast<const ComplexVector>(b_)) {
+            auto dense_r = vec_b->clone();
+            auto neg_one = gko::initialize<ComplexVector>({-1}, exec);
+            auto one = gko::initialize<ComplexVector>({1}, exec);
+            system_matrix_->apply(neg_one.get(), updater.solution_, one.get(),
+                                  dense_r.get());
+            dense_r->compute_norm2(u_dense_tau_.get());
+        } else if (auto vec_b = std::dynamic_pointer_cast<const Vector>(b_)) {
+            auto dense_r = vec_b->clone();
+            auto neg_one = gko::initialize<Vector>({-1}, exec);
+            auto one = gko::initialize<Vector>({1}, exec);
+            system_matrix_->apply(neg_one.get(), updater.solution_, one.get(),
+                                  dense_r.get());
+            dense_r->compute_norm2(u_dense_tau_.get());
+        } else {
+            GKO_NOT_SUPPORTED(nullptr);
+        }
+        dense_tau = u_dense_tau_.get();
     } else {
         GKO_NOT_SUPPORTED(nullptr);
     }

--- a/core/stop/residual_norm.cpp
+++ b/core/stop/residual_norm.cpp
@@ -78,18 +78,17 @@ bool ResidualNormBase<ValueType>::check_impl(
     } else if (updater.solution_ != nullptr && system_matrix_ != nullptr &&
                b_ != nullptr) {
         auto exec = this->get_executor();
-        if (auto vec_b = std::dynamic_pointer_cast<const ComplexVector>(b_)) {
+        // when LinOp is real but rhs is complex, we use real view on complex,
+        // so it still uses the same type of scalar in apply.
+        if (auto vec_b = std::dynamic_pointer_cast<const Vector>(b_)) {
             auto dense_r = vec_b->clone();
-            auto neg_one = gko::initialize<ComplexVector>({-1}, exec);
-            auto one = gko::initialize<ComplexVector>({1}, exec);
-            system_matrix_->apply(neg_one.get(), updater.solution_, one.get(),
+            system_matrix_->apply(neg_one_.get(), updater.solution_, one_.get(),
                                   dense_r.get());
             dense_r->compute_norm2(u_dense_tau_.get());
-        } else if (auto vec_b = std::dynamic_pointer_cast<const Vector>(b_)) {
+        } else if (auto vec_b =
+                       std::dynamic_pointer_cast<const ComplexVector>(b_)) {
             auto dense_r = vec_b->clone();
-            auto neg_one = gko::initialize<Vector>({-1}, exec);
-            auto one = gko::initialize<Vector>({1}, exec);
-            system_matrix_->apply(neg_one.get(), updater.solution_, one.get(),
+            system_matrix_->apply(neg_one_.get(), updater.solution_, one_.get(),
                                   dense_r.get());
             dense_r->compute_norm2(u_dense_tau_.get());
         } else {


### PR DESCRIPTION
This PR makes the Residual Norm criterion be able to handle the residual computation if the solver does not provide.
- ResidualNormRedouction can get initial_res from given args in generate (A, b, x)
- others can use solution to compute residual in check (A, b)

It reduce the iterative method effort on calculate residual additionally (only for support criterion).
It only compute the residual when user requires these criterion.