### PR TITLE
Fix CMake Modules install location

### DIFF
--- a/cmake/install_helpers.cmake
+++ b/cmake/install_helpers.cmake
@@ -105,7 +105,7 @@ function(ginkgo_install)
     endif()
 
     # Install CMake modules
-    install(DIRECTORY "${Ginkgo_SOURCE_DIR}/cmake/Modules"
+    install(DIRECTORY "${Ginkgo_SOURCE_DIR}/cmake/Modules/"
         DESTINATION "${GINKGO_INSTALL_MODULE_DIR}"
         FILES_MATCHING PATTERN "*.cmake"
         )


### PR DESCRIPTION
[`install(DIRECTORY ...)`](https://cmake.org/cmake/help/latest/command/install.html#directory) works differently dependent on whether the directory to be installed ends in a slash. The missing slash leads to the modules being installed in Modules/Modules

Fixes #1152 