### PR TITLE
Enable changing the residual tolerance after a batch solver is created

### DIFF
--- a/benchmark/solver/batch_solver.hpp
+++ b/benchmark/solver/batch_solver.hpp
@@ -295,8 +295,8 @@ std::unique_ptr<gko::BatchLinOpFactory> generate_solver(
     if (description == "richardson") {
         using Solver = gko::solver::BatchRichardson<etype>;
         return Solver::build()
-            .with_max_iterations(static_cast<int>(FLAGS_max_iters))
-            .with_residual_tol(
+            .with_default_max_iterations(static_cast<int>(FLAGS_max_iters))
+            .with_default_residual_tol(
                 static_cast<gko::remove_complex<etype>>(FLAGS_rel_res_goal))
             .with_preconditioner(prec_fact)
             .with_relaxation_factor(static_cast<gko::remove_complex<etype>>(
@@ -308,8 +308,8 @@ std::unique_ptr<gko::BatchLinOpFactory> generate_solver(
     } else if (description == "bicgstab") {
         using Solver = gko::solver::BatchBicgstab<etype>;
         return Solver::build()
-            .with_max_iterations(static_cast<int>(FLAGS_max_iters))
-            .with_residual_tol(
+            .with_default_max_iterations(static_cast<int>(FLAGS_max_iters))
+            .with_default_residual_tol(
                 static_cast<gko::remove_complex<etype>>(FLAGS_rel_res_goal))
             .with_preconditioner(prec_fact)
             .with_tolerance_type(toltype)
@@ -319,8 +319,8 @@ std::unique_ptr<gko::BatchLinOpFactory> generate_solver(
     } else if (description == "gmres") {
         using Solver = gko::solver::BatchGmres<etype>;
         return Solver::build()
-            .with_max_iterations(static_cast<int>(FLAGS_max_iters))
-            .with_residual_tol(
+            .with_default_max_iterations(static_cast<int>(FLAGS_max_iters))
+            .with_default_residual_tol(
                 static_cast<gko::remove_complex<etype>>(FLAGS_rel_res_goal))
             .with_preconditioner(prec_fact)
             .with_tolerance_type(toltype)

--- a/core/solver/batch_bicgstab.cpp
+++ b/core/solver/batch_bicgstab.cpp
@@ -61,11 +61,11 @@ std::unique_ptr<BatchLinOp> BatchBicgstab<ValueType>::transpose() const
         .with_generated_preconditioner(share(
             as<BatchTransposable>(this->get_preconditioner())->transpose()))
         .with_left_scaling_op(share(
-            as<BatchTransposable>(parameters_.left_scaling_op)->transpose()))
+            as<BatchTransposable>(this->get_left_scaling_op())->transpose()))
         .with_right_scaling_op(share(
-            as<BatchTransposable>(parameters_.right_scaling_op)->transpose()))
+            as<BatchTransposable>(this->get_right_scaling_op())->transpose()))
         .with_max_iterations(parameters_.max_iterations)
-        .with_residual_tol(parameters_.residual_tol)
+        .with_residual_tol(static_cast<real_type>(this->residual_tol_))
         .with_tolerance_type(parameters_.tolerance_type)
         .on(this->get_executor())
         ->generate(share(
@@ -82,13 +82,13 @@ std::unique_ptr<BatchLinOp> BatchBicgstab<ValueType>::conj_transpose() const
             share(as<BatchTransposable>(this->get_preconditioner())
                       ->conj_transpose()))
         .with_left_scaling_op(
-            share(as<BatchTransposable>(parameters_.left_scaling_op)
+            share(as<BatchTransposable>(this->get_left_scaling_op())
                       ->conj_transpose()))
         .with_right_scaling_op(
-            share(as<BatchTransposable>(parameters_.right_scaling_op)
+            share(as<BatchTransposable>(this->get_right_scaling_op())
                       ->conj_transpose()))
         .with_max_iterations(parameters_.max_iterations)
-        .with_residual_tol(parameters_.residual_tol)
+        .with_residual_tol(static_cast<real_type>(this->residual_tol_))
         .with_tolerance_type(parameters_.tolerance_type)
         .on(this->get_executor())
         ->generate(share(as<BatchTransposable>(this->get_system_matrix())
@@ -104,7 +104,8 @@ void BatchBicgstab<ValueType>::solver_apply(const BatchLinOp* const b,
     using Dense = matrix::BatchDense<ValueType>;
     const kernels::batch_bicgstab::BatchBicgstabOptions<
         remove_complex<ValueType>>
-        opts{parameters_.max_iterations, parameters_.residual_tol,
+        opts{parameters_.max_iterations,
+             static_cast<real_type>(this->residual_tol_),
              parameters_.tolerance_type};
     auto exec = this->get_executor();
     exec->run(batch_bicgstab::make_apply(

--- a/core/solver/batch_bicgstab.cpp
+++ b/core/solver/batch_bicgstab.cpp
@@ -75,6 +75,7 @@ std::unique_ptr<BatchLinOp> BatchBicgstab<ValueType>::transpose() const
             ->generate(share(
                 as<BatchTransposable>(this->get_system_matrix())->transpose()));
     tsolver->set_residual_tolerance(this->residual_tol_);
+    tsolver->set_max_iterations(this->max_iterations_);
     return tsolver;
 }
 
@@ -102,6 +103,7 @@ std::unique_ptr<BatchLinOp> BatchBicgstab<ValueType>::conj_transpose() const
             ->generate(share(as<BatchTransposable>(this->get_system_matrix())
                                  ->conj_transpose()));
     ctsolver->set_residual_tolerance(this->residual_tol_);
+    ctsolver->set_max_iterations(this->max_iterations_);
     return ctsolver;
 }
 

--- a/core/solver/batch_cg.cpp
+++ b/core/solver/batch_cg.cpp
@@ -61,11 +61,11 @@ std::unique_ptr<BatchLinOp> BatchCg<ValueType>::transpose() const
         .with_generated_preconditioner(share(
             as<BatchTransposable>(this->get_preconditioner())->transpose()))
         .with_left_scaling_op(share(
-            as<BatchTransposable>(parameters_.left_scaling_op)->transpose()))
+            as<BatchTransposable>(this->get_left_scaling_op())->transpose()))
         .with_right_scaling_op(share(
-            as<BatchTransposable>(parameters_.right_scaling_op)->transpose()))
+            as<BatchTransposable>(this->get_right_scaling_op())->transpose()))
         .with_max_iterations(parameters_.max_iterations)
-        .with_residual_tol(parameters_.residual_tol)
+        .with_residual_tol(static_cast<real_type>(this->residual_tol_))
         .with_tolerance_type(parameters_.tolerance_type)
         .on(this->get_executor())
         ->generate(share(
@@ -82,13 +82,13 @@ std::unique_ptr<BatchLinOp> BatchCg<ValueType>::conj_transpose() const
             share(as<BatchTransposable>(this->get_preconditioner())
                       ->conj_transpose()))
         .with_left_scaling_op(
-            share(as<BatchTransposable>(parameters_.left_scaling_op)
+            share(as<BatchTransposable>(this->get_left_scaling_op())
                       ->conj_transpose()))
         .with_right_scaling_op(
-            share(as<BatchTransposable>(parameters_.right_scaling_op)
+            share(as<BatchTransposable>(this->get_right_scaling_op())
                       ->conj_transpose()))
         .with_max_iterations(parameters_.max_iterations)
-        .with_residual_tol(parameters_.residual_tol)
+        .with_residual_tol(static_cast<real_type>(this->residual_tol_))
         .with_tolerance_type(parameters_.tolerance_type)
         .on(this->get_executor())
         ->generate(share(as<BatchTransposable>(this->get_system_matrix())
@@ -103,7 +103,7 @@ void BatchCg<ValueType>::solver_apply(const BatchLinOp* const b,
 {
     using Dense = matrix::BatchDense<ValueType>;
     const kernels::batch_cg::BatchCgOptions<remove_complex<ValueType>> opts{
-        parameters_.max_iterations, parameters_.residual_tol,
+        parameters_.max_iterations, static_cast<real_type>(this->residual_tol_),
         parameters_.tolerance_type};
     auto exec = this->get_executor();
     exec->run(batch_cg::make_apply(

--- a/core/solver/batch_cg.cpp
+++ b/core/solver/batch_cg.cpp
@@ -56,43 +56,53 @@ GKO_REGISTER_OPERATION(apply, batch_cg::apply);
 template <typename ValueType>
 std::unique_ptr<BatchLinOp> BatchCg<ValueType>::transpose() const
 {
-    return build()
-        .with_preconditioner(parameters_.preconditioner)
-        .with_generated_preconditioner(share(
-            as<BatchTransposable>(this->get_preconditioner())->transpose()))
-        .with_left_scaling_op(share(
-            as<BatchTransposable>(this->get_left_scaling_op())->transpose()))
-        .with_right_scaling_op(share(
-            as<BatchTransposable>(this->get_right_scaling_op())->transpose()))
-        .with_max_iterations(parameters_.max_iterations)
-        .with_residual_tol(static_cast<real_type>(this->residual_tol_))
-        .with_tolerance_type(parameters_.tolerance_type)
-        .on(this->get_executor())
-        ->generate(share(
-            as<BatchTransposable>(this->get_system_matrix())->transpose()));
+    auto tsolver =
+        build()
+            .with_preconditioner(parameters_.preconditioner)
+            .with_generated_preconditioner(share(
+                as<BatchTransposable>(this->get_preconditioner())->transpose()))
+            .with_left_scaling_op(
+                share(as<BatchTransposable>(this->get_left_scaling_op())
+                          ->transpose()))
+            .with_right_scaling_op(
+                share(as<BatchTransposable>(this->get_right_scaling_op())
+                          ->transpose()))
+            .with_default_max_iterations(parameters_.default_max_iterations)
+            .with_default_residual_tol(parameters_.default_residual_tol)
+            .with_tolerance_type(parameters_.tolerance_type)
+            .on(this->get_executor())
+            ->generate(share(
+                as<BatchTransposable>(this->get_system_matrix())->transpose()));
+    tsolver->set_residual_tolerance(this->residual_tol_);
+    tsolver->set_max_iterations(this->max_iterations_);
+    return tsolver;
 }
 
 
 template <typename ValueType>
 std::unique_ptr<BatchLinOp> BatchCg<ValueType>::conj_transpose() const
 {
-    return build()
-        .with_preconditioner(parameters_.preconditioner)
-        .with_generated_preconditioner(
-            share(as<BatchTransposable>(this->get_preconditioner())
-                      ->conj_transpose()))
-        .with_left_scaling_op(
-            share(as<BatchTransposable>(this->get_left_scaling_op())
-                      ->conj_transpose()))
-        .with_right_scaling_op(
-            share(as<BatchTransposable>(this->get_right_scaling_op())
-                      ->conj_transpose()))
-        .with_max_iterations(parameters_.max_iterations)
-        .with_residual_tol(static_cast<real_type>(this->residual_tol_))
-        .with_tolerance_type(parameters_.tolerance_type)
-        .on(this->get_executor())
-        ->generate(share(as<BatchTransposable>(this->get_system_matrix())
-                             ->conj_transpose()));
+    auto ctsolver =
+        build()
+            .with_preconditioner(parameters_.preconditioner)
+            .with_generated_preconditioner(
+                share(as<BatchTransposable>(this->get_preconditioner())
+                          ->conj_transpose()))
+            .with_left_scaling_op(
+                share(as<BatchTransposable>(this->get_left_scaling_op())
+                          ->conj_transpose()))
+            .with_right_scaling_op(
+                share(as<BatchTransposable>(this->get_right_scaling_op())
+                          ->conj_transpose()))
+            .with_default_max_iterations(parameters_.default_max_iterations)
+            .with_default_residual_tol(parameters_.default_residual_tol)
+            .with_tolerance_type(parameters_.tolerance_type)
+            .on(this->get_executor())
+            ->generate(share(as<BatchTransposable>(this->get_system_matrix())
+                                 ->conj_transpose()));
+    ctsolver->set_residual_tolerance(this->residual_tol_);
+    ctsolver->set_max_iterations(this->max_iterations_);
+    return ctsolver;
 }
 
 
@@ -103,7 +113,7 @@ void BatchCg<ValueType>::solver_apply(const BatchLinOp* const b,
 {
     using Dense = matrix::BatchDense<ValueType>;
     const kernels::batch_cg::BatchCgOptions<remove_complex<ValueType>> opts{
-        parameters_.max_iterations, static_cast<real_type>(this->residual_tol_),
+        this->max_iterations_, static_cast<real_type>(this->residual_tol_),
         parameters_.tolerance_type};
     auto exec = this->get_executor();
     exec->run(batch_cg::make_apply(

--- a/core/solver/batch_dispatch.hpp
+++ b/core/solver/batch_dispatch.hpp
@@ -34,13 +34,13 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define GKO_CORE_SOLVER_BATCH_DISPATCH_HPP_
 
 
+#include <ginkgo/core/matrix/batch_identity.hpp>
 #include <ginkgo/core/preconditioner/batch_ilu.hpp>
 #include <ginkgo/core/preconditioner/batch_isai.hpp>
 #include <ginkgo/core/preconditioner/batch_jacobi.hpp>
 
 
 #include "core/log/batch_logging.hpp"
-#include "ginkgo/core/matrix/batch_identity.hpp"
 
 
 #if defined GKO_COMPILING_CUDA
@@ -197,8 +197,7 @@ public:
         const gko::batch_dense::UniformBatch<device_value_type>& x_b)
     {
         if (!precon_ ||
-            dynamic_cast<const matrix::BatchIdentity<device_value_type>*>(
-                precon_)) {
+            dynamic_cast<const matrix::BatchIdentity<value_type>*>(precon_)) {
             dispatch_on_stop<device::BatchIdentity<device_value_type>>(
                 logger, amat, device::BatchIdentity<device_value_type>(), b_b,
                 x_b);

--- a/core/solver/batch_dispatch.hpp
+++ b/core/solver/batch_dispatch.hpp
@@ -40,6 +40,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
 #include "core/log/batch_logging.hpp"
+#include "ginkgo/core/matrix/batch_identity.hpp"
 
 
 #if defined GKO_COMPILING_CUDA
@@ -195,7 +196,9 @@ public:
         const gko::batch_dense::UniformBatch<const device_value_type>& b_b,
         const gko::batch_dense::UniformBatch<device_value_type>& x_b)
     {
-        if (!precon_) {
+        if (!precon_ ||
+            dynamic_cast<const matrix::BatchIdentity<device_value_type>*>(
+                precon_)) {
             dispatch_on_stop<device::BatchIdentity<device_value_type>>(
                 logger, amat, device::BatchIdentity<device_value_type>(), b_b,
                 x_b);

--- a/core/solver/batch_gmres.cpp
+++ b/core/solver/batch_gmres.cpp
@@ -61,11 +61,11 @@ std::unique_ptr<BatchLinOp> BatchGmres<ValueType>::transpose() const
         .with_generated_preconditioner(share(
             as<BatchTransposable>(this->get_preconditioner())->transpose()))
         .with_left_scaling_op(share(
-            as<BatchTransposable>(parameters_.left_scaling_op)->transpose()))
+            as<BatchTransposable>(this->get_left_scaling_op())->transpose()))
         .with_right_scaling_op(share(
-            as<BatchTransposable>(parameters_.right_scaling_op)->transpose()))
+            as<BatchTransposable>(this->get_right_scaling_op())->transpose()))
         .with_max_iterations(parameters_.max_iterations)
-        .with_residual_tol(parameters_.residual_tol)
+        .with_residual_tol(static_cast<real_type>(this->residual_tol_))
         .with_restart(parameters_.restart)
         .with_tolerance_type(parameters_.tolerance_type)
         .on(this->get_executor())
@@ -83,13 +83,13 @@ std::unique_ptr<BatchLinOp> BatchGmres<ValueType>::conj_transpose() const
             share(as<BatchTransposable>(this->get_preconditioner())
                       ->conj_transpose()))
         .with_left_scaling_op(
-            share(as<BatchTransposable>(parameters_.left_scaling_op)
+            share(as<BatchTransposable>(this->get_left_scaling_op())
                       ->conj_transpose()))
         .with_right_scaling_op(
-            share(as<BatchTransposable>(parameters_.right_scaling_op)
+            share(as<BatchTransposable>(this->get_right_scaling_op())
                       ->conj_transpose()))
         .with_max_iterations(parameters_.max_iterations)
-        .with_residual_tol(parameters_.residual_tol)
+        .with_residual_tol(static_cast<real_type>(this->residual_tol_))
         .with_restart(parameters_.restart)
         .with_tolerance_type(parameters_.tolerance_type)
         .on(this->get_executor())
@@ -105,8 +105,9 @@ void BatchGmres<ValueType>::solver_apply(const BatchLinOp* const b,
 {
     using Dense = matrix::BatchDense<ValueType>;
     const kernels::batch_gmres::BatchGmresOptions<remove_complex<ValueType>>
-        opts{parameters_.max_iterations, parameters_.residual_tol,
-             parameters_.restart, parameters_.tolerance_type};
+        opts{parameters_.max_iterations,
+             static_cast<real_type>(this->residual_tol_), parameters_.restart,
+             parameters_.tolerance_type};
     auto exec = this->get_executor();
     exec->run(batch_gmres::make_apply(
         opts, this->system_matrix_.get(), this->preconditioner_.get(),

--- a/core/solver/batch_idr.cpp
+++ b/core/solver/batch_idr.cpp
@@ -61,11 +61,11 @@ std::unique_ptr<BatchLinOp> BatchIdr<ValueType>::transpose() const
         .with_generated_preconditioner(share(
             as<BatchTransposable>(this->get_preconditioner())->transpose()))
         .with_left_scaling_op(share(
-            as<BatchTransposable>(parameters_.left_scaling_op)->transpose()))
+            as<BatchTransposable>(this->get_left_scaling_op())->transpose()))
         .with_right_scaling_op(share(
-            as<BatchTransposable>(parameters_.right_scaling_op)->transpose()))
+            as<BatchTransposable>(this->get_right_scaling_op())->transpose()))
         .with_max_iterations(parameters_.max_iterations)
-        .with_residual_tol(parameters_.residual_tol)
+        .with_residual_tol(static_cast<real_type>(this->residual_tol_))
         .with_subspace_dim(parameters_.subspace_dim)
         .with_complex_subspace(parameters_.complex_subspace)
         .with_kappa(parameters_.kappa)
@@ -87,13 +87,13 @@ std::unique_ptr<BatchLinOp> BatchIdr<ValueType>::conj_transpose() const
             share(as<BatchTransposable>(this->get_preconditioner())
                       ->conj_transpose()))
         .with_left_scaling_op(
-            share(as<BatchTransposable>(parameters_.left_scaling_op)
+            share(as<BatchTransposable>(this->get_left_scaling_op())
                       ->conj_transpose()))
         .with_right_scaling_op(
-            share(as<BatchTransposable>(parameters_.right_scaling_op)
+            share(as<BatchTransposable>(this->get_right_scaling_op())
                       ->conj_transpose()))
         .with_max_iterations(parameters_.max_iterations)
-        .with_residual_tol(parameters_.residual_tol)
+        .with_residual_tol(static_cast<real_type>(this->residual_tol_))
         .with_subspace_dim(parameters_.subspace_dim)
         .with_complex_subspace(parameters_.complex_subspace)
         .with_kappa(parameters_.kappa)
@@ -113,7 +113,7 @@ void BatchIdr<ValueType>::solver_apply(const BatchLinOp* const b,
 {
     using Dense = matrix::BatchDense<ValueType>;
     const kernels::batch_idr::BatchIdrOptions<remove_complex<ValueType>> opts{
-        parameters_.max_iterations, parameters_.residual_tol,
+        parameters_.max_iterations, static_cast<real_type>(this->residual_tol_),
         parameters_.subspace_dim,   parameters_.complex_subspace,
         parameters_.kappa,          parameters_.smoothing,
         parameters_.deterministic,  parameters_.tolerance_type};

--- a/core/solver/batch_idr.cpp
+++ b/core/solver/batch_idr.cpp
@@ -56,53 +56,63 @@ GKO_REGISTER_OPERATION(apply, batch_idr::apply);
 template <typename ValueType>
 std::unique_ptr<BatchLinOp> BatchIdr<ValueType>::transpose() const
 {
-    return build()
-        .with_preconditioner(parameters_.preconditioner)
-        .with_generated_preconditioner(share(
-            as<BatchTransposable>(this->get_preconditioner())->transpose()))
-        .with_left_scaling_op(share(
-            as<BatchTransposable>(this->get_left_scaling_op())->transpose()))
-        .with_right_scaling_op(share(
-            as<BatchTransposable>(this->get_right_scaling_op())->transpose()))
-        .with_max_iterations(parameters_.max_iterations)
-        .with_residual_tol(static_cast<real_type>(this->residual_tol_))
-        .with_subspace_dim(parameters_.subspace_dim)
-        .with_complex_subspace(parameters_.complex_subspace)
-        .with_kappa(parameters_.kappa)
-        .with_smoothing(parameters_.smoothing)
-        .with_deterministic(parameters_.deterministic)
-        .with_tolerance_type(parameters_.tolerance_type)
-        .on(this->get_executor())
-        ->generate(share(
-            as<BatchTransposable>(this->get_system_matrix())->transpose()));
+    auto tsolver =
+        build()
+            .with_preconditioner(parameters_.preconditioner)
+            .with_generated_preconditioner(share(
+                as<BatchTransposable>(this->get_preconditioner())->transpose()))
+            .with_left_scaling_op(
+                share(as<BatchTransposable>(this->get_left_scaling_op())
+                          ->transpose()))
+            .with_right_scaling_op(
+                share(as<BatchTransposable>(this->get_right_scaling_op())
+                          ->transpose()))
+            .with_default_max_iterations(parameters_.default_max_iterations)
+            .with_default_residual_tol(parameters_.default_residual_tol)
+            .with_subspace_dim(parameters_.subspace_dim)
+            .with_complex_subspace(parameters_.complex_subspace)
+            .with_kappa(parameters_.kappa)
+            .with_smoothing(parameters_.smoothing)
+            .with_deterministic(parameters_.deterministic)
+            .with_tolerance_type(parameters_.tolerance_type)
+            .on(this->get_executor())
+            ->generate(share(
+                as<BatchTransposable>(this->get_system_matrix())->transpose()));
+    tsolver->set_residual_tolerance(this->residual_tol_);
+    tsolver->set_max_iterations(this->max_iterations_);
+    return tsolver;
 }
 
 
 template <typename ValueType>
 std::unique_ptr<BatchLinOp> BatchIdr<ValueType>::conj_transpose() const
 {
-    return build()
-        .with_preconditioner(parameters_.preconditioner)
-        .with_generated_preconditioner(
-            share(as<BatchTransposable>(this->get_preconditioner())
-                      ->conj_transpose()))
-        .with_left_scaling_op(
-            share(as<BatchTransposable>(this->get_left_scaling_op())
-                      ->conj_transpose()))
-        .with_right_scaling_op(
-            share(as<BatchTransposable>(this->get_right_scaling_op())
-                      ->conj_transpose()))
-        .with_max_iterations(parameters_.max_iterations)
-        .with_residual_tol(static_cast<real_type>(this->residual_tol_))
-        .with_subspace_dim(parameters_.subspace_dim)
-        .with_complex_subspace(parameters_.complex_subspace)
-        .with_kappa(parameters_.kappa)
-        .with_smoothing(parameters_.smoothing)
-        .with_deterministic(parameters_.deterministic)
-        .with_tolerance_type(parameters_.tolerance_type)
-        .on(this->get_executor())
-        ->generate(share(as<BatchTransposable>(this->get_system_matrix())
-                             ->conj_transpose()));
+    auto ctsolver =
+        build()
+            .with_preconditioner(parameters_.preconditioner)
+            .with_generated_preconditioner(
+                share(as<BatchTransposable>(this->get_preconditioner())
+                          ->conj_transpose()))
+            .with_left_scaling_op(
+                share(as<BatchTransposable>(this->get_left_scaling_op())
+                          ->conj_transpose()))
+            .with_right_scaling_op(
+                share(as<BatchTransposable>(this->get_right_scaling_op())
+                          ->conj_transpose()))
+            .with_default_max_iterations(parameters_.default_max_iterations)
+            .with_default_residual_tol(parameters_.default_residual_tol)
+            .with_subspace_dim(parameters_.subspace_dim)
+            .with_complex_subspace(parameters_.complex_subspace)
+            .with_kappa(parameters_.kappa)
+            .with_smoothing(parameters_.smoothing)
+            .with_deterministic(parameters_.deterministic)
+            .with_tolerance_type(parameters_.tolerance_type)
+            .on(this->get_executor())
+            ->generate(share(as<BatchTransposable>(this->get_system_matrix())
+                                 ->conj_transpose()));
+    ctsolver->set_residual_tolerance(this->residual_tol_);
+    ctsolver->set_max_iterations(this->max_iterations_);
+    return ctsolver;
 }
 
 
@@ -113,10 +123,10 @@ void BatchIdr<ValueType>::solver_apply(const BatchLinOp* const b,
 {
     using Dense = matrix::BatchDense<ValueType>;
     const kernels::batch_idr::BatchIdrOptions<remove_complex<ValueType>> opts{
-        parameters_.max_iterations, static_cast<real_type>(this->residual_tol_),
-        parameters_.subspace_dim,   parameters_.complex_subspace,
-        parameters_.kappa,          parameters_.smoothing,
-        parameters_.deterministic,  parameters_.tolerance_type};
+        this->max_iterations_,     static_cast<real_type>(this->residual_tol_),
+        parameters_.subspace_dim,  parameters_.complex_subspace,
+        parameters_.kappa,         parameters_.smoothing,
+        parameters_.deterministic, parameters_.tolerance_type};
     auto exec = this->get_executor();
     exec->run(batch_idr::make_apply(
         opts, this->system_matrix_.get(), this->preconditioner_.get(),

--- a/core/solver/batch_richardson.cpp
+++ b/core/solver/batch_richardson.cpp
@@ -61,11 +61,11 @@ std::unique_ptr<BatchLinOp> BatchRichardson<ValueType>::transpose() const
         .with_generated_preconditioner(share(
             as<BatchTransposable>(this->get_preconditioner())->transpose()))
         .with_left_scaling_op(share(
-            as<BatchTransposable>(parameters_.left_scaling_op)->transpose()))
+            as<BatchTransposable>(this->get_left_scaling_op())->transpose()))
         .with_right_scaling_op(share(
-            as<BatchTransposable>(parameters_.right_scaling_op)->transpose()))
+            as<BatchTransposable>(this->get_right_scaling_op())->transpose()))
         .with_max_iterations(parameters_.max_iterations)
-        .with_residual_tol(parameters_.residual_tol)
+        .with_residual_tol(static_cast<real_type>(this->residual_tol_))
         .with_tolerance_type(parameters_.tolerance_type)
         .with_relaxation_factor(parameters_.relaxation_factor)
         .on(this->get_executor())
@@ -83,13 +83,13 @@ std::unique_ptr<BatchLinOp> BatchRichardson<ValueType>::conj_transpose() const
             share(as<BatchTransposable>(this->get_preconditioner())
                       ->conj_transpose()))
         .with_left_scaling_op(
-            share(as<BatchTransposable>(parameters_.left_scaling_op)
+            share(as<BatchTransposable>(this->get_left_scaling_op())
                       ->conj_transpose()))
         .with_right_scaling_op(
-            share(as<BatchTransposable>(parameters_.right_scaling_op)
+            share(as<BatchTransposable>(this->get_right_scaling_op())
                       ->conj_transpose()))
         .with_max_iterations(parameters_.max_iterations)
-        .with_residual_tol(parameters_.residual_tol)
+        .with_residual_tol(static_cast<real_type>(this->residual_tol_))
         .with_tolerance_type(parameters_.tolerance_type)
         .with_relaxation_factor(conj(parameters_.relaxation_factor))
         .on(this->get_executor())
@@ -105,7 +105,8 @@ void BatchRichardson<ValueType>::solver_apply(const BatchLinOp* const b,
 {
     using Dense = matrix::BatchDense<ValueType>;
     const kernels::batch_rich::BatchRichardsonOptions<remove_complex<ValueType>>
-        opts{parameters_.max_iterations, parameters_.residual_tol,
+        opts{parameters_.max_iterations,
+             static_cast<real_type>(this->residual_tol_),
              parameters_.tolerance_type, parameters_.relaxation_factor};
     auto exec = this->get_executor();
     exec->run(batch_rich::make_apply(

--- a/core/solver/batch_solver.ipp
+++ b/core/solver/batch_solver.ipp
@@ -62,7 +62,8 @@ EnableBatchSolver<ConcreteSolver, PolymorphicBase>::EnableBatchSolver(
         exec, gko::transpose(system_matrix->get_size())),
       system_matrix_{std::move(system_matrix)},
       left_scaling_{common_params.left_scaling_op},
-      right_scaling_{common_params.right_scaling_op}
+      right_scaling_{common_params.right_scaling_op},
+      residual_tol_{common_params.residual_tolerance}
 {
     GKO_ASSERT_BATCH_HAS_SQUARE_MATRICES(system_matrix_);
 

--- a/core/solver/batch_solver.ipp
+++ b/core/solver/batch_solver.ipp
@@ -58,12 +58,12 @@ EnableBatchSolver<ConcreteSolver, PolymorphicBase>::EnableBatchSolver(
     std::shared_ptr<const Executor> exec,
     std::shared_ptr<const BatchLinOp> system_matrix,
     detail::common_batch_params common_params)
-    : EnableBatchLinOp<ConcreteSolver, PolymorphicBase>(
-        exec, gko::transpose(system_matrix->get_size())),
-      system_matrix_{std::move(system_matrix)},
-      left_scaling_{common_params.left_scaling_op},
-      right_scaling_{common_params.right_scaling_op},
-      residual_tol_{common_params.residual_tolerance}
+    : BatchSolver(system_matrix, nullptr,
+                  common_params.left_scaling_op, common_params.right_scaling_op,
+                  common_params.residual_tolerance,
+                  common_params.max_iterations),
+      EnableBatchLinOp<ConcreteSolver, PolymorphicBase>(
+          exec, gko::transpose(system_matrix->get_size()))
 {
     GKO_ASSERT_BATCH_HAS_SQUARE_MATRICES(system_matrix_);
 

--- a/core/test/solver/batch_bicgstab.cpp
+++ b/core/test/solver/batch_bicgstab.cpp
@@ -65,8 +65,8 @@ protected:
                   this->exec),
               nrows, nbatch)),
           batchbicgstab_factory(Solver::build()
-                                    .with_max_iterations(def_max_iters)
-                                    .with_residual_tol(def_abs_res_tol)
+                                    .with_default_max_iterations(def_max_iters)
+                                    .with_default_residual_tol(def_abs_res_tol)
                                     .with_tolerance_type(def_tol_type)
                                     .on(exec)),
           solver(batchbicgstab_factory->generate(mtx))
@@ -186,15 +186,15 @@ TYPED_TEST(BatchBicgstab, CanSetCriteriaInFactory)
 
     auto batchbicgstab_factory =
         Solver::build()
-            .with_max_iterations(22)
-            .with_residual_tol(static_cast<RT>(0.25))
+            .with_default_max_iterations(22)
+            .with_default_residual_tol(static_cast<RT>(0.25))
             .with_tolerance_type(gko::stop::batch::ToleranceType::relative)
             .on(this->exec);
     auto solver = batchbicgstab_factory->generate(this->mtx);
 
-    ASSERT_EQ(solver->get_parameters().max_iterations, 22);
+    ASSERT_EQ(solver->get_parameters().default_max_iterations, 22);
     const RT tol = std::numeric_limits<RT>::epsilon();
-    ASSERT_NEAR(solver->get_parameters().residual_tol, 0.25, tol);
+    ASSERT_NEAR(solver->get_parameters().default_residual_tol, 0.25, tol);
     ASSERT_EQ(solver->get_parameters().tolerance_type,
               gko::stop::batch::ToleranceType::relative);
 }
@@ -206,16 +206,35 @@ TYPED_TEST(BatchBicgstab, CanSetResidualTol)
     using RT = typename TestFixture::real_type;
     auto batchbicgstab_factory =
         Solver::build()
-            .with_max_iterations(22)
-            .with_residual_tol(static_cast<RT>(0.25))
+            .with_default_max_iterations(22)
+            .with_default_residual_tol(static_cast<RT>(0.25))
             .with_tolerance_type(gko::stop::batch::ToleranceType::relative)
             .on(this->exec);
     auto solver = batchbicgstab_factory->generate(this->mtx);
 
     solver->set_residual_tolerance(0.5);
 
-    ASSERT_NEAR(solver->get_parameters().residual_tol, 0.25, 0.0);
+    ASSERT_NEAR(solver->get_parameters().default_residual_tol, 0.25, 0.0);
     ASSERT_EQ(solver->get_residual_tolerance(), 0.5);
+}
+
+
+TYPED_TEST(BatchBicgstab, CanSetMaxIterations)
+{
+    using Solver = typename TestFixture::Solver;
+    using RT = typename TestFixture::real_type;
+    auto batchbicgstab_factory =
+        Solver::build()
+            .with_default_max_iterations(22)
+            .with_default_residual_tol(static_cast<RT>(0.25))
+            .with_tolerance_type(gko::stop::batch::ToleranceType::relative)
+            .on(this->exec);
+    auto solver = batchbicgstab_factory->generate(this->mtx);
+
+    solver->set_max_iterations(10);
+
+    ASSERT_NEAR(solver->get_parameters().default_max_iterations, 22, 0.0);
+    ASSERT_EQ(solver->get_max_iterations(), 10);
 }
 
 
@@ -227,7 +246,7 @@ TYPED_TEST(BatchBicgstab, CanSetPreconditionerFactory)
         gko::preconditioner::BatchJacobi<value_type>::build().on(this->exec));
 
     auto batchbicgstab_factory = Solver::build()
-                                     .with_max_iterations(3)
+                                     .with_default_max_iterations(3)
                                      .with_preconditioner(prec_factory)
                                      .on(this->exec);
     auto solver = batchbicgstab_factory->generate(this->mtx);

--- a/core/test/solver/batch_bicgstab.cpp
+++ b/core/test/solver/batch_bicgstab.cpp
@@ -286,31 +286,31 @@ TYPED_TEST(BatchBicgstab, CanSetScalingVectors)
                                      .on(this->exec);
     auto solver = batchbicgstab_factory->generate(this->mtx);
 
-    // solver->batch_scale(left_scale.get(), right_scale.get());
-    // auto s_solver = gko::as<gko::EnableBatchScaling>(solver.get());
-
-    // ASSERT_TRUE(s_solver);
     ASSERT_EQ(solver->get_left_scaling_op(), left_scale);
     ASSERT_EQ(solver->get_right_scaling_op(), right_scale);
 }
 
 
-// TYPED_TEST(BatchBicgstab, SolverTransposeRetainsFactoryParameters)
+// TYPED_TEST(BatchBicgstab, SolverTransposeRetainsParameters)
 // {
 //     using Solver = typename TestFixture::Solver;
-
 //     auto batchbicgstab_factory =
-// Solver::build().with_max_iterations(3).with_residual_tol(0.25f)
-// .with_tolerance_type(gko::stop::batch::ToleranceType::relative).with_preconditioner(gko::preconditioner::batch::type::none).on(this->exec);
+//         Solver::build().with_default_max_iterations(3).with_default_residual_tol(0.25f)
+//         .with_tolerance_type(gko::stop::batch::ToleranceType::relative).on(this->exec);
 //     auto solver = batchbicgstab_factory->generate(this->mtx);
-// 	auto solver_trans = gko::as<Solver>(solver->transpose());
-// 	auto params = solver_trans->get_parameters();
 
-// 	ASSERT_EQ(params.preconditioner,
-// gko::preconditioner::batch::type::none); ASSERT_EQ(params.max_iterations, 3);
-// 	ASSERT_EQ(params.residual_tol, 0.25);
+//     solver->set_residual_tolerance(0.5f);
+//     solver->set_max_iterations(5);
+// 	auto solver_trans = gko::as<Solver>(solver->transpose());
+
+// 	auto params = solver_trans->get_parameters();
+//     ASSERT_EQ(params.preconditioner, nullptr);
+//     ASSERT_EQ(params.default_max_iterations, 3);
+// 	ASSERT_EQ(params.default_residual_tol, 0.25);
 // 	ASSERT_EQ(params.tolerance_type,
 // gko::stop::batch::ToleranceType::relative);
+//     ASSERT_EQ(solver_trans->get_max_iterations(), 5);
+//     ASSERT_EQ(solver_trans->get_residual_tolerance(), 0.5f);
 // }
 
 

--- a/core/test/solver/batch_bicgstab.cpp
+++ b/core/test/solver/batch_bicgstab.cpp
@@ -179,7 +179,7 @@ TYPED_TEST(BatchBicgstab, ApplyUsesInitialGuessReturnsTrue)
 }
 
 
-TYPED_TEST(BatchBicgstab, CanSetCriteria)
+TYPED_TEST(BatchBicgstab, CanSetCriteriaInFactory)
 {
     using Solver = typename TestFixture::Solver;
     using RT = typename TestFixture::real_type;
@@ -197,6 +197,25 @@ TYPED_TEST(BatchBicgstab, CanSetCriteria)
     ASSERT_NEAR(solver->get_parameters().residual_tol, 0.25, tol);
     ASSERT_EQ(solver->get_parameters().tolerance_type,
               gko::stop::batch::ToleranceType::relative);
+}
+
+
+TYPED_TEST(BatchBicgstab, CanSetResidualTol)
+{
+    using Solver = typename TestFixture::Solver;
+    using RT = typename TestFixture::real_type;
+    auto batchbicgstab_factory =
+        Solver::build()
+            .with_max_iterations(22)
+            .with_residual_tol(static_cast<RT>(0.25))
+            .with_tolerance_type(gko::stop::batch::ToleranceType::relative)
+            .on(this->exec);
+    auto solver = batchbicgstab_factory->generate(this->mtx);
+
+    solver->set_residual_tolerance(0.5);
+
+    ASSERT_NEAR(solver->get_parameters().residual_tol, 0.25, 0.0);
+    ASSERT_EQ(solver->get_residual_tolerance(), 0.5);
 }
 
 

--- a/core/test/solver/batch_cg.cpp
+++ b/core/test/solver/batch_cg.cpp
@@ -178,7 +178,7 @@ TYPED_TEST(BatchCg, ApplyUsesInitialGuessReturnsTrue)
 }
 
 
-TYPED_TEST(BatchCg, CanSetCriteria)
+TYPED_TEST(BatchCg, CanSetCriteriaInFactory)
 {
     using Solver = typename TestFixture::Solver;
     using RT = typename TestFixture::real_type;
@@ -196,6 +196,25 @@ TYPED_TEST(BatchCg, CanSetCriteria)
     ASSERT_NEAR(solver->get_parameters().residual_tol, 0.25, tol);
     ASSERT_EQ(solver->get_parameters().tolerance_type,
               gko::stop::batch::ToleranceType::relative);
+}
+
+
+TYPED_TEST(BatchCg, CanSetResidualTol)
+{
+    using Solver = typename TestFixture::Solver;
+    using RT = typename TestFixture::real_type;
+    auto factory =
+        Solver::build()
+            .with_max_iterations(22)
+            .with_residual_tol(static_cast<RT>(0.25))
+            .with_tolerance_type(gko::stop::batch::ToleranceType::relative)
+            .on(this->exec);
+    auto solver = factory->generate(this->mtx);
+
+    solver->set_residual_tolerance(0.5);
+
+    ASSERT_EQ(solver->get_parameters().residual_tol, 0.25);
+    ASSERT_EQ(solver->get_residual_tolerance(), 0.5);
 }
 
 

--- a/core/test/solver/batch_cg.cpp
+++ b/core/test/solver/batch_cg.cpp
@@ -65,8 +65,8 @@ protected:
                   this->exec),
               nrows, nbatch)),
           batchcg_factory(Solver::build()
-                              .with_max_iterations(def_max_iters)
-                              .with_residual_tol(def_abs_res_tol)
+                              .with_default_max_iterations(def_max_iters)
+                              .with_default_residual_tol(def_abs_res_tol)
                               .with_tolerance_type(def_tol_type)
                               .on(exec)),
           solver(batchcg_factory->generate(mtx))
@@ -185,15 +185,15 @@ TYPED_TEST(BatchCg, CanSetCriteriaInFactory)
 
     auto batchcg_factory =
         Solver::build()
-            .with_max_iterations(22)
-            .with_residual_tol(static_cast<RT>(0.25))
+            .with_default_max_iterations(22)
+            .with_default_residual_tol(static_cast<RT>(0.25))
             .with_tolerance_type(gko::stop::batch::ToleranceType::relative)
             .on(this->exec);
     auto solver = batchcg_factory->generate(this->mtx);
 
-    ASSERT_EQ(solver->get_parameters().max_iterations, 22);
+    ASSERT_EQ(solver->get_parameters().default_max_iterations, 22);
     const RT tol = std::numeric_limits<RT>::epsilon();
-    ASSERT_NEAR(solver->get_parameters().residual_tol, 0.25, tol);
+    ASSERT_NEAR(solver->get_parameters().default_residual_tol, 0.25, tol);
     ASSERT_EQ(solver->get_parameters().tolerance_type,
               gko::stop::batch::ToleranceType::relative);
 }
@@ -205,15 +205,15 @@ TYPED_TEST(BatchCg, CanSetResidualTol)
     using RT = typename TestFixture::real_type;
     auto factory =
         Solver::build()
-            .with_max_iterations(22)
-            .with_residual_tol(static_cast<RT>(0.25))
+            .with_default_max_iterations(22)
+            .with_default_residual_tol(static_cast<RT>(0.25))
             .with_tolerance_type(gko::stop::batch::ToleranceType::relative)
             .on(this->exec);
     auto solver = factory->generate(this->mtx);
 
     solver->set_residual_tolerance(0.5);
 
-    ASSERT_EQ(solver->get_parameters().residual_tol, 0.25);
+    ASSERT_EQ(solver->get_parameters().default_residual_tol, 0.25);
     ASSERT_EQ(solver->get_residual_tolerance(), 0.5);
 }
 
@@ -226,7 +226,7 @@ TYPED_TEST(BatchCg, CanSetPreconditionerFactory)
         gko::preconditioner::BatchJacobi<value_type>::build().on(this->exec));
 
     auto batchcg_factory = Solver::build()
-                               .with_max_iterations(3)
+                               .with_default_max_iterations(3)
                                .with_preconditioner(prec_factory)
                                .on(this->exec);
     auto solver = batchcg_factory->generate(this->mtx);
@@ -277,8 +277,8 @@ TYPED_TEST(BatchCg, CanSetScalingOps)
 
 //     auto batchcg_factory =
 //         Solver::build()
-//             .with_max_iterations(3)
-//             .with_residual_tol(0.25f)
+//             .with_default_max_iterations(3)
+//             .with_default_residual_tol(0.25f)
 //             .with_tolerance_type(gko::stop::batch::ToleranceType::relative)
 //             .with_preconditioner(gko::preconditioner::batch::type::none)
 //             .on(this->exec);
@@ -287,8 +287,8 @@ TYPED_TEST(BatchCg, CanSetScalingOps)
 //     auto params = solver_trans->get_parameters();
 
 //     ASSERT_EQ(params.preconditioner, gko::preconditioner::batch::type::none);
-//     ASSERT_EQ(params.max_iterations, 3);
-//     ASSERT_EQ(params.residual_tol, 0.25);
+//     ASSERT_EQ(params.default_max_iterations, 3);
+//     ASSERT_EQ(params.default_residual_tol, 0.25);
 //     ASSERT_EQ(params.tolerance_type,
 //     gko::stop::batch::ToleranceType::relative);
 // }

--- a/core/test/solver/batch_gmres.cpp
+++ b/core/test/solver/batch_gmres.cpp
@@ -179,7 +179,7 @@ TYPED_TEST(BatchGmres, ApplyUsesInitialGuessReturnsTrue)
 }
 
 
-TYPED_TEST(BatchGmres, CanSetCriteria)
+TYPED_TEST(BatchGmres, CanSetCriteriaInFactory)
 {
     using Solver = typename TestFixture::Solver;
     using RT = typename TestFixture::real_type;
@@ -199,6 +199,25 @@ TYPED_TEST(BatchGmres, CanSetCriteria)
     ASSERT_EQ(solver->get_parameters().tolerance_type,
               gko::stop::batch::ToleranceType::relative);
     ASSERT_EQ(solver->get_parameters().restart, 3);
+}
+
+
+TYPED_TEST(BatchGmres, CanSetResidualTol)
+{
+    using Solver = typename TestFixture::Solver;
+    using RT = typename TestFixture::real_type;
+    auto factory =
+        Solver::build()
+            .with_max_iterations(22)
+            .with_residual_tol(static_cast<RT>(0.25))
+            .with_tolerance_type(gko::stop::batch::ToleranceType::relative)
+            .on(this->exec);
+    auto solver = factory->generate(this->mtx);
+
+    solver->set_residual_tolerance(0.5);
+
+    ASSERT_NEAR(solver->get_parameters().residual_tol, 0.25, 0.0);
+    ASSERT_EQ(solver->get_residual_tolerance(), 0.5);
 }
 
 

--- a/core/test/solver/batch_gmres.cpp
+++ b/core/test/solver/batch_gmres.cpp
@@ -65,8 +65,8 @@ protected:
                   this->exec),
               nrows, nbatch)),
           batchgmres_factory(Solver::build()
-                                 .with_max_iterations(def_max_iters)
-                                 .with_residual_tol(def_abs_res_tol)
+                                 .with_default_max_iterations(def_max_iters)
+                                 .with_default_residual_tol(def_abs_res_tol)
                                  .with_tolerance_type(def_tol_type)
                                  .with_restart(2)
                                  .on(exec)),
@@ -186,16 +186,16 @@ TYPED_TEST(BatchGmres, CanSetCriteriaInFactory)
 
     auto batchgmres_factory =
         Solver::build()
-            .with_max_iterations(22)
-            .with_residual_tol(static_cast<RT>(0.25))
+            .with_default_max_iterations(22)
+            .with_default_residual_tol(static_cast<RT>(0.25))
             .with_tolerance_type(gko::stop::batch::ToleranceType::relative)
             .with_restart(3)
             .on(this->exec);
     auto solver = batchgmres_factory->generate(this->mtx);
 
-    ASSERT_EQ(solver->get_parameters().max_iterations, 22);
+    ASSERT_EQ(solver->get_parameters().default_max_iterations, 22);
     const RT tol = std::numeric_limits<RT>::epsilon();
-    ASSERT_NEAR(solver->get_parameters().residual_tol, 0.25, tol);
+    ASSERT_NEAR(solver->get_parameters().default_residual_tol, 0.25, tol);
     ASSERT_EQ(solver->get_parameters().tolerance_type,
               gko::stop::batch::ToleranceType::relative);
     ASSERT_EQ(solver->get_parameters().restart, 3);
@@ -208,15 +208,15 @@ TYPED_TEST(BatchGmres, CanSetResidualTol)
     using RT = typename TestFixture::real_type;
     auto factory =
         Solver::build()
-            .with_max_iterations(22)
-            .with_residual_tol(static_cast<RT>(0.25))
+            .with_default_max_iterations(22)
+            .with_default_residual_tol(static_cast<RT>(0.25))
             .with_tolerance_type(gko::stop::batch::ToleranceType::relative)
             .on(this->exec);
     auto solver = factory->generate(this->mtx);
 
     solver->set_residual_tolerance(0.5);
 
-    ASSERT_NEAR(solver->get_parameters().residual_tol, 0.25, 0.0);
+    ASSERT_NEAR(solver->get_parameters().default_residual_tol, 0.25, 0.0);
     ASSERT_EQ(solver->get_residual_tolerance(), 0.5);
 }
 
@@ -247,7 +247,7 @@ TYPED_TEST(BatchGmres, CanSetPreconditionerFactory)
         gko::preconditioner::BatchJacobi<value_type>::build().on(this->exec));
 
     auto batchgmres_factory = Solver::build()
-                                  .with_max_iterations(3)
+                                  .with_default_max_iterations(3)
                                   .with_preconditioner(prec_factory)
                                   .on(this->exec);
     auto solver = batchgmres_factory->generate(this->mtx);
@@ -298,8 +298,8 @@ TYPED_TEST(BatchGmres, CanSetScalingVectors)
 
 //    auto batchgmres_factory =
 //        Solver::build()
-//            .with_max_iterations(3)
-//            .with_residual_tol(0.25f)
+//            .with_default_max_iterations(3)
+//            .with_default_residual_tol(0.25f)
 //            .with_tolerance_type(gko::stop::batch::ToleranceType::relative)
 //            .with_preconditioner(gko::preconditioner::batch::type::none)
 //            .on(this->exec);
@@ -308,8 +308,8 @@ TYPED_TEST(BatchGmres, CanSetScalingVectors)
 //    auto params = solver_trans->get_parameters();
 
 //    ASSERT_EQ(params.preconditioner, gko::preconditioner::batch::type::none);
-//    ASSERT_EQ(params.max_iterations, 3);
-//    ASSERT_EQ(params.residual_tol, 0.25);
+//    ASSERT_EQ(params.default_max_iterations, 3);
+//    ASSERT_EQ(params.default_residual_tol, 0.25);
 //    ASSERT_EQ(params.tolerance_type,
 //    gko::stop::batch::ToleranceType::relative);
 // }

--- a/core/test/solver/batch_idr.cpp
+++ b/core/test/solver/batch_idr.cpp
@@ -66,7 +66,7 @@ protected:
               nrows, nbatch)),
           batchidr_factory(
               Solver::build()
-                  .with_max_iterations(def_max_iters)
+                  .with_default_max_iterations(def_max_iters)
                   .with_tolerance_type(def_tol_type)
                   .with_deterministic(false)
                   .with_smoothing(true)
@@ -188,8 +188,8 @@ TYPED_TEST(BatchIdr, CanSetCriteriaInFactory)
 
     auto batchidr_factory =
         Solver::build()
-            .with_max_iterations(22)
-            .with_residual_tol(static_cast<RT>(0.25))
+            .with_default_max_iterations(22)
+            .with_default_residual_tol(static_cast<RT>(0.25))
             .with_tolerance_type(gko::stop::batch::ToleranceType::relative)
             .with_deterministic(false)
             .with_smoothing(true)
@@ -198,9 +198,9 @@ TYPED_TEST(BatchIdr, CanSetCriteriaInFactory)
             .on(this->exec);
     auto solver = batchidr_factory->generate(this->mtx);
 
-    ASSERT_EQ(solver->get_parameters().max_iterations, 22);
+    ASSERT_EQ(solver->get_parameters().default_max_iterations, 22);
     const RT tol = std::numeric_limits<RT>::epsilon();
-    ASSERT_NEAR(solver->get_parameters().residual_tol, 0.25, tol);
+    ASSERT_NEAR(solver->get_parameters().default_residual_tol, 0.25, tol);
     ASSERT_EQ(solver->get_parameters().tolerance_type,
               gko::stop::batch::ToleranceType::relative);
     ASSERT_EQ(solver->get_parameters().deterministic, false);
@@ -217,15 +217,15 @@ TYPED_TEST(BatchIdr, CanSetResidualTol)
     using RT = typename TestFixture::real_type;
     auto factory =
         Solver::build()
-            .with_max_iterations(22)
-            .with_residual_tol(static_cast<RT>(0.25))
+            .with_default_max_iterations(22)
+            .with_default_residual_tol(static_cast<RT>(0.25))
             .with_tolerance_type(gko::stop::batch::ToleranceType::relative)
             .on(this->exec);
     auto solver = factory->generate(this->mtx);
 
     solver->set_residual_tolerance(0.5);
 
-    ASSERT_EQ(solver->get_parameters().residual_tol, 0.25);
+    ASSERT_EQ(solver->get_parameters().default_residual_tol, 0.25);
     ASSERT_EQ(solver->get_residual_tolerance(), 0.5);
 }
 
@@ -281,7 +281,7 @@ TYPED_TEST(BatchIdr, CanSetPreconditionerFactory)
         gko::preconditioner::BatchJacobi<value_type>::build().on(this->exec));
 
     auto batchidr_factory = Solver::build()
-                                .with_max_iterations(3)
+                                .with_default_max_iterations(3)
                                 .with_preconditioner(prec_factory)
                                 .on(this->exec);
     auto solver = batchidr_factory->generate(this->mtx);
@@ -331,8 +331,8 @@ TYPED_TEST(BatchIdr, CanSetScalingOps)
 
 //    auto batchidr_factory =
 //        Solver::build()
-//            .with_max_iterations(3)
-//            .with_residual_tol(0.25f)
+//            .with_default_max_iterations(3)
+//            .with_default_residual_tol(0.25f)
 //            .with_tolerance_type(gko::stop::batch::ToleranceType::relative)
 //            .with_preconditioner(gko::preconditioner::batch::type::none)
 //            .on(this->exec);
@@ -341,8 +341,8 @@ TYPED_TEST(BatchIdr, CanSetScalingOps)
 //    auto params = solver_trans->get_parameters();
 
 //    ASSERT_EQ(params.preconditioner, gko::preconditioner::batch::type::none);
-//    ASSERT_EQ(params.max_iterations, 3);
-//    ASSERT_EQ(params.residual_tol, 0.25);
+//    ASSERT_EQ(params.default_max_iterations, 3);
+//    ASSERT_EQ(params.default_residual_tol, 0.25);
 //    ASSERT_EQ(params.tolerance_type,
 //    gko::stop::batch::ToleranceType::relative);
 // }

--- a/core/test/solver/batch_idr.cpp
+++ b/core/test/solver/batch_idr.cpp
@@ -181,7 +181,7 @@ TYPED_TEST(BatchIdr, ApplyUsesInitialGuessReturnsTrue)
 }
 
 
-TYPED_TEST(BatchIdr, CanSetCriteria)
+TYPED_TEST(BatchIdr, CanSetCriteriaInFactory)
 {
     using Solver = typename TestFixture::Solver;
     using RT = typename TestFixture::real_type;
@@ -208,6 +208,25 @@ TYPED_TEST(BatchIdr, CanSetCriteria)
     ASSERT_EQ(solver->get_parameters().complex_subspace, true);
     ASSERT_EQ(solver->get_parameters().subspace_dim,
               static_cast<gko::size_type>(3));
+}
+
+
+TYPED_TEST(BatchIdr, CanSetResidualTol)
+{
+    using Solver = typename TestFixture::Solver;
+    using RT = typename TestFixture::real_type;
+    auto factory =
+        Solver::build()
+            .with_max_iterations(22)
+            .with_residual_tol(static_cast<RT>(0.25))
+            .with_tolerance_type(gko::stop::batch::ToleranceType::relative)
+            .on(this->exec);
+    auto solver = factory->generate(this->mtx);
+
+    solver->set_residual_tolerance(0.5);
+
+    ASSERT_EQ(solver->get_parameters().residual_tol, 0.25);
+    ASSERT_EQ(solver->get_residual_tolerance(), 0.5);
 }
 
 

--- a/core/test/solver/batch_richardson.cpp
+++ b/core/test/solver/batch_richardson.cpp
@@ -81,12 +81,13 @@ protected:
 
     std::unique_ptr<Solver> generate_solver()
     {
-        auto batchrich_factory = Solver::build()
-                                     .with_max_iterations(this->def_max_iters)
-                                     .with_residual_tol(this->def_rel_res_tol)
-                                     .with_preconditioner(prec_factory)
-                                     .with_relaxation_factor(this->def_relax)
-                                     .on(this->exec);
+        auto batchrich_factory =
+            Solver::build()
+                .with_default_max_iterations(this->def_max_iters)
+                .with_default_residual_tol(this->def_rel_res_tol)
+                .with_preconditioner(prec_factory)
+                .with_relaxation_factor(this->def_relax)
+                .on(this->exec);
         auto solver = batchrich_factory->generate(this->mtx);
         return std::unique_ptr<Solver>(static_cast<Solver*>(solver.release()));
     }
@@ -101,10 +102,10 @@ protected:
     // Checks equality of the matrix and parameters with defaults
     void assert_solver_params(const Solver* const a)
     {
-        ASSERT_EQ(a->get_parameters().max_iterations, def_max_iters);
+        ASSERT_EQ(a->get_parameters().default_max_iterations, def_max_iters);
         ASSERT_EQ(a->get_parameters().preconditioner, prec_factory);
         ASSERT_EQ(a->get_parameters().relaxation_factor, def_relax);
-        ASSERT_EQ(a->get_parameters().residual_tol, def_rel_res_tol);
+        ASSERT_EQ(a->get_parameters().default_residual_tol, def_rel_res_tol);
         ASSERT_EQ(a->get_parameters().tolerance_type, def_tol_type);
     }
 
@@ -213,18 +214,19 @@ TYPED_TEST(BatchRich, CanSetCriteriaInFactory)
     using Solver = typename TestFixture::Solver;
     using RT = typename TestFixture::real_type;
 
-    auto batchrich_factory = Solver::build()
-                                 .with_max_iterations(22)
-                                 .with_residual_tol(static_cast<RT>(0.25))
-                                 .with_relaxation_factor(static_cast<RT>(0.28))
-                                 .on(this->exec);
+    auto batchrich_factory =
+        Solver::build()
+            .with_default_max_iterations(22)
+            .with_default_residual_tol(static_cast<RT>(0.25))
+            .with_relaxation_factor(static_cast<RT>(0.28))
+            .on(this->exec);
     auto solver = batchrich_factory->generate(this->mtx);
 
-    ASSERT_EQ(solver->get_parameters().max_iterations, 22);
+    ASSERT_EQ(solver->get_parameters().default_max_iterations, 22);
     ASSERT_EQ(solver->get_parameters().relaxation_factor,
               static_cast<RT>(0.28));
     const RT tol = std::numeric_limits<RT>::epsilon();
-    ASSERT_NEAR(solver->get_parameters().residual_tol, 0.25, tol);
+    ASSERT_NEAR(solver->get_parameters().default_residual_tol, 0.25, tol);
 }
 
 
@@ -234,15 +236,15 @@ TYPED_TEST(BatchRich, CanSetResidualTol)
     using RT = typename TestFixture::real_type;
     auto factory =
         Solver::build()
-            .with_max_iterations(22)
-            .with_residual_tol(static_cast<RT>(0.25))
+            .with_default_max_iterations(22)
+            .with_default_residual_tol(static_cast<RT>(0.25))
             .with_tolerance_type(gko::stop::batch::ToleranceType::relative)
             .on(this->exec);
     auto solver = factory->generate(this->mtx);
 
     solver->set_residual_tolerance(0.5);
 
-    ASSERT_EQ(solver->get_parameters().residual_tol, 0.25);
+    ASSERT_EQ(solver->get_parameters().default_residual_tol, 0.25);
     ASSERT_EQ(solver->get_residual_tolerance(), 0.5);
 }
 
@@ -304,15 +306,15 @@ TYPED_TEST(BatchRich, CanSetScalingOps)
 //     using Solver = typename TestFixture::Solver;
 
 //     auto batchrich_factory =
-//         Solver::build().with_max_iterations(3).with_residual_tol(0.25f)
+//         Solver::build().with_default_max_iterations(3).with_default_residual_tol(0.25f)
 // 		.with_relaxation_factor(2.0f).with_preconditioner(gpb::none).on(this->exec);
 //     auto solver = batchrich_factory->generate(this->mtx);
 // 	auto solver_trans = gko::as<Solver>(solver->transpose());
 // 	auto params = solver_trans->get_parameters();
 
 // 	ASSERT_EQ(params.preconditioner, gpb::none);
-// 	ASSERT_EQ(params.max_iterations, 3);
-// 	ASSERT_EQ(params.residual_tol, 0.25);
+// 	ASSERT_EQ(params.default_max_iterations, 3);
+// 	ASSERT_EQ(params.default_residual_tol, 0.25);
 // 	ASSERT_EQ(params.relaxation_factor, 2.0);
 // }
 

--- a/core/test/solver/batch_richardson.cpp
+++ b/core/test/solver/batch_richardson.cpp
@@ -208,7 +208,7 @@ TYPED_TEST(BatchRich, ApplyUsesInitialGuessReturnsTrue)
 }
 
 
-TYPED_TEST(BatchRich, CanSetCriteria)
+TYPED_TEST(BatchRich, CanSetCriteriaInFactory)
 {
     using Solver = typename TestFixture::Solver;
     using RT = typename TestFixture::real_type;
@@ -225,6 +225,25 @@ TYPED_TEST(BatchRich, CanSetCriteria)
               static_cast<RT>(0.28));
     const RT tol = std::numeric_limits<RT>::epsilon();
     ASSERT_NEAR(solver->get_parameters().residual_tol, 0.25, tol);
+}
+
+
+TYPED_TEST(BatchRich, CanSetResidualTol)
+{
+    using Solver = typename TestFixture::Solver;
+    using RT = typename TestFixture::real_type;
+    auto factory =
+        Solver::build()
+            .with_max_iterations(22)
+            .with_residual_tol(static_cast<RT>(0.25))
+            .with_tolerance_type(gko::stop::batch::ToleranceType::relative)
+            .on(this->exec);
+    auto solver = factory->generate(this->mtx);
+
+    solver->set_residual_tolerance(0.5);
+
+    ASSERT_EQ(solver->get_parameters().residual_tol, 0.25);
+    ASSERT_EQ(solver->get_residual_tolerance(), 0.5);
 }
 
 

--- a/examples/batched-solver-from-files/batched-solver-from-files.cpp
+++ b/examples/batched-solver-from-files/batched-solver-from-files.cpp
@@ -165,8 +165,8 @@ int main(int argc, char* argv[])
     // Create a batched solver factory with relevant parameters.
     auto solver_gen =
         solver_type::build()
-            .with_max_iterations(500)
-            .with_residual_tol(reduction_factor)
+            .with_default_max_iterations(500)
+            .with_default_residual_tol(reduction_factor)
             .with_tolerance_type(gko::stop::batch::ToleranceType::relative)
             // .with_preconditioner(gko::preconditioner::batch::type::jacobi)
             .on(exec);

--- a/examples/batched-solver/batched-solver.cpp
+++ b/examples/batched-solver/batched-solver.cpp
@@ -196,8 +196,8 @@ int main(int argc, char* argv[])
     // Create a batched solver factory with relevant parameters.
     auto solver_gen =
         solver_type::build()
-            .with_max_iterations(500)
-            .with_residual_tol(reduction_factor)
+            .with_default_max_iterations(500)
+            .with_default_residual_tol(reduction_factor)
             .with_tolerance_type(gko::stop::batch::ToleranceType::relative)
             .with_preconditioner(
                 gko::preconditioner::BatchJacobi<value_type>::build().on(exec))

--- a/include/ginkgo/core/solver/batch_bicgstab.hpp
+++ b/include/ginkgo/core/solver/batch_bicgstab.hpp
@@ -114,15 +114,21 @@ public:
             right_scaling_op, nullptr);
 
         /**
-         * Maximum number iterations allowed.
+         * Default maximum number iterations allowed.
+         *
+         * Generated solvers are initialized with this value for their maximum
+         * iterations.
          */
-        int GKO_FACTORY_PARAMETER_SCALAR(max_iterations, 100);
+        int GKO_FACTORY_PARAMETER_SCALAR(default_max_iterations, 100);
 
 
         /**
-         * Residual tolerance.
+         * Default residual tolerance.
+         *
+         * Generated solvers are initialized with this value for their residual
+         * tolerance.
          */
-        real_type GKO_FACTORY_PARAMETER_SCALAR(residual_tol, 1e-11);
+        real_type GKO_FACTORY_PARAMETER_SCALAR(default_residual_tol, 1e-11);
 
 
         /**

--- a/include/ginkgo/core/solver/batch_cg.hpp
+++ b/include/ginkgo/core/solver/batch_cg.hpp
@@ -119,12 +119,12 @@ public:
         /**
          * Maximum number iterations allowed.
          */
-        int GKO_FACTORY_PARAMETER_SCALAR(max_iterations, 100);
+        int GKO_FACTORY_PARAMETER_SCALAR(default_max_iterations, 100);
 
         /**
          * Residual tolerance.
          */
-        real_type GKO_FACTORY_PARAMETER_SCALAR(residual_tol, 1e-6);
+        real_type GKO_FACTORY_PARAMETER_SCALAR(default_residual_tol, 1e-6);
 
         /**
          * To specify which tolerance is to be considered.

--- a/include/ginkgo/core/solver/batch_gmres.hpp
+++ b/include/ginkgo/core/solver/batch_gmres.hpp
@@ -131,12 +131,12 @@ public:
         /**
          * Maximum number iterations allowed.
          */
-        int GKO_FACTORY_PARAMETER_SCALAR(max_iterations, 100);
+        int GKO_FACTORY_PARAMETER_SCALAR(default_max_iterations, 100);
 
         /**
          * Residual tolerance.
          */
-        real_type GKO_FACTORY_PARAMETER_SCALAR(residual_tol, 1e-6);
+        real_type GKO_FACTORY_PARAMETER_SCALAR(default_residual_tol, 1e-6);
 
         /**
          * Restart parameter for Gmres

--- a/include/ginkgo/core/solver/batch_idr.hpp
+++ b/include/ginkgo/core/solver/batch_idr.hpp
@@ -205,14 +205,14 @@ public:
         /**
          * Maximum number iterations allowed.
          */
-        int GKO_FACTORY_PARAMETER_SCALAR(max_iterations, 100);
+        int GKO_FACTORY_PARAMETER_SCALAR(default_max_iterations, 100);
 
         /**
          * Residual tolerance.
          *
          * @sa tolerance_type
          */
-        real_type GKO_FACTORY_PARAMETER_SCALAR(residual_tol, 1e-8);
+        real_type GKO_FACTORY_PARAMETER_SCALAR(default_residual_tol, 1e-8);
 
         /**
          * Subspace Dimension

--- a/include/ginkgo/core/solver/batch_richardson.hpp
+++ b/include/ginkgo/core/solver/batch_richardson.hpp
@@ -128,12 +128,12 @@ public:
         /**
          * Maximum number iterations allowed.
          */
-        int GKO_FACTORY_PARAMETER_SCALAR(max_iterations, 100);
+        int GKO_FACTORY_PARAMETER_SCALAR(default_max_iterations, 100);
 
         /**
          * Relative residual tolerance.
          */
-        real_type GKO_FACTORY_PARAMETER_SCALAR(residual_tol, 1e-6);
+        real_type GKO_FACTORY_PARAMETER_SCALAR(default_residual_tol, 1e-6);
 
         /**
          * Tolerance type.

--- a/include/ginkgo/core/solver/batch_solver.hpp
+++ b/include/ginkgo/core/solver/batch_solver.hpp
@@ -47,6 +47,7 @@ struct common_batch_params {
     std::shared_ptr<const BatchLinOp> generated_prec;
     std::shared_ptr<const BatchLinOp> left_scaling_op;
     std::shared_ptr<const BatchLinOp> right_scaling_op;
+    double residual_tolerance;
 };
 
 
@@ -54,7 +55,8 @@ template <typename ParamsType>
 common_batch_params extract_common_batch_params(ParamsType& params)
 {
     return {params.preconditioner, params.generated_preconditioner,
-            params.left_scaling_op, params.right_scaling_op};
+            params.left_scaling_op, params.right_scaling_op,
+            params.residual_tol};
 }
 
 
@@ -107,6 +109,10 @@ public:
         return right_scaling_;
     }
 
+    double get_residual_tolerance() const { return residual_tol_; }
+
+    void set_residual_tolerance(double res_tol) { residual_tol_ = res_tol; }
+
 protected:
     explicit EnableBatchSolver(std::shared_ptr<const Executor> exec)
         : EnableBatchLinOp<ConcreteSolver, PolymorphicBase>(std::move(exec))
@@ -125,6 +131,7 @@ protected:
     std::shared_ptr<const BatchLinOp> preconditioner_{};
     std::shared_ptr<const BatchLinOp> left_scaling_{};
     std::shared_ptr<const BatchLinOp> right_scaling_{};
+    double residual_tol_;
 
 private:
     /**

--- a/include/ginkgo/core/solver/batch_solver.hpp
+++ b/include/ginkgo/core/solver/batch_solver.hpp
@@ -94,8 +94,19 @@ public:
      */
     void set_residual_tolerance(double res_tol) { residual_tol_ = res_tol; }
 
+    /**
+     * Get the maximum number of iterations set on the solver.
+     *
+     * @return  Maximum number of iterations.
+     */
     int get_max_iterations() const { return max_iterations_; }
 
+    /**
+     * Set the maximum number of iterations for the solver to use,
+     * independent of the factory that created it.
+     *
+     * @param max_iterations  The maximum number of iterations for the solver.
+     */
     void set_max_iterations(int max_iterations)
     {
         max_iterations_ = max_iterations;

--- a/include/ginkgo/core/solver/batch_solver.hpp
+++ b/include/ginkgo/core/solver/batch_solver.hpp
@@ -109,8 +109,19 @@ public:
         return right_scaling_;
     }
 
+    /**
+     * Get the residual tolerance used by the solver.
+     *
+     * @return The residual tolerance.
+     */
     double get_residual_tolerance() const { return residual_tol_; }
 
+    /**
+     * Update the residual tolerance to be used by the solver.
+     *
+     * @param res_tol  The residual tolerance to be used for subsequent
+     *                 invocations of the solver.
+     */
     void set_residual_tolerance(double res_tol) { residual_tol_ = res_tol; }
 
 protected:

--- a/include/ginkgo/ginkgo.hpp
+++ b/include/ginkgo/ginkgo.hpp
@@ -141,6 +141,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <ginkgo/core/solver/gmres.hpp>
 #include <ginkgo/core/solver/idr.hpp>
 #include <ginkgo/core/solver/ir.hpp>
+#include <ginkgo/core/solver/lower_trs.hpp>
 #include <ginkgo/core/solver/multigrid.hpp>
 #include <ginkgo/core/solver/solver_base.hpp>
 #include <ginkgo/core/solver/solver_traits.hpp>

--- a/include/ginkgo/ginkgo.hpp
+++ b/include/ginkgo/ginkgo.hpp
@@ -141,7 +141,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <ginkgo/core/solver/gmres.hpp>
 #include <ginkgo/core/solver/idr.hpp>
 #include <ginkgo/core/solver/ir.hpp>
-#include <ginkgo/core/solver/lower_trs.hpp>
 #include <ginkgo/core/solver/multigrid.hpp>
 #include <ginkgo/core/solver/solver_base.hpp>
 #include <ginkgo/core/solver/solver_traits.hpp>

--- a/reference/test/solver/batch_bicgstab_kernels.cpp
+++ b/reference/test/solver/batch_bicgstab_kernels.cpp
@@ -100,8 +100,8 @@ protected:
         std::shared_ptr<const BDiag> right_scale = nullptr)
     {
         return solver_type::build()
-            .with_max_iterations(opts.max_its)
-            .with_residual_tol(opts.residual_tol)
+            .with_default_max_iterations(opts.max_its)
+            .with_default_residual_tol(opts.residual_tol)
             .with_tolerance_type(opts.tol_type)
             .with_preconditioner(prec_factory)
             .with_left_scaling_op(left_scale)
@@ -221,14 +221,14 @@ TEST(BatchBicgstab, GoodScalingImprovesConvergence)
     }
     auto factory =
         Solver::build()
-            .with_max_iterations(10)
-            .with_residual_tol(10 * eps)
+            .with_default_max_iterations(10)
+            .with_default_residual_tol(10 * eps)
             .with_tolerance_type(gko::stop::batch::ToleranceType::relative)
             .on(exec);
     auto factory_s =
         Solver::build()
-            .with_max_iterations(10)
-            .with_residual_tol(10 * eps)
+            .with_default_max_iterations(10)
+            .with_default_residual_tol(10 * eps)
             .with_tolerance_type(gko::stop::batch::ToleranceType::relative)
             .with_left_scaling_op(left_scale)
             .with_right_scaling_op(right_scale)
@@ -251,8 +251,8 @@ TEST(BatchBicgstab, CoreCanSolveCsrWithoutScaling)
         gko::ReferenceExecutor::create();
     auto batchbicgstab_factory =
         Solver::build()
-            .with_max_iterations(maxits)
-            .with_residual_tol(tol)
+            .with_default_max_iterations(maxits)
+            .with_default_residual_tol(tol)
             .with_tolerance_type(gko::stop::batch::ToleranceType::relative)
             .with_preconditioner(
                 gko::preconditioner::BatchJacobi<T>::build().on(exec))
@@ -278,8 +278,8 @@ TEST(BatchBicgstab, CoreCanSolveEllWithoutScaling)
         gko::ReferenceExecutor::create();
     auto batchbicgstab_factory =
         Solver::build()
-            .with_max_iterations(maxits)
-            .with_residual_tol(tol)
+            .with_default_max_iterations(maxits)
+            .with_default_residual_tol(tol)
             .with_tolerance_type(gko::stop::batch::ToleranceType::relative)
             .with_preconditioner(
                 gko::preconditioner::BatchJacobi<T>::build().on(exec))
@@ -305,8 +305,8 @@ TEST(BatchBicgstab, CoreCanSolveDenseWithoutScaling)
         gko::ReferenceExecutor::create();
     auto batchbicgstab_factory =
         Solver::build()
-            .with_max_iterations(maxits)
-            .with_residual_tol(tol)
+            .with_default_max_iterations(maxits)
+            .with_default_residual_tol(tol)
             .with_tolerance_type(gko::stop::batch::ToleranceType::relative)
             .with_preconditioner(
                 gko::preconditioner::BatchJacobi<T>::build().on(exec))
@@ -345,8 +345,8 @@ TEST(BatchBicgstab, CoreCanSolveCsrWithScaling)
     }
     auto batchbicgstab_factory =
         Solver::build()
-            .with_max_iterations(maxits)
-            .with_residual_tol(tol)
+            .with_default_max_iterations(maxits)
+            .with_default_residual_tol(tol)
             .with_tolerance_type(gko::stop::batch::ToleranceType::relative)
             .with_preconditioner(
                 gko::preconditioner::BatchJacobi<T>::build().on(exec))

--- a/reference/test/solver/batch_cg_kernels.cpp
+++ b/reference/test/solver/batch_cg_kernels.cpp
@@ -99,8 +99,8 @@ protected:
         std::shared_ptr<const BDiag> right_scale = nullptr)
     {
         return solver_type::build()
-            .with_max_iterations(opts.max_its)
-            .with_residual_tol(opts.residual_tol)
+            .with_default_max_iterations(opts.max_its)
+            .with_default_residual_tol(opts.residual_tol)
             .with_tolerance_type(opts.tol_type)
             .with_preconditioner(prec_factory)
             .with_left_scaling_op(left_scale)
@@ -212,14 +212,14 @@ TEST(BatchCg, GoodScalingImprovesConvergence)
     }
     auto factory =
         Solver::build()
-            .with_max_iterations(20)
-            .with_residual_tol(10 * eps)
+            .with_default_max_iterations(20)
+            .with_default_residual_tol(10 * eps)
             .with_tolerance_type(gko::stop::batch::ToleranceType::relative)
             .on(exec);
     auto factory_s =
         Solver::build()
-            .with_max_iterations(10)
-            .with_residual_tol(10 * eps)
+            .with_default_max_iterations(10)
+            .with_default_residual_tol(10 * eps)
             .with_tolerance_type(gko::stop::batch::ToleranceType::relative)
             .with_left_scaling_op(left_scale)
             .with_right_scaling_op(right_scale)
@@ -244,8 +244,8 @@ TEST(BatchCg, CanSolveWithoutScaling)
         gko::ReferenceExecutor::create();
     auto batchcg_factory =
         Solver::build()
-            .with_max_iterations(maxits)
-            .with_residual_tol(tol)
+            .with_default_max_iterations(maxits)
+            .with_default_residual_tol(tol)
             .with_tolerance_type(gko::stop::batch::ToleranceType::relative)
             .with_preconditioner(
                 gko::preconditioner::BatchJacobi<T>::build().on(exec))

--- a/reference/test/solver/batch_gmres_kernels.cpp
+++ b/reference/test/solver/batch_gmres_kernels.cpp
@@ -98,8 +98,8 @@ protected:
         std::shared_ptr<const BDiag> right_scale = nullptr)
     {
         return solver_type::build()
-            .with_max_iterations(opts.max_its)
-            .with_residual_tol(opts.residual_tol)
+            .with_default_max_iterations(opts.max_its)
+            .with_default_residual_tol(opts.residual_tol)
             .with_tolerance_type(opts.tol_type)
             .with_preconditioner(prec_factory)
             .with_restart(opts.restart_num)
@@ -212,14 +212,14 @@ TEST(BatchGmres, GoodScalingImprovesConvergence)
     auto factory =
         Solver::build()
             .with_restart(15)
-            .with_max_iterations(30)
-            .with_residual_tol(10 * eps)
+            .with_default_max_iterations(30)
+            .with_default_residual_tol(10 * eps)
             .with_tolerance_type(gko::stop::batch::ToleranceType::relative)
             .on(exec);
     auto factory_s =
         Solver::build()
-            .with_max_iterations(10)
-            .with_residual_tol(10 * eps)
+            .with_default_max_iterations(10)
+            .with_default_residual_tol(10 * eps)
             .with_tolerance_type(gko::stop::batch::ToleranceType::relative)
             .with_left_scaling_op(left_scale)
             .with_right_scaling_op(right_scale)
@@ -248,8 +248,8 @@ TEST(BatchGmres, CanSolveDenseWithScaling)
         gko::batch_initialize<BDiag>(nbatch, {1.0, 1.5, 1.05}, exec));
     auto factory_s =
         Solver::build()
-            .with_max_iterations(10)
-            .with_residual_tol(10 * eps)
+            .with_default_max_iterations(10)
+            .with_default_residual_tol(10 * eps)
             .with_tolerance_type(gko::stop::batch::ToleranceType::relative)
             .with_left_scaling_op(left_scale)
             .with_right_scaling_op(right_scale)
@@ -298,8 +298,8 @@ TEST(BatchGmres, CanSolveWithoutScaling)
     }
     auto factory =
         Solver::build()
-            .with_max_iterations(1000)
-            .with_residual_tol(tol)
+            .with_default_max_iterations(1000)
+            .with_default_residual_tol(tol)
             .with_tolerance_type(gko::stop::batch::ToleranceType::relative)
             .with_preconditioner(
                 gko::preconditioner::BatchJacobi<T>::build().on(exec))
@@ -307,8 +307,8 @@ TEST(BatchGmres, CanSolveWithoutScaling)
             .on(exec);
     auto factory_s =
         Solver::build()
-            .with_max_iterations(1000)
-            .with_residual_tol(tol)
+            .with_default_max_iterations(1000)
+            .with_default_residual_tol(tol)
             .with_tolerance_type(gko::stop::batch::ToleranceType::relative)
             .with_preconditioner(
                 gko::preconditioner::BatchJacobi<T>::build().on(exec))

--- a/reference/test/solver/batch_idr_kernels.cpp
+++ b/reference/test/solver/batch_idr_kernels.cpp
@@ -103,8 +103,8 @@ protected:
         std::shared_ptr<const BDiag> right_scale = nullptr)
     {
         return solver_type::build()
-            .with_max_iterations(opts.max_its)
-            .with_residual_tol(opts.residual_tol)
+            .with_default_max_iterations(opts.max_its)
+            .with_default_residual_tol(opts.residual_tol)
             .with_tolerance_type(opts.tol_type)
             .with_preconditioner(prec_factory)
             .with_subspace_dim(opts.subspace_dim_val)
@@ -210,8 +210,8 @@ TEST(BatchIdr, CanSolveWithoutScaling)
         gko::ReferenceExecutor::create();
     auto batchidr_factory =
         Solver::build()
-            .with_max_iterations(maxits)
-            .with_residual_tol(tol)
+            .with_default_max_iterations(maxits)
+            .with_default_residual_tol(tol)
             .with_tolerance_type(gko::stop::batch::ToleranceType::relative)
             .with_preconditioner(
                 gko::preconditioner::BatchJacobi<T>::build().on(exec))

--- a/reference/test/solver/batch_richardson_kernels.cpp
+++ b/reference/test/solver/batch_richardson_kernels.cpp
@@ -102,8 +102,8 @@ protected:
         std::shared_ptr<const BDiag> right_scale = nullptr)
     {
         return solver_type::build()
-            .with_max_iterations(opts.max_its)
-            .with_residual_tol(opts.residual_tol)
+            .with_default_max_iterations(opts.max_its)
+            .with_default_residual_tol(opts.residual_tol)
             .with_tolerance_type(opts.tol_type)
             .with_preconditioner(prec_factory)
             .with_left_scaling_op(left_scale)
@@ -261,8 +261,8 @@ TEST(BatchRich, CoreCanSolveWithoutScaling)
     const int maxits = 10000;
     auto batchrich_factory =
         Solver::build()
-            .with_max_iterations(maxits)
-            .with_residual_tol(tol)
+            .with_default_max_iterations(maxits)
+            .with_default_residual_tol(tol)
             .with_tolerance_type(gko::stop::batch::ToleranceType::relative)
             .with_relaxation_factor(RT{0.98})
             .with_preconditioner(
@@ -288,8 +288,8 @@ TEST(BatchRich, CoreCanSolveWithScaling)
         gko::ReferenceExecutor::create();
     auto batchrich_factory =
         Solver::build()
-            .with_max_iterations(maxits)
-            .with_residual_tol(tol)
+            .with_default_max_iterations(maxits)
+            .with_default_residual_tol(tol)
             .with_tolerance_type(gko::stop::batch::ToleranceType::relative)
             .with_preconditioner(
                 gko::preconditioner::BatchJacobi<T>::build().on(exec))

--- a/test/solver/batch_bicgstab_kernels.cpp
+++ b/test/solver/batch_bicgstab_kernels.cpp
@@ -118,8 +118,8 @@ protected:
         std::shared_ptr<const BDiag> right_scale = nullptr)
     {
         return solver_type::build()
-            .with_max_iterations(opts.max_its)
-            .with_residual_tol(opts.residual_tol)
+            .with_default_max_iterations(opts.max_its)
+            .with_default_residual_tol(opts.residual_tol)
             .with_tolerance_type(opts.tol_type)
             .with_preconditioner(prec_factory)
             .with_left_scaling_op(left_scale)
@@ -193,8 +193,8 @@ TEST_F(BatchBicgstab, CoreSolvesSystemJacobi)
     auto dexec = this->d_exec;
     std::unique_ptr<typename solver_type::Factory> batchbicgstab_factory =
         solver_type::build()
-            .with_max_iterations(100)
-            .with_residual_tol(1e-6f)
+            .with_default_max_iterations(100)
+            .with_default_residual_tol(1e-6f)
             .with_preconditioner(
                 gko::preconditioner::BatchJacobi<value_type>::build().on(dexec))
             .with_tolerance_type(gko::stop::batch::ToleranceType::relative)
@@ -273,14 +273,14 @@ TEST_F(BatchBicgstab, GoodScalingImprovesConvergence)
     auto d_right = gko::share(gko::clone(d_exec, right_scale));
     auto factory =
         solver_type::build()
-            .with_max_iterations(10)
-            .with_residual_tol(10 * eps)
+            .with_default_max_iterations(10)
+            .with_default_residual_tol(10 * eps)
             .with_tolerance_type(gko::stop::batch::ToleranceType::relative)
             .on(d_exec);
     auto factory_s =
         solver_type::build()
-            .with_max_iterations(10)
-            .with_residual_tol(10 * eps)
+            .with_default_max_iterations(10)
+            .with_default_residual_tol(10 * eps)
             .with_tolerance_type(gko::stop::batch::ToleranceType::relative)
             .with_left_scaling_op(d_left)
             .with_right_scaling_op(d_right)
@@ -305,8 +305,8 @@ TEST(BatchBicgstabCsr, CanSolveWithoutScaling)
     const int maxits = 5000;
     auto batchbicgstab_factory =
         Solver::build()
-            .with_max_iterations(maxits)
-            .with_residual_tol(tol)
+            .with_default_max_iterations(maxits)
+            .with_default_residual_tol(tol)
             .with_tolerance_type(gko::stop::batch::ToleranceType::relative)
             .with_preconditioner(
                 gko::preconditioner::BatchJacobi<T>::build().on(d_exec))
@@ -339,15 +339,15 @@ TEST(BatchBicgstabCsr, SolvesLargeSystemEquivalentToReference)
         gko::preconditioner::BatchJacobi<value_type>::build().on(d_exec));
     auto r_factory =
         solver_type::build()
-            .with_max_iterations(500)
-            .with_residual_tol(solver_restol)
+            .with_default_max_iterations(500)
+            .with_default_residual_tol(solver_restol)
             .with_tolerance_type(gko::stop::batch::ToleranceType::relative)
             .with_preconditioner(r_jac_factory)
             .on(refexec);
     auto d_factory =
         solver_type::build()
-            .with_max_iterations(500)
-            .with_residual_tol(solver_restol)
+            .with_default_max_iterations(500)
+            .with_default_residual_tol(solver_restol)
             .with_tolerance_type(gko::stop::batch::ToleranceType::relative)
             .with_preconditioner(d_jac_factory)
             .on(d_exec);
@@ -380,15 +380,15 @@ TEST(BatchBicgstabDense, SolvesLargeSystemEquivalentToReference)
         gko::preconditioner::BatchJacobi<value_type>::build().on(d_exec));
     auto r_factory =
         solver_type::build()
-            .with_max_iterations(500)
-            .with_residual_tol(solver_restol)
+            .with_default_max_iterations(500)
+            .with_default_residual_tol(solver_restol)
             .with_tolerance_type(gko::stop::batch::ToleranceType::relative)
             .with_preconditioner(r_jac_factory)
             .on(refexec);
     auto d_factory =
         solver_type::build()
-            .with_max_iterations(500)
-            .with_residual_tol(solver_restol)
+            .with_default_max_iterations(500)
+            .with_default_residual_tol(solver_restol)
             .with_tolerance_type(gko::stop::batch::ToleranceType::relative)
             .with_preconditioner(d_jac_factory)
             .on(d_exec);
@@ -421,15 +421,15 @@ TEST(BatchBicgstabEll, SolvesLargeSystemEquivalentToReference)
         gko::preconditioner::BatchJacobi<value_type>::build().on(d_exec));
     auto r_factory =
         solver_type::build()
-            .with_max_iterations(500)
-            .with_residual_tol(solver_restol)
+            .with_default_max_iterations(500)
+            .with_default_residual_tol(solver_restol)
             .with_tolerance_type(gko::stop::batch::ToleranceType::relative)
             .with_preconditioner(r_jac_factory)
             .on(refexec);
     auto d_factory =
         solver_type::build()
-            .with_max_iterations(500)
-            .with_residual_tol(solver_restol)
+            .with_default_max_iterations(500)
+            .with_default_residual_tol(solver_restol)
             .with_tolerance_type(gko::stop::batch::ToleranceType::relative)
             .with_preconditioner(d_jac_factory)
             .on(d_exec);

--- a/test/solver/batch_cg_kernels.cpp
+++ b/test/solver/batch_cg_kernels.cpp
@@ -116,8 +116,8 @@ protected:
         std::shared_ptr<const BDiag> right_scale = nullptr)
     {
         return solver_type::build()
-            .with_max_iterations(opts.max_its)
-            .with_residual_tol(opts.residual_tol)
+            .with_default_max_iterations(opts.max_its)
+            .with_default_residual_tol(opts.residual_tol)
             .with_tolerance_type(opts.tol_type)
             .with_preconditioner(prec_factory)
             .with_left_scaling_op(left_scale)
@@ -188,8 +188,8 @@ TEST_F(BatchCg, CoreSolvesSystemJacobi)
 {
     std::unique_ptr<typename solver_type::Factory> batchcg_factory =
         solver_type::build()
-            .with_max_iterations(100)
-            .with_residual_tol(1e-6f)
+            .with_default_max_iterations(100)
+            .with_default_residual_tol(1e-6f)
             .with_preconditioner(
                 gko::preconditioner::BatchJacobi<value_type>::build().on(
                     d_exec))
@@ -267,14 +267,14 @@ TEST_F(BatchCg, GoodScalingImprovesConvergence)
     auto d_right = gko::share(gko::clone(d_exec, right_scale));
     auto factory =
         solver_type::build()
-            .with_max_iterations(20)
-            .with_residual_tol(10 * eps)
+            .with_default_max_iterations(20)
+            .with_default_residual_tol(10 * eps)
             .with_tolerance_type(gko::stop::batch::ToleranceType::relative)
             .on(d_exec);
     auto factory_s =
         solver_type::build()
-            .with_max_iterations(10)
-            .with_residual_tol(10 * eps)
+            .with_default_max_iterations(10)
+            .with_default_residual_tol(10 * eps)
             .with_tolerance_type(gko::stop::batch::ToleranceType::relative)
             .with_left_scaling_op(d_left)
             .with_right_scaling_op(d_right)
@@ -299,8 +299,8 @@ TEST(BatchCgCsr, CanSolveWithoutScaling)
     const int maxits = 100;
     auto batchcg_factory =
         Solver::build()
-            .with_max_iterations(maxits)
-            .with_residual_tol(tol)
+            .with_default_max_iterations(maxits)
+            .with_default_residual_tol(tol)
             .with_tolerance_type(gko::stop::batch::ToleranceType::relative)
             .with_preconditioner(
                 gko::preconditioner::BatchJacobi<T>::build().on(d_exec))

--- a/test/solver/batch_gmres_kernels.cpp
+++ b/test/solver/batch_gmres_kernels.cpp
@@ -119,8 +119,8 @@ protected:
         std::shared_ptr<const BDiag> right_scale = nullptr)
     {
         return solver_type::build()
-            .with_max_iterations(opts.max_its)
-            .with_residual_tol(opts.residual_tol)
+            .with_default_max_iterations(opts.max_its)
+            .with_default_residual_tol(opts.residual_tol)
             .with_tolerance_type(opts.tol_type)
             .with_preconditioner(prec_factory)
             .with_restart(opts.restart_num)
@@ -194,8 +194,8 @@ TEST_F(BatchGmres, CoreSolvesSystemJacobi)
     using Solver = gko::solver::BatchGmres<value_type>;
     std::unique_ptr<typename Solver::Factory> batchgmres_factory =
         Solver::build()
-            .with_max_iterations(100)
-            .with_residual_tol(1e-6f)
+            .with_default_max_iterations(100)
+            .with_default_residual_tol(1e-6f)
             .with_preconditioner(
                 gko::preconditioner::BatchJacobi<value_type>::build().on(
                     d_exec))
@@ -279,14 +279,14 @@ TEST_F(BatchGmres, GoodScalingImprovesConvergence)
     auto d_right = gko::share(gko::clone(d_exec, right_scale));
     auto factory =
         solver_type::build()
-            .with_max_iterations(20)
-            .with_residual_tol(10 * eps)
+            .with_default_max_iterations(20)
+            .with_default_residual_tol(10 * eps)
             .with_tolerance_type(gko::stop::batch::ToleranceType::relative)
             .on(d_exec);
     auto factory_s =
         solver_type::build()
-            .with_max_iterations(10)
-            .with_residual_tol(10 * eps)
+            .with_default_max_iterations(10)
+            .with_default_residual_tol(10 * eps)
             .with_tolerance_type(gko::stop::batch::ToleranceType::relative)
             .with_left_scaling_op(d_left)
             .with_right_scaling_op(d_right)
@@ -311,8 +311,8 @@ TEST(BatchGmresCsr, CanSolveWithoutScaling)
     const int maxits = 5000;
     auto batchgmres_factory =
         Solver::build()
-            .with_max_iterations(maxits)
-            .with_residual_tol(tol)
+            .with_default_max_iterations(maxits)
+            .with_default_residual_tol(tol)
             .with_tolerance_type(gko::stop::batch::ToleranceType::relative)
             .with_restart(5)
             .on(d_exec);

--- a/test/solver/batch_idr_kernels.cpp
+++ b/test/solver/batch_idr_kernels.cpp
@@ -117,8 +117,8 @@ protected:
         std::shared_ptr<const BDiag> right_scale = nullptr)
     {
         return solver_type::build()
-            .with_max_iterations(opts.max_its)
-            .with_residual_tol(opts.residual_tol)
+            .with_default_max_iterations(opts.max_its)
+            .with_default_residual_tol(opts.residual_tol)
             .with_tolerance_type(opts.tol_type)
             .with_preconditioner(prec_factory)
             .with_subspace_dim(opts.subspace_dim_val)
@@ -238,8 +238,8 @@ TEST(BatchIdrCsr, CanSolveWithoutScaling)
     const int maxits = 5000;
     auto batchidr_factory =
         Solver::build()
-            .with_max_iterations(maxits)
-            .with_residual_tol(tol)
+            .with_default_max_iterations(maxits)
+            .with_default_residual_tol(tol)
             .with_tolerance_type(gko::stop::batch::ToleranceType::relative)
             .with_preconditioner(
                 gko::preconditioner::BatchJacobi<T>::build().on(exec))
@@ -270,8 +270,8 @@ TEST(BatchIdrCsr, SolvesSystemWithJacobiPreconditioner)
     const float eps = r<value_type>::value;
     std::unique_ptr<typename Solver::Factory> batchidr_factory =
         Solver::build()
-            .with_max_iterations(100)
-            .with_residual_tol(eps * 100)
+            .with_default_max_iterations(100)
+            .with_default_residual_tol(eps * 100)
             .with_preconditioner(
                 gko::preconditioner::BatchJacobi<value_type>::build().on(exec))
             .with_deterministic(true)

--- a/test/solver/batch_richardson_kernels.cpp
+++ b/test/solver/batch_richardson_kernels.cpp
@@ -114,8 +114,8 @@ protected:
         std::shared_ptr<const BDiag> right_scale = nullptr)
     {
         return solver_type::build()
-            .with_max_iterations(opts.max_its)
-            .with_residual_tol(opts.residual_tol)
+            .with_default_max_iterations(opts.max_its)
+            .with_default_residual_tol(opts.residual_tol)
             .with_tolerance_type(opts.tol_type)
             .with_preconditioner(prec_factory)
             .with_left_scaling_op(left_scale)
@@ -221,8 +221,8 @@ TEST_F(BatchRich, CoreSolvesSystemJacobi)
 {
     std::unique_ptr<typename solver_type::Factory> batchrich_factory =
         solver_type::build()
-            .with_max_iterations(100)
-            .with_residual_tol(5e-7f)
+            .with_default_max_iterations(100)
+            .with_default_residual_tol(5e-7f)
             .with_preconditioner(
                 gko::preconditioner::BatchJacobi<value_type>::build().on(
                     d_exec))
@@ -313,8 +313,8 @@ TEST(BatchRichCsr, CanSolveWithoutScaling)
     const int nrhs = 1;
     auto batchrich_factory =
         Solver::build()
-            .with_max_iterations(maxits)
-            .with_residual_tol(tol)
+            .with_default_max_iterations(maxits)
+            .with_default_residual_tol(tol)
             .with_relaxation_factor(RT{0.95})
             .with_tolerance_type(gko::stop::batch::ToleranceType::relative)
             .with_preconditioner(


### PR DESCRIPTION
This adds an interface to change the residual tolerance for subsequent runs of a solver, so that a new factory does not have to be created just for changing the tolerance. In cases where batch scaling is needed, this removes the need for redoing the setup task of scaling just for changing the tolerance, among potentially other things in the future.

A new, non-templated base class `BatchSolver` is added. This contains all functionality that is agnostic of the concrete type - preconditioner, generated preconditioner, scaling operators, residual tolerance, maximum iteration count. Thus, the user only needs a pointer to `BatchLinOp` for applying the solver, and a dynamic cast to `BatchSolver` to get and set/get solver-agnostic parameters like the residual tolerance.

The factory parameter is now renamed to `default_residual_tol`, and this is used to initialize the `residual_tol_` values of generated solvers. The `set_residual_tolerance(double)` member function directly sets the `residual_tol_` on the solver object.

Drawback:
- Casts are needed to the corresponding `real_type`s of the solvers. This was done so that the residual tolerance can be updated independent of the concrete batched solver type - the application does not always need to know the concrete type.