### PR TITLE
Add format rebase bot command

### DIFF
--- a/.github/bot-pr-base.sh
+++ b/.github/bot-pr-base.sh
@@ -2,6 +2,11 @@
 
 source .github/bot-base.sh
 
+EXTENSION_REGEX='\.(cuh?|hpp|hpp\.inc?|cpp)$'
+FORMAT_HEADER_REGEX='^(benchmark|core|cuda|hip|include/ginkgo/core|omp|reference|dpcpp|common/unified)/'
+FORMAT_REGEX='^(common|examples|test_install)/'
+CLANG_FORMAT=clang-format-9
+
 echo -n "Collecting information on triggering PR"
 PR_URL=$(jq -r .pull_request.url "$GITHUB_EVENT_PATH")
 if [[ "$PR_URL" == "null" ]]; then

--- a/.github/bot-pr-format-base.sh
+++ b/.github/bot-pr-format-base.sh
@@ -2,10 +2,6 @@
 
 source .github/bot-pr-base.sh
 
-EXTENSION_REGEX='\.(cuh?|hpp|hpp\.inc?|cpp)$'
-FORMAT_HEADER_REGEX='^(benchmark|core|cuda|hip|include/ginkgo/core|omp|reference|dpcpp|common/unified)/'
-FORMAT_REGEX='^(common/cuda_hip|examples|test)/'
-
 echo "Retrieving PR file list"
 PR_FILES=$(bot_get_all_changed_files ${PR_URL})
 NUM=$(echo "${PR_FILES}" | wc -l)
@@ -34,7 +30,6 @@ cp /tmp/format_header.sh dev_tools/scripts/
 cp /tmp/update_ginkgo_header.sh dev_tools/scripts/
 
 # format files
-CLANG_FORMAT=clang-format-9
 dev_tools/scripts/add_license.sh
 dev_tools/scripts/update_ginkgo_header.sh
 for f in $(echo "$TO_FORMAT" | grep -E $FORMAT_HEADER_REGEX); do dev_tools/scripts/format_header.sh "$f"; done

--- a/.github/format-rebase.sh
+++ b/.github/format-rebase.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+source .github/bot-pr-base.sh
+
+git remote add base "$BASE_URL"
+git remote add fork "$HEAD_URL"
+
+git remote -v
+
+git fetch base $BASE_BRANCH
+git fetch fork $HEAD_BRANCH
+
+git config user.email "$USER_EMAIL"
+git config user.name "$USER_NAME"
+
+LOCAL_BRANCH=rebase-tmp-$HEAD_BRANCH
+git checkout -b $LOCAL_BRANCH fork/$HEAD_BRANCH
+
+# save scripts from develop
+pushd dev_tools/scripts
+cp add_license.sh format_header.sh update_ginkgo_header.sh /tmp
+popd
+
+bot_delete_comments_matching "Error: Rebase failed"
+
+DIFF_COMMAND="git diff --name-only --no-renames --diff-filter=AM HEAD~ | grep -E '$EXTENSION_REGEX'"
+
+# do the formatting rebase
+git rebase --empty=drop --no-keep-empty \
+    --exec "cp /tmp/add_license.sh /tmp/format_header.sh /tmp/update_ginkgo_header.sh dev_tools/scripts/ && \
+            dev_tools/scripts/add_license.sh && dev_tools/scripts/update_ginkgo_header.sh && \
+            for f in \$($DIFF_COMMAND | grep -E '$FORMAT_HEADER_REGEX'); do dev_tools/scripts/format_header.sh \$f; done && \
+            for f in \$($DIFF_COMMAND | grep -E '$FORMAT_REGEX'); do $CLANG_FORMAT -i \$f; done && \
+            git checkout dev_tools/scripts && git add . && git commit --amend --no-edit --allow-empty" \
+    base/$BASE_BRANCH 2>&1 || bot_error "Rebase failed, see the related [Action]($JOB_URL) for details"
+
+# push back
+git push --force-with-lease fork $LOCAL_BRANCH:$HEAD_BRANCH 2>&1 || bot_error "Cannot push rebased branch, are edits for maintainers allowed?"

--- a/.github/rebase.sh
+++ b/.github/rebase.sh
@@ -20,4 +20,4 @@ bot_delete_comments_matching "Error: Rebase failed"
 git rebase base/$BASE_BRANCH 2>&1 || bot_error "Rebase failed, see the related [Action]($JOB_URL) for details"
 
 # push back
-git push --force-with-lease fork $LOCAL_BRANCH:$HEAD_BRANCH 2>&1 || bot_error "Cannot push rebased branch, are edits for maintainers allowed?"
+git push --force-with-lease fork $LOCAL_BRANCH:$HEAD_BRANCH 2>&1 || bot_error "Cannot push rebased branch, are edits for maintainers allowed, or were changes pushed while the rebase was running?"

--- a/.github/workflows/bot-pr-comment.yml
+++ b/.github/workflows/bot-pr-comment.yml
@@ -78,3 +78,9 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.BOT_TOKEN }}
       run: cp .github/format-rebase.sh /tmp && /tmp/format-rebase.sh
+    - name: Upload code formatting diffs
+      if: success()
+      uses: actions/upload-artifact@v2
+      with:
+          name: patch
+          path: diff.patch

--- a/.github/workflows/bot-pr-comment.yml
+++ b/.github/workflows/bot-pr-comment.yml
@@ -63,3 +63,18 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.BOT_TOKEN }}
       run: cp .github/rebase.sh /tmp && /tmp/rebase.sh
+  format-rebase:
+    name: format-rebase
+    if: github.event.issue.pull_request != '' && github.event.comment.body == 'format-rebase!' && (github.event.comment.author_association == 'COLLABORATOR' || github.event.comment.author_association == 'MEMBER' || github.event.comment.author_association == 'OWNER')
+    runs-on: ubuntu-18.04
+    steps:
+    - name: Checkout the latest code
+      uses: actions/checkout@v2
+      with:
+        ref: develop
+        fetch-depth: 0
+        persist-credentials: false
+    - name: Automatic Formatting Rebase
+      env:
+        GITHUB_TOKEN: ${{ secrets.BOT_TOKEN }}
+      run: cp .github/format-rebase.sh /tmp && /tmp/format-rebase.sh


### PR DESCRIPTION
Instead of filling the git history with ` format `  commits, this PR adds a ` format-rebase!`  command that formats each individual commit instead by rewriting the history.