### PR TITLE
Adds simple functions to create Dense view

### DIFF
--- a/core/test/matrix/dense.cpp
+++ b/core/test/matrix/dense.cpp
@@ -412,6 +412,8 @@ TYPED_TEST(Dense, CanMakeMutableView)
     auto view = gko::make_dense_view(this->mtx.get());
 
     ASSERT_EQ(view->get_values(), this->mtx->get_values());
+    ASSERT_EQ(view->get_executor(), this->mtx->get_executor());
+    GKO_ASSERT_MTX_NEAR(view, this->mtx, 0.0);
 }
 
 
@@ -420,6 +422,8 @@ TYPED_TEST(Dense, CanMakeConstView)
     auto view = gko::make_const_dense_view(this->mtx.get());
 
     ASSERT_EQ(view->get_const_values(), this->mtx->get_const_values());
+    ASSERT_EQ(view->get_executor(), this->mtx->get_executor());
+    GKO_ASSERT_MTX_NEAR(view, this->mtx, 0.0);
 }
 
 
@@ -448,8 +452,7 @@ private:
     std::unique_ptr<gko::matrix::Dense<>> create_view_of_impl() override
     {
         auto view = create(this->get_executor(), {}, this->get_data());
-        (*static_cast<gko::matrix::Dense<>*>(view.get())) =
-            std::move(*gko::matrix::Dense<>::create_view_of_impl());
+        gko::matrix::Dense<>::create_view_of_impl()->move_to(this);
         return view;
     }
 

--- a/core/test/matrix/dense.cpp
+++ b/core/test/matrix/dense.cpp
@@ -452,7 +452,7 @@ private:
     std::unique_ptr<gko::matrix::Dense<>> create_view_of_impl() override
     {
         auto view = create(this->get_executor(), {}, this->get_data());
-        gko::matrix::Dense<>::create_view_of_impl()->move_to(this);
+        gko::matrix::Dense<>::create_view_of_impl()->move_to(view.get());
         return view;
     }
 

--- a/core/test/matrix/dense.cpp
+++ b/core/test/matrix/dense.cpp
@@ -407,4 +407,22 @@ TYPED_TEST(Dense, CanCreateRealView)
 }
 
 
+TYPED_TEST(Dense, CanMakeMutableView)
+{
+    auto view = gko::make_dense_view(this->mtx.get());
+
+    ASSERT_EQ(view->get_values(), this->mtx->get_values());
+}
+
+
+TYPED_TEST(Dense, CanMakeConstView)
+{
+    using value_type = typename TestFixture::value_type;
+    const gko::matrix::Dense<value_type>* const_mtx = this->mtx.get();
+
+    auto view = gko::make_dense_view(const_mtx);
+
+    ASSERT_EQ(view->get_const_values(), this->mtx->get_const_values());
+}
+
 }  // namespace

--- a/core/test/matrix/dense.cpp
+++ b/core/test/matrix/dense.cpp
@@ -417,10 +417,7 @@ TYPED_TEST(Dense, CanMakeMutableView)
 
 TYPED_TEST(Dense, CanMakeConstView)
 {
-    using value_type = typename TestFixture::value_type;
-    const gko::matrix::Dense<value_type>* const_mtx = this->mtx.get();
-
-    auto view = gko::make_dense_view(const_mtx);
+    auto view = gko::make_const_dense_view(this->mtx.get());
 
     ASSERT_EQ(view->get_const_values(), this->mtx->get_const_values());
 }

--- a/core/test/matrix/dense.cpp
+++ b/core/test/matrix/dense.cpp
@@ -429,42 +429,44 @@ class CustomDense : public gko::EnableLinOp<CustomDense, gko::matrix::Dense<>> {
 
 public:
     static std::unique_ptr<CustomDense> create(
-        std::shared_ptr<const gko::Executor> exec, gko::dim<2> size)
+        std::shared_ptr<const gko::Executor> exec, gko::dim<2> size, int data)
     {
         return std::unique_ptr<CustomDense>(
-            new CustomDense(std::move(exec), size));
+            new CustomDense(std::move(exec), size, data));
     }
+
+    int get_data() const { return data_; }
 
 private:
     explicit CustomDense(std::shared_ptr<const gko::Executor> exec,
-                         gko::dim<2> size = {})
+                         gko::dim<2> size = {}, int data = 0)
         : gko::EnableLinOp<CustomDense, gko::matrix::Dense<>>(std::move(exec),
-                                                              size)
+                                                              size),
+          data_(data)
     {}
+
+    std::unique_ptr<gko::matrix::Dense<>> create_view_of_impl() override
+    {
+        auto view = create(this->get_executor(), {}, this->get_data());
+        (*static_cast<gko::matrix::Dense<>*>(view.get())) =
+            std::move(*gko::matrix::Dense<>::create_view_of_impl());
+        return view;
+    }
+
+    int data_;
 };
 
 
-TEST(DenseView, MutableViewKeepsRuntimeType)
+TEST(DenseView, CustomViewKeepsRuntimeType)
 {
     auto vector = CustomDense::create(gko::ReferenceExecutor::create(),
-                                      gko::dim<2>{3, 4});
+                                      gko::dim<2>{3, 4}, 2);
 
     auto view = gko::make_dense_view(vector.get());
 
     ASSERT_EQ(view->get_values(), vector->get_values());
-    ASSERT_TRUE(dynamic_cast<CustomDense*>(view.get()));
-}
-
-
-TEST(DenseView, ConstViewKeepsRuntimeType)
-{
-    auto vector = CustomDense::create(gko::ReferenceExecutor::create(),
-                                      gko::dim<2>{3, 4});
-
-    auto view = gko::make_const_dense_view(vector.get());
-
-    ASSERT_EQ(view->get_const_values(), vector->get_const_values());
-    ASSERT_TRUE(dynamic_cast<const CustomDense*>(view.get()));
+    EXPECT_TRUE(dynamic_cast<CustomDense*>(view.get()));
+    ASSERT_EQ(dynamic_cast<CustomDense*>(view.get())->get_data(), 2);
 }
 
 

--- a/include/ginkgo/core/matrix/dense.hpp
+++ b/include/ginkgo/core/matrix/dense.hpp
@@ -1202,7 +1202,7 @@ std::unique_ptr<matrix::Dense<ValueType>> make_dense_view(
  * @param vector  the vector on which to create the view
  */
 template <typename ValueType>
-std::unique_ptr<const matrix::Dense<ValueType>> make_dense_view(
+std::unique_ptr<const matrix::Dense<ValueType>> make_const_dense_view(
     const matrix::Dense<ValueType>* vector)
 {
     auto exec = vector->get_executor();

--- a/include/ginkgo/core/matrix/dense.hpp
+++ b/include/ginkgo/core/matrix/dense.hpp
@@ -1023,12 +1023,11 @@ protected:
     virtual std::unique_ptr<Dense> create_view_of_impl()
     {
         auto exec = this->get_executor();
-        auto view = this->create_default(exec);
-        view->set_size(this->get_size());
-        view->values_ = gko::make_array_view(
-            exec, this->get_num_stored_elements(), this->get_values());
-        view->stride_ = this->get_stride();
-        return view;
+        return Dense::create(
+            exec, this->get_size(),
+            gko::make_array_view(exec, this->get_num_stored_elements(),
+                                 this->get_values()),
+            this->get_stride());
     }
 
     /**
@@ -1040,13 +1039,11 @@ protected:
     virtual std::unique_ptr<const Dense> create_const_view_of_impl() const
     {
         auto exec = this->get_executor();
-        auto view = this->create_default(exec);
-        view->set_size(this->get_size());
-        view->values_ = gko::make_array_view(
-            exec, this->get_num_stored_elements(),
-            const_cast<value_type*>(this->get_const_values()));
-        view->stride_ = this->get_stride();
-        return view;
+        return Dense::create_const(
+            exec, this->get_size(),
+            gko::make_const_array_view(exec, this->get_num_stored_elements(),
+                                       this->get_const_values()),
+            this->get_stride());
     }
 
     template <typename IndexType>

--- a/include/ginkgo/core/matrix/dense.hpp
+++ b/include/ginkgo/core/matrix/dense.hpp
@@ -207,11 +207,25 @@ public:
         return (*other).create_with_type_of_impl(exec, size, stride);
     }
 
+    /**
+     * Creates a Dense matrix, where the underlying array is a view of another
+     * Dense matrix' array.
+     *
+     * @param other  The other matrix on which to create the view
+     * @return  A Dense matrix that is a view of other
+     */
     static std::unique_ptr<Dense> create_view_of(Dense* other)
     {
         return other->create_view_of_impl();
     }
 
+    /**
+     * Creates a immutable Dense matrix, where the underlying array is a view of
+     * another Dense matrix' array.
+     *
+     * @param other  The other matrix on which to create the view
+     * @return  A immutable Dense matrix that is a view of other
+     */
     static std::unique_ptr<const Dense> create_const_view_of(const Dense* other)
     {
         return other->create_const_view_of_impl();
@@ -1000,6 +1014,12 @@ protected:
         return Dense::create(exec, size, stride);
     }
 
+    /**
+     * Creates a Dense matrix where the underlying array is a view of this'
+     * array.
+     *
+     * @return  A Dense matrix that is a view of this.
+     */
     virtual std::unique_ptr<Dense> create_view_of_impl()
     {
         auto exec = this->get_executor();
@@ -1011,6 +1031,12 @@ protected:
         return view;
     }
 
+    /**
+     * Creates a immutable Dense matrix where the underlying array is a view of
+     * this' array.
+     *
+     * @return  A immutable Dense matrix that is a view of this.
+     */
     virtual std::unique_ptr<const Dense> create_const_view_of_impl() const
     {
         auto exec = this->get_executor();

--- a/include/ginkgo/core/matrix/dense.hpp
+++ b/include/ginkgo/core/matrix/dense.hpp
@@ -1177,6 +1177,44 @@ struct temporary_clone_helper<matrix::Dense<ValueType>> {
 
 
 /**
+ * Creates a view of a given Dense vector.
+ *
+ * @tparam ValueType  the underlying value type of the vector
+ * @param vector  the vector on which to create the view
+ */
+template <typename ValueType>
+std::unique_ptr<matrix::Dense<ValueType>> make_dense_view(
+    matrix::Dense<ValueType>* vector)
+{
+    auto exec = vector->get_executor();
+    return matrix::Dense<ValueType>::create(
+        exec, vector->get_size(),
+        make_array_view(exec, vector->get_num_stored_elements(),
+                        vector->get_values()),
+        vector->get_stride());
+}
+
+
+/**
+ * Creates a view of a given Dense vector.
+ *
+ * @tparam ValueType  the underlying value type of the vector
+ * @param vector  the vector on which to create the view
+ */
+template <typename ValueType>
+std::unique_ptr<const matrix::Dense<ValueType>> make_dense_view(
+    const matrix::Dense<ValueType>* vector)
+{
+    auto exec = vector->get_executor();
+    return matrix::Dense<ValueType>::create_const(
+        exec, vector->get_size(),
+        make_const_array_view(exec, vector->get_num_stored_elements(),
+                              vector->get_const_values()),
+        vector->get_stride());
+}
+
+
+/**
  * Creates and initializes a column-vector.
  *
  * This function first creates a temporary Dense matrix, fills it with passed in

--- a/include/ginkgo/core/matrix/dense.hpp
+++ b/include/ginkgo/core/matrix/dense.hpp
@@ -1236,6 +1236,7 @@ struct temporary_clone_helper<matrix::Dense<ValueType>> {
  * Creates a view of a given Dense vector.
  *
  * @tparam ValueType  the underlying value type of the vector
+ *
  * @param vector  the vector on which to create the view
  */
 template <typename ValueType>
@@ -1250,6 +1251,7 @@ std::unique_ptr<matrix::Dense<ValueType>> make_dense_view(
  * Creates a view of a given Dense vector.
  *
  * @tparam ValueType  the underlying value type of the vector
+ *
  * @param vector  the vector on which to create the view
  */
 template <typename ValueType>

--- a/include/ginkgo/core/matrix/dense.hpp
+++ b/include/ginkgo/core/matrix/dense.hpp
@@ -212,6 +212,7 @@ public:
      * Dense matrix' array.
      *
      * @param other  The other matrix on which to create the view
+     *
      * @return  A Dense matrix that is a view of other
      */
     static std::unique_ptr<Dense> create_view_of(Dense* other)


### PR DESCRIPTION
This PR adds functionality to create a view on an existing Dense vector in a simple manner. With this, a view can be created by
```
auto view = gko::make_dense_view(gko::lend(other));
auto view = Dense::create_view_of(gko::lend(other));
```
If `other` is derived from `Dense`, then `view` will have the same runtime type.

This will make it easier to create distributed vectors (#1133) from existing local vectors, while keeping the local vectors valid.