### PR TITLE
Update GTEST to fix gcc 11.2 issues

### DIFF
--- a/third_party/gtest/CMakeLists.txt
+++ b/third_party/gtest/CMakeLists.txt
@@ -3,7 +3,7 @@ include(FetchContent)
 FetchContent_Declare(
     googletest
     GIT_REPOSITORY https://github.com/google/googletest.git
-    GIT_TAG        6a7ed316a5cdc07b6d26362c90770787513822d4
+    GIT_TAG        master
 )
 # need to set the variables in CACHE due to CMP0077
 set(gtest_disable_pthreads ON CACHE INTERNAL "")


### PR DESCRIPTION
The current GTest version is incompatible with gcc 11.2, which has already been mentioned somewhere, see also [[1](https://github.com/google/googletest/issues/3219)].
Since GTest now also follows abseil's live at head philosophy (see [[2](https://abseil.io/about/philosophy#upgrade-support)]), they advise using the latest commit in master. 
If we decide against that, we should update to the latest release v1.11.0 with `e2239ee6043f73722e7aa812a459f54a28552929`.