### PR TITLE
Ensure we do not use shallow clone

### DIFF
--- a/.github/workflows/mirror.yml
+++ b/.github/workflows/mirror.yml
@@ -9,6 +9,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           ref: develop
+          fetch-depth: 0
           persist-credentials: false
       - name: Push to Gitlab
         run: cp --preserve .github/mirror.sh /tmp && /tmp/mirror.sh


### PR DESCRIPTION
Fix an error that appeared due to the last change

`fetch-depth: 0` ensures the complete history (of all branches) is pulled from the repository, otherwise shallow clone is used