### PR TITLE
Only allow gko::share() to work with rvalue references

### DIFF
--- a/core/preconditioner/isai.cpp
+++ b/core/preconditioner/isai.cpp
@@ -225,8 +225,7 @@ void Isai<IsaiType, ValueType, IndexType>::generate_inverse(
             auto rhs_copy = gko::clone(exec->get_master(), excess_rhs);
             std::shared_ptr<LinOpFactory> excess_solver_factory;
             if (parameters_.excess_solver_factory) {
-                excess_solver_factory =
-                    share(parameters_.excess_solver_factory);
+                excess_solver_factory = parameters_.excess_solver_factory;
                 excess_solution->copy_from(excess_rhs.get());
             } else if (is_general || is_spd) {
                 excess_solver_factory =

--- a/core/test/base/utils.cpp
+++ b/core/test/base/utils.cpp
@@ -163,7 +163,7 @@ TEST(Share, SharesSharedPointer)
     std::shared_ptr<Derived> p(new Derived());
     auto plain = p.get();
 
-    auto shared = gko::share(p);
+    auto shared = gko::share(std::move(p));
 
     ::testing::StaticAssertTypeEq<decltype(shared), std::shared_ptr<Derived>>();
     ASSERT_EQ(plain, shared.get());
@@ -175,7 +175,7 @@ TEST(Share, SharesUniquePointer)
     std::unique_ptr<Derived> p(new Derived());
     auto plain = p.get();
 
-    auto shared = gko::share(p);
+    auto shared = gko::share(std::move(p));
 
     ::testing::StaticAssertTypeEq<decltype(shared), std::shared_ptr<Derived>>();
     ASSERT_EQ(plain, shared.get());

--- a/core/test/base/utils.cpp
+++ b/core/test/base/utils.cpp
@@ -170,6 +170,14 @@ TEST(Share, SharesSharedPointer)
 }
 
 
+TEST(Share, SharesTemporarySharedPointer)
+{
+    auto shared = gko::share(std::make_shared<Derived>());
+
+    ::testing::StaticAssertTypeEq<decltype(shared), std::shared_ptr<Derived>>();
+}
+
+
 TEST(Share, SharesUniquePointer)
 {
     std::unique_ptr<Derived> p(new Derived());
@@ -179,6 +187,14 @@ TEST(Share, SharesUniquePointer)
 
     ::testing::StaticAssertTypeEq<decltype(shared), std::shared_ptr<Derived>>();
     ASSERT_EQ(plain, shared.get());
+}
+
+
+TEST(Share, SharesTemporaryUniquePointer)
+{
+    auto shared = gko::share(std::make_unique<Derived>());
+
+    ::testing::StaticAssertTypeEq<decltype(shared), std::shared_ptr<Derived>>();
 }
 
 

--- a/core/test/preconditioner/isai.cpp
+++ b/core/test/preconditioner/isai.cpp
@@ -261,9 +261,9 @@ TYPED_TEST(IsaiFactory, CanSetExcessSolverFactoryU)
 TYPED_TEST(IsaiFactory, ThrowsWrongDimensionA)
 {
     using Csr = typename TestFixture::Csr;
-    auto mtx = Csr::create(this->exec, gko::dim<2>{1, 2}, 1);
+    auto mtx = gko::share(Csr::create(this->exec, gko::dim<2>{1, 2}, 1));
 
-    ASSERT_THROW(this->general_isai_factory->generate(gko::share(mtx)),
+    ASSERT_THROW(this->general_isai_factory->generate(mtx),
                  gko::DimensionMismatch);
 }
 
@@ -271,19 +271,18 @@ TYPED_TEST(IsaiFactory, ThrowsWrongDimensionA)
 TYPED_TEST(IsaiFactory, ThrowsWrongDimensionSpd)
 {
     using Csr = typename TestFixture::Csr;
-    auto mtx = Csr::create(this->exec, gko::dim<2>{1, 2}, 1);
+    auto mtx = gko::share(Csr::create(this->exec, gko::dim<2>{1, 2}, 1));
 
-    ASSERT_THROW(this->spd_isai_factory->generate(gko::share(mtx)),
-                 gko::DimensionMismatch);
+    ASSERT_THROW(this->spd_isai_factory->generate(mtx), gko::DimensionMismatch);
 }
 
 
 TYPED_TEST(IsaiFactory, ThrowsWrongDimensionL)
 {
     using Csr = typename TestFixture::Csr;
-    auto mtx = Csr::create(this->exec, gko::dim<2>{1, 2}, 1);
+    auto mtx = gko::share(Csr::create(this->exec, gko::dim<2>{1, 2}, 1));
 
-    ASSERT_THROW(this->lower_isai_factory->generate(gko::share(mtx)),
+    ASSERT_THROW(this->lower_isai_factory->generate(mtx),
                  gko::DimensionMismatch);
 }
 
@@ -291,9 +290,9 @@ TYPED_TEST(IsaiFactory, ThrowsWrongDimensionL)
 TYPED_TEST(IsaiFactory, ThrowsWrongDimensionU)
 {
     using Csr = typename TestFixture::Csr;
-    auto mtx = Csr::create(this->exec, gko::dim<2>{1, 2}, 1);
+    auto mtx = gko::share(Csr::create(this->exec, gko::dim<2>{1, 2}, 1));
 
-    ASSERT_THROW(this->upper_isai_factory->generate(gko::share(mtx)),
+    ASSERT_THROW(this->upper_isai_factory->generate(mtx),
                  gko::DimensionMismatch);
 }
 
@@ -301,40 +300,36 @@ TYPED_TEST(IsaiFactory, ThrowsWrongDimensionU)
 TYPED_TEST(IsaiFactory, ThrowsNoConversionCsrA)
 {
     using Csr = typename TestFixture::Csr;
-    auto mtx = DummyOperator::create(this->exec, gko::dim<2>{2, 2});
+    auto mtx = gko::share(DummyOperator::create(this->exec, gko::dim<2>{2, 2}));
 
-    ASSERT_THROW(this->general_isai_factory->generate(gko::share(mtx)),
-                 gko::NotSupported);
+    ASSERT_THROW(this->general_isai_factory->generate(mtx), gko::NotSupported);
 }
 
 
 TYPED_TEST(IsaiFactory, ThrowsNoConversionCsrSpd)
 {
     using Csr = typename TestFixture::Csr;
-    auto mtx = DummyOperator::create(this->exec, gko::dim<2>{2, 2});
+    auto mtx = gko::share(DummyOperator::create(this->exec, gko::dim<2>{2, 2}));
 
-    ASSERT_THROW(this->spd_isai_factory->generate(gko::share(mtx)),
-                 gko::NotSupported);
+    ASSERT_THROW(this->spd_isai_factory->generate(mtx), gko::NotSupported);
 }
 
 
 TYPED_TEST(IsaiFactory, ThrowsNoConversionCsrL)
 {
     using Csr = typename TestFixture::Csr;
-    auto mtx = DummyOperator::create(this->exec, gko::dim<2>{2, 2});
+    auto mtx = gko::share(DummyOperator::create(this->exec, gko::dim<2>{2, 2}));
 
-    ASSERT_THROW(this->lower_isai_factory->generate(gko::share(mtx)),
-                 gko::NotSupported);
+    ASSERT_THROW(this->lower_isai_factory->generate(mtx), gko::NotSupported);
 }
 
 
 TYPED_TEST(IsaiFactory, ThrowsNoConversionCsrU)
 {
     using Csr = typename TestFixture::Csr;
-    auto mtx = DummyOperator::create(this->exec, gko::dim<2>{2, 2});
+    auto mtx = gko::share(DummyOperator::create(this->exec, gko::dim<2>{2, 2}));
 
-    ASSERT_THROW(this->upper_isai_factory->generate(gko::share(mtx)),
-                 gko::NotSupported);
+    ASSERT_THROW(this->upper_isai_factory->generate(mtx), gko::NotSupported);
 }
 
 

--- a/core/test/solver/ir.cpp
+++ b/core/test/solver/ir.cpp
@@ -76,7 +76,7 @@ protected:
 
     std::shared_ptr<const gko::Executor> exec;
     std::shared_ptr<Mtx> mtx;
-    std::unique_ptr<typename Solver::Factory> ir_factory;
+    std::shared_ptr<typename Solver::Factory> ir_factory;
     std::unique_ptr<gko::LinOp> solver;
 
     static void assert_same_matrices(const Mtx* m1, const Mtx* m2)
@@ -374,7 +374,7 @@ TYPED_TEST(Ir, DefaultSmootherBuildWithSolver)
 {
     using value_type = typename TestFixture::value_type;
     using Solver = typename TestFixture::Solver;
-    auto solver = gko::as<Solver>(share(this->solver));
+    auto solver = gko::as<Solver>(share(std::move(this->solver)));
 
     auto smoother_factory = gko::solver::build_smoother<value_type>(solver);
     auto criteria =
@@ -394,7 +394,7 @@ TYPED_TEST(Ir, DefaultSmootherBuildWithFactory)
 {
     using value_type = typename TestFixture::value_type;
     using Solver = typename TestFixture::Solver;
-    auto factory = share(this->ir_factory);
+    auto factory = this->ir_factory;
 
     auto smoother_factory = gko::solver::build_smoother<value_type>(factory);
     auto criteria =
@@ -413,7 +413,7 @@ TYPED_TEST(Ir, SmootherBuildWithSolver)
 {
     using value_type = typename TestFixture::value_type;
     using Solver = typename TestFixture::Solver;
-    auto solver = gko::as<Solver>(share(this->solver));
+    auto solver = gko::as<Solver>(gko::share(std::move(this->solver)));
 
     auto smoother_factory =
         gko::solver::build_smoother<value_type>(solver, 3, value_type{0.5});
@@ -434,7 +434,7 @@ TYPED_TEST(Ir, SmootherBuildWithFactory)
 {
     using value_type = typename TestFixture::value_type;
     using Solver = typename TestFixture::Solver;
-    auto factory = share(this->ir_factory);
+    auto factory = this->ir_factory;
 
     auto smoother_factory =
         gko::solver::build_smoother<value_type>(factory, 3, value_type{0.5});

--- a/core/test/stop/combined.cpp
+++ b/core/test/stop/combined.cpp
@@ -150,10 +150,11 @@ TEST_F(Combined, FunctionCanThrowAllNullptr)
 
 TEST_F(Combined, FunctionCanThrowFirstIsInvalid)
 {
-    auto stop =
-        gko::stop::Iteration::build().with_max_iters(test_iterations).on(exec_);
+    auto stop = gko::share(gko::stop::Iteration::build()
+                               .with_max_iters(test_iterations)
+                               .on(exec_));
     std::vector<std::shared_ptr<const gko::stop::CriterionFactory>>
-        criterion_vec{nullptr, gko::share(stop)};
+        criterion_vec{nullptr, stop};
 
     ASSERT_THROW(gko::stop::combine(criterion_vec), gko::NotSupported);
 }
@@ -161,10 +162,11 @@ TEST_F(Combined, FunctionCanThrowFirstIsInvalid)
 
 TEST_F(Combined, FunctionCanIgnoreNullptr)
 {
-    auto stop =
-        gko::stop::Iteration::build().with_max_iters(test_iterations).on(exec_);
+    auto stop = gko::share(gko::stop::Iteration::build()
+                               .with_max_iters(test_iterations)
+                               .on(exec_));
     std::vector<std::shared_ptr<const gko::stop::CriterionFactory>>
-        criterion_vec{gko::share(stop), nullptr};
+        criterion_vec{stop, nullptr};
     auto combined = gko::stop::combine(criterion_vec);
 
     ASSERT_NO_THROW(combined->generate(nullptr, nullptr, nullptr));

--- a/examples/adaptiveprecision-blockjacobi/adaptiveprecision-blockjacobi.cpp
+++ b/examples/adaptiveprecision-blockjacobi/adaptiveprecision-blockjacobi.cpp
@@ -107,11 +107,11 @@ int main(int argc, char* argv[])
     // copy b again
     b->copy_from(host_x.get());
     const RealValueType reduction_factor = 1e-7;
-    auto iter_stop =
-        gko::stop::Iteration::build().with_max_iters(10000u).on(exec);
-    auto tol_stop = gko::stop::ResidualNorm<ValueType>::build()
-                        .with_reduction_factor(reduction_factor)
-                        .on(exec);
+    auto iter_stop = gko::share(
+        gko::stop::Iteration::build().with_max_iters(10000u).on(exec));
+    auto tol_stop = gko::share(gko::stop::ResidualNorm<ValueType>::build()
+                                   .with_reduction_factor(reduction_factor)
+                                   .on(exec));
 
     std::shared_ptr<const gko::log::Convergence<ValueType>> logger =
         gko::log::Convergence<ValueType>::create(exec);
@@ -121,7 +121,7 @@ int main(int argc, char* argv[])
     // Create solver factory
     auto solver_gen =
         cg::build()
-            .with_criteria(gko::share(iter_stop), gko::share(tol_stop))
+            .with_criteria(iter_stop, tol_stop)
             // Add preconditioner, these 2 lines are the only
             // difference from the simple solver example
             .with_preconditioner(bj::build()

--- a/examples/ilu-preconditioned-solver/ilu-preconditioned-solver.cpp
+++ b/examples/ilu-preconditioned-solver/ilu-preconditioned-solver.cpp
@@ -95,7 +95,7 @@ int main(int argc, char* argv[])
     auto par_ilu_fact =
         gko::factorization::ParIlu<ValueType, IndexType>::build().on(exec);
     // Generate concrete factorization for input matrix
-    auto par_ilu = par_ilu_fact->generate(A);
+    auto par_ilu = gko::share(par_ilu_fact->generate(A));
 
     // Generate an ILU preconditioner factory by setting lower and upper
     // triangular solver - in this case the exact triangular solves
@@ -106,7 +106,7 @@ int main(int argc, char* argv[])
             .on(exec);
 
     // Use incomplete factors to generate ILU preconditioner
-    auto ilu_preconditioner = ilu_pre_factory->generate(gko::share(par_ilu));
+    auto ilu_preconditioner = gko::share(ilu_pre_factory->generate(par_ilu));
 
     // Use preconditioner inside GMRES solver factory
     // Generating a solver factory tied to a specific preconditioner makes sense
@@ -120,7 +120,7 @@ int main(int argc, char* argv[])
                 gko::stop::ResidualNorm<ValueType>::build()
                     .with_reduction_factor(reduction_factor)
                     .on(exec))
-            .with_generated_preconditioner(gko::share(ilu_preconditioner))
+            .with_generated_preconditioner(ilu_preconditioner)
             .on(exec);
 
     // Generate preconditioned solver for a specific target system

--- a/examples/ir-ilu-preconditioned-solver/ir-ilu-preconditioned-solver.cpp
+++ b/examples/ir-ilu-preconditioned-solver/ir-ilu-preconditioned-solver.cpp
@@ -105,21 +105,21 @@ int main(int argc, char* argv[])
     auto par_ilu_fact =
         gko::factorization::ParIlu<ValueType, IndexType>::build().on(exec);
     // Generate concrete factorization for input matrix
-    auto par_ilu = par_ilu_fact->generate(A);
+    auto par_ilu = gko::share(par_ilu_fact->generate(A));
 
     // Generate an iterative refinement factory to be used as a triangular
     // solver in the preconditioner application. The generated method is
     // equivalent to doing five block-Jacobi sweeps with a maximum block size
     // of 16.
-    auto bj_factory =
+    auto bj_factory = gko::share(
         bj::build()
             .with_max_block_size(16u)
             .with_storage_optimization(gko::precision_reduction::autodetect())
-            .on(exec);
+            .on(exec));
 
     auto trisolve_factory =
         ir::build()
-            .with_solver(share(bj_factory))
+            .with_solver(bj_factory)
             .with_criteria(
                 gko::stop::Iteration::build().with_max_iters(sweeps).on(exec))
             .on(exec);
@@ -134,15 +134,15 @@ int main(int argc, char* argv[])
             .on(exec);
 
     // Use incomplete factors to generate ILU preconditioner
-    auto ilu_preconditioner = ilu_pre_factory->generate(gko::share(par_ilu));
+    auto ilu_preconditioner = gko::share(ilu_pre_factory->generate(par_ilu));
 
     // Create stopping criteria for Gmres
     const RealValueType reduction_factor{1e-12};
-    auto iter_stop =
-        gko::stop::Iteration::build().with_max_iters(1000u).on(exec);
-    auto tol_stop = gko::stop::ResidualNorm<ValueType>::build()
-                        .with_reduction_factor(reduction_factor)
-                        .on(exec);
+    auto iter_stop = gko::share(
+        gko::stop::Iteration::build().with_max_iters(1000u).on(exec));
+    auto tol_stop = gko::share(gko::stop::ResidualNorm<ValueType>::build()
+                                   .with_reduction_factor(reduction_factor)
+                                   .on(exec));
 
     std::shared_ptr<const gko::log::Convergence<ValueType>> logger =
         gko::log::Convergence<ValueType>::create(exec);
@@ -155,8 +155,8 @@ int main(int argc, char* argv[])
     // solver+preconditioner combination is expected to be effective.
     auto ilu_gmres_factory =
         gmres::build()
-            .with_criteria(gko::share(iter_stop), gko::share(tol_stop))
-            .with_generated_preconditioner(gko::share(ilu_preconditioner))
+            .with_criteria(iter_stop, tol_stop)
+            .with_generated_preconditioner(ilu_preconditioner)
             .on(exec);
 
     // Generate preconditioned solver for a specific target system

--- a/examples/iterative-refinement/iterative-refinement.cpp
+++ b/examples/iterative-refinement/iterative-refinement.cpp
@@ -109,11 +109,12 @@ int main(int argc, char* argv[])
     b->copy_from(host_x.get());
     gko::size_type max_iters = 10000u;
     RealValueType outer_reduction_factor{1e-12};
-    auto iter_stop =
-        gko::stop::Iteration::build().with_max_iters(max_iters).on(exec);
-    auto tol_stop = gko::stop::ResidualNorm<ValueType>::build()
-                        .with_reduction_factor(outer_reduction_factor)
-                        .on(exec);
+    auto iter_stop = gko::share(
+        gko::stop::Iteration::build().with_max_iters(max_iters).on(exec));
+    auto tol_stop =
+        gko::share(gko::stop::ResidualNorm<ValueType>::build()
+                       .with_reduction_factor(outer_reduction_factor)
+                       .on(exec));
 
     std::shared_ptr<const gko::log::Convergence<ValueType>> logger =
         gko::log::Convergence<ValueType>::create(exec);
@@ -131,7 +132,7 @@ int main(int argc, char* argv[])
                             .with_reduction_factor(inner_reduction_factor)
                             .on(exec))
                     .on(exec))
-            .with_criteria(gko::share(iter_stop), gko::share(tol_stop))
+            .with_criteria(iter_stop, tol_stop)
             .on(exec);
     // Create solver
     auto solver = solver_gen->generate(A);

--- a/examples/multigrid-preconditioned-solver/multigrid-preconditioned-solver.cpp
+++ b/examples/multigrid-preconditioned-solver/multigrid-preconditioned-solver.cpp
@@ -111,10 +111,11 @@ int main(int argc, char* argv[])
     // Prepare the stopping criteria
     const gko::remove_complex<ValueType> tolerance = 1e-8;
     auto iter_stop =
-        gko::stop::Iteration::build().with_max_iters(100u).on(exec);
-    auto tol_stop = gko::stop::AbsoluteResidualNorm<ValueType>::build()
-                        .with_tolerance(tolerance)
-                        .on(exec);
+        gko::share(gko::stop::Iteration::build().with_max_iters(100u).on(exec));
+    auto tol_stop =
+        gko::share(gko::stop::AbsoluteResidualNorm<ValueType>::build()
+                       .with_tolerance(tolerance)
+                       .on(exec));
 
     std::shared_ptr<const gko::log::Convergence<ValueType>> logger =
         gko::log::Convergence<ValueType>::create(exec);
@@ -132,7 +133,8 @@ int main(int argc, char* argv[])
                 gko::stop::Iteration::build().with_max_iters(2u).on(exec))
             .on(exec));
     // Create MultigridLevel factory
-    auto mg_level_gen = amgx_pgm::build().with_deterministic(true).on(exec);
+    auto mg_level_gen =
+        gko::share(amgx_pgm::build().with_deterministic(true).on(exec));
     // Create CoarsestSolver factory
     auto coarsest_gen = gko::share(
         ir::build()
@@ -142,24 +144,23 @@ int main(int argc, char* argv[])
                 gko::stop::Iteration::build().with_max_iters(4u).on(exec))
             .on(exec));
     // Create multigrid factory
-    auto multigrid_gen =
+    auto multigrid_gen = gko::share(
         mg::build()
             .with_max_levels(9u)
             .with_min_coarse_rows(10u)
             .with_pre_smoother(smoother_gen)
             .with_post_uses_pre(true)
-            .with_mg_level(gko::share(mg_level_gen))
+            .with_mg_level(mg_level_gen)
             .with_coarsest_solver(coarsest_gen)
             .with_zero_guess(true)
             .with_criteria(
                 gko::stop::Iteration::build().with_max_iters(1u).on(exec))
-            .on(exec);
+            .on(exec));
     // Create solver factory
-    auto solver_gen =
-        cg::build()
-            .with_criteria(gko::share(iter_stop), gko::share(tol_stop))
-            .with_preconditioner(gko::share(multigrid_gen))
-            .on(exec);
+    auto solver_gen = cg::build()
+                          .with_criteria(iter_stop, tol_stop)
+                          .with_preconditioner(multigrid_gen)
+                          .on(exec);
     // Create solver
     std::chrono::nanoseconds gen_time(0);
     auto gen_tic = std::chrono::steady_clock::now();

--- a/include/ginkgo/core/base/utils_helper.hpp
+++ b/include/ginkgo/core/base/utils_helper.hpp
@@ -202,8 +202,8 @@ inline detail::cloned_type<Pointer> clone(std::shared_ptr<const Executor> exec,
  * @tparam OwningPointer  type of pointer with ownership to the object
  *                        (has to be a smart pointer)
  *
- * @param p  a pointer to the object. It must be movable, meaning it must be an
- *           rvalue reference.
+ * @param p  a pointer to the object. It must be a temporary or explicitly
+ *           marked movable (rvalue reference).
  *
  * @note The original pointer `p` becomes invalid after this call.
  */
@@ -213,7 +213,7 @@ inline detail::shared_type<OwningPointer> share(OwningPointer&& p)
     static_assert(detail::have_ownership<OwningPointer>(),
                   "OwningPointer does not have ownership of the object");
     static_assert(std::is_rvalue_reference<decltype(p)>::value,
-                  "p must be an xvalue for this function to work");
+                  "p must be an rvalue for this function to work");
     return detail::shared_type<OwningPointer>(std::move(p));
 }
 

--- a/include/ginkgo/core/base/utils_helper.hpp
+++ b/include/ginkgo/core/base/utils_helper.hpp
@@ -202,7 +202,8 @@ inline detail::cloned_type<Pointer> clone(std::shared_ptr<const Executor> exec,
  * @tparam OwningPointer  type of pointer with ownership to the object
  *                        (has to be a smart pointer)
  *
- * @param p  a pointer to the object
+ * @param p  a pointer to the object. It must be movable, meaning it must be an
+ *           rvalue reference.
  *
  * @note The original pointer `p` becomes invalid after this call.
  */
@@ -211,6 +212,8 @@ inline detail::shared_type<OwningPointer> share(OwningPointer&& p)
 {
     static_assert(detail::have_ownership<OwningPointer>(),
                   "OwningPointer does not have ownership of the object");
+    static_assert(std::is_rvalue_reference<decltype(p)>::value,
+                  "p must be an xvalue for this function to work");
     return detail::shared_type<OwningPointer>(std::move(p));
 }
 

--- a/include/ginkgo/core/reorder/rcm.hpp
+++ b/include/ginkgo/core/reorder/rcm.hpp
@@ -194,13 +194,14 @@ protected:
         // Copy back results to gpu if necessary.
         if (is_gpu_executor) {
             const auto gpu_exec = this->get_executor();
-            auto gpu_perm = PermutationMatrix::create(gpu_exec, dim);
+            auto gpu_perm = share(PermutationMatrix::create(gpu_exec, dim));
             gpu_perm->copy_from(permutation_.get());
-            permutation_ = gko::share(gpu_perm);
+            permutation_ = gpu_perm;
             if (inv_permutation_) {
-                auto gpu_inv_perm = PermutationMatrix::create(gpu_exec, dim);
+                auto gpu_inv_perm =
+                    share(PermutationMatrix::create(gpu_exec, dim));
                 gpu_inv_perm->copy_from(inv_permutation_.get());
-                inv_permutation_ = gko::share(gpu_inv_perm);
+                inv_permutation_ = gpu_inv_perm;
             }
         }
     }

--- a/omp/test/reorder/rcm_kernels.cpp
+++ b/omp/test/reorder/rcm_kernels.cpp
@@ -315,8 +315,9 @@ protected:
     std::shared_ptr<const gko::Executor> omp;
     std::shared_ptr<CsrMtx> o_1138_bus_mtx;
     std::shared_ptr<CsrMtx> d_1138_bus_mtx;
-    std::unique_ptr<reorder_type> reorder_op;
-    std::unique_ptr<reorder_type> d_reorder_op;
+    // Can't std::move parameter when using ASSERT_PREDN, no perfect forwarding.
+    // Therefore, use shared pointer
+    std::shared_ptr<reorder_type> d_reorder_op;
 };
 
 TEST_F(Rcm, OmpPermutationIsRcmOrdered)
@@ -325,9 +326,7 @@ TEST_F(Rcm, OmpPermutationIsRcmOrdered)
 
     auto perm = d_reorder_op->get_permutation();
 
-    // Can't std::move parameter when using ASSERT_PREDN, no perfect forwarding.
-    auto d_reorder_op_shared = gko::share(d_reorder_op);
-    ASSERT_PRED2(is_rcm_ordered, d_1138_bus_mtx, d_reorder_op_shared);
+    ASSERT_PRED2(is_rcm_ordered, d_1138_bus_mtx, d_reorder_op);
 }
 
 }  // namespace

--- a/omp/test/solver/gmres_kernels.cpp
+++ b/omp/test/solver/gmres_kernels.cpp
@@ -165,8 +165,8 @@ protected:
 
     std::default_random_engine rand_engine;
 
-    std::unique_ptr<Mtx> mtx;
-    std::unique_ptr<Mtx> d_mtx;
+    std::shared_ptr<Mtx> mtx;
+    std::shared_ptr<Mtx> d_mtx;
     std::unique_ptr<Solver::Factory> omp_gmres_factory;
     std::unique_ptr<Solver::Factory> ref_gmres_factory;
 
@@ -290,8 +290,8 @@ TEST_F(Gmres, GmresApplyOneRHSIsEquivalentToRef)
 {
     int m = 123;
     int n = 1;
-    auto ref_solver = ref_gmres_factory->generate(gko::share(mtx));
-    auto omp_solver = omp_gmres_factory->generate(gko::share(d_mtx));
+    auto ref_solver = ref_gmres_factory->generate(mtx);
+    auto omp_solver = omp_gmres_factory->generate(d_mtx);
     auto b = gen_mtx(m, n);
     auto x = gen_mtx(m, n);
     auto d_b = gko::clone(omp, b);

--- a/reference/test/base/utils.cpp
+++ b/reference/test/base/utils.cpp
@@ -103,7 +103,7 @@ TEST_F(ConvertToWithSorting, DontSortWithUniquePtr)
 
 TEST_F(ConvertToWithSorting, SortWithSharedPtr)
 {
-    std::shared_ptr<Csr> shared = gko::share(unsorted_csr);
+    std::shared_ptr<Csr> shared = gko::share(unsorted_csr->clone());
 
     auto result = gko::convert_to_with_sorting<Csr>(ref, shared, false);
 
@@ -114,7 +114,7 @@ TEST_F(ConvertToWithSorting, SortWithSharedPtr)
 
 TEST_F(ConvertToWithSorting, DontSortWithSharedPtr)
 {
-    std::shared_ptr<Csr> shared = gko::share(unsorted_csr);
+    std::shared_ptr<Csr> shared = gko::share(unsorted_csr->clone());
 
     auto result = gko::convert_to_with_sorting<Csr>(ref, shared, true);
 
@@ -125,7 +125,7 @@ TEST_F(ConvertToWithSorting, DontSortWithSharedPtr)
 
 TEST_F(ConvertToWithSorting, SortWithSharedConstPtr)
 {
-    std::shared_ptr<const Coo> shared = gko::share(unsorted_coo);
+    std::shared_ptr<const Coo> shared = gko::share(unsorted_coo->clone());
 
     auto result = gko::convert_to_with_sorting<Csr>(ref, shared, false);
 
@@ -136,7 +136,7 @@ TEST_F(ConvertToWithSorting, SortWithSharedConstPtr)
 
 TEST_F(ConvertToWithSorting, DontSortWithSharedConstPtr)
 {
-    std::shared_ptr<const Coo> shared = gko::share(unsorted_coo);
+    std::shared_ptr<const Coo> shared = gko::share(unsorted_coo->clone());
 
     auto result = gko::convert_to_with_sorting<Csr>(ref, shared, true);
 

--- a/reference/test/factorization/ic_kernels.cpp
+++ b/reference/test/factorization/ic_kernels.cpp
@@ -121,20 +121,18 @@ TYPED_TEST_SUITE(Ic, gko::test::ValueIndexTypes, PairTypenameNameGenerator);
 
 TYPED_TEST(Ic, ThrowNotSupportedForWrongLinOp)
 {
-    auto lin_op = DummyLinOp::create(this->ref);
+    auto lin_op = gko::share(DummyLinOp::create(this->ref));
 
-    ASSERT_THROW(this->fact_fact->generate(gko::share(lin_op)),
-                 gko::NotSupported);
+    ASSERT_THROW(this->fact_fact->generate(lin_op), gko::NotSupported);
 }
 
 
 TYPED_TEST(Ic, ThrowDimensionMismatch)
 {
     using Csr = typename TestFixture::Csr;
-    auto matrix = Csr::create(this->ref, gko::dim<2>{2, 3}, 4);
+    auto matrix = gko::share(Csr::create(this->ref, gko::dim<2>{2, 3}, 4));
 
-    ASSERT_THROW(this->fact_fact->generate(gko::share(matrix)),
-                 gko::DimensionMismatch);
+    ASSERT_THROW(this->fact_fact->generate(matrix), gko::DimensionMismatch);
 }
 
 
@@ -182,10 +180,11 @@ TYPED_TEST(Ic, GenerateIdentity)
 TYPED_TEST(Ic, GenerateDenseIdentity)
 {
     using Dense = typename TestFixture::Dense;
-    auto dense_id = Dense::create(this->exec, this->identity->get_size());
+    auto dense_id =
+        gko::share(Dense::create(this->exec, this->identity->get_size()));
     this->identity->convert_to(dense_id.get());
 
-    auto fact = this->fact_fact->generate(gko::share(dense_id));
+    auto fact = this->fact_fact->generate(dense_id);
 
     GKO_ASSERT_MTX_NEAR(fact->get_l_factor(), this->identity, this->tol);
     GKO_ASSERT_MTX_NEAR(fact->get_lt_factor(), this->identity, this->tol);

--- a/reference/test/factorization/ilu_kernels.cpp
+++ b/reference/test/factorization/ilu_kernels.cpp
@@ -208,28 +208,26 @@ TYPED_TEST_SUITE(Ilu, gko::test::ValueIndexTypes, PairTypenameNameGenerator);
 
 TYPED_TEST(Ilu, ThrowNotSupportedForWrongLinOp1)
 {
-    auto linOp = DummyLinOp::create(this->ref);
+    auto linOp = gko::share(DummyLinOp::create(this->ref));
 
-    ASSERT_THROW(this->ilu_factory_skip->generate(gko::share(linOp)),
-                 gko::NotSupported);
+    ASSERT_THROW(this->ilu_factory_skip->generate(linOp), gko::NotSupported);
 }
 
 
 TYPED_TEST(Ilu, ThrowNotSupportedForWrongLinOp2)
 {
-    auto linOp = DummyLinOp::create(this->ref);
+    auto linOp = gko::share(DummyLinOp::create(this->ref));
 
-    ASSERT_THROW(this->ilu_factory_sort->generate(gko::share(linOp)),
-                 gko::NotSupported);
+    ASSERT_THROW(this->ilu_factory_sort->generate(linOp), gko::NotSupported);
 }
 
 
 TYPED_TEST(Ilu, ThrowDimensionMismatch)
 {
     using Csr = typename TestFixture::Csr;
-    auto matrix = Csr::create(this->ref, gko::dim<2>{2, 3}, 4);
+    auto matrix = gko::share(Csr::create(this->ref, gko::dim<2>{2, 3}, 4));
 
-    ASSERT_THROW(this->ilu_factory_sort->generate(gko::share(matrix)),
+    ASSERT_THROW(this->ilu_factory_sort->generate(matrix),
                  gko::DimensionMismatch);
 }
 

--- a/reference/test/factorization/par_ic_kernels.cpp
+++ b/reference/test/factorization/par_ic_kernels.cpp
@@ -159,20 +159,18 @@ TYPED_TEST(ParIc, KernelInit)
 
 TYPED_TEST(ParIc, ThrowNotSupportedForWrongLinOp)
 {
-    auto lin_op = DummyLinOp::create(this->ref);
+    auto lin_op = gko::share(DummyLinOp::create(this->ref));
 
-    ASSERT_THROW(this->fact_fact->generate(gko::share(lin_op)),
-                 gko::NotSupported);
+    ASSERT_THROW(this->fact_fact->generate(lin_op), gko::NotSupported);
 }
 
 
 TYPED_TEST(ParIc, ThrowDimensionMismatch)
 {
     using Csr = typename TestFixture::Csr;
-    auto matrix = Csr::create(this->ref, gko::dim<2>{2, 3}, 4);
+    auto matrix = gko::share(Csr::create(this->ref, gko::dim<2>{2, 3}, 4));
 
-    ASSERT_THROW(this->fact_fact->generate(gko::share(matrix)),
-                 gko::DimensionMismatch);
+    ASSERT_THROW(this->fact_fact->generate(matrix), gko::DimensionMismatch);
 }
 
 
@@ -239,10 +237,11 @@ TYPED_TEST(ParIc, GenerateIdentity)
 TYPED_TEST(ParIc, GenerateDenseIdentity)
 {
     using Dense = typename TestFixture::Dense;
-    auto dense_id = Dense::create(this->exec, this->identity->get_size());
+    auto dense_id =
+        gko::share(Dense::create(this->exec, this->identity->get_size()));
     this->identity->convert_to(dense_id.get());
 
-    auto fact = this->fact_fact->generate(gko::share(dense_id));
+    auto fact = this->fact_fact->generate(dense_id);
 
     GKO_ASSERT_MTX_NEAR(fact->get_l_factor(), this->identity, this->tol);
     GKO_ASSERT_MTX_NEAR(fact->get_lt_factor(), this->identity, this->tol);

--- a/reference/test/factorization/par_ict_kernels.cpp
+++ b/reference/test/factorization/par_ict_kernels.cpp
@@ -240,20 +240,18 @@ TYPED_TEST(ParIct, KernelComputeLU)
 
 TYPED_TEST(ParIct, ThrowNotSupportedForWrongLinOp)
 {
-    auto lin_op = DummyLinOp::create(this->ref);
+    auto lin_op = gko::share(DummyLinOp::create(this->ref));
 
-    ASSERT_THROW(this->fact_fact->generate(gko::share(lin_op)),
-                 gko::NotSupported);
+    ASSERT_THROW(this->fact_fact->generate(lin_op), gko::NotSupported);
 }
 
 
 TYPED_TEST(ParIct, ThrowDimensionMismatch)
 {
     using Csr = typename TestFixture::Csr;
-    auto matrix = Csr::create(this->ref, gko::dim<2>{2, 3}, 4);
+    auto matrix = gko::share(Csr::create(this->ref, gko::dim<2>{2, 3}, 4));
 
-    ASSERT_THROW(this->fact_fact->generate(gko::share(matrix)),
-                 gko::DimensionMismatch);
+    ASSERT_THROW(this->fact_fact->generate(matrix), gko::DimensionMismatch);
 }
 
 
@@ -307,9 +305,10 @@ TYPED_TEST(ParIct, GenerateIdentity)
 TYPED_TEST(ParIct, GenerateDenseIdentity)
 {
     using Dense = typename TestFixture::Dense;
-    auto dense_id = Dense::create(this->exec, this->identity->get_size());
+    auto dense_id =
+        gko::share(Dense::create(this->exec, this->identity->get_size()));
     this->identity->convert_to(dense_id.get());
-    auto fact = this->fact_fact->generate(gko::share(dense_id));
+    auto fact = this->fact_fact->generate(dense_id);
 
     GKO_ASSERT_MTX_NEAR(fact->get_l_factor(), this->identity, this->tol);
     GKO_ASSERT_MTX_NEAR(fact->get_lt_factor(), this->identity, this->tol);

--- a/reference/test/factorization/par_ilu_kernels.cpp
+++ b/reference/test/factorization/par_ilu_kernels.cpp
@@ -447,28 +447,26 @@ TYPED_TEST(ParIlu, KernelComputeLU)
 
 TYPED_TEST(ParIlu, ThrowNotSupportedForWrongLinOp1)
 {
-    auto linOp = DummyLinOp::create(this->ref);
+    auto linOp = gko::share(DummyLinOp::create(this->ref));
 
-    ASSERT_THROW(this->ilu_factory_skip->generate(gko::share(linOp)),
-                 gko::NotSupported);
+    ASSERT_THROW(this->ilu_factory_skip->generate(linOp), gko::NotSupported);
 }
 
 
 TYPED_TEST(ParIlu, ThrowNotSupportedForWrongLinOp2)
 {
-    auto linOp = DummyLinOp::create(this->ref);
+    auto linOp = gko::share(DummyLinOp::create(this->ref));
 
-    ASSERT_THROW(this->ilu_factory_sort->generate(gko::share(linOp)),
-                 gko::NotSupported);
+    ASSERT_THROW(this->ilu_factory_sort->generate(linOp), gko::NotSupported);
 }
 
 
 TYPED_TEST(ParIlu, ThrowDimensionMismatch)
 {
     using Csr = typename TestFixture::Csr;
-    auto matrix = Csr::create(this->ref, gko::dim<2>{2, 3}, 4);
+    auto matrix = gko::share(Csr::create(this->ref, gko::dim<2>{2, 3}, 4));
 
-    ASSERT_THROW(this->ilu_factory_sort->generate(gko::share(matrix)),
+    ASSERT_THROW(this->ilu_factory_sort->generate(matrix),
                  gko::DimensionMismatch);
 }
 

--- a/reference/test/factorization/par_ilut_kernels.cpp
+++ b/reference/test/factorization/par_ilut_kernels.cpp
@@ -515,20 +515,18 @@ TYPED_TEST(ParIlut, KernelComputeLU)
 
 TYPED_TEST(ParIlut, ThrowNotSupportedForWrongLinOp)
 {
-    auto lin_op = DummyLinOp::create(this->ref);
+    auto lin_op = gko::share(DummyLinOp::create(this->ref));
 
-    ASSERT_THROW(this->fact_fact->generate(gko::share(lin_op)),
-                 gko::NotSupported);
+    ASSERT_THROW(this->fact_fact->generate(lin_op), gko::NotSupported);
 }
 
 
 TYPED_TEST(ParIlut, ThrowDimensionMismatch)
 {
     using Csr = typename TestFixture::Csr;
-    auto matrix = Csr::create(this->ref, gko::dim<2>{2, 3}, 4);
+    auto matrix = gko::share(Csr::create(this->ref, gko::dim<2>{2, 3}, 4));
 
-    ASSERT_THROW(this->fact_fact->generate(gko::share(matrix)),
-                 gko::DimensionMismatch);
+    ASSERT_THROW(this->fact_fact->generate(matrix), gko::DimensionMismatch);
 }
 
 
@@ -582,9 +580,10 @@ TYPED_TEST(ParIlut, GenerateIdentity)
 TYPED_TEST(ParIlut, GenerateDenseIdentity)
 {
     using Dense = typename TestFixture::Dense;
-    auto dense_id = Dense::create(this->exec, this->identity->get_size());
+    auto dense_id =
+        gko::share(Dense::create(this->exec, this->identity->get_size()));
     this->identity->convert_to(dense_id.get());
-    auto fact = this->fact_fact->generate(gko::share(dense_id));
+    auto fact = this->fact_fact->generate(dense_id);
 
     GKO_ASSERT_MTX_NEAR(fact->get_l_factor(), this->identity, this->tol);
     GKO_ASSERT_MTX_NEAR(fact->get_u_factor(), this->identity, this->tol);

--- a/reference/test/preconditioner/ic.cpp
+++ b/reference/test/preconditioner/ic.cpp
@@ -180,10 +180,9 @@ TYPED_TEST(Ic, CanBeCopied)
     auto before_lh_solver = ic->get_lh_solver();
     // The switch up of matrices is intentional, to make sure they are distinct!
     auto lh_l_composition =
-        Composition::create(this->lh_factor, this->l_factor);
-    auto copied = ic_prec_type::build()
-                      .on(this->exec)
-                      ->generate(gko::share(lh_l_composition));
+        gko::share(Composition::create(this->lh_factor, this->l_factor));
+    auto copied =
+        ic_prec_type::build().on(this->exec)->generate(lh_l_composition);
 
     copied->copy_from(ic.get());
 
@@ -202,10 +201,9 @@ TYPED_TEST(Ic, CanBeMoved)
     auto before_lh_solver = ic->get_lh_solver();
     // The switch up of matrices is intentional, to make sure they are distinct!
     auto lh_l_composition =
-        Composition::create(this->lh_factor, this->l_factor);
-    auto moved = ic_prec_type::build()
-                     .on(this->exec)
-                     ->generate(gko::share(lh_l_composition));
+        gko::share(Composition::create(this->lh_factor, this->l_factor));
+    auto moved =
+        ic_prec_type::build().on(this->exec)->generate(lh_l_composition);
 
     moved->copy_from(std::move(ic));
 

--- a/reference/test/preconditioner/ilu.cpp
+++ b/reference/test/preconditioner/ilu.cpp
@@ -200,10 +200,10 @@ TYPED_TEST(Ilu, CanBeCopied)
     auto before_l_solver = ilu->get_l_solver();
     auto before_u_solver = ilu->get_u_solver();
     // The switch up of matrices is intentional, to make sure they are distinct!
-    auto u_l_composition = Composition::create(this->u_factor, this->l_factor);
-    auto copied = ilu_prec_type::build()
-                      .on(this->exec)
-                      ->generate(gko::share(u_l_composition));
+    auto u_l_composition =
+        gko::share(Composition::create(this->u_factor, this->l_factor));
+    auto copied =
+        ilu_prec_type::build().on(this->exec)->generate(u_l_composition);
 
     copied->copy_from(ilu.get());
 
@@ -220,10 +220,10 @@ TYPED_TEST(Ilu, CanBeMoved)
     auto before_l_solver = ilu->get_l_solver();
     auto before_u_solver = ilu->get_u_solver();
     // The switch up of matrices is intentional, to make sure they are distinct!
-    auto u_l_composition = Composition::create(this->u_factor, this->l_factor);
-    auto moved = ilu_prec_type::build()
-                     .on(this->exec)
-                     ->generate(gko::share(u_l_composition));
+    auto u_l_composition =
+        gko::share(Composition::create(this->u_factor, this->l_factor));
+    auto moved =
+        ilu_prec_type::build().on(this->exec)->generate(u_l_composition);
 
     moved->copy_from(std::move(ilu));
 
@@ -316,9 +316,9 @@ TYPED_TEST(Ilu, SolvesSingleRhsWithParIlu)
     x->copy_from(b.get());
     auto par_ilu_fact =
         gko::factorization::ParIlu<value_type>::build().on(this->exec);
-    auto par_ilu = par_ilu_fact->generate(this->mtx);
+    auto par_ilu = gko::share(par_ilu_fact->generate(this->mtx));
 
-    auto preconditioner = this->ilu_pre_factory->generate(gko::share(par_ilu));
+    auto preconditioner = this->ilu_pre_factory->generate(par_ilu);
     preconditioner->apply(b.get(), x.get());
 
     GKO_ASSERT_MTX_NEAR(x.get(), l({-0.125, 0.25, 1.0}),

--- a/reference/test/preconditioner/jacobi_kernels.cpp
+++ b/reference/test/preconditioner/jacobi_kernels.cpp
@@ -1132,11 +1132,10 @@ TYPED_TEST(Jacobi, ConvertsToDenseWithAdaptivePrecision)
 TYPED_TEST(Jacobi, ConvertsEmptyToDense)
 {
     using Vec = typename TestFixture::Vec;
-    auto empty = Vec::create(this->exec);
+    auto empty = gko::share(Vec::create(this->exec));
     auto res = Vec::create(this->exec);
 
-    res->copy_from(
-        TestFixture::Bj::build().on(this->exec)->generate(gko::share(empty)));
+    res->copy_from(TestFixture::Bj::build().on(this->exec)->generate(empty));
 
     ASSERT_FALSE(res->get_size());
 }

--- a/reference/test/solver/ir_kernels.cpp
+++ b/reference/test/solver/ir_kernels.cpp
@@ -178,12 +178,12 @@ TYPED_TEST(Ir, SolvesTriangularSystemWithIterativeInnerSolver)
     using value_type = typename TestFixture::value_type;
 
     const gko::remove_complex<value_type> inner_reduction_factor = 1e-2;
-    auto inner_solver_factory =
+    auto inner_solver_factory = gko::share(
         gko::solver::Gmres<value_type>::build()
             .with_criteria(gko::stop::ResidualNorm<value_type>::build()
                                .with_reduction_factor(inner_reduction_factor)
                                .on(this->exec))
-            .on(this->exec);
+            .on(this->exec));
 
     auto solver_factory =
         gko::solver::Ir<value_type>::build()
@@ -192,7 +192,7 @@ TYPED_TEST(Ir, SolvesTriangularSystemWithIterativeInnerSolver)
                            gko::stop::ResidualNorm<value_type>::build()
                                .with_reduction_factor(r<value_type>::value)
                                .on(this->exec))
-            .with_solver(gko::share(inner_solver_factory))
+            .with_solver(inner_solver_factory)
             .on(this->exec);
     auto b = gko::initialize<Mtx>({3.9, 9.0, 2.2}, this->exec);
     auto x = gko::initialize<Mtx>({0.0, 0.0, 0.0}, this->exec);
@@ -378,12 +378,12 @@ TYPED_TEST(Ir, RichardsonSolvesTriangularSystemWithIterativeInnerSolver)
     using Mtx = typename TestFixture::Mtx;
     using value_type = typename TestFixture::value_type;
     const gko::remove_complex<value_type> inner_reduction_factor = 1e-2;
-    auto inner_solver_factory =
+    auto inner_solver_factory = gko::share(
         gko::solver::Gmres<value_type>::build()
             .with_criteria(gko::stop::ResidualNorm<value_type>::build()
                                .with_reduction_factor(inner_reduction_factor)
                                .on(this->exec))
-            .on(this->exec);
+            .on(this->exec));
     auto solver_factory =
         gko::solver::Ir<value_type>::build()
             .with_criteria(
@@ -393,7 +393,7 @@ TYPED_TEST(Ir, RichardsonSolvesTriangularSystemWithIterativeInnerSolver)
                     .with_reduction_factor(r<value_type>::value)
                     .on(this->exec))
             .with_relaxation_factor(value_type{0.9})
-            .with_solver(gko::share(inner_solver_factory))
+            .with_solver(inner_solver_factory)
             .on(this->exec);
     auto b = gko::initialize<Mtx>({3.9, 9.0, 2.2}, this->exec);
     auto x = gko::initialize<Mtx>({0.0, 0.0, 0.0}, this->exec);


### PR DESCRIPTION
Previously, `gko::share()` is allowed to act on regular references, which leads some users to incorrectly use `gko::share`.
By restricting it to rvalue references, it is harder to misuse this function while still allowing the same functionality with `gko::share(gko::give(val))` or `gko::share(std::move(val))` (both do the exact same thing).

Note: This does break the public interface as it is no longer possible to call `gko::share` with lvalues of any sort. However, I do consider it a bug that it was possible previously.
In its current form, writing errors accidentally is too easy, especially when examples are extended / modified.

If we don't adopt the `static_assert` for the xvalue check (rvalue reference for the caller), I would still suggest to have all other changes merged (especially the examples) in order to prevent new users or developers to reuse moved-from variables.