### PR TITLE
Adds move_from to PolymorphicObject

### DIFF
--- a/core/log/logger.cpp
+++ b/core/log/logger.cpp
@@ -59,6 +59,8 @@ constexpr Logger::mask_type Logger::polymorphic_object_create_started_mask;
 constexpr Logger::mask_type Logger::polymorphic_object_create_completed_mask;
 constexpr Logger::mask_type Logger::polymorphic_object_copy_started_mask;
 constexpr Logger::mask_type Logger::polymorphic_object_copy_completed_mask;
+constexpr Logger::mask_type Logger::polymorphic_object_move_started_mask;
+constexpr Logger::mask_type Logger::polymorphic_object_move_completed_mask;
 constexpr Logger::mask_type Logger::polymorphic_object_deleted_mask;
 
 constexpr Logger::mask_type Logger::linop_apply_started_mask;

--- a/core/log/papi.cpp
+++ b/core/log/papi.cpp
@@ -149,6 +149,24 @@ void Papi<ValueType>::on_polymorphic_object_copy_completed(
 
 
 template <typename ValueType>
+void Papi<ValueType>::on_polymorphic_object_move_started(
+    const Executor* exec, const PolymorphicObject* from,
+    const PolymorphicObject* to) const
+{
+    polymorphic_object_move_started.get_counter(exec) += 1;
+}
+
+
+template <typename ValueType>
+void Papi<ValueType>::on_polymorphic_object_move_completed(
+    const Executor* exec, const PolymorphicObject* from,
+    const PolymorphicObject* to) const
+{
+    polymorphic_object_move_completed.get_counter(exec) += 1;
+}
+
+
+template <typename ValueType>
 void Papi<ValueType>::on_polymorphic_object_deleted(
     const Executor* exec, const PolymorphicObject* po) const
 {

--- a/core/log/record.cpp
+++ b/core/log/record.cpp
@@ -162,6 +162,24 @@ void Record::on_polymorphic_object_copy_completed(
 }
 
 
+void Record::on_polymorphic_object_move_started(
+    const Executor* exec, const PolymorphicObject* from,
+    const PolymorphicObject* to) const
+{
+    append_deque(data_.polymorphic_object_move_started,
+                 (std::make_unique<polymorphic_object_data>(exec, from, to)));
+}
+
+
+void Record::on_polymorphic_object_move_completed(
+    const Executor* exec, const PolymorphicObject* from,
+    const PolymorphicObject* to) const
+{
+    append_deque(data_.polymorphic_object_move_completed,
+                 (std::make_unique<polymorphic_object_data>(exec, from, to)));
+}
+
+
 void Record::on_polymorphic_object_deleted(const Executor* exec,
                                            const PolymorphicObject* po) const
 {

--- a/core/log/stream.cpp
+++ b/core/log/stream.cpp
@@ -246,6 +246,26 @@ void Stream<ValueType>::on_polymorphic_object_copy_completed(
 
 
 template <typename ValueType>
+void Stream<ValueType>::on_polymorphic_object_move_started(
+    const Executor* exec, const PolymorphicObject* from,
+    const PolymorphicObject* to) const
+{
+    os_ << prefix_ << demangle_name(from) << " move started to "
+        << demangle_name(to) << " on " << demangle_name(exec) << std::endl;
+}
+
+
+template <typename ValueType>
+void Stream<ValueType>::on_polymorphic_object_move_completed(
+    const Executor* exec, const PolymorphicObject* from,
+    const PolymorphicObject* to) const
+{
+    os_ << prefix_ << demangle_name(from) << " move completed to "
+        << demangle_name(to) << " on " << demangle_name(exec) << std::endl;
+}
+
+
+template <typename ValueType>
 void Stream<ValueType>::on_polymorphic_object_deleted(
     const Executor* exec, const PolymorphicObject* po) const
 {

--- a/core/test/base/polymorphic_object.cpp
+++ b/core/test/base/polymorphic_object.cpp
@@ -146,7 +146,7 @@ TEST_F(EnablePolymorphicObject, CopiesObject)
 }
 
 
-TEST_F(EnablePolymorphicObject, MovesFromUniquePtr)
+TEST_F(EnablePolymorphicObject, MovesObjectByCopyFromUniquePtr)
 {
     auto copy = DummyObject::create(ref, 7);
 
@@ -169,6 +169,18 @@ TEST_F(EnablePolymorphicObject, MovesObject)
     ASSERT_EQ(copy->x, 5);
     ASSERT_EQ(obj->get_executor(), ref);
     ASSERT_EQ(obj->x, 0);
+}
+
+
+TEST_F(EnablePolymorphicObject, MovesFromUniquePtr)
+{
+    auto copy = DummyObject::create(ref, 7);
+
+    copy->copy_from(gko::give(obj));
+
+    ASSERT_NE(copy, obj);
+    ASSERT_EQ(copy->get_executor(), ref);
+    ASSERT_EQ(copy->x, 5);
 }
 
 

--- a/core/test/base/polymorphic_object.cpp
+++ b/core/test/base/polymorphic_object.cpp
@@ -46,6 +46,33 @@ struct DummyObject : gko::EnablePolymorphicObject<DummyObject>,
         : gko::EnablePolymorphicObject<DummyObject>(std::move(exec)), x{v}
     {}
 
+    DummyObject(const DummyObject& other) : DummyObject(other.get_executor())
+    {
+        *this = other;
+    }
+
+    DummyObject(DummyObject&& other) : DummyObject(other.get_executor())
+    {
+        *this = std::move(other);
+    }
+
+    DummyObject& operator=(const DummyObject& other)
+    {
+        if (this != &other) {
+            x = other.x;
+        }
+        return *this;
+    }
+
+    DummyObject& operator=(DummyObject&& other) noexcept
+    {
+        if (this != &other) {
+            x = std::exchange(other.x, 0);
+        }
+        return *this;
+    }
+
+
     int x;
 };
 
@@ -114,10 +141,12 @@ TEST_F(EnablePolymorphicObject, CopiesObject)
     ASSERT_NE(copy, obj);
     ASSERT_EQ(copy->get_executor(), omp);
     ASSERT_EQ(copy->x, 5);
+    ASSERT_EQ(obj->get_executor(), ref);
+    ASSERT_EQ(obj->x, 5);
 }
 
 
-TEST_F(EnablePolymorphicObject, MovesObject)
+TEST_F(EnablePolymorphicObject, MovesFromUniquePtr)
 {
     auto copy = DummyObject::create(ref, 7);
 
@@ -126,6 +155,20 @@ TEST_F(EnablePolymorphicObject, MovesObject)
     ASSERT_NE(copy, obj);
     ASSERT_EQ(copy->get_executor(), ref);
     ASSERT_EQ(copy->x, 5);
+}
+
+
+TEST_F(EnablePolymorphicObject, MovesObject)
+{
+    auto copy = DummyObject::create(ref, 7);
+
+    copy->move_from(gko::lend(obj));
+
+    ASSERT_NE(copy, obj);
+    ASSERT_EQ(copy->get_executor(), ref);
+    ASSERT_EQ(copy->x, 5);
+    ASSERT_EQ(obj->get_executor(), ref);
+    ASSERT_EQ(obj->x, 0);
 }
 
 

--- a/core/test/log/papi.cpp
+++ b/core/test/log/papi.cpp
@@ -338,6 +338,42 @@ TYPED_TEST(Papi, CatchesPolymorphicObjectCopyCompleted)
 }
 
 
+TYPED_TEST(Papi, CatchesPolymorphicObjectMoveStarted)
+{
+    auto str =
+        this->init(gko::log::Logger::polymorphic_object_move_started_mask,
+                   "polymorphic_object_move_started", this->exec.get());
+    this->add_event(str);
+
+    this->start();
+    this->logger
+        ->template on<gko::log::Logger::polymorphic_object_move_started>(
+            this->exec.get(), nullptr, nullptr);
+    long long int value = 0;
+    this->stop(&value);
+
+    ASSERT_EQ(value, 1);
+}
+
+
+TYPED_TEST(Papi, CatchesPolymorphicObjectMoveCompleted)
+{
+    auto str =
+        this->init(gko::log::Logger::polymorphic_object_move_completed_mask,
+                   "polymorphic_object_move_completed", this->exec.get());
+    this->add_event(str);
+
+    this->start();
+    this->logger
+        ->template on<gko::log::Logger::polymorphic_object_move_completed>(
+            this->exec.get(), nullptr, nullptr);
+    long long int value = 0;
+    this->stop(&value);
+
+    ASSERT_EQ(value, 1);
+}
+
+
 TYPED_TEST(Papi, CatchesPolymorphicObjectDeleted)
 {
     auto str = this->init(gko::log::Logger::polymorphic_object_deleted_mask,

--- a/core/test/log/record.cpp
+++ b/core/test/log/record.cpp
@@ -285,6 +285,45 @@ TEST(Record, CatchesPolymorphicObjectCopyCompleted)
 }
 
 
+TEST(Record, CatchesPolymorphicObjectMoveStarted)
+{
+    using Dense = gko::matrix::Dense<>;
+    auto exec = gko::ReferenceExecutor::create();
+    auto logger = gko::log::Record::create(
+        exec, gko::log::Logger::polymorphic_object_move_started_mask);
+    auto from = gko::matrix::Dense<>::create(exec);
+    auto to = gko::matrix::Dense<>::create(exec);
+
+    logger->on<gko::log::Logger::polymorphic_object_move_started>(
+        exec.get(), from.get(), to.get());
+
+    auto& data = logger->get().polymorphic_object_move_started.back();
+    ASSERT_EQ(data->exec, exec.get());
+    GKO_ASSERT_MTX_NEAR(gko::as<Dense>(data->input.get()), from.get(), 0);
+    GKO_ASSERT_MTX_NEAR(gko::as<Dense>(data->output.get()), to.get(), 0);
+}
+
+
+TEST(Record, CatchesPolymorphicObjectMoveCompleted)
+{
+    using Dense = gko::matrix::Dense<>;
+    auto exec = gko::ReferenceExecutor::create();
+    auto logger = gko::log::Record::create(
+        exec, gko::log::Logger::polymorphic_object_move_completed_mask);
+    auto from = gko::matrix::Dense<>::create(exec);
+    auto to = gko::matrix::Dense<>::create(exec);
+
+    logger->on<gko::log::Logger::polymorphic_object_move_completed>(
+        exec.get(), from.get(), to.get());
+
+
+    auto& data = logger->get().polymorphic_object_move_completed.back();
+    ASSERT_EQ(data->exec, exec.get());
+    GKO_ASSERT_MTX_NEAR(gko::as<Dense>(data->input.get()), from.get(), 0);
+    GKO_ASSERT_MTX_NEAR(gko::as<Dense>(data->output.get()), to.get(), 0);
+}
+
+
 TEST(Record, CatchesPolymorphicObjectDeleted)
 {
     using Dense = gko::matrix::Dense<>;

--- a/core/test/log/stream.cpp
+++ b/core/test/log/stream.cpp
@@ -313,6 +313,52 @@ TYPED_TEST(Stream, CatchesPolymorphicObjectCopyCompleted)
 }
 
 
+TYPED_TEST(Stream, CatchesPolymorphicObjectMoveStarted)
+{
+    auto exec = gko::ReferenceExecutor::create();
+    std::stringstream out;
+    auto logger = gko::log::Stream<TypeParam>::create(
+        exec, gko::log::Logger::polymorphic_object_move_started_mask, out);
+    auto from = gko::matrix::Dense<TypeParam>::create(exec);
+    auto to = gko::matrix::Dense<TypeParam>::create(exec);
+    std::stringstream ptrstream_from;
+    ptrstream_from << from.get();
+    std::stringstream ptrstream_to;
+    ptrstream_to << to.get();
+
+    logger->template on<gko::log::Logger::polymorphic_object_move_started>(
+        exec.get(), from.get(), to.get());
+
+    auto os = out.str();
+    GKO_ASSERT_STR_CONTAINS(os, ptrstream_from.str());
+    GKO_ASSERT_STR_CONTAINS(os, "move started to");
+    GKO_ASSERT_STR_CONTAINS(os, ptrstream_to.str());
+}
+
+
+TYPED_TEST(Stream, CatchesPolymorphicObjectMoveCompleted)
+{
+    auto exec = gko::ReferenceExecutor::create();
+    std::stringstream out;
+    auto logger = gko::log::Stream<TypeParam>::create(
+        exec, gko::log::Logger::polymorphic_object_move_completed_mask, out);
+    auto from = gko::matrix::Dense<TypeParam>::create(exec);
+    auto to = gko::matrix::Dense<TypeParam>::create(exec);
+    std::stringstream ptrstream_from;
+    ptrstream_from << from.get();
+    std::stringstream ptrstream_to;
+    ptrstream_to << to.get();
+
+    logger->template on<gko::log::Logger::polymorphic_object_move_completed>(
+        exec.get(), from.get(), to.get());
+
+    auto os = out.str();
+    GKO_ASSERT_STR_CONTAINS(os, ptrstream_from.str());
+    GKO_ASSERT_STR_CONTAINS(os, "move completed to");
+    GKO_ASSERT_STR_CONTAINS(os, ptrstream_to.str());
+}
+
+
 TYPED_TEST(Stream, CatchesPolymorphicObjectDeleted)
 {
     auto exec = gko::ReferenceExecutor::create();

--- a/include/ginkgo/core/base/polymorphic_object.hpp
+++ b/include/ginkgo/core/base/polymorphic_object.hpp
@@ -208,6 +208,27 @@ public:
     }
 
     /**
+     * Moves another object into this object.
+     *
+     * This is the polymorphic equivalent of the move assignment operator.
+     *
+     * @see move_from_impl(std::unique_ptr<PolymorphicObject>)
+     *
+     * @param other  the object to move from
+     *
+     * @return this
+     */
+    PolymorphicObject* move_from(std::unique_ptr<PolymorphicObject> other)
+    {
+        this->template log<log::Logger::polymorphic_object_move_started>(
+            exec_.get(), other.get(), this);
+        auto copied = this->copy_from_impl(std::move(other));
+        this->template log<log::Logger::polymorphic_object_move_completed>(
+            exec_.get(), other.get(), this);
+        return copied;
+    }
+
+    /**
      * Transforms the object into its default state.
      *
      * Equivalent to `this->copy_from(this->create_default())`.
@@ -293,6 +314,17 @@ protected:
 
     /**
      * Implementers of PolymorphicObject should implement this function instead
+     * of move_from(std::unique_ptr<PolymorphicObject>).
+     *
+     * @param other  the object to move from
+     *
+     * @return this
+     */
+    virtual PolymorphicObject* move_from_impl(
+        std::unique_ptr<PolymorphicObject> other) = 0;
+
+    /**
+     * Implementers of PolymorphicObject should implement this function instead
      * of clear().
      *
      * @return this
@@ -366,6 +398,12 @@ public:
     AbstractObject* move_from(PolymorphicObject* other)
     {
         return static_cast<AbstractObject*>(this->move_from_impl(other));
+    }
+
+    AbstractObject* move_from(std::unique_ptr<PolymorphicObject> other)
+    {
+        return static_cast<AbstractObject*>(
+            this->move_from_impl(std::move(other)));
     }
 
     AbstractObject* clear()
@@ -631,6 +669,13 @@ protected:
     PolymorphicObject* move_from_impl(PolymorphicObject* other) override
     {
         as<ConvertibleTo<ConcreteObject>>(other)->move_to(self());
+        return this;
+    }
+
+    PolymorphicObject* move_from_impl(
+        std::unique_ptr<PolymorphicObject> other) override
+    {
+        as<ConvertibleTo<ConcreteObject>>(other.get())->move_to(self());
         return this;
     }
 

--- a/include/ginkgo/core/base/polymorphic_object.hpp
+++ b/include/ginkgo/core/base/polymorphic_object.hpp
@@ -187,6 +187,27 @@ public:
     }
 
     /**
+     * Moves another object into this object.
+     *
+     * This is the polymorphic equivalent of the move assignment operator.
+     *
+     * @see move_from_impl(PolymorphicObject *)
+     *
+     * @param other  the object to move from
+     *
+     * @return this
+     */
+    PolymorphicObject* move_from(PolymorphicObject* other)
+    {
+        this->template log<log::Logger::polymorphic_object_copy_started>(
+            exec_.get(), other, this);
+        auto moved = this->move_from_impl(other);
+        this->template log<log::Logger::polymorphic_object_copy_completed>(
+            exec_.get(), other, this);
+        return moved;
+    }
+
+    /**
      * Transforms the object into its default state.
      *
      * Equivalent to `this->copy_from(this->create_default())`.
@@ -262,6 +283,16 @@ protected:
 
     /**
      * Implementers of PolymorphicObject should implement this function instead
+     * of move_from(PolymorphicObject *).
+     *
+     * @param other  the object to move from
+     *
+     * @return this
+     */
+    virtual PolymorphicObject* move_from_impl(PolymorphicObject* other) = 0;
+
+    /**
+     * Implementers of PolymorphicObject should implement this function instead
      * of clear().
      *
      * @return this
@@ -330,6 +361,11 @@ public:
     {
         return static_cast<AbstractObject*>(
             this->copy_from_impl(std::move(other)));
+    }
+
+    AbstractObject* move_from(PolymorphicObject* other)
+    {
+        return static_cast<AbstractObject*>(this->move_from_impl(other));
     }
 
     AbstractObject* clear()
@@ -589,6 +625,12 @@ protected:
         std::unique_ptr<PolymorphicObject> other) override
     {
         as<ConvertibleTo<ConcreteObject>>(other.get())->move_to(self());
+        return this;
+    }
+
+    PolymorphicObject* move_from_impl(PolymorphicObject* other) override
+    {
+        as<ConvertibleTo<ConcreteObject>>(other)->move_to(self());
         return this;
     }
 

--- a/include/ginkgo/core/base/polymorphic_object.hpp
+++ b/include/ginkgo/core/base/polymorphic_object.hpp
@@ -178,10 +178,10 @@ public:
      */
     PolymorphicObject* copy_from(std::unique_ptr<PolymorphicObject> other)
     {
-        this->template log<log::Logger::polymorphic_object_copy_started>(
+        this->template log<log::Logger::polymorphic_object_move_started>(
             exec_.get(), other.get(), this);
         auto copied = this->copy_from_impl(std::move(other));
-        this->template log<log::Logger::polymorphic_object_copy_completed>(
+        this->template log<log::Logger::polymorphic_object_move_completed>(
             exec_.get(), other.get(), this);
         return copied;
     }
@@ -199,10 +199,10 @@ public:
      */
     PolymorphicObject* move_from(PolymorphicObject* other)
     {
-        this->template log<log::Logger::polymorphic_object_copy_started>(
+        this->template log<log::Logger::polymorphic_object_move_started>(
             exec_.get(), other, this);
         auto moved = this->move_from_impl(other);
-        this->template log<log::Logger::polymorphic_object_copy_completed>(
+        this->template log<log::Logger::polymorphic_object_move_completed>(
             exec_.get(), other, this);
         return moved;
     }

--- a/include/ginkgo/core/log/logger.hpp
+++ b/include/ginkgo/core/log/logger.hpp
@@ -458,6 +458,30 @@ protected:
         this->on_iteration_complete(solver, it, r, x, tau);
     }
 
+    /**
+     * PolymorphicObject's move started event.
+     *
+     * @param exec  the executor used
+     * @param input  the PolymorphicObject to be move from
+     * @param output  the PolymorphicObject to be move to
+     */
+    GKO_LOGGER_REGISTER_EVENT(22, polymorphic_object_move_started,
+                              const Executor* exec,
+                              const PolymorphicObject* input,
+                              const PolymorphicObject* output)
+
+    /**
+     * PolymorphicObject's move completed event.
+     *
+     * @param exec  the executor used
+     * @param input  the PolymorphicObject to be move from
+     * @param output  the PolymorphicObject to be move to
+     */
+    GKO_LOGGER_REGISTER_EVENT(23, polymorphic_object_move_completed,
+                              const Executor* exec,
+                              const PolymorphicObject* input,
+                              const PolymorphicObject* output)
+
 public:
 #undef GKO_LOGGER_REGISTER_EVENT
 
@@ -483,6 +507,8 @@ public:
         polymorphic_object_create_completed_mask |
         polymorphic_object_copy_started_mask |
         polymorphic_object_copy_completed_mask |
+        polymorphic_object_move_started_mask |
+        polymorphic_object_move_completed_mask |
         polymorphic_object_deleted_mask;
 
     /**

--- a/include/ginkgo/core/log/logger.hpp
+++ b/include/ginkgo/core/log/logger.hpp
@@ -458,12 +458,13 @@ protected:
         this->on_iteration_complete(solver, it, r, x, tau);
     }
 
+public:
     /**
      * PolymorphicObject's move started event.
      *
      * @param exec  the executor used
      * @param input  the PolymorphicObject to be move from
-     * @param output  the PolymorphicObject to be move to
+     * @param output  the PolymorphicObject to be move into
      */
     GKO_LOGGER_REGISTER_EVENT(22, polymorphic_object_move_started,
                               const Executor* exec,
@@ -475,14 +476,13 @@ protected:
      *
      * @param exec  the executor used
      * @param input  the PolymorphicObject to be move from
-     * @param output  the PolymorphicObject to be move to
+     * @param output  the PolymorphicObject to be move into
      */
     GKO_LOGGER_REGISTER_EVENT(23, polymorphic_object_move_completed,
                               const Executor* exec,
                               const PolymorphicObject* input,
                               const PolymorphicObject* output)
 
-public:
 #undef GKO_LOGGER_REGISTER_EVENT
 
     /**

--- a/include/ginkgo/core/log/papi.hpp
+++ b/include/ginkgo/core/log/papi.hpp
@@ -138,6 +138,14 @@ public:
         const Executor* exec, const PolymorphicObject* from,
         const PolymorphicObject* to) const override;
 
+    void on_polymorphic_object_move_started(
+        const Executor* exec, const PolymorphicObject* from,
+        const PolymorphicObject* to) const override;
+
+    void on_polymorphic_object_move_completed(
+        const Executor* exec, const PolymorphicObject* from,
+        const PolymorphicObject* to) const override;
+
     void on_polymorphic_object_deleted(
         const Executor* exec, const PolymorphicObject* po) const override;
 
@@ -291,6 +299,10 @@ private:
         &papi_handle, "polymorphic_object_copy_started"};
     mutable papi_queue<Executor> polymorphic_object_copy_completed{
         &papi_handle, "polymorphic_object_copy_completed"};
+    mutable papi_queue<Executor> polymorphic_object_move_started{
+        &papi_handle, "polymorphic_object_move_started"};
+    mutable papi_queue<Executor> polymorphic_object_move_completed{
+        &papi_handle, "polymorphic_object_move_completed"};
     mutable papi_queue<Executor> polymorphic_object_deleted{
         &papi_handle, "polymorphic_object_deleted"};
 

--- a/include/ginkgo/core/log/record.hpp
+++ b/include/ginkgo/core/log/record.hpp
@@ -263,6 +263,10 @@ public:
         std::deque<std::unique_ptr<polymorphic_object_data>>
             polymorphic_object_copy_completed;
         std::deque<std::unique_ptr<polymorphic_object_data>>
+            polymorphic_object_move_started;
+        std::deque<std::unique_ptr<polymorphic_object_data>>
+            polymorphic_object_move_completed;
+        std::deque<std::unique_ptr<polymorphic_object_data>>
             polymorphic_object_deleted;
 
         std::deque<std::unique_ptr<linop_data>> linop_apply_started;
@@ -325,6 +329,14 @@ public:
         const PolymorphicObject* to) const override;
 
     void on_polymorphic_object_copy_completed(
+        const Executor* exec, const PolymorphicObject* from,
+        const PolymorphicObject* to) const override;
+
+    void on_polymorphic_object_move_started(
+        const Executor* exec, const PolymorphicObject* from,
+        const PolymorphicObject* to) const override;
+
+    void on_polymorphic_object_move_completed(
         const Executor* exec, const PolymorphicObject* from,
         const PolymorphicObject* to) const override;
 

--- a/include/ginkgo/core/log/stream.hpp
+++ b/include/ginkgo/core/log/stream.hpp
@@ -105,6 +105,14 @@ public:
         const Executor* exec, const PolymorphicObject* from,
         const PolymorphicObject* to) const override;
 
+    void on_polymorphic_object_move_started(
+        const Executor* exec, const PolymorphicObject* from,
+        const PolymorphicObject* to) const override;
+
+    void on_polymorphic_object_move_completed(
+        const Executor* exec, const PolymorphicObject* from,
+        const PolymorphicObject* to) const override;
+
     void on_polymorphic_object_deleted(
         const Executor* exec, const PolymorphicObject* po) const override;
 


### PR DESCRIPTION
This PR adds `move_from(PolymorphicObject*)` to PolymorphicObject. It enables us to use the generic `copy_from` mechanisms for moves even if the move-from object is not available as a unique_ptr. That situation can appear if one tries to move from an object that is stored as a shared_ptr. (I know that moving from an object inside a shared_ptr is generally not a good idea, but I currently have no other option)