### PR TITLE
Add missing thrust header to partition

### DIFF
--- a/cuda/distributed/partition_kernels.cu
+++ b/cuda/distributed/partition_kernels.cu
@@ -33,6 +33,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "core/distributed/partition_kernels.hpp"
 
 
+#include <thrust/count.h>
 #include <thrust/device_ptr.h>
 #include <thrust/execution_policy.h>
 #include <thrust/iterator/zip_iterator.h>

--- a/hip/distributed/partition_kernels.hip.cpp
+++ b/hip/distributed/partition_kernels.hip.cpp
@@ -33,6 +33,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "core/distributed/partition_kernels.hpp"
 
 
+#include <thrust/count.h>
 #include <thrust/device_ptr.h>
 #include <thrust/execution_policy.h>
 #include <thrust/iterator/zip_iterator.h>


### PR DESCRIPTION
Add missing thrust header to partition

Thanks to the AMD staff for fixing this and spack's CI for finding this problem. This issue creates a compilation error when compiling Ginkgo with ROCm 5.3.0.