### PR TITLE
throws in `Executor::create` if module is not compiled

### DIFF
--- a/core/device_hooks/cuda_hooks.cpp
+++ b/core/device_hooks/cuda_hooks.cpp
@@ -52,17 +52,11 @@ version version_info::get_cuda_version() noexcept
 
 std::shared_ptr<CudaExecutor> CudaExecutor::create(
     int device_id, std::shared_ptr<Executor> master, bool device_reset,
-    allocation_mode alloc_mode)
-{
-    return std::shared_ptr<CudaExecutor>(new CudaExecutor(
-        device_id, std::move(master), device_reset, alloc_mode));
-}
+    allocation_mode alloc_mode) GKO_NOT_COMPILED(cuda);
 
 
 void CudaExecutor::populate_exec_info(const machine_topology* mach_topo)
-{
-    // This method is always called, so cannot throw when not compiled.
-}
+    GKO_NOT_COMPILED(cuda);
 
 
 void OmpExecutor::raw_copy_to(const CudaExecutor*, size_type num_bytes,

--- a/core/device_hooks/dpcpp_hooks.cpp
+++ b/core/device_hooks/dpcpp_hooks.cpp
@@ -53,17 +53,11 @@ version version_info::get_dpcpp_version() noexcept
 
 std::shared_ptr<DpcppExecutor> DpcppExecutor::create(
     int device_id, std::shared_ptr<Executor> master, std::string device_type,
-    dpcpp_queue_property property)
-{
-    return std::shared_ptr<DpcppExecutor>(
-        new DpcppExecutor(device_id, std::move(master), device_type, property));
-}
+    dpcpp_queue_property property) GKO_NOT_COMPILED(dpcpp);
 
 
 void DpcppExecutor::populate_exec_info(const machine_topology* mach_topo)
-{
-    // This method is always called, so cannot throw when not compiled.
-}
+    GKO_NOT_COMPILED(dpcpp);
 
 
 void OmpExecutor::raw_copy_to(const DpcppExecutor*, size_type num_bytes,
@@ -82,7 +76,7 @@ bool OmpExecutor::verify_memory_to(const DpcppExecutor* dest_exec) const
 void DpcppExecutor::raw_free(void* ptr) const noexcept
 {
     // Free must never fail, as it can be called in destructors.
-    // If the nvidia module was not compiled, the library couldn't have
+    // If the dpcpp module was not compiled, the library couldn't have
     // allocated the memory, so there is no need to deallocate it.
 }
 

--- a/core/device_hooks/hip_hooks.cpp
+++ b/core/device_hooks/hip_hooks.cpp
@@ -53,17 +53,11 @@ version version_info::get_hip_version() noexcept
 
 std::shared_ptr<HipExecutor> HipExecutor::create(
     int device_id, std::shared_ptr<Executor> master, bool device_reset,
-    allocation_mode alloc_mode)
-{
-    return std::shared_ptr<HipExecutor>(new HipExecutor(
-        device_id, std::move(master), device_reset, alloc_mode));
-}
+    allocation_mode alloc_mode) GKO_NOT_COMPILED(hip);
 
 
 void HipExecutor::populate_exec_info(const machine_topology* mach_topo)
-{
-    // This method is always called, so cannot throw when not compiled.
-}
+    GKO_NOT_COMPILED(hip);
 
 
 void OmpExecutor::raw_copy_to(const HipExecutor*, size_type num_bytes,
@@ -74,7 +68,7 @@ void OmpExecutor::raw_copy_to(const HipExecutor*, size_type num_bytes,
 void HipExecutor::raw_free(void* ptr) const noexcept
 {
     // Free must never fail, as it can be called in destructors.
-    // If the nvidia module was not compiled, the library couldn't have
+    // If the hip module was not compiled, the library couldn't have
     // allocated the memory, so there is no need to deallocate it.
 }
 

--- a/core/device_hooks/reference_hooks.cpp
+++ b/core/device_hooks/reference_hooks.cpp
@@ -31,6 +31,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ******************************<GINKGO LICENSE>*******************************/
 
 #include <ginkgo/core/base/exception_helpers.hpp>
+#include <ginkgo/core/base/executor.hpp>
 #include <ginkgo/core/base/scoped_device_id_guard.hpp>
 #include <ginkgo/core/base/version.hpp>
 
@@ -44,6 +45,10 @@ version version_info::get_reference_version() noexcept
     // placeholder modules.
     return {GKO_VERSION_STR, "not compiled"};
 }
+
+
+std::shared_ptr<ReferenceExecutor> ReferenceExecutor::create()
+    GKO_NOT_COMPILED(reference);
 
 
 scoped_device_id_guard::scoped_device_id_guard(const ReferenceExecutor* exec,

--- a/include/ginkgo/core/base/executor.hpp
+++ b/include/ginkgo/core/base/executor.hpp
@@ -1262,10 +1262,7 @@ public:
     /**
      * Creates a new OmpExecutor.
      */
-    static std::shared_ptr<OmpExecutor> create()
-    {
-        return std::shared_ptr<OmpExecutor>(new OmpExecutor());
-    }
+    static std::shared_ptr<OmpExecutor> create();
 
     std::shared_ptr<Executor> get_master() noexcept override;
 
@@ -1327,10 +1324,7 @@ using DefaultExecutor = OmpExecutor;
  */
 class ReferenceExecutor : public OmpExecutor {
 public:
-    static std::shared_ptr<ReferenceExecutor> create()
-    {
-        return std::shared_ptr<ReferenceExecutor>(new ReferenceExecutor());
-    }
+    static std::shared_ptr<ReferenceExecutor> create();
 
     scoped_device_id_guard get_scoped_device_id_guard() const override
     {

--- a/omp/CMakeLists.txt
+++ b/omp/CMakeLists.txt
@@ -2,6 +2,7 @@ add_library(ginkgo_omp $<TARGET_OBJECTS:ginkgo_omp_device> "")
 target_sources(ginkgo_omp
     PRIVATE
     base/device_matrix_data_kernels.cpp
+    base/executor.cpp
     base/index_set_kernels.cpp
     base/scoped_device_id.cpp
     base/version.cpp

--- a/omp/base/executor.cpp
+++ b/omp/base/executor.cpp
@@ -32,6 +32,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <ginkgo/core/base/executor.hpp>
 
+
 namespace gko {
 
 

--- a/omp/base/executor.cpp
+++ b/omp/base/executor.cpp
@@ -30,34 +30,15 @@ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ******************************<GINKGO LICENSE>*******************************/
 
-#include <ginkgo/core/base/exception_helpers.hpp>
 #include <ginkgo/core/base/executor.hpp>
-#include <ginkgo/core/base/scoped_device_id_guard.hpp>
-#include <ginkgo/core/base/version.hpp>
-
 
 namespace gko {
 
 
-version version_info::get_omp_version() noexcept
+std::shared_ptr<OmpExecutor> OmpExecutor::create()
 {
-    // We just return the version with a special "not compiled" tag in
-    // placeholder modules.
-    return {GKO_VERSION_STR, "not compiled"};
+    return std::shared_ptr<OmpExecutor>(new OmpExecutor);
 }
 
 
-std::shared_ptr<OmpExecutor> OmpExecutor::create() GKO_NOT_COMPILED(omp);
-
-
-scoped_device_id_guard::scoped_device_id_guard(const OmpExecutor* exec,
-                                               int device_id)
-    GKO_NOT_COMPILED(omp);
-
-
 }  // namespace gko
-
-
-#define GKO_HOOK_MODULE omp
-#include "core/device_hooks/common_kernels.inc.cpp"
-#undef GKO_HOOK_MODULE

--- a/reference/CMakeLists.txt
+++ b/reference/CMakeLists.txt
@@ -2,6 +2,7 @@ add_library(ginkgo_reference $<TARGET_OBJECTS:ginkgo_reference_device> "")
 target_sources(ginkgo_reference
     PRIVATE
     base/device_matrix_data_kernels.cpp
+    base/executor.cpp
     base/index_set_kernels.cpp
     base/scoped_device_id.cpp
     base/version.cpp

--- a/reference/base/executor.cpp
+++ b/reference/base/executor.cpp
@@ -30,34 +30,15 @@ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ******************************<GINKGO LICENSE>*******************************/
 
-#include <ginkgo/core/base/exception_helpers.hpp>
 #include <ginkgo/core/base/executor.hpp>
-#include <ginkgo/core/base/scoped_device_id_guard.hpp>
-#include <ginkgo/core/base/version.hpp>
-
 
 namespace gko {
 
 
-version version_info::get_omp_version() noexcept
+std::shared_ptr<ReferenceExecutor> ReferenceExecutor::create()
 {
-    // We just return the version with a special "not compiled" tag in
-    // placeholder modules.
-    return {GKO_VERSION_STR, "not compiled"};
+    return std::shared_ptr<ReferenceExecutor>(new ReferenceExecutor);
 }
 
 
-std::shared_ptr<OmpExecutor> OmpExecutor::create() GKO_NOT_COMPILED(omp);
-
-
-scoped_device_id_guard::scoped_device_id_guard(const OmpExecutor* exec,
-                                               int device_id)
-    GKO_NOT_COMPILED(omp);
-
-
 }  // namespace gko
-
-
-#define GKO_HOOK_MODULE omp
-#include "core/device_hooks/common_kernels.inc.cpp"
-#undef GKO_HOOK_MODULE

--- a/reference/base/executor.cpp
+++ b/reference/base/executor.cpp
@@ -32,6 +32,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <ginkgo/core/base/executor.hpp>
 
+
 namespace gko {
 
 


### PR DESCRIPTION
This PR makes all the `ConcreteExecutor::create` throw if the module is not compiled. This is also true for `OmpExecutor` and `ReferenceExecutor`. Also, the `populate_exec_info` function now also throws.