### PR TITLE
Automatic tuning for batch Bicgstab: shared memory usage and warps per block

### DIFF
--- a/benchmark/run_all_benchmarks.sh
+++ b/benchmark/run_all_benchmarks.sh
@@ -176,6 +176,13 @@ else
     PRINT_RES_ITER_STR="--print_residuals_and_iters=true"
 fi
 
+# Control whether to run dense direct solver in addition, in order to compute 'exact' solution
+if  [ ! "${COMPUTE_BATCH_ERRORS}" ] || [ "${COMPUTE_BATCH_ERRORS}" -eq 0 ]; then
+    COMPUTE_BATCH_ERRORS_STR="--compute_errors=false"
+else
+    COMPUTE_BATCH_ERRORS_STR="--compute_errors=true"
+fi
+
 if  [ ! "${BATCH_SCALING}" ] ; then
     BATCH_SCALING_STR="--batch_scaling=none"
     echo "BATCH_SCALING environment variable not set - assuming \"none\"" 1>&2
@@ -392,7 +399,7 @@ run_batch_solver_benchmarks() {
                     --executor="${EXECUTOR}" --batch_solvers="${BATCH_SOLVERS}" \
                     --preconditioners="${PRECONDS}" \
                     --num_duplications="${NUM_BATCH_DUP}" "${BATCH_SCALING_STR}" \
-                    "${PRINT_RES_ITER_STR}" \
+                    "${PRINT_RES_ITER_STR}" "${COMPUTE_BATCH_ERRORS_STR}" \
                     --num_batches="${NUM_BATCH_ENTRIES}" "${SS_STR}" \
                     --num_shared_vecs="${NUM_SHARED_VECS}" \
                     --max_iters=${SOLVERS_MAX_ITERATIONS} --rel_res_goal=${SOLVERS_PRECISION} \

--- a/benchmark/utils/general.hpp
+++ b/benchmark/utils/general.hpp
@@ -759,6 +759,11 @@ private:
                    (cur_it >= max_it ||
                     managed_timer.get_total_time() >= max_runtime);
         }
+
+        bool is_last_iteration() const
+        {
+            return cur_it >= min_it && cur_it == max_it - 1;
+        }
     };
 
     /**

--- a/common/cuda_hip/solver/batch_bicgstab_kernels.hpp.inc
+++ b/common/cuda_hip/solver/batch_bicgstab_kernels.hpp.inc
@@ -178,14 +178,13 @@ __device__ __forceinline__ void update_x_middle(
 
 template <typename StopType, typename PrecType, typename LogType,
           typename BatchMatrixType, typename ValueType>
-__global__ void apply_kernel(const int num_sh_vecs, const int shared_gap,
-                             const int max_iter,
-                             const gko::remove_complex<ValueType> tol,
-                             LogType logger, PrecType prec_shared,
-                             const BatchMatrixType a,
-                             const ValueType* const __restrict__ b,
-                             ValueType* const __restrict__ x,
-                             ValueType* const __restrict__ workspace = nullptr)
+__global__ void apply_kernel(
+    const int shared_gap,
+    const gko::kernels::batch_bicgstab::StorageConfig sconf, const int max_iter,
+    const gko::remove_complex<ValueType> tol, LogType logger,
+    PrecType prec_shared, const BatchMatrixType a,
+    const ValueType* const __restrict__ b, ValueType* const __restrict__ x,
+    ValueType* const __restrict__ workspace = nullptr)
 {
     using real_type = typename gko::remove_complex<ValueType>;
     const auto nbatch = a.num_batch;
@@ -196,7 +195,9 @@ __global__ void apply_kernel(const int num_sh_vecs, const int shared_gap,
     auto warp_grp = group::tiled_partition<tile_size>(thread_block);
 
     for (size_type ibatch = blockIdx.x; ibatch < nbatch; ibatch += gridDim.x) {
-        int gmem_offset = ibatch * (shared_gap * (10 - num_sh_vecs));
+        // int gmem_offset = ibatch * (shared_gap * (10 - num_sh_vecs));
+        const int gmem_offset =
+            ibatch * sconf.gmem_stride_bytes / sizeof(ValueType);
         extern __shared__ char local_mem_sh[];
 
         ValueType* p_hat_sh;
@@ -210,55 +211,55 @@ __global__ void apply_kernel(const int num_sh_vecs, const int shared_gap,
         ValueType* x_sh;
         ValueType* prec_work_sh;
 
-        if (num_sh_vecs >= 1) {
+        if (sconf.n_shared >= 1) {
             p_hat_sh = reinterpret_cast<ValueType*>(local_mem_sh);
         } else {
             p_hat_sh = workspace + gmem_offset;
         }
-        if (num_sh_vecs == 1) {
+        if (sconf.n_shared == 1) {
             s_hat_sh = workspace + gmem_offset;
         } else {
             s_hat_sh = p_hat_sh + shared_gap;
         }
-        if (num_sh_vecs == 2) {
-            p_sh = workspace + gmem_offset;
-        } else {
-            p_sh = s_hat_sh + shared_gap;
-        }
-        if (num_sh_vecs == 3) {
-            s_sh = workspace + gmem_offset;
-        } else {
-            s_sh = p_sh + shared_gap;
-        }
-        if (num_sh_vecs == 4) {
-            r_sh = workspace + gmem_offset;
-        } else {
-            r_sh = s_sh + shared_gap;
-        }
-        if (num_sh_vecs == 5) {
-            r_hat_sh = workspace + gmem_offset;
-        } else {
-            r_hat_sh = r_sh + shared_gap;
-        }
-        if (num_sh_vecs == 6) {
+        if (sconf.n_shared == 2) {
             v_sh = workspace + gmem_offset;
         } else {
-            v_sh = r_hat_sh + shared_gap;
+            v_sh = s_hat_sh + shared_gap;
         }
-        if (num_sh_vecs == 7) {
+        if (sconf.n_shared == 3) {
             t_sh = workspace + gmem_offset;
         } else {
             t_sh = v_sh + shared_gap;
         }
-        if (num_sh_vecs == 8) {
+        if (sconf.prec_shared) {
+            prec_work_sh = t_sh + shared_gap;
+        } else {
+            prec_work_sh = workspace + gmem_offset;
+        }
+        if (sconf.n_shared == 4) {
+            p_sh = workspace + gmem_offset;
+        } else {
+            p_sh = prec_work_sh + PrecType::dynamic_work_size(nrows, a.num_nnz);
+        }
+        if (sconf.n_shared == 5) {
+            s_sh = workspace + gmem_offset;
+        } else {
+            s_sh = p_sh + shared_gap;
+        }
+        if (sconf.n_shared == 6) {
+            r_sh = workspace + gmem_offset;
+        } else {
+            r_sh = s_sh + shared_gap;
+        }
+        if (sconf.n_shared == 7) {
+            r_hat_sh = workspace + gmem_offset;
+        } else {
+            r_hat_sh = r_sh + shared_gap;
+        }
+        if (sconf.n_shared == 8) {
             x_sh = workspace + gmem_offset;
         } else {
-            x_sh = t_sh + shared_gap;
-        }
-        if (num_sh_vecs == 9) {
-            prec_work_sh = workspace + gmem_offset;
-        } else {
-            prec_work_sh = x_sh + shared_gap;
+            x_sh = r_hat_sh + shared_gap;
         }
 
         __shared__ UninitializedArray<ValueType, 1> rho_old_sh;

--- a/common/cuda_hip/solver/batch_bicgstab_kernels.hpp.inc
+++ b/common/cuda_hip/solver/batch_bicgstab_kernels.hpp.inc
@@ -179,7 +179,7 @@ __device__ __forceinline__ void update_x_middle(
 template <typename StopType, typename PrecType, typename LogType,
           typename BatchMatrixType, typename ValueType>
 __global__ void apply_kernel(
-    const int shared_gap,
+    const int padded_vec_len,
     const gko::kernels::batch_bicgstab::StorageConfig sconf, const int max_iter,
     const gko::remove_complex<ValueType> tol, LogType logger,
     PrecType prec_shared, const BatchMatrixType a,
@@ -195,7 +195,7 @@ __global__ void apply_kernel(
     auto warp_grp = group::tiled_partition<tile_size>(thread_block);
 
     for (size_type ibatch = blockIdx.x; ibatch < nbatch; ibatch += gridDim.x) {
-        // int gmem_offset = ibatch * (shared_gap * (10 - num_sh_vecs));
+        // int gmem_offset = ibatch * (padded_vec_len * (10 - num_sh_vecs));
         const int gmem_offset =
             ibatch * sconf.gmem_stride_bytes / sizeof(ValueType);
         extern __shared__ char local_mem_sh[];
@@ -219,24 +219,24 @@ __global__ void apply_kernel(
         if (sconf.n_shared == 1) {
             s_hat_sh = workspace + gmem_offset;
         } else {
-            s_hat_sh = p_hat_sh + shared_gap;
+            s_hat_sh = p_hat_sh + padded_vec_len;
         }
         if (sconf.n_shared == 2) {
             v_sh = workspace + gmem_offset;
         } else {
-            v_sh = s_hat_sh + shared_gap;
+            v_sh = s_hat_sh + padded_vec_len;
         }
         if (sconf.n_shared == 3) {
             t_sh = workspace + gmem_offset;
         } else {
-            t_sh = v_sh + shared_gap;
+            t_sh = v_sh + padded_vec_len;
         }
-        if (sconf.prec_shared) {
-            prec_work_sh = t_sh + shared_gap;
-        } else {
+        if (!sconf.prec_shared && sconf.n_shared == 4) {
             prec_work_sh = workspace + gmem_offset;
+        } else {
+            prec_work_sh = t_sh + padded_vec_len;
         }
-        if (sconf.n_shared == 4) {
+        if (sconf.n_shared == 4 && sconf.prec_shared) {
             p_sh = workspace + gmem_offset;
         } else {
             p_sh = prec_work_sh + PrecType::dynamic_work_size(nrows, a.num_nnz);
@@ -244,22 +244,22 @@ __global__ void apply_kernel(
         if (sconf.n_shared == 5) {
             s_sh = workspace + gmem_offset;
         } else {
-            s_sh = p_sh + shared_gap;
+            s_sh = p_sh + padded_vec_len;
         }
         if (sconf.n_shared == 6) {
             r_sh = workspace + gmem_offset;
         } else {
-            r_sh = s_sh + shared_gap;
+            r_sh = s_sh + padded_vec_len;
         }
         if (sconf.n_shared == 7) {
             r_hat_sh = workspace + gmem_offset;
         } else {
-            r_hat_sh = r_sh + shared_gap;
+            r_hat_sh = r_sh + padded_vec_len;
         }
         if (sconf.n_shared == 8) {
             x_sh = workspace + gmem_offset;
         } else {
-            x_sh = r_hat_sh + shared_gap;
+            x_sh = r_hat_sh + padded_vec_len;
         }
 
         __shared__ UninitializedArray<ValueType, 1> rho_old_sh;

--- a/core/solver/batch_bicgstab_kernels.hpp
+++ b/core/solver/batch_bicgstab_kernels.hpp
@@ -164,12 +164,12 @@ StorageConfig compute_shared_storage(const int shared_mem_per_sm,
     const int num_priority_vecs = 4;
     const int prec_storage =
         Prectype::dynamic_work_size(num_rows, num_nz) * sizeof(ValueType);
+    // Prioritize caching of matrix in L1 cache
     // for now, this is hard-coded for CSR
     // TODO: add functions to batch matrix formats to return storage per batch
-    const int matrix_storage = (num_rows + 1) * sizeof(int) +
-                               num_nz * (sizeof(int) + sizeof(ValueType));
-    // Prioritize caching of matrix in L1 cache
-    int rem_shared = shared_mem_per_sm - matrix_storage -
+    // const int matrix_storage = (num_rows + 1) * sizeof(int) +
+    //                           num_nz * (sizeof(int) + sizeof(ValueType));
+    int rem_shared = shared_mem_per_sm - /*matrix_storage -*/
                      num_value_scalars * sizeof(ValueType) -
                      num_real_scalars * sizeof(real_type);
     StorageConfig sconf{false, 0, 9, 0};

--- a/cuda/base/executor.cpp
+++ b/cuda/base/executor.cpp
@@ -261,6 +261,9 @@ void CudaExecutor::set_gpu_property()
             kernels::cuda::config::warp_size;
         this->get_exec_info().max_subgroup_size =
             kernels::cuda::config::warp_size;
+        GKO_ASSERT_NO_CUDA_ERRORS(cudaDeviceGetAttribute(
+            &this->get_exec_info().max_shared_memory_per_workgroup,
+            cudaDevAttrMaxSharedMemoryPerBlock, this->get_device_id()));
     }
 }
 

--- a/cuda/base/kernel_config.cuh
+++ b/cuda/base/kernel_config.cuh
@@ -48,7 +48,7 @@ namespace cuda {
  * \tparam ValueType  The scalar type used for computations.
  */
 template <typename ValueType>
-inline void configure_shared_memory()
+inline void configure_shared_memory_banks()
 {
     if (sizeof(ValueType) == 4) {
         cudaDeviceSetSharedMemConfig(cudaSharedMemBankSizeFourByte);

--- a/cuda/solver/batch_bicgstab_kernels.cu
+++ b/cuda/solver/batch_bicgstab_kernels.cu
@@ -112,9 +112,12 @@ int get_max_dynamic_shared_memory(std::shared_ptr<const CudaExecutor> exec,
                            cudaDevAttrMaxSharedMemoryPerMultiprocessor,
                            exec->get_device_id());
     printf(" Max shared mem per SM = %d.\n", shmem_per_sm);
-    const int max_shared_pc =
+    int max_shared_pc =
         100 - static_cast<int>(static_cast<double>(required_cache_storage) /
                                shmem_per_sm * 100);
+    if (max_shared_pc <= 0) {
+        max_shared_pc = 1;
+    }
     printf(" Max shared pc required = %d.\n", max_shared_pc);
     GKO_ASSERT_NO_CUDA_ERRORS(cudaFuncSetAttribute(
         apply_kernel<StopType, PrecType, LogType, BatchMatrixType, ValueType>,

--- a/cuda/solver/batch_richardson_kernels.cu
+++ b/cuda/solver/batch_richardson_kernels.cu
@@ -91,19 +91,19 @@ template <typename BatchMatrixType, typename LogType, typename ValueType>
 static void apply_impl(
     std::shared_ptr<const CudaExecutor> exec,
     const BatchRichardsonOptions<remove_complex<ValueType>> opts,
-    LogType logger, const BatchMatrixType &a,
-    const gko::batch_dense::UniformBatch<const ValueType> &b,
-    const gko::batch_dense::UniformBatch<ValueType> &x)
+    LogType logger, const BatchMatrixType& a,
+    const gko::batch_dense::UniformBatch<const ValueType>& b,
+    const gko::batch_dense::UniformBatch<ValueType>& x)
 {
     using real_type = gko::remove_complex<ValueType>;
     const size_type nbatch = a.num_batch;
     if (b.num_rhs > 1) {
         GKO_NOT_IMPLEMENTED;
     }
-    const ValueType *const bptr = b.values;
-    ValueType *const xptr = x.values;
+    const ValueType* const bptr = b.values;
+    ValueType* const xptr = x.values;
 
-    gko::kernels::cuda::configure_shared_memory<ValueType>();
+    gko::kernels::cuda::configure_shared_memory_banks<ValueType>();
 
     int shared_size =
 #if GKO_CUDA_BATCH_USE_DYNAMIC_SHARED_MEM
@@ -145,11 +145,11 @@ static void apply_impl(
 
 template <typename ValueType>
 void apply(std::shared_ptr<const CudaExecutor> exec,
-           const BatchRichardsonOptions<remove_complex<ValueType>> &opts,
-           const BatchLinOp *const a,
-           const matrix::BatchDense<ValueType> *const b,
-           matrix::BatchDense<ValueType> *const x,
-           log::BatchLogData<ValueType> &logdata)
+           const BatchRichardsonOptions<remove_complex<ValueType>>& opts,
+           const BatchLinOp* const a,
+           const matrix::BatchDense<ValueType>* const b,
+           matrix::BatchDense<ValueType>* const x,
+           log::BatchLogData<ValueType>& logdata)
 {
     using cu_value_type = cuda_type<ValueType>;
 
@@ -161,7 +161,7 @@ void apply(std::shared_ptr<const CudaExecutor> exec,
 
     const gko::batch_dense::UniformBatch<cu_value_type> x_b =
         get_batch_struct(x);
-    if (auto amat = dynamic_cast<const matrix::BatchCsr<ValueType> *>(a)) {
+    if (auto amat = dynamic_cast<const matrix::BatchCsr<ValueType>*>(a)) {
         auto m_b = get_batch_struct(amat);
         auto b_b = get_batch_struct(b);
         apply_impl(exec, opts, logger, m_b, b_b, x_b);

--- a/cuda/test/solver/CMakeLists.txt
+++ b/cuda/test/solver/CMakeLists.txt
@@ -1,4 +1,5 @@
 ginkgo_create_test(batch_bicgstab_kernels)
+ginkgo_create_cuda_test(batch_bicgstab_allocation)
 ginkgo_create_test(batch_cg_kernels)
 ginkgo_create_test(batch_direct_kernels)
 ginkgo_create_test(batch_gmres_kernels)

--- a/cuda/test/solver/batch_bicgstab_allocation.cu
+++ b/cuda/test/solver/batch_bicgstab_allocation.cu
@@ -77,9 +77,9 @@ TEST(BatchBicgstab, AssignsPriorityVectorsToSharedMemoryFirst)
     const int nrows = 5;
     const int nrhs = 1;
     const int nnz = 16;
-    const int matrix_storage =
-        6 * sizeof(int) + nnz * (sizeof(int) + sizeof(T));
-    int shmem_per_sm = (2 * nrows + 7) * sizeof(T) + matrix_storage;
+    // const int matrix_storage =
+    //    6 * sizeof(int) + nnz * (sizeof(int) + sizeof(T));
+    int shmem_per_sm = (2 * nrows + 7) * sizeof(T) /*+ matrix_storage*/;
     const int gmem_batch_storage = 8 * nrows * sizeof(T);
 
     const auto conf =
@@ -99,9 +99,9 @@ TEST(BatchBicgstab, CanAssignAllVectorsToSharedMemory)
     const int nrows = 5;
     const int nrhs = 1;
     const int nnz = 16;
-    const int matrix_storage =
-        6 * sizeof(int) + nnz * (sizeof(int) + sizeof(T));
-    const int shmem_per_sm = (10 * nrows + 7) * sizeof(T) + matrix_storage;
+    // const int matrix_storage =
+    //    6 * sizeof(int) + nnz * (sizeof(int) + sizeof(T));
+    const int shmem_per_sm = (10 * nrows + 7) * sizeof(T) /*+ matrix_storage*/;
 
     const auto conf =
         gko::kernels::batch_bicgstab::compute_shared_storage<PC, T>(
@@ -120,9 +120,9 @@ TEST(BatchBicgstab, AssignsMultipleRHSCorrectly)
     const int nrows = 5;
     const int nrhs = 3;
     const int nnz = 16;
-    const int matrix_storage =
-        6 * sizeof(int) + nnz * (sizeof(int) + sizeof(T));
-    int shmem_per_sm = 3 * nrhs * nrows * sizeof(T) + matrix_storage;
+    // const int matrix_storage =
+    //    6 * sizeof(int) + nnz * (sizeof(int) + sizeof(T));
+    int shmem_per_sm = 3 * nrhs * nrows * sizeof(T) /*+ matrix_storage*/;
 
     const auto conf =
         gko::kernels::batch_bicgstab::compute_shared_storage<PC, T>(

--- a/cuda/test/solver/batch_bicgstab_allocation.cu
+++ b/cuda/test/solver/batch_bicgstab_allocation.cu
@@ -1,0 +1,141 @@
+/*******************************<GINKGO LICENSE>******************************
+Copyright (c) 2017-2021, the Ginkgo authors
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+******************************<GINKGO LICENSE>*******************************/
+
+
+#include <gtest/gtest.h>
+
+
+#include "core/matrix/batch_struct.hpp"
+#include "core/solver/batch_bicgstab_kernels.hpp"
+#include "cuda/base/config.hpp"
+#include "cuda/components/cooperative_groups.cuh"
+#include "cuda/matrix/batch_struct.hpp"
+
+
+namespace gko {
+namespace kernels {
+namespace cuda {
+#include "common/cuda_hip/preconditioner/batch_jacobi.hpp.inc"
+}
+}  // namespace kernels
+}  // namespace gko
+
+
+TEST(BatchBicgstab, CanAssignVectorsToGlobalMemory)
+{
+    using T = double;
+    using PC = gko::kernels::cuda::BatchJacobi<T>;
+    const int nrows = 5;
+    const int nrhs = 1;
+    const int nnz = 16;
+    size_t shmem_per_sm = 64;
+
+    auto conf = gko::kernels::batch_bicgstab::compute_shared_storage<PC, T>(
+        shmem_per_sm, nrows, nnz, nrhs);
+
+    ASSERT_FALSE(conf.p_hat_shared);
+    ASSERT_FALSE(conf.s_hat_shared);
+    ASSERT_FALSE(conf.v_shared);
+    ASSERT_FALSE(conf.t_shared);
+    ASSERT_FALSE(conf.prec_shared);
+    ASSERT_EQ(conf.n_shared, 0);
+    ASSERT_EQ(conf.n_global, 9);
+}
+
+TEST(BatchBicgstab, AssignsPriorityVectorsToSharedMemoryFirst)
+{
+    using T = double;
+    using PC = gko::kernels::cuda::BatchJacobi<T>;
+    const int nrows = 5;
+    const int nrhs = 1;
+    const int nnz = 16;
+    const int matrix_storage =
+        6 * sizeof(int) + nnz * (sizeof(int) + sizeof(T));
+    int shmem_per_sm = (2 * nrows + 7) * sizeof(T) + matrix_storage;
+
+    auto conf = gko::kernels::batch_bicgstab::compute_shared_storage<PC, T>(
+        shmem_per_sm, nrows, nnz, nrhs);
+
+    ASSERT_TRUE(conf.p_hat_shared);
+    ASSERT_TRUE(conf.s_hat_shared);
+    ASSERT_FALSE(conf.v_shared);
+    ASSERT_FALSE(conf.t_shared);
+    ASSERT_FALSE(conf.prec_shared);
+    ASSERT_EQ(conf.n_shared, 2);
+    ASSERT_EQ(conf.n_global, 7);
+}
+
+TEST(BatchBicgstab, CanAssignAllVectorsToSharedMemory)
+{
+    using T = double;
+    using PC = gko::kernels::cuda::BatchJacobi<T>;
+    const int nrows = 5;
+    const int nrhs = 1;
+    const int nnz = 16;
+    const int matrix_storage =
+        6 * sizeof(int) + nnz * (sizeof(int) + sizeof(T));
+    const int shmem_per_sm = (10 * nrows + 7) * sizeof(T) + matrix_storage;
+
+    auto conf = gko::kernels::batch_bicgstab::compute_shared_storage<PC, T>(
+        shmem_per_sm, nrows, nnz, nrhs);
+
+    ASSERT_TRUE(conf.p_hat_shared);
+    ASSERT_TRUE(conf.s_hat_shared);
+    ASSERT_TRUE(conf.v_shared);
+    ASSERT_TRUE(conf.t_shared);
+    ASSERT_TRUE(conf.prec_shared);
+    ASSERT_EQ(conf.n_shared, 9);
+    ASSERT_EQ(conf.n_global, 0);
+}
+
+TEST(BatchBicgstab, AssignsMultipleRHSCorrectly)
+{
+    using T = double;
+    using PC = gko::kernels::cuda::BatchJacobi<T>;
+    const int nrows = 5;
+    const int nrhs = 3;
+    const int nnz = 16;
+    const int matrix_storage =
+        6 * sizeof(int) + nnz * (sizeof(int) + sizeof(T));
+    int shmem_per_sm = 3 * nrhs * nrows * sizeof(T) + matrix_storage;
+
+    auto conf = gko::kernels::batch_bicgstab::compute_shared_storage<PC, T>(
+        shmem_per_sm, nrows, nnz, nrhs);
+
+    ASSERT_TRUE(conf.p_hat_shared);
+    ASSERT_TRUE(conf.s_hat_shared);
+    ASSERT_FALSE(conf.v_shared);
+    ASSERT_FALSE(conf.t_shared);
+    ASSERT_FALSE(conf.prec_shared);
+    ASSERT_EQ(conf.n_shared, 2);
+    ASSERT_EQ(conf.n_global, 7);
+}

--- a/cuda/test/solver/batch_bicgstab_allocation.cu
+++ b/cuda/test/solver/batch_bicgstab_allocation.cu
@@ -56,7 +56,7 @@ TEST(BatchBicgstab, CanAssignVectorsToGlobalMemory)
     const int nrows = 5;
     const int nrhs = 1;
     const int nnz = 16;
-    size_t shmem_per_sm = 64;
+    size_t shmem_per_sm = 4;
     const int batch_storage = 10 * nrows * sizeof(T);
 
     const auto conf =
@@ -76,9 +76,7 @@ TEST(BatchBicgstab, AssignsPriorityVectorsToSharedMemoryFirst)
     const int nrows = 5;
     const int nrhs = 1;
     const int nnz = 16;
-    // const int matrix_storage =
-    //    6 * sizeof(int) + nnz * (sizeof(int) + sizeof(T));
-    int shmem_per_sm = (2 * nrows + 7) * sizeof(T) /*+ matrix_storage*/;
+    int shmem_per_sm = (2 * nrows) * sizeof(T);
     const int gmem_batch_storage = 8 * nrows * sizeof(T);
 
     const auto conf =
@@ -98,9 +96,7 @@ TEST(BatchBicgstab, CanAssignAllVectorsToSharedMemory)
     const int nrows = 5;
     const int nrhs = 1;
     const int nnz = 16;
-    // const int matrix_storage =
-    //    6 * sizeof(int) + nnz * (sizeof(int) + sizeof(T));
-    const int shmem_per_sm = (10 * nrows + 7) * sizeof(T) /*+ matrix_storage*/;
+    const int shmem_per_sm = (10 * nrows) * sizeof(T);
 
     const auto conf =
         gko::kernels::batch_bicgstab::compute_shared_storage<PC, T>(
@@ -119,17 +115,15 @@ TEST(BatchBicgstab, AssignsMultipleRHSCorrectly)
     const int nrows = 5;
     const int nrhs = 3;
     const int nnz = 16;
-    // const int matrix_storage =
-    //    6 * sizeof(int) + nnz * (sizeof(int) + sizeof(T));
-    int shmem_per_sm = 3 * nrhs * nrows * sizeof(T) /*+ matrix_storage*/;
+    int shmem_per_sm = 3 * nrhs * nrows * sizeof(T);
 
     const auto conf =
         gko::kernels::batch_bicgstab::compute_shared_storage<PC, T>(
             shmem_per_sm, nrows, nnz, nrhs);
 
-    ASSERT_EQ(conf.n_shared, 1);
-    ASSERT_EQ(conf.n_global, 8);
+    ASSERT_EQ(conf.n_shared, 3);
+    ASSERT_EQ(conf.n_global, 6);
     ASSERT_FALSE(conf.prec_shared);
     ASSERT_EQ(conf.gmem_stride_bytes,
-              (((8 * nrows * nrhs + nrows) * sizeof(T) - 1) / 32 + 1) * 32);
+              (((6 * nrows * nrhs + nrows) * sizeof(T) - 1) / 32 + 1) * 32);
 }

--- a/cuda/test/solver/batch_bicgstab_allocation.cu
+++ b/cuda/test/solver/batch_bicgstab_allocation.cu
@@ -30,7 +30,6 @@ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ******************************<GINKGO LICENSE>*******************************/
 
-
 #include <gtest/gtest.h>
 
 

--- a/cuda/test/solver/batch_bicgstab_kernels.cpp
+++ b/cuda/test/solver/batch_bicgstab_kernels.cpp
@@ -138,15 +138,25 @@ TYPED_TEST_SUITE(BatchBicgstab, gko::test::ValueTypes);
 
 TYPED_TEST(BatchBicgstab, SolvesStencilSystem)
 {
-    auto r_1 = gko::test::solve_poisson_uniform(
-        this->cuexec, this->solve_fn, this->scale_mat, this->scale_vecs,
-        this->opts_1, this->sys_1, 1);
+    using value_type = typename TestFixture::value_type;
+    using solver_type = gko::solver::BatchBicgstab<value_type>;
+    using opts_type = typename TestFixture::Options;
+    constexpr bool issingle =
+        std::is_same<gko::remove_complex<value_type>, float>::value;
+    const float solver_restol = issingle ? 50 * this->eps : this->eps;
+    const opts_type opts{gko::preconditioner::batch::type::none, 500,
+                         solver_restol,
+                         gko::stop::batch::ToleranceType::relative};
+    auto r_sys = gko::test::generate_solvable_batch_system<value_type>(
+        this->exec, this->nbatch, 11, 1, false);
+    auto r_factory = this->create_factory(this->exec, opts);
+    const double iter_tol = 0.01;
+    const double res_tol = 10 * r<value_type>::value;
+    const double sol_tol = 10 * solver_restol;
 
-    GKO_ASSERT_BATCH_MTX_NEAR(r_1.x, this->sys_1.xex, this->eps);
-    for (size_t ib = 0; ib < this->nbatch; ib++) {
-        ASSERT_LE(r_1.resnorm->at(ib, 0, 0) / this->sys_1.bnorm->at(ib, 0, 0),
-                  this->opts_1.residual_tol);
-    }
+    gko::test::compare_with_reference<value_type, solver_type>(
+        this->cuexec, r_sys, r_factory.get(), false, iter_tol, res_tol,
+        sol_tol);
 }
 
 

--- a/hip/base/executor.hip.cpp
+++ b/hip/base/executor.hip.cpp
@@ -276,6 +276,9 @@ void HipExecutor::set_gpu_property()
 #endif  // GINKGO_HIP_PLATFORM_NVCC
         this->get_exec_info().max_subgroup_size =
             kernels::hip::config::warp_size;
+        GKO_ASSERT_NO_HIP_ERRORS(hipDeviceGetAttribute(
+            &this->get_exec_info().max_shared_memory_per_workgroup,
+            hipDeviceAttributeMaxSharedMemoryPerBlock, this->get_device_id()));
     }
 }
 

--- a/hip/solver/batch_bicgstab_kernels.hip.cpp
+++ b/hip/solver/batch_bicgstab_kernels.hip.cpp
@@ -101,8 +101,7 @@ static void apply_impl(
 
     const size_t prec_size =
         PrecType::dynamic_work_size(shared_gap, a.num_nnz) * sizeof(ValueType);
-    // TODO: Query this from runtime
-    const int shmem_per_blk = 48000;
+    const int shmem_per_blk = exec->get_max_shared_memory_per_block();
     const auto sconf =
         gko::kernels::batch_bicgstab::compute_shared_storage<PrecType,
                                                              ValueType>(
@@ -141,12 +140,12 @@ void apply(std::shared_ptr<const HipExecutor> exec,
         auto m_b = get_batch_struct(amat);
         auto b_b = get_batch_struct(b);
         if (opts.preconditioner == gko::preconditioner::batch::type::none) {
-            apply_impl<BatchIdentity<cu_value_type>>(exec, opts, logger, m_b,
-                                                     b_b, x_b);
+            apply_impl<BatchIdentity<hip_value_type>>(exec, opts, logger, m_b,
+                                                      b_b, x_b);
         } else if (opts.preconditioner ==
                    gko::preconditioner::batch::type::jacobi) {
-            apply_impl<BatchJacobi<cu_value_type>>(exec, opts, logger, m_b, b_b,
-                                                   x_b);
+            apply_impl<BatchJacobi<hip_value_type>>(exec, opts, logger, m_b,
+                                                    b_b, x_b);
         } else {
             GKO_NOT_IMPLEMENTED;
         }

--- a/hip/test/solver/batch_bicgstab_kernels.cpp
+++ b/hip/test/solver/batch_bicgstab_kernels.cpp
@@ -233,4 +233,32 @@ TEST(BatchBicgstab, GoodScalingImprovesConvergence)
                                                           nrhs, factory.get());
 }
 
+
+TEST(BatchBicgstab, SolvesLargeSystemEquivalentToReference)
+{
+    using value_type = double;
+    using real_type = double;
+    using solver_type = gko::solver::BatchBicgstab<value_type>;
+    std::shared_ptr<gko::ReferenceExecutor> refexec =
+        gko::ReferenceExecutor::create();
+    std::shared_ptr<const gko::HipExecutor> d_exec =
+        gko::HipExecutor::create(0, refexec);
+    const float solver_restol = 1e-4;
+    auto r_sys = gko::test::generate_solvable_batch_system<value_type>(
+        refexec, 2, 1090, 1, false);
+    auto r_factory =
+        solver_type::build()
+            .with_max_iterations(500)
+            .with_residual_tol(solver_restol)
+            .with_tolerance_type(gko::stop::batch::ToleranceType::relative)
+            .with_preconditioner(gko::preconditioner::batch::type::jacobi)
+            .on(refexec);
+    const double iter_tol = 0.01;
+    const double res_tol = 1e-9;
+    const double sol_tol = 10 * solver_restol;
+
+    gko::test::compare_with_reference<value_type, solver_type>(
+        d_exec, r_sys, r_factory.get(), false, iter_tol, res_tol, sol_tol);
+}
+
 }  // namespace

--- a/include/ginkgo/core/base/executor.hpp
+++ b/include/ginkgo/core/base/executor.hpp
@@ -1644,6 +1644,14 @@ public:
     }
 
     /**
+     * Get maximum shared memory per block.
+     */
+    int get_max_shared_memory_per_block() const noexcept
+    {
+        return this->get_exec_info().max_shared_memory_per_workgroup;
+    }
+
+    /**
      * Get the hipblas handle for this executor
      *
      * @return  the hipblas handle (hipblasContext*) for this executor

--- a/include/ginkgo/core/base/executor.hpp
+++ b/include/ginkgo/core/base/executor.hpp
@@ -846,6 +846,11 @@ protected:
         int max_workgroup_size;
 
         /**
+         * Maximum available local shared memory per workgroup.
+         */
+        int max_shared_memory_per_workgroup;
+
+        /**
          * The major version for CUDA/HIP device.
          */
         int major = -1;
@@ -1408,6 +1413,14 @@ public:
     int get_warp_size() const noexcept
     {
         return this->get_exec_info().max_subgroup_size;
+    }
+
+    /**
+     * Get maximum shared memory per block.
+     */
+    int get_max_shared_memory_per_block() const noexcept
+    {
+        return this->get_exec_info().max_shared_memory_per_workgroup;
     }
 
     /**


### PR DESCRIPTION
Batch Bicgstab is now able to automatically determine how many (and which) vectors go to local shared memory.

Originally, space was left for the matrix before assigning vectors to shared memory so that the matrix would certainly be cached in L1 (ie., the amount of shared memory requested was never more than `total_shared_mem - matrix_storage`. However, since the full amount of hardware shared memory cannot be used by a single block and thus there should be space left for L1 caching anyway, for now we ignore the matrix storage and just query the amount of shared memory available per block.

- [x] Move querying of device properties to executors
- [x] Try setting cache preference

In addition, the number of warps per block is now a function of the number of rows. This makes sense for CSR SPMV. In the future, if other batch matrix formats are introduced, this will need to be format-dependent.