### PR TITLE
Enable distributed Gmres

### DIFF
--- a/core/distributed/vector.cpp
+++ b/core/distributed/vector.cpp
@@ -478,8 +478,8 @@ ValueType& Vector<ValueType>::at_local(size_type row, size_type col) noexcept
 }
 
 template <typename ValueType>
-ValueType Vector<ValueType>::at_local(size_type row,
-                                      size_type col) const noexcept
+ValueType Vector<ValueType>::at_local(size_type row, size_type col) const
+    noexcept
 {
     return local_.at(row, col);
 }

--- a/core/matrix/dense.cpp
+++ b/core/matrix/dense.cpp
@@ -1657,15 +1657,14 @@ std::unique_ptr<Dense<ValueType>> Dense<ValueType>::create_submatrix_impl(
 {
     row_major_range range_this{this->get_values(), this->get_size()[0],
                                this->get_size()[1], this->get_stride()};
-    auto range_result = range_this(rows, columns);
+    auto sub_range = range_this(rows, columns);
     size_type storage_size =
-        rows.length() > 0
-            ? range_result.length(0) * this->get_stride() - columns.begin
-            : 0;
+        rows.length() > 0 ? sub_range.length(1) +
+                                (sub_range.length(0) - 1) * this->get_stride()
+                          : 0;
     return Dense::create(
-        this->get_executor(),
-        dim<2>{range_result.length(0), range_result.length(1)},
-        make_array_view(this->get_executor(), storage_size, range_result->data),
+        this->get_executor(), dim<2>{sub_range.length(0), sub_range.length(1)},
+        make_array_view(this->get_executor(), storage_size, sub_range->data),
         stride);
 }
 

--- a/core/solver/gmres.cpp
+++ b/core/solver/gmres.cpp
@@ -138,6 +138,11 @@ struct help_compute_norm<ValueType,
 };
 
 
+/**
+ * Helper to extract a submatrix.
+ *
+ * @note  global_size is unused, since it can be deferred from rows and cols.
+ */
 template <typename ValueType>
 std::unique_ptr<matrix::Dense<ValueType>> create_submatrix_helper(
     matrix::Dense<ValueType>* mtx, dim<2> global_size, span rows, span cols)
@@ -149,6 +154,13 @@ std::unique_ptr<matrix::Dense<ValueType>> create_submatrix_helper(
 #if GINKGO_BUILD_MPI
 
 
+/**
+ * Helper to extract a submatrix.
+ *
+ * @param global_size  the global_size of the submatrix
+ * @param rows  the rows of the submatrix in local indices
+ * @param cols  the columns of the submatrix in local indices
+ */
 template <typename ValueType>
 std::unique_ptr<experimental::distributed::Vector<ValueType>>
 create_submatrix_helper(experimental::distributed::Vector<ValueType>* mtx,

--- a/core/solver/gmres.cpp
+++ b/core/solver/gmres.cpp
@@ -136,11 +136,12 @@ struct help_compute_norm<ValueType,
 
 
 template <typename ValueType>
-void Gmres<ValueType>::apply_dense_impl(const matrix::Dense<ValueType>* dense_b,
-                                        matrix::Dense<ValueType>* dense_x) const
+template <typename VectorType>
+void Gmres<ValueType>::apply_dense_impl(const VectorType* dense_b,
+                                        VectorType* dense_x) const
 {
-    using Vector = matrix::Dense<ValueType>;
-    using NormVector = matrix::Dense<remove_complex<ValueType>>;
+    using Vector = VectorType;
+    using NormVector = typename Vector::absolute_type;
     using ws = workspace_traits<Gmres>;
 
     constexpr uint8 RelativeStoppingId{1};

--- a/core/solver/gmres.cpp
+++ b/core/solver/gmres.cpp
@@ -45,6 +45,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <ginkgo/core/matrix/identity.hpp>
 
 
+#include "core/distributed/helpers.hpp"
 #include "core/solver/common_gmres_kernels.hpp"
 #include "core/solver/gmres_kernels.hpp"
 #include "core/solver/solver_boilerplate.hpp"
@@ -136,12 +137,47 @@ struct help_compute_norm<ValueType,
 
 
 template <typename ValueType>
+std::unique_ptr<matrix::Dense<ValueType>> create_submatrix_helper(
+    matrix::Dense<ValueType>* mtx, span rows, span cols)
+{
+    return mtx->create_submatrix(rows, cols);
+}
+
+
+#if GINKGO_BUILD_MPI
+
+
+template <typename ValueType>
+std::unique_ptr<experimental::distributed::Vector<ValueType>>
+create_submatrix_helper(experimental::distributed::Vector<ValueType>* mtx,
+                        span rows, span cols)
+{
+    dim<2> global_size{rows.length() * mtx->get_communicator().size(),
+                       cols.length()};
+    const auto exec = mtx->get_executor();
+    auto local_view = matrix::Dense<ValueType>::create(
+        exec, dim<2>{rows.length(), cols.length()},
+        make_array_view(exec,
+                        mtx->get_local_vector()->get_num_stored_elements(),
+                        mtx->get_local_values()),
+        mtx->get_local_vector()->get_stride());
+    return experimental::distributed::Vector<ValueType>::create(
+        exec, mtx->get_communicator(), global_size,
+        local_view->create_submatrix(rows, cols).get());
+}
+
+
+#endif
+
+
+template <typename ValueType>
 template <typename VectorType>
 void Gmres<ValueType>::apply_dense_impl(const VectorType* dense_b,
                                         VectorType* dense_x) const
 {
     using Vector = VectorType;
-    using NormVector = typename Vector::absolute_type;
+    using LocalVector = matrix::Dense<typename Vector::value_type>;
+    using NormVector = typename LocalVector::absolute_type;
     using ws = workspace_traits<Gmres>;
 
     constexpr uint8 RelativeStoppingId{1};
@@ -150,25 +186,28 @@ void Gmres<ValueType>::apply_dense_impl(const VectorType* dense_b,
     this->setup_workspace();
 
     const auto num_rows = this->get_size()[0];
+    const auto local_num_rows =
+        ::gko::detail::get_local(dense_b)->get_size()[0];
     const auto num_rhs = dense_b->get_size()[1];
     const auto krylov_dim = this->get_krylov_dim();
     GKO_SOLVER_VECTOR(residual, dense_b);
     GKO_SOLVER_VECTOR(preconditioned_vector, dense_b);
     auto krylov_bases = this->create_workspace_op_with_type_of(
-        ws::krylov_bases, dense_b,
-        dim<2>{num_rows * (krylov_dim + 1), num_rhs});
+        ws::krylov_bases, dense_b, dim<2>{num_rows * (krylov_dim + 1), num_rhs},
+        dim<2>{local_num_rows * (krylov_dim + 1), num_rhs});
     // rows: rows of Hessenberg matrix, columns: block for each entry
-    auto hessenberg = this->template create_workspace_op<Vector>(
+    auto hessenberg = this->template create_workspace_op<LocalVector>(
         ws::hessenberg, dim<2>{krylov_dim + 1, krylov_dim * num_rhs});
-    auto givens_sin = this->template create_workspace_op<Vector>(
+    auto givens_sin = this->template create_workspace_op<LocalVector>(
         ws::givens_sin, dim<2>{krylov_dim, num_rhs});
-    auto givens_cos = this->template create_workspace_op<Vector>(
+    auto givens_cos = this->template create_workspace_op<LocalVector>(
         ws::givens_cos, dim<2>{krylov_dim, num_rhs});
-    auto residual_norm_collection = this->template create_workspace_op<Vector>(
-        ws::residual_norm_collection, dim<2>{krylov_dim + 1, num_rhs});
+    auto residual_norm_collection =
+        this->template create_workspace_op<LocalVector>(
+            ws::residual_norm_collection, dim<2>{krylov_dim + 1, num_rhs});
     auto residual_norm = this->template create_workspace_op<NormVector>(
         ws::residual_norm, dim<2>{1, num_rhs});
-    auto y = this->template create_workspace_op<Vector>(
+    auto y = this->template create_workspace_op<LocalVector>(
         ws::y, dim<2>{krylov_dim, num_rhs});
     // next_krylov_norm_tmp is only required for complex types to move real
     // values into a complex matrix
@@ -190,8 +229,9 @@ void Gmres<ValueType>::apply_dense_impl(const VectorType* dense_b,
     // residual = dense_b
     // givens_sin = givens_cos = 0
     // reset stop status
-    exec->run(gmres::make_initialize(dense_b, residual, givens_sin, givens_cos,
-                                     stop_status.get_data()));
+    exec->run(gmres::make_initialize(
+        gko::detail::get_local(dense_b), gko::detail::get_local(residual),
+        givens_sin, givens_cos, stop_status.get_data()));
     // residual = residual - Ax
     this->get_system_matrix()->apply(neg_one_op, dense_x, one_op, residual);
 
@@ -200,8 +240,9 @@ void Gmres<ValueType>::apply_dense_impl(const VectorType* dense_b,
     // residual_norm_collection = {residual_norm, unchanged}
     // krylov_bases(:, 1) = residual / residual_norm
     // final_iter_nums = {0, ..., 0}
-    exec->run(gmres::make_restart(residual, residual_norm,
-                                  residual_norm_collection, krylov_bases,
+    exec->run(gmres::make_restart(gko::detail::get_local(residual),
+                                  residual_norm, residual_norm_collection,
+                                  gko::detail::get_local(krylov_bases),
                                   final_iter_nums.get_data()));
 
     auto stop_criterion = this->get_stop_criterion_factory()->generate(
@@ -253,7 +294,8 @@ void Gmres<ValueType>::apply_dense_impl(const VectorType* dense_b,
                                                stop_status.get_const_data()));
             // before_preconditioner = krylov_bases * y
             exec->run(gmres::make_multi_axpy(
-                krylov_bases, y, before_preconditioner,
+                gko::detail::get_local(krylov_bases), y,
+                gko::detail::get_local(before_preconditioner),
                 final_iter_nums.get_const_data(), stop_status.get_data()));
 
             // x = x + get_preconditioner() * before_preconditioner
@@ -271,15 +313,18 @@ void Gmres<ValueType>::apply_dense_impl(const VectorType* dense_b,
             // krylov_bases(:, 1) = residual / residual_norm
             // final_iter_nums = {0, ..., 0}
             exec->run(gmres::make_restart(
-                residual, residual_norm, residual_norm_collection, krylov_bases,
+                gko::detail::get_local(residual), residual_norm,
+                residual_norm_collection, gko::detail::get_local(krylov_bases),
                 final_iter_nums.get_data()));
             restart_iter = 0;
         }
-        auto this_krylov = krylov_bases->create_submatrix(
+        auto this_krylov = create_submatrix_helper(
+            krylov_bases,
             span{num_rows * restart_iter, num_rows * (restart_iter + 1)},
             span{0, num_rhs});
 
-        auto next_krylov = krylov_bases->create_submatrix(
+        auto next_krylov = create_submatrix_helper(
+            krylov_bases,
             span{num_rows * (restart_iter + 1), num_rows * (restart_iter + 2)},
             span{0, num_rhs});
         // preconditioned_vector = get_preconditioner() * this_krylov
@@ -303,8 +348,9 @@ void Gmres<ValueType>::apply_dense_impl(const VectorType* dense_b,
             // next_krylov -= hessenberg(i, restart_iter) * krylov_bases(:, i)
             auto hessenberg_entry = hessenberg_iter->create_submatrix(
                 span{i, i + 1}, span{0, num_rhs});
-            auto krylov_basis = krylov_bases->create_submatrix(
-                span{num_rows * i, num_rows * (i + 1)}, span{0, num_rhs});
+            auto krylov_basis = create_submatrix_helper(
+                krylov_bases, span{num_rows * i, num_rows * (i + 1)},
+                span{0, num_rhs});
             next_krylov->compute_conj_dot(
                 krylov_basis.get(), hessenberg_entry.get(), reduction_tmp);
             next_krylov->sub_scaled(hessenberg_entry.get(), krylov_basis.get());
@@ -315,8 +361,8 @@ void Gmres<ValueType>::apply_dense_impl(const VectorType* dense_b,
         auto hessenberg_norm_entry = hessenberg_iter->create_submatrix(
             span{restart_iter + 1, restart_iter + 2}, span{0, num_rhs});
         help_compute_norm<ValueType>::compute_next_krylov_norm_into_hessenberg(
-            next_krylov.get(), hessenberg_norm_entry.get(),
-            next_krylov_norm_tmp, reduction_tmp);
+            gko::detail::get_local(next_krylov.get()),
+            hessenberg_norm_entry.get(), next_krylov_norm_tmp, reduction_tmp);
         next_krylov->inv_scale(hessenberg_norm_entry.get());
         // End of Arnoldi
 
@@ -350,8 +396,8 @@ void Gmres<ValueType>::apply_dense_impl(const VectorType* dense_b,
         restart_iter++;
     }
 
-    auto krylov_bases_small = krylov_bases->create_submatrix(
-        span{0, num_rows * (restart_iter + 1)}, span{0, num_rhs});
+    auto krylov_bases_small = create_submatrix_helper(
+        krylov_bases, span{0, num_rows * (restart_iter + 1)}, span{0, num_rhs});
     auto hessenberg_small = hessenberg->create_submatrix(
         span{0, restart_iter}, span{0, num_rhs * (restart_iter)});
 
@@ -362,7 +408,8 @@ void Gmres<ValueType>::apply_dense_impl(const VectorType* dense_b,
         final_iter_nums.get_const_data(), stop_status.get_const_data()));
     // before_preconditioner = krylov_bases * y
     exec->run(gmres::make_multi_axpy(
-        krylov_bases_small.get(), y, before_preconditioner,
+        gko::detail::get_local(krylov_bases_small.get()), y,
+        gko::detail::get_local(before_preconditioner),
         final_iter_nums.get_const_data(), stop_status.get_data()));
 
     // x = x + get_preconditioner() * before_preconditioner
@@ -379,7 +426,7 @@ void Gmres<ValueType>::apply_impl(const LinOp* alpha, const LinOp* b,
     if (!this->get_system_matrix()) {
         return;
     }
-    precision_dispatch_real_complex<ValueType>(
+    experimental::precision_dispatch_real_complex_distributed<ValueType>(
         [this](auto dense_alpha, auto dense_b, auto dense_beta, auto dense_x) {
             auto x_clone = dense_x->clone();
             this->apply_dense_impl(dense_b, x_clone.get());

--- a/core/test/matrix/dense.cpp
+++ b/core/test/matrix/dense.cpp
@@ -362,12 +362,11 @@ TYPED_TEST(Dense, CanCreateSubmatrixWithStride)
 {
     using value_type = typename TestFixture::value_type;
     auto submtx =
-        this->mtx->create_submatrix(gko::span{0, 1}, gko::span{1, 2}, 3);
+        this->mtx->create_submatrix(gko::span{1, 2}, gko::span{1, 3}, 3);
 
-    EXPECT_EQ(submtx->at(0, 0), value_type{2.0});
-    EXPECT_EQ(submtx->at(0, 1), value_type{3.0});
-    EXPECT_EQ(submtx->at(1, 0), value_type{1.5});
-    EXPECT_EQ(submtx->at(1, 1), value_type{2.5});
+    EXPECT_EQ(submtx->at(0, 0), value_type{2.5});
+    EXPECT_EQ(submtx->at(0, 1), value_type{3.5});
+    EXPECT_EQ(submtx->get_num_stored_elements(), 2);
 }
 
 

--- a/include/ginkgo/core/distributed/vector.hpp
+++ b/include/ginkgo/core/distributed/vector.hpp
@@ -121,6 +121,44 @@ public:
         return (*other).create_with_same_config();
     }
 
+
+    /**
+     * Creates an empty Vector with the same type as another Vector, but on a
+     * different executor.
+     *
+     * @param other  The other multi-vector whose type we target.
+     * @param exec  The executor of the new multi-vector.
+     *
+     * @note  The new multi-vector uses the same communicator as other.
+     *
+     * @returns an empty Vector with the type of other.
+     */
+    static std::unique_ptr<Vector> create_with_type_of(
+        const Vector* other, std::shared_ptr<const Executor> exec)
+    {
+        return (*other).create_with_type_of_impl(exec, {}, {}, 0);
+    }
+
+    /**
+     * Creates an Vector with the same type as another Vector, but on a
+     * different executor and with a different size.
+     *
+     * @param other  The other multi-vector whose type we target.
+     * @param exec  The executor of the new multi-vector.
+     * @param global_size  The global size of the multi-vector.
+     * @param local_size  The local size of the multi-vector.
+     * @param stride  The stride of the new multi-vector.
+     *
+     * @returns a Vector of specified size with the type of other.
+     */
+    static std::unique_ptr<Vector> create_with_type_of(
+        const Vector* other, std::shared_ptr<const Executor> exec,
+        const dim<2>& global_size, const dim<2>& local_size, size_type stride)
+    {
+        return (*other).create_with_type_of_impl(exec, global_size, local_size,
+                                                 stride);
+    }
+
     /**
      * Reads a vector from the device_matrix_data structure and a global row
      * partition.
@@ -498,6 +536,21 @@ protected:
         return Vector::create(
             this->get_executor(), this->get_communicator(), this->get_size(),
             this->get_local_vector()->get_size(), this->get_stride());
+    }
+
+    /**
+     * Creates a Dense matrix with the same type as the callers matrix.
+     *
+     * @param global_size  global_size of the matrix
+     *
+     * @returns a Dense matrix with the same type as the caller.
+     */
+    virtual std::unique_ptr<Vector> create_with_type_of_impl(
+        std::shared_ptr<const Executor> exec, const dim<2>& global_size,
+        const dim<2>& local_size, size_type stride) const
+    {
+        return Vector::create(exec, this->get_communicator(), global_size,
+                              local_size, stride);
     }
 
 private:

--- a/include/ginkgo/core/distributed/vector.hpp
+++ b/include/ginkgo/core/distributed/vector.hpp
@@ -112,14 +112,7 @@ public:
      *
      * @param other  The other vector whose configuration needs to copied.
      */
-    static std::unique_ptr<Vector> create_with_config_of(const Vector* other)
-    {
-        // De-referencing `other` before calling the functions (instead of
-        // using operator `->`) is currently required to be compatible with
-        // CUDA 10.1.
-        // Otherwise, it results in a compile error.
-        return (*other).create_with_same_config();
-    }
+    static std::unique_ptr<Vector> create_with_config_of(const Vector* other);
 
 
     /**
@@ -134,10 +127,7 @@ public:
      * @returns an empty Vector with the type of other.
      */
     static std::unique_ptr<Vector> create_with_type_of(
-        const Vector* other, std::shared_ptr<const Executor> exec)
-    {
-        return (*other).create_with_type_of_impl(exec, {}, {}, 0);
-    }
+        const Vector* other, std::shared_ptr<const Executor> exec);
 
     /**
      * Creates an Vector with the same type as another Vector, but on a
@@ -153,11 +143,7 @@ public:
      */
     static std::unique_ptr<Vector> create_with_type_of(
         const Vector* other, std::shared_ptr<const Executor> exec,
-        const dim<2>& global_size, const dim<2>& local_size, size_type stride)
-    {
-        return (*other).create_with_type_of_impl(exec, global_size, local_size,
-                                                 stride);
-    }
+        const dim<2>& global_size, const dim<2>& local_size, size_type stride);
 
     /**
      * Reads a vector from the device_matrix_data structure and a global row
@@ -531,27 +517,23 @@ protected:
      *
      * @returns a Vector with the same size and stride as the caller.
      */
-    std::unique_ptr<Vector> create_with_same_config() const
-    {
-        return Vector::create(
-            this->get_executor(), this->get_communicator(), this->get_size(),
-            this->get_local_vector()->get_size(), this->get_stride());
-    }
+    virtual std::unique_ptr<Vector> create_with_same_config() const;
 
     /**
-     * Creates a Dense matrix with the same type as the callers matrix.
+     * Creates a Vector with the same type as the callers multi-vector.
      *
-     * @param global_size  global_size of the matrix
+     * @note The new vector will use the same communicator as the caller.
      *
-     * @returns a Dense matrix with the same type as the caller.
+     * @param exec  the executor of the new vector.
+     * @param global_size  global_size of the vector.
+     * @param local_size  the size of the local Dense vector.
+     * @param stride  the stride of the local Dense vector.
+     *
+     * @returns a Vector with the same type as the caller.
      */
     virtual std::unique_ptr<Vector> create_with_type_of_impl(
         std::shared_ptr<const Executor> exec, const dim<2>& global_size,
-        const dim<2>& local_size, size_type stride) const
-    {
-        return Vector::create(exec, this->get_communicator(), global_size,
-                              local_size, stride);
-    }
+        const dim<2>& local_size, size_type stride) const;
 
 private:
     local_vector_type local_;

--- a/include/ginkgo/core/matrix/dense.hpp
+++ b/include/ginkgo/core/matrix/dense.hpp
@@ -186,8 +186,8 @@ public:
     }
 
     /**
-     * Creates a Dense matrix with the same type and executor as another Dense
-     * matrix but a different size.
+     * Creates a Dense matrix with the same type as another Dense
+     * matrix but on a different executor and with a different size.
      *
      * @param other  The other matrix whose type we target.
      * @param exec  The executor of the new matrix.
@@ -215,6 +215,24 @@ public:
     static std::unique_ptr<Dense> create_with_type_of(
         const Dense* other, std::shared_ptr<const Executor> exec,
         const dim<2>& size, size_type stride)
+    {
+        // See create_with_config_of()
+        return (*other).create_with_type_of_impl(exec, size, stride);
+    }
+
+    /**
+     * @copydoc create_with_type_of(const Dense*, std::shared_ptr<const
+     * Executor>, const dim<2>)
+     *
+     * @param local_size  Unused
+     * @param stride  The stride of the new matrix.
+     *
+     * @note This is an overload to stay consistent with
+     *       gko::experimental::distributed::Vector
+     */
+    static std::unique_ptr<Dense> create_with_type_of(
+        const Dense* other, std::shared_ptr<const Executor> exec,
+        const dim<2>& size, const dim<2>& local_size, size_type stride)
     {
         // See create_with_config_of()
         return (*other).create_with_type_of_impl(exec, size, stride);

--- a/include/ginkgo/core/solver/gmres.hpp
+++ b/include/ginkgo/core/solver/gmres.hpp
@@ -139,8 +139,8 @@ public:
 protected:
     void apply_impl(const LinOp* b, LinOp* x) const override;
 
-    void apply_dense_impl(const matrix::Dense<ValueType>* b,
-                          matrix::Dense<ValueType>* x) const;
+    template <typename VectorType>
+    void apply_dense_impl(const VectorType* b, VectorType* x) const;
 
     void apply_impl(const LinOp* alpha, const LinOp* b, const LinOp* beta,
                     LinOp* x) const override;

--- a/include/ginkgo/core/solver/solver_base.hpp
+++ b/include/ginkgo/core/solver/solver_base.hpp
@@ -449,6 +449,22 @@ protected:
             typeid(*vec), size, size[1]);
     }
 
+    template <typename LinOpType>
+    LinOpType* create_workspace_op_with_type_of(int vector_id,
+                                                const LinOpType* vec,
+                                                dim<2> global_size,
+                                                dim<2> local_size) const
+    {
+        return workspace_.template create_or_get_op<LinOpType>(
+            vector_id,
+            [&] {
+                return LinOpType::create_with_type_of(
+                    vec, workspace_.get_executor(), global_size, local_size,
+                    local_size[1]);
+            },
+            typeid(*vec), global_size, local_size[1]);
+    }
+
     template <typename ValueType>
     matrix::Dense<ValueType>* create_workspace_scalar(int vector_id,
                                                       size_type size) const

--- a/test/mpi/distributed/vector.cpp
+++ b/test/mpi/distributed/vector.cpp
@@ -91,12 +91,15 @@ private:
 template <typename ValueLocalGlobalIndexType>
 class VectorCreation : public CommonMpiTestFixture {
 public:
-    using value_type = typename std::tuple_element<
-        0, decltype(ValueLocalGlobalIndexType())>::type;
-    using local_index_type = typename std::tuple_element<
-        1, decltype(ValueLocalGlobalIndexType())>::type;
-    using global_index_type = typename std::tuple_element<
-        2, decltype(ValueLocalGlobalIndexType())>::type;
+    using value_type =
+        typename std::tuple_element<0, decltype(
+                                           ValueLocalGlobalIndexType())>::type;
+    using local_index_type =
+        typename std::tuple_element<1, decltype(
+                                           ValueLocalGlobalIndexType())>::type;
+    using global_index_type =
+        typename std::tuple_element<2, decltype(
+                                           ValueLocalGlobalIndexType())>::type;
     using part_type =
         gko::experimental::distributed::Partition<local_index_type,
                                                   global_index_type>;

--- a/test/mpi/solver/solver.cpp
+++ b/test/mpi/solver/solver.cpp
@@ -330,7 +330,7 @@ protected:
         }
         {
             SCOPED_TRACE("Some empty partition");
-            guarded_fn(gen_part(50, comm.size() - 1));
+            guarded_fn(gen_part(50, std::max(1, comm.size() - 1)));
         }
     }
 

--- a/test/mpi/solver/solver.cpp
+++ b/test/mpi/solver/solver.cpp
@@ -497,7 +497,7 @@ protected:
     std::default_random_engine rand_engine;
 };
 
-using SolverTypes = ::testing::Types<Cg, Cgs, Fcg, Bicgstab, Ir, Gmres<50u>, Gmres<200u>>;
+using SolverTypes = ::testing::Types<Cg, Cgs, Fcg, Bicgstab, Ir, Gmres<10u>, Gmres<100u>>;
 
 TYPED_TEST_SUITE(Solver, SolverTypes, TypenameNameGenerator);
 

--- a/test/mpi/solver/solver.cpp
+++ b/test/mpi/solver/solver.cpp
@@ -51,6 +51,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <ginkgo/core/solver/cg.hpp>
 #include <ginkgo/core/solver/cgs.hpp>
 #include <ginkgo/core/solver/fcg.hpp>
+#include <ginkgo/core/solver/gmres.hpp>
 #include <ginkgo/core/solver/ir.hpp>
 #include <ginkgo/core/stop/residual_norm.hpp>
 
@@ -174,6 +175,18 @@ struct Ir : SimpleSolverTest<gko::solver::Ir<solver_value_type>> {
                             .on(exec))
                     .on(exec))
             .with_relaxation_factor(0.9);
+    }
+};
+
+
+template <unsigned dimension>
+struct Gmres : SimpleSolverTest<gko::solver::Gmres<solver_value_type>> {
+    static typename solver_type::parameters_type build(
+        std::shared_ptr<const gko::Executor> exec)
+    {
+        return SimpleSolverTest<gko::solver::Gmres<solver_value_type>>::build(
+                   std::move(exec))
+            .with_krylov_dim(dimension);
     }
 };
 
@@ -484,7 +497,7 @@ protected:
     std::default_random_engine rand_engine;
 };
 
-using SolverTypes = ::testing::Types<Cg, Cgs, Fcg, Bicgstab, Ir>;
+using SolverTypes = ::testing::Types<Cg, Cgs, Fcg, Bicgstab, Ir, Gmres<50u>, Gmres<200u>>;
 
 TYPED_TEST_SUITE(Solver, SolverTypes, TypenameNameGenerator);
 

--- a/test/mpi/solver/solver.cpp
+++ b/test/mpi/solver/solver.cpp
@@ -497,7 +497,8 @@ protected:
     std::default_random_engine rand_engine;
 };
 
-using SolverTypes = ::testing::Types<Cg, Cgs, Fcg, Bicgstab, Ir, Gmres<10u>, Gmres<100u>>;
+using SolverTypes =
+    ::testing::Types<Cg, Cgs, Fcg, Bicgstab, Ir, Gmres<10u>, Gmres<100u>>;
 
 TYPED_TEST_SUITE(Solver, SolverTypes, TypenameNameGenerator);
 


### PR DESCRIPTION
This PR enables Gmres for our distributed matrices and vectors.

Thanks to the changes in #861 this was quite simple to adapt. Only adding `create_with_type_of` to `Vector` was really necessary. As a consequence, I also needed to add `create_with_type_of(..., gko::dim<2>, gko::dim<2>, stride)` to `Dense` so that both `Vector` and `Dense` have the same interface. It might be possible to sidestep this, but that would require annoying template meta programming.

I decided against adding `create_submatrix` to `Vector`, because I would need to think a bit more about the interface for that.