### PR TITLE
Fix remaining warnings

### DIFF
--- a/cuda/test/base/CMakeLists.txt
+++ b/cuda/test/base/CMakeLists.txt
@@ -1,6 +1,6 @@
 ginkgo_create_cuda_test(array)
 ginkgo_create_cuda_test(cuda_executor)
-ginkgo_create_cuda_test(index_set)
+ginkgo_create_test(index_set)
 ginkgo_create_test(cuda_executor_reset ADDITIONAL_LIBRARIES Threads::Threads)
 if(GINKGO_HAVE_HWLOC)
     find_package(NUMA REQUIRED)

--- a/cuda/test/base/index_set.cpp
+++ b/cuda/test/base/index_set.cpp
@@ -81,15 +81,6 @@ protected:
         }
     }
 
-    static void assert_equal_arrays(const T num_elems, const T* a, const T* b)
-    {
-        if (num_elems > 0) {
-            for (auto i = 0; i < num_elems; ++i) {
-                EXPECT_EQ(a[i], b[i]);
-            }
-        }
-    }
-
     std::shared_ptr<const gko::Executor> exec;
     std::shared_ptr<gko::CudaExecutor> cuda;
 };

--- a/doc/conf/Doxyfile-pdf.in
+++ b/doc/conf/Doxyfile-pdf.in
@@ -24,7 +24,6 @@ LATEX_TIMESTAMP        = NO
 PREDEFINED = @default_predefined_macros@ protected=private
 
 # hide all unnecessary graphs
-CLASS_DIAGRAMS         = NO
 CLASS_GRAPH            = NO
 COLLABORATION_GRAPH    = NO
 GROUP_GRAPHS           = NO

--- a/doc/conf/Doxyfile.in
+++ b/doc/conf/Doxyfile.in
@@ -82,8 +82,7 @@ ALLEXTERNALS           = NO
 EXTERNAL_GROUPS        = YES
 
 # Graph generation
-CLASS_DIAGRAMS         = YES
-CLASS_GRAPH            = NO
+CLASS_GRAPH            = YES
 COLLABORATION_GRAPH    = YES
 GROUP_GRAPHS           = YES
 GRAPHICAL_HIERARCHY    = YES

--- a/hip/test/base/CMakeLists.txt
+++ b/hip/test/base/CMakeLists.txt
@@ -1,5 +1,5 @@
 ginkgo_create_hip_test(hip_executor)
-ginkgo_create_hip_test(index_set)
+ginkgo_create_test(index_set)
 ginkgo_create_test(hip_executor_reset ADDITIONAL_LIBRARIES Threads::Threads)
 if(GINKGO_HAVE_HWLOC)
     find_package(NUMA REQUIRED)

--- a/hip/test/base/index_set.cpp
+++ b/hip/test/base/index_set.cpp
@@ -81,15 +81,6 @@ protected:
         }
     }
 
-    static void assert_equal_arrays(const T num_elems, const T* a, const T* b)
-    {
-        if (num_elems > 0) {
-            for (auto i = 0; i < num_elems; ++i) {
-                EXPECT_EQ(a[i], b[i]);
-            }
-        }
-    }
-
     std::shared_ptr<const gko::Executor> exec;
     std::shared_ptr<gko::HipExecutor> hip;
 };


### PR DESCRIPTION
Removes a unused function and a deprecated Doxygen option.

Fixes #1185