### PR TITLE
Add abidiff action

### DIFF
--- a/.github/abidiff.sh
+++ b/.github/abidiff.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+pushd old
+source .github/bot-pr-base.sh
+popd
+
+bot_delete_comments_matching "Note: This PR changes the Ginkgo ABI"
+
+abidiff build-old/lib/libginkgod.so build-new/lib/libginkgod.so &> abi.diff || (bot_comment "Note: This PR changes the Ginkgo ABI:\n\`\`\`\n$(head -n2 abi.diff | tr '\n' ';' | sed 's/;/\\n/g')\`\`\`\nFor details check the full ABI diff under **Artifacts** [here]($JOB_URL)" && false)

--- a/.github/workflows/bot-pr-updated.yml
+++ b/.github/workflows/bot-pr-updated.yml
@@ -22,3 +22,39 @@ jobs:
         with:
           name: patch
           path: format.patch
+  abidiff:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.author_association == 'COLLABORATOR' || github.event.pull_request.author_association == 'MEMBER' || github.event.pull_request.author_association == 'OWNER'
+    env:
+      CMAKE_FLAGS: -DBUILD_SHARED_LIBS=ON -DCMAKE_BUILD_TYPE=DEBUG -DGINKGO_BUILD_TESTS=OFF -DGINKGO_BUILD_EXAMPLES=OFF -DGINKGO_BUILD_BENCHMARKS=OFF -DGINKGO_BUILD_HWLOC=OFF -DGINKGO_BUILD_REFERENCE=OFF -DGINKGO_BUILD_OMP=OFF -DGINKGO_BUILD_CUDA=OFF -DGINKGO_BUILD_HIP=OFF -DGINKGO_BUILD_DPCPP=OFF
+    steps:
+      - name: Checkout the new code (shallow clone)
+        uses: actions/checkout@v2
+        with:
+          path: new
+          ref: ${{ github.event.pull_request.head.ref }}
+      - name: Checkout the old code (shallow clone)
+        uses: actions/checkout@v2
+        with:
+          path: old
+          ref: develop
+      - name: Install abidiff
+        run: sudo apt-get install abigail-tools
+      - name: Build both libraries
+        run: |
+          mkdir build-new
+          mkdir build-old
+          cmake -B build-new new ${{ env.CMAKE_FLAGS }}
+          cmake -B build-old old ${{ env.CMAKE_FLAGS }}
+          cmake --build build-new -j`nproc`
+          cmake --build build-old -j`nproc`
+      - name: Compute abidiff
+        env:
+          GITHUB_TOKEN: ${{ secrets.BOT_TOKEN }}
+        run: old/.github/abidiff.sh
+      - name: Upload ABI diff
+        if: failure()
+        uses: actions/upload-artifact@v2
+        with:
+            name: abi
+            path: abi.diff


### PR DESCRIPTION
Add a Github Action that runs abidiff on the old and new version of the library in a PR and reports the difference if they differ.

You can see this in action at https://github.com/upsj/ginkgo-bot-playground/pull/14, where it reports the change to Sellp and all ripple effects.

Fixes #776 