### PR TITLE
Use consistent matrix index type in benchmark

### DIFF
--- a/benchmark/conversions/conversions.cpp
+++ b/benchmark/conversions/conversions.cpp
@@ -69,7 +69,7 @@ void convert_matrix(const gko::LinOp *matrix_from, const char *format_to,
         add_or_set_member(conversion_case, conversion_name,
                           rapidjson::Value(rapidjson::kObjectType), allocator);
 
-        gko::matrix_data<etype> data{gko::dim<2>{1, 1}, 1};
+        gko::matrix_data<etype, itype> data{gko::dim<2>{1, 1}, 1};
         auto matrix_to =
             share(formats::matrix_factory.at(format_to)(exec, data));
 
@@ -148,9 +148,9 @@ int main(int argc, char *argv[])
 
         std::clog << "Running test case: " << test_case << std::endl;
         std::ifstream mtx_fd(test_case["filename"].GetString());
-        gko::matrix_data<etype> data;
+        gko::matrix_data<etype, itype> data;
         try {
-            data = gko::read_raw<etype>(mtx_fd);
+            data = gko::read_raw<etype, itype>(mtx_fd);
         } catch (std::exception &e) {
             std::cerr << "Error setting up matrix data, what(): " << e.what()
                       << std::endl;

--- a/benchmark/matrix_generator/matrix_generator.cpp
+++ b/benchmark/matrix_generator/matrix_generator.cpp
@@ -96,13 +96,13 @@ void validate_option_object(const rapidjson::Value &value)
 }
 
 
-using generator_function =
-    std::function<gko::matrix_data<etype>(rapidjson::Value &, std::ranlux24 &)>;
+using generator_function = std::function<gko::matrix_data<etype, itype>(
+    rapidjson::Value &, std::ranlux24 &)>;
 
 
 // matrix generators
-gko::matrix_data<etype> generate_block_diagonal(rapidjson::Value &config,
-                                                std::ranlux24 &engine)
+gko::matrix_data<etype, itype> generate_block_diagonal(rapidjson::Value &config,
+                                                       std::ranlux24 &engine)
 {
     if (!config.HasMember("num_blocks") || !config["num_blocks"].IsUint() ||
         !config.HasMember("block_size") || !config["block_size"].IsUint()) {
@@ -110,10 +110,10 @@ gko::matrix_data<etype> generate_block_diagonal(rapidjson::Value &config,
     }
     auto num_blocks = config["num_blocks"].GetUint();
     auto block_size = config["block_size"].GetUint();
-    auto block = gko::matrix_data<etype>(
+    auto block = gko::matrix_data<etype, itype>(
         gko::dim<2>(block_size),
         std::uniform_real_distribution<rc_etype>(-1.0, 1.0), engine);
-    return gko::matrix_data<etype>::diag(num_blocks, block);
+    return gko::matrix_data<etype, itype>::diag(num_blocks, block);
 }
 
 

--- a/benchmark/preconditioner/preconditioner.cpp
+++ b/benchmark/preconditioner/preconditioner.cpp
@@ -296,7 +296,7 @@ int main(int argc, char *argv[])
             std::clog << "Running test case: " << test_case << std::endl;
 
             std::ifstream mtx_fd(test_case["filename"].GetString());
-            auto data = gko::read_raw<etype>(mtx_fd);
+            auto data = gko::read_raw<etype, itype>(mtx_fd);
 
             auto system_matrix =
                 share(formats::matrix_factory.at(FLAGS_formats)(exec, data));

--- a/benchmark/solver/solver.cpp
+++ b/benchmark/solver/solver.cpp
@@ -609,7 +609,7 @@ int main(int argc, char *argv[])
                     {std::numeric_limits<rc_etype>::quiet_NaN()}, exec);
                 x = gko::initialize<Vec>({0.0}, exec);
             } else {
-                auto data = gko::read_raw<etype>(mtx_fd);
+                auto data = gko::read_raw<etype, itype>(mtx_fd);
                 system_matrix = share(formats::matrix_factory.at(
                     test_case["optimal"]["spmv"].GetString())(exec, data));
                 if (test_case.HasMember("rhs")) {

--- a/benchmark/spmv/spmv.cpp
+++ b/benchmark/spmv/spmv.cpp
@@ -63,7 +63,7 @@ DEFINE_uint32(nrhs, 1, "The number of right hand sides");
 // This function supposes that management of `FLAGS_overwrite` is done before
 // calling it
 void apply_spmv(const char *format_name, std::shared_ptr<gko::Executor> exec,
-                const gko::matrix_data<etype> &data, const vec<etype> *b,
+                const gko::matrix_data<etype, itype> &data, const vec<etype> *b,
                 const vec<etype> *x, const vec<etype> *answer,
                 rapidjson::Value &test_case,
                 rapidjson::MemoryPoolAllocator<> &allocator)
@@ -212,7 +212,7 @@ int main(int argc, char *argv[])
             }
             std::clog << "Running test case: " << test_case << std::endl;
             std::ifstream mtx_fd(test_case["filename"].GetString());
-            auto data = gko::read_raw<etype>(mtx_fd);
+            auto data = gko::read_raw<etype, itype>(mtx_fd);
 
             auto nrhs = FLAGS_nrhs;
             auto b = create_matrix<etype>(exec, gko::dim<2>{data.size[1], nrhs},

--- a/benchmark/utils/cuda_linops.hpp
+++ b/benchmark/utils/cuda_linops.hpp
@@ -685,11 +685,11 @@ private:
 
 
 // Some shortcuts
-using cusp_csrex = detail::CuspCsrEx<etype>;
+using cusp_csrex = detail::CuspCsrEx<etype, itype>;
 #if defined(CUDA_VERSION) && (CUDA_VERSION < 11000)
-using cusp_csr = detail::CuspCsr<etype>;
-using cusp_csrmp = detail::CuspCsrmp<etype>;
-using cusp_csrmm = detail::CuspCsrmm<etype>;
+using cusp_csr = detail::CuspCsr<etype, itype>;
+using cusp_csrmp = detail::CuspCsrmp<etype, itype>;
+using cusp_csrmm = detail::CuspCsrmm<etype, itype>;
 #endif  // defined(CUDA_VERSION) && (CUDA_VERSION < 11000)
 
 
@@ -698,10 +698,9 @@ using cusp_csrmm = detail::CuspCsrmm<etype>;
      ((CUDA_VERSION >= 10020) && !(defined(_WIN32) || defined(__CYGWIN__))))
 
 
-using cusp_gcsr = detail::CuspGenericCsr<etype>;
-using cusp_gcsr2 =
-    detail::CuspGenericCsr<etype, gko::int32, CUSPARSE_CSRMV_ALG2>;
-using cusp_gcoo = detail::CuspGenericCoo<etype>;
+using cusp_gcsr = detail::CuspGenericCsr<etype, itype>;
+using cusp_gcsr2 = detail::CuspGenericCsr<etype, itype, CUSPARSE_CSRMV_ALG2>;
+using cusp_gcoo = detail::CuspGenericCoo<etype, itype>;
 
 
 #endif  // defined(CUDA_VERSION) && (CUDA_VERSION >= 11000 || ((CUDA_VERSION >=
@@ -710,10 +709,10 @@ using cusp_gcoo = detail::CuspGenericCoo<etype>;
 
 #if defined(CUDA_VERSION) && (CUDA_VERSION < 11000)
 using cusp_coo =
-    detail::CuspHybrid<etype, gko::int32, CUSPARSE_HYB_PARTITION_USER, 0>;
+    detail::CuspHybrid<etype, itype, CUSPARSE_HYB_PARTITION_USER, 0>;
 using cusp_ell =
-    detail::CuspHybrid<etype, gko::int32, CUSPARSE_HYB_PARTITION_MAX, 0>;
-using cusp_hybrid = detail::CuspHybrid<etype>;
+    detail::CuspHybrid<etype, itype, CUSPARSE_HYB_PARTITION_MAX, 0>;
+using cusp_hybrid = detail::CuspHybrid<etype, itype>;
 #endif  // defined(CUDA_VERSION) && (CUDA_VERSION < 11000)
 
 

--- a/benchmark/utils/general.hpp
+++ b/benchmark/utils/general.hpp
@@ -59,6 +59,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
 #include "benchmark/utils/timer.hpp"
+#include "benchmark/utils/types.hpp"
 
 
 // Global command-line arguments
@@ -366,7 +367,7 @@ std::unique_ptr<vec<ValueType>> create_matrix(
     ValueType value)
 {
     auto res = vec<ValueType>::create(exec);
-    res->read(gko::matrix_data<ValueType>(size, value));
+    res->read(gko::matrix_data<ValueType, itype>(size, value));
     return res;
 }
 
@@ -378,7 +379,7 @@ std::unique_ptr<vec<ValueType>> create_matrix(
     RandomEngine &engine)
 {
     auto res = vec<ValueType>::create(exec);
-    res->read(gko::matrix_data<ValueType>(
+    res->read(gko::matrix_data<ValueType, itype>(
         size,
         std::uniform_real_distribution<gko::remove_complex<ValueType>>(-1.0,
                                                                        1.0),
@@ -393,7 +394,7 @@ std::unique_ptr<vec<ValueType>> create_vector(
     std::shared_ptr<const gko::Executor> exec, gko::size_type size)
 {
     auto res = vec<ValueType>::create(exec);
-    res->read(gko::matrix_data<ValueType>(gko::dim<2>{size, 1}));
+    res->read(gko::matrix_data<ValueType, itype>(gko::dim<2>{size, 1}));
     return res;
 }
 

--- a/benchmark/utils/hip_linops.hip.hpp
+++ b/benchmark/utils/hip_linops.hip.hpp
@@ -322,14 +322,14 @@ private:
 
 
 // Some shortcuts
-using hipsp_csr = detail::HipspCsr<etype>;
-using hipsp_csrmm = detail::HipspCsrmm<etype>;
+using hipsp_csr = detail::HipspCsr<etype, itype>;
+using hipsp_csrmm = detail::HipspCsrmm<etype, itype>;
 
 
 using hipsp_coo =
-    detail::HipspHybrid<etype, gko::int32, HIPSPARSE_HYB_PARTITION_USER, 0>;
+    detail::HipspHybrid<etype, itype, HIPSPARSE_HYB_PARTITION_USER, 0>;
 using hipsp_ell =
-    detail::HipspHybrid<etype, gko::int32, HIPSPARSE_HYB_PARTITION_MAX, 0>;
-using hipsp_hybrid = detail::HipspHybrid<etype>;
+    detail::HipspHybrid<etype, itype, HIPSPARSE_HYB_PARTITION_MAX, 0>;
+using hipsp_hybrid = detail::HipspHybrid<etype, itype>;
 
 #endif  // GKO_BENCHMARK_UTILS_HIP_LINOPS_HIP_HPP_

--- a/benchmark/utils/preconditioners.hpp
+++ b/benchmark/utils/preconditioners.hpp
@@ -105,7 +105,7 @@ const std::map<std::string, std::function<std::unique_ptr<gko::LinOpFactory>(
          }},
         {"jacobi",
          [](std::shared_ptr<const gko::Executor> exec) {
-             return gko::preconditioner::Jacobi<etype>::build()
+             return gko::preconditioner::Jacobi<etype, itype>::build()
                  .with_max_block_size(FLAGS_jacobi_max_block_size)
                  .with_storage_optimization(
                      parse_storage_optimization(FLAGS_jacobi_storage))
@@ -116,90 +116,91 @@ const std::map<std::string, std::function<std::unique_ptr<gko::LinOpFactory>(
         {"paric",
          [](std::shared_ptr<const gko::Executor> exec) {
              auto fact =
-                 gko::share(gko::factorization::ParIc<etype>::build()
+                 gko::share(gko::factorization::ParIc<etype, itype>::build()
                                 .with_iterations(FLAGS_parilu_iterations)
                                 .with_skip_sorting(true)
                                 .on(exec));
-             return gko::preconditioner::Ic<
-                        gko::solver::LowerTrs<etype>>::build()
+             return gko::preconditioner::Ic<gko::solver::LowerTrs<etype, itype>,
+                                            itype>::build()
                  .with_factorization_factory(fact)
                  .on(exec);
          }},
         {"parict",
          [](std::shared_ptr<const gko::Executor> exec) {
              auto fact = gko::share(
-                 gko::factorization::ParIct<etype>::build()
+                 gko::factorization::ParIct<etype, itype>::build()
                      .with_iterations(FLAGS_parilu_iterations)
                      .with_approximate_select(FLAGS_parilut_approx_select)
                      .with_fill_in_limit(FLAGS_parilut_limit)
                      .with_skip_sorting(true)
                      .on(exec));
-             return gko::preconditioner::Ilu<
-                        gko::solver::LowerTrs<etype>,
-                        gko::solver::UpperTrs<etype>>::build()
-                 .with_factorization_factory(fact)
-                 .on(exec);
+             return gko::preconditioner::
+                 Ilu<gko::solver::LowerTrs<etype, itype>,
+                     gko::solver::UpperTrs<etype, itype>, false, itype>::build()
+                     .with_factorization_factory(fact)
+                     .on(exec);
          }},
         {"parilu",
          [](std::shared_ptr<const gko::Executor> exec) {
              auto fact =
-                 gko::share(gko::factorization::ParIlu<etype>::build()
+                 gko::share(gko::factorization::ParIlu<etype, itype>::build()
                                 .with_iterations(FLAGS_parilu_iterations)
                                 .with_skip_sorting(true)
                                 .on(exec));
-             return gko::preconditioner::Ilu<
-                        gko::solver::LowerTrs<etype>,
-                        gko::solver::UpperTrs<etype>>::build()
-                 .with_factorization_factory(fact)
-                 .on(exec);
+             return gko::preconditioner::
+                 Ilu<gko::solver::LowerTrs<etype, itype>,
+                     gko::solver::UpperTrs<etype, itype>, false, itype>::build()
+                     .with_factorization_factory(fact)
+                     .on(exec);
          }},
         {"parilut",
          [](std::shared_ptr<const gko::Executor> exec) {
              auto fact = gko::share(
-                 gko::factorization::ParIlut<etype>::build()
+                 gko::factorization::ParIlut<etype, itype>::build()
                      .with_iterations(FLAGS_parilu_iterations)
                      .with_approximate_select(FLAGS_parilut_approx_select)
                      .with_fill_in_limit(FLAGS_parilut_limit)
                      .with_skip_sorting(true)
                      .on(exec));
-             return gko::preconditioner::Ilu<
-                        gko::solver::LowerTrs<etype>,
-                        gko::solver::UpperTrs<etype>>::build()
-                 .with_factorization_factory(fact)
-                 .on(exec);
+             return gko::preconditioner::
+                 Ilu<gko::solver::LowerTrs<etype, itype>,
+                     gko::solver::UpperTrs<etype, itype>, false, itype>::build()
+                     .with_factorization_factory(fact)
+                     .on(exec);
          }},
         {"ic",
          [](std::shared_ptr<const gko::Executor> exec) {
-             auto fact =
-                 gko::share(gko::factorization::Ic<etype>::build().on(exec));
-             return gko::preconditioner::Ic<
-                        gko::solver::LowerTrs<etype>>::build()
+             auto fact = gko::share(
+                 gko::factorization::Ic<etype, itype>::build().on(exec));
+             return gko::preconditioner::Ic<gko::solver::LowerTrs<etype, itype>,
+                                            itype>::build()
                  .with_factorization_factory(fact)
                  .on(exec);
          }},
         {"ilu",
          [](std::shared_ptr<const gko::Executor> exec) {
-             auto fact =
-                 gko::share(gko::factorization::Ilu<etype>::build().on(exec));
-             return gko::preconditioner::Ilu<
-                        gko::solver::LowerTrs<etype>,
-                        gko::solver::UpperTrs<etype>>::build()
-                 .with_factorization_factory(fact)
-                 .on(exec);
+             auto fact = gko::share(
+                 gko::factorization::Ilu<etype, itype>::build().on(exec));
+             return gko::preconditioner::
+                 Ilu<gko::solver::LowerTrs<etype, itype>,
+                     gko::solver::UpperTrs<etype, itype>, false, itype>::build()
+                     .with_factorization_factory(fact)
+                     .on(exec);
          }},
         {"paric-isai",
          [](std::shared_ptr<const gko::Executor> exec) {
              auto fact =
-                 gko::share(gko::factorization::ParIc<etype>::build()
+                 gko::share(gko::factorization::ParIc<etype, itype>::build()
                                 .with_iterations(FLAGS_parilu_iterations)
                                 .with_skip_sorting(true)
                                 .on(exec));
-             auto lisai =
-                 gko::share(gko::preconditioner::LowerIsai<etype>::build()
-                                .with_sparsity_power(FLAGS_isai_power)
-                                .on(exec));
+             auto lisai = gko::share(
+                 gko::preconditioner::LowerIsai<etype, itype>::build()
+                     .with_sparsity_power(FLAGS_isai_power)
+                     .on(exec));
              return gko::preconditioner::Ic<
-                        gko::preconditioner::LowerIsai<etype>>::build()
+                        gko::preconditioner::LowerIsai<etype, itype>,
+                        itype>::build()
                  .with_factorization_factory(fact)
                  .with_l_solver_factory(lisai)
                  .on(exec);
@@ -207,18 +208,19 @@ const std::map<std::string, std::function<std::unique_ptr<gko::LinOpFactory>(
         {"parict-isai",
          [](std::shared_ptr<const gko::Executor> exec) {
              auto fact = gko::share(
-                 gko::factorization::ParIct<etype>::build()
+                 gko::factorization::ParIct<etype, itype>::build()
                      .with_iterations(FLAGS_parilu_iterations)
                      .with_approximate_select(FLAGS_parilut_approx_select)
                      .with_fill_in_limit(FLAGS_parilut_limit)
                      .with_skip_sorting(true)
                      .on(exec));
-             auto lisai =
-                 gko::share(gko::preconditioner::LowerIsai<etype>::build()
-                                .with_sparsity_power(FLAGS_isai_power)
-                                .on(exec));
+             auto lisai = gko::share(
+                 gko::preconditioner::LowerIsai<etype, itype>::build()
+                     .with_sparsity_power(FLAGS_isai_power)
+                     .on(exec));
              return gko::preconditioner::Ic<
-                        gko::preconditioner::LowerIsai<etype>>::build()
+                        gko::preconditioner::LowerIsai<etype, itype>,
+                        itype>::build()
                  .with_factorization_factory(fact)
                  .with_l_solver_factory(lisai)
                  .on(exec);
@@ -226,21 +228,22 @@ const std::map<std::string, std::function<std::unique_ptr<gko::LinOpFactory>(
         {"parilu-isai",
          [](std::shared_ptr<const gko::Executor> exec) {
              auto fact =
-                 gko::share(gko::factorization::ParIlu<etype>::build()
+                 gko::share(gko::factorization::ParIlu<etype, itype>::build()
                                 .with_iterations(FLAGS_parilu_iterations)
                                 .with_skip_sorting(true)
                                 .on(exec));
-             auto lisai =
-                 gko::share(gko::preconditioner::LowerIsai<etype>::build()
-                                .with_sparsity_power(FLAGS_isai_power)
-                                .on(exec));
-             auto uisai =
-                 gko::share(gko::preconditioner::UpperIsai<etype>::build()
-                                .with_sparsity_power(FLAGS_isai_power)
-                                .on(exec));
+             auto lisai = gko::share(
+                 gko::preconditioner::LowerIsai<etype, itype>::build()
+                     .with_sparsity_power(FLAGS_isai_power)
+                     .on(exec));
+             auto uisai = gko::share(
+                 gko::preconditioner::UpperIsai<etype, itype>::build()
+                     .with_sparsity_power(FLAGS_isai_power)
+                     .on(exec));
              return gko::preconditioner::Ilu<
-                        gko::preconditioner::LowerIsai<etype>,
-                        gko::preconditioner::UpperIsai<etype>>::build()
+                        gko::preconditioner::LowerIsai<etype, itype>,
+                        gko::preconditioner::UpperIsai<etype, itype>, false,
+                        itype>::build()
                  .with_factorization_factory(fact)
                  .with_l_solver_factory(lisai)
                  .with_u_solver_factory(uisai)
@@ -249,23 +252,24 @@ const std::map<std::string, std::function<std::unique_ptr<gko::LinOpFactory>(
         {"parilut-isai",
          [](std::shared_ptr<const gko::Executor> exec) {
              auto fact = gko::share(
-                 gko::factorization::ParIlut<etype>::build()
+                 gko::factorization::ParIlut<etype, itype>::build()
                      .with_iterations(FLAGS_parilu_iterations)
                      .with_approximate_select(FLAGS_parilut_approx_select)
                      .with_fill_in_limit(FLAGS_parilut_limit)
                      .with_skip_sorting(true)
                      .on(exec));
-             auto lisai =
-                 gko::share(gko::preconditioner::LowerIsai<etype>::build()
-                                .with_sparsity_power(FLAGS_isai_power)
-                                .on(exec));
-             auto uisai =
-                 gko::share(gko::preconditioner::UpperIsai<etype>::build()
-                                .with_sparsity_power(FLAGS_isai_power)
-                                .on(exec));
+             auto lisai = gko::share(
+                 gko::preconditioner::LowerIsai<etype, itype>::build()
+                     .with_sparsity_power(FLAGS_isai_power)
+                     .on(exec));
+             auto uisai = gko::share(
+                 gko::preconditioner::UpperIsai<etype, itype>::build()
+                     .with_sparsity_power(FLAGS_isai_power)
+                     .on(exec));
              return gko::preconditioner::Ilu<
-                        gko::preconditioner::LowerIsai<etype>,
-                        gko::preconditioner::UpperIsai<etype>>::build()
+                        gko::preconditioner::LowerIsai<etype, itype>,
+                        gko::preconditioner::UpperIsai<etype, itype>, false,
+                        itype>::build()
                  .with_factorization_factory(fact)
                  .with_l_solver_factory(lisai)
                  .with_u_solver_factory(uisai)
@@ -273,33 +277,35 @@ const std::map<std::string, std::function<std::unique_ptr<gko::LinOpFactory>(
          }},
         {"ic-isai",
          [](std::shared_ptr<const gko::Executor> exec) {
-             auto fact =
-                 gko::share(gko::factorization::Ic<etype>::build().on(exec));
-             auto lisai =
-                 gko::share(gko::preconditioner::LowerIsai<etype>::build()
-                                .with_sparsity_power(FLAGS_isai_power)
-                                .on(exec));
+             auto fact = gko::share(
+                 gko::factorization::Ic<etype, itype>::build().on(exec));
+             auto lisai = gko::share(
+                 gko::preconditioner::LowerIsai<etype, itype>::build()
+                     .with_sparsity_power(FLAGS_isai_power)
+                     .on(exec));
              return gko::preconditioner::Ic<
-                        gko::preconditioner::LowerIsai<etype>>::build()
+                        gko::preconditioner::LowerIsai<etype, itype>,
+                        itype>::build()
                  .with_factorization_factory(fact)
                  .with_l_solver_factory(lisai)
                  .on(exec);
          }},
         {"ilu-isai",
          [](std::shared_ptr<const gko::Executor> exec) {
-             auto fact =
-                 gko::share(gko::factorization::Ilu<etype>::build().on(exec));
-             auto lisai =
-                 gko::share(gko::preconditioner::LowerIsai<etype>::build()
-                                .with_sparsity_power(FLAGS_isai_power)
-                                .on(exec));
-             auto uisai =
-                 gko::share(gko::preconditioner::UpperIsai<etype>::build()
-                                .with_sparsity_power(FLAGS_isai_power)
-                                .on(exec));
+             auto fact = gko::share(
+                 gko::factorization::Ilu<etype, itype>::build().on(exec));
+             auto lisai = gko::share(
+                 gko::preconditioner::LowerIsai<etype, itype>::build()
+                     .with_sparsity_power(FLAGS_isai_power)
+                     .on(exec));
+             auto uisai = gko::share(
+                 gko::preconditioner::UpperIsai<etype, itype>::build()
+                     .with_sparsity_power(FLAGS_isai_power)
+                     .on(exec));
              return gko::preconditioner::Ilu<
-                        gko::preconditioner::LowerIsai<etype>,
-                        gko::preconditioner::UpperIsai<etype>>::build()
+                        gko::preconditioner::LowerIsai<etype, itype>,
+                        gko::preconditioner::UpperIsai<etype, itype>, false,
+                        itype>::build()
                  .with_factorization_factory(fact)
                  .with_l_solver_factory(lisai)
                  .with_u_solver_factory(uisai)
@@ -307,13 +313,13 @@ const std::map<std::string, std::function<std::unique_ptr<gko::LinOpFactory>(
          }},
         {"general-isai",
          [](std::shared_ptr<const gko::Executor> exec) {
-             return gko::preconditioner::GeneralIsai<>::build()
+             return gko::preconditioner::GeneralIsai<etype, itype>::build()
                  .with_sparsity_power(FLAGS_isai_power)
                  .on(exec);
          }},
         {"spd-isai",
          [](std::shared_ptr<const gko::Executor> exec) {
-             return gko::preconditioner::SpdIsai<>::build()
+             return gko::preconditioner::SpdIsai<etype, itype>::build()
                  .with_sparsity_power(FLAGS_isai_power)
                  .on(exec);
          }},

--- a/benchmark/utils/types.hpp
+++ b/benchmark/utils/types.hpp
@@ -40,6 +40,9 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <ginkgo/core/base/math.hpp>
 
 
+using itype = gko::int32;
+
+
 #if defined(GKO_BENCHMARK_USE_DOUBLE_PRECISION)
 using etype = double;
 #elif defined(GKO_BENCHMARK_USE_SINGLE_PRECISION)


### PR DESCRIPTION
To prepare for larger benchmark types, I added a index type (32 bit for now) to all benchmarks and use it in all related types (Feel free to double-check I didn't miss anything!)