### PR TITLE
Add support for Batch Operators

### DIFF
--- a/core/log/logger.cpp
+++ b/core/log/logger.cpp
@@ -41,6 +41,8 @@ constexpr Logger::mask_type Logger::all_events_mask;
 constexpr Logger::mask_type Logger::executor_events_mask;
 constexpr Logger::mask_type Logger::operation_events_mask;
 constexpr Logger::mask_type Logger::polymorphic_object_events_mask;
+constexpr Logger::mask_type Logger::batch_linop_events_mask;
+constexpr Logger::mask_type Logger::batch_linop_factory_events_mask;
 constexpr Logger::mask_type Logger::linop_events_mask;
 constexpr Logger::mask_type Logger::linop_factory_events_mask;
 constexpr Logger::mask_type Logger::criterion_events_mask;
@@ -62,6 +64,14 @@ constexpr Logger::mask_type Logger::polymorphic_object_copy_completed_mask;
 constexpr Logger::mask_type Logger::polymorphic_object_move_started_mask;
 constexpr Logger::mask_type Logger::polymorphic_object_move_completed_mask;
 constexpr Logger::mask_type Logger::polymorphic_object_deleted_mask;
+
+constexpr Logger::mask_type Logger::batch_linop_apply_started_mask;
+constexpr Logger::mask_type Logger::batch_linop_apply_completed_mask;
+constexpr Logger::mask_type Logger::batch_linop_advanced_apply_started_mask;
+constexpr Logger::mask_type Logger::batch_linop_advanced_apply_completed_mask;
+
+constexpr Logger::mask_type Logger::batch_linop_factory_generate_started_mask;
+constexpr Logger::mask_type Logger::batch_linop_factory_generate_completed_mask;
 
 constexpr Logger::mask_type Logger::linop_apply_started_mask;
 constexpr Logger::mask_type Logger::linop_apply_completed_mask;

--- a/core/test/base/CMakeLists.txt
+++ b/core/test/base/CMakeLists.txt
@@ -1,6 +1,8 @@
 ginkgo_create_test(abstract_factory)
 ginkgo_create_test(allocator)
 ginkgo_create_test(array)
+ginkgo_create_test(batch_dim)
+ginkgo_create_test(batch_lin_op)
 ginkgo_create_test(dense_cache)
 ginkgo_create_test(combination)
 ginkgo_create_test(composition)

--- a/core/test/base/batch_dim.cpp
+++ b/core/test/base/batch_dim.cpp
@@ -30,13 +30,14 @@ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ******************************<GINKGO LICENSE>*******************************/
 
+#include <ginkgo/core/base/batch_dim.hpp>
+
+
 #include <memory>
+#include <vector>
 
 
 #include <gtest/gtest.h>
-
-
-#include <ginkgo/core/base/batch_dim.hpp>
 
 
 namespace {

--- a/core/test/base/batch_dim.cpp
+++ b/core/test/base/batch_dim.cpp
@@ -1,0 +1,171 @@
+/*******************************<GINKGO LICENSE>******************************
+Copyright (c) 2017-2021, the Ginkgo authors
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+******************************<GINKGO LICENSE>*******************************/
+
+#include <memory>
+
+
+#include <gtest/gtest.h>
+
+
+#include <ginkgo/core/base/batch_dim.hpp>
+
+
+namespace {
+
+
+TEST(BatchDim, ConstructsCorrectUniformObject)
+{
+    gko::batch_dim<2> d{4, gko::dim<2>(5)};
+
+    ASSERT_EQ(d.stores_equal_sizes(), true);
+    ASSERT_EQ(d.get_num_batch_entries(), 4);
+    ASSERT_EQ(d.get_batch_sizes()[0], gko::dim<2>(5));
+    ASSERT_EQ(d.get_batch_sizes()[3], gko::dim<2>(5));
+}
+
+
+TEST(BatchDim, ConstructsCorrectNonUniformObject)
+{
+    gko::batch_dim<3> d{std::vector<gko::dim<3>>{gko::dim<3>(1), gko::dim<3>(5),
+                                                 gko::dim<3>(2)}};
+
+    ASSERT_EQ(d.stores_equal_sizes(), false);
+    ASSERT_EQ(d.get_num_batch_entries(), 3);
+    ASSERT_EQ(d.get_batch_sizes()[0], gko::dim<3>(1));
+    ASSERT_EQ(d.get_batch_sizes()[2], gko::dim<3>(2));
+}
+
+
+TEST(BatchDim, ConstructsNullObject)
+{
+    gko::batch_dim<2> d{};
+
+    ASSERT_EQ(d.get_num_batch_entries(), 0);
+    ASSERT_EQ(d.get_batch_sizes()[0], gko::dim<2>{});
+}
+
+
+class batch_dim_manager {
+public:
+    using batch_dim = gko::batch_dim<3>;
+    const batch_dim& get_size() const { return size_; }
+
+    static std::unique_ptr<batch_dim_manager> create(const batch_dim& size)
+    {
+        return std::unique_ptr<batch_dim_manager>{new batch_dim_manager{size}};
+    }
+
+private:
+    batch_dim_manager(const batch_dim& size) : size_{size} {}
+    batch_dim size_;
+};
+
+
+TEST(BatchDim, CopiesProperlyOnHeap)
+{
+    auto manager =
+        batch_dim_manager::create(gko::batch_dim<3>{std::vector<gko::dim<3>>{
+            gko::dim<3>(1), gko::dim<3>(5), gko::dim<3>(2)}}
+
+        );
+
+    const gko::batch_dim<3> copy = manager->get_size();
+
+    ASSERT_EQ(copy.stores_equal_sizes(), false);
+    ASSERT_EQ(copy.get_num_batch_entries(), 3);
+    ASSERT_EQ(copy.get_batch_sizes()[0], gko::dim<3>(1));
+    ASSERT_EQ(copy.get_batch_sizes()[2], gko::dim<3>(2));
+}
+
+
+TEST(BatchDim, EqualityReturnsTrueWhenEqual)
+{
+    ASSERT_TRUE(gko::batch_dim<2>(2, gko::dim<2>{3}) ==
+                gko::batch_dim<2>(2, gko::dim<2>{3}));
+}
+
+
+TEST(BatchDim, EqualityReturnsFalseWhenDifferentNumBatches)
+{
+    ASSERT_FALSE(gko::batch_dim<2>(3, gko::dim<2>{3}) ==
+                 gko::batch_dim<2>(2, gko::dim<2>{3}));
+}
+
+
+TEST(BatchDim, EqualityReturnsFalseWhenDifferentBatchSizes)
+{
+    ASSERT_FALSE(gko::batch_dim<2>(3, gko::dim<2>{3}) ==
+                 gko::batch_dim<2>(3, gko::dim<2>{4}));
+}
+
+
+TEST(BatchDim, EqualityReturnsFalseWhenOneBatchSizeIsDifferent)
+{
+    ASSERT_FALSE(gko::batch_dim<2>(std::vector<gko::dim<2>>{gko::dim<2>{4},
+                                                            gko::dim<2>{3}}) ==
+                 gko::batch_dim<2>(
+                     std::vector<gko::dim<2>>{gko::dim<2>{4}, gko::dim<2>{2}}));
+}
+
+
+TEST(BatchDim, CanDetectUniformBatchesWhenUsingNonUniformBatchConstructor)
+{
+    auto b1 = gko::batch_dim<2>(std::vector<gko::dim<2>>{
+        gko::dim<2>{3}, gko::dim<2>{3}, gko::dim<2>{3}});
+    ASSERT_TRUE(b1.stores_equal_sizes());
+}
+
+
+TEST(BatchDim, NotEqualWorks)
+{
+    ASSERT_TRUE(gko::batch_dim<2>(3, gko::dim<2>{3}) !=
+                gko::batch_dim<2>(3, gko::dim<2>{4}));
+}
+
+
+TEST(BatchDim, TransposesNonUniformBatchDimensions)
+{
+    ASSERT_EQ(gko::transpose(gko::batch_dim<2>(
+                  std::vector<gko::dim<2>>{gko::dim<2>{4, 2}, gko::dim<2>{3}})),
+              gko::batch_dim<2>(
+                  std::vector<gko::dim<2>>{gko::dim<2>{2, 4}, gko::dim<2>{3}}));
+}
+
+
+TEST(BatchDim, TransposesUniformBatchDimensions)
+{
+    ASSERT_EQ(gko::transpose(gko::batch_dim<2>(3, gko::dim<2>{4, 2})),
+              gko::batch_dim<2>(3, gko::dim<2>{2, 4}));
+}
+
+
+}  // namespace

--- a/core/test/base/batch_lin_op.cpp
+++ b/core/test/base/batch_lin_op.cpp
@@ -1,0 +1,414 @@
+/*******************************<GINKGO LICENSE>******************************
+Copyright (c) 2017-2021, the Ginkgo authors
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+******************************<GINKGO LICENSE>*******************************/
+
+#include <ginkgo/core/base/batch_lin_op.hpp>
+#include <ginkgo/core/base/lin_op.hpp>
+
+
+#include <complex>
+#include <memory>
+#include <type_traits>
+#include <vector>
+
+
+#include <gtest/gtest.h>
+
+
+#include <ginkgo/core/base/math.hpp>
+
+
+namespace {
+
+
+class DummyBatchLinOp : public gko::EnableBatchLinOp<DummyBatchLinOp>,
+                        public gko::EnableCreateMethod<DummyBatchLinOp> {
+public:
+    DummyBatchLinOp(std::shared_ptr<const gko::Executor> exec,
+                    std::vector<gko::dim<2>> size = std::vector<gko::dim<2>>{})
+        : EnableBatchLinOp<DummyBatchLinOp>(exec, size)
+    {}
+
+    void access() const { last_access = this->get_executor(); }
+
+    mutable std::shared_ptr<const gko::Executor> last_access;
+    mutable std::shared_ptr<const gko::Executor> last_b_access;
+    mutable std::shared_ptr<const gko::Executor> last_x_access;
+    mutable std::shared_ptr<const gko::Executor> last_alpha_access;
+    mutable std::shared_ptr<const gko::Executor> last_beta_access;
+
+protected:
+    void apply_impl(const gko::BatchLinOp* b, gko::BatchLinOp* x) const override
+    {
+        this->access();
+        static_cast<const DummyBatchLinOp*>(b)->access();
+        static_cast<const DummyBatchLinOp*>(x)->access();
+        last_b_access = b->get_executor();
+        last_x_access = x->get_executor();
+    }
+
+    void apply_impl(const gko::BatchLinOp* alpha, const gko::BatchLinOp* b,
+                    const gko::BatchLinOp* beta,
+                    gko::BatchLinOp* x) const override
+    {
+        this->access();
+        static_cast<const DummyBatchLinOp*>(alpha)->access();
+        static_cast<const DummyBatchLinOp*>(b)->access();
+        static_cast<const DummyBatchLinOp*>(beta)->access();
+        static_cast<const DummyBatchLinOp*>(x)->access();
+        last_alpha_access = alpha->get_executor();
+        last_b_access = b->get_executor();
+        last_beta_access = beta->get_executor();
+        last_x_access = x->get_executor();
+    }
+};
+
+
+class EnableBatchLinOp : public ::testing::Test {
+protected:
+    EnableBatchLinOp()
+        : ref{gko::ReferenceExecutor::create()},
+          ref2{gko::ReferenceExecutor::create()},
+          op{DummyBatchLinOp::create(
+              ref2, std::vector<gko::dim<2>>{gko::dim<2>{3, 5}})},
+          op2{DummyBatchLinOp::create(
+              ref2,
+              std::vector<gko::dim<2>>{gko::dim<2>{3, 5}, gko::dim<2>{3, 5}})},
+          alpha{DummyBatchLinOp::create(
+              ref, std::vector<gko::dim<2>>{gko::dim<2>{1}})},
+          alpha2{DummyBatchLinOp::create(
+              ref, std::vector<gko::dim<2>>{gko::dim<2>{1}, gko::dim<2>{1}})},
+          beta{DummyBatchLinOp::create(
+              ref, std::vector<gko::dim<2>>{gko::dim<2>{1}})},
+          beta2{DummyBatchLinOp::create(
+              ref, std::vector<gko::dim<2>>{gko::dim<2>{1}, gko::dim<2>{1}})},
+          b{DummyBatchLinOp::create(
+              ref, std::vector<gko::dim<2>>{gko::dim<2>{5, 4}})},
+          b2{DummyBatchLinOp::create(
+              ref,
+              std::vector<gko::dim<2>>{gko::dim<2>{5, 4}, gko::dim<2>{5, 4}})},
+          x{DummyBatchLinOp::create(
+              ref, std::vector<gko::dim<2>>{gko::dim<2>{3, 4}})},
+          x2{DummyBatchLinOp::create(
+              ref,
+              std::vector<gko::dim<2>>{gko::dim<2>{3, 4}, gko::dim<2>{3, 4}})}
+    {}
+
+    std::shared_ptr<const gko::ReferenceExecutor> ref;
+    std::shared_ptr<const gko::ReferenceExecutor> ref2;
+    std::unique_ptr<DummyBatchLinOp> op;
+    std::unique_ptr<DummyBatchLinOp> op2;
+    std::unique_ptr<DummyBatchLinOp> alpha;
+    std::unique_ptr<DummyBatchLinOp> alpha2;
+    std::unique_ptr<DummyBatchLinOp> beta;
+    std::unique_ptr<DummyBatchLinOp> beta2;
+    std::unique_ptr<DummyBatchLinOp> b;
+    std::unique_ptr<DummyBatchLinOp> b2;
+    std::unique_ptr<DummyBatchLinOp> x;
+    std::unique_ptr<DummyBatchLinOp> x2;
+};
+
+
+TEST_F(EnableBatchLinOp, KnowsNumBatches)
+{
+    ASSERT_EQ(op->get_num_batch_entries(), 1);
+    ASSERT_EQ(op2->get_num_batch_entries(), 2);
+}
+
+
+TEST_F(EnableBatchLinOp, KnowsItsSizes)
+{
+    auto op1_sizes =
+        gko::batch_dim<2>(std::vector<gko::dim<2>>{gko::dim<2>{3, 5}});
+    auto op2_sizes = gko::batch_dim<2>(
+        std::vector<gko::dim<2>>{gko::dim<2>{3, 5}, gko::dim<2>{3, 5}});
+    ASSERT_EQ(op->get_size(), op1_sizes);
+    ASSERT_EQ(op2->get_size(), op2_sizes);
+}
+
+
+TEST_F(EnableBatchLinOp, CallsApplyImpl)
+{
+    op->apply(gko::lend(b), gko::lend(x));
+
+    ASSERT_EQ(op->last_access, ref2);
+}
+
+
+TEST_F(EnableBatchLinOp, CallsApplyImplForBatch)
+{
+    op2->apply(gko::lend(b2), gko::lend(x2));
+
+    ASSERT_EQ(op2->last_access, ref2);
+}
+
+
+TEST_F(EnableBatchLinOp, CallsExtendedApplyImpl)
+{
+    op->apply(gko::lend(alpha), gko::lend(b), gko::lend(beta), gko::lend(x));
+
+    ASSERT_EQ(op->last_access, ref2);
+}
+
+
+TEST_F(EnableBatchLinOp, CallsExtendedApplyImplBatch)
+{
+    op2->apply(gko::lend(alpha2), gko::lend(b2), gko::lend(beta2),
+               gko::lend(x2));
+
+    ASSERT_EQ(op2->last_access, ref2);
+}
+
+
+TEST_F(EnableBatchLinOp, ApplyFailsOnWrongBSize)
+{
+    auto wrong = DummyBatchLinOp::create(
+        ref, std::vector<gko::dim<2>>{gko::dim<2>{3, 4}});
+
+    ASSERT_THROW(op->apply(gko::lend(wrong), gko::lend(x)),
+                 gko::DimensionMismatch);
+}
+
+
+TEST_F(EnableBatchLinOp, ApplyFailsOnWrongBatchSize)
+{
+    auto wrong = DummyBatchLinOp::create(
+        ref, std::vector<gko::dim<2>>{gko::dim<2>{3, 4}});
+
+    ASSERT_THROW(op2->apply(gko::lend(wrong), gko::lend(x2)),
+                 gko::DimensionMismatch);
+}
+
+
+TEST_F(EnableBatchLinOp, ApplyFailsOnWrongSolutionRows)
+{
+    auto wrong = DummyBatchLinOp::create(
+        ref, std::vector<gko::dim<2>>{gko::dim<2>{5, 4}});
+
+    ASSERT_THROW(op->apply(gko::lend(b), gko::lend(wrong)),
+                 gko::DimensionMismatch);
+}
+
+
+TEST_F(EnableBatchLinOp, ApplyFailsOnOneBatchWrongSolutionRows)
+{
+    auto wrong = DummyBatchLinOp::create(
+        ref, std::vector<gko::dim<2>>{gko::dim<2>{5, 4}, gko::dim<2>{5, 4}});
+
+    ASSERT_THROW(op2->apply(gko::lend(b2), gko::lend(wrong)),
+                 gko::DimensionMismatch);
+}
+
+
+TEST_F(EnableBatchLinOp, ApplyFailsOnWrongSolutionColumns)
+{
+    auto wrong = DummyBatchLinOp::create(
+        ref, std::vector<gko::dim<2>>{gko::dim<2>{3, 5}});
+
+    ASSERT_THROW(op->apply(gko::lend(b), gko::lend(wrong)),
+                 gko::DimensionMismatch);
+}
+
+
+TEST_F(EnableBatchLinOp, ExtendedApplyFailsOnWrongBSize)
+{
+    auto wrong = DummyBatchLinOp::create(
+        ref, std::vector<gko::dim<2>>{gko::dim<2>{3, 4}});
+
+    ASSERT_THROW(op->apply(gko::lend(alpha), gko::lend(wrong), gko::lend(beta),
+                           gko::lend(x)),
+                 gko::DimensionMismatch);
+}
+
+
+TEST_F(EnableBatchLinOp, ExtendedApplyFailsOnWrongSolutionRows)
+{
+    auto wrong = DummyBatchLinOp::create(
+        ref, std::vector<gko::dim<2>>{gko::dim<2>{5, 4}});
+
+    ASSERT_THROW(op->apply(gko::lend(alpha), gko::lend(b), gko::lend(beta),
+                           gko::lend(wrong)),
+                 gko::DimensionMismatch);
+}
+
+
+TEST_F(EnableBatchLinOp, ExtendedApplyFailsOnWrongSolutionColumns)
+{
+    auto wrong = DummyBatchLinOp::create(
+        ref, std::vector<gko::dim<2>>{gko::dim<2>{3, 5}});
+
+    ASSERT_THROW(op->apply(gko::lend(alpha), gko::lend(b), gko::lend(beta),
+                           gko::lend(wrong)),
+                 gko::DimensionMismatch);
+}
+
+
+TEST_F(EnableBatchLinOp, ExtendedApplyFailsOnWrongAlphaDimension)
+{
+    auto wrong = DummyBatchLinOp::create(
+        ref, std::vector<gko::dim<2>>{gko::dim<2>{2, 5}});
+
+    ASSERT_THROW(op->apply(gko::lend(wrong), gko::lend(b), gko::lend(beta),
+                           gko::lend(x)),
+                 gko::DimensionMismatch);
+}
+
+
+TEST_F(EnableBatchLinOp, ExtendedApplyFailsOnWrongBetaDimension)
+{
+    auto wrong = DummyBatchLinOp::create(
+        ref, std::vector<gko::dim<2>>{gko::dim<2>{2, 5}});
+
+    ASSERT_THROW(op->apply(gko::lend(alpha), gko::lend(b), gko::lend(wrong),
+                           gko::lend(x)),
+                 gko::DimensionMismatch);
+}
+
+
+// For tests between different memory, check cuda/test/base/batch_lin_op.cu
+TEST_F(EnableBatchLinOp, ApplyDoesNotCopyBetweenSameMemory)
+{
+    op->apply(gko::lend(b), gko::lend(x));
+
+    ASSERT_EQ(op->last_b_access, ref);
+    ASSERT_EQ(op->last_x_access, ref);
+}
+
+
+TEST_F(EnableBatchLinOp, ApplyNoCopyBackBetweenSameMemory)
+{
+    op->apply(gko::lend(b), gko::lend(x));
+
+    ASSERT_EQ(b->last_access, ref);
+    ASSERT_EQ(x->last_access, ref);
+}
+
+
+TEST_F(EnableBatchLinOp, ExtendedApplyDoesNotCopyBetweenSameMemory)
+{
+    op->apply(gko::lend(alpha), gko::lend(b), gko::lend(beta), gko::lend(x));
+
+    ASSERT_EQ(op->last_alpha_access, ref);
+    ASSERT_EQ(op->last_b_access, ref);
+    ASSERT_EQ(op->last_beta_access, ref);
+    ASSERT_EQ(op->last_x_access, ref);
+}
+
+
+TEST_F(EnableBatchLinOp, ExtendedApplyNoCopyBackBetweenSameMemory)
+{
+    op->apply(gko::lend(alpha), gko::lend(b), gko::lend(beta), gko::lend(x));
+
+    ASSERT_EQ(alpha->last_access, ref);
+    ASSERT_EQ(b->last_access, ref);
+    ASSERT_EQ(beta->last_access, ref);
+    ASSERT_EQ(x->last_access, ref);
+}
+
+
+template <typename T = int>
+class DummyBatchLinOpWithFactory
+    : public gko::EnableBatchLinOp<DummyBatchLinOpWithFactory<T>> {
+public:
+    DummyBatchLinOpWithFactory(std::shared_ptr<const gko::Executor> exec)
+        : gko::EnableBatchLinOp<DummyBatchLinOpWithFactory>(exec)
+    {}
+
+    GKO_CREATE_FACTORY_PARAMETERS(parameters, Factory)
+    {
+        T GKO_FACTORY_PARAMETER_SCALAR(value, T{5});
+    };
+    GKO_ENABLE_BATCH_LIN_OP_FACTORY(DummyBatchLinOpWithFactory, parameters,
+                                    Factory);
+    GKO_ENABLE_BUILD_METHOD(Factory);
+
+    DummyBatchLinOpWithFactory(const Factory* factory,
+                               std::shared_ptr<const gko::BatchLinOp> op)
+        : gko::EnableBatchLinOp<DummyBatchLinOpWithFactory>(
+              factory->get_executor()),
+          parameters_{factory->get_parameters()},
+          op_{op}
+    {}
+
+    std::shared_ptr<const gko::BatchLinOp> op_;
+
+protected:
+    void apply_impl(const gko::BatchLinOp* b, gko::BatchLinOp* x) const override
+    {}
+
+    void apply_impl(const gko::BatchLinOp* alpha, const gko::BatchLinOp* b,
+                    const gko::BatchLinOp* beta,
+                    gko::BatchLinOp* x) const override
+    {}
+};
+
+
+class EnableBatchLinOpFactory : public ::testing::Test {
+protected:
+    EnableBatchLinOpFactory() : ref{gko::ReferenceExecutor::create()} {}
+
+    std::shared_ptr<const gko::ReferenceExecutor> ref;
+};
+
+
+TEST_F(EnableBatchLinOpFactory, CreatesDefaultFactory)
+{
+    auto factory = DummyBatchLinOpWithFactory<>::build().on(ref);
+
+    ASSERT_EQ(factory->get_parameters().value, 5);
+    ASSERT_EQ(factory->get_executor(), ref);
+}
+
+
+TEST_F(EnableBatchLinOpFactory, CreatesFactoryWithParameters)
+{
+    auto factory = DummyBatchLinOpWithFactory<>::build().with_value(7).on(ref);
+
+    ASSERT_EQ(factory->get_parameters().value, 7);
+    ASSERT_EQ(factory->get_executor(), ref);
+}
+
+
+TEST_F(EnableBatchLinOpFactory, PassesParametersToBatchLinOp)
+{
+    auto dummy = gko::share(DummyBatchLinOp::create(
+        ref, std::vector<gko::dim<2>>{gko::dim<2>{3, 5}}));
+    auto factory = DummyBatchLinOpWithFactory<>::build().with_value(6).on(ref);
+
+    auto op = factory->generate(dummy);
+
+    ASSERT_EQ(op->get_executor(), ref);
+    ASSERT_EQ(op->get_parameters().value, 6);
+    ASSERT_EQ(op->op_.get(), dummy.get());
+}
+
+
+}  // namespace

--- a/core/test/base/batch_lin_op.cpp
+++ b/core/test/base/batch_lin_op.cpp
@@ -31,7 +31,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ******************************<GINKGO LICENSE>*******************************/
 
 #include <ginkgo/core/base/batch_lin_op.hpp>
-#include <ginkgo/core/base/lin_op.hpp>
 
 
 #include <complex>
@@ -43,6 +42,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <gtest/gtest.h>
 
 
+#include <ginkgo/core/base/lin_op.hpp>
 #include <ginkgo/core/base/math.hpp>
 
 

--- a/include/ginkgo/core/base/batch_dim.hpp
+++ b/include/ginkgo/core/base/batch_dim.hpp
@@ -1,0 +1,236 @@
+/*******************************<GINKGO LICENSE>******************************
+Copyright (c) 2017-2021, the Ginkgo authors
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+******************************<GINKGO LICENSE>*******************************/
+
+#ifndef GKO_PUBLIC_CORE_BASE_BATCH_DIM_HPP_
+#define GKO_PUBLIC_CORE_BASE_BATCH_DIM_HPP_
+
+
+#include <iostream>
+
+
+#include <ginkgo/core/base/dim.hpp>
+#include <ginkgo/core/base/types.hpp>
+
+
+namespace gko {
+
+
+/**
+ * A type representing the dimensions of a multidimensional batch object.
+ *
+ * @tparam Dimensionality  number of dimensions of the object
+ * @tparam DimensionType  datatype used to represent each dimension
+ *
+ * @ingroup batch_dim
+ */
+template <size_type Dimensionality = 2, typename DimensionType = size_type>
+struct batch_dim {
+    static constexpr size_type dimensionality = Dimensionality;
+    using dimension_type = DimensionType;
+
+    /**
+     * Checks if the batch_dim object stores equal sizes.
+     *
+     * @return bool representing whether equal sizes are being stored
+     */
+    bool stores_equal_sizes() const { return equal_sizes_; }
+
+    /**
+     * Get the number of batch entries stored
+     *
+     * @return num_batch_entries
+     */
+    size_type get_num_batch_entries() const { return num_batch_entries_; }
+
+    /**
+     * Get the sizes of all entries as a std::vector.
+     *
+     * @return  the std::vector of batch sizes
+     */
+    std::vector<dim<dimensionality, dimension_type>> get_batch_sizes() const
+    {
+        if (equal_sizes_) {
+            if (num_batch_entries_ > 0) {
+                return std::vector<dim<dimensionality, dimension_type>>(
+                    num_batch_entries_, common_size_);
+            } else {
+                return std::vector<dim<dimensionality, dimension_type>>{
+                    common_size_};
+            }
+        } else {
+            return sizes_;
+        }
+    }
+
+    /**
+     * Get the batch size at a particular index.
+     *
+     * @param batch_entry  the index of the entry whose size is needed
+     *
+     * @return  the size of the batch entry at the requested batch-index
+     */
+    const dim<dimensionality, dimension_type>& at(
+        const size_type batch_entry = 0) const
+    {
+        if (equal_sizes_) {
+            return common_size_;
+        } else {
+            GKO_ASSERT(batch_entry < num_batch_entries_);
+            return sizes_[batch_entry];
+        }
+    }
+
+    /**
+     * Checks if two batch_dim objects are equal.
+     *
+     * @param x  first object
+     * @param y  second object
+     *
+     * @return true if and only if all dimensions of both objects are equal.
+     */
+    friend bool operator==(const batch_dim& x, const batch_dim& y)
+    {
+        if (x.equal_sizes_ && y.equal_sizes_) {
+            return x.num_batch_entries_ == y.num_batch_entries_ &&
+                   x.common_size_ == y.common_size_;
+        } else {
+            return x.sizes_ == y.sizes_;
+        }
+    }
+
+    /**
+     * Creates a batch_dim object which stores a uniform size for all batch
+     * entries.
+     *
+     * @param num_batch_entries  number of batch entries to be stored
+     * @param common_size  the common size of all the batch entries stored
+     *
+     * @note  Use this constructor when uniform batches need to be stored.
+     */
+    batch_dim(const size_type num_batch_entries = 0,
+              const dim<dimensionality, dimension_type>& common_size =
+                  dim<dimensionality, dimension_type>{})
+        : equal_sizes_(true),
+          common_size_(common_size),
+          num_batch_entries_(num_batch_entries),
+          sizes_()
+    {}
+
+    /**
+     * Creates a batch_dim object which stores possibly non-uniform sizes for
+     * the different batch entries.
+     *
+     * @param batch_sizes  the std::vector object that stores the batch_sizes
+     *
+     * @note  Use this constructor when non-uniform batches need to be stored.
+     */
+    batch_dim(
+        const std::vector<dim<dimensionality, dimension_type>>& batch_sizes)
+        : equal_sizes_(false),
+          common_size_(dim<dimensionality, dimension_type>{}),
+          num_batch_entries_(batch_sizes.size()),
+          sizes_(batch_sizes)
+    {
+        check_size_equality();
+    }
+
+private:
+    void check_size_equality()
+    {
+        for (size_type i = 0; i < num_batch_entries_; ++i) {
+            if (!(sizes_[i] == sizes_[0])) {
+                return;
+            }
+        }
+        common_size_ = sizes_[0];
+        equal_sizes_ = true;
+    }
+
+    bool equal_sizes_{};
+    size_type num_batch_entries_{};
+    dim<dimensionality, dimension_type> common_size_{};
+    std::vector<dim<dimensionality, dimension_type>> sizes_{};
+};
+
+
+/**
+ * Checks if two batch dim objects are different.
+ *
+ * @tparam Dimensionality  number of dimensions of the dim objects
+ * @tparam DimensionType  datatype used to represent each dimension
+ *
+ * @param x  first object
+ * @param y  second object
+ *
+ * @return `!(x == y)`
+ */
+template <size_type Dimensionality, typename DimensionType>
+inline bool operator!=(const batch_dim<Dimensionality, DimensionType>& x,
+                       const batch_dim<Dimensionality, DimensionType>& y)
+{
+    return !(x == y);
+}
+
+
+/**
+ * Returns a batch_dim object with its dimensions swapped for batched operators
+ *
+ * @tparam DimensionType  datatype used to represent each dimension
+ *
+ * @param dimensions original object
+ *
+ * @return a batch_dim object with the individual batches having their
+ *         dimensions swapped
+ */
+template <typename DimensionType>
+inline batch_dim<2, DimensionType> transpose(
+    const batch_dim<2, DimensionType>& input)
+{
+    batch_dim<2, DimensionType> out{};
+    if (input.stores_equal_sizes()) {
+        out = batch_dim<2, DimensionType>(input.get_num_batch_entries(),
+                                          gko::transpose(input.at(0)));
+        return out;
+    }
+    auto trans =
+        std::vector<dim<2, DimensionType>>(input.get_num_batch_entries());
+    for (size_type i = 0; i < trans.size(); ++i) {
+        trans[i] = transpose(input.at(i));
+    }
+    return batch_dim<2, DimensionType>(trans);
+}
+
+
+}  // namespace gko
+
+
+#endif  // GKO_PUBLIC_CORE_BASE_BATCH_DIM_HPP_

--- a/include/ginkgo/core/base/batch_dim.hpp
+++ b/include/ginkgo/core/base/batch_dim.hpp
@@ -35,6 +35,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
 #include <iostream>
+#include <vector>
 
 
 #include <ginkgo/core/base/dim.hpp>

--- a/include/ginkgo/core/base/batch_lin_op.hpp
+++ b/include/ginkgo/core/base/batch_lin_op.hpp
@@ -55,6 +55,18 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 namespace gko {
 
 
+/**
+ * @addtogroup BatchLinOp
+ *
+ * The batch_stride class stores the strides of the batch entries in a
+ * BatchLinOp object. The design allows for optimized storage in case of same
+ * strides among the batch entries by storing a common stride. All member
+ * functions and getters are optimized for this case of common stride.
+ *
+ * While the common stride is the frequently encountered case, the batch_stride
+ * class additionally allows the user to store different strides for different
+ * batch entries as well.
+ */
 class batch_stride {
 public:
     /**
@@ -65,7 +77,7 @@ public:
     bool stores_equal_strides() const { return equal_strides_; }
 
     /**
-     * Get the number of batche entries stored
+     * Get the number of batch entries stored
      *
      * @return num_batch_entries
      */
@@ -593,7 +605,7 @@ protected:
  * entries should implement the BatchTransposable interface.
  *
  * It provides two functionalities, the normal transpose and the
- * conjugate transpose, both transposing the invidual batch entries.
+ * conjugate transpose, both transposing the individual batch entries.
  *
  * The normal transpose returns the transpose of the linear operator without
  * changing any of its elements representing the operation, $B = A^{T}$.
@@ -707,13 +719,13 @@ public:
  *
  * @tparam ConcreteFactory  the concrete factory which is being implemented
  *                          [CRTP parmeter]
- * @tparam ConcreteLinOp  the concrete BatchLinOp type which this factory
+ * @tparam ConcreteBatchLinOp  the concrete BatchLinOp type which this factory
  * produces, needs to have a constructor which takes a const ConcreteFactory *,
  * and an std::shared_ptr<const BatchLinOp> as parameters.
  * @tparam ParametersType  a subclass of enable_parameters_type template which
  *                         defines all of the parameters of the factory
  * @tparam PolymorphicBase  parent of ConcreteFactory in the polymorphic
- *                          hierarchy, has to be a subclass of LinOpFactory
+ *                          hierarchy, has to be a subclass of BatchLinOpFactory
  *
  * @ingroup BatchLinOp
  */
@@ -777,7 +789,7 @@ using EnableDefaultBatchLinOpFactory =
  * std::cout << my_op->get_my_parameters().my_value;  // prints 5
  *
  * // create a factory with custom `my_value` parameter
- * auto fact = MyLinOp::build().with_my_value(0).on(exec);
+ * auto fact = MyBatchLinOp::build().with_my_value(0).on(exec);
  * // create a operator using the factory:
  * auto my_op = fact->generate(gko::matrix::BatchIdentity::create(exec, 2));
  * std::cout << my_op->get_my_parameters().my_value;  // prints 0
@@ -789,8 +801,8 @@ using EnableDefaultBatchLinOpFactory =
  * in all contexts. See <https://stackoverflow.com/q/50202718/9385966> for more
  * details.
  *
- * @param _lin_op  concrete operator for which the factory is to be created
- *                 [CRTP parameter]
+ * @param _batch_lin_op  concrete operator for which the factory is to be
+ * created [CRTP parameter]
  * @param _parameters_name  name of the parameters member in the class
  *                          (its type is `<_parameters_name>_type`, the
  *                          protected member's name is `<_parameters_name>_`,

--- a/include/ginkgo/core/base/batch_lin_op.hpp
+++ b/include/ginkgo/core/base/batch_lin_op.hpp
@@ -1,0 +1,846 @@
+/*******************************<GINKGO LICENSE>******************************
+Copyright (c) 2017-2021, the Ginkgo authors
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+******************************<GINKGO LICENSE>*******************************/
+
+#ifndef GKO_PUBLIC_CORE_BASE_BATCH_LIN_OP_HPP_
+#define GKO_PUBLIC_CORE_BASE_BATCH_LIN_OP_HPP_
+
+
+#include <memory>
+#include <type_traits>
+#include <utility>
+
+
+#include <ginkgo/core/base/abstract_factory.hpp>
+#include <ginkgo/core/base/batch_dim.hpp>
+#include <ginkgo/core/base/dim.hpp>
+#include <ginkgo/core/base/exception_helpers.hpp>
+#include <ginkgo/core/base/math.hpp>
+#include <ginkgo/core/base/matrix_assembly_data.hpp>
+#include <ginkgo/core/base/matrix_data.hpp>
+#include <ginkgo/core/base/polymorphic_object.hpp>
+#include <ginkgo/core/base/types.hpp>
+#include <ginkgo/core/base/utils.hpp>
+#include <ginkgo/core/log/logger.hpp>
+
+
+namespace gko {
+
+
+class batch_stride {
+public:
+    /**
+     * Checks if the batch_stride object stores equal sizes.
+     *
+     * @return bool representing whether equal strides are being stored
+     */
+    bool stores_equal_strides() const { return equal_strides_; }
+
+    /**
+     * Get the number of batche entries stored
+     *
+     * @return num_batch_entries
+     */
+    size_type get_num_batch_entries() const { return num_batch_entries_; }
+
+    /**
+     * Get the batch strides as a std::vector.
+     *
+     * @return  the std::vector of batch strides
+     */
+    std::vector<size_type> get_batch_strides() const
+    {
+        if (!equal_strides_) {
+            return strides_;
+        } else {
+            return std::vector<size_type>(num_batch_entries_, common_stride_);
+        }
+    }
+
+    /**
+     * Get the batch size of a particular entry in the batch.
+     *
+     * @param batch_entry the entry whose size is needed
+     *
+     * @return  the size of the batch entry at the requested index
+     */
+    const size_type& at(const size_type batch_entry = 0) const
+    {
+        if (equal_strides_) {
+            return common_stride_;
+        } else {
+            GKO_ASSERT(batch_entry < num_batch_entries_);
+            return strides_[batch_entry];
+        }
+    }
+
+    /**
+     * Checks if two batch_stride objects are equal.
+     *
+     * @param x  first object
+     * @param y  second object
+     *
+     * @return true if and only if all dimensions of both objects are equal.
+     */
+    friend bool operator==(const batch_stride& x, const batch_stride& y)
+    {
+        if (x.equal_strides_ && y.equal_strides_) {
+            return x.num_batch_entries_ == y.num_batch_entries_ &&
+                   x.common_stride_ == y.common_stride_;
+        } else {
+            return x.strides_ == y.strides_;
+        }
+    }
+
+    /**
+     * Creates a batch_stride object which stores uniform batch strides.
+     *
+     * @param num_batch_entries  number of batche entries to be stored
+     * @param common_stride  the common stride of all the batch entries to be
+     * stored
+     *
+     * @note  Use this constructor when uniform batches need to be stored.
+     */
+    batch_stride(const size_type num_batch_entries = 0,
+                 const size_type& common_stride = 0)
+        : equal_strides_(true),
+          common_stride_(common_stride),
+          num_batch_entries_(num_batch_entries),
+          strides_()
+    {}
+
+    /**
+     * Creates a batch_stride object which stores possibly non-uniform batch
+     * strides.
+     *
+     * @param batch_strides  the std::vector object that stores the
+     * batch_strides
+     *
+     * @note  Use this constructor when non-uniform batches need to be stored.
+     */
+    batch_stride(const std::vector<size_type>& batch_strides)
+        : equal_strides_(false),
+          common_stride_(size_type{}),
+          num_batch_entries_(batch_strides.size()),
+          strides_(batch_strides)
+    {
+        check_equal_strides();
+    }
+
+private:
+    inline void check_equal_strides()
+    {
+        for (size_type b = 1; b < num_batch_entries_; ++b) {
+            if (strides_[0] != strides_[b]) {
+                equal_strides_ = false;
+                common_stride_ = 0;
+                return;
+            }
+        }
+        equal_strides_ = true;
+        common_stride_ = strides_[0];
+    }
+
+    bool equal_strides_{};
+    size_type num_batch_entries_{};
+    size_type common_stride_{};
+    std::vector<size_type> strides_{};
+};
+
+
+/**
+ * @addtogroup BatchLinOp
+ *
+ * @section batch_linop_concept Batched Linear operator as a concept
+ *
+ * A batch linear operator (BatchLinOp) forms the base class for all batched
+ * linear algebra objects. In general, it follows the same structure as the
+ * LinOp class, but has some crucial differences which make it not strictly
+ * representable through or with the LinOp class.
+ *
+ * A batched operator is defined as a set of independent linear operators which
+ * have no communication/information exchange between them. Therefore, any
+ * collective operations between the batches is not possible and not
+ * implemented. This allows for each batch to be computed and operated on in an
+ * embarrasingly parallel fashion.
+ *
+ * Similar to the LinOp class, the BatchLinOp also implements
+ * BatchLinOp::apply() methods which call the internal apply_impl() methods
+ * which the concrete BatchLinOp's have to implement.
+ *
+ * A key difference between the LinOp and the BatchLinOp classes is the storing
+ * of dimensions. BatchLinOp allows for storing non-equal objects in the
+ * batches and hence stores a batch_dim object instead of a dim object. The
+ * batch_dim object is optimized to store less amount of data when storing
+ * uniform batches.
+ *
+ * All size validation functions again verify first that the number of batches
+ * are conformant and that the dimensions in the corresponding batches
+ * themselves are also valid/conformant. Here too, optimizations for uniform
+ * batches have been added.
+ *
+ * @ref BatchLinOp
+ */
+class BatchLinOp : public EnableAbstractPolymorphicObject<BatchLinOp> {
+public:
+    /**
+     * Applies a batch linear operator to a batch vector (or a sequence of batch
+     * of vectors).
+     *
+     * Performs the operation x = op(b), where op is this batch linear operator.
+     *
+     * @param b  the input batch vector(s) on which the batch operator is
+     *           applied
+     * @param x  the output batch vector(s) where the result is stored
+     *
+     * @return this
+     */
+    BatchLinOp* apply(const BatchLinOp* b, BatchLinOp* x)
+    {
+        this->template log<log::Logger::batch_linop_apply_started>(this, b, x);
+        this->validate_application_parameters(b, x);
+        auto exec = this->get_executor();
+        this->apply_impl(make_temporary_clone(exec, b).get(),
+                         make_temporary_clone(exec, x).get());
+        this->template log<log::Logger::batch_linop_apply_completed>(this, b,
+                                                                     x);
+        return this;
+    }
+
+    /**
+     * @copydoc apply(const BatchLinOp *, BatchLinOp *)
+     */
+    const BatchLinOp* apply(const BatchLinOp* b, BatchLinOp* x) const
+    {
+        this->template log<log::Logger::batch_linop_apply_started>(this, b, x);
+        this->validate_application_parameters(b, x);
+        auto exec = this->get_executor();
+        this->apply_impl(make_temporary_clone(exec, b).get(),
+                         make_temporary_clone(exec, x).get());
+        this->template log<log::Logger::batch_linop_apply_completed>(this, b,
+                                                                     x);
+        return this;
+    }
+
+    /**
+     * Performs the operation x = alpha * op(b) + beta * x.
+     *
+     * @param alpha  scaling of the result of op(b)
+     * @param b  vector(s) on which the operator is applied
+     * @param beta  scaling of the input x
+     * @param x  output vector(s)
+     *
+     * @return this
+     */
+    BatchLinOp* apply(const BatchLinOp* alpha, const BatchLinOp* b,
+                      const BatchLinOp* beta, BatchLinOp* x)
+    {
+        this->template log<log::Logger::batch_linop_advanced_apply_started>(
+            this, alpha, b, beta, x);
+        this->validate_application_parameters(alpha, b, beta, x);
+        auto exec = this->get_executor();
+        this->apply_impl(make_temporary_clone(exec, alpha).get(),
+                         make_temporary_clone(exec, b).get(),
+                         make_temporary_clone(exec, beta).get(),
+                         make_temporary_clone(exec, x).get());
+        this->template log<log::Logger::batch_linop_advanced_apply_completed>(
+            this, alpha, b, beta, x);
+        return this;
+    }
+
+    /**
+     * @copydoc apply(const BatchLinOp *, const BatchLinOp *, const BatchLinOp
+     * *, BatchLinOp *)
+     */
+    const BatchLinOp* apply(const BatchLinOp* alpha, const BatchLinOp* b,
+                            const BatchLinOp* beta, BatchLinOp* x) const
+    {
+        this->template log<log::Logger::batch_linop_advanced_apply_started>(
+            this, alpha, b, beta, x);
+        this->validate_application_parameters(alpha, b, beta, x);
+        auto exec = this->get_executor();
+        this->apply_impl(make_temporary_clone(exec, alpha).get(),
+                         make_temporary_clone(exec, b).get(),
+                         make_temporary_clone(exec, beta).get(),
+                         make_temporary_clone(exec, x).get());
+        this->template log<log::Logger::batch_linop_advanced_apply_completed>(
+            this, alpha, b, beta, x);
+        return this;
+    }
+
+    /**
+     * Returns the number of batches in the batch operator.
+     *
+     * @return number of batches in the batch operator
+     */
+    size_type get_num_batch_entries() const noexcept
+    {
+        return size_.get_num_batch_entries();
+    }
+
+    /**
+     * Sets the size of the batch operator.
+     *
+     * @param size to be set
+     */
+    void set_size(const batch_dim<2>& size) { size_ = size; }
+
+    /**
+     * Returns the size of the batch operator.
+     *
+     * @return size of the batch operator
+     */
+    const batch_dim<2>& get_size() const noexcept { return size_; }
+
+    /**
+     * Returns true if the batch operator uses the data given in x as
+     * an initial guess. Returns false otherwise.
+     *
+     * @return true if the batch operator uses the data given in x as
+     *         an initial guess. Returns false otherwise.
+     */
+    virtual bool apply_uses_initial_guess() const { return false; }
+
+protected:
+    /**
+     * Creates a batch operator with uniform batches.
+     *
+     * @param exec        the executor where all the operations are performed
+     * @param num_batch_entries the number of batches to be stored in the
+     * operator
+     * @param size        the size of on of the operator in the batched operator
+     */
+    explicit BatchLinOp(std::shared_ptr<const Executor> exec,
+                        const size_type num_batch_entries = 0,
+                        const dim<2>& size = dim<2>{})
+        : EnableAbstractPolymorphicObject<BatchLinOp>(exec),
+          size_{num_batch_entries > 0 ? batch_dim<2>(num_batch_entries, size)
+                                      : batch_dim<2>{}}
+    {}
+
+    /**
+     * Creates a batch operator.
+     *
+     * @param exec  the executor where all the operations are performed
+     * @param batch_sizes  the vector containing the sizes of the batches to be
+     * stored in the batch operator.
+     *
+     * @note If possible and you have uniform batches, please prefer to use the
+     * constructor above, as it optimizes the size validations and hence can be
+     * significantly faster
+     */
+    explicit BatchLinOp(std::shared_ptr<const Executor> exec,
+                        const std::vector<dim<2>>& batch_sizes)
+        : EnableAbstractPolymorphicObject<BatchLinOp>(exec),
+          size_{batch_dim<2>(batch_sizes)}
+    {}
+
+    /**
+     * Creates a batch operator.
+     *
+     * @param exec  the executor where all the operations are performed
+     * @param batch_sizes  the sizes of the batch operator stored as a batch_dim
+     */
+    explicit BatchLinOp(std::shared_ptr<const Executor> exec,
+                        const batch_dim<2>& batch_sizes)
+        : EnableAbstractPolymorphicObject<BatchLinOp>(exec), size_{batch_sizes}
+    {}
+
+    /**
+     * Implementers of BatchLinOp should override this function instead
+     * of apply(const BatchLinOp *, BatchLinOp *).
+     *
+     * Performs the operation x = op(b), where op is this linear operator.
+     *
+     * @param b  the input batch vector(s) on which the operator is applied
+     * @param x  the output batch vector(s) where the result is stored
+     */
+    virtual void apply_impl(const BatchLinOp* b, BatchLinOp* x) const = 0;
+
+    /**
+     * Implementers of BatchLinOp should override this function instead
+     * of apply(const BatchLinOp *, const BatchLinOp *, const BatchLinOp *,
+     * BatchLinOp *).
+     *
+     * @param alpha  scaling of the result of op(b)
+     * @param b  vector(s) on which the operator is applied
+     * @param beta  scaling of the input x
+     * @param x  output vector(s)
+     */
+    virtual void apply_impl(const BatchLinOp* alpha, const BatchLinOp* b,
+                            const BatchLinOp* beta, BatchLinOp* x) const = 0;
+
+    /**
+     * Throws a DimensionMismatch exception if the parameters to `apply` are of
+     * the wrong size.
+     *
+     * @param b  batch vector(s) on which the operator is applied
+     * @param x  output batch vector(s)
+     */
+    void validate_application_parameters(const BatchLinOp* b,
+                                         const BatchLinOp* x) const
+    {
+        GKO_ASSERT_BATCH_CONFORMANT(this, b);
+        GKO_ASSERT_BATCH_EQUAL_ROWS(this, x);
+        GKO_ASSERT_BATCH_EQUAL_COLS(b, x);
+    }
+
+    /**
+     * Throws a DimensionMismatch exception if the parameters to `apply` are of
+     * the wrong size.
+     *
+     * @param alpha  scaling of the result of op(b)
+     * @param b  batch vector(s) on which the operator is applied
+     * @param beta  scaling of the input x
+     * @param x  output batch vector(s)
+     */
+    void validate_application_parameters(const BatchLinOp* alpha,
+                                         const BatchLinOp* b,
+                                         const BatchLinOp* beta,
+                                         const BatchLinOp* x) const
+    {
+        this->validate_application_parameters(b, x);
+        GKO_ASSERT_BATCH_EQUAL_DIMENSIONS(
+            alpha, batch_dim<2>(b->get_num_batch_entries(), dim<2>(1, 1)));
+        GKO_ASSERT_BATCH_EQUAL_DIMENSIONS(
+            beta, batch_dim<2>(b->get_num_batch_entries(), dim<2>(1, 1)));
+    }
+
+private:
+    batch_dim<2> size_{};
+};
+
+
+/**
+ * A BatchLinOpFactory represents a higher order mapping which transforms one
+ * batch linear operator into another.
+ *
+ * In a similar fashion to LinOps, BatchLinOps are also "generated" from the
+ * BatchLinOpFactory. A function of this class is to provide a generate method,
+ * which internally cals the generate_impl(), which the concrete BatchLinOps
+ * have to implement.
+ *
+ * Example: using BatchCG in Ginkgo
+ * ---------------------------
+ *
+ * ```c++
+ * // Suppose A is a batch matrix, batch_b a batch rhs vector, and batch_x an
+ * // initial guess
+ * // Create a BatchCG which runs for at most 1000 iterations, and stops after
+ * // reducing the residual norm by 6 orders of magnitude
+ * auto batch_cg_factory = solver::BatchCg<>::build()
+ *     .with_max_iters(1000)
+ *     .with_rel_residual_goal(1e-6)
+ *     .on(cuda);
+ * // create a batch linear operator which represents the solver
+ * auto batch_cg = batch_cg_factory->generate(A);
+ * // solve the system
+ * batch_cg->apply(gko::lend(batch_b), gko::lend(batch_x));
+ * ```
+ *
+ * @ingroup BatchLinOp
+ */
+class BatchLinOpFactory
+    : public AbstractFactory<BatchLinOp, std::shared_ptr<const BatchLinOp>> {
+public:
+    using AbstractFactory<BatchLinOp,
+                          std::shared_ptr<const BatchLinOp>>::AbstractFactory;
+
+    std::unique_ptr<BatchLinOp> generate(
+        std::shared_ptr<const BatchLinOp> input) const
+    {
+        this->template log<log::Logger::batch_linop_factory_generate_started>(
+            this, input.get());
+        auto generated = AbstractFactory::generate(input);
+        this->template log<log::Logger::batch_linop_factory_generate_completed>(
+            this, input.get(), generated.get());
+        return generated;
+    }
+};
+
+
+/**
+ * The EnableBatchLinOp mixin can be used to provide sensible default
+ * implementations of the majority of the BatchLinOp and PolymorphicObject
+ * interface.
+ *
+ * The goal of the mixin is to facilitate the development of new BatchLinOp, by
+ * enabling the implementers to focus on the important parts of their operator,
+ * while the library takes care of generating the trivial utility functions.
+ * The mixin will provide default implementations for the entire
+ * PolymorphicObject interface, including a default implementation of
+ * `copy_from` between objects of the new BatchLinOp type. It will also hide the
+ * default BatchLinOp::apply() methods with versions that preserve the static
+ * type of the object.
+ *
+ * Implementers of new BatchLinOps are required to specify only the following
+ * aspects:
+ *
+ * 1.  Creation of the BatchLinOp: This can be facilitated via either
+ *     EnableCreateMethod mixin (used mostly for matrix formats),
+ *     or GKO_ENABLE_BATCH_LIN_OP_FACTORY macro (used for operators created from
+ *     other operators, like preconditioners and solvers).
+ * 2.  Application of the BatchLinOp: Implementers have to override the two
+ *     overloads of the BatchLinOp::apply_impl() virtual methods.
+ *
+ * @tparam ConcreteBatchLinOp  the concrete BatchLinOp which is being
+ *                             implemented [CRTP parameter]
+ * @tparam PolymorphicBase  parent of ConcreteBatchLinOp in the polymorphic
+ *                          hierarchy, has to be a subclass of BatchLinOp
+ *
+ * @ingroup BatchLinOp
+ */
+template <typename ConcreteBatchLinOp, typename PolymorphicBase = BatchLinOp>
+class EnableBatchLinOp
+    : public EnablePolymorphicObject<ConcreteBatchLinOp, PolymorphicBase>,
+      public EnablePolymorphicAssignment<ConcreteBatchLinOp> {
+public:
+    using EnablePolymorphicObject<ConcreteBatchLinOp,
+                                  PolymorphicBase>::EnablePolymorphicObject;
+
+    const ConcreteBatchLinOp* apply(const BatchLinOp* b, BatchLinOp* x) const
+    {
+        this->template log<log::Logger::batch_linop_apply_started>(this, b, x);
+        this->validate_application_parameters(b, x);
+        auto exec = this->get_executor();
+        this->apply_impl(make_temporary_clone(exec, b).get(),
+                         make_temporary_clone(exec, x).get());
+        this->template log<log::Logger::batch_linop_apply_completed>(this, b,
+                                                                     x);
+        return self();
+    }
+
+    ConcreteBatchLinOp* apply(const BatchLinOp* b, BatchLinOp* x)
+    {
+        this->template log<log::Logger::batch_linop_apply_started>(this, b, x);
+        this->validate_application_parameters(b, x);
+        auto exec = this->get_executor();
+        this->apply_impl(make_temporary_clone(exec, b).get(),
+                         make_temporary_clone(exec, x).get());
+        this->template log<log::Logger::batch_linop_apply_completed>(this, b,
+                                                                     x);
+        return self();
+    }
+
+    const ConcreteBatchLinOp* apply(const BatchLinOp* alpha,
+                                    const BatchLinOp* b, const BatchLinOp* beta,
+                                    BatchLinOp* x) const
+    {
+        this->template log<log::Logger::batch_linop_advanced_apply_started>(
+            this, alpha, b, beta, x);
+        this->validate_application_parameters(alpha, b, beta, x);
+        auto exec = this->get_executor();
+        this->apply_impl(make_temporary_clone(exec, alpha).get(),
+                         make_temporary_clone(exec, b).get(),
+                         make_temporary_clone(exec, beta).get(),
+                         make_temporary_clone(exec, x).get());
+        this->template log<log::Logger::batch_linop_advanced_apply_completed>(
+            this, alpha, b, beta, x);
+        return self();
+    }
+
+    ConcreteBatchLinOp* apply(const BatchLinOp* alpha, const BatchLinOp* b,
+                              const BatchLinOp* beta, BatchLinOp* x)
+    {
+        this->template log<log::Logger::batch_linop_advanced_apply_started>(
+            this, alpha, b, beta, x);
+        this->validate_application_parameters(alpha, b, beta, x);
+        auto exec = this->get_executor();
+        this->apply_impl(make_temporary_clone(exec, alpha).get(),
+                         make_temporary_clone(exec, b).get(),
+                         make_temporary_clone(exec, beta).get(),
+                         make_temporary_clone(exec, x).get());
+        this->template log<log::Logger::batch_linop_advanced_apply_completed>(
+            this, alpha, b, beta, x);
+        return self();
+    }
+
+protected:
+    GKO_ENABLE_SELF(ConcreteBatchLinOp);
+};
+
+
+/**
+ * Batch Linear operators which support transposition of the distinct batch
+ * entries should implement the BatchTransposable interface.
+ *
+ * It provides two functionalities, the normal transpose and the
+ * conjugate transpose, both transposing the invidual batch entries.
+ *
+ * The normal transpose returns the transpose of the linear operator without
+ * changing any of its elements representing the operation, $B = A^{T}$.
+ *
+ * The conjugate transpose returns the conjugate of each of the elements and
+ * additionally transposes the linear operator representing the operation, $B
+ * = A^{H}$.
+ *
+ * Example: Transposing a BatchCsr matrix:
+ * ------------------------------------
+ *
+ * ```c++
+ * //Transposing an object of BatchLinOp type.
+ * //The object you want to transpose.
+ * auto op = matrix::BatchCsr::create(exec);
+ * //Transpose the object by first converting it to a transposable type.
+ * auto trans = op->transpose();
+ * ```
+ */
+class BatchTransposable {
+public:
+    virtual ~BatchTransposable() = default;
+
+    /**
+     * Returns a BatchLinOp containing the transposes of the distinct entries of
+     * the BatchTransposable object.
+     *
+     * @return a pointer to the new transposed object
+     */
+    virtual std::unique_ptr<BatchLinOp> transpose() const = 0;
+
+    /**
+     * Returns a BatchLinOp containing the conjugate transpose of the distinct
+     * entries of the BatchTransposable object.
+     *
+     * @return a pointer to the new conjugate transposed object
+     */
+    virtual std::unique_ptr<BatchLinOp> conj_transpose() const = 0;
+};
+
+
+/**
+ * A BatchLinOp implementing this interface can read its data from a matrix_data
+ * structure.
+ *
+ * @ingroup BatchLinOp
+ */
+template <typename ValueType, typename IndexType>
+class BatchReadableFromMatrixData {
+public:
+    using value_type = ValueType;
+    using index_type = IndexType;
+
+    virtual ~BatchReadableFromMatrixData() = default;
+
+    /**
+     * Reads a batch matrix from a std::vector of matrix_data objects.
+     *
+     * @param data  the std::vector of matrix_data objects
+     */
+    virtual void read(
+        const std::vector<matrix_data<ValueType, IndexType>>& data) = 0;
+
+    /**
+     * Reads a matrix from a std::vector of matrix_assembly_data objects.
+     *
+     * @param data  the std::vector of matrix_assembly_data objects
+     */
+    void read(const std::vector<matrix_assembly_data<ValueType, IndexType>>&
+                  assembly_data)
+    {
+        auto mat_data = std::vector<matrix_data<ValueType, IndexType>>(
+            assembly_data.size());
+        size_type ind = 0;
+        for (const auto& i : assembly_data) {
+            mat_data[ind] = i.get_ordered_data();
+            ++ind;
+        }
+        this->read(mat_data);
+    }
+};
+
+
+/**
+ * A BatchLinOp implementing this interface can write its data to a std::vector
+ * of matrix_data objects.
+ *
+ * @ingroup BatchLinOp
+ */
+template <typename ValueType, typename IndexType>
+class BatchWritableToMatrixData {
+public:
+    using value_type = ValueType;
+    using index_type = IndexType;
+
+    virtual ~BatchWritableToMatrixData() = default;
+
+    /**
+     * Writes a matrix to a matrix_data structure.
+     *
+     * @param data  the matrix_data structure
+     */
+    virtual void write(
+        std::vector<matrix_data<ValueType, IndexType>>& data) const = 0;
+};
+
+
+/**
+ * This is an alias for the EnableDefaultFactory mixin, which correctly sets the
+ * template parameters to enable a subclass of BatchLinOpFactory.
+ *
+ * @tparam ConcreteFactory  the concrete factory which is being implemented
+ *                          [CRTP parmeter]
+ * @tparam ConcreteLinOp  the concrete BatchLinOp type which this factory
+ * produces, needs to have a constructor which takes a const ConcreteFactory *,
+ * and an std::shared_ptr<const BatchLinOp> as parameters.
+ * @tparam ParametersType  a subclass of enable_parameters_type template which
+ *                         defines all of the parameters of the factory
+ * @tparam PolymorphicBase  parent of ConcreteFactory in the polymorphic
+ *                          hierarchy, has to be a subclass of LinOpFactory
+ *
+ * @ingroup BatchLinOp
+ */
+template <typename ConcreteFactory, typename ConcreteBatchLinOp,
+          typename ParametersType, typename PolymorphicBase = BatchLinOpFactory>
+using EnableDefaultBatchLinOpFactory =
+    EnableDefaultFactory<ConcreteFactory, ConcreteBatchLinOp, ParametersType,
+                         PolymorphicBase>;
+
+
+/**
+ * This macro will generate a default implementation of a BatchLinOpFactory for
+ * the BatchLinOp subclass it is defined in.
+ *
+ * It is required to first call the macro #GKO_CREATE_FACTORY_PARAMETERS()
+ * before this one in order to instantiate the parameters type first.
+ *
+ * The list of parameters for the factory should be defined in a code block
+ * after the macro definition, and should contain a list of
+ * GKO_FACTORY_PARAMETER_* declarations. The class should provide a constructor
+ * with signature
+ * _batch_lin_op(const _factory_name *, std::shared_ptr<const BatchLinOp>)
+ * which the factory will use a callback to construct the object.
+ *
+ * A minimal example of a batch linear operator is the following:
+ *
+ * ```c++
+ * struct MyBatchLinOp : public EnableBatchLinOp<MyBatchLinOp> {
+ *     GKO_ENABLE_BATCH_LIN_OP_FACTORY(MyBatchLinOp, my_parameters, Factory) {
+ *         // a factory parameter named "my_value", of type int and default
+ *         // value of 5
+ *         int GKO_FACTORY_PARAMETER_SCALAR(my_value, 5);
+ *         // a factory parameter named `my_pair` of type `std::pair<int,int>`
+ *         // and default value {5, 5}
+ *         std::pair<int, int> GKO_FACTORY_PARAMETER_VECTOR(my_pair, 5, 5);
+ *     };
+ *     // constructor needed by EnableBatchLinOp
+ *     explicit MyBatchLinOp(std::shared_ptr<const Executor> exec) {
+ *         : EnableBatchLinOp<MyBatchLinOp>(exec) {}
+ *     // constructor needed by the factory
+ *     explicit MyBatchLinOp(const Factory *factory,
+ *                      std::shared_ptr<const BatchLinOp> matrix)
+ *         : EnableBatchLinOp<MyBatchLinOp>(factory->get_executor()),
+ *                                          matrix->get_size()),
+ *           // store factory's parameters locally
+ *           my_parameters_{factory->get_parameters()}
+ *     {
+ *          int value = my_parameters_.my_value;
+ *          // do something with value
+ *     }
+ * ```
+ *
+ * MyBatchLinOp can then be created as follows:
+ *
+ * ```c++
+ * auto exec = gko::ReferenceExecutor::create();
+ * // create a factory with default `my_value` parameter
+ * auto fact = MyBatchLinOp::build().on(exec);
+ * // create a operator using the factory:
+ * auto my_op = fact->generate(gko::matrix::BatchIdentity::create(exec, 2));
+ * std::cout << my_op->get_my_parameters().my_value;  // prints 5
+ *
+ * // create a factory with custom `my_value` parameter
+ * auto fact = MyLinOp::build().with_my_value(0).on(exec);
+ * // create a operator using the factory:
+ * auto my_op = fact->generate(gko::matrix::BatchIdentity::create(exec, 2));
+ * std::cout << my_op->get_my_parameters().my_value;  // prints 0
+ * ```
+ *
+ * @note It is possible to combine both the #GKO_CREATE_FACTORY_PARAMETER_*()
+ * macros with this one in a unique macro for class __templates__ (not with
+ * regular classes). Splitting this into two distinct macros allows to use them
+ * in all contexts. See <https://stackoverflow.com/q/50202718/9385966> for more
+ * details.
+ *
+ * @param _lin_op  concrete operator for which the factory is to be created
+ *                 [CRTP parameter]
+ * @param _parameters_name  name of the parameters member in the class
+ *                          (its type is `<_parameters_name>_type`, the
+ *                          protected member's name is `<_parameters_name>_`,
+ *                          and the public getter's name is
+ *                          `get_<_parameters_name>()`)
+ * @param _factory_name  name of the generated factory type
+ *
+ * @ingroup BatchLinOp
+ */
+#define GKO_ENABLE_BATCH_LIN_OP_FACTORY(_batch_lin_op, _parameters_name,       \
+                                        _factory_name)                         \
+public:                                                                        \
+    const _parameters_name##_type& get_##_parameters_name() const              \
+    {                                                                          \
+        return _parameters_name##_;                                            \
+    }                                                                          \
+                                                                               \
+    class _factory_name                                                        \
+        : public ::gko::EnableDefaultBatchLinOpFactory<                        \
+              _factory_name, _batch_lin_op, _parameters_name##_type> {         \
+        friend class ::gko::EnablePolymorphicObject<_factory_name,             \
+                                                    ::gko::BatchLinOpFactory>; \
+        friend class ::gko::enable_parameters_type<_parameters_name##_type,    \
+                                                   _factory_name>;             \
+        explicit _factory_name(std::shared_ptr<const ::gko::Executor> exec)    \
+            : ::gko::EnableDefaultBatchLinOpFactory<                           \
+                  _factory_name, _batch_lin_op, _parameters_name##_type>(      \
+                  std::move(exec))                                             \
+        {}                                                                     \
+        explicit _factory_name(std::shared_ptr<const ::gko::Executor> exec,    \
+                               const _parameters_name##_type& parameters)      \
+            : ::gko::EnableDefaultBatchLinOpFactory<                           \
+                  _factory_name, _batch_lin_op, _parameters_name##_type>(      \
+                  std::move(exec), parameters)                                 \
+        {}                                                                     \
+    };                                                                         \
+    friend ::gko::EnableDefaultBatchLinOpFactory<_factory_name, _batch_lin_op, \
+                                                 _parameters_name##_type>;     \
+                                                                               \
+                                                                               \
+private:                                                                       \
+    _parameters_name##_type _parameters_name##_;                               \
+                                                                               \
+public:                                                                        \
+    static_assert(true,                                                        \
+                  "This assert is used to counter the false positive extra "   \
+                  "semi-colon warnings")
+
+
+}  // namespace gko
+
+
+#endif  // GKO_PUBLIC_CORE_BASE_BATCH_LIN_OP_HPP_

--- a/include/ginkgo/core/log/logger.hpp
+++ b/include/ginkgo/core/log/logger.hpp
@@ -541,7 +541,7 @@ public:
      * @param input  the PolymorphicObject to be move from
      * @param output  the PolymorphicObject to be move into
      */
-    GKO_LOGGER_REGISTER_EVENT(22, polymorphic_object_move_started,
+    GKO_LOGGER_REGISTER_EVENT(28, polymorphic_object_move_started,
                               const Executor* exec,
                               const PolymorphicObject* input,
                               const PolymorphicObject* output)
@@ -553,7 +553,7 @@ public:
      * @param input  the PolymorphicObject to be move from
      * @param output  the PolymorphicObject to be move into
      */
-    GKO_LOGGER_REGISTER_EVENT(23, polymorphic_object_move_completed,
+    GKO_LOGGER_REGISTER_EVENT(29, polymorphic_object_move_completed,
                               const Executor* exec,
                               const PolymorphicObject* input,
                               const PolymorphicObject* output)

--- a/include/ginkgo/core/log/logger.hpp
+++ b/include/ginkgo/core/log/logger.hpp
@@ -53,7 +53,9 @@ template <typename ValueType>
 class array;
 class Executor;
 class LinOp;
+class BatchLinOp;
 class LinOpFactory;
+class BatchLinOpFactory;
 class PolymorphicObject;
 class Operation;
 class stopping_status;
@@ -349,6 +351,79 @@ public:                                                              \
                               const LinOp* output)
 
     /**
+     * BatchLinOp's apply started event.
+     *
+     * @param A  the system matrix
+     * @param b  the input vector(s)
+     * @param x  the output vector(s)
+     */
+    GKO_LOGGER_REGISTER_EVENT(19, batch_linop_apply_started,
+                              const BatchLinOp* A, const BatchLinOp* b,
+                              const BatchLinOp* x)
+
+    /**
+     * BatchLinOp's apply completed event.
+     *
+     * @param A  the system matrix
+     * @param b  the input vector(s)
+     * @param x  the output vector(s)
+     */
+    GKO_LOGGER_REGISTER_EVENT(20, batch_linop_apply_completed,
+                              const BatchLinOp* A, const BatchLinOp* b,
+                              const BatchLinOp* x)
+
+    /**
+     * BatchLinOp's advanced apply started event.
+     *
+     * @param A  the system matrix
+     * @param alpha  scaling of the result of op(b)
+     * @param b  the input vector(s)
+     * @param beta  scaling of the input x
+     * @param x  the output vector(s)
+     */
+    GKO_LOGGER_REGISTER_EVENT(21, batch_linop_advanced_apply_started,
+                              const BatchLinOp* A, const BatchLinOp* alpha,
+                              const BatchLinOp* b, const BatchLinOp* beta,
+                              const BatchLinOp* x)
+
+    /**
+     * BatchLinOp's advanced apply completed event.
+     *
+     * @param A  the system matrix
+     * @param alpha  scaling of the result of op(b)
+     * @param b  the input vector(s)
+     * @param beta  scaling of the input x
+     * @param x  the output vector(s)
+     */
+    GKO_LOGGER_REGISTER_EVENT(22, batch_linop_advanced_apply_completed,
+                              const BatchLinOp* A, const BatchLinOp* alpha,
+                              const BatchLinOp* b, const BatchLinOp* beta,
+                              const BatchLinOp* x)
+
+    /**
+     * BatchLinOp Factory's generate started event.
+     *
+     * @param factory  the factory used
+     * @param input  the BatchLinOp object used as input for the generation
+     * (usually a system matrix)
+     */
+    GKO_LOGGER_REGISTER_EVENT(23, batch_linop_factory_generate_started,
+                              const BatchLinOpFactory* factory,
+                              const BatchLinOp* input)
+
+    /**
+     * BatchLinOp Factory's generate completed event.
+     *
+     * @param factory  the factory used
+     * @param input  the BatchLinOp object used as input for the generation
+     * (usually a system matrix)
+     * @param output  the generated BatchLinOp object
+     */
+    GKO_LOGGER_REGISTER_EVENT(24, batch_linop_factory_generate_completed,
+                              const BatchLinOpFactory* factory,
+                              const BatchLinOp* input, const BatchLinOp* output)
+
+    /**
      * stop::Criterion's check started event.
      *
      * @param criterion  the criterion used
@@ -359,7 +434,7 @@ public:                                                              \
      * @param stopping_id  the id of the stopping criterion
      * @param set_finalized  whether this finalizes the iteration
      */
-    GKO_LOGGER_REGISTER_EVENT(19, criterion_check_started,
+    GKO_LOGGER_REGISTER_EVENT(25, criterion_check_started,
                               const stop::Criterion* criterion,
                               const size_type& it, const LinOp* r,
                               const LinOp* tau, const LinOp* x,
@@ -387,7 +462,7 @@ public:                                                              \
      * parameter as below.
      */
     GKO_LOGGER_REGISTER_EVENT(
-        20, criterion_check_completed, const stop::Criterion* criterion,
+        26, criterion_check_completed, const stop::Criterion* criterion,
         const size_type& it, const LinOp* r, const LinOp* tau, const LinOp* x,
         const uint8& stopping_id, const bool& set_finalized,
         const array<stopping_status>* status, const bool& one_changed,
@@ -435,7 +510,7 @@ protected:
      * deprecated. Please use the one with the additional implicit_tau_sq
      * parameter as below.
      */
-    GKO_LOGGER_REGISTER_EVENT(21, iteration_complete, const LinOp* solver,
+    GKO_LOGGER_REGISTER_EVENT(27, iteration_complete, const LinOp* solver,
                               const size_type& it, const LinOp* r,
                               const LinOp* x = nullptr,
                               const LinOp* tau = nullptr)
@@ -510,6 +585,21 @@ public:
         polymorphic_object_move_started_mask |
         polymorphic_object_move_completed_mask |
         polymorphic_object_deleted_mask;
+
+    /**
+     * Bitset Mask which activates all batch linop events
+     */
+    static constexpr mask_type batch_linop_events_mask =
+        batch_linop_apply_started_mask | batch_linop_apply_completed_mask |
+        batch_linop_advanced_apply_started_mask |
+        batch_linop_advanced_apply_completed_mask;
+
+    /**
+     * Bitset Mask which activates all batch linop factory events
+     */
+    static constexpr mask_type batch_linop_factory_events_mask =
+        batch_linop_factory_generate_started_mask |
+        batch_linop_factory_generate_completed_mask;
 
     /**
      * Bitset Mask which activates all linop events

--- a/include/ginkgo/ginkgo.hpp
+++ b/include/ginkgo/ginkgo.hpp
@@ -39,6 +39,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <ginkgo/core/base/abstract_factory.hpp>
 #include <ginkgo/core/base/array.hpp>
+#include <ginkgo/core/base/batch_dim.hpp>
+#include <ginkgo/core/base/batch_lin_op.hpp>
 #include <ginkgo/core/base/combination.hpp>
 #include <ginkgo/core/base/composition.hpp>
 #include <ginkgo/core/base/dense_cache.hpp>


### PR DESCRIPTION
This PR is the first in a sequence of PR's to integrate the Batch functionality in batch-develop into main develop. This PR adds a batch versions and specializations for the `dim`, `stride` and the `LinOp` hierarchy.

### TODO

+ [x] Complete the documentation for the different batch classes.
+ [ ] Try to see if duplication between the `LinOp` and the `BatchLinOp` hierarchy can be reduced. 