### PR TITLE
Updates git-cmake-format

### DIFF
--- a/third_party/dummy-hook/CMakeLists.txt
+++ b/third_party/dummy-hook/CMakeLists.txt
@@ -1,7 +1,7 @@
 find_package(Git QUIET)
 if(GIT_FOUND)
     execute_process(COMMAND ${GIT_EXECUTABLE} rev-parse --git-path hooks
-      WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+      WORKING_DIRECTORY ${Ginkgo_SOURCE_DIR}
       OUTPUT_VARIABLE Ginkgo_GIT_HOOKS_DIR
       OUTPUT_STRIP_TRAILING_WHITESPACE)
     # If it is not in git, give an error and return
@@ -9,7 +9,7 @@ if(GIT_FOUND)
         message(STATUS "Ginkgo is not in a git repository, so no git hook was installed")
         return()
     endif()
-    get_filename_component(Ginkgo_GIT_HOOKS_DIR ${Ginkgo_GIT_HOOKS_DIR} REALPATH BASE_DIR ${CMAKE_SOURCE_DIR})
+    get_filename_component(Ginkgo_GIT_HOOKS_DIR ${Ginkgo_GIT_HOOKS_DIR} REALPATH BASE_DIR ${Ginkgo_SOURCE_DIR})
     if(EXISTS "${Ginkgo_GIT_HOOKS_DIR}")
         set(ADD_HOOK FALSE)
         set(HOOK_LOCATION "${Ginkgo_GIT_HOOKS_DIR}/pre-commit")

--- a/third_party/git-cmake-format/CMakeLists.txt
+++ b/third_party/git-cmake-format/CMakeLists.txt
@@ -1,16 +1,15 @@
 message(STATUS "Fetching git-cmake-format")
 include(FetchContent)
 FetchContent_Declare(
-    git_cmake_format
-    GIT_REPOSITORY https://github.com/ginkgo-project/git-cmake-format.git
-    GIT_TAG        e9a82f20d36f1a92d4c52910a8d0a694e7673c54
+        git_cmake_format
+        GIT_REPOSITORY https://github.com/ginkgo-project/git-cmake-format.git
+        GIT_TAG customize-toplevel-dir
 )
 FetchContent_GetProperties(git_cmake_format)
 if(NOT git_cmake_format_POPULATED)
     FetchContent_Populate(git_cmake_format)
 
-    if(NOT DEFINED GCF_FORCE_OVERWRITE)
-        set(GCF_FORCE_OVERWRITE ON CACHE INTERNAL "If true, always overwrite pre-commit hook and script")
-    endif()
+    set(GCF_FORCE_OVERWRITE ON CACHE INTERNAL "If true, always overwrite pre-commit hook and script")
+    set(GCF_GIT_TOP_LEVEL_DIR ${Ginkgo_SOURCE_DIR})
     add_subdirectory(${git_cmake_format_SOURCE_DIR} ${git_cmake_format_BINARY_DIR} EXCLUDE_FROM_ALL)
 endif()

--- a/third_party/git-cmake-format/CMakeLists.txt
+++ b/third_party/git-cmake-format/CMakeLists.txt
@@ -3,7 +3,7 @@ include(FetchContent)
 FetchContent_Declare(
         git_cmake_format
         GIT_REPOSITORY https://github.com/ginkgo-project/git-cmake-format.git
-        GIT_TAG customize-toplevel-dir
+        GIT_TAG 966837ee83f2b3b7df9acf59e9d801fcd189dd9b
 )
 FetchContent_GetProperties(git_cmake_format)
 if(NOT git_cmake_format_POPULATED)


### PR DESCRIPTION
This PR updates git-cmake-format to include the latest fix for setting the git hooks directory. This also fixes the directory for the dummy hook.

Fixes #1223.

Todo:
- [x] wait for https://github.com/ginkgo-project/git-cmake-format/pull/11