### PR TITLE
Add missing examples in list

### DIFF
--- a/doc/examples/examples.hpp.in
+++ b/doc/examples/examples.hpp.in
@@ -323,5 +323,14 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *     <td> @ref ginkgo_ranges
  *     </td>
  *   </tr>
+ *
+ *   <tr valign="top">
+ *     <td> Mixed precision.
+ *     </td>
+ *     <td>@ref mixed_spmv,
+ *         @ref mixed_precision_ir,
+ *         @ref adaptiveprecision_blockjacobi
+ *     </td>
+ *   </tr>
  * </table>
  */

--- a/doc/examples/examples.hpp.in
+++ b/doc/examples/examples.hpp.in
@@ -187,6 +187,23 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *            factorization.
  *       </td></tr>
  *
+ *   <tr valign="top">
+ *       <td>@ref mixed_spmv</td>
+ *       <td> Shows the Ginkgo mixed precision spmv functionality.
+ *       </td></tr>
+ *
+ *   <tr valign="top">
+ *       <td>@ref mixed_precision_ir</td>
+ *       <td> Manual implementation of a Mixed Precision Iterative Refinement
+ *            (MPIR) solver.
+ *       </td></tr>
+ *
+ *   <tr valign="top">
+ *       <td>@ref adaptiveprecision_blockjacobi</td>
+ *       <td> Shows how to use the adaptive precision block-Jacobi
+ *            reconditioner.
+ *       </td></tr>
+ *
  * </table>
  *
  * <a name="topic"></a>

--- a/doc/examples/examples.hpp.in
+++ b/doc/examples/examples.hpp.in
@@ -201,7 +201,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *   <tr valign="top">
  *       <td>@ref adaptiveprecision_blockjacobi</td>
  *       <td> Shows how to use the adaptive precision block-Jacobi
- *            reconditioner.
+ *            preconditioner.
  *       </td></tr>
  *
  *   <tr valign="top">
@@ -212,17 +212,18 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *   <tr valign="top">
  *       <td>@ref heat_equation</td>
  *       <td> Solving a 2D heat equation and showing matrix assembly, vector
- *            initalization and solver setup in a more complex setting.
+ *            initalization and solver setup in a more complex setting with
+ *            output visualization.
  *       </td></tr>
  *
  *   <tr valign="top">
  *       <td>@ref iterative_refinement</td>
- *       <td> Using an inaccurate CG solver as inner solver to an iterative
+ *       <td> Using a low accuracy CG solver as an inner solver to an iterative
  *            refinement (IR) method which solves a linear system.
  *       </td></tr>
  *
  *   <tr valign="top">
- *       <td>@ref  ir_ilu_preconditioned_solver</td>
+ *       <td>@ref ir_ilu_preconditioned_solver</td>
  *       <td> Combining iterative refinement with the adaptive precision
  *            block-Jacobi preconditioner to approximate triangular systems
  *            occurring in ILU preconditioning.
@@ -256,9 +257,10 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *   </tr>
  *
  *   <tr valign="top">
- *     <td> Debug the performance of a solver using loggers
+ *     <td> Debug the performance of a solver or preconditioner
  *     </td>
  *     <td>@ref performance_debugging
+ *         @ref preconditioner_export
  *     </td>
  *   </tr>
  *
@@ -273,7 +275,11 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *     <td width="400px"> Using preconditioners
  *     </td>
  *     <td>@ref preconditioned_solver,
- *         @ref ilu_preconditioned_solver
+ *         @ref ilu_preconditioned_solver,
+ *         @ref ir_ilu_preconditioned_solver,
+ *         @ref adaptiveprecision_blockjacobi,
+ *         @ref par_ilu_convergence,
+ *         @ref preconditioner_export
  *     </td>
  *   </tr>
  *
@@ -281,6 +287,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *     <td> Iterative refinement
  *     </td>
  *     <td>@ref iterative_refinement,
+ *         @ref mixed_precision_ir,
  *         @ref ir_ilu_preconditioned_solver
  *     </td>
  *   </tr>
@@ -350,6 +357,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *     </td>
  *     <td> @ref simple_solver_logging,
  *          @ref papi_logging,
+ *          @ref performance_debugging
  *          @ref custom_logger
  *     </td>
  *   </tr>

--- a/doc/examples/examples.hpp.in
+++ b/doc/examples/examples.hpp.in
@@ -204,6 +204,42 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *            reconditioner.
  *       </td></tr>
  *
+ *   <tr valign="top">
+ *       <td>@ref cb_gmres</td>
+ *       <td> Using the Ginkgo CB-GMRES solver (Compressed Basis GMRES).
+ *       </td></tr>
+ *
+ *   <tr valign="top">
+ *       <td>@ref heat_equation</td>
+ *       <td> Solving a 2D heat equation and showing matrix assembly, vector
+ *            initalization and solver setup in a more complex setting.
+ *       </td></tr>
+ *
+ *   <tr valign="top">
+ *       <td>@ref iterative_refinement</td>
+ *       <td> Using an inaccurate CG solver as inner solver to an iterative
+ *            refinement (IR) method which solves a linear system.
+ *       </td></tr>
+ *
+ *   <tr valign="top">
+ *       <td>@ref  ir_ilu_preconditioned_solver</td>
+ *       <td> Combining iterative refinement with the adaptive precision
+ *            block-Jacobi preconditioner to approximate triangular systems
+ *            occurring in ILU preconditioning.
+ *       </td></tr>
+ *
+ *   <tr valign="top">
+ *       <td>@ref par_ilu_convergence</td>
+ *       <td> Convergence analysis at the examples of parallel incomplete
+ *            factorization solver.
+ *       </td></tr>
+ *
+ *   <tr valign="top">
+ *       <td>@ref preconditioner_export</td>
+ *       <td> Explicit generation and storage of preconditioners for given
+ *            matrices.
+ *       </td></tr>
+ *
  * </table>
  *
  * <a name="topic"></a>

--- a/doc/examples/examples.hpp.in
+++ b/doc/examples/examples.hpp.in
@@ -249,14 +249,14 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  * <table align="center" width="90%">
  *
  *   <tr valign="top">
- *     <td> Solving a simple linear system with choice of executors.
+ *     <td> Solving a simple linear system with choice of executors
  *     </td>
  *     <td>@ref simple_solver
  *     </td>
  *   </tr>
  *
  *   <tr valign="top">
- *     <td> Debug the performance of a solver using loggers.
+ *     <td> Debug the performance of a solver using loggers
  *     </td>
  *     <td>@ref performance_debugging
  *     </td>
@@ -278,6 +278,14 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *   </tr>
  *
  *   <tr valign="top">
+ *     <td> Iterative refinement
+ *     </td>
+ *     <td>@ref iterative_refinement,
+ *         @ref ir_ilu_preconditioned_solver
+ *     </td>
+ *   </tr>
+ *
+ *   <tr valign="top">
  *     <td width="400px"> Solving a physically relevant problem
  *     </td>
  *     <td>@ref poisson_solver,
@@ -288,7 +296,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *   </tr>
  *
  *   <tr valign="top">
- *     <td width="400px"> Reading in a matrix and right hand side from a file.
+ *     <td width="400px"> Reading in a matrix and right hand side from a file
  *     </td>
  *     <td>@ref simple_solver,
  *         @ref minimal_cuda_solver,
@@ -308,7 +316,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  * <table align="center" width="90%">
  *
  *   <tr valign="top">
- *     <td> Using Ginkgo with external libraries.
+ *     <td> Using Ginkgo with external libraries
  *     </td>
  *     <td>@ref external_lib_interfacing
  *     </td>
@@ -331,14 +339,14 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *   </tr>
  *
  *   <tr valign="top">
- *     <td> Using Ginkgo to construct more complex linear algebra routines.
+ *     <td> Using Ginkgo to construct more complex linear algebra routines
  *     </td>
  *     <td> @ref inverse_iteration
  *     </td>
  *   </tr>
  *
  *   <tr valign="top">
- *     <td> Logging within Ginkgo.
+ *     <td> Logging within Ginkgo
  *     </td>
  *     <td> @ref simple_solver_logging,
  *          @ref papi_logging,
@@ -347,21 +355,21 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *   </tr>
  *
  *   <tr valign="top">
- *     <td> Constructing your own stopping criterion.
+ *     <td> Constructing your own stopping criterion
  *     </td>
  *     <td> @ref custom_stopping_criterion
  *     </td>
  *   </tr>
  *
  *   <tr valign="top">
- *     <td> Using ranges in Ginkgo.
+ *     <td> Using ranges in Ginkgo
  *     </td>
  *     <td> @ref ginkgo_ranges
  *     </td>
  *   </tr>
  *
  *   <tr valign="top">
- *     <td> Mixed precision.
+ *     <td> Mixed precision
  *     </td>
  *     <td>@ref mixed_spmv,
  *         @ref mixed_precision_ir,


### PR DESCRIPTION
Related to #815

This patch adds the three missing examples into the list. Any suggestions are welcome. For the brief description I took the headlines of the corresponding examples. Is the ordering in the list OK?