### PR TITLE
Add fix for GCC 12

### DIFF
--- a/core/base/mtx_io.cpp
+++ b/core/base/mtx_io.cpp
@@ -35,6 +35,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <algorithm>
 #include <cctype>
+#include <cstring>
 #include <limits>
 #include <map>
 #include <regex>


### PR DESCRIPTION
This adds an include that is missing in gcc-12. It seems that we relied on which headers the standard header include internally for `std::memcpy`.