### PR TITLE
Fix path to openmpi_test.cpp in uses_openmpi try_run

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -224,8 +224,8 @@ if(GINKGO_BUILD_MPI)
     endif()
 
     try_run(uses_openmpi gko_result_unused
-        ${PROJECT_BINARY_DIR}
-        ${CMAKE_SOURCE_DIR}/cmake/openmpi_test.cpp
+        ${Ginkgo_BINARY_DIR}
+        ${Ginkgo_SOURCE_DIR}/cmake/openmpi_test.cpp
         LINK_LIBRARIES MPI::MPI_CXX
         RUN_OUTPUT_VARIABLE openmpi_version
         )

--- a/contributors.txt
+++ b/contributors.txt
@@ -23,3 +23,4 @@ Olenik Gregor <go@hpsim.de> HPSim
 Ribizel Tobias <mail@upsj.de> Karlsruhe Institute of Technology
 Riemer Lukas <lksriemer@gmail.com> Karlsruhe Institute of Technology
 Tsai Yuhsiang <yhmtsai@gmail.com> National Taiwan University
+Niklas Conen <niklas.conen@student.kit.edu> Karlsruhe Institute of Technology

--- a/contributors.txt
+++ b/contributors.txt
@@ -7,6 +7,7 @@ Boman Erik <egboman@sandia.gov> Sandia National Laboratories
 Castelli Fabian <fabian.castelli@kit.edu> Karlsruhe Institute of Technology
 Chen Yenchen <yanjen224@gmail.com> National Taiwan University
 Cojean Terry <terry.cojean@kit.edu> Karlsruhe Institute of Technology
+Conen Niklas <niklas.conen@student.kit.edu> Karlsruhe Institute of Technology
 Drzaic Jelena <jelena.drzaic1@gmail.com> University of Zagreb
 Flegar Goran <flegar@uji.es> Universitat Jaume I
 Göbel Fritz <goebel.fritz@gmail.com> Karlsruhe Institute of Technology
@@ -23,4 +24,3 @@ Olenik Gregor <go@hpsim.de> HPSim
 Ribizel Tobias <mail@upsj.de> Karlsruhe Institute of Technology
 Riemer Lukas <lksriemer@gmail.com> Karlsruhe Institute of Technology
 Tsai Yuhsiang <yhmtsai@gmail.com> National Taiwan University
-Niklas Conen <niklas.conen@student.kit.edu> Karlsruhe Institute of Technology


### PR DESCRIPTION
This fixes an issue with the uses_openmpi test run to determine the OpenMPI version introduced in commit https://github.com/ginkgo-project/ginkgo/commit/2c05a7949974dfeb0562590d8ae51861b8a5eb8b#.

Currently the path to the openmpi_test.cpp file is given using CMAKE_SOURCE_DIR which resolves to the source direction of the highest cmake script. In M++ we include Ginkgo as subproject which results in an error when compiling, because the test file can not be found.
I switched this to Ginkgo_SOURCE_DIR which resolves to ginkgos project directory. 

This compiles within M++ and as standalone project without errors now.
