### PR TITLE
CSR: better strategy defaults.

### DIFF
--- a/cuda/test/matrix/csr_kernels.cpp
+++ b/cuda/test/matrix/csr_kernels.cpp
@@ -409,7 +409,7 @@ TEST_F(Csr, AdvancedApplyToDenseMatrixIsEquivalentToRefWithMergePath)
 
 TEST_F(Csr, AdvancedApplyToCsrMatrixIsEquivalentToRef)
 {
-    set_up_apply_data(std::make_shared<Mtx::automatical>());
+    set_up_apply_data(std::make_shared<Mtx::automatical>(cuda));
     auto trans = mtx->transpose();
     auto d_trans = dmtx->transpose();
 
@@ -424,7 +424,7 @@ TEST_F(Csr, AdvancedApplyToCsrMatrixIsEquivalentToRef)
 
 TEST_F(Csr, SimpleApplyToCsrMatrixIsEquivalentToRef)
 {
-    set_up_apply_data(std::make_shared<Mtx::automatical>());
+    set_up_apply_data(std::make_shared<Mtx::automatical>(cuda));
     auto trans = mtx->transpose();
     auto d_trans = dmtx->transpose();
 
@@ -439,7 +439,7 @@ TEST_F(Csr, SimpleApplyToCsrMatrixIsEquivalentToRef)
 
 TEST_F(Csr, AdvancedApplyToIdentityMatrixIsEquivalentToRef)
 {
-    set_up_apply_data(std::make_shared<Mtx::automatical>());
+    set_up_apply_data(std::make_shared<Mtx::automatical>(cuda));
     auto a = gen_mtx<Mtx>(mtx_size[0], mtx_size[1], 0);
     auto b = gen_mtx<Mtx>(mtx_size[0], mtx_size[1], 0);
     auto da = gko::clone(cuda, a);
@@ -459,7 +459,7 @@ TEST_F(Csr, AdvancedApplyToIdentityMatrixIsEquivalentToRef)
 
 TEST_F(Csr, ApplyToComplexIsEquivalentToRef)
 {
-    set_up_apply_data(std::make_shared<Mtx::automatical>());
+    set_up_apply_data(std::make_shared<Mtx::automatical>(cuda));
     auto complex_b = gen_mtx<ComplexVec>(this->mtx_size[1], 3, 1);
     auto dcomplex_b = gko::clone(cuda, complex_b);
     auto complex_x = gen_mtx<ComplexVec>(this->mtx_size[0], 3, 1);
@@ -474,7 +474,7 @@ TEST_F(Csr, ApplyToComplexIsEquivalentToRef)
 
 TEST_F(Csr, AdvancedApplyToComplexIsEquivalentToRef)
 {
-    set_up_apply_data(std::make_shared<Mtx::automatical>());
+    set_up_apply_data(std::make_shared<Mtx::automatical>(cuda));
     auto complex_b = gen_mtx<ComplexVec>(this->mtx_size[1], 3, 1);
     auto dcomplex_b = gko::clone(cuda, complex_b);
     auto complex_x = gen_mtx<ComplexVec>(this->mtx_size[0], 3, 1);
@@ -767,7 +767,7 @@ TEST_F(Csr, IsInverseColPermutable)
 
 TEST_F(Csr, RecognizeSortedMatrixIsEquivalentToRef)
 {
-    set_up_apply_data(std::make_shared<Mtx::automatical>());
+    set_up_apply_data(std::make_shared<Mtx::automatical>(cuda));
     bool is_sorted_cuda{};
     bool is_sorted_ref{};
 
@@ -794,7 +794,7 @@ TEST_F(Csr, RecognizeUnsortedMatrixIsEquivalentToRef)
 
 TEST_F(Csr, SortSortedMatrixIsEquivalentToRef)
 {
-    set_up_apply_data(std::make_shared<Mtx::automatical>());
+    set_up_apply_data(std::make_shared<Mtx::automatical>(cuda));
 
     mtx->sort_by_column_index();
     dmtx->sort_by_column_index();
@@ -819,7 +819,7 @@ TEST_F(Csr, SortUnsortedMatrixIsEquivalentToRef)
 
 TEST_F(Csr, OneAutomaticalWorksWithDifferentMatrices)
 {
-    auto automatical = std::make_shared<Mtx::automatical>();
+    auto automatical = std::make_shared<Mtx::automatical>(cuda);
     auto row_len_limit = std::max(automatical->nvidia_row_len_limit,
                                   automatical->amd_row_len_limit);
     auto load_balance_mtx =
@@ -840,7 +840,7 @@ TEST_F(Csr, OneAutomaticalWorksWithDifferentMatrices)
 
 TEST_F(Csr, ExtractDiagonalIsEquivalentToRef)
 {
-    set_up_apply_data(std::make_shared<Mtx::automatical>());
+    set_up_apply_data(std::make_shared<Mtx::automatical>(cuda));
 
     auto diag = mtx->extract_diagonal();
     auto ddiag = dmtx->extract_diagonal();

--- a/dpcpp/test/matrix/csr_kernels.cpp
+++ b/dpcpp/test/matrix/csr_kernels.cpp
@@ -410,7 +410,7 @@ TEST_F(Csr, AdvancedApplyToDenseMatrixIsEquivalentToRefWithMergePath)
 
 TEST_F(Csr, AdvancedApplyToCsrMatrixIsEquivalentToRef)
 {
-    set_up_apply_data(std::make_shared<Mtx::automatical>());
+    set_up_apply_data(std::make_shared<Mtx::automatical>(dpcpp));
     auto trans = mtx->transpose();
     auto d_trans = dmtx->transpose();
 
@@ -425,7 +425,7 @@ TEST_F(Csr, AdvancedApplyToCsrMatrixIsEquivalentToRef)
 
 TEST_F(Csr, SimpleApplyToCsrMatrixIsEquivalentToRef)
 {
-    set_up_apply_data(std::make_shared<Mtx::automatical>());
+    set_up_apply_data(std::make_shared<Mtx::automatical>(dpcpp));
     auto trans = mtx->transpose();
     auto d_trans = dmtx->transpose();
 
@@ -440,7 +440,7 @@ TEST_F(Csr, SimpleApplyToCsrMatrixIsEquivalentToRef)
 
 TEST_F(Csr, AdvancedApplyToIdentityMatrixIsEquivalentToRef)
 {
-    set_up_apply_data(std::make_shared<Mtx::automatical>());
+    set_up_apply_data(std::make_shared<Mtx::automatical>(dpcpp));
     auto a = gen_mtx<Mtx>(mtx_size[0], mtx_size[1], 0);
     auto b = gen_mtx<Mtx>(mtx_size[0], mtx_size[1], 0);
     auto da = gko::clone(dpcpp, a);
@@ -460,7 +460,7 @@ TEST_F(Csr, AdvancedApplyToIdentityMatrixIsEquivalentToRef)
 
 TEST_F(Csr, ApplyToComplexIsEquivalentToRef)
 {
-    set_up_apply_data(std::make_shared<Mtx::automatical>());
+    set_up_apply_data(std::make_shared<Mtx::automatical>(dpcpp));
     auto complex_b = gen_mtx<ComplexVec>(this->mtx_size[1], 3, 1);
     auto dcomplex_b = gko::clone(dpcpp, complex_b);
     auto complex_x = gen_mtx<ComplexVec>(this->mtx_size[0], 3, 1);
@@ -475,7 +475,7 @@ TEST_F(Csr, ApplyToComplexIsEquivalentToRef)
 
 TEST_F(Csr, AdvancedApplyToComplexIsEquivalentToRef)
 {
-    set_up_apply_data(std::make_shared<Mtx::automatical>());
+    set_up_apply_data(std::make_shared<Mtx::automatical>(dpcpp));
     auto complex_b = gen_mtx<ComplexVec>(this->mtx_size[1], 3, 1);
     auto dcomplex_b = gko::clone(dpcpp, complex_b);
     auto complex_x = gen_mtx<ComplexVec>(this->mtx_size[0], 3, 1);
@@ -768,7 +768,7 @@ TEST_F(Csr, IsInverseColPermutable)
 
 TEST_F(Csr, RecognizeSortedMatrixIsEquivalentToRef)
 {
-    set_up_apply_data(std::make_shared<Mtx::automatical>());
+    set_up_apply_data(std::make_shared<Mtx::automatical>(dpcpp));
     bool is_sorted_dpcpp{};
     bool is_sorted_ref{};
 
@@ -795,7 +795,7 @@ TEST_F(Csr, RecognizeUnsortedMatrixIsEquivalentToRef)
 
 TEST_F(Csr, SortSortedMatrixIsEquivalentToRef)
 {
-    set_up_apply_data(std::make_shared<Mtx::automatical>());
+    set_up_apply_data(std::make_shared<Mtx::automatical>(dpcpp));
 
     mtx->sort_by_column_index();
     dmtx->sort_by_column_index();
@@ -820,7 +820,7 @@ TEST_F(Csr, SortUnsortedMatrixIsEquivalentToRef)
 
 TEST_F(Csr, OneAutomaticalWorksWithDifferentMatrices)
 {
-    auto automatical = std::make_shared<Mtx::automatical>();
+    auto automatical = std::make_shared<Mtx::automatical>(dpcpp);
     auto row_len_limit = std::max(automatical->nvidia_row_len_limit,
                                   automatical->amd_row_len_limit);
     auto load_balance_mtx =
@@ -841,7 +841,7 @@ TEST_F(Csr, OneAutomaticalWorksWithDifferentMatrices)
 
 TEST_F(Csr, ExtractDiagonalIsEquivalentToRef)
 {
-    set_up_apply_data(std::make_shared<Mtx::automatical>());
+    set_up_apply_data(std::make_shared<Mtx::automatical>(dpcpp));
 
     auto diag = mtx->extract_diagonal();
     auto ddiag = dmtx->extract_diagonal();

--- a/dpcpp/test/matrix/csr_kernels.cpp
+++ b/dpcpp/test/matrix/csr_kernels.cpp
@@ -821,8 +821,7 @@ TEST_F(Csr, SortUnsortedMatrixIsEquivalentToRef)
 TEST_F(Csr, OneAutomaticalWorksWithDifferentMatrices)
 {
     auto automatical = std::make_shared<Mtx::automatical>(dpcpp);
-    auto row_len_limit = std::max(automatical->nvidia_row_len_limit,
-                                  automatical->amd_row_len_limit);
+    auto row_len_limit = automatical->intel_row_len_limit;
     auto load_balance_mtx =
         gen_mtx<Mtx>(1, row_len_limit + 1000, row_len_limit + 1);
     auto classical_mtx = gen_mtx<Mtx>(50, 50, 1);

--- a/include/ginkgo/core/matrix/csr.hpp
+++ b/include/ginkgo/core/matrix/csr.hpp
@@ -351,8 +351,11 @@ public:
     public:
         /**
          * Creates a load_balance strategy.
+         *
+         * @warning this is deprecated! Please rely on the new automatic
+         *          strategy instantiation or use one of the other constructors.
          */
-        load_balance()
+        [[deprecated]] load_balance()
             : load_balance(std::move(
                   gko::CudaExecutor::create(0, gko::OmpExecutor::create())))
         {}
@@ -532,8 +535,11 @@ public:
     public:
         /**
          * Creates an automatical strategy.
+         *
+         * @warning this is deprecated! Please rely on the new automatic
+         *          strategy instantiation or use one of the other constructors.
          */
-        automatical()
+        [[deprecated]] automatical()
             : automatical(std::move(
                   gko::CudaExecutor::create(0, gko::OmpExecutor::create())))
         {}
@@ -1102,11 +1108,14 @@ protected:
     {
         auto cuda_exec = std::dynamic_pointer_cast<const CudaExecutor>(exec);
         auto hip_exec = std::dynamic_pointer_cast<const HipExecutor>(exec);
+        auto dpcpp_exec = std::dynamic_pointer_cast<const DpcppExecutor>(exec);
         std::shared_ptr<strategy_type> new_strategy;
         if (cuda_exec) {
             new_strategy = std::make_shared<automatical>(cuda_exec);
         } else if (hip_exec) {
             new_strategy = std::make_shared<automatical>(hip_exec);
+        } else if (dpcpp_exec) {
+            new_strategy = std::make_shared<classical>();
         } else {
             new_strategy = std::make_shared<classical>();
         }
@@ -1204,17 +1213,11 @@ protected:
                                 this_dpcpp_exec);
                     }
                 } else {
+                    // FIXME: this changes strategies.
                     // We had a load balance or automatical strategy from a non
                     // HIP or Cuda executor and are moving to a non HIP or Cuda
                     // executor.
-                    // FIXME this creates a long delay
-                    if (lb) {
-                        new_strat =
-                            std::make_shared<typename CsrType::load_balance>();
-                    } else {
-                        new_strat =
-                            std::make_shared<typename CsrType::automatical>();
-                    }
+                    new_strat = std::make_shared<typename CsrType::classical>();
                 }
             }
         }

--- a/include/ginkgo/core/matrix/csr.hpp
+++ b/include/ginkgo/core/matrix/csr.hpp
@@ -531,6 +531,12 @@ public:
         /* Use imbalance strategy when the matrix has more more than 1e8 on AMD
          * hardware */
         const index_type amd_nnz_limit{static_cast<index_type>(1e8)};
+        /* Use imbalance strategy when the maximum number of nonzero per row is
+         * more than 25600 on Intel hardware */
+        const index_type intel_row_len_limit = 25600;
+        /* Use imbalance strategy when the matrix has more more than 3e8 on
+         * Intel hardware */
+        const index_type intel_nnz_limit{static_cast<index_type>(3e8)};
 
     public:
         /**
@@ -606,12 +612,8 @@ public:
             index_type nnz_limit = nvidia_nnz_limit;
             index_type row_len_limit = nvidia_row_len_limit;
             if (strategy_name_ == "intel") {
-                /* Use imbalance strategy when the maximum number of nonzero per
-                 * row is more than 25600 on Intel hardware. */
-                nnz_limit = 25600;
-                /* Use imbalance strategy when the matrix has more more than 3e8
-                 * on Intel hardware */
-                row_len_limit = 3e8;
+                nnz_limit = intel_nnz_limit;
+                row_len_limit = intel_row_len_limit;
             }
 #if GINKGO_HIP_PLATFORM_HCC
             if (!cuda_strategy_) {
@@ -1115,7 +1117,7 @@ protected:
         } else if (hip_exec) {
             new_strategy = std::make_shared<automatical>(hip_exec);
         } else if (dpcpp_exec) {
-            new_strategy = std::make_shared<classical>();
+            new_strategy = std::make_shared<automatical>(dpcpp_exec);
         } else {
             new_strategy = std::make_shared<classical>();
         }


### PR DESCRIPTION
Provide better CSR strategy defaults.

This duplicates two constructors to select a strategy based on the
executor type instead of defaulting to `automatical(CUDA)`. This should
not break any existing behavior (the `CUDA` case still defaults to
`automatical`), but instead, fix the currently broken combinations.

Background:
Some interesting situation just happened. Due to a seemingly broken
CUDA installation on a cluster, the CUDA API call in `get_num_devices()`
can fail, for example, due to an insufficient driver version or something
else:
```
terminate called after throwing an instance of 'gko::CudaError'
  what():  ../cuda/base/executor.cpp:223: get_num_devices: cudaErrorInsufficientDriver: CUDA driver version is insufficient for CUDA runtime version
```

Since the current CSR strategy is to instantiate a `CudaExecutor`, this
means that in that case all of Ginkgo is broken at runtime, even when
not using an actual `CudaExecutor`. The aim of this PR is to change this
long-time problem with the default strategy type.