### PR TITLE
Enable batch dense to be used as matrix type for batch solvers

### DIFF
--- a/benchmark/solver/batch_solver.hpp
+++ b/benchmark/solver/batch_solver.hpp
@@ -352,6 +352,10 @@ void solve_system(const std::string& sol_name, const std::string& prec_name,
                           rapidjson::Value(rapidjson::kObjectType), allocator);
         auto& solver_json = solver_case[solver_name];
         const size_type nbatch = system_matrix->get_num_batch_entries();
+        add_or_set_member(
+            solver_json, "matrix_format",
+            rapidjson::StringRef(FLAGS_batch_solver_mat_format.c_str()),
+            allocator);
         add_or_set_member(solver_json, "num_batch_entries", nbatch, allocator);
         add_or_set_member(solver_json, "scaling",
                           rapidjson::StringRef(FLAGS_batch_scaling.c_str()),

--- a/benchmark/utils/formats.hpp
+++ b/benchmark/utils/formats.hpp
@@ -172,6 +172,7 @@ using hybrid = gko::matrix::Hybrid<etype, itype>;
 using csr = gko::matrix::Csr<etype, itype>;
 using batch_csr = gko::matrix::BatchCsr<etype>;
 using batch_ell = gko::matrix::BatchEll<etype>;
+using batch_dense = gko::matrix::BatchDense<etype>;
 
 /**
  * Creates a Ginkgo matrix from the intermediate data representation format
@@ -319,7 +320,9 @@ const std::map<std::string, std::function<std::unique_ptr<gko::BatchLinOp>(
         {"batch_ell",
          read_batch_matrix_from_data<gko::matrix::BatchEll<etype>>},
         {"batch_csr",
-         read_batch_matrix_from_data<gko::matrix::BatchCsr<etype>>}};
+         read_batch_matrix_from_data<gko::matrix::BatchCsr<etype>>},
+        {"batch_dense",
+         read_batch_matrix_from_data<gko::matrix::BatchDense<etype>>}};
 
 
 // clang-format off

--- a/benchmark/utils/formats.hpp
+++ b/benchmark/utils/formats.hpp
@@ -170,9 +170,6 @@ namespace formats {
 // some shortcuts
 using hybrid = gko::matrix::Hybrid<etype, itype>;
 using csr = gko::matrix::Csr<etype, itype>;
-using batch_csr = gko::matrix::BatchCsr<etype>;
-using batch_ell = gko::matrix::BatchEll<etype>;
-using batch_dense = gko::matrix::BatchDense<etype>;
 
 /**
  * Creates a Ginkgo matrix from the intermediate data representation format

--- a/common/cuda_hip/matrix/batch_csr_kernels.hpp.inc
+++ b/common/cuda_hip/matrix/batch_csr_kernels.hpp.inc
@@ -37,7 +37,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  * Assumes the input and output multi-vectors are stored row-major.
  */
 template <typename ValueType>
-__device__ __forceinline__ void spmv_kernel(
+__device__ __forceinline__ void matvec_kernel(
     const gko::batch_csr::BatchEntry<const ValueType>& a,
     const gko::batch_dense::BatchEntry<const ValueType>& b,
     const gko::batch_dense::BatchEntry<ValueType>& c)
@@ -85,7 +85,7 @@ __device__ __forceinline__ void spmv_kernel(
 }
 
 template <typename ValueType>
-__device__ __forceinline__ void single_spmv_kernel(
+__device__ __forceinline__ void single_matvec_kernel(
     const gko::batch_csr::BatchEntry<const ValueType>& a,
     const ValueType* const __restrict__ b, ValueType* const __restrict__ c)
 {
@@ -121,7 +121,7 @@ __device__ __forceinline__ void single_spmv_kernel(
 }
 
 template <typename ValueType>
-__device__ __forceinline__ void csr_spmv_kernel(
+__device__ __forceinline__ void csr_matvec_kernel(
     const int nrows, const ValueType* const __restrict__ avalues,
     const int* const __restrict__ col_idxs,
     const int* const __restrict__ row_ptrs, const size_type stride,
@@ -181,7 +181,7 @@ __global__ __launch_bounds__(default_block_size, sm_multiplier) void spmv(
         const auto a_b = gko::batch::batch_entry(a, ibatch);
         const auto b_b = gko::batch::batch_entry(b, ibatch);
         const auto c_b = gko::batch::batch_entry(c, ibatch);
-        spmv_kernel(a_b, b_b, c_b);
+        matvec_kernel(a_b, b_b, c_b);
     }
 }
 
@@ -192,7 +192,7 @@ __global__ __launch_bounds__(default_block_size, sm_multiplier) void spmv(
  * Assumes the input and output multi-vectors are stored row-major.
  */
 template <typename ValueType>
-__device__ __forceinline__ void advanced_spmv_kernel(
+__device__ __forceinline__ void advanced_matvec_kernel(
     const ValueType alpha, const gko::batch_csr::BatchEntry<const ValueType>& a,
     const gko::batch_dense::BatchEntry<const ValueType>& b,
     const ValueType beta, const gko::batch_dense::BatchEntry<ValueType>& c)
@@ -240,7 +240,7 @@ __device__ __forceinline__ void advanced_spmv_kernel(
 }
 
 template <typename ValueType>
-__device__ __forceinline__ void single_advanced_spmv_kernel(
+__device__ __forceinline__ void single_advanced_matvec_kernel(
     const ValueType alpha, const gko::batch_csr::BatchEntry<const ValueType>& a,
     const ValueType* const __restrict__ b, const ValueType beta,
     ValueType* const __restrict__ c)
@@ -277,7 +277,7 @@ __device__ __forceinline__ void single_advanced_spmv_kernel(
 }
 
 template <typename ValueType>
-__device__ __forceinline__ void csr_advanced_spmv_kernel(
+__device__ __forceinline__ void csr_advanced_matvec_kernel(
     const ValueType alpha, const int nrows,
     const ValueType* const __restrict__ avalues,
     const int* const __restrict__ col_idxs,
@@ -340,8 +340,8 @@ __global__
         const auto c_b = gko::batch::batch_entry(c, ibatch);
         const auto alpha_b = gko::batch::batch_entry(alpha, ibatch);
         const auto beta_b = gko::batch::batch_entry(beta, ibatch);
-        advanced_spmv_kernel(alpha_b.values[0], a_b, b_b, beta_b.values[0],
-                             c_b);
+        advanced_matvec_kernel(alpha_b.values[0], a_b, b_b, beta_b.values[0],
+                               c_b);
     }
 }
 

--- a/common/cuda_hip/matrix/batch_dense_kernels.hpp.inc
+++ b/common/cuda_hip/matrix/batch_dense_kernels.hpp.inc
@@ -36,7 +36,7 @@ using BatchEntry = gko::batch_dense::BatchEntry<ValueType>;
 
 
 template <typename ValueType>
-__device__ __forceinline__ void single_spmv_kernel(
+__device__ __forceinline__ void single_matvec_kernel(
     const gko::batch_dense::BatchEntry<const ValueType>& a,
     const ValueType* const __restrict__ b, ValueType* const __restrict__ c)
 {
@@ -78,13 +78,13 @@ __global__ __launch_bounds__(default_block_size, sm_multiplier) void mv(
         const auto a_b = gko::batch::batch_entry(a, ibatch);
         const auto b_b = gko::batch::batch_entry(b, ibatch);
         const auto c_b = gko::batch::batch_entry(c, ibatch);
-        single_spmv_kernel(a_b, b_b.values, c_b.values);
+        single_matvec_kernel(a_b, b_b.values, c_b.values);
     }
 }
 
 
 template <typename ValueType>
-__device__ __forceinline__ void single_advanced_spmv_kernel(
+__device__ __forceinline__ void single_advanced_matvec_kernel(
     const ValueType alpha,
     const gko::batch_dense::BatchEntry<const ValueType>& a,
     const ValueType* const __restrict__ b, const ValueType beta,
@@ -133,8 +133,8 @@ __global__
         const auto c_b = gko::batch::batch_entry(c, ibatch);
         const auto alpha_b = gko::batch::batch_entry(alpha, ibatch);
         const auto beta_b = gko::batch::batch_entry(beta, ibatch);
-        single_advanced_spmv_kernel(alpha_b.values[0], a_b, b_b.values,
-                                    beta_b.values[0], c_b.values);
+        single_advanced_matvec_kernel(alpha_b.values[0], a_b, b_b.values,
+                                      beta_b.values[0], c_b.values);
     }
 }
 

--- a/common/cuda_hip/matrix/batch_dense_kernels.hpp.inc
+++ b/common/cuda_hip/matrix/batch_dense_kernels.hpp.inc
@@ -35,6 +35,109 @@ template <typename ValueType>
 using BatchEntry = gko::batch_dense::BatchEntry<ValueType>;
 
 
+template <typename ValueType>
+__device__ __forceinline__ void single_spmv_kernel(
+    const gko::batch_dense::BatchEntry<const ValueType>& a,
+    const ValueType* const __restrict__ b, ValueType* const __restrict__ c)
+{
+    constexpr auto tile_size = config::warp_size;
+
+    auto thread_block = group::this_thread_block();
+    auto subwarp_grp = group::tiled_partition<tile_size>(thread_block);
+    const auto subwarp_grp_id = static_cast<int>(threadIdx.x / tile_size);
+    const int num_subwarp_grps_per_block = ceildiv(blockDim.x, tile_size);
+
+    for (int row = subwarp_grp_id; row < a.num_rows;
+         row += num_subwarp_grps_per_block) {
+        ValueType temp = zero<ValueType>();
+        for (int j = subwarp_grp.thread_rank(); j < a.num_rhs;
+             j += subwarp_grp.size()) {
+            const ValueType val = a.values[row * a.stride + j];
+            temp += val * b[j];
+        }
+
+#pragma unroll
+        for (int i = static_cast<int>(tile_size) / 2; i > 0; i /= 2) {
+            temp += subwarp_grp.shfl_down(temp, i);
+        }
+
+        if (subwarp_grp.thread_rank() == 0) {
+            c[row] = temp;
+        }
+    }
+}
+
+template <typename ValueType>
+__global__ __launch_bounds__(default_block_size, sm_multiplier) void mv(
+    const gko::batch_dense::UniformBatch<const ValueType> a,
+    const gko::batch_dense::UniformBatch<const ValueType> b,
+    const gko::batch_dense::UniformBatch<ValueType> c)
+{
+    for (size_type ibatch = blockIdx.x; ibatch < a.num_batch;
+         ibatch += gridDim.x) {
+        const auto a_b = gko::batch::batch_entry(a, ibatch);
+        const auto b_b = gko::batch::batch_entry(b, ibatch);
+        const auto c_b = gko::batch::batch_entry(c, ibatch);
+        single_spmv_kernel(a_b, b_b.values, c_b.values);
+    }
+}
+
+
+template <typename ValueType>
+__device__ __forceinline__ void single_advanced_spmv_kernel(
+    const ValueType alpha,
+    const gko::batch_dense::BatchEntry<const ValueType>& a,
+    const ValueType* const __restrict__ b, const ValueType beta,
+    ValueType* const __restrict__ c)
+{
+    constexpr auto tile_size = config::warp_size;
+
+    auto thread_block = group::this_thread_block();
+    auto subwarp_grp = group::tiled_partition<tile_size>(thread_block);
+    const auto subwarp_grp_id = static_cast<int>(threadIdx.x / tile_size);
+    const int num_subwarp_grps_per_block = ceildiv(blockDim.x, tile_size);
+
+    for (int row = subwarp_grp_id; row < a.num_rows;
+         row += num_subwarp_grps_per_block) {
+        ValueType temp = zero<ValueType>();
+        for (int j = subwarp_grp.thread_rank(); j < a.num_rhs;
+             j += subwarp_grp.size()) {
+            const ValueType val = a.values[row * a.stride + j];
+            temp += alpha * val * b[j];
+        }
+
+#pragma unroll
+        for (int i = static_cast<int>(tile_size) / 2; i > 0; i /= 2) {
+            temp += subwarp_grp.shfl_down(temp, i);
+        }
+
+        if (subwarp_grp.thread_rank() == 0) {
+            c[row] = temp + beta * c[row];
+        }
+    }
+}
+
+template <typename ValueType>
+__global__
+    __launch_bounds__(default_block_size, sm_multiplier) void advanced_mv(
+        const gko::batch_dense::UniformBatch<const ValueType> alpha,
+        const gko::batch_dense::UniformBatch<const ValueType> a,
+        const gko::batch_dense::UniformBatch<const ValueType> b,
+        const gko::batch_dense::UniformBatch<const ValueType> beta,
+        const gko::batch_dense::UniformBatch<ValueType> c)
+{
+    for (size_type ibatch = blockIdx.x; ibatch < a.num_batch;
+         ibatch += gridDim.x) {
+        const auto a_b = gko::batch::batch_entry(a, ibatch);
+        const auto b_b = gko::batch::batch_entry(b, ibatch);
+        const auto c_b = gko::batch::batch_entry(c, ibatch);
+        const auto alpha_b = gko::batch::batch_entry(alpha, ibatch);
+        const auto beta_b = gko::batch::batch_entry(beta, ibatch);
+        single_advanced_spmv_kernel(alpha_b.values[0], a_b, b_b.values,
+                                    beta_b.values[0], c_b.values);
+    }
+}
+
 /**
  *
  *   Scales the vectors in global or shared memory with a factor of alpha(alpha

--- a/common/cuda_hip/matrix/batch_ell_kernels.hpp.inc
+++ b/common/cuda_hip/matrix/batch_ell_kernels.hpp.inc
@@ -35,7 +35,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  * Device kernel for SpMV of one ELL matrix in a batch.
  */
 template <typename ValueType>
-__device__ __forceinline__ void single_spmv_kernel(
+__device__ __forceinline__ void single_matvec_kernel(
     const gko::batch_ell::BatchEntry<const ValueType>& a,
     const ValueType* const __restrict__ b, ValueType* const __restrict__ c)
 {
@@ -67,7 +67,7 @@ __device__ __forceinline__ void single_spmv_kernel(
  * Device kernel for SpMV of one ELL matrix in a batch.
  */
 template <typename ValueType>
-__device__ __forceinline__ void single_advanced_spmv_kernel(
+__device__ __forceinline__ void single_advanced_matvec_kernel(
     const ValueType alpha, const gko::batch_ell::BatchEntry<const ValueType>& a,
     const ValueType* const __restrict__ b, const ValueType beta,
     ValueType* const __restrict__ c)
@@ -99,7 +99,7 @@ __device__ __forceinline__ void single_advanced_spmv_kernel(
  * Device kernel for SpMV of one ELL matrix in a batch.
  */
 template <typename ValueType>
-__device__ __forceinline__ void spmv_kernel(
+__device__ __forceinline__ void matvec_kernel(
     const gko::batch_ell::BatchEntry<const ValueType>& a,
     const gko::batch_dense::BatchEntry<const ValueType>& bobj,
     const gko::batch_dense::BatchEntry<ValueType>& cobj)
@@ -135,7 +135,7 @@ __device__ __forceinline__ void spmv_kernel(
  * Device kernel for SpMV of one ELL matrix in a batch.
  */
 template <typename ValueType>
-__device__ __forceinline__ void advanced_spmv_kernel(
+__device__ __forceinline__ void advanced_matvec_kernel(
     const ValueType alpha, const gko::batch_ell::BatchEntry<const ValueType>& a,
     const gko::batch_dense::BatchEntry<const ValueType>& bobj,
     const ValueType beta, const gko::batch_dense::BatchEntry<ValueType>& cobj)
@@ -178,7 +178,7 @@ __global__ __launch_bounds__(default_block_size, sm_multiplier) void spmv(
         const auto a_b = gko::batch::batch_entry(a, ibatch);
         const auto b_b = gko::batch::batch_entry(b, ibatch);
         const auto c_b = gko::batch::batch_entry(c, ibatch);
-        spmv_kernel(a_b, b_b, c_b);
+        matvec_kernel(a_b, b_b, c_b);
     }
 }
 
@@ -200,7 +200,7 @@ __global__
         const auto beta_b = gko::batch::batch_entry(beta, ibatch);
         const ValueType alphav = alpha_b.values[0];
         const ValueType betav = beta_b.values[0];
-        advanced_spmv_kernel(alphav, a_b, b_b, betav, c_b);
+        advanced_matvec_kernel(alphav, a_b, b_b, betav, c_b);
     }
 }
 

--- a/common/cuda_hip/preconditioner/batch_identity.hpp.inc
+++ b/common/cuda_hip/preconditioner/batch_identity.hpp.inc
@@ -82,6 +82,10 @@ public:
         const gko::batch_csr::BatchEntry<const ValueType>& mat, ValueType*)
     {}
 
+    __device__ __forceinline__ void generate(
+        const gko::batch_dense::BatchEntry<const ValueType>& mat, ValueType*)
+    {}
+
     __device__ __forceinline__ void apply(const int num_rows,
                                           const ValueType* const r,
                                           ValueType* const z) const

--- a/common/cuda_hip/preconditioner/batch_jacobi.hpp.inc
+++ b/common/cuda_hip/preconditioner/batch_jacobi.hpp.inc
@@ -115,6 +115,34 @@ public:
         __syncthreads();
     }
 
+    /**
+     * Sets the input and generates the preconditioner by storing the inverse
+     * diagonal entries in the work vector.
+     *
+     * @param mat  Matrix for which to build a Jacobi preconditioner.
+     * @param work  A 'work-vector', used here to store the inverse diagonal
+     *              entries. It must be allocated with at least the amount
+     *              of memory given by dynamic_work_size.
+     */
+    __device__ __forceinline__ void generate(
+        const gko::batch_dense::BatchEntry<const ValueType>& mat,
+        ValueType* const __restrict__ work)
+    {
+        work_ = work;
+        constexpr auto warp_size = config::warp_size;
+        const auto tile =
+            group::tiled_partition<warp_size>(group::this_thread_block());
+        const int tile_rank = threadIdx.x / warp_size;
+        const int num_tiles = (blockDim.x - 1) / warp_size + 1;
+        for (int irow = tile_rank; irow < mat.num_rows; irow += num_tiles) {
+            const int iz = irow * static_cast<int>(mat.stride) + irow;
+            work_[irow] = (mat.values[iz] != zero<ValueType>())
+                              ? one<ValueType>() / mat.values[iz]
+                              : one<ValueType>();
+        }
+        __syncthreads();
+    }
+
     __device__ __forceinline__ void apply(const int num_rows,
                                           const ValueType* const r,
                                           ValueType* const z) const

--- a/common/cuda_hip/solver/batch_bicgstab_kernels.hpp.inc
+++ b/common/cuda_hip/solver/batch_bicgstab_kernels.hpp.inc
@@ -59,9 +59,9 @@ __device__ __forceinline__ void initialize(
     __syncthreads();
 
     // r = b - A*x
-    single_advanced_spmv_kernel(static_cast<ValueType>(-1.0), a_global_entry,
-                                x_shared_entry, static_cast<ValueType>(1.0),
-                                r_shared_entry);
+    single_advanced_matvec_kernel(static_cast<ValueType>(-1.0), a_global_entry,
+                                  x_shared_entry, static_cast<ValueType>(1.0),
+                                  r_shared_entry);
     __syncthreads();
 
     if (threadIdx.x / config::warp_size == 0) {
@@ -319,7 +319,7 @@ __global__ void apply_kernel(
             __syncthreads();
 
             // v = A * p_hat
-            single_spmv_kernel(a_global_entry, p_hat_sh, v_sh);
+            single_matvec_kernel(a_global_entry, p_hat_sh, v_sh);
             __syncthreads();
 
             // alpha = rho_new / < r_hat , v>
@@ -348,7 +348,7 @@ __global__ void apply_kernel(
             __syncthreads();
 
             // t = A * s_hat
-            single_spmv_kernel(a_global_entry, s_hat_sh, t_sh);
+            single_matvec_kernel(a_global_entry, s_hat_sh, t_sh);
             __syncthreads();
 
             // omega = <t,s> / <t,t>

--- a/common/cuda_hip/solver/batch_cg_kernels.hpp.inc
+++ b/common/cuda_hip/solver/batch_cg_kernels.hpp.inc
@@ -54,9 +54,9 @@ __device__ __forceinline__ void initialize(
     __syncthreads();
 
     // r = b - A*x
-    single_advanced_spmv_kernel(static_cast<ValueType>(-1.0), A_global_entry,
-                                x_shared_entry, static_cast<ValueType>(1.0),
-                                r_shared_entry);
+    single_advanced_matvec_kernel(static_cast<ValueType>(-1.0), A_global_entry,
+                                  x_shared_entry, static_cast<ValueType>(1.0),
+                                  r_shared_entry);
     __syncthreads();
 
     // z = precond * r
@@ -182,7 +182,7 @@ __global__ void apply_kernel(const int max_iter,
             }
 
             // Ap = A * p
-            single_spmv_kernel(A_global_entry, p_sh, Ap_sh);
+            single_matvec_kernel(A_global_entry, p_sh, Ap_sh);
             __syncthreads();
 
             // alpha = rho_old / (p' * Ap)

--- a/common/cuda_hip/solver/batch_gmres_kernels.hpp.inc
+++ b/common/cuda_hip/solver/batch_gmres_kernels.hpp.inc
@@ -53,9 +53,9 @@ __device__ __forceinline__ void initialize(
     __syncthreads();
 
     // r = b - A*x
-    single_advanced_spmv_kernel(static_cast<ValueType>(-1.0), a_gl_entry,
-                                x_shared_entry, static_cast<ValueType>(1.0),
-                                r_shared_entry);
+    single_advanced_matvec_kernel(static_cast<ValueType>(-1.0), a_gl_entry,
+                                  x_shared_entry, static_cast<ValueType>(1.0),
+                                  r_shared_entry);
     __syncthreads();
 
     if (threadIdx.x / config::warp_size == 0) {
@@ -125,7 +125,7 @@ __device__ __forceinline__ void arnoldi(
 
     const ValueType* const v_i_sh = V_shared_entry + inner_iter * num_rows;
 
-    single_spmv_kernel(a_gl_entry, v_i_sh, helper_shared_entry);
+    single_matvec_kernel(a_gl_entry, v_i_sh, helper_shared_entry);
     __syncthreads();
 
     prec_shared.apply(num_rows, helper_shared_entry, w_shared_entry);
@@ -425,9 +425,9 @@ __global__ void apply_kernel(const int global_gap, const int max_iter,
             single_copy(nrows, b_entry_ptr, r_sh);
             __syncthreads();
             // r = r - A*x
-            single_advanced_spmv_kernel(static_cast<ValueType>(-1.0),
-                                        a_gl_entry, x_sh,
-                                        static_cast<ValueType>(1.0), r_sh);
+            single_advanced_matvec_kernel(static_cast<ValueType>(-1.0),
+                                          a_gl_entry, x_sh,
+                                          static_cast<ValueType>(1.0), r_sh);
             __syncthreads();
 
             if (threadIdx.x / config::warp_size == 0) {

--- a/common/cuda_hip/solver/batch_idr_kernels.hpp.inc
+++ b/common/cuda_hip/solver/batch_idr_kernels.hpp.inc
@@ -123,9 +123,9 @@ __device__ __forceinline__ void initialize(
     __syncthreads();
 
     // r = b - A*x
-    single_advanced_spmv_kernel(static_cast<ValueType>(-1.0), A_global_entry,
-                                x_shared_entry, static_cast<ValueType>(1.0),
-                                r_shared_entry);
+    single_advanced_matvec_kernel(static_cast<ValueType>(-1.0), A_global_entry,
+                                  x_shared_entry, static_cast<ValueType>(1.0),
+                                  r_shared_entry);
     __syncthreads();
 
     if (threadIdx.x / config::warp_size == 0) {
@@ -629,7 +629,7 @@ __global__ void apply_kernel(
                 __syncthreads();
 
                 // g_k = A * u_k
-                single_spmv_kernel(A_global_entry, u_k_sh, g_k_sh);
+                single_matvec_kernel(A_global_entry, u_k_sh, g_k_sh);
                 __syncthreads();
 
                 // for i = 0 to k-1
@@ -691,7 +691,7 @@ __global__ void apply_kernel(
             __syncthreads();
 
             // t = A *v
-            single_spmv_kernel(A_global_entry, v_sh, t_sh);
+            single_matvec_kernel(A_global_entry, v_sh, t_sh);
             __syncthreads();
 
             // omega = ( t * r )/ (t * t)

--- a/common/cuda_hip/solver/batch_richardson_kernels.hpp.inc
+++ b/common/cuda_hip/solver/batch_richardson_kernels.hpp.inc
@@ -88,8 +88,9 @@ __global__ void apply_kernel(const int max_iter,
             // r <- b - Ax
             single_copy(num_rows, b_b, residual);
             __syncthreads();
-            single_advanced_spmv_kernel(static_cast<ValueType>(-1.0), a_b, x_b,
-                                        static_cast<ValueType>(1.0), residual);
+            single_advanced_matvec_kernel(static_cast<ValueType>(-1.0), a_b,
+                                          x_b, static_cast<ValueType>(1.0),
+                                          residual);
             __syncthreads();
 
             if (threadIdx.x / config::warp_size == 0) {

--- a/core/matrix/batch_struct.hpp
+++ b/core/matrix/batch_struct.hpp
@@ -78,6 +78,11 @@ struct UniformBatch {
     size_type stride;                    ///< Number of matrices in the batch
     int num_rows;  ///< (common) number of rows in each matrix
     int num_nnz;   ///< (common) number of nonzeros in each matrix
+
+    size_type get_entry_storage() const
+    {
+        return num_nnz * (sizeof(value_type) + sizeof(index_type));
+    }
 };
 
 
@@ -119,6 +124,12 @@ struct UniformBatch {
     size_type num_batch;  ///< Number of matrices in the batch
     int num_rows;         ///< (common) number of rows in each matrix
     int num_nnz;          ///< (common) number of nonzeros in each matrix
+
+    size_type get_entry_storage() const
+    {
+        return num_nnz * (sizeof(value_type) + sizeof(index_type)) +
+               (num_rows + 1) * sizeof(index_type);
+    }
 };
 
 
@@ -155,7 +166,10 @@ struct UniformBatch {
     size_type stride;     ///< Common stride of each dense matrix
     int num_rows;         ///< Common number of rows in each matrix
     int num_rhs;          ///< Common number of columns of each matrix
-    int num_nnz;          ///< Common number of non-zeros of each matrix
+    int num_nnz;          ///< Common number of non-zeros of each matrix, ie.,
+                          ///< the number or rows times the number of columns
+
+    size_type get_entry_storage() const { return num_nnz * sizeof(value_type); }
 };
 
 

--- a/core/matrix/batch_struct.hpp
+++ b/core/matrix/batch_struct.hpp
@@ -155,6 +155,7 @@ struct UniformBatch {
     size_type stride;     ///< Common stride of each dense matrix
     int num_rows;         ///< Common number of rows in each matrix
     int num_rhs;          ///< Common number of columns of each matrix
+    int num_nnz;          ///< Common number of non-zeros of each matrix
 };
 
 

--- a/core/solver/batch_bicgstab.cpp
+++ b/core/solver/batch_bicgstab.cpp
@@ -100,7 +100,6 @@ void BatchBicgstab<ValueType>::apply_impl(const BatchLinOp* b,
     const bool to_scale =
         this->get_left_scaling_vector() && this->get_right_scaling_vector();
     const auto acsr = dynamic_cast<const Mtx*>(system_matrix_.get());
-    const auto aell = dynamic_cast<const EllMtx*>(system_matrix_.get());
     const Mtx* a_scaled{};
     const Vector* b_scaled{};
     auto a_scaled_smart = Mtx::create(exec);
@@ -146,13 +145,10 @@ void BatchBicgstab<ValueType>::apply_impl(const BatchLinOp* b,
     if (acsr) {
         exec->run(batch_bicgstab::make_apply(opts, a_scaled, b_scaled, dense_x,
                                              logdata));
-    } else if (aell) {
-        exec->run(
-            batch_bicgstab::make_apply(opts, aell, b_scaled, dense_x, logdata));
     } else {
-        GKO_NOT_SUPPORTED(system_matrix_);
+        exec->run(batch_bicgstab::make_apply(opts, system_matrix_.get(),
+                                             b_scaled, dense_x, logdata));
     }
-
     this->template log<log::Logger::batch_solver_completed>(
         logdata.iter_counts, logdata.res_norms.get());
 

--- a/core/solver/batch_dispatch.hpp
+++ b/core/solver/batch_dispatch.hpp
@@ -233,6 +233,10 @@ public:
                        dynamic_cast<const matrix::BatchEll<ValueType>*>(a)) {
             auto m_b = device::get_batch_struct(amat);
             dispatch_on_logger(m_b, b_b, x_b, logdata);
+        } else if (auto amat =
+                       dynamic_cast<const matrix::BatchDense<ValueType>*>(a)) {
+            auto m_b = device::get_batch_struct(amat);
+            dispatch_on_logger(m_b, b_b, x_b, logdata);
         } else {
             GKO_NOT_SUPPORTED(a);
         }

--- a/core/test/solver/batch_bicgstab.cpp
+++ b/core/test/solver/batch_bicgstab.cpp
@@ -58,7 +58,7 @@ protected:
 
     BatchBicgstab()
         : exec(gko::ReferenceExecutor::create()),
-          mtx(gko::test::create_poisson1d_batch<value_type>(
+          mtx(gko::test::create_poisson1d_batch<Mtx>(
               std::static_pointer_cast<const gko::ReferenceExecutor>(
                   this->exec),
               nrows, nbatch)),

--- a/core/test/solver/batch_cg.cpp
+++ b/core/test/solver/batch_cg.cpp
@@ -58,7 +58,7 @@ protected:
 
     BatchCg()
         : exec(gko::ReferenceExecutor::create()),
-          mtx(gko::test::create_poisson1d_batch<value_type>(
+          mtx(gko::test::create_poisson1d_batch<Mtx>(
               std::static_pointer_cast<const gko::ReferenceExecutor>(
                   this->exec),
               nrows, nbatch)),

--- a/core/test/solver/batch_gmres.cpp
+++ b/core/test/solver/batch_gmres.cpp
@@ -58,7 +58,7 @@ protected:
 
     BatchGmres()
         : exec(gko::ReferenceExecutor::create()),
-          mtx(gko::test::create_poisson1d_batch<value_type>(
+          mtx(gko::test::create_poisson1d_batch<Mtx>(
               std::static_pointer_cast<const gko::ReferenceExecutor>(
                   this->exec),
               nrows, nbatch)),

--- a/core/test/solver/batch_idr.cpp
+++ b/core/test/solver/batch_idr.cpp
@@ -58,7 +58,7 @@ protected:
 
     BatchIdr()
         : exec(gko::ReferenceExecutor::create()),
-          mtx(gko::test::create_poisson1d_batch<value_type>(
+          mtx(gko::test::create_poisson1d_batch<Mtx>(
               std::static_pointer_cast<const gko::ReferenceExecutor>(
                   this->exec),
               nrows, nbatch)),
@@ -102,7 +102,7 @@ TYPED_TEST(BatchIdr, FactoryCreatesCorrectSolver)
         ASSERT_EQ(this->solver->get_size().at(i),
                   gko::dim<2>(this->nrows, this->nrows));
     }
-    auto batchidr_solver = static_cast<Solver *>(this->solver.get());
+    auto batchidr_solver = static_cast<Solver*>(this->solver.get());
     ASSERT_NE(batchidr_solver->get_system_matrix(), nullptr);
     ASSERT_EQ(batchidr_solver->get_system_matrix(), this->mtx);
 }
@@ -120,8 +120,8 @@ TYPED_TEST(BatchIdr, CanBeCopied)
         ASSERT_EQ(copy->get_size().at(i),
                   gko::dim<2>(this->nrows, this->nrows));
     }
-    auto copy_mtx = static_cast<Solver *>(copy.get())->get_system_matrix();
-    const auto copy_batch_mtx = static_cast<const Mtx *>(copy_mtx.get());
+    auto copy_mtx = static_cast<Solver*>(copy.get())->get_system_matrix();
+    const auto copy_batch_mtx = static_cast<const Mtx*>(copy_mtx.get());
     GKO_ASSERT_BATCH_MTX_NEAR(this->mtx.get(), copy_batch_mtx, 0.0);
 }
 
@@ -138,8 +138,8 @@ TYPED_TEST(BatchIdr, CanBeMoved)
         ASSERT_EQ(copy->get_size().at(i),
                   gko::dim<2>(this->nrows, this->nrows));
     }
-    auto copy_mtx = static_cast<Solver *>(copy.get())->get_system_matrix();
-    const auto copy_batch_mtx = static_cast<const Mtx *>(copy_mtx.get());
+    auto copy_mtx = static_cast<Solver*>(copy.get())->get_system_matrix();
+    const auto copy_batch_mtx = static_cast<const Mtx*>(copy_mtx.get());
     GKO_ASSERT_BATCH_MTX_NEAR(this->mtx.get(), copy_batch_mtx, 0.0);
 }
 
@@ -154,8 +154,8 @@ TYPED_TEST(BatchIdr, CanBeCloned)
         ASSERT_EQ(clone->get_size().at(i),
                   gko::dim<2>(this->nrows, this->nrows));
     }
-    auto clone_mtx = static_cast<Solver *>(clone.get())->get_system_matrix();
-    const auto clone_batch_mtx = static_cast<const Mtx *>(clone_mtx.get());
+    auto clone_mtx = static_cast<Solver*>(clone.get())->get_system_matrix();
+    const auto clone_batch_mtx = static_cast<const Mtx*>(clone_mtx.get());
     GKO_ASSERT_BATCH_MTX_NEAR(this->mtx.get(), clone_batch_mtx, 0.0);
 }
 
@@ -169,7 +169,7 @@ TYPED_TEST(BatchIdr, CanBeCleared)
     ASSERT_EQ(this->solver->get_num_batch_entries(), 0);
     ASSERT_EQ(this->solver->get_size().get_num_batch_entries(), 0);
     auto solver_mtx =
-        static_cast<Solver *>(this->solver.get())->get_system_matrix();
+        static_cast<Solver*>(this->solver.get())->get_system_matrix();
     ASSERT_EQ(solver_mtx, nullptr);
 }
 
@@ -296,7 +296,7 @@ TYPED_TEST(BatchIdr, CanSetScalingVectors)
     solver->batch_scale(left_scale.get(), right_scale.get());
 
     auto s_solver =
-        dynamic_cast<gko::EnableBatchScaledSolver<value_type> *>(solver.get());
+        dynamic_cast<gko::EnableBatchScaledSolver<value_type>*>(solver.get());
     ASSERT_TRUE(s_solver);
     ASSERT_EQ(s_solver->get_left_scaling_vector(), left_scale.get());
     ASSERT_EQ(s_solver->get_right_scaling_vector(), right_scale.get());

--- a/core/test/solver/batch_richardson.cpp
+++ b/core/test/solver/batch_richardson.cpp
@@ -61,7 +61,7 @@ protected:
 
     BatchRich()
         : exec(gko::ReferenceExecutor::create()),
-          mtx(gko::test::create_poisson1d_batch<value_type>(
+          mtx(gko::test::create_poisson1d_batch<Mtx>(
               std::static_pointer_cast<const gko::ReferenceExecutor>(exec),
               nrows, nbatch))
     {}
@@ -85,10 +85,10 @@ protected:
                                      .with_relaxation_factor(this->def_relax)
                                      .on(this->exec);
         auto solver = batchrich_factory->generate(this->mtx);
-        return std::unique_ptr<Solver>(static_cast<Solver *>(solver.release()));
+        return std::unique_ptr<Solver>(static_cast<Solver*>(solver.release()));
     }
 
-    void assert_size(const gko::BatchLinOp *const solver)
+    void assert_size(const gko::BatchLinOp* const solver)
     {
         for (size_t i = 0; i < nbatch; i++) {
             ASSERT_EQ(solver->get_size().at(i), gko::dim<2>(nrows, nrows));
@@ -96,7 +96,7 @@ protected:
     }
 
     // Checks equality of the matrix and parameters with defaults
-    void assert_solver_params(const Solver *const a)
+    void assert_solver_params(const Solver* const a)
     {
         ASSERT_EQ(a->get_parameters().max_iterations, def_max_iters);
         ASSERT_EQ(a->get_parameters().preconditioner, gpb::type::jacobi);
@@ -106,11 +106,10 @@ protected:
     }
 
     // Checks equality of the matrix and parameters with defaults
-    void assert_solver_with_mtx(const Solver *const a)
+    void assert_solver_with_mtx(const Solver* const a)
     {
         auto a_copy_mtx = a->get_system_matrix();
-        const auto a_copy_batch_mtx =
-            static_cast<const Mtx *>(a_copy_mtx.get());
+        const auto a_copy_batch_mtx = static_cast<const Mtx*>(a_copy_mtx.get());
         GKO_ASSERT_BATCH_MTX_NEAR(a_copy_batch_mtx, mtx, 0.0);
         assert_solver_params(a);
     }
@@ -151,7 +150,7 @@ TYPED_TEST(BatchRich, CanBeCopied)
     copy->copy_from(solver.get());
 
     this->assert_size(copy.get());
-    this->assert_solver_with_mtx(static_cast<Solver *>(copy.get()));
+    this->assert_solver_with_mtx(static_cast<Solver*>(copy.get()));
 }
 
 
@@ -166,7 +165,7 @@ TYPED_TEST(BatchRich, CanBeMoved)
     copy->copy_from(std::move(solver));
 
     this->assert_size(copy.get());
-    this->assert_solver_with_mtx(static_cast<Solver *>(copy.get()));
+    this->assert_solver_with_mtx(static_cast<Solver*>(copy.get()));
     ASSERT_EQ(solver.get(), nullptr);
 }
 
@@ -180,7 +179,7 @@ TYPED_TEST(BatchRich, CanBeCloned)
     auto clone = solver->clone();
 
     this->assert_size(clone.get());
-    this->assert_solver_with_mtx(static_cast<Solver *>(clone.get()));
+    this->assert_solver_with_mtx(static_cast<Solver*>(clone.get()));
 }
 
 
@@ -193,7 +192,7 @@ TYPED_TEST(BatchRich, CanBeCleared)
 
     ASSERT_EQ(solver->get_num_batch_entries(), 0);
     ASSERT_EQ(solver->get_size().at(0), gko::dim<2>(0, 0));
-    auto solver_mtx = static_cast<Solver *>(solver.get())->get_system_matrix();
+    auto solver_mtx = static_cast<Solver*>(solver.get())->get_system_matrix();
     ASSERT_EQ(solver_mtx, nullptr);
 }
 
@@ -267,7 +266,7 @@ TYPED_TEST(BatchRich, CanSetScalingVectors)
     solver->batch_scale(left_scale.get(), right_scale.get());
 
     auto s_solver =
-        dynamic_cast<gko::EnableBatchScaledSolver<value_type> *>(solver.get());
+        dynamic_cast<gko::EnableBatchScaledSolver<value_type>*>(solver.get());
     ASSERT_TRUE(s_solver);
     ASSERT_EQ(s_solver->get_left_scaling_vector(), left_scale.get());
     ASSERT_EQ(s_solver->get_right_scaling_vector(), right_scale.get());

--- a/core/test/utils/batch.hpp
+++ b/core/test/utils/batch.hpp
@@ -40,6 +40,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <ginkgo/core/base/matrix_data.hpp>
 #include <ginkgo/core/matrix/batch_csr.hpp>
 #include <ginkgo/core/matrix/batch_dense.hpp>
+#include <ginkgo/core/matrix/batch_ell.hpp>
 
 
 namespace gko {
@@ -193,7 +194,6 @@ std::unique_ptr<MatrixType> create_poisson1d_batch(
 
 template <typename ValueType>
 struct BatchSystem {
-    // using mtx_type = matrix::BatchCsr<ValueType, int>;
     using vec_type = matrix::BatchDense<ValueType>;
     std::unique_ptr<BatchLinOp> A;
     std::unique_ptr<vec_type> b;

--- a/core/test/utils/batch.hpp
+++ b/core/test/utils/batch.hpp
@@ -284,19 +284,6 @@ BatchSystem<typename MatrixType::value_type> generate_solvable_batch_system(
     mcsr->write(mdata);
     auto mtx = MatrixType::create(exec);
     mtx->read(mdata);
-    {
-        // check
-        std::vector<matrix_data<value_type, index_type>> mdata2;
-        mtx->write(mdata2);
-        if (mdata.size() != mdata2.size()) {
-            throw std::runtime_error("sizes not same");
-        }
-        for (size_t ib = 0; ib < mdata.size(); ib++) {
-            if (mdata[ib].nonzeros != mdata2[ib].nonzeros) {
-                throw std::runtime_error("Not same");
-            }
-        }
-    }
     BatchSystem<value_type> sys;
     sys.A = gko::give(mtx);
     sys.b = BatchSystem<value_type>::vec_type::create(exec, vec_size, h_allb,

--- a/core/test/utils/batch_test_utils.hpp
+++ b/core/test/utils/batch_test_utils.hpp
@@ -280,7 +280,7 @@ Result<ValueType> solve_poisson_uniform_core(
 }
 
 
-template <typename SolverType>
+template <typename SolverType, typename MatrixType>
 void test_solve(std::shared_ptr<const Executor> exec, const size_t nbatch,
                 const int nrows, const int nrhs,
                 const remove_complex<typename SolverType::value_type> res_tol,
@@ -293,7 +293,7 @@ void test_solve(std::shared_ptr<const Executor> exec, const size_t nbatch,
     using RT = typename gko::remove_complex<T>;
     using Dense = gko::matrix::BatchDense<T>;
     using RDense = gko::matrix::BatchDense<RT>;
-    using Mtx = typename gko::matrix::BatchCsr<T>;
+    using Mtx = MatrixType;
     using factory_type = typename SolverType::Factory;
     std::shared_ptr<const gko::ReferenceExecutor> refexec =
         gko::ReferenceExecutor::create();

--- a/cuda/matrix/batch_dense_kernels.cu
+++ b/cuda/matrix/batch_dense_kernels.cu
@@ -72,7 +72,17 @@ template <typename ValueType>
 void simple_apply(std::shared_ptr<const CudaExecutor> exec,
                   const matrix::BatchDense<ValueType>* a,
                   const matrix::BatchDense<ValueType>* b,
-                  matrix::BatchDense<ValueType>* c) GKO_NOT_IMPLEMENTED;
+                  matrix::BatchDense<ValueType>* c)
+{
+    const auto num_blocks = exec->get_num_multiprocessor() * sm_multiplier;
+    const auto a_ub = get_batch_struct(a);
+    const auto b_ub = get_batch_struct(b);
+    const auto c_ub = get_batch_struct(c);
+    if (b_ub.num_rhs > 1) {
+        GKO_NOT_IMPLEMENTED;
+    }
+    mv<<<num_blocks, default_block_size>>>(a_ub, b_ub, c_ub);
+}
 
 GKO_INSTANTIATE_FOR_EACH_VALUE_TYPE(
     GKO_DECLARE_BATCH_DENSE_SIMPLE_APPLY_KERNEL);
@@ -84,7 +94,20 @@ void apply(std::shared_ptr<const CudaExecutor> exec,
            const matrix::BatchDense<ValueType>* a,
            const matrix::BatchDense<ValueType>* b,
            const matrix::BatchDense<ValueType>* beta,
-           matrix::BatchDense<ValueType>* c) GKO_NOT_IMPLEMENTED;
+           matrix::BatchDense<ValueType>* c)
+{
+    const auto num_blocks = exec->get_num_multiprocessor() * sm_multiplier;
+    const auto a_ub = get_batch_struct(a);
+    const auto b_ub = get_batch_struct(b);
+    const auto c_ub = get_batch_struct(c);
+    const auto alpha_ub = get_batch_struct(alpha);
+    const auto beta_ub = get_batch_struct(beta);
+    if (b_ub.num_rhs > 1) {
+        GKO_NOT_IMPLEMENTED;
+    }
+    advanced_mv<<<num_blocks, default_block_size>>>(alpha_ub, a_ub, b_ub,
+                                                    beta_ub, c_ub);
+}
 
 GKO_INSTANTIATE_FOR_EACH_VALUE_TYPE(GKO_DECLARE_BATCH_DENSE_APPLY_KERNEL);
 

--- a/cuda/matrix/batch_struct.hpp
+++ b/cuda/matrix/batch_struct.hpp
@@ -69,9 +69,13 @@ template <typename ValueType>
 inline gko::batch_dense::UniformBatch<const cuda_type<ValueType>>
 get_batch_struct(const matrix::BatchDense<ValueType>* const op)
 {
-    return {as_cuda_type(op->get_const_values()), op->get_num_batch_entries(),
-            op->get_stride().at(0), static_cast<int>(op->get_size().at(0)[0]),
-            static_cast<int>(op->get_size().at(0)[1])};
+    return {
+        as_cuda_type(op->get_const_values()),
+        op->get_num_batch_entries(),
+        op->get_stride().at(0),
+        static_cast<int>(op->get_size().at(0)[0]),
+        static_cast<int>(op->get_size().at(0)[1]),
+        static_cast<int>(op->get_size().at(0)[0] * op->get_size().at(0)[1])};
 }
 
 /**
@@ -81,9 +85,13 @@ template <typename ValueType>
 inline gko::batch_dense::UniformBatch<cuda_type<ValueType>> get_batch_struct(
     matrix::BatchDense<ValueType>* const op)
 {
-    return {as_cuda_type(op->get_values()), op->get_num_batch_entries(),
-            op->get_stride().at(0), static_cast<int>(op->get_size().at(0)[0]),
-            static_cast<int>(op->get_size().at(0)[1])};
+    return {
+        as_cuda_type(op->get_values()),
+        op->get_num_batch_entries(),
+        op->get_stride().at(0),
+        static_cast<int>(op->get_size().at(0)[0]),
+        static_cast<int>(op->get_size().at(0)[1]),
+        static_cast<int>(op->get_size().at(0)[0] * op->get_size().at(0)[1])};
 }
 
 /**

--- a/cuda/solver/batch_bicgstab_kernels.cu
+++ b/cuda/solver/batch_bicgstab_kernels.cu
@@ -154,7 +154,8 @@ public:
         const size_type nbatch = a.num_batch;
         const int shared_gap = ((a.num_rows - 1) / 8 + 1) * 8;
 
-        // TODO: Add function to BatchCSR to return storage needed per matrix
+        // TODO: Add function to batch matrix types to return storage needed per
+        // matrix
         const int matrix_storage =
             (a.num_rows + 1) * sizeof(int) +
             a.num_nnz * (sizeof(int) + sizeof(value_type));
@@ -182,14 +183,17 @@ public:
             exec_, sconf.gmem_stride_bytes * nbatch / sizeof(value_type));
         assert(sconf.gmem_stride_bytes % sizeof(value_type) == 0);
 
-        std::cerr << " Bicgstab: vectors in shared memory = " << sconf.n_shared
-                  << "\n";
-        if (sconf.prec_shared) {
-            std::cerr << " Bicgstab: precondiioner is in shared memory.\n";
-        }
-        std::cerr << " Bicgstab: vectors in global memory = " << sconf.n_global
-                  << "\n Bicgstab: number of threads per block = " << block_size
-                  << "\n";
+        // std::cerr << " Bicgstab: vectors in shared memory = " <<
+        // sconf.n_shared
+        //          << "\n";
+        // if (sconf.prec_shared) {
+        //    std::cerr << " Bicgstab: precondiioner is in shared memory.\n";
+        //}
+        // std::cerr << " Bicgstab: vectors in global memory = " <<
+        // sconf.n_global
+        //          << "\n Bicgstab: number of threads per block = " <<
+        //          block_size
+        //          << "\n";
 
         apply_kernel<StopType><<<nbatch, block_size, shared_size>>>(
             shared_gap, sconf, opts_.max_its, opts_.residual_tol, logger,

--- a/cuda/test/log/batch_logger.cu
+++ b/cuda/test/log/batch_logger.cu
@@ -39,7 +39,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "core/matrix/batch_struct.hpp"
 #include "core/test/utils.hpp"
-#include "core/test/utils/batch.hpp"
 #include "cuda/base/config.hpp"
 #include "cuda/base/types.hpp"
 

--- a/cuda/test/matrix/batch_csr_kernels.cpp
+++ b/cuda/test/matrix/batch_csr_kernels.cpp
@@ -46,7 +46,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
 #include "core/matrix/batch_csr_kernels.hpp"
-#include "core/test/utils/batch_test_utils.hpp"
+#include "core/test/utils/batch.hpp"
 #include "cuda/test/utils.hpp"
 
 

--- a/cuda/test/matrix/batch_dense_kernels.cpp
+++ b/cuda/test/matrix/batch_dense_kernels.cpp
@@ -107,9 +107,9 @@ protected:
             cuda, gko::batch_dim<>(batch_size, gko::dim<2>{1, num_vecs}));
     }
 
-    void set_up_apply_data()
+    void set_up_apply_data(const int p = 1)
     {
-        const int m = 35, n = 15, p = 25;
+        const int m = 35, n = 15;
         x = gen_mtx<Mtx>(batch_size, m, n);
         c_x = gen_mtx<ComplexMtx>(batch_size, m, n);
         y = gen_mtx<Mtx>(batch_size, n, p);
@@ -155,6 +155,28 @@ protected:
     std::unique_ptr<Mtx> dbeta;
     std::unique_ptr<Mtx> dsquare;
 };
+
+
+TEST_F(BatchDense, SingleVectorAppyIsEquivalentToRef)
+{
+    set_up_apply_data(1);
+
+    x->apply(y.get(), expected.get());
+    dx->apply(dy.get(), dresult.get());
+
+    GKO_ASSERT_BATCH_MTX_NEAR(dresult, expected, 1e-14);
+}
+
+
+TEST_F(BatchDense, SingleVectorAdvancedAppyIsEquivalentToRef)
+{
+    set_up_apply_data(1);
+
+    x->apply(alpha.get(), y.get(), beta.get(), expected.get());
+    dx->apply(dalpha.get(), dy.get(), dbeta.get(), dresult.get());
+
+    GKO_ASSERT_BATCH_MTX_NEAR(dresult, expected, 1e-14);
+}
 
 
 TEST_F(BatchDense, SingleVectorAddScaledIsEquivalentToRef)

--- a/cuda/test/matrix/batch_ell_kernels.cpp
+++ b/cuda/test/matrix/batch_ell_kernels.cpp
@@ -46,7 +46,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
 #include "core/matrix/batch_ell_kernels.hpp"
-#include "core/test/utils/batch_test_utils.hpp"
+#include "core/test/utils/batch.hpp"
 #include "cuda/test/utils.hpp"
 
 

--- a/cuda/test/solver/batch_bicgstab_kernels.cpp
+++ b/cuda/test/solver/batch_bicgstab_kernels.cpp
@@ -381,7 +381,7 @@ TEST(BatchBicgstab, SolvesLargeEllSystemEquivalentToReference)
         gko::CudaExecutor::create(0, refexec);
     const float solver_restol = 1e-4;
     auto r_sys = gko::test::generate_solvable_batch_system<mtx_type>(
-        refexec, 2, 90, 1, false);
+        refexec, 2, 91, 1, false);
     auto r_factory =
         solver_type::build()
             .with_max_iterations(500)

--- a/cuda/test/solver/batch_bicgstab_kernels.cpp
+++ b/cuda/test/solver/batch_bicgstab_kernels.cpp
@@ -284,11 +284,12 @@ TEST(BatchBicgstab, GoodScalingImprovesConvergence)
 }
 
 
-TEST(BatchBicgstab, CanSolveWithoutScaling)
+TEST(BatchBicgstab, CanSolveCsrWithoutScaling)
 {
     using T = std::complex<float>;
     using RT = typename gko::remove_complex<T>;
     using Solver = gko::solver::BatchBicgstab<T>;
+    using Csr = gko::matrix::BatchCsr<T>;
     const RT tol = 1e-5;
     std::shared_ptr<gko::ReferenceExecutor> refexec =
         gko::ReferenceExecutor::create();
@@ -306,8 +307,8 @@ TEST(BatchBicgstab, CanSolveWithoutScaling)
     const size_t nbatch = 3;
     const int nrhs = 1;
 
-    gko::test::test_solve<Solver>(exec, nbatch, nrows, nrhs, tol, maxits,
-                                  batchbicgstab_factory.get(), 5);
+    gko::test::test_solve<Solver, Csr>(exec, nbatch, nrows, nrhs, tol, maxits,
+                                       batchbicgstab_factory.get(), 5);
 }
 
 

--- a/cuda/test/solver/batch_cg_kernels.cpp
+++ b/cuda/test/solver/batch_cg_kernels.cpp
@@ -139,6 +139,7 @@ TYPED_TEST(BatchCg, SolveIsEquivalentToReference)
 {
     using value_type = typename TestFixture::value_type;
     using solver_type = gko::solver::BatchCg<value_type>;
+    using mtx_type = typename TestFixture::Mtx;
     using opts_type = typename TestFixture::Options;
     constexpr bool issingle =
         std::is_same<gko::remove_complex<value_type>, float>::value;
@@ -146,7 +147,7 @@ TYPED_TEST(BatchCg, SolveIsEquivalentToReference)
     const opts_type opts{gko::preconditioner::batch::type::none, 500,
                          solver_restol,
                          gko::stop::batch::ToleranceType::relative};
-    auto r_sys = gko::test::generate_solvable_batch_system<value_type>(
+    auto r_sys = gko::test::generate_solvable_batch_system<mtx_type>(
         this->exec, this->nbatch, 11, 1, true);
     auto r_factory = this->create_factory(this->exec, opts);
     const double iter_tol = 0.01;

--- a/cuda/test/solver/batch_cg_kernels.cpp
+++ b/cuda/test/solver/batch_cg_kernels.cpp
@@ -279,11 +279,12 @@ TEST(BatchCg, GoodScalingImprovesConvergence)
 }
 
 
-TEST(BatchCg, CanSolveWithoutScaling)
+TEST(BatchCg, CanSolveCsrWithoutScaling)
 {
     using T = std::complex<float>;
     using RT = typename gko::remove_complex<T>;
     using Solver = gko::solver::BatchCg<T>;
+    using Csr = gko::matrix::BatchCsr<T>;
     const RT tol = 1e-5;
     std::shared_ptr<gko::ReferenceExecutor> refexec =
         gko::ReferenceExecutor::create();
@@ -300,8 +301,9 @@ TEST(BatchCg, CanSolveWithoutScaling)
     const int nrows = 28;
     const size_t nbatch = 3;
     const int nrhs = 1;
-    gko::test::test_solve<Solver>(exec, nbatch, nrows, nrhs, tol, maxits,
-                                  batchcg_factory.get(), 10);
+
+    gko::test::test_solve<Solver, Csr>(exec, nbatch, nrows, nrhs, tol, maxits,
+                                       batchcg_factory.get(), 10);
 }
 
 

--- a/cuda/test/solver/batch_gmres_kernels.cpp
+++ b/cuda/test/solver/batch_gmres_kernels.cpp
@@ -141,6 +141,7 @@ TYPED_TEST(BatchGmres, SolveIsEquivalentToReference)
 {
     using value_type = typename TestFixture::value_type;
     using solver_type = gko::solver::BatchGmres<value_type>;
+    using mtx_type = typename TestFixture::Mtx;
     using opts_type = typename TestFixture::Options;
     constexpr bool issingle =
         std::is_same<gko::remove_complex<value_type>, float>::value;
@@ -148,7 +149,7 @@ TYPED_TEST(BatchGmres, SolveIsEquivalentToReference)
     const opts_type opts{gko::preconditioner::batch::type::none, 500,
                          solver_restol, 30,
                          gko::stop::batch::ToleranceType::relative};
-    auto r_sys = gko::test::generate_solvable_batch_system<value_type>(
+    auto r_sys = gko::test::generate_solvable_batch_system<mtx_type>(
         this->exec, this->nbatch, 11, 1, false);
     auto r_factory = this->create_factory(this->exec, opts);
     const double iter_tol = 0.01;

--- a/cuda/test/solver/batch_gmres_kernels.cpp
+++ b/cuda/test/solver/batch_gmres_kernels.cpp
@@ -283,11 +283,12 @@ TEST(BatchGmres, GoodScalingImprovesConvergence)
 }
 
 
-TEST(BatchGmres, CanSolveWithoutScaling)
+TEST(BatchGmres, CanSolveCsrWithoutScaling)
 {
     using T = std::complex<double>;
     using RT = typename gko::remove_complex<T>;
     using Solver = gko::solver::BatchGmres<T>;
+    using Csr = gko::matrix::BatchCsr<T>;
     const RT tol = 1e-8;
     std::shared_ptr<gko::ReferenceExecutor> refexec =
         gko::ReferenceExecutor::create();
@@ -305,8 +306,9 @@ TEST(BatchGmres, CanSolveWithoutScaling)
     const int nrows = 23;
     const size_t nbatch = 3;
     const int nrhs = 1;
-    gko::test::test_solve<Solver>(exec, nbatch, nrows, nrhs, tol, maxits,
-                                  batchgmres_factory.get(), 10);
+
+    gko::test::test_solve<Solver, Csr>(exec, nbatch, nrows, nrhs, tol, maxits,
+                                       batchgmres_factory.get(), 10);
 }
 
 }  // namespace

--- a/cuda/test/solver/batch_idr_kernels.cpp
+++ b/cuda/test/solver/batch_idr_kernels.cpp
@@ -246,6 +246,7 @@ TEST(BatchIdr, CanSolveWithoutScaling)
     using T = std::complex<double>;
     using RT = typename gko::remove_complex<T>;
     using Solver = gko::solver::BatchIdr<T>;
+    using Csr = gko::matrix::BatchCsr<T>;
     const RT tol = 1e-9;
     std::shared_ptr<gko::ReferenceExecutor> refexec =
         gko::ReferenceExecutor::create();
@@ -266,8 +267,9 @@ TEST(BatchIdr, CanSolveWithoutScaling)
     const int nrows = 33;
     const size_t nbatch = 3;
     const int nrhs = 1;
-    gko::test::test_solve<Solver>(exec, nbatch, nrows, nrhs, tol, maxits,
-                                  batchidr_factory.get(), 1.1);
+
+    gko::test::test_solve<Solver, Csr>(exec, nbatch, nrows, nrhs, tol, maxits,
+                                       batchidr_factory.get(), 1.1);
 }
 
 

--- a/cuda/test/solver/batch_idr_kernels.cpp
+++ b/cuda/test/solver/batch_idr_kernels.cpp
@@ -150,6 +150,7 @@ TYPED_TEST(BatchIdr, SolveIsEquivalentToReference)
 {
     using value_type = typename TestFixture::value_type;
     using solver_type = gko::solver::BatchIdr<value_type>;
+    using mtx_type = typename TestFixture::Mtx;
     using opts_type = typename TestFixture::Options;
     constexpr bool issingle =
         std::is_same<gko::remove_complex<value_type>, float>::value;
@@ -163,7 +164,7 @@ TYPED_TEST(BatchIdr, SolveIsEquivalentToReference)
                          true,
                          true,
                          gko::stop::batch::ToleranceType::relative};
-    auto r_sys = gko::test::generate_solvable_batch_system<value_type>(
+    auto r_sys = gko::test::generate_solvable_batch_system<mtx_type>(
         this->exec, this->nbatch, 11, 1, false);
     auto r_factory = this->create_factory(this->exec, opts);
     const double iter_tol = 0.01;

--- a/hip/matrix/batch_dense_kernels.hip.cpp
+++ b/hip/matrix/batch_dense_kernels.hip.cpp
@@ -75,7 +75,18 @@ template <typename ValueType>
 void simple_apply(std::shared_ptr<const HipExecutor> exec,
                   const matrix::BatchDense<ValueType>* a,
                   const matrix::BatchDense<ValueType>* b,
-                  matrix::BatchDense<ValueType>* c) GKO_NOT_IMPLEMENTED;
+                  matrix::BatchDense<ValueType>* c)
+{
+    const auto num_blocks = exec->get_num_multiprocessor() * sm_multiplier;
+    const auto a_ub = get_batch_struct(a);
+    const auto b_ub = get_batch_struct(b);
+    const auto c_ub = get_batch_struct(c);
+    if (b_ub.num_rhs > 1) {
+        GKO_NOT_IMPLEMENTED;
+    }
+    hipLaunchKernelGGL(mv, num_blocks, default_block_size, 0, 0, a_ub, b_ub,
+                       c_ub);
+}
 
 GKO_INSTANTIATE_FOR_EACH_VALUE_TYPE(
     GKO_DECLARE_BATCH_DENSE_SIMPLE_APPLY_KERNEL);
@@ -87,7 +98,20 @@ void apply(std::shared_ptr<const HipExecutor> exec,
            const matrix::BatchDense<ValueType>* a,
            const matrix::BatchDense<ValueType>* b,
            const matrix::BatchDense<ValueType>* beta,
-           matrix::BatchDense<ValueType>* c) GKO_NOT_IMPLEMENTED;
+           matrix::BatchDense<ValueType>* c)
+{
+    const auto num_blocks = exec->get_num_multiprocessor() * sm_multiplier;
+    const auto a_ub = get_batch_struct(a);
+    const auto b_ub = get_batch_struct(b);
+    const auto c_ub = get_batch_struct(c);
+    const auto alpha_ub = get_batch_struct(alpha);
+    const auto beta_ub = get_batch_struct(beta);
+    if (b_ub.num_rhs > 1) {
+        GKO_NOT_IMPLEMENTED;
+    }
+    hipLaunchKernelGGL(advanced_mv, num_blocks, default_block_size, 0, 0,
+                       alpha_ub, a_ub, b_ub, beta_ub, c_ub);
+}
 
 GKO_INSTANTIATE_FOR_EACH_VALUE_TYPE(GKO_DECLARE_BATCH_DENSE_APPLY_KERNEL);
 

--- a/hip/matrix/batch_struct.hip.hpp
+++ b/hip/matrix/batch_struct.hip.hpp
@@ -69,9 +69,13 @@ template <typename ValueType>
 inline gko::batch_dense::UniformBatch<const hip_type<ValueType>>
 get_batch_struct(const matrix::BatchDense<ValueType>* const op)
 {
-    return {as_hip_type(op->get_const_values()), op->get_num_batch_entries(),
-            op->get_stride().at(0), static_cast<int>(op->get_size().at(0)[0]),
-            static_cast<int>(op->get_size().at(0)[1])};
+    return {
+        as_hip_type(op->get_const_values()),
+        op->get_num_batch_entries(),
+        op->get_stride().at(0),
+        static_cast<int>(op->get_size().at(0)[0]),
+        static_cast<int>(op->get_size().at(0)[1]),
+        static_cast<int>(op->get_size().at(0)[0] * op->get_size().at(0)[1])};
 }
 
 /**
@@ -81,9 +85,13 @@ template <typename ValueType>
 inline gko::batch_dense::UniformBatch<hip_type<ValueType>> get_batch_struct(
     matrix::BatchDense<ValueType>* const op)
 {
-    return {as_hip_type(op->get_values()), op->get_num_batch_entries(),
-            op->get_stride().at(0), static_cast<int>(op->get_size().at(0)[0]),
-            static_cast<int>(op->get_size().at(0)[1])};
+    return {
+        as_hip_type(op->get_values()),
+        op->get_num_batch_entries(),
+        op->get_stride().at(0),
+        static_cast<int>(op->get_size().at(0)[0]),
+        static_cast<int>(op->get_size().at(0)[1]),
+        static_cast<int>(op->get_size().at(0)[0] * op->get_size().at(0)[1])};
 }
 
 /**

--- a/hip/solver/batch_bicgstab_kernels.hip.cpp
+++ b/hip/solver/batch_bicgstab_kernels.hip.cpp
@@ -67,6 +67,7 @@ namespace batch_bicgstab {
 #include "common/cuda_hip/components/uninitialized_array.hpp.inc"
 // include all depedencies (note: do not remove this comment)
 #include "common/cuda_hip/matrix/batch_csr_kernels.hpp.inc"
+#include "common/cuda_hip/matrix/batch_dense_kernels.hpp.inc"
 #include "common/cuda_hip/matrix/batch_ell_kernels.hpp.inc"
 #include "common/cuda_hip/matrix/batch_vector_kernels.hpp.inc"
 #include "common/cuda_hip/solver/batch_bicgstab_kernels.hpp.inc"
@@ -137,16 +138,19 @@ public:
             exec_, sconf.gmem_stride_bytes * nbatch / sizeof(value_type));
         assert(sconf.gmem_stride_bytes % sizeof(value_type) == 0);
 
-        std::cerr << " Bicgstab: vectors in shared memory = " << sconf.n_shared
-                  << "\n";
-        if (sconf.prec_shared) {
-            std::cerr << " Bicgstab: precondiioner is in shared memory.\n";
-        }
-        std::cerr << " Bicgstab: vectors in global memory = " << sconf.n_global
-                  << "\n Hip: number of threads per warp = "
-                  << config::warp_size
-                  << "\n Bicgstab: number of threads per block = " << block_size
-                  << "\n";
+        // std::cerr << " Bicgstab: vectors in shared memory = " <<
+        // sconf.n_shared
+        //          << "\n";
+        // if (sconf.prec_shared) {
+        //    std::cerr << " Bicgstab: precondiioner is in shared memory.\n";
+        //}
+        // std::cerr << " Bicgstab: vectors in global memory = " <<
+        // sconf.n_global
+        //          << "\n Hip: number of threads per warp = "
+        //          << config::warp_size
+        //          << "\n Bicgstab: number of threads per block = " <<
+        //          block_size
+        //          << "\n";
         hipLaunchKernelGGL(
             apply_kernel<StopType>, dim3(nbatch), dim3(block_size), shared_size,
             0, shared_gap, sconf, opts_.max_its, opts_.residual_tol, logger,

--- a/hip/solver/batch_cg_kernels.hip.cpp
+++ b/hip/solver/batch_cg_kernels.hip.cpp
@@ -63,6 +63,7 @@ namespace batch_cg {
 #include "common/cuda_hip/components/uninitialized_array.hpp.inc"
 // include all depedencies (note: do not remove this comment)
 #include "common/cuda_hip/matrix/batch_csr_kernels.hpp.inc"
+#include "common/cuda_hip/matrix/batch_dense_kernels.hpp.inc"
 #include "common/cuda_hip/matrix/batch_ell_kernels.hpp.inc"
 #include "common/cuda_hip/matrix/batch_vector_kernels.hpp.inc"
 #include "common/cuda_hip/solver/batch_cg_kernels.hpp.inc"

--- a/hip/test/matrix/batch_dense_kernels.cpp
+++ b/hip/test/matrix/batch_dense_kernels.cpp
@@ -107,9 +107,9 @@ protected:
             hip, gko::batch_dim<>(batch_size, gko::dim<2>{1, num_vecs}));
     }
 
-    void set_up_apply_data()
+    void set_up_apply_data(const int p = 1)
     {
-        const int m = 35, n = 15, p = 25;
+        const int m = 35, n = 15;
         x = gen_mtx<Mtx>(batch_size, m, n);
         c_x = gen_mtx<ComplexMtx>(batch_size, m, n);
         y = gen_mtx<Mtx>(batch_size, n, p);
@@ -155,6 +155,28 @@ protected:
     std::unique_ptr<Mtx> dbeta;
     std::unique_ptr<Mtx> dsquare;
 };
+
+
+TEST_F(BatchDense, SingleVectorAppyIsEquivalentToRef)
+{
+    set_up_apply_data(1);
+
+    x->apply(y.get(), expected.get());
+    dx->apply(dy.get(), dresult.get());
+
+    GKO_ASSERT_BATCH_MTX_NEAR(dresult, expected, 1e-14);
+}
+
+
+TEST_F(BatchDense, SingleVectorAdvancedAppyIsEquivalentToRef)
+{
+    set_up_apply_data(1);
+
+    x->apply(alpha.get(), y.get(), beta.get(), expected.get());
+    dx->apply(dalpha.get(), dy.get(), dbeta.get(), dresult.get());
+
+    GKO_ASSERT_BATCH_MTX_NEAR(dresult, expected, 1e-14);
+}
 
 
 TEST_F(BatchDense, SingleVectorAddScaledIsEquivalentToRef)

--- a/hip/test/solver/batch_bicgstab_kernels.cpp
+++ b/hip/test/solver/batch_bicgstab_kernels.cpp
@@ -262,4 +262,62 @@ TEST(BatchBicgstab, SolvesLargeSystemEquivalentToReference)
         d_exec, r_sys, r_factory.get(), iter_tol, res_tol, sol_tol);
 }
 
+
+TEST(BatchBicgstab, SolvesLargeEllSystemEquivalentToReference)
+{
+    using value_type = double;
+    using real_type = double;
+    using mtx_type = gko::matrix::BatchEll<value_type, int>;
+    using solver_type = gko::solver::BatchBicgstab<value_type>;
+    std::shared_ptr<gko::ReferenceExecutor> refexec =
+        gko::ReferenceExecutor::create();
+    std::shared_ptr<const gko::HipExecutor> d_exec =
+        gko::HipExecutor::create(0, refexec);
+    const float solver_restol = 1e-4;
+    auto r_sys = gko::test::generate_solvable_batch_system<mtx_type>(
+        refexec, 2, 95, 1, false);
+    auto r_factory =
+        solver_type::build()
+            .with_max_iterations(500)
+            .with_residual_tol(solver_restol)
+            .with_tolerance_type(gko::stop::batch::ToleranceType::relative)
+            .with_preconditioner(gko::preconditioner::batch::type::jacobi)
+            .on(refexec);
+    const double iter_tol = 0.01;
+    const double res_tol = 1e-9;
+    const double sol_tol = 10 * solver_restol;
+
+    gko::test::compare_with_reference<value_type, solver_type>(
+        d_exec, r_sys, r_factory.get(), iter_tol, res_tol, sol_tol);
+}
+
+
+TEST(BatchBicgstab, SolvesLargeDenseSystemEquivalentToReference)
+{
+    using value_type = double;
+    using real_type = double;
+    using mtx_type = gko::matrix::BatchDense<value_type>;
+    using solver_type = gko::solver::BatchBicgstab<value_type>;
+    std::shared_ptr<gko::ReferenceExecutor> refexec =
+        gko::ReferenceExecutor::create();
+    std::shared_ptr<const gko::HipExecutor> d_exec =
+        gko::HipExecutor::create(0, refexec);
+    const float solver_restol = 1e-4;
+    auto r_sys = gko::test::generate_solvable_batch_system<mtx_type>(
+        refexec, 2, 37, 1, false);
+    auto r_factory =
+        solver_type::build()
+            .with_max_iterations(500)
+            .with_residual_tol(solver_restol)
+            .with_tolerance_type(gko::stop::batch::ToleranceType::relative)
+            .with_preconditioner(gko::preconditioner::batch::type::jacobi)
+            .on(refexec);
+    const double iter_tol = 0.01;
+    const double res_tol = 1e-9;
+    const double sol_tol = 10 * solver_restol;
+
+    gko::test::compare_with_reference<value_type, solver_type>(
+        d_exec, r_sys, r_factory.get(), iter_tol, res_tol, sol_tol);
+}
+
 }  // namespace

--- a/hip/test/solver/batch_bicgstab_kernels.cpp
+++ b/hip/test/solver/batch_bicgstab_kernels.cpp
@@ -121,10 +121,11 @@ TYPED_TEST(BatchBicgstab, SolveIsEquivalentToReference)
 {
     using value_type = typename TestFixture::value_type;
     using solver_type = gko::solver::BatchBicgstab<value_type>;
+    using mtx_type = typename TestFixture::Mtx;
     using opts_type = typename TestFixture::Options;
     const opts_type opts{gko::preconditioner::batch::type::none, 500, this->eps,
                          gko::stop::batch::ToleranceType::relative};
-    auto r_sys = gko::test::generate_solvable_batch_system<value_type>(
+    auto r_sys = gko::test::generate_solvable_batch_system<mtx_type>(
         this->exec, this->nbatch, 11, 1, false);
     auto r_factory = this->create_factory(this->exec, opts);
     const double iter_tol = 0.01;
@@ -237,13 +238,14 @@ TEST(BatchBicgstab, SolvesLargeSystemEquivalentToReference)
 {
     using value_type = double;
     using real_type = double;
+    using mtx_type = gko::matrix::BatchCsr<value_type, int>;
     using solver_type = gko::solver::BatchBicgstab<value_type>;
     std::shared_ptr<gko::ReferenceExecutor> refexec =
         gko::ReferenceExecutor::create();
     std::shared_ptr<const gko::HipExecutor> d_exec =
         gko::HipExecutor::create(0, refexec);
     const float solver_restol = 1e-4;
-    auto r_sys = gko::test::generate_solvable_batch_system<value_type>(
+    auto r_sys = gko::test::generate_solvable_batch_system<mtx_type>(
         refexec, 2, 1090, 1, false);
     auto r_factory =
         solver_type::build()

--- a/hip/test/solver/batch_cg_kernels.cpp
+++ b/hip/test/solver/batch_cg_kernels.cpp
@@ -139,6 +139,7 @@ TYPED_TEST(BatchCg, SolveIsEquivalentToReference)
 {
     using value_type = typename TestFixture::value_type;
     using solver_type = gko::solver::BatchCg<value_type>;
+    using mtx_type = typename TestFixture::Mtx;
     using opts_type = typename TestFixture::Options;
     constexpr bool issingle =
         std::is_same<gko::remove_complex<value_type>, float>::value;
@@ -146,7 +147,7 @@ TYPED_TEST(BatchCg, SolveIsEquivalentToReference)
     const opts_type opts{gko::preconditioner::batch::type::none, 500,
                          solver_restol,
                          gko::stop::batch::ToleranceType::relative};
-    auto r_sys = gko::test::generate_solvable_batch_system<value_type>(
+    auto r_sys = gko::test::generate_solvable_batch_system<mtx_type>(
         this->exec, this->nbatch, 11, 1, true);
     auto r_factory = this->create_factory(this->exec, opts);
     const double iter_tol = 0.01;

--- a/hip/test/solver/batch_cg_kernels.cpp
+++ b/hip/test/solver/batch_cg_kernels.cpp
@@ -284,6 +284,7 @@ TEST(BatchCg, CanSolveLargerSystemWithoutScaling)
     using T = std::complex<float>;
     using RT = typename gko::remove_complex<T>;
     using Solver = gko::solver::BatchCg<T>;
+    using Mtx = gko::matrix::BatchCsr<T, int>;
     const RT tol = 1e-5;
     std::shared_ptr<gko::ReferenceExecutor> refexec =
         gko::ReferenceExecutor::create();
@@ -300,8 +301,8 @@ TEST(BatchCg, CanSolveLargerSystemWithoutScaling)
     const int nrows = 28;
     const size_t nbatch = 3;
     const int nrhs = 1;
-    gko::test::test_solve<Solver>(exec, nbatch, nrows, nrhs, tol, maxits,
-                                  batchcg_factory.get(), 10);
+    gko::test::test_solve<Solver, Mtx>(exec, nbatch, nrows, nrhs, tol, maxits,
+                                       batchcg_factory.get(), 10);
 }
 
 

--- a/hip/test/solver/batch_gmres_kernels.cpp
+++ b/hip/test/solver/batch_gmres_kernels.cpp
@@ -133,10 +133,11 @@ TYPED_TEST(BatchGmres, SolvesSystemEquivalentToReference)
 {
     using value_type = typename TestFixture::value_type;
     using solver_type = gko::solver::BatchGmres<value_type>;
+    using mtx_type = typename TestFixture::Mtx;
     using opts_type = typename TestFixture::Options;
     const opts_type opts{gko::preconditioner::batch::type::none, 700, this->eps,
                          10, gko::stop::batch::ToleranceType::relative};
-    auto r_sys = gko::test::generate_solvable_batch_system<value_type>(
+    auto r_sys = gko::test::generate_solvable_batch_system<mtx_type>(
         this->exec, this->nbatch, 7, 1, false);
     auto r_factory = this->create_factory(this->exec, opts);
     const double iter_tol = 0.01;

--- a/hip/test/solver/batch_richardson_kernels.cpp
+++ b/hip/test/solver/batch_richardson_kernels.cpp
@@ -156,10 +156,11 @@ TYPED_TEST(BatchRich, SolvesStencilSystemJacobi)
 {
     using value_type = typename TestFixture::value_type;
     using solver_type = gko::solver::BatchRichardson<value_type>;
+    using mtx_type = typename TestFixture::Mtx;
     using opts_type = typename TestFixture::Options;
     const opts_type opts{gpb::type::jacobi, 1000, r<value_type>::value,
                          gko::stop::batch::ToleranceType::relative, 1.0};
-    auto r_sys = gko::test::generate_solvable_batch_system<value_type>(
+    auto r_sys = gko::test::generate_solvable_batch_system<mtx_type>(
         this->exec, this->nbatch, 6, 1, false);
     auto r_factory = this->create_factory(this->exec, opts);
     const double iter_tol = 0.01;

--- a/hip/test/solver/batch_richardson_kernels.cpp
+++ b/hip/test/solver/batch_richardson_kernels.cpp
@@ -323,6 +323,7 @@ TEST(BatchRich, CanSolveWithoutScaling)
     using T = std::complex<float>;
     using RT = typename gko::remove_complex<T>;
     using Solver = gko::solver::BatchRichardson<T>;
+    using Mtx = gko::matrix::BatchCsr<T, int>;
     const RT tol = 1e-5;
     std::shared_ptr<gko::ReferenceExecutor> refexec =
         gko::ReferenceExecutor::create();
@@ -340,8 +341,8 @@ TEST(BatchRich, CanSolveWithoutScaling)
             .with_tolerance_type(gko::stop::batch::ToleranceType::relative)
             .with_preconditioner(gko::preconditioner::batch::type::jacobi)
             .on(exec);
-    gko::test::test_solve<Solver>(exec, nbatch, nrows, nrhs, 10 * tol, maxits,
-                                  batchrich_factory.get(), 2);
+    gko::test::test_solve<Solver, Mtx>(exec, nbatch, nrows, nrhs, 10 * tol,
+                                       maxits, batchrich_factory.get(), 2);
 }
 
 }  // namespace

--- a/include/ginkgo/core/matrix/batch_ell.hpp
+++ b/include/ginkgo/core/matrix/batch_ell.hpp
@@ -409,6 +409,9 @@ protected:
      *
      * @param exec  Executor associated to the matrix
      * @param size  the batch size of the batch matrices
+     * @param num_stored_elems_per_row  The (common) number of stored entries
+     *                                  per row.
+     * @param stride  (Common) row-stride of the small matrices.
      * @param values  array of matrix values concatenated for the different
      *                batches
      * @param col_idxs  array of column indexes which is common among all the

--- a/omp/matrix/batch_csr_kernels.cpp
+++ b/omp/matrix/batch_csr_kernels.cpp
@@ -75,7 +75,7 @@ void spmv(std::shared_ptr<const OmpExecutor> exec,
         const auto a_b = gko::batch::batch_entry(a_ub, batch);
         const auto b_b = gko::batch::batch_entry(b_ub, batch);
         const auto c_b = gko::batch::batch_entry(c_ub, batch);
-        spmv_kernel(a_b, b_b, c_b);
+        matvec_kernel(a_b, b_b, c_b);
     }
 }
 
@@ -104,8 +104,8 @@ void advanced_spmv(std::shared_ptr<const OmpExecutor> exec,
         const auto c_b = gko::batch::batch_entry(c_ub, batch);
         const auto alpha_b = gko::batch::batch_entry(alpha_ub, batch);
         const auto beta_b = gko::batch::batch_entry(beta_ub, batch);
-        advanced_spmv_kernel(alpha_b.values[0], a_b, b_b, beta_b.values[0],
-                             c_b);
+        advanced_matvec_kernel(alpha_b.values[0], a_b, b_b, beta_b.values[0],
+                               c_b);
     }
 }
 

--- a/omp/matrix/batch_dense_kernels.cpp
+++ b/omp/matrix/batch_dense_kernels.cpp
@@ -74,7 +74,7 @@ void simple_apply(std::shared_ptr<const OmpExecutor> exec,
         const auto a_b = gko::batch::batch_entry(a_ub, batch);
         const auto b_b = gko::batch::batch_entry(b_ub, batch);
         const auto c_b = gko::batch::batch_entry(c_ub, batch);
-        spmv_kernel(a_b, b_b, c_b);
+        matvec_kernel(a_b, b_b, c_b);
     }
 }
 
@@ -102,8 +102,8 @@ void apply(std::shared_ptr<const OmpExecutor> exec,
         const auto c_b = gko::batch::batch_entry(c_ub, batch);
         const auto alpha_b = gko::batch::batch_entry(alpha_ub, batch);
         const auto beta_b = gko::batch::batch_entry(beta_ub, batch);
-        advanced_spmv_kernel(alpha_b.values[0], a_b, b_b, beta_b.values[0],
-                             c_b);
+        advanced_matvec_kernel(alpha_b.values[0], a_b, b_b, beta_b.values[0],
+                               c_b);
     }
 }
 

--- a/omp/matrix/batch_ell_kernels.cpp
+++ b/omp/matrix/batch_ell_kernels.cpp
@@ -76,7 +76,7 @@ void spmv(std::shared_ptr<const OmpExecutor> exec,
         const auto a_b = gko::batch::batch_entry(a_ub, batch);
         const auto b_b = gko::batch::batch_entry(b_ub, batch);
         const auto c_b = gko::batch::batch_entry(c_ub, batch);
-        spmv_kernel(a_b, b_b, c_b);
+        matvec_kernel(a_b, b_b, c_b);
     }
 }
 
@@ -105,8 +105,8 @@ void advanced_spmv(std::shared_ptr<const OmpExecutor> exec,
         const auto c_b = gko::batch::batch_entry(c_ub, batch);
         const auto alpha_b = gko::batch::batch_entry(alpha_ub, batch);
         const auto beta_b = gko::batch::batch_entry(beta_ub, batch);
-        advanced_spmv_kernel(alpha_b.values[0], a_b, b_b, beta_b.values[0],
-                             c_b);
+        advanced_matvec_kernel(alpha_b.values[0], a_b, b_b, beta_b.values[0],
+                               c_b);
     }
 }
 

--- a/omp/solver/batch_bicgstab_kernels.cpp
+++ b/omp/solver/batch_bicgstab_kernels.cpp
@@ -35,7 +35,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "core/solver/batch_dispatch.hpp"
 #include "omp/base/config.hpp"
-#include "reference/matrix/batch_dense_kernels.hpp"
 
 
 namespace gko {
@@ -49,10 +48,10 @@ namespace omp {
 namespace batch_bicgstab {
 
 
-namespace batch_dense = gko::kernels::reference::batch_dense;
 constexpr int max_num_rhs = 1;
 
 #include "reference/matrix/batch_csr_kernels.hpp.inc"
+#include "reference/matrix/batch_dense_kernels.hpp.inc"
 #include "reference/matrix/batch_ell_kernels.hpp.inc"
 #include "reference/solver/batch_bicgstab_kernels.hpp.inc"
 

--- a/omp/solver/batch_cg_kernels.cpp
+++ b/omp/solver/batch_cg_kernels.cpp
@@ -35,8 +35,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "core/solver/batch_dispatch.hpp"
 #include "omp/base/config.hpp"
-// include device kernels for every matrix and preconditioner type
-#include "reference/matrix/batch_dense_kernels.hpp"
 
 
 namespace gko {
@@ -50,10 +48,10 @@ namespace omp {
 namespace batch_cg {
 
 
-namespace batch_dense = gko::kernels::reference::batch_dense;
 constexpr int max_num_rhs = 1;
 
 #include "reference/matrix/batch_csr_kernels.hpp.inc"
+#include "reference/matrix/batch_dense_kernels.hpp.inc"
 #include "reference/matrix/batch_ell_kernels.hpp.inc"
 #include "reference/solver/batch_cg_kernels.hpp.inc"
 

--- a/omp/test/solver/batch_bicgstab_kernels.cpp
+++ b/omp/test/solver/batch_bicgstab_kernels.cpp
@@ -141,7 +141,8 @@ TYPED_TEST(BatchBicgstab, SolvesSystemEquivalentToReference)
 {
     using value_type = typename TestFixture::value_type;
     using solver_type = gko::solver::BatchBicgstab<value_type>;
-    auto r_sys = gko::test::generate_solvable_batch_system<value_type>(
+    using mtx_type = typename TestFixture::Mtx;
+    auto r_sys = gko::test::generate_solvable_batch_system<mtx_type>(
         this->exec, this->nbatch, this->nrows, 1, false);
     auto r_factory = this->create_factory(this->exec, this->opts_1);
     const double iter_tol = 0.01;

--- a/omp/test/solver/batch_bicgstab_kernels.cpp
+++ b/omp/test/solver/batch_bicgstab_kernels.cpp
@@ -279,6 +279,7 @@ TEST(BatchBicgstab, CanSolveWithoutScaling)
     using T = std::complex<float>;
     using RT = typename gko::remove_complex<T>;
     using Solver = gko::solver::BatchBicgstab<T>;
+    using Mtx = gko::matrix::BatchCsr<T, int>;
     const RT tol = 1e-5;
     std::shared_ptr<gko::ReferenceExecutor> refexec =
         gko::ReferenceExecutor::create();
@@ -295,8 +296,64 @@ TEST(BatchBicgstab, CanSolveWithoutScaling)
     const size_t nbatch = 3;
     const int nrhs = 1;
 
-    gko::test::test_solve<Solver>(exec, nbatch, nrows, nrhs, tol, maxits,
-                                  batchbicgstab_factory.get(), 10);
+    gko::test::test_solve<Solver, Mtx>(exec, nbatch, nrows, nrhs, tol, maxits,
+                                       batchbicgstab_factory.get(), 10);
+}
+
+
+TEST(BatchBicgstab, SolvesLargeEllSystemEquivalentToReference)
+{
+    using value_type = double;
+    using real_type = double;
+    using mtx_type = gko::matrix::BatchEll<value_type, int>;
+    using solver_type = gko::solver::BatchBicgstab<value_type>;
+    std::shared_ptr<gko::ReferenceExecutor> refexec =
+        gko::ReferenceExecutor::create();
+    std::shared_ptr<const gko::OmpExecutor> d_exec = gko::OmpExecutor::create();
+    const float solver_restol = 1e-4;
+    auto r_sys = gko::test::generate_solvable_batch_system<mtx_type>(
+        refexec, 2, 95, 1, false);
+    auto r_factory =
+        solver_type::build()
+            .with_max_iterations(500)
+            .with_residual_tol(solver_restol)
+            .with_tolerance_type(gko::stop::batch::ToleranceType::relative)
+            .with_preconditioner(gko::preconditioner::batch::type::jacobi)
+            .on(refexec);
+    const double iter_tol = 0.01;
+    const double res_tol = 1e-9;
+    const double sol_tol = 10 * solver_restol;
+
+    gko::test::compare_with_reference<value_type, solver_type>(
+        d_exec, r_sys, r_factory.get(), iter_tol, res_tol, sol_tol);
+}
+
+
+TEST(BatchBicgstab, SolvesLargeDenseSystemEquivalentToReference)
+{
+    using value_type = double;
+    using real_type = double;
+    using mtx_type = gko::matrix::BatchDense<value_type>;
+    using solver_type = gko::solver::BatchBicgstab<value_type>;
+    std::shared_ptr<gko::ReferenceExecutor> refexec =
+        gko::ReferenceExecutor::create();
+    std::shared_ptr<const gko::OmpExecutor> d_exec = gko::OmpExecutor::create();
+    const float solver_restol = 1e-4;
+    auto r_sys = gko::test::generate_solvable_batch_system<mtx_type>(
+        refexec, 2, 37, 1, false);
+    auto r_factory =
+        solver_type::build()
+            .with_max_iterations(500)
+            .with_residual_tol(solver_restol)
+            .with_tolerance_type(gko::stop::batch::ToleranceType::relative)
+            .with_preconditioner(gko::preconditioner::batch::type::jacobi)
+            .on(refexec);
+    const double iter_tol = 0.01;
+    const double res_tol = 1e-9;
+    const double sol_tol = 10 * solver_restol;
+
+    gko::test::compare_with_reference<value_type, solver_type>(
+        d_exec, r_sys, r_factory.get(), iter_tol, res_tol, sol_tol);
 }
 
 }  // namespace

--- a/omp/test/solver/batch_cg_kernels.cpp
+++ b/omp/test/solver/batch_cg_kernels.cpp
@@ -138,6 +138,7 @@ TYPED_TEST(BatchCg, SolveIsEquivalentToReference)
 {
     using value_type = typename TestFixture::value_type;
     using solver_type = gko::solver::BatchCg<value_type>;
+    using mtx_type = typename TestFixture::Mtx;
     using opts_type = typename TestFixture::Options;
     constexpr bool issingle =
         std::is_same<gko::remove_complex<value_type>, float>::value;
@@ -145,7 +146,7 @@ TYPED_TEST(BatchCg, SolveIsEquivalentToReference)
     const opts_type opts{gko::preconditioner::batch::type::none, 500,
                          solver_restol,
                          gko::stop::batch::ToleranceType::relative};
-    auto r_sys = gko::test::generate_solvable_batch_system<value_type>(
+    auto r_sys = gko::test::generate_solvable_batch_system<mtx_type>(
         this->exec, this->nbatch, 11, 1, true);
     auto r_factory = this->create_factory(this->exec, opts);
     const double iter_tol = 0.01;

--- a/omp/test/solver/batch_cg_kernels.cpp
+++ b/omp/test/solver/batch_cg_kernels.cpp
@@ -282,6 +282,7 @@ TEST(BatchCg, CanSolveWithoutScaling)
     using T = std::complex<float>;
     using RT = typename gko::remove_complex<T>;
     using Solver = gko::solver::BatchCg<T>;
+    using Mtx = gko::matrix::BatchCsr<T, int>;
     const RT tol = 1e-5;
     std::shared_ptr<gko::ReferenceExecutor> refexec =
         gko::ReferenceExecutor::create();
@@ -298,8 +299,8 @@ TEST(BatchCg, CanSolveWithoutScaling)
     const size_t nbatch = 3;
     const int nrhs = 1;
 
-    gko::test::test_solve<Solver>(exec, nbatch, nrows, nrhs, tol, maxits,
-                                  factory.get(), 10);
+    gko::test::test_solve<Solver, Mtx>(exec, nbatch, nrows, nrhs, tol, maxits,
+                                       factory.get(), 10);
 }
 
 }  // namespace

--- a/reference/matrix/batch_csr_kernels.cpp
+++ b/reference/matrix/batch_csr_kernels.cpp
@@ -76,7 +76,7 @@ void spmv(std::shared_ptr<const ReferenceExecutor>,
         const auto a_b = gko::batch::batch_entry(a_ub, batch);
         const auto b_b = gko::batch::batch_entry(b_ub, batch);
         const auto c_b = gko::batch::batch_entry(c_ub, batch);
-        spmv_kernel(a_b, b_b, c_b);
+        matvec_kernel(a_b, b_b, c_b);
     }
 }
 
@@ -103,8 +103,8 @@ void advanced_spmv(std::shared_ptr<const ReferenceExecutor>,
         const auto c_b = gko::batch::batch_entry(c_ub, batch);
         const auto alpha_b = gko::batch::batch_entry(alpha_ub, batch);
         const auto beta_b = gko::batch::batch_entry(beta_ub, batch);
-        advanced_spmv_kernel(alpha_b.values[0], a_b, b_b, beta_b.values[0],
-                             c_b);
+        advanced_matvec_kernel(alpha_b.values[0], a_b, b_b, beta_b.values[0],
+                               c_b);
     }
 }
 

--- a/reference/matrix/batch_csr_kernels.hpp.inc
+++ b/reference/matrix/batch_csr_kernels.hpp.inc
@@ -36,9 +36,10 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  * Assumes the input and output multi-vectors are stored row-major.
  */
 template <typename ValueType>
-inline void spmv_kernel(const gko::batch_csr::BatchEntry<const ValueType>& a,
-                        const gko::batch_dense::BatchEntry<const ValueType>& b,
-                        const gko::batch_dense::BatchEntry<ValueType>& c)
+inline void matvec_kernel(
+    const gko::batch_csr::BatchEntry<const ValueType>& a,
+    const gko::batch_dense::BatchEntry<const ValueType>& b,
+    const gko::batch_dense::BatchEntry<ValueType>& c)
 {
     for (int row = 0; row < a.num_rows; ++row) {
         for (int j = 0; j < b.num_rhs; ++j) {
@@ -62,7 +63,7 @@ inline void spmv_kernel(const gko::batch_csr::BatchEntry<const ValueType>& a,
  * Assumes the input and output multi-vectors are stored row-major.
  */
 template <typename ValueType>
-inline void advanced_spmv_kernel(
+inline void advanced_matvec_kernel(
     const ValueType alpha, const gko::batch_csr::BatchEntry<const ValueType>& a,
     const gko::batch_dense::BatchEntry<const ValueType>& b,
     const ValueType beta, const gko::batch_dense::BatchEntry<ValueType>& c)

--- a/reference/matrix/batch_dense_kernels.cpp
+++ b/reference/matrix/batch_dense_kernels.cpp
@@ -73,7 +73,7 @@ void simple_apply(std::shared_ptr<const ReferenceExecutor> exec,
         const auto a_b = gko::batch::batch_entry(a_ub, batch);
         const auto b_b = gko::batch::batch_entry(b_ub, batch);
         const auto c_b = gko::batch::batch_entry(c_ub, batch);
-        spmv_kernel(a_b, b_b, c_b);
+        matvec_kernel(a_b, b_b, c_b);
     }
 }
 
@@ -100,8 +100,8 @@ void apply(std::shared_ptr<const ReferenceExecutor> exec,
         const auto c_b = gko::batch::batch_entry(c_ub, batch);
         const auto alpha_b = gko::batch::batch_entry(alpha_ub, batch);
         const auto beta_b = gko::batch::batch_entry(beta_ub, batch);
-        advanced_spmv_kernel(alpha_b.values[0], a_b, b_b, beta_b.values[0],
-                             c_b);
+        advanced_matvec_kernel(alpha_b.values[0], a_b, b_b, beta_b.values[0],
+                               c_b);
     }
 }
 

--- a/reference/matrix/batch_dense_kernels.hpp.inc
+++ b/reference/matrix/batch_dense_kernels.hpp.inc
@@ -30,44 +30,14 @@ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ******************************<GINKGO LICENSE>*******************************/
 
-#ifndef GKO_REFERENCE_MATRIX_BATCH_DENSE_KERNELS_HPP_
-#define GKO_REFERENCE_MATRIX_BATCH_DENSE_KERNELS_HPP_
-
-
-#include <algorithm>
-
-
-#include <ginkgo/core/base/array.hpp>
-#include <ginkgo/core/base/math.hpp>
-#include <ginkgo/core/base/range_accessors.hpp>
-
-
-#include "core/matrix/batch_struct.hpp"
-
-
-namespace gko {
-namespace kernels {
-namespace reference {
-/**
- * @brief The BatchDense matrix format namespace.
- * @ref BatchDense
- * @ingroup batch_dense
- */
-namespace batch_dense {
-
-
 template <typename ValueType>
-using BatchEntry = gko::batch_dense::BatchEntry<ValueType>;
-
-
-template <typename ValueType>
-inline void simple_apply(const BatchEntry<const ValueType> &a,
-                         const BatchEntry<const ValueType> &b,
-                         const BatchEntry<ValueType> &c)
+inline void spmv_kernel(const gko::batch_dense::BatchEntry<const ValueType>& a,
+                        const gko::batch_dense::BatchEntry<const ValueType>& b,
+                        const gko::batch_dense::BatchEntry<ValueType>& c)
 {
     for (int row = 0; row < c.num_rows; ++row) {
         for (int col = 0; col < c.num_rhs; ++col) {
-            c.values[row * c.stride + col] = zero<ValueType>();
+            c.values[row * c.stride + col] = gko::zero<ValueType>();
         }
     }
 
@@ -84,11 +54,13 @@ inline void simple_apply(const BatchEntry<const ValueType> &a,
 
 
 template <typename ValueType>
-inline void apply(const ValueType alpha, const BatchEntry<const ValueType> &a,
-                  const BatchEntry<const ValueType> &b, const ValueType beta,
-                  const BatchEntry<ValueType> &c)
+inline void advanced_spmv_kernel(
+    const ValueType alpha,
+    const gko::batch_dense::BatchEntry<const ValueType>& a,
+    const gko::batch_dense::BatchEntry<const ValueType>& b,
+    const ValueType beta, const gko::batch_dense::BatchEntry<ValueType>& c)
 {
-    if (beta != zero<ValueType>()) {
+    if (beta != gko::zero<ValueType>()) {
         for (int row = 0; row < c.num_rows; ++row) {
             for (int col = 0; col < c.num_rhs; ++col) {
                 c.values[row * c.stride + col] *= beta;
@@ -97,7 +69,7 @@ inline void apply(const ValueType alpha, const BatchEntry<const ValueType> &a,
     } else {
         for (int row = 0; row < c.num_rows; ++row) {
             for (int col = 0; col < c.num_rhs; ++col) {
-                c.values[row * c.stride + col] *= zero<ValueType>();
+                c.values[row * c.stride + col] *= gko::zero<ValueType>();
             }
         }
     }
@@ -115,8 +87,8 @@ inline void apply(const ValueType alpha, const BatchEntry<const ValueType> &a,
 
 
 template <typename ValueType>
-inline void scale(const BatchEntry<const ValueType> &alpha,
-                  const BatchEntry<ValueType> &x)
+inline void scale(const gko::batch_dense::BatchEntry<const ValueType>& alpha,
+                  const gko::batch_dense::BatchEntry<ValueType>& x)
 {
     if (alpha.num_rhs == 1) {
         for (int i = 0; i < x.num_rows; ++i) {
@@ -135,9 +107,10 @@ inline void scale(const BatchEntry<const ValueType> &alpha,
 
 
 template <typename ValueType>
-inline void add_scaled(const BatchEntry<const ValueType> &alpha,
-                       const BatchEntry<const ValueType> &x,
-                       const BatchEntry<ValueType> &y)
+inline void add_scaled(
+    const gko::batch_dense::BatchEntry<const ValueType>& alpha,
+    const gko::batch_dense::BatchEntry<const ValueType>& x,
+    const gko::batch_dense::BatchEntry<ValueType>& y)
 {
     if (alpha.num_rhs == 1) {
         for (int i = 0; i < x.num_rows; ++i) {
@@ -158,14 +131,15 @@ inline void add_scaled(const BatchEntry<const ValueType> &alpha,
 
 
 template <typename ValueType>
-inline void compute_norm2(const BatchEntry<const ValueType> &x,
-                          const BatchEntry<remove_complex<ValueType>> &result)
+inline void compute_norm2(
+    const gko::batch_dense::BatchEntry<const ValueType>& x,
+    const gko::batch_dense::BatchEntry<gko::remove_complex<ValueType>>& result)
 {
     for (int j = 0; j < x.num_rhs; ++j) {
-        result.values[j] = zero<remove_complex<ValueType>>();
+        result.values[j] = gko::zero<gko::remove_complex<ValueType>>();
     }
     for (int i = 0; i < x.num_rows; ++i) {
-        for (size_type j = 0; j < x.num_rhs; ++j) {
+        for (int j = 0; j < x.num_rhs; ++j) {
             result.values[j] += squared_norm(x.values[i * x.stride + j]);
         }
     }
@@ -183,8 +157,8 @@ inline void compute_norm2(const BatchEntry<const ValueType> &x,
  */
 template <typename ValueType>
 inline void batch_scale(
-    const gko::batch_dense::BatchEntry<const ValueType> &diag_vec,
-    const gko::batch_dense::BatchEntry<ValueType> &a)
+    const gko::batch_dense::BatchEntry<const ValueType>& diag_vec,
+    const gko::batch_dense::BatchEntry<ValueType>& a)
 {
     for (int i_row = 0; i_row < a.num_rows; i_row++) {
         const ValueType scale = diag_vec.values[i_row];
@@ -202,8 +176,8 @@ inline void batch_scale(
  * and stride set.
  */
 template <typename ValueType>
-inline void copy(const gko::batch_dense::BatchEntry<const ValueType> &in,
-                 const gko::batch_dense::BatchEntry<ValueType> &out)
+inline void copy(const gko::batch_dense::BatchEntry<const ValueType>& in,
+                 const gko::batch_dense::BatchEntry<ValueType>& out)
 {
     for (int iz = 0; iz < in.num_rows * in.num_rhs; iz++) {
         const int i = iz / in.num_rhs;
@@ -214,12 +188,13 @@ inline void copy(const gko::batch_dense::BatchEntry<const ValueType> &in,
 
 
 template <typename ValueType>
-inline void compute_dot_product(const BatchEntry<const ValueType> &x,
-                                const BatchEntry<const ValueType> &y,
-                                const BatchEntry<ValueType> &result)
+inline void compute_dot_product(
+    const gko::batch_dense::BatchEntry<const ValueType>& x,
+    const gko::batch_dense::BatchEntry<const ValueType>& y,
+    const gko::batch_dense::BatchEntry<ValueType>& result)
 {
     for (int c = 0; c < result.num_rhs; c++) {
-        result.values[c] = zero<ValueType>();
+        result.values[c] = gko::zero<ValueType>();
     }
 
     for (int r = 0; r < x.num_rows; r++) {
@@ -233,13 +208,13 @@ inline void compute_dot_product(const BatchEntry<const ValueType> &x,
 
 template <typename ValueType>
 inline void copy(
-    const gko::batch_dense::BatchEntry<const ValueType> &source_entry,
-    const gko::batch_dense::BatchEntry<ValueType> &destination_entry,
-    const uint32 &converged)
+    const gko::batch_dense::BatchEntry<const ValueType>& source_entry,
+    const gko::batch_dense::BatchEntry<ValueType>& destination_entry,
+    const gko::uint32& converged)
 {
     for (int r = 0; r < source_entry.num_rows; r++) {
         for (int c = 0; c < source_entry.num_rhs; c++) {
-            const uint32 conv = converged & (1 << c);
+            const gko::uint32 conv = converged & (1 << c);
 
             if (conv) {
                 continue;
@@ -253,13 +228,14 @@ inline void copy(
 
 
 template <typename ValueType>
-inline void scale(const BatchEntry<const ValueType> &alpha,
-                  const BatchEntry<ValueType> &x, const uint32 &converged)
+inline void scale(const gko::batch_dense::BatchEntry<const ValueType>& alpha,
+                  const gko::batch_dense::BatchEntry<ValueType>& x,
+                  const gko::uint32& converged)
 {
     if (alpha.num_rhs == 1) {
         for (int i = 0; i < x.num_rows; ++i) {
             for (int j = 0; j < x.num_rhs; ++j) {
-                const uint32 conv = converged & (1 << j);
+                const gko::uint32 conv = converged & (1 << j);
 
                 if (conv) {
                     continue;
@@ -272,7 +248,7 @@ inline void scale(const BatchEntry<const ValueType> &alpha,
     } else {
         for (int i = 0; i < x.num_rows; ++i) {
             for (int j = 0; j < x.num_rhs; ++j) {
-                const uint32 conv = converged & (1 << j);
+                const gko::uint32 conv = converged & (1 << j);
 
                 if (conv) {
                     continue;
@@ -286,14 +262,16 @@ inline void scale(const BatchEntry<const ValueType> &alpha,
 
 
 template <typename ValueType>
-inline void add_scaled(const BatchEntry<const ValueType> &alpha,
-                       const BatchEntry<const ValueType> &x,
-                       const BatchEntry<ValueType> &y, const uint32 &converged)
+inline void add_scaled(
+    const gko::batch_dense::BatchEntry<const ValueType>& alpha,
+    const gko::batch_dense::BatchEntry<const ValueType>& x,
+    const gko::batch_dense::BatchEntry<ValueType>& y,
+    const gko::uint32& converged)
 {
     if (alpha.num_rhs == 1) {
         for (int i = 0; i < x.num_rows; ++i) {
             for (int j = 0; j < x.num_rhs; ++j) {
-                const uint32 conv = converged & (1 << j);
+                const gko::uint32 conv = converged & (1 << j);
 
                 if (conv) {
                     continue;
@@ -306,7 +284,7 @@ inline void add_scaled(const BatchEntry<const ValueType> &alpha,
     } else {
         for (int i = 0; i < x.num_rows; ++i) {
             for (int j = 0; j < x.num_rhs; ++j) {
-                const uint32 conv = converged & (1 << j);
+                const gko::uint32 conv = converged & (1 << j);
 
                 if (conv) {
                     continue;
@@ -322,22 +300,23 @@ inline void add_scaled(const BatchEntry<const ValueType> &alpha,
 
 
 template <typename ValueType>
-inline void compute_norm2(const BatchEntry<const ValueType> &x,
-                          const BatchEntry<remove_complex<ValueType>> &result,
-                          const uint32 &converged)
+inline void compute_norm2(
+    const gko::batch_dense::BatchEntry<const ValueType>& x,
+    const gko::batch_dense::BatchEntry<gko::remove_complex<ValueType>>& result,
+    const gko::uint32& converged)
 {
     for (int j = 0; j < x.num_rhs; ++j) {
-        const uint32 conv = converged & (1 << j);
+        const gko::uint32 conv = converged & (1 << j);
 
         if (conv) {
             continue;
         }
 
-        result.values[j] = zero<remove_complex<ValueType>>();
+        result.values[j] = gko::zero<gko::remove_complex<ValueType>>();
     }
     for (int i = 0; i < x.num_rows; ++i) {
-        for (size_type j = 0; j < x.num_rhs; ++j) {
-            const uint32 conv = converged & (1 << j);
+        for (int j = 0; j < x.num_rhs; ++j) {
+            const gko::uint32 conv = converged & (1 << j);
 
             if (conv) {
                 continue;
@@ -347,7 +326,7 @@ inline void compute_norm2(const BatchEntry<const ValueType> &x,
         }
     }
     for (int j = 0; j < x.num_rhs; ++j) {
-        const uint32 conv = converged & (1 << j);
+        const gko::uint32 conv = converged & (1 << j);
 
         if (conv) {
             continue;
@@ -359,24 +338,25 @@ inline void compute_norm2(const BatchEntry<const ValueType> &x,
 
 
 template <typename ValueType>
-inline void compute_dot_product(const BatchEntry<const ValueType> &x,
-                                const BatchEntry<const ValueType> &y,
-                                const BatchEntry<ValueType> &result,
-                                const uint32 &converged)
+inline void compute_dot_product(
+    const gko::batch_dense::BatchEntry<const ValueType>& x,
+    const gko::batch_dense::BatchEntry<const ValueType>& y,
+    const gko::batch_dense::BatchEntry<ValueType>& result,
+    const gko::uint32& converged)
 {
     for (int c = 0; c < result.num_rhs; c++) {
-        const uint32 conv = converged & (1 << c);
+        const gko::uint32 conv = converged & (1 << c);
 
         if (conv) {
             continue;
         }
 
-        result.values[c] = zero<ValueType>();
+        result.values[c] = gko::zero<ValueType>();
     }
 
     for (int r = 0; r < x.num_rows; r++) {
         for (int c = 0; c < x.num_rhs; c++) {
-            const uint32 conv = converged & (1 << c);
+            const gko::uint32 conv = converged & (1 << c);
 
             if (conv) {
                 continue;
@@ -387,12 +367,3 @@ inline void compute_dot_product(const BatchEntry<const ValueType> &x,
         }
     }
 }
-
-
-}  // namespace batch_dense
-}  // namespace reference
-}  // namespace kernels
-}  // namespace gko
-
-
-#endif  // GKO_REFERENCE_MATRIX_BATCH_DENSE_KERNELS_HPP_

--- a/reference/matrix/batch_dense_kernels.hpp.inc
+++ b/reference/matrix/batch_dense_kernels.hpp.inc
@@ -31,9 +31,10 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ******************************<GINKGO LICENSE>*******************************/
 
 template <typename ValueType>
-inline void spmv_kernel(const gko::batch_dense::BatchEntry<const ValueType>& a,
-                        const gko::batch_dense::BatchEntry<const ValueType>& b,
-                        const gko::batch_dense::BatchEntry<ValueType>& c)
+inline void matvec_kernel(
+    const gko::batch_dense::BatchEntry<const ValueType>& a,
+    const gko::batch_dense::BatchEntry<const ValueType>& b,
+    const gko::batch_dense::BatchEntry<ValueType>& c)
 {
     for (int row = 0; row < c.num_rows; ++row) {
         for (int col = 0; col < c.num_rhs; ++col) {
@@ -54,7 +55,7 @@ inline void spmv_kernel(const gko::batch_dense::BatchEntry<const ValueType>& a,
 
 
 template <typename ValueType>
-inline void advanced_spmv_kernel(
+inline void advanced_matvec_kernel(
     const ValueType alpha,
     const gko::batch_dense::BatchEntry<const ValueType>& a,
     const gko::batch_dense::BatchEntry<const ValueType>& b,

--- a/reference/matrix/batch_ell_kernels.cpp
+++ b/reference/matrix/batch_ell_kernels.cpp
@@ -77,7 +77,7 @@ void spmv(std::shared_ptr<const ReferenceExecutor>,
         const auto a_b = gko::batch::batch_entry(a_ub, batch);
         const auto b_b = gko::batch::batch_entry(b_ub, batch);
         const auto c_b = gko::batch::batch_entry(c_ub, batch);
-        spmv_kernel(a_b, b_b, c_b);
+        matvec_kernel(a_b, b_b, c_b);
     }
 }
 
@@ -104,8 +104,8 @@ void advanced_spmv(std::shared_ptr<const ReferenceExecutor>,
         const auto c_b = gko::batch::batch_entry(c_ub, batch);
         const auto alpha_b = gko::batch::batch_entry(alpha_ub, batch);
         const auto beta_b = gko::batch::batch_entry(beta_ub, batch);
-        advanced_spmv_kernel(alpha_b.values[0], a_b, b_b, beta_b.values[0],
-                             c_b);
+        advanced_matvec_kernel(alpha_b.values[0], a_b, b_b, beta_b.values[0],
+                               c_b);
     }
 }
 

--- a/reference/matrix/batch_ell_kernels.hpp.inc
+++ b/reference/matrix/batch_ell_kernels.hpp.inc
@@ -36,9 +36,10 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  * Assumes the input and output multi-vectors are stored row-major.
  */
 template <typename ValueType>
-inline void spmv_kernel(const gko::batch_ell::BatchEntry<const ValueType>& a,
-                        const gko::batch_dense::BatchEntry<const ValueType>& b,
-                        const gko::batch_dense::BatchEntry<ValueType>& c)
+inline void matvec_kernel(
+    const gko::batch_ell::BatchEntry<const ValueType>& a,
+    const gko::batch_dense::BatchEntry<const ValueType>& b,
+    const gko::batch_dense::BatchEntry<ValueType>& c)
 {
     for (int row = 0; row < a.num_rows; ++row) {
         for (int j = 0; j < b.num_rhs; ++j) {
@@ -62,7 +63,7 @@ inline void spmv_kernel(const gko::batch_ell::BatchEntry<const ValueType>& a,
  * Assumes the input and output multi-vectors are stored row-major.
  */
 template <typename ValueType>
-inline void advanced_spmv_kernel(
+inline void advanced_matvec_kernel(
     const ValueType alpha, const gko::batch_ell::BatchEntry<const ValueType>& a,
     const gko::batch_dense::BatchEntry<const ValueType>& b,
     const ValueType beta, const gko::batch_dense::BatchEntry<ValueType>& c)

--- a/reference/matrix/batch_struct.hpp
+++ b/reference/matrix/batch_struct.hpp
@@ -68,9 +68,13 @@ template <typename ValueType>
 inline gko::batch_dense::UniformBatch<const ValueType> get_batch_struct(
     const matrix::BatchDense<ValueType>* const op)
 {
-    return {op->get_const_values(), op->get_num_batch_entries(),
-            op->get_stride().at(0), static_cast<int>(op->get_size().at(0)[0]),
-            static_cast<int>(op->get_size().at(0)[1])};
+    return {
+        op->get_const_values(),
+        op->get_num_batch_entries(),
+        op->get_stride().at(0),
+        static_cast<int>(op->get_size().at(0)[0]),
+        static_cast<int>(op->get_size().at(0)[1]),
+        static_cast<int>(op->get_size().at(0)[0] * op->get_size().at(0)[1])};
 }
 
 
@@ -81,9 +85,13 @@ template <typename ValueType>
 inline gko::batch_dense::UniformBatch<ValueType> get_batch_struct(
     matrix::BatchDense<ValueType>* const op)
 {
-    return {op->get_values(), op->get_num_batch_entries(),
-            op->get_stride().at(0), static_cast<int>(op->get_size().at(0)[0]),
-            static_cast<int>(op->get_size().at(0)[1])};
+    return {
+        op->get_values(),
+        op->get_num_batch_entries(),
+        op->get_stride().at(0),
+        static_cast<int>(op->get_size().at(0)[0]),
+        static_cast<int>(op->get_size().at(0)[1]),
+        static_cast<int>(op->get_size().at(0)[0] * op->get_size().at(0)[1])};
 }
 
 

--- a/reference/preconditioner/batch_identity.hpp
+++ b/reference/preconditioner/batch_identity.hpp
@@ -71,16 +71,20 @@ public:
      * @param work  A 'work-vector', which is unneecessary here as no
      * preconditioner values are to be stored.
      */
-    inline void generate(const gko::batch_csr::BatchEntry<const ValueType>& mat,
-                         ValueType* const work)
+    void generate(const gko::batch_csr::BatchEntry<const ValueType>& mat,
+                  ValueType* const work)
     {}
 
-    inline void generate(const gko::batch_ell::BatchEntry<const ValueType>& mat,
-                         ValueType* const work)
+    void generate(const gko::batch_ell::BatchEntry<const ValueType>& mat,
+                  ValueType* const work)
     {}
 
-    inline void apply(const gko::batch_dense::BatchEntry<const ValueType>& r,
-                      const gko::batch_dense::BatchEntry<ValueType>& z) const
+    void generate(const gko::batch_dense::BatchEntry<const ValueType>& mat,
+                  ValueType* const work)
+    {}
+
+    void apply(const gko::batch_dense::BatchEntry<const ValueType>& r,
+               const gko::batch_dense::BatchEntry<ValueType>& z) const
     {
         for (int i = 0; i < r.num_rows; i++) {
             for (int j = 0; j < r.num_rhs; j++)

--- a/reference/preconditioner/batch_jacobi.hpp
+++ b/reference/preconditioner/batch_jacobi.hpp
@@ -74,9 +74,10 @@ public:
         work_ = work;
         for (int i = 0; i < mat.num_rows; i++) {
             for (int j = 0; j < mat.num_stored_elems_per_row; j++) {
-                if (mat.col_idxs[j] == i &&
-                    mat.values[j] != zero<ValueType>()) {
-                    work_[i] = one<ValueType>() / mat.values[j];
+                const auto idx = i + j * mat.stride;
+                if (mat.col_idxs[idx] == i &&
+                    mat.values[idx] != zero<ValueType>()) {
+                    work_[i] = one<ValueType>() / mat.values[idx];
                     break;
                 }
             }

--- a/reference/preconditioner/batch_jacobi.hpp
+++ b/reference/preconditioner/batch_jacobi.hpp
@@ -107,6 +107,24 @@ public:
         }
     }
 
+    /**
+     * Sets the input and generates the preconditioner by storing the inverse
+     * diagonal entries in the work vector.
+     *
+     * @param mat  Matrix for which to build a Jacobi preconditioner.
+     * @param work  A 'work-vector', used here to store the inverse diagonal
+     *              entries. It must be allocated with at least the amount
+     *              of memory given by work_size or dynamic_work_size.
+     */
+    void generate(const gko::batch_dense::BatchEntry<const ValueType>& mat,
+                  ValueType* const work)
+    {
+        work_ = work;
+        for (int i = 0; i < mat.num_rows; i++) {
+            work_[i] = one<ValueType>() / mat.values[i * mat.stride + i];
+        }
+    }
+
     void apply(const gko::batch_dense::BatchEntry<const ValueType>& r,
                const gko::batch_dense::BatchEntry<ValueType>& z) const
     {

--- a/reference/solver/batch_bicgstab_kernels.cpp
+++ b/reference/solver/batch_bicgstab_kernels.cpp
@@ -35,8 +35,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "core/solver/batch_dispatch.hpp"
 #include "reference/base/config.hpp"
-// include device kernels for every matrix and preconditioner type
-#include "reference/matrix/batch_dense_kernels.hpp"
 #include "reference/preconditioner/batch_identity.hpp"
 #include "reference/preconditioner/batch_jacobi.hpp"
 
@@ -60,6 +58,7 @@ namespace {
 constexpr int max_num_rhs = 1;
 
 #include "reference/matrix/batch_csr_kernels.hpp.inc"
+#include "reference/matrix/batch_dense_kernels.hpp.inc"
 #include "reference/matrix/batch_ell_kernels.hpp.inc"
 #include "reference/solver/batch_bicgstab_kernels.hpp.inc"
 

--- a/reference/solver/batch_bicgstab_kernels.hpp.inc
+++ b/reference/solver/batch_bicgstab_kernels.hpp.inc
@@ -54,20 +54,19 @@ inline void initialize(
     }
 
     // Compute norms of rhs
-    batch_dense::compute_norm2<ValueType>(b_entry, rhs_norms_entry);
+    compute_norm2<ValueType>(b_entry, rhs_norms_entry);
 
 
     // r = b
-    batch_dense::copy(b_entry, r_entry);
+    copy(b_entry, r_entry);
 
     // r = b - A*x
     advanced_spmv_kernel(static_cast<ValueType>(-1.0), A_entry,
                          gko::batch::to_const(x_entry),
                          static_cast<ValueType>(1.0), r_entry);
-    batch_dense::compute_norm2<ValueType>(gko::batch::to_const(r_entry),
-                                          res_norms_entry);
+    compute_norm2<ValueType>(gko::batch::to_const(r_entry), res_norms_entry);
 
-    batch_dense::copy(gko::batch::to_const(r_entry), r_hat_entry);
+    copy(gko::batch::to_const(r_entry), r_hat_entry);
 
     for (int r = 0; r < p_entry.num_rows; r++) {
         for (int c = 0; c < p_entry.num_rhs; c++) {
@@ -106,8 +105,7 @@ inline void compute_alpha(
     const gko::batch_dense::BatchEntry<const ValueType>& v_entry,
     const gko::batch_dense::BatchEntry<ValueType>& alpha_entry)
 {
-    batch_dense::compute_dot_product<ValueType>(r_hat_entry, v_entry,
-                                                alpha_entry);
+    compute_dot_product<ValueType>(r_hat_entry, v_entry, alpha_entry);
     alpha_entry.values[0] = rho_new_entry.values[0] / alpha_entry.values[0];
 }
 
@@ -134,8 +132,8 @@ inline void compute_omega(
     const gko::batch_dense::BatchEntry<ValueType>& temp_entry,
     const gko::batch_dense::BatchEntry<ValueType>& omega_entry)
 {
-    batch_dense::compute_dot_product<ValueType>(t_entry, s_entry, omega_entry);
-    batch_dense::compute_dot_product<ValueType>(t_entry, t_entry, temp_entry);
+    compute_dot_product<ValueType>(t_entry, s_entry, omega_entry);
+    compute_dot_product<ValueType>(t_entry, t_entry, temp_entry);
     omega_entry.values[0] /= temp_entry.values[0];
 }
 
@@ -293,9 +291,9 @@ inline void batch_entry_bicgstab_impl(
         }
 
         // rho_new =  < r_hat , r > = (r_hat)' * (r)
-        batch_dense::compute_dot_product<ValueType>(
-            gko::batch::to_const(r_hat_entry), gko::batch::to_const(r_entry),
-            rho_new_entry);
+        compute_dot_product<ValueType>(gko::batch::to_const(r_hat_entry),
+                                       gko::batch::to_const(r_entry),
+                                       rho_new_entry);
 
 
         // beta = (rho_new / rho_old)*(alpha / omega)
@@ -325,8 +323,8 @@ inline void batch_entry_bicgstab_impl(
                  gko::batch::to_const(alpha_entry),
                  gko::batch::to_const(v_entry), s_entry);
         // an estimate of residual norms
-        batch_dense::compute_norm2<ValueType>(gko::batch::to_const(s_entry),
-                                              res_norms_entry);
+        compute_norm2<ValueType>(gko::batch::to_const(s_entry),
+                                 res_norms_entry);
 
 
         if (stop.check_converged(res_norms_entry.values)) {
@@ -360,11 +358,11 @@ inline void batch_entry_bicgstab_impl(
                        gko::batch::to_const(s_entry),
                        gko::batch::to_const(t_entry), x_entry, r_entry);
 
-        batch_dense::compute_norm2<ValueType>(gko::batch::to_const(r_entry),
-                                              res_norms_entry);
+        compute_norm2<ValueType>(gko::batch::to_const(r_entry),
+                                 res_norms_entry);
 
         // rho_old = rho_new
-        batch_dense::copy(gko::batch::to_const(rho_new_entry), rho_old_entry);
+        copy(gko::batch::to_const(rho_new_entry), rho_old_entry);
     }
 
     logger.log_iteration(ibatch, iter, res_norms_entry.values[0]);

--- a/reference/solver/batch_bicgstab_kernels.hpp.inc
+++ b/reference/solver/batch_bicgstab_kernels.hpp.inc
@@ -61,9 +61,9 @@ inline void initialize(
     copy(b_entry, r_entry);
 
     // r = b - A*x
-    advanced_spmv_kernel(static_cast<ValueType>(-1.0), A_entry,
-                         gko::batch::to_const(x_entry),
-                         static_cast<ValueType>(1.0), r_entry);
+    advanced_matvec_kernel(static_cast<ValueType>(-1.0), A_entry,
+                           gko::batch::to_const(x_entry),
+                           static_cast<ValueType>(1.0), r_entry);
     compute_norm2<ValueType>(gko::batch::to_const(r_entry), res_norms_entry);
 
     copy(gko::batch::to_const(r_entry), r_hat_entry);
@@ -310,7 +310,7 @@ inline void batch_entry_bicgstab_impl(
         prec.apply(gko::batch::to_const(p_entry), p_hat_entry);
 
         // v = A * p_hat
-        spmv_kernel(A_entry, gko::batch::to_const(p_hat_entry), v_entry);
+        matvec_kernel(A_entry, gko::batch::to_const(p_hat_entry), v_entry);
 
         // alpha = rho_new / < r_hat , v>
         compute_alpha(gko::batch::to_const(rho_new_entry),
@@ -342,7 +342,7 @@ inline void batch_entry_bicgstab_impl(
         prec.apply(gko::batch::to_const(s_entry), s_hat_entry);
 
         // t = A * s_hat
-        spmv_kernel(A_entry, gko::batch::to_const(s_hat_entry), t_entry);
+        matvec_kernel(A_entry, gko::batch::to_const(s_hat_entry), t_entry);
 
         // omega = <t,s> / <t,t>
         compute_omega(gko::batch::to_const(t_entry),

--- a/reference/solver/batch_cg_kernels.cpp
+++ b/reference/solver/batch_cg_kernels.cpp
@@ -35,7 +35,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "core/solver/batch_dispatch.hpp"
 #include "reference/base/config.hpp"
-#include "reference/matrix/batch_dense_kernels.hpp"
 
 
 namespace gko {
@@ -52,6 +51,7 @@ namespace batch_cg {
 
 
 #include "reference/matrix/batch_csr_kernels.hpp.inc"
+#include "reference/matrix/batch_dense_kernels.hpp.inc"
 #include "reference/matrix/batch_ell_kernels.hpp.inc"
 #include "reference/solver/batch_cg_kernels.hpp.inc"
 

--- a/reference/solver/batch_cg_kernels.hpp.inc
+++ b/reference/solver/batch_cg_kernels.hpp.inc
@@ -51,9 +51,9 @@ inline void initialize(
     copy(b_entry, r_entry);
 
     // r = b - A*x
-    advanced_spmv_kernel(static_cast<ValueType>(-1.0), A_entry,
-                         gko::batch::to_const(x_entry),
-                         static_cast<ValueType>(1.0), r_entry);
+    advanced_matvec_kernel(static_cast<ValueType>(-1.0), A_entry,
+                           gko::batch::to_const(x_entry),
+                           static_cast<ValueType>(1.0), r_entry);
     // z = precond * r
     prec.apply(gko::batch::to_const(r_entry), z_entry);
 
@@ -189,7 +189,7 @@ inline void batch_entry_cg_impl(
         }
 
         // Ap = A * p
-        spmv_kernel(A_entry, gko::batch::to_const(p_entry), Ap_entry);
+        matvec_kernel(A_entry, gko::batch::to_const(p_entry), Ap_entry);
 
         // alpha = rho_old / (p' * Ap)
         // x = x + alpha * p

--- a/reference/solver/batch_cg_kernels.hpp.inc
+++ b/reference/solver/batch_cg_kernels.hpp.inc
@@ -44,11 +44,11 @@ inline void initialize(
         rhs_norms_entry)
 {
     // Compute norms of rhs
-    batch_dense::compute_norm2<ValueType>(b_entry, rhs_norms_entry);
+    compute_norm2<ValueType>(b_entry, rhs_norms_entry);
 
 
     // r = b
-    batch_dense::copy(b_entry, r_entry);
+    copy(b_entry, r_entry);
 
     // r = b - A*x
     advanced_spmv_kernel(static_cast<ValueType>(-1.0), A_entry,
@@ -59,12 +59,11 @@ inline void initialize(
 
 
     // p = z
-    batch_dense::copy(gko::batch::to_const(z_entry), p_entry);
+    copy(gko::batch::to_const(z_entry), p_entry);
 
     // rho_old = r' * z
-    batch_dense::compute_dot_product(gko::batch::to_const(r_entry),
-                                     gko::batch::to_const(z_entry),
-                                     rho_old_entry);
+    compute_dot_product(gko::batch::to_const(r_entry),
+                        gko::batch::to_const(z_entry), rho_old_entry);
 }
 
 
@@ -93,7 +92,7 @@ inline void update_x_and_r(
     const gko::batch_dense::BatchEntry<ValueType>& x_entry,
     const gko::batch_dense::BatchEntry<ValueType>& r_entry)
 {
-    batch_dense::compute_dot_product<ValueType>(p_entry, Ap_entry, alpha_entry);
+    compute_dot_product<ValueType>(p_entry, Ap_entry, alpha_entry);
 
     const ValueType alpha = rho_old_entry.values[0] / alpha_entry.values[0];
     for (int r = 0; r < r_entry.num_rows; r++) {
@@ -203,9 +202,9 @@ inline void batch_entry_cg_impl(
         prec.apply(gko::batch::to_const(r_entry), z_entry);
 
         // rho_new =  (r)' * (z)
-        batch_dense::compute_dot_product<ValueType>(
-            gko::batch::to_const(r_entry), gko::batch::to_const(z_entry),
-            rho_new_entry);
+        compute_dot_product<ValueType>(gko::batch::to_const(r_entry),
+                                       gko::batch::to_const(z_entry),
+                                       rho_new_entry);
 
         // beta = rho_new / rho_old
         // p = z + beta * p
@@ -214,7 +213,7 @@ inline void batch_entry_cg_impl(
                  gko::batch::to_const(z_entry), p_entry);
 
         // rho_old = rho_new
-        batch_dense::copy(gko::batch::to_const(rho_new_entry), rho_old_entry);
+        copy(gko::batch::to_const(rho_new_entry), rho_old_entry);
     }
 
     logger.log_iteration(ibatch, iter, res_norms_entry.values[0]);

--- a/reference/solver/batch_gmres_kernels.cpp
+++ b/reference/solver/batch_gmres_kernels.cpp
@@ -35,8 +35,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "core/solver/batch_dispatch.hpp"
 #include "reference/base/config.hpp"
-// include device kernels for every matrix and preconditioner type
-#include "reference/matrix/batch_dense_kernels.hpp"
 
 
 namespace gko {
@@ -54,6 +52,7 @@ namespace batch_gmres {
 namespace {
 
 #include "reference/matrix/batch_csr_kernels.hpp.inc"
+#include "reference/matrix/batch_dense_kernels.hpp.inc"
 #include "reference/matrix/batch_ell_kernels.hpp.inc"
 #include "reference/solver/batch_gmres_kernels.hpp.inc"
 

--- a/reference/solver/batch_gmres_kernels.hpp.inc
+++ b/reference/solver/batch_gmres_kernels.hpp.inc
@@ -48,18 +48,17 @@ inline void initialize(
         res_norms_entry)
 {
     // Compute norms of rhs
-    batch_dense::compute_norm2<ValueType>(b_entry, rhs_norms_entry);
+    compute_norm2<ValueType>(b_entry, rhs_norms_entry);
 
 
     // r = b
-    batch_dense::copy(b_entry, r_entry);
+    copy(b_entry, r_entry);
 
     // r = b - A*x
     advanced_spmv_kernel(static_cast<ValueType>(-1.0), A_entry,
                          gko::batch::to_const(x_entry),
                          static_cast<ValueType>(1.0), r_entry);
-    batch_dense::compute_norm2<ValueType>(gko::batch::to_const(r_entry),
-                                          res_norms_entry);
+    compute_norm2<ValueType>(gko::batch::to_const(r_entry), res_norms_entry);
 
 
     // z = precond * r
@@ -153,7 +152,7 @@ inline void update_v_naught_and_s(
     const gko::batch_dense::BatchEntry<real_type>& z_norms_entry =
         tmp_norms_entry;
 
-    batch_dense::compute_norm2(z_entry, z_norms_entry);
+    compute_norm2(z_entry, z_norms_entry);
 
     for (int r = 0; r < v_naught_entry.num_rows; r++) {
         v_naught_entry.values[r * v_naught_entry.stride] =
@@ -203,8 +202,8 @@ inline void arnoldi_method(
             &H_entry.values[k * H_entry.stride + i * num_rhs],
             static_cast<size_type>(w_entry.num_rhs), 1, w_entry.num_rhs};
 
-        batch_dense::compute_dot_product(gko::batch::to_const(w_entry),
-                                         v_k_entry, h_k_i_entry);
+        compute_dot_product(gko::batch::to_const(w_entry), v_k_entry,
+                            h_k_i_entry);
 
         for (int r = 0; r < w_entry.num_rows; r++) {
             ValueType h_k_i_scalar = h_k_i_entry.values[0];
@@ -217,7 +216,7 @@ inline void arnoldi_method(
     const gko::batch_dense::BatchEntry<real_type>& w_norms_entry =
         tmp_norms_entry;
 
-    batch_dense::compute_norm2(gko::batch::to_const(w_entry), w_norms_entry);
+    compute_norm2(gko::batch::to_const(w_entry), w_norms_entry);
 
     const gko::batch_dense::BatchEntry<ValueType> h_i_plus_1_i_entry{
         &H_entry.values[(i + 1) * H_entry.stride + i * num_rhs],
@@ -459,14 +458,14 @@ inline void batch_entry_gmres_impl(
                  x_entry, y_entry);
 
         // r = b
-        batch_dense::copy(b_entry, r_entry);
+        copy(b_entry, r_entry);
 
         // r = r - A*x
         advanced_spmv_kernel(static_cast<ValueType>(-1.0), A_entry,
                              gko::batch::to_const(x_entry),
                              static_cast<ValueType>(1.0), r_entry);
-        batch_dense::compute_norm2<ValueType>(gko::batch::to_const(r_entry),
-                                              res_norms_entry);
+        compute_norm2<ValueType>(gko::batch::to_const(r_entry),
+                                 res_norms_entry);
 
         // z = precond * r
         prec.apply(gko::batch::to_const(r_entry), z_entry);

--- a/reference/solver/batch_gmres_kernels.hpp.inc
+++ b/reference/solver/batch_gmres_kernels.hpp.inc
@@ -55,9 +55,9 @@ inline void initialize(
     copy(b_entry, r_entry);
 
     // r = b - A*x
-    advanced_spmv_kernel(static_cast<ValueType>(-1.0), A_entry,
-                         gko::batch::to_const(x_entry),
-                         static_cast<ValueType>(1.0), r_entry);
+    advanced_matvec_kernel(static_cast<ValueType>(-1.0), A_entry,
+                           gko::batch::to_const(x_entry),
+                           static_cast<ValueType>(1.0), r_entry);
     compute_norm2<ValueType>(gko::batch::to_const(r_entry), res_norms_entry);
 
 
@@ -189,7 +189,7 @@ inline void arnoldi_method(
         &V_entry.values[i * V_entry.stride * num_rows], V_entry.stride,
         num_rows, V_entry.num_rhs};
 
-    spmv_kernel(A_entry, v_i_entry, helper_entry);
+    matvec_kernel(A_entry, v_i_entry, helper_entry);
 
     prec.apply(gko::batch::to_const(helper_entry), w_entry);
 
@@ -461,9 +461,9 @@ inline void batch_entry_gmres_impl(
         copy(b_entry, r_entry);
 
         // r = r - A*x
-        advanced_spmv_kernel(static_cast<ValueType>(-1.0), A_entry,
-                             gko::batch::to_const(x_entry),
-                             static_cast<ValueType>(1.0), r_entry);
+        advanced_matvec_kernel(static_cast<ValueType>(-1.0), A_entry,
+                               gko::batch::to_const(x_entry),
+                               static_cast<ValueType>(1.0), r_entry);
         compute_norm2<ValueType>(gko::batch::to_const(r_entry),
                                  res_norms_entry);
 

--- a/reference/solver/batch_idr_kernels.cpp
+++ b/reference/solver/batch_idr_kernels.cpp
@@ -39,7 +39,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "core/solver/batch_dispatch.hpp"
 #include "reference/base/config.hpp"
-#include "reference/matrix/batch_dense_kernels.hpp"
 
 
 namespace gko {
@@ -58,6 +57,7 @@ namespace {
 constexpr int max_num_rhs = 1;
 
 #include "reference/matrix/batch_csr_kernels.hpp.inc"
+#include "reference/matrix/batch_dense_kernels.hpp.inc"
 #include "reference/matrix/batch_ell_kernels.hpp.inc"
 #include "reference/solver/batch_idr_kernels.hpp.inc"
 

--- a/reference/solver/batch_idr_kernels.hpp.inc
+++ b/reference/solver/batch_idr_kernels.hpp.inc
@@ -147,9 +147,9 @@ inline void initialize(
     // r = b
     copy(b_entry, r_entry);
     // r = b - A*x
-    advanced_spmv_kernel(static_cast<ValueType>(-1.0), A_entry,
-                         gko::batch::to_const(x_entry),
-                         static_cast<ValueType>(1.0), r_entry);
+    advanced_matvec_kernel(static_cast<ValueType>(-1.0), A_entry,
+                           gko::batch::to_const(x_entry),
+                           static_cast<ValueType>(1.0), r_entry);
     // compute residual norms
     compute_norm2<ValueType>(gko::batch::to_const(r_entry), res_norms_entry);
 
@@ -710,7 +710,7 @@ inline void batch_entry_idr_impl(
                 gko::batch::to_const(U_entry), k, helper_entry, u_k_entry);
 
             // g_k = A * u_k
-            spmv_kernel(A_entry, gko::batch::to_const(u_k_entry), g_k_entry);
+            matvec_kernel(A_entry, gko::batch::to_const(u_k_entry), g_k_entry);
 
             // for i = 0 to k-1
             //     alpha = (p_i * g_k)/M(i,i)
@@ -771,7 +771,7 @@ inline void batch_entry_idr_impl(
         prec.apply(gko::batch::to_const(r_entry), v_entry);
 
         // t = A *v
-        spmv_kernel(A_entry, gko::batch::to_const(v_entry), t_entry);
+        matvec_kernel(A_entry, gko::batch::to_const(v_entry), t_entry);
 
         // omega = ( t * r )/ (t * t)
         // rho = (t * r ) /(||t|| * || r||)

--- a/reference/solver/batch_idr_kernels.hpp.inc
+++ b/reference/solver/batch_idr_kernels.hpp.inc
@@ -65,7 +65,7 @@ inline void orthonormalize_subspace_vectors(
             temp_for_single_rhs_entry;
 
         // w_i = p_i
-        batch_dense::copy(gko::batch::to_const(p_i_entry), w_i_entry);
+        copy(gko::batch::to_const(p_i_entry), w_i_entry);
 
         for (int j = 0; j < i; j++) {
             // w_i = w_i - proj(p_i) on w_j that is w_i = w_i - (< w_j , p_i >
@@ -79,23 +79,22 @@ inline void orthonormalize_subspace_vectors(
             ValueType mul;
             const gko::batch_dense::BatchEntry<ValueType> mul_entry{&mul, 1, 1,
                                                                     1};
-            batch_dense::compute_dot_product(gko::batch::to_const(w_j_entry),
-                                             gko::batch::to_const(p_i_entry),
-                                             mul_entry);
+            compute_dot_product(gko::batch::to_const(w_j_entry),
+                                gko::batch::to_const(p_i_entry), mul_entry);
             mul_entry.values[0] /= static_cast<ValueType>(
                 tmp_norms_entry.values[j] * tmp_norms_entry.values[j]);
 
             mul_entry.values[0] *= -one<ValueType>();
-            batch_dense::add_scaled(gko::batch::to_const(mul_entry),
-                                    gko::batch::to_const(w_j_entry), w_i_entry);
+            add_scaled(gko::batch::to_const(mul_entry),
+                       gko::batch::to_const(w_j_entry), w_i_entry);
         }
 
         // p_i = w_i
-        batch_dense::copy(gko::batch::to_const(w_i_entry), p_i_entry);
+        copy(gko::batch::to_const(w_i_entry), p_i_entry);
 
-        batch_dense::compute_norm2(gko::batch::to_const(w_i_entry),
-                                   gko::batch_dense::BatchEntry<real_type>{
-                                       &tmp_norms_entry.values[i], 1, 1, 1});
+        compute_norm2(gko::batch::to_const(w_i_entry),
+                      gko::batch_dense::BatchEntry<real_type>{
+                          &tmp_norms_entry.values[i], 1, 1, 1});
     }
 
     // e_k = w_k / || w_k ||
@@ -109,10 +108,9 @@ inline void orthonormalize_subspace_vectors(
             one<ValueType>() /
             static_cast<ValueType>(tmp_norms_entry.values[k]);
 
-        batch_dense::scale(
-            gko::batch_dense::BatchEntry<const ValueType>{&scale_factor, 1, 1,
-                                                          1},
-            w_k_entry);
+        scale(gko::batch_dense::BatchEntry<const ValueType>{&scale_factor, 1, 1,
+                                                            1},
+              w_k_entry);
     }
 }
 
@@ -140,21 +138,20 @@ inline void initialize(
         tmp_norms_entry)
 {
     // Compute norms of rhs
-    batch_dense::compute_norm2<ValueType>(b_entry, rhs_norms_entry);
+    compute_norm2<ValueType>(b_entry, rhs_norms_entry);
 
     const auto subspace_dim = M_entry.num_rows;
     const auto num_rows = b_entry.num_rows;
     const auto num_rhs = b_entry.num_rhs;
 
     // r = b
-    batch_dense::copy(b_entry, r_entry);
+    copy(b_entry, r_entry);
     // r = b - A*x
     advanced_spmv_kernel(static_cast<ValueType>(-1.0), A_entry,
                          gko::batch::to_const(x_entry),
                          static_cast<ValueType>(1.0), r_entry);
     // compute residual norms
-    batch_dense::compute_norm2<ValueType>(gko::batch::to_const(r_entry),
-                                          res_norms_entry);
+    compute_norm2<ValueType>(gko::batch::to_const(r_entry), res_norms_entry);
 
     // omega = 1
     for (int c = 0; c < omega_entry.num_rhs; c++) {
@@ -162,8 +159,8 @@ inline void initialize(
     }
 
     if (smoothing == true) {
-        batch_dense::copy(x_entry, xs_entry);
-        batch_dense::copy(gko::batch::to_const(r_entry), rs_entry);
+        copy(x_entry, xs_entry);
+        copy(gko::batch::to_const(r_entry), rs_entry);
     }
 
     // initialize G,U with zeroes
@@ -269,7 +266,7 @@ inline void update_v(
     const gko::batch_dense::BatchEntry<const ValueType>& r_entry,
     const gko::batch_dense::BatchEntry<ValueType>& v_entry, const size_type k)
 {
-    batch_dense::copy(gko::batch::to_const(r_entry), v_entry);
+    copy(gko::batch::to_const(r_entry), v_entry);
 
     const auto subspace_dim = c_entry.num_rows;
     const auto nrows = r_entry.num_rows;
@@ -312,7 +309,7 @@ inline void update_u_k(
         }
     }
 
-    batch_dense::copy(gko::batch::to_const(helper_entry), u_k_entry);
+    copy(gko::batch::to_const(helper_entry), u_k_entry);
 }
 
 
@@ -419,11 +416,10 @@ inline void compute_omega(
     const gko::batch_dense::BatchEntry<ValueType>& omega_entry,
     const gko::remove_complex<ValueType> kappa)
 {
-    batch_dense::compute_dot_product(gko::batch::to_const(t_entry),
-                                     gko::batch::to_const(r_entry),
-                                     t_r_dot_entry);
-    batch_dense::compute_norm2(gko::batch::to_const(t_entry), norms_t_entry);
-    batch_dense::compute_norm2(gko::batch::to_const(r_entry), norms_r_entry);
+    compute_dot_product(gko::batch::to_const(t_entry),
+                        gko::batch::to_const(r_entry), t_r_dot_entry);
+    compute_norm2(gko::batch::to_const(t_entry), norms_t_entry);
+    compute_norm2(gko::batch::to_const(r_entry), norms_r_entry);
 
     // omega = ( t * r )/ (t * t)
     omega_entry.values[0] = t_r_dot_entry.values[0] /
@@ -483,10 +479,9 @@ inline void smoothing_operation(
     }
 
     // gamma = (t * rs)/(t * t)
-    batch_dense::compute_dot_product(gko::batch::to_const(t_entry),
-                                     gko::batch::to_const(rs_entry),
-                                     gamma_entry);
-    batch_dense::compute_norm2(gko::batch::to_const(t_entry), norms_t_entry);
+    compute_dot_product(gko::batch::to_const(t_entry),
+                        gko::batch::to_const(rs_entry), gamma_entry);
+    compute_norm2(gko::batch::to_const(t_entry), norms_t_entry);
 
     gamma_entry.values[0] /= static_cast<ValueType>(norms_t_entry.values[0] *
                                                     norms_t_entry.values[0]);
@@ -702,7 +697,7 @@ inline void batch_entry_idr_impl(
                      gko::batch::to_const(r_entry), v_entry, k);
 
             // helper = v
-            batch_dense::copy(gko::batch::to_const(v_entry), helper_entry);
+            copy(gko::batch::to_const(v_entry), helper_entry);
 
             // v = precond * helper
             prec.apply(gko::batch::to_const(helper_entry), v_entry);
@@ -802,18 +797,18 @@ inline void batch_entry_idr_impl(
             smoothing_operation(gko::batch::to_const(x_entry),
                                 gko::batch::to_const(r_entry), gamma_entry,
                                 t_entry, xs_entry, rs_entry, t_norms_entry);
-            batch_dense::compute_norm2<ValueType>(
-                gko::batch::to_const(rs_entry), res_norms_entry);
+            compute_norm2<ValueType>(gko::batch::to_const(rs_entry),
+                                     res_norms_entry);
         } else {
-            batch_dense::compute_norm2<ValueType>(gko::batch::to_const(r_entry),
-                                                  res_norms_entry);
+            compute_norm2<ValueType>(gko::batch::to_const(r_entry),
+                                     res_norms_entry);
         }
     }
 
     logger.log_iteration(ibatch, outer_iter, res_norms_entry.values[0]);
 
     if (smoothing == true) {
-        batch_dense::copy(gko::batch::to_const(xs_entry), x_entry);
-        batch_dense::copy(gko::batch::to_const(rs_entry), r_entry);
+        copy(gko::batch::to_const(xs_entry), x_entry);
+        copy(gko::batch::to_const(rs_entry), r_entry);
     }
 }

--- a/reference/solver/batch_richardson_kernels.cpp
+++ b/reference/solver/batch_richardson_kernels.cpp
@@ -36,7 +36,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "core/matrix/batch_struct.hpp"
 #include "core/solver/batch_dispatch.hpp"
 #include "reference/base/config.hpp"
-#include "reference/matrix/batch_dense_kernels.hpp"
 
 
 namespace gko {
@@ -58,6 +57,7 @@ namespace {
 constexpr int max_num_rhs = 1;
 
 #include "reference/matrix/batch_csr_kernels.hpp.inc"
+#include "reference/matrix/batch_dense_kernels.hpp.inc"
 #include "reference/matrix/batch_ell_kernels.hpp.inc"
 #include "reference/solver/batch_richardson_kernels.hpp.inc"
 

--- a/reference/solver/batch_richardson_kernels.hpp.inc
+++ b/reference/solver/batch_richardson_kernels.hpp.inc
@@ -86,9 +86,9 @@ inline void batch_entry_richardson_impl(
 
         // r <- b - Ax
         copy(b_b, r_b);
-        advanced_spmv_kernel(static_cast<ValueType>(-1.0), a_b,
-                             gko::batch::to_const(x_b),
-                             static_cast<ValueType>(1.0), r_b);
+        advanced_matvec_kernel(static_cast<ValueType>(-1.0), a_b,
+                               gko::batch::to_const(x_b),
+                               static_cast<ValueType>(1.0), r_b);
 
         compute_norm2(gko::batch::to_const(r_b), norms_b);
 

--- a/reference/solver/batch_richardson_kernels.hpp.inc
+++ b/reference/solver/batch_richardson_kernels.hpp.inc
@@ -72,8 +72,8 @@ inline void batch_entry_richardson_impl(
     prec.generate(a_b, prec_work);
 
     // initial residual
-    batch_dense::compute_norm2<ValueType>(gko::batch::to_const(b_b), norms_b);
-    batch_dense::copy(gko::batch::to_const(norms_b), init_res_norm_b);
+    compute_norm2<ValueType>(gko::batch::to_const(b_b), norms_b);
+    copy(gko::batch::to_const(norms_b), init_res_norm_b);
 
     StopType stop(opts.residual_tol, init_res_norm_b.values);
 
@@ -85,12 +85,12 @@ inline void batch_entry_richardson_impl(
         // static_cast<ValueType>(1.0), r_b);
 
         // r <- b - Ax
-        batch_dense::copy(b_b, r_b);
+        copy(b_b, r_b);
         advanced_spmv_kernel(static_cast<ValueType>(-1.0), a_b,
                              gko::batch::to_const(x_b),
                              static_cast<ValueType>(1.0), r_b);
 
-        batch_dense::compute_norm2(gko::batch::to_const(r_b), norms_b);
+        compute_norm2(gko::batch::to_const(r_b), norms_b);
 
         if (stop.check_converged(norms)) {
             break;
@@ -98,7 +98,7 @@ inline void batch_entry_richardson_impl(
 
         prec.apply(gko::batch::to_const(r_b), dx_b);
 
-        batch_dense::add_scaled(relax_b, gko::batch::to_const(dx_b), x_b);
+        add_scaled(relax_b, gko::batch::to_const(dx_b), x_b);
     }
 
     logger.log_iteration(ibatch, iter, norms[0]);

--- a/reference/stop/batch_criteria.hpp
+++ b/reference/stop/batch_criteria.hpp
@@ -39,8 +39,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
 #include "reference/base/config.hpp"
-#include "reference/matrix/batch_dense_kernels.hpp"
-#include "reference/matrix/batch_struct.hpp"
 
 
 namespace gko {

--- a/reference/test/matrix/batch_csr_kernels.cpp
+++ b/reference/test/matrix/batch_csr_kernels.cpp
@@ -77,11 +77,11 @@ protected:
         this->create_mtx3(mtx3_sorted.get(), mtx3_unsorted.get());
     }
 
-    void create_mtx(Mtx *m)
+    void create_mtx(Mtx* m)
     {
-        value_type *v = m->get_values();
-        index_type *c = m->get_col_idxs();
-        index_type *r = m->get_row_ptrs();
+        value_type* v = m->get_values();
+        index_type* c = m->get_col_idxs();
+        index_type* r = m->get_row_ptrs();
         /*
          * 1   3   2
          * 0   5   0
@@ -106,11 +106,11 @@ protected:
         v[7] = 8.0;
     }
 
-    void create_mtx2(Mtx *m)
+    void create_mtx2(Mtx* m)
     {
-        value_type *v = m->get_values();
-        index_type *c = m->get_col_idxs();
-        index_type *r = m->get_row_ptrs();
+        value_type* v = m->get_values();
+        index_type* c = m->get_col_idxs();
+        index_type* r = m->get_row_ptrs();
         // It keeps an explict zero
         /*
          *  1    3   2
@@ -139,7 +139,7 @@ protected:
         v[9] = -9.0;
     }
 
-    void create_mtx3(Mtx *sorted, Mtx *unsorted)
+    void create_mtx3(Mtx* sorted, Mtx* unsorted)
     {
         auto vals_s = sorted->get_values();
         auto cols_s = sorted->get_col_idxs();
@@ -449,15 +449,15 @@ TYPED_TEST(BatchCsr, CanBeBatchScaled)
     const size_t nbatch = 2;
     const int nrows = 3;
     const int nrhs_1 = 1;
-    auto mtx = gko::test::create_poisson1d_batch<value_type, index_type>(
-        this->exec, nrows, nbatch);
+    auto mtx =
+        gko::test::create_poisson1d_batch<Mtx>(this->exec, nrows, nbatch);
     auto left =
         gko::batch_initialize<Vec>(nbatch, {-1.0, 3.0, 1.0}, this->exec);
     auto right =
         gko::batch_initialize<Vec>(nbatch, {1.0, 2.0, -1.0}, this->exec);
     auto ref_scaled_mtx = Mtx::create(this->exec);
     ref_scaled_mtx->copy_from(mtx.get());
-    value_type *const refvals = ref_scaled_mtx->get_values();
+    value_type* const refvals = ref_scaled_mtx->get_values();
     // clang-format off
     refvals[0] = -2; refvals[1] = 2;
     refvals[2] = -3; refvals[3] = 12; refvals[4] = 3;
@@ -484,8 +484,8 @@ TYPED_TEST(BatchCsr, CanPreScaleSystem)
     const int nrows = 3;
     const int nrhs = 2;
     const int nnz = 7;
-    auto mtx = gko::test::create_poisson1d_batch<value_type, index_type>(
-        this->exec, nrows, nbatch);
+    auto mtx =
+        gko::test::create_poisson1d_batch<Mtx>(this->exec, nrows, nbatch);
     mtx->get_col_idxs()[5] = 0;  // make unsymmetric
     mtx->get_values()[4] = -0.5;
     mtx->get_values()[nnz + 2] = -0.25;
@@ -498,7 +498,7 @@ TYPED_TEST(BatchCsr, CanPreScaleSystem)
     right->at(1, 2, 0) = 3.0;
     auto ref_scaled_mtx = Mtx::create(this->exec);
     ref_scaled_mtx->copy_from(mtx.get());
-    value_type *const refvals = ref_scaled_mtx->get_values();
+    value_type* const refvals = ref_scaled_mtx->get_values();
     // clang-format off
     refvals[0] = -2; refvals[1] = 2;
     refvals[2] = -3; refvals[3] = 12; refvals[4] = 1.5;
@@ -542,8 +542,8 @@ TYPED_TEST(BatchCsr, ConvertibleToBatchDense)
     const size_t nbatch = 2;
     const int nrows = 3;
     const int nnz = 7;
-    auto mtx = gko::test::create_poisson1d_batch<value_type, index_type>(
-        this->exec, nrows, nbatch);
+    std::shared_ptr<Mtx> mtx =
+        gko::test::create_poisson1d_batch<Mtx>(this->exec, nrows, nbatch);
     auto ans = Dense::create(
         this->exec, gko::batch_dim<>(nbatch, gko::dim<2>(nrows, nrows)));
     for (size_t ib = 0; ib < nbatch; ib++) {

--- a/reference/test/matrix/batch_dense_kernels.cpp
+++ b/reference/test/matrix/batch_dense_kernels.cpp
@@ -133,16 +133,6 @@ protected:
     std::unique_ptr<Mtx> mtx_6;
 
     std::ranlux48 rand_engine;
-
-    // template <typename MtxType>
-    // std::unique_ptr<MtxType> gen_mtx(int num_rows, int num_cols)
-    //{
-    //    return gko::test::generate_random_matrix<MtxType>(
-    //        num_rows, num_cols,
-    //        std::uniform_int_distribution<gko::size_type>(num_cols, num_cols),
-    //        std::normal_distribution<gko::remove_complex<value_type>>(0.0, 1.0),
-    //        rand_engine, exec);
-    //}
 };
 
 
@@ -958,7 +948,7 @@ TYPED_TEST(BatchDense, SquareMatrixIsTransposable)
 {
     using Mtx = typename TestFixture::Mtx;
     auto trans = this->mtx_4->transpose();
-    auto trans_as_batch_dense = static_cast<Mtx *>(trans.get());
+    auto trans_as_batch_dense = static_cast<Mtx*>(trans.get());
 
     auto utb = trans_as_batch_dense->unbatch();
     GKO_ASSERT_MTX_NEAR(utb[0].get(),
@@ -974,7 +964,7 @@ TYPED_TEST(BatchDense, NonSquareMatrixIsTransposable)
 {
     using Mtx = typename TestFixture::Mtx;
     auto trans = this->mtx_5->transpose();
-    auto trans_as_batch_dense = static_cast<Mtx *>(trans.get());
+    auto trans_as_batch_dense = static_cast<Mtx*>(trans.get());
 
     auto utb = trans_as_batch_dense->unbatch();
     GKO_ASSERT_MTX_NEAR(utb[0].get(), l({{1.0, 6.0, 7.0}, {1.5, 1.0, -4.5}}),

--- a/reference/test/solver/batch_bicgstab_kernels.cpp
+++ b/reference/test/solver/batch_bicgstab_kernels.cpp
@@ -224,11 +224,12 @@ TEST(BatchBicgstab, GoodScalingImprovesConvergence)
 }
 
 
-TEST(BatchBicgstab, CoreCanSolveWithoutScaling)
+TEST(BatchBicgstab, CoreCanSolveCsrWithoutScaling)
 {
     using T = std::complex<float>;
     using RT = typename gko::remove_complex<T>;
     using Solver = gko::solver::BatchBicgstab<T>;
+    using Mtx = gko::matrix::BatchCsr<T, int>;
     const RT tol = 1e-5;
     const int maxits = 1000;
     std::shared_ptr<gko::ReferenceExecutor> exec =
@@ -244,15 +245,68 @@ TEST(BatchBicgstab, CoreCanSolveWithoutScaling)
     const size_t nbatch = 3;
     const int nrhs = 1;
 
-    gko::test::test_solve<Solver>(exec, nbatch, nrows, nrhs, tol, maxits,
-                                  batchbicgstab_factory.get(), 10);
+    gko::test::test_solve<Solver, Mtx>(exec, nbatch, nrows, nrhs, tol, maxits,
+                                       batchbicgstab_factory.get(), 10);
 }
 
 
-TEST(BatchBicgstab, CoreCanSolveWithScaling)
+TEST(BatchBicgstab, CoreCanSolveEllWithoutScaling)
+{
+    using T = std::complex<float>;
+    using RT = typename gko::remove_complex<T>;
+    using Solver = gko::solver::BatchBicgstab<T>;
+    using Mtx = gko::matrix::BatchEll<T, int>;
+    const RT tol = 1e-5;
+    const int maxits = 1000;
+    std::shared_ptr<gko::ReferenceExecutor> exec =
+        gko::ReferenceExecutor::create();
+    auto batchbicgstab_factory =
+        Solver::build()
+            .with_max_iterations(maxits)
+            .with_residual_tol(tol)
+            .with_tolerance_type(gko::stop::batch::ToleranceType::relative)
+            .with_preconditioner(gko::preconditioner::batch::type::jacobi)
+            .on(exec);
+    const int nrows = 39;
+    const size_t nbatch = 3;
+    const int nrhs = 1;
+
+    gko::test::test_solve<Solver, Mtx>(exec, nbatch, nrows, nrhs, tol, maxits,
+                                       batchbicgstab_factory.get(), 10);
+}
+
+
+TEST(BatchBicgstab, CoreCanSolveDenseWithoutScaling)
+{
+    using T = std::complex<float>;
+    using RT = typename gko::remove_complex<T>;
+    using Solver = gko::solver::BatchBicgstab<T>;
+    using Mtx = gko::matrix::BatchDense<T>;
+    const RT tol = 1e-5;
+    const int maxits = 1000;
+    std::shared_ptr<gko::ReferenceExecutor> exec =
+        gko::ReferenceExecutor::create();
+    auto batchbicgstab_factory =
+        Solver::build()
+            .with_max_iterations(maxits)
+            .with_residual_tol(tol)
+            .with_tolerance_type(gko::stop::batch::ToleranceType::relative)
+            .with_preconditioner(gko::preconditioner::batch::type::jacobi)
+            .on(exec);
+    const int nrows = 13;
+    const size_t nbatch = 3;
+    const int nrhs = 1;
+
+    gko::test::test_solve<Solver, Mtx>(exec, nbatch, nrows, nrhs, tol, maxits,
+                                       batchbicgstab_factory.get(), 10);
+}
+
+
+TEST(BatchBicgstab, CoreCanSolveCsrWithScaling)
 {
     using T = double;
     using RT = typename gko::remove_complex<T>;
+    using Mtx = gko::matrix::BatchCsr<T, int>;
     using Solver = gko::solver::BatchBicgstab<T>;
     const RT tol = 1e-10;
     const int maxits = 1000;
@@ -269,8 +323,8 @@ TEST(BatchBicgstab, CoreCanSolveWithScaling)
     const size_t nbatch = 3;
     const int nrhs = 1;
 
-    gko::test::test_solve<Solver>(exec, nbatch, nrows, nrhs, tol, maxits,
-                                  batchbicgstab_factory.get(), 10, true);
+    gko::test::test_solve<Solver, Mtx>(exec, nbatch, nrows, nrhs, tol, maxits,
+                                       batchbicgstab_factory.get(), 10, true);
 }
 
 

--- a/reference/test/solver/batch_cg_kernels.cpp
+++ b/reference/test/solver/batch_cg_kernels.cpp
@@ -225,7 +225,7 @@ TEST(BatchCg, CanSolveWithoutScaling)
     using Solver = gko::solver::BatchCg<T>;
     using Dense = gko::matrix::BatchDense<T>;
     using RDense = gko::matrix::BatchDense<RT>;
-    using Mtx = typename gko::matrix::BatchCsr<T>;
+    using Mtx = gko::matrix::BatchCsr<T>;
     const RT tol = 1e-9;
     const int maxits = 1000;
     std::shared_ptr<gko::ReferenceExecutor> exec =
@@ -240,8 +240,8 @@ TEST(BatchCg, CanSolveWithoutScaling)
     const int nrows = 41;
     const size_t nbatch = 3;
     const int nrhs = 1;
-    gko::test::test_solve<Solver>(exec, nbatch, nrows, nrhs, tol, maxits,
-                                  batchcg_factory.get(), 1.01);
+    gko::test::test_solve<Solver, Mtx>(exec, nbatch, nrows, nrhs, tol, maxits,
+                                       batchcg_factory.get(), 1.01);
 }
 
 

--- a/reference/test/solver/batch_idr_kernels.cpp
+++ b/reference/test/solver/batch_idr_kernels.cpp
@@ -212,6 +212,7 @@ TEST(BatchIdr, CanSolveWithoutScaling)
     using T = std::complex<double>;
     using RT = typename gko::remove_complex<T>;
     using Solver = gko::solver::BatchIdr<T>;
+    using Mtx = gko::matrix::BatchCsr<T, int>;
     const RT tol = 1e-9;
     const int maxits = 1000;
     std::shared_ptr<gko::ReferenceExecutor> exec =
@@ -230,8 +231,8 @@ TEST(BatchIdr, CanSolveWithoutScaling)
     const int nrows = 40;
     const size_t nbatch = 3;
     const int nrhs = 1;
-    gko::test::test_solve<Solver>(exec, nbatch, nrows, nrhs, tol, maxits,
-                                  batchidr_factory.get(), 1.001);
+    gko::test::test_solve<Solver, Mtx>(exec, nbatch, nrows, nrhs, tol, maxits,
+                                       batchidr_factory.get(), 1.001);
 }
 
 

--- a/reference/test/solver/batch_richardson_kernels.cpp
+++ b/reference/test/solver/batch_richardson_kernels.cpp
@@ -251,6 +251,7 @@ TEST(BatchRich, CoreCanSolveWithoutScaling)
     using T = std::complex<float>;
     using RT = typename gko::remove_complex<T>;
     using Solver = gko::solver::BatchRichardson<T>;
+    using Mtx = gko::matrix::BatchCsr<T, int>;
     const RT tol = 200 * std::numeric_limits<RT>::epsilon();
     std::shared_ptr<gko::ReferenceExecutor> exec =
         gko::ReferenceExecutor::create();
@@ -265,8 +266,8 @@ TEST(BatchRich, CoreCanSolveWithoutScaling)
     const int nrows = 42;
     const size_t nbatch = 3;
     const int nrhs = 1;
-    gko::test::test_solve<Solver>(exec, nbatch, nrows, nrhs, tol, maxits,
-                                  batchrich_factory.get());
+    gko::test::test_solve<Solver, Mtx>(exec, nbatch, nrows, nrhs, tol, maxits,
+                                       batchrich_factory.get());
 }
 
 
@@ -274,6 +275,7 @@ TEST(BatchRich, CoreCanSolveWithScaling)
 {
     using T = double;
     using RT = typename gko::remove_complex<T>;
+    using Mtx = gko::matrix::BatchCsr<T, int>;
     using Solver = gko::solver::BatchRichardson<T>;
     const RT tol = 10000 * std::numeric_limits<RT>::epsilon();
     const int maxits = 10000;
@@ -290,8 +292,9 @@ TEST(BatchRich, CoreCanSolveWithScaling)
     const size_t nbatch = 3;
     const int nrhs = 1;
 
-    gko::test::test_solve<Solver>(exec, nbatch, nrows, nrhs, 20 * tol, maxits,
-                                  batchrich_factory.get(), 10, true);
+    gko::test::test_solve<Solver, Mtx>(exec, nbatch, nrows, nrhs, 20 * tol,
+                                       maxits, batchrich_factory.get(), 10,
+                                       true);
 }
 
 

--- a/reference/test/solver/batch_richardson_kernels.cpp
+++ b/reference/test/solver/batch_richardson_kernels.cpp
@@ -69,8 +69,7 @@ protected:
         sys_1.xex =
             gko::batch_initialize<BDense>(nbatch, {1.0, 3.0, 2.0}, exec);
         sys_1.b = gko::batch_initialize<BDense>(nbatch, {-1.0, 3.0, 1.0}, exec);
-        sys_1.mtx =
-            gko::test::create_poisson1d_batch<value_type>(exec, nrows, nbatch);
+        sys_1.mtx = gko::test::create_poisson1d_batch<Mtx>(exec, nrows, nbatch);
         sys_1.bnorm = gko::batch_initialize<RBDense>(nbatch, {0.0}, exec);
         sys_1.b->compute_norm2(sys_1.bnorm.get());
 


### PR DESCRIPTION
- Adds missing batch dense kernels.
- Enables testing of solvers with different batch matrix types.
- Enables benchmarking of solvers with batch dense as well.