### PR TITLE
fix warning: comparison of integer expressions of different signedness

### DIFF
--- a/include/ginkgo/core/base/mpi.hpp
+++ b/include/ginkgo/core/base/mpi.hpp
@@ -274,7 +274,7 @@ private:
 inline std::vector<status> wait_all(std::vector<request>& req)
 {
     std::vector<status> stat;
-    for (auto i = 0; i < req.size(); ++i) {
+    for (std::size_t i = 0; i < req.size(); ++i) {
         stat.emplace_back(req[i].wait());
     }
     return stat;


### PR DESCRIPTION
This fixes a compiler warning in the `mpi.hpp` file:
```
/home/lahwaacz/.local/include/ginkgo/core/base/mpi.hpp: In function ‘std::vector<gko::mpi::status> gko::mpi::wait_all(std::vector<gko::mpi::request>&)’:
/home/lahwaacz/.local/include/ginkgo/core/base/mpi.hpp:277:20: warning: comparison of integer expressions of different signedness: ‘int’ and ‘std::vector<gko::mpi::request>::size_type’ {aka ‘long unsigned int’} [-Wsign-compare]
  277 |     for (auto i = 0; i < req.size(); ++i) {
      |                  ~~^~~~~~~~~~~~
```
Here `auto` cannot be used, because it takes the type of `0`, which is `int`. Later it is compared with `req.size()` which leads to the warning.