### PR TITLE
Use lambda captures for GKO_REGISTER_OPERATION

### DIFF
--- a/core/matrix/dense.cpp
+++ b/core/matrix/dense.cpp
@@ -468,10 +468,9 @@ void Dense<ValueType>::move_to(Dense<next_precision<ValueType>> *result)
 template <typename ValueType>
 void Dense<ValueType>::convert_to(Coo<ValueType, int32> *result) const
 {
-    conversion_helper(
-        result, this,
-        dense::template make_convert_to_coo<const Dense<ValueType> *&,
-                                            decltype(result)>);
+    conversion_helper(result, this, [](const auto &in, const auto &out) {
+        return dense::make_convert_to_coo(in, out);
+    });
 }
 
 
@@ -485,10 +484,9 @@ void Dense<ValueType>::move_to(Coo<ValueType, int32> *result)
 template <typename ValueType>
 void Dense<ValueType>::convert_to(Coo<ValueType, int64> *result) const
 {
-    conversion_helper(
-        result, this,
-        dense::template make_convert_to_coo<const Dense<ValueType> *&,
-                                            decltype(result)>);
+    conversion_helper(result, this, [](const auto &in, const auto &out) {
+        return dense::make_convert_to_coo(in, out);
+    });
 }
 
 
@@ -502,10 +500,9 @@ void Dense<ValueType>::move_to(Coo<ValueType, int64> *result)
 template <typename ValueType>
 void Dense<ValueType>::convert_to(Csr<ValueType, int32> *result) const
 {
-    conversion_helper(
-        result, this,
-        dense::template make_convert_to_csr<const Dense<ValueType> *&,
-                                            decltype(result)>);
+    conversion_helper(result, this, [](const auto &in, const auto &out) {
+        return dense::make_convert_to_csr(in, out);
+    });
     result->make_srow();
 }
 
@@ -520,10 +517,9 @@ void Dense<ValueType>::move_to(Csr<ValueType, int32> *result)
 template <typename ValueType>
 void Dense<ValueType>::convert_to(Csr<ValueType, int64> *result) const
 {
-    conversion_helper(
-        result, this,
-        dense::template make_convert_to_csr<const Dense<ValueType> *&,
-                                            decltype(result)>);
+    conversion_helper(result, this, [](const auto &in, const auto &out) {
+        return dense::make_convert_to_csr(in, out);
+    });
     result->make_srow();
 }
 
@@ -538,10 +534,9 @@ void Dense<ValueType>::move_to(Csr<ValueType, int64> *result)
 template <typename ValueType>
 void Dense<ValueType>::convert_to(Ell<ValueType, int32> *result) const
 {
-    conversion_helper(
-        result, this,
-        dense::template make_convert_to_ell<const Dense<ValueType> *&,
-                                            decltype(result)>);
+    conversion_helper(result, this, [](const auto &in, const auto &out) {
+        return dense::make_convert_to_ell(in, out);
+    });
 }
 
 
@@ -555,10 +550,9 @@ void Dense<ValueType>::move_to(Ell<ValueType, int32> *result)
 template <typename ValueType>
 void Dense<ValueType>::convert_to(Ell<ValueType, int64> *result) const
 {
-    conversion_helper(
-        result, this,
-        dense::template make_convert_to_ell<const Dense<ValueType> *&,
-                                            decltype(result)>);
+    conversion_helper(result, this, [](const auto &in, const auto &out) {
+        return dense::make_convert_to_ell(in, out);
+    });
 }
 
 
@@ -572,10 +566,9 @@ void Dense<ValueType>::move_to(Ell<ValueType, int64> *result)
 template <typename ValueType>
 void Dense<ValueType>::convert_to(Hybrid<ValueType, int32> *result) const
 {
-    conversion_helper(
-        result, this,
-        dense::template make_convert_to_hybrid<const Dense<ValueType> *&,
-                                               decltype(result)>);
+    conversion_helper(result, this, [](const auto &in, const auto &out) {
+        return dense::make_convert_to_hybrid(in, out);
+    });
 }
 
 
@@ -589,10 +582,9 @@ void Dense<ValueType>::move_to(Hybrid<ValueType, int32> *result)
 template <typename ValueType>
 void Dense<ValueType>::convert_to(Hybrid<ValueType, int64> *result) const
 {
-    conversion_helper(
-        result, this,
-        dense::template make_convert_to_hybrid<const Dense<ValueType> *&,
-                                               decltype(result)>);
+    conversion_helper(result, this, [](const auto &in, const auto &out) {
+        return dense::make_convert_to_hybrid(in, out);
+    });
 }
 
 
@@ -606,10 +598,9 @@ void Dense<ValueType>::move_to(Hybrid<ValueType, int64> *result)
 template <typename ValueType>
 void Dense<ValueType>::convert_to(Sellp<ValueType, int32> *result) const
 {
-    conversion_helper(
-        result, this,
-        dense::template make_convert_to_sellp<const Dense<ValueType> *&,
-                                              decltype(result)>);
+    conversion_helper(result, this, [](const auto &in, const auto &out) {
+        return dense::make_convert_to_sellp(in, out);
+    });
 }
 
 
@@ -623,10 +614,9 @@ void Dense<ValueType>::move_to(Sellp<ValueType, int32> *result)
 template <typename ValueType>
 void Dense<ValueType>::convert_to(Sellp<ValueType, int64> *result) const
 {
-    conversion_helper(
-        result, this,
-        dense::template make_convert_to_sellp<const Dense<ValueType> *&,
-                                              decltype(result)>);
+    conversion_helper(result, this, [](const auto &in, const auto &out) {
+        return dense::make_convert_to_sellp(in, out);
+    });
 }
 
 
@@ -640,10 +630,9 @@ void Dense<ValueType>::move_to(Sellp<ValueType, int64> *result)
 template <typename ValueType>
 void Dense<ValueType>::convert_to(SparsityCsr<ValueType, int32> *result) const
 {
-    conversion_helper(
-        result, this,
-        dense::template make_convert_to_sparsity_csr<const Dense<ValueType> *&,
-                                                     decltype(result)>);
+    conversion_helper(result, this, [](const auto &in, const auto &out) {
+        return dense::make_convert_to_sparsity_csr(in, out);
+    });
 }
 
 
@@ -657,10 +646,9 @@ void Dense<ValueType>::move_to(SparsityCsr<ValueType, int32> *result)
 template <typename ValueType>
 void Dense<ValueType>::convert_to(SparsityCsr<ValueType, int64> *result) const
 {
-    conversion_helper(
-        result, this,
-        dense::template make_convert_to_sparsity_csr<const Dense<ValueType> *&,
-                                                     decltype(result)>);
+    conversion_helper(result, this, [](const auto &in, const auto &out) {
+        return dense::make_convert_to_sparsity_csr(in, out);
+    });
 }
 
 

--- a/core/matrix/dense.cpp
+++ b/core/matrix/dense.cpp
@@ -468,6 +468,7 @@ void Dense<ValueType>::move_to(Dense<next_precision<ValueType>> *result)
 template <typename ValueType>
 void Dense<ValueType>::convert_to(Coo<ValueType, int32> *result) const
 {
+    // const ref parameters, as make_* functions take parameters by ref
     conversion_helper(result, this, [](const auto &in, const auto &out) {
         return dense::make_convert_to_coo(in, out);
     });


### PR DESCRIPTION
This PR simplifies the GKO_REGISTER_OPERATION macros by using lambda captures of the arguments instead of storing them inside a `std::tuple`. This would make the code much easier to understand, and also make it more easy for indexers like in CLion or clangd, allowing them to infer the parameters that can be passed to the make_* function.

~~A notable downside to this is that it creates 5 copies of the kernel arguments instead of only one. It should be possible to work around this by creating the lambda that is being executed only on-the-fly, but I'm not sure that's even necessary. We are talking about the choice between 128 bytes and 640 bytes of stack space for running the operation for the largest kernels we are launching (BiCGStab initialize), which amounts to less than 0.1us difference per iteration (1000 iterations) in the `overhead` solver benchmark~~

I rewrote the dispatch to avoid the overhead of 5-fold storage of the operation arguments by putting everything into the same lambda.

Closes #177