### PR TITLE
Improve test naming in typed tests

### DIFF
--- a/core/test/base/array.cpp
+++ b/core/test/base/array.cpp
@@ -72,7 +72,7 @@ protected:
     gko::Array<T> x;
 };
 
-TYPED_TEST_SUITE(Array, gko::test::ValueAndIndexTypes);
+TYPED_TEST_SUITE(Array, gko::test::ValueAndIndexTypes, TypenameNameGenerator);
 
 
 TYPED_TEST(Array, CanBeCreatedWithoutAnExecutor)

--- a/core/test/base/combination.cpp
+++ b/core/test/base/combination.cpp
@@ -74,7 +74,7 @@ protected:
     std::vector<std::shared_ptr<gko::LinOp>> coefficients;
 };
 
-TYPED_TEST_SUITE(Combination, gko::test::ValueTypes);
+TYPED_TEST_SUITE(Combination, gko::test::ValueTypes, TypenameNameGenerator);
 
 
 TYPED_TEST(Combination, CanBeEmpty)

--- a/core/test/base/composition.cpp
+++ b/core/test/base/composition.cpp
@@ -72,7 +72,7 @@ protected:
     std::vector<std::shared_ptr<gko::LinOp>> operators;
 };
 
-TYPED_TEST_SUITE(Composition, gko::test::ValueTypes);
+TYPED_TEST_SUITE(Composition, gko::test::ValueTypes, TypenameNameGenerator);
 
 
 TYPED_TEST(Composition, CanBeEmpty)

--- a/core/test/base/iterator_factory.cpp
+++ b/core/test/base/iterator_factory.cpp
@@ -96,7 +96,8 @@ protected:
     const std::vector<value_type> ordered_value;
 };
 
-TYPED_TEST_SUITE(IteratorFactory, gko::test::ValueIndexTypes);
+TYPED_TEST_SUITE(IteratorFactory, gko::test::ValueIndexTypes,
+                 PairTypenameNameGenerator);
 
 
 TYPED_TEST(IteratorFactory, EmptyIterator)

--- a/core/test/base/mtx_io.cpp
+++ b/core/test/base/mtx_io.cpp
@@ -640,7 +640,8 @@ protected:
         typename std::tuple_element<1, decltype(ValueIndexType())>::type;
 };
 
-TYPED_TEST_SUITE(RealDummyLinOpTest, gko::test::RealValueIndexTypes);
+TYPED_TEST_SUITE(RealDummyLinOpTest, gko::test::RealValueIndexTypes,
+                 PairTypenameNameGenerator);
 
 
 TYPED_TEST(RealDummyLinOpTest, ReadsLinOpFromStream)
@@ -713,7 +714,8 @@ protected:
         typename std::tuple_element<1, decltype(ValueIndexType())>::type;
 };
 
-TYPED_TEST_SUITE(ComplexDummyLinOpTest, gko::test::ComplexValueIndexTypes);
+TYPED_TEST_SUITE(ComplexDummyLinOpTest, gko::test::ComplexValueIndexTypes,
+                 PairTypenameNameGenerator);
 
 
 TYPED_TEST(ComplexDummyLinOpTest, ReadsLinOpFromStream)

--- a/core/test/factorization/par_ic.cpp
+++ b/core/test/factorization/par_ic.cpp
@@ -61,7 +61,7 @@ protected:
     std::shared_ptr<const gko::ReferenceExecutor> ref;
 };
 
-TYPED_TEST_SUITE(ParIc, gko::test::ValueIndexTypes);
+TYPED_TEST_SUITE(ParIc, gko::test::ValueIndexTypes, PairTypenameNameGenerator);
 
 
 TYPED_TEST(ParIc, SetIterations)

--- a/core/test/factorization/par_ict.cpp
+++ b/core/test/factorization/par_ict.cpp
@@ -61,7 +61,7 @@ protected:
     std::shared_ptr<const gko::ReferenceExecutor> ref;
 };
 
-TYPED_TEST_SUITE(ParIct, gko::test::ValueIndexTypes);
+TYPED_TEST_SUITE(ParIct, gko::test::ValueIndexTypes, PairTypenameNameGenerator);
 
 
 TYPED_TEST(ParIct, SetIterations)

--- a/core/test/factorization/par_ilu.cpp
+++ b/core/test/factorization/par_ilu.cpp
@@ -61,7 +61,7 @@ protected:
     std::shared_ptr<const gko::ReferenceExecutor> ref;
 };
 
-TYPED_TEST_SUITE(ParIlu, gko::test::ValueIndexTypes);
+TYPED_TEST_SUITE(ParIlu, gko::test::ValueIndexTypes, PairTypenameNameGenerator);
 
 
 TYPED_TEST(ParIlu, SetIterations)

--- a/core/test/factorization/par_ilut.cpp
+++ b/core/test/factorization/par_ilut.cpp
@@ -62,7 +62,8 @@ protected:
     std::shared_ptr<const gko::ReferenceExecutor> ref;
 };
 
-TYPED_TEST_SUITE(ParIlut, gko::test::ValueIndexTypes);
+TYPED_TEST_SUITE(ParIlut, gko::test::ValueIndexTypes,
+                 PairTypenameNameGenerator);
 
 
 TYPED_TEST(ParIlut, SetIterations)

--- a/core/test/log/convergence.cpp
+++ b/core/test/log/convergence.cpp
@@ -47,7 +47,7 @@ namespace {
 template <typename T>
 class Convergence : public ::testing::Test {};
 
-TYPED_TEST_SUITE(Convergence, gko::test::ValueTypes);
+TYPED_TEST_SUITE(Convergence, gko::test::ValueTypes, TypenameNameGenerator);
 
 
 TYPED_TEST(Convergence, CanGetData)

--- a/core/test/log/papi.cpp
+++ b/core/test/log/papi.cpp
@@ -119,7 +119,7 @@ protected:
     int eventset;
 };
 
-TYPED_TEST_SUITE(Papi, gko::test::ValueTypes);
+TYPED_TEST_SUITE(Papi, gko::test::ValueTypes, TypenameNameGenerator);
 
 
 TYPED_TEST(Papi, CatchesAllocationStarted)

--- a/core/test/log/stream.cpp
+++ b/core/test/log/stream.cpp
@@ -59,7 +59,7 @@ constexpr int num_iters = 10;
 template <typename T>
 class Stream : public ::testing::Test {};
 
-TYPED_TEST_SUITE(Stream, gko::test::ValueTypes);
+TYPED_TEST_SUITE(Stream, gko::test::ValueTypes, TypenameNameGenerator);
 
 
 TYPED_TEST(Stream, CatchesAllocationStarted)

--- a/core/test/matrix/coo.cpp
+++ b/core/test/matrix/coo.cpp
@@ -107,7 +107,7 @@ protected:
     }
 };
 
-TYPED_TEST_SUITE(Coo, gko::test::ValueIndexTypes);
+TYPED_TEST_SUITE(Coo, gko::test::ValueIndexTypes, PairTypenameNameGenerator);
 
 
 TYPED_TEST(Coo, KnowsItsSize)

--- a/core/test/matrix/coo_builder.cpp
+++ b/core/test/matrix/coo_builder.cpp
@@ -63,7 +63,8 @@ protected:
     std::unique_ptr<Mtx> mtx;
 };
 
-TYPED_TEST_SUITE(CooBuilder, gko::test::ValueIndexTypes);
+TYPED_TEST_SUITE(CooBuilder, gko::test::ValueIndexTypes,
+                 PairTypenameNameGenerator);
 
 
 TYPED_TEST(CooBuilder, ReturnsCorrectArrays)

--- a/core/test/matrix/csr.cpp
+++ b/core/test/matrix/csr.cpp
@@ -111,7 +111,7 @@ protected:
     }
 };
 
-TYPED_TEST_SUITE(Csr, gko::test::ValueIndexTypes);
+TYPED_TEST_SUITE(Csr, gko::test::ValueIndexTypes, PairTypenameNameGenerator);
 
 
 TYPED_TEST(Csr, KnowsItsSize)

--- a/core/test/matrix/csr_builder.cpp
+++ b/core/test/matrix/csr_builder.cpp
@@ -64,7 +64,8 @@ protected:
     std::unique_ptr<Mtx> mtx;
 };
 
-TYPED_TEST_SUITE(CsrBuilder, gko::test::ValueIndexTypes);
+TYPED_TEST_SUITE(CsrBuilder, gko::test::ValueIndexTypes,
+                 PairTypenameNameGenerator);
 
 
 TYPED_TEST(CsrBuilder, ReturnsCorrectArrays)

--- a/core/test/matrix/dense.cpp
+++ b/core/test/matrix/dense.cpp
@@ -80,7 +80,7 @@ protected:
     std::unique_ptr<gko::matrix::Dense<value_type>> mtx;
 };
 
-TYPED_TEST_SUITE(Dense, gko::test::ValueTypes);
+TYPED_TEST_SUITE(Dense, gko::test::ValueTypes, TypenameNameGenerator);
 
 
 TYPED_TEST(Dense, CanBeEmpty)

--- a/core/test/matrix/diagonal.cpp
+++ b/core/test/matrix/diagonal.cpp
@@ -77,7 +77,7 @@ protected:
     }
 };
 
-TYPED_TEST_SUITE(Diagonal, gko::test::ValueTypes);
+TYPED_TEST_SUITE(Diagonal, gko::test::ValueTypes, TypenameNameGenerator);
 
 
 TYPED_TEST(Diagonal, KnowsItsSize)

--- a/core/test/matrix/ell.cpp
+++ b/core/test/matrix/ell.cpp
@@ -110,7 +110,7 @@ protected:
     }
 };
 
-TYPED_TEST_SUITE(Ell, gko::test::ValueIndexTypes);
+TYPED_TEST_SUITE(Ell, gko::test::ValueIndexTypes, PairTypenameNameGenerator);
 
 
 TYPED_TEST(Ell, KnowsItsSize)

--- a/core/test/matrix/fbcsr.cpp
+++ b/core/test/matrix/fbcsr.cpp
@@ -160,7 +160,8 @@ protected:
 };
 
 
-TYPED_TEST_SUITE(FbcsrSample, gko::test::ValueIndexTypes);
+TYPED_TEST_SUITE(FbcsrSample, gko::test::ValueIndexTypes,
+                 PairTypenameNameGenerator);
 
 
 TYPED_TEST(FbcsrSample, SampleGeneratorsAreCorrect)
@@ -221,7 +222,8 @@ protected:
 };
 
 
-TYPED_TEST_SUITE(FbcsrSampleComplex, gko::test::ComplexValueIndexTypes);
+TYPED_TEST_SUITE(FbcsrSampleComplex, gko::test::ComplexValueIndexTypes,
+                 PairTypenameNameGenerator);
 
 
 TYPED_TEST(FbcsrSampleComplex, ComplexSampleGeneratorIsCorrect)
@@ -319,7 +321,7 @@ protected:
     }
 };
 
-TYPED_TEST_SUITE(Fbcsr, gko::test::ValueIndexTypes);
+TYPED_TEST_SUITE(Fbcsr, gko::test::ValueIndexTypes, PairTypenameNameGenerator);
 
 
 TYPED_TEST(Fbcsr, GetNumBlocksCorrectlyThrows)

--- a/core/test/matrix/fbcsr_builder.cpp
+++ b/core/test/matrix/fbcsr_builder.cpp
@@ -64,7 +64,8 @@ protected:
     std::unique_ptr<Mtx> mtx;
 };
 
-TYPED_TEST_SUITE(FbcsrBuilder, gko::test::ValueIndexTypes);
+TYPED_TEST_SUITE(FbcsrBuilder, gko::test::ValueIndexTypes,
+                 PairTypenameNameGenerator);
 
 
 TYPED_TEST(FbcsrBuilder, ReturnsCorrectArrays)

--- a/core/test/matrix/hybrid.cpp
+++ b/core/test/matrix/hybrid.cpp
@@ -127,7 +127,7 @@ protected:
     }
 };
 
-TYPED_TEST_SUITE(Hybrid, gko::test::ValueIndexTypes);
+TYPED_TEST_SUITE(Hybrid, gko::test::ValueIndexTypes, PairTypenameNameGenerator);
 
 
 TYPED_TEST(Hybrid, KnowsItsSize)

--- a/core/test/matrix/identity.cpp
+++ b/core/test/matrix/identity.cpp
@@ -58,7 +58,7 @@ protected:
     std::shared_ptr<const gko::Executor> exec;
 };
 
-TYPED_TEST_SUITE(Identity, gko::test::ValueTypes);
+TYPED_TEST_SUITE(Identity, gko::test::ValueTypes, TypenameNameGenerator);
 
 
 TYPED_TEST(Identity, CanBeEmpty)
@@ -102,7 +102,7 @@ protected:
     using value_type = T;
 };
 
-TYPED_TEST_SUITE(IdentityFactory, gko::test::ValueTypes);
+TYPED_TEST_SUITE(IdentityFactory, gko::test::ValueTypes, TypenameNameGenerator);
 
 
 TYPED_TEST(IdentityFactory, CanGenerateIdentityMatrix)

--- a/core/test/matrix/permutation.cpp
+++ b/core/test/matrix/permutation.cpp
@@ -86,7 +86,8 @@ protected:
     std::unique_ptr<gko::matrix::Permutation<i_type>> mtx;
 };
 
-TYPED_TEST_SUITE(Permutation, gko::test::ValueIndexTypes);
+TYPED_TEST_SUITE(Permutation, gko::test::ValueIndexTypes,
+                 PairTypenameNameGenerator);
 
 
 TYPED_TEST(Permutation, CanBeEmpty)

--- a/core/test/matrix/sellp.cpp
+++ b/core/test/matrix/sellp.cpp
@@ -138,7 +138,7 @@ protected:
     }
 };
 
-TYPED_TEST_SUITE(Sellp, gko::test::ValueIndexTypes);
+TYPED_TEST_SUITE(Sellp, gko::test::ValueIndexTypes, PairTypenameNameGenerator);
 
 
 TYPED_TEST(Sellp, KnowsItsSize)

--- a/core/test/matrix/sparsity_csr.cpp
+++ b/core/test/matrix/sparsity_csr.cpp
@@ -107,7 +107,8 @@ protected:
     }
 };
 
-TYPED_TEST_SUITE(SparsityCsr, gko::test::ValueIndexTypes);
+TYPED_TEST_SUITE(SparsityCsr, gko::test::ValueIndexTypes,
+                 PairTypenameNameGenerator);
 
 
 TYPED_TEST(SparsityCsr, KnowsItsSize)

--- a/core/test/multigrid/amgx_pgm.cpp
+++ b/core/test/multigrid/amgx_pgm.cpp
@@ -73,7 +73,8 @@ protected:
     std::unique_ptr<typename MgLevel::Factory> amgxpgm_factory;
 };
 
-TYPED_TEST_SUITE(AmgxPgmFactory, gko::test::ValueIndexTypes);
+TYPED_TEST_SUITE(AmgxPgmFactory, gko::test::ValueIndexTypes,
+                 PairTypenameNameGenerator);
 
 
 TYPED_TEST(AmgxPgmFactory, FactoryKnowsItsExecutor)

--- a/core/test/preconditioner/isai.cpp
+++ b/core/test/preconditioner/isai.cpp
@@ -97,7 +97,8 @@ protected:
     std::unique_ptr<typename UpperIsai::Factory> upper_isai_factory;
 };
 
-TYPED_TEST_SUITE(IsaiFactory, gko::test::ValueIndexTypes);
+TYPED_TEST_SUITE(IsaiFactory, gko::test::ValueIndexTypes,
+                 PairTypenameNameGenerator);
 
 
 TYPED_TEST(IsaiFactory, KnowsItsExecutor)

--- a/core/test/preconditioner/jacobi.cpp
+++ b/core/test/preconditioner/jacobi.cpp
@@ -75,7 +75,8 @@ protected:
     std::shared_ptr<gko::matrix::Csr<value_type, index_type>> mtx;
 };
 
-TYPED_TEST_SUITE(JacobiFactory, gko::test::ValueIndexTypes);
+TYPED_TEST_SUITE(JacobiFactory, gko::test::ValueIndexTypes,
+                 PairTypenameNameGenerator);
 
 
 TYPED_TEST(JacobiFactory, KnowsItsExecutor)
@@ -156,7 +157,8 @@ protected:
                                                                         2};
 };
 
-TYPED_TEST_SUITE(BlockInterleavedStorageScheme, gko::test::IndexTypes);
+TYPED_TEST_SUITE(BlockInterleavedStorageScheme, gko::test::IndexTypes,
+                 TypenameNameGenerator);
 
 
 TYPED_TEST(BlockInterleavedStorageScheme, ComputesStorageSpace)

--- a/core/test/solver/bicg.cpp
+++ b/core/test/solver/bicg.cpp
@@ -91,7 +91,7 @@ protected:
     }
 };
 
-TYPED_TEST_SUITE(Bicg, gko::test::ValueTypes);
+TYPED_TEST_SUITE(Bicg, gko::test::ValueTypes, TypenameNameGenerator);
 
 
 TYPED_TEST(Bicg, BicgFactoryKnowsItsExecutor)

--- a/core/test/solver/bicgstab.cpp
+++ b/core/test/solver/bicgstab.cpp
@@ -89,7 +89,7 @@ protected:
     }
 };
 
-TYPED_TEST_SUITE(Bicgstab, gko::test::ValueTypes);
+TYPED_TEST_SUITE(Bicgstab, gko::test::ValueTypes, TypenameNameGenerator);
 
 
 TYPED_TEST(Bicgstab, BicgstabFactoryKnowsItsExecutor)

--- a/core/test/solver/cb_gmres.cpp
+++ b/core/test/solver/cb_gmres.cpp
@@ -143,7 +143,7 @@ using TestTypes =
                      std::tuple<std::complex<double>, st_r2>,
                      std::tuple<std::complex<float>, st_keep>>;
 
-TYPED_TEST_SUITE(CbGmres, TestTypes);
+TYPED_TEST_SUITE(CbGmres, TestTypes, PairTypenameNameGenerator);
 
 
 TYPED_TEST(CbGmres, CbGmresFactoryKnowsItsExecutor)

--- a/core/test/solver/cg.cpp
+++ b/core/test/solver/cg.cpp
@@ -91,7 +91,7 @@ protected:
     }
 };
 
-TYPED_TEST_SUITE(Cg, gko::test::ValueTypes);
+TYPED_TEST_SUITE(Cg, gko::test::ValueTypes, TypenameNameGenerator);
 
 
 TYPED_TEST(Cg, CgFactoryKnowsItsExecutor)

--- a/core/test/solver/cgs.cpp
+++ b/core/test/solver/cgs.cpp
@@ -91,7 +91,7 @@ protected:
     }
 };
 
-TYPED_TEST_SUITE(Cgs, gko::test::ValueTypes);
+TYPED_TEST_SUITE(Cgs, gko::test::ValueTypes, TypenameNameGenerator);
 
 
 TYPED_TEST(Cgs, CgsFactoryKnowsItsExecutor)

--- a/core/test/solver/fcg.cpp
+++ b/core/test/solver/fcg.cpp
@@ -77,7 +77,7 @@ protected:
     std::unique_ptr<gko::LinOp> solver;
 };
 
-TYPED_TEST_SUITE(Fcg, gko::test::ValueTypes);
+TYPED_TEST_SUITE(Fcg, gko::test::ValueTypes, TypenameNameGenerator);
 
 
 TYPED_TEST(Fcg, FcgFactoryKnowsItsExecutor)

--- a/core/test/solver/gmres.cpp
+++ b/core/test/solver/gmres.cpp
@@ -110,7 +110,7 @@ protected:
 template <typename T>
 constexpr gko::remove_complex<T> Gmres<T>::reduction_factor;
 
-TYPED_TEST_SUITE(Gmres, gko::test::ValueTypes);
+TYPED_TEST_SUITE(Gmres, gko::test::ValueTypes, TypenameNameGenerator);
 
 
 TYPED_TEST(Gmres, GmresFactoryKnowsItsExecutor)

--- a/core/test/solver/idr.cpp
+++ b/core/test/solver/idr.cpp
@@ -89,7 +89,7 @@ protected:
     }
 };
 
-TYPED_TEST_SUITE(Idr, gko::test::ValueTypes);
+TYPED_TEST_SUITE(Idr, gko::test::ValueTypes, TypenameNameGenerator);
 
 
 TYPED_TEST(Idr, IdrFactoryKnowsItsExecutor)

--- a/core/test/solver/ir.cpp
+++ b/core/test/solver/ir.cpp
@@ -91,7 +91,7 @@ protected:
     }
 };
 
-TYPED_TEST_SUITE(Ir, gko::test::ValueTypes);
+TYPED_TEST_SUITE(Ir, gko::test::ValueTypes, TypenameNameGenerator);
 
 
 TYPED_TEST(Ir, IrFactoryKnowsItsExecutor)

--- a/core/test/solver/lower_trs.cpp
+++ b/core/test/solver/lower_trs.cpp
@@ -66,7 +66,8 @@ protected:
     std::unique_ptr<typename Solver::Factory> lower_trs_factory;
 };
 
-TYPED_TEST_SUITE(LowerTrs, gko::test::ValueIndexTypes);
+TYPED_TEST_SUITE(LowerTrs, gko::test::ValueIndexTypes,
+                 PairTypenameNameGenerator);
 
 
 TYPED_TEST(LowerTrs, LowerTrsFactoryKnowsItsExecutor)

--- a/core/test/solver/multigrid.cpp
+++ b/core/test/solver/multigrid.cpp
@@ -199,7 +199,7 @@ protected:
     }
 };
 
-TYPED_TEST_CASE(Multigrid, gko::test::ValueTypes);
+TYPED_TEST_CASE(Multigrid, gko::test::ValueTypes, TypenameNameGenerator);
 
 
 TYPED_TEST(Multigrid, MultigridFactoryKnowsItsExecutor)

--- a/core/test/solver/upper_trs.cpp
+++ b/core/test/solver/upper_trs.cpp
@@ -66,7 +66,8 @@ protected:
     std::unique_ptr<typename Solver::Factory> upper_trs_factory;
 };
 
-TYPED_TEST_SUITE(UpperTrs, gko::test::ValueIndexTypes);
+TYPED_TEST_SUITE(UpperTrs, gko::test::ValueIndexTypes,
+                 PairTypenameNameGenerator);
 
 
 TYPED_TEST(UpperTrs, UpperTrsFactoryKnowsItsExecutor)

--- a/core/test/utils.hpp
+++ b/core/test/utils.hpp
@@ -37,6 +37,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <complex>
 #include <initializer_list>
 #include <limits>
+#include <tuple>
 #include <type_traits>
 
 
@@ -44,6 +45,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
 #include <ginkgo/core/base/math.hpp>
+#include <ginkgo/core/base/name_demangling.hpp>
 #include <ginkgo/core/base/types.hpp>
 
 
@@ -166,6 +168,31 @@ constexpr double r_mixed()
 
 template <typename T>
 using I = std::initializer_list<T>;
+
+
+struct TypenameNameGenerator {
+    template <typename T>
+    static std::string GetName(int i)
+    {
+        return gko::name_demangling::get_type_name(typeid(T));
+    }
+};
+
+
+struct PairTypenameNameGenerator {
+    template <typename T>
+    static std::string GetName(int i)
+    {
+        static_assert(std::tuple_size<T>::value == 2, "expected a pair");
+        return "<" +
+               gko::name_demangling::get_type_name(
+                   typeid(typename std::tuple_element<0, T>::type)) +
+               ", " +
+               gko::name_demangling::get_type_name(
+                   typeid(typename std::tuple_element<1, T>::type)) +
+               ">";
+    }
+};
 
 
 #endif  // GKO_CORE_TEST_UTILS_HPP_

--- a/core/test/utils/array_generator_test.cpp
+++ b/core/test/utils/array_generator_test.cpp
@@ -93,7 +93,7 @@ protected:
     }
 };
 
-TYPED_TEST_SUITE(ArrayGenerator, gko::test::ValueTypes);
+TYPED_TEST_SUITE(ArrayGenerator, gko::test::ValueTypes, TypenameNameGenerator);
 
 
 TYPED_TEST(ArrayGenerator, OutputHasCorrectSize)

--- a/core/test/utils/matrix_generator_test.cpp
+++ b/core/test/utils/matrix_generator_test.cpp
@@ -145,7 +145,7 @@ protected:
     }
 };
 
-TYPED_TEST_SUITE(MatrixGenerator, gko::test::ValueTypes);
+TYPED_TEST_SUITE(MatrixGenerator, gko::test::ValueTypes, TypenameNameGenerator);
 
 
 TYPED_TEST(MatrixGenerator, OutputHasCorrectSize)

--- a/core/test/utils/matrix_utils_test.cpp
+++ b/core/test/utils/matrix_utils_test.cpp
@@ -69,7 +69,7 @@ protected:
     std::unique_ptr<mtx_type> unsquare_mtx;
 };
 
-TYPED_TEST_SUITE(MatrixUtils, gko::test::ValueTypes);
+TYPED_TEST_SUITE(MatrixUtils, gko::test::ValueTypes, TypenameNameGenerator);
 
 
 TYPED_TEST(MatrixUtils, MakeSymmetricThrowsError)

--- a/core/test/utils/unsort_matrix_test.cpp
+++ b/core/test/utils/unsort_matrix_test.cpp
@@ -149,7 +149,8 @@ protected:
     std::unique_ptr<Coo> coo_empty;
 };
 
-TYPED_TEST_SUITE(UnsortMatrix, gko::test::ValueIndexTypes);
+TYPED_TEST_SUITE(UnsortMatrix, gko::test::ValueIndexTypes,
+                 PairTypenameNameGenerator);
 
 
 TYPED_TEST(UnsortMatrix, CsrWorks)

--- a/core/test/utils/value_generator_test.cpp
+++ b/core/test/utils/value_generator_test.cpp
@@ -87,7 +87,7 @@ protected:
     }
 };
 
-TYPED_TEST_SUITE(ValueGenerator, gko::test::ValueTypes);
+TYPED_TEST_SUITE(ValueGenerator, gko::test::ValueTypes, TypenameNameGenerator);
 
 
 TYPED_TEST(ValueGenerator, OutputHasCorrectAverageAndDeviation)

--- a/cuda/test/base/array.cu
+++ b/cuda/test/base/array.cu
@@ -64,7 +64,7 @@ protected:
     gko::Array<T> x;
 };
 
-TYPED_TEST_SUITE(Array, gko::test::ValueAndIndexTypes);
+TYPED_TEST_SUITE(Array, gko::test::ValueAndIndexTypes, TypenameNameGenerator);
 
 
 TYPED_TEST(Array, CanCreateTemporaryCloneOnDifferentExecutor)

--- a/cuda/test/components/fill_array.cpp
+++ b/cuda/test/components/fill_array.cpp
@@ -75,7 +75,8 @@ protected:
     gko::Array<value_type> seqs;
 };
 
-TYPED_TEST_SUITE(FillArray, gko::test::ValueAndIndexTypes);
+TYPED_TEST_SUITE(FillArray, gko::test::ValueAndIndexTypes,
+                 TypenameNameGenerator);
 
 
 TYPED_TEST(FillArray, EqualsReference)

--- a/cuda/test/matrix/fft_kernels.cpp
+++ b/cuda/test/matrix/fft_kernels.cpp
@@ -142,7 +142,7 @@ protected:
 };
 
 
-TYPED_TEST_SUITE(Fft, gko::test::ComplexValueTypes);
+TYPED_TEST_SUITE(Fft, gko::test::ComplexValueTypes, TypenameNameGenerator);
 
 
 TYPED_TEST(Fft, Apply1DIsEqualToReference)

--- a/dpcpp/test/components/fill_array.cpp
+++ b/dpcpp/test/components/fill_array.cpp
@@ -74,7 +74,8 @@ protected:
     gko::Array<value_type> seqs;
 };
 
-TYPED_TEST_SUITE(FillArray, gko::test::ValueAndIndexTypes);
+TYPED_TEST_SUITE(FillArray, gko::test::ValueAndIndexTypes,
+                 TypenameNameGenerator);
 
 
 TYPED_TEST(FillArray, EqualsReference)

--- a/hip/test/components/fill_array.hip.cpp
+++ b/hip/test/components/fill_array.hip.cpp
@@ -81,7 +81,8 @@ protected:
     gko::Array<value_type> seqs;
 };
 
-TYPED_TEST_SUITE(FillArray, gko::test::ValueAndIndexTypes);
+TYPED_TEST_SUITE(FillArray, gko::test::ValueAndIndexTypes,
+                 TypenameNameGenerator);
 
 
 TYPED_TEST(FillArray, EqualsReference)

--- a/hip/test/matrix/fft_kernels.hip.cpp
+++ b/hip/test/matrix/fft_kernels.hip.cpp
@@ -145,7 +145,7 @@ protected:
 };
 
 
-TYPED_TEST_SUITE(Fft, gko::test::ComplexValueTypes);
+TYPED_TEST_SUITE(Fft, gko::test::ComplexValueTypes, TypenameNameGenerator);
 
 
 TYPED_TEST(Fft, Apply1DIsEqualToReference)

--- a/omp/test/components/fill_array.cpp
+++ b/omp/test/components/fill_array.cpp
@@ -74,7 +74,8 @@ protected:
     gko::Array<value_type> seqs;
 };
 
-TYPED_TEST_SUITE(FillArray, gko::test::ValueAndIndexTypes);
+TYPED_TEST_SUITE(FillArray, gko::test::ValueAndIndexTypes,
+                 TypenameNameGenerator);
 
 
 TYPED_TEST(FillArray, EqualsReference)

--- a/omp/test/components/prefix_sum.cpp
+++ b/omp/test/components/prefix_sum.cpp
@@ -86,7 +86,7 @@ protected:
     gko::Array<index_type> dvals;
 };
 
-TYPED_TEST_SUITE(PrefixSum, gko::test::IndexTypes);
+TYPED_TEST_SUITE(PrefixSum, gko::test::IndexTypes, TypenameNameGenerator);
 
 
 TYPED_TEST(PrefixSum, TrivialCasesEqualReference)

--- a/omp/test/factorization/par_ic_kernels.cpp
+++ b/omp/test/factorization/par_ic_kernels.cpp
@@ -137,7 +137,7 @@ protected:
     std::unique_ptr<Csr> dmtx_l_ani_init;
 };
 
-TYPED_TEST_SUITE(ParIc, gko::test::ValueIndexTypes);
+TYPED_TEST_SUITE(ParIc, gko::test::ValueIndexTypes, PairTypenameNameGenerator);
 
 
 TYPED_TEST(ParIc, KernelInitFactorIsEquivalentToRef)

--- a/omp/test/factorization/par_ict_kernels.cpp
+++ b/omp/test/factorization/par_ict_kernels.cpp
@@ -144,7 +144,7 @@ protected:
     std::unique_ptr<Csr> dmtx_l;
 };
 
-TYPED_TEST_SUITE(ParIct, gko::test::ValueIndexTypes);
+TYPED_TEST_SUITE(ParIct, gko::test::ValueIndexTypes, PairTypenameNameGenerator);
 
 
 TYPED_TEST(ParIct, KernelAddCandidatesIsEquivalentToRef)

--- a/omp/test/factorization/par_ilu_kernels.cpp
+++ b/omp/test/factorization/par_ilu_kernels.cpp
@@ -223,7 +223,7 @@ protected:
     }
 };
 
-TYPED_TEST_SUITE(ParIlu, gko::test::ValueIndexTypes);
+TYPED_TEST_SUITE(ParIlu, gko::test::ValueIndexTypes, PairTypenameNameGenerator);
 
 
 TYPED_TEST(ParIlu, OmpKernelAddDiagonalElementsSortedEquivalentToRef)

--- a/omp/test/factorization/par_ilut_kernels.cpp
+++ b/omp/test/factorization/par_ilut_kernels.cpp
@@ -277,7 +277,8 @@ protected:
     std::unique_ptr<Csr> dmtx_u;
 };
 
-TYPED_TEST_SUITE(ParIlut, gko::test::ValueIndexTypes);
+TYPED_TEST_SUITE(ParIlut, gko::test::ValueIndexTypes,
+                 PairTypenameNameGenerator);
 
 
 TYPED_TEST(ParIlut, KernelThresholdSelectIsEquivalentToRef)

--- a/omp/test/matrix/fft_kernels.cpp
+++ b/omp/test/matrix/fft_kernels.cpp
@@ -130,7 +130,7 @@ protected:
 };
 
 
-TYPED_TEST_SUITE(Fft, gko::test::ComplexValueTypes);
+TYPED_TEST_SUITE(Fft, gko::test::ComplexValueTypes, TypenameNameGenerator);
 
 
 TYPED_TEST(Fft, Apply1DIsEqualToReference)

--- a/omp/test/stop/residual_norm_kernels.cpp
+++ b/omp/test/stop/residual_norm_kernels.cpp
@@ -73,7 +73,7 @@ protected:
     std::shared_ptr<const gko::Executor> exec_;
 };
 
-TYPED_TEST_SUITE(ResidualNorm, gko::test::ValueTypes);
+TYPED_TEST_SUITE(ResidualNorm, gko::test::ValueTypes, TypenameNameGenerator);
 
 
 TYPED_TEST(ResidualNorm, WaitsTillResidualGoal)
@@ -307,7 +307,8 @@ protected:
     std::shared_ptr<const gko::OmpExecutor> exec_;
 };
 
-TYPED_TEST_SUITE(ResidualNormReduction, gko::test::ValueTypes);
+TYPED_TEST_SUITE(ResidualNormReduction, gko::test::ValueTypes,
+                 TypenameNameGenerator);
 
 
 TYPED_TEST(ResidualNormReduction, WaitsTillResidualGoal)
@@ -407,7 +408,8 @@ protected:
     std::shared_ptr<const gko::OmpExecutor> exec_;
 };
 
-TYPED_TEST_SUITE(RelativeResidualNorm, gko::test::ValueTypes);
+TYPED_TEST_SUITE(RelativeResidualNorm, gko::test::ValueTypes,
+                 TypenameNameGenerator);
 
 
 TYPED_TEST(RelativeResidualNorm, WaitsTillResidualGoal)
@@ -514,7 +516,8 @@ protected:
     std::shared_ptr<const gko::Executor> exec_;
 };
 
-TYPED_TEST_SUITE(ImplicitResidualNorm, gko::test::ValueTypes);
+TYPED_TEST_SUITE(ImplicitResidualNorm, gko::test::ValueTypes,
+                 TypenameNameGenerator);
 
 
 TYPED_TEST(ImplicitResidualNorm, WaitsTillResidualGoal)
@@ -622,7 +625,8 @@ protected:
     std::shared_ptr<const gko::OmpExecutor> exec_;
 };
 
-TYPED_TEST_SUITE(AbsoluteResidualNorm, gko::test::ValueTypes);
+TYPED_TEST_SUITE(AbsoluteResidualNorm, gko::test::ValueTypes,
+                 TypenameNameGenerator);
 
 
 TYPED_TEST(AbsoluteResidualNorm, WaitsTillResidualGoal)

--- a/reference/test/base/array.cpp
+++ b/reference/test/base/array.cpp
@@ -61,7 +61,7 @@ protected:
     gko::Array<T> x;
 };
 
-TYPED_TEST_SUITE(Array, gko::test::ValueAndIndexTypes);
+TYPED_TEST_SUITE(Array, gko::test::ValueAndIndexTypes, TypenameNameGenerator);
 
 
 TYPED_TEST(Array, CanBeFilledWithValue)

--- a/reference/test/base/combination.cpp
+++ b/reference/test/base/combination.cpp
@@ -67,7 +67,7 @@ protected:
     std::vector<std::shared_ptr<gko::LinOp>> operators;
 };
 
-TYPED_TEST_SUITE(Combination, gko::test::ValueTypes);
+TYPED_TEST_SUITE(Combination, gko::test::ValueTypes, TypenameNameGenerator);
 
 
 TYPED_TEST(Combination, AppliesToVector)

--- a/reference/test/base/composition.cpp
+++ b/reference/test/base/composition.cpp
@@ -108,7 +108,7 @@ protected:
     std::shared_ptr<Mtx> product;
 };
 
-TYPED_TEST_SUITE(Composition, gko::test::ValueTypes);
+TYPED_TEST_SUITE(Composition, gko::test::ValueTypes, TypenameNameGenerator);
 
 
 TYPED_TEST(Composition, AppliesSingleToVector)

--- a/reference/test/base/perturbation.cpp
+++ b/reference/test/base/perturbation.cpp
@@ -66,7 +66,7 @@ protected:
     std::shared_ptr<gko::LinOp> scalar;
 };
 
-TYPED_TEST_SUITE(Perturbation, gko::test::ValueTypes);
+TYPED_TEST_SUITE(Perturbation, gko::test::ValueTypes, TypenameNameGenerator);
 
 
 TYPED_TEST(Perturbation, AppliesToVector)

--- a/reference/test/components/absolute_array.cpp
+++ b/reference/test/components/absolute_array.cpp
@@ -75,7 +75,7 @@ protected:
     gko::Array<value_type> vals;
 };
 
-TYPED_TEST_SUITE(AbsoluteArray, gko::test::ValueTypes);
+TYPED_TEST_SUITE(AbsoluteArray, gko::test::ValueTypes, TypenameNameGenerator);
 
 
 TYPED_TEST(AbsoluteArray, InplaceEqualsExpected)

--- a/reference/test/components/fill_array.cpp
+++ b/reference/test/components/fill_array.cpp
@@ -72,7 +72,8 @@ protected:
     gko::Array<value_type> seqs;
 };
 
-TYPED_TEST_SUITE(FillArray, gko::test::ValueAndIndexTypes);
+TYPED_TEST_SUITE(FillArray, gko::test::ValueAndIndexTypes,
+                 TypenameNameGenerator);
 
 
 TYPED_TEST(FillArray, EqualsReference)

--- a/reference/test/components/prefix_sum.cpp
+++ b/reference/test/components/prefix_sum.cpp
@@ -62,7 +62,7 @@ protected:
     std::vector<index_type> expected;
 };
 
-TYPED_TEST_SUITE(PrefixSum, gko::test::IndexTypes);
+TYPED_TEST_SUITE(PrefixSum, gko::test::IndexTypes, TypenameNameGenerator);
 
 
 TYPED_TEST(PrefixSum, Works)

--- a/reference/test/factorization/ic_kernels.cpp
+++ b/reference/test/factorization/ic_kernels.cpp
@@ -116,7 +116,7 @@ protected:
     gko::remove_complex<value_type> tol;
 };
 
-TYPED_TEST_SUITE(Ic, gko::test::ValueIndexTypes);
+TYPED_TEST_SUITE(Ic, gko::test::ValueIndexTypes, PairTypenameNameGenerator);
 
 
 TYPED_TEST(Ic, ThrowNotSupportedForWrongLinOp)

--- a/reference/test/factorization/ilu_kernels.cpp
+++ b/reference/test/factorization/ilu_kernels.cpp
@@ -203,7 +203,7 @@ protected:
     std::unique_ptr<typename ilu_type::Factory> ilu_factory_sort;
 };
 
-TYPED_TEST_SUITE(Ilu, gko::test::ValueIndexTypes);
+TYPED_TEST_SUITE(Ilu, gko::test::ValueIndexTypes, PairTypenameNameGenerator);
 
 
 TYPED_TEST(Ilu, ThrowNotSupportedForWrongLinOp1)

--- a/reference/test/factorization/par_ic_kernels.cpp
+++ b/reference/test/factorization/par_ic_kernels.cpp
@@ -136,7 +136,7 @@ protected:
     gko::remove_complex<value_type> tol;
 };
 
-TYPED_TEST_SUITE(ParIc, gko::test::ValueIndexTypes);
+TYPED_TEST_SUITE(ParIc, gko::test::ValueIndexTypes, PairTypenameNameGenerator);
 
 
 TYPED_TEST(ParIc, KernelCompute)

--- a/reference/test/factorization/par_ict_kernels.cpp
+++ b/reference/test/factorization/par_ict_kernels.cpp
@@ -169,7 +169,7 @@ protected:
     gko::remove_complex<value_type> tol;
 };
 
-TYPED_TEST_SUITE(ParIct, gko::test::ValueIndexTypes);
+TYPED_TEST_SUITE(ParIct, gko::test::ValueIndexTypes, PairTypenameNameGenerator);
 
 
 TYPED_TEST(ParIct, KernelInitializeRowPtrsL)

--- a/reference/test/factorization/par_ilu_kernels.cpp
+++ b/reference/test/factorization/par_ilu_kernels.cpp
@@ -212,7 +212,7 @@ protected:
     std::unique_ptr<typename par_ilu_type::Factory> ilu_factory_sort;
 };
 
-TYPED_TEST_SUITE(ParIlu, gko::test::ValueIndexTypes);
+TYPED_TEST_SUITE(ParIlu, gko::test::ValueIndexTypes, PairTypenameNameGenerator);
 
 
 TYPED_TEST(ParIlu, KernelAddDiagonalElementsEmpty)

--- a/reference/test/factorization/par_ilut_kernels.cpp
+++ b/reference/test/factorization/par_ilut_kernels.cpp
@@ -300,7 +300,8 @@ protected:
     gko::remove_complex<value_type> tol;
 };  // namespace
 
-TYPED_TEST_SUITE(ParIlut, gko::test::ValueIndexTypes);
+TYPED_TEST_SUITE(ParIlut, gko::test::ValueIndexTypes,
+                 PairTypenameNameGenerator);
 
 
 TYPED_TEST(ParIlut, KernelThresholdSelect)

--- a/reference/test/log/convergence.cpp
+++ b/reference/test/log/convergence.cpp
@@ -51,7 +51,7 @@ namespace {
 template <typename T>
 class Convergence : public ::testing::Test {};
 
-TYPED_TEST_SUITE(Convergence, gko::test::ValueTypes);
+TYPED_TEST_SUITE(Convergence, gko::test::ValueTypes, TypenameNameGenerator);
 
 
 TYPED_TEST(Convergence, CatchesCriterionCheckCompleted)

--- a/reference/test/log/papi.cpp
+++ b/reference/test/log/papi.cpp
@@ -115,7 +115,7 @@ protected:
     int eventset;
 };
 
-TYPED_TEST_SUITE(Papi, gko::test::ValueTypes);
+TYPED_TEST_SUITE(Papi, gko::test::ValueTypes, TypenameNameGenerator);
 
 
 TYPED_TEST(Papi, CatchesCriterionCheckCompleted)

--- a/reference/test/matrix/coo_kernels.cpp
+++ b/reference/test/matrix/coo_kernels.cpp
@@ -104,7 +104,7 @@ protected:
     std::unique_ptr<Mtx> uns_mtx;
 };
 
-TYPED_TEST_SUITE(Coo, gko::test::ValueIndexTypes);
+TYPED_TEST_SUITE(Coo, gko::test::ValueIndexTypes, PairTypenameNameGenerator);
 
 
 TYPED_TEST(Coo, ConvertsToPrecision)
@@ -940,7 +940,8 @@ protected:
     using Mtx = gko::matrix::Coo<value_type, index_type>;
 };
 
-TYPED_TEST_SUITE(CooComplex, gko::test::ComplexValueIndexTypes);
+TYPED_TEST_SUITE(CooComplex, gko::test::ComplexValueIndexTypes,
+                 PairTypenameNameGenerator);
 
 
 TYPED_TEST(CooComplex, OutplaceAbsolute)

--- a/reference/test/matrix/csr_kernels.cpp
+++ b/reference/test/matrix/csr_kernels.cpp
@@ -350,7 +350,7 @@ protected:
     std::unique_ptr<Mtx> mtx3_unsorted;
 };
 
-TYPED_TEST_SUITE(Csr, gko::test::ValueIndexTypes);
+TYPED_TEST_SUITE(Csr, gko::test::ValueIndexTypes, PairTypenameNameGenerator);
 
 
 TYPED_TEST(Csr, AppliesToDenseVector)
@@ -1554,7 +1554,8 @@ protected:
     using Mtx = gko::matrix::Csr<value_type, index_type>;
 };
 
-TYPED_TEST_SUITE(CsrComplex, gko::test::ComplexValueIndexTypes);
+TYPED_TEST_SUITE(CsrComplex, gko::test::ComplexValueIndexTypes,
+                 PairTypenameNameGenerator);
 
 
 TYPED_TEST(CsrComplex, MtxIsConjugateTransposable)

--- a/reference/test/matrix/dense_kernels.cpp
+++ b/reference/test/matrix/dense_kernels.cpp
@@ -112,7 +112,7 @@ protected:
 };
 
 
-TYPED_TEST_SUITE(Dense, gko::test::ValueTypes);
+TYPED_TEST_SUITE(Dense, gko::test::ValueTypes, TypenameNameGenerator);
 
 
 TYPED_TEST(Dense, CopyRespectsStride)
@@ -4053,7 +4053,8 @@ protected:
 };
 
 
-TYPED_TEST_SUITE(DenseComplex, gko::test::ComplexValueTypes);
+TYPED_TEST_SUITE(DenseComplex, gko::test::ComplexValueTypes,
+                 TypenameNameGenerator);
 
 
 TYPED_TEST(DenseComplex, ScalesWithRealScalar)

--- a/reference/test/matrix/diagonal_kernels.cpp
+++ b/reference/test/matrix/diagonal_kernels.cpp
@@ -105,7 +105,7 @@ protected:
     std::unique_ptr<Dense> dense2;
 };
 
-TYPED_TEST_SUITE(Diagonal, gko::test::ValueTypes);
+TYPED_TEST_SUITE(Diagonal, gko::test::ValueTypes, TypenameNameGenerator);
 
 
 TYPED_TEST(Diagonal, ConvertsToPrecision)
@@ -634,7 +634,8 @@ protected:
     using Diag = gko::matrix::Diagonal<value_type>;
 };
 
-TYPED_TEST_SUITE(DiagonalComplex, gko::test::ComplexValueTypes);
+TYPED_TEST_SUITE(DiagonalComplex, gko::test::ComplexValueTypes,
+                 TypenameNameGenerator);
 
 
 TYPED_TEST(DiagonalComplex, MtxIsConjugateTransposable)

--- a/reference/test/matrix/ell_kernels.cpp
+++ b/reference/test/matrix/ell_kernels.cpp
@@ -105,7 +105,7 @@ protected:
     std::unique_ptr<Mtx> mtx2;
 };
 
-TYPED_TEST_SUITE(Ell, gko::test::ValueIndexTypes);
+TYPED_TEST_SUITE(Ell, gko::test::ValueIndexTypes, PairTypenameNameGenerator);
 
 
 TYPED_TEST(Ell, AppliesToDenseVector)
@@ -1022,7 +1022,8 @@ protected:
     using Mtx = gko::matrix::Ell<value_type, index_type>;
 };
 
-TYPED_TEST_SUITE(EllComplex, gko::test::ComplexValueIndexTypes);
+TYPED_TEST_SUITE(EllComplex, gko::test::ComplexValueIndexTypes,
+                 PairTypenameNameGenerator);
 
 
 TYPED_TEST(EllComplex, InplaceAbsolute)

--- a/reference/test/matrix/fbcsr_kernels.cpp
+++ b/reference/test/matrix/fbcsr_kernels.cpp
@@ -135,7 +135,7 @@ protected:
     const std::unique_ptr<const Mtx> mtxsq;
 };
 
-TYPED_TEST_SUITE(Fbcsr, gko::test::ValueIndexTypes);
+TYPED_TEST_SUITE(Fbcsr, gko::test::ValueIndexTypes, PairTypenameNameGenerator);
 
 
 template <typename T>
@@ -690,7 +690,8 @@ protected:
     using Csr = gko::matrix::Csr<value_type, index_type>;
 };
 
-TYPED_TEST_SUITE(FbcsrComplex, gko::test::ComplexValueIndexTypes);
+TYPED_TEST_SUITE(FbcsrComplex, gko::test::ComplexValueIndexTypes,
+                 PairTypenameNameGenerator);
 
 
 TYPED_TEST(FbcsrComplex, ConvertsComplexToCsr)

--- a/reference/test/matrix/fft_kernels.cpp
+++ b/reference/test/matrix/fft_kernels.cpp
@@ -181,7 +181,7 @@ protected:
     std::unique_ptr<Vec> dense_ifft3;
 };
 
-TYPED_TEST_SUITE(Fft, gko::test::ComplexValueTypes);
+TYPED_TEST_SUITE(Fft, gko::test::ComplexValueTypes, TypenameNameGenerator);
 
 
 TYPED_TEST(Fft, ThrowsOnNonPowerOfTwo1D)

--- a/reference/test/matrix/hybrid_kernels.cpp
+++ b/reference/test/matrix/hybrid_kernels.cpp
@@ -131,7 +131,7 @@ protected:
     std::unique_ptr<Mtx> mtx3;
 };
 
-TYPED_TEST_SUITE(Hybrid, gko::test::ValueIndexTypes);
+TYPED_TEST_SUITE(Hybrid, gko::test::ValueIndexTypes, PairTypenameNameGenerator);
 
 
 TYPED_TEST(Hybrid, AppliesToDenseVector)
@@ -838,7 +838,8 @@ protected:
     using Mtx = gko::matrix::Hybrid<value_type, index_type>;
 };
 
-TYPED_TEST_SUITE(HybridComplex, gko::test::ComplexValueIndexTypes);
+TYPED_TEST_SUITE(HybridComplex, gko::test::ComplexValueIndexTypes,
+                 PairTypenameNameGenerator);
 
 
 TYPED_TEST(HybridComplex, OutplaceAbsolute)

--- a/reference/test/matrix/identity.cpp
+++ b/reference/test/matrix/identity.cpp
@@ -61,7 +61,7 @@ protected:
 };
 
 
-TYPED_TEST_SUITE(Identity, gko::test::ValueTypes);
+TYPED_TEST_SUITE(Identity, gko::test::ValueTypes, TypenameNameGenerator);
 
 
 TYPED_TEST(Identity, AppliesToVector)

--- a/reference/test/matrix/permutation.cpp
+++ b/reference/test/matrix/permutation.cpp
@@ -63,7 +63,8 @@ protected:
     std::shared_ptr<const gko::Executor> exec;
 };
 
-TYPED_TEST_SUITE(Permutation, gko::test::ValueIndexTypes);
+TYPED_TEST_SUITE(Permutation, gko::test::ValueIndexTypes,
+                 PairTypenameNameGenerator);
 
 
 TYPED_TEST(Permutation, AppliesRowPermutationToDense)

--- a/reference/test/matrix/sellp_kernels.cpp
+++ b/reference/test/matrix/sellp_kernels.cpp
@@ -81,7 +81,7 @@ protected:
     std::unique_ptr<Mtx> mtx2;
 };
 
-TYPED_TEST_SUITE(Sellp, gko::test::ValueIndexTypes);
+TYPED_TEST_SUITE(Sellp, gko::test::ValueIndexTypes, PairTypenameNameGenerator);
 
 
 TYPED_TEST(Sellp, AppliesToDenseVector)
@@ -789,7 +789,8 @@ protected:
     using Mtx = gko::matrix::Sellp<value_type, index_type>;
 };
 
-TYPED_TEST_SUITE(SellpComplex, gko::test::ComplexValueIndexTypes);
+TYPED_TEST_SUITE(SellpComplex, gko::test::ComplexValueIndexTypes,
+                 PairTypenameNameGenerator);
 
 
 TYPED_TEST(SellpComplex, OutplaceAbsolute)

--- a/reference/test/matrix/sparsity_csr.cpp
+++ b/reference/test/matrix/sparsity_csr.cpp
@@ -79,7 +79,8 @@ protected:
     std::unique_ptr<Mtx> mtx;
 };
 
-TYPED_TEST_SUITE(SparsityCsr, gko::test::ValueIndexTypes);
+TYPED_TEST_SUITE(SparsityCsr, gko::test::ValueIndexTypes,
+                 PairTypenameNameGenerator);
 
 
 TYPED_TEST(SparsityCsr, CanBeCreatedFromExistingCsrMatrix)

--- a/reference/test/matrix/sparsity_csr_kernels.cpp
+++ b/reference/test/matrix/sparsity_csr_kernels.cpp
@@ -157,7 +157,8 @@ protected:
     std::unique_ptr<Mtx> mtx3_unsorted;
 };
 
-TYPED_TEST_SUITE(SparsityCsr, gko::test::ValueIndexTypes);
+TYPED_TEST_SUITE(SparsityCsr, gko::test::ValueIndexTypes,
+                 PairTypenameNameGenerator);
 
 
 TYPED_TEST(SparsityCsr, AppliesToDenseVector)

--- a/reference/test/multigrid/amgx_pgm_kernels.cpp
+++ b/reference/test/multigrid/amgx_pgm_kernels.cpp
@@ -215,7 +215,8 @@ protected:
     std::unique_ptr<MgLevel> mg_level;
 };
 
-TYPED_TEST_SUITE(AmgxPgm, gko::test::ValueIndexTypes);
+TYPED_TEST_SUITE(AmgxPgm, gko::test::ValueIndexTypes,
+                 PairTypenameNameGenerator);
 
 
 TYPED_TEST(AmgxPgm, CanBeCopied)

--- a/reference/test/preconditioner/ic.cpp
+++ b/reference/test/preconditioner/ic.cpp
@@ -100,7 +100,7 @@ protected:
     gko::remove_complex<value_type> tol;
 };
 
-TYPED_TEST_SUITE(Ic, gko::test::ValueIndexTypes);
+TYPED_TEST_SUITE(Ic, gko::test::ValueIndexTypes, PairTypenameNameGenerator);
 
 
 TYPED_TEST(Ic, BuildsTwoFactorComposition)

--- a/reference/test/preconditioner/ilu.cpp
+++ b/reference/test/preconditioner/ilu.cpp
@@ -125,7 +125,7 @@ protected:
     std::shared_ptr<typename ilu_rev_prec_type::Factory> ilu_rev_pre_factory;
 };
 
-TYPED_TEST_SUITE(Ilu, gko::test::ValueTypes);
+TYPED_TEST_SUITE(Ilu, gko::test::ValueTypes, TypenameNameGenerator);
 
 
 TYPED_TEST(Ilu, BuildsDefaultWithoutThrowing)

--- a/reference/test/preconditioner/isai_kernels.cpp
+++ b/reference/test/preconditioner/isai_kernels.cpp
@@ -323,7 +323,7 @@ protected:
     std::shared_ptr<Csr> spd_sparse_inv;
 };
 
-TYPED_TEST_SUITE(Isai, gko::test::ValueIndexTypes);
+TYPED_TEST_SUITE(Isai, gko::test::ValueIndexTypes, PairTypenameNameGenerator);
 
 
 TYPED_TEST(Isai, KernelGenerateA)

--- a/reference/test/preconditioner/jacobi.cpp
+++ b/reference/test/preconditioner/jacobi.cpp
@@ -176,7 +176,7 @@ protected:
     std::unique_ptr<Bj> adaptive_bj;
 };
 
-TYPED_TEST_SUITE(Jacobi, gko::test::ValueIndexTypes);
+TYPED_TEST_SUITE(Jacobi, gko::test::ValueIndexTypes, PairTypenameNameGenerator);
 
 
 TYPED_TEST(Jacobi, GeneratesCorrectStorageScheme)

--- a/reference/test/preconditioner/jacobi_kernels.cpp
+++ b/reference/test/preconditioner/jacobi_kernels.cpp
@@ -119,7 +119,7 @@ protected:
     std::shared_ptr<gko::matrix::Csr<value_type, index_type>> mtx;
 };
 
-TYPED_TEST_SUITE(Jacobi, gko::test::ValueIndexTypes);
+TYPED_TEST_SUITE(Jacobi, gko::test::ValueIndexTypes, PairTypenameNameGenerator);
 
 
 TYPED_TEST(Jacobi, CanBeGenerated)

--- a/reference/test/reorder/rcm.cpp
+++ b/reference/test/reorder/rcm.cpp
@@ -87,7 +87,7 @@ protected:
     std::unique_ptr<reorder_type> reorder_op;
 };
 
-TYPED_TEST_SUITE(Rcm, gko::test::ValueIndexTypes);
+TYPED_TEST_SUITE(Rcm, gko::test::ValueIndexTypes, PairTypenameNameGenerator);
 
 
 TYPED_TEST(Rcm, CanBeCleared)

--- a/reference/test/solver/bicg_kernels.cpp
+++ b/reference/test/solver/bicg_kernels.cpp
@@ -160,7 +160,7 @@ protected:
     std::unique_ptr<typename Solver::Factory> bicg_factory_non_symmetric;
 };
 
-TYPED_TEST_SUITE(Bicg, gko::test::ValueTypes);
+TYPED_TEST_SUITE(Bicg, gko::test::ValueTypes, TypenameNameGenerator);
 
 
 TYPED_TEST(Bicg, KernelInitialize)

--- a/reference/test/solver/bicgstab_kernels.cpp
+++ b/reference/test/solver/bicgstab_kernels.cpp
@@ -160,7 +160,7 @@ protected:
     std::unique_ptr<typename Solver::Factory> bicgstab_factory_precision;
 };
 
-TYPED_TEST_SUITE(Bicgstab, gko::test::ValueTypes);
+TYPED_TEST_SUITE(Bicgstab, gko::test::ValueTypes, TypenameNameGenerator);
 
 
 TYPED_TEST(Bicgstab, KernelInitialize)

--- a/reference/test/solver/cb_gmres_kernels.cpp
+++ b/reference/test/solver/cb_gmres_kernels.cpp
@@ -182,7 +182,7 @@ using TestTypes =
                      std::tuple<std::complex<double>, st_r2>,
                      std::tuple<std::complex<float>, st_keep>>;
 
-TYPED_TEST_SUITE(CbGmres, TestTypes);
+TYPED_TEST_SUITE(CbGmres, TestTypes, PairTypenameNameGenerator);
 
 
 TYPED_TEST(CbGmres, SolvesStencilSystem)

--- a/reference/test/solver/cg_kernels.cpp
+++ b/reference/test/solver/cg_kernels.cpp
@@ -147,7 +147,7 @@ protected:
     std::unique_ptr<typename Solver::Factory> cg_factory_big2;
 };
 
-TYPED_TEST_SUITE(Cg, gko::test::ValueTypes);
+TYPED_TEST_SUITE(Cg, gko::test::ValueTypes, TypenameNameGenerator);
 
 
 TYPED_TEST(Cg, KernelInitialize)

--- a/reference/test/solver/cgs_kernels.cpp
+++ b/reference/test/solver/cgs_kernels.cpp
@@ -160,7 +160,7 @@ protected:
     std::unique_ptr<typename Solver::Factory> cgs_factory_big2;
 };
 
-TYPED_TEST_SUITE(Cgs, gko::test::ValueTypes);
+TYPED_TEST_SUITE(Cgs, gko::test::ValueTypes, TypenameNameGenerator);
 
 
 TYPED_TEST(Cgs, KernelInitialize)

--- a/reference/test/solver/fcg_kernels.cpp
+++ b/reference/test/solver/fcg_kernels.cpp
@@ -151,7 +151,7 @@ protected:
     std::unique_ptr<typename Solver::Factory> fcg_factory_big2;
 };
 
-TYPED_TEST_SUITE(Fcg, gko::test::ValueTypes);
+TYPED_TEST_SUITE(Fcg, gko::test::ValueTypes, TypenameNameGenerator);
 
 
 TYPED_TEST(Fcg, KernelInitialize)

--- a/reference/test/solver/gmres_kernels.cpp
+++ b/reference/test/solver/gmres_kernels.cpp
@@ -118,7 +118,7 @@ protected:
     std::unique_ptr<typename Solver::Factory> gmres_factory_big2;
 };
 
-TYPED_TEST_SUITE(Gmres, gko::test::ValueTypes);
+TYPED_TEST_SUITE(Gmres, gko::test::ValueTypes, TypenameNameGenerator);
 
 
 TYPED_TEST(Gmres, SolvesStencilSystem)

--- a/reference/test/solver/idr_kernels.cpp
+++ b/reference/test/solver/idr_kernels.cpp
@@ -95,7 +95,7 @@ protected:
     std::unique_ptr<typename Solver::Factory> idr_factory_precision;
 };
 
-TYPED_TEST_SUITE(Idr, gko::test::ValueTypes);
+TYPED_TEST_SUITE(Idr, gko::test::ValueTypes, TypenameNameGenerator);
 
 
 TYPED_TEST(Idr, SolvesDenseSystem)

--- a/reference/test/solver/ir_kernels.cpp
+++ b/reference/test/solver/ir_kernels.cpp
@@ -81,7 +81,7 @@ protected:
     std::unique_ptr<typename Solver::Factory> ir_factory;
 };
 
-TYPED_TEST_SUITE(Ir, gko::test::ValueTypes);
+TYPED_TEST_SUITE(Ir, gko::test::ValueTypes, TypenameNameGenerator);
 
 
 TYPED_TEST(Ir, KernelInitialize)

--- a/reference/test/solver/lower_trs.cpp
+++ b/reference/test/solver/lower_trs.cpp
@@ -78,7 +78,8 @@ protected:
     std::unique_ptr<Solver> solver;
 };
 
-TYPED_TEST_SUITE(LowerTrs, gko::test::ValueIndexTypes);
+TYPED_TEST_SUITE(LowerTrs, gko::test::ValueIndexTypes,
+                 PairTypenameNameGenerator);
 
 
 TYPED_TEST(LowerTrs, LowerTrsFactoryCreatesCorrectSolver)

--- a/reference/test/solver/lower_trs_kernels.cpp
+++ b/reference/test/solver/lower_trs_kernels.cpp
@@ -93,7 +93,8 @@ protected:
     std::unique_ptr<typename Solver::Factory> lower_trs_factory_big;
 };
 
-TYPED_TEST_SUITE(LowerTrs, gko::test::ValueIndexTypes);
+TYPED_TEST_SUITE(LowerTrs, gko::test::ValueIndexTypes,
+                 PairTypenameNameGenerator);
 
 
 TYPED_TEST(LowerTrs, RefLowerTrsFlagCheckIsCorrect)

--- a/reference/test/solver/multigrid_kernels.cpp
+++ b/reference/test/solver/multigrid_kernels.cpp
@@ -474,7 +474,8 @@ protected:
     std::shared_ptr<Mtx> x2;
 };
 using VIT = ::testing::Types<std::tuple<double, gko::int32>>;
-TYPED_TEST_CASE(Multigrid, gko::test::ValueIndexTypes);
+TYPED_TEST_CASE(Multigrid, gko::test::ValueIndexTypes,
+                PairTypenameNameGenerator);
 
 
 TYPED_TEST(Multigrid, KCycleStep1)

--- a/reference/test/solver/upper_trs.cpp
+++ b/reference/test/solver/upper_trs.cpp
@@ -78,7 +78,8 @@ protected:
     std::unique_ptr<Solver> upper_trs_solver;
 };
 
-TYPED_TEST_SUITE(UpperTrs, gko::test::ValueIndexTypes);
+TYPED_TEST_SUITE(UpperTrs, gko::test::ValueIndexTypes,
+                 PairTypenameNameGenerator);
 
 
 TYPED_TEST(UpperTrs, UpperTrsFactoryCreatesCorrectSolver)

--- a/reference/test/solver/upper_trs_kernels.cpp
+++ b/reference/test/solver/upper_trs_kernels.cpp
@@ -91,7 +91,8 @@ protected:
     std::unique_ptr<typename Solver::Factory> upper_trs_factory_mrhs;
 };
 
-TYPED_TEST_SUITE(UpperTrs, gko::test::ValueIndexTypes);
+TYPED_TEST_SUITE(UpperTrs, gko::test::ValueIndexTypes,
+                 PairTypenameNameGenerator);
 
 
 TYPED_TEST(UpperTrs, RefUpperTrsFlagCheckIsCorrect)

--- a/reference/test/stop/residual_norm_kernels.cpp
+++ b/reference/test/stop/residual_norm_kernels.cpp
@@ -77,7 +77,7 @@ protected:
     std::shared_ptr<const gko::Executor> exec_;
 };
 
-TYPED_TEST_SUITE(ResidualNorm, gko::test::ValueTypes);
+TYPED_TEST_SUITE(ResidualNorm, gko::test::ValueTypes, TypenameNameGenerator);
 
 
 TYPED_TEST(ResidualNorm, CanCreateFactory)
@@ -567,7 +567,8 @@ protected:
     std::shared_ptr<const gko::ReferenceExecutor> exec_;
 };
 
-TYPED_TEST_SUITE(ResidualNormReduction, gko::test::ValueTypes);
+TYPED_TEST_SUITE(ResidualNormReduction, gko::test::ValueTypes,
+                 TypenameNameGenerator);
 
 
 TYPED_TEST(ResidualNormReduction,
@@ -718,7 +719,8 @@ protected:
     std::shared_ptr<const gko::Executor> exec_;
 };
 
-TYPED_TEST_SUITE(RelativeResidualNorm, gko::test::ValueTypes);
+TYPED_TEST_SUITE(RelativeResidualNorm, gko::test::ValueTypes,
+                 TypenameNameGenerator);
 
 
 TYPED_TEST(RelativeResidualNorm, CanCreateFactory)
@@ -864,7 +866,8 @@ protected:
     std::shared_ptr<const gko::Executor> exec_;
 };
 
-TYPED_TEST_SUITE(ImplicitResidualNorm, gko::test::ValueTypes);
+TYPED_TEST_SUITE(ImplicitResidualNorm, gko::test::ValueTypes,
+                 TypenameNameGenerator);
 
 
 TYPED_TEST(ImplicitResidualNorm, CanCreateFactory)
@@ -1016,7 +1019,8 @@ protected:
     std::shared_ptr<const gko::Executor> exec_;
 };
 
-TYPED_TEST_SUITE(AbsoluteResidualNorm, gko::test::ValueTypes);
+TYPED_TEST_SUITE(AbsoluteResidualNorm, gko::test::ValueTypes,
+                 TypenameNameGenerator);
 
 
 TYPED_TEST(AbsoluteResidualNorm, CanCreateFactory)

--- a/reference/test/utils/assertions_test.cpp
+++ b/reference/test/utils/assertions_test.cpp
@@ -48,7 +48,7 @@ namespace {
 template <typename T>
 class MatricesNear : public ::testing::Test {};
 
-TYPED_TEST_SUITE(MatricesNear, gko::test::ValueTypes);
+TYPED_TEST_SUITE(MatricesNear, gko::test::ValueTypes, TypenameNameGenerator);
 
 
 TYPED_TEST(MatricesNear, CanPassAnyMatrixType)


### PR DESCRIPTION
This passes a suitable NameGenerator to all templated tests, which results in a more descriptive test name:
Before:
`Csr/7.GeneratesCorrectMatrixData`
After
`Csr/<std::complex<double>, long>.GeneratesCorrectMatrixData`