### PR TITLE
Batched: Make number of vectors in shared memory configurable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,6 +98,14 @@ option(GINKGO_INSTALL_RPATH "Set the RPATH when installing its libraries." ON)
 option(GINKGO_INSTALL_RPATH_ORIGIN "Add $ORIGIN (Linux) or @loader_path (MacOS) to the installation RPATH." ON)
 option(GINKGO_INSTALL_RPATH_DEPENDENCIES "Add dependencies to the installation RPATH." OFF)
 
+#Batch Ginkgo options:
+option(GINKGO_CUDA_BATCH_USE_NO_SHMEM "Use no shared memory in the batch solver kernels (Might be necessary for large matrices)" OFF)
+if(GINKGO_CUDA_BATCH_USE_NO_SHMEM)
+    set(GINKGO_CUDA_BATCH_HAVE_NO_SHMEM 1)
+else()
+    set(GINKGO_CUDA_BATCH_HAVE_NO_SHMEM 0)
+endif()
+
 set(GINKGO_CIRCULAR_DEPS_FLAGS "-Wl,--no-undefined")
 
 # Use ccache as compilation launcher
@@ -236,6 +244,9 @@ if(MSVC)
         set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS FALSE)
     endif()
 endif()
+
+configure_file(${Ginkgo_SOURCE_DIR}/include/ginkgo/batch_config.hpp.in
+    ${Ginkgo_BINARY_DIR}/include/ginkgo/batch_config.hpp @ONLY)
 
 configure_file(${Ginkgo_SOURCE_DIR}/include/ginkgo/config.hpp.in
     ${Ginkgo_BINARY_DIR}/include/ginkgo/config.hpp @ONLY)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -99,11 +99,11 @@ option(GINKGO_INSTALL_RPATH_ORIGIN "Add $ORIGIN (Linux) or @loader_path (MacOS) 
 option(GINKGO_INSTALL_RPATH_DEPENDENCIES "Add dependencies to the installation RPATH." OFF)
 
 #Batch Ginkgo options:
-option(GINKGO_CUDA_BATCH_USE_NO_SHMEM "Use no shared memory in the batch solver kernels (Might be necessary for large matrices)" OFF)
-if(GINKGO_CUDA_BATCH_USE_NO_SHMEM)
-    set(GINKGO_CUDA_BATCH_HAVE_NO_SHMEM 1)
+option(GINKGO_CUDA_BATCH_GMRES_USE_NO_SHMEM "Use no shared memory in the batch gmres solver kernels (Might be necessary for large matrices)" OFF)
+if(GINKGO_CUDA_BATCH_GMRES_USE_NO_SHMEM)
+    set(GINKGO_CUDA_BATCH_GMRES_HAVE_NO_SHMEM 1)
 else()
-    set(GINKGO_CUDA_BATCH_HAVE_NO_SHMEM 0)
+    set(GINKGO_CUDA_BATCH_GMRES_HAVE_NO_SHMEM 0)
 endif()
 
 set(GINKGO_CIRCULAR_DEPS_FLAGS "-Wl,--no-undefined")

--- a/benchmark/run_all_benchmarks.sh
+++ b/benchmark/run_all_benchmarks.sh
@@ -55,6 +55,11 @@ if [ ! "${ELL_IMBALANCE_LIMIT}" ]; then
     ELL_IMBALANCE_LIMIT=100
 fi
 
+if [ ! "${NUM_SHARED_VECS}" ]; then
+    NUM_SHARED_VECS="-1"
+    echo "NUM_SHARED_VECS environment variable not set - assuming \"${NUM_SHARED_VECS}\"" 1>&2
+fi
+
 if [ ! "${BATCH_SOLVERS}" ]; then
     BATCH_SOLVERS="richardson"
     echo "BATCH_SOLVERS    environment variable not set - assuming \"${BATCH_SOLVERS}\"" 1>&2
@@ -389,6 +394,7 @@ run_batch_solver_benchmarks() {
                     --num_duplications="${NUM_BATCH_DUP}" "${BATCH_SCALING_STR}" \
                     "${PRINT_RES_ITER_STR}" \
                     --num_batches="${NUM_BATCH_ENTRIES}" "${SS_STR}" \
+                    --num_shared_vecs="${NUM_SHARED_VECS}" \
                     --max_iters=${SOLVERS_MAX_ITERATIONS} --rel_res_goal=${SOLVERS_PRECISION} \
                     ${SOLVERS_RHS_FLAG} ${DETAILED_STR} ${SOLVERS_INITIAL_GUESS_FLAG} \
                     --gpu_timer=${GPU_TIMER} \

--- a/benchmark/solver/batch_solver.hpp
+++ b/benchmark/solver/batch_solver.hpp
@@ -464,7 +464,7 @@ void solve_system(const std::string& sol_name, const std::string& prec_name,
             err->add_scaled(neg_one.get(), x_clone.get());
             err->compute_norm2(err_nrm.get());
             exec->synchronize();
-            add_or_set_member(solver_json["apply"], "l2_error",
+            add_or_set_member(solver_json["apply"], "error_norm",
                               rapidjson::Value(rapidjson::kObjectType),
                               allocator);
             for (size_type i = 0; i < nbatch; ++i) {

--- a/benchmark/solver/batch_solver.hpp
+++ b/benchmark/solver/batch_solver.hpp
@@ -345,10 +345,11 @@ void solve_system(const std::string& sol_name, const std::string& prec_name,
         add_or_set_member(solver_case, solver_name,
                           rapidjson::Value(rapidjson::kObjectType), allocator);
         auto& solver_json = solver_case[solver_name];
+        const size_type nbatch = system_matrix->get_num_batch_entries();
+        add_or_set_member(solver_json, "num_batch_entries", nbatch, allocator);
         add_or_set_member(solver_json, "scaling",
                           rapidjson::StringRef(FLAGS_batch_scaling.c_str()),
                           allocator);
-        const size_type nbatch = system_matrix->get_num_batch_entries();
         if (FLAGS_detailed && b->get_size().at(0)[1] == 1 && !FLAGS_overhead) {
             add_or_set_member(solver_json, "rhs_norm",
                               rapidjson::Value(rapidjson::kObjectType),

--- a/benchmark/solver/batch_solver.hpp
+++ b/benchmark/solver/batch_solver.hpp
@@ -119,6 +119,7 @@ DEFINE_bool(overhead, false,
             "If set, uses dummy data to benchmark Ginkgo overhead");
 
 
+DEFINE_int32(num_shared_vecs, -1, "The number of vectors in shared memory");
 DEFINE_uint32(num_duplications, 1, "The number of duplications");
 DEFINE_uint32(num_batches, 1, "The number of batch entries");
 DEFINE_string(batch_scaling, "none", "Whether to use scaled matrices");
@@ -298,6 +299,7 @@ std::unique_ptr<gko::BatchLinOpFactory> generate_solver(
     } else if (description == "bicgstab") {
         using Solver = gko::solver::BatchBicgstab<etype>;
         return Solver::build()
+            .with_num_shared_vectors(static_cast<int>(FLAGS_num_shared_vecs))
             .with_max_iterations(static_cast<int>(FLAGS_max_iters))
             .with_residual_tol(
                 static_cast<gko::remove_complex<etype>>(FLAGS_rel_res_goal))

--- a/cmake/install_helpers.cmake
+++ b/cmake/install_helpers.cmake
@@ -81,6 +81,9 @@ function(ginkgo_install)
     install(FILES "${Ginkgo_BINARY_DIR}/include/ginkgo/config.hpp"
         DESTINATION "${GINKGO_INSTALL_INCLUDE_DIR}/ginkgo"
         )
+    install(FILES "${Ginkgo_BINARY_DIR}/include/ginkgo/batch_config.hpp"
+        DESTINATION "${GINKGO_INSTALL_INCLUDE_DIR}/ginkgo"
+        )
     if (GINKGO_HAVE_PAPI_SDE)
         install(FILES "${Ginkgo_SOURCE_DIR}/third_party/papi_sde/papi_sde_interface.h"
             DESTINATION "${GINKGO_INSTALL_INCLUDE_DIR}/third_party/papi_sde"

--- a/common/cuda_hip/solver/batch_bicgstab_kernels.hpp.inc
+++ b/common/cuda_hip/solver/batch_bicgstab_kernels.hpp.inc
@@ -196,61 +196,59 @@ __global__ void apply_kernel(const int num_sh_vecs, const int shared_gap,
     auto warp_grp = group::tiled_partition<tile_size>(thread_block);
 
     for (size_type ibatch = blockIdx.x; ibatch < nbatch; ibatch += gridDim.x) {
-#if GKO_CUDA_BATCH_HAVE_NO_SHMEM
         int gmem_offset = ibatch * (shared_gap * (10 - num_sh_vecs));
-        assert(workspace != nullptr);
         extern __shared__ char local_mem_sh[];
 
+        ValueType* p_hat_sh;
+        ValueType* s_hat_sh;
+        ValueType* p_sh;
+        ValueType* s_sh;
         ValueType* r_sh;
         ValueType* r_hat_sh;
-        ValueType* p_sh;
-        ValueType* p_hat_sh;
         ValueType* v_sh;
-        ValueType* s_sh;
-        ValueType* s_hat_sh;
         ValueType* t_sh;
         ValueType* x_sh;
         ValueType* prec_work_sh;
 
         if (num_sh_vecs >= 1) {
-            r_sh = reinterpret_cast<ValueType*>(local_mem_sh);
+            p_hat_sh = reinterpret_cast<ValueType*>(local_mem_sh);
         } else {
-            r_sh = workspace + gmem_offset;
+            p_hat_sh = workspace + gmem_offset;
         }
         if (num_sh_vecs == 1) {
-            r_hat_sh = workspace + gmem_offset;
+            s_hat_sh = workspace + gmem_offset;
         } else {
-            r_hat_sh = r_sh + shared_gap;
+            s_hat_sh = p_hat_sh + shared_gap;
         }
         if (num_sh_vecs == 2) {
             p_sh = workspace + gmem_offset;
         } else {
-            p_sh = r_hat_sh + shared_gap;
+            p_sh = s_hat_sh + shared_gap;
         }
         if (num_sh_vecs == 3) {
-            p_hat_sh = workspace + gmem_offset;
-        } else {
-            p_hat_sh = p_sh + shared_gap;
-        }
-        if (num_sh_vecs == 4) {
-            v_sh = workspace + gmem_offset;
-        } else {
-            v_sh = p_hat_sh + shared_gap;
-        }
-        if (num_sh_vecs == 5) {
             s_sh = workspace + gmem_offset;
         } else {
-            s_sh = v_sh + shared_gap;
+            s_sh = p_sh + shared_gap;
+        }
+        if (num_sh_vecs == 4) {
+            r_sh = workspace + gmem_offset;
+        } else {
+            r_sh = s_sh + shared_gap;
+        }
+        if (num_sh_vecs == 5) {
+            r_hat_sh = workspace + gmem_offset;
+        } else {
+            r_hat_sh = r_sh + shared_gap;
         }
         if (num_sh_vecs == 6) {
-            s_hat_sh = workspace + gmem_offset;
+            v_sh = workspace + gmem_offset;
         } else {
-            s_hat_sh = s_sh + shared_gap;
+            v_sh = r_hat_sh + shared_gap;
         }
         if (num_sh_vecs == 7) {
             t_sh = workspace + gmem_offset;
         } else {
-            t_sh = s_hat_sh + shared_gap;
+            t_sh = v_sh + shared_gap;
         }
         if (num_sh_vecs == 8) {
             x_sh = workspace + gmem_offset;
@@ -262,19 +260,7 @@ __global__ void apply_kernel(const int num_sh_vecs, const int shared_gap,
         } else {
             prec_work_sh = x_sh + shared_gap;
         }
-#else
-        extern __shared__ char local_mem_sh[];
-        ValueType* const r_sh = reinterpret_cast<ValueType*>(local_mem_sh);
-        ValueType* const r_hat_sh = r_sh + shared_gap;
-        ValueType* const p_sh = r_hat_sh + shared_gap;
-        ValueType* const p_hat_sh = p_sh + shared_gap;
-        ValueType* const v_sh = p_hat_sh + shared_gap;
-        ValueType* const s_sh = v_sh + shared_gap;
-        ValueType* const s_hat_sh = s_sh + shared_gap;
-        ValueType* const t_sh = s_hat_sh + shared_gap;
-        ValueType* const x_sh = t_sh + shared_gap;
-        ValueType* const prec_work_sh = x_sh + shared_gap;
-#endif
+
         __shared__ UninitializedArray<ValueType, 1> rho_old_sh;
         __shared__ UninitializedArray<ValueType, 1> rho_new_sh;
         __shared__ UninitializedArray<ValueType, 1> omega_sh;

--- a/common/cuda_hip/solver/batch_bicgstab_kernels.hpp.inc
+++ b/common/cuda_hip/solver/batch_bicgstab_kernels.hpp.inc
@@ -185,7 +185,7 @@ __global__ void apply_kernel(const int num_sh_vecs, const int shared_gap,
                              const BatchMatrixType a,
                              const ValueType* const __restrict__ b,
                              ValueType* const __restrict__ x,
-                             ValueType* const workspace = nullptr)
+                             ValueType* const __restrict__ workspace = nullptr)
 {
     using real_type = typename gko::remove_complex<ValueType>;
     const auto nbatch = a.num_batch;

--- a/common/cuda_hip/solver/batch_bicgstab_kernels.hpp.inc
+++ b/common/cuda_hip/solver/batch_bicgstab_kernels.hpp.inc
@@ -178,7 +178,7 @@ __device__ __forceinline__ void update_x_middle(
 
 template <typename StopType, typename PrecType, typename LogType,
           typename BatchMatrixType, typename ValueType>
-__global__ void apply_kernel(const int shared_gap, const int max_iter,
+__global__ void apply_kernel(const int num_sh_vecs, const int shared_gap, const int max_iter,
                              const gko::remove_complex<ValueType> tol,
                              LogType logger, PrecType prec_shared,
                              const BatchMatrixType a,
@@ -197,7 +197,7 @@ __global__ void apply_kernel(const int shared_gap, const int max_iter,
     for (size_type ibatch = blockIdx.x; ibatch < nbatch; ibatch += gridDim.x) {
 #if GKO_CUDA_BATCH_HAVE_NO_SHMEM
         assert(workspace != nullptr);
-        ValueType *const r_sh = workspace + ibatch * (shared_gap * 10);
+        ValueType *const r_sh = workspace + ibatch * (shared_gap * 11);
         ValueType *const r_hat_sh = r_sh + shared_gap;
         ValueType *const p_sh = r_hat_sh + shared_gap;
         ValueType *const p_hat_sh = p_sh + shared_gap;
@@ -208,8 +208,6 @@ __global__ void apply_kernel(const int shared_gap, const int max_iter,
         ValueType *const x_sh = t_sh + shared_gap;
         ValueType *const prec_work_sh = x_sh + shared_gap;
 #else
-
-#if GKO_CUDA_BATCH_USE_DYNAMIC_SHARED_MEM
         extern __shared__ char local_mem_sh[];
         ValueType* const r_sh = reinterpret_cast<ValueType*>(local_mem_sh);
         ValueType* const r_hat_sh = r_sh + shared_gap;
@@ -221,19 +219,6 @@ __global__ void apply_kernel(const int shared_gap, const int max_iter,
         ValueType* const t_sh = s_hat_sh + shared_gap;
         ValueType* const x_sh = t_sh + shared_gap;
         ValueType* const prec_work_sh = x_sh + shared_gap;
-#else
-        __shared__ ValueType r_sh[batch_config<ValueType>::max_num_rows];
-        __shared__ ValueType r_hat_sh[batch_config<ValueType>::max_num_rows];
-        __shared__ ValueType p_sh[batch_config<ValueType>::max_num_rows];
-        __shared__ ValueType p_hat_sh[batch_config<ValueType>::max_num_rows];
-        __shared__ ValueType s_sh[batch_config<ValueType>::max_num_rows];
-        __shared__ ValueType s_hat_sh[batch_config<ValueType>::max_num_rows];
-        __shared__ ValueType v_sh[batch_config<ValueType>::max_num_rows];
-        __shared__ ValueType t_sh[batch_config<ValueType>::max_num_rows];
-        __shared__ ValueType x_sh[batch_config<ValueType>::max_num_rows];
-        __shared__ ValueType
-            prec_work_sh[batch_config<ValueType>::max_num_rows];
-#endif
 #endif
         __shared__ UninitializedArray<ValueType, 1> rho_old_sh;
         __shared__ UninitializedArray<ValueType, 1> rho_new_sh;

--- a/common/cuda_hip/solver/batch_bicgstab_kernels.hpp.inc
+++ b/common/cuda_hip/solver/batch_bicgstab_kernels.hpp.inc
@@ -178,7 +178,8 @@ __device__ __forceinline__ void update_x_middle(
 
 template <typename StopType, typename PrecType, typename LogType,
           typename BatchMatrixType, typename ValueType>
-__global__ void apply_kernel(const int num_sh_vecs, const int shared_gap, const int max_iter,
+__global__ void apply_kernel(const int num_sh_vecs, const int shared_gap,
+                             const int max_iter,
                              const gko::remove_complex<ValueType> tol,
                              LogType logger, PrecType prec_shared,
                              const BatchMatrixType a,
@@ -196,22 +197,71 @@ __global__ void apply_kernel(const int num_sh_vecs, const int shared_gap, const 
 
     for (size_type ibatch = blockIdx.x; ibatch < nbatch; ibatch += gridDim.x) {
 #if GKO_CUDA_BATCH_HAVE_NO_SHMEM
-        int gmem_offset = ibatch * (shared_gap * 7);
-        extern __shared__ char local_mem_sh[];
-        // ValueType *const r_sh, r_hat_sh, p_sh, p_hat_sh, v_sh, s_sh,
-        // s_hat_sh,
-        //     t_sh, x_sh, prec_work_sh;
-        ValueType *const r_sh = reinterpret_cast<ValueType *>(local_mem_sh);
-        ValueType *const r_hat_sh = r_sh + shared_gap;
-        ValueType *const p_sh = r_hat_sh + shared_gap;
+        int gmem_offset = ibatch * (shared_gap * (10 - num_sh_vecs));
         assert(workspace != nullptr);
-        ValueType *const p_hat_sh = workspace + gmem_offset;
-        ValueType *const v_sh = p_hat_sh + shared_gap;
-        ValueType *const s_sh = v_sh + shared_gap;
-        ValueType *const s_hat_sh = s_sh + shared_gap;
-        ValueType *const t_sh = s_hat_sh + shared_gap;
-        ValueType *const x_sh = t_sh + shared_gap;
-        ValueType *const prec_work_sh = x_sh + shared_gap;
+        extern __shared__ char local_mem_sh[];
+
+        ValueType* r_sh;
+        ValueType* r_hat_sh;
+        ValueType* p_sh;
+        ValueType* p_hat_sh;
+        ValueType* v_sh;
+        ValueType* s_sh;
+        ValueType* s_hat_sh;
+        ValueType* t_sh;
+        ValueType* x_sh;
+        ValueType* prec_work_sh;
+
+        if (num_sh_vecs >= 1) {
+            r_sh = reinterpret_cast<ValueType*>(local_mem_sh);
+        } else {
+            r_sh = workspace + gmem_offset;
+        }
+        if (num_sh_vecs == 1) {
+            r_hat_sh = workspace + gmem_offset;
+        } else {
+            r_hat_sh = r_sh + shared_gap;
+        }
+        if (num_sh_vecs == 2) {
+            p_sh = workspace + gmem_offset;
+        } else {
+            p_sh = r_hat_sh + shared_gap;
+        }
+        if (num_sh_vecs == 3) {
+            p_hat_sh = workspace + gmem_offset;
+        } else {
+            p_hat_sh = p_sh + shared_gap;
+        }
+        if (num_sh_vecs == 4) {
+            v_sh = workspace + gmem_offset;
+        } else {
+            v_sh = p_hat_sh + shared_gap;
+        }
+        if (num_sh_vecs == 5) {
+            s_sh = workspace + gmem_offset;
+        } else {
+            s_sh = v_sh + shared_gap;
+        }
+        if (num_sh_vecs == 6) {
+            s_hat_sh = workspace + gmem_offset;
+        } else {
+            s_hat_sh = s_sh + shared_gap;
+        }
+        if (num_sh_vecs == 7) {
+            t_sh = workspace + gmem_offset;
+        } else {
+            t_sh = s_hat_sh + shared_gap;
+        }
+        if (num_sh_vecs == 8) {
+            x_sh = workspace + gmem_offset;
+        } else {
+            x_sh = t_sh + shared_gap;
+        }
+        if (num_sh_vecs == 9) {
+            prec_work_sh = workspace + gmem_offset;
+        } else {
+            prec_work_sh = x_sh + shared_gap;
+        }
 #else
         extern __shared__ char local_mem_sh[];
         ValueType* const r_sh = reinterpret_cast<ValueType*>(local_mem_sh);

--- a/common/cuda_hip/solver/batch_bicgstab_kernels.hpp.inc
+++ b/common/cuda_hip/solver/batch_bicgstab_kernels.hpp.inc
@@ -195,9 +195,9 @@ __global__ void apply_kernel(const int shared_gap, const int max_iter,
     auto warp_grp = group::tiled_partition<tile_size>(thread_block);
 
     for (size_type ibatch = blockIdx.x; ibatch < nbatch; ibatch += gridDim.x) {
-#if GKO_CUDA_BATCH_USE_NO_SHARED_MEM
+#if GKO_CUDA_BATCH_HAVE_NO_SHMEM
         assert(workspace != nullptr);
-        ValueType *const r_sh = workspace + ibatch*(shared_gap*10);
+        ValueType *const r_sh = workspace + ibatch * (shared_gap * 10);
         ValueType *const r_hat_sh = r_sh + shared_gap;
         ValueType *const p_sh = r_hat_sh + shared_gap;
         ValueType *const p_hat_sh = p_sh + shared_gap;
@@ -209,7 +209,7 @@ __global__ void apply_kernel(const int shared_gap, const int max_iter,
         ValueType *const prec_work_sh = x_sh + shared_gap;
 #else
 
-#ifdef GKO_CUDA_BATCH_USE_DYNAMIC_SHARED_MEM
+#if GKO_CUDA_BATCH_USE_DYNAMIC_SHARED_MEM
         extern __shared__ char local_mem_sh[];
         ValueType* const r_sh = reinterpret_cast<ValueType*>(local_mem_sh);
         ValueType* const r_hat_sh = r_sh + shared_gap;

--- a/common/cuda_hip/solver/batch_bicgstab_kernels.hpp.inc
+++ b/common/cuda_hip/solver/batch_bicgstab_kernels.hpp.inc
@@ -183,7 +183,8 @@ __global__ void apply_kernel(const int shared_gap, const int max_iter,
                              LogType logger, PrecType prec_shared,
                              const BatchMatrixType a,
                              const ValueType* const __restrict__ b,
-                             ValueType* const __restrict__ x)
+                             ValueType* const __restrict__ x,
+                             ValueType* const workspace = nullptr)
 {
     using real_type = typename gko::remove_complex<ValueType>;
     const auto nbatch = a.num_batch;
@@ -194,6 +195,20 @@ __global__ void apply_kernel(const int shared_gap, const int max_iter,
     auto warp_grp = group::tiled_partition<tile_size>(thread_block);
 
     for (size_type ibatch = blockIdx.x; ibatch < nbatch; ibatch += gridDim.x) {
+#if GKO_CUDA_BATCH_USE_NO_SHARED_MEM
+        assert(workspace != nullptr);
+        ValueType *const r_sh = workspace + ibatch*(shared_gap*10);
+        ValueType *const r_hat_sh = r_sh + shared_gap;
+        ValueType *const p_sh = r_hat_sh + shared_gap;
+        ValueType *const p_hat_sh = p_sh + shared_gap;
+        ValueType *const v_sh = p_hat_sh + shared_gap;
+        ValueType *const s_sh = v_sh + shared_gap;
+        ValueType *const s_hat_sh = s_sh + shared_gap;
+        ValueType *const t_sh = s_hat_sh + shared_gap;
+        ValueType *const x_sh = t_sh + shared_gap;
+        ValueType *const prec_work_sh = x_sh + shared_gap;
+#else
+
 #ifdef GKO_CUDA_BATCH_USE_DYNAMIC_SHARED_MEM
         extern __shared__ char local_mem_sh[];
         ValueType* const r_sh = reinterpret_cast<ValueType*>(local_mem_sh);
@@ -218,6 +233,7 @@ __global__ void apply_kernel(const int shared_gap, const int max_iter,
         __shared__ ValueType x_sh[batch_config<ValueType>::max_num_rows];
         __shared__ ValueType
             prec_work_sh[batch_config<ValueType>::max_num_rows];
+#endif
 #endif
         __shared__ UninitializedArray<ValueType, 1> rho_old_sh;
         __shared__ UninitializedArray<ValueType, 1> rho_new_sh;

--- a/common/cuda_hip/solver/batch_bicgstab_kernels.hpp.inc
+++ b/common/cuda_hip/solver/batch_bicgstab_kernels.hpp.inc
@@ -196,11 +196,16 @@ __global__ void apply_kernel(const int num_sh_vecs, const int shared_gap, const 
 
     for (size_type ibatch = blockIdx.x; ibatch < nbatch; ibatch += gridDim.x) {
 #if GKO_CUDA_BATCH_HAVE_NO_SHMEM
-        assert(workspace != nullptr);
-        ValueType *const r_sh = workspace + ibatch * (shared_gap * 11);
+        int gmem_offset = ibatch * (shared_gap * 7);
+        extern __shared__ char local_mem_sh[];
+        // ValueType *const r_sh, r_hat_sh, p_sh, p_hat_sh, v_sh, s_sh,
+        // s_hat_sh,
+        //     t_sh, x_sh, prec_work_sh;
+        ValueType *const r_sh = reinterpret_cast<ValueType *>(local_mem_sh);
         ValueType *const r_hat_sh = r_sh + shared_gap;
         ValueType *const p_sh = r_hat_sh + shared_gap;
-        ValueType *const p_hat_sh = p_sh + shared_gap;
+        assert(workspace != nullptr);
+        ValueType *const p_hat_sh = workspace + gmem_offset;
         ValueType *const v_sh = p_hat_sh + shared_gap;
         ValueType *const s_sh = v_sh + shared_gap;
         ValueType *const s_hat_sh = s_sh + shared_gap;

--- a/common/cuda_hip/solver/batch_gmres_kernels.hpp.inc
+++ b/common/cuda_hip/solver/batch_gmres_kernels.hpp.inc
@@ -249,7 +249,7 @@ __device__ __forceinline__ void update_x(
 
 template <typename StopType, typename PrecType, typename LogType,
           typename BatchMatrixType, typename ValueType>
-__global__ void apply_kernel(const int shared_gap, const int max_iter,
+__global__ void apply_kernel(const int global_gap, const int max_iter,
                              const gko::remove_complex<ValueType> tol,
                              const int restart, LogType logger,
                              PrecType prec_shared, const BatchMatrixType a,
@@ -272,24 +272,11 @@ __global__ void apply_kernel(const int shared_gap, const int max_iter,
     for (size_type ibatch = blockIdx.x; ibatch < nbatch; ibatch += gridDim.x) {
 #if GKO_CUDA_BATCH_GMRES_HAVE_NO_SHMEM
         assert(workspace != nullptr);
-        ValueType* const r_sh = workspace + ibatch * (shared_gap);
-        ValueType* const z_sh = r_sh + nrows * nrhs;
-        ValueType* const w_sh = z_sh + nrows * nrhs;
-        ValueType* const x_sh = w_sh + nrows * nrhs;
-        ValueType* const helper_sh = x_sh + nrows * nrhs;
-        ValueType* const cs_sh = helper_sh + nrows * nrhs;
-        ValueType* const sn_sh = cs_sh + restart * nrhs;
-        ValueType* const y_sh = sn_sh + restart * nrhs;
-        ValueType* const s_sh = y_sh + restart * nrhs;
-
-        ValueType* const H_sh = s_sh + (restart + 1) * nrhs;
-
-        ValueType* const V_sh = H_sh + restart * (restart + 1) * nrhs;
-
-        ValueType* const prec_work_sh = V_sh + nrows * (restart + 1) * nrhs;
+        ValueType* const r_sh = workspace + ibatch * (global_gap);
 #else
         extern __shared__ char local_mem_sh[];
         ValueType* const r_sh = reinterpret_cast<ValueType*>(local_mem_sh);
+#endif
         ValueType* const z_sh = r_sh + nrows * nrhs;
         ValueType* const w_sh = z_sh + nrows * nrhs;
         ValueType* const x_sh = w_sh + nrows * nrhs;
@@ -321,7 +308,6 @@ __global__ void apply_kernel(const int shared_gap, const int max_iter,
         ValueType* const V_sh = H_sh + restart * (restart + 1) * nrhs;
 
         ValueType* const prec_work_sh = V_sh + nrows * (restart + 1) * nrhs;
-#endif
 
         // real_type *const norms_rhs_sh = reinterpret_cast<real_type *>(
         //     prec_work_sh + PrecType::dynamic_work_size(nrows, a.num_nnz));

--- a/common/cuda_hip/solver/batch_gmres_kernels.hpp.inc
+++ b/common/cuda_hip/solver/batch_gmres_kernels.hpp.inc
@@ -254,7 +254,8 @@ __global__ void apply_kernel(const int max_iter,
                              const int restart, LogType logger,
                              PrecType prec_shared, const BatchMatrixType a,
                              const ValueType* const __restrict__ b,
-                             ValueType* const __restrict__ x)
+                             ValueType* const __restrict__ x,
+                             ValueType* const workspace = nullptr)
 {
     using real_type = typename gko::remove_complex<ValueType>;
     const auto nbatch = a.num_batch;
@@ -269,6 +270,24 @@ __global__ void apply_kernel(const int max_iter,
     auto warp_grp = group::tiled_partition<tile_size>(thread_block);
 
     for (size_type ibatch = blockIdx.x; ibatch < nbatch; ibatch += gridDim.x) {
+#if GKO_CUDA_BATCH_USE_NO_SHARED_MEM
+        assert(workspace != nullptr);
+        ValueType* const r_sh = workspace + ibatch * (nrows * 12 * nrhs);
+        ValueType* const z_sh = r_sh + nrows * nrhs;
+        ValueType* const w_sh = z_sh + nrows * nrhs;
+        ValueType* const x_sh = w_sh + nrows * nrhs;
+        ValueType* const helper_sh = x_sh + nrows * nrhs;
+        ValueType* const cs_sh = helper_sh + nrows * nrhs;
+        ValueType* const sn_sh = cs_sh + restart * nrhs;
+        ValueType* const y_sh = sn_sh + restart * nrhs;
+        ValueType* const s_sh = y_sh + restart * nrhs;
+
+        ValueType* const H_sh = s_sh + (restart + 1) * nrhs;
+
+        ValueType* const V_sh = H_sh + restart * (restart + 1) * nrhs;
+
+        ValueType* const prec_work_sh = V_sh + nrows * (restart + 1) * nrhs;
+#else
         extern __shared__ char local_mem_sh[];
         ValueType* const r_sh = reinterpret_cast<ValueType*>(local_mem_sh);
         ValueType* const z_sh = r_sh + nrows * nrhs;
@@ -302,6 +321,7 @@ __global__ void apply_kernel(const int max_iter,
         ValueType* const V_sh = H_sh + restart * (restart + 1) * nrhs;
 
         ValueType* const prec_work_sh = V_sh + nrows * (restart + 1) * nrhs;
+#endif
 
         // real_type *const norms_rhs_sh = reinterpret_cast<real_type *>(
         //     prec_work_sh + PrecType::dynamic_work_size(nrows, a.num_nnz));

--- a/common/cuda_hip/solver/batch_gmres_kernels.hpp.inc
+++ b/common/cuda_hip/solver/batch_gmres_kernels.hpp.inc
@@ -270,7 +270,7 @@ __global__ void apply_kernel(const int shared_gap, const int max_iter,
     auto warp_grp = group::tiled_partition<tile_size>(thread_block);
 
     for (size_type ibatch = blockIdx.x; ibatch < nbatch; ibatch += gridDim.x) {
-#if GKO_CUDA_BATCH_HAVE_NO_SHMEM
+#if GKO_CUDA_BATCH_GMRES_HAVE_NO_SHMEM
         assert(workspace != nullptr);
         ValueType* const r_sh = workspace + ibatch * (shared_gap);
         ValueType* const z_sh = r_sh + nrows * nrhs;

--- a/common/cuda_hip/solver/batch_gmres_kernels.hpp.inc
+++ b/common/cuda_hip/solver/batch_gmres_kernels.hpp.inc
@@ -270,7 +270,7 @@ __global__ void apply_kernel(const int shared_gap, const int max_iter,
     auto warp_grp = group::tiled_partition<tile_size>(thread_block);
 
     for (size_type ibatch = blockIdx.x; ibatch < nbatch; ibatch += gridDim.x) {
-#if GKO_CUDA_BATCH_USE_NO_SHARED_MEM
+#if GKO_CUDA_BATCH_HAVE_NO_SHMEM
         assert(workspace != nullptr);
         ValueType* const r_sh = workspace + ibatch * (shared_gap);
         ValueType* const z_sh = r_sh + nrows * nrhs;

--- a/common/cuda_hip/solver/batch_gmres_kernels.hpp.inc
+++ b/common/cuda_hip/solver/batch_gmres_kernels.hpp.inc
@@ -249,7 +249,7 @@ __device__ __forceinline__ void update_x(
 
 template <typename StopType, typename PrecType, typename LogType,
           typename BatchMatrixType, typename ValueType>
-__global__ void apply_kernel(const int max_iter,
+__global__ void apply_kernel(const int shared_gap, const int max_iter,
                              const gko::remove_complex<ValueType> tol,
                              const int restart, LogType logger,
                              PrecType prec_shared, const BatchMatrixType a,
@@ -272,7 +272,7 @@ __global__ void apply_kernel(const int max_iter,
     for (size_type ibatch = blockIdx.x; ibatch < nbatch; ibatch += gridDim.x) {
 #if GKO_CUDA_BATCH_USE_NO_SHARED_MEM
         assert(workspace != nullptr);
-        ValueType* const r_sh = workspace + ibatch * (nrows * 12 * nrhs);
+        ValueType* const r_sh = workspace + ibatch * (shared_gap);
         ValueType* const z_sh = r_sh + nrows * nrhs;
         ValueType* const w_sh = z_sh + nrows * nrhs;
         ValueType* const x_sh = w_sh + nrows * nrhs;

--- a/core/solver/batch_bicgstab.cpp
+++ b/core/solver/batch_bicgstab.cpp
@@ -120,8 +120,9 @@ void BatchBicgstab<ValueType>::apply_impl(const BatchLinOp* b,
 
     const kernels::batch_bicgstab::BatchBicgstabOptions<
         remove_complex<ValueType>>
-        opts{parameters_.preconditioner, parameters_.max_iterations,
-             parameters_.residual_tol, parameters_.tolerance_type};
+        opts{parameters_.num_shared_vectors, parameters_.preconditioner,
+             parameters_.max_iterations, parameters_.residual_tol,
+             parameters_.tolerance_type};
 
     log::BatchLogData<ValueType> logdata;
 

--- a/core/solver/batch_bicgstab.cpp
+++ b/core/solver/batch_bicgstab.cpp
@@ -120,9 +120,9 @@ void BatchBicgstab<ValueType>::apply_impl(const BatchLinOp* b,
 
     const kernels::batch_bicgstab::BatchBicgstabOptions<
         remove_complex<ValueType>>
-        opts{parameters_.num_shared_vectors, parameters_.preconditioner,
-             parameters_.max_iterations, parameters_.residual_tol,
-             parameters_.tolerance_type};
+        opts{parameters_.preconditioner, parameters_.max_iterations,
+             parameters_.residual_tol, parameters_.tolerance_type,
+             parameters_.num_shared_vectors};
 
     log::BatchLogData<ValueType> logdata;
 

--- a/core/solver/batch_bicgstab.cpp
+++ b/core/solver/batch_bicgstab.cpp
@@ -62,6 +62,7 @@ std::unique_ptr<BatchLinOp> BatchBicgstab<ValueType>::transpose() const
         .with_max_iterations(parameters_.max_iterations)
         .with_residual_tol(parameters_.residual_tol)
         .with_tolerance_type(parameters_.tolerance_type)
+        .with_num_shared_vectors(parameters_.num_shared_vectors)
         .on(this->get_executor())
         ->generate(share(
             as<BatchTransposable>(this->get_system_matrix())->transpose()));
@@ -76,6 +77,7 @@ std::unique_ptr<BatchLinOp> BatchBicgstab<ValueType>::conj_transpose() const
         .with_max_iterations(parameters_.max_iterations)
         .with_residual_tol(parameters_.residual_tol)
         .with_tolerance_type(parameters_.tolerance_type)
+        .with_num_shared_vectors(parameters_.num_shared_vectors)
         .on(this->get_executor())
         ->generate(share(as<BatchTransposable>(this->get_system_matrix())
                              ->conj_transpose()));

--- a/core/solver/batch_bicgstab_kernels.hpp
+++ b/core/solver/batch_bicgstab_kernels.hpp
@@ -52,11 +52,11 @@ namespace batch_bicgstab {
  */
 template <typename RealType>
 struct BatchBicgstabOptions {
-    int num_sh_vecs;
     preconditioner::batch::type preconditioner;
     int max_its;
     RealType residual_tol;
     ::gko::stop::batch::ToleranceType tol_type;
+    int num_sh_vecs = 0;
 };
 
 
@@ -94,11 +94,11 @@ inline int local_memory_requirement(const int num_rows, const int num_rhs)
 #define GKO_DECLARE_BATCH_BICGSTAB_APPLY_KERNEL(_type)                   \
     void apply(std::shared_ptr<const DefaultExecutor> exec,              \
                const gko::kernels::batch_bicgstab::BatchBicgstabOptions< \
-                   remove_complex<_type>> &options,                      \
-               const BatchLinOp *const a,                                \
-               const matrix::BatchDense<_type> *const b,                 \
-               matrix::BatchDense<_type> *const x,                       \
-               gko::log::BatchLogData<_type> &logdata)
+                   remove_complex<_type>>& options,                      \
+               const BatchLinOp* const a,                                \
+               const matrix::BatchDense<_type>* const b,                 \
+               matrix::BatchDense<_type>* const x,                       \
+               gko::log::BatchLogData<_type>& logdata)
 
 
 #define GKO_DECLARE_ALL_AS_TEMPLATES \

--- a/core/solver/batch_bicgstab_kernels.hpp
+++ b/core/solver/batch_bicgstab_kernels.hpp
@@ -56,7 +56,7 @@ struct BatchBicgstabOptions {
     int max_its;
     RealType residual_tol;
     ::gko::stop::batch::ToleranceType tol_type;
-    int num_sh_vecs = 0;
+    int num_sh_vecs = 10;
 };
 
 

--- a/core/solver/batch_bicgstab_kernels.hpp
+++ b/core/solver/batch_bicgstab_kernels.hpp
@@ -52,6 +52,7 @@ namespace batch_bicgstab {
  */
 template <typename RealType>
 struct BatchBicgstabOptions {
+    int num_sh_vecs;
     preconditioner::batch::type preconditioner;
     int max_its;
     RealType residual_tol;

--- a/cuda/solver/batch_gmres_kernels.cu
+++ b/cuda/solver/batch_gmres_kernels.cu
@@ -77,7 +77,7 @@ namespace batch_gmres {
 template <typename T>
 using BatchGmresOptions = gko::kernels::batch_gmres::BatchGmresOptions<T>;
 
-#if GKO_CUDA_BATCH_HAVE_NO_SHMEM
+#if GKO_CUDA_BATCH_GMRES_HAVE_NO_SHMEM
 
 #define BATCH_GMRES_KERNEL_LAUNCH(_stoppertype, _prectype)                    \
     apply_kernel<stop::_stoppertype<ValueType>>                               \
@@ -99,14 +99,14 @@ using BatchGmresOptions = gko::kernels::batch_gmres::BatchGmresOptions<T>;
 template <typename BatchMatrixType, typename LogType, typename ValueType>
 static void apply_impl(std::shared_ptr<const CudaExecutor> exec,
                        const BatchGmresOptions<remove_complex<ValueType>> opts,
-                       LogType logger, const BatchMatrixType &a,
-                       const gko::batch_dense::UniformBatch<const ValueType> &b,
-                       const gko::batch_dense::UniformBatch<ValueType> &x)
+                       LogType logger, const BatchMatrixType& a,
+                       const gko::batch_dense::UniformBatch<const ValueType>& b,
+                       const gko::batch_dense::UniformBatch<ValueType>& x)
 {
     using real_type = gko::remove_complex<ValueType>;
     const size_type nbatch = a.num_batch;
-    const ValueType *const bptr = b.values;
-    ValueType *const xptr = x.values;
+    const ValueType* const bptr = b.values;
+    ValueType* const xptr = x.values;
 
     static_assert(default_block_size >= 2 * config::warp_size,
                   "Need at least two warps per block!");
@@ -126,7 +126,7 @@ static void apply_impl(std::shared_ptr<const CudaExecutor> exec,
         shared_size +=
             BatchIdentity<ValueType>::dynamic_work_size(a.num_rows, a.num_nnz) *
             sizeof(ValueType);
-#if GKO_CUDA_BATCH_HAVE_NO_SHMEM
+#if GKO_CUDA_BATCH_GMRES_HAVE_NO_SHMEM
         workspace = gko::Array<ValueType>(
             exec,
             static_cast<size_type>(shared_size * nbatch / sizeof(ValueType)));
@@ -141,7 +141,7 @@ static void apply_impl(std::shared_ptr<const CudaExecutor> exec,
         shared_size +=
             BatchJacobi<ValueType>::dynamic_work_size(a.num_rows, a.num_nnz) *
             sizeof(ValueType);
-#if GKO_CUDA_BATCH_HAVE_NO_SHMEM
+#if GKO_CUDA_BATCH_GMRES_HAVE_NO_SHMEM
         workspace = gko::Array<ValueType>(
             exec,
             static_cast<size_type>(shared_size * nbatch / sizeof(ValueType)));
@@ -160,11 +160,11 @@ static void apply_impl(std::shared_ptr<const CudaExecutor> exec,
 
 template <typename ValueType>
 void apply(std::shared_ptr<const CudaExecutor> exec,
-           const BatchGmresOptions<remove_complex<ValueType>> &opts,
-           const BatchLinOp *const a,
-           const matrix::BatchDense<ValueType> *const b,
-           matrix::BatchDense<ValueType> *const x,
-           log::BatchLogData<ValueType> &logdata)
+           const BatchGmresOptions<remove_complex<ValueType>>& opts,
+           const BatchLinOp* const a,
+           const matrix::BatchDense<ValueType>* const b,
+           matrix::BatchDense<ValueType>* const x,
+           log::BatchLogData<ValueType>& logdata)
 {
     using cu_value_type = cuda_type<ValueType>;
 
@@ -174,7 +174,7 @@ void apply(std::shared_ptr<const CudaExecutor> exec,
     const gko::batch_dense::UniformBatch<cu_value_type> x_b =
         get_batch_struct(x);
 
-    if (auto amat = dynamic_cast<const matrix::BatchCsr<ValueType> *>(a)) {
+    if (auto amat = dynamic_cast<const matrix::BatchCsr<ValueType>*>(a)) {
         // const gko::batch_csr::UniformBatch<cu_value_type> m_b =
         //     get_batch_struct(const_cast<matrix::BatchCsr<ValueType>
         //     *>(amat));

--- a/cuda/solver/batch_gmres_kernels.cu
+++ b/cuda/solver/batch_gmres_kernels.cu
@@ -81,7 +81,7 @@ using BatchGmresOptions = gko::kernels::batch_gmres::BatchGmresOptions<T>;
 
 #define BATCH_GMRES_KERNEL_LAUNCH(_stoppertype, _prectype)                    \
     apply_kernel<stop::_stoppertype<ValueType>>                               \
-        <<<nbatch, default_block_size>>>(shared_gap, opts.max_its,            \
+        <<<nbatch, default_block_size>>>(global_gap, opts.max_its,            \
                                          opts.residual_tol, opts.restart_num, \
                                          logger, _prectype<ValueType>(), a,   \
                                          bptr, xptr, workspace.get_data())
@@ -91,7 +91,7 @@ using BatchGmresOptions = gko::kernels::batch_gmres::BatchGmresOptions<T>;
 #define BATCH_GMRES_KERNEL_LAUNCH(_stoppertype, _prectype)                 \
     apply_kernel<stop::_stoppertype<ValueType>>                            \
         <<<nbatch, default_block_size, shared_size>>>(                     \
-            shared_gap, opts.max_its, opts.residual_tol, opts.restart_num, \
+            global_gap, opts.max_its, opts.residual_tol, opts.restart_num, \
             logger, _prectype<ValueType>(), a, bptr, xptr)
 
 #endif
@@ -117,7 +117,7 @@ static void apply_impl(std::shared_ptr<const CudaExecutor> exec,
     auto nrhs = b.num_rhs;
     auto nrows = a.num_rows;
     auto restart = opts.restart_num;
-    int shared_gap = 6 * nrows * nrhs + 3 * restart * nrhs +
+    int global_gap = 6 * nrows * nrhs + 3 * restart * nrhs +
                      (restart + 1) * nrhs + restart * (restart + 1) * nrhs +
                      nrows * (restart + 1) * nrhs;
     auto workspace = gko::Array<ValueType>(exec);

--- a/cuda/test/solver/batch_bicgstab_kernels.cpp
+++ b/cuda/test/solver/batch_bicgstab_kernels.cpp
@@ -102,7 +102,7 @@ protected:
     const int nrows = 3;
     const Options opts_1{gko::preconditioner::batch::type::none, 500,
                          static_cast<real_type>(1e3) * eps,
-                         gko::stop::batch::ToleranceType::relative};
+                         gko::stop::batch::ToleranceType::relative, 10};
     gko::test::LinSys<T> sys_1;
 
     std::function<void(Options, const Mtx*, const BDense*, BDense*, LogData&)>

--- a/include/ginkgo/batch_config.hpp.in
+++ b/include/ginkgo/batch_config.hpp.in
@@ -34,9 +34,9 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define GKO_INCLUDE_BATCH_CONFIG_H
 
 
-/* Should we compile with shared_memory for Batched Ginkgo? */
+/* Should we compile with shared_memory for Batched GMRES in Ginkgo? */
 // clang-format off
-#define GKO_CUDA_BATCH_HAVE_NO_SHMEM @GINKGO_CUDA_BATCH_HAVE_NO_SHMEM@
+#define GKO_CUDA_BATCH_GMRES_HAVE_NO_SHMEM @GINKGO_CUDA_BATCH_GMRES_HAVE_NO_SHMEM@
 // clang-format on
 
 

--- a/include/ginkgo/batch_config.hpp.in
+++ b/include/ginkgo/batch_config.hpp.in
@@ -30,15 +30,14 @@ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ******************************<GINKGO LICENSE>*******************************/
 
-#ifndef GKO_GINKGO_HPP_
-#define GKO_GINKGO_HPP_
+#ifndef GKO_INCLUDE_BATCH_CONFIG_H
+#define GKO_INCLUDE_BATCH_CONFIG_H
 
 
-#include <ginkgo/batch_config.hpp>
-#include <ginkgo/config.hpp>
+/* Should we compile with shared_memory for Batched Ginkgo? */
+// clang-format off
+#define GKO_CUDA_BATCH_HAVE_NO_SHMEM @GINKGO_CUDA_BATCH_HAVE_NO_SHMEM@
+// clang-format on
 
 
-#PUBLIC_HEADER_PLACE_HOLDER
-
-
-#endif  // GKO_GINKGO_HPP_
+#endif  // GKO_INCLUDE_BATCH_CONFIG_H

--- a/include/ginkgo/core/solver/batch_bicgstab.hpp
+++ b/include/ginkgo/core/solver/batch_bicgstab.hpp
@@ -109,6 +109,11 @@ public:
             preconditioner, preconditioner::batch::type::none);
 
         /**
+         * Number of shared vectors.
+         */
+        int GKO_FACTORY_PARAMETER_SCALAR(num_shared_vectors, 0);
+
+        /**
          * Maximum number iterations allowed.
          */
         int GKO_FACTORY_PARAMETER_SCALAR(max_iterations, 100);

--- a/include/ginkgo/core/solver/batch_bicgstab.hpp
+++ b/include/ginkgo/core/solver/batch_bicgstab.hpp
@@ -110,8 +110,9 @@ public:
 
         /**
          * Number of shared vectors.
+         * TODO: Remove this
          */
-        int GKO_FACTORY_PARAMETER_SCALAR(num_shared_vectors, 0);
+        int GKO_FACTORY_PARAMETER_SCALAR(num_shared_vectors, 10);
 
         /**
          * Maximum number iterations allowed.

--- a/include/ginkgo/ginkgo.hpp
+++ b/include/ginkgo/ginkgo.hpp
@@ -34,6 +34,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define GKO_GINKGO_HPP_
 
 
+#include <ginkgo/batch_config.hpp>
 #include <ginkgo/config.hpp>
 
 


### PR DESCRIPTION
This PR allows configuring the number of auxiliary vectors in shared memory for the batched BiCGSTAB solver. 

It also provides a compile time flag to switch between all shared and all global memory for batched GMRES.

Currently, the number of vectors in shared memory is a factory parameter, but that can be adapted as necessary. 

![dgb_expt_shared_0to5](https://user-images.githubusercontent.com/10301328/132234869-cf3ad043-2104-42c8-968f-c0ade689761a.png)

![speedup_wrt_global_mem](https://user-images.githubusercontent.com/10301328/132287286-ad8210b0-1ebc-48e1-86d1-825f3d23a9a8.png)