### PR TITLE
Exclude CUDA 11.3.0 from the triangular solver

### DIFF
--- a/cuda/base/cusparse_bindings.hpp
+++ b/cuda/base/cusparse_bindings.hpp
@@ -879,7 +879,7 @@ inline void destroy(cusparseSpMatDescr_t descr)
 }
 
 
-#if (CUDA_VERSION >= 11030)
+#if (CUDA_VERSION >= 11031)
 
 
 template <typename AttribType>
@@ -905,7 +905,7 @@ inline void destroy(cusparseSpSMDescr_t info)
 }
 
 
-#endif  // CUDA_VERSION >= 11030
+#endif  // CUDA_VERSION >= 11031
 
 
 #endif  // defined(CUDA_VERSION) && (CUDA_VERSION >= 11000)
@@ -1108,7 +1108,7 @@ GKO_BIND_CUSPARSE64_CSRSM2_SOLVE(ValueType, detail::not_implemented);
 #undef GKO_BIND_CUSPARSE64_CSRSM2_SOLVE
 
 
-#if (defined(CUDA_VERSION) && (CUDA_VERSION >= 11030))
+#if (defined(CUDA_VERSION) && (CUDA_VERSION >= 11031))
 
 
 template <typename ValueType>
@@ -1153,7 +1153,7 @@ void spsm_solve(cusparseHandle_t handle, cusparseOperation_t op_a,
 }
 
 
-#endif  // (defined(CUDA_VERSION) && (CUDA_VERSION >= 11030))
+#endif  // (defined(CUDA_VERSION) && (CUDA_VERSION >= 11031))
 
 
 template <typename IndexType>

--- a/cuda/solver/common_trs_kernels.cuh
+++ b/cuda/solver/common_trs_kernels.cuh
@@ -75,7 +75,7 @@ namespace cuda {
 namespace {
 
 
-#if (defined(CUDA_VERSION) && (CUDA_VERSION >= 11030))
+#if (defined(CUDA_VERSION) && (CUDA_VERSION >= 11031))
 
 
 template <typename ValueType, typename IndexType>

--- a/cuda/test/solver/lower_trs_kernels.cpp
+++ b/cuda/test/solver/lower_trs_kernels.cpp
@@ -199,7 +199,7 @@ TEST_F(LowerTrs, CudaMultipleRhsApplyIsEquivalentToRef)
     d_b2->convert_to(db2_strided.get());
     // The cuSPARSE Generic SpSM implementation uses the wrong stride here
     // so the input and output stride need to match
-#if CUDA_VERSION >= 11030
+#if CUDA_VERSION >= 11031
     auto dx_strided = Mtx::create(cuda, x->get_size(), 4);
 #else
     auto dx_strided = Mtx::create(cuda, x->get_size(), 5);


### PR DESCRIPTION
Only CUDA 11.3.1 starts to support `cusparseSpSM` (see the [CUDA documentation for 11.3.1](https://docs.nvidia.com/cuda/archive/11.3.1/cusparse/index.html#cusparse-generic-function-spsm)), version 11.3.0 does not support it yet (`cusparseSpSM` is not present in [CUDA documentation for 11.3.0](https://docs.nvidia.com/cuda/archive/11.3.0/cusparse/index.html)).