### PR TITLE
Work around ILU and IC use-after-free on CUDA 11.4

### DIFF
--- a/cuda/factorization/ic_kernels.cu
+++ b/cuda/factorization/ic_kernels.cu
@@ -81,6 +81,11 @@ void compute(std::shared_ptr<const DefaultExecutor> exec,
                   m->get_const_row_ptrs(), m->get_const_col_idxs(), info,
                   CUSPARSE_SOLVE_POLICY_USE_LEVEL, buffer.get_data());
 
+    // CUDA 11.4 has a use-after-free bug on Turing
+#if (CUDA_VERSION >= 11040)
+    exec->synchronize();
+#endif
+
     cusparse::destroy(info);
     cusparse::destroy(desc);
 }

--- a/cuda/factorization/ilu_kernels.cu
+++ b/cuda/factorization/ilu_kernels.cu
@@ -81,6 +81,11 @@ void compute_lu(std::shared_ptr<const DefaultExecutor> exec,
                    m->get_const_row_ptrs(), m->get_const_col_idxs(), info,
                    CUSPARSE_SOLVE_POLICY_USE_LEVEL, buffer.get_data());
 
+    // CUDA 11.4 has a use-after-free bug on Turing
+#if (CUDA_VERSION >= 11040)
+    exec->synchronize();
+#endif
+
     cusparse::destroy(info);
     cusparse::destroy(desc);
 }


### PR DESCRIPTION
This PR works around an issue in CUDA 11.4 probably caused by the ILU info destruction not waiting for the previous kernels.