### PR TITLE
Hide executor operation symbols in core

### DIFF
--- a/.github/workflows/windows-msvc-ref.yml
+++ b/.github/workflows/windows-msvc-ref.yml
@@ -35,7 +35,7 @@ jobs:
       run: |
         mkdir build
         cd build
-        cmake  -DBUILD_SHARED_LIBS=${{ matrix.config.shared }} -DCMAKE_CXX_FLAGS_DEBUG="/MDd /Zi /Ob1 /Od /RTC1" -DGINKGO_BUILD_CUDA=OFF -DGINKGO_BUILD_OMP=OFF -DGINKGO_MIXED_PRECISION=${{ matrix.config.mixed }} ..
+        cmake  -DBUILD_SHARED_LIBS=${{ matrix.config.shared }} -DGINKGO_BUILD_CUDA=OFF -DGINKGO_BUILD_OMP=OFF -DGINKGO_MIXED_PRECISION=${{ matrix.config.mixed }} ..
         cmake --build . -j4 --config ${{ matrix.config.build_type }}
         ctest . -C ${{ matrix.config.build_type }} --output-on-failure
 

--- a/core/base/array.cpp
+++ b/core/base/array.cpp
@@ -42,20 +42,24 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 namespace gko {
 namespace conversion {
+namespace {
 
 
 GKO_REGISTER_OPERATION(convert, components::convert_precision);
 
 
+}  // anonymous namespace
 }  // namespace conversion
 
 
 namespace array {
+namespace {
 
 
 GKO_REGISTER_OPERATION(fill_array, components::fill_array);
 
 
+}  // anonymous namespace
 }  // namespace array
 
 

--- a/core/base/composition.cpp
+++ b/core/base/composition.cpp
@@ -46,11 +46,13 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 namespace gko {
 namespace composition {
+namespace {
 
 
 GKO_REGISTER_OPERATION(fill_array, components::fill_array);
 
 
+}  // anonymous namespace
 }  // namespace composition
 
 

--- a/core/factorization/ic.cpp
+++ b/core/factorization/ic.cpp
@@ -48,6 +48,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 namespace gko {
 namespace factorization {
 namespace ic_factorization {
+namespace {
 
 
 GKO_REGISTER_OPERATION(compute, ic_factorization::compute);
@@ -58,6 +59,7 @@ GKO_REGISTER_OPERATION(initialize_row_ptrs_l,
 GKO_REGISTER_OPERATION(initialize_l, factorization::initialize_l);
 
 
+}  // anonymous namespace
 }  // namespace ic_factorization
 
 

--- a/core/factorization/ilu.cpp
+++ b/core/factorization/ilu.cpp
@@ -48,6 +48,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 namespace gko {
 namespace factorization {
 namespace ilu_factorization {
+namespace {
 
 
 GKO_REGISTER_OPERATION(compute_ilu, ilu_factorization::compute_lu);
@@ -58,6 +59,7 @@ GKO_REGISTER_OPERATION(initialize_row_ptrs_l_u,
 GKO_REGISTER_OPERATION(initialize_l_u, factorization::initialize_l_u);
 
 
+}  // anonymous namespace
 }  // namespace ilu_factorization
 
 

--- a/core/factorization/par_ic.cpp
+++ b/core/factorization/par_ic.cpp
@@ -53,6 +53,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 namespace gko {
 namespace factorization {
 namespace par_ic_factorization {
+namespace {
 
 
 GKO_REGISTER_OPERATION(add_diagonal_elements,
@@ -66,6 +67,7 @@ GKO_REGISTER_OPERATION(csr_transpose, csr::transpose);
 GKO_REGISTER_OPERATION(convert_to_coo, csr::convert_to_coo);
 
 
+}  // anonymous namespace
 }  // namespace par_ic_factorization
 
 

--- a/core/factorization/par_ict.cpp
+++ b/core/factorization/par_ict.cpp
@@ -57,6 +57,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 namespace gko {
 namespace factorization {
 namespace par_ict_factorization {
+namespace {
 
 
 GKO_REGISTER_OPERATION(threshold_select,
@@ -77,6 +78,7 @@ GKO_REGISTER_OPERATION(convert_to_coo, csr::convert_to_coo);
 GKO_REGISTER_OPERATION(spgemm, csr::spgemm);
 
 
+}  // anonymous namespace
 }  // namespace par_ict_factorization
 
 

--- a/core/factorization/par_ilu.cpp
+++ b/core/factorization/par_ilu.cpp
@@ -52,6 +52,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 namespace gko {
 namespace factorization {
 namespace par_ilu_factorization {
+namespace {
 
 
 GKO_REGISTER_OPERATION(add_diagonal_elements,
@@ -64,6 +65,7 @@ GKO_REGISTER_OPERATION(compute_l_u_factors,
 GKO_REGISTER_OPERATION(csr_transpose, csr::transpose);
 
 
+}  // anonymous namespace
 }  // namespace par_ilu_factorization
 
 

--- a/core/factorization/par_ilut.cpp
+++ b/core/factorization/par_ilut.cpp
@@ -56,6 +56,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 namespace gko {
 namespace factorization {
 namespace par_ilut_factorization {
+namespace {
 
 
 GKO_REGISTER_OPERATION(threshold_select,
@@ -77,6 +78,7 @@ GKO_REGISTER_OPERATION(convert_to_coo, csr::convert_to_coo);
 GKO_REGISTER_OPERATION(spgemm, csr::spgemm);
 
 
+}  // anonymous namespace
 }  // namespace par_ilut_factorization
 
 

--- a/core/matrix/coo.cpp
+++ b/core/matrix/coo.cpp
@@ -53,9 +53,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 namespace gko {
 namespace matrix {
-
-
 namespace coo {
+namespace {
 
 
 GKO_REGISTER_OPERATION(spmv, coo::spmv);
@@ -72,6 +71,7 @@ GKO_REGISTER_OPERATION(outplace_absolute_array,
                        components::outplace_absolute_array);
 
 
+}  // anonymous namespace
 }  // namespace coo
 
 

--- a/core/matrix/csr.cpp
+++ b/core/matrix/csr.cpp
@@ -55,6 +55,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 namespace gko {
 namespace matrix {
 namespace csr {
+namespace {
 
 
 GKO_REGISTER_OPERATION(spmv, csr::spmv);
@@ -90,6 +91,7 @@ GKO_REGISTER_OPERATION(outplace_absolute_array,
                        components::outplace_absolute_array);
 
 
+}  // anonymous namespace
 }  // namespace csr
 
 

--- a/core/matrix/dense.cpp
+++ b/core/matrix/dense.cpp
@@ -59,6 +59,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 namespace gko {
 namespace matrix {
 namespace dense {
+namespace {
 
 
 GKO_REGISTER_OPERATION(simple_apply, dense::simple_apply);
@@ -102,6 +103,7 @@ GKO_REGISTER_OPERATION(get_real, dense::get_real);
 GKO_REGISTER_OPERATION(get_imag, dense::get_imag);
 
 
+}  // anonymous namespace
 }  // namespace dense
 
 

--- a/core/matrix/diagonal.cpp
+++ b/core/matrix/diagonal.cpp
@@ -46,6 +46,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 namespace gko {
 namespace matrix {
 namespace diagonal {
+namespace {
 
 
 GKO_REGISTER_OPERATION(apply_to_dense, diagonal::apply_to_dense);
@@ -60,6 +61,7 @@ GKO_REGISTER_OPERATION(outplace_absolute_array,
                        components::outplace_absolute_array);
 
 
+}  // anonymous namespace
 }  // namespace diagonal
 
 

--- a/core/matrix/ell.cpp
+++ b/core/matrix/ell.cpp
@@ -53,6 +53,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 namespace gko {
 namespace matrix {
 namespace ell {
+namespace {
 
 
 GKO_REGISTER_OPERATION(spmv, ell::spmv);
@@ -70,6 +71,7 @@ GKO_REGISTER_OPERATION(outplace_absolute_array,
                        components::outplace_absolute_array);
 
 
+}  // anonymous namespace
 }  // namespace ell
 
 

--- a/core/matrix/fbcsr.cpp
+++ b/core/matrix/fbcsr.cpp
@@ -57,6 +57,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 namespace gko {
 namespace matrix {
 namespace fbcsr {
+namespace {
 
 
 GKO_REGISTER_OPERATION(spmv, fbcsr::spmv);
@@ -80,6 +81,7 @@ GKO_REGISTER_OPERATION(outplace_absolute_array,
                        components::outplace_absolute_array);
 
 
+}  // anonymous namespace
 }  // namespace fbcsr
 
 

--- a/core/matrix/hybrid.cpp
+++ b/core/matrix/hybrid.cpp
@@ -54,6 +54,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 namespace gko {
 namespace matrix {
 namespace hybrid {
+namespace {
 
 
 GKO_REGISTER_OPERATION(convert_to_dense, hybrid::convert_to_dense);
@@ -68,6 +69,7 @@ GKO_REGISTER_OPERATION(outplace_absolute_array,
                        components::outplace_absolute_array);
 
 
+}  // anonymous namespace
 }  // namespace hybrid
 
 

--- a/core/matrix/sellp.cpp
+++ b/core/matrix/sellp.cpp
@@ -51,6 +51,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 namespace gko {
 namespace matrix {
 namespace sellp {
+namespace {
 
 
 GKO_REGISTER_OPERATION(spmv, sellp::spmv);
@@ -66,6 +67,7 @@ GKO_REGISTER_OPERATION(outplace_absolute_array,
                        components::outplace_absolute_array);
 
 
+}  // anonymous namespace
 }  // namespace sellp
 
 

--- a/core/matrix/sparsity_csr.cpp
+++ b/core/matrix/sparsity_csr.cpp
@@ -47,6 +47,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 namespace gko {
 namespace matrix {
 namespace sparsity_csr {
+namespace {
 
 
 GKO_REGISTER_OPERATION(spmv, sparsity_csr::spmv);
@@ -62,6 +63,7 @@ GKO_REGISTER_OPERATION(is_sorted_by_column_index,
                        sparsity_csr::is_sorted_by_column_index);
 
 
+}  // anonymous namespace
 }  // namespace sparsity_csr
 
 

--- a/core/multigrid/amgx_pgm.cpp
+++ b/core/multigrid/amgx_pgm.cpp
@@ -52,6 +52,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 namespace gko {
 namespace multigrid {
 namespace amgx_pgm {
+namespace {
 
 
 GKO_REGISTER_OPERATION(match_edge, amgx_pgm::match_edge);
@@ -64,6 +65,7 @@ GKO_REGISTER_OPERATION(fill_array, components::fill_array);
 GKO_REGISTER_OPERATION(fill_seq_array, components::fill_seq_array);
 
 
+}  // anonymous namespace
 }  // namespace amgx_pgm
 
 

--- a/core/preconditioner/isai.cpp
+++ b/core/preconditioner/isai.cpp
@@ -58,6 +58,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 namespace gko {
 namespace preconditioner {
 namespace isai {
+namespace {
 
 
 GKO_REGISTER_OPERATION(generate_tri_inverse, isai::generate_tri_inverse);
@@ -71,6 +72,7 @@ GKO_REGISTER_OPERATION(initialize_row_ptrs_l,
 GKO_REGISTER_OPERATION(initialize_l, factorization::initialize_l);
 
 
+}  // anonymous namespace
 }  // namespace isai
 
 

--- a/core/preconditioner/jacobi.cpp
+++ b/core/preconditioner/jacobi.cpp
@@ -55,6 +55,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 namespace gko {
 namespace preconditioner {
 namespace jacobi {
+namespace {
 
 
 GKO_REGISTER_OPERATION(simple_apply, jacobi::simple_apply);
@@ -73,6 +74,7 @@ GKO_REGISTER_OPERATION(scalar_convert_to_dense,
 GKO_REGISTER_OPERATION(initialize_precisions, jacobi::initialize_precisions);
 
 
+}  // anonymous namespace
 }  // namespace jacobi
 
 

--- a/core/reorder/rcm.cpp
+++ b/core/reorder/rcm.cpp
@@ -54,12 +54,14 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 namespace gko {
 namespace reorder {
 namespace rcm {
+namespace {
 
 
 GKO_REGISTER_OPERATION(get_permutation, rcm::get_permutation);
 GKO_REGISTER_OPERATION(get_degree_of_nodes, rcm::get_degree_of_nodes);
 
 
+}  // anonymous namespace
 }  // namespace rcm
 
 

--- a/core/solver/bicg.cpp
+++ b/core/solver/bicg.cpp
@@ -47,9 +47,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 namespace gko {
 namespace solver {
-
-
 namespace bicg {
+namespace {
 
 
 GKO_REGISTER_OPERATION(initialize, bicg::initialize);
@@ -57,6 +56,7 @@ GKO_REGISTER_OPERATION(step_1, bicg::step_1);
 GKO_REGISTER_OPERATION(step_2, bicg::step_2);
 
 
+}  // anonymous namespace
 }  // namespace bicg
 
 

--- a/core/solver/bicgstab.cpp
+++ b/core/solver/bicgstab.cpp
@@ -47,6 +47,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 namespace gko {
 namespace solver {
 namespace bicgstab {
+namespace {
 
 
 GKO_REGISTER_OPERATION(initialize, bicgstab::initialize);
@@ -56,6 +57,7 @@ GKO_REGISTER_OPERATION(step_3, bicgstab::step_3);
 GKO_REGISTER_OPERATION(finalize, bicgstab::finalize);
 
 
+}  // anonymous namespace
 }  // namespace bicgstab
 
 

--- a/core/solver/cb_gmres.cpp
+++ b/core/solver/cb_gmres.cpp
@@ -54,9 +54,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 namespace gko {
 namespace solver {
-
-
 namespace cb_gmres {
+namespace {
 
 
 GKO_REGISTER_OPERATION(initialize_1, cb_gmres::initialize_1);
@@ -65,6 +64,7 @@ GKO_REGISTER_OPERATION(step_1, cb_gmres::step_1);
 GKO_REGISTER_OPERATION(step_2, cb_gmres::step_2);
 
 
+}  // anonymous namespace
 }  // namespace cb_gmres
 
 

--- a/core/solver/cg.cpp
+++ b/core/solver/cg.cpp
@@ -47,9 +47,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 namespace gko {
 namespace solver {
-
-
 namespace cg {
+namespace {
 
 
 GKO_REGISTER_OPERATION(initialize, cg::initialize);
@@ -57,6 +56,7 @@ GKO_REGISTER_OPERATION(step_1, cg::step_1);
 GKO_REGISTER_OPERATION(step_2, cg::step_2);
 
 
+}  // anonymous namespace
 }  // namespace cg
 
 

--- a/core/solver/cgs.cpp
+++ b/core/solver/cgs.cpp
@@ -46,9 +46,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 namespace gko {
 namespace solver {
-
-
 namespace cgs {
+namespace {
 
 
 GKO_REGISTER_OPERATION(initialize, cgs::initialize);
@@ -57,6 +56,7 @@ GKO_REGISTER_OPERATION(step_2, cgs::step_2);
 GKO_REGISTER_OPERATION(step_3, cgs::step_3);
 
 
+}  // anonymous namespace
 }  // namespace cgs
 
 

--- a/core/solver/fcg.cpp
+++ b/core/solver/fcg.cpp
@@ -47,6 +47,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 namespace gko {
 namespace solver {
 namespace fcg {
+namespace {
 
 
 GKO_REGISTER_OPERATION(initialize, fcg::initialize);
@@ -54,6 +55,7 @@ GKO_REGISTER_OPERATION(step_1, fcg::step_1);
 GKO_REGISTER_OPERATION(step_2, fcg::step_2);
 
 
+}  // anonymous namespace
 }  // namespace fcg
 
 

--- a/core/solver/gmres.cpp
+++ b/core/solver/gmres.cpp
@@ -50,9 +50,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 namespace gko {
 namespace solver {
-
-
 namespace gmres {
+namespace {
 
 
 GKO_REGISTER_OPERATION(initialize_1, gmres::initialize_1);
@@ -61,6 +60,7 @@ GKO_REGISTER_OPERATION(step_1, gmres::step_1);
 GKO_REGISTER_OPERATION(step_2, gmres::step_2);
 
 
+}  // anonymous namespace
 }  // namespace gmres
 
 

--- a/core/solver/idr.cpp
+++ b/core/solver/idr.cpp
@@ -48,6 +48,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 namespace gko {
 namespace solver {
 namespace idr {
+namespace {
 
 
 GKO_REGISTER_OPERATION(initialize, idr::initialize);
@@ -58,6 +59,7 @@ GKO_REGISTER_OPERATION(compute_omega, idr::compute_omega);
 GKO_REGISTER_OPERATION(fill_array, components::fill_array);
 
 
+}  // anonymous namespace
 }  // namespace idr
 
 

--- a/core/solver/ir.cpp
+++ b/core/solver/ir.cpp
@@ -43,11 +43,13 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 namespace gko {
 namespace solver {
 namespace ir {
+namespace {
 
 
 GKO_REGISTER_OPERATION(initialize, ir::initialize);
 
 
+}  // anonymous namespace
 }  // namespace ir
 
 

--- a/core/solver/lower_trs.cpp
+++ b/core/solver/lower_trs.cpp
@@ -51,6 +51,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 namespace gko {
 namespace solver {
 namespace lower_trs {
+namespace {
 
 
 GKO_REGISTER_OPERATION(generate, lower_trs::generate);
@@ -60,6 +61,7 @@ GKO_REGISTER_OPERATION(should_perform_transpose,
 GKO_REGISTER_OPERATION(solve, lower_trs::solve);
 
 
+}  // anonymous namespace
 }  // namespace lower_trs
 
 

--- a/core/solver/upper_trs.cpp
+++ b/core/solver/upper_trs.cpp
@@ -51,6 +51,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 namespace gko {
 namespace solver {
 namespace upper_trs {
+namespace {
 
 
 GKO_REGISTER_OPERATION(generate, upper_trs::generate);
@@ -60,6 +61,7 @@ GKO_REGISTER_OPERATION(should_perform_transpose,
 GKO_REGISTER_OPERATION(solve, upper_trs::solve);
 
 
+}  // anonymous namespace
 }  // namespace upper_trs
 
 

--- a/core/stop/criterion.cpp
+++ b/core/stop/criterion.cpp
@@ -39,11 +39,13 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 namespace gko {
 namespace stop {
 namespace criterion {
+namespace {
 
 
 GKO_REGISTER_OPERATION(set_all_statuses, set_all_statuses::set_all_statuses);
 
 
+}  // anonymous namespace
 }  // namespace criterion
 
 

--- a/core/stop/residual_norm.cpp
+++ b/core/stop/residual_norm.cpp
@@ -40,21 +40,25 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 namespace gko {
 namespace stop {
 namespace residual_norm {
+namespace {
 
 
 GKO_REGISTER_OPERATION(residual_norm, residual_norm::residual_norm);
 
 
+}  // anonymous namespace
 }  // namespace residual_norm
 
 
 namespace implicit_residual_norm {
+namespace {
 
 
 GKO_REGISTER_OPERATION(implicit_residual_norm,
                        implicit_residual_norm::implicit_residual_norm);
 
 
+}  // anonymous namespace
 }  // namespace implicit_residual_norm
 
 


### PR DESCRIPTION
This significantly reduces the number of symbols being exported in Windows builds, allowing both Debug and Release builds with CUDA on Windows without modifying the compilation flags.