### PR TITLE
Build smoother on current level fine not previous level coarse

### DIFF
--- a/core/multigrid/amgx_pgm.cpp
+++ b/core/multigrid/amgx_pgm.cpp
@@ -90,9 +90,9 @@ void AmgxPgm<ValueType, IndexType>::generate()
         amgxpgm_op_shared_ptr = convert_to_with_sorting<matrix_type>(
             exec, system_matrix_, parameters_.skip_sorting);
         amgxpgm_op = amgxpgm_op_shared_ptr.get();
+        // keep the same precision data in fine_op
+        this->set_fine_op(amgxpgm_op_shared_ptr);
     }
-    // keep the same precision data in fine_op
-    this->set_fine_op(amgxpgm_op_shared_ptr);
     // Initial agg = -1
     exec->run(amgx_pgm::make_fill_array(agg_.get_data(), agg_.get_num_elems(),
                                         -one<IndexType>()));

--- a/core/multigrid/amgx_pgm.cpp
+++ b/core/multigrid/amgx_pgm.cpp
@@ -84,14 +84,15 @@ void AmgxPgm<ValueType, IndexType>::generate()
     // Only support csr matrix currently.
     const matrix_type* amgxpgm_op =
         dynamic_cast<const matrix_type*>(system_matrix_.get());
-    std::shared_ptr<const matrix_type> amgxpgm_op_unique_ptr{};
+    std::shared_ptr<const matrix_type> amgxpgm_op_shared_ptr{};
     // If system matrix is not csr or need sorting, generate the csr.
     if (!parameters_.skip_sorting || !amgxpgm_op) {
-        amgxpgm_op_unique_ptr = convert_to_with_sorting<matrix_type>(
+        amgxpgm_op_shared_ptr = convert_to_with_sorting<matrix_type>(
             exec, system_matrix_, parameters_.skip_sorting);
-        amgxpgm_op = amgxpgm_op_unique_ptr.get();
+        amgxpgm_op = amgxpgm_op_shared_ptr.get();
     }
-
+    // keep the same precision data in fine_op
+    this->set_fine_op(amgxpgm_op_shared_ptr);
     // Initial agg = -1
     exec->run(amgx_pgm::make_fill_array(agg_.get_data(), agg_.get_num_elems(),
                                         -one<IndexType>()));

--- a/core/solver/multigrid.cpp
+++ b/core/solver/multigrid.cpp
@@ -560,7 +560,7 @@ void Multigrid::generate()
                         parameters_.smoother_relax);
                 }
             },
-            index, matrix);
+            index, mg_level->get_fine_op());
 
         mg_level_list_.emplace_back(mg_level);
         matrix = mg_level_list_.back()->get_coarse_op();

--- a/core/solver/multigrid.cpp
+++ b/core/solver/multigrid.cpp
@@ -323,19 +323,23 @@ struct MultigridState {
         mg_level->get_restrict_op()->apply(r.get(), g.get());
         // next level
         e->fill(zero<VT>());
-        this->run_cycle(cycle, level + 1, mg_level->get_coarse_op(), g.get(),
-                        e.get(), true, cycle == multigrid::cycle::v);
+        auto next_level_matrix =
+            (level + 1 < total_level)
+                ? multigrid->get_mg_level_list().at(level + 1)->get_fine_op()
+                : mg_level->get_coarse_op();
+        this->run_cycle(cycle, level + 1, next_level_matrix, g.get(), e.get(),
+                        true, cycle == multigrid::cycle::v);
         if (level < multigrid->get_mg_level_list().size() - 1) {
             // additional work for non-v_cycle
             // next level
             if (cycle == multigrid::cycle::f) {
                 // f_cycle call v_cycle in the second cycle
                 this->run_cycle(multigrid::cycle::v, level + 1,
-                                mg_level->get_coarse_op(), g.get(), e.get(),
-                                false, true);
+                                next_level_matrix, g.get(), e.get(), false,
+                                true);
             } else if (cycle == multigrid::cycle::w) {
-                this->run_cycle(cycle, level + 1, mg_level->get_coarse_op(),
-                                g.get(), e.get(), false, true);
+                this->run_cycle(cycle, level + 1, next_level_matrix, g.get(),
+                                e.get(), false, true);
             } else if ((cycle == multigrid::cycle::kfcg ||
                         cycle == multigrid::cycle::kgcr) &&
                        level % multigrid->get_parameters().kcycle_base == 0) {

--- a/include/ginkgo/core/multigrid/multigrid_level.hpp
+++ b/include/ginkgo/core/multigrid/multigrid_level.hpp
@@ -152,6 +152,18 @@ protected:
         this->set_composition(prolong_op, coarse_op, restrict_op);
     }
 
+    /**
+     * Sets the multigrid level fine operator, which is used to update fine
+     * operator when the MultigridLevel changes the precision of the operator.
+     *
+     * @param fine_op  the fine operator
+     */
+    void set_fine_op(std::shared_ptr<const LinOp> fine_op)
+    {
+        GKO_ASSERT_EQUAL_DIMENSIONS(fine_op_->get_size(), fine_op->get_size());
+        fine_op_ = fine_op;
+    }
+
     explicit EnableMultigridLevel() {}
 
     /**


### PR DESCRIPTION
It only changes the behavior when building mixed precision multigrid.
Originally, the smoother (float) uses coarse matrix from previous level (double), so it will lead many precision conversion inside the smoother.
MultigridLevel will set the fine_op after conversion, so it will give the float matrix.
Create smoother on the fine matrix such that the smoother uses the precision of the current level