### PR TITLE
Automatically cancel earlier actions on the same branch

### DIFF
--- a/.github/abidiff.sh
+++ b/.github/abidiff.sh
@@ -6,4 +6,4 @@ popd
 
 bot_delete_comments_matching "Note: This PR changes the Ginkgo ABI"
 
-abidiff build-old/lib/libginkgod.so build-new/lib/libginkgod.so &> abi.diff || (bot_comment "Note: This PR changes the Ginkgo ABI:\n\`\`\`\n$(head -n2 abi.diff | tr '\n' ';' | sed 's/;/\\n/g')\`\`\`\nFor details check the full ABI diff under **Artifacts** [here]($JOB_URL)" && false)
+abidiff build-old/lib/libginkgod.so build-new/lib/libginkgod.so &> abi.diff || (bot_comment "Note: This PR changes the Ginkgo ABI:\n\`\`\`\n$(head -n2 abi.diff | tr '\n' ';' | sed 's/;/\\n/g')\`\`\`\nFor details check the full ABI diff under **Artifacts** [here]($JOB_URL)")

--- a/.github/workflows/bot-pr-created.yml
+++ b/.github/workflows/bot-pr-created.yml
@@ -1,7 +1,6 @@
 on:
   pull_request_target:
     types: [opened]
-
 name: OnNewPR
 jobs:
   label:

--- a/.github/workflows/bot-pr-updated.yml
+++ b/.github/workflows/bot-pr-updated.yml
@@ -3,7 +3,7 @@ on:
     types: [opened,synchronize]
 name: OnSyncPR
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 jobs:
   check-format:

--- a/.github/workflows/bot-pr-updated.yml
+++ b/.github/workflows/bot-pr-updated.yml
@@ -1,8 +1,10 @@
 on:
   pull_request_target:
     types: [opened,synchronize]
-
 name: OnSyncPR
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref }}
+  cancel-in-progress: true
 jobs:
   check-format:
     runs-on: ubuntu-18.04

--- a/.github/workflows/osx.yml
+++ b/.github/workflows/osx.yml
@@ -9,6 +9,10 @@ on:
         required: false
         default: false
 
+concurrency:
+  group: ${{ github.workflow}}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   osx-clang-omp:
     strategy:

--- a/.github/workflows/osx.yml
+++ b/.github/workflows/osx.yml
@@ -2,6 +2,13 @@ name: OSX-build
 
 on:
   push:
+    branches:
+      - 'master'
+      - 'develop'
+    tags:
+      - '**'
+  pull_request_target:
+    types: [opened,synchronize]
   workflow_dispatch:
     inputs:
       debug_enabled:
@@ -10,7 +17,7 @@ on:
         default: false
 
 concurrency:
-  group: ${{ github.workflow}}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ (github.head_ref && github.ref) || github.run_id }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/osx.yml
+++ b/.github/workflows/osx.yml
@@ -5,9 +5,10 @@ on:
     branches:
       - 'master'
       - 'develop'
+      - 'release/**'
     tags:
       - '**'
-  pull_request_target:
+  pull_request:
     types: [opened,synchronize]
   workflow_dispatch:
     inputs:

--- a/.github/workflows/windows-cygwin.yml
+++ b/.github/workflows/windows-cygwin.yml
@@ -9,6 +9,10 @@ on:
         required: false
         default: false
 
+concurrency:
+  group: ${{ github.workflow}}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   windows_cygwin:
     strategy:

--- a/.github/workflows/windows-cygwin.yml
+++ b/.github/workflows/windows-cygwin.yml
@@ -2,6 +2,13 @@ name: Windows-Cygwin
 
 on:
   push:
+    branches:
+      - 'master'
+      - 'develop'
+    tags:
+      - '**'
+  pull_request_target:
+    types: [opened,synchronize]
   workflow_dispatch:
     inputs:
       debug_enabled:
@@ -10,7 +17,7 @@ on:
         default: false
 
 concurrency:
-  group: ${{ github.workflow}}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ (github.head_ref && github.ref) || github.run_id }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/windows-cygwin.yml
+++ b/.github/workflows/windows-cygwin.yml
@@ -5,9 +5,10 @@ on:
     branches:
       - 'master'
       - 'develop'
+      - 'release/**'
     tags:
       - '**'
-  pull_request_target:
+  pull_request:
     types: [opened,synchronize]
   workflow_dispatch:
     inputs:

--- a/.github/workflows/windows-mingw.yml
+++ b/.github/workflows/windows-mingw.yml
@@ -2,6 +2,13 @@ name: Windows-MinGW
 
 on:
   push:
+    branches:
+      - 'master'
+      - 'develop'
+    tags:
+      - '**'
+  pull_request_target:
+    types: [opened,synchronize]
   workflow_dispatch:
     inputs:
       debug_enabled:
@@ -10,7 +17,7 @@ on:
         default: false
 
 concurrency:
-  group: ${{ github.workflow}}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ (github.head_ref && github.ref) || github.run_id }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/windows-mingw.yml
+++ b/.github/workflows/windows-mingw.yml
@@ -9,6 +9,10 @@ on:
         required: false
         default: false
 
+concurrency:
+  group: ${{ github.workflow}}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   windows_mingw:
     strategy:

--- a/.github/workflows/windows-mingw.yml
+++ b/.github/workflows/windows-mingw.yml
@@ -5,9 +5,10 @@ on:
     branches:
       - 'master'
       - 'develop'
+      - 'release/**'
     tags:
       - '**'
-  pull_request_target:
+  pull_request:
     types: [opened,synchronize]
   workflow_dispatch:
     inputs:

--- a/.github/workflows/windows-msvc-cuda.yml
+++ b/.github/workflows/windows-msvc-cuda.yml
@@ -5,9 +5,10 @@ on:
     branches:
       - 'master'
       - 'develop'
+      - 'release/**'
     tags:
       - '**'
-  pull_request_target:
+  pull_request:
     types: [opened,synchronize]
   workflow_dispatch:
     inputs:

--- a/.github/workflows/windows-msvc-cuda.yml
+++ b/.github/workflows/windows-msvc-cuda.yml
@@ -9,6 +9,10 @@ on:
         required: false
         default: false
 
+concurrency:
+  group: ${{ github.workflow}}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   windows_cuda:
     strategy:

--- a/.github/workflows/windows-msvc-cuda.yml
+++ b/.github/workflows/windows-msvc-cuda.yml
@@ -2,6 +2,13 @@ name: Windows-MSVC-CUDA (compile-only)
 
 on:
   push:
+    branches:
+      - 'master'
+      - 'develop'
+    tags:
+      - '**'
+  pull_request_target:
+    types: [opened,synchronize]
   workflow_dispatch:
     inputs:
       debug_enabled:
@@ -10,7 +17,7 @@ on:
         default: false
 
 concurrency:
-  group: ${{ github.workflow}}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ (github.head_ref && github.ref) || github.run_id }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/windows-msvc-ref.yml
+++ b/.github/workflows/windows-msvc-ref.yml
@@ -9,6 +9,10 @@ on:
         required: false
         default: false
 
+concurrency:
+  group: ${{ github.workflow}}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   windows_ref:
     strategy:

--- a/.github/workflows/windows-msvc-ref.yml
+++ b/.github/workflows/windows-msvc-ref.yml
@@ -5,9 +5,10 @@ on:
     branches:
       - 'master'
       - 'develop'
+      - 'release/**'
     tags:
       - '**'
-  pull_request_target:
+  pull_request:
     types: [opened,synchronize]
   workflow_dispatch:
     inputs:

--- a/.github/workflows/windows-msvc-ref.yml
+++ b/.github/workflows/windows-msvc-ref.yml
@@ -2,6 +2,13 @@ name: Windows-MSVC-Reference
 
 on:
   push:
+    branches:
+      - 'master'
+      - 'develop'
+    tags:
+      - '**'
+  pull_request_target:
+    types: [opened,synchronize]
   workflow_dispatch:
     inputs:
       debug_enabled:
@@ -10,7 +17,7 @@ on:
         default: false
 
 concurrency:
-  group: ${{ github.workflow}}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ (github.head_ref && github.ref) || github.run_id }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
This PR enables automatic cancellation of actions on outdated commits of a branch. This will also cancel already running actions. The feature is still in beta, so we might need to adjust it in the future. 

Github docs: https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#concurrency