### PR TITLE
Fix Readme and disable MSVC-CUDA 10.2

### DIFF
--- a/.github/workflows/windows-msvc-cuda.yml
+++ b/.github/workflows/windows-msvc-cuda.yml
@@ -15,7 +15,6 @@ jobs:
       fail-fast: false
       matrix:
         config:
-        - {version: "10.2.89.20191206", name: "cuda102/release/shared", "mixed": "ON"}
         - {version: "latest", name: "cuda-latest/release/shared", "mixed": "OFF"}
     name: msvc/${{ matrix.config.name }} (only compile)
     runs-on: [windows-latest]

--- a/.github/workflows/windows-msvc-cuda.yml
+++ b/.github/workflows/windows-msvc-cuda.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         config:
-        - {version: "latest", name: "cuda-latest/release/shared", "mixed": "OFF"}
+        - {version: "latest", name: "cuda-latest/release/shared", "mixed": "ON"}
     name: msvc/${{ matrix.config.name }} (only compile)
     runs-on: [windows-latest]
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -2,7 +2,7 @@ Installation Instructions                      {#install_ginkgo}
 -------------------------------------
 ### Building
 
-Use the standard cmake build procedure:
+Use the standard CMake build procedure:
 
 ```sh
 mkdir build; cd build
@@ -152,15 +152,6 @@ of HIP either at `/opt/rocm/hip` or at the path specified by `HIP_PATH` as a
 CMake parameter (`-DHIP_PATH=`) or environment variable (`export HIP_PATH=`),
 unless `-DGINKGO_BUILD_HIP=ON/OFF` is set explicitly.
 
-#### HIP dependencies for Ginkgo
-Ginkgo's HIP backend adds a dependency to the following packages:
-+ HIP,
-+ hipBLAS,
-+ hipSPARSE,
-+ rocRAND,
-+ rocThrust.
-
-
 #### Changing the paths to search for HIP and other packages
 All HIP installation paths can be configured through the use of environment
 variables or CMake variables. This way of configuring the paths is currently
@@ -193,14 +184,6 @@ GPUs, this should output `hcc` by default. To change this value, export the
 environment variable `HIP_PLATFORM` like so:
 ```bash
 export HIP_PLATFORM=nvcc # or nvidia for ROCM >= 4.1
-```
-
-When using `HIP_PLATFORM=hcc` (or `amd`), note that two `HIP` compilers can be
-set: the old `hcc`, or since ROCm 3.5, `clang`. Ginkgo is only compatible with
-the `clang` based installations. Although this setting should be automatically
-done, it is also possible to manually set the `HIP` compiler to `clang`:
-```
-export HIP_COMPILER=clang
 ```
 
 #### Setting platform specific compilation flags

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Prerequisites
 
 For Ginkgo core library:
 
-*   _cmake 3.9+_
+*   _cmake 3.13+_
 *   C++14 compliant compiler, one of:
     *   _gcc 5.3+, 6.3+, 7.3+, all versions after 8.1+_
     *   _clang 3.9+_
@@ -51,6 +51,20 @@ The Ginkgo CUDA module has the following __additional__ requirements:
     [CUDA installation guide for Linux](https://docs.nvidia.com/cuda/cuda-installation-guide-linux/index.html)
     or [CUDA installation guide for Mac Os X](https://docs.nvidia.com/cuda/cuda-installation-guide-mac-os-x/index.html)
 
+The Ginkgo HIP module has the following __additional__ requirements:
+
+* _ROCm 3.5+_
+*    the HIP, hipBLAS, hipSPARSE, hip/rocRAND and rocThrust packages compiled with either:
+    * _AMD_ backend (using the `clang` compiler)
+    * _9.2 <= CUDA < 11_ backend
+
+The Ginkgo DPC++ module has the following __additional__ requirements:
+
+* _OneAPI 2021.3+_
+* Set `dpcpp` as the `CMAKE_CXX_COMPILER`
+* The following oneAPI packages should be available:
+    * oneMKL
+    * oneDPL
 
 In addition, if you want to contribute code to Ginkgo, you will also need the
 following:
@@ -59,21 +73,14 @@ following:
 *   _clang-tidy_ (optional, when setting the flag `-DGINKGO_WITH_CLANG_TIDY=ON`)
 *   _iwyu_ (Include What You Use, optional, when setting the flag `-DGINKGO_WITH_IWYU=ON`)
 
-The Ginkgo HIP module has the following __additional__ requirements:
-
-* _ROCm 3.5+_
-*    the HIP, hipBLAS, hipSPARSE, hip/rocRAND packages compiled with either:
-    * _AMD_ backend (using the `clang` compiler)
-    * _CUDA 9.2+_ backend. When using CUDA 10+, _cmake 3.12.2+_ is required.
-
 ### Windows
 
 The prequirement needs to be verified
-*   _cmake 3.9+_
+*   _cmake 3.13+_
 *   C++14 compliant 64-bit compiler:
     *   _MinGW : gcc 5.3+, 6.3+, 7.3+, all versions after 8.1+_
     *   _Cygwin : gcc 5.3+, 6.3+, 7.3+, all versions after 8.1+_
-    *   _Microsoft Visual Studio : VS 2017 15.7+_
+    *   _Microsoft Visual Studio : VS 2019+_
 
 __NOTE:__ Need to add `--autocrlf=input` after `git clone` in _Cygwin_.
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ For Ginkgo core library:
 
 *   _cmake 3.13+_
 *   C++14 compliant compiler, one of:
-    *   _gcc 5.3+, 6.3+, 7.3+, all versions after 8.1+_
+    *   _gcc 5.5+_
     *   _clang 3.9+_
     *   _Intel compiler 2018+_
     *   _Apple LLVM 8.0+_
@@ -75,11 +75,10 @@ following:
 
 ### Windows
 
-The prequirement needs to be verified
 *   _cmake 3.13+_
 *   C++14 compliant 64-bit compiler:
-    *   _MinGW : gcc 5.3+, 6.3+, 7.3+, all versions after 8.1+_
-    *   _Cygwin : gcc 5.3+, 6.3+, 7.3+, all versions after 8.1+_
+    *   _MinGW : gcc 5.5+_
+    *   _Cygwin : gcc 5.5+_
     *   _Microsoft Visual Studio : VS 2019+_
 
 __NOTE:__ Need to add `--autocrlf=input` after `git clone` in _Cygwin_.


### PR DESCRIPTION
+ Update to the new package status. Simplify the HIP-related INSTALL.md section.
+ Disable the MSVC-CUDA 10.2 job.

There is an issue with the CUDA implementation which prevents a proper
execution. See pytorch/pytorch#25393 and NVIDIA/thrust#1090. Tweaking
the compiler settings would allow getting fewer errors, but it seems
impossible to prevent the errors altogether.

Is there anything else that should be updated?