### PR TITLE
Fix the edge case in residual stopping criterion

### DIFF
--- a/cuda/stop/residual_norm_kernels.cu
+++ b/cuda/stop/residual_norm_kernels.cu
@@ -67,7 +67,7 @@ __global__ __launch_bounds__(default_block_size) void residual_norm_kernel(
 {
     const auto tidx = thread::get_thread_id_flat();
     if (tidx < num_cols) {
-        if (tau[tidx] < rel_residual_goal * orig_tau[tidx]) {
+        if (tau[tidx] <= rel_residual_goal * orig_tau[tidx]) {
             stop_status[tidx].converge(stoppingId, setFinalized);
             device_storage[1] = true;
         }
@@ -139,16 +139,17 @@ constexpr int default_block_size = 512;
 
 template <typename ValueType>
 __global__
-__launch_bounds__(default_block_size) void implicit_residual_norm_kernel(
-    size_type num_cols, remove_complex<ValueType> rel_residual_goal,
-    const ValueType* __restrict__ tau,
-    const remove_complex<ValueType>* __restrict__ orig_tau, uint8 stoppingId,
-    bool setFinalized, stopping_status* __restrict__ stop_status,
-    bool* __restrict__ device_storage)
+    __launch_bounds__(default_block_size) void implicit_residual_norm_kernel(
+        size_type num_cols, remove_complex<ValueType> rel_residual_goal,
+        const ValueType* __restrict__ tau,
+        const remove_complex<ValueType>* __restrict__ orig_tau,
+        uint8 stoppingId, bool setFinalized,
+        stopping_status* __restrict__ stop_status,
+        bool* __restrict__ device_storage)
 {
     const auto tidx = thread::get_thread_id_flat();
     if (tidx < num_cols) {
-        if (sqrt(abs(tau[tidx])) < rel_residual_goal * orig_tau[tidx]) {
+        if (sqrt(abs(tau[tidx])) <= rel_residual_goal * orig_tau[tidx]) {
             stop_status[tidx].converge(stoppingId, setFinalized);
             device_storage[1] = true;
         }

--- a/cuda/stop/residual_norm_kernels.cu
+++ b/cuda/stop/residual_norm_kernels.cu
@@ -139,13 +139,12 @@ constexpr int default_block_size = 512;
 
 template <typename ValueType>
 __global__
-    __launch_bounds__(default_block_size) void implicit_residual_norm_kernel(
-        size_type num_cols, remove_complex<ValueType> rel_residual_goal,
-        const ValueType* __restrict__ tau,
-        const remove_complex<ValueType>* __restrict__ orig_tau,
-        uint8 stoppingId, bool setFinalized,
-        stopping_status* __restrict__ stop_status,
-        bool* __restrict__ device_storage)
+__launch_bounds__(default_block_size) void implicit_residual_norm_kernel(
+    size_type num_cols, remove_complex<ValueType> rel_residual_goal,
+    const ValueType* __restrict__ tau,
+    const remove_complex<ValueType>* __restrict__ orig_tau, uint8 stoppingId,
+    bool setFinalized, stopping_status* __restrict__ stop_status,
+    bool* __restrict__ device_storage)
 {
     const auto tidx = thread::get_thread_id_flat();
     if (tidx < num_cols) {

--- a/dpcpp/stop/residual_norm_kernels.dp.cpp
+++ b/dpcpp/stop/residual_norm_kernels.dp.cpp
@@ -82,7 +82,7 @@ void residual_norm(std::shared_ptr<const DpcppExecutor> exec,
         cgh.parallel_for(
             sycl::range<1>{tau->get_size()[1]}, [=](sycl::id<1> idx_id) {
                 const auto tidx = idx_id[0];
-                if (tau_val[tidx] < rel_residual_goal * orig_tau_val[tidx]) {
+                if (tau_val[tidx] <= rel_residual_goal * orig_tau_val[tidx]) {
                     stop_status_val[tidx].converge(stoppingId, setFinalized);
                     device_storage_val[1] = true;
                 }
@@ -138,7 +138,7 @@ void implicit_residual_norm(
         cgh.parallel_for(
             sycl::range<1>{tau->get_size()[1]}, [=](sycl::id<1> idx_id) {
                 const auto tidx = idx_id[0];
-                if (std::sqrt(std::abs(tau_val[tidx])) <
+                if (std::sqrt(std::abs(tau_val[tidx])) <=
                     rel_residual_goal * orig_tau_val[tidx]) {
                     stop_status_val[tidx].converge(stoppingId, setFinalized);
                     device_storage_val[1] = true;

--- a/hip/stop/residual_norm_kernels.hip.cpp
+++ b/hip/stop/residual_norm_kernels.hip.cpp
@@ -70,7 +70,7 @@ __global__ __launch_bounds__(default_block_size) void residual_norm_kernel(
 {
     const auto tidx = thread::get_thread_id_flat();
     if (tidx < num_cols) {
-        if (tau[tidx] < rel_residual_goal * orig_tau[tidx]) {
+        if (tau[tidx] <= rel_residual_goal * orig_tau[tidx]) {
             stop_status[tidx].converge(stoppingId, setFinalized);
             device_storage[1] = true;
         }
@@ -142,16 +142,17 @@ constexpr int default_block_size = 512;
 
 template <typename ValueType>
 __global__
-__launch_bounds__(default_block_size) void implicit_residual_norm_kernel(
-    size_type num_cols, remove_complex<ValueType> rel_residual_goal,
-    const ValueType* __restrict__ tau,
-    const remove_complex<ValueType>* __restrict__ orig_tau, uint8 stoppingId,
-    bool setFinalized, stopping_status* __restrict__ stop_status,
-    bool* __restrict__ device_storage)
+    __launch_bounds__(default_block_size) void implicit_residual_norm_kernel(
+        size_type num_cols, remove_complex<ValueType> rel_residual_goal,
+        const ValueType* __restrict__ tau,
+        const remove_complex<ValueType>* __restrict__ orig_tau,
+        uint8 stoppingId, bool setFinalized,
+        stopping_status* __restrict__ stop_status,
+        bool* __restrict__ device_storage)
 {
     const auto tidx = thread::get_thread_id_flat();
     if (tidx < num_cols) {
-        if (sqrt(abs(tau[tidx])) < rel_residual_goal * orig_tau[tidx]) {
+        if (sqrt(abs(tau[tidx])) <= rel_residual_goal * orig_tau[tidx]) {
             stop_status[tidx].converge(stoppingId, setFinalized);
             device_storage[1] = true;
         }

--- a/hip/stop/residual_norm_kernels.hip.cpp
+++ b/hip/stop/residual_norm_kernels.hip.cpp
@@ -142,13 +142,12 @@ constexpr int default_block_size = 512;
 
 template <typename ValueType>
 __global__
-    __launch_bounds__(default_block_size) void implicit_residual_norm_kernel(
-        size_type num_cols, remove_complex<ValueType> rel_residual_goal,
-        const ValueType* __restrict__ tau,
-        const remove_complex<ValueType>* __restrict__ orig_tau,
-        uint8 stoppingId, bool setFinalized,
-        stopping_status* __restrict__ stop_status,
-        bool* __restrict__ device_storage)
+__launch_bounds__(default_block_size) void implicit_residual_norm_kernel(
+    size_type num_cols, remove_complex<ValueType> rel_residual_goal,
+    const ValueType* __restrict__ tau,
+    const remove_complex<ValueType>* __restrict__ orig_tau, uint8 stoppingId,
+    bool setFinalized, stopping_status* __restrict__ stop_status,
+    bool* __restrict__ device_storage)
 {
     const auto tidx = thread::get_thread_id_flat();
     if (tidx < num_cols) {

--- a/include/ginkgo/core/stop/residual_norm.hpp
+++ b/include/ginkgo/core/stop/residual_norm.hpp
@@ -52,13 +52,13 @@ namespace stop {
  * The mode for the residual norm criterion.
  *
  * - absolute:        Check for tolerance against residual norm.
- *                    $ || r || < \tau $
+ *                    $ || r || \leq \tau $
  *
  * - initial_resnorm: Check for tolerance relative to the initial residual norm.
- *                    $ \frac{|| r ||}{|| r_0||} < \tau $
+ *                    $ || r || \leq \tau \times || r_0|| $
  *
  * - rhs_norm:        Check for tolerance relative to the rhs norm.
- *                    $ \frac{|| r ||}{|| b ||} < \tau $
+ *                    $ || r || \leq \tau \times || b || $
  *
  * @ingroup stop
  */
@@ -118,10 +118,11 @@ private:
  * The ResidualNorm class is a stopping criterion which
  * stops the iteration process when the actual residual norm is below a
  * certain threshold relative to
- * 1. the norm of the right-hand side, norm(residual) / norm(right_hand_side)
- *                                                                  < threshold
- * 2. the initial residual, norm(residual) / norm(initial_residual) < threshold.
- * 3. one,  norm(residual) < threshold.
+ * 1. the norm of the right-hand side, norm(residual) $\leq$ < threshold *
+ *    norm(right_hand_side).
+ * 2. the initial residual, norm(residual) $\leq$ threshold *
+ *    norm(initial_residual).
+ * 3. one,  norm(residual) $\leq$ threshold.
  *
  * For better performance, the checks are run on the executor
  * where the algorithm is executed.
@@ -176,11 +177,11 @@ protected:
  * The ImplicitResidualNorm class is a stopping criterion which
  * stops the iteration process when the implicit residual norm is below a
  * certain threshold relative to
- * 1. the norm of the right-hand side, implicit_resnorm / norm(right_hand_side)
- *                                                          < threshold
- * 2. the initial residual, implicit_resnorm / norm(initial_residual) <
- *                                                          < threshold.
- * 3. one, implicit_resnorm < threshold.
+ * 1. the norm of the right-hand side, implicit_resnorm $\leq$ < threshold *
+ * norm(right_hand_side)
+ * 2. the initial residual, implicit_resnorm $\leq$ threshold *
+ * norm(initial_residual) .
+ * 3. one,  implicit_resnorm $\leq$ threshold.
  *
  * @note To use this stopping criterion there are some dependencies. The
  * constructor depends on either `b` or the `initial_residual` in order to

--- a/omp/stop/residual_norm_kernels.cpp
+++ b/omp/stop/residual_norm_kernels.cpp
@@ -65,7 +65,7 @@ void residual_norm(std::shared_ptr<const OmpExecutor> exec,
     bool local_one_changed = false;
 #pragma omp parallel for reduction(|| : local_one_changed)
     for (size_type i = 0; i < tau->get_size()[1]; ++i) {
-        if (tau->at(i) < rel_residual_goal * orig_tau->at(i)) {
+        if (tau->at(i) <= rel_residual_goal * orig_tau->at(i)) {
             stop_status->get_data()[i].converge(stoppingId, setFinalized);
             local_one_changed = true;
         }
@@ -110,7 +110,7 @@ void implicit_residual_norm(
     bool local_one_changed = false;
 #pragma omp parallel for reduction(|| : local_one_changed)
     for (size_type i = 0; i < tau->get_size()[1]; ++i) {
-        if (sqrt(abs(tau->at(i))) < rel_residual_goal * orig_tau->at(i)) {
+        if (sqrt(abs(tau->at(i))) <= rel_residual_goal * orig_tau->at(i)) {
             stop_status->get_data()[i].converge(stoppingId, setFinalized);
             local_one_changed = true;
         }

--- a/reference/stop/residual_norm_kernels.cpp
+++ b/reference/stop/residual_norm_kernels.cpp
@@ -67,7 +67,7 @@ void residual_norm(std::shared_ptr<const ReferenceExecutor> exec,
     *all_converged = true;
     *one_changed = false;
     for (size_type i = 0; i < tau->get_size()[1]; ++i) {
-        if (tau->at(i) < rel_residual_goal * orig_tau->at(i)) {
+        if (tau->at(i) <= rel_residual_goal * orig_tau->at(i)) {
             stop_status->get_data()[i].converge(stoppingId, setFinalized);
             *one_changed = true;
         }
@@ -107,7 +107,7 @@ void implicit_residual_norm(
     *all_converged = true;
     *one_changed = false;
     for (size_type i = 0; i < tau->get_size()[1]; ++i) {
-        if (sqrt(abs(tau->at(i))) < rel_residual_goal * orig_tau->at(i)) {
+        if (sqrt(abs(tau->at(i))) <= rel_residual_goal * orig_tau->at(i)) {
             stop_status->get_data()[i].converge(stoppingId, setFinalized);
             *one_changed = true;
         }

--- a/reference/test/stop/residual_norm_kernels.cpp
+++ b/reference/test/stop/residual_norm_kernels.cpp
@@ -108,50 +108,22 @@ TYPED_TEST(ResidualNorm, CheckIfResZeroConverges)
     using Mtx = typename TestFixture::Mtx;
     using NormVector = typename TestFixture::NormVector;
     using T = typename TestFixture::ValueType;
+    using mode = typename gko::stop::mode;
     std::shared_ptr<gko::LinOp> mtx = gko::initialize<Mtx>({1.0}, this->exec_);
     std::shared_ptr<gko::LinOp> rhs = gko::initialize<Mtx>({0.0}, this->exec_);
     std::shared_ptr<gko::LinOp> x = gko::initialize<Mtx>({0.0}, this->exec_);
     std::shared_ptr<gko::LinOp> res_norm =
         gko::initialize<NormVector>({0.0}, this->exec_);
 
-    {
+    for (auto baseline :
+         {mode::rhs_norm, mode::initial_resnorm, mode::absolute}) {
+        gko::remove_complex<T> factor =
+            (baseline == mode::absolute) ? 0.0 : r<T>::value;
         auto criterion = gko::stop::ResidualNorm<T>::build()
-                             .with_reduction_factor(r<T>::value)
+                             .with_reduction_factor(factor)
+                             .with_baseline(baseline)
                              .on(this->exec_)
                              ->generate(mtx, rhs, x.get(), nullptr);
-        constexpr gko::uint8 RelativeStoppingId{1};
-        bool one_changed{};
-        gko::array<gko::stopping_status> stop_status(this->exec_, 1);
-        stop_status.get_data()[0].reset();
-
-        EXPECT_TRUE(criterion->update().residual_norm(res_norm).check(
-            RelativeStoppingId, true, &stop_status, &one_changed));
-        EXPECT_TRUE(stop_status.get_data()[0].has_converged());
-        EXPECT_TRUE(one_changed);
-    }
-    {
-        auto criterion = gko::stop::ResidualNorm<T>::build()
-                             .with_reduction_factor(r<T>::value)
-                             .with_baseline(gko::stop::mode::initial_resnorm)
-                             .on(this->exec_)
-                             ->generate(mtx, rhs, x.get(), nullptr);
-        constexpr gko::uint8 RelativeStoppingId{1};
-        bool one_changed{};
-        gko::array<gko::stopping_status> stop_status(this->exec_, 1);
-        stop_status.get_data()[0].reset();
-
-        EXPECT_TRUE(criterion->update().residual_norm(res_norm).check(
-            RelativeStoppingId, true, &stop_status, &one_changed));
-        EXPECT_TRUE(stop_status.get_data()[0].has_converged());
-        EXPECT_TRUE(one_changed);
-    }
-    {
-        auto criterion =
-            gko::stop::ResidualNorm<T>::build()
-                .with_reduction_factor(gko::zero<gko::remove_complex<T>>())
-                .with_baseline(gko::stop::mode::absolute)
-                .on(this->exec_)
-                ->generate(mtx, rhs, x.get(), nullptr);
         constexpr gko::uint8 RelativeStoppingId{1};
         bool one_changed{};
         gko::array<gko::stopping_status> stop_status(this->exec_, 1);
@@ -887,54 +859,22 @@ TYPED_TEST(ImplicitResidualNorm, CheckIfResZeroConverges)
 {
     using Mtx = typename TestFixture::Mtx;
     using T = typename TestFixture::ValueType;
+    using mode = typename gko::stop::mode;
     std::shared_ptr<gko::LinOp> mtx = gko::initialize<Mtx>({1.0}, this->exec_);
     std::shared_ptr<gko::LinOp> rhs = gko::initialize<Mtx>({0.0}, this->exec_);
     std::shared_ptr<gko::LinOp> x = gko::initialize<Mtx>({0.0}, this->exec_);
     std::shared_ptr<gko::LinOp> implicit_sq_res_norm =
         gko::initialize<Mtx>({0.0}, this->exec_);
 
-    {
+    for (auto baseline :
+         {mode::rhs_norm, mode::initial_resnorm, mode::absolute}) {
+        gko::remove_complex<T> factor =
+            (baseline == mode::absolute) ? 0.0 : r<T>::value;
         auto criterion = gko::stop::ImplicitResidualNorm<T>::build()
-                             .with_reduction_factor(r<T>::value)
+                             .with_reduction_factor(factor)
+                             .with_baseline(baseline)
                              .on(this->exec_)
                              ->generate(mtx, rhs, x.get(), nullptr);
-        constexpr gko::uint8 RelativeStoppingId{1};
-        bool one_changed{};
-        gko::array<gko::stopping_status> stop_status(this->exec_, 1);
-        stop_status.get_data()[0].reset();
-
-        EXPECT_TRUE(
-            criterion->update()
-                .implicit_sq_residual_norm(implicit_sq_res_norm)
-                .check(RelativeStoppingId, true, &stop_status, &one_changed));
-        EXPECT_TRUE(stop_status.get_data()[0].has_converged());
-        EXPECT_TRUE(one_changed);
-    }
-    {
-        auto criterion = gko::stop::ImplicitResidualNorm<T>::build()
-                             .with_reduction_factor(r<T>::value)
-                             .with_baseline(gko::stop::mode::initial_resnorm)
-                             .on(this->exec_)
-                             ->generate(mtx, rhs, x.get(), nullptr);
-        constexpr gko::uint8 RelativeStoppingId{1};
-        bool one_changed{};
-        gko::array<gko::stopping_status> stop_status(this->exec_, 1);
-        stop_status.get_data()[0].reset();
-
-        EXPECT_TRUE(
-            criterion->update()
-                .implicit_sq_residual_norm(implicit_sq_res_norm)
-                .check(RelativeStoppingId, true, &stop_status, &one_changed));
-        EXPECT_TRUE(stop_status.get_data()[0].has_converged());
-        EXPECT_TRUE(one_changed);
-    }
-    {
-        auto criterion =
-            gko::stop::ImplicitResidualNorm<T>::build()
-                .with_reduction_factor(gko::zero<gko::remove_complex<T>>())
-                .with_baseline(gko::stop::mode::absolute)
-                .on(this->exec_)
-                ->generate(mtx, rhs, x.get(), nullptr);
         constexpr gko::uint8 RelativeStoppingId{1};
         bool one_changed{};
         gko::array<gko::stopping_status> stop_status(this->exec_, 1);

--- a/reference/test/stop/residual_norm_kernels.cpp
+++ b/reference/test/stop/residual_norm_kernels.cpp
@@ -54,6 +54,7 @@ class ResidualNorm : public ::testing::Test {
 protected:
     using Mtx = gko::matrix::Dense<T>;
     using NormVector = gko::matrix::Dense<gko::remove_complex<T>>;
+    using ValueType = T;
 
     ResidualNorm()
     {
@@ -100,6 +101,67 @@ TYPED_TEST(ResidualNorm, CanCreateFactory)
     ASSERT_EQ(this->abs_factory_->get_parameters().baseline,
               gko::stop::mode::absolute);
     ASSERT_EQ(this->abs_factory_->get_executor(), this->exec_);
+}
+
+TYPED_TEST(ResidualNorm, CheckIfResZeroConverges)
+{
+    using Mtx = typename TestFixture::Mtx;
+    using NormVector = typename TestFixture::NormVector;
+    using T = typename TestFixture::ValueType;
+    std::shared_ptr<gko::LinOp> mtx = gko::initialize<Mtx>({1.0}, this->exec_);
+    std::shared_ptr<gko::LinOp> rhs = gko::initialize<Mtx>({0.0}, this->exec_);
+    std::shared_ptr<gko::LinOp> x = gko::initialize<Mtx>({0.0}, this->exec_);
+    std::shared_ptr<gko::LinOp> res_norm =
+        gko::initialize<NormVector>({0.0}, this->exec_);
+
+    {
+        auto criterion = gko::stop::ResidualNorm<T>::build()
+                             .with_reduction_factor(r<T>::value)
+                             .on(this->exec_)
+                             ->generate(mtx, rhs, x.get(), nullptr);
+        constexpr gko::uint8 RelativeStoppingId{1};
+        bool one_changed{};
+        gko::array<gko::stopping_status> stop_status(this->exec_, 1);
+        stop_status.get_data()[0].reset();
+
+        EXPECT_TRUE(criterion->update().residual_norm(res_norm).check(
+            RelativeStoppingId, true, &stop_status, &one_changed));
+        EXPECT_TRUE(stop_status.get_data()[0].has_converged());
+        EXPECT_TRUE(one_changed);
+    }
+    {
+        auto criterion = gko::stop::ResidualNorm<T>::build()
+                             .with_reduction_factor(r<T>::value)
+                             .with_baseline(gko::stop::mode::initial_resnorm)
+                             .on(this->exec_)
+                             ->generate(mtx, rhs, x.get(), nullptr);
+        constexpr gko::uint8 RelativeStoppingId{1};
+        bool one_changed{};
+        gko::array<gko::stopping_status> stop_status(this->exec_, 1);
+        stop_status.get_data()[0].reset();
+
+        EXPECT_TRUE(criterion->update().residual_norm(res_norm).check(
+            RelativeStoppingId, true, &stop_status, &one_changed));
+        EXPECT_TRUE(stop_status.get_data()[0].has_converged());
+        EXPECT_TRUE(one_changed);
+    }
+    {
+        auto criterion =
+            gko::stop::ResidualNorm<T>::build()
+                .with_reduction_factor(gko::zero<gko::remove_complex<T>>())
+                .with_baseline(gko::stop::mode::absolute)
+                .on(this->exec_)
+                ->generate(mtx, rhs, x.get(), nullptr);
+        constexpr gko::uint8 RelativeStoppingId{1};
+        bool one_changed{};
+        gko::array<gko::stopping_status> stop_status(this->exec_, 1);
+        stop_status.get_data()[0].reset();
+
+        EXPECT_TRUE(criterion->update().residual_norm(res_norm).check(
+            RelativeStoppingId, true, &stop_status, &one_changed));
+        EXPECT_TRUE(stop_status.get_data()[0].has_converged());
+        EXPECT_TRUE(one_changed);
+    }
 }
 
 
@@ -776,6 +838,7 @@ class ImplicitResidualNorm : public ::testing::Test {
 protected:
     using Mtx = gko::matrix::Dense<T>;
     using NormVector = gko::matrix::Dense<gko::remove_complex<T>>;
+    using ValueType = T;
 
     ImplicitResidualNorm()
     {
@@ -818,6 +881,72 @@ TYPED_TEST(ImplicitResidualNorm, CanCreateFactory)
     ASSERT_EQ(this->factory_3_->get_parameters().baseline,
               gko::stop::mode::rhs_norm);
     ASSERT_EQ(this->factory_->get_executor(), this->exec_);
+}
+
+TYPED_TEST(ImplicitResidualNorm, CheckIfResZeroConverges)
+{
+    using Mtx = typename TestFixture::Mtx;
+    using T = typename TestFixture::ValueType;
+    std::shared_ptr<gko::LinOp> mtx = gko::initialize<Mtx>({1.0}, this->exec_);
+    std::shared_ptr<gko::LinOp> rhs = gko::initialize<Mtx>({0.0}, this->exec_);
+    std::shared_ptr<gko::LinOp> x = gko::initialize<Mtx>({0.0}, this->exec_);
+    std::shared_ptr<gko::LinOp> implicit_sq_res_norm =
+        gko::initialize<Mtx>({0.0}, this->exec_);
+
+    {
+        auto criterion = gko::stop::ImplicitResidualNorm<T>::build()
+                             .with_reduction_factor(r<T>::value)
+                             .on(this->exec_)
+                             ->generate(mtx, rhs, x.get(), nullptr);
+        constexpr gko::uint8 RelativeStoppingId{1};
+        bool one_changed{};
+        gko::array<gko::stopping_status> stop_status(this->exec_, 1);
+        stop_status.get_data()[0].reset();
+
+        EXPECT_TRUE(
+            criterion->update()
+                .implicit_sq_residual_norm(implicit_sq_res_norm)
+                .check(RelativeStoppingId, true, &stop_status, &one_changed));
+        EXPECT_TRUE(stop_status.get_data()[0].has_converged());
+        EXPECT_TRUE(one_changed);
+    }
+    {
+        auto criterion = gko::stop::ImplicitResidualNorm<T>::build()
+                             .with_reduction_factor(r<T>::value)
+                             .with_baseline(gko::stop::mode::initial_resnorm)
+                             .on(this->exec_)
+                             ->generate(mtx, rhs, x.get(), nullptr);
+        constexpr gko::uint8 RelativeStoppingId{1};
+        bool one_changed{};
+        gko::array<gko::stopping_status> stop_status(this->exec_, 1);
+        stop_status.get_data()[0].reset();
+
+        EXPECT_TRUE(
+            criterion->update()
+                .implicit_sq_residual_norm(implicit_sq_res_norm)
+                .check(RelativeStoppingId, true, &stop_status, &one_changed));
+        EXPECT_TRUE(stop_status.get_data()[0].has_converged());
+        EXPECT_TRUE(one_changed);
+    }
+    {
+        auto criterion =
+            gko::stop::ImplicitResidualNorm<T>::build()
+                .with_reduction_factor(gko::zero<gko::remove_complex<T>>())
+                .with_baseline(gko::stop::mode::absolute)
+                .on(this->exec_)
+                ->generate(mtx, rhs, x.get(), nullptr);
+        constexpr gko::uint8 RelativeStoppingId{1};
+        bool one_changed{};
+        gko::array<gko::stopping_status> stop_status(this->exec_, 1);
+        stop_status.get_data()[0].reset();
+
+        EXPECT_TRUE(
+            criterion->update()
+                .implicit_sq_residual_norm(implicit_sq_res_norm)
+                .check(RelativeStoppingId, true, &stop_status, &one_changed));
+        EXPECT_TRUE(stop_status.get_data()[0].has_converged());
+        EXPECT_TRUE(one_changed);
+    }
 }
 
 

--- a/test/stop/residual_norm_kernels.cpp
+++ b/test/stop/residual_norm_kernels.cpp
@@ -116,54 +116,22 @@ TYPED_TEST(ResidualNorm, CheckIfResZeroConverges)
     using Mtx = typename TestFixture::Mtx;
     using NormVector = typename TestFixture::NormVector;
     using T = typename TestFixture::ValueType;
+    using mode = gko::stop::mode;
     std::shared_ptr<gko::LinOp> mtx = gko::initialize<Mtx>({1.0}, this->exec);
     std::shared_ptr<gko::LinOp> rhs = gko::initialize<Mtx>({0.0}, this->exec);
     std::shared_ptr<gko::LinOp> x = gko::initialize<Mtx>({0.0}, this->exec);
     std::shared_ptr<gko::LinOp> res_norm =
         gko::initialize<NormVector>({0.0}, this->exec);
 
-    {
+    for (auto baseline :
+         {mode::rhs_norm, mode::initial_resnorm, mode::absolute}) {
+        gko::remove_complex<T> factor =
+            (baseline == mode::absolute) ? 0.0 : r<T>::value;
         auto criterion = gko::stop::ResidualNorm<T>::build()
-                             .with_reduction_factor(r<T>::value)
+                             .with_reduction_factor(factor)
+                             .with_baseline(baseline)
                              .on(this->exec)
                              ->generate(mtx, rhs, x.get(), nullptr);
-        constexpr gko::uint8 RelativeStoppingId{1};
-        bool one_changed{};
-        gko::array<gko::stopping_status> stop_status(this->ref, 1);
-        stop_status.get_data()[0].reset();
-        stop_status.set_executor(this->exec);
-
-        EXPECT_TRUE(criterion->update().residual_norm(res_norm).check(
-            RelativeStoppingId, true, &stop_status, &one_changed));
-        stop_status.set_executor(this->ref);
-        EXPECT_TRUE(stop_status.get_data()[0].has_converged());
-        EXPECT_TRUE(one_changed);
-    }
-    {
-        auto criterion = gko::stop::ResidualNorm<T>::build()
-                             .with_reduction_factor(r<T>::value)
-                             .with_baseline(gko::stop::mode::initial_resnorm)
-                             .on(this->exec)
-                             ->generate(mtx, rhs, x.get(), nullptr);
-        constexpr gko::uint8 RelativeStoppingId{1};
-        bool one_changed{};
-        gko::array<gko::stopping_status> stop_status(this->ref, 1);
-        stop_status.get_data()[0].reset();
-        stop_status.set_executor(this->exec);
-
-        EXPECT_TRUE(criterion->update().residual_norm(res_norm).check(
-            RelativeStoppingId, true, &stop_status, &one_changed));
-        stop_status.set_executor(this->ref);
-        EXPECT_TRUE(stop_status.get_data()[0].has_converged());
-        EXPECT_TRUE(one_changed);
-    }
-    {
-        auto criterion =
-            gko::stop::ResidualNorm<T>::build()
-                .with_reduction_factor(gko::zero<gko::remove_complex<T>>())
-                .with_baseline(gko::stop::mode::absolute)
-                .on(this->exec)
-                ->generate(mtx, rhs, x.get(), nullptr);
         constexpr gko::uint8 RelativeStoppingId{1};
         bool one_changed{};
         gko::array<gko::stopping_status> stop_status(this->ref, 1);
@@ -610,58 +578,22 @@ TYPED_TEST(ImplicitResidualNorm, CheckIfResZeroConverges)
 {
     using Mtx = typename TestFixture::Mtx;
     using T = typename TestFixture::ValueType;
+    using mode = typename gko::stop::mode;
     std::shared_ptr<gko::LinOp> mtx = gko::initialize<Mtx>({1.0}, this->exec);
     std::shared_ptr<gko::LinOp> rhs = gko::initialize<Mtx>({0.0}, this->exec);
     std::shared_ptr<gko::LinOp> x = gko::initialize<Mtx>({0.0}, this->exec);
     std::shared_ptr<gko::LinOp> implicit_sq_res_norm =
         gko::initialize<Mtx>({0.0}, this->exec);
 
-    {
+    for (auto baseline :
+         {mode::rhs_norm, mode::initial_resnorm, mode::absolute}) {
+        gko::remove_complex<T> factor =
+            (baseline == mode::absolute) ? 0.0 : r<T>::value;
         auto criterion = gko::stop::ImplicitResidualNorm<T>::build()
-                             .with_reduction_factor(r<T>::value)
+                             .with_reduction_factor(factor)
+                             .with_baseline(baseline)
                              .on(this->exec)
                              ->generate(mtx, rhs, x.get(), nullptr);
-        constexpr gko::uint8 RelativeStoppingId{1};
-        bool one_changed{};
-        gko::array<gko::stopping_status> stop_status(this->ref, 1);
-        stop_status.get_data()[0].reset();
-        stop_status.set_executor(this->exec);
-
-        EXPECT_TRUE(
-            criterion->update()
-                .implicit_sq_residual_norm(implicit_sq_res_norm)
-                .check(RelativeStoppingId, true, &stop_status, &one_changed));
-        stop_status.set_executor(this->ref);
-        EXPECT_TRUE(stop_status.get_data()[0].has_converged());
-        EXPECT_TRUE(one_changed);
-    }
-    {
-        auto criterion = gko::stop::ImplicitResidualNorm<T>::build()
-                             .with_reduction_factor(r<T>::value)
-                             .with_baseline(gko::stop::mode::initial_resnorm)
-                             .on(this->exec)
-                             ->generate(mtx, rhs, x.get(), nullptr);
-        constexpr gko::uint8 RelativeStoppingId{1};
-        bool one_changed{};
-        gko::array<gko::stopping_status> stop_status(this->ref, 1);
-        stop_status.get_data()[0].reset();
-        stop_status.set_executor(this->exec);
-
-        EXPECT_TRUE(
-            criterion->update()
-                .implicit_sq_residual_norm(implicit_sq_res_norm)
-                .check(RelativeStoppingId, true, &stop_status, &one_changed));
-        stop_status.set_executor(this->ref);
-        EXPECT_TRUE(stop_status.get_data()[0].has_converged());
-        EXPECT_TRUE(one_changed);
-    }
-    {
-        auto criterion =
-            gko::stop::ImplicitResidualNorm<T>::build()
-                .with_reduction_factor(gko::zero<gko::remove_complex<T>>())
-                .with_baseline(gko::stop::mode::absolute)
-                .on(this->exec)
-                ->generate(mtx, rhs, x.get(), nullptr);
         constexpr gko::uint8 RelativeStoppingId{1};
         bool one_changed{};
         gko::array<gko::stopping_status> stop_status(this->ref, 1);

--- a/test/stop/residual_norm_kernels.cpp
+++ b/test/stop/residual_norm_kernels.cpp
@@ -65,6 +65,7 @@ class ResidualNorm : public CommonTestFixture {
 protected:
     using Mtx = gko::matrix::Dense<T>;
     using NormVector = gko::matrix::Dense<gko::remove_complex<T>>;
+    using ValueType = T;
 
     ResidualNorm()
     {
@@ -110,6 +111,72 @@ TYPED_TEST(ResidualNorm, CanIgorneResidualNorm)
                  gko::NotSupported);
 }
 
+TYPED_TEST(ResidualNorm, CheckIfResZeroConverges)
+{
+    using Mtx = typename TestFixture::Mtx;
+    using NormVector = typename TestFixture::NormVector;
+    using T = typename TestFixture::ValueType;
+    std::shared_ptr<gko::LinOp> mtx = gko::initialize<Mtx>({1.0}, this->exec);
+    std::shared_ptr<gko::LinOp> rhs = gko::initialize<Mtx>({0.0}, this->exec);
+    std::shared_ptr<gko::LinOp> x = gko::initialize<Mtx>({0.0}, this->exec);
+    std::shared_ptr<gko::LinOp> res_norm =
+        gko::initialize<NormVector>({0.0}, this->exec);
+
+    {
+        auto criterion = gko::stop::ResidualNorm<T>::build()
+                             .with_reduction_factor(r<T>::value)
+                             .on(this->exec)
+                             ->generate(mtx, rhs, x.get(), nullptr);
+        constexpr gko::uint8 RelativeStoppingId{1};
+        bool one_changed{};
+        gko::array<gko::stopping_status> stop_status(this->ref, 1);
+        stop_status.get_data()[0].reset();
+        stop_status.set_executor(this->exec);
+
+        EXPECT_TRUE(criterion->update().residual_norm(res_norm).check(
+            RelativeStoppingId, true, &stop_status, &one_changed));
+        stop_status.set_executor(this->ref);
+        EXPECT_TRUE(stop_status.get_data()[0].has_converged());
+        EXPECT_TRUE(one_changed);
+    }
+    {
+        auto criterion = gko::stop::ResidualNorm<T>::build()
+                             .with_reduction_factor(r<T>::value)
+                             .with_baseline(gko::stop::mode::initial_resnorm)
+                             .on(this->exec)
+                             ->generate(mtx, rhs, x.get(), nullptr);
+        constexpr gko::uint8 RelativeStoppingId{1};
+        bool one_changed{};
+        gko::array<gko::stopping_status> stop_status(this->ref, 1);
+        stop_status.get_data()[0].reset();
+        stop_status.set_executor(this->exec);
+
+        EXPECT_TRUE(criterion->update().residual_norm(res_norm).check(
+            RelativeStoppingId, true, &stop_status, &one_changed));
+        stop_status.set_executor(this->ref);
+        EXPECT_TRUE(stop_status.get_data()[0].has_converged());
+        EXPECT_TRUE(one_changed);
+    }
+    {
+        auto criterion =
+            gko::stop::ResidualNorm<T>::build()
+                .with_reduction_factor(gko::zero<gko::remove_complex<T>>())
+                .with_baseline(gko::stop::mode::absolute)
+                .on(this->exec)
+                ->generate(mtx, rhs, x.get(), nullptr);
+        constexpr gko::uint8 RelativeStoppingId{1};
+        bool one_changed{};
+        gko::array<gko::stopping_status> stop_status(this->ref, 1);
+        stop_status.get_data()[0].reset();
+        stop_status.set_executor(this->exec);
+
+        EXPECT_TRUE(criterion->update().residual_norm(res_norm).check(
+            RelativeStoppingId, true, &stop_status, &one_changed));
+        stop_status.set_executor(this->ref);
+        EXPECT_TRUE(stop_status.get_data()[0].has_converged());
+        EXPECT_TRUE(one_changed);
+    }
+}
 
 TYPED_TEST(ResidualNorm, WaitsTillResidualGoal)
 {
@@ -522,6 +589,7 @@ class ImplicitResidualNorm : public CommonTestFixture {
 protected:
     using Mtx = gko::matrix::Dense<T>;
     using NormVector = gko::matrix::Dense<gko::remove_complex<T>>;
+    using ValueType = T;
 
     ImplicitResidualNorm()
     {
@@ -537,6 +605,78 @@ protected:
 TYPED_TEST_SUITE(ImplicitResidualNorm, gko::test::ValueTypes,
                  TypenameNameGenerator);
 
+
+TYPED_TEST(ImplicitResidualNorm, CheckIfResZeroConverges)
+{
+    using Mtx = typename TestFixture::Mtx;
+    using T = typename TestFixture::ValueType;
+    std::shared_ptr<gko::LinOp> mtx = gko::initialize<Mtx>({1.0}, this->exec);
+    std::shared_ptr<gko::LinOp> rhs = gko::initialize<Mtx>({0.0}, this->exec);
+    std::shared_ptr<gko::LinOp> x = gko::initialize<Mtx>({0.0}, this->exec);
+    std::shared_ptr<gko::LinOp> implicit_sq_res_norm =
+        gko::initialize<Mtx>({0.0}, this->exec);
+
+    {
+        auto criterion = gko::stop::ImplicitResidualNorm<T>::build()
+                             .with_reduction_factor(r<T>::value)
+                             .on(this->exec)
+                             ->generate(mtx, rhs, x.get(), nullptr);
+        constexpr gko::uint8 RelativeStoppingId{1};
+        bool one_changed{};
+        gko::array<gko::stopping_status> stop_status(this->ref, 1);
+        stop_status.get_data()[0].reset();
+        stop_status.set_executor(this->exec);
+
+        EXPECT_TRUE(
+            criterion->update()
+                .implicit_sq_residual_norm(implicit_sq_res_norm)
+                .check(RelativeStoppingId, true, &stop_status, &one_changed));
+        stop_status.set_executor(this->ref);
+        EXPECT_TRUE(stop_status.get_data()[0].has_converged());
+        EXPECT_TRUE(one_changed);
+    }
+    {
+        auto criterion = gko::stop::ImplicitResidualNorm<T>::build()
+                             .with_reduction_factor(r<T>::value)
+                             .with_baseline(gko::stop::mode::initial_resnorm)
+                             .on(this->exec)
+                             ->generate(mtx, rhs, x.get(), nullptr);
+        constexpr gko::uint8 RelativeStoppingId{1};
+        bool one_changed{};
+        gko::array<gko::stopping_status> stop_status(this->ref, 1);
+        stop_status.get_data()[0].reset();
+        stop_status.set_executor(this->exec);
+
+        EXPECT_TRUE(
+            criterion->update()
+                .implicit_sq_residual_norm(implicit_sq_res_norm)
+                .check(RelativeStoppingId, true, &stop_status, &one_changed));
+        stop_status.set_executor(this->ref);
+        EXPECT_TRUE(stop_status.get_data()[0].has_converged());
+        EXPECT_TRUE(one_changed);
+    }
+    {
+        auto criterion =
+            gko::stop::ImplicitResidualNorm<T>::build()
+                .with_reduction_factor(gko::zero<gko::remove_complex<T>>())
+                .with_baseline(gko::stop::mode::absolute)
+                .on(this->exec)
+                ->generate(mtx, rhs, x.get(), nullptr);
+        constexpr gko::uint8 RelativeStoppingId{1};
+        bool one_changed{};
+        gko::array<gko::stopping_status> stop_status(this->ref, 1);
+        stop_status.get_data()[0].reset();
+        stop_status.set_executor(this->exec);
+
+        EXPECT_TRUE(
+            criterion->update()
+                .implicit_sq_residual_norm(implicit_sq_res_norm)
+                .check(RelativeStoppingId, true, &stop_status, &one_changed));
+        stop_status.set_executor(this->ref);
+        EXPECT_TRUE(stop_status.get_data()[0].has_converged());
+        EXPECT_TRUE(one_changed);
+    }
+}
 
 TYPED_TEST(ImplicitResidualNorm, WaitsTillResidualGoal)
 {


### PR DESCRIPTION
Regarding #1051 this would fix the edge case with an rhs vector filled with zeroes.

Used '<=' instead of '<' in residual operations. Test cases will be added