### PR TITLE
Add fallback transpose kernel

### DIFF
--- a/.gitlab/scripts.yml
+++ b/.gitlab/scripts.yml
@@ -94,7 +94,7 @@
     - ninja -j${NUM_CORES} -l${CI_LOAD_LIMIT} install
     - |
         (( $(ctest -N | tail -1 | sed 's/Total Tests: //') != 0 )) || exit 1
-    - ctest -V --timeout 3000
+    - ctest -V --timeout 6000
     - ninja test_install
     - pushd test/test_install
     - ninja install
@@ -145,7 +145,7 @@
     - cd ${CI_JOB_NAME/test/build}
     - |
         (( $(ctest -N | tail -1 | sed 's/Total Tests: //') != 0 )) || exit 1
-    - ctest -V --timeout 3000
+    - ctest -V --timeout 6000
     - ninja test_install
     - pushd test/test_install
     - ninja install

--- a/common/cuda_hip/matrix/csr_kernels.hpp.inc
+++ b/common/cuda_hip/matrix/csr_kernels.hpp.inc
@@ -1122,17 +1122,11 @@ void fallback_transpose(std::shared_ptr<const DefaultExecutor> exec,
                                      out_col_idxs);
     exec->copy(nnz, in_vals, out_vals);
     exec->copy(nnz, in_col_idxs, out_row_idxs.get_data());
-    auto zip_it = thrust::make_zip_iterator(
-        thrust::make_tuple(thrust::device_pointer_cast(out_row_idxs.get_data()),
-                           thrust::device_pointer_cast(out_col_idxs),
-                           thrust::device_pointer_cast(out_vals)));
+    auto loc_it = thrust::make_zip_iterator(
+        thrust::make_tuple(out_row_idxs.get_data(), out_col_idxs));
     using tuple_type =
-        thrust::tuple<IndexType, IndexType, device_member_type<ValueType>>;
-    thrust::sort(thrust::device, zip_it, zip_it + nnz,
-                 [] __device__(const tuple_type& a, const tuple_type& b) {
-                     return thrust::tie(thrust::get<0>(a), thrust::get<1>(a)) <
-                            thrust::tie(thrust::get<0>(b), thrust::get<1>(b));
-                 });
+        thrust::tuple<IndexType, IndexType, device_type<ValueType>>;
+    thrust::sort_by_key(thrust::device, loc_it, loc_it + nnz, out_vals);
     components::convert_idxs_to_ptrs(exec, out_row_idxs.get_data(), nnz,
                                      out_num_rows, out_row_ptrs);
 }

--- a/common/cuda_hip/matrix/csr_kernels.hpp.inc
+++ b/common/cuda_hip/matrix/csr_kernels.hpp.inc
@@ -1098,3 +1098,38 @@ void build_lookup(std::shared_ptr<const DefaultExecutor> exec,
 }
 
 GKO_INSTANTIATE_FOR_EACH_INDEX_TYPE(GKO_DECLARE_CSR_BUILD_LOOKUP_KERNEL);
+
+
+template <typename ValueType, typename IndexType>
+void fallback_transpose(std::shared_ptr<const DefaultExecutor> exec,
+                        const matrix::Csr<ValueType, IndexType>* input,
+                        matrix::Csr<ValueType, IndexType>* output)
+{
+    const auto in_num_rows = input->get_size()[0];
+    const auto out_num_rows = output->get_size()[0];
+    const auto nnz = output->get_num_stored_elements();
+    const auto in_row_ptrs = input->get_const_row_ptrs();
+    const auto in_col_idxs = input->get_const_col_idxs();
+    const auto in_vals = as_device_type(input->get_const_values());
+    const auto out_row_ptrs = output->get_row_ptrs();
+    const auto out_col_idxs = output->get_col_idxs();
+    const auto out_vals = as_device_type(output->get_values());
+    array<IndexType> out_row_idxs{exec, nnz};
+    components::convert_ptrs_to_idxs(exec, in_row_ptrs, in_num_rows,
+                                     out_col_idxs);
+    exec->copy(nnz, in_vals, out_vals);
+    exec->copy(nnz, in_col_idxs, out_row_idxs.get_data());
+    auto zip_it = thrust::make_zip_iterator(
+        thrust::make_tuple(thrust::device_pointer_cast(out_row_idxs.get_data()),
+                           thrust::device_pointer_cast(out_col_idxs),
+                           thrust::device_pointer_cast(out_vals)));
+    using tuple_type =
+        thrust::tuple<IndexType, IndexType, cuda_type<ValueType>>;
+    thrust::sort(thrust::device, zip_it, zip_it + nnz,
+                 [] __device__(const tuple_type& a, const tuple_type& b) {
+                     return thrust::tie(thrust::get<0>(a), thrust::get<1>(a)) <
+                            thrust::tie(thrust::get<0>(b), thrust::get<1>(b));
+                 });
+    components::convert_idxs_to_ptrs(exec, out_row_idxs.get_data(), nnz,
+                                     out_num_rows, out_row_ptrs);
+}

--- a/common/cuda_hip/matrix/csr_kernels.hpp.inc
+++ b/common/cuda_hip/matrix/csr_kernels.hpp.inc
@@ -1110,10 +1110,13 @@ void fallback_transpose(std::shared_ptr<const DefaultExecutor> exec,
     const auto nnz = output->get_num_stored_elements();
     const auto in_row_ptrs = input->get_const_row_ptrs();
     const auto in_col_idxs = input->get_const_col_idxs();
-    const auto in_vals = as_device_type(input->get_const_values());
+    // workaround for CUDA 9.2 Thrust unconstrained constructor issues
+    const auto in_vals = reinterpret_cast<const device_member_type<ValueType>*>(
+        input->get_const_values());
     const auto out_row_ptrs = output->get_row_ptrs();
     const auto out_col_idxs = output->get_col_idxs();
-    const auto out_vals = as_device_type(output->get_values());
+    const auto out_vals =
+        reinterpret_cast<device_member_type<ValueType>*>(output->get_values());
     array<IndexType> out_row_idxs{exec, nnz};
     components::convert_ptrs_to_idxs(exec, in_row_ptrs, in_num_rows,
                                      out_col_idxs);
@@ -1124,7 +1127,7 @@ void fallback_transpose(std::shared_ptr<const DefaultExecutor> exec,
                            thrust::device_pointer_cast(out_col_idxs),
                            thrust::device_pointer_cast(out_vals)));
     using tuple_type =
-        thrust::tuple<IndexType, IndexType, device_type<ValueType>>;
+        thrust::tuple<IndexType, IndexType, device_member_type<ValueType>>;
     thrust::sort(thrust::device, zip_it, zip_it + nnz,
                  [] __device__(const tuple_type& a, const tuple_type& b) {
                      return thrust::tie(thrust::get<0>(a), thrust::get<1>(a)) <

--- a/common/cuda_hip/matrix/csr_kernels.hpp.inc
+++ b/common/cuda_hip/matrix/csr_kernels.hpp.inc
@@ -1124,7 +1124,7 @@ void fallback_transpose(std::shared_ptr<const DefaultExecutor> exec,
                            thrust::device_pointer_cast(out_col_idxs),
                            thrust::device_pointer_cast(out_vals)));
     using tuple_type =
-        thrust::tuple<IndexType, IndexType, cuda_type<ValueType>>;
+        thrust::tuple<IndexType, IndexType, device_type<ValueType>>;
     thrust::sort(thrust::device, zip_it, zip_it + nnz,
                  [] __device__(const tuple_type& a, const tuple_type& b) {
                      return thrust::tie(thrust::get<0>(a), thrust::get<1>(a)) <

--- a/common/cuda_hip/matrix/fbcsr_kernels.hpp.inc
+++ b/common/cuda_hip/matrix/fbcsr_kernels.hpp.inc
@@ -244,3 +244,68 @@ void fill_in_matrix_data(std::shared_ptr<const DefaultExecutor> exec,
 
 GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
     GKO_DECLARE_FBCSR_FILL_IN_MATRIX_DATA_KERNEL);
+
+
+namespace kernel {
+
+
+template <typename ValueType, typename IndexType>
+__global__ void __launch_bounds__(default_block_size)
+    permute_transpose(const ValueType* __restrict__ in,
+                      ValueType* __restrict__ out, int bs, size_type nnzb,
+                      const IndexType* perm)
+{
+    const auto idx = thread::get_thread_id_flat();
+    const auto block = idx / (bs * bs);
+    const auto i = (idx % (bs * bs)) / bs;
+    const auto j = idx % bs;
+    if (block < nnzb) {
+        out[block * bs * bs + j * bs + i] =
+            in[perm[block] * bs * bs + i * bs + j];
+    }
+}
+
+
+}  // namespace kernel
+
+
+template <typename ValueType, typename IndexType>
+void fallback_transpose(const std::shared_ptr<const DefaultExecutor> exec,
+                        const matrix::Fbcsr<ValueType, IndexType>* const input,
+                        matrix::Fbcsr<ValueType, IndexType>* const output)
+{
+    const auto in_num_row_blocks = input->get_num_block_rows();
+    const auto out_num_row_blocks = output->get_num_block_rows();
+    const auto nnzb = output->get_num_stored_blocks();
+    const auto bs = input->get_block_size();
+    const auto in_row_ptrs = input->get_const_row_ptrs();
+    const auto in_col_idxs = input->get_const_col_idxs();
+    const auto in_vals = as_device_type(input->get_const_values());
+    const auto out_row_ptrs = output->get_row_ptrs();
+    const auto out_col_idxs = output->get_col_idxs();
+    const auto out_vals = as_device_type(output->get_values());
+    array<IndexType> out_row_idxs{exec, nnzb};
+    array<IndexType> permutation{exec, nnzb};
+    components::fill_seq_array(exec, permutation.get_data(), nnzb);
+    components::convert_ptrs_to_idxs(exec, in_row_ptrs, in_num_row_blocks,
+                                     out_col_idxs);
+    exec->copy(nnzb, in_col_idxs, out_row_idxs.get_data());
+    auto zip_it = thrust::make_zip_iterator(thrust::make_tuple(
+        thrust::device_pointer_cast(out_row_idxs.get_data()),
+        thrust::device_pointer_cast(out_col_idxs),
+        thrust::device_pointer_cast(permutation.get_data())));
+    using tuple_type =
+        thrust::tuple<IndexType, IndexType, device_type<ValueType>>;
+    thrust::sort(thrust::device, zip_it, zip_it + nnzb,
+                 [] __device__(const tuple_type& a, const tuple_type& b) {
+                     return thrust::tie(thrust::get<0>(a), thrust::get<1>(a)) <
+                            thrust::tie(thrust::get<0>(b), thrust::get<1>(b));
+                 });
+    components::convert_idxs_to_ptrs(exec, out_row_idxs.get_data(), nnzb,
+                                     out_num_row_blocks, out_row_ptrs);
+    const auto grid_size = ceildiv(nnzb * bs * bs, default_block_size);
+    if (grid_size > 0) {
+        kernel::permute_transpose<<<grid_size, default_block_size>>>(
+            in_vals, out_vals, bs, nnzb, permutation.get_const_data());
+    }
+}

--- a/cuda/matrix/csr_kernels.cu
+++ b/cuda/matrix/csr_kernels.cu
@@ -1008,7 +1008,7 @@ void conj_transpose(std::shared_ptr<const CudaExecutor> exec,
     } else {
         fallback_transpose(exec, orig, trans);
     }
-    if (grid_size > 0) {
+    if (grid_size > 0 && is_complex<ValueType>()) {
         kernel::conjugate<<<grid_size, block_size, 0, 0>>>(
             trans->get_num_stored_elements(),
             as_cuda_type(trans->get_values()));

--- a/cuda/matrix/fbcsr_kernels.cu
+++ b/cuda/matrix/fbcsr_kernels.cu
@@ -340,7 +340,7 @@ void transpose(const std::shared_ptr<const CudaExecutor> exec,
             [bs](int compiled_block_size) { return bs == compiled_block_size; },
             syn::value_list<int>(), syn::type_list<>(), trans);
     } else {
-        GKO_NOT_IMPLEMENTED;
+        fallback_transpose(exec, orig, trans);
     }
 }
 
@@ -356,7 +356,7 @@ void conj_transpose(std::shared_ptr<const CudaExecutor> exec,
     const int grid_size =
         ceildiv(trans->get_num_stored_elements(), default_block_size);
     transpose(exec, orig, trans);
-    if (grid_size > 0) {
+    if (grid_size > 0 && is_complex<ValueType>()) {
         kernel::conjugate<<<grid_size, default_block_size>>>(
             trans->get_num_stored_elements(),
             as_cuda_type(trans->get_values()));

--- a/cuda/test/matrix/csr_kernels.cpp
+++ b/cuda/test/matrix/csr_kernels.cpp
@@ -500,12 +500,40 @@ TEST_F(Csr, TransposeIsEquivalentToRef)
 }
 
 
+TEST_F(Csr, Transpose64IsEquivalentToRef)
+{
+    using Mtx64 = gko::matrix::Csr<double, gko::int64>;
+    auto mtx = gen_mtx<Mtx64>(123, 234, 0);
+    auto dmtx = gko::clone(cuda, mtx);
+
+    auto trans = gko::as<Mtx64>(mtx->transpose());
+    auto d_trans = gko::as<Mtx64>(dmtx->transpose());
+
+    GKO_ASSERT_MTX_NEAR(d_trans, trans, 0.0);
+    ASSERT_TRUE(d_trans->is_sorted_by_column_index());
+}
+
+
 TEST_F(Csr, ConjugateTransposeIsEquivalentToRef)
 {
     set_up_apply_complex_data(std::make_shared<ComplexMtx::automatical>(cuda));
 
     auto trans = gko::as<ComplexMtx>(complex_mtx->conj_transpose());
     auto d_trans = gko::as<ComplexMtx>(complex_dmtx->conj_transpose());
+
+    GKO_ASSERT_MTX_NEAR(d_trans, trans, 0.0);
+    ASSERT_TRUE(d_trans->is_sorted_by_column_index());
+}
+
+
+TEST_F(Csr, ConjugateTranspose64IsEquivalentToRef)
+{
+    using Mtx64 = gko::matrix::Csr<double, gko::int64>;
+    auto mtx = gen_mtx<Mtx64>(123, 234, 0);
+    auto dmtx = gko::clone(cuda, mtx);
+
+    auto trans = gko::as<Mtx64>(mtx->transpose());
+    auto d_trans = gko::as<Mtx64>(dmtx->transpose());
 
     GKO_ASSERT_MTX_NEAR(d_trans, trans, 0.0);
     ASSERT_TRUE(d_trans->is_sorted_by_column_index());

--- a/hip/matrix/csr_kernels.hip.cpp
+++ b/hip/matrix/csr_kernels.hip.cpp
@@ -786,7 +786,7 @@ void conj_transpose(std::shared_ptr<const HipExecutor> exec,
     } else {
         fallback_transpose(exec, orig, trans);
     }
-    if (grid_size > 0) {
+    if (grid_size > 0 && is_complex<ValueType>()) {
         hipLaunchKernelGGL(kernel::conjugate, grid_size, block_size, 0, 0,
                            trans->get_num_stored_elements(),
                            as_hip_type(trans->get_values()));

--- a/hip/matrix/csr_kernels.hip.cpp
+++ b/hip/matrix/csr_kernels.hip.cpp
@@ -755,7 +755,7 @@ void transpose(std::shared_ptr<const HipExecutor> exec,
             orig->get_const_col_idxs(), trans->get_values(),
             trans->get_row_ptrs(), trans->get_col_idxs(), copyValues, idxBase);
     } else {
-        GKO_NOT_IMPLEMENTED;
+        fallback_transpose(exec, orig, trans);
     }
 }
 
@@ -770,11 +770,10 @@ void conj_transpose(std::shared_ptr<const HipExecutor> exec,
     if (orig->get_size()[0] == 0) {
         return;
     }
+    const auto block_size = default_block_size;
+    const auto grid_size =
+        ceildiv(trans->get_num_stored_elements(), block_size);
     if (hipsparse::is_supported<ValueType, IndexType>::value) {
-        const auto block_size = default_block_size;
-        const auto grid_size =
-            ceildiv(trans->get_num_stored_elements(), block_size);
-
         hipsparseAction_t copyValues = HIPSPARSE_ACTION_NUMERIC;
         hipsparseIndexBase_t idxBase = HIPSPARSE_INDEX_BASE_ZERO;
 
@@ -784,14 +783,13 @@ void conj_transpose(std::shared_ptr<const HipExecutor> exec,
             orig->get_const_values(), orig->get_const_row_ptrs(),
             orig->get_const_col_idxs(), trans->get_values(),
             trans->get_row_ptrs(), trans->get_col_idxs(), copyValues, idxBase);
-
-        if (grid_size > 0) {
-            hipLaunchKernelGGL(kernel::conjugate, grid_size, block_size, 0, 0,
-                               trans->get_num_stored_elements(),
-                               as_hip_type(trans->get_values()));
-        }
     } else {
-        GKO_NOT_IMPLEMENTED;
+        fallback_transpose(exec, orig, trans);
+    }
+    if (grid_size > 0) {
+        hipLaunchKernelGGL(kernel::conjugate, grid_size, block_size, 0, 0,
+                           trans->get_num_stored_elements(),
+                           as_hip_type(trans->get_values()));
     }
 }
 

--- a/hip/test/matrix/csr_kernels.hip.cpp
+++ b/hip/test/matrix/csr_kernels.hip.cpp
@@ -510,12 +510,40 @@ TEST_F(Csr, TransposeIsEquivalentToRef)
 }
 
 
+TEST_F(Csr, Transpose64IsEquivalentToRef)
+{
+    using Mtx64 = gko::matrix::Csr<double, gko::int64>;
+    auto mtx = gen_mtx<Mtx64>(123, 234, 0);
+    auto dmtx = gko::clone(hip, mtx);
+
+    auto trans = gko::as<Mtx64>(mtx->transpose());
+    auto d_trans = gko::as<Mtx64>(dmtx->transpose());
+
+    GKO_ASSERT_MTX_NEAR(d_trans, trans, 0.0);
+    ASSERT_TRUE(d_trans->is_sorted_by_column_index());
+}
+
+
 TEST_F(Csr, ConjugateTransposeIsEquivalentToRef)
 {
     set_up_apply_data(std::make_shared<Mtx::automatical>(hip));
 
     auto trans = gko::as<Mtx>(mtx->conj_transpose());
     auto d_trans = gko::as<Mtx>(dmtx->conj_transpose());
+
+    GKO_ASSERT_MTX_NEAR(d_trans, trans, 0.0);
+    ASSERT_TRUE(d_trans->is_sorted_by_column_index());
+}
+
+
+TEST_F(Csr, ConjugateTranspose64IsEquivalentToRef)
+{
+    using Mtx64 = gko::matrix::Csr<double, gko::int64>;
+    auto mtx = gen_mtx<Mtx64>(123, 234, 0);
+    auto dmtx = gko::clone(hip, mtx);
+
+    auto trans = gko::as<Mtx64>(mtx->transpose());
+    auto d_trans = gko::as<Mtx64>(dmtx->transpose());
 
     GKO_ASSERT_MTX_NEAR(d_trans, trans, 0.0);
     ASSERT_TRUE(d_trans->is_sorted_by_column_index());

--- a/hip/test/matrix/fbcsr_kernels.hip.cpp
+++ b/hip/test/matrix/fbcsr_kernels.hip.cpp
@@ -33,28 +33,47 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <ginkgo/core/matrix/fbcsr.hpp>
 
 
+#include <random>
+
+
 #include <gtest/gtest.h>
 
 
 #include <ginkgo/core/base/executor.hpp>
 
 
+#include "core/matrix/fbcsr_kernels.hpp"
 #include "core/test/matrix/fbcsr_sample.hpp"
+#include "core/test/utils.hpp"
+#include "core/test/utils/fb_matrix_generator.hpp"
 #include "hip/test/utils.hip.hpp"
 
 
 namespace {
 
 
+template <typename T>
 class Fbcsr : public ::testing::Test {
 protected:
-    using Mtx = gko::matrix::Fbcsr<>;
+    using value_type = T;
+    using index_type = int;
+    using real_type = gko::remove_complex<value_type>;
+    using Mtx = gko::matrix::Fbcsr<value_type, index_type>;
+    using Dense = gko::matrix::Dense<value_type>;
+
+    Fbcsr() : distb(), engine(42) {}
 
     void SetUp()
     {
         ASSERT_GT(gko::HipExecutor::get_num_devices(), 0);
         ref = gko::ReferenceExecutor::create();
         hip = gko::HipExecutor::create(0, ref);
+        const index_type rand_brows = 100;
+        const index_type rand_bcols = 70;
+        const int block_size = 3;
+        rsorted_ref = gko::test::generate_random_fbcsr<value_type, index_type>(
+            ref, rand_brows, rand_bcols, block_size, false, false,
+            std::default_random_engine(43));
     }
 
     void TearDown()
@@ -67,18 +86,39 @@ protected:
     std::shared_ptr<gko::ReferenceExecutor> ref;
     std::shared_ptr<const gko::HipExecutor> hip;
 
-    std::unique_ptr<Mtx> mtx;
+    std::unique_ptr<const Mtx> rsorted_ref;
+
+    std::normal_distribution<gko::remove_complex<T>> distb;
+    std::default_random_engine engine;
+
+    value_type get_random_value()
+    {
+        return gko::test::detail::get_rand_value<T>(distb, engine);
+    }
+
+    void generate_sin(Dense* const x)
+    {
+        value_type* const xarr = x->get_values();
+        for (index_type i = 0; i < x->get_size()[0] * x->get_size()[1]; i++) {
+            xarr[i] =
+                static_cast<real_type>(2.0) *
+                std::sin(static_cast<real_type>(i / 2.0) + get_random_value());
+        }
+    }
 };
 
+TYPED_TEST_SUITE(Fbcsr, gko::test::RealValueTypes, TypenameNameGenerator);
 
-TEST_F(Fbcsr, CanWriteFromMatrixOnDevice)
+
+TYPED_TEST(Fbcsr, CanWriteFromMatrixOnDevice)
 {
-    using value_type = Mtx::value_type;
-    using index_type = Mtx::index_type;
+    using Mtx = typename TestFixture::Mtx;
+    using value_type = typename Mtx::value_type;
+    using index_type = typename Mtx::index_type;
     using MatData = gko::matrix_data<value_type, index_type>;
-    gko::testing::FbcsrSample<value_type, index_type> sample(ref);
+    gko::testing::FbcsrSample<value_type, index_type> sample(this->ref);
     auto refmat = sample.generate_fbcsr();
-    auto hipmat = gko::clone(hip, refmat);
+    auto hipmat = gko::clone(this->hip, refmat);
     MatData refdata;
     MatData hipdata;
 
@@ -86,6 +126,251 @@ TEST_F(Fbcsr, CanWriteFromMatrixOnDevice)
     hipmat->write(hipdata);
 
     ASSERT_TRUE(refdata.nonzeros == hipdata.nonzeros);
+}
+
+
+TYPED_TEST(Fbcsr, TransposeIsEquivalentToRefSortedBS3)
+{
+    using Mtx = typename TestFixture::Mtx;
+    using value_type = typename Mtx::value_type;
+    using index_type = typename Mtx::index_type;
+    auto rand_hip = Mtx::create(this->hip);
+    rand_hip->copy_from(gko::lend(this->rsorted_ref));
+    auto trans_ref_linop = this->rsorted_ref->transpose();
+    std::unique_ptr<const Mtx> trans_ref =
+        gko::as<const Mtx>(std::move(trans_ref_linop));
+
+    auto trans_hip_linop = rand_hip->transpose();
+    std::unique_ptr<const Mtx> trans_hip =
+        gko::as<const Mtx>(std::move(trans_hip_linop));
+
+    GKO_ASSERT_MTX_EQ_SPARSITY(trans_ref, trans_hip);
+    GKO_ASSERT_MTX_NEAR(trans_ref, trans_hip, 0.0);
+}
+
+
+TYPED_TEST(Fbcsr, TransposeIsEquivalentToRefSortedBS7)
+{
+    using Mtx = typename TestFixture::Mtx;
+    using value_type = typename Mtx::value_type;
+    using index_type = typename Mtx::index_type;
+    auto rand_hip = Mtx::create(this->hip);
+    const index_type rand_brows = 50;
+    const index_type rand_bcols = 40;
+    const int block_size = 7;
+    auto rsorted_ref2 =
+        gko::test::generate_random_fbcsr<value_type, index_type>(
+            this->ref, rand_brows, rand_bcols, block_size, false, false,
+            std::default_random_engine(43));
+    rand_hip->copy_from(gko::lend(rsorted_ref2));
+
+    auto trans_ref_linop = rsorted_ref2->transpose();
+    std::unique_ptr<const Mtx> trans_ref =
+        gko::as<const Mtx>(std::move(trans_ref_linop));
+    auto trans_hip_linop = rand_hip->transpose();
+    std::unique_ptr<const Mtx> trans_hip =
+        gko::as<const Mtx>(std::move(trans_hip_linop));
+
+    GKO_ASSERT_MTX_EQ_SPARSITY(trans_ref, trans_hip);
+    GKO_ASSERT_MTX_NEAR(trans_ref, trans_hip, 0.0);
+}
+
+
+TYPED_TEST(Fbcsr, SpmvIsEquivalentToRefSorted)
+{
+    using Mtx = typename TestFixture::Mtx;
+    using Dense = typename TestFixture::Dense;
+    using value_type = typename Mtx::value_type;
+    auto rand_hip = Mtx::create(this->hip);
+    rand_hip->copy_from(gko::lend(this->rsorted_ref));
+    auto x_ref = Dense::create(
+        this->ref, gko::dim<2>(this->rsorted_ref->get_size()[1], 1));
+    this->generate_sin(x_ref.get());
+    auto x_hip = Dense::create(this->hip);
+    x_hip->copy_from(x_ref.get());
+    auto prod_ref = Dense::create(
+        this->ref, gko::dim<2>(this->rsorted_ref->get_size()[0], 1));
+    auto prod_hip = Dense::create(this->hip, prod_ref->get_size());
+
+    rand_hip->apply(x_hip.get(), prod_hip.get());
+    this->rsorted_ref->apply(x_ref.get(), prod_ref.get());
+
+    const double tol = r<value_type>::value;
+    GKO_ASSERT_MTX_NEAR(prod_ref, prod_hip, 5 * tol);
+}
+
+
+TYPED_TEST(Fbcsr, SpmvMultiIsEquivalentToRefSorted)
+{
+    using Mtx = typename TestFixture::Mtx;
+    using Dense = typename TestFixture::Dense;
+    using value_type = typename Mtx::value_type;
+    auto rand_hip = Mtx::create(this->hip);
+    rand_hip->copy_from(gko::lend(this->rsorted_ref));
+    auto x_ref = Dense::create(
+        this->ref, gko::dim<2>(this->rsorted_ref->get_size()[1], 3));
+    this->generate_sin(x_ref.get());
+    auto x_hip = Dense::create(this->hip);
+    x_hip->copy_from(x_ref.get());
+    auto prod_ref = Dense::create(
+        this->ref, gko::dim<2>(this->rsorted_ref->get_size()[0], 3));
+    auto prod_hip = Dense::create(this->hip, prod_ref->get_size());
+
+    rand_hip->apply(x_hip.get(), prod_hip.get());
+    this->rsorted_ref->apply(x_ref.get(), prod_ref.get());
+
+    const double tol = r<value_type>::value;
+    GKO_ASSERT_MTX_NEAR(prod_ref, prod_hip, 5 * tol);
+}
+
+
+TYPED_TEST(Fbcsr, AdvancedSpmvIsEquivalentToRefSorted)
+{
+    using Mtx = typename TestFixture::Mtx;
+    using Dense = typename TestFixture::Dense;
+    using value_type = typename TestFixture::value_type;
+    using real_type = typename TestFixture::real_type;
+    auto rand_hip = Mtx::create(this->hip);
+    rand_hip->copy_from(gko::lend(this->rsorted_ref));
+    auto x_ref = Dense::create(
+        this->ref, gko::dim<2>(this->rsorted_ref->get_size()[1], 1));
+    this->generate_sin(x_ref.get());
+    auto x_hip = Dense::create(this->hip);
+    x_hip->copy_from(x_ref.get());
+    auto prod_ref = Dense::create(
+        this->ref, gko::dim<2>(this->rsorted_ref->get_size()[0], 1));
+    this->generate_sin(prod_ref.get());
+    auto prod_hip = Dense::create(this->hip);
+    prod_hip->copy_from(prod_ref.get());
+    auto alpha_ref = Dense::create(this->ref, gko::dim<2>(1, 1));
+    alpha_ref->get_values()[0] =
+        static_cast<real_type>(2.4) + this->get_random_value();
+    auto beta_ref = Dense::create(this->ref, gko::dim<2>(1, 1));
+    beta_ref->get_values()[0] = -1.2;
+    auto alpha = Dense::create(this->hip);
+    alpha->copy_from(alpha_ref.get());
+    auto beta = Dense::create(this->hip);
+    beta->copy_from(beta_ref.get());
+
+    rand_hip->apply(alpha.get(), x_hip.get(), beta.get(), prod_hip.get());
+    this->rsorted_ref->apply(alpha_ref.get(), x_ref.get(), beta_ref.get(),
+                             prod_ref.get());
+
+    const double tol = r<value_type>::value;
+    GKO_ASSERT_MTX_NEAR(prod_ref, prod_hip, 5 * tol);
+}
+
+
+TYPED_TEST(Fbcsr, AdvancedSpmvMultiIsEquivalentToRefSorted)
+{
+    using Mtx = typename TestFixture::Mtx;
+    using Dense = typename TestFixture::Dense;
+    using value_type = typename TestFixture::value_type;
+    using real_type = typename TestFixture::real_type;
+    auto rand_hip = Mtx::create(this->hip);
+    rand_hip->copy_from(gko::lend(this->rsorted_ref));
+    auto x_ref = Dense::create(
+        this->ref, gko::dim<2>(this->rsorted_ref->get_size()[1], 3));
+    this->generate_sin(x_ref.get());
+    auto x_hip = Dense::create(this->hip);
+    x_hip->copy_from(x_ref.get());
+    auto prod_ref = Dense::create(
+        this->ref, gko::dim<2>(this->rsorted_ref->get_size()[0], 3));
+    this->generate_sin(prod_ref.get());
+    auto prod_hip = Dense::create(this->hip);
+    prod_hip->copy_from(prod_ref.get());
+    auto alpha_ref = Dense::create(this->ref, gko::dim<2>(1, 1));
+    alpha_ref->get_values()[0] =
+        static_cast<real_type>(2.4) + this->get_random_value();
+    auto beta_ref = Dense::create(this->ref, gko::dim<2>(1, 1));
+    beta_ref->get_values()[0] = -1.2;
+    auto alpha = Dense::create(this->hip);
+    alpha->copy_from(alpha_ref.get());
+    auto beta = Dense::create(this->hip);
+    beta->copy_from(beta_ref.get());
+
+    rand_hip->apply(alpha.get(), x_hip.get(), beta.get(), prod_hip.get());
+    this->rsorted_ref->apply(alpha_ref.get(), x_ref.get(), beta_ref.get(),
+                             prod_ref.get());
+
+    const double tol = r<value_type>::value;
+    GKO_ASSERT_MTX_NEAR(prod_ref, prod_hip, 5 * tol);
+}
+
+
+TYPED_TEST(Fbcsr, ConjTransposeIsEquivalentToRefSortedBS3)
+{
+    using Mtx = typename TestFixture::Mtx;
+    using value_type = typename Mtx::value_type;
+    using index_type = typename Mtx::index_type;
+    auto rand_hip = Mtx::create(this->hip);
+    rand_hip->copy_from(gko::lend(this->rsorted_ref));
+    auto trans_ref_linop = this->rsorted_ref->conj_transpose();
+    std::unique_ptr<const Mtx> trans_ref =
+        gko::as<const Mtx>(std::move(trans_ref_linop));
+
+    auto trans_hip_linop = rand_hip->conj_transpose();
+    std::unique_ptr<const Mtx> trans_hip =
+        gko::as<const Mtx>(std::move(trans_hip_linop));
+
+    GKO_ASSERT_MTX_EQ_SPARSITY(trans_ref, trans_hip);
+    GKO_ASSERT_MTX_NEAR(trans_ref, trans_hip, 0.0);
+}
+
+
+TYPED_TEST(Fbcsr, RecognizeSortedMatrix)
+{
+    using Mtx = typename TestFixture::Mtx;
+    auto rand_hip = Mtx::create(this->hip);
+    rand_hip->copy_from(gko::lend(this->rsorted_ref));
+
+    ASSERT_TRUE(rand_hip->is_sorted_by_column_index());
+}
+
+
+TYPED_TEST(Fbcsr, RecognizeUnsortedMatrix)
+{
+    using Mtx = typename TestFixture::Mtx;
+    using index_type = typename TestFixture::index_type;
+    auto mat = this->rsorted_ref->clone();
+    index_type* const colinds = mat->get_col_idxs();
+    std::swap(colinds[0], colinds[1]);
+    auto unsrt_hip = Mtx::create(this->hip);
+    unsrt_hip->copy_from(gko::lend(mat));
+
+    ASSERT_FALSE(unsrt_hip->is_sorted_by_column_index());
+}
+
+
+TYPED_TEST(Fbcsr, InplaceAbsoluteMatrixIsEquivalentToRef)
+{
+    using Mtx = typename TestFixture::Mtx;
+    using value_type = typename Mtx::value_type;
+    auto rand_ref = Mtx::create(this->ref);
+    rand_ref->copy_from(this->rsorted_ref.get());
+    auto rand_hip = Mtx::create(this->hip);
+    rand_hip->copy_from(gko::lend(this->rsorted_ref));
+
+    rand_ref->compute_absolute_inplace();
+    rand_hip->compute_absolute_inplace();
+
+    const double tol = r<value_type>::value;
+    GKO_ASSERT_MTX_NEAR(rand_ref, rand_hip, tol);
+}
+
+
+TYPED_TEST(Fbcsr, OutplaceAbsoluteMatrixIsEquivalentToRef)
+{
+    using Mtx = typename TestFixture::Mtx;
+    using value_type = typename Mtx::value_type;
+    auto rand_hip = Mtx::create(this->hip);
+    rand_hip->copy_from(gko::lend(this->rsorted_ref));
+
+    auto abs_mtx = this->rsorted_ref->compute_absolute();
+    auto dabs_mtx = rand_hip->compute_absolute();
+
+    const double tol = r<value_type>::value;
+    GKO_ASSERT_MTX_NEAR(abs_mtx, dabs_mtx, tol);
 }
 
 


### PR DESCRIPTION
cuSPARSE and hipSPARSE don't support long indices, so this adds a fall-back sorting based transpose kernel