### PR TITLE
Move BwUni-CI to nla-gpu1 during maintenance

### DIFF
--- a/.gitlab/image.yml
+++ b/.gitlab/image.yml
@@ -10,21 +10,24 @@
   tags:
     - private_ci
     - cpu
-    - controller
+#    - controller
+    - nla-gpu
 
 .use_gko-cuda90-gnu5-llvm39:
   image: ginkgohub/cuda:90-gnu5-llvm39
   tags:
     - private_ci
-    - controller
     - cpu
+#    - controller
+    - nla-gpu
 
 .use_gko-cuda91-gnu6-llvm40:
   image: ginkgohub/cuda:91-gnu6-llvm40
   tags:
     - private_ci
-    - controller
     - cpu
+#    - controller
+    - nla-gpu
 
 .use_gko-cuda92-gnu7-llvm50-intel2017:
   image: ginkgohub/cuda:92-gnu7-llvm50-intel2017
@@ -36,29 +39,33 @@
   image: ginkgohub/cuda:100-gnu7-llvm60-intel2018
   tags:
     - private_ci
-    - controller
     - cpu
+#    - controller
+    - nla-gpu
 
 .use_gko-cuda101-gnu8-llvm7-intel2019:
   image: ginkgohub/cuda:101-gnu8-llvm7-intel2019
   tags:
     - private_ci
-    - controller
     - cpu
+#    - controller
+    - nla-gpu
 
 .use_gko-cuda101-gnu8-llvm10-intel2019:
   image: ginkgohub/cuda:101-gnu8-llvm10-intel2019
   tags:
     - private_ci
-    - controller
     - cpu
+#    - controller
+    - nla-gpu
 
 .use_gko-cuda102-gnu8-llvm8-intel2019:
   image: ginkgohub/cuda:102-gnu8-llvm8-intel2019
   tags:
     - private_ci
-    - controller
     - cpu
+#    - controller
+    - nla-gpu
 
 .use_gko-cuda110-gnu9-llvm9-intel2020:
   image: ginkgohub/cuda:110-gnu9-llvm9-intel2020


### PR DESCRIPTION
Since BwUniCluster is currently under maintenance, its jobs are moved to our new AMD systems for now.