### PR TITLE
Fix mingw 0xc0000139 issue in github action

### DIFF
--- a/.github/workflows/osx.yml
+++ b/.github/workflows/osx.yml
@@ -13,7 +13,7 @@ on:
   workflow_dispatch:
     inputs:
       debug_enabled:
-        description: 'Run the build with tmate debugging enabled (https://github.com/marketplace/actions/debugging-with-tmate)'
+        description: 'Run the build with tmate debugging enabled by `debug_enabled` keyword (https://github.com/marketplace/actions/debugging-with-tmate)'
         required: false
         default: false
 

--- a/.github/workflows/windows-cygwin.yml
+++ b/.github/workflows/windows-cygwin.yml
@@ -13,7 +13,7 @@ on:
   workflow_dispatch:
     inputs:
       debug_enabled:
-        description: 'Run the build with tmate debugging enabled (https://github.com/marketplace/actions/debugging-with-tmate)'
+        description: 'Run the build with tmate debugging enabled by `debug_enabled` keyword (https://github.com/marketplace/actions/debugging-with-tmate)'
         required: false
         default: false
 

--- a/.github/workflows/windows-mingw.yml
+++ b/.github/workflows/windows-mingw.yml
@@ -13,7 +13,7 @@ on:
   workflow_dispatch:
     inputs:
       debug_enabled:
-        description: 'Run the build with tmate debugging enabled (https://github.com/marketplace/actions/debugging-with-tmate)'
+        description: 'Run the build with tmate debugging enabled by `debug_enabled` keyword (https://github.com/marketplace/actions/debugging-with-tmate)'
         required: false
         default: false
 

--- a/.github/workflows/windows-mingw.yml
+++ b/.github/workflows/windows-mingw.yml
@@ -45,19 +45,19 @@ jobs:
       run: |
         bcdedit /set IncreaseUserVa 3072
         editbin /LARGEADDRESSAWARE "C:\Program Files\Git\mingw64\bin\cc1plus.exe"
-        path %PATH:C:\Program Files\Git\bin;=%
-        path %PATH:C:\Program Files\Git\usr\bin;=%
+        set PATH=C:\Program Files\Git\mingw64\bin;%PATH%
+        set PATH=C:\ProgramData\chocolatey\lib\mingw\tools\install\mingw64\bin;%PATH%
         mkdir build
         cd build
         cmake -G "MinGW Makefiles" -DBUILD_SHARED_LIBS=${{ matrix.config.shared }} -DCMAKE_BUILD_TYPE=${{ matrix.config.build_type }} -DGINKGO_COMPILER_FLAGS=${{ matrix.config.cflags }} ..
         cmake --build . -j4
-        ctest . --output-on-failure
       shell: cmd
 
     - name: install
       run: |
-        set PATH=%PATH:C:\Program Files\Git\bin;=%
-        set PATH=%PATH:C:\Program Files\Git\usr\bin;=%;C:\Program Files (x86)\Ginkgo\bin
+        set PATH=C:\Program Files\Git\mingw64\bin;%PATH%
+        set PATH=C:\ProgramData\chocolatey\lib\mingw\tools\install\mingw64\bin;%PATH%
+        set PATH=C:\Program Files (x86)\Ginkgo\bin;%PATH%
         cd build
         cmake --install .
         cmake --build . --target test_install

--- a/.github/workflows/windows-msvc-cuda.yml
+++ b/.github/workflows/windows-msvc-cuda.yml
@@ -13,7 +13,7 @@ on:
   workflow_dispatch:
     inputs:
       debug_enabled:
-        description: 'Run the build with tmate debugging enabled (https://github.com/marketplace/actions/debugging-with-tmate)'
+        description: 'Run the build with tmate debugging enabled by `debug_enabled` keyword (https://github.com/marketplace/actions/debugging-with-tmate)'
         required: false
         default: false
 

--- a/.github/workflows/windows-msvc-ref.yml
+++ b/.github/workflows/windows-msvc-ref.yml
@@ -13,7 +13,7 @@ on:
   workflow_dispatch:
     inputs:
       debug_enabled:
-        description: 'Run the build with tmate debugging enabled (https://github.com/marketplace/actions/debugging-with-tmate)'
+        description: 'Run the build with tmate debugging enabled by `debug_enabled` keyword (https://github.com/marketplace/actions/debugging-with-tmate)'
         required: false
         default: false
 


### PR DESCRIPTION
This pr is to fix the mingw issue when github action is updated recently.
I also include some descriptions of how I check the error.

0xc0000139 error code means DLL issue - DLL not-found or the DLL does not match
Use `ldd` (`C:\Program Files\Git\usr\bin\ldd.exe`) from Git for Windows to check
In the current github action environment, two DLLs using the wrong DLLs.
`libstdc++-6.dll` and `libgcc_s_seh-1.dll`
From `ldd`, the executable files use the DLLs from `C:\Strawberry\c\bin` first
remove it by `path %PATH:C:\Strawberry\c\bin;=%` in cmd, but they will use the DLLs from `C:\Strawberry\perl\bin`
remove it again.
Repeatedly doing that until the executable files use the DLLs from `C:\Program Files\Git\mingw64\bin`
note: `C:\Strawberry\perl\site\bin` does not contain these DLLs, but I just remove all from Strawberry out.
~~Another way~~ might be moving the `C:\Program Files\Git\mingw64\bin` to the first one of PATH. -> current treatment

It gets the 0xc0000135 after the above treatment due to missing libgomp-1.dll
I found it in https://gist.github.com/choco-bot/a0c8c0c07dd2c923130365c7d1301568 but I think it should be available in the choco.
Something related to it, CMake found libgomp to enable openmp module but it links libgomp-1 in the end.
I do not spend too much time digging into it. I guess it may be similar to linux *.so.version and always have a soft link to *.so.

I add these two `C:\ProgramData\chocolatey\lib\mingw\tools\install\mingw64\bin;C:\Program Files\Git\mingw64\bin;` in the front of PATH.
Moreover, I add the keyword `debug_enabled` to the trigger description.

TODO:
- [x] ensure it indeed passes the MinGW test