### PR TITLE
Remove unnecessary device_guard usage

### DIFF
--- a/cuda/base/device_guard.hpp
+++ b/cuda/base/device_guard.hpp
@@ -60,7 +60,9 @@ public:
     device_guard(int device_id)
     {
         GKO_ASSERT_NO_CUDA_ERRORS(cudaGetDevice(&original_device_id));
-        GKO_ASSERT_NO_CUDA_ERRORS(cudaSetDevice(device_id));
+        if (original_device_id != device_id) {
+            GKO_ASSERT_NO_CUDA_ERRORS(cudaSetDevice(device_id));
+        }
     }
 
     device_guard(device_guard& other) = delete;

--- a/cuda/base/kernel_launch.cuh
+++ b/cuda/base/kernel_launch.cuh
@@ -36,7 +36,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #endif
 
 
-#include "cuda/base/device_guard.hpp"
 #include "cuda/base/types.hpp"
 #include "cuda/components/thread_ids.cuh"
 
@@ -80,7 +79,6 @@ void run_kernel(std::shared_ptr<const CudaExecutor> exec, KernelFunction fn,
                 size_type size, KernelArgs&&... args)
 {
     if (size > 0) {
-        gko::cuda::device_guard guard{exec->get_device_id()};
         constexpr auto block_size = default_block_size;
         auto num_blocks = ceildiv(size, block_size);
         generic_kernel_1d<<<num_blocks, block_size>>>(
@@ -93,7 +91,6 @@ void run_kernel(std::shared_ptr<const CudaExecutor> exec, KernelFunction fn,
                 dim<2> size, KernelArgs&&... args)
 {
     if (size[0] * size[1] > 0) {
-        gko::cuda::device_guard guard{exec->get_device_id()};
         constexpr auto block_size = default_block_size;
         auto num_blocks = ceildiv(size[0] * size[1], block_size);
         generic_kernel_2d<<<num_blocks, block_size>>>(

--- a/cuda/base/kernel_launch_reduction.cuh
+++ b/cuda/base/kernel_launch_reduction.cuh
@@ -37,7 +37,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
 #include "core/synthesizer/implementation_selection.hpp"
-#include "cuda/base/device_guard.hpp"
 #include "cuda/base/types.hpp"
 #include "cuda/components/cooperative_groups.cuh"
 #include "cuda/components/reduction.cuh"
@@ -144,7 +143,6 @@ void run_kernel_reduction(std::shared_ptr<const CudaExecutor> exec,
                           KernelArgs&&... args)
 {
     constexpr int oversubscription = 16;
-    gko::cuda::device_guard guard{exec->get_device_id()};
     constexpr auto block_size = default_block_size;
     const auto num_blocks = std::min<int64>(
         ceildiv(size, block_size), exec->get_num_warps() * oversubscription);
@@ -175,7 +173,6 @@ void run_kernel_reduction(std::shared_ptr<const CudaExecutor> exec,
                           ValueType* result, dim<2> size, KernelArgs&&... args)
 {
     constexpr int oversubscription = 16;
-    gko::cuda::device_guard guard{exec->get_device_id()};
     constexpr auto block_size = default_block_size;
     const auto rows = static_cast<int64>(size[0]);
     const auto cols = static_cast<int64>(size[1]);
@@ -433,7 +430,6 @@ void run_kernel_row_reduction(std::shared_ptr<const CudaExecutor> exec,
     using subwarp_sizes =
         syn::value_list<int, 1, 2, 4, 8, 16, 32, config::warp_size>;
     constexpr int oversubscription = 16;
-    gko::cuda::device_guard guard{exec->get_device_id()};
     const auto rows = static_cast<int64>(size[0]);
     const auto cols = static_cast<int64>(size[1]);
     const auto resources =
@@ -480,7 +476,6 @@ void run_kernel_col_reduction(std::shared_ptr<const CudaExecutor> exec,
     using subwarp_sizes =
         syn::value_list<int, 1, 2, 4, 8, 16, 32, config::warp_size>;
     constexpr int oversubscription = 16;
-    gko::cuda::device_guard guard{exec->get_device_id()};
     const auto rows = static_cast<int64>(size[0]);
     const auto cols = static_cast<int64>(size[1]);
     const auto max_blocks = exec->get_num_warps() * config::warp_size *

--- a/cuda/base/kernel_launch_solver.cuh
+++ b/cuda/base/kernel_launch_solver.cuh
@@ -63,7 +63,6 @@ void run_kernel_solver(std::shared_ptr<const CudaExecutor> exec,
                        KernelArgs&&... args)
 {
     if (size[0] * size[1] > 0) {
-        gko::cuda::device_guard guard{exec->get_device_id()};
         constexpr auto block_size = default_block_size;
         auto num_blocks = ceildiv(size[0] * size[1], block_size);
         generic_kernel_2d_solver<<<num_blocks, block_size>>>(

--- a/cuda/factorization/ic_kernels.cu
+++ b/cuda/factorization/ic_kernels.cu
@@ -37,7 +37,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
 #include "cuda/base/cusparse_bindings.hpp"
-#include "cuda/base/device_guard.hpp"
 
 
 namespace gko {
@@ -57,7 +56,6 @@ void compute(std::shared_ptr<const DefaultExecutor> exec,
 {
     const auto id = exec->get_device_id();
     auto handle = exec->get_cusparse_handle();
-    gko::cuda::device_guard g{id};
     auto desc = cusparse::create_mat_descr();
     auto info = cusparse::create_ic0_info();
 

--- a/cuda/factorization/ilu_kernels.cu
+++ b/cuda/factorization/ilu_kernels.cu
@@ -37,7 +37,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
 #include "cuda/base/cusparse_bindings.hpp"
-#include "cuda/base/device_guard.hpp"
 
 
 namespace gko {
@@ -57,7 +56,6 @@ void compute_lu(std::shared_ptr<const DefaultExecutor> exec,
 {
     const auto id = exec->get_device_id();
     auto handle = exec->get_cusparse_handle();
-    gko::cuda::device_guard g{id};
     auto desc = cusparse::create_mat_descr();
     auto info = cusparse::create_ilu0_info();
 

--- a/hip/base/device_guard.hip.hpp
+++ b/hip/base/device_guard.hip.hpp
@@ -57,11 +57,12 @@ namespace hip {
  */
 class device_guard {
 public:
-    device_guard(int device_id)
+    device_guard(int device_id) : original_device_id{}, need_reset{}
     {
         GKO_ASSERT_NO_HIP_ERRORS(hipGetDevice(&original_device_id));
         if (original_device_id != device_id) {
             GKO_ASSERT_NO_HIP_ERRORS(hipSetDevice(device_id));
+            need_reset = true;
         }
     }
 
@@ -75,16 +76,19 @@ public:
 
     ~device_guard() noexcept(false)
     {
-        /* Ignore the error during stack unwinding for this call */
-        if (std::uncaught_exception()) {
-            hipSetDevice(original_device_id);
-        } else {
-            GKO_ASSERT_NO_HIP_ERRORS(hipSetDevice(original_device_id));
+        if (need_reset) {
+            /* Ignore the error during stack unwinding for this call */
+            if (std::uncaught_exception()) {
+                hipSetDevice(original_device_id);
+            } else {
+                GKO_ASSERT_NO_HIP_ERRORS(hipSetDevice(original_device_id));
+            }
         }
     }
 
 private:
-    int original_device_id{};
+    int original_device_id;
+    bool need_reset;
 };
 
 

--- a/hip/base/device_guard.hip.hpp
+++ b/hip/base/device_guard.hip.hpp
@@ -60,7 +60,9 @@ public:
     device_guard(int device_id)
     {
         GKO_ASSERT_NO_HIP_ERRORS(hipGetDevice(&original_device_id));
-        GKO_ASSERT_NO_HIP_ERRORS(hipSetDevice(device_id));
+        if (original_device_id != device_id) {
+            GKO_ASSERT_NO_HIP_ERRORS(hipSetDevice(device_id));
+        }
     }
 
     device_guard(device_guard& other) = delete;

--- a/hip/base/kernel_launch.hip.hpp
+++ b/hip/base/kernel_launch.hip.hpp
@@ -39,7 +39,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <hip/hip_runtime.h>
 
 
-#include "hip/base/device_guard.hip.hpp"
 #include "hip/base/types.hip.hpp"
 #include "hip/components/thread_ids.hip.hpp"
 
@@ -83,7 +82,6 @@ void run_kernel(std::shared_ptr<const HipExecutor> exec, KernelFunction fn,
                 size_type size, KernelArgs&&... args)
 {
     if (size > 0) {
-        gko::hip::device_guard guard{exec->get_device_id()};
         constexpr auto block_size = default_block_size;
         auto num_blocks = ceildiv(size, block_size);
         hipLaunchKernelGGL(generic_kernel_1d, num_blocks, block_size, 0, 0,
@@ -97,7 +95,6 @@ void run_kernel(std::shared_ptr<const HipExecutor> exec, KernelFunction fn,
                 dim<2> size, KernelArgs&&... args)
 {
     if (size[0] * size[1] > 0) {
-        gko::hip::device_guard guard{exec->get_device_id()};
         constexpr auto block_size = default_block_size;
         auto num_blocks = ceildiv(size[0] * size[1], block_size);
         hipLaunchKernelGGL(generic_kernel_2d, num_blocks, block_size, 0, 0,

--- a/hip/base/kernel_launch_reduction.hip.hpp
+++ b/hip/base/kernel_launch_reduction.hip.hpp
@@ -37,7 +37,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
 #include "core/synthesizer/implementation_selection.hpp"
-#include "hip/base/device_guard.hip.hpp"
 #include "hip/base/types.hip.hpp"
 #include "hip/components/cooperative_groups.hip.hpp"
 #include "hip/components/reduction.hip.hpp"
@@ -144,7 +143,6 @@ void run_kernel_reduction(std::shared_ptr<const HipExecutor> exec,
                           KernelArgs&&... args)
 {
     constexpr int oversubscription = 16;
-    gko::hip::device_guard guard{exec->get_device_id()};
     constexpr auto block_size = default_block_size;
     const auto num_blocks = std::min<int64>(
         ceildiv(size, block_size), exec->get_num_warps() * oversubscription);
@@ -178,7 +176,6 @@ void run_kernel_reduction(std::shared_ptr<const HipExecutor> exec,
                           ValueType* result, dim<2> size, KernelArgs&&... args)
 {
     constexpr int oversubscription = 16;
-    gko::hip::device_guard guard{exec->get_device_id()};
     constexpr auto block_size = default_block_size;
     const auto rows = static_cast<int64>(size[0]);
     const auto cols = static_cast<int64>(size[1]);
@@ -441,7 +438,6 @@ void run_kernel_row_reduction(std::shared_ptr<const HipExecutor> exec,
     using subwarp_sizes =
         syn::value_list<int, 1, 2, 4, 8, 16, 32, config::warp_size>;
     constexpr int oversubscription = 16;
-    gko::hip::device_guard guard{exec->get_device_id()};
     const auto rows = static_cast<int64>(size[0]);
     const auto cols = static_cast<int64>(size[1]);
     const auto resources =
@@ -488,7 +484,6 @@ void run_kernel_col_reduction(std::shared_ptr<const HipExecutor> exec,
     using subwarp_sizes =
         syn::value_list<int, 1, 2, 4, 8, 16, 32, config::warp_size>;
     constexpr int oversubscription = 16;
-    gko::hip::device_guard guard{exec->get_device_id()};
     const auto rows = static_cast<int64>(size[0]);
     const auto cols = static_cast<int64>(size[1]);
     const auto max_blocks = exec->get_num_warps() * config::warp_size *

--- a/hip/base/kernel_launch_solver.hip.hpp
+++ b/hip/base/kernel_launch_solver.hip.hpp
@@ -66,7 +66,6 @@ void run_kernel_solver(std::shared_ptr<const HipExecutor> exec,
                        KernelArgs&&... args)
 {
     if (size[0] * size[1] > 0) {
-        gko::hip::device_guard guard{exec->get_device_id()};
         constexpr auto block_size = kernels::hip::default_block_size;
         auto num_blocks = ceildiv(size[0] * size[1], block_size);
         hipLaunchKernelGGL(kernels::hip::generic_kernel_2d_solver, num_blocks,

--- a/hip/factorization/ic_kernels.hip.cpp
+++ b/hip/factorization/ic_kernels.hip.cpp
@@ -39,7 +39,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <ginkgo/core/base/array.hpp>
 
 
-#include "hip/base/device_guard.hip.hpp"
 #include "hip/base/hipsparse_bindings.hip.hpp"
 
 
@@ -60,7 +59,6 @@ void compute(std::shared_ptr<const DefaultExecutor> exec,
 {
     const auto id = exec->get_device_id();
     auto handle = exec->get_hipsparse_handle();
-    gko::hip::device_guard g{id};
     auto desc = hipsparse::create_mat_descr();
     auto info = hipsparse::create_ic0_info();
 

--- a/hip/factorization/ilu_kernels.hip.cpp
+++ b/hip/factorization/ilu_kernels.hip.cpp
@@ -39,7 +39,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <ginkgo/core/base/array.hpp>
 
 
-#include "hip/base/device_guard.hip.hpp"
 #include "hip/base/hipsparse_bindings.hip.hpp"
 
 
@@ -60,7 +59,6 @@ void compute_lu(std::shared_ptr<const DefaultExecutor> exec,
 {
     const auto id = exec->get_device_id();
     auto handle = exec->get_hipsparse_handle();
-    gko::hip::device_guard g{id};
     auto desc = hipsparse::create_mat_descr();
     auto info = hipsparse::create_ilu0_info();
 

--- a/hip/solver/common_trs_kernels.hip.hpp
+++ b/hip/solver/common_trs_kernels.hip.hpp
@@ -48,7 +48,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "core/matrix/dense_kernels.hpp"
 #include "core/synthesizer/implementation_selection.hpp"
-#include "hip/base/device_guard.hip.hpp"
 #include "hip/base/hipsparse_bindings.hip.hpp"
 #include "hip/base/math.hip.hpp"
 #include "hip/base/pointer_mode_guard.hip.hpp"


### PR DESCRIPTION
pulled out of #938, we don't need to set the device ID kernels, because it already gets set by the executor->run function.