### PR TITLE
Some fixes for hwloc and the distributed-solver example

### DIFF
--- a/examples/distributed-solver/distributed-solver.cpp
+++ b/examples/distributed-solver/distributed-solver.cpp
@@ -104,6 +104,8 @@ int main(int argc, char* argv[])
     const auto executor_string = argc >= 2 ? argv[1] : "reference";
     const auto grid_dim =
         static_cast<gko::size_type>(argc >= 3 ? std::atoi(argv[2]) : 100);
+    const auto num_iters =
+        static_cast<gko::size_type>(argc >= 4 ? std::atoi(argv[3]) : 1000);
 
     // Pick the requested executor.
     std::map<std::string, std::function<std::shared_ptr<gko::Executor>()>>
@@ -216,7 +218,8 @@ int main(int argc, char* argv[])
     auto Ainv =
         solver::build()
             .with_criteria(
-                gko::stop::Iteration::build().with_max_iters(num_rows).on(exec),
+                gko::stop::Iteration::build().with_max_iters(num_iters).on(
+                    exec),
                 gko::stop::ResidualNorm<ValueType>::build()
                     .with_baseline(gko::stop::mode::absolute)
                     .with_reduction_factor(1e-4)

--- a/examples/distributed-solver/distributed-solver.cpp
+++ b/examples/distributed-solver/distributed-solver.cpp
@@ -216,7 +216,7 @@ int main(int argc, char* argv[])
     auto Ainv =
         solver::build()
             .with_criteria(
-                gko::stop::Iteration::build().with_max_iters(100u).on(exec),
+                gko::stop::Iteration::build().with_max_iters(num_rows).on(exec),
                 gko::stop::ResidualNorm<ValueType>::build()
                     .with_baseline(gko::stop::mode::absolute)
                     .with_reduction_factor(1e-4)

--- a/examples/distributed-solver/distributed-solver.cpp
+++ b/examples/distributed-solver/distributed-solver.cpp
@@ -91,7 +91,8 @@ int main(int argc, char* argv[])
     if (argc == 2 && (std::string(argv[1]) == "--help")) {
         if (rank == 0) {
             std::cerr << "Usage: " << argv[0]
-                      << " [executor] [num_grid_points] " << std::endl;
+                      << " [executor] [num_grid_points] [num_iterations] "
+                      << std::endl;
         }
         std::exit(-1);
     }

--- a/examples/distributed-solver/doc/intro.dox
+++ b/examples/distributed-solver/doc/intro.dox
@@ -2,7 +2,7 @@
 <h1>Introduction</h1>
 This distributed solver example should help you understand the basics of using Ginkgo in a distributed setting.
 The example will solve a simple 1D Laplace equation where the system can be distributed row-wise to multiple processes.
-To run the solver with multiple processes, use `mpirun -n NUM_PROCS ./distributed-solver [executor] [num_grid_points]`.
+To run the solver with multiple processes, use `mpirun -n NUM_PROCS ./distributed-solver [executor] [num_grid_points] [num_iterations]`.
 
 If you are using GPU devices, please make sure that you run this example with at most as many processes as you have GPU
 devices available.

--- a/include/ginkgo/core/base/executor.hpp
+++ b/include/ginkgo/core/base/executor.hpp
@@ -1526,12 +1526,6 @@ protected:
         this->get_exec_info().num_pu_per_cu = 0;
         this->CudaExecutor::populate_exec_info(
             machine_topology::get_instance());
-        // FIXME: Binding GPU to the closest pus seems to have significant
-        // slowdowns on some systems
-        // if (this->get_exec_info().closest_pu_ids.size()) {
-        //     machine_topology::get_instance()->bind_to_pus(
-        //         this->get_closest_pus());
-        // }
 
         // it only gets attribute from device, so it should not be affected by
         // DeviceReset.
@@ -1735,12 +1729,6 @@ protected:
         this->get_exec_info().num_computing_units = 0;
         this->get_exec_info().num_pu_per_cu = 0;
         this->HipExecutor::populate_exec_info(machine_topology::get_instance());
-        // FIXME: Binding GPU to the closest pus seems to have significant
-        // slowdowns on some systems
-        // if (this->get_exec_info().closest_pu_ids.size()) {
-        //     machine_topology::get_instance()->bind_to_pus(
-        //         this->get_closest_pus());
-        // }
 
         // it only gets attribute from device, so it should not be affected by
         // DeviceReset.

--- a/include/ginkgo/core/base/executor.hpp
+++ b/include/ginkgo/core/base/executor.hpp
@@ -1526,10 +1526,13 @@ protected:
         this->get_exec_info().num_pu_per_cu = 0;
         this->CudaExecutor::populate_exec_info(
             machine_topology::get_instance());
-        if (this->get_exec_info().closest_pu_ids.size()) {
-            machine_topology::get_instance()->bind_to_pus(
-                this->get_closest_pus());
-        }
+        // FIXME: Binding GPU to the closest pus seems to have significant
+        // slowdowns on some systems
+        // if (this->get_exec_info().closest_pu_ids.size()) {
+        //     machine_topology::get_instance()->bind_to_pus(
+        //         this->get_closest_pus());
+        // }
+
         // it only gets attribute from device, so it should not be affected by
         // DeviceReset.
         this->set_gpu_property();
@@ -1732,10 +1735,13 @@ protected:
         this->get_exec_info().num_computing_units = 0;
         this->get_exec_info().num_pu_per_cu = 0;
         this->HipExecutor::populate_exec_info(machine_topology::get_instance());
-        if (this->get_exec_info().closest_pu_ids.size()) {
-            machine_topology::get_instance()->bind_to_pus(
-                this->get_closest_pus());
-        }
+        // FIXME: Binding GPU to the closest pus seems to have significant
+        // slowdowns on some systems
+        // if (this->get_exec_info().closest_pu_ids.size()) {
+        //     machine_topology::get_instance()->bind_to_pus(
+        //         this->get_closest_pus());
+        // }
+
         // it only gets attribute from device, so it should not be affected by
         // DeviceReset.
         this->set_gpu_property();


### PR DESCRIPTION
This PR comments out the binding that we did for the GPU to the closest PUs we detected. This binding seems to be counter-productive on some systems. On systems where we were not having any issues, removing this binding does not seem to have any negative effects, so I decided to comment it out for now and investigate this more later.

The distributed solver was using 100 as the default iteration count, which is now updated to the number of rows in the matrix.

Related to #1221 , but does not close that issue but only temporarily fixes it.