### PR TITLE
Add support for distributed block-diagonal preconditioners. 

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -80,7 +80,8 @@ if(GINKGO_BUILD_MPI)
         PRIVATE
         mpi/exception.cpp
         distributed/matrix.cpp
-        distributed/vector.cpp)
+        distributed/vector.cpp
+        distributed/preconditioner/schwarz.cpp)
 endif()
 
 ginkgo_compile_features(ginkgo)

--- a/core/distributed/preconditioner/schwarz.cpp
+++ b/core/distributed/preconditioner/schwarz.cpp
@@ -1,5 +1,5 @@
 /*******************************<GINKGO LICENSE>******************************
-Copyright (c) 2017-2022, the Ginkgo authors
+Copyright (c) 2017-2023, the Ginkgo authors
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/core/distributed/preconditioner/schwarz.cpp
+++ b/core/distributed/preconditioner/schwarz.cpp
@@ -1,0 +1,126 @@
+/*******************************<GINKGO LICENSE>******************************
+Copyright (c) 2017-2022, the Ginkgo authors
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+******************************<GINKGO LICENSE>*******************************/
+
+#include <ginkgo/core/distributed/preconditioner/schwarz.hpp>
+
+
+#include <memory>
+
+
+#include <ginkgo/core/base/exception_helpers.hpp>
+#include <ginkgo/core/base/executor.hpp>
+#include <ginkgo/core/base/math.hpp>
+#include <ginkgo/core/base/precision_dispatch.hpp>
+#include <ginkgo/core/base/temporary_conversion.hpp>
+#include <ginkgo/core/base/utils.hpp>
+#include <ginkgo/core/distributed/matrix.hpp>
+#include <ginkgo/core/matrix/csr.hpp>
+#include <ginkgo/core/matrix/dense.hpp>
+
+
+#include "core/base/utils.hpp"
+#include "core/distributed/helpers.hpp"
+
+
+namespace gko {
+namespace distributed {
+namespace preconditioner {
+
+
+template <typename ValueType, typename IndexType>
+void Schwarz<ValueType, IndexType>::apply_impl(const LinOp* b, LinOp* x) const
+{
+    precision_dispatch_real_complex_distributed<ValueType>(
+        [this](auto dense_b, auto dense_x) {
+            this->apply_dense_impl(dense_b, dense_x);
+        },
+        b, x);
+}
+
+
+template <typename ValueType, typename IndexType>
+template <typename VectorType>
+void Schwarz<ValueType, IndexType>::apply_dense_impl(const VectorType* dense_b,
+                                                     VectorType* dense_x) const
+{
+    using Vector = matrix::Dense<ValueType>;
+    auto exec = this->get_executor();
+    auto one_op = initialize<Vector>({one<ValueType>()}, exec);
+    auto neg_one_op = initialize<Vector>({-one<ValueType>()}, exec);
+    this->local_solver_->apply(gko::detail::get_local(dense_b),
+                               gko::detail::get_local(dense_x));
+
+    if (coarse_solvers_[0]) {
+        for (auto& coarse : coarse_solvers_) {
+            coarse->apply(dense_b, dense_x);
+        }
+    }
+}
+
+
+template <typename ValueType, typename IndexType>
+void Schwarz<ValueType, IndexType>::apply_impl(const LinOp* alpha,
+                                               const LinOp* b,
+                                               const LinOp* beta,
+                                               LinOp* x) const
+{
+    precision_dispatch_real_complex_distributed<ValueType>(
+        [this](auto dense_alpha, auto dense_b, auto dense_beta, auto dense_x) {
+            auto x_clone = dense_x->clone();
+            this->apply_dense_impl(dense_b, x_clone.get());
+            dense_x->scale(dense_beta);
+            dense_x->add_scaled(dense_alpha, x_clone.get());
+        },
+        alpha, b, beta, x);
+}
+
+
+template <typename ValueType, typename IndexType>
+void Schwarz<ValueType, IndexType>::generate()
+{
+    if (parameters_.generated_local_solver) {
+        this->local_solver_ = parameters_.generated_local_solver;
+    } else {
+        this->local_solver_ =
+            parameters_.local_solver->generate(local_system_matrix_);
+    }
+}
+
+
+#define GKO_DECLARE_SCHWARZ(ValueType, IndexType) \
+    class Schwarz<ValueType, IndexType>
+GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(GKO_DECLARE_SCHWARZ);
+
+
+}  // namespace preconditioner
+}  // namespace distributed
+}  // namespace gko

--- a/core/distributed/preconditioner/schwarz.cpp
+++ b/core/distributed/preconditioner/schwarz.cpp
@@ -57,8 +57,9 @@ namespace distributed {
 namespace preconditioner {
 
 
-template <typename ValueType, typename IndexType>
-void Schwarz<ValueType, IndexType>::apply_impl(const LinOp* b, LinOp* x) const
+template <typename ValueType, typename LocalIndexType, typename GlobalIndexType>
+void Schwarz<ValueType, LocalIndexType, GlobalIndexType>::apply_impl(
+    const LinOp* b, LinOp* x) const
 {
     precision_dispatch_real_complex_distributed<ValueType>(
         [this](auto dense_b, auto dense_x) {
@@ -68,10 +69,10 @@ void Schwarz<ValueType, IndexType>::apply_impl(const LinOp* b, LinOp* x) const
 }
 
 
-template <typename ValueType, typename IndexType>
+template <typename ValueType, typename LocalIndexType, typename GlobalIndexType>
 template <typename VectorType>
-void Schwarz<ValueType, IndexType>::apply_dense_impl(const VectorType* dense_b,
-                                                     VectorType* dense_x) const
+void Schwarz<ValueType, LocalIndexType, GlobalIndexType>::apply_dense_impl(
+    const VectorType* dense_b, VectorType* dense_x) const
 {
     using Vector = matrix::Dense<ValueType>;
     auto exec = this->get_executor();
@@ -80,11 +81,9 @@ void Schwarz<ValueType, IndexType>::apply_dense_impl(const VectorType* dense_b,
 }
 
 
-template <typename ValueType, typename IndexType>
-void Schwarz<ValueType, IndexType>::apply_impl(const LinOp* alpha,
-                                               const LinOp* b,
-                                               const LinOp* beta,
-                                               LinOp* x) const
+template <typename ValueType, typename LocalIndexType, typename GlobalIndexType>
+void Schwarz<ValueType, LocalIndexType, GlobalIndexType>::apply_impl(
+    const LinOp* alpha, const LinOp* b, const LinOp* beta, LinOp* x) const
 {
     precision_dispatch_real_complex_distributed<ValueType>(
         [this](auto dense_alpha, auto dense_b, auto dense_beta, auto dense_x) {
@@ -97,8 +96,8 @@ void Schwarz<ValueType, IndexType>::apply_impl(const LinOp* alpha,
 }
 
 
-template <typename ValueType, typename IndexType>
-void Schwarz<ValueType, IndexType>::generate()
+template <typename ValueType, typename LocalIndexType, typename GlobalIndexType>
+void Schwarz<ValueType, LocalIndexType, GlobalIndexType>::generate()
 {
     if (parameters_.local_solver_factory) {
         this->local_solver_ =
@@ -109,9 +108,9 @@ void Schwarz<ValueType, IndexType>::generate()
 }
 
 
-#define GKO_DECLARE_SCHWARZ(ValueType, IndexType) \
-    class Schwarz<ValueType, IndexType>
-GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(GKO_DECLARE_SCHWARZ);
+#define GKO_DECLARE_SCHWARZ(ValueType, LocalIndexType, GlobalIndexType) \
+    class Schwarz<ValueType, LocalIndexType, GlobalIndexType>
+GKO_INSTANTIATE_FOR_EACH_VALUE_AND_LOCAL_GLOBAL_INDEX_TYPE(GKO_DECLARE_SCHWARZ);
 
 
 }  // namespace preconditioner

--- a/core/distributed/preconditioner/schwarz.cpp
+++ b/core/distributed/preconditioner/schwarz.cpp
@@ -52,6 +52,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
 namespace gko {
+namespace experimental {
 namespace distributed {
 namespace preconditioner {
 
@@ -123,4 +124,5 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(GKO_DECLARE_SCHWARZ);
 
 }  // namespace preconditioner
 }  // namespace distributed
+}  // namespace experimental
 }  // namespace gko

--- a/core/distributed/preconditioner/schwarz.cpp
+++ b/core/distributed/preconditioner/schwarz.cpp
@@ -75,8 +75,6 @@ void Schwarz<ValueType, IndexType>::apply_dense_impl(const VectorType* dense_b,
 {
     using Vector = matrix::Dense<ValueType>;
     auto exec = this->get_executor();
-    auto one_op = initialize<Vector>({one<ValueType>()}, exec);
-    auto neg_one_op = initialize<Vector>({-one<ValueType>()}, exec);
     this->local_solver_->apply(gko::detail::get_local(dense_b),
                                gko::detail::get_local(dense_x));
 }

--- a/core/distributed/preconditioner/schwarz.cpp
+++ b/core/distributed/preconditioner/schwarz.cpp
@@ -79,12 +79,6 @@ void Schwarz<ValueType, IndexType>::apply_dense_impl(const VectorType* dense_b,
     auto neg_one_op = initialize<Vector>({-one<ValueType>()}, exec);
     this->local_solver_->apply(gko::detail::get_local(dense_b),
                                gko::detail::get_local(dense_x));
-
-    if (coarse_solvers_[0]) {
-        for (auto& coarse : coarse_solvers_) {
-            coarse->apply(dense_b, dense_x);
-        }
-    }
 }
 
 
@@ -108,11 +102,11 @@ void Schwarz<ValueType, IndexType>::apply_impl(const LinOp* alpha,
 template <typename ValueType, typename IndexType>
 void Schwarz<ValueType, IndexType>::generate()
 {
-    if (parameters_.generated_local_solver) {
-        this->local_solver_ = parameters_.generated_local_solver;
-    } else {
+    if (parameters_.local_solver_factory) {
         this->local_solver_ =
-            parameters_.local_solver->generate(local_system_matrix_);
+            parameters_.local_solver_factory->generate(local_system_matrix_);
+    } else {
+        GKO_NOT_IMPLEMENTED;
     }
 }
 

--- a/core/test/mpi/distributed/CMakeLists.txt
+++ b/core/test/mpi/distributed/CMakeLists.txt
@@ -1,2 +1,4 @@
 ginkgo_create_test(helpers MPI_SIZE 1)
 ginkgo_create_test(matrix MPI_SIZE 1)
+
+add_subdirectory(preconditioner)

--- a/core/test/mpi/distributed/preconditioner/CMakeLists.txt
+++ b/core/test/mpi/distributed/preconditioner/CMakeLists.txt
@@ -1,0 +1,1 @@
+ginkgo_create_test(schwarz MPI_SIZE 1)

--- a/core/test/mpi/distributed/preconditioner/schwarz.cpp
+++ b/core/test/mpi/distributed/preconditioner/schwarz.cpp
@@ -1,5 +1,5 @@
 /*******************************<GINKGO LICENSE>******************************
-Copyright (c) 2017-2022, the Ginkgo authors
+Copyright (c) 2017-2023, the Ginkgo authors
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/core/test/mpi/distributed/preconditioner/schwarz.cpp
+++ b/core/test/mpi/distributed/preconditioner/schwarz.cpp
@@ -1,0 +1,92 @@
+/*******************************<GINKGO LICENSE>******************************
+Copyright (c) 2017-2022, the Ginkgo authors
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+******************************<GINKGO LICENSE>*******************************/
+
+#include <gtest/gtest.h>
+
+
+#include <ginkgo/config.hpp>
+#include <ginkgo/core/distributed/preconditioner/schwarz.hpp>
+#include <ginkgo/core/matrix/csr.hpp>
+#include <ginkgo/core/preconditioner/jacobi.hpp>
+
+
+#include "core/test/utils.hpp"
+
+
+namespace {
+
+
+template <typename ValueIndexType>
+class SchwarzFactory : public ::testing::Test {
+protected:
+    using value_type =
+        typename std::tuple_element<0, decltype(ValueIndexType())>::type;
+    using index_type =
+        typename std::tuple_element<1, decltype(ValueIndexType())>::type;
+    using Schwarz =
+        gko::experimental::distributed::preconditioner::Schwarz<value_type,
+                                                                index_type>;
+    using Jacobi = gko::preconditioner::Jacobi<value_type, index_type>;
+
+    SchwarzFactory()
+        : exec(gko::ReferenceExecutor::create()),
+          jacobi_factory(Jacobi::build().on(exec)),
+          mtx(gko::matrix::Csr<value_type, index_type>::create(
+              exec, gko::dim<2>{5, 5}, 13)),
+          schwarz_factory(Schwarz::build()
+                              .with_local_solver_factory(jacobi_factory)
+                              .on(exec))
+    {}
+
+    std::shared_ptr<const gko::Executor> exec;
+    std::shared_ptr<typename Schwarz::Factory> schwarz_factory;
+    std::shared_ptr<typename Jacobi::Factory> jacobi_factory;
+    std::shared_ptr<gko::matrix::Csr<value_type, index_type>> mtx;
+};
+
+TYPED_TEST_SUITE(SchwarzFactory, gko::test::ValueIndexTypes);
+
+
+TYPED_TEST(SchwarzFactory, KnowsItsExecutor)
+{
+    ASSERT_EQ(this->schwarz_factory->get_executor(), this->exec);
+}
+
+
+TYPED_TEST(SchwarzFactory, CanSetLocalFactory)
+{
+    ASSERT_EQ(this->schwarz_factory->get_parameters().local_solver_factory,
+              this->jacobi_factory);
+}
+
+
+}  // namespace

--- a/core/test/mpi/distributed/preconditioner/schwarz.cpp
+++ b/core/test/mpi/distributed/preconditioner/schwarz.cpp
@@ -84,8 +84,7 @@ protected:
 
     void assert_same_precond(const Schwarz* a, const Schwarz* b)
     {
-        ASSERT_EQ(a->get_size()[0], b->get_size()[0]);
-        ASSERT_EQ(a->get_size()[1], b->get_size()[1]);
+        ASSERT_EQ(a->get_size(), b->get_size());
         ASSERT_EQ(a->get_parameters().local_solver_factory,
                   b->get_parameters().local_solver_factory);
     }
@@ -149,7 +148,7 @@ TYPED_TEST(SchwarzFactory, CanBeMoved)
                     .on(this->exec)
                     ->generate(Mtx::create(this->exec, MPI_COMM_WORLD));
 
-    copy->copy_from(give(this->schwarz));
+    copy->move_from(gko::lend(this->schwarz));
 
     this->assert_same_precond(lend(copy), lend(tmp));
 }

--- a/core/test/mpi/distributed/preconditioner/schwarz.cpp
+++ b/core/test/mpi/distributed/preconditioner/schwarz.cpp
@@ -45,18 +45,24 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 namespace {
 
 
-template <typename ValueIndexType>
+template <typename ValueLocalGlobalIndexType>
 class SchwarzFactory : public ::testing::Test {
 protected:
     using value_type =
-        typename std::tuple_element<0, decltype(ValueIndexType())>::type;
-    using index_type =
-        typename std::tuple_element<1, decltype(ValueIndexType())>::type;
-    using Schwarz =
-        gko::experimental::distributed::preconditioner::Schwarz<value_type,
-                                                                index_type>;
-    using Jacobi = gko::preconditioner::Jacobi<value_type, index_type>;
-    using Mtx = gko::experimental::distributed::Matrix<value_type, index_type>;
+        typename std::tuple_element<0, decltype(
+                                           ValueLocalGlobalIndexType())>::type;
+    using local_index_type =
+        typename std::tuple_element<1, decltype(
+                                           ValueLocalGlobalIndexType())>::type;
+    using global_index_type =
+        typename std::tuple_element<1, decltype(
+                                           ValueLocalGlobalIndexType())>::type;
+    using Schwarz = gko::experimental::distributed::preconditioner::Schwarz<
+        value_type, local_index_type, global_index_type>;
+    using Jacobi = gko::preconditioner::Jacobi<value_type, local_index_type>;
+    using Mtx =
+        gko::experimental::distributed::Matrix<value_type, local_index_type,
+                                               global_index_type>;
 
     SchwarzFactory()
         : exec(gko::ReferenceExecutor::create()),
@@ -90,7 +96,7 @@ protected:
     std::shared_ptr<Mtx> mtx;
 };
 
-TYPED_TEST_SUITE(SchwarzFactory, gko::test::ValueIndexTypes);
+TYPED_TEST_SUITE(SchwarzFactory, gko::test::ValueLocalGlobalIndexTypes);
 
 
 TYPED_TEST(SchwarzFactory, KnowsItsExecutor)

--- a/examples/distributed-solver/distributed-solver.cpp
+++ b/examples/distributed-solver/distributed-solver.cpp
@@ -45,6 +45,9 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 int main(int argc, char* argv[])
 {
+    // @sect3{MPI environment}
+    // Start an scoped MPI environment, which gets cleaned up on the exit of the
+    // function.
     const gko::experimental::mpi::environment env(argc, argv);
     // @sect3{Type Definitiions}
     // Define the needed types. In a parallel program we need to differentiate
@@ -77,6 +80,7 @@ int main(int argc, char* argv[])
         ValueType, LocalIndexType, GlobalIndexType>;
     using bj = gko::preconditioner::Jacobi<ValueType, LocalIndexType>;
 
+    // Create an MPI communicator get the rank of the calling process.
     const auto comm = gko::experimental::mpi::communicator(MPI_COMM_WORLD);
     const auto rank = comm.rank();
 
@@ -135,7 +139,7 @@ int main(int argc, char* argv[])
                      device_id = gko::experimental::mpi::map_rank_to_device_id(
                          comm, gko::DpcppExecutor::get_num_devices("cpu"));
                  } else {
-                     GKO_NOT_IMPLEMENTED;
+                     throw std::runtime_error("No suitable DPC++ devices");
                  }
                  return gko::DpcppExecutor::create(
                      device_id, gko::ReferenceExecutor::create());

--- a/examples/distributed-solver/distributed-solver.cpp
+++ b/examples/distributed-solver/distributed-solver.cpp
@@ -211,7 +211,6 @@ int main(int argc, char* argv[])
     // @sect3{Solve the Distributed System}
     // Generate the solver, this is the same as in the non-distributed case.
     // with a local block diagonal preconditioner.
-    //
 
     // Setup the local block diagonal solver factory.
     auto local_solver = gko::share(bj::build().on(exec));

--- a/examples/distributed-solver/distributed-solver.cpp
+++ b/examples/distributed-solver/distributed-solver.cpp
@@ -45,6 +45,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 int main(int argc, char* argv[])
 {
+    const gko::mpi::environment env(argc, argv);
     // @sect3{Type Definitiions}
     // Define the needed types. In a parallel program we need to differentiate
     // beweeen global and local indices, thus we have two index types.
@@ -66,28 +67,20 @@ int main(int argc, char* argv[])
     // The partition type describes how the rows of the matrices are
     // distributed.
     using part_type =
-        gko::experimental::distributed::Partition<LocalIndexType,
-                                                  GlobalIndexType>;
+        gko::distributed::Partition<LocalIndexType, GlobalIndexType>;
     // We can use here the same solver type as you would use in a
     // non-distributed program. Please note that not all solvers support
     // distributed systems at the moment.
     using solver = gko::solver::Cg<ValueType>;
+    using schwarz =
+        gko::distributed::preconditioner::Schwarz<ValueType, LocalIndexType>;
+    using bj = gko::preconditioner::Jacobi<ValueType, LocalIndexType>;
 
     // @sect3{Initialization and User Input Handling}
     // Since this is an MPI program, we need to initialize and finalize
     // MPI at the begin and end respectively of our program. This can be easily
     // done with the following helper construct that uses RAII to automize the
     // initialization and finalization.
-    const gko::experimental::mpi::environment env(argc, argv);
-
-    // Create an MPI communicator wrapper and get the rank.
-    const gko::experimental::mpi::communicator comm{MPI_COMM_WORLD};
-    const auto rank = comm.rank();
-
-    // Print the ginkgo version information and help message.
-    if (rank == 0) {
-        std::cout << gko::version_info::get() << std::endl;
-    }
     if (argc == 2 && (std::string(argv[1]) == "--help")) {
         if (rank == 0) {
             std::cerr << "Usage: " << argv[0]
@@ -97,7 +90,7 @@ int main(int argc, char* argv[])
         std::exit(-1);
     }
 
-    ValueType t_init = gko::experimental::mpi::get_walltime();
+    ValueType t_init = gko::mpi::get_walltime();
 
     // User input settings:
     // - The executor, defaults to reference.
@@ -108,46 +101,46 @@ int main(int argc, char* argv[])
     const auto num_iters =
         static_cast<gko::size_type>(argc >= 4 ? std::atoi(argv[3]) : 1000);
 
-    // Pick the requested executor.
-    std::map<std::string, std::function<std::shared_ptr<gko::Executor>()>>
-        exec_map{
-            {"omp", [] { return gko::OmpExecutor::create(); }},
+    const std::map<std::string,
+                   std::function<std::shared_ptr<gko::Executor>(MPI_Comm)>>
+        executor_factory_mpi{
+            {"reference",
+             [](MPI_Comm) { return gko::ReferenceExecutor::create(); }},
+            {"omp", [](MPI_Comm) { return gko::OmpExecutor::create(); }},
             {"cuda",
-             [&] {
+             [](MPI_Comm comm) {
+                 int device_id = gko::mpi::map_rank_to_device_id(
+                     comm, gko::CudaExecutor::get_num_devices());
                  return gko::CudaExecutor::create(
-                     gko::experimental::mpi::map_rank_to_device_id(
-                         MPI_COMM_WORLD, gko::CudaExecutor::get_num_devices()),
-                     gko::ReferenceExecutor::create(), false,
+                     device_id, gko::ReferenceExecutor::create(), false,
                      gko::allocation_mode::device);
              }},
             {"hip",
-             [&] {
+             [](MPI_Comm comm) {
+                 int device_id = gko::mpi::map_rank_to_device_id(
+                     comm, gko::HipExecutor::get_num_devices());
                  return gko::HipExecutor::create(
-                     gko::experimental::mpi::map_rank_to_device_id(
-                         MPI_COMM_WORLD, gko::HipExecutor::get_num_devices()),
-                     gko::ReferenceExecutor::create(), true);
+                     device_id, gko::ReferenceExecutor::create(), true);
              }},
-            {"dpcpp",
-             [&] {
-                 auto ref = gko::ReferenceExecutor::create();
-                 if (gko::DpcppExecutor::get_num_devices("gpu") > 0) {
-                     return gko::DpcppExecutor::create(
-                         gko::experimental::mpi::map_rank_to_device_id(
-                             MPI_COMM_WORLD,
-                             gko::DpcppExecutor::get_num_devices("gpu")),
-                         ref);
-                 } else if (gko::DpcppExecutor::get_num_devices("cpu") > 0) {
-                     return gko::DpcppExecutor::create(
-                         gko::experimental::mpi::map_rank_to_device_id(
-                             MPI_COMM_WORLD,
-                             gko::DpcppExecutor::get_num_devices("cpu")),
-                         ref);
+            {"dpcpp", [](MPI_Comm comm) {
+                 int device_id = 0;
+                 if (gko::DpcppExecutor::get_num_devices("gpu")) {
+                     device_id = gko::mpi::map_rank_to_device_id(
+                         comm, gko::DpcppExecutor::get_num_devices("gpu"));
+                 } else if (gko::DpcppExecutor::get_num_devices("cpu")) {
+                     device_id = gko::mpi::map_rank_to_device_id(
+                         comm, gko::DpcppExecutor::get_num_devices("cpu"));
                  } else {
-                     throw std::runtime_error("No suitable DPC++ devices");
+                     GKO_NOT_IMPLEMENTED;
                  }
-             }},
-            {"reference", [] { return gko::ReferenceExecutor::create(); }}};
-    const auto exec = exec_map.at(executor_string)();
+                 return gko::DpcppExecutor::create(
+                     device_id, gko::ReferenceExecutor::create());
+             }}};
+
+    auto exec = executor_factory_mpi.at(executor_string)(MPI_COMM_WORLD);
+
+    const auto comm = gko::mpi::communicator(MPI_COMM_WORLD, exec);
+    const auto rank = comm.rank();
 
     // @sect3{Creating the Distributed Matrix and Vectors}
     // As a first step, we create a partition of the rows. The partition
@@ -155,9 +148,8 @@ int main(int argc, char* argv[])
     // These part-ids will be used for the distributed data structures to
     // determine which rows will be stored locally. In this example each rank
     // has (nearly) the same number of rows, so we can use the following
-    // specialized constructor. See @ref
-    // gko::experimental::distributed::Partition for other modes of creating a
-    // partition.
+    // specialized constructor. See @ref gko::distributed::Partition for other
+    // modes of creating a partition.
     const auto num_rows = grid_dim;
     auto partition = gko::share(part_type::build_from_global_size_uniform(
         exec->get_master(), comm.size(),
@@ -190,7 +182,7 @@ int main(int argc, char* argv[])
 
     // Take timings.
     comm.synchronize();
-    ValueType t_init_end = gko::experimental::mpi::get_walltime();
+    ValueType t_init_end = gko::mpi::get_walltime();
 
     // Read the matrix data, currently this is only supported on CPU executors.
     // This will also set up the communication pattern needed for the
@@ -212,12 +204,16 @@ int main(int argc, char* argv[])
 
     // Take timings.
     comm.synchronize();
-    ValueType t_read_setup_end = gko::experimental::mpi::get_walltime();
+    ValueType t_read_setup_end = gko::mpi::get_walltime();
 
     // @sect3{Solve the Distributed System}
     // Generate the solver, this is the same as in the non-distributed case.
+    //
+    auto local_solver = gko::share(bj::build().on(exec));
     auto Ainv =
         solver::build()
+            .with_preconditioner(
+                schwarz::build().with_local_solver(local_solver).on(exec))
             .with_criteria(
                 gko::stop::Iteration::build().with_max_iters(num_iters).on(
                     exec),
@@ -230,7 +226,7 @@ int main(int argc, char* argv[])
 
     // Take timings.
     comm.synchronize();
-    ValueType t_solver_generate_end = gko::experimental::mpi::get_walltime();
+    ValueType t_solver_generate_end = gko::mpi::get_walltime();
 
     // Apply the distributed solver, this is the same as in the non-distributed
     // case.
@@ -238,7 +234,7 @@ int main(int argc, char* argv[])
 
     // Take timings.
     comm.synchronize();
-    ValueType t_solver_apply_end = gko::experimental::mpi::get_walltime();
+    ValueType t_solver_apply_end = gko::mpi::get_walltime();
 
     // Compute the residual, this is done in the same way as in the
     // non-distributed case.
@@ -252,7 +248,7 @@ int main(int argc, char* argv[])
 
     // Take timings.
     comm.synchronize();
-    ValueType t_end = gko::experimental::mpi::get_walltime();
+    ValueType t_end = gko::mpi::get_walltime();
 
     // @sect3{Printing Results}
     // Print the achieved residual norm and timings on rank 0.

--- a/examples/distributed-solver/distributed-solver.cpp
+++ b/examples/distributed-solver/distributed-solver.cpp
@@ -208,23 +208,38 @@ int main(int argc, char* argv[])
     comm.synchronize();
     ValueType t_read_setup_end = gko::experimental::mpi::get_walltime();
 
+
     // @sect3{Solve the Distributed System}
     // Generate the solver, this is the same as in the non-distributed case.
+    // with a local block diagonal preconditioner.
     //
+
+    // Setup the local block diagonal solver factory.
     auto local_solver = gko::share(bj::build().on(exec));
+
+    // Setup the stopping criterion and logger
+    const gko::remove_complex<ValueType> reduction_factor{1e-8};
+    std::shared_ptr<const gko::log::Convergence<ValueType>> logger =
+        gko::log::Convergence<ValueType>::create();
+    auto iter_stop = gko::share(
+        gko::stop::Iteration::build().with_max_iters(num_iters).on(exec));
+    auto tol_stop = gko::share(gko::stop::ResidualNorm<ValueType>::build()
+                                   .with_reduction_factor(reduction_factor)
+                                   .on(exec));
+    iter_stop->add_logger(logger);
+    tol_stop->add_logger(logger);
+
     auto Ainv =
         solver::build()
-            .with_preconditioner(
-                schwarz::build().with_local_solver(local_solver).on(exec))
-            .with_criteria(
-                gko::stop::Iteration::build().with_max_iters(num_iters).on(
-                    exec),
-                gko::stop::ResidualNorm<ValueType>::build()
-                    .with_baseline(gko::stop::mode::absolute)
-                    .with_reduction_factor(1e-4)
-                    .on(exec))
+            .with_preconditioner(schwarz::build()
+                                     .with_local_solver_factory(local_solver)
+                                     .on(exec))
+            .with_criteria(iter_stop, tol_stop)
             .on(exec)
             ->generate(A);
+    // Add logger to the generated solver to log the iteration count and
+    // residual norm
+    Ainv->add_logger(logger);
 
     // Take timings.
     comm.synchronize();
@@ -259,6 +274,7 @@ int main(int argc, char* argv[])
         std::cout << "\nNum rows in matrix: " << num_rows
                   << "\nNum ranks: " << comm.size()
                   << "\nFinal Res norm: " << *res_norm->get_values()
+                  << "\nIteration count: " << logger->get_num_iterations()
                   << "\nInit time: " << t_init_end - t_init
                   << "\nRead time: " << t_read_setup_end - t_init
                   << "\nSolver generate time: " << t_solver_generate_end - t_read_setup_end

--- a/examples/distributed-solver/distributed-solver.cpp
+++ b/examples/distributed-solver/distributed-solver.cpp
@@ -45,9 +45,11 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 int main(int argc, char* argv[])
 {
-    // @sect3{MPI environment}
-    // Start an scoped MPI environment, which gets cleaned up on the exit of the
-    // function.
+    // @sect3{Initialize the MPI environment}
+    // Since this is an MPI program, we need to initialize and finalize
+    // MPI at the begin and end respectively of our program. This can be easily
+    // done with the following helper construct that uses RAII to automate the
+    // initialization and finalization.
     const gko::experimental::mpi::environment env(argc, argv);
     // @sect3{Type Definitiions}
     // Define the needed types. In a parallel program we need to differentiate
@@ -84,11 +86,11 @@ int main(int argc, char* argv[])
     const auto comm = gko::experimental::mpi::communicator(MPI_COMM_WORLD);
     const auto rank = comm.rank();
 
-    // @sect3{Initialization and User Input Handling}
-    // Since this is an MPI program, we need to initialize and finalize
-    // MPI at the begin and end respectively of our program. This can be easily
-    // done with the following helper construct that uses RAII to automize the
-    // initialization and finalization.
+    // @sect3{User Input Handling}
+    // User input settings:
+    // - The executor, defaults to reference.
+    // - The number of grid points, defaults to 100.
+    // - The number of iterations, defaults to 1000.
     if (argc == 2 && (std::string(argv[1]) == "--help")) {
         if (rank == 0) {
             std::cerr << "Usage: " << argv[0]
@@ -100,9 +102,6 @@ int main(int argc, char* argv[])
 
     ValueType t_init = gko::experimental::mpi::get_walltime();
 
-    // User input settings:
-    // - The executor, defaults to reference.
-    // - The number of grid points, defaults to 100.
     const auto executor_string = argc >= 2 ? argv[1] : "reference";
     const auto grid_dim =
         static_cast<gko::size_type>(argc >= 3 ? std::atoi(argv[2]) : 100);

--- a/examples/distributed-solver/distributed-solver.cpp
+++ b/examples/distributed-solver/distributed-solver.cpp
@@ -73,9 +73,8 @@ int main(int argc, char* argv[])
     // non-distributed program. Please note that not all solvers support
     // distributed systems at the moment.
     using solver = gko::solver::Cg<ValueType>;
-    using schwarz =
-        gko::experimental::distributed::preconditioner::Schwarz<ValueType,
-                                                                LocalIndexType>;
+    using schwarz = gko::experimental::distributed::preconditioner::Schwarz<
+        ValueType, LocalIndexType, GlobalIndexType>;
     using bj = gko::preconditioner::Jacobi<ValueType, LocalIndexType>;
 
     const auto comm = gko::experimental::mpi::communicator(MPI_COMM_WORLD);

--- a/examples/distributed-solver/doc/results.dox
+++ b/examples/distributed-solver/doc/results.dox
@@ -6,6 +6,7 @@ This is the expected output for `mpirun -n 4 ./distributed-solver`:
 Num rows in matrix: 100
 Num ranks: 4
 Final Res norm: 5.58392e-12
+Iteration count: 7
 Init time: 0.0663887
 Read time: 0.0729806
 Solver generate time: 7.6348e-05

--- a/include/ginkgo/core/distributed/preconditioner/schwarz.hpp
+++ b/include/ginkgo/core/distributed/preconditioner/schwarz.hpp
@@ -1,5 +1,5 @@
 /*******************************<GINKGO LICENSE>******************************
-Copyright (c) 2017-2022, the Ginkgo authors
+Copyright (c) 2017-2023, the Ginkgo authors
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/include/ginkgo/core/distributed/preconditioner/schwarz.hpp
+++ b/include/ginkgo/core/distributed/preconditioner/schwarz.hpp
@@ -40,7 +40,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #if GINKGO_BUILD_MPI
 
 
-#include <ginkgo/core/base/array.hpp>
 #include <ginkgo/core/base/lin_op.hpp>
 #include <ginkgo/core/distributed/matrix.hpp>
 #include <ginkgo/core/distributed/vector.hpp>
@@ -65,7 +64,7 @@ namespace preconditioner {
  * See Iterative Methods for Sparse Linear Systems (Y. Saad) for a general
  * treatment and variations of the method.
  *
- * @note Currently overlaps are not supported (TODO).
+ * @note Currently overlap and coarse grid correction are not supported (TODO).
  *
  * @tparam ValueType  precision of matrix elements
  * @tparam IndexType  integral type of the preconditioner

--- a/include/ginkgo/core/distributed/preconditioner/schwarz.hpp
+++ b/include/ginkgo/core/distributed/preconditioner/schwarz.hpp
@@ -34,6 +34,12 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define GKO_PUBLIC_CORE_DISTRIBUTED_PRECONDITIONER_SCHWARZ_HPP_
 
 
+#include <ginkgo/config.hpp>
+
+
+#if GINKGO_BUILD_MPI
+
+
 #include <ginkgo/core/base/array.hpp>
 #include <ginkgo/core/base/lin_op.hpp>
 #include <ginkgo/core/distributed/matrix.hpp>
@@ -177,4 +183,5 @@ private:
 }  // namespace gko
 
 
+#endif  // GINKGO_BUILD_MPI
 #endif  // GKO_PUBLIC_CORE_DISTRIBUTED_PRECONDITIONER_SCHWARZ_HPP_

--- a/include/ginkgo/core/distributed/preconditioner/schwarz.hpp
+++ b/include/ginkgo/core/distributed/preconditioner/schwarz.hpp
@@ -84,7 +84,6 @@ public:
     using EnableLinOp<Schwarz>::move_to;
     using value_type = ValueType;
     using index_type = IndexType;
-    using mat_data = matrix_data<ValueType, IndexType>;
 
     /**
      * Returns the number of blocks of the operator.

--- a/include/ginkgo/core/distributed/preconditioner/schwarz.hpp
+++ b/include/ginkgo/core/distributed/preconditioner/schwarz.hpp
@@ -74,8 +74,10 @@ namespace preconditioner {
  * @ingroup precond
  * @ingroup LinOp
  */
-template <typename ValueType = default_precision, typename IndexType = int32>
-class Schwarz : public EnableLinOp<Schwarz<ValueType, IndexType>> {
+template <typename ValueType = default_precision,
+          typename LocalIndexType = int32, typename GlobalIndexType = int64>
+class Schwarz
+    : public EnableLinOp<Schwarz<ValueType, LocalIndexType, GlobalIndexType>> {
     friend class EnableLinOp<Schwarz>;
     friend class EnablePolymorphicObject<Schwarz, LinOp>;
 
@@ -83,12 +85,14 @@ public:
     using EnableLinOp<Schwarz>::convert_to;
     using EnableLinOp<Schwarz>::move_to;
     using value_type = ValueType;
-    using index_type = IndexType;
+    using index_type = GlobalIndexType;
+    using local_index_type = LocalIndexType;
+    using global_index_type = GlobalIndexType;
 
     /**
-     * Returns the number of blocks of the operator.
+     * Returns the local system matrix (rank-local diagonal block).
      *
-     * @return the number of blocks of the operator
+     * @return the local system matrix
      */
     std::shared_ptr<const LinOp> get_local_system_matrix() const
     {
@@ -130,7 +134,8 @@ protected:
                                gko::transpose(system_matrix->get_size())),
           parameters_{factory->get_parameters()},
           local_system_matrix_{std::move(
-              as<experimental::distributed::Matrix<ValueType, IndexType>>(
+              as<experimental::distributed::Matrix<ValueType, LocalIndexType,
+                                                   GlobalIndexType>>(
                   system_matrix.get())
                   ->get_local_matrix())}
     {

--- a/include/ginkgo/core/distributed/preconditioner/schwarz.hpp
+++ b/include/ginkgo/core/distributed/preconditioner/schwarz.hpp
@@ -88,17 +88,6 @@ public:
     using local_index_type = LocalIndexType;
     using global_index_type = GlobalIndexType;
 
-    /**
-     * Returns the local system matrix (rank-local diagonal block).
-     *
-     * @return the local system matrix
-     */
-    std::shared_ptr<const LinOp> get_local_system_matrix() const
-    {
-        return local_system_matrix_;
-    }
-
-
     GKO_CREATE_FACTORY_PARAMETERS(parameters, Factory)
     {
         /**
@@ -131,20 +120,16 @@ protected:
                      std::shared_ptr<const LinOp> system_matrix)
         : EnableLinOp<Schwarz>(factory->get_executor(),
                                gko::transpose(system_matrix->get_size())),
-          parameters_{factory->get_parameters()},
-          local_system_matrix_{std::move(
-              as<experimental::distributed::Matrix<ValueType, LocalIndexType,
-                                                   GlobalIndexType>>(
-                  system_matrix.get())
-                  ->get_local_matrix())}
+          parameters_{factory->get_parameters()}
     {
-        this->generate();
+        this->generate(system_matrix);
     }
 
     /**
      * Generates the preconditoner.
      */
-    void generate();
+    void generate(std::shared_ptr<const LinOp> system_matrix);
+
 
     void apply_impl(const LinOp* b, LinOp* x) const override;
 
@@ -155,7 +140,6 @@ protected:
                     LinOp* x) const override;
 
 private:
-    std::shared_ptr<const LinOp> local_system_matrix_;
     std::shared_ptr<const LinOp> local_solver_;
 };
 

--- a/include/ginkgo/core/distributed/preconditioner/schwarz.hpp
+++ b/include/ginkgo/core/distributed/preconditioner/schwarz.hpp
@@ -144,9 +144,6 @@ protected:
 
     /**
      * Generates the preconditoner.
-     *
-     * @param system_matrix  the source matrix used to generate the
-     *                       preconditioner
      */
     void generate();
 

--- a/include/ginkgo/core/distributed/preconditioner/schwarz.hpp
+++ b/include/ginkgo/core/distributed/preconditioner/schwarz.hpp
@@ -1,0 +1,177 @@
+/*******************************<GINKGO LICENSE>******************************
+Copyright (c) 2017-2022, the Ginkgo authors
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+******************************<GINKGO LICENSE>*******************************/
+
+#ifndef GKO_PUBLIC_CORE_DISTRIBUTED_PRECONDITIONER_SCHWARZ_HPP_
+#define GKO_PUBLIC_CORE_DISTRIBUTED_PRECONDITIONER_SCHWARZ_HPP_
+
+
+#include <ginkgo/core/base/array.hpp>
+#include <ginkgo/core/base/lin_op.hpp>
+#include <ginkgo/core/distributed/matrix.hpp>
+#include <ginkgo/core/distributed/vector.hpp>
+
+
+namespace gko {
+namespace distributed {
+/**
+ * @brief The Preconditioner namespace.
+ *
+ * @ingroup precond
+ */
+namespace preconditioner {
+
+
+/**
+ * A Schwarz preconditioner is a simple domain decomposition preconditioner that
+ * generalizes the Block Jacobi preconditioner, incorporating options for
+ * different local subdomain solvers and overlaps between the subdomains.
+ *
+ * See Iterative Methods for Sparse Linear Systems (Y. Saad) for a general
+ * treatment and variations of the method.
+ *
+ * @tparam ValueType  precision of matrix elements
+ * @tparam IndexType  integral type of the preconditioner
+ *
+ * @ingroup schwarz
+ * @ingroup precond
+ * @ingroup LinOp
+ */
+template <typename ValueType = default_precision, typename IndexType = int32>
+class Schwarz : public EnableLinOp<Schwarz<ValueType, IndexType>> {
+    friend class EnableLinOp<Schwarz>;
+    friend class EnablePolymorphicObject<Schwarz, LinOp>;
+
+public:
+    using EnableLinOp<Schwarz>::convert_to;
+    using EnableLinOp<Schwarz>::move_to;
+    using value_type = ValueType;
+    using index_type = IndexType;
+    using mat_data = matrix_data<ValueType, IndexType>;
+
+    /**
+     * Returns the number of blocks of the operator.
+     *
+     * @return the number of blocks of the operator
+     */
+    std::shared_ptr<const LinOp> get_local_system_matrix() const
+    {
+        return local_system_matrix_;
+    }
+
+
+    GKO_CREATE_FACTORY_PARAMETERS(parameters, Factory)
+    {
+        /**
+         * Local solver factory.
+         */
+        std::shared_ptr<const LinOpFactory> GKO_FACTORY_PARAMETER_SCALAR(
+            local_solver, nullptr);
+
+        /**
+         * Generated Local solvers.
+         */
+        std::shared_ptr<const LinOp> GKO_FACTORY_PARAMETER_SCALAR(
+            generated_local_solver, nullptr);
+
+        /**
+         * Coarse solvers.
+         *
+         * Note: Coarse solvers need to be of type gko::solver::Multigrid.
+         */
+        std::vector<std::shared_ptr<const LinOp>> GKO_FACTORY_PARAMETER_VECTOR(
+            coarse_solvers, nullptr);
+    };
+    GKO_ENABLE_LIN_OP_FACTORY(Schwarz, parameters, Factory);
+    GKO_ENABLE_BUILD_METHOD(Factory);
+
+protected:
+    /**
+     * Creates an empty Schwarz preconditioner.
+     *
+     * @param exec  the executor this object is assigned to
+     */
+    explicit Schwarz(std::shared_ptr<const Executor> exec)
+        : EnableLinOp<Schwarz>(std::move(exec))
+    {}
+
+    /**
+     * Creates a Schwarz preconditioner from a matrix using a Schwarz::Factory.
+     *
+     * @param factory  the factory to use to create the preconditoner
+     * @param system_matrix  the matrix this preconditioner should be created
+     *                       from
+     */
+    explicit Schwarz(const Factory* factory,
+                     std::shared_ptr<const LinOp> system_matrix)
+        : EnableLinOp<Schwarz>(factory->get_executor(),
+                               gko::transpose(system_matrix->get_size())),
+          parameters_{factory->get_parameters()},
+          local_system_matrix_{std::move(
+              as<distributed::Matrix<ValueType, IndexType>>(system_matrix.get())
+                  ->get_local_matrix())},
+          coarse_solvers_{parameters_.coarse_solvers}
+    {
+        this->generate();
+    }
+
+    /**
+     * Generates the preconditoner.
+     *
+     * @param system_matrix  the source matrix used to generate the
+     *                       preconditioner
+     * @param skip_sorting  determines if the sorting of system_matrix can be
+     *                      skipped (therefore, marking that it is already
+     *                      sorted)
+     */
+    void generate();
+
+    void apply_impl(const LinOp* b, LinOp* x) const override;
+
+    template <typename VectorType>
+    void apply_dense_impl(const VectorType* b, VectorType* x) const;
+
+    void apply_impl(const LinOp* alpha, const LinOp* b, const LinOp* beta,
+                    LinOp* x) const override;
+
+private:
+    std::shared_ptr<const LinOp> local_system_matrix_;
+    std::shared_ptr<const LinOp> local_solver_;
+    std::vector<std::shared_ptr<const LinOp>> coarse_solvers_;
+};
+
+
+}  // namespace preconditioner
+}  // namespace distributed
+}  // namespace gko
+
+
+#endif  // GKO_PUBLIC_CORE_DISTRIBUTED_PRECONDITIONER_SCHWARZ_HPP_

--- a/include/ginkgo/core/distributed/preconditioner/schwarz.hpp
+++ b/include/ginkgo/core/distributed/preconditioner/schwarz.hpp
@@ -65,6 +65,8 @@ namespace preconditioner {
  * See Iterative Methods for Sparse Linear Systems (Y. Saad) for a general
  * treatment and variations of the method.
  *
+ * @note Currently overlaps are not supported (TODO).
+ *
  * @tparam ValueType  precision of matrix elements
  * @tparam IndexType  integral type of the preconditioner
  *
@@ -101,21 +103,7 @@ public:
          * Local solver factory.
          */
         std::shared_ptr<const LinOpFactory> GKO_FACTORY_PARAMETER_SCALAR(
-            local_solver, nullptr);
-
-        /**
-         * Generated Local solvers.
-         */
-        std::shared_ptr<const LinOp> GKO_FACTORY_PARAMETER_SCALAR(
-            generated_local_solver, nullptr);
-
-        /**
-         * Coarse solvers.
-         *
-         * Note: Coarse solvers need to be of type gko::solver::Multigrid.
-         */
-        std::vector<std::shared_ptr<const LinOp>> GKO_FACTORY_PARAMETER_VECTOR(
-            coarse_solvers, nullptr);
+            local_solver_factory, nullptr);
     };
     GKO_ENABLE_LIN_OP_FACTORY(Schwarz, parameters, Factory);
     GKO_ENABLE_BUILD_METHOD(Factory);
@@ -145,8 +133,7 @@ protected:
           local_system_matrix_{std::move(
               as<experimental::distributed::Matrix<ValueType, IndexType>>(
                   system_matrix.get())
-                  ->get_local_matrix())},
-          coarse_solvers_{parameters_.coarse_solvers}
+                  ->get_local_matrix())}
     {
         this->generate();
     }
@@ -156,9 +143,6 @@ protected:
      *
      * @param system_matrix  the source matrix used to generate the
      *                       preconditioner
-     * @param skip_sorting  determines if the sorting of system_matrix can be
-     *                      skipped (therefore, marking that it is already
-     *                      sorted)
      */
     void generate();
 
@@ -173,7 +157,6 @@ protected:
 private:
     std::shared_ptr<const LinOp> local_system_matrix_;
     std::shared_ptr<const LinOp> local_solver_;
-    std::vector<std::shared_ptr<const LinOp>> coarse_solvers_;
 };
 
 

--- a/include/ginkgo/core/distributed/preconditioner/schwarz.hpp
+++ b/include/ginkgo/core/distributed/preconditioner/schwarz.hpp
@@ -41,6 +41,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
 namespace gko {
+namespace experimental {
 namespace distributed {
 /**
  * @brief The Preconditioner namespace.
@@ -136,7 +137,8 @@ protected:
                                gko::transpose(system_matrix->get_size())),
           parameters_{factory->get_parameters()},
           local_system_matrix_{std::move(
-              as<distributed::Matrix<ValueType, IndexType>>(system_matrix.get())
+              as<experimental::distributed::Matrix<ValueType, IndexType>>(
+                  system_matrix.get())
                   ->get_local_matrix())},
           coarse_solvers_{parameters_.coarse_solvers}
     {
@@ -171,6 +173,7 @@ private:
 
 }  // namespace preconditioner
 }  // namespace distributed
+}  // namespace experimental
 }  // namespace gko
 
 

--- a/include/ginkgo/ginkgo.hpp
+++ b/include/ginkgo/ginkgo.hpp
@@ -77,9 +77,10 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <ginkgo/core/distributed/matrix.hpp>
 #include <ginkgo/core/distributed/partition.hpp>
 #include <ginkgo/core/distributed/polymorphic_object.hpp>
-#include <ginkgo/core/distributed/vector.hpp>
 
 #include <ginkgo/core/distributed/preconditioner/schwarz.hpp>
+
+#include <ginkgo/core/distributed/vector.hpp>
 
 #include <ginkgo/core/factorization/factorization.hpp>
 #include <ginkgo/core/factorization/ic.hpp>

--- a/include/ginkgo/ginkgo.hpp
+++ b/include/ginkgo/ginkgo.hpp
@@ -77,6 +77,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <ginkgo/core/distributed/matrix.hpp>
 #include <ginkgo/core/distributed/partition.hpp>
 #include <ginkgo/core/distributed/polymorphic_object.hpp>
+#include <ginkgo/core/distributed/preconditioner/schwarz.hpp>
 #include <ginkgo/core/distributed/vector.hpp>
 
 #include <ginkgo/core/factorization/factorization.hpp>

--- a/include/ginkgo/ginkgo.hpp
+++ b/include/ginkgo/ginkgo.hpp
@@ -77,8 +77,9 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <ginkgo/core/distributed/matrix.hpp>
 #include <ginkgo/core/distributed/partition.hpp>
 #include <ginkgo/core/distributed/polymorphic_object.hpp>
-#include <ginkgo/core/distributed/preconditioner/schwarz.hpp>
 #include <ginkgo/core/distributed/vector.hpp>
+
+#include <ginkgo/core/distributed/preconditioner/schwarz.hpp>
 
 #include <ginkgo/core/factorization/factorization.hpp>
 #include <ginkgo/core/factorization/ic.hpp>

--- a/test/mpi/distributed/CMakeLists.txt
+++ b/test/mpi/distributed/CMakeLists.txt
@@ -1,2 +1,4 @@
 ginkgo_create_common_and_reference_test(matrix MPI_SIZE 3)
 ginkgo_create_common_and_reference_test(vector MPI_SIZE 3)
+
+add_subdirectory(preconditioner)

--- a/test/mpi/distributed/preconditioner/CMakeLists.txt
+++ b/test/mpi/distributed/preconditioner/CMakeLists.txt
@@ -1,0 +1,1 @@
+ginkgo_create_common_and_reference_test(schwarz MPI_SIZE 3)

--- a/test/mpi/distributed/preconditioner/schwarz.cpp
+++ b/test/mpi/distributed/preconditioner/schwarz.cpp
@@ -199,8 +199,7 @@ TYPED_TEST(SchwarzPreconditioner, CanApplyPreconditionedSolver)
     using csr = typename TestFixture::local_matrix_type;
     using cg = typename TestFixture::solver_type;
     using prec = typename TestFixture::dist_prec_type;
-
-    static constexpr double tolerance = 1e-3;
+    constexpr double tolerance = 1e-3;
     auto iter_stop = gko::share(
         gko::stop::Iteration::build().with_max_iters(200u).on(this->exec));
     auto tol_stop = gko::share(

--- a/test/mpi/distributed/preconditioner/schwarz.cpp
+++ b/test/mpi/distributed/preconditioner/schwarz.cpp
@@ -1,0 +1,222 @@
+/*******************************<GINKGO LICENSE>******************************
+Copyright (c) 2017-2023, the Ginkgo authors
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+******************************<GINKGO LICENSE>*******************************/
+
+#include <array>
+#include <memory>
+#include <random>
+
+
+#include <mpi.h>
+
+
+#include <gtest/gtest.h>
+
+
+#include <ginkgo/config.hpp>
+#include <ginkgo/core/base/array.hpp>
+#include <ginkgo/core/base/matrix_data.hpp>
+#include <ginkgo/core/distributed/matrix.hpp>
+#include <ginkgo/core/distributed/partition.hpp>
+#include <ginkgo/core/distributed/preconditioner/schwarz.hpp>
+#include <ginkgo/core/distributed/vector.hpp>
+#include <ginkgo/core/log/logger.hpp>
+#include <ginkgo/core/matrix/csr.hpp>
+#include <ginkgo/core/matrix/dense.hpp>
+#include <ginkgo/core/preconditioner/jacobi.hpp>
+#include <ginkgo/core/solver/bicgstab.hpp>
+#include <ginkgo/core/solver/cg.hpp>
+#include <ginkgo/core/stop/iteration.hpp>
+#include <ginkgo/core/stop/residual_norm.hpp>
+
+
+#include "core/test/utils.hpp"
+#include "core/test/utils/matrix_generator.hpp"
+#include "core/utils/matrix_utils.hpp"
+#include "test/utils/mpi/executor.hpp"
+
+
+#if GINKGO_DPCPP_SINGLE_MODE
+using solver_value_type = float;
+#else
+using solver_value_type = double;
+#endif  // GINKGO_DPCPP_SINGLE_MODE
+
+
+template <typename ValueLocalGlobalIndexType>
+class SchwarzPreconditioner : public CommonMpiTestFixture {
+protected:
+    using value_type =
+        typename std::tuple_element<0, decltype(
+                                           ValueLocalGlobalIndexType())>::type;
+    using local_index_type =
+        typename std::tuple_element<1, decltype(
+                                           ValueLocalGlobalIndexType())>::type;
+    using global_index_type =
+        typename std::tuple_element<2, decltype(
+                                           ValueLocalGlobalIndexType())>::type;
+    using dist_mtx_type =
+        gko::experimental::distributed::Matrix<value_type, local_index_type,
+                                               global_index_type>;
+    using dist_vec_type = gko::experimental::distributed::Vector<value_type>;
+    using local_vec_type = gko::matrix::Dense<value_type>;
+    using dist_prec_type =
+        gko::experimental::distributed::preconditioner::Schwarz<
+            value_type, local_index_type, global_index_type>;
+    using solver_type = gko::solver::Bicgstab<value_type>;
+    using local_prec_type =
+        gko::preconditioner::Jacobi<value_type, local_index_type>;
+    using local_matrix_type = gko::matrix::Csr<value_type, local_index_type>;
+    using Partition =
+        gko::experimental::distributed::Partition<local_index_type,
+                                                  global_index_type>;
+    using matrix_data = gko::matrix_data<value_type, global_index_type>;
+
+
+    SchwarzPreconditioner()
+        : size{8, 8},
+          mat_input{size,
+                    {{0, 0, 2},  {0, 1, -1}, {1, 0, -1}, {1, 1, 2},  {1, 2, -1},
+                     {2, 1, -1}, {2, 2, 2},  {2, 3, -1}, {3, 2, -1}, {3, 3, 2},
+                     {3, 4, -1}, {4, 3, -1}, {4, 4, 2},  {4, 5, -1}, {5, 4, -1},
+                     {5, 5, 2},  {5, 6, -1}, {6, 5, -1}, {6, 6, 2},  {6, 7, -1},
+                     {7, 6, -1}, {7, 7, 2}}},
+          engine(42)
+    {
+        row_part = Partition::build_from_contiguous(
+            exec, gko::array<global_index_type>(
+                      exec, I<global_index_type>{0, 2, 4, 8}));
+
+        dist_mat = dist_mtx_type::create(exec, comm);
+        dist_mat->read_distributed(mat_input, row_part.get());
+
+        auto nrhs = 2;
+        auto global_size =
+            gko::dim<2>{size[0], static_cast<gko::size_type>(nrhs)};
+        auto local_size = gko::dim<2>{
+            static_cast<gko::size_type>(row_part->get_part_size(comm.rank())),
+            static_cast<gko::size_type>(nrhs)};
+        auto dist_result =
+            dist_vec_type::create(ref, comm, global_size, local_size, nrhs);
+        dist_result->read_distributed(
+            gen_dense_data<typename dist_vec_type::value_type,
+                           global_index_type>(global_size),
+            row_part.get());
+        dist_b = gko::share(gko::clone(exec, dist_result));
+        dist_x = gko::share(gko::clone(exec, dist_result));
+
+        local_solver_factory =
+            local_prec_type::build().with_max_block_size(1u).on(exec);
+    }
+
+    void SetUp() override { ASSERT_EQ(comm.size(), 3); }
+
+    template <typename ValueType, typename IndexType>
+    gko::matrix_data<ValueType, IndexType> gen_dense_data(gko::dim<2> size)
+    {
+        return {
+            size,
+            std::normal_distribution<gko::remove_complex<ValueType>>(0.0, 1.0),
+            engine};
+    }
+
+    template <typename M1, typename DistVecType>
+    void assert_residual_near(const std::shared_ptr<M1>& mtx,
+                              const std::shared_ptr<DistVecType>& x,
+                              const std::shared_ptr<DistVecType>& b,
+                              double tolerance)
+    {
+        auto one =
+            gko::initialize<local_vec_type>({gko::one<value_type>()}, exec);
+        auto neg_one =
+            gko::initialize<local_vec_type>({-gko::one<value_type>()}, exec);
+        auto norm = DistVecType::local_vector_type::absolute_type::create(
+            ref, gko::dim<2>{1, b->get_size()[1]});
+        auto dist_res = gko::clone(b);
+        mtx->apply(neg_one.get(), x.get(), one.get(), dist_res.get());
+        dist_res->compute_norm2(norm.get());
+
+        for (int i = 0; i < norm->get_num_stored_elements(); ++i) {
+            EXPECT_LE(norm->at(i), tolerance);
+        }
+    }
+
+
+    gko::dim<2> size;
+    std::shared_ptr<Partition> row_part;
+
+    gko::matrix_data<value_type, global_index_type> mat_input;
+
+    std::shared_ptr<dist_mtx_type> dist_mat;
+    std::shared_ptr<dist_vec_type> dist_b;
+    std::shared_ptr<dist_vec_type> dist_x;
+    std::shared_ptr<gko::LinOpFactory> solver_factory;
+    std::shared_ptr<gko::LinOpFactory> local_solver_factory;
+
+    std::default_random_engine engine;
+};
+
+TYPED_TEST_SUITE(SchwarzPreconditioner, gko::test::ValueLocalGlobalIndexTypes,
+                 TupleTypenameNameGenerator);
+
+
+TYPED_TEST(SchwarzPreconditioner, CanApplyPreconditionedSolver)
+{
+    using value_type = typename TestFixture::value_type;
+    using csr = typename TestFixture::local_matrix_type;
+    using cg = typename TestFixture::solver_type;
+    using prec = typename TestFixture::dist_prec_type;
+
+    double tolerance = 5e-6;
+    auto iter_stop = gko::share(
+        gko::stop::Iteration::build().with_max_iters(50u).on(this->exec));
+    auto tol_stop = gko::share(
+        gko::stop::ResidualNorm<value_type>::build()
+            .with_reduction_factor(
+                static_cast<gko::remove_complex<value_type>>(tolerance))
+            .on(this->exec));
+
+    this->solver_factory =
+        cg::build()
+            .with_preconditioner(
+                prec::build()
+                    .with_local_solver_factory(this->local_solver_factory)
+                    .on(this->exec))
+            .with_criteria(iter_stop, tol_stop)
+            .on(this->exec);
+
+    auto solver = this->solver_factory->generate(this->dist_mat);
+
+    solver->apply(this->dist_b.get(), this->dist_x.get());
+
+    this->assert_residual_near(this->dist_mat, this->dist_x, this->dist_b,
+                               tolerance);
+}


### PR DESCRIPTION
This PR is the first set of PRs enabling distributed preconditioning for our distributed solvers.

+ As discussed, everything is in the `experimental` namespace and in the `distributed/` folder.
+ ~~An example has been added to show the usage of the preconditioner~~.
+ ~~Some minor fixes have also been done to mpi, the run and dispatch function and also moving some things into the experimental namespace (Some contributed by @MarcelKoch)~~.
+ ~~A distributed stream logger was also added, but this probably needs more discussion (By @MarcelKoch).~~ Removed for now, as it is a separate thing, for which a new PR should be created.

### TODO
+ [x] Add tests.
