### PR TITLE
Use reductions with reused tmp storage in solver

### DIFF
--- a/core/solver/bicg.cpp
+++ b/core/solver/bicg.cpp
@@ -129,6 +129,8 @@ void Bicg<ValueType>::apply_dense_impl(const matrix::Dense<ValueType>* dense_b,
 
     auto exec = this->get_executor();
 
+    Array<char> reduction_tmp{exec};
+
     auto one_op = initialize<Vector>({one<ValueType>()}, exec);
     auto neg_one_op = initialize<Vector>({-one<ValueType>()}, exec);
 
@@ -208,7 +210,7 @@ void Bicg<ValueType>::apply_dense_impl(const matrix::Dense<ValueType>* dense_b,
     while (true) {
         get_preconditioner()->apply(r.get(), z.get());
         conj_trans_preconditioner->apply(r2.get(), z2.get());
-        z->compute_conj_dot(r2.get(), rho.get());
+        z->compute_conj_dot(r2.get(), rho.get(), reduction_tmp);
 
         ++iter;
         this->template log<log::Logger::iteration_complete>(
@@ -229,7 +231,7 @@ void Bicg<ValueType>::apply_dense_impl(const matrix::Dense<ValueType>* dense_b,
                                     rho.get(), prev_rho.get(), &stop_status));
         system_matrix_->apply(p.get(), q.get());
         conj_trans_A->apply(p2.get(), q2.get());
-        p2->compute_conj_dot(q.get(), beta.get());
+        p2->compute_conj_dot(q.get(), beta.get(), reduction_tmp);
         // tmp = rho / beta
         // x = x + tmp * p
         // r = r - tmp * q

--- a/core/solver/bicgstab.cpp
+++ b/core/solver/bicgstab.cpp
@@ -111,6 +111,8 @@ void Bicgstab<ValueType>::apply_dense_impl(
 
     auto exec = this->get_executor();
 
+    Array<char> reduction_tmp{exec};
+
     auto one_op = initialize<Vector>({one<ValueType>()}, exec);
     auto neg_one_op = initialize<Vector>({-one<ValueType>()}, exec);
 
@@ -168,7 +170,7 @@ void Bicgstab<ValueType>::apply_dense_impl(
         ++iter;
         this->template log<log::Logger::iteration_complete>(
             this, iter, r.get(), dense_x, nullptr, rho.get());
-        rr->compute_conj_dot(r.get(), rho.get());
+        rr->compute_conj_dot(r.get(), rho.get(), reduction_tmp);
 
         if (stop_criterion->update()
                 .num_iterations(iter)
@@ -187,7 +189,7 @@ void Bicgstab<ValueType>::apply_dense_impl(
 
         get_preconditioner()->apply(p.get(), y.get());
         system_matrix_->apply(y.get(), v.get());
-        rr->compute_conj_dot(v.get(), beta.get());
+        rr->compute_conj_dot(v.get(), beta.get(), reduction_tmp);
         // alpha = rho / beta
         // s = r - alpha * v
         exec->run(bicgstab::make_step_2(r.get(), s.get(), v.get(), rho.get(),
@@ -210,8 +212,8 @@ void Bicgstab<ValueType>::apply_dense_impl(
 
         get_preconditioner()->apply(s.get(), z.get());
         system_matrix_->apply(z.get(), t.get());
-        s->compute_conj_dot(t.get(), gamma.get());
-        t->compute_conj_dot(t.get(), beta.get());
+        s->compute_conj_dot(t.get(), gamma.get(), reduction_tmp);
+        t->compute_conj_dot(t.get(), beta.get(), reduction_tmp);
         // omega = gamma / beta
         // x = x + alpha * y + omega * z
         // r = s - omega * t


### PR DESCRIPTION
This PR uses the new interface for Dense reduction kernels from #990 in all Krylov solvers that use them