### PR TITLE
Allow `rebase!` and `format-rebase!` to preserve merge commits

### DIFF
--- a/.github/format-rebase.sh
+++ b/.github/format-rebase.sh
@@ -26,7 +26,7 @@ bot_delete_comments_matching "Error: Rebase failed"
 DIFF_COMMAND="git diff --name-only --no-renames --diff-filter=AM HEAD~ | grep -E '$EXTENSION_REGEX'"
 
 # do the formatting rebase
-git rebase --empty=drop --no-keep-empty \
+git rebase --rebase-merges --empty=drop --no-keep-empty \
     --exec "cp /tmp/add_license.sh /tmp/format_header.sh /tmp/update_ginkgo_header.sh dev_tools/scripts/ && \
             dev_tools/scripts/add_license.sh && dev_tools/scripts/update_ginkgo_header.sh && \
             for f in \$($DIFF_COMMAND | grep -E '$FORMAT_HEADER_REGEX'); do dev_tools/scripts/format_header.sh \$f; done && \
@@ -35,7 +35,7 @@ git rebase --empty=drop --no-keep-empty \
     base/$BASE_BRANCH 2>&1 || bot_error "Rebase failed, see the related [Action]($JOB_URL) for details"
 
 # repeat rebase to delete empty commits
-git rebase --empty=drop --no-keep-empty --exec true \
+git rebase --rebase-merges --empty=drop --no-keep-empty --exec true \
     base/$BASE_BRANCH 2>&1 || bot_error "Rebase failed, see the related [Action]($JOB_URL) for details"
 
 cp /tmp/difflog diff.patch

--- a/.github/rebase.sh
+++ b/.github/rebase.sh
@@ -17,7 +17,7 @@ git checkout -b "$LOCAL_BRANCH" "fork/$HEAD_BRANCH"
 bot_delete_comments_matching "Error: Rebase failed"
 
 # do the rebase
-git rebase "base/$BASE_BRANCH" 2>&1 || bot_error "Rebase failed, see the related [Action]($JOB_URL) for details"
+git rebase --rebase-merges "base/$BASE_BRANCH" 2>&1 || bot_error "Rebase failed, see the related [Action]($JOB_URL) for details"
 
 # push back
 git push --force-with-lease fork "$LOCAL_BRANCH:$HEAD_BRANCH" 2>&1 || bot_error "Cannot push rebased branch, are edits for maintainers allowed, or were changes pushed while the rebase was running?"


### PR DESCRIPTION
A small fix to allow `rebase!` and `format-rebase!` commands to preserve the merge commits. This is useful for long-standing feature branches so that the merge commit history is still preserved when rebasing.