### PR TITLE
Errors with the pipelines for 1.5.0

### DIFF
--- a/.github/workflows/joss.yml
+++ b/.github/workflows/joss.yml
@@ -28,7 +28,7 @@ jobs:
         cd doc
         cp -r ../../doc/joss ./
         cd joss
-        pandoc paper.md -o paper.pdf --bibliography ./paper.bib --latex-engine=xelatex
+        pandoc paper.md -o paper.pdf --bibliography ./paper.bib --pdf-engine=xelatex
         popd
     - uses: actions/upload-artifact@v1.0.0
       with:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -924,7 +924,7 @@ gh-pages:
     - git diff --quiet HEAD ||
       (git commit -m "Update documentation from ginkgo-project/ginkgo@${CURRENT_SHA}" && git push)
   dependencies: null
-  needs: [ "sync" ]
+  needs: []
 
 
 threadsanitizer:


### PR DESCRIPTION
Some fixes required if we want passing pipelines for master and v1.5.0 tag