### PR TITLE
Update math.hpp

### DIFF
--- a/include/ginkgo/core/base/math.hpp
+++ b/include/ginkgo/core/base/math.hpp
@@ -658,7 +658,7 @@ GKO_INLINE GKO_ATTRIBUTES constexpr int64 ceildiv(int64 num, int64 den)
  * @return additive identity for T
  */
 template <typename T>
-GKO_INLINE __host__ constexpr T zero()
+GKO_INLINE __host__ __device__ constexpr T zero()
 {
     return T{};
 }
@@ -686,7 +686,7 @@ GKO_INLINE __host__ constexpr T zero(const T&)
  * @return the multiplicative identity for T
  */
 template <typename T>
-GKO_INLINE __host__ constexpr T one()
+GKO_INLINE __host__ __device__ constexpr T one()
 {
     return T(1);
 }


### PR DESCRIPTION
The `zero()` and `one()` functions are missing `__device__` implementations when building for HIP/ROCm. Without this change, Ginkgo fails to build with `-DGINKGO_BUILD_HIP=ON -DGINKGO_HIP_AMDGPU=gfx90a` with hipcc 5.2.0. hipcc didn't like creating separate functions for the device, so I added the device tag to the host implementation to be used for both.