### PR TITLE
Allows checking if host MPI buffers are required at runtime

### DIFF
--- a/core/base/mpi.cpp
+++ b/core/base/mpi.cpp
@@ -94,8 +94,8 @@ int map_rank_to_device_id(MPI_Comm comm, const int num_devices)
 bool requires_host_buffer(const std::shared_ptr<const Executor>& exec,
                           const communicator& comm)
 {
-    return comm.force_host_buffer() ||
-           (exec != exec->get_master() && !is_gpu_aware());
+    return exec != exec->get_master() &&
+           (comm.force_host_buffer() || !is_gpu_aware());
 }
 
 

--- a/core/base/mpi.cpp
+++ b/core/base/mpi.cpp
@@ -91,6 +91,14 @@ int map_rank_to_device_id(MPI_Comm comm, const int num_devices)
 }
 
 
+bool requires_host_buffer(const std::shared_ptr<const Executor>& exec,
+                          const communicator& comm)
+{
+    return comm.force_host_buffer() ||
+           (exec != exec->get_master() && !is_gpu_aware());
+}
+
+
 }  // namespace mpi
 }  // namespace experimental
 }  // namespace gko

--- a/core/distributed/matrix.cpp
+++ b/core/distributed/matrix.cpp
@@ -209,7 +209,7 @@ void Matrix<ValueType, LocalIndexType, GlobalIndexType>::read_distributed(
 
     // exchange step 2: exchange gather_idxs from receivers to senders
     auto use_host_buffer = exec->get_master() != exec && !mpi::is_gpu_aware();
-    if (use_host_buffer) {
+    if (use_host_buffer || comm.force_host_buffer()) {
         recv_gather_idxs.set_executor(exec->get_master());
         gather_idxs_.clear();
         gather_idxs_.set_executor(exec->get_master());
@@ -219,7 +219,7 @@ void Matrix<ValueType, LocalIndexType, GlobalIndexType>::read_distributed(
                       recv_gather_idxs.get_const_data(), recv_sizes_.data(),
                       recv_offsets_.data(), gather_idxs_.get_data(),
                       send_sizes_.data(), send_offsets_.data());
-    if (use_host_buffer) {
+    if (use_host_buffer || comm.force_host_buffer()) {
         gather_idxs_.set_executor(exec);
     }
 }
@@ -276,17 +276,19 @@ mpi::request Matrix<ValueType, LocalIndexType, GlobalIndexType>::communicate(
     local_b->row_gather(&gather_idxs_, send_buffer_.get());
 
     auto use_host_buffer = exec->get_master() != exec && !mpi::is_gpu_aware();
-    if (use_host_buffer) {
+    if (use_host_buffer || comm.force_host_buffer()) {
         host_recv_buffer_.init(exec->get_master(), recv_dim);
         host_send_buffer_.init(exec->get_master(), send_dim);
         host_send_buffer_->copy_from(send_buffer_.get());
     }
 
     mpi::contiguous_type type(num_cols, mpi::type_impl<ValueType>::get_type());
-    auto send_ptr = use_host_buffer ? host_send_buffer_->get_const_values()
-                                    : send_buffer_->get_const_values();
-    auto recv_ptr = use_host_buffer ? host_recv_buffer_->get_values()
-                                    : recv_buffer_->get_values();
+    auto send_ptr = use_host_buffer || comm.force_host_buffer()
+                        ? host_send_buffer_->get_const_values()
+                        : send_buffer_->get_const_values();
+    auto recv_ptr = use_host_buffer || comm.force_host_buffer()
+                        ? host_recv_buffer_->get_values()
+                        : recv_buffer_->get_values();
     exec->synchronize();
 #ifdef GINKGO_FORCE_SPMV_BLOCKING_COMM
     comm.all_to_all_v(use_host_buffer ? exec->get_master() : exec, send_ptr,
@@ -318,6 +320,7 @@ void Matrix<ValueType, LocalIndexType, GlobalIndexType>::apply_impl(
                     dense_x->get_local_values()),
                 dense_x->get_local_vector()->get_stride());
 
+            auto comm = this->get_communicator();
             auto req = this->communicate(dense_b->get_local_vector());
             local_mtx_->apply(dense_b->get_local_vector(), local_x.get());
             req.wait();
@@ -325,7 +328,7 @@ void Matrix<ValueType, LocalIndexType, GlobalIndexType>::apply_impl(
             auto exec = this->get_executor();
             auto use_host_buffer =
                 exec->get_master() != exec && !mpi::is_gpu_aware();
-            if (use_host_buffer) {
+            if (use_host_buffer || comm.force_host_buffer()) {
                 recv_buffer_->copy_from(host_recv_buffer_.get());
             }
             non_local_mtx_->apply(one_scalar_.get(), recv_buffer_.get(),
@@ -351,6 +354,7 @@ void Matrix<ValueType, LocalIndexType, GlobalIndexType>::apply_impl(
                     dense_x->get_local_values()),
                 dense_x->get_local_vector()->get_stride());
 
+            auto comm = this->get_communicator();
             auto req = this->communicate(dense_b->get_local_vector());
             local_mtx_->apply(local_alpha, dense_b->get_local_vector(),
                               local_beta, local_x.get());
@@ -359,7 +363,7 @@ void Matrix<ValueType, LocalIndexType, GlobalIndexType>::apply_impl(
             auto exec = this->get_executor();
             auto use_host_buffer =
                 exec->get_master() != exec && !mpi::is_gpu_aware();
-            if (use_host_buffer) {
+            if (use_host_buffer || comm.force_host_buffer()) {
                 recv_buffer_->copy_from(host_recv_buffer_.get());
             }
             non_local_mtx_->apply(local_alpha, recv_buffer_.get(),

--- a/core/distributed/vector.cpp
+++ b/core/distributed/vector.cpp
@@ -355,8 +355,7 @@ void Vector<ValueType>::compute_dot(const LinOp* b, LinOp* result,
     this->get_local_vector()->compute_dot(as<Vector>(b)->get_local_vector(),
                                           dense_res.get(), tmp);
     exec->synchronize();
-    auto use_host_buffer = exec->get_master() != exec && !mpi::is_gpu_aware();
-    if (use_host_buffer || comm.force_host_buffer()) {
+    if (mpi::requires_host_buffer(exec, comm)) {
         host_reduction_buffer_.init(exec->get_master(), dense_res->get_size());
         host_reduction_buffer_->copy_from(dense_res.get());
         comm.all_reduce(exec->get_master(),
@@ -390,8 +389,7 @@ void Vector<ValueType>::compute_conj_dot(const LinOp* b, LinOp* result,
     this->get_local_vector()->compute_conj_dot(
         as<Vector>(b)->get_local_vector(), dense_res.get(), tmp);
     exec->synchronize();
-    auto use_host_buffer = exec->get_master() != exec && !mpi::is_gpu_aware();
-    if (use_host_buffer || comm.force_host_buffer()) {
+    if (mpi::requires_host_buffer(exec, comm)) {
         host_reduction_buffer_.init(exec->get_master(), dense_res->get_size());
         host_reduction_buffer_->copy_from(dense_res.get());
         comm.all_reduce(exec->get_master(),
@@ -424,8 +422,7 @@ void Vector<ValueType>::compute_norm2(LinOp* result, array<char>& tmp) const
     exec->run(vector::make_compute_squared_norm2(this->get_local_vector(),
                                                  dense_res.get(), tmp));
     exec->synchronize();
-    auto use_host_buffer = exec->get_master() != exec && !mpi::is_gpu_aware();
-    if (use_host_buffer || comm.force_host_buffer()) {
+    if (mpi::requires_host_buffer(exec, comm)) {
         host_norm_buffer_.init(exec->get_master(), dense_res->get_size());
         host_norm_buffer_->copy_from(dense_res.get());
         comm.all_reduce(exec->get_master(), host_norm_buffer_->get_values(),
@@ -457,8 +454,7 @@ void Vector<ValueType>::compute_norm1(LinOp* result, array<char>& tmp) const
     auto dense_res = make_temporary_clone(exec, as<NormVector>(result));
     this->get_local_vector()->compute_norm1(dense_res.get());
     exec->synchronize();
-    auto use_host_buffer = exec->get_master() != exec && !mpi::is_gpu_aware();
-    if (use_host_buffer || comm.force_host_buffer()) {
+    if (mpi::requires_host_buffer(exec, comm)) {
         host_norm_buffer_.init(exec->get_master(), dense_res->get_size());
         host_norm_buffer_->copy_from(dense_res.get());
         comm.all_reduce(exec->get_master(), host_norm_buffer_->get_values(),

--- a/core/distributed/vector.cpp
+++ b/core/distributed/vector.cpp
@@ -356,7 +356,7 @@ void Vector<ValueType>::compute_dot(const LinOp* b, LinOp* result,
                                           dense_res.get(), tmp);
     exec->synchronize();
     auto use_host_buffer = exec->get_master() != exec && !mpi::is_gpu_aware();
-    if (use_host_buffer) {
+    if (use_host_buffer || comm.force_host_buffer()) {
         host_reduction_buffer_.init(exec->get_master(), dense_res->get_size());
         host_reduction_buffer_->copy_from(dense_res.get());
         comm.all_reduce(exec->get_master(),
@@ -391,7 +391,7 @@ void Vector<ValueType>::compute_conj_dot(const LinOp* b, LinOp* result,
         as<Vector>(b)->get_local_vector(), dense_res.get(), tmp);
     exec->synchronize();
     auto use_host_buffer = exec->get_master() != exec && !mpi::is_gpu_aware();
-    if (use_host_buffer) {
+    if (use_host_buffer || comm.force_host_buffer()) {
         host_reduction_buffer_.init(exec->get_master(), dense_res->get_size());
         host_reduction_buffer_->copy_from(dense_res.get());
         comm.all_reduce(exec->get_master(),
@@ -425,7 +425,7 @@ void Vector<ValueType>::compute_norm2(LinOp* result, array<char>& tmp) const
                                                  dense_res.get(), tmp));
     exec->synchronize();
     auto use_host_buffer = exec->get_master() != exec && !mpi::is_gpu_aware();
-    if (use_host_buffer) {
+    if (use_host_buffer || comm.force_host_buffer()) {
         host_norm_buffer_.init(exec->get_master(), dense_res->get_size());
         host_norm_buffer_->copy_from(dense_res.get());
         comm.all_reduce(exec->get_master(), host_norm_buffer_->get_values(),
@@ -458,7 +458,7 @@ void Vector<ValueType>::compute_norm1(LinOp* result, array<char>& tmp) const
     this->get_local_vector()->compute_norm1(dense_res.get());
     exec->synchronize();
     auto use_host_buffer = exec->get_master() != exec && !mpi::is_gpu_aware();
-    if (use_host_buffer) {
+    if (use_host_buffer || comm.force_host_buffer()) {
         host_norm_buffer_.init(exec->get_master(), dense_res->get_size());
         host_norm_buffer_->copy_from(dense_res.get());
         comm.all_reduce(exec->get_master(), host_norm_buffer_->get_values(),

--- a/include/ginkgo/core/base/mpi.hpp
+++ b/include/ginkgo/core/base/mpi.hpp
@@ -1505,6 +1505,14 @@ private:
 
 
 /**
+ * Checks if the combination of Executor and communicator requires passing
+ * MPI buffers from the host memory.
+ */
+bool requires_host_buffer(const std::shared_ptr<const Executor>& exec,
+                          const communicator& comm);
+
+
+/**
  * Get the rank in the communicator of the calling process.
  *
  * @param comm  the communicator

--- a/include/ginkgo/core/base/mpi.hpp
+++ b/include/ginkgo/core/base/mpi.hpp
@@ -443,7 +443,8 @@ public:
      *
      * @param comm The input MPI_Comm object.
      */
-    communicator(const MPI_Comm& comm)
+    communicator(const MPI_Comm& comm, bool force_host_buffer = false)
+        : comm_(), force_host_buffer_(force_host_buffer)
     {
         this->comm_.reset(new MPI_Comm(comm));
     }
@@ -485,6 +486,8 @@ public:
      * @return  the MPI_Comm object
      */
     const MPI_Comm& get() const { return *(this->comm_.get()); }
+
+    bool force_host_buffer() const { return force_host_buffer_; }
 
     /**
      * Return the size of the communicator (number of ranks).
@@ -1465,6 +1468,7 @@ public:
 
 private:
     std::shared_ptr<MPI_Comm> comm_;
+    bool force_host_buffer_;
 
     int get_my_rank() const
     {

--- a/include/ginkgo/core/base/mpi.hpp
+++ b/include/ginkgo/core/base/mpi.hpp
@@ -442,7 +442,8 @@ public:
      * original MPI_Comm object.
      *
      * @param comm The input MPI_Comm object.
-     * @param force_host_buffer If set to true, always communicates through host memory
+     * @param force_host_buffer If set to true, always communicates through host
+     * memory
      */
     communicator(const MPI_Comm& comm, bool force_host_buffer = false)
         : comm_(), force_host_buffer_(force_host_buffer)

--- a/include/ginkgo/core/base/mpi.hpp
+++ b/include/ginkgo/core/base/mpi.hpp
@@ -442,6 +442,7 @@ public:
      * original MPI_Comm object.
      *
      * @param comm The input MPI_Comm object.
+     * @param force_host_buffer If set to true, always communicates through host memory
      */
     communicator(const MPI_Comm& comm, bool force_host_buffer = false)
         : comm_(), force_host_buffer_(force_host_buffer)


### PR DESCRIPTION
This PR adds the option to use host MPI buffers even if `GINKGO_FORCE_GPU_AWARE_MPI` is true. The option can be set in the `communicator` constructor. Additionally, a helper function is added that checks if the combination of executor and communicator needs to use host buffers.