### PR TITLE
add simple check on wiki Changelog

### DIFF
--- a/.github/bot-pr-base.sh
+++ b/.github/bot-pr-base.sh
@@ -30,6 +30,8 @@ PR_JSON=$(api_get $PR_URL)
 echo -n .
 PR_MERGED=$(echo "$PR_JSON" | jq -r .merged)
 echo -n .
+PR_NUMBER=$(echo "$PR_JSON" | jq -r .number)
+echo -n .
 ISSUE_URL=$(echo "$PR_JSON" | jq -er ".issue_url")
 echo -n .
 BASE_REPO=$(echo "$PR_JSON" | jq -er .base.repo.full_name)

--- a/.github/check-wiki-changelog.sh
+++ b/.github/check-wiki-changelog.sh
@@ -2,20 +2,21 @@
 
 source .github/bot-pr-base.sh
 
-echo "Check whether PR contains 1:ST:skip-changelog-wiki-check label"
+echo "Checking whether the PR contains the 1:ST:skip-changelog-wiki-check label"
 SKIP_CHECK=$(api_get "$PR_URL" | jq -r 'any( [.labels | .[] | .name ] | .[] ; . == "1:ST:skip-changelog-wiki-check")')
 
 if [[ "$SKIP_CHECK" == "true" ]]; then
-  echo "The PR contains 1:ST:skip-changelog-wiki-check label, so skip the wiki check"
+  echo "The PR contains the 1:ST:skip-changelog-wiki-check label. Skipping the wiki check."
 elif [[ "$HEAD_BRANCH" =~ ^release.* ]]; then
-  echo "The PR branch name starts with release, so skip the wiki check"
+  echo "The PR branch name starts with release. Skipping the wiki check."
 else
   curl https://raw.githubusercontent.com/wiki/ginkgo-project/ginkgo/Changelog.md > Changelog.md
   PR="\[\#${PR_NUMBER}\]\(https://github.com/ginkgo-project/ginkgo/(issues|pull)/${PR_NUMBER}\)"
   HAS_WIKI="$(cat Changelog.md | grep -E ${PR} || echo false)"
   if [[ "${HAS_WIKI}" == "false" ]]; then
     echo "This PR does not create the corresponding entry in wiki/Changelog"
-    echo "Please adds [#${PR_NUMBER}](https://github.com/ginkgo-project/ginkgo/pull/${PR_NUMBER}) in wiki/Changelog"
+    echo "Please add [#${PR_NUMBER}](https://github.com/ginkgo-project/ginkgo/pull/${PR_NUMBER}) in the wiki/Changelog page"
+    echo "Alternatively, use the label 1:ST:skip-changelog-wiki-check to skip this check."
     exit 1
   else
     echo "wiki/Changelog already has this PR entry."

--- a/.github/check-wiki-changelog.sh
+++ b/.github/check-wiki-changelog.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+source .github/bot-pr-base.sh
+
+echo "Check whether PR contains 1:ST:skip-changelog-wiki-check label"
+SKIP_CHECK=$(api_get "$PR_URL" | jq -r 'any( [.labels | .[] | .name ] | .[] ; . == "1:ST:skip-changelog-wiki-check")')
+
+if [[ "$SKIP_CHECK" == "true" ]]; then
+  echo "The PR contains 1:ST:skip-changelog-wiki-check label, so skip the wiki check"
+elif [[ "$HEAD_BRANCH" =~ ^release.* ]]; then
+  echo "The PR branch name starts with release, so skip the wiki check"
+else
+  curl https://raw.githubusercontent.com/wiki/ginkgo-project/ginkgo/Changelog.md > Changelog.md
+  PR="\[\#${PR_NUMBER}\]\(https://github.com/ginkgo-project/ginkgo/(issues|pull)/${PR_NUMBER}\)"
+  HAS_WIKI="$(cat Changelog.md | grep -E ${PR} || echo false)"
+  if [[ "${HAS_WIKI}" == "false" ]]; then
+    echo "This PR does not create the corresponding entry in wiki/Changelog"
+    echo "Please adds [#${PR_NUMBER}](https://github.com/ginkgo-project/ginkgo/pull/${PR_NUMBER}) in wiki/Changelog"
+    exit 1
+  else
+    echo "wiki/Changelog already has this PR entry."
+  fi
+fi

--- a/.github/check-wiki-changelog.sh
+++ b/.github/check-wiki-changelog.sh
@@ -7,7 +7,7 @@ SKIP_CHECK=$(api_get "$PR_URL" | jq -r 'any( [.labels | .[] | .name ] | .[] ; . 
 
 if [[ "$SKIP_CHECK" == "true" ]]; then
   echo "The PR contains the 1:ST:skip-changelog-wiki-check label. Skipping the wiki check."
-elif [[ "$HEAD_BRANCH" =~ ^release.* ]]; then
+elif [[ "$HEAD_BRANCH" =~ ^release-.* ]]; then
   echo "The PR branch name starts with release. Skipping the wiki check."
 else
   curl https://raw.githubusercontent.com/wiki/ginkgo-project/ginkgo/Changelog.md > Changelog.md

--- a/.github/check-wiki-changelog.sh
+++ b/.github/check-wiki-changelog.sh
@@ -2,11 +2,11 @@
 
 source .github/bot-pr-base.sh
 
-echo "Checking whether the PR contains the 1:ST:skip-changelog-wiki-check label"
-SKIP_CHECK=$(api_get "$PR_URL" | jq -r 'any( [.labels | .[] | .name ] | .[] ; . == "1:ST:skip-changelog-wiki-check")')
+echo "Checking whether the PR contains the 1:ST:no-changelog-entry label"
+SKIP_CHECK=$(api_get "$PR_URL" | jq -r 'any( [.labels | .[] | .name ] | .[] ; . == "1:ST:no-changelog-entry")')
 
 if [[ "$SKIP_CHECK" == "true" ]]; then
-  echo "The PR contains the 1:ST:skip-changelog-wiki-check label. Skipping the wiki check."
+  echo "The PR contains the 1:ST:no-changelog-entry label. Skipping the wiki check."
 elif [[ "$HEAD_BRANCH" =~ ^release-.* ]]; then
   echo "The PR branch name starts with release. Skipping the wiki check."
 else
@@ -16,7 +16,7 @@ else
   if [[ "${HAS_WIKI}" == "false" ]]; then
     echo "This PR does not create the corresponding entry in wiki/Changelog"
     echo "Please add [#${PR_NUMBER}](https://github.com/ginkgo-project/ginkgo/pull/${PR_NUMBER}) in the wiki/Changelog page"
-    echo "Alternatively, use the label 1:ST:skip-changelog-wiki-check to skip this check."
+    echo "Alternatively, use the label 1:ST:no-changelog-entry to skip this check."
     exit 1
   else
     echo "wiki/Changelog already has this PR entry."

--- a/.github/workflows/bot-pr-updated.yml
+++ b/.github/workflows/bot-pr-updated.yml
@@ -60,3 +60,14 @@ jobs:
         with:
             name: abi
             path: abi.diff
+  changelog-wiki-check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: check if the PR ID exists in wiki
+        # Disable it when label contains 1:ST:skip-changelog-wiki-check or the branch name starts with release
+        if: ! contains(github.event.issue.labels.*.name, '1:ST:skip-changelog-wiki-check') || ! startsWith( ${{ github.event.pull_request.head.name }}, 'release')
+        run: |
+          PR_NUMBER=${{ github.event.pull_request.number }}
+          curl https://raw.githubusercontent.com/wiki/ginkgo-project/ginkgo/Changelog.md > Changelog.md
+          PR=\[\#${PR_NUMBER}\]\(https://github.com/ginkgo-project/ginkgo/(issues|pull)/${PR_NUMBER}\)
+          cat Changelog.md | grep -E ${PR}

--- a/.github/workflows/bot-pr-updated.yml
+++ b/.github/workflows/bot-pr-updated.yml
@@ -64,10 +64,29 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: check if the PR ID exists in wiki
+        env:
+          # it suggests the head.ref should be accessd by environment.
+          BRANCH_NAME: ${{ github.event.pull_request.head.ref }}
         # Disable it when label contains 1:ST:skip-changelog-wiki-check or the branch name starts with release
-        if: ! contains(github.event.issue.labels.*.name, '1:ST:skip-changelog-wiki-check') || ! startsWith( ${{ github.event.pull_request.head.name }}, 'release')
+        # need use ${{  }} evaluate to avoid special character ! as the first one
+        # On the pull_request trigger, it needs to use github.event.pull_request
+        # In if statement, the environment is accessed by env.variable. It can not be accessed by $variable because it is on action side not runner side.
+        # The label is not updated if we only change the label and rerun the action.
+        if: |
+          ${{
+            !contains(github.event.pull_request.labels.*.name, '1:ST:skip-changelog-wiki-check') && 
+            !startsWith( env.BRANCH_NAME, 'release')
+          }}
+        # echo accepts "$variable" not "${variable}" from environment
         run: |
           PR_NUMBER=${{ github.event.pull_request.number }}
           curl https://raw.githubusercontent.com/wiki/ginkgo-project/ginkgo/Changelog.md > Changelog.md
-          PR=\[\#${PR_NUMBER}\]\(https://github.com/ginkgo-project/ginkgo/(issues|pull)/${PR_NUMBER}\)
-          cat Changelog.md | grep -E ${PR}
+          PR="\[\#${PR_NUMBER}\]\(https://github.com/ginkgo-project/ginkgo/(issues|pull)/${PR_NUMBER}\)
+          HAS_WIKI="$(cat Changelog.md | grep -E ${PR} || echo false)"
+          if [[ "${HAS_WIKI}" == "false" ]]; then
+            echo "This PR does not create the corresponding entry in wiki/Changelog"
+            echo "Please adds [#${PR_NUMBER}](https://github.com/ginkgo-project/ginkgo/pull/${PR_NUMBER}) in wiki/Changelog"
+            exit 1
+          else
+            echo "Wiki already has this PR entry."
+          fi

--- a/.github/workflows/bot-pr-updated.yml
+++ b/.github/workflows/bot-pr-updated.yml
@@ -71,4 +71,4 @@ jobs:
     - name: Check if PR number exists in wiki/Changelog
       env:
         GITHUB_TOKEN: ${{ secrets.BOT_TOKEN }}
-      run: cp --preserve .github/check-wiki-changelog.sh /tmp && /tmp/check-wiki-changelog.sh
+      run: .github/check-wiki-changelog.sh

--- a/.github/workflows/bot-pr-updated.yml
+++ b/.github/workflows/bot-pr-updated.yml
@@ -60,33 +60,15 @@ jobs:
         with:
             name: abi
             path: abi.diff
-  changelog-wiki-check:
+  check-wiki-changelog:
     runs-on: ubuntu-latest
+    if: github.event.pull_request.author_association == 'COLLABORATOR' || github.event.pull_request.author_association == 'MEMBER' || github.event.pull_request.author_association == 'OWNER'
     steps:
-      - name: check if the PR ID exists in wiki
-        env:
-          # it suggests the head.ref should be accessd by environment.
-          BRANCH_NAME: ${{ github.event.pull_request.head.ref }}
-        # Disable it when label contains 1:ST:skip-changelog-wiki-check or the branch name starts with release
-        # need use ${{  }} evaluate to avoid special character ! as the first one
-        # On the pull_request trigger, it needs to use github.event.pull_request
-        # In if statement, the environment is accessed by env.variable. It can not be accessed by $variable because it is on action side not runner side.
-        # The label is not updated if we only change the label and rerun the action.
-        if: |
-          ${{
-            !contains(github.event.pull_request.labels.*.name, '1:ST:skip-changelog-wiki-check') && 
-            !startsWith( env.BRANCH_NAME, 'release')
-          }}
-        # echo accepts "$variable" not "${variable}" from environment
-        run: |
-          PR_NUMBER=${{ github.event.pull_request.number }}
-          curl https://raw.githubusercontent.com/wiki/ginkgo-project/ginkgo/Changelog.md > Changelog.md
-          PR="\[\#${PR_NUMBER}\]\(https://github.com/ginkgo-project/ginkgo/(issues|pull)/${PR_NUMBER}\)
-          HAS_WIKI="$(cat Changelog.md | grep -E ${PR} || echo false)"
-          if [[ "${HAS_WIKI}" == "false" ]]; then
-            echo "This PR does not create the corresponding entry in wiki/Changelog"
-            echo "Please adds [#${PR_NUMBER}](https://github.com/ginkgo-project/ginkgo/pull/${PR_NUMBER}) in wiki/Changelog"
-            exit 1
-          else
-            echo "Wiki already has this PR entry."
-          fi
+    - name: Checkout the latest code (shallow clone)
+      uses: actions/checkout@v2
+      with:
+        ref: develop
+    - name: Check if PR number exists in wiki/Changelog
+      env:
+        GITHUB_TOKEN: ${{ secrets.BOT_TOKEN }}
+      run: cp --preserve .github/check-wiki-changelog.sh /tmp && /tmp/check-wiki-changelog.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ git log --first-parent
 ```
 
 
+## Unreleased
+
+Please visit our wiki [Changelog](https://github.com/ginkgo-project/ginkgo/wiki/Changelog) for unreleased changes.
+
+
 ## Version 1.5.0
 
 The Ginkgo team is proud to announce the new Ginkgo minor release 1.5.0. This release brings many important new features such as:
@@ -42,7 +47,7 @@ Supported systems and requirements:
   + OpenMP module: MinGW or Cygwin.
 
 
-Algorithm and important feature additions:
+### Algorithm and important feature additions
 + Add MPI-based multi-node for all matrix formats and solvers (except GMRES and IDR). ([#676](https://github.com/ginkgo-project/ginkgo/pull/676), [#908](https://github.com/ginkgo-project/ginkgo/pull/908), [#909](https://github.com/ginkgo-project/ginkgo/pull/909), [#932](https://github.com/ginkgo-project/ginkgo/pull/932), [#951](https://github.com/ginkgo-project/ginkgo/pull/951), [#961](https://github.com/ginkgo-project/ginkgo/pull/961), [#971](https://github.com/ginkgo-project/ginkgo/pull/971), [#976](https://github.com/ginkgo-project/ginkgo/pull/976), [#985](https://github.com/ginkgo-project/ginkgo/pull/985), [#1007](https://github.com/ginkgo-project/ginkgo/pull/1007), [#1030](https://github.com/ginkgo-project/ginkgo/pull/1030), [#1054](https://github.com/ginkgo-project/ginkgo/pull/1054), [#1100](https://github.com/ginkgo-project/ginkgo/pull/1100), [#1148](https://github.com/ginkgo-project/ginkgo/pull/1148))
 + Porting the remaining algorithms (preconditioners like ISAI, Jacobi, Multigrid, ParILU(T) and ParIC(T)) to DPC++/SYCL, update to SYCL 2020, and improve support and performance ([#896](https://github.com/ginkgo-project/ginkgo/pull/896), [#924](https://github.com/ginkgo-project/ginkgo/pull/924), [#928](https://github.com/ginkgo-project/ginkgo/pull/928), [#929](https://github.com/ginkgo-project/ginkgo/pull/929), [#933](https://github.com/ginkgo-project/ginkgo/pull/933), [#943](https://github.com/ginkgo-project/ginkgo/pull/943), [#960](https://github.com/ginkgo-project/ginkgo/pull/960), [#1057](https://github.com/ginkgo-project/ginkgo/pull/1057), [#1110](https://github.com/ginkgo-project/ginkgo/pull/1110),  [#1142](https://github.com/ginkgo-project/ginkgo/pull/1142))
 + Add a Sparse Direct interface supporting GPU-resident numerical LU factorization, symbolic Cholesky factorization, improved triangular solvers, and more ([#957](https://github.com/ginkgo-project/ginkgo/pull/957), [#1058](https://github.com/ginkgo-project/ginkgo/pull/1058), [#1072](https://github.com/ginkgo-project/ginkgo/pull/1072), [#1082](https://github.com/ginkgo-project/ginkgo/pull/1082))
@@ -62,7 +67,7 @@ Algorithm and important feature additions:
 + Add a scaled identity addition (M <- aI + bM) feature interface and impls for Csr and Dense ([#942](https://github.com/ginkgo-project/ginkgo/pull/942))
 
 
-Deprecations and important changes:
+### Deprecations and important changes
 + Deprecate AmgxPgm in favor of the new Pgm name. ([#1149](https://github.com/ginkgo-project/ginkgo/pull/1149)).
 + Deprecate specialized residual norm classes in favor of a common `ResidualNorm` class ([#1101](https://github.com/ginkgo-project/ginkgo/pull/1101))
 + Deprecate CamelCase non-polymorphic types in favor of snake_case versions (like array, machine_topology, uninitialized_array, index_set) ([#1031](https://github.com/ginkgo-project/ginkgo/pull/1031), [#1052](https://github.com/ginkgo-project/ginkgo/pull/1052))
@@ -71,14 +76,14 @@ Deprecations and important changes:
 + Drop official support for old CUDA < 9.2 ([#887](https://github.com/ginkgo-project/ginkgo/pull/887))
 
 
-Improved performance additions:
+### Improved performance additions
 + Reuse tmp storage in reductions in solvers and add a mutable workspace to all solvers ([#1013](https://github.com/ginkgo-project/ginkgo/pull/1013), [#1028](https://github.com/ginkgo-project/ginkgo/pull/1028))
 + Add HIP unsafe atomic option for AMD ([#1091](https://github.com/ginkgo-project/ginkgo/pull/1091))
 + Prefer vendor implementations for Dense dot, conj_dot and norm2 when available ([#967](https://github.com/ginkgo-project/ginkgo/pull/967)).
 + Tuned OpenMP SellP, COO, and ELL SpMV kernels for a small number of RHS ([#809](https://github.com/ginkgo-project/ginkgo/pull/809))
 
 
-Fixes:
+### Fixes
 + Fix various compilation warnings ([#1076](https://github.com/ginkgo-project/ginkgo/pull/1076), [#1183](https://github.com/ginkgo-project/ginkgo/pull/1183), [#1189](https://github.com/ginkgo-project/ginkgo/pull/1189))
 + Fix issues with hwloc-related tests ([#1074](https://github.com/ginkgo-project/ginkgo/pull/1074))
 + Fix include headers for GCC 12 ([#1071](https://github.com/ginkgo-project/ginkgo/pull/1071))
@@ -93,7 +98,7 @@ Fixes:
 + Fixes for `NVHPC` compiler support ([#1194](https://github.com/ginkgo-project/ginkgo/pull/1194))
 
 
-Other additions:
+### Other additions
 + Simplify and properly name GMRES kernels ([#861](https://github.com/ginkgo-project/ginkgo/pull/861))
 + Improve pkg-config support for non-CMake libraries ([#923](https://github.com/ginkgo-project/ginkgo/pull/923), [#1109](https://github.com/ginkgo-project/ginkgo/pull/1109))
 + Improve gdb pretty printer ([#987](https://github.com/ginkgo-project/ginkgo/pull/987), [#1114](https://github.com/ginkgo-project/ginkgo/pull/1114))
@@ -167,7 +172,7 @@ Supported systems and requirements:
   + OpenMP module: MinGW or Cygwin.
 
 
-Algorithm and important feature additions:
+### Algorithm and important feature additions
 + Add a new DPC++ Executor for SYCL execution and other base utilities
   [#648](https://github.com/ginkgo-project/ginkgo/pull/648), [#661](https://github.com/ginkgo-project/ginkgo/pull/661), [#757](https://github.com/ginkgo-project/ginkgo/pull/757), [#832](https://github.com/ginkgo-project/ginkgo/pull/832)
 + Port matrix formats, solvers and related kernels to DPC++. For some kernels,
@@ -190,7 +195,7 @@ Algorithm and important feature additions:
 + Add matrix assembly support on CPUs. [#644](https://github.com/ginkgo-project/ginkgo/pull/644)
 + Extends ISAI from triangular to general and spd matrices. [#690](https://github.com/ginkgo-project/ginkgo/pull/690)
 
-Other additions:
+### Other additions
 + Add possibility to apply real matrices to complex vectors.
   [#655](https://github.com/ginkgo-project/ginkgo/pull/655), [#658](https://github.com/ginkgo-project/ginkgo/pull/658)
 + Add functions to compute the absolute of a matrix format. [#636](https://github.com/ginkgo-project/ginkgo/pull/636)
@@ -214,7 +219,7 @@ Other additions:
 + Add pipeline segmentation for better CI speed. [#737](https://github.com/ginkgo-project/ginkgo/pull/737)
 
 
-Changes:
+### Changes
 + Add a Scalar Jacobi specialization and kernels. [#808](https://github.com/ginkgo-project/ginkgo/pull/808), [#834](https://github.com/ginkgo-project/ginkgo/pull/834), [#854](https://github.com/ginkgo-project/ginkgo/pull/854)
 + Add implicit residual log for solvers and benchmarks. [#714](https://github.com/ginkgo-project/ginkgo/pull/714)
 + Change handling of the conjugate in the dense dot product. [#755](https://github.com/ginkgo-project/ginkgo/pull/755)
@@ -234,7 +239,7 @@ an exclusive prefix sum, and more. [#703](https://github.com/ginkgo-project/gink
 + Improve benchmark timing and output. [#669](https://github.com/ginkgo-project/ginkgo/pull/669), [#791](https://github.com/ginkgo-project/ginkgo/pull/791), [#801](https://github.com/ginkgo-project/ginkgo/pull/801), [#812](https://github.com/ginkgo-project/ginkgo/pull/812)
 
 
-Fixes:
+### Fixes
 + Sorting fix for the Jacobi preconditioner. [#659](https://github.com/ginkgo-project/ginkgo/pull/659)
 + Also log the first residual norm in CGS [#735](https://github.com/ginkgo-project/ginkgo/pull/735)
 + Fix BiCG and HIP CSR to work with complex matrices. [#651](https://github.com/ginkgo-project/ginkgo/pull/651)


### PR DESCRIPTION
this PR adds a small check on Changelog from wiki.
If it is not in the wiki, it should give a failure in pipeline.
The entry must be `[#PR_NUMBER](https://https://github.com/ginkgo-project/ginkgo/issues/${PR_NUMBER})` (for the previous release) or `[#PR_NUMBER](https://https://github.com/ginkgo-project/ginkgo/pull/${PR_NUMBER})` 
If the branch name starts with release or the pr contains the label 1:ST:skip-changelog-wiki-check, it will skip the tests
I use the script based on the rest api to get the latest label in the end.
I do not include the comment usage because it is on develop not link the status to the pr.
We can still rerun the action or push new commit after change the label.
I can link it like gitlab did, but I think it's not quite necessary.

I still keep the commits using action file directly to record the following issue faced and solved.
- yaml considers ! as a special character, so in if condition it can not use ! as the first character.
using ${{ expression }} the evaluation to quote the expression to avoid the issue
- On the pull_request event trigger, needs to use `github.event.pull_request` not `github.event.issue` to get the corresponding data. We can get the same things from rest api via pulls/number and issues/number. One more note: we use pull/number for the link but need to use pulls/number in rest api.
- they suggest github.event.pull_request.head.ref should be accessed by environment not directly in if
- In if condition, we can not access the environment variable like $variable but use env.variable to access it. The if condition is on action side not the runner side, so it does not in the bash yet.
- In bash, I use `echo ${env_variable}`, `echo "$env_variable"` and `echo "${env_variable}"`. The first two are replaced by variable context but the last one print plain text `${env_variable}`
- `github.event.pull_request.labels.*.name` does not update latest status if we only change the labels and rerun the action.

TODO:
- [x] check whether it runs as expected (https://github.com/yhmtsai/ginkgo/pull/7 for the label/wiki behavior and https://github.com/yhmtsai/ginkgo/pull/8 for the release branch)
For https://github.com/yhmtsai/ginkgo/pull/7, please go into the check-wiki action, there are four runs on right top.
first one is pr without label and wiki, second is pr with label but without wiki, the latest on is with wiki