### PR TITLE
Proof of concept: local operation for mpi

### DIFF
--- a/examples/distributed-solver/distributed-solver.cpp
+++ b/examples/distributed-solver/distributed-solver.cpp
@@ -42,6 +42,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 // Add the string manipulation header to handle strings.
 #include <string>
 
+#include <ginkgo/core/distributed/local_factory.hpp>
+
 
 int main(int argc, char* argv[])
 {
@@ -224,6 +226,12 @@ int main(int argc, char* argv[])
                 gko::stop::ResidualNorm<ValueType>::build()
                     .with_baseline(gko::stop::mode::absolute)
                     .with_reduction_factor(1e-4)
+                    .on(exec))
+            .with_preconditioner(
+                gko::experimental::distributed::LocalFactory::build()
+                    .with_local_factory(
+                        gko::preconditioner::Jacobi<ValueType>::build().on(
+                            exec))
                     .on(exec))
             .on(exec)
             ->generate(A);

--- a/include/ginkgo/core/distributed/base.hpp
+++ b/include/ginkgo/core/distributed/base.hpp
@@ -95,6 +95,21 @@ private:
 };
 
 
+class GetLocal {
+public:
+    virtual const LinOp* get_const_local() const = 0;
+
+    virtual LinOp* get_local() = 0;
+};
+
+class GetLocalShared {
+public:
+    virtual std::shared_ptr<const LinOp> get_const_local() const = 0;
+
+    virtual std::shared_ptr<LinOp> get_local() = 0;
+};
+
+
 }  // namespace distributed
 }  // namespace experimental
 }  // namespace gko

--- a/include/ginkgo/core/distributed/local_factory.hpp
+++ b/include/ginkgo/core/distributed/local_factory.hpp
@@ -1,0 +1,129 @@
+/*******************************<GINKGO LICENSE>******************************
+Copyright (c) 2017-2022, the Ginkgo authors
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+******************************<GINKGO LICENSE>*******************************/
+
+#ifndef GKO_PUBLIC_CORE_DISTRIBUTED_LOCAL_FACTORY_HPP_
+#define GKO_PUBLIC_CORE_DISTRIBUTED_LOCAL_FACTORY_HPP_
+
+
+#include <ginkgo/config.hpp>
+
+
+#if GINKGO_BUILD_MPI
+
+
+#include <ginkgo/core/base/dense_cache.hpp>
+#include <ginkgo/core/base/mpi.hpp>
+#include <ginkgo/core/distributed/base.hpp>
+#include <ginkgo/core/distributed/lin_op.hpp>
+#include <ginkgo/core/distributed/matrix.hpp>
+#include <ginkgo/core/distributed/vector.hpp>
+
+namespace gko {
+namespace experimental {
+namespace distributed {
+
+
+/**
+ * The LocalFactory class defines a local factory for (MPI-)distributed system
+ *
+ * It will generate individual factory on the local matrix, so there's no
+ * communication in the local factory or corresponding operation.
+ */
+class LocalFactory : public EnableLinOp<LocalFactory> {
+    friend class EnablePolymorphicObject<LocalFactory, LinOp>;
+
+public:
+    using EnableLinOp<LocalFactory>::convert_to;
+    using EnableLinOp<LocalFactory>::move_to;
+
+    /**
+     * Get read access to the stored local matrix.
+     *
+     * @return  Shared pointer to the stored local matrix
+     */
+    std::shared_ptr<const LinOp> get_local_op() const { return local_op_; }
+
+    GKO_CREATE_FACTORY_PARAMETERS(parameters, Factory)
+    {
+        /**
+         * Already generated preconditioner. If one is provided, the factory
+         * `preconditioner` will be ignored.
+         */
+        std::shared_ptr<const LinOpFactory> GKO_FACTORY_PARAMETER_SCALAR(
+            local_factory, nullptr);
+    };
+    GKO_ENABLE_LIN_OP_FACTORY(LocalFactory, parameters, Factory);
+    GKO_ENABLE_BUILD_METHOD(Factory);
+
+protected:
+    explicit LocalFactory(std::shared_ptr<const Executor> exec)
+        : EnableLinOp<LocalFactory>(std::move(exec))
+    {}
+    explicit LocalFactory(const Factory* factory,
+                          std::shared_ptr<const LinOp> system_matrix)
+        : EnableLinOp<LocalFactory>(factory->get_executor(),
+                                    gko::transpose(system_matrix->get_size())),
+          parameters_{factory->get_parameters()}
+    {
+        if (parameters_.local_factory != nullptr) {
+            local_op_ = parameters_.local_factory->generate(
+                as<GetLocalShared>(system_matrix)->get_const_local());
+        }
+    }
+
+    void apply_impl(const LinOp* b, LinOp* x) const override
+    {
+        local_op_->apply(as<GetLocal>(b)->get_const_local(),
+                         as<GetLocal>(x)->get_local());
+    }
+
+    void apply_impl(const LinOp* alpha, const LinOp* b, const LinOp* beta,
+                    LinOp* x) const override
+    {
+        local_op_->apply(alpha, as<GetLocal>(b)->get_const_local(), beta,
+                         as<GetLocal>(x)->get_local());
+    }
+
+private:
+    std::shared_ptr<const LinOp> local_op_;
+};
+
+
+}  // namespace distributed
+}  // namespace experimental
+}  // namespace gko
+
+
+#endif
+
+
+#endif  // GKO_PUBLIC_CORE_DISTRIBUTED_LOCAL_FACTORY_HPP_

--- a/include/ginkgo/core/distributed/matrix.hpp
+++ b/include/ginkgo/core/distributed/matrix.hpp
@@ -72,8 +72,8 @@ struct is_matrix_type_builder : std::false_type {};
 template <typename Builder, typename ValueType, typename IndexType>
 struct is_matrix_type_builder<
     Builder, ValueType, IndexType,
-    gko::xstd::void_t<decltype(
-        std::declval<Builder>().template create<ValueType, IndexType>(
+    gko::xstd::void_t<
+        decltype(std::declval<Builder>().template create<ValueType, IndexType>(
             std::declval<std::shared_ptr<const Executor>>()))>>
     : std::true_type {};
 
@@ -268,7 +268,8 @@ class Matrix
           Matrix<ValueType, LocalIndexType, GlobalIndexType>>,
       public ConvertibleTo<
           Matrix<next_precision<ValueType>, LocalIndexType, GlobalIndexType>>,
-      public DistributedBase {
+      public DistributedBase,
+      public GetLocalShared {
     friend class EnableCreateMethod<Matrix>;
     friend class EnableDistributedPolymorphicObject<Matrix, LinOp>;
     friend class Matrix<next_precision<ValueType>, LocalIndexType,
@@ -363,6 +364,13 @@ public:
      * @return  Shared pointer to the stored local matrix
      */
     std::shared_ptr<const LinOp> get_local_matrix() const { return local_mtx_; }
+
+    std::shared_ptr<const LinOp> get_const_local() const override
+    {
+        return local_mtx_;
+    }
+
+    std::shared_ptr<LinOp> get_local() override { return local_mtx_; }
 
     /**
      * Get read access to the stored non-local matrix.

--- a/include/ginkgo/core/distributed/vector.hpp
+++ b/include/ginkgo/core/distributed/vector.hpp
@@ -89,7 +89,8 @@ class Vector
       public EnableCreateMethod<Vector<ValueType>>,
       public ConvertibleTo<Vector<next_precision<ValueType>>>,
       public EnableAbsoluteComputation<remove_complex<Vector<ValueType>>>,
-      public DistributedBase {
+      public DistributedBase,
+      public GetLocal {
     friend class EnableCreateMethod<Vector>;
     friend class EnableDistributedPolymorphicObject<Vector, LinOp>;
     friend class Vector<to_complex<ValueType>>;
@@ -428,6 +429,13 @@ public:
      * @return a constant pointer to the underlying local_vector_type vectors
      */
     const local_vector_type* get_local_vector() const;
+
+    const LinOp* get_const_local() const override
+    {
+        return this->get_local_vector();
+    }
+
+    LinOp* get_local() override { return &local_; }
 
     /**
      * Create a real view of the (potentially) complex original multi-vector.


### PR DESCRIPTION
The idea is simple: the operation only considers the local matrix (the diagonal part).
`op->apply(b, x) on mtx` -> `op->apply(b.local, x.local)` on mtx.local no communication is needed.
Of course, the generated matrix is only based on the diagonal part, so it might lose some global information.
ILU/IC might not prefer this way. I guess it still works well when the offdiagonal is not heavy/strong
Jacobi should be quite suitable for this case unless we would like to have a cross rank block.
With this, we can also have a distributed IR with local preconditioner to refine solution by global communication.
all LinOpFactory (it can easily extend to LinOp) including Multigrid