### PR TITLE
Add support for host operations to executor

### DIFF
--- a/benchmark/preconditioner/preconditioner.cpp
+++ b/benchmark/preconditioner/preconditioner.cpp
@@ -201,9 +201,15 @@ void run_preconditioner(const char* precond_name,
             auto gen_logger =
                 std::make_shared<OperationLogger>(FLAGS_nested_names);
             exec->add_logger(gen_logger);
+            if (exec->get_master() != exec) {
+                exec->get_master()->add_logger(gen_logger);
+            }
             std::unique_ptr<gko::LinOp> precond_op;
             for (auto i = 0u; i < ic_gen.get_num_repetitions(); ++i) {
                 precond_op = precond->generate(system_matrix);
+            }
+            if (exec->get_master() != exec) {
+                exec->get_master()->remove_logger(gko::lend(gen_logger));
             }
             exec->remove_logger(gko::lend(gen_logger));
 
@@ -213,8 +219,14 @@ void run_preconditioner(const char* precond_name,
             auto apply_logger =
                 std::make_shared<OperationLogger>(FLAGS_nested_names);
             exec->add_logger(apply_logger);
+            if (exec->get_master() != exec) {
+                exec->get_master()->add_logger(apply_logger);
+            }
             for (auto i = 0u; i < ic_apply.get_num_repetitions(); ++i) {
                 precond_op->apply(lend(b), lend(x_clone));
+            }
+            if (exec->get_master() != exec) {
+                exec->get_master()->remove_logger(gko::lend(apply_logger));
             }
             exec->remove_logger(gko::lend(apply_logger));
 

--- a/core/factorization/elimination_forest.hpp
+++ b/core/factorization/elimination_forest.hpp
@@ -63,8 +63,9 @@ struct elimination_forest {
 
 
 template <typename ValueType, typename IndexType>
-elimination_forest<IndexType> compute_elim_forest(
-    const matrix::Csr<ValueType, IndexType>* mtx);
+void compute_elim_forest(
+    const matrix::Csr<ValueType, IndexType>* mtx,
+    std::unique_ptr<elimination_forest<IndexType>>& forest);
 
 
 }  // namespace factorization

--- a/core/factorization/lu.cpp
+++ b/core/factorization/lu.cpp
@@ -56,6 +56,9 @@ GKO_REGISTER_OPERATION(build_lookup_offsets, csr::build_lookup_offsets);
 GKO_REGISTER_OPERATION(build_lookup, csr::build_lookup);
 GKO_REGISTER_OPERATION(initialize, lu_factorization::initialize);
 GKO_REGISTER_OPERATION(factorize, lu_factorization::factorize);
+GKO_REGISTER_HOST_OPERATION(symbolic_cholesky,
+                            gko::factorization::symbolic_cholesky);
+GKO_REGISTER_HOST_OPERATION(symbolic_lu, gko::factorization::symbolic_lu);
 
 
 }  // namespace
@@ -93,9 +96,9 @@ std::unique_ptr<LinOp> Lu<ValueType, IndexType>::generate_impl(
     std::unique_ptr<matrix_type> factors;
     if (!parameters_.symbolic_factorization) {
         if (parameters_.symmetric_sparsity) {
-            factors = gko::factorization::symbolic_cholesky(mtx.get());
+            exec->run(make_symbolic_cholesky(mtx.get(), factors));
         } else {
-            factors = gko::factorization::symbolic_lu(mtx.get());
+            exec->run(make_symbolic_lu(mtx.get(), factors));
         }
     } else {
         const auto& symbolic = parameters_.symbolic_factorization;

--- a/core/factorization/symbolic.cpp
+++ b/core/factorization/symbolic.cpp
@@ -58,6 +58,7 @@ GKO_REGISTER_OPERATION(cholesky_symbolic,
 GKO_REGISTER_OPERATION(prefix_sum, components::prefix_sum);
 GKO_REGISTER_OPERATION(initialize, lu_factorization::initialize);
 GKO_REGISTER_OPERATION(factorize, lu_factorization::factorize);
+GKO_REGISTER_HOST_OPERATION(compute_elim_forest, compute_elim_forest);
 
 
 }  // namespace
@@ -65,38 +66,40 @@ GKO_REGISTER_OPERATION(factorize, lu_factorization::factorize);
 
 /** Computes the symbolic Cholesky factorization of the given matrix. */
 template <typename ValueType, typename IndexType>
-std::unique_ptr<matrix::Csr<ValueType, IndexType>> symbolic_cholesky(
-    const matrix::Csr<ValueType, IndexType>* mtx)
+void symbolic_cholesky(
+    const matrix::Csr<ValueType, IndexType>* mtx,
+    std::unique_ptr<matrix::Csr<ValueType, IndexType>>& factors)
 {
     using matrix_type = matrix::Csr<ValueType, IndexType>;
     const auto exec = mtx->get_executor();
     const auto host_exec = exec->get_master();
-    const auto forest = compute_elim_forest(mtx);
+    std::unique_ptr<elimination_forest<IndexType>> forest;
+    exec->run(make_compute_elim_forest(mtx, forest));
     const auto num_rows = mtx->get_size()[0];
     array<IndexType> row_ptrs{exec, num_rows + 1};
     array<IndexType> tmp{exec};
     exec->run(
-        make_cholesky_symbolic_count(mtx, forest, row_ptrs.get_data(), tmp));
+        make_cholesky_symbolic_count(mtx, *forest, row_ptrs.get_data(), tmp));
     exec->run(make_prefix_sum(row_ptrs.get_data(), num_rows + 1));
     const auto factor_nnz = static_cast<size_type>(
         exec->copy_val_to_host(row_ptrs.get_const_data() + num_rows));
-    auto factor = matrix_type::create(
+    factors = matrix_type::create(
         exec, mtx->get_size(), array<ValueType>{exec, factor_nnz},
         array<IndexType>{exec, factor_nnz}, std::move(row_ptrs));
-    exec->run(make_cholesky_symbolic(mtx, forest, factor.get(), tmp));
-    factor->sort_by_column_index();
-    auto lt_factor = as<matrix_type>(factor->transpose());
+    exec->run(make_cholesky_symbolic(mtx, *forest, factors.get(), tmp));
+    factors->sort_by_column_index();
+    auto lt_factor = as<matrix_type>(factors->transpose());
     const auto scalar =
         initialize<matrix::Dense<ValueType>>({one<ValueType>()}, exec);
     const auto id = matrix::Identity<ValueType>::create(exec, num_rows);
-    lt_factor->apply(scalar.get(), id.get(), scalar.get(), factor.get());
-    return factor;
+    lt_factor->apply(scalar.get(), id.get(), scalar.get(), factors.get());
 }
 
 
-#define GKO_DECLARE_SYMBOLIC_CHOLESKY(ValueType, IndexType)               \
-    std::unique_ptr<matrix::Csr<ValueType, IndexType>> symbolic_cholesky( \
-        const matrix::Csr<ValueType, IndexType>* mtx)
+#define GKO_DECLARE_SYMBOLIC_CHOLESKY(ValueType, IndexType) \
+    void symbolic_cholesky(                                 \
+        const matrix::Csr<ValueType, IndexType>* mtx,       \
+        std::unique_ptr<matrix::Csr<ValueType, IndexType>>& factors)
 
 GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(GKO_DECLARE_SYMBOLIC_CHOLESKY);
 
@@ -109,8 +112,8 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(GKO_DECLARE_SYMBOLIC_CHOLESKY);
  * "GSoFa: Scalable Sparse Symbolic LU Factorization on GPUs," arXiv 2021
  */
 template <typename ValueType, typename IndexType>
-std::unique_ptr<matrix::Csr<ValueType, IndexType>> symbolic_lu(
-    const matrix::Csr<ValueType, IndexType>* mtx)
+void symbolic_lu(const matrix::Csr<ValueType, IndexType>* mtx,
+                 std::unique_ptr<matrix::Csr<ValueType, IndexType>>& factors)
 {
     using matrix_type = matrix::Csr<ValueType, IndexType>;
     const auto exec = mtx->get_executor();
@@ -179,16 +182,16 @@ std::unique_ptr<matrix::Csr<ValueType, IndexType>> symbolic_lu(
     array<ValueType> out_val_array{exec, out_nnz};
     exec->copy_from(host_exec.get(), out_nnz, out_col_idxs.data(),
                     out_col_idx_array.get_data());
-    auto result = matrix_type::create(
+    factors = matrix_type::create(
         exec, mtx->get_size(), std::move(out_val_array),
         std::move(out_col_idx_array), std::move(out_row_ptr_array));
-    return result;
 }
 
 
-#define GKO_DECLARE_SYMBOLIC_LU(ValueType, IndexType)               \
-    std::unique_ptr<matrix::Csr<ValueType, IndexType>> symbolic_lu( \
-        const matrix::Csr<ValueType, IndexType>* mtx)
+#define GKO_DECLARE_SYMBOLIC_LU(ValueType, IndexType) \
+    void symbolic_lu(                                 \
+        const matrix::Csr<ValueType, IndexType>* mtx, \
+        std::unique_ptr<matrix::Csr<ValueType, IndexType>>& factors)
 
 GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(GKO_DECLARE_SYMBOLIC_LU);
 

--- a/core/factorization/symbolic.hpp
+++ b/core/factorization/symbolic.hpp
@@ -37,15 +37,24 @@ namespace gko {
 namespace factorization {
 
 
-/** Computes the symbolic Cholesky factorization of the given matrix. */
+/**
+ * Computes the symbolic Cholesky factorization of the given matrix.
+ * @param mtx  the input matrix
+ * @param factors  the output factors stored in a combined pattern
+ */
 template <typename ValueType, typename IndexType>
-std::unique_ptr<matrix::Csr<ValueType, IndexType>> symbolic_cholesky(
-    const matrix::Csr<ValueType, IndexType>*);
+void symbolic_cholesky(
+    const matrix::Csr<ValueType, IndexType>* mtx,
+    std::unique_ptr<matrix::Csr<ValueType, IndexType>>& factors);
 
-/** Computes the symbolic LU factorization of the given matrix. */
+/**
+ * Computes the symbolic LU factorization of the given matrix.
+ * @param mtx  the input matrix
+ * @param factors  the output factors stored in a combined pattern
+ */
 template <typename ValueType, typename IndexType>
-std::unique_ptr<matrix::Csr<ValueType, IndexType>> symbolic_lu(
-    const matrix::Csr<ValueType, IndexType>*);
+void symbolic_lu(const matrix::Csr<ValueType, IndexType>* mtx,
+                 std::unique_ptr<matrix::Csr<ValueType, IndexType>>& factors);
 
 
 }  // namespace factorization

--- a/core/factorization/symbolic.hpp
+++ b/core/factorization/symbolic.hpp
@@ -39,6 +39,7 @@ namespace factorization {
 
 /**
  * Computes the symbolic Cholesky factorization of the given matrix.
+ *
  * @param mtx  the input matrix
  * @param factors  the output factors stored in a combined pattern
  */
@@ -49,6 +50,7 @@ void symbolic_cholesky(
 
 /**
  * Computes the symbolic LU factorization of the given matrix.
+ *
  * @param mtx  the input matrix
  * @param factors  the output factors stored in a combined pattern
  */

--- a/core/test/factorization/elimination_forest.cpp
+++ b/core/test/factorization/elimination_forest.cpp
@@ -86,19 +86,20 @@ TYPED_TEST(EliminationForest, WorksForExample)
          {0, 1, 0, 1, 1, 0, 0, 1, 0, 1}},
         this->ref);
 
-    auto forest = gko::factorization::compute_elim_forest(mtx.get());
+    std::unique_ptr<gko::factorization::elimination_forest<index_type>> forest;
+    gko::factorization::compute_elim_forest(mtx.get(), forest);
 
-    GKO_ASSERT_ARRAY_EQ(forest.parents,
+    GKO_ASSERT_ARRAY_EQ(forest->parents,
                         I<index_type>({2, 4, 6, 8, 8, 6, 7, 8, 9, 10}));
-    GKO_ASSERT_ARRAY_EQ(forest.child_ptrs,
+    GKO_ASSERT_ARRAY_EQ(forest->child_ptrs,
                         I<index_type>({0, 0, 0, 1, 1, 2, 2, 4, 5, 8, 9, 10}));
-    GKO_ASSERT_ARRAY_EQ(forest.children,
+    GKO_ASSERT_ARRAY_EQ(forest->children,
                         I<index_type>({0, 1, 2, 5, 6, 3, 4, 7, 8, 9}));
-    GKO_ASSERT_ARRAY_EQ(forest.postorder,
+    GKO_ASSERT_ARRAY_EQ(forest->postorder,
                         I<index_type>({3, 1, 4, 0, 2, 5, 6, 7, 8, 9}));
-    GKO_ASSERT_ARRAY_EQ(forest.inv_postorder,
+    GKO_ASSERT_ARRAY_EQ(forest->inv_postorder,
                         I<index_type>({3, 1, 4, 0, 2, 5, 6, 7, 8, 9}));
-    GKO_ASSERT_ARRAY_EQ(forest.postorder_parents,
+    GKO_ASSERT_ARRAY_EQ(forest->postorder_parents,
                         I<index_type>({8, 2, 8, 4, 6, 6, 7, 8, 9, 10}));
 }
 
@@ -122,19 +123,20 @@ TYPED_TEST(EliminationForest, WorksForSeparable)
         },
         this->ref);
 
-    auto forest = gko::factorization::compute_elim_forest(mtx.get());
+    std::unique_ptr<gko::factorization::elimination_forest<index_type>> forest;
+    gko::factorization::compute_elim_forest(mtx.get(), forest);
 
-    GKO_ASSERT_ARRAY_EQ(forest.parents,
+    GKO_ASSERT_ARRAY_EQ(forest->parents,
                         I<index_type>({2, 2, 10, 4, 5, 9, 7, 9, 9, 10}));
-    GKO_ASSERT_ARRAY_EQ(forest.child_ptrs,
+    GKO_ASSERT_ARRAY_EQ(forest->child_ptrs,
                         I<index_type>({0, 0, 0, 2, 2, 3, 4, 4, 5, 5, 8, 10}));
-    GKO_ASSERT_ARRAY_EQ(forest.children,
+    GKO_ASSERT_ARRAY_EQ(forest->children,
                         I<index_type>({0, 1, 3, 4, 6, 5, 7, 8, 2, 9}));
-    GKO_ASSERT_ARRAY_EQ(forest.postorder,
+    GKO_ASSERT_ARRAY_EQ(forest->postorder,
                         I<index_type>({0, 1, 2, 3, 4, 5, 6, 7, 8, 9}));
-    GKO_ASSERT_ARRAY_EQ(forest.inv_postorder,
+    GKO_ASSERT_ARRAY_EQ(forest->inv_postorder,
                         I<index_type>({0, 1, 2, 3, 4, 5, 6, 7, 8, 9}));
-    GKO_ASSERT_ARRAY_EQ(forest.postorder_parents,
+    GKO_ASSERT_ARRAY_EQ(forest->postorder_parents,
                         I<index_type>({2, 2, 10, 4, 5, 9, 7, 9, 9, 10}));
 }
 
@@ -157,18 +159,19 @@ TYPED_TEST(EliminationForest, WorksForPostOrderNotSelfInverse)
             {0, 0, 0, 0, 0, 0, 1, 0, 1, 1},
         },
         this->ref);
-    auto forest = gko::factorization::compute_elim_forest(mtx.get());
-    GKO_ASSERT_ARRAY_EQ(forest.parents,
+    std::unique_ptr<gko::factorization::elimination_forest<index_type>> forest;
+    gko::factorization::compute_elim_forest(mtx.get(), forest);
+    GKO_ASSERT_ARRAY_EQ(forest->parents,
                         I<index_type>({2, 4, 6, 8, 5, 6, 7, 8, 9, 10}));
-    GKO_ASSERT_ARRAY_EQ(forest.child_ptrs,
+    GKO_ASSERT_ARRAY_EQ(forest->child_ptrs,
                         I<index_type>({0, 0, 0, 1, 1, 2, 3, 5, 6, 8, 9, 10}));
-    GKO_ASSERT_ARRAY_EQ(forest.children,
+    GKO_ASSERT_ARRAY_EQ(forest->children,
                         I<index_type>({0, 1, 4, 2, 5, 6, 3, 7, 8, 9}));
-    GKO_ASSERT_ARRAY_EQ(forest.postorder,
+    GKO_ASSERT_ARRAY_EQ(forest->postorder,
                         I<index_type>({3, 0, 2, 1, 4, 5, 6, 7, 8, 9}));
-    GKO_ASSERT_ARRAY_EQ(forest.inv_postorder,
+    GKO_ASSERT_ARRAY_EQ(forest->inv_postorder,
                         I<index_type>({1, 3, 2, 0, 4, 5, 6, 7, 8, 9}));
-    GKO_ASSERT_ARRAY_EQ(forest.postorder_parents,
+    GKO_ASSERT_ARRAY_EQ(forest->postorder_parents,
                         I<index_type>({8, 2, 6, 4, 5, 6, 7, 8, 9, 10}));
 }
 
@@ -180,7 +183,8 @@ TYPED_TEST(EliminationForest, WorksForAni1)
     std::ifstream stream{gko::matrices::location_ani1_mtx};
     auto mtx = gko::read<matrix_type>(stream, this->ref);
 
-    auto forest = gko::factorization::compute_elim_forest(mtx.get());
+    std::unique_ptr<gko::factorization::elimination_forest<index_type>> forest;
+    gko::factorization::compute_elim_forest(mtx.get(), forest);
 
     // the elimination tree is a path
     gko::array<index_type> iota_arr{this->ref, 36};
@@ -188,13 +192,13 @@ TYPED_TEST(EliminationForest, WorksForAni1)
     std::iota(iota_arr.get_data(), iota_arr.get_data() + 36, 1);
     std::iota(iota_arr2.get_data() + 1, iota_arr2.get_data() + 38, 0);
     iota_arr2.get_data()[0] = 0;
-    GKO_ASSERT_ARRAY_EQ(forest.parents, iota_arr);
-    GKO_ASSERT_ARRAY_EQ(forest.postorder_parents, iota_arr);
-    GKO_ASSERT_ARRAY_EQ(forest.child_ptrs, iota_arr2);
+    GKO_ASSERT_ARRAY_EQ(forest->parents, iota_arr);
+    GKO_ASSERT_ARRAY_EQ(forest->postorder_parents, iota_arr);
+    GKO_ASSERT_ARRAY_EQ(forest->child_ptrs, iota_arr2);
     std::iota(iota_arr.get_data(), iota_arr.get_data() + 36, 0);
-    GKO_ASSERT_ARRAY_EQ(forest.children, iota_arr);
-    GKO_ASSERT_ARRAY_EQ(forest.postorder, iota_arr);
-    GKO_ASSERT_ARRAY_EQ(forest.inv_postorder, iota_arr);
+    GKO_ASSERT_ARRAY_EQ(forest->children, iota_arr);
+    GKO_ASSERT_ARRAY_EQ(forest->postorder, iota_arr);
+    GKO_ASSERT_ARRAY_EQ(forest->inv_postorder, iota_arr);
 }
 
 
@@ -205,29 +209,30 @@ TYPED_TEST(EliminationForest, WorksForAni1Amd)
     std::ifstream stream{gko::matrices::location_ani1_amd_mtx};
     auto mtx = gko::read<matrix_type>(stream, this->ref);
 
-    auto forest = gko::factorization::compute_elim_forest(mtx.get());
+    std::unique_ptr<gko::factorization::elimination_forest<index_type>> forest;
+    gko::factorization::compute_elim_forest(mtx.get(), forest);
 
     GKO_ASSERT_ARRAY_EQ(
-        forest.parents,
+        forest->parents,
         I<index_type>({4,  2,  3,  4,  5,  29, 7,  8,  9,  27, 11, 12,
                        13, 14, 16, 16, 17, 18, 24, 20, 21, 22, 23, 24,
                        25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36}));
     GKO_ASSERT_ARRAY_EQ(
-        forest.child_ptrs,
+        forest->child_ptrs,
         I<index_type>({0,  0,  0,  1,  2,  4,  5,  5,  6,  7,  8,  8,  9,
                        10, 11, 12, 12, 14, 15, 16, 16, 17, 18, 19, 20, 22,
                        23, 24, 26, 27, 29, 30, 31, 32, 33, 34, 35, 36}));
     GKO_ASSERT_ARRAY_EQ(
-        forest.children,
+        forest->children,
         I<index_type>({1,  2,  0,  3,  4,  6,  7,  8,  10, 11, 12, 13,
                        14, 15, 16, 17, 19, 20, 21, 22, 18, 23, 24, 25,
                        9,  26, 27, 5,  28, 29, 30, 31, 32, 33, 34, 35}));
     gko::array<index_type> iota_arr{this->ref, 36};
     std::iota(iota_arr.get_data(), iota_arr.get_data() + 36, 0);
-    GKO_ASSERT_ARRAY_EQ(forest.postorder, iota_arr);
-    GKO_ASSERT_ARRAY_EQ(forest.inv_postorder, iota_arr);
+    GKO_ASSERT_ARRAY_EQ(forest->postorder, iota_arr);
+    GKO_ASSERT_ARRAY_EQ(forest->inv_postorder, iota_arr);
     GKO_ASSERT_ARRAY_EQ(
-        forest.postorder_parents,
+        forest->postorder_parents,
         I<index_type>({4,  2,  3,  4,  5,  29, 7,  8,  9,  27, 11, 12,
                        13, 14, 16, 16, 17, 18, 24, 20, 21, 22, 23, 24,
                        25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36}));

--- a/reference/test/factorization/cholesky_kernels.cpp
+++ b/reference/test/factorization/cholesky_kernels.cpp
@@ -99,11 +99,12 @@ TYPED_TEST(Cholesky, KernelSymbolicCountExample)
          {0, 0, 0, 1, 1, 0, 0, 1, 1, 0},
          {0, 1, 0, 1, 1, 0, 0, 1, 0, 1}},
         this->ref);
-    auto forest = gko::factorization::compute_elim_forest(mtx.get());
+    std::unique_ptr<gko::factorization::elimination_forest<index_type>> forest;
+    gko::factorization::compute_elim_forest(mtx.get(), forest);
     gko::array<index_type> row_nnz{this->ref, 10};
 
     gko::kernels::reference::cholesky::cholesky_symbolic_count(
-        this->ref, mtx.get(), forest, row_nnz.get_data(), this->tmp);
+        this->ref, mtx.get(), *forest, row_nnz.get_data(), this->tmp);
 
     GKO_ASSERT_ARRAY_EQ(row_nnz, I<index_type>({1, 1, 2, 1, 2, 1, 3, 5, 4, 6}));
 }
@@ -125,15 +126,16 @@ TYPED_TEST(Cholesky, KernelSymbolicFactorizeExample)
          {0, 0, 0, 1, 1, 0, 0, 1, 1, 0},
          {0, 1, 0, 1, 1, 0, 0, 1, 0, 1}},
         this->ref);
-    auto forest = gko::factorization::compute_elim_forest(mtx.get());
+    std::unique_ptr<gko::factorization::elimination_forest<index_type>> forest;
+    gko::factorization::compute_elim_forest(mtx.get(), forest);
     auto l_factor = matrix_type::create(this->ref, gko::dim<2>{10, 10}, 26);
     gko::kernels::reference::cholesky::cholesky_symbolic_count(
-        this->ref, mtx.get(), forest, l_factor->get_row_ptrs(), this->tmp);
+        this->ref, mtx.get(), *forest, l_factor->get_row_ptrs(), this->tmp);
     gko::kernels::reference::components::prefix_sum(
         this->ref, l_factor->get_row_ptrs(), 11);
 
     gko::kernels::reference::cholesky::cholesky_symbolic_factorize(
-        this->ref, mtx.get(), forest, l_factor.get(), this->tmp);
+        this->ref, mtx.get(), *forest, l_factor.get(), this->tmp);
 
     GKO_ASSERT_MTX_EQ_SPARSITY(l_factor,
                                l({{1., 0., 0., 0., 0., 0., 0., 0., 0., 0.},
@@ -165,11 +167,12 @@ TYPED_TEST(Cholesky, KernelSymbolicCountSeparable)
          {0, 0, 0, 0, 0, 0, 0, 0, 1, 1},
          {0, 0, 0, 0, 1, 0, 1, 0, 1, 1}},
         this->ref);
-    auto forest = gko::factorization::compute_elim_forest(mtx.get());
+    std::unique_ptr<gko::factorization::elimination_forest<index_type>> forest;
+    gko::factorization::compute_elim_forest(mtx.get(), forest);
     gko::array<index_type> row_nnz{this->ref, 10};
 
     gko::kernels::reference::cholesky::cholesky_symbolic_count(
-        this->ref, mtx.get(), forest, row_nnz.get_data(), this->tmp);
+        this->ref, mtx.get(), *forest, row_nnz.get_data(), this->tmp);
 
     GKO_ASSERT_ARRAY_EQ(row_nnz, I<index_type>({1, 1, 3, 1, 2, 2, 1, 2, 1, 6}));
 }
@@ -191,15 +194,16 @@ TYPED_TEST(Cholesky, KernelSymbolicFactorizeSeparable)
          {0, 0, 0, 0, 0, 0, 0, 0, 1, 1},
          {0, 0, 0, 0, 1, 0, 1, 0, 1, 1}},
         this->ref);
-    auto forest = gko::factorization::compute_elim_forest(mtx.get());
+    std::unique_ptr<gko::factorization::elimination_forest<index_type>> forest;
+    gko::factorization::compute_elim_forest(mtx.get(), forest);
     auto l_factor = matrix_type::create(this->ref, gko::dim<2>{10, 10}, 26);
     gko::kernels::reference::cholesky::cholesky_symbolic_count(
-        this->ref, mtx.get(), forest, l_factor->get_row_ptrs(), this->tmp);
+        this->ref, mtx.get(), *forest, l_factor->get_row_ptrs(), this->tmp);
     gko::kernels::reference::components::prefix_sum(
         this->ref, l_factor->get_row_ptrs(), 11);
 
     gko::kernels::reference::cholesky::cholesky_symbolic_factorize(
-        this->ref, mtx.get(), forest, l_factor.get(), this->tmp);
+        this->ref, mtx.get(), *forest, l_factor.get(), this->tmp);
 
     GKO_ASSERT_MTX_EQ_SPARSITY(l_factor,
                                l({{1., 0., 0., 0., 0., 0., 0., 0., 0., 0.},
@@ -221,11 +225,12 @@ TYPED_TEST(Cholesky, KernelSymbolicCountAni1)
     using index_type = typename TestFixture::index_type;
     std::ifstream stream{gko::matrices::location_ani1_mtx};
     auto mtx = gko::read<matrix_type>(stream, this->ref);
-    auto forest = gko::factorization::compute_elim_forest(mtx.get());
+    std::unique_ptr<gko::factorization::elimination_forest<index_type>> forest;
+    gko::factorization::compute_elim_forest(mtx.get(), forest);
     gko::array<index_type> row_nnz{this->ref, mtx->get_size()[0]};
 
     gko::kernels::reference::cholesky::cholesky_symbolic_count(
-        this->ref, mtx.get(), forest, row_nnz.get_data(), this->tmp);
+        this->ref, mtx.get(), *forest, row_nnz.get_data(), this->tmp);
 
     GKO_ASSERT_ARRAY_EQ(
         row_nnz, I<index_type>({1, 2, 3, 3, 2, 2,  7,  7,  7,  8, 8, 7,
@@ -242,17 +247,18 @@ TYPED_TEST(Cholesky, KernelSymbolicFactorizeAni1)
     std::ifstream ref_stream{gko::matrices::location_ani1_chol_mtx};
     auto mtx = gko::read<matrix_type>(stream, this->ref);
     auto l_factor_ref = gko::read<matrix_type>(ref_stream, this->ref);
-    auto forest = gko::factorization::compute_elim_forest(mtx.get());
+    std::unique_ptr<gko::factorization::elimination_forest<index_type>> forest;
+    gko::factorization::compute_elim_forest(mtx.get(), forest);
     auto l_factor =
         matrix_type::create(this->ref, l_factor_ref->get_size(),
                             l_factor_ref->get_num_stored_elements());
     gko::kernels::reference::cholesky::cholesky_symbolic_count(
-        this->ref, mtx.get(), forest, l_factor->get_row_ptrs(), this->tmp);
+        this->ref, mtx.get(), *forest, l_factor->get_row_ptrs(), this->tmp);
     gko::kernels::reference::components::prefix_sum(
         this->ref, l_factor->get_row_ptrs(), mtx->get_size()[0] + 1);
 
     gko::kernels::reference::cholesky::cholesky_symbolic_factorize(
-        this->ref, mtx.get(), forest, l_factor.get(), this->tmp);
+        this->ref, mtx.get(), *forest, l_factor.get(), this->tmp);
 
     GKO_ASSERT_MTX_EQ_SPARSITY(l_factor, l_factor_ref);
 }
@@ -268,7 +274,8 @@ TYPED_TEST(Cholesky, SymbolicFactorizeAni1)
     auto l_factor_ref = gko::read<matrix_type>(ref_stream, this->ref);
     auto combined_factor_ref = this->combined_factor(l_factor_ref.get());
 
-    auto combined_factor = gko::factorization::symbolic_cholesky(mtx.get());
+    std::unique_ptr<matrix_type> combined_factor;
+    gko::factorization::symbolic_cholesky(mtx.get(), combined_factor);
 
     GKO_ASSERT_MTX_EQ_SPARSITY(combined_factor, combined_factor_ref);
 }
@@ -280,11 +287,12 @@ TYPED_TEST(Cholesky, KernelSymbolicCountAni1Amd)
     using index_type = typename TestFixture::index_type;
     std::ifstream stream{gko::matrices::location_ani1_amd_mtx};
     auto mtx = gko::read<matrix_type>(stream, this->ref);
-    auto forest = gko::factorization::compute_elim_forest(mtx.get());
+    std::unique_ptr<gko::factorization::elimination_forest<index_type>> forest;
+    gko::factorization::compute_elim_forest(mtx.get(), forest);
     gko::array<index_type> row_nnz{this->ref, mtx->get_size()[0]};
 
     gko::kernels::reference::cholesky::cholesky_symbolic_count(
-        this->ref, mtx.get(), forest, row_nnz.get_data(), this->tmp);
+        this->ref, mtx.get(), *forest, row_nnz.get_data(), this->tmp);
 
     GKO_ASSERT_ARRAY_EQ(
         row_nnz, I<index_type>({1, 1,  2, 3, 5,  4, 1, 2,  3,  4, 1,  2,
@@ -301,17 +309,18 @@ TYPED_TEST(Cholesky, KernelSymbolicFactorizeAni1Amd)
     std::ifstream ref_stream{gko::matrices::location_ani1_amd_chol_mtx};
     auto mtx = gko::read<matrix_type>(stream, this->ref);
     auto l_factor_ref = gko::read<matrix_type>(ref_stream, this->ref);
-    auto forest = gko::factorization::compute_elim_forest(mtx.get());
+    std::unique_ptr<gko::factorization::elimination_forest<index_type>> forest;
+    gko::factorization::compute_elim_forest(mtx.get(), forest);
     auto l_factor =
         matrix_type::create(this->ref, l_factor_ref->get_size(),
                             l_factor_ref->get_num_stored_elements());
     gko::kernels::reference::cholesky::cholesky_symbolic_count(
-        this->ref, mtx.get(), forest, l_factor->get_row_ptrs(), this->tmp);
+        this->ref, mtx.get(), *forest, l_factor->get_row_ptrs(), this->tmp);
     gko::kernels::reference::components::prefix_sum(
         this->ref, l_factor->get_row_ptrs(), mtx->get_size()[0] + 1);
 
     gko::kernels::reference::cholesky::cholesky_symbolic_factorize(
-        this->ref, mtx.get(), forest, l_factor.get(), this->tmp);
+        this->ref, mtx.get(), *forest, l_factor.get(), this->tmp);
 
     GKO_ASSERT_MTX_EQ_SPARSITY(l_factor, l_factor_ref);
 }
@@ -327,7 +336,8 @@ TYPED_TEST(Cholesky, SymbolicFactorizeAni1Amd)
     auto l_factor_ref = gko::read<matrix_type>(ref_stream, this->ref);
     auto combined_factor_ref = this->combined_factor(l_factor_ref.get());
 
-    auto combined_factor = gko::factorization::symbolic_cholesky(mtx.get());
+    std::unique_ptr<matrix_type> combined_factor;
+    gko::factorization::symbolic_cholesky(mtx.get(), combined_factor);
 
     GKO_ASSERT_MTX_EQ_SPARSITY(combined_factor, combined_factor_ref);
 }

--- a/reference/test/factorization/lu_kernels.cpp
+++ b/reference/test/factorization/lu_kernels.cpp
@@ -118,7 +118,8 @@ TYPED_TEST(Lu, SymbolicCholeskyWorks)
     this->setup(gko::matrices::location_ani1_mtx,
                 gko::matrices::location_ani1_lu_mtx);
 
-    auto lu = gko::factorization::symbolic_cholesky(this->mtx.get());
+    std::unique_ptr<gko::matrix::Csr<value_type, index_type>> lu;
+    gko::factorization::symbolic_cholesky(this->mtx.get(), lu);
 
     GKO_ASSERT_MTX_EQ_SPARSITY(lu, this->mtx_lu);
 }
@@ -131,7 +132,8 @@ TYPED_TEST(Lu, SymbolicLUWorks)
     this->setup(gko::matrices::location_ani1_nonsymm_mtx,
                 gko::matrices::location_ani1_nonsymm_lu_mtx);
 
-    auto lu = gko::factorization::symbolic_lu(this->mtx.get());
+    std::unique_ptr<gko::matrix::Csr<value_type, index_type>> lu;
+    gko::factorization::symbolic_lu(this->mtx.get(), lu);
 
     GKO_ASSERT_MTX_EQ_SPARSITY(lu, this->mtx_lu);
 }

--- a/test/base/executor.cpp
+++ b/test/base/executor.cpp
@@ -104,6 +104,21 @@ TEST_F(Executor, RunsCorrectOperation)
 }
 
 
+void host_operation(int& value) { value = 1234; }
+
+GKO_REGISTER_HOST_OPERATION(host_operation, host_operation);
+
+
+TEST_F(Executor, RunsCorrectHostOperation)
+{
+    int value = 0;
+
+    exec->run(make_host_operation(value));
+
+    ASSERT_EQ(1234, value);
+}
+
+
 #ifndef GKO_COMPILING_REFERENCE
 
 


### PR DESCRIPTION
This adds the `GKO_REGISTER_HOST_OPERATION` macro which can be used to annotate a costly `core`-side computation for benchmarking and (later on, once #1036 is merged) profiling. Additionally, it adds the `OperationLogger` to the host executor in GPU executions, which will make host-side operations visible in detailed benchmark results.

TODO:
- [x] Add tests

Closes #1211
Closes #1113 