### PR TITLE
Move internal constexpr symbols to internal linkage

### DIFF
--- a/common/factorization/par_ilut_select_kernels.hpp.inc
+++ b/common/factorization/par_ilut_select_kernels.hpp.inc
@@ -33,15 +33,17 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 namespace kernel {
 
 
-constexpr auto searchtree_width = 1 << sampleselect_searchtree_height;
-constexpr auto searchtree_inner_size = searchtree_width - 1;
-constexpr auto searchtree_size = searchtree_width + searchtree_inner_size;
+static constexpr auto searchtree_width = 1 << sampleselect_searchtree_height;
+static constexpr auto searchtree_inner_size = searchtree_width - 1;
+static constexpr auto searchtree_size =
+    searchtree_width + searchtree_inner_size;
 
-constexpr auto sample_size = searchtree_width * sampleselect_oversampling;
+static constexpr auto sample_size =
+    searchtree_width * sampleselect_oversampling;
 
-constexpr auto basecase_size = 1024;
-constexpr auto basecase_local_size = 4;
-constexpr auto basecase_block_size = basecase_size / basecase_local_size;
+static constexpr auto basecase_size = 1024;
+static constexpr auto basecase_local_size = 4;
+static constexpr auto basecase_block_size = basecase_size / basecase_local_size;
 
 
 // must be launched with one thread block and block size == searchtree_width

--- a/cuda/base/kernel_launch.cuh
+++ b/cuda/base/kernel_launch.cuh
@@ -45,7 +45,7 @@ namespace kernels {
 namespace cuda {
 
 
-constexpr int default_block_size = 512;
+static constexpr int default_block_size = 512;
 
 
 template <typename KernelFunction, typename... KernelArgs>

--- a/cuda/components/absolute_array.cu
+++ b/cuda/components/absolute_array.cu
@@ -43,7 +43,7 @@ namespace cuda {
 namespace components {
 
 
-constexpr int default_block_size = 512;
+static constexpr int default_block_size = 512;
 
 
 #include "common/components/absolute_array.hpp.inc"

--- a/cuda/components/fill_array.cu
+++ b/cuda/components/fill_array.cu
@@ -43,7 +43,7 @@ namespace cuda {
 namespace components {
 
 
-constexpr int default_block_size = 512;
+static constexpr int default_block_size = 512;
 
 
 #include "common/components/fill_array.hpp.inc"

--- a/cuda/components/prefix_sum.cu
+++ b/cuda/components/prefix_sum.cu
@@ -42,7 +42,7 @@ namespace cuda {
 namespace components {
 
 
-constexpr int prefix_sum_block_size = 512;
+static constexpr int prefix_sum_block_size = 512;
 
 
 template <typename IndexType>

--- a/cuda/components/reduction.cuh
+++ b/cuda/components/reduction.cuh
@@ -53,7 +53,7 @@ namespace kernels {
 namespace cuda {
 
 
-constexpr int default_block_size = 512;
+static constexpr int default_block_size = 512;
 
 
 #include "common/components/reduction.hpp.inc"

--- a/cuda/factorization/factorization_kernels.cu
+++ b/cuda/factorization/factorization_kernels.cu
@@ -57,7 +57,7 @@ namespace cuda {
 namespace factorization {
 
 
-constexpr int default_block_size{512};
+static constexpr int default_block_size{512};
 
 
 #include "common/factorization/factorization_kernels.hpp.inc"

--- a/cuda/factorization/par_ic_kernels.cu
+++ b/cuda/factorization/par_ic_kernels.cu
@@ -54,7 +54,7 @@ namespace cuda {
 namespace par_ic_factorization {
 
 
-constexpr auto default_block_size = 512;
+static constexpr auto default_block_size = 512;
 
 
 // subwarp sizes for all warp-parallel kernels (sweep)

--- a/cuda/factorization/par_ict_kernels.cu
+++ b/cuda/factorization/par_ict_kernels.cu
@@ -65,7 +65,7 @@ namespace cuda {
 namespace par_ict_factorization {
 
 
-constexpr auto default_block_size = 512;
+static constexpr auto default_block_size = 512;
 
 
 // subwarp sizes for all warp-parallel kernels (filter, add_candidates)

--- a/cuda/factorization/par_ilu_kernels.cu
+++ b/cuda/factorization/par_ilu_kernels.cu
@@ -52,7 +52,7 @@ namespace cuda {
 namespace par_ilu_factorization {
 
 
-constexpr int default_block_size{512};
+static constexpr int default_block_size{512};
 
 
 #include "common/factorization/par_ilu_kernels.hpp.inc"

--- a/cuda/factorization/par_ilut_filter_kernel.cu
+++ b/cuda/factorization/par_ilut_filter_kernel.cu
@@ -64,7 +64,7 @@ namespace cuda {
 namespace par_ilut_factorization {
 
 
-constexpr auto default_block_size = 512;
+static constexpr auto default_block_size = 512;
 
 
 // subwarp sizes for filter kernels

--- a/cuda/factorization/par_ilut_select_common.cuh
+++ b/cuda/factorization/par_ilut_select_common.cuh
@@ -45,8 +45,8 @@ namespace cuda {
 namespace par_ilut_factorization {
 
 
-constexpr auto default_block_size = 512;
-constexpr auto items_per_thread = 16;
+static constexpr auto default_block_size = 512;
+static constexpr auto items_per_thread = 16;
 
 
 template <typename ValueType, typename IndexType>

--- a/cuda/factorization/par_ilut_spgeam_kernel.cu
+++ b/cuda/factorization/par_ilut_spgeam_kernel.cu
@@ -65,7 +65,7 @@ namespace cuda {
 namespace par_ilut_factorization {
 
 
-constexpr auto default_block_size = 512;
+static constexpr auto default_block_size = 512;
 
 
 // subwarp sizes for add_candidates kernels

--- a/cuda/factorization/par_ilut_sweep_kernel.cu
+++ b/cuda/factorization/par_ilut_sweep_kernel.cu
@@ -65,7 +65,7 @@ namespace cuda {
 namespace par_ilut_factorization {
 
 
-constexpr auto default_block_size = 512;
+static constexpr auto default_block_size = 512;
 
 
 // subwarp sizes for all warp-parallel kernels (filter, add_candidates)

--- a/cuda/matrix/coo_kernels.cu
+++ b/cuda/matrix/coo_kernels.cu
@@ -68,9 +68,9 @@ namespace cuda {
 namespace coo {
 
 
-constexpr int default_block_size = 512;
-constexpr int warps_in_block = 4;
-constexpr int spmv_block_size = warps_in_block * config::warp_size;
+static constexpr int default_block_size = 512;
+static constexpr int warps_in_block = 4;
+static constexpr int spmv_block_size = warps_in_block * config::warp_size;
 
 
 #include "common/matrix/coo_kernels.hpp.inc"

--- a/cuda/matrix/csr_kernels.cu
+++ b/cuda/matrix/csr_kernels.cu
@@ -77,11 +77,11 @@ namespace cuda {
 namespace csr {
 
 
-constexpr int default_block_size = 512;
-constexpr int warps_in_block = 4;
-constexpr int spmv_block_size = warps_in_block * config::warp_size;
-constexpr int wsize = config::warp_size;
-constexpr int classical_overweight = 32;
+static constexpr int default_block_size = 512;
+static constexpr int warps_in_block = 4;
+static constexpr int spmv_block_size = warps_in_block * config::warp_size;
+static constexpr int wsize = config::warp_size;
+static constexpr int classical_overweight = 32;
 
 
 /**

--- a/cuda/matrix/dense_kernels.cu
+++ b/cuda/matrix/dense_kernels.cu
@@ -64,7 +64,7 @@ namespace cuda {
 namespace dense {
 
 
-constexpr auto default_block_size = 512;
+static constexpr auto default_block_size = 512;
 
 
 #include "common/matrix/dense_kernels.hpp.inc"

--- a/cuda/matrix/diagonal_kernels.cu
+++ b/cuda/matrix/diagonal_kernels.cu
@@ -54,7 +54,7 @@ namespace cuda {
 namespace diagonal {
 
 
-constexpr auto default_block_size = 512;
+static constexpr auto default_block_size = 512;
 
 
 #include "common/matrix/diagonal_kernels.hpp.inc"

--- a/cuda/matrix/ell_kernels.cu
+++ b/cuda/matrix/ell_kernels.cu
@@ -70,7 +70,7 @@ namespace cuda {
 namespace ell {
 
 
-constexpr int default_block_size = 512;
+static constexpr int default_block_size = 512;
 
 
 // TODO: num_threads_per_core and ratio are parameters should be tuned
@@ -78,21 +78,21 @@ constexpr int default_block_size = 512;
  * num_threads_per_core is the oversubscribing parameter. There are
  * `num_threads_per_core` threads assigned to each physical core.
  */
-constexpr int num_threads_per_core = 4;
+static constexpr int num_threads_per_core = 4;
 
 
 /**
  * ratio is the parameter to decide when to use threads to do reduction on each
  * row. (#cols/#rows > ratio)
  */
-constexpr double ratio = 1e-2;
+static constexpr double ratio = 1e-2;
 
 
 /**
  * max_thread_per_worker is the max number of thread per worker. The
  * `compiled_kernels` must be a list <0, 1, 2, ..., max_thread_per_worker>
  */
-constexpr int max_thread_per_worker = 32;
+static constexpr int max_thread_per_worker = 32;
 
 
 /**

--- a/cuda/matrix/hybrid_kernels.cu
+++ b/cuda/matrix/hybrid_kernels.cu
@@ -62,8 +62,8 @@ namespace cuda {
 namespace hybrid {
 
 
-constexpr int default_block_size = 512;
-constexpr int warps_in_block = 4;
+static constexpr int default_block_size = 512;
+static constexpr int warps_in_block = 4;
 
 
 #include "common/matrix/hybrid_kernels.hpp.inc"

--- a/cuda/matrix/sellp_kernels.cu
+++ b/cuda/matrix/sellp_kernels.cu
@@ -59,7 +59,7 @@ namespace cuda {
 namespace sellp {
 
 
-constexpr auto default_block_size = 512;
+static constexpr auto default_block_size = 512;
 
 
 #include "common/matrix/sellp_kernels.hpp.inc"

--- a/cuda/multigrid/amgx_pgm_kernels.cu
+++ b/cuda/multigrid/amgx_pgm_kernels.cu
@@ -69,7 +69,7 @@ namespace cuda {
 namespace amgx_pgm {
 
 
-constexpr int default_block_size = 512;
+static constexpr int default_block_size = 512;
 
 
 #include "common/multigrid/amgx_pgm_kernels.hpp.inc"

--- a/cuda/preconditioner/isai_kernels.cu
+++ b/cuda/preconditioner/isai_kernels.cu
@@ -61,9 +61,9 @@ namespace cuda {
 namespace isai {
 
 
-constexpr int subwarp_size{row_size_limit};
-constexpr int subwarps_per_block{2};
-constexpr int default_block_size{subwarps_per_block * subwarp_size};
+static constexpr int subwarp_size{row_size_limit};
+static constexpr int subwarps_per_block{2};
+static constexpr int default_block_size{subwarps_per_block * subwarp_size};
 
 
 #include "common/components/atomic.hpp.inc"

--- a/cuda/preconditioner/jacobi_kernels.cu
+++ b/cuda/preconditioner/jacobi_kernels.cu
@@ -60,12 +60,12 @@ namespace {
 
 
 // a total of 32 warps (1024 threads)
-constexpr int default_num_warps = 32;
+static constexpr int default_num_warps = 32;
 // with current architectures, at most 32 warps can be scheduled per SM (and
 // current GPUs have at most 84 SMs)
-constexpr int default_grid_size = 32 * 32 * 128;
+static constexpr int default_grid_size = 32 * 32 * 128;
 
-constexpr int default_block_size = 512;
+static constexpr int default_block_size = 512;
 
 
 #include "common/preconditioner/jacobi_kernels.hpp.inc"

--- a/cuda/solver/cb_gmres_kernels.cu
+++ b/cuda/solver/cb_gmres_kernels.cu
@@ -69,9 +69,9 @@ namespace cuda {
 namespace cb_gmres {
 
 
-constexpr int default_block_size = 512;
-constexpr int default_dot_dim = 32;
-constexpr int default_dot_size = default_dot_dim * default_dot_dim;
+static constexpr int default_block_size = 512;
+static constexpr int default_dot_dim = 32;
+static constexpr int default_dot_size = default_dot_dim * default_dot_dim;
 
 
 #include "common/solver/cb_gmres_kernels.hpp.inc"

--- a/cuda/solver/gmres_kernels.cu
+++ b/cuda/solver/gmres_kernels.cu
@@ -66,11 +66,11 @@ namespace cuda {
 namespace gmres {
 
 
-constexpr int default_block_size = 512;
+static constexpr int default_block_size = 512;
 // default_dot_dim can not be 64 in hip because 64 * 64 exceeds their max block
 // size limit.
-constexpr int default_dot_dim = 32;
-constexpr int default_dot_size = default_dot_dim * default_dot_dim;
+static constexpr int default_dot_dim = 32;
+static constexpr int default_dot_size = default_dot_dim * default_dot_dim;
 
 
 #include "common/solver/gmres_kernels.hpp.inc"

--- a/cuda/solver/idr_kernels.cu
+++ b/cuda/solver/idr_kernels.cu
@@ -64,9 +64,9 @@ namespace cuda {
 namespace idr {
 
 
-constexpr int default_block_size = 512;
-constexpr int default_dot_dim = 32;
-constexpr int default_dot_size = default_dot_dim * default_dot_dim;
+static constexpr int default_block_size = 512;
+static constexpr int default_dot_dim = 32;
+static constexpr int default_dot_size = default_dot_dim * default_dot_dim;
 
 
 #include "common/solver/idr_kernels.hpp.inc"

--- a/cuda/stop/criterion_kernels.cu
+++ b/cuda/stop/criterion_kernels.cu
@@ -54,7 +54,7 @@ namespace cuda {
 namespace set_all_statuses {
 
 
-constexpr int default_block_size = 512;
+static constexpr int default_block_size = 512;
 
 
 __global__ __launch_bounds__(default_block_size) void set_all_statuses(

--- a/cuda/stop/residual_norm_kernels.cu
+++ b/cuda/stop/residual_norm_kernels.cu
@@ -54,7 +54,7 @@ namespace cuda {
 namespace residual_norm {
 
 
-constexpr int default_block_size = 512;
+static constexpr int default_block_size = 512;
 
 
 template <typename ValueType>
@@ -131,7 +131,7 @@ GKO_INSTANTIATE_FOR_EACH_NON_COMPLEX_VALUE_TYPE(
 namespace implicit_residual_norm {
 
 
-constexpr int default_block_size = 512;
+static constexpr int default_block_size = 512;
 
 
 template <typename ValueType>

--- a/dpcpp/components/atomic.dp.hpp
+++ b/dpcpp/components/atomic.dp.hpp
@@ -49,8 +49,10 @@ namespace dpcpp {
 namespace atomic {
 
 
-constexpr auto local_space = cl::sycl::access::address_space::local_space;
-constexpr auto global_space = cl::sycl::access::address_space::global_space;
+static constexpr auto local_space =
+    cl::sycl::access::address_space::local_space;
+static constexpr auto global_space =
+    cl::sycl::access::address_space::global_space;
 
 
 }  // namespace atomic

--- a/dpcpp/components/prefix_sum.dp.cpp
+++ b/dpcpp/components/prefix_sum.dp.cpp
@@ -52,7 +52,7 @@ namespace components {
 
 using BlockCfg = ConfigSet<11>;
 
-constexpr auto block_cfg_list =
+static constexpr auto block_cfg_list =
     ::gko::syn::value_list<std::uint32_t, BlockCfg::encode(512),
                            BlockCfg::encode(256), BlockCfg::encode(128)>();
 

--- a/dpcpp/components/reduction.dp.hpp
+++ b/dpcpp/components/reduction.dp.hpp
@@ -61,14 +61,14 @@ namespace kernels {
 namespace dpcpp {
 
 
-constexpr int default_block_size = 256;
+static constexpr int default_block_size = 256;
 using KCFG_1D = ConfigSet<11, 7>;
-constexpr auto kcfg_1d_list =
+static constexpr auto kcfg_1d_list =
     syn::value_list<std::uint32_t, KCFG_1D::encode(512, 64),
                     KCFG_1D::encode(512, 32), KCFG_1D::encode(512, 16),
                     KCFG_1D::encode(256, 32), KCFG_1D::encode(256, 16),
                     KCFG_1D::encode(256, 8)>();
-constexpr auto kcfg_1d_array = as_array(kcfg_1d_list);
+static constexpr auto kcfg_1d_array = as_array(kcfg_1d_list);
 
 /**
  * @internal

--- a/dpcpp/factorization/par_ilut_kernels.dp.cpp
+++ b/dpcpp/factorization/par_ilut_kernels.dp.cpp
@@ -102,8 +102,8 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
     GKO_DECLARE_PAR_ILUT_THRESHOLD_FILTER_KERNEL);
 
 
-constexpr auto bucket_count = 1 << sampleselect_searchtree_height;
-constexpr auto sample_size = bucket_count * sampleselect_oversampling;
+static constexpr auto bucket_count = 1 << sampleselect_searchtree_height;
+static constexpr auto sample_size = bucket_count * sampleselect_oversampling;
 
 
 template <typename ValueType, typename IndexType>

--- a/dpcpp/matrix/dense_kernels.dp.cpp
+++ b/dpcpp/matrix/dense_kernels.dp.cpp
@@ -70,15 +70,15 @@ namespace dense {
 
 
 using KCFG_1D = ConfigSet<11, 7>;
-constexpr auto kcfg_1d_list =
+static constexpr auto kcfg_1d_list =
     syn::value_list<std::uint32_t, KCFG_1D::encode(512, 64),
                     KCFG_1D::encode(512, 32), KCFG_1D::encode(512, 16),
                     KCFG_1D::encode(256, 32), KCFG_1D::encode(256, 16),
                     KCFG_1D::encode(256, 8)>();
-constexpr auto subgroup_list =
+static constexpr auto subgroup_list =
     syn::value_list<std::uint32_t, 64, 32, 16, 8, 4>();
-constexpr auto kcfg_1d_array = syn::as_array(kcfg_1d_list);
-constexpr auto default_block_size = 256;
+static constexpr auto kcfg_1d_array = syn::as_array(kcfg_1d_list);
+static constexpr auto default_block_size = 256;
 
 
 namespace kernel {

--- a/dpcpp/matrix/ell_kernels.dp.cpp
+++ b/dpcpp/matrix/ell_kernels.dp.cpp
@@ -72,7 +72,7 @@ namespace dpcpp {
 namespace ell {
 
 
-constexpr int default_block_size = 256;
+static constexpr int default_block_size = 256;
 
 
 // TODO: num_threads_per_core and ratio are parameters should be tuned
@@ -80,21 +80,21 @@ constexpr int default_block_size = 256;
  * num_threads_per_core is the oversubscribing parameter. There are
  * `num_threads_per_core` threads assigned to each physical core.
  */
-constexpr int num_threads_per_core = 4;
+static constexpr int num_threads_per_core = 4;
 
 
 /**
  * ratio is the parameter to decide when to use threads to do reduction on each
  * row. (#cols/#rows > ratio)
  */
-constexpr double ratio = 1e-2;
+static constexpr double ratio = 1e-2;
 
 
 /**
  * max_thread_per_worker is the max number of thread per worker. The
  * `compiled_kernels` must be a list <0, 1, 2, ..., max_thread_per_worker>
  */
-constexpr int max_thread_per_worker = 32;
+static constexpr int max_thread_per_worker = 32;
 
 
 /**

--- a/dpcpp/solver/cb_gmres_kernels.dp.cpp
+++ b/dpcpp/solver/cb_gmres_kernels.dp.cpp
@@ -71,9 +71,9 @@ namespace dpcpp {
 namespace cb_gmres {
 
 
-constexpr int default_block_size = 256;
-constexpr int default_dot_dim = 16;
-constexpr int default_dot_size = default_dot_dim * default_dot_dim;
+static constexpr int default_block_size = 256;
+static constexpr int default_dot_dim = 16;
+static constexpr int default_dot_size = default_dot_dim * default_dot_dim;
 
 
 #include "dpcpp/solver/common_gmres_kernels.dp.inc"

--- a/dpcpp/solver/gmres_kernels.dp.cpp
+++ b/dpcpp/solver/gmres_kernels.dp.cpp
@@ -68,9 +68,9 @@ namespace dpcpp {
 namespace gmres {
 
 
-constexpr int default_block_size = 256;
-constexpr int default_dot_dim = 16;
-constexpr int default_dot_size = default_dot_dim * default_dot_dim;
+static constexpr int default_block_size = 256;
+static constexpr int default_dot_dim = 16;
+static constexpr int default_dot_size = default_dot_dim * default_dot_dim;
 
 
 #include "dpcpp/solver/common_gmres_kernels.dp.inc"

--- a/hip/base/kernel_launch.hip.hpp
+++ b/hip/base/kernel_launch.hip.hpp
@@ -48,7 +48,7 @@ namespace kernels {
 namespace hip {
 
 
-constexpr int default_block_size = 512;
+static constexpr int default_block_size = 512;
 
 
 template <typename KernelFunction, typename... KernelArgs>

--- a/hip/components/absolute_array.hip.cpp
+++ b/hip/components/absolute_array.hip.cpp
@@ -46,7 +46,7 @@ namespace hip {
 namespace components {
 
 
-constexpr int default_block_size = 512;
+static constexpr int default_block_size = 512;
 
 
 #include "common/components/absolute_array.hpp.inc"

--- a/hip/components/fill_array.hip.cpp
+++ b/hip/components/fill_array.hip.cpp
@@ -48,7 +48,7 @@ namespace kernels {
 namespace hip {
 namespace components {
 
-constexpr int default_block_size = 512;
+static constexpr int default_block_size = 512;
 
 
 #include "common/components/fill_array.hpp.inc"

--- a/hip/components/prefix_sum.hip.cpp
+++ b/hip/components/prefix_sum.hip.cpp
@@ -42,7 +42,7 @@ namespace hip {
 namespace components {
 
 
-constexpr int prefix_sum_block_size = 512;
+static constexpr int prefix_sum_block_size = 512;
 
 
 template <typename IndexType>

--- a/hip/components/reduction.hip.hpp
+++ b/hip/components/reduction.hip.hpp
@@ -55,7 +55,7 @@ namespace kernels {
 namespace hip {
 
 
-constexpr int default_block_size = 512;
+static constexpr int default_block_size = 512;
 
 
 #include "common/components/reduction.hpp.inc"

--- a/hip/factorization/factorization_kernels.hip.cpp
+++ b/hip/factorization/factorization_kernels.hip.cpp
@@ -59,7 +59,7 @@ namespace hip {
 namespace factorization {
 
 
-constexpr int default_block_size{512};
+static constexpr int default_block_size{512};
 
 
 #include "common/factorization/factorization_kernels.hpp.inc"

--- a/hip/factorization/par_ic_kernels.hip.cpp
+++ b/hip/factorization/par_ic_kernels.hip.cpp
@@ -54,7 +54,7 @@ namespace hip {
 namespace par_ic_factorization {
 
 
-constexpr auto default_block_size = 512;
+static constexpr auto default_block_size = 512;
 
 
 // subwarp sizes for all warp-parallel kernels (sweep)

--- a/hip/factorization/par_ict_kernels.hip.cpp
+++ b/hip/factorization/par_ict_kernels.hip.cpp
@@ -68,7 +68,7 @@ namespace hip {
 namespace par_ict_factorization {
 
 
-constexpr auto default_block_size = 512;
+static constexpr auto default_block_size = 512;
 
 
 // subwarp sizes for all warp-parallel kernels (filter, add_candidates)

--- a/hip/factorization/par_ilu_kernels.hip.cpp
+++ b/hip/factorization/par_ilu_kernels.hip.cpp
@@ -56,7 +56,7 @@ namespace hip {
 namespace par_ilu_factorization {
 
 
-constexpr int default_block_size{512};
+static constexpr int default_block_size{512};
 
 
 #include "common/factorization/par_ilu_kernels.hpp.inc"

--- a/hip/factorization/par_ilut_filter_kernel.hip.cpp
+++ b/hip/factorization/par_ilut_filter_kernel.hip.cpp
@@ -67,7 +67,7 @@ namespace hip {
 namespace par_ilut_factorization {
 
 
-constexpr auto default_block_size = 512;
+static constexpr auto default_block_size = 512;
 
 
 // subwarp sizes for filter kernels

--- a/hip/factorization/par_ilut_select_common.hip.hpp
+++ b/hip/factorization/par_ilut_select_common.hip.hpp
@@ -45,8 +45,8 @@ namespace hip {
 namespace par_ilut_factorization {
 
 
-constexpr auto default_block_size = 512;
-constexpr auto items_per_thread = 16;
+static constexpr auto default_block_size = 512;
+static constexpr auto items_per_thread = 16;
 
 
 template <typename ValueType, typename IndexType>

--- a/hip/factorization/par_ilut_spgeam_kernel.hip.cpp
+++ b/hip/factorization/par_ilut_spgeam_kernel.hip.cpp
@@ -68,7 +68,7 @@ namespace hip {
 namespace par_ilut_factorization {
 
 
-constexpr auto default_block_size = 512;
+static constexpr auto default_block_size = 512;
 
 
 // subwarp sizes for add_candidates kernels

--- a/hip/factorization/par_ilut_sweep_kernel.hip.cpp
+++ b/hip/factorization/par_ilut_sweep_kernel.hip.cpp
@@ -68,7 +68,7 @@ namespace hip {
 namespace par_ilut_factorization {
 
 
-constexpr auto default_block_size = 512;
+static constexpr auto default_block_size = 512;
 
 
 // subwarp sizes for all warp-parallel kernels (filter, add_candidates)

--- a/hip/matrix/coo_kernels.hip.cpp
+++ b/hip/matrix/coo_kernels.hip.cpp
@@ -71,9 +71,9 @@ namespace hip {
 namespace coo {
 
 
-constexpr int default_block_size = 512;
-constexpr int warps_in_block = 4;
-constexpr int spmv_block_size = warps_in_block * config::warp_size;
+static constexpr int default_block_size = 512;
+static constexpr int warps_in_block = 4;
+static constexpr int spmv_block_size = warps_in_block * config::warp_size;
 
 
 #include "common/matrix/coo_kernels.hpp.inc"

--- a/hip/matrix/csr_kernels.hip.cpp
+++ b/hip/matrix/csr_kernels.hip.cpp
@@ -80,11 +80,11 @@ namespace hip {
 namespace csr {
 
 
-constexpr int default_block_size = 512;
-constexpr int warps_in_block = 4;
-constexpr int spmv_block_size = warps_in_block * config::warp_size;
-constexpr int wsize = config::warp_size;
-constexpr int classical_overweight = 32;
+static constexpr int default_block_size = 512;
+static constexpr int warps_in_block = 4;
+static constexpr int spmv_block_size = warps_in_block * config::warp_size;
+static constexpr int wsize = config::warp_size;
+static constexpr int classical_overweight = 32;
 
 
 /**

--- a/hip/matrix/dense_kernels.hip.cpp
+++ b/hip/matrix/dense_kernels.hip.cpp
@@ -67,7 +67,7 @@ namespace hip {
 namespace dense {
 
 
-constexpr auto default_block_size = 512;
+static constexpr auto default_block_size = 512;
 
 
 #include "common/matrix/dense_kernels.hpp.inc"

--- a/hip/matrix/diagonal_kernels.hip.cpp
+++ b/hip/matrix/diagonal_kernels.hip.cpp
@@ -57,7 +57,7 @@ namespace hip {
 namespace diagonal {
 
 
-constexpr auto default_block_size = 512;
+static constexpr auto default_block_size = 512;
 
 
 #include "common/matrix/diagonal_kernels.hpp.inc"

--- a/hip/matrix/ell_kernels.hip.cpp
+++ b/hip/matrix/ell_kernels.hip.cpp
@@ -73,7 +73,7 @@ namespace hip {
 namespace ell {
 
 
-constexpr int default_block_size = 512;
+static constexpr int default_block_size = 512;
 
 
 // TODO: num_threads_per_core and ratio are parameters should be tuned
@@ -81,21 +81,21 @@ constexpr int default_block_size = 512;
  * num_threads_per_core is the oversubscribing parameter. There are
  * `num_threads_per_core` threads assigned to each physical core.
  */
-constexpr int num_threads_per_core = 4;
+static constexpr int num_threads_per_core = 4;
 
 
 /**
  * ratio is the parameter to decide when to use threads to do reduction on each
  * row. (#cols/#rows > ratio)
  */
-constexpr double ratio = 1e-2;
+static constexpr double ratio = 1e-2;
 
 
 /**
  * max_thread_per_worker is the max number of thread per worker. The
  * `compiled_kernels` must be a list <0, 1, 2, ..., max_thread_per_worker>
  */
-constexpr int max_thread_per_worker = 32;
+static constexpr int max_thread_per_worker = 32;
 
 
 /**

--- a/hip/matrix/hybrid_kernels.hip.cpp
+++ b/hip/matrix/hybrid_kernels.hip.cpp
@@ -65,8 +65,8 @@ namespace hip {
 namespace hybrid {
 
 
-constexpr int default_block_size = 512;
-constexpr int warps_in_block = 4;
+static constexpr int default_block_size = 512;
+static constexpr int warps_in_block = 4;
 
 
 #include "common/matrix/hybrid_kernels.hpp.inc"

--- a/hip/matrix/sellp_kernels.hip.cpp
+++ b/hip/matrix/sellp_kernels.hip.cpp
@@ -62,7 +62,7 @@ namespace hip {
 namespace sellp {
 
 
-constexpr auto default_block_size = 512;
+static constexpr auto default_block_size = 512;
 
 
 #include "common/matrix/sellp_kernels.hpp.inc"

--- a/hip/multigrid/amgx_pgm_kernels.hip.cpp
+++ b/hip/multigrid/amgx_pgm_kernels.hip.cpp
@@ -69,7 +69,7 @@ namespace hip {
 namespace amgx_pgm {
 
 
-constexpr int default_block_size = 512;
+static constexpr int default_block_size = 512;
 
 
 #include "common/multigrid/amgx_pgm_kernels.hpp.inc"

--- a/hip/preconditioner/isai_kernels.hip.cpp
+++ b/hip/preconditioner/isai_kernels.hip.cpp
@@ -64,9 +64,9 @@ namespace hip {
 namespace isai {
 
 
-constexpr int subwarp_size{row_size_limit};
-constexpr int subwarps_per_block{2};
-constexpr int default_block_size{subwarps_per_block * subwarp_size};
+static constexpr int subwarp_size{row_size_limit};
+static constexpr int subwarps_per_block{2};
+static constexpr int default_block_size{subwarps_per_block * subwarp_size};
 
 
 #include "common/components/atomic.hpp.inc"

--- a/hip/preconditioner/jacobi_kernels.hip.cpp
+++ b/hip/preconditioner/jacobi_kernels.hip.cpp
@@ -64,15 +64,15 @@ namespace {
 
 // a total of 32/16 warps (1024 threads)
 #if GINKGO_HIP_PLATFORM_HCC
-constexpr int default_num_warps = 16;
+static constexpr int default_num_warps = 16;
 #else  // GINKGO_HIP_PLATFORM_NVCC
-constexpr int default_num_warps = 32;
+static constexpr int default_num_warps = 32;
 #endif
 // with current architectures, at most 32 warps can be scheduled per SM (and
 // current GPUs have at most 84 SMs)
-constexpr int default_grid_size = 32 * 32 * 128;
+static constexpr int default_grid_size = 32 * 32 * 128;
 
-constexpr int default_block_size = 512;
+static constexpr int default_block_size = 512;
 
 #include "common/preconditioner/jacobi_kernels.hpp.inc"
 

--- a/hip/solver/cb_gmres_kernels.hip.cpp
+++ b/hip/solver/cb_gmres_kernels.hip.cpp
@@ -69,11 +69,11 @@ namespace hip {
 namespace cb_gmres {
 
 
-constexpr int default_block_size = 512;
+static constexpr int default_block_size = 512;
 // default_dot_dim can not be 64 in hip because 64 * 64 exceeds their max block
 // size limit.
-constexpr int default_dot_dim = 32;
-constexpr int default_dot_size = default_dot_dim * default_dot_dim;
+static constexpr int default_dot_dim = 32;
+static constexpr int default_dot_size = default_dot_dim * default_dot_dim;
 
 
 #include "common/solver/cb_gmres_kernels.hpp.inc"

--- a/hip/solver/gmres_kernels.hip.cpp
+++ b/hip/solver/gmres_kernels.hip.cpp
@@ -69,11 +69,11 @@ namespace hip {
 namespace gmres {
 
 
-constexpr int default_block_size = 512;
+static constexpr int default_block_size = 512;
 // default_dot_dim can not be 64 in hip because 64 * 64 exceeds their max block
 // size limit.
-constexpr int default_dot_dim = 32;
-constexpr int default_dot_size = default_dot_dim * default_dot_dim;
+static constexpr int default_dot_dim = 32;
+static constexpr int default_dot_size = default_dot_dim * default_dot_dim;
 
 
 #include "common/solver/gmres_kernels.hpp.inc"

--- a/hip/solver/idr_kernels.hip.cpp
+++ b/hip/solver/idr_kernels.hip.cpp
@@ -66,9 +66,9 @@ namespace hip {
 namespace idr {
 
 
-constexpr int default_block_size = 512;
-constexpr int default_dot_dim = 32;
-constexpr int default_dot_size = default_dot_dim * default_dot_dim;
+static constexpr int default_block_size = 512;
+static constexpr int default_dot_dim = 32;
+static constexpr int default_dot_size = default_dot_dim * default_dot_dim;
 
 
 #include "common/solver/idr_kernels.hpp.inc"

--- a/hip/stop/criterion_kernels.hip.cpp
+++ b/hip/stop/criterion_kernels.hip.cpp
@@ -54,7 +54,7 @@ namespace hip {
 namespace set_all_statuses {
 
 
-constexpr int default_block_size = 512;
+static constexpr int default_block_size = 512;
 
 
 __global__ __launch_bounds__(default_block_size) void set_all_statuses(

--- a/hip/stop/residual_norm_kernels.hip.cpp
+++ b/hip/stop/residual_norm_kernels.hip.cpp
@@ -57,7 +57,7 @@ namespace hip {
 namespace residual_norm {
 
 
-constexpr int default_block_size = 512;
+static constexpr int default_block_size = 512;
 
 
 template <typename ValueType>
@@ -135,7 +135,7 @@ GKO_INSTANTIATE_FOR_EACH_NON_COMPLEX_VALUE_TYPE(
 namespace implicit_residual_norm {
 
 
-constexpr int default_block_size = 512;
+static constexpr int default_block_size = 512;
 
 
 template <typename ValueType>

--- a/omp/factorization/par_ilut_kernels.cpp
+++ b/omp/factorization/par_ilut_kernels.cpp
@@ -180,8 +180,8 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
     GKO_DECLARE_PAR_ILUT_THRESHOLD_FILTER_KERNEL);
 
 
-constexpr auto bucket_count = 1 << sampleselect_searchtree_height;
-constexpr auto sample_size = bucket_count * sampleselect_oversampling;
+static constexpr auto bucket_count = 1 << sampleselect_searchtree_height;
+static constexpr auto sample_size = bucket_count * sampleselect_oversampling;
 
 
 template <typename ValueType, typename IndexType>

--- a/omp/reorder/rcm_kernels.cpp
+++ b/omp/reorder/rcm_kernels.cpp
@@ -100,7 +100,7 @@ GKO_INSTANTIATE_FOR_EACH_INDEX_TYPE(GKO_DECLARE_RCM_GET_DEGREE_OF_NODES_KERNEL);
 // This constant controls how many nodes can be dequeued from the
 // UbfsLinearQueue at once at most. Increasing it reduces lock contention and
 // "unneccesary work", but disturbs queue ordering, generating extra work.
-constexpr int32 chunk_bound = 512;
+static constexpr int32 chunk_bound = 512;
 
 
 template <typename IndexType>
@@ -636,13 +636,13 @@ vector<IndexType> compute_level_offsets(std::shared_ptr<const OmpExecutor> exec,
 // Signal value to which the entire permutation is intialized.
 // Threads spin on this value, until it is replaced by another value,
 // written by another thread.
-constexpr int32 perm_untouched = -1;
+static constexpr int32 perm_untouched = -1;
 
 // Signal value which a thread writes to a level (as in the level of a node
 // becomes -1), to signal that it has been processed. This information is only
 // relevant local to the thread, since only a single thread is responsible for a
 // node.
-constexpr int32 level_processed = -1;
+static constexpr int32 level_processed = -1;
 
 /**
  * Implements the last phase of urcm,

--- a/reference/factorization/par_ilut_kernels.cpp
+++ b/reference/factorization/par_ilut_kernels.cpp
@@ -185,8 +185,8 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
     GKO_DECLARE_PAR_ILUT_THRESHOLD_FILTER_KERNEL);
 
 
-constexpr auto bucket_count = 1 << sampleselect_searchtree_height;
-constexpr auto sample_size = bucket_count * sampleselect_oversampling;
+static constexpr auto bucket_count = 1 << sampleselect_searchtree_height;
+static constexpr auto sample_size = bucket_count * sampleselect_oversampling;
 
 
 /**


### PR DESCRIPTION
constexpr configuration variables in our GPU implementations are only used inside the same translation unit, but still emit symbols which might cause some issues if we changed the value for a single definition of this value (more precisely, ODR violations). Just to be safe, this PR sets all of them to internal linkage.
For more details: https://en.cppreference.com/w/cpp/language/storage_duration