### PR TITLE
Fixes distributed Matrix constructor with LinOp* input

### DIFF
--- a/core/test/mpi/distributed/CMakeLists.txt
+++ b/core/test/mpi/distributed/CMakeLists.txt
@@ -1,1 +1,1 @@
-ginkgo_create_test(matrix MPI_SIZE 3)
+ginkgo_create_test(matrix MPI_SIZE 1)

--- a/core/test/mpi/distributed/matrix.cpp
+++ b/core/test/mpi/distributed/matrix.cpp
@@ -79,12 +79,15 @@ protected:
 template <typename ValueLocalGlobalIndexType>
 class MatrixBuilder : public ::testing::Test {
 protected:
-    using value_type = typename std::tuple_element<
-        0, decltype(ValueLocalGlobalIndexType())>::type;
-    using local_index_type = typename std::tuple_element<
-        1, decltype(ValueLocalGlobalIndexType())>::type;
-    using global_index_type = typename std::tuple_element<
-        2, decltype(ValueLocalGlobalIndexType())>::type;
+    using value_type =
+        typename std::tuple_element<0, decltype(
+                                           ValueLocalGlobalIndexType())>::type;
+    using local_index_type =
+        typename std::tuple_element<1, decltype(
+                                           ValueLocalGlobalIndexType())>::type;
+    using global_index_type =
+        typename std::tuple_element<2, decltype(
+                                           ValueLocalGlobalIndexType())>::type;
     using dist_mtx_type =
         gko::experimental::distributed::Matrix<value_type, local_index_type,
                                                global_index_type>;
@@ -213,8 +216,8 @@ TYPED_TEST(MatrixBuilder, BuildWithLocal)
     this->template forall_matrix_types([this](auto with_matrix_type,
                                               auto expected_type_ptr,
                                               auto additional_test) {
-        using expected_type = typename std::remove_pointer<
-            decltype(expected_type_ptr.get())>::type;
+        using expected_type = typename std::remove_pointer<decltype(
+            expected_type_ptr.get())>::type;
 
         auto mat =
             dist_mat_type ::create(this->ref, this->comm, with_matrix_type);
@@ -236,13 +239,14 @@ TYPED_TEST(MatrixBuilder, BuildWithLocalAndNonLocal)
     this->template forall_matrix_types([this](auto with_local_matrix_type,
                                               auto expected_local_type_ptr,
                                               auto additional_local_test) {
-        using expected_local_type = typename std::remove_pointer<
-            decltype(expected_local_type_ptr.get())>::type;
+        using expected_local_type = typename std::remove_pointer<decltype(
+            expected_local_type_ptr.get())>::type;
         this->forall_matrix_types([&](auto with_non_local_matrix_type,
                                       auto expected_non_local_type_ptr,
                                       auto additional_non_local_test) {
-            using expected_non_local_type = typename std::remove_pointer<
-                decltype(expected_non_local_type_ptr.get())>::type;
+            using expected_non_local_type =
+                typename std::remove_pointer<decltype(
+                    expected_non_local_type_ptr.get())>::type;
 
             auto mat = dist_mat_type ::create(this->ref, this->comm,
                                               with_local_matrix_type,
@@ -286,8 +290,8 @@ TYPED_TEST(MatrixBuilder, BuildFromLinOpLocal)
     this->template forall_matrix_types([this](auto with_matrix_type,
                                               auto expected_type_ptr,
                                               auto additional_test) {
-        using expected_type = typename std::remove_pointer<
-            decltype(expected_type_ptr.get())>::type;
+        using expected_type = typename std::remove_pointer<decltype(
+            expected_type_ptr.get())>::type;
 
         auto mat = dist_mat_type ::create(this->ref, this->comm,
                                           expected_type_ptr.get());
@@ -309,13 +313,14 @@ TYPED_TEST(MatrixBuilder, BuildFromLinOpLocalAndNonLocal)
     this->template forall_matrix_types([this](auto with_local_matrix_type,
                                               auto expected_local_type_ptr,
                                               auto additional_local_test) {
-        using expected_local_type = typename std::remove_pointer<
-            decltype(expected_local_type_ptr.get())>::type;
+        using expected_local_type = typename std::remove_pointer<decltype(
+            expected_local_type_ptr.get())>::type;
         this->forall_matrix_types([&](auto with_non_local_matrix_type,
                                       auto expected_non_local_type_ptr,
                                       auto additional_non_local_test) {
-            using expected_non_local_type = typename std::remove_pointer<
-                decltype(expected_non_local_type_ptr.get())>::type;
+            using expected_non_local_type =
+                typename std::remove_pointer<decltype(
+                    expected_non_local_type_ptr.get())>::type;
 
             auto mat = dist_mat_type ::create(
                 this->ref, this->comm, expected_local_type_ptr.get(),

--- a/include/ginkgo/core/distributed/matrix.hpp
+++ b/include/ginkgo/core/distributed/matrix.hpp
@@ -123,7 +123,7 @@ template <template <typename, typename> class MatrixType, typename... Args>
 auto with_matrix_type(Args&&... create_args)
 {
     return detail::MatrixTypeBuilderFromValueAndIndex<MatrixType, Args...>{
-        std::make_tuple(create_args...)};
+        std::tuple<Args...>{std::forward<Args>(create_args)...}};
 }
 
 

--- a/include/ginkgo/core/distributed/matrix.hpp
+++ b/include/ginkgo/core/distributed/matrix.hpp
@@ -72,8 +72,8 @@ struct is_matrix_type_builder : std::false_type {};
 template <typename Builder, typename ValueType, typename IndexType>
 struct is_matrix_type_builder<
     Builder, ValueType, IndexType,
-    gko::xstd::void_t<
-        decltype(std::declval<Builder>().template create<ValueType, IndexType>(
+    gko::xstd::void_t<decltype(
+        std::declval<Builder>().template create<ValueType, IndexType>(
             std::declval<std::shared_ptr<const Executor>>()))>>
     : std::true_type {};
 

--- a/include/ginkgo/core/distributed/matrix.hpp
+++ b/include/ginkgo/core/distributed/matrix.hpp
@@ -72,8 +72,8 @@ struct is_matrix_type_builder : std::false_type {};
 template <typename Builder, typename ValueType, typename IndexType>
 struct is_matrix_type_builder<
     Builder, ValueType, IndexType,
-    gko::xstd::void_t<decltype(
-        std::declval<Builder>().template create<ValueType, IndexType>(
+    gko::xstd::void_t<
+        decltype(std::declval<Builder>().template create<ValueType, IndexType>(
             std::declval<std::shared_ptr<const Executor>>()))>>
     : std::true_type {};
 
@@ -141,7 +141,7 @@ template <template <typename, typename> class MatrixType, typename... Args>
 auto with_matrix_type(Args&&... create_args)
 {
     return detail::MatrixTypeBuilderFromValueAndIndex<MatrixType, Args...>{
-        std::tuple<Args...>{std::forward<Args>(create_args)...}};
+        std::forward_as_tuple(create_args...)};
 }
 
 


### PR DESCRIPTION
This PR fixes the distributed matrix creation with local and non-local templates passed in as LinOp*. Before, the LinOp* overload would only be used if the input argument has exactly the type `const LinOp*`. In all other cases, eg an input as `LinOp*` or `Csr<...>*`, the templated constructor would be chosen, because, after template deduction, that constructor matches better than the LinOp* one. To prevent this from happening, I've enabled the templated constructor only if the template parameter has a `create<ValueType, IndexType>(exec)` function.