### PR TITLE
Try to reproduce and fix CI test failures

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -935,7 +935,7 @@ threadsanitizer:
   script:
     - LD_PRELOAD=/usr/local/lib/libomp.so
       CC=clang CXX=clang++
-        ctest -V -S cmake/CTestScript.cmake -DCTEST_BUILD_CONFIGURATION=TSAN
+        ctest --output-on-failure -S cmake/CTestScript.cmake -DCTEST_BUILD_CONFIGURATION=TSAN
         -DCTEST_MEMORYCHECK_TYPE=ThreadSanitizer
         -DCTEST_MEMORYCHECK_SANITIZER_OPTIONS=ignore_noninstrumented_modules=1
         --timeout 6000
@@ -948,7 +948,7 @@ leaksanitizer:
     - .before_script_template
     - .use_gko-cuda101-openmpi-gnu8-llvm11-intel2019
   script:
-    - ctest -V -S cmake/CTestScript.cmake -DCTEST_BUILD_CONFIGURATION=LSAN
+    - ctest --output-on-failure -S cmake/CTestScript.cmake -DCTEST_BUILD_CONFIGURATION=LSAN
       -DCTEST_MEMORYCHECK_TYPE=LeakSanitizer
 
 addresssanitizer:
@@ -959,7 +959,7 @@ addresssanitizer:
     - .before_script_template
     - .use_gko-cuda101-openmpi-gnu8-llvm11-intel2019
   script:
-    - ctest -V -S cmake/CTestScript.cmake -DCTEST_BUILD_CONFIGURATION=ASAN
+    - ctest --output-on-failure -S cmake/CTestScript.cmake -DCTEST_BUILD_CONFIGURATION=ASAN
       -DCTEST_MEMORYCHECK_TYPE=AddressSanitizer
 
 undefinedsanitizer:
@@ -972,7 +972,7 @@ undefinedsanitizer:
   script:
     # the Gold linker is required because of a linker flag issues given by UBsan
     # in the Ubuntu setup we are using.
-    - ctest -V -S cmake/CTestScript.cmake -DCTEST_BUILD_CONFIGURATION=UBSAN
+    - ctest --output-on-failure -S cmake/CTestScript.cmake -DCTEST_BUILD_CONFIGURATION=UBSAN
       -DCTEST_MEMORYCHECK_TYPE=UndefinedBehaviorSanitizer
 
 cudamemcheck:
@@ -986,7 +986,7 @@ cudamemcheck:
     - private_ci
     - nvidia-gpu
   script:
-    - ctest -V -S cmake/CTestScript.cmake -DCTEST_BUILD_CONFIGURATION=RelWithDebInfo
+    - ctest --output-on-failure -S cmake/CTestScript.cmake -DCTEST_BUILD_CONFIGURATION=RelWithDebInfo
       -DCTEST_MEMORYCHECK_TYPE=CudaMemcheck
 
 new-issue-on-failure:

--- a/.gitlab/scripts.yml
+++ b/.gitlab/scripts.yml
@@ -94,7 +94,7 @@
     - ninja -j${NUM_CORES} -l${CI_LOAD_LIMIT} install
     - |
         (( $(ctest -N | tail -1 | sed 's/Total Tests: //') != 0 )) || exit 1
-    - ctest -V --timeout 3000
+    - ctest --output-on-failure --timeout 3000
     - ninja test_install
     - pushd test/test_install
     - ninja install
@@ -145,7 +145,7 @@
     - cd ${CI_JOB_NAME/test/build}
     - |
         (( $(ctest -N | tail -1 | sed 's/Total Tests: //') != 0 )) || exit 1
-    - ctest -V --timeout 3000
+    - ctest --output-on-failure --timeout 3000
     - ninja test_install
     - pushd test/test_install
     - ninja install


### PR DESCRIPTION
Also, reduce the size of our CI logs by only printing detailed test output on error.