### PR TITLE
Fix scalar jacobi generate on different precision and add DiagonalLinOpExtractable

### DIFF
--- a/core/matrix/diagonal.cpp
+++ b/core/matrix/diagonal.cpp
@@ -302,4 +302,24 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_TYPE(GKO_DECLARE_DIAGONAL_MATRIX);
 
 
 }  // namespace matrix
+
+
+// Implement DiagonalExtractable for LinOp when Diagonal is complete class
+template <typename ValueType>
+std::unique_ptr<LinOp> DiagonalExtractable<ValueType>::extract_diagonal_linop()
+    const
+{
+    auto diag = this->extract_diagonal();
+    auto p = dynamic_cast<LinOp *>(diag.get());
+    diag.release();
+    return std::unique_ptr<LinOp>{p};
+}
+
+
+#define GKO_DECLARE_DIAGONAL_EXTRACTABLE(value_type) \
+    std::unique_ptr<LinOp>                           \
+    DiagonalExtractable<value_type>::extract_diagonal_linop() const
+GKO_INSTANTIATE_FOR_EACH_VALUE_TYPE(GKO_DECLARE_DIAGONAL_EXTRACTABLE);
+
+
 }  // namespace gko

--- a/core/matrix/diagonal.cpp
+++ b/core/matrix/diagonal.cpp
@@ -147,6 +147,22 @@ std::unique_ptr<LinOp> Diagonal<ValueType>::conj_transpose() const
 
 
 template <typename ValueType>
+void Diagonal<ValueType>::convert_to(
+    Diagonal<next_precision<ValueType>> *result) const
+{
+    result->values_ = this->values_;
+    result->set_size(this->get_size());
+}
+
+
+template <typename ValueType>
+void Diagonal<ValueType>::move_to(Diagonal<next_precision<ValueType>> *result)
+{
+    this->convert_to(result);
+}
+
+
+template <typename ValueType>
 void Diagonal<ValueType>::convert_to(Csr<ValueType, int32> *result) const
 {
     auto exec = this->get_executor();

--- a/core/matrix/diagonal.cpp
+++ b/core/matrix/diagonal.cpp
@@ -325,10 +325,7 @@ template <typename ValueType>
 std::unique_ptr<LinOp> DiagonalExtractable<ValueType>::extract_diagonal_linop()
     const
 {
-    auto diag = this->extract_diagonal();
-    auto p = dynamic_cast<LinOp *>(diag.get());
-    diag.release();
-    return std::unique_ptr<LinOp>{p};
+    return this->extract_diagonal();
 }
 
 

--- a/core/preconditioner/jacobi.cpp
+++ b/core/preconditioner/jacobi.cpp
@@ -237,13 +237,15 @@ void Jacobi<ValueType, IndexType>::generate(const LinOp *system_matrix,
         if (auto diag_dense =
                 std::dynamic_pointer_cast<matrix::Diagonal<ValueType>>(diag)) {
             auto temp = gko::Array<ValueType>::view(
-                exec, system_matrix->get_size()[0], diag_dense->get_values());
+                diag_dense->get_executor(), system_matrix->get_size()[0],
+                diag_dense->get_values());
             this->blocks_ = temp;
         } else if (auto diag_dense =
                        std::dynamic_pointer_cast<matrix::Diagonal<next_type>>(
                            diag)) {
             auto temp = gko::Array<next_type>::view(
-                exec, system_matrix->get_size()[0], diag_dense->get_values());
+                diag_dense->get_executor(), system_matrix->get_size()[0],
+                diag_dense->get_values());
             this->blocks_ = temp;
         } else {
             GKO_NOT_SUPPORTED(system_matrix);

--- a/core/preconditioner/jacobi.cpp
+++ b/core/preconditioner/jacobi.cpp
@@ -241,9 +241,9 @@ void Jacobi<ValueType, IndexType>::generate(const LinOp *system_matrix,
         if (!diag_vt) {
             GKO_NOT_SUPPORTED(system_matrix);
         }
-        auto temp = gko::Array<ValueType>::view(diag_vt->get_executor(),
-                                                diag_vt->get_size()[0],
-                                                diag_vt->get_values());
+        auto temp = Array<ValueType>::view(diag_vt->get_executor(),
+                                           diag_vt->get_size()[0],
+                                           diag_vt->get_values());
         this->blocks_ = temp;
         this->num_blocks_ = diag_vt->get_size()[0];
     } else {

--- a/include/ginkgo/core/base/lin_op.hpp
+++ b/include/ginkgo/core/base/lin_op.hpp
@@ -655,6 +655,28 @@ private:
 
 
 /**
+ * The diagonal of a LinOp can be extracted. It will be implemented by
+ * DiagonalExtractable<ValueType>, so the class does not need to implement it.
+ * extract_diagonal_linop returns a linop which extracts the elements whose col
+ * and row index are the same and stores the result in a min(nrows, ncols) x 1
+ * dense matrix.
+ *
+ * @ingroup LinOp
+ */
+class DiagonalLinOpExtractable {
+public:
+    virtual ~DiagonalLinOpExtractable() = default;
+
+    /**
+     * Extracts the diagonal entries of the matrix into a vector.
+     *
+     * @return linop  the linop of diagonal format
+     */
+    virtual std::unique_ptr<LinOp> extract_diagonal_linop() const = 0;
+};
+
+
+/**
  * The diagonal of a LinOp implementing this interface can be extracted.
  * extract_diagonal extracts the elements whose col and row index are the
  * same and stores the result in a min(nrows, ncols) x 1 dense matrix.
@@ -662,11 +684,13 @@ private:
  * @ingroup LinOp
  */
 template <typename ValueType>
-class DiagonalExtractable {
+class DiagonalExtractable : public DiagonalLinOpExtractable {
 public:
     using value_type = ValueType;
 
     virtual ~DiagonalExtractable() = default;
+
+    std::unique_ptr<LinOp> extract_diagonal_linop() const override;
 
     /**
      * Extracts the diagonal entries of the matrix into a vector.

--- a/include/ginkgo/core/base/lin_op.hpp
+++ b/include/ginkgo/core/base/lin_op.hpp
@@ -661,6 +661,7 @@ private:
  * and row index are the same and stores the result in a min(nrows, ncols) x 1
  * dense matrix.
  *
+ * @ingroup diagonal
  * @ingroup LinOp
  */
 class DiagonalLinOpExtractable {

--- a/include/ginkgo/core/matrix/diagonal.hpp
+++ b/include/ginkgo/core/matrix/diagonal.hpp
@@ -209,6 +209,19 @@ private:
 
 
 }  // namespace matrix
+
+
+template <typename ValueType>
+std::unique_ptr<LinOp> DiagonalExtractable<ValueType>::extract_diagonal_linop()
+    const
+{
+    auto diag = this->extract_diagonal();
+    auto p = dynamic_cast<LinOp *>(diag.get());
+    diag.release();
+    return std::unique_ptr<LinOp>{p};
+}
+
+
 }  // namespace gko
 
 

--- a/include/ginkgo/core/matrix/diagonal.hpp
+++ b/include/ginkgo/core/matrix/diagonal.hpp
@@ -209,19 +209,6 @@ private:
 
 
 }  // namespace matrix
-
-
-template <typename ValueType>
-std::unique_ptr<LinOp> DiagonalExtractable<ValueType>::extract_diagonal_linop()
-    const
-{
-    auto diag = this->extract_diagonal();
-    auto p = dynamic_cast<LinOp *>(diag.get());
-    diag.release();
-    return std::unique_ptr<LinOp>{p};
-}
-
-
 }  // namespace gko
 
 

--- a/include/ginkgo/core/matrix/diagonal.hpp
+++ b/include/ginkgo/core/matrix/diagonal.hpp
@@ -70,6 +70,7 @@ class Diagonal
       public EnableCreateMethod<Diagonal<ValueType>>,
       public ConvertibleTo<Csr<ValueType, int32>>,
       public ConvertibleTo<Csr<ValueType, int64>>,
+      public ConvertibleTo<Diagonal<next_precision<ValueType>>>,
       public Transposable,
       public WritableToMatrixData<ValueType, int32>,
       public WritableToMatrixData<ValueType, int64>,
@@ -92,9 +93,15 @@ public:
     using mat_data32 = gko::matrix_data<ValueType, int32>;
     using absolute_type = remove_complex<Diagonal>;
 
+    friend class Diagonal<next_precision<ValueType>>;
+
     std::unique_ptr<LinOp> transpose() const override;
 
     std::unique_ptr<LinOp> conj_transpose() const override;
+
+    void convert_to(Diagonal<next_precision<ValueType>> *result) const override;
+
+    void move_to(Diagonal<next_precision<ValueType>> *result) override;
 
     void convert_to(Csr<ValueType, int32> *result) const override;
 

--- a/reference/test/matrix/diagonal_kernels.cpp
+++ b/reference/test/matrix/diagonal_kernels.cpp
@@ -108,6 +108,46 @@ protected:
 TYPED_TEST_SUITE(Diagonal, gko::test::ValueTypes);
 
 
+TYPED_TEST(Diagonal, ConvertsToPrecision)
+{
+    using ValueType = typename TestFixture::value_type;
+    using OtherType = typename gko::next_precision<ValueType>;
+    using Diagonal = typename TestFixture::Diag;
+    using OtherDiagonal = gko::matrix::Diagonal<OtherType>;
+    auto tmp = OtherDiagonal::create(this->exec);
+    auto res = Diagonal::create(this->exec);
+    // If OtherType is more precise: 0, otherwise r
+    auto residual = r<OtherType>::value < r<ValueType>::value
+                        ? gko::remove_complex<ValueType>{0}
+                        : gko::remove_complex<ValueType>{r<OtherType>::value};
+
+    this->diag1->convert_to(tmp.get());
+    tmp->convert_to(res.get());
+
+    GKO_ASSERT_MTX_NEAR(this->diag1, res, residual);
+}
+
+
+TYPED_TEST(Diagonal, MovesToPrecision)
+{
+    using ValueType = typename TestFixture::value_type;
+    using OtherType = typename gko::next_precision<ValueType>;
+    using Diagonal = typename TestFixture::Diag;
+    using OtherDiagonal = gko::matrix::Diagonal<OtherType>;
+    auto tmp = OtherDiagonal::create(this->exec);
+    auto res = Diagonal::create(this->exec);
+    // If OtherType is more precise: 0, otherwise r
+    auto residual = r<OtherType>::value < r<ValueType>::value
+                        ? gko::remove_complex<ValueType>{0}
+                        : gko::remove_complex<ValueType>{r<OtherType>::value};
+
+    this->diag1->move_to(tmp.get());
+    tmp->move_to(res.get());
+
+    GKO_ASSERT_MTX_NEAR(this->diag1, res, residual);
+}
+
+
 TYPED_TEST(Diagonal, AppliesToDense)
 {
     using value_type = typename TestFixture::value_type;

--- a/reference/test/preconditioner/jacobi.cpp
+++ b/reference/test/preconditioner/jacobi.cpp
@@ -385,11 +385,19 @@ TYPED_TEST(Jacobi, ScalarJacobiGeneratesOnDifferentPrecision)
     using value_type = typename TestFixture::value_type;
     using index_type = typename TestFixture::index_type;
     using next_type = gko::next_precision<value_type>;
+    using Bj = typename TestFixture::Bj;
     auto csr =
         gko::share(gko::matrix::Csr<next_type, index_type>::create(this->exec));
     csr->copy_from(gko::lend(this->mtx));
+    std::shared_ptr<Bj> bj{};
 
-    ASSERT_NO_THROW(this->scalar_j_factory->generate(csr));
+    ASSERT_NO_THROW(bj = this->scalar_j_factory->generate(csr));
+    ASSERT_EQ(bj->get_num_blocks(), 5u);
+    ASSERT_EQ(bj->get_blocks()[0], value_type{4});
+    ASSERT_EQ(bj->get_blocks()[1], value_type{4});
+    ASSERT_EQ(bj->get_blocks()[2], value_type{4});
+    ASSERT_EQ(bj->get_blocks()[3], value_type{4});
+    ASSERT_EQ(bj->get_blocks()[4], value_type{4});
 }
 
 


### PR DESCRIPTION
This pr adds DiagonalLinOpExtractable and fix scalar Jacobi issue on generation on different precision matrix.

the failed test can be found in https://gitlab.com/ginkgo-project/ginkgo-public-ci/-/pipelines/336902618