### PR TITLE
Fixes handling of multiple worktrees

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -17,7 +17,9 @@ Ginkgo adds the following additional switches to control what is being built:
 
 *   `-DGINKGO_DEVEL_TOOLS={ON, OFF}` sets up the build system for development
     (requires clang-format, will also download git-cmake-format),
-    default is `OFF`.
+    default is `OFF`. If it is set to `ON`, a pre-commit hook for formatting
+    will be installed. This hook may overwrite a user defined pre-commit hook
+    when Ginkgo is used as a submodule.
 *   `-DGINKGO_MIXED_PRECISION={ON, OFF}` compiles true mixed-precision kernels
     instead of converting data on the fly, default is `OFF`.
     Enabling this flag increases the library size, but improves performance of

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -17,9 +17,11 @@ Ginkgo adds the following additional switches to control what is being built:
 
 *   `-DGINKGO_DEVEL_TOOLS={ON, OFF}` sets up the build system for development
     (requires clang-format, will also download git-cmake-format),
-    default is `OFF`. If it is set to `ON`, a pre-commit hook for formatting
-    will be installed. This hook may overwrite a user defined pre-commit hook
-    when Ginkgo is used as a submodule.
+    default is `OFF`. The default behavior installs a pre-commit hook, which
+    disables git commits.  If it is set to `ON`, a new pre-commit hook for
+    formatting will be installed (enabling commits again). In both cases the
+    hook may overwrite a user defined pre-commit hook when Ginkgo is used as
+    a submodule.
 *   `-DGINKGO_MIXED_PRECISION={ON, OFF}` compiles true mixed-precision kernels
     instead of converting data on the fly, default is `OFF`.
     Enabling this flag increases the library size, but improves performance of

--- a/third_party/dummy-hook/CMakeLists.txt
+++ b/third_party/dummy-hook/CMakeLists.txt
@@ -1,18 +1,27 @@
-if(EXISTS "${Ginkgo_SOURCE_DIR}/.git")
-    set(ADD_HOOK FALSE)
-    set(HOOK_LOCATION "${Ginkgo_SOURCE_DIR}/.git/hooks/pre-commit")
-    if(NOT EXISTS "${HOOK_LOCATION}")
-        set(ADD_HOOK TRUE)
-    else()
-        # check if the correct hook is installed
-        execute_process(COMMAND grep git-cmake-format.py "${HOOK_LOCATION}"
-                        RESULT_VARIABLE res OUTPUT_QUIET)
-        # return value =/= 0 means the pattern was not found
-        if(NOT res EQUAL 0)
+find_package(Git QUIET)
+if(GIT_FOUND)
+    execute_process(COMMAND ${GIT_EXECUTABLE} rev-parse --git-path hooks
+      WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+      OUTPUT_VARIABLE Ginkgo_GIT_HOOKS_DIR
+      OUTPUT_STRIP_TRAILING_WHITESPACE)
+    get_filename_component(Ginkgo_GIT_HOOKS_DIR ${Ginkgo_GIT_HOOKS_DIR} REALPATH BASE_DIR ${CMAKE_SOURCE_DIR})
+
+    if(EXISTS "${Ginkgo_GIT_HOOKS_DIR}")
+        set(ADD_HOOK FALSE)
+        set(HOOK_LOCATION "${Ginkgo_GIT_HOOKS_DIR}/pre-commit")
+        if(NOT EXISTS "${HOOK_LOCATION}")
             set(ADD_HOOK TRUE)
+        else()
+            # check if the correct hook is installed
+            execute_process(COMMAND grep git-cmake-format.py "${HOOK_LOCATION}"
+                            RESULT_VARIABLE res OUTPUT_QUIET)
+            # return value =/= 0 means the pattern was not found
+            if(NOT res EQUAL 0)
+                set(ADD_HOOK TRUE)
+            endif()
         endif()
-    endif()
-    if(ADD_HOOK)
-        configure_file(dummy_hook "${HOOK_LOCATION}" COPYONLY)
+        if(ADD_HOOK)
+            configure_file(dummy_hook "${HOOK_LOCATION}" COPYONLY)
+        endif()
     endif()
 endif()

--- a/third_party/git-cmake-format/CMakeLists.txt
+++ b/third_party/git-cmake-format/CMakeLists.txt
@@ -8,5 +8,9 @@ FetchContent_Declare(
 FetchContent_GetProperties(git_cmake_format)
 if(NOT git_cmake_format_POPULATED)
     FetchContent_Populate(git_cmake_format)
+
+    if(NOT DEFINED GCF_FORCE_OVERWRITE)
+        set(GCF_FORCE_OVERWRITE ON CACHE INTERNAL "If true, always overwrite pre-commit hook and script")
+    endif()
     add_subdirectory(${git_cmake_format_SOURCE_DIR} ${git_cmake_format_BINARY_DIR} EXCLUDE_FROM_ALL)
 endif()

--- a/third_party/git-cmake-format/CMakeLists.txt
+++ b/third_party/git-cmake-format/CMakeLists.txt
@@ -3,7 +3,7 @@ include(FetchContent)
 FetchContent_Declare(
     git_cmake_format
     GIT_REPOSITORY https://github.com/ginkgo-project/git-cmake-format.git
-    GIT_TAG        be9554a5d71030dcc23f1eb355c41ab9d876e776
+    GIT_TAG        069338e8afd47e6a27e661940cd36e940253f81c
 )
 FetchContent_GetProperties(git_cmake_format)
 if(NOT git_cmake_format_POPULATED)


### PR DESCRIPTION
Uses the correct .git directory in case of multiple worktrees created by `git worktree add`.

WIP: Waiting on ginkgo-project/git-cmake-format#5