### PR TITLE
Add functions to wrap `const` user arrays into Ginkgo batched matrices

### DIFF
--- a/core/matrix/batch_ell.cpp
+++ b/core/matrix/batch_ell.cpp
@@ -185,9 +185,10 @@ void BatchEll<ValueType, IndexType>::read(const std::vector<mat_data>& data)
         }
     }
     GKO_ASSERT(std::equal(nnz.begin() + 1, nnz.end(), nnz.begin()));
-    auto tmp =
-        BatchEll::create(this->get_executor()->get_master(), num_batch_entries,
-                         data[0].size, num_stored_elements_per_row);
+    auto tmp = BatchEll::create(
+        this->get_executor()->get_master(),
+        batch_dim<2>{num_batch_entries, data[0].size},
+        batch_stride{num_batch_entries, num_stored_elements_per_row});
     // Get values and column indexes.
     for (size_type id = 0; id < num_batch_entries; ++id) {
         const auto& batch_data = data[id];

--- a/core/test/matrix/batch_csr.cpp
+++ b/core/test/matrix/batch_csr.cpp
@@ -240,6 +240,27 @@ TYPED_TEST(BatchCsr, CanBeCreatedFromExistingData)
 }
 
 
+TYPED_TEST(BatchCsr, CanBeCreatedFromExistingConstData)
+{
+    using Mtx = typename TestFixture::Mtx;
+    using value_type = typename TestFixture::value_type;
+    using index_type = typename TestFixture::index_type;
+    const value_type values[] = {1.0, 2.0, 3.0, 4.0, -1.0, 12.0, 13.0, 14.0};
+    const index_type col_idxs[] = {0, 1, 1, 0};
+    index_type row_ptrs[] = {0, 2, 3, 4};
+
+    auto mtx = gko::matrix::BatchCsr<value_type, index_type>::create_const(
+        this->exec, gko::batch_dim<2>{2, gko::dim<2>{3, 2}},
+        gko::Array<value_type>::const_view(this->exec, 8, values),
+        gko::Array<index_type>::const_view(this->exec, 4, col_idxs),
+        gko::Array<index_type>::const_view(this->exec, 4, row_ptrs));
+
+    ASSERT_EQ(mtx->get_const_values(), values);
+    ASSERT_EQ(mtx->get_const_col_idxs(), col_idxs);
+    ASSERT_EQ(mtx->get_const_row_ptrs(), row_ptrs);
+}
+
+
 TYPED_TEST(BatchCsr, CanBeCopied)
 {
     using Mtx = typename TestFixture::Mtx;

--- a/core/test/matrix/batch_dense.cpp
+++ b/core/test/matrix/batch_dense.cpp
@@ -172,6 +172,32 @@ TYPED_TEST(BatchDense, CanBeConstructedFromExistingData)
 }
 
 
+TYPED_TEST(BatchDense, CanBeConstructedFromExistingConstData)
+{
+    using value_type = typename TestFixture::value_type;
+    using size_type = gko::size_type;
+    // clang-format off
+    const value_type data[] = {
+       1.0, 2.0, -1.0,
+       3.0, 4.0, -1.0,
+       3.0, 5.0, 1.0,
+       5.0, 6.0, -3.0};
+    // clang-format on
+
+    auto m = gko::matrix::BatchDense<TypeParam>::create_const(
+        this->exec,
+        std::vector<gko::dim<2>>{gko::dim<2>{2, 2}, gko::dim<2>{2, 2}},
+        gko::Array<value_type>::const_view(this->exec, 12, data),
+        std::vector<size_type>{3, 3});
+
+    ASSERT_EQ(m->get_const_values(), data);
+    ASSERT_EQ(m->at(0, 0, 1), value_type{2.0});
+    ASSERT_EQ(m->at(0, 1, 2), value_type{-1.0});
+    ASSERT_EQ(m->at(1, 0, 1), value_type{5.0});
+    ASSERT_EQ(m->at(1, 1, 2), value_type{-3.0});
+}
+
+
 TYPED_TEST(BatchDense, CanBeConstructedFromBatchDenseMatrices)
 {
     using value_type = typename TestFixture::value_type;

--- a/core/test/matrix/batch_ell.cpp
+++ b/core/test/matrix/batch_ell.cpp
@@ -56,7 +56,8 @@ protected:
     BatchEll()
         : exec(gko::ReferenceExecutor::create()),
           mtx(gko::matrix::BatchEll<value_type, index_type>::create(
-              exec, 2, gko::dim<2>{3, 3}, 2))
+              exec, gko::batch_dim<2>{2, gko::dim<2>{3, 3}},
+              gko::batch_stride{2, 2}))
     {
         value_type* v = mtx->get_values();
         index_type* c = mtx->get_col_idxs();
@@ -226,7 +227,8 @@ TYPED_TEST(BatchEll, CanBeCreatedFromExistingData)
     index_type col_idxs[] = {0, 1, 1, 2, 2, 3};
 
     auto batch_mtx = gko::matrix::BatchEll<value_type, index_type>::create(
-        this->exec, gko::batch_dim<2>{2, gko::dim<2>{3, 4}}, 2, 3,
+        this->exec, gko::batch_dim<2>{2, gko::dim<2>{3, 4}},
+        gko::batch_stride(2, 2), gko::batch_stride{2, 3},
         gko::Array<value_type>::view(this->exec, 12, values),
         gko::Array<index_type>::view(this->exec, 6, col_idxs));
 
@@ -273,7 +275,8 @@ TYPED_TEST(BatchEll, CanBeDuplicatedFromBatchMatrices)
         1.0, 0.0, 2.0, 3.0, 4.0, 0.0, -1.0, 0.0, 12.0, 13.0, 14.0, 0.0};
 
     auto batch_mtx = gko::matrix::BatchEll<value_type, index_type>::create(
-        this->exec, gko::batch_dim<2>{2, gko::dim<2>{3, 4}}, 2, 3,
+        this->exec, gko::batch_dim<2>{2, gko::dim<2>{3, 4}},
+        gko::batch_stride{2, 2}, gko::batch_stride{2, 3},
         gko::Array<value_type>::view(this->exec, 12, values),
         gko::Array<index_type>::view(this->exec, 6, col_idxs));
 

--- a/core/test/matrix/batch_ell.cpp
+++ b/core/test/matrix/batch_ell.cpp
@@ -226,7 +226,7 @@ TYPED_TEST(BatchEll, CanBeCreatedFromExistingData)
     index_type col_idxs[] = {0, 1, 1, 2, 2, 3};
 
     auto batch_mtx = gko::matrix::BatchEll<value_type, index_type>::create(
-        this->exec, 2, gko::dim<2>{3, 4}, 2, 3,
+        this->exec, gko::batch_dim<2>{2, gko::dim<2>{3, 4}}, 2, 3,
         gko::Array<value_type>::view(this->exec, 12, values),
         gko::Array<index_type>::view(this->exec, 6, col_idxs));
 
@@ -273,7 +273,7 @@ TYPED_TEST(BatchEll, CanBeDuplicatedFromBatchMatrices)
         1.0, 0.0, 2.0, 3.0, 4.0, 0.0, -1.0, 0.0, 12.0, 13.0, 14.0, 0.0};
 
     auto batch_mtx = gko::matrix::BatchEll<value_type, index_type>::create(
-        this->exec, 2, gko::dim<2>{3, 4}, 2, 3,
+        this->exec, gko::batch_dim<2>{2, gko::dim<2>{3, 4}}, 2, 3,
         gko::Array<value_type>::view(this->exec, 12, values),
         gko::Array<index_type>::view(this->exec, 6, col_idxs));
 

--- a/core/test/matrix/batch_ell.cpp
+++ b/core/test/matrix/batch_ell.cpp
@@ -237,6 +237,27 @@ TYPED_TEST(BatchEll, CanBeCreatedFromExistingData)
 }
 
 
+TYPED_TEST(BatchEll, CanBeCreatedFromExistingConstData)
+{
+    using Mtx = typename TestFixture::Mtx;
+    using value_type = typename TestFixture::value_type;
+    using index_type = typename TestFixture::index_type;
+    const value_type values[] = {1.0,  0.0, 2.0,  3.0,  4.0,  0.0,
+                                 -1.0, 0.0, 12.0, 13.0, 14.0, 0.0};
+    index_type col_idxs[] = {0, 1, 1, 2, 2, 3};
+
+    auto batch_mtx =
+        gko::matrix::BatchEll<value_type, index_type>::create_const(
+            this->exec, gko::batch_dim<2>{2, gko::dim<2>{3, 4}},
+            gko::batch_stride(2, 2), gko::batch_stride{2, 3},
+            gko::Array<value_type>::const_view(this->exec, 12, values),
+            gko::Array<index_type>::const_view(this->exec, 6, col_idxs));
+
+    ASSERT_EQ(batch_mtx->get_const_values(), values);
+    ASSERT_EQ(batch_mtx->get_const_col_idxs(), col_idxs);
+}
+
+
 TYPED_TEST(BatchEll, CanBeDuplicatedFromOneEllMatrix)
 {
     using Mtx = typename TestFixture::Mtx;

--- a/hip/log/batch_loggers.hip.hpp
+++ b/hip/log/batch_loggers.hip.hpp
@@ -34,6 +34,9 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define GKO_HIP_LOG_BATCH_LOGGERS_HIP_HPP_
 
 
+#include <ginkgo/core/base/types.hpp>
+
+
 namespace gko {
 namespace kernels {
 namespace hip {

--- a/include/ginkgo/core/base/exception_helpers.hpp
+++ b/include/ginkgo/core/base/exception_helpers.hpp
@@ -159,6 +159,13 @@ inline batch_dim<2> get_batch_size(const T& op)
 inline batch_dim<2> get_batch_size(const batch_dim<2>& size) { return size; }
 
 
+template <typename T>
+inline size_type get_num_batch_entries(const T& obj)
+{
+    return obj.get_num_batch_entries();
+}
+
+
 inline std::tuple<bool, int> compare_batch_inner(const batch_dim<2>& size1,
                                                  const batch_dim<2>& size2)
 {
@@ -630,6 +637,24 @@ inline std::tuple<bool, size_type> check_batch_single_column(
     static_assert(true,                                                      \
                   "This assert is used to counter the false positive extra " \
                   "semi-colon warnings")
+
+
+/**
+ * Asserts that _op1 has the same number of batch entries as _op2.
+ *
+ * @throw DimensionMismatch  if _op1 contains a different number of entries
+ *   from _op2.
+ */
+#define GKO_ASSERT_EQUAL_BATCH_ENTRIES(_op1, _op2)                          \
+    {                                                                       \
+        auto sz1 = ::gko::detail::get_num_batch_entries(_op1);              \
+        auto sz2 = ::gko::detail::get_num_batch_entries(_op2);              \
+        if (sz1 != sz2) {                                                   \
+            throw ::gko::DimensionMismatch(                                 \
+                __FILE__, __LINE__, __func__, #_op1, sz1, 0, #_op2, sz2, 0, \
+                "expected matching number of batch entries");               \
+        }                                                                   \
+    }
 
 
 /**

--- a/include/ginkgo/core/matrix/batch_csr.hpp
+++ b/include/ginkgo/core/matrix/batch_csr.hpp
@@ -234,6 +234,32 @@ public:
         return values_.get_num_elems();
     }
 
+    /**
+     * Creates a constant BatchCsr matrix by wrapping a set of constant arrays.
+     *
+     * @param exec  the executor to create the matrix on
+     * @param size  the dimensions of the matrix
+     * @param values  the value array of the matrix
+     * @param col_idxs  the column index array of the matrix
+     * @param row_ptrs  the row pointer array of the matrix
+     * @returns A smart pointer to the constant matrix wrapping the input arrays
+     *          (if they reside on the same executor as the matrix) or a copy of
+     *          these arrays on the correct executor.
+     */
+    static std::unique_ptr<const BatchCsr> create_const(
+        std::shared_ptr<const Executor> exec, const batch_dim<2>& size,
+        gko::detail::ConstArrayView<ValueType>&& values,
+        gko::detail::ConstArrayView<IndexType>&& col_idxs,
+        gko::detail::ConstArrayView<IndexType>&& row_ptrs)
+    {
+        // cast const-ness away, but return a const object afterwards,
+        // so we can ensure that no modifications take place.
+        return std::unique_ptr<const BatchCsr>(new BatchCsr{
+            exec, size, gko::detail::array_const_cast(std::move(values)),
+            gko::detail::array_const_cast(std::move(col_idxs)),
+            gko::detail::array_const_cast(std::move(row_ptrs))});
+    }
+
 protected:
     /**
      * Creates an uninitialized BatchCsr matrix of the specified size.

--- a/include/ginkgo/core/matrix/batch_dense.hpp
+++ b/include/ginkgo/core/matrix/batch_dense.hpp
@@ -367,6 +367,29 @@ public:
         this->compute_norm2_impl(make_temporary_clone(exec, result).get());
     }
 
+    /**
+     * Creates a constant (immutable) batch dense matrix from a constant array.
+     *
+     * @param exec  the executor to create the matrix on
+     * @param size  the dimensions of the matrix
+     * @param values  the value array of the matrix
+     * @param stride  the row-stride of the matrix
+     * @returns A smart pointer to the constant matrix wrapping the input array
+     *          (if it resides on the same executor as the matrix) or a copy of
+     *          the array on the correct executor.
+     */
+    static std::unique_ptr<const BatchDense> create_const(
+        std::shared_ptr<const Executor> exec, const batch_dim<2>& sizes,
+        gko::detail::ConstArrayView<ValueType>&& values,
+        const batch_stride& strides)
+    {
+        // cast const-ness away, but return a const object afterwards,
+        // so we can ensure that no modifications take place.
+        return std::unique_ptr<const BatchDense>(new BatchDense{
+            exec, sizes, gko::detail::array_const_cast(std::move(values)),
+            strides});
+    }
+
 private:
     /**
      * Compute the memory required for the values array from the sizes and the

--- a/include/ginkgo/core/matrix/batch_ell.hpp
+++ b/include/ginkgo/core/matrix/batch_ell.hpp
@@ -312,10 +312,10 @@ public:
     {
         // cast const-ness away, but return a const object afterwards,
         // so we can ensure that no modifications take place.
-        return std::unique_ptr<const BatchEll>(new BatchEll{
-            exec, size, num_stored_elems_per_row.at(0), stride.at(0),
-            gko::detail::array_const_cast(std::move(values)),
-            gko::detail::array_const_cast(std::move(col_idxs))});
+        return std::unique_ptr<const BatchEll>(
+            new BatchEll{exec, size, num_stored_elems_per_row, stride,
+                         gko::detail::array_const_cast(std::move(values)),
+                         gko::detail::array_const_cast(std::move(col_idxs))});
     }
 
 protected:

--- a/omp/test/matrix/batch_ell_kernels.cpp
+++ b/omp/test/matrix/batch_ell_kernels.cpp
@@ -68,8 +68,10 @@ protected:
           mtx_size(10, gko::dim<2>(12, 7)),
           rand_engine(42)
     {
-        mtx = Mtx::create(exec, 2, gko::dim<2>{2, 3}, 2);
-        mtx2 = Mtx::create(exec, 2, gko::dim<2>{3, 3}, 2);
+        mtx = Mtx::create(exec, gko::batch_dim<2>{2, gko::dim<2>{2, 3}},
+                          gko::batch_stride{2, 2});
+        mtx2 = Mtx::create(exec, gko::batch_dim<2>{2, gko::dim<2>{3, 3}},
+                           gko::batch_stride{2, 2});
         create_mtx(mtx.get());
         create_mtx2(mtx2.get());
     }

--- a/reference/test/matrix/batch_ell_kernels.cpp
+++ b/reference/test/matrix/batch_ell_kernels.cpp
@@ -67,8 +67,10 @@ protected:
 
     BatchEll()
         : exec(gko::ReferenceExecutor::create()),
-          mtx(Mtx::create(exec, 2, gko::dim<2>{2, 3}, 2)),
-          mtx2(Mtx::create(exec, 2, gko::dim<2>{3, 3}, 2))
+          mtx(Mtx::create(exec, gko::batch_dim<2>{2, gko::dim<2>{2, 3}},
+                          gko::batch_stride{2, 2})),
+          mtx2(Mtx::create(exec, gko::batch_dim<2>{2, gko::dim<2>{3, 3}},
+                           gko::batch_stride{2, 2}))
     {
         this->create_mtx(mtx.get());
         this->create_mtx2(mtx2.get());
@@ -209,7 +211,8 @@ TYPED_TEST(BatchEll, CanBeCreatedFromExistingCscData)
             gko::Array<index_type>::view(this->exec, 3, col_ptrs));
 
     auto comp = gko::matrix::BatchEll<value_type, index_type>::create(
-        this->exec, gko::batch_dim<2>{2, gko::dim<2>{3, 2}}, 2, 3,
+        this->exec, gko::batch_dim<2>{2, gko::dim<2>{3, 2}},
+        gko::batch_stride{2, 2}, gko::batch_stride{2, 3},
         gko::Array<value_type>::view(this->exec, 12, ell_values),
         gko::Array<index_type>::view(this->exec, 6, col_idxs));
 
@@ -433,7 +436,8 @@ TYPED_TEST(BatchEll, CanDetectMissingDiagonalEntry)
     using T = typename TestFixture::value_type;
     using index_type = typename TestFixture::index_type;
     using Mtx = typename TestFixture::Mtx;
-    auto mat = Mtx::create(this->exec, 2, gko::dim<2>{3, 4}, 4);
+    auto mat = Mtx::create(this->exec, gko::batch_dim<2>{2, gko::dim<2>{3, 4}},
+                           gko::batch_stride{2, 4});
     // clang-format off
     //     {{2.0, 0.0, -1.0, 0.0},
     //      {0.0, 1.0, -1.5, -2.0},
@@ -477,7 +481,8 @@ TYPED_TEST(BatchEll, CanDetectMissingDiagonalEntryInFirstRow)
     using T = typename TestFixture::value_type;
     using index_type = typename TestFixture::index_type;
     using Mtx = typename TestFixture::Mtx;
-    auto mat = Mtx::create(this->exec, 2, gko::dim<2>{3, 4}, 4);
+    auto mat = Mtx::create(this->exec, gko::batch_dim<2>{2, gko::dim<2>{3, 4}},
+                           gko::batch_stride{2, 4});
     {
         const auto vals = mat->get_values();
         const auto cols = mat->get_col_idxs();
@@ -516,7 +521,8 @@ TYPED_TEST(BatchEll, CanDetectPresenceOfAllDiagonalEntries)
     using T = typename TestFixture::value_type;
     using index_type = typename TestFixture::index_type;
     using Mtx = typename TestFixture::Mtx;
-    auto mat = Mtx::create(this->exec, 2, gko::dim<2>{3, 4}, 3);
+    auto mat = Mtx::create(this->exec, gko::batch_dim<2>{2, gko::dim<2>{3, 4}},
+                           gko::batch_stride{2, 3});
     {
         const auto vals = mat->get_values();
         const auto cols = mat->get_col_idxs();
@@ -553,7 +559,8 @@ TYPED_TEST(BatchEll, AddScaledIdentity)
     using index_type = typename TestFixture::index_type;
     using Mtx = typename TestFixture::Mtx;
     using BDense = gko::matrix::BatchDense<T>;
-    auto mat = Mtx::create(this->exec, 2, gko::dim<2>{3, 4}, 4);
+    auto mat = Mtx::create(this->exec, gko::batch_dim<2>{2, gko::dim<2>{3, 4}},
+                           gko::batch_stride{2, 4});
     {
         const auto vals = mat->get_values();
         const auto cols = mat->get_col_idxs();

--- a/reference/test/matrix/batch_ell_kernels.cpp
+++ b/reference/test/matrix/batch_ell_kernels.cpp
@@ -209,7 +209,7 @@ TYPED_TEST(BatchEll, CanBeCreatedFromExistingCscData)
             gko::Array<index_type>::view(this->exec, 3, col_ptrs));
 
     auto comp = gko::matrix::BatchEll<value_type, index_type>::create(
-        this->exec, 2, gko::dim<2>{3, 2}, 2, 3,
+        this->exec, gko::batch_dim<2>{2, gko::dim<2>{3, 2}}, 2, 3,
         gko::Array<value_type>::view(this->exec, 12, ell_values),
         gko::Array<index_type>::view(this->exec, 6, col_idxs));
 


### PR DESCRIPTION
`create_const` functions are added to `BatchCsr`, `BatchEll` and `BatchDense` for the purpose of wrapping user data pointed to by `const` pointers.

In addition, the `BatchEll` interface is made more agnostic of whether the batch is uniform or non-uniform.