### PR TITLE
Add Reference ILU(0)

### DIFF
--- a/reference/factorization/ic_kernels.cpp
+++ b/reference/factorization/ic_kernels.cpp
@@ -33,6 +33,9 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "core/factorization/ic_kernels.hpp"
 
 
+#include <ginkgo/core/base/math.hpp>
+
+
 #include "core/base/allocator.hpp"
 
 

--- a/reference/factorization/ic_kernels.cpp
+++ b/reference/factorization/ic_kernels.cpp
@@ -54,7 +54,7 @@ template <typename ValueType, typename IndexType>
 void compute(std::shared_ptr<const DefaultExecutor> exec,
              matrix::Csr<ValueType, IndexType> *m)
 {
-    vector<IndexType> diagonals{m->get_size()[0], -1, {exec}};
+    vector<IndexType> diagonals{m->get_size()[0], -1, exec};
     const auto row_ptrs = m->get_const_row_ptrs();
     const auto col_idxs = m->get_const_col_idxs();
     const auto values = m->get_values();

--- a/reference/factorization/ic_kernels.cpp
+++ b/reference/factorization/ic_kernels.cpp
@@ -33,6 +33,9 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "core/factorization/ic_kernels.hpp"
 
 
+#include "core/base/allocator.hpp"
+
+
 namespace gko {
 namespace kernels {
 namespace reference {
@@ -46,7 +49,52 @@ namespace ic_factorization {
 
 template <typename ValueType, typename IndexType>
 void compute(std::shared_ptr<const DefaultExecutor> exec,
-             matrix::Csr<ValueType, IndexType> *m) GKO_NOT_IMPLEMENTED;
+             matrix::Csr<ValueType, IndexType> *m)
+{
+    vector<IndexType> diagonals{m->get_size()[0], -1, {exec}};
+    const auto row_ptrs = m->get_const_row_ptrs();
+    const auto col_idxs = m->get_const_col_idxs();
+    const auto values = m->get_values();
+    for (size_type row = 0; row < m->get_size()[0]; row++) {
+        const auto begin = row_ptrs[row];
+        const auto end = row_ptrs[row + 1];
+        for (auto nz = begin; nz < end; nz++) {
+            const auto col = col_idxs[nz];
+            if (col == row) {
+                diagonals[row] = nz;
+            }
+            if (col > row) {
+                continue;
+            }
+            // accumulate l(row,:) * l(col,:) without the last entry l(col, col)
+            ValueType sum{};
+            auto l_idx = begin;
+            const auto l_end = end;
+            auto lh_idx = row_ptrs[col];
+            const auto lh_end = row_ptrs[col + 1];
+            while (l_idx < l_end && lh_idx < lh_end) {
+                const auto l_col = col_idxs[l_idx];
+                const auto lh_row = col_idxs[lh_idx];
+                // only consider lower triangle of L
+                if (max(l_col, lh_row) > row) {
+                    break;
+                }
+                // ignore l(col, col)
+                if (l_col == lh_row && l_col < col) {
+                    sum += values[l_idx] * values[lh_idx];
+                }
+                l_idx += l_col <= lh_row ? 1 : 0;
+                lh_idx += lh_row <= l_col ? 1 : 0;
+            }
+            if (row == col) {
+                values[nz] = sqrt(values[nz] - sum);
+            } else {
+                GKO_ASSERT(diagonals[col] != -1);
+                values[nz] = (values[nz] - sum) / values[diagonals[col]];
+            }
+        }
+    }
+}
 
 GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(GKO_DECLARE_IC_COMPUTE_KERNEL);
 

--- a/reference/factorization/ic_kernels.cpp
+++ b/reference/factorization/ic_kernels.cpp
@@ -81,7 +81,7 @@ void compute(std::shared_ptr<const DefaultExecutor> exec,
                 }
                 // ignore l(col, col)
                 if (l_col == lh_row && l_col < col) {
-                    sum += values[l_idx] * values[lh_idx];
+                    sum += values[l_idx] * conj(values[lh_idx]);
                 }
                 l_idx += l_col <= lh_row ? 1 : 0;
                 lh_idx += lh_row <= l_col ? 1 : 0;

--- a/reference/factorization/ilu_kernels.cpp
+++ b/reference/factorization/ilu_kernels.cpp
@@ -57,7 +57,7 @@ template <typename ValueType, typename IndexType>
 void compute_lu(std::shared_ptr<const DefaultExecutor> exec,
                 matrix::Csr<ValueType, IndexType> *m)
 {
-    vector<IndexType> diagonals{m->get_size()[0], -1, {exec}};
+    vector<IndexType> diagonals{m->get_size()[0], -1, exec};
     const auto row_ptrs = m->get_const_row_ptrs();
     const auto col_idxs = m->get_const_col_idxs();
     const auto values = m->get_values();
@@ -71,9 +71,7 @@ void compute_lu(std::shared_ptr<const DefaultExecutor> exec,
                 diagonals[row] = nz;
             }
             auto value = values[nz];
-            const auto l_begin = begin;
-            const auto l_end = end;
-            for (auto l_nz = l_begin; l_nz < l_end; l_nz++) {
+            for (auto l_nz = begin; l_nz < end; l_nz++) {
                 // for each lower triangular entry l_ik
                 const auto l_col = col_idxs[l_nz];
                 if (l_col >= min(row, col)) {

--- a/reference/factorization/ilu_kernels.cpp
+++ b/reference/factorization/ilu_kernels.cpp
@@ -33,6 +33,12 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "core/factorization/ilu_kernels.hpp"
 
 
+#include <algorithm>
+
+
+#include <ginkgo/core/base/math.hpp>
+
+
 #include "core/base/allocator.hpp"
 
 
@@ -67,10 +73,10 @@ void compute_lu(std::shared_ptr<const DefaultExecutor> exec,
             auto value = values[nz];
             const auto l_begin = begin;
             const auto l_end = end;
-            for (auto l_nz = begin; l_nz < end; l_nz++) {
+            for (auto l_nz = l_begin; l_nz < l_end; l_nz++) {
                 // for each lower triangular entry l_ik
                 const auto l_col = col_idxs[l_nz];
-                if (l_col >= std::min(row, col)) {
+                if (l_col >= min(row, col)) {
                     continue;
                 }
                 // find corresponding entry u_kj

--- a/reference/factorization/ilu_kernels.cpp
+++ b/reference/factorization/ilu_kernels.cpp
@@ -33,6 +33,9 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "core/factorization/ilu_kernels.hpp"
 
 
+#include "core/base/allocator.hpp"
+
+
 namespace gko {
 namespace kernels {
 namespace reference {
@@ -46,7 +49,48 @@ namespace ilu_factorization {
 
 template <typename ValueType, typename IndexType>
 void compute_lu(std::shared_ptr<const DefaultExecutor> exec,
-                matrix::Csr<ValueType, IndexType> *m) GKO_NOT_IMPLEMENTED;
+                matrix::Csr<ValueType, IndexType> *m)
+{
+    vector<IndexType> diagonals{m->get_size()[0], -1, {exec}};
+    const auto row_ptrs = m->get_const_row_ptrs();
+    const auto col_idxs = m->get_const_col_idxs();
+    const auto values = m->get_values();
+    for (IndexType row = 0; row < static_cast<IndexType>(m->get_size()[0]);
+         row++) {
+        const auto begin = row_ptrs[row];
+        const auto end = row_ptrs[row + 1];
+        for (auto nz = begin; nz < end; nz++) {
+            const auto col = col_idxs[nz];
+            if (col == row) {
+                diagonals[row] = nz;
+            }
+            auto value = values[nz];
+            const auto l_begin = begin;
+            const auto l_end = end;
+            for (auto l_nz = begin; l_nz < end; l_nz++) {
+                // for each lower triangular entry l_ik
+                const auto l_col = col_idxs[l_nz];
+                if (l_col >= std::min(row, col)) {
+                    continue;
+                }
+                // find corresponding entry u_kj
+                const auto u_begin_it = col_idxs + row_ptrs[l_col];
+                const auto u_end_it = col_idxs + row_ptrs[l_col + 1];
+                const auto u_it = std::lower_bound(u_begin_it, u_end_it, col);
+                const auto u_nz = std::distance(col_idxs, u_it);
+                if (u_it != u_end_it && *u_it == col) {
+                    value -= values[l_nz] * values[u_nz];
+                }
+            }
+            if (row <= col) {
+                values[nz] = value;
+            } else {
+                GKO_ASSERT(diagonals[col] != -1);
+                values[nz] = value / values[diagonals[col]];
+            }
+        }
+    }
+}
 
 GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
     GKO_DECLARE_ILU_COMPUTE_LU_KERNEL);

--- a/reference/test/factorization/CMakeLists.txt
+++ b/reference/test/factorization/CMakeLists.txt
@@ -1,3 +1,5 @@
+ginkgo_create_test(ic_kernels)
+ginkgo_create_test(ilu_kernels)
 ginkgo_create_test(par_ic_kernels)
 ginkgo_create_test(par_ict_kernels)
 ginkgo_create_test(par_ilu_kernels)

--- a/reference/test/factorization/ic_kernels.cpp
+++ b/reference/test/factorization/ic_kernels.cpp
@@ -96,18 +96,6 @@ protected:
                                            {-6., 18., 17., 14.},
                                            {-3., 24., 14., 18.}},
                                           ref)),
-          mtx_l_system(gko::initialize<Csr>({{9., 0., 0., 0.},
-                                             {0., 36., 0., 0.},
-                                             {-6., 18., 17., 0.},
-                                             {-3., 24., 14., 18.}},
-                                            ref)),
-          mtx_l_system_coo(Coo::create(exec)),
-          mtx_l_init_expect(gko::initialize<Csr>(
-              {{3., 0., 0., 0.},
-               {0., 6., 0., 0.},
-               {-6., 18., static_cast<value_type>(sqrt(17.)), 0.},
-               {-3., 24., 14., static_cast<value_type>(sqrt(18.))}},
-              ref)),
           mtx_l_it_expect(gko::initialize<Csr>({{3., 0., 0., 0.},
                                                 {0., 6., 0., 0.},
                                                 {-2., 3., 2., 0.},
@@ -115,9 +103,7 @@ protected:
                                                ref)),
           fact_fact(factorization_type::build().on(exec)),
           tol{r<value_type>::value}
-    {
-        mtx_l_system->convert_to(gko::lend(mtx_l_system_coo));
-    }
+    {}
 
     std::shared_ptr<const gko::ReferenceExecutor> ref;
     std::shared_ptr<const gko::Executor> exec;
@@ -125,9 +111,6 @@ protected:
     std::shared_ptr<Csr> banded;
     std::shared_ptr<Csr> banded_l_expect;
     std::shared_ptr<Csr> mtx_system;
-    std::unique_ptr<Csr> mtx_l_system;
-    std::unique_ptr<Coo> mtx_l_system_coo;
-    std::unique_ptr<Csr> mtx_l_init_expect;
     std::unique_ptr<Csr> mtx_l_it_expect;
     std::unique_ptr<typename factorization_type::Factory> fact_fact;
     gko::remove_complex<value_type> tol;
@@ -201,6 +184,7 @@ TYPED_TEST(Ic, GenerateDenseIdentity)
     using Dense = typename TestFixture::Dense;
     auto dense_id = Dense::create(this->exec, this->identity->get_size());
     this->identity->convert_to(dense_id.get());
+
     auto fact = this->fact_fact->generate(gko::share(dense_id));
 
     GKO_ASSERT_MTX_NEAR(fact->get_l_factor(), this->identity, this->tol);
@@ -212,6 +196,7 @@ TYPED_TEST(Ic, GenerateBanded)
 {
     using factorization_type = typename TestFixture::factorization_type;
     using Csr = typename TestFixture::Csr;
+
     auto fact =
         factorization_type::build().on(this->exec)->generate(this->banded);
 
@@ -226,6 +211,7 @@ TYPED_TEST(Ic, GenerateGeneral)
 {
     using factorization_type = typename TestFixture::factorization_type;
     using Csr = typename TestFixture::Csr;
+
     auto fact =
         factorization_type::build().on(this->exec)->generate(this->mtx_system);
 

--- a/reference/test/factorization/ic_kernels.cpp
+++ b/reference/test/factorization/ic_kernels.cpp
@@ -1,0 +1,239 @@
+/*******************************<GINKGO LICENSE>******************************
+Copyright (c) 2017-2021, the Ginkgo authors
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+******************************<GINKGO LICENSE>*******************************/
+
+#include <ginkgo/core/factorization/ic.hpp>
+
+
+#include <algorithm>
+#include <memory>
+#include <vector>
+
+
+#include <gtest/gtest.h>
+
+
+#include <ginkgo/core/base/executor.hpp>
+#include <ginkgo/core/matrix/coo.hpp>
+#include <ginkgo/core/matrix/csr.hpp>
+#include <ginkgo/core/matrix/dense.hpp>
+
+
+#include "core/test/utils.hpp"
+
+
+namespace {
+
+
+class DummyLinOp : public gko::EnableLinOp<DummyLinOp>,
+                   public gko::EnableCreateMethod<DummyLinOp> {
+public:
+    DummyLinOp(std::shared_ptr<const gko::Executor> exec,
+               gko::dim<2> size = gko::dim<2>{})
+        : EnableLinOp<DummyLinOp>(exec, size)
+    {}
+
+protected:
+    void apply_impl(const gko::LinOp *b, gko::LinOp *x) const override {}
+
+    void apply_impl(const gko::LinOp *alpha, const gko::LinOp *b,
+                    const gko::LinOp *beta, gko::LinOp *x) const override
+    {}
+};
+
+
+template <typename ValueIndexType>
+class Ic : public ::testing::Test {
+protected:
+    using value_type =
+        typename std::tuple_element<0, decltype(ValueIndexType())>::type;
+    using index_type =
+        typename std::tuple_element<1, decltype(ValueIndexType())>::type;
+    using factorization_type = gko::factorization::Ic<value_type, index_type>;
+    using Coo = gko::matrix::Coo<value_type, index_type>;
+    using Csr = gko::matrix::Csr<value_type, index_type>;
+    using Dense = gko::matrix::Dense<value_type>;
+
+    Ic()
+        : ref(gko::ReferenceExecutor::create()),
+          exec(std::static_pointer_cast<const gko::Executor>(ref)),
+          identity(gko::initialize<Csr>(
+              {{1., 0., 0.}, {0., 1., 0.}, {0., 0., 1.}}, ref)),
+          banded(gko::initialize<Csr>(
+              {{1., 1., 0.}, {1., 2., 1.}, {0., 1., 2.}}, ref)),
+          banded_l_expect(gko::initialize<Csr>(
+              {{1., 0., 0.}, {1., 1., 0.}, {0., 1., 1.}}, ref)),
+          mtx_system(gko::initialize<Csr>({{9., 0., -6., 3.},
+                                           {0., 36., 18., 24.},
+                                           {-6., 18., 17., 14.},
+                                           {-3., 24., 14., 18.}},
+                                          ref)),
+          mtx_l_system(gko::initialize<Csr>({{9., 0., 0., 0.},
+                                             {0., 36., 0., 0.},
+                                             {-6., 18., 17., 0.},
+                                             {-3., 24., 14., 18.}},
+                                            ref)),
+          mtx_l_system_coo(Coo::create(exec)),
+          mtx_l_init_expect(gko::initialize<Csr>(
+              {{3., 0., 0., 0.},
+               {0., 6., 0., 0.},
+               {-6., 18., static_cast<value_type>(sqrt(17.)), 0.},
+               {-3., 24., 14., static_cast<value_type>(sqrt(18.))}},
+              ref)),
+          mtx_l_it_expect(gko::initialize<Csr>({{3., 0., 0., 0.},
+                                                {0., 6., 0., 0.},
+                                                {-2., 3., 2., 0.},
+                                                {-1., 4., 0., 1.}},
+                                               ref)),
+          fact_fact(factorization_type::build().on(exec)),
+          tol{r<value_type>::value}
+    {
+        mtx_l_system->convert_to(gko::lend(mtx_l_system_coo));
+    }
+
+    std::shared_ptr<const gko::ReferenceExecutor> ref;
+    std::shared_ptr<const gko::Executor> exec;
+    std::shared_ptr<Csr> identity;
+    std::shared_ptr<Csr> banded;
+    std::shared_ptr<Csr> banded_l_expect;
+    std::shared_ptr<Csr> mtx_system;
+    std::unique_ptr<Csr> mtx_l_system;
+    std::unique_ptr<Coo> mtx_l_system_coo;
+    std::unique_ptr<Csr> mtx_l_init_expect;
+    std::unique_ptr<Csr> mtx_l_it_expect;
+    std::unique_ptr<typename factorization_type::Factory> fact_fact;
+    gko::remove_complex<value_type> tol;
+};
+
+TYPED_TEST_SUITE(Ic, gko::test::ValueIndexTypes);
+
+
+TYPED_TEST(Ic, ThrowNotSupportedForWrongLinOp)
+{
+    auto lin_op = DummyLinOp::create(this->ref);
+
+    ASSERT_THROW(this->fact_fact->generate(gko::share(lin_op)),
+                 gko::NotSupported);
+}
+
+
+TYPED_TEST(Ic, ThrowDimensionMismatch)
+{
+    using Csr = typename TestFixture::Csr;
+    auto matrix = Csr::create(this->ref, gko::dim<2>{2, 3}, 4);
+
+    ASSERT_THROW(this->fact_fact->generate(gko::share(matrix)),
+                 gko::DimensionMismatch);
+}
+
+
+TYPED_TEST(Ic, SetStrategy)
+{
+    using Csr = typename TestFixture::Csr;
+    using factorization_type = typename TestFixture::factorization_type;
+    auto l_strategy = std::make_shared<typename Csr::merge_path>();
+
+    auto factory =
+        factorization_type::build().with_l_strategy(l_strategy).on(this->ref);
+    auto fact = factory->generate(this->mtx_system);
+
+    ASSERT_EQ(factory->get_parameters().l_strategy, l_strategy);
+    ASSERT_EQ(fact->get_l_factor()->get_strategy()->get_name(),
+              l_strategy->get_name());
+    ASSERT_EQ(fact->get_lt_factor()->get_strategy()->get_name(),
+              l_strategy->get_name());
+}
+
+
+TYPED_TEST(Ic, IsConsistentWithComposition)
+{
+    auto fact = this->fact_fact->generate(this->mtx_system);
+
+    auto lin_op_l_factor = gko::as<gko::LinOp>(fact->get_l_factor());
+    auto lin_op_lt_factor = gko::as<gko::LinOp>(fact->get_lt_factor());
+    auto first_operator = fact->get_operators()[0];
+    auto second_operator = fact->get_operators()[1];
+
+    ASSERT_EQ(lin_op_l_factor, first_operator);
+    ASSERT_EQ(lin_op_lt_factor, second_operator);
+}
+
+
+TYPED_TEST(Ic, GenerateIdentity)
+{
+    auto fact = this->fact_fact->generate(this->identity);
+
+    GKO_ASSERT_MTX_NEAR(fact->get_l_factor(), this->identity, this->tol);
+    GKO_ASSERT_MTX_NEAR(fact->get_lt_factor(), this->identity, this->tol);
+}
+
+
+TYPED_TEST(Ic, GenerateDenseIdentity)
+{
+    using Dense = typename TestFixture::Dense;
+    auto dense_id = Dense::create(this->exec, this->identity->get_size());
+    this->identity->convert_to(dense_id.get());
+    auto fact = this->fact_fact->generate(gko::share(dense_id));
+
+    GKO_ASSERT_MTX_NEAR(fact->get_l_factor(), this->identity, this->tol);
+    GKO_ASSERT_MTX_NEAR(fact->get_lt_factor(), this->identity, this->tol);
+}
+
+
+TYPED_TEST(Ic, GenerateBanded)
+{
+    using factorization_type = typename TestFixture::factorization_type;
+    using Csr = typename TestFixture::Csr;
+    auto fact =
+        factorization_type::build().on(this->exec)->generate(this->banded);
+
+    GKO_ASSERT_MTX_NEAR(fact->get_l_factor(), this->banded_l_expect, this->tol);
+    GKO_ASSERT_MTX_NEAR(fact->get_lt_factor(),
+                        gko::as<Csr>(this->banded_l_expect->conj_transpose()),
+                        this->tol);
+}
+
+
+TYPED_TEST(Ic, GenerateGeneral)
+{
+    using factorization_type = typename TestFixture::factorization_type;
+    using Csr = typename TestFixture::Csr;
+    auto fact =
+        factorization_type::build().on(this->exec)->generate(this->mtx_system);
+
+    GKO_ASSERT_MTX_NEAR(fact->get_l_factor(), this->mtx_l_it_expect, this->tol);
+    GKO_ASSERT_MTX_NEAR(fact->get_lt_factor(),
+                        gko::as<Csr>(this->mtx_l_it_expect->conj_transpose()),
+                        this->tol);
+}
+
+
+}  // namespace

--- a/reference/test/factorization/ilu_kernels.cpp
+++ b/reference/test/factorization/ilu_kernels.cpp
@@ -1,0 +1,505 @@
+/*******************************<GINKGO LICENSE>******************************
+Copyright (c) 2017-2021, the Ginkgo authors
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+******************************<GINKGO LICENSE>*******************************/
+
+#include <ginkgo/core/factorization/ilu.hpp>
+
+
+#include <algorithm>
+#include <initializer_list>
+#include <memory>
+#include <vector>
+
+
+#include <gtest/gtest.h>
+
+
+#include <ginkgo/core/base/executor.hpp>
+#include <ginkgo/core/matrix/coo.hpp>
+#include <ginkgo/core/matrix/csr.hpp>
+#include <ginkgo/core/matrix/dense.hpp>
+
+
+#include "core/test/utils.hpp"
+
+
+namespace {
+
+
+class DummyLinOp : public gko::EnableLinOp<DummyLinOp>,
+                   public gko::EnableCreateMethod<DummyLinOp> {
+public:
+    DummyLinOp(std::shared_ptr<const gko::Executor> exec,
+               gko::dim<2> size = gko::dim<2>{})
+        : EnableLinOp<DummyLinOp>(exec, size)
+    {}
+
+protected:
+    void apply_impl(const gko::LinOp *b, gko::LinOp *x) const override {}
+
+    void apply_impl(const gko::LinOp *alpha, const gko::LinOp *b,
+                    const gko::LinOp *beta, gko::LinOp *x) const override
+    {}
+};
+
+
+template <typename ValueIndexType>
+class Ilu : public ::testing::Test {
+protected:
+    using value_type =
+        typename std::tuple_element<0, decltype(ValueIndexType())>::type;
+    using index_type =
+        typename std::tuple_element<1, decltype(ValueIndexType())>::type;
+    using Dense = gko::matrix::Dense<value_type>;
+    using Coo = gko::matrix::Coo<value_type, index_type>;
+    using Csr = gko::matrix::Csr<value_type, index_type>;
+    using ilu_type = gko::factorization::Ilu<value_type, index_type>;
+    Ilu()
+        : ref(gko::ReferenceExecutor::create()),
+          exec(std::static_pointer_cast<const gko::Executor>(ref)),
+          // clang-format off
+          empty_csr(gko::initialize<Csr>(
+              {{0., 0., 0.},
+               {0., 0., 0.},
+               {0., 0., 0.}}, exec)),
+          identity(gko::initialize<Dense>(
+              {{1., 0., 0.},
+               {0., 1., 0.},
+               {0., 0., 1.}}, exec)),
+          lower_triangular(gko::initialize<Dense>(
+              {{1., 0., 0.},
+               {1., 1., 0.},
+               {1., 1., 1.}}, exec)),
+          upper_triangular(gko::initialize<Dense>(
+              {{1., 1., 1.},
+               {0., 1., 1.},
+               {0., 0., 1.}}, exec)),
+          mtx_small(gko::initialize<Dense>(
+              {{4., 6., 8.},
+               {2., 2., 5.},
+               {1., 1., 1.}}, exec)),
+          mtx_csr_small(nullptr),
+          small_l_expected(gko::initialize<Dense>(
+              {{1., 0., 0.},
+               {0.5, 1., 0.},
+               {0.25, 0.5, 1.}}, exec)),
+          small_u_expected(gko::initialize<Dense>(
+              {{4., 6., 8.},
+               {0., -1., 1.},
+               {0., 0., -1.5}}, exec)),
+          mtx_small2(gko::initialize<Dense>(
+              {{8., 8., 0},
+              {2., 0., 5.},
+              {1., 1., 1}}, exec)),
+          mtx_csr_small2(nullptr),
+          small2_l_expected(gko::initialize<Dense>(
+              {{1., 0., 0},
+              {.25, 1., 0.},
+              {.125, 0., 1}}, exec)),
+          small2_u_expected(gko::initialize<Dense>(
+              {{8., 8., 0},
+              {0., -2., 5.},
+              {0., 0., 1}}, exec)),
+          mtx_big(gko::initialize<Dense>({{1., 1., 1., 0., 1., 3.},
+                                          {1., 2., 2., 0., 2., 0.},
+                                          {0., 2., 3., 3., 3., 5.},
+                                          {1., 0., 3., 4., 4., 4.},
+                                          {1., 2., 0., 4., 5., 6.},
+                                          {0., 2., 3., 4., 5., 8.}},
+                                         exec)),
+          big_l_expected(gko::initialize<Dense>({{1., 0., 0., 0., 0., 0.},
+                                                 {1., 1., 0., 0., 0., 0.},
+                                                 {0., 2., 1., 0., 0., 0.},
+                                                 {1., 0., 2., 1., 0., 0.},
+                                                 {1., 1., 0., -2., 1., 0.},
+                                                 {0., 2., 1., -0.5, 0.5, 1.}},
+                                                exec)),
+          big_u_expected(gko::initialize<Dense>({{1., 1., 1., 0., 1., 3.},
+                                                 {0., 1., 1., 0., 1., 0.},
+                                                 {0., 0., 1., 3., 1., 5.},
+                                                 {0., 0., 0., -2., 1., -9.},
+                                                 {0., 0., 0., 0., 5., -15.},
+                                                 {0., 0., 0., 0., 0., 6.}},
+                                                exec)),
+          mtx_big_nodiag(gko::initialize<Csr>({{1., 1., 1., 0., 1., 3.},
+                                               {1., 2., 2., 0., 2., 0.},
+                                               {0., 2., 0., 3., 3., 5.},
+                                               {1., 0., 3., 4., 4., 4.},
+                                               {1., 2., 0., 4., 1., 6.},
+                                               {0., 2., 3., 4., 5., 8.}},
+                                         exec)),
+          big_nodiag_l_expected(gko::initialize<Dense>(
+            {{1., 0., 0., 0., 0., 0.},
+             {1., 1., 0., 0., 0., 0.},
+             {0., 2., 1., 0., 0., 0.},
+             {1., 0., -1., 1., 0., 0.},
+             {1., 1., 0., 0.571428571428571, 1., 0.},
+             {0., 2., -0.5, 0.785714285714286, -0.108695652173913, 1.}},
+            exec)),
+          big_nodiag_u_expected(gko::initialize<Dense>(
+            {{1., 1., 1., 0., 1., 3.},
+             {0., 1., 1., 0., 1., 0.},
+             {0., 0., -2., 3., 1., 5.},
+             {0., 0., 0., 7., 4., 6.},
+             {0., 0., 0., 0., -3.28571428571429, -0.428571428571429},
+             {0., 0., 0., 0., 0., 5.73913043478261}},
+            exec)),
+          // clang-format on
+          ilu_factory_skip(ilu_type::build().with_skip_sorting(true).on(exec)),
+          ilu_factory_sort(ilu_type::build().with_skip_sorting(false).on(exec))
+    {
+        auto tmp_csr = Csr::create(exec);
+        mtx_small->convert_to(gko::lend(tmp_csr));
+        mtx_csr_small = std::move(tmp_csr);
+        auto tmp_csr2 = Csr::create(exec);
+        mtx_small2->convert_to(gko::lend(tmp_csr2));
+        mtx_csr_small2 = std::move(tmp_csr2);
+    }
+
+    std::shared_ptr<const gko::ReferenceExecutor> ref;
+    std::shared_ptr<const gko::Executor> exec;
+    std::shared_ptr<const Csr> empty_csr;
+    std::shared_ptr<const Dense> identity;
+    std::shared_ptr<const Dense> lower_triangular;
+    std::shared_ptr<const Dense> upper_triangular;
+    std::shared_ptr<const Dense> mtx_small;
+    std::shared_ptr<const Csr> mtx_csr_small;
+    std::shared_ptr<const Dense> small_l_expected;
+    std::shared_ptr<const Dense> small_u_expected;
+    std::shared_ptr<const Dense> mtx_small2;
+    std::shared_ptr<const Csr> mtx_csr_small2;
+    std::shared_ptr<const Dense> small2_l_expected;
+    std::shared_ptr<const Dense> small2_u_expected;
+    std::shared_ptr<const Dense> mtx_big;
+    std::shared_ptr<const Dense> big_l_expected;
+    std::shared_ptr<const Dense> big_u_expected;
+    std::shared_ptr<const Csr> mtx_big_nodiag;
+    std::shared_ptr<const Dense> big_nodiag_l_expected;
+    std::shared_ptr<const Dense> big_nodiag_u_expected;
+    std::unique_ptr<typename ilu_type::Factory> ilu_factory_skip;
+    std::unique_ptr<typename ilu_type::Factory> ilu_factory_sort;
+};
+
+TYPED_TEST_SUITE(Ilu, gko::test::ValueIndexTypes);
+
+
+TYPED_TEST(Ilu, ThrowNotSupportedForWrongLinOp1)
+{
+    auto linOp = DummyLinOp::create(this->ref);
+
+    ASSERT_THROW(this->ilu_factory_skip->generate(gko::share(linOp)),
+                 gko::NotSupported);
+}
+
+
+TYPED_TEST(Ilu, ThrowNotSupportedForWrongLinOp2)
+{
+    auto linOp = DummyLinOp::create(this->ref);
+
+    ASSERT_THROW(this->ilu_factory_sort->generate(gko::share(linOp)),
+                 gko::NotSupported);
+}
+
+
+TYPED_TEST(Ilu, ThrowDimensionMismatch)
+{
+    using Csr = typename TestFixture::Csr;
+    auto matrix = Csr::create(this->ref, gko::dim<2>{2, 3}, 4);
+
+    ASSERT_THROW(this->ilu_factory_sort->generate(gko::share(matrix)),
+                 gko::DimensionMismatch);
+}
+
+
+TYPED_TEST(Ilu, SetLStrategy)
+{
+    using Csr = typename TestFixture::Csr;
+    using ilu_type = typename TestFixture::ilu_type;
+    auto l_strategy = std::make_shared<typename Csr::classical>();
+
+    auto factory = ilu_type::build().with_l_strategy(l_strategy).on(this->ref);
+    auto ilu = factory->generate(this->mtx_small);
+
+    ASSERT_EQ(factory->get_parameters().l_strategy, l_strategy);
+    ASSERT_EQ(ilu->get_l_factor()->get_strategy()->get_name(),
+              l_strategy->get_name());
+}
+
+
+TYPED_TEST(Ilu, SetUStrategy)
+{
+    using Csr = typename TestFixture::Csr;
+    using ilu_type = typename TestFixture::ilu_type;
+    auto u_strategy = std::make_shared<typename Csr::classical>();
+
+    auto factory = ilu_type::build().with_u_strategy(u_strategy).on(this->ref);
+    auto ilu = factory->generate(this->mtx_small);
+
+    ASSERT_EQ(factory->get_parameters().u_strategy, u_strategy);
+    ASSERT_EQ(ilu->get_u_factor()->get_strategy()->get_name(),
+              u_strategy->get_name());
+}
+
+
+TYPED_TEST(Ilu, LUFactorFunctionsSetProperly)
+{
+    auto factors = this->ilu_factory_skip->generate(this->mtx_small);
+
+    auto lin_op_l_factor =
+        static_cast<const gko::LinOp *>(gko::lend(factors->get_l_factor()));
+    auto lin_op_u_factor =
+        static_cast<const gko::LinOp *>(gko::lend(factors->get_u_factor()));
+    auto first_operator = gko::lend(factors->get_operators()[0]);
+    auto second_operator = gko::lend(factors->get_operators()[1]);
+
+    ASSERT_EQ(lin_op_l_factor, first_operator);
+    ASSERT_EQ(lin_op_u_factor, second_operator);
+}
+
+
+TYPED_TEST(Ilu, GenerateForCooIdentity)
+{
+    using Coo = typename TestFixture::Coo;
+    using value_type = typename TestFixture::value_type;
+    auto coo_mtx = gko::share(Coo::create(this->exec));
+    this->identity->convert_to(gko::lend(coo_mtx));
+
+    auto factors = this->ilu_factory_skip->generate(coo_mtx);
+    auto l_factor = factors->get_l_factor();
+    auto u_factor = factors->get_u_factor();
+
+    GKO_ASSERT_MTX_NEAR(l_factor, this->identity, r<value_type>::value);
+    GKO_ASSERT_MTX_NEAR(u_factor, this->identity, r<value_type>::value);
+}
+
+
+TYPED_TEST(Ilu, GenerateForCsrIdentity)
+{
+    using Csr = typename TestFixture::Csr;
+    using value_type = typename TestFixture::value_type;
+    auto csr_mtx = gko::share(Csr::create(this->exec));
+    this->identity->convert_to(gko::lend(csr_mtx));
+
+    auto factors = this->ilu_factory_skip->generate(csr_mtx);
+    auto l_factor = factors->get_l_factor();
+    auto u_factor = factors->get_u_factor();
+
+    GKO_ASSERT_MTX_NEAR(l_factor, this->identity, r<value_type>::value);
+    GKO_ASSERT_MTX_NEAR(u_factor, this->identity, r<value_type>::value);
+}
+
+
+TYPED_TEST(Ilu, GenerateForDenseIdentity)
+{
+    using value_type = typename TestFixture::value_type;
+    auto factors = this->ilu_factory_skip->generate(this->identity);
+    auto l_factor = factors->get_l_factor();
+    auto u_factor = factors->get_u_factor();
+
+    GKO_ASSERT_MTX_NEAR(l_factor, this->identity, r<value_type>::value);
+    GKO_ASSERT_MTX_NEAR(u_factor, this->identity, r<value_type>::value);
+}
+
+
+TYPED_TEST(Ilu, GenerateForDenseLowerTriangular)
+{
+    using value_type = typename TestFixture::value_type;
+    auto factors = this->ilu_factory_skip->generate(this->lower_triangular);
+    auto l_factor = factors->get_l_factor();
+    auto u_factor = factors->get_u_factor();
+
+    GKO_ASSERT_MTX_NEAR(l_factor, this->lower_triangular, r<value_type>::value);
+    GKO_ASSERT_MTX_NEAR(u_factor, this->identity, r<value_type>::value);
+}
+
+
+TYPED_TEST(Ilu, GenerateForDenseUpperTriangular)
+{
+    using value_type = typename TestFixture::value_type;
+    auto factors = this->ilu_factory_skip->generate(this->upper_triangular);
+    auto l_factor = factors->get_l_factor();
+    auto u_factor = factors->get_u_factor();
+
+    GKO_ASSERT_MTX_NEAR(l_factor, this->identity, r<value_type>::value);
+    GKO_ASSERT_MTX_NEAR(u_factor, this->upper_triangular, r<value_type>::value);
+}
+
+
+TYPED_TEST(Ilu, ApplyMethodDenseSmall)
+{
+    using value_type = typename TestFixture::value_type;
+    using Dense = typename TestFixture::Dense;
+    const auto x = gko::initialize<Dense>({1., 2., 3.}, this->exec);
+    auto b_lu = Dense::create_with_config_of(gko::lend(x));
+    auto b_ref = Dense::create_with_config_of(gko::lend(x));
+
+    auto factors = this->ilu_factory_skip->generate(this->mtx_small);
+    factors->apply(gko::lend(x), gko::lend(b_lu));
+    this->mtx_small->apply(gko::lend(x), gko::lend(b_ref));
+
+    GKO_ASSERT_MTX_NEAR(b_lu, b_ref, r<value_type>::value);
+}
+
+
+TYPED_TEST(Ilu, GenerateForDenseSmall)
+{
+    using value_type = typename TestFixture::value_type;
+    auto factors = this->ilu_factory_skip->generate(this->mtx_small);
+    auto l_factor = factors->get_l_factor();
+    auto u_factor = factors->get_u_factor();
+
+    GKO_ASSERT_MTX_NEAR(l_factor, this->small_l_expected, r<value_type>::value);
+    GKO_ASSERT_MTX_NEAR(u_factor, this->small_u_expected, r<value_type>::value);
+}
+
+
+TYPED_TEST(Ilu, GenerateForCsrSmall)
+{
+    using value_type = typename TestFixture::value_type;
+    auto factors = this->ilu_factory_skip->generate(this->mtx_csr_small);
+    auto l_factor = factors->get_l_factor();
+    auto u_factor = factors->get_u_factor();
+
+    GKO_ASSERT_MTX_NEAR(l_factor, this->small_l_expected, r<value_type>::value);
+    GKO_ASSERT_MTX_NEAR(u_factor, this->small_u_expected, r<value_type>::value);
+}
+
+
+TYPED_TEST(Ilu, GenerateForCsrSmall2ZeroDiagonal)
+{
+    using value_type = typename TestFixture::value_type;
+    auto factors = this->ilu_factory_skip->generate(this->mtx_csr_small2);
+    auto l_factor = factors->get_l_factor();
+    auto u_factor = factors->get_u_factor();
+
+    GKO_ASSERT_MTX_NEAR(l_factor, this->small2_l_expected,
+                        r<value_type>::value);
+    GKO_ASSERT_MTX_NEAR(u_factor, this->small2_u_expected,
+                        r<value_type>::value);
+}
+
+
+TYPED_TEST(Ilu, GenerateForCsrBigWithDiagonalZeros)
+{
+    using value_type = typename TestFixture::value_type;
+    auto factors = this->ilu_factory_skip->generate(this->mtx_big_nodiag);
+    auto l_factor = factors->get_l_factor();
+    auto u_factor = factors->get_u_factor();
+
+    GKO_ASSERT_MTX_NEAR(l_factor, this->big_nodiag_l_expected,
+                        r<value_type>::value);
+    GKO_ASSERT_MTX_NEAR(u_factor, this->big_nodiag_u_expected,
+                        r<value_type>::value);
+}
+
+
+TYPED_TEST(Ilu, GenerateForDenseBig)
+{
+    using value_type = typename TestFixture::value_type;
+    auto factors = this->ilu_factory_skip->generate(this->mtx_big);
+    auto l_factor = factors->get_l_factor();
+    auto u_factor = factors->get_u_factor();
+
+    GKO_ASSERT_MTX_NEAR(l_factor, this->big_l_expected, r<value_type>::value);
+    GKO_ASSERT_MTX_NEAR(u_factor, this->big_u_expected, r<value_type>::value);
+}
+
+
+TYPED_TEST(Ilu, GenerateForDenseBigSort)
+{
+    using value_type = typename TestFixture::value_type;
+    auto factors = this->ilu_factory_skip->generate(this->mtx_big);
+    auto l_factor = factors->get_l_factor();
+    auto u_factor = factors->get_u_factor();
+
+    GKO_ASSERT_MTX_NEAR(l_factor, this->big_l_expected, r<value_type>::value);
+    GKO_ASSERT_MTX_NEAR(u_factor, this->big_u_expected, r<value_type>::value);
+}
+
+
+TYPED_TEST(Ilu, GenerateForReverseCooSmall)
+{
+    using value_type = typename TestFixture::value_type;
+    using Coo = typename TestFixture::Coo;
+    const auto size = this->mtx_small->get_size();
+    const auto nnz = size[0] * size[1];
+    auto reverse_coo = gko::share(Coo::create(this->exec, size, nnz));
+    // Fill the Coo matrix in reversed row order (right to left)
+    for (size_t i = 0; i < size[0]; ++i) {
+        for (size_t j = 0; j < size[1]; ++j) {
+            const auto coo_idx = i * size[1] + (size[1] - 1 - j);
+            reverse_coo->get_row_idxs()[coo_idx] = i;
+            reverse_coo->get_col_idxs()[coo_idx] = j;
+            reverse_coo->get_values()[coo_idx] = this->mtx_small->at(i, j);
+        }
+    }
+
+    auto factors = this->ilu_factory_sort->generate(reverse_coo);
+    auto l_factor = factors->get_l_factor();
+    auto u_factor = factors->get_u_factor();
+
+    GKO_ASSERT_MTX_NEAR(reverse_coo, this->mtx_small, r<value_type>::value);
+    GKO_ASSERT_MTX_NEAR(l_factor, this->small_l_expected, r<value_type>::value);
+    GKO_ASSERT_MTX_NEAR(u_factor, this->small_u_expected, r<value_type>::value);
+}
+
+
+TYPED_TEST(Ilu, GenerateForReverseCsrSmall)
+{
+    using value_type = typename TestFixture::value_type;
+    using Csr = typename TestFixture::Csr;
+    const auto size = this->mtx_csr_small->get_size();
+    const auto nnz = size[0] * size[1];
+    auto reverse_csr = gko::share(Csr::create(this->exec));
+    reverse_csr->copy_from(gko::lend(this->mtx_csr_small));
+    // Fill the Csr matrix rows in reverse order
+    for (size_t i = 0; i < size[0]; ++i) {
+        const auto row_start = reverse_csr->get_row_ptrs()[i];
+        const auto row_end = reverse_csr->get_row_ptrs()[i + 1];
+        for (size_t j = row_start; j < row_end; ++j) {
+            const auto reverse_j = row_end - 1 - (j - row_start);
+            reverse_csr->get_values()[reverse_j] =
+                this->mtx_csr_small->get_const_values()[j];
+            reverse_csr->get_col_idxs()[reverse_j] =
+                this->mtx_csr_small->get_const_col_idxs()[j];
+        }
+    }
+
+    auto factors = this->ilu_factory_sort->generate(reverse_csr);
+    auto l_factor = factors->get_l_factor();
+    auto u_factor = factors->get_u_factor();
+
+    GKO_ASSERT_MTX_NEAR(l_factor, this->small_l_expected, r<value_type>::value);
+    GKO_ASSERT_MTX_NEAR(u_factor, this->small_u_expected, r<value_type>::value);
+}
+
+
+}  // namespace

--- a/reference/test/factorization/ilu_kernels.cpp
+++ b/reference/test/factorization/ilu_kernels.cpp
@@ -86,10 +86,6 @@ protected:
         : ref(gko::ReferenceExecutor::create()),
           exec(std::static_pointer_cast<const gko::Executor>(ref)),
           // clang-format off
-          empty_csr(gko::initialize<Csr>(
-              {{0., 0., 0.},
-               {0., 0., 0.},
-               {0., 0., 0.}}, exec)),
           identity(gko::initialize<Dense>(
               {{1., 0., 0.},
                {0., 1., 0.},
@@ -186,7 +182,6 @@ protected:
 
     std::shared_ptr<const gko::ReferenceExecutor> ref;
     std::shared_ptr<const gko::Executor> exec;
-    std::shared_ptr<const Csr> empty_csr;
     std::shared_ptr<const Dense> identity;
     std::shared_ptr<const Dense> lower_triangular;
     std::shared_ptr<const Dense> upper_triangular;
@@ -436,7 +431,7 @@ TYPED_TEST(Ilu, GenerateForDenseBig)
 TYPED_TEST(Ilu, GenerateForDenseBigSort)
 {
     using value_type = typename TestFixture::value_type;
-    auto factors = this->ilu_factory_skip->generate(this->mtx_big);
+    auto factors = this->ilu_factory_sort->generate(this->mtx_big);
     auto l_factor = factors->get_l_factor();
     auto u_factor = factors->get_u_factor();
 

--- a/reference/test/factorization/par_ic_kernels.cpp
+++ b/reference/test/factorization/par_ic_kernels.cpp
@@ -241,6 +241,7 @@ TYPED_TEST(ParIc, GenerateDenseIdentity)
     using Dense = typename TestFixture::Dense;
     auto dense_id = Dense::create(this->exec, this->identity->get_size());
     this->identity->convert_to(dense_id.get());
+
     auto fact = this->fact_fact->generate(gko::share(dense_id));
 
     GKO_ASSERT_MTX_NEAR(fact->get_l_factor(), this->identity, this->tol);
@@ -252,6 +253,7 @@ TYPED_TEST(ParIc, GenerateBanded)
 {
     using factorization_type = typename TestFixture::factorization_type;
     using Csr = typename TestFixture::Csr;
+
     auto fact =
         factorization_type::build().on(this->exec)->generate(this->banded);
 
@@ -266,6 +268,7 @@ TYPED_TEST(ParIc, GenerateGeneral)
 {
     using factorization_type = typename TestFixture::factorization_type;
     using Csr = typename TestFixture::Csr;
+
     auto fact =
         factorization_type::build().on(this->exec)->generate(this->mtx_system);
 

--- a/reference/test/factorization/par_ilu_kernels.cpp
+++ b/reference/test/factorization/par_ilu_kernels.cpp
@@ -688,7 +688,7 @@ TYPED_TEST(ParIlu, GenerateForDenseBig)
 TYPED_TEST(ParIlu, GenerateForDenseBigSort)
 {
     using value_type = typename TestFixture::value_type;
-    auto factors = this->ilu_factory_skip->generate(this->mtx_big);
+    auto factors = this->ilu_factory_sort->generate(this->mtx_big);
     auto l_factor = factors->get_l_factor();
     auto u_factor = factors->get_u_factor();
 


### PR DESCRIPTION
This PR adds a reference ILU(0) and IC(0) implementation with accompanying tests. The tests are exactly the ones we use for ParIlu/ParIc.