### PR TITLE
Batch solver abstraction for common core code

### DIFF
--- a/benchmark/solver/batch_solver.hpp
+++ b/benchmark/solver/batch_solver.hpp
@@ -305,7 +305,6 @@ std::unique_ptr<gko::BatchLinOpFactory> generate_solver(
     } else if (description == "bicgstab") {
         using Solver = gko::solver::BatchBicgstab<etype>;
         return Solver::build()
-            .with_num_shared_vectors(static_cast<int>(FLAGS_num_shared_vecs))
             .with_max_iterations(static_cast<int>(FLAGS_max_iters))
             .with_residual_tol(
                 static_cast<gko::remove_complex<etype>>(FLAGS_rel_res_goal))

--- a/core/log/batch_logging.hpp
+++ b/core/log/batch_logging.hpp
@@ -52,22 +52,27 @@ enum class BatchLogType {
 };
 
 
-/**
- * Stores logging data for batch solver kernels.
- */
-template <typename ValueType>
-struct BatchLogData {
-    /**
-     * Stores residual norm values for every linear system in the batch
-     * for every right-hand side.
-     */
-    std::shared_ptr<matrix::BatchDense<remove_complex<ValueType>>> res_norms;
-
+struct BatchLogDataBase {
     /**
      * Stores convergence iteration counts for every matrix in the batch and
      * for every right-hand side.
      */
     Array<int> iter_counts;
+
+    virtual ~BatchLogDataBase() = default;
+};
+
+
+/**
+ * Stores logging data for batch solver kernels.
+ */
+template <typename ValueType>
+struct BatchLogData : public BatchLogDataBase {
+    /**
+     * Stores residual norm values for every linear system in the batch
+     * for every right-hand side.
+     */
+    std::shared_ptr<matrix::BatchDense<remove_complex<ValueType>>> res_norms;
 };
 
 

--- a/core/matrix/batch_csr.cpp
+++ b/core/matrix/batch_csr.cpp
@@ -210,50 +210,20 @@ void BatchCsr<ValueType, IndexType>::write(std::vector<mat_data>& data) const
 template <typename ValueType, typename IndexType>
 std::unique_ptr<BatchLinOp> BatchCsr<ValueType, IndexType>::transpose() const
     GKO_NOT_IMPLEMENTED;
-//{
-//    auto exec = this->get_executor();
-//    auto trans_cpy =
-//        BatchCsr::create(exec, gko::transpose(this->get_size()),
-//                    this->get_num_stored_elements(), this->get_strategy());
-//
-//    exec->run(batch_csr::make_transpose(this, trans_cpy.get()));
-//    trans_cpy->make_srow();
-//    return std::move(trans_cpy);
-//}
 
 
 template <typename ValueType, typename IndexType>
 std::unique_ptr<BatchLinOp> BatchCsr<ValueType, IndexType>::conj_transpose()
     const GKO_NOT_IMPLEMENTED;
-//{
-//    auto exec = this->get_executor();
-//    auto trans_cpy =
-//        BatchCsr::create(exec, gko::transpose(this->get_size()),
-//                    this->get_num_stored_elements(), this->get_strategy());
-//
-//    exec->run(batch_csr::make_conj_transpose(this, trans_cpy.get()));
-//    trans_cpy->make_srow();
-//    return std::move(trans_cpy);
-//}
 
 
 template <typename ValueType, typename IndexType>
 void BatchCsr<ValueType, IndexType>::sort_by_column_index() GKO_NOT_IMPLEMENTED;
-//{
-//    auto exec = this->get_executor();
-//    exec->run(batch_csr::make_sort_by_column_index(this));
-//}
 
 
 template <typename ValueType, typename IndexType>
 bool BatchCsr<ValueType, IndexType>::is_sorted_by_column_index() const
     GKO_NOT_IMPLEMENTED;
-//{
-//    auto exec = this->get_executor();
-//    bool is_sorted;
-//    exec->run(batch_csr::make_is_sorted_by_column_index(this, &is_sorted));
-//    return is_sorted;
-//}
 
 
 template <typename ValueType, typename IndexType>
@@ -262,9 +232,8 @@ void BatchCsr<ValueType, IndexType>::batch_scale_impl(
     const BatchLinOp* const right_scale_op)
 {
     auto exec = this->get_executor();
-    const auto left = static_cast<const BatchDense<ValueType>*>(left_scale_op);
-    const auto right =
-        static_cast<const BatchDense<ValueType>*>(right_scale_op);
+    const auto left = as<const BatchDense<ValueType>>(left_scale_op);
+    const auto right = as<const BatchDense<ValueType>>(right_scale_op);
     exec->run(batch_csr::make_batch_scale(left, right, this));
 }
 

--- a/core/matrix/batch_ell.cpp
+++ b/core/matrix/batch_ell.cpp
@@ -279,9 +279,8 @@ void BatchEll<ValueType, IndexType>::batch_scale_impl(
     const BatchLinOp* const right_scale_op)
 {
     auto exec = this->get_executor();
-    const auto left = static_cast<const BatchDense<ValueType>*>(left_scale_op);
-    const auto right =
-        static_cast<const BatchDense<ValueType>*>(right_scale_op);
+    const auto left = as<const BatchDense<ValueType>>(left_scale_op);
+    const auto right = as<const BatchDense<ValueType>>(right_scale_op);
     exec->run(batch_ell::make_batch_scale(left, right, this));
 }
 

--- a/core/solver/batch_bicgstab.cpp
+++ b/core/solver/batch_bicgstab.cpp
@@ -85,7 +85,7 @@ template <typename ValueType>
 void BatchBicgstab<ValueType>::solver_apply(const BatchLinOp* const mtx,
                                             const BatchLinOp* const b,
                                             BatchLinOp* const x,
-                                            BatchInfo& info) const
+                                            BatchInfo* const info) const
 {
     using Dense = matrix::BatchDense<ValueType>;
     const kernels::batch_bicgstab::BatchBicgstabOptions<
@@ -95,7 +95,7 @@ void BatchBicgstab<ValueType>::solver_apply(const BatchLinOp* const mtx,
     auto exec = this->get_executor();
     exec->run(batch_bicgstab::make_apply(
         opts, mtx, as<const Dense>(b), as<Dense>(x),
-        *as<log::BatchLogData<ValueType>>(info.logdata.get())));
+        *as<log::BatchLogData<ValueType>>(info->logdata.get())));
 }
 
 

--- a/core/solver/batch_bicgstab.cpp
+++ b/core/solver/batch_bicgstab.cpp
@@ -117,5 +117,11 @@ void BatchBicgstab<ValueType>::apply_impl(const BatchLinOp* alpha,
 GKO_INSTANTIATE_FOR_EACH_VALUE_TYPE(GKO_DECLARE_BATCH_BICGSTAB);
 
 
+#define GKO_DECLARE_BATCH_BICGSTAB_APPLY_FUNCTION(_type)                  \
+    void EnableBatchSolver<BatchBicgstab<_type>, BatchLinOp>::apply_impl( \
+        const BatchLinOp* b, BatchLinOp* x) const
+GKO_INSTANTIATE_FOR_EACH_VALUE_TYPE(GKO_DECLARE_BATCH_BICGSTAB_APPLY_FUNCTION);
+
+
 }  // namespace solver
 }  // namespace gko

--- a/core/solver/batch_bicgstab.cpp
+++ b/core/solver/batch_bicgstab.cpp
@@ -82,16 +82,19 @@ std::unique_ptr<BatchLinOp> BatchBicgstab<ValueType>::conj_transpose() const
 
 
 template <typename ValueType>
-void BatchBicgstab<ValueType>::solver_apply(
-    const BatchLinOp* const mtx, const matrix::BatchDense<ValueType>* b,
-    matrix::BatchDense<ValueType>* x, BatchInfo<ValueType>& info) const
+void BatchBicgstab<ValueType>::solver_apply(const BatchLinOp* const mtx,
+                                            const BatchLinOp* b, BatchLinOp* x,
+                                            BatchInfo& info) const
 {
+    using Dense = matrix::BatchDense<ValueType>;
     const kernels::batch_bicgstab::BatchBicgstabOptions<
         remove_complex<ValueType>>
         opts{parameters_.preconditioner, parameters_.max_iterations,
              parameters_.residual_tol, parameters_.tolerance_type};
     auto exec = this->get_executor();
-    exec->run(batch_bicgstab::make_apply(opts, mtx, b, x, info.logdata));
+    exec->run(batch_bicgstab::make_apply(
+        opts, mtx, as<const Dense>(b), as<Dense>(x),
+        *static_cast<log::BatchLogData<ValueType>*>(info.logdata)));
 }
 
 

--- a/core/solver/batch_bicgstab.cpp
+++ b/core/solver/batch_bicgstab.cpp
@@ -83,7 +83,8 @@ std::unique_ptr<BatchLinOp> BatchBicgstab<ValueType>::conj_transpose() const
 
 template <typename ValueType>
 void BatchBicgstab<ValueType>::solver_apply(const BatchLinOp* const mtx,
-                                            const BatchLinOp* b, BatchLinOp* x,
+                                            const BatchLinOp* const b,
+                                            BatchLinOp* const x,
                                             BatchInfo& info) const
 {
     using Dense = matrix::BatchDense<ValueType>;
@@ -94,7 +95,7 @@ void BatchBicgstab<ValueType>::solver_apply(const BatchLinOp* const mtx,
     auto exec = this->get_executor();
     exec->run(batch_bicgstab::make_apply(
         opts, mtx, as<const Dense>(b), as<Dense>(x),
-        *static_cast<log::BatchLogData<ValueType>*>(info.logdata)));
+        *as<log::BatchLogData<ValueType>>(info.logdata.get())));
 }
 
 

--- a/core/solver/batch_bicgstab.cpp
+++ b/core/solver/batch_bicgstab.cpp
@@ -98,29 +98,18 @@ void BatchBicgstab<ValueType>::solver_apply(const BatchLinOp* const mtx,
 }
 
 
-template <typename ValueType>
-void BatchBicgstab<ValueType>::apply_impl(const BatchLinOp* alpha,
-                                          const BatchLinOp* b,
-                                          const BatchLinOp* beta,
-                                          BatchLinOp* x) const
-{
-    auto dense_x = as<matrix::BatchDense<ValueType>>(x);
-
-    auto x_clone = dense_x->clone();
-    this->apply(b, x_clone.get());
-    dense_x->scale(beta);
-    dense_x->add_scaled(alpha, x_clone.get());
-}
-
-
 #define GKO_DECLARE_BATCH_BICGSTAB(_type) class BatchBicgstab<_type>
 GKO_INSTANTIATE_FOR_EACH_VALUE_TYPE(GKO_DECLARE_BATCH_BICGSTAB);
 
 
-#define GKO_DECLARE_BATCH_BICGSTAB_APPLY_FUNCTION(_type)                  \
-    void EnableBatchSolver<BatchBicgstab<_type>, BatchLinOp>::apply_impl( \
-        const BatchLinOp* b, BatchLinOp* x) const
-GKO_INSTANTIATE_FOR_EACH_VALUE_TYPE(GKO_DECLARE_BATCH_BICGSTAB_APPLY_FUNCTION);
+#define GKO_DECLARE_BATCH_BICGSTAB_APPLY_FUNCTIONS(_type)                     \
+    void EnableBatchSolver<BatchBicgstab<_type>, BatchLinOp>::apply_impl(     \
+        const BatchLinOp* b, BatchLinOp* x) const;                            \
+    template void                                                             \
+    EnableBatchSolver<BatchBicgstab<_type>, BatchLinOp>::apply_impl(          \
+        const BatchLinOp* alpha, const BatchLinOp* b, const BatchLinOp* beta, \
+        BatchLinOp* x) const
+GKO_INSTANTIATE_FOR_EACH_VALUE_TYPE(GKO_DECLARE_BATCH_BICGSTAB_APPLY_FUNCTIONS);
 
 
 }  // namespace solver

--- a/core/solver/batch_cg.cpp
+++ b/core/solver/batch_cg.cpp
@@ -97,27 +97,16 @@ void BatchCg<ValueType>::solver_apply(const BatchLinOp* const mtx,
 }
 
 
-template <typename ValueType>
-void BatchCg<ValueType>::apply_impl(const BatchLinOp* alpha,
-                                    const BatchLinOp* b, const BatchLinOp* beta,
-                                    BatchLinOp* x) const
-{
-    auto dense_x = as<matrix::BatchDense<ValueType>>(x);
-
-    auto x_clone = dense_x->clone();
-    this->apply(b, x_clone.get());
-    dense_x->scale(beta);
-    dense_x->add_scaled(alpha, x_clone.get());
-}
-
-
 #define GKO_DECLARE_BATCH_CG(_type) class BatchCg<_type>
 GKO_INSTANTIATE_FOR_EACH_VALUE_TYPE(GKO_DECLARE_BATCH_CG);
 
 
-#define GKO_DECLARE_BATCH_CG_APPLY_FUNCTION(_type)                  \
-    void EnableBatchSolver<BatchCg<_type>, BatchLinOp>::apply_impl( \
-        const BatchLinOp* b, BatchLinOp* x) const
+#define GKO_DECLARE_BATCH_CG_APPLY_FUNCTION(_type)                            \
+    void EnableBatchSolver<BatchCg<_type>, BatchLinOp>::apply_impl(           \
+        const BatchLinOp* b, BatchLinOp* x) const;                            \
+    template void EnableBatchSolver<BatchCg<_type>, BatchLinOp>::apply_impl(  \
+        const BatchLinOp* alpha, const BatchLinOp* b, const BatchLinOp* beta, \
+        BatchLinOp* x) const
 GKO_INSTANTIATE_FOR_EACH_VALUE_TYPE(GKO_DECLARE_BATCH_CG_APPLY_FUNCTION);
 
 

--- a/core/solver/batch_cg.cpp
+++ b/core/solver/batch_cg.cpp
@@ -115,5 +115,11 @@ void BatchCg<ValueType>::apply_impl(const BatchLinOp* alpha,
 GKO_INSTANTIATE_FOR_EACH_VALUE_TYPE(GKO_DECLARE_BATCH_CG);
 
 
+#define GKO_DECLARE_BATCH_CG_APPLY_FUNCTION(_type)                  \
+    void EnableBatchSolver<BatchCg<_type>, BatchLinOp>::apply_impl( \
+        const BatchLinOp* b, BatchLinOp* x) const
+GKO_INSTANTIATE_FOR_EACH_VALUE_TYPE(GKO_DECLARE_BATCH_CG_APPLY_FUNCTION);
+
+
 }  // namespace solver
 }  // namespace gko

--- a/core/solver/batch_cg.cpp
+++ b/core/solver/batch_cg.cpp
@@ -83,15 +83,17 @@ std::unique_ptr<BatchLinOp> BatchCg<ValueType>::conj_transpose() const
 
 template <typename ValueType>
 void BatchCg<ValueType>::solver_apply(const BatchLinOp* const mtx,
-                                      const matrix::BatchDense<ValueType>* b,
-                                      matrix::BatchDense<ValueType>* x,
-                                      BatchInfo<ValueType>& info) const
+                                      const BatchLinOp* b, BatchLinOp* x,
+                                      BatchInfo& info) const
 {
+    using Dense = matrix::BatchDense<ValueType>;
     const kernels::batch_cg::BatchCgOptions<remove_complex<ValueType>> opts{
         parameters_.preconditioner, parameters_.max_iterations,
         parameters_.residual_tol, parameters_.tolerance_type};
     auto exec = this->get_executor();
-    exec->run(batch_cg::make_apply(opts, mtx, b, x, info.logdata));
+    exec->run(batch_cg::make_apply(
+        opts, mtx, as<const Dense>(b), as<Dense>(x),
+        *static_cast<log::BatchLogData<ValueType>*>(info.logdata)));
 }
 
 

--- a/core/solver/batch_cg.cpp
+++ b/core/solver/batch_cg.cpp
@@ -39,6 +39,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "core/matrix/batch_csr_kernels.hpp"
 #include "core/matrix/batch_dense_kernels.hpp"
 #include "core/solver/batch_cg_kernels.hpp"
+#include "core/solver/batch_solver.ipp"
 
 
 namespace gko {
@@ -46,8 +47,6 @@ namespace solver {
 namespace batch_cg {
 
 
-GKO_REGISTER_OPERATION(pre_diag_scale_system, batch_csr::pre_diag_scale_system);
-GKO_REGISTER_OPERATION(vec_scale, batch_dense::batch_scale);
 GKO_REGISTER_OPERATION(apply, batch_cg::apply);
 
 
@@ -83,65 +82,16 @@ std::unique_ptr<BatchLinOp> BatchCg<ValueType>::conj_transpose() const
 
 
 template <typename ValueType>
-void BatchCg<ValueType>::apply_impl(const BatchLinOp* b, BatchLinOp* x) const
+void BatchCg<ValueType>::solver_apply(const BatchLinOp* const mtx,
+                                      const matrix::BatchDense<ValueType>* b,
+                                      matrix::BatchDense<ValueType>* x,
+                                      BatchInfo<ValueType>& info) const
 {
-    using Mtx = matrix::BatchCsr<ValueType>;
-    using Vector = matrix::BatchDense<ValueType>;
-    using real_type = remove_complex<ValueType>;
-
-    auto exec = this->get_executor();
-    auto dense_b = as<const Vector>(b);
-    auto dense_x = as<Vector>(x);
-    const auto acsr = dynamic_cast<const Mtx*>(system_matrix_.get());
-    if (!acsr) {
-        GKO_NOT_SUPPORTED(system_matrix_);
-    }
-
-    auto a_scaled_smart = Mtx::create(exec);
-    auto b_scaled_smart = Vector::create(exec);
-    const Mtx* a_scaled{};
-    const Vector* b_scaled{};
-    const bool to_scale =
-        this->get_left_scaling_vector() && this->get_right_scaling_vector();
-    if (to_scale) {
-        a_scaled_smart->copy_from(acsr);
-        b_scaled_smart->copy_from(dense_b);
-        exec->run(batch_cg::make_pre_diag_scale_system(
-            this->get_left_scaling_vector(), this->get_right_scaling_vector(),
-            a_scaled_smart.get(), b_scaled_smart.get()));
-        a_scaled = a_scaled_smart.get();
-        b_scaled = b_scaled_smart.get();
-    } else {
-        a_scaled = acsr;
-        b_scaled = dense_b;
-    }
-
     const kernels::batch_cg::BatchCgOptions<remove_complex<ValueType>> opts{
         parameters_.preconditioner, parameters_.max_iterations,
         parameters_.residual_tol, parameters_.tolerance_type};
-
-    // allocate logging arrays assuming uniform size batch
-    log::BatchLogData<ValueType> logdata;
-    // GKO_ASSERT(dense_b->stores_equal_sizes());
-
-    const size_type num_rhs = dense_b->get_size().at(0)[1];
-    const size_type num_batches = dense_b->get_num_batch_entries();
-    batch_dim<> sizes(num_batches, dim<2>{1, num_rhs});
-
-    logdata.res_norms =
-        matrix::BatchDense<real_type>::create(this->get_executor(), sizes);
-    logdata.iter_counts.set_executor(this->get_executor());
-    logdata.iter_counts.resize_and_reset(num_rhs * num_batches);
-
-    exec->run(batch_cg::make_apply(opts, a_scaled, b_scaled, dense_x, logdata));
-
-    this->template log<log::Logger::batch_solver_completed>(
-        logdata.iter_counts, logdata.res_norms.get());
-
-    if (to_scale) {
-        exec->run(batch_cg::make_vec_scale(this->get_right_scaling_vector(),
-                                           dense_x));
-    }
+    auto exec = this->get_executor();
+    exec->run(batch_cg::make_apply(opts, mtx, b, x, info.logdata));
 }
 
 

--- a/core/solver/batch_cg.cpp
+++ b/core/solver/batch_cg.cpp
@@ -85,7 +85,7 @@ template <typename ValueType>
 void BatchCg<ValueType>::solver_apply(const BatchLinOp* const mtx,
                                       const BatchLinOp* const b,
                                       BatchLinOp* const x,
-                                      BatchInfo& info) const
+                                      BatchInfo* const info) const
 {
     using Dense = matrix::BatchDense<ValueType>;
     const kernels::batch_cg::BatchCgOptions<remove_complex<ValueType>> opts{
@@ -94,7 +94,7 @@ void BatchCg<ValueType>::solver_apply(const BatchLinOp* const mtx,
     auto exec = this->get_executor();
     exec->run(batch_cg::make_apply(
         opts, mtx, as<const Dense>(b), as<Dense>(x),
-        *as<log::BatchLogData<ValueType>>(info.logdata.get())));
+        *as<log::BatchLogData<ValueType>>(info->logdata.get())));
 }
 
 

--- a/core/solver/batch_cg.cpp
+++ b/core/solver/batch_cg.cpp
@@ -83,7 +83,8 @@ std::unique_ptr<BatchLinOp> BatchCg<ValueType>::conj_transpose() const
 
 template <typename ValueType>
 void BatchCg<ValueType>::solver_apply(const BatchLinOp* const mtx,
-                                      const BatchLinOp* b, BatchLinOp* x,
+                                      const BatchLinOp* const b,
+                                      BatchLinOp* const x,
                                       BatchInfo& info) const
 {
     using Dense = matrix::BatchDense<ValueType>;
@@ -93,7 +94,7 @@ void BatchCg<ValueType>::solver_apply(const BatchLinOp* const mtx,
     auto exec = this->get_executor();
     exec->run(batch_cg::make_apply(
         opts, mtx, as<const Dense>(b), as<Dense>(x),
-        *static_cast<log::BatchLogData<ValueType>*>(info.logdata)));
+        *as<log::BatchLogData<ValueType>>(info.logdata.get())));
 }
 
 

--- a/core/solver/batch_dispatch.hpp
+++ b/core/solver/batch_dispatch.hpp
@@ -34,6 +34,9 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define GKO_CORE_SOLVER_BATCH_DISPATCH_HPP_
 
 
+#include <ginkgo/core/preconditioner/batch_preconditioner_types.hpp>
+
+
 #include "core/log/batch_logging.hpp"
 
 

--- a/core/solver/batch_gmres.cpp
+++ b/core/solver/batch_gmres.cpp
@@ -85,16 +85,19 @@ std::unique_ptr<BatchLinOp> BatchGmres<ValueType>::conj_transpose() const
 
 template <typename ValueType>
 void BatchGmres<ValueType>::solver_apply(const BatchLinOp* const mtx,
-                                         const matrix::BatchDense<ValueType>* b,
-                                         matrix::BatchDense<ValueType>* x,
-                                         BatchInfo<ValueType>& info) const
+                                         const BatchLinOp* const b,
+                                         BatchLinOp* const x,
+                                         BatchInfo& info) const
 {
+    using Dense = matrix::BatchDense<ValueType>;
     const kernels::batch_gmres::BatchGmresOptions<remove_complex<ValueType>>
         opts{parameters_.preconditioner, parameters_.max_iterations,
              parameters_.residual_tol, parameters_.restart,
              parameters_.tolerance_type};
     auto exec = this->get_executor();
-    exec->run(batch_gmres::make_apply(opts, mtx, b, x, info.logdata));
+    exec->run(batch_gmres::make_apply(
+        opts, mtx, as<const Dense>(b), as<Dense>(x),
+        *static_cast<log::BatchLogData<ValueType>*>(info.logdata)));
 }
 
 

--- a/core/solver/batch_gmres.cpp
+++ b/core/solver/batch_gmres.cpp
@@ -121,5 +121,11 @@ void BatchGmres<ValueType>::apply_impl(const BatchLinOp* alpha,
 GKO_INSTANTIATE_FOR_EACH_VALUE_TYPE(GKO_DECLARE_BATCH_GMRES);
 
 
+#define GKO_DECLARE_BATCH_GMRES_APPLY_FUNCTION(_type)                  \
+    void EnableBatchSolver<BatchGmres<_type>, BatchLinOp>::apply_impl( \
+        const BatchLinOp* b, BatchLinOp* x) const
+GKO_INSTANTIATE_FOR_EACH_VALUE_TYPE(GKO_DECLARE_BATCH_GMRES_APPLY_FUNCTION);
+
+
 }  // namespace solver
 }  // namespace gko

--- a/core/solver/batch_gmres.cpp
+++ b/core/solver/batch_gmres.cpp
@@ -101,29 +101,17 @@ void BatchGmres<ValueType>::solver_apply(const BatchLinOp* const mtx,
 }
 
 
-template <typename ValueType>
-void BatchGmres<ValueType>::apply_impl(const BatchLinOp* alpha,
-                                       const BatchLinOp* b,
-                                       const BatchLinOp* beta,
-                                       BatchLinOp* x) const
-
-{
-    auto dense_x = as<matrix::BatchDense<ValueType>>(x);
-
-    auto x_clone = dense_x->clone();
-    this->apply(b, x_clone.get());
-    dense_x->scale(beta);
-    dense_x->add_scaled(alpha, x_clone.get());
-}
-
-
 #define GKO_DECLARE_BATCH_GMRES(_type) class BatchGmres<_type>
 GKO_INSTANTIATE_FOR_EACH_VALUE_TYPE(GKO_DECLARE_BATCH_GMRES);
 
 
-#define GKO_DECLARE_BATCH_GMRES_APPLY_FUNCTION(_type)                  \
-    void EnableBatchSolver<BatchGmres<_type>, BatchLinOp>::apply_impl( \
-        const BatchLinOp* b, BatchLinOp* x) const
+#define GKO_DECLARE_BATCH_GMRES_APPLY_FUNCTION(_type)                         \
+    void EnableBatchSolver<BatchGmres<_type>, BatchLinOp>::apply_impl(        \
+        const BatchLinOp* b, BatchLinOp* x) const;                            \
+    template void                                                             \
+    EnableBatchSolver<BatchGmres<_type>, BatchLinOp>::apply_impl(             \
+        const BatchLinOp* alpha, const BatchLinOp* b, const BatchLinOp* beta, \
+        BatchLinOp* x) const
 GKO_INSTANTIATE_FOR_EACH_VALUE_TYPE(GKO_DECLARE_BATCH_GMRES_APPLY_FUNCTION);
 
 

--- a/core/solver/batch_gmres.cpp
+++ b/core/solver/batch_gmres.cpp
@@ -97,7 +97,7 @@ void BatchGmres<ValueType>::solver_apply(const BatchLinOp* const mtx,
     auto exec = this->get_executor();
     exec->run(batch_gmres::make_apply(
         opts, mtx, as<const Dense>(b), as<Dense>(x),
-        *static_cast<log::BatchLogData<ValueType>*>(info.logdata)));
+        *as<log::BatchLogData<ValueType>>(info.logdata.get())));
 }
 
 

--- a/core/solver/batch_gmres.cpp
+++ b/core/solver/batch_gmres.cpp
@@ -87,7 +87,7 @@ template <typename ValueType>
 void BatchGmres<ValueType>::solver_apply(const BatchLinOp* const mtx,
                                          const BatchLinOp* const b,
                                          BatchLinOp* const x,
-                                         BatchInfo& info) const
+                                         BatchInfo* const info) const
 {
     using Dense = matrix::BatchDense<ValueType>;
     const kernels::batch_gmres::BatchGmresOptions<remove_complex<ValueType>>
@@ -97,7 +97,7 @@ void BatchGmres<ValueType>::solver_apply(const BatchLinOp* const mtx,
     auto exec = this->get_executor();
     exec->run(batch_gmres::make_apply(
         opts, mtx, as<const Dense>(b), as<Dense>(x),
-        *as<log::BatchLogData<ValueType>>(info.logdata.get())));
+        *as<log::BatchLogData<ValueType>>(info->logdata.get())));
 }
 
 

--- a/core/solver/batch_gmres.cpp
+++ b/core/solver/batch_gmres.cpp
@@ -39,6 +39,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "core/matrix/batch_csr_kernels.hpp"
 #include "core/matrix/batch_dense_kernels.hpp"
 #include "core/solver/batch_gmres_kernels.hpp"
+#include "core/solver/batch_solver.ipp"
 
 
 namespace gko {
@@ -46,8 +47,6 @@ namespace solver {
 namespace batch_gmres {
 
 
-GKO_REGISTER_OPERATION(pre_diag_scale_system, batch_csr::pre_diag_scale_system);
-GKO_REGISTER_OPERATION(vec_scale, batch_dense::batch_scale);
 GKO_REGISTER_OPERATION(apply, batch_gmres::apply);
 
 
@@ -85,65 +84,17 @@ std::unique_ptr<BatchLinOp> BatchGmres<ValueType>::conj_transpose() const
 
 
 template <typename ValueType>
-void BatchGmres<ValueType>::apply_impl(const BatchLinOp* b, BatchLinOp* x) const
+void BatchGmres<ValueType>::solver_apply(const BatchLinOp* const mtx,
+                                         const matrix::BatchDense<ValueType>* b,
+                                         matrix::BatchDense<ValueType>* x,
+                                         BatchInfo<ValueType>& info) const
 {
-    using Mtx = matrix::BatchCsr<ValueType>;
-    using Vector = matrix::BatchDense<ValueType>;
-    using real_type = remove_complex<ValueType>;
-
-    auto exec = this->get_executor();
-    auto dense_b = as<const Vector>(b);
-    auto dense_x = as<Vector>(x);
-    const auto acsr = dynamic_cast<const Mtx*>(system_matrix_.get());
-    if (!acsr) {
-        GKO_NOT_SUPPORTED(system_matrix_);
-    }
-
-    auto a_scaled_smart = Mtx::create(exec);
-    auto b_scaled_smart = Vector::create(exec);
-    const Mtx* a_scaled{};
-    const Vector* b_scaled{};
-    const bool to_scale =
-        this->get_left_scaling_vector() && this->get_right_scaling_vector();
-    if (to_scale) {
-        a_scaled_smart->copy_from(acsr);
-        b_scaled_smart->copy_from(dense_b);
-        exec->run(batch_gmres::make_pre_diag_scale_system(
-            this->get_left_scaling_vector(), this->get_right_scaling_vector(),
-            a_scaled_smart.get(), b_scaled_smart.get()));
-        a_scaled = a_scaled_smart.get();
-        b_scaled = b_scaled_smart.get();
-    } else {
-        a_scaled = acsr;
-        b_scaled = dense_b;
-    }
-
     const kernels::batch_gmres::BatchGmresOptions<remove_complex<ValueType>>
         opts{parameters_.preconditioner, parameters_.max_iterations,
              parameters_.residual_tol, parameters_.restart,
              parameters_.tolerance_type};
-
-    log::BatchLogData<ValueType> logdata;
-    // allocate logging arrays assuming uniform size batch
-    const size_type num_rhs = dense_b->get_size().at(0)[1];
-    const size_type num_batches = dense_b->get_num_batch_entries();
-    batch_dim<> sizes(num_batches, dim<2>{1, num_rhs});
-
-    logdata.res_norms =
-        matrix::BatchDense<real_type>::create(this->get_executor(), sizes);
-    logdata.iter_counts.set_executor(this->get_executor());
-    logdata.iter_counts.resize_and_reset(num_rhs * num_batches);
-
-    exec->run(
-        batch_gmres::make_apply(opts, a_scaled, b_scaled, dense_x, logdata));
-
-    this->template log<log::Logger::batch_solver_completed>(
-        logdata.iter_counts, logdata.res_norms.get());
-
-    if (to_scale) {
-        exec->run(batch_gmres::make_vec_scale(this->get_right_scaling_vector(),
-                                              dense_x));
-    }
+    auto exec = this->get_executor();
+    exec->run(batch_gmres::make_apply(opts, mtx, b, x, info.logdata));
 }
 
 

--- a/core/solver/batch_idr.cpp
+++ b/core/solver/batch_idr.cpp
@@ -93,7 +93,8 @@ std::unique_ptr<BatchLinOp> BatchIdr<ValueType>::conj_transpose() const
 
 template <typename ValueType>
 void BatchIdr<ValueType>::solver_apply(const BatchLinOp* const mtx,
-                                       const BatchLinOp* b, BatchLinOp* x,
+                                       const BatchLinOp* const b,
+                                       BatchLinOp* const x,
                                        BatchInfo& info) const
 {
     using Dense = matrix::BatchDense<ValueType>;
@@ -106,7 +107,7 @@ void BatchIdr<ValueType>::solver_apply(const BatchLinOp* const mtx,
     auto exec = this->get_executor();
     exec->run(batch_idr::make_apply(
         opts, mtx, as<const Dense>(b), as<Dense>(x),
-        *static_cast<log::BatchLogData<ValueType>*>(info.logdata)));
+        *as<log::BatchLogData<ValueType>>(info.logdata.get())));
 }
 
 

--- a/core/solver/batch_idr.cpp
+++ b/core/solver/batch_idr.cpp
@@ -95,7 +95,7 @@ template <typename ValueType>
 void BatchIdr<ValueType>::solver_apply(const BatchLinOp* const mtx,
                                        const BatchLinOp* const b,
                                        BatchLinOp* const x,
-                                       BatchInfo& info) const
+                                       BatchInfo* const info) const
 {
     using Dense = matrix::BatchDense<ValueType>;
     const kernels::batch_idr::BatchIdrOptions<remove_complex<ValueType>> opts{
@@ -107,7 +107,7 @@ void BatchIdr<ValueType>::solver_apply(const BatchLinOp* const mtx,
     auto exec = this->get_executor();
     exec->run(batch_idr::make_apply(
         opts, mtx, as<const Dense>(b), as<Dense>(x),
-        *as<log::BatchLogData<ValueType>>(info.logdata.get())));
+        *as<log::BatchLogData<ValueType>>(info->logdata.get())));
 }
 
 

--- a/core/solver/batch_idr.cpp
+++ b/core/solver/batch_idr.cpp
@@ -93,10 +93,10 @@ std::unique_ptr<BatchLinOp> BatchIdr<ValueType>::conj_transpose() const
 
 template <typename ValueType>
 void BatchIdr<ValueType>::solver_apply(const BatchLinOp* const mtx,
-                                       const matrix::BatchDense<ValueType>* b,
-                                       matrix::BatchDense<ValueType>* x,
-                                       BatchInfo<ValueType>& info) const
+                                       const BatchLinOp* b, BatchLinOp* x,
+                                       BatchInfo& info) const
 {
+    using Dense = matrix::BatchDense<ValueType>;
     const kernels::batch_idr::BatchIdrOptions<remove_complex<ValueType>> opts{
         parameters_.preconditioner,   parameters_.max_iterations,
         parameters_.residual_tol,     parameters_.subspace_dim,
@@ -104,7 +104,9 @@ void BatchIdr<ValueType>::solver_apply(const BatchLinOp* const mtx,
         parameters_.smoothing,        parameters_.deterministic,
         parameters_.tolerance_type};
     auto exec = this->get_executor();
-    exec->run(batch_idr::make_apply(opts, mtx, b, x, info.logdata));
+    exec->run(batch_idr::make_apply(
+        opts, mtx, as<const Dense>(b), as<Dense>(x),
+        *static_cast<log::BatchLogData<ValueType>*>(info.logdata)));
 }
 
 

--- a/core/solver/batch_idr.cpp
+++ b/core/solver/batch_idr.cpp
@@ -39,6 +39,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "core/matrix/batch_csr_kernels.hpp"
 #include "core/matrix/batch_dense_kernels.hpp"
 #include "core/solver/batch_idr_kernels.hpp"
+#include "core/solver/batch_solver.ipp"
 
 
 namespace gko {
@@ -46,8 +47,6 @@ namespace solver {
 namespace batch_idr {
 
 
-GKO_REGISTER_OPERATION(pre_diag_scale_system, batch_csr::pre_diag_scale_system);
-GKO_REGISTER_OPERATION(vec_scale, batch_dense::batch_scale);
 GKO_REGISTER_OPERATION(apply, batch_idr::apply);
 
 
@@ -93,67 +92,19 @@ std::unique_ptr<BatchLinOp> BatchIdr<ValueType>::conj_transpose() const
 
 
 template <typename ValueType>
-void BatchIdr<ValueType>::apply_impl(const BatchLinOp* b, BatchLinOp* x) const
+void BatchIdr<ValueType>::solver_apply(const BatchLinOp* const mtx,
+                                       const matrix::BatchDense<ValueType>* b,
+                                       matrix::BatchDense<ValueType>* x,
+                                       BatchInfo<ValueType>& info) const
 {
-    using Vector = matrix::BatchDense<ValueType>;
-    using Mtx = matrix::BatchCsr<ValueType>;
-    using real_type = remove_complex<ValueType>;
-
-    auto exec = this->get_executor();
-    auto dense_b = as<const Vector>(b);
-    auto dense_x = as<Vector>(x);
-    const auto acsr = dynamic_cast<const Mtx*>(system_matrix_.get());
-    if (!acsr) {
-        GKO_NOT_SUPPORTED(system_matrix_);
-    }
-
-    auto a_scaled_smart = Mtx::create(exec);
-    auto b_scaled_smart = Vector::create(exec);
-    const Mtx* a_scaled{};
-    const Vector* b_scaled{};
-    const bool to_scale =
-        this->get_left_scaling_vector() && this->get_right_scaling_vector();
-    if (to_scale) {
-        a_scaled_smart->copy_from(acsr);
-        b_scaled_smart->copy_from(dense_b);
-        exec->run(batch_idr::make_pre_diag_scale_system(
-            this->get_left_scaling_vector(), this->get_right_scaling_vector(),
-            a_scaled_smart.get(), b_scaled_smart.get()));
-        a_scaled = a_scaled_smart.get();
-        b_scaled = b_scaled_smart.get();
-    } else {
-        a_scaled = acsr;
-        b_scaled = dense_b;
-    }
-
     const kernels::batch_idr::BatchIdrOptions<remove_complex<ValueType>> opts{
         parameters_.preconditioner,   parameters_.max_iterations,
         parameters_.residual_tol,     parameters_.subspace_dim,
         parameters_.complex_subspace, parameters_.kappa,
         parameters_.smoothing,        parameters_.deterministic,
         parameters_.tolerance_type};
-
-    // allocate logging arrays assuming uniform size batch
-    log::BatchLogData<ValueType> logdata;
-    const size_type num_rhs = dense_b->get_size().at(0)[1];
-    const size_type num_batches = dense_b->get_num_batch_entries();
-    batch_dim<> sizes(num_batches, dim<2>{1, num_rhs});
-
-    logdata.res_norms =
-        matrix::BatchDense<real_type>::create(this->get_executor(), sizes);
-    logdata.iter_counts.set_executor(this->get_executor());
-    logdata.iter_counts.resize_and_reset(num_rhs * num_batches);
-
-    exec->run(
-        batch_idr::make_apply(opts, a_scaled, b_scaled, dense_x, logdata));
-
-    this->template log<log::Logger::batch_solver_completed>(
-        logdata.iter_counts, logdata.res_norms.get());
-
-    if (to_scale) {
-        exec->run(batch_idr::make_vec_scale(this->get_right_scaling_vector(),
-                                            dense_x));
-    }
+    auto exec = this->get_executor();
+    exec->run(batch_idr::make_apply(opts, mtx, b, x, info.logdata));
 }
 
 

--- a/core/solver/batch_idr.cpp
+++ b/core/solver/batch_idr.cpp
@@ -110,29 +110,16 @@ void BatchIdr<ValueType>::solver_apply(const BatchLinOp* const mtx,
 }
 
 
-template <typename ValueType>
-void BatchIdr<ValueType>::apply_impl(const BatchLinOp* alpha,
-                                     const BatchLinOp* b,
-                                     const BatchLinOp* beta,
-                                     BatchLinOp* x) const
-
-{
-    auto dense_x = as<matrix::BatchDense<ValueType>>(x);
-
-    auto x_clone = dense_x->clone();
-    this->apply(b, x_clone.get());
-    dense_x->scale(beta);
-    dense_x->add_scaled(alpha, x_clone.get());
-}
-
-
 #define GKO_DECLARE_BATCH_IDR(_type) class BatchIdr<_type>
 GKO_INSTANTIATE_FOR_EACH_VALUE_TYPE(GKO_DECLARE_BATCH_IDR);
 
 
-#define GKO_DECLARE_BATCH_IDR_APPLY_FUNCTION(_type)                  \
-    void EnableBatchSolver<BatchIdr<_type>, BatchLinOp>::apply_impl( \
-        const BatchLinOp* b, BatchLinOp* x) const
+#define GKO_DECLARE_BATCH_IDR_APPLY_FUNCTION(_type)                           \
+    void EnableBatchSolver<BatchIdr<_type>, BatchLinOp>::apply_impl(          \
+        const BatchLinOp* b, BatchLinOp* x) const;                            \
+    template void EnableBatchSolver<BatchIdr<_type>, BatchLinOp>::apply_impl( \
+        const BatchLinOp* alpha, const BatchLinOp* b, const BatchLinOp* beta, \
+        BatchLinOp* x) const
 GKO_INSTANTIATE_FOR_EACH_VALUE_TYPE(GKO_DECLARE_BATCH_IDR_APPLY_FUNCTION);
 
 

--- a/core/solver/batch_idr.cpp
+++ b/core/solver/batch_idr.cpp
@@ -130,5 +130,11 @@ void BatchIdr<ValueType>::apply_impl(const BatchLinOp* alpha,
 GKO_INSTANTIATE_FOR_EACH_VALUE_TYPE(GKO_DECLARE_BATCH_IDR);
 
 
+#define GKO_DECLARE_BATCH_IDR_APPLY_FUNCTION(_type)                  \
+    void EnableBatchSolver<BatchIdr<_type>, BatchLinOp>::apply_impl( \
+        const BatchLinOp* b, BatchLinOp* x) const
+GKO_INSTANTIATE_FOR_EACH_VALUE_TYPE(GKO_DECLARE_BATCH_IDR_APPLY_FUNCTION);
+
+
 }  // namespace solver
 }  // namespace gko

--- a/core/solver/batch_richardson.cpp
+++ b/core/solver/batch_richardson.cpp
@@ -100,28 +100,18 @@ void BatchRichardson<ValueType>::solver_apply(const BatchLinOp* const mtx,
         *static_cast<log::BatchLogData<ValueType>*>(info.logdata)));
 }
 
-template <typename ValueType>
-void BatchRichardson<ValueType>::apply_impl(const BatchLinOp* alpha,
-                                            const BatchLinOp* b,
-                                            const BatchLinOp* beta,
-                                            BatchLinOp* x) const
-{
-    auto dense_x = as<matrix::BatchDense<ValueType>>(x);
-
-    auto x_clone = dense_x->clone();
-    this->apply(b, x_clone.get());
-    dense_x->scale(beta);
-    dense_x->add_scaled(alpha, x_clone.get());
-}
-
 
 #define GKO_DECLARE_BATCH_RICHARDSON(_type) class BatchRichardson<_type>
 GKO_INSTANTIATE_FOR_EACH_VALUE_TYPE(GKO_DECLARE_BATCH_RICHARDSON);
 
 
-#define GKO_DECLARE_BATCH_RICH_APPLY_FUNCTION(_type)                        \
-    void EnableBatchSolver<BatchRichardson<_type>, BatchLinOp>::apply_impl( \
-        const BatchLinOp* b, BatchLinOp* x) const
+#define GKO_DECLARE_BATCH_RICH_APPLY_FUNCTION(_type)                          \
+    void EnableBatchSolver<BatchRichardson<_type>, BatchLinOp>::apply_impl(   \
+        const BatchLinOp* b, BatchLinOp* x) const;                            \
+    template void                                                             \
+    EnableBatchSolver<BatchRichardson<_type>, BatchLinOp>::apply_impl(        \
+        const BatchLinOp* alpha, const BatchLinOp* b, const BatchLinOp* beta, \
+        BatchLinOp* x) const
 GKO_INSTANTIATE_FOR_EACH_VALUE_TYPE(GKO_DECLARE_BATCH_RICH_APPLY_FUNCTION);
 
 

--- a/core/solver/batch_richardson.cpp
+++ b/core/solver/batch_richardson.cpp
@@ -119,5 +119,11 @@ void BatchRichardson<ValueType>::apply_impl(const BatchLinOp* alpha,
 GKO_INSTANTIATE_FOR_EACH_VALUE_TYPE(GKO_DECLARE_BATCH_RICHARDSON);
 
 
+#define GKO_DECLARE_BATCH_RICH_APPLY_FUNCTION(_type)                        \
+    void EnableBatchSolver<BatchRichardson<_type>, BatchLinOp>::apply_impl( \
+        const BatchLinOp* b, BatchLinOp* x) const
+GKO_INSTANTIATE_FOR_EACH_VALUE_TYPE(GKO_DECLARE_BATCH_RICH_APPLY_FUNCTION);
+
+
 }  // namespace solver
 }  // namespace gko

--- a/core/solver/batch_richardson.cpp
+++ b/core/solver/batch_richardson.cpp
@@ -39,6 +39,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "core/matrix/batch_csr_kernels.hpp"
 #include "core/matrix/batch_dense_kernels.hpp"
 #include "core/solver/batch_richardson_kernels.hpp"
+#include "core/solver/batch_solver.ipp"
 
 
 namespace gko {
@@ -46,8 +47,6 @@ namespace solver {
 namespace batch_rich {
 
 
-GKO_REGISTER_OPERATION(pre_diag_scale_system, batch_csr::pre_diag_scale_system);
-GKO_REGISTER_OPERATION(vec_scale, batch_dense::batch_scale);
 GKO_REGISTER_OPERATION(apply, batch_rich::apply);
 
 
@@ -85,67 +84,17 @@ std::unique_ptr<BatchLinOp> BatchRichardson<ValueType>::conj_transpose() const
 
 
 template <typename ValueType>
-void BatchRichardson<ValueType>::apply_impl(const BatchLinOp* const b,
-                                            BatchLinOp* const x) const
+void BatchRichardson<ValueType>::solver_apply(
+    const BatchLinOp* const mtx, const matrix::BatchDense<ValueType>* b,
+    matrix::BatchDense<ValueType>* x, BatchInfo<ValueType>& info) const
 {
-    using Mtx = matrix::BatchCsr<ValueType>;
-    using Vector = matrix::BatchDense<ValueType>;
-
+    const kernels::batch_rich::BatchRichardsonOptions<remove_complex<ValueType>>
+        opts{parameters_.preconditioner, parameters_.max_iterations,
+             parameters_.residual_tol, parameters_.tolerance_type,
+             parameters_.relaxation_factor};
     auto exec = this->get_executor();
-    auto dense_b = as<const Vector>(b);
-    auto dense_x = as<Vector>(x);
-    const auto acsr = dynamic_cast<const Mtx*>(system_matrix_.get());
-    if (!acsr) {
-        GKO_NOT_SUPPORTED(system_matrix_);
-    }
-
-    // copies to scale
-    auto a_scaled_smart = Mtx::create(exec);
-    auto b_scaled_smart = Vector::create(exec);
-    const Mtx* a_scaled{};
-    const Vector* b_scaled{};
-    const bool to_scale =
-        this->get_left_scaling_vector() && this->get_right_scaling_vector();
-    if (to_scale) {
-        a_scaled_smart->copy_from(acsr);
-        b_scaled_smart->copy_from(dense_b);
-        exec->run(batch_rich::make_pre_diag_scale_system(
-            this->get_left_scaling_vector(), this->get_right_scaling_vector(),
-            a_scaled_smart.get(), b_scaled_smart.get()));
-        a_scaled = a_scaled_smart.get();
-        b_scaled = b_scaled_smart.get();
-    } else {
-        a_scaled = acsr;
-        b_scaled = dense_b;
-    }
-
-    const kernels::batch_rich::BatchRichardsonOptions<real_type> opts{
-        parameters_.preconditioner, parameters_.max_iterations,
-        parameters_.residual_tol, parameters_.tolerance_type,
-        parameters_.relaxation_factor};
-
-    log::BatchLogData<ValueType> logdata;
-    // allocate logging arrays assuming uniform size batch
-    const size_type num_rhs = dense_b->get_size().at(0)[1];
-    const size_type num_batches = dense_b->get_num_batch_entries();
-    batch_dim<> sizes(num_batches, dim<2>{1, num_rhs});
-    logdata.res_norms =
-        matrix::BatchDense<real_type>::create(this->get_executor(), sizes);
-    logdata.iter_counts.set_executor(this->get_executor());
-    logdata.iter_counts.resize_and_reset(num_rhs * num_batches);
-
-    exec->run(
-        batch_rich::make_apply(opts, a_scaled, b_scaled, dense_x, logdata));
-
-    this->template log<log::Logger::batch_solver_completed>(
-        logdata.iter_counts, logdata.res_norms.get());
-
-    if (to_scale) {
-        exec->run(batch_rich::make_vec_scale(this->get_right_scaling_vector(),
-                                             dense_x));
-    }
+    exec->run(batch_rich::make_apply(opts, mtx, b, x, info.logdata));
 }
-
 
 template <typename ValueType>
 void BatchRichardson<ValueType>::apply_impl(const BatchLinOp* alpha,

--- a/core/solver/batch_richardson.cpp
+++ b/core/solver/batch_richardson.cpp
@@ -84,16 +84,20 @@ std::unique_ptr<BatchLinOp> BatchRichardson<ValueType>::conj_transpose() const
 
 
 template <typename ValueType>
-void BatchRichardson<ValueType>::solver_apply(
-    const BatchLinOp* const mtx, const matrix::BatchDense<ValueType>* b,
-    matrix::BatchDense<ValueType>* x, BatchInfo<ValueType>& info) const
+void BatchRichardson<ValueType>::solver_apply(const BatchLinOp* const mtx,
+                                              const BatchLinOp* b,
+                                              BatchLinOp* x,
+                                              BatchInfo& info) const
 {
+    using Dense = matrix::BatchDense<ValueType>;
     const kernels::batch_rich::BatchRichardsonOptions<remove_complex<ValueType>>
         opts{parameters_.preconditioner, parameters_.max_iterations,
              parameters_.residual_tol, parameters_.tolerance_type,
              parameters_.relaxation_factor};
     auto exec = this->get_executor();
-    exec->run(batch_rich::make_apply(opts, mtx, b, x, info.logdata));
+    exec->run(batch_rich::make_apply(
+        opts, mtx, as<const Dense>(b), as<Dense>(x),
+        *static_cast<log::BatchLogData<ValueType>*>(info.logdata)));
 }
 
 template <typename ValueType>

--- a/core/solver/batch_richardson.cpp
+++ b/core/solver/batch_richardson.cpp
@@ -87,7 +87,7 @@ template <typename ValueType>
 void BatchRichardson<ValueType>::solver_apply(const BatchLinOp* const mtx,
                                               const BatchLinOp* const b,
                                               BatchLinOp* const x,
-                                              BatchInfo& info) const
+                                              BatchInfo* const info) const
 {
     using Dense = matrix::BatchDense<ValueType>;
     const kernels::batch_rich::BatchRichardsonOptions<remove_complex<ValueType>>
@@ -97,7 +97,7 @@ void BatchRichardson<ValueType>::solver_apply(const BatchLinOp* const mtx,
     auto exec = this->get_executor();
     exec->run(batch_rich::make_apply(
         opts, mtx, as<const Dense>(b), as<Dense>(x),
-        *as<log::BatchLogData<ValueType>>(info.logdata.get())));
+        *as<log::BatchLogData<ValueType>>(info->logdata.get())));
 }
 
 

--- a/core/solver/batch_richardson.cpp
+++ b/core/solver/batch_richardson.cpp
@@ -85,8 +85,8 @@ std::unique_ptr<BatchLinOp> BatchRichardson<ValueType>::conj_transpose() const
 
 template <typename ValueType>
 void BatchRichardson<ValueType>::solver_apply(const BatchLinOp* const mtx,
-                                              const BatchLinOp* b,
-                                              BatchLinOp* x,
+                                              const BatchLinOp* const b,
+                                              BatchLinOp* const x,
                                               BatchInfo& info) const
 {
     using Dense = matrix::BatchDense<ValueType>;
@@ -97,7 +97,7 @@ void BatchRichardson<ValueType>::solver_apply(const BatchLinOp* const mtx,
     auto exec = this->get_executor();
     exec->run(batch_rich::make_apply(
         opts, mtx, as<const Dense>(b), as<Dense>(x),
-        *static_cast<log::BatchLogData<ValueType>*>(info.logdata)));
+        *as<log::BatchLogData<ValueType>>(info.logdata.get())));
 }
 
 

--- a/core/solver/batch_solver.ipp
+++ b/core/solver/batch_solver.ipp
@@ -1,5 +1,5 @@
 /*******************************<GINKGO LICENSE>******************************
-Copyright (c) 2017-2021, the Ginkgo authors
+Copyright (c) 2017-2022, the Ginkgo authors
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -110,7 +110,7 @@ void EnableBatchSolver<ConcreteSolver, PolymorphicBase>::apply_impl(const BatchL
     concrete_logdata->iter_counts.set_executor(this->get_executor());
     concrete_logdata->iter_counts.resize_and_reset(num_rhs * num_batches);
 
-    this->solver_apply(a_scaled, b_scaled, dense_x, info);
+    this->solver_apply(a_scaled, b_scaled, dense_x, &info);
 
     this->template log<log::Logger::batch_solver_completed>(
         concrete_logdata->iter_counts, concrete_logdata->res_norms.get());

--- a/core/solver/batch_solver.ipp
+++ b/core/solver/batch_solver.ipp
@@ -1,0 +1,128 @@
+/*******************************<GINKGO LICENSE>******************************
+Copyright (c) 2017-2021, the Ginkgo authors
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+******************************<GINKGO LICENSE>*******************************/
+
+#ifndef GKO_CORE_SOLVER_BATCH_SOLVER_IPP_
+#define GKO_CORE_SOLVER_BATCH_SOLVER_IPP_
+
+
+#include <ginkgo/core/solver/batch_solver.hpp>
+
+
+#include "core/log/batch_logging.hpp"
+#include "core/matrix/batch_csr_kernels.hpp"
+#include "core/matrix/batch_dense_kernels.hpp"
+
+
+namespace gko {
+namespace solver {
+namespace batch {
+
+
+GKO_REGISTER_OPERATION(pre_diag_scale_system, batch_csr::pre_diag_scale_system);
+GKO_REGISTER_OPERATION(vec_scale, batch_dense::batch_scale);
+
+
+}
+
+
+template <typename ValueType>
+struct BatchInfo {
+    gko::log::BatchLogData<ValueType> logdata;
+};
+
+
+template <typename ValueType, typename ConcreteSolver, typename PolymorphicBase>
+void EnableBatchSolver<ValueType, ConcreteSolver, PolymorphicBase>::apply_impl(const BatchLinOp* b,
+                                          BatchLinOp* x) const
+{
+    using Csr = matrix::BatchCsr<value_type>;
+    using Vector = matrix::BatchDense<value_type>;
+    using real_type = remove_complex<value_type>;
+
+    auto exec = this->get_executor();
+    auto dense_b = as<const Vector>(b);
+    auto dense_x = as<Vector>(x);
+    const bool to_scale =
+        this->get_left_scaling_vector() && this->get_right_scaling_vector();
+    const auto acsr = dynamic_cast<const Csr*>(system_matrix_.get());
+    const BatchLinOp* a_scaled{};
+    const Vector* b_scaled{};
+    auto a_scaled_smart = Csr::create(exec);
+    auto b_scaled_smart = Vector::create(exec);
+    if (to_scale && !acsr) {
+        GKO_NOT_SUPPORTED(system_matrix_);
+    }
+
+    // copies to scale
+    if (to_scale) {
+        a_scaled_smart->copy_from(acsr);
+        b_scaled_smart->copy_from(dense_b);
+        exec->run(batch::make_pre_diag_scale_system(
+            this->get_left_scaling_vector(), this->get_right_scaling_vector(),
+            a_scaled_smart.get(), b_scaled_smart.get()));
+        a_scaled = a_scaled_smart.get();
+        b_scaled = b_scaled_smart.get();
+    } else {
+        a_scaled = system_matrix_.get();
+        b_scaled = dense_b;
+    }
+
+    BatchInfo<value_type> info;
+
+    // allocate logging arrays assuming uniform size batch
+    // GKO_ASSERT(dense_b->stores_equal_sizes());
+
+    const size_type num_rhs = dense_b->get_size().at(0)[1];
+    const size_type num_batches = dense_b->get_num_batch_entries();
+    batch_dim<> sizes(num_batches, dim<2>{1, num_rhs});
+
+    info.logdata.res_norms =
+        matrix::BatchDense<real_type>::create(this->get_executor(), sizes);
+    info.logdata.iter_counts.set_executor(this->get_executor());
+    info.logdata.iter_counts.resize_and_reset(num_rhs * num_batches);
+
+    this->solver_apply(a_scaled, b_scaled, dense_x, info);
+
+    this->template log<log::Logger::batch_solver_completed>(
+        info.logdata.iter_counts, info.logdata.res_norms.get());
+
+    if (to_scale) {
+        exec->run(batch::make_vec_scale(
+            this->get_right_scaling_vector(), dense_x));
+    }
+}
+
+
+}
+}
+
+#endif

--- a/core/solver/batch_solver.ipp
+++ b/core/solver/batch_solver.ipp
@@ -126,6 +126,20 @@ void EnableBatchSolver<ConcreteSolver, PolymorphicBase>::apply_impl(const BatchL
 }
 
 
+template <typename ConcreteSolver, typename PolymorphicBase>
+void EnableBatchSolver<ConcreteSolver, PolymorphicBase>::apply_impl(
+    const BatchLinOp* alpha, const BatchLinOp* b,
+    const BatchLinOp* beta, BatchLinOp* x) const
+{
+    using value_type = typename ConcreteSolver::value_type;
+    auto dense_x = as<matrix::BatchDense<value_type>>(x);
+    auto x_clone = dense_x->clone();
+    this->apply(b, x_clone.get());
+    dense_x->scale(beta);
+    dense_x->add_scaled(alpha, x_clone.get());
+}
+
+
 }
 }
 

--- a/core/test/solver/batch_bicgstab.cpp
+++ b/core/test/solver/batch_bicgstab.cpp
@@ -234,16 +234,15 @@ TYPED_TEST(BatchBicgstab, CanSetScalingVectors)
     using value_type = typename TestFixture::value_type;
     using Solver = typename TestFixture::Solver;
     using Dense = typename TestFixture::Dense;
-
     auto batchbicgstab_factory = Solver::build().on(this->exec);
     auto solver = batchbicgstab_factory->generate(this->mtx);
     auto left_scale = Dense::create(
         this->exec, gko::batch_dim<>(2, gko::dim<2>(this->nrows, 1)));
     auto right_scale = Dense::create_with_config_of(left_scale.get());
-    solver->batch_scale(left_scale.get(), right_scale.get());
 
-    auto s_solver =
-        dynamic_cast<gko::EnableBatchScaledSolver<value_type>*>(solver.get());
+    solver->batch_scale(left_scale.get(), right_scale.get());
+    auto s_solver = gko::as<gko::EnableBatchScaling>(solver.get());
+
     ASSERT_TRUE(s_solver);
     ASSERT_EQ(s_solver->get_left_scaling_vector(), left_scale.get());
     ASSERT_EQ(s_solver->get_right_scaling_vector(), right_scale.get());

--- a/core/test/solver/batch_cg.cpp
+++ b/core/test/solver/batch_cg.cpp
@@ -240,10 +240,10 @@ TYPED_TEST(BatchCg, CanSetScalingVectors)
     auto left_scale = Dense::create(
         this->exec, gko::batch_dim<>(2, gko::dim<2>(this->nrows, 1)));
     auto right_scale = Dense::create_with_config_of(left_scale.get());
-    solver->batch_scale(left_scale.get(), right_scale.get());
 
-    auto s_solver =
-        dynamic_cast<gko::EnableBatchScaledSolver<value_type>*>(solver.get());
+    solver->batch_scale(left_scale.get(), right_scale.get());
+    auto s_solver = gko::as<gko::EnableBatchScaling>(solver.get());
+
     ASSERT_TRUE(s_solver);
     ASSERT_EQ(s_solver->get_left_scaling_vector(), left_scale.get());
     ASSERT_EQ(s_solver->get_right_scaling_vector(), right_scale.get());

--- a/core/test/solver/batch_gmres.cpp
+++ b/core/test/solver/batch_gmres.cpp
@@ -255,16 +255,15 @@ TYPED_TEST(BatchGmres, CanSetScalingVectors)
     using value_type = typename TestFixture::value_type;
     using Solver = typename TestFixture::Solver;
     using Dense = typename TestFixture::Dense;
-
     auto batchgmres_factory = Solver::build().on(this->exec);
     auto solver = batchgmres_factory->generate(this->mtx);
     auto left_scale = Dense::create(
         this->exec, gko::batch_dim<>(2, gko::dim<2>(this->nrows, 1)));
     auto right_scale = Dense::create_with_config_of(left_scale.get());
-    solver->batch_scale(left_scale.get(), right_scale.get());
 
-    auto s_solver =
-        dynamic_cast<gko::EnableBatchScaledSolver<value_type>*>(solver.get());
+    solver->batch_scale(left_scale.get(), right_scale.get());
+    auto s_solver = gko::as<gko::EnableBatchScaling>(solver.get());
+
     ASSERT_TRUE(s_solver);
     ASSERT_EQ(s_solver->get_left_scaling_vector(), left_scale.get());
     ASSERT_EQ(s_solver->get_right_scaling_vector(), right_scale.get());

--- a/core/test/solver/batch_idr.cpp
+++ b/core/test/solver/batch_idr.cpp
@@ -293,10 +293,10 @@ TYPED_TEST(BatchIdr, CanSetScalingVectors)
     auto left_scale = Dense::create(
         this->exec, gko::batch_dim<>(2, gko::dim<2>(this->nrows, 1)));
     auto right_scale = Dense::create_with_config_of(left_scale.get());
-    solver->batch_scale(left_scale.get(), right_scale.get());
 
-    auto s_solver =
-        dynamic_cast<gko::EnableBatchScaledSolver<value_type>*>(solver.get());
+    solver->batch_scale(left_scale.get(), right_scale.get());
+    auto s_solver = gko::as<gko::EnableBatchScaling>(solver.get());
+
     ASSERT_TRUE(s_solver);
     ASSERT_EQ(s_solver->get_left_scaling_vector(), left_scale.get());
     ASSERT_EQ(s_solver->get_right_scaling_vector(), right_scale.get());

--- a/core/test/solver/batch_richardson.cpp
+++ b/core/test/solver/batch_richardson.cpp
@@ -263,10 +263,10 @@ TYPED_TEST(BatchRich, CanSetScalingVectors)
     auto left_scale = Dense::create(
         this->exec, gko::batch_dim<>(2, gko::dim<2>(this->nrows, 1)));
     auto right_scale = Dense::create_with_config_of(left_scale.get());
-    solver->batch_scale(left_scale.get(), right_scale.get());
 
-    auto s_solver =
-        dynamic_cast<gko::EnableBatchScaledSolver<value_type>*>(solver.get());
+    solver->batch_scale(left_scale.get(), right_scale.get());
+    auto s_solver = gko::as<gko::EnableBatchScaling>(solver.get());
+
     ASSERT_TRUE(s_solver);
     ASSERT_EQ(s_solver->get_left_scaling_vector(), left_scale.get());
     ASSERT_EQ(s_solver->get_right_scaling_vector(), right_scale.get());

--- a/core/test/utils/batch_test_utils.hpp
+++ b/core/test/utils/batch_test_utils.hpp
@@ -258,7 +258,7 @@ Result<ValueType> solve_poisson_uniform_core(
         }
         d_left->copy_from(left_scale);
         d_right->copy_from(right_scale);
-        dynamic_cast<gko::EnableBatchScaledSolver<ValueType>*>(solver.get())
+        dynamic_cast<gko::EnableBatchScaling*>(solver.get())
             ->batch_scale(lend(d_left), lend(d_right));
     }
 
@@ -316,7 +316,7 @@ void test_solve(std::shared_ptr<const Executor> exec, const size_t nbatch,
     auto right_scale = Dense::create(exec, s_vec_sz);
     right_scale->copy_from(ref_right_scale.get());
     if (use_scaling) {
-        dynamic_cast<gko::EnableBatchScaledSolver<T>*>(solver.get())
+        dynamic_cast<gko::EnableBatchScaling*>(solver.get())
             ->batch_scale(lend(left_scale), lend(right_scale));
     }
     std::shared_ptr<const gko::log::BatchConvergence<T>> logger =
@@ -435,7 +435,7 @@ void test_solve_iterations_with_scaling(
     std::shared_ptr<const gko::log::BatchConvergence<value_type>> logger_s =
         gko::log::BatchConvergence<value_type>::create(exec);
     auto solver_s = factory->generate(d_mtx);
-    dynamic_cast<gko::EnableBatchScaledSolver<value_type>*>(solver_s.get())
+    dynamic_cast<gko::EnableBatchScaling*>(solver_s.get())
         ->batch_scale(lend(d_left_scale), lend(d_right_scale));
 
     solver->add_logger(logger);

--- a/cuda/log/batch_loggers.cuh
+++ b/cuda/log/batch_loggers.cuh
@@ -34,9 +34,13 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define GKO_CUDA_LOG_BATCH_LOGGERS_CUH_
 
 
+#include <ginkgo/core/base/types.hpp>
+
+
 namespace gko {
 namespace kernels {
 namespace cuda {
+
 
 #include "common/cuda_hip/log/batch_logger.hpp.inc"
 

--- a/cuda/stop/batch_stop.cuh
+++ b/cuda/stop/batch_stop.cuh
@@ -34,6 +34,9 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define GKO_CUDA_STOP_BATCH_STOP_CUH_
 
 
+#include <ginkgo/core/base/math.hpp>
+
+
 namespace gko {
 namespace kernels {
 namespace cuda {

--- a/dev_tools/scripts/add_license.sh
+++ b/dev_tools/scripts/add_license.sh
@@ -53,7 +53,7 @@ echo -e "/*${GINKGO_LICENSE_BEACON}\n$(cat ${LICENSE_FILE})\n${GINKGO_LICENSE_BE
 
 # Does not work if a found file (including the path) contains a newline
 find "${GINKGO_ROOT_DIR}" \
-    \( -name '*.cuh' -o -name '*.hpp' -o -name '*.hpp.in' -o -name '*.cpp' -o -name '*.cu' -o -name '*.hpp.inc' \) \
+    \( -name '*.cuh' -o -name '*.hpp' -o -name '*.hpp.in' -o -name '*.cpp' -o -name '*.cu' -o -name '*.ipp' -o -name '*.hpp.inc' \) \
     -type f -print \
     | grep -F -v -f "${THIS_DIR}/add_license.ignore" \
     | \

--- a/examples/batched-solver/batched-solver.cpp
+++ b/examples/batched-solver/batched-solver.cpp
@@ -215,7 +215,7 @@ int main(int argc, char* argv[])
     solver->apply(lend(b), lend(x));
     // This is not necessary, but one might want to remove the logger before
     //  the next solve using the same solver object.
-    // solver->remove_logger(logger.get());
+    solver->remove_logger(logger.get());
 
     // @sect3{Check result}
     // Compute norm of RHS on the device and automatically copy to host

--- a/hip/stop/batch_stop.hip.hpp
+++ b/hip/stop/batch_stop.hip.hpp
@@ -34,6 +34,9 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define GKO_HIP_STOP_BATCH_STOP_HIP_HPP_
 
 
+#include <ginkgo/core/base/math.hpp>
+
+
 namespace gko {
 namespace kernels {
 namespace hip {

--- a/include/ginkgo/core/base/batch_lin_op.hpp
+++ b/include/ginkgo/core/base/batch_lin_op.hpp
@@ -671,9 +671,12 @@ class BatchDense;
  *
  * @see BatchScalable
  */
-template <typename ValueType>
 class EnableBatchScaling : public BatchScalable {
 public:
+    const BatchLinOp* get_left_scaling_vector() const { return left_scale_; }
+
+    const BatchLinOp* get_right_scaling_vector() const { return right_scale_; }
+
     /**
      * Scales each matrix in a batch from the left and right.
      *
@@ -690,16 +693,6 @@ public:
             return;
         }
 
-        if (left_scale) {
-            if (!dynamic_cast<const matrix::BatchDense<ValueType>*>(left_scale))
-                GKO_NOT_SUPPORTED(left_scale);
-        }
-        if (right_scale) {
-            if (!dynamic_cast<const matrix::BatchDense<ValueType>*>(
-                    right_scale))
-                GKO_NOT_SUPPORTED(right_scale);
-        }
-
         /* TODO: Somehow restrict BatchScalable and EnableBatchScaling to
          * BatchLinOp so that the following dynamic_cast is not needed.
          */
@@ -709,12 +702,19 @@ public:
             GKO_NOT_SUPPORTED(this);
         }
 
+        left_scale_ = left_scale;
+        right_scale_ = right_scale;
+
         this->batch_scale_impl(left_scale, right_scale);
     }
 
 private:
     virtual void batch_scale_impl(const BatchLinOp* left_scale,
-                                  const BatchLinOp* right_scale) = 0;
+                                  const BatchLinOp* right_scale)
+    {}
+
+    const BatchLinOp* left_scale_ = nullptr;
+    const BatchLinOp* right_scale_ = nullptr;
 };
 
 
@@ -728,7 +728,7 @@ private:
  * it represents a new solver F(S(A)) (F composed with S applied to A).
  */
 template <typename ValueType>
-class EnableBatchScaledSolver : public EnableBatchScaling<ValueType> {
+class EnableBatchScaledSolver : public EnableBatchScaling {
 public:
     using value_type = ValueType;
 

--- a/include/ginkgo/core/matrix/batch_csr.hpp
+++ b/include/ginkgo/core/matrix/batch_csr.hpp
@@ -75,7 +75,7 @@ class BatchCsr
       public BatchReadableFromMatrixData<ValueType, IndexType>,
       public BatchWritableToMatrixData<ValueType, IndexType>,
       public BatchTransposable,
-      public EnableBatchScaling<ValueType> {
+      public EnableBatchScaling {
     friend class EnableCreateMethod<BatchCsr>;
     friend class EnablePolymorphicObject<BatchCsr, BatchLinOp>;
     friend class BatchCsr<to_complex<ValueType>, IndexType>;

--- a/include/ginkgo/core/matrix/batch_ell.hpp
+++ b/include/ginkgo/core/matrix/batch_ell.hpp
@@ -76,7 +76,7 @@ class BatchEll
       public BatchReadableFromMatrixData<ValueType, IndexType>,
       public BatchWritableToMatrixData<ValueType, IndexType>,
       public BatchTransposable,
-      public EnableBatchScaling<ValueType> {
+      public EnableBatchScaling {
     friend class EnableCreateMethod<BatchEll>;
     friend class EnablePolymorphicObject<BatchEll, BatchLinOp>;
     friend class BatchEll<to_complex<ValueType>, IndexType>;

--- a/include/ginkgo/core/solver/batch_bicgstab.hpp
+++ b/include/ginkgo/core/solver/batch_bicgstab.hpp
@@ -132,7 +132,7 @@ protected:
 
 private:
     void solver_apply(const BatchLinOp* mtx, const BatchLinOp* b, BatchLinOp* x,
-                      BatchInfo& info) const override;
+                      BatchInfo* const info) const override;
 };
 
 

--- a/include/ginkgo/core/solver/batch_bicgstab.hpp
+++ b/include/ginkgo/core/solver/batch_bicgstab.hpp
@@ -119,9 +119,6 @@ public:
     GKO_ENABLE_BUILD_METHOD(Factory);
 
 protected:
-    void solver_apply(const BatchLinOp* const mtx, const BatchLinOp* const b,
-                      BatchLinOp* const x, BatchInfo& info) const override;
-
     explicit BatchBicgstab(std::shared_ptr<const Executor> exec)
         : EnableBatchSolver<BatchBicgstab>(std::move(exec))
     {}
@@ -132,6 +129,10 @@ protected:
                                            std::move(system_matrix)),
           parameters_{factory->get_parameters()}
     {}
+
+private:
+    void solver_apply(const BatchLinOp* mtx, const BatchLinOp* b, BatchLinOp* x,
+                      BatchInfo& info) const override;
 };
 
 

--- a/include/ginkgo/core/solver/batch_bicgstab.hpp
+++ b/include/ginkgo/core/solver/batch_bicgstab.hpp
@@ -41,8 +41,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <ginkgo/core/base/lin_op.hpp>
 #include <ginkgo/core/base/types.hpp>
 #include <ginkgo/core/matrix/batch_dense.hpp>
-#include <ginkgo/core/matrix/identity.hpp>
 #include <ginkgo/core/preconditioner/batch_preconditioner_types.hpp>
+#include <ginkgo/core/solver/batch_solver.hpp>
 #include <ginkgo/core/stop/batch_stop_enum.hpp>
 
 
@@ -68,9 +68,9 @@ namespace solver {
  * @ingroup BatchLinOp
  */
 template <typename ValueType = default_precision>
-class BatchBicgstab : public EnableBatchLinOp<BatchBicgstab<ValueType>>,
-                      public BatchTransposable,
-                      public EnableBatchScaledSolver<ValueType> {
+class BatchBicgstab
+    : public EnableBatchSolver<ValueType, BatchBicgstab<ValueType>>,
+      public BatchTransposable {
     friend class EnableBatchLinOp<BatchBicgstab>;
     friend class EnablePolymorphicObject<BatchBicgstab, BatchLinOp>;
 
@@ -78,16 +78,6 @@ public:
     using value_type = ValueType;
     using real_type = gko::remove_complex<ValueType>;
     using transposed_type = BatchBicgstab<ValueType>;
-
-    /**
-     * Returns the system operator (matrix) of the linear system.
-     *
-     * @return the system operator (matrix)
-     */
-    std::shared_ptr<const BatchLinOp> get_system_matrix() const
-    {
-        return system_matrix_;
-    }
 
     std::unique_ptr<BatchLinOp> transpose() const override;
 
@@ -107,12 +97,6 @@ public:
          */
         preconditioner::batch::type GKO_FACTORY_PARAMETER_SCALAR(
             preconditioner, preconditioner::batch::type::none);
-
-        /**
-         * Number of shared vectors.
-         * TODO: Remove this
-         */
-        int GKO_FACTORY_PARAMETER_SCALAR(num_shared_vectors, 10);
 
         /**
          * Maximum number iterations allowed.
@@ -136,28 +120,24 @@ public:
     GKO_ENABLE_BUILD_METHOD(Factory);
 
 protected:
-    void apply_impl(const BatchLinOp* b, BatchLinOp* x) const override;
+    void solver_apply(const BatchLinOp* const mtx,
+                      const matrix::BatchDense<value_type>* const b,
+                      matrix::BatchDense<value_type>* const x,
+                      BatchInfo<value_type>& info) const override;
 
     void apply_impl(const BatchLinOp* alpha, const BatchLinOp* b,
                     const BatchLinOp* beta, BatchLinOp* x) const override;
 
     explicit BatchBicgstab(std::shared_ptr<const Executor> exec)
-        : EnableBatchLinOp<BatchBicgstab>(std::move(exec))
+        : EnableBatchSolver<ValueType, BatchBicgstab>(std::move(exec))
     {}
 
     explicit BatchBicgstab(const Factory* factory,
                            std::shared_ptr<const BatchLinOp> system_matrix)
-        : EnableBatchLinOp<BatchBicgstab>(
-              factory->get_executor(),
-              gko::transpose(system_matrix->get_size())),
-          parameters_{factory->get_parameters()},
-          system_matrix_{std::move(system_matrix)}
-    {
-        GKO_ASSERT_BATCH_HAS_SQUARE_MATRICES(system_matrix_);
-    }
-
-private:
-    std::shared_ptr<const BatchLinOp> system_matrix_{};
+        : EnableBatchSolver<ValueType, BatchBicgstab>(factory->get_executor(),
+                                                      std::move(system_matrix)),
+          parameters_{factory->get_parameters()}
+    {}
 };
 
 

--- a/include/ginkgo/core/solver/batch_bicgstab.hpp
+++ b/include/ginkgo/core/solver/batch_bicgstab.hpp
@@ -68,9 +68,8 @@ namespace solver {
  * @ingroup BatchLinOp
  */
 template <typename ValueType = default_precision>
-class BatchBicgstab
-    : public EnableBatchSolver<ValueType, BatchBicgstab<ValueType>>,
-      public BatchTransposable {
+class BatchBicgstab : public EnableBatchSolver<BatchBicgstab<ValueType>>,
+                      public BatchTransposable {
     friend class EnableBatchLinOp<BatchBicgstab>;
     friend class EnablePolymorphicObject<BatchBicgstab, BatchLinOp>;
 
@@ -120,22 +119,20 @@ public:
     GKO_ENABLE_BUILD_METHOD(Factory);
 
 protected:
-    void solver_apply(const BatchLinOp* const mtx,
-                      const matrix::BatchDense<value_type>* const b,
-                      matrix::BatchDense<value_type>* const x,
-                      BatchInfo<value_type>& info) const override;
+    void solver_apply(const BatchLinOp* const mtx, const BatchLinOp* const b,
+                      BatchLinOp* const x, BatchInfo& info) const override;
 
     void apply_impl(const BatchLinOp* alpha, const BatchLinOp* b,
                     const BatchLinOp* beta, BatchLinOp* x) const override;
 
     explicit BatchBicgstab(std::shared_ptr<const Executor> exec)
-        : EnableBatchSolver<ValueType, BatchBicgstab>(std::move(exec))
+        : EnableBatchSolver<BatchBicgstab>(std::move(exec))
     {}
 
     explicit BatchBicgstab(const Factory* factory,
                            std::shared_ptr<const BatchLinOp> system_matrix)
-        : EnableBatchSolver<ValueType, BatchBicgstab>(factory->get_executor(),
-                                                      std::move(system_matrix)),
+        : EnableBatchSolver<BatchBicgstab>(factory->get_executor(),
+                                           std::move(system_matrix)),
           parameters_{factory->get_parameters()}
     {}
 };

--- a/include/ginkgo/core/solver/batch_bicgstab.hpp
+++ b/include/ginkgo/core/solver/batch_bicgstab.hpp
@@ -122,9 +122,6 @@ protected:
     void solver_apply(const BatchLinOp* const mtx, const BatchLinOp* const b,
                       BatchLinOp* const x, BatchInfo& info) const override;
 
-    void apply_impl(const BatchLinOp* alpha, const BatchLinOp* b,
-                    const BatchLinOp* beta, BatchLinOp* x) const override;
-
     explicit BatchBicgstab(std::shared_ptr<const Executor> exec)
         : EnableBatchSolver<BatchBicgstab>(std::move(exec))
     {}

--- a/include/ginkgo/core/solver/batch_cg.hpp
+++ b/include/ginkgo/core/solver/batch_cg.hpp
@@ -120,9 +120,6 @@ public:
     GKO_ENABLE_BUILD_METHOD(Factory);
 
 protected:
-    void solver_apply(const BatchLinOp* const mtx, const BatchLinOp* const b,
-                      BatchLinOp* const x, BatchInfo& info) const override;
-
     explicit BatchCg(std::shared_ptr<const Executor> exec)
         : EnableBatchSolver<BatchCg>(std::move(exec))
     {}
@@ -133,6 +130,10 @@ protected:
                                      std::move(system_matrix)),
           parameters_{factory->get_parameters()}
     {}
+
+private:
+    void solver_apply(const BatchLinOp* mtx, const BatchLinOp* b, BatchLinOp* x,
+                      BatchInfo& info) const override;
 };
 
 

--- a/include/ginkgo/core/solver/batch_cg.hpp
+++ b/include/ginkgo/core/solver/batch_cg.hpp
@@ -133,7 +133,7 @@ protected:
 
 private:
     void solver_apply(const BatchLinOp* mtx, const BatchLinOp* b, BatchLinOp* x,
-                      BatchInfo& info) const override;
+                      BatchInfo* const info) const override;
 };
 
 

--- a/include/ginkgo/core/solver/batch_cg.hpp
+++ b/include/ginkgo/core/solver/batch_cg.hpp
@@ -123,9 +123,6 @@ protected:
     void solver_apply(const BatchLinOp* const mtx, const BatchLinOp* const b,
                       BatchLinOp* const x, BatchInfo& info) const override;
 
-    void apply_impl(const BatchLinOp* alpha, const BatchLinOp* b,
-                    const BatchLinOp* beta, BatchLinOp* x) const override;
-
     explicit BatchCg(std::shared_ptr<const Executor> exec)
         : EnableBatchSolver<BatchCg>(std::move(exec))
     {}

--- a/include/ginkgo/core/solver/batch_cg.hpp
+++ b/include/ginkgo/core/solver/batch_cg.hpp
@@ -71,7 +71,7 @@ namespace solver {
  * @ingroup BatchLinOp
  */
 template <typename ValueType = default_precision>
-class BatchCg : public EnableBatchSolver<ValueType, BatchCg<ValueType>>,
+class BatchCg : public EnableBatchSolver<BatchCg<ValueType>>,
                 public BatchTransposable {
     friend class EnableBatchLinOp<BatchCg>;
     friend class EnablePolymorphicObject<BatchCg, BatchLinOp>;
@@ -120,22 +120,20 @@ public:
     GKO_ENABLE_BUILD_METHOD(Factory);
 
 protected:
-    void solver_apply(const BatchLinOp* const mtx,
-                      const matrix::BatchDense<value_type>* const b,
-                      matrix::BatchDense<value_type>* const x,
-                      BatchInfo<value_type>& info) const override;
+    void solver_apply(const BatchLinOp* const mtx, const BatchLinOp* const b,
+                      BatchLinOp* const x, BatchInfo& info) const override;
 
     void apply_impl(const BatchLinOp* alpha, const BatchLinOp* b,
                     const BatchLinOp* beta, BatchLinOp* x) const override;
 
     explicit BatchCg(std::shared_ptr<const Executor> exec)
-        : EnableBatchSolver<ValueType, BatchCg>(std::move(exec))
+        : EnableBatchSolver<BatchCg>(std::move(exec))
     {}
 
     explicit BatchCg(const Factory* factory,
                      std::shared_ptr<const BatchLinOp> system_matrix)
-        : EnableBatchSolver<ValueType, BatchCg>(factory->get_executor(),
-                                                std::move(system_matrix)),
+        : EnableBatchSolver<BatchCg>(factory->get_executor(),
+                                     std::move(system_matrix)),
           parameters_{factory->get_parameters()}
     {}
 };

--- a/include/ginkgo/core/solver/batch_gmres.hpp
+++ b/include/ginkgo/core/solver/batch_gmres.hpp
@@ -137,9 +137,6 @@ public:
     GKO_ENABLE_BUILD_METHOD(Factory);
 
 protected:
-    void solver_apply(const BatchLinOp* const mtx, const BatchLinOp* b,
-                      BatchLinOp* x, BatchInfo& info) const override;
-
     explicit BatchGmres(std::shared_ptr<const Executor> exec)
         : EnableBatchSolver<BatchGmres>(std::move(exec))
     {}
@@ -150,6 +147,10 @@ protected:
                                         std::move(system_matrix)),
           parameters_{factory->get_parameters()}
     {}
+
+private:
+    void solver_apply(const BatchLinOp* mtx, const BatchLinOp* b, BatchLinOp* x,
+                      BatchInfo& info) const override;
 };
 
 

--- a/include/ginkgo/core/solver/batch_gmres.hpp
+++ b/include/ginkgo/core/solver/batch_gmres.hpp
@@ -150,7 +150,7 @@ protected:
 
 private:
     void solver_apply(const BatchLinOp* mtx, const BatchLinOp* b, BatchLinOp* x,
-                      BatchInfo& info) const override;
+                      BatchInfo* const info) const override;
 };
 
 

--- a/include/ginkgo/core/solver/batch_gmres.hpp
+++ b/include/ginkgo/core/solver/batch_gmres.hpp
@@ -68,7 +68,7 @@ namespace solver {
  * @ingroup BatchLinOp
  */
 template <typename ValueType = default_precision>
-class BatchGmres : public EnableBatchSolver<ValueType, BatchGmres<ValueType>>,
+class BatchGmres : public EnableBatchSolver<BatchGmres<ValueType>>,
                    public BatchTransposable {
     friend class EnableBatchLinOp<BatchGmres>;
     friend class EnablePolymorphicObject<BatchGmres, BatchLinOp>;
@@ -137,22 +137,20 @@ public:
     GKO_ENABLE_BUILD_METHOD(Factory);
 
 protected:
-    void solver_apply(const BatchLinOp* const mtx,
-                      const matrix::BatchDense<value_type>* const b,
-                      matrix::BatchDense<value_type>* const x,
-                      BatchInfo<value_type>& info) const override;
+    void solver_apply(const BatchLinOp* const mtx, const BatchLinOp* b,
+                      BatchLinOp* x, BatchInfo& info) const override;
 
     void apply_impl(const BatchLinOp* alpha, const BatchLinOp* b,
                     const BatchLinOp* beta, BatchLinOp* x) const override;
 
     explicit BatchGmres(std::shared_ptr<const Executor> exec)
-        : EnableBatchSolver<ValueType, BatchGmres>(std::move(exec))
+        : EnableBatchSolver<BatchGmres>(std::move(exec))
     {}
 
     explicit BatchGmres(const Factory* factory,
                         std::shared_ptr<const BatchLinOp> system_matrix)
-        : EnableBatchSolver<ValueType, BatchGmres>(factory->get_executor(),
-                                                   std::move(system_matrix)),
+        : EnableBatchSolver<BatchGmres>(factory->get_executor(),
+                                        std::move(system_matrix)),
           parameters_{factory->get_parameters()}
     {}
 };

--- a/include/ginkgo/core/solver/batch_gmres.hpp
+++ b/include/ginkgo/core/solver/batch_gmres.hpp
@@ -140,9 +140,6 @@ protected:
     void solver_apply(const BatchLinOp* const mtx, const BatchLinOp* b,
                       BatchLinOp* x, BatchInfo& info) const override;
 
-    void apply_impl(const BatchLinOp* alpha, const BatchLinOp* b,
-                    const BatchLinOp* beta, BatchLinOp* x) const override;
-
     explicit BatchGmres(std::shared_ptr<const Executor> exec)
         : EnableBatchSolver<BatchGmres>(std::move(exec))
     {}

--- a/include/ginkgo/core/solver/batch_idr.hpp
+++ b/include/ginkgo/core/solver/batch_idr.hpp
@@ -256,9 +256,6 @@ protected:
     void solver_apply(const BatchLinOp* const mtx, const BatchLinOp* const b,
                       BatchLinOp* const x, BatchInfo& info) const override;
 
-    void apply_impl(const BatchLinOp* alpha, const BatchLinOp* b,
-                    const BatchLinOp* beta, BatchLinOp* x) const override;
-
     explicit BatchIdr(std::shared_ptr<const Executor> exec)
         : EnableBatchSolver<BatchIdr>(std::move(exec))
     {}

--- a/include/ginkgo/core/solver/batch_idr.hpp
+++ b/include/ginkgo/core/solver/batch_idr.hpp
@@ -266,7 +266,7 @@ protected:
 
 private:
     void solver_apply(const BatchLinOp* mtx, const BatchLinOp* b, BatchLinOp* x,
-                      BatchInfo& info) const override;
+                      BatchInfo* const info) const override;
 };
 
 

--- a/include/ginkgo/core/solver/batch_idr.hpp
+++ b/include/ginkgo/core/solver/batch_idr.hpp
@@ -253,9 +253,6 @@ public:
     GKO_ENABLE_BUILD_METHOD(Factory);
 
 protected:
-    void solver_apply(const BatchLinOp* const mtx, const BatchLinOp* const b,
-                      BatchLinOp* const x, BatchInfo& info) const override;
-
     explicit BatchIdr(std::shared_ptr<const Executor> exec)
         : EnableBatchSolver<BatchIdr>(std::move(exec))
     {}
@@ -268,7 +265,8 @@ protected:
     {}
 
 private:
-    std::shared_ptr<const BatchLinOp> system_matrix_{};
+    void solver_apply(const BatchLinOp* mtx, const BatchLinOp* b, BatchLinOp* x,
+                      BatchInfo& info) const override;
 };
 
 

--- a/include/ginkgo/core/solver/batch_idr.hpp
+++ b/include/ginkgo/core/solver/batch_idr.hpp
@@ -74,7 +74,7 @@ namespace solver {
  * @ingroup BatchLinOp
  */
 template <typename ValueType = default_precision>
-class BatchIdr : public EnableBatchSolver<ValueType, BatchIdr<ValueType>>,
+class BatchIdr : public EnableBatchSolver<BatchIdr<ValueType>>,
                  public BatchTransposable {
     friend class EnableBatchLinOp<BatchIdr>;
     friend class EnablePolymorphicObject<BatchIdr, BatchLinOp>;
@@ -253,22 +253,20 @@ public:
     GKO_ENABLE_BUILD_METHOD(Factory);
 
 protected:
-    void solver_apply(const BatchLinOp* const mtx,
-                      const matrix::BatchDense<value_type>* const b,
-                      matrix::BatchDense<value_type>* const x,
-                      BatchInfo<value_type>& info) const override;
+    void solver_apply(const BatchLinOp* const mtx, const BatchLinOp* const b,
+                      BatchLinOp* const x, BatchInfo& info) const override;
 
     void apply_impl(const BatchLinOp* alpha, const BatchLinOp* b,
                     const BatchLinOp* beta, BatchLinOp* x) const override;
 
     explicit BatchIdr(std::shared_ptr<const Executor> exec)
-        : EnableBatchSolver<ValueType, BatchIdr>(std::move(exec))
+        : EnableBatchSolver<BatchIdr>(std::move(exec))
     {}
 
     explicit BatchIdr(const Factory* factory,
                       std::shared_ptr<const BatchLinOp> system_matrix)
-        : EnableBatchSolver<ValueType, BatchIdr>(factory->get_executor(),
-                                                 std::move(system_matrix)),
+        : EnableBatchSolver<BatchIdr>(factory->get_executor(),
+                                      std::move(system_matrix)),
           parameters_{factory->get_parameters()}
     {}
 

--- a/include/ginkgo/core/solver/batch_richardson.hpp
+++ b/include/ginkgo/core/solver/batch_richardson.hpp
@@ -137,9 +137,6 @@ protected:
     void solver_apply(const BatchLinOp* const mtx, const BatchLinOp* const b,
                       BatchLinOp* const x, BatchInfo& info) const override;
 
-    void apply_impl(const BatchLinOp* alpha, const BatchLinOp* b,
-                    const BatchLinOp* beta, BatchLinOp* x) const override;
-
     explicit BatchRichardson(std::shared_ptr<const Executor> exec)
         : EnableBatchSolver<BatchRichardson>(std::move(exec))
     {}

--- a/include/ginkgo/core/solver/batch_richardson.hpp
+++ b/include/ginkgo/core/solver/batch_richardson.hpp
@@ -147,7 +147,7 @@ protected:
 
 private:
     void solver_apply(const BatchLinOp* mtx, const BatchLinOp* b, BatchLinOp* x,
-                      BatchInfo& info) const override;
+                      BatchInfo* const info) const override;
 };
 
 

--- a/include/ginkgo/core/solver/batch_richardson.hpp
+++ b/include/ginkgo/core/solver/batch_richardson.hpp
@@ -80,9 +80,8 @@ namespace solver {
  * @ingroup BatchLinOp
  */
 template <typename ValueType = default_precision>
-class BatchRichardson
-    : public EnableBatchSolver<ValueType, BatchRichardson<ValueType>>,
-      public BatchTransposable {
+class BatchRichardson : public EnableBatchSolver<BatchRichardson<ValueType>>,
+                        public BatchTransposable {
     friend class EnableBatchLinOp<BatchRichardson>;
     friend class EnablePolymorphicObject<BatchRichardson, BatchLinOp>;
 
@@ -135,22 +134,20 @@ public:
     GKO_ENABLE_BUILD_METHOD(Factory);
 
 protected:
-    void solver_apply(const BatchLinOp* const mtx,
-                      const matrix::BatchDense<value_type>* const b,
-                      matrix::BatchDense<value_type>* const x,
-                      BatchInfo<value_type>& info) const override;
+    void solver_apply(const BatchLinOp* const mtx, const BatchLinOp* const b,
+                      BatchLinOp* const x, BatchInfo& info) const override;
 
     void apply_impl(const BatchLinOp* alpha, const BatchLinOp* b,
                     const BatchLinOp* beta, BatchLinOp* x) const override;
 
     explicit BatchRichardson(std::shared_ptr<const Executor> exec)
-        : EnableBatchSolver<ValueType, BatchRichardson>(std::move(exec))
+        : EnableBatchSolver<BatchRichardson>(std::move(exec))
     {}
 
     explicit BatchRichardson(const Factory* factory,
                              std::shared_ptr<const BatchLinOp> system_matrix)
-        : EnableBatchSolver<ValueType, BatchRichardson>(
-              factory->get_executor(), std::move(system_matrix)),
+        : EnableBatchSolver<BatchRichardson>(factory->get_executor(),
+                                             std::move(system_matrix)),
           parameters_{factory->get_parameters()}
     {}
 };

--- a/include/ginkgo/core/solver/batch_richardson.hpp
+++ b/include/ginkgo/core/solver/batch_richardson.hpp
@@ -134,9 +134,6 @@ public:
     GKO_ENABLE_BUILD_METHOD(Factory);
 
 protected:
-    void solver_apply(const BatchLinOp* const mtx, const BatchLinOp* const b,
-                      BatchLinOp* const x, BatchInfo& info) const override;
-
     explicit BatchRichardson(std::shared_ptr<const Executor> exec)
         : EnableBatchSolver<BatchRichardson>(std::move(exec))
     {}
@@ -147,6 +144,10 @@ protected:
                                              std::move(system_matrix)),
           parameters_{factory->get_parameters()}
     {}
+
+private:
+    void solver_apply(const BatchLinOp* mtx, const BatchLinOp* b, BatchLinOp* x,
+                      BatchInfo& info) const override;
 };
 
 

--- a/include/ginkgo/core/solver/batch_solver.hpp
+++ b/include/ginkgo/core/solver/batch_solver.hpp
@@ -42,18 +42,16 @@ namespace gko {
 namespace solver {
 
 
-template <typename ValueType>
 struct BatchInfo;
 
 
 /**
  * @tparam PolymorphicBase  The base class; must be a subclass of BatchLinOp.
  */
-template <typename ValueType, typename ConcreteSolver,
-          typename PolymorphicBase = BatchLinOp>
+template <typename ConcreteSolver, typename PolymorphicBase = BatchLinOp>
 class EnableBatchSolver
     : public EnableBatchLinOp<ConcreteSolver, PolymorphicBase>,
-      public EnableBatchScaledSolver<ValueType> {
+      public EnableBatchScaling {
 public:
     /**
      * Returns the system operator (matrix) of the linear system.
@@ -65,14 +63,19 @@ public:
         return system_matrix_;
     }
 
-private:
-    using value_type = ValueType;
-
 protected:
-    virtual void solver_apply(const BatchLinOp* const mtx,
-                              const matrix::BatchDense<value_type>* const b,
-                              matrix::BatchDense<value_type>* const x,
-                              BatchInfo<value_type>& info) const = 0;
+    /**
+     * Calls the concrete solver on the given system (not necessarily on
+     * system_matrix_).
+     *
+     * @param mtx  Left-hand side matrix for the linear solve.
+     * @param b  Right-hand side vector.
+     * @param x  Solution vector and initial guess.
+     * @param info  Batch logging information. NOTE: This may change in the
+     *              future.
+     */
+    virtual void solver_apply(const BatchLinOp* const mtx, const BatchLinOp* b,
+                              BatchLinOp* x, BatchInfo& info) const = 0;
 
     explicit EnableBatchSolver(std::shared_ptr<const Executor> exec)
         : EnableBatchLinOp<ConcreteSolver, PolymorphicBase>(std::move(exec))

--- a/include/ginkgo/core/solver/batch_solver.hpp
+++ b/include/ginkgo/core/solver/batch_solver.hpp
@@ -1,5 +1,5 @@
 /*******************************<GINKGO LICENSE>******************************
-Copyright (c) 2017-2021, the Ginkgo authors
+Copyright (c) 2017-2022, the Ginkgo authors
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -91,11 +91,10 @@ private:
      * @param mtx  Left-hand side matrix for the linear solve.
      * @param b  Right-hand side vector.
      * @param x  Solution vector and initial guess.
-     * @param info  Batch logging information. NOTE: This may change in the
-     *              future.
+     * @param info  Batch logging information.
      */
     virtual void solver_apply(const BatchLinOp* mtx, const BatchLinOp* b,
-                              BatchLinOp* x, BatchInfo& info) const = 0;
+                              BatchLinOp* x, BatchInfo* const info) const = 0;
 };
 
 

--- a/include/ginkgo/core/solver/batch_solver.hpp
+++ b/include/ginkgo/core/solver/batch_solver.hpp
@@ -91,6 +91,9 @@ protected:
 
     void apply_impl(const BatchLinOp* b, BatchLinOp* x) const override;
 
+    void apply_impl(const BatchLinOp* alpha, const BatchLinOp* b,
+                    const BatchLinOp* beta, BatchLinOp* x) const override;
+
 private:
     std::shared_ptr<const BatchLinOp> system_matrix_{};
 };

--- a/include/ginkgo/core/solver/batch_solver.hpp
+++ b/include/ginkgo/core/solver/batch_solver.hpp
@@ -35,7 +35,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
 #include <ginkgo/core/matrix/batch_dense.hpp>
-//#include "core/log/batch_logging.hpp"
 
 
 namespace gko {

--- a/include/ginkgo/core/solver/batch_solver.hpp
+++ b/include/ginkgo/core/solver/batch_solver.hpp
@@ -63,19 +63,6 @@ public:
     }
 
 protected:
-    /**
-     * Calls the concrete solver on the given system (not necessarily on
-     * system_matrix_).
-     *
-     * @param mtx  Left-hand side matrix for the linear solve.
-     * @param b  Right-hand side vector.
-     * @param x  Solution vector and initial guess.
-     * @param info  Batch logging information. NOTE: This may change in the
-     *              future.
-     */
-    virtual void solver_apply(const BatchLinOp* const mtx, const BatchLinOp* b,
-                              BatchLinOp* x, BatchInfo& info) const = 0;
-
     explicit EnableBatchSolver(std::shared_ptr<const Executor> exec)
         : EnableBatchLinOp<ConcreteSolver, PolymorphicBase>(std::move(exec))
     {}
@@ -96,6 +83,19 @@ protected:
 
 private:
     std::shared_ptr<const BatchLinOp> system_matrix_{};
+
+    /**
+     * Calls the concrete solver on the given system (not necessarily on
+     * system_matrix_).
+     *
+     * @param mtx  Left-hand side matrix for the linear solve.
+     * @param b  Right-hand side vector.
+     * @param x  Solution vector and initial guess.
+     * @param info  Batch logging information. NOTE: This may change in the
+     *              future.
+     */
+    virtual void solver_apply(const BatchLinOp* mtx, const BatchLinOp* b,
+                              BatchLinOp* x, BatchInfo& info) const = 0;
 };
 
 

--- a/include/ginkgo/core/solver/batch_solver.hpp
+++ b/include/ginkgo/core/solver/batch_solver.hpp
@@ -1,0 +1,100 @@
+/*******************************<GINKGO LICENSE>******************************
+Copyright (c) 2017-2021, the Ginkgo authors
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+******************************<GINKGO LICENSE>*******************************/
+
+#ifndef GKO_PUBLIC_CORE_SOLVER_BATCH_SOLVER_HPP_
+#define GKO_PUBLIC_CORE_SOLVER_BATCH_SOLVER_HPP_
+
+
+#include <ginkgo/core/matrix/batch_dense.hpp>
+//#include "core/log/batch_logging.hpp"
+
+
+namespace gko {
+namespace solver {
+
+
+template <typename ValueType>
+struct BatchInfo;
+
+
+/**
+ * @tparam PolymorphicBase  The base class; must be a subclass of BatchLinOp.
+ */
+template <typename ValueType, typename ConcreteSolver,
+          typename PolymorphicBase = BatchLinOp>
+class EnableBatchSolver
+    : public EnableBatchLinOp<ConcreteSolver, PolymorphicBase>,
+      public EnableBatchScaledSolver<ValueType> {
+public:
+    /**
+     * Returns the system operator (matrix) of the linear system.
+     *
+     * @return the system operator (matrix)
+     */
+    std::shared_ptr<const BatchLinOp> get_system_matrix() const
+    {
+        return system_matrix_;
+    }
+
+private:
+    using value_type = ValueType;
+
+protected:
+    virtual void solver_apply(const BatchLinOp* const mtx,
+                              const matrix::BatchDense<value_type>* const b,
+                              matrix::BatchDense<value_type>* const x,
+                              BatchInfo<value_type>& info) const = 0;
+
+    explicit EnableBatchSolver(std::shared_ptr<const Executor> exec)
+        : EnableBatchLinOp<ConcreteSolver, PolymorphicBase>(std::move(exec))
+    {}
+
+    explicit EnableBatchSolver(std::shared_ptr<const Executor> exec,
+                               std::shared_ptr<const BatchLinOp> system_matrix)
+        : EnableBatchLinOp<ConcreteSolver, PolymorphicBase>(
+              exec, gko::transpose(system_matrix->get_size())),
+          system_matrix_{std::move(system_matrix)}
+    {
+        GKO_ASSERT_BATCH_HAS_SQUARE_MATRICES(system_matrix_);
+    }
+
+    void apply_impl(const BatchLinOp* b, BatchLinOp* x) const override;
+
+private:
+    std::shared_ptr<const BatchLinOp> system_matrix_{};
+};
+
+
+}  // namespace solver
+}  // namespace gko
+
+#endif  // GKO_PUBLIC_CORE_SOLVER_BATCH_SOLVER_HPP_

--- a/include/ginkgo/ginkgo.hpp
+++ b/include/ginkgo/ginkgo.hpp
@@ -123,6 +123,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <ginkgo/core/solver/batch_gmres.hpp>
 #include <ginkgo/core/solver/batch_idr.hpp>
 #include <ginkgo/core/solver/batch_richardson.hpp>
+#include <ginkgo/core/solver/batch_solver.hpp>
 #include <ginkgo/core/solver/bicg.hpp>
 #include <ginkgo/core/solver/bicgstab.hpp>
 #include <ginkgo/core/solver/cb_gmres.hpp>

--- a/reference/stop/batch_criteria.hpp
+++ b/reference/stop/batch_criteria.hpp
@@ -34,6 +34,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define GKO_REFERENCE_STOP_BATCH_CRITERIA_HPP_
 
 
+#include <ginkgo/core/base/math.hpp>
 #include <ginkgo/core/base/types.hpp>
 #include <ginkgo/core/stop/batch_stop_enum.hpp>
 


### PR DESCRIPTION
This adds an `EnableBatchSolver` CRTP class for holding the common functionality shared by all batched iterative solvers. The common code is in an "ipp" file, which is unconventional for Ginkgo.

Things to be addressed here or in the next PR:
- Passing the logger from the concrete solvers back to the calling `EnableBatchSolver::apply_impl`. This is somewhat ugly right now.
- The "batch scaling" stuff (`EnableBatchScaling`, `EnableBatchScaledSolver`) might be removed in a future PR in favour of batch diagonal and batch identity matrices and their operations.