### PR TITLE
Some utilities for span and dim

### DIFF
--- a/core/test/base/dim.cpp
+++ b/core/test/base/dim.cpp
@@ -117,6 +117,26 @@ TEST(Dim, ConvertsToBool)
 }
 
 
+TEST(Dim, CanAppendToStream1)
+{
+    gko::dim<2> d2{2, 3};
+
+    std::ostringstream os;
+    os << d2;
+    ASSERT_EQ(os.str(), "(2 , 3)");
+}
+
+
+TEST(Dim, CanAppendToStream2)
+{
+    gko::dim<3> d2{2, 3, 4};
+
+    std::ostringstream os;
+    os << d2;
+    ASSERT_EQ(os.str(), "(2 , (3 , 4))");
+}
+
+
 TEST(Dim, EqualityReturnsTrueWhenEqual)
 {
     ASSERT_TRUE(gko::dim<2>(2, 3) == gko::dim<2>(2, 3));

--- a/core/test/base/dim.cpp
+++ b/core/test/base/dim.cpp
@@ -123,7 +123,7 @@ TEST(Dim, CanAppendToStream1)
 
     std::ostringstream os;
     os << d2;
-    ASSERT_EQ(os.str(), "(2 , 3)");
+    ASSERT_EQ(os.str(), "(2, 3)");
 }
 
 
@@ -133,7 +133,7 @@ TEST(Dim, CanAppendToStream2)
 
     std::ostringstream os;
     os << d2;
-    ASSERT_EQ(os.str(), "(2 , (3 , 4))");
+    ASSERT_EQ(os.str(), "(2, 3, 4)");
 }
 
 

--- a/core/test/base/range.cpp
+++ b/core/test/base/range.cpp
@@ -60,6 +60,13 @@ TEST(Span, CreatesPoint)
 }
 
 
+TEST(Span, KnowsItsLength)
+{
+    gko::span s{3, 5};
+    ASSERT_EQ(2, s.length());
+}
+
+
 TEST(Span, LessThanEvaluatesToTrue)
 {
     ASSERT_TRUE(gko::span(2, 3) < gko::span(4, 7));
@@ -645,7 +652,7 @@ TEST(Range, DividesScalarAndRange)
 }
 
 
-TEST(Range, AddsRangeAndSclar)
+TEST(Range, AddsRangeAndScalar)
 {
     dummy_range r{5u, 1, 2};
 
@@ -656,7 +663,7 @@ TEST(Range, AddsRangeAndSclar)
 }
 
 
-TEST(Range, SubtractsRangeAndSclar)
+TEST(Range, SubtractsRangeAndScalar)
 {
     dummy_range r{5u, 1, 2};
 
@@ -667,7 +674,7 @@ TEST(Range, SubtractsRangeAndSclar)
 }
 
 
-TEST(Range, MultipliesRangeAndSclar)
+TEST(Range, MultipliesRangeAndScalar)
 {
     dummy_range r{5u, 1, 2};
 
@@ -678,7 +685,7 @@ TEST(Range, MultipliesRangeAndSclar)
 }
 
 
-TEST(Range, DividesRangeAndSclar)
+TEST(Range, DividesRangeAndScalar)
 {
     dummy_range r{5u, 1, 2};
 

--- a/include/ginkgo/core/base/dim.hpp
+++ b/include/ginkgo/core/base/dim.hpp
@@ -164,8 +164,7 @@ struct dim {
      *
      * @return a stream object appended with the dim output
      */
-    friend GKO_ATTRIBUTES std::ostream &operator<<(std::ostream &os,
-                                                   const dim &x)
+    friend std::ostream &operator<<(std::ostream &os, const dim &x)
     {
         os << "(";
         x.print_to(os);
@@ -229,8 +228,7 @@ struct dim<1u, DimensionType> {
         return dim(x.first_ * y.first_);
     }
 
-    friend GKO_ATTRIBUTES std::ostream &operator<<(std::ostream &os,
-                                                   const dim &x)
+    friend std::ostream &operator<<(std::ostream &os, const dim &x)
     {
         os << "(";
         x.print_to(os);

--- a/include/ginkgo/core/base/dim.hpp
+++ b/include/ginkgo/core/base/dim.hpp
@@ -34,6 +34,9 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define GKO_PUBLIC_CORE_BASE_DIM_HPP_
 
 
+#include <iostream>
+
+
 #include <ginkgo/core/base/types.hpp>
 
 
@@ -51,6 +54,7 @@ namespace gko {
 template <size_type Dimensionality, typename DimensionType = size_type>
 struct dim {
     static constexpr size_type dimensionality = Dimensionality;
+    friend class dim<dimensionality + 1>;
 
     using dimension_type = DimensionType;
 
@@ -163,10 +167,20 @@ struct dim {
     friend GKO_ATTRIBUTES std::ostream &operator<<(std::ostream &os,
                                                    const dim &x)
     {
-        return os << "(" << x.first_ << " , " << x.rest_ << ")";
+        os << "(";
+        x.print_to(os);
+        os << ")";
+        return os;
     }
 
 private:
+    void inline print_to(std::ostream &os) const
+    {
+        os << first_ << ", ";
+        rest_.print_to(os);
+    }
+
+
     constexpr GKO_ATTRIBUTES dim(const dimension_type first,
                                  dim<dimensionality - 1> rest)
         : first_{first}, rest_{rest}
@@ -181,6 +195,7 @@ private:
 template <typename DimensionType>
 struct dim<1u, DimensionType> {
     static constexpr size_type dimensionality = 1u;
+    friend class dim<2>;
 
     using dimension_type = DimensionType;
 
@@ -217,10 +232,15 @@ struct dim<1u, DimensionType> {
     friend GKO_ATTRIBUTES std::ostream &operator<<(std::ostream &os,
                                                    const dim &x)
     {
-        return os << x.first_;
+        os << "(";
+        x.print_to(os);
+        os << ")";
+        return os;
     }
 
 private:
+    void inline print_to(std::ostream &os) const { os << first_; }
+
     dimension_type first_;
 };
 

--- a/include/ginkgo/core/base/dim.hpp
+++ b/include/ginkgo/core/base/dim.hpp
@@ -152,6 +152,20 @@ struct dim {
         return dim(x.first_ * y.first_, x.rest_ * y.rest_);
     }
 
+    /**
+     * A stream operator overload for dim
+     *
+     * @param os  stream object
+     * @param x  dim object
+     *
+     * @return a stream object appended with the dim output
+     */
+    friend GKO_ATTRIBUTES std::ostream &operator<<(std::ostream &os,
+                                                   const dim &x)
+    {
+        return os << "(" << x.first_ << " , " << x.rest_ << ")";
+    }
+
 private:
     constexpr GKO_ATTRIBUTES dim(const dimension_type first,
                                  dim<dimensionality - 1> rest)
@@ -198,6 +212,12 @@ struct dim<1u, DimensionType> {
     friend constexpr GKO_ATTRIBUTES dim operator*(const dim &x, const dim &y)
     {
         return dim(x.first_ * y.first_);
+    }
+
+    friend GKO_ATTRIBUTES std::ostream &operator<<(std::ostream &os,
+                                                   const dim &x)
+    {
+        return os << x.first_;
     }
 
 private:

--- a/include/ginkgo/core/base/range.hpp
+++ b/include/ginkgo/core/base/range.hpp
@@ -102,6 +102,17 @@ struct span {
     constexpr bool is_valid() const { return begin < end; }
 
     /**
+     * Returns the length of a span.
+     *
+     * @return `this->end - this->begin`
+     */
+    constexpr size_type length() const
+    {
+        GKO_ASSERT(is_valid());
+        return end - begin;
+    }
+
+    /**
      * Beginning of the span.
      */
     const size_type begin;

--- a/include/ginkgo/core/base/range.hpp
+++ b/include/ginkgo/core/base/range.hpp
@@ -99,14 +99,14 @@ struct span {
      *
      * @return true if and only if `this->begin < this->end`
      */
-    constexpr bool is_valid() const { return begin < end; }
+    GKO_ATTRIBUTES constexpr bool is_valid() const { return begin < end; }
 
     /**
      * Returns the length of a span.
      *
      * @return `this->end - this->begin`
      */
-    constexpr size_type length() const
+    GKO_ATTRIBUTES constexpr size_type length() const
     {
         GKO_ASSERT(is_valid());
         return end - begin;


### PR DESCRIPTION
This PR adds some useful utilities for dim and span.

1. An ostream << operator overload for dim.
~~2. Adding two spans.~~
3. Getting the length of a span.