### PR TITLE
Fix enablelogging superclass

### DIFF
--- a/include/ginkgo/core/log/logger.hpp
+++ b/include/ginkgo/core/log/logger.hpp
@@ -584,7 +584,7 @@ public:
  *                          class.
  */
 template <typename ConcreteLoggable, typename PolymorphicBase = Loggable>
-class EnableLogging : public Loggable {
+class EnableLogging : public PolymorphicBase {
 public:
     void add_logger(std::shared_ptr<const Logger> logger) override
     {

--- a/include/ginkgo/core/log/logger.hpp
+++ b/include/ginkgo/core/log/logger.hpp
@@ -593,10 +593,9 @@ public:
 
     void remove_logger(const Logger *logger) override
     {
-        auto idx = find_if(begin(loggers_), end(loggers_),
-                           [&logger](std::shared_ptr<const Logger> &l) {
-                               return lend(l) == logger;
-                           });
+        auto idx =
+            find_if(begin(loggers_), end(loggers_),
+                    [&logger](const auto &l) { return lend(l) == logger; });
         if (idx != end(loggers_)) {
             loggers_.erase(idx);
         } else {

--- a/include/ginkgo/core/log/logger.hpp
+++ b/include/ginkgo/core/log/logger.hpp
@@ -594,7 +594,7 @@ public:
     void remove_logger(const Logger *logger) override
     {
         auto idx = find_if(begin(loggers_), end(loggers_),
-                           [&logger](std::shared_ptr<const Logger> l) {
+                           [&logger](std::shared_ptr<const Logger> &l) {
                                return lend(l) == logger;
                            });
         if (idx != end(loggers_)) {


### PR DESCRIPTION
Currently, the documentation of `EnableLogging` says that it is derived from the template parameter, but that is not the case. This PR fixes the issue, although it seems like it didn't cause any problems.