### PR TITLE
Add partition dpcpp kernels

### DIFF
--- a/dpcpp/base/device_matrix_data_kernels.dp.cpp
+++ b/dpcpp/base/device_matrix_data_kernels.dp.cpp
@@ -33,7 +33,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 // force-top: on
 // oneDPL needs to be first to avoid issues with libstdc++ TBB impl
 #include <oneapi/dpl/algorithm>
-#include <oneapi/dpl/execution>
 // force-top: off
 
 
@@ -41,6 +40,9 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
 #include <ginkgo/core/base/exception_helpers.hpp>
+
+
+#include "dpcpp/base/onedpl.hpp"
 
 
 namespace gko {
@@ -56,8 +58,7 @@ void remove_zeros(std::shared_ptr<const DefaultExecutor> exec,
 {
     using nonzero_type = matrix_data_entry<ValueType, IndexType>;
     auto size = values.get_num_elems();
-    auto policy =
-        oneapi::dpl::execution::make_device_policy(*exec->get_queue());
+    auto policy = onedpl_policy(exec);
     auto nnz = std::count_if(
         policy, values.get_const_data(), values.get_const_data() + size,
         [](ValueType val) { return is_nonzero<ValueType>(val); });
@@ -96,8 +97,7 @@ void sum_duplicates(std::shared_ptr<const DefaultExecutor> exec, size_type,
     if (size == 0) {
         return;
     }
-    auto policy =
-        oneapi::dpl::execution::make_device_policy(*exec->get_queue());
+    auto policy = onedpl_policy(exec);
     auto in_loc_it = oneapi::dpl::make_zip_iterator(row_idxs.get_const_data(),
                                                     col_idxs.get_const_data());
     auto adj_in_loc_it =
@@ -136,8 +136,7 @@ template <typename ValueType, typename IndexType>
 void sort_row_major(std::shared_ptr<const DefaultExecutor> exec,
                     device_matrix_data<ValueType, IndexType>& data)
 {
-    auto policy =
-        oneapi::dpl::execution::make_device_policy(*exec->get_queue());
+    auto policy = onedpl_policy(exec);
     auto input_it = oneapi::dpl::make_zip_iterator(
         data.get_row_idxs(), data.get_col_idxs(), data.get_values());
     std::sort(policy, input_it, input_it + data.get_num_elems(),

--- a/dpcpp/base/onedpl.hpp
+++ b/dpcpp/base/onedpl.hpp
@@ -1,0 +1,61 @@
+/*******************************<GINKGO LICENSE>******************************
+Copyright (c) 2017-2023, the Ginkgo authors
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+******************************<GINKGO LICENSE>*******************************/
+
+#ifndef GKO_DPCPP_BASE_ONEDPL_HPP_
+#define GKO_DPCPP_BASE_ONEDPL_HPP_
+
+
+// force-top: on
+#include <oneapi/dpl/execution>
+// force-top: off
+
+
+#include <ginkgo/core/base/executor.hpp>
+
+
+namespace gko {
+namespace kernels {
+namespace dpcpp {
+
+
+inline auto onedpl_policy(std::shared_ptr<const DpcppExecutor> exec)
+{
+    return oneapi::dpl::execution::make_device_policy(*exec->get_queue());
+}
+
+
+}  // namespace dpcpp
+}  // namespace kernels
+}  // namespace gko
+
+
+#endif  // GKO_DPCPP_BASE_ONEDPL_HPP_

--- a/dpcpp/distributed/partition_kernels.dp.cpp
+++ b/dpcpp/distributed/partition_kernels.dp.cpp
@@ -30,17 +30,86 @@ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ******************************<GINKGO LICENSE>*******************************/
 
+// force-top: on
+#include <oneapi/dpl/algorithm>
+#include <oneapi/dpl/execution>
+#include <oneapi/dpl/iterator>
+// force-top: off
+
+
 #include "core/distributed/partition_kernels.hpp"
+
+
+#include "common/unified/base/kernel_launch.hpp"
+#include "core/components/fill_array_kernels.hpp"
 
 
 namespace gko {
 namespace kernels {
 namespace dpcpp {
 namespace partition {
+namespace kernel {
 
 
-// TODO: wait until https://github.com/oneapi-src/oneDPL/pull/388 is release to
-// implement it similar to cuda/hip
+template <typename LocalIndexType, typename GlobalIndexType>
+void setup_sizes_ids_permutation(
+    std::shared_ptr<const DefaultExecutor> exec, size_type num_ranges,
+    comm_index_type num_parts, const GlobalIndexType* range_offsets,
+    const comm_index_type* range_parts, Array<LocalIndexType>& range_sizes,
+    Array<comm_index_type>& part_ids, Array<GlobalIndexType>& permutation)
+{
+    run_kernel(
+        exec,
+        [] GKO_KERNEL(auto i, auto num_ranges, auto num_parts,
+                      auto range_offsets, auto range_parts, auto range_sizes,
+                      auto part_ids, auto permutation) {
+            if (i == 0) {
+                // set sentinel value at the end
+                part_ids[num_ranges] = num_parts;
+            }
+            range_sizes[i] = range_offsets[i + 1] - range_offsets[i];
+            part_ids[i] = range_parts[i];
+            permutation[i] = static_cast<GlobalIndexType>(i);
+        },
+        num_ranges, num_ranges, num_parts, range_offsets, range_parts,
+        range_sizes.get_data(), part_ids.get_data(), permutation.get_data());
+}
+
+
+template <typename LocalIndexType, typename GlobalIndexType>
+void compute_part_sizes_and_starting_indices(
+    std::shared_ptr<const DefaultExecutor> exec, size_type num_ranges,
+    const Array<LocalIndexType>& range_sizes,
+    const Array<comm_index_type>& part_ids,
+    const Array<GlobalIndexType>& permutation, LocalIndexType* starting_indices,
+    LocalIndexType* part_sizes)
+{
+    run_kernel(
+        exec,
+        [] GKO_KERNEL(auto i, auto grouped_starting_indices,
+                      auto grouped_part_ids, auto orig_idxs,
+                      auto starting_indices, auto part_sizes) {
+            auto prev_part = i > 0 ? grouped_part_ids[i - 1]
+                                   : invalid_index<comm_index_type>();
+            auto cur_part = grouped_part_ids[i];
+            auto next_part =
+                grouped_part_ids[i + 1];  // last element has to be num_parts
+            if (cur_part != next_part) {
+                part_sizes[cur_part] = grouped_starting_indices[i];
+            }
+            // write result shifted by one entry to get exclusive prefix sum
+            starting_indices[orig_idxs[i]] =
+                prev_part == cur_part ? grouped_starting_indices[i - 1]
+                                      : LocalIndexType{};
+        },
+        num_ranges, range_sizes.get_const_data(), part_ids.get_const_data(),
+        permutation.get_const_data(), starting_indices, part_sizes);
+}
+
+
+}  // namespace kernel
+
+
 template <typename LocalIndexType, typename GlobalIndexType>
 void build_starting_indices(std::shared_ptr<const DefaultExecutor> exec,
                             const GlobalIndexType* range_offsets,
@@ -48,7 +117,47 @@ void build_starting_indices(std::shared_ptr<const DefaultExecutor> exec,
                             size_type num_ranges, comm_index_type num_parts,
                             comm_index_type& num_empty_parts,
                             LocalIndexType* starting_indices,
-                            LocalIndexType* part_sizes) GKO_NOT_IMPLEMENTED;
+                            LocalIndexType* part_sizes)
+{
+    if (num_ranges > 0) {
+        auto policy =
+            oneapi::dpl::execution::make_device_policy(*exec->get_queue());
+
+        Array<LocalIndexType> range_sizes{exec, num_ranges};
+        // num_parts sentinel at the end
+        Array<comm_index_type> tmp_part_ids{exec, num_ranges + 1};
+        Array<GlobalIndexType> permutation{exec, num_ranges};
+        // set part_sizes to 0 in case of empty parts
+        components::fill_array(exec, part_sizes, num_parts,
+                               zero<LocalIndexType>());
+
+        kernel::setup_sizes_ids_permutation(
+            exec, num_ranges, num_parts, range_offsets, range_parts,
+            range_sizes, tmp_part_ids, permutation);
+
+        auto tmp_part_id_ptr = tmp_part_ids.get_data();
+        auto range_sizes_ptr = range_sizes.get_data();
+        auto sort_it = oneapi::dpl::make_zip_iterator(
+            tmp_part_id_ptr, range_sizes_ptr, permutation.get_data());
+        // group range_sizes by part ID
+        oneapi::dpl::stable_sort(policy, sort_it, sort_it + num_ranges,
+                                 [](const auto t_a, const auto t_b) {
+                                     return std::get<0>(t_a) < std::get<0>(t_b);
+                                 });
+        // compute inclusive prefix sum for each part
+        oneapi::dpl::inclusive_scan_by_segment(
+            policy, tmp_part_id_ptr, tmp_part_id_ptr + num_ranges,
+            range_sizes_ptr, range_sizes_ptr);
+        // write back the results
+        kernel::compute_part_sizes_and_starting_indices(
+            exec, num_ranges, range_sizes, tmp_part_ids, permutation,
+            starting_indices, part_sizes);
+        num_empty_parts =
+            oneapi::dpl::count(policy, part_sizes, part_sizes + num_parts, 0);
+    } else {
+        num_empty_parts = num_parts;
+    }
+}
 
 GKO_INSTANTIATE_FOR_EACH_LOCAL_GLOBAL_INDEX_TYPE(
     GKO_DECLARE_PARTITION_BUILD_STARTING_INDICES);

--- a/dpcpp/multigrid/pgm_kernels.dp.cpp
+++ b/dpcpp/multigrid/pgm_kernels.dp.cpp
@@ -33,7 +33,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 // force-top: on
 // oneDPL needs to be first to avoid issues with libstdc++ TBB impl
 #include <oneapi/dpl/algorithm>
-#include <oneapi/dpl/execution>
 // force-top: off
 
 
@@ -46,6 +45,9 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <ginkgo/core/base/exception_helpers.hpp>
 #include <ginkgo/core/base/math.hpp>
 #include <ginkgo/core/multigrid/pgm.hpp>
+
+
+#include "dpcpp/base/onedpl.hpp"
 
 
 namespace gko {
@@ -63,8 +65,7 @@ template <typename IndexType>
 void sort_agg(std::shared_ptr<const DefaultExecutor> exec, IndexType num,
               IndexType* row_idxs, IndexType* col_idxs)
 {
-    auto policy =
-        oneapi::dpl::execution::make_device_policy(*exec->get_queue());
+    auto policy = onedpl_policy(exec);
     auto it = oneapi::dpl::make_zip_iterator(row_idxs, col_idxs);
     std::sort(policy, it, it + num, [](auto a, auto b) {
         return std::tie(std::get<0>(a), std::get<1>(a)) <
@@ -79,8 +80,7 @@ template <typename ValueType, typename IndexType>
 void sort_row_major(std::shared_ptr<const DefaultExecutor> exec, size_type nnz,
                     IndexType* row_idxs, IndexType* col_idxs, ValueType* vals)
 {
-    auto policy =
-        oneapi::dpl::execution::make_device_policy(*exec->get_queue());
+    auto policy = onedpl_policy(exec);
     auto it = oneapi::dpl::make_zip_iterator(row_idxs, col_idxs, vals);
     // Because reduce_by_segment is not determinstic, so we do not need
     // stable_sort

--- a/test/mpi/CMakeLists.txt
+++ b/test/mpi/CMakeLists.txt
@@ -1,4 +1,4 @@
-ginkgo_create_common_and_reference_test(matrix MPI_SIZE 3 DISABLE_EXECUTORS dpcpp)
+ginkgo_create_common_and_reference_test(matrix MPI_SIZE 3)
 ginkgo_create_common_and_reference_test(vector MPI_SIZE 3)
 
 add_subdirectory(preconditioner)


### PR DESCRIPTION
This PR adds the missing partition dpcpp kernels. I think the previous issue https://github.com/oneapi-src/oneDPL/pull/388 is resolved.

Needed for #985.