### PR TITLE
Push mirroring

### DIFF
--- a/.github/abidiff.sh
+++ b/.github/abidiff.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 pushd old
 source .github/bot-pr-base.sh

--- a/.github/bot-base.sh
+++ b/.github/bot-base.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/.github/bot-pr-base.sh
+++ b/.github/bot-pr-base.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 source .github/bot-base.sh
 

--- a/.github/bot-pr-format-base.sh
+++ b/.github/bot-pr-format-base.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 source .github/bot-pr-base.sh
 

--- a/.github/check-format.sh
+++ b/.github/check-format.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 cp .github/bot-pr-format-base.sh /tmp
 source /tmp/bot-pr-format-base.sh

--- a/.github/format-rebase.sh
+++ b/.github/format-rebase.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 source .github/bot-pr-base.sh
 

--- a/.github/format.sh
+++ b/.github/format.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 cp .github/bot-pr-format-base.sh /tmp
 source /tmp/bot-pr-format-base.sh

--- a/.github/label.sh
+++ b/.github/label.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 source .github/bot-pr-base.sh
 

--- a/.github/mirror.sh
+++ b/.github/mirror.sh
@@ -16,7 +16,7 @@ ssh-keyscan -t rsa gitlab.com github.com >>~/.ssh/known_hosts
 
 # Fetch from github
 git fetch fork "$BRANCH_NAME"
-git checkout -b "$BRANCH_NAME"
+git checkout -B "$BRANCH_NAME"
 git reset --hard fork/"$BRANCH_NAME"
 # Push to gitlab
-git push -u --force --prune gitlab HEAD:$BRANCH_NAME
+git push -u --force gitlab HEAD:$BRANCH_NAME

--- a/.github/mirror.sh
+++ b/.github/mirror.sh
@@ -13,8 +13,6 @@ echo "${BOT_KEY}" | tr -d '\r' | ssh-add - >/dev/null
 mkdir -p ~/.ssh
 chmod 700 ~/.ssh
 ssh-keyscan -t rsa gitlab.com github.com >>~/.ssh/known_hosts
-git config user.email "ginkgo.library@gmail.com"
-git config user.name "Ginkgo Bot"
 
 # Fetch from github
 git fetch fork "$BRANCH_NAME"

--- a/.github/mirror.sh
+++ b/.github/mirror.sh
@@ -18,6 +18,7 @@ git config user.name "Ginkgo Bot"
 
 # Fetch from github
 git fetch fork "$BRANCH_NAME"
-git checkout -b fork/$BRANCH_NAME
+git checkout -b "$BRANCH_NAME"
+git reset --hard fork/"$BRANCH_NAME"
 # Push to gitlab
-git push --force --prune gitlab $BRANCH_NAME
+git push -u --force --prune gitlab HEAD:$BRANCH_NAME

--- a/.github/mirror.sh
+++ b/.github/mirror.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+BRANCH_NAME=${BRANCH_NAME##*/}
+
+git remote add fork "git@github.com:${GITHUB_REPO}.git"
+git remote add gitlab "git@gitlab.com:ginkgo-project/ginkgo-public-ci.git"
+
+git remote -v
+
+# Setup ssh
+eval $(ssh-agent -s)
+echo "${BOT_KEY}" | tr -d '\r' | ssh-add - >/dev/null
+mkdir -p ~/.ssh
+chmod 700 ~/.ssh
+ssh-keyscan -t rsa gitlab.com github.com >>~/.ssh/known_hosts
+git config user.email "ginkgo.library@gmail.com"
+git config user.name "Ginkgo Bot"
+
+# Fetch from github
+git fetch fork "$BRANCH_NAME"
+git checkout -b fork/$BRANCH_NAME
+# Push to gitlab
+git push --force --prune gitlab $BRANCH_NAME

--- a/.github/rebase.sh
+++ b/.github/rebase.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 source .github/bot-pr-base.sh
 

--- a/.github/workflows/mirror.yml
+++ b/.github/workflows/mirror.yml
@@ -1,0 +1,19 @@
+name: Mirroring
+on: push
+
+jobs:
+  to_gitlab:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          ref: develop
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Push to Gitlab
+        run: cp --preserve .github/mirror.sh /tmp && /tmp/mirror.sh
+        env:
+          BOT_KEY: ${{ secrets.GITLAB_MIRROR_PRIV_KEY }}
+          BRANCH_NAME: ${{ github.ref }}
+          GITHUB_REPO: ${{ github.repository }}

--- a/.github/workflows/mirror.yml
+++ b/.github/workflows/mirror.yml
@@ -9,7 +9,6 @@ jobs:
         uses: actions/checkout@v2
         with:
           ref: develop
-          fetch-depth: 0
           persist-credentials: false
       - name: Push to Gitlab
         run: cp --preserve .github/mirror.sh /tmp && /tmp/mirror.sh


### PR DESCRIPTION
This adds push mirroring for the current branch.

The way it works is simple, add the GitLab remote, the ssh key, push force, and prune as needed.

See: https://gitlab.com/ginkgo-project/ginkgo-public-ci/-/pipelines/592229289

Questions: 
* can we assume there is always a branch?
* is there any implication of this change for our current workflow, do labels work as intended, etc?
* should we try pushing all branches simultaneously instead of only the current branch?
* ginkgo-bot will always be the triggerer in this way, should we reuse the author from the last commit instead?