### PR TITLE
Update cuda archCoresPerSM

### DIFF
--- a/common/cuda_hip/base/executor.hpp.inc
+++ b/common/cuda_hip/base/executor.hpp.inc
@@ -34,7 +34,7 @@ namespace {
 
 
 // The function is copied from _ConvertSMVer2Cores of
-// cuda-11.0/samples/common/inc/helper_cuda.h
+// cuda-samples:Common/helper_cuda.h
 inline int convert_sm_ver_to_cores(int major, int minor)
 {
     // Defines for GPU Architecture types (using the SM version to determine
@@ -60,6 +60,9 @@ inline int convert_sm_ver_to_cores(int major, int minor)
         {0x72, 64},   // Volta Generation (SM 7.2) GV11b class
         {0x75, 64},   // Turing Generation (SM 7.5) TU1xx class
         {0x80, 64},   // Ampere Generation (SM 8.0) GA100 class
+        {0x86, 128},  // Ampere Generation (SM 8.6)
+        {0x87, 128},  // Ampere Generation (SM 8.7)
+        {0x90, 128},  // Hopper Generation (SM 9.0)
         {-1, -1}};
 
     int index = 0;


### PR DESCRIPTION
This PR updates the Arch CorePerSM map from 11.8 sample, which add SM 8.x and SM 9.0 for Hopper
They also move the sample from the toolkit to GitHub cuds-samples
It should eliminate the warning message mentioned in #1150 