### PR TITLE
Temporarily disables nla-gpu tests or moves them to other systems

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -472,21 +472,22 @@ build/amd/nompi/gcc/rocm40/debug/shared:
     BUILD_TYPE: "Debug"
     FAST_TESTS: "ON"
 
-build/amd/openmpi/clang/rocm40/release/static:
-  extends:
-    - .build_and_test_template
-    - .default_variables
-    - .quick_test_condition
-    - .use_gko-rocm40-openmpi-gnu8-llvm50
-  variables:
-    C_COMPILER: "clang"
-    CXX_COMPILER: "clang++"
-    BUILD_OMP: "ON"
-    BUILD_HIP: "ON"
-    BUILD_MPI: "ON"
-    MPI_AS_ROOT: "ON"
-    BUILD_TYPE: "Release"
-    BUILD_SHARED_LIBS: "OFF"
+# TODO: enable when nla-gpu is available
+#build/amd/openmpi/clang/rocm40/release/static:
+#  extends:
+#    - .build_and_test_template
+#    - .default_variables
+#    - .quick_test_condition
+#    - .use_gko-rocm40-openmpi-gnu8-llvm50
+#  variables:
+#    C_COMPILER: "clang"
+#    CXX_COMPILER: "clang++"
+#    BUILD_OMP: "ON"
+#    BUILD_HIP: "ON"
+#    BUILD_MPI: "ON"
+#    MPI_AS_ROOT: "ON"
+#    BUILD_TYPE: "Release"
+#    BUILD_SHARED_LIBS: "OFF"
 
 # ROCm 4.5 and friends
 build/amd/nompi/gcc/rocm45/release/shared:

--- a/.gitlab/image.yml
+++ b/.gitlab/image.yml
@@ -8,7 +8,7 @@
   image: ginkgohub/cpu:openmpi-gnu9-llvm8
   tags:
     - private_ci
-    - nla-gpu
+#    - nla-gpu  # TODO: enable when nla-gpu is available
 
 .use_gko-nocuda-nompi-gnu9-llvm8:
   image: ginkgohub/cpu:openmpi-gnu9-llvm8
@@ -73,7 +73,9 @@
   image: ginkgohub/rocm:40-openmpi-gnu8-llvm50
   tags:
     - private_ci
-    - nla-gpu
+    - amdci
+#    - nla-gpu  # TODO: enable when nla-gpu is available
+
 
 .use_gko-rocm45-nompi-gnu8-llvm8:
   image: ginkgohub/rocm:45-mvapich2-gnu8-llvm8


### PR DESCRIPTION
I propose these changes to temporarily deal with nla-gpu not being available. I think we will only miss an MPI + ROCm test, but that seems unavoidable.