### PR TITLE
removes unnecessary run overrides in concrete executors

### DIFF
--- a/core/device_hooks/cuda_hooks.cpp
+++ b/core/device_hooks/cuda_hooks.cpp
@@ -108,13 +108,6 @@ scoped_device_id_guard CudaExecutor::get_scoped_device_id_guard() const
     GKO_NOT_COMPILED(cuda);
 
 
-void CudaExecutor::run(const Operation& op) const
-{
-    op.run(
-        std::static_pointer_cast<const CudaExecutor>(this->shared_from_this()));
-}
-
-
 std::string CudaError::get_error(int64)
 {
     return "ginkgo CUDA module is not compiled";

--- a/core/device_hooks/dpcpp_hooks.cpp
+++ b/core/device_hooks/dpcpp_hooks.cpp
@@ -114,13 +114,6 @@ void DpcppExecutor::raw_copy_to(const DpcppExecutor*, size_type num_bytes,
 void DpcppExecutor::synchronize() const GKO_NOT_COMPILED(dpcpp);
 
 
-void DpcppExecutor::run(const Operation& op) const
-{
-    op.run(std::static_pointer_cast<const DpcppExecutor>(
-        this->shared_from_this()));
-}
-
-
 scoped_device_id_guard DpcppExecutor::get_scoped_device_id_guard() const
     GKO_NOT_COMPILED(dpcpp);
 

--- a/core/device_hooks/hip_hooks.cpp
+++ b/core/device_hooks/hip_hooks.cpp
@@ -105,13 +105,6 @@ void HipExecutor::raw_copy_to(const DpcppExecutor*, size_type num_bytes,
 void HipExecutor::synchronize() const GKO_NOT_COMPILED(hip);
 
 
-void HipExecutor::run(const Operation& op) const
-{
-    op.run(
-        std::static_pointer_cast<const HipExecutor>(this->shared_from_this()));
-}
-
-
 scoped_device_id_guard HipExecutor::get_scoped_device_id_guard() const
     GKO_NOT_COMPILED(hip);
 

--- a/core/test/base/executor.cpp
+++ b/core/test/base/executor.cpp
@@ -54,60 +54,6 @@ namespace {
 using exec_ptr = std::shared_ptr<gko::Executor>;
 
 
-class ExampleOperation : public gko::Operation {
-public:
-    explicit ExampleOperation(int& val) : value(val) {}
-    void run(std::shared_ptr<const gko::OmpExecutor>) const override
-    {
-        value = 1;
-    }
-    void run(std::shared_ptr<const gko::CudaExecutor>) const override
-    {
-        value = 2;
-    }
-    void run(std::shared_ptr<const gko::HipExecutor>) const override
-    {
-        value = 3;
-    }
-    void run(std::shared_ptr<const gko::DpcppExecutor>) const override
-    {
-        value = 4;
-    }
-    void run(std::shared_ptr<const gko::ReferenceExecutor>) const override
-    {
-        value = 5;
-    }
-
-    int& value;
-};
-
-
-TEST(OmpExecutor, RunsCorrectOperation)
-{
-    int value = 0;
-    exec_ptr omp = gko::OmpExecutor::create();
-
-    omp->run(ExampleOperation(value));
-
-    ASSERT_EQ(1, value);
-}
-
-
-TEST(OmpExecutor, RunsCorrectLambdaOperation)
-{
-    int value = 0;
-    auto omp_lambda = [&value]() { value = 1; };
-    auto cuda_lambda = [&value]() { value = 2; };
-    auto hip_lambda = [&value]() { value = 3; };
-    auto dpcpp_lambda = [&value]() { value = 4; };
-    exec_ptr omp = gko::OmpExecutor::create();
-
-    omp->run(omp_lambda, cuda_lambda, hip_lambda, dpcpp_lambda);
-
-    ASSERT_EQ(1, value);
-}
-
-
 TEST(OmpExecutor, AllocatesAndFreesMemory)
 {
     const int num_elems = 10;
@@ -197,32 +143,6 @@ TEST(MachineTopology, CanBindToARangeofCores)
 
 
 #endif
-
-
-TEST(ReferenceExecutor, RunsCorrectOperation)
-{
-    int value = 0;
-    exec_ptr ref = gko::ReferenceExecutor::create();
-
-    ref->run(ExampleOperation(value));
-
-    ASSERT_EQ(5, value);
-}
-
-
-TEST(ReferenceExecutor, RunsCorrectLambdaOperation)
-{
-    int value = 0;
-    auto omp_lambda = [&value]() { value = 1; };
-    auto cuda_lambda = [&value]() { value = 2; };
-    auto hip_lambda = [&value]() { value = 3; };
-    auto dpcpp_lambda = [&value]() { value = 4; };
-    exec_ptr ref = gko::ReferenceExecutor::create();
-
-    ref->run(omp_lambda, cuda_lambda, hip_lambda, dpcpp_lambda);
-
-    ASSERT_EQ(1, value);
-}
 
 
 TEST(ReferenceExecutor, AllocatesAndFreesMemory)
@@ -325,34 +245,6 @@ TEST(ReferenceExecutor, IsItsOwnMaster)
 }
 
 
-TEST(CudaExecutor, RunsCorrectOperation)
-{
-    int value = 0;
-    exec_ptr cuda =
-        gko::CudaExecutor::create(0, gko::OmpExecutor::create(), true);
-
-    cuda->run(ExampleOperation(value));
-
-    ASSERT_EQ(2, value);
-}
-
-
-TEST(CudaExecutor, RunsCorrectLambdaOperation)
-{
-    int value = 0;
-    auto omp_lambda = [&value]() { value = 1; };
-    auto cuda_lambda = [&value]() { value = 2; };
-    auto hip_lambda = [&value]() { value = 3; };
-    auto dpcpp_lambda = [&value]() { value = 4; };
-    exec_ptr cuda =
-        gko::CudaExecutor::create(0, gko::OmpExecutor::create(), true);
-
-    cuda->run(omp_lambda, cuda_lambda, hip_lambda, dpcpp_lambda);
-
-    ASSERT_EQ(2, value);
-}
-
-
 TEST(CudaExecutor, KnowsItsMaster)
 {
     auto omp = gko::OmpExecutor::create();
@@ -400,32 +292,6 @@ TEST(CudaExecutor, CanSetDeviceResetBoolean)
 }
 
 
-TEST(HipExecutor, RunsCorrectOperation)
-{
-    int value = 0;
-    exec_ptr hip = gko::HipExecutor::create(0, gko::OmpExecutor::create());
-
-    hip->run(ExampleOperation(value));
-
-    ASSERT_EQ(3, value);
-}
-
-
-TEST(HipExecutor, RunsCorrectLambdaOperation)
-{
-    int value = 0;
-    auto omp_lambda = [&value]() { value = 1; };
-    auto cuda_lambda = [&value]() { value = 2; };
-    auto hip_lambda = [&value]() { value = 3; };
-    auto dpcpp_lambda = [&value]() { value = 4; };
-    exec_ptr hip = gko::HipExecutor::create(0, gko::OmpExecutor::create());
-
-    hip->run(omp_lambda, cuda_lambda, hip_lambda, dpcpp_lambda);
-
-    ASSERT_EQ(3, value);
-}
-
-
 TEST(HipExecutor, KnowsItsMaster)
 {
     auto omp = gko::OmpExecutor::create();
@@ -470,32 +336,6 @@ TEST(HipExecutor, CanSetDeviceResetBoolean)
     hip->set_device_reset(true);
 
     ASSERT_EQ(true, hip->get_device_reset());
-}
-
-
-TEST(DpcppExecutor, RunsCorrectOperation)
-{
-    int value = 0;
-    exec_ptr dpcpp = gko::DpcppExecutor::create(0, gko::OmpExecutor::create());
-
-    dpcpp->run(ExampleOperation(value));
-
-    ASSERT_EQ(4, value);
-}
-
-
-TEST(DpcppExecutor, RunsCorrectLambdaOperation)
-{
-    int value = 0;
-    auto omp_lambda = [&value]() { value = 1; };
-    auto cuda_lambda = [&value]() { value = 2; };
-    auto hip_lambda = [&value]() { value = 3; };
-    auto dpcpp_lambda = [&value]() { value = 4; };
-    exec_ptr dpcpp = gko::DpcppExecutor::create(0, gko::OmpExecutor::create());
-
-    dpcpp->run(omp_lambda, cuda_lambda, hip_lambda, dpcpp_lambda);
-
-    ASSERT_EQ(4, value);
 }
 
 
@@ -754,12 +594,21 @@ TEST_F(ExecutorLogging, LogsCopy)
 }
 
 
+class ExampleOperation : public gko::Operation {
+public:
+    void run(std::shared_ptr<const gko::OmpExecutor>) const override {}
+    void run(std::shared_ptr<const gko::CudaExecutor>) const override {}
+    void run(std::shared_ptr<const gko::HipExecutor>) const override {}
+    void run(std::shared_ptr<const gko::DpcppExecutor>) const override {}
+    void run(std::shared_ptr<const gko::ReferenceExecutor>) const override {}
+};
+
+
 TEST_F(ExecutorLogging, LogsOperation)
 {
     auto before_logger = *logger;
-    int value = 0;
 
-    exec->run(ExampleOperation(value));
+    exec->run(ExampleOperation());
 
     ASSERT_EQ(logger->operation_launched, before_logger.operation_launched + 1);
     ASSERT_EQ(logger->operation_completed,

--- a/cuda/base/executor.cpp
+++ b/cuda/base/executor.cpp
@@ -209,16 +209,6 @@ scoped_device_id_guard CudaExecutor::get_scoped_device_id_guard() const
 }
 
 
-void CudaExecutor::run(const Operation& op) const
-{
-    this->template log<log::Logger::operation_launched>(this, &op);
-    detail::cuda_scoped_device_id_guard g(this->get_device_id());
-    op.run(
-        std::static_pointer_cast<const CudaExecutor>(this->shared_from_this()));
-    this->template log<log::Logger::operation_completed>(this, &op);
-}
-
-
 int CudaExecutor::get_num_devices()
 {
     int deviceCount = 0;

--- a/dpcpp/base/executor.dp.cpp
+++ b/dpcpp/base/executor.dp.cpp
@@ -193,15 +193,6 @@ scoped_device_id_guard DpcppExecutor::get_scoped_device_id_guard() const
 }
 
 
-void DpcppExecutor::run(const Operation& op) const
-{
-    this->template log<log::Logger::operation_launched>(this, &op);
-    op.run(std::static_pointer_cast<const DpcppExecutor>(
-        this->shared_from_this()));
-    this->template log<log::Logger::operation_completed>(this, &op);
-}
-
-
 int DpcppExecutor::get_num_devices(std::string device_type)
 {
     return detail::get_devices(device_type).size();

--- a/hip/base/executor.hip.cpp
+++ b/hip/base/executor.hip.cpp
@@ -210,16 +210,6 @@ void HipExecutor::synchronize() const
 }
 
 
-void HipExecutor::run(const Operation& op) const
-{
-    this->template log<log::Logger::operation_launched>(this, &op);
-    detail::hip_scoped_device_id_guard g(this->get_device_id());
-    op.run(
-        std::static_pointer_cast<const HipExecutor>(this->shared_from_this()));
-    this->template log<log::Logger::operation_completed>(this, &op);
-}
-
-
 scoped_device_id_guard HipExecutor::get_scoped_device_id_guard() const
 {
     return {this, this->get_device_id()};

--- a/include/ginkgo/core/base/executor.hpp
+++ b/include/ginkgo/core/base/executor.hpp
@@ -1330,6 +1330,14 @@ public:
         return {this, 0};
     }
 
+    void run(const Operation& op) const override
+    {
+        this->template log<log::Logger::operation_launched>(this, &op);
+        op.run(std::static_pointer_cast<const ReferenceExecutor>(
+            this->shared_from_this()));
+        this->template log<log::Logger::operation_completed>(this, &op);
+    }
+
 protected:
     ReferenceExecutor()
     {

--- a/include/ginkgo/core/base/executor.hpp
+++ b/include/ginkgo/core/base/executor.hpp
@@ -1155,6 +1155,8 @@ class ExecutorBase : public Executor {
     friend class ReferenceExecutor;
 
 public:
+    using Executor::run;
+
     void run(const Operation& op) const override
     {
         this->template log<log::Logger::operation_launched>(this, &op);

--- a/include/ginkgo/core/base/executor.hpp
+++ b/include/ginkgo/core/base/executor.hpp
@@ -1153,6 +1153,7 @@ public:
     void run(const Operation& op) const override
     {
         this->template log<log::Logger::operation_launched>(this, &op);
+        auto scope_guard = get_scoped_device_id_guard();
         op.run(self()->shared_from_this());
         this->template log<log::Logger::operation_completed>(this, &op);
     }
@@ -1324,14 +1325,6 @@ public:
         return std::shared_ptr<ReferenceExecutor>(new ReferenceExecutor());
     }
 
-    void run(const Operation& op) const override
-    {
-        this->template log<log::Logger::operation_launched>(this, &op);
-        op.run(std::static_pointer_cast<const ReferenceExecutor>(
-            this->shared_from_this()));
-        this->template log<log::Logger::operation_completed>(this, &op);
-    }
-
     scoped_device_id_guard get_scoped_device_id_guard() const override
     {
         return {this, 0};
@@ -1408,8 +1401,6 @@ public:
     std::shared_ptr<const Executor> get_master() const noexcept override;
 
     void synchronize() const override;
-
-    void run(const Operation& op) const override;
 
     scoped_device_id_guard get_scoped_device_id_guard() const override;
 
@@ -1613,8 +1604,6 @@ public:
 
     void synchronize() const override;
 
-    void run(const Operation& op) const override;
-
     scoped_device_id_guard get_scoped_device_id_guard() const override;
 
     /**
@@ -1812,8 +1801,6 @@ public:
     std::shared_ptr<const Executor> get_master() const noexcept override;
 
     void synchronize() const override;
-
-    void run(const Operation& op) const override;
 
     scoped_device_id_guard get_scoped_device_id_guard() const override;
 

--- a/include/ginkgo/core/base/executor.hpp
+++ b/include/ginkgo/core/base/executor.hpp
@@ -1057,6 +1057,11 @@ private:
             op_omp_();
         }
 
+        void run(std::shared_ptr<const ReferenceExecutor>) const override
+        {
+            op_omp_();
+        }
+
         void run(std::shared_ptr<const CudaExecutor>) const override
         {
             op_cuda_();

--- a/test/base/CMakeLists.txt
+++ b/test/base/CMakeLists.txt
@@ -1,2 +1,3 @@
 ginkgo_create_common_and_reference_test(device_matrix_data_kernels)
 ginkgo_create_common_device_test(kernel_launch_generic)
+ginkgo_create_common_and_reference_test(executor)

--- a/test/base/executor.cpp
+++ b/test/base/executor.cpp
@@ -1,4 +1,38 @@
+/*******************************<GINKGO LICENSE>******************************
+Copyright (c) 2017-2022, the Ginkgo authors
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+******************************<GINKGO LICENSE>*******************************/
+
 #include <ginkgo/core/base/executor.hpp>
+
+
 #include <map>
 
 

--- a/test/base/executor.cpp
+++ b/test/base/executor.cpp
@@ -6,6 +6,7 @@
 
 
 #include "core/test/utils/assertions.hpp"
+#include "test/utils/executor.hpp"
 
 
 namespace reference {
@@ -56,11 +57,12 @@ public:
     int& value;
 };
 
+class Executor : public CommonTestFixture {};
 
-TEST(Executor, RunsCorrectOperation)
+
+TEST_F(Executor, RunsCorrectOperation)
 {
     int value = 0;
-    auto exec = gko::EXEC_TYPE::create();
 
     exec->run(ExampleOperation(value));
 
@@ -71,14 +73,13 @@ TEST(Executor, RunsCorrectOperation)
 #ifndef GKO_COMPILING_REFERENCE
 
 
-TEST(Executor, RunsCorrectLambdaOperation)
+TEST_F(Executor, RunsCorrectLambdaOperation)
 {
     int value = 0;
     auto omp_lambda = [&value]() { value = omp::value; };
     auto cuda_lambda = [&value]() { value = cuda::value; };
     auto hip_lambda = [&value]() { value = hip::value; };
     auto dpcpp_lambda = [&value]() { value = dpcpp::value; };
-    auto exec = gko::EXEC_TYPE::create();
 
     exec->run(omp_lambda, cuda_lambda, hip_lambda, dpcpp_lambda);
 

--- a/test/base/executor.cpp
+++ b/test/base/executor.cpp
@@ -1,0 +1,89 @@
+#include <ginkgo/core/base/executor.hpp>
+#include <map>
+
+
+#include <gtest/gtest.h>
+
+
+#include "core/test/utils/assertions.hpp"
+
+
+namespace reference {
+int value = 5;
+}
+
+namespace omp {
+int value = 1;
+}
+
+namespace cuda {
+int value = 2;
+}
+
+namespace hip {
+int value = 3;
+}
+
+namespace dpcpp {
+int value = 4;
+}
+
+
+class ExampleOperation : public gko::Operation {
+public:
+    explicit ExampleOperation(int& val) : value(val) {}
+    void run(std::shared_ptr<const gko::OmpExecutor>) const override
+    {
+        value = omp::value;
+    }
+    void run(std::shared_ptr<const gko::CudaExecutor>) const override
+    {
+        value = cuda::value;
+    }
+    void run(std::shared_ptr<const gko::HipExecutor>) const override
+    {
+        value = hip::value;
+    }
+    void run(std::shared_ptr<const gko::DpcppExecutor>) const override
+    {
+        value = dpcpp::value;
+    }
+    void run(std::shared_ptr<const gko::ReferenceExecutor>) const override
+    {
+        value = reference::value;
+    }
+
+    int& value;
+};
+
+
+TEST(Executor, RunsCorrectOperation)
+{
+    int value = 0;
+    auto exec = gko::EXEC_TYPE::create();
+
+    exec->run(ExampleOperation(value));
+
+    ASSERT_EQ(EXEC_NAMESPACE::value, value);
+}
+
+
+#ifndef GKO_COMPILING_REFERENCE
+
+
+TEST(Executor, RunsCorrectLambdaOperation)
+{
+    int value = 0;
+    auto omp_lambda = [&value]() { value = omp::value; };
+    auto cuda_lambda = [&value]() { value = cuda::value; };
+    auto hip_lambda = [&value]() { value = hip::value; };
+    auto dpcpp_lambda = [&value]() { value = dpcpp::value; };
+    auto exec = gko::EXEC_TYPE::create();
+
+    exec->run(omp_lambda, cuda_lambda, hip_lambda, dpcpp_lambda);
+
+    ASSERT_EQ(EXEC_NAMESPACE::value, value);
+}
+
+
+#endif  // GKO_COMPILING_REFERENCE


### PR DESCRIPTION
The overrides of `run` in our concrete executors are unnecessary. With the addition of the generic device-id scope guard, the implementation in `ExecutorBase` is sufficient.