### PR TITLE
Change random number generator and update gtest

### DIFF
--- a/benchmark/matrix_generator/matrix_generator.cpp
+++ b/benchmark/matrix_generator/matrix_generator.cpp
@@ -97,12 +97,12 @@ void validate_option_object(const rapidjson::Value& value)
 
 
 using generator_function = std::function<gko::matrix_data<etype, itype>(
-    rapidjson::Value&, std::ranlux24&)>;
+    rapidjson::Value&, std::default_random_engine&)>;
 
 
 // matrix generators
-gko::matrix_data<etype, itype> generate_block_diagonal(rapidjson::Value& config,
-                                                       std::ranlux24& engine)
+gko::matrix_data<etype, itype> generate_block_diagonal(
+    rapidjson::Value& config, std::default_random_engine& engine)
 {
     if (!config.HasMember("num_blocks") || !config["num_blocks"].IsUint() ||
         !config.HasMember("block_size") || !config["block_size"].IsUint()) {

--- a/benchmark/utils/general.hpp
+++ b/benchmark/utils/general.hpp
@@ -196,9 +196,9 @@ std::unique_ptr<gko::LinOp> read_matrix(
 
 
 // Returns a random number engine
-std::ranlux24& get_engine()
+std::default_random_engine& get_engine()
 {
-    static std::ranlux24 engine(FLAGS_seed);
+    static std::default_random_engine engine(FLAGS_seed);
     return engine;
 }
 

--- a/core/test/base/matrix_data.cpp
+++ b/core/test/base/matrix_data.cpp
@@ -83,7 +83,7 @@ TEST(MatrixData, InitializesWithRandomValues)
 
     gko::matrix_data<double, int> m(
         gko::dim<2>{2, 3}, std::uniform_real_distribution<double>(-1, 1),
-        std::ranlux48(19));
+        std::default_random_engine(19));
 
     ASSERT_EQ(m.size, gko::dim<2>(2, 3));
     ASSERT_LE(m.nonzeros.size(), 6);
@@ -262,7 +262,7 @@ TEST(MatrixData, InitializesDiagonalWithConditionNumber)
 
     const auto m =
         data::cond(3, 100.0, std::uniform_real_distribution<double>(-1, 1),
-                   std::ranlux48(42), 0);
+                   std::default_random_engine(42), 0);
 
     ASSERT_EQ(m.size, gko::dim<2>(3, 3));
     ASSERT_NEAR(m.nonzeros[0].value / m.nonzeros[2].value, 100.0, 1e-16);
@@ -322,7 +322,8 @@ TEST(MatrixData, InitializesGeneralMatrixWithConditionNumber)
     using data = gko::matrix_data<double, int>;
     using nnz = data::nonzero_type;
 
-    const auto m = data::cond(2, 4.0, dummy_distribution{}, std::ranlux48(42));
+    const auto m = data::cond(2, 4.0, dummy_distribution{},
+                              std::default_random_engine(42));
 
     ASSERT_EQ(m.size, gko::dim<2>(2, 2));
     ASSERT_EQ(m.nonzeros.size(), 4);

--- a/core/test/utils/array_generator_test.cpp
+++ b/core/test/utils/array_generator_test.cpp
@@ -54,7 +54,7 @@ protected:
     {
         array = gko::test::generate_random_array<T>(
             500, std::normal_distribution<gko::remove_complex<T>>(20.0, 5.0),
-            std::ranlux48(42), exec);
+            std::default_random_engine(42), exec);
     }
 
     std::shared_ptr<const gko::Executor> exec;

--- a/core/test/utils/fb_matrix_generator.hpp
+++ b/core/test/utils/fb_matrix_generator.hpp
@@ -131,7 +131,8 @@ std::unique_ptr<MatrixType> generate_random_matrix_with_diag(
  * @param row_diag_dominant  If true, a row-diagonal-dominant Fbcsr matrix is
  *                           generated. Note that in this case, the intput Csr
  *                           matrix must have diagonal entries in all rows.
- * @param rand_engine  Random number engine to use, such as std::ranlux48.
+ * @param rand_engine  Random number engine to use, such as
+ * std::default_random_engine.
  */
 template <typename ValueType, typename IndexType, typename RandEngine>
 std::unique_ptr<matrix::Fbcsr<ValueType, IndexType>> generate_fbcsr_from_csr(
@@ -219,7 +220,8 @@ std::unique_ptr<matrix::Fbcsr<ValueType, IndexType>> generate_fbcsr_from_csr(
  * @param unsort  If true, the blocks of the generated matrix within each
  *                block-row are ordered randomly. Otherwise, blocks in each row
  *                are ordered by block-column index.
- * @param engine  Random number engine to use, such as std::ranlux48.
+ * @param engine  Random number engine to use, such as
+ * std::default_random_engine.
  */
 template <typename ValueType, typename IndexType, typename RandEngine>
 std::unique_ptr<matrix::Fbcsr<ValueType, IndexType>> generate_random_fbcsr(

--- a/core/test/utils/fb_matrix_generator_test.cpp
+++ b/core/test/utils/fb_matrix_generator_test.cpp
@@ -60,14 +60,15 @@ protected:
           mtx(gko::test::generate_random_matrix<
               gko::matrix::Csr<real_type, int>>(
               nbrows, nbcols, std::normal_distribution<real_type>(10, 5),
-              std::normal_distribution<real_type>(20.0, 5.0), std::ranlux48(42),
-              exec)),
-          rbmtx(gko::test::generate_fbcsr_from_csr(exec, mtx.get(), blk_sz,
-                                                   false, std::ranlux48(42))),
-          rbmtx_dd(gko::test::generate_fbcsr_from_csr(exec, mtx.get(), blk_sz,
-                                                      true, std::ranlux48(42))),
+              std::normal_distribution<real_type>(20.0, 5.0),
+              std::default_random_engine(42), exec)),
+          rbmtx(gko::test::generate_fbcsr_from_csr(
+              exec, mtx.get(), blk_sz, false, std::default_random_engine(42))),
+          rbmtx_dd(gko::test::generate_fbcsr_from_csr(
+              exec, mtx.get(), blk_sz, true, std::default_random_engine(42))),
           cbmtx(gko::test::generate_random_fbcsr<value_type>(
-              exec, nbrows, nbcols, blk_sz, true, false, std::ranlux48(42)))
+              exec, nbrows, nbcols, blk_sz, true, false,
+              std::default_random_engine(42)))
     {}
 
     const int nbrows = 100;

--- a/core/test/utils/matrix_generator_test.cpp
+++ b/core/test/utils/matrix_generator_test.cpp
@@ -57,22 +57,22 @@ protected:
         : exec(gko::ReferenceExecutor::create()),
           mtx(gko::test::generate_random_matrix<mtx_type>(
               500, 100, std::normal_distribution<real_type>(50, 5),
-              std::normal_distribution<real_type>(20.0, 5.0), std::ranlux48(42),
-              exec)),
+              std::normal_distribution<real_type>(20.0, 5.0),
+              std::default_random_engine(42), exec)),
           l_mtx(gko::test::generate_random_lower_triangular_matrix<mtx_type>(
               4, 3, true, std::normal_distribution<real_type>(50, 5),
-              std::normal_distribution<real_type>(20.0, 5.0), std::ranlux48(42),
-              exec)),
+              std::normal_distribution<real_type>(20.0, 5.0),
+              std::default_random_engine(42), exec)),
           u_mtx(gko::test::generate_random_upper_triangular_matrix<mtx_type>(
               3, 4, true, std::normal_distribution<real_type>(50, 5),
-              std::normal_distribution<real_type>(20.0, 5.0), std::ranlux48(42),
-              exec)),
+              std::normal_distribution<real_type>(20.0, 5.0),
+              std::default_random_engine(42), exec)),
           lower_bandwidth(2),
           upper_bandwidth(3),
           band_mtx(gko::test::generate_random_band_matrix<mtx_type>(
               100, lower_bandwidth, upper_bandwidth,
-              std::normal_distribution<real_type>(20.0, 5.0), std::ranlux48(42),
-              exec)),
+              std::normal_distribution<real_type>(20.0, 5.0),
+              std::default_random_engine(42), exec)),
           nnz_per_row_sample(500, 0),
           values_sample(0),
           band_values_sample(0)

--- a/core/test/utils/matrix_utils_test.cpp
+++ b/core/test/utils/matrix_utils_test.cpp
@@ -59,8 +59,8 @@ protected:
         : exec(gko::ReferenceExecutor::create()),
           mtx(gko::test::generate_random_matrix<mtx_type>(
               500, 500, std::normal_distribution<real_type>(50, 5),
-              std::normal_distribution<real_type>(20.0, 5.0), std::ranlux48(42),
-              exec)),
+              std::normal_distribution<real_type>(20.0, 5.0),
+              std::default_random_engine(42), exec)),
           unsquare_mtx(mtx_type::create(exec, gko::dim<2>(500, 100)))
     {}
 

--- a/core/test/utils/unsort_matrix_test.cpp
+++ b/core/test/utils/unsort_matrix_test.cpp
@@ -144,7 +144,7 @@ protected:
     }
 
     std::shared_ptr<const gko::Executor> exec;
-    std::ranlux48 rand_engine;
+    std::default_random_engine rand_engine;
     std::unique_ptr<Csr> csr_empty;
     std::unique_ptr<Coo> coo_empty;
 };

--- a/core/test/utils/value_generator_test.cpp
+++ b/core/test/utils/value_generator_test.cpp
@@ -96,7 +96,7 @@ TYPED_TEST(ValueGenerator, OutputHasCorrectAverageAndDeviation)
     int num = 500;
     std::vector<T> values(num);
     auto dist = std::normal_distribution<double>(20.0, 5.0);
-    auto engine = std::ranlux48(42);
+    auto engine = std::default_random_engine(42);
 
     for (int i = 0; i < num; i++) {
         values.at(i) = gko::test::detail::get_rand_value<T>(dist, engine);

--- a/cuda/solver/idr_kernels.cu
+++ b/cuda/solver/idr_kernels.cu
@@ -96,7 +96,7 @@ void initialize_subspace_vectors(matrix::Dense<ValueType>* subspace_vectors,
     if (deterministic) {
         auto subspace_vectors_data = matrix_data<ValueType>(
             subspace_vectors->get_size(), std::normal_distribution<>(0.0, 1.0),
-            std::ranlux48(15));
+            std::default_random_engine(15));
         subspace_vectors->read(subspace_vectors_data);
     } else {
         auto gen =

--- a/cuda/test/factorization/ic_kernels.cpp
+++ b/cuda/test/factorization/ic_kernels.cpp
@@ -62,7 +62,7 @@ protected:
 
     std::shared_ptr<gko::ReferenceExecutor> ref;
     std::shared_ptr<gko::CudaExecutor> cuda;
-    std::ranlux48 rand_engine;
+    std::default_random_engine rand_engine;
     std::shared_ptr<Csr> csr_ref;
     std::shared_ptr<Csr> csr_cuda;
 

--- a/cuda/test/factorization/ilu_kernels.cpp
+++ b/cuda/test/factorization/ilu_kernels.cpp
@@ -62,7 +62,7 @@ protected:
 
     std::shared_ptr<gko::ReferenceExecutor> ref;
     std::shared_ptr<gko::CudaExecutor> cuda;
-    std::ranlux48 rand_engine;
+    std::default_random_engine rand_engine;
     std::shared_ptr<Csr> csr_ref;
     std::shared_ptr<Csr> csr_cuda;
 

--- a/cuda/test/factorization/par_ilu_kernels.cpp
+++ b/cuda/test/factorization/par_ilu_kernels.cpp
@@ -66,7 +66,7 @@ protected:
     using Coo = gko::matrix::Coo<value_type, index_type>;
     using Csr = gko::matrix::Csr<value_type, index_type>;
 
-    std::ranlux48 rand_engine;
+    std::default_random_engine rand_engine;
     std::shared_ptr<gko::ReferenceExecutor> ref;
     std::shared_ptr<gko::CudaExecutor> cuda;
     std::shared_ptr<const Csr> csr_ref;

--- a/cuda/test/matrix/coo_kernels.cpp
+++ b/cuda/test/matrix/coo_kernels.cpp
@@ -108,7 +108,7 @@ protected:
     std::shared_ptr<gko::ReferenceExecutor> ref;
     std::shared_ptr<const gko::CudaExecutor> cuda;
 
-    std::ranlux48 rand_engine;
+    std::default_random_engine rand_engine;
 
     std::unique_ptr<Mtx> mtx;
     std::unique_ptr<Vec> expected;

--- a/cuda/test/matrix/csr_kernels.cpp
+++ b/cuda/test/matrix/csr_kernels.cpp
@@ -161,7 +161,7 @@ protected:
     std::shared_ptr<const gko::CudaExecutor> cuda;
 
     const gko::dim<2> mtx_size;
-    std::ranlux48 rand_engine;
+    std::default_random_engine rand_engine;
 
     std::unique_ptr<Mtx> mtx;
     std::unique_ptr<Mtx> mtx2;

--- a/cuda/test/matrix/dense_kernels.cpp
+++ b/cuda/test/matrix/dense_kernels.cpp
@@ -160,7 +160,7 @@ protected:
     std::shared_ptr<gko::ReferenceExecutor> ref;
     std::shared_ptr<const gko::CudaExecutor> cuda;
 
-    std::ranlux48 rand_engine;
+    std::default_random_engine rand_engine;
 
     std::unique_ptr<Mtx> x;
     std::unique_ptr<ComplexMtx> c_x;

--- a/cuda/test/matrix/diagonal_kernels.cpp
+++ b/cuda/test/matrix/diagonal_kernels.cpp
@@ -152,7 +152,7 @@ protected:
     std::shared_ptr<const gko::CudaExecutor> cuda;
 
     const gko::dim<2> mtx_size;
-    std::ranlux48 rand_engine;
+    std::default_random_engine rand_engine;
 
     std::unique_ptr<Diag> diag;
     std::unique_ptr<Diag> ddiag;

--- a/cuda/test/matrix/ell_kernels.cpp
+++ b/cuda/test/matrix/ell_kernels.cpp
@@ -118,7 +118,7 @@ protected:
     std::shared_ptr<gko::ReferenceExecutor> ref;
     std::shared_ptr<const gko::CudaExecutor> cuda;
 
-    std::ranlux48 rand_engine;
+    std::default_random_engine rand_engine;
     gko::dim<2> size;
     gko::size_type num_els_rowwise;
     gko::size_type ell_stride;

--- a/cuda/test/matrix/fbcsr_kernels.cpp
+++ b/cuda/test/matrix/fbcsr_kernels.cpp
@@ -73,7 +73,7 @@ protected:
         const int block_size = 3;
         rsorted_ref = gko::test::generate_random_fbcsr<value_type, index_type>(
             ref, rand_brows, rand_bcols, block_size, false, false,
-            std::ranlux48(43));
+            std::default_random_engine(43));
     }
 
     void TearDown()
@@ -89,7 +89,7 @@ protected:
     std::unique_ptr<const Mtx> rsorted_ref;
 
     std::normal_distribution<gko::remove_complex<T>> distb;
-    std::ranlux48 engine;
+    std::default_random_engine engine;
 
     value_type get_random_value()
     {
@@ -161,7 +161,7 @@ TYPED_TEST(Fbcsr, TransposeIsEquivalentToRefSortedBS7)
     auto rsorted_ref2 =
         gko::test::generate_random_fbcsr<value_type, index_type>(
             this->ref, rand_brows, rand_bcols, block_size, false, false,
-            std::ranlux48(43));
+            std::default_random_engine(43));
     rand_cuda->copy_from(gko::lend(rsorted_ref2));
 
     auto trans_ref_linop = rsorted_ref2->transpose();

--- a/cuda/test/matrix/hybrid_kernels.cpp
+++ b/cuda/test/matrix/hybrid_kernels.cpp
@@ -107,7 +107,7 @@ protected:
     std::shared_ptr<gko::ReferenceExecutor> ref;
     std::shared_ptr<const gko::CudaExecutor> cuda;
 
-    std::ranlux48 rand_engine;
+    std::default_random_engine rand_engine;
 
     std::unique_ptr<Mtx> mtx;
     std::unique_ptr<Vec> expected;

--- a/cuda/test/matrix/sellp_kernels.cpp
+++ b/cuda/test/matrix/sellp_kernels.cpp
@@ -105,7 +105,7 @@ protected:
     std::shared_ptr<gko::ReferenceExecutor> ref;
     std::shared_ptr<const gko::CudaExecutor> cuda;
 
-    std::ranlux48 rand_engine;
+    std::default_random_engine rand_engine;
 
     std::unique_ptr<Mtx> mtx;
     std::unique_ptr<Mtx> empty;

--- a/cuda/test/multigrid/amgx_pgm_kernels.cpp
+++ b/cuda/test/multigrid/amgx_pgm_kernels.cpp
@@ -166,7 +166,7 @@ protected:
     std::shared_ptr<gko::ReferenceExecutor> ref;
     std::shared_ptr<const gko::CudaExecutor> cuda;
 
-    std::ranlux48 rand_engine;
+    std::default_random_engine rand_engine;
 
     gko::Array<index_type> agg;
     gko::Array<index_type> unfinished_agg;

--- a/cuda/test/preconditioner/jacobi_kernels.cpp
+++ b/cuda/test/preconditioner/jacobi_kernels.cpp
@@ -78,7 +78,7 @@ protected:
         gko::uint32 max_block_size, int min_nnz, int max_nnz, int num_rhs = 1,
         double accuracy = 0.1, bool skip_sorting = true)
     {
-        std::ranlux48 engine(42);
+        std::default_random_engine engine(42);
         const auto dim = *(end(block_pointers) - 1);
         if (condition_numbers.size() == 0) {
             mtx = gko::test::generate_random_matrix<Mtx>(
@@ -306,7 +306,7 @@ TEST_F(Jacobi, CudaPreconditionerEquivalentToRefWithBlockSize32Sorted)
 
 TEST_F(Jacobi, CudaPreconditionerEquivalentToRefWithBlockSize32Unsorted)
 {
-    std::ranlux48 engine(42);
+    std::default_random_engine engine(42);
     initialize_data({0, 32, 64, 96, 128}, {}, {}, 32, 100, 110, 1, 0.1, false);
     gko::test::unsort_matrix(mtx.get(), engine);
 
@@ -413,7 +413,7 @@ TEST_F(Jacobi, CudaApplyEquivalentToRef)
 TEST_F(Jacobi, CudaScalarApplyEquivalentToRef)
 {
     gko::size_type dim = 313;
-    std::ranlux48 engine(42);
+    std::default_random_engine engine(42);
     auto dense_smtx = gko::share(gko::test::generate_random_matrix<Vec>(
         dim, dim, std::uniform_int_distribution<>(1, dim),
         std::normal_distribution<>(1.0, 2.0), engine, ref));
@@ -462,7 +462,7 @@ TEST_F(Jacobi, CudaLinearCombinationApplyEquivalentToRef)
 TEST_F(Jacobi, CudaScalarLinearCombinationApplyEquivalentToRef)
 {
     gko::size_type dim = 313;
-    std::ranlux48 engine(42);
+    std::default_random_engine engine(42);
     auto dense_smtx = gko::share(gko::test::generate_random_matrix<Vec>(
         dim, dim, std::uniform_int_distribution<>(1, dim),
         std::normal_distribution<>(1.0, 2.0), engine, ref));

--- a/cuda/test/solver/cb_gmres_kernels.cpp
+++ b/cuda/test/solver/cb_gmres_kernels.cpp
@@ -205,7 +205,7 @@ protected:
     std::shared_ptr<gko::ReferenceExecutor> ref;
     std::shared_ptr<const gko::CudaExecutor> cuda;
 
-    std::ranlux48 rand_engine;
+    std::default_random_engine rand_engine;
 
     std::unique_ptr<Mtx> before_preconditioner;
     std::unique_ptr<Mtx> x;

--- a/cuda/test/solver/gmres_kernels.cpp
+++ b/cuda/test/solver/gmres_kernels.cpp
@@ -143,7 +143,7 @@ protected:
     std::shared_ptr<gko::ReferenceExecutor> ref;
     std::shared_ptr<const gko::CudaExecutor> cuda;
 
-    std::ranlux48 rand_engine;
+    std::default_random_engine rand_engine;
 
     std::unique_ptr<Mtx> before_preconditioner;
     std::unique_ptr<Mtx> x;

--- a/cuda/test/solver/idr_kernels.cpp
+++ b/cuda/test/solver/idr_kernels.cpp
@@ -244,13 +244,13 @@ TEST_F(Idr, IdrStep3IsEquivalentToRef)
         cuda, nrhs, k, d_p.get(), d_g.get(), d_v.get(), d_u.get(), d_m.get(),
         d_f.get(), d_alpha.get(), d_r.get(), d_x.get(), d_stop_status.get());
 
-    GKO_ASSERT_MTX_NEAR(g, d_g, 1e-14);
-    GKO_ASSERT_MTX_NEAR(v, d_v, 1e-14);
-    GKO_ASSERT_MTX_NEAR(u, d_u, 1e-14);
-    GKO_ASSERT_MTX_NEAR(m, d_m, 1e-14);
-    GKO_ASSERT_MTX_NEAR(f, d_f, 1e-14);
-    GKO_ASSERT_MTX_NEAR(r, d_r, 1e-14);
-    GKO_ASSERT_MTX_NEAR(x, d_x, 1e-14);
+    GKO_ASSERT_MTX_NEAR(g, d_g, 2 * 1e-14);
+    GKO_ASSERT_MTX_NEAR(v, d_v, 2 * 1e-14);
+    GKO_ASSERT_MTX_NEAR(u, d_u, 2 * 1e-14);
+    GKO_ASSERT_MTX_NEAR(m, d_m, 2 * 1e-14);
+    GKO_ASSERT_MTX_NEAR(f, d_f, 150 * 1e-14);
+    GKO_ASSERT_MTX_NEAR(r, d_r, 50 * 1e-14);
+    GKO_ASSERT_MTX_NEAR(x, d_x, 50 * 1e-14);
 }
 
 

--- a/cuda/test/solver/idr_kernels.cpp
+++ b/cuda/test/solver/idr_kernels.cpp
@@ -144,7 +144,7 @@ protected:
     std::shared_ptr<gko::ReferenceExecutor> ref;
     std::shared_ptr<const gko::CudaExecutor> cuda;
 
-    std::ranlux48 rand_engine;
+    std::default_random_engine rand_engine;
 
     std::shared_ptr<Mtx> mtx;
     std::shared_ptr<Mtx> d_mtx;

--- a/cuda/test/solver/lower_trs_kernels.cpp
+++ b/cuda/test/solver/lower_trs_kernels.cpp
@@ -119,7 +119,7 @@ protected:
     std::shared_ptr<CsrMtx> d_csr_mtx;
     std::shared_ptr<gko::ReferenceExecutor> ref;
     std::shared_ptr<const gko::CudaExecutor> cuda;
-    std::ranlux48 rand_engine;
+    std::default_random_engine rand_engine;
 };
 
 

--- a/cuda/test/solver/multigrid_kernels.cpp
+++ b/cuda/test/solver/multigrid_kernels.cpp
@@ -169,7 +169,7 @@ protected:
     std::shared_ptr<gko::ReferenceExecutor> ref;
     std::shared_ptr<const gko::CudaExecutor> cuda;
 
-    std::ranlux48 rand_engine;
+    std::default_random_engine rand_engine;
 
     std::unique_ptr<Mtx> v;
     std::unique_ptr<Mtx> d;

--- a/cuda/test/solver/upper_trs_kernels.cpp
+++ b/cuda/test/solver/upper_trs_kernels.cpp
@@ -119,7 +119,7 @@ protected:
     std::shared_ptr<CsrMtx> d_csr_mtx;
     std::shared_ptr<gko::ReferenceExecutor> ref;
     std::shared_ptr<const gko::CudaExecutor> cuda;
-    std::ranlux48 rand_engine;
+    std::default_random_engine rand_engine;
 };
 
 

--- a/dpcpp/solver/idr_kernels.dp.cpp
+++ b/dpcpp/solver/idr_kernels.dp.cpp
@@ -609,7 +609,7 @@ void initialize_subspace_vectors(std::shared_ptr<const DpcppExecutor> exec,
         auto subspace_vectors_data = matrix_data<ValueType>(
             subspace_vectors->get_size(),
             std::normal_distribution<remove_complex<ValueType>>(0.0, 1.0),
-            std::ranlux48(15));
+            std::default_random_engine(15));
         subspace_vectors->read(subspace_vectors_data);
     } else {
         auto seed = time(NULL);

--- a/dpcpp/test/matrix/coo_kernels.cpp
+++ b/dpcpp/test/matrix/coo_kernels.cpp
@@ -113,7 +113,7 @@ protected:
     std::shared_ptr<gko::ReferenceExecutor> ref;
     std::shared_ptr<const gko::DpcppExecutor> dpcpp;
 
-    std::ranlux48 rand_engine;
+    std::default_random_engine rand_engine;
 
     std::unique_ptr<Mtx> mtx;
     std::unique_ptr<Vec> expected;

--- a/dpcpp/test/matrix/csr_kernels.cpp
+++ b/dpcpp/test/matrix/csr_kernels.cpp
@@ -162,7 +162,7 @@ protected:
     std::shared_ptr<const gko::DpcppExecutor> dpcpp;
 
     const gko::dim<2> mtx_size;
-    std::ranlux48 rand_engine;
+    std::default_random_engine rand_engine;
 
     std::unique_ptr<Mtx> mtx;
     std::unique_ptr<Mtx> mtx2;

--- a/dpcpp/test/matrix/dense_kernels.cpp
+++ b/dpcpp/test/matrix/dense_kernels.cpp
@@ -164,7 +164,7 @@ protected:
     std::shared_ptr<gko::ReferenceExecutor> ref;
     std::shared_ptr<const gko::DpcppExecutor> dpcpp;
 
-    std::ranlux48 rand_engine;
+    std::default_random_engine rand_engine;
 
     std::unique_ptr<Mtx> x;
     std::unique_ptr<ComplexMtx> c_x;

--- a/dpcpp/test/matrix/diagonal_kernels.cpp
+++ b/dpcpp/test/matrix/diagonal_kernels.cpp
@@ -154,7 +154,7 @@ protected:
     std::shared_ptr<const gko::DpcppExecutor> dpcpp;
 
     const gko::dim<2> mtx_size;
-    std::ranlux48 rand_engine;
+    std::default_random_engine rand_engine;
 
     std::unique_ptr<Diag> diag;
     std::unique_ptr<Diag> ddiag;

--- a/dpcpp/test/matrix/ell_kernels.cpp
+++ b/dpcpp/test/matrix/ell_kernels.cpp
@@ -124,7 +124,7 @@ protected:
     std::shared_ptr<gko::ReferenceExecutor> ref;
     std::shared_ptr<const gko::DpcppExecutor> dpcpp;
 
-    std::ranlux48 rand_engine;
+    std::default_random_engine rand_engine;
     gko::dim<2> size;
     gko::size_type num_els_rowwise;
     gko::size_type ell_stride;

--- a/dpcpp/test/matrix/hybrid_kernels.cpp
+++ b/dpcpp/test/matrix/hybrid_kernels.cpp
@@ -109,7 +109,7 @@ protected:
     std::shared_ptr<gko::ReferenceExecutor> ref;
     std::shared_ptr<const gko::DpcppExecutor> dpcpp;
 
-    std::ranlux48 rand_engine;
+    std::default_random_engine rand_engine;
 
     std::unique_ptr<Mtx> mtx;
     std::unique_ptr<Vec> expected;

--- a/dpcpp/test/matrix/sellp_kernels.cpp
+++ b/dpcpp/test/matrix/sellp_kernels.cpp
@@ -107,7 +107,7 @@ protected:
     std::shared_ptr<gko::ReferenceExecutor> ref;
     std::shared_ptr<const gko::DpcppExecutor> dpcpp;
 
-    std::ranlux48 rand_engine;
+    std::default_random_engine rand_engine;
 
     std::unique_ptr<Mtx> mtx;
     std::unique_ptr<Mtx> empty;

--- a/dpcpp/test/solver/cb_gmres_kernels.cpp
+++ b/dpcpp/test/solver/cb_gmres_kernels.cpp
@@ -215,7 +215,7 @@ protected:
     std::shared_ptr<gko::ReferenceExecutor> ref;
     std::shared_ptr<const gko::DpcppExecutor> dpcpp;
 
-    std::ranlux48 rand_engine;
+    std::default_random_engine rand_engine;
 
     std::unique_ptr<Mtx> before_preconditioner;
     std::unique_ptr<Mtx> x;

--- a/dpcpp/test/solver/gmres_kernels.cpp
+++ b/dpcpp/test/solver/gmres_kernels.cpp
@@ -148,7 +148,7 @@ protected:
     std::shared_ptr<gko::ReferenceExecutor> ref;
     std::shared_ptr<const gko::DpcppExecutor> dpcpp;
 
-    std::ranlux48 rand_engine;
+    std::default_random_engine rand_engine;
 
     std::unique_ptr<Mtx> before_preconditioner;
     std::unique_ptr<Mtx> x;

--- a/dpcpp/test/solver/idr_kernels.cpp
+++ b/dpcpp/test/solver/idr_kernels.cpp
@@ -154,7 +154,7 @@ protected:
     std::shared_ptr<gko::ReferenceExecutor> ref;
     std::shared_ptr<const gko::DpcppExecutor> dpcpp;
 
-    std::ranlux48 rand_engine;
+    std::default_random_engine rand_engine;
 
     std::shared_ptr<Mtx> mtx;
     std::shared_ptr<Mtx> d_mtx;

--- a/dpcpp/test/solver/idr_kernels.cpp
+++ b/dpcpp/test/solver/idr_kernels.cpp
@@ -258,9 +258,9 @@ TEST_F(Idr, IdrStep3IsEquivalentToRef)
     GKO_ASSERT_MTX_NEAR(v, d_v, 2 * rr<value_type>::value);
     GKO_ASSERT_MTX_NEAR(u, d_u, 2 * rr<value_type>::value);
     GKO_ASSERT_MTX_NEAR(m, d_m, 2 * rr<value_type>::value);
-    GKO_ASSERT_MTX_NEAR(f, d_f, 13 * rr<value_type>::value);
-    GKO_ASSERT_MTX_NEAR(r, d_r, 2 * rr<value_type>::value);
-    GKO_ASSERT_MTX_NEAR(x, d_x, 2 * rr<value_type>::value);
+    GKO_ASSERT_MTX_NEAR(f, d_f, 150 * rr<value_type>::value);
+    GKO_ASSERT_MTX_NEAR(r, d_r, 50 * rr<value_type>::value);
+    GKO_ASSERT_MTX_NEAR(x, d_x, 50 * rr<value_type>::value);
 }
 
 

--- a/examples/mixed-spmv/mixed-spmv.cpp
+++ b/examples/mixed-spmv/mixed-spmv.cpp
@@ -206,7 +206,7 @@ int main(int argc, char* argv[])
     auto x_dim = gko::dim<2>{A_dim[0], b_dim[1]};
     auto host_b = hp_vec::create(exec->get_master(), b_dim);
     // fill the b vector with some random data
-    std::ranlux48 rand_engine(32);
+    std::default_random_engine rand_engine(32);
     auto dist = std::uniform_real_distribution<RealValueType>(0.0, 1.0);
     for (int i = 0; i < host_b->get_size()[0]; i++) {
         host_b->at(i, 0) = get_rand_value<HighPrecision>(dist, rand_engine);

--- a/hip/solver/idr_kernels.hip.cpp
+++ b/hip/solver/idr_kernels.hip.cpp
@@ -99,7 +99,7 @@ void initialize_subspace_vectors(matrix::Dense<ValueType>* subspace_vectors,
     if (deterministic) {
         auto subspace_vectors_data = matrix_data<ValueType>(
             subspace_vectors->get_size(), std::normal_distribution<>(0.0, 1.0),
-            std::ranlux48(15));
+            std::default_random_engine(15));
         subspace_vectors->read(subspace_vectors_data);
     } else {
         auto gen =

--- a/hip/test/factorization/ic_kernels.cpp
+++ b/hip/test/factorization/ic_kernels.cpp
@@ -62,7 +62,7 @@ protected:
 
     std::shared_ptr<gko::ReferenceExecutor> ref;
     std::shared_ptr<gko::HipExecutor> hip;
-    std::ranlux48 rand_engine;
+    std::default_random_engine rand_engine;
     std::shared_ptr<Csr> csr_ref;
     std::shared_ptr<Csr> csr_hip;
 

--- a/hip/test/factorization/ilu_kernels.cpp
+++ b/hip/test/factorization/ilu_kernels.cpp
@@ -62,7 +62,7 @@ protected:
 
     std::shared_ptr<gko::ReferenceExecutor> ref;
     std::shared_ptr<gko::HipExecutor> hip;
-    std::ranlux48 rand_engine;
+    std::default_random_engine rand_engine;
     std::shared_ptr<Csr> csr_ref;
     std::shared_ptr<Csr> csr_hip;
 

--- a/hip/test/factorization/par_ilu_kernels.hip.cpp
+++ b/hip/test/factorization/par_ilu_kernels.hip.cpp
@@ -66,7 +66,7 @@ protected:
     using Coo = gko::matrix::Coo<value_type, index_type>;
     using Csr = gko::matrix::Csr<value_type, index_type>;
 
-    std::ranlux48 rand_engine;
+    std::default_random_engine rand_engine;
     std::shared_ptr<gko::ReferenceExecutor> ref;
     std::shared_ptr<gko::HipExecutor> hip;
     std::shared_ptr<const Csr> csr_ref;

--- a/hip/test/matrix/coo_kernels.hip.cpp
+++ b/hip/test/matrix/coo_kernels.hip.cpp
@@ -109,7 +109,7 @@ protected:
     std::shared_ptr<gko::ReferenceExecutor> ref;
     std::shared_ptr<const gko::HipExecutor> hip;
 
-    std::ranlux48 rand_engine;
+    std::default_random_engine rand_engine;
 
     std::unique_ptr<Mtx> mtx;
     std::unique_ptr<Vec> expected;

--- a/hip/test/matrix/csr_kernels.hip.cpp
+++ b/hip/test/matrix/csr_kernels.hip.cpp
@@ -160,7 +160,7 @@ protected:
     std::shared_ptr<const gko::HipExecutor> hip;
 
     const gko::dim<2> mtx_size;
-    std::ranlux48 rand_engine;
+    std::default_random_engine rand_engine;
 
     std::unique_ptr<Mtx> mtx;
     std::unique_ptr<Mtx> mtx2;

--- a/hip/test/matrix/dense_kernels.hip.cpp
+++ b/hip/test/matrix/dense_kernels.hip.cpp
@@ -158,7 +158,7 @@ protected:
     std::shared_ptr<gko::ReferenceExecutor> ref;
     std::shared_ptr<const gko::HipExecutor> hip;
 
-    std::ranlux48 rand_engine;
+    std::default_random_engine rand_engine;
 
     std::unique_ptr<Mtx> x;
     std::unique_ptr<Mtx> y;

--- a/hip/test/matrix/diagonal_kernels.hip.cpp
+++ b/hip/test/matrix/diagonal_kernels.hip.cpp
@@ -152,7 +152,7 @@ protected:
     std::shared_ptr<const gko::HipExecutor> hip;
 
     const gko::dim<2> mtx_size;
-    std::ranlux48 rand_engine;
+    std::default_random_engine rand_engine;
 
     std::unique_ptr<Diag> diag;
     std::unique_ptr<Diag> ddiag;

--- a/hip/test/matrix/ell_kernels.hip.cpp
+++ b/hip/test/matrix/ell_kernels.hip.cpp
@@ -119,7 +119,7 @@ protected:
     std::shared_ptr<gko::ReferenceExecutor> ref;
     std::shared_ptr<const gko::HipExecutor> hip;
 
-    std::ranlux48 rand_engine;
+    std::default_random_engine rand_engine;
     gko::dim<2> size;
     gko::size_type num_els_rowwise;
     gko::size_type ell_stride;

--- a/hip/test/matrix/hybrid_kernels.hip.cpp
+++ b/hip/test/matrix/hybrid_kernels.hip.cpp
@@ -107,7 +107,7 @@ protected:
     std::shared_ptr<gko::ReferenceExecutor> ref;
     std::shared_ptr<const gko::HipExecutor> hip;
 
-    std::ranlux48 rand_engine;
+    std::default_random_engine rand_engine;
 
     std::unique_ptr<Mtx> mtx;
     std::unique_ptr<Vec> expected;

--- a/hip/test/matrix/sellp_kernels.hip.cpp
+++ b/hip/test/matrix/sellp_kernels.hip.cpp
@@ -105,7 +105,7 @@ protected:
     std::shared_ptr<gko::ReferenceExecutor> ref;
     std::shared_ptr<const gko::HipExecutor> hip;
 
-    std::ranlux48 rand_engine;
+    std::default_random_engine rand_engine;
 
     std::unique_ptr<Mtx> mtx;
     std::unique_ptr<Mtx> empty;

--- a/hip/test/multigrid/amgx_pgm_kernels.cpp
+++ b/hip/test/multigrid/amgx_pgm_kernels.cpp
@@ -165,7 +165,7 @@ protected:
     std::shared_ptr<gko::ReferenceExecutor> ref;
     std::shared_ptr<const gko::HipExecutor> hip;
 
-    std::ranlux48 rand_engine;
+    std::default_random_engine rand_engine;
 
     gko::Array<index_type> agg;
     gko::Array<index_type> unfinished_agg;

--- a/hip/test/preconditioner/jacobi_kernels.cpp
+++ b/hip/test/preconditioner/jacobi_kernels.cpp
@@ -78,7 +78,7 @@ protected:
         gko::uint32 max_block_size, int min_nnz, int max_nnz, int num_rhs = 1,
         double accuracy = 0.1, bool skip_sorting = true)
     {
-        std::ranlux48 engine(42);
+        std::default_random_engine engine(42);
         const auto dim = *(end(block_pointers) - 1);
         if (condition_numbers.size() == 0) {
             mtx = gko::test::generate_random_matrix<Mtx>(
@@ -309,7 +309,7 @@ TEST_F(Jacobi, HipPreconditionerEquivalentToRefWithBlockSize32Sorted)
 
 TEST_F(Jacobi, HipPreconditionerEquivalentToRefWithBlockSize32Unsorted)
 {
-    std::ranlux48 engine(43);
+    std::default_random_engine engine(43);
     initialize_data({0, 32, 64, 96, 128}, {}, {}, 32, 100, 110, 1, 0.1, false);
     gko::test::unsort_matrix(mtx.get(), engine);
 
@@ -444,7 +444,7 @@ TEST_F(Jacobi, HipApplyEquivalentToRef)
 TEST_F(Jacobi, HipScalarApplyEquivalentToRef)
 {
     gko::size_type dim = 313;
-    std::ranlux48 engine(42);
+    std::default_random_engine engine(42);
     auto dense_smtx = gko::share(gko::test::generate_random_matrix<Vec>(
         dim, dim, std::uniform_int_distribution<>(1, dim),
         std::normal_distribution<>(1.0, 2.0), engine, ref));
@@ -493,7 +493,7 @@ TEST_F(Jacobi, HipLinearCombinationApplyEquivalentToRef)
 TEST_F(Jacobi, HipScalarLinearCombinationApplyEquivalentToRef)
 {
     gko::size_type dim = 313;
-    std::ranlux48 engine(42);
+    std::default_random_engine engine(42);
     auto dense_smtx = gko::share(gko::test::generate_random_matrix<Vec>(
         dim, dim, std::uniform_int_distribution<>(1, dim),
         std::normal_distribution<>(1.0, 2.0), engine, ref));

--- a/hip/test/solver/cb_gmres_kernels.cpp
+++ b/hip/test/solver/cb_gmres_kernels.cpp
@@ -205,7 +205,7 @@ protected:
     std::shared_ptr<gko::ReferenceExecutor> ref;
     std::shared_ptr<const gko::HipExecutor> hip;
 
-    std::ranlux48 rand_engine;
+    std::default_random_engine rand_engine;
 
     std::unique_ptr<Mtx> before_preconditioner;
     std::unique_ptr<Mtx> x;

--- a/hip/test/solver/gmres_kernels.cpp
+++ b/hip/test/solver/gmres_kernels.cpp
@@ -144,7 +144,7 @@ protected:
     std::shared_ptr<gko::ReferenceExecutor> ref;
     std::shared_ptr<const gko::HipExecutor> hip;
 
-    std::ranlux48 rand_engine;
+    std::default_random_engine rand_engine;
 
     std::unique_ptr<Mtx> before_preconditioner;
     std::unique_ptr<Mtx> x;

--- a/hip/test/solver/idr_kernels.cpp
+++ b/hip/test/solver/idr_kernels.cpp
@@ -244,13 +244,13 @@ TEST_F(Idr, IdrStep3IsEquivalentToRef)
         hip, nrhs, k, d_p.get(), d_g.get(), d_v.get(), d_u.get(), d_m.get(),
         d_f.get(), d_alpha.get(), d_r.get(), d_x.get(), d_stop_status.get());
 
-    GKO_ASSERT_MTX_NEAR(g, d_g, 1e-14);
-    GKO_ASSERT_MTX_NEAR(v, d_v, 1e-14);
-    GKO_ASSERT_MTX_NEAR(u, d_u, 1e-14);
-    GKO_ASSERT_MTX_NEAR(m, d_m, 1e-14);
-    GKO_ASSERT_MTX_NEAR(f, d_f, 1e-14);
-    GKO_ASSERT_MTX_NEAR(r, d_r, 1e-14);
-    GKO_ASSERT_MTX_NEAR(x, d_x, 1e-14);
+    GKO_ASSERT_MTX_NEAR(g, d_g, 2 * 1e-14);
+    GKO_ASSERT_MTX_NEAR(v, d_v, 2 * 1e-14);
+    GKO_ASSERT_MTX_NEAR(u, d_u, 2 * 1e-14);
+    GKO_ASSERT_MTX_NEAR(m, d_m, 2 * 1e-14);
+    GKO_ASSERT_MTX_NEAR(f, d_f, 150 * 1e-14);
+    GKO_ASSERT_MTX_NEAR(r, d_r, 50 * 1e-14);
+    GKO_ASSERT_MTX_NEAR(x, d_x, 50 * 1e-14);
 }
 
 

--- a/hip/test/solver/idr_kernels.cpp
+++ b/hip/test/solver/idr_kernels.cpp
@@ -144,7 +144,7 @@ protected:
     std::shared_ptr<gko::ReferenceExecutor> ref;
     std::shared_ptr<const gko::HipExecutor> hip;
 
-    std::ranlux48 rand_engine;
+    std::default_random_engine rand_engine;
 
     std::shared_ptr<Mtx> mtx;
     std::shared_ptr<Mtx> d_mtx;

--- a/hip/test/solver/lower_trs_kernels.cpp
+++ b/hip/test/solver/lower_trs_kernels.cpp
@@ -116,7 +116,7 @@ protected:
     std::shared_ptr<CsrMtx> d_csr_mtx;
     std::shared_ptr<gko::ReferenceExecutor> ref;
     std::shared_ptr<const gko::HipExecutor> hip;
-    std::ranlux48 rand_engine;
+    std::default_random_engine rand_engine;
 };
 
 

--- a/hip/test/solver/multigrid_kernels.cpp
+++ b/hip/test/solver/multigrid_kernels.cpp
@@ -169,7 +169,7 @@ protected:
     std::shared_ptr<gko::ReferenceExecutor> ref;
     std::shared_ptr<const gko::HipExecutor> hip;
 
-    std::ranlux48 rand_engine;
+    std::default_random_engine rand_engine;
 
     std::unique_ptr<Mtx> v;
     std::unique_ptr<Mtx> d;

--- a/hip/test/solver/upper_trs_kernels.cpp
+++ b/hip/test/solver/upper_trs_kernels.cpp
@@ -116,7 +116,7 @@ protected:
     std::shared_ptr<CsrMtx> d_csr_mtx;
     std::shared_ptr<gko::ReferenceExecutor> ref;
     std::shared_ptr<const gko::HipExecutor> hip;
-    std::ranlux48 rand_engine;
+    std::default_random_engine rand_engine;
 };
 
 

--- a/omp/solver/idr_kernels.cpp
+++ b/omp/solver/idr_kernels.cpp
@@ -164,7 +164,7 @@ void initialize(std::shared_ptr<const OmpExecutor> exec, const size_type nrhs,
     const auto num_cols = subspace_vectors->get_size()[1];
     auto dist = std::normal_distribution<remove_complex<ValueType>>(0.0, 1.0);
     auto seed = deterministic ? 15 : time(NULL);
-    auto gen = std::ranlux48(seed);
+    auto gen = std::default_random_engine(seed);
     for (size_type row = 0; row < num_rows; row++) {
         for (size_type col = 0; col < num_cols; col++) {
             subspace_vectors->at(row, col) =

--- a/omp/test/factorization/par_ilu_kernels.cpp
+++ b/omp/test/factorization/par_ilu_kernels.cpp
@@ -70,7 +70,7 @@ protected:
     using Coo = gko::matrix::Coo<value_type, index_type>;
     using Csr = gko::matrix::Csr<value_type, index_type>;
 
-    std::ranlux48 rand_engine;
+    std::default_random_engine rand_engine;
     std::shared_ptr<gko::ReferenceExecutor> ref;
     std::shared_ptr<gko::OmpExecutor> omp;
     std::shared_ptr<const Csr> csr_ref;

--- a/omp/test/matrix/coo_kernels.cpp
+++ b/omp/test/matrix/coo_kernels.cpp
@@ -123,7 +123,7 @@ protected:
     std::shared_ptr<const gko::OmpExecutor> omp;
 
     const gko::dim<2> mtx_size;
-    std::ranlux48 rand_engine;
+    std::default_random_engine rand_engine;
 
     std::unique_ptr<Mtx> mtx;
     std::unique_ptr<Vec> expected;

--- a/omp/test/matrix/csr_kernels.cpp
+++ b/omp/test/matrix/csr_kernels.cpp
@@ -164,7 +164,7 @@ protected:
     std::shared_ptr<const gko::OmpExecutor> omp;
 
     const gko::dim<2> mtx_size;
-    std::ranlux48 rand_engine;
+    std::default_random_engine rand_engine;
 
     std::unique_ptr<Mtx> mtx;
     std::unique_ptr<Mtx> mtx2;

--- a/omp/test/matrix/dense_kernels.cpp
+++ b/omp/test/matrix/dense_kernels.cpp
@@ -173,7 +173,7 @@ protected:
     std::shared_ptr<gko::ReferenceExecutor> ref;
     std::shared_ptr<const gko::OmpExecutor> omp;
 
-    std::ranlux48 rand_engine;
+    std::default_random_engine rand_engine;
 
     std::unique_ptr<Mtx> x;
     std::unique_ptr<ComplexMtx> c_x;

--- a/omp/test/matrix/diagonal_kernels.cpp
+++ b/omp/test/matrix/diagonal_kernels.cpp
@@ -151,7 +151,7 @@ protected:
     std::shared_ptr<const gko::OmpExecutor> omp;
 
     const gko::dim<2> mtx_size;
-    std::ranlux48 rand_engine;
+    std::default_random_engine rand_engine;
 
     std::unique_ptr<Diag> diag;
     std::unique_ptr<Diag> ddiag;

--- a/omp/test/matrix/ell_kernels.cpp
+++ b/omp/test/matrix/ell_kernels.cpp
@@ -114,7 +114,7 @@ protected:
     std::shared_ptr<gko::ReferenceExecutor> ref;
     std::shared_ptr<const gko::OmpExecutor> omp;
 
-    std::ranlux48 rand_engine;
+    std::default_random_engine rand_engine;
 
     std::unique_ptr<Mtx> mtx;
     std::unique_ptr<Vec> expected;

--- a/omp/test/matrix/fbcsr_kernels.cpp
+++ b/omp/test/matrix/fbcsr_kernels.cpp
@@ -145,7 +145,7 @@ protected:
     const index_type num_brows = 112;
     const index_type num_bcols = 31;
     const int blk_sz = 3;
-    std::ranlux48 rand_engine;
+    std::default_random_engine rand_engine;
 
     std::unique_ptr<Mtx> mtx;
     std::unique_ptr<ComplexMtx> complex_mtx;

--- a/omp/test/matrix/hybrid_kernels.cpp
+++ b/omp/test/matrix/hybrid_kernels.cpp
@@ -114,7 +114,7 @@ protected:
     std::shared_ptr<gko::ReferenceExecutor> ref;
     std::shared_ptr<const gko::OmpExecutor> omp;
 
-    std::ranlux48 rand_engine;
+    std::default_random_engine rand_engine;
 
     std::unique_ptr<Mtx> mtx;
     std::unique_ptr<Vec> expected;

--- a/omp/test/matrix/sellp_kernels.cpp
+++ b/omp/test/matrix/sellp_kernels.cpp
@@ -104,7 +104,7 @@ protected:
     std::shared_ptr<gko::ReferenceExecutor> ref;
     std::shared_ptr<const gko::OmpExecutor> omp;
 
-    std::ranlux48 rand_engine;
+    std::default_random_engine rand_engine;
 
     std::unique_ptr<Mtx> mtx;
     std::unique_ptr<Mtx> empty;

--- a/omp/test/matrix/sparsity_csr_kernels.cpp
+++ b/omp/test/matrix/sparsity_csr_kernels.cpp
@@ -134,7 +134,7 @@ protected:
     std::shared_ptr<const gko::OmpExecutor> omp;
 
     const gko::dim<2> mtx_size;
-    std::ranlux48 rand_engine;
+    std::default_random_engine rand_engine;
 
     std::unique_ptr<Mtx> mtx;
     std::unique_ptr<ComplexMtx> complex_mtx;

--- a/omp/test/multigrid/amgx_pgm_kernels.cpp
+++ b/omp/test/multigrid/amgx_pgm_kernels.cpp
@@ -157,7 +157,7 @@ protected:
     std::shared_ptr<gko::ReferenceExecutor> ref;
     std::shared_ptr<const gko::OmpExecutor> omp;
 
-    std::ranlux48 rand_engine;
+    std::default_random_engine rand_engine;
 
     gko::Array<index_type> agg;
     gko::Array<index_type> unfinished_agg;

--- a/omp/test/preconditioner/jacobi_kernels.cpp
+++ b/omp/test/preconditioner/jacobi_kernels.cpp
@@ -77,7 +77,7 @@ protected:
         gko::uint32 max_block_size, int min_nnz, int max_nnz, int num_rhs = 1,
         double accuracy = 0.1, bool skip_sorting = true)
     {
-        std::ranlux48 engine(42);
+        std::default_random_engine engine(42);
         const auto dim = *(end(block_pointers) - 1);
         if (condition_numbers.size() == 0) {
             mtx = gko::test::generate_random_matrix<Mtx>(
@@ -305,7 +305,7 @@ TEST_F(Jacobi, OmpPreconditionerEquivalentToRefWithBlockSize32Sorted)
 
 TEST_F(Jacobi, OmpPreconditionerEquivalentToRefWithBlockSize32Unsorted)
 {
-    std::ranlux48 engine(43);
+    std::default_random_engine engine(43);
     initialize_data({0, 32, 64, 96, 128}, {}, {}, 32, 100, 110, 1, 0.1, false);
     gko::test::unsort_matrix(mtx.get(), engine);
 
@@ -398,7 +398,7 @@ TEST_F(Jacobi, OmpApplyEquivalentToRefWithDifferentBlockSize)
 TEST_F(Jacobi, OmpScalarApplyEquivalentToRef)
 {
     gko::size_type dim = 313;
-    std::ranlux48 engine(42);
+    std::default_random_engine engine(42);
     auto dense_smtx = gko::share(gko::test::generate_random_matrix<Vec>(
         dim, dim, std::uniform_int_distribution<>(1, dim),
         std::normal_distribution<>(1.0, 2.0), engine, ref));
@@ -461,7 +461,7 @@ TEST_F(Jacobi, OmpLinearCombinationApplyEquivalentToRef)
 TEST_F(Jacobi, OmpScalarLinearCombinationApplyEquivalentToRef)
 {
     gko::size_type dim = 5;
-    std::ranlux48 engine(42);
+    std::default_random_engine engine(42);
     auto dense_smtx = gko::share(gko::test::generate_random_matrix<Vec>(
         dim, dim, std::uniform_int_distribution<>(1, dim),
         std::normal_distribution<>(1.0, 2.0), engine, ref));

--- a/omp/test/solver/cb_gmres_kernels.cpp
+++ b/omp/test/solver/cb_gmres_kernels.cpp
@@ -207,7 +207,7 @@ protected:
     std::shared_ptr<gko::ReferenceExecutor> ref;
     std::shared_ptr<const gko::OmpExecutor> omp;
 
-    std::ranlux48 rand_engine;
+    std::default_random_engine rand_engine;
 
     std::unique_ptr<Mtx> before_preconditioner;
     std::unique_ptr<Mtx> x;

--- a/omp/test/solver/gmres_kernels.cpp
+++ b/omp/test/solver/gmres_kernels.cpp
@@ -163,7 +163,7 @@ protected:
     std::shared_ptr<gko::ReferenceExecutor> ref;
     std::shared_ptr<const gko::OmpExecutor> omp;
 
-    std::ranlux48 rand_engine;
+    std::default_random_engine rand_engine;
 
     std::unique_ptr<Mtx> mtx;
     std::unique_ptr<Mtx> d_mtx;

--- a/omp/test/solver/idr_kernels.cpp
+++ b/omp/test/solver/idr_kernels.cpp
@@ -150,7 +150,7 @@ protected:
     std::shared_ptr<const gko::ReferenceExecutor> ref;
     std::shared_ptr<const gko::OmpExecutor> omp;
 
-    std::ranlux48 rand_engine;
+    std::default_random_engine rand_engine;
 
     std::shared_ptr<Mtx> mtx;
     std::shared_ptr<Mtx> d_mtx;

--- a/omp/test/solver/idr_kernels.cpp
+++ b/omp/test/solver/idr_kernels.cpp
@@ -250,13 +250,13 @@ TEST_F(Idr, IdrStep3IsEquivalentToRef)
         omp, nrhs, k, d_p.get(), d_g.get(), d_v.get(), d_u.get(), d_m.get(),
         d_f.get(), d_alpha.get(), d_r.get(), d_x.get(), d_stop_status.get());
 
-    GKO_ASSERT_MTX_NEAR(g, d_g, 1e-14);
-    GKO_ASSERT_MTX_NEAR(v, d_v, 1e-14);
-    GKO_ASSERT_MTX_NEAR(u, d_u, 1e-14);
-    GKO_ASSERT_MTX_NEAR(m, d_m, 1e-14);
-    GKO_ASSERT_MTX_NEAR(f, d_f, 1e-14);
-    GKO_ASSERT_MTX_NEAR(r, d_r, 1e-14);
-    GKO_ASSERT_MTX_NEAR(x, d_x, 1e-14);
+    GKO_ASSERT_MTX_NEAR(g, d_g, 2 * 1e-14);
+    GKO_ASSERT_MTX_NEAR(v, d_v, 2 * 1e-14);
+    GKO_ASSERT_MTX_NEAR(u, d_u, 2 * 1e-14);
+    GKO_ASSERT_MTX_NEAR(m, d_m, 2 * 1e-14);
+    GKO_ASSERT_MTX_NEAR(f, d_f, 150 * 1e-14);
+    GKO_ASSERT_MTX_NEAR(r, d_r, 50 * 1e-14);
+    GKO_ASSERT_MTX_NEAR(x, d_x, 50 * 1e-14);
 }
 
 

--- a/omp/test/solver/lower_trs_kernels.cpp
+++ b/omp/test/solver/lower_trs_kernels.cpp
@@ -109,7 +109,7 @@ protected:
     std::shared_ptr<gko::ReferenceExecutor> ref;
     std::shared_ptr<const gko::OmpExecutor> omp;
 
-    std::ranlux48 rand_engine;
+    std::default_random_engine rand_engine;
 
     std::shared_ptr<Mtx> b;
     std::shared_ptr<Mtx> x;

--- a/omp/test/solver/multigrid_kernels.cpp
+++ b/omp/test/solver/multigrid_kernels.cpp
@@ -168,7 +168,7 @@ protected:
     std::shared_ptr<gko::ReferenceExecutor> ref;
     std::shared_ptr<const gko::OmpExecutor> omp;
 
-    std::ranlux48 rand_engine;
+    std::default_random_engine rand_engine;
 
     std::unique_ptr<Mtx> v;
     std::unique_ptr<Mtx> d;

--- a/omp/test/solver/upper_trs_kernels.cpp
+++ b/omp/test/solver/upper_trs_kernels.cpp
@@ -109,7 +109,7 @@ protected:
     std::shared_ptr<gko::ReferenceExecutor> ref;
     std::shared_ptr<const gko::OmpExecutor> omp;
 
-    std::ranlux48 rand_engine;
+    std::default_random_engine rand_engine;
 
     std::shared_ptr<Mtx> b;
     std::shared_ptr<Mtx> x;

--- a/reference/solver/idr_kernels.cpp
+++ b/reference/solver/idr_kernels.cpp
@@ -154,7 +154,7 @@ void initialize(std::shared_ptr<const ReferenceExecutor> exec,
     const auto num_cols = subspace_vectors->get_size()[1];
     auto dist = std::normal_distribution<remove_complex<ValueType>>(0.0, 1.0);
     auto seed = deterministic ? 15 : time(NULL);
-    auto gen = std::ranlux48(seed);
+    auto gen = std::default_random_engine(seed);
     for (size_type row = 0; row < num_rows; row++) {
         for (size_type col = 0; col < num_cols; col++) {
             subspace_vectors->at(row, col) =

--- a/reference/test/matrix/dense_kernels.cpp
+++ b/reference/test/matrix/dense_kernels.cpp
@@ -98,7 +98,7 @@ protected:
     std::unique_ptr<Mtx> mtx7;
     std::unique_ptr<Mtx> mtx8;
 
-    std::ranlux48 rand_engine;
+    std::default_random_engine rand_engine;
 
     template <typename MtxType>
     std::unique_ptr<MtxType> gen_mtx(int num_rows, int num_cols)

--- a/reference/test/matrix/fbcsr_kernels.cpp
+++ b/reference/test/matrix/fbcsr_kernels.cpp
@@ -145,7 +145,7 @@ std::unique_ptr<gko::matrix::Dense<T>> get_some_vectors(
     const size_t nrhs)
 {
     using RT = gko::remove_complex<T>;
-    std::ranlux48 engine(39);
+    std::default_random_engine engine(39);
     std::normal_distribution<RT> dist(0.0, 5.0);
     std::uniform_int_distribution<> nnzdist(1, nrhs);
     return gko::test::generate_random_matrix<gko::matrix::Dense<T>>(

--- a/test/distributed/partition_kernels.cpp
+++ b/test/distributed/partition_kernels.cpp
@@ -118,7 +118,7 @@ protected:
                 const_cast<local_index_type*>(dpart->get_part_sizes())));
     }
 
-    std::ranlux48 rand_engine;
+    std::default_random_engine rand_engine;
 
     std::shared_ptr<gko::ReferenceExecutor> ref;
     std::shared_ptr<gko::EXEC_TYPE> exec;

--- a/test/matrix/csr_kernels.cpp
+++ b/test/matrix/csr_kernels.cpp
@@ -102,7 +102,7 @@ protected:
     std::shared_ptr<gko::ReferenceExecutor> ref;
     std::shared_ptr<gko::EXEC_TYPE> exec;
 
-    std::ranlux48 rand_engine;
+    std::default_random_engine rand_engine;
 
     std::unique_ptr<Mtx> x;
     std::unique_ptr<Vec> alpha;

--- a/test/matrix/dense_kernels.cpp
+++ b/test/matrix/dense_kernels.cpp
@@ -180,7 +180,7 @@ protected:
     std::shared_ptr<gko::ReferenceExecutor> ref;
     std::shared_ptr<gko::EXEC_TYPE> exec;
 
-    std::ranlux48 rand_engine;
+    std::default_random_engine rand_engine;
 
     std::unique_ptr<Mtx> x;
     std::unique_ptr<ComplexMtx> c_x;

--- a/test/solver/bicg_kernels.cpp
+++ b/test/solver/bicg_kernels.cpp
@@ -151,7 +151,7 @@ protected:
     std::shared_ptr<gko::ReferenceExecutor> ref;
     std::shared_ptr<gko::EXEC_TYPE> exec;
 
-    std::ranlux48 rand_engine;
+    std::default_random_engine rand_engine;
 
     std::unique_ptr<Mtx> b;
     std::unique_ptr<Mtx> r;

--- a/test/solver/bicgstab_kernels.cpp
+++ b/test/solver/bicgstab_kernels.cpp
@@ -172,7 +172,7 @@ protected:
     std::shared_ptr<gko::ReferenceExecutor> ref;
     std::shared_ptr<gko::EXEC_TYPE> exec;
 
-    std::ranlux48 rand_engine;
+    std::default_random_engine rand_engine;
 
     std::shared_ptr<Mtx> mtx;
     std::shared_ptr<Mtx> d_mtx;

--- a/test/solver/cg_kernels.cpp
+++ b/test/solver/cg_kernels.cpp
@@ -132,7 +132,7 @@ protected:
     std::shared_ptr<gko::ReferenceExecutor> ref;
     std::shared_ptr<gko::EXEC_TYPE> exec;
 
-    std::ranlux48 rand_engine;
+    std::default_random_engine rand_engine;
 
     std::unique_ptr<Mtx> b;
     std::unique_ptr<Mtx> r;

--- a/test/solver/cgs_kernels.cpp
+++ b/test/solver/cgs_kernels.cpp
@@ -164,7 +164,7 @@ protected:
     std::shared_ptr<gko::ReferenceExecutor> ref;
     std::shared_ptr<gko::EXEC_TYPE> exec;
 
-    std::ranlux48 rand_engine;
+    std::default_random_engine rand_engine;
 
     std::shared_ptr<Mtx> mtx;
     std::shared_ptr<Mtx> d_mtx;

--- a/test/solver/fcg_kernels.cpp
+++ b/test/solver/fcg_kernels.cpp
@@ -136,7 +136,7 @@ protected:
     std::shared_ptr<gko::ReferenceExecutor> ref;
     std::shared_ptr<gko::EXEC_TYPE> exec;
 
-    std::ranlux48 rand_engine;
+    std::default_random_engine rand_engine;
 
     std::unique_ptr<Mtx> b;
     std::unique_ptr<Mtx> r;

--- a/test/solver/ir_kernels.cpp
+++ b/test/solver/ir_kernels.cpp
@@ -87,7 +87,7 @@ protected:
     std::shared_ptr<gko::ReferenceExecutor> ref;
     std::shared_ptr<gko::EXEC_TYPE> exec;
 
-    std::ranlux48 rand_engine;
+    std::default_random_engine rand_engine;
 };
 
 

--- a/test/solver/ir_kernels.cpp
+++ b/test/solver/ir_kernels.cpp
@@ -177,10 +177,10 @@ TEST_F(Ir, ApplyWithIterativeInnerSolverIsEquivalentToRef)
     solver->apply(lend(b), lend(x));
     d_solver->apply(lend(d_b), lend(d_x));
 
-    // Note: r<value_type>::value * 1e2 instead of r<value_type>::value, as
+    // Note: r<value_type>::value * 150 instead of r<value_type>::value, as
     // the difference in the inner gmres iteration gets amplified by the
     // difference in IR.
-    GKO_ASSERT_MTX_NEAR(d_x, x, r<value_type>::value * 100);
+    GKO_ASSERT_MTX_NEAR(d_x, x, r<value_type>::value * 150);
 }
 
 

--- a/third_party/gtest/CMakeLists.txt
+++ b/third_party/gtest/CMakeLists.txt
@@ -3,7 +3,7 @@ include(FetchContent)
 FetchContent_Declare(
     googletest
     GIT_REPOSITORY https://github.com/google/googletest.git
-    GIT_TAG        6a7ed316a5cdc07b6d26362c90770787513822d4
+    GIT_TAG        release-1.11.0
 )
 # need to set the variables in CACHE due to CMP0077
 set(gtest_disable_pthreads ON CACHE INTERNAL "")

--- a/third_party/gtest/CMakeLists.txt
+++ b/third_party/gtest/CMakeLists.txt
@@ -20,6 +20,12 @@ set_target_properties(gtest gtest_main PROPERTIES
     RUNTIME_OUTPUT_DIRECTORY "${GINKGO_LIBRARY_PATH}"
     ARCHIVE_OUTPUT_DIRECTORY "${GINKGO_LIBRARY_PATH}"
     LIBRARY_OUTPUT_DIRECTORY "${GINKGO_LIBRARY_PATH}")
+# If CXX compiler is dpcpp, use -ffp-model=precise
+# Otherwise, it will throw src/gtest.cc:1583:8: error: comparison with NaN always evaluates to false in fast floating point modes
+if(CMAKE_CXX_COMPILER MATCHES "dpcpp")
+    target_compile_options(gtest PRIVATE "-ffp-model=precise")
+    target_compile_options(gtest_main PRIVATE "-ffp-model=precise")
+endif()
 # by default, the outdated targets are not being exported
 add_library(GTest::Main ALIAS gtest_main)
 add_library(GTest::GTest ALIAS gtest)


### PR DESCRIPTION
This PR change ranlux generator to default generator to avoid MSVC SFIANE issue with gtest.
~~Moreover, it picks small fix of hybrid -> csr from @upsj #905~~ already merged
Update Gtest to release v1.11.0, which also fix the gcc 11.2 issue as #914 mentioned