### PR TITLE
Add zip_iterator implementation

### DIFF
--- a/core/base/iterator_factory.hpp
+++ b/core/base/iterator_factory.hpp
@@ -34,353 +34,263 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define GKO_CORE_BASE_ITERATOR_FACTORY_HPP_
 
 
+#include <cassert>
+#include <cstddef>
 #include <iterator>
-
-
-#include <ginkgo/core/base/types.hpp>
+#include <tuple>
+#include <utility>
 
 
 namespace gko {
 namespace detail {
 
 
-/**
- * @internal
- * @brief This class is used to sort two distinct arrays (`dominant_values` and
- * `secondary_values`) with the same number of elements (it can be different
- * types) according to the `dominant_values` in ascending order.
- *
- * Stores the pointers of two arrays, one storing the type `SecondaryType`, and
- * one storing the type `ToSortType`. This class also provides an iterator
- * class, which can be used for `std::sort`. Without a custom iterator, memory
- * copies would be necessary to create, for example, one array of `std::pairs`
- * to use `std::sort`, or a self written sort function.
- *
- * Example of using this class to sort a list of people according to their age:
- * -----------------------------------------------------------------
- * ```cpp
- * std::vector<int> age{50, 44, 43, 42};
- * std::vector<std::string> person{"Karl", "Susanne", "Max", "Hannah"};
- * IteratorFactory<int, std::string> factory{age.data(), person.data(), 4};
- * std::sort(factory.begin(), factory.end());
- * ```
- * Here, `person` now contains: `{"Hannah", "Max", "Susanne", "Karl"}` and
- * `age` is now `{42, 43, 44, 50}`. Therefore, both arrays are now sorted
- * according to the values in ascending order of `age`.
- *
- * @tparam ToSortType  Type of the values which will be used for sorting.
- *                     It must support `operator<`.
- * @tparam SecondaryType  Type of the values which will be moved synchronous
- *                        to the array of type `ToSortType`. No comparisons
- *                        with this type will be performed.
- */
-template <typename ToSortType, typename SecondaryType>
-class IteratorFactory {
-    // All nested classes are hidden, so they can't be misused
-private:
-    /**
-     * Helper struct, needed for the default construction and assignment inside
-     * `std::sort` through Reference. They are used as an intermediate data
-     * type for some of the swaps `std::sort` performs.
-     */
-    struct element {
-        ToSortType dominant;
-        SecondaryType secondary;
-
-        friend bool operator<(const element& left, const element& right)
-        {
-            return left.dominant < right.dominant;
-        }
-    };
-
-    /**
-     * This class is used as a reference to a sorting target, which abstracts
-     * the existence of two distinct arrays.
-     * It meets the requirements of `MoveAssignable`, `MoveConstructible`
-     * In all comparisons, only the values of `dominant_values_` matter, while
-     * the corresponding value of `secondary_values_` will always be copied /
-     * moved / swapped to the same place.
-     */
-    class Reference {
-    public:
-        using array_index_type = int64;
-
-        // An empty reference makes no sense, so is is disabled
-        Reference() = delete;
-
-        ~Reference() {}
-
-        Reference(IteratorFactory* parent, array_index_type array_index)
-            : parent_(parent), arr_index_(array_index)
-        {}
-
-        // Since it must be `MoveConstructible`
-        Reference(Reference&& other)
-            : parent_(other.parent_), arr_index_(std::move(other.arr_index_))
-        {}
-
-        Reference(const Reference& other)
-            : parent_(other.parent_), arr_index_(other.arr_index_)
-        {}
+template <typename... Args>
+void tuple_unpack_sink(Args&&...)
+{}
 
 
-        Reference& operator=(element other)
-        {
-            dominant() = other.dominant;
-            secondary() = other.secondary;
-            return *this;
-        }
+template <typename... Iterators>
+class zip_iterator;
 
-        Reference& operator=(const Reference& other)
-        {
-            dominant() = other.dominant();
-            secondary() = other.secondary();
-            return *this;
-        }
 
-        // Since it must be `MoveAssignable`
-        Reference& operator=(Reference&& other)
-        {
-            // In C++11, it is legal for a nested class to access private
-            // members of the parent class.
-            parent_->dominant_values_[arr_index_] =
-                std::move(other.parent_->dominant_values_[other.arr_index_]);
-            parent_->secondary_values_[arr_index_] =
-                std::move(other.parent_->secondary_values_[other.arr_index_]);
-            return *this;
-        }
+template <typename... Iterators>
+class zip_iterator_reference
+    : public std::tuple<
+          typename std::iterator_traits<Iterators>::reference...> {
+    using ref_tuple_type =
+        std::tuple<typename std::iterator_traits<Iterators>::reference...>;
+    using value_type =
+        std::tuple<typename std::iterator_traits<Iterators>::value_type...>;
+    using index_sequence = std::index_sequence_for<Iterators...>;
 
-        // Conversion operator to `element`
-        operator element() const { return {dominant(), secondary()}; }
+    friend class zip_iterator<Iterators...>;
 
-        friend void swap(Reference a, Reference b)
-        {
-            std::swap(a.dominant(), b.dominant());
-            std::swap(a.secondary(), b.secondary());
-        }
+    template <std::size_t... idxs>
+    value_type cast_impl(std::index_sequence<idxs...>) const
+    {
+        return {std::get<idxs>(*this)...};
+    }
 
-        friend bool operator<(const Reference& left, const Reference& right)
-        {
-            return left.dominant() < right.dominant();
-        }
+    template <std::size_t... idxs>
+    void assign_impl(std::index_sequence<idxs...>, const value_type& other)
+    {
+        tuple_unpack_sink(
+            (std::get<idxs>(*this) = std::get<idxs>(other), 0)...);
+    }
 
-        friend bool operator<(const Reference& left, const element& right)
-        {
-            return left.dominant() < right.dominant;
-        }
-
-        friend bool operator<(const element& left, const Reference& right)
-        {
-            return left.dominant < right.dominant();
-        }
-
-        ToSortType& dominant() { return parent_->dominant_values_[arr_index_]; }
-
-        const ToSortType& dominant() const
-        {
-            return parent_->dominant_values_[arr_index_];
-        }
-
-        SecondaryType& secondary()
-        {
-            return parent_->secondary_values_[arr_index_];
-        }
-
-        const SecondaryType& secondary() const
-        {
-            return parent_->secondary_values_[arr_index_];
-        }
-
-    private:
-        IteratorFactory* parent_;
-        array_index_type arr_index_;
-    };
-
-    /**
-     * The iterator that can be used for `std::sort`. It meets the requirements
-     * of `LegacyRandomAccessIterator` and `ValueSwappable`.
-     * For performance reasons, it is expected that all iterators that are
-     * compared / used with each other have the same `parent`, so the check
-     * if they are the same can be omitted.
-     * This class uses a single variable to keep track of where the iterator
-     * points to both arrays.
-     */
-    class Iterator {
-    public:
-        // Needed to count as a `LegacyRandomAccessIterator`
-        using difference_type = typename Reference::array_index_type;
-        using value_type = element;
-        using pointer = Reference;
-        using reference = Reference;
-        using iterator_category = std::random_access_iterator_tag;
-
-        Iterator() = default;
-
-        ~Iterator() {}
-
-        Iterator(IteratorFactory* parent, difference_type array_index)
-            : parent_(parent), arr_index_(array_index)
-        {}
-
-        Iterator(const Iterator& other)
-            : parent_(other.parent_), arr_index_(other.arr_index_)
-        {}
-
-        Iterator& operator=(const Iterator& other)
-        {
-            arr_index_ = other.arr_index_;
-            return *this;
-        }
-
-        // Operators needed for the std::sort requirement of
-        // `LegacyRandomAccessIterator`
-        Iterator& operator+=(difference_type i)
-        {
-            arr_index_ += i;
-            return *this;
-        }
-
-        Iterator& operator-=(difference_type i)
-        {
-            arr_index_ -= i;
-            return *this;
-        }
-
-        Iterator& operator++()  // Prefix increment (++i)
-        {
-            ++arr_index_;
-            return *this;
-        }
-
-        Iterator operator++(int)  // Postfix increment (i++)
-        {
-            Iterator temp(*this);
-            ++arr_index_;
-            return temp;
-        }
-
-        Iterator& operator--()  // Prefix decrement (--i)
-        {
-            --arr_index_;
-            return *this;
-        }
-
-        Iterator operator--(int)  // Postfix decrement (i--)
-        {
-            Iterator temp(*this);
-            --arr_index_;
-            return temp;
-        }
-
-        Iterator operator+(difference_type i) const
-        {
-            return {parent_, arr_index_ + i};
-        }
-
-        friend Iterator operator+(difference_type i, const Iterator& iter)
-        {
-            return {iter.parent_, iter.arr_index_ + i};
-        }
-
-        Iterator operator-(difference_type i) const
-        {
-            return {parent_, arr_index_ - i};
-        }
-
-        difference_type operator-(const Iterator& other) const
-        {
-            return arr_index_ - other.arr_index_;
-        }
-
-        Reference operator*() const { return {parent_, arr_index_}; }
-
-        Reference operator[](difference_type idx) const
-        {
-            return {parent_, arr_index_ + idx};
-        }
-
-        // Comparable operators
-        bool operator==(const Iterator& other) const
-        {
-            return arr_index_ == other.arr_index_;
-        }
-
-        bool operator!=(const Iterator& other) const
-        {
-            return arr_index_ != other.arr_index_;
-        }
-
-        bool operator<(const Iterator& other) const
-        {
-            return arr_index_ < other.arr_index_;
-        }
-
-        bool operator<=(const Iterator& other) const
-        {
-            return arr_index_ <= other.arr_index_;
-        }
-
-        bool operator>(const Iterator& other) const
-        {
-            return arr_index_ > other.arr_index_;
-        }
-
-        bool operator>=(const Iterator& other) const
-        {
-            return arr_index_ >= other.arr_index_;
-        }
-
-    private:
-        IteratorFactory* parent_{};
-        difference_type arr_index_{};
-    };
+    zip_iterator_reference(Iterators... it) : ref_tuple_type{*it...} {}
 
 public:
-    /**
-     * Allows creating an iterator, which makes it look like the data consists
-     * of `size` `std::pair<ToSortType, SecondaryType>`s, which are also
-     * sortable (according to the value of `dominant_values`) as long as
-     * `ToSortType` can be comparable with `operator<`. No additional data is
-     * allocated, all operations performed through the Iterator object will be
-     * done on the given arrays. The iterators given by this object (through
-     * `begin()` and `end()`) can be used with `std::sort()`.
-     * @param dominant_values  Array of at least `size` values, which are the
-     * only values considered when comparing values (for example while sorting)
-     * @param secondary_values  Array of at least `size` values, which will not
-     * be considered when comparing. However, they will be moved / copied to the
-     * same place as their corresponding value in `dominant_values` (with the
-     * same index).
-     * @param size  Size of the arrays when constructiong the iterators.
-     * @note Both arrays must have at least `size` elements, otherwise, the
-     * behaviour is undefined.
-     */
-    IteratorFactory(ToSortType* dominant_values,
-                    SecondaryType* secondary_values, size_type size)
-        : dominant_values_(dominant_values),
-          secondary_values_(secondary_values),
-          size_(size)
-    {}
+    operator value_type() const { return cast_impl(index_sequence{}); }
 
-    /**
-     * Creates an iterator pointing to the beginning of both arrays
-     * @returns  an iterator pointing to the beginning of both arrays
-     */
-    Iterator begin() { return {this, 0}; }
-
-    /**
-     * Creates an iterator pointing to the (excluding) end of both arrays
-     * @returns  an iterator pointing to the (excluding) end of both arrays
-     */
-    Iterator end()
+    zip_iterator_reference& operator=(const value_type& other)
     {
-        return {this, static_cast<typename Iterator::difference_type>(size_)};
+        assign_impl(index_sequence{}, other);
+        return *this;
+    }
+};
+
+
+template <typename... Iterators>
+class zip_iterator {
+    static_assert(sizeof...(Iterators) > 0, "Can't build empty zip iterator");
+
+public:
+    using difference_type = std::ptrdiff_t;
+    using value_type =
+        std::tuple<typename std::iterator_traits<Iterators>::value_type...>;
+    using pointer = value_type*;
+    using reference = zip_iterator_reference<Iterators...>;
+    using iterator_category = std::random_access_iterator_tag;
+    using index_sequence = std::index_sequence_for<Iterators...>;
+
+    explicit zip_iterator() = default;
+
+    explicit zip_iterator(Iterators... its) : iterators_{its...} {}
+
+    zip_iterator& operator+=(difference_type i)
+    {
+        forall([i](auto& it) { it += i; });
+        return *this;
+    }
+
+    zip_iterator& operator-=(difference_type i)
+    {
+        forall([i](auto& it) { it -= i; });
+        return *this;
+    }
+
+    zip_iterator& operator++()
+    {
+        forall([](auto& it) { it++; });
+        return *this;
+    }
+
+    zip_iterator operator++(int)
+    {
+        auto tmp = *this;
+        ++(*this);
+        return tmp;
+    }
+
+    zip_iterator& operator--()
+    {
+        forall([](auto& it) { it--; });
+        return *this;
+    }
+
+    zip_iterator operator--(int)
+    {
+        auto tmp = *this;
+        --(*this);
+        return tmp;
+    }
+
+    zip_iterator operator+(difference_type i) const
+    {
+        auto tmp = *this;
+        tmp += i;
+        return tmp;
+    }
+
+    friend zip_iterator operator+(difference_type i, const zip_iterator& iter)
+    {
+        return iter + i;
+    }
+
+    zip_iterator operator-(difference_type i) const
+    {
+        auto tmp = *this;
+        tmp -= i;
+        return tmp;
+    }
+
+    difference_type operator-(const zip_iterator& other) const
+    {
+        return forall_check_consistent(
+            other, [](const auto& a, const auto& b) { return a - b; });
+    }
+
+    reference operator*() const
+    {
+        return deref_impl(std::index_sequence_for<Iterators...>{});
+    }
+
+    reference operator[](difference_type i) const { return *(*this + i); }
+
+    bool operator==(const zip_iterator& other) const
+    {
+        return forall_check_consistent(
+            other, [](const auto& a, const auto& b) { return a == b; });
+    }
+
+    bool operator!=(const zip_iterator& other) const
+    {
+        return !(*this == other);
+    }
+
+    bool operator<(const zip_iterator& other) const
+    {
+        return forall_check_consistent(
+            other, [](const auto& a, const auto& b) { return a < b; });
+    }
+
+    bool operator<=(const zip_iterator& other) const
+    {
+        return forall_check_consistent(
+            other, [](const auto& a, const auto& b) { return a <= b; });
+    }
+
+    bool operator>(const zip_iterator& other) const
+    {
+        return !(*this <= other);
+    }
+
+    bool operator>=(const zip_iterator& other) const
+    {
+        return !(*this < other);
     }
 
 private:
-    ToSortType* dominant_values_;
-    SecondaryType* secondary_values_;
-    size_type size_;
+    template <std::size_t... idxs>
+    reference deref_impl(std::index_sequence<idxs...>) const
+    {
+        return reference{std::get<idxs>(iterators_)...};
+    }
+
+    template <typename Functor>
+    void forall(Functor fn)
+    {
+        forall_impl(fn, index_sequence{});
+    }
+
+    template <typename Functor, std::size_t... idxs>
+    void forall_impl(Functor fn, std::index_sequence<idxs...>)
+    {
+        tuple_unpack_sink((fn(std::get<idxs>(iterators_)), 0)...);
+    }
+
+    template <typename Functor, std::size_t... idxs>
+    void forall_impl(const zip_iterator& other, Functor fn,
+                     std::index_sequence<idxs...>) const
+    {
+        tuple_unpack_sink(
+            (fn(std::get<idxs>(iterators_), std::get<idxs>(other.iterators_)),
+             0)...);
+    }
+
+    template <typename Functor>
+    auto forall_check_consistent(const zip_iterator& other, Functor fn) const
+    {
+        auto result =
+            fn(std::get<0>(iterators_), std::get<0>(other.iterators_));
+        forall_impl(
+            other, [&](auto a, auto b) { assert(fn(a, b) == result); },
+            index_sequence{});
+        return result;
+    }
+
+    std::tuple<Iterators...> iterators_;
 };
+
+
+template <typename... Iterators>
+zip_iterator<std::decay_t<Iterators>...> make_zip_iterator(Iterators&&... it)
+{
+    return zip_iterator<std::decay_t<Iterators>...>{
+        std::forward<Iterators>(it)...};
+}
+
+
+template <typename... Iterators>
+void swap(zip_iterator_reference<Iterators...> a,
+          zip_iterator_reference<Iterators...> b)
+{
+    typename zip_iterator<Iterators...>::value_type tmp = a;
+    a = b;
+    b = tmp;
+}
+
+
+template <typename... Iterators>
+void swap(typename zip_iterator<Iterators...>::value_type& a,
+          zip_iterator_reference<Iterators...> b)
+{
+    typename zip_iterator<Iterators...>::value_type tmp = a;
+    a = b;
+    b = tmp;
+}
+
+
+template <typename... Iterators>
+void swap(zip_iterator_reference<Iterators...> a,
+          typename zip_iterator<Iterators...>::value_type& b)
+{
+    typename zip_iterator<Iterators...>::value_type tmp = a;
+    a = b;
+    b = tmp;
+}
 
 
 }  // namespace detail

--- a/core/base/iterator_factory.hpp
+++ b/core/base/iterator_factory.hpp
@@ -118,6 +118,23 @@ public:
  * to the individual tuple elements get translated to the corresponding
  * iterator's references.
  *
+ * @note Two zip_iterators can only be compared if each individual pair of
+ *       wrapped iterators has the same distance. Otherwise the behavior is
+ *       undefined. This means that the only guaranteed safe way to use multiple
+ *       zip_iterators is if they are all derived from the same iterator:
+ *       ```
+ *       Iterator i, j;
+ *       auto it1 = make_zip_iterator(i, j);
+ *       auto it2 = make_zip_iterator(i, j + 1);
+ *       auto it3 = make_zip_iterator(i + 1, j + 1);
+ *       auto it4 = it1 + 1;
+ *       it1 == it2; // undefined
+ *       it1 == it3; // well-defined false
+ *       it3 == it4; // well-defined true
+ *       ```
+ *       This property is checked automatically in Debug builds and assumed in
+ *       Release builds.
+ *
  * @see zip_iterator_reference
  * @tparam Iterators  the iterators to zip together
  */

--- a/core/test/base/iterator_factory.cpp
+++ b/core/test/base/iterator_factory.cpp
@@ -260,13 +260,13 @@ TYPED_TEST(IteratorFactory, IncompatibleIteratorDeathTest)
 
     // a set of operations that return inconsistent results for the two
     // different iterators
-    EXPECT_EXIT(it2 - it1, testing::KilledBySignal(SIGABRT), "");
-    EXPECT_EXIT(it2 == it1, testing::KilledBySignal(SIGABRT), "");
-    EXPECT_EXIT(it2 != it1, testing::KilledBySignal(SIGABRT), "");
-    EXPECT_EXIT(it1 < it2, testing::KilledBySignal(SIGABRT), "");
-    EXPECT_EXIT(it2 <= it1, testing::KilledBySignal(SIGABRT), "");
-    EXPECT_EXIT(it2 > it1, testing::KilledBySignal(SIGABRT), "");
-    EXPECT_EXIT(it1 >= it2, testing::KilledBySignal(SIGABRT), "");
+    EXPECT_DEATH(it2 - it1, "");
+    EXPECT_DEATH(it2 == it1, "");
+    EXPECT_DEATH(it2 != it1, "");
+    EXPECT_DEATH(it1 < it2, "");
+    EXPECT_DEATH(it2 <= it1, "");
+    EXPECT_DEATH(it2 > it1, "");
+    EXPECT_DEATH(it1 >= it2, "");
 }
 
 

--- a/core/test/base/iterator_factory.cpp
+++ b/core/test/base/iterator_factory.cpp
@@ -34,6 +34,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
 #include <algorithm>
+#include <complex>
 #include <numeric>
 #include <vector>
 

--- a/core/test/base/iterator_factory.cpp
+++ b/core/test/base/iterator_factory.cpp
@@ -246,6 +246,33 @@ TYPED_TEST(IteratorFactory, IncreasingIterator)
 }
 
 
+#ifndef NDEBUG
+
+
+TYPED_TEST(IteratorFactory, IncompatibleIteratorDeathTest)
+{
+    using index_type = typename TestFixture::index_type;
+    using value_type = typename TestFixture::value_type;
+    auto it1 = gko::detail::make_zip_iterator(this->ordered_index.data(),
+                                              this->ordered_value.data());
+    auto it2 = gko::detail::make_zip_iterator(this->ordered_index.data() + 1,
+                                              this->ordered_value.data());
+
+    // a set of operations that return inconsistent results for the two
+    // different iterators
+    EXPECT_EXIT(it2 - it1, testing::KilledBySignal(SIGABRT), "");
+    EXPECT_EXIT(it2 == it1, testing::KilledBySignal(SIGABRT), "");
+    EXPECT_EXIT(it2 != it1, testing::KilledBySignal(SIGABRT), "");
+    EXPECT_EXIT(it1 < it2, testing::KilledBySignal(SIGABRT), "");
+    EXPECT_EXIT(it2 <= it1, testing::KilledBySignal(SIGABRT), "");
+    EXPECT_EXIT(it2 > it1, testing::KilledBySignal(SIGABRT), "");
+    EXPECT_EXIT(it1 >= it2, testing::KilledBySignal(SIGABRT), "");
+}
+
+
+#endif
+
+
 TYPED_TEST(IteratorFactory, DecreasingIterator)
 {
     using index_type = typename TestFixture::index_type;

--- a/core/test/base/iterator_factory.cpp
+++ b/core/test/base/iterator_factory.cpp
@@ -250,6 +250,18 @@ TYPED_TEST(IteratorFactory, IncreasingIterator)
 #ifndef NDEBUG
 
 
+bool check_assertion_exit_code(int exit_code)
+{
+#ifdef _MSC_VER
+    // MSVC picks up the exit code incorrectly,
+    // so we can only check that it exits
+    return true;
+#else
+    return exit_code != 0;
+#endif
+}
+
+
 TYPED_TEST(IteratorFactory, IncompatibleIteratorDeathTest)
 {
     using index_type = typename TestFixture::index_type;
@@ -261,13 +273,13 @@ TYPED_TEST(IteratorFactory, IncompatibleIteratorDeathTest)
 
     // a set of operations that return inconsistent results for the two
     // different iterators
-    EXPECT_DEATH(it2 - it1, "");
-    EXPECT_DEATH(it2 == it1, "");
-    EXPECT_DEATH(it2 != it1, "");
-    EXPECT_DEATH(it1 < it2, "");
-    EXPECT_DEATH(it2 <= it1, "");
-    EXPECT_DEATH(it2 > it1, "");
-    EXPECT_DEATH(it1 >= it2, "");
+    EXPECT_EXIT(it2 - it1, check_assertion_exit_code, "");
+    EXPECT_EXIT(it2 == it1, check_assertion_exit_code, "");
+    EXPECT_EXIT(it2 != it1, check_assertion_exit_code, "");
+    EXPECT_EXIT(it1 < it2, check_assertion_exit_code, "");
+    EXPECT_EXIT(it2 <= it1, check_assertion_exit_code, "");
+    EXPECT_EXIT(it2 > it1, check_assertion_exit_code, "");
+    EXPECT_EXIT(it1 >= it2, check_assertion_exit_code, "");
 }
 
 

--- a/core/test/utils/unsort_matrix.hpp
+++ b/core/test/utils/unsort_matrix.hpp
@@ -81,9 +81,8 @@ void unsort_matrix(matrix::Csr<ValueType, IndexType>* mtx,
     for (index_type row = 0; row < size[0]; ++row) {
         auto start = row_ptrs[row];
         auto end = row_ptrs[row + 1];
-        auto sort_wrapper = gko::detail::IteratorFactory<IndexType, ValueType>(
-            cols + start, vals + start, end - start);
-        std::shuffle(sort_wrapper.begin(), sort_wrapper.end(), engine);
+        auto it = gko::detail::make_zip_iterator(cols + start, vals + start);
+        std::shuffle(it, it + (end - start), engine);
     }
 }
 

--- a/omp/matrix/csr_kernels.cpp
+++ b/omp/matrix/csr_kernels.cpp
@@ -903,9 +903,11 @@ void sort_by_column_index(std::shared_ptr<const OmpExecutor> exec,
     for (size_type i = 0; i < number_rows; ++i) {
         auto start_row_idx = row_ptrs[i];
         auto row_nnz = row_ptrs[i + 1] - start_row_idx;
-        auto helper = detail::IteratorFactory<IndexType, ValueType>(
-            col_idxs + start_row_idx, values + start_row_idx, row_nnz);
-        std::sort(helper.begin(), helper.end());
+        auto it = detail::make_zip_iterator(col_idxs + start_row_idx,
+                                            values + start_row_idx);
+        std::sort(it, it + row_nnz, [](auto t1, auto t2) {
+            return std::get<0>(t1) < std::get<0>(t2);
+        });
     }
 }
 

--- a/omp/matrix/fbcsr_kernels.cpp
+++ b/omp/matrix/fbcsr_kernels.cpp
@@ -391,9 +391,10 @@ void sort_by_column_index_impl(
 
         std::vector<IndexType> col_permute(nbnz_brow);
         std::iota(col_permute.begin(), col_permute.end(), 0);
-        auto helper = detail::IteratorFactory<IndexType, IndexType>(
-            brow_col_idxs, col_permute.data(), nbnz_brow);
-        std::sort(helper.begin(), helper.end());
+        auto it = detail::make_zip_iterator(brow_col_idxs, col_permute.data());
+        std::sort(it, it + nbnz_brow, [](auto a, auto b) {
+            return std::get<0>(a) < std::get<0>(b);
+        });
 
         std::vector<ValueType> oldvalues(nbnz_brow * bs2);
         std::copy(brow_vals, brow_vals + nbnz_brow * bs2, oldvalues.begin());

--- a/omp/matrix/sparsity_csr_kernels.cpp
+++ b/omp/matrix/sparsity_csr_kernels.cpp
@@ -46,7 +46,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <ginkgo/core/matrix/dense.hpp>
 
 
-#include "core/base/iterator_factory.hpp"
 #include "core/components/fill_array_kernels.hpp"
 #include "core/components/prefix_sum_kernels.hpp"
 

--- a/reference/matrix/csr_kernels.cpp
+++ b/reference/matrix/csr_kernels.cpp
@@ -874,9 +874,11 @@ void sort_by_column_index(std::shared_ptr<const ReferenceExecutor> exec,
     for (size_type i = 0; i < number_rows; ++i) {
         auto start_row_idx = row_ptrs[i];
         auto row_nnz = row_ptrs[i + 1] - start_row_idx;
-        auto helper = detail::IteratorFactory<IndexType, ValueType>(
-            col_idxs + start_row_idx, values + start_row_idx, row_nnz);
-        std::sort(helper.begin(), helper.end());
+        auto it = detail::make_zip_iterator(col_idxs + start_row_idx,
+                                            values + start_row_idx);
+        std::sort(it, it + row_nnz, [](auto t1, auto t2) {
+            return std::get<0>(t1) < std::get<0>(t2);
+        });
     }
 }
 

--- a/reference/matrix/fbcsr_kernels.cpp
+++ b/reference/matrix/fbcsr_kernels.cpp
@@ -445,9 +445,10 @@ void sort_by_column_index_impl(
 
         std::vector<IndexType> col_permute(nbnz_brow);
         std::iota(col_permute.begin(), col_permute.end(), 0);
-        auto helper = detail::IteratorFactory<IndexType, IndexType>(
-            brow_col_idxs, col_permute.data(), nbnz_brow);
-        std::sort(helper.begin(), helper.end());
+        auto it = detail::make_zip_iterator(brow_col_idxs, col_permute.data());
+        std::sort(it, it + nbnz_brow, [](auto a, auto b) {
+            return std::get<0>(a) < std::get<0>(b);
+        });
 
         std::vector<ValueType> oldvalues(nbnz_brow * bs2);
         std::copy(brow_vals, brow_vals + nbnz_brow * bs2, oldvalues.begin());

--- a/reference/matrix/sparsity_csr_kernels.cpp
+++ b/reference/matrix/sparsity_csr_kernels.cpp
@@ -43,7 +43,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <ginkgo/core/matrix/dense.hpp>
 
 
-#include "core/base/iterator_factory.hpp"
 #include "core/components/fill_array_kernels.hpp"
 #include "core/components/prefix_sum_kernels.hpp"
 


### PR DESCRIPTION
This PR adds a generic zip_iterator implementation as a replacement for IteratorFactory, which is currently limited to only two types with a fixed comparison operator. Most of the code is boilerplate, a few important things are:

* `zip_iterator_reference` is basically a std::tuple of references, so any assignment to it goes directly to the underlying values. This has the same caveats and downsides as the `std::vector<bool>` bit reference type and, coincidentally, accessors, i.e.
  * `auto a = *it` returns a value for normal iterators, but a reference-like type in our case, so subsequent assignment to `a` writes to the underlying memory!
  * `auto& a = *it` leads to a dangling reference (unless you make it const, which extends the lifetime AFAIK)
  * `std::swap(a, b)` for two such references leads to one of the values written to both. This is why we provide a `swap` implementation ourselves. The suggested way to use it in generic code is `using std::swap; swap(a, b)` to enable the namespace-local function to be found first via ADL.
* The comparison and difference operators are implemented such that in debug builds, they assert that the different iterators in the tuple provide the same result to comparisons (in release we just use the first iterator). This behavior is checked using GTest death tests.

Luckily, the C++ standard library already deals correctly with these issues by always writing to `value_type` directly or using only functions like `swap` for actual operations on entries.

A nice side-effect is that it gets rid of the `-Wpsabi` warnings related to the `std::complex` ABI, since everything now happens inside system headers, which AFAIK don't report warnings.

I guess @thoasm is probably most experienced with these kinds of constructions, but I can also provide some pointers to whoever else wants to review it :)

motivated by a comment by @pratikvn, implemented as a nice excercise in C++ edge cases :)

- [x] Add some comments