### PR TITLE
Fix potential memory leak in Logger

### DIFF
--- a/benchmark/preconditioner/preconditioner.cpp
+++ b/benchmark/preconditioner/preconditioner.cpp
@@ -199,7 +199,7 @@ void run_preconditioner(const char* precond_name,
             auto precond = precond_factory.at(precond_name)(exec);
 
             auto gen_logger =
-                std::make_shared<OperationLogger>(exec, FLAGS_nested_names);
+                std::make_shared<OperationLogger>(FLAGS_nested_names);
             exec->add_logger(gen_logger);
             std::unique_ptr<gko::LinOp> precond_op;
             for (auto i = 0u; i < ic_gen.get_num_repetitions(); ++i) {
@@ -211,7 +211,7 @@ void run_preconditioner(const char* precond_name,
                                    allocator, ic_gen.get_num_repetitions());
 
             auto apply_logger =
-                std::make_shared<OperationLogger>(exec, FLAGS_nested_names);
+                std::make_shared<OperationLogger>(FLAGS_nested_names);
             exec->add_logger(apply_logger);
             for (auto i = 0u; i < ic_apply.get_num_repetitions(); ++i) {
                 precond_op->apply(lend(b), lend(x_clone));

--- a/benchmark/solver/solver.cpp
+++ b/benchmark/solver/solver.cpp
@@ -423,7 +423,7 @@ void solve_system(const std::string& solver_name,
             auto x_clone = clone(x);
 
             auto gen_logger =
-                std::make_shared<OperationLogger>(exec, FLAGS_nested_names);
+                std::make_shared<OperationLogger>(FLAGS_nested_names);
             exec->add_logger(gen_logger);
 
             auto precond = precond_factory.at(precond_name)(exec);
@@ -446,7 +446,7 @@ void solve_system(const std::string& solver_name,
             }
 
             auto apply_logger =
-                std::make_shared<OperationLogger>(exec, FLAGS_nested_names);
+                std::make_shared<OperationLogger>(FLAGS_nested_names);
             exec->add_logger(apply_logger);
 
             solver->apply(lend(b), lend(x_clone));
@@ -459,8 +459,7 @@ void solve_system(const std::string& solver_name,
             if (b->get_size()[1] == 1) {
                 x_clone = clone(x);
                 auto res_logger = std::make_shared<ResidualLogger<etype>>(
-                    exec, lend(system_matrix), b,
-                    solver_json["recurrent_residuals"],
+                    lend(system_matrix), b, solver_json["recurrent_residuals"],
                     solver_json["true_residuals"],
                     solver_json["implicit_residuals"],
                     solver_json["iteration_timestamps"], allocator);
@@ -474,7 +473,7 @@ void solve_system(const std::string& solver_name,
         }
 
         // timed run
-        auto it_logger = std::make_shared<IterationLogger>(exec);
+        auto it_logger = std::make_shared<IterationLogger>();
         auto generate_timer = get_timer(exec, FLAGS_gpu_timer);
         auto apply_timer = ic.get_timer();
         auto x_clone = clone(x);

--- a/benchmark/spmv/spmv.cpp
+++ b/benchmark/spmv/spmv.cpp
@@ -73,7 +73,7 @@ void apply_spmv(const char* format_name, std::shared_ptr<gko::Executor> exec,
         add_or_set_member(spmv_case, format_name,
                           rapidjson::Value(rapidjson::kObjectType), allocator);
 
-        auto storage_logger = std::make_shared<StorageLogger>(exec);
+        auto storage_logger = std::make_shared<StorageLogger>();
         exec->add_logger(storage_logger);
         auto system_matrix =
             share(formats::matrix_factory.at(format_name)(exec, data));

--- a/benchmark/utils/loggers.hpp
+++ b/benchmark/utils/loggers.hpp
@@ -116,9 +116,7 @@ struct OperationLogger : gko::log::Logger {
         }
     }
 
-    OperationLogger(std::shared_ptr<const gko::Executor> exec, bool nested_name)
-        : gko::log::Logger(exec), use_nested_name{nested_name}
-    {}
+    OperationLogger(bool nested_name) : use_nested_name{nested_name} {}
 
 private:
     void start_operation(const gko::Executor* exec,
@@ -188,10 +186,6 @@ struct StorageLogger : gko::log::Logger {
         add_or_set_member(output, "storage", total, allocator);
     }
 
-    StorageLogger(std::shared_ptr<const gko::Executor> exec)
-        : gko::log::Logger(exec)
-    {}
-
 private:
     mutable std::mutex mutex;
     mutable std::unordered_map<gko::uintptr, gko::size_type> storage;
@@ -249,14 +243,13 @@ struct ResidualLogger : gko::log::Logger {
         }
     }
 
-    ResidualLogger(std::shared_ptr<const gko::Executor> exec,
-                   const gko::LinOp* matrix, const vec<ValueType>* b,
+    ResidualLogger(const gko::LinOp* matrix, const vec<ValueType>* b,
                    rapidjson::Value& rec_res_norms,
                    rapidjson::Value& true_res_norms,
                    rapidjson::Value& implicit_res_norms,
                    rapidjson::Value& timestamps,
                    rapidjson::MemoryPoolAllocator<>& alloc)
-        : gko::log::Logger(exec, gko::log::Logger::iteration_complete_mask),
+        : gko::log::Logger(gko::log::Logger::iteration_complete_mask),
           matrix{matrix},
           b{b},
           start{std::chrono::steady_clock::now()},
@@ -293,8 +286,8 @@ struct IterationLogger : gko::log::Logger {
         this->num_iters = num_iterations;
     }
 
-    IterationLogger(std::shared_ptr<const gko::Executor> exec)
-        : gko::log::Logger(exec, gko::log::Logger::iteration_complete_mask)
+    IterationLogger()
+        : gko::log::Logger(gko::log::Logger::iteration_complete_mask)
     {}
 
     void write_data(rapidjson::Value& output,

--- a/core/test/base/executor.cpp
+++ b/core/test/base/executor.cpp
@@ -652,10 +652,9 @@ TEST(ExecutorDeleter, AvoidsDeletionForNullExecutor)
 
 
 struct DummyLogger : public gko::log::Logger {
-    DummyLogger(std::shared_ptr<const gko::Executor> exec)
-        : gko::log::Logger(std::move(exec),
-                           gko::log::Logger::executor_events_mask |
-                               gko::log::Logger::operation_events_mask)
+    DummyLogger()
+        : gko::log::Logger(gko::log::Logger::executor_events_mask |
+                           gko::log::Logger::operation_events_mask)
     {}
 
     void on_allocation_started(const gko::Executor* exec,
@@ -729,7 +728,7 @@ class ExecutorLogging : public ::testing::Test {
 protected:
     ExecutorLogging()
         : exec(gko::ReferenceExecutor::create()),
-          logger(std::make_shared<DummyLogger>(exec))
+          logger(std::make_shared<DummyLogger>())
     {
         exec->add_logger(logger);
     }

--- a/core/test/base/lin_op.cpp
+++ b/core/test/base/lin_op.cpp
@@ -49,10 +49,9 @@ namespace {
 
 
 struct DummyLogger : gko::log::Logger {
-    DummyLogger(std::shared_ptr<const gko::Executor> exec)
-        : gko::log::Logger(std::move(exec),
-                           gko::log::Logger::linop_events_mask |
-                               gko::log::Logger::linop_factory_events_mask)
+    DummyLogger()
+        : gko::log::Logger(gko::log::Logger::linop_events_mask |
+                           gko::log::Logger::linop_factory_events_mask)
     {}
 
     void on_linop_apply_started(const gko::LinOp*, const gko::LinOp*,
@@ -155,7 +154,7 @@ protected:
           beta{DummyLinOp::create(ref, gko::dim<2>{1})},
           b{DummyLinOp::create(ref, gko::dim<2>{5, 4})},
           x{DummyLinOp::create(ref, gko::dim<2>{3, 4})},
-          logger{std::make_shared<DummyLogger>(ref)}
+          logger{std::make_shared<DummyLogger>()}
     {
         op->add_logger(logger);
     }
@@ -374,7 +373,7 @@ class EnableLinOpFactory : public ::testing::Test {
 protected:
     EnableLinOpFactory()
         : ref{gko::ReferenceExecutor::create()},
-          logger{std::make_shared<DummyLogger>(ref)}
+          logger{std::make_shared<DummyLogger>()}
     {}
 
     std::shared_ptr<const gko::ReferenceExecutor> ref;

--- a/core/test/base/polymorphic_object.cpp
+++ b/core/test/base/polymorphic_object.cpp
@@ -78,9 +78,8 @@ struct DummyObject : gko::EnablePolymorphicObject<DummyObject>,
 
 
 struct DummyLogger : gko::log::Logger {
-    DummyLogger(std::shared_ptr<const gko::Executor> exec)
-        : gko::log::Logger(std::move(exec),
-                           gko::log::Logger::polymorphic_object_events_mask)
+    DummyLogger()
+        : gko::log::Logger(gko::log::Logger::polymorphic_object_events_mask)
     {}
 
     void on_polymorphic_object_create_started(
@@ -146,7 +145,7 @@ protected:
         gko::ReferenceExecutor::create()};
     std::shared_ptr<gko::OmpExecutor> omp{gko::OmpExecutor::create()};
     std::unique_ptr<DummyObject> obj{new DummyObject(ref, 5)};
-    std::shared_ptr<DummyLogger> logger{std::make_shared<DummyLogger>(ref)};
+    std::shared_ptr<DummyLogger> logger{std::make_shared<DummyLogger>()};
 
     void SetUp() override
     {

--- a/core/test/log/convergence.cpp
+++ b/core/test/log/convergence.cpp
@@ -54,7 +54,7 @@ TYPED_TEST(Convergence, CanGetData)
 {
     auto exec = gko::ReferenceExecutor::create();
     auto logger = gko::log::Convergence<TypeParam>::create(
-        exec, gko::log::Logger::iteration_complete_mask);
+        gko::log::Logger::iteration_complete_mask);
 
     ASSERT_EQ(logger->has_converged(), false);
     ASSERT_EQ(logger->get_num_iterations(), 0);

--- a/core/test/log/logger.cpp
+++ b/core/test/log/logger.cpp
@@ -66,8 +66,8 @@ TEST(DummyLogged, CanAddLogger)
     auto exec = gko::ReferenceExecutor::create();
     DummyLoggedClass c;
 
-    c.add_logger(gko::log::Convergence<>::create(
-        exec, gko::log::Logger::all_events_mask));
+    c.add_logger(
+        gko::log::Convergence<>::create(gko::log::Logger::all_events_mask));
 
     ASSERT_EQ(c.get_num_loggers(), 1);
 }
@@ -78,10 +78,10 @@ TEST(DummyLogged, CanAddMultipleLoggers)
     auto exec = gko::ReferenceExecutor::create();
     DummyLoggedClass c;
 
-    c.add_logger(gko::log::Convergence<>::create(
-        exec, gko::log::Logger::all_events_mask));
-    c.add_logger(gko::log::Stream<>::create(
-        exec, gko::log::Logger::all_events_mask, std::cout));
+    c.add_logger(
+        gko::log::Convergence<>::create(gko::log::Logger::all_events_mask));
+    c.add_logger(gko::log::Stream<>::create(gko::log::Logger::all_events_mask,
+                                            std::cout));
 
     ASSERT_EQ(c.get_num_loggers(), 2);
 }
@@ -92,10 +92,10 @@ TEST(DummyLogged, CanAccessLoggers)
     auto exec = gko::ReferenceExecutor::create();
     DummyLoggedClass c;
 
-    auto logger1 = gko::share(
-        gko::log::Record::create(exec, gko::log::Logger::all_events_mask));
+    auto logger1 =
+        gko::share(gko::log::Record::create(gko::log::Logger::all_events_mask));
     auto logger2 = gko::share(gko::log::Stream<>::create(
-        exec, gko::log::Logger::all_events_mask, std::cout));
+        gko::log::Logger::all_events_mask, std::cout));
 
     c.add_logger(logger1);
     c.add_logger(logger2);
@@ -110,10 +110,9 @@ TEST(DummyLogged, CanClearLoggers)
 {
     auto exec = gko::ReferenceExecutor::create();
     DummyLoggedClass c;
-    c.add_logger(
-        gko::log::Record::create(exec, gko::log::Logger::all_events_mask));
-    c.add_logger(gko::log::Stream<>::create(
-        exec, gko::log::Logger::all_events_mask, std::cout));
+    c.add_logger(gko::log::Record::create(gko::log::Logger::all_events_mask));
+    c.add_logger(gko::log::Stream<>::create(gko::log::Logger::all_events_mask,
+                                            std::cout));
 
     c.clear_loggers();
 
@@ -125,11 +124,11 @@ TEST(DummyLogged, CanRemoveLogger)
 {
     auto exec = gko::ReferenceExecutor::create();
     DummyLoggedClass c;
-    auto r = gko::share(gko::log::Convergence<>::create(
-        exec, gko::log::Logger::all_events_mask));
+    auto r = gko::share(
+        gko::log::Convergence<>::create(gko::log::Logger::all_events_mask));
     c.add_logger(r);
-    c.add_logger(gko::log::Stream<>::create(
-        exec, gko::log::Logger::all_events_mask, std::cout));
+    c.add_logger(gko::log::Stream<>::create(gko::log::Logger::all_events_mask,
+                                            std::cout));
 
     c.remove_logger(gko::lend(r));
 
@@ -140,9 +139,8 @@ struct DummyLogger : gko::log::Logger {
     using Logger = gko::log::Logger;
 
     explicit DummyLogger(
-        std::shared_ptr<const gko::Executor> exec,
         const mask_type& enabled_events = Logger::all_events_mask)
-        : Logger(exec, enabled_events)
+        : Logger(enabled_events)
     {}
 
     void on_iteration_complete(
@@ -161,7 +159,7 @@ TEST(DummyLogged, CanLogEvents)
 {
     auto exec = gko::ReferenceExecutor::create();
     auto l = std::shared_ptr<DummyLogger>(
-        new DummyLogger(exec, gko::log::Logger::iteration_complete_mask));
+        new DummyLogger(gko::log::Logger::iteration_complete_mask));
     DummyLoggedClass c;
     c.add_logger(l);
 

--- a/core/test/log/record.cpp
+++ b/core/test/log/record.cpp
@@ -55,8 +55,8 @@ const std::string apply_str = "Dummy::apply";
 TEST(Record, CanGetData)
 {
     auto exec = gko::ReferenceExecutor::create();
-    auto logger = gko::log::Record::create(
-        exec, gko::log::Logger::iteration_complete_mask);
+    auto logger =
+        gko::log::Record::create(gko::log::Logger::iteration_complete_mask);
 
     ASSERT_EQ(logger->get().allocation_started.size(), 0);
 }
@@ -65,8 +65,8 @@ TEST(Record, CanGetData)
 TEST(Record, CatchesAllocationStarted)
 {
     auto exec = gko::ReferenceExecutor::create();
-    auto logger = gko::log::Record::create(
-        exec, gko::log::Logger::allocation_started_mask);
+    auto logger =
+        gko::log::Record::create(gko::log::Logger::allocation_started_mask);
 
     logger->on<gko::log::Logger::allocation_started>(exec.get(), 42);
 
@@ -80,8 +80,8 @@ TEST(Record, CatchesAllocationStarted)
 TEST(Record, CatchesAllocationCompleted)
 {
     auto exec = gko::ReferenceExecutor::create();
-    auto logger = gko::log::Record::create(
-        exec, gko::log::Logger::allocation_completed_mask);
+    auto logger =
+        gko::log::Record::create(gko::log::Logger::allocation_completed_mask);
     int dummy = 1;
     auto ptr = reinterpret_cast<gko::uintptr>(&dummy);
 
@@ -97,8 +97,7 @@ TEST(Record, CatchesAllocationCompleted)
 TEST(Record, CatchesFreeStarted)
 {
     auto exec = gko::ReferenceExecutor::create();
-    auto logger =
-        gko::log::Record::create(exec, gko::log::Logger::free_started_mask);
+    auto logger = gko::log::Record::create(gko::log::Logger::free_started_mask);
     int dummy = 1;
     auto ptr = reinterpret_cast<gko::uintptr>(&dummy);
 
@@ -115,7 +114,7 @@ TEST(Record, CatchesFreeCompleted)
 {
     auto exec = gko::ReferenceExecutor::create();
     auto logger =
-        gko::log::Record::create(exec, gko::log::Logger::free_completed_mask);
+        gko::log::Record::create(gko::log::Logger::free_completed_mask);
     int dummy = 1;
     auto ptr = reinterpret_cast<gko::uintptr>(&dummy);
 
@@ -131,8 +130,7 @@ TEST(Record, CatchesFreeCompleted)
 TEST(Record, CatchesCopyStarted)
 {
     auto exec = gko::ReferenceExecutor::create();
-    auto logger =
-        gko::log::Record::create(exec, gko::log::Logger::copy_started_mask);
+    auto logger = gko::log::Record::create(gko::log::Logger::copy_started_mask);
     int dummy_from = 1;
     int dummy_to = 1;
     auto ptr_from = reinterpret_cast<gko::uintptr>(&dummy_from);
@@ -157,7 +155,7 @@ TEST(Record, CatchesCopyCompleted)
 {
     auto exec = gko::ReferenceExecutor::create();
     auto logger =
-        gko::log::Record::create(exec, gko::log::Logger::copy_completed_mask);
+        gko::log::Record::create(gko::log::Logger::copy_completed_mask);
     int dummy_from = 1;
     int dummy_to = 1;
     auto ptr_from = reinterpret_cast<gko::uintptr>(&dummy_from);
@@ -181,8 +179,8 @@ TEST(Record, CatchesCopyCompleted)
 TEST(Record, CatchesOperationLaunched)
 {
     auto exec = gko::ReferenceExecutor::create();
-    auto logger = gko::log::Record::create(
-        exec, gko::log::Logger::operation_launched_mask);
+    auto logger =
+        gko::log::Record::create(gko::log::Logger::operation_launched_mask);
     gko::Operation op;
 
     logger->on<gko::log::Logger::operation_launched>(exec.get(), &op);
@@ -196,8 +194,8 @@ TEST(Record, CatchesOperationLaunched)
 TEST(Record, CatchesOperationCompleted)
 {
     auto exec = gko::ReferenceExecutor::create();
-    auto logger = gko::log::Record::create(
-        exec, gko::log::Logger::operation_completed_mask);
+    auto logger =
+        gko::log::Record::create(gko::log::Logger::operation_completed_mask);
     gko::Operation op;
 
     logger->on<gko::log::Logger::operation_completed>(exec.get(), &op);
@@ -213,7 +211,7 @@ TEST(Record, CatchesPolymorphicObjectCreateStarted)
     using Dense = gko::matrix::Dense<>;
     auto exec = gko::ReferenceExecutor::create();
     auto logger = gko::log::Record::create(
-        exec, gko::log::Logger::polymorphic_object_create_started_mask);
+        gko::log::Logger::polymorphic_object_create_started_mask);
     auto po = gko::matrix::Dense<>::create(exec);
 
     logger->on<gko::log::Logger::polymorphic_object_create_started>(exec.get(),
@@ -232,7 +230,7 @@ TEST(Record, CatchesPolymorphicObjectCreateCompleted)
     using Dense = gko::matrix::Dense<>;
     auto exec = gko::ReferenceExecutor::create();
     auto logger = gko::log::Record::create(
-        exec, gko::log::Logger::polymorphic_object_create_completed_mask);
+        gko::log::Logger::polymorphic_object_create_completed_mask);
     auto po = gko::matrix::Dense<>::create(exec);
     auto output = gko::matrix::Dense<>::create(exec);
 
@@ -251,7 +249,7 @@ TEST(Record, CatchesPolymorphicObjectCopyStarted)
     using Dense = gko::matrix::Dense<>;
     auto exec = gko::ReferenceExecutor::create();
     auto logger = gko::log::Record::create(
-        exec, gko::log::Logger::polymorphic_object_copy_started_mask);
+        gko::log::Logger::polymorphic_object_copy_started_mask);
     auto from = gko::matrix::Dense<>::create(exec);
     auto to = gko::matrix::Dense<>::create(exec);
 
@@ -270,7 +268,7 @@ TEST(Record, CatchesPolymorphicObjectCopyCompleted)
     using Dense = gko::matrix::Dense<>;
     auto exec = gko::ReferenceExecutor::create();
     auto logger = gko::log::Record::create(
-        exec, gko::log::Logger::polymorphic_object_copy_completed_mask);
+        gko::log::Logger::polymorphic_object_copy_completed_mask);
     auto from = gko::matrix::Dense<>::create(exec);
     auto to = gko::matrix::Dense<>::create(exec);
 
@@ -290,7 +288,7 @@ TEST(Record, CatchesPolymorphicObjectMoveStarted)
     using Dense = gko::matrix::Dense<>;
     auto exec = gko::ReferenceExecutor::create();
     auto logger = gko::log::Record::create(
-        exec, gko::log::Logger::polymorphic_object_move_started_mask);
+        gko::log::Logger::polymorphic_object_move_started_mask);
     auto from = gko::matrix::Dense<>::create(exec);
     auto to = gko::matrix::Dense<>::create(exec);
 
@@ -309,7 +307,7 @@ TEST(Record, CatchesPolymorphicObjectMoveCompleted)
     using Dense = gko::matrix::Dense<>;
     auto exec = gko::ReferenceExecutor::create();
     auto logger = gko::log::Record::create(
-        exec, gko::log::Logger::polymorphic_object_move_completed_mask);
+        gko::log::Logger::polymorphic_object_move_completed_mask);
     auto from = gko::matrix::Dense<>::create(exec);
     auto to = gko::matrix::Dense<>::create(exec);
 
@@ -329,7 +327,7 @@ TEST(Record, CatchesPolymorphicObjectDeleted)
     using Dense = gko::matrix::Dense<>;
     auto exec = gko::ReferenceExecutor::create();
     auto logger = gko::log::Record::create(
-        exec, gko::log::Logger::polymorphic_object_deleted_mask);
+        gko::log::Logger::polymorphic_object_deleted_mask);
     auto po = gko::matrix::Dense<>::create(exec);
 
     logger->on<gko::log::Logger::polymorphic_object_deleted>(exec.get(),
@@ -347,8 +345,8 @@ TEST(Record, CatchesLinOpApplyStarted)
 {
     using Dense = gko::matrix::Dense<>;
     auto exec = gko::ReferenceExecutor::create();
-    auto logger = gko::log::Record::create(
-        exec, gko::log::Logger::linop_apply_started_mask);
+    auto logger =
+        gko::log::Record::create(gko::log::Logger::linop_apply_started_mask);
     auto A = gko::initialize<Dense>({1.1}, exec);
     auto b = gko::initialize<Dense>({-2.2}, exec);
     auto x = gko::initialize<Dense>({3.3}, exec);
@@ -369,8 +367,8 @@ TEST(Record, CatchesLinOpApplyCompleted)
 {
     using Dense = gko::matrix::Dense<>;
     auto exec = gko::ReferenceExecutor::create();
-    auto logger = gko::log::Record::create(
-        exec, gko::log::Logger::linop_apply_completed_mask);
+    auto logger =
+        gko::log::Record::create(gko::log::Logger::linop_apply_completed_mask);
     auto A = gko::initialize<Dense>({1.1}, exec);
     auto b = gko::initialize<Dense>({-2.2}, exec);
     auto x = gko::initialize<Dense>({3.3}, exec);
@@ -392,7 +390,7 @@ TEST(Record, CatchesLinOpAdvancedApplyStarted)
     using Dense = gko::matrix::Dense<>;
     auto exec = gko::ReferenceExecutor::create();
     auto logger = gko::log::Record::create(
-        exec, gko::log::Logger::linop_advanced_apply_started_mask);
+        gko::log::Logger::linop_advanced_apply_started_mask);
     auto A = gko::initialize<Dense>({1.1}, exec);
     auto alpha = gko::initialize<Dense>({-4.4}, exec);
     auto b = gko::initialize<Dense>({-2.2}, exec);
@@ -416,7 +414,7 @@ TEST(Record, CatchesLinOpAdvancedApplyCompleted)
     using Dense = gko::matrix::Dense<>;
     auto exec = gko::ReferenceExecutor::create();
     auto logger = gko::log::Record::create(
-        exec, gko::log::Logger::linop_advanced_apply_completed_mask);
+        gko::log::Logger::linop_advanced_apply_completed_mask);
     auto A = gko::initialize<Dense>({1.1}, exec);
     auto alpha = gko::initialize<Dense>({-4.4}, exec);
     auto b = gko::initialize<Dense>({-2.2}, exec);
@@ -439,7 +437,7 @@ TEST(Record, CatchesLinopFactoryGenerateStarted)
 {
     auto exec = gko::ReferenceExecutor::create();
     auto logger = gko::log::Record::create(
-        exec, gko::log::Logger::linop_factory_generate_started_mask);
+        gko::log::Logger::linop_factory_generate_started_mask);
     auto factory =
         gko::solver::Bicgstab<>::build()
             .with_criteria(
@@ -461,7 +459,7 @@ TEST(Record, CatchesLinopFactoryGenerateCompleted)
 {
     auto exec = gko::ReferenceExecutor::create();
     auto logger = gko::log::Record::create(
-        exec, gko::log::Logger::linop_factory_generate_completed_mask);
+        gko::log::Logger::linop_factory_generate_completed_mask);
     auto factory =
         gko::solver::Bicgstab<>::build()
             .with_criteria(
@@ -484,7 +482,7 @@ TEST(Record, CatchesCriterionCheckStarted)
 {
     auto exec = gko::ReferenceExecutor::create();
     auto logger = gko::log::Record::create(
-        exec, gko::log::Logger::criterion_check_started_mask);
+        gko::log::Logger::criterion_check_started_mask);
     auto criterion =
         gko::stop::Iteration::build().with_max_iters(3u).on(exec)->generate(
             nullptr, nullptr, nullptr);
@@ -507,7 +505,7 @@ TEST(Record, CatchesCriterionCheckCompletedOld)
 {
     auto exec = gko::ReferenceExecutor::create();
     auto logger = gko::log::Record::create(
-        exec, gko::log::Logger::criterion_check_completed_mask);
+        gko::log::Logger::criterion_check_completed_mask);
     auto criterion =
         gko::stop::Iteration::build().with_max_iters(3u).on(exec)->generate(
             nullptr, nullptr, nullptr);
@@ -537,7 +535,7 @@ TEST(Record, CatchesCriterionCheckCompleted)
 {
     auto exec = gko::ReferenceExecutor::create();
     auto logger = gko::log::Record::create(
-        exec, gko::log::Logger::criterion_check_completed_mask);
+        gko::log::Logger::criterion_check_completed_mask);
     auto criterion =
         gko::stop::Iteration::build().with_max_iters(3u).on(exec)->generate(
             nullptr, nullptr, nullptr);
@@ -567,8 +565,8 @@ TEST(Record, CatchesIterations)
 {
     using Dense = gko::matrix::Dense<>;
     auto exec = gko::ReferenceExecutor::create();
-    auto logger = gko::log::Record::create(
-        exec, gko::log::Logger::iteration_complete_mask);
+    auto logger =
+        gko::log::Record::create(gko::log::Logger::iteration_complete_mask);
     auto factory =
         gko::solver::Bicgstab<>::build()
             .with_criteria(

--- a/core/test/log/stream.cpp
+++ b/core/test/log/stream.cpp
@@ -67,7 +67,7 @@ TYPED_TEST(Stream, CatchesAllocationStarted)
     auto exec = gko::ReferenceExecutor::create();
     std::stringstream out;
     auto logger = gko::log::Stream<TypeParam>::create(
-        exec, gko::log::Logger::allocation_started_mask, out);
+        gko::log::Logger::allocation_started_mask, out);
 
     logger->template on<gko::log::Logger::allocation_started>(exec.get(), 42);
 
@@ -82,7 +82,7 @@ TYPED_TEST(Stream, CatchesAllocationCompleted)
     auto exec = gko::ReferenceExecutor::create();
     std::stringstream out;
     auto logger = gko::log::Stream<TypeParam>::create(
-        exec, gko::log::Logger::allocation_completed_mask, out);
+        gko::log::Logger::allocation_completed_mask, out);
     int dummy = 1;
     std::stringstream ptrstream;
     ptrstream << std::hex << "0x" << reinterpret_cast<gko::uintptr>(&dummy);
@@ -102,7 +102,7 @@ TYPED_TEST(Stream, CatchesFreeStarted)
     auto exec = gko::ReferenceExecutor::create();
     std::stringstream out;
     auto logger = gko::log::Stream<TypeParam>::create(
-        exec, gko::log::Logger::free_started_mask, out);
+        gko::log::Logger::free_started_mask, out);
     int dummy = 1;
     std::stringstream ptrstream;
     ptrstream << std::hex << "0x" << reinterpret_cast<gko::uintptr>(&dummy);
@@ -121,7 +121,7 @@ TYPED_TEST(Stream, CatchesFreeCompleted)
     auto exec = gko::ReferenceExecutor::create();
     std::stringstream out;
     auto logger = gko::log::Stream<TypeParam>::create(
-        exec, gko::log::Logger::free_completed_mask, out);
+        gko::log::Logger::free_completed_mask, out);
     int dummy = 1;
     std::stringstream ptrstream;
     ptrstream << std::hex << "0x" << reinterpret_cast<gko::uintptr>(&dummy);
@@ -140,7 +140,7 @@ TYPED_TEST(Stream, CatchesCopyStarted)
     auto exec = gko::ReferenceExecutor::create();
     std::stringstream out;
     auto logger = gko::log::Stream<TypeParam>::create(
-        exec, gko::log::Logger::copy_started_mask, out);
+        gko::log::Logger::copy_started_mask, out);
     int dummy_in = 1;
     int dummy_out = 1;
     std::stringstream ptrstream_in;
@@ -167,7 +167,7 @@ TYPED_TEST(Stream, CatchesCopyCompleted)
     auto exec = gko::ReferenceExecutor::create();
     std::stringstream out;
     auto logger = gko::log::Stream<TypeParam>::create(
-        exec, gko::log::Logger::copy_completed_mask, out);
+        gko::log::Logger::copy_completed_mask, out);
     int dummy_in = 1;
     int dummy_out = 1;
     std::stringstream ptrstream_in;
@@ -194,7 +194,7 @@ TYPED_TEST(Stream, CatchesOperationLaunched)
     auto exec = gko::ReferenceExecutor::create();
     std::stringstream out;
     auto logger = gko::log::Stream<TypeParam>::create(
-        exec, gko::log::Logger::operation_launched_mask, out);
+        gko::log::Logger::operation_launched_mask, out);
     gko::Operation op;
     std::stringstream ptrstream;
     ptrstream << &op;
@@ -212,7 +212,7 @@ TYPED_TEST(Stream, CatchesOperationCompleted)
     auto exec = gko::ReferenceExecutor::create();
     std::stringstream out;
     auto logger = gko::log::Stream<TypeParam>::create(
-        exec, gko::log::Logger::operation_completed_mask, out);
+        gko::log::Logger::operation_completed_mask, out);
     gko::Operation op;
     std::stringstream ptrstream;
     ptrstream << &op;
@@ -230,7 +230,7 @@ TYPED_TEST(Stream, CatchesPolymorphicObjectCreateStarted)
     auto exec = gko::ReferenceExecutor::create();
     std::stringstream out;
     auto logger = gko::log::Stream<TypeParam>::create(
-        exec, gko::log::Logger::polymorphic_object_create_started_mask, out);
+        gko::log::Logger::polymorphic_object_create_started_mask, out);
     auto po = gko::matrix::Dense<TypeParam>::create(exec);
     std::stringstream ptrstream;
     ptrstream << po.get();
@@ -249,7 +249,7 @@ TYPED_TEST(Stream, CatchesPolymorphicObjectCreateCompleted)
     auto exec = gko::ReferenceExecutor::create();
     std::stringstream out;
     auto logger = gko::log::Stream<TypeParam>::create(
-        exec, gko::log::Logger::polymorphic_object_create_completed_mask, out);
+        gko::log::Logger::polymorphic_object_create_completed_mask, out);
     auto po = gko::matrix::Dense<TypeParam>::create(exec);
     auto output = gko::matrix::Dense<TypeParam>::create(exec);
     std::stringstream ptrstream_in;
@@ -272,7 +272,7 @@ TYPED_TEST(Stream, CatchesPolymorphicObjectCopyStarted)
     auto exec = gko::ReferenceExecutor::create();
     std::stringstream out;
     auto logger = gko::log::Stream<TypeParam>::create(
-        exec, gko::log::Logger::polymorphic_object_copy_started_mask, out);
+        gko::log::Logger::polymorphic_object_copy_started_mask, out);
     auto from = gko::matrix::Dense<TypeParam>::create(exec);
     auto to = gko::matrix::Dense<TypeParam>::create(exec);
     std::stringstream ptrstream_from;
@@ -295,7 +295,7 @@ TYPED_TEST(Stream, CatchesPolymorphicObjectCopyCompleted)
     auto exec = gko::ReferenceExecutor::create();
     std::stringstream out;
     auto logger = gko::log::Stream<TypeParam>::create(
-        exec, gko::log::Logger::polymorphic_object_copy_completed_mask, out);
+        gko::log::Logger::polymorphic_object_copy_completed_mask, out);
     auto from = gko::matrix::Dense<TypeParam>::create(exec);
     auto to = gko::matrix::Dense<TypeParam>::create(exec);
     std::stringstream ptrstream_from;
@@ -318,7 +318,7 @@ TYPED_TEST(Stream, CatchesPolymorphicObjectMoveStarted)
     auto exec = gko::ReferenceExecutor::create();
     std::stringstream out;
     auto logger = gko::log::Stream<TypeParam>::create(
-        exec, gko::log::Logger::polymorphic_object_move_started_mask, out);
+        gko::log::Logger::polymorphic_object_move_started_mask, out);
     auto from = gko::matrix::Dense<TypeParam>::create(exec);
     auto to = gko::matrix::Dense<TypeParam>::create(exec);
     std::stringstream ptrstream_from;
@@ -341,7 +341,7 @@ TYPED_TEST(Stream, CatchesPolymorphicObjectMoveCompleted)
     auto exec = gko::ReferenceExecutor::create();
     std::stringstream out;
     auto logger = gko::log::Stream<TypeParam>::create(
-        exec, gko::log::Logger::polymorphic_object_move_completed_mask, out);
+        gko::log::Logger::polymorphic_object_move_completed_mask, out);
     auto from = gko::matrix::Dense<TypeParam>::create(exec);
     auto to = gko::matrix::Dense<TypeParam>::create(exec);
     std::stringstream ptrstream_from;
@@ -364,7 +364,7 @@ TYPED_TEST(Stream, CatchesPolymorphicObjectDeleted)
     auto exec = gko::ReferenceExecutor::create();
     std::stringstream out;
     auto logger = gko::log::Stream<TypeParam>::create(
-        exec, gko::log::Logger::polymorphic_object_deleted_mask, out);
+        gko::log::Logger::polymorphic_object_deleted_mask, out);
     auto po = gko::matrix::Dense<TypeParam>::create(exec);
     std::stringstream ptrstream;
     ptrstream << po.get();
@@ -384,7 +384,7 @@ TYPED_TEST(Stream, CatchesLinOpApplyStarted)
     auto exec = gko::ReferenceExecutor::create();
     std::stringstream out;
     auto logger = gko::log::Stream<TypeParam>::create(
-        exec, gko::log::Logger::linop_apply_started_mask, out);
+        gko::log::Logger::linop_apply_started_mask, out);
     auto A = Dense::create(exec);
     auto b = Dense::create(exec);
     auto x = Dense::create(exec);
@@ -412,7 +412,7 @@ TYPED_TEST(Stream, CatchesLinOpApplyStartedWithVerbose)
     auto exec = gko::ReferenceExecutor::create();
     std::stringstream out;
     auto logger = gko::log::Stream<TypeParam>::create(
-        exec, gko::log::Logger::linop_apply_started_mask, out, true);
+        gko::log::Logger::linop_apply_started_mask, out, true);
     auto A = gko::initialize<Dense>({1.1}, exec);
     auto b = gko::initialize<Dense>({-2.2}, exec);
     auto x = gko::initialize<Dense>({3.3}, exec);
@@ -433,7 +433,7 @@ TYPED_TEST(Stream, CatchesLinOpApplyCompleted)
     auto exec = gko::ReferenceExecutor::create();
     std::stringstream out;
     auto logger = gko::log::Stream<TypeParam>::create(
-        exec, gko::log::Logger::linop_apply_completed_mask, out);
+        gko::log::Logger::linop_apply_completed_mask, out);
     auto A = Dense::create(exec);
     auto b = Dense::create(exec);
     auto x = Dense::create(exec);
@@ -461,7 +461,7 @@ TYPED_TEST(Stream, CatchesLinOpApplyCompletedWithVerbose)
     auto exec = gko::ReferenceExecutor::create();
     std::stringstream out;
     auto logger = gko::log::Stream<TypeParam>::create(
-        exec, gko::log::Logger::linop_apply_completed_mask, out, true);
+        gko::log::Logger::linop_apply_completed_mask, out, true);
     auto A = gko::initialize<Dense>({1.1}, exec);
     auto b = gko::initialize<Dense>({-2.2}, exec);
     auto x = gko::initialize<Dense>({3.3}, exec);
@@ -482,7 +482,7 @@ TYPED_TEST(Stream, CatchesLinOpAdvancedApplyStarted)
     auto exec = gko::ReferenceExecutor::create();
     std::stringstream out;
     auto logger = gko::log::Stream<TypeParam>::create(
-        exec, gko::log::Logger::linop_advanced_apply_started_mask, out);
+        gko::log::Logger::linop_advanced_apply_started_mask, out);
     auto A = Dense::create(exec);
     auto alpha = Dense::create(exec);
     auto b = Dense::create(exec);
@@ -518,7 +518,7 @@ TYPED_TEST(Stream, CatchesLinOpAdvancedApplyStartedWithVerbose)
     auto exec = gko::ReferenceExecutor::create();
     std::stringstream out;
     auto logger = gko::log::Stream<TypeParam>::create(
-        exec, gko::log::Logger::linop_advanced_apply_started_mask, out, true);
+        gko::log::Logger::linop_advanced_apply_started_mask, out, true);
     auto A = gko::initialize<Dense>({1.1}, exec);
     auto alpha = gko::initialize<Dense>({-4.4}, exec);
     auto b = gko::initialize<Dense>({-2.2}, exec);
@@ -543,7 +543,7 @@ TYPED_TEST(Stream, CatchesLinOpAdvancedApplyCompleted)
     auto exec = gko::ReferenceExecutor::create();
     std::stringstream out;
     auto logger = gko::log::Stream<TypeParam>::create(
-        exec, gko::log::Logger::linop_advanced_apply_completed_mask, out);
+        gko::log::Logger::linop_advanced_apply_completed_mask, out);
     auto A = Dense::create(exec);
     auto alpha = Dense::create(exec);
     auto b = Dense::create(exec);
@@ -579,7 +579,7 @@ TYPED_TEST(Stream, CatchesLinOpAdvancedApplyCompletedWithVerbose)
     auto exec = gko::ReferenceExecutor::create();
     std::stringstream out;
     auto logger = gko::log::Stream<TypeParam>::create(
-        exec, gko::log::Logger::linop_advanced_apply_completed_mask, out, true);
+        gko::log::Logger::linop_advanced_apply_completed_mask, out, true);
     auto A = gko::initialize<Dense>({1.1}, exec);
     auto alpha = gko::initialize<Dense>({-4.4}, exec);
     auto b = gko::initialize<Dense>({-2.2}, exec);
@@ -603,7 +603,7 @@ TYPED_TEST(Stream, CatchesLinopFactoryGenerateStarted)
     auto exec = gko::ReferenceExecutor::create();
     std::stringstream out;
     auto logger = gko::log::Stream<TypeParam>::create(
-        exec, gko::log::Logger::linop_factory_generate_started_mask, out);
+        gko::log::Logger::linop_factory_generate_started_mask, out);
     auto factory =
         gko::solver::Bicgstab<TypeParam>::build()
             .with_criteria(
@@ -630,7 +630,7 @@ TYPED_TEST(Stream, CatchesLinopFactoryGenerateCompleted)
     auto exec = gko::ReferenceExecutor::create();
     std::stringstream out;
     auto logger = gko::log::Stream<TypeParam>::create(
-        exec, gko::log::Logger::linop_factory_generate_completed_mask, out);
+        gko::log::Logger::linop_factory_generate_completed_mask, out);
     auto factory =
         gko::solver::Bicgstab<TypeParam>::build()
             .with_criteria(
@@ -662,7 +662,7 @@ TYPED_TEST(Stream, CatchesCriterionCheckStarted)
     auto exec = gko::ReferenceExecutor::create();
     std::stringstream out;
     auto logger = gko::log::Stream<TypeParam>::create(
-        exec, gko::log::Logger::criterion_check_started_mask, out);
+        gko::log::Logger::criterion_check_started_mask, out);
     auto criterion =
         gko::stop::Iteration::build().with_max_iters(3u).on(exec)->generate(
             nullptr, nullptr, nullptr);
@@ -689,7 +689,7 @@ TYPED_TEST(Stream, CatchesCriterionCheckCompleted)
     auto exec = gko::ReferenceExecutor::create();
     std::stringstream out;
     auto logger = gko::log::Stream<TypeParam>::create(
-        exec, gko::log::Logger::criterion_check_completed_mask, out);
+        gko::log::Logger::criterion_check_completed_mask, out);
     auto criterion =
         gko::stop::Iteration::build().with_max_iters(3u).on(exec)->generate(
             nullptr, nullptr, nullptr);
@@ -720,7 +720,7 @@ TYPED_TEST(Stream, CatchesCriterionCheckCompletedWithVerbose)
     auto exec = gko::ReferenceExecutor::create();
     std::stringstream out;
     auto logger = gko::log::Stream<TypeParam>::create(
-        exec, gko::log::Logger::criterion_check_completed_mask, out, true);
+        gko::log::Logger::criterion_check_completed_mask, out, true);
     auto criterion =
         gko::stop::Iteration::build().with_max_iters(3u).on(exec)->generate(
             nullptr, nullptr, nullptr);
@@ -749,7 +749,7 @@ TYPED_TEST(Stream, CatchesIterations)
     auto exec = gko::ReferenceExecutor::create();
     std::stringstream out;
     auto logger = gko::log::Stream<TypeParam>::create(
-        exec, gko::log::Logger::iteration_complete_mask, out);
+        gko::log::Logger::iteration_complete_mask, out);
     auto solver = Dense::create(exec);
     auto residual = Dense::create(exec);
     auto solution = Dense::create(exec);
@@ -777,7 +777,7 @@ TYPED_TEST(Stream, CatchesIterationsWithVerbose)
     auto exec = gko::ReferenceExecutor::create();
     std::stringstream out;
     auto logger = gko::log::Stream<TypeParam>::create(
-        exec, gko::log::Logger::iteration_complete_mask, out, true);
+        gko::log::Logger::iteration_complete_mask, out, true);
 
     auto factory =
         gko::solver::Bicgstab<TypeParam>::build()

--- a/core/test/stop/criterion.cpp
+++ b/core/test/stop/criterion.cpp
@@ -40,10 +40,7 @@ namespace {
 
 
 struct DummyLogger : public gko::log::Logger {
-    DummyLogger(std::shared_ptr<const gko::Executor> exec)
-        : gko::log::Logger(std::move(exec),
-                           gko::log::Logger::criterion_events_mask)
-    {}
+    DummyLogger() : gko::log::Logger(gko::log::Logger::criterion_events_mask) {}
 
     void on_criterion_check_started(const gko::stop::Criterion* criterion,
                                     const gko::size_type& num_iterations,
@@ -101,7 +98,7 @@ protected:
         : exec{gko::ReferenceExecutor::create()},
           criterion{std::make_unique<DummyCriterion>(exec)},
           stopping_status{exec},
-          logger{std::make_shared<DummyLogger>(exec)}
+          logger{std::make_shared<DummyLogger>()}
     {
         criterion->add_logger(logger);
     }

--- a/examples/adaptiveprecision-blockjacobi/adaptiveprecision-blockjacobi.cpp
+++ b/examples/adaptiveprecision-blockjacobi/adaptiveprecision-blockjacobi.cpp
@@ -114,7 +114,7 @@ int main(int argc, char* argv[])
                                    .on(exec));
 
     std::shared_ptr<const gko::log::Convergence<ValueType>> logger =
-        gko::log::Convergence<ValueType>::create(exec);
+        gko::log::Convergence<ValueType>::create();
     iter_stop->add_logger(logger);
     tol_stop->add_logger(logger);
 

--- a/examples/custom-logger/custom-logger.cpp
+++ b/examples/custom-logger/custom-logger.cpp
@@ -195,9 +195,8 @@ struct ResidualLogger : gko::log::Logger {
     }
 
     // Construct the logger and store the system matrix and b vectors
-    ResidualLogger(std::shared_ptr<const gko::Executor> exec,
-                   const gko::LinOp* matrix, const gko_dense* b)
-        : gko::log::Logger(exec, gko::log::Logger::iteration_complete_mask),
+    ResidualLogger(const gko::LinOp* matrix, const gko_dense* b)
+        : gko::log::Logger(gko::log::Logger::iteration_complete_mask),
           matrix{matrix},
           b{b}
     {}
@@ -312,8 +311,8 @@ int main(int argc, char* argv[])
             .on(exec);
 
     // Instantiate a ResidualLogger logger.
-    auto logger = std::make_shared<ResidualLogger<ValueType>>(
-        exec, gko::lend(A), gko::lend(b));
+    auto logger =
+        std::make_shared<ResidualLogger<ValueType>>(gko::lend(A), gko::lend(b));
 
     // Add the previously created logger to the solver factory. The logger
     // will be automatically propagated to all solvers created from this

--- a/examples/custom-stopping-criterion/custom-stopping-criterion.cpp
+++ b/examples/custom-stopping-criterion/custom-stopping-criterion.cpp
@@ -117,7 +117,7 @@ void run_solver(volatile bool* stop_iteration_process,
                       .on(exec)
                       ->generate(A);
     solver->add_logger(gko::log::Stream<ValueType>::create(
-        exec, gko::log::Logger::iteration_complete_mask, std::cout, true));
+        gko::log::Logger::iteration_complete_mask, std::cout, true));
     solver->apply(lend(b), lend(x));
 
     std::cout << "Solver stopped" << std::endl;

--- a/examples/ir-ilu-preconditioned-solver/ir-ilu-preconditioned-solver.cpp
+++ b/examples/ir-ilu-preconditioned-solver/ir-ilu-preconditioned-solver.cpp
@@ -145,7 +145,7 @@ int main(int argc, char* argv[])
                                    .on(exec));
 
     std::shared_ptr<const gko::log::Convergence<ValueType>> logger =
-        gko::log::Convergence<ValueType>::create(exec);
+        gko::log::Convergence<ValueType>::create();
     iter_stop->add_logger(logger);
     tol_stop->add_logger(logger);
 

--- a/examples/iterative-refinement/iterative-refinement.cpp
+++ b/examples/iterative-refinement/iterative-refinement.cpp
@@ -117,7 +117,7 @@ int main(int argc, char* argv[])
                        .on(exec));
 
     std::shared_ptr<const gko::log::Convergence<ValueType>> logger =
-        gko::log::Convergence<ValueType>::create(exec);
+        gko::log::Convergence<ValueType>::create();
     iter_stop->add_logger(logger);
     tol_stop->add_logger(logger);
 

--- a/examples/mixed-multigrid-solver/mixed-multigrid-solver.cpp
+++ b/examples/mixed-multigrid-solver/mixed-multigrid-solver.cpp
@@ -122,7 +122,7 @@ int main(int argc, char* argv[])
                        .on(exec));
 
     std::shared_ptr<const gko::log::Convergence<ValueType>> logger =
-        gko::log::Convergence<ValueType>::create(exec);
+        gko::log::Convergence<ValueType>::create();
     iter_stop->add_logger(logger);
     tol_stop->add_logger(logger);
 

--- a/examples/multigrid-preconditioned-solver/multigrid-preconditioned-solver.cpp
+++ b/examples/multigrid-preconditioned-solver/multigrid-preconditioned-solver.cpp
@@ -118,7 +118,7 @@ int main(int argc, char* argv[])
                        .on(exec));
 
     std::shared_ptr<const gko::log::Convergence<ValueType>> logger =
-        gko::log::Convergence<ValueType>::create(exec);
+        gko::log::Convergence<ValueType>::create();
     iter_stop->add_logger(logger);
     tol_stop->add_logger(logger);
 

--- a/examples/simple-solver-logging/simple-solver-logging.cpp
+++ b/examples/simple-solver-logging/simple-solver-logging.cpp
@@ -114,7 +114,6 @@ int main(int argc, char* argv[])
     // for convenience.
     std::shared_ptr<gko::log::Stream<ValueType>> stream_logger =
         gko::log::Stream<ValueType>::create(
-            exec,
             gko::log::Logger::all_events_mask ^
                 gko::log::Logger::linop_factory_events_mask ^
                 gko::log::Logger::polymorphic_object_events_mask,
@@ -151,15 +150,15 @@ int main(int argc, char* argv[])
     // Logger class for more information.
     std::ofstream filestream("my_file.txt");
     solver->add_logger(gko::log::Stream<ValueType>::create(
-        exec, gko::log::Logger::all_events_mask, filestream));
+        gko::log::Logger::all_events_mask, filestream));
     solver->add_logger(stream_logger);
 
     // Add another logger which puts all the data in an object, we can later
     // retrieve this object in our code. Here we only have want Executor
     // and criterion check completed events.
     std::shared_ptr<gko::log::Record> record_logger = gko::log::Record::create(
-        exec, gko::log::Logger::executor_events_mask |
-                  gko::log::Logger::criterion_check_completed_mask);
+        gko::log::Logger::executor_events_mask |
+        gko::log::Logger::criterion_check_completed_mask);
     exec->add_logger(record_logger);
     residual_criterion->add_logger(record_logger);
 

--- a/include/ginkgo/core/log/convergence.hpp
+++ b/include/ginkgo/core/log/convergence.hpp
@@ -94,12 +94,31 @@ public:
      * dependencies. At the same time, this method is short enough that it
      * shouldn't be a problem.
      */
+    [[deprecated(
+        "use single-parameter create")]] static std::unique_ptr<Convergence>
+    create(std::shared_ptr<const Executor>,
+           const mask_type& enabled_events = Logger::all_events_mask)
+    {
+        return std::unique_ptr<Convergence>(new Convergence(enabled_events));
+    }
+
+    /**
+     * Creates a convergence logger. This dynamically allocates the memory,
+     * constructs the object and returns an std::unique_ptr to this object.
+     *
+     * @param enabled_events  the events enabled for this logger. By default all
+     *                        events.
+     *
+     * @return an std::unique_ptr to the the constructed object
+     *
+     * @internal here I cannot use EnableCreateMethod due to complex circular
+     * dependencies. At the same time, this method is short enough that it
+     * shouldn't be a problem.
+     */
     static std::unique_ptr<Convergence> create(
-        std::shared_ptr<const Executor> exec,
         const mask_type& enabled_events = Logger::all_events_mask)
     {
-        return std::unique_ptr<Convergence>(
-            new Convergence(exec, enabled_events));
+        return std::unique_ptr<Convergence>(new Convergence(enabled_events));
     }
 
     /**
@@ -159,10 +178,21 @@ protected:
      * @param enabled_events  the events enabled for this logger. By default all
      *                        events.
      */
-    explicit Convergence(
-        std::shared_ptr<const gko::Executor> exec,
+    [[deprecated("use single-parameter constructor")]] explicit Convergence(
+        std::shared_ptr<const gko::Executor>,
         const mask_type& enabled_events = Logger::all_events_mask)
-        : Logger(exec, enabled_events)
+        : Logger(enabled_events)
+    {}
+
+    /**
+     * Creates a Convergence logger.
+     *
+     * @param enabled_events  the events enabled for this logger. By default all
+     *                        events.
+     */
+    explicit Convergence(
+        const mask_type& enabled_events = Logger::all_events_mask)
+        : Logger(enabled_events)
     {}
 
 private:

--- a/include/ginkgo/core/log/logger.hpp
+++ b/include/ginkgo/core/log/logger.hpp
@@ -546,13 +546,31 @@ protected:
      *                           logs every event except linop's apply started
      *                           event.
      */
-    explicit Logger(std::shared_ptr<const gko::Executor> exec,
-                    const mask_type& enabled_events = all_events_mask)
-        : exec_{exec}, enabled_events_{enabled_events}
+    [[deprecated("use single-parameter constructor")]] explicit Logger(
+        std::shared_ptr<const gko::Executor> exec,
+        const mask_type& enabled_events = all_events_mask)
+        : Logger{enabled_events}
+    {}
+
+    /**
+     * Constructor for a Logger object.
+     *
+     * @param enabled_events  the events enabled for this Logger. These can be
+     *                        of the following form:
+     *                        1. `all_event_mask` which logs every event;
+     *                        2. an OR combination of masks, e.g.
+     *                           `iteration_complete_mask|linop_apply_started_mask`
+     *                           which activates both of these events;
+     *                        3. all events with exclusion through XOR, e.g.
+     *                           `all_event_mask^linop_apply_started_mask` which
+     *                           logs every event except linop's apply started
+     *                           event.
+     */
+    explicit Logger(const mask_type& enabled_events = all_events_mask)
+        : enabled_events_{enabled_events}
     {}
 
 private:
-    std::shared_ptr<const Executor> exec_;
     mask_type enabled_events_;
 };
 

--- a/include/ginkgo/core/log/papi.hpp
+++ b/include/ginkgo/core/log/papi.hpp
@@ -195,13 +195,23 @@ public:
      * Creates a Papi Logger.
      *
      * @param enabled_events  the events enabled for this Logger
-     * @param handle  the papi handle
+     */
+    [[deprecated("use single-parameter create")]] static std::shared_ptr<Papi>
+    create(std::shared_ptr<const gko::Executor>,
+           const Logger::mask_type& enabled_events = Logger::all_events_mask)
+    {
+        return std::shared_ptr<Papi>(new Papi(enabled_events));
+    }
+
+    /**
+     * Creates a Papi Logger.
+     *
+     * @param enabled_events  the events enabled for this Logger
      */
     static std::shared_ptr<Papi> create(
-        std::shared_ptr<const gko::Executor> exec,
         const Logger::mask_type& enabled_events = Logger::all_events_mask)
     {
-        return std::shared_ptr<Papi>(new Papi(exec, enabled_events));
+        return std::shared_ptr<Papi>(new Papi(enabled_events));
     }
 
     /**
@@ -213,10 +223,15 @@ public:
     const std::string get_handle_name() const { return name; }
 
 protected:
-    explicit Papi(
+    [[deprecated("use single-parameter constructor")]] explicit Papi(
         std::shared_ptr<const gko::Executor> exec,
         const Logger::mask_type& enabled_events = Logger::all_events_mask)
-        : Logger(exec, enabled_events)
+        : Papi(enabled_events)
+    {}
+
+    explicit Papi(
+        const Logger::mask_type& enabled_events = Logger::all_events_mask)
+        : Logger(enabled_events)
     {
         std::ostringstream os;
 

--- a/include/ginkgo/core/log/record.hpp
+++ b/include/ginkgo/core/log/record.hpp
@@ -420,13 +420,37 @@ public:
      * dependencies. At the same time, this method is short enough that it
      * shouldn't be a problem.
      */
+    [[deprecated("use two-parameter create")]] static std::unique_ptr<Record>
+    create(std::shared_ptr<const Executor> exec,
+           const mask_type& enabled_events = Logger::all_events_mask,
+           size_type max_storage = 1)
+    {
+        return std::unique_ptr<Record>(new Record(enabled_events, max_storage));
+    }
+
+    /**
+     * Creates a Record logger. This dynamically allocates the memory,
+     * constructs the object and returns an std::unique_ptr to this object.
+     *
+     * @param exec  the executor
+     * @param enabled_events  the events enabled for this logger. By default all
+     *                        events.
+     * @param max_storage  the size of storage (i.e. history) wanted by the
+     *                     user. By default 0 is used, which means unlimited
+     *                     storage. It is advised to control this to reduce
+     *                     memory overhead of this logger.
+     *
+     * @return an std::unique_ptr to the the constructed object
+     *
+     * @internal here I cannot use EnableCreateMethod due to complex circular
+     * dependencies. At the same time, this method is short enough that it
+     * shouldn't be a problem.
+     */
     static std::unique_ptr<Record> create(
-        std::shared_ptr<const Executor> exec,
         const mask_type& enabled_events = Logger::all_events_mask,
         size_type max_storage = 1)
     {
-        return std::unique_ptr<Record>(
-            new Record(exec, enabled_events, max_storage));
+        return std::unique_ptr<Record>(new Record(enabled_events, max_storage));
     }
 
     /**
@@ -453,10 +477,26 @@ protected:
      *                     storage. It is advised to control this to reduce
      *                     memory overhead of this logger.
      */
-    explicit Record(std::shared_ptr<const gko::Executor> exec,
-                    const mask_type& enabled_events = Logger::all_events_mask,
+    [[deprecated("use two-parameter constructor")]] explicit Record(
+        std::shared_ptr<const gko::Executor> exec,
+        const mask_type& enabled_events = Logger::all_events_mask,
+        size_type max_storage = 0)
+        : Record(enabled_events, max_storage)
+    {}
+
+    /**
+     * Creates a Record logger.
+     *
+     * @param enabled_events  the events enabled for this logger. By default all
+     *                        events.
+     * @param max_storage  the size of storage (i.e. history) wanted by the
+     *                     user. By default 0 is used, which means unlimited
+     *                     storage. It is advised to control this to reduce
+     *                     memory overhead of this logger.
+     */
+    explicit Record(const mask_type& enabled_events = Logger::all_events_mask,
                     size_type max_storage = 0)
-        : Logger(exec, enabled_events), max_storage_{max_storage}
+        : Logger(enabled_events), max_storage_{max_storage}
     {}
 
     /**

--- a/include/ginkgo/core/log/stream.hpp
+++ b/include/ginkgo/core/log/stream.hpp
@@ -185,13 +185,37 @@ public:
      * dependencies. At the same time, this method is short enough that it
      * shouldn't be a problem.
      */
+    [[deprecated("use three-parameter create")]] static std::unique_ptr<Stream>
+    create(std::shared_ptr<const Executor> exec,
+           const Logger::mask_type& enabled_events = Logger::all_events_mask,
+           std::ostream& os = std::cout, bool verbose = false)
+    {
+        return std::unique_ptr<Stream>(new Stream(enabled_events, os, verbose));
+    }
+
+    /**
+     * Creates a Stream logger. This dynamically allocates the memory,
+     * constructs the object and returns an std::unique_ptr to this object.
+     *
+     * @param exec  the executor
+     * @param enabled_events  the events enabled for this logger. By default all
+     *                        events.
+     * @param os  the stream used for this logger
+     * @param verbose  whether we want detailed information or not. This
+     *                 includes always printing residuals and other information
+     *                 which can give a large output.
+     *
+     * @return an std::unique_ptr to the the constructed object
+     *
+     * @internal here I cannot use EnableCreateMethod due to complex circular
+     * dependencies. At the same time, this method is short enough that it
+     * shouldn't be a problem.
+     */
     static std::unique_ptr<Stream> create(
-        std::shared_ptr<const Executor> exec,
         const Logger::mask_type& enabled_events = Logger::all_events_mask,
         std::ostream& os = std::cout, bool verbose = false)
     {
-        return std::unique_ptr<Stream>(
-            new Stream(exec, enabled_events, os, verbose));
+        return std::unique_ptr<Stream>(new Stream(enabled_events, os, verbose));
     }
 
 protected:
@@ -206,11 +230,28 @@ protected:
      *                 includes always printing residuals and other information
      *                 which can give a large output.
      */
-    explicit Stream(
+    [[deprecated("use three-parameter constructor")]] explicit Stream(
         std::shared_ptr<const gko::Executor> exec,
         const Logger::mask_type& enabled_events = Logger::all_events_mask,
         std::ostream& os = std::cout, bool verbose = false)
-        : Logger(exec, enabled_events), os_(os), verbose_(verbose)
+        : Stream(enabled_events, os, verbose)
+    {}
+
+    /**
+     * Creates a Stream logger.
+     *
+     * @param exec  the executor
+     * @param enabled_events  the events enabled for this logger. By default all
+     *                        events.
+     * @param os  the stream used for this logger
+     * @param verbose  whether we want detailed information or not. This
+     *                 includes always printing residuals and other information
+     *                 which can give a large output.
+     */
+    explicit Stream(
+        const Logger::mask_type& enabled_events = Logger::all_events_mask,
+        std::ostream& os = std::cout, bool verbose = false)
+        : Logger(enabled_events), os_(os), verbose_(verbose)
     {}
 
 

--- a/reference/test/log/convergence.cpp
+++ b/reference/test/log/convergence.cpp
@@ -58,7 +58,7 @@ TYPED_TEST(Convergence, CatchesCriterionCheckCompleted)
 {
     auto exec = gko::ReferenceExecutor::create();
     auto logger = gko::log::Convergence<TypeParam>::create(
-        exec, gko::log::Logger::criterion_check_completed_mask);
+        gko::log::Logger::criterion_check_completed_mask);
     auto criterion =
         gko::stop::Iteration::build().with_max_iters(3u).on(exec)->generate(
             nullptr, nullptr, nullptr);
@@ -86,7 +86,7 @@ TYPED_TEST(Convergence, CatchesCriterionCheckCompletedWithConvCheck)
 {
     auto exec = gko::ReferenceExecutor::create();
     auto logger = gko::log::Convergence<TypeParam>::create(
-        exec, gko::log::Logger::criterion_check_completed_mask);
+        gko::log::Logger::criterion_check_completed_mask);
     auto criterion =
         gko::stop::Iteration::build().with_max_iters(3u).on(exec)->generate(
             nullptr, nullptr, nullptr);
@@ -115,7 +115,7 @@ TYPED_TEST(Convergence, CatchesCriterionCheckCompletedWithStopCheck)
 {
     auto exec = gko::ReferenceExecutor::create();
     auto logger = gko::log::Convergence<TypeParam>::create(
-        exec, gko::log::Logger::criterion_check_completed_mask);
+        gko::log::Logger::criterion_check_completed_mask);
     auto criterion =
         gko::stop::Iteration::build().with_max_iters(3u).on(exec)->generate(
             nullptr, nullptr, nullptr);
@@ -144,7 +144,7 @@ TYPED_TEST(Convergence, CanResetConvergenceStatus)
 {
     auto exec = gko::ReferenceExecutor::create();
     auto logger = gko::log::Convergence<TypeParam>::create(
-        exec, gko::log::Logger::criterion_check_completed_mask);
+        gko::log::Logger::criterion_check_completed_mask);
     auto criterion =
         gko::stop::Iteration::build().with_max_iters(3u).on(exec)->generate(
             nullptr, nullptr, nullptr);
@@ -172,7 +172,7 @@ TYPED_TEST(Convergence, CatchesCriterionCheckCompletedWithImplicitNorm)
 {
     auto exec = gko::ReferenceExecutor::create();
     auto logger = gko::log::Convergence<TypeParam>::create(
-        exec, gko::log::Logger::criterion_check_completed_mask);
+        gko::log::Logger::criterion_check_completed_mask);
     auto criterion =
         gko::stop::Iteration::build().with_max_iters(3u).on(exec)->generate(
             nullptr, nullptr, nullptr);

--- a/test/solver/solver.cpp
+++ b/test/solver/solver.cpp
@@ -377,9 +377,7 @@ struct test_pair {
 
 
 struct DummyLogger : gko::log::Logger {
-    DummyLogger(std::shared_ptr<const gko::Executor> exec)
-        : gko::log::Logger(std::move(exec),
-                           gko::log::Logger::iteration_complete_mask)
+    DummyLogger() : gko::log::Logger(gko::log::Logger::iteration_complete_mask)
     {}
 
     void on_iteration_complete(const gko::LinOp* solver,
@@ -413,7 +411,7 @@ protected:
     {
         ref = gko::ReferenceExecutor::create();
         init_executor(ref, exec);
-        logger = std::make_shared<DummyLogger>(exec);
+        logger = std::make_shared<DummyLogger>();
     }
 
     void TearDown()


### PR DESCRIPTION
loggers store a shared_ptr to an executor, but don't provide any access to it (this appears to be an oversight). When adding a logger containing an executor to this executor, we prevent both from being freed, since they create an ownership cycle:

```cpp
{
    auto exec = ReferenceExecutor::create() // refcount 1
    auto logger = SomeLogger::create(exec); // refcount exec 2, refcount logger 1
    exec->add_logger(logger); // refcount exec 2, logger 2
} // refcount exec 1, logger 1, thus none of the two can be destroyed
```

Thus this PR removes the executor member and deprecates all corresponding constructors, prodiving replacements without the executor parameter.