### PR TITLE
moves nocuda-mpi job to fairrs

### DIFF
--- a/.gitlab/image.yml
+++ b/.gitlab/image.yml
@@ -8,6 +8,7 @@
   image: ginkgohub/cpu:openmpi-gnu9-llvm8
   tags:
     - private_ci
+    - fairrs
 #    - nla-gpu  # TODO: enable when nla-gpu is available
 
 .use_gko-nocuda-nompi-gnu9-llvm8:


### PR DESCRIPTION
The mpi job might otherwise get picked up by a runner that has not as many cores available as are necessary for the communicator test.