### PR TITLE
Fix Logger in Mixin Usage

### DIFF
--- a/core/test/base/abstract_factory.cpp
+++ b/core/test/base/abstract_factory.cpp
@@ -60,7 +60,7 @@ struct IntFactory
                                     base>::EnableDefaultFactory;
 };
 
-struct MyInt {
+struct MyInt : gko::log::EnableLogging<MyInt> {
     MyInt(const IntFactory* factory, int orig_value)
         : value{orig_value * factory->get_parameters().coefficient}
     {}

--- a/core/test/base/array.cpp
+++ b/core/test/base/array.cpp
@@ -200,7 +200,7 @@ TYPED_TEST(Array, CanBeMoveConstructedToADifferentExecutor)
 
 TYPED_TEST(Array, MoveConstructedFromArrayExecutorlessIsEmpty)
 {
-    gko::Array<TypeParam> a{std::move(this->x)};
+    gko::array<TypeParam> a{std::move(this->x)};
 
     a = std::move(this->x);
 
@@ -211,7 +211,7 @@ TYPED_TEST(Array, MoveConstructedFromArrayExecutorlessIsEmpty)
 
 TYPED_TEST(Array, MoveConstructedFromArraySameExecutorIsEmpty)
 {
-    gko::Array<TypeParam> a{this->exec, std::move(this->x)};
+    gko::array<TypeParam> a{this->exec, std::move(this->x)};
 
     ASSERT_EQ(this->x.get_executor(), this->exec);
     ASSERT_EQ(this->x.get_num_elems(), 0);
@@ -220,7 +220,7 @@ TYPED_TEST(Array, MoveConstructedFromArraySameExecutorIsEmpty)
 
 TYPED_TEST(Array, MoveConstructedFromArrayDifferentExecutorIsEmpty)
 {
-    gko::Array<TypeParam> a{gko::ReferenceExecutor::create(),
+    gko::array<TypeParam> a{gko::ReferenceExecutor::create(),
                             std::move(this->x)};
 
     ASSERT_EQ(this->x.get_executor(), this->exec);
@@ -297,7 +297,7 @@ TYPED_TEST(Array, CanBeMovedFromExecutorlessArray)
 
 TYPED_TEST(Array, MovedFromArrayExecutorlessIsEmpty)
 {
-    gko::Array<TypeParam> a;
+    gko::array<TypeParam> a;
 
     a = std::move(this->x);
 
@@ -308,7 +308,7 @@ TYPED_TEST(Array, MovedFromArrayExecutorlessIsEmpty)
 
 TYPED_TEST(Array, MovedFromArraySameExecutorIsEmpty)
 {
-    gko::Array<TypeParam> a{this->exec};
+    gko::array<TypeParam> a{this->exec};
 
     a = std::move(this->x);
 
@@ -319,7 +319,7 @@ TYPED_TEST(Array, MovedFromArraySameExecutorIsEmpty)
 
 TYPED_TEST(Array, MovedFromArrayDifferentExecutorIsEmpty)
 {
-    gko::Array<TypeParam> a{gko::ReferenceExecutor::create()};
+    gko::array<TypeParam> a{gko::ReferenceExecutor::create()};
 
     a = std::move(this->x);
 

--- a/core/test/base/executor.cpp
+++ b/core/test/base/executor.cpp
@@ -651,4 +651,131 @@ TEST(ExecutorDeleter, AvoidsDeletionForNullExecutor)
 }
 
 
+struct DummyLogger : public gko::log::Logger {
+    DummyLogger(std::shared_ptr<const gko::Executor> exec)
+        : gko::log::Logger(std::move(exec),
+                           gko::log::Logger::executor_events_mask |
+                               gko::log::Logger::operation_events_mask)
+    {}
+
+    void on_allocation_started(const gko::Executor* exec,
+                               const gko::size_type& num_bytes) const override
+    {
+        allocation_started++;
+    }
+    void on_allocation_completed(const gko::Executor* exec,
+                                 const gko::size_type& num_bytes,
+                                 const gko::uintptr& location) const override
+    {
+        alloctaion_completed++;
+    }
+
+    void on_free_started(const gko::Executor* exec,
+                         const gko::uintptr& location) const override
+    {
+        free_started++;
+    }
+
+
+    void on_free_completed(const gko::Executor* exec,
+                           const gko::uintptr& location) const override
+    {
+        free_completed++;
+    }
+
+    void on_copy_started(const gko::Executor* exec_from,
+                         const gko::Executor* exec_to,
+                         const gko::uintptr& loc_from,
+                         const gko::uintptr& loc_to,
+                         const gko::size_type& num_bytes) const override
+    {
+        copy_started++;
+    }
+
+    void on_copy_completed(const gko::Executor* exec_from,
+                           const gko::Executor* exec_to,
+                           const gko::uintptr& loc_from,
+                           const gko::uintptr& loc_to,
+                           const gko::size_type& num_bytes) const override
+    {
+        copy_completed++;
+    }
+
+    void on_operation_launched(const gko::Executor* exec,
+                               const gko::Operation* op) const override
+    {
+        operation_launched++;
+    }
+
+
+    void on_operation_completed(const gko::Executor* exec,
+                                const gko::Operation* op) const override
+    {
+        operation_completed++;
+    }
+
+    int mutable allocation_started = 0;
+    int mutable alloctaion_completed = 0;
+    int mutable free_started = 0;
+    int mutable free_completed = 0;
+    int mutable copy_started = 0;
+    int mutable copy_completed = 0;
+    int mutable operation_launched = 0;
+    int mutable operation_completed = 0;
+};
+
+
+class ExecutorLogging : public ::testing::Test {
+protected:
+    ExecutorLogging()
+        : exec(gko::ReferenceExecutor::create()),
+          logger(std::make_shared<DummyLogger>(exec))
+    {
+        exec->add_logger(logger);
+    }
+
+    std::shared_ptr<gko::ReferenceExecutor> exec;
+    std::shared_ptr<DummyLogger> logger;
+};
+
+
+TEST_F(ExecutorLogging, LogsAllocationAndFree)
+{
+    auto before_logger = *logger;
+
+    auto p = exec->alloc<int>(1);
+    exec->free(p);
+
+    ASSERT_EQ(logger->allocation_started, before_logger.allocation_started + 1);
+    ASSERT_EQ(logger->alloctaion_completed,
+              before_logger.alloctaion_completed + 1);
+    ASSERT_EQ(logger->free_started, before_logger.free_started + 1);
+    ASSERT_EQ(logger->free_completed, before_logger.free_completed + 1);
+}
+
+
+TEST_F(ExecutorLogging, LogsCopy)
+{
+    auto before_logger = *logger;
+
+    exec->copy<std::nullptr_t>(0, nullptr, nullptr);
+
+    ASSERT_EQ(logger->copy_started, before_logger.copy_started + 1);
+    ASSERT_EQ(logger->copy_completed, before_logger.copy_completed + 1);
+}
+
+
+TEST_F(ExecutorLogging, LogsOperation)
+{
+    auto before_logger = *logger;
+    int value = 0;
+
+    exec->run(ExampleOperation(value));
+
+    ASSERT_EQ(logger->operation_launched, before_logger.operation_launched + 1);
+    ASSERT_EQ(logger->operation_completed,
+              before_logger.operation_completed + 1);
+}
+
+
 }  // namespace

--- a/core/test/base/executor.cpp
+++ b/core/test/base/executor.cpp
@@ -667,7 +667,7 @@ struct DummyLogger : public gko::log::Logger {
                                  const gko::size_type& num_bytes,
                                  const gko::uintptr& location) const override
     {
-        alloctaion_completed++;
+        allocation_completed++;
     }
 
     void on_free_started(const gko::Executor* exec,
@@ -714,14 +714,14 @@ struct DummyLogger : public gko::log::Logger {
         operation_completed++;
     }
 
-    int mutable allocation_started = 0;
-    int mutable alloctaion_completed = 0;
-    int mutable free_started = 0;
-    int mutable free_completed = 0;
-    int mutable copy_started = 0;
-    int mutable copy_completed = 0;
-    int mutable operation_launched = 0;
-    int mutable operation_completed = 0;
+    mutable int allocation_started = 0;
+    mutable int allocation_completed = 0;
+    mutable int free_started = 0;
+    mutable int free_completed = 0;
+    mutable int copy_started = 0;
+    mutable int copy_completed = 0;
+    mutable int operation_launched = 0;
+    mutable int operation_completed = 0;
 };
 
 
@@ -747,8 +747,8 @@ TEST_F(ExecutorLogging, LogsAllocationAndFree)
     exec->free(p);
 
     ASSERT_EQ(logger->allocation_started, before_logger.allocation_started + 1);
-    ASSERT_EQ(logger->alloctaion_completed,
-              before_logger.alloctaion_completed + 1);
+    ASSERT_EQ(logger->allocation_completed,
+              before_logger.allocation_completed + 1);
     ASSERT_EQ(logger->free_started, before_logger.free_started + 1);
     ASSERT_EQ(logger->free_completed, before_logger.free_completed + 1);
 }

--- a/core/test/base/lin_op.cpp
+++ b/core/test/base/lin_op.cpp
@@ -41,6 +41,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <gtest/gtest.h>
 
 
+#include <ginkgo/core/base/executor.hpp>
 #include <ginkgo/core/base/math.hpp>
 
 
@@ -423,6 +424,22 @@ TEST_F(EnableLinOpFactory, FactoryGenerateIsLogged)
               before_logger.linop_factory_generate_started + 1);
     ASSERT_EQ(logger->linop_factory_generate_completed,
               before_logger.linop_factory_generate_completed + 1);
+}
+
+
+TEST_F(EnableLinOpFactory, CopiesLinOpToOtherExecutor)
+{
+    auto ref2 = gko::ReferenceExecutor::create();
+    auto dummy = gko::share(DummyLinOp::create(ref2, gko::dim<2>{3, 5}));
+    auto factory = DummyLinOpWithFactory<>::build().with_value(6).on(ref);
+
+    auto op = factory->generate(dummy);
+
+    ASSERT_EQ(op->get_executor(), ref);
+    ASSERT_EQ(op->get_parameters().value, 6);
+    ASSERT_EQ(op->op_->get_executor(), ref);
+    ASSERT_NE(op->op_.get(), dummy.get());
+    ASSERT_TRUE(dynamic_cast<const DummyLinOp*>(op->op_.get()));
 }
 
 

--- a/core/test/base/polymorphic_object.cpp
+++ b/core/test/base/polymorphic_object.cpp
@@ -77,12 +77,90 @@ struct DummyObject : gko::EnablePolymorphicObject<DummyObject>,
 };
 
 
+struct DummyLogger : gko::log::Logger {
+    DummyLogger(std::shared_ptr<const gko::Executor> exec)
+        : gko::log::Logger(std::move(exec),
+                           gko::log::Logger::polymorphic_object_events_mask)
+    {}
+
+    void on_polymorphic_object_create_started(
+        const gko::Executor*, const gko::PolymorphicObject*) const override
+    {
+        create_started++;
+    }
+
+    void on_polymorphic_object_create_completed(
+        const gko::Executor*, const gko::PolymorphicObject*,
+        const gko::PolymorphicObject*) const override
+    {
+        create_completed++;
+    }
+
+    void on_polymorphic_object_copy_started(
+        const gko::Executor*, const gko::PolymorphicObject*,
+        const gko::PolymorphicObject*) const override
+    {
+        copy_started++;
+    }
+
+    void on_polymorphic_object_copy_completed(
+        const gko::Executor*, const gko::PolymorphicObject*,
+        const gko::PolymorphicObject*) const override
+    {
+        copy_completed++;
+    }
+
+    void on_polymorphic_object_move_started(
+        const gko::Executor*, const gko::PolymorphicObject*,
+        const gko::PolymorphicObject*) const override
+    {
+        move_started++;
+    }
+
+    void on_polymorphic_object_move_completed(
+        const gko::Executor*, const gko::PolymorphicObject*,
+        const gko::PolymorphicObject*) const override
+    {
+        move_completed++;
+    }
+
+    void on_polymorphic_object_deleted(
+        const gko::Executor*, const gko::PolymorphicObject*) const override
+    {
+        deleted++;
+    }
+
+    int mutable create_started = 0;
+    int mutable create_completed = 0;
+    int mutable copy_started = 0;
+    int mutable copy_completed = 0;
+    int mutable move_started = 0;
+    int mutable move_completed = 0;
+    int mutable deleted = 0;
+};
+
+
 class EnablePolymorphicObject : public testing::Test {
 protected:
     std::shared_ptr<gko::ReferenceExecutor> ref{
         gko::ReferenceExecutor::create()};
     std::shared_ptr<gko::OmpExecutor> omp{gko::OmpExecutor::create()};
     std::unique_ptr<DummyObject> obj{new DummyObject(ref, 5)};
+    std::shared_ptr<DummyLogger> logger{std::make_shared<DummyLogger>(ref)};
+
+    void SetUp() override
+    {
+        if (obj) {
+            obj->add_logger(logger);
+        }
+    }
+
+    void TearDown() override
+    {
+        if (obj) {
+            obj->remove_logger(logger.get());
+        }
+    }
 };
 
 
@@ -109,6 +187,17 @@ TEST_F(EnablePolymorphicObject, CreatesDefaultObjectOnAnotherExecutor)
     ASSERT_NE(def, obj);
     ASSERT_EQ(def->get_executor(), omp);
     ASSERT_EQ(def->x, 0);
+}
+
+
+TEST_F(EnablePolymorphicObject, CreatesDefaultObjectIsLogged)
+{
+    auto before_logger = *this->logger;
+
+    auto def = obj->create_default();
+
+    ASSERT_EQ(logger->create_started, before_logger.create_started + 1);
+    ASSERT_EQ(logger->create_completed, before_logger.create_completed + 1);
 }
 
 
@@ -146,6 +235,19 @@ TEST_F(EnablePolymorphicObject, CopiesObject)
 }
 
 
+TEST_F(EnablePolymorphicObject, CopiesObjectIsLogged)
+{
+    auto before_logger = *logger;
+    auto copy = DummyObject::create(omp, 7);
+    copy->add_logger(logger);
+
+    copy->copy_from(gko::lend(obj));
+
+    ASSERT_EQ(logger->copy_started, before_logger.copy_started + 1);
+    ASSERT_EQ(logger->copy_completed, before_logger.copy_completed + 1);
+}
+
+
 TEST_F(EnablePolymorphicObject, MovesObjectByCopyFromUniquePtr)
 {
     auto copy = DummyObject::create(ref, 7);
@@ -155,6 +257,19 @@ TEST_F(EnablePolymorphicObject, MovesObjectByCopyFromUniquePtr)
     ASSERT_NE(copy, obj);
     ASSERT_EQ(copy->get_executor(), ref);
     ASSERT_EQ(copy->x, 5);
+}
+
+
+TEST_F(EnablePolymorphicObject, MovesObjectByCopyFromUniquePtrIsLogged)
+{
+    auto before_logger = *this->logger;
+    auto copy = DummyObject::create(ref, 7);
+    copy->add_logger(logger);
+
+    copy->copy_from(gko::give(obj));
+
+    ASSERT_EQ(logger->move_started, before_logger.move_started + 1);
+    ASSERT_EQ(logger->move_completed, before_logger.move_completed + 1);
 }
 
 
@@ -172,6 +287,19 @@ TEST_F(EnablePolymorphicObject, MovesObject)
 }
 
 
+TEST_F(EnablePolymorphicObject, MovesObjectIsLogged)
+{
+    auto before_logger = *this->logger;
+    auto copy = DummyObject::create(ref, 7);
+    copy->add_logger(logger);
+
+    copy->move_from(gko::lend(obj));
+
+    ASSERT_EQ(logger->move_started, before_logger.move_started + 1);
+    ASSERT_EQ(logger->move_completed, before_logger.move_completed + 1);
+}
+
+
 TEST_F(EnablePolymorphicObject, MovesFromUniquePtr)
 {
     auto copy = DummyObject::create(ref, 7);
@@ -181,6 +309,19 @@ TEST_F(EnablePolymorphicObject, MovesFromUniquePtr)
     ASSERT_NE(copy, obj);
     ASSERT_EQ(copy->get_executor(), ref);
     ASSERT_EQ(copy->x, 5);
+}
+
+
+TEST_F(EnablePolymorphicObject, MovesFromUniquePtrIsLogged)
+{
+    auto before_logger = *this->logger;
+    auto copy = DummyObject::create(ref, 7);
+    copy->add_logger(logger);
+
+    copy->copy_from(gko::give(obj));
+
+    ASSERT_EQ(logger->move_started, before_logger.move_started + 1);
+    ASSERT_EQ(logger->move_completed, before_logger.move_completed + 1);
 }
 
 

--- a/core/test/base/polymorphic_object.cpp
+++ b/core/test/base/polymorphic_object.cpp
@@ -130,13 +130,13 @@ struct DummyLogger : gko::log::Logger {
         deleted++;
     }
 
-    int mutable create_started = 0;
-    int mutable create_completed = 0;
-    int mutable copy_started = 0;
-    int mutable copy_completed = 0;
-    int mutable move_started = 0;
-    int mutable move_completed = 0;
-    int mutable deleted = 0;
+    mutable int create_started = 0;
+    mutable int create_completed = 0;
+    mutable int copy_started = 0;
+    mutable int copy_completed = 0;
+    mutable int move_started = 0;
+    mutable int move_completed = 0;
+    mutable int deleted = 0;
 };
 
 

--- a/core/test/stop/CMakeLists.txt
+++ b/core/test/stop/CMakeLists.txt
@@ -1,4 +1,5 @@
 ginkgo_create_test(combined)
+ginkgo_create_test(criterion)
 ginkgo_create_test(iteration)
 ginkgo_create_test(stopping_status)
 ginkgo_create_test(time)

--- a/core/test/stop/criterion.cpp
+++ b/core/test/stop/criterion.cpp
@@ -1,0 +1,131 @@
+/*******************************<GINKGO LICENSE>******************************
+Copyright (c) 2017-2022, the Ginkgo authors
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+******************************<GINKGO LICENSE>*******************************/
+
+#include <ginkgo/core/stop/criterion.hpp>
+
+
+#include <gtest/gtest.h>
+
+
+namespace {
+
+
+struct DummyLogger : public gko::log::Logger {
+    DummyLogger(std::shared_ptr<const gko::Executor> exec)
+        : gko::log::Logger(std::move(exec),
+                           gko::log::Logger::criterion_events_mask)
+    {}
+
+    void on_criterion_check_started(const gko::stop::Criterion* criterion,
+                                    const gko::size_type& num_iterations,
+                                    const gko::LinOp* residual,
+                                    const gko::LinOp* residual_norm,
+                                    const gko::LinOp* solution,
+                                    const gko::uint8& stopping_id,
+                                    const bool& set_finalized) const override
+    {
+        criterion_check_started++;
+    }
+
+    void on_criterion_check_completed(
+        const gko::stop::Criterion* criterion,
+        const gko::size_type& num_iterations, const gko::LinOp* residual,
+        const gko::LinOp* residual_norm, const gko::LinOp* solutino,
+        const gko::uint8& stopping_id, const bool& set_finalized,
+        const gko::array<gko::stopping_status>* status, const bool& one_changed,
+        const bool& all_converged) const override
+    {
+        criterion_check_completed++;
+    }
+
+
+    int mutable criterion_check_started = 0;
+    int mutable criterion_check_completed = 0;
+};
+
+
+class DummyCriterion
+    : public gko::EnablePolymorphicObject<DummyCriterion,
+                                          gko::stop::Criterion> {
+    friend class gko::EnablePolymorphicObject<DummyCriterion,
+                                              gko::stop::Criterion>;
+
+public:
+    explicit DummyCriterion(std::shared_ptr<const gko::Executor> exec)
+        : gko::EnablePolymorphicObject<DummyCriterion, gko::stop::Criterion>(
+              std::move(exec))
+    {}
+
+protected:
+    bool check_impl(gko::uint8 stopping_id, bool set_finalized,
+                    gko::array<gko::stopping_status>* stop_status,
+                    bool* one_changed, const Updater& updater) override
+    {
+        return true;
+    }
+};
+
+
+class Criterion : public ::testing::Test {
+protected:
+    Criterion()
+        : exec{gko::ReferenceExecutor::create()},
+          criterion{std::make_unique<DummyCriterion>(exec)},
+          stopping_status{exec},
+          logger{std::make_shared<DummyLogger>(exec)}
+    {
+        criterion->add_logger(logger);
+    }
+
+    std::shared_ptr<const gko::Executor> exec;
+    std::unique_ptr<DummyCriterion> criterion;
+    gko::array<gko::stopping_status> stopping_status;
+    std::shared_ptr<DummyLogger> logger;
+};
+
+
+TEST_F(Criterion, CanLogCheck)
+{
+    auto before_logger = *logger;
+    bool one_changed = false;
+
+    criterion->check(gko::uint8(0), false, &stopping_status, &one_changed,
+                     criterion->update());
+
+    ASSERT_EQ(logger->criterion_check_started,
+              before_logger.criterion_check_started + 1);
+    ASSERT_EQ(logger->criterion_check_completed,
+              before_logger.criterion_check_completed + 1);
+}
+
+
+}  // namespace

--- a/core/test/stop/criterion.cpp
+++ b/core/test/stop/criterion.cpp
@@ -68,8 +68,8 @@ struct DummyLogger : public gko::log::Logger {
     }
 
 
-    int mutable criterion_check_started = 0;
-    int mutable criterion_check_completed = 0;
+    mutable int criterion_check_started = 0;
+    mutable int criterion_check_completed = 0;
 };
 
 

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -28,7 +28,6 @@ set(EXAMPLES_LIST
     par-ilu-convergence
     performance-debugging
     preconditioner-export
-    schroedinger-splitting
     simple-solver-logging)
 
 if(GINKGO_BUILD_CUDA AND GINKGO_BUILD_OMP)
@@ -41,9 +40,9 @@ endif()
 
 find_package(OpenCV QUIET)
 if(OpenCV_FOUND)
-    list(APPEND EXAMPLES_LIST heat-equation)
+    list(APPEND EXAMPLES_LIST heat-equation schroedinger-splitting)
 else()
-    message(STATUS "No OpenCV found, disabling heat-equation example")
+    message(STATUS "No OpenCV found, disabling examples with video output")
 endif()
 
 if(GINKGO_HAVE_PAPI_SDE)

--- a/examples/schroedinger-splitting/CMakeLists.txt
+++ b/examples/schroedinger-splitting/CMakeLists.txt
@@ -1,12 +1,15 @@
-set(target_name "schroedinger-splitting")
-find_package(OpenCV)
+cmake_minimum_required(VERSION 3.9)
+project(schroedinger-splitting)
 
-if (OpenCV_FOUND)
-    add_executable(${target_name} ${target_name}.cpp)
-    target_link_libraries(${target_name} Ginkgo::ginkgo ${OpenCV_LIBS})
-    target_include_directories(${target_name} PRIVATE ${PROJECT_SOURCE_DIR})
-    configure_file(../../matrices/examples/gko_logo_2d.mtx data/gko_logo_2d.mtx COPYONLY)
-    configure_file(../../matrices/examples/gko_text_2d.mtx data/gko_text_2d.mtx COPYONLY)
-else()
-    message("OpenCV not found, skipping schroedinger-splitting example")
+# We only need to find Ginkgo if we build this example stand-alone
+if (NOT GINKGO_BUILD_EXAMPLES)
+    find_package(Ginkgo 1.5.0 REQUIRED)
 endif()
+find_package(OpenCV REQUIRED)
+
+add_executable(schroedinger-splitting schroedinger-splitting.cpp)
+target_link_libraries(schroedinger-splitting Ginkgo::ginkgo ${OpenCV_LIBS})
+
+# Copy the data files to the execution directory
+configure_file(../../matrices/examples/gko_logo_2d.mtx data/gko_logo_2d.mtx COPYONLY)
+configure_file(../../matrices/examples/gko_text_2d.mtx data/gko_text_2d.mtx COPYONLY)

--- a/include/ginkgo/core/base/abstract_factory.hpp
+++ b/include/ginkgo/core/base/abstract_factory.hpp
@@ -89,9 +89,13 @@ public:
      * @return an instance of AbstractProductType
      */
     template <typename... Args>
-    std::unique_ptr<AbstractProductType> generate(Args&&... args) const
+    std::unique_ptr<abstract_product_type> generate(Args&&... args) const
     {
-        auto product = this->generate_impl({std::forward<Args>(args)...});
+        auto product =
+            this->generate_impl(components_type{std::forward<Args>(args)...});
+        for (auto logger : this->loggers_) {
+            product->add_logger(logger);
+        }
         return product;
     }
 
@@ -112,7 +116,7 @@ protected:
      *
      * @return an instance of AbstractProductType
      */
-    virtual std::unique_ptr<AbstractProductType> generate_impl(
+    virtual std::unique_ptr<abstract_product_type> generate_impl(
         ComponentsType args) const = 0;
 };
 
@@ -156,11 +160,11 @@ public:
     using components_type = typename PolymorphicBase::components_type;
 
     template <typename... Args>
-    std::unique_ptr<ProductType> generate(Args&&... args) const
+    std::unique_ptr<product_type> generate(Args&&... args) const
     {
-        auto product = std::unique_ptr<ProductType>(static_cast<ProductType*>(
-            PolymorphicBase::generate(std::forward<Args>(args)...).release()));
-        propagate_loggers<ConcreteFactory, ProductType>(product.get());
+        auto product = std::unique_ptr<product_type>(static_cast<product_type*>(
+            this->polymorphic_base::generate(std::forward<Args>(args)...)
+                .release()));
         return product;
     }
 
@@ -190,40 +194,6 @@ public:
 
 protected:
     /**
-     * Automatically propagate loggers from the factory to the product. Use
-     * `std::enable_if(...)` to ensure both TheType and TheFactory have logging
-     * facilities in this case.
-     *
-     * @param product  the product to add loggers to
-     */
-    template <typename TheFactory, typename TheType>
-    typename std::enable_if<
-        std::is_base_of<log::Loggable, TheType>::value &&
-            std::is_base_of<log::Loggable, TheFactory>::value,
-        void>::type
-    propagate_loggers(TheType* product) const
-    {
-        for (auto logger : this->loggers_) {
-            product->add_logger(logger);
-        }
-    }
-
-    /**
-     * Automatically propagate loggers from the factory to the product. Use
-     * `std::enable_if(...)` to ensure either TheType or TheFactory do not have
-     * logging facilities in this case.
-     *
-     * @param product  the product to *not* add loggers to
-     */
-    template <typename TheFactory, typename TheType>
-    typename std::enable_if<
-        !std::is_base_of<log::Loggable, TheType>::value ||
-            !std::is_base_of<log::Loggable, TheFactory>::value,
-        void>::type
-    propagate_loggers(TheType* product) const
-    {}
-
-    /**
      * Creates a new factory using the specified executor and parameters.
      *
      * @param exec  the executor where the factory will be constructed
@@ -240,7 +210,7 @@ protected:
         components_type args) const override
     {
         return std::unique_ptr<abstract_product_type>(
-            new ProductType(self(), args));
+            new product_type(self(), args));
     }
 
 private:

--- a/include/ginkgo/core/base/abstract_factory.hpp
+++ b/include/ginkgo/core/base/abstract_factory.hpp
@@ -92,9 +92,6 @@ public:
     std::unique_ptr<AbstractProductType> generate(Args&&... args) const
     {
         auto product = this->generate_impl({std::forward<Args>(args)...});
-        for (auto logger : this->loggers_) {
-            product->add_logger(logger);
-        }
         return product;
     }
 
@@ -162,7 +159,7 @@ public:
     std::unique_ptr<ProductType> generate(Args&&... args) const
     {
         auto product = std::unique_ptr<ProductType>(static_cast<ProductType*>(
-            this->generate_impl({std::forward<Args>(args)...}).release()));
+            PolymorphicBase::generate(std::forward<Args>(args)...).release()));
         propagate_loggers<ConcreteFactory, ProductType>(product.get());
         return product;
     }

--- a/include/ginkgo/core/base/lin_op.hpp
+++ b/include/ginkgo/core/base/lin_op.hpp
@@ -413,7 +413,14 @@ public:
     {
         this->template log<log::Logger::linop_factory_generate_started>(
             this, input.get());
-        auto generated = AbstractFactory::generate(input);
+        const auto exec = this->get_executor();
+        std::unique_ptr<LinOp> generated;
+        if (input->get_executor() == exec) {
+            generated = this->AbstractFactory::generate(input);
+        } else {
+            generated =
+                this->AbstractFactory::generate(gko::clone(exec, input));
+        }
         this->template log<log::Logger::linop_factory_generate_completed>(
             this, input.get(), generated.get());
         return generated;

--- a/include/ginkgo/core/base/lin_op.hpp
+++ b/include/ginkgo/core/base/lin_op.hpp
@@ -876,55 +876,27 @@ public:
 
     const ConcreteLinOp* apply(const LinOp* b, LinOp* x) const
     {
-        this->template log<log::Logger::linop_apply_started>(this, b, x);
-        this->validate_application_parameters(b, x);
-        auto exec = this->get_executor();
-        this->apply_impl(make_temporary_clone(exec, b).get(),
-                         make_temporary_clone(exec, x).get());
-        this->template log<log::Logger::linop_apply_completed>(this, b, x);
+        PolymorphicBase::apply(b, x);
         return self();
     }
 
     ConcreteLinOp* apply(const LinOp* b, LinOp* x)
     {
-        this->template log<log::Logger::linop_apply_started>(this, b, x);
-        this->validate_application_parameters(b, x);
-        auto exec = this->get_executor();
-        this->apply_impl(make_temporary_clone(exec, b).get(),
-                         make_temporary_clone(exec, x).get());
-        this->template log<log::Logger::linop_apply_completed>(this, b, x);
+        PolymorphicBase::apply(b, x);
         return self();
     }
 
     const ConcreteLinOp* apply(const LinOp* alpha, const LinOp* b,
                                const LinOp* beta, LinOp* x) const
     {
-        this->template log<log::Logger::linop_advanced_apply_started>(
-            this, alpha, b, beta, x);
-        this->validate_application_parameters(alpha, b, beta, x);
-        auto exec = this->get_executor();
-        this->apply_impl(make_temporary_clone(exec, alpha).get(),
-                         make_temporary_clone(exec, b).get(),
-                         make_temporary_clone(exec, beta).get(),
-                         make_temporary_clone(exec, x).get());
-        this->template log<log::Logger::linop_advanced_apply_completed>(
-            this, alpha, b, beta, x);
+        PolymorphicBase::apply(alpha, b, beta, x);
         return self();
     }
 
     ConcreteLinOp* apply(const LinOp* alpha, const LinOp* b, const LinOp* beta,
                          LinOp* x)
     {
-        this->template log<log::Logger::linop_advanced_apply_started>(
-            this, alpha, b, beta, x);
-        this->validate_application_parameters(alpha, b, beta, x);
-        auto exec = this->get_executor();
-        this->apply_impl(make_temporary_clone(exec, alpha).get(),
-                         make_temporary_clone(exec, b).get(),
-                         make_temporary_clone(exec, beta).get(),
-                         make_temporary_clone(exec, x).get());
-        this->template log<log::Logger::linop_advanced_apply_completed>(
-            this, alpha, b, beta, x);
+        PolymorphicBase::apply(alpha, b, beta, x);
         return self();
     }
 

--- a/include/ginkgo/core/base/polymorphic_object.hpp
+++ b/include/ginkgo/core/base/polymorphic_object.hpp
@@ -363,52 +363,55 @@ public:
         std::shared_ptr<const Executor> exec) const
     {
         return std::unique_ptr<AbstractObject>{static_cast<AbstractObject*>(
-            this->create_default_impl(std::move(exec)).release())};
+            this->PolymorphicBase::create_default(std::move(exec)).release())};
     }
 
     std::unique_ptr<AbstractObject> create_default() const
     {
-        return this->create_default(this->get_executor());
+        return std::unique_ptr<AbstractObject>{static_cast<AbstractObject*>(
+            this->PolymorphicBase::create_default().release())};
     }
 
     std::unique_ptr<AbstractObject> clone(
         std::shared_ptr<const Executor> exec) const
     {
-        auto new_op = this->create_default(exec);
-        new_op->copy_from(this);
-        return new_op;
+        return std::unique_ptr<AbstractObject>{static_cast<AbstractObject*>(
+            this->PolymorphicBase::clone(std::move(exec)).release())};
     }
 
     std::unique_ptr<AbstractObject> clone() const
     {
-        return this->clone(this->get_executor());
+        return std::unique_ptr<AbstractObject>{static_cast<AbstractObject*>(
+            this->PolymorphicBase::clone().release())};
     }
 
     AbstractObject* copy_from(const PolymorphicObject* other)
     {
-        return static_cast<AbstractObject*>(this->copy_from_impl(other));
+        return static_cast<AbstractObject*>(
+            this->PolymorphicBase::copy_from(other));
     }
 
     AbstractObject* copy_from(std::unique_ptr<PolymorphicObject> other)
     {
         return static_cast<AbstractObject*>(
-            this->copy_from_impl(std::move(other)));
+            this->PolymorphicBase::copy_from(std::move(other)));
     }
 
     AbstractObject* move_from(PolymorphicObject* other)
     {
-        return static_cast<AbstractObject*>(this->move_from_impl(other));
+        return static_cast<AbstractObject*>(
+            this->PolymorphicBase::move_from(other));
     }
 
     AbstractObject* move_from(std::unique_ptr<PolymorphicObject> other)
     {
         return static_cast<AbstractObject*>(
-            this->move_from_impl(std::move(other)));
+            this->PolymorphicBase::move_from(std::move(other)));
     }
 
     AbstractObject* clear()
     {
-        return static_cast<AbstractObject*>(this->clear_impl());
+        return static_cast<AbstractObject*>(this->PolymorphicBase::clear());
     }
 };
 

--- a/include/ginkgo/core/solver/solver_base.hpp
+++ b/include/ginkgo/core/solver/solver_base.hpp
@@ -167,7 +167,7 @@ public:
     }
 
 protected:
-    void set_system_matrix(std::shared_ptr<const MatrixType> system_matrix)
+    void set_system_matrix_base(std::shared_ptr<const MatrixType> system_matrix)
     {
         system_matrix_ = std::move(system_matrix);
     }
@@ -242,7 +242,7 @@ protected:
                 new_system_matrix = gko::clone(exec, new_system_matrix);
             }
         }
-        SolverBase<MatrixType>::set_system_matrix(new_system_matrix);
+        this->set_system_matrix_base(new_system_matrix);
     }
 
 private:

--- a/test/solver/solver.cpp
+++ b/test/solver/solver.cpp
@@ -390,7 +390,7 @@ struct DummyLogger : gko::log::Logger {
         iteration_complete++;
     }
 
-    int mutable iteration_complete = 0;
+    mutable int iteration_complete = 0;
 };
 
 

--- a/test/solver/solver.cpp
+++ b/test/solver/solver.cpp
@@ -131,7 +131,7 @@ struct SimpleSolverTest {
         ASSERT_EQ(mtx->get_stopping_criterion_factory(), nullptr);
     }
 
-    static constexpr bool logs_iteration_complete() { return true;}
+    static constexpr bool logs_iteration_complete() { return true; }
 };
 
 
@@ -306,7 +306,7 @@ struct LowerTrs : SimpleSolverTest<gko::solver::LowerTrs<solver_value_type>> {
         return nullptr;
     }
 
-    static constexpr bool logs_iteration_complete() { return false;}
+    static constexpr bool logs_iteration_complete() { return false; }
 };
 
 
@@ -349,7 +349,7 @@ struct UpperTrs : SimpleSolverTest<gko::solver::UpperTrs<solver_value_type>> {
         return nullptr;
     }
 
-    static constexpr bool logs_iteration_complete() { return false;}
+    static constexpr bool logs_iteration_complete() { return false; }
 };
 
 
@@ -956,7 +956,7 @@ TYPED_TEST(Solver, CreateDefaultIsEmpty)
 TYPED_TEST(Solver, LogsIterationComplete)
 {
     using Config = typename TestFixture::Config;
-    if(Config::logs_iteration_complete()) {
+    if (Config::logs_iteration_complete()) {
         using Mtx = typename TestFixture::Mtx;
         using Vec = typename TestFixture::Vec;
         auto mtx = gko::share(Mtx::create(this->exec));


### PR DESCRIPTION
This PR fixes logging used in the following mixins:
- EnablePolymorphicObject
- EnableDefaultLinOpFactory
Before, any class derived from EnablePolymorphicObject would not log the PolymorphicObject events. In the EnableDefaultLinOpFactory case, the generate function with logging is implemented in LinOpFactory, but in the current version this function does not get called. Instead, the default generate function is called (this has also been noted by @upsj).

This removes the adding of loggers from the AbstractFactory, so now only EnableDefaultFactory adds logger, if the concrete type supports it. And additionally, some implementation is simplified. Some tests are added to make sure that we actually log all events.