### PR TITLE
Missing fixes for 1.5.0

### DIFF
--- a/.github/workflows/joss.yml
+++ b/.github/workflows/joss.yml
@@ -28,7 +28,7 @@ jobs:
         cd doc
         cp -r ../../doc/joss ./
         cd joss
-        pandoc paper.md -o paper.pdf --bibliography ./paper.bib --latex-engine=xelatex
+        pandoc paper.md -o paper.pdf --bibliography ./paper.bib --pdf-engine=xelatex
         popd
     - uses: actions/upload-artifact@v1.0.0
       with:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -924,7 +924,7 @@ gh-pages:
     - git diff --quiet HEAD ||
       (git commit -m "Update documentation from ginkgo-project/ginkgo@${CURRENT_SHA}" && git push)
   dependencies: null
-  needs: [ "sync" ]
+  needs: []
 
 
 threadsanitizer:

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -28,8 +28,8 @@ authors:
 - family-names: "Tsai"
   given-names: "Yuhsiang"
 title: "Ginkgo: A Modern Linear Operator Algebra Framework for High Performance Computing"
-version: 1.4.0
-date-released: 2021-08-23
+version: 1.5.0
+date-released: 2022-11-12
 url: "https://github.com/ginkgo-project/ginkgo"
 preferred-citation:
   type: article

--- a/core/mpi/exception.cpp
+++ b/core/mpi/exception.cpp
@@ -31,8 +31,10 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ******************************<GINKGO LICENSE>*******************************/
 
 #include <array>
-#include <mpi.h>
 #include <string>
+
+
+#include <mpi.h>
 
 
 #include <ginkgo/core/base/exception.hpp>

--- a/examples/mixed-multigrid-solver/CMakeLists.txt
+++ b/examples/mixed-multigrid-solver/CMakeLists.txt
@@ -3,7 +3,7 @@ project(mixed-multigrid-solver)
 
 # We only need to find Ginkgo if we build this example stand-alone
 if (NOT GINKGO_BUILD_EXAMPLES)
-    find_package(Ginkgo 1.4.0 REQUIRED)
+    find_package(Ginkgo 1.5.0 REQUIRED)
 endif()
 
 add_executable(mixed-multigrid-solver mixed-multigrid-solver.cpp)

--- a/examples/multigrid-preconditioned-solver/CMakeLists.txt
+++ b/examples/multigrid-preconditioned-solver/CMakeLists.txt
@@ -3,7 +3,7 @@ project(multigrid-preconditioned-solver)
 
 # We only need to find Ginkgo if we build this example stand-alone
 if (NOT GINKGO_BUILD_EXAMPLES)
-    find_package(Ginkgo 1.4.0 REQUIRED)
+    find_package(Ginkgo 1.5.0 REQUIRED)
 endif()
 
 add_executable(multigrid-preconditioned-solver multigrid-preconditioned-solver.cpp)


### PR DESCRIPTION
A few versions were still wrong, and pandoc for JOSS failed:

https://github.com/ginkgo-project/ginkgo/actions/runs/3455660807/jobs/5767841397

This contains the same pipeline fixes as #1199 but for develop.