### PR TITLE
Fix when ginkgo is not in git

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -278,7 +278,10 @@ if(GINKGO_DEVEL_TOOLS)
     add_custom_target(add_license
         COMMAND ${Ginkgo_SOURCE_DIR}/dev_tools/scripts/add_license.sh
         WORKING_DIRECTORY ${Ginkgo_SOURCE_DIR})
-    add_dependencies(format add_license)
+    # if git-cmake-format can not build format target, do not add the dependencies
+    if(TARGET format)
+        add_dependencies(format add_license)
+    endif()
 endif()
 
 # MacOS needs to install bash, gnu-sed, findutils and coreutils

--- a/third_party/dummy-hook/CMakeLists.txt
+++ b/third_party/dummy-hook/CMakeLists.txt
@@ -4,8 +4,12 @@ if(GIT_FOUND)
       WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
       OUTPUT_VARIABLE Ginkgo_GIT_HOOKS_DIR
       OUTPUT_STRIP_TRAILING_WHITESPACE)
+    # If it is not in git, give an error and return
+    if(NOT Ginkgo_GIT_HOOKS_DIR)
+        message(STATUS "Ginkgo is not in a git repository, so no git hook was installed")
+        return()
+    endif()
     get_filename_component(Ginkgo_GIT_HOOKS_DIR ${Ginkgo_GIT_HOOKS_DIR} REALPATH BASE_DIR ${CMAKE_SOURCE_DIR})
-
     if(EXISTS "${Ginkgo_GIT_HOOKS_DIR}")
         set(ADD_HOOK FALSE)
         set(HOOK_LOCATION "${Ginkgo_GIT_HOOKS_DIR}/pre-commit")

--- a/third_party/git-cmake-format/CMakeLists.txt
+++ b/third_party/git-cmake-format/CMakeLists.txt
@@ -3,7 +3,7 @@ include(FetchContent)
 FetchContent_Declare(
     git_cmake_format
     GIT_REPOSITORY https://github.com/ginkgo-project/git-cmake-format.git
-    GIT_TAG        069338e8afd47e6a27e661940cd36e940253f81c
+    GIT_TAG        e9a82f20d36f1a92d4c52910a8d0a694e7673c54
 )
 FetchContent_GetProperties(git_cmake_format)
 if(NOT git_cmake_format_POPULATED)


### PR DESCRIPTION
This pr fixes the issue when the folder is not in valid git structure.
also, when git-cmake-format is failed to add `format` target, do not add the dependency, which gives error.


TODO:
- [x] Merge https://github.com/ginkgo-project/git-cmake-format/pull/8