### PR TITLE
Move implementation from headers to source files

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -496,6 +496,7 @@ build/amd/mvapich2/gcc/rocm45/release/shared:
     - .quick_test_condition
     - .use_gko-rocm45-mvapich2-gnu8-llvm8
   variables:
+    BUILD_MPI: "ON"
     BUILD_OMP: "ON"
     BUILD_HIP: "ON"
     RUN_EXAMPLES: "ON"
@@ -510,6 +511,7 @@ build/amd/mvapich2/clang/rocm45/debug/shared:
   variables:
     C_COMPILER: "clang"
     CXX_COMPILER: "clang++"
+    BUILD_MPI: "ON"
     BUILD_OMP: "ON"
     BUILD_HIP: "ON"
     RUN_EXAMPLES: "ON"
@@ -523,6 +525,7 @@ build/amd/openmpi/gcc/rocm502/debug/static:
     - .full_test_condition
     - .use_gko-rocm502-openmpi-gnu11-llvm11
   variables:
+    BUILD_MPI: "ON"
     BUILD_OMP: "ON"
     BUILD_HIP: "ON"
     RUN_EXAMPLES: "ON"
@@ -538,6 +541,7 @@ build/amd/openmpi/clang/rocm502/release/shared:
   variables:
     C_COMPILER: "clang"
     CXX_COMPILER: "clang++"
+    BUILD_MPI: "ON"
     BUILD_OMP: "ON"
     BUILD_HIP: "ON"
     RUN_EXAMPLES: "ON"

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -7,10 +7,14 @@ target_sources(ginkgo
     base/combination.cpp
     base/composition.cpp
     base/device_matrix_data.cpp
+    base/exception.cpp
     base/executor.cpp
     base/index_set.cpp
+    base/lin_op.cpp
+    base/name_demangling.cpp
     base/mtx_io.cpp
     base/perturbation.cpp
+    base/polymorphic_object.cpp
     base/version.cpp
     distributed/partition.cpp
     factorization/elimination_forest.cpp
@@ -68,6 +72,9 @@ endif()
 if (GINKGO_BUILD_MPI)
     target_sources(ginkgo
         PRIVATE mpi/exception.cpp)
+else()
+    target_sources(ginkgo
+        PRIVATE mpi/exception_stub.cpp)
 endif()
 
 ginkgo_compile_features(ginkgo)

--- a/core/base/device_matrix_data.cpp
+++ b/core/base/device_matrix_data.cpp
@@ -78,6 +78,73 @@ device_matrix_data<ValueType, IndexType>::device_matrix_data(
 
 
 template <typename ValueType, typename IndexType>
+std::shared_ptr<const Executor>
+device_matrix_data<ValueType, IndexType>::get_executor() const
+{
+    return values_.get_executor();
+}
+
+
+template <typename ValueType, typename IndexType>
+dim<2> device_matrix_data<ValueType, IndexType>::get_size() const
+{
+    return size_;
+}
+
+
+template <typename ValueType, typename IndexType>
+size_type device_matrix_data<ValueType, IndexType>::get_num_elems() const
+{
+    return values_.get_num_elems();
+}
+
+
+template <typename ValueType, typename IndexType>
+IndexType* device_matrix_data<ValueType, IndexType>::get_row_idxs()
+{
+    return row_idxs_.get_data();
+}
+
+
+template <typename ValueType, typename IndexType>
+const IndexType* device_matrix_data<ValueType, IndexType>::get_const_row_idxs()
+    const
+{
+    return row_idxs_.get_const_data();
+}
+
+
+template <typename ValueType, typename IndexType>
+IndexType* device_matrix_data<ValueType, IndexType>::get_col_idxs()
+{
+    return col_idxs_.get_data();
+}
+
+
+template <typename ValueType, typename IndexType>
+const IndexType* device_matrix_data<ValueType, IndexType>::get_const_col_idxs()
+    const
+{
+    return col_idxs_.get_const_data();
+}
+
+
+template <typename ValueType, typename IndexType>
+ValueType* device_matrix_data<ValueType, IndexType>::get_values()
+{
+    return values_.get_data();
+}
+
+
+template <typename ValueType, typename IndexType>
+const ValueType* device_matrix_data<ValueType, IndexType>::get_const_values()
+    const
+{
+    return values_.get_const_data();
+}
+
+
+template <typename ValueType, typename IndexType>
 matrix_data<ValueType, IndexType>
 device_matrix_data<ValueType, IndexType>::copy_to_host() const
 {

--- a/core/base/exception.cpp
+++ b/core/base/exception.cpp
@@ -1,0 +1,203 @@
+/*******************************<GINKGO LICENSE>******************************
+Copyright (c) 2017-2022, the Ginkgo authors
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+******************************<GINKGO LICENSE>*******************************/
+
+#include <ginkgo/core/base/exception.hpp>
+
+
+namespace gko {
+
+
+Error::Error(const std::string& file, int line, const std::string& what)
+    : what_(file + ":" + std::to_string(line) + ": " + what)
+{}
+
+
+const char* Error::what() const noexcept { return what_.c_str(); }
+
+
+NotImplemented::NotImplemented(const std::string& file, int line,
+                               const std::string& func)
+    : Error(file, line, func + " is not implemented")
+{}
+
+
+NotCompiled::NotCompiled(const std::string& file, int line,
+                         const std::string& func, const std::string& module)
+    : Error(file, line,
+            "feature " + func + " is part of the " + module +
+                " module, which is not compiled on this system")
+{}
+
+
+NotSupported::NotSupported(const std::string& file, int line,
+                           const std::string& func, const std::string& obj_type)
+    : Error(file, line,
+            "Operation " + func + " does not support parameters of type " +
+                obj_type)
+{}
+
+
+MpiError::MpiError(const std::string& file, int line, const std::string& func,
+                   int64 error_code)
+    : Error(file, line, func + ": " + get_error(error_code))
+{}
+
+
+CudaError::CudaError(const std::string& file, int line, const std::string& func,
+                     int64 error_code)
+    : Error(file, line, func + ": " + get_error(error_code))
+{}
+
+
+CublasError::CublasError(const std::string& file, int line,
+                         const std::string& func, int64 error_code)
+    : Error(file, line, func + ": " + get_error(error_code))
+{}
+
+
+CurandError::CurandError(const std::string& file, int line,
+                         const std::string& func, int64 error_code)
+    : Error(file, line, func + ": " + get_error(error_code))
+{}
+
+
+CusparseError::CusparseError(const std::string& file, int line,
+                             const std::string& func, int64 error_code)
+    : Error(file, line, func + ": " + get_error(error_code))
+{}
+
+
+CufftError::CufftError(const std::string& file, int line,
+                       const std::string& func, int64 error_code)
+    : Error(file, line, func + ": " + get_error(error_code))
+{}
+
+HipError::HipError(const std::string& file, int line, const std::string& func,
+                   int64 error_code)
+    : Error(file, line, func + ": " + get_error(error_code))
+{}
+
+
+HipblasError::HipblasError(const std::string& file, int line,
+                           const std::string& func, int64 error_code)
+    : Error(file, line, func + ": " + get_error(error_code))
+{}
+
+
+HiprandError::HiprandError(const std::string& file, int line,
+                           const std::string& func, int64 error_code)
+    : Error(file, line, func + ": " + get_error(error_code))
+{}
+
+
+HipsparseError::HipsparseError(const std::string& file, int line,
+                               const std::string& func, int64 error_code)
+    : Error(file, line, func + ": " + get_error(error_code))
+{}
+
+
+HipfftError::HipfftError(const std::string& file, int line,
+                         const std::string& func, int64 error_code)
+    : Error(file, line, func + ": " + get_error(error_code))
+{}
+
+
+DimensionMismatch::DimensionMismatch(
+    const std::string& file, int line, const std::string& func,
+    const std::string& first_name, size_type first_rows, size_type first_cols,
+    const std::string& second_name, size_type second_rows,
+    size_type second_cols, const std::string& clarification)
+    : Error(file, line,
+            func + ": attempting to combine operators " + first_name + " [" +
+                std::to_string(first_rows) + " x " +
+                std::to_string(first_cols) + "] and " + second_name + " [" +
+                std::to_string(second_rows) + " x " +
+                std::to_string(second_cols) + "]: " + clarification)
+{}
+
+
+BadDimension::BadDimension(const std::string& file, int line,
+                           const std::string& func, const std::string& op_name,
+                           size_type op_num_rows, size_type op_num_cols,
+                           const std::string& clarification)
+    : Error(file, line,
+            func + ": Object " + op_name + " has dimensions [" +
+                std::to_string(op_num_rows) + " x " +
+                std::to_string(op_num_cols) + "]: " + clarification)
+{}
+
+
+ValueMismatch::ValueMismatch(const std::string& file, int line,
+                             const std::string& func, size_type val1,
+                             size_type val2, const std::string& clarification)
+    : Error(file, line,
+            func + ": Value mismatch : " + std::to_string(val1) + " and " +
+                std::to_string(val2) + " : " + clarification)
+{}
+
+
+AllocationError::AllocationError(const std::string& file, int line,
+                                 const std::string& device, size_type bytes)
+    : Error(file, line,
+            device + ": failed to allocate memory block of " +
+                std::to_string(bytes) + "B")
+{}
+
+
+OutOfBoundsError::OutOfBoundsError(const std::string& file, int line,
+                                   size_type index, size_type bound)
+    : Error(file, line,
+            "trying to access index " + std::to_string(index) +
+                " in a memory block of " + std::to_string(bound) + " elements")
+{}
+
+
+StreamError::StreamError(const std::string& file, int line,
+                         const std::string& func, const std::string& message)
+    : Error(file, line, func + ": " + message)
+{}
+
+
+KernelNotFound::KernelNotFound(const std::string& file, int line,
+                               const std::string& func)
+    : Error(file, line, func + ": unable to find an eligible kernel")
+{}
+
+
+UnsupportedMatrixProperty::UnsupportedMatrixProperty(const std::string& file,
+                                                     const int line,
+                                                     const std::string& msg)
+    : Error(file, line, msg)
+{}
+
+
+}  // namespace gko

--- a/core/base/executor.cpp
+++ b/core/base/executor.cpp
@@ -70,4 +70,423 @@ const char* Operation::get_name() const noexcept
 }
 
 
+bool Executor::memory_accessible(
+    const std::shared_ptr<const Executor>& other) const
+{
+    return this->verify_memory_from(other.get());
+}
+
+
+const Executor::exec_info& Executor::get_exec_info() const
+{
+    return this->exec_info_;
+}
+
+
+std::shared_ptr<OmpExecutor> OmpExecutor::create()
+{
+    return std::shared_ptr<OmpExecutor>(new OmpExecutor());
+}
+
+
+int OmpExecutor::get_num_cores() const
+{
+    return this->get_exec_info().num_computing_units;
+}
+
+
+int OmpExecutor::get_num_threads_per_core() const
+{
+    return this->get_exec_info().num_pu_per_cu;
+}
+
+
+OmpExecutor::OmpExecutor()
+{
+    this->OmpExecutor::populate_exec_info(machine_topology::get_instance());
+}
+
+
+bool OmpExecutor::verify_memory_to(const OmpExecutor* other) const
+{
+    return true;
+}
+
+
+bool OmpExecutor::verify_memory_to(const ReferenceExecutor* other) const
+{
+    return false;
+}
+
+
+bool OmpExecutor::verify_memory_to(const HipExecutor* other) const
+{
+    return false;
+}
+
+
+bool OmpExecutor::verify_memory_to(const CudaExecutor* other) const
+{
+    return false;
+}
+
+
+std::shared_ptr<ReferenceExecutor> ReferenceExecutor::create()
+{
+    return std::shared_ptr<ReferenceExecutor>(new ReferenceExecutor());
+}
+
+
+void ReferenceExecutor::run(const Operation& op) const
+{
+    this->template log<log::Logger::operation_launched>(this, &op);
+    op.run(std::static_pointer_cast<const ReferenceExecutor>(
+        this->shared_from_this()));
+    this->template log<log::Logger::operation_completed>(this, &op);
+}
+
+
+ReferenceExecutor::ReferenceExecutor()
+{
+    this->ReferenceExecutor::populate_exec_info(
+        machine_topology::get_instance());
+}
+
+
+void ReferenceExecutor::populate_exec_info(const machine_topology*)
+{
+    this->get_exec_info().device_id = -1;
+    this->get_exec_info().num_computing_units = 1;
+    this->get_exec_info().num_pu_per_cu = 1;
+}
+
+
+bool ReferenceExecutor::verify_memory_from(const Executor* src_exec) const
+{
+    return src_exec->verify_memory_to(this);
+}
+
+
+bool ReferenceExecutor::verify_memory_to(const ReferenceExecutor* other) const
+{
+    return true;
+}
+
+
+bool ReferenceExecutor::verify_memory_to(const OmpExecutor* other) const
+{
+    return false;
+}
+
+
+bool ReferenceExecutor::verify_memory_to(const DpcppExecutor* other) const
+{
+    return false;
+}
+
+
+bool ReferenceExecutor::verify_memory_to(const CudaExecutor* other) const
+{
+    return false;
+}
+
+
+bool ReferenceExecutor::verify_memory_to(const HipExecutor* other) const
+{
+    return false;
+}
+
+
+int CudaExecutor::get_device_id() const noexcept
+{
+    return this->get_exec_info().device_id;
+}
+
+
+int CudaExecutor::get_num_warps_per_sm() const noexcept
+{
+    return this->get_exec_info().num_pu_per_cu;
+}
+
+
+int CudaExecutor::get_num_multiprocessor() const noexcept
+{
+    return this->get_exec_info().num_computing_units;
+}
+
+
+int CudaExecutor::get_num_warps() const noexcept
+{
+    return this->get_exec_info().num_computing_units *
+           this->get_exec_info().num_pu_per_cu;
+}
+
+
+int CudaExecutor::get_warp_size() const noexcept
+{
+    return this->get_exec_info().max_subgroup_size;
+}
+
+
+int CudaExecutor::get_major_version() const noexcept
+{
+    return this->get_exec_info().major;
+}
+
+
+int CudaExecutor::get_minor_version() const noexcept
+{
+    return this->get_exec_info().minor;
+}
+
+
+cublasContext* CudaExecutor::get_cublas_handle() const
+{
+    return cublas_handle_.get();
+}
+
+
+cusparseContext* CudaExecutor::get_cusparse_handle() const
+{
+    return cusparse_handle_.get();
+}
+
+
+std::vector<int> CudaExecutor::get_closest_pus() const
+{
+    return this->get_exec_info().closest_pu_ids;
+}
+
+
+int CudaExecutor::get_closest_numa() const
+{
+    return this->get_exec_info().numa_node;
+}
+
+
+CudaExecutor::CudaExecutor(int device_id, std::shared_ptr<Executor> master,
+                           bool device_reset = false,
+                           allocation_mode alloc_mode = default_cuda_alloc_mode)
+    : EnableDeviceReset{device_reset}, master_(master), alloc_mode_{alloc_mode}
+{
+    this->get_exec_info().device_id = device_id;
+    this->get_exec_info().num_computing_units = 0;
+    this->get_exec_info().num_pu_per_cu = 0;
+    this->CudaExecutor::populate_exec_info(machine_topology::get_instance());
+    if (this->get_exec_info().closest_pu_ids.size()) {
+        machine_topology::get_instance()->bind_to_pus(this->get_closest_pus());
+    }
+    // it only gets attribute from device, so it should not be affected by
+    // DeviceReset.
+    this->set_gpu_property();
+    // increase the number of executor before any operations may be affected
+    // by DeviceReset.
+    increase_num_execs(this->get_exec_info().device_id);
+    this->init_handles();
+}
+
+
+bool CudaExecutor::verify_memory_to(const ReferenceExecutor* other) const
+{
+    return false;
+}
+
+
+bool CudaExecutor::verify_memory_to(const OmpExecutor* other) const
+{
+    return false;
+}
+
+
+bool CudaExecutor::verify_memory_to(const DpcppExecutor* other) const
+{
+    return false;
+}
+
+
+int HipExecutor::get_device_id() const noexcept
+{
+    return this->get_exec_info().device_id;
+}
+
+
+int HipExecutor::get_num_warps_per_sm() const noexcept
+{
+    return this->get_exec_info().num_pu_per_cu;
+}
+
+
+int HipExecutor::get_num_multiprocessor() const noexcept
+{
+    return this->get_exec_info().num_computing_units;
+}
+
+
+int HipExecutor::get_num_warps() const noexcept
+{
+    return this->get_exec_info().num_computing_units *
+           this->get_exec_info().num_pu_per_cu;
+}
+
+
+int HipExecutor::get_warp_size() const noexcept
+{
+    return this->get_exec_info().max_subgroup_size;
+}
+
+
+int HipExecutor::get_major_version() const noexcept
+{
+    return this->get_exec_info().major;
+}
+
+
+int HipExecutor::get_minor_version() const noexcept
+{
+    return this->get_exec_info().minor;
+}
+
+
+hipblasContext* HipExecutor::get_hipblas_handle() const
+{
+    return hipblas_handle_.get();
+}
+
+
+hipsparseContext* HipExecutor::get_hipsparse_handle() const
+{
+    return hipsparse_handle_.get();
+}
+
+
+std::vector<int> HipExecutor::get_closest_pus() const
+{
+    return this->get_exec_info().closest_pu_ids;
+}
+
+
+int HipExecutor::get_closest_numa() const
+{
+    return this->get_exec_info().numa_node;
+}
+
+
+HipExecutor::HipExecutor(int device_id, std::shared_ptr<Executor> master,
+                         bool device_reset = false,
+                         allocation_mode alloc_mode = default_hip_alloc_mode)
+    : EnableDeviceReset{device_reset}, master_(master), alloc_mode_(alloc_mode)
+{
+    this->get_exec_info().device_id = device_id;
+    this->get_exec_info().num_computing_units = 0;
+    this->get_exec_info().num_pu_per_cu = 0;
+    this->HipExecutor::populate_exec_info(machine_topology::get_instance());
+    if (this->get_exec_info().closest_pu_ids.size()) {
+        machine_topology::get_instance()->bind_to_pus(this->get_closest_pus());
+    }
+    // it only gets attribute from device, so it should not be affected by
+    // DeviceReset.
+    this->set_gpu_property();
+    // increase the number of executor before any operations may be affected
+    // by DeviceReset.
+    increase_num_execs(this->get_exec_info().device_id);
+    this->init_handles();
+}
+
+
+bool HipExecutor::verify_memory_to(const ReferenceExecutor* other) const
+{
+    return false;
+}
+
+
+bool HipExecutor::verify_memory_to(const OmpExecutor* other) const
+{
+    return false;
+}
+
+
+bool HipExecutor::verify_memory_to(const DpcppExecutor* other) const
+{
+    return false;
+}
+
+
+int DpcppExecutor::get_device_id() const noexcept
+{
+    return this->get_exec_info().device_id;
+}
+
+
+::cl::sycl::queue* DpcppExecutor::get_queue() const noexcept
+{
+    return queue_.get();
+}
+
+
+const std::vector<int>& DpcppExecutor::get_subgroup_sizes() const noexcept
+{
+    return this->get_exec_info().subgroup_sizes;
+}
+
+
+int DpcppExecutor::get_num_computing_units() const noexcept
+{
+    return this->get_exec_info().num_computing_units;
+}
+
+
+const std::vector<int>& DpcppExecutor::get_max_workitem_sizes() const noexcept
+{
+    return this->get_exec_info().max_workitem_sizes;
+}
+
+
+int DpcppExecutor::get_max_workgroup_size() const noexcept
+{
+    return this->get_exec_info().max_workgroup_size;
+}
+
+
+int DpcppExecutor::get_max_subgroup_size() const noexcept
+{
+    return this->get_exec_info().max_subgroup_size;
+}
+
+
+const std::string& DpcppExecutor::get_device_type() const noexcept
+{
+    return this->get_exec_info().device_type;
+}
+
+
+DpcppExecutor::DpcppExecutor(int device_id, std::shared_ptr<Executor> master,
+                             std::string device_type)
+    : master_(master)
+{
+    std::for_each(device_type.begin(), device_type.end(),
+                  [](char& c) { c = std::tolower(c); });
+    this->get_exec_info().device_type = std::string(device_type);
+    this->get_exec_info().device_id = device_id;
+    this->set_device_property();
+}
+
+
+bool DpcppExecutor::verify_memory_to(const ReferenceExecutor* other) const
+{
+    return false;
+}
+
+
+bool DpcppExecutor::verify_memory_to(const CudaExecutor* other) const
+{
+    return false;
+}
+
+
+bool DpcppExecutor::verify_memory_to(const HipExecutor* other) const
+{
+    return false;
+}
+
+
 }  // namespace gko

--- a/core/base/lin_op.cpp
+++ b/core/base/lin_op.cpp
@@ -1,0 +1,194 @@
+/*******************************<GINKGO LICENSE>******************************
+Copyright (c) 2017-2022, the Ginkgo authors
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+******************************<GINKGO LICENSE>*******************************/
+
+#include <ginkgo/core/base/lin_op.hpp>
+
+
+#include <memory>
+#include <type_traits>
+#include <utility>
+
+
+#include <ginkgo/core/base/abstract_factory.hpp>
+#include <ginkgo/core/base/device_matrix_data.hpp>
+#include <ginkgo/core/base/dim.hpp>
+#include <ginkgo/core/base/exception_helpers.hpp>
+#include <ginkgo/core/base/math.hpp>
+#include <ginkgo/core/base/matrix_assembly_data.hpp>
+#include <ginkgo/core/base/matrix_data.hpp>
+#include <ginkgo/core/base/polymorphic_object.hpp>
+#include <ginkgo/core/base/types.hpp>
+#include <ginkgo/core/base/utils.hpp>
+#include <ginkgo/core/log/logger.hpp>
+
+
+namespace gko {
+
+
+LinOp* LinOp::apply(const LinOp* b, LinOp* x)
+{
+    this->template log<log::Logger::linop_apply_started>(this, b, x);
+    this->validate_application_parameters(b, x);
+    auto exec = this->get_executor();
+    this->apply_impl(make_temporary_clone(exec, b).get(),
+                     make_temporary_clone(exec, x).get());
+    this->template log<log::Logger::linop_apply_completed>(this, b, x);
+    return this;
+}
+
+
+const LinOp* LinOp::apply(const LinOp* b, LinOp* x) const
+{
+    this->template log<log::Logger::linop_apply_started>(this, b, x);
+    this->validate_application_parameters(b, x);
+    auto exec = this->get_executor();
+    this->apply_impl(make_temporary_clone(exec, b).get(),
+                     make_temporary_clone(exec, x).get());
+    this->template log<log::Logger::linop_apply_completed>(this, b, x);
+    return this;
+}
+
+
+LinOp* LinOp::apply(const LinOp* alpha, const LinOp* b, const LinOp* beta,
+                    LinOp* x)
+{
+    this->template log<log::Logger::linop_advanced_apply_started>(this, alpha,
+                                                                  b, beta, x);
+    this->validate_application_parameters(alpha, b, beta, x);
+    auto exec = this->get_executor();
+    this->apply_impl(make_temporary_clone(exec, alpha).get(),
+                     make_temporary_clone(exec, b).get(),
+                     make_temporary_clone(exec, beta).get(),
+                     make_temporary_clone(exec, x).get());
+    this->template log<log::Logger::linop_advanced_apply_completed>(this, alpha,
+                                                                    b, beta, x);
+    return this;
+}
+
+
+const LinOp* LinOp::apply(const LinOp* alpha, const LinOp* b, const LinOp* beta,
+                          LinOp* x) const
+{
+    this->template log<log::Logger::linop_advanced_apply_started>(this, alpha,
+                                                                  b, beta, x);
+    this->validate_application_parameters(alpha, b, beta, x);
+    auto exec = this->get_executor();
+    this->apply_impl(make_temporary_clone(exec, alpha).get(),
+                     make_temporary_clone(exec, b).get(),
+                     make_temporary_clone(exec, beta).get(),
+                     make_temporary_clone(exec, x).get());
+    this->template log<log::Logger::linop_advanced_apply_completed>(this, alpha,
+                                                                    b, beta, x);
+    return this;
+}
+
+
+const dim<2>& LinOp::get_size() const noexcept { return size_; }
+
+
+bool LinOp::apply_uses_initial_guess() const { return false; }
+
+
+LinOp& LinOp::operator=(LinOp&& other)
+{
+    if (this != &other) {
+        EnableAbstractPolymorphicObject<LinOp>::operator=(std::move(other));
+        this->set_size(other.get_size());
+        other.set_size({});
+    }
+    return *this;
+}
+
+
+LinOp::LinOp(LinOp&& other)
+    : EnableAbstractPolymorphicObject<LinOp>(std::move(other)),
+      size_{std::exchange(other.size_, dim<2>{})}
+{}
+
+
+LinOp::LinOp(std::shared_ptr<const Executor> exec, const dim<2>& size)
+    : EnableAbstractPolymorphicObject<LinOp>(exec), size_{size}
+{}
+
+
+void LinOp::set_size(const dim<2>& value) noexcept { size_ = value; }
+
+
+void LinOp::validate_application_parameters(const LinOp* b,
+                                            const LinOp* x) const
+{
+    GKO_ASSERT_CONFORMANT(this, b);
+    GKO_ASSERT_EQUAL_ROWS(this, x);
+    GKO_ASSERT_EQUAL_COLS(b, x);
+}
+
+
+void LinOp::validate_application_parameters(const LinOp* alpha, const LinOp* b,
+                                            const LinOp* beta,
+                                            const LinOp* x) const
+{
+    this->validate_application_parameters(b, x);
+    GKO_ASSERT_EQUAL_DIMENSIONS(alpha, dim<2>(1, 1));
+    GKO_ASSERT_EQUAL_DIMENSIONS(beta, dim<2>(1, 1));
+}
+
+
+std::unique_ptr<LinOp> LinOpFactory::generate(
+    std::shared_ptr<const LinOp> input) const
+{
+    this->template log<log::Logger::linop_factory_generate_started>(
+        this, input.get());
+    const auto exec = this->get_executor();
+    std::unique_ptr<LinOp> generated;
+    if (input->get_executor() == exec) {
+        generated = this->AbstractFactory::generate(input);
+    } else {
+        generated = this->AbstractFactory::generate(gko::clone(exec, input));
+    }
+    this->template log<log::Logger::linop_factory_generate_completed>(
+        this, input.get(), generated.get());
+    return generated;
+}
+
+
+void ScaledIdentityAddable::add_scaled_identity(const LinOp* const a,
+                                                const LinOp* const b)
+{
+    GKO_ASSERT_IS_SCALAR(a);
+    GKO_ASSERT_IS_SCALAR(b);
+    auto ae = make_temporary_clone(as<LinOp>(this)->get_executor(), a);
+    auto be = make_temporary_clone(as<LinOp>(this)->get_executor(), b);
+    add_scaled_identity_impl(ae.get(), be.get());
+}
+
+
+}  // namespace gko

--- a/core/base/polymorphic_object.cpp
+++ b/core/base/polymorphic_object.cpp
@@ -1,0 +1,153 @@
+/*******************************<GINKGO LICENSE>******************************
+Copyright (c) 2017-2022, the Ginkgo authors
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+******************************<GINKGO LICENSE>*******************************/
+
+#include <ginkgo/core/base/polymorphic_object.hpp>
+
+
+namespace gko {
+
+
+PolymorphicObject::~PolymorphicObject()
+{
+    this->template log<log::Logger::polymorphic_object_deleted>(exec_.get(),
+                                                                this);
+}
+
+
+std::unique_ptr<PolymorphicObject> PolymorphicObject::create_default(
+    std::shared_ptr<const Executor> exec) const
+{
+    this->template log<log::Logger::polymorphic_object_create_started>(
+        exec_.get(), this);
+    auto created = this->create_default_impl(std::move(exec));
+    this->template log<log::Logger::polymorphic_object_create_completed>(
+        exec_.get(), this, created.get());
+    return created;
+}
+
+
+std::unique_ptr<PolymorphicObject> PolymorphicObject::create_default() const
+{
+    return this->create_default(exec_);
+}
+
+
+std::unique_ptr<PolymorphicObject> PolymorphicObject::clone(
+    std::shared_ptr<const Executor> exec) const
+{
+    auto new_op = this->create_default(exec);
+    new_op->copy_from(this);
+    return new_op;
+}
+
+
+std::unique_ptr<PolymorphicObject> PolymorphicObject::clone() const
+{
+    return this->clone(exec_);
+}
+
+
+PolymorphicObject* PolymorphicObject::copy_from(const PolymorphicObject* other)
+{
+    this->template log<log::Logger::polymorphic_object_copy_started>(
+        exec_.get(), other, this);
+    auto copied = this->copy_from_impl(other);
+    this->template log<log::Logger::polymorphic_object_copy_completed>(
+        exec_.get(), other, this);
+    return copied;
+}
+
+
+PolymorphicObject* PolymorphicObject::copy_from(
+    std::unique_ptr<PolymorphicObject> other)
+{
+    this->template log<log::Logger::polymorphic_object_move_started>(
+        exec_.get(), other.get(), this);
+    auto copied = this->copy_from_impl(std::move(other));
+    this->template log<log::Logger::polymorphic_object_move_completed>(
+        exec_.get(), other.get(), this);
+    return copied;
+}
+
+
+PolymorphicObject* PolymorphicObject::move_from(PolymorphicObject* other)
+{
+    this->template log<log::Logger::polymorphic_object_move_started>(
+        exec_.get(), other, this);
+    auto moved = this->move_from_impl(other);
+    this->template log<log::Logger::polymorphic_object_move_completed>(
+        exec_.get(), other, this);
+    return moved;
+}
+
+
+PolymorphicObject* PolymorphicObject::move_from(
+    std::unique_ptr<PolymorphicObject> other)
+{
+    this->template log<log::Logger::polymorphic_object_move_started>(
+        exec_.get(), other.get(), this);
+    auto copied = this->copy_from_impl(std::move(other));
+    this->template log<log::Logger::polymorphic_object_move_completed>(
+        exec_.get(), other.get(), this);
+    return copied;
+}
+
+
+PolymorphicObject* PolymorphicObject::clear() { return this->clear_impl(); }
+
+
+std::shared_ptr<const Executor> PolymorphicObject::get_executor() const noexcept
+{
+    return exec_;
+}
+
+
+PolymorphicObject::PolymorphicObject(std::shared_ptr<const Executor> exec)
+    : exec_{std::move(exec)}
+{}
+
+
+PolymorphicObject::PolymorphicObject(const PolymorphicObject& other)
+{
+    // preserve the executor of the object
+    *this = other;
+}
+
+
+PolymorphicObject& PolymorphicObject::operator=(const PolymorphicObject&)
+{
+    // preserve the executor of the object
+    return *this;
+}
+
+
+}  // namespace gko

--- a/core/base/version.cpp
+++ b/core/base/version.cpp
@@ -33,7 +33,58 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <ginkgo/core/base/version.hpp>
 
 
+#include <tuple>
+
+
 namespace gko {
+
+
+bool operator==(const version& first, const version& second)
+{
+    return std::tie(first.major, first.minor, first.patch) ==
+           std::tie(second.major, second.minor, second.patch);
+}
+
+
+bool operator!=(const version& first, const version& second)
+{
+    return !(first == second);
+}
+
+
+bool operator<(const version& first, const version& second)
+{
+    return std::tie(first.major, first.minor, first.patch) <
+           std::tie(second.major, second.minor, second.patch);
+}
+
+
+bool operator<=(const version& first, const version& second)
+{
+    return !(second < first);
+}
+
+
+bool operator>(const version& first, const version& second)
+{
+    return second < first;
+}
+
+
+bool operator>=(const version& first, const version& second)
+{
+    return !(first < second);
+}
+
+
+std::ostream& operator<<(std::ostream& os, const version& ver)
+{
+    os << ver.major << "." << ver.minor << "." << ver.patch;
+    if (ver.tag) {
+        os << " (" << ver.tag << ")";
+    }
+    return os;
+}
 
 
 version version_info::get_core_version() noexcept
@@ -43,6 +94,24 @@ version version_info::get_core_version() noexcept
     // if using shared libraries from different versions of Ginkgo.
     return version_info::get_header_version();
 }
+
+
+const version_info& version_info::get()
+{
+    static version_info info{};
+    return info;
+}
+
+
+version_info::version_info()
+    : header_version{get_header_version()},
+      core_version{get_core_version()},
+      reference_version{get_reference_version()},
+      omp_version{get_omp_version()},
+      cuda_version{get_cuda_version()},
+      hip_version{get_hip_version()},
+      dpcpp_version{get_dpcpp_version()}
+{}
 
 
 std::ostream& operator<<(std::ostream& os, const version_info& ver_info)

--- a/core/distributed/partition.cpp
+++ b/core/distributed/partition.cpp
@@ -55,6 +55,99 @@ GKO_REGISTER_OPERATION(has_ordered_parts, partition::has_ordered_parts);
 
 
 template <typename LocalIndexType, typename GlobalIndexType>
+size_type Partition<LocalIndexType, GlobalIndexType>::get_size() const noexcept
+{
+    return size_;
+}
+
+
+template <typename LocalIndexType, typename GlobalIndexType>
+size_type Partition<LocalIndexType, GlobalIndexType>::get_num_ranges() const
+    noexcept
+{
+    return offsets_.get_num_elems() - 1;
+}
+
+
+template <typename LocalIndexType, typename GlobalIndexType>
+comm_index_type Partition<LocalIndexType, GlobalIndexType>::get_num_parts()
+    const noexcept
+{
+    return num_parts_;
+}
+
+
+template <typename LocalIndexType, typename GlobalIndexType>
+comm_index_type
+Partition<LocalIndexType, GlobalIndexType>::get_num_empty_parts() const noexcept
+{
+    return num_empty_parts_;
+}
+
+
+template <typename LocalIndexType, typename GlobalIndexType>
+const GlobalIndexType*
+Partition<LocalIndexType, GlobalIndexType>::get_range_bounds() const noexcept
+{
+    return offsets_.get_const_data();
+}
+
+
+template <typename LocalIndexType, typename GlobalIndexType>
+const comm_index_type*
+Partition<LocalIndexType, GlobalIndexType>::get_part_ids() const noexcept
+{
+    return part_ids_.get_const_data();
+}
+
+
+template <typename LocalIndexType, typename GlobalIndexType>
+const LocalIndexType*
+Partition<LocalIndexType, GlobalIndexType>::get_range_starting_indices() const
+    noexcept
+{
+    return starting_indices_.get_const_data();
+}
+
+
+template <typename LocalIndexType, typename GlobalIndexType>
+const LocalIndexType*
+Partition<LocalIndexType, GlobalIndexType>::get_part_sizes() const noexcept
+{
+    return part_sizes_.get_const_data();
+}
+
+
+template <typename LocalIndexType, typename GlobalIndexType>
+LocalIndexType Partition<LocalIndexType, GlobalIndexType>::get_part_size(
+    comm_index_type part) const
+{
+    return this->get_executor()->copy_val_to_host(part_sizes_.get_const_data() +
+                                                  part);
+}
+
+
+template <typename LocalIndexType, typename GlobalIndexType>
+Partition<LocalIndexType, GlobalIndexType>::Partition(
+    std::shared_ptr<const Executor> exec, comm_index_type num_parts,
+    size_type num_ranges)
+    : EnablePolymorphicObject<Partition>{exec},
+      num_parts_{num_parts},
+      num_empty_parts_{0},
+      size_{0},
+      offsets_{exec, num_ranges + 1},
+      starting_indices_{exec, num_ranges},
+      part_sizes_{exec, static_cast<size_type>(num_parts)},
+      part_ids_{exec, num_ranges}
+{
+    offsets_.fill(0);
+    starting_indices_.fill(0);
+    part_sizes_.fill(0);
+    part_ids_.fill(0);
+}
+
+
+template <typename LocalIndexType, typename GlobalIndexType>
 std::unique_ptr<Partition<LocalIndexType, GlobalIndexType>>
 Partition<LocalIndexType, GlobalIndexType>::build_from_mapping(
     std::shared_ptr<const Executor> exec, const array<comm_index_type>& mapping,

--- a/core/factorization/ic.cpp
+++ b/core/factorization/ic.cpp
@@ -64,6 +64,46 @@ GKO_REGISTER_OPERATION(initialize_l, factorization::initialize_l);
 
 
 template <typename ValueType, typename IndexType>
+std::shared_ptr<const matrix::Csr<ValueType, IndexType>>
+Ic<ValueType, IndexType>::get_l_factor() const
+{
+    // Can be `static_cast` since the type is guaranteed in this class
+    return std::static_pointer_cast<const matrix_type>(
+        this->get_operators()[0]);
+}
+
+
+template <typename ValueType, typename IndexType>
+std::shared_ptr<const matrix::Csr<ValueType, IndexType>>
+Ic<ValueType, IndexType>::get_lt_factor() const
+{
+    if (this->get_operators().size() == 2) {
+        // Can be `static_cast` since the type is guaranteed in this class
+        return std::static_pointer_cast<const matrix_type>(
+            this->get_operators()[1]);
+    } else {
+        return std::static_pointer_cast<const matrix_type>(
+            share(get_l_factor()->conj_transpose()));
+    }
+}
+
+
+template <typename ValueType, typename IndexType>
+Ic<ValueType, IndexType>::Ic(const Factory* factory,
+                             std::shared_ptr<const gko::LinOp> system_matrix)
+    : Composition<ValueType>{factory->get_executor()},
+      parameters_{factory->get_parameters()}
+{
+    if (parameters_.l_strategy == nullptr) {
+        parameters_.l_strategy =
+            std::make_shared<typename matrix_type::classical>();
+    }
+    generate(system_matrix, parameters_.skip_sorting, parameters_.both_factors)
+        ->move_to(this);
+}
+
+
+template <typename ValueType, typename IndexType>
 std::unique_ptr<Composition<ValueType>> Ic<ValueType, IndexType>::generate(
     const std::shared_ptr<const LinOp>& system_matrix, bool skip_sorting,
     bool both_factors) const

--- a/core/factorization/ilu.cpp
+++ b/core/factorization/ilu.cpp
@@ -64,6 +64,44 @@ GKO_REGISTER_OPERATION(initialize_l_u, factorization::initialize_l_u);
 
 
 template <typename ValueType, typename IndexType>
+std::shared_ptr<const matrix::Csr<ValueType, IndexType>>
+Ilu<ValueType, IndexType>::get_l_factor() const
+{
+    // Can be `static_cast` since the type is guaranteed in this class
+    return std::static_pointer_cast<const matrix_type>(
+        this->get_operators()[0]);
+}
+
+
+template <typename ValueType, typename IndexType>
+std::shared_ptr<const matrix::Csr<ValueType, IndexType>>
+Ilu<ValueType, IndexType>::get_u_factor() const
+{
+    // Can be `static_cast` since the type is guaranteed in this class
+    return std::static_pointer_cast<const matrix_type>(
+        this->get_operators()[1]);
+}
+
+
+template <typename ValueType, typename IndexType>
+Ilu<ValueType, IndexType>::Ilu(const Factory* factory,
+                               std::shared_ptr<const gko::LinOp> system_matrix)
+    : Composition<ValueType>{factory->get_executor()},
+      parameters_{factory->get_parameters()}
+{
+    if (parameters_.l_strategy == nullptr) {
+        parameters_.l_strategy =
+            std::make_shared<typename matrix_type::classical>();
+    }
+    if (parameters_.u_strategy == nullptr) {
+        parameters_.u_strategy =
+            std::make_shared<typename matrix_type::classical>();
+    }
+    generate_l_u(system_matrix, parameters_.skip_sorting)->move_to(this);
+}
+
+
+template <typename ValueType, typename IndexType>
 std::unique_ptr<Composition<ValueType>> Ilu<ValueType, IndexType>::generate_l_u(
     const std::shared_ptr<const LinOp>& system_matrix, bool skip_sorting) const
 {

--- a/core/factorization/par_ic.cpp
+++ b/core/factorization/par_ic.cpp
@@ -73,6 +73,46 @@ GKO_REGISTER_OPERATION(convert_ptrs_to_idxs, components::convert_ptrs_to_idxs);
 
 
 template <typename ValueType, typename IndexType>
+std::shared_ptr<const matrix::Csr<ValueType, IndexType>>
+ParIc<ValueType, IndexType>::get_l_factor() const
+{
+    // Can be `static_cast` since the type is guaranteed in this class
+    return std::static_pointer_cast<const matrix_type>(
+        this->get_operators()[0]);
+}
+
+
+template <typename ValueType, typename IndexType>
+std::shared_ptr<const matrix::Csr<ValueType, IndexType>>
+ParIc<ValueType, IndexType>::get_lt_factor() const
+{
+    if (this->get_operators().size() == 2) {
+        // Can be `static_cast` since the type is guaranteed in this class
+        return std::static_pointer_cast<const matrix_type>(
+            this->get_operators()[1]);
+    } else {
+        return std::static_pointer_cast<const matrix_type>(
+            share(get_l_factor()->conj_transpose()));
+    }
+}
+
+
+template <typename ValueType, typename IndexType>
+ParIc<ValueType, IndexType>::ParIc(const Factory* factory,
+                                   std::shared_ptr<const LinOp> system_matrix)
+    : Composition<ValueType>(factory->get_executor()),
+      parameters_{factory->get_parameters()}
+{
+    if (parameters_.l_strategy == nullptr) {
+        parameters_.l_strategy =
+            std::make_shared<typename matrix_type::classical>();
+    }
+    generate(system_matrix, parameters_.skip_sorting, parameters_.both_factors)
+        ->move_to(this);
+}
+
+
+template <typename ValueType, typename IndexType>
 std::unique_ptr<Composition<ValueType>> ParIc<ValueType, IndexType>::generate(
     const std::shared_ptr<const LinOp>& system_matrix, bool skip_sorting,
     bool both_factors) const

--- a/core/factorization/par_ict.cpp
+++ b/core/factorization/par_ict.cpp
@@ -172,6 +172,44 @@ struct ParIctState {
 
 
 template <typename ValueType, typename IndexType>
+std::shared_ptr<const matrix::Csr<ValueType, IndexType>>
+ParIct<ValueType, IndexType>::get_l_factor() const
+{
+    // Can be `static_cast` since the type is guaranteed in this class
+    return std::static_pointer_cast<const matrix_type>(
+        this->get_operators()[0]);
+}
+
+
+template <typename ValueType, typename IndexType>
+std::shared_ptr<const matrix::Csr<ValueType, IndexType>>
+ParIct<ValueType, IndexType>::get_lt_factor() const
+{
+    // Can be `static_cast` since the type is guaranteed in this class
+    return std::static_pointer_cast<const matrix_type>(
+        this->get_operators()[1]);
+}
+
+
+template <typename ValueType, typename IndexType>
+ParIct<ValueType, IndexType>::ParIct(const Factory* factory,
+                                     std::shared_ptr<const LinOp> system_matrix)
+    : Composition<ValueType>(factory->get_executor()),
+      parameters_{factory->get_parameters()}
+{
+    if (parameters_.l_strategy == nullptr) {
+        parameters_.l_strategy =
+            std::make_shared<typename matrix_type::classical>();
+    }
+    if (parameters_.lt_strategy == nullptr) {
+        parameters_.lt_strategy =
+            std::make_shared<typename matrix_type::classical>();
+    }
+    generate_l_lt(std::move(system_matrix))->move_to(this);
+}
+
+
+template <typename ValueType, typename IndexType>
 std::unique_ptr<Composition<ValueType>>
 ParIct<ValueType, IndexType>::generate_l_lt(
     const std::shared_ptr<const LinOp>& system_matrix) const

--- a/core/factorization/par_ilu.cpp
+++ b/core/factorization/par_ilu.cpp
@@ -70,6 +70,46 @@ GKO_REGISTER_OPERATION(csr_transpose, csr::transpose);
 
 
 template <typename ValueType, typename IndexType>
+std::shared_ptr<const matrix::Csr<ValueType, IndexType>>
+ParIlu<ValueType, IndexType>::get_l_factor() const
+{
+    // Can be `static_cast` since the type is guaranteed in this class
+    return std::static_pointer_cast<const matrix_type>(
+        this->get_operators()[0]);
+}
+
+
+template <typename ValueType, typename IndexType>
+std::shared_ptr<const matrix::Csr<ValueType, IndexType>>
+ParIlu<ValueType, IndexType>::get_u_factor() const
+{
+    // Can be `static_cast` since the type is guaranteed in this class
+    return std::static_pointer_cast<const matrix_type>(
+        this->get_operators()[1]);
+}
+
+
+template <typename ValueType, typename IndexType>
+ParIlu<ValueType, IndexType>::ParIlu(const Factory* factory,
+                                     std::shared_ptr<const LinOp> system_matrix)
+    : Composition<ValueType>(factory->get_executor()),
+      parameters_{factory->get_parameters()}
+{
+    if (parameters_.l_strategy == nullptr) {
+        parameters_.l_strategy =
+            std::make_shared<typename matrix_type::classical>();
+    }
+    if (parameters_.u_strategy == nullptr) {
+        parameters_.u_strategy =
+            std::make_shared<typename matrix_type::classical>();
+    }
+    generate_l_u(system_matrix, parameters_.skip_sorting,
+                 parameters_.l_strategy, parameters_.u_strategy)
+        ->move_to(this);
+}
+
+
+template <typename ValueType, typename IndexType>
 std::unique_ptr<Composition<ValueType>>
 ParIlu<ValueType, IndexType>::generate_l_u(
     const std::shared_ptr<const LinOp>& system_matrix, bool skip_sorting,

--- a/core/factorization/par_ilut.cpp
+++ b/core/factorization/par_ilut.cpp
@@ -188,6 +188,44 @@ struct ParIlutState {
 
 
 template <typename ValueType, typename IndexType>
+std::shared_ptr<const matrix::Csr<ValueType, IndexType>>
+ParIlut<ValueType, IndexType>::get_l_factor() const
+{
+    // Can be `static_cast` since the type is guaranteed in this class
+    return std::static_pointer_cast<const matrix_type>(
+        this->get_operators()[0]);
+}
+
+
+template <typename ValueType, typename IndexType>
+std::shared_ptr<const matrix::Csr<ValueType, IndexType>>
+ParIlut<ValueType, IndexType>::get_u_factor() const
+{
+    // Can be `static_cast` since the type is guaranteed in this class
+    return std::static_pointer_cast<const matrix_type>(
+        this->get_operators()[1]);
+}
+
+
+template <typename ValueType, typename IndexType>
+ParIlut<ValueType, IndexType>::ParIlut(
+    const Factory* factory, std::shared_ptr<const LinOp> system_matrix)
+    : Composition<ValueType>(factory->get_executor()),
+      parameters_{factory->get_parameters()}
+{
+    if (parameters_.l_strategy == nullptr) {
+        parameters_.l_strategy =
+            std::make_shared<typename matrix_type::classical>();
+    }
+    if (parameters_.u_strategy == nullptr) {
+        parameters_.u_strategy =
+            std::make_shared<typename matrix_type::classical>();
+    }
+    generate_l_u(std::move(system_matrix))->move_to(this);
+}
+
+
+template <typename ValueType, typename IndexType>
 std::unique_ptr<Composition<ValueType>>
 ParIlut<ValueType, IndexType>::generate_l_u(
     const std::shared_ptr<const LinOp>& system_matrix) const

--- a/core/log/convergence.cpp
+++ b/core/log/convergence.cpp
@@ -44,6 +44,77 @@ namespace log {
 
 
 template <typename ValueType>
+std::unique_ptr<Convergence<ValueType>> Convergence<ValueType>::create(
+    std::shared_ptr<const Executor>, const mask_type& enabled_events)
+{
+    return std::unique_ptr<Convergence>(new Convergence(enabled_events));
+}
+
+
+template <typename ValueType>
+std::unique_ptr<Convergence<ValueType>> Convergence<ValueType>::create(
+    const mask_type& enabled_events)
+{
+    return std::unique_ptr<Convergence>(new Convergence(enabled_events));
+}
+
+
+template <typename ValueType>
+bool Convergence<ValueType>::has_converged() const noexcept
+{
+    return convergence_status_;
+}
+
+
+template <typename ValueType>
+void Convergence<ValueType>::reset_convergence_status()
+{
+    this->convergence_status_ = false;
+}
+
+
+template <typename ValueType>
+const size_type& Convergence<ValueType>::get_num_iterations() const noexcept
+{
+    return num_iterations_;
+}
+
+
+template <typename ValueType>
+const LinOp* Convergence<ValueType>::get_residual() const noexcept
+{
+    return residual_.get();
+}
+
+
+template <typename ValueType>
+const LinOp* Convergence<ValueType>::get_residual_norm() const noexcept
+{
+    return residual_norm_.get();
+}
+
+
+template <typename ValueType>
+const LinOp* Convergence<ValueType>::get_implicit_sq_resnorm() const noexcept
+{
+    return implicit_sq_resnorm_.get();
+}
+
+
+template <typename ValueType>
+Convergence<ValueType>::Convergence(std::shared_ptr<const gko::Executor>,
+                                    const mask_type& enabled_events)
+    : Logger(enabled_events)
+{}
+
+
+template <typename ValueType>
+Convergence<ValueType>::Convergence(const mask_type& enabled_events)
+    : Logger(enabled_events)
+{}
+
+
+template <typename ValueType>
 void Convergence<ValueType>::on_criterion_check_completed(
     const stop::Criterion* criterion, const size_type& num_iterations,
     const LinOp* residual, const LinOp* residual_norm,

--- a/core/log/performance_hint.cpp
+++ b/core/log/performance_hint.cpp
@@ -105,6 +105,27 @@ void print_copy_to_message(std::ostream& stream, gko::uintptr ptr, int count)
 }  // namespace
 
 
+std::unique_ptr<PerformanceHint> PerformanceHint::create(
+    std::ostream& os, size_type allocation_size_limit,
+    size_type copy_size_limit, size_type histogram_max_size)
+{
+    return std::unique_ptr<PerformanceHint>(new PerformanceHint(
+        os, allocation_size_limit, copy_size_limit, histogram_max_size));
+}
+
+
+PerformanceHint::PerformanceHint(std::ostream& os,
+                                 size_type allocation_size_limit,
+                                 size_type copy_size_limit,
+                                 size_type histogram_max_size)
+    : Logger(mask_),
+      os_(&os),
+      allocation_size_limit_{allocation_size_limit},
+      copy_size_limit_{copy_size_limit},
+      histogram_max_size_{histogram_max_size}
+{}
+
+
 void PerformanceHint::on_allocation_completed(const Executor* exec,
                                               const size_type& num_bytes,
                                               const uintptr& location) const

--- a/core/log/stream.cpp
+++ b/core/log/stream.cpp
@@ -123,6 +123,38 @@ GKO_ENABLE_DEMANGLE_NAME(Operation);
 
 
 template <typename ValueType>
+std::unique_ptr<Stream<ValueType>> Stream<ValueType>::create(
+    std::shared_ptr<const Executor> exec,
+    const Logger::mask_type& enabled_events, std::ostream& os, bool verbose)
+{
+    return std::unique_ptr<Stream>(new Stream(enabled_events, os, verbose));
+}
+
+
+template <typename ValueType>
+std::unique_ptr<Stream<ValueType>> Stream<ValueType>::create(
+    const Logger::mask_type& enabled_events, std::ostream& os, bool verbose)
+{
+    return std::unique_ptr<Stream>(new Stream(enabled_events, os, verbose));
+}
+
+
+template <typename ValueType>
+Stream<ValueType>::Stream(std::shared_ptr<const gko::Executor> exec,
+                          const Logger::mask_type& enabled_events,
+                          std::ostream& os, bool verbose)
+    : Stream(enabled_events, os, verbose)
+{}
+
+
+template <typename ValueType>
+Stream<ValueType>::Stream(const Logger::mask_type& enabled_events,
+                          std::ostream& os, bool verbose)
+    : Logger(enabled_events), os_(&os), verbose_(verbose)
+{}
+
+
+template <typename ValueType>
 void Stream<ValueType>::on_allocation_started(const Executor* exec,
                                               const size_type& num_bytes) const
 {
@@ -412,13 +444,13 @@ void Stream<ValueType>::on_criterion_check_completed(
     const stop::Criterion* criterion, const size_type& num_iterations,
     const LinOp* residual, const LinOp* residual_norm, const LinOp* solution,
     const uint8& stoppingId, const bool& setFinalized,
-    const array<stopping_status>* status, const bool& oneChanged,
+    const array<stopping_status>* status, const bool& one_changed,
     const bool& converged) const
 {
     *os_ << prefix_ << "check completed for " << demangle_name(criterion)
          << " at iteration " << num_iterations << " with ID "
          << static_cast<int>(stoppingId) << " and finalized set to "
-         << setFinalized << ". It changed one RHS " << oneChanged
+         << setFinalized << ". It changed one RHS " << one_changed
          << ", stopped the iteration process " << converged << std::endl;
 
     if (verbose_) {

--- a/core/matrix/ell.cpp
+++ b/core/matrix/ell.cpp
@@ -84,6 +84,101 @@ GKO_REGISTER_OPERATION(outplace_absolute_array,
 
 
 template <typename ValueType, typename IndexType>
+ValueType* Ell<ValueType, IndexType>::get_values() noexcept
+{
+    return values_.get_data();
+}
+
+
+template <typename ValueType, typename IndexType>
+const ValueType* Ell<ValueType, IndexType>::get_const_values() const noexcept
+{
+    return values_.get_const_data();
+}
+
+
+template <typename ValueType, typename IndexType>
+IndexType* Ell<ValueType, IndexType>::get_col_idxs() noexcept
+{
+    return col_idxs_.get_data();
+}
+
+
+template <typename ValueType, typename IndexType>
+const IndexType* Ell<ValueType, IndexType>::get_const_col_idxs() const noexcept
+{
+    return col_idxs_.get_const_data();
+}
+
+
+template <typename ValueType, typename IndexType>
+size_type Ell<ValueType, IndexType>::get_num_stored_elements_per_row() const
+    noexcept
+{
+    return num_stored_elements_per_row_;
+}
+
+
+template <typename ValueType, typename IndexType>
+size_type Ell<ValueType, IndexType>::get_stride() const noexcept
+{
+    return stride_;
+}
+
+
+template <typename ValueType, typename IndexType>
+size_type Ell<ValueType, IndexType>::get_num_stored_elements() const noexcept
+{
+    return values_.get_num_elems();
+}
+
+
+template <typename ValueType, typename IndexType>
+std::unique_ptr<const Ell<ValueType, IndexType>>
+Ell<ValueType, IndexType>::create_const(
+    std::shared_ptr<const Executor> exec, const dim<2>& size,
+    gko::detail::const_array_view<ValueType>&& values,
+    gko::detail::const_array_view<IndexType>&& col_idxs,
+    size_type num_stored_elements_per_row, size_type stride)
+{
+    // cast const-ness away, but return a const object afterwards,
+    // so we can ensure that no modifications take place.
+    return std::unique_ptr<const Ell>(
+        new Ell{exec, size, gko::detail::array_const_cast(std::move(values)),
+                gko::detail::array_const_cast(std::move(col_idxs)),
+                num_stored_elements_per_row, stride});
+}
+
+
+template <typename ValueType, typename IndexType>
+Ell<ValueType, IndexType>::Ell(std::shared_ptr<const Executor> exec,
+                               const dim<2>& size)
+    : Ell(std::move(exec), size, size[1])
+{}
+
+
+template <typename ValueType, typename IndexType>
+Ell<ValueType, IndexType>::Ell(std::shared_ptr<const Executor> exec,
+                               const dim<2>& size,
+                               size_type num_stored_elements_per_row)
+    : Ell(std::move(exec), size, num_stored_elements_per_row, size[0])
+{}
+
+
+template <typename ValueType, typename IndexType>
+Ell<ValueType, IndexType>::Ell(std::shared_ptr<const Executor> exec,
+                               const dim<2>& size,
+                               size_type num_stored_elements_per_row,
+                               size_type stride)
+    : EnableLinOp<Ell>(exec, size),
+      values_(exec, stride * num_stored_elements_per_row),
+      col_idxs_(exec, stride * num_stored_elements_per_row),
+      num_stored_elements_per_row_(num_stored_elements_per_row),
+      stride_(stride)
+{}
+
+
+template <typename ValueType, typename IndexType>
 Ell<ValueType, IndexType>& Ell<ValueType, IndexType>::operator=(
     const Ell& other)
 {

--- a/core/matrix/fft.cpp
+++ b/core/matrix/fft.cpp
@@ -138,6 +138,54 @@ void write_impl_3d(int64 size1, int64 size2, int64 size3, bool inverse,
 }  // namespace fft
 
 
+Fft::Fft(std::shared_ptr<const Executor> exec)
+    : EnableLinOp<Fft>(exec), buffer_{exec}, inverse_{}
+{}
+
+
+Fft::Fft(std::shared_ptr<const Executor> exec, size_type size, bool inverse)
+    : EnableLinOp<Fft>(exec, dim<2>{size}), buffer_{exec}, inverse_{inverse}
+{}
+
+
+Fft2::Fft2(std::shared_ptr<const Executor> exec)
+    : EnableLinOp<Fft2>(exec), buffer_{exec}, fft_size_{}, inverse_{}
+{}
+
+
+Fft2::Fft2(std::shared_ptr<const Executor> exec, size_type size)
+    : Fft2{exec, size, size}
+{}
+
+
+Fft2::Fft2(std::shared_ptr<const Executor> exec, size_type size1,
+           size_type size2, bool inverse)
+    : EnableLinOp<Fft2>(exec, dim<2>{size1 * size2}),
+      buffer_{exec},
+      fft_size_{size1, size2},
+      inverse_{inverse}
+{}
+
+
+Fft3::Fft3(std::shared_ptr<const Executor> exec)
+    : EnableLinOp<Fft3>(exec), buffer_{exec}, fft_size_{}, inverse_{}
+{}
+
+
+Fft3::Fft3(std::shared_ptr<const Executor> exec, size_type size)
+    : Fft3{exec, size, size, size}
+{}
+
+
+Fft3::Fft3(std::shared_ptr<const Executor> exec, size_type size1,
+           size_type size2, size_type size3, bool inverse)
+    : EnableLinOp<Fft3>(exec, dim<2>{size1 * size2 * size3}),
+      buffer_{exec},
+      fft_size_{size1, size2, size3},
+      inverse_{inverse}
+{}
+
+
 std::unique_ptr<LinOp> Fft::transpose() const
 {
     return Fft::create(this->get_executor(), this->get_size()[0], inverse_);

--- a/core/matrix/identity.cpp
+++ b/core/matrix/identity.cpp
@@ -44,6 +44,27 @@ namespace matrix {
 
 
 template <typename ValueType>
+Identity<ValueType>::Identity(std::shared_ptr<const Executor> exec)
+    : EnableLinOp<Identity>(exec)
+{}
+
+
+template <typename ValueType>
+Identity<ValueType>::Identity(std::shared_ptr<const Executor> exec, dim<2> size)
+    : EnableLinOp<Identity>(exec, size)
+{
+    GKO_ASSERT_IS_SQUARE_MATRIX(this);
+}
+
+
+template <typename ValueType>
+Identity<ValueType>::Identity(std::shared_ptr<const Executor> exec,
+                              size_type size)
+    : EnableLinOp<Identity>(exec, dim<2>{size})
+{}
+
+
+template <typename ValueType>
 void Identity<ValueType>::apply_impl(const LinOp* b, LinOp* x) const
 {
     x->copy_from(b);
@@ -64,16 +85,6 @@ void Identity<ValueType>::apply_impl(const LinOp* alpha, const LinOp* b,
 
 
 template <typename ValueType>
-std::unique_ptr<LinOp> IdentityFactory<ValueType>::generate_impl(
-    std::shared_ptr<const LinOp> base) const
-{
-    GKO_ASSERT_EQUAL_DIMENSIONS(base, transpose(base->get_size()));
-    return Identity<ValueType>::create(this->get_executor(),
-                                       base->get_size()[0]);
-}
-
-
-template <typename ValueType>
 std::unique_ptr<LinOp> Identity<ValueType>::transpose() const
 {
     return this->clone();
@@ -84,6 +95,32 @@ template <typename ValueType>
 std::unique_ptr<LinOp> Identity<ValueType>::conj_transpose() const
 {
     return this->clone();
+}
+
+
+template <typename ValueType>
+std::unique_ptr<IdentityFactory<ValueType>> IdentityFactory<ValueType>::create(
+    std::shared_ptr<const Executor> exec)
+{
+    return std::unique_ptr<IdentityFactory>(
+        new IdentityFactory(std::move(exec)));
+}
+
+
+template <typename ValueType>
+IdentityFactory<ValueType>::IdentityFactory(
+    std::shared_ptr<const Executor> exec)
+    : EnablePolymorphicObject<IdentityFactory, LinOpFactory>(exec)
+{}
+
+
+template <typename ValueType>
+std::unique_ptr<LinOp> IdentityFactory<ValueType>::generate_impl(
+    std::shared_ptr<const LinOp> base) const
+{
+    GKO_ASSERT_EQUAL_DIMENSIONS(base, transpose(base->get_size()));
+    return Identity<ValueType>::create(this->get_executor(),
+                                       base->get_size()[0]);
 }
 
 

--- a/core/matrix/row_gatherer.cpp
+++ b/core/matrix/row_gatherer.cpp
@@ -44,6 +44,46 @@ namespace matrix {
 
 
 template <typename IndexType>
+IndexType* RowGatherer<IndexType>::get_row_idxs() noexcept
+{
+    return row_idxs_.get_data();
+}
+
+
+template <typename IndexType>
+const IndexType* RowGatherer<IndexType>::get_const_row_idxs() const noexcept
+{
+    return row_idxs_.get_const_data();
+}
+
+
+template <typename IndexType>
+std::unique_ptr<const RowGatherer<IndexType>>
+RowGatherer<IndexType>::create_const(
+    std::shared_ptr<const Executor> exec, const dim<2>& size,
+    gko::detail::const_array_view<IndexType>&& row_idxs)
+{
+    // cast const-ness away, but return a const object afterwards,
+    // so we can ensure that no modifications take place.
+    return std::unique_ptr<const RowGatherer>(new RowGatherer{
+        exec, size, gko::detail::array_const_cast(std::move(row_idxs))});
+}
+
+
+template <typename IndexType>
+RowGatherer<IndexType>::RowGatherer(std::shared_ptr<const Executor> exec)
+    : RowGatherer(std::move(exec), dim<2>{})
+{}
+
+
+template <typename IndexType>
+RowGatherer<IndexType>::RowGatherer(std::shared_ptr<const Executor> exec,
+                                    const dim<2>& size)
+    : EnableLinOp<RowGatherer>(exec, size), row_idxs_(exec, size[0])
+{}
+
+
+template <typename IndexType>
 void RowGatherer<IndexType>::apply_impl(const LinOp* in, LinOp* out) const
 {
     run<const Dense<float>*, const Dense<double>*,

--- a/core/matrix/sellp.cpp
+++ b/core/matrix/sellp.cpp
@@ -79,6 +79,127 @@ GKO_REGISTER_OPERATION(outplace_absolute_array,
 
 
 template <typename ValueType, typename IndexType>
+ValueType* Sellp<ValueType, IndexType>::get_values() noexcept
+{
+    return values_.get_data();
+}
+
+
+template <typename ValueType, typename IndexType>
+const ValueType* Sellp<ValueType, IndexType>::get_const_values() const noexcept
+{
+    return values_.get_const_data();
+}
+
+
+template <typename ValueType, typename IndexType>
+IndexType* Sellp<ValueType, IndexType>::get_col_idxs() noexcept
+{
+    return col_idxs_.get_data();
+}
+
+
+template <typename ValueType, typename IndexType>
+const IndexType* Sellp<ValueType, IndexType>::get_const_col_idxs() const
+    noexcept
+{
+    return col_idxs_.get_const_data();
+}
+
+
+template <typename ValueType, typename IndexType>
+size_type* Sellp<ValueType, IndexType>::get_slice_lengths() noexcept
+{
+    return slice_lengths_.get_data();
+}
+
+
+template <typename ValueType, typename IndexType>
+const size_type* Sellp<ValueType, IndexType>::get_const_slice_lengths() const
+    noexcept
+{
+    return slice_lengths_.get_const_data();
+}
+
+
+template <typename ValueType, typename IndexType>
+size_type* Sellp<ValueType, IndexType>::get_slice_sets() noexcept
+{
+    return slice_sets_.get_data();
+}
+
+
+template <typename ValueType, typename IndexType>
+const size_type* Sellp<ValueType, IndexType>::get_const_slice_sets() const
+    noexcept
+{
+    return slice_sets_.get_const_data();
+}
+
+
+template <typename ValueType, typename IndexType>
+size_type Sellp<ValueType, IndexType>::get_slice_size() const noexcept
+{
+    return slice_size_;
+}
+
+
+template <typename ValueType, typename IndexType>
+size_type Sellp<ValueType, IndexType>::get_stride_factor() const noexcept
+{
+    return stride_factor_;
+}
+
+
+template <typename ValueType, typename IndexType>
+size_type Sellp<ValueType, IndexType>::get_total_cols() const noexcept
+{
+    return values_.get_num_elems() / slice_size_;
+}
+
+
+template <typename ValueType, typename IndexType>
+size_type Sellp<ValueType, IndexType>::get_num_stored_elements() const noexcept
+{
+    return values_.get_num_elems();
+}
+
+
+template <typename ValueType, typename IndexType>
+Sellp<ValueType, IndexType>::Sellp(std::shared_ptr<const Executor> exec,
+                                   const dim<2>& size)
+    : Sellp(std::move(exec), size,
+            ceildiv(size[0], default_slice_size) * size[1])
+{}
+
+
+template <typename ValueType, typename IndexType>
+Sellp<ValueType, IndexType>::Sellp(std::shared_ptr<const Executor> exec,
+                                   const dim<2>& size, size_type total_cols)
+    : Sellp(std::move(exec), size, default_slice_size, default_stride_factor,
+            total_cols)
+{}
+
+
+template <typename ValueType, typename IndexType>
+Sellp<ValueType, IndexType>::Sellp(std::shared_ptr<const Executor> exec,
+                                   const dim<2>& size, size_type slice_size,
+                                   size_type stride_factor,
+                                   size_type total_cols)
+    : EnableLinOp<Sellp>(exec, size),
+      values_(exec, slice_size * total_cols),
+      col_idxs_(exec, slice_size * total_cols),
+      slice_lengths_(exec, ceildiv(size[0], slice_size)),
+      slice_sets_(exec, ceildiv(size[0], slice_size) + 1),
+      slice_size_(slice_size),
+      stride_factor_(stride_factor)
+{
+    slice_sets_.fill(0);
+    slice_lengths_.fill(0);
+}
+
+
+template <typename ValueType, typename IndexType>
 Sellp<ValueType, IndexType>& Sellp<ValueType, IndexType>::operator=(
     const Sellp& other)
 {

--- a/core/mpi/exception_stub.cpp
+++ b/core/mpi/exception_stub.cpp
@@ -30,41 +30,14 @@ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ******************************<GINKGO LICENSE>*******************************/
 
-#include <ginkgo/core/stop/time.hpp>
+#include <ginkgo/core/base/exception.hpp>
+#include <ginkgo/core/base/exception_helpers.hpp>
 
 
 namespace gko {
-namespace stop {
 
 
-Time::Time(std::shared_ptr<const gko::Executor> exec)
-    : EnablePolymorphicObject<Time, Criterion>(std::move(exec)),
-      time_limit_{},
-      start_{}
-{}
+std::string MpiError::get_error(int64 error_code) GKO_NOT_IMPLEMENTED;
 
 
-Time::Time(const Factory* factory, const CriterionArgs args)
-    : EnablePolymorphicObject<Time, Criterion>(factory->get_executor()),
-      parameters_{factory->get_parameters()},
-      time_limit_{
-          std::chrono::duration<double>(factory->get_parameters().time_limit)},
-      start_{clock::now()}
-{}
-
-
-bool Time::check_impl(uint8 stoppingId, bool setFinalized,
-                      array<stopping_status>* stop_status, bool* one_changed,
-                      const Updater& updater)
-{
-    bool result = clock::now() - start_ >= time_limit_;
-    if (result) {
-        this->set_all_statuses(stoppingId, setFinalized, stop_status);
-        *one_changed = true;
-    }
-    return result;
-}
-
-
-}  // namespace stop
 }  // namespace gko

--- a/core/preconditioner/jacobi.cpp
+++ b/core/preconditioner/jacobi.cpp
@@ -130,6 +130,76 @@ Jacobi<ValueType, IndexType>::Jacobi(Jacobi&& other)
 
 
 template <typename ValueType, typename IndexType>
+Jacobi<ValueType, IndexType>::Jacobi(std::shared_ptr<const Executor> exec)
+    : EnableLinOp<Jacobi>(exec),
+      num_blocks_{},
+      blocks_(exec),
+      conditioning_(exec)
+{
+    parameters_.block_pointers.set_executor(exec);
+    parameters_.storage_optimization.block_wise.set_executor(exec);
+}
+
+
+template <typename ValueType, typename IndexType>
+Jacobi<ValueType, IndexType>::Jacobi(const Factory* factory,
+                                     std::shared_ptr<const LinOp> system_matrix)
+    : EnableLinOp<Jacobi>(factory->get_executor(),
+                          gko::transpose(system_matrix->get_size())),
+      parameters_{factory->get_parameters()},
+      storage_scheme_{this->compute_storage_scheme(
+          parameters_.max_block_size, parameters_.max_block_stride)},
+      num_blocks_{parameters_.block_pointers.get_num_elems() - 1},
+      blocks_(factory->get_executor(),
+              storage_scheme_.compute_storage_space(
+                  parameters_.block_pointers.get_num_elems() - 1)),
+      conditioning_(factory->get_executor())
+{
+    parameters_.block_pointers.set_executor(this->get_executor());
+    parameters_.storage_optimization.block_wise.set_executor(
+        this->get_executor());
+    this->generate(lend(system_matrix), parameters_.skip_sorting);
+}
+
+
+template <typename ValueType, typename IndexType>
+block_interleaved_storage_scheme<IndexType>
+Jacobi<ValueType, IndexType>::compute_storage_scheme(
+    uint32 max_block_size, uint32 param_max_block_stride) const
+{
+    uint32 default_block_stride = 32;
+    // If the executor is hip, the warp size is 32 or 64
+    if (auto hip_exec = std::dynamic_pointer_cast<const gko::HipExecutor>(
+            this->get_executor())) {
+        default_block_stride = hip_exec->get_warp_size();
+    }
+    uint32 max_block_stride = default_block_stride;
+    if (param_max_block_stride != 0) {
+        // if parameter max_block_stride is not zero, set max_block_stride =
+        // param_max_block_stride
+        max_block_stride = param_max_block_stride;
+        if (this->get_executor() != this->get_executor()->get_master() &&
+            max_block_stride != default_block_stride) {
+            // only support the default value on the gpu devive
+            GKO_NOT_SUPPORTED(this);
+        }
+    }
+    if (parameters_.max_block_size > max_block_stride ||
+        parameters_.max_block_size < 1) {
+        GKO_NOT_SUPPORTED(this);
+    }
+    const auto group_size = static_cast<uint32>(
+        max_block_stride / get_superior_power(uint32{2}, max_block_size));
+    const auto block_offset = max_block_size;
+    const auto block_stride = group_size * block_offset;
+    const auto group_offset = max_block_size * block_stride;
+    return {static_cast<index_type>(block_offset),
+            static_cast<index_type>(group_offset),
+            get_significant_bit(group_size)};
+}
+
+
+template <typename ValueType, typename IndexType>
 void Jacobi<ValueType, IndexType>::apply_impl(const LinOp* b, LinOp* x) const
 {
     precision_dispatch_real_complex<ValueType>(

--- a/core/solver/bicg.cpp
+++ b/core/solver/bicg.cpp
@@ -62,6 +62,30 @@ GKO_REGISTER_OPERATION(step_2, bicg::step_2);
 
 
 template <typename ValueType>
+bool Bicg<ValueType>::apply_uses_initial_guess() const
+{
+    return true;
+}
+
+
+template <typename ValueType>
+Bicg<ValueType>::Bicg(std::shared_ptr<const Executor> exec)
+    : EnableLinOp<Bicg>(std::move(exec))
+{}
+
+
+template <typename ValueType>
+Bicg<ValueType>::Bicg(const Factory* factory,
+                      std::shared_ptr<const LinOp> system_matrix)
+    : EnableLinOp<Bicg>(factory->get_executor(),
+                        gko::transpose(system_matrix->get_size())),
+      EnablePreconditionedIterativeSolver<ValueType, Bicg<ValueType>>{
+          std::move(system_matrix), factory->get_parameters()},
+      parameters_{factory->get_parameters()}
+{}
+
+
+template <typename ValueType>
 std::unique_ptr<LinOp> Bicg<ValueType>::transpose() const
 {
     return build()

--- a/core/solver/bicgstab.cpp
+++ b/core/solver/bicgstab.cpp
@@ -64,6 +64,30 @@ GKO_REGISTER_OPERATION(finalize, bicgstab::finalize);
 
 
 template <typename ValueType>
+bool Bicgstab<ValueType>::apply_uses_initial_guess() const
+{
+    return true;
+}
+
+
+template <typename ValueType>
+Bicgstab<ValueType>::Bicgstab(std::shared_ptr<const Executor> exec)
+    : EnableLinOp<Bicgstab>(std::move(exec))
+{}
+
+
+template <typename ValueType>
+Bicgstab<ValueType>::Bicgstab(const Factory* factory,
+                              std::shared_ptr<const LinOp> system_matrix)
+    : EnableLinOp<Bicgstab>(factory->get_executor(),
+                            gko::transpose(system_matrix->get_size())),
+      EnablePreconditionedIterativeSolver<ValueType, Bicgstab<ValueType>>{
+          std::move(system_matrix), factory->get_parameters()},
+      parameters_{factory->get_parameters()}
+{}
+
+
+template <typename ValueType>
 std::unique_ptr<LinOp> Bicgstab<ValueType>::transpose() const
 {
     return build()

--- a/core/solver/cb_gmres.cpp
+++ b/core/solver/cb_gmres.cpp
@@ -187,6 +187,51 @@ struct helper<std::complex<T>> {
 
 
 template <typename ValueType>
+size_type CbGmres<ValueType>::get_krylov_dim() const
+{
+    return parameters_.krylov_dim;
+}
+
+
+template <typename ValueType>
+void CbGmres<ValueType>::set_krylov_dim(size_type other)
+{
+    parameters_.krylov_dim = other;
+}
+
+
+template <typename ValueType>
+cb_gmres::storage_precision CbGmres<ValueType>::get_storage_precision() const
+{
+    return parameters_.storage_precision;
+}
+
+
+template <typename ValueType>
+bool CbGmres<ValueType>::apply_uses_initial_guess() const
+{
+    return true;
+}
+
+
+template <typename ValueType>
+CbGmres<ValueType>::CbGmres(std::shared_ptr<const Executor> exec)
+    : EnableLinOp<CbGmres>(std::move(exec))
+{}
+
+
+template <typename ValueType>
+CbGmres<ValueType>::CbGmres(const Factory* factory,
+                            std::shared_ptr<const LinOp> system_matrix)
+    : EnableLinOp<CbGmres>(factory->get_executor(),
+                           transpose(system_matrix->get_size())),
+      EnablePreconditionedIterativeSolver<ValueType, CbGmres<ValueType>>{
+          std::move(system_matrix), factory->get_parameters()},
+      parameters_{factory->get_parameters()}
+{}
+
+
+template <typename ValueType>
 void CbGmres<ValueType>::apply_impl(const LinOp* b, LinOp* x) const
 {
     if (!this->get_system_matrix()) {

--- a/core/solver/cg.cpp
+++ b/core/solver/cg.cpp
@@ -62,6 +62,30 @@ GKO_REGISTER_OPERATION(step_2, cg::step_2);
 
 
 template <typename ValueType>
+bool Cg<ValueType>::apply_uses_initial_guess() const
+{
+    return true;
+}
+
+
+template <typename ValueType>
+Cg<ValueType>::Cg(std::shared_ptr<const Executor> exec)
+    : EnableLinOp<Cg>(std::move(exec))
+{}
+
+
+template <typename ValueType>
+Cg<ValueType>::Cg(const Factory* factory,
+                  std::shared_ptr<const LinOp> system_matrix)
+    : EnableLinOp<Cg>(factory->get_executor(),
+                      gko::transpose(system_matrix->get_size())),
+      EnablePreconditionedIterativeSolver<ValueType, Cg<ValueType>>{
+          std::move(system_matrix), factory->get_parameters()},
+      parameters_{factory->get_parameters()}
+{}
+
+
+template <typename ValueType>
 std::unique_ptr<LinOp> Cg<ValueType>::transpose() const
 {
     return build()

--- a/core/solver/cgs.cpp
+++ b/core/solver/cgs.cpp
@@ -63,6 +63,30 @@ GKO_REGISTER_OPERATION(step_3, cgs::step_3);
 
 
 template <typename ValueType>
+bool Cgs<ValueType>::apply_uses_initial_guess() const
+{
+    return true;
+}
+
+
+template <typename ValueType>
+Cgs<ValueType>::Cgs(std::shared_ptr<const Executor> exec)
+    : EnableLinOp<Cgs>(std::move(exec))
+{}
+
+
+template <typename ValueType>
+Cgs<ValueType>::Cgs(const Factory* factory,
+                    std::shared_ptr<const LinOp> system_matrix)
+    : EnableLinOp<Cgs>(factory->get_executor(),
+                       gko::transpose(system_matrix->get_size())),
+      EnablePreconditionedIterativeSolver<ValueType, Cgs<ValueType>>{
+          std::move(system_matrix), factory->get_parameters()},
+      parameters_{factory->get_parameters()}
+{}
+
+
+template <typename ValueType>
 std::unique_ptr<LinOp> Cgs<ValueType>::transpose() const
 {
     return build()

--- a/core/solver/fcg.cpp
+++ b/core/solver/fcg.cpp
@@ -61,6 +61,30 @@ GKO_REGISTER_OPERATION(step_2, fcg::step_2);
 
 
 template <typename ValueType>
+bool Fcg<ValueType>::apply_uses_initial_guess() const
+{
+    return true;
+}
+
+
+template <typename ValueType>
+Fcg<ValueType>::Fcg(std::shared_ptr<const Executor> exec)
+    : EnableLinOp<Fcg>(std::move(exec))
+{}
+
+
+template <typename ValueType>
+Fcg<ValueType>::Fcg(const Factory* factory,
+                    std::shared_ptr<const LinOp> system_matrix)
+    : EnableLinOp<Fcg>(factory->get_executor(),
+                       gko::transpose(system_matrix->get_size())),
+      EnablePreconditionedIterativeSolver<ValueType, Fcg<ValueType>>{
+          std::move(system_matrix), factory->get_parameters()},
+      parameters_{factory->get_parameters()}
+{}
+
+
+template <typename ValueType>
 std::unique_ptr<LinOp> Fcg<ValueType>::transpose() const
 {
     return build()

--- a/core/solver/gmres.cpp
+++ b/core/solver/gmres.cpp
@@ -66,6 +66,48 @@ GKO_REGISTER_OPERATION(step_2, gmres::step_2);
 
 
 template <typename ValueType>
+bool Gmres<ValueType>::apply_uses_initial_guess() const
+{
+    return true;
+}
+
+
+template <typename ValueType>
+size_type Gmres<ValueType>::get_krylov_dim() const
+{
+    return parameters_.krylov_dim;
+}
+
+
+template <typename ValueType>
+void Gmres<ValueType>::set_krylov_dim(size_type other)
+{
+    parameters_.krylov_dim = other;
+}
+
+
+template <typename ValueType>
+Gmres<ValueType>::Gmres(std::shared_ptr<const Executor> exec)
+    : EnableLinOp<Gmres>(std::move(exec))
+{}
+
+
+template <typename ValueType>
+Gmres<ValueType>::Gmres(const Factory* factory,
+                        std::shared_ptr<const LinOp> system_matrix)
+    : EnableLinOp<Gmres>(factory->get_executor(),
+                         gko::transpose(system_matrix->get_size())),
+      EnablePreconditionedIterativeSolver<ValueType, Gmres<ValueType>>{
+          std::move(system_matrix), factory->get_parameters()},
+      parameters_{factory->get_parameters()}
+{
+    if (!parameters_.krylov_dim) {
+        parameters_.krylov_dim = default_krylov_dim;
+    }
+}
+
+
+template <typename ValueType>
 std::unique_ptr<LinOp> Gmres<ValueType>::transpose() const
 {
     return build()

--- a/core/solver/idr.cpp
+++ b/core/solver/idr.cpp
@@ -64,6 +64,86 @@ GKO_REGISTER_OPERATION(compute_omega, idr::compute_omega);
 
 
 template <typename ValueType>
+bool Idr<ValueType>::apply_uses_initial_guess() const
+{
+    return true;
+}
+
+
+template <typename ValueType>
+size_type Idr<ValueType>::get_subspace_dim() const
+{
+    return parameters_.subspace_dim;
+}
+
+
+template <typename ValueType>
+void Idr<ValueType>::set_subspace_dim(const size_type other)
+{
+    parameters_.subspace_dim = other;
+}
+
+
+template <typename ValueType>
+remove_complex<ValueType> Idr<ValueType>::get_kappa() const
+{
+    return parameters_.kappa;
+}
+
+
+template <typename ValueType>
+void Idr<ValueType>::set_kappa(const remove_complex<ValueType> other)
+{
+    parameters_.kappa = other;
+}
+
+
+template <typename ValueType>
+bool Idr<ValueType>::get_deterministic() const
+{
+    return parameters_.deterministic;
+}
+
+
+template <typename ValueType>
+void Idr<ValueType>::set_deterministic(const bool other)
+{
+    parameters_.deterministic = other;
+}
+
+
+template <typename ValueType>
+bool Idr<ValueType>::get_complex_subspace() const
+{
+    return parameters_.complex_subspace;
+}
+
+
+template <typename ValueType>
+void Idr<ValueType>::set_complex_subpsace(const bool other)
+{
+    parameters_.complex_subspace = other;
+}
+
+
+template <typename ValueType>
+Idr<ValueType>::Idr(std::shared_ptr<const Executor> exec)
+    : EnableLinOp<Idr>(std::move(exec))
+{}
+
+
+template <typename ValueType>
+Idr<ValueType>::Idr(const Factory* factory,
+                    std::shared_ptr<const LinOp> system_matrix)
+    : EnableLinOp<Idr>(factory->get_executor(),
+                       gko::transpose(system_matrix->get_size())),
+      EnablePreconditionedIterativeSolver<ValueType, Idr<ValueType>>{
+          std::move(system_matrix), factory->get_parameters()},
+      parameters_{factory->get_parameters()}
+{}
+
+
+template <typename ValueType>
 std::unique_ptr<LinOp> Idr<ValueType>::transpose() const
 {
     return build()

--- a/core/solver/lower_trs.cpp
+++ b/core/solver/lower_trs.cpp
@@ -62,6 +62,26 @@ GKO_REGISTER_OPERATION(solve, lower_trs::solve);
 
 
 template <typename ValueType, typename IndexType>
+LowerTrs<ValueType, IndexType>::LowerTrs(std::shared_ptr<const Executor> exec)
+    : EnableLinOp<LowerTrs>(std::move(exec))
+{}
+
+
+template <typename ValueType, typename IndexType>
+LowerTrs<ValueType, IndexType>::LowerTrs(
+    const Factory* factory, std::shared_ptr<const LinOp> system_matrix)
+    : EnableLinOp<LowerTrs>(factory->get_executor(),
+                            gko::transpose(system_matrix->get_size())),
+      EnableSolverBase<LowerTrs<ValueType, IndexType>, CsrMatrix>{
+          copy_and_convert_to<CsrMatrix>(factory->get_executor(),
+                                         system_matrix)},
+      parameters_{factory->get_parameters()}
+{
+    this->generate();
+}
+
+
+template <typename ValueType, typename IndexType>
 LowerTrs<ValueType, IndexType>::LowerTrs(const LowerTrs& other)
     : EnableLinOp<LowerTrs>(other.get_executor())
 {

--- a/core/solver/upper_trs.cpp
+++ b/core/solver/upper_trs.cpp
@@ -62,6 +62,26 @@ GKO_REGISTER_OPERATION(solve, upper_trs::solve);
 
 
 template <typename ValueType, typename IndexType>
+UpperTrs<ValueType, IndexType>::UpperTrs(std::shared_ptr<const Executor> exec)
+    : EnableLinOp<UpperTrs>(std::move(exec))
+{}
+
+
+template <typename ValueType, typename IndexType>
+UpperTrs<ValueType, IndexType>::UpperTrs(
+    const Factory* factory, std::shared_ptr<const LinOp> system_matrix)
+    : EnableLinOp<UpperTrs>(factory->get_executor(),
+                            gko::transpose(system_matrix->get_size())),
+      EnableSolverBase<UpperTrs<ValueType, IndexType>, CsrMatrix>{
+          copy_and_convert_to<CsrMatrix>(factory->get_executor(),
+                                         system_matrix)},
+      parameters_{factory->get_parameters()}
+{
+    this->generate();
+}
+
+
+template <typename ValueType, typename IndexType>
 UpperTrs<ValueType, IndexType>::UpperTrs(const UpperTrs& other)
     : EnableLinOp<UpperTrs>(other.get_executor())
 {

--- a/core/stop/combined.cpp
+++ b/core/stop/combined.cpp
@@ -37,6 +37,28 @@ namespace gko {
 namespace stop {
 
 
+Combined::Combined(std::shared_ptr<const gko::Executor> exec)
+    : EnablePolymorphicObject<Combined, Criterion>(std::move(exec))
+{}
+
+
+Combined::Combined(const Factory* factory, const CriterionArgs& args)
+    : EnablePolymorphicObject<Combined, Criterion>(factory->get_executor()),
+      parameters_{factory->get_parameters()}
+{
+    for (const auto& f : parameters_.criteria) {
+        // Ignore the nullptr from the list
+        if (f != nullptr) {
+            criteria_.push_back(f->generate(args));
+        }
+    }
+    // If the list are empty or all nullptr, throw gko::NotSupported
+    if (criteria_.size() == 0) {
+        GKO_NOT_SUPPORTED(this);
+    }
+}
+
+
 bool Combined::check_impl(uint8 stoppingId, bool setFinalized,
                           array<stopping_status>* stop_status,
                           bool* one_changed, const Updater& updater)

--- a/core/stop/iteration.cpp
+++ b/core/stop/iteration.cpp
@@ -37,6 +37,17 @@ namespace gko {
 namespace stop {
 
 
+Iteration::Iteration(std::shared_ptr<const gko::Executor> exec)
+    : EnablePolymorphicObject<Iteration, Criterion>(std::move(exec))
+{}
+
+
+Iteration::Iteration(const Factory* factory, const CriterionArgs& args)
+    : EnablePolymorphicObject<Iteration, Criterion>(factory->get_executor()),
+      parameters_{factory->get_parameters()}
+{}
+
+
 bool Iteration::check_impl(uint8 stoppingId, bool setFinalized,
                            array<stopping_status>* stop_status,
                            bool* one_changed, const Updater& updater)

--- a/core/stop/residual_norm.cpp
+++ b/core/stop/residual_norm.cpp
@@ -63,6 +63,94 @@ GKO_REGISTER_OPERATION(implicit_residual_norm,
 
 
 template <typename ValueType>
+ResidualNormBase<ValueType>::ResidualNormBase(
+    std::shared_ptr<const gko::Executor> exec)
+    : EnablePolymorphicObject<ResidualNormBase, Criterion>(exec),
+      device_storage_{exec, 2}
+{}
+
+
+template <typename ValueType>
+ResidualNormBase<ValueType>::ResidualNormBase(
+    std::shared_ptr<const gko::Executor> exec, const CriterionArgs& args,
+    remove_complex<ValueType> reduction_factor, mode baseline)
+    : EnablePolymorphicObject<ResidualNormBase, Criterion>(exec),
+      reduction_factor_{reduction_factor},
+      device_storage_{exec, 2},
+      baseline_{baseline},
+      system_matrix_{args.system_matrix},
+      b_{args.b},
+      one_{gko::initialize<Vector>({1}, exec)},
+      neg_one_{gko::initialize<Vector>({-1}, exec)}
+{
+    switch (baseline_) {
+    case mode::initial_resnorm: {
+        if (args.initial_residual == nullptr) {
+            if (args.system_matrix == nullptr || args.b == nullptr ||
+                args.x == nullptr) {
+                GKO_NOT_SUPPORTED(nullptr);
+            } else {
+                this->starting_tau_ =
+                    NormVector::create(exec, dim<2>{1, args.b->get_size()[1]});
+                auto b_clone = share(args.b->clone());
+                args.system_matrix->apply(neg_one_.get(), args.x, one_.get(),
+                                          b_clone.get());
+                if (auto vec = std::dynamic_pointer_cast<const ComplexVector>(
+                        b_clone)) {
+                    vec->compute_norm2(this->starting_tau_.get());
+                } else if (auto vec = std::dynamic_pointer_cast<const Vector>(
+                               b_clone)) {
+                    vec->compute_norm2(this->starting_tau_.get());
+                } else {
+                    GKO_NOT_SUPPORTED(nullptr);
+                }
+            }
+        } else {
+            this->starting_tau_ = NormVector::create(
+                exec, dim<2>{1, args.initial_residual->get_size()[1]});
+            if (dynamic_cast<const ComplexVector*>(args.initial_residual)) {
+                auto dense_r = as<ComplexVector>(args.initial_residual);
+                dense_r->compute_norm2(this->starting_tau_.get());
+            } else {
+                auto dense_r = as<Vector>(args.initial_residual);
+                dense_r->compute_norm2(this->starting_tau_.get());
+            }
+        }
+        break;
+    }
+    case mode::rhs_norm: {
+        if (args.b == nullptr) {
+            GKO_NOT_SUPPORTED(nullptr);
+        }
+        this->starting_tau_ =
+            NormVector::create(exec, dim<2>{1, args.b->get_size()[1]});
+        if (dynamic_cast<const ComplexVector*>(args.b.get())) {
+            auto dense_rhs = as<ComplexVector>(args.b);
+            dense_rhs->compute_norm2(this->starting_tau_.get());
+        } else {
+            auto dense_rhs = as<Vector>(args.b);
+            dense_rhs->compute_norm2(this->starting_tau_.get());
+        }
+        break;
+    }
+    case mode::absolute: {
+        if (args.b == nullptr) {
+            GKO_NOT_SUPPORTED(nullptr);
+        }
+        this->starting_tau_ =
+            NormVector::create(exec, dim<2>{1, args.b->get_size()[1]});
+        this->starting_tau_->fill(gko::one<remove_complex<ValueType>>());
+        break;
+    }
+    default:
+        GKO_NOT_SUPPORTED(nullptr);
+    }
+    this->u_dense_tau_ =
+        NormVector::create_with_config_of(this->starting_tau_.get());
+}
+
+
+template <typename ValueType>
 bool ResidualNormBase<ValueType>::check_impl(
     uint8 stopping_id, bool set_finalized, array<stopping_status>* stop_status,
     bool* one_changed, const Criterion::Updater& updater)
@@ -136,13 +224,123 @@ bool ImplicitResidualNorm<ValueType>::check_impl(
 }
 
 
-#define GKO_DECLARE_RESIDUAL_NORM(_type) class ResidualNormBase<_type>
-GKO_INSTANTIATE_FOR_EACH_VALUE_TYPE(GKO_DECLARE_RESIDUAL_NORM);
+template <typename ValueType>
+ResidualNorm<ValueType>::ResidualNorm(std::shared_ptr<const gko::Executor> exec)
+    : ResidualNormBase<ValueType>(exec)
+{}
 
 
+template <typename ValueType>
+ResidualNorm<ValueType>::ResidualNorm(const Factory* factory,
+                                      const CriterionArgs& args)
+    : ResidualNormBase<ValueType>(factory->get_executor(), args,
+                                  factory->get_parameters().reduction_factor,
+                                  factory->get_parameters().baseline),
+      parameters_{factory->get_parameters()}
+{}
+
+
+template <typename ValueType>
+ImplicitResidualNorm<ValueType>::ImplicitResidualNorm(
+    std::shared_ptr<const gko::Executor> exec)
+    : ResidualNormBase<ValueType>(exec)
+{}
+
+
+template <typename ValueType>
+ImplicitResidualNorm<ValueType>::ImplicitResidualNorm(const Factory* factory,
+                                                      const CriterionArgs& args)
+    : ResidualNormBase<ValueType>(factory->get_executor(), args,
+                                  factory->get_parameters().reduction_factor,
+                                  factory->get_parameters().baseline),
+      parameters_{factory->get_parameters()}
+{}
+
+
+// The following classes are deprecated, but they internally reference
+// themselves. To reduce unnecessary warnings, we disable deprecation warnings
+// for the definition of these classes.
+#if defined(__GNUC__) || defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#elif defined(_MSC_BUILD) || defined(__INTEL_LLVM_COMPILER)
+#pragma warning(push)
+#pragma warning(disable : 4996)
+#endif
+
+
+template <typename ValueType>
+ResidualNormReduction<ValueType>::ResidualNormReduction(
+    std::shared_ptr<const gko::Executor> exec)
+    : ResidualNormBase<ValueType>(exec)
+{}
+
+
+template <typename ValueType>
+ResidualNormReduction<ValueType>::ResidualNormReduction(
+    const Factory* factory, const CriterionArgs& args)
+    : ResidualNormBase<ValueType>(factory->get_executor(), args,
+                                  factory->get_parameters().reduction_factor,
+                                  mode::initial_resnorm),
+      parameters_{factory->get_parameters()}
+{}
+
+
+template <typename ValueType>
+RelativeResidualNorm<ValueType>::RelativeResidualNorm(
+    std::shared_ptr<const gko::Executor> exec)
+    : ResidualNormBase<ValueType>(exec)
+{}
+
+
+template <typename ValueType>
+RelativeResidualNorm<ValueType>::RelativeResidualNorm(const Factory* factory,
+                                                      const CriterionArgs& args)
+    : ResidualNormBase<ValueType>(factory->get_executor(), args,
+                                  factory->get_parameters().tolerance,
+                                  mode::rhs_norm),
+      parameters_{factory->get_parameters()}
+{}
+
+
+template <typename ValueType>
+AbsoluteResidualNorm<ValueType>::AbsoluteResidualNorm(
+    std::shared_ptr<const gko::Executor> exec)
+    : ResidualNormBase<ValueType>(exec)
+{}
+
+
+template <typename ValueType>
+AbsoluteResidualNorm<ValueType>::AbsoluteResidualNorm(const Factory* factory,
+                                                      const CriterionArgs& args)
+    : ResidualNormBase<ValueType>(factory->get_executor(), args,
+                                  factory->get_parameters().tolerance,
+                                  mode::absolute),
+      parameters_{factory->get_parameters()}
+{}
+
+
+#define GKO_DECLARE_RESIDUAL_NORM_BASE(_type) class ResidualNormBase<_type>
+#define GKO_DECLARE_RESIDUAL_NORM(_type) class ResidualNorm<_type>
+#define GKO_DECLARE_RESIDUAL_NORM_REDUCTION(_type) \
+    class ResidualNormReduction<_type>
+#define GKO_DECLARE_REL_RESIDUAL_NORM(_type) class RelativeResidualNorm<_type>
+#define GKO_DECLARE_ABS_RESIDUAL_NORM(_type) class AbsoluteResidualNorm<_type>
 #define GKO_DECLARE_IMPLICIT_RESIDUAL_NORM(_type) \
     class ImplicitResidualNorm<_type>
+GKO_INSTANTIATE_FOR_EACH_VALUE_TYPE(GKO_DECLARE_RESIDUAL_NORM_BASE);
+GKO_INSTANTIATE_FOR_EACH_VALUE_TYPE(GKO_DECLARE_RESIDUAL_NORM);
+GKO_INSTANTIATE_FOR_EACH_VALUE_TYPE(GKO_DECLARE_RESIDUAL_NORM_REDUCTION);
+GKO_INSTANTIATE_FOR_EACH_VALUE_TYPE(GKO_DECLARE_REL_RESIDUAL_NORM);
+GKO_INSTANTIATE_FOR_EACH_VALUE_TYPE(GKO_DECLARE_ABS_RESIDUAL_NORM);
 GKO_INSTANTIATE_FOR_EACH_VALUE_TYPE(GKO_DECLARE_IMPLICIT_RESIDUAL_NORM);
+
+
+#if defined(__GNUC__) || defined(__clang__)
+#pragma GCC diagnostic pop
+#elif defined(_MSC_BUILD) || defined(__INTEL_LLVM_COMPILER)
+#pragma warning(pop)
+#endif
 
 
 }  // namespace stop

--- a/core/test/log/record.cpp
+++ b/core/test/log/record.cpp
@@ -496,7 +496,7 @@ TEST(Record, CatchesCriterionCheckStarted)
     ASSERT_NE(data->criterion, nullptr);
     ASSERT_EQ(data->stopping_id, RelativeStoppingId);
     ASSERT_EQ(data->set_finalized, true);
-    ASSERT_EQ(data->oneChanged, false);
+    ASSERT_EQ(data->one_changed, false);
     ASSERT_EQ(data->converged, false);
 }
 
@@ -526,7 +526,7 @@ TEST(Record, CatchesCriterionCheckCompletedOld)
     ASSERT_EQ(data->status->get_const_data()->get_id(),
               stop_status.get_const_data()->get_id());
     ASSERT_EQ(data->status->get_const_data()->is_finalized(), true);
-    ASSERT_EQ(data->oneChanged, true);
+    ASSERT_EQ(data->one_changed, true);
     ASSERT_EQ(data->converged, true);
 }
 
@@ -556,7 +556,7 @@ TEST(Record, CatchesCriterionCheckCompleted)
     ASSERT_EQ(data->status->get_const_data()->get_id(),
               stop_status.get_const_data()->get_id());
     ASSERT_EQ(data->status->get_const_data()->is_finalized(), true);
-    ASSERT_EQ(data->oneChanged, true);
+    ASSERT_EQ(data->one_changed, true);
     ASSERT_EQ(data->converged, true);
 }
 

--- a/devices/machine_topology.cpp
+++ b/devices/machine_topology.cpp
@@ -258,4 +258,79 @@ void machine_topology::load_objects(
 }
 
 
+machine_topology* machine_topology::get_instance()
+{
+    static machine_topology instance;
+    return &instance;
+}
+
+
+void machine_topology::bind_to_cores(const std::vector<int>& ids,
+                                     const bool singlify) const
+{
+    hwloc_binding_helper(this->cores_, ids, singlify);
+}
+
+
+void machine_topology::bind_to_core(const int& id) const
+{
+    machine_topology::get_instance()->bind_to_cores(std::vector<int>{id});
+}
+
+
+void machine_topology::bind_to_pus(const std::vector<int>& ids,
+                                   const bool singlify) const
+{
+    hwloc_binding_helper(this->pus_, ids, singlify);
+}
+
+
+void machine_topology::bind_to_pu(const int& id) const
+{
+    machine_topology::get_instance()->bind_to_pus(std::vector<int>{id});
+}
+
+
+const machine_topology::normal_obj_info* machine_topology::get_pu(
+    size_type id) const
+{
+    GKO_ENSURE_IN_BOUNDS(id, this->pus_.size());
+    return &this->pus_[id];
+}
+
+
+const machine_topology::normal_obj_info* machine_topology::get_core(
+    size_type id) const
+{
+    GKO_ENSURE_IN_BOUNDS(id, this->cores_.size());
+    return &this->cores_[id];
+}
+
+
+const machine_topology::io_obj_info* machine_topology::get_pci_device(
+    size_type id) const
+{
+    GKO_ENSURE_IN_BOUNDS(id, this->pci_devices_.size());
+    return &this->pci_devices_[id];
+}
+
+
+size_type machine_topology::get_num_pus() const { return this->pus_.size(); }
+
+
+size_type machine_topology::get_num_cores() const
+{
+    return this->cores_.size();
+}
+
+
+size_type machine_topology::get_num_pci_devices() const
+{
+    return this->pci_devices_.size();
+}
+
+
+size_type machine_topology::get_num_numas() const { return this->num_numas_; }
+
+
 }  // namespace gko

--- a/include/ginkgo/core/base/device_matrix_data.hpp
+++ b/include/ginkgo/core/base/device_matrix_data.hpp
@@ -158,75 +158,63 @@ public:
      *
      * @return the executor used to store the device_matrix_data entries.
      */
-    std::shared_ptr<const Executor> get_executor() const
-    {
-        return values_.get_executor();
-    }
+    std::shared_ptr<const Executor> get_executor() const;
 
     /**
      * Returns the dimensions of the matrix.
      *
      * @return the dimensions of the matrix.
      */
-    dim<2> get_size() const { return size_; }
+    dim<2> get_size() const;
 
     /**
      * Returns the number of stored elements of the matrix.
      *
      * @return the number of stored elements of the matrix.
      */
-    size_type get_num_elems() const { return values_.get_num_elems(); }
+    size_type get_num_elems() const;
 
     /**
      * Returns a pointer to the row index array
      *
      * @return a pointer to the row index array
      */
-    index_type* get_row_idxs() { return row_idxs_.get_data(); }
+    index_type* get_row_idxs();
 
     /**
      * Returns a pointer to the constant row index array
      *
      * @return a pointer to the constant row index array
      */
-    const index_type* get_const_row_idxs() const
-    {
-        return row_idxs_.get_const_data();
-    }
+    const index_type* get_const_row_idxs() const;
 
     /**
      * Returns a pointer to the column index array
      *
      * @return a pointer to the column index array
      */
-    index_type* get_col_idxs() { return col_idxs_.get_data(); }
+    index_type* get_col_idxs();
 
     /**
      * Returns a pointer to the constant column index array
      *
      * @return a pointer to the constant column index array
      */
-    const index_type* get_const_col_idxs() const
-    {
-        return col_idxs_.get_const_data();
-    }
+    const index_type* get_const_col_idxs() const;
 
     /**
      * Returns a pointer to the value array
      *
      * @return a pointer to the value array
      */
-    value_type* get_values() { return values_.get_data(); }
+    value_type* get_values();
 
     /**
      * Returns a pointer to the constant value array
      *
      * @return a pointer to the constant value array
      */
-    const value_type* get_const_values() const
-    {
-        return values_.get_const_data();
-    }
+    const value_type* get_const_values() const;
 
     /**
      * Resizes the internal storage to the given number of stored matrix

--- a/include/ginkgo/core/base/exception.hpp
+++ b/include/ginkgo/core/base/exception.hpp
@@ -92,15 +92,13 @@ public:
      * @param line  The source code line number where the error occurred
      * @param what  The error message
      */
-    Error(const std::string& file, int line, const std::string& what)
-        : what_(file + ":" + std::to_string(line) + ": " + what)
-    {}
+    Error(const std::string& file, int line, const std::string& what);
 
     /**
      * Returns a human-readable string with a more detailed description of the
      * error.
      */
-    virtual const char* what() const noexcept override { return what_.c_str(); }
+    virtual const char* what() const noexcept override;
 
 private:
     const std::string what_;
@@ -120,9 +118,7 @@ public:
      * @param line  The source code line number where the error occurred
      * @param func  The name of the not-yet implemented function
      */
-    NotImplemented(const std::string& file, int line, const std::string& func)
-        : Error(file, line, func + " is not implemented")
-    {}
+    NotImplemented(const std::string& file, int line, const std::string& func);
 };
 
 
@@ -141,11 +137,7 @@ public:
      * @param module  The name of the module which contains the function
      */
     NotCompiled(const std::string& file, int line, const std::string& func,
-                const std::string& module)
-        : Error(file, line,
-                "feature " + func + " is part of the " + module +
-                    " module, which is not compiled on this system")
-    {}
+                const std::string& module);
 };
 
 
@@ -165,11 +157,7 @@ public:
                        cannot be performed.
      */
     NotSupported(const std::string& file, int line, const std::string& func,
-                 const std::string& obj_type)
-        : Error(file, line,
-                "Operation " + func + " does not support parameters of type " +
-                    obj_type)
-    {}
+                 const std::string& obj_type);
 };
 
 
@@ -186,9 +174,7 @@ public:
      * @param error_code The resulting MPI error code
      */
     MpiError(const std::string& file, int line, const std::string& func,
-             int64 error_code)
-        : Error(file, line, func + ": " + get_error(error_code))
-    {}
+             int64 error_code);
 
 private:
     static std::string get_error(int64 error_code);
@@ -209,9 +195,7 @@ public:
      * @param error_code  The resulting CUDA error code
      */
     CudaError(const std::string& file, int line, const std::string& func,
-              int64 error_code)
-        : Error(file, line, func + ": " + get_error(error_code))
-    {}
+              int64 error_code);
 
 private:
     static std::string get_error(int64 error_code);
@@ -232,9 +216,7 @@ public:
      * @param error_code  The resulting cuBLAS error code
      */
     CublasError(const std::string& file, int line, const std::string& func,
-                int64 error_code)
-        : Error(file, line, func + ": " + get_error(error_code))
-    {}
+                int64 error_code);
 
 private:
     static std::string get_error(int64 error_code);
@@ -255,9 +237,7 @@ public:
      * @param error_code  The resulting cuRAND error code
      */
     CurandError(const std::string& file, int line, const std::string& func,
-                int64 error_code)
-        : Error(file, line, func + ": " + get_error(error_code))
-    {}
+                int64 error_code);
 
 private:
     static std::string get_error(int64 error_code);
@@ -278,9 +258,7 @@ public:
      * @param error_code  The resulting cuSPARSE error code
      */
     CusparseError(const std::string& file, int line, const std::string& func,
-                  int64 error_code)
-        : Error(file, line, func + ": " + get_error(error_code))
-    {}
+                  int64 error_code);
 
 private:
     static std::string get_error(int64 error_code);
@@ -301,9 +279,7 @@ public:
      * @param error_code  The resulting cuFFT error code
      */
     CufftError(const std::string& file, int line, const std::string& func,
-               int64 error_code)
-        : Error(file, line, func + ": " + get_error(error_code))
-    {}
+               int64 error_code);
 
 private:
     static std::string get_error(int64 error_code);
@@ -324,9 +300,7 @@ public:
      * @param error_code  The resulting HIP error code
      */
     HipError(const std::string& file, int line, const std::string& func,
-             int64 error_code)
-        : Error(file, line, func + ": " + get_error(error_code))
-    {}
+             int64 error_code);
 
 private:
     static std::string get_error(int64 error_code);
@@ -347,9 +321,7 @@ public:
      * @param error_code  The resulting hipBLAS error code
      */
     HipblasError(const std::string& file, int line, const std::string& func,
-                 int64 error_code)
-        : Error(file, line, func + ": " + get_error(error_code))
-    {}
+                 int64 error_code);
 
 private:
     static std::string get_error(int64 error_code);
@@ -370,9 +342,7 @@ public:
      * @param error_code  The resulting hipRAND error code
      */
     HiprandError(const std::string& file, int line, const std::string& func,
-                 int64 error_code)
-        : Error(file, line, func + ": " + get_error(error_code))
-    {}
+                 int64 error_code);
 
 private:
     static std::string get_error(int64 error_code);
@@ -394,9 +364,7 @@ public:
      * @param error_code  The resulting hipSPARSE error code
      */
     HipsparseError(const std::string& file, int line, const std::string& func,
-                   int64 error_code)
-        : Error(file, line, func + ": " + get_error(error_code))
-    {}
+                   int64 error_code);
 
 private:
     static std::string get_error(int64 error_code);
@@ -417,9 +385,7 @@ public:
      * @param error_code  The resulting hipFFT error code
      */
     HipfftError(const std::string& file, int line, const std::string& func,
-                int64 error_code)
-        : Error(file, line, func + ": " + get_error(error_code))
-    {}
+                int64 error_code);
 
 private:
     static std::string get_error(int64 error_code);
@@ -450,14 +416,7 @@ public:
                       const std::string& func, const std::string& first_name,
                       size_type first_rows, size_type first_cols,
                       const std::string& second_name, size_type second_rows,
-                      size_type second_cols, const std::string& clarification)
-        : Error(file, line,
-                func + ": attempting to combine operators " + first_name +
-                    " [" + std::to_string(first_rows) + " x " +
-                    std::to_string(first_cols) + "] and " + second_name + " [" +
-                    std::to_string(second_rows) + " x " +
-                    std::to_string(second_cols) + "]: " + clarification)
-    {}
+                      size_type second_cols, const std::string& clarification);
 };
 
 
@@ -480,12 +439,7 @@ public:
      */
     BadDimension(const std::string& file, int line, const std::string& func,
                  const std::string& op_name, size_type op_num_rows,
-                 size_type op_num_cols, const std::string& clarification)
-        : Error(file, line,
-                func + ": Object " + op_name + " has dimensions [" +
-                    std::to_string(op_num_rows) + " x " +
-                    std::to_string(op_num_cols) + "]: " + clarification)
-    {}
+                 size_type op_num_cols, const std::string& clarification);
 };
 
 
@@ -530,11 +484,7 @@ public:
      */
     ValueMismatch(const std::string& file, int line, const std::string& func,
                   size_type val1, size_type val2,
-                  const std::string& clarification)
-        : Error(file, line,
-                func + ": Value mismatch : " + std::to_string(val1) + " and " +
-                    std::to_string(val2) + " : " + clarification)
-    {}
+                  const std::string& clarification);
 };
 
 
@@ -552,11 +502,7 @@ public:
      * @param bytes  The size of the memory block whose allocation failed.
      */
     AllocationError(const std::string& file, int line,
-                    const std::string& device, size_type bytes)
-        : Error(file, line,
-                device + ": failed to allocate memory block of " +
-                    std::to_string(bytes) + "B")
-    {}
+                    const std::string& device, size_type bytes);
 };
 
 
@@ -575,12 +521,7 @@ public:
      * @param bound  The first out-of-bound index
      */
     OutOfBoundsError(const std::string& file, int line, size_type index,
-                     size_type bound)
-        : Error(file, line,
-                "trying to access index " + std::to_string(index) +
-                    " in a memory block of " + std::to_string(bound) +
-                    " elements")
-    {}
+                     size_type bound);
 };
 
 
@@ -598,9 +539,7 @@ public:
      * @param message  The error message
      */
     StreamError(const std::string& file, int line, const std::string& func,
-                const std::string& message)
-        : Error(file, line, func + ": " + message)
-    {}
+                const std::string& message);
 };
 
 
@@ -617,9 +556,7 @@ public:
      * @param line  The source code line number where the error occurred
      * @param func  The name of the function where the error occurred
      */
-    KernelNotFound(const std::string& file, int line, const std::string& func)
-        : Error(file, line, func + ": unable to find an eligible kernel")
-    {}
+    KernelNotFound(const std::string& file, int line, const std::string& func);
 };
 
 
@@ -639,9 +576,7 @@ public:
      * @param msg  A message describing the property required.
      */
     UnsupportedMatrixProperty(const std::string& file, const int line,
-                              const std::string& msg)
-        : Error(file, line, msg)
-    {}
+                              const std::string& msg);
 };
 
 

--- a/include/ginkgo/core/base/lin_op.hpp
+++ b/include/ginkgo/core/base/lin_op.hpp
@@ -155,30 +155,12 @@ public:
      *
      * @return this
      */
-    LinOp* apply(const LinOp* b, LinOp* x)
-    {
-        this->template log<log::Logger::linop_apply_started>(this, b, x);
-        this->validate_application_parameters(b, x);
-        auto exec = this->get_executor();
-        this->apply_impl(make_temporary_clone(exec, b).get(),
-                         make_temporary_clone(exec, x).get());
-        this->template log<log::Logger::linop_apply_completed>(this, b, x);
-        return this;
-    }
+    LinOp* apply(const LinOp* b, LinOp* x);
 
     /**
      * @copydoc apply(const LinOp *, LinOp *)
      */
-    const LinOp* apply(const LinOp* b, LinOp* x) const
-    {
-        this->template log<log::Logger::linop_apply_started>(this, b, x);
-        this->validate_application_parameters(b, x);
-        auto exec = this->get_executor();
-        this->apply_impl(make_temporary_clone(exec, b).get(),
-                         make_temporary_clone(exec, x).get());
-        this->template log<log::Logger::linop_apply_completed>(this, b, x);
-        return this;
-    }
+    const LinOp* apply(const LinOp* b, LinOp* x) const;
 
     /**
      * Performs the operation x = alpha * op(b) + beta * x.
@@ -191,46 +173,20 @@ public:
      * @return this
      */
     LinOp* apply(const LinOp* alpha, const LinOp* b, const LinOp* beta,
-                 LinOp* x)
-    {
-        this->template log<log::Logger::linop_advanced_apply_started>(
-            this, alpha, b, beta, x);
-        this->validate_application_parameters(alpha, b, beta, x);
-        auto exec = this->get_executor();
-        this->apply_impl(make_temporary_clone(exec, alpha).get(),
-                         make_temporary_clone(exec, b).get(),
-                         make_temporary_clone(exec, beta).get(),
-                         make_temporary_clone(exec, x).get());
-        this->template log<log::Logger::linop_advanced_apply_completed>(
-            this, alpha, b, beta, x);
-        return this;
-    }
+                 LinOp* x);
 
     /**
      * @copydoc apply(const LinOp *, const LinOp *, const LinOp *, LinOp *)
      */
     const LinOp* apply(const LinOp* alpha, const LinOp* b, const LinOp* beta,
-                       LinOp* x) const
-    {
-        this->template log<log::Logger::linop_advanced_apply_started>(
-            this, alpha, b, beta, x);
-        this->validate_application_parameters(alpha, b, beta, x);
-        auto exec = this->get_executor();
-        this->apply_impl(make_temporary_clone(exec, alpha).get(),
-                         make_temporary_clone(exec, b).get(),
-                         make_temporary_clone(exec, beta).get(),
-                         make_temporary_clone(exec, x).get());
-        this->template log<log::Logger::linop_advanced_apply_completed>(
-            this, alpha, b, beta, x);
-        return this;
-    }
+                       LinOp* x) const;
 
     /**
      * Returns the size of the operator.
      *
      * @return size of the operator
      */
-    const dim<2>& get_size() const noexcept { return size_; }
+    const dim<2>& get_size() const noexcept;
 
     /**
      * Returns true if the linear operator uses the data given in x as
@@ -239,7 +195,7 @@ public:
      * @return true if the linear operator uses the data given in x as
      *         an initial guess. Returns false otherwise.
      */
-    virtual bool apply_uses_initial_guess() const { return false; }
+    virtual bool apply_uses_initial_guess() const;
 
     /** Copy-assigns a LinOp. Preserves the executor and copies the size. */
     LinOp& operator=(const LinOp&) = default;
@@ -249,15 +205,7 @@ public:
      * The moved-from object has size 0x0 afterwards, but its executor is
      * unchanged.
      */
-    LinOp& operator=(LinOp&& other)
-    {
-        if (this != &other) {
-            EnableAbstractPolymorphicObject<LinOp>::operator=(std::move(other));
-            this->set_size(other.get_size());
-            other.set_size({});
-        }
-        return *this;
-    }
+    LinOp& operator=(LinOp&& other);
 
     /** Copy-constructs a LinOp. Inherits executor and size from the input. */
     LinOp(const LinOp&) = default;
@@ -266,10 +214,7 @@ public:
      * Move-constructs a LinOp. Inherits executor and size from the input,
      * which will have size 0x0 and unchanged executor afterwards.
      */
-    LinOp(LinOp&& other)
-        : EnableAbstractPolymorphicObject<LinOp>(std::move(other)),
-          size_{std::exchange(other.size_, dim<2>{})}
-    {}
+    LinOp(LinOp&& other);
 
 protected:
     /**
@@ -279,16 +224,14 @@ protected:
      * @param size  the size of the operator
      */
     explicit LinOp(std::shared_ptr<const Executor> exec,
-                   const dim<2>& size = dim<2>{})
-        : EnableAbstractPolymorphicObject<LinOp>(exec), size_{size}
-    {}
+                   const dim<2>& size = dim<2>{});
 
     /**
      * Sets the size of the operator.
      *
      * @param value  the new size of the operator
      */
-    void set_size(const dim<2>& value) noexcept { size_ = value; }
+    void set_size(const dim<2>& value) noexcept;
 
     /**
      * Implementers of LinOp should override this function instead
@@ -320,12 +263,7 @@ protected:
      * @param b  vector(s) on which the operator is applied
      * @param x  output vector(s)
      */
-    void validate_application_parameters(const LinOp* b, const LinOp* x) const
-    {
-        GKO_ASSERT_CONFORMANT(this, b);
-        GKO_ASSERT_EQUAL_ROWS(this, x);
-        GKO_ASSERT_EQUAL_COLS(b, x);
-    }
+    void validate_application_parameters(const LinOp* b, const LinOp* x) const;
 
     /**
      * Throws a DimensionMismatch exception if the parameters to `apply` are of
@@ -338,12 +276,7 @@ protected:
      */
     void validate_application_parameters(const LinOp* alpha, const LinOp* b,
                                          const LinOp* beta,
-                                         const LinOp* x) const
-    {
-        this->validate_application_parameters(b, x);
-        GKO_ASSERT_EQUAL_DIMENSIONS(alpha, dim<2>(1, 1));
-        GKO_ASSERT_EQUAL_DIMENSIONS(beta, dim<2>(1, 1));
-    }
+                                         const LinOp* x) const;
 
 private:
     dim<2> size_{};
@@ -409,22 +342,7 @@ class LinOpFactory
 public:
     using AbstractFactory<LinOp, std::shared_ptr<const LinOp>>::AbstractFactory;
 
-    std::unique_ptr<LinOp> generate(std::shared_ptr<const LinOp> input) const
-    {
-        this->template log<log::Logger::linop_factory_generate_started>(
-            this, input.get());
-        const auto exec = this->get_executor();
-        std::unique_ptr<LinOp> generated;
-        if (input->get_executor() == exec) {
-            generated = this->AbstractFactory::generate(input);
-        } else {
-            generated =
-                this->AbstractFactory::generate(gko::clone(exec, input));
-        }
-        this->template log<log::Logger::linop_factory_generate_completed>(
-            this, input.get(), generated.get());
-        return generated;
-    }
+    std::unique_ptr<LinOp> generate(std::shared_ptr<const LinOp> input) const;
 };
 
 
@@ -829,14 +747,7 @@ public:
      * @param b  Scalar to multiply this before adding the scaled identity to
      *           it.
      */
-    void add_scaled_identity(const LinOp* const a, const LinOp* const b)
-    {
-        GKO_ASSERT_IS_SCALAR(a);
-        GKO_ASSERT_IS_SCALAR(b);
-        auto ae = make_temporary_clone(as<LinOp>(this)->get_executor(), a);
-        auto be = make_temporary_clone(as<LinOp>(this)->get_executor(), b);
-        add_scaled_identity_impl(ae.get(), be.get());
-    }
+    void add_scaled_identity(const LinOp* const a, const LinOp* const b);
 
 private:
     virtual void add_scaled_identity_impl(const LinOp* a, const LinOp* b) = 0;

--- a/include/ginkgo/core/base/machine_topology.hpp
+++ b/include/ginkgo/core/base/machine_topology.hpp
@@ -208,11 +208,7 @@ public:
      *
      * @return  the machine_topology instance
      */
-    static machine_topology* get_instance()
-    {
-        static machine_topology instance;
-        return &instance;
-    }
+    static machine_topology* get_instance();
 
     /**
      * Bind the calling process to the CPU cores associated with
@@ -227,20 +223,14 @@ public:
      *                  [singlify](https://www.open-mpi.org/projects/hwloc/doc/v2.4.0/a00175.php#gaa611a77c092e679246afdf9a60d5db8b)
      */
     void bind_to_cores(const std::vector<int>& ids,
-                       const bool singlify = true) const
-    {
-        hwloc_binding_helper(this->cores_, ids, singlify);
-    }
+                       const bool singlify = true) const;
 
     /**
      * Bind to a single core
      *
      * @param ids  The ids of the core to be bound to the calling process.
      */
-    void bind_to_core(const int& id) const
-    {
-        machine_topology::get_instance()->bind_to_cores(std::vector<int>{id});
-    }
+    void bind_to_core(const int& id) const;
 
     /**
      * Bind the calling process to PUs associated with
@@ -255,20 +245,14 @@ public:
      *                  [singlify](https://www.open-mpi.org/projects/hwloc/doc/v2.4.0/a00175.php#gaa611a77c092e679246afdf9a60d5db8b)
      */
     void bind_to_pus(const std::vector<int>& ids,
-                     const bool singlify = true) const
-    {
-        hwloc_binding_helper(this->pus_, ids, singlify);
-    }
+                     const bool singlify = true) const;
 
     /**
      * Bind to a Processing unit (PU)
      *
      * @param ids  The ids of PUs to be bound to the calling process.
      */
-    void bind_to_pu(const int& id) const
-    {
-        machine_topology::get_instance()->bind_to_pus(std::vector<int>{id});
-    }
+    void bind_to_pu(const int& id) const;
 
     /**
      * Get the object of type PU associated with the id.
@@ -276,11 +260,7 @@ public:
      * @param id  The id of the PU
      * @return  the PU object struct.
      */
-    const normal_obj_info* get_pu(size_type id) const
-    {
-        GKO_ENSURE_IN_BOUNDS(id, this->pus_.size());
-        return &this->pus_[id];
-    }
+    const normal_obj_info* get_pu(size_type id) const;
 
     /**
      * Get the object of type core associated with the id.
@@ -288,11 +268,7 @@ public:
      * @param id  The id of the core
      * @return  the core object struct.
      */
-    const normal_obj_info* get_core(size_type id) const
-    {
-        GKO_ENSURE_IN_BOUNDS(id, this->cores_.size());
-        return &this->cores_[id];
-    }
+    const normal_obj_info* get_core(size_type id) const;
 
     /**
      * Get the object of type pci device associated with the id.
@@ -300,11 +276,7 @@ public:
      * @param id  The id of the pci device
      * @return  the PCI object struct.
      */
-    const io_obj_info* get_pci_device(size_type id) const
-    {
-        GKO_ENSURE_IN_BOUNDS(id, this->pci_devices_.size());
-        return &this->pci_devices_[id];
-    }
+    const io_obj_info* get_pci_device(size_type id) const;
 
     /**
      * Get the object of type pci device associated with the PCI bus id.
@@ -319,28 +291,28 @@ public:
      *
      * @return  the number of PUs.
      */
-    size_type get_num_pus() const { return this->pus_.size(); }
+    size_type get_num_pus() const;
 
     /**
      * Get the number of core objects stored in this Topology tree.
      *
      * @return  the number of cores.
      */
-    size_type get_num_cores() const { return this->cores_.size(); }
+    size_type get_num_cores() const;
 
     /**
      * Get the number of PCI device objects stored in this Topology tree.
      *
      * @return  the number of PCI devices.
      */
-    size_type get_num_pci_devices() const { return this->pci_devices_.size(); }
+    size_type get_num_pci_devices() const;
 
     /**
      * Get the number of NUMA objects stored in this Topology tree.
      *
      * @return  the number of NUMA objects.
      */
-    size_type get_num_numas() const { return this->num_numas_; }
+    size_type get_num_numas() const;
 
     /**
      * @internal

--- a/include/ginkgo/core/base/name_demangling.hpp
+++ b/include/ginkgo/core/base/name_demangling.hpp
@@ -34,16 +34,11 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define GKO_PUBLIC_CORE_BASE_NAME_DEMANGLING_HPP_
 
 
-#include <ginkgo/config.hpp>
-
-
-#ifdef GKO_HAVE_CXXABI_H
-#include <cxxabi.h>
-#endif  // GKO_HAVE_CXXABI_H
-
-
 #include <memory>
 #include <string>
+
+
+#include <ginkgo/config.hpp>
 
 
 namespace gko {
@@ -56,21 +51,7 @@ namespace gko {
 namespace name_demangling {
 
 
-inline std::string get_type_name(const std::type_info& tinfo)
-{
-#ifdef GKO_HAVE_CXXABI_H
-    int status{};
-    const std::string name(
-        std::unique_ptr<char[], void (*)(void*)>(
-            abi::__cxa_demangle(tinfo.name(), nullptr, nullptr, &status),
-            std::free)
-            .get());
-    if (!status)
-        return name;
-    else
-#endif  // GKO_HAVE_CXXABI_H
-        return std::string(tinfo.name());
-}
+std::string get_type_name(const std::type_info& tinfo);
 
 
 /**

--- a/include/ginkgo/core/base/perturbation.hpp
+++ b/include/ginkgo/core/base/perturbation.hpp
@@ -77,30 +77,21 @@ public:
      *
      * @return the basis of the perturbation
      */
-    const std::shared_ptr<const LinOp> get_basis() const noexcept
-    {
-        return basis_;
-    }
+    const std::shared_ptr<const LinOp> get_basis() const noexcept;
 
     /**
      * Returns the projector of the perturbation.
      *
      * @return the projector of the perturbation
      */
-    const std::shared_ptr<const LinOp> get_projector() const noexcept
-    {
-        return projector_;
-    }
+    const std::shared_ptr<const LinOp> get_projector() const noexcept;
 
     /**
      * Returns the scalar of the perturbation.
      *
      * @return the scalar of the perturbation
      */
-    const std::shared_ptr<const LinOp> get_scalar() const noexcept
-    {
-        return scalar_;
-    }
+    const std::shared_ptr<const LinOp> get_scalar() const noexcept;
 
     Perturbation& operator=(const Perturbation& other);
 
@@ -116,9 +107,7 @@ protected:
      *
      * @param exec  Executor associated to the perturbation
      */
-    explicit Perturbation(std::shared_ptr<const Executor> exec)
-        : EnableLinOp<Perturbation>(std::move(exec))
-    {}
+    explicit Perturbation(std::shared_ptr<const Executor> exec);
 
     /**
      * Creates a perturbation with scalar and basis by setting projector to the
@@ -129,14 +118,7 @@ protected:
      * @param basis  the direction basis
      */
     explicit Perturbation(std::shared_ptr<const LinOp> scalar,
-                          std::shared_ptr<const LinOp> basis)
-        : Perturbation(
-              std::move(scalar),
-              // basis can not be std::move(basis). Otherwise, Program deletes
-              // basis before applying conjugate transpose
-              basis,
-              std::move((as<gko::Transposable>(lend(basis)))->conj_transpose()))
-    {}
+                          std::shared_ptr<const LinOp> basis);
 
     /**
      * Creates a perturbation of scalar, basis and projector.
@@ -147,32 +129,12 @@ protected:
      */
     explicit Perturbation(std::shared_ptr<const LinOp> scalar,
                           std::shared_ptr<const LinOp> basis,
-                          std::shared_ptr<const LinOp> projector)
-        : EnableLinOp<Perturbation>(basis->get_executor(),
-                                    gko::dim<2>{basis->get_size()[0]}),
-          scalar_{std::move(scalar)},
-          basis_{std::move(basis)},
-          projector_{std::move(projector)}
-    {
-        this->validate_perturbation();
-    }
+                          std::shared_ptr<const LinOp> projector);
 
     void apply_impl(const LinOp* b, LinOp* x) const override;
 
     void apply_impl(const LinOp* alpha, const LinOp* b, const LinOp* beta,
                     LinOp* x) const override;
-
-    /**
-     * Validates the dimensions of the `scalar`, `basis` and `projector`
-     * parameters for the `apply`. scalar must be 1 by 1. The dimension of basis
-     * should be same as the dimension of conjugate transpose of projector.
-     */
-    void validate_perturbation()
-    {
-        GKO_ASSERT_CONFORMANT(basis_, projector_);
-        GKO_ASSERT_CONFORMANT(projector_, basis_);
-        GKO_ASSERT_EQUAL_DIMENSIONS(scalar_, dim<2>(1, 1));
-    }
 
 private:
     std::shared_ptr<const LinOp> basis_;
@@ -189,19 +151,7 @@ private:
         // allocate linops of cache. The dimenstion of `intermediate` is
         // (the number of rows of projector, the number of columns of b). Others
         // are 1x1 scalar.
-        void allocate(std::shared_ptr<const Executor> exec, dim<2> size)
-        {
-            using vec = gko::matrix::Dense<ValueType>;
-            if (one == nullptr) {
-                one = initialize<vec>({gko::one<ValueType>()}, exec);
-            }
-            if (alpha_scalar == nullptr) {
-                alpha_scalar = vec::create(exec, gko::dim<2>(1));
-            }
-            if (intermediate == nullptr || intermediate->get_size() != size) {
-                intermediate = vec::create(exec, size);
-            }
-        }
+        void allocate(std::shared_ptr<const Executor> exec, dim<2> size);
 
         std::unique_ptr<LinOp> intermediate;
         std::unique_ptr<LinOp> one;

--- a/include/ginkgo/core/base/polymorphic_object.hpp
+++ b/include/ginkgo/core/base/polymorphic_object.hpp
@@ -70,14 +70,10 @@ namespace gko {
  */
 class PolymorphicObject : public log::EnableLogging<PolymorphicObject> {
 public:
-    virtual ~PolymorphicObject()
-    {
-        this->template log<log::Logger::polymorphic_object_deleted>(exec_.get(),
-                                                                    this);
-    }
+    virtual ~PolymorphicObject();
 
     // preserve the executor of the object
-    PolymorphicObject& operator=(const PolymorphicObject&) { return *this; }
+    PolymorphicObject& operator=(const PolymorphicObject&);
 
     /**
      * Creates a new "default" object of the same dynamic type as this object.
@@ -90,15 +86,7 @@ public:
      * @return a polymorphic object of the same type as this
      */
     std::unique_ptr<PolymorphicObject> create_default(
-        std::shared_ptr<const Executor> exec) const
-    {
-        this->template log<log::Logger::polymorphic_object_create_started>(
-            exec_.get(), this);
-        auto created = this->create_default_impl(std::move(exec));
-        this->template log<log::Logger::polymorphic_object_create_completed>(
-            exec_.get(), this, created.get());
-        return created;
-    }
+        std::shared_ptr<const Executor> exec) const;
 
     /**
      * Creates a new "default" object of the same dynamic type as this object.
@@ -108,10 +96,7 @@ public:
      *
      * @return a polymorphic object of the same type as this
      */
-    std::unique_ptr<PolymorphicObject> create_default() const
-    {
-        return this->create_default(exec_);
-    }
+    std::unique_ptr<PolymorphicObject> create_default() const;
 
     /**
      * Creates a clone of the object.
@@ -124,12 +109,7 @@ public:
      * @return A clone of the LinOp.
      */
     std::unique_ptr<PolymorphicObject> clone(
-        std::shared_ptr<const Executor> exec) const
-    {
-        auto new_op = this->create_default(exec);
-        new_op->copy_from(this);
-        return new_op;
-    }
+        std::shared_ptr<const Executor> exec) const;
 
     /**
      * Creates a clone of the object.
@@ -139,10 +119,7 @@ public:
      *
      * @return A clone of the LinOp.
      */
-    std::unique_ptr<PolymorphicObject> clone() const
-    {
-        return this->clone(exec_);
-    }
+    std::unique_ptr<PolymorphicObject> clone() const;
 
     /**
      * Copies another object into this object.
@@ -155,15 +132,7 @@ public:
      *
      * @return this
      */
-    PolymorphicObject* copy_from(const PolymorphicObject* other)
-    {
-        this->template log<log::Logger::polymorphic_object_copy_started>(
-            exec_.get(), other, this);
-        auto copied = this->copy_from_impl(other);
-        this->template log<log::Logger::polymorphic_object_copy_completed>(
-            exec_.get(), other, this);
-        return copied;
-    }
+    PolymorphicObject* copy_from(const PolymorphicObject* other);
 
     /**
      * Moves another object into this object.
@@ -176,15 +145,7 @@ public:
      *
      * @return this
      */
-    PolymorphicObject* copy_from(std::unique_ptr<PolymorphicObject> other)
-    {
-        this->template log<log::Logger::polymorphic_object_move_started>(
-            exec_.get(), other.get(), this);
-        auto copied = this->copy_from_impl(std::move(other));
-        this->template log<log::Logger::polymorphic_object_move_completed>(
-            exec_.get(), other.get(), this);
-        return copied;
-    }
+    PolymorphicObject* copy_from(std::unique_ptr<PolymorphicObject> other);
 
     /**
      * Moves another object into this object.
@@ -197,15 +158,7 @@ public:
      *
      * @return this
      */
-    PolymorphicObject* move_from(PolymorphicObject* other)
-    {
-        this->template log<log::Logger::polymorphic_object_move_started>(
-            exec_.get(), other, this);
-        auto moved = this->move_from_impl(other);
-        this->template log<log::Logger::polymorphic_object_move_completed>(
-            exec_.get(), other, this);
-        return moved;
-    }
+    PolymorphicObject* move_from(PolymorphicObject* other);
 
     /**
      * Moves another object into this object.
@@ -218,15 +171,7 @@ public:
      *
      * @return this
      */
-    PolymorphicObject* move_from(std::unique_ptr<PolymorphicObject> other)
-    {
-        this->template log<log::Logger::polymorphic_object_move_started>(
-            exec_.get(), other.get(), this);
-        auto copied = this->copy_from_impl(std::move(other));
-        this->template log<log::Logger::polymorphic_object_move_completed>(
-            exec_.get(), other.get(), this);
-        return copied;
-    }
+    PolymorphicObject* move_from(std::unique_ptr<PolymorphicObject> other);
 
     /**
      * Transforms the object into its default state.
@@ -237,17 +182,14 @@ public:
      *
      * @return this
      */
-    PolymorphicObject* clear() { return this->clear_impl(); }
+    PolymorphicObject* clear();
 
     /**
      * Returns the Executor of the object.
      *
      * @return Executor of the object
      */
-    std::shared_ptr<const Executor> get_executor() const noexcept
-    {
-        return exec_;
-    }
+    std::shared_ptr<const Executor> get_executor() const noexcept;
 
 protected:
     // This method is defined as protected since a polymorphic object should not
@@ -259,15 +201,10 @@ protected:
      *
      * @param exec  executor where the object will be created
      */
-    explicit PolymorphicObject(std::shared_ptr<const Executor> exec)
-        : exec_{std::move(exec)}
-    {}
+    explicit PolymorphicObject(std::shared_ptr<const Executor> exec);
 
     // preserve the executor of the object
-    explicit PolymorphicObject(const PolymorphicObject& other)
-    {
-        *this = other;
-    }
+    explicit PolymorphicObject(const PolymorphicObject& other);
 
     /**
      * Implementers of PolymorphicObject should override this function instead

--- a/include/ginkgo/core/base/version.hpp
+++ b/include/ginkgo/core/base/version.hpp
@@ -78,45 +78,19 @@ struct version {
      * It does not participate in comparisons.
      */
     const char* const tag;
+
+    friend bool operator==(const version& first, const version& second);
+
+    friend bool operator!=(const version& first, const version& second);
+
+    friend bool operator<(const version& first, const version& second);
+
+    friend bool operator<=(const version& first, const version& second);
+
+    friend bool operator>(const version& first, const version& second);
+
+    friend bool operator>=(const version& first, const version& second);
 };
-
-inline bool operator==(const version& first, const version& second)
-{
-    return first.major == second.major && first.minor == second.minor &&
-           first.patch == second.patch;
-}
-
-inline bool operator!=(const version& first, const version& second)
-{
-    return !(first == second);
-}
-
-inline bool operator<(const version& first, const version& second)
-{
-    if (first.major < second.major) return true;
-    if (first.major == second.major && first.minor < second.minor) return true;
-    if (first.major == second.major && first.minor == second.minor &&
-        first.patch < second.patch)
-        return true;
-    return false;
-}
-
-inline bool operator<=(const version& first, const version& second)
-{
-    return !(second < first);
-}
-
-inline bool operator>(const version& first, const version& second)
-{
-    return second < first;
-}
-
-inline bool operator>=(const version& first, const version& second)
-{
-    return !(first < second);
-}
-
-#undef GKO_ENABLE_VERSION_COMPARISON
 
 
 /**
@@ -127,14 +101,7 @@ inline bool operator>=(const version& first, const version& second)
  *
  * @return os
  */
-inline std::ostream& operator<<(std::ostream& os, const version& ver)
-{
-    os << ver.major << "." << ver.minor << "." << ver.patch;
-    if (ver.tag) {
-        os << " (" << ver.tag << ")";
-    }
-    return os;
-}
+std::ostream& operator<<(std::ostream& os, const version& ver);
 
 
 /**
@@ -165,11 +132,7 @@ public:
      *
      * @return an instance of version info
      */
-    static const version_info& get()
-    {
-        static version_info info{};
-        return info;
-    }
+    static const version_info& get();
 
     /**
      * Contains version information of the header files.
@@ -238,15 +201,7 @@ private:
 
     static version get_dpcpp_version() noexcept;
 
-    version_info()
-        : header_version{get_header_version()},
-          core_version{get_core_version()},
-          reference_version{get_reference_version()},
-          omp_version{get_omp_version()},
-          cuda_version{get_cuda_version()},
-          hip_version{get_hip_version()},
-          dpcpp_version{get_dpcpp_version()}
-    {}
+    version_info();
 };
 
 

--- a/include/ginkgo/core/distributed/partition.hpp
+++ b/include/ginkgo/core/distributed/partition.hpp
@@ -120,7 +120,7 @@ public:
      *
      * @return  number elements.
      */
-    size_type get_size() const { return size_; }
+    size_type get_size() const noexcept;
 
     /**
      * Returns the number of ranges stored by this partition.
@@ -128,27 +128,21 @@ public:
      *
      * @return number of ranges.
      */
-    size_type get_num_ranges() const noexcept
-    {
-        return offsets_.get_num_elems() - 1;
-    }
+    size_type get_num_ranges() const noexcept;
 
     /**
      * Returns the number of parts represented in this partition.
      *
      * @return number of parts.
      */
-    comm_index_type get_num_parts() const noexcept { return num_parts_; }
+    comm_index_type get_num_parts() const noexcept;
 
     /**
      * Returns the number of empty parts within this partition.
      *
      * @return number of empty parts.
      */
-    comm_index_type get_num_empty_parts() const noexcept
-    {
-        return num_empty_parts_;
-    }
+    comm_index_type get_num_empty_parts() const noexcept;
 
     /**
      * Returns the ranges boundary array stored by this partition.
@@ -157,10 +151,7 @@ public:
      *
      * @return  range boundaries array.
      */
-    const global_index_type* get_range_bounds() const noexcept
-    {
-        return offsets_.get_const_data();
-    }
+    const global_index_type* get_range_bounds() const noexcept;
 
     /**
      * Returns the part IDs of the ranges in this partition.
@@ -169,10 +160,7 @@ public:
      *
      * @return  part ID array.
      */
-    const comm_index_type* get_part_ids() const noexcept
-    {
-        return part_ids_.get_const_data();
-    }
+    const comm_index_type* get_part_ids() const noexcept;
 
     /**
      * Returns the part-local starting index for each range in this partition.
@@ -187,10 +175,7 @@ public:
      *
      * @return  part-local starting index array.
      */
-    const local_index_type* get_range_starting_indices() const noexcept
-    {
-        return starting_indices_.get_const_data();
-    }
+    const local_index_type* get_range_starting_indices() const noexcept;
 
     /**
      * Returns the part size array.
@@ -198,10 +183,7 @@ public:
      *
      * @return  part size array.
      */
-    const local_index_type* get_part_sizes() const noexcept
-    {
-        return part_sizes_.get_const_data();
-    }
+    const local_index_type* get_part_sizes() const noexcept;
 
     /**
      * Returns the size of a part given by its part ID.
@@ -211,11 +193,7 @@ public:
      *
      * @return  size of part.
      */
-    local_index_type get_part_size(comm_index_type part) const
-    {
-        return this->get_executor()->copy_val_to_host(
-            part_sizes_.get_const_data() + part);
-    }
+    local_index_type get_part_size(comm_index_type part) const;
 
     /**
      * Checks if each part has no more than one contiguous range.
@@ -282,21 +260,7 @@ private:
      * consecutive ranges and parts.
      */
     Partition(std::shared_ptr<const Executor> exec,
-              comm_index_type num_parts = 0, size_type num_ranges = 0)
-        : EnablePolymorphicObject<Partition>{exec},
-          num_parts_{num_parts},
-          num_empty_parts_{0},
-          size_{0},
-          offsets_{exec, num_ranges + 1},
-          starting_indices_{exec, num_ranges},
-          part_sizes_{exec, static_cast<size_type>(num_parts)},
-          part_ids_{exec, num_ranges}
-    {
-        offsets_.fill(0);
-        starting_indices_.fill(0);
-        part_sizes_.fill(0);
-        part_ids_.fill(0);
-    }
+              comm_index_type num_parts = 0, size_type num_ranges = 0);
 
     /**
      * Finalizes the construction in the create_* methods, by computing the

--- a/include/ginkgo/core/factorization/ic.hpp
+++ b/include/ginkgo/core/factorization/ic.hpp
@@ -74,24 +74,9 @@ public:
     using index_type = IndexType;
     using matrix_type = matrix::Csr<ValueType, IndexType>;
 
-    std::shared_ptr<const matrix_type> get_l_factor() const
-    {
-        // Can be `static_cast` since the type is guaranteed in this class
-        return std::static_pointer_cast<const matrix_type>(
-            this->get_operators()[0]);
-    }
+    std::shared_ptr<const matrix_type> get_l_factor() const;
 
-    std::shared_ptr<const matrix_type> get_lt_factor() const
-    {
-        if (this->get_operators().size() == 2) {
-            // Can be `static_cast` since the type is guaranteed in this class
-            return std::static_pointer_cast<const matrix_type>(
-                this->get_operators()[1]);
-        } else {
-            return std::static_pointer_cast<const matrix_type>(
-                share(get_l_factor()->conj_transpose()));
-        }
-    }
+    std::shared_ptr<const matrix_type> get_lt_factor() const;
 
     // Remove the possibility of calling `create`, which was enabled by
     // `Composition`
@@ -131,18 +116,7 @@ public:
     GKO_ENABLE_BUILD_METHOD(Factory);
 
 protected:
-    Ic(const Factory* factory, std::shared_ptr<const gko::LinOp> system_matrix)
-        : Composition<ValueType>{factory->get_executor()},
-          parameters_{factory->get_parameters()}
-    {
-        if (parameters_.l_strategy == nullptr) {
-            parameters_.l_strategy =
-                std::make_shared<typename matrix_type::classical>();
-        }
-        generate(system_matrix, parameters_.skip_sorting,
-                 parameters_.both_factors)
-            ->move_to(this);
-    }
+    Ic(const Factory* factory, std::shared_ptr<const gko::LinOp> system_matrix);
 
     std::unique_ptr<Composition<ValueType>> generate(
         const std::shared_ptr<const LinOp>& system_matrix, bool skip_sorting,

--- a/include/ginkgo/core/factorization/ilu.hpp
+++ b/include/ginkgo/core/factorization/ilu.hpp
@@ -74,19 +74,9 @@ public:
     using index_type = IndexType;
     using matrix_type = matrix::Csr<ValueType, IndexType>;
 
-    std::shared_ptr<const matrix_type> get_l_factor() const
-    {
-        // Can be `static_cast` since the type is guaranteed in this class
-        return std::static_pointer_cast<const matrix_type>(
-            this->get_operators()[0]);
-    }
+    std::shared_ptr<const matrix_type> get_l_factor() const;
 
-    std::shared_ptr<const matrix_type> get_u_factor() const
-    {
-        // Can be `static_cast` since the type is guaranteed in this class
-        return std::static_pointer_cast<const matrix_type>(
-            this->get_operators()[1]);
-    }
+    std::shared_ptr<const matrix_type> get_u_factor() const;
 
     // Remove the possibility of calling `create`, which was enabled by
     // `Composition`
@@ -126,20 +116,8 @@ public:
     GKO_ENABLE_BUILD_METHOD(Factory);
 
 protected:
-    Ilu(const Factory* factory, std::shared_ptr<const gko::LinOp> system_matrix)
-        : Composition<ValueType>{factory->get_executor()},
-          parameters_{factory->get_parameters()}
-    {
-        if (parameters_.l_strategy == nullptr) {
-            parameters_.l_strategy =
-                std::make_shared<typename matrix_type::classical>();
-        }
-        if (parameters_.u_strategy == nullptr) {
-            parameters_.u_strategy =
-                std::make_shared<typename matrix_type::classical>();
-        }
-        generate_l_u(system_matrix, parameters_.skip_sorting)->move_to(this);
-    }
+    Ilu(const Factory* factory,
+        std::shared_ptr<const gko::LinOp> system_matrix);
 
     /**
      * Generates the incomplete LU factors, which will be returned as a

--- a/include/ginkgo/core/factorization/par_ic.hpp
+++ b/include/ginkgo/core/factorization/par_ic.hpp
@@ -99,24 +99,9 @@ public:
     using index_type = IndexType;
     using matrix_type = matrix::Csr<ValueType, IndexType>;
 
-    std::shared_ptr<const matrix_type> get_l_factor() const
-    {
-        // Can be `static_cast` since the type is guaranteed in this class
-        return std::static_pointer_cast<const matrix_type>(
-            this->get_operators()[0]);
-    }
+    std::shared_ptr<const matrix_type> get_l_factor() const;
 
-    std::shared_ptr<const matrix_type> get_lt_factor() const
-    {
-        if (this->get_operators().size() == 2) {
-            // Can be `static_cast` since the type is guaranteed in this class
-            return std::static_pointer_cast<const matrix_type>(
-                this->get_operators()[1]);
-        } else {
-            return std::static_pointer_cast<const matrix_type>(
-                share(get_l_factor()->conj_transpose()));
-        }
-    }
+    std::shared_ptr<const matrix_type> get_lt_factor() const;
 
     // Remove the possibility of calling `create`, which was enabled by
     // `Composition`
@@ -165,18 +150,7 @@ public:
 
 protected:
     explicit ParIc(const Factory* factory,
-                   std::shared_ptr<const LinOp> system_matrix)
-        : Composition<ValueType>(factory->get_executor()),
-          parameters_{factory->get_parameters()}
-    {
-        if (parameters_.l_strategy == nullptr) {
-            parameters_.l_strategy =
-                std::make_shared<typename matrix_type::classical>();
-        }
-        generate(system_matrix, parameters_.skip_sorting,
-                 parameters_.both_factors)
-            ->move_to(this);
-    }
+                   std::shared_ptr<const LinOp> system_matrix);
 
     std::unique_ptr<Composition<ValueType>> generate(
         const std::shared_ptr<const LinOp>& system_matrix, bool skip_sorting,

--- a/include/ginkgo/core/factorization/par_ict.hpp
+++ b/include/ginkgo/core/factorization/par_ict.hpp
@@ -99,19 +99,9 @@ public:
     using index_type = IndexType;
     using matrix_type = matrix::Csr<ValueType, IndexType>;
 
-    std::shared_ptr<const matrix_type> get_l_factor() const
-    {
-        // Can be `static_cast` since the type is guaranteed in this class
-        return std::static_pointer_cast<const matrix_type>(
-            this->get_operators()[0]);
-    }
+    std::shared_ptr<const matrix_type> get_l_factor() const;
 
-    std::shared_ptr<const matrix_type> get_lt_factor() const
-    {
-        // Can be `static_cast` since the type is guaranteed in this class
-        return std::static_pointer_cast<const matrix_type>(
-            this->get_operators()[1]);
-    }
+    std::shared_ptr<const matrix_type> get_lt_factor() const;
 
     // Remove the possibility of calling `create`, which was enabled by
     // `Composition`
@@ -214,20 +204,7 @@ public:
 
 protected:
     explicit ParIct(const Factory* factory,
-                    std::shared_ptr<const LinOp> system_matrix)
-        : Composition<ValueType>(factory->get_executor()),
-          parameters_{factory->get_parameters()}
-    {
-        if (parameters_.l_strategy == nullptr) {
-            parameters_.l_strategy =
-                std::make_shared<typename matrix_type::classical>();
-        }
-        if (parameters_.lt_strategy == nullptr) {
-            parameters_.lt_strategy =
-                std::make_shared<typename matrix_type::classical>();
-        }
-        generate_l_lt(std::move(system_matrix))->move_to(this);
-    }
+                    std::shared_ptr<const LinOp> system_matrix);
 
     /**
      * Generates the incomplete LL^T factors, which will be returned as a

--- a/include/ginkgo/core/factorization/par_ilu.hpp
+++ b/include/ginkgo/core/factorization/par_ilu.hpp
@@ -102,19 +102,9 @@ public:
     using l_matrix_type = matrix_type;
     using u_matrix_type = matrix_type;
 
-    std::shared_ptr<const matrix_type> get_l_factor() const
-    {
-        // Can be `static_cast` since the type is guaranteed in this class
-        return std::static_pointer_cast<const matrix_type>(
-            this->get_operators()[0]);
-    }
+    std::shared_ptr<const matrix_type> get_l_factor() const;
 
-    std::shared_ptr<const matrix_type> get_u_factor() const
-    {
-        // Can be `static_cast` since the type is guaranteed in this class
-        return std::static_pointer_cast<const matrix_type>(
-            this->get_operators()[1]);
-    }
+    std::shared_ptr<const matrix_type> get_u_factor() const;
 
     // Remove the possibility of calling `create`, which was enabled by
     // `Composition`
@@ -163,22 +153,7 @@ public:
 
 protected:
     explicit ParIlu(const Factory* factory,
-                    std::shared_ptr<const LinOp> system_matrix)
-        : Composition<ValueType>(factory->get_executor()),
-          parameters_{factory->get_parameters()}
-    {
-        if (parameters_.l_strategy == nullptr) {
-            parameters_.l_strategy =
-                std::make_shared<typename matrix_type::classical>();
-        }
-        if (parameters_.u_strategy == nullptr) {
-            parameters_.u_strategy =
-                std::make_shared<typename matrix_type::classical>();
-        }
-        generate_l_u(system_matrix, parameters_.skip_sorting,
-                     parameters_.l_strategy, parameters_.u_strategy)
-            ->move_to(this);
-    }
+                    std::shared_ptr<const LinOp> system_matrix);
 
     /**
      * Generates the incomplete LU factors, which will be returned as a

--- a/include/ginkgo/core/factorization/par_ilut.hpp
+++ b/include/ginkgo/core/factorization/par_ilut.hpp
@@ -104,19 +104,9 @@ public:
     using l_matrix_type = matrix_type;
     using u_matrix_type = matrix_type;
 
-    std::shared_ptr<const matrix_type> get_l_factor() const
-    {
-        // Can be `static_cast` since the type is guaranteed in this class
-        return std::static_pointer_cast<const matrix_type>(
-            this->get_operators()[0]);
-    }
+    std::shared_ptr<const matrix_type> get_l_factor() const;
 
-    std::shared_ptr<const matrix_type> get_u_factor() const
-    {
-        // Can be `static_cast` since the type is guaranteed in this class
-        return std::static_pointer_cast<const matrix_type>(
-            this->get_operators()[1]);
-    }
+    std::shared_ptr<const matrix_type> get_u_factor() const;
 
     // Remove the possibility of calling `create`, which was enabled by
     // `Composition`
@@ -220,20 +210,7 @@ public:
 
 protected:
     explicit ParIlut(const Factory* factory,
-                     std::shared_ptr<const LinOp> system_matrix)
-        : Composition<ValueType>(factory->get_executor()),
-          parameters_{factory->get_parameters()}
-    {
-        if (parameters_.l_strategy == nullptr) {
-            parameters_.l_strategy =
-                std::make_shared<typename matrix_type::classical>();
-        }
-        if (parameters_.u_strategy == nullptr) {
-            parameters_.u_strategy =
-                std::make_shared<typename matrix_type::classical>();
-        }
-        generate_l_u(std::move(system_matrix))->move_to(this);
-    }
+                     std::shared_ptr<const LinOp> system_matrix);
 
     /**
      * Generates the incomplete LU factors, which will be returned as a

--- a/include/ginkgo/core/log/convergence.hpp
+++ b/include/ginkgo/core/log/convergence.hpp
@@ -97,10 +97,7 @@ public:
     [[deprecated(
         "use single-parameter create")]] static std::unique_ptr<Convergence>
     create(std::shared_ptr<const Executor>,
-           const mask_type& enabled_events = Logger::all_events_mask)
-    {
-        return std::unique_ptr<Convergence>(new Convergence(enabled_events));
-    }
+           const mask_type& enabled_events = Logger::all_events_mask);
 
     /**
      * Creates a convergence logger. This dynamically allocates the memory,
@@ -116,59 +113,47 @@ public:
      * shouldn't be a problem.
      */
     static std::unique_ptr<Convergence> create(
-        const mask_type& enabled_events = Logger::all_events_mask)
-    {
-        return std::unique_ptr<Convergence>(new Convergence(enabled_events));
-    }
+        const mask_type& enabled_events = Logger::all_events_mask);
 
     /**
      * Returns true if the solver has converged.
      *
      * @return the bool flag for convergence status
      */
-    bool has_converged() const noexcept { return convergence_status_; }
+    bool has_converged() const noexcept;
 
     /**
      * Resets the convergence status to false.
      */
-    void reset_convergence_status() { this->convergence_status_ = false; }
+    void reset_convergence_status();
 
     /**
      * Returns the number of iterations
      *
      * @return the number of iterations
      */
-    const size_type& get_num_iterations() const noexcept
-    {
-        return num_iterations_;
-    }
+    const size_type& get_num_iterations() const noexcept;
 
     /**
      * Returns the residual
      *
      * @return the residual
      */
-    const LinOp* get_residual() const noexcept { return residual_.get(); }
+    const LinOp* get_residual() const noexcept;
 
     /**
      * Returns the residual norm
      *
      * @return the residual norm
      */
-    const LinOp* get_residual_norm() const noexcept
-    {
-        return residual_norm_.get();
-    }
+    const LinOp* get_residual_norm() const noexcept;
 
     /**
      * Returns the implicit squared residual norm
      *
      * @return the implicit squared residual norm
      */
-    const LinOp* get_implicit_sq_resnorm() const noexcept
-    {
-        return implicit_sq_resnorm_.get();
-    }
+    const LinOp* get_implicit_sq_resnorm() const noexcept;
 
 protected:
     /**
@@ -180,9 +165,7 @@ protected:
      */
     [[deprecated("use single-parameter constructor")]] explicit Convergence(
         std::shared_ptr<const gko::Executor>,
-        const mask_type& enabled_events = Logger::all_events_mask)
-        : Logger(enabled_events)
-    {}
+        const mask_type& enabled_events = Logger::all_events_mask);
 
     /**
      * Creates a Convergence logger.
@@ -191,9 +174,7 @@ protected:
      *                        events.
      */
     explicit Convergence(
-        const mask_type& enabled_events = Logger::all_events_mask)
-        : Logger(enabled_events)
-    {}
+        const mask_type& enabled_events = Logger::all_events_mask);
 
 private:
     mutable bool convergence_status_{false};

--- a/include/ginkgo/core/log/papi.hpp
+++ b/include/ginkgo/core/log/papi.hpp
@@ -198,10 +198,7 @@ public:
      */
     [[deprecated("use single-parameter create")]] static std::shared_ptr<Papi>
     create(std::shared_ptr<const gko::Executor>,
-           const Logger::mask_type& enabled_events = Logger::all_events_mask)
-    {
-        return std::shared_ptr<Papi>(new Papi(enabled_events));
-    }
+           const Logger::mask_type& enabled_events = Logger::all_events_mask);
 
     /**
      * Creates a Papi Logger.
@@ -209,10 +206,7 @@ public:
      * @param enabled_events  the events enabled for this Logger
      */
     static std::shared_ptr<Papi> create(
-        const Logger::mask_type& enabled_events = Logger::all_events_mask)
-    {
-        return std::shared_ptr<Papi>(new Papi(enabled_events));
-    }
+        const Logger::mask_type& enabled_events = Logger::all_events_mask);
 
     /**
      * Returns the unique name of this logger, which can be used in the
@@ -220,64 +214,25 @@ public:
      *
      * @return the unique name of this logger
      */
-    const std::string get_handle_name() const { return name; }
+    const std::string get_handle_name() const;
 
 protected:
     [[deprecated("use single-parameter constructor")]] explicit Papi(
         std::shared_ptr<const gko::Executor> exec,
-        const Logger::mask_type& enabled_events = Logger::all_events_mask)
-        : Papi(enabled_events)
-    {}
+        const Logger::mask_type& enabled_events = Logger::all_events_mask);
 
     explicit Papi(
-        const Logger::mask_type& enabled_events = Logger::all_events_mask)
-        : Logger(enabled_events)
-    {
-        std::ostringstream os;
-
-        std::lock_guard<std::mutex> guard(papi_count_mutex);
-        os << "ginkgo" << papi_logger_count;
-        name = os.str();
-        papi_handle = papi_sde_init(name.c_str());
-        papi_logger_count++;
-    }
+        const Logger::mask_type& enabled_events = Logger::all_events_mask);
 
 private:
     template <typename PointerType>
     class papi_queue {
     public:
-        papi_queue(papi_handle_t* handle, const char* counter_name)
-            : handle{handle}, counter_name{counter_name}
-        {}
+        papi_queue(papi_handle_t* handle, const char* counter_name);
 
-        ~papi_queue()
-        {
-            if (PAPI_is_initialized()) {
-                for (auto e : data) {
-                    std::ostringstream oss;
-                    oss << counter_name << "::" << e.first;
-                    papi_sde_unregister_counter(*handle, oss.str().c_str());
-                }
-            }
-            data.clear();
-        }
+        ~papi_queue();
 
-        size_type& get_counter(const PointerType* ptr)
-        {
-            const auto tmp = reinterpret_cast<uintptr>(ptr);
-            if (data.find(tmp) == data.end()) {
-                data[tmp] = 0;
-            }
-            auto& value = data[tmp];
-            if (!value) {
-                std::ostringstream oss;
-                oss << counter_name << "::" << tmp;
-                papi_sde_register_counter(*handle, oss.str().c_str(),
-                                          PAPI_SDE_RO | PAPI_SDE_INSTANT,
-                                          PAPI_SDE_long_long, &value);
-            }
-            return data[tmp];
-        }
+        size_type& get_counter(const PointerType* ptr);
 
     private:
         papi_handle_t* handle;

--- a/include/ginkgo/core/log/performance_hint.hpp
+++ b/include/ginkgo/core/log/performance_hint.hpp
@@ -89,22 +89,12 @@ public:
      */
     static std::unique_ptr<PerformanceHint> create(
         std::ostream& os = std::cerr, size_type allocation_size_limit = 16,
-        size_type copy_size_limit = 16, size_type histogram_max_size = 1024)
-    {
-        return std::unique_ptr<PerformanceHint>(new PerformanceHint(
-            os, allocation_size_limit, copy_size_limit, histogram_max_size));
-    }
+        size_type copy_size_limit = 16, size_type histogram_max_size = 1024);
 
 protected:
     explicit PerformanceHint(std::ostream& os, size_type allocation_size_limit,
                              size_type copy_size_limit,
-                             size_type histogram_max_size)
-        : Logger(mask_),
-          os_(&os),
-          allocation_size_limit_{allocation_size_limit},
-          copy_size_limit_{copy_size_limit},
-          histogram_max_size_{histogram_max_size}
-    {}
+                             size_type histogram_max_size);
 
 private:
     // set a breakpoint here if you want to see where the output comes from!

--- a/include/ginkgo/core/log/record.hpp
+++ b/include/ginkgo/core/log/record.hpp
@@ -68,29 +68,7 @@ struct iteration_complete_data {
                             const LinOp* residual = nullptr,
                             const LinOp* solution = nullptr,
                             const LinOp* residual_norm = nullptr,
-                            const LinOp* implicit_sq_residual_norm = nullptr)
-        : solver{nullptr},
-          num_iterations{num_iterations},
-          residual{nullptr},
-          solution{nullptr},
-          residual_norm{nullptr},
-          implicit_sq_residual_norm{nullptr}
-    {
-        this->solver = solver->clone();
-        if (residual != nullptr) {
-            this->residual = residual->clone();
-        }
-        if (solution != nullptr) {
-            this->solution = solution->clone();
-        }
-        if (residual_norm != nullptr) {
-            this->residual_norm = residual_norm->clone();
-        }
-        if (implicit_sq_residual_norm != nullptr) {
-            this->implicit_sq_residual_norm =
-                implicit_sq_residual_norm->clone();
-        }
-    }
+                            const LinOp* implicit_sq_residual_norm = nullptr);
 };
 
 
@@ -123,14 +101,7 @@ struct polymorphic_object_data {
 
     polymorphic_object_data(const Executor* exec,
                             const PolymorphicObject* input,
-                            const PolymorphicObject* output = nullptr)
-        : exec{exec}
-    {
-        this->input = input->clone();
-        if (output != nullptr) {
-            this->output = output->clone();
-        }
-    }
+                            const PolymorphicObject* output = nullptr);
 };
 
 
@@ -145,18 +116,7 @@ struct linop_data {
     std::unique_ptr<const LinOp> x;
 
     linop_data(const LinOp* A, const LinOp* alpha, const LinOp* b,
-               const LinOp* beta, const LinOp* x)
-    {
-        this->A = A->clone();
-        if (alpha != nullptr) {
-            this->alpha = alpha->clone();
-        }
-        this->b = b->clone();
-        if (beta != nullptr) {
-            this->beta = beta->clone();
-        }
-        this->x = x->clone();
-    }
+               const LinOp* beta, const LinOp* x);
 };
 
 
@@ -169,14 +129,7 @@ struct linop_factory_data {
     std::unique_ptr<const LinOp> output;
 
     linop_factory_data(const LinOpFactory* factory, const LinOp* input,
-                       const LinOp* output)
-        : factory{factory}
-    {
-        this->input = input->clone();
-        if (output != nullptr) {
-            this->output = output->clone();
-        }
-    }
+                       const LinOp* output);
 };
 
 
@@ -192,7 +145,7 @@ struct criterion_data {
     const uint8 stopping_id;
     const bool set_finalized;
     const array<stopping_status>* status;
-    const bool oneChanged;
+    const bool one_changed;
     const bool converged;
 
     criterion_data(const stop::Criterion* criterion,
@@ -200,29 +153,8 @@ struct criterion_data {
                    const LinOp* residual_norm, const LinOp* solution,
                    const uint8 stopping_id, const bool set_finalized,
                    const array<stopping_status>* status = nullptr,
-                   const bool oneChanged = false, const bool converged = false)
-        : criterion{criterion},
-          num_iterations{num_iterations},
-          residual{nullptr},
-          residual_norm{nullptr},
-          solution{nullptr},
-          stopping_id{stopping_id},
-          set_finalized{set_finalized},
-          status{status},
-          oneChanged{oneChanged},
-          converged{converged}
-    {
-        if (residual != nullptr) {
-            this->residual = std::unique_ptr<const LinOp>(residual->clone());
-        }
-        if (residual_norm != nullptr) {
-            this->residual_norm =
-                std::unique_ptr<const LinOp>(residual_norm->clone());
-        }
-        if (solution != nullptr) {
-            this->solution = std::unique_ptr<const LinOp>(solution->clone());
-        }
-    }
+                   const bool one_changed = false,
+                   const bool converged = false);
 };
 
 
@@ -423,10 +355,7 @@ public:
     [[deprecated("use two-parameter create")]] static std::unique_ptr<Record>
     create(std::shared_ptr<const Executor> exec,
            const mask_type& enabled_events = Logger::all_events_mask,
-           size_type max_storage = 1)
-    {
-        return std::unique_ptr<Record>(new Record(enabled_events, max_storage));
-    }
+           size_type max_storage = 1);
 
     /**
      * Creates a Record logger. This dynamically allocates the memory,
@@ -448,22 +377,19 @@ public:
      */
     static std::unique_ptr<Record> create(
         const mask_type& enabled_events = Logger::all_events_mask,
-        size_type max_storage = 1)
-    {
-        return std::unique_ptr<Record>(new Record(enabled_events, max_storage));
-    }
+        size_type max_storage = 1);
 
     /**
      * Returns the logged data
      *
      * @return the logged data
      */
-    const logged_data& get() const noexcept { return data_; }
+    const logged_data& get() const noexcept;
 
     /**
      * @copydoc ::get()
      */
-    logged_data& get() noexcept { return data_; }
+    logged_data& get() noexcept;
 
 protected:
     /**
@@ -479,10 +405,7 @@ protected:
      */
     [[deprecated("use two-parameter constructor")]] explicit Record(
         std::shared_ptr<const gko::Executor> exec,
-        const mask_type& enabled_events = Logger::all_events_mask,
-        size_type max_storage = 0)
-        : Record(enabled_events, max_storage)
-    {}
+        const mask_type& enabled_events, size_type max_storage);
 
     /**
      * Creates a Record logger.
@@ -494,27 +417,7 @@ protected:
      *                     storage. It is advised to control this to reduce
      *                     memory overhead of this logger.
      */
-    explicit Record(const mask_type& enabled_events = Logger::all_events_mask,
-                    size_type max_storage = 0)
-        : Logger(enabled_events), max_storage_{max_storage}
-    {}
-
-    /**
-     * Helper function which appends an object to a deque
-     *
-     * @tparam deque_type  the type of objects in the deque
-     *
-     * @param deque  the deque to append the object to
-     * @param object  the object to append
-     */
-    template <typename deque_type>
-    void append_deque(std::deque<deque_type>& deque, deque_type object) const
-    {
-        if (this->max_storage_ && deque.size() == this->max_storage_) {
-            deque.pop_front();
-        }
-        deque.push_back(std::move(object));
-    }
+    explicit Record(const mask_type& enabled_events, size_type max_storage);
 
 private:
     mutable logged_data data_{};

--- a/include/ginkgo/core/log/stream.hpp
+++ b/include/ginkgo/core/log/stream.hpp
@@ -188,10 +188,7 @@ public:
     [[deprecated("use three-parameter create")]] static std::unique_ptr<Stream>
     create(std::shared_ptr<const Executor> exec,
            const Logger::mask_type& enabled_events = Logger::all_events_mask,
-           std::ostream& os = std::cout, bool verbose = false)
-    {
-        return std::unique_ptr<Stream>(new Stream(enabled_events, os, verbose));
-    }
+           std::ostream& os = std::cout, bool verbose = false);
 
     /**
      * Creates a Stream logger. This dynamically allocates the memory,
@@ -213,10 +210,7 @@ public:
      */
     static std::unique_ptr<Stream> create(
         const Logger::mask_type& enabled_events = Logger::all_events_mask,
-        std::ostream& os = std::cerr, bool verbose = false)
-    {
-        return std::unique_ptr<Stream>(new Stream(enabled_events, os, verbose));
-    }
+        std::ostream& os = std::cerr, bool verbose = false);
 
 protected:
     /**
@@ -232,28 +226,22 @@ protected:
      */
     [[deprecated("use three-parameter constructor")]] explicit Stream(
         std::shared_ptr<const gko::Executor> exec,
-        const Logger::mask_type& enabled_events = Logger::all_events_mask,
-        std::ostream& os = std::cerr, bool verbose = false)
-        : Stream(enabled_events, os, verbose)
-    {}
+        const Logger::mask_type& enabled_events, std::ostream& os,
+        bool verbose);
 
     /**
      * Creates a Stream logger.
      *
      * @param exec  the executor
-     * @param enabled_events  the events enabled for this logger. By default all
-     *                        events.
+     * @param enabled_events  the events enabled for this logger. By default
+     * all events.
      * @param os  the stream used for this logger
      * @param verbose  whether we want detailed information or not. This
-     *                 includes always printing residuals and other information
-     *                 which can give a large output.
+     *                 includes always printing residuals and other
+     * information which can give a large output.
      */
-    explicit Stream(
-        const Logger::mask_type& enabled_events = Logger::all_events_mask,
-        std::ostream& os = std::cerr, bool verbose = false)
-        : Logger(enabled_events), os_(&os), verbose_(verbose)
-    {}
-
+    explicit Stream(const Logger::mask_type& enabled_events, std::ostream& os,
+                    bool verbose);
 
 private:
     std::ostream* os_;

--- a/include/ginkgo/core/matrix/coo.hpp
+++ b/include/ginkgo/core/matrix/coo.hpp
@@ -138,7 +138,7 @@ public:
      *
      * @return the values of the matrix.
      */
-    value_type* get_values() noexcept { return values_.get_data(); }
+    value_type* get_values() noexcept;
 
     /**
      * @copydoc Csr::get_values()
@@ -147,17 +147,14 @@ public:
      *       significantly more memory efficient than the non-constant version,
      *       so always prefer this version.
      */
-    const value_type* get_const_values() const noexcept
-    {
-        return values_.get_const_data();
-    }
+    const value_type* get_const_values() const noexcept;
 
     /**
      * Returns the column indexes of the matrix.
      *
      * @return the column indexes of the matrix.
      */
-    index_type* get_col_idxs() noexcept { return col_idxs_.get_data(); }
+    index_type* get_col_idxs() noexcept;
 
     /**
      * @copydoc Csr::get_col_idxs()
@@ -166,17 +163,14 @@ public:
      *       significantly more memory efficient than the non-constant version,
      *       so always prefer this version.
      */
-    const index_type* get_const_col_idxs() const noexcept
-    {
-        return col_idxs_.get_const_data();
-    }
+    const index_type* get_const_col_idxs() const noexcept;
 
     /**
      * Returns the row indexes of the matrix.
      *
      * @return the row indexes of the matrix.
      */
-    index_type* get_row_idxs() noexcept { return row_idxs_.get_data(); }
+    index_type* get_row_idxs() noexcept;
 
     /**
      * @copydoc Csr::get_row_idxs()
@@ -185,20 +179,14 @@ public:
      *       significantly more memory efficient than the non-constant version,
      *       so always prefer this version.
      */
-    const index_type* get_const_row_idxs() const noexcept
-    {
-        return row_idxs_.get_const_data();
-    }
+    const index_type* get_const_row_idxs() const noexcept;
 
     /**
      * Returns the number of elements explicitly stored in the matrix.
      *
      * @return the number of elements explicitly stored in the matrix
      */
-    size_type get_num_stored_elements() const noexcept
-    {
-        return values_.get_num_elems();
-    }
+    size_type get_num_stored_elements() const noexcept;
 
     /**
      * Applies Coo matrix axpy to a vector (or a sequence of vectors).
@@ -210,26 +198,12 @@ public:
      *
      * @return this
      */
-    LinOp* apply2(const LinOp* b, LinOp* x)
-    {
-        this->validate_application_parameters(b, x);
-        auto exec = this->get_executor();
-        this->apply2_impl(make_temporary_clone(exec, b).get(),
-                          make_temporary_clone(exec, x).get());
-        return this;
-    }
+    LinOp* apply2(const LinOp* b, LinOp* x);
 
     /**
      * @copydoc apply2(cost LinOp *, LinOp *)
      */
-    const LinOp* apply2(const LinOp* b, LinOp* x) const
-    {
-        this->validate_application_parameters(b, x);
-        auto exec = this->get_executor();
-        this->apply2_impl(make_temporary_clone(exec, b).get(),
-                          make_temporary_clone(exec, x).get());
-        return this;
-    }
+    const LinOp* apply2(const LinOp* b, LinOp* x) const;
 
     /**
      * Performs the operation x = alpha * Coo * b + x.
@@ -240,30 +214,12 @@ public:
      *
      * @return this
      */
-    LinOp* apply2(const LinOp* alpha, const LinOp* b, LinOp* x)
-    {
-        this->validate_application_parameters(b, x);
-        GKO_ASSERT_EQUAL_DIMENSIONS(alpha, dim<2>(1, 1));
-        auto exec = this->get_executor();
-        this->apply2_impl(make_temporary_clone(exec, alpha).get(),
-                          make_temporary_clone(exec, b).get(),
-                          make_temporary_clone(exec, x).get());
-        return this;
-    }
+    LinOp* apply2(const LinOp* alpha, const LinOp* b, LinOp* x);
 
     /**
      * @copydoc apply2(const LinOp *, const LinOp *, LinOp *)
      */
-    const LinOp* apply2(const LinOp* alpha, const LinOp* b, LinOp* x) const
-    {
-        this->validate_application_parameters(b, x);
-        GKO_ASSERT_EQUAL_DIMENSIONS(alpha, dim<2>(1, 1));
-        auto exec = this->get_executor();
-        this->apply2_impl(make_temporary_clone(exec, alpha).get(),
-                          make_temporary_clone(exec, b).get(),
-                          make_temporary_clone(exec, x).get());
-        return this;
-    }
+    const LinOp* apply2(const LinOp* alpha, const LinOp* b, LinOp* x) const;
 
     /**
      * Creates a constant (immutable) Coo matrix from a set of constant arrays.
@@ -281,15 +237,7 @@ public:
         std::shared_ptr<const Executor> exec, const dim<2>& size,
         gko::detail::const_array_view<ValueType>&& values,
         gko::detail::const_array_view<IndexType>&& col_idxs,
-        gko::detail::const_array_view<IndexType>&& row_idxs)
-    {
-        // cast const-ness away, but return a const object afterwards,
-        // so we can ensure that no modifications take place.
-        return std::unique_ptr<const Coo>(new Coo{
-            exec, size, gko::detail::array_const_cast(std::move(values)),
-            gko::detail::array_const_cast(std::move(col_idxs)),
-            gko::detail::array_const_cast(std::move(row_idxs))});
-    }
+        gko::detail::const_array_view<IndexType>&& row_idxs);
 
 protected:
     /**
@@ -300,12 +248,7 @@ protected:
      * @param num_nonzeros  number of nonzeros
      */
     Coo(std::shared_ptr<const Executor> exec, const dim<2>& size = dim<2>{},
-        size_type num_nonzeros = {})
-        : EnableLinOp<Coo>(exec, size),
-          values_(exec, num_nonzeros),
-          col_idxs_(exec, num_nonzeros),
-          row_idxs_(exec, num_nonzeros)
-    {}
+        size_type num_nonzeros = {});
 
     /**
      * Creates a COO matrix from already allocated (and initialized) row

--- a/include/ginkgo/core/matrix/csr.hpp
+++ b/include/ginkgo/core/matrix/csr.hpp
@@ -75,16 +75,6 @@ template <typename ValueType, typename IndexType>
 class CsrBuilder;
 
 
-namespace detail {
-
-
-template <typename ValueType = default_precision, typename IndexType = int32>
-void strategy_rebuild_helper(Csr<ValueType, IndexType>* result);
-
-
-}  // namespace detail
-
-
 /**
  * CSR is a matrix format which stores only the nonzero coefficients by
  * compressing each row of the matrix (compressed sparse row format).
@@ -184,7 +174,7 @@ public:
          *
          * @param name  the name of strategy
          */
-        strategy_type(std::string name) : name_(name) {}
+        strategy_type(std::string name);
 
         virtual ~strategy_type() = default;
 
@@ -193,7 +183,7 @@ public:
          *
          * @return the name of strategy
          */
-        std::string get_name() { return name_; }
+        std::string get_name();
 
         /**
          * Computes srow according to row pointers.
@@ -220,7 +210,7 @@ public:
         virtual std::shared_ptr<strategy_type> copy() = 0;
 
     protected:
-        void set_name(std::string name) { name_ = name; }
+        void set_name(std::string name);
 
     private:
         std::string name_;
@@ -237,41 +227,16 @@ public:
         /**
          * Creates a classical strategy.
          */
-        classical() : strategy_type("classical"), max_length_per_row_(0) {}
+        classical();
 
         void process(const array<index_type>& mtx_row_ptrs,
-                     array<index_type>* mtx_srow) override
-        {
-            auto host_mtx_exec = mtx_row_ptrs.get_executor()->get_master();
-            array<index_type> row_ptrs_host(host_mtx_exec);
-            const bool is_mtx_on_host{host_mtx_exec ==
-                                      mtx_row_ptrs.get_executor()};
-            const index_type* row_ptrs{};
-            if (is_mtx_on_host) {
-                row_ptrs = mtx_row_ptrs.get_const_data();
-            } else {
-                row_ptrs_host = mtx_row_ptrs;
-                row_ptrs = row_ptrs_host.get_const_data();
-            }
-            auto num_rows = mtx_row_ptrs.get_num_elems() - 1;
-            max_length_per_row_ = 0;
-            for (size_type i = 0; i < num_rows; i++) {
-                max_length_per_row_ = std::max(max_length_per_row_,
-                                               row_ptrs[i + 1] - row_ptrs[i]);
-            }
-        }
+                     array<index_type>* mtx_srow) override;
 
-        int64_t clac_size(const int64_t nnz) override { return 0; }
+        int64_t clac_size(const int64_t nnz) override;
 
-        index_type get_max_length_per_row() const noexcept
-        {
-            return max_length_per_row_;
-        }
+        index_type get_max_length_per_row() const noexcept;
 
-        std::shared_ptr<strategy_type> copy() override
-        {
-            return std::make_shared<classical>();
-        }
+        std::shared_ptr<strategy_type> copy() override;
 
     private:
         index_type max_length_per_row_;
@@ -287,18 +252,14 @@ public:
         /**
          * Creates a merge_path strategy.
          */
-        merge_path() : strategy_type("merge_path") {}
+        merge_path();
 
         void process(const array<index_type>& mtx_row_ptrs,
-                     array<index_type>* mtx_srow) override
-        {}
+                     array<index_type>* mtx_srow) override;
 
-        int64_t clac_size(const int64_t nnz) override { return 0; }
+        int64_t clac_size(const int64_t nnz) override;
 
-        std::shared_ptr<strategy_type> copy() override
-        {
-            return std::make_shared<merge_path>();
-        }
+        std::shared_ptr<strategy_type> copy() override;
     };
 
     /**
@@ -312,18 +273,14 @@ public:
         /**
          * Creates a cusparse strategy.
          */
-        cusparse() : strategy_type("cusparse") {}
+        cusparse();
 
         void process(const array<index_type>& mtx_row_ptrs,
-                     array<index_type>* mtx_srow) override
-        {}
+                     array<index_type>* mtx_srow) override;
 
-        int64_t clac_size(const int64_t nnz) override { return 0; }
+        int64_t clac_size(const int64_t nnz) override;
 
-        std::shared_ptr<strategy_type> copy() override
-        {
-            return std::make_shared<cusparse>();
-        }
+        std::shared_ptr<strategy_type> copy() override;
     };
 
     /**
@@ -336,18 +293,14 @@ public:
         /**
          * Creates a sparselib strategy.
          */
-        sparselib() : strategy_type("sparselib") {}
+        sparselib();
 
         void process(const array<index_type>& mtx_row_ptrs,
-                     array<index_type>* mtx_srow) override
-        {}
+                     array<index_type>* mtx_srow) override;
 
-        int64_t clac_size(const int64_t nnz) override { return 0; }
+        int64_t clac_size(const int64_t nnz) override;
 
-        std::shared_ptr<strategy_type> copy() override
-        {
-            return std::make_shared<sparselib>();
-        }
+        std::shared_ptr<strategy_type> copy() override;
     };
 
     /**
@@ -361,28 +314,21 @@ public:
          * @warning this is deprecated! Please rely on the new automatic
          *          strategy instantiation or use one of the other constructors.
          */
-        [[deprecated]] load_balance()
-            : load_balance(std::move(
-                  gko::CudaExecutor::create(0, gko::OmpExecutor::create())))
-        {}
+        [[deprecated]] load_balance();
 
         /**
          * Creates a load_balance strategy with CUDA executor.
          *
          * @param exec the CUDA executor
          */
-        load_balance(std::shared_ptr<const CudaExecutor> exec)
-            : load_balance(exec->get_num_warps(), exec->get_warp_size())
-        {}
+        load_balance(std::shared_ptr<const CudaExecutor> exec);
 
         /**
          * Creates a load_balance strategy with HIP executor.
          *
          * @param exec the HIP executor
          */
-        load_balance(std::shared_ptr<const HipExecutor> exec)
-            : load_balance(exec->get_num_warps(), exec->get_warp_size(), false)
-        {}
+        load_balance(std::shared_ptr<const HipExecutor> exec);
 
         /**
          * Creates a load_balance strategy with DPCPP executor.
@@ -392,10 +338,7 @@ public:
          * @note TODO: porting - we hardcode the subgroup size is 32 and the
          *             number of threads in a SIMD unit is 7
          */
-        load_balance(std::shared_ptr<const DpcppExecutor> exec)
-            : load_balance(exec->get_num_computing_units() * 7, 32, false,
-                           "intel")
-        {}
+        load_balance(std::shared_ptr<const DpcppExecutor> exec);
 
         /**
          * Creates a load_balance strategy with specified parameters
@@ -410,111 +353,14 @@ public:
          */
         load_balance(int64_t nwarps, int warp_size = 32,
                      bool cuda_strategy = true,
-                     std::string strategy_name = "none")
-            : strategy_type("load_balance"),
-              nwarps_(nwarps),
-              warp_size_(warp_size),
-              cuda_strategy_(cuda_strategy),
-              strategy_name_(strategy_name)
-        {}
+                     std::string strategy_name = "none");
 
         void process(const array<index_type>& mtx_row_ptrs,
-                     array<index_type>* mtx_srow) override
-        {
-            auto nwarps = mtx_srow->get_num_elems();
+                     array<index_type>* mtx_srow) override;
 
-            if (nwarps > 0) {
-                auto host_srow_exec = mtx_srow->get_executor()->get_master();
-                auto host_mtx_exec = mtx_row_ptrs.get_executor()->get_master();
-                const bool is_srow_on_host{host_srow_exec ==
-                                           mtx_srow->get_executor()};
-                const bool is_mtx_on_host{host_mtx_exec ==
-                                          mtx_row_ptrs.get_executor()};
-                array<index_type> row_ptrs_host(host_mtx_exec);
-                array<index_type> srow_host(host_srow_exec);
-                const index_type* row_ptrs{};
-                index_type* srow{};
-                if (is_srow_on_host) {
-                    srow = mtx_srow->get_data();
-                } else {
-                    srow_host = *mtx_srow;
-                    srow = srow_host.get_data();
-                }
-                if (is_mtx_on_host) {
-                    row_ptrs = mtx_row_ptrs.get_const_data();
-                } else {
-                    row_ptrs_host = mtx_row_ptrs;
-                    row_ptrs = row_ptrs_host.get_const_data();
-                }
-                for (size_type i = 0; i < nwarps; i++) {
-                    srow[i] = 0;
-                }
-                const auto num_rows = mtx_row_ptrs.get_num_elems() - 1;
-                const auto num_elems = row_ptrs[num_rows];
-                const auto bucket_divider =
-                    num_elems > 0 ? ceildiv(num_elems, warp_size_) : 1;
-                for (size_type i = 0; i < num_rows; i++) {
-                    auto bucket =
-                        ceildiv((ceildiv(row_ptrs[i + 1], warp_size_) * nwarps),
-                                bucket_divider);
-                    if (bucket < nwarps) {
-                        srow[bucket]++;
-                    }
-                }
-                // find starting row for thread i
-                for (size_type i = 1; i < nwarps; i++) {
-                    srow[i] += srow[i - 1];
-                }
-                if (!is_srow_on_host) {
-                    *mtx_srow = srow_host;
-                }
-            }
-        }
+        int64_t clac_size(const int64_t nnz) override;
 
-        int64_t clac_size(const int64_t nnz) override
-        {
-            if (warp_size_ > 0) {
-                int multiple = 8;
-                if (nnz >= static_cast<int64_t>(2e8)) {
-                    multiple = 2048;
-                } else if (nnz >= static_cast<int64_t>(2e7)) {
-                    multiple = 512;
-                } else if (nnz >= static_cast<int64_t>(2e6)) {
-                    multiple = 128;
-                } else if (nnz >= static_cast<int64_t>(2e5)) {
-                    multiple = 32;
-                }
-                if (strategy_name_ == "intel") {
-                    multiple = 8;
-                    if (nnz >= static_cast<int64_t>(2e8)) {
-                        multiple = 256;
-                    } else if (nnz >= static_cast<int64_t>(2e7)) {
-                        multiple = 32;
-                    }
-                }
-#if GINKGO_HIP_PLATFORM_HCC
-                if (!cuda_strategy_) {
-                    multiple = 8;
-                    if (nnz >= static_cast<int64_t>(1e7)) {
-                        multiple = 64;
-                    } else if (nnz >= static_cast<int64_t>(1e6)) {
-                        multiple = 16;
-                    }
-                }
-#endif  // GINKGO_HIP_PLATFORM_HCC
-
-                auto nwarps = nwarps_ * multiple;
-                return min(ceildiv(nnz, warp_size_), nwarps);
-            } else {
-                return 0;
-            }
-        }
-
-        std::shared_ptr<strategy_type> copy() override
-        {
-            return std::make_shared<load_balance>(
-                nwarps_, warp_size_, cuda_strategy_, strategy_name_);
-        }
+        std::shared_ptr<strategy_type> copy() override;
 
     private:
         int64_t nwarps_;
@@ -551,28 +397,21 @@ public:
          * @warning this is deprecated! Please rely on the new automatic
          *          strategy instantiation or use one of the other constructors.
          */
-        [[deprecated]] automatical()
-            : automatical(std::move(
-                  gko::CudaExecutor::create(0, gko::OmpExecutor::create())))
-        {}
+        [[deprecated]] automatical();
 
         /**
          * Creates an automatical strategy with CUDA executor.
          *
          * @param exec the CUDA executor
          */
-        automatical(std::shared_ptr<const CudaExecutor> exec)
-            : automatical(exec->get_num_warps(), exec->get_warp_size())
-        {}
+        automatical(std::shared_ptr<const CudaExecutor> exec);
 
         /**
          * Creates an automatical strategy with HIP executor.
          *
          * @param exec the HIP executor
          */
-        automatical(std::shared_ptr<const HipExecutor> exec)
-            : automatical(exec->get_num_warps(), exec->get_warp_size(), false)
-        {}
+        automatical(std::shared_ptr<const HipExecutor> exec);
 
         /**
          * Creates an automatical strategy with Dpcpp executor.
@@ -582,10 +421,7 @@ public:
          * @note TODO: porting - we hardcode the subgroup size is 32 and the
          *             number of threads in a SIMD unit is 7
          */
-        automatical(std::shared_ptr<const DpcppExecutor> exec)
-            : automatical(exec->get_num_computing_units() * 7, 32, false,
-                          "intel")
-        {}
+        automatical(std::shared_ptr<const DpcppExecutor> exec);
 
         /**
          * Creates an automatical strategy with specified parameters
@@ -600,101 +436,16 @@ public:
          */
         automatical(int64_t nwarps, int warp_size = 32,
                     bool cuda_strategy = true,
-                    std::string strategy_name = "none")
-            : strategy_type("automatical"),
-              nwarps_(nwarps),
-              warp_size_(warp_size),
-              cuda_strategy_(cuda_strategy),
-              strategy_name_(strategy_name),
-              max_length_per_row_(0)
-        {}
+                    std::string strategy_name = "none");
 
         void process(const array<index_type>& mtx_row_ptrs,
-                     array<index_type>* mtx_srow) override
-        {
-            // if the number of stored elements is larger than <nnz_limit> or
-            // the maximum number of stored elements per row is larger than
-            // <row_len_limit>, use load_balance otherwise use classical
-            index_type nnz_limit = nvidia_nnz_limit;
-            index_type row_len_limit = nvidia_row_len_limit;
-            if (strategy_name_ == "intel") {
-                nnz_limit = intel_nnz_limit;
-                row_len_limit = intel_row_len_limit;
-            }
-#if GINKGO_HIP_PLATFORM_HCC
-            if (!cuda_strategy_) {
-                nnz_limit = amd_nnz_limit;
-                row_len_limit = amd_row_len_limit;
-            }
-#endif  // GINKGO_HIP_PLATFORM_HCC
-            auto host_mtx_exec = mtx_row_ptrs.get_executor()->get_master();
-            const bool is_mtx_on_host{host_mtx_exec ==
-                                      mtx_row_ptrs.get_executor()};
-            array<index_type> row_ptrs_host(host_mtx_exec);
-            const index_type* row_ptrs{};
-            if (is_mtx_on_host) {
-                row_ptrs = mtx_row_ptrs.get_const_data();
-            } else {
-                row_ptrs_host = mtx_row_ptrs;
-                row_ptrs = row_ptrs_host.get_const_data();
-            }
-            const auto num_rows = mtx_row_ptrs.get_num_elems() - 1;
-            if (row_ptrs[num_rows] > nnz_limit) {
-                load_balance actual_strategy(nwarps_, warp_size_,
-                                             cuda_strategy_, strategy_name_);
-                if (is_mtx_on_host) {
-                    actual_strategy.process(mtx_row_ptrs, mtx_srow);
-                } else {
-                    actual_strategy.process(row_ptrs_host, mtx_srow);
-                }
-                this->set_name(actual_strategy.get_name());
-            } else {
-                index_type maxnum = 0;
-                for (size_type i = 0; i < num_rows; i++) {
-                    maxnum = std::max(maxnum, row_ptrs[i + 1] - row_ptrs[i]);
-                }
-                if (maxnum > row_len_limit) {
-                    load_balance actual_strategy(
-                        nwarps_, warp_size_, cuda_strategy_, strategy_name_);
-                    if (is_mtx_on_host) {
-                        actual_strategy.process(mtx_row_ptrs, mtx_srow);
-                    } else {
-                        actual_strategy.process(row_ptrs_host, mtx_srow);
-                    }
-                    this->set_name(actual_strategy.get_name());
-                } else {
-                    classical actual_strategy;
-                    if (is_mtx_on_host) {
-                        actual_strategy.process(mtx_row_ptrs, mtx_srow);
-                        max_length_per_row_ =
-                            actual_strategy.get_max_length_per_row();
-                    } else {
-                        actual_strategy.process(row_ptrs_host, mtx_srow);
-                        max_length_per_row_ =
-                            actual_strategy.get_max_length_per_row();
-                    }
-                    this->set_name(actual_strategy.get_name());
-                }
-            }
-        }
+                     array<index_type>* mtx_srow) override;
 
-        int64_t clac_size(const int64_t nnz) override
-        {
-            return std::make_shared<load_balance>(
-                       nwarps_, warp_size_, cuda_strategy_, strategy_name_)
-                ->clac_size(nnz);
-        }
+        int64_t clac_size(const int64_t nnz) override;
 
-        index_type get_max_length_per_row() const noexcept
-        {
-            return max_length_per_row_;
-        }
+        index_type get_max_length_per_row() const noexcept;
 
-        std::shared_ptr<strategy_type> copy() override
-        {
-            return std::make_shared<automatical>(
-                nwarps_, warp_size_, cuda_strategy_, strategy_name_);
-        }
+        std::shared_ptr<strategy_type> copy() override;
 
     private:
         int64_t nwarps_;
@@ -793,7 +544,7 @@ public:
      *
      * @return the values of the matrix.
      */
-    value_type* get_values() noexcept { return values_.get_data(); }
+    value_type* get_values() noexcept;
 
     /**
      * @copydoc Csr::get_values()
@@ -802,17 +553,14 @@ public:
      *       significantly more memory efficient than the non-constant version,
      *       so always prefer this version.
      */
-    const value_type* get_const_values() const noexcept
-    {
-        return values_.get_const_data();
-    }
+    const value_type* get_const_values() const noexcept;
 
     /**
      * Returns the column indexes of the matrix.
      *
      * @return the column indexes of the matrix.
      */
-    index_type* get_col_idxs() noexcept { return col_idxs_.get_data(); }
+    index_type* get_col_idxs() noexcept;
 
     /**
      * @copydoc Csr::get_col_idxs()
@@ -821,17 +569,14 @@ public:
      *       significantly more memory efficient than the non-constant version,
      *       so always prefer this version.
      */
-    const index_type* get_const_col_idxs() const noexcept
-    {
-        return col_idxs_.get_const_data();
-    }
+    const index_type* get_const_col_idxs() const noexcept;
 
     /**
      * Returns the row pointers of the matrix.
      *
      * @return the row pointers of the matrix.
      */
-    index_type* get_row_ptrs() noexcept { return row_ptrs_.get_data(); }
+    index_type* get_row_ptrs() noexcept;
 
     /**
      * @copydoc Csr::get_row_ptrs()
@@ -840,17 +585,14 @@ public:
      *       significantly more memory efficient than the non-constant version,
      *       so always prefer this version.
      */
-    const index_type* get_const_row_ptrs() const noexcept
-    {
-        return row_ptrs_.get_const_data();
-    }
+    const index_type* get_const_row_ptrs() const noexcept;
 
     /**
      * Returns the starting rows.
      *
      * @return the starting rows.
      */
-    index_type* get_srow() noexcept { return srow_.get_data(); }
+    index_type* get_srow() noexcept;
 
     /**
      * @copydoc Csr::get_srow()
@@ -859,50 +601,34 @@ public:
      *       significantly more memory efficient than the non-constant version,
      *       so always prefer this version.
      */
-    const index_type* get_const_srow() const noexcept
-    {
-        return srow_.get_const_data();
-    }
+    const index_type* get_const_srow() const noexcept;
 
     /**
      * Returns the number of the srow stored elements (involved warps)
      *
      * @return the number of the srow stored elements (involved warps)
      */
-    size_type get_num_srow_elements() const noexcept
-    {
-        return srow_.get_num_elems();
-    }
+    size_type get_num_srow_elements() const noexcept;
 
     /**
      * Returns the number of elements explicitly stored in the matrix.
      *
      * @return the number of elements explicitly stored in the matrix
      */
-    size_type get_num_stored_elements() const noexcept
-    {
-        return values_.get_num_elems();
-    }
+    size_type get_num_stored_elements() const noexcept;
 
     /** Returns the strategy
      *
      * @return the strategy
      */
-    std::shared_ptr<strategy_type> get_strategy() const noexcept
-    {
-        return strategy_;
-    }
+    std::shared_ptr<strategy_type> get_strategy() const noexcept;
 
     /**
      * Set the strategy
      *
      * @param strategy the csr strategy
      */
-    void set_strategy(std::shared_ptr<strategy_type> strategy)
-    {
-        strategy_ = std::move(strategy->copy());
-        this->make_srow();
-    }
+    void set_strategy(std::shared_ptr<strategy_type> strategy);
 
     /**
      * Scales the matrix with a scalar.
@@ -910,12 +636,7 @@ public:
      * @param alpha  The entire matrix is scaled by alpha. alpha has to be a 1x1
      * Dense matrix.
      */
-    void scale(const LinOp* alpha)
-    {
-        auto exec = this->get_executor();
-        GKO_ASSERT_EQUAL_DIMENSIONS(alpha, dim<2>(1, 1));
-        this->scale_impl(make_temporary_clone(exec, alpha).get());
-    }
+    void scale(const LinOp* alpha);
 
     /**
      * Scales the matrix with the inverse of a scalar.
@@ -923,12 +644,7 @@ public:
      * @param alpha  The entire matrix is scaled by 1 / alpha. alpha has to be a
      * 1x1 Dense matrix.
      */
-    void inv_scale(const LinOp* alpha)
-    {
-        auto exec = this->get_executor();
-        GKO_ASSERT_EQUAL_DIMENSIONS(alpha, dim<2>(1, 1));
-        this->inv_scale_impl(make_temporary_clone(exec, alpha).get());
-    }
+    void inv_scale(const LinOp* alpha);
 
     /**
      * Creates a constant (immutable) Csr matrix from a set of constant arrays.
@@ -948,15 +664,7 @@ public:
         gko::detail::const_array_view<ValueType>&& values,
         gko::detail::const_array_view<IndexType>&& col_idxs,
         gko::detail::const_array_view<IndexType>&& row_ptrs,
-        std::shared_ptr<strategy_type> strategy)
-    {
-        // cast const-ness away, but return a const object afterwards,
-        // so we can ensure that no modifications take place.
-        return std::unique_ptr<const Csr>(new Csr{
-            exec, size, gko::detail::array_const_cast(std::move(values)),
-            gko::detail::array_const_cast(std::move(col_idxs)),
-            gko::detail::array_const_cast(std::move(row_ptrs)), strategy});
-    }
+        std::shared_ptr<strategy_type> strategy);
 
     /**
      * This is version of create_const with a default strategy.
@@ -965,12 +673,7 @@ public:
         std::shared_ptr<const Executor> exec, const dim<2>& size,
         gko::detail::const_array_view<ValueType>&& values,
         gko::detail::const_array_view<IndexType>&& col_idxs,
-        gko::detail::const_array_view<IndexType>&& row_ptrs)
-    {
-        return Csr::create_const(exec, size, std::move(values),
-                                 std::move(col_idxs), std::move(row_ptrs),
-                                 Csr::make_default_strategy(exec));
-    }
+        gko::detail::const_array_view<IndexType>&& row_ptrs);
 
     /**
      * Creates a submatrix from this Csr matrix given row and column index_set
@@ -1034,9 +737,7 @@ protected:
      * @param strategy  the strategy of CSR
      */
     Csr(std::shared_ptr<const Executor> exec,
-        std::shared_ptr<strategy_type> strategy)
-        : Csr(std::move(exec), dim<2>{}, {}, std::move(strategy))
-    {}
+        std::shared_ptr<strategy_type> strategy);
 
     /**
      * Creates an uninitialized CSR matrix of the specified size with a user
@@ -1048,17 +749,7 @@ protected:
      * @param strategy  the strategy of CSR
      */
     Csr(std::shared_ptr<const Executor> exec, const dim<2>& size,
-        size_type num_nonzeros, std::shared_ptr<strategy_type> strategy)
-        : EnableLinOp<Csr>(exec, size),
-          values_(exec, num_nonzeros),
-          col_idxs_(exec, num_nonzeros),
-          row_ptrs_(exec, size[0] + 1),
-          srow_(exec, strategy->clac_size(num_nonzeros)),
-          strategy_(strategy->copy())
-    {
-        row_ptrs_.fill(0);
-        this->make_srow();
-    }
+        size_type num_nonzeros, std::shared_ptr<strategy_type> strategy);
 
     /**
      * Creates an uninitialized CSR matrix of the specified size with a
@@ -1069,9 +760,7 @@ protected:
      * @param num_nonzeros  number of nonzeros
      */
     Csr(std::shared_ptr<const Executor> exec, const dim<2>& size = dim<2>{},
-        size_type num_nonzeros = {})
-        : Csr{exec, size, num_nonzeros, Csr::make_default_strategy(exec)}
-    {}
+        size_type num_nonzeros = {});
 
     /**
      * Creates a CSR matrix from already allocated (and initialized) row
@@ -1137,134 +826,16 @@ protected:
 
     // TODO: This provides some more sane settings. Please fix this!
     static std::shared_ptr<strategy_type> make_default_strategy(
-        std::shared_ptr<const Executor> exec)
-    {
-        auto cuda_exec = std::dynamic_pointer_cast<const CudaExecutor>(exec);
-        auto hip_exec = std::dynamic_pointer_cast<const HipExecutor>(exec);
-        auto dpcpp_exec = std::dynamic_pointer_cast<const DpcppExecutor>(exec);
-        std::shared_ptr<strategy_type> new_strategy;
-        if (cuda_exec) {
-            new_strategy = std::make_shared<automatical>(cuda_exec);
-        } else if (hip_exec) {
-            new_strategy = std::make_shared<automatical>(hip_exec);
-        } else if (dpcpp_exec) {
-            new_strategy = std::make_shared<automatical>(dpcpp_exec);
-        } else {
-            new_strategy = std::make_shared<classical>();
-        }
-        return new_strategy;
-    }
+        std::shared_ptr<const Executor> exec);
 
     // TODO clean this up as soon as we improve strategy_type
     template <typename CsrType>
-    void convert_strategy_helper(CsrType* result) const
-    {
-        auto strat = this->get_strategy().get();
-        std::shared_ptr<typename CsrType::strategy_type> new_strat;
-        if (dynamic_cast<classical*>(strat)) {
-            new_strat = std::make_shared<typename CsrType::classical>();
-        } else if (dynamic_cast<merge_path*>(strat)) {
-            new_strat = std::make_shared<typename CsrType::merge_path>();
-        } else if (dynamic_cast<cusparse*>(strat)) {
-            new_strat = std::make_shared<typename CsrType::cusparse>();
-        } else if (dynamic_cast<sparselib*>(strat)) {
-            new_strat = std::make_shared<typename CsrType::sparselib>();
-        } else {
-            auto rexec = result->get_executor();
-            auto cuda_exec =
-                std::dynamic_pointer_cast<const CudaExecutor>(rexec);
-            auto hip_exec = std::dynamic_pointer_cast<const HipExecutor>(rexec);
-            auto dpcpp_exec =
-                std::dynamic_pointer_cast<const DpcppExecutor>(rexec);
-            auto lb = dynamic_cast<load_balance*>(strat);
-            if (cuda_exec) {
-                if (lb) {
-                    new_strat =
-                        std::make_shared<typename CsrType::load_balance>(
-                            cuda_exec);
-                } else {
-                    new_strat = std::make_shared<typename CsrType::automatical>(
-                        cuda_exec);
-                }
-            } else if (hip_exec) {
-                if (lb) {
-                    new_strat =
-                        std::make_shared<typename CsrType::load_balance>(
-                            hip_exec);
-                } else {
-                    new_strat = std::make_shared<typename CsrType::automatical>(
-                        hip_exec);
-                }
-            } else if (dpcpp_exec) {
-                if (lb) {
-                    new_strat =
-                        std::make_shared<typename CsrType::load_balance>(
-                            dpcpp_exec);
-                } else {
-                    new_strat = std::make_shared<typename CsrType::automatical>(
-                        dpcpp_exec);
-                }
-            } else {
-                // Try to preserve this executor's configuration
-                auto this_cuda_exec =
-                    std::dynamic_pointer_cast<const CudaExecutor>(
-                        this->get_executor());
-                auto this_hip_exec =
-                    std::dynamic_pointer_cast<const HipExecutor>(
-                        this->get_executor());
-                auto this_dpcpp_exec =
-                    std::dynamic_pointer_cast<const DpcppExecutor>(
-                        this->get_executor());
-                if (this_cuda_exec) {
-                    if (lb) {
-                        new_strat =
-                            std::make_shared<typename CsrType::load_balance>(
-                                this_cuda_exec);
-                    } else {
-                        new_strat =
-                            std::make_shared<typename CsrType::automatical>(
-                                this_cuda_exec);
-                    }
-                } else if (this_hip_exec) {
-                    if (lb) {
-                        new_strat =
-                            std::make_shared<typename CsrType::load_balance>(
-                                this_hip_exec);
-                    } else {
-                        new_strat =
-                            std::make_shared<typename CsrType::automatical>(
-                                this_hip_exec);
-                    }
-                } else if (this_dpcpp_exec) {
-                    if (lb) {
-                        new_strat =
-                            std::make_shared<typename CsrType::load_balance>(
-                                this_dpcpp_exec);
-                    } else {
-                        new_strat =
-                            std::make_shared<typename CsrType::automatical>(
-                                this_dpcpp_exec);
-                    }
-                } else {
-                    // FIXME: this changes strategies.
-                    // We had a load balance or automatical strategy from a non
-                    // HIP or Cuda executor and are moving to a non HIP or Cuda
-                    // executor.
-                    new_strat = std::make_shared<typename CsrType::classical>();
-                }
-            }
-        }
-        result->set_strategy(new_strat);
-    }
+    void convert_strategy_helper(CsrType* result) const;
 
     /**
      * Computes srow. It should be run after changing any row_ptrs_ value.
      */
-    void make_srow()
-    {
-        srow_.resize_and_reset(strategy_->clac_size(values_.get_num_elems()));
-        strategy_->process(row_ptrs_, &srow_);
-    }
+    void make_srow();
 
     /**
      * @copydoc scale(const LinOp *)
@@ -1293,43 +864,6 @@ private:
 };
 
 
-namespace detail {
-
-
-/**
- * When strategy is load_balance or automatical, rebuild the strategy
- * according to executor's property.
- *
- * @param result  the csr matrix.
- */
-template <typename ValueType, typename IndexType>
-void strategy_rebuild_helper(Csr<ValueType, IndexType>* result)
-{
-    using load_balance = typename Csr<ValueType, IndexType>::load_balance;
-    using automatical = typename Csr<ValueType, IndexType>::automatical;
-    auto strategy = result->get_strategy();
-    auto executor = result->get_executor();
-    if (std::dynamic_pointer_cast<load_balance>(strategy)) {
-        if (auto exec =
-                std::dynamic_pointer_cast<const HipExecutor>(executor)) {
-            result->set_strategy(std::make_shared<load_balance>(exec));
-        } else if (auto exec = std::dynamic_pointer_cast<const CudaExecutor>(
-                       executor)) {
-            result->set_strategy(std::make_shared<load_balance>(exec));
-        }
-    } else if (std::dynamic_pointer_cast<automatical>(strategy)) {
-        if (auto exec =
-                std::dynamic_pointer_cast<const HipExecutor>(executor)) {
-            result->set_strategy(std::make_shared<automatical>(exec));
-        } else if (auto exec = std::dynamic_pointer_cast<const CudaExecutor>(
-                       executor)) {
-            result->set_strategy(std::make_shared<automatical>(exec));
-        }
-    }
-}
-
-
-}  // namespace detail
 }  // namespace matrix
 }  // namespace gko
 

--- a/include/ginkgo/core/matrix/dense.hpp
+++ b/include/ginkgo/core/matrix/dense.hpp
@@ -163,14 +163,7 @@ public:
      *
      * @param other  The other matrix whose configuration needs to copied.
      */
-    static std::unique_ptr<Dense> create_with_config_of(const Dense* other)
-    {
-        // De-referencing `other` before calling the functions (instead of
-        // using operator `->`) is currently required to be compatible with
-        // CUDA 10.1.
-        // Otherwise, it results in a compile error.
-        return (*other).create_with_same_config();
-    }
+    static std::unique_ptr<Dense> create_with_config_of(const Dense* other);
 
     /**
      * Creates a Dense matrix with the same type and executor as another Dense
@@ -185,11 +178,7 @@ public:
      */
     static std::unique_ptr<Dense> create_with_type_of(
         const Dense* other, std::shared_ptr<const Executor> exec,
-        const dim<2>& size = dim<2>{})
-    {
-        // See create_with_config_of()
-        return (*other).create_with_type_of_impl(exec, size, size[1]);
-    }
+        const dim<2>& size = dim<2>{});
 
     /**
      * @copydoc create_with_type_of(const Dense*, std::shared_ptr<const
@@ -201,11 +190,7 @@ public:
      */
     static std::unique_ptr<Dense> create_with_type_of(
         const Dense* other, std::shared_ptr<const Executor> exec,
-        const dim<2>& size, size_type stride)
-    {
-        // See create_with_config_of()
-        return (*other).create_with_type_of_impl(exec, size, stride);
-    }
+        const dim<2>& size, size_type stride);
 
     friend class Dense<next_precision<ValueType>>;
 
@@ -601,7 +586,7 @@ public:
      *
      * @return the pointer to the array of values
      */
-    value_type* get_values() noexcept { return values_.get_data(); }
+    value_type* get_values() noexcept;
 
     /**
      * @copydoc get_values()
@@ -610,27 +595,21 @@ public:
      *       significantly more memory efficient than the non-constant version,
      *       so always prefer this version.
      */
-    const value_type* get_const_values() const noexcept
-    {
-        return values_.get_const_data();
-    }
+    const value_type* get_const_values() const noexcept;
 
     /**
      * Returns the stride of the matrix.
      *
      * @return the stride of the matrix.
      */
-    size_type get_stride() const noexcept { return stride_; }
+    size_type get_stride() const noexcept;
 
     /**
      * Returns the number of elements explicitly stored in the matrix.
      *
      * @return the number of elements explicitly stored in the matrix
      */
-    size_type get_num_stored_elements() const noexcept
-    {
-        return values_.get_num_elems();
-    }
+    size_type get_num_stored_elements() const noexcept;
 
     /**
      * Returns a single element of the matrix.
@@ -829,10 +808,7 @@ public:
      */
     std::unique_ptr<Dense> create_submatrix(const span& rows,
                                             const span& columns,
-                                            const size_type stride)
-    {
-        return this->create_submatrix_impl(rows, columns, stride);
-    }
+                                            const size_type stride);
 
     /**
      * Create a submatrix from the original matrix.
@@ -841,10 +817,7 @@ public:
      * @param columns  column span
      */
     std::unique_ptr<Dense> create_submatrix(const span& rows,
-                                            const span& columns)
-    {
-        return create_submatrix(rows, columns, this->get_stride());
-    }
+                                            const span& columns);
 
     /**
      * Create a real view of the (potentially) complex original matrix.
@@ -873,14 +846,7 @@ public:
      */
     static std::unique_ptr<const Dense> create_const(
         std::shared_ptr<const Executor> exec, const dim<2>& size,
-        gko::detail::const_array_view<ValueType>&& values, size_type stride)
-    {
-        // cast const-ness away, but return a const object afterwards,
-        // so we can ensure that no modifications take place.
-        return std::unique_ptr<const Dense>(new Dense{
-            exec, size, gko::detail::array_const_cast(std::move(values)),
-            stride});
-    }
+        gko::detail::const_array_view<ValueType>&& values, size_type stride);
 
     /**
      * Copy-assigns a Dense matrix. Preserves the executor, reallocates the
@@ -915,9 +881,7 @@ protected:
      * @param exec  Executor associated to the matrix
      * @param size  size of the matrix
      */
-    Dense(std::shared_ptr<const Executor> exec, const dim<2>& size = dim<2>{})
-        : Dense(std::move(exec), size, size[1])
-    {}
+    Dense(std::shared_ptr<const Executor> exec, const dim<2>& size = dim<2>{});
 
     /**
      * Creates an uninitialized Dense matrix of the specified size.
@@ -929,11 +893,7 @@ protected:
      *                  number of matrix elements)
      */
     Dense(std::shared_ptr<const Executor> exec, const dim<2>& size,
-          size_type stride)
-        : EnableLinOp<Dense>(exec, size),
-          values_(exec, size[0] * stride),
-          stride_(stride)
-    {}
+          size_type stride);
 
     /**
      * Creates a Dense matrix from an already allocated (and initialized) array.
@@ -970,11 +930,7 @@ protected:
      *
      * @returns a Dense matrix with the same size and stride as the caller.
      */
-    virtual std::unique_ptr<Dense> create_with_same_config() const
-    {
-        return Dense::create(this->get_executor(), this->get_size(),
-                             this->get_stride());
-    }
+    virtual std::unique_ptr<Dense> create_with_same_config() const;
 
     /**
      * Creates a Dense matrix with the same type as the callers matrix.
@@ -985,10 +941,7 @@ protected:
      */
     virtual std::unique_ptr<Dense> create_with_type_of_impl(
         std::shared_ptr<const Executor> exec, const dim<2>& size,
-        size_type stride) const
-    {
-        return Dense::create(exec, size, stride);
-    }
+        size_type stride) const;
 
     template <typename IndexType>
     void convert_impl(Coo<ValueType, IndexType>* result) const;

--- a/include/ginkgo/core/matrix/diagonal.hpp
+++ b/include/ginkgo/core/matrix/diagonal.hpp
@@ -122,7 +122,7 @@ public:
      *
      * @return the pointer to the array of values
      */
-    value_type* get_values() noexcept { return values_.get_data(); }
+    value_type* get_values() noexcept;
 
     /**
      * @copydoc get_values()
@@ -131,10 +131,7 @@ public:
      *       significantly more memory efficient than the non-constant version,
      *       so always prefer this version.
      */
-    const value_type* get_const_values() const noexcept
-    {
-        return values_.get_const_data();
-    }
+    const value_type* get_const_values() const noexcept;
 
     /**
      * Applies the diagonal matrix from the right side to a matrix b,
@@ -143,14 +140,7 @@ public:
      * @param b  the input vector(s) on which the diagonal matrix is applied
      * @param x  the output vector(s) where the result is stored
      */
-    void rapply(const LinOp* b, LinOp* x) const
-    {
-        GKO_ASSERT_REVERSE_CONFORMANT(this, b);
-        GKO_ASSERT_EQUAL_ROWS(b, x);
-        GKO_ASSERT_EQUAL_COLS(this, x);
-
-        this->rapply_impl(b, x);
-    }
+    void rapply(const LinOp* b, LinOp* x) const;
 
     void read(const mat_data& data) override;
 
@@ -180,13 +170,7 @@ public:
      */
     static std::unique_ptr<const Diagonal> create_const(
         std::shared_ptr<const Executor> exec, size_type size,
-        gko::detail::const_array_view<ValueType>&& values)
-    {
-        // cast const-ness away, but return a const object afterwards,
-        // so we can ensure that no modifications take place.
-        return std::unique_ptr<const Diagonal>(new Diagonal{
-            exec, size, gko::detail::array_const_cast(std::move(values))});
-    }
+        gko::detail::const_array_view<ValueType>&& values);
 
 protected:
     /**
@@ -194,9 +178,7 @@ protected:
      *
      * @param exec  Executor associated to the matrix
      */
-    explicit Diagonal(std::shared_ptr<const Executor> exec)
-        : Diagonal(std::move(exec), size_type{})
-    {}
+    explicit Diagonal(std::shared_ptr<const Executor> exec);
 
     /**
      * Creates an Diagonal matrix of the specified size.
@@ -204,9 +186,7 @@ protected:
      * @param exec  Executor associated to the matrix
      * @param size  size of the matrix
      */
-    Diagonal(std::shared_ptr<const Executor> exec, size_type size)
-        : EnableLinOp<Diagonal>(exec, dim<2>{size}), values_(exec, size)
-    {}
+    Diagonal(std::shared_ptr<const Executor> exec, size_type size);
 
     /**
      * Creates a Diagonal matrix from an already allocated (and initialized)
@@ -228,7 +208,9 @@ protected:
         : EnableLinOp<Diagonal>(exec, dim<2>(size)),
           values_{exec, std::forward<ValuesArray>(values)}
     {
-        GKO_ENSURE_IN_BOUNDS(size - 1, values_.get_num_elems());
+        if (size != 0) {
+            GKO_ENSURE_IN_BOUNDS(size - 1, values_.get_num_elems());
+        }
     }
 
     void apply_impl(const LinOp* b, LinOp* x) const override;

--- a/include/ginkgo/core/matrix/ell.hpp
+++ b/include/ginkgo/core/matrix/ell.hpp
@@ -139,7 +139,7 @@ public:
      *
      * @return the values of the matrix.
      */
-    value_type* get_values() noexcept { return values_.get_data(); }
+    value_type* get_values() noexcept;
 
     /**
      * @copydoc Ell::get_values()
@@ -148,17 +148,14 @@ public:
      *       significantly more memory efficient than the non-constant version,
      *       so always prefer this version.
      */
-    const value_type* get_const_values() const noexcept
-    {
-        return values_.get_const_data();
-    }
+    const value_type* get_const_values() const noexcept;
 
     /**
      * Returns the column indexes of the matrix.
      *
      * @return the column indexes of the matrix.
      */
-    index_type* get_col_idxs() noexcept { return col_idxs_.get_data(); }
+    index_type* get_col_idxs() noexcept;
 
     /**
      * @copydoc Ell::get_col_idxs()
@@ -167,37 +164,28 @@ public:
      *       significantly more memory efficient than the non-constant version,
      *       so always prefer this version.
      */
-    const index_type* get_const_col_idxs() const noexcept
-    {
-        return col_idxs_.get_const_data();
-    }
+    const index_type* get_const_col_idxs() const noexcept;
 
     /**
      * Returns the number of stored elements per row.
      *
      * @return the number of stored elements per row.
      */
-    size_type get_num_stored_elements_per_row() const noexcept
-    {
-        return num_stored_elements_per_row_;
-    }
+    size_type get_num_stored_elements_per_row() const noexcept;
 
     /**
      * Returns the stride of the matrix.
      *
      * @return the stride of the matrix.
      */
-    size_type get_stride() const noexcept { return stride_; }
+    size_type get_stride() const noexcept;
 
     /**
      * Returns the number of elements explicitly stored in the matrix.
      *
      * @return the number of elements explicitly stored in the matrix
      */
-    size_type get_num_stored_elements() const noexcept
-    {
-        return values_.get_num_elems();
-    }
+    size_type get_num_stored_elements() const noexcept;
 
     /**
      * Returns the `idx`-th non-zero element of the `row`-th row .
@@ -262,15 +250,7 @@ public:
         std::shared_ptr<const Executor> exec, const dim<2>& size,
         gko::detail::const_array_view<ValueType>&& values,
         gko::detail::const_array_view<IndexType>&& col_idxs,
-        size_type num_stored_elements_per_row, size_type stride)
-    {
-        // cast const-ness away, but return a const object afterwards,
-        // so we can ensure that no modifications take place.
-        return std::unique_ptr<const Ell>(new Ell{
-            exec, size, gko::detail::array_const_cast(std::move(values)),
-            gko::detail::array_const_cast(std::move(col_idxs)),
-            num_stored_elements_per_row, stride});
-    }
+        size_type num_stored_elements_per_row, size_type stride);
 
     /**
      * Copy-assigns an Ell matrix. Preserves the executor, reallocates the
@@ -308,9 +288,7 @@ protected:
      * @param exec  Executor associated to the matrix
      * @param size  size of the matrix
      */
-    Ell(std::shared_ptr<const Executor> exec, const dim<2>& size = dim<2>{})
-        : Ell(std::move(exec), size, size[1])
-    {}
+    Ell(std::shared_ptr<const Executor> exec, const dim<2>& size = dim<2>{});
 
     /**
      * Creates an uninitialized Ell matrix of the specified size.
@@ -322,9 +300,7 @@ protected:
      *                                      row
      */
     Ell(std::shared_ptr<const Executor> exec, const dim<2>& size,
-        size_type num_stored_elements_per_row)
-        : Ell(std::move(exec), size, num_stored_elements_per_row, size[0])
-    {}
+        size_type num_stored_elements_per_row);
 
     /**
      * Creates an uninitialized Ell matrix of the specified size.
@@ -336,13 +312,7 @@ protected:
      * @param stride                stride of the rows
      */
     Ell(std::shared_ptr<const Executor> exec, const dim<2>& size,
-        size_type num_stored_elements_per_row, size_type stride)
-        : EnableLinOp<Ell>(exec, size),
-          values_(exec, stride * num_stored_elements_per_row),
-          col_idxs_(exec, stride * num_stored_elements_per_row),
-          num_stored_elements_per_row_(num_stored_elements_per_row),
-          stride_(stride)
-    {}
+        size_type num_stored_elements_per_row, size_type stride);
 
 
     /**

--- a/include/ginkgo/core/matrix/fbcsr.hpp
+++ b/include/ginkgo/core/matrix/fbcsr.hpp
@@ -237,7 +237,7 @@ public:
     /**
      * @return The values of the matrix.
      */
-    value_type* get_values() noexcept { return values_.get_data(); }
+    value_type* get_values() noexcept;
 
     /**
      * @copydoc Fbcsr::get_values()
@@ -246,15 +246,12 @@ public:
      *       significantly more memory efficient than the non-constant version,
      *       so always prefer this version.
      */
-    const value_type* get_const_values() const noexcept
-    {
-        return values_.get_const_data();
-    }
+    const value_type* get_const_values() const noexcept;
 
     /**
      * @return The column indexes of the matrix.
      */
-    index_type* get_col_idxs() noexcept { return col_idxs_.get_data(); }
+    index_type* get_col_idxs() noexcept;
 
     /**
      * @copydoc Fbcsr::get_col_idxs()
@@ -263,15 +260,12 @@ public:
      *       significantly more memory efficient than the non-constant version,
      *       so always prefer this version.
      */
-    const index_type* get_const_col_idxs() const noexcept
-    {
-        return col_idxs_.get_const_data();
-    }
+    const index_type* get_const_col_idxs() const noexcept;
 
     /**
      * @return The row pointers of the matrix.
      */
-    index_type* get_row_ptrs() noexcept { return row_ptrs_.get_data(); }
+    index_type* get_row_ptrs() noexcept;
 
     /**
      * @copydoc Fbcsr::get_row_ptrs()
@@ -280,47 +274,32 @@ public:
      *       significantly more memory efficient than the non-constant version,
      *       so always prefer this version.
      */
-    const index_type* get_const_row_ptrs() const noexcept
-    {
-        return row_ptrs_.get_const_data();
-    }
+    const index_type* get_const_row_ptrs() const noexcept;
 
     /**
      * @return  The number of elements explicitly stored in the matrix
      */
-    size_type get_num_stored_elements() const noexcept
-    {
-        return values_.get_num_elems();
-    }
+    size_type get_num_stored_elements() const noexcept;
 
     /**
      * @return  The number of non-zero blocks explicitly stored in the matrix
      */
-    size_type get_num_stored_blocks() const noexcept
-    {
-        return col_idxs_.get_num_elems();
-    }
+    size_type get_num_stored_blocks() const noexcept;
 
     /**
      * @return The fixed block size for this matrix
      */
-    int get_block_size() const noexcept { return bs_; }
+    int get_block_size() const noexcept;
 
     /**
      * @return The number of block-rows in the matrix
      */
-    index_type get_num_block_rows() const noexcept
-    {
-        return this->get_size()[0] / bs_;
-    }
+    index_type get_num_block_rows() const noexcept;
 
     /**
      * @return The number of block-columns in the matrix
      */
-    index_type get_num_block_cols() const noexcept
-    {
-        return this->get_size()[1] / bs_;
-    }
+    index_type get_num_block_cols() const noexcept;
 
     /**
      * Creates a constant (immutable) Fbcsr matrix from a constant array.
@@ -339,16 +318,7 @@ public:
         std::shared_ptr<const Executor> exec, const dim<2>& size, int blocksize,
         gko::detail::const_array_view<ValueType>&& values,
         gko::detail::const_array_view<IndexType>&& col_idxs,
-        gko::detail::const_array_view<IndexType>&& row_ptrs)
-    {
-        // cast const-ness away, but return a const object afterwards,
-        // so we can ensure that no modifications take place.
-        return std::unique_ptr<const Fbcsr>(
-            new Fbcsr{exec, size, blocksize,
-                      gko::detail::array_const_cast(std::move(values)),
-                      gko::detail::array_const_cast(std::move(col_idxs)),
-                      gko::detail::array_const_cast(std::move(row_ptrs))});
-    }
+        gko::detail::const_array_view<IndexType>&& row_ptrs);
 
     /**
      * Copy-assigns an Fbcsr matrix. Preserves the executor, copies data and
@@ -383,9 +353,7 @@ protected:
      * @param block_size  The desired size of the dense square nonzero blocks;
      *                    defaults to 1.
      */
-    Fbcsr(std::shared_ptr<const Executor> exec, int block_size = 1)
-        : Fbcsr(std::move(exec), dim<2>{}, {}, block_size)
-    {}
+    Fbcsr(std::shared_ptr<const Executor> exec, int block_size = 1);
 
     /**
      * Creates an uninitialized FBCSR matrix of the specified size.
@@ -397,17 +365,7 @@ protected:
      * @param block_size  size of the small dense square blocks
      */
     Fbcsr(std::shared_ptr<const Executor> exec, const dim<2>& size,
-          size_type num_nonzeros, int block_size)
-        : EnableLinOp<Fbcsr>(exec, size),
-          bs_{block_size},
-          values_(exec, num_nonzeros),
-          col_idxs_(exec, detail::get_num_blocks(block_size * block_size,
-                                                 num_nonzeros)),
-          row_ptrs_(exec, detail::get_num_blocks(block_size, size[0]) + 1)
-    {
-        GKO_ASSERT_BLOCK_SIZE_CONFORMANT(size[1], bs_);
-        row_ptrs_.fill(0);
-    }
+          size_type num_nonzeros, int block_size);
 
     /**
      * Creates a FBCSR matrix from already allocated (and initialized) row

--- a/include/ginkgo/core/matrix/fft.hpp
+++ b/include/ginkgo/core/matrix/fft.hpp
@@ -110,9 +110,7 @@ protected:
      *
      * @param exec  Executor associated to the matrix
      */
-    explicit Fft(std::shared_ptr<const Executor> exec)
-        : EnableLinOp<Fft>(exec), buffer_{exec}, inverse_{}
-    {}
+    explicit Fft(std::shared_ptr<const Executor> exec);
 
     /**
      * Creates an Fourier matrix with the given dimensions.
@@ -121,9 +119,7 @@ protected:
      * @param inverse  true to compute an inverse DFT instead of a normal DFT
      */
     Fft(std::shared_ptr<const Executor> exec, size_type size,
-        bool inverse = false)
-        : EnableLinOp<Fft>(exec, dim<2>{size}), buffer_{exec}, inverse_{inverse}
-    {}
+        bool inverse = false);
 
     void apply_impl(const LinOp* b, LinOp* x) const override;
 
@@ -206,18 +202,14 @@ protected:
      *
      * @param exec  Executor associated to the matrix
      */
-    explicit Fft2(std::shared_ptr<const Executor> exec)
-        : EnableLinOp<Fft2>(exec), buffer_{exec}, fft_size_{}, inverse_{}
-    {}
+    explicit Fft2(std::shared_ptr<const Executor> exec);
 
     /**
      * Creates an Fourier matrix with the given dimensions.
      *
      * @param size  size of both FFT dimensions
      */
-    Fft2(std::shared_ptr<const Executor> exec, size_type size)
-        : Fft2{exec, size, size}
-    {}
+    Fft2(std::shared_ptr<const Executor> exec, size_type size);
 
     /**
      * Creates an Fourier matrix with the given dimensions.
@@ -227,12 +219,7 @@ protected:
      * @param inverse  true to compute an inverse DFT instead of a normal DFT
      */
     Fft2(std::shared_ptr<const Executor> exec, size_type size1, size_type size2,
-         bool inverse = false)
-        : EnableLinOp<Fft2>(exec, dim<2>{size1 * size2}),
-          buffer_{exec},
-          fft_size_{size1, size2},
-          inverse_{inverse}
-    {}
+         bool inverse = false);
 
     void apply_impl(const LinOp* b, LinOp* x) const override;
 
@@ -318,18 +305,14 @@ protected:
      *
      * @param exec  Executor associated to the matrix
      */
-    explicit Fft3(std::shared_ptr<const Executor> exec)
-        : EnableLinOp<Fft3>(exec), buffer_{exec}, fft_size_{}, inverse_{}
-    {}
+    explicit Fft3(std::shared_ptr<const Executor> exec);
 
     /**
      * Creates an Fourier matrix with the given dimensions.
      *
      * @param size  size of all FFT dimensions
      */
-    Fft3(std::shared_ptr<const Executor> exec, size_type size)
-        : Fft3{exec, size, size, size}
-    {}
+    Fft3(std::shared_ptr<const Executor> exec, size_type size);
 
     /**
      * Creates an Fourier matrix with the given dimensions.
@@ -340,12 +323,7 @@ protected:
      * @param inverse  true to compute an inverse DFT instead of a normal DFT
      */
     Fft3(std::shared_ptr<const Executor> exec, size_type size1, size_type size2,
-         size_type size3, bool inverse = false)
-        : EnableLinOp<Fft3>(exec, dim<2>{size1 * size2 * size3}),
-          buffer_{exec},
-          fft_size_{size1, size2, size3},
-          inverse_{inverse}
-    {}
+         size_type size3, bool inverse = false);
 
     void apply_impl(const LinOp* b, LinOp* x) const override;
 

--- a/include/ginkgo/core/matrix/identity.hpp
+++ b/include/ginkgo/core/matrix/identity.hpp
@@ -84,29 +84,21 @@ protected:
      *
      * @param exec  Executor associated to the matrix
      */
-    explicit Identity(std::shared_ptr<const Executor> exec)
-        : EnableLinOp<Identity>(exec)
-    {}
+    explicit Identity(std::shared_ptr<const Executor> exec);
 
     /**
      * Creates an Identity matrix of the specified size.
      *
      * @param size  size of the matrix (must be square)
      */
-    Identity(std::shared_ptr<const Executor> exec, dim<2> size)
-        : EnableLinOp<Identity>(exec, size)
-    {
-        GKO_ASSERT_IS_SQUARE_MATRIX(this);
-    }
+    Identity(std::shared_ptr<const Executor> exec, dim<2> size);
 
     /**
      * Creates an Identity matrix of the specified size.
      *
      * @param size  size of the matrix
      */
-    Identity(std::shared_ptr<const Executor> exec, size_type size)
-        : EnableLinOp<Identity>(exec, dim<2>{size})
-    {}
+    Identity(std::shared_ptr<const Executor> exec, size_type size);
 
     void apply_impl(const LinOp* b, LinOp* x) const override;
 
@@ -143,19 +135,13 @@ public:
      * @return a unique pointer to the newly created factory
      */
     static std::unique_ptr<IdentityFactory> create(
-        std::shared_ptr<const Executor> exec)
-    {
-        return std::unique_ptr<IdentityFactory>(
-            new IdentityFactory(std::move(exec)));
-    }
+        std::shared_ptr<const Executor> exec);
 
 protected:
     std::unique_ptr<LinOp> generate_impl(
         std::shared_ptr<const LinOp> base) const override;
 
-    IdentityFactory(std::shared_ptr<const Executor> exec)
-        : EnablePolymorphicObject<IdentityFactory, LinOpFactory>(exec)
-    {}
+    IdentityFactory(std::shared_ptr<const Executor> exec);
 };
 
 

--- a/include/ginkgo/core/matrix/row_gatherer.hpp
+++ b/include/ginkgo/core/matrix/row_gatherer.hpp
@@ -82,7 +82,7 @@ public:
      *
      * @return the pointer to the row index array for gathering.
      */
-    index_type* get_row_idxs() noexcept { return row_idxs_.get_data(); }
+    index_type* get_row_idxs() noexcept;
 
     /**
      * @copydoc get_row_idxs()
@@ -91,10 +91,7 @@ public:
      *       significantly more memory efficient than the non-constant version,
      *       so always prefer this version.
      */
-    const index_type* get_const_row_idxs() const noexcept
-    {
-        return row_idxs_.get_const_data();
-    }
+    const index_type* get_const_row_idxs() const noexcept;
 
     /**
      * Creates a constant (immutable) RowGatherer matrix from a constant array.
@@ -108,13 +105,7 @@ public:
      */
     static std::unique_ptr<const RowGatherer> create_const(
         std::shared_ptr<const Executor> exec, const dim<2>& size,
-        gko::detail::const_array_view<IndexType>&& row_idxs)
-    {
-        // cast const-ness away, but return a const object afterwards,
-        // so we can ensure that no modifications take place.
-        return std::unique_ptr<const RowGatherer>(new RowGatherer{
-            exec, size, gko::detail::array_const_cast(std::move(row_idxs))});
-    }
+        gko::detail::const_array_view<IndexType>&& row_idxs);
 
 protected:
     /**
@@ -122,9 +113,7 @@ protected:
      *
      * @param exec  Executor associated to the LinOp
      */
-    RowGatherer(std::shared_ptr<const Executor> exec)
-        : RowGatherer(std::move(exec), dim<2>{})
-    {}
+    RowGatherer(std::shared_ptr<const Executor> exec);
 
     /**
      * Creates uninitialized RowGatherer arrays of the specified size.
@@ -132,9 +121,7 @@ protected:
      * @param exec  Executor associated to the matrix
      * @param size  size of the RowGatherable matrix
      */
-    RowGatherer(std::shared_ptr<const Executor> exec, const dim<2>& size)
-        : EnableLinOp<RowGatherer>(exec, size), row_idxs_(exec, size[0])
-    {}
+    RowGatherer(std::shared_ptr<const Executor> exec, const dim<2>& size);
 
     /**
      * Creates a RowGatherer matrix from an already allocated (and initialized)

--- a/include/ginkgo/core/matrix/sellp.hpp
+++ b/include/ginkgo/core/matrix/sellp.hpp
@@ -129,7 +129,7 @@ public:
      *
      * @return the values of the matrix.
      */
-    value_type* get_values() noexcept { return values_.get_data(); }
+    value_type* get_values() noexcept;
 
     /**
      * @copydoc Sellp::get_values()
@@ -138,17 +138,14 @@ public:
      *       significantly more memory efficient than the non-constant version,
      *       so always prefer this version.
      */
-    const value_type* get_const_values() const noexcept
-    {
-        return values_.get_const_data();
-    }
+    const value_type* get_const_values() const noexcept;
 
     /**
      * Returns the column indexes of the matrix.
      *
      * @return the column indexes of the matrix.
      */
-    index_type* get_col_idxs() noexcept { return col_idxs_.get_data(); }
+    index_type* get_col_idxs() noexcept;
 
     /**
      * @copydoc Sellp::get_col_idxs()
@@ -157,20 +154,14 @@ public:
      *       significantly more memory efficient than the non-constant version,
      *       so always prefer this version.
      */
-    const index_type* get_const_col_idxs() const noexcept
-    {
-        return col_idxs_.get_const_data();
-    }
+    const index_type* get_const_col_idxs() const noexcept;
 
     /**
      * Returns the lengths(columns) of slices.
      *
      * @return the lengths(columns) of slices.
      */
-    size_type* get_slice_lengths() noexcept
-    {
-        return slice_lengths_.get_data();
-    }
+    size_type* get_slice_lengths() noexcept;
 
     /**
      * @copydoc Sellp::get_slice_lengths()
@@ -179,17 +170,14 @@ public:
      *       significantly more memory efficient than the non-constant version,
      *       so always prefer this version.
      */
-    const size_type* get_const_slice_lengths() const noexcept
-    {
-        return slice_lengths_.get_const_data();
-    }
+    const size_type* get_const_slice_lengths() const noexcept;
 
     /**
      * Returns the offsets of slices.
      *
      * @return the offsets of slices.
      */
-    size_type* get_slice_sets() noexcept { return slice_sets_.get_data(); }
+    size_type* get_slice_sets() noexcept;
 
     /**
      * @copydoc Sellp::get_slice_sets()
@@ -198,44 +186,35 @@ public:
      *       significantly more memory efficient than the non-constant version,
      *       so always prefer this version.
      */
-    const size_type* get_const_slice_sets() const noexcept
-    {
-        return slice_sets_.get_const_data();
-    }
+    const size_type* get_const_slice_sets() const noexcept;
 
     /**
      * Returns the size of a slice.
      *
      * @return the size of a slice.
      */
-    size_type get_slice_size() const noexcept { return slice_size_; }
+    size_type get_slice_size() const noexcept;
 
     /**
      * Returns the stride factor(t) of SELL-P.
      *
      * @return the stride factor(t) of SELL-P.
      */
-    size_type get_stride_factor() const noexcept { return stride_factor_; }
+    size_type get_stride_factor() const noexcept;
 
     /**
      * Returns the total column number.
      *
      * @return the total column number.
      */
-    size_type get_total_cols() const noexcept
-    {
-        return values_.get_num_elems() / slice_size_;
-    }
+    size_type get_total_cols() const noexcept;
 
     /**
      * Returns the number of elements explicitly stored in the matrix.
      *
      * @return the number of elements explicitly stored in the matrix
      */
-    size_type get_num_stored_elements() const noexcept
-    {
-        return values_.get_num_elems();
-    }
+    size_type get_num_stored_elements() const noexcept;
 
     /**
      * Returns the `idx`-th non-zero element of the `row`-th row with
@@ -328,10 +307,7 @@ protected:
      * @param exec  Executor associated to the matrix
      * @param size  size of the matrix
      */
-    Sellp(std::shared_ptr<const Executor> exec, const dim<2>& size = dim<2>{})
-        : Sellp(std::move(exec), size,
-                ceildiv(size[0], default_slice_size) * size[1])
-    {}
+    Sellp(std::shared_ptr<const Executor> exec, const dim<2>& size = dim<2>{});
 
     /**
      * Creates an uninitialized Sellp matrix of the specified size.
@@ -342,10 +318,7 @@ protected:
      * @param total_cols   number of the sum of all cols in every slice.
      */
     Sellp(std::shared_ptr<const Executor> exec, const dim<2>& size,
-          size_type total_cols)
-        : Sellp(std::move(exec), size, default_slice_size,
-                default_stride_factor, total_cols)
-    {}
+          size_type total_cols);
 
     /**
      * Creates an uninitialized Sellp matrix of the specified size.
@@ -358,18 +331,7 @@ protected:
      * @param total_cols   number of the sum of all cols in every slice.
      */
     Sellp(std::shared_ptr<const Executor> exec, const dim<2>& size,
-          size_type slice_size, size_type stride_factor, size_type total_cols)
-        : EnableLinOp<Sellp>(exec, size),
-          values_(exec, slice_size * total_cols),
-          col_idxs_(exec, slice_size * total_cols),
-          slice_lengths_(exec, ceildiv(size[0], slice_size)),
-          slice_sets_(exec, ceildiv(size[0], slice_size) + 1),
-          slice_size_(slice_size),
-          stride_factor_(stride_factor)
-    {
-        slice_sets_.fill(0);
-        slice_lengths_.fill(0);
-    }
+          size_type slice_size, size_type stride_factor, size_type total_cols);
 
     void apply_impl(const LinOp* b, LinOp* x) const override;
 

--- a/include/ginkgo/core/matrix/sparsity_csr.hpp
+++ b/include/ginkgo/core/matrix/sparsity_csr.hpp
@@ -150,7 +150,7 @@ public:
      *
      * @return the column indices of the matrix.
      */
-    index_type* get_col_idxs() noexcept { return col_idxs_.get_data(); }
+    index_type* get_col_idxs() noexcept;
 
     /**
      * @copydoc SparsityCsr::get_col_idxs()
@@ -159,17 +159,14 @@ public:
      *       significantly more memory efficient than the non-constant version,
      *       so always prefer this version.
      */
-    const index_type* get_const_col_idxs() const noexcept
-    {
-        return col_idxs_.get_const_data();
-    }
+    const index_type* get_const_col_idxs() const noexcept;
 
     /**
      * Returns the row pointers of the matrix.
      *
      * @return the row pointers of the matrix.
      */
-    index_type* get_row_ptrs() noexcept { return row_ptrs_.get_data(); }
+    index_type* get_row_ptrs() noexcept;
 
     /**
      * @copydoc SparsityCsr::get_row_ptrs()
@@ -178,17 +175,14 @@ public:
      *       significantly more memory efficient than the non-constant version,
      *       so always prefer this version.
      */
-    const index_type* get_const_row_ptrs() const noexcept
-    {
-        return row_ptrs_.get_const_data();
-    }
+    const index_type* get_const_row_ptrs() const noexcept;
 
     /**
      * Returns the value stored in the matrix.
      *
      * @return the value of the matrix.
      */
-    value_type* get_value() noexcept { return value_.get_data(); }
+    value_type* get_value() noexcept;
 
     /**
      * @copydoc SparsityCsr::get_value()
@@ -197,10 +191,7 @@ public:
      *       significantly more memory efficient than the non-constant version,
      *       so always prefer this version.
      */
-    const value_type* get_const_value() const noexcept
-    {
-        return value_.get_const_data();
-    }
+    const value_type* get_const_value() const noexcept;
 
 
     /**
@@ -208,10 +199,7 @@ public:
      *
      * @return the number of elements explicitly stored in the matrix
      */
-    size_type get_num_nonzeros() const noexcept
-    {
-        return col_idxs_.get_num_elems();
-    }
+    size_type get_num_nonzeros() const noexcept;
 
     /**
      * Creates a constant (immutable) SparsityCsr matrix from constant arrays.
@@ -230,14 +218,7 @@ public:
         std::shared_ptr<const Executor> exec, const dim<2>& size,
         gko::detail::const_array_view<IndexType>&& col_idxs,
         gko::detail::const_array_view<IndexType>&& row_ptrs,
-        ValueType value = one<ValueType>())
-    {
-        // cast const-ness away, but return a const object afterwards,
-        // so we can ensure that no modifications take place.
-        return std::unique_ptr<const SparsityCsr>(new SparsityCsr{
-            exec, size, gko::detail::array_const_cast(std::move(col_idxs)),
-            gko::detail::array_const_cast(std::move(row_ptrs)), value});
-    }
+        ValueType value = one<ValueType>());
 
     /**
      * Copy-assigns a SparsityCsr matrix. Preserves executor, copies everything
@@ -274,14 +255,7 @@ protected:
      * @param num_nonzeros  number of nonzeros
      */
     SparsityCsr(std::shared_ptr<const Executor> exec,
-                const dim<2>& size = dim<2>{}, size_type num_nonzeros = {})
-        : EnableLinOp<SparsityCsr>(exec, size),
-          col_idxs_(exec, num_nonzeros),
-          row_ptrs_(exec, size[0] + 1),
-          value_(exec, {one<ValueType>()})
-    {
-        row_ptrs_.fill(0);
-    }
+                const dim<2>& size = dim<2>{}, size_type num_nonzeros = {});
 
     /**
      * Creates a SparsityCsr matrix from already allocated (and initialized) row
@@ -322,12 +296,7 @@ protected:
      * @param matrix The input matrix
      */
     SparsityCsr(std::shared_ptr<const Executor> exec,
-                std::shared_ptr<const LinOp> matrix)
-        : EnableLinOp<SparsityCsr>(exec, matrix->get_size())
-    {
-        auto tmp_ = copy_and_convert_to<SparsityCsr>(exec, matrix);
-        this->copy_from(std::move(tmp_.get()));
-    }
+                std::shared_ptr<const LinOp> matrix);
 
     void apply_impl(const LinOp* b, LinOp* x) const override;
 

--- a/include/ginkgo/core/multigrid/amgx_pgm.hpp
+++ b/include/ginkgo/core/multigrid/amgx_pgm.hpp
@@ -86,10 +86,7 @@ public:
      *
      * @return the system operator (matrix)
      */
-    std::shared_ptr<const LinOp> get_system_matrix() const
-    {
-        return system_matrix_;
-    }
+    std::shared_ptr<const LinOp> get_system_matrix() const;
 
     /**
      * Returns the aggregate group.
@@ -100,7 +97,7 @@ public:
      *
      * @return the aggregate group.
      */
-    IndexType* get_agg() noexcept { return agg_.get_data(); }
+    IndexType* get_agg() noexcept;
 
     /**
      * @copydoc AmgxPgm::get_agg()
@@ -109,10 +106,7 @@ public:
      *       significantly more memory efficient than the non-constant version,
      *       so always prefer this version.
      */
-    const IndexType* get_const_agg() const noexcept
-    {
-        return agg_.get_const_data();
-    }
+    const IndexType* get_const_agg() const noexcept;
 
     GKO_CREATE_FACTORY_PARAMETERS(parameters, Factory)
     {
@@ -156,37 +150,15 @@ public:
     GKO_ENABLE_BUILD_METHOD(Factory);
 
 protected:
-    void apply_impl(const LinOp* b, LinOp* x) const override
-    {
-        this->get_composition()->apply(b, x);
-    }
+    void apply_impl(const LinOp* b, LinOp* x) const override;
 
     void apply_impl(const LinOp* alpha, const LinOp* b, const LinOp* beta,
-                    LinOp* x) const override
-    {
-        this->get_composition()->apply(alpha, b, beta, x);
-    }
+                    LinOp* x) const override;
 
-    explicit AmgxPgm(std::shared_ptr<const Executor> exec)
-        : EnableLinOp<AmgxPgm>(std::move(exec))
-    {}
+    explicit AmgxPgm(std::shared_ptr<const Executor> exec);
 
     explicit AmgxPgm(const Factory* factory,
-                     std::shared_ptr<const LinOp> system_matrix)
-        : EnableLinOp<AmgxPgm>(factory->get_executor(),
-                               system_matrix->get_size()),
-          EnableMultigridLevel<ValueType>(system_matrix),
-          parameters_{factory->get_parameters()},
-          system_matrix_{system_matrix},
-          agg_(factory->get_executor(), system_matrix_->get_size()[0])
-    {
-        GKO_ASSERT(parameters_.max_unassigned_ratio <= 1.0);
-        GKO_ASSERT(parameters_.max_unassigned_ratio >= 0.0);
-        if (system_matrix_->get_size()[0] != 0) {
-            // generate on the existed matrix
-            this->generate();
-        }
-    }
+                     std::shared_ptr<const LinOp> system_matrix);
 
     void generate();
 

--- a/include/ginkgo/core/multigrid/fixed_coarsening.hpp
+++ b/include/ginkgo/core/multigrid/fixed_coarsening.hpp
@@ -82,11 +82,7 @@ public:
      *
      * @return the system operator (matrix)
      */
-    std::shared_ptr<const LinOp> get_system_matrix() const
-    {
-        return system_matrix_;
-    }
-
+    std::shared_ptr<const LinOp> get_system_matrix() const;
 
     GKO_CREATE_FACTORY_PARAMETERS(parameters, Factory)
     {
@@ -112,34 +108,15 @@ public:
     GKO_ENABLE_BUILD_METHOD(Factory);
 
 protected:
-    void apply_impl(const LinOp* b, LinOp* x) const override
-    {
-        this->get_composition()->apply(b, x);
-    }
+    void apply_impl(const LinOp* b, LinOp* x) const override;
 
     void apply_impl(const LinOp* alpha, const LinOp* b, const LinOp* beta,
-                    LinOp* x) const override
-    {
-        this->get_composition()->apply(alpha, b, beta, x);
-    }
+                    LinOp* x) const override;
 
-    explicit FixedCoarsening(std::shared_ptr<const Executor> exec)
-        : EnableLinOp<FixedCoarsening>(std::move(exec))
-    {}
+    explicit FixedCoarsening(std::shared_ptr<const Executor> exec);
 
     explicit FixedCoarsening(const Factory* factory,
-                             std::shared_ptr<const LinOp> system_matrix)
-        : EnableLinOp<FixedCoarsening>(factory->get_executor(),
-                                       system_matrix->get_size()),
-          EnableMultigridLevel<ValueType>(system_matrix),
-          parameters_{factory->get_parameters()},
-          system_matrix_{system_matrix}
-    {
-        if (system_matrix_->get_size()[0] != 0) {
-            // generate on the existing matrix
-            this->generate();
-        }
-    }
+                             std::shared_ptr<const LinOp> system_matrix);
 
     void generate();
 

--- a/include/ginkgo/core/preconditioner/isai.hpp
+++ b/include/ginkgo/core/preconditioner/isai.hpp
@@ -137,11 +137,7 @@ public:
      */
     std::shared_ptr<const typename std::conditional<IsaiType == isai_type::spd,
                                                     Comp, Csr>::type>
-    get_approximate_inverse() const
-    {
-        return as<typename std::conditional<IsaiType == isai_type::spd, Comp,
-                                            Csr>::type>(approximate_inverse_);
-    }
+    get_approximate_inverse() const;
 
     /**
      * Copy-assigns an ISAI preconditioner. Preserves the executor,
@@ -224,9 +220,7 @@ public:
     std::unique_ptr<LinOp> conj_transpose() const override;
 
 protected:
-    explicit Isai(std::shared_ptr<const Executor> exec)
-        : EnableLinOp<Isai>(std::move(exec))
-    {}
+    explicit Isai(std::shared_ptr<const Executor> exec);
 
     /**
      * Creates an Isai preconditioner from a matrix using an Isai::Factory.
@@ -235,32 +229,12 @@ protected:
      * @param system_matrix  the matrix for which an ISAI is to be computed
      */
     explicit Isai(const Factory* factory,
-                  std::shared_ptr<const LinOp> system_matrix)
-        : EnableLinOp<Isai>(factory->get_executor(), system_matrix->get_size()),
-          parameters_{factory->get_parameters()}
-    {
-        const auto skip_sorting = parameters_.skip_sorting;
-        const auto power = parameters_.sparsity_power;
-        const auto excess_limit = parameters_.excess_limit;
-        generate_inverse(system_matrix, skip_sorting, power, excess_limit);
-        if (IsaiType == isai_type::spd) {
-            auto inv = share(as<Csr>(approximate_inverse_));
-            auto inv_transp = share(inv->conj_transpose());
-            approximate_inverse_ =
-                Composition<ValueType>::create(inv_transp, inv);
-        }
-    }
+                  std::shared_ptr<const LinOp> system_matrix);
 
-    void apply_impl(const LinOp* b, LinOp* x) const override
-    {
-        approximate_inverse_->apply(b, x);
-    }
+    void apply_impl(const LinOp* b, LinOp* x) const override;
 
     void apply_impl(const LinOp* alpha, const LinOp* b, const LinOp* beta,
-                    LinOp* x) const override
-    {
-        approximate_inverse_->apply(alpha, b, beta, x);
-    }
+                    LinOp* x) const override;
 
 private:
     /**

--- a/include/ginkgo/core/reorder/rcm.hpp
+++ b/include/ginkgo/core/reorder/rcm.hpp
@@ -109,10 +109,7 @@ public:
      *
      * @return the permutation (permutation matrix)
      */
-    std::shared_ptr<const PermutationMatrix> get_permutation() const
-    {
-        return permutation_;
-    }
+    std::shared_ptr<const PermutationMatrix> get_permutation() const;
 
     /**
      * Gets the inverse permutation (permutation matrix, output of the
@@ -120,10 +117,7 @@ public:
      *
      * @return the inverse permutation (permutation matrix)
      */
-    std::shared_ptr<const PermutationMatrix> get_inverse_permutation() const
-    {
-        return inv_permutation_;
-    }
+    std::shared_ptr<const PermutationMatrix> get_inverse_permutation() const;
 
     GKO_CREATE_FACTORY_PARAMETERS(parameters, Factory)
     {
@@ -151,60 +145,9 @@ protected:
     void generate(std::shared_ptr<const Executor>& exec,
                   std::unique_ptr<SparsityMatrix> adjacency_matrix) const;
 
-    explicit Rcm(std::shared_ptr<const Executor> exec)
-        : EnablePolymorphicObject<Rcm, ReorderingBase>(std::move(exec))
-    {}
+    explicit Rcm(std::shared_ptr<const Executor> exec);
 
-    explicit Rcm(const Factory* factory, const ReorderingBaseArgs& args)
-        : EnablePolymorphicObject<Rcm, ReorderingBase>(factory->get_executor()),
-          parameters_{factory->get_parameters()}
-    {
-        // Always execute the reordering on the cpu.
-        const auto is_gpu_executor =
-            this->get_executor() != this->get_executor()->get_master();
-        auto cpu_exec = is_gpu_executor ? this->get_executor()->get_master()
-                                        : this->get_executor();
-
-        auto adjacency_matrix = SparsityMatrix::create(cpu_exec);
-        array<IndexType> degrees;
-
-        // The adjacency matrix has to be square.
-        GKO_ASSERT_IS_SQUARE_MATRIX(args.system_matrix);
-        // This is needed because it does not make sense to call the copy and
-        // convert if the existing matrix is empty.
-        if (args.system_matrix->get_size()) {
-            auto tmp = copy_and_convert_to<SparsityMatrix>(cpu_exec,
-                                                           args.system_matrix);
-            // This function provided within the Sparsity matrix format removes
-            // the diagonal elements and outputs an adjacency matrix.
-            adjacency_matrix = tmp->to_adjacency_matrix();
-        }
-
-        auto const dim = adjacency_matrix->get_size();
-        permutation_ = PermutationMatrix::create(cpu_exec, dim);
-
-        // To make it explicit.
-        inv_permutation_ = nullptr;
-        if (parameters_.construct_inverse_permutation) {
-            inv_permutation_ = PermutationMatrix::create(cpu_exec, dim);
-        }
-
-        this->generate(cpu_exec, std::move(adjacency_matrix));
-
-        // Copy back results to gpu if necessary.
-        if (is_gpu_executor) {
-            const auto gpu_exec = this->get_executor();
-            auto gpu_perm = share(PermutationMatrix::create(gpu_exec, dim));
-            gpu_perm->copy_from(permutation_.get());
-            permutation_ = gpu_perm;
-            if (inv_permutation_) {
-                auto gpu_inv_perm =
-                    share(PermutationMatrix::create(gpu_exec, dim));
-                gpu_inv_perm->copy_from(inv_permutation_.get());
-                inv_permutation_ = gpu_inv_perm;
-            }
-        }
-    }
+    explicit Rcm(const Factory* factory, const ReorderingBaseArgs& args);
 
 private:
     std::shared_ptr<PermutationMatrix> permutation_;

--- a/include/ginkgo/core/solver/bicg.hpp
+++ b/include/ginkgo/core/solver/bicg.hpp
@@ -97,7 +97,7 @@ public:
      *
      * @return true as iterative solvers use the data in x as an initial guess.
      */
-    bool apply_uses_initial_guess() const override { return true; }
+    bool apply_uses_initial_guess() const override;
 
     GKO_CREATE_FACTORY_PARAMETERS(parameters, Factory)
     {
@@ -132,18 +132,10 @@ protected:
     void apply_impl(const LinOp* alpha, const LinOp* b, const LinOp* beta,
                     LinOp* x) const override;
 
-    explicit Bicg(std::shared_ptr<const Executor> exec)
-        : EnableLinOp<Bicg>(std::move(exec))
-    {}
+    explicit Bicg(std::shared_ptr<const Executor> exec);
 
     explicit Bicg(const Factory* factory,
-                  std::shared_ptr<const LinOp> system_matrix)
-        : EnableLinOp<Bicg>(factory->get_executor(),
-                            gko::transpose(system_matrix->get_size())),
-          EnablePreconditionedIterativeSolver<ValueType, Bicg<ValueType>>{
-              std::move(system_matrix), factory->get_parameters()},
-          parameters_{factory->get_parameters()}
-    {}
+                  std::shared_ptr<const LinOp> system_matrix);
 };
 
 

--- a/include/ginkgo/core/solver/bicgstab.hpp
+++ b/include/ginkgo/core/solver/bicgstab.hpp
@@ -96,7 +96,7 @@ public:
      *
      * @return true as iterative solvers use the data in x as an initial guess.
      */
-    bool apply_uses_initial_guess() const override { return true; }
+    bool apply_uses_initial_guess() const override;
 
     GKO_CREATE_FACTORY_PARAMETERS(parameters, Factory)
     {
@@ -131,18 +131,10 @@ protected:
     void apply_impl(const LinOp* alpha, const LinOp* b, const LinOp* beta,
                     LinOp* x) const override;
 
-    explicit Bicgstab(std::shared_ptr<const Executor> exec)
-        : EnableLinOp<Bicgstab>(std::move(exec))
-    {}
+    explicit Bicgstab(std::shared_ptr<const Executor> exec);
 
     explicit Bicgstab(const Factory* factory,
-                      std::shared_ptr<const LinOp> system_matrix)
-        : EnableLinOp<Bicgstab>(factory->get_executor(),
-                                gko::transpose(system_matrix->get_size())),
-          EnablePreconditionedIterativeSolver<ValueType, Bicgstab<ValueType>>{
-              std::move(system_matrix), factory->get_parameters()},
-          parameters_{factory->get_parameters()}
-    {}
+                      std::shared_ptr<const LinOp> system_matrix);
 };
 
 

--- a/include/ginkgo/core/solver/cb_gmres.hpp
+++ b/include/ginkgo/core/solver/cb_gmres.hpp
@@ -134,24 +134,28 @@ public:
      *
      * @return the Krylov dimension
      */
-    size_type get_krylov_dim() const { return parameters_.krylov_dim; }
+    size_type get_krylov_dim() const;
 
     /**
      * Sets the Krylov dimension
      *
      * @param other  the new Krylov dimension
      */
-    void set_krylov_dim(size_type other) { parameters_.krylov_dim = other; }
+    void set_krylov_dim(size_type other);
 
     /**
      * Returns the storage precision used internally.
      *
      * @return the storage precision used internally
      */
-    cb_gmres::storage_precision get_storage_precision() const
-    {
-        return parameters_.storage_precision;
-    }
+    cb_gmres::storage_precision get_storage_precision() const;
+
+    /**
+     * Return true as iterative solvers use the data in x as an initial guess.
+     *
+     * @return true as iterative solvers use the data in x as an initial guess.
+     */
+    bool apply_uses_initial_guess() const override;
 
     GKO_CREATE_FACTORY_PARAMETERS(parameters, Factory)
     {
@@ -197,18 +201,10 @@ protected:
     void apply_impl(const LinOp* alpha, const LinOp* b, const LinOp* beta,
                     LinOp* x) const override;
 
-    explicit CbGmres(std::shared_ptr<const Executor> exec)
-        : EnableLinOp<CbGmres>(std::move(exec))
-    {}
+    explicit CbGmres(std::shared_ptr<const Executor> exec);
 
     explicit CbGmres(const Factory* factory,
-                     std::shared_ptr<const LinOp> system_matrix)
-        : EnableLinOp<CbGmres>(factory->get_executor(),
-                               transpose(system_matrix->get_size())),
-          EnablePreconditionedIterativeSolver<ValueType, CbGmres<ValueType>>{
-              std::move(system_matrix), factory->get_parameters()},
-          parameters_{factory->get_parameters()}
-    {}
+                     std::shared_ptr<const LinOp> system_matrix);
 };
 
 

--- a/include/ginkgo/core/solver/cg.hpp
+++ b/include/ginkgo/core/solver/cg.hpp
@@ -90,7 +90,7 @@ public:
      *
      * @return true as iterative solvers use the data in x as an initial guess.
      */
-    bool apply_uses_initial_guess() const override { return true; }
+    bool apply_uses_initial_guess() const override;
 
     GKO_CREATE_FACTORY_PARAMETERS(parameters, Factory)
     {
@@ -125,18 +125,10 @@ protected:
     void apply_impl(const LinOp* alpha, const LinOp* b, const LinOp* beta,
                     LinOp* x) const override;
 
-    explicit Cg(std::shared_ptr<const Executor> exec)
-        : EnableLinOp<Cg>(std::move(exec))
-    {}
+    explicit Cg(std::shared_ptr<const Executor> exec);
 
     explicit Cg(const Factory* factory,
-                std::shared_ptr<const LinOp> system_matrix)
-        : EnableLinOp<Cg>(factory->get_executor(),
-                          gko::transpose(system_matrix->get_size())),
-          EnablePreconditionedIterativeSolver<ValueType, Cg<ValueType>>{
-              std::move(system_matrix), factory->get_parameters()},
-          parameters_{factory->get_parameters()}
-    {}
+                std::shared_ptr<const LinOp> system_matrix);
 };
 
 

--- a/include/ginkgo/core/solver/cgs.hpp
+++ b/include/ginkgo/core/solver/cgs.hpp
@@ -88,7 +88,7 @@ public:
      *
      * @return true as iterative solvers use the data in x as an initial guess.
      */
-    bool apply_uses_initial_guess() const override { return true; }
+    bool apply_uses_initial_guess() const override;
 
     GKO_CREATE_FACTORY_PARAMETERS(parameters, Factory)
     {
@@ -123,18 +123,10 @@ protected:
     void apply_impl(const LinOp* alpha, const LinOp* b, const LinOp* beta,
                     LinOp* x) const override;
 
-    explicit Cgs(std::shared_ptr<const Executor> exec)
-        : EnableLinOp<Cgs>(std::move(exec))
-    {}
+    explicit Cgs(std::shared_ptr<const Executor> exec);
 
     explicit Cgs(const Factory* factory,
-                 std::shared_ptr<const LinOp> system_matrix)
-        : EnableLinOp<Cgs>(factory->get_executor(),
-                           gko::transpose(system_matrix->get_size())),
-          EnablePreconditionedIterativeSolver<ValueType, Cgs<ValueType>>{
-              std::move(system_matrix), factory->get_parameters()},
-          parameters_{factory->get_parameters()}
-    {}
+                 std::shared_ptr<const LinOp> system_matrix);
 };
 
 

--- a/include/ginkgo/core/solver/fcg.hpp
+++ b/include/ginkgo/core/solver/fcg.hpp
@@ -96,7 +96,7 @@ public:
      *
      * @return true as iterative solvers use the data in x as an initial guess.
      */
-    bool apply_uses_initial_guess() const override { return true; }
+    bool apply_uses_initial_guess() const override;
 
     GKO_CREATE_FACTORY_PARAMETERS(parameters, Factory)
     {
@@ -131,18 +131,10 @@ protected:
     void apply_impl(const LinOp* alpha, const LinOp* b, const LinOp* beta,
                     LinOp* x) const override;
 
-    explicit Fcg(std::shared_ptr<const Executor> exec)
-        : EnableLinOp<Fcg>(std::move(exec))
-    {}
+    explicit Fcg(std::shared_ptr<const Executor> exec);
 
     explicit Fcg(const Factory* factory,
-                 std::shared_ptr<const LinOp> system_matrix)
-        : EnableLinOp<Fcg>(factory->get_executor(),
-                           gko::transpose(system_matrix->get_size())),
-          EnablePreconditionedIterativeSolver<ValueType, Fcg<ValueType>>{
-              std::move(system_matrix), factory->get_parameters()},
-          parameters_{factory->get_parameters()}
-    {}
+                 std::shared_ptr<const LinOp> system_matrix);
 };
 
 

--- a/include/ginkgo/core/solver/gmres.hpp
+++ b/include/ginkgo/core/solver/gmres.hpp
@@ -91,21 +91,21 @@ public:
      *
      * @return true as iterative solvers use the data in x as an initial guess.
      */
-    bool apply_uses_initial_guess() const override { return true; }
+    bool apply_uses_initial_guess() const override;
 
     /**
      * Gets the Krylov dimension of the solver
      *
      * @return the Krylov dimension
      */
-    size_type get_krylov_dim() const { return parameters_.krylov_dim; }
+    size_type get_krylov_dim() const;
 
     /**
      * Sets the Krylov dimension
      *
      * @param other  the new Krylov dimension
      */
-    void set_krylov_dim(size_type other) { parameters_.krylov_dim = other; }
+    void set_krylov_dim(size_type other);
 
     GKO_CREATE_FACTORY_PARAMETERS(parameters, Factory)
     {
@@ -145,22 +145,10 @@ protected:
     void apply_impl(const LinOp* alpha, const LinOp* b, const LinOp* beta,
                     LinOp* x) const override;
 
-    explicit Gmres(std::shared_ptr<const Executor> exec)
-        : EnableLinOp<Gmres>(std::move(exec))
-    {}
+    explicit Gmres(std::shared_ptr<const Executor> exec);
 
     explicit Gmres(const Factory* factory,
-                   std::shared_ptr<const LinOp> system_matrix)
-        : EnableLinOp<Gmres>(factory->get_executor(),
-                             gko::transpose(system_matrix->get_size())),
-          EnablePreconditionedIterativeSolver<ValueType, Gmres<ValueType>>{
-              std::move(system_matrix), factory->get_parameters()},
-          parameters_{factory->get_parameters()}
-    {
-        if (!parameters_.krylov_dim) {
-            parameters_.krylov_dim = default_krylov_dim;
-        }
-    }
+                   std::shared_ptr<const LinOp> system_matrix);
 };
 
 

--- a/include/ginkgo/core/solver/idr.hpp
+++ b/include/ginkgo/core/solver/idr.hpp
@@ -100,73 +100,61 @@ public:
      *
      * @return true as iterative solvers use the data in x as an initial guess.
      */
-    bool apply_uses_initial_guess() const override { return true; }
+    bool apply_uses_initial_guess() const override;
 
     /**
      * Gets the subspace dimension of the solver.
      *
      * @return the subspace Dimension*/
-    size_type get_subspace_dim() const { return parameters_.subspace_dim; }
+    size_type get_subspace_dim() const;
 
     /**
      * Sets the subspace dimension of the solver.
      *
      * @param other  the new subspace Dimension*/
-    void set_subspace_dim(const size_type other)
-    {
-        parameters_.subspace_dim = other;
-    }
+    void set_subspace_dim(const size_type other);
 
     /**
      * Gets the kappa parameter of the solver.
      *
      * @return the kappa parameter
      */
-    remove_complex<ValueType> get_kappa() const { return parameters_.kappa; }
+    remove_complex<ValueType> get_kappa() const;
 
     /**
      * Sets the kappa parameter of the solver.
      *
      * @param other  the new kappa parameter
      */
-    void set_kappa(const remove_complex<ValueType> other)
-    {
-        parameters_.kappa = other;
-    }
+    void set_kappa(const remove_complex<ValueType> other);
 
     /**
      * Gets the deterministic parameter of the solver.
      *
      * @return the deterministic parameter
      */
-    bool get_deterministic() const { return parameters_.deterministic; }
+    bool get_deterministic() const;
 
     /**
      * Sets the deterministic parameter of the solver.
      *
      * @param other  the new deterministic parameter
      */
-    void set_deterministic(const bool other)
-    {
-        parameters_.deterministic = other;
-    }
+    void set_deterministic(const bool other);
 
     /**
      * Gets the complex_subspace parameter of the solver.
      *
      * @return the complex_subspace parameter
      */
-    bool get_complex_subspace() const { return parameters_.complex_subspace; }
+    bool get_complex_subspace() const;
 
     /**
      * Sets the complex_subspace parameter of the solver.
      *
      * @param other  the new complex_subspace parameter
      */
-    void set_complex_subpsace(const bool other)
-    {
-        parameters_.complex_subspace = other;
-    }
+    void set_complex_subpsace(const bool other);
 
     GKO_CREATE_FACTORY_PARAMETERS(parameters, Factory)
     {
@@ -236,18 +224,10 @@ protected:
     void iterate(const matrix::Dense<SubspaceType>* dense_b,
                  matrix::Dense<SubspaceType>* dense_x) const;
 
-    explicit Idr(std::shared_ptr<const Executor> exec)
-        : EnableLinOp<Idr>(std::move(exec))
-    {}
+    explicit Idr(std::shared_ptr<const Executor> exec);
 
     explicit Idr(const Factory* factory,
-                 std::shared_ptr<const LinOp> system_matrix)
-        : EnableLinOp<Idr>(factory->get_executor(),
-                           gko::transpose(system_matrix->get_size())),
-          EnablePreconditionedIterativeSolver<ValueType, Idr<ValueType>>{
-              std::move(system_matrix), factory->get_parameters()},
-          parameters_{factory->get_parameters()}
-    {}
+                 std::shared_ptr<const LinOp> system_matrix);
 };
 
 

--- a/include/ginkgo/core/solver/triangular.hpp
+++ b/include/ginkgo/core/solver/triangular.hpp
@@ -180,21 +180,10 @@ protected:
      */
     void generate();
 
-    explicit LowerTrs(std::shared_ptr<const Executor> exec)
-        : EnableLinOp<LowerTrs>(std::move(exec))
-    {}
+    explicit LowerTrs(std::shared_ptr<const Executor> exec);
 
     explicit LowerTrs(const Factory* factory,
-                      std::shared_ptr<const LinOp> system_matrix)
-        : EnableLinOp<LowerTrs>(factory->get_executor(),
-                                gko::transpose(system_matrix->get_size())),
-          EnableSolverBase<LowerTrs<ValueType, IndexType>, CsrMatrix>{
-              copy_and_convert_to<CsrMatrix>(factory->get_executor(),
-                                             system_matrix)},
-          parameters_{factory->get_parameters()}
-    {
-        this->generate();
-    }
+                      std::shared_ptr<const LinOp> system_matrix);
 
 private:
     std::shared_ptr<solver::SolveStruct> solve_struct_;
@@ -333,21 +322,10 @@ protected:
      */
     void generate();
 
-    explicit UpperTrs(std::shared_ptr<const Executor> exec)
-        : EnableLinOp<UpperTrs>(std::move(exec))
-    {}
+    explicit UpperTrs(std::shared_ptr<const Executor> exec);
 
     explicit UpperTrs(const Factory* factory,
-                      std::shared_ptr<const LinOp> system_matrix)
-        : EnableLinOp<UpperTrs>(factory->get_executor(),
-                                gko::transpose(system_matrix->get_size())),
-          EnableSolverBase<UpperTrs<ValueType, IndexType>, CsrMatrix>{
-              copy_and_convert_to<CsrMatrix>(factory->get_executor(),
-                                             system_matrix)},
-          parameters_{factory->get_parameters()}
-    {
-        this->generate();
-    }
+                      std::shared_ptr<const LinOp> system_matrix);
 
 private:
     std::shared_ptr<solver::SolveStruct> solve_struct_;

--- a/include/ginkgo/core/stop/combined.hpp
+++ b/include/ginkgo/core/stop/combined.hpp
@@ -78,25 +78,9 @@ protected:
                     array<stopping_status>* stop_status, bool* one_changed,
                     const Updater&) override;
 
-    explicit Combined(std::shared_ptr<const gko::Executor> exec)
-        : EnablePolymorphicObject<Combined, Criterion>(std::move(exec))
-    {}
+    explicit Combined(std::shared_ptr<const gko::Executor> exec);
 
-    explicit Combined(const Factory* factory, const CriterionArgs& args)
-        : EnablePolymorphicObject<Combined, Criterion>(factory->get_executor()),
-          parameters_{factory->get_parameters()}
-    {
-        for (const auto& f : parameters_.criteria) {
-            // Ignore the nullptr from the list
-            if (f != nullptr) {
-                criteria_.push_back(f->generate(args));
-            }
-        }
-        // If the list are empty or all nullptr, throw gko::NotSupported
-        if (criteria_.size() == 0) {
-            GKO_NOT_SUPPORTED(this);
-        }
-    }
+    explicit Combined(const Factory* factory, const CriterionArgs& args);
 
 private:
     std::vector<std::unique_ptr<Criterion>> criteria_{};

--- a/include/ginkgo/core/stop/criterion.hpp
+++ b/include/ginkgo/core/stop/criterion.hpp
@@ -104,24 +104,45 @@ public:
             return converged;
         }
 
-        /**
-         * Helper macro to add parameters and setters to updater
-         */
-#define GKO_UPDATER_REGISTER_PARAMETER(_type, _name) \
-    const Updater& _name(_type const& value) const   \
-    {                                                \
-        _name##_ = value;                            \
-        return *this;                                \
-    }                                                \
-    mutable _type _name##_ {}
+        size_type num_iterations_{};
 
-        GKO_UPDATER_REGISTER_PARAMETER(size_type, num_iterations);
-        GKO_UPDATER_REGISTER_PARAMETER(const LinOp*, residual);
-        GKO_UPDATER_REGISTER_PARAMETER(const LinOp*, residual_norm);
-        GKO_UPDATER_REGISTER_PARAMETER(const LinOp*, implicit_sq_residual_norm);
-        GKO_UPDATER_REGISTER_PARAMETER(const LinOp*, solution);
+        const LinOp* residual_{};
 
-#undef GKO_UPDATER_REGISTER_PARAMETER
+        const LinOp* residual_norm_{};
+
+        const LinOp* implicit_sq_residual_norm_{};
+
+        const LinOp* solution_{};
+
+        Updater& num_iterations(size_type const& value)
+        {
+            num_iterations_ = value;
+            return *this;
+        }
+
+        Updater& residual(const LinOp* const& value)
+        {
+            residual_ = value;
+            return *this;
+        }
+
+        Updater& residual_norm(const LinOp* const& value)
+        {
+            residual_norm_ = value;
+            return *this;
+        }
+
+        Updater& implicit_sq_residual_norm(const LinOp* const& value)
+        {
+            implicit_sq_residual_norm_ = value;
+            return *this;
+        }
+
+        Updater& solution(const LinOp* const& value)
+        {
+            solution_ = value;
+            return *this;
+        }
 
     private:
         Updater(Criterion* parent) : parent_{parent} {}
@@ -151,21 +172,7 @@ public:
      */
     bool check(uint8 stopping_id, bool set_finalized,
                array<stopping_status>* stop_status, bool* one_changed,
-               const Updater& updater)
-    {
-        this->template log<log::Logger::criterion_check_started>(
-            this, updater.num_iterations_, updater.residual_,
-            updater.residual_norm_, updater.solution_, stopping_id,
-            set_finalized);
-        auto all_converged = this->check_impl(
-            stopping_id, set_finalized, stop_status, one_changed, updater);
-        this->template log<log::Logger::criterion_check_completed>(
-            this, updater.num_iterations_, updater.residual_,
-            updater.residual_norm_, updater.implicit_sq_residual_norm_,
-            updater.solution_, stopping_id, set_finalized, stop_status,
-            *one_changed, all_converged);
-        return all_converged;
-    }
+               const Updater& updater);
 
 protected:
     /**
@@ -201,9 +208,7 @@ protected:
     void set_all_statuses(uint8 stopping_id, bool set_finalized,
                           array<stopping_status>* stop_status);
 
-    explicit Criterion(std::shared_ptr<const gko::Executor> exec)
-        : EnableAbstractPolymorphicObject<Criterion>(exec)
-    {}
+    explicit Criterion(std::shared_ptr<const gko::Executor> exec);
 };
 
 
@@ -223,15 +228,9 @@ struct CriterionArgs {
     const LinOp* x;
     const LinOp* initial_residual;
 
-
     CriterionArgs(std::shared_ptr<const LinOp> system_matrix,
                   std::shared_ptr<const LinOp> b, const LinOp* x,
-                  const LinOp* initial_residual = nullptr)
-        : system_matrix{system_matrix},
-          b{b},
-          x{x},
-          initial_residual{initial_residual}
-    {}
+                  const LinOp* initial_residual = nullptr);
 };
 
 

--- a/include/ginkgo/core/stop/iteration.hpp
+++ b/include/ginkgo/core/stop/iteration.hpp
@@ -68,15 +68,9 @@ protected:
                     array<stopping_status>* stop_status, bool* one_changed,
                     const Updater& updater) override;
 
-    explicit Iteration(std::shared_ptr<const gko::Executor> exec)
-        : EnablePolymorphicObject<Iteration, Criterion>(std::move(exec))
-    {}
+    explicit Iteration(std::shared_ptr<const gko::Executor> exec);
 
-    explicit Iteration(const Factory* factory, const CriterionArgs& args)
-        : EnablePolymorphicObject<Iteration, Criterion>(
-              factory->get_executor()),
-          parameters_{factory->get_parameters()}
-    {}
+    explicit Iteration(const Factory* factory, const CriterionArgs& args);
 };
 
 

--- a/include/ginkgo/core/stop/time.hpp
+++ b/include/ginkgo/core/stop/time.hpp
@@ -71,19 +71,9 @@ protected:
                     array<stopping_status>* stop_status, bool* one_changed,
                     const Updater&) override;
 
-    explicit Time(std::shared_ptr<const gko::Executor> exec)
-        : EnablePolymorphicObject<Time, Criterion>(std::move(exec)),
-          time_limit_{},
-          start_{}
-    {}
+    explicit Time(std::shared_ptr<const gko::Executor> exec);
 
-    explicit Time(const Factory* factory, const CriterionArgs args)
-        : EnablePolymorphicObject<Time, Criterion>(factory->get_executor()),
-          parameters_{factory->get_parameters()},
-          time_limit_{std::chrono::duration<double>(
-              factory->get_parameters().time_limit)},
-          start_{clock::now()}
-    {}
+    explicit Time(const Factory* factory, const CriterionArgs args);
 
 private:
     /**


### PR DESCRIPTION
This PR moves almost all function implementations from headers to source files. This should make the headers easier to read and maybe also faster to compile.

To finish this up, I would like to suggest additional changes:

* I held off on MPI, since the interface is still in flux, but lots of the non-templated functions could be moved to source files as well
* Dense::at should be deprecated in favor of a function that returns a row-major accessor. This gives us a single consistent, but efficient way of accessing entries.
* Ell::val_at and Ell::col_at should in the same way be replaced by a column-major accessor
* For Sellp, Fbcsr and Csr, it might make sense to also provide accessors with variable-size semantics, but I haven't thought this part through yet. At least Sellp has similar access functions to Ell, so it would probably be a good start.

TODO:
- [ ] Deal with ExecutorBase - that probably requires creating a new library `ginkgo_executor` that has all executor-specific functionality, and implement it for different backends. That would also slim down our link dependencies a bit. ![graphviz](https://user-images.githubusercontent.com/1693511/187080353-51d356f1-925b-42de-af91-56c9ddb2f8e0.png)

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1202932419787352