### PR TITLE
Fix test execution on Horeka

### DIFF
--- a/.gitlab/scripts.yml
+++ b/.gitlab/scripts.yml
@@ -143,8 +143,13 @@
     # build to test
     - cd ${CI_PROJECT_DIR}${CI_PROJECT_DIR_SUFFIX}
     - cd ${CI_JOB_NAME/test/build}
-    - ninja test
+    - |
+        (( $(ctest -N | tail -1 | sed 's/Total Tests: //') != 0 )) || exit 1
+    - ctest -V --timeout 3000
     - ninja test_install
+    - pushd test/test_install
+    - ninja install
+    - popd
   cache: []
 
 


### PR DESCRIPTION
We should use the same commands for both Horeka and our own CI nodes.
This was motivated by https://gitlab.com/ginkgo-project/ginkgo-public-ci/-/jobs/2711963119 not printing the error messages (probably GPU driver failures)