### PR TITLE
Distinguish between structural and numerical zeros in Ell/Sellp

### DIFF
--- a/common/cuda_hip/matrix/dense_kernels.hpp.inc
+++ b/common/cuda_hip/matrix/dense_kernels.hpp.inc
@@ -324,7 +324,7 @@ __global__ __launch_bounds__(default_block_size) void fill_in_ell(
              i < max_nnz_per_row; i += config::warp_size) {
             const auto out_idx = row + i * result_stride;
             values[out_idx] = zero<ValueType>();
-            col_idxs[out_idx] = 0;
+            col_idxs[out_idx] = invalid_index<IndexType>();
         }
     }
 }
@@ -375,7 +375,7 @@ __global__ __launch_bounds__(default_block_size) void fill_in_hybrid(
              i < ell_max_nnz_per_row; i += config::warp_size) {
             const auto out_idx = row + i * ell_stride;
             ell_values[out_idx] = zero<ValueType>();
-            ell_col_idxs[out_idx] = 0;
+            ell_col_idxs[out_idx] = invalid_index<IndexType>();
         }
     }
 }
@@ -416,7 +416,7 @@ __global__ __launch_bounds__(default_block_size) void fill_in_sellp(
         for (auto i = base_idx + lane * slice_size; i < slice_end;
              i += config::warp_size * slice_size) {
             values[i] = zero<ValueType>();
-            col_idxs[i] = 0;
+            col_idxs[i] = invalid_index<IndexType>();
         }
     }
 }

--- a/common/cuda_hip/matrix/ell_kernels.hpp.inc
+++ b/common/cuda_hip/matrix/ell_kernels.hpp.inc
@@ -53,7 +53,7 @@ __device__ void spmv_kernel(
             for (size_type idx = 0; idx < num_stored_elements_per_row; idx++) {
                 const auto ind = tidx + idx * stride;
                 const auto col_idx = col[ind];
-                if (col_idx < idx) {
+                if (col_idx == invalid_index<IndexType>()) {
                     break;
                 } else {
                     temp += val(ind) * b(col_idx, column_id);
@@ -81,7 +81,7 @@ __device__ void spmv_kernel(
                  idx < num_stored_elements_per_row; idx += step_size) {
                 const auto ind = x + idx * stride;
                 const auto col_idx = col[ind];
-                if (col_idx < idx) {
+                if (col_idx == invalid_index<IndexType>()) {
                     break;
                 } else {
                     temp += val(ind) * b(col_idx, column_id);

--- a/common/cuda_hip/matrix/sellp_kernels.hpp.inc
+++ b/common/cuda_hip/matrix/sellp_kernels.hpp.inc
@@ -36,7 +36,7 @@ __global__ __launch_bounds__(default_block_size) void spmv_kernel(
     size_type num_rows, size_type num_right_hand_sides, size_type b_stride,
     size_type c_stride, size_type slice_size,
     const size_type* __restrict__ slice_sets, const ValueType* __restrict__ a,
-    const IndexType* __restrict__ col, const ValueType* __restrict__ b,
+    const IndexType* __restrict__ cols, const ValueType* __restrict__ b,
     ValueType* __restrict__ c)
 {
     const auto row = thread::get_thread_id_flat();
@@ -47,7 +47,10 @@ __global__ __launch_bounds__(default_block_size) void spmv_kernel(
     if (row < num_rows && column_id < num_right_hand_sides) {
         for (auto i = slice_sets[slice_id]; i < slice_sets[slice_id + 1]; i++) {
             const auto ind = row_in_slice + i * slice_size;
-            val += a[ind] * b[col[ind] * b_stride + column_id];
+            const auto col = cols[ind];
+            if (col != invalid_index<IndexType>()) {
+                val += a[ind] * b[col * b_stride + column_id];
+            }
         }
         c[row * c_stride + column_id] = val;
     }
@@ -60,7 +63,7 @@ __global__ __launch_bounds__(default_block_size) void advanced_spmv_kernel(
     size_type c_stride, size_type slice_size,
     const size_type* __restrict__ slice_sets,
     const ValueType* __restrict__ alpha, const ValueType* __restrict__ a,
-    const IndexType* __restrict__ col, const ValueType* __restrict__ b,
+    const IndexType* __restrict__ cols, const ValueType* __restrict__ b,
     const ValueType* __restrict__ beta, ValueType* __restrict__ c)
 {
     const auto row = thread::get_thread_id_flat();
@@ -71,7 +74,10 @@ __global__ __launch_bounds__(default_block_size) void advanced_spmv_kernel(
     if (row < num_rows && column_id < num_right_hand_sides) {
         for (auto i = slice_sets[slice_id]; i < slice_sets[slice_id + 1]; i++) {
             const auto ind = row_in_slice + i * slice_size;
-            val += a[ind] * b[col[ind] * b_stride + column_id];
+            const auto col = cols[ind];
+            if (col != invalid_index<IndexType>()) {
+                val += a[ind] * b[col * b_stride + column_id];
+            }
         }
         c[row * c_stride + column_id] =
             beta[0] * c[row * c_stride + column_id] + alpha[0] * val;

--- a/common/unified/matrix/csr_kernels.cpp
+++ b/common/unified/matrix/csr_kernels.cpp
@@ -151,7 +151,8 @@ void convert_to_sellp(std::shared_ptr<const DefaultExecutor> exec,
             const auto slice_length = slice_end - slice_begin;
             auto out_idx = slice_begin * slice_size + local_row;
             for (auto i = row_begin; i < row_begin + slice_length; i++) {
-                cols[out_idx] = i < row_end ? in_cols[i] : 0;
+                cols[out_idx] =
+                    i < row_end ? in_cols[i] : invalid_index<IndexType>();
                 values[out_idx] = i < row_end ? unpack_member(in_values[i])
                                               : zero(values[out_idx]);
                 out_idx += slice_size;
@@ -181,7 +182,8 @@ void convert_to_ell(std::shared_ptr<const DefaultExecutor> exec,
             const auto row_end = row_ptrs[row + 1];
             auto out_idx = row;
             for (auto i = row_begin; i < row_begin + ell_length; i++) {
-                cols[out_idx] = i < row_end ? in_cols[i] : 0;
+                cols[out_idx] =
+                    i < row_end ? in_cols[i] : invalid_index<IndexType>();
                 values[out_idx] = i < row_end ? unpack_member(in_values[i])
                                               : zero(values[out_idx]);
                 out_idx += ell_stride;
@@ -215,7 +217,8 @@ void convert_to_hybrid(std::shared_ptr<const DefaultExecutor> exec,
                 const auto out_idx = row + ell_stride * i;
                 const auto in_idx = i + row_begin;
                 const bool use = i < row_size;
-                ell_cols[out_idx] = use ? cols[in_idx] : 0;
+                ell_cols[out_idx] =
+                    use ? cols[in_idx] : invalid_index<IndexType>();
                 ell_vals[out_idx] = use ? vals[in_idx] : zero(vals[in_idx]);
             }
             const auto coo_begin = coo_row_ptrs[row];

--- a/common/unified/matrix/ell_kernels.cpp
+++ b/common/unified/matrix/ell_kernels.cpp
@@ -84,7 +84,8 @@ void fill_in_matrix_data(std::shared_ptr<const DefaultExecutor> exec,
             const auto end = row_ptrs[row + 1];
             auto out_idx = row;
             for (auto i = begin; i < begin + num_cols; i++) {
-                cols[out_idx] = i < end ? in_cols[i] : 0;
+                cols[out_idx] =
+                    i < end ? in_cols[i] : invalid_index<IndexType>();
                 values[out_idx] = i < end ? in_vals[i] : zero(values[out_idx]);
                 out_idx += stride;
             }
@@ -104,20 +105,20 @@ void fill_in_dense(std::shared_ptr<const DefaultExecutor> exec,
                    const matrix::Ell<ValueType, IndexType>* source,
                    matrix::Dense<ValueType>* result)
 {
-    // TODO simplify once we can guarantee unique column indices outside padding
+    // ELL is stored in column-major, so we swap row and column parameters
     run_kernel(
         exec,
-        [] GKO_KERNEL(auto row, auto cols, auto ell_cols, auto ell_stride,
-                      auto in_cols, auto in_vals, auto out) {
-            for (int64 ell_col = 0; ell_col < ell_cols; ell_col++) {
-                const auto ell_idx = ell_col * ell_stride + row;
-                const auto col = in_cols[ell_idx];
-                const auto val = in_vals[ell_idx];
-                out(row, col) += val;
+        [] GKO_KERNEL(auto ell_col, auto row, auto ell_stride, auto in_cols,
+                      auto in_vals, auto out) {
+            const auto ell_idx = ell_col * ell_stride + row;
+            const auto col = in_cols[ell_idx];
+            const auto val = in_vals[ell_idx];
+            if (col != invalid_index<IndexType>()) {
+                out(row, col) = val;
             }
         },
-        source->get_size()[0], source->get_size()[1],
-        source->get_num_stored_elements_per_row(),
+        dim<2>{source->get_num_stored_elements_per_row(),
+               source->get_size()[0]},
         static_cast<int64>(source->get_stride()), source->get_const_col_idxs(),
         source->get_const_values(), result);
 }
@@ -190,14 +191,14 @@ void count_nonzeros_per_row(std::shared_ptr<const DefaultExecutor> exec,
     // ELL is stored in column-major, so we swap row and column parameters
     run_kernel_col_reduction(
         exec,
-        [] GKO_KERNEL(auto ell_col, auto row, auto ell_stride, auto in_vals) {
+        [] GKO_KERNEL(auto ell_col, auto row, auto ell_stride, auto in_cols) {
             const auto ell_idx = ell_col * ell_stride + row;
-            return is_nonzero(in_vals[ell_idx]) ? 1 : 0;
+            return in_cols[ell_idx] != invalid_index<IndexType>() ? 1 : 0;
         },
         GKO_KERNEL_REDUCE_SUM(IndexType), result,
         dim<2>{source->get_num_stored_elements_per_row(),
                source->get_size()[0]},
-        static_cast<int64>(source->get_stride()), source->get_const_values());
+        static_cast<int64>(source->get_stride()), source->get_const_col_idxs());
 }
 
 GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
@@ -217,7 +218,7 @@ void extract_diagonal(std::shared_ptr<const DefaultExecutor> exec,
             const auto ell_idx = ell_col * ell_stride + row;
             const auto col = in_cols[ell_idx];
             const auto val = in_vals[ell_idx];
-            if (row == col && is_nonzero(val)) {
+            if (row == col) {
                 out_vals[row] = val;
             }
         },

--- a/common/unified/matrix/hybrid_kernels.cpp
+++ b/common/unified/matrix/hybrid_kernels.cpp
@@ -94,7 +94,8 @@ void fill_in_matrix_data(std::shared_ptr<const DefaultExecutor> exec,
                 const auto out_idx = row + ell_stride * i;
                 const auto in_idx = i + row_begin;
                 const bool use = i < row_size;
-                ell_cols[out_idx] = use ? cols[in_idx] : 0;
+                ell_cols[out_idx] =
+                    use ? cols[in_idx] : invalid_index<IndexType>();
                 ell_vals[out_idx] =
                     use ? vals[in_idx] : zero<device_value_type>();
             }

--- a/common/unified/matrix/sellp_kernels.cpp
+++ b/common/unified/matrix/sellp_kernels.cpp
@@ -104,7 +104,8 @@ void fill_in_matrix_data(std::shared_ptr<const DefaultExecutor> exec,
             const auto slice_length = slice_end - slice_begin;
             auto out_idx = slice_begin * slice_size + local_row;
             for (auto i = row_begin; i < row_begin + slice_length; i++) {
-                cols[out_idx] = i < row_end ? in_cols[i] : 0;
+                cols[out_idx] =
+                    i < row_end ? in_cols[i] : invalid_index<IndexType>();
                 values[out_idx] =
                     i < row_end ? in_vals[i] : zero(values[out_idx]);
                 out_idx += slice_size;
@@ -136,7 +137,10 @@ void fill_in_dense(std::shared_ptr<const DefaultExecutor> exec,
             const auto slice_length = slice_end - slice_begin;
             auto in_idx = slice_begin * slice_size + local_row;
             for (int64 i = 0; i < slice_length; i++) {
-                result(row, cols[in_idx]) += values[in_idx];
+                const auto col = cols[in_idx];
+                if (col != invalid_index<IndexType>()) {
+                    result(row, cols[in_idx]) = values[in_idx];
+                }
                 in_idx += slice_size;
             }
         },
@@ -156,7 +160,7 @@ void count_nonzeros_per_row(std::shared_ptr<const DefaultExecutor> exec,
 {
     run_kernel(
         exec,
-        [] GKO_KERNEL(auto row, auto slice_size, auto slice_sets, auto values,
+        [] GKO_KERNEL(auto row, auto slice_size, auto slice_sets, auto cols,
                       auto result) {
             const auto slice = row / slice_size;
             const auto local_row = row % slice_size;
@@ -166,13 +170,13 @@ void count_nonzeros_per_row(std::shared_ptr<const DefaultExecutor> exec,
             auto in_idx = slice_begin * slice_size + local_row;
             IndexType row_nnz{};
             for (int64 i = 0; i < slice_length; i++) {
-                row_nnz += is_nonzero(values[in_idx]);
+                row_nnz += cols[in_idx] != invalid_index<IndexType>() ? 1 : 0;
                 in_idx += slice_size;
             }
             result[row] = row_nnz;
         },
         source->get_size()[0], source->get_slice_size(),
-        source->get_const_slice_sets(), source->get_const_values(), result);
+        source->get_const_slice_sets(), source->get_const_col_idxs(), result);
 }
 
 GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(

--- a/core/matrix/ell.cpp
+++ b/core/matrix/ell.cpp
@@ -306,8 +306,8 @@ void Ell<ValueType, IndexType>::write(mat_data& data) const
     for (size_type row = 0; row < tmp->get_size()[0]; ++row) {
         for (size_type i = 0; i < tmp->num_stored_elements_per_row_; ++i) {
             const auto val = tmp->val_at(row, i);
-            if (is_nonzero(val)) {
-                const auto col = tmp->col_at(row, i);
+            const auto col = tmp->col_at(row, i);
+            if (col != invalid_index<IndexType>()) {
                 data.nonzeros.emplace_back(row, col, val);
             }
         }

--- a/core/matrix/hybrid.cpp
+++ b/core/matrix/hybrid.cpp
@@ -315,8 +315,8 @@ void Hybrid<ValueType, IndexType>::write(mat_data& data) const
         for (size_type i = 0; i < tmp->get_ell_num_stored_elements_per_row();
              ++i) {
             const auto val = tmp->ell_val_at(row, i);
-            if (is_nonzero(val)) {
-                const auto col = tmp->ell_col_at(row, i);
+            const auto col = tmp->ell_col_at(row, i);
+            if (col != invalid_index<IndexType>()) {
                 data.nonzeros.emplace_back(row, col, val);
             }
         }

--- a/core/matrix/sellp.cpp
+++ b/core/matrix/sellp.cpp
@@ -281,14 +281,12 @@ void Sellp<ValueType, IndexType>::write(mat_data& data) const
              row_in_slice++) {
             auto row = slice * slice_size + row_in_slice;
             if (row < tmp->get_size()[0]) {
-                for (size_type i = 0; i < tmp->get_const_slice_lengths()[slice];
-                     i++) {
-                    const auto val = tmp->val_at(
-                        row_in_slice, tmp->get_const_slice_sets()[slice], i);
-                    if (is_nonzero(val)) {
-                        const auto col =
-                            tmp->col_at(row_in_slice,
-                                        tmp->get_const_slice_sets()[slice], i);
+                const auto slice_len = tmp->get_const_slice_lengths()[slice];
+                const auto slice_offset = tmp->get_const_slice_sets()[slice];
+                for (size_type i = 0; i < slice_len; i++) {
+                    const auto col = tmp->col_at(row_in_slice, slice_offset, i);
+                    const auto val = tmp->val_at(row_in_slice, slice_offset, i);
+                    if (col != invalid_index<IndexType>()) {
                         data.nonzeros.emplace_back(row, col, val);
                     }
                 }

--- a/core/test/matrix/ell.cpp
+++ b/core/test/matrix/ell.cpp
@@ -39,9 +39,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "core/test/utils.hpp"
 
 
-namespace {
-
-
 template <typename ValueIndexType>
 class Ell : public ::testing::Test {
 protected:
@@ -51,6 +48,8 @@ protected:
         typename std::tuple_element<1, decltype(ValueIndexType())>::type;
     using Mtx = gko::matrix::Ell<value_type, index_type>;
 
+    index_type invalid_index = gko::invalid_index<index_type>();
+
     Ell()
         : exec(gko::ReferenceExecutor::create()),
           mtx(gko::matrix::Ell<value_type, index_type>::create(
@@ -59,15 +58,15 @@ protected:
         value_type* v = mtx->get_values();
         index_type* c = mtx->get_col_idxs();
         c[0] = 0;
-        c[1] = 1;
+        c[1] = 0;
         c[2] = 1;
-        c[3] = 0;
+        c[3] = 1;
         c[4] = 2;
-        c[5] = 0;
+        c[5] = invalid_index;
         v[0] = 1.0;
-        v[1] = 5.0;
+        v[1] = 0.0;
         v[2] = 3.0;
-        v[3] = 0.0;
+        v[3] = 5.0;
         v[4] = 2.0;
         v[5] = 0.0;
     }
@@ -86,15 +85,15 @@ protected:
         EXPECT_EQ(n, 3);
         EXPECT_EQ(p, 2);
         EXPECT_EQ(c[0], 0);
-        EXPECT_EQ(c[1], 1);
+        EXPECT_EQ(c[1], 0);
         EXPECT_EQ(c[2], 1);
-        EXPECT_EQ(c[3], 0);
+        EXPECT_EQ(c[3], 1);
         EXPECT_EQ(c[4], 2);
-        EXPECT_EQ(c[5], 0);
+        EXPECT_EQ(c[5], invalid_index);
         EXPECT_EQ(v[0], value_type{1.0});
-        EXPECT_EQ(v[1], value_type{5.0});
+        EXPECT_EQ(v[1], value_type{0.0});
         EXPECT_EQ(v[2], value_type{3.0});
-        EXPECT_EQ(v[3], value_type{0.0});
+        EXPECT_EQ(v[3], value_type{5.0});
         EXPECT_EQ(v[4], value_type{2.0});
         EXPECT_EQ(v[5], value_type{0.0});
     }
@@ -218,7 +217,9 @@ TYPED_TEST(Ell, CanBeReadFromMatrixData)
 {
     using Mtx = typename TestFixture::Mtx;
     auto m = Mtx::create(this->exec);
-    m->read({{2, 3}, {{0, 0, 1.0}, {0, 1, 3.0}, {0, 2, 2.0}, {1, 1, 5.0}}});
+    m->read(
+        {{2, 3},
+         {{0, 0, 1.0}, {0, 1, 3.0}, {0, 2, 2.0}, {1, 0, 0.0}, {1, 1, 5.0}}});
 
     this->assert_equal_to_original_mtx(m.get());
 }
@@ -234,11 +235,12 @@ TYPED_TEST(Ell, GeneratesCorrectMatrixData)
     this->mtx->write(data);
 
     ASSERT_EQ(data.size, gko::dim<2>(2, 3));
-    ASSERT_EQ(data.nonzeros.size(), 4);
+    ASSERT_EQ(data.nonzeros.size(), 5);
     EXPECT_EQ(data.nonzeros[0], tpl(0, 0, value_type{1.0}));
     EXPECT_EQ(data.nonzeros[1], tpl(0, 1, value_type{3.0}));
     EXPECT_EQ(data.nonzeros[2], tpl(0, 2, value_type{2.0}));
-    EXPECT_EQ(data.nonzeros[3], tpl(1, 1, value_type{5.0}));
+    EXPECT_EQ(data.nonzeros[3], tpl(1, 0, value_type{0.0}));
+    EXPECT_EQ(data.nonzeros[4], tpl(1, 1, value_type{5.0}));
 }
 
 
@@ -252,12 +254,10 @@ TYPED_TEST(Ell, CanBeReadFromMatrixAssemblyData)
     data.set_value(0, 0, 1.0);
     data.set_value(0, 1, 3.0);
     data.set_value(0, 2, 2.0);
+    data.set_value(1, 0, 0.0);
     data.set_value(1, 1, 5.0);
 
     m->read(data);
 
     this->assert_equal_to_original_mtx(m.get());
 }
-
-
-}  // namespace

--- a/dpcpp/matrix/dense_kernels.dp.cpp
+++ b/dpcpp/matrix/dense_kernels.dp.cpp
@@ -371,7 +371,7 @@ void convert_to_ell(std::shared_ptr<const DefaultExecutor> exec,
                 }
             }
             for (; col_idx < max_nnz_per_row; col_idx++) {
-                cols[col_idx * stride + row] = 0;
+                cols[col_idx * stride + row] = invalid_index<IndexType>();
                 vals[col_idx * stride + row] = zero<ValueType>();
             }
         });
@@ -437,7 +437,7 @@ void convert_to_hybrid(std::shared_ptr<const DefaultExecutor> exec,
             }
             for (; ell_count < ell_lim; ell_count++) {
                 ell_vals[ell_idx] = zero<ValueType>();
-                ell_cols[ell_idx] = 0;
+                ell_cols[ell_idx] = invalid_index<IndexType>();
                 ell_idx += ell_stride;
             }
             auto coo_idx = coo_row_ptrs[row];
@@ -490,7 +490,7 @@ void convert_to_sellp(std::shared_ptr<const DefaultExecutor> exec,
                 }
             }
             for (; out_idx < slice_end; out_idx += slice_size) {
-                col_idxs[out_idx] = 0;
+                col_idxs[out_idx] = invalid_index<IndexType>();
                 vals[out_idx] = zero<ValueType>();
             }
         });

--- a/dpcpp/matrix/ell_kernels.dp.cpp
+++ b/dpcpp/matrix/ell_kernels.dp.cpp
@@ -133,7 +133,7 @@ void spmv_kernel(
             for (size_type idx = 0; idx < num_stored_elements_per_row; idx++) {
                 const auto ind = tidx + idx * stride;
                 const auto col_idx = col[ind];
-                if (col_idx < idx) {
+                if (col_idx == invalid_index<IndexType>()) {
                     break;
                 } else {
                     temp += val(ind) * b(col_idx, column_id);
@@ -161,7 +161,7 @@ void spmv_kernel(
                  idx < num_stored_elements_per_row; idx += step_size) {
                 const auto ind = x + idx * stride;
                 const auto col_idx = col[ind];
-                if (col_idx < idx) {
+                if (col_idx == invalid_index<IndexType>()) {
                     break;
                 } else {
                     temp += val(ind) * b(col_idx, column_id);

--- a/include/ginkgo/core/matrix/ell.hpp
+++ b/include/ginkgo/core/matrix/ell.hpp
@@ -66,6 +66,9 @@ class Hybrid;
  * fashion. The columns are padded to the length by user-defined stride
  * parameter whose default value is the number of rows of the matrix.
  *
+ * This implementation uses the column index value invalid_index<IndexType>()
+ * to mark padding entries that are not part of the sparsity pattern.
+ *
  * @tparam ValueType  precision of matrix elements
  * @tparam IndexType  precision of matrix indexes
  *

--- a/include/ginkgo/core/matrix/sellp.hpp
+++ b/include/ginkgo/core/matrix/sellp.hpp
@@ -57,6 +57,9 @@ class Csr;
  * SELL-P format divides rows into smaller slices and store each slice with ELL
  * format.
  *
+ * This implementation uses the column index value invalid_index<IndexType>()
+ * to mark padding entries that are not part of the sparsity pattern.
+ *
  * @tparam ValueType  precision of matrix elements
  * @tparam IndexType  precision of matrix indexes
  *

--- a/omp/matrix/dense_kernels.cpp
+++ b/omp/matrix/dense_kernels.cpp
@@ -247,7 +247,7 @@ void convert_to_ell(std::shared_ptr<const DefaultExecutor> exec,
     for (size_type i = 0; i < max_nnz_per_row; i++) {
         for (size_type j = 0; j < result->get_stride(); j++) {
             result->val_at(j, i) = zero<ValueType>();
-            result->col_at(j, i) = 0;
+            result->col_at(j, i) = invalid_index<IndexType>();
         }
     }
 #pragma omp parallel for
@@ -343,7 +343,7 @@ void convert_to_hybrid(std::shared_ptr<const DefaultExecutor> exec,
         }
         for (; ell_count < ell_lim; ell_count++) {
             result->ell_val_at(row, ell_count) = zero<ValueType>();
-            result->ell_col_at(row, ell_count) = 0;
+            result->ell_col_at(row, ell_count) = invalid_index<IndexType>();
         }
         auto coo_idx = coo_row_ptrs[row];
         for (; col < num_cols; col++) {
@@ -393,7 +393,7 @@ void convert_to_sellp(std::shared_ptr<const DefaultExecutor> exec,
                 }
             }
             for (; sellp_idx < sellp_end; sellp_idx += slice_size) {
-                col_idxs[sellp_idx] = 0;
+                col_idxs[sellp_idx] = invalid_index<IndexType>();
                 vals[sellp_idx] = zero<ValueType>();
             }
         }

--- a/omp/matrix/ell_kernels.cpp
+++ b/omp/matrix/ell_kernels.cpp
@@ -97,9 +97,11 @@ void spmv_small_rhs(std::shared_ptr<const OmpExecutor> exec,
         for (size_type i = 0; i < num_stored_elements_per_row; i++) {
             auto val = a_vals(row + i * stride);
             auto col = a->col_at(row, i);
+            if (col != invalid_index<IndexType>()) {
 #pragma unroll
-            for (size_type j = 0; j < num_rhs; j++) {
-                partial_sum[j] += val * b_vals(col, j);
+                for (size_type j = 0; j < num_rhs; j++) {
+                    partial_sum[j] += val * b_vals(col, j);
+                }
             }
         }
 #pragma unroll
@@ -152,9 +154,11 @@ void spmv_blocked(std::shared_ptr<const OmpExecutor> exec,
             for (size_type i = 0; i < num_stored_elements_per_row; i++) {
                 auto val = a_vals(row + i * stride);
                 auto col = a->col_at(row, i);
+                if (col != invalid_index<IndexType>()) {
 #pragma unroll
-                for (size_type j = 0; j < block_size; j++) {
-                    partial_sum[j] += val * b_vals(col, j + rhs_base);
+                    for (size_type j = 0; j < block_size; j++) {
+                        partial_sum[j] += val * b_vals(col, j + rhs_base);
+                    }
                 }
             }
 #pragma unroll
@@ -167,8 +171,10 @@ void spmv_blocked(std::shared_ptr<const OmpExecutor> exec,
         for (size_type i = 0; i < num_stored_elements_per_row; i++) {
             auto val = a_vals(row + i * stride);
             auto col = a->col_at(row, i);
-            for (size_type j = rounded_rhs; j < num_rhs; j++) {
-                partial_sum[j - rounded_rhs] += val * b_vals(col, j);
+            if (col != invalid_index<IndexType>()) {
+                for (size_type j = rounded_rhs; j < num_rhs; j++) {
+                    partial_sum[j - rounded_rhs] += val * b_vals(col, j);
+                }
             }
         }
         for (size_type j = rounded_rhs; j < num_rhs; j++) {

--- a/omp/matrix/sellp_kernels.cpp
+++ b/omp/matrix/sellp_kernels.cpp
@@ -74,9 +74,11 @@ void spmv_small_rhs(std::shared_ptr<const OmpExecutor> exec,
                 for (size_type i = 0; i < slice_lengths[slice]; i++) {
                     auto val = a->val_at(row, slice_sets[slice], i);
                     auto col = a->col_at(row, slice_sets[slice], i);
+                    if (col != invalid_index<IndexType>()) {
 #pragma unroll
-                    for (size_type j = 0; j < num_rhs; j++) {
-                        partial_sum[j] += val * b->at(col, j);
+                        for (size_type j = 0; j < num_rhs; j++) {
+                            partial_sum[j] += val * b->at(col, j);
+                        }
                     }
                 }
 #pragma unroll
@@ -117,9 +119,12 @@ void spmv_blocked(std::shared_ptr<const OmpExecutor> exec,
                     for (size_type i = 0; i < slice_lengths[slice]; i++) {
                         auto val = a->val_at(row, slice_sets[slice], i);
                         auto col = a->col_at(row, slice_sets[slice], i);
+                        if (col != invalid_index<IndexType>()) {
 #pragma unroll
-                        for (size_type j = 0; j < block_size; j++) {
-                            partial_sum[j] += val * b->at(col, j + rhs_base);
+                            for (size_type j = 0; j < block_size; j++) {
+                                partial_sum[j] +=
+                                    val * b->at(col, j + rhs_base);
+                            }
                         }
                     }
 #pragma unroll
@@ -134,8 +139,10 @@ void spmv_blocked(std::shared_ptr<const OmpExecutor> exec,
                 for (size_type i = 0; i < slice_lengths[slice]; i++) {
                     auto val = a->val_at(row, slice_sets[slice], i);
                     auto col = a->col_at(row, slice_sets[slice], i);
-                    for (size_type j = rounded_rhs; j < num_rhs; j++) {
-                        partial_sum[j - rounded_rhs] += val * b->at(col, j);
+                    if (col != invalid_index<IndexType>()) {
+                        for (size_type j = rounded_rhs; j < num_rhs; j++) {
+                            partial_sum[j - rounded_rhs] += val * b->at(col, j);
+                        }
                     }
                 }
                 for (size_type j = rounded_rhs; j < num_rhs; j++) {

--- a/reference/matrix/csr_kernels.cpp
+++ b/reference/matrix/csr_kernels.cpp
@@ -418,7 +418,7 @@ void convert_to_sellp(std::shared_ptr<const ReferenceExecutor> exec,
                  i <
                  (slice_sets[slice] + slice_lengths[slice]) * slice_size + row;
                  i += slice_size) {
-                col_idxs[i] = 0;
+                col_idxs[i] = invalid_index<IndexType>();
                 vals[i] = zero<ValueType>();
             }
         }
@@ -446,7 +446,7 @@ void convert_to_ell(std::shared_ptr<const ReferenceExecutor> exec,
     for (size_type row = 0; row < num_rows; row++) {
         for (size_type i = 0; i < num_stored_elements_per_row; i++) {
             result->val_at(row, i) = zero<ValueType>();
-            result->col_at(row, i) = 0;
+            result->col_at(row, i) = invalid_index<IndexType>();
         }
         for (size_type col_idx = 0; col_idx < row_ptrs[row + 1] - row_ptrs[row];
              col_idx++) {
@@ -783,13 +783,8 @@ void convert_to_hybrid(std::shared_ptr<const ReferenceExecutor> exec,
          i++) {
         for (size_type j = 0; j < result->get_ell_stride(); j++) {
             result->ell_val_at(j, i) = zero<ValueType>();
-            result->ell_col_at(j, i) = 0;
+            result->ell_col_at(j, i) = invalid_index<IndexType>();
         }
-    }
-    for (size_type i = 0; i < result->get_coo_num_stored_elements(); i++) {
-        coo_val[i] = zero<ValueType>();
-        coo_col[i] = 0;
-        coo_row[i] = 0;
     }
 
     const auto csr_row_ptrs = source->get_const_row_ptrs();

--- a/reference/matrix/dense_kernels.cpp
+++ b/reference/matrix/dense_kernels.cpp
@@ -486,7 +486,7 @@ void convert_to_ell(std::shared_ptr<const ReferenceExecutor> exec,
     for (size_type i = 0; i < max_nnz_per_row; i++) {
         for (size_type j = 0; j < result->get_stride(); j++) {
             result->val_at(j, i) = zero<ValueType>();
-            result->col_at(j, i) = 0;
+            result->col_at(j, i) = invalid_index<IndexType>();
         }
     }
     size_type col_idx = 0;
@@ -571,28 +571,23 @@ void convert_to_hybrid(std::shared_ptr<const ReferenceExecutor> exec,
          i++) {
         for (size_type j = 0; j < result->get_ell_stride(); j++) {
             result->ell_val_at(j, i) = zero<ValueType>();
-            result->ell_col_at(j, i) = 0;
+            result->ell_col_at(j, i) = invalid_index<IndexType>();
         }
-    }
-    for (size_type i = 0; i < result->get_coo_num_stored_elements(); i++) {
-        coo_val[i] = zero<ValueType>();
-        coo_col[i] = 0;
-        coo_row[i] = 0;
     }
 
     size_type coo_idx = 0;
     for (size_type row = 0; row < num_rows; row++) {
-        size_type col_idx = 0, col = 0;
-        while (col < num_cols && col_idx < ell_lim) {
+        size_type col = 0;
+        for (size_type col_idx = 0; col < num_cols && col_idx < ell_lim;
+             col++) {
             auto val = source->at(row, col);
             if (is_nonzero(val)) {
                 result->ell_val_at(row, col_idx) = val;
                 result->ell_col_at(row, col_idx) = col;
                 col_idx++;
             }
-            col++;
         }
-        while (col < num_cols) {
+        for (; col < num_cols; col++) {
             auto val = source->at(row, col);
             if (is_nonzero(val)) {
                 coo_val[coo_idx] = val;
@@ -600,7 +595,6 @@ void convert_to_hybrid(std::shared_ptr<const ReferenceExecutor> exec,
                 coo_row[coo_idx] = row;
                 coo_idx++;
             }
-            col++;
         }
     }
 }
@@ -635,7 +629,7 @@ void convert_to_sellp(std::shared_ptr<const ReferenceExecutor> exec,
             }
         }
         for (; sellp_ind < sellp_end; sellp_ind += slice_size) {
-            col_idxs[sellp_ind] = 0;
+            col_idxs[sellp_ind] = invalid_index<IndexType>();
             vals[sellp_ind] = zero<ValueType>();
         }
     }

--- a/reference/matrix/ell_kernels.cpp
+++ b/reference/matrix/ell_kernels.cpp
@@ -89,7 +89,9 @@ void spmv(std::shared_ptr<const ReferenceExecutor> exec,
             for (size_type i = 0; i < num_stored_elements_per_row; i++) {
                 auto val = a_vals(row + i * stride);
                 auto col = a->col_at(row, i);
-                result += val * b_vals(col, j);
+                if (col != invalid_index<IndexType>()) {
+                    result += val * b_vals(col, j);
+                }
             }
             c->at(row, j) = result;
         }
@@ -140,7 +142,9 @@ void advanced_spmv(std::shared_ptr<const ReferenceExecutor> exec,
             for (size_type i = 0; i < num_stored_elements_per_row; i++) {
                 auto val = a_vals(row + i * stride);
                 auto col = a->col_at(row, i);
-                result += alpha_val * val * b_vals(col, j);
+                if (col != invalid_index<IndexType>()) {
+                    result += alpha_val * val * b_vals(col, j);
+                }
             }
             c->at(row, j) = result;
         }
@@ -181,7 +185,7 @@ void fill_in_matrix_data(std::shared_ptr<const DefaultExecutor> exec,
             col_idx++;
         }
         for (; col_idx < output->get_num_stored_elements_per_row(); col_idx++) {
-            output->col_at(row, col_idx) = 0;
+            output->col_at(row, col_idx) = invalid_index<IndexType>();
             output->val_at(row, col_idx) = zero<ValueType>();
         }
     }
@@ -203,7 +207,10 @@ void fill_in_dense(std::shared_ptr<const ReferenceExecutor> exec,
 
     for (size_type row = 0; row < num_rows; row++) {
         for (size_type i = 0; i < num_stored_elements_per_row; i++) {
-            result->at(row, source->col_at(row, i)) += source->val_at(row, i);
+            const auto col = source->col_at(row, i);
+            if (col != invalid_index<IndexType>()) {
+                result->at(row, col) = source->val_at(row, i);
+            }
         }
     }
 }
@@ -247,7 +254,7 @@ void convert_to_csr(std::shared_ptr<const ReferenceExecutor> exec,
         for (size_type i = 0; i < max_nnz_per_row; i++) {
             const auto val = source->val_at(row, i);
             const auto col = source->col_at(row, i);
-            if (is_nonzero(val)) {
+            if (col != invalid_index<IndexType>()) {
                 values[cur_ptr] = val;
                 col_idxs[cur_ptr] = col;
                 cur_ptr++;
@@ -273,7 +280,9 @@ void count_nonzeros_per_row(std::shared_ptr<const ReferenceExecutor> exec,
     for (size_type row = 0; row < num_rows; row++) {
         size_type nonzeros_in_this_row = 0;
         for (size_type i = 0; i < max_nnz_per_row; i++) {
-            nonzeros_in_this_row += is_nonzero(source->val_at(row, i));
+            if (source->col_at(row, i) != invalid_index<IndexType>()) {
+                nonzeros_in_this_row++;
+            }
         }
         result[row] = nonzeros_in_this_row;
     }

--- a/reference/matrix/hybrid_kernels.cpp
+++ b/reference/matrix/hybrid_kernels.cpp
@@ -109,7 +109,7 @@ void fill_in_matrix_data(std::shared_ptr<const DefaultExecutor> exec,
             }
         }
         for (; ell_nz < ell_max_nnz; ell_nz++) {
-            result->ell_col_at(row, ell_nz) = 0;
+            result->ell_col_at(row, ell_nz) = invalid_index<IndexType>();
             result->ell_val_at(row, ell_nz) = zero<ValueType>();
         }
     }
@@ -139,11 +139,12 @@ void convert_to_csr(std::shared_ptr<const ReferenceExecutor> exec,
     size_type coo_idx = 0;
     for (IndexType row = 0; row < source->get_size()[0]; row++) {
         // Ell part
-        for (IndexType col = 0; col < max_nnz_per_row; col++) {
-            const auto val = ell->val_at(row, col);
-            if (is_nonzero(val)) {
+        for (IndexType i = 0; i < max_nnz_per_row; i++) {
+            const auto val = ell->val_at(row, i);
+            const auto col = ell->col_at(row, i);
+            if (col != invalid_index<IndexType>()) {
                 csr_val[csr_idx] = val;
-                csr_col_idxs[csr_idx] = ell->col_at(row, col);
+                csr_col_idxs[csr_idx] = col;
                 csr_idx++;
             }
         }

--- a/reference/matrix/sellp_kernels.cpp
+++ b/reference/matrix/sellp_kernels.cpp
@@ -221,7 +221,7 @@ void fill_in_dense(std::shared_ptr<const ReferenceExecutor> exec,
                  i++) {
                 const auto col = col_idxs[row + i * slice_size];
                 if (col != invalid_index<IndexType>()) {
-                    result->at(global_row, col) += vals[row + i * slice_size];
+                    result->at(global_row, col) = vals[row + i * slice_size];
                 }
             }
         }

--- a/reference/matrix/sellp_kernels.cpp
+++ b/reference/matrix/sellp_kernels.cpp
@@ -75,8 +75,10 @@ void spmv(std::shared_ptr<const ReferenceExecutor> exec,
             for (size_type i = 0; i < slice_lengths[slice]; i++) {
                 auto val = a->val_at(row, slice_sets[slice], i);
                 auto col = a->col_at(row, slice_sets[slice], i);
-                for (size_type j = 0; j < c->get_size()[1]; j++) {
-                    c->at(global_row, j) += val * b->at(col, j);
+                if (col != invalid_index<IndexType>()) {
+                    for (size_type j = 0; j < c->get_size()[1]; j++) {
+                        c->at(global_row, j) += val * b->at(col, j);
+                    }
                 }
             }
         }
@@ -114,8 +116,10 @@ void advanced_spmv(std::shared_ptr<const ReferenceExecutor> exec,
             for (size_type i = 0; i < slice_lengths[slice]; i++) {
                 auto val = a->val_at(row, slice_sets[slice], i);
                 auto col = a->col_at(row, slice_sets[slice], i);
-                for (size_type j = 0; j < c->get_size()[1]; j++) {
-                    c->at(global_row, j) += valpha * val * b->at(col, j);
+                if (col != invalid_index<IndexType>()) {
+                    for (size_type j = 0; j < c->get_size()[1]; j++) {
+                        c->at(global_row, j) += valpha * val * b->at(col, j);
+                    }
                 }
             }
         }
@@ -182,7 +186,7 @@ void fill_in_matrix_data(std::shared_ptr<const DefaultExecutor> exec,
             out_idx += slice_size;
         }
         for (auto i = row_nnz; i < slice_length; i++) {
-            cols[out_idx] = 0;
+            cols[out_idx] = invalid_index<IndexType>();
             vals[out_idx] = zero<ValueType>();
             out_idx += slice_size;
         }
@@ -215,8 +219,10 @@ void fill_in_dense(std::shared_ptr<const ReferenceExecutor> exec,
             }
             for (size_type i = slice_sets[slice]; i < slice_sets[slice + 1];
                  i++) {
-                result->at(global_row, col_idxs[row + i * slice_size]) +=
-                    vals[row + i * slice_size];
+                const auto col = col_idxs[row + i * slice_size];
+                if (col != invalid_index<IndexType>()) {
+                    result->at(global_row, col) += vals[row + i * slice_size];
+                }
             }
         }
     }
@@ -235,10 +241,10 @@ void count_nonzeros_per_row(std::shared_ptr<const DefaultExecutor> exec,
     auto slice_size = source->get_slice_size();
     auto slice_num = ceildiv(num_rows, slice_size);
 
-    const auto source_vals = source->get_const_values();
-    const auto source_slice_lengths = source->get_const_slice_lengths();
-    const auto source_slice_sets = source->get_const_slice_sets();
-    const auto source_col_idxs = source->get_const_col_idxs();
+    const auto vals = source->get_const_values();
+    const auto slice_lengths = source->get_const_slice_lengths();
+    const auto slice_sets = source->get_const_slice_sets();
+    const auto col_idxs = source->get_const_col_idxs();
 
     for (size_type slice = 0; slice < slice_num; slice++) {
         for (size_type row = 0; row < slice_size; row++) {
@@ -247,11 +253,11 @@ void count_nonzeros_per_row(std::shared_ptr<const DefaultExecutor> exec,
                 break;
             }
             IndexType row_nnz{};
-            for (size_type sellp_ind =
-                     source_slice_sets[slice] * slice_size + row;
-                 sellp_ind < source_slice_sets[slice + 1] * slice_size + row;
+            for (size_type sellp_ind = slice_sets[slice] * slice_size + row;
+                 sellp_ind < slice_sets[slice + 1] * slice_size + row;
                  sellp_ind += slice_size) {
-                row_nnz += is_nonzero(source_vals[sellp_ind]);
+                row_nnz +=
+                    col_idxs[sellp_ind] != invalid_index<IndexType>() ? 1 : 0;
             }
             result[global_row] = row_nnz;
         }
@@ -293,7 +299,7 @@ void convert_to_csr(std::shared_ptr<const ReferenceExecutor> exec,
                      source_slice_sets[slice] * slice_size + row;
                  sellp_ind < source_slice_sets[slice + 1] * slice_size + row;
                  sellp_ind += slice_size) {
-                if (is_nonzero(source_vals[sellp_ind])) {
+                if (source_col_idxs[sellp_ind] != invalid_index<IndexType>()) {
                     result_vals[cur_ptr] = source_vals[sellp_ind];
                     result_col_idxs[cur_ptr] = source_col_idxs[sellp_ind];
                     cur_ptr++;

--- a/reference/test/matrix/csr_kernels.cpp
+++ b/reference/test/matrix/csr_kernels.cpp
@@ -238,9 +238,9 @@ protected:
         EXPECT_EQ(c[0], 0);
         EXPECT_EQ(c[1], 1);
         EXPECT_EQ(c[64], 1);
-        EXPECT_EQ(c[65], 0);
+        EXPECT_EQ(c[65], this->invalid_index);
         EXPECT_EQ(c[128], 2);
-        EXPECT_EQ(c[129], 0);
+        EXPECT_EQ(c[129], this->invalid_index);
         EXPECT_EQ(v[0], value_type{1.0});
         EXPECT_EQ(v[1], value_type{5.0});
         EXPECT_EQ(v[64], value_type{3.0});
@@ -275,9 +275,9 @@ protected:
         EXPECT_EQ(c[0], 0);
         EXPECT_EQ(c[1], 1);
         EXPECT_EQ(c[2], 1);
-        EXPECT_EQ(c[3], 0);
+        EXPECT_EQ(c[3], invalid_index);
         EXPECT_EQ(c[4], 2);
-        EXPECT_EQ(c[5], 0);
+        EXPECT_EQ(c[5], invalid_index);
         EXPECT_EQ(v[0], value_type{1.0});
         EXPECT_EQ(v[1], value_type{5.0});
         EXPECT_EQ(v[2], value_type{3.0});
@@ -348,6 +348,7 @@ protected:
     std::unique_ptr<Mtx> mtx2;
     std::unique_ptr<Mtx> mtx3_sorted;
     std::unique_ptr<Mtx> mtx3_unsorted;
+    index_type invalid_index = gko::invalid_index<index_type>();
 };
 
 TYPED_TEST_SUITE(Csr, gko::test::ValueIndexTypes, PairTypenameNameGenerator);

--- a/reference/test/matrix/dense_kernels.cpp
+++ b/reference/test/matrix/dense_kernels.cpp
@@ -97,7 +97,7 @@ protected:
     std::unique_ptr<Mtx> mtx6;
     std::unique_ptr<Mtx> mtx7;
     std::unique_ptr<Mtx> mtx8;
-
+    gko::int32 invalid_index = gko::invalid_index<gko::int32>();
     std::default_random_engine rand_engine;
 
     template <typename MtxType>
@@ -1110,7 +1110,7 @@ TYPED_TEST(Dense, ConvertsToEll32)
     EXPECT_EQ(c[0], 0);
     EXPECT_EQ(c[1], 1);
     EXPECT_EQ(c[2], 1);
-    EXPECT_EQ(c[3], 0);
+    EXPECT_EQ(c[3], this->invalid_index);
     EXPECT_EQ(v[0], T{1.0});
     EXPECT_EQ(v[1], T{1.5});
     EXPECT_EQ(v[2], T{2.0});
@@ -1135,7 +1135,7 @@ TYPED_TEST(Dense, MovesToEll32)
     EXPECT_EQ(c[0], 0);
     EXPECT_EQ(c[1], 1);
     EXPECT_EQ(c[2], 1);
-    EXPECT_EQ(c[3], 0);
+    EXPECT_EQ(c[3], this->invalid_index);
     EXPECT_EQ(v[0], T{1.0});
     EXPECT_EQ(v[1], T{1.5});
     EXPECT_EQ(v[2], T{2.0});
@@ -1160,7 +1160,7 @@ TYPED_TEST(Dense, ConvertsToEll64)
     EXPECT_EQ(c[0], 0);
     EXPECT_EQ(c[1], 1);
     EXPECT_EQ(c[2], 1);
-    EXPECT_EQ(c[3], 0);
+    EXPECT_EQ(c[3], this->invalid_index);
     EXPECT_EQ(v[0], T{1.0});
     EXPECT_EQ(v[1], T{1.5});
     EXPECT_EQ(v[2], T{2.0});
@@ -1185,7 +1185,7 @@ TYPED_TEST(Dense, MovesToEll64)
     EXPECT_EQ(c[0], 0);
     EXPECT_EQ(c[1], 1);
     EXPECT_EQ(c[2], 1);
-    EXPECT_EQ(c[3], 0);
+    EXPECT_EQ(c[3], this->invalid_index);
     EXPECT_EQ(v[0], T{1.0});
     EXPECT_EQ(v[1], T{1.5});
     EXPECT_EQ(v[2], T{2.0});
@@ -1210,10 +1210,10 @@ TYPED_TEST(Dense, ConvertsToEllWithStride)
     ASSERT_EQ(ell_mtx->get_stride(), 3);
     EXPECT_EQ(c[0], 0);
     EXPECT_EQ(c[1], 1);
-    EXPECT_EQ(c[2], 0);
+    EXPECT_EQ(c[2], this->invalid_index);
     EXPECT_EQ(c[3], 1);
-    EXPECT_EQ(c[4], 0);
-    EXPECT_EQ(c[5], 0);
+    EXPECT_EQ(c[4], this->invalid_index);
+    EXPECT_EQ(c[5], this->invalid_index);
     EXPECT_EQ(v[0], T{1.0});
     EXPECT_EQ(v[1], T{1.5});
     EXPECT_EQ(v[2], T{0.0});
@@ -1240,10 +1240,10 @@ TYPED_TEST(Dense, MovesToEllWithStride)
     ASSERT_EQ(ell_mtx->get_stride(), 3);
     EXPECT_EQ(c[0], 0);
     EXPECT_EQ(c[1], 1);
-    EXPECT_EQ(c[2], 0);
+    EXPECT_EQ(c[2], this->invalid_index);
     EXPECT_EQ(c[3], 1);
-    EXPECT_EQ(c[4], 0);
-    EXPECT_EQ(c[5], 0);
+    EXPECT_EQ(c[4], this->invalid_index);
+    EXPECT_EQ(c[5], this->invalid_index);
     EXPECT_EQ(v[0], T{1.0});
     EXPECT_EQ(v[1], T{1.5});
     EXPECT_EQ(v[2], T{0.0});
@@ -1474,10 +1474,10 @@ TYPED_TEST(Dense, MovesToHybridWithStrideAndCooLengthByColumns2)
     EXPECT_EQ(p, 3);
     EXPECT_EQ(c[0], 0);
     EXPECT_EQ(c[1], 1);
-    EXPECT_EQ(c[2], 0);
+    EXPECT_EQ(c[2], this->invalid_index);
     EXPECT_EQ(c[3], 1);
-    EXPECT_EQ(c[4], 0);
-    EXPECT_EQ(c[5], 0);
+    EXPECT_EQ(c[4], this->invalid_index);
+    EXPECT_EQ(c[5], this->invalid_index);
     EXPECT_EQ(v[0], T{1.0});
     EXPECT_EQ(v[1], T{5.0});
     EXPECT_EQ(v[2], T{0.0});
@@ -1511,10 +1511,10 @@ TYPED_TEST(Dense, ConvertsToHybridWithStrideAndCooLengthByColumns2)
     EXPECT_EQ(p, 3);
     EXPECT_EQ(c[0], 0);
     EXPECT_EQ(c[1], 1);
-    EXPECT_EQ(c[2], 0);
+    EXPECT_EQ(c[2], this->invalid_index);
     EXPECT_EQ(c[3], 1);
-    EXPECT_EQ(c[4], 0);
-    EXPECT_EQ(c[5], 0);
+    EXPECT_EQ(c[4], this->invalid_index);
+    EXPECT_EQ(c[5], this->invalid_index);
     EXPECT_EQ(v[0], T{1.0});
     EXPECT_EQ(v[1], T{5.0});
     EXPECT_EQ(v[2], T{0.0});
@@ -1550,7 +1550,7 @@ TYPED_TEST(Dense, MovesToHybridWithStrideByPercent40)
     EXPECT_EQ(p, 3);
     EXPECT_EQ(c[0], 0);
     EXPECT_EQ(c[1], 1);
-    EXPECT_EQ(c[2], 0);
+    EXPECT_EQ(c[2], this->invalid_index);
     EXPECT_EQ(v[0], T{1.0});
     EXPECT_EQ(v[1], T{5.0});
     EXPECT_EQ(v[2], T{0.0});
@@ -1587,7 +1587,7 @@ TYPED_TEST(Dense, ConvertsToHybridWithStrideByPercent40)
     EXPECT_EQ(p, 3);
     EXPECT_EQ(c[0], 0);
     EXPECT_EQ(c[1], 1);
-    EXPECT_EQ(c[2], 0);
+    EXPECT_EQ(c[2], this->invalid_index);
     EXPECT_EQ(v[0], T{1.0});
     EXPECT_EQ(v[1], T{5.0});
     EXPECT_EQ(v[2], T{0.0});
@@ -1623,9 +1623,9 @@ TYPED_TEST(Dense, ConvertsToSellp32)
     EXPECT_EQ(c[0], 0);
     EXPECT_EQ(c[1], 1);
     EXPECT_EQ(c[gko::matrix::default_slice_size], 1);
-    EXPECT_EQ(c[gko::matrix::default_slice_size + 1], 0);
+    EXPECT_EQ(c[gko::matrix::default_slice_size + 1], this->invalid_index);
     EXPECT_EQ(c[2 * gko::matrix::default_slice_size], 2);
-    EXPECT_EQ(c[2 * gko::matrix::default_slice_size + 1], 0);
+    EXPECT_EQ(c[2 * gko::matrix::default_slice_size + 1], this->invalid_index);
     EXPECT_EQ(v[0], T{1.0});
     EXPECT_EQ(v[1], T{1.5});
     EXPECT_EQ(v[gko::matrix::default_slice_size], T{2.0});
@@ -1660,9 +1660,9 @@ TYPED_TEST(Dense, MovesToSellp32)
     EXPECT_EQ(c[0], 0);
     EXPECT_EQ(c[1], 1);
     EXPECT_EQ(c[gko::matrix::default_slice_size], 1);
-    EXPECT_EQ(c[gko::matrix::default_slice_size + 1], 0);
+    EXPECT_EQ(c[gko::matrix::default_slice_size + 1], this->invalid_index);
     EXPECT_EQ(c[2 * gko::matrix::default_slice_size], 2);
-    EXPECT_EQ(c[2 * gko::matrix::default_slice_size + 1], 0);
+    EXPECT_EQ(c[2 * gko::matrix::default_slice_size + 1], this->invalid_index);
     EXPECT_EQ(v[0], T{1.0});
     EXPECT_EQ(v[1], T{1.5});
     EXPECT_EQ(v[gko::matrix::default_slice_size], T{2.0});
@@ -1697,9 +1697,9 @@ TYPED_TEST(Dense, ConvertsToSellp64)
     EXPECT_EQ(c[0], 0);
     EXPECT_EQ(c[1], 1);
     EXPECT_EQ(c[gko::matrix::default_slice_size], 1);
-    EXPECT_EQ(c[gko::matrix::default_slice_size + 1], 0);
+    EXPECT_EQ(c[gko::matrix::default_slice_size + 1], this->invalid_index);
     EXPECT_EQ(c[2 * gko::matrix::default_slice_size], 2);
-    EXPECT_EQ(c[2 * gko::matrix::default_slice_size + 1], 0);
+    EXPECT_EQ(c[2 * gko::matrix::default_slice_size + 1], this->invalid_index);
     EXPECT_EQ(v[0], T{1.0});
     EXPECT_EQ(v[1], T{1.5});
     EXPECT_EQ(v[gko::matrix::default_slice_size], T{2.0});
@@ -1734,9 +1734,9 @@ TYPED_TEST(Dense, MovesToSellp64)
     EXPECT_EQ(c[0], 0);
     EXPECT_EQ(c[1], 1);
     EXPECT_EQ(c[gko::matrix::default_slice_size], 1);
-    EXPECT_EQ(c[gko::matrix::default_slice_size + 1], 0);
+    EXPECT_EQ(c[gko::matrix::default_slice_size + 1], this->invalid_index);
     EXPECT_EQ(c[2 * gko::matrix::default_slice_size], 2);
-    EXPECT_EQ(c[2 * gko::matrix::default_slice_size + 1], 0);
+    EXPECT_EQ(c[2 * gko::matrix::default_slice_size + 1], this->invalid_index);
     EXPECT_EQ(v[0], T{1.0});
     EXPECT_EQ(v[1], T{1.5});
     EXPECT_EQ(v[gko::matrix::default_slice_size], T{2.0});
@@ -1770,11 +1770,11 @@ TYPED_TEST(Dense, ConvertsToSellpWithSliceSizeAndStrideFactor)
     EXPECT_EQ(c[0], 0);
     EXPECT_EQ(c[1], 1);
     EXPECT_EQ(c[2], 1);
-    EXPECT_EQ(c[3], 0);
+    EXPECT_EQ(c[3], this->invalid_index);
     EXPECT_EQ(c[4], 2);
-    EXPECT_EQ(c[5], 0);
-    EXPECT_EQ(c[6], 0);
-    EXPECT_EQ(c[7], 0);
+    EXPECT_EQ(c[5], this->invalid_index);
+    EXPECT_EQ(c[6], this->invalid_index);
+    EXPECT_EQ(c[7], this->invalid_index);
     EXPECT_EQ(v[0], T{1.0});
     EXPECT_EQ(v[1], T{1.5});
     EXPECT_EQ(v[2], T{2.0});
@@ -1810,11 +1810,11 @@ TYPED_TEST(Dense, MovesToSellpWithSliceSizeAndStrideFactor)
     EXPECT_EQ(c[0], 0);
     EXPECT_EQ(c[1], 1);
     EXPECT_EQ(c[2], 1);
-    EXPECT_EQ(c[3], 0);
+    EXPECT_EQ(c[3], this->invalid_index);
     EXPECT_EQ(c[4], 2);
-    EXPECT_EQ(c[5], 0);
-    EXPECT_EQ(c[6], 0);
-    EXPECT_EQ(c[7], 0);
+    EXPECT_EQ(c[5], this->invalid_index);
+    EXPECT_EQ(c[6], this->invalid_index);
+    EXPECT_EQ(c[7], this->invalid_index);
     EXPECT_EQ(v[0], T{1.0});
     EXPECT_EQ(v[1], T{1.5});
     EXPECT_EQ(v[2], T{2.0});

--- a/reference/test/matrix/hybrid_kernels.cpp
+++ b/reference/test/matrix/hybrid_kernels.cpp
@@ -92,7 +92,7 @@ protected:
         ell_val[2] = 3.0;
         ell_val[3] = 5.0;
         ell_col[0] = 0;
-        ell_col[1] = 0;
+        ell_col[1] = gko::invalid_index<index_type>();
         ell_col[2] = 1;
         ell_col[3] = 1;
         // Set Coo values

--- a/test/matrix/matrix.cpp
+++ b/test/matrix/matrix.cpp
@@ -724,6 +724,16 @@ protected:
         }
         {
             SCOPED_TRACE(
+                "Sparse Matrix with variable row nnz and some numerical zeros "
+                "(200x100)");
+            auto data = gen_mtx_data(200, 100, 10, 50);
+            for (int i = 0; i < data.nonzeros.size() / 4; i++) {
+                data.nonzeros[i * 4].value = gko::zero<value_type>();
+            }
+            guarded_fn(data);
+        }
+        {
+            SCOPED_TRACE(
                 "Sparse Matrix with heavily imbalanced row nnz (200x100)");
             guarded_fn(
                 gen_mtx_data(200, 100, std::poisson_distribution<>{1.5}));


### PR DESCRIPTION
This changes the column index for structural zeros/padding to `invalid_index<...>` to enable us to distinguish between numerical and structural zeros. It also leads to the important property that each column index occurs only once in each row, which  is necessary to build reusable generic matrix assembly structures for all sparse matrix formats.

Closes #1018