### PR TITLE
Allow passing smart pointers to functions directly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -599,9 +599,9 @@ int main()
                     .on(gpu))
             .on(gpu);
     // Solve system
-    solver->generate(give(A))->apply(lend(b), lend(x));
+    solver->generate(give(A))->apply(b, x);
     // Write result
-    write(std::cout, lend(x));
+    write(std::cout, x);
 }
 ```
 
@@ -624,7 +624,7 @@ Ginkgo 1.0.0 also offers initial support for the OpenMP executor. OpenMP kernels
 Memory Management
 -----------------
 
-As a result of its executor-based design and high level abstractions, Ginkgo has explicit information about the location of every piece of data it needs and can automatically allocate, free and move the data where it is needed. However, lazily moving data around is often not optimal, and determining when a piece of data should be copied or shared in general cannot be done automatically. For this reason, Ginkgo also gives explicit control of sharing and moving its objects to the user via the dedicated ownership commands: `gko::clone`, `gko::share`, `gko::give` and `gko::lend`. If you are interested in a detailed description of the problems the C++ standard has with these concepts check out [this Ginkgo Wiki page](https://github.com/ginkgo-project/ginkgo/wiki/Library-design#use-of-pointers), and for more details about Ginkgo's solution to the problem and the description of ownership commands take a look at [this issue](https://github.com/ginkgo-project/ginkgo/issues/30).
+As a result of its executor-based design and high level abstractions, Ginkgo has explicit information about the location of every piece of data it needs and can automatically allocate, free and move the data where it is needed. However, lazily moving data around is often not optimal, and determining when a piece of data should be copied or shared in general cannot be done automatically. For this reason, Ginkgo also gives explicit control of sharing and moving its objects to the user via the dedicated ownership commands: `gko::clone`, `gko::share` and `gko::give`. If you are interested in a detailed description of the problems the C++ standard has with these concepts check out [this Ginkgo Wiki page](https://github.com/ginkgo-project/ginkgo/wiki/Library-design#use-of-pointers), and for more details about Ginkgo's solution to the problem and the description of ownership commands take a look at [this issue](https://github.com/ginkgo-project/ginkgo/issues/30).
 
 Components
 ----------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -599,9 +599,9 @@ int main()
                     .on(gpu))
             .on(gpu);
     // Solve system
-    solver->generate(give(A))->apply(b, x);
+    solver->generate(give(A))->apply(lend(b), lend(x));
     // Write result
-    write(std::cout, x);
+    write(std::cout, lend(x));
 }
 ```
 
@@ -624,7 +624,7 @@ Ginkgo 1.0.0 also offers initial support for the OpenMP executor. OpenMP kernels
 Memory Management
 -----------------
 
-As a result of its executor-based design and high level abstractions, Ginkgo has explicit information about the location of every piece of data it needs and can automatically allocate, free and move the data where it is needed. However, lazily moving data around is often not optimal, and determining when a piece of data should be copied or shared in general cannot be done automatically. For this reason, Ginkgo also gives explicit control of sharing and moving its objects to the user via the dedicated ownership commands: `gko::clone`, `gko::share` and `gko::give`. If you are interested in a detailed description of the problems the C++ standard has with these concepts check out [this Ginkgo Wiki page](https://github.com/ginkgo-project/ginkgo/wiki/Library-design#use-of-pointers), and for more details about Ginkgo's solution to the problem and the description of ownership commands take a look at [this issue](https://github.com/ginkgo-project/ginkgo/issues/30).
+As a result of its executor-based design and high level abstractions, Ginkgo has explicit information about the location of every piece of data it needs and can automatically allocate, free and move the data where it is needed. However, lazily moving data around is often not optimal, and determining when a piece of data should be copied or shared in general cannot be done automatically. For this reason, Ginkgo also gives explicit control of sharing and moving its objects to the user via the dedicated ownership commands: `gko::clone`, `gko::share`, `gko::give` and `gko::lend`. If you are interested in a detailed description of the problems the C++ standard has with these concepts check out [this Ginkgo Wiki page](https://github.com/ginkgo-project/ginkgo/wiki/Library-design#use-of-pointers), and for more details about Ginkgo's solution to the problem and the description of ownership commands take a look at [this issue](https://github.com/ginkgo-project/ginkgo/issues/30).
 
 Components
 ----------

--- a/benchmark/blas/blas_common.hpp
+++ b/benchmark/blas/blas_common.hpp
@@ -84,9 +84,9 @@ public:
 };
 
 template <typename Generator, typename T>
-auto as_vector(T& p)
+auto as_vector(const std::unique_ptr<T>& p)
 {
-    return gko::as<typename Generator::Vec>(gko::lend(p));
+    return gko::as<typename Generator::Vec>(p.get());
 }
 
 
@@ -156,10 +156,7 @@ public:
 
     void prepare() override { as_vector<Generator>(y_)->fill(1); }
 
-    void run() override
-    {
-        as_vector<Generator>(y_)->add_scaled(lend(alpha_), lend(x_));
-    }
+    void run() override { as_vector<Generator>(y_)->add_scaled(alpha_, x_); }
 
 private:
     std::unique_ptr<gko::matrix::Dense<etype>> alpha_;
@@ -194,7 +191,7 @@ public:
 
     void prepare() override { as_vector<Generator>(y_)->fill(1); }
 
-    void run() override { as_vector<Generator>(y_)->scale(lend(alpha_)); }
+    void run() override { as_vector<Generator>(y_)->scale(alpha_); }
 
 private:
     std::unique_ptr<gko::matrix::Dense<etype>> alpha_;
@@ -229,10 +226,7 @@ public:
         return y_->get_size()[0] * y_->get_size()[1] * sizeof(etype) * 2;
     }
 
-    void run() override
-    {
-        as_vector<Generator>(x_)->compute_dot(lend(y_), lend(alpha_));
-    }
+    void run() override { as_vector<Generator>(x_)->compute_dot(y_, alpha_); }
 
 private:
     std::unique_ptr<gko::matrix::Dense<etype>> alpha_;
@@ -264,10 +258,7 @@ public:
         return y_->get_size()[0] * y_->get_size()[1] * sizeof(etype);
     }
 
-    void run() override
-    {
-        as_vector<Generator>(y_)->compute_norm2(lend(alpha_));
-    }
+    void run() override { as_vector<Generator>(y_)->compute_norm2(alpha_); }
 
 private:
     std::unique_ptr<gko::matrix::Dense<etype>> alpha_;
@@ -306,7 +297,7 @@ public:
                sizeof(etype);
     }
 
-    void run() override { A_->apply(lend(B_), lend(C_)); }
+    void run() override { A_->apply(B_, C_); }
 
 private:
     std::unique_ptr<gko::LinOp> A_;
@@ -352,10 +343,7 @@ public:
                sizeof(etype);
     }
 
-    void run() override
-    {
-        A_->apply(lend(alpha_), lend(B_), lend(beta_), lend(C_));
-    }
+    void run() override { A_->apply(alpha_, B_, beta_, C_); }
 
 private:
     std::unique_ptr<gko::matrix::Dense<etype>> alpha_;

--- a/benchmark/preconditioner/preconditioner.cpp
+++ b/benchmark/preconditioner/preconditioner.cpp
@@ -169,7 +169,7 @@ void run_preconditioner(const char* precond_name,
 
 
             for (auto _ : ic_apply.warmup_run()) {
-                precond->generate(system_matrix)->apply(lend(b), lend(x_clone));
+                precond->generate(system_matrix)->apply(b, x_clone);
             }
 
             std::unique_ptr<gko::LinOp> precond_op;
@@ -183,7 +183,7 @@ void run_preconditioner(const char* precond_name,
                               ic_gen.get_num_repetitions(), allocator);
 
             for (auto _ : ic_apply.run()) {
-                precond_op->apply(lend(b), lend(x_clone));
+                precond_op->apply(b, x_clone);
             }
 
             add_or_set_member(this_precond_data["apply"], "time",
@@ -208,9 +208,9 @@ void run_preconditioner(const char* precond_name,
                 precond_op = precond->generate(system_matrix);
             }
             if (exec->get_master() != exec) {
-                exec->get_master()->remove_logger(gko::lend(gen_logger));
+                exec->get_master()->remove_logger(gen_logger);
             }
-            exec->remove_logger(gko::lend(gen_logger));
+            exec->remove_logger(gen_logger);
 
             gen_logger->write_data(this_precond_data["generate"]["components"],
                                    allocator, ic_gen.get_num_repetitions());
@@ -222,12 +222,12 @@ void run_preconditioner(const char* precond_name,
                 exec->get_master()->add_logger(apply_logger);
             }
             for (auto i = 0u; i < ic_apply.get_num_repetitions(); ++i) {
-                precond_op->apply(lend(b), lend(x_clone));
+                precond_op->apply(b, x_clone);
             }
             if (exec->get_master() != exec) {
-                exec->get_master()->remove_logger(gko::lend(apply_logger));
+                exec->get_master()->remove_logger(apply_logger);
             }
-            exec->remove_logger(gko::lend(apply_logger));
+            exec->remove_logger(apply_logger);
 
             apply_logger->write_data(this_precond_data["apply"]["components"],
                                      allocator, ic_apply.get_num_repetitions());
@@ -321,7 +321,7 @@ int main(int argc, char* argv[])
             add_or_set_member(test_case, "size", data.size[0], allocator);
             for (const auto& precond_name : preconditioners) {
                 run_preconditioner(precond_name.c_str(), exec, system_matrix,
-                                   lend(b), lend(x), test_case, allocator);
+                                   b.get(), x.get(), test_case, allocator);
                 std::clog << "Current state:" << std::endl
                           << test_cases << std::endl;
                 backup_results(test_cases);

--- a/benchmark/solver/solver_common.hpp
+++ b/benchmark/solver/solver_common.hpp
@@ -341,17 +341,17 @@ struct SolverGenerator : DefaultSystemGenerator<> {
                 auto tmp = create_matrix_sin<etype>(exec, vec_size);
                 auto scalar = gko::matrix::Dense<rc_etype>::create(
                     exec->get_master(), gko::dim<2>{1, vec_size[1]});
-                tmp->compute_norm2(scalar.get());
+                tmp->compute_norm2(scalar);
                 for (gko::size_type i = 0; i < vec_size[1]; ++i) {
                     scalar->at(0, i) = gko::one<rc_etype>() / scalar->at(0, i);
                 }
                 // normalize sin-vector
                 if (gko::is_complex_s<etype>::value) {
-                    tmp->scale(scalar->make_complex().get());
+                    tmp->scale(scalar->make_complex());
                 } else {
-                    tmp->scale(scalar.get());
+                    tmp->scale(scalar);
                 }
-                system_matrix->apply(tmp.get(), rhs.get());
+                system_matrix->apply(tmp, rhs);
                 return rhs;
             }
             throw std::invalid_argument(std::string("\"rhs_generation\" = ") +

--- a/benchmark/solver/solver_common.hpp
+++ b/benchmark/solver/solver_common.hpp
@@ -417,7 +417,7 @@ void solve_system(const std::string& solver_name,
         add_or_set_member(solver_json, "iteration_timestamps",
                           rapidjson::Value(rapidjson::kArrayType), allocator);
         if (b->get_size()[1] == 1 && !FLAGS_overhead) {
-            auto rhs_norm = compute_norm2(lend(b));
+            auto rhs_norm = compute_norm2(b);
             add_or_set_member(solver_json, "rhs_norm", rhs_norm, allocator);
         }
         for (auto stage : {"generate", "apply"}) {
@@ -439,7 +439,7 @@ void solve_system(const std::string& solver_name,
             solver = generate_solver(exec, give(precond), solver_name,
                                      FLAGS_warmup_max_iters)
                          ->generate(system_matrix);
-            solver->apply(lend(b), lend(x_clone));
+            solver->apply(b, x_clone);
             exec->synchronize();
         }
 
@@ -460,20 +460,20 @@ void solve_system(const std::string& solver_name,
                                      FLAGS_max_iters)
                          ->generate(system_matrix);
 
-            exec->remove_logger(gko::lend(gen_logger));
+            exec->remove_logger(gen_logger);
             if (exec != exec->get_master()) {
-                exec->get_master()->remove_logger(gko::lend(gen_logger));
+                exec->get_master()->remove_logger(gen_logger);
             }
             gen_logger->write_data(solver_json["generate"]["components"],
                                    allocator, 1);
 
             if (auto prec =
-                    dynamic_cast<const gko::Preconditionable*>(lend(solver))) {
+                    dynamic_cast<const gko::Preconditionable*>(solver.get())) {
                 add_or_set_member(solver_json, "preconditioner",
                                   rapidjson::Value(rapidjson::kObjectType),
                                   allocator);
                 write_precond_info(
-                    lend(clone(exec->get_master(), prec->get_preconditioner())),
+                    clone(exec->get_master(), prec->get_preconditioner()).get(),
                     solver_json["preconditioner"], allocator);
             }
 
@@ -485,11 +485,11 @@ void solve_system(const std::string& solver_name,
             }
 
 
-            solver->apply(lend(b), lend(x_clone));
+            solver->apply(b, x_clone);
 
-            exec->remove_logger(gko::lend(apply_logger));
+            exec->remove_logger(apply_logger);
             if (exec != exec->get_master()) {
-                exec->get_master()->remove_logger(gko::lend(apply_logger));
+                exec->get_master()->remove_logger(apply_logger);
             }
             apply_logger->write_data(solver_json["apply"]["components"],
                                      allocator, 1);
@@ -498,12 +498,12 @@ void solve_system(const std::string& solver_name,
             if (b->get_size()[1] == 1) {
                 x_clone = clone(x);
                 auto res_logger = std::make_shared<ResidualLogger<etype>>(
-                    lend(system_matrix), b, solver_json["recurrent_residuals"],
+                    system_matrix, b, solver_json["recurrent_residuals"],
                     solver_json["true_residuals"],
                     solver_json["implicit_residuals"],
                     solver_json["iteration_timestamps"], allocator);
                 solver->add_logger(res_logger);
-                solver->apply(lend(b), lend(x_clone));
+                solver->apply(b, x_clone);
                 if (!res_logger->has_implicit_res_norms()) {
                     solver_json.RemoveMember("implicit_residuals");
                 }
@@ -532,10 +532,10 @@ void solve_system(const std::string& solver_name,
                 solver->add_logger(it_logger);
             }
             apply_timer->tic();
-            solver->apply(lend(b), lend(x_clone));
+            solver->apply(b, x_clone);
             apply_timer->toc();
             if (ic.get_num_repetitions() == 0) {
-                solver->remove_logger(gko::lend(it_logger));
+                solver->remove_logger(it_logger);
             }
         }
         it_logger->write_data(solver_json["apply"], allocator);
@@ -545,12 +545,12 @@ void solve_system(const std::string& solver_name,
             if (solver_json["apply"].HasMember("iterations") &&
                 solver_json["apply"]["iterations"].GetInt() == 0) {
                 auto error =
-                    compute_direct_error(lend(solver), lend(b), lend(x_clone));
+                    compute_direct_error(solver.get(), b, x_clone.get());
                 add_or_set_member(solver_json, "forward_error", error,
                                   allocator);
             }
-            auto residual = compute_residual_norm(lend(system_matrix), lend(b),
-                                                  lend(x_clone));
+            auto residual =
+                compute_residual_norm(system_matrix.get(), b, x_clone.get());
             add_or_set_member(solver_json, "residual_norm", residual,
                               allocator);
         }
@@ -653,7 +653,7 @@ void run_solver_benchmarks(std::shared_ptr<gko::Executor> exec,
                     }
                     solve_system(solver_name, precond_name,
                                  precond_solver_name->c_str(), exec, timer,
-                                 system_matrix, lend(b), lend(x), test_case,
+                                 system_matrix, b.get(), x.get(), test_case,
                                  allocator);
                     if (do_print) {
                         backup_results(test_cases);

--- a/benchmark/sparse_blas/operations.cpp
+++ b/benchmark/sparse_blas/operations.cpp
@@ -77,9 +77,8 @@ DEFINE_int32(spgemm_rowlength, 10,
 using Mtx = gko::matrix::Csr<etype, itype>;
 
 
-std::pair<bool, double> validate_result(
-    gko::pointer_param<const Mtx> correct_mtx,
-    gko::pointer_param<const Mtx> test_mtx)
+std::pair<bool, double> validate_result(gko::ptr_param<const Mtx> correct_mtx,
+                                        gko::ptr_param<const Mtx> test_mtx)
 {
     auto ref = gko::ReferenceExecutor::create();
     auto host_correct_mtx = gko::make_temporary_clone(ref, correct_mtx);

--- a/benchmark/sparse_blas/operations.cpp
+++ b/benchmark/sparse_blas/operations.cpp
@@ -176,8 +176,8 @@ public:
     gko::size_type get_flops() const override
     {
         auto host_exec = mtx_->get_executor()->get_master();
-        auto host_mtx = gko::make_temporary_clone(host_exec, lend(mtx_));
-        auto host_mtx2 = gko::make_temporary_clone(host_exec, lend(mtx2_));
+        auto host_mtx = gko::make_temporary_clone(host_exec, mtx_);
+        auto host_mtx2 = gko::make_temporary_clone(host_exec, mtx2_);
         // count the individual products a_ik * b_kj
         gko::size_type work{};
         for (gko::size_type row = 0; row < host_mtx->get_size()[0]; row++) {
@@ -209,7 +209,7 @@ public:
                         gko::dim<2>{mtx_->get_size()[0], mtx2_->get_size()[1]});
     }
 
-    void run() override { mtx_->apply(lend(mtx2_), lend(mtx_out_)); }
+    void run() override { mtx_->apply(mtx2_, mtx_out_); }
 
 private:
     const Mtx* mtx_;

--- a/benchmark/sparse_blas/sparse_blas.cpp
+++ b/benchmark/sparse_blas/sparse_blas.cpp
@@ -132,7 +132,7 @@ void apply_sparse_blas(const char* operation_name,
                 std::make_shared<OperationLogger>(FLAGS_nested_names);
             exec->add_logger(gen_logger);
             op->run();
-            exec->remove_logger(gko::lend(gen_logger));
+            exec->remove_logger(gen_logger);
             gen_logger->write_data(test_case[operation_name]["components"],
                                    allocator, 1);
         }

--- a/benchmark/utils/general.hpp
+++ b/benchmark/utils/general.hpp
@@ -408,8 +408,8 @@ gko::remove_complex<ValueType> compute_norm2(const VectorType* b)
     auto exec = b->get_executor();
     auto b_norm =
         gko::initialize<vec<gko::remove_complex<ValueType>>>({0.0}, exec);
-    b->compute_norm2(lend(b_norm));
-    return get_norm(lend(b_norm));
+    b->compute_norm2(b_norm);
+    return get_norm(b_norm.get());
 }
 
 
@@ -425,8 +425,8 @@ gko::remove_complex<ValueType> compute_direct_error(const gko::LinOp* solver,
     auto one = gko::initialize<vec<ValueType>>({1.0}, exec);
     auto neg_one = gko::initialize<vec<ValueType>>({-1.0}, exec);
     auto err = gko::clone(ref_exec, x);
-    ref_solver->apply(lend(one), lend(b), lend(neg_one), lend(err));
-    return compute_norm2(lend(err));
+    ref_solver->apply(one, b, neg_one, err);
+    return compute_norm2(err.get());
 }
 
 
@@ -439,8 +439,8 @@ gko::remove_complex<ValueType> compute_residual_norm(
     auto one = gko::initialize<vec<ValueType>>({1.0}, exec);
     auto neg_one = gko::initialize<vec<ValueType>>({-1.0}, exec);
     auto res = clone(b);
-    system_matrix->apply(lend(one), lend(x), lend(neg_one), lend(res));
-    return compute_norm2(lend(res));
+    system_matrix->apply(one, x, neg_one, res);
+    return compute_norm2(res.get());
 }
 
 
@@ -453,12 +453,12 @@ gko::remove_complex<ValueType> compute_max_relative_norm2(
     auto exec = answer->get_executor();
     auto answer_norm =
         vec<rc_vtype>::create(exec, gko::dim<2>{1, answer->get_size()[1]});
-    answer->compute_norm2(lend(answer_norm));
+    answer->compute_norm2(answer_norm);
     auto neg_one = gko::initialize<vec<ValueType>>({-1.0}, exec);
-    result->add_scaled(lend(neg_one), lend(answer));
+    result->add_scaled(neg_one, answer);
     auto absolute_norm =
         vec<rc_vtype>::create(exec, gko::dim<2>{1, answer->get_size()[1]});
-    result->compute_norm2(lend(absolute_norm));
+    result->compute_norm2(absolute_norm);
     auto host_answer_norm =
         clone(answer_norm->get_executor()->get_master(), answer_norm);
     auto host_absolute_norm =

--- a/benchmark/utils/general.hpp
+++ b/benchmark/utils/general.hpp
@@ -369,7 +369,7 @@ create_matrix_sin(std::shared_ptr<const gko::Executor> exec, gko::dim<2> size)
         }
     }
     auto res = vec<ValueType>::create(exec);
-    h_res->move_to(res.get());
+    h_res->move_to(res);
     return res;
 }
 
@@ -389,7 +389,7 @@ create_matrix_sin(std::shared_ptr<const gko::Executor> exec, gko::dim<2> size)
         }
     }
     auto res = vec<ValueType>::create(exec);
-    h_res->move_to(res.get());
+    h_res->move_to(res);
     return res;
 }
 

--- a/benchmark/utils/generator.hpp
+++ b/benchmark/utils/generator.hpp
@@ -90,7 +90,7 @@ struct DefaultSystemGenerator {
             gko::share(::formats::matrix_factory(format_name, exec, data));
 
         if (spmv_case && allocator) {
-            exec->remove_logger(gko::lend(storage_logger));
+            exec->remove_logger(storage_logger);
             storage_logger->write_data(*spmv_case, *allocator);
         }
 
@@ -207,7 +207,7 @@ struct DistributedDefaultSystemGenerator {
         dist_mat->read_distributed(data, part.get());
 
         if (spmv_case && allocator) {
-            exec->remove_logger(gko::lend(storage_logger));
+            exec->remove_logger(storage_logger);
             storage_logger->write_data(comm, *spmv_case, *allocator);
         }
 

--- a/benchmark/utils/generator.hpp
+++ b/benchmark/utils/generator.hpp
@@ -203,8 +203,8 @@ struct DistributedDefaultSystemGenerator {
         }
 
         auto dist_mat = dist_mtx<etype, itype, global_itype>::create(
-            exec, comm, local_mat.get(), non_local_mat.get());
-        dist_mat->read_distributed(data, part.get());
+            exec, comm, local_mat, non_local_mat);
+        dist_mat->read_distributed(data, part);
 
         if (spmv_case && allocator) {
             exec->remove_logger(storage_logger);
@@ -230,14 +230,12 @@ struct DistributedDefaultSystemGenerator {
                 exec, comm.size(), static_cast<global_itype>(size[0]));
         return Vec::create(
             exec, comm, size,
-            local_generator
-                .create_multi_vector(
-                    exec,
-                    gko::dim<2>{static_cast<gko::size_type>(
-                                    part->get_part_size(comm.rank())),
-                                size[1]},
-                    value)
-                .get());
+            local_generator.create_multi_vector(
+                exec,
+                gko::dim<2>{static_cast<gko::size_type>(
+                                part->get_part_size(comm.rank())),
+                            size[1]},
+                value));
     }
 
     std::unique_ptr<Vec> create_multi_vector_strided(
@@ -249,14 +247,12 @@ struct DistributedDefaultSystemGenerator {
                 exec, comm.size(), static_cast<global_itype>(size[0]));
         return Vec::create(
             exec, comm, size,
-            local_generator
-                .create_multi_vector_strided(
-                    exec,
-                    gko::dim<2>{static_cast<gko::size_type>(
-                                    part->get_part_size(comm.rank())),
-                                size[1]},
-                    stride)
-                .get());
+            local_generator.create_multi_vector_strided(
+                exec,
+                gko::dim<2>{static_cast<gko::size_type>(
+                                part->get_part_size(comm.rank())),
+                            size[1]},
+                stride));
     }
 
     // creates a random multi_vector
@@ -268,12 +264,10 @@ struct DistributedDefaultSystemGenerator {
                 exec, comm.size(), static_cast<global_itype>(size[0]));
         return Vec::create(
             exec, comm, size,
-            local_generator
-                .create_multi_vector_random(
-                    exec, gko::dim<2>{static_cast<gko::size_type>(
-                                          part->get_part_size(comm.rank())),
-                                      size[1]})
-                .get());
+            local_generator.create_multi_vector_random(
+                exec, gko::dim<2>{static_cast<gko::size_type>(
+                                      part->get_part_size(comm.rank())),
+                                  size[1]}));
     }
 
     std::unique_ptr<Vec> initialize(
@@ -285,9 +279,8 @@ struct DistributedDefaultSystemGenerator {
         auto global_rows = local->get_size()[0];
         comm.all_reduce(gko::ReferenceExecutor::create(), &global_rows, 1,
                         MPI_SUM);
-        return Vec::create(exec, comm,
-                           gko::dim<2>{global_rows, local->get_size()[1]},
-                           local.get());
+        return Vec::create(
+            exec, comm, gko::dim<2>{global_rows, local->get_size()[1]}, local);
     }
 
     gko::experimental::mpi::communicator comm;

--- a/benchmark/utils/loggers.hpp
+++ b/benchmark/utils/loggers.hpp
@@ -270,15 +270,16 @@ struct ResidualLogger : gko::log::Logger {
         }
     }
 
-    ResidualLogger(const gko::LinOp* matrix, const gko::LinOp* b,
+    ResidualLogger(gko::pointer_param<const gko::LinOp> matrix,
+                   gko::pointer_param<const gko::LinOp> b,
                    rapidjson::Value& rec_res_norms,
                    rapidjson::Value& true_res_norms,
                    rapidjson::Value& implicit_res_norms,
                    rapidjson::Value& timestamps,
                    rapidjson::MemoryPoolAllocator<>& alloc)
         : gko::log::Logger(gko::log::Logger::iteration_complete_mask),
-          matrix{matrix},
-          b{b},
+          matrix{matrix.get()},
+          b{b.get()},
           start{std::chrono::steady_clock::now()},
           rec_res_norms{rec_res_norms},
           true_res_norms{true_res_norms},

--- a/benchmark/utils/loggers.hpp
+++ b/benchmark/utils/loggers.hpp
@@ -270,8 +270,8 @@ struct ResidualLogger : gko::log::Logger {
         }
     }
 
-    ResidualLogger(gko::pointer_param<const gko::LinOp> matrix,
-                   gko::pointer_param<const gko::LinOp> b,
+    ResidualLogger(gko::ptr_param<const gko::LinOp> matrix,
+                   gko::ptr_param<const gko::LinOp> b,
                    rapidjson::Value& rec_res_norms,
                    rapidjson::Value& true_res_norms,
                    rapidjson::Value& implicit_res_norms,

--- a/benchmark/utils/overhead_linop.hpp
+++ b/benchmark/utils/overhead_linop.hpp
@@ -153,9 +153,9 @@ protected:
         auto dense_x = as<matrix::Dense<ValueType>>(x);
 
         auto x_clone = dense_x->clone();
-        this->apply(b, x_clone.get());
+        this->apply(b, x_clone);
         dense_x->scale(beta);
-        dense_x->add_scaled(alpha, x_clone.get());
+        dense_x->add_scaled(alpha, x_clone);
     }
 
     explicit Overhead(std::shared_ptr<const Executor> exec)

--- a/core/base/combination.cpp
+++ b/core/base/combination.cpp
@@ -167,11 +167,11 @@ void Combination<ValueType>::apply_impl(const LinOp* b, LinOp* x) const
                                   cache_.one);
     precision_dispatch_real_complex<ValueType>(
         [this](auto dense_b, auto dense_x) {
-            operators_[0]->apply(lend(coefficients_[0]), dense_b,
-                                 lend(cache_.zero), dense_x);
+            operators_[0]->apply(coefficients_[0], dense_b, cache_.zero,
+                                 dense_x);
             for (size_type i = 1; i < operators_.size(); ++i) {
-                operators_[i]->apply(lend(coefficients_[i]), dense_b,
-                                     lend(cache_.one), dense_x);
+                operators_[i]->apply(coefficients_[i], dense_b, cache_.one,
+                                     dense_x);
             }
         },
         b, x);
@@ -188,9 +188,9 @@ void Combination<ValueType>::apply_impl(const LinOp* alpha, const LinOp* b,
                 cache_.intermediate_x->get_size() != dense_x->get_size()) {
                 cache_.intermediate_x = dense_x->clone();
             }
-            this->apply_impl(dense_b, lend(cache_.intermediate_x));
+            this->apply_impl(dense_b, cache_.intermediate_x.get());
             dense_x->scale(dense_beta);
-            dense_x->add_scaled(dense_alpha, lend(cache_.intermediate_x));
+            dense_x->add_scaled(dense_alpha, cache_.intermediate_x);
         },
         alpha, b, beta, x);
 }

--- a/core/base/composition.cpp
+++ b/core/base/composition.cpp
@@ -96,7 +96,7 @@ std::unique_ptr<LinOp> apply_inner_operators(
                                                    zero<ValueType>()));
         }
     }
-    operators.back()->apply(rhs, lend(out));
+    operators.back()->apply(rhs, out);
     // apply following operators
     // alternate intermediate vectors between beginning/end of storage
     auto reversed_storage = true;
@@ -124,7 +124,7 @@ std::unique_ptr<LinOp> apply_inner_operators(
             }
         }
         // apply operator
-        operators[i]->apply(lend(in), lend(out));
+        operators[i]->apply(in, out);
     }
 
     return std::move(out);
@@ -223,7 +223,7 @@ void Composition<ValueType>::apply_impl(const LinOp* b, LinOp* x) const
         [this](auto dense_b, auto dense_x) {
             if (operators_.size() > 1) {
                 operators_[0]->apply(
-                    lend(apply_inner_operators(operators_, storage_, dense_b)),
+                    apply_inner_operators(operators_, storage_, dense_b),
                     dense_x);
             } else {
                 operators_[0]->apply(dense_b, dense_x);
@@ -242,7 +242,7 @@ void Composition<ValueType>::apply_impl(const LinOp* alpha, const LinOp* b,
             if (operators_.size() > 1) {
                 operators_[0]->apply(
                     dense_alpha,
-                    lend(apply_inner_operators(operators_, storage_, dense_b)),
+                    apply_inner_operators(operators_, storage_, dense_b),
                     dense_beta, dense_x);
             } else {
                 operators_[0]->apply(dense_alpha, dense_b, dense_beta, dense_x);

--- a/core/base/perturbation.cpp
+++ b/core/base/perturbation.cpp
@@ -108,10 +108,9 @@ void Perturbation<ValueType>::apply_impl(const LinOp* b, LinOp* x) const
             auto intermediate_size =
                 gko::dim<2>(projector_->get_size()[0], dense_b->get_size()[1]);
             cache_.allocate(exec, intermediate_size);
-            projector_->apply(dense_b, lend(cache_.intermediate));
+            projector_->apply(dense_b, cache_.intermediate);
             dense_x->copy_from(dense_b);
-            basis_->apply(lend(scalar_), lend(cache_.intermediate),
-                          lend(cache_.one), dense_x);
+            basis_->apply(scalar_, cache_.intermediate, cache_.one, dense_x);
         },
         b, x);
 }
@@ -134,12 +133,12 @@ void Perturbation<ValueType>::apply_impl(const LinOp* alpha, const LinOp* b,
             auto intermediate_size =
                 gko::dim<2>(projector_->get_size()[0], dense_b->get_size()[1]);
             cache_.allocate(exec, intermediate_size);
-            projector_->apply(dense_b, lend(cache_.intermediate));
+            projector_->apply(dense_b, cache_.intermediate);
             dense_x->scale(dense_beta);
             dense_x->add_scaled(dense_alpha, dense_b);
-            dense_alpha->apply(lend(scalar_), lend(cache_.alpha_scalar));
-            basis_->apply(lend(cache_.alpha_scalar), lend(cache_.intermediate),
-                          lend(cache_.one), dense_x);
+            dense_alpha->apply(scalar_, cache_.alpha_scalar);
+            basis_->apply(cache_.alpha_scalar, cache_.intermediate, cache_.one,
+                          dense_x);
         },
         alpha, b, beta, x);
 }

--- a/core/base/utils.hpp
+++ b/core/base/utils.hpp
@@ -76,7 +76,7 @@ struct conversion_sort_helper<matrix::Csr<ValueType, IndexType>> {
         std::shared_ptr<const Executor>& exec, Source* source)
     {
         auto editable_mtx = mtx_type::create(exec);
-        as<ConvertibleTo<mtx_type>>(source)->convert_to(lend(editable_mtx));
+        as<ConvertibleTo<mtx_type>>(source)->convert_to(editable_mtx);
         editable_mtx->sort_by_column_index();
         return editable_mtx;
     }

--- a/core/distributed/matrix.cpp
+++ b/core/distributed/matrix.cpp
@@ -107,8 +107,8 @@ void Matrix<ValueType, LocalIndexType, GlobalIndexType>::convert_to(
 {
     GKO_ASSERT(this->get_communicator().size() ==
                result->get_communicator().size());
-    result->local_mtx_->copy_from(this->local_mtx_.get());
-    result->non_local_mtx_->copy_from(this->non_local_mtx_.get());
+    result->local_mtx_->copy_from(this->local_mtx_);
+    result->non_local_mtx_->copy_from(this->non_local_mtx_);
     result->gather_idxs_ = this->gather_idxs_;
     result->send_offsets_ = this->send_offsets_;
     result->recv_offsets_ = this->recv_offsets_;
@@ -126,8 +126,8 @@ void Matrix<ValueType, LocalIndexType, GlobalIndexType>::move_to(
 {
     GKO_ASSERT(this->get_communicator().size() ==
                result->get_communicator().size());
-    result->local_mtx_->move_from(this->local_mtx_.get());
-    result->non_local_mtx_->move_from(this->non_local_mtx_.get());
+    result->local_mtx_->move_from(this->local_mtx_);
+    result->non_local_mtx_->move_from(this->non_local_mtx_);
     result->gather_idxs_ = std::move(this->gather_idxs_);
     result->send_offsets_ = std::move(this->send_offsets_);
     result->recv_offsets_ = std::move(this->recv_offsets_);
@@ -199,9 +199,8 @@ void Matrix<ValueType, LocalIndexType, GlobalIndexType>::read_distributed(
         ->read(std::move(non_local_data));
 
     // exchange step 1: determine recv_sizes, send_sizes, send_offsets
-    exec->get_master()->copy_from(exec.get(), num_parts,
-                                  recv_sizes_array.get_const_data(),
-                                  recv_sizes_.data());
+    exec->get_master()->copy_from(
+        exec, num_parts, recv_sizes_array.get_const_data(), recv_sizes_.data());
     std::partial_sum(recv_sizes_.begin(), recv_sizes_.end(),
                      recv_offsets_.begin() + 1);
     comm.all_to_all(exec, recv_sizes_.data(), 1, send_sizes_.data(), 1);
@@ -325,7 +324,7 @@ void Matrix<ValueType, LocalIndexType, GlobalIndexType>::apply_impl(
 
             auto comm = this->get_communicator();
             auto req = this->communicate(dense_b->get_local_vector());
-            local_mtx_->apply(dense_b->get_local_vector(), local_x.get());
+            local_mtx_->apply(dense_b->get_local_vector(), local_x);
             req.wait();
 
             auto exec = this->get_executor();
@@ -334,7 +333,7 @@ void Matrix<ValueType, LocalIndexType, GlobalIndexType>::apply_impl(
                 recv_buffer_->copy_from(host_recv_buffer_.get());
             }
             non_local_mtx_->apply(one_scalar_.get(), recv_buffer_.get(),
-                                  one_scalar_.get(), local_x.get());
+                                  one_scalar_.get(), local_x);
         },
         b, x);
 }
@@ -359,7 +358,7 @@ void Matrix<ValueType, LocalIndexType, GlobalIndexType>::apply_impl(
             auto comm = this->get_communicator();
             auto req = this->communicate(dense_b->get_local_vector());
             local_mtx_->apply(local_alpha, dense_b->get_local_vector(),
-                              local_beta, local_x.get());
+                              local_beta, local_x);
             req.wait();
 
             auto exec = this->get_executor();
@@ -368,7 +367,7 @@ void Matrix<ValueType, LocalIndexType, GlobalIndexType>::apply_impl(
                 recv_buffer_->copy_from(host_recv_buffer_.get());
             }
             non_local_mtx_->apply(local_alpha, recv_buffer_.get(),
-                                  one_scalar_.get(), local_x.get());
+                                  one_scalar_.get(), local_x);
         },
         alpha, b, beta, x);
 }
@@ -404,8 +403,8 @@ Matrix<ValueType, LocalIndexType, GlobalIndexType>::operator=(
         GKO_ASSERT_EQ(other.get_communicator().size(),
                       this->get_communicator().size());
         this->set_size(other.get_size());
-        local_mtx_->copy_from(other.local_mtx_.get());
-        non_local_mtx_->copy_from(other.non_local_mtx_.get());
+        local_mtx_->copy_from(other.local_mtx_);
+        non_local_mtx_->copy_from(other.non_local_mtx_);
         gather_idxs_ = other.gather_idxs_;
         send_offsets_ = other.send_offsets_;
         recv_offsets_ = other.recv_offsets_;
@@ -428,8 +427,8 @@ Matrix<ValueType, LocalIndexType, GlobalIndexType>::operator=(Matrix&& other)
                       this->get_communicator().size());
         this->set_size(other.get_size());
         other.set_size({});
-        local_mtx_->move_from(other.local_mtx_.get());
-        non_local_mtx_->move_from(other.non_local_mtx_.get());
+        local_mtx_->move_from(other.local_mtx_);
+        non_local_mtx_->move_from(other.non_local_mtx_);
         gather_idxs_ = std::move(other.gather_idxs_);
         send_offsets_ = std::move(other.send_offsets_);
         recv_offsets_ = std::move(other.recv_offsets_);

--- a/core/distributed/vector.cpp
+++ b/core/distributed/vector.cpp
@@ -304,7 +304,7 @@ Vector<ValueType>::make_complex() const
         this->get_executor(), this->get_communicator(), this->get_size(),
         this->get_local_vector()->get_size(),
         this->get_local_vector()->get_stride());
-    this->make_complex(result.get());
+    this->make_complex(result);
     return result;
 }
 
@@ -325,7 +325,7 @@ Vector<ValueType>::get_real() const
                                     this->get_communicator(), this->get_size(),
                                     this->get_local_vector()->get_size(),
                                     this->get_local_vector()->get_stride());
-    this->get_real(result.get());
+    this->get_real(result);
     return result;
 }
 
@@ -345,7 +345,7 @@ Vector<ValueType>::get_imag() const
                                     this->get_communicator(), this->get_size(),
                                     this->get_local_vector()->get_size(),
                                     this->get_local_vector()->get_stride());
-    this->get_imag(result.get());
+    this->get_imag(result);
     return result;
 }
 
@@ -602,7 +602,7 @@ Vector<ValueType>::create_real_view()
 
     return real_type::create(this->get_executor(), this->get_communicator(),
                              dim<2>{num_global_rows, num_cols},
-                             local_.create_real_view().get());
+                             local_.create_real_view());
 }
 
 

--- a/core/factorization/ic.cpp
+++ b/core/factorization/ic.cpp
@@ -76,7 +76,7 @@ std::unique_ptr<Composition<ValueType>> Ic<ValueType, IndexType>::generate(
     // Throws an exception if it is not convertible.
     auto local_system_matrix = matrix_type::create(exec);
     as<ConvertibleTo<matrix_type>>(system_matrix.get())
-        ->convert_to(local_system_matrix.get());
+        ->convert_to(local_system_matrix);
 
     if (!skip_sorting) {
         local_system_matrix->sort_by_column_index();

--- a/core/factorization/ilu.cpp
+++ b/core/factorization/ilu.cpp
@@ -75,7 +75,7 @@ std::unique_ptr<Composition<ValueType>> Ilu<ValueType, IndexType>::generate_l_u(
     // Throws an exception if it is not convertible.
     auto local_system_matrix = matrix_type::create(exec);
     as<ConvertibleTo<matrix_type>>(system_matrix.get())
-        ->convert_to(local_system_matrix.get());
+        ->convert_to(local_system_matrix);
 
     if (!skip_sorting) {
         local_system_matrix->sort_by_column_index();

--- a/core/factorization/lu.cpp
+++ b/core/factorization/lu.cpp
@@ -96,9 +96,9 @@ std::unique_ptr<LinOp> Lu<ValueType, IndexType>::generate_impl(
     std::unique_ptr<matrix_type> factors;
     if (!parameters_.symbolic_factorization) {
         if (parameters_.symmetric_sparsity) {
-            exec->run(make_symbolic_cholesky(mtx, factors));
+            exec->run(make_symbolic_cholesky(mtx.get(), factors));
         } else {
-            exec->run(make_symbolic_lu(mtx, factors));
+            exec->run(make_symbolic_lu(mtx.get(), factors));
         }
     } else {
         const auto& symbolic = parameters_.symbolic_factorization;

--- a/core/factorization/lu.cpp
+++ b/core/factorization/lu.cpp
@@ -96,19 +96,19 @@ std::unique_ptr<LinOp> Lu<ValueType, IndexType>::generate_impl(
     std::unique_ptr<matrix_type> factors;
     if (!parameters_.symbolic_factorization) {
         if (parameters_.symmetric_sparsity) {
-            exec->run(make_symbolic_cholesky(mtx.get(), factors));
+            exec->run(make_symbolic_cholesky(mtx, factors));
         } else {
-            exec->run(make_symbolic_lu(mtx.get(), factors));
+            exec->run(make_symbolic_lu(mtx, factors));
         }
     } else {
         const auto& symbolic = parameters_.symbolic_factorization;
         const auto factor_nnz = symbolic->get_num_nonzeros();
         factors = matrix_type::create(exec, mtx->get_size(), factor_nnz);
         const auto symbolic_exec = symbolic->get_executor();
-        exec->copy_from(symbolic_exec.get(), factor_nnz,
+        exec->copy_from(symbolic_exec, factor_nnz,
                         symbolic->get_const_col_idxs(),
                         factors->get_col_idxs());
-        exec->copy_from(symbolic_exec.get(), num_rows + 1,
+        exec->copy_from(symbolic_exec, num_rows + 1,
                         symbolic->get_const_row_ptrs(),
                         factors->get_row_ptrs());
         // update srow to be safe

--- a/core/factorization/par_ic.cpp
+++ b/core/factorization/par_ic.cpp
@@ -88,7 +88,7 @@ std::unique_ptr<Composition<ValueType>> ParIc<ValueType, IndexType>::generate(
     // Throws an exception if it is not convertible.
     auto csr_system_matrix = CsrMatrix::create(exec);
     as<ConvertibleTo<CsrMatrix>>(system_matrix.get())
-        ->convert_to(csr_system_matrix.get());
+        ->convert_to(csr_system_matrix);
     // If necessary, sort it
     if (!skip_sorting) {
         csr_system_matrix->sort_by_column_index();

--- a/core/factorization/par_ict.cpp
+++ b/core/factorization/par_ict.cpp
@@ -238,7 +238,7 @@ void ParIctState<ValueType, IndexType>::iterate()
     // update L(COO), L'^H sizes and pointers
     {
         auto l_nnz = l_new->get_num_stored_elements();
-        CooBuilder l_builder{l_coo.get()};
+        CooBuilder l_builder{l_coo};
         // resize arrays that will be filled
         l_builder.get_row_idx_array().resize_and_reset(l_nnz);
         // update arrays that will be aliased
@@ -284,7 +284,7 @@ void ParIctState<ValueType, IndexType>::iterate()
     // convert L to L^H
     {
         auto l_nnz = l->get_num_stored_elements();
-        CsrBuilder lt_builder{lh.get()};
+        CsrBuilder lt_builder{lh};
         lt_builder.get_col_idx_array().resize_and_reset(l_nnz);
         lt_builder.get_value_array().resize_and_reset(l_nnz);
     }

--- a/core/factorization/par_ilu.cpp
+++ b/core/factorization/par_ilu.cpp
@@ -87,7 +87,7 @@ ParIlu<ValueType, IndexType>::generate_l_u(
     // Throws an exception if it is not convertible.
     auto csr_system_matrix = CsrMatrix::create(exec);
     as<ConvertibleTo<CsrMatrix>>(system_matrix.get())
-        ->convert_to(csr_system_matrix.get());
+        ->convert_to(csr_system_matrix);
     // If necessary, sort it
     if (!skip_sorting) {
         csr_system_matrix->sort_by_column_index();
@@ -144,7 +144,7 @@ ParIlu<ValueType, IndexType>::generate_l_u(
     // We also have to move from the CSR matrix if it was not already sorted.
     if (!skip_sorting || coo_system_matrix_ptr == nullptr) {
         coo_system_matrix_unique_ptr = CooMatrix::create(exec);
-        csr_system_matrix->move_to(coo_system_matrix_unique_ptr.get());
+        csr_system_matrix->move_to(coo_system_matrix_unique_ptr);
         coo_system_matrix_ptr = coo_system_matrix_unique_ptr.get();
     }
 

--- a/core/factorization/par_ilut.cpp
+++ b/core/factorization/par_ilut.cpp
@@ -267,9 +267,9 @@ void ParIlutState<ValueType, IndexType>::iterate()
     {
         auto l_nnz = l_new->get_num_stored_elements();
         auto u_nnz = u_new->get_num_stored_elements();
-        CooBuilder l_builder{l_coo.get()};
-        CooBuilder u_builder{u_coo.get()};
-        CsrBuilder u_csc_builder{u_new_csc.get()};
+        CooBuilder l_builder{l_coo};
+        CooBuilder u_builder{u_coo};
+        CsrBuilder u_csc_builder{u_new_csc};
         // resize arrays that will be filled
         l_builder.get_row_idx_array().resize_and_reset(l_nnz);
         u_builder.get_row_idx_array().resize_and_reset(u_nnz);

--- a/core/factorization/symbolic.cpp
+++ b/core/factorization/symbolic.cpp
@@ -67,38 +67,41 @@ GKO_REGISTER_HOST_OPERATION(compute_elim_forest, compute_elim_forest);
 /** Computes the symbolic Cholesky factorization of the given matrix. */
 template <typename ValueType, typename IndexType>
 void symbolic_cholesky(
-    const matrix::Csr<ValueType, IndexType>* mtx,
+    xstd::dont_deduce_t<pointer_param<const matrix::Csr<ValueType, IndexType>>>
+        mtx,
     std::unique_ptr<matrix::Csr<ValueType, IndexType>>& factors)
 {
     using matrix_type = matrix::Csr<ValueType, IndexType>;
     const auto exec = mtx->get_executor();
     const auto host_exec = exec->get_master();
     std::unique_ptr<elimination_forest<IndexType>> forest;
-    exec->run(make_compute_elim_forest(mtx, forest));
+    exec->run(make_compute_elim_forest(mtx.get(), forest));
     const auto num_rows = mtx->get_size()[0];
     array<IndexType> row_ptrs{exec, num_rows + 1};
     array<IndexType> tmp{exec};
-    exec->run(
-        make_cholesky_symbolic_count(mtx, *forest, row_ptrs.get_data(), tmp));
+    exec->run(make_cholesky_symbolic_count(mtx.get(), *forest,
+                                           row_ptrs.get_data(), tmp));
     exec->run(make_prefix_sum(row_ptrs.get_data(), num_rows + 1));
     const auto factor_nnz = static_cast<size_type>(
         exec->copy_val_to_host(row_ptrs.get_const_data() + num_rows));
     factors = matrix_type::create(
         exec, mtx->get_size(), array<ValueType>{exec, factor_nnz},
         array<IndexType>{exec, factor_nnz}, std::move(row_ptrs));
-    exec->run(make_cholesky_symbolic(mtx, *forest, factors.get(), tmp));
+    exec->run(make_cholesky_symbolic(mtx.get(), *forest, factors.get(), tmp));
     factors->sort_by_column_index();
     auto lt_factor = as<matrix_type>(factors->transpose());
     const auto scalar =
         initialize<matrix::Dense<ValueType>>({one<ValueType>()}, exec);
     const auto id = matrix::Identity<ValueType>::create(exec, num_rows);
-    lt_factor->apply(scalar.get(), id.get(), scalar.get(), factors.get());
+    lt_factor->apply(scalar, id, scalar, factors);
 }
 
 
-#define GKO_DECLARE_SYMBOLIC_CHOLESKY(ValueType, IndexType) \
-    void symbolic_cholesky(                                 \
-        const matrix::Csr<ValueType, IndexType>* mtx,       \
+#define GKO_DECLARE_SYMBOLIC_CHOLESKY(ValueType, IndexType)         \
+    void symbolic_cholesky(                                         \
+        xstd::dont_deduce_t<                                        \
+            pointer_param<const matrix::Csr<ValueType, IndexType>>> \
+            mtx,                                                    \
         std::unique_ptr<matrix::Csr<ValueType, IndexType>>& factors)
 
 GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(GKO_DECLARE_SYMBOLIC_CHOLESKY);
@@ -112,8 +115,10 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(GKO_DECLARE_SYMBOLIC_CHOLESKY);
  * "GSoFa: Scalable Sparse Symbolic LU Factorization on GPUs," arXiv 2021
  */
 template <typename ValueType, typename IndexType>
-void symbolic_lu(const matrix::Csr<ValueType, IndexType>* mtx,
-                 std::unique_ptr<matrix::Csr<ValueType, IndexType>>& factors)
+void symbolic_lu(
+    xstd::dont_deduce_t<pointer_param<const matrix::Csr<ValueType, IndexType>>>
+        mtx,
+    std::unique_ptr<matrix::Csr<ValueType, IndexType>>& factors)
 {
     using matrix_type = matrix::Csr<ValueType, IndexType>;
     const auto exec = mtx->get_executor();
@@ -181,7 +186,7 @@ void symbolic_lu(const matrix::Csr<ValueType, IndexType>* mtx,
     array<IndexType> out_row_ptr_array{exec, std::move(host_out_row_ptr_array)};
     array<IndexType> out_col_idx_array{exec, out_nnz};
     array<ValueType> out_val_array{exec, out_nnz};
-    exec->copy_from(host_exec.get(), out_nnz, out_col_idxs.data(),
+    exec->copy_from(host_exec, out_nnz, out_col_idxs.data(),
                     out_col_idx_array.get_data());
     factors = matrix_type::create(
         exec, mtx->get_size(), std::move(out_val_array),
@@ -189,9 +194,11 @@ void symbolic_lu(const matrix::Csr<ValueType, IndexType>* mtx,
 }
 
 
-#define GKO_DECLARE_SYMBOLIC_LU(ValueType, IndexType) \
-    void symbolic_lu(                                 \
-        const matrix::Csr<ValueType, IndexType>* mtx, \
+#define GKO_DECLARE_SYMBOLIC_LU(ValueType, IndexType)               \
+    void symbolic_lu(                                               \
+        xstd::dont_deduce_t<                                        \
+            pointer_param<const matrix::Csr<ValueType, IndexType>>> \
+            mtx,                                                    \
         std::unique_ptr<matrix::Csr<ValueType, IndexType>>& factors)
 
 GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(GKO_DECLARE_SYMBOLIC_LU);

--- a/core/factorization/symbolic.hpp
+++ b/core/factorization/symbolic.hpp
@@ -45,8 +45,7 @@ namespace factorization {
  */
 template <typename ValueType, typename IndexType>
 void symbolic_cholesky(
-    xstd::dont_deduce_t<pointer_param<const matrix::Csr<ValueType, IndexType>>>
-        mtx,
+    const matrix::Csr<ValueType, IndexType>* mtx,
     std::unique_ptr<matrix::Csr<ValueType, IndexType>>& factors);
 
 /**
@@ -56,10 +55,8 @@ void symbolic_cholesky(
  * @param factors  the output factors stored in a combined pattern
  */
 template <typename ValueType, typename IndexType>
-void symbolic_lu(
-    xstd::dont_deduce_t<pointer_param<const matrix::Csr<ValueType, IndexType>>>
-        mtx,
-    std::unique_ptr<matrix::Csr<ValueType, IndexType>>& factors);
+void symbolic_lu(const matrix::Csr<ValueType, IndexType>* mtx,
+                 std::unique_ptr<matrix::Csr<ValueType, IndexType>>& factors);
 
 
 }  // namespace factorization

--- a/core/factorization/symbolic.hpp
+++ b/core/factorization/symbolic.hpp
@@ -45,7 +45,8 @@ namespace factorization {
  */
 template <typename ValueType, typename IndexType>
 void symbolic_cholesky(
-    const matrix::Csr<ValueType, IndexType>* mtx,
+    xstd::dont_deduce_t<pointer_param<const matrix::Csr<ValueType, IndexType>>>
+        mtx,
     std::unique_ptr<matrix::Csr<ValueType, IndexType>>& factors);
 
 /**
@@ -55,8 +56,10 @@ void symbolic_cholesky(
  * @param factors  the output factors stored in a combined pattern
  */
 template <typename ValueType, typename IndexType>
-void symbolic_lu(const matrix::Csr<ValueType, IndexType>* mtx,
-                 std::unique_ptr<matrix::Csr<ValueType, IndexType>>& factors);
+void symbolic_lu(
+    xstd::dont_deduce_t<pointer_param<const matrix::Csr<ValueType, IndexType>>>
+        mtx,
+    std::unique_ptr<matrix::Csr<ValueType, IndexType>>& factors);
 
 
 }  // namespace factorization

--- a/core/log/convergence.cpp
+++ b/core/log/convergence.cpp
@@ -84,7 +84,7 @@ void Convergence<ValueType>::on_criterion_check_completed(
                     this->residual_norm_ =
                         NormVector::create(residual->get_executor(),
                                            dim<2>{1, residual->get_size()[1]});
-                    dense_r->compute_norm2(this->residual_norm_.get());
+                    dense_r->compute_norm2(this->residual_norm_);
                 });
         }
     }

--- a/core/log/papi.cpp
+++ b/core/log/papi.cpp
@@ -249,7 +249,7 @@ void Papi<ValueType>::on_criterion_check_completed(
         detail::vector_dispatch<ValueType>(residual, [&](const auto* dense_r) {
             auto tmp_res_norm = Vector::create(
                 residual->get_executor(), dim<2>{1, residual->get_size()[1]});
-            dense_r->compute_norm2(tmp_res_norm.get());
+            dense_r->compute_norm2(tmp_res_norm);
             residual_norm_d =
                 static_cast<double>(std::real(tmp_res_norm->at(0, 0)));
         });

--- a/core/matrix/coo.cpp
+++ b/core/matrix/coo.cpp
@@ -257,7 +257,7 @@ Coo<ValueType, IndexType>::extract_diagonal() const
     auto diag = Diagonal<ValueType>::create(exec, diag_size);
     exec->run(coo::make_fill_array(diag->get_values(), diag->get_size()[0],
                                    zero<ValueType>()));
-    exec->run(coo::make_extract_diagonal(this, lend(diag)));
+    exec->run(coo::make_extract_diagonal(this, diag.get()));
     return diag;
 }
 

--- a/core/matrix/coo_builder.hpp
+++ b/core/matrix/coo_builder.hpp
@@ -70,7 +70,9 @@ public:
     /**
      * Initializes a CooBuilder from an existing COO matrix.
      */
-    explicit CooBuilder(Coo<ValueType, IndexType>* matrix) : matrix_{matrix} {}
+    explicit CooBuilder(pointer_param<Coo<ValueType, IndexType>> matrix)
+        : matrix_{matrix.get()}
+    {}
 
     // make this type non-movable
     CooBuilder(const CooBuilder&) = delete;

--- a/core/matrix/coo_builder.hpp
+++ b/core/matrix/coo_builder.hpp
@@ -70,7 +70,7 @@ public:
     /**
      * Initializes a CooBuilder from an existing COO matrix.
      */
-    explicit CooBuilder(pointer_param<Coo<ValueType, IndexType>> matrix)
+    explicit CooBuilder(ptr_param<Coo<ValueType, IndexType>> matrix)
         : matrix_{matrix.get()}
     {}
 

--- a/core/matrix/csr.cpp
+++ b/core/matrix/csr.cpp
@@ -220,7 +220,7 @@ void Csr<ValueType, IndexType>::apply_impl(const LinOp* alpha, const LinOp* b,
         auto x_copy = x_csr->clone();
         this->get_executor()->run(
             csr::make_spgeam(as<Dense<ValueType>>(alpha), this,
-                             as<Dense<ValueType>>(beta), lend(x_copy), x_csr));
+                             as<Dense<ValueType>>(beta), x_copy.get(), x_csr));
     } else {
         precision_dispatch_real_complex<ValueType>(
             [this](auto dense_alpha, auto dense_b, auto dense_beta,
@@ -734,7 +734,7 @@ Csr<ValueType, IndexType>::extract_diagonal() const
     auto diag = Diagonal<ValueType>::create(exec, diag_size);
     exec->run(csr::make_fill_array(diag->get_values(), diag->get_size()[0],
                                    zero<ValueType>()));
-    exec->run(csr::make_extract_diagonal(this, lend(diag)));
+    exec->run(csr::make_extract_diagonal(this, diag.get()));
     return diag;
 }
 

--- a/core/matrix/csr_builder.hpp
+++ b/core/matrix/csr_builder.hpp
@@ -65,7 +65,9 @@ public:
     /**
      * Initializes a CsrBuilder from an existing CSR matrix.
      */
-    explicit CsrBuilder(Csr<ValueType, IndexType>* matrix) : matrix_{matrix} {}
+    explicit CsrBuilder(pointer_param<Csr<ValueType, IndexType>> matrix)
+        : matrix_{matrix.get()}
+    {}
 
     /**
      * Updates the internal matrix data structures at destruction.

--- a/core/matrix/csr_builder.hpp
+++ b/core/matrix/csr_builder.hpp
@@ -65,7 +65,7 @@ public:
     /**
      * Initializes a CsrBuilder from an existing CSR matrix.
      */
-    explicit CsrBuilder(pointer_param<Csr<ValueType, IndexType>> matrix)
+    explicit CsrBuilder(ptr_param<Csr<ValueType, IndexType>> matrix)
         : matrix_{matrix.get()}
     {}
 

--- a/core/matrix/dense.cpp
+++ b/core/matrix/dense.cpp
@@ -1002,7 +1002,7 @@ std::unique_ptr<LinOp> Dense<ValueType>::transpose() const
 {
     auto result =
         Dense::create(this->get_executor(), gko::transpose(this->get_size()));
-    this->transpose(result.get());
+    this->transpose(result);
     return result;
 }
 
@@ -1012,7 +1012,7 @@ std::unique_ptr<LinOp> Dense<ValueType>::conj_transpose() const
 {
     auto result =
         Dense::create(this->get_executor(), gko::transpose(this->get_size()));
-    this->conj_transpose(result.get());
+    this->conj_transpose(result);
     return result;
 }
 
@@ -1167,7 +1167,7 @@ std::unique_ptr<LinOp> Dense<ValueType>::permute(
     const array<int32>* permutation_indices) const
 {
     auto result = Dense::create(this->get_executor(), this->get_size());
-    this->permute(permutation_indices, result.get());
+    this->permute(permutation_indices, result);
     return result;
 }
 
@@ -1177,7 +1177,7 @@ std::unique_ptr<LinOp> Dense<ValueType>::permute(
     const array<int64>* permutation_indices) const
 {
     auto result = Dense::create(this->get_executor(), this->get_size());
-    this->permute(permutation_indices, result.get());
+    this->permute(permutation_indices, result);
     return result;
 }
 
@@ -1203,7 +1203,7 @@ std::unique_ptr<LinOp> Dense<ValueType>::inverse_permute(
     const array<int32>* permutation_indices) const
 {
     auto result = Dense::create(this->get_executor(), this->get_size());
-    this->inverse_permute(permutation_indices, result.get());
+    this->inverse_permute(permutation_indices, result);
     return result;
 }
 
@@ -1213,7 +1213,7 @@ std::unique_ptr<LinOp> Dense<ValueType>::inverse_permute(
     const array<int64>* permutation_indices) const
 {
     auto result = Dense::create(this->get_executor(), this->get_size());
-    this->inverse_permute(permutation_indices, result.get());
+    this->inverse_permute(permutation_indices, result);
     return result;
 }
 
@@ -1239,7 +1239,7 @@ std::unique_ptr<LinOp> Dense<ValueType>::row_permute(
     const array<int32>* permutation_indices) const
 {
     auto result = Dense::create(this->get_executor(), this->get_size());
-    this->row_permute(permutation_indices, result.get());
+    this->row_permute(permutation_indices, result);
     return result;
 }
 
@@ -1249,7 +1249,7 @@ std::unique_ptr<LinOp> Dense<ValueType>::row_permute(
     const array<int64>* permutation_indices) const
 {
     auto result = Dense::create(this->get_executor(), this->get_size());
-    this->row_permute(permutation_indices, result.get());
+    this->row_permute(permutation_indices, result);
     return result;
 }
 
@@ -1277,7 +1277,7 @@ std::unique_ptr<Dense<ValueType>> Dense<ValueType>::row_gather(
     auto exec = this->get_executor();
     dim<2> out_dim{row_idxs->get_num_elems(), this->get_size()[1]};
     auto result = Dense::create(exec, out_dim);
-    this->row_gather(row_idxs, result.get());
+    this->row_gather(row_idxs, result);
     return result;
 }
 
@@ -1288,7 +1288,7 @@ std::unique_ptr<Dense<ValueType>> Dense<ValueType>::row_gather(
     auto exec = this->get_executor();
     dim<2> out_dim{row_idxs->get_num_elems(), this->get_size()[1]};
     auto result = Dense::create(exec, out_dim);
-    this->row_gather(row_idxs, result.get());
+    this->row_gather(row_idxs, result);
     return result;
 }
 
@@ -1374,7 +1374,7 @@ std::unique_ptr<LinOp> Dense<ValueType>::column_permute(
     const array<int32>* permutation_indices) const
 {
     auto result = Dense::create(this->get_executor(), this->get_size());
-    this->column_permute(permutation_indices, result.get());
+    this->column_permute(permutation_indices, result);
     return result;
 }
 
@@ -1384,7 +1384,7 @@ std::unique_ptr<LinOp> Dense<ValueType>::column_permute(
     const array<int64>* permutation_indices) const
 {
     auto result = Dense::create(this->get_executor(), this->get_size());
-    this->column_permute(permutation_indices, result.get());
+    this->column_permute(permutation_indices, result);
     return result;
 }
 
@@ -1410,7 +1410,7 @@ std::unique_ptr<LinOp> Dense<ValueType>::inverse_row_permute(
     const array<int32>* permutation_indices) const
 {
     auto result = Dense::create(this->get_executor(), this->get_size());
-    this->inverse_row_permute(permutation_indices, result.get());
+    this->inverse_row_permute(permutation_indices, result);
     return result;
 }
 
@@ -1420,7 +1420,7 @@ std::unique_ptr<LinOp> Dense<ValueType>::inverse_row_permute(
     const array<int64>* permutation_indices) const
 {
     auto result = Dense::create(this->get_executor(), this->get_size());
-    this->inverse_row_permute(permutation_indices, result.get());
+    this->inverse_row_permute(permutation_indices, result);
     return result;
 }
 
@@ -1448,7 +1448,7 @@ std::unique_ptr<LinOp> Dense<ValueType>::inverse_column_permute(
     const array<int32>* permutation_indices) const
 {
     auto result = Dense::create(this->get_executor(), this->get_size());
-    this->inverse_column_permute(permutation_indices, result.get());
+    this->inverse_column_permute(permutation_indices, result);
     return result;
 }
 
@@ -1458,7 +1458,7 @@ std::unique_ptr<LinOp> Dense<ValueType>::inverse_column_permute(
     const array<int64>* permutation_indices) const
 {
     auto result = Dense::create(this->get_executor(), this->get_size());
-    this->inverse_column_permute(permutation_indices, result.get());
+    this->inverse_column_permute(permutation_indices, result);
     return result;
 }
 
@@ -1499,7 +1499,7 @@ std::unique_ptr<Diagonal<ValueType>> Dense<ValueType>::extract_diagonal() const
 {
     const auto diag_size = std::min(this->get_size()[0], this->get_size()[1]);
     auto diag = Diagonal<ValueType>::create(this->get_executor(), diag_size);
-    this->extract_diagonal(diag.get());
+    this->extract_diagonal(diag);
     return diag;
 }
 
@@ -1517,7 +1517,7 @@ Dense<ValueType>::compute_absolute() const
 {
     // do not inherit the stride
     auto result = absolute_type::create(this->get_executor(), this->get_size());
-    this->compute_absolute(result.get());
+    this->compute_absolute(result);
     return result;
 }
 
@@ -1538,7 +1538,7 @@ std::unique_ptr<typename Dense<ValueType>::complex_type>
 Dense<ValueType>::make_complex() const
 {
     auto result = complex_type::create(this->get_executor(), this->get_size());
-    this->make_complex(result.get());
+    this->make_complex(result);
     return result;
 }
 
@@ -1559,7 +1559,7 @@ std::unique_ptr<typename Dense<ValueType>::real_type>
 Dense<ValueType>::get_real() const
 {
     auto result = real_type::create(this->get_executor(), this->get_size());
-    this->get_real(result.get());
+    this->get_real(result);
     return result;
 }
 
@@ -1580,7 +1580,7 @@ std::unique_ptr<typename Dense<ValueType>::real_type>
 Dense<ValueType>::get_imag() const
 {
     auto result = real_type::create(this->get_executor(), this->get_size());
-    this->get_imag(result.get());
+    this->get_imag(result);
     return result;
 }
 

--- a/core/matrix/diagonal.cpp
+++ b/core/matrix/diagonal.cpp
@@ -153,7 +153,7 @@ void Diagonal<ValueType>::apply_impl(const LinOp* alpha, const LinOp* b,
             auto x_clone = dense_x->clone();
             this->apply_impl(dense_b, x_clone.get());
             dense_x->scale(dense_beta);
-            dense_x->add_scaled(dense_alpha, x_clone.get());
+            dense_x->add_scaled(dense_alpha, x_clone);
         },
         alpha, b, beta, x);
 }

--- a/core/matrix/ell.cpp
+++ b/core/matrix/ell.cpp
@@ -325,7 +325,7 @@ Ell<ValueType, IndexType>::extract_diagonal() const
     auto diag = Diagonal<ValueType>::create(exec, diag_size);
     exec->run(ell::make_fill_array(diag->get_values(), diag->get_size()[0],
                                    zero<ValueType>()));
-    exec->run(ell::make_extract_diagonal(this, lend(diag)));
+    exec->run(ell::make_extract_diagonal(this, diag.get()));
     return diag;
 }
 

--- a/core/matrix/fbcsr.cpp
+++ b/core/matrix/fbcsr.cpp
@@ -382,7 +382,7 @@ Fbcsr<ValueType, IndexType>::extract_diagonal() const
     auto diag = Diagonal<ValueType>::create(exec, diag_size);
     exec->run(fbcsr::make_fill_array(diag->get_values(), diag->get_size()[0],
                                      zero<ValueType>()));
-    exec->run(fbcsr::make_extract_diagonal(this, lend(diag)));
+    exec->run(fbcsr::make_extract_diagonal(this, diag.get()));
     return diag;
 }
 

--- a/core/matrix/fbcsr_builder.hpp
+++ b/core/matrix/fbcsr_builder.hpp
@@ -71,8 +71,9 @@ public:
      * @param matrix  An existing FBCSR matrix
      *                for which intrusive access is needed
      */
-    explicit FbcsrBuilder(Fbcsr<ValueType, IndexType>* const matrix)
-        : matrix_{matrix}
+    explicit FbcsrBuilder(
+        pointer_param<Fbcsr<ValueType, IndexType>> const matrix)
+        : matrix_{matrix.get()}
     {}
 
     ~FbcsrBuilder() = default;

--- a/core/matrix/fbcsr_builder.hpp
+++ b/core/matrix/fbcsr_builder.hpp
@@ -71,8 +71,7 @@ public:
      * @param matrix  An existing FBCSR matrix
      *                for which intrusive access is needed
      */
-    explicit FbcsrBuilder(
-        pointer_param<Fbcsr<ValueType, IndexType>> const matrix)
+    explicit FbcsrBuilder(ptr_param<Fbcsr<ValueType, IndexType>> const matrix)
         : matrix_{matrix.get()}
     {}
 

--- a/core/matrix/fft.cpp
+++ b/core/matrix/fft.cpp
@@ -198,15 +198,15 @@ void Fft::apply_impl(const LinOp* alpha, const LinOp* b, const LinOp* beta,
 {
     if (auto float_x = dynamic_cast<Dense<std::complex<float>>*>(x)) {
         auto clone_x = x->clone();
-        this->apply_impl(b, lend(clone_x));
+        this->apply_impl(b, clone_x.get());
         float_x->scale(beta);
-        float_x->add_scaled(alpha, lend(clone_x));
+        float_x->add_scaled(alpha, clone_x);
     } else {
         auto dense_x = as<Dense<std::complex<double>>>(x);
         auto clone_x = x->clone();
-        this->apply_impl(b, lend(clone_x));
+        this->apply_impl(b, clone_x.get());
         dense_x->scale(beta);
-        dense_x->add_scaled(alpha, lend(clone_x));
+        dense_x->add_scaled(alpha, clone_x);
     }
 }
 
@@ -275,15 +275,15 @@ void Fft2::apply_impl(const LinOp* alpha, const LinOp* b, const LinOp* beta,
 {
     if (auto float_x = dynamic_cast<Dense<std::complex<float>>*>(x)) {
         auto clone_x = x->clone();
-        this->apply_impl(b, lend(clone_x));
+        this->apply_impl(b, clone_x.get());
         float_x->scale(beta);
-        float_x->add_scaled(alpha, lend(clone_x));
+        float_x->add_scaled(alpha, clone_x);
     } else {
         auto dense_x = as<Dense<std::complex<double>>>(x);
         auto clone_x = x->clone();
-        this->apply_impl(b, lend(clone_x));
+        this->apply_impl(b, clone_x.get());
         dense_x->scale(beta);
-        dense_x->add_scaled(alpha, lend(clone_x));
+        dense_x->add_scaled(alpha, clone_x);
     }
 }
 
@@ -358,15 +358,15 @@ void Fft3::apply_impl(const LinOp* alpha, const LinOp* b, const LinOp* beta,
 {
     if (auto float_x = dynamic_cast<Dense<std::complex<float>>*>(x)) {
         auto clone_x = x->clone();
-        this->apply_impl(b, lend(clone_x));
+        this->apply_impl(b, clone_x.get());
         float_x->scale(beta);
-        float_x->add_scaled(alpha, lend(clone_x));
+        float_x->add_scaled(alpha, clone_x);
     } else {
         auto dense_x = as<Dense<std::complex<double>>>(x);
         auto clone_x = x->clone();
-        this->apply_impl(b, lend(clone_x));
+        this->apply_impl(b, clone_x.get());
         dense_x->scale(beta);
-        dense_x->add_scaled(alpha, lend(clone_x));
+        dense_x->add_scaled(alpha, clone_x);
     }
 }
 

--- a/core/matrix/hybrid.cpp
+++ b/core/matrix/hybrid.cpp
@@ -340,8 +340,8 @@ Hybrid<ValueType, IndexType>::extract_diagonal() const
     auto diag = Diagonal<ValueType>::create(exec, diag_size);
     exec->run(hybrid::make_fill_array(diag->get_values(), diag->get_size()[0],
                                       zero<ValueType>()));
-    exec->run(hybrid::make_ell_extract_diagonal(this->get_ell(), lend(diag)));
-    exec->run(hybrid::make_coo_extract_diagonal(this->get_coo(), lend(diag)));
+    exec->run(hybrid::make_ell_extract_diagonal(this->get_ell(), diag.get()));
+    exec->run(hybrid::make_coo_extract_diagonal(this->get_coo(), diag.get()));
     return diag;
 }
 

--- a/core/matrix/hybrid.cpp
+++ b/core/matrix/hybrid.cpp
@@ -163,8 +163,8 @@ template <typename ValueType, typename IndexType>
 void Hybrid<ValueType, IndexType>::convert_to(
     Hybrid<next_precision<ValueType>, IndexType>* result) const
 {
-    this->ell_->convert_to(result->ell_.get());
-    this->coo_->convert_to(result->coo_.get());
+    this->ell_->convert_to(result->ell_);
+    this->coo_->convert_to(result->coo_);
     // TODO set strategy correctly
     // There is no way to correctly clone the strategy like in
     // Csr::convert_to

--- a/core/matrix/hybrid.cpp
+++ b/core/matrix/hybrid.cpp
@@ -367,8 +367,8 @@ Hybrid<ValueType, IndexType>::compute_absolute() const
     auto abs_hybrid = absolute_type::create(
         exec, this->get_size(), this->get_strategy<absolute_type>());
 
-    abs_hybrid->ell_->copy_from(ell_->compute_absolute());
-    abs_hybrid->coo_->copy_from(coo_->compute_absolute());
+    abs_hybrid->ell_->move_from(ell_->compute_absolute());
+    abs_hybrid->coo_->move_from(coo_->compute_absolute());
 
     return abs_hybrid;
 }

--- a/core/matrix/sellp.cpp
+++ b/core/matrix/sellp.cpp
@@ -306,7 +306,7 @@ Sellp<ValueType, IndexType>::extract_diagonal() const
     auto diag = Diagonal<ValueType>::create(exec, diag_size);
     exec->run(sellp::make_fill_array(diag->get_values(), diag->get_size()[0],
                                      zero<ValueType>()));
-    exec->run(sellp::make_extract_diagonal(this, lend(diag)));
+    exec->run(sellp::make_extract_diagonal(this, diag.get()));
     return diag;
 }
 

--- a/core/multigrid/fixed_coarsening.cpp
+++ b/core/multigrid/fixed_coarsening.cpp
@@ -95,7 +95,7 @@ void FixedCoarsening<ValueType, IndexType>::generate()
     auto restrict_op = share(
         csr_type::create(exec, gko::dim<2>{coarse_dim, fine_dim}, coarse_dim,
                          fixed_coarsening_op->get_strategy()));
-    exec->copy_from(parameters_.coarse_rows.get_executor().get(), coarse_dim,
+    exec->copy_from(parameters_.coarse_rows.get_executor(), coarse_dim,
                     parameters_.coarse_rows.get_const_data(),
                     restrict_op->get_col_idxs());
     exec->run(fixed_coarsening::make_fill_array(restrict_op->get_values(),
@@ -111,8 +111,8 @@ void FixedCoarsening<ValueType, IndexType>::generate()
     coarse_matrix->set_strategy(fixed_coarsening_op->get_strategy());
     auto tmp = csr_type::create(exec, gko::dim<2>{fine_dim, coarse_dim});
     tmp->set_strategy(fixed_coarsening_op->get_strategy());
-    fixed_coarsening_op->apply(prolong_op.get(), tmp.get());
-    restrict_op->apply(tmp.get(), coarse_matrix.get());
+    fixed_coarsening_op->apply(prolong_op, tmp);
+    restrict_op->apply(tmp, coarse_matrix);
 
     this->set_multigrid_level(prolong_op, coarse_matrix, restrict_op);
 }

--- a/core/multigrid/pgm.cpp
+++ b/core/multigrid/pgm.cpp
@@ -133,7 +133,7 @@ std::shared_ptr<matrix::Csr<ValueType, IndexType>> generate_coarse(
         coarse_nnz);
     exec->run(pgm::make_compute_coarse_coo(
         nnz, row_idxs.get_const_data(), col_idxs.get_const_data(),
-        vals.get_const_data(), gko::lend(coarse_coo)));
+        vals.get_const_data(), coarse_coo.get()));
     // use move_to
     auto coarse_csr = matrix::Csr<ValueType, IndexType>::create(exec);
     coarse_csr->copy_from(std::move(coarse_coo));
@@ -180,8 +180,7 @@ void Pgm<ValueType, IndexType>::generate()
     auto half_scalar = initialize<matrix::Dense<real_type>>({0.5}, exec);
     auto identity = matrix::Identity<real_type>::create(exec, num_rows);
     // W = (abs_mtx + transpose(abs_mtx))/2
-    abs_mtx->apply(lend(half_scalar), lend(identity), lend(half_scalar),
-                   lend(weight_mtx));
+    abs_mtx->apply(half_scalar, identity, half_scalar, weight_mtx);
     // Extract the diagonal value of matrix
     auto diag = weight_mtx->extract_diagonal();
     for (int i = 0; i < parameters_.max_iterations; i++) {

--- a/core/multigrid/pgm.cpp
+++ b/core/multigrid/pgm.cpp
@@ -135,7 +135,7 @@ std::shared_ptr<matrix::Csr<ValueType, IndexType>> generate_coarse(
         vals.get_const_data(), coarse_coo.get()));
     // use move_to
     auto coarse_csr = matrix::Csr<ValueType, IndexType>::create(exec);
-    coarse_csr->copy_from(std::move(coarse_coo));
+    coarse_csr->move_from(coarse_coo);
     return std::move(coarse_csr);
 }
 

--- a/core/multigrid/pgm.cpp
+++ b/core/multigrid/pgm.cpp
@@ -109,8 +109,7 @@ std::shared_ptr<matrix::Csr<ValueType, IndexType>> generate_coarse(
     gko::array<IndexType> row_idxs(exec, nnz);
     gko::array<IndexType> col_idxs(exec, nnz);
     gko::array<ValueType> vals(exec, nnz);
-    exec->copy_from(exec.get(), nnz, fine_csr->get_const_values(),
-                    vals.get_data());
+    exec->copy_from(exec, nnz, fine_csr->get_const_values(), vals.get_data());
     // map row_ptrs to coarse row index
     exec->run(pgm::make_map_row(num, fine_csr->get_const_row_ptrs(),
                                 agg.get_const_data(), row_idxs.get_data()));
@@ -218,7 +217,7 @@ void Pgm<ValueType, IndexType>::generate()
     // prolong_row_gather is the lightway implementation for prolongation
     auto prolong_row_gather = share(matrix::RowGatherer<IndexType>::create(
         exec, gko::dim<2>{fine_dim, coarse_dim}));
-    exec->copy_from(exec.get(), agg_.get_num_elems(), agg_.get_const_data(),
+    exec->copy_from(exec, agg_.get_num_elems(), agg_.get_const_data(),
                     prolong_row_gather->get_row_idxs());
     auto restrict_sparsity =
         share(matrix::SparsityCsr<ValueType, IndexType>::create(

--- a/core/preconditioner/isai.cpp
+++ b/core/preconditioner/isai.cpp
@@ -225,7 +225,7 @@ void Isai<IsaiType, ValueType, IndexType>::generate_inverse(
             std::shared_ptr<LinOpFactory> excess_solver_factory;
             if (parameters_.excess_solver_factory) {
                 excess_solver_factory = parameters_.excess_solver_factory;
-                excess_solution->copy_from(excess_rhs.get());
+                excess_solution->copy_from(excess_rhs);
             } else if (is_general || is_spd) {
                 excess_solver_factory =
                     Gmres::build()
@@ -241,7 +241,7 @@ void Isai<IsaiType, ValueType, IndexType>::generate_inverse(
                                     remove_complex<ValueType>{1e-6})
                                 .on(exec))
                         .on(exec);
-                excess_solution->copy_from(excess_rhs.get());
+                excess_solution->copy_from(excess_rhs);
             } else if (is_lower) {
                 excess_solver_factory = UpperTrs::build().on(exec);
             } else {

--- a/core/reorder/scaled_reordered.cpp
+++ b/core/reorder/scaled_reordered.cpp
@@ -56,42 +56,40 @@ void ScaledReordered<ValueType, IndexType>::apply_impl(const LinOp* b,
 
             // Preprocess the input vectors before applying the inner operator.
             if (row_scaling_) {
-                row_scaling_->apply(cache_.inner_b.get(),
-                                    cache_.intermediate.get());
+                row_scaling_->apply(cache_.inner_b, cache_.intermediate);
                 std::swap(cache_.inner_b, cache_.intermediate);
             }
             // Col scaling for x is only necessary if the inner operator uses an
             // initial guess. Otherwise x is overwritten anyway.
             if (col_scaling_ && inner_operator_->apply_uses_initial_guess()) {
-                col_scaling_->inverse_apply(cache_.inner_x.get(),
-                                            cache_.intermediate.get());
+                col_scaling_->inverse_apply(cache_.inner_x,
+                                            cache_.intermediate);
                 std::swap(cache_.inner_x, cache_.intermediate);
             }
             if (permutation_array_.get_num_elems() > 0) {
                 cache_.inner_b->row_permute(&permutation_array_,
-                                            cache_.intermediate.get());
+                                            cache_.intermediate);
                 std::swap(cache_.inner_b, cache_.intermediate);
                 if (inner_operator_->apply_uses_initial_guess()) {
                     cache_.inner_x->row_permute(&permutation_array_,
-                                                cache_.intermediate.get());
+                                                cache_.intermediate);
                     std::swap(cache_.inner_x, cache_.intermediate);
                 }
             }
 
-            inner_operator_->apply(cache_.inner_b.get(), cache_.inner_x.get());
+            inner_operator_->apply(cache_.inner_b, cache_.inner_x);
 
             // Permute and scale the solution vector back.
             if (permutation_array_.get_num_elems() > 0) {
                 cache_.inner_x->inverse_row_permute(&permutation_array_,
-                                                    cache_.intermediate.get());
+                                                    cache_.intermediate);
                 std::swap(cache_.inner_x, cache_.intermediate);
             }
             if (col_scaling_) {
-                col_scaling_->apply(cache_.inner_x.get(),
-                                    cache_.intermediate.get());
+                col_scaling_->apply(cache_.inner_x, cache_.intermediate);
                 std::swap(cache_.inner_x, cache_.intermediate);
             }
-            dense_x->copy_from(cache_.inner_x.get());
+            dense_x->copy_from(cache_.inner_x);
         },
         b, x);
 }
@@ -108,7 +106,7 @@ void ScaledReordered<ValueType, IndexType>::apply_impl(const LinOp* alpha,
             auto x_clone = dense_x->clone();
             this->apply_impl(dense_b, x_clone.get());
             dense_x->scale(dense_beta);
-            dense_x->add_scaled(dense_alpha, x_clone.get());
+            dense_x->add_scaled(dense_alpha, x_clone);
         },
         alpha, b, beta, x);
 }

--- a/core/solver/bicg.cpp
+++ b/core/solver/bicg.cpp
@@ -254,7 +254,7 @@ void Bicg<ValueType>::apply_impl(const LinOp* alpha, const LinOp* b,
             auto x_clone = dense_x->clone();
             this->apply_dense_impl(dense_b, x_clone.get());
             dense_x->scale(dense_beta);
-            dense_x->add_scaled(dense_alpha, x_clone.get());
+            dense_x->add_scaled(dense_alpha, x_clone);
         },
         alpha, b, beta, x);
 }

--- a/core/solver/bicgstab.cpp
+++ b/core/solver/bicgstab.cpp
@@ -253,7 +253,7 @@ void Bicgstab<ValueType>::apply_impl(const LinOp* alpha, const LinOp* b,
             auto x_clone = dense_x->clone();
             this->apply_dense_impl(dense_b, x_clone.get());
             dense_x->scale(dense_beta);
-            dense_x->add_scaled(dense_alpha, x_clone.get());
+            dense_x->add_scaled(dense_alpha, x_clone);
         },
         alpha, b, beta, x);
 }

--- a/core/solver/cb_gmres.cpp
+++ b/core/solver/cb_gmres.cpp
@@ -277,8 +277,7 @@ void CbGmres<ValueType>::apply_dense_impl(
                                             &stop_status, krylov_dim));
         // residual = dense_b
         // givens_sin = givens_cos = 0
-        this->get_system_matrix()->apply(neg_one_op.get(), dense_x,
-                                         one_op.get(), residual.get());
+        this->get_system_matrix()->apply(neg_one_op, dense_x, one_op, residual);
         // residual = residual - Ax
 
         exec->run(cb_gmres::make_restart(
@@ -335,8 +334,8 @@ void CbGmres<ValueType>::apply_dense_impl(
             } else {
                 bool all_changed = stop_criterion->update()
                                        .num_iterations(total_iter)
-                                       .residual(residual.get())
-                                       .residual_norm(residual_norm.get())
+                                       .residual(residual)
+                                       .residual_norm(residual_norm)
                                        .solution(dense_x)
                                        .check(RelativeStoppingId, true,
                                               &stop_status, &one_changed);
@@ -397,15 +396,15 @@ void CbGmres<ValueType>::apply_dense_impl(
                 // Solve upper triangular.
                 // y = hessenberg \ residual_norm_collection
 
-                this->get_preconditioner()->apply(before_preconditioner.get(),
-                                                  after_preconditioner.get());
-                dense_x->add_scaled(one_op.get(), after_preconditioner.get());
+                this->get_preconditioner()->apply(before_preconditioner,
+                                                  after_preconditioner);
+                dense_x->add_scaled(one_op, after_preconditioner);
                 // Solve x
                 // x = x + get_preconditioner() * krylov_bases * y
                 residual->copy_from(dense_b);
                 // residual = dense_b
-                this->get_system_matrix()->apply(neg_one_op.get(), dense_x,
-                                                 one_op.get(), residual.get());
+                this->get_system_matrix()->apply(neg_one_op, dense_x, one_op,
+                                                 residual);
                 // residual = residual - Ax
                 exec->run(cb_gmres::make_restart(
                     residual.get(), residual_norm.get(),
@@ -420,8 +419,8 @@ void CbGmres<ValueType>::apply_dense_impl(
                 restart_iter = 0;
             }
 
-            this->get_preconditioner()->apply(next_krylov_basis.get(),
-                                              preconditioned_vector.get());
+            this->get_preconditioner()->apply(next_krylov_basis,
+                                              preconditioned_vector);
             // preconditioned_vector = get_preconditioner() *
             // next_krylov_basis
 
@@ -433,8 +432,8 @@ void CbGmres<ValueType>::apply_dense_impl(
                 span{0, restart_iter + 2}, span{0, num_rhs});
 
             // Start of arnoldi
-            this->get_system_matrix()->apply(preconditioned_vector.get(),
-                                             next_krylov_basis.get());
+            this->get_system_matrix()->apply(preconditioned_vector,
+                                             next_krylov_basis);
             // next_krylov_basis = A * preconditioned_vector
             exec->run(cb_gmres::make_arnoldi(
                 next_krylov_basis.get(), givens_sin.get(), givens_cos.get(),
@@ -479,9 +478,9 @@ void CbGmres<ValueType>::apply_dense_impl(
             &final_iter_nums));
         // Solve upper triangular.
         // y = hessenberg \ residual_norm_collection
-        this->get_preconditioner()->apply(before_preconditioner.get(),
-                                          after_preconditioner.get());
-        dense_x->add_scaled(one_op.get(), after_preconditioner.get());
+        this->get_preconditioner()->apply(before_preconditioner,
+                                          after_preconditioner);
+        dense_x->add_scaled(one_op, after_preconditioner);
         // Solve x
         // x = x + get_preconditioner() * krylov_bases * y
     };  // End of apply_lambda
@@ -503,7 +502,7 @@ void CbGmres<ValueType>::apply_impl(const LinOp* alpha, const LinOp* b,
             auto x_clone = dense_x->clone();
             this->apply_dense_impl(dense_b, x_clone.get());
             dense_x->scale(dense_beta);
-            dense_x->add_scaled(dense_alpha, x_clone.get());
+            dense_x->add_scaled(dense_alpha, x_clone);
         },
         alpha, b, beta, x);
 }

--- a/core/solver/cg.cpp
+++ b/core/solver/cg.cpp
@@ -205,7 +205,7 @@ void Cg<ValueType>::apply_impl(const LinOp* alpha, const LinOp* b,
             auto x_clone = dense_x->clone();
             this->apply_dense_impl(dense_b, x_clone.get());
             dense_x->scale(dense_beta);
-            dense_x->add_scaled(dense_alpha, x_clone.get());
+            dense_x->add_scaled(dense_alpha, x_clone);
         },
         alpha, b, beta, x);
 }

--- a/core/solver/cgs.cpp
+++ b/core/solver/cgs.cpp
@@ -225,7 +225,7 @@ void Cgs<ValueType>::apply_impl(const LinOp* alpha, const LinOp* b,
             auto x_clone = dense_x->clone();
             this->apply_dense_impl(dense_b, x_clone.get());
             dense_x->scale(dense_beta);
-            dense_x->add_scaled(dense_alpha, x_clone.get());
+            dense_x->add_scaled(dense_alpha, x_clone);
         },
         alpha, b, beta, x);
 }

--- a/core/solver/fcg.cpp
+++ b/core/solver/fcg.cpp
@@ -208,7 +208,7 @@ void Fcg<ValueType>::apply_impl(const LinOp* alpha, const LinOp* b,
             auto x_clone = dense_x->clone();
             this->apply_dense_impl(dense_b, x_clone.get());
             dense_x->scale(dense_beta);
-            dense_x->add_scaled(dense_alpha, x_clone.get());
+            dense_x->add_scaled(dense_alpha, x_clone);
         },
         alpha, b, beta, x);
 }

--- a/core/solver/idr.cpp
+++ b/core/solver/idr.cpp
@@ -241,7 +241,7 @@ void Idr<ValueType>::iterate(const VectorType* dense_b,
                                            span{k * nrhs, (k + 1) * nrhs});
 
             // g_k = Au_k
-            this->get_system_matrix()->apply(u_k.get(), helper);
+            this->get_system_matrix()->apply(u_k, helper);
 
             // for i = [0,k)
             //     alpha = p^H_i * g_k / m_i,i
@@ -328,7 +328,7 @@ void Idr<ValueType>::apply_impl(const LinOp* alpha, const LinOp* b,
             auto x_clone = dense_x->clone();
             this->apply_impl(dense_b, x_clone.get());
             dense_x->scale(dense_beta);
-            dense_x->add_scaled(dense_alpha, x_clone.get());
+            dense_x->add_scaled(dense_alpha, x_clone);
         },
         alpha, b, beta, x);
 }

--- a/core/solver/ir.cpp
+++ b/core/solver/ir.cpp
@@ -246,8 +246,8 @@ void Ir<ValueType>::apply_dense_impl(const VectorType* dense_b,
             residual_ptr = residual;
             // residual = b - A * x
             residual->copy_from(dense_b);
-            this->get_system_matrix()->apply(lend(neg_one_op), dense_x,
-                                             lend(one_op), lend(residual));
+            this->get_system_matrix()->apply(neg_one_op, dense_x, one_op,
+                                             residual);
             if (stop_criterion->update()
                     .num_iterations(iter)
                     .residual(residual_ptr)

--- a/core/solver/ir.cpp
+++ b/core/solver/ir.cpp
@@ -266,11 +266,10 @@ void Ir<ValueType>::apply_dense_impl(const VectorType* dense_b,
             solver_->apply(residual_ptr, inner_solution);
 
             // x = x + relaxation_factor * inner_solution
-            dense_x->add_scaled(relaxation_factor_.get(), inner_solution);
+            dense_x->add_scaled(relaxation_factor_, inner_solution);
         } else {
             // x = x + relaxation_factor * A \ residual
-            solver_->apply(relaxation_factor_.get(), residual_ptr, one_op,
-                           dense_x);
+            solver_->apply(relaxation_factor_, residual_ptr, one_op, dense_x);
         }
     }
 }
@@ -299,7 +298,7 @@ void Ir<ValueType>::apply_with_initial_guess_impl(
             auto x_clone = dense_x->clone();
             this->apply_dense_impl(dense_b, x_clone.get(), guess);
             dense_x->scale(dense_beta);
-            dense_x->add_scaled(dense_alpha, x_clone.get());
+            dense_x->add_scaled(dense_alpha, x_clone);
         },
         alpha, b, beta, x);
 }

--- a/core/solver/lower_trs.cpp
+++ b/core/solver/lower_trs.cpp
@@ -177,7 +177,7 @@ void LowerTrs<ValueType, IndexType>::apply_impl(const LinOp* b, LinOp* x) const
                     ws::transposed_x, gko::transpose(dense_x->get_size()));
             }
             exec->run(lower_trs::make_solve(
-                lend(this->get_system_matrix()), lend(this->solve_struct_),
+                this->get_system_matrix().get(), this->solve_struct_.get(),
                 this->get_parameters().unit_diagonal, parameters_.algorithm,
                 trans_b, trans_x, dense_b, dense_x));
         },

--- a/core/solver/lower_trs.cpp
+++ b/core/solver/lower_trs.cpp
@@ -199,7 +199,7 @@ void LowerTrs<ValueType, IndexType>::apply_impl(const LinOp* alpha,
             auto x_clone = dense_x->clone();
             this->apply_impl(dense_b, x_clone.get());
             dense_x->scale(dense_beta);
-            dense_x->add_scaled(dense_alpha, x_clone.get());
+            dense_x->add_scaled(dense_alpha, x_clone);
         },
         alpha, b, beta, x);
 }

--- a/core/solver/multigrid.cpp
+++ b/core/solver/multigrid.cpp
@@ -498,7 +498,7 @@ void Multigrid::generate()
     // Always generate smoother with size = level.
     while (level < parameters_.max_levels &&
            num_rows > parameters_.min_coarse_rows) {
-        auto index = level_selector_(level, lend(matrix));
+        auto index = level_selector_(level, matrix.get());
         GKO_ENSURE_IN_BOUNDS(index, parameters_.mg_level.size());
         auto mg_level_factory = parameters_.mg_level.at(index);
         // coarse generate
@@ -558,7 +558,7 @@ void Multigrid::generate()
                 coarsest_solver_ = matrix::Identity<value_type>::create(
                     exec, matrix->get_size()[0]);
             } else {
-                auto temp_index = solver_selector_(level, lend(matrix));
+                auto temp_index = solver_selector_(level, matrix.get());
                 GKO_ENSURE_IN_BOUNDS(temp_index,
                                      parameters_.coarsest_solver.size());
                 auto solver = parameters_.coarsest_solver.at(temp_index);

--- a/core/solver/multigrid.cpp
+++ b/core/solver/multigrid.cpp
@@ -428,10 +428,10 @@ void MultigridState::run_cycle(multigrid::cycle cycle, size_type level,
     // TODO: if already computes the residual outside, the first level may not
     // need this residual computation when no presmoother in the first level.
     r->copy_from(b);  // n * b
-    matrix->apply(neg_one, x, one, r.get());
+    matrix->apply(neg_one, x, one, r);
 
     // first cycle
-    mg_level->get_restrict_op()->apply(r.get(), g.get());
+    mg_level->get_restrict_op()->apply(r, g);
     // next level
     if (level + 1 == total_level) {
         // the coarsest solver use the last level valuetype
@@ -462,7 +462,7 @@ void MultigridState::run_cycle(multigrid::cycle cycle, size_type level,
         }
     }
     // prolong
-    mg_level->get_prolong_op()->apply(next_one, e.get(), next_one, x);
+    mg_level->get_prolong_op()->apply(next_one, e, next_one, x);
 
     // end or origin previous
     bool use_post = has_property(mode, cycle_mode::end_of_cycle) ||
@@ -632,7 +632,7 @@ void Multigrid::apply_with_initial_guess_impl(const LinOp* alpha,
                 auto x_clone = dense_x->clone();
                 this->apply_dense_impl(dense_b, x_clone.get(), guess);
                 dense_x->scale(dense_beta);
-                dense_x->add_scaled(dense_alpha, x_clone.get());
+                dense_x->add_scaled(dense_alpha, x_clone);
             },
             alpha, b, beta, x);
     };

--- a/core/solver/upper_trs.cpp
+++ b/core/solver/upper_trs.cpp
@@ -177,7 +177,7 @@ void UpperTrs<ValueType, IndexType>::apply_impl(const LinOp* b, LinOp* x) const
                     ws::transposed_x, gko::transpose(dense_x->get_size()));
             }
             exec->run(upper_trs::make_solve(
-                lend(this->get_system_matrix()), lend(this->solve_struct_),
+                this->get_system_matrix().get(), this->solve_struct_.get(),
                 this->get_parameters().unit_diagonal, parameters_.algorithm,
                 trans_b, trans_x, dense_b, dense_x));
         },

--- a/core/solver/upper_trs.cpp
+++ b/core/solver/upper_trs.cpp
@@ -199,7 +199,7 @@ void UpperTrs<ValueType, IndexType>::apply_impl(const LinOp* alpha,
             auto x_clone = dense_x->clone();
             this->apply_impl(dense_b, x_clone.get());
             dense_x->scale(dense_beta);
-            dense_x->add_scaled(dense_alpha, x_clone.get());
+            dense_x->add_scaled(dense_alpha, x_clone);
         },
         alpha, b, beta, x);
 }

--- a/core/test/base/executor.cpp
+++ b/core/test/base/executor.cpp
@@ -212,7 +212,7 @@ TEST(ReferenceExecutor, CopiesDataFromOmp)
     int* copy = ref->alloc<int>(num_elems);
 
     // ReferenceExecutor is a type of OMP executor, so this is O.K.
-    ref->copy_from(omp.get(), num_elems, orig, copy);
+    ref->copy_from(omp, num_elems, orig, copy);
     EXPECT_EQ(3, copy[0]);
     EXPECT_EQ(8, copy[1]);
 
@@ -229,7 +229,7 @@ TEST(ReferenceExecutor, CopiesDataToOmp)
     int* copy = omp->alloc<int>(num_elems);
 
     // ReferenceExecutor is a type of OMP executor, so this is O.K.
-    omp->copy_from(ref.get(), num_elems, orig, copy);
+    omp->copy_from(ref, num_elems, orig, copy);
     EXPECT_EQ(3, copy[0]);
     EXPECT_EQ(8, copy[1]);
 

--- a/core/test/base/lin_op.cpp
+++ b/core/test/base/lin_op.cpp
@@ -172,7 +172,7 @@ protected:
 
 TEST_F(EnableLinOp, CallsApplyImpl)
 {
-    op->apply(gko::lend(b), gko::lend(x));
+    op->apply(b, x);
 
     ASSERT_EQ(op->last_access, ref2);
 }
@@ -180,7 +180,7 @@ TEST_F(EnableLinOp, CallsApplyImpl)
 
 TEST_F(EnableLinOp, CallsExtendedApplyImpl)
 {
-    op->apply(gko::lend(alpha), gko::lend(b), gko::lend(beta), gko::lend(x));
+    op->apply(alpha, b, beta, x);
 
     ASSERT_EQ(op->last_access, ref2);
 }
@@ -190,8 +190,7 @@ TEST_F(EnableLinOp, ApplyFailsOnWrongBSize)
 {
     auto wrong = DummyLinOp::create(ref, gko::dim<2>{3, 4});
 
-    ASSERT_THROW(op->apply(gko::lend(wrong), gko::lend(x)),
-                 gko::DimensionMismatch);
+    ASSERT_THROW(op->apply(wrong, x), gko::DimensionMismatch);
 }
 
 
@@ -199,8 +198,7 @@ TEST_F(EnableLinOp, ApplyFailsOnWrongSolutionRows)
 {
     auto wrong = DummyLinOp::create(ref, gko::dim<2>{5, 4});
 
-    ASSERT_THROW(op->apply(gko::lend(b), gko::lend(wrong)),
-                 gko::DimensionMismatch);
+    ASSERT_THROW(op->apply(b, wrong), gko::DimensionMismatch);
 }
 
 
@@ -208,8 +206,7 @@ TEST_F(EnableLinOp, ApplyFailsOnWrongSolutionColumns)
 {
     auto wrong = DummyLinOp::create(ref, gko::dim<2>{3, 5});
 
-    ASSERT_THROW(op->apply(gko::lend(b), gko::lend(wrong)),
-                 gko::DimensionMismatch);
+    ASSERT_THROW(op->apply(b, wrong), gko::DimensionMismatch);
 }
 
 
@@ -217,9 +214,7 @@ TEST_F(EnableLinOp, ExtendedApplyFailsOnWrongBSize)
 {
     auto wrong = DummyLinOp::create(ref, gko::dim<2>{3, 4});
 
-    ASSERT_THROW(op->apply(gko::lend(alpha), gko::lend(wrong), gko::lend(beta),
-                           gko::lend(x)),
-                 gko::DimensionMismatch);
+    ASSERT_THROW(op->apply(alpha, wrong, beta, x), gko::DimensionMismatch);
 }
 
 
@@ -227,9 +222,7 @@ TEST_F(EnableLinOp, ExtendedApplyFailsOnWrongSolutionRows)
 {
     auto wrong = DummyLinOp::create(ref, gko::dim<2>{5, 4});
 
-    ASSERT_THROW(op->apply(gko::lend(alpha), gko::lend(b), gko::lend(beta),
-                           gko::lend(wrong)),
-                 gko::DimensionMismatch);
+    ASSERT_THROW(op->apply(alpha, b, beta, wrong), gko::DimensionMismatch);
 }
 
 
@@ -237,9 +230,7 @@ TEST_F(EnableLinOp, ExtendedApplyFailsOnWrongSolutionColumns)
 {
     auto wrong = DummyLinOp::create(ref, gko::dim<2>{3, 5});
 
-    ASSERT_THROW(op->apply(gko::lend(alpha), gko::lend(b), gko::lend(beta),
-                           gko::lend(wrong)),
-                 gko::DimensionMismatch);
+    ASSERT_THROW(op->apply(alpha, b, beta, wrong), gko::DimensionMismatch);
 }
 
 
@@ -247,9 +238,7 @@ TEST_F(EnableLinOp, ExtendedApplyFailsOnWrongAlphaDimension)
 {
     auto wrong = DummyLinOp::create(ref, gko::dim<2>{2, 5});
 
-    ASSERT_THROW(op->apply(gko::lend(wrong), gko::lend(b), gko::lend(beta),
-                           gko::lend(x)),
-                 gko::DimensionMismatch);
+    ASSERT_THROW(op->apply(wrong, b, beta, x), gko::DimensionMismatch);
 }
 
 
@@ -257,16 +246,14 @@ TEST_F(EnableLinOp, ExtendedApplyFailsOnWrongBetaDimension)
 {
     auto wrong = DummyLinOp::create(ref, gko::dim<2>{2, 5});
 
-    ASSERT_THROW(op->apply(gko::lend(alpha), gko::lend(b), gko::lend(wrong),
-                           gko::lend(x)),
-                 gko::DimensionMismatch);
+    ASSERT_THROW(op->apply(alpha, b, wrong, x), gko::DimensionMismatch);
 }
 
 
 // For tests between different memory, check cuda/test/base/lin_op.cu
 TEST_F(EnableLinOp, ApplyDoesNotCopyBetweenSameMemory)
 {
-    op->apply(gko::lend(b), gko::lend(x));
+    op->apply(b, x);
 
     ASSERT_EQ(op->last_b_access, ref);
     ASSERT_EQ(op->last_x_access, ref);
@@ -275,7 +262,7 @@ TEST_F(EnableLinOp, ApplyDoesNotCopyBetweenSameMemory)
 
 TEST_F(EnableLinOp, ApplyNoCopyBackBetweenSameMemory)
 {
-    op->apply(gko::lend(b), gko::lend(x));
+    op->apply(b, x);
 
     ASSERT_EQ(b->last_access, ref);
     ASSERT_EQ(x->last_access, ref);
@@ -284,7 +271,7 @@ TEST_F(EnableLinOp, ApplyNoCopyBackBetweenSameMemory)
 
 TEST_F(EnableLinOp, ExtendedApplyDoesNotCopyBetweenSameMemory)
 {
-    op->apply(gko::lend(alpha), gko::lend(b), gko::lend(beta), gko::lend(x));
+    op->apply(alpha, b, beta, x);
 
     ASSERT_EQ(op->last_alpha_access, ref);
     ASSERT_EQ(op->last_b_access, ref);
@@ -295,7 +282,7 @@ TEST_F(EnableLinOp, ExtendedApplyDoesNotCopyBetweenSameMemory)
 
 TEST_F(EnableLinOp, ExtendedApplyNoCopyBackBetweenSameMemory)
 {
-    op->apply(gko::lend(alpha), gko::lend(b), gko::lend(beta), gko::lend(x));
+    op->apply(alpha, b, beta, x);
 
     ASSERT_EQ(alpha->last_access, ref);
     ASSERT_EQ(b->last_access, ref);
@@ -314,7 +301,7 @@ TEST_F(EnableLinOp, ApplyIsLogged)
 {
     auto before_logger = *logger;
 
-    op->apply(gko::lend(b), gko::lend(x));
+    op->apply(b, x);
 
     ASSERT_EQ(logger->linop_apply_started,
               before_logger.linop_apply_started + 1);
@@ -327,7 +314,7 @@ TEST_F(EnableLinOp, AdvancedApplyIsLogged)
 {
     auto before_logger = *logger;
 
-    op->apply(gko::lend(alpha), gko::lend(b), gko::lend(beta), gko::lend(x));
+    op->apply(alpha, b, beta, x);
 
     ASSERT_EQ(logger->linop_advanced_apply_started,
               before_logger.linop_advanced_apply_started + 1);

--- a/core/test/base/mtx_io.cpp
+++ b/core/test/base/mtx_io.cpp
@@ -1032,7 +1032,7 @@ TYPED_TEST(RealDummyLinOpTest, WritesLinOpToStreamArray)
         iss, gko::ReferenceExecutor::create());
     std::ostringstream oss{};
 
-    write(oss, lend(lin_op), gko::layout_type::array);
+    write(oss, lin_op, gko::layout_type::array);
 
     ASSERT_EQ(oss.str(),
               "%%MatrixMarket matrix array real general\n"
@@ -1063,7 +1063,7 @@ TYPED_TEST(RealDummyLinOpTest, WritesLinOpToStreamCoordinate)
         iss, gko::ReferenceExecutor::create());
     std::ostringstream oss{};
 
-    write(oss, lend(lin_op), gko::layout_type::coordinate);
+    write(oss, lin_op, gko::layout_type::coordinate);
 
     ASSERT_EQ(oss.str(),
               "%%MatrixMarket matrix coordinate real general\n2 3 6\n1 1 1\n1 "
@@ -1117,7 +1117,7 @@ TYPED_TEST(RealDummyLinOpTest, WritesAndReadsBinaryLinOpToStreamArray)
     auto lin_op = gko::read<DummyLinOp<value_type, index_type>>(iss, ref);
     std::ostringstream oss{};
 
-    gko::write_binary(oss, lend(lin_op));
+    gko::write_binary(oss, lin_op);
     std::istringstream iss2{oss.str()};
     auto lin_op2 =
         gko::read_binary<DummyLinOp<value_type, index_type>>(iss2, ref);
@@ -1155,7 +1155,7 @@ TYPED_TEST(DenseTest, WritesToStreamDefault)
         iss, gko::ReferenceExecutor::create());
     std::ostringstream oss{};
 
-    write(oss, lend(lin_op));
+    write(oss, lin_op);
 
     ASSERT_EQ(oss.str(),
               "%%MatrixMarket matrix array real general\n"
@@ -1288,7 +1288,7 @@ TYPED_TEST(ComplexDummyLinOpTest, WritesLinOpToStreamArray)
         iss, gko::ReferenceExecutor::create());
     std::ostringstream oss{};
 
-    write(oss, lend(lin_op), gko::layout_type::array);
+    write(oss, lin_op, gko::layout_type::array);
 
     ASSERT_EQ(oss.str(),
               "%%MatrixMarket matrix array complex general\n"
@@ -1319,7 +1319,7 @@ TYPED_TEST(ComplexDummyLinOpTest, WritesAndReadsBinaryLinOpToStreamArray)
     auto lin_op = gko::read<DummyLinOp<value_type, index_type>>(iss, ref);
     std::ostringstream oss{};
 
-    gko::write_binary(oss, lend(lin_op));
+    gko::write_binary(oss, lin_op);
     std::istringstream iss2{oss.str()};
     auto lin_op2 =
         gko::read_binary<DummyLinOp<value_type, index_type>>(iss2, ref);

--- a/core/test/base/polymorphic_object.cpp
+++ b/core/test/base/polymorphic_object.cpp
@@ -224,7 +224,7 @@ TEST_F(EnablePolymorphicObject, CopiesObject)
 {
     auto copy = DummyObject::create(omp, 7);
 
-    copy->copy_from(gko::lend(obj));
+    copy->copy_from(obj);
 
     ASSERT_NE(copy, obj);
     ASSERT_EQ(copy->get_executor(), omp);
@@ -240,7 +240,7 @@ TEST_F(EnablePolymorphicObject, CopiesObjectIsLogged)
     auto copy = DummyObject::create(omp, 7);
     copy->add_logger(logger);
 
-    copy->copy_from(gko::lend(obj));
+    copy->copy_from(obj);
 
     ASSERT_EQ(logger->copy_started, before_logger.copy_started + 1);
     ASSERT_EQ(logger->copy_completed, before_logger.copy_completed + 1);
@@ -276,7 +276,7 @@ TEST_F(EnablePolymorphicObject, MovesObject)
 {
     auto copy = DummyObject::create(ref, 7);
 
-    copy->move_from(gko::lend(obj));
+    copy->move_from(obj);
 
     ASSERT_NE(copy, obj);
     ASSERT_EQ(copy->get_executor(), ref);
@@ -292,7 +292,7 @@ TEST_F(EnablePolymorphicObject, MovesObjectIsLogged)
     auto copy = DummyObject::create(ref, 7);
     copy->add_logger(logger);
 
-    copy->move_from(gko::lend(obj));
+    copy->move_from(obj);
 
     ASSERT_EQ(logger->move_started, before_logger.move_started + 1);
     ASSERT_EQ(logger->move_completed, before_logger.move_completed + 1);
@@ -368,7 +368,7 @@ TEST(CopyAndConvertTo, ConvertsToDummyObj)
     auto ref = gko::ReferenceExecutor::create();
     auto convertible = ConvertibleToDummyObject::create(ref, 5);
 
-    auto dummy = gko::copy_and_convert_to<DummyObject>(ref, lend(convertible));
+    auto dummy = gko::copy_and_convert_to<DummyObject>(ref, convertible.get());
 
     ASSERT_EQ(dummy->x, 5);
 }
@@ -380,7 +380,7 @@ TEST(CopyAndConvertTo, ConvertsConstToDummyObj)
     std::unique_ptr<const ConvertibleToDummyObject> convertible =
         ConvertibleToDummyObject::create(ref, 5);
 
-    auto dummy = gko::copy_and_convert_to<DummyObject>(ref, lend(convertible));
+    auto dummy = gko::copy_and_convert_to<DummyObject>(ref, convertible.get());
 
     ASSERT_EQ(dummy->x, 5);
 }
@@ -391,9 +391,9 @@ TEST(CopyAndConvertTo, AvoidsConversion)
     auto ref = gko::ReferenceExecutor::create();
     auto convertible = DummyObject::create(ref, 5);
 
-    auto dummy = gko::copy_and_convert_to<DummyObject>(ref, lend(convertible));
+    auto dummy = gko::copy_and_convert_to<DummyObject>(ref, convertible.get());
 
-    ASSERT_EQ(gko::lend(dummy), gko::lend(convertible));
+    ASSERT_EQ(dummy, convertible);
 }
 
 

--- a/core/test/base/polymorphic_object.cpp
+++ b/core/test/base/polymorphic_object.cpp
@@ -247,31 +247,6 @@ TEST_F(EnablePolymorphicObject, CopiesObjectIsLogged)
 }
 
 
-TEST_F(EnablePolymorphicObject, MovesObjectByCopyFromUniquePtr)
-{
-    auto copy = DummyObject::create(ref, 7);
-
-    copy->copy_from(gko::give(obj));
-
-    ASSERT_NE(copy, obj);
-    ASSERT_EQ(copy->get_executor(), ref);
-    ASSERT_EQ(copy->x, 5);
-}
-
-
-TEST_F(EnablePolymorphicObject, MovesObjectByCopyFromUniquePtrIsLogged)
-{
-    auto before_logger = *this->logger;
-    auto copy = DummyObject::create(ref, 7);
-    copy->add_logger(logger);
-
-    copy->copy_from(gko::give(obj));
-
-    ASSERT_EQ(logger->move_started, before_logger.move_started + 1);
-    ASSERT_EQ(logger->move_completed, before_logger.move_completed + 1);
-}
-
-
 TEST_F(EnablePolymorphicObject, MovesObject)
 {
     auto copy = DummyObject::create(ref, 7);
@@ -293,31 +268,6 @@ TEST_F(EnablePolymorphicObject, MovesObjectIsLogged)
     copy->add_logger(logger);
 
     copy->move_from(obj);
-
-    ASSERT_EQ(logger->move_started, before_logger.move_started + 1);
-    ASSERT_EQ(logger->move_completed, before_logger.move_completed + 1);
-}
-
-
-TEST_F(EnablePolymorphicObject, MovesFromUniquePtr)
-{
-    auto copy = DummyObject::create(ref, 7);
-
-    copy->copy_from(gko::give(obj));
-
-    ASSERT_NE(copy, obj);
-    ASSERT_EQ(copy->get_executor(), ref);
-    ASSERT_EQ(copy->x, 5);
-}
-
-
-TEST_F(EnablePolymorphicObject, MovesFromUniquePtrIsLogged)
-{
-    auto before_logger = *this->logger;
-    auto copy = DummyObject::create(ref, 7);
-    copy->add_logger(logger);
-
-    copy->copy_from(gko::give(obj));
 
     ASSERT_EQ(logger->move_started, before_logger.move_started + 1);
     ASSERT_EQ(logger->move_completed, before_logger.move_completed + 1);

--- a/core/test/base/polymorphic_object.cpp
+++ b/core/test/base/polymorphic_object.cpp
@@ -157,7 +157,7 @@ protected:
     void TearDown() override
     {
         if (obj) {
-            obj->remove_logger(logger.get());
+            obj->remove_logger(logger);
         }
     }
 };

--- a/core/test/base/utils.cpp
+++ b/core/test/base/utils.cpp
@@ -439,7 +439,7 @@ protected:
 TEST_F(TemporaryClone, DoesNotCopyToSameMemory)
 {
     auto other = gko::ReferenceExecutor::create();
-    auto clone = make_temporary_clone(other, obj.get());
+    auto clone = make_temporary_clone(other, obj);
 
     ASSERT_NE(clone.get()->get_executor(), other);
     ASSERT_EQ(obj->get_executor(), ref);
@@ -449,7 +449,7 @@ TEST_F(TemporaryClone, DoesNotCopyToSameMemory)
 TEST_F(TemporaryClone, OutputDoesNotCopyToSameMemory)
 {
     auto other = gko::ReferenceExecutor::create();
-    auto clone = make_temporary_output_clone(other, obj.get());
+    auto clone = make_temporary_output_clone(other, obj);
 
     ASSERT_NE(clone.get()->get_executor(), other);
     ASSERT_EQ(obj->get_executor(), ref);
@@ -460,7 +460,7 @@ TEST_F(TemporaryClone, CopiesBackAfterLeavingScope)
 {
     obj->data = 4;
     {
-        auto clone = make_temporary_clone(omp, obj.get());
+        auto clone = make_temporary_clone(omp, obj);
         clone.get()->data = 7;
 
         ASSERT_EQ(obj->data, 4);
@@ -474,7 +474,7 @@ TEST_F(TemporaryClone, OutputCopiesBackAfterLeavingScope)
 {
     obj->data = 4;
     {
-        auto clone = make_temporary_output_clone(omp, obj.get());
+        auto clone = make_temporary_output_clone(omp, obj);
         clone.get()->data = 7;
 
         ASSERT_EQ(obj->data, 4);
@@ -499,7 +499,7 @@ TEST_F(TemporaryClone, DoesntCopyBackConstAfterLeavingScope)
 
 TEST_F(TemporaryClone, AvoidsCopyOnSameExecutor)
 {
-    auto clone = make_temporary_clone(ref, obj.get());
+    auto clone = make_temporary_clone(ref, obj);
 
     ASSERT_EQ(clone.get(), obj.get());
 }

--- a/core/test/base/utils.cpp
+++ b/core/test/base/utils.cpp
@@ -275,39 +275,6 @@ TEST(Give, GivesUniquePointer)
 }
 
 
-TEST(Lend, LendsUniquePointer)
-{
-    std::unique_ptr<Derived> p(new Derived());
-
-    auto lent = gko::lend(p);
-
-    ::testing::StaticAssertTypeEq<decltype(lent), Derived*>();
-    ASSERT_EQ(p.get(), lent);
-}
-
-
-TEST(Lend, LendsSharedPointer)
-{
-    std::shared_ptr<Derived> p(new Derived());
-
-    auto lent = gko::lend(p);
-
-    ::testing::StaticAssertTypeEq<decltype(lent), Derived*>();
-    ASSERT_EQ(p.get(), lent);
-}
-
-
-TEST(Lend, LendsPlainPointer)
-{
-    std::unique_ptr<Derived> p(new Derived());
-
-    auto lent = gko::lend(p.get());
-
-    ::testing::StaticAssertTypeEq<decltype(lent), Derived*>();
-    ASSERT_EQ(p.get(), lent);
-}
-
-
 TEST(As, ConvertsPolymorphicType)
 {
     Derived d;
@@ -472,7 +439,7 @@ protected:
 TEST_F(TemporaryClone, DoesNotCopyToSameMemory)
 {
     auto other = gko::ReferenceExecutor::create();
-    auto clone = make_temporary_clone(other, gko::lend(obj));
+    auto clone = make_temporary_clone(other, obj.get());
 
     ASSERT_NE(clone.get()->get_executor(), other);
     ASSERT_EQ(obj->get_executor(), ref);
@@ -482,7 +449,7 @@ TEST_F(TemporaryClone, DoesNotCopyToSameMemory)
 TEST_F(TemporaryClone, OutputDoesNotCopyToSameMemory)
 {
     auto other = gko::ReferenceExecutor::create();
-    auto clone = make_temporary_output_clone(other, gko::lend(obj));
+    auto clone = make_temporary_output_clone(other, obj.get());
 
     ASSERT_NE(clone.get()->get_executor(), other);
     ASSERT_EQ(obj->get_executor(), ref);
@@ -493,7 +460,7 @@ TEST_F(TemporaryClone, CopiesBackAfterLeavingScope)
 {
     obj->data = 4;
     {
-        auto clone = make_temporary_clone(omp, gko::lend(obj));
+        auto clone = make_temporary_clone(omp, obj.get());
         clone.get()->data = 7;
 
         ASSERT_EQ(obj->data, 4);
@@ -507,7 +474,7 @@ TEST_F(TemporaryClone, OutputCopiesBackAfterLeavingScope)
 {
     obj->data = 4;
     {
-        auto clone = make_temporary_output_clone(omp, gko::lend(obj));
+        auto clone = make_temporary_output_clone(omp, obj.get());
         clone.get()->data = 7;
 
         ASSERT_EQ(obj->data, 4);
@@ -521,7 +488,7 @@ TEST_F(TemporaryClone, DoesntCopyBackConstAfterLeavingScope)
 {
     {
         auto clone = make_temporary_clone(
-            omp, static_cast<const DummyObject*>(gko::lend(obj)));
+            omp, static_cast<const DummyObject*>(obj.get()));
         obj->data = 7;
     }
 
@@ -532,7 +499,7 @@ TEST_F(TemporaryClone, DoesntCopyBackConstAfterLeavingScope)
 
 TEST_F(TemporaryClone, AvoidsCopyOnSameExecutor)
 {
-    auto clone = make_temporary_clone(ref, gko::lend(obj));
+    auto clone = make_temporary_clone(ref, obj.get());
 
     ASSERT_EQ(clone.get(), obj.get());
 }

--- a/core/test/log/convergence.cpp
+++ b/core/test/log/convergence.cpp
@@ -100,13 +100,13 @@ TYPED_TEST(Convergence, CanLogData)
 
     ASSERT_EQ(logger->has_converged(), true);
     ASSERT_EQ(logger->get_num_iterations(), 100);
-    GKO_ASSERT_MTX_NEAR(gko::as<Dense>(logger->get_residual()),
-                        this->residual.get(), 0);
+    GKO_ASSERT_MTX_NEAR(gko::as<Dense>(logger->get_residual()), this->residual,
+                        0);
     GKO_ASSERT_MTX_NEAR(gko::as<AbsoluteDense>(logger->get_residual_norm()),
-                        this->residual_norm.get(), 0);
+                        this->residual_norm, 0);
     GKO_ASSERT_MTX_NEAR(
         gko::as<AbsoluteDense>(logger->get_implicit_sq_resnorm()),
-        this->implicit_sq_resnorm.get(), 0);
+        this->implicit_sq_resnorm, 0);
 }
 
 

--- a/core/test/log/logger.cpp
+++ b/core/test/log/logger.cpp
@@ -138,7 +138,7 @@ TEST(DummyLogged, CanRemoveLogger)
     c.add_logger(gko::log::Stream<>::create(gko::log::Logger::all_events_mask,
                                             std::cout));
 
-    c.remove_logger(gko::lend(r));
+    c.remove_logger(r);
 
     ASSERT_EQ(c.get_num_loggers(), 1);
 }

--- a/core/test/log/record.cpp
+++ b/core/test/log/record.cpp
@@ -220,7 +220,7 @@ TEST(Record, CatchesPolymorphicObjectCreateStarted)
 
     auto& data = logger->get().polymorphic_object_create_started.back();
     ASSERT_EQ(data->exec, exec.get());
-    GKO_ASSERT_MTX_NEAR(gko::as<Dense>(data->input.get()), po.get(), 0);
+    GKO_ASSERT_MTX_NEAR(gko::as<Dense>(data->input.get()), po, 0);
     ASSERT_EQ(data->output.get(), nullptr);
 }
 
@@ -239,8 +239,8 @@ TEST(Record, CatchesPolymorphicObjectCreateCompleted)
 
     auto& data = logger->get().polymorphic_object_create_completed.back();
     ASSERT_EQ(data->exec, exec.get());
-    GKO_ASSERT_MTX_NEAR(gko::as<Dense>(data->input.get()), po.get(), 0);
-    GKO_ASSERT_MTX_NEAR(gko::as<Dense>(data->output.get()), output.get(), 0);
+    GKO_ASSERT_MTX_NEAR(gko::as<Dense>(data->input.get()), po, 0);
+    GKO_ASSERT_MTX_NEAR(gko::as<Dense>(data->output.get()), output, 0);
 }
 
 
@@ -258,8 +258,8 @@ TEST(Record, CatchesPolymorphicObjectCopyStarted)
 
     auto& data = logger->get().polymorphic_object_copy_started.back();
     ASSERT_EQ(data->exec, exec.get());
-    GKO_ASSERT_MTX_NEAR(gko::as<Dense>(data->input.get()), from.get(), 0);
-    GKO_ASSERT_MTX_NEAR(gko::as<Dense>(data->output.get()), to.get(), 0);
+    GKO_ASSERT_MTX_NEAR(gko::as<Dense>(data->input.get()), from, 0);
+    GKO_ASSERT_MTX_NEAR(gko::as<Dense>(data->output.get()), to, 0);
 }
 
 
@@ -278,8 +278,8 @@ TEST(Record, CatchesPolymorphicObjectCopyCompleted)
 
     auto& data = logger->get().polymorphic_object_copy_completed.back();
     ASSERT_EQ(data->exec, exec.get());
-    GKO_ASSERT_MTX_NEAR(gko::as<Dense>(data->input.get()), from.get(), 0);
-    GKO_ASSERT_MTX_NEAR(gko::as<Dense>(data->output.get()), to.get(), 0);
+    GKO_ASSERT_MTX_NEAR(gko::as<Dense>(data->input.get()), from, 0);
+    GKO_ASSERT_MTX_NEAR(gko::as<Dense>(data->output.get()), to, 0);
 }
 
 
@@ -297,8 +297,8 @@ TEST(Record, CatchesPolymorphicObjectMoveStarted)
 
     auto& data = logger->get().polymorphic_object_move_started.back();
     ASSERT_EQ(data->exec, exec.get());
-    GKO_ASSERT_MTX_NEAR(gko::as<Dense>(data->input.get()), from.get(), 0);
-    GKO_ASSERT_MTX_NEAR(gko::as<Dense>(data->output.get()), to.get(), 0);
+    GKO_ASSERT_MTX_NEAR(gko::as<Dense>(data->input.get()), from, 0);
+    GKO_ASSERT_MTX_NEAR(gko::as<Dense>(data->output.get()), to, 0);
 }
 
 
@@ -317,8 +317,8 @@ TEST(Record, CatchesPolymorphicObjectMoveCompleted)
 
     auto& data = logger->get().polymorphic_object_move_completed.back();
     ASSERT_EQ(data->exec, exec.get());
-    GKO_ASSERT_MTX_NEAR(gko::as<Dense>(data->input.get()), from.get(), 0);
-    GKO_ASSERT_MTX_NEAR(gko::as<Dense>(data->output.get()), to.get(), 0);
+    GKO_ASSERT_MTX_NEAR(gko::as<Dense>(data->input.get()), from, 0);
+    GKO_ASSERT_MTX_NEAR(gko::as<Dense>(data->output.get()), to, 0);
 }
 
 
@@ -336,7 +336,7 @@ TEST(Record, CatchesPolymorphicObjectDeleted)
 
     auto& data = logger->get().polymorphic_object_deleted.back();
     ASSERT_EQ(data->exec, exec.get());
-    GKO_ASSERT_MTX_NEAR(gko::as<Dense>(data->input.get()), po.get(), 0);
+    GKO_ASSERT_MTX_NEAR(gko::as<Dense>(data->input.get()), po, 0);
     ASSERT_EQ(data->output, nullptr);
 }
 

--- a/core/test/matrix/coo.cpp
+++ b/core/test/matrix/coo.cpp
@@ -190,7 +190,7 @@ TYPED_TEST(Coo, CanBeMoved)
     using Mtx = typename TestFixture::Mtx;
     auto copy = Mtx::create(this->exec);
 
-    copy->copy_from(std::move(this->mtx));
+    copy->move_from(this->mtx);
 
     this->assert_equal_to_original_mtx(copy);
 }

--- a/core/test/matrix/coo.cpp
+++ b/core/test/matrix/coo.cpp
@@ -76,7 +76,7 @@ protected:
     std::shared_ptr<const gko::Executor> exec;
     std::unique_ptr<Mtx> mtx;
 
-    void assert_equal_to_original_mtx(const Mtx* m)
+    void assert_equal_to_original_mtx(gko::pointer_param<const Mtx> m)
     {
         auto v = m->get_const_values();
         auto c = m->get_const_col_idxs();
@@ -119,7 +119,7 @@ TYPED_TEST(Coo, KnowsItsSize)
 
 TYPED_TEST(Coo, ContainsCorrectData)
 {
-    this->assert_equal_to_original_mtx(this->mtx.get());
+    this->assert_equal_to_original_mtx(this->mtx);
 }
 
 
@@ -177,11 +177,11 @@ TYPED_TEST(Coo, CanBeCopied)
     using Mtx = typename TestFixture::Mtx;
     auto copy = Mtx::create(this->exec);
 
-    copy->copy_from(this->mtx.get());
+    copy->copy_from(this->mtx);
 
-    this->assert_equal_to_original_mtx(this->mtx.get());
+    this->assert_equal_to_original_mtx(this->mtx);
     this->mtx->get_values()[1] = 5.0;
-    this->assert_equal_to_original_mtx(copy.get());
+    this->assert_equal_to_original_mtx(copy);
 }
 
 
@@ -192,7 +192,7 @@ TYPED_TEST(Coo, CanBeMoved)
 
     copy->copy_from(std::move(this->mtx));
 
-    this->assert_equal_to_original_mtx(copy.get());
+    this->assert_equal_to_original_mtx(copy);
 }
 
 
@@ -201,7 +201,7 @@ TYPED_TEST(Coo, CanBeCloned)
     using Mtx = typename TestFixture::Mtx;
     auto clone = this->mtx->clone();
 
-    this->assert_equal_to_original_mtx(this->mtx.get());
+    this->assert_equal_to_original_mtx(this->mtx);
     this->mtx->get_values()[1] = 5.0;
     this->assert_equal_to_original_mtx(dynamic_cast<Mtx*>(clone.get()));
 }
@@ -221,7 +221,7 @@ TYPED_TEST(Coo, CanBeReadFromMatrixData)
     auto m = Mtx::create(this->exec);
     m->read({{2, 3}, {{0, 0, 1.0}, {0, 1, 3.0}, {0, 2, 2.0}, {1, 1, 5.0}}});
 
-    this->assert_equal_to_original_mtx(m.get());
+    this->assert_equal_to_original_mtx(m);
 }
 
 
@@ -239,7 +239,7 @@ TYPED_TEST(Coo, CanBeReadFromMatrixAssemblyData)
 
     m->read(data);
 
-    this->assert_equal_to_original_mtx(m.get());
+    this->assert_equal_to_original_mtx(m);
 }
 
 

--- a/core/test/matrix/coo.cpp
+++ b/core/test/matrix/coo.cpp
@@ -76,7 +76,7 @@ protected:
     std::shared_ptr<const gko::Executor> exec;
     std::unique_ptr<Mtx> mtx;
 
-    void assert_equal_to_original_mtx(gko::pointer_param<const Mtx> m)
+    void assert_equal_to_original_mtx(gko::ptr_param<const Mtx> m)
     {
         auto v = m->get_const_values();
         auto c = m->get_const_col_idxs();

--- a/core/test/matrix/coo_builder.cpp
+++ b/core/test/matrix/coo_builder.cpp
@@ -71,7 +71,7 @@ TYPED_TEST(CooBuilder, ReturnsCorrectArrays)
 {
     using value_type = typename TestFixture::value_type;
     using index_type = typename TestFixture::index_type;
-    gko::matrix::CooBuilder<value_type, index_type> builder{this->mtx.get()};
+    gko::matrix::CooBuilder<value_type, index_type> builder{this->mtx};
 
     auto builder_row_idxs = builder.get_row_idx_array().get_data();
     auto builder_col_idxs = builder.get_col_idx_array().get_data();

--- a/core/test/matrix/csr.cpp
+++ b/core/test/matrix/csr.cpp
@@ -78,7 +78,7 @@ protected:
     std::shared_ptr<const gko::Executor> exec;
     std::unique_ptr<Mtx> mtx;
 
-    void assert_equal_to_original_mtx(gko::pointer_param<const Mtx> m)
+    void assert_equal_to_original_mtx(gko::ptr_param<const Mtx> m)
     {
         auto v = m->get_const_values();
         auto c = m->get_const_col_idxs();
@@ -100,7 +100,7 @@ protected:
         EXPECT_EQ(s[0], 0);
     }
 
-    void assert_empty(gko::pointer_param<const Mtx> m)
+    void assert_empty(gko::ptr_param<const Mtx> m)
     {
         ASSERT_EQ(m->get_size(), gko::dim<2>(0, 0));
         ASSERT_EQ(m->get_num_stored_elements(), 0);

--- a/core/test/matrix/csr.cpp
+++ b/core/test/matrix/csr.cpp
@@ -78,7 +78,7 @@ protected:
     std::shared_ptr<const gko::Executor> exec;
     std::unique_ptr<Mtx> mtx;
 
-    void assert_equal_to_original_mtx(const Mtx* m)
+    void assert_equal_to_original_mtx(gko::pointer_param<const Mtx> m)
     {
         auto v = m->get_const_values();
         auto c = m->get_const_col_idxs();
@@ -100,7 +100,7 @@ protected:
         EXPECT_EQ(s[0], 0);
     }
 
-    void assert_empty(const Mtx* m)
+    void assert_empty(gko::pointer_param<const Mtx> m)
     {
         ASSERT_EQ(m->get_size(), gko::dim<2>(0, 0));
         ASSERT_EQ(m->get_num_stored_elements(), 0);
@@ -123,7 +123,7 @@ TYPED_TEST(Csr, KnowsItsSize)
 
 TYPED_TEST(Csr, ContainsCorrectData)
 {
-    this->assert_equal_to_original_mtx(this->mtx.get());
+    this->assert_equal_to_original_mtx(this->mtx);
 }
 
 
@@ -189,11 +189,11 @@ TYPED_TEST(Csr, CanBeCopied)
     using Mtx = typename TestFixture::Mtx;
     auto copy = Mtx::create(this->exec);
 
-    copy->copy_from(this->mtx.get());
+    copy->copy_from(this->mtx);
 
-    this->assert_equal_to_original_mtx(this->mtx.get());
+    this->assert_equal_to_original_mtx(this->mtx);
     this->mtx->get_values()[1] = 5.0;
-    this->assert_equal_to_original_mtx(copy.get());
+    this->assert_equal_to_original_mtx(copy);
 }
 
 
@@ -204,7 +204,7 @@ TYPED_TEST(Csr, CanBeMoved)
 
     copy->copy_from(std::move(this->mtx));
 
-    this->assert_equal_to_original_mtx(copy.get());
+    this->assert_equal_to_original_mtx(copy);
 }
 
 
@@ -213,7 +213,7 @@ TYPED_TEST(Csr, CanBeCloned)
     using Mtx = typename TestFixture::Mtx;
     auto clone = this->mtx->clone();
 
-    this->assert_equal_to_original_mtx(this->mtx.get());
+    this->assert_equal_to_original_mtx(this->mtx);
     this->mtx->get_values()[1] = 5.0;
     this->assert_equal_to_original_mtx(dynamic_cast<Mtx*>(clone.get()));
 }
@@ -235,7 +235,7 @@ TYPED_TEST(Csr, CanBeReadFromMatrixData)
 
     m->read({{2, 3}, {{0, 0, 1.0}, {0, 1, 3.0}, {0, 2, 2.0}, {1, 1, 5.0}}});
 
-    this->assert_equal_to_original_mtx(m.get());
+    this->assert_equal_to_original_mtx(m);
 }
 
 
@@ -254,7 +254,7 @@ TYPED_TEST(Csr, CanBeReadFromMatrixAssemblyData)
 
     m->read(data);
 
-    this->assert_equal_to_original_mtx(m.get());
+    this->assert_equal_to_original_mtx(m);
 }
 
 

--- a/core/test/matrix/csr.cpp
+++ b/core/test/matrix/csr.cpp
@@ -202,7 +202,7 @@ TYPED_TEST(Csr, CanBeMoved)
     using Mtx = typename TestFixture::Mtx;
     auto copy = Mtx::create(this->exec);
 
-    copy->copy_from(std::move(this->mtx));
+    copy->move_from(this->mtx);
 
     this->assert_equal_to_original_mtx(copy);
 }

--- a/core/test/matrix/csr_builder.cpp
+++ b/core/test/matrix/csr_builder.cpp
@@ -72,7 +72,7 @@ TYPED_TEST(CsrBuilder, ReturnsCorrectArrays)
 {
     using value_type = typename TestFixture::value_type;
     using index_type = typename TestFixture::index_type;
-    gko::matrix::CsrBuilder<value_type, index_type> builder{this->mtx.get()};
+    gko::matrix::CsrBuilder<value_type, index_type> builder{this->mtx};
 
     auto builder_col_idxs = builder.get_col_idx_array().get_data();
     auto builder_values = builder.get_value_array().get_data();
@@ -111,7 +111,7 @@ TYPED_TEST(CsrBuilder, UpdatesSrowOnDestruction)
     this->mtx->set_strategy(std::make_shared<mock_strategy>(was_called));
     was_called = false;
 
-    gko::matrix::CsrBuilder<value_type, index_type>{this->mtx.get()};
+    gko::matrix::CsrBuilder<value_type, index_type>{this->mtx};
 
     ASSERT_TRUE(was_called);
 }

--- a/core/test/matrix/dense.cpp
+++ b/core/test/matrix/dense.cpp
@@ -251,7 +251,7 @@ TYPED_TEST(Dense, CanBeCopied)
 TYPED_TEST(Dense, CanBeMoved)
 {
     auto mtx_copy = gko::matrix::Dense<TypeParam>::create(this->exec);
-    mtx_copy->copy_from(std::move(this->mtx));
+    mtx_copy->move_from(this->mtx);
     this->assert_equal_to_original_mtx(mtx_copy);
     ASSERT_EQ(mtx_copy->get_stride(), 4);
 }

--- a/core/test/matrix/dense.cpp
+++ b/core/test/matrix/dense.cpp
@@ -58,7 +58,7 @@ protected:
 
 
     static void assert_equal_to_original_mtx(
-        gko::pointer_param<gko::matrix::Dense<value_type>> m)
+        gko::ptr_param<gko::matrix::Dense<value_type>> m)
     {
         ASSERT_EQ(m->get_size(), gko::dim<2>(2, 3));
         ASSERT_EQ(m->get_num_stored_elements(), 2 * m->get_stride());
@@ -70,8 +70,7 @@ protected:
         ASSERT_EQ(m->at(1, 2), value_type{3.5});
     }
 
-    static void assert_empty(
-        gko::pointer_param<gko::matrix::Dense<value_type>> m)
+    static void assert_empty(gko::ptr_param<gko::matrix::Dense<value_type>> m)
     {
         ASSERT_EQ(m->get_size(), gko::dim<2>(0, 0));
         ASSERT_EQ(m->get_num_stored_elements(), 0);

--- a/core/test/matrix/dense.cpp
+++ b/core/test/matrix/dense.cpp
@@ -57,7 +57,8 @@ protected:
     {}
 
 
-    static void assert_equal_to_original_mtx(gko::matrix::Dense<value_type>* m)
+    static void assert_equal_to_original_mtx(
+        gko::pointer_param<gko::matrix::Dense<value_type>> m)
     {
         ASSERT_EQ(m->get_size(), gko::dim<2>(2, 3));
         ASSERT_EQ(m->get_num_stored_elements(), 2 * m->get_stride());
@@ -69,7 +70,8 @@ protected:
         ASSERT_EQ(m->at(1, 2), value_type{3.5});
     }
 
-    static void assert_empty(gko::matrix::Dense<value_type>* m)
+    static void assert_empty(
+        gko::pointer_param<gko::matrix::Dense<value_type>> m)
     {
         ASSERT_EQ(m->get_size(), gko::dim<2>(0, 0));
         ASSERT_EQ(m->get_num_stored_elements(), 0);
@@ -160,7 +162,7 @@ TYPED_TEST(Dense, CreateWithSameConfigKeepsStride)
 {
     auto m =
         gko::matrix::Dense<TypeParam>::create(this->exec, gko::dim<2>{2, 3}, 4);
-    auto m2 = gko::matrix::Dense<TypeParam>::create_with_config_of(m.get());
+    auto m2 = gko::matrix::Dense<TypeParam>::create_with_config_of(m);
 
     ASSERT_EQ(m2->get_size(), gko::dim<2>(2, 3));
     EXPECT_EQ(m2->get_stride(), 4);
@@ -170,7 +172,7 @@ TYPED_TEST(Dense, CreateWithSameConfigKeepsStride)
 
 TYPED_TEST(Dense, KnowsItsSizeAndValues)
 {
-    this->assert_equal_to_original_mtx(this->mtx.get());
+    this->assert_equal_to_original_mtx(this->mtx);
     ASSERT_EQ(this->mtx->get_stride(), 4);
 }
 
@@ -237,10 +239,10 @@ TYPED_TEST(Dense, CanBeDoubleListConstructedWithstride)
 TYPED_TEST(Dense, CanBeCopied)
 {
     auto mtx_copy = gko::matrix::Dense<TypeParam>::create(this->exec);
-    mtx_copy->copy_from(this->mtx.get());
-    this->assert_equal_to_original_mtx(this->mtx.get());
+    mtx_copy->copy_from(this->mtx);
+    this->assert_equal_to_original_mtx(this->mtx);
     this->mtx->at(0) = 7;
-    this->assert_equal_to_original_mtx(mtx_copy.get());
+    this->assert_equal_to_original_mtx(mtx_copy);
     ASSERT_EQ(this->mtx->get_stride(), 4);
     ASSERT_EQ(mtx_copy->get_stride(), 3);
 }
@@ -250,7 +252,7 @@ TYPED_TEST(Dense, CanBeMoved)
 {
     auto mtx_copy = gko::matrix::Dense<TypeParam>::create(this->exec);
     mtx_copy->copy_from(std::move(this->mtx));
-    this->assert_equal_to_original_mtx(mtx_copy.get());
+    this->assert_equal_to_original_mtx(mtx_copy);
     ASSERT_EQ(mtx_copy->get_stride(), 4);
 }
 
@@ -258,7 +260,7 @@ TYPED_TEST(Dense, CanBeMoved)
 TYPED_TEST(Dense, CanBeCloned)
 {
     auto mtx_clone = this->mtx->clone();
-    this->assert_equal_to_original_mtx(mtx_clone.get());
+    this->assert_equal_to_original_mtx(mtx_clone);
     ASSERT_EQ(mtx_clone->get_stride(), 3);
 }
 
@@ -408,7 +410,7 @@ TYPED_TEST(Dense, CanCreateRealView)
 
 TYPED_TEST(Dense, CanMakeMutableView)
 {
-    auto view = gko::make_dense_view(this->mtx.get());
+    auto view = gko::make_dense_view(this->mtx);
 
     ASSERT_EQ(view->get_values(), this->mtx->get_values());
     ASSERT_EQ(view->get_executor(), this->mtx->get_executor());
@@ -418,7 +420,7 @@ TYPED_TEST(Dense, CanMakeMutableView)
 
 TYPED_TEST(Dense, CanMakeConstView)
 {
-    auto view = gko::make_const_dense_view(this->mtx.get());
+    auto view = gko::make_const_dense_view(this->mtx);
 
     ASSERT_EQ(view->get_const_values(), this->mtx->get_const_values());
     ASSERT_EQ(view->get_executor(), this->mtx->get_executor());
@@ -451,7 +453,7 @@ private:
     std::unique_ptr<gko::matrix::Dense<>> create_view_of_impl() override
     {
         auto view = create(this->get_executor(), {}, this->get_data());
-        gko::matrix::Dense<>::create_view_of_impl()->move_to(view.get());
+        gko::matrix::Dense<>::create_view_of_impl()->move_to(view);
         return view;
     }
 
@@ -464,7 +466,7 @@ TEST(DenseView, CustomViewKeepsRuntimeType)
     auto vector = CustomDense::create(gko::ReferenceExecutor::create(),
                                       gko::dim<2>{3, 4}, 2);
 
-    auto view = gko::make_dense_view(vector.get());
+    auto view = gko::make_dense_view(vector);
 
     ASSERT_EQ(view->get_values(), vector->get_values());
     EXPECT_TRUE(dynamic_cast<CustomDense*>(view.get()));

--- a/core/test/matrix/diagonal.cpp
+++ b/core/test/matrix/diagonal.cpp
@@ -61,7 +61,7 @@ protected:
     std::shared_ptr<const gko::Executor> exec;
     std::unique_ptr<Diag> diag;
 
-    void assert_equal_to_original_mtx(const Diag* m)
+    void assert_equal_to_original_mtx(gko::pointer_param<const Diag> m)
     {
         auto v = m->get_const_values();
         ASSERT_EQ(m->get_size(), gko::dim<2>(3, 3));
@@ -88,7 +88,7 @@ TYPED_TEST(Diagonal, KnowsItsSize)
 
 TYPED_TEST(Diagonal, ContainsCorrectData)
 {
-    this->assert_equal_to_original_mtx(this->diag.get());
+    this->assert_equal_to_original_mtx(this->diag);
 }
 
 
@@ -132,11 +132,11 @@ TYPED_TEST(Diagonal, CanBeCopied)
     using Diag = typename TestFixture::Diag;
     auto copy = Diag::create(this->exec);
 
-    copy->copy_from(this->diag.get());
+    copy->copy_from(this->diag);
 
-    this->assert_equal_to_original_mtx(this->diag.get());
+    this->assert_equal_to_original_mtx(this->diag);
     this->diag->get_values()[1] = 5.0;
-    this->assert_equal_to_original_mtx(copy.get());
+    this->assert_equal_to_original_mtx(copy);
 }
 
 
@@ -147,7 +147,7 @@ TYPED_TEST(Diagonal, CanBeMoved)
 
     copy->copy_from(std::move(this->diag));
 
-    this->assert_equal_to_original_mtx(copy.get());
+    this->assert_equal_to_original_mtx(copy);
 }
 
 
@@ -157,7 +157,7 @@ TYPED_TEST(Diagonal, CanBeCloned)
 
     auto clone = this->diag->clone();
 
-    this->assert_equal_to_original_mtx(this->diag.get());
+    this->assert_equal_to_original_mtx(this->diag);
     this->diag->get_values()[1] = 5.0;
     this->assert_equal_to_original_mtx(dynamic_cast<Diag*>(clone.get()));
 }

--- a/core/test/matrix/diagonal.cpp
+++ b/core/test/matrix/diagonal.cpp
@@ -61,7 +61,7 @@ protected:
     std::shared_ptr<const gko::Executor> exec;
     std::unique_ptr<Diag> diag;
 
-    void assert_equal_to_original_mtx(gko::pointer_param<const Diag> m)
+    void assert_equal_to_original_mtx(gko::ptr_param<const Diag> m)
     {
         auto v = m->get_const_values();
         ASSERT_EQ(m->get_size(), gko::dim<2>(3, 3));

--- a/core/test/matrix/diagonal.cpp
+++ b/core/test/matrix/diagonal.cpp
@@ -145,7 +145,7 @@ TYPED_TEST(Diagonal, CanBeMoved)
     using Diag = typename TestFixture::Diag;
     auto copy = Diag::create(this->exec);
 
-    copy->copy_from(std::move(this->diag));
+    copy->move_from(this->diag);
 
     this->assert_equal_to_original_mtx(copy);
 }

--- a/core/test/matrix/ell.cpp
+++ b/core/test/matrix/ell.cpp
@@ -74,7 +74,7 @@ protected:
     std::shared_ptr<const gko::Executor> exec;
     std::unique_ptr<Mtx> mtx;
 
-    void assert_equal_to_original_mtx(gko::pointer_param<const Mtx> m)
+    void assert_equal_to_original_mtx(gko::ptr_param<const Mtx> m)
     {
         auto v = m->get_const_values();
         auto c = m->get_const_col_idxs();

--- a/core/test/matrix/ell.cpp
+++ b/core/test/matrix/ell.cpp
@@ -74,7 +74,7 @@ protected:
     std::shared_ptr<const gko::Executor> exec;
     std::unique_ptr<Mtx> mtx;
 
-    void assert_equal_to_original_mtx(const Mtx* m)
+    void assert_equal_to_original_mtx(gko::pointer_param<const Mtx> m)
     {
         auto v = m->get_const_values();
         auto c = m->get_const_col_idxs();
@@ -123,7 +123,7 @@ TYPED_TEST(Ell, KnowsItsSize)
 
 TYPED_TEST(Ell, ContainsCorrectData)
 {
-    this->assert_equal_to_original_mtx(this->mtx.get());
+    this->assert_equal_to_original_mtx(this->mtx);
 }
 
 
@@ -175,11 +175,11 @@ TYPED_TEST(Ell, CanBeCopied)
     using Mtx = typename TestFixture::Mtx;
     auto copy = Mtx::create(this->exec);
 
-    copy->copy_from(this->mtx.get());
+    copy->copy_from(this->mtx);
 
-    this->assert_equal_to_original_mtx(this->mtx.get());
+    this->assert_equal_to_original_mtx(this->mtx);
     this->mtx->get_values()[1] = 5.0;
-    this->assert_equal_to_original_mtx(copy.get());
+    this->assert_equal_to_original_mtx(copy);
 }
 
 
@@ -190,7 +190,7 @@ TYPED_TEST(Ell, CanBeMoved)
 
     copy->copy_from(std::move(this->mtx));
 
-    this->assert_equal_to_original_mtx(copy.get());
+    this->assert_equal_to_original_mtx(copy);
 }
 
 
@@ -199,7 +199,7 @@ TYPED_TEST(Ell, CanBeCloned)
     using Mtx = typename TestFixture::Mtx;
     auto clone = this->mtx->clone();
 
-    this->assert_equal_to_original_mtx(this->mtx.get());
+    this->assert_equal_to_original_mtx(this->mtx);
     this->mtx->get_values()[1] = 5.0;
     this->assert_equal_to_original_mtx(static_cast<Mtx*>(clone.get()));
 }
@@ -221,7 +221,7 @@ TYPED_TEST(Ell, CanBeReadFromMatrixData)
         {{2, 3},
          {{0, 0, 1.0}, {0, 1, 3.0}, {0, 2, 2.0}, {1, 0, 0.0}, {1, 1, 5.0}}});
 
-    this->assert_equal_to_original_mtx(m.get());
+    this->assert_equal_to_original_mtx(m);
 }
 
 
@@ -259,5 +259,5 @@ TYPED_TEST(Ell, CanBeReadFromMatrixAssemblyData)
 
     m->read(data);
 
-    this->assert_equal_to_original_mtx(m.get());
+    this->assert_equal_to_original_mtx(m);
 }

--- a/core/test/matrix/ell.cpp
+++ b/core/test/matrix/ell.cpp
@@ -188,7 +188,7 @@ TYPED_TEST(Ell, CanBeMoved)
     using Mtx = typename TestFixture::Mtx;
     auto copy = Mtx::create(this->exec);
 
-    copy->copy_from(std::move(this->mtx));
+    copy->move_from(this->mtx);
 
     this->assert_equal_to_original_mtx(copy);
 }

--- a/core/test/matrix/fbcsr.cpp
+++ b/core/test/matrix/fbcsr.cpp
@@ -76,8 +76,8 @@ protected:
     FbcsrSample() : ref(gko::ReferenceExecutor::create()) {}
 
     void assert_matrices_are_same(
-        gko::pointer_param<const gko::matrix::Fbcsr<value_type, index_type>> bm,
-        gko::pointer_param<const gko::matrix::Csr<value_type, index_type>> cm,
+        gko::ptr_param<const gko::matrix::Fbcsr<value_type, index_type>> bm,
+        gko::ptr_param<const gko::matrix::Csr<value_type, index_type>> cm,
         const gko::matrix::Diagonal<value_type>* const diam = nullptr,
         const gko::matrix_data<value_type, index_type>* const md = nullptr)
     {
@@ -275,7 +275,7 @@ protected:
     std::vector<index_type> orig_rowptrs;
     std::vector<index_type> orig_colinds;
 
-    void assert_equal_to_original_mtx(gko::pointer_param<const Mtx> m)
+    void assert_equal_to_original_mtx(gko::ptr_param<const Mtx> m)
     {
         auto v = m->get_const_values();
         auto c = m->get_const_col_idxs();

--- a/core/test/matrix/fbcsr.cpp
+++ b/core/test/matrix/fbcsr.cpp
@@ -444,7 +444,7 @@ TYPED_TEST(Fbcsr, CanBeMoved)
     using Mtx = typename TestFixture::Mtx;
     auto copy = Mtx::create(this->exec);
 
-    copy->copy_from(std::move(this->mtx));
+    copy->move_from(this->mtx);
 
     this->assert_equal_to_original_mtx(copy);
 }

--- a/core/test/matrix/fbcsr_builder.cpp
+++ b/core/test/matrix/fbcsr_builder.cpp
@@ -72,7 +72,7 @@ TYPED_TEST(FbcsrBuilder, ReturnsCorrectArrays)
 {
     using value_type = typename TestFixture::value_type;
     using index_type = typename TestFixture::index_type;
-    gko::matrix::FbcsrBuilder<value_type, index_type> builder{this->mtx.get()};
+    gko::matrix::FbcsrBuilder<value_type, index_type> builder{this->mtx};
 
     auto builder_col_idxs = builder.get_col_idx_array().get_data();
     auto builder_values = builder.get_value_array().get_data();

--- a/core/test/matrix/hybrid.cpp
+++ b/core/test/matrix/hybrid.cpp
@@ -172,7 +172,7 @@ TYPED_TEST(Hybrid, CanBeMoved)
     using Mtx = typename TestFixture::Mtx;
     auto copy = Mtx::create(this->exec);
 
-    copy->copy_from(std::move(this->mtx));
+    copy->move_from(this->mtx);
 
     this->assert_equal_to_original_mtx(copy);
 }

--- a/core/test/matrix/hybrid.cpp
+++ b/core/test/matrix/hybrid.cpp
@@ -88,7 +88,7 @@ protected:
     std::shared_ptr<const gko::Executor> exec;
     std::unique_ptr<Mtx> mtx;
 
-    void assert_equal_to_original_mtx(const Mtx* m)
+    void assert_equal_to_original_mtx(gko::pointer_param<const Mtx> m)
     {
         auto v = m->get_const_ell_values();
         auto c = m->get_const_ell_col_idxs();
@@ -112,7 +112,7 @@ protected:
         EXPECT_EQ(m->get_const_coo_row_idxs()[0], 0);
     }
 
-    void assert_empty(const Mtx* m)
+    void assert_empty(gko::pointer_param<const Mtx> m)
     {
         ASSERT_EQ(m->get_size(), gko::dim<2>(0, 0));
         ASSERT_EQ(m->get_ell_num_stored_elements(), 0);
@@ -141,7 +141,7 @@ TYPED_TEST(Hybrid, KnowsItsSize)
 
 TYPED_TEST(Hybrid, ContainsCorrectData)
 {
-    this->assert_equal_to_original_mtx(this->mtx.get());
+    this->assert_equal_to_original_mtx(this->mtx);
 }
 
 
@@ -159,11 +159,11 @@ TYPED_TEST(Hybrid, CanBeCopied)
     using Mtx = typename TestFixture::Mtx;
     auto copy = Mtx::create(this->exec);
 
-    copy->copy_from(this->mtx.get());
+    copy->copy_from(this->mtx);
 
-    this->assert_equal_to_original_mtx(this->mtx.get());
+    this->assert_equal_to_original_mtx(this->mtx);
     this->mtx->get_ell_values()[1] = 5.0;
-    this->assert_equal_to_original_mtx(copy.get());
+    this->assert_equal_to_original_mtx(copy);
 }
 
 
@@ -174,7 +174,7 @@ TYPED_TEST(Hybrid, CanBeMoved)
 
     copy->copy_from(std::move(this->mtx));
 
-    this->assert_equal_to_original_mtx(copy.get());
+    this->assert_equal_to_original_mtx(copy);
 }
 
 
@@ -183,7 +183,7 @@ TYPED_TEST(Hybrid, CanBeCloned)
     using Mtx = typename TestFixture::Mtx;
     auto clone = this->mtx->clone();
 
-    this->assert_equal_to_original_mtx(this->mtx.get());
+    this->assert_equal_to_original_mtx(this->mtx);
     this->mtx->get_ell_values()[1] = 5.0;
     this->assert_equal_to_original_mtx(static_cast<Mtx*>(clone.get()));
 }
@@ -237,7 +237,7 @@ TYPED_TEST(Hybrid, CanBeReadFromMatrixDataByColumns2)
                          std::make_shared<typename Mtx::column_limit>(2));
     m->read({{2, 3}, {{0, 0, 1.0}, {0, 1, 0.0}, {0, 2, 2.0}, {1, 1, 5.0}}});
 
-    this->assert_equal_to_original_mtx(m.get());
+    this->assert_equal_to_original_mtx(m);
 }
 
 
@@ -329,7 +329,7 @@ TYPED_TEST(Hybrid, CanBeReadFromMatrixAssemblyDataByColumns2)
 
     m->read(data);
 
-    this->assert_equal_to_original_mtx(m.get());
+    this->assert_equal_to_original_mtx(m);
 }
 
 

--- a/core/test/matrix/hybrid.cpp
+++ b/core/test/matrix/hybrid.cpp
@@ -88,7 +88,7 @@ protected:
     std::shared_ptr<const gko::Executor> exec;
     std::unique_ptr<Mtx> mtx;
 
-    void assert_equal_to_original_mtx(gko::pointer_param<const Mtx> m)
+    void assert_equal_to_original_mtx(gko::ptr_param<const Mtx> m)
     {
         auto v = m->get_const_ell_values();
         auto c = m->get_const_ell_col_idxs();
@@ -112,7 +112,7 @@ protected:
         EXPECT_EQ(m->get_const_coo_row_idxs()[0], 0);
     }
 
-    void assert_empty(gko::pointer_param<const Mtx> m)
+    void assert_empty(gko::ptr_param<const Mtx> m)
     {
         ASSERT_EQ(m->get_size(), gko::dim<2>(0, 0));
         ASSERT_EQ(m->get_ell_num_stored_elements(), 0);

--- a/core/test/matrix/permutation.cpp
+++ b/core/test/matrix/permutation.cpp
@@ -255,7 +255,7 @@ TYPED_TEST(Permutation, CanBeMoved)
     using i_type = typename TestFixture::i_type;
     auto mtx_copy = gko::matrix::Permutation<i_type>::create(this->exec);
 
-    mtx_copy->copy_from(std::move(this->mtx));
+    mtx_copy->move_from(this->mtx);
 
     this->assert_equal_to_original_mtx(mtx_copy);
 }

--- a/core/test/matrix/permutation.cpp
+++ b/core/test/matrix/permutation.cpp
@@ -65,7 +65,7 @@ protected:
 
 
     static void assert_equal_to_original_mtx(
-        gko::pointer_param<gko::matrix::Permutation<i_type>> m)
+        gko::ptr_param<gko::matrix::Permutation<i_type>> m)
     {
         auto perm = m->get_permutation();
         ASSERT_EQ(m->get_size(), gko::dim<2>(4, 3));

--- a/core/test/matrix/permutation.cpp
+++ b/core/test/matrix/permutation.cpp
@@ -65,7 +65,7 @@ protected:
 
 
     static void assert_equal_to_original_mtx(
-        gko::matrix::Permutation<i_type>* m)
+        gko::pointer_param<gko::matrix::Permutation<i_type>> m)
     {
         auto perm = m->get_permutation();
         ASSERT_EQ(m->get_size(), gko::dim<2>(4, 3));
@@ -233,7 +233,7 @@ TYPED_TEST(Permutation, PermutationThrowsforWrongColPermDimensions)
 
 TYPED_TEST(Permutation, KnowsItsSizeAndValues)
 {
-    this->assert_equal_to_original_mtx(this->mtx.get());
+    this->assert_equal_to_original_mtx(this->mtx);
 }
 
 
@@ -242,11 +242,11 @@ TYPED_TEST(Permutation, CanBeCopied)
     using i_type = typename TestFixture::i_type;
     auto mtx_copy = gko::matrix::Permutation<i_type>::create(this->exec);
 
-    mtx_copy->copy_from(this->mtx.get());
+    mtx_copy->copy_from(this->mtx);
 
-    this->assert_equal_to_original_mtx(this->mtx.get());
+    this->assert_equal_to_original_mtx(this->mtx);
     this->mtx->get_permutation()[0] = 3;
-    this->assert_equal_to_original_mtx(mtx_copy.get());
+    this->assert_equal_to_original_mtx(mtx_copy);
 }
 
 
@@ -257,7 +257,7 @@ TYPED_TEST(Permutation, CanBeMoved)
 
     mtx_copy->copy_from(std::move(this->mtx));
 
-    this->assert_equal_to_original_mtx(mtx_copy.get());
+    this->assert_equal_to_original_mtx(mtx_copy);
 }
 
 
@@ -266,7 +266,7 @@ TYPED_TEST(Permutation, CopyingPreservesMask)
     using i_type = typename TestFixture::i_type;
     auto mtx_copy = gko::matrix::Permutation<i_type>::create(this->exec);
 
-    mtx_copy->copy_from(this->mtx.get());
+    mtx_copy->copy_from(this->mtx);
 
     auto o_mask = this->mtx->get_permute_mask();
     auto n_mask = mtx_copy->get_permute_mask();
@@ -280,7 +280,7 @@ TYPED_TEST(Permutation, CopyingPreservesMask)
     ASSERT_EQ(o_mask, gko::matrix::column_permute);
     ASSERT_NE(o_mask, n_mask);
 
-    mtx_copy->copy_from(this->mtx.get());
+    mtx_copy->copy_from(this->mtx);
 
     n_mask = mtx_copy->get_permute_mask();
     ASSERT_EQ(o_mask, n_mask);

--- a/core/test/matrix/row_gatherer.cpp
+++ b/core/test/matrix/row_gatherer.cpp
@@ -75,7 +75,7 @@ protected:
 
 
     static void assert_equal_to_original_mtx(
-        const gko::matrix::RowGatherer<i_type>* m)
+        gko::pointer_param<const gko::matrix::RowGatherer<i_type>> m)
     {
         auto gather = m->get_const_row_idxs();
         ASSERT_EQ(m->get_size(), gko::dim<2>(4, 3));
@@ -147,7 +147,7 @@ TYPED_TEST(RowGatherer, RowGathererThrowsforWrongRowPermDimensions)
 
 TYPED_TEST(RowGatherer, KnowsItsSizeAndValues)
 {
-    this->assert_equal_to_original_mtx(this->mtx.get());
+    this->assert_equal_to_original_mtx(this->mtx);
 }
 
 
@@ -160,7 +160,7 @@ TYPED_TEST(RowGatherer, CanBeCreatedFromExistingConstData)
         this->exec, gko::dim<2>{4, 3},
         gko::array<i_type>::const_view(this->exec, 4, row_idxs));
 
-    this->assert_equal_to_original_mtx(const_mtx.get());
+    this->assert_equal_to_original_mtx(const_mtx);
 }
 
 
@@ -169,11 +169,11 @@ TYPED_TEST(RowGatherer, CanBeCopied)
     using i_type = typename TestFixture::i_type;
     auto mtx_copy = gko::matrix::RowGatherer<i_type>::create(this->exec);
 
-    mtx_copy->copy_from(this->mtx.get());
+    mtx_copy->copy_from(this->mtx);
 
-    this->assert_equal_to_original_mtx(this->mtx.get());
+    this->assert_equal_to_original_mtx(this->mtx);
     this->mtx->get_row_idxs()[0] = 3;
-    this->assert_equal_to_original_mtx(mtx_copy.get());
+    this->assert_equal_to_original_mtx(mtx_copy);
 }
 
 
@@ -184,7 +184,7 @@ TYPED_TEST(RowGatherer, CanBeMoved)
 
     mtx_copy->copy_from(std::move(this->mtx));
 
-    this->assert_equal_to_original_mtx(mtx_copy.get());
+    this->assert_equal_to_original_mtx(mtx_copy);
 }
 
 
@@ -208,7 +208,7 @@ TYPED_TEST(RowGatherer, CanBeCleared)
 TYPED_TEST(RowGatherer, CanRowGatherMixed)
 {
     using o_type = typename TestFixture::o_type;
-    this->mtx->apply(this->in.get(), this->out.get());
+    this->mtx->apply(this->in, this->out);
 
     GKO_ASSERT_MTX_NEAR(this->out,
                         l<o_type>({{0.0, -2.0, 1.0},
@@ -228,7 +228,7 @@ TYPED_TEST(RowGatherer, CanAdvancedRowGatherMixed)
     auto alpha = gko::initialize<Vec>({2.0}, this->exec);
     auto beta = gko::initialize<Vec>({-1.0}, this->exec);
 
-    this->mtx->apply(alpha.get(), this->in.get(), beta.get(), this->out.get());
+    this->mtx->apply(alpha, this->in, beta, this->out);
 
     GKO_ASSERT_MTX_NEAR(this->out,
                         l<o_type>({{0.0, -3.0, 1.0},

--- a/core/test/matrix/row_gatherer.cpp
+++ b/core/test/matrix/row_gatherer.cpp
@@ -75,7 +75,7 @@ protected:
 
 
     static void assert_equal_to_original_mtx(
-        gko::pointer_param<const gko::matrix::RowGatherer<i_type>> m)
+        gko::ptr_param<const gko::matrix::RowGatherer<i_type>> m)
     {
         auto gather = m->get_const_row_idxs();
         ASSERT_EQ(m->get_size(), gko::dim<2>(4, 3));

--- a/core/test/matrix/row_gatherer.cpp
+++ b/core/test/matrix/row_gatherer.cpp
@@ -182,7 +182,7 @@ TYPED_TEST(RowGatherer, CanBeMoved)
     using i_type = typename TestFixture::i_type;
     auto mtx_copy = gko::matrix::RowGatherer<i_type>::create(this->exec);
 
-    mtx_copy->copy_from(std::move(this->mtx));
+    mtx_copy->move_from(this->mtx);
 
     this->assert_equal_to_original_mtx(mtx_copy);
 }

--- a/core/test/matrix/sellp.cpp
+++ b/core/test/matrix/sellp.cpp
@@ -62,7 +62,7 @@ protected:
     std::shared_ptr<const gko::Executor> exec;
     std::unique_ptr<Mtx> mtx;
 
-    void assert_equal_to_original_mtx(gko::pointer_param<const Mtx> m)
+    void assert_equal_to_original_mtx(gko::ptr_param<const Mtx> m)
     {
         auto v = m->get_const_values();
         auto c = m->get_const_col_idxs();

--- a/core/test/matrix/sellp.cpp
+++ b/core/test/matrix/sellp.cpp
@@ -197,7 +197,7 @@ TYPED_TEST(Sellp, CanBeMoved)
     using Mtx = typename TestFixture::Mtx;
     auto copy = Mtx::create(this->exec);
 
-    copy->copy_from(std::move(this->mtx));
+    copy->move_from(this->mtx);
 
     this->assert_equal_to_original_mtx(copy);
 }

--- a/core/test/matrix/sellp.cpp
+++ b/core/test/matrix/sellp.cpp
@@ -62,7 +62,7 @@ protected:
     std::shared_ptr<const gko::Executor> exec;
     std::unique_ptr<Mtx> mtx;
 
-    void assert_equal_to_original_mtx(const Mtx* m)
+    void assert_equal_to_original_mtx(gko::pointer_param<const Mtx> m)
     {
         auto v = m->get_const_values();
         auto c = m->get_const_col_idxs();
@@ -153,7 +153,7 @@ TYPED_TEST(Sellp, KnowsItsSize)
 
 TYPED_TEST(Sellp, ContainsCorrectData)
 {
-    this->assert_equal_to_original_mtx(this->mtx.get());
+    this->assert_equal_to_original_mtx(this->mtx);
 }
 
 
@@ -184,11 +184,11 @@ TYPED_TEST(Sellp, CanBeCopied)
     using Mtx = typename TestFixture::Mtx;
     auto copy = Mtx::create(this->exec);
 
-    copy->copy_from(this->mtx.get());
+    copy->copy_from(this->mtx);
 
-    this->assert_equal_to_original_mtx(this->mtx.get());
+    this->assert_equal_to_original_mtx(this->mtx);
     this->mtx->get_values()[1] = 5.0;
-    this->assert_equal_to_original_mtx(copy.get());
+    this->assert_equal_to_original_mtx(copy);
 }
 
 
@@ -199,7 +199,7 @@ TYPED_TEST(Sellp, CanBeMoved)
 
     copy->copy_from(std::move(this->mtx));
 
-    this->assert_equal_to_original_mtx(copy.get());
+    this->assert_equal_to_original_mtx(copy);
 }
 
 
@@ -208,7 +208,7 @@ TYPED_TEST(Sellp, CanBeCloned)
     using Mtx = typename TestFixture::Mtx;
     auto clone = this->mtx->clone();
 
-    this->assert_equal_to_original_mtx(this->mtx.get());
+    this->assert_equal_to_original_mtx(this->mtx);
     this->mtx->get_values()[1] = 5.0;
     this->assert_equal_to_original_mtx(dynamic_cast<Mtx*>(clone.get()));
 }
@@ -228,7 +228,7 @@ TYPED_TEST(Sellp, CanBeReadFromMatrixData)
     auto m = Mtx::create(this->exec);
     m->read({{2, 3}, {{0, 0, 1.0}, {0, 1, 0.0}, {0, 2, 2.0}, {1, 1, 5.0}}});
 
-    this->assert_equal_to_original_mtx(m.get());
+    this->assert_equal_to_original_mtx(m);
 }
 
 
@@ -275,7 +275,7 @@ TYPED_TEST(Sellp, CanBeReadFromMatrixAssemblyData)
 
     m->read(data);
 
-    this->assert_equal_to_original_mtx(m.get());
+    this->assert_equal_to_original_mtx(m);
 }
 
 

--- a/core/test/matrix/sparsity_csr.cpp
+++ b/core/test/matrix/sparsity_csr.cpp
@@ -201,7 +201,7 @@ TYPED_TEST(SparsityCsr, CanBeMoved)
     using Mtx = typename TestFixture::Mtx;
     auto copy = Mtx::create(this->exec);
 
-    copy->copy_from(std::move(this->mtx));
+    copy->move_from(this->mtx);
 
     this->assert_equal_to_original_mtx(copy);
 }

--- a/core/test/matrix/sparsity_csr.cpp
+++ b/core/test/matrix/sparsity_csr.cpp
@@ -77,7 +77,7 @@ protected:
     std::shared_ptr<const gko::Executor> exec;
     std::unique_ptr<Mtx> mtx;
 
-    void assert_equal_to_original_mtx(gko::pointer_param<const Mtx> m)
+    void assert_equal_to_original_mtx(gko::ptr_param<const Mtx> m)
     {
         auto c = m->get_const_col_idxs();
         auto r = m->get_const_row_ptrs();

--- a/core/test/matrix/sparsity_csr.cpp
+++ b/core/test/matrix/sparsity_csr.cpp
@@ -77,7 +77,7 @@ protected:
     std::shared_ptr<const gko::Executor> exec;
     std::unique_ptr<Mtx> mtx;
 
-    void assert_equal_to_original_mtx(const Mtx* m)
+    void assert_equal_to_original_mtx(gko::pointer_param<const Mtx> m)
     {
         auto c = m->get_const_col_idxs();
         auto r = m->get_const_row_ptrs();
@@ -120,7 +120,7 @@ TYPED_TEST(SparsityCsr, KnowsItsSize)
 
 TYPED_TEST(SparsityCsr, ContainsCorrectData)
 {
-    this->assert_equal_to_original_mtx(this->mtx.get());
+    this->assert_equal_to_original_mtx(this->mtx);
 }
 
 
@@ -189,10 +189,10 @@ TYPED_TEST(SparsityCsr, CanBeCopied)
     using Mtx = typename TestFixture::Mtx;
     auto copy = Mtx::create(this->exec);
 
-    copy->copy_from(this->mtx.get());
+    copy->copy_from(this->mtx);
 
-    this->assert_equal_to_original_mtx(this->mtx.get());
-    this->assert_equal_to_original_mtx(copy.get());
+    this->assert_equal_to_original_mtx(this->mtx);
+    this->assert_equal_to_original_mtx(copy);
 }
 
 
@@ -203,7 +203,7 @@ TYPED_TEST(SparsityCsr, CanBeMoved)
 
     copy->copy_from(std::move(this->mtx));
 
-    this->assert_equal_to_original_mtx(copy.get());
+    this->assert_equal_to_original_mtx(copy);
 }
 
 
@@ -212,7 +212,7 @@ TYPED_TEST(SparsityCsr, CanBeCloned)
     using Mtx = typename TestFixture::Mtx;
     auto clone = this->mtx->clone();
 
-    this->assert_equal_to_original_mtx(this->mtx.get());
+    this->assert_equal_to_original_mtx(this->mtx);
     this->assert_equal_to_original_mtx(dynamic_cast<Mtx*>(clone.get()));
 }
 
@@ -232,7 +232,7 @@ TYPED_TEST(SparsityCsr, CanBeReadFromMatrixData)
 
     m->read({{2, 3}, {{0, 0, 1.0}, {0, 1, 3.0}, {0, 2, 2.0}, {1, 1, 5.0}}});
 
-    this->assert_equal_to_original_mtx(m.get());
+    this->assert_equal_to_original_mtx(m);
 }
 
 

--- a/core/test/mpi/base/polymorphic_object.cpp
+++ b/core/test/mpi/base/polymorphic_object.cpp
@@ -244,7 +244,7 @@ TEST_F(EnableDistributedPolymorphicObject, CopiesObject)
 {
     auto copy = DummyDistributedObject::create(omp, comm, 7);
 
-    copy->copy_from(gko::lend(obj));
+    copy->copy_from(obj);
 
     ASSERT_NE(copy, obj);
     ASSERT_EQ(copy->get_executor(), omp);
@@ -261,7 +261,7 @@ TEST_F(EnableDistributedPolymorphicObject, CopiesObjectIsLogged)
     auto copy = DummyDistributedObject::create(omp, comm, 7);
     copy->add_logger(logger);
 
-    copy->copy_from(gko::lend(obj));
+    copy->copy_from(obj);
 
     ASSERT_EQ(logger->copy_started, before_logger.copy_started + 1);
     ASSERT_EQ(logger->copy_completed, before_logger.copy_completed + 1);
@@ -299,7 +299,7 @@ TEST_F(EnableDistributedPolymorphicObject, MovesObject)
 {
     auto copy = DummyDistributedObject::create(ref, comm, 7);
 
-    copy->move_from(gko::lend(obj));
+    copy->move_from(obj);
 
     ASSERT_NE(copy, obj);
     ASSERT_EQ(copy->get_executor(), ref);
@@ -316,7 +316,7 @@ TEST_F(EnableDistributedPolymorphicObject, MovesObjectIsLogged)
     auto copy = DummyDistributedObject::create(ref, comm, 7);
     copy->add_logger(logger);
 
-    copy->move_from(gko::lend(obj));
+    copy->move_from(obj);
 
     ASSERT_EQ(logger->move_started, before_logger.move_started + 1);
     ASSERT_EQ(logger->move_completed, before_logger.move_completed + 1);

--- a/core/test/mpi/base/polymorphic_object.cpp
+++ b/core/test/mpi/base/polymorphic_object.cpp
@@ -268,33 +268,6 @@ TEST_F(EnableDistributedPolymorphicObject, CopiesObjectIsLogged)
 }
 
 
-TEST_F(EnableDistributedPolymorphicObject, MovesObjectByCopyFromUniquePtr)
-{
-    auto copy = DummyDistributedObject::create(ref, comm, 7);
-
-    copy->copy_from(gko::give(obj));
-
-    ASSERT_NE(copy, obj);
-    ASSERT_EQ(copy->get_executor(), ref);
-    ASSERT_EQ(copy->x, 5);
-    ASSERT_EQ(copy->get_communicator().get(), comm.get());
-}
-
-
-TEST_F(EnableDistributedPolymorphicObject,
-       MovesObjectByCopyFromUniquePtrIsLogged)
-{
-    auto before_logger = *this->logger;
-    auto copy = DummyDistributedObject::create(ref, comm, 7);
-    copy->add_logger(logger);
-
-    copy->copy_from(gko::give(obj));
-
-    ASSERT_EQ(logger->move_started, before_logger.move_started + 1);
-    ASSERT_EQ(logger->move_completed, before_logger.move_completed + 1);
-}
-
-
 TEST_F(EnableDistributedPolymorphicObject, MovesObject)
 {
     auto copy = DummyDistributedObject::create(ref, comm, 7);
@@ -317,32 +290,6 @@ TEST_F(EnableDistributedPolymorphicObject, MovesObjectIsLogged)
     copy->add_logger(logger);
 
     copy->move_from(obj);
-
-    ASSERT_EQ(logger->move_started, before_logger.move_started + 1);
-    ASSERT_EQ(logger->move_completed, before_logger.move_completed + 1);
-}
-
-
-TEST_F(EnableDistributedPolymorphicObject, MovesFromUniquePtr)
-{
-    auto copy = DummyDistributedObject::create(ref, comm, 7);
-
-    copy->copy_from(gko::give(obj));
-
-    ASSERT_NE(copy, obj);
-    ASSERT_EQ(copy->get_executor(), ref);
-    ASSERT_EQ(copy->x, 5);
-    ASSERT_EQ(copy->get_communicator().get(), comm.get());
-}
-
-
-TEST_F(EnableDistributedPolymorphicObject, MovesFromUniquePtrIsLogged)
-{
-    auto before_logger = *this->logger;
-    auto copy = DummyDistributedObject::create(ref, comm, 7);
-    copy->add_logger(logger);
-
-    copy->copy_from(gko::give(obj));
 
     ASSERT_EQ(logger->move_started, before_logger.move_started + 1);
     ASSERT_EQ(logger->move_completed, before_logger.move_completed + 1);

--- a/core/test/mpi/base/polymorphic_object.cpp
+++ b/core/test/mpi/base/polymorphic_object.cpp
@@ -171,7 +171,7 @@ protected:
     void TearDown() override
     {
         if (obj) {
-            obj->remove_logger(logger.get());
+            obj->remove_logger(logger);
         }
     }
 };

--- a/core/test/mpi/distributed/matrix.cpp
+++ b/core/test/mpi/distributed/matrix.cpp
@@ -122,7 +122,7 @@ protected:
             f(gko::with_matrix_type<Csr>(strategy),
               ConcreteCsr::create(this->ref, strategy),
               [](gko::pointer_param<const gko::LinOp> local_mat) {
-                  auto local_csr = gko::as<ConcreteCsr>(local_mat.get());
+                  auto local_csr = gko::as<ConcreteCsr>(local_mat);
 
                   ASSERT_NO_THROW(gko::as<typename ConcreteCsr::classical>(
                       local_csr->get_strategy()));
@@ -145,8 +145,7 @@ protected:
               Fbcsr<value_type, local_index_type>::create(this->ref, 5),
               [](gko::pointer_param<const gko::LinOp> local_mat) {
                   auto local_fbcsr =
-                      gko::as<Fbcsr<value_type, local_index_type>>(
-                          local_mat.get());
+                      gko::as<Fbcsr<value_type, local_index_type>>(local_mat);
 
                   ASSERT_EQ(local_fbcsr->get_block_size(), 5);
               });
@@ -165,7 +164,7 @@ protected:
             f(gko::with_matrix_type<Hybrid>(strategy),
               Concrete::create(this->ref, strategy),
               [](gko::pointer_param<const gko::LinOp> local_mat) {
-                  auto local_hy = gko::as<Concrete>(local_mat.get());
+                  auto local_hy = gko::as<Concrete>(local_mat);
 
                   ASSERT_NO_THROW(gko::as<typename Concrete::column_limit>(
                       local_hy->get_strategy()));

--- a/core/test/mpi/distributed/matrix.cpp
+++ b/core/test/mpi/distributed/matrix.cpp
@@ -104,7 +104,7 @@ protected:
     void forall_matrix_types(F&& f)
     {
         using namespace gko::matrix;
-        auto empty_test = [](const gko::LinOp*) {};
+        auto empty_test = [](gko::pointer_param<const gko::LinOp>) {};
         {
             SCOPED_TRACE("With Coo");
             f(gko::with_matrix_type<Coo>(),
@@ -121,8 +121,8 @@ protected:
             auto strategy = std::make_shared<typename ConcreteCsr::classical>();
             f(gko::with_matrix_type<Csr>(strategy),
               ConcreteCsr::create(this->ref, strategy),
-              [](const gko::LinOp* local_mat) {
-                  auto local_csr = gko::as<ConcreteCsr>(local_mat);
+              [](gko::pointer_param<const gko::LinOp> local_mat) {
+                  auto local_csr = gko::as<ConcreteCsr>(local_mat.get());
 
                   ASSERT_NO_THROW(gko::as<typename ConcreteCsr::classical>(
                       local_csr->get_strategy()));
@@ -143,9 +143,10 @@ protected:
             SCOPED_TRACE("With Fbcsr with block_size");
             f(gko::with_matrix_type<Fbcsr>(5),
               Fbcsr<value_type, local_index_type>::create(this->ref, 5),
-              [](const gko::LinOp* local_mat) {
+              [](gko::pointer_param<const gko::LinOp> local_mat) {
                   auto local_fbcsr =
-                      gko::as<Fbcsr<value_type, local_index_type>>(local_mat);
+                      gko::as<Fbcsr<value_type, local_index_type>>(
+                          local_mat.get());
 
                   ASSERT_EQ(local_fbcsr->get_block_size(), 5);
               });
@@ -163,8 +164,8 @@ protected:
                 std::make_shared<typename Concrete::column_limit>(11);
             f(gko::with_matrix_type<Hybrid>(strategy),
               Concrete::create(this->ref, strategy),
-              [](const gko::LinOp* local_mat) {
-                  auto local_hy = gko::as<Concrete>(local_mat);
+              [](gko::pointer_param<const gko::LinOp> local_mat) {
+                  auto local_hy = gko::as<Concrete>(local_mat.get());
 
                   ASSERT_NO_THROW(gko::as<typename Concrete::column_limit>(
                       local_hy->get_strategy()));
@@ -183,9 +184,9 @@ protected:
     }
 
     template <typename LocalMatrixType, typename NonLocalMatrixType>
-    void expected_interface_no_throw(dist_mtx_type* mat,
-                                     LocalMatrixType local_matrix_type,
-                                     NonLocalMatrixType non_local_matrix_type)
+    void expected_interface_no_throw(gko::pointer_param<dist_mtx_type> mat,
+                                     LocalMatrixType&& local_matrix_type,
+                                     NonLocalMatrixType&& non_local_matrix_type)
     {
         auto num_rows = mat->get_size()[0];
         auto a = dist_vec_type::create(ref, comm);
@@ -195,9 +196,9 @@ protected:
         auto move_result = dist_mtx_type::create(ref, comm, local_matrix_type,
                                                  non_local_matrix_type);
 
-        ASSERT_NO_THROW(mat->apply(a.get(), b.get()));
-        ASSERT_NO_THROW(mat->convert_to(convert_result.get()));
-        ASSERT_NO_THROW(mat->move_to(move_result.get()));
+        ASSERT_NO_THROW(mat->apply(a, b));
+        ASSERT_NO_THROW(mat->convert_to(convert_result));
+        ASSERT_NO_THROW(mat->move_to(move_result));
     }
 
 
@@ -223,9 +224,9 @@ TYPED_TEST(MatrixBuilder, BuildWithLocal)
             dist_mat_type ::create(this->ref, this->comm, with_matrix_type);
 
         ASSERT_NO_THROW(gko::as<expected_type>(mat->get_local_matrix()));
-        additional_test(mat->get_local_matrix().get());
-        additional_test(mat->get_non_local_matrix().get());
-        this->expected_interface_no_throw(mat.get(), with_matrix_type,
+        additional_test(mat->get_local_matrix());
+        additional_test(mat->get_non_local_matrix());
+        this->expected_interface_no_throw(mat, with_matrix_type,
                                           with_matrix_type);
     });
 }
@@ -256,9 +257,9 @@ TYPED_TEST(MatrixBuilder, BuildWithLocalAndNonLocal)
                 gko::as<expected_local_type>(mat->get_local_matrix()));
             ASSERT_NO_THROW(
                 gko::as<expected_non_local_type>(mat->get_non_local_matrix()));
-            additional_local_test(mat->get_local_matrix().get());
-            additional_non_local_test(mat->get_non_local_matrix().get());
-            this->expected_interface_no_throw(mat.get(), with_local_matrix_type,
+            additional_local_test(mat->get_local_matrix());
+            additional_non_local_test(mat->get_non_local_matrix());
+            this->expected_interface_no_throw(mat, with_local_matrix_type,
                                               with_non_local_matrix_type);
         });
     });
@@ -276,8 +277,7 @@ TYPED_TEST(MatrixBuilder, BuildWithCustomLinOp)
                                      gko::with_matrix_type<CustomLinOp>());
 
     ASSERT_NO_THROW(gko::as<custom_type>(mat->get_local_matrix()));
-    this->expected_interface_no_throw(mat.get(),
-                                      gko::with_matrix_type<CustomLinOp>(),
+    this->expected_interface_no_throw(mat, gko::with_matrix_type<CustomLinOp>(),
                                       gko::with_matrix_type<CustomLinOp>());
 }
 
@@ -293,13 +293,13 @@ TYPED_TEST(MatrixBuilder, BuildFromLinOpLocal)
         using expected_type = typename std::remove_pointer<decltype(
             expected_type_ptr.get())>::type;
 
-        auto mat = dist_mat_type ::create(this->ref, this->comm,
-                                          expected_type_ptr.get());
+        auto mat =
+            dist_mat_type ::create(this->ref, this->comm, expected_type_ptr);
 
         ASSERT_NO_THROW(gko::as<expected_type>(mat->get_local_matrix()));
-        additional_test(mat->get_local_matrix().get());
-        additional_test(mat->get_non_local_matrix().get());
-        this->expected_interface_no_throw(mat.get(), with_matrix_type,
+        additional_test(mat->get_local_matrix());
+        additional_test(mat->get_non_local_matrix());
+        this->expected_interface_no_throw(mat, with_matrix_type,
                                           with_matrix_type);
     });
 }
@@ -322,17 +322,17 @@ TYPED_TEST(MatrixBuilder, BuildFromLinOpLocalAndNonLocal)
                 typename std::remove_pointer<decltype(
                     expected_non_local_type_ptr.get())>::type;
 
-            auto mat = dist_mat_type ::create(
-                this->ref, this->comm, expected_local_type_ptr.get(),
-                expected_non_local_type_ptr.get());
+            auto mat = dist_mat_type ::create(this->ref, this->comm,
+                                              expected_local_type_ptr,
+                                              expected_non_local_type_ptr);
 
             ASSERT_NO_THROW(
                 gko::as<expected_local_type>(mat->get_local_matrix()));
             ASSERT_NO_THROW(
                 gko::as<expected_non_local_type>(mat->get_non_local_matrix()));
-            additional_local_test(mat->get_local_matrix().get());
-            additional_non_local_test(mat->get_non_local_matrix().get());
-            this->expected_interface_no_throw(mat.get(), with_local_matrix_type,
+            additional_local_test(mat->get_local_matrix());
+            additional_non_local_test(mat->get_non_local_matrix());
+            this->expected_interface_no_throw(mat, with_local_matrix_type,
                                               with_non_local_matrix_type);
         });
     });

--- a/core/test/mpi/distributed/matrix.cpp
+++ b/core/test/mpi/distributed/matrix.cpp
@@ -104,7 +104,7 @@ protected:
     void forall_matrix_types(F&& f)
     {
         using namespace gko::matrix;
-        auto empty_test = [](gko::pointer_param<const gko::LinOp>) {};
+        auto empty_test = [](gko::ptr_param<const gko::LinOp>) {};
         {
             SCOPED_TRACE("With Coo");
             f(gko::with_matrix_type<Coo>(),
@@ -121,7 +121,7 @@ protected:
             auto strategy = std::make_shared<typename ConcreteCsr::classical>();
             f(gko::with_matrix_type<Csr>(strategy),
               ConcreteCsr::create(this->ref, strategy),
-              [](gko::pointer_param<const gko::LinOp> local_mat) {
+              [](gko::ptr_param<const gko::LinOp> local_mat) {
                   auto local_csr = gko::as<ConcreteCsr>(local_mat);
 
                   ASSERT_NO_THROW(gko::as<typename ConcreteCsr::classical>(
@@ -143,7 +143,7 @@ protected:
             SCOPED_TRACE("With Fbcsr with block_size");
             f(gko::with_matrix_type<Fbcsr>(5),
               Fbcsr<value_type, local_index_type>::create(this->ref, 5),
-              [](gko::pointer_param<const gko::LinOp> local_mat) {
+              [](gko::ptr_param<const gko::LinOp> local_mat) {
                   auto local_fbcsr =
                       gko::as<Fbcsr<value_type, local_index_type>>(local_mat);
 
@@ -163,7 +163,7 @@ protected:
                 std::make_shared<typename Concrete::column_limit>(11);
             f(gko::with_matrix_type<Hybrid>(strategy),
               Concrete::create(this->ref, strategy),
-              [](gko::pointer_param<const gko::LinOp> local_mat) {
+              [](gko::ptr_param<const gko::LinOp> local_mat) {
                   auto local_hy = gko::as<Concrete>(local_mat);
 
                   ASSERT_NO_THROW(gko::as<typename Concrete::column_limit>(
@@ -183,7 +183,7 @@ protected:
     }
 
     template <typename LocalMatrixType, typename NonLocalMatrixType>
-    void expected_interface_no_throw(gko::pointer_param<dist_mtx_type> mat,
+    void expected_interface_no_throw(gko::ptr_param<dist_mtx_type> mat,
                                      LocalMatrixType&& local_matrix_type,
                                      NonLocalMatrixType&& non_local_matrix_type)
     {

--- a/core/test/solver/bicg.cpp
+++ b/core/test/solver/bicg.cpp
@@ -110,8 +110,7 @@ TYPED_TEST(Bicg, CanBeCopied)
 
     ASSERT_EQ(copy->get_size(), gko::dim<2>(3, 3));
     auto copy_mtx = static_cast<Solver*>(copy.get())->get_system_matrix();
-    GKO_ASSERT_MTX_NEAR(static_cast<const Mtx*>(copy_mtx.get()), this->mtx,
-                        0.0);
+    GKO_ASSERT_MTX_NEAR(gko::as<Mtx>(copy_mtx), this->mtx, 0.0);
 }
 
 
@@ -125,8 +124,7 @@ TYPED_TEST(Bicg, CanBeMoved)
 
     ASSERT_EQ(copy->get_size(), gko::dim<2>(3, 3));
     auto copy_mtx = static_cast<Solver*>(copy.get())->get_system_matrix();
-    GKO_ASSERT_MTX_NEAR(static_cast<const Mtx*>(copy_mtx.get()), this->mtx,
-                        0.0);
+    GKO_ASSERT_MTX_NEAR(gko::as<Mtx>(copy_mtx), this->mtx, 0.0);
 }
 
 
@@ -138,8 +136,7 @@ TYPED_TEST(Bicg, CanBeCloned)
 
     ASSERT_EQ(clone->get_size(), gko::dim<2>(3, 3));
     auto clone_mtx = static_cast<Solver*>(clone.get())->get_system_matrix();
-    GKO_ASSERT_MTX_NEAR(static_cast<const Mtx*>(clone_mtx.get()), this->mtx,
-                        0.0);
+    GKO_ASSERT_MTX_NEAR(gko::as<Mtx>(clone_mtx), this->mtx, 0.0);
 }
 
 

--- a/core/test/solver/bicg.cpp
+++ b/core/test/solver/bicg.cpp
@@ -121,7 +121,7 @@ TYPED_TEST(Bicg, CanBeMoved)
     using Solver = typename TestFixture::Solver;
     auto copy = this->bicg_factory->generate(Mtx::create(this->exec));
 
-    copy->copy_from(std::move(this->solver));
+    copy->move_from(this->solver);
 
     ASSERT_EQ(copy->get_size(), gko::dim<2>(3, 3));
     auto copy_mtx = static_cast<Solver*>(copy.get())->get_system_matrix();

--- a/core/test/solver/bicg.cpp
+++ b/core/test/solver/bicg.cpp
@@ -78,17 +78,6 @@ protected:
     std::shared_ptr<Mtx> mtx;
     std::unique_ptr<typename Solver::Factory> bicg_factory;
     std::unique_ptr<gko::LinOp> solver;
-
-    static void assert_same_matrices(const Mtx* m1, const Mtx* m2)
-    {
-        ASSERT_EQ(m1->get_size()[0], m2->get_size()[0]);
-        ASSERT_EQ(m1->get_size()[1], m2->get_size()[1]);
-        for (gko::size_type i = 0; i < m1->get_size()[0]; ++i) {
-            for (gko::size_type j = 0; j < m2->get_size()[1]; ++j) {
-                EXPECT_EQ(m1->at(i, j), m2->at(i, j));
-            }
-        }
-    }
 };
 
 TYPED_TEST_SUITE(Bicg, gko::test::ValueTypes, TypenameNameGenerator);
@@ -117,12 +106,12 @@ TYPED_TEST(Bicg, CanBeCopied)
     using Solver = typename TestFixture::Solver;
     auto copy = this->bicg_factory->generate(Mtx::create(this->exec));
 
-    copy->copy_from(this->solver.get());
+    copy->copy_from(this->solver);
 
     ASSERT_EQ(copy->get_size(), gko::dim<2>(3, 3));
     auto copy_mtx = static_cast<Solver*>(copy.get())->get_system_matrix();
-    this->assert_same_matrices(static_cast<const Mtx*>(copy_mtx.get()),
-                               this->mtx.get());
+    GKO_ASSERT_MTX_NEAR(static_cast<const Mtx*>(copy_mtx.get()), this->mtx,
+                        0.0);
 }
 
 
@@ -136,8 +125,8 @@ TYPED_TEST(Bicg, CanBeMoved)
 
     ASSERT_EQ(copy->get_size(), gko::dim<2>(3, 3));
     auto copy_mtx = static_cast<Solver*>(copy.get())->get_system_matrix();
-    this->assert_same_matrices(static_cast<const Mtx*>(copy_mtx.get()),
-                               this->mtx.get());
+    GKO_ASSERT_MTX_NEAR(static_cast<const Mtx*>(copy_mtx.get()), this->mtx,
+                        0.0);
 }
 
 
@@ -149,8 +138,8 @@ TYPED_TEST(Bicg, CanBeCloned)
 
     ASSERT_EQ(clone->get_size(), gko::dim<2>(3, 3));
     auto clone_mtx = static_cast<Solver*>(clone.get())->get_system_matrix();
-    this->assert_same_matrices(static_cast<const Mtx*>(clone_mtx.get()),
-                               this->mtx.get());
+    GKO_ASSERT_MTX_NEAR(static_cast<const Mtx*>(clone_mtx.get()), this->mtx,
+                        0.0);
 }
 
 

--- a/core/test/solver/bicgstab.cpp
+++ b/core/test/solver/bicgstab.cpp
@@ -102,7 +102,7 @@ TYPED_TEST(Bicgstab, BicgstabFactoryCreatesCorrectSolver)
 {
     using Solver = typename TestFixture::Solver;
     ASSERT_EQ(this->solver->get_size(), gko::dim<2>(3, 3));
-    auto bicgstab_solver = static_cast<Solver*>(this->solver.get());
+    auto bicgstab_solver = gko::as<Solver>(this->solver.get());
     ASSERT_NE(bicgstab_solver->get_system_matrix(), nullptr);
     ASSERT_EQ(bicgstab_solver->get_system_matrix(), this->mtx);
 }
@@ -117,9 +117,8 @@ TYPED_TEST(Bicgstab, CanBeCopied)
     copy->copy_from(this->solver.get());
 
     ASSERT_EQ(copy->get_size(), gko::dim<2>(3, 3));
-    auto copy_mtx = static_cast<Solver*>(copy.get())->get_system_matrix();
-    this->assert_same_matrices(static_cast<const Mtx*>(copy_mtx.get()),
-                               this->mtx.get());
+    auto copy_mtx = gko::as<Solver>(copy.get())->get_system_matrix();
+    this->assert_same_matrices(gko::as<Mtx>(copy_mtx.get()), this->mtx.get());
 }
 
 
@@ -132,9 +131,8 @@ TYPED_TEST(Bicgstab, CanBeMoved)
     copy->copy_from(std::move(this->solver));
 
     ASSERT_EQ(copy->get_size(), gko::dim<2>(3, 3));
-    auto copy_mtx = static_cast<Solver*>(copy.get())->get_system_matrix();
-    this->assert_same_matrices(static_cast<const Mtx*>(copy_mtx.get()),
-                               this->mtx.get());
+    auto copy_mtx = gko::as<Solver>(copy.get())->get_system_matrix();
+    this->assert_same_matrices(gko::as<Mtx>(copy_mtx.get()), this->mtx.get());
 }
 
 
@@ -145,9 +143,8 @@ TYPED_TEST(Bicgstab, CanBeCloned)
     auto clone = this->solver->clone();
 
     ASSERT_EQ(clone->get_size(), gko::dim<2>(3, 3));
-    auto clone_mtx = static_cast<Solver*>(clone.get())->get_system_matrix();
-    this->assert_same_matrices(static_cast<const Mtx*>(clone_mtx.get()),
-                               this->mtx.get());
+    auto clone_mtx = gko::as<Solver>(clone.get())->get_system_matrix();
+    this->assert_same_matrices(gko::as<Mtx>(clone_mtx.get()), this->mtx.get());
 }
 
 
@@ -157,8 +154,7 @@ TYPED_TEST(Bicgstab, CanBeCleared)
     this->solver->clear();
 
     ASSERT_EQ(this->solver->get_size(), gko::dim<2>(0, 0));
-    auto solver_mtx =
-        static_cast<Solver*>(this->solver.get())->get_system_matrix();
+    auto solver_mtx = gko::as<Solver>(this->solver.get())->get_system_matrix();
     ASSERT_EQ(solver_mtx, nullptr);
 }
 
@@ -186,10 +182,9 @@ TYPED_TEST(Bicgstab, CanSetPreconditionerGenerator)
             .on(this->exec);
 
     auto solver = bicgstab_factory->generate(this->mtx);
-    auto precond = dynamic_cast<const gko::solver::Bicgstab<value_type>*>(
-        gko::lend(solver->get_preconditioner()));
+    auto precond = gko::as<gko::solver::Bicgstab<value_type>>(
+        solver->get_preconditioner());
 
-    ASSERT_NE(precond, nullptr);
     ASSERT_EQ(precond->get_size(), gko::dim<2>(3, 3));
     ASSERT_EQ(precond->get_system_matrix(), this->mtx);
 }
@@ -211,10 +206,9 @@ TYPED_TEST(Bicgstab, CanSetCriteriaAgain)
 
     solver->set_stop_criterion_factory(new_crit);
     auto new_crit_fac = solver->get_stop_criterion_factory();
-    auto niter =
-        static_cast<const gko::stop::Iteration::Factory*>(new_crit_fac.get())
-            ->get_parameters()
-            .max_iters;
+    auto niter = gko::as<gko::stop::Iteration::Factory>(new_crit_fac.get())
+                     ->get_parameters()
+                     .max_iters;
 
     ASSERT_EQ(niter, 5);
 }

--- a/core/test/solver/bicgstab.cpp
+++ b/core/test/solver/bicgstab.cpp
@@ -117,7 +117,7 @@ TYPED_TEST(Bicgstab, CanBeMoved)
     using Solver = typename TestFixture::Solver;
     auto copy = this->bicgstab_factory->generate(Mtx::create(this->exec));
 
-    copy->copy_from(std::move(this->solver));
+    copy->move_from(this->solver);
 
     ASSERT_EQ(copy->get_size(), gko::dim<2>(3, 3));
     auto copy_mtx = gko::as<Solver>(copy.get())->get_system_matrix();

--- a/core/test/solver/bicgstab.cpp
+++ b/core/test/solver/bicgstab.cpp
@@ -107,7 +107,7 @@ TYPED_TEST(Bicgstab, CanBeCopied)
 
     ASSERT_EQ(copy->get_size(), gko::dim<2>(3, 3));
     auto copy_mtx = gko::as<Solver>(copy.get())->get_system_matrix();
-    GKO_ASSERT_MTX_NEAR(gko::as<Mtx>(copy_mtx.get()), this->mtx, 0.0);
+    GKO_ASSERT_MTX_NEAR(gko::as<Mtx>(copy_mtx), this->mtx, 0.0);
 }
 
 
@@ -121,7 +121,7 @@ TYPED_TEST(Bicgstab, CanBeMoved)
 
     ASSERT_EQ(copy->get_size(), gko::dim<2>(3, 3));
     auto copy_mtx = gko::as<Solver>(copy.get())->get_system_matrix();
-    GKO_ASSERT_MTX_NEAR(gko::as<Mtx>(copy_mtx.get()), this->mtx, 0.0);
+    GKO_ASSERT_MTX_NEAR(gko::as<Mtx>(copy_mtx), this->mtx, 0.0);
 }
 
 
@@ -195,7 +195,7 @@ TYPED_TEST(Bicgstab, CanSetCriteriaAgain)
 
     solver->set_stop_criterion_factory(new_crit);
     auto new_crit_fac = solver->get_stop_criterion_factory();
-    auto niter = gko::as<gko::stop::Iteration::Factory>(new_crit_fac.get())
+    auto niter = gko::as<gko::stop::Iteration::Factory>(new_crit_fac)
                      ->get_parameters()
                      .max_iters;
 

--- a/core/test/solver/bicgstab.cpp
+++ b/core/test/solver/bicgstab.cpp
@@ -76,17 +76,6 @@ protected:
     std::shared_ptr<Mtx> mtx;
     std::unique_ptr<typename Solver::Factory> bicgstab_factory;
     std::unique_ptr<gko::LinOp> solver;
-
-    static void assert_same_matrices(const Mtx* m1, const Mtx* m2)
-    {
-        ASSERT_EQ(m1->get_size()[0], m2->get_size()[0]);
-        ASSERT_EQ(m1->get_size()[1], m2->get_size()[1]);
-        for (gko::size_type i = 0; i < m1->get_size()[0]; ++i) {
-            for (gko::size_type j = 0; j < m2->get_size()[1]; ++j) {
-                EXPECT_EQ(m1->at(i, j), m2->at(i, j));
-            }
-        }
-    }
 };
 
 TYPED_TEST_SUITE(Bicgstab, gko::test::ValueTypes, TypenameNameGenerator);
@@ -114,11 +103,11 @@ TYPED_TEST(Bicgstab, CanBeCopied)
     using Solver = typename TestFixture::Solver;
     auto copy = this->bicgstab_factory->generate(Mtx::create(this->exec));
 
-    copy->copy_from(this->solver.get());
+    copy->copy_from(this->solver);
 
     ASSERT_EQ(copy->get_size(), gko::dim<2>(3, 3));
     auto copy_mtx = gko::as<Solver>(copy.get())->get_system_matrix();
-    this->assert_same_matrices(gko::as<Mtx>(copy_mtx.get()), this->mtx.get());
+    GKO_ASSERT_MTX_NEAR(gko::as<Mtx>(copy_mtx.get()), this->mtx, 0.0);
 }
 
 
@@ -132,7 +121,7 @@ TYPED_TEST(Bicgstab, CanBeMoved)
 
     ASSERT_EQ(copy->get_size(), gko::dim<2>(3, 3));
     auto copy_mtx = gko::as<Solver>(copy.get())->get_system_matrix();
-    this->assert_same_matrices(gko::as<Mtx>(copy_mtx.get()), this->mtx.get());
+    GKO_ASSERT_MTX_NEAR(gko::as<Mtx>(copy_mtx.get()), this->mtx, 0.0);
 }
 
 
@@ -144,7 +133,7 @@ TYPED_TEST(Bicgstab, CanBeCloned)
 
     ASSERT_EQ(clone->get_size(), gko::dim<2>(3, 3));
     auto clone_mtx = gko::as<Solver>(clone.get())->get_system_matrix();
-    this->assert_same_matrices(gko::as<Mtx>(clone_mtx.get()), this->mtx.get());
+    GKO_ASSERT_MTX_NEAR(gko::as<Mtx>(clone_mtx.get()), this->mtx, 0.0);
 }
 
 

--- a/core/test/solver/cb_gmres.cpp
+++ b/core/test/solver/cb_gmres.cpp
@@ -167,8 +167,7 @@ TYPED_TEST(CbGmres, CanBeCopied)
 
     ASSERT_EQ(copy->get_size(), gko::dim<2>(3, 3));
     auto copy_mtx = r_copy->get_system_matrix();
-    GKO_ASSERT_MTX_NEAR(static_cast<const Mtx*>(copy_mtx.get()), this->mtx,
-                        0.0);
+    GKO_ASSERT_MTX_NEAR(gko::as<Mtx>(copy_mtx), this->mtx, 0.0);
     ASSERT_EQ(r_copy->get_storage_precision(),
               this->solver->get_storage_precision());
     ASSERT_EQ(r_copy->get_krylov_dim(), this->solver->get_krylov_dim());
@@ -186,8 +185,7 @@ TYPED_TEST(CbGmres, CanBeMoved)
 
     ASSERT_EQ(copy->get_size(), gko::dim<2>(3, 3));
     auto copy_mtx = r_copy->get_system_matrix();
-    GKO_ASSERT_MTX_NEAR(static_cast<const Mtx*>(copy_mtx.get()), this->mtx,
-                        0.0);
+    GKO_ASSERT_MTX_NEAR(gko::as<Mtx>(copy_mtx), this->mtx, 0.0);
     ASSERT_EQ(r_copy->get_storage_precision(), this->storage_precision);
     ASSERT_EQ(r_copy->get_krylov_dim(), 100u);
 }
@@ -202,8 +200,7 @@ TYPED_TEST(CbGmres, CanBeCloned)
 
     ASSERT_EQ(clone->get_size(), gko::dim<2>(3, 3));
     auto clone_mtx = r_clone->get_system_matrix();
-    GKO_ASSERT_MTX_NEAR(static_cast<const Mtx*>(clone_mtx.get()), this->mtx,
-                        0.0);
+    GKO_ASSERT_MTX_NEAR(gko::as<Mtx>(clone_mtx), this->mtx, 0.0);
     ASSERT_EQ(r_clone->get_storage_precision(),
               this->solver->get_storage_precision());
     ASSERT_EQ(r_clone->get_krylov_dim(), this->solver->get_krylov_dim());

--- a/core/test/solver/cb_gmres.cpp
+++ b/core/test/solver/cb_gmres.cpp
@@ -100,17 +100,6 @@ protected:
     std::unique_ptr<Solver> solver;
     std::unique_ptr<typename Solver::Factory> cb_gmres_big_factory;
     std::unique_ptr<Solver> big_solver;
-
-    static void assert_same_matrices(const Mtx* m1, const Mtx* m2)
-    {
-        ASSERT_EQ(m1->get_size()[0], m2->get_size()[0]);
-        ASSERT_EQ(m1->get_size()[1], m2->get_size()[1]);
-        for (gko::size_type i = 0; i < m1->get_size()[0]; ++i) {
-            for (gko::size_type j = 0; j < m2->get_size()[1]; ++j) {
-                EXPECT_EQ(m1->at(i, j), m2->at(i, j));
-            }
-        }
-    }
 };
 
 
@@ -174,12 +163,12 @@ TYPED_TEST(CbGmres, CanBeCopied)
     auto copy = this->cb_gmres_factory->generate(Mtx::create(this->exec));
     auto r_copy = static_cast<Solver*>(copy.get());
 
-    copy->copy_from(this->solver.get());
+    copy->copy_from(this->solver);
 
     ASSERT_EQ(copy->get_size(), gko::dim<2>(3, 3));
     auto copy_mtx = r_copy->get_system_matrix();
-    this->assert_same_matrices(static_cast<const Mtx*>(copy_mtx.get()),
-                               this->mtx.get());
+    GKO_ASSERT_MTX_NEAR(static_cast<const Mtx*>(copy_mtx.get()), this->mtx,
+                        0.0);
     ASSERT_EQ(r_copy->get_storage_precision(),
               this->solver->get_storage_precision());
     ASSERT_EQ(r_copy->get_krylov_dim(), this->solver->get_krylov_dim());
@@ -197,8 +186,8 @@ TYPED_TEST(CbGmres, CanBeMoved)
 
     ASSERT_EQ(copy->get_size(), gko::dim<2>(3, 3));
     auto copy_mtx = r_copy->get_system_matrix();
-    this->assert_same_matrices(static_cast<const Mtx*>(copy_mtx.get()),
-                               this->mtx.get());
+    GKO_ASSERT_MTX_NEAR(static_cast<const Mtx*>(copy_mtx.get()), this->mtx,
+                        0.0);
     ASSERT_EQ(r_copy->get_storage_precision(), this->storage_precision);
     ASSERT_EQ(r_copy->get_krylov_dim(), 100u);
 }
@@ -213,8 +202,8 @@ TYPED_TEST(CbGmres, CanBeCloned)
 
     ASSERT_EQ(clone->get_size(), gko::dim<2>(3, 3));
     auto clone_mtx = r_clone->get_system_matrix();
-    this->assert_same_matrices(static_cast<const Mtx*>(clone_mtx.get()),
-                               this->mtx.get());
+    GKO_ASSERT_MTX_NEAR(static_cast<const Mtx*>(clone_mtx.get()), this->mtx,
+                        0.0);
     ASSERT_EQ(r_clone->get_storage_precision(),
               this->solver->get_storage_precision());
     ASSERT_EQ(r_clone->get_krylov_dim(), this->solver->get_krylov_dim());

--- a/core/test/solver/cb_gmres.cpp
+++ b/core/test/solver/cb_gmres.cpp
@@ -182,7 +182,7 @@ TYPED_TEST(CbGmres, CanBeMoved)
     auto copy = this->cb_gmres_factory->generate(Mtx::create(this->exec));
     auto r_copy = static_cast<Solver*>(copy.get());
 
-    copy->copy_from(std::move(this->solver));
+    copy->move_from(this->solver);
 
     ASSERT_EQ(copy->get_size(), gko::dim<2>(3, 3));
     auto copy_mtx = r_copy->get_system_matrix();

--- a/core/test/solver/cg.cpp
+++ b/core/test/solver/cg.cpp
@@ -121,7 +121,7 @@ TYPED_TEST(Cg, CanBeMoved)
     using Solver = typename TestFixture::Solver;
     auto copy = this->cg_factory->generate(Mtx::create(this->exec));
 
-    copy->copy_from(std::move(this->solver));
+    copy->move_from(this->solver);
 
     ASSERT_EQ(copy->get_size(), gko::dim<2>(3, 3));
     auto copy_mtx = static_cast<Solver*>(copy.get())->get_system_matrix();

--- a/core/test/solver/cg.cpp
+++ b/core/test/solver/cg.cpp
@@ -110,8 +110,7 @@ TYPED_TEST(Cg, CanBeCopied)
 
     ASSERT_EQ(copy->get_size(), gko::dim<2>(3, 3));
     auto copy_mtx = static_cast<Solver*>(copy.get())->get_system_matrix();
-    GKO_ASSERT_MTX_NEAR(static_cast<const Mtx*>(copy_mtx.get()), this->mtx,
-                        0.0);
+    GKO_ASSERT_MTX_NEAR(gko::as<Mtx>(copy_mtx), this->mtx, 0.0);
 }
 
 
@@ -125,8 +124,7 @@ TYPED_TEST(Cg, CanBeMoved)
 
     ASSERT_EQ(copy->get_size(), gko::dim<2>(3, 3));
     auto copy_mtx = static_cast<Solver*>(copy.get())->get_system_matrix();
-    GKO_ASSERT_MTX_NEAR(static_cast<const Mtx*>(copy_mtx.get()), this->mtx,
-                        0.0);
+    GKO_ASSERT_MTX_NEAR(gko::as<Mtx>(copy_mtx), this->mtx, 0.0);
 }
 
 
@@ -138,8 +136,7 @@ TYPED_TEST(Cg, CanBeCloned)
 
     ASSERT_EQ(clone->get_size(), gko::dim<2>(3, 3));
     auto clone_mtx = static_cast<Solver*>(clone.get())->get_system_matrix();
-    GKO_ASSERT_MTX_NEAR(static_cast<const Mtx*>(clone_mtx.get()), this->mtx,
-                        0.0);
+    GKO_ASSERT_MTX_NEAR(gko::as<Mtx>(clone_mtx), this->mtx, 0.0);
 }
 
 

--- a/core/test/solver/cg.cpp
+++ b/core/test/solver/cg.cpp
@@ -78,17 +78,6 @@ protected:
     std::shared_ptr<Mtx> mtx;
     std::unique_ptr<typename Solver::Factory> cg_factory;
     std::unique_ptr<gko::LinOp> solver;
-
-    static void assert_same_matrices(const Mtx* m1, const Mtx* m2)
-    {
-        ASSERT_EQ(m1->get_size()[0], m2->get_size()[0]);
-        ASSERT_EQ(m1->get_size()[1], m2->get_size()[1]);
-        for (gko::size_type i = 0; i < m1->get_size()[0]; ++i) {
-            for (gko::size_type j = 0; j < m2->get_size()[1]; ++j) {
-                EXPECT_EQ(m1->at(i, j), m2->at(i, j));
-            }
-        }
-    }
 };
 
 TYPED_TEST_SUITE(Cg, gko::test::ValueTypes, TypenameNameGenerator);
@@ -117,12 +106,12 @@ TYPED_TEST(Cg, CanBeCopied)
     using Solver = typename TestFixture::Solver;
     auto copy = this->cg_factory->generate(Mtx::create(this->exec));
 
-    copy->copy_from(this->solver.get());
+    copy->copy_from(this->solver);
 
     ASSERT_EQ(copy->get_size(), gko::dim<2>(3, 3));
     auto copy_mtx = static_cast<Solver*>(copy.get())->get_system_matrix();
-    this->assert_same_matrices(static_cast<const Mtx*>(copy_mtx.get()),
-                               this->mtx.get());
+    GKO_ASSERT_MTX_NEAR(static_cast<const Mtx*>(copy_mtx.get()), this->mtx,
+                        0.0);
 }
 
 
@@ -136,8 +125,8 @@ TYPED_TEST(Cg, CanBeMoved)
 
     ASSERT_EQ(copy->get_size(), gko::dim<2>(3, 3));
     auto copy_mtx = static_cast<Solver*>(copy.get())->get_system_matrix();
-    this->assert_same_matrices(static_cast<const Mtx*>(copy_mtx.get()),
-                               this->mtx.get());
+    GKO_ASSERT_MTX_NEAR(static_cast<const Mtx*>(copy_mtx.get()), this->mtx,
+                        0.0);
 }
 
 
@@ -149,8 +138,8 @@ TYPED_TEST(Cg, CanBeCloned)
 
     ASSERT_EQ(clone->get_size(), gko::dim<2>(3, 3));
     auto clone_mtx = static_cast<Solver*>(clone.get())->get_system_matrix();
-    this->assert_same_matrices(static_cast<const Mtx*>(clone_mtx.get()),
-                               this->mtx.get());
+    GKO_ASSERT_MTX_NEAR(static_cast<const Mtx*>(clone_mtx.get()), this->mtx,
+                        0.0);
 }
 
 

--- a/core/test/solver/cgs.cpp
+++ b/core/test/solver/cgs.cpp
@@ -120,7 +120,7 @@ TYPED_TEST(Cgs, CanBeMoved)
     using Solver = typename TestFixture::Solver;
     auto copy = this->cgs_factory->generate(Mtx::create(this->exec));
 
-    copy->copy_from(std::move(this->solver));
+    copy->move_from(this->solver);
 
     ASSERT_EQ(copy->get_size(), gko::dim<2>(3, 3));
     auto copy_mtx = static_cast<Solver*>(copy.get())->get_system_matrix();

--- a/core/test/solver/cgs.cpp
+++ b/core/test/solver/cgs.cpp
@@ -78,17 +78,6 @@ protected:
     std::shared_ptr<Mtx> mtx;
     std::unique_ptr<typename Solver::Factory> cgs_factory;
     std::unique_ptr<gko::LinOp> solver;
-
-    static void assert_same_matrices(const Mtx* m1, const Mtx* m2)
-    {
-        ASSERT_EQ(m1->get_size()[0], m2->get_size()[0]);
-        ASSERT_EQ(m1->get_size()[1], m2->get_size()[1]);
-        for (gko::size_type i = 0; i < m1->get_size()[0]; ++i) {
-            for (gko::size_type j = 0; j < m2->get_size()[1]; ++j) {
-                EXPECT_EQ(m1->at(i, j), m2->at(i, j));
-            }
-        }
-    }
 };
 
 TYPED_TEST_SUITE(Cgs, gko::test::ValueTypes, TypenameNameGenerator);
@@ -116,12 +105,12 @@ TYPED_TEST(Cgs, CanBeCopied)
     using Solver = typename TestFixture::Solver;
     auto copy = this->cgs_factory->generate(Mtx::create(this->exec));
 
-    copy->copy_from(this->solver.get());
+    copy->copy_from(this->solver);
 
     ASSERT_EQ(copy->get_size(), gko::dim<2>(3, 3));
     auto copy_mtx = static_cast<Solver*>(copy.get())->get_system_matrix();
-    this->assert_same_matrices(static_cast<const Mtx*>(copy_mtx.get()),
-                               this->mtx.get());
+    GKO_ASSERT_MTX_NEAR(static_cast<const Mtx*>(copy_mtx.get()), this->mtx,
+                        0.0);
 }
 
 
@@ -135,8 +124,8 @@ TYPED_TEST(Cgs, CanBeMoved)
 
     ASSERT_EQ(copy->get_size(), gko::dim<2>(3, 3));
     auto copy_mtx = static_cast<Solver*>(copy.get())->get_system_matrix();
-    this->assert_same_matrices(static_cast<const Mtx*>(copy_mtx.get()),
-                               this->mtx.get());
+    GKO_ASSERT_MTX_NEAR(static_cast<const Mtx*>(copy_mtx.get()), this->mtx,
+                        0.0);
 }
 
 
@@ -148,8 +137,8 @@ TYPED_TEST(Cgs, CanBeCloned)
 
     ASSERT_EQ(clone->get_size(), gko::dim<2>(3, 3));
     auto clone_mtx = static_cast<Solver*>(clone.get())->get_system_matrix();
-    this->assert_same_matrices(static_cast<const Mtx*>(clone_mtx.get()),
-                               this->mtx.get());
+    GKO_ASSERT_MTX_NEAR(static_cast<const Mtx*>(clone_mtx.get()), this->mtx,
+                        0.0);
 }
 
 

--- a/core/test/solver/cgs.cpp
+++ b/core/test/solver/cgs.cpp
@@ -109,8 +109,7 @@ TYPED_TEST(Cgs, CanBeCopied)
 
     ASSERT_EQ(copy->get_size(), gko::dim<2>(3, 3));
     auto copy_mtx = static_cast<Solver*>(copy.get())->get_system_matrix();
-    GKO_ASSERT_MTX_NEAR(static_cast<const Mtx*>(copy_mtx.get()), this->mtx,
-                        0.0);
+    GKO_ASSERT_MTX_NEAR(gko::as<Mtx>(copy_mtx), this->mtx, 0.0);
 }
 
 
@@ -124,8 +123,7 @@ TYPED_TEST(Cgs, CanBeMoved)
 
     ASSERT_EQ(copy->get_size(), gko::dim<2>(3, 3));
     auto copy_mtx = static_cast<Solver*>(copy.get())->get_system_matrix();
-    GKO_ASSERT_MTX_NEAR(static_cast<const Mtx*>(copy_mtx.get()), this->mtx,
-                        0.0);
+    GKO_ASSERT_MTX_NEAR(gko::as<Mtx>(copy_mtx), this->mtx, 0.0);
 }
 
 
@@ -137,8 +135,7 @@ TYPED_TEST(Cgs, CanBeCloned)
 
     ASSERT_EQ(clone->get_size(), gko::dim<2>(3, 3));
     auto clone_mtx = static_cast<Solver*>(clone.get())->get_system_matrix();
-    GKO_ASSERT_MTX_NEAR(static_cast<const Mtx*>(clone_mtx.get()), this->mtx,
-                        0.0);
+    GKO_ASSERT_MTX_NEAR(gko::as<Mtx>(clone_mtx), this->mtx, 0.0);
 }
 
 

--- a/core/test/solver/fcg.cpp
+++ b/core/test/solver/fcg.cpp
@@ -117,7 +117,7 @@ TYPED_TEST(Fcg, CanBeMoved)
     using Solver = typename TestFixture::Solver;
     auto copy = this->fcg_factory->generate(Mtx::create(this->exec));
 
-    copy->copy_from(std::move(this->solver));
+    copy->move_from(this->solver);
 
     ASSERT_EQ(copy->get_size(), gko::dim<2>(3, 3));
     auto copy_mtx = dynamic_cast<Solver*>(copy.get())->get_system_matrix();

--- a/core/test/solver/fcg.cpp
+++ b/core/test/solver/fcg.cpp
@@ -102,12 +102,12 @@ TYPED_TEST(Fcg, CanBeCopied)
     using Solver = typename TestFixture::Solver;
     auto copy = this->fcg_factory->generate(Mtx::create(this->exec));
 
-    copy->copy_from(this->solver.get());
+    copy->copy_from(this->solver);
 
     ASSERT_EQ(copy->get_size(), gko::dim<2>(3, 3));
     auto copy_mtx = dynamic_cast<Solver*>(copy.get())->get_system_matrix();
-    GKO_ASSERT_MTX_NEAR(dynamic_cast<const Mtx*>(copy_mtx.get()),
-                        this->mtx.get(), 0.0);
+    GKO_ASSERT_MTX_NEAR(dynamic_cast<const Mtx*>(copy_mtx.get()), this->mtx,
+                        0.0);
 }
 
 
@@ -121,8 +121,8 @@ TYPED_TEST(Fcg, CanBeMoved)
 
     ASSERT_EQ(copy->get_size(), gko::dim<2>(3, 3));
     auto copy_mtx = dynamic_cast<Solver*>(copy.get())->get_system_matrix();
-    GKO_ASSERT_MTX_NEAR(dynamic_cast<const Mtx*>(copy_mtx.get()),
-                        this->mtx.get(), 0.0);
+    GKO_ASSERT_MTX_NEAR(dynamic_cast<const Mtx*>(copy_mtx.get()), this->mtx,
+                        0.0);
 }
 
 
@@ -134,8 +134,8 @@ TYPED_TEST(Fcg, CanBeCloned)
 
     ASSERT_EQ(clone->get_size(), gko::dim<2>(3, 3));
     auto clone_mtx = dynamic_cast<Solver*>(clone.get())->get_system_matrix();
-    GKO_ASSERT_MTX_NEAR(dynamic_cast<const Mtx*>(clone_mtx.get()),
-                        this->mtx.get(), 0.0);
+    GKO_ASSERT_MTX_NEAR(dynamic_cast<const Mtx*>(clone_mtx.get()), this->mtx,
+                        0.0);
 }
 
 

--- a/core/test/solver/gmres.cpp
+++ b/core/test/solver/gmres.cpp
@@ -94,17 +94,6 @@ protected:
     std::unique_ptr<gko::LinOp> solver;
     std::unique_ptr<Big_solver::Factory> gmres_big_factory;
     std::unique_ptr<gko::LinOp> big_solver;
-
-    static void assert_same_matrices(const Mtx* m1, const Mtx* m2)
-    {
-        ASSERT_EQ(m1->get_size()[0], m2->get_size()[0]);
-        ASSERT_EQ(m1->get_size()[1], m2->get_size()[1]);
-        for (gko::size_type i = 0; i < m1->get_size()[0]; ++i) {
-            for (gko::size_type j = 0; j < m2->get_size()[1]; ++j) {
-                EXPECT_EQ(m1->at(i, j), m2->at(i, j));
-            }
-        }
-    }
 };
 
 template <typename T>
@@ -135,12 +124,12 @@ TYPED_TEST(Gmres, CanBeCopied)
     using Solver = typename TestFixture::Solver;
     auto copy = this->gmres_factory->generate(Mtx::create(this->exec));
 
-    copy->copy_from(this->solver.get());
+    copy->copy_from(this->solver);
 
     ASSERT_EQ(copy->get_size(), gko::dim<2>(3, 3));
     auto copy_mtx = static_cast<Solver*>(copy.get())->get_system_matrix();
-    this->assert_same_matrices(static_cast<const Mtx*>(copy_mtx.get()),
-                               this->mtx.get());
+    GKO_ASSERT_MTX_NEAR(static_cast<const Mtx*>(copy_mtx.get()), this->mtx,
+                        0.0);
 }
 
 
@@ -154,8 +143,8 @@ TYPED_TEST(Gmres, CanBeMoved)
 
     ASSERT_EQ(copy->get_size(), gko::dim<2>(3, 3));
     auto copy_mtx = static_cast<Solver*>(copy.get())->get_system_matrix();
-    this->assert_same_matrices(static_cast<const Mtx*>(copy_mtx.get()),
-                               this->mtx.get());
+    GKO_ASSERT_MTX_NEAR(static_cast<const Mtx*>(copy_mtx.get()), this->mtx,
+                        0.0);
 }
 
 
@@ -167,8 +156,8 @@ TYPED_TEST(Gmres, CanBeCloned)
 
     ASSERT_EQ(clone->get_size(), gko::dim<2>(3, 3));
     auto clone_mtx = static_cast<Solver*>(clone.get())->get_system_matrix();
-    this->assert_same_matrices(static_cast<const Mtx*>(clone_mtx.get()),
-                               this->mtx.get());
+    GKO_ASSERT_MTX_NEAR(static_cast<const Mtx*>(clone_mtx.get()), this->mtx,
+                        0.0);
 }
 
 

--- a/core/test/solver/gmres.cpp
+++ b/core/test/solver/gmres.cpp
@@ -128,8 +128,7 @@ TYPED_TEST(Gmres, CanBeCopied)
 
     ASSERT_EQ(copy->get_size(), gko::dim<2>(3, 3));
     auto copy_mtx = static_cast<Solver*>(copy.get())->get_system_matrix();
-    GKO_ASSERT_MTX_NEAR(static_cast<const Mtx*>(copy_mtx.get()), this->mtx,
-                        0.0);
+    GKO_ASSERT_MTX_NEAR(gko::as<Mtx>(copy_mtx), this->mtx, 0.0);
 }
 
 
@@ -143,8 +142,7 @@ TYPED_TEST(Gmres, CanBeMoved)
 
     ASSERT_EQ(copy->get_size(), gko::dim<2>(3, 3));
     auto copy_mtx = static_cast<Solver*>(copy.get())->get_system_matrix();
-    GKO_ASSERT_MTX_NEAR(static_cast<const Mtx*>(copy_mtx.get()), this->mtx,
-                        0.0);
+    GKO_ASSERT_MTX_NEAR(gko::as<Mtx>(copy_mtx), this->mtx, 0.0);
 }
 
 
@@ -156,8 +154,7 @@ TYPED_TEST(Gmres, CanBeCloned)
 
     ASSERT_EQ(clone->get_size(), gko::dim<2>(3, 3));
     auto clone_mtx = static_cast<Solver*>(clone.get())->get_system_matrix();
-    GKO_ASSERT_MTX_NEAR(static_cast<const Mtx*>(clone_mtx.get()), this->mtx,
-                        0.0);
+    GKO_ASSERT_MTX_NEAR(gko::as<Mtx>(clone_mtx), this->mtx, 0.0);
 }
 
 

--- a/core/test/solver/gmres.cpp
+++ b/core/test/solver/gmres.cpp
@@ -139,7 +139,7 @@ TYPED_TEST(Gmres, CanBeMoved)
     using Solver = typename TestFixture::Solver;
     auto copy = this->gmres_factory->generate(Mtx::create(this->exec));
 
-    copy->copy_from(std::move(this->solver));
+    copy->move_from(this->solver);
 
     ASSERT_EQ(copy->get_size(), gko::dim<2>(3, 3));
     auto copy_mtx = static_cast<Solver*>(copy.get())->get_system_matrix();

--- a/core/test/solver/idr.cpp
+++ b/core/test/solver/idr.cpp
@@ -102,7 +102,7 @@ TYPED_TEST(Idr, IdrFactoryCreatesCorrectSolver)
 {
     using Solver = typename TestFixture::Solver;
     ASSERT_EQ(this->solver->get_size(), gko::dim<2>(3, 3));
-    auto idr_solver = static_cast<Solver*>(this->solver.get());
+    auto idr_solver = gko::as<Solver>(this->solver.get());
     ASSERT_NE(idr_solver->get_system_matrix(), nullptr);
     ASSERT_EQ(idr_solver->get_system_matrix(), this->mtx);
 }
@@ -117,9 +117,8 @@ TYPED_TEST(Idr, CanBeCopied)
     copy->copy_from(this->solver.get());
 
     ASSERT_EQ(copy->get_size(), gko::dim<2>(3, 3));
-    auto copy_mtx = static_cast<Solver*>(copy.get())->get_system_matrix();
-    this->assert_same_matrices(static_cast<const Mtx*>(copy_mtx.get()),
-                               this->mtx.get());
+    auto copy_mtx = gko::as<Solver>(copy.get())->get_system_matrix();
+    this->assert_same_matrices(gko::as<Mtx>(copy_mtx.get()), this->mtx.get());
 }
 
 
@@ -132,9 +131,8 @@ TYPED_TEST(Idr, CanBeMoved)
     copy->copy_from(std::move(this->solver));
 
     ASSERT_EQ(copy->get_size(), gko::dim<2>(3, 3));
-    auto copy_mtx = static_cast<Solver*>(copy.get())->get_system_matrix();
-    this->assert_same_matrices(static_cast<const Mtx*>(copy_mtx.get()),
-                               this->mtx.get());
+    auto copy_mtx = gko::as<Solver>(copy.get())->get_system_matrix();
+    this->assert_same_matrices(gko::as<Mtx>(copy_mtx.get()), this->mtx.get());
 }
 
 
@@ -146,9 +144,8 @@ TYPED_TEST(Idr, CanBeCloned)
     auto clone = this->solver->clone();
 
     ASSERT_EQ(clone->get_size(), gko::dim<2>(3, 3));
-    auto clone_mtx = static_cast<Solver*>(clone.get())->get_system_matrix();
-    this->assert_same_matrices(static_cast<const Mtx*>(clone_mtx.get()),
-                               this->mtx.get());
+    auto clone_mtx = gko::as<Solver>(clone.get())->get_system_matrix();
+    this->assert_same_matrices(gko::as<Mtx>(clone_mtx.get()), this->mtx.get());
 }
 
 
@@ -159,8 +156,7 @@ TYPED_TEST(Idr, CanBeCleared)
     this->solver->clear();
 
     ASSERT_EQ(this->solver->get_size(), gko::dim<2>(0, 0));
-    auto solver_mtx =
-        static_cast<Solver*>(this->solver.get())->get_system_matrix();
+    auto solver_mtx = gko::as<Solver>(this->solver.get())->get_system_matrix();
     ASSERT_EQ(solver_mtx, nullptr);
 }
 
@@ -188,10 +184,9 @@ TYPED_TEST(Idr, CanSetPreconditionerGenerator)
             .on(this->exec);
 
     auto solver = idr_factory->generate(this->mtx);
-    auto precond = dynamic_cast<const gko::solver::Idr<value_type>*>(
-        gko::lend(solver->get_preconditioner()));
+    auto precond =
+        gko::as<gko::solver::Idr<value_type>>(solver->get_preconditioner());
 
-    ASSERT_NE(precond, nullptr);
     ASSERT_EQ(precond->get_size(), gko::dim<2>(3, 3));
     ASSERT_EQ(precond->get_system_matrix(), this->mtx);
 }
@@ -212,10 +207,9 @@ TYPED_TEST(Idr, CanSetCriteriaAgain)
 
     solver->set_stop_criterion_factory(new_crit);
     auto new_crit_fac = solver->get_stop_criterion_factory();
-    auto niter =
-        static_cast<const gko::stop::Iteration::Factory*>(new_crit_fac.get())
-            ->get_parameters()
-            .max_iters;
+    auto niter = gko::as<gko::stop::Iteration::Factory>(new_crit_fac.get())
+                     ->get_parameters()
+                     .max_iters;
 
     ASSERT_EQ(niter, 5);
 }

--- a/core/test/solver/idr.cpp
+++ b/core/test/solver/idr.cpp
@@ -76,17 +76,6 @@ protected:
     std::shared_ptr<Mtx> mtx;
     std::unique_ptr<typename Solver::Factory> idr_factory;
     std::unique_ptr<gko::LinOp> solver;
-
-    static void assert_same_matrices(const Mtx* m1, const Mtx* m2)
-    {
-        ASSERT_EQ(m1->get_size()[0], m2->get_size()[0]);
-        ASSERT_EQ(m1->get_size()[1], m2->get_size()[1]);
-        for (gko::size_type i = 0; i < m1->get_size()[0]; ++i) {
-            for (gko::size_type j = 0; j < m2->get_size()[1]; ++j) {
-                EXPECT_EQ(m1->at(i, j), m2->at(i, j));
-            }
-        }
-    }
 };
 
 TYPED_TEST_SUITE(Idr, gko::test::ValueTypes, TypenameNameGenerator);
@@ -114,11 +103,11 @@ TYPED_TEST(Idr, CanBeCopied)
     using Solver = typename TestFixture::Solver;
     auto copy = this->idr_factory->generate(Mtx::create(this->exec));
 
-    copy->copy_from(this->solver.get());
+    copy->copy_from(this->solver);
 
     ASSERT_EQ(copy->get_size(), gko::dim<2>(3, 3));
     auto copy_mtx = gko::as<Solver>(copy.get())->get_system_matrix();
-    this->assert_same_matrices(gko::as<Mtx>(copy_mtx.get()), this->mtx.get());
+    GKO_ASSERT_MTX_NEAR(gko::as<Mtx>(copy_mtx.get()), this->mtx, 0.0);
 }
 
 
@@ -132,7 +121,7 @@ TYPED_TEST(Idr, CanBeMoved)
 
     ASSERT_EQ(copy->get_size(), gko::dim<2>(3, 3));
     auto copy_mtx = gko::as<Solver>(copy.get())->get_system_matrix();
-    this->assert_same_matrices(gko::as<Mtx>(copy_mtx.get()), this->mtx.get());
+    GKO_ASSERT_MTX_NEAR(gko::as<Mtx>(copy_mtx.get()), this->mtx, 0.0);
 }
 
 
@@ -145,7 +134,7 @@ TYPED_TEST(Idr, CanBeCloned)
 
     ASSERT_EQ(clone->get_size(), gko::dim<2>(3, 3));
     auto clone_mtx = gko::as<Solver>(clone.get())->get_system_matrix();
-    this->assert_same_matrices(gko::as<Mtx>(clone_mtx.get()), this->mtx.get());
+    GKO_ASSERT_MTX_NEAR(gko::as<Mtx>(clone_mtx.get()), this->mtx, 0.0);
 }
 
 

--- a/core/test/solver/idr.cpp
+++ b/core/test/solver/idr.cpp
@@ -107,7 +107,7 @@ TYPED_TEST(Idr, CanBeCopied)
 
     ASSERT_EQ(copy->get_size(), gko::dim<2>(3, 3));
     auto copy_mtx = gko::as<Solver>(copy.get())->get_system_matrix();
-    GKO_ASSERT_MTX_NEAR(gko::as<Mtx>(copy_mtx.get()), this->mtx, 0.0);
+    GKO_ASSERT_MTX_NEAR(gko::as<Mtx>(copy_mtx), this->mtx, 0.0);
 }
 
 
@@ -121,7 +121,7 @@ TYPED_TEST(Idr, CanBeMoved)
 
     ASSERT_EQ(copy->get_size(), gko::dim<2>(3, 3));
     auto copy_mtx = gko::as<Solver>(copy.get())->get_system_matrix();
-    GKO_ASSERT_MTX_NEAR(gko::as<Mtx>(copy_mtx.get()), this->mtx, 0.0);
+    GKO_ASSERT_MTX_NEAR(gko::as<Mtx>(copy_mtx), this->mtx, 0.0);
 }
 
 

--- a/core/test/solver/idr.cpp
+++ b/core/test/solver/idr.cpp
@@ -117,7 +117,7 @@ TYPED_TEST(Idr, CanBeMoved)
     using Solver = typename TestFixture::Solver;
     auto copy = this->idr_factory->generate(Mtx::create(this->exec));
 
-    copy->copy_from(std::move(this->solver));
+    copy->move_from(this->solver);
 
     ASSERT_EQ(copy->get_size(), gko::dim<2>(3, 3));
     auto copy_mtx = gko::as<Solver>(copy.get())->get_system_matrix();

--- a/core/test/solver/ir.cpp
+++ b/core/test/solver/ir.cpp
@@ -78,17 +78,6 @@ protected:
     std::shared_ptr<Mtx> mtx;
     std::shared_ptr<typename Solver::Factory> ir_factory;
     std::unique_ptr<gko::LinOp> solver;
-
-    static void assert_same_matrices(const Mtx* m1, const Mtx* m2)
-    {
-        ASSERT_EQ(m1->get_size()[0], m2->get_size()[0]);
-        ASSERT_EQ(m1->get_size()[1], m2->get_size()[1]);
-        for (gko::size_type i = 0; i < m1->get_size()[0]; ++i) {
-            for (gko::size_type j = 0; j < m2->get_size()[1]; ++j) {
-                EXPECT_EQ(m1->at(i, j), m2->at(i, j));
-            }
-        }
-    }
 };
 
 TYPED_TEST_SUITE(Ir, gko::test::ValueTypes, TypenameNameGenerator);
@@ -116,12 +105,12 @@ TYPED_TEST(Ir, CanBeCopied)
     using Solver = typename TestFixture::Solver;
     auto copy = this->ir_factory->generate(Mtx::create(this->exec));
 
-    copy->copy_from(this->solver.get());
+    copy->copy_from(this->solver);
 
     ASSERT_EQ(copy->get_size(), gko::dim<2>(3, 3));
     auto copy_mtx = static_cast<Solver*>(copy.get())->get_system_matrix();
-    this->assert_same_matrices(static_cast<const Mtx*>(copy_mtx.get()),
-                               this->mtx.get());
+    GKO_ASSERT_MTX_NEAR(static_cast<const Mtx*>(copy_mtx.get()), this->mtx,
+                        0.0);
 }
 
 
@@ -135,8 +124,8 @@ TYPED_TEST(Ir, CanBeMoved)
 
     ASSERT_EQ(copy->get_size(), gko::dim<2>(3, 3));
     auto copy_mtx = static_cast<Solver*>(copy.get())->get_system_matrix();
-    this->assert_same_matrices(static_cast<const Mtx*>(copy_mtx.get()),
-                               this->mtx.get());
+    GKO_ASSERT_MTX_NEAR(static_cast<const Mtx*>(copy_mtx.get()), this->mtx,
+                        0.0);
 }
 
 
@@ -148,8 +137,8 @@ TYPED_TEST(Ir, CanBeCloned)
 
     ASSERT_EQ(clone->get_size(), gko::dim<2>(3, 3));
     auto clone_mtx = static_cast<Solver*>(clone.get())->get_system_matrix();
-    this->assert_same_matrices(static_cast<const Mtx*>(clone_mtx.get()),
-                               this->mtx.get());
+    GKO_ASSERT_MTX_NEAR(static_cast<const Mtx*>(clone_mtx.get()), this->mtx,
+                        0.0);
 }
 
 

--- a/core/test/solver/ir.cpp
+++ b/core/test/solver/ir.cpp
@@ -120,7 +120,7 @@ TYPED_TEST(Ir, CanBeMoved)
     using Solver = typename TestFixture::Solver;
     auto copy = this->ir_factory->generate(Mtx::create(this->exec));
 
-    copy->copy_from(std::move(this->solver));
+    copy->move_from(this->solver);
 
     ASSERT_EQ(copy->get_size(), gko::dim<2>(3, 3));
     auto copy_mtx = static_cast<Solver*>(copy.get())->get_system_matrix();

--- a/core/test/solver/ir.cpp
+++ b/core/test/solver/ir.cpp
@@ -109,8 +109,7 @@ TYPED_TEST(Ir, CanBeCopied)
 
     ASSERT_EQ(copy->get_size(), gko::dim<2>(3, 3));
     auto copy_mtx = static_cast<Solver*>(copy.get())->get_system_matrix();
-    GKO_ASSERT_MTX_NEAR(static_cast<const Mtx*>(copy_mtx.get()), this->mtx,
-                        0.0);
+    GKO_ASSERT_MTX_NEAR(gko::as<Mtx>(copy_mtx), this->mtx, 0.0);
 }
 
 
@@ -124,8 +123,7 @@ TYPED_TEST(Ir, CanBeMoved)
 
     ASSERT_EQ(copy->get_size(), gko::dim<2>(3, 3));
     auto copy_mtx = static_cast<Solver*>(copy.get())->get_system_matrix();
-    GKO_ASSERT_MTX_NEAR(static_cast<const Mtx*>(copy_mtx.get()), this->mtx,
-                        0.0);
+    GKO_ASSERT_MTX_NEAR(gko::as<Mtx>(copy_mtx), this->mtx, 0.0);
 }
 
 
@@ -137,8 +135,7 @@ TYPED_TEST(Ir, CanBeCloned)
 
     ASSERT_EQ(clone->get_size(), gko::dim<2>(3, 3));
     auto clone_mtx = static_cast<Solver*>(clone.get())->get_system_matrix();
-    GKO_ASSERT_MTX_NEAR(static_cast<const Mtx*>(clone_mtx.get()), this->mtx,
-                        0.0);
+    GKO_ASSERT_MTX_NEAR(gko::as<Mtx>(clone_mtx), this->mtx, 0.0);
 }
 
 

--- a/core/test/solver/multigrid.cpp
+++ b/core/test/solver/multigrid.cpp
@@ -234,7 +234,7 @@ TYPED_TEST(Multigrid, CanBeMoved)
     using Solver = typename TestFixture::Solver;
     auto copy = this->multigrid_factory->generate(Mtx::create(this->exec));
 
-    copy->copy_from(std::move(this->solver));
+    copy->move_from(this->solver);
 
     ASSERT_EQ(copy->get_size(), gko::dim<2>(4, 4));
     auto copy_mtx = static_cast<Solver*>(copy.get())->get_system_matrix();

--- a/core/test/solver/multigrid.cpp
+++ b/core/test/solver/multigrid.cpp
@@ -224,7 +224,7 @@ TYPED_TEST(Multigrid, CanBeCopied)
 
     ASSERT_EQ(copy->get_size(), gko::dim<2>(4, 4));
     auto copy_mtx = static_cast<Solver*>(copy.get())->get_system_matrix();
-    GKO_ASSERT_MTX_NEAR(gko::as<Mtx>(copy_mtx.get()), this->mtx, 0.0);
+    GKO_ASSERT_MTX_NEAR(gko::as<Mtx>(copy_mtx), this->mtx, 0.0);
 }
 
 
@@ -238,8 +238,7 @@ TYPED_TEST(Multigrid, CanBeMoved)
 
     ASSERT_EQ(copy->get_size(), gko::dim<2>(4, 4));
     auto copy_mtx = static_cast<Solver*>(copy.get())->get_system_matrix();
-    GKO_ASSERT_MTX_NEAR(static_cast<const Mtx*>(copy_mtx.get()), this->mtx,
-                        0.0);
+    GKO_ASSERT_MTX_NEAR(gko::as<Mtx>(copy_mtx), this->mtx, 0.0);
 }
 
 
@@ -251,8 +250,7 @@ TYPED_TEST(Multigrid, CanBeCloned)
 
     ASSERT_EQ(clone->get_size(), gko::dim<2>(4, 4));
     auto clone_mtx = static_cast<Solver*>(clone.get())->get_system_matrix();
-    GKO_ASSERT_MTX_NEAR(static_cast<const Mtx*>(clone_mtx.get()), this->mtx,
-                        0.0);
+    GKO_ASSERT_MTX_NEAR(gko::as<Mtx>(clone_mtx), this->mtx, 0.0);
 }
 
 

--- a/core/test/solver/multigrid.cpp
+++ b/core/test/solver/multigrid.cpp
@@ -179,14 +179,14 @@ protected:
     std::shared_ptr<const gko::stop::CriterionFactory> criterion;
 
     static int get_value(
-        gko::pointer_param<const gko::multigrid::MultigridLevel> rp)
+        gko::ptr_param<const gko::multigrid::MultigridLevel> rp)
     {
         return dynamic_cast<const DummyRPFactory*>(rp.get())
             ->get_parameters()
             .value;
     }
 
-    static int get_value(gko::pointer_param<const gko::LinOp> lo)
+    static int get_value(gko::ptr_param<const gko::LinOp> lo)
     {
         return dynamic_cast<const DummyFactory*>(lo.get())
             ->get_parameters()

--- a/core/test/solver/multigrid.cpp
+++ b/core/test/solver/multigrid.cpp
@@ -178,25 +178,19 @@ protected:
     std::shared_ptr<typename DummyFactory::Factory> lo_factory2;
     std::shared_ptr<const gko::stop::CriterionFactory> criterion;
 
-    static void assert_same_matrices(const Mtx* m1, const Mtx* m2)
+    static int get_value(
+        gko::pointer_param<const gko::multigrid::MultigridLevel> rp)
     {
-        ASSERT_EQ(m1->get_size()[0], m2->get_size()[0]);
-        ASSERT_EQ(m1->get_size()[1], m2->get_size()[1]);
-        for (gko::size_type i = 0; i < m1->get_size()[0]; ++i) {
-            for (gko::size_type j = 0; j < m2->get_size()[1]; ++j) {
-                EXPECT_EQ(m1->at(i, j), m2->at(i, j));
-            }
-        }
+        return dynamic_cast<const DummyRPFactory*>(rp.get())
+            ->get_parameters()
+            .value;
     }
 
-    static int get_value(const gko::multigrid::MultigridLevel* rp)
+    static int get_value(gko::pointer_param<const gko::LinOp> lo)
     {
-        return dynamic_cast<const DummyRPFactory*>(rp)->get_parameters().value;
-    }
-
-    static int get_value(const gko::LinOp* lo)
-    {
-        return dynamic_cast<const DummyFactory*>(lo)->get_parameters().value;
+        return dynamic_cast<const DummyFactory*>(lo.get())
+            ->get_parameters()
+            .value;
     }
 };
 
@@ -226,12 +220,11 @@ TYPED_TEST(Multigrid, CanBeCopied)
     using Solver = typename TestFixture::Solver;
     auto copy = this->multigrid_factory->generate(Mtx::create(this->exec));
 
-    copy->copy_from(this->solver.get());
+    copy->copy_from(this->solver);
 
     ASSERT_EQ(copy->get_size(), gko::dim<2>(4, 4));
     auto copy_mtx = static_cast<Solver*>(copy.get())->get_system_matrix();
-    this->assert_same_matrices(static_cast<const Mtx*>(copy_mtx.get()),
-                               this->mtx.get());
+    GKO_ASSERT_MTX_NEAR(gko::as<Mtx>(copy_mtx.get()), this->mtx, 0.0);
 }
 
 
@@ -245,8 +238,8 @@ TYPED_TEST(Multigrid, CanBeMoved)
 
     ASSERT_EQ(copy->get_size(), gko::dim<2>(4, 4));
     auto copy_mtx = static_cast<Solver*>(copy.get())->get_system_matrix();
-    this->assert_same_matrices(static_cast<const Mtx*>(copy_mtx.get()),
-                               this->mtx.get());
+    GKO_ASSERT_MTX_NEAR(static_cast<const Mtx*>(copy_mtx.get()), this->mtx,
+                        0.0);
 }
 
 
@@ -258,8 +251,8 @@ TYPED_TEST(Multigrid, CanBeCloned)
 
     ASSERT_EQ(clone->get_size(), gko::dim<2>(4, 4));
     auto clone_mtx = static_cast<Solver*>(clone.get())->get_system_matrix();
-    this->assert_same_matrices(static_cast<const Mtx*>(clone_mtx.get()),
-                               this->mtx.get());
+    GKO_ASSERT_MTX_NEAR(static_cast<const Mtx*>(clone_mtx.get()), this->mtx,
+                        0.0);
 }
 
 
@@ -334,20 +327,20 @@ TYPED_TEST(Multigrid, EachLevelAreDistinct)
 
     ASSERT_EQ(mg_level.size(), 2);
     ASSERT_NE(mg_level.at(0), mg_level.at(1));
-    ASSERT_EQ(this->get_value(mg_level.at(0).get()), 5);
-    ASSERT_EQ(this->get_value(mg_level.at(1).get()), 5);
+    ASSERT_EQ(this->get_value(mg_level.at(0)), 5);
+    ASSERT_EQ(this->get_value(mg_level.at(1)), 5);
     ASSERT_EQ(pre_smoother.size(), 2);
     ASSERT_NE(pre_smoother.at(0), pre_smoother.at(1));
-    ASSERT_EQ(this->get_value(pre_smoother.at(0).get()), 5);
-    ASSERT_EQ(this->get_value(pre_smoother.at(1).get()), 5);
+    ASSERT_EQ(this->get_value(pre_smoother.at(0)), 5);
+    ASSERT_EQ(this->get_value(pre_smoother.at(1)), 5);
     ASSERT_EQ(mid_smoother.size(), 2);
     ASSERT_NE(mid_smoother.at(0), mid_smoother.at(1));
-    ASSERT_EQ(this->get_value(mid_smoother.at(0).get()), 5);
-    ASSERT_EQ(this->get_value(mid_smoother.at(1).get()), 5);
+    ASSERT_EQ(this->get_value(mid_smoother.at(0)), 5);
+    ASSERT_EQ(this->get_value(mid_smoother.at(1)), 5);
     ASSERT_EQ(post_smoother.size(), 2);
     ASSERT_NE(post_smoother.at(0), post_smoother.at(1));
-    ASSERT_EQ(this->get_value(post_smoother.at(0).get()), 5);
-    ASSERT_EQ(this->get_value(post_smoother.at(1).get()), 5);
+    ASSERT_EQ(this->get_value(post_smoother.at(0)), 5);
+    ASSERT_EQ(this->get_value(post_smoother.at(1)), 5);
     ASSERT_NE(coarsest_solver, nullptr);
 }
 
@@ -614,14 +607,14 @@ TYPED_TEST(Multigrid, TwoMgLevel)
 
     ASSERT_EQ(mg_level.size(), 2);
     ASSERT_NE(mg_level.at(0), mg_level.at(1));
-    ASSERT_EQ(this->get_value(mg_level.at(0).get()), 5);
-    ASSERT_EQ(this->get_value(mg_level.at(1).get()), 2);
-    ASSERT_EQ(this->get_value(pre_smoother.at(0).get()), 5);
-    ASSERT_EQ(this->get_value(pre_smoother.at(1).get()), 2);
-    ASSERT_EQ(this->get_value(mid_smoother.at(0).get()), 5);
-    ASSERT_EQ(this->get_value(mid_smoother.at(1).get()), 2);
-    ASSERT_EQ(this->get_value(post_smoother.at(0).get()), 2);
-    ASSERT_EQ(this->get_value(post_smoother.at(1).get()), 5);
+    ASSERT_EQ(this->get_value(mg_level.at(0)), 5);
+    ASSERT_EQ(this->get_value(mg_level.at(1)), 2);
+    ASSERT_EQ(this->get_value(pre_smoother.at(0)), 5);
+    ASSERT_EQ(this->get_value(pre_smoother.at(1)), 2);
+    ASSERT_EQ(this->get_value(mid_smoother.at(0)), 5);
+    ASSERT_EQ(this->get_value(mid_smoother.at(1)), 2);
+    ASSERT_EQ(this->get_value(post_smoother.at(0)), 2);
+    ASSERT_EQ(this->get_value(post_smoother.at(1)), 5);
     // coarset_solver is identity by default
     ASSERT_NE(identity, nullptr);
 }
@@ -656,14 +649,14 @@ TYPED_TEST(Multigrid, TwoMgLevelWithOneSmootherRelaxation)
 
     ASSERT_EQ(mg_level.size(), 2);
     ASSERT_NE(mg_level.at(0), mg_level.at(1));
-    ASSERT_EQ(this->get_value(mg_level.at(0).get()), 5);
-    ASSERT_EQ(this->get_value(mg_level.at(1).get()), 2);
-    ASSERT_EQ(this->get_value(pre_smoother.at(0).get()), 5);
-    ASSERT_EQ(this->get_value(pre_smoother.at(1).get()), 5);
-    ASSERT_EQ(this->get_value(mid_smoother.at(0).get()), 5);
-    ASSERT_EQ(this->get_value(mid_smoother.at(1).get()), 5);
-    ASSERT_EQ(this->get_value(post_smoother.at(0).get()), 2);
-    ASSERT_EQ(this->get_value(post_smoother.at(1).get()), 2);
+    ASSERT_EQ(this->get_value(mg_level.at(0)), 5);
+    ASSERT_EQ(this->get_value(mg_level.at(1)), 2);
+    ASSERT_EQ(this->get_value(pre_smoother.at(0)), 5);
+    ASSERT_EQ(this->get_value(pre_smoother.at(1)), 5);
+    ASSERT_EQ(this->get_value(mid_smoother.at(0)), 5);
+    ASSERT_EQ(this->get_value(mid_smoother.at(1)), 5);
+    ASSERT_EQ(this->get_value(post_smoother.at(0)), 2);
+    ASSERT_EQ(this->get_value(post_smoother.at(1)), 2);
     ASSERT_NE(identity, nullptr);
 }
 
@@ -696,20 +689,20 @@ TYPED_TEST(Multigrid, CustomSelectorWithSameSize)
     auto post_smoother = solver->get_post_smoother_list();
 
     ASSERT_EQ(mg_level.size(), 2);
-    ASSERT_EQ(this->get_value(mg_level.at(0).get()), 2);
-    ASSERT_EQ(this->get_value(mg_level.at(1).get()), 5);
+    ASSERT_EQ(this->get_value(mg_level.at(0)), 2);
+    ASSERT_EQ(this->get_value(mg_level.at(1)), 5);
     // pre_smoother use the same index as mg_level
     ASSERT_EQ(pre_smoother.size(), 2);
-    ASSERT_EQ(this->get_value(pre_smoother.at(0).get()), 2);
-    ASSERT_EQ(this->get_value(pre_smoother.at(1).get()), 5);
+    ASSERT_EQ(this->get_value(pre_smoother.at(0)), 2);
+    ASSERT_EQ(this->get_value(pre_smoother.at(1)), 5);
     // pre_smoother use the same index as mg_level
     ASSERT_EQ(mid_smoother.size(), 2);
-    ASSERT_EQ(this->get_value(mid_smoother.at(0).get()), 5);
-    ASSERT_EQ(this->get_value(mid_smoother.at(1).get()), 2);
+    ASSERT_EQ(this->get_value(mid_smoother.at(0)), 5);
+    ASSERT_EQ(this->get_value(mid_smoother.at(1)), 2);
     // post_smoother has the same index as mg_level
     ASSERT_EQ(post_smoother.size(), 2);
-    ASSERT_EQ(this->get_value(post_smoother.at(0).get()), 2);
-    ASSERT_EQ(this->get_value(post_smoother.at(1).get()), 5);
+    ASSERT_EQ(this->get_value(post_smoother.at(0)), 2);
+    ASSERT_EQ(this->get_value(post_smoother.at(1)), 5);
 }
 
 
@@ -741,20 +734,20 @@ TYPED_TEST(Multigrid, CustomSelectorWithOneSmootherRelaxation)
     auto post_smoother = solver->get_post_smoother_list();
 
     ASSERT_EQ(mg_level.size(), 2);
-    ASSERT_EQ(this->get_value(mg_level.at(0).get()), 2);
-    ASSERT_EQ(this->get_value(mg_level.at(1).get()), 5);
+    ASSERT_EQ(this->get_value(mg_level.at(0)), 2);
+    ASSERT_EQ(this->get_value(mg_level.at(1)), 5);
     // pre_smoother always uses the same factory
     ASSERT_EQ(pre_smoother.size(), 2);
-    ASSERT_EQ(this->get_value(pre_smoother.at(0).get()), 5);
-    ASSERT_EQ(this->get_value(pre_smoother.at(1).get()), 5);
+    ASSERT_EQ(this->get_value(pre_smoother.at(0)), 5);
+    ASSERT_EQ(this->get_value(pre_smoother.at(1)), 5);
     // mid_smoother always uses the same factory
     ASSERT_EQ(mid_smoother.size(), 2);
-    ASSERT_EQ(this->get_value(mid_smoother.at(0).get()), 5);
-    ASSERT_EQ(this->get_value(mid_smoother.at(1).get()), 5);
+    ASSERT_EQ(this->get_value(mid_smoother.at(0)), 5);
+    ASSERT_EQ(this->get_value(mid_smoother.at(1)), 5);
     // post_smoother always uses the same factory
     ASSERT_EQ(post_smoother.size(), 2);
-    ASSERT_EQ(this->get_value(post_smoother.at(0).get()), 2);
-    ASSERT_EQ(this->get_value(post_smoother.at(1).get()), 2);
+    ASSERT_EQ(this->get_value(post_smoother.at(0)), 2);
+    ASSERT_EQ(this->get_value(post_smoother.at(1)), 2);
 }
 
 
@@ -785,20 +778,20 @@ TYPED_TEST(Multigrid, CustomSelectorWithMix)
     auto post_smoother = solver->get_post_smoother_list();
 
     ASSERT_EQ(mg_level.size(), 2);
-    ASSERT_EQ(this->get_value(mg_level.at(0).get()), 2);
-    ASSERT_EQ(this->get_value(mg_level.at(1).get()), 5);
+    ASSERT_EQ(this->get_value(mg_level.at(0)), 2);
+    ASSERT_EQ(this->get_value(mg_level.at(1)), 5);
     // pre_smoother always uses the same factory
     ASSERT_EQ(pre_smoother.size(), 2);
-    ASSERT_EQ(this->get_value(pre_smoother.at(0).get()), 5);
-    ASSERT_EQ(this->get_value(pre_smoother.at(1).get()), 5);
+    ASSERT_EQ(this->get_value(pre_smoother.at(0)), 5);
+    ASSERT_EQ(this->get_value(pre_smoother.at(1)), 5);
     // mid_smoother uses the nullptr by default
     ASSERT_EQ(mid_smoother.size(), 2);
-    ASSERT_EQ(mid_smoother.at(0).get(), nullptr);
-    ASSERT_EQ(mid_smoother.at(1).get(), nullptr);
+    ASSERT_EQ(mid_smoother.at(0), nullptr);
+    ASSERT_EQ(mid_smoother.at(1), nullptr);
     // post_smoother uses the same index as mg_level
     ASSERT_EQ(post_smoother.size(), 2);
-    ASSERT_EQ(this->get_value(post_smoother.at(0).get()), 5);
-    ASSERT_EQ(this->get_value(post_smoother.at(1).get()), 2);
+    ASSERT_EQ(this->get_value(post_smoother.at(0)), 5);
+    ASSERT_EQ(this->get_value(post_smoother.at(1)), 2);
 }
 
 
@@ -820,8 +813,8 @@ TYPED_TEST(Multigrid, PostUsesPre)
     auto pre_smoother = solver->get_pre_smoother_list();
     auto post_smoother = solver->get_post_smoother_list();
 
-    ASSERT_EQ(this->get_value(pre_smoother.at(0).get()), 5);
-    ASSERT_EQ(this->get_value(pre_smoother.at(1).get()), 2);
+    ASSERT_EQ(this->get_value(pre_smoother.at(0)), 5);
+    ASSERT_EQ(this->get_value(pre_smoother.at(1)), 2);
     // post_smoother ignore the manual setting because the post_uses_pre = true
     // the elements are copied from pre_smoother, so the pointers are the same
     ASSERT_EQ(post_smoother.size(), 2);
@@ -850,8 +843,8 @@ TYPED_TEST(Multigrid, MidUsesPre)
     auto pre_smoother = solver->get_pre_smoother_list();
     auto mid_smoother = solver->get_mid_smoother_list();
 
-    ASSERT_EQ(this->get_value(pre_smoother.at(0).get()), 5);
-    ASSERT_EQ(this->get_value(pre_smoother.at(1).get()), 2);
+    ASSERT_EQ(this->get_value(pre_smoother.at(0)), 5);
+    ASSERT_EQ(this->get_value(pre_smoother.at(1)), 2);
     // mid is handled by the pre smoother of next level, so the mid_smoother is
     // empty mid_smoother ignores the manual setting because
     // multigrid::mid_smooth_type::pre_smoother
@@ -881,8 +874,8 @@ TYPED_TEST(Multigrid, MidUsesPost)
     auto post_smoother = solver->get_post_smoother_list();
     auto mid_smoother = solver->get_mid_smoother_list();
 
-    ASSERT_EQ(this->get_value(post_smoother.at(0).get()), 5);
-    ASSERT_EQ(this->get_value(post_smoother.at(1).get()), 2);
+    ASSERT_EQ(this->get_value(post_smoother.at(0)), 5);
+    ASSERT_EQ(this->get_value(post_smoother.at(1)), 2);
     // mid is handled by the post smoother of previous level, so the
     // mid_smoother is empty mid_smoother ignores the manual setting because
     // multigrid::mid_smooth_type::post_smoother
@@ -913,8 +906,8 @@ TYPED_TEST(Multigrid, PostUsesPreAndMidUsesPre)
     auto post_smoother = solver->get_post_smoother_list();
 
     ASSERT_EQ(pre_smoother.size(), 2);
-    ASSERT_EQ(this->get_value(pre_smoother.at(0).get()), 5);
-    ASSERT_EQ(this->get_value(pre_smoother.at(1).get()), 2);
+    ASSERT_EQ(this->get_value(pre_smoother.at(0)), 5);
+    ASSERT_EQ(this->get_value(pre_smoother.at(1)), 2);
     // post uses pre
     ASSERT_EQ(post_smoother.size(), 2);
     ASSERT_EQ(post_smoother.at(0).get(), pre_smoother.at(0).get());
@@ -949,8 +942,8 @@ TYPED_TEST(Multigrid, PostUsesPreAndMidUsesPost)
     auto post_smoother = solver->get_post_smoother_list();
 
     ASSERT_EQ(pre_smoother.size(), 2);
-    ASSERT_EQ(this->get_value(pre_smoother.at(0).get()), 5);
-    ASSERT_EQ(this->get_value(pre_smoother.at(1).get()), 2);
+    ASSERT_EQ(this->get_value(pre_smoother.at(0)), 5);
+    ASSERT_EQ(this->get_value(pre_smoother.at(1)), 2);
     // post uses pre
     ASSERT_EQ(post_smoother.size(), 2);
     ASSERT_EQ(post_smoother.at(0).get(), pre_smoother.at(0).get());
@@ -977,7 +970,7 @@ TYPED_TEST(Multigrid, DefaultCoarsestSolverSelectorUsesTheFirstOne)
                       ->generate(this->mtx);
     auto coarsest_solver = solver->get_coarsest_solver();
 
-    ASSERT_EQ(this->get_value(coarsest_solver.get()), 5);
+    ASSERT_EQ(this->get_value(coarsest_solver), 5);
 }
 
 
@@ -1001,7 +994,7 @@ TYPED_TEST(Multigrid, CustomCoarsestSolverSelector)
                       ->generate(this->mtx);
     auto coarsest_solver = solver->get_coarsest_solver();
 
-    ASSERT_EQ(this->get_value(coarsest_solver.get()), 2);
+    ASSERT_EQ(this->get_value(coarsest_solver), 2);
 }
 
 

--- a/core/test/utils.hpp
+++ b/core/test/utils.hpp
@@ -48,6 +48,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <ginkgo/core/base/math.hpp>
 #include <ginkgo/core/base/name_demangling.hpp>
 #include <ginkgo/core/base/types.hpp>
+#include <ginkgo/core/base/utils_helper.hpp>
 
 
 #include "core/base/extended_float.hpp"
@@ -236,6 +237,22 @@ template <typename Precision1, typename Precision2>
 constexpr double r_mixed()
 {
     return std::max<double>(r<Precision1>::value, r<Precision2>::value);
+}
+
+
+template <typename PtrType>
+gko::remove_complex<typename gko::detail::pointee<PtrType>::value_type>
+inf_norm(PtrType&& mat, size_t col = 0)
+{
+    using T = typename gko::detail::pointee<PtrType>::value_type;
+    using std::abs;
+    using no_cpx_t = gko::remove_complex<T>;
+    no_cpx_t norm = 0.0;
+    for (size_t i = 0; i < mat->get_size()[0]; ++i) {
+        no_cpx_t absEntry = abs(mat->at(i, col));
+        if (norm < absEntry) norm = absEntry;
+    }
+    return norm;
 }
 
 

--- a/core/test/utils.hpp
+++ b/core/test/utils.hpp
@@ -248,7 +248,7 @@ inf_norm(PtrType&& mat, size_t col = 0)
     using std::abs;
     using no_cpx_t = gko::remove_complex<T>;
     no_cpx_t norm = 0.0;
-    for (size_t i = 0; i < mat->get_size()[0]; ++i) {
+    for (std::size_t i = 0; i < mat->get_size()[0]; ++i) {
         no_cpx_t absEntry = abs(mat->at(i, col));
         if (norm < absEntry) norm = absEntry;
     }

--- a/core/test/utils/assertions.hpp
+++ b/core/test/utils/assertions.hpp
@@ -881,8 +881,8 @@ T* plain_ptr(const std::shared_ptr<T>& ptr)
     return ptr.get();
 }
 
-template <typename T>
-T* plain_ptr(const std::unique_ptr<T>& ptr)
+template <typename T, typename Deleter>
+T* plain_ptr(const std::unique_ptr<T, Deleter>& ptr)
 {
     return ptr.get();
 }

--- a/core/test/utils/fb_matrix_generator.hpp
+++ b/core/test/utils/fb_matrix_generator.hpp
@@ -243,7 +243,7 @@ std::unique_ptr<matrix::Fbcsr<ValueType, IndexType>> generate_random_fbcsr(
                   std::normal_distribution<real_type>(0.0, 1.0),
                   std::move(engine), ref);
     if (unsort && rand_csr_ref->is_sorted_by_column_index()) {
-        unsort_matrix(rand_csr_ref.get(), engine);
+        unsort_matrix(rand_csr_ref, engine);
     }
     return generate_fbcsr_from_csr(ref, rand_csr_ref.get(), mat_blk_sz,
                                    diag_dominant, std::move(engine));

--- a/core/test/utils/unsort_matrix.hpp
+++ b/core/test/utils/unsort_matrix.hpp
@@ -69,8 +69,8 @@ void unsort_matrix(matrix::Csr<ValueType, IndexType>* mtx,
     // unsorting there, followed by copying it back
     if (exec != master) {
         auto h_mtx = mtx->clone(master);
-        unsort_matrix(lend(h_mtx), engine);
-        mtx->copy_from(lend(h_mtx));
+        unsort_matrix(h_mtx.get(), engine);
+        mtx->copy_from(h_mtx.get());
         return;
     }
 
@@ -107,8 +107,8 @@ void unsort_matrix(matrix::Coo<ValueType, IndexType>* mtx,
     // unsorting there, followed by copying it back
     if (exec != master) {
         auto h_mtx = mtx->clone(master);
-        unsort_matrix(lend(h_mtx), engine);
-        mtx->copy_from(lend(h_mtx));
+        unsort_matrix(h_mtx.get(), engine);
+        mtx->copy_from(h_mtx.get());
         return;
     }
     matrix_data<value_type, index_type> data;

--- a/core/test/utils/unsort_matrix.hpp
+++ b/core/test/utils/unsort_matrix.hpp
@@ -52,49 +52,11 @@ namespace test {
 
 // Plan for now: shuffle values and column indices to unsort the given matrix
 // without changing the represented matrix.
-template <typename ValueType, typename IndexType, typename RandomEngine>
-void unsort_matrix(matrix::Csr<ValueType, IndexType>* mtx,
-                   RandomEngine&& engine)
+template <typename MtxPtr, typename RandomEngine>
+void unsort_matrix(MtxPtr&& mtx, RandomEngine&& engine)
 {
-    using value_type = ValueType;
-    using index_type = IndexType;
-    auto size = mtx->get_size();
-    if (mtx->get_num_stored_elements() <= 0) {
-        return;
-    }
-    const auto exec = mtx->get_executor();
-    const auto master = exec->get_master();
-
-    // If exec is not the master/host, extract the master and perform the
-    // unsorting there, followed by copying it back
-    if (exec != master) {
-        auto h_mtx = mtx->clone(master);
-        unsort_matrix(h_mtx.get(), engine);
-        mtx->copy_from(h_mtx.get());
-        return;
-    }
-
-    auto vals = mtx->get_values();
-    auto row_ptrs = mtx->get_row_ptrs();
-    auto cols = mtx->get_col_idxs();
-
-    for (index_type row = 0; row < size[0]; ++row) {
-        auto start = row_ptrs[row];
-        auto end = row_ptrs[row + 1];
-        auto it = gko::detail::make_zip_iterator(cols + start, vals + start);
-        std::shuffle(it, it + (end - start), engine);
-    }
-}
-
-
-// Plan for now: shuffle values and column indices to unsort the given matrix
-// without changing the represented matrix.
-template <typename ValueType, typename IndexType, typename RandomEngine>
-void unsort_matrix(matrix::Coo<ValueType, IndexType>* mtx,
-                   RandomEngine&& engine)
-{
-    using value_type = ValueType;
-    using index_type = IndexType;
+    using value_type = gko::detail::pointee<decltype(mtx->get_values())>;
+    using index_type = gko::detail::pointee<decltype(mtx->get_col_idxs())>;
     auto nnz = mtx->get_num_stored_elements();
     if (nnz <= 0) {
         return;
@@ -107,8 +69,8 @@ void unsort_matrix(matrix::Coo<ValueType, IndexType>* mtx,
     // unsorting there, followed by copying it back
     if (exec != master) {
         auto h_mtx = mtx->clone(master);
-        unsort_matrix(h_mtx.get(), engine);
-        mtx->copy_from(h_mtx.get());
+        unsort_matrix(h_mtx, engine);
+        mtx->copy_from(h_mtx);
         return;
     }
     matrix_data<value_type, index_type> data;

--- a/core/test/utils/unsort_matrix_test.cpp
+++ b/core/test/utils/unsort_matrix_test.cpp
@@ -157,11 +157,11 @@ TYPED_TEST(UnsortMatrix, CsrWorks)
 {
     auto csr = this->get_sorted_csr();
     const auto ref_mtx = this->get_sorted_csr();
-    bool was_sorted = this->is_csr_matrix_sorted(gko::lend(csr));
+    bool was_sorted = this->is_csr_matrix_sorted(csr.get());
 
-    gko::test::unsort_matrix(gko::lend(csr), this->rand_engine);
+    gko::test::unsort_matrix(csr.get(), this->rand_engine);
 
-    ASSERT_FALSE(this->is_csr_matrix_sorted(gko::lend(csr)));
+    ASSERT_FALSE(this->is_csr_matrix_sorted(csr.get()));
     ASSERT_TRUE(was_sorted);
     GKO_ASSERT_MTX_NEAR(csr, ref_mtx, 0.);
 }
@@ -169,10 +169,9 @@ TYPED_TEST(UnsortMatrix, CsrWorks)
 
 TYPED_TEST(UnsortMatrix, CsrWorksWithEmpty)
 {
-    const bool was_sorted =
-        this->is_csr_matrix_sorted(gko::lend(this->csr_empty));
+    const bool was_sorted = this->is_csr_matrix_sorted(this->csr_empty.get());
 
-    gko::test::unsort_matrix(gko::lend(this->csr_empty), this->rand_engine);
+    gko::test::unsort_matrix(this->csr_empty.get(), this->rand_engine);
 
     ASSERT_TRUE(was_sorted);
     ASSERT_EQ(this->csr_empty->get_num_stored_elements(), 0);
@@ -183,11 +182,11 @@ TYPED_TEST(UnsortMatrix, CooWorks)
 {
     auto coo = this->get_sorted_coo();
     const auto ref_mtx = this->get_sorted_coo();
-    const bool was_sorted = this->is_coo_matrix_sorted(gko::lend(coo));
+    const bool was_sorted = this->is_coo_matrix_sorted(coo.get());
 
-    gko::test::unsort_matrix(gko::lend(coo), this->rand_engine);
+    gko::test::unsort_matrix(coo.get(), this->rand_engine);
 
-    ASSERT_FALSE(this->is_coo_matrix_sorted(gko::lend(coo)));
+    ASSERT_FALSE(this->is_coo_matrix_sorted(coo.get()));
     ASSERT_TRUE(was_sorted);
     GKO_ASSERT_MTX_NEAR(coo, ref_mtx, 0.);
 }
@@ -195,10 +194,9 @@ TYPED_TEST(UnsortMatrix, CooWorks)
 
 TYPED_TEST(UnsortMatrix, CooWorksWithEmpty)
 {
-    const bool was_sorted =
-        this->is_coo_matrix_sorted(gko::lend(this->coo_empty));
+    const bool was_sorted = this->is_coo_matrix_sorted(this->coo_empty.get());
 
-    gko::test::unsort_matrix(gko::lend(this->coo_empty), this->rand_engine);
+    gko::test::unsort_matrix(this->coo_empty.get(), this->rand_engine);
 
     ASSERT_TRUE(was_sorted);
     ASSERT_EQ(this->coo_empty->get_num_stored_elements(), 0);

--- a/core/test/utils/unsort_matrix_test.cpp
+++ b/core/test/utils/unsort_matrix_test.cpp
@@ -95,7 +95,7 @@ protected:
                            I<index_type>{0, 0, 2, 2, 2, 2, 3, 4, 4, 4});
     }
 
-    bool is_coo_matrix_sorted(Coo* mtx)
+    bool is_coo_matrix_sorted(gko::pointer_param<Coo> mtx)
     {
         auto rows = mtx->get_const_row_idxs();
         auto cols = mtx->get_const_col_idxs();
@@ -119,7 +119,7 @@ protected:
         return true;
     }
 
-    bool is_csr_matrix_sorted(Csr* mtx)
+    bool is_csr_matrix_sorted(gko::pointer_param<Csr> mtx)
     {
         auto size = mtx->get_size();
         auto rows = mtx->get_const_row_ptrs();
@@ -157,11 +157,11 @@ TYPED_TEST(UnsortMatrix, CsrWorks)
 {
     auto csr = this->get_sorted_csr();
     const auto ref_mtx = this->get_sorted_csr();
-    bool was_sorted = this->is_csr_matrix_sorted(csr.get());
+    bool was_sorted = this->is_csr_matrix_sorted(csr);
 
-    gko::test::unsort_matrix(csr.get(), this->rand_engine);
+    gko::test::unsort_matrix(csr, this->rand_engine);
 
-    ASSERT_FALSE(this->is_csr_matrix_sorted(csr.get()));
+    ASSERT_FALSE(this->is_csr_matrix_sorted(csr));
     ASSERT_TRUE(was_sorted);
     GKO_ASSERT_MTX_NEAR(csr, ref_mtx, 0.);
 }
@@ -169,9 +169,9 @@ TYPED_TEST(UnsortMatrix, CsrWorks)
 
 TYPED_TEST(UnsortMatrix, CsrWorksWithEmpty)
 {
-    const bool was_sorted = this->is_csr_matrix_sorted(this->csr_empty.get());
+    const bool was_sorted = this->is_csr_matrix_sorted(this->csr_empty);
 
-    gko::test::unsort_matrix(this->csr_empty.get(), this->rand_engine);
+    gko::test::unsort_matrix(this->csr_empty, this->rand_engine);
 
     ASSERT_TRUE(was_sorted);
     ASSERT_EQ(this->csr_empty->get_num_stored_elements(), 0);
@@ -182,11 +182,11 @@ TYPED_TEST(UnsortMatrix, CooWorks)
 {
     auto coo = this->get_sorted_coo();
     const auto ref_mtx = this->get_sorted_coo();
-    const bool was_sorted = this->is_coo_matrix_sorted(coo.get());
+    const bool was_sorted = this->is_coo_matrix_sorted(coo);
 
-    gko::test::unsort_matrix(coo.get(), this->rand_engine);
+    gko::test::unsort_matrix(coo, this->rand_engine);
 
-    ASSERT_FALSE(this->is_coo_matrix_sorted(coo.get()));
+    ASSERT_FALSE(this->is_coo_matrix_sorted(coo));
     ASSERT_TRUE(was_sorted);
     GKO_ASSERT_MTX_NEAR(coo, ref_mtx, 0.);
 }
@@ -194,9 +194,9 @@ TYPED_TEST(UnsortMatrix, CooWorks)
 
 TYPED_TEST(UnsortMatrix, CooWorksWithEmpty)
 {
-    const bool was_sorted = this->is_coo_matrix_sorted(this->coo_empty.get());
+    const bool was_sorted = this->is_coo_matrix_sorted(this->coo_empty);
 
-    gko::test::unsort_matrix(this->coo_empty.get(), this->rand_engine);
+    gko::test::unsort_matrix(this->coo_empty, this->rand_engine);
 
     ASSERT_TRUE(was_sorted);
     ASSERT_EQ(this->coo_empty->get_num_stored_elements(), 0);

--- a/core/test/utils/unsort_matrix_test.cpp
+++ b/core/test/utils/unsort_matrix_test.cpp
@@ -95,7 +95,7 @@ protected:
                            I<index_type>{0, 0, 2, 2, 2, 2, 3, 4, 4, 4});
     }
 
-    bool is_coo_matrix_sorted(gko::pointer_param<Coo> mtx)
+    bool is_coo_matrix_sorted(gko::ptr_param<Coo> mtx)
     {
         auto rows = mtx->get_const_row_idxs();
         auto cols = mtx->get_const_col_idxs();
@@ -119,7 +119,7 @@ protected:
         return true;
     }
 
-    bool is_csr_matrix_sorted(gko::pointer_param<Csr> mtx)
+    bool is_csr_matrix_sorted(gko::ptr_param<Csr> mtx)
     {
         auto size = mtx->get_size();
         auto rows = mtx->get_const_row_ptrs();

--- a/core/utils/matrix_utils.hpp
+++ b/core/utils/matrix_utils.hpp
@@ -275,7 +275,7 @@ void make_hpd(matrix_data<ValueType, IndexType>& data,
  */
 template <typename MtxType>
 void remove_diagonal_entry_from_row(
-    MtxType* const mtx, const typename MtxType::index_type row_to_process)
+    MtxType* mtx, const typename MtxType::index_type row_to_process)
 {
     using value_type = typename MtxType::value_type;
     using index_type = typename MtxType::index_type;
@@ -295,7 +295,7 @@ void remove_diagonal_entry_from_row(
  * Ensures each row has a diagonal entry.
  */
 template <typename MtxType>
-void ensure_all_diagonal_entries(MtxType* const mtx)
+void ensure_all_diagonal_entries(MtxType* mtx)
 {
     using value_type = typename MtxType::value_type;
     using index_type = typename MtxType::index_type;

--- a/cuda/factorization/par_ilut_select_common.cu
+++ b/cuda/factorization/par_ilut_select_common.cu
@@ -102,7 +102,7 @@ sampleselect_bucket<IndexType> sampleselect_find_bucket(
 {
     kernel::find_bucket<<<1, config::warp_size>>>(prefix_sum, rank);
     IndexType values[3]{};
-    exec->get_master()->copy_from(exec.get(), 3, prefix_sum, values);
+    exec->get_master()->copy_from(exec, 3, prefix_sum, values);
     return {values[0], values[1], values[2]};
 }
 

--- a/cuda/matrix/fbcsr_kernels.cu
+++ b/cuda/matrix/fbcsr_kernels.cu
@@ -376,8 +376,7 @@ void is_sorted_by_column_index(
     *is_sorted = true;
     auto gpu_array = array<bool>(exec, 1);
     // need to initialize the GPU value to true
-    exec->copy_from(exec->get_master().get(), 1, is_sorted,
-                    gpu_array.get_data());
+    exec->copy_from(exec->get_master(), 1, is_sorted, gpu_array.get_data());
     auto block_size = default_block_size;
     const auto num_brows =
         static_cast<IndexType>(to_check->get_num_block_rows());

--- a/cuda/test/base/cuda_executor.cu
+++ b/cuda/test/base/cuda_executor.cu
@@ -175,7 +175,7 @@ TEST_F(CudaExecutor, CopiesDataToCuda)
     int orig[] = {3, 8};
     auto* copy = cuda->alloc<int>(2);
 
-    cuda->copy_from(omp.get(), 2, orig, copy);
+    cuda->copy_from(omp, 2, orig, copy);
 
     check_data<<<1, 1>>>(copy);
     ASSERT_NO_THROW(cuda->synchronize());
@@ -196,7 +196,7 @@ TEST_F(CudaExecutor, CanAllocateOnUnifiedMemory)
     int orig[] = {3, 8};
     auto* copy = cuda3->alloc<int>(2);
 
-    cuda3->copy_from(omp.get(), 2, orig, copy);
+    cuda3->copy_from(omp, 2, orig, copy);
 
     check_data<<<1, 1>>>(copy);
     ASSERT_NO_THROW(cuda3->synchronize());
@@ -218,7 +218,7 @@ TEST_F(CudaExecutor, CopiesDataFromCuda)
     auto orig = cuda->alloc<int>(2);
     init_data<<<1, 1>>>(orig);
 
-    omp->copy_from(cuda.get(), 2, orig, copy);
+    omp->copy_from(cuda, 2, orig, copy);
 
     EXPECT_EQ(3, copy[0]);
     ASSERT_EQ(8, copy[1]);
@@ -261,7 +261,7 @@ TEST_F(CudaExecutor, CopiesDataFromCudaToCuda)
     init_data<<<1, 1>>>(orig);
 
     auto copy_cuda2 = cuda2->alloc<int>(2);
-    cuda2->copy_from(cuda.get(), 2, orig, copy_cuda2);
+    cuda2->copy_from(cuda, 2, orig, copy_cuda2);
 
     // Check that the data is really on GPU2 and ensure we did not cheat
     int value = -1;
@@ -271,7 +271,7 @@ TEST_F(CudaExecutor, CopiesDataFromCudaToCuda)
     cuda2->run(ExampleOperation(value));
     ASSERT_EQ(value, cuda2->get_device_id());
     // Put the results on OpenMP and run CPU side assertions
-    omp->copy_from(cuda2.get(), 2, copy_cuda2, copy);
+    omp->copy_from(cuda2, 2, copy_cuda2, copy);
     EXPECT_EQ(3, copy[0]);
     ASSERT_EQ(8, copy[1]);
     cuda2->free(copy_cuda2);

--- a/cuda/test/base/kernel_launch.cu
+++ b/cuda/test/base/kernel_launch.cu
@@ -110,7 +110,7 @@ protected:
         }
         zero_dense->fill(0.0);
         zero_dense2->fill(0.0);
-        iota_dense->copy_from(ref_iota_dense.get());
+        iota_dense->copy_from(ref_iota_dense);
         zero_array.set_executor(exec);
         iota_array.set_executor(exec);
         iota_transp_array.set_executor(exec);

--- a/cuda/test/base/lin_op.cu
+++ b/cuda/test/base/lin_op.cu
@@ -105,7 +105,7 @@ protected:
 
 TEST_F(EnableLinOp, ApplyCopiesDataToCorrectExecutor)
 {
-    op->apply(gko::lend(b), gko::lend(x));
+    op->apply(b, x);
 
     ASSERT_EQ(op->last_b_access, cuda);
     ASSERT_EQ(op->last_x_access, cuda);
@@ -114,7 +114,7 @@ TEST_F(EnableLinOp, ApplyCopiesDataToCorrectExecutor)
 
 TEST_F(EnableLinOp, ApplyCopiesBackOnlyX)
 {
-    op->apply(gko::lend(b), gko::lend(x));
+    op->apply(b, x);
 
     ASSERT_EQ(b->last_access, nullptr);
     ASSERT_EQ(x->last_access, cuda);
@@ -123,7 +123,7 @@ TEST_F(EnableLinOp, ApplyCopiesBackOnlyX)
 
 TEST_F(EnableLinOp, ExtendedApplyCopiesDataToCorrectExecutor)
 {
-    op->apply(gko::lend(alpha), gko::lend(b), gko::lend(beta), gko::lend(x));
+    op->apply(alpha, b, beta, x);
 
     ASSERT_EQ(op->last_alpha_access, cuda);
     ASSERT_EQ(op->last_b_access, cuda);
@@ -134,7 +134,7 @@ TEST_F(EnableLinOp, ExtendedApplyCopiesDataToCorrectExecutor)
 
 TEST_F(EnableLinOp, ExtendedApplyCopiesBackOnlyX)
 {
-    op->apply(gko::lend(alpha), gko::lend(b), gko::lend(beta), gko::lend(x));
+    op->apply(alpha, b, beta, x);
 
     ASSERT_EQ(alpha->last_access, nullptr);
     ASSERT_EQ(b->last_access, nullptr);

--- a/cuda/test/solver/lower_trs_kernels.cpp
+++ b/cuda/test/solver/lower_trs_kernels.cpp
@@ -96,13 +96,13 @@ protected:
         b = gen_mtx(m, n);
         x = gen_mtx(m, n);
         csr_mtx = CsrMtx::create(ref);
-        mtx->convert_to(csr_mtx.get());
+        mtx->convert_to(csr_mtx);
         d_csr_mtx = CsrMtx::create(cuda);
         d_x = gko::clone(cuda, x);
-        d_csr_mtx->copy_from(csr_mtx.get());
+        d_csr_mtx->copy_from(csr_mtx);
         b2 = Mtx::create(ref);
         d_b2 = gko::clone(cuda, b);
-        b2->copy_from(b.get());
+        b2->copy_from(b);
     }
 
     std::shared_ptr<Mtx> b;
@@ -142,8 +142,8 @@ TEST_F(LowerTrs, CudaSingleRhsApplySyncfreeIsEquivalentToRef)
     auto solver = lower_trs_factory->generate(csr_mtx);
     auto d_solver = d_lower_trs_factory->generate(d_csr_mtx);
 
-    solver->apply(b2.get(), x.get());
-    d_solver->apply(d_b2.get(), d_x.get());
+    solver->apply(b2, x);
+    d_solver->apply(d_b2, d_x);
 
     GKO_ASSERT_MTX_NEAR(d_x, x, 1e-14);
 }
@@ -157,8 +157,8 @@ TEST_F(LowerTrs, CudaSingleRhsApplyIsEquivalentToRef)
     auto solver = lower_trs_factory->generate(csr_mtx);
     auto d_solver = d_lower_trs_factory->generate(d_csr_mtx);
 
-    solver->apply(b2.get(), x.get());
-    d_solver->apply(d_b2.get(), d_x.get());
+    solver->apply(b2, x);
+    d_solver->apply(d_b2, d_x);
 
     GKO_ASSERT_MTX_NEAR(d_x, x, 1e-14);
 }
@@ -177,11 +177,11 @@ TEST_F(LowerTrs, CudaMultipleRhsApplySyncfreeIsEquivalentToRef)
     auto solver = lower_trs_factory->generate(csr_mtx);
     auto d_solver = d_lower_trs_factory->generate(d_csr_mtx);
     auto db2_strided = Mtx::create(cuda, b->get_size(), 4);
-    d_b2->convert_to(db2_strided.get());
+    d_b2->convert_to(db2_strided);
     auto dx_strided = Mtx::create(cuda, x->get_size(), 5);
 
-    solver->apply(b2.get(), x.get());
-    d_solver->apply(db2_strided.get(), dx_strided.get());
+    solver->apply(b2, x);
+    d_solver->apply(db2_strided, dx_strided);
 
     GKO_ASSERT_MTX_NEAR(dx_strided, x, 1e-14);
 }
@@ -197,7 +197,7 @@ TEST_F(LowerTrs, CudaMultipleRhsApplyIsEquivalentToRef)
     auto solver = lower_trs_factory->generate(csr_mtx);
     auto d_solver = d_lower_trs_factory->generate(d_csr_mtx);
     auto db2_strided = Mtx::create(cuda, b->get_size(), 4);
-    d_b2->convert_to(db2_strided.get());
+    d_b2->convert_to(db2_strided);
     // The cuSPARSE Generic SpSM implementation uses the wrong stride here
     // so the input and output stride need to match
 #if CUDA_VERSION >= 11031
@@ -206,8 +206,8 @@ TEST_F(LowerTrs, CudaMultipleRhsApplyIsEquivalentToRef)
     auto dx_strided = Mtx::create(cuda, x->get_size(), 5);
 #endif
 
-    solver->apply(b2.get(), x.get());
-    d_solver->apply(db2_strided.get(), dx_strided.get());
+    solver->apply(b2, x);
+    d_solver->apply(db2_strided, dx_strided);
 
     GKO_ASSERT_MTX_NEAR(dx_strided, x, 1e-14);
 }
@@ -219,7 +219,7 @@ TEST_F(LowerTrs, CudaApplyThrowsWithWrongNumRHS)
     auto d_lower_trs_factory = gko::solver::LowerTrs<>::build().on(cuda);
     auto d_solver = d_lower_trs_factory->generate(d_csr_mtx);
 
-    ASSERT_THROW(d_solver->apply(d_b2.get(), d_x.get()), gko::ValueMismatch);
+    ASSERT_THROW(d_solver->apply(d_b2, d_x), gko::ValueMismatch);
 }
 
 

--- a/cuda/test/solver/upper_trs_kernels.cpp
+++ b/cuda/test/solver/upper_trs_kernels.cpp
@@ -96,13 +96,13 @@ protected:
         b = gen_mtx(m, n);
         x = gen_mtx(m, n);
         csr_mtx = CsrMtx::create(ref);
-        mtx->convert_to(csr_mtx.get());
+        mtx->convert_to(csr_mtx);
         d_csr_mtx = CsrMtx::create(cuda);
         d_x = gko::clone(cuda, x);
-        d_csr_mtx->copy_from(csr_mtx.get());
+        d_csr_mtx->copy_from(csr_mtx);
         b2 = Mtx::create(ref);
         d_b2 = gko::clone(cuda, b);
-        b2->copy_from(b.get());
+        b2->copy_from(b);
     }
 
     std::shared_ptr<Mtx> b;
@@ -142,8 +142,8 @@ TEST_F(UpperTrs, CudaSingleRhsApplySyncfreelibIsEquivalentToRef)
     auto solver = upper_trs_factory->generate(csr_mtx);
     auto d_solver = d_upper_trs_factory->generate(d_csr_mtx);
 
-    solver->apply(b2.get(), x.get());
-    d_solver->apply(d_b2.get(), d_x.get());
+    solver->apply(b2, x);
+    d_solver->apply(d_b2, d_x);
 
     GKO_ASSERT_MTX_NEAR(d_x, x, 1e-14);
 }
@@ -157,8 +157,8 @@ TEST_F(UpperTrs, CudaSingleRhsApplyIsEquivalentToRef)
     auto solver = upper_trs_factory->generate(csr_mtx);
     auto d_solver = d_upper_trs_factory->generate(d_csr_mtx);
 
-    solver->apply(b2.get(), x.get());
-    d_solver->apply(d_b2.get(), d_x.get());
+    solver->apply(b2, x);
+    d_solver->apply(d_b2, d_x);
 
     GKO_ASSERT_MTX_NEAR(d_x, x, 1e-14);
 }
@@ -177,11 +177,11 @@ TEST_F(UpperTrs, CudaMultipleRhsApplySyncfreeIsEquivalentToRef)
     auto solver = upper_trs_factory->generate(csr_mtx);
     auto d_solver = d_upper_trs_factory->generate(d_csr_mtx);
     auto db2_strided = Mtx::create(cuda, b->get_size(), 4);
-    d_b2->convert_to(db2_strided.get());
+    d_b2->convert_to(db2_strided);
     auto dx_strided = Mtx::create(cuda, x->get_size(), 5);
 
-    solver->apply(b2.get(), x.get());
-    d_solver->apply(db2_strided.get(), dx_strided.get());
+    solver->apply(b2, x);
+    d_solver->apply(db2_strided, dx_strided);
 
     GKO_ASSERT_MTX_NEAR(dx_strided, x, 1e-14);
 }
@@ -197,7 +197,7 @@ TEST_F(UpperTrs, CudaMultipleRhsApplyIsEquivalentToRef)
     auto solver = upper_trs_factory->generate(csr_mtx);
     auto d_solver = d_upper_trs_factory->generate(d_csr_mtx);
     auto db2_strided = Mtx::create(cuda, b->get_size(), 4);
-    d_b2->convert_to(db2_strided.get());
+    d_b2->convert_to(db2_strided);
     // The cuSPARSE Generic SpSM implementation uses the wrong stride here
     // so the input and output stride need to match
 #if CUDA_VERSION >= 11030
@@ -206,8 +206,8 @@ TEST_F(UpperTrs, CudaMultipleRhsApplyIsEquivalentToRef)
     auto dx_strided = Mtx::create(cuda, x->get_size(), 5);
 #endif
 
-    solver->apply(b2.get(), x.get());
-    d_solver->apply(db2_strided.get(), dx_strided.get());
+    solver->apply(b2, x);
+    d_solver->apply(db2_strided, dx_strided);
 
     GKO_ASSERT_MTX_NEAR(dx_strided, x, 1e-14);
 }
@@ -219,7 +219,7 @@ TEST_F(UpperTrs, CudaApplyThrowsWithWrongNumRHS)
     auto d_lower_trs_factory = gko::solver::UpperTrs<>::build().on(cuda);
     auto d_solver = d_lower_trs_factory->generate(d_csr_mtx);
 
-    ASSERT_THROW(d_solver->apply(d_b2.get(), d_x.get()), gko::ValueMismatch);
+    ASSERT_THROW(d_solver->apply(d_b2, d_x), gko::ValueMismatch);
 }
 
 

--- a/cuda/test/utils/assertions_test.cpp
+++ b/cuda/test/utils/assertions_test.cpp
@@ -72,7 +72,7 @@ TEST_F(MatricesNear, CanPassCudaMatrix)
     auto mtx = gko::initialize<gko::matrix::Dense<>>(
         {{1.0, 2.0, 3.0}, {0.0, 4.0, 0.0}}, ref);
     auto csr_ref = gko::matrix::Csr<>::create(ref);
-    csr_ref->copy_from(mtx.get());
+    csr_ref->copy_from(mtx);
     auto csr_mtx = gko::matrix::Csr<>::create(cuda);
     csr_mtx->copy_from(std::move(csr_ref));
 

--- a/cuda/test/utils/assertions_test.cpp
+++ b/cuda/test/utils/assertions_test.cpp
@@ -74,7 +74,7 @@ TEST_F(MatricesNear, CanPassCudaMatrix)
     auto csr_ref = gko::matrix::Csr<>::create(ref);
     csr_ref->copy_from(mtx);
     auto csr_mtx = gko::matrix::Csr<>::create(cuda);
-    csr_mtx->copy_from(std::move(csr_ref));
+    csr_mtx->copy_from(csr_ref);
 
     GKO_EXPECT_MTX_NEAR(csr_mtx, mtx, 0.0);
     GKO_ASSERT_MTX_NEAR(csr_mtx, mtx, 0.0);

--- a/dpcpp/factorization/par_ilut_select_common.dp.cpp
+++ b/dpcpp/factorization/par_ilut_select_common.dp.cpp
@@ -109,7 +109,7 @@ sampleselect_bucket<IndexType> sampleselect_find_bucket(
     kernel::find_bucket(1, config::warp_size, 0, exec->get_queue(), prefix_sum,
                         rank);
     IndexType values[3]{};
-    exec->get_master()->copy_from(exec.get(), 3, prefix_sum, values);
+    exec->get_master()->copy_from(exec, 3, prefix_sum, values);
     return {values[0], values[1], values[2]};
 }
 

--- a/dpcpp/test/base/executor.dp.cpp
+++ b/dpcpp/test/base/executor.dp.cpp
@@ -193,7 +193,7 @@ TEST_F(DpcppExecutor, CopiesDataToCPU)
     auto* copy = dpcpp->alloc<int>(2);
     gko::array<bool> is_set(ref, 1);
 
-    dpcpp->copy_from(ref.get(), 2, orig, copy);
+    dpcpp->copy_from(ref, 2, orig, copy);
 
     is_set.set_executor(dpcpp);
     ASSERT_NO_THROW(dpcpp->synchronize());
@@ -221,7 +221,7 @@ TEST_F(DpcppExecutor, CopiesDataFromCPU)
         cgh.single_task([=]() { init_data(orig); });
     });
 
-    ref->copy_from(dpcpp.get(), 2, orig, copy);
+    ref->copy_from(dpcpp, 2, orig, copy);
 
     EXPECT_EQ(3, copy[0]);
     ASSERT_EQ(8, copy[1]);
@@ -243,7 +243,7 @@ TEST_F(DpcppExecutor, CopiesDataFromDpcppToDpcpp)
     });
 
     auto copy_dpcpp2 = dpcpp2->alloc<int>(2);
-    dpcpp2->copy_from(dpcpp.get(), 2, orig, copy_dpcpp2);
+    dpcpp2->copy_from(dpcpp, 2, orig, copy_dpcpp2);
     // Check that the data is really on GPU
     is_set.set_executor(dpcpp2);
     ASSERT_NO_THROW(dpcpp2->get_queue()->submit([&](sycl::handler& cgh) {
@@ -254,7 +254,7 @@ TEST_F(DpcppExecutor, CopiesDataFromDpcppToDpcpp)
     ASSERT_EQ(*is_set.get_data(), true);
 
     // Put the results on OpenMP and run CPU side assertions
-    ref->copy_from(dpcpp2.get(), 2, copy_dpcpp2, copy);
+    ref->copy_from(dpcpp2, 2, copy_dpcpp2, copy);
     EXPECT_EQ(3, copy[0]);
     ASSERT_EQ(8, copy[1]);
     dpcpp2->free(copy_dpcpp2);

--- a/dpcpp/test/base/kernel_launch.dp.cpp
+++ b/dpcpp/test/base/kernel_launch.dp.cpp
@@ -117,7 +117,7 @@ protected:
         }
         zero_dense->fill(0.0);
         zero_dense2->fill(0.0);
-        iota_dense->copy_from(ref_iota_dense.get());
+        iota_dense->copy_from(ref_iota_dense);
         zero_array.set_executor(exec);
         iota_array.set_executor(exec);
         iota_transp_array.set_executor(exec);

--- a/dpcpp/test/preconditioner/jacobi_kernels.cpp
+++ b/dpcpp/test/preconditioner/jacobi_kernels.cpp
@@ -636,7 +636,7 @@ TEST_F(Jacobi, DpcppPreconditionerEquivalentToRefWithFullPrecision)
     auto bj = bj_factory->generate(mtx);
     auto d_bj = d_bj_factory->generate(mtx);
 
-    GKO_ASSERT_MTX_NEAR(lend(d_bj), lend(bj), 1e-13);
+    GKO_ASSERT_MTX_NEAR(d_bj, bj, 1e-13);
 }
 
 
@@ -649,7 +649,7 @@ TEST_F(Jacobi, DpcppPreconditionerEquivalentToRefWithReducedPrecision)
     auto bj = bj_factory->generate(mtx);
     auto d_bj = d_bj_factory->generate(mtx);
 
-    GKO_ASSERT_MTX_NEAR(lend(d_bj), lend(bj), 1e-5);
+    GKO_ASSERT_MTX_NEAR(d_bj, bj, 1e-5);
 }
 
 
@@ -662,7 +662,7 @@ TEST_F(Jacobi, DpcppPreconditionerEquivalentToRefWithCustomReducedPrecision)
     auto bj = bj_factory->generate(mtx);
     auto d_bj = d_bj_factory->generate(mtx);
 
-    GKO_ASSERT_MTX_NEAR(lend(d_bj), lend(bj), 1e-6);
+    GKO_ASSERT_MTX_NEAR(d_bj, bj, 1e-6);
 }
 
 
@@ -675,7 +675,7 @@ TEST_F(Jacobi, DpcppPreconditionerEquivalentToRefWithQuarteredPrecision)
     auto bj = bj_factory->generate(mtx);
     auto d_bj = d_bj_factory->generate(mtx);
 
-    GKO_ASSERT_MTX_NEAR(lend(d_bj), lend(bj), 1e-3);
+    GKO_ASSERT_MTX_NEAR(d_bj, bj, 1e-3);
 }
 
 
@@ -688,7 +688,7 @@ TEST_F(Jacobi, DpcppPreconditionerEquivalentToRefWithCustomQuarteredPrecision)
     auto bj = bj_factory->generate(mtx);
     auto d_bj = d_bj_factory->generate(mtx);
 
-    GKO_ASSERT_MTX_NEAR(lend(d_bj), lend(bj), 1e-1);
+    GKO_ASSERT_MTX_NEAR(d_bj, bj, 1e-1);
 }
 
 
@@ -702,7 +702,7 @@ TEST_F(Jacobi, DpcppPreconditionerEquivalentToRefWithAdaptivePrecision)
     auto bj = bj_factory->generate(mtx);
     auto d_bj = d_bj_factory->generate(mtx);
 
-    GKO_ASSERT_MTX_NEAR(lend(d_bj), lend(bj), 1e-1);
+    GKO_ASSERT_MTX_NEAR(d_bj, bj, 1e-1);
 }
 
 

--- a/dpcpp/test/preconditioner/jacobi_kernels.cpp
+++ b/dpcpp/test/preconditioner/jacobi_kernels.cpp
@@ -322,7 +322,7 @@ TEST_F(Jacobi, DpcppPreconditionerEquivalentToRefWithBlockSize32Unsorted)
 {
     std::default_random_engine engine(42);
     initialize_data({0, 32, 64, 96, 128}, {}, {}, 32, 100, 110, 1, 0.1, false);
-    gko::test::unsort_matrix(mtx.get(), engine);
+    gko::test::unsort_matrix(mtx, engine);
 
     auto bj = bj_factory->generate(mtx);
     auto d_bj = d_bj_factory->generate(mtx);
@@ -365,7 +365,7 @@ TEST_F(Jacobi, DpcppTransposedPreconditionerEquivalentToRefWithMPW)
 
     auto bj = bj_factory->generate(mtx);
     auto d_bj = d_bj_factory->generate(mtx);
-    d_bj->copy_from(bj.get());
+    d_bj->copy_from(bj);
 
     GKO_ASSERT_MTX_NEAR(gko::as<Bj>(d_bj->transpose()),
                         gko::as<Bj>(bj->transpose()), 1e-14);
@@ -379,7 +379,7 @@ TEST_F(Jacobi, DpcppConjTransposedPreconditionerEquivalentToRefWithMPW)
 
     auto bj = bj_factory->generate(mtx);
     auto d_bj = d_bj_factory->generate(mtx);
-    d_bj->copy_from(bj.get());
+    d_bj->copy_from(bj);
 
     GKO_ASSERT_MTX_NEAR(gko::as<Bj>(d_bj->conj_transpose()),
                         gko::as<Bj>(bj->conj_transpose()), 1e-14);
@@ -392,8 +392,8 @@ TEST_F(Jacobi, DpcppApplyEquivalentToRefWithBlockSize32)
     auto bj = bj_factory->generate(mtx);
     auto d_bj = d_bj_factory->generate(mtx);
 
-    bj->apply(b.get(), x.get());
-    d_bj->apply(d_b.get(), d_x.get());
+    bj->apply(b, x);
+    d_bj->apply(d_b, d_x);
 
     GKO_ASSERT_MTX_NEAR(d_x, x, 100 * r<value_type>::value);
 }
@@ -406,8 +406,8 @@ TEST_F(Jacobi, DpcppApplyEquivalentToRefWithDifferentBlockSize)
     auto bj = bj_factory->generate(mtx);
     auto d_bj = d_bj_factory->generate(mtx);
 
-    bj->apply(b.get(), x.get());
-    d_bj->apply(d_b.get(), d_x.get());
+    bj->apply(b, x);
+    d_bj->apply(d_b, d_x);
 
     GKO_ASSERT_MTX_NEAR(d_x, x, 100 * r<value_type>::value);
 }
@@ -420,8 +420,8 @@ TEST_F(Jacobi, DpcppApplyEquivalentToRef)
     auto bj = bj_factory->generate(mtx);
     auto d_bj = d_bj_factory->generate(mtx);
 
-    bj->apply(b.get(), x.get());
-    d_bj->apply(d_b.get(), d_x.get());
+    bj->apply(b, x);
+    d_bj->apply(d_b, d_x);
 
     GKO_ASSERT_MTX_NEAR(d_x, x, 100 * r<value_type>::value);
 }
@@ -439,7 +439,7 @@ TEST_F(Jacobi, DpcppScalarApplyEquivalentToRef)
     auto dense_smtx = gko::share(Vec::create(ref));
     dense_smtx->read(dense_data);
     auto smtx = gko::share(Mtx::create(ref));
-    smtx->copy_from(dense_smtx.get());
+    smtx->copy_from(dense_smtx);
     auto sb = gko::share(gko::test::generate_random_matrix<Vec>(
         dim, 3, std::uniform_int_distribution<>(1, 1),
         std::normal_distribution<value_type>(0.0, 1.0), engine, ref));
@@ -448,16 +448,16 @@ TEST_F(Jacobi, DpcppScalarApplyEquivalentToRef)
     auto d_smtx = gko::share(Mtx::create(dpcpp));
     auto d_sb = gko::share(Vec::create(dpcpp));
     auto d_sx = gko::share(Vec::create(dpcpp, sb->get_size()));
-    d_smtx->copy_from(smtx.get());
-    d_sb->copy_from(sb.get());
+    d_smtx->copy_from(smtx);
+    d_sb->copy_from(sb);
 
     auto sj = Bj::build().with_max_block_size(1u).on(ref)->generate(smtx);
     auto d_sj = Bj::build().with_max_block_size(1u).on(dpcpp)->generate(d_smtx);
 
-    sj->apply(sb.get(), sx.get());
-    d_sj->apply(d_sb.get(), d_sx.get());
+    sj->apply(sb, sx);
+    d_sj->apply(d_sb, d_sx);
 
-    GKO_ASSERT_MTX_NEAR(sx.get(), d_sx.get(), 100 * r<value_type>::value);
+    GKO_ASSERT_MTX_NEAR(sx, d_sx, 100 * r<value_type>::value);
 }
 
 
@@ -472,8 +472,8 @@ TEST_F(Jacobi, DpcppLinearCombinationApplyEquivalentToRef)
     auto bj = bj_factory->generate(mtx);
     auto d_bj = d_bj_factory->generate(mtx);
 
-    bj->apply(alpha.get(), b.get(), beta.get(), x.get());
-    d_bj->apply(d_alpha.get(), d_b.get(), d_beta.get(), d_x.get());
+    bj->apply(alpha, b, beta, x);
+    d_bj->apply(d_alpha, d_b, d_beta, d_x);
 
     GKO_ASSERT_MTX_NEAR(d_x, x, 100 * r<value_type>::value);
 }
@@ -491,7 +491,7 @@ TEST_F(Jacobi, DpcppScalarLinearCombinationApplyEquivalentToRef)
     auto dense_smtx = gko::share(Vec::create(ref));
     dense_smtx->read(dense_data);
     auto smtx = gko::share(Mtx::create(ref));
-    smtx->copy_from(dense_smtx.get());
+    smtx->copy_from(dense_smtx);
     auto sb = gko::share(gko::test::generate_random_matrix<Vec>(
         dim, 3, std::uniform_int_distribution<>(1, 1),
         std::normal_distribution<value_type>(0.0, 1.0), engine, ref,
@@ -512,10 +512,10 @@ TEST_F(Jacobi, DpcppScalarLinearCombinationApplyEquivalentToRef)
     auto sj = Bj::build().with_max_block_size(1u).on(ref)->generate(smtx);
     auto d_sj = Bj::build().with_max_block_size(1u).on(dpcpp)->generate(d_smtx);
 
-    sj->apply(alpha.get(), sb.get(), beta.get(), sx.get());
-    d_sj->apply(d_alpha.get(), d_sb.get(), d_beta.get(), d_sx.get());
+    sj->apply(alpha, sb, beta, sx);
+    d_sj->apply(d_alpha, d_sb, d_beta, d_sx);
 
-    GKO_ASSERT_MTX_NEAR(sx.get(), d_sx.get(), 100 * r<value_type>::value);
+    GKO_ASSERT_MTX_NEAR(sx, d_sx, 100 * r<value_type>::value);
 }
 
 
@@ -526,8 +526,8 @@ TEST_F(Jacobi, DpcppApplyToMultipleVectorsEquivalentToRef)
     auto bj = bj_factory->generate(mtx);
     auto d_bj = d_bj_factory->generate(mtx);
 
-    bj->apply(b.get(), x.get());
-    d_bj->apply(d_b.get(), d_x.get());
+    bj->apply(b, x);
+    d_bj->apply(d_b, d_x);
 
     GKO_ASSERT_MTX_NEAR(d_x, x, 100 * r<value_type>::value);
 }
@@ -544,8 +544,8 @@ TEST_F(Jacobi, DpcppLinearCombinationApplyToMultipleVectorsEquivalentToRef)
     auto bj = bj_factory->generate(mtx);
     auto d_bj = d_bj_factory->generate(mtx);
 
-    bj->apply(alpha.get(), b.get(), beta.get(), x.get());
-    d_bj->apply(d_alpha.get(), d_b.get(), d_beta.get(), d_x.get());
+    bj->apply(alpha, b, beta, x);
+    d_bj->apply(d_alpha, d_b, d_beta, d_x);
 
     GKO_ASSERT_MTX_NEAR(d_x, x, 100 * r<value_type>::value);
 }
@@ -716,7 +716,7 @@ TEST_F(Jacobi,
 
     auto bj = bj_factory->generate(mtx);
     auto d_bj = d_bj_factory->generate(mtx);
-    d_bj->copy_from(bj.get());
+    d_bj->copy_from(bj);
 
     GKO_ASSERT_MTX_NEAR(gko::as<Bj>(d_bj->transpose()),
                         gko::as<Bj>(bj->transpose()), 1e-14);
@@ -733,7 +733,7 @@ TEST_F(Jacobi,
 
     auto bj = bj_factory->generate(mtx);
     auto d_bj = d_bj_factory->generate(mtx);
-    d_bj->copy_from(bj.get());
+    d_bj->copy_from(bj);
 
     GKO_ASSERT_MTX_NEAR(gko::as<Bj>(d_bj->conj_transpose()),
                         gko::as<Bj>(bj->conj_transpose()), 1e-14);
@@ -749,8 +749,8 @@ TEST_F(Jacobi, DpcppApplyEquivalentToRefWithFullPrecision)
     auto bj = bj_factory->generate(mtx);
     auto d_bj = d_bj_factory->generate(mtx);
 
-    bj->apply(b.get(), x.get());
-    d_bj->apply(d_b.get(), d_x.get());
+    bj->apply(b, x);
+    d_bj->apply(d_b, d_x);
 
     GKO_ASSERT_MTX_NEAR(d_x, x, 1e-12);
 }
@@ -765,8 +765,8 @@ TEST_F(Jacobi, DpcppApplyEquivalentToRefWithReducedPrecision)
     auto bj = bj_factory->generate(mtx);
     auto d_bj = d_bj_factory->generate(mtx);
 
-    bj->apply(b.get(), x.get());
-    d_bj->apply(d_b.get(), d_x.get());
+    bj->apply(b, x);
+    d_bj->apply(d_b, d_x);
 
     GKO_ASSERT_MTX_NEAR(d_x, x, 1e-6);
 }
@@ -781,8 +781,8 @@ TEST_F(Jacobi, DpcppApplyEquivalentToRefWithCustomReducedPrecision)
     auto bj = bj_factory->generate(mtx);
     auto d_bj = d_bj_factory->generate(mtx);
 
-    bj->apply(b.get(), x.get());
-    d_bj->apply(d_b.get(), d_x.get());
+    bj->apply(b, x);
+    d_bj->apply(d_b, d_x);
 
     GKO_ASSERT_MTX_NEAR(d_x, x, 1e-5);
 }
@@ -796,8 +796,8 @@ TEST_F(Jacobi, DpcppApplyEquivalentToRefWithQuarteredPrecision)
     auto bj = bj_factory->generate(mtx);
     auto d_bj = d_bj_factory->generate(mtx);
 
-    bj->apply(b.get(), x.get());
-    d_bj->apply(d_b.get(), d_x.get());
+    bj->apply(b, x);
+    d_bj->apply(d_b, d_x);
 
     GKO_ASSERT_MTX_NEAR(d_x, x, 1e-2);
 }
@@ -811,8 +811,8 @@ TEST_F(Jacobi, DpcppApplyEquivalentToRefWithCustomReducedAndReducedPrecision)
     auto bj = bj_factory->generate(mtx);
     auto d_bj = d_bj_factory->generate(mtx);
 
-    bj->apply(b.get(), x.get());
-    d_bj->apply(d_b.get(), d_x.get());
+    bj->apply(b, x);
+    d_bj->apply(d_b, d_x);
 
     GKO_ASSERT_MTX_NEAR(d_x, x, 1e-2);
 }
@@ -826,8 +826,8 @@ TEST_F(Jacobi, DpcppApplyEquivalentToRefWithCustomQuarteredPrecision)
     auto bj = bj_factory->generate(mtx);
     auto d_bj = d_bj_factory->generate(mtx);
 
-    bj->apply(b.get(), x.get());
-    d_bj->apply(d_b.get(), d_x.get());
+    bj->apply(b, x);
+    d_bj->apply(d_b, d_x);
 
     GKO_ASSERT_MTX_NEAR(d_x, x, 1e-6);
 }
@@ -842,8 +842,8 @@ TEST_F(Jacobi, DpcppApplyEquivalentToRefWithAdaptivePrecision)
     auto bj = bj_factory->generate(mtx);
     auto d_bj = d_bj_factory->generate(mtx);
 
-    bj->apply(b.get(), x.get());
-    d_bj->apply(d_b.get(), d_x.get());
+    bj->apply(b, x);
+    d_bj->apply(d_b, d_x);
 
     GKO_ASSERT_MTX_NEAR(d_x, x, 1e-1);
 }
@@ -862,8 +862,8 @@ TEST_F(Jacobi, DpcppLinearCombinationApplyEquivalentToRefWithAdaptivePrecision)
     auto bj = bj_factory->generate(mtx);
     auto d_bj = d_bj_factory->generate(mtx);
 
-    bj->apply(b.get(), x.get());
-    d_bj->apply(d_b.get(), d_x.get());
+    bj->apply(b, x);
+    d_bj->apply(d_b, d_x);
 
     GKO_ASSERT_MTX_NEAR(d_x, x, 1e-6);
 }
@@ -878,8 +878,8 @@ TEST_F(Jacobi, DpcppApplyToMultipleVectorsEquivalentToRefWithFullPrecision)
     auto bj = bj_factory->generate(mtx);
     auto d_bj = d_bj_factory->generate(mtx);
 
-    bj->apply(b.get(), x.get());
-    d_bj->apply(d_b.get(), d_x.get());
+    bj->apply(b, x);
+    d_bj->apply(d_b, d_x);
 
     GKO_ASSERT_MTX_NEAR(d_x, x, 1e-12);
 }
@@ -893,8 +893,8 @@ TEST_F(Jacobi, DpcppApplyToMultipleVectorsEquivalentToRefWithReducedPrecision)
     auto bj = bj_factory->generate(mtx);
     auto d_bj = d_bj_factory->generate(mtx);
 
-    bj->apply(b.get(), x.get());
-    d_bj->apply(d_b.get(), d_x.get());
+    bj->apply(b, x);
+    d_bj->apply(d_b, d_x);
 
     GKO_ASSERT_MTX_NEAR(d_x, x, 1e-5);
 }
@@ -909,8 +909,8 @@ TEST_F(Jacobi, DpcppApplyToMultipleVectorsEquivalentToRefWithAdaptivePrecision)
     auto bj = bj_factory->generate(mtx);
     auto d_bj = d_bj_factory->generate(mtx);
 
-    bj->apply(b.get(), x.get());
-    d_bj->apply(d_b.get(), d_x.get());
+    bj->apply(b, x);
+    d_bj->apply(d_b, d_x);
 
     GKO_ASSERT_MTX_NEAR(d_x, x, 1e-1);
 }
@@ -931,8 +931,8 @@ TEST_F(
     auto bj = bj_factory->generate(mtx);
     auto d_bj = d_bj_factory->generate(mtx);
 
-    bj->apply(b.get(), x.get());
-    d_bj->apply(d_b.get(), d_x.get());
+    bj->apply(b, x);
+    d_bj->apply(d_b, d_x);
 
     GKO_ASSERT_MTX_NEAR(d_x, x, 1e-6);
 }

--- a/examples/adaptiveprecision-blockjacobi/adaptiveprecision-blockjacobi.cpp
+++ b/examples/adaptiveprecision-blockjacobi/adaptiveprecision-blockjacobi.cpp
@@ -101,8 +101,8 @@ int main(int argc, char* argv[])
     auto one = gko::initialize<vec>({1.0}, exec);
     auto neg_one = gko::initialize<vec>({-1.0}, exec);
     auto initres = gko::initialize<real_vec>({0.0}, exec);
-    A->apply(lend(one), lend(x), lend(neg_one), lend(b));
-    b->compute_norm2(lend(initres));
+    A->apply(one, x, neg_one, b);
+    b->compute_norm2(initres);
 
     // copy b again
     b->copy_from(host_x.get());
@@ -139,22 +139,22 @@ int main(int argc, char* argv[])
     exec->synchronize();
     std::chrono::nanoseconds time(0);
     auto tic = std::chrono::steady_clock::now();
-    solver->apply(lend(b), lend(x));
+    solver->apply(b, x);
     auto toc = std::chrono::steady_clock::now();
     time += std::chrono::duration_cast<std::chrono::nanoseconds>(toc - tic);
 
     // Calculate residual
     auto res = gko::initialize<real_vec>({0.0}, exec);
-    A->apply(lend(one), lend(x), lend(neg_one), lend(b));
-    b->compute_norm2(lend(res));
+    A->apply(one, x, neg_one, b);
+    b->compute_norm2(res);
     auto impl_res = gko::as<real_vec>(logger->get_implicit_sq_resnorm());
 
     std::cout << "Initial residual norm sqrt(r^T r):\n";
-    write(std::cout, lend(initres));
+    write(std::cout, initres);
     std::cout << "Final residual norm sqrt(r^T r):\n";
-    write(std::cout, lend(res));
+    write(std::cout, res);
     std::cout << "Implicit residual norm squared (r^2):\n";
-    write(std::cout, lend(impl_res));
+    write(std::cout, impl_res);
 
     // Print solver statistics
     std::cout << "CG iteration count:     " << logger->get_num_iterations()

--- a/examples/adaptiveprecision-blockjacobi/adaptiveprecision-blockjacobi.cpp
+++ b/examples/adaptiveprecision-blockjacobi/adaptiveprecision-blockjacobi.cpp
@@ -105,7 +105,7 @@ int main(int argc, char* argv[])
     b->compute_norm2(initres);
 
     // copy b again
-    b->copy_from(host_x.get());
+    b->copy_from(host_x);
     const RealValueType reduction_factor = 1e-7;
     auto iter_stop = gko::share(
         gko::stop::Iteration::build().with_max_iters(10000u).on(exec));

--- a/examples/custom-matrix-format/custom-matrix-format.cpp
+++ b/examples/custom-matrix-format/custom-matrix-format.cpp
@@ -146,9 +146,9 @@ protected:
         auto dense_b = gko::as<vec>(b);
         auto dense_x = gko::as<vec>(x);
         auto tmp_x = dense_x->clone();
-        this->apply_impl(b, lend(tmp_x));
+        this->apply_impl(b, tmp_x.get());
         dense_x->scale(beta);
-        dense_x->add_scaled(alpha, lend(tmp_x));
+        dense_x->add_scaled(alpha, tmp_x);
     }
 
 private:
@@ -283,7 +283,7 @@ int main(int argc, char* argv[])
 
     // initialize vectors
     auto rhs = vec::create(app_exec, gko::dim<2>(discretization_points, 1));
-    generate_rhs(f, u0, u1, lend(rhs));
+    generate_rhs(f, u0, u1, rhs.get());
     auto u = vec::create(app_exec, gko::dim<2>(discretization_points, 1));
     for (int i = 0; i < u->get_size()[0]; ++i) {
         u->get_values()[i] = 0.0;
@@ -303,11 +303,11 @@ int main(int argc, char* argv[])
         // any built-in type
         ->generate(StencilMatrix<ValueType>::create(exec, discretization_points,
                                                     -1, 2, -1))
-        ->apply(lend(rhs), lend(u));
+        ->apply(rhs, u);
 
     std::cout << "\nSolve complete."
               << "\nThe average relative error is "
-              << calculate_error(discretization_points, lend(u), correct_u) /
+              << calculate_error(discretization_points, u.get(), correct_u) /
                      discretization_points
               << std::endl;
 }

--- a/examples/custom-stopping-criterion/custom-stopping-criterion.cpp
+++ b/examples/custom-stopping-criterion/custom-stopping-criterion.cpp
@@ -118,23 +118,23 @@ void run_solver(volatile bool* stop_iteration_process,
                       ->generate(A);
     solver->add_logger(gko::log::Stream<ValueType>::create(
         gko::log::Logger::iteration_complete_mask, std::cout, true));
-    solver->apply(lend(b), lend(x));
+    solver->apply(b, x);
 
     std::cout << "Solver stopped" << std::endl;
 
     // Print solution
     std::cout << "Solution (x): \n";
-    write(std::cout, lend(x));
+    write(std::cout, x);
 
     // Calculate residual
     auto one = gko::initialize<vec>({1.0}, exec);
     auto neg_one = gko::initialize<vec>({-1.0}, exec);
     auto res = gko::initialize<real_vec>({0.0}, exec);
-    A->apply(lend(one), lend(x), lend(neg_one), lend(b));
-    b->compute_norm2(lend(res));
+    A->apply(one, x, neg_one, b);
+    b->compute_norm2(res);
 
     std::cout << "Residual norm sqrt(r^T r): \n";
-    write(std::cout, lend(res));
+    write(std::cout, res);
 }
 
 

--- a/examples/distributed-solver/distributed-solver.cpp
+++ b/examples/distributed-solver/distributed-solver.cpp
@@ -194,17 +194,17 @@ int main(int argc, char* argv[])
     auto A_host = gko::share(dist_mtx::create(exec->get_master(), comm));
     auto x_host = dist_vec::create(exec->get_master(), comm);
     auto b_host = dist_vec::create(exec->get_master(), comm);
-    A_host->read_distributed(A_data, partition.get());
-    b_host->read_distributed(b_data, partition.get());
-    x_host->read_distributed(x_data, partition.get());
+    A_host->read_distributed(A_data, partition);
+    b_host->read_distributed(b_data, partition);
+    x_host->read_distributed(x_data, partition);
     // After reading, the matrix and vector can be moved to the chosen executor,
     // since the distributed matrix supports SpMV also on devices.
     auto A = gko::share(dist_mtx::create(exec, comm));
     auto x = dist_vec::create(exec, comm);
     auto b = dist_vec::create(exec, comm);
-    A->copy_from(A_host.get());
-    b->copy_from(b_host.get());
-    x->copy_from(x_host.get());
+    A->copy_from(A_host);
+    b->copy_from(b_host);
+    x->copy_from(x_host);
 
     // Take timings.
     comm.synchronize();
@@ -256,7 +256,7 @@ int main(int argc, char* argv[])
 
     // Compute the residual, this is done in the same way as in the
     // non-distributed case.
-    x_host->copy_from(x.get());
+    x_host->copy_from(x);
     auto one = gko::initialize<vec>({1.0}, exec);
     auto minus_one = gko::initialize<vec>({-1.0}, exec);
     A_host->apply(minus_one, x_host, one, b_host);

--- a/examples/distributed-solver/distributed-solver.cpp
+++ b/examples/distributed-solver/distributed-solver.cpp
@@ -248,7 +248,7 @@ int main(int argc, char* argv[])
 
     // Apply the distributed solver, this is the same as in the non-distributed
     // case.
-    Ainv->apply(gko::lend(b), gko::lend(x));
+    Ainv->apply(b, x);
 
     // Take timings.
     comm.synchronize();
@@ -259,10 +259,9 @@ int main(int argc, char* argv[])
     x_host->copy_from(x.get());
     auto one = gko::initialize<vec>({1.0}, exec);
     auto minus_one = gko::initialize<vec>({-1.0}, exec);
-    A_host->apply(gko::lend(minus_one), gko::lend(x_host), gko::lend(one),
-                  gko::lend(b_host));
+    A_host->apply(minus_one, x_host, one, b_host);
     auto res_norm = gko::initialize<vec>({0.0}, exec->get_master());
-    b_host->compute_norm2(gko::lend(res_norm));
+    b_host->compute_norm2(res_norm);
 
     // Take timings.
     comm.synchronize();

--- a/examples/external-lib-interfacing/CMakeLists.txt
+++ b/examples/external-lib-interfacing/CMakeLists.txt
@@ -4,7 +4,7 @@ if(GINKGO_BUILD_EXTLIB_EXAMPLE)
     cmake_minimum_required(VERSION 3.9)
     project(DEAL_II_EXAMPLE LANGUAGES CXX)
 
-    find_package(MPI REQUIRED)
+    find_package(MPI 3.1 COMPONENTS CXX REQUIRED)
 
     set(deal.II_DIR "/path/to/deal.ii/installation")
     find_package(deal.II 9.0.0 REQUIRED

--- a/examples/external-lib-interfacing/external-lib-interfacing.cpp
+++ b/examples/external-lib-interfacing/external-lib-interfacing.cpp
@@ -889,7 +889,7 @@ void AdvectionProblem<dim>::solve()
     auto solver = solver_gen->generate(gko::give(A));
 
     // Solve system
-    solver->apply(gko::lend(b), gko::lend(x));
+    solver->apply(b, x);
 
     // Copy the solution vector back to deal.ii's data structures.
     std::copy(x->get_values(), x->get_values() + num_rows, solution.begin());

--- a/examples/ginkgo-overhead/ginkgo-overhead.cpp
+++ b/examples/ginkgo-overhead/ginkgo-overhead.cpp
@@ -82,7 +82,7 @@ int main(int argc, char* argv[])
     auto tic = std::chrono::steady_clock::now();
 
     auto solver = cg_factory->generate(gko::give(A));
-    solver->apply(lend(x), lend(b));
+    solver->apply(x, b);
     exec->synchronize();
 
     auto tac = std::chrono::steady_clock::now();

--- a/examples/heat-equation/heat-equation.cpp
+++ b/examples/heat-equation/heat-equation.cpp
@@ -213,9 +213,9 @@ int main(int argc, char* argv[])
                     ->get_const_values());
         }
         // add heat source contribution
-        in_vector->add_scaled(gko::lend(tau_source_scalar), gko::lend(source));
+        in_vector->add_scaled(tau_source_scalar, source);
         // execute Euler step
-        solver->apply(gko::lend(in_vector), gko::lend(out_vector));
+        solver->apply(in_vector, out_vector);
         // swap input and output
         std::swap(in_vector, out_vector);
     }

--- a/examples/heat-equation/heat-equation.cpp
+++ b/examples/heat-equation/heat-equation.cpp
@@ -209,7 +209,7 @@ int main(int argc, char* argv[])
             std::cout << t << std::endl;
             output_timestep(
                 output, n,
-                gko::make_temporary_clone(exec->get_master(), in_vector.get())
+                gko::make_temporary_clone(exec->get_master(), in_vector)
                     ->get_const_values());
         }
         // add heat source contribution

--- a/examples/ilu-preconditioned-solver/ilu-preconditioned-solver.cpp
+++ b/examples/ilu-preconditioned-solver/ilu-preconditioned-solver.cpp
@@ -127,19 +127,19 @@ int main(int argc, char* argv[])
     auto ilu_gmres = ilu_gmres_factory->generate(A);
 
     // Solve system
-    ilu_gmres->apply(gko::lend(b), gko::lend(x));
+    ilu_gmres->apply(b, x);
 
     // Print solution
     std::cout << "Solution (x):\n";
-    write(std::cout, gko::lend(x));
+    write(std::cout, x);
 
     // Calculate residual
     auto one = gko::initialize<vec>({1.0}, exec);
     auto neg_one = gko::initialize<vec>({-1.0}, exec);
     auto res = gko::initialize<real_vec>({0.0}, exec);
-    A->apply(gko::lend(one), gko::lend(x), gko::lend(neg_one), gko::lend(b));
-    b->compute_norm2(gko::lend(res));
+    A->apply(one, x, neg_one, b);
+    b->compute_norm2(res);
 
     std::cout << "Residual norm sqrt(r^T r):\n";
-    write(std::cout, gko::lend(res));
+    write(std::cout, res);
 }

--- a/examples/inverse-iteration/inverse-iteration.cpp
+++ b/examples/inverse-iteration/inverse-iteration.cpp
@@ -148,26 +148,26 @@ int main(int argc, char* argv[])
     for (auto i = 0u; i < max_iterations; ++i) {
         std::cout << "{ ";
         // (A - zI)y = x
-        solver->apply(lend(x), lend(y));
-        system_matrix->apply(lend(one), lend(y), lend(neg_one), lend(x));
-        x->compute_norm2(lend(norm));
+        solver->apply(x, y);
+        system_matrix->apply(one, y, neg_one, x);
+        x->compute_norm2(norm);
         std::cout << "\"system_residual\": "
                   << clone(this_exec, norm)->get_values()[0] << ", ";
-        x->copy_from(lend(y));
+        x->copy_from(y);
         // x = y / || y ||
-        x->compute_norm2(lend(norm));
+        x->compute_norm2(norm);
         inv_norm->get_values()[0] =
             real_precision{1.0} / clone(this_exec, norm)->get_values()[0];
-        x->scale(lend(clone(exec, inv_norm)));
+        x->scale(clone(exec, inv_norm));
         // g = x^* A x
-        A->apply(lend(x), lend(tmp));
-        x->compute_dot(lend(tmp), lend(g));
+        A->apply(x, tmp);
+        x->compute_dot(tmp, g);
         auto g_val = clone(this_exec, g)->get_values()[0];
         std::cout << "\"eigenvalue\": " << g_val << ", ";
         // ||Ax - gx|| < tol * g
         auto v = gko::initialize<vec>({-g_val}, exec);
-        tmp->add_scaled(lend(v), lend(x));
-        tmp->compute_norm2(lend(norm));
+        tmp->add_scaled(v, x);
+        tmp->compute_norm2(norm);
         auto res_val = clone(exec->get_master(), norm)->get_values()[0];
         std::cout << "\"residual\": " << res_val / g_val << " }," << std::endl;
         if (abs(res_val) < residual_goal * abs(g_val)) {

--- a/examples/ir-ilu-preconditioned-solver/ir-ilu-preconditioned-solver.cpp
+++ b/examples/ir-ilu-preconditioned-solver/ir-ilu-preconditioned-solver.cpp
@@ -163,14 +163,14 @@ int main(int argc, char* argv[])
     auto ilu_gmres = ilu_gmres_factory->generate(A);
 
     // Warmup run
-    ilu_gmres->apply(lend(b), lend(x));
+    ilu_gmres->apply(b, x);
 
     // Solve system 100 times and take the average time.
     std::chrono::nanoseconds time(0);
     for (int i = 0; i < 100; i++) {
-        x->copy_from(lend(clone_x));
+        x->copy_from(clone_x);
         auto tic = std::chrono::high_resolution_clock::now();
-        ilu_gmres->apply(lend(b), lend(x));
+        ilu_gmres->apply(b, x);
         auto toc = std::chrono::high_resolution_clock::now();
         time += std::chrono::duration_cast<std::chrono::nanoseconds>(toc - tic);
     }
@@ -179,19 +179,19 @@ int main(int argc, char* argv[])
 
     // Print solution
     std::cout << "Solution (x):\n";
-    write(std::cout, gko::lend(x));
+    write(std::cout, x);
 
     // Calculate residual
     auto one = gko::initialize<vec>({1.0}, exec);
     auto neg_one = gko::initialize<vec>({-1.0}, exec);
     auto res = gko::initialize<real_vec>({0.0}, exec);
-    A->apply(gko::lend(one), gko::lend(x), gko::lend(neg_one), gko::lend(b));
-    b->compute_norm2(gko::lend(res));
+    A->apply(one, x, neg_one, b);
+    b->compute_norm2(res);
 
     std::cout << "GMRES iteration count:     " << logger->get_num_iterations()
               << "\n";
     std::cout << "GMRES execution time [ms]: "
               << static_cast<double>(time.count()) / 100000000.0 << "\n";
     std::cout << "Residual norm sqrt(r^T r):\n";
-    write(std::cout, gko::lend(res));
+    write(std::cout, res);
 }

--- a/examples/iterative-refinement/iterative-refinement.cpp
+++ b/examples/iterative-refinement/iterative-refinement.cpp
@@ -102,8 +102,8 @@ int main(int argc, char* argv[])
     auto one = gko::initialize<vec>({1.0}, exec);
     auto neg_one = gko::initialize<vec>({-1.0}, exec);
     auto initres = gko::initialize<real_vec>({0.0}, exec);
-    A->apply(lend(one), lend(x), lend(neg_one), lend(b));
-    b->compute_norm2(lend(initres));
+    A->apply(one, x, neg_one, b);
+    b->compute_norm2(initres);
 
     // copy b again
     b->copy_from(host_x.get());
@@ -142,19 +142,19 @@ int main(int argc, char* argv[])
     exec->synchronize();
     std::chrono::nanoseconds time(0);
     auto tic = std::chrono::steady_clock::now();
-    solver->apply(lend(b), lend(x));
+    solver->apply(b, x);
     auto toc = std::chrono::steady_clock::now();
     time += std::chrono::duration_cast<std::chrono::nanoseconds>(toc - tic);
 
     // Calculate residual
     auto res = gko::initialize<real_vec>({0.0}, exec);
-    A->apply(lend(one), lend(x), lend(neg_one), lend(b));
-    b->compute_norm2(lend(res));
+    A->apply(one, x, neg_one, b);
+    b->compute_norm2(res);
 
     std::cout << "Initial residual norm sqrt(r^T r):\n";
-    write(std::cout, lend(initres));
+    write(std::cout, initres);
     std::cout << "Final residual norm sqrt(r^T r):\n";
-    write(std::cout, lend(res));
+    write(std::cout, res);
 
     // Print solver statistics
     std::cout << "IR iteration count:     " << logger->get_num_iterations()

--- a/examples/iterative-refinement/iterative-refinement.cpp
+++ b/examples/iterative-refinement/iterative-refinement.cpp
@@ -106,7 +106,7 @@ int main(int argc, char* argv[])
     b->compute_norm2(initres);
 
     // copy b again
-    b->copy_from(host_x.get());
+    b->copy_from(host_x);
     gko::size_type max_iters = 10000u;
     RealValueType outer_reduction_factor{1e-12};
     auto iter_stop = gko::share(

--- a/examples/kokkos_assembly/kokkos_assembly.cpp
+++ b/examples/kokkos_assembly/kokkos_assembly.cpp
@@ -194,7 +194,7 @@ int main(int argc, char* argv[])
 
     // initialize vectors
     auto rhs = vec::create(exec, gko::dim<2>(discretization_points, 1));
-    generate_rhs(f, u0, u1, lend(rhs));
+    generate_rhs(f, u0, u1, rhs);
     auto u = vec::create(exec, gko::dim<2>(discretization_points, 1));
     for (int i = 0; i < u->get_size()[0]; ++i) {
         u->get_values()[i] = 0.0;
@@ -203,7 +203,7 @@ int main(int argc, char* argv[])
     // initialize the stencil matrix
     auto A = share(mtx::create(
         exec, gko::dim<2>{discretization_points, discretization_points}));
-    generate_stencil_matrix(lend(A));
+    generate_stencil_matrix(A);
 
     const RealValueType reduction_factor{1e-7};
     // Generate solver and solve the system
@@ -217,11 +217,11 @@ int main(int argc, char* argv[])
         .with_preconditioner(bj::build().on(exec))
         .on(exec)
         ->generate(A)
-        ->apply(lend(rhs), lend(u));
+        ->apply(rhs, u);
 
     std::cout << "\nSolve complete."
               << "\nThe average relative error is "
-              << calculate_error(discretization_points, lend(u), correct_u) /
+              << calculate_error(discretization_points, u, correct_u) /
                      discretization_points
               << std::endl;
 }

--- a/examples/kokkos_assembly/kokkos_assembly.cpp
+++ b/examples/kokkos_assembly/kokkos_assembly.cpp
@@ -194,7 +194,7 @@ int main(int argc, char* argv[])
 
     // initialize vectors
     auto rhs = vec::create(exec, gko::dim<2>(discretization_points, 1));
-    generate_rhs(f, u0, u1, rhs);
+    generate_rhs(f, u0, u1, rhs.get());
     auto u = vec::create(exec, gko::dim<2>(discretization_points, 1));
     for (int i = 0; i < u->get_size()[0]; ++i) {
         u->get_values()[i] = 0.0;
@@ -203,7 +203,7 @@ int main(int argc, char* argv[])
     // initialize the stencil matrix
     auto A = share(mtx::create(
         exec, gko::dim<2>{discretization_points, discretization_points}));
-    generate_stencil_matrix(A);
+    generate_stencil_matrix(A.get());
 
     const RealValueType reduction_factor{1e-7};
     // Generate solver and solve the system
@@ -221,7 +221,7 @@ int main(int argc, char* argv[])
 
     std::cout << "\nSolve complete."
               << "\nThe average relative error is "
-              << calculate_error(discretization_points, u, correct_u) /
+              << calculate_error(discretization_points, u.get(), correct_u) /
                      discretization_points
               << std::endl;
 }

--- a/examples/minimal-cuda-solver/minimal-cuda-solver.cpp
+++ b/examples/minimal-cuda-solver/minimal-cuda-solver.cpp
@@ -52,7 +52,7 @@ int main()
                     .on(gpu))
             .on(gpu);
     // Solve system
-    solver->generate(give(A))->apply(lend(b), lend(x));
+    solver->generate(give(A))->apply(b, x);
     // Write result
-    write(std::cout, lend(x));
+    write(std::cout, x);
 }

--- a/examples/mixed-multigrid-solver/mixed-multigrid-solver.cpp
+++ b/examples/mixed-multigrid-solver/mixed-multigrid-solver.cpp
@@ -108,8 +108,8 @@ int main(int argc, char* argv[])
     auto one = gko::initialize<vec>({1.0}, exec);
     auto neg_one = gko::initialize<vec>({-1.0}, exec);
     auto initres = gko::initialize<vec>({0.0}, exec);
-    A->apply(lend(one), lend(x), lend(neg_one), lend(b));
-    b->compute_norm2(lend(initres));
+    A->apply(one, x, neg_one, b);
+    b->compute_norm2(initres);
 
     // copy b again
     b->copy_from(host_b.get());
@@ -211,20 +211,20 @@ int main(int argc, char* argv[])
     exec->synchronize();
     std::chrono::nanoseconds time(0);
     auto tic = std::chrono::steady_clock::now();
-    solver->apply(lend(b), lend(x));
+    solver->apply(b, x);
     exec->synchronize();
     auto toc = std::chrono::steady_clock::now();
     time += std::chrono::duration_cast<std::chrono::nanoseconds>(toc - tic);
 
     // Calculate residual
     auto res = gko::initialize<vec>({0.0}, exec);
-    A->apply(lend(one), lend(x), lend(neg_one), lend(b));
-    b->compute_norm2(lend(res));
+    A->apply(one, x, neg_one, b);
+    b->compute_norm2(res);
 
     std::cout << "Initial residual norm sqrt(r^T r): \n";
-    write(std::cout, lend(initres));
+    write(std::cout, initres);
     std::cout << "Final residual norm sqrt(r^T r): \n";
-    write(std::cout, lend(res));
+    write(std::cout, res);
 
     // Print solver statistics
     std::cout << "Multigrid iteration count:     "

--- a/examples/mixed-multigrid-solver/mixed-multigrid-solver.cpp
+++ b/examples/mixed-multigrid-solver/mixed-multigrid-solver.cpp
@@ -101,8 +101,8 @@ int main(int argc, char* argv[])
     }
     auto x = vec::create(exec);
     auto b = vec::create(exec);
-    x->copy_from(host_x.get());
-    b->copy_from(host_b.get());
+    x->copy_from(host_x);
+    b->copy_from(host_b);
 
     // Calculate initial residual by overwriting b
     auto one = gko::initialize<vec>({1.0}, exec);
@@ -112,7 +112,7 @@ int main(int argc, char* argv[])
     b->compute_norm2(initres);
 
     // copy b again
-    b->copy_from(host_b.get());
+    b->copy_from(host_b);
 
     // Prepare the stopping criteria
     const gko::remove_complex<ValueType> tolerance = 1e-12;

--- a/examples/mixed-precision-ir/mixed-precision-ir.cpp
+++ b/examples/mixed-precision-ir/mixed-precision-ir.cpp
@@ -120,7 +120,7 @@ int main(int argc, char* argv[])
     b->convert_to(outer_residual);
 
     // restore b
-    b->copy_from(host_x.get());
+    b->copy_from(host_x);
 
     // Create inner solver
     auto inner_solver =

--- a/examples/multigrid-preconditioned-solver/multigrid-preconditioned-solver.cpp
+++ b/examples/multigrid-preconditioned-solver/multigrid-preconditioned-solver.cpp
@@ -111,8 +111,8 @@ int main(int argc, char* argv[])
     auto one = gko::initialize<vec>({1.0}, exec);
     auto neg_one = gko::initialize<vec>({-1.0}, exec);
     auto initres = gko::initialize<vec>({0.0}, exec);
-    A->apply(lend(one), lend(x), lend(neg_one), lend(b));
-    b->compute_norm2(lend(initres));
+    A->apply(one, x, neg_one, b);
+    b->compute_norm2(initres);
 
     // copy b again
     b->copy_from(host_b.get());
@@ -229,20 +229,20 @@ int main(int argc, char* argv[])
     exec->synchronize();
     std::chrono::nanoseconds time(0);
     auto tic = std::chrono::steady_clock::now();
-    solver->apply(lend(b), lend(x));
+    solver->apply(b, x);
     exec->synchronize();
     auto toc = std::chrono::steady_clock::now();
     time += std::chrono::duration_cast<std::chrono::nanoseconds>(toc - tic);
 
     // Calculate residual
     auto res = gko::initialize<vec>({0.0}, exec);
-    A->apply(lend(one), lend(x), lend(neg_one), lend(b));
-    b->compute_norm2(lend(res));
+    A->apply(one, x, neg_one, b);
+    b->compute_norm2(res);
 
     std::cout << "Initial residual norm sqrt(r^T r): \n";
-    write(std::cout, lend(initres));
+    write(std::cout, initres);
     std::cout << "Final residual norm sqrt(r^T r): \n";
-    write(std::cout, lend(res));
+    write(std::cout, res);
 
     // Print solver statistics
     std::cout << "CG iteration count:     " << logger->get_num_iterations()

--- a/examples/multigrid-preconditioned-solver/multigrid-preconditioned-solver.cpp
+++ b/examples/multigrid-preconditioned-solver/multigrid-preconditioned-solver.cpp
@@ -104,8 +104,8 @@ int main(int argc, char* argv[])
     }
     auto x = vec::create(exec);
     auto b = vec::create(exec);
-    x->copy_from(host_x.get());
-    b->copy_from(host_b.get());
+    x->copy_from(host_x);
+    b->copy_from(host_b);
 
     // Calculate initial residual by overwriting b
     auto one = gko::initialize<vec>({1.0}, exec);
@@ -115,7 +115,7 @@ int main(int argc, char* argv[])
     b->compute_norm2(initres);
 
     // copy b again
-    b->copy_from(host_b.get());
+    b->copy_from(host_b);
 
     // Prepare the stopping criteria
     const gko::remove_complex<ValueType> tolerance = 1e-8;

--- a/examples/nine-pt-stencil-solver/nine-pt-stencil-solver.cpp
+++ b/examples/nine-pt-stencil-solver/nine-pt-stencil-solver.cpp
@@ -293,7 +293,7 @@ void solve_system(const std::string& executor_string,
     auto solver = solver_gen->generate(gko::give(matrix));
 
     // Solve system
-    solver->apply(gko::lend(b), gko::lend(x));
+    solver->apply(b, x);
 }
 
 

--- a/examples/papi-logging/papi-logging.cpp
+++ b/examples/papi-logging/papi-logging.cpp
@@ -202,7 +202,7 @@ int main(int argc, char* argv[])
     A->add_logger(logger);
 
     // Solve system
-    solver->apply(lend(b), lend(x));
+    solver->apply(b, x);
 
 
     // Stop PAPI event gathering and print the counters
@@ -210,15 +210,15 @@ int main(int argc, char* argv[])
 
     // Print solution
     std::cout << "Solution (x): \n";
-    write(std::cout, lend(x));
+    write(std::cout, x);
 
     // Calculate residual
     auto one = gko::initialize<vec>({1.0}, exec);
     auto neg_one = gko::initialize<vec>({-1.0}, exec);
     auto res = gko::initialize<real_vec>({0.0}, exec);
-    A->apply(lend(one), lend(x), lend(neg_one), lend(b));
-    b->compute_norm2(lend(res));
+    A->apply(one, x, neg_one, b);
+    b->compute_norm2(res);
 
     std::cout << "Residual norm sqrt(r^T r): \n";
-    write(std::cout, lend(res));
+    write(std::cout, res);
 }

--- a/examples/par-ilu-convergence/par-ilu-convergence.cpp
+++ b/examples/par-ilu-convergence/par-ilu-convergence.cpp
@@ -189,14 +189,13 @@ int main(int argc, char* argv[])
             exec->synchronize();
             auto toc = std::chrono::high_resolution_clock::now();
             auto residual = gko::clone(exec, mtx);
-            result->get_operators()[0]->apply(lend(one),
-                                              lend(result->get_operators()[1]),
-                                              lend(minus_one), lend(residual));
+            result->get_operators()[0]->apply(one, result->get_operators()[1],
+                                              minus_one, residual);
             times.push_back(
                 std::chrono::duration_cast<std::chrono::nanoseconds>(toc - tic)
                     .count());
             residuals.push_back(
-                compute_ilu_residual_norm(lend(residual), lend(mtx)));
+                compute_ilu_residual_norm(residual.get(), mtx.get()));
         }
         for (auto el : times) {
             std::cout << el << ';';

--- a/examples/poisson-solver/poisson-solver.cpp
+++ b/examples/poisson-solver/poisson-solver.cpp
@@ -174,9 +174,9 @@ int main(int argc, char* argv[])
     // initialize matrix and vectors
     auto matrix = mtx::create(app_exec, gko::dim<2>(discretization_points),
                               3 * discretization_points - 2);
-    generate_stencil_matrix(lend(matrix));
+    generate_stencil_matrix(matrix.get());
     auto rhs = vec::create(app_exec, gko::dim<2>(discretization_points, 1));
-    generate_rhs(f, u0, u1, lend(rhs));
+    generate_rhs(f, u0, u1, rhs.get());
     auto u = vec::create(app_exec, gko::dim<2>(discretization_points, 1));
     for (int i = 0; i < u->get_size()[0]; ++i) {
         u->get_values()[i] = 0.0;
@@ -194,12 +194,12 @@ int main(int argc, char* argv[])
         .with_preconditioner(bj::build().on(exec))
         .on(exec)
         ->generate(clone(exec, matrix))  // copy the matrix to the executor
-        ->apply(lend(rhs), lend(u));
+        ->apply(rhs, u);
 
     // Uncomment to print the solution
-    // print_solution<ValueType>(u0, u1, lend(u));
+    // print_solution<ValueType>(u0, u1, u.get());
     std::cout << "Solve complete.\nThe average relative error is "
-              << calculate_error(discretization_points, lend(u), correct_u) /
+              << calculate_error(discretization_points, u.get(), correct_u) /
                      static_cast<gko::remove_complex<ValueType>>(
                          discretization_points)
               << std::endl;

--- a/examples/preconditioned-solver/preconditioned-solver.cpp
+++ b/examples/preconditioned-solver/preconditioned-solver.cpp
@@ -109,19 +109,19 @@ int main(int argc, char* argv[])
     auto solver = solver_gen->generate(A);
 
     // Solve system
-    solver->apply(lend(b), lend(x));
+    solver->apply(b, x);
 
     // Print solution
     std::cout << "Solution (x):\n";
-    write(std::cout, lend(x));
+    write(std::cout, x);
 
     // Calculate residual
     auto one = gko::initialize<vec>({1.0}, exec);
     auto neg_one = gko::initialize<vec>({-1.0}, exec);
     auto res = gko::initialize<real_vec>({0.0}, exec);
-    A->apply(lend(one), lend(x), lend(neg_one), lend(b));
-    b->compute_norm2(lend(res));
+    A->apply(one, x, neg_one, b);
+    b->compute_norm2(res);
 
     std::cout << "Residual norm sqrt(r^T r):\n";
-    write(std::cout, lend(res));
+    write(std::cout, res);
 }

--- a/examples/preconditioner-export/preconditioner-export.cpp
+++ b/examples/preconditioner-export/preconditioner-export.cpp
@@ -61,9 +61,8 @@ const std::map<std::string, std::function<std::shared_ptr<gko::Executor>()>>
                }}};
 
 
-void output(
-    gko::pointer_param<const gko::WritableToMatrixData<double, int>> mtx,
-    std::string name)
+void output(gko::ptr_param<const gko::WritableToMatrixData<double, int>> mtx,
+            std::string name)
 {
     std::ofstream stream{name};
     std::cerr << "Writing " << name << std::endl;

--- a/examples/preconditioner-export/preconditioner-export.cpp
+++ b/examples/preconditioner-export/preconditioner-export.cpp
@@ -61,7 +61,9 @@ const std::map<std::string, std::function<std::shared_ptr<gko::Executor>()>>
                }}};
 
 
-void output(const gko::WritableToMatrixData<double, int>* mtx, std::string name)
+void output(
+    gko::pointer_param<const gko::WritableToMatrixData<double, int>> mtx,
+    std::string name)
 {
     std::ofstream stream{name};
     std::cerr << "Writing " << name << std::endl;
@@ -144,15 +146,15 @@ int main(int argc, char* argv[])
                     : gko::precision_reduction(0, std::stoi(argv[6]));
         }
         auto jacobi = try_generate([&] { return factory->generate(mtx); });
-        output(jacobi.get(), matrix + ".jacobi" + output_suffix);
+        output(jacobi, matrix + ".jacobi" + output_suffix);
     } else if (precond == "ilu") {
         // ilu: no parameters
         auto ilu = gko::as<gko::Composition<>>(try_generate([&] {
             return gko::factorization::Ilu<>::build().on(exec)->generate(mtx);
         }));
-        output(gko::as<gko::matrix::Csr<>>(ilu->get_operators()[0].get()),
+        output(gko::as<gko::matrix::Csr<>>(ilu->get_operators()[0]),
                matrix + ".ilu-l");
-        output(gko::as<gko::matrix::Csr<>>(ilu->get_operators()[1].get()),
+        output(gko::as<gko::matrix::Csr<>>(ilu->get_operators()[1]),
                matrix + ".ilu-u");
     } else if (precond == "parilu") {
         // parilu: iterations
@@ -162,9 +164,9 @@ int main(int argc, char* argv[])
         }
         auto ilu = gko::as<gko::Composition<>>(
             try_generate([&] { return factory->generate(mtx); }));
-        output(gko::as<gko::matrix::Csr<>>(ilu->get_operators()[0].get()),
+        output(gko::as<gko::matrix::Csr<>>(ilu->get_operators()[0]),
                matrix + ".parilu" + output_suffix + "-l");
-        output(gko::as<gko::matrix::Csr<>>(ilu->get_operators()[1].get()),
+        output(gko::as<gko::matrix::Csr<>>(ilu->get_operators()[1]),
                matrix + ".parilu" + output_suffix + "-u");
     } else if (precond == "parilut") {
         // parilut: iterations, fill-in limit
@@ -177,9 +179,9 @@ int main(int argc, char* argv[])
         }
         auto ilut = gko::as<gko::Composition<>>(
             try_generate([&] { return factory->generate(mtx); }));
-        output(gko::as<gko::matrix::Csr<>>(ilut->get_operators()[0].get()),
+        output(gko::as<gko::matrix::Csr<>>(ilut->get_operators()[0]),
                matrix + ".parilut" + output_suffix + "-l");
-        output(gko::as<gko::matrix::Csr<>>(ilut->get_operators()[1].get()),
+        output(gko::as<gko::matrix::Csr<>>(ilut->get_operators()[1]),
                matrix + ".parilut" + output_suffix + "-u");
     } else if (precond == "ilu-isai") {
         // ilu-isai: sparsity power
@@ -201,9 +203,9 @@ int main(int argc, char* argv[])
                                            .on(exec))
                 .on(exec);
         auto ilu_isai = try_generate([&] { return factory->generate(mtx); });
-        output(ilu_isai->get_l_solver()->get_approximate_inverse().get(),
+        output(ilu_isai->get_l_solver()->get_approximate_inverse(),
                matrix + ".ilu-isai" + output_suffix + "-l");
-        output(ilu_isai->get_u_solver()->get_approximate_inverse().get(),
+        output(ilu_isai->get_u_solver()->get_approximate_inverse(),
                matrix + ".ilu-isai" + output_suffix + "-u");
     } else if (precond == "parilu-isai") {
         // parilu-isai: iterations, sparsity power
@@ -228,9 +230,9 @@ int main(int argc, char* argv[])
                                            .on(exec))
                 .on(exec);
         auto ilu_isai = try_generate([&] { return factory->generate(mtx); });
-        output(ilu_isai->get_l_solver()->get_approximate_inverse().get(),
+        output(ilu_isai->get_l_solver()->get_approximate_inverse(),
                matrix + ".parilu-isai" + output_suffix + "-l");
-        output(ilu_isai->get_u_solver()->get_approximate_inverse().get(),
+        output(ilu_isai->get_u_solver()->get_approximate_inverse(),
                matrix + ".parilu-isai" + output_suffix + "-u");
     } else if (precond == "parilut-isai") {
         // parilut-isai: iterations, fill-in limit, sparsity power
@@ -258,9 +260,9 @@ int main(int argc, char* argv[])
                                            .on(exec))
                 .on(exec);
         auto ilu_isai = try_generate([&] { return factory->generate(mtx); });
-        output(ilu_isai->get_l_solver()->get_approximate_inverse().get(),
+        output(ilu_isai->get_l_solver()->get_approximate_inverse(),
                matrix + ".parilut-isai" + output_suffix + "-l");
-        output(ilu_isai->get_u_solver()->get_approximate_inverse().get(),
+        output(ilu_isai->get_u_solver()->get_approximate_inverse(),
                matrix + ".parilut-isai" + output_suffix + "-u");
     }
 }

--- a/examples/schroedinger-splitting/schroedinger-splitting.cpp
+++ b/examples/schroedinger-splitting/schroedinger-splitting.cpp
@@ -188,7 +188,7 @@ int main(int argc, char* argv[])
             output_timestep(output, n, amplitude->get_const_values());
         }
         // time step in linear part
-        fft->apply(lend(amplitude), lend(frequency));
+        fft->apply(amplitude, frequency);
         for (int i = 0; i < n; i++) {
             for (int j = 0; j < n; j++) {
                 frequency->at(idx(i, j)) *=
@@ -197,7 +197,7 @@ int main(int argc, char* argv[])
                 frequency->at(idx(i, j)) *= 1.0 / n2;
             }
         }
-        ifft->apply(lend(frequency), lend(amplitude));
+        ifft->apply(frequency, amplitude);
         // time step in non-linear part
         for (int i = 0; i < n; i++) {
             for (int j = 0; j < n; j++) {

--- a/examples/simple-solver-logging/simple-solver-logging.cpp
+++ b/examples/simple-solver-logging/simple-solver-logging.cpp
@@ -163,7 +163,7 @@ int main(int argc, char* argv[])
     residual_criterion->add_logger(record_logger);
 
     // Solve system
-    solver->apply(lend(b), lend(x));
+    solver->apply(b, x);
 
     // Print the residual of the last criterion check event (where
     // convergence happened)
@@ -174,15 +174,15 @@ int main(int argc, char* argv[])
 
     // Print solution
     std::cout << "Solution (x):\n";
-    write(std::cout, lend(x));
+    write(std::cout, x);
 
     // Calculate residual
     auto one = gko::initialize<vec>({1.0}, exec);
     auto neg_one = gko::initialize<vec>({-1.0}, exec);
     auto res = gko::initialize<real_vec>({0.0}, exec);
-    A->apply(lend(one), lend(x), lend(neg_one), lend(b));
-    b->compute_norm2(lend(res));
+    A->apply(one, x, neg_one, b);
+    b->compute_norm2(res);
 
     std::cout << "Residual norm sqrt(r^T r):\n";
-    write(std::cout, lend(res));
+    write(std::cout, res);
 }

--- a/examples/simple-solver/simple-solver.cpp
+++ b/examples/simple-solver/simple-solver.cpp
@@ -113,8 +113,8 @@ int main(int argc, char* argv[])
     // @note Ginkgo uses C++ smart pointers to automatically manage memory. To
     // this end, we use our own object ownership transfer functions that under
     // the hood call the required smart pointer functions to manage object
-    // ownership. The gko::share , gko::give and gko::lend are the functions
-    // that you would need to use.
+    // ownership. gko::share and gko::give are the functions that you would need
+    // to use.
     auto A = gko::share(gko::read<mtx>(std::ifstream("data/A.mtx"), exec));
     auto b = gko::read<vec>(std::ifstream("data/b.mtx"), exec);
     auto x = gko::read<vec>(std::ifstream("data/x0.mtx"), exec);
@@ -150,11 +150,11 @@ int main(int argc, char* argv[])
     // Finally, solve the system. The solver, being a gko::LinOp, can be applied
     // to a right hand side, b to
     // obtain the solution, x.
-    solver->apply(lend(b), lend(x));
+    solver->apply(b, x);
 
     // Print the solution to the command line.
     std::cout << "Solution (x):\n";
-    write(std::cout, lend(x));
+    write(std::cout, x);
 
     // To measure if your solution has actually converged, you can measure the
     // error of the solution.
@@ -166,9 +166,9 @@ int main(int argc, char* argv[])
     auto one = gko::initialize<vec>({1.0}, exec);
     auto neg_one = gko::initialize<vec>({-1.0}, exec);
     auto res = gko::initialize<real_vec>({0.0}, exec);
-    A->apply(lend(one), lend(x), lend(neg_one), lend(b));
-    b->compute_norm2(lend(res));
+    A->apply(one, x, neg_one, b);
+    b->compute_norm2(res);
 
     std::cout << "Residual norm sqrt(r^T r):\n";
-    write(std::cout, lend(res));
+    write(std::cout, res);
 }

--- a/examples/three-pt-stencil-solver/three-pt-stencil-solver.cpp
+++ b/examples/three-pt-stencil-solver/three-pt-stencil-solver.cpp
@@ -228,7 +228,7 @@ void solve_system(const std::string& executor_string,
     auto solver = solver_gen->generate(gko::give(matrix));
 
     // Solve system
-    solver->apply(gko::lend(b), gko::lend(x));
+    solver->apply(b, x);
 }
 
 

--- a/hip/factorization/par_ilut_select_common.hip.cpp
+++ b/hip/factorization/par_ilut_select_common.hip.cpp
@@ -112,7 +112,7 @@ sampleselect_bucket<IndexType> sampleselect_find_bucket(
     hipLaunchKernelGGL(HIP_KERNEL_NAME(kernel::find_bucket), 1,
                        config::warp_size, 0, 0, prefix_sum, rank);
     IndexType values[3]{};
-    exec->get_master()->copy_from(exec.get(), 3, prefix_sum, values);
+    exec->get_master()->copy_from(exec, 3, prefix_sum, values);
     return {values[0], values[1], values[2]};
 }
 

--- a/hip/matrix/fbcsr_kernels.hip.cpp
+++ b/hip/matrix/fbcsr_kernels.hip.cpp
@@ -327,8 +327,7 @@ void is_sorted_by_column_index(
     *is_sorted = true;
     auto gpu_array = array<bool>(exec, 1);
     // need to initialize the GPU value to true
-    exec->copy_from(exec->get_master().get(), 1, is_sorted,
-                    gpu_array.get_data());
+    exec->copy_from(exec->get_master(), 1, is_sorted, gpu_array.get_data());
     auto block_size = default_block_size;
     const auto num_brows =
         static_cast<IndexType>(to_check->get_num_block_rows());

--- a/hip/test/base/hip_executor.hip.cpp
+++ b/hip/test/base/hip_executor.hip.cpp
@@ -184,7 +184,7 @@ TEST_F(HipExecutor, CopiesDataToHip)
     int orig[] = {3, 8};
     auto* copy = hip->alloc<int>(2);
 
-    hip->copy_from(omp.get(), 2, orig, copy);
+    hip->copy_from(omp, 2, orig, copy);
 
     hipLaunchKernelGGL((check_data), 1, 1, 0, 0, copy);
     ASSERT_NO_THROW(hip->synchronize());
@@ -212,7 +212,7 @@ TEST_F(HipExecutor, CanAllocateOnUnifiedMemory)
     int orig[] = {3, 8};
     auto* copy = hip3->alloc<int>(2);
 
-    hip3->copy_from(omp.get(), 2, orig, copy);
+    hip3->copy_from(omp, 2, orig, copy);
 
     check_data<<<1, 1>>>(copy);
     ASSERT_NO_THROW(hip3->synchronize());
@@ -237,7 +237,7 @@ TEST_F(HipExecutor, CopiesDataFromHip)
     auto orig = hip->alloc<int>(2);
     hipLaunchKernelGGL((init_data), 1, 1, 0, 0, orig);
 
-    omp->copy_from(hip.get(), 2, orig, copy);
+    omp->copy_from(hip, 2, orig, copy);
 
     EXPECT_EQ(3, copy[0]);
     ASSERT_EQ(8, copy[1]);
@@ -280,7 +280,7 @@ TEST_F(HipExecutor, CopiesDataFromHipToHip)
     hipLaunchKernelGGL((init_data), 1, 1, 0, 0, orig);
 
     auto copy_hip2 = hip2->alloc<int>(2);
-    hip2->copy_from(hip.get(), 2, orig, copy_hip2);
+    hip2->copy_from(hip, 2, orig, copy_hip2);
 
     // Check that the data is really on GPU2 and ensure we did not cheat
     int value = -1;
@@ -290,7 +290,7 @@ TEST_F(HipExecutor, CopiesDataFromHipToHip)
     hip2->run(ExampleOperation(value));
     ASSERT_EQ(value, hip2->get_device_id());
     // Put the results on OpenMP and run CPU side assertions
-    omp->copy_from(hip2.get(), 2, copy_hip2, copy);
+    omp->copy_from(hip2, 2, copy_hip2, copy);
     EXPECT_EQ(3, copy[0]);
     ASSERT_EQ(8, copy[1]);
     hip2->free(copy_hip2);

--- a/hip/test/base/kernel_launch.hip.cpp
+++ b/hip/test/base/kernel_launch.hip.cpp
@@ -109,7 +109,7 @@ protected:
         }
         zero_dense->fill(0.0);
         zero_dense2->fill(0.0);
-        iota_dense->copy_from(ref_iota_dense.get());
+        iota_dense->copy_from(ref_iota_dense);
         zero_array.set_executor(exec);
         iota_array.set_executor(exec);
         iota_transp_array.set_executor(exec);

--- a/hip/test/matrix/fbcsr_kernels.hip.cpp
+++ b/hip/test/matrix/fbcsr_kernels.hip.cpp
@@ -135,7 +135,7 @@ TYPED_TEST(Fbcsr, TransposeIsEquivalentToRefSortedBS3)
     using value_type = typename Mtx::value_type;
     using index_type = typename Mtx::index_type;
     auto rand_hip = Mtx::create(this->hip);
-    rand_hip->copy_from(gko::lend(this->rsorted_ref));
+    rand_hip->copy_from(this->rsorted_ref);
     auto trans_ref_linop = this->rsorted_ref->transpose();
     std::unique_ptr<const Mtx> trans_ref =
         gko::as<const Mtx>(std::move(trans_ref_linop));
@@ -162,7 +162,7 @@ TYPED_TEST(Fbcsr, TransposeIsEquivalentToRefSortedBS7)
         gko::test::generate_random_fbcsr<value_type, index_type>(
             this->ref, rand_brows, rand_bcols, block_size, false, false,
             std::default_random_engine(43));
-    rand_hip->copy_from(gko::lend(rsorted_ref2));
+    rand_hip->copy_from(rsorted_ref2);
 
     auto trans_ref_linop = rsorted_ref2->transpose();
     std::unique_ptr<const Mtx> trans_ref =
@@ -182,7 +182,7 @@ TYPED_TEST(Fbcsr, SpmvIsEquivalentToRefSorted)
     using Dense = typename TestFixture::Dense;
     using value_type = typename Mtx::value_type;
     auto rand_hip = Mtx::create(this->hip);
-    rand_hip->copy_from(gko::lend(this->rsorted_ref));
+    rand_hip->copy_from(this->rsorted_ref);
     auto x_ref = Dense::create(
         this->ref, gko::dim<2>(this->rsorted_ref->get_size()[1], 1));
     this->generate_sin(x_ref.get());
@@ -206,7 +206,7 @@ TYPED_TEST(Fbcsr, SpmvMultiIsEquivalentToRefSorted)
     using Dense = typename TestFixture::Dense;
     using value_type = typename Mtx::value_type;
     auto rand_hip = Mtx::create(this->hip);
-    rand_hip->copy_from(gko::lend(this->rsorted_ref));
+    rand_hip->copy_from(this->rsorted_ref);
     auto x_ref = Dense::create(
         this->ref, gko::dim<2>(this->rsorted_ref->get_size()[1], 3));
     this->generate_sin(x_ref.get());
@@ -231,7 +231,7 @@ TYPED_TEST(Fbcsr, AdvancedSpmvIsEquivalentToRefSorted)
     using value_type = typename TestFixture::value_type;
     using real_type = typename TestFixture::real_type;
     auto rand_hip = Mtx::create(this->hip);
-    rand_hip->copy_from(gko::lend(this->rsorted_ref));
+    rand_hip->copy_from(this->rsorted_ref);
     auto x_ref = Dense::create(
         this->ref, gko::dim<2>(this->rsorted_ref->get_size()[1], 1));
     this->generate_sin(x_ref.get());
@@ -268,7 +268,7 @@ TYPED_TEST(Fbcsr, AdvancedSpmvMultiIsEquivalentToRefSorted)
     using value_type = typename TestFixture::value_type;
     using real_type = typename TestFixture::real_type;
     auto rand_hip = Mtx::create(this->hip);
-    rand_hip->copy_from(gko::lend(this->rsorted_ref));
+    rand_hip->copy_from(this->rsorted_ref);
     auto x_ref = Dense::create(
         this->ref, gko::dim<2>(this->rsorted_ref->get_size()[1], 3));
     this->generate_sin(x_ref.get());
@@ -304,7 +304,7 @@ TYPED_TEST(Fbcsr, ConjTransposeIsEquivalentToRefSortedBS3)
     using value_type = typename Mtx::value_type;
     using index_type = typename Mtx::index_type;
     auto rand_hip = Mtx::create(this->hip);
-    rand_hip->copy_from(gko::lend(this->rsorted_ref));
+    rand_hip->copy_from(this->rsorted_ref);
     auto trans_ref_linop = this->rsorted_ref->conj_transpose();
     std::unique_ptr<const Mtx> trans_ref =
         gko::as<const Mtx>(std::move(trans_ref_linop));
@@ -322,7 +322,7 @@ TYPED_TEST(Fbcsr, RecognizeSortedMatrix)
 {
     using Mtx = typename TestFixture::Mtx;
     auto rand_hip = Mtx::create(this->hip);
-    rand_hip->copy_from(gko::lend(this->rsorted_ref));
+    rand_hip->copy_from(this->rsorted_ref);
 
     ASSERT_TRUE(rand_hip->is_sorted_by_column_index());
 }
@@ -336,7 +336,7 @@ TYPED_TEST(Fbcsr, RecognizeUnsortedMatrix)
     index_type* const colinds = mat->get_col_idxs();
     std::swap(colinds[0], colinds[1]);
     auto unsrt_hip = Mtx::create(this->hip);
-    unsrt_hip->copy_from(gko::lend(mat));
+    unsrt_hip->copy_from(mat);
 
     ASSERT_FALSE(unsrt_hip->is_sorted_by_column_index());
 }
@@ -349,7 +349,7 @@ TYPED_TEST(Fbcsr, InplaceAbsoluteMatrixIsEquivalentToRef)
     auto rand_ref = Mtx::create(this->ref);
     rand_ref->copy_from(this->rsorted_ref.get());
     auto rand_hip = Mtx::create(this->hip);
-    rand_hip->copy_from(gko::lend(this->rsorted_ref));
+    rand_hip->copy_from(this->rsorted_ref);
 
     rand_ref->compute_absolute_inplace();
     rand_hip->compute_absolute_inplace();
@@ -364,7 +364,7 @@ TYPED_TEST(Fbcsr, OutplaceAbsoluteMatrixIsEquivalentToRef)
     using Mtx = typename TestFixture::Mtx;
     using value_type = typename Mtx::value_type;
     auto rand_hip = Mtx::create(this->hip);
-    rand_hip->copy_from(gko::lend(this->rsorted_ref));
+    rand_hip->copy_from(this->rsorted_ref);
 
     auto abs_mtx = this->rsorted_ref->compute_absolute();
     auto dabs_mtx = rand_hip->compute_absolute();

--- a/hip/test/matrix/fbcsr_kernels.hip.cpp
+++ b/hip/test/matrix/fbcsr_kernels.hip.cpp
@@ -187,13 +187,13 @@ TYPED_TEST(Fbcsr, SpmvIsEquivalentToRefSorted)
         this->ref, gko::dim<2>(this->rsorted_ref->get_size()[1], 1));
     this->generate_sin(x_ref.get());
     auto x_hip = Dense::create(this->hip);
-    x_hip->copy_from(x_ref.get());
+    x_hip->copy_from(x_ref);
     auto prod_ref = Dense::create(
         this->ref, gko::dim<2>(this->rsorted_ref->get_size()[0], 1));
     auto prod_hip = Dense::create(this->hip, prod_ref->get_size());
 
-    rand_hip->apply(x_hip.get(), prod_hip.get());
-    this->rsorted_ref->apply(x_ref.get(), prod_ref.get());
+    rand_hip->apply(x_hip, prod_hip);
+    this->rsorted_ref->apply(x_ref, prod_ref);
 
     const double tol = r<value_type>::value;
     GKO_ASSERT_MTX_NEAR(prod_ref, prod_hip, 5 * tol);
@@ -211,13 +211,13 @@ TYPED_TEST(Fbcsr, SpmvMultiIsEquivalentToRefSorted)
         this->ref, gko::dim<2>(this->rsorted_ref->get_size()[1], 3));
     this->generate_sin(x_ref.get());
     auto x_hip = Dense::create(this->hip);
-    x_hip->copy_from(x_ref.get());
+    x_hip->copy_from(x_ref);
     auto prod_ref = Dense::create(
         this->ref, gko::dim<2>(this->rsorted_ref->get_size()[0], 3));
     auto prod_hip = Dense::create(this->hip, prod_ref->get_size());
 
-    rand_hip->apply(x_hip.get(), prod_hip.get());
-    this->rsorted_ref->apply(x_ref.get(), prod_ref.get());
+    rand_hip->apply(x_hip, prod_hip);
+    this->rsorted_ref->apply(x_ref, prod_ref);
 
     const double tol = r<value_type>::value;
     GKO_ASSERT_MTX_NEAR(prod_ref, prod_hip, 5 * tol);
@@ -236,25 +236,24 @@ TYPED_TEST(Fbcsr, AdvancedSpmvIsEquivalentToRefSorted)
         this->ref, gko::dim<2>(this->rsorted_ref->get_size()[1], 1));
     this->generate_sin(x_ref.get());
     auto x_hip = Dense::create(this->hip);
-    x_hip->copy_from(x_ref.get());
+    x_hip->copy_from(x_ref);
     auto prod_ref = Dense::create(
         this->ref, gko::dim<2>(this->rsorted_ref->get_size()[0], 1));
     this->generate_sin(prod_ref.get());
     auto prod_hip = Dense::create(this->hip);
-    prod_hip->copy_from(prod_ref.get());
+    prod_hip->copy_from(prod_ref);
     auto alpha_ref = Dense::create(this->ref, gko::dim<2>(1, 1));
     alpha_ref->get_values()[0] =
         static_cast<real_type>(2.4) + this->get_random_value();
     auto beta_ref = Dense::create(this->ref, gko::dim<2>(1, 1));
     beta_ref->get_values()[0] = -1.2;
     auto alpha = Dense::create(this->hip);
-    alpha->copy_from(alpha_ref.get());
+    alpha->copy_from(alpha_ref);
     auto beta = Dense::create(this->hip);
-    beta->copy_from(beta_ref.get());
+    beta->copy_from(beta_ref);
 
-    rand_hip->apply(alpha.get(), x_hip.get(), beta.get(), prod_hip.get());
-    this->rsorted_ref->apply(alpha_ref.get(), x_ref.get(), beta_ref.get(),
-                             prod_ref.get());
+    rand_hip->apply(alpha, x_hip, beta, prod_hip);
+    this->rsorted_ref->apply(alpha_ref, x_ref, beta_ref, prod_ref);
 
     const double tol = r<value_type>::value;
     GKO_ASSERT_MTX_NEAR(prod_ref, prod_hip, 5 * tol);
@@ -273,25 +272,24 @@ TYPED_TEST(Fbcsr, AdvancedSpmvMultiIsEquivalentToRefSorted)
         this->ref, gko::dim<2>(this->rsorted_ref->get_size()[1], 3));
     this->generate_sin(x_ref.get());
     auto x_hip = Dense::create(this->hip);
-    x_hip->copy_from(x_ref.get());
+    x_hip->copy_from(x_ref);
     auto prod_ref = Dense::create(
         this->ref, gko::dim<2>(this->rsorted_ref->get_size()[0], 3));
     this->generate_sin(prod_ref.get());
     auto prod_hip = Dense::create(this->hip);
-    prod_hip->copy_from(prod_ref.get());
+    prod_hip->copy_from(prod_ref);
     auto alpha_ref = Dense::create(this->ref, gko::dim<2>(1, 1));
     alpha_ref->get_values()[0] =
         static_cast<real_type>(2.4) + this->get_random_value();
     auto beta_ref = Dense::create(this->ref, gko::dim<2>(1, 1));
     beta_ref->get_values()[0] = -1.2;
     auto alpha = Dense::create(this->hip);
-    alpha->copy_from(alpha_ref.get());
+    alpha->copy_from(alpha_ref);
     auto beta = Dense::create(this->hip);
-    beta->copy_from(beta_ref.get());
+    beta->copy_from(beta_ref);
 
-    rand_hip->apply(alpha.get(), x_hip.get(), beta.get(), prod_hip.get());
-    this->rsorted_ref->apply(alpha_ref.get(), x_ref.get(), beta_ref.get(),
-                             prod_ref.get());
+    rand_hip->apply(alpha, x_hip, beta, prod_hip);
+    this->rsorted_ref->apply(alpha_ref, x_ref, beta_ref, prod_ref);
 
     const double tol = r<value_type>::value;
     GKO_ASSERT_MTX_NEAR(prod_ref, prod_hip, 5 * tol);
@@ -347,7 +345,7 @@ TYPED_TEST(Fbcsr, InplaceAbsoluteMatrixIsEquivalentToRef)
     using Mtx = typename TestFixture::Mtx;
     using value_type = typename Mtx::value_type;
     auto rand_ref = Mtx::create(this->ref);
-    rand_ref->copy_from(this->rsorted_ref.get());
+    rand_ref->copy_from(this->rsorted_ref);
     auto rand_hip = Mtx::create(this->hip);
     rand_hip->copy_from(this->rsorted_ref);
 

--- a/hip/test/solver/lower_trs_kernels.cpp
+++ b/hip/test/solver/lower_trs_kernels.cpp
@@ -93,13 +93,13 @@ protected:
         b = gen_mtx(m, n);
         x = gen_mtx(m, n);
         csr_mtx = CsrMtx::create(ref);
-        mtx->convert_to(csr_mtx.get());
+        mtx->convert_to(csr_mtx);
         d_csr_mtx = CsrMtx::create(hip);
         d_x = gko::clone(hip, x);
-        d_csr_mtx->copy_from(csr_mtx.get());
+        d_csr_mtx->copy_from(csr_mtx);
         b2 = Mtx::create(ref);
         d_b2 = gko::clone(hip, b);
-        b2->copy_from(b.get());
+        b2->copy_from(b);
     }
 
     std::shared_ptr<Mtx> b;
@@ -135,8 +135,8 @@ TEST_F(LowerTrs, HipSingleRhsApplyIsEquivalentToRef)
     auto solver = lower_trs_factory->generate(csr_mtx);
     auto d_solver = d_lower_trs_factory->generate(d_csr_mtx);
 
-    solver->apply(b2.get(), x.get());
-    d_solver->apply(d_b2.get(), d_x.get());
+    solver->apply(b2, x);
+    d_solver->apply(d_b2, d_x);
 
     GKO_ASSERT_MTX_NEAR(d_x, x, 1e-14);
 }
@@ -152,8 +152,8 @@ TEST_F(LowerTrs, HipMultipleRhsApplyIsEquivalentToRef)
     auto solver = lower_trs_factory->generate(csr_mtx);
     auto d_solver = d_lower_trs_factory->generate(d_csr_mtx);
 
-    solver->apply(b2.get(), x.get());
-    d_solver->apply(d_b2.get(), d_x.get());
+    solver->apply(b2, x);
+    d_solver->apply(d_b2, d_x);
 
     GKO_ASSERT_MTX_NEAR(d_x, x, 1e-14);
 }

--- a/hip/test/solver/upper_trs_kernels.cpp
+++ b/hip/test/solver/upper_trs_kernels.cpp
@@ -93,13 +93,13 @@ protected:
         b = gen_mtx(m, n);
         x = gen_mtx(m, n);
         csr_mtx = CsrMtx::create(ref);
-        mtx->convert_to(csr_mtx.get());
+        mtx->convert_to(csr_mtx);
         d_csr_mtx = CsrMtx::create(hip);
         d_x = gko::clone(hip, x);
-        d_csr_mtx->copy_from(csr_mtx.get());
+        d_csr_mtx->copy_from(csr_mtx);
         b2 = Mtx::create(ref);
         d_b2 = gko::clone(hip, b);
-        b2->copy_from(b.get());
+        b2->copy_from(b);
     }
 
     std::shared_ptr<Mtx> b;
@@ -135,8 +135,8 @@ TEST_F(UpperTrs, HipSingleRhsApplyIsEquivalentToRef)
     auto solver = upper_trs_factory->generate(csr_mtx);
     auto d_solver = d_upper_trs_factory->generate(d_csr_mtx);
 
-    solver->apply(b2.get(), x.get());
-    d_solver->apply(d_b2.get(), d_x.get());
+    solver->apply(b2, x);
+    d_solver->apply(d_b2, d_x);
 
     GKO_ASSERT_MTX_NEAR(d_x, x, 1e-14);
 }
@@ -152,8 +152,8 @@ TEST_F(UpperTrs, HipMultipleRhsApplyIsEquivalentToRef)
     auto solver = upper_trs_factory->generate(csr_mtx);
     auto d_solver = d_upper_trs_factory->generate(d_csr_mtx);
 
-    solver->apply(b2.get(), x.get());
-    d_solver->apply(d_b2.get(), d_x.get());
+    solver->apply(b2, x);
+    d_solver->apply(d_b2, d_x);
 
     GKO_ASSERT_MTX_NEAR(d_x, x, 1e-14);
 }

--- a/hip/test/utils/assertions_test.hip.cpp
+++ b/hip/test/utils/assertions_test.hip.cpp
@@ -72,7 +72,7 @@ TEST_F(MatricesNear, CanPassHipMatrix)
     auto mtx = gko::initialize<gko::matrix::Dense<>>(
         {{1.0, 2.0, 3.0}, {0.0, 4.0, 0.0}}, ref);
     auto csr_ref = gko::matrix::Csr<>::create(ref);
-    csr_ref->copy_from(mtx.get());
+    csr_ref->copy_from(mtx);
     auto csr_mtx = gko::matrix::Csr<>::create(hip);
     csr_mtx->copy_from(std::move(csr_ref));
 

--- a/hip/test/utils/assertions_test.hip.cpp
+++ b/hip/test/utils/assertions_test.hip.cpp
@@ -74,7 +74,7 @@ TEST_F(MatricesNear, CanPassHipMatrix)
     auto csr_ref = gko::matrix::Csr<>::create(ref);
     csr_ref->copy_from(mtx);
     auto csr_mtx = gko::matrix::Csr<>::create(hip);
-    csr_mtx->copy_from(std::move(csr_ref));
+    csr_mtx->move_from(csr_ref);
 
     GKO_EXPECT_MTX_NEAR(csr_mtx, mtx, 0.0);
     GKO_ASSERT_MTX_NEAR(csr_mtx, mtx, 0.0);

--- a/include/ginkgo/core/base/array.hpp
+++ b/include/ginkgo/core/base/array.hpp
@@ -467,7 +467,7 @@ public:
             GKO_ENSURE_COMPATIBLE_BOUNDS(other.get_num_elems(),
                                          this->num_elems_);
         }
-        exec_->copy_from(other.get_executor().get(), other.get_num_elems(),
+        exec_->copy_from(other.get_executor(), other.get_num_elems(),
                          other.get_const_data(), this->get_data());
         return *this;
     }
@@ -865,7 +865,7 @@ template <typename ValueType>
 array<ValueType> const_array_view<ValueType>::copy_to_array() const
 {
     array<ValueType> result(this->get_executor(), this->get_num_elems());
-    result.get_executor()->copy_from(this->get_executor().get(),
+    result.get_executor()->copy_from(this->get_executor(),
                                      this->get_num_elems(),
                                      this->get_const_data(), result.get_data());
     return result;

--- a/include/ginkgo/core/base/exception.hpp
+++ b/include/ginkgo/core/base/exception.hpp
@@ -71,7 +71,7 @@ namespace gko {
  *     auto A = randn_fill<matrix::Csr<float>>(5, 5, 0f, 1f, omp);
  *     auto x = fill<matrix::Dense<float>>(6, 1, 1f, omp);
  *     try {
- *         auto y = apply(A.get(), x.get());
+ *         auto y = apply(A, x);
  *     } catch(Error e) {
  *         // an error occured, write the message to screen and exit
  *         std::cout << e.what() << std::endl;

--- a/include/ginkgo/core/base/lin_op.hpp
+++ b/include/ginkgo/core/base/lin_op.hpp
@@ -134,7 +134,7 @@ class Diagonal;
  *
  * Here, if $L$ is a matrix, LinOp::apply() refers to the matrix vector
  * product, and `L->apply(a, b)` computes $b = L \cdot a$.
- * `x->add_scaled(one.get(), b.get())` is the `axpy` vector update $x:=x+b$.
+ * `x->add_scaled(one, b)` is the `axpy` vector update $x:=x+b$.
  *
  * The interesting part of this example is the apply() routine at line 4 of the
  * function body. Since this routine is part of the LinOp base class, the

--- a/include/ginkgo/core/base/precision_dispatch.hpp
+++ b/include/ginkgo/core/base/precision_dispatch.hpp
@@ -82,7 +82,7 @@ make_temporary_conversion(Ptr&& matrix)
     auto result = detail::temporary_conversion<
         MaybeConstDense>::template create<NextDense>(matrix);
     if (!result) {
-        GKO_NOT_SUPPORTED(matrix);
+        GKO_NOT_SUPPORTED(*matrix);
     }
     return result;
 }

--- a/include/ginkgo/core/base/std_extensions.hpp
+++ b/include/ginkgo/core/base/std_extensions.hpp
@@ -64,17 +64,6 @@ struct make_void {
 }  // namespace detail
 
 
-template <typename T>
-struct dont_deduce {
-    using type = T;
-};
-
-
-// Avoid a parameter being involved in type deduction
-template <typename T>
-using dont_deduce_t = typename dont_deduce<T>::type;
-
-
 // Added in C++17
 template <typename... Ts>
 using void_t = typename detail::make_void<Ts...>::type;

--- a/include/ginkgo/core/base/std_extensions.hpp
+++ b/include/ginkgo/core/base/std_extensions.hpp
@@ -64,6 +64,17 @@ struct make_void {
 }  // namespace detail
 
 
+template <typename T>
+struct dont_deduce {
+    using type = T;
+};
+
+
+// Avoid a parameter being involved in type deduction
+template <typename T>
+using dont_deduce_t = typename dont_deduce<T>::type;
+
+
 // Added in C++17
 template <typename... Ts>
 using void_t = typename detail::make_void<Ts...>::type;

--- a/include/ginkgo/core/base/temporary_conversion.hpp
+++ b/include/ginkgo/core/base/temporary_conversion.hpp
@@ -176,7 +176,7 @@ struct conversion_helper {
             // so we can convert from this type to TargetType
             auto converted = conversion_target_helper<
                 std::remove_cv_t<TargetType>>::create_empty(cast_obj);
-            cast_obj->convert_to(converted.get());
+            cast_obj->convert_to(converted);
             // Make sure ConvertibleTo<TargetType> is available and symmetric
             static_assert(
                 std::is_base_of<ConvertibleTo<std::remove_cv_t<TargetType>>,

--- a/include/ginkgo/core/distributed/matrix.hpp
+++ b/include/ginkgo/core/distributed/matrix.hpp
@@ -454,8 +454,7 @@ protected:
                     mpi::communicator comm, MatrixType matrix_template)
         : Matrix(
               exec, comm,
-              matrix_template.template create<ValueType, LocalIndexType>(exec)
-                  .get())
+              matrix_template.template create<ValueType, LocalIndexType>(exec))
     {}
 
     /**
@@ -494,13 +493,12 @@ protected:
                     mpi::communicator comm,
                     LocalMatrixType local_matrix_template,
                     NonLocalMatrixType non_local_matrix_template)
-        : Matrix(exec, comm,
-                 local_matrix_template
-                     .template create<ValueType, LocalIndexType>(exec)
-                     .get(),
-                 non_local_matrix_template
-                     .template create<ValueType, LocalIndexType>(exec)
-                     .get())
+        : Matrix(
+              exec, comm,
+              local_matrix_template.template create<ValueType, LocalIndexType>(
+                  exec),
+              non_local_matrix_template
+                  .template create<ValueType, LocalIndexType>(exec))
     {}
 
     /**

--- a/include/ginkgo/core/matrix/dense.hpp
+++ b/include/ginkgo/core/matrix/dense.hpp
@@ -1352,7 +1352,7 @@ std::unique_ptr<Matrix> initialize(
         ++idx;
     }
     auto mtx = Matrix::create(exec, std::forward<TArgs>(create_args)...);
-    tmp->move_to(mtx.get());
+    tmp->move_to(mtx);
     return mtx;
 }
 
@@ -1428,7 +1428,7 @@ std::unique_ptr<Matrix> initialize(
         ++ridx;
     }
     auto mtx = Matrix::create(exec, std::forward<TArgs>(create_args)...);
-    tmp->move_to(mtx.get());
+    tmp->move_to(mtx);
     return mtx;
 }
 

--- a/include/ginkgo/core/matrix/permutation.hpp
+++ b/include/ginkgo/core/matrix/permutation.hpp
@@ -243,7 +243,7 @@ protected:
                 }
             }
         }
-        out->copy_from(std::move(tmp));
+        out->move_from(tmp);
     }
 
 

--- a/include/ginkgo/core/matrix/sparsity_csr.hpp
+++ b/include/ginkgo/core/matrix/sparsity_csr.hpp
@@ -330,7 +330,7 @@ protected:
         : EnableLinOp<SparsityCsr>(exec, matrix->get_size())
     {
         auto tmp_ = copy_and_convert_to<SparsityCsr>(exec, matrix);
-        this->copy_from(std::move(tmp_.get()));
+        this->copy_from(tmp_);
     }
 
     void apply_impl(const LinOp* b, LinOp* x) const override;

--- a/include/ginkgo/core/preconditioner/ic.hpp
+++ b/include/ginkgo/core/preconditioner/ic.hpp
@@ -250,11 +250,11 @@ protected:
         precision_dispatch_real_complex<value_type>(
             [&](auto dense_b, auto dense_x) {
                 this->set_cache_to(dense_b);
-                l_solver_->apply(dense_b, cache_.intermediate.get());
+                l_solver_->apply(dense_b, cache_.intermediate);
                 if (lh_solver_->apply_uses_initial_guess()) {
-                    dense_x->copy_from(cache_.intermediate.get());
+                    dense_x->copy_from(cache_.intermediate);
                 }
-                lh_solver_->apply(cache_.intermediate.get(), dense_x);
+                lh_solver_->apply(cache_.intermediate, dense_x);
             },
             b, x);
     }
@@ -265,9 +265,9 @@ protected:
         precision_dispatch_real_complex<value_type>(
             [&](auto dense_alpha, auto dense_b, auto dense_beta, auto dense_x) {
                 this->set_cache_to(dense_b);
-                l_solver_->apply(dense_b, cache_.intermediate.get());
-                lh_solver_->apply(dense_alpha, cache_.intermediate.get(),
-                                  dense_beta, dense_x);
+                l_solver_->apply(dense_b, cache_.intermediate);
+                lh_solver_->apply(dense_alpha, cache_.intermediate, dense_beta,
+                                  dense_x);
             },
             alpha, b, beta, x);
     }

--- a/include/ginkgo/core/preconditioner/ilu.hpp
+++ b/include/ginkgo/core/preconditioner/ilu.hpp
@@ -269,17 +269,17 @@ protected:
             [&](auto dense_b, auto dense_x) {
                 this->set_cache_to(dense_b);
                 if (!ReverseApply) {
-                    l_solver_->apply(dense_b, cache_.intermediate.get());
+                    l_solver_->apply(dense_b, cache_.intermediate);
                     if (u_solver_->apply_uses_initial_guess()) {
-                        dense_x->copy_from(cache_.intermediate.get());
+                        dense_x->copy_from(cache_.intermediate);
                     }
-                    u_solver_->apply(cache_.intermediate.get(), dense_x);
+                    u_solver_->apply(cache_.intermediate, dense_x);
                 } else {
-                    u_solver_->apply(dense_b, cache_.intermediate.get());
+                    u_solver_->apply(dense_b, cache_.intermediate);
                     if (l_solver_->apply_uses_initial_guess()) {
-                        dense_x->copy_from(cache_.intermediate.get());
+                        dense_x->copy_from(cache_.intermediate);
                     }
-                    l_solver_->apply(cache_.intermediate.get(), dense_x);
+                    l_solver_->apply(cache_.intermediate, dense_x);
                 }
             },
             b, x);
@@ -292,12 +292,12 @@ protected:
             [&](auto dense_alpha, auto dense_b, auto dense_beta, auto dense_x) {
                 this->set_cache_to(dense_b);
                 if (!ReverseApply) {
-                    l_solver_->apply(dense_b, cache_.intermediate.get());
-                    u_solver_->apply(dense_alpha, cache_.intermediate.get(),
+                    l_solver_->apply(dense_b, cache_.intermediate);
+                    u_solver_->apply(dense_alpha, cache_.intermediate,
                                      dense_beta, dense_x);
                 } else {
-                    u_solver_->apply(dense_b, cache_.intermediate.get());
-                    l_solver_->apply(dense_alpha, cache_.intermediate.get(),
+                    u_solver_->apply(dense_b, cache_.intermediate);
+                    l_solver_->apply(dense_alpha, cache_.intermediate,
                                      dense_beta, dense_x);
                 }
             },

--- a/include/ginkgo/core/reorder/rcm.hpp
+++ b/include/ginkgo/core/reorder/rcm.hpp
@@ -202,12 +202,12 @@ protected:
         if (is_gpu_executor) {
             const auto gpu_exec = this->get_executor();
             auto gpu_perm = share(PermutationMatrix::create(gpu_exec, dim));
-            gpu_perm->copy_from(permutation_.get());
+            gpu_perm->copy_from(permutation_);
             permutation_ = gpu_perm;
             if (inv_permutation_) {
                 auto gpu_inv_perm =
                     share(PermutationMatrix::create(gpu_exec, dim));
-                gpu_inv_perm->copy_from(inv_permutation_.get());
+                gpu_inv_perm->copy_from(inv_permutation_);
                 inv_permutation_ = gpu_inv_perm;
             }
         }

--- a/include/ginkgo/core/reorder/scaled_reordered.hpp
+++ b/include/ginkgo/core/reorder/scaled_reordered.hpp
@@ -151,13 +151,13 @@ protected:
             GKO_ASSERT_EQUAL_DIMENSIONS(parameters_.row_scaling,
                                         system_matrix_);
             row_scaling_ = parameters_.row_scaling;
-            row_scaling_->apply(system_matrix_.get(), system_matrix_.get());
+            row_scaling_->apply(system_matrix_, system_matrix_);
         }
         if (parameters_.col_scaling) {
             GKO_ASSERT_EQUAL_DIMENSIONS(parameters_.col_scaling,
                                         system_matrix_);
             col_scaling_ = parameters_.col_scaling;
-            col_scaling_->rapply(system_matrix_.get(), system_matrix_.get());
+            col_scaling_->rapply(system_matrix_, system_matrix_);
         }
 
         // If a reordering factory is provided, generate the reordering and

--- a/omp/test/matrix/fbcsr_kernels.cpp
+++ b/omp/test/matrix/fbcsr_kernels.cpp
@@ -103,23 +103,23 @@ protected:
         square_mtx = gko::test::generate_random_fbcsr<real_type>(
             ref, num_brows, num_brows, blk_sz, false, false, rand_engine);
         dmtx = Mtx::create(omp);
-        dmtx->copy_from(mtx.get());
+        dmtx->copy_from(mtx);
         complex_dmtx = ComplexMtx::create(omp);
-        complex_dmtx->copy_from(complex_mtx.get());
+        complex_dmtx->copy_from(complex_mtx);
         square_dmtx = Mtx::create(omp);
-        square_dmtx->copy_from(square_mtx.get());
+        square_dmtx->copy_from(square_mtx);
         expected = gen_mtx<Vec>(num_brows * blk_sz, num_vectors, 1);
         y = gen_mtx<Vec>(num_bcols * blk_sz, num_vectors, 1);
         alpha = gko::initialize<Vec>({2.0}, ref);
         beta = gko::initialize<Vec>({-1.0}, ref);
         dresult = Vec::create(omp);
-        dresult->copy_from(expected.get());
+        dresult->copy_from(expected);
         dy = Vec::create(omp);
-        dy->copy_from(y.get());
+        dy->copy_from(y);
         dalpha = Vec::create(omp);
-        dalpha->copy_from(alpha.get());
+        dalpha->copy_from(alpha);
         dbeta = Vec::create(omp);
-        dbeta->copy_from(beta.get());
+        dbeta->copy_from(beta);
     }
 
     struct matrix_pair {
@@ -134,7 +134,7 @@ protected:
             ref, num_brows, num_bcols, blk_sz, false, true, rand_engine);
 
         auto local_mtx_omp = Mtx::create(omp);
-        local_mtx_omp->copy_from(local_mtx_ref.get());
+        local_mtx_omp->copy_from(local_mtx_ref);
 
         return matrix_pair{std::move(local_mtx_ref), std::move(local_mtx_omp)};
     }
@@ -187,8 +187,8 @@ TEST_F(Fbcsr, SimpleApplyIsEquivalentToRef)
 {
     set_up_apply_data();
 
-    mtx->apply(y.get(), expected.get());
-    dmtx->apply(dy.get(), dresult.get());
+    mtx->apply(y, expected);
+    dmtx->apply(dy, dresult);
 
     GKO_ASSERT_MTX_NEAR(dresult, expected, 1e-14);
 }
@@ -198,8 +198,8 @@ TEST_F(Fbcsr, SimpleApplyToDenseMatrixIsEquivalentToRef)
 {
     set_up_apply_data(3);
 
-    mtx->apply(y.get(), expected.get());
-    dmtx->apply(dy.get(), dresult.get());
+    mtx->apply(y, expected);
+    dmtx->apply(dy, dresult);
 
     GKO_ASSERT_MTX_NEAR(dresult, expected, 1e-14);
 }
@@ -210,8 +210,8 @@ TEST_F(Fbcsr, SimpleApplyToDenseMatrixIsEquivalentToRefUnsorted)
     set_up_apply_data(3);
     auto pair = gen_unsorted_mtx();
 
-    pair.ref->apply(y.get(), expected.get());
-    pair.omp->apply(dy.get(), dresult.get());
+    pair.ref->apply(y, expected);
+    pair.omp->apply(dy, dresult);
 
     GKO_ASSERT_MTX_NEAR(dresult, expected, 1e-14);
 }
@@ -221,8 +221,8 @@ TEST_F(Fbcsr, AdvancedApplyToDenseMatrixIsEquivalentToRef)
 {
     set_up_apply_data(3);
 
-    mtx->apply(alpha.get(), y.get(), beta.get(), expected.get());
-    dmtx->apply(dalpha.get(), dy.get(), dbeta.get(), dresult.get());
+    mtx->apply(alpha, y, beta, expected);
+    dmtx->apply(dalpha, dy, dbeta, dresult);
 
     GKO_ASSERT_MTX_NEAR(dresult, expected, 1e-14);
 }
@@ -233,13 +233,13 @@ TEST_F(Fbcsr, ApplyToComplexIsEquivalentToRef)
     set_up_apply_data(3);
     auto complex_b = gen_mtx<ComplexVec>(num_bcols * blk_sz, 3, 1);
     auto dcomplex_b = ComplexVec::create(omp);
-    dcomplex_b->copy_from(complex_b.get());
+    dcomplex_b->copy_from(complex_b);
     auto complex_x = gen_mtx<ComplexVec>(num_brows * blk_sz, 3, 1);
     auto dcomplex_x = ComplexVec::create(omp);
-    dcomplex_x->copy_from(complex_x.get());
+    dcomplex_x->copy_from(complex_x);
 
-    mtx->apply(complex_b.get(), complex_x.get());
-    dmtx->apply(dcomplex_b.get(), dcomplex_x.get());
+    mtx->apply(complex_b, complex_x);
+    dmtx->apply(dcomplex_b, dcomplex_x);
 
     GKO_ASSERT_MTX_NEAR(dcomplex_x, complex_x, 1e-14);
 }
@@ -250,13 +250,13 @@ TEST_F(Fbcsr, AdvancedApplyToComplexIsEquivalentToRef)
     set_up_apply_data(3);
     auto complex_b = gen_mtx<ComplexVec>(num_bcols * blk_sz, 3, 1);
     auto dcomplex_b = ComplexVec::create(omp);
-    dcomplex_b->copy_from(complex_b.get());
+    dcomplex_b->copy_from(complex_b);
     auto complex_x = gen_mtx<ComplexVec>(num_brows * blk_sz, 3, 1);
     auto dcomplex_x = ComplexVec::create(omp);
-    dcomplex_x->copy_from(complex_x.get());
+    dcomplex_x->copy_from(complex_x);
 
-    mtx->apply(alpha.get(), complex_b.get(), beta.get(), complex_x.get());
-    dmtx->apply(dalpha.get(), dcomplex_b.get(), dbeta.get(), dcomplex_x.get());
+    mtx->apply(alpha, complex_b, beta, complex_x);
+    dmtx->apply(dalpha, dcomplex_b, dbeta, dcomplex_x);
 
     GKO_ASSERT_MTX_NEAR(dcomplex_x, complex_x, 1e-14);
 }
@@ -339,7 +339,7 @@ TEST_F(Fbcsr, ExtractDiagonalIsEquivalentToRef)
     auto diag = mtx->extract_diagonal();
     auto ddiag = dmtx->extract_diagonal();
 
-    GKO_ASSERT_MTX_NEAR(diag.get(), ddiag.get(), 0);
+    GKO_ASSERT_MTX_NEAR(diag, ddiag, 0);
 }
 
 

--- a/reference/test/base/combination.cpp
+++ b/reference/test/base/combination.cpp
@@ -135,7 +135,7 @@ TYPED_TEST(Combination, AppliesToVector)
     auto x = gko::initialize<Mtx>({1.0, 2.0}, this->exec);
     auto res = clone(x);
 
-    cmb->apply(lend(x), lend(res));
+    cmb->apply(x, res);
 
     GKO_ASSERT_MTX_NEAR(res, l({22.0, 13.0}), r<TypeParam>::value);
 }
@@ -155,7 +155,7 @@ TYPED_TEST(Combination, AppliesToMixedVector)
     auto x = gko::initialize<Mtx>({1.0, 2.0}, this->exec);
     auto res = clone(x);
 
-    cmb->apply(lend(x), lend(res));
+    cmb->apply(x, res);
 
     GKO_ASSERT_MTX_NEAR(res, l({22.0, 13.0}),
                         (r_mixed<value_type, TypeParam>()));
@@ -176,7 +176,7 @@ TYPED_TEST(Combination, AppliesToComplexVector)
     auto x = gko::initialize<Mtx>({T{1.0, -2.0}, T{2.0, -4.0}}, this->exec);
     auto res = clone(x);
 
-    cmb->apply(lend(x), lend(res));
+    cmb->apply(x, res);
 
     GKO_ASSERT_MTX_NEAR(res, l({T{22.0, -44.0}, T{13.0, -26.0}}),
                         r<TypeParam>::value);
@@ -198,7 +198,7 @@ TYPED_TEST(Combination, AppliesToMixedComplexVector)
         {value_type{1.0, -2.0}, value_type{2.0, -4.0}}, this->exec);
     auto res = clone(x);
 
-    cmb->apply(lend(x), lend(res));
+    cmb->apply(x, res);
 
     GKO_ASSERT_MTX_NEAR(res,
                         l({value_type{22.0, -44.0}, value_type{13.0, -26.0}}),
@@ -221,7 +221,7 @@ TYPED_TEST(Combination, AppliesLinearCombinationToVector)
     auto x = gko::initialize<Mtx>({1.0, 2.0}, this->exec);
     auto res = clone(x);
 
-    cmb->apply(lend(alpha), lend(x), lend(beta), lend(res));
+    cmb->apply(alpha, x, beta, res);
 
     GKO_ASSERT_MTX_NEAR(res, l({65.0, 37.0}), r<TypeParam>::value);
 }
@@ -243,7 +243,7 @@ TYPED_TEST(Combination, AppliesLinearCombinationToMixedVector)
     auto x = gko::initialize<Mtx>({1.0, 2.0}, this->exec);
     auto res = clone(x);
 
-    cmb->apply(lend(alpha), lend(x), lend(beta), lend(res));
+    cmb->apply(alpha, x, beta, res);
 
     GKO_ASSERT_MTX_NEAR(res, l({65.0, 37.0}),
                         (r_mixed<value_type, TypeParam>()));
@@ -268,7 +268,7 @@ TYPED_TEST(Combination, AppliesLinearCombinationToComplexVector)
         gko::initialize<DenseComplex>({T{1.0, -2.0}, T{2.0, -4.0}}, this->exec);
     auto res = clone(x);
 
-    cmb->apply(lend(alpha), lend(x), lend(beta), lend(res));
+    cmb->apply(alpha, x, beta, res);
 
     GKO_ASSERT_MTX_NEAR(res, l({T{65.0, -130.0}, T{37.0, -74.0}}),
                         r<TypeParam>::value);
@@ -293,7 +293,7 @@ TYPED_TEST(Combination, AppliesLinearCombinationToMixedComplexVector)
         {value_type{1.0, -2.0}, value_type{2.0, -4.0}}, this->exec);
     auto res = clone(x);
 
-    cmb->apply(lend(alpha), lend(x), lend(beta), lend(res));
+    cmb->apply(alpha, x, beta, res);
 
     GKO_ASSERT_MTX_NEAR(res,
                         l({value_type{65.0, -130.0}, value_type{37.0, -74.0}}),

--- a/reference/test/base/combination.cpp
+++ b/reference/test/base/combination.cpp
@@ -78,7 +78,7 @@ TYPED_TEST(Combination, CopiesOnSameExecutor)
         this->operators[1]);
     auto out = cmb->create_default();
 
-    cmb->convert_to(out.get());
+    cmb->convert_to(out);
 
     ASSERT_EQ(out->get_size(), cmb->get_size());
     ASSERT_EQ(out->get_executor(), cmb->get_executor());
@@ -102,7 +102,7 @@ TYPED_TEST(Combination, MovesOnSameExecutor)
     auto cmb2 = cmb->clone();
     auto out = cmb->create_default();
 
-    cmb->move_to(out.get());
+    cmb->move_to(out);
 
     ASSERT_EQ(out->get_size(), cmb2->get_size());
     ASSERT_EQ(out->get_executor(), cmb2->get_executor());

--- a/reference/test/base/composition.cpp
+++ b/reference/test/base/composition.cpp
@@ -163,7 +163,7 @@ TYPED_TEST(Composition, AppliesSingleToVector)
     auto x = gko::initialize<Mtx>({1.0, 2.0}, this->exec);
     auto res = clone(x);
 
-    cmp->apply(lend(x), lend(res));
+    cmp->apply(x, res);
 
     GKO_ASSERT_MTX_NEAR(res, l({-13.0, 79.0}), r<TypeParam>::value);
 }
@@ -181,7 +181,7 @@ TYPED_TEST(Composition, AppliesSingleToMixedVector)
     auto x = gko::initialize<Mtx>({1.0, 2.0}, this->exec);
     auto res = clone(x);
 
-    cmp->apply(lend(x), lend(res));
+    cmp->apply(x, res);
 
     GKO_ASSERT_MTX_NEAR(res, l({-13.0, 79.0}),
                         (r_mixed<value_type, TypeParam>()));
@@ -201,7 +201,7 @@ TYPED_TEST(Composition, AppliesSingleToComplexVector)
         {value_type{1.0, -2.0}, value_type{2.0, -4.0}}, this->exec);
     auto res = clone(x);
 
-    cmp->apply(lend(x), lend(res));
+    cmp->apply(x, res);
 
     GKO_ASSERT_MTX_NEAR(res,
                         l({value_type{-13.0, 26.0}, value_type{79.0, -158.0}}),
@@ -222,7 +222,7 @@ TYPED_TEST(Composition, AppliesSingleToMixedComplexVector)
         {value_type{1.0, -2.0}, value_type{2.0, -4.0}}, this->exec);
     auto res = clone(x);
 
-    cmp->apply(lend(x), lend(res));
+    cmp->apply(x, res);
 
     GKO_ASSERT_MTX_NEAR(res,
                         l({value_type{-13.0, 26.0}, value_type{79.0, -158.0}}),
@@ -243,7 +243,7 @@ TYPED_TEST(Composition, AppliesSingleLinearCombinationToVector)
     auto x = gko::initialize<Mtx>({1.0, 2.0}, this->exec);
     auto res = clone(x);
 
-    cmp->apply(lend(alpha), lend(x), lend(beta), lend(res));
+    cmp->apply(alpha, x, beta, res);
 
     GKO_ASSERT_MTX_NEAR(res, l({-40.0, 235.0}), r<TypeParam>::value);
 }
@@ -263,7 +263,7 @@ TYPED_TEST(Composition, AppliesSingleLinearCombinationToMixedVector)
     auto x = gko::initialize<Mtx>({1.0, 2.0}, this->exec);
     auto res = clone(x);
 
-    cmp->apply(lend(alpha), lend(x), lend(beta), lend(res));
+    cmp->apply(alpha, x, beta, res);
 
     GKO_ASSERT_MTX_NEAR(res, l({-40.0, 235.0}),
                         (r_mixed<value_type, TypeParam>()));
@@ -286,7 +286,7 @@ TYPED_TEST(Composition, AppliesSingleLinearCombinationToComplexVector)
         {value_type{1.0, -2.0}, value_type{2.0, -4.0}}, this->exec);
     auto res = clone(x);
 
-    cmp->apply(lend(alpha), lend(x), lend(beta), lend(res));
+    cmp->apply(alpha, x, beta, res);
 
     GKO_ASSERT_MTX_NEAR(res,
                         l({value_type{-40.0, 80.0}, value_type{235.0, -470.0}}),
@@ -310,7 +310,7 @@ TYPED_TEST(Composition, AppliesSingleLinearCombinationToMixedComplexVector)
         {value_type{1.0, -2.0}, value_type{2.0, -4.0}}, this->exec);
     auto res = clone(x);
 
-    cmp->apply(lend(alpha), lend(x), lend(beta), lend(res));
+    cmp->apply(alpha, x, beta, res);
 
     GKO_ASSERT_MTX_NEAR(res,
                         l({value_type{-40.0, 80.0}, value_type{235.0, -470.0}}),
@@ -330,7 +330,7 @@ TYPED_TEST(Composition, AppliesToVector)
     auto x = gko::initialize<Mtx>({1.0, 2.0}, this->exec);
     auto res = clone(x);
 
-    cmp->apply(lend(x), lend(res));
+    cmp->apply(x, res);
 
     GKO_ASSERT_MTX_NEAR(res, l({14.0, 7.0}), r<TypeParam>::value);
 }
@@ -350,7 +350,7 @@ TYPED_TEST(Composition, AppliesLinearCombinationToVector)
     auto x = gko::initialize<Mtx>({1.0, 2.0}, this->exec);
     auto res = clone(x);
 
-    cmp->apply(lend(alpha), lend(x), lend(beta), lend(res));
+    cmp->apply(alpha, x, beta, res);
 
     GKO_ASSERT_MTX_NEAR(res, l({41.0, 19.0}), r<TypeParam>::value);
 }
@@ -368,7 +368,7 @@ TYPED_TEST(Composition, AppliesLongerToVector)
     auto x = gko::initialize<Mtx>({1.0, 2.0}, this->exec);
     auto res = clone(x);
 
-    cmp->apply(lend(x), lend(res));
+    cmp->apply(x, res);
 
     GKO_ASSERT_MTX_NEAR(res, l({238.0, 119.0}), r<TypeParam>::value);
 }
@@ -388,7 +388,7 @@ TYPED_TEST(Composition, AppliesLongerLinearCombinationToVector)
     auto x = gko::initialize<Mtx>({1.0, 2.0}, this->exec);
     auto res = clone(x);
 
-    cmp->apply(lend(alpha), lend(x), lend(beta), lend(res));
+    cmp->apply(alpha, x, beta, res);
 
     GKO_ASSERT_MTX_NEAR(res, l({713.0, 355.0}), r<TypeParam>::value);
 }
@@ -407,7 +407,7 @@ TYPED_TEST(Composition, AppliesLongestToVector)
     auto x = gko::initialize<Mtx>({1.0, 2.0}, this->exec);
     auto res = clone(x);
 
-    cmp->apply(lend(x), lend(res));
+    cmp->apply(x, res);
 
     GKO_ASSERT_MTX_NEAR(res, l({238.0, 119.0}), r<TypeParam>::value);
 }
@@ -428,7 +428,7 @@ TYPED_TEST(Composition, AppliesLongestLinearCombinationToVector)
     auto x = gko::initialize<Mtx>({1.0, 2.0}, this->exec);
     auto res = clone(x);
 
-    cmp->apply(lend(alpha), lend(x), lend(beta), lend(res));
+    cmp->apply(alpha, x, beta, res);
 
     GKO_ASSERT_MTX_NEAR(res, l({713.0, 355.0}), r<TypeParam>::value);
 }
@@ -447,7 +447,7 @@ TYPED_TEST(Composition, AppliesLongestToVectorMultipleRhs)
     auto x = clone(this->identity);
     auto res = clone(x);
 
-    cmp->apply(lend(x), lend(res));
+    cmp->apply(x, res);
 
     GKO_ASSERT_MTX_NEAR(res, l({{54.0, 92.0}, {27.0, 46.0}}),
                         r<TypeParam>::value);
@@ -469,7 +469,7 @@ TYPED_TEST(Composition, AppliesLongestLinearCombinationToVectorMultipleRhs)
     auto x = clone(this->identity);
     auto res = clone(x);
 
-    cmp->apply(lend(alpha), lend(x), lend(beta), lend(res));
+    cmp->apply(alpha, x, beta, res);
 
     GKO_ASSERT_MTX_NEAR(res, l({{161.0, 276.0}, {81.0, 137.0}}),
                         r<TypeParam>::value);
@@ -490,7 +490,7 @@ TYPED_TEST(Composition, AppliesToVectorWithInitialGuess)
     auto x = gko::initialize<Mtx>({1.0, 2.0}, this->exec);
     auto res = clone(x);
 
-    cmp->apply(lend(x), lend(res));
+    cmp->apply(x, res);
 
     GKO_ASSERT_MTX_NEAR(res, l({1.0, 2.0}), 0);
 }
@@ -511,7 +511,7 @@ TYPED_TEST(Composition, AppliesToVectorWithInitialGuess2)
     auto x = gko::initialize<Mtx>({1.0, 2.0}, this->exec);
     auto res = clone(x);
 
-    cmp->apply(lend(x), lend(res));
+    cmp->apply(x, res);
 
     GKO_ASSERT_MTX_NEAR(res, l({0.0, 0.0}), 0);
 }
@@ -530,7 +530,7 @@ TYPED_TEST(Composition, AppliesToVectorWithInitialGuess3)
     auto x = gko::initialize<Mtx>({1.0, 2.0}, this->exec);
     auto res = clone(x);
 
-    cmp->apply(lend(x), lend(res));
+    cmp->apply(x, res);
 
     GKO_ASSERT_MTX_NEAR(res, l({1.0, 2.0}), 0);
 }
@@ -551,7 +551,7 @@ TYPED_TEST(Composition, AppliesToVectorWithInitialGuess4)
     auto x = gko::initialize<Mtx>({1.0, 2.0}, this->exec);
     auto res = clone(x);
 
-    cmp->apply(lend(x), lend(res));
+    cmp->apply(x, res);
 
     GKO_ASSERT_MTX_NEAR(res, l({0.0, 0.0}), 0);
 }
@@ -572,7 +572,7 @@ TYPED_TEST(Composition, AppliesToVectorWithInitialGuess5)
     auto x = gko::initialize<Mtx>({1.0, 2.0}, this->exec);
     auto res = clone(x);
 
-    cmp->apply(lend(x), lend(res));
+    cmp->apply(x, res);
 
     GKO_ASSERT_MTX_NEAR(res, l({1.0, 2.0}), 0);
 }

--- a/reference/test/base/composition.cpp
+++ b/reference/test/base/composition.cpp
@@ -118,7 +118,7 @@ TYPED_TEST(Composition, CopiesOnSameExecutor)
                                                    this->operators[1]);
     auto out = cmp->create_default();
 
-    cmp->convert_to(out.get());
+    cmp->convert_to(out);
 
     ASSERT_EQ(out->get_size(), cmp->get_size());
     ASSERT_EQ(out->get_executor(), cmp->get_executor());
@@ -137,7 +137,7 @@ TYPED_TEST(Composition, MovesOnSameExecutor)
     auto cmp2 = cmp->clone();
     auto out = cmp->create_default();
 
-    cmp->move_to(out.get());
+    cmp->move_to(out);
 
     ASSERT_EQ(out->get_size(), cmp2->get_size());
     ASSERT_EQ(out->get_executor(), cmp2->get_executor());

--- a/reference/test/base/perturbation.cpp
+++ b/reference/test/base/perturbation.cpp
@@ -120,9 +120,9 @@ TYPED_TEST(Perturbation, AppliesToVector)
     auto cmp = gko::Perturbation<TypeParam>::create(this->scalar, this->basis,
                                                     this->projector);
     auto x = gko::initialize<Mtx>({1.0, 2.0}, this->exec);
-    auto res = Mtx::create_with_config_of(gko::lend(x));
+    auto res = Mtx::create_with_config_of(x);
 
-    cmp->apply(gko::lend(x), gko::lend(res));
+    cmp->apply(x, res);
 
     GKO_ASSERT_MTX_NEAR(res, l({29.0, 16.0}), r<TypeParam>::value);
 }
@@ -139,9 +139,9 @@ TYPED_TEST(Perturbation, AppliesToMixedVector)
     auto cmp = gko::Perturbation<TypeParam>::create(this->scalar, this->basis,
                                                     this->projector);
     auto x = gko::initialize<Mtx>({1.0, 2.0}, this->exec);
-    auto res = Mtx::create_with_config_of(gko::lend(x));
+    auto res = Mtx::create_with_config_of(x);
 
-    cmp->apply(gko::lend(x), gko::lend(res));
+    cmp->apply(x, res);
 
     GKO_ASSERT_MTX_NEAR(res, l({29.0, 16.0}),
                         (r_mixed<value_type, TypeParam>()));
@@ -160,9 +160,9 @@ TYPED_TEST(Perturbation, AppliesToComplexVector)
                                                     this->projector);
     auto x = gko::initialize<Mtx>(
         {value_type{1.0, -2.0}, value_type{2.0, -4.0}}, this->exec);
-    auto res = Mtx::create_with_config_of(gko::lend(x));
+    auto res = Mtx::create_with_config_of(x);
 
-    cmp->apply(gko::lend(x), gko::lend(res));
+    cmp->apply(x, res);
 
     GKO_ASSERT_MTX_NEAR(res,
                         l({value_type{29.0, -58.0}, value_type{16.0, -32.0}}),
@@ -182,9 +182,9 @@ TYPED_TEST(Perturbation, AppliesToMixedComplexVector)
                                                     this->projector);
     auto x = gko::initialize<Mtx>(
         {value_type{1.0, -2.0}, value_type{2.0, -4.0}}, this->exec);
-    auto res = Mtx::create_with_config_of(gko::lend(x));
+    auto res = Mtx::create_with_config_of(x);
 
-    cmp->apply(gko::lend(x), gko::lend(res));
+    cmp->apply(x, res);
 
     GKO_ASSERT_MTX_NEAR(res,
                         l({value_type{29.0, -58.0}, value_type{16.0, -32.0}}),
@@ -206,7 +206,7 @@ TYPED_TEST(Perturbation, AppliesLinearCombinationToVector)
     auto x = gko::initialize<Mtx>({1.0, 2.0}, this->exec);
     auto res = gko::clone(x);
 
-    cmp->apply(gko::lend(alpha), gko::lend(x), gko::lend(beta), gko::lend(res));
+    cmp->apply(alpha, x, beta, res);
 
     GKO_ASSERT_MTX_NEAR(res, l({86.0, 46.0}), r<TypeParam>::value);
 }
@@ -227,7 +227,7 @@ TYPED_TEST(Perturbation, AppliesLinearCombinationToMixedVector)
     auto x = gko::initialize<Mtx>({1.0, 2.0}, this->exec);
     auto res = gko::clone(x);
 
-    cmp->apply(gko::lend(alpha), gko::lend(x), gko::lend(beta), gko::lend(res));
+    cmp->apply(alpha, x, beta, res);
 
     GKO_ASSERT_MTX_NEAR(res, l({86.0, 46.0}),
                         (r_mixed<value_type, TypeParam>()));
@@ -251,7 +251,7 @@ TYPED_TEST(Perturbation, AppliesLinearCombinationToComplexVector)
         {value_type{1.0, -2.0}, value_type{2.0, -4.0}}, this->exec);
     auto res = gko::clone(x);
 
-    cmp->apply(gko::lend(alpha), gko::lend(x), gko::lend(beta), gko::lend(res));
+    cmp->apply(alpha, x, beta, res);
 
     GKO_ASSERT_MTX_NEAR(res,
                         l({value_type{86.0, -172.0}, value_type{46.0, -92.0}}),
@@ -276,7 +276,7 @@ TYPED_TEST(Perturbation, AppliesLinearCombinationToMixedComplexVector)
         {value_type{1.0, -2.0}, value_type{2.0, -4.0}}, this->exec);
     auto res = gko::clone(x);
 
-    cmp->apply(gko::lend(alpha), gko::lend(x), gko::lend(beta), gko::lend(res));
+    cmp->apply(alpha, x, beta, res);
 
     GKO_ASSERT_MTX_NEAR(res,
                         l({value_type{86.0, -172.0}, value_type{46.0, -92.0}}),
@@ -293,9 +293,9 @@ TYPED_TEST(Perturbation, ConstructionByBasisAppliesToVector)
     using Mtx = typename TestFixture::Mtx;
     auto cmp = gko::Perturbation<TypeParam>::create(this->scalar, this->basis);
     auto x = gko::initialize<Mtx>({1.0, 2.0}, this->exec);
-    auto res = Mtx::create_with_config_of(gko::lend(x));
+    auto res = Mtx::create_with_config_of(x);
 
-    cmp->apply(gko::lend(x), gko::lend(res));
+    cmp->apply(x, res);
 
     GKO_ASSERT_MTX_NEAR(res, l({17.0, 10.0}), r<TypeParam>::value);
 }
@@ -314,7 +314,7 @@ TYPED_TEST(Perturbation, ConstructionByBasisAppliesLinearCombinationToVector)
     auto x = gko::initialize<Mtx>({1.0, 2.0}, this->exec);
     auto res = gko::clone(x);
 
-    cmp->apply(gko::lend(alpha), gko::lend(x), gko::lend(beta), gko::lend(res));
+    cmp->apply(alpha, x, beta, res);
 
     GKO_ASSERT_MTX_NEAR(res, l({50.0, 28.0}), r<TypeParam>::value);
 }

--- a/reference/test/base/perturbation.cpp
+++ b/reference/test/base/perturbation.cpp
@@ -76,7 +76,7 @@ TYPED_TEST(Perturbation, CopiesOnSameExecutor)
                                                     this->projector);
     auto out = per->create_default();
 
-    per->convert_to(out.get());
+    per->convert_to(out);
 
     ASSERT_EQ(out->get_size(), per->get_size());
     ASSERT_EQ(out->get_executor(), per->get_executor());
@@ -94,7 +94,7 @@ TYPED_TEST(Perturbation, MovesOnSameExecutor)
     auto per2 = per->clone();
     auto out = per->create_default();
 
-    per->move_to(out.get());
+    per->move_to(out);
 
     ASSERT_EQ(out->get_size(), per2->get_size());
     ASSERT_EQ(out->get_executor(), per2->get_executor());

--- a/reference/test/base/utils.cpp
+++ b/reference/test/base/utils.cpp
@@ -88,7 +88,7 @@ TEST_F(ConvertToWithSorting, SortWithUniquePtr)
     auto result = gko::convert_to_with_sorting<Csr>(ref, unsorted_coo, false);
 
     ASSERT_TRUE(result->is_sorted_by_column_index());
-    GKO_ASSERT_MTX_NEAR(result.get(), mtx.get(), 0.);
+    GKO_ASSERT_MTX_NEAR(result, mtx, 0.);
 }
 
 
@@ -97,7 +97,7 @@ TEST_F(ConvertToWithSorting, DontSortWithUniquePtr)
     auto result = gko::convert_to_with_sorting<Csr>(ref, unsorted_csr, true);
 
     ASSERT_EQ(result.get(), unsorted_csr.get());
-    GKO_ASSERT_MTX_NEAR(result.get(), mtx.get(), 0.);
+    GKO_ASSERT_MTX_NEAR(result, mtx, 0.);
 }
 
 
@@ -108,7 +108,7 @@ TEST_F(ConvertToWithSorting, SortWithSharedPtr)
     auto result = gko::convert_to_with_sorting<Csr>(ref, shared, false);
 
     ASSERT_TRUE(result->is_sorted_by_column_index());
-    GKO_ASSERT_MTX_NEAR(result.get(), mtx.get(), 0.);
+    GKO_ASSERT_MTX_NEAR(result, mtx, 0.);
 }
 
 
@@ -119,7 +119,7 @@ TEST_F(ConvertToWithSorting, DontSortWithSharedPtr)
     auto result = gko::convert_to_with_sorting<Csr>(ref, shared, true);
 
     ASSERT_EQ(result.get(), shared.get());
-    GKO_ASSERT_MTX_NEAR(result.get(), mtx.get(), 0.);
+    GKO_ASSERT_MTX_NEAR(result, mtx, 0.);
 }
 
 
@@ -130,7 +130,7 @@ TEST_F(ConvertToWithSorting, SortWithSharedConstPtr)
     auto result = gko::convert_to_with_sorting<Csr>(ref, shared, false);
 
     ASSERT_TRUE(result->is_sorted_by_column_index());
-    GKO_ASSERT_MTX_NEAR(result.get(), mtx.get(), 0.);
+    GKO_ASSERT_MTX_NEAR(result, mtx, 0.);
 }
 
 
@@ -140,7 +140,7 @@ TEST_F(ConvertToWithSorting, DontSortWithSharedConstPtr)
 
     auto result = gko::convert_to_with_sorting<Csr>(ref, shared, true);
 
-    GKO_ASSERT_MTX_NEAR(result.get(), mtx.get(), 0.);
+    GKO_ASSERT_MTX_NEAR(result, mtx, 0.);
 }
 
 
@@ -150,7 +150,7 @@ TEST_F(ConvertToWithSorting, SortWithRawPtr)
         gko::convert_to_with_sorting<Csr>(ref, unsorted_coo.get(), false);
 
     ASSERT_TRUE(result->is_sorted_by_column_index());
-    GKO_ASSERT_MTX_NEAR(result.get(), mtx.get(), 0.);
+    GKO_ASSERT_MTX_NEAR(result, mtx, 0.);
 }
 
 
@@ -159,7 +159,7 @@ TEST_F(ConvertToWithSorting, DontSortWithRawPtr)
     auto result =
         gko::convert_to_with_sorting<Csr>(ref, unsorted_coo.get(), true);
 
-    GKO_ASSERT_MTX_NEAR(result.get(), mtx.get(), 0.);
+    GKO_ASSERT_MTX_NEAR(result, mtx, 0.);
 }
 
 
@@ -170,7 +170,7 @@ TEST_F(ConvertToWithSorting, SortWithConstRawPtr)
     auto result = gko::convert_to_with_sorting<Csr>(ref, cptr, false);
 
     ASSERT_TRUE(result->is_sorted_by_column_index());
-    GKO_ASSERT_MTX_NEAR(result.get(), mtx.get(), 0.);
+    GKO_ASSERT_MTX_NEAR(result, mtx, 0.);
 }
 
 
@@ -180,7 +180,7 @@ TEST_F(ConvertToWithSorting, DontSortWithConstRawPtr)
 
     auto result = gko::convert_to_with_sorting<Csr>(ref, cptr, true);
 
-    GKO_ASSERT_MTX_NEAR(result.get(), mtx.get(), 0.);
+    GKO_ASSERT_MTX_NEAR(result, mtx, 0.);
 }
 
 

--- a/reference/test/distributed/matrix_kernels.cpp
+++ b/reference/test/distributed/matrix_kernels.cpp
@@ -85,10 +85,10 @@ protected:
 
     void validate(
         gko::dim<2> size,
-        gko::pointer_param<const gko::experimental::distributed::Partition<
+        gko::ptr_param<const gko::experimental::distributed::Partition<
             local_index_type, global_index_type>>
             row_partition,
-        gko::pointer_param<const gko::experimental::distributed::Partition<
+        gko::ptr_param<const gko::experimental::distributed::Partition<
             local_index_type, global_index_type>>
             col_partition,
         std::initializer_list<global_index_type> input_rows,

--- a/reference/test/distributed/matrix_kernels.cpp
+++ b/reference/test/distributed/matrix_kernels.cpp
@@ -85,10 +85,12 @@ protected:
 
     void validate(
         gko::dim<2> size,
-        const gko::experimental::distributed::Partition<
-            local_index_type, global_index_type>* row_partition,
-        const gko::experimental::distributed::Partition<
-            local_index_type, global_index_type>* col_partition,
+        gko::pointer_param<const gko::experimental::distributed::Partition<
+            local_index_type, global_index_type>>
+            row_partition,
+        gko::pointer_param<const gko::experimental::distributed::Partition<
+            local_index_type, global_index_type>>
+            col_partition,
         std::initializer_list<global_index_type> input_rows,
         std::initializer_list<global_index_type> input_cols,
         std::initializer_list<value_type> input_vals,
@@ -137,10 +139,10 @@ protected:
         for (comm_index_type part = 0; part < row_partition->get_num_parts();
              ++part) {
             gko::kernels::reference::distributed_matrix::build_local_nonlocal(
-                ref, input, row_partition, col_partition, part, local_row_idxs,
-                local_col_idxs, local_values, non_local_row_idxs,
-                non_local_col_idxs, non_local_values, gather_idxs, recv_sizes,
-                non_local_to_global);
+                ref, input, row_partition.get(), col_partition.get(), part,
+                local_row_idxs, local_col_idxs, local_values,
+                non_local_row_idxs, non_local_col_idxs, non_local_values,
+                gather_idxs, recv_sizes, non_local_to_global);
 
             assert_device_matrix_data_equal(local_row_idxs, local_col_idxs,
                                             local_values, ref_locals[part]);
@@ -211,7 +213,7 @@ TYPED_TEST(Matrix, BuildsLocalNonLocalEmpty)
             this->ref, this->mapping, num_parts);
 
     this->validate(
-        gko::dim<2>{8, 8}, partition.get(), partition.get(), {}, {}, {},
+        gko::dim<2>{8, 8}, partition, partition, {}, {}, {},
         {std::make_tuple(gko::dim<2>{2, 2}, I<git>{}, I<git>{}, I<vt>{}),
          std::make_tuple(gko::dim<2>{3, 3}, I<git>{}, I<git>{}, I<vt>{}),
          std::make_tuple(gko::dim<2>{3, 3}, I<git>{}, I<git>{}, I<vt>{})},
@@ -234,8 +236,8 @@ TYPED_TEST(Matrix, BuildsLocalNonLocalSmall)
             this->ref, this->mapping, num_parts);
 
     this->validate(
-        gko::dim<2>{2, 2}, partition.get(), partition.get(), {0, 0, 1, 1},
-        {0, 1, 0, 1}, {1, 2, 3, 4},
+        gko::dim<2>{2, 2}, partition, partition, {0, 0, 1, 1}, {0, 1, 0, 1},
+        {1, 2, 3, 4},
         {std::make_tuple(gko::dim<2>{1, 1}, I<git>{0}, I<git>{0}, I<vt>{4}),
          std::make_tuple(gko::dim<2>{1, 1}, I<git>{0}, I<git>{0}, I<vt>{1})},
         {std::make_tuple(gko::dim<2>{1, 1}, I<git>{0}, I<git>{0}, I<vt>{3}),
@@ -256,9 +258,8 @@ TYPED_TEST(Matrix, BuildsLocalNonLocalNoNonLocal)
             this->ref, this->mapping, num_parts);
 
     this->validate(
-        gko::dim<2>{6, 6}, partition.get(), partition.get(),
-        {0, 0, 1, 1, 2, 3, 4, 5}, {0, 5, 1, 4, 3, 2, 4, 0},
-        {1, 2, 3, 4, 5, 6, 7, 8},
+        gko::dim<2>{6, 6}, partition, partition, {0, 0, 1, 1, 2, 3, 4, 5},
+        {0, 5, 1, 4, 3, 2, 4, 0}, {1, 2, 3, 4, 5, 6, 7, 8},
         {std::make_tuple(gko::dim<2>{2, 2}, I<git>{0, 1}, I<git>{1, 0},
                          I<vt>{5, 6}),
          std::make_tuple(gko::dim<2>{2, 2}, I<git>{0, 0, 1}, I<git>{0, 1, 0},
@@ -284,7 +285,7 @@ TYPED_TEST(Matrix, BuildsLocalNonLocalNoLocal)
             this->ref, this->mapping, num_parts);
 
     this->validate(
-        gko::dim<2>{6, 6}, partition.get(), partition.get(), {0, 0, 1, 3, 4, 5},
+        gko::dim<2>{6, 6}, partition, partition, {0, 0, 1, 3, 4, 5},
         {1, 3, 5, 1, 3, 2}, {1, 2, 5, 6, 7, 8},
         {std::make_tuple(gko::dim<2>{2, 2}, I<git>{}, I<git>{}, I<vt>{}),
          std::make_tuple(gko::dim<2>{2, 2}, I<git>{}, I<git>{}, I<vt>{}),
@@ -310,7 +311,7 @@ TYPED_TEST(Matrix, BuildsLocalNonLocalMixed)
             this->ref, this->mapping, num_parts);
 
     this->validate(
-        gko::dim<2>{6, 6}, partition.get(), partition.get(),
+        gko::dim<2>{6, 6}, partition, partition,
         {0, 0, 0, 0, 1, 1, 1, 2, 3, 3, 4, 4, 5, 5},
         {0, 1, 3, 5, 1, 4, 5, 3, 1, 2, 3, 4, 0, 2},
         {11, 1, 2, 12, 13, 14, 5, 15, 6, 16, 7, 17, 18, 8},
@@ -347,7 +348,7 @@ TYPED_TEST(Matrix, BuildsLocalNonLocalEmptyWithColPartition)
             this->ref, col_mapping, num_parts);
 
     this->validate(
-        gko::dim<2>{8, 8}, partition.get(), col_partition.get(), {}, {}, {},
+        gko::dim<2>{8, 8}, partition, col_partition, {}, {}, {},
         {std::make_tuple(gko::dim<2>{2, 2}, I<git>{}, I<git>{}, I<vt>{}),
          std::make_tuple(gko::dim<2>{3, 3}, I<git>{}, I<git>{}, I<vt>{}),
          std::make_tuple(gko::dim<2>{3, 3}, I<git>{}, I<git>{}, I<vt>{})},
@@ -374,8 +375,8 @@ TYPED_TEST(Matrix, BuildsLocalNonLocalSmallWithColPartition)
             this->ref, col_mapping, num_parts);
 
     this->validate(
-        gko::dim<2>{2, 2}, partition.get(), col_partition.get(), {0, 0, 1, 1},
-        {0, 1, 0, 1}, {1, 2, 3, 4},
+        gko::dim<2>{2, 2}, partition, col_partition, {0, 0, 1, 1}, {0, 1, 0, 1},
+        {1, 2, 3, 4},
         {std::make_tuple(gko::dim<2>{1, 1}, I<git>{0}, I<git>{0}, I<vt>{3}),
          std::make_tuple(gko::dim<2>{1, 1}, I<git>{0}, I<git>{0}, I<vt>{2})},
         {std::make_tuple(gko::dim<2>{1, 1}, I<git>{0}, I<git>{0}, I<vt>{4}),
@@ -399,8 +400,8 @@ TYPED_TEST(Matrix, BuildsLocalNonLocalNoNonLocalWithColPartition)
             this->ref, col_mapping, num_parts);
 
     this->validate(
-        gko::dim<2>{6, 6}, partition.get(), col_partition.get(),
-        {3, 0, 5, 1, 1, 4}, {1, 4, 5, 2, 3, 3}, {1, 2, 3, 4, 5, 6},
+        gko::dim<2>{6, 6}, partition, col_partition, {3, 0, 5, 1, 1, 4},
+        {1, 4, 5, 2, 3, 3}, {1, 2, 3, 4, 5, 6},
         {std::make_tuple(gko::dim<2>{2, 2}, I<git>{1}, I<git>{1}, I<vt>{1}),
          std::make_tuple(gko::dim<2>{2, 2}, I<git>{0, 1}, I<git>{0, 1},
                          I<vt>{2, 3}),
@@ -429,8 +430,8 @@ TYPED_TEST(Matrix, BuildsLocalNonLocalNoLocalWithColPartition)
             this->ref, col_mapping, num_parts);
 
     this->validate(
-        gko::dim<2>{6, 6}, partition.get(), col_partition.get(),
-        {2, 3, 2, 0, 5, 1, 1}, {2, 3, 5, 0, 1, 1, 4}, {1, 2, 3, 4, 5, 6, 7},
+        gko::dim<2>{6, 6}, partition, col_partition, {2, 3, 2, 0, 5, 1, 1},
+        {2, 3, 5, 0, 1, 1, 4}, {1, 2, 3, 4, 5, 6, 7},
         {std::make_tuple(gko::dim<2>{2, 2}, I<git>{}, I<git>{}, I<vt>{}),
          std::make_tuple(gko::dim<2>{2, 2}, I<git>{}, I<git>{}, I<vt>{}),
          std::make_tuple(gko::dim<2>{2, 2}, I<git>{}, I<git>{}, I<vt>{})},
@@ -459,7 +460,7 @@ TYPED_TEST(Matrix, BuildsLocalNonLocalMixedWithColPartition)
         gko::experimental::distributed::Partition<lit, git>::build_from_mapping(
             this->ref, col_mapping, num_parts);
 
-    this->validate(gko::dim<2>{6, 6}, partition.get(), col_partition.get(),
+    this->validate(gko::dim<2>{6, 6}, partition, col_partition,
                    {2, 3, 3, 0, 5, 1, 4, 2, 3, 2, 0, 0, 1, 1, 4, 4},
                    {0, 0, 1, 5, 4, 2, 2, 3, 2, 4, 1, 2, 4, 5, 0, 5},
                    {11, 12, 13, 14, 15, 16, 17, 1, 2, 3, 4, 5, 6, 7, 8, 9},
@@ -496,7 +497,7 @@ TYPED_TEST(Matrix, BuildsLocalNonLocalNonSquare)
             this->ref, col_mapping, num_parts);
 
     this->validate(
-        gko::dim<2>{6, 4}, partition.get(), col_partition.get(),
+        gko::dim<2>{6, 4}, partition, col_partition,
         {2, 3, 0, 1, 4, 3, 3, 0, 1, 4}, {0, 0, 3, 2, 1, 2, 3, 0, 3, 3},
         {1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
         {std::make_tuple(gko::dim<2>{2, 1}, I<git>{0, 1}, I<git>{0, 0},

--- a/reference/test/distributed/vector_kernels.cpp
+++ b/reference/test/distributed/vector_kernels.cpp
@@ -69,12 +69,13 @@ protected:
 
     Vector() : ref(gko::ReferenceExecutor::create()) {}
 
-    void validate(const gko::dim<2> size,
-                  const gko::experimental::distributed::Partition<
-                      local_index_type, global_index_type>* partition,
-                  I<global_index_type> input_rows,
-                  I<global_index_type> input_cols, I<value_type> input_vals,
-                  I<I<I<value_type>>> output_entries)
+    void validate(
+        const gko::dim<2> size,
+        gko::pointer_param<const gko::experimental::distributed::Partition<
+            local_index_type, global_index_type>>
+            partition,
+        I<global_index_type> input_rows, I<global_index_type> input_cols,
+        I<value_type> input_vals, I<I<I<value_type>>> output_entries)
     {
         std::vector<I<I<value_type>>> ref_outputs;
         auto input = gko::device_matrix_data<value_type, global_index_type>{
@@ -90,7 +91,7 @@ protected:
             output->fill(gko::zero<value_type>());
 
             gko::kernels::reference::distributed_vector::build_local(
-                ref, input, partition, part, output.get());
+                ref, input, partition.get(), part, output.get());
 
             GKO_ASSERT_MTX_NEAR(output, ref_outputs[part], 0);
         }
@@ -113,7 +114,7 @@ TYPED_TEST(Vector, BuildsLocalEmpty)
                                                                  mapping,
                                                                  num_parts);
 
-    this->validate(gko::dim<2>{0, 0}, partition.get(), {}, {}, {},
+    this->validate(gko::dim<2>{0, 0}, partition, {}, {}, {},
                    {{{}, {}}, {{}, {}, {}}, {{}, {}, {}}});
 }
 
@@ -129,8 +130,8 @@ TYPED_TEST(Vector, BuildsLocalSmall)
                                                                  mapping,
                                                                  num_parts);
 
-    this->validate(gko::dim<2>{2, 2}, partition.get(), {0, 0, 1, 1},
-                   {0, 1, 0, 1}, {1, 2, 3, 4}, {{{3, 4}}, {{1, 2}}});
+    this->validate(gko::dim<2>{2, 2}, partition, {0, 0, 1, 1}, {0, 1, 0, 1},
+                   {1, 2, 3, 4}, {{{3, 4}}, {{1, 2}}});
 }
 
 
@@ -145,7 +146,7 @@ TYPED_TEST(Vector, BuildsLocal)
                                                                  mapping,
                                                                  num_parts);
 
-    this->validate(gko::dim<2>{6, 8}, partition.get(), {0, 0, 1, 1, 2, 3, 4, 5},
+    this->validate(gko::dim<2>{6, 8}, partition, {0, 0, 1, 1, 2, 3, 4, 5},
                    {0, 1, 2, 3, 4, 5, 6, 7}, {1, 2, 3, 4, 5, 6, 7, 8},
                    {{{0, 0, 0, 0, 5, 0, 0, 0}, {0, 0, 0, 0, 0, 6, 0, 0}},
                     {{1, 2, 0, 0, 0, 0, 0, 0}, {0, 0, 0, 0, 0, 0, 0, 8}},

--- a/reference/test/distributed/vector_kernels.cpp
+++ b/reference/test/distributed/vector_kernels.cpp
@@ -71,7 +71,7 @@ protected:
 
     void validate(
         const gko::dim<2> size,
-        gko::pointer_param<const gko::experimental::distributed::Partition<
+        gko::ptr_param<const gko::experimental::distributed::Partition<
             local_index_type, global_index_type>>
             partition,
         I<global_index_type> input_rows, I<global_index_type> input_cols,

--- a/reference/test/factorization/cholesky_kernels.cpp
+++ b/reference/test/factorization/cholesky_kernels.cpp
@@ -344,7 +344,7 @@ TYPED_TEST(Cholesky, SymbolicFactorizeAni1)
     auto combined_factor_ref = this->combined_factor(l_factor_ref);
 
     std::unique_ptr<matrix_type> combined_factor;
-    gko::factorization::symbolic_cholesky(mtx, combined_factor);
+    gko::factorization::symbolic_cholesky(mtx.get(), combined_factor);
 
     GKO_ASSERT_MTX_EQ_SPARSITY(combined_factor, combined_factor_ref);
 }
@@ -406,7 +406,7 @@ TYPED_TEST(Cholesky, SymbolicFactorizeAni1Amd)
     auto combined_factor_ref = this->combined_factor(l_factor_ref);
 
     std::unique_ptr<matrix_type> combined_factor;
-    gko::factorization::symbolic_cholesky(mtx, combined_factor);
+    gko::factorization::symbolic_cholesky(mtx.get(), combined_factor);
 
     GKO_ASSERT_MTX_EQ_SPARSITY(combined_factor, combined_factor_ref);
 }

--- a/reference/test/factorization/cholesky_kernels.cpp
+++ b/reference/test/factorization/cholesky_kernels.cpp
@@ -64,14 +64,15 @@ protected:
 
     Cholesky() : ref(gko::ReferenceExecutor::create()), tmp{ref} {}
 
-    std::unique_ptr<matrix_type> combined_factor(const matrix_type* l_factor)
+    std::unique_ptr<matrix_type> combined_factor(
+        gko::pointer_param<const matrix_type> l_factor)
     {
         auto one = gko::initialize<gko::matrix::Dense<value_type>>(
             {gko::one<value_type>()}, ref);
         auto id = gko::matrix::Identity<value_type>::create(
             ref, l_factor->get_size()[0]);
         auto result = gko::as<matrix_type>(l_factor->transpose());
-        l_factor->apply(one.get(), id.get(), one.get(), result.get());
+        l_factor->apply(one, id, one, result);
         return result;
     }
 
@@ -340,10 +341,10 @@ TYPED_TEST(Cholesky, SymbolicFactorizeAni1)
     std::ifstream ref_stream{gko::matrices::location_ani1_chol_mtx};
     auto mtx = gko::read<matrix_type>(stream, this->ref);
     auto l_factor_ref = gko::read<matrix_type>(ref_stream, this->ref);
-    auto combined_factor_ref = this->combined_factor(l_factor_ref.get());
+    auto combined_factor_ref = this->combined_factor(l_factor_ref);
 
     std::unique_ptr<matrix_type> combined_factor;
-    gko::factorization::symbolic_cholesky(mtx.get(), combined_factor);
+    gko::factorization::symbolic_cholesky(mtx, combined_factor);
 
     GKO_ASSERT_MTX_EQ_SPARSITY(combined_factor, combined_factor_ref);
 }
@@ -402,10 +403,10 @@ TYPED_TEST(Cholesky, SymbolicFactorizeAni1Amd)
     std::ifstream ref_stream{gko::matrices::location_ani1_amd_chol_mtx};
     auto mtx = gko::read<matrix_type>(stream, this->ref);
     auto l_factor_ref = gko::read<matrix_type>(ref_stream, this->ref);
-    auto combined_factor_ref = this->combined_factor(l_factor_ref.get());
+    auto combined_factor_ref = this->combined_factor(l_factor_ref);
 
     std::unique_ptr<matrix_type> combined_factor;
-    gko::factorization::symbolic_cholesky(mtx.get(), combined_factor);
+    gko::factorization::symbolic_cholesky(mtx, combined_factor);
 
     GKO_ASSERT_MTX_EQ_SPARSITY(combined_factor, combined_factor_ref);
 }

--- a/reference/test/factorization/cholesky_kernels.cpp
+++ b/reference/test/factorization/cholesky_kernels.cpp
@@ -65,7 +65,7 @@ protected:
     Cholesky() : ref(gko::ReferenceExecutor::create()), tmp{ref} {}
 
     std::unique_ptr<matrix_type> combined_factor(
-        gko::pointer_param<const matrix_type> l_factor)
+        gko::ptr_param<const matrix_type> l_factor)
     {
         auto one = gko::initialize<gko::matrix::Dense<value_type>>(
             {gko::one<value_type>()}, ref);

--- a/reference/test/factorization/factorization.cpp
+++ b/reference/test/factorization/factorization.cpp
@@ -189,11 +189,10 @@ TYPED_TEST(Factorization, CreateCombinedLUWorks)
     ASSERT_EQ(fact->get_diagonal(), nullptr);
     ASSERT_EQ(fact->get_upper_factor(), nullptr);
     GKO_ASSERT_MTX_NEAR(fact->get_combined(), this->combined_mtx, 0.0);
-    ASSERT_THROW(fact->apply(this->input.get(), this->output.get()),
-                 gko::NotSupported);
-    ASSERT_THROW(fact->apply(this->alpha.get(), this->input.get(),
-                             this->beta.get(), this->output.get()),
-                 gko::NotSupported);
+    ASSERT_THROW(fact->apply(this->input, this->output), gko::NotSupported);
+    ASSERT_THROW(
+        fact->apply(this->alpha, this->input, this->beta, this->output),
+        gko::NotSupported);
 }
 
 
@@ -211,11 +210,10 @@ TYPED_TEST(Factorization, CreateCombinedLDUWorks)
     ASSERT_EQ(fact->get_diagonal(), nullptr);
     ASSERT_EQ(fact->get_upper_factor(), nullptr);
     GKO_ASSERT_MTX_NEAR(fact->get_combined(), this->combined_mtx, 0.0);
-    ASSERT_THROW(fact->apply(this->input.get(), this->output.get()),
-                 gko::NotSupported);
-    ASSERT_THROW(fact->apply(this->alpha.get(), this->input.get(),
-                             this->beta.get(), this->output.get()),
-                 gko::NotSupported);
+    ASSERT_THROW(fact->apply(this->input, this->output), gko::NotSupported);
+    ASSERT_THROW(
+        fact->apply(this->alpha, this->input, this->beta, this->output),
+        gko::NotSupported);
 }
 
 
@@ -234,11 +232,10 @@ TYPED_TEST(Factorization, CreateSymmCombinedCholeskyWorks)
     ASSERT_EQ(fact->get_diagonal(), nullptr);
     ASSERT_EQ(fact->get_upper_factor(), nullptr);
     GKO_ASSERT_MTX_NEAR(fact->get_combined(), this->combined_mtx, 0.0);
-    ASSERT_THROW(fact->apply(this->input.get(), this->output.get()),
-                 gko::NotSupported);
-    ASSERT_THROW(fact->apply(this->alpha.get(), this->input.get(),
-                             this->beta.get(), this->output.get()),
-                 gko::NotSupported);
+    ASSERT_THROW(fact->apply(this->input, this->output), gko::NotSupported);
+    ASSERT_THROW(
+        fact->apply(this->alpha, this->input, this->beta, this->output),
+        gko::NotSupported);
 }
 
 
@@ -257,11 +254,10 @@ TYPED_TEST(Factorization, CreateSymmCombinedLDLWorks)
     ASSERT_EQ(fact->get_diagonal(), nullptr);
     ASSERT_EQ(fact->get_upper_factor(), nullptr);
     GKO_ASSERT_MTX_NEAR(fact->get_combined(), this->combined_mtx, 0.0);
-    ASSERT_THROW(fact->apply(this->input.get(), this->output.get()),
-                 gko::NotSupported);
-    ASSERT_THROW(fact->apply(this->alpha.get(), this->input.get(),
-                             this->beta.get(), this->output.get()),
-                 gko::NotSupported);
+    ASSERT_THROW(fact->apply(this->input, this->output), gko::NotSupported);
+    ASSERT_THROW(
+        fact->apply(this->alpha, this->input, this->beta, this->output),
+        gko::NotSupported);
 }
 
 
@@ -273,10 +269,10 @@ TYPED_TEST(Factorization, ApplyFromCompositionWorks)
     auto fact = factorization_type::create_from_composition(comp->clone());
     auto ref_out = this->output->clone();
 
-    fact->apply(this->input.get(), this->output.get());
-    comp->apply(this->input.get(), ref_out.get());
+    fact->apply(this->input, this->output);
+    comp->apply(this->input, ref_out);
 
-    GKO_ASSERT_MTX_NEAR(this->output.get(), ref_out.get(), 0.0);
+    GKO_ASSERT_MTX_NEAR(this->output, ref_out, 0.0);
 }
 
 
@@ -289,10 +285,10 @@ TYPED_TEST(Factorization, ApplyFromCompositionWithDiagonalWorks)
     auto fact = factorization_type::create_from_composition(comp->clone());
     auto ref_out = this->output->clone();
 
-    fact->apply(this->input.get(), this->output.get());
-    comp->apply(this->input.get(), ref_out.get());
+    fact->apply(this->input, this->output);
+    comp->apply(this->input, ref_out);
 
-    GKO_ASSERT_MTX_NEAR(this->output.get(), ref_out.get(), 0.0);
+    GKO_ASSERT_MTX_NEAR(this->output, ref_out, 0.0);
 }
 
 
@@ -304,10 +300,10 @@ TYPED_TEST(Factorization, ApplyFromSymmCompositionWorks)
     auto fact = factorization_type::create_from_symm_composition(comp->clone());
     auto ref_out = this->output->clone();
 
-    fact->apply(this->input.get(), this->output.get());
-    comp->apply(this->input.get(), ref_out.get());
+    fact->apply(this->input, this->output);
+    comp->apply(this->input, ref_out);
 
-    GKO_ASSERT_MTX_NEAR(this->output.get(), ref_out.get(), 0.0);
+    GKO_ASSERT_MTX_NEAR(this->output, ref_out, 0.0);
 }
 
 
@@ -320,10 +316,10 @@ TYPED_TEST(Factorization, ApplyFromSymmCompositionWithDiagonalWorks)
     auto fact = factorization_type::create_from_symm_composition(comp->clone());
     auto ref_out = this->output->clone();
 
-    fact->apply(this->input.get(), this->output.get());
-    comp->apply(this->input.get(), ref_out.get());
+    fact->apply(this->input, this->output);
+    comp->apply(this->input, ref_out);
 
-    GKO_ASSERT_MTX_NEAR(this->output.get(), ref_out.get(), 0.0);
+    GKO_ASSERT_MTX_NEAR(this->output, ref_out, 0.0);
 }
 
 
@@ -335,12 +331,10 @@ TYPED_TEST(Factorization, AdvancedApplyFromCompositionWorks)
     auto fact = factorization_type::create_from_composition(comp->clone());
     auto ref_out = this->output->clone();
 
-    fact->apply(this->alpha.get(), this->input.get(), this->beta.get(),
-                this->output.get());
-    comp->apply(this->alpha.get(), this->input.get(), this->beta.get(),
-                ref_out.get());
+    fact->apply(this->alpha, this->input, this->beta, this->output);
+    comp->apply(this->alpha, this->input, this->beta, ref_out);
 
-    GKO_ASSERT_MTX_NEAR(this->output.get(), ref_out.get(), 0.0);
+    GKO_ASSERT_MTX_NEAR(this->output, ref_out, 0.0);
 }
 
 
@@ -353,12 +347,10 @@ TYPED_TEST(Factorization, AdvancedApplyFromCompositionWithDiagonalWorks)
     auto fact = factorization_type::create_from_composition(comp->clone());
     auto ref_out = this->output->clone();
 
-    fact->apply(this->alpha.get(), this->input.get(), this->beta.get(),
-                this->output.get());
-    comp->apply(this->alpha.get(), this->input.get(), this->beta.get(),
-                ref_out.get());
+    fact->apply(this->alpha, this->input, this->beta, this->output);
+    comp->apply(this->alpha, this->input, this->beta, ref_out);
 
-    GKO_ASSERT_MTX_NEAR(this->output.get(), ref_out.get(), 0.0);
+    GKO_ASSERT_MTX_NEAR(this->output, ref_out, 0.0);
 }
 
 
@@ -370,12 +362,10 @@ TYPED_TEST(Factorization, AdvancedApplyFromSymmCompositionWorks)
     auto fact = factorization_type::create_from_symm_composition(comp->clone());
     auto ref_out = this->output->clone();
 
-    fact->apply(this->alpha.get(), this->input.get(), this->beta.get(),
-                this->output.get());
-    comp->apply(this->alpha.get(), this->input.get(), this->beta.get(),
-                ref_out.get());
+    fact->apply(this->alpha, this->input, this->beta, this->output);
+    comp->apply(this->alpha, this->input, this->beta, ref_out);
 
-    GKO_ASSERT_MTX_NEAR(this->output.get(), ref_out.get(), 0.0);
+    GKO_ASSERT_MTX_NEAR(this->output, ref_out, 0.0);
 }
 
 
@@ -388,10 +378,8 @@ TYPED_TEST(Factorization, AdvancedApplyFromSymmCompositionWithDiagonalWorks)
     auto fact = factorization_type::create_from_symm_composition(comp->clone());
     auto ref_out = this->output->clone();
 
-    fact->apply(this->alpha.get(), this->input.get(), this->beta.get(),
-                this->output.get());
-    comp->apply(this->alpha.get(), this->input.get(), this->beta.get(),
-                ref_out.get());
+    fact->apply(this->alpha, this->input, this->beta, this->output);
+    comp->apply(this->alpha, this->input, this->beta, ref_out);
 
-    GKO_ASSERT_MTX_NEAR(this->output.get(), ref_out.get(), 0.0);
+    GKO_ASSERT_MTX_NEAR(this->output, ref_out, 0.0);
 }

--- a/reference/test/factorization/ic_kernels.cpp
+++ b/reference/test/factorization/ic_kernels.cpp
@@ -182,7 +182,7 @@ TYPED_TEST(Ic, GenerateDenseIdentity)
     using Dense = typename TestFixture::Dense;
     auto dense_id =
         gko::share(Dense::create(this->exec, this->identity->get_size()));
-    this->identity->convert_to(dense_id.get());
+    this->identity->convert_to(dense_id);
 
     auto fact = this->fact_fact->generate(dense_id);
 

--- a/reference/test/factorization/lu_kernels.cpp
+++ b/reference/test/factorization/lu_kernels.cpp
@@ -119,7 +119,7 @@ TYPED_TEST(Lu, SymbolicCholeskyWorks)
                 gko::matrices::location_ani1_lu_mtx);
 
     std::unique_ptr<gko::matrix::Csr<value_type, index_type>> lu;
-    gko::factorization::symbolic_cholesky(this->mtx, lu);
+    gko::factorization::symbolic_cholesky(this->mtx.get(), lu);
 
     GKO_ASSERT_MTX_EQ_SPARSITY(lu, this->mtx_lu);
 }
@@ -133,7 +133,7 @@ TYPED_TEST(Lu, SymbolicLUWorks)
                 gko::matrices::location_ani1_nonsymm_lu_mtx);
 
     std::unique_ptr<gko::matrix::Csr<value_type, index_type>> lu;
-    gko::factorization::symbolic_lu(this->mtx, lu);
+    gko::factorization::symbolic_lu(this->mtx.get(), lu);
 
     GKO_ASSERT_MTX_EQ_SPARSITY(lu, this->mtx_lu);
 }

--- a/reference/test/factorization/lu_kernels.cpp
+++ b/reference/test/factorization/lu_kernels.cpp
@@ -119,7 +119,7 @@ TYPED_TEST(Lu, SymbolicCholeskyWorks)
                 gko::matrices::location_ani1_lu_mtx);
 
     std::unique_ptr<gko::matrix::Csr<value_type, index_type>> lu;
-    gko::factorization::symbolic_cholesky(this->mtx.get(), lu);
+    gko::factorization::symbolic_cholesky(this->mtx, lu);
 
     GKO_ASSERT_MTX_EQ_SPARSITY(lu, this->mtx_lu);
 }
@@ -133,7 +133,7 @@ TYPED_TEST(Lu, SymbolicLUWorks)
                 gko::matrices::location_ani1_nonsymm_lu_mtx);
 
     std::unique_ptr<gko::matrix::Csr<value_type, index_type>> lu;
-    gko::factorization::symbolic_lu(this->mtx.get(), lu);
+    gko::factorization::symbolic_lu(this->mtx, lu);
 
     GKO_ASSERT_MTX_EQ_SPARSITY(lu, this->mtx_lu);
 }
@@ -323,7 +323,7 @@ TYPED_TEST(Lu, FactorizeAmdWorks)
                 gko::matrices::location_ani1_amd_lu_mtx);
     auto pattern = gko::share(
         gko::matrix::SparsityCsr<value_type, index_type>::create(this->ref));
-    pattern->copy_from(this->mtx_lu.get());
+    pattern->copy_from(this->mtx_lu);
     auto factory =
         gko::experimental::factorization::Lu<value_type, index_type>::build()
             .with_symbolic_factorization(pattern)

--- a/reference/test/factorization/par_ic_kernels.cpp
+++ b/reference/test/factorization/par_ic_kernels.cpp
@@ -119,7 +119,7 @@ protected:
           fact_fact(factorization_type::build().on(exec)),
           tol{r<value_type>::value}
     {
-        mtx_l_system->convert_to(gko::lend(mtx_l_system_coo));
+        mtx_l_system->convert_to(mtx_l_system_coo);
     }
 
     std::shared_ptr<const gko::ReferenceExecutor> ref;

--- a/reference/test/factorization/par_ic_kernels.cpp
+++ b/reference/test/factorization/par_ic_kernels.cpp
@@ -239,7 +239,7 @@ TYPED_TEST(ParIc, GenerateDenseIdentity)
     using Dense = typename TestFixture::Dense;
     auto dense_id =
         gko::share(Dense::create(this->exec, this->identity->get_size()));
-    this->identity->convert_to(dense_id.get());
+    this->identity->convert_to(dense_id);
 
     auto fact = this->fact_fact->generate(dense_id);
 

--- a/reference/test/factorization/par_ict_kernels.cpp
+++ b/reference/test/factorization/par_ict_kernels.cpp
@@ -281,12 +281,10 @@ TYPED_TEST(ParIct, IsConsistentWithComposition)
 {
     auto fact = this->fact_fact->generate(this->mtx_system);
 
-    auto lin_op_l_factor =
-        static_cast<const gko::LinOp*>(gko::lend(fact->get_l_factor()));
-    auto lin_op_lt_factor =
-        static_cast<const gko::LinOp*>(gko::lend(fact->get_lt_factor()));
-    auto first_operator = gko::lend(fact->get_operators()[0]);
-    auto second_operator = gko::lend(fact->get_operators()[1]);
+    auto lin_op_l_factor = gko::as<gko::LinOp>(fact->get_l_factor());
+    auto lin_op_lt_factor = gko::as<gko::LinOp>(fact->get_lt_factor());
+    auto first_operator = fact->get_operators()[0];
+    auto second_operator = fact->get_operators()[1];
 
     ASSERT_EQ(lin_op_l_factor, first_operator);
     ASSERT_EQ(lin_op_lt_factor, second_operator);

--- a/reference/test/factorization/par_ict_kernels.cpp
+++ b/reference/test/factorization/par_ict_kernels.cpp
@@ -228,7 +228,7 @@ TYPED_TEST(ParIct, KernelComputeLU)
     using Coo = typename TestFixture::Coo;
     using value_type = typename TestFixture::value_type;
     auto mtx_l_coo = Coo::create(this->exec, this->mtx_system->get_size());
-    this->mtx_l_system->convert_to(mtx_l_coo.get());
+    this->mtx_l_system->convert_to(mtx_l_coo);
 
     gko::kernels::reference::par_ict_factorization::compute_factor(
         this->ref, this->mtx_system.get(), this->mtx_l_system.get(),
@@ -305,7 +305,7 @@ TYPED_TEST(ParIct, GenerateDenseIdentity)
     using Dense = typename TestFixture::Dense;
     auto dense_id =
         gko::share(Dense::create(this->exec, this->identity->get_size()));
-    this->identity->convert_to(dense_id.get());
+    this->identity->convert_to(dense_id);
     auto fact = this->fact_fact->generate(dense_id);
 
     GKO_ASSERT_MTX_NEAR(fact->get_l_factor(), this->identity, this->tol);

--- a/reference/test/factorization/par_ilut_kernels.cpp
+++ b/reference/test/factorization/par_ilut_kernels.cpp
@@ -556,12 +556,10 @@ TYPED_TEST(ParIlut, IsConsistentWithComposition)
 {
     auto fact = this->fact_fact->generate(this->mtx_system);
 
-    auto lin_op_l_factor =
-        static_cast<const gko::LinOp*>(gko::lend(fact->get_l_factor()));
-    auto lin_op_u_factor =
-        static_cast<const gko::LinOp*>(gko::lend(fact->get_u_factor()));
-    auto first_operator = gko::lend(fact->get_operators()[0]);
-    auto second_operator = gko::lend(fact->get_operators()[1]);
+    auto lin_op_l_factor = gko::as<gko::LinOp>(fact->get_l_factor());
+    auto lin_op_u_factor = gko::as<gko::LinOp>(fact->get_u_factor());
+    auto first_operator = fact->get_operators()[0];
+    auto second_operator = fact->get_operators()[1];
 
     ASSERT_EQ(lin_op_l_factor, first_operator);
     ASSERT_EQ(lin_op_u_factor, second_operator);

--- a/reference/test/factorization/par_ilut_kernels.cpp
+++ b/reference/test/factorization/par_ilut_kernels.cpp
@@ -496,10 +496,10 @@ TYPED_TEST(ParIlut, KernelComputeLU)
     using Coo = typename TestFixture::Coo;
     using value_type = typename TestFixture::value_type;
     auto mtx_l_coo = Coo::create(this->exec, this->mtx_system->get_size());
-    this->mtx_l_system->convert_to(mtx_l_coo.get());
+    this->mtx_l_system->convert_to(mtx_l_coo);
     auto mtx_u_transp = this->mtx_u_system->transpose();
     auto mtx_u_coo = Coo::create(this->exec, this->mtx_system->get_size());
-    this->mtx_u_system->convert_to(mtx_u_coo.get());
+    this->mtx_u_system->convert_to(mtx_u_coo);
     auto mtx_u_csc = gko::as<Csr>(mtx_u_transp.get());
 
     gko::kernels::reference::par_ilut_factorization::compute_l_u_factors(
@@ -580,7 +580,7 @@ TYPED_TEST(ParIlut, GenerateDenseIdentity)
     using Dense = typename TestFixture::Dense;
     auto dense_id =
         gko::share(Dense::create(this->exec, this->identity->get_size()));
-    this->identity->convert_to(dense_id.get());
+    this->identity->convert_to(dense_id);
     auto fact = this->fact_fact->generate(dense_id);
 
     GKO_ASSERT_MTX_NEAR(fact->get_l_factor(), this->identity, this->tol);

--- a/reference/test/matrix/coo_kernels.cpp
+++ b/reference/test/matrix/coo_kernels.cpp
@@ -121,8 +121,8 @@ TYPED_TEST(Coo, ConvertsToPrecision)
                         ? gko::remove_complex<ValueType>{0}
                         : gko::remove_complex<ValueType>{r<OtherType>::value};
 
-    this->mtx->convert_to(tmp.get());
-    tmp->convert_to(res.get());
+    this->mtx->convert_to(tmp);
+    tmp->convert_to(res);
 
     GKO_ASSERT_MTX_NEAR(this->mtx, res, residual);
 }
@@ -142,8 +142,8 @@ TYPED_TEST(Coo, MovesToPrecision)
                         ? gko::remove_complex<ValueType>{0}
                         : gko::remove_complex<ValueType>{r<OtherType>::value};
 
-    this->mtx->move_to(tmp.get());
-    tmp->move_to(res.get());
+    this->mtx->move_to(tmp);
+    tmp->move_to(res);
 
     GKO_ASSERT_MTX_NEAR(this->mtx, res, residual);
 }
@@ -159,8 +159,8 @@ TYPED_TEST(Coo, ConvertsToCsr)
     auto csr_mtx_c = Csr::create(this->mtx->get_executor(), csr_s_classical);
     auto csr_mtx_m = Csr::create(this->mtx->get_executor(), csr_s_merge);
 
-    this->mtx->convert_to(csr_mtx_c.get());
-    this->mtx->convert_to(csr_mtx_m.get());
+    this->mtx->convert_to(csr_mtx_c);
+    this->mtx->convert_to(csr_mtx_m);
 
     this->assert_equal_to_mtx_in_csr_format(csr_mtx_c.get());
     this->assert_equal_to_mtx_in_csr_format(csr_mtx_m.get());
@@ -180,8 +180,8 @@ TYPED_TEST(Coo, MovesToCsr)
     auto csr_mtx_m = Csr::create(this->mtx->get_executor(), csr_s_merge);
     auto mtx_clone = this->mtx->clone();
 
-    this->mtx->move_to(csr_mtx_c.get());
-    mtx_clone->move_to(csr_mtx_m.get());
+    this->mtx->move_to(csr_mtx_c);
+    mtx_clone->move_to(csr_mtx_m);
 
     this->assert_equal_to_mtx_in_csr_format(csr_mtx_c.get());
     this->assert_equal_to_mtx_in_csr_format(csr_mtx_m.get());
@@ -197,7 +197,7 @@ TYPED_TEST(Coo, ConvertsToDense)
     using Dense = typename TestFixture::Vec;
     auto dense_mtx = Dense::create(this->mtx->get_executor());
 
-    this->mtx->convert_to(dense_mtx.get());
+    this->mtx->convert_to(dense_mtx);
 
     // clang-format off
     GKO_ASSERT_MTX_NEAR(dense_mtx,
@@ -214,7 +214,7 @@ TYPED_TEST(Coo, ConvertsToDenseUnsorted)
     using Dense = typename TestFixture::Vec;
     auto dense_mtx = Dense::create(this->mtx->get_executor());
 
-    this->uns_mtx->convert_to(dense_mtx.get());
+    this->uns_mtx->convert_to(dense_mtx);
 
     // clang-format off
     GKO_ASSERT_MTX_NEAR(dense_mtx,
@@ -230,7 +230,7 @@ TYPED_TEST(Coo, MovesToDense)
     using Dense = typename TestFixture::Vec;
     auto dense_mtx = Dense::create(this->mtx->get_executor());
 
-    this->mtx->move_to(dense_mtx.get());
+    this->mtx->move_to(dense_mtx);
 
     // clang-format off
     GKO_ASSERT_MTX_NEAR(dense_mtx,
@@ -250,7 +250,7 @@ TYPED_TEST(Coo, ConvertsEmptyToPrecision)
     auto empty = OtherCoo::create(this->exec);
     auto res = Coo::create(this->exec);
 
-    empty->convert_to(res.get());
+    empty->convert_to(res);
 
     ASSERT_EQ(res->get_num_stored_elements(), 0);
     ASSERT_FALSE(res->get_size());
@@ -267,7 +267,7 @@ TYPED_TEST(Coo, MovesEmptyToPrecision)
     auto empty = OtherCoo::create(this->exec);
     auto res = Coo::create(this->exec);
 
-    empty->move_to(res.get());
+    empty->move_to(res);
 
     ASSERT_EQ(res->get_num_stored_elements(), 0);
     ASSERT_FALSE(res->get_size());
@@ -283,7 +283,7 @@ TYPED_TEST(Coo, ConvertsEmptyToCsr)
     auto empty = Coo::create(this->exec);
     auto res = Csr::create(this->exec);
 
-    empty->convert_to(res.get());
+    empty->convert_to(res);
 
     ASSERT_EQ(res->get_num_stored_elements(), 0);
     ASSERT_EQ(*res->get_const_row_ptrs(), 0);
@@ -300,7 +300,7 @@ TYPED_TEST(Coo, MovesEmptyToCsr)
     auto empty = Coo::create(this->exec);
     auto res = Csr::create(this->exec);
 
-    empty->move_to(res.get());
+    empty->move_to(res);
 
     ASSERT_EQ(res->get_num_stored_elements(), 0);
     ASSERT_EQ(*res->get_const_row_ptrs(), 0);
@@ -317,7 +317,7 @@ TYPED_TEST(Coo, ConvertsEmptyToDense)
     auto empty = Coo::create(this->exec);
     auto res = Dense::create(this->exec);
 
-    empty->convert_to(res.get());
+    empty->convert_to(res);
 
     ASSERT_FALSE(res->get_size());
 }
@@ -332,7 +332,7 @@ TYPED_TEST(Coo, MovesEmptyToDense)
     auto empty = Coo::create(this->exec);
     auto res = Dense::create(this->exec);
 
-    empty->move_to(res.get());
+    empty->move_to(res);
 
     ASSERT_FALSE(res->get_size());
 }
@@ -344,7 +344,7 @@ TYPED_TEST(Coo, AppliesToDenseVector)
     auto x = gko::initialize<Vec>({2.0, 1.0, 4.0}, this->exec);
     auto y = Vec::create(this->exec, gko::dim<2>{2, 1});
 
-    this->mtx->apply(x.get(), y.get());
+    this->mtx->apply(x, y);
 
     GKO_ASSERT_MTX_NEAR(y, l({13.0, 5.0}), 0.0);
 }
@@ -358,7 +358,7 @@ TYPED_TEST(Coo, ApplyToStridedVectorKeepsPadding)
     auto y = Vec::create(this->exec, gko::dim<2>{2, 1}, 2);
     y->get_values()[1] = 1234;
 
-    this->mtx->apply(x.get(), y.get());
+    this->mtx->apply(x, y);
 
     GKO_ASSERT_MTX_NEAR(y, l({13.0, 5.0}), 0.0);
     ASSERT_EQ(y->get_values()[1], T{1234});
@@ -371,7 +371,7 @@ TYPED_TEST(Coo, AppliesToMixedDenseVector)
     auto x = gko::initialize<MixedVec>({2.0, 1.0, 4.0}, this->exec);
     auto y = MixedVec::create(this->exec, gko::dim<2>{2, 1});
 
-    this->mtx->apply(x.get(), y.get());
+    this->mtx->apply(x, y);
 
     GKO_ASSERT_MTX_NEAR(y, l({13.0, 5.0}), 0.0);
 }
@@ -383,7 +383,7 @@ TYPED_TEST(Coo, AppliesToDenseVectorUnsorted)
     auto x = gko::initialize<Vec>({2.0, 1.0, 4.0}, this->exec);
     auto y = Vec::create(this->exec, gko::dim<2>{2, 1});
 
-    this->uns_mtx->apply(x.get(), y.get());
+    this->uns_mtx->apply(x, y);
 
     GKO_ASSERT_MTX_NEAR(y, l({13.0, 5.0}), 0.0);
 }
@@ -401,7 +401,7 @@ TYPED_TEST(Coo, AppliesToDenseMatrix)
     // clang-format on
     auto y = Vec::create(this->exec, gko::dim<2>{2, 2});
 
-    this->mtx->apply(x.get(), y.get());
+    this->mtx->apply(x, y);
 
     // clang-format off
     GKO_ASSERT_MTX_NEAR(y,
@@ -423,7 +423,7 @@ TYPED_TEST(Coo, AppliesToDenseMatrixUnsorted)
     // clang-format on
     auto y = Vec::create(this->exec, gko::dim<2>{2, 2});
 
-    this->uns_mtx->apply(x.get(), y.get());
+    this->uns_mtx->apply(x, y);
 
     // clang-format off
     GKO_ASSERT_MTX_NEAR(y,
@@ -441,7 +441,7 @@ TYPED_TEST(Coo, AppliesLinearCombinationToDenseVector)
     auto x = gko::initialize<Vec>({2.0, 1.0, 4.0}, this->exec);
     auto y = gko::initialize<Vec>({1.0, 2.0}, this->exec);
 
-    this->mtx->apply(alpha.get(), x.get(), beta.get(), y.get());
+    this->mtx->apply(alpha, x, beta, y);
 
     GKO_ASSERT_MTX_NEAR(y, l({-11.0, -1.0}), 0.0);
 }
@@ -459,7 +459,7 @@ TYPED_TEST(Coo, ApplyLinearCombinationToStridedVectorKeepsPadding)
     y->at(0, 0) = 1.0;
     y->at(1, 0) = 2.0;
 
-    this->mtx->apply(alpha.get(), x.get(), beta.get(), y.get());
+    this->mtx->apply(alpha, x, beta, y);
 
     GKO_ASSERT_MTX_NEAR(y, l({-11.0, -1.0}), 0.0);
     ASSERT_EQ(y->get_values()[1], T{1234});
@@ -474,7 +474,7 @@ TYPED_TEST(Coo, AppliesLinearCombinationToMixedDenseVector)
     auto x = gko::initialize<MixedVec>({2.0, 1.0, 4.0}, this->exec);
     auto y = gko::initialize<MixedVec>({1.0, 2.0}, this->exec);
 
-    this->mtx->apply(alpha.get(), x.get(), beta.get(), y.get());
+    this->mtx->apply(alpha, x, beta, y);
 
     GKO_ASSERT_MTX_NEAR(y, l({-11.0, -1.0}), 0.0);
 }
@@ -496,7 +496,7 @@ TYPED_TEST(Coo, AppliesLinearCombinationToDenseMatrix)
          I<T>{2.0, -1.5}}, this->exec);
     // clang-format on
 
-    this->mtx->apply(alpha.get(), x.get(), beta.get(), y.get());
+    this->mtx->apply(alpha, x, beta, y);
 
     // clang-format off
     GKO_ASSERT_MTX_NEAR(y,
@@ -512,7 +512,7 @@ TYPED_TEST(Coo, ApplyFailsOnWrongInnerDimension)
     auto x = Vec::create(this->exec, gko::dim<2>{2});
     auto y = Vec::create(this->exec, gko::dim<2>{2});
 
-    ASSERT_THROW(this->mtx->apply(x.get(), y.get()), gko::DimensionMismatch);
+    ASSERT_THROW(this->mtx->apply(x, y), gko::DimensionMismatch);
 }
 
 
@@ -522,7 +522,7 @@ TYPED_TEST(Coo, ApplyFailsOnWrongNumberOfRows)
     auto x = Vec::create(this->exec, gko::dim<2>{3, 2});
     auto y = Vec::create(this->exec, gko::dim<2>{3, 2});
 
-    ASSERT_THROW(this->mtx->apply(x.get(), y.get()), gko::DimensionMismatch);
+    ASSERT_THROW(this->mtx->apply(x, y), gko::DimensionMismatch);
 }
 
 
@@ -532,7 +532,7 @@ TYPED_TEST(Coo, ApplyFailsOnWrongNumberOfCols)
     auto x = Vec::create(this->exec, gko::dim<2>{3});
     auto y = Vec::create(this->exec, gko::dim<2>{2});
 
-    ASSERT_THROW(this->mtx->apply(x.get(), y.get()), gko::DimensionMismatch);
+    ASSERT_THROW(this->mtx->apply(x, y), gko::DimensionMismatch);
 }
 
 
@@ -542,7 +542,7 @@ TYPED_TEST(Coo, AppliesAddToDenseVector)
     auto x = gko::initialize<Vec>({2.0, 1.0, 4.0}, this->exec);
     auto y = gko::initialize<Vec>({2.0, 1.0}, this->exec);
 
-    this->mtx->apply2(x.get(), y.get());
+    this->mtx->apply2(x, y);
 
     GKO_ASSERT_MTX_NEAR(y, l({15.0, 6.0}), 0.0);
 }
@@ -554,7 +554,7 @@ TYPED_TEST(Coo, AppliesAddToMixedDenseVector)
     auto x = gko::initialize<MixedVec>({2.0, 1.0, 4.0}, this->exec);
     auto y = gko::initialize<MixedVec>({2.0, 1.0}, this->exec);
 
-    this->mtx->apply2(x.get(), y.get());
+    this->mtx->apply2(x, y);
 
     GKO_ASSERT_MTX_NEAR(y, l({15.0, 6.0}), 0.0);
 }
@@ -574,7 +574,7 @@ TYPED_TEST(Coo, AppliesAddToDenseMatrix)
          I<T>{2.0, -1.5}}, this->exec);
     // clang-format on
 
-    this->mtx->apply2(x.get(), y.get());
+    this->mtx->apply2(x, y);
 
     // clang-format off
     GKO_ASSERT_MTX_NEAR(y,
@@ -591,7 +591,7 @@ TYPED_TEST(Coo, AppliesLinearCombinationAddToDenseVector)
     auto x = gko::initialize<Vec>({2.0, 1.0, 4.0}, this->exec);
     auto y = gko::initialize<Vec>({1.0, 2.0}, this->exec);
 
-    this->mtx->apply2(alpha.get(), x.get(), y.get());
+    this->mtx->apply2(alpha, x, y);
 
     GKO_ASSERT_MTX_NEAR(y, l({-12.0, -3.0}), 0.0);
 }
@@ -604,7 +604,7 @@ TYPED_TEST(Coo, AppliesLinearCombinationAddToMixedDenseVector)
     auto x = gko::initialize<MixedVec>({2.0, 1.0, 4.0}, this->exec);
     auto y = gko::initialize<MixedVec>({1.0, 2.0}, this->exec);
 
-    this->mtx->apply2(alpha.get(), x.get(), y.get());
+    this->mtx->apply2(alpha, x, y);
 
     GKO_ASSERT_MTX_NEAR(y, l({-12.0, -3.0}), 0.0);
 }
@@ -625,7 +625,7 @@ TYPED_TEST(Coo, AppliesLinearCombinationAddToDenseMatrix)
          I<T>{2.0, -1.5}}, this->exec);
     // clang-format on
 
-    this->mtx->apply2(alpha.get(), x.get(), y.get());
+    this->mtx->apply2(alpha, x, y);
 
     // clang-format off
     GKO_ASSERT_MTX_NEAR(y,
@@ -719,7 +719,7 @@ TYPED_TEST(Coo, AppliesToComplex)
     auto x = Vec::create(exec, gko::dim<2>{2,2});
     // clang-format on
 
-    this->mtx->apply(b.get(), x.get());
+    this->mtx->apply(b, x);
 
     GKO_ASSERT_MTX_NEAR(
         x,
@@ -745,7 +745,7 @@ TYPED_TEST(Coo, AppliesToMixedComplex)
     auto x = Vec::create(exec, gko::dim<2>{2,2});
     // clang-format on
 
-    this->mtx->apply(b.get(), x.get());
+    this->mtx->apply(b, x);
 
     GKO_ASSERT_MTX_NEAR(
         x,
@@ -775,7 +775,7 @@ TYPED_TEST(Coo, AdvancedAppliesToComplex)
     auto beta = gko::initialize<Dense>({2.0}, this->exec);
     // clang-format on
 
-    this->mtx->apply(alpha.get(), b.get(), beta.get(), x.get());
+    this->mtx->apply(alpha, b, beta, x);
 
     GKO_ASSERT_MTX_NEAR(
         x,
@@ -806,7 +806,7 @@ TYPED_TEST(Coo, AdvancedAppliesToMixedComplex)
     auto beta = gko::initialize<MixedDense>({2.0}, this->exec);
     // clang-format on
 
-    this->mtx->apply(alpha.get(), b.get(), beta.get(), x.get());
+    this->mtx->apply(alpha, b, beta, x);
 
     GKO_ASSERT_MTX_NEAR(
         x,
@@ -833,7 +833,7 @@ TYPED_TEST(Coo, ApplyAddsToComplex)
          {complex_type{2.0, 2.0}, complex_type{3.0, 3.0}}}, exec);
     // clang-format on
 
-    this->mtx->apply2(b.get(), x.get());
+    this->mtx->apply2(b, x);
 
     GKO_ASSERT_MTX_NEAR(
         x,
@@ -861,7 +861,7 @@ TYPED_TEST(Coo, ApplyAddsToMixedComplex)
          {mixed_complex_type{2.0, 2.0}, mixed_complex_type{3.0, 3.0}}}, exec);
     // clang-format on
 
-    this->mtx->apply2(b.get(), x.get());
+    this->mtx->apply2(b, x);
 
     GKO_ASSERT_MTX_NEAR(
         x,
@@ -890,7 +890,7 @@ TYPED_TEST(Coo, ApplyAddsScaledToComplex)
     auto alpha = gko::initialize<Dense>({-1.0}, this->exec);
     // clang-format on
 
-    this->mtx->apply2(alpha.get(), b.get(), x.get());
+    this->mtx->apply2(alpha, b, x);
 
     GKO_ASSERT_MTX_NEAR(
         x,
@@ -920,7 +920,7 @@ TYPED_TEST(Coo, ApplyAddsScaledToMixedComplex)
     auto alpha = gko::initialize<MixedDense>({-1.0}, this->exec);
     // clang-format on
 
-    this->mtx->apply2(alpha.get(), b.get(), x.get());
+    this->mtx->apply2(alpha, b, x);
 
     GKO_ASSERT_MTX_NEAR(
         x,

--- a/reference/test/matrix/csr_kernels.cpp
+++ b/reference/test/matrix/csr_kernels.cpp
@@ -543,7 +543,7 @@ TYPED_TEST(Csr, AppliesLinearCombinationToIdentityMatrix)
         this->exec);
     auto id = gko::matrix::Identity<T>::create(this->exec, a->get_size()[1]);
 
-    a->apply(gko::lend(alpha), gko::lend(id), gko::lend(beta), gko::lend(b));
+    a->apply(alpha, id, beta, b);
 
     GKO_ASSERT_MTX_NEAR(b, expect, r<T>::value);
     GKO_ASSERT_MTX_EQ_SPARSITY(b, expect);

--- a/reference/test/matrix/csr_kernels.cpp
+++ b/reference/test/matrix/csr_kernels.cpp
@@ -362,7 +362,7 @@ TYPED_TEST(Csr, AppliesToDenseVector)
     auto x = gko::initialize<Vec>({2.0, 1.0, 4.0}, this->exec);
     auto y = Vec::create(this->exec, gko::dim<2>{2, 1});
 
-    this->mtx->apply(x.get(), y.get());
+    this->mtx->apply(x, y);
 
     EXPECT_EQ(y->at(0), T{13.0});
     EXPECT_EQ(y->at(1), T{5.0});
@@ -376,7 +376,7 @@ TYPED_TEST(Csr, AppliesToMixedDenseVector)
     auto x = gko::initialize<MixedVec>({2.0, 1.0, 4.0}, this->exec);
     auto y = MixedVec::create(this->exec, gko::dim<2>{2, 1});
 
-    this->mtx->apply(x.get(), y.get());
+    this->mtx->apply(x, y);
 
     EXPECT_EQ(y->at(0), MixedT{13.0});
     EXPECT_EQ(y->at(1), MixedT{5.0});
@@ -391,7 +391,7 @@ TYPED_TEST(Csr, AppliesToDenseMatrix)
         {I<T>{2.0, 3.0}, I<T>{1.0, -1.5}, I<T>{4.0, 2.5}}, this->exec);
     auto y = Vec::create(this->exec, gko::dim<2>{2});
 
-    this->mtx->apply(x.get(), y.get());
+    this->mtx->apply(x, y);
 
     EXPECT_EQ(y->at(0, 0), T{13.0});
     EXPECT_EQ(y->at(1, 0), T{5.0});
@@ -409,7 +409,7 @@ TYPED_TEST(Csr, AppliesLinearCombinationToDenseVector)
     auto x = gko::initialize<Vec>({2.0, 1.0, 4.0}, this->exec);
     auto y = gko::initialize<Vec>({1.0, 2.0}, this->exec);
 
-    this->mtx->apply(alpha.get(), x.get(), beta.get(), y.get());
+    this->mtx->apply(alpha, x, beta, y);
 
     EXPECT_EQ(y->at(0), T{-11.0});
     EXPECT_EQ(y->at(1), T{-1.0});
@@ -425,7 +425,7 @@ TYPED_TEST(Csr, AppliesLinearCombinationToMixedDenseVector)
     auto x = gko::initialize<MixedVec>({2.0, 1.0, 4.0}, this->exec);
     auto y = gko::initialize<MixedVec>({1.0, 2.0}, this->exec);
 
-    this->mtx->apply(alpha.get(), x.get(), beta.get(), y.get());
+    this->mtx->apply(alpha, x, beta, y);
 
     EXPECT_EQ(y->at(0), MixedT{-11.0});
     EXPECT_EQ(y->at(1), MixedT{-1.0});
@@ -443,7 +443,7 @@ TYPED_TEST(Csr, AppliesLinearCombinationToDenseMatrix)
     auto y =
         gko::initialize<Vec>({I<T>{1.0, 0.5}, I<T>{2.0, -1.5}}, this->exec);
 
-    this->mtx->apply(alpha.get(), x.get(), beta.get(), y.get());
+    this->mtx->apply(alpha, x, beta, y);
 
     EXPECT_EQ(y->at(0, 0), T{-11.0});
     EXPECT_EQ(y->at(1, 0), T{-1.0});
@@ -455,7 +455,7 @@ TYPED_TEST(Csr, AppliesLinearCombinationToDenseMatrix)
 TYPED_TEST(Csr, AppliesToCsrMatrix)
 {
     using T = typename TestFixture::value_type;
-    this->mtx->apply(this->mtx3_unsorted.get(), this->mtx2.get());
+    this->mtx->apply(this->mtx3_unsorted, this->mtx2);
 
     ASSERT_EQ(this->mtx2->get_size(), gko::dim<2>(2, 3));
     ASSERT_EQ(this->mtx2->get_num_stored_elements(), 6);
@@ -490,8 +490,7 @@ TYPED_TEST(Csr, AppliesLinearCombinationToCsrMatrix)
     auto alpha = gko::initialize<Vec>({-1.0}, this->exec);
     auto beta = gko::initialize<Vec>({2.0}, this->exec);
 
-    this->mtx->apply(alpha.get(), this->mtx3_unsorted.get(), beta.get(),
-                     this->mtx2.get());
+    this->mtx->apply(alpha, this->mtx3_unsorted, beta, this->mtx2);
 
     ASSERT_EQ(this->mtx2->get_size(), gko::dim<2>(2, 3));
     ASSERT_EQ(this->mtx2->get_num_stored_elements(), 6);
@@ -557,7 +556,7 @@ TYPED_TEST(Csr, ApplyFailsOnWrongInnerDimension)
     auto x = Vec::create(this->exec, gko::dim<2>{2});
     auto y = Vec::create(this->exec, gko::dim<2>{2});
 
-    ASSERT_THROW(this->mtx->apply(x.get(), y.get()), gko::DimensionMismatch);
+    ASSERT_THROW(this->mtx->apply(x, y), gko::DimensionMismatch);
 }
 
 
@@ -567,7 +566,7 @@ TYPED_TEST(Csr, ApplyFailsOnWrongNumberOfRows)
     auto x = Vec::create(this->exec, gko::dim<2>{3, 2});
     auto y = Vec::create(this->exec, gko::dim<2>{3, 2});
 
-    ASSERT_THROW(this->mtx->apply(x.get(), y.get()), gko::DimensionMismatch);
+    ASSERT_THROW(this->mtx->apply(x, y), gko::DimensionMismatch);
 }
 
 
@@ -577,7 +576,7 @@ TYPED_TEST(Csr, ApplyFailsOnWrongNumberOfCols)
     auto x = Vec::create(this->exec, gko::dim<2>{3});
     auto y = Vec::create(this->exec, gko::dim<2>{2});
 
-    ASSERT_THROW(this->mtx->apply(x.get(), y.get()), gko::DimensionMismatch);
+    ASSERT_THROW(this->mtx->apply(x, y), gko::DimensionMismatch);
 }
 
 
@@ -596,8 +595,8 @@ TYPED_TEST(Csr, ConvertsToPrecision)
                         : gko::remove_complex<ValueType>{r<OtherType>::value};
 
     // use mtx2 as mtx's strategy would involve creating a CudaExecutor
-    this->mtx2->convert_to(tmp.get());
-    tmp->convert_to(res.get());
+    this->mtx2->convert_to(tmp);
+    tmp->convert_to(res);
 
     GKO_ASSERT_MTX_NEAR(this->mtx2, res, residual);
     auto first_strategy = this->mtx2->get_strategy();
@@ -621,8 +620,8 @@ TYPED_TEST(Csr, MovesToPrecision)
                         : gko::remove_complex<ValueType>{r<OtherType>::value};
 
     // use mtx2 as mtx's strategy would involve creating a CudaExecutor
-    this->mtx2->move_to(tmp.get());
-    tmp->move_to(res.get());
+    this->mtx2->move_to(tmp);
+    tmp->move_to(res);
 
     GKO_ASSERT_MTX_NEAR(this->mtx2, res, residual);
     auto first_strategy = this->mtx2->get_strategy();
@@ -638,7 +637,7 @@ TYPED_TEST(Csr, ConvertsToDense)
     auto dense_other = gko::initialize<Dense>(
         4, {{1.0, 3.0, 2.0}, {0.0, 5.0, 0.0}}, this->exec);
 
-    this->mtx->convert_to(dense_mtx.get());
+    this->mtx->convert_to(dense_mtx);
 
     GKO_ASSERT_MTX_NEAR(dense_mtx, dense_other, 0.0);
 }
@@ -651,7 +650,7 @@ TYPED_TEST(Csr, MovesToDense)
     auto dense_other = gko::initialize<Dense>(
         4, {{1.0, 3.0, 2.0}, {0.0, 5.0, 0.0}}, this->exec);
 
-    this->mtx->move_to(dense_mtx.get());
+    this->mtx->move_to(dense_mtx);
 
     GKO_ASSERT_MTX_NEAR(dense_mtx, dense_other, 0.0);
 }
@@ -662,7 +661,7 @@ TYPED_TEST(Csr, ConvertsToCoo)
     using Coo = typename TestFixture::Coo;
     auto coo_mtx = Coo::create(this->mtx->get_executor());
 
-    this->mtx->convert_to(coo_mtx.get());
+    this->mtx->convert_to(coo_mtx);
 
     this->assert_equal_to_mtx(coo_mtx.get());
 }
@@ -673,7 +672,7 @@ TYPED_TEST(Csr, MovesToCoo)
     using Coo = typename TestFixture::Coo;
     auto coo_mtx = Coo::create(this->mtx->get_executor());
 
-    this->mtx->move_to(coo_mtx.get());
+    this->mtx->move_to(coo_mtx);
 
     this->assert_equal_to_mtx(coo_mtx.get());
 }
@@ -684,7 +683,7 @@ TYPED_TEST(Csr, ConvertsToSellp)
     using Sellp = typename TestFixture::Sellp;
     auto sellp_mtx = Sellp::create(this->mtx->get_executor());
 
-    this->mtx->convert_to(sellp_mtx.get());
+    this->mtx->convert_to(sellp_mtx);
 
     this->assert_equal_to_mtx(sellp_mtx.get());
 }
@@ -697,8 +696,8 @@ TYPED_TEST(Csr, MovesToSellp)
     auto sellp_mtx = Sellp::create(this->mtx->get_executor());
     auto csr_ref = Csr::create(this->mtx->get_executor());
 
-    csr_ref->copy_from(this->mtx.get());
-    csr_ref->move_to(sellp_mtx.get());
+    csr_ref->copy_from(this->mtx);
+    csr_ref->move_to(sellp_mtx);
 
     this->assert_equal_to_mtx(sellp_mtx.get());
 }
@@ -709,7 +708,7 @@ TYPED_TEST(Csr, ConvertsToSparsityCsr)
     using SparsityCsr = typename TestFixture::SparsityCsr;
     auto sparsity_mtx = SparsityCsr::create(this->mtx->get_executor());
 
-    this->mtx->convert_to(sparsity_mtx.get());
+    this->mtx->convert_to(sparsity_mtx);
 
     this->assert_equal_to_mtx(sparsity_mtx.get());
 }
@@ -722,8 +721,8 @@ TYPED_TEST(Csr, MovesToSparsityCsr)
     auto sparsity_mtx = SparsityCsr::create(this->mtx->get_executor());
     auto csr_ref = Csr::create(this->mtx->get_executor());
 
-    csr_ref->copy_from(this->mtx.get());
-    csr_ref->move_to(sparsity_mtx.get());
+    csr_ref->copy_from(this->mtx);
+    csr_ref->move_to(sparsity_mtx);
 
     this->assert_equal_to_mtx(sparsity_mtx.get());
 }
@@ -734,7 +733,7 @@ TYPED_TEST(Csr, ConvertsToHybridAutomatically)
     using Hybrid = typename TestFixture::Hybrid;
     auto hybrid_mtx = Hybrid::create(this->mtx->get_executor());
 
-    this->mtx->convert_to(hybrid_mtx.get());
+    this->mtx->convert_to(hybrid_mtx);
 
     this->assert_equal_to_mtx(hybrid_mtx.get());
 }
@@ -747,8 +746,8 @@ TYPED_TEST(Csr, MovesToHybridAutomatically)
     auto hybrid_mtx = Hybrid::create(this->mtx->get_executor());
     auto csr_ref = Csr::create(this->mtx->get_executor());
 
-    csr_ref->copy_from(this->mtx.get());
-    csr_ref->move_to(hybrid_mtx.get());
+    csr_ref->copy_from(this->mtx);
+    csr_ref->move_to(hybrid_mtx);
 
     this->assert_equal_to_mtx(hybrid_mtx.get());
 }
@@ -761,7 +760,7 @@ TYPED_TEST(Csr, ConvertsToHybridByColumn2)
         Hybrid::create(this->mtx2->get_executor(),
                        std::make_shared<typename Hybrid::column_limit>(2));
 
-    this->mtx2->convert_to(hybrid_mtx.get());
+    this->mtx2->convert_to(hybrid_mtx);
 
     this->assert_equal_to_mtx2(hybrid_mtx.get());
 }
@@ -776,8 +775,8 @@ TYPED_TEST(Csr, MovesToHybridByColumn2)
                        std::make_shared<typename Hybrid::column_limit>(2));
     auto csr_ref = Csr::create(this->mtx2->get_executor());
 
-    csr_ref->copy_from(this->mtx2.get());
-    csr_ref->move_to(hybrid_mtx.get());
+    csr_ref->copy_from(this->mtx2);
+    csr_ref->move_to(hybrid_mtx);
 
     this->assert_equal_to_mtx2(hybrid_mtx.get());
 }
@@ -794,7 +793,7 @@ TYPED_TEST(Csr, ConvertsEmptyToPrecision)
     empty->get_row_ptrs()[0] = 0;
     auto res = Csr::create(this->exec);
 
-    empty->convert_to(res.get());
+    empty->convert_to(res);
 
     ASSERT_EQ(res->get_num_stored_elements(), 0);
     ASSERT_EQ(*res->get_const_row_ptrs(), 0);
@@ -813,7 +812,7 @@ TYPED_TEST(Csr, MovesEmptyToPrecision)
     empty->get_row_ptrs()[0] = 0;
     auto res = Csr::create(this->exec);
 
-    empty->move_to(res.get());
+    empty->move_to(res);
 
     ASSERT_EQ(res->get_num_stored_elements(), 0);
     ASSERT_EQ(*res->get_const_row_ptrs(), 0);
@@ -829,7 +828,7 @@ TYPED_TEST(Csr, ConvertsEmptyToDense)
     auto empty = Csr::create(this->exec);
     auto res = Dense::create(this->exec);
 
-    empty->convert_to(res.get());
+    empty->convert_to(res);
 
     ASSERT_FALSE(res->get_size());
 }
@@ -843,7 +842,7 @@ TYPED_TEST(Csr, MovesEmptyToDense)
     auto empty = Csr::create(this->exec);
     auto res = Dense::create(this->exec);
 
-    empty->move_to(res.get());
+    empty->move_to(res);
 
     ASSERT_FALSE(res->get_size());
 }
@@ -858,7 +857,7 @@ TYPED_TEST(Csr, ConvertsEmptyToCoo)
     auto empty = Csr::create(this->exec);
     auto res = Coo::create(this->exec);
 
-    empty->convert_to(res.get());
+    empty->convert_to(res);
 
     ASSERT_EQ(res->get_num_stored_elements(), 0);
     ASSERT_FALSE(res->get_size());
@@ -874,7 +873,7 @@ TYPED_TEST(Csr, MovesEmptyToCoo)
     auto empty = Csr::create(this->exec);
     auto res = Coo::create(this->exec);
 
-    empty->move_to(res.get());
+    empty->move_to(res);
 
     ASSERT_EQ(res->get_num_stored_elements(), 0);
     ASSERT_FALSE(res->get_size());
@@ -890,7 +889,7 @@ TYPED_TEST(Csr, ConvertsEmptyToEll)
     auto empty = Csr::create(this->exec);
     auto res = Ell::create(this->exec);
 
-    empty->convert_to(res.get());
+    empty->convert_to(res);
 
     ASSERT_EQ(res->get_num_stored_elements(), 0);
     ASSERT_FALSE(res->get_size());
@@ -906,7 +905,7 @@ TYPED_TEST(Csr, MovesEmptyToEll)
     auto empty = Csr::create(this->exec);
     auto res = Ell::create(this->exec);
 
-    empty->move_to(res.get());
+    empty->move_to(res);
 
     ASSERT_EQ(res->get_num_stored_elements(), 0);
     ASSERT_FALSE(res->get_size());
@@ -922,7 +921,7 @@ TYPED_TEST(Csr, ConvertsEmptyToSellp)
     auto empty = Csr::create(this->exec);
     auto res = Sellp::create(this->exec);
 
-    empty->convert_to(res.get());
+    empty->convert_to(res);
 
     ASSERT_EQ(res->get_num_stored_elements(), 0);
     ASSERT_EQ(*res->get_const_slice_sets(), 0);
@@ -939,7 +938,7 @@ TYPED_TEST(Csr, MovesEmptyToSellp)
     auto empty = Csr::create(this->exec);
     auto res = Sellp::create(this->exec);
 
-    empty->move_to(res.get());
+    empty->move_to(res);
 
     ASSERT_EQ(res->get_num_stored_elements(), 0);
     ASSERT_EQ(*res->get_const_slice_sets(), 0);
@@ -957,7 +956,7 @@ TYPED_TEST(Csr, ConvertsEmptyToSparsityCsr)
     empty->get_row_ptrs()[0] = 0;
     auto res = SparsityCsr::create(this->exec);
 
-    empty->convert_to(res.get());
+    empty->convert_to(res);
 
     ASSERT_EQ(res->get_num_nonzeros(), 0);
     ASSERT_EQ(*res->get_const_row_ptrs(), 0);
@@ -974,7 +973,7 @@ TYPED_TEST(Csr, MovesEmptyToSparsityCsr)
     empty->get_row_ptrs()[0] = 0;
     auto res = SparsityCsr::create(this->exec);
 
-    empty->move_to(res.get());
+    empty->move_to(res);
 
     ASSERT_EQ(res->get_num_nonzeros(), 0);
     ASSERT_EQ(*res->get_const_row_ptrs(), 0);
@@ -990,7 +989,7 @@ TYPED_TEST(Csr, ConvertsEmptyToHybrid)
     auto empty = Csr::create(this->exec);
     auto res = Hybrid::create(this->exec);
 
-    empty->convert_to(res.get());
+    empty->convert_to(res);
 
     ASSERT_EQ(res->get_num_stored_elements(), 0);
     ASSERT_FALSE(res->get_size());
@@ -1006,7 +1005,7 @@ TYPED_TEST(Csr, MovesEmptyToHybrid)
     auto empty = Csr::create(this->exec);
     auto res = Hybrid::create(this->exec);
 
-    empty->move_to(res.get());
+    empty->move_to(res);
 
     ASSERT_EQ(res->get_num_stored_elements(), 0);
     ASSERT_FALSE(res->get_size());
@@ -1021,7 +1020,7 @@ TYPED_TEST(Csr, ConvertsToEll)
     auto dense_mtx = Dense::create(this->mtx->get_executor());
     auto ref_dense_mtx = Dense::create(this->mtx->get_executor());
 
-    this->mtx->convert_to(ell_mtx.get());
+    this->mtx->convert_to(ell_mtx);
 
     this->assert_equal_to_mtx(ell_mtx.get());
 }
@@ -1035,7 +1034,7 @@ TYPED_TEST(Csr, MovesToEll)
     auto dense_mtx = Dense::create(this->mtx->get_executor());
     auto ref_dense_mtx = Dense::create(this->mtx->get_executor());
 
-    this->mtx->move_to(ell_mtx.get());
+    this->mtx->move_to(ell_mtx);
 
     this->assert_equal_to_mtx(ell_mtx.get());
 }
@@ -1387,7 +1386,7 @@ TYPED_TEST(Csr, AppliesToComplex)
     auto x = Vec::create(exec, gko::dim<2>{2,2});
     // clang-format on
 
-    this->mtx->apply(b.get(), x.get());
+    this->mtx->apply(b, x);
 
     GKO_ASSERT_MTX_NEAR(
         x,
@@ -1413,7 +1412,7 @@ TYPED_TEST(Csr, AppliesToMixedComplex)
     auto x = Vec::create(exec, gko::dim<2>{2,2});
     // clang-format on
 
-    this->mtx->apply(b.get(), x.get());
+    this->mtx->apply(b, x);
 
     GKO_ASSERT_MTX_NEAR(
         x,
@@ -1443,7 +1442,7 @@ TYPED_TEST(Csr, AdvancedAppliesToComplex)
     auto beta = gko::initialize<Dense>({2.0}, this->exec);
     // clang-format on
 
-    this->mtx->apply(alpha.get(), b.get(), beta.get(), x.get());
+    this->mtx->apply(alpha, b, beta, x);
 
     GKO_ASSERT_MTX_NEAR(
         x,
@@ -1474,7 +1473,7 @@ TYPED_TEST(Csr, AdvancedAppliesToMixedComplex)
     auto beta = gko::initialize<MixedDense>({2.0}, this->exec);
     // clang-format on
 
-    this->mtx->apply(alpha.get(), b.get(), beta.get(), x.get());
+    this->mtx->apply(alpha, b, beta, x);
 
     GKO_ASSERT_MTX_NEAR(
         x,
@@ -1492,7 +1491,7 @@ TYPED_TEST(Csr, ScalesData)
     auto alpha = gko::initialize<Dense>({I<T>{2.0}}, this->exec);
     auto to_scale = gko::clone(this->mtx2);
 
-    to_scale->scale(alpha.get());
+    to_scale->scale(alpha);
 
     GKO_ASSERT_MTX_EQ_SPARSITY(to_scale, this->mtx2);
     EXPECT_EQ(to_scale->get_values()[0], T{2.0});
@@ -1511,7 +1510,7 @@ TYPED_TEST(Csr, InvScalesData)
     auto alpha = gko::initialize<Dense>({I<T>{2.0}}, this->exec);
     auto to_scale = gko::clone(this->mtx2);
 
-    to_scale->inv_scale(alpha.get());
+    to_scale->inv_scale(alpha);
 
     GKO_ASSERT_MTX_EQ_SPARSITY(to_scale, this->mtx2);
     EXPECT_EQ(to_scale->get_values()[0], T{0.5});
@@ -1681,7 +1680,7 @@ TYPED_TEST(Csr, CanGetSubmatrix)
     auto ref =
         gko::initialize<Mtx>({I<T>{1.0, 3.0}, I<T>{0.0, 5.0}}, this->exec);
 
-    GKO_ASSERT_MTX_NEAR(sub_mat.get(), ref.get(), 0.0);
+    GKO_ASSERT_MTX_NEAR(sub_mat, ref, 0.0);
 }
 
 
@@ -1708,7 +1707,7 @@ TYPED_TEST(Csr, CanGetSubmatrix2)
         auto ref1 =
             gko::initialize<Mtx>({I<T>{1.0, 3.0}, I<T>{1.0, 0.0}}, this->exec);
 
-        GKO_EXPECT_MTX_NEAR(sub_mat1.get(), ref1.get(), 0.0);
+        GKO_EXPECT_MTX_NEAR(sub_mat1, ref1, 0.0);
     }
     {
         SCOPED_TRACE("Left boundary: Square 2x2");
@@ -1716,7 +1715,7 @@ TYPED_TEST(Csr, CanGetSubmatrix2)
         auto ref2 =
             gko::initialize<Mtx>({I<T>{0.0, 3.0}, I<T>{0.0, -1.0}}, this->exec);
 
-        GKO_EXPECT_MTX_NEAR(sub_mat2.get(), ref2.get(), 0.0);
+        GKO_EXPECT_MTX_NEAR(sub_mat2, ref2, 0.0);
     }
     {
         SCOPED_TRACE("Right boundary: Square 2x2");
@@ -1724,7 +1723,7 @@ TYPED_TEST(Csr, CanGetSubmatrix2)
         auto ref3 =
             gko::initialize<Mtx>({I<T>{0.0, 2.0}, I<T>{7.5, 3.0}}, this->exec);
 
-        GKO_EXPECT_MTX_NEAR(sub_mat3.get(), ref3.get(), 0.0);
+        GKO_EXPECT_MTX_NEAR(sub_mat3, ref3, 0.0);
     }
     {
         SCOPED_TRACE("Non-square 5x2");
@@ -1741,7 +1740,7 @@ TYPED_TEST(Csr, CanGetSubmatrix2)
              I<T>{0.0, 0.0}},
             this->exec);
 
-        GKO_EXPECT_MTX_NEAR(sub_mat4.get(), ref4.get(), 0.0);
+        GKO_EXPECT_MTX_NEAR(sub_mat4, ref4, 0.0);
     }
     {
         auto sub_mat5 = mat->create_submatrix(gko::span(0, 7), gko::span(0, 5));
@@ -1757,13 +1756,13 @@ TYPED_TEST(Csr, CanGetSubmatrix2)
             },
             this->exec);
 
-        GKO_EXPECT_MTX_NEAR(sub_mat5.get(), ref5.get(), 0.0);
+        GKO_EXPECT_MTX_NEAR(sub_mat5, ref5, 0.0);
     }
     {
         auto sub_mat7 = mat->create_submatrix(gko::span(0, 1), gko::span(0, 1));
         auto ref7 = gko::initialize<Mtx>({I<T>{1.0}}, this->exec);
 
-        GKO_EXPECT_MTX_NEAR(sub_mat7.get(), ref7.get(), 0.0);
+        GKO_EXPECT_MTX_NEAR(sub_mat7, ref7, 0.0);
     }
 }
 
@@ -1795,7 +1794,7 @@ TYPED_TEST(Csr, CanGetSubmatrixWithindex_set)
         auto sub_mat1 = mat->create_submatrix(row_set, col_set);
         auto ref1 = Mtx::create(this->exec);
 
-        GKO_EXPECT_MTX_NEAR(sub_mat1.get(), ref1.get(), 0.0);
+        GKO_EXPECT_MTX_NEAR(sub_mat1, ref1, 0.0);
     }
 
     {
@@ -1805,7 +1804,7 @@ TYPED_TEST(Csr, CanGetSubmatrixWithindex_set)
         auto sub_mat1 = mat->create_submatrix(row_set, col_set);
         auto ref1 = Mtx::create(this->exec);
 
-        GKO_EXPECT_MTX_NEAR(sub_mat1.get(), ref1.get(), 0.0);
+        GKO_EXPECT_MTX_NEAR(sub_mat1, ref1, 0.0);
     }
 
     {
@@ -1826,7 +1825,7 @@ TYPED_TEST(Csr, CanGetSubmatrixWithindex_set)
             },
             this->exec);
 
-        GKO_EXPECT_MTX_NEAR(sub_mat1.get(), ref1.get(), 0.0);
+        GKO_EXPECT_MTX_NEAR(sub_mat1, ref1, 0.0);
     }
 
     {
@@ -1837,7 +1836,7 @@ TYPED_TEST(Csr, CanGetSubmatrixWithindex_set)
         auto ref1 =
             gko::initialize<Mtx>({I<T>{1.0, 3.0}, I<T>{1.0, 0.0}}, this->exec);
 
-        GKO_EXPECT_MTX_NEAR(sub_mat1.get(), ref1.get(), 0.0);
+        GKO_EXPECT_MTX_NEAR(sub_mat1, ref1, 0.0);
     }
 
     {
@@ -1849,7 +1848,7 @@ TYPED_TEST(Csr, CanGetSubmatrixWithindex_set)
             {I<T>{0.0, 7.5}, I<T>{3.0, 0.0}, I<T>{-1.0, 0.0}, I<T>{0.0, 3.5}},
             this->exec);
 
-        GKO_EXPECT_MTX_NEAR(sub_mat1.get(), ref1.get(), 0.0);
+        GKO_EXPECT_MTX_NEAR(sub_mat1, ref1, 0.0);
     }
 
     {
@@ -1861,7 +1860,7 @@ TYPED_TEST(Csr, CanGetSubmatrixWithindex_set)
             {I<T>{1.0, 0.0, 7.5}, I<T>{0.0, -1.0, 0.0}, I<T>{1.0, 0.0, 3.5}},
             this->exec);
 
-        GKO_EXPECT_MTX_NEAR(sub_mat1.get(), ref1.get(), 0.0);
+        GKO_EXPECT_MTX_NEAR(sub_mat1, ref1, 0.0);
     }
 
     {
@@ -1877,7 +1876,7 @@ TYPED_TEST(Csr, CanGetSubmatrixWithindex_set)
                                           I<T>{0.0, 3.0, 7.5, 1.0}},  // 6
                                          this->exec);
 
-        GKO_EXPECT_MTX_NEAR(sub_mat1.get(), ref1.get(), 0.0);
+        GKO_EXPECT_MTX_NEAR(sub_mat1, ref1, 0.0);
     }
 
     {
@@ -1889,7 +1888,7 @@ TYPED_TEST(Csr, CanGetSubmatrixWithindex_set)
                                           I<T>{0.0, 3.0, 7.5, 1.0}},  // 6
                                          this->exec);
 
-        GKO_EXPECT_MTX_NEAR(sub_mat1.get(), ref1.get(), 0.0);
+        GKO_EXPECT_MTX_NEAR(sub_mat1, ref1, 0.0);
     }
 }
 

--- a/reference/test/matrix/dense_kernels.cpp
+++ b/reference/test/matrix/dense_kernels.cpp
@@ -125,7 +125,7 @@ TYPED_TEST(Dense, CopyRespectsStride)
     auto original_data = m2->get_values();
     original_data[1] = TypeParam{3.0};
 
-    m->convert_to(m2.get());
+    m->convert_to(m2);
 
     EXPECT_EQ(m2->at(0, 0), value_type{1.0});
     EXPECT_EQ(m2->get_stride(), 2);
@@ -142,7 +142,7 @@ TYPED_TEST(Dense, TemporaryOutputCloneWorks)
     auto m = gko::initialize<gko::matrix::Dense<TypeParam>>({1.0, 2.0}, other);
 
     {
-        auto clone = gko::make_temporary_output_clone(this->exec, m.get());
+        auto clone = gko::make_temporary_output_clone(this->exec, m);
         clone->at(0) = 4.0;
         clone->at(1) = 5.0;
 
@@ -209,7 +209,7 @@ TYPED_TEST(Dense, AppliesToDense)
     T in_stride{-1};
     this->mtx3->get_values()[3] = in_stride;
 
-    this->mtx2->apply(this->mtx1.get(), this->mtx3.get());
+    this->mtx2->apply(this->mtx1, this->mtx3);
 
     EXPECT_EQ(this->mtx3->at(0, 0), T{-0.5});
     EXPECT_EQ(this->mtx3->at(0, 1), T{-0.5});
@@ -227,10 +227,10 @@ TYPED_TEST(Dense, AppliesToMixedDense)
     using MixedT = typename MixedMtx::value_type;
     auto mmtx1 = MixedMtx::create(this->exec);
     auto mmtx3 = MixedMtx::create(this->exec);
-    this->mtx1->convert_to(mmtx1.get());
-    this->mtx3->convert_to(mmtx3.get());
+    this->mtx1->convert_to(mmtx1);
+    this->mtx3->convert_to(mmtx3);
 
-    this->mtx2->apply(mmtx1.get(), mmtx3.get());
+    this->mtx2->apply(mmtx1, mmtx3);
 
     EXPECT_EQ(mmtx3->at(0, 0), MixedT{-0.5});
     EXPECT_EQ(mmtx3->at(0, 1), MixedT{-0.5});
@@ -250,8 +250,7 @@ TYPED_TEST(Dense, AppliesLinearCombinationToDense)
     T in_stride{-1};
     this->mtx3->get_values()[3] = in_stride;
 
-    this->mtx2->apply(alpha.get(), this->mtx1.get(), beta.get(),
-                      this->mtx3.get());
+    this->mtx2->apply(alpha, this->mtx1, beta, this->mtx3);
 
     EXPECT_EQ(this->mtx3->at(0, 0), T{2.5});
     EXPECT_EQ(this->mtx3->at(0, 1), T{4.5});
@@ -269,12 +268,12 @@ TYPED_TEST(Dense, AppliesLinearCombinationToMixedDense)
     using MixedT = typename MixedMtx::value_type;
     auto mmtx1 = MixedMtx::create(this->exec);
     auto mmtx3 = MixedMtx::create(this->exec);
-    this->mtx1->convert_to(mmtx1.get());
-    this->mtx3->convert_to(mmtx3.get());
+    this->mtx1->convert_to(mmtx1);
+    this->mtx3->convert_to(mmtx3);
     auto alpha = gko::initialize<MixedMtx>({-1.0}, this->exec);
     auto beta = gko::initialize<MixedMtx>({2.0}, this->exec);
 
-    this->mtx2->apply(alpha.get(), mmtx1.get(), beta.get(), mmtx3.get());
+    this->mtx2->apply(alpha, mmtx1, beta, mmtx3);
 
     EXPECT_EQ(mmtx3->at(0, 0), MixedT{2.5});
     EXPECT_EQ(mmtx3->at(0, 1), MixedT{4.5});
@@ -290,8 +289,7 @@ TYPED_TEST(Dense, ApplyFailsOnWrongInnerDimension)
     using Mtx = typename TestFixture::Mtx;
     auto res = Mtx::create(this->exec, gko::dim<2>{2});
 
-    ASSERT_THROW(this->mtx2->apply(this->mtx1.get(), res.get()),
-                 gko::DimensionMismatch);
+    ASSERT_THROW(this->mtx2->apply(this->mtx1, res), gko::DimensionMismatch);
 }
 
 
@@ -300,8 +298,7 @@ TYPED_TEST(Dense, ApplyFailsOnWrongNumberOfRows)
     using Mtx = typename TestFixture::Mtx;
     auto res = Mtx::create(this->exec, gko::dim<2>{3});
 
-    ASSERT_THROW(this->mtx1->apply(this->mtx2.get(), res.get()),
-                 gko::DimensionMismatch);
+    ASSERT_THROW(this->mtx1->apply(this->mtx2, res), gko::DimensionMismatch);
 }
 
 
@@ -310,8 +307,7 @@ TYPED_TEST(Dense, ApplyFailsOnWrongNumberOfCols)
     using Mtx = typename TestFixture::Mtx;
     auto res = Mtx::create(this->exec, gko::dim<2>{2}, 3);
 
-    ASSERT_THROW(this->mtx1->apply(this->mtx2.get(), res.get()),
-                 gko::DimensionMismatch);
+    ASSERT_THROW(this->mtx1->apply(this->mtx2, res), gko::DimensionMismatch);
 }
 
 
@@ -321,7 +317,7 @@ TYPED_TEST(Dense, ScalesData)
     using T = typename TestFixture::value_type;
     auto alpha = gko::initialize<Mtx>({I<T>{2.0, -2.0}}, this->exec);
 
-    this->mtx2->scale(alpha.get());
+    this->mtx2->scale(alpha);
 
     EXPECT_EQ(this->mtx2->at(0, 0), T{2.0});
     EXPECT_EQ(this->mtx2->at(0, 1), T{2.0});
@@ -337,7 +333,7 @@ TYPED_TEST(Dense, ScalesDataMixed)
     using T = typename TestFixture::value_type;
     auto alpha = gko::initialize<MixedMtx>({I<MixedT>{2.0, -2.0}}, this->exec);
 
-    this->mtx2->scale(alpha.get());
+    this->mtx2->scale(alpha);
 
     EXPECT_EQ(this->mtx2->at(0, 0), T{2.0});
     EXPECT_EQ(this->mtx2->at(0, 1), T{2.0});
@@ -352,7 +348,7 @@ TYPED_TEST(Dense, InvScalesData)
     using T = typename TestFixture::value_type;
     auto alpha = gko::initialize<Mtx>({I<T>{0.5, -0.5}}, this->exec);
 
-    this->mtx2->inv_scale(alpha.get());
+    this->mtx2->inv_scale(alpha);
 
     EXPECT_EQ(this->mtx2->at(0, 0), T{2.0});
     EXPECT_EQ(this->mtx2->at(0, 1), T{2.0});
@@ -367,7 +363,7 @@ TYPED_TEST(Dense, ScalesDataWithScalar)
     using T = typename TestFixture::value_type;
     auto alpha = gko::initialize<Mtx>({2.0}, this->exec);
 
-    this->mtx2->scale(alpha.get());
+    this->mtx2->scale(alpha);
 
     EXPECT_EQ(this->mtx2->at(0, 0), T{2.0});
     EXPECT_EQ(this->mtx2->at(0, 1), T{-2.0});
@@ -382,7 +378,7 @@ TYPED_TEST(Dense, InvScalesDataWithScalar)
     using T = typename TestFixture::value_type;
     auto alpha = gko::initialize<Mtx>({0.5}, this->exec);
 
-    this->mtx2->inv_scale(alpha.get());
+    this->mtx2->inv_scale(alpha);
 
     EXPECT_EQ(this->mtx2->at(0, 0), T{2.0});
     EXPECT_EQ(this->mtx2->at(0, 1), T{-2.0});
@@ -399,7 +395,7 @@ TYPED_TEST(Dense, ScalesDataWithStride)
     T in_stride{-1};
     this->mtx1->get_values()[3] = in_stride;
 
-    this->mtx1->scale(alpha.get());
+    this->mtx1->scale(alpha);
 
     EXPECT_EQ(this->mtx1->at(0, 0), T{-1.0});
     EXPECT_EQ(this->mtx1->at(0, 1), T{2.0});
@@ -419,7 +415,7 @@ TYPED_TEST(Dense, AddsScaled)
     T in_stride{-1};
     this->mtx1->get_values()[3] = in_stride;
 
-    this->mtx1->add_scaled(alpha.get(), this->mtx3.get());
+    this->mtx1->add_scaled(alpha, this->mtx3);
 
     EXPECT_EQ(this->mtx1->at(0, 0), T{3.0});
     EXPECT_EQ(this->mtx1->at(0, 1), T{4.0});
@@ -436,12 +432,12 @@ TYPED_TEST(Dense, AddsScaledMixed)
     using MixedMtx = typename TestFixture::MixedMtx;
     using T = typename TestFixture::value_type;
     auto mmtx3 = MixedMtx::create(this->exec);
-    this->mtx3->convert_to(mmtx3.get());
+    this->mtx3->convert_to(mmtx3);
     auto alpha = gko::initialize<MixedMtx>({{2.0, 1.0, -2.0}}, this->exec);
     T in_stride{-1};
     this->mtx1->get_values()[3] = in_stride;
 
-    this->mtx1->add_scaled(alpha.get(), this->mtx3.get());
+    this->mtx1->add_scaled(alpha, this->mtx3);
 
     EXPECT_EQ(this->mtx1->at(0, 0), T{3.0});
     EXPECT_EQ(this->mtx1->at(0, 1), T{4.0});
@@ -461,7 +457,7 @@ TYPED_TEST(Dense, SubtractsScaled)
     T in_stride{-1};
     this->mtx1->get_values()[3] = in_stride;
 
-    this->mtx1->sub_scaled(alpha.get(), this->mtx3.get());
+    this->mtx1->sub_scaled(alpha, this->mtx3);
 
     EXPECT_EQ(this->mtx1->at(0, 0), T{3.0});
     EXPECT_EQ(this->mtx1->at(0, 1), T{4.0});
@@ -481,7 +477,7 @@ TYPED_TEST(Dense, AddsScaledWithScalar)
     T in_stride{-1};
     this->mtx1->get_values()[3] = in_stride;
 
-    this->mtx1->add_scaled(alpha.get(), this->mtx3.get());
+    this->mtx1->add_scaled(alpha, this->mtx3);
 
     EXPECT_EQ(this->mtx1->at(0, 0), T{3.0});
     EXPECT_EQ(this->mtx1->at(0, 1), T{6.0});
@@ -498,7 +494,7 @@ TYPED_TEST(Dense, AddScaledFailsOnWrongSizes)
     using Mtx = typename TestFixture::Mtx;
     auto alpha = Mtx::create(this->exec, gko::dim<2>{1, 2});
 
-    ASSERT_THROW(this->mtx1->add_scaled(alpha.get(), this->mtx2.get()),
+    ASSERT_THROW(this->mtx1->add_scaled(alpha, this->mtx2),
                  gko::DimensionMismatch);
 }
 
@@ -510,7 +506,7 @@ TYPED_TEST(Dense, AddsScaledDiag)
     auto alpha = gko::initialize<Mtx>({2.0}, this->exec);
     auto diag = gko::matrix::Diagonal<T>::create(this->exec, 2, I<T>{3.0, 2.0});
 
-    this->mtx2->add_scaled(alpha.get(), diag.get());
+    this->mtx2->add_scaled(alpha, diag);
 
     ASSERT_EQ(this->mtx2->at(0, 0), T{7.0});
     ASSERT_EQ(this->mtx2->at(0, 1), T{-1.0});
@@ -526,7 +522,7 @@ TYPED_TEST(Dense, SubtractsScaledDiag)
     auto alpha = gko::initialize<Mtx>({-2.0}, this->exec);
     auto diag = gko::matrix::Diagonal<T>::create(this->exec, 2, I<T>{3.0, 2.0});
 
-    this->mtx2->sub_scaled(alpha.get(), diag.get());
+    this->mtx2->sub_scaled(alpha, diag);
 
     ASSERT_EQ(this->mtx2->at(0, 0), T{7.0});
     ASSERT_EQ(this->mtx2->at(0, 1), T{-1.0});
@@ -541,7 +537,7 @@ TYPED_TEST(Dense, ComputesDot)
     using T = typename TestFixture::value_type;
     auto result = Mtx::create(this->exec, gko::dim<2>{1, 3});
 
-    this->mtx1->compute_dot(this->mtx3.get(), result.get());
+    this->mtx1->compute_dot(this->mtx3, result);
 
     EXPECT_EQ(result->at(0, 0), T{1.75});
     EXPECT_EQ(result->at(0, 1), T{7.75});
@@ -554,10 +550,10 @@ TYPED_TEST(Dense, ComputesDotMixed)
     using MixedMtx = typename TestFixture::MixedMtx;
     using MixedT = typename MixedMtx::value_type;
     auto mmtx3 = MixedMtx::create(this->exec);
-    this->mtx3->convert_to(mmtx3.get());
+    this->mtx3->convert_to(mmtx3);
     auto result = MixedMtx::create(this->exec, gko::dim<2>{1, 3});
 
-    this->mtx1->compute_dot(this->mtx3.get(), result.get());
+    this->mtx1->compute_dot(this->mtx3, result);
 
     EXPECT_EQ(result->at(0, 0), MixedT{1.75});
     EXPECT_EQ(result->at(0, 1), MixedT{7.75});
@@ -571,7 +567,7 @@ TYPED_TEST(Dense, ComputesConjDot)
     using T = typename TestFixture::value_type;
     auto result = Mtx::create(this->exec, gko::dim<2>{1, 3});
 
-    this->mtx1->compute_conj_dot(this->mtx3.get(), result.get());
+    this->mtx1->compute_conj_dot(this->mtx3, result);
 
     EXPECT_EQ(result->at(0, 0), T{1.75});
     EXPECT_EQ(result->at(0, 1), T{7.75});
@@ -584,10 +580,10 @@ TYPED_TEST(Dense, ComputesConjDotMixed)
     using MixedMtx = typename TestFixture::MixedMtx;
     using MixedT = typename MixedMtx::value_type;
     auto mmtx3 = MixedMtx::create(this->exec);
-    this->mtx3->convert_to(mmtx3.get());
+    this->mtx3->convert_to(mmtx3);
     auto result = MixedMtx::create(this->exec, gko::dim<2>{1, 3});
 
-    this->mtx1->compute_conj_dot(this->mtx3.get(), result.get());
+    this->mtx1->compute_conj_dot(this->mtx3, result);
 
     EXPECT_EQ(result->at(0, 0), MixedT{1.75});
     EXPECT_EQ(result->at(0, 1), MixedT{7.75});
@@ -605,7 +601,7 @@ TYPED_TEST(Dense, ComputesNorm2)
         {I<T>{1.0, 0.0}, I<T>{2.0, 3.0}, I<T>{2.0, 4.0}}, this->exec));
     auto result = NormVector::create(this->exec, gko::dim<2>{1, 2});
 
-    mtx->compute_norm2(result.get());
+    mtx->compute_norm2(result);
 
     EXPECT_EQ(result->at(0, 0), T_nc{3.0});
     EXPECT_EQ(result->at(0, 1), T_nc{5.0});
@@ -624,7 +620,7 @@ TYPED_TEST(Dense, ComputesNorm2Mixed)
         {I<T>{1.0, 0.0}, I<T>{2.0, 3.0}, I<T>{2.0, 4.0}}, this->exec));
     auto result = MixedNormVector::create(this->exec, gko::dim<2>{1, 2});
 
-    mtx->compute_norm2(result.get());
+    mtx->compute_norm2(result);
 
     EXPECT_EQ(result->at(0, 0), MixedT_nc{3.0});
     EXPECT_EQ(result->at(0, 1), MixedT_nc{5.0});
@@ -678,7 +674,7 @@ TYPED_TEST(Dense, ComputesNorm1)
         this->exec));
     auto result = NormVector::create(this->exec, gko::dim<2>{1, 2});
 
-    mtx->compute_norm1(result.get());
+    mtx->compute_norm1(result);
 
     EXPECT_EQ(result->at(0, 0), T_nc{6.0});
     EXPECT_EQ(result->at(0, 1), T_nc{8.0});
@@ -697,7 +693,7 @@ TYPED_TEST(Dense, ComputesNorm1Mixed)
                                   this->exec));
     auto result = MixedNormVector::create(this->exec, gko::dim<2>{1, 2});
 
-    mtx->compute_norm1(result.get());
+    mtx->compute_norm1(result);
 
     EXPECT_EQ(result->at(0, 0), MixedT_nc{6.0});
     EXPECT_EQ(result->at(0, 1), MixedT_nc{8.0});
@@ -709,7 +705,7 @@ TYPED_TEST(Dense, ComputeDotFailsOnWrongInputSize)
     using Mtx = typename TestFixture::Mtx;
     auto result = Mtx::create(this->exec, gko::dim<2>{1, 3});
 
-    ASSERT_THROW(this->mtx1->compute_dot(this->mtx2.get(), result.get()),
+    ASSERT_THROW(this->mtx1->compute_dot(this->mtx2, result),
                  gko::DimensionMismatch);
 }
 
@@ -719,7 +715,7 @@ TYPED_TEST(Dense, ComputeDotFailsOnWrongResultSize)
     using Mtx = typename TestFixture::Mtx;
     auto result = Mtx::create(this->exec, gko::dim<2>{1, 2});
 
-    ASSERT_THROW(this->mtx1->compute_dot(this->mtx3.get(), result.get()),
+    ASSERT_THROW(this->mtx1->compute_dot(this->mtx3, result),
                  gko::DimensionMismatch);
 }
 
@@ -729,7 +725,7 @@ TYPED_TEST(Dense, ComputeConjDotFailsOnWrongInputSize)
     using Mtx = typename TestFixture::Mtx;
     auto result = Mtx::create(this->exec, gko::dim<2>{1, 3});
 
-    ASSERT_THROW(this->mtx1->compute_conj_dot(this->mtx2.get(), result.get()),
+    ASSERT_THROW(this->mtx1->compute_conj_dot(this->mtx2, result),
                  gko::DimensionMismatch);
 }
 
@@ -739,7 +735,7 @@ TYPED_TEST(Dense, ComputeConjDotFailsOnWrongResultSize)
     using Mtx = typename TestFixture::Mtx;
     auto result = Mtx::create(this->exec, gko::dim<2>{1, 2});
 
-    ASSERT_THROW(this->mtx1->compute_conj_dot(this->mtx3.get(), result.get()),
+    ASSERT_THROW(this->mtx1->compute_conj_dot(this->mtx3, result),
                  gko::DimensionMismatch);
 }
 
@@ -757,8 +753,8 @@ TYPED_TEST(Dense, ConvertsToPrecision)
                         ? gko::remove_complex<T>{0}
                         : gko::remove_complex<T>{r<OtherT>::value};
 
-    this->mtx1->convert_to(tmp.get());
-    tmp->convert_to(res.get());
+    this->mtx1->convert_to(tmp);
+    tmp->convert_to(res);
 
     GKO_ASSERT_MTX_NEAR(this->mtx1, res, residual);
 }
@@ -777,8 +773,8 @@ TYPED_TEST(Dense, MovesToPrecision)
                         ? gko::remove_complex<T>{0}
                         : gko::remove_complex<T>{r<OtherT>::value};
 
-    this->mtx1->move_to(tmp.get());
-    tmp->move_to(res.get());
+    this->mtx1->move_to(tmp);
+    tmp->move_to(res);
 
     GKO_ASSERT_MTX_NEAR(this->mtx1, res, residual);
 }
@@ -790,7 +786,7 @@ TYPED_TEST(Dense, ConvertsToCoo32)
     using Coo = typename gko::matrix::Coo<T, gko::int32>;
     auto coo_mtx = Coo::create(this->mtx4->get_executor());
 
-    this->mtx4->convert_to(coo_mtx.get());
+    this->mtx4->convert_to(coo_mtx);
     auto v = coo_mtx->get_const_values();
     auto c = coo_mtx->get_const_col_idxs();
     auto r = coo_mtx->get_const_row_idxs();
@@ -818,7 +814,7 @@ TYPED_TEST(Dense, MovesToCoo32)
     using Coo = typename gko::matrix::Coo<T, gko::int32>;
     auto coo_mtx = Coo::create(this->mtx4->get_executor());
 
-    this->mtx4->move_to(coo_mtx.get());
+    this->mtx4->move_to(coo_mtx);
     auto v = coo_mtx->get_const_values();
     auto c = coo_mtx->get_const_col_idxs();
     auto r = coo_mtx->get_const_row_idxs();
@@ -846,7 +842,7 @@ TYPED_TEST(Dense, ConvertsToCoo64)
     using Coo = typename gko::matrix::Coo<T, gko::int64>;
     auto coo_mtx = Coo::create(this->mtx4->get_executor());
 
-    this->mtx4->convert_to(coo_mtx.get());
+    this->mtx4->convert_to(coo_mtx);
     auto v = coo_mtx->get_const_values();
     auto c = coo_mtx->get_const_col_idxs();
     auto r = coo_mtx->get_const_row_idxs();
@@ -874,7 +870,7 @@ TYPED_TEST(Dense, MovesToCoo64)
     using Coo = typename gko::matrix::Coo<T, gko::int64>;
     auto coo_mtx = Coo::create(this->mtx4->get_executor());
 
-    this->mtx4->move_to(coo_mtx.get());
+    this->mtx4->move_to(coo_mtx);
     auto v = coo_mtx->get_const_values();
     auto c = coo_mtx->get_const_col_idxs();
     auto r = coo_mtx->get_const_row_idxs();
@@ -905,8 +901,8 @@ TYPED_TEST(Dense, ConvertsToCsr32)
     auto csr_mtx_c = Csr::create(this->mtx4->get_executor(), csr_s_classical);
     auto csr_mtx_m = Csr::create(this->mtx4->get_executor(), csr_s_merge);
 
-    this->mtx4->convert_to(csr_mtx_c.get());
-    this->mtx4->convert_to(csr_mtx_m.get());
+    this->mtx4->convert_to(csr_mtx_c);
+    this->mtx4->convert_to(csr_mtx_m);
 
     auto v = csr_mtx_c->get_const_values();
     auto c = csr_mtx_c->get_const_col_idxs();
@@ -925,7 +921,7 @@ TYPED_TEST(Dense, ConvertsToCsr32)
     EXPECT_EQ(v[2], T{2.0});
     EXPECT_EQ(v[3], T{5.0});
     ASSERT_EQ(csr_mtx_c->get_strategy()->get_name(), "classical");
-    GKO_ASSERT_MTX_NEAR(csr_mtx_c.get(), csr_mtx_m.get(), 0.0);
+    GKO_ASSERT_MTX_NEAR(csr_mtx_c, csr_mtx_m, 0.0);
     ASSERT_EQ(csr_mtx_m->get_strategy()->get_name(), "merge_path");
 }
 
@@ -940,8 +936,8 @@ TYPED_TEST(Dense, MovesToCsr32)
     auto csr_mtx_m = Csr::create(this->mtx4->get_executor(), csr_s_merge);
     auto mtx_clone = this->mtx4->clone();
 
-    this->mtx4->move_to(csr_mtx_c.get());
-    mtx_clone->move_to(csr_mtx_m.get());
+    this->mtx4->move_to(csr_mtx_c);
+    mtx_clone->move_to(csr_mtx_m);
 
     auto v = csr_mtx_c->get_const_values();
     auto c = csr_mtx_c->get_const_col_idxs();
@@ -960,7 +956,7 @@ TYPED_TEST(Dense, MovesToCsr32)
     EXPECT_EQ(v[2], T{2.0});
     EXPECT_EQ(v[3], T{5.0});
     ASSERT_EQ(csr_mtx_c->get_strategy()->get_name(), "classical");
-    GKO_ASSERT_MTX_NEAR(csr_mtx_c.get(), csr_mtx_m.get(), 0.0);
+    GKO_ASSERT_MTX_NEAR(csr_mtx_c, csr_mtx_m, 0.0);
     ASSERT_EQ(csr_mtx_m->get_strategy()->get_name(), "merge_path");
 }
 
@@ -974,8 +970,8 @@ TYPED_TEST(Dense, ConvertsToCsr64)
     auto csr_mtx_c = Csr::create(this->mtx4->get_executor(), csr_s_classical);
     auto csr_mtx_m = Csr::create(this->mtx4->get_executor(), csr_s_merge);
 
-    this->mtx4->convert_to(csr_mtx_c.get());
-    this->mtx4->convert_to(csr_mtx_m.get());
+    this->mtx4->convert_to(csr_mtx_c);
+    this->mtx4->convert_to(csr_mtx_m);
 
     auto v = csr_mtx_c->get_const_values();
     auto c = csr_mtx_c->get_const_col_idxs();
@@ -994,7 +990,7 @@ TYPED_TEST(Dense, ConvertsToCsr64)
     EXPECT_EQ(v[2], T{2.0});
     EXPECT_EQ(v[3], T{5.0});
     ASSERT_EQ(csr_mtx_c->get_strategy()->get_name(), "classical");
-    GKO_ASSERT_MTX_NEAR(csr_mtx_c.get(), csr_mtx_m.get(), 0.0);
+    GKO_ASSERT_MTX_NEAR(csr_mtx_c, csr_mtx_m, 0.0);
     ASSERT_EQ(csr_mtx_m->get_strategy()->get_name(), "merge_path");
 }
 
@@ -1009,8 +1005,8 @@ TYPED_TEST(Dense, MovesToCsr64)
     auto csr_mtx_m = Csr::create(this->mtx4->get_executor(), csr_s_merge);
     auto mtx_clone = this->mtx4->clone();
 
-    this->mtx4->move_to(csr_mtx_c.get());
-    mtx_clone->move_to(csr_mtx_m.get());
+    this->mtx4->move_to(csr_mtx_c);
+    mtx_clone->move_to(csr_mtx_m);
 
     auto v = csr_mtx_c->get_const_values();
     auto c = csr_mtx_c->get_const_col_idxs();
@@ -1029,7 +1025,7 @@ TYPED_TEST(Dense, MovesToCsr64)
     EXPECT_EQ(v[2], T{2.0});
     EXPECT_EQ(v[3], T{5.0});
     ASSERT_EQ(csr_mtx_c->get_strategy()->get_name(), "classical");
-    GKO_ASSERT_MTX_NEAR(csr_mtx_c.get(), csr_mtx_m.get(), 0.0);
+    GKO_ASSERT_MTX_NEAR(csr_mtx_c, csr_mtx_m, 0.0);
     ASSERT_EQ(csr_mtx_m->get_strategy()->get_name(), "merge_path");
 }
 
@@ -1040,7 +1036,7 @@ TYPED_TEST(Dense, ConvertsToSparsityCsr32)
     using SparsityCsr = typename gko::matrix::SparsityCsr<T, gko::int32>;
     auto sparsity_csr_mtx = SparsityCsr::create(this->mtx4->get_executor());
 
-    this->mtx4->convert_to(sparsity_csr_mtx.get());
+    this->mtx4->convert_to(sparsity_csr_mtx);
     auto v = sparsity_csr_mtx->get_const_value();
     auto c = sparsity_csr_mtx->get_const_col_idxs();
     auto r = sparsity_csr_mtx->get_const_row_ptrs();
@@ -1064,7 +1060,7 @@ TYPED_TEST(Dense, MovesToSparsityCsr32)
     using SparsityCsr = typename gko::matrix::SparsityCsr<T, gko::int32>;
     auto sparsity_csr_mtx = SparsityCsr::create(this->mtx4->get_executor());
 
-    this->mtx4->move_to(sparsity_csr_mtx.get());
+    this->mtx4->move_to(sparsity_csr_mtx);
     auto v = sparsity_csr_mtx->get_const_value();
     auto c = sparsity_csr_mtx->get_const_col_idxs();
     auto r = sparsity_csr_mtx->get_const_row_ptrs();
@@ -1088,7 +1084,7 @@ TYPED_TEST(Dense, ConvertsToSparsityCsr64)
     using SparsityCsr = typename gko::matrix::SparsityCsr<T, gko::int64>;
     auto sparsity_csr_mtx = SparsityCsr::create(this->mtx4->get_executor());
 
-    this->mtx4->convert_to(sparsity_csr_mtx.get());
+    this->mtx4->convert_to(sparsity_csr_mtx);
     auto v = sparsity_csr_mtx->get_const_value();
     auto c = sparsity_csr_mtx->get_const_col_idxs();
     auto r = sparsity_csr_mtx->get_const_row_ptrs();
@@ -1112,7 +1108,7 @@ TYPED_TEST(Dense, MovesToSparsityCsr64)
     using SparsityCsr = typename gko::matrix::SparsityCsr<T, gko::int64>;
     auto sparsity_csr_mtx = SparsityCsr::create(this->mtx4->get_executor());
 
-    this->mtx4->move_to(sparsity_csr_mtx.get());
+    this->mtx4->move_to(sparsity_csr_mtx);
     auto v = sparsity_csr_mtx->get_const_value();
     auto c = sparsity_csr_mtx->get_const_col_idxs();
     auto r = sparsity_csr_mtx->get_const_row_ptrs();
@@ -1136,7 +1132,7 @@ TYPED_TEST(Dense, ConvertsToEll32)
     using Ell = typename gko::matrix::Ell<T, gko::int32>;
     auto ell_mtx = Ell::create(this->mtx6->get_executor());
 
-    this->mtx6->convert_to(ell_mtx.get());
+    this->mtx6->convert_to(ell_mtx);
     auto v = ell_mtx->get_const_values();
     auto c = ell_mtx->get_const_col_idxs();
 
@@ -1161,7 +1157,7 @@ TYPED_TEST(Dense, MovesToEll32)
     using Ell = typename gko::matrix::Ell<T, gko::int32>;
     auto ell_mtx = Ell::create(this->mtx6->get_executor());
 
-    this->mtx6->move_to(ell_mtx.get());
+    this->mtx6->move_to(ell_mtx);
     auto v = ell_mtx->get_const_values();
     auto c = ell_mtx->get_const_col_idxs();
 
@@ -1186,7 +1182,7 @@ TYPED_TEST(Dense, ConvertsToEll64)
     using Ell = typename gko::matrix::Ell<T, gko::int64>;
     auto ell_mtx = Ell::create(this->mtx6->get_executor());
 
-    this->mtx6->convert_to(ell_mtx.get());
+    this->mtx6->convert_to(ell_mtx);
     auto v = ell_mtx->get_const_values();
     auto c = ell_mtx->get_const_col_idxs();
 
@@ -1211,7 +1207,7 @@ TYPED_TEST(Dense, MovesToEll64)
     using Ell = typename gko::matrix::Ell<T, gko::int64>;
     auto ell_mtx = Ell::create(this->mtx6->get_executor());
 
-    this->mtx6->move_to(ell_mtx.get());
+    this->mtx6->move_to(ell_mtx);
     auto v = ell_mtx->get_const_values();
     auto c = ell_mtx->get_const_col_idxs();
 
@@ -1237,7 +1233,7 @@ TYPED_TEST(Dense, ConvertsToEllWithStride)
     auto ell_mtx =
         Ell::create(this->mtx6->get_executor(), gko::dim<2>{2, 3}, 2, 3);
 
-    this->mtx6->convert_to(ell_mtx.get());
+    this->mtx6->convert_to(ell_mtx);
     auto v = ell_mtx->get_const_values();
     auto c = ell_mtx->get_const_col_idxs();
 
@@ -1267,7 +1263,7 @@ TYPED_TEST(Dense, MovesToEllWithStride)
     auto ell_mtx =
         Ell::create(this->mtx6->get_executor(), gko::dim<2>{2, 3}, 2, 3);
 
-    this->mtx6->move_to(ell_mtx.get());
+    this->mtx6->move_to(ell_mtx);
     auto v = ell_mtx->get_const_values();
     auto c = ell_mtx->get_const_col_idxs();
 
@@ -1296,7 +1292,7 @@ TYPED_TEST(Dense, MovesToHybridAutomatically32)
     using Hybrid = typename gko::matrix::Hybrid<T, gko::int32>;
     auto hybrid_mtx = Hybrid::create(this->mtx4->get_executor());
 
-    this->mtx4->move_to(hybrid_mtx.get());
+    this->mtx4->move_to(hybrid_mtx);
     auto v = hybrid_mtx->get_const_coo_values();
     auto c = hybrid_mtx->get_const_coo_col_idxs();
     auto r = hybrid_mtx->get_const_coo_row_idxs();
@@ -1329,7 +1325,7 @@ TYPED_TEST(Dense, ConvertsToHybridAutomatically32)
     using Hybrid = typename gko::matrix::Hybrid<T, gko::int32>;
     auto hybrid_mtx = Hybrid::create(this->mtx4->get_executor());
 
-    this->mtx4->convert_to(hybrid_mtx.get());
+    this->mtx4->convert_to(hybrid_mtx);
     auto v = hybrid_mtx->get_const_coo_values();
     auto c = hybrid_mtx->get_const_coo_col_idxs();
     auto r = hybrid_mtx->get_const_coo_row_idxs();
@@ -1362,7 +1358,7 @@ TYPED_TEST(Dense, MovesToHybridAutomatically64)
     using Hybrid = typename gko::matrix::Hybrid<T, gko::int64>;
     auto hybrid_mtx = Hybrid::create(this->mtx4->get_executor());
 
-    this->mtx4->move_to(hybrid_mtx.get());
+    this->mtx4->move_to(hybrid_mtx);
     auto v = hybrid_mtx->get_const_coo_values();
     auto c = hybrid_mtx->get_const_coo_col_idxs();
     auto r = hybrid_mtx->get_const_coo_row_idxs();
@@ -1395,7 +1391,7 @@ TYPED_TEST(Dense, ConvertsToHybridAutomatically64)
     using Hybrid = typename gko::matrix::Hybrid<T, gko::int64>;
     auto hybrid_mtx = Hybrid::create(this->mtx4->get_executor());
 
-    this->mtx4->convert_to(hybrid_mtx.get());
+    this->mtx4->convert_to(hybrid_mtx);
     auto v = hybrid_mtx->get_const_coo_values();
     auto c = hybrid_mtx->get_const_coo_col_idxs();
     auto r = hybrid_mtx->get_const_coo_row_idxs();
@@ -1429,7 +1425,7 @@ TYPED_TEST(Dense, MovesToHybridWithStrideAutomatically)
     auto hybrid_mtx =
         Hybrid::create(this->mtx4->get_executor(), gko::dim<2>{2, 3}, 0, 3);
 
-    this->mtx4->move_to(hybrid_mtx.get());
+    this->mtx4->move_to(hybrid_mtx);
     auto v = hybrid_mtx->get_const_coo_values();
     auto c = hybrid_mtx->get_const_coo_col_idxs();
     auto r = hybrid_mtx->get_const_coo_row_idxs();
@@ -1463,7 +1459,7 @@ TYPED_TEST(Dense, ConvertsToHybridWithStrideAutomatically)
     auto hybrid_mtx =
         Hybrid::create(this->mtx4->get_executor(), gko::dim<2>{2, 3}, 0, 3);
 
-    this->mtx4->convert_to(hybrid_mtx.get());
+    this->mtx4->convert_to(hybrid_mtx);
     auto v = hybrid_mtx->get_const_coo_values();
     auto c = hybrid_mtx->get_const_coo_col_idxs();
     auto r = hybrid_mtx->get_const_coo_row_idxs();
@@ -1498,7 +1494,7 @@ TYPED_TEST(Dense, MovesToHybridWithStrideAndCooLengthByColumns2)
         Hybrid::create(this->mtx4->get_executor(), gko::dim<2>{2, 3}, 2, 3, 3,
                        std::make_shared<typename Hybrid::column_limit>(2));
 
-    this->mtx4->move_to(hybrid_mtx.get());
+    this->mtx4->move_to(hybrid_mtx);
     auto v = hybrid_mtx->get_const_ell_values();
     auto c = hybrid_mtx->get_const_ell_col_idxs();
     auto n = hybrid_mtx->get_ell_num_stored_elements_per_row();
@@ -1535,7 +1531,7 @@ TYPED_TEST(Dense, ConvertsToHybridWithStrideAndCooLengthByColumns2)
         Hybrid::create(this->mtx4->get_executor(), gko::dim<2>{2, 3}, 2, 3, 3,
                        std::make_shared<typename Hybrid::column_limit>(2));
 
-    this->mtx4->convert_to(hybrid_mtx.get());
+    this->mtx4->convert_to(hybrid_mtx);
     auto v = hybrid_mtx->get_const_ell_values();
     auto c = hybrid_mtx->get_const_ell_col_idxs();
     auto n = hybrid_mtx->get_ell_num_stored_elements_per_row();
@@ -1572,7 +1568,7 @@ TYPED_TEST(Dense, MovesToHybridWithStrideByPercent40)
         Hybrid::create(this->mtx4->get_executor(), gko::dim<2>{2, 3}, 1, 3,
                        std::make_shared<typename Hybrid::imbalance_limit>(0.4));
 
-    this->mtx4->move_to(hybrid_mtx.get());
+    this->mtx4->move_to(hybrid_mtx);
     auto v = hybrid_mtx->get_const_ell_values();
     auto c = hybrid_mtx->get_const_ell_col_idxs();
     auto n = hybrid_mtx->get_ell_num_stored_elements_per_row();
@@ -1609,7 +1605,7 @@ TYPED_TEST(Dense, ConvertsToHybridWithStrideByPercent40)
         Hybrid::create(this->mtx4->get_executor(), gko::dim<2>{2, 3}, 1, 3,
                        std::make_shared<typename Hybrid::imbalance_limit>(0.4));
 
-    this->mtx4->convert_to(hybrid_mtx.get());
+    this->mtx4->convert_to(hybrid_mtx);
     auto v = hybrid_mtx->get_const_ell_values();
     auto c = hybrid_mtx->get_const_ell_col_idxs();
     auto n = hybrid_mtx->get_ell_num_stored_elements_per_row();
@@ -1644,7 +1640,7 @@ TYPED_TEST(Dense, ConvertsToSellp32)
     using Sellp = typename gko::matrix::Sellp<T, gko::int32>;
     auto sellp_mtx = Sellp::create(this->mtx7->get_executor());
 
-    this->mtx7->convert_to(sellp_mtx.get());
+    this->mtx7->convert_to(sellp_mtx);
     auto v = sellp_mtx->get_const_values();
     auto c = sellp_mtx->get_const_col_idxs();
     auto s = sellp_mtx->get_const_slice_sets();
@@ -1681,7 +1677,7 @@ TYPED_TEST(Dense, MovesToSellp32)
     using Sellp = typename gko::matrix::Sellp<T, gko::int32>;
     auto sellp_mtx = Sellp::create(this->mtx7->get_executor());
 
-    this->mtx7->move_to(sellp_mtx.get());
+    this->mtx7->move_to(sellp_mtx);
     auto v = sellp_mtx->get_const_values();
     auto c = sellp_mtx->get_const_col_idxs();
     auto s = sellp_mtx->get_const_slice_sets();
@@ -1718,7 +1714,7 @@ TYPED_TEST(Dense, ConvertsToSellp64)
     using Sellp = typename gko::matrix::Sellp<T, gko::int64>;
     auto sellp_mtx = Sellp::create(this->mtx7->get_executor());
 
-    this->mtx7->convert_to(sellp_mtx.get());
+    this->mtx7->convert_to(sellp_mtx);
     auto v = sellp_mtx->get_const_values();
     auto c = sellp_mtx->get_const_col_idxs();
     auto s = sellp_mtx->get_const_slice_sets();
@@ -1755,7 +1751,7 @@ TYPED_TEST(Dense, MovesToSellp64)
     using Sellp = typename gko::matrix::Sellp<T, gko::int64>;
     auto sellp_mtx = Sellp::create(this->mtx7->get_executor());
 
-    this->mtx7->move_to(sellp_mtx.get());
+    this->mtx7->move_to(sellp_mtx);
     auto v = sellp_mtx->get_const_values();
     auto c = sellp_mtx->get_const_col_idxs();
     auto s = sellp_mtx->get_const_slice_sets();
@@ -1793,7 +1789,7 @@ TYPED_TEST(Dense, ConvertsToSellpWithSliceSizeAndStrideFactor)
     auto sellp_mtx =
         Sellp::create(this->mtx7->get_executor(), gko::dim<2>{}, 2, 2, 0);
 
-    this->mtx7->convert_to(sellp_mtx.get());
+    this->mtx7->convert_to(sellp_mtx);
     auto v = sellp_mtx->get_const_values();
     auto c = sellp_mtx->get_const_col_idxs();
     auto s = sellp_mtx->get_const_slice_sets();
@@ -1833,7 +1829,7 @@ TYPED_TEST(Dense, MovesToSellpWithSliceSizeAndStrideFactor)
     auto sellp_mtx =
         Sellp::create(this->mtx7->get_executor(), gko::dim<2>{}, 2, 2, 0);
 
-    this->mtx7->move_to(sellp_mtx.get());
+    this->mtx7->move_to(sellp_mtx);
     auto v = sellp_mtx->get_const_values();
     auto c = sellp_mtx->get_const_col_idxs();
     auto s = sellp_mtx->get_const_slice_sets();
@@ -1875,10 +1871,10 @@ TYPED_TEST(Dense, ConvertsToAndFromSellpWithMoreThanOneSlice)
 
     auto sellp_mtx = Sellp::create(this->exec);
     auto dense_mtx = Mtx::create(this->exec);
-    x->convert_to(sellp_mtx.get());
-    sellp_mtx->convert_to(dense_mtx.get());
+    x->convert_to(sellp_mtx);
+    sellp_mtx->convert_to(dense_mtx);
 
-    GKO_ASSERT_MTX_NEAR(dense_mtx.get(), x.get(), 0.0);
+    GKO_ASSERT_MTX_NEAR(dense_mtx, x, 0.0);
 }
 
 
@@ -1891,7 +1887,7 @@ TYPED_TEST(Dense, ConvertsEmptyToPrecision)
     auto empty = OtherDense::create(this->exec);
     auto res = Dense::create(this->exec);
 
-    empty->convert_to(res.get());
+    empty->convert_to(res);
 
     ASSERT_FALSE(res->get_size());
 }
@@ -1906,7 +1902,7 @@ TYPED_TEST(Dense, MovesEmptyToPrecision)
     auto empty = OtherDense::create(this->exec);
     auto res = Dense::create(this->exec);
 
-    empty->move_to(res.get());
+    empty->move_to(res);
 
     ASSERT_FALSE(res->get_size());
 }
@@ -1920,7 +1916,7 @@ TYPED_TEST(Dense, ConvertsEmptyToCoo)
     auto empty = Dense::create(this->exec);
     auto res = Coo::create(this->exec);
 
-    empty->convert_to(res.get());
+    empty->convert_to(res);
 
     ASSERT_EQ(res->get_num_stored_elements(), 0);
     ASSERT_FALSE(res->get_size());
@@ -1935,7 +1931,7 @@ TYPED_TEST(Dense, MovesEmptyToCoo)
     auto empty = Dense::create(this->exec);
     auto res = Coo::create(this->exec);
 
-    empty->move_to(res.get());
+    empty->move_to(res);
 
     ASSERT_EQ(res->get_num_stored_elements(), 0);
     ASSERT_FALSE(res->get_size());
@@ -1950,7 +1946,7 @@ TYPED_TEST(Dense, ConvertsEmptyMatrixToCsr)
     auto empty = Dense::create(this->exec);
     auto res = Csr::create(this->exec);
 
-    empty->convert_to(res.get());
+    empty->convert_to(res);
 
     ASSERT_EQ(res->get_num_stored_elements(), 0);
     ASSERT_EQ(*res->get_const_row_ptrs(), 0);
@@ -1966,7 +1962,7 @@ TYPED_TEST(Dense, MovesEmptyMatrixToCsr)
     auto empty = Dense::create(this->exec);
     auto res = Csr::create(this->exec);
 
-    empty->move_to(res.get());
+    empty->move_to(res);
 
     ASSERT_EQ(res->get_num_stored_elements(), 0);
     ASSERT_EQ(*res->get_const_row_ptrs(), 0);
@@ -1982,7 +1978,7 @@ TYPED_TEST(Dense, ConvertsEmptyToSparsityCsr)
     auto empty = Dense::create(this->exec);
     auto res = SparsityCsr::create(this->exec);
 
-    empty->convert_to(res.get());
+    empty->convert_to(res);
 
     ASSERT_EQ(res->get_num_nonzeros(), 0);
     ASSERT_EQ(*res->get_const_row_ptrs(), 0);
@@ -1998,7 +1994,7 @@ TYPED_TEST(Dense, MovesEmptyToSparsityCsr)
     auto empty = Dense::create(this->exec);
     auto res = SparsityCsr::create(this->exec);
 
-    empty->move_to(res.get());
+    empty->move_to(res);
 
     ASSERT_EQ(res->get_num_nonzeros(), 0);
     ASSERT_EQ(*res->get_const_row_ptrs(), 0);
@@ -2014,7 +2010,7 @@ TYPED_TEST(Dense, ConvertsEmptyToEll)
     auto empty = Dense::create(this->exec);
     auto res = Ell::create(this->exec);
 
-    empty->convert_to(res.get());
+    empty->convert_to(res);
 
     ASSERT_EQ(res->get_num_stored_elements(), 0);
     ASSERT_FALSE(res->get_size());
@@ -2029,7 +2025,7 @@ TYPED_TEST(Dense, MovesEmptyToEll)
     auto empty = Dense::create(this->exec);
     auto res = Ell::create(this->exec);
 
-    empty->move_to(res.get());
+    empty->move_to(res);
 
     ASSERT_EQ(res->get_num_stored_elements(), 0);
     ASSERT_FALSE(res->get_size());
@@ -2044,7 +2040,7 @@ TYPED_TEST(Dense, ConvertsEmptyToHybrid)
     auto empty = Dense::create(this->exec);
     auto res = Hybrid::create(this->exec);
 
-    empty->convert_to(res.get());
+    empty->convert_to(res);
 
     ASSERT_EQ(res->get_num_stored_elements(), 0);
     ASSERT_FALSE(res->get_size());
@@ -2059,7 +2055,7 @@ TYPED_TEST(Dense, MovesEmptyToHybrid)
     auto empty = Dense::create(this->exec);
     auto res = Hybrid::create(this->exec);
 
-    empty->move_to(res.get());
+    empty->move_to(res);
 
     ASSERT_EQ(res->get_num_stored_elements(), 0);
     ASSERT_FALSE(res->get_size());
@@ -2074,7 +2070,7 @@ TYPED_TEST(Dense, ConvertsEmptyToSellp)
     auto empty = Dense::create(this->exec);
     auto res = Sellp::create(this->exec);
 
-    empty->convert_to(res.get());
+    empty->convert_to(res);
 
     ASSERT_EQ(res->get_num_stored_elements(), 0);
     ASSERT_EQ(*res->get_const_slice_sets(), 0);
@@ -2090,7 +2086,7 @@ TYPED_TEST(Dense, MovesEmptyToSellp)
     auto empty = Dense::create(this->exec);
     auto res = Sellp::create(this->exec);
 
-    empty->move_to(res.get());
+    empty->move_to(res);
 
     ASSERT_EQ(res->get_num_stored_elements(), 0);
     ASSERT_EQ(*res->get_const_slice_sets(), 0);
@@ -2116,7 +2112,7 @@ TYPED_TEST(Dense, SquareMatrixIsTransposableIntoDense)
     using T = typename TestFixture::value_type;
     auto trans = Mtx::create(this->exec, this->mtx5->get_size());
 
-    this->mtx5->transpose(trans.get());
+    this->mtx5->transpose(trans);
 
     GKO_ASSERT_MTX_NEAR(
         trans, l<T>({{1.0, -2.0, 2.1}, {-1.0, 2.0, 3.4}, {-0.5, 4.5, 1.2}}),
@@ -2130,7 +2126,7 @@ TYPED_TEST(Dense, SquareSubmatrixIsTransposableIntoDense)
     using T = typename TestFixture::value_type;
     auto trans = Mtx::create(this->exec, gko::dim<2>{2, 2}, 4);
 
-    this->mtx5->create_submatrix({0, 2}, {0, 2})->transpose(trans.get());
+    this->mtx5->create_submatrix({0, 2}, {0, 2})->transpose(trans);
 
     GKO_ASSERT_MTX_NEAR(trans, l<T>({{1.0, -2.0}, {-1.0, 2.0}}), 0.0);
     ASSERT_EQ(trans->get_stride(), 4);
@@ -2141,7 +2137,7 @@ TYPED_TEST(Dense, SquareMatrixIsTransposableIntoDenseFailsForWrongDimensions)
 {
     using Mtx = typename TestFixture::Mtx;
 
-    ASSERT_THROW(this->mtx5->transpose(Mtx::create(this->exec).get()),
+    ASSERT_THROW(this->mtx5->transpose(Mtx::create(this->exec)),
                  gko::DimensionMismatch);
 }
 
@@ -2163,7 +2159,7 @@ TYPED_TEST(Dense, NonSquareMatrixIsTransposableIntoDense)
     auto trans =
         Mtx::create(this->exec, gko::transpose(this->mtx4->get_size()));
 
-    this->mtx4->transpose(trans.get());
+    this->mtx4->transpose(trans);
 
     GKO_ASSERT_MTX_NEAR(trans, l<T>({{1.0, 0.0}, {3.0, 5.0}, {2.0, 0.0}}), 0.0);
 }
@@ -2175,7 +2171,7 @@ TYPED_TEST(Dense, NonSquareSubmatrixIsTransposableIntoDense)
     using T = typename TestFixture::value_type;
     auto trans = Mtx::create(this->exec, gko::dim<2>{2, 1}, 5);
 
-    this->mtx4->create_submatrix({0, 1}, {0, 2})->transpose(trans.get());
+    this->mtx4->create_submatrix({0, 1}, {0, 2})->transpose(trans);
 
     GKO_ASSERT_MTX_NEAR(trans, l({1.0, 3.0}), 0.0);
     ASSERT_EQ(trans->get_stride(), 5);
@@ -2186,7 +2182,7 @@ TYPED_TEST(Dense, NonSquareMatrixIsTransposableIntoDenseFailsForWrongDimensions)
 {
     using Mtx = typename TestFixture::Mtx;
 
-    ASSERT_THROW(this->mtx4->transpose(Mtx::create(this->exec).get()),
+    ASSERT_THROW(this->mtx4->transpose(Mtx::create(this->exec)),
                  gko::DimensionMismatch);
 }
 
@@ -2213,7 +2209,7 @@ TYPED_TEST(Dense, SquareMatrixCanGatherRowsIntoDense)
     gko::array<gko::int32> permute_idxs{exec, {1, 0}};
     auto row_collection = Mtx::create(exec, gko::dim<2>{2, 3});
 
-    this->mtx5->row_gather(&permute_idxs, row_collection.get());
+    this->mtx5->row_gather(&permute_idxs, row_collection);
 
     GKO_ASSERT_MTX_NEAR(row_collection,
                         l<T>({{-2.0, 2.0, 4.5}, {1.0, -1.0, -0.5}}), 0.0);
@@ -2229,7 +2225,7 @@ TYPED_TEST(Dense, SquareSubmatrixCanGatherRowsIntoDense)
     auto row_collection = Mtx::create(exec, gko::dim<2>{2, 2}, 4);
 
     this->mtx5->create_submatrix({0, 2}, {1, 3})
-        ->row_gather(&permute_idxs, row_collection.get());
+        ->row_gather(&permute_idxs, row_collection);
 
     GKO_ASSERT_MTX_NEAR(row_collection, l<T>({{2.0, 4.5}, {-1.0, -0.5}}), 0.0);
     ASSERT_EQ(row_collection->get_stride(), 4);
@@ -2245,7 +2241,7 @@ TYPED_TEST(Dense, NonSquareSubmatrixCanGatherRowsIntoMixedDense)
     gko::array<gko::int32> gather_index{exec, {1, 0, 1}};
     auto row_collection = MixedMtx::create(exec, gko::dim<2>{3, 3}, 4);
 
-    this->mtx4->row_gather(&gather_index, row_collection.get());
+    this->mtx4->row_gather(&gather_index, row_collection);
 
     GKO_ASSERT_MTX_NEAR(
         row_collection,
@@ -2267,8 +2263,7 @@ TYPED_TEST(Dense, NonSquareSubmatrixCanAdvancedGatherRowsIntoMixedDense)
     auto alpha = gko::initialize<MixedMtx>({1.0}, exec);
     auto beta = gko::initialize<Mtx>({2.0}, exec);
 
-    this->mtx4->row_gather(alpha.get(), &gather_index, beta.get(),
-                           row_collection.get());
+    this->mtx4->row_gather(alpha, &gather_index, beta, row_collection);
 
     GKO_ASSERT_MTX_NEAR(
         row_collection,
@@ -2285,7 +2280,7 @@ TYPED_TEST(Dense, SquareMatrixGatherRowsIntoDenseFailsForWrongDimensions)
     auto exec = this->mtx5->get_executor();
     gko::array<gko::int32> permute_idxs{exec, {1, 0}};
 
-    ASSERT_THROW(this->mtx5->row_gather(&permute_idxs, Mtx::create(exec).get()),
+    ASSERT_THROW(this->mtx5->row_gather(&permute_idxs, Mtx::create(exec)),
                  gko::DimensionMismatch);
 }
 
@@ -2312,7 +2307,7 @@ TYPED_TEST(Dense, SquareMatrixCanGatherRowsIntoDense64)
     gko::array<gko::int64> permute_idxs{exec, {1, 0}};
     auto row_collection = Mtx::create(exec, gko::dim<2>{2, 3});
 
-    this->mtx5->row_gather(&permute_idxs, row_collection.get());
+    this->mtx5->row_gather(&permute_idxs, row_collection);
 
     GKO_ASSERT_MTX_NEAR(row_collection,
                         l<T>({{-2.0, 2.0, 4.5}, {1.0, -1.0, -0.5}}), 0.0);
@@ -2328,7 +2323,7 @@ TYPED_TEST(Dense, SquareSubmatrixCanGatherRowsIntoDense64)
     auto row_collection = Mtx::create(exec, gko::dim<2>{2, 2}, 4);
 
     this->mtx5->create_submatrix({0, 2}, {1, 3})
-        ->row_gather(&permute_idxs, row_collection.get());
+        ->row_gather(&permute_idxs, row_collection);
 
     GKO_ASSERT_MTX_NEAR(row_collection, l<T>({{2.0, 4.5}, {-1.0, -0.5}}), 0.0);
     ASSERT_EQ(row_collection->get_stride(), 4);
@@ -2344,7 +2339,7 @@ TYPED_TEST(Dense, NonSquareSubmatrixCanGatherRowsIntoMixedDense64)
     gko::array<gko::int64> gather_index{exec, {1, 0, 1}};
     auto row_collection = MixedMtx::create(exec, gko::dim<2>{3, 3}, 4);
 
-    this->mtx4->row_gather(&gather_index, row_collection.get());
+    this->mtx4->row_gather(&gather_index, row_collection);
 
     GKO_ASSERT_MTX_NEAR(
         row_collection,
@@ -2361,7 +2356,7 @@ TYPED_TEST(Dense, SquareMatrixGatherRowsIntoDenseFailsForWrongDimensions64)
     auto exec = this->mtx5->get_executor();
     gko::array<gko::int64> permute_idxs{exec, {1, 0}};
 
-    ASSERT_THROW(this->mtx5->row_gather(&permute_idxs, Mtx::create(exec).get()),
+    ASSERT_THROW(this->mtx5->row_gather(&permute_idxs, Mtx::create(exec)),
                  gko::DimensionMismatch);
 }
 
@@ -2391,7 +2386,7 @@ TYPED_TEST(Dense, SquareMatrixIsPermutableIntoDense)
     auto ref_permuted =
         gko::as<Mtx>(gko::as<Mtx>(this->mtx5->row_permute(&permute_idxs))
                          ->column_permute(&permute_idxs));
-    this->mtx5->permute(&permute_idxs, permuted.get());
+    this->mtx5->permute(&permute_idxs, permuted);
 
     GKO_ASSERT_MTX_NEAR(permuted, ref_permuted, 0.0);
 }
@@ -2408,7 +2403,7 @@ TYPED_TEST(Dense, SquareSubmatrixIsPermutableIntoDense)
     auto ref_permuted =
         gko::as<Mtx>(gko::as<Mtx>(mtx->row_permute(&permute_idxs))
                          ->column_permute(&permute_idxs));
-    mtx->permute(&permute_idxs, permuted.get());
+    mtx->permute(&permute_idxs, permuted);
 
     GKO_ASSERT_MTX_NEAR(permuted, ref_permuted, 0.0);
     ASSERT_EQ(permuted->get_stride(), 4);
@@ -2421,7 +2416,7 @@ TYPED_TEST(Dense, NonSquareMatrixPermuteIntoDenseFails)
     auto exec = this->mtx4->get_executor();
     gko::array<gko::int32> permute_idxs{exec, {1, 2, 0}};
 
-    ASSERT_THROW(this->mtx4->permute(&permute_idxs, this->mtx4->clone().get()),
+    ASSERT_THROW(this->mtx4->permute(&permute_idxs, this->mtx4->clone()),
                  gko::DimensionMismatch);
 }
 
@@ -2432,7 +2427,7 @@ TYPED_TEST(Dense, SquareMatrixPermuteIntoDenseFailsForWrongPermutationSize)
     auto exec = this->mtx5->get_executor();
     gko::array<gko::int32> permute_idxs{exec, {1, 2}};
 
-    ASSERT_THROW(this->mtx5->permute(&permute_idxs, this->mtx5->clone().get()),
+    ASSERT_THROW(this->mtx5->permute(&permute_idxs, this->mtx5->clone()),
                  gko::ValueMismatch);
 }
 
@@ -2443,7 +2438,7 @@ TYPED_TEST(Dense, SquareMatrixPermuteIntoDenseFailsForWrongDimensions)
     auto exec = this->mtx5->get_executor();
     gko::array<gko::int32> permute_idxs{exec, {1, 2, 0}};
 
-    ASSERT_THROW(this->mtx5->permute(&permute_idxs, Mtx::create(exec).get()),
+    ASSERT_THROW(this->mtx5->permute(&permute_idxs, Mtx::create(exec)),
                  gko::DimensionMismatch);
 }
 
@@ -2473,7 +2468,7 @@ TYPED_TEST(Dense, SquareMatrixIsInversePermutableIntoDense)
     auto ref_permuted = gko::as<Mtx>(
         gko::as<Mtx>(this->mtx5->inverse_row_permute(&permute_idxs))
             ->inverse_column_permute(&permute_idxs));
-    this->mtx5->inverse_permute(&permute_idxs, permuted.get());
+    this->mtx5->inverse_permute(&permute_idxs, permuted);
 
     GKO_ASSERT_MTX_NEAR(permuted, ref_permuted, 0.0);
 }
@@ -2490,7 +2485,7 @@ TYPED_TEST(Dense, SquareSubmatrixIsInversePermutableIntoDense)
     auto ref_permuted =
         gko::as<Mtx>(gko::as<Mtx>(mtx->inverse_row_permute(&permute_idxs))
                          ->inverse_column_permute(&permute_idxs));
-    mtx->inverse_permute(&permute_idxs, permuted.get());
+    mtx->inverse_permute(&permute_idxs, permuted);
 
     GKO_ASSERT_MTX_NEAR(permuted, ref_permuted, 0.0);
     ASSERT_EQ(permuted->get_stride(), 4);
@@ -2504,7 +2499,7 @@ TYPED_TEST(Dense, NonSquareMatrixInversePermuteIntoDenseFails)
     gko::array<gko::int32> permute_idxs{exec, {1, 2, 0}};
 
     ASSERT_THROW(
-        this->mtx4->inverse_permute(&permute_idxs, this->mtx4->clone().get()),
+        this->mtx4->inverse_permute(&permute_idxs, this->mtx4->clone()),
         gko::DimensionMismatch);
 }
 
@@ -2517,7 +2512,7 @@ TYPED_TEST(Dense,
     gko::array<gko::int32> permute_idxs{exec, {0, 1}};
 
     ASSERT_THROW(
-        this->mtx5->inverse_permute(&permute_idxs, this->mtx5->clone().get()),
+        this->mtx5->inverse_permute(&permute_idxs, this->mtx5->clone()),
         gko::ValueMismatch);
 }
 
@@ -2528,9 +2523,8 @@ TYPED_TEST(Dense, SquareMatrixInversePermuteIntoDenseFailsForWrongDimensions)
     auto exec = this->mtx5->get_executor();
     gko::array<gko::int32> permute_idxs{exec, {1, 2, 0}};
 
-    ASSERT_THROW(
-        this->mtx5->inverse_permute(&permute_idxs, Mtx::create(exec).get()),
-        gko::DimensionMismatch);
+    ASSERT_THROW(this->mtx5->inverse_permute(&permute_idxs, Mtx::create(exec)),
+                 gko::DimensionMismatch);
 }
 
 
@@ -2559,7 +2553,7 @@ TYPED_TEST(Dense, SquareMatrixIsPermutableIntoDense64)
     auto ref_permuted =
         gko::as<Mtx>(gko::as<Mtx>(this->mtx5->row_permute(&permute_idxs))
                          ->column_permute(&permute_idxs));
-    this->mtx5->permute(&permute_idxs, permuted.get());
+    this->mtx5->permute(&permute_idxs, permuted);
 
     GKO_ASSERT_MTX_NEAR(permuted, ref_permuted, 0.0);
 }
@@ -2576,7 +2570,7 @@ TYPED_TEST(Dense, SquareSubmatrixIsPermutableIntoDense64)
     auto ref_permuted =
         gko::as<Mtx>(gko::as<Mtx>(mtx->row_permute(&permute_idxs))
                          ->column_permute(&permute_idxs));
-    mtx->permute(&permute_idxs, permuted.get());
+    mtx->permute(&permute_idxs, permuted);
 
     GKO_ASSERT_MTX_NEAR(permuted, ref_permuted, 0.0);
     ASSERT_EQ(permuted->get_stride(), 4);
@@ -2589,7 +2583,7 @@ TYPED_TEST(Dense, NonSquareMatrixPermuteIntoDenseFails64)
     auto exec = this->mtx4->get_executor();
     gko::array<gko::int64> permute_idxs{exec, {1, 2, 0}};
 
-    ASSERT_THROW(this->mtx4->permute(&permute_idxs, this->mtx4->clone().get()),
+    ASSERT_THROW(this->mtx4->permute(&permute_idxs, this->mtx4->clone()),
                  gko::DimensionMismatch);
 }
 
@@ -2600,7 +2594,7 @@ TYPED_TEST(Dense, SquareMatrixPermuteIntoDenseFailsForWrongPermutationSize64)
     auto exec = this->mtx5->get_executor();
     gko::array<gko::int64> permute_idxs{exec, {1, 2}};
 
-    ASSERT_THROW(this->mtx5->permute(&permute_idxs, this->mtx5->clone().get()),
+    ASSERT_THROW(this->mtx5->permute(&permute_idxs, this->mtx5->clone()),
                  gko::ValueMismatch);
 }
 
@@ -2611,7 +2605,7 @@ TYPED_TEST(Dense, SquareMatrixPermuteIntoDenseFailsForWrongDimensions64)
     auto exec = this->mtx5->get_executor();
     gko::array<gko::int64> permute_idxs{exec, {1, 2, 0}};
 
-    ASSERT_THROW(this->mtx5->permute(&permute_idxs, Mtx::create(exec).get()),
+    ASSERT_THROW(this->mtx5->permute(&permute_idxs, Mtx::create(exec)),
                  gko::DimensionMismatch);
 }
 
@@ -2641,7 +2635,7 @@ TYPED_TEST(Dense, SquareMatrixIsInversePermutableIntoDense64)
     auto ref_permuted = gko::as<Mtx>(
         gko::as<Mtx>(this->mtx5->inverse_row_permute(&permute_idxs))
             ->inverse_column_permute(&permute_idxs));
-    this->mtx5->inverse_permute(&permute_idxs, permuted.get());
+    this->mtx5->inverse_permute(&permute_idxs, permuted);
 
     GKO_ASSERT_MTX_NEAR(permuted, ref_permuted, 0.0);
 }
@@ -2658,7 +2652,7 @@ TYPED_TEST(Dense, SquareSubmatrixIsInversePermutableIntoDense64)
     auto ref_permuted =
         gko::as<Mtx>(gko::as<Mtx>(mtx->inverse_row_permute(&permute_idxs))
                          ->inverse_column_permute(&permute_idxs));
-    mtx->inverse_permute(&permute_idxs, permuted.get());
+    mtx->inverse_permute(&permute_idxs, permuted);
 
     GKO_ASSERT_MTX_NEAR(permuted, ref_permuted, 0.0);
     ASSERT_EQ(permuted->get_stride(), 4);
@@ -2672,7 +2666,7 @@ TYPED_TEST(Dense, NonSquareMatrixInversePermuteIntoDenseFails64)
     gko::array<gko::int64> permute_idxs{exec, {1, 2, 0}};
 
     ASSERT_THROW(
-        this->mtx4->inverse_permute(&permute_idxs, this->mtx4->clone().get()),
+        this->mtx4->inverse_permute(&permute_idxs, this->mtx4->clone()),
         gko::DimensionMismatch);
 }
 
@@ -2685,7 +2679,7 @@ TYPED_TEST(Dense,
     gko::array<gko::int64> permute_idxs{exec, {1, 2}};
 
     ASSERT_THROW(
-        this->mtx5->inverse_permute(&permute_idxs, this->mtx5->clone().get()),
+        this->mtx5->inverse_permute(&permute_idxs, this->mtx5->clone()),
         gko::ValueMismatch);
 }
 
@@ -2696,9 +2690,8 @@ TYPED_TEST(Dense, SquareMatrixInversePermuteIntoDenseFailsForWrongDimensions64)
     auto exec = this->mtx5->get_executor();
     gko::array<gko::int64> permute_idxs{exec, {1, 2, 0}};
 
-    ASSERT_THROW(
-        this->mtx5->inverse_permute(&permute_idxs, Mtx::create(exec).get()),
-        gko::DimensionMismatch);
+    ASSERT_THROW(this->mtx5->inverse_permute(&permute_idxs, Mtx::create(exec)),
+                 gko::DimensionMismatch);
 }
 
 
@@ -2739,7 +2732,7 @@ TYPED_TEST(Dense, SquareMatrixIsRowPermutableIntoDense)
     gko::array<gko::int32> permute_idxs{exec, {1, 2, 0}};
     auto row_permute = Mtx::create(exec, this->mtx5->get_size());
 
-    this->mtx5->row_permute(&permute_idxs, row_permute.get());
+    this->mtx5->row_permute(&permute_idxs, row_permute);
 
     GKO_ASSERT_MTX_NEAR(
         row_permute,
@@ -2756,7 +2749,7 @@ TYPED_TEST(Dense, SquareSubmatrixIsRowPermutableIntoDense)
     auto row_permute = Mtx::create(exec, gko::dim<2>{2, 2}, 4);
 
     this->mtx5->create_submatrix({0, 2}, {0, 2})
-        ->row_permute(&permute_idxs, row_permute.get());
+        ->row_permute(&permute_idxs, row_permute);
 
     GKO_ASSERT_MTX_NEAR(row_permute, l<T>({{-2.0, 2.0}, {1.0, -1.0}}), 0.0);
     ASSERT_EQ(row_permute->get_stride(), 4);
@@ -2771,7 +2764,7 @@ TYPED_TEST(Dense, SquareMatrixRowPermuteIntoDenseFailsForWrongPermutationSize)
     gko::array<gko::int32> permute_idxs{exec, {1, 2}};
     auto row_permute = Mtx::create(exec, this->mtx5->get_size());
 
-    ASSERT_THROW(this->mtx5->row_permute(&permute_idxs, row_permute.get()),
+    ASSERT_THROW(this->mtx5->row_permute(&permute_idxs, row_permute),
                  gko::ValueMismatch);
 }
 
@@ -2783,9 +2776,8 @@ TYPED_TEST(Dense, SquareMatrixRowPermuteIntoDenseFailsForWrongDimensions)
     auto exec = this->mtx5->get_executor();
     gko::array<gko::int32> permute_idxs{exec, {1, 2, 0}};
 
-    ASSERT_THROW(
-        this->mtx5->row_permute(&permute_idxs, Mtx::create(exec).get()),
-        gko::DimensionMismatch);
+    ASSERT_THROW(this->mtx5->row_permute(&permute_idxs, Mtx::create(exec)),
+                 gko::DimensionMismatch);
 }
 
 
@@ -2826,7 +2818,7 @@ TYPED_TEST(Dense, SquareMatrixIsColPermutableIntoDense)
     gko::array<gko::int32> permute_idxs{exec, {1, 2, 0}};
     auto c_permute = Mtx::create(exec, this->mtx5->get_size());
 
-    this->mtx5->column_permute(&permute_idxs, c_permute.get());
+    this->mtx5->column_permute(&permute_idxs, c_permute);
 
     GKO_ASSERT_MTX_NEAR(
         c_permute, l<T>({{-1.0, -0.5, 1.0}, {2.0, 4.5, -2.0}, {3.4, 1.2, 2.1}}),
@@ -2843,7 +2835,7 @@ TYPED_TEST(Dense, SquareSubmatrixIsColPermutableIntoDense)
     auto c_permute = Mtx::create(exec, gko::dim<2>{2, 2}, 4);
 
     this->mtx5->create_submatrix({0, 2}, {0, 2})
-        ->column_permute(&permute_idxs, c_permute.get());
+        ->column_permute(&permute_idxs, c_permute);
 
     GKO_ASSERT_MTX_NEAR(c_permute, l<T>({{-1.0, 1.0}, {2.0, -2.0}}), 0.0);
     ASSERT_EQ(c_permute->get_stride(), 4);
@@ -2858,7 +2850,7 @@ TYPED_TEST(Dense, SquareMatrixColPermuteIntoDenseFailsForWrongPermutationSize)
     gko::array<gko::int32> permute_idxs{exec, {1, 2}};
     auto row_permute = Mtx::create(exec, this->mtx5->get_size());
 
-    ASSERT_THROW(this->mtx5->column_permute(&permute_idxs, row_permute.get()),
+    ASSERT_THROW(this->mtx5->column_permute(&permute_idxs, row_permute),
                  gko::ValueMismatch);
 }
 
@@ -2870,9 +2862,8 @@ TYPED_TEST(Dense, SquareMatrixColPermuteIntoDenseFailsForWrongDimensions)
     auto exec = this->mtx5->get_executor();
     gko::array<gko::int32> permute_idxs{exec, {1, 2, 0}};
 
-    ASSERT_THROW(
-        this->mtx5->column_permute(&permute_idxs, Mtx::create(exec).get()),
-        gko::DimensionMismatch);
+    ASSERT_THROW(this->mtx5->column_permute(&permute_idxs, Mtx::create(exec)),
+                 gko::DimensionMismatch);
 }
 
 
@@ -2915,7 +2906,7 @@ TYPED_TEST(Dense, SquareMatrixIsInverseRowPermutableIntoDense)
     gko::array<gko::int32> permute_idxs{exec, {1, 2, 0}};
     auto row_permute = Mtx::create(exec, this->mtx5->get_size());
 
-    this->mtx5->inverse_row_permute(&permute_idxs, row_permute.get());
+    this->mtx5->inverse_row_permute(&permute_idxs, row_permute);
 
     GKO_ASSERT_MTX_NEAR(
         row_permute,
@@ -2932,7 +2923,7 @@ TYPED_TEST(Dense, SquareSubmatrixIsInverseRowPermutableIntoDense)
     auto row_permute = Mtx::create(exec, gko::dim<2>{2, 2}, 4);
 
     this->mtx5->create_submatrix({0, 2}, {0, 2})
-        ->inverse_row_permute(&permute_idxs, row_permute.get());
+        ->inverse_row_permute(&permute_idxs, row_permute);
 
     GKO_ASSERT_MTX_NEAR(row_permute, l<T>({{-2.0, 2.0}, {1.0, -1.0}}), 0.0);
     ASSERT_EQ(row_permute->get_stride(), 4);
@@ -2948,9 +2939,8 @@ TYPED_TEST(Dense,
     gko::array<gko::int32> permute_idxs{exec, {1, 2}};
     auto row_permute = Mtx::create(exec, this->mtx5->get_size());
 
-    ASSERT_THROW(
-        this->mtx5->inverse_row_permute(&permute_idxs, row_permute.get()),
-        gko::ValueMismatch);
+    ASSERT_THROW(this->mtx5->inverse_row_permute(&permute_idxs, row_permute),
+                 gko::ValueMismatch);
 }
 
 
@@ -2962,7 +2952,7 @@ TYPED_TEST(Dense, SquareMatrixInverseRowPermuteIntoDenseFailsForWrongDimensions)
     gko::array<gko::int32> permute_idxs{exec, {1, 2, 0}};
 
     ASSERT_THROW(
-        this->mtx5->inverse_row_permute(&permute_idxs, Mtx::create(exec).get()),
+        this->mtx5->inverse_row_permute(&permute_idxs, Mtx::create(exec)),
         gko::DimensionMismatch);
 }
 
@@ -3006,7 +2996,7 @@ TYPED_TEST(Dense, SquareMatrixIsInverseColPermutableIntoDense)
     gko::array<gko::int32> permute_idxs{exec, {1, 2, 0}};
     auto c_permute = Mtx::create(exec, this->mtx5->get_size());
 
-    this->mtx5->inverse_column_permute(&permute_idxs, c_permute.get());
+    this->mtx5->inverse_column_permute(&permute_idxs, c_permute);
 
     GKO_ASSERT_MTX_NEAR(
         c_permute, l<T>({{-0.5, 1.0, -1.0}, {4.5, -2.0, 2.0}, {1.2, 2.1, 3.4}}),
@@ -3023,7 +3013,7 @@ TYPED_TEST(Dense, SquareSubmatrixIsInverseColPermutableIntoDense)
     auto c_permute = Mtx::create(exec, gko::dim<2>{2, 2}, 4);
 
     this->mtx5->create_submatrix({0, 2}, {0, 2})
-        ->column_permute(&permute_idxs, c_permute.get());
+        ->column_permute(&permute_idxs, c_permute);
 
     GKO_ASSERT_MTX_NEAR(c_permute, l<T>({{-1.0, 1.0}, {2.0, -2.0}}), 0.0);
     ASSERT_EQ(c_permute->get_stride(), 4);
@@ -3039,9 +3029,8 @@ TYPED_TEST(Dense,
     gko::array<gko::int32> permute_idxs{exec, {1, 2}};
     auto row_permute = Mtx::create(exec, this->mtx5->get_size());
 
-    ASSERT_THROW(
-        this->mtx5->inverse_column_permute(&permute_idxs, row_permute.get()),
-        gko::ValueMismatch);
+    ASSERT_THROW(this->mtx5->inverse_column_permute(&permute_idxs, row_permute),
+                 gko::ValueMismatch);
 }
 
 
@@ -3052,9 +3041,9 @@ TYPED_TEST(Dense, SquareMatrixInverseColPermuteIntoDenseFailsForWrongDimensions)
     auto exec = this->mtx5->get_executor();
     gko::array<gko::int32> permute_idxs{exec, {1, 2, 0}};
 
-    ASSERT_THROW(this->mtx5->inverse_column_permute(&permute_idxs,
-                                                    Mtx::create(exec).get()),
-                 gko::DimensionMismatch);
+    ASSERT_THROW(
+        this->mtx5->inverse_column_permute(&permute_idxs, Mtx::create(exec)),
+        gko::DimensionMismatch);
 }
 
 
@@ -3095,7 +3084,7 @@ TYPED_TEST(Dense, SquareMatrixIsRowPermutableIntoDense64)
     gko::array<gko::int64> permute_idxs{exec, {1, 2, 0}};
     auto row_permute = Mtx::create(exec, this->mtx5->get_size());
 
-    this->mtx5->row_permute(&permute_idxs, row_permute.get());
+    this->mtx5->row_permute(&permute_idxs, row_permute);
 
     GKO_ASSERT_MTX_NEAR(
         row_permute,
@@ -3112,7 +3101,7 @@ TYPED_TEST(Dense, SquareSubmatrixIsRowPermutableIntoDense64)
     auto row_permute = Mtx::create(exec, gko::dim<2>{2, 2}, 4);
 
     this->mtx5->create_submatrix({0, 2}, {0, 2})
-        ->row_permute(&permute_idxs, row_permute.get());
+        ->row_permute(&permute_idxs, row_permute);
 
     GKO_ASSERT_MTX_NEAR(row_permute, l<T>({{-2.0, 2.0}, {1.0, -1.0}}), 0.0);
     ASSERT_EQ(row_permute->get_stride(), 4);
@@ -3127,7 +3116,7 @@ TYPED_TEST(Dense, SquareMatrixRowPermuteIntoDenseFailsForWrongPermutationSize64)
     gko::array<gko::int64> permute_idxs{exec, {1, 2}};
     auto row_permute = Mtx::create(exec, this->mtx5->get_size());
 
-    ASSERT_THROW(this->mtx5->row_permute(&permute_idxs, row_permute.get()),
+    ASSERT_THROW(this->mtx5->row_permute(&permute_idxs, row_permute),
                  gko::ValueMismatch);
 }
 
@@ -3139,9 +3128,8 @@ TYPED_TEST(Dense, SquareMatrixRowPermuteIntoDenseFailsForWrongDimensions64)
     auto exec = this->mtx5->get_executor();
     gko::array<gko::int64> permute_idxs{exec, {1, 2, 0}};
 
-    ASSERT_THROW(
-        this->mtx5->row_permute(&permute_idxs, Mtx::create(exec).get()),
-        gko::DimensionMismatch);
+    ASSERT_THROW(this->mtx5->row_permute(&permute_idxs, Mtx::create(exec)),
+                 gko::DimensionMismatch);
 }
 
 
@@ -3182,7 +3170,7 @@ TYPED_TEST(Dense, SquareMatrixIsColPermutableIntoDense64)
     gko::array<gko::int64> permute_idxs{exec, {1, 2, 0}};
     auto c_permute = Mtx::create(exec, this->mtx5->get_size());
 
-    this->mtx5->column_permute(&permute_idxs, c_permute.get());
+    this->mtx5->column_permute(&permute_idxs, c_permute);
 
     GKO_ASSERT_MTX_NEAR(
         c_permute, l<T>({{-1.0, -0.5, 1.0}, {2.0, 4.5, -2.0}, {3.4, 1.2, 2.1}}),
@@ -3199,7 +3187,7 @@ TYPED_TEST(Dense, SquareSubmatrixIsColPermutableIntoDense64)
     auto c_permute = Mtx::create(exec, gko::dim<2>{2, 2}, 4);
 
     this->mtx5->create_submatrix({0, 2}, {0, 2})
-        ->column_permute(&permute_idxs, c_permute.get());
+        ->column_permute(&permute_idxs, c_permute);
 
     GKO_ASSERT_MTX_NEAR(c_permute, l<T>({{-1.0, 1.0}, {2.0, -2.0}}), 0.0);
     ASSERT_EQ(c_permute->get_stride(), 4);
@@ -3214,7 +3202,7 @@ TYPED_TEST(Dense, SquareMatrixColPermuteIntoDenseFailsForWrongPermutationSize64)
     gko::array<gko::int64> permute_idxs{exec, {1, 2}};
     auto row_permute = Mtx::create(exec, this->mtx5->get_size());
 
-    ASSERT_THROW(this->mtx5->column_permute(&permute_idxs, row_permute.get()),
+    ASSERT_THROW(this->mtx5->column_permute(&permute_idxs, row_permute),
                  gko::ValueMismatch);
 }
 
@@ -3226,9 +3214,8 @@ TYPED_TEST(Dense, SquareMatrixColPermuteIntoDenseFailsForWrongDimensions64)
     auto exec = this->mtx5->get_executor();
     gko::array<gko::int64> permute_idxs{exec, {1, 2, 0}};
 
-    ASSERT_THROW(
-        this->mtx5->column_permute(&permute_idxs, Mtx::create(exec).get()),
-        gko::DimensionMismatch);
+    ASSERT_THROW(this->mtx5->column_permute(&permute_idxs, Mtx::create(exec)),
+                 gko::DimensionMismatch);
 }
 
 
@@ -3271,7 +3258,7 @@ TYPED_TEST(Dense, SquareMatrixIsInverseRowPermutableIntoDense64)
     gko::array<gko::int64> permute_idxs{exec, {1, 2, 0}};
     auto row_permute = Mtx::create(exec, this->mtx5->get_size());
 
-    this->mtx5->inverse_row_permute(&permute_idxs, row_permute.get());
+    this->mtx5->inverse_row_permute(&permute_idxs, row_permute);
 
     GKO_ASSERT_MTX_NEAR(
         row_permute,
@@ -3288,7 +3275,7 @@ TYPED_TEST(Dense, SquareSubmatrixIsInverseRowPermutableIntoDense64)
     auto row_permute = Mtx::create(exec, gko::dim<2>{2, 2}, 4);
 
     this->mtx5->create_submatrix({0, 2}, {0, 2})
-        ->inverse_row_permute(&permute_idxs, row_permute.get());
+        ->inverse_row_permute(&permute_idxs, row_permute);
 
     GKO_ASSERT_MTX_NEAR(row_permute, l<T>({{-2.0, 2.0}, {1.0, -1.0}}), 0.0);
     ASSERT_EQ(row_permute->get_stride(), 4);
@@ -3304,9 +3291,8 @@ TYPED_TEST(Dense,
     gko::array<gko::int64> permute_idxs{exec, {1, 2}};
     auto row_permute = Mtx::create(exec, this->mtx5->get_size());
 
-    ASSERT_THROW(
-        this->mtx5->inverse_row_permute(&permute_idxs, row_permute.get()),
-        gko::ValueMismatch);
+    ASSERT_THROW(this->mtx5->inverse_row_permute(&permute_idxs, row_permute),
+                 gko::ValueMismatch);
 }
 
 
@@ -3319,7 +3305,7 @@ TYPED_TEST(Dense,
     gko::array<gko::int64> permute_idxs{exec, {1, 2, 0}};
 
     ASSERT_THROW(
-        this->mtx5->inverse_row_permute(&permute_idxs, Mtx::create(exec).get()),
+        this->mtx5->inverse_row_permute(&permute_idxs, Mtx::create(exec)),
         gko::DimensionMismatch);
 }
 
@@ -3363,7 +3349,7 @@ TYPED_TEST(Dense, SquareMatrixIsInverseColPermutableIntoDense64)
     gko::array<gko::int64> permute_idxs{exec, {1, 2, 0}};
     auto c_permute = Mtx::create(exec, this->mtx5->get_size());
 
-    this->mtx5->inverse_column_permute(&permute_idxs, c_permute.get());
+    this->mtx5->inverse_column_permute(&permute_idxs, c_permute);
 
     GKO_ASSERT_MTX_NEAR(
         c_permute, l<T>({{-0.5, 1.0, -1.0}, {4.5, -2.0, 2.0}, {1.2, 2.1, 3.4}}),
@@ -3380,7 +3366,7 @@ TYPED_TEST(Dense, SquareSubmatrixIsInverseColPermutableIntoDense64)
     auto c_permute = Mtx::create(exec, gko::dim<2>{2, 2}, 4);
 
     this->mtx5->create_submatrix({0, 2}, {0, 2})
-        ->column_permute(&permute_idxs, c_permute.get());
+        ->column_permute(&permute_idxs, c_permute);
 
     GKO_ASSERT_MTX_NEAR(c_permute, l<T>({{-1.0, 1.0}, {2.0, -2.0}}), 0.0);
     ASSERT_EQ(c_permute->get_stride(), 4);
@@ -3396,9 +3382,8 @@ TYPED_TEST(Dense,
     gko::array<gko::int64> permute_idxs{exec, {1, 2}};
     auto row_permute = Mtx::create(exec, this->mtx5->get_size());
 
-    ASSERT_THROW(
-        this->mtx5->inverse_column_permute(&permute_idxs, row_permute.get()),
-        gko::ValueMismatch);
+    ASSERT_THROW(this->mtx5->inverse_column_permute(&permute_idxs, row_permute),
+                 gko::ValueMismatch);
 }
 
 
@@ -3410,9 +3395,9 @@ TYPED_TEST(Dense,
     auto exec = this->mtx5->get_executor();
     gko::array<gko::int64> permute_idxs{exec, {1, 2, 0}};
 
-    ASSERT_THROW(this->mtx5->inverse_column_permute(&permute_idxs,
-                                                    Mtx::create(exec).get()),
-                 gko::DimensionMismatch);
+    ASSERT_THROW(
+        this->mtx5->inverse_column_permute(&permute_idxs, Mtx::create(exec)),
+        gko::DimensionMismatch);
 }
 
 
@@ -3461,7 +3446,7 @@ TYPED_TEST(Dense, ExtractsDiagonalFromSquareMatrixIntoDiagonal)
     using T = typename TestFixture::value_type;
     auto diag = gko::matrix::Diagonal<T>::create(this->exec, 3);
 
-    this->mtx5->extract_diagonal(diag.get());
+    this->mtx5->extract_diagonal(diag);
 
     ASSERT_EQ(diag->get_size()[0], 3);
     ASSERT_EQ(diag->get_size()[1], 3);
@@ -3476,7 +3461,7 @@ TYPED_TEST(Dense, ExtractsDiagonalFromTallSkinnyMatrixIntoDiagonal)
     using T = typename TestFixture::value_type;
     auto diag = gko::matrix::Diagonal<T>::create(this->exec, 2);
 
-    this->mtx4->extract_diagonal(diag.get());
+    this->mtx4->extract_diagonal(diag);
 
     ASSERT_EQ(diag->get_size()[0], 2);
     ASSERT_EQ(diag->get_size()[1], 2);
@@ -3490,7 +3475,7 @@ TYPED_TEST(Dense, ExtractsDiagonalFromShortFatMatrixIntoDiagonal)
     using T = typename TestFixture::value_type;
     auto diag = gko::matrix::Diagonal<T>::create(this->exec, 2);
 
-    this->mtx8->extract_diagonal(diag.get());
+    this->mtx8->extract_diagonal(diag);
 
     ASSERT_EQ(diag->get_size()[0], 2);
     ASSERT_EQ(diag->get_size()[1], 2);
@@ -3543,7 +3528,7 @@ TYPED_TEST(Dense, OutplaceAbsoluteIntoDense)
     auto abs_mtx =
         gko::remove_complex<Mtx>::create(this->exec, this->mtx5->get_size());
 
-    this->mtx5->compute_absolute(abs_mtx.get());
+    this->mtx5->compute_absolute(abs_mtx);
 
     GKO_ASSERT_MTX_NEAR(
         abs_mtx, l<T>({{1.0, 1.0, 0.5}, {2.0, 2.0, 4.5}, {2.1, 3.4, 1.2}}),
@@ -3571,7 +3556,7 @@ TYPED_TEST(Dense, OutplaceSubmatrixAbsoluteIntoDense)
     auto abs_mtx =
         gko::remove_complex<Mtx>::create(this->exec, gko::dim<2>{2, 2}, 4);
 
-    mtx->compute_absolute(abs_mtx.get());
+    mtx->compute_absolute(abs_mtx);
 
     GKO_ASSERT_MTX_NEAR(abs_mtx, l<T>({{1.0, 1.0}, {2.0, 2.0}}), 0);
     GKO_ASSERT_EQ(abs_mtx->get_stride(), 4);
@@ -3591,7 +3576,7 @@ TYPED_TEST(Dense, AppliesToComplex)
                              exec);
     auto x = Vec::create(exec, gko::dim<2>{2, 2});
 
-    this->mtx1->apply(b.get(), x.get());
+    this->mtx1->apply(b, x);
 
     GKO_ASSERT_MTX_NEAR(
         x,
@@ -3615,7 +3600,7 @@ TYPED_TEST(Dense, AppliesToMixedComplex)
         exec);
     auto x = Vec::create(exec, gko::dim<2>{2, 2});
 
-    this->mtx1->apply(b.get(), x.get());
+    this->mtx1->apply(b, x);
 
     GKO_ASSERT_MTX_NEAR(
         x,
@@ -3645,7 +3630,7 @@ TYPED_TEST(Dense, AdvancedAppliesToComplex)
     auto alpha = gko::initialize<Dense>({-1.0}, this->exec);
     auto beta = gko::initialize<Dense>({2.0}, this->exec);
 
-    this->mtx1->apply(alpha.get(), b.get(), beta.get(), x.get());
+    this->mtx1->apply(alpha, b, beta, x);
 
     GKO_ASSERT_MTX_NEAR(
         x,
@@ -3676,7 +3661,7 @@ TYPED_TEST(Dense, AdvancedAppliesToMixedComplex)
     auto alpha = gko::initialize<MixedDense>({-1.0}, this->exec);
     auto beta = gko::initialize<MixedDense>({2.0}, this->exec);
 
-    this->mtx1->apply(alpha.get(), b.get(), beta.get(), x.get());
+    this->mtx1->apply(alpha, b, beta, x);
 
     GKO_ASSERT_MTX_NEAR(
         x,
@@ -3704,7 +3689,7 @@ TYPED_TEST(Dense, MakeComplexIntoDense)
     auto exec = this->mtx5->get_executor();
 
     auto complex_mtx = ComplexMtx::create(exec, this->mtx5->get_size());
-    this->mtx5->make_complex(complex_mtx.get());
+    this->mtx5->make_complex(complex_mtx);
 
     GKO_ASSERT_MTX_NEAR(complex_mtx, this->mtx5, 0.0);
 }
@@ -3718,8 +3703,7 @@ TYPED_TEST(Dense, MakeComplexIntoDenseFailsForWrongDimensions)
 
     auto complex_mtx = ComplexMtx::create(exec);
 
-    ASSERT_THROW(this->mtx5->make_complex(complex_mtx.get()),
-                 gko::DimensionMismatch);
+    ASSERT_THROW(this->mtx5->make_complex(complex_mtx), gko::DimensionMismatch);
 }
 
 
@@ -3740,7 +3724,7 @@ TYPED_TEST(Dense, GetRealIntoDense)
     auto exec = this->mtx5->get_executor();
 
     auto real_mtx = RealMtx::create(exec, this->mtx5->get_size());
-    this->mtx5->get_real(real_mtx.get());
+    this->mtx5->get_real(real_mtx);
 
     GKO_ASSERT_MTX_NEAR(real_mtx, this->mtx5, 0.0);
 }
@@ -3753,7 +3737,7 @@ TYPED_TEST(Dense, GetRealIntoDenseFailsForWrongDimensions)
     auto exec = this->mtx5->get_executor();
 
     auto real_mtx = RealMtx::create(exec);
-    ASSERT_THROW(this->mtx5->get_real(real_mtx.get()), gko::DimensionMismatch);
+    ASSERT_THROW(this->mtx5->get_real(real_mtx), gko::DimensionMismatch);
 }
 
 
@@ -3776,7 +3760,7 @@ TYPED_TEST(Dense, GetImagIntoDense)
     auto exec = this->mtx5->get_executor();
 
     auto imag_mtx = RealMtx::create(exec, this->mtx5->get_size());
-    this->mtx5->get_imag(imag_mtx.get());
+    this->mtx5->get_imag(imag_mtx);
 
     GKO_ASSERT_MTX_NEAR(
         imag_mtx, l<T>({{0.0, 0.0, 0.0}, {0.0, 0.0, 0.0}, {0.0, 0.0, 0.0}}),
@@ -3791,7 +3775,7 @@ TYPED_TEST(Dense, GetImagIntoDenseFailsForWrongDimensions)
     auto exec = this->mtx5->get_executor();
 
     auto imag_mtx = RealMtx::create(exec);
-    ASSERT_THROW(this->mtx5->get_imag(imag_mtx.get()), gko::DimensionMismatch);
+    ASSERT_THROW(this->mtx5->get_imag(imag_mtx), gko::DimensionMismatch);
 }
 
 
@@ -3801,8 +3785,7 @@ TYPED_TEST(Dense, MakeTemporaryConversionDoesntConvertOnMatch)
     using T = typename TestFixture::value_type;
     auto alpha = gko::initialize<Mtx>({8.0}, this->exec);
 
-    ASSERT_EQ(gko::make_temporary_conversion<T>(alpha.get()).get(),
-              alpha.get());
+    ASSERT_EQ(gko::make_temporary_conversion<T>(alpha).get(), alpha.get());
 }
 
 
@@ -3814,7 +3797,7 @@ TYPED_TEST(Dense, MakeTemporaryConversionConvertsBack)
     auto alpha = gko::initialize<MixedMtx>({8.0}, this->exec);
 
     {
-        auto conversion = gko::make_temporary_conversion<T>(alpha.get());
+        auto conversion = gko::make_temporary_conversion<T>(alpha);
         conversion->at(0, 0) = T{7.0};
     }
 
@@ -3849,7 +3832,7 @@ TYPED_TEST(Dense, ScaleAddIdentityRectangular)
     auto b = gko::initialize<Vec>(
         {I<T>{2.0, 0.0}, I<T>{1.0, 2.5}, I<T>{0.0, -4.0}}, this->exec);
 
-    b->add_scaled_identity(alpha.get(), beta.get());
+    b->add_scaled_identity(alpha, beta);
 
     GKO_ASSERT_MTX_NEAR(b, l({{0.0, 0.0}, {-1.0, -0.5}, {0.0, 4.0}}), 0.0);
 }
@@ -3881,7 +3864,7 @@ TYPED_TEST(DenseComplex, ScalesWithRealScalar)
     auto alpha =
         gko::initialize<RealDense>({gko::remove_complex<T>{-2.0}}, exec);
 
-    mtx->scale(alpha.get());
+    mtx->scale(alpha);
 
     GKO_ASSERT_MTX_NEAR(mtx,
                         l<T>({{T{-2.0, -4.0}, T{2.0, -4.5}},
@@ -3904,7 +3887,7 @@ TYPED_TEST(DenseComplex, ScalesWithRealVector)
                                       exec);
     auto alpha = gko::initialize<RealDense>({{RealT{-2.0}, RealT{4.0}}}, exec);
 
-    mtx->scale(alpha.get());
+    mtx->scale(alpha);
 
     GKO_ASSERT_MTX_NEAR(mtx,
                         l<T>({{T{-2.0, -4.0}, T{-4.0, 9.0}},
@@ -3927,7 +3910,7 @@ TYPED_TEST(DenseComplex, InvScalesWithRealScalar)
     auto alpha =
         gko::initialize<RealDense>({gko::remove_complex<T>{-0.5}}, exec);
 
-    mtx->inv_scale(alpha.get());
+    mtx->inv_scale(alpha);
 
     GKO_ASSERT_MTX_NEAR(mtx,
                         l<T>({{T{-2.0, -4.0}, T{2.0, -4.5}},
@@ -3950,7 +3933,7 @@ TYPED_TEST(DenseComplex, InvScalesWithRealVector)
                                       exec);
     auto alpha = gko::initialize<RealDense>({{RealT{-0.5}, RealT{0.25}}}, exec);
 
-    mtx->inv_scale(alpha.get());
+    mtx->inv_scale(alpha);
 
     GKO_ASSERT_MTX_NEAR(mtx,
                         l<T>({{T{-2.0, -4.0}, T{-4.0, 9.0}},
@@ -3977,7 +3960,7 @@ TYPED_TEST(DenseComplex, AddsScaledWithRealScalar)
     auto alpha =
         gko::initialize<RealDense>({gko::remove_complex<T>{-2.0}}, exec);
 
-    mtx->add_scaled(alpha.get(), mtx2.get());
+    mtx->add_scaled(alpha, mtx2);
 
     GKO_ASSERT_MTX_NEAR(mtx,
                         l<T>({{T{-7.0, 4.0}, T{-11.0, -0.75}},
@@ -4004,7 +3987,7 @@ TYPED_TEST(DenseComplex, AddsScaledWithRealVector)
                                        exec);
     auto alpha = gko::initialize<RealDense>({{RealT{-2.0}, RealT{4.0}}}, exec);
 
-    mtx->add_scaled(alpha.get(), mtx2.get());
+    mtx->add_scaled(alpha, mtx2);
 
     GKO_ASSERT_MTX_NEAR(mtx,
                         l<T>({{T{-7.0, 4.0}, T{19.0, 8.25}},
@@ -4031,7 +4014,7 @@ TYPED_TEST(DenseComplex, SubtractsScaledWithRealScalar)
     auto alpha =
         gko::initialize<RealDense>({gko::remove_complex<T>{2.0}}, exec);
 
-    mtx->sub_scaled(alpha.get(), mtx2.get());
+    mtx->sub_scaled(alpha, mtx2);
 
     GKO_ASSERT_MTX_NEAR(mtx,
                         l<T>({{T{-7.0, 4.0}, T{-11.0, -0.75}},
@@ -4058,7 +4041,7 @@ TYPED_TEST(DenseComplex, SubtractsScaledWithRealVector)
                                        exec);
     auto alpha = gko::initialize<RealDense>({{RealT{2.0}, RealT{-4.0}}}, exec);
 
-    mtx->sub_scaled(alpha.get(), mtx2.get());
+    mtx->sub_scaled(alpha, mtx2);
 
     GKO_ASSERT_MTX_NEAR(mtx,
                         l<T>({{T{-7.0, 4.0}, T{19.0, 8.25}},
@@ -4098,7 +4081,7 @@ TYPED_TEST(DenseComplex, NonSquareMatrixIsConjugateTransposableIntoDense)
                                       exec);
     auto trans = Dense::create(exec, gko::transpose(mtx->get_size()));
 
-    mtx->conj_transpose(trans.get());
+    mtx->conj_transpose(trans);
 
     GKO_ASSERT_MTX_NEAR(trans,
                         l<T>({{T{1.0, -2.0}, T{-2.0, -1.5}, T{1.0, 0.0}},
@@ -4153,7 +4136,7 @@ TYPED_TEST(DenseComplex, OutplaceAbsoluteIntoDense)
                                     exec);
     auto abs_mtx = gko::remove_complex<Mtx>::create(exec, mtx->get_size());
 
-    mtx->compute_absolute(abs_mtx.get());
+    mtx->compute_absolute(abs_mtx);
 
     GKO_ASSERT_MTX_NEAR(
         abs_mtx, l<T>({{1.0, 5.0, 2.0}, {5.0, 1.0, 0.0}, {0.0, 1.5, 2.0}}),
@@ -4188,7 +4171,7 @@ TYPED_TEST(DenseComplex, MakeComplexIntoDense)
                                     exec);
 
     auto complex_mtx = Mtx::create(exec, mtx->get_size());
-    mtx->make_complex(complex_mtx.get());
+    mtx->make_complex(complex_mtx);
 
     GKO_ASSERT_MTX_NEAR(complex_mtx, mtx, 0.0);
 }
@@ -4224,7 +4207,7 @@ TYPED_TEST(DenseComplex, GetRealIntoDense)
                                     exec);
 
     auto real_mtx = RealMtx::create(exec, mtx->get_size());
-    mtx->get_real(real_mtx.get());
+    mtx->get_real(real_mtx);
 
     GKO_ASSERT_MTX_NEAR(
         real_mtx, l<T>({{1.0, 3.0, 0.0}, {-4.0, -1.0, 0.0}, {0.0, 0.0, 2.0}}),
@@ -4262,7 +4245,7 @@ TYPED_TEST(DenseComplex, GetImagIntoDense)
                                     exec);
 
     auto imag_mtx = RealMtx::create(exec, mtx->get_size());
-    mtx->get_imag(imag_mtx.get());
+    mtx->get_imag(imag_mtx);
 
     GKO_ASSERT_MTX_NEAR(
         imag_mtx, l<T>({{0.0, 4.0, 2.0}, {-3.0, 0.0, 0.0}, {0.0, -1.5, 0.0}}),
@@ -4281,7 +4264,7 @@ TYPED_TEST(DenseComplex, Dot)
         gko::initialize<Mtx>({T{1.0, -2.0}, T{5.0, 0.0}, T{0.0, -3.0}}, exec);
     auto result = gko::initialize<Mtx>({T{0.0, 0.0}}, exec);
 
-    a->compute_dot(b.get(), result.get());
+    a->compute_dot(b, result);
 
     GKO_ASSERT_MTX_NEAR(result, l({T{22.0, 15.0}}), 0.0);
 }
@@ -4298,7 +4281,7 @@ TYPED_TEST(DenseComplex, ConjDot)
         gko::initialize<Mtx>({T{1.0, -2.0}, T{5.0, 0.0}, T{0.0, -3.0}}, exec);
     auto result = gko::initialize<Mtx>({T{0.0, 0.0}}, exec);
 
-    a->compute_conj_dot(b.get(), result.get());
+    a->compute_conj_dot(b, result);
 
     GKO_ASSERT_MTX_NEAR(result, l({T{10.0, -25.0}}), 0.0);
 }

--- a/reference/test/matrix/diagonal_kernels.cpp
+++ b/reference/test/matrix/diagonal_kernels.cpp
@@ -76,11 +76,11 @@ protected:
                                         exec))
     {
         csr1 = Csr::create(exec);
-        csr1->copy_from(dense1.get());
+        csr1->copy_from(dense1);
         csr2 = Csr::create(exec);
-        csr2->copy_from(dense2.get());
+        csr2->copy_from(dense2);
         csr3 = Csr::create(exec);
-        csr3->copy_from(dense3.get());
+        csr3->copy_from(dense3);
         this->create_diag1(diag1.get());
         this->create_diag2(diag2.get());
     }
@@ -127,8 +127,8 @@ TYPED_TEST(Diagonal, ConvertsToPrecision)
                         ? gko::remove_complex<ValueType>{0}
                         : gko::remove_complex<ValueType>{r<OtherType>::value};
 
-    this->diag1->convert_to(tmp.get());
-    tmp->convert_to(res.get());
+    this->diag1->convert_to(tmp);
+    tmp->convert_to(res);
 
     GKO_ASSERT_MTX_NEAR(this->diag1, res, residual);
 }
@@ -147,8 +147,8 @@ TYPED_TEST(Diagonal, MovesToPrecision)
                         ? gko::remove_complex<ValueType>{0}
                         : gko::remove_complex<ValueType>{r<OtherType>::value};
 
-    this->diag1->move_to(tmp.get());
-    tmp->move_to(res.get());
+    this->diag1->move_to(tmp);
+    tmp->move_to(res);
 
     GKO_ASSERT_MTX_NEAR(this->diag1, res, residual);
 }
@@ -157,7 +157,7 @@ TYPED_TEST(Diagonal, MovesToPrecision)
 TYPED_TEST(Diagonal, AppliesToDense)
 {
     using value_type = typename TestFixture::value_type;
-    this->diag1->apply(this->dense1.get(), this->dense2.get());
+    this->diag1->apply(this->dense1, this->dense2);
 
     EXPECT_EQ(this->dense2->at(0, 0), value_type{2.0});
     EXPECT_EQ(this->dense2->at(0, 1), value_type{4.0});
@@ -175,10 +175,10 @@ TYPED_TEST(Diagonal, AppliesToMixedDense)
     using mixed_value_type = typename MixedDense::value_type;
     auto mdense1 = MixedDense::create(this->exec);
     auto mdense2 = MixedDense::create(this->exec);
-    this->dense1->convert_to(mdense1.get());
-    this->dense2->convert_to(mdense2.get());
+    this->dense1->convert_to(mdense1);
+    this->dense2->convert_to(mdense2);
 
-    this->diag1->apply(mdense1.get(), mdense2.get());
+    this->diag1->apply(mdense1, mdense2);
 
     EXPECT_EQ(mdense2->at(0, 0), mixed_value_type{2.0});
     EXPECT_EQ(mdense2->at(0, 1), mixed_value_type{4.0});
@@ -192,7 +192,7 @@ TYPED_TEST(Diagonal, AppliesToMixedDense)
 TYPED_TEST(Diagonal, RightAppliesToDense)
 {
     using value_type = typename TestFixture::value_type;
-    this->diag2->rapply(this->dense1.get(), this->dense2.get());
+    this->diag2->rapply(this->dense1, this->dense2);
 
     EXPECT_EQ(this->dense2->at(0, 0), value_type{2.0});
     EXPECT_EQ(this->dense2->at(0, 1), value_type{6.0});
@@ -210,10 +210,10 @@ TYPED_TEST(Diagonal, RightAppliesToMixedDense)
     using mixed_value_type = typename MixedDense::value_type;
     auto mdense1 = MixedDense::create(this->exec);
     auto mdense2 = MixedDense::create(this->exec);
-    this->dense1->convert_to(mdense1.get());
-    this->dense2->convert_to(mdense2.get());
+    this->dense1->convert_to(mdense1);
+    this->dense2->convert_to(mdense2);
 
-    this->diag2->rapply(mdense1.get(), mdense2.get());
+    this->diag2->rapply(mdense1, mdense2);
 
     EXPECT_EQ(mdense2->at(0, 0), mixed_value_type{2.0});
     EXPECT_EQ(mdense2->at(0, 1), mixed_value_type{6.0});
@@ -227,7 +227,7 @@ TYPED_TEST(Diagonal, RightAppliesToMixedDense)
 TYPED_TEST(Diagonal, InverseAppliesToDense)
 {
     using value_type = typename TestFixture::value_type;
-    this->diag1->inverse_apply(this->dense3.get(), this->dense2.get());
+    this->diag1->inverse_apply(this->dense3, this->dense2);
 
     EXPECT_EQ(this->dense2->at(0, 0), value_type{1.0});
     EXPECT_EQ(this->dense2->at(0, 1), value_type{1.5});
@@ -245,10 +245,10 @@ TYPED_TEST(Diagonal, InverseAppliesToMixedDense)
     using mixed_value_type = typename MixedDense::value_type;
     auto mdense2 = MixedDense::create(this->exec);
     auto mdense3 = MixedDense::create(this->exec);
-    this->dense2->convert_to(mdense2.get());
-    this->dense3->convert_to(mdense3.get());
+    this->dense2->convert_to(mdense2);
+    this->dense3->convert_to(mdense3);
 
-    this->diag1->inverse_apply(mdense3.get(), mdense2.get());
+    this->diag1->inverse_apply(mdense3, mdense2);
 
     EXPECT_EQ(mdense2->at(0, 0), mixed_value_type{1.0});
     EXPECT_EQ(mdense2->at(0, 1), mixed_value_type{1.5});
@@ -266,8 +266,7 @@ TYPED_TEST(Diagonal, AppliesLinearCombinationToDense)
     auto alpha = gko::initialize<Dense>({-1.0}, this->exec);
     auto beta = gko::initialize<Dense>({2.0}, this->exec);
 
-    this->diag1->apply(alpha.get(), this->dense1.get(), beta.get(),
-                       this->dense2.get());
+    this->diag1->apply(alpha, this->dense1, beta, this->dense2);
 
     EXPECT_EQ(this->dense2->at(0, 0), value_type{0.0});
     EXPECT_EQ(this->dense2->at(0, 1), value_type{0.0});
@@ -287,10 +286,10 @@ TYPED_TEST(Diagonal, AppliesLinearCombinationToMixedDense)
     auto mdense2 = MixedDense::create(this->exec);
     auto alpha = gko::initialize<MixedDense>({-1.0}, this->exec);
     auto beta = gko::initialize<MixedDense>({2.0}, this->exec);
-    this->dense1->convert_to(mdense1.get());
-    this->dense2->convert_to(mdense2.get());
+    this->dense1->convert_to(mdense1);
+    this->dense2->convert_to(mdense2);
 
-    this->diag1->apply(alpha.get(), mdense1.get(), beta.get(), mdense2.get());
+    this->diag1->apply(alpha, mdense1, beta, mdense2);
 
     EXPECT_EQ(mdense2->at(0, 0), mixed_value_type{0.0});
     EXPECT_EQ(mdense2->at(0, 1), mixed_value_type{0.0});
@@ -308,7 +307,7 @@ TYPED_TEST(Diagonal, ApplyToDenseFailsForWrongInnerDimensions)
         gko::matrix::Dense<value_type>::create(this->exec, gko::dim<2>{3});
 
     // 3x3 times 2x3 = 3x3 --> mismatch for inner dimensions
-    ASSERT_THROW(this->diag2->apply(this->dense1.get(), result.get()),
+    ASSERT_THROW(this->diag2->apply(this->dense1, result),
                  gko::DimensionMismatch);
 }
 
@@ -320,7 +319,7 @@ TYPED_TEST(Diagonal, ApplyToDenseFailsForWrongNumberOfRows)
         gko::matrix::Dense<value_type>::create(this->exec, gko::dim<2>{3});
 
     // 2x2 times 2x3 = 3x3 --> mismatch for rows of diagonal and result
-    ASSERT_THROW(this->diag1->apply(this->dense1.get(), result.get()),
+    ASSERT_THROW(this->diag1->apply(this->dense1, result),
                  gko::DimensionMismatch);
 }
 
@@ -332,7 +331,7 @@ TYPED_TEST(Diagonal, ApplyToDenseFailsForWrongNumberOfCols)
         gko::matrix::Dense<value_type>::create(this->exec, gko::dim<2>{2});
 
     // 2x2 times 2x3 = 2x2 --> mismatch for cols of dense1 and result
-    ASSERT_THROW(this->diag1->apply(this->dense1.get(), result.get()),
+    ASSERT_THROW(this->diag1->apply(this->dense1, result),
                  gko::DimensionMismatch);
 }
 
@@ -344,7 +343,7 @@ TYPED_TEST(Diagonal, RightApplyToDenseFailsForWrongInnerDimensions)
         gko::matrix::Dense<value_type>::create(this->exec, gko::dim<2>{2});
 
     // 2x3 times 2x2 = 2x2 --> mismatch for inner DimensionMismatch
-    ASSERT_THROW(this->diag1->rapply(this->dense1.get(), result.get()),
+    ASSERT_THROW(this->diag1->rapply(this->dense1, result),
                  gko::DimensionMismatch);
 }
 
@@ -356,7 +355,7 @@ TYPED_TEST(Diagonal, RightApplyToDenseFailsForWrongNumberOfRows)
         gko::matrix::Dense<value_type>::create(this->exec, gko::dim<2>{3});
 
     // 2x3 times 3x3 = 3x3 --> mismatch for rows of dense1 and result
-    ASSERT_THROW(this->diag2->rapply(this->dense1.get(), result.get()),
+    ASSERT_THROW(this->diag2->rapply(this->dense1, result),
                  gko::DimensionMismatch);
 }
 
@@ -368,7 +367,7 @@ TYPED_TEST(Diagonal, RightApplyToDenseFailsForWrongNumberOfCols)
         gko::matrix::Dense<value_type>::create(this->exec, gko::dim<2>{2});
 
     // 2x3 times 3x3 = 2x2 --> mismatch for cols of diagonal and result
-    ASSERT_THROW(this->diag2->rapply(this->dense1.get(), result.get()),
+    ASSERT_THROW(this->diag2->rapply(this->dense1, result),
                  gko::DimensionMismatch);
 }
 
@@ -376,7 +375,7 @@ TYPED_TEST(Diagonal, RightApplyToDenseFailsForWrongNumberOfCols)
 TYPED_TEST(Diagonal, AppliesToCsr)
 {
     using value_type = typename TestFixture::value_type;
-    this->diag1->apply(this->csr1.get(), this->csr2.get());
+    this->diag1->apply(this->csr1, this->csr2);
 
     const auto values = this->csr2->get_const_values();
     const auto row_ptrs = this->csr2->get_const_row_ptrs();
@@ -404,7 +403,7 @@ TYPED_TEST(Diagonal, AppliesToCsr)
 TYPED_TEST(Diagonal, RightAppliesToCsr)
 {
     using value_type = typename TestFixture::value_type;
-    this->diag2->rapply(this->csr1.get(), this->csr2.get());
+    this->diag2->rapply(this->csr1, this->csr2);
 
     const auto values = this->csr2->get_const_values();
     const auto row_ptrs = this->csr2->get_const_row_ptrs();
@@ -432,7 +431,7 @@ TYPED_TEST(Diagonal, RightAppliesToCsr)
 TYPED_TEST(Diagonal, InverseAppliesToCsr)
 {
     using value_type = typename TestFixture::value_type;
-    this->diag1->inverse_apply(this->csr3.get(), this->csr2.get());
+    this->diag1->inverse_apply(this->csr3, this->csr2);
 
     const auto values = this->csr2->get_const_values();
     const auto row_ptrs = this->csr2->get_const_row_ptrs();
@@ -464,7 +463,7 @@ TYPED_TEST(Diagonal, ApplyToCsrFailsForWrongInnerDimensions)
         gko::matrix::Csr<value_type>::create(this->exec, gko::dim<2>{3});
 
     // 3x3 times 2x3 = 3x3 --> mismatch for inner dimensions
-    ASSERT_THROW(this->diag2->apply(this->csr1.get(), result.get()),
+    ASSERT_THROW(this->diag2->apply(this->csr1, result),
                  gko::DimensionMismatch);
 }
 
@@ -476,7 +475,7 @@ TYPED_TEST(Diagonal, ApplyToCsrFailsForWrongNumberOfRows)
         gko::matrix::Csr<value_type>::create(this->exec, gko::dim<2>{3});
 
     // 2x2 times 2x3 = 3x3 --> mismatch for rows of diagonal and result
-    ASSERT_THROW(this->diag1->apply(this->csr1.get(), result.get()),
+    ASSERT_THROW(this->diag1->apply(this->csr1, result),
                  gko::DimensionMismatch);
 }
 
@@ -488,7 +487,7 @@ TYPED_TEST(Diagonal, ApplyToCsrFailsForWrongNumberOfCols)
         gko::matrix::Csr<value_type>::create(this->exec, gko::dim<2>{2});
 
     // 2x2 times 2x3 = 2x2 --> mismatch for cols of csr1 and result
-    ASSERT_THROW(this->diag1->apply(this->csr1.get(), result.get()),
+    ASSERT_THROW(this->diag1->apply(this->csr1, result),
                  gko::DimensionMismatch);
 }
 
@@ -500,7 +499,7 @@ TYPED_TEST(Diagonal, RightApplyToCsrFailsForWrongInnerDimensions)
         gko::matrix::Csr<value_type>::create(this->exec, gko::dim<2>{2});
 
     // 2x3 times 2x2 = 2x2 --> mismatch for inner DimensionMismatch
-    ASSERT_THROW(this->diag1->rapply(this->csr1.get(), result.get()),
+    ASSERT_THROW(this->diag1->rapply(this->csr1, result),
                  gko::DimensionMismatch);
 }
 
@@ -512,7 +511,7 @@ TYPED_TEST(Diagonal, RightApplyToCsrFailsForWrongNumberOfRows)
         gko::matrix::Csr<value_type>::create(this->exec, gko::dim<2>{3});
 
     // 2x3 times 3x3 = 3x3 --> mismatch for rows of csr1 and result
-    ASSERT_THROW(this->diag2->rapply(this->csr1.get(), result.get()),
+    ASSERT_THROW(this->diag2->rapply(this->csr1, result),
                  gko::DimensionMismatch);
 }
 
@@ -524,7 +523,7 @@ TYPED_TEST(Diagonal, RightApplyToCsrFailsForWrongNumberOfCols)
         gko::matrix::Csr<value_type>::create(this->exec, gko::dim<2>{2});
 
     // 2x3 times 3x3 = 2x2 --> mismatch for cols of diagonal and result
-    ASSERT_THROW(this->diag2->rapply(this->csr1.get(), result.get()),
+    ASSERT_THROW(this->diag2->rapply(this->csr1, result),
                  gko::DimensionMismatch);
 }
 
@@ -533,7 +532,7 @@ TYPED_TEST(Diagonal, ConvertsToCsr)
 {
     using value_type = typename TestFixture::value_type;
 
-    this->diag1->convert_to(this->csr1.get());
+    this->diag1->convert_to(this->csr1);
 
     const auto nnz = this->csr1->get_num_stored_elements();
     const auto row_ptrs = this->csr1->get_const_row_ptrs();
@@ -590,7 +589,7 @@ TYPED_TEST(Diagonal, AppliesToComplex)
                              exec);
     auto dense2 = Vec::create(exec, gko::dim<2>{2, 3});
 
-    this->diag1->apply(dense1.get(), dense2.get());
+    this->diag1->apply(dense1, dense2);
 
     GKO_ASSERT_MTX_NEAR(dense2,
                         l({{complex_type{2.0, 4.0}, complex_type{4.0, 8.0},
@@ -616,7 +615,7 @@ TYPED_TEST(Diagonal, AppliesToMixedComplex)
         exec);
     auto mdense2 = Vec::create(exec, gko::dim<2>{2, 3});
 
-    this->diag1->apply(mdense1.get(), mdense2.get());
+    this->diag1->apply(mdense1, mdense2);
 
     GKO_ASSERT_MTX_NEAR(
         mdense2,
@@ -650,7 +649,7 @@ TYPED_TEST(Diagonal, AppliesLinearCombinationToComplex)
     auto alpha = gko::initialize<Scalar>({-1.0}, this->exec);
     auto beta = gko::initialize<Scalar>({2.0}, this->exec);
 
-    this->diag1->apply(alpha.get(), dense1.get(), beta.get(), dense2.get());
+    this->diag1->apply(alpha, dense1, beta, dense2);
 
     GKO_ASSERT_MTX_NEAR(dense2,
                         l({{complex_type{0.0, 0.0}, complex_type{0.0, 0.0},
@@ -684,7 +683,7 @@ TYPED_TEST(Diagonal, AppliesLinearCombinationToMixedComplex)
     auto alpha = gko::initialize<Scalar>({-1.0}, this->exec);
     auto beta = gko::initialize<Scalar>({2.0}, this->exec);
 
-    this->diag1->apply(alpha.get(), dense1.get(), beta.get(), dense2.get());
+    this->diag1->apply(alpha, dense1, beta, dense2);
 
     GKO_ASSERT_MTX_NEAR(
         dense2,

--- a/reference/test/matrix/ell_kernels.cpp
+++ b/reference/test/matrix/ell_kernels.cpp
@@ -79,7 +79,7 @@ protected:
         // clang-format on
     }
 
-    void assert_equal_to_mtx(gko::pointer_param<const Csr> m)
+    void assert_equal_to_mtx(gko::ptr_param<const Csr> m)
     {
         auto v = m->get_const_values();
         auto c = m->get_const_col_idxs();

--- a/reference/test/matrix/ell_kernels.cpp
+++ b/reference/test/matrix/ell_kernels.cpp
@@ -79,7 +79,7 @@ protected:
         // clang-format on
     }
 
-    void assert_equal_to_mtx(const Csr* m)
+    void assert_equal_to_mtx(gko::pointer_param<const Csr> m)
     {
         auto v = m->get_const_values();
         auto c = m->get_const_col_idxs();
@@ -114,7 +114,7 @@ TYPED_TEST(Ell, AppliesToDenseVector)
     auto x = gko::initialize<Vec>({2.0, 1.0, 4.0}, this->exec);
     auto y = Vec::create(this->exec, gko::dim<2>{2, 1});
 
-    this->mtx1->apply(x.get(), y.get());
+    this->mtx1->apply(x, y);
 
     GKO_ASSERT_MTX_NEAR(y, l({13.0, 5.0}), 0.0);
 }
@@ -129,7 +129,7 @@ TYPED_TEST(Ell, MixedAppliesToDenseVector1)
     auto x = gko::initialize<Vec>({2.0, 1.0, 4.0}, this->exec);
     auto y = Vec::create(this->exec, gko::dim<2>{2, 1});
 
-    this->mtx1->apply(x.get(), y.get());
+    this->mtx1->apply(x, y);
 
     GKO_ASSERT_MTX_NEAR(y, l({13.0, 5.0}), 0.0);
 }
@@ -145,7 +145,7 @@ TYPED_TEST(Ell, MixedAppliesToDenseVector2)
     auto x = gko::initialize<Vec1>({2.0, 1.0, 4.0}, this->exec);
     auto y = Vec2::create(this->exec, gko::dim<2>{2, 1});
 
-    this->mtx1->apply(x.get(), y.get());
+    this->mtx1->apply(x, y);
 
     GKO_ASSERT_MTX_NEAR(y, l({13.0, 5.0}), 0.0);
 }
@@ -161,7 +161,7 @@ TYPED_TEST(Ell, MixedAppliesToDenseVector3)
     auto x = gko::initialize<Vec2>({2.0, 1.0, 4.0}, this->exec);
     auto y = Vec1::create(this->exec, gko::dim<2>{2, 1});
 
-    this->mtx1->apply(x.get(), y.get());
+    this->mtx1->apply(x, y);
 
     GKO_ASSERT_MTX_NEAR(y, l({13.0, 5.0}), 0.0);
 }
@@ -179,7 +179,7 @@ TYPED_TEST(Ell, AppliesToDenseMatrix)
     // clang-format on
     auto y = Vec::create(this->exec, gko::dim<2>{2});
 
-    this->mtx1->apply(x.get(), y.get());
+    this->mtx1->apply(x, y);
 
     // clang-format off
     GKO_ASSERT_MTX_NEAR(y,
@@ -203,7 +203,7 @@ TYPED_TEST(Ell, MixedAppliesToDenseMatrix1)
     // clang-format on
     auto y = Vec::create(this->exec, gko::dim<2>{2});
 
-    this->mtx1->apply(x.get(), y.get());
+    this->mtx1->apply(x, y);
 
     // clang-format off
     GKO_ASSERT_MTX_NEAR(y,
@@ -228,7 +228,7 @@ TYPED_TEST(Ell, MixedAppliesToDenseMatrix2)
     // clang-format on
     auto y = Vec2::create(this->exec, gko::dim<2>{2});
 
-    this->mtx1->apply(x.get(), y.get());
+    this->mtx1->apply(x, y);
 
     // clang-format off
     GKO_ASSERT_MTX_NEAR(y,
@@ -253,7 +253,7 @@ TYPED_TEST(Ell, MixedAppliesToDenseMatrix3)
     // clang-format on
     auto y = Vec1::create(this->exec, gko::dim<2>{2});
 
-    this->mtx1->apply(x.get(), y.get());
+    this->mtx1->apply(x, y);
 
     // clang-format off
     GKO_ASSERT_MTX_NEAR(y,
@@ -271,7 +271,7 @@ TYPED_TEST(Ell, AppliesLinearCombinationToDenseVector)
     auto x = gko::initialize<Vec>({2.0, 1.0, 4.0}, this->exec);
     auto y = gko::initialize<Vec>({1.0, 2.0}, this->exec);
 
-    this->mtx1->apply(alpha.get(), x.get(), beta.get(), y.get());
+    this->mtx1->apply(alpha, x, beta, y);
 
     GKO_ASSERT_MTX_NEAR(y, l({-11.0, -1.0}), 0.0);
 }
@@ -288,7 +288,7 @@ TYPED_TEST(Ell, MixedAppliesLinearCombinationToDenseVector1)
     auto x = gko::initialize<Vec>({2.0, 1.0, 4.0}, this->exec);
     auto y = gko::initialize<Vec>({1.0, 2.0}, this->exec);
 
-    this->mtx1->apply(alpha.get(), x.get(), beta.get(), y.get());
+    this->mtx1->apply(alpha, x, beta, y);
 
     GKO_ASSERT_MTX_NEAR(y, l({-11.0, -1.0}), 0.0);
 }
@@ -306,7 +306,7 @@ TYPED_TEST(Ell, MixedAppliesLinearCombinationToDenseVector2)
     auto x = gko::initialize<Vec1>({2.0, 1.0, 4.0}, this->exec);
     auto y = gko::initialize<Vec2>({1.0, 2.0}, this->exec);
 
-    this->mtx1->apply(alpha.get(), x.get(), beta.get(), y.get());
+    this->mtx1->apply(alpha, x, beta, y);
 
     GKO_ASSERT_MTX_NEAR(y, l({-11.0, -1.0}), 0.0);
 }
@@ -324,7 +324,7 @@ TYPED_TEST(Ell, MixedAppliesLinearCombinationToDenseVector3)
     auto x = gko::initialize<Vec2>({2.0, 1.0, 4.0}, this->exec);
     auto y = gko::initialize<Vec1>({1.0, 2.0}, this->exec);
 
-    this->mtx1->apply(alpha.get(), x.get(), beta.get(), y.get());
+    this->mtx1->apply(alpha, x, beta, y);
 
     GKO_ASSERT_MTX_NEAR(y, l({-11.0, -1.0}), 0.0);
 }
@@ -346,7 +346,7 @@ TYPED_TEST(Ell, AppliesLinearCombinationToDenseMatrix)
          I<T>{2.0, -1.5}}, this->exec);
     // clang-format on
 
-    this->mtx1->apply(alpha.get(), x.get(), beta.get(), y.get());
+    this->mtx1->apply(alpha, x, beta, y);
 
     // clang-format off
     GKO_ASSERT_MTX_NEAR(y,
@@ -374,7 +374,7 @@ TYPED_TEST(Ell, MixedAppliesLinearCombinationToDenseMatrix1)
          I<next_T>{2.0, -1.5}}, this->exec);
     // clang-format on
 
-    this->mtx1->apply(alpha.get(), x.get(), beta.get(), y.get());
+    this->mtx1->apply(alpha, x, beta, y);
 
     // clang-format off
     GKO_ASSERT_MTX_NEAR(y,
@@ -403,7 +403,7 @@ TYPED_TEST(Ell, MixedAppliesLinearCombinationToDenseMatrix2)
          I<next_T>{2.0, -1.5}}, this->exec);
     // clang-format on
 
-    this->mtx1->apply(alpha.get(), x.get(), beta.get(), y.get());
+    this->mtx1->apply(alpha, x, beta, y);
 
     // clang-format off
     GKO_ASSERT_MTX_NEAR(y,
@@ -432,7 +432,7 @@ TYPED_TEST(Ell, MixedAppliesLinearCombinationToDenseMatrix3)
          I<T>{2.0, -1.5}}, this->exec);
     // clang-format on
 
-    this->mtx1->apply(alpha.get(), x.get(), beta.get(), y.get());
+    this->mtx1->apply(alpha, x, beta, y);
 
     // clang-format off
     GKO_ASSERT_MTX_NEAR(y,
@@ -448,7 +448,7 @@ TYPED_TEST(Ell, ApplyFailsOnWrongInnerDimension)
     auto x = Vec::create(this->exec, gko::dim<2>{2});
     auto y = Vec::create(this->exec, gko::dim<2>{2});
 
-    ASSERT_THROW(this->mtx1->apply(x.get(), y.get()), gko::DimensionMismatch);
+    ASSERT_THROW(this->mtx1->apply(x, y), gko::DimensionMismatch);
 }
 
 
@@ -458,7 +458,7 @@ TYPED_TEST(Ell, ApplyFailsOnWrongNumberOfRows)
     auto x = Vec::create(this->exec, gko::dim<2>{3, 2});
     auto y = Vec::create(this->exec, gko::dim<2>{3, 2});
 
-    ASSERT_THROW(this->mtx1->apply(x.get(), y.get()), gko::DimensionMismatch);
+    ASSERT_THROW(this->mtx1->apply(x, y), gko::DimensionMismatch);
 }
 
 
@@ -468,7 +468,7 @@ TYPED_TEST(Ell, ApplyFailsOnWrongNumberOfCols)
     auto x = Vec::create(this->exec, gko::dim<2>{3}, 2);
     auto y = Vec::create(this->exec, gko::dim<2>{2});
 
-    ASSERT_THROW(this->mtx1->apply(x.get(), y.get()), gko::DimensionMismatch);
+    ASSERT_THROW(this->mtx1->apply(x, y), gko::DimensionMismatch);
 }
 
 
@@ -486,8 +486,8 @@ TYPED_TEST(Ell, ConvertsToPrecision)
                         ? gko::remove_complex<ValueType>{0}
                         : gko::remove_complex<ValueType>{r<OtherType>::value};
 
-    this->mtx1->convert_to(tmp.get());
-    tmp->convert_to(res.get());
+    this->mtx1->convert_to(tmp);
+    tmp->convert_to(res);
 
     GKO_ASSERT_MTX_NEAR(this->mtx1, res, residual);
 }
@@ -507,8 +507,8 @@ TYPED_TEST(Ell, MovesToPrecision)
                         ? gko::remove_complex<ValueType>{0}
                         : gko::remove_complex<ValueType>{r<OtherType>::value};
 
-    this->mtx1->move_to(tmp.get());
-    tmp->move_to(res.get());
+    this->mtx1->move_to(tmp);
+    tmp->move_to(res);
 
     GKO_ASSERT_MTX_NEAR(this->mtx1, res, residual);
 }
@@ -519,7 +519,7 @@ TYPED_TEST(Ell, ConvertsToDense)
     using Vec = typename TestFixture::Vec;
     auto dense_mtx = Vec::create(this->mtx1->get_executor());
 
-    this->mtx1->convert_to(dense_mtx.get());
+    this->mtx1->convert_to(dense_mtx);
 
     // clang-format off
     GKO_ASSERT_MTX_NEAR(dense_mtx,
@@ -534,7 +534,7 @@ TYPED_TEST(Ell, MovesToDense)
     using Vec = typename TestFixture::Vec;
     auto dense_mtx = Vec::create(this->mtx1->get_executor());
 
-    this->mtx1->move_to(dense_mtx.get());
+    this->mtx1->move_to(dense_mtx);
 
     // clang-format off
     GKO_ASSERT_MTX_NEAR(dense_mtx,
@@ -550,7 +550,7 @@ TYPED_TEST(Ell, AppliesWithStrideToDenseVector)
     auto x = gko::initialize<Vec>({2.0, 1.0, 4.0}, this->exec);
     auto y = Vec::create(this->exec, gko::dim<2>{2, 1});
 
-    this->mtx2->apply(x.get(), y.get());
+    this->mtx2->apply(x, y);
 
     GKO_ASSERT_MTX_NEAR(y, l({13.0, 5.0}), 0.0);
 }
@@ -568,7 +568,7 @@ TYPED_TEST(Ell, AppliesWithStrideToDenseMatrix)
     // clang-format on
     auto y = Vec::create(this->exec, gko::dim<2>{2});
 
-    this->mtx2->apply(x.get(), y.get());
+    this->mtx2->apply(x, y);
 
     // clang-format off
     GKO_ASSERT_MTX_NEAR(y,
@@ -586,7 +586,7 @@ TYPED_TEST(Ell, AppliesWithStrideLinearCombinationToDenseVector)
     auto x = gko::initialize<Vec>({2.0, 1.0, 4.0}, this->exec);
     auto y = gko::initialize<Vec>({1.0, 2.0}, this->exec);
 
-    this->mtx2->apply(alpha.get(), x.get(), beta.get(), y.get());
+    this->mtx2->apply(alpha, x, beta, y);
 
     GKO_ASSERT_MTX_NEAR(y, l({-11.0, -1.0}), 0.0);
 }
@@ -608,7 +608,7 @@ TYPED_TEST(Ell, AppliesWithStrideLinearCombinationToDenseMatrix)
          I<T>{2.0, -1.5}}, this->exec);
     // clang-format on
 
-    this->mtx2->apply(alpha.get(), x.get(), beta.get(), y.get());
+    this->mtx2->apply(alpha, x, beta, y);
 
     // clang-format off
     GKO_ASSERT_MTX_NEAR(y,
@@ -624,7 +624,7 @@ TYPED_TEST(Ell, ApplyWithStrideFailsOnWrongInnerDimension)
     auto x = Vec::create(this->exec, gko::dim<2>{2});
     auto y = Vec::create(this->exec, gko::dim<2>{2});
 
-    ASSERT_THROW(this->mtx2->apply(x.get(), y.get()), gko::DimensionMismatch);
+    ASSERT_THROW(this->mtx2->apply(x, y), gko::DimensionMismatch);
 }
 
 
@@ -634,7 +634,7 @@ TYPED_TEST(Ell, ApplyWithStrideFailsOnWrongNumberOfRows)
     auto x = Vec::create(this->exec, gko::dim<2>{3, 2});
     auto y = Vec::create(this->exec, gko::dim<2>{3, 2});
 
-    ASSERT_THROW(this->mtx2->apply(x.get(), y.get()), gko::DimensionMismatch);
+    ASSERT_THROW(this->mtx2->apply(x, y), gko::DimensionMismatch);
 }
 
 
@@ -644,7 +644,7 @@ TYPED_TEST(Ell, ApplyWithStrideFailsOnWrongNumberOfCols)
     auto x = Vec::create(this->exec, gko::dim<2>{3}, 2);
     auto y = Vec::create(this->exec, gko::dim<2>{2});
 
-    ASSERT_THROW(this->mtx2->apply(x.get(), y.get()), gko::DimensionMismatch);
+    ASSERT_THROW(this->mtx2->apply(x, y), gko::DimensionMismatch);
 }
 
 
@@ -658,7 +658,7 @@ TYPED_TEST(Ell, ConvertsWithStrideToDense)
             {0.0, 5.0, 0.0}}, this->exec);
     // clang-format on
 
-    this->mtx2->convert_to(dense_mtx.get());
+    this->mtx2->convert_to(dense_mtx);
 
     // clang-format off
     GKO_ASSERT_MTX_NEAR(dense_mtx,
@@ -673,7 +673,7 @@ TYPED_TEST(Ell, MovesWithStrideToDense)
     using Vec = typename TestFixture::Vec;
     auto dense_mtx = Vec::create(this->mtx2->get_executor());
 
-    this->mtx2->move_to(dense_mtx.get());
+    this->mtx2->move_to(dense_mtx);
 
     // clang-format off
     GKO_ASSERT_MTX_NEAR(dense_mtx,
@@ -692,8 +692,8 @@ TYPED_TEST(Ell, ConvertsToCsr)
     auto csr_mtx_c = Csr::create(this->mtx1->get_executor(), csr_s_classical);
     auto csr_mtx_m = Csr::create(this->mtx1->get_executor(), csr_s_merge);
 
-    this->mtx1->convert_to(csr_mtx_c.get());
-    this->mtx1->convert_to(csr_mtx_m.get());
+    this->mtx1->convert_to(csr_mtx_c);
+    this->mtx1->convert_to(csr_mtx_m);
 
     this->assert_equal_to_mtx(csr_mtx_c.get());
     this->assert_equal_to_mtx(csr_mtx_m.get());
@@ -711,8 +711,8 @@ TYPED_TEST(Ell, MovesToCsr)
     auto csr_mtx_c = Csr::create(this->mtx1->get_executor(), csr_s_classical);
     auto csr_mtx_m = Csr::create(this->mtx1->get_executor(), csr_s_merge);
 
-    this->mtx1->move_to(csr_mtx_c.get());
-    this->mtx1->move_to(csr_mtx_m.get());
+    this->mtx1->move_to(csr_mtx_c);
+    this->mtx1->move_to(csr_mtx_m);
 
     this->assert_equal_to_mtx(csr_mtx_c.get());
     this->assert_equal_to_mtx(csr_mtx_m.get());
@@ -731,8 +731,8 @@ TYPED_TEST(Ell, ConvertsWithStrideToCsr)
     auto csr_mtx_m = Csr::create(this->mtx2->get_executor(), csr_s_merge);
     auto mtx_clone = this->mtx2->clone();
 
-    this->mtx2->convert_to(csr_mtx_c.get());
-    mtx_clone->convert_to(csr_mtx_m.get());
+    this->mtx2->convert_to(csr_mtx_c);
+    mtx_clone->convert_to(csr_mtx_m);
 
     this->assert_equal_to_mtx(csr_mtx_c.get());
     this->assert_equal_to_mtx(csr_mtx_m.get());
@@ -751,8 +751,8 @@ TYPED_TEST(Ell, MovesWithStrideToCsr)
     auto csr_mtx_m = Csr::create(this->mtx2->get_executor(), csr_s_merge);
     auto mtx_clone = this->mtx2->clone();
 
-    this->mtx2->move_to(csr_mtx_c.get());
-    mtx_clone->move_to(csr_mtx_m.get());
+    this->mtx2->move_to(csr_mtx_c);
+    mtx_clone->move_to(csr_mtx_m);
 
     this->assert_equal_to_mtx(csr_mtx_c.get());
     this->assert_equal_to_mtx(csr_mtx_m.get());
@@ -771,7 +771,7 @@ TYPED_TEST(Ell, ConvertsEmptyToPrecision)
     auto empty = Ell::create(this->exec);
     auto res = OtherEll::create(this->exec);
 
-    empty->convert_to(res.get());
+    empty->convert_to(res);
 
     ASSERT_EQ(res->get_num_stored_elements(), 0);
     ASSERT_FALSE(res->get_size());
@@ -788,7 +788,7 @@ TYPED_TEST(Ell, MovesEmptyToPrecision)
     auto empty = Ell::create(this->exec);
     auto res = OtherEll::create(this->exec);
 
-    empty->move_to(res.get());
+    empty->move_to(res);
 
     ASSERT_EQ(res->get_num_stored_elements(), 0);
     ASSERT_FALSE(res->get_size());
@@ -804,7 +804,7 @@ TYPED_TEST(Ell, ConvertsEmptyToDense)
     auto empty = Ell::create(this->exec);
     auto res = Dense::create(this->exec);
 
-    empty->convert_to(res.get());
+    empty->convert_to(res);
 
     ASSERT_FALSE(res->get_size());
 }
@@ -819,7 +819,7 @@ TYPED_TEST(Ell, MovesEmptyToDense)
     auto empty = Ell::create(this->exec);
     auto res = Dense::create(this->exec);
 
-    empty->move_to(res.get());
+    empty->move_to(res);
 
     ASSERT_FALSE(res->get_size());
 }
@@ -834,7 +834,7 @@ TYPED_TEST(Ell, ConvertsEmptyToCsr)
     auto empty = Ell::create(this->exec);
     auto res = Csr::create(this->exec);
 
-    empty->convert_to(res.get());
+    empty->convert_to(res);
 
     ASSERT_EQ(res->get_num_stored_elements(), 0);
     ASSERT_EQ(*res->get_const_row_ptrs(), 0);
@@ -851,7 +851,7 @@ TYPED_TEST(Ell, MovesEmptyToCsr)
     auto empty = Ell::create(this->exec);
     auto res = Csr::create(this->exec);
 
-    empty->move_to(res.get());
+    empty->move_to(res);
 
     ASSERT_EQ(res->get_num_stored_elements(), 0);
     ASSERT_EQ(*res->get_const_row_ptrs(), 0);
@@ -914,7 +914,7 @@ TYPED_TEST(Ell, AppliesToComplex)
     auto x = Vec::create(exec, gko::dim<2>{2,2});
     // clang-format on
 
-    this->mtx1->apply(b.get(), x.get());
+    this->mtx1->apply(b, x);
 
     GKO_ASSERT_MTX_NEAR(
         x,
@@ -940,7 +940,7 @@ TYPED_TEST(Ell, AppliesToMixedComplex)
     auto x = Vec::create(exec, gko::dim<2>{2,2});
     // clang-format on
 
-    this->mtx1->apply(b.get(), x.get());
+    this->mtx1->apply(b, x);
 
     GKO_ASSERT_MTX_NEAR(
         x,
@@ -971,7 +971,7 @@ TYPED_TEST(Ell, AdvancedAppliesToComplex)
     auto beta = gko::initialize<Dense>({2.0}, this->exec);
     // clang-format on
 
-    this->mtx1->apply(alpha.get(), b.get(), beta.get(), x.get());
+    this->mtx1->apply(alpha, b, beta, x);
 
     GKO_ASSERT_MTX_NEAR(
         x,
@@ -1002,7 +1002,7 @@ TYPED_TEST(Ell, AdvancedAppliesToMixedComplex)
     auto beta = gko::initialize<MixedDense>({2.0}, this->exec);
     // clang-format on
 
-    this->mtx1->apply(alpha.get(), b.get(), beta.get(), x.get());
+    this->mtx1->apply(alpha, b, beta, x);
 
     GKO_ASSERT_MTX_NEAR(
         x,

--- a/reference/test/matrix/fbcsr_kernels.cpp
+++ b/reference/test/matrix/fbcsr_kernels.cpp
@@ -90,7 +90,7 @@ protected:
           mtxsq(fbsamplesquare.generate_fbcsr())
     {}
 
-    void assert_equal_to_mtx(const Csr* const m)
+    void assert_equal_to_mtx(gko::pointer_param<const Csr> m)
     {
         ASSERT_EQ(m->get_size(), refcsrmtx->get_size());
         ASSERT_EQ(m->get_num_stored_elements(),
@@ -106,7 +106,7 @@ protected:
         }
     }
 
-    void assert_equal_to_mtx(const SparCsr* m)
+    void assert_equal_to_mtx(gko::pointer_param<const SparCsr> m)
     {
         ASSERT_EQ(m->get_size(), refspcmtx->get_size());
         ASSERT_EQ(m->get_num_nonzeros(), refspcmtx->get_num_nonzeros());
@@ -166,10 +166,10 @@ TYPED_TEST(Fbcsr, AppliesToDenseVector)
     using Csr = typename TestFixture::Csr;
     auto csr_mtx = Csr::create(this->mtx->get_executor(),
                                std::make_shared<typename Csr::classical>());
-    this->mtx2->convert_to(csr_mtx.get());
+    this->mtx2->convert_to(csr_mtx);
 
-    this->mtx2->apply(x.get(), y.get());
-    csr_mtx->apply(x.get(), yref.get());
+    this->mtx2->apply(x, y);
+    csr_mtx->apply(x, yref);
 
     const double tolerance =
         std::numeric_limits<gko::remove_complex<T>>::epsilon();
@@ -189,8 +189,8 @@ TYPED_TEST(Fbcsr, AppliesToDenseMatrix)
     auto y = Vec::create(this->exec, gko::dim<2>{nrows, nvecs});
     auto yref = Vec::create(this->exec, gko::dim<2>{nrows, nvecs});
 
-    this->mtx2->apply(x.get(), y.get());
-    this->ref2csrmtx->apply(x.get(), yref.get());
+    this->mtx2->apply(x, y);
+    this->ref2csrmtx->apply(x, yref);
 
     const double tolerance =
         std::numeric_limits<gko::remove_complex<T>>::epsilon();
@@ -211,8 +211,8 @@ TYPED_TEST(Fbcsr, AppliesToDenseComplexMatrix)
     auto y = CVec::create(this->exec, gko::dim<2>{nrows, nvecs});
     auto yref = CVec::create(this->exec, gko::dim<2>{nrows, nvecs});
 
-    this->mtx2->apply(x.get(), y.get());
-    this->ref2csrmtx->apply(x.get(), yref.get());
+    this->mtx2->apply(x, y);
+    this->ref2csrmtx->apply(x, yref);
 
     const double tolerance =
         std::numeric_limits<gko::remove_complex<T>>::epsilon();
@@ -235,8 +235,8 @@ TYPED_TEST(Fbcsr, AppliesLinearCombinationToDenseVector)
     auto y = get_some_vectors<T>(this->exec, nrows, 1);
     auto yref = y->clone();
 
-    this->mtx2->apply(alpha.get(), x.get(), beta.get(), y.get());
-    this->ref2csrmtx->apply(alpha.get(), x.get(), beta.get(), yref.get());
+    this->mtx2->apply(alpha, x, beta, y);
+    this->ref2csrmtx->apply(alpha, x, beta, yref);
 
     const double tolerance =
         std::numeric_limits<gko::remove_complex<T>>::epsilon();
@@ -260,8 +260,8 @@ TYPED_TEST(Fbcsr, AppliesLinearCombinationToDenseMatrix)
     auto y = get_some_vectors<T>(this->exec, nrows, nvecs);
     auto yref = y->clone();
 
-    this->mtx2->apply(alpha.get(), x.get(), beta.get(), y.get());
-    this->ref2csrmtx->apply(alpha.get(), x.get(), beta.get(), yref.get());
+    this->mtx2->apply(alpha, x, beta, y);
+    this->ref2csrmtx->apply(alpha, x, beta, yref);
 
     const double tolerance =
         std::numeric_limits<gko::remove_complex<T>>::epsilon();
@@ -275,7 +275,7 @@ TYPED_TEST(Fbcsr, ApplyFailsOnWrongInnerDimension)
     auto x = Vec::create(this->exec, gko::dim<2>{2});
     auto y = Vec::create(this->exec, gko::dim<2>{this->fbsample.nrows});
 
-    ASSERT_THROW(this->mtx->apply(x.get(), y.get()), gko::DimensionMismatch);
+    ASSERT_THROW(this->mtx->apply(x, y), gko::DimensionMismatch);
 }
 
 
@@ -285,7 +285,7 @@ TYPED_TEST(Fbcsr, ApplyFailsOnWrongNumberOfRows)
     auto x = Vec::create(this->exec, gko::dim<2>{this->fbsample.ncols, 2});
     auto y = Vec::create(this->exec, gko::dim<2>{3, 2});
 
-    ASSERT_THROW(this->mtx->apply(x.get(), y.get()), gko::DimensionMismatch);
+    ASSERT_THROW(this->mtx->apply(x, y), gko::DimensionMismatch);
 }
 
 
@@ -295,7 +295,7 @@ TYPED_TEST(Fbcsr, ApplyFailsOnWrongNumberOfCols)
     auto x = Vec::create(this->exec, gko::dim<2>{this->fbsample.ncols, 3});
     auto y = Vec::create(this->exec, gko::dim<2>{this->fbsample.nrows, 2});
 
-    ASSERT_THROW(this->mtx->apply(x.get(), y.get()), gko::DimensionMismatch);
+    ASSERT_THROW(this->mtx->apply(x, y), gko::DimensionMismatch);
 }
 
 
@@ -313,8 +313,8 @@ TYPED_TEST(Fbcsr, ConvertsToPrecision)
                         ? gko::remove_complex<ValueType>{0}
                         : gko::remove_complex<ValueType>{r<OtherType>::value};
 
-    this->mtx->convert_to(tmp.get());
-    tmp->convert_to(res.get());
+    this->mtx->convert_to(tmp);
+    tmp->convert_to(res);
 
     GKO_ASSERT_MTX_NEAR(this->mtx, res, residual);
 }
@@ -334,8 +334,8 @@ TYPED_TEST(Fbcsr, MovesToPrecision)
                         ? gko::remove_complex<ValueType>{0}
                         : gko::remove_complex<ValueType>{r<OtherType>::value};
 
-    this->mtx->move_to(tmp.get());
-    tmp->move_to(res.get());
+    this->mtx->move_to(tmp);
+    tmp->move_to(res);
 
     GKO_ASSERT_MTX_NEAR(this->mtx, res, residual);
 }
@@ -346,10 +346,10 @@ TYPED_TEST(Fbcsr, ConvertsToDense)
     using Dense = typename TestFixture::Dense;
     auto dense_mtx = Dense::create(this->mtx->get_executor());
 
-    this->mtx->convert_to(dense_mtx.get());
+    this->mtx->convert_to(dense_mtx);
 
     auto refdenmtx = Dense::create(this->mtx->get_executor());
-    this->refcsrmtx->convert_to(refdenmtx.get());
+    this->refcsrmtx->convert_to(refdenmtx);
     GKO_ASSERT_MTX_NEAR(dense_mtx, refdenmtx, 0.0);
 }
 
@@ -359,10 +359,10 @@ TYPED_TEST(Fbcsr, MovesToDense)
     using Dense = typename TestFixture::Dense;
     auto dense_mtx = Dense::create(this->mtx->get_executor());
 
-    this->mtx->move_to(dense_mtx.get());
+    this->mtx->move_to(dense_mtx);
 
     auto refdenmtx = Dense::create(this->mtx->get_executor());
-    this->refcsrmtx->convert_to(refdenmtx.get());
+    this->refcsrmtx->convert_to(refdenmtx);
     GKO_ASSERT_MTX_NEAR(dense_mtx, refdenmtx, 0.0);
 }
 
@@ -372,12 +372,12 @@ TYPED_TEST(Fbcsr, ConvertsToCsr)
     using Csr = typename TestFixture::Csr;
     auto csr_mtx = Csr::create(this->mtx->get_executor(),
                                std::make_shared<typename Csr::classical>());
-    this->mtx->convert_to(csr_mtx.get());
+    this->mtx->convert_to(csr_mtx);
     this->assert_equal_to_mtx(csr_mtx.get());
 
     auto csr_mtx_2 = Csr::create(this->mtx->get_executor(),
                                  std::make_shared<typename Csr::classical>());
-    this->ref2mtx->convert_to(csr_mtx_2.get());
+    this->ref2mtx->convert_to(csr_mtx_2);
     GKO_ASSERT_MTX_NEAR(csr_mtx_2, this->ref2csrmtx, 0.0);
 }
 
@@ -388,7 +388,7 @@ TYPED_TEST(Fbcsr, MovesToCsr)
     auto csr_mtx = Csr::create(this->mtx->get_executor(),
                                std::make_shared<typename Csr::classical>());
 
-    this->mtx->move_to(csr_mtx.get());
+    this->mtx->move_to(csr_mtx);
 
     this->assert_equal_to_mtx(csr_mtx.get());
 }
@@ -399,7 +399,7 @@ TYPED_TEST(Fbcsr, ConvertsToSparsityCsr)
     using SparsityCsr = typename TestFixture::SparCsr;
     auto sparsity_mtx = SparsityCsr::create(this->mtx->get_executor());
 
-    this->mtx->convert_to(sparsity_mtx.get());
+    this->mtx->convert_to(sparsity_mtx);
 
     this->assert_equal_to_mtx(sparsity_mtx.get());
 }
@@ -411,7 +411,7 @@ TYPED_TEST(Fbcsr, MovesToSparsityCsr)
     using Fbcsr = typename TestFixture::Mtx;
     auto sparsity_mtx = SparsityCsr::create(this->mtx->get_executor());
 
-    this->mtx->move_to(sparsity_mtx.get());
+    this->mtx->move_to(sparsity_mtx);
 
     this->assert_equal_to_mtx(sparsity_mtx.get());
 }
@@ -428,7 +428,7 @@ TYPED_TEST(Fbcsr, ConvertsEmptyToPrecision)
     empty->get_row_ptrs()[0] = 0;
     auto res = Fbcsr::create(this->exec);
 
-    empty->convert_to(res.get());
+    empty->convert_to(res);
 
     ASSERT_EQ(res->get_num_stored_elements(), 0);
     ASSERT_EQ(*res->get_const_row_ptrs(), 0);
@@ -447,7 +447,7 @@ TYPED_TEST(Fbcsr, MovesEmptyToPrecision)
     empty->get_row_ptrs()[0] = 0;
     auto res = Fbcsr::create(this->exec);
 
-    empty->move_to(res.get());
+    empty->move_to(res);
 
     ASSERT_EQ(res->get_num_stored_elements(), 0);
     ASSERT_EQ(*res->get_const_row_ptrs(), 0);
@@ -463,7 +463,7 @@ TYPED_TEST(Fbcsr, ConvertsEmptyToDense)
     auto empty = Fbcsr::create(this->exec);
     auto res = Dense::create(this->exec);
 
-    empty->convert_to(res.get());
+    empty->convert_to(res);
 
     ASSERT_FALSE(res->get_size());
 }
@@ -477,7 +477,7 @@ TYPED_TEST(Fbcsr, MovesEmptyToDense)
     auto empty = Fbcsr::create(this->exec);
     auto res = Dense::create(this->exec);
 
-    empty->move_to(res.get());
+    empty->move_to(res);
 
     ASSERT_FALSE(res->get_size());
 }
@@ -493,7 +493,7 @@ TYPED_TEST(Fbcsr, ConvertsEmptyToSparsityCsr)
     empty->get_row_ptrs()[0] = 0;
     auto res = SparCsr::create(this->exec);
 
-    empty->convert_to(res.get());
+    empty->convert_to(res);
 
     ASSERT_EQ(res->get_num_nonzeros(), 0);
     ASSERT_EQ(*res->get_const_row_ptrs(), 0);
@@ -510,7 +510,7 @@ TYPED_TEST(Fbcsr, MovesEmptyToSparsityCsr)
     empty->get_row_ptrs()[0] = 0;
     auto res = SparCsr::create(this->exec);
 
-    empty->move_to(res.get());
+    empty->move_to(res);
 
     ASSERT_EQ(res->get_num_nonzeros(), 0);
     ASSERT_EQ(*res->get_const_row_ptrs(), 0);
@@ -523,7 +523,7 @@ TYPED_TEST(Fbcsr, SquareMtxIsTransposable)
     using Csr = typename TestFixture::Csr;
     auto csrmtxsq =
         Csr::create(this->exec, std::make_shared<typename Csr::classical>());
-    this->mtxsq->convert_to(csrmtxsq.get());
+    this->mtxsq->convert_to(csrmtxsq);
 
     std::unique_ptr<const gko::LinOp> reftmtx = csrmtxsq->transpose();
     auto reftmtx_as_csr = static_cast<const Csr*>(reftmtx.get());
@@ -540,7 +540,7 @@ TYPED_TEST(Fbcsr, NonSquareMtxIsTransposable)
     using Csr = typename TestFixture::Csr;
     auto csrmtx =
         Csr::create(this->exec, std::make_shared<typename Csr::classical>());
-    this->mtx2->convert_to(csrmtx.get());
+    this->mtx2->convert_to(csrmtx);
 
     std::unique_ptr<gko::LinOp> reftmtx = csrmtx->transpose();
     auto reftmtx_as_csr = static_cast<Csr*>(reftmtx.get());
@@ -664,7 +664,7 @@ TYPED_TEST(FbcsrComplex, ConvertsComplexToCsr)
     auto csr_mtx =
         Csr::create(exec, std::make_shared<typename Csr::classical>());
 
-    mtx->convert_to(csr_mtx.get());
+    mtx->convert_to(csr_mtx);
 
     GKO_ASSERT_MTX_NEAR(csr_mtx, mtx, 0.0);
 }

--- a/reference/test/matrix/fbcsr_kernels.cpp
+++ b/reference/test/matrix/fbcsr_kernels.cpp
@@ -90,7 +90,7 @@ protected:
           mtxsq(fbsamplesquare.generate_fbcsr())
     {}
 
-    void assert_equal_to_mtx(gko::pointer_param<const Csr> m)
+    void assert_equal_to_mtx(gko::ptr_param<const Csr> m)
     {
         ASSERT_EQ(m->get_size(), refcsrmtx->get_size());
         ASSERT_EQ(m->get_num_stored_elements(),
@@ -106,7 +106,7 @@ protected:
         }
     }
 
-    void assert_equal_to_mtx(gko::pointer_param<const SparCsr> m)
+    void assert_equal_to_mtx(gko::ptr_param<const SparCsr> m)
     {
         ASSERT_EQ(m->get_size(), refspcmtx->get_size());
         ASSERT_EQ(m->get_num_nonzeros(), refspcmtx->get_num_nonzeros());

--- a/reference/test/matrix/fft_kernels.cpp
+++ b/reference/test/matrix/fft_kernels.cpp
@@ -108,7 +108,7 @@ protected:
                 dense_ifft->at(i, j) = conj(dense_fft->at(i, j));
             }
         }
-        dense_fft->apply(amplitude.get(), frequency1.get());
+        dense_fft->apply(amplitude, frequency1);
         auto idx2 = [&](gko::size_type x, gko::size_type y) {
             return x * n3 + y;
         };
@@ -125,7 +125,7 @@ protected:
                 }
             }
         }
-        dense_fft2->apply(amplitude.get(), frequency2.get());
+        dense_fft2->apply(amplitude, frequency2);
         auto idx3 = [&](gko::size_type x, gko::size_type y, gko::size_type z) {
             return x * n2 * n3 + y * n3 + z;
         };
@@ -149,7 +149,7 @@ protected:
                 }
             }
         }
-        dense_fft3->apply(amplitude.get(), frequency3.get());
+        dense_fft3->apply(amplitude, frequency3);
     }
 
     std::shared_ptr<const gko::Executor> exec;
@@ -189,8 +189,7 @@ TYPED_TEST(Fft, ThrowsOnNonPowerOfTwo1D)
     auto wrong_fft = TestFixture::Mtx::create(this->exec, 3);
     auto wrong_vec = TestFixture::Vec::create(this->exec, gko::dim<2>(3, 1));
 
-    ASSERT_THROW(wrong_fft->apply(wrong_vec.get(), wrong_vec.get()),
-                 gko::BadDimension);
+    ASSERT_THROW(wrong_fft->apply(wrong_vec, wrong_vec), gko::BadDimension);
 }
 
 
@@ -200,10 +199,10 @@ TYPED_TEST(Fft, ThrowsOnNonPowerOfTwo2D)
         TestFixture::Vec::create(this->exec, gko::dim<2>(3 * 2, 1));
 
     ASSERT_THROW(TestFixture::Mtx2::create(this->exec, 3, 2)
-                     ->apply(wrong_vec.get(), wrong_vec.get()),
+                     ->apply(wrong_vec, wrong_vec),
                  gko::BadDimension);
     ASSERT_THROW(TestFixture::Mtx2::create(this->exec, 2, 3)
-                     ->apply(wrong_vec.get(), wrong_vec.get()),
+                     ->apply(wrong_vec, wrong_vec),
                  gko::BadDimension);
 }
 
@@ -214,13 +213,13 @@ TYPED_TEST(Fft, ThrowsOnNonPowerOfTwo3D)
         TestFixture::Vec::create(this->exec, gko::dim<2>(3 * 2 * 4, 1));
 
     ASSERT_THROW(TestFixture::Mtx3::create(this->exec, 3, 2, 4)
-                     ->apply(wrong_vec.get(), wrong_vec.get()),
+                     ->apply(wrong_vec, wrong_vec),
                  gko::BadDimension);
     ASSERT_THROW(TestFixture::Mtx3::create(this->exec, 2, 3, 4)
-                     ->apply(wrong_vec.get(), wrong_vec.get()),
+                     ->apply(wrong_vec, wrong_vec),
                  gko::BadDimension);
     ASSERT_THROW(TestFixture::Mtx3::create(this->exec, 4, 2, 3)
-                     ->apply(wrong_vec.get(), wrong_vec.get()),
+                     ->apply(wrong_vec, wrong_vec),
                  gko::BadDimension);
 }
 
@@ -344,7 +343,7 @@ TYPED_TEST(Fft, Applies1DToDense)
     using T = typename TestFixture::value_type;
     auto out = this->amplitude->clone();
 
-    this->fft->apply(this->amplitude.get(), out.get());
+    this->fft->apply(this->amplitude, out);
 
     GKO_ASSERT_MTX_NEAR(out, this->frequency1, r<T>::value);
 }
@@ -360,7 +359,7 @@ TYPED_TEST(Fft, AppliesStrided1DToDense)
     auto out =
         TestFixture::Vec::create(this->exec, in_view->get_size(), this->stride);
 
-    this->fft->apply(in_view.get(), out.get());
+    this->fft->apply(in_view, out);
 
     GKO_ASSERT_MTX_NEAR(out, ref_view, r<T>::value);
 }
@@ -371,8 +370,8 @@ TYPED_TEST(Fft, AppliesInverse1DToDense)
     using T = typename TestFixture::value_type;
     auto out = this->frequency1->clone();
 
-    this->ifft->apply(this->frequency1.get(), out.get());
-    out->scale(this->inv_n_scalar.get());
+    this->ifft->apply(this->frequency1, out);
+    out->scale(this->inv_n_scalar);
 
     GKO_ASSERT_MTX_NEAR(out, this->amplitude, r<T>::value);
 }
@@ -388,8 +387,8 @@ TYPED_TEST(Fft, AppliesStridedInverse1DToDense)
     auto out =
         TestFixture::Vec::create(this->exec, in_view->get_size(), this->stride);
 
-    this->ifft->apply(in_view.get(), out.get());
-    out->scale(this->inv_n_scalar.get());
+    this->ifft->apply(in_view, out);
+    out->scale(this->inv_n_scalar);
 
     GKO_ASSERT_MTX_NEAR(out, ref_view, r<T>::value);
 }
@@ -400,7 +399,7 @@ TYPED_TEST(Fft, Applies2DToDense)
     using T = typename TestFixture::value_type;
     auto out = this->amplitude->clone();
 
-    this->fft2->apply(this->amplitude.get(), out.get());
+    this->fft2->apply(this->amplitude, out);
 
     GKO_ASSERT_MTX_NEAR(out, this->frequency2, r<T>::value);
 }
@@ -416,7 +415,7 @@ TYPED_TEST(Fft, AppliesStrided2DToDense)
     auto out =
         TestFixture::Vec::create(this->exec, in_view->get_size(), this->stride);
 
-    this->fft2->apply(in_view.get(), out.get());
+    this->fft2->apply(in_view, out);
 
     GKO_ASSERT_MTX_NEAR(out, ref_view, r<T>::value);
 }
@@ -427,8 +426,8 @@ TYPED_TEST(Fft, AppliesInverse2DToDense)
     using T = typename TestFixture::value_type;
     auto out = this->frequency2->clone();
 
-    this->ifft2->apply(this->frequency2.get(), out.get());
-    out->scale(this->inv_n_scalar.get());
+    this->ifft2->apply(this->frequency2, out);
+    out->scale(this->inv_n_scalar);
 
     GKO_ASSERT_MTX_NEAR(out, this->amplitude, r<T>::value);
 }
@@ -444,8 +443,8 @@ TYPED_TEST(Fft, AppliesStridedInverse2DToDense)
     auto out =
         TestFixture::Vec::create(this->exec, in_view->get_size(), this->stride);
 
-    this->ifft2->apply(in_view.get(), out.get());
-    out->scale(this->inv_n_scalar.get());
+    this->ifft2->apply(in_view, out);
+    out->scale(this->inv_n_scalar);
 
     GKO_ASSERT_MTX_NEAR(out, ref_view, r<T>::value);
 }
@@ -456,7 +455,7 @@ TYPED_TEST(Fft, Applies3DToDense)
     using T = typename TestFixture::value_type;
     auto out = this->amplitude->clone();
 
-    this->fft3->apply(this->amplitude.get(), out.get());
+    this->fft3->apply(this->amplitude, out);
 
     GKO_ASSERT_MTX_NEAR(out, this->frequency3, r<T>::value);
 }
@@ -472,7 +471,7 @@ TYPED_TEST(Fft, AppliesStrided3DToDense)
     auto out =
         TestFixture::Vec::create(this->exec, in_view->get_size(), this->stride);
 
-    this->fft3->apply(in_view.get(), out.get());
+    this->fft3->apply(in_view, out);
 
     GKO_ASSERT_MTX_NEAR(out, ref_view, r<T>::value);
 }
@@ -483,8 +482,8 @@ TYPED_TEST(Fft, AppliesInverse3DToDense)
     using T = typename TestFixture::value_type;
     auto out = this->frequency3->clone();
 
-    this->ifft3->apply(this->frequency3.get(), out.get());
-    out->scale(this->inv_n_scalar.get());
+    this->ifft3->apply(this->frequency3, out);
+    out->scale(this->inv_n_scalar);
 
     GKO_ASSERT_MTX_NEAR(out, this->amplitude, r<T>::value);
 }
@@ -500,8 +499,8 @@ TYPED_TEST(Fft, AppliesStridedInverse3DToDense)
     auto out =
         TestFixture::Vec::create(this->exec, in_view->get_size(), this->stride);
 
-    this->ifft3->apply(in_view.get(), out.get());
-    out->scale(this->inv_n_scalar.get());
+    this->ifft3->apply(in_view, out);
+    out->scale(this->inv_n_scalar);
 
     GKO_ASSERT_MTX_NEAR(out, ref_view, r<T>::value);
 }

--- a/reference/test/matrix/hybrid_kernels.cpp
+++ b/reference/test/matrix/hybrid_kernels.cpp
@@ -137,7 +137,7 @@ TYPED_TEST(Hybrid, AppliesToDenseVector)
     auto x = gko::initialize<Vec>({2.0, 1.0, 4.0}, this->exec);
     auto y = Vec::create(this->exec, gko::dim<2>{2, 1});
 
-    this->mtx1->apply(x.get(), y.get());
+    this->mtx1->apply(x, y);
 
     GKO_ASSERT_MTX_NEAR(y, l({13.0, 5.0}), 0.0);
 }
@@ -149,7 +149,7 @@ TYPED_TEST(Hybrid, AppliesToMixedDenseVector)
     auto x = gko::initialize<MixedVec>({2.0, 1.0, 4.0}, this->exec);
     auto y = MixedVec::create(this->exec, gko::dim<2>{2, 1});
 
-    this->mtx1->apply(x.get(), y.get());
+    this->mtx1->apply(x, y);
 
     GKO_ASSERT_MTX_NEAR(y, l({13.0, 5.0}), 0.0);
 }
@@ -167,7 +167,7 @@ TYPED_TEST(Hybrid, AppliesToDenseMatrix)
     // clang-format on
     auto y = Vec::create(this->exec, gko::dim<2>{2});
 
-    this->mtx1->apply(x.get(), y.get());
+    this->mtx1->apply(x, y);
 
     // clang-format off
     GKO_ASSERT_MTX_NEAR(y,
@@ -185,7 +185,7 @@ TYPED_TEST(Hybrid, AppliesLinearCombinationToDenseVector)
     auto x = gko::initialize<Vec>({2.0, 1.0, 4.0}, this->exec);
     auto y = gko::initialize<Vec>({1.0, 2.0}, this->exec);
 
-    this->mtx1->apply(alpha.get(), x.get(), beta.get(), y.get());
+    this->mtx1->apply(alpha, x, beta, y);
 
     GKO_ASSERT_MTX_NEAR(y, l({-11.0, -1.0}), 0.0);
 }
@@ -199,7 +199,7 @@ TYPED_TEST(Hybrid, AppliesLinearCombinationToMixedDenseVector)
     auto x = gko::initialize<MixedVec>({2.0, 1.0, 4.0}, this->exec);
     auto y = gko::initialize<MixedVec>({1.0, 2.0}, this->exec);
 
-    this->mtx1->apply(alpha.get(), x.get(), beta.get(), y.get());
+    this->mtx1->apply(alpha, x, beta, y);
 
     GKO_ASSERT_MTX_NEAR(y, l({-11.0, -1.0}), 0.0);
 }
@@ -221,7 +221,7 @@ TYPED_TEST(Hybrid, AppliesLinearCombinationToDenseMatrix)
          I<T>{2.0, -1.5}}, this->exec);
     // clang-format on
 
-    this->mtx1->apply(alpha.get(), x.get(), beta.get(), y.get());
+    this->mtx1->apply(alpha, x, beta, y);
 
     // clang-format off
     GKO_ASSERT_MTX_NEAR(y,
@@ -237,7 +237,7 @@ TYPED_TEST(Hybrid, ApplyFailsOnWrongInnerDimension)
     auto x = Vec::create(this->exec, gko::dim<2>{2});
     auto y = Vec::create(this->exec, gko::dim<2>{2});
 
-    ASSERT_THROW(this->mtx1->apply(x.get(), y.get()), gko::DimensionMismatch);
+    ASSERT_THROW(this->mtx1->apply(x, y), gko::DimensionMismatch);
 }
 
 
@@ -247,7 +247,7 @@ TYPED_TEST(Hybrid, ApplyFailsOnWrongNumberOfRows)
     auto x = Vec::create(this->exec, gko::dim<2>{3, 2});
     auto y = Vec::create(this->exec, gko::dim<2>{3, 2});
 
-    ASSERT_THROW(this->mtx1->apply(x.get(), y.get()), gko::DimensionMismatch);
+    ASSERT_THROW(this->mtx1->apply(x, y), gko::DimensionMismatch);
 }
 
 
@@ -257,7 +257,7 @@ TYPED_TEST(Hybrid, ApplyFailsOnWrongNumberOfCols)
     auto x = Vec::create(this->exec, gko::dim<2>{3}, 2);
     auto y = Vec::create(this->exec, gko::dim<2>{2});
 
-    ASSERT_THROW(this->mtx1->apply(x.get(), y.get()), gko::DimensionMismatch);
+    ASSERT_THROW(this->mtx1->apply(x, y), gko::DimensionMismatch);
 }
 
 
@@ -275,8 +275,8 @@ TYPED_TEST(Hybrid, ConvertsToPrecision)
                         ? gko::remove_complex<ValueType>{0}
                         : gko::remove_complex<ValueType>{r<OtherType>::value};
 
-    this->mtx1->convert_to(tmp.get());
-    tmp->convert_to(res.get());
+    this->mtx1->convert_to(tmp);
+    tmp->convert_to(res);
 
     GKO_ASSERT_MTX_NEAR(this->mtx1, res, residual);
 }
@@ -296,8 +296,8 @@ TYPED_TEST(Hybrid, MovesToPrecision)
                         ? gko::remove_complex<ValueType>{0}
                         : gko::remove_complex<ValueType>{r<OtherType>::value};
 
-    this->mtx1->move_to(tmp.get());
-    tmp->move_to(res.get());
+    this->mtx1->move_to(tmp);
+    tmp->move_to(res);
 
     GKO_ASSERT_MTX_NEAR(this->mtx1, res, residual);
 }
@@ -308,7 +308,7 @@ TYPED_TEST(Hybrid, ConvertsToDense)
     using Vec = typename TestFixture::Vec;
     auto dense_mtx = Vec::create(this->mtx1->get_executor());
 
-    this->mtx1->convert_to(dense_mtx.get());
+    this->mtx1->convert_to(dense_mtx);
 
     // clang-format off
     GKO_ASSERT_MTX_NEAR(dense_mtx,
@@ -323,7 +323,7 @@ TYPED_TEST(Hybrid, MovesToDense)
     using Vec = typename TestFixture::Vec;
     auto dense_mtx = Vec::create(this->mtx1->get_executor());
 
-    this->mtx1->move_to(dense_mtx.get());
+    this->mtx1->move_to(dense_mtx);
 
     // clang-format off
     GKO_ASSERT_MTX_NEAR(dense_mtx,
@@ -341,8 +341,8 @@ TYPED_TEST(Hybrid, ConvertsToCsr)
     auto csr_mtx_c = Csr::create(this->mtx1->get_executor(), csr_s_classical);
     auto csr_mtx_m = Csr::create(this->mtx1->get_executor(), csr_s_merge);
 
-    this->mtx1->convert_to(csr_mtx_c.get());
-    this->mtx1->convert_to(csr_mtx_m.get());
+    this->mtx1->convert_to(csr_mtx_c);
+    this->mtx1->convert_to(csr_mtx_m);
 
     this->assert_equal_to_mtx(csr_mtx_c.get());
     this->assert_equal_to_mtx(csr_mtx_m.get());
@@ -360,8 +360,8 @@ TYPED_TEST(Hybrid, MovesToCsr)
     auto csr_mtx_m = Csr::create(this->mtx1->get_executor(), csr_s_merge);
     auto mtx_clone = this->mtx1->clone();
 
-    this->mtx1->move_to(csr_mtx_c.get());
-    mtx_clone->move_to(csr_mtx_m.get());
+    this->mtx1->move_to(csr_mtx_c);
+    mtx_clone->move_to(csr_mtx_m);
 
     this->assert_equal_to_mtx(csr_mtx_c.get());
     this->assert_equal_to_mtx(csr_mtx_m.get());
@@ -375,7 +375,7 @@ TYPED_TEST(Hybrid, ConvertsToCsrWithoutZeros)
     using Csr = typename TestFixture::Csr;
     auto csr_mtx = Csr::create(this->mtx3->get_executor());
 
-    this->mtx3->convert_to(csr_mtx.get());
+    this->mtx3->convert_to(csr_mtx);
 
     this->assert_equal_to_mtx(csr_mtx.get());
 }
@@ -386,7 +386,7 @@ TYPED_TEST(Hybrid, MovesToCsrWithoutZeros)
     using Csr = typename TestFixture::Csr;
     auto csr_mtx = Csr::create(this->mtx3->get_executor());
 
-    this->mtx3->move_to(csr_mtx.get());
+    this->mtx3->move_to(csr_mtx);
 
     this->assert_equal_to_mtx(csr_mtx.get());
 }
@@ -402,7 +402,7 @@ TYPED_TEST(Hybrid, ConvertsEmptyToPrecision)
     auto other = Hybrid::create(this->exec);
     auto res = OtherHybrid::create(this->exec);
 
-    other->convert_to(res.get());
+    other->convert_to(res);
 
     ASSERT_EQ(res->get_num_stored_elements(), 0);
     ASSERT_FALSE(res->get_size());
@@ -419,7 +419,7 @@ TYPED_TEST(Hybrid, MovesEmptyToPrecision)
     auto other = Hybrid::create(this->exec);
     auto res = OtherHybrid::create(this->exec);
 
-    other->move_to(res.get());
+    other->move_to(res);
 
     ASSERT_EQ(res->get_num_stored_elements(), 0);
     ASSERT_FALSE(res->get_size());
@@ -435,7 +435,7 @@ TYPED_TEST(Hybrid, ConvertsEmptyToDense)
     auto other = Hybrid::create(this->exec);
     auto res = Dense::create(this->exec);
 
-    other->convert_to(res.get());
+    other->convert_to(res);
 
     ASSERT_FALSE(res->get_size());
 }
@@ -450,7 +450,7 @@ TYPED_TEST(Hybrid, MovesEmptyToDense)
     auto other = Hybrid::create(this->exec);
     auto res = Dense::create(this->exec);
 
-    other->move_to(res.get());
+    other->move_to(res);
 
     ASSERT_FALSE(res->get_size());
 }
@@ -465,7 +465,7 @@ TYPED_TEST(Hybrid, ConvertsEmptyToCsr)
     auto other = Hybrid::create(this->exec);
     auto res = Csr::create(this->exec);
 
-    other->convert_to(res.get());
+    other->convert_to(res);
 
     ASSERT_EQ(res->get_num_stored_elements(), 0);
     ASSERT_EQ(*res->get_const_row_ptrs(), 0);
@@ -482,7 +482,7 @@ TYPED_TEST(Hybrid, MovesEmptyToCsr)
     auto other = Hybrid::create(this->exec);
     auto res = Csr::create(this->exec);
 
-    other->move_to(res.get());
+    other->move_to(res);
 
     ASSERT_EQ(res->get_num_stored_elements(), 0);
     ASSERT_EQ(*res->get_const_row_ptrs(), 0);
@@ -496,7 +496,7 @@ TYPED_TEST(Hybrid, AppliesWithStrideToDenseVector)
     auto x = gko::initialize<Vec>({2.0, 1.0, 4.0}, this->exec);
     auto y = Vec::create(this->exec, gko::dim<2>{2, 1});
 
-    this->mtx2->apply(x.get(), y.get());
+    this->mtx2->apply(x, y);
 
     GKO_ASSERT_MTX_NEAR(y, l({13.0, 5.0}), 0.0);
 }
@@ -514,7 +514,7 @@ TYPED_TEST(Hybrid, AppliesWithStrideToDenseMatrix)
     // clang-format on
     auto y = Vec::create(this->exec, gko::dim<2>{2});
 
-    this->mtx2->apply(x.get(), y.get());
+    this->mtx2->apply(x, y);
 
     // clang-format off
     GKO_ASSERT_MTX_NEAR(y,
@@ -532,7 +532,7 @@ TYPED_TEST(Hybrid, AppliesWithStrideLinearCombinationToDenseVector)
     auto x = gko::initialize<Vec>({2.0, 1.0, 4.0}, this->exec);
     auto y = gko::initialize<Vec>({1.0, 2.0}, this->exec);
 
-    this->mtx2->apply(alpha.get(), x.get(), beta.get(), y.get());
+    this->mtx2->apply(alpha, x, beta, y);
 
     GKO_ASSERT_MTX_NEAR(y, l({-11.0, -1.0}), 0.0);
 }
@@ -554,7 +554,7 @@ TYPED_TEST(Hybrid, AppliesWithStrideLinearCombinationToDenseMatrix)
          I<T>{2.0, -1.5}}, this->exec);
     // clang-format on
 
-    this->mtx2->apply(alpha.get(), x.get(), beta.get(), y.get());
+    this->mtx2->apply(alpha, x, beta, y);
 
     // clang-format off
     GKO_ASSERT_MTX_NEAR(y,
@@ -570,7 +570,7 @@ TYPED_TEST(Hybrid, ApplyWithStrideFailsOnWrongInnerDimension)
     auto x = Vec::create(this->exec, gko::dim<2>{2});
     auto y = Vec::create(this->exec, gko::dim<2>{2});
 
-    ASSERT_THROW(this->mtx2->apply(x.get(), y.get()), gko::DimensionMismatch);
+    ASSERT_THROW(this->mtx2->apply(x, y), gko::DimensionMismatch);
 }
 
 
@@ -580,7 +580,7 @@ TYPED_TEST(Hybrid, ApplyWithStrideFailsOnWrongNumberOfRows)
     auto x = Vec::create(this->exec, gko::dim<2>{3, 2});
     auto y = Vec::create(this->exec, gko::dim<2>{3, 2});
 
-    ASSERT_THROW(this->mtx2->apply(x.get(), y.get()), gko::DimensionMismatch);
+    ASSERT_THROW(this->mtx2->apply(x, y), gko::DimensionMismatch);
 }
 
 
@@ -590,7 +590,7 @@ TYPED_TEST(Hybrid, ApplyWithStrideFailsOnWrongNumberOfCols)
     auto x = Vec::create(this->exec, gko::dim<2>{3}, 2);
     auto y = Vec::create(this->exec, gko::dim<2>{2});
 
-    ASSERT_THROW(this->mtx2->apply(x.get(), y.get()), gko::DimensionMismatch);
+    ASSERT_THROW(this->mtx2->apply(x, y), gko::DimensionMismatch);
 }
 
 
@@ -604,7 +604,7 @@ TYPED_TEST(Hybrid, ConvertsWithStrideToDense)
             {0.0, 5.0, 0.0}}, this->exec);
     // clang-format on
 
-    this->mtx2->convert_to(dense_mtx.get());
+    this->mtx2->convert_to(dense_mtx);
 
     // clang-format off
     GKO_ASSERT_MTX_NEAR(dense_mtx,
@@ -619,7 +619,7 @@ TYPED_TEST(Hybrid, MovesWithStrideToDense)
     using Vec = typename TestFixture::Vec;
     auto dense_mtx = Vec::create(this->mtx2->get_executor());
 
-    this->mtx2->move_to(dense_mtx.get());
+    this->mtx2->move_to(dense_mtx);
 
     // clang-format off
     GKO_ASSERT_MTX_NEAR(dense_mtx,
@@ -715,7 +715,7 @@ TYPED_TEST(Hybrid, AppliesToComplex)
     auto x = Vec::create(exec, gko::dim<2>{2,2});
     // clang-format on
 
-    this->mtx1->apply(b.get(), x.get());
+    this->mtx1->apply(b, x);
 
     GKO_ASSERT_MTX_NEAR(
         x,
@@ -741,7 +741,7 @@ TYPED_TEST(Hybrid, AppliesToMixedComplex)
     auto x = Vec::create(exec, gko::dim<2>{2,2});
     // clang-format on
 
-    this->mtx1->apply(b.get(), x.get());
+    this->mtx1->apply(b, x);
 
     GKO_ASSERT_MTX_NEAR(
         x,
@@ -772,7 +772,7 @@ TYPED_TEST(Hybrid, AdvancedAppliesToComplex)
     auto beta = gko::initialize<Dense>({2.0}, this->exec);
     // clang-format on
 
-    this->mtx1->apply(alpha.get(), b.get(), beta.get(), x.get());
+    this->mtx1->apply(alpha, b, beta, x);
 
     GKO_ASSERT_MTX_NEAR(
         x,
@@ -804,7 +804,7 @@ TYPED_TEST(Hybrid, AdvancedAppliesToMixedComplex)
     auto beta = gko::initialize<MixedDense>({2.0}, this->exec);
     // clang-format on
 
-    this->mtx1->apply(alpha.get(), b.get(), beta.get(), x.get());
+    this->mtx1->apply(alpha, b, beta, x);
 
     GKO_ASSERT_MTX_NEAR(
         x,

--- a/reference/test/matrix/identity.cpp
+++ b/reference/test/matrix/identity.cpp
@@ -72,7 +72,7 @@ TYPED_TEST(Identity, AppliesToVector)
     auto x = gko::initialize<Vec>({3.0, -1.0, 2.0}, this->exec);
     auto b = gko::initialize<Vec>({2.0, 1.0, 5.0}, this->exec);
 
-    identity->apply(b.get(), x.get());
+    identity->apply(b, x);
 
     GKO_ASSERT_MTX_NEAR(x, l({2.0, 1.0, 5.0}), 0.0);
 }
@@ -88,7 +88,7 @@ TYPED_TEST(Identity, AppliesToMultipleVectors)
     auto b = gko::initialize<Vec>(
         3, {I<T>{2.0, 3.0}, I<T>{1.0, 2.0}, I<T>{5.0, -1.0}}, this->exec);
 
-    identity->apply(b.get(), x.get());
+    identity->apply(b, x);
 
     GKO_ASSERT_MTX_NEAR(x, l({{2.0, 3.0}, {1.0, 2.0}, {5.0, -1.0}}), 0.0);
 }
@@ -102,7 +102,7 @@ TYPED_TEST(Identity, AppliesToMixedVector)
     auto x = gko::initialize<MixedVec>({3.0, -1.0, 2.0}, this->exec);
     auto b = gko::initialize<MixedVec>({2.0, 1.0, 5.0}, this->exec);
 
-    identity->apply(b.get(), x.get());
+    identity->apply(b, x);
 
     GKO_ASSERT_MTX_NEAR(x, l({2.0, 1.0, 5.0}), 0.0);
 }
@@ -118,7 +118,7 @@ TYPED_TEST(Identity, AppliesLinearCombinationToVector)
     auto x = gko::initialize<Vec>({3.0, -1.0, 2.0}, this->exec);
     auto b = gko::initialize<Vec>({2.0, 1.0, 5.0}, this->exec);
 
-    identity->apply(alpha.get(), b.get(), beta.get(), x.get());
+    identity->apply(alpha, b, beta, x);
 
     GKO_ASSERT_MTX_NEAR(x, l({7.0, 1.0, 12.0}), 0.0);
 }
@@ -134,7 +134,7 @@ TYPED_TEST(Identity, AppliesLinearCombinationToMixedVector)
     auto x = gko::initialize<MixedVec>({3.0, -1.0, 2.0}, this->exec);
     auto b = gko::initialize<MixedVec>({2.0, 1.0, 5.0}, this->exec);
 
-    identity->apply(alpha.get(), b.get(), beta.get(), x.get());
+    identity->apply(alpha, b, beta, x);
 
     GKO_ASSERT_MTX_NEAR(x, l({7.0, 1.0, 12.0}), 0.0);
 }
@@ -153,7 +153,7 @@ TYPED_TEST(Identity, AppliesLinearCombinationToMultipleVectors)
     auto b = gko::initialize<Vec>(
         3, {I<T>{2.0, 3.0}, I<T>{1.0, 2.0}, I<T>{5.0, -1.0}}, this->exec);
 
-    identity->apply(alpha.get(), b.get(), beta.get(), x.get());
+    identity->apply(alpha, b, beta, x);
 
     GKO_ASSERT_MTX_NEAR(x, l({{7.0, 6.5}, {1.0, 6.5}, {12.0, 1.5}}), 0.0);
 }
@@ -167,7 +167,7 @@ TYPED_TEST(Identity, AppliesToComplex)
     auto x = gko::initialize<ComplexVec>({3.0, -1.0, 2.0}, this->exec);
     auto b = gko::initialize<ComplexVec>({2.0, 1.0, 5.0}, this->exec);
 
-    identity->apply(b.get(), x.get());
+    identity->apply(b, x);
 
     GKO_ASSERT_MTX_NEAR(x, l({2.0, 1.0, 5.0}), 0.0);
 }
@@ -181,7 +181,7 @@ TYPED_TEST(Identity, AppliesToMixedComplex)
     auto x = gko::initialize<MixedComplexVec>({3.0, -1.0, 2.0}, this->exec);
     auto b = gko::initialize<MixedComplexVec>({2.0, 1.0, 5.0}, this->exec);
 
-    identity->apply(b.get(), x.get());
+    identity->apply(b, x);
 
     GKO_ASSERT_MTX_NEAR(x, l({2.0, 1.0, 5.0}), 0.0);
 }
@@ -198,7 +198,7 @@ TYPED_TEST(Identity, AppliesLinearCombinationToComplex)
     auto x = gko::initialize<ComplexVec>({3.0, -1.0, 2.0}, this->exec);
     auto b = gko::initialize<ComplexVec>({2.0, 1.0, 5.0}, this->exec);
 
-    identity->apply(alpha.get(), b.get(), beta.get(), x.get());
+    identity->apply(alpha, b, beta, x);
 
     GKO_ASSERT_MTX_NEAR(x, l({7.0, 1.0, 12.0}), 0.0);
 }
@@ -215,7 +215,7 @@ TYPED_TEST(Identity, AppliesLinearCombinationToMixedComplex)
     auto x = gko::initialize<MixedComplexVec>({3.0, -1.0, 2.0}, this->exec);
     auto b = gko::initialize<MixedComplexVec>({2.0, 1.0, 5.0}, this->exec);
 
-    identity->apply(alpha.get(), b.get(), beta.get(), x.get());
+    identity->apply(alpha, b, beta, x);
 
     GKO_ASSERT_MTX_NEAR(x, l({7.0, 1.0, 12.0}), 0.0);
 }

--- a/reference/test/matrix/permutation.cpp
+++ b/reference/test/matrix/permutation.cpp
@@ -83,9 +83,9 @@ TYPED_TEST(Permutation, AppliesRowPermutationToDense)
     auto perm = gko::matrix::Permutation<i_type>::create(
         this->exec, gko::dim<2>{2}, gko::make_array_view(this->exec, 2, rdata));
 
-    perm->apply(x.get(), y.get());
+    perm->apply(x, y);
     // clang-format off
-    GKO_ASSERT_MTX_NEAR(y.get(),
+    GKO_ASSERT_MTX_NEAR(y,
                         l({{4.0, 2.5},
                            {2.0, 3.0}}),
                         0.0);
@@ -110,9 +110,9 @@ TYPED_TEST(Permutation, AppliesColPermutationToDense)
         this->exec, gko::dim<2>{2}, gko::make_array_view(this->exec, 2, rdata),
         gko::matrix::column_permute);
 
-    perm->apply(x.get(), y.get());
+    perm->apply(x, y);
     // clang-format off
-    GKO_ASSERT_MTX_NEAR(y.get(),
+    GKO_ASSERT_MTX_NEAR(y,
                         l({{3.0, 2.0},
                            {2.5, 4.0}}),
                         0.0);
@@ -141,10 +141,10 @@ TYPED_TEST(Permutation, AppliesRowAndColPermutationToDense)
         this->exec, gko::dim<2>{2}, gko::make_array_view(this->exec, 2, cdata),
         gko::matrix::column_permute);
 
-    rperm->apply(x.get(), y1.get());
-    cperm->apply(y1.get(), y2.get());
+    rperm->apply(x, y1);
+    cperm->apply(y1, y2);
     // clang-format off
-    GKO_ASSERT_MTX_NEAR(y2.get(),
+    GKO_ASSERT_MTX_NEAR(y2,
                         l({{2.5, 4.0},
                            {3.0, 2.0}}),
                         0.0);
@@ -169,9 +169,9 @@ TYPED_TEST(Permutation, AppliesRowAndColPermutationToDenseWithOneArray)
         this->exec, gko::dim<2>{2}, gko::make_array_view(this->exec, 2, data),
         gko::matrix::row_permute | gko::matrix::column_permute);
 
-    perm->apply(x.get(), y1.get());
+    perm->apply(x, y1);
     // clang-format off
-    GKO_ASSERT_MTX_NEAR(y1.get(),
+    GKO_ASSERT_MTX_NEAR(y1,
                         l({{2.5, 4.0},
                            {3.0, 2.0}}),
                         0.0);
@@ -201,10 +201,10 @@ TYPED_TEST(Permutation, AppliesInverseRowAndColPermutationToDense)
         this->exec, gko::dim<2>{3}, gko::make_array_view(this->exec, 3, cdata),
         gko::matrix::inverse_permute | gko::matrix::column_permute);
 
-    rperm->apply(x.get(), y1.get());
-    cperm->apply(y1.get(), y2.get());
+    rperm->apply(x, y1);
+    cperm->apply(y1, y2);
     // clang-format off
-    GKO_ASSERT_MTX_NEAR(y2.get(),
+    GKO_ASSERT_MTX_NEAR(y2,
                         l({{2.5, 0.0, 4.0},
                            {0.0, 2.0, 3.0},
                            {0.0, 0.0, 1.0}}),
@@ -231,9 +231,9 @@ TYPED_TEST(Permutation, AppliesInverseRowAndColPermutationToDenseWithOneArray)
         gko::matrix::column_permute | gko::matrix::row_permute |
             gko::matrix::inverse_permute);
 
-    perm->apply(x.get(), y1.get());
+    perm->apply(x, y1);
     // clang-format off
-    GKO_ASSERT_MTX_NEAR(y1.get(),
+    GKO_ASSERT_MTX_NEAR(y1,
                         l({{2.5, 0.0, 4.0},
                            {0.0, 2.0, 3.0},
                            {0.0, 0.0, 1.0}}),
@@ -259,9 +259,9 @@ TYPED_TEST(Permutation, AppliesInverseRowPermutationToDense)
         this->exec, gko::dim<2>{3}, gko::make_array_view(this->exec, 3, rdata),
         gko::matrix::row_permute | gko::matrix::inverse_permute);
 
-    rperm->apply(x.get(), y.get());
+    rperm->apply(x, y);
     // clang-format off
-    GKO_ASSERT_MTX_NEAR(y.get(),
+    GKO_ASSERT_MTX_NEAR(y,
                         l({{0.0, 4.0, 2.5},
                            {2.0, 3.0, 0.0},
                            {0.0, 1.0, 0.0}}),
@@ -287,9 +287,9 @@ TYPED_TEST(Permutation, AppliesInverseColPermutationToDense)
         this->exec, gko::dim<2>{3}, gko::make_array_view(this->exec, 3, cdata),
         gko::matrix::inverse_permute | gko::matrix::column_permute);
 
-    cperm->apply(x.get(), y.get());
+    cperm->apply(x, y);
     // clang-format off
-    GKO_ASSERT_MTX_NEAR(y.get(),
+    GKO_ASSERT_MTX_NEAR(y,
                       l({{0.0, 2.0, 3.0},
                          {0.0, 0.0, 1.0},
                          {2.5, 0.0, 4.0}}),
@@ -315,9 +315,9 @@ TYPED_TEST(Permutation, AppliesRowPermutationToCsr)
     auto perm = gko::matrix::Permutation<i_type>::create(
         this->exec, gko::dim<2>{3}, gko::make_array_view(this->exec, 3, rdata));
 
-    perm->apply(x.get(), y.get());
+    perm->apply(x, y);
     // clang-format off
-    GKO_ASSERT_MTX_NEAR(y.get(),
+    GKO_ASSERT_MTX_NEAR(y,
                         l({{0.0, 1.0, 0.0},
                            {0.0, 4.0, 2.5},
                            {2.0, 3.0, 0.0}}),
@@ -344,9 +344,9 @@ TYPED_TEST(Permutation, AppliesColPermutationToCsr)
         this->exec, gko::dim<2>{3}, gko::make_array_view(this->exec, 3, cdata),
         gko::matrix::column_permute);
 
-    perm->apply(x.get(), y.get());
+    perm->apply(x, y);
     // clang-format off
-    GKO_ASSERT_MTX_NEAR(y.get(),
+    GKO_ASSERT_MTX_NEAR(y,
                       l({{3.0, 0.0, 2.0},
                          {1.0, 0.0, 0.0},
                          {4.0, 2.5, 0.0}}),
@@ -377,10 +377,10 @@ TYPED_TEST(Permutation, AppliesRowAndColPermutationToCsr)
         this->exec, gko::dim<2>{3}, gko::make_array_view(this->exec, 3, cdata),
         gko::matrix::column_permute);
 
-    rperm->apply(x.get(), y1.get());
-    cperm->apply(y1.get(), y2.get());
+    rperm->apply(x, y1);
+    cperm->apply(y1, y2);
     // clang-format off
-    GKO_ASSERT_MTX_NEAR(y2.get(),
+    GKO_ASSERT_MTX_NEAR(y2,
                       l({{1.0, 0.0, 0.0},
                          {4.0, 2.5, 0.0},
                          {3.0, 0.0, 2.0}}),
@@ -406,9 +406,9 @@ TYPED_TEST(Permutation, AppliesInverseRowPermutationToCsr)
         this->exec, gko::dim<2>{3}, gko::make_array_view(this->exec, 3, rdata),
         gko::matrix::row_permute | gko::matrix::inverse_permute);
 
-    rperm->apply(x.get(), y.get());
+    rperm->apply(x, y);
     // clang-format off
-    GKO_ASSERT_MTX_NEAR(y.get(),
+    GKO_ASSERT_MTX_NEAR(y,
                         l({{0.0, 4.0, 2.5},
                            {2.0, 3.0, 0.0},
                            {0.0, 1.0, 0.0}}),
@@ -434,9 +434,9 @@ TYPED_TEST(Permutation, AppliesInverseColPermutationToCsr)
         this->exec, gko::dim<2>{3}, gko::make_array_view(this->exec, 3, cdata),
         gko::matrix::inverse_permute | gko::matrix::column_permute);
 
-    cperm->apply(x.get(), y.get());
+    cperm->apply(x, y);
     // clang-format off
-    GKO_ASSERT_MTX_NEAR(y.get(),
+    GKO_ASSERT_MTX_NEAR(y,
                       l({{0.0, 2.0, 3.0},
                          {0.0, 0.0, 1.0},
                          {2.5, 0.0, 4.0}}),
@@ -467,10 +467,10 @@ TYPED_TEST(Permutation, AppliesInverseRowAndColPermutationToCsr)
         this->exec, gko::dim<2>{3}, gko::make_array_view(this->exec, 3, cdata),
         gko::matrix::inverse_permute | gko::matrix::column_permute);
 
-    rperm->apply(x.get(), y1.get());
-    cperm->apply(y1.get(), y2.get());
+    rperm->apply(x, y1);
+    cperm->apply(y1, y2);
     // clang-format off
-    GKO_ASSERT_MTX_NEAR(y2.get(),
+    GKO_ASSERT_MTX_NEAR(y2,
                         l({{2.5, 0.0, 4.0},
                            {0.0, 2.0, 3.0},
                            {0.0, 0.0, 1.0}}),

--- a/reference/test/matrix/sellp_kernels.cpp
+++ b/reference/test/matrix/sellp_kernels.cpp
@@ -90,7 +90,7 @@ TYPED_TEST(Sellp, AppliesToDenseVector)
     auto x = gko::initialize<Vec>({2.0, 1.0, 4.0}, this->exec);
     auto y = Vec::create(this->exec, gko::dim<2>{2, 1});
 
-    this->mtx1->apply(x.get(), y.get());
+    this->mtx1->apply(x, y);
 
     GKO_ASSERT_MTX_NEAR(y, l({13.0, 5.0}), 0.0);
 }
@@ -103,7 +103,7 @@ TYPED_TEST(Sellp, AppliesToMixedDenseVector)
     auto x = gko::initialize<Vec>({2.0, 1.0, 4.0}, this->exec);
     auto y = Vec::create(this->exec, gko::dim<2>{2, 1});
 
-    this->mtx1->apply(x.get(), y.get());
+    this->mtx1->apply(x, y);
 
     GKO_ASSERT_MTX_NEAR(y, l({13.0, 5.0}), 0.0);
 }
@@ -121,7 +121,7 @@ TYPED_TEST(Sellp, AppliesToDenseMatrix)
     // clang-format on
     auto y = Vec::create(this->exec, gko::dim<2>{2});
 
-    this->mtx1->apply(x.get(), y.get());
+    this->mtx1->apply(x, y);
 
     // clang-format off
     GKO_ASSERT_MTX_NEAR(y,
@@ -139,7 +139,7 @@ TYPED_TEST(Sellp, AppliesLinearCombinationToDenseVector)
     auto x = gko::initialize<Vec>({2.0, 1.0, 4.0}, this->exec);
     auto y = gko::initialize<Vec>({1.0, 2.0}, this->exec);
 
-    this->mtx1->apply(alpha.get(), x.get(), beta.get(), y.get());
+    this->mtx1->apply(alpha, x, beta, y);
 
     GKO_ASSERT_MTX_NEAR(y, l({-11.0, -1.0}), 0.0);
 }
@@ -154,7 +154,7 @@ TYPED_TEST(Sellp, AppliesLinearCombinationToMixedDenseVector)
     auto x = gko::initialize<Vec>({2.0, 1.0, 4.0}, this->exec);
     auto y = gko::initialize<Vec>({1.0, 2.0}, this->exec);
 
-    this->mtx1->apply(alpha.get(), x.get(), beta.get(), y.get());
+    this->mtx1->apply(alpha, x, beta, y);
 
     GKO_ASSERT_MTX_NEAR(y, l({-11.0, -1.0}), 0.0);
 }
@@ -176,7 +176,7 @@ TYPED_TEST(Sellp, AppliesLinearCombinationToDenseMatrix)
          I<T>{2.0, -1.5}}, this->exec);
     // clang-format on
 
-    this->mtx1->apply(alpha.get(), x.get(), beta.get(), y.get());
+    this->mtx1->apply(alpha, x, beta, y);
 
     // clang-format off
     GKO_ASSERT_MTX_NEAR(y,
@@ -192,7 +192,7 @@ TYPED_TEST(Sellp, ApplyFailsOnWrongInnerDimension)
     auto x = Vec::create(this->exec, gko::dim<2>{2});
     auto y = Vec::create(this->exec, gko::dim<2>{2});
 
-    ASSERT_THROW(this->mtx1->apply(x.get(), y.get()), gko::DimensionMismatch);
+    ASSERT_THROW(this->mtx1->apply(x, y), gko::DimensionMismatch);
 }
 
 
@@ -202,7 +202,7 @@ TYPED_TEST(Sellp, ApplyFailsOnWrongNumberOfRows)
     auto x = Vec::create(this->exec, gko::dim<2>{3, 2});
     auto y = Vec::create(this->exec, gko::dim<2>{3, 2});
 
-    ASSERT_THROW(this->mtx1->apply(x.get(), y.get()), gko::DimensionMismatch);
+    ASSERT_THROW(this->mtx1->apply(x, y), gko::DimensionMismatch);
 }
 
 
@@ -212,7 +212,7 @@ TYPED_TEST(Sellp, ApplyFailsOnWrongNumberOfCols)
     auto x = Vec::create(this->exec, gko::dim<2>{3}, 2);
     auto y = Vec::create(this->exec, gko::dim<2>{2});
 
-    ASSERT_THROW(this->mtx1->apply(x.get(), y.get()), gko::DimensionMismatch);
+    ASSERT_THROW(this->mtx1->apply(x, y), gko::DimensionMismatch);
 }
 
 
@@ -230,8 +230,8 @@ TYPED_TEST(Sellp, ConvertsToPrecision)
                         ? gko::remove_complex<ValueType>{0}
                         : gko::remove_complex<ValueType>{r<OtherType>::value};
 
-    this->mtx1->convert_to(tmp.get());
-    tmp->convert_to(res.get());
+    this->mtx1->convert_to(tmp);
+    tmp->convert_to(res);
 
     GKO_ASSERT_MTX_NEAR(this->mtx1, res, residual);
 }
@@ -251,8 +251,8 @@ TYPED_TEST(Sellp, MovesToPrecision)
                         ? gko::remove_complex<ValueType>{0}
                         : gko::remove_complex<ValueType>{r<OtherType>::value};
 
-    this->mtx1->move_to(tmp.get());
-    tmp->move_to(res.get());
+    this->mtx1->move_to(tmp);
+    tmp->move_to(res);
 
     GKO_ASSERT_MTX_NEAR(this->mtx1, res, residual);
 }
@@ -263,7 +263,7 @@ TYPED_TEST(Sellp, ConvertsToDense)
     using Vec = typename TestFixture::Vec;
     auto dense_mtx = Vec::create(this->mtx1->get_executor());
 
-    this->mtx1->convert_to(dense_mtx.get());
+    this->mtx1->convert_to(dense_mtx);
 
     // clang-format off
     GKO_ASSERT_MTX_NEAR(dense_mtx,
@@ -278,7 +278,7 @@ TYPED_TEST(Sellp, MovesToDense)
     using Vec = typename TestFixture::Vec;
     auto dense_mtx = Vec::create(this->mtx1->get_executor());
 
-    this->mtx1->move_to(dense_mtx.get());
+    this->mtx1->move_to(dense_mtx);
 
     // clang-format off
     GKO_ASSERT_MTX_NEAR(dense_mtx,
@@ -296,15 +296,15 @@ TYPED_TEST(Sellp, ConvertsToCsr)
     auto csr_mtx_c = Csr::create(this->mtx1->get_executor(), csr_s_classical);
     auto csr_mtx_m = Csr::create(this->mtx1->get_executor(), csr_s_merge);
 
-    this->mtx1->convert_to(csr_mtx_c.get());
-    this->mtx1->convert_to(csr_mtx_m.get());
+    this->mtx1->convert_to(csr_mtx_c);
+    this->mtx1->convert_to(csr_mtx_m);
 
     // clang-format off
     GKO_ASSERT_MTX_NEAR(csr_mtx_c,
                         l({{1.0, 3.0, 2.0},
                            {0.0, 5.0, 0.0}}), 0.0);
     // clang-format on
-    GKO_ASSERT_MTX_NEAR(csr_mtx_c.get(), csr_mtx_m.get(), 0.0);
+    GKO_ASSERT_MTX_NEAR(csr_mtx_c, csr_mtx_m, 0.0);
     ASSERT_EQ(csr_mtx_c->get_strategy()->get_name(), "classical");
     ASSERT_EQ(csr_mtx_m->get_strategy()->get_name(), "merge_path");
 }
@@ -319,15 +319,15 @@ TYPED_TEST(Sellp, MovesToCsr)
     auto csr_mtx_m = Csr::create(this->mtx1->get_executor(), csr_s_merge);
     auto mtx_clone = this->mtx1->clone();
 
-    this->mtx1->move_to(csr_mtx_c.get());
-    mtx_clone->move_to(csr_mtx_m.get());
+    this->mtx1->move_to(csr_mtx_c);
+    mtx_clone->move_to(csr_mtx_m);
 
     // clang-format off
     GKO_ASSERT_MTX_NEAR(csr_mtx_c,
                         l({{1.0, 3.0, 2.0},
                            {0.0, 5.0, 0.0}}), 0.0);
     // clang-format on
-    GKO_ASSERT_MTX_NEAR(csr_mtx_c.get(), csr_mtx_m.get(), 0.0);
+    GKO_ASSERT_MTX_NEAR(csr_mtx_c, csr_mtx_m, 0.0);
     ASSERT_EQ(csr_mtx_c->get_strategy()->get_name(), "classical");
     ASSERT_EQ(csr_mtx_m->get_strategy()->get_name(), "merge_path");
 }
@@ -344,7 +344,7 @@ TYPED_TEST(Sellp, ConvertsEmptyToPrecision)
     empty->get_slice_sets()[0] = 0;
     auto res = Sellp::create(this->exec);
 
-    empty->convert_to(res.get());
+    empty->convert_to(res);
 
     ASSERT_EQ(res->get_num_stored_elements(), 0);
     ASSERT_EQ(*res->get_const_slice_sets(), 0);
@@ -363,7 +363,7 @@ TYPED_TEST(Sellp, MovesEmptyToPrecision)
     empty->get_slice_sets()[0] = 0;
     auto res = Sellp::create(this->exec);
 
-    empty->move_to(res.get());
+    empty->move_to(res);
 
     ASSERT_EQ(res->get_num_stored_elements(), 0);
     ASSERT_EQ(*res->get_const_slice_sets(), 0);
@@ -380,7 +380,7 @@ TYPED_TEST(Sellp, ConvertsEmptyToDense)
     auto empty = Sellp::create(this->exec);
     auto res = Dense::create(this->exec);
 
-    empty->convert_to(res.get());
+    empty->convert_to(res);
 
     ASSERT_FALSE(res->get_size());
 }
@@ -395,7 +395,7 @@ TYPED_TEST(Sellp, MovesEmptyToDense)
     auto empty = Sellp::create(this->exec);
     auto res = Dense::create(this->exec);
 
-    empty->move_to(res.get());
+    empty->move_to(res);
 
     ASSERT_FALSE(res->get_size());
 }
@@ -410,7 +410,7 @@ TYPED_TEST(Sellp, ConvertsEmptyToCsr)
     auto empty = Sellp::create(this->exec);
     auto res = Csr::create(this->exec);
 
-    empty->convert_to(res.get());
+    empty->convert_to(res);
 
     ASSERT_EQ(res->get_num_stored_elements(), 0);
     ASSERT_EQ(*res->get_const_row_ptrs(), 0);
@@ -427,7 +427,7 @@ TYPED_TEST(Sellp, MovesEmptyToCsr)
     auto empty = Sellp::create(this->exec);
     auto res = Csr::create(this->exec);
 
-    empty->move_to(res.get());
+    empty->move_to(res);
 
     ASSERT_EQ(res->get_num_stored_elements(), 0);
     ASSERT_EQ(*res->get_const_row_ptrs(), 0);
@@ -441,7 +441,7 @@ TYPED_TEST(Sellp, AppliesWithSliceSizeAndStrideFactorToDenseVector)
     auto x = gko::initialize<Vec>({2.0, 1.0, 4.0}, this->exec);
     auto y = Vec::create(this->exec, gko::dim<2>{2, 1});
 
-    this->mtx2->apply(x.get(), y.get());
+    this->mtx2->apply(x, y);
 
     GKO_ASSERT_MTX_NEAR(y, l({13.0, 5.0}), 0.0);
 }
@@ -459,7 +459,7 @@ TYPED_TEST(Sellp, AppliesWithSliceSizeAndStrideFactorToDenseMatrix)
     // clang-format on
     auto y = Vec::create(this->exec, gko::dim<2>{2});
 
-    this->mtx2->apply(x.get(), y.get());
+    this->mtx2->apply(x, y);
 
     // clang-format off
     GKO_ASSERT_MTX_NEAR(y,
@@ -478,7 +478,7 @@ TYPED_TEST(Sellp,
     auto x = gko::initialize<Vec>({2.0, 1.0, 4.0}, this->exec);
     auto y = gko::initialize<Vec>({1.0, 2.0}, this->exec);
 
-    this->mtx2->apply(alpha.get(), x.get(), beta.get(), y.get());
+    this->mtx2->apply(alpha, x, beta, y);
 
     GKO_ASSERT_MTX_NEAR(y, l({-11.0, -1.0}), 0.0);
 }
@@ -501,7 +501,7 @@ TYPED_TEST(Sellp,
          I<T>{2.0, -1.5}}, this->exec);
     // clang-format on
 
-    this->mtx2->apply(alpha.get(), x.get(), beta.get(), y.get());
+    this->mtx2->apply(alpha, x, beta, y);
 
     // clang-format off
     GKO_ASSERT_MTX_NEAR(y,
@@ -517,7 +517,7 @@ TYPED_TEST(Sellp, ApplyWithSliceSizeAndStrideFactorFailsOnWrongInnerDimension)
     auto x = Vec::create(this->exec, gko::dim<2>{2});
     auto y = Vec::create(this->exec, gko::dim<2>{2});
 
-    ASSERT_THROW(this->mtx2->apply(x.get(), y.get()), gko::DimensionMismatch);
+    ASSERT_THROW(this->mtx2->apply(x, y), gko::DimensionMismatch);
 }
 
 
@@ -527,7 +527,7 @@ TYPED_TEST(Sellp, ApplyWithSliceSizeAndStrideFactorFailsOnWrongNumberOfRows)
     auto x = Vec::create(this->exec, gko::dim<2>{3, 2});
     auto y = Vec::create(this->exec, gko::dim<2>{3, 2});
 
-    ASSERT_THROW(this->mtx2->apply(x.get(), y.get()), gko::DimensionMismatch);
+    ASSERT_THROW(this->mtx2->apply(x, y), gko::DimensionMismatch);
 }
 
 
@@ -537,7 +537,7 @@ TYPED_TEST(Sellp, ApplyWithSliceSizeAndStrideFactorFailsOnWrongNumberOfCols)
     auto x = Vec::create(this->exec, gko::dim<2>{3}, 2);
     auto y = Vec::create(this->exec, gko::dim<2>{2});
 
-    ASSERT_THROW(this->mtx2->apply(x.get(), y.get()), gko::DimensionMismatch);
+    ASSERT_THROW(this->mtx2->apply(x, y), gko::DimensionMismatch);
 }
 
 
@@ -551,7 +551,7 @@ TYPED_TEST(Sellp, ConvertsWithSliceSizeAndStrideFactorToDense)
             {0.0, 5.0, 0.0}}, this->exec);
     // clang-format on
 
-    this->mtx2->convert_to(dense_mtx.get());
+    this->mtx2->convert_to(dense_mtx);
 
     // clang-format off
     GKO_ASSERT_MTX_NEAR(dense_mtx,
@@ -566,7 +566,7 @@ TYPED_TEST(Sellp, MovesWithSliceSizeAndStrideFactorToDense)
     using Vec = typename TestFixture::Vec;
     auto dense_mtx = Vec::create(this->mtx2->get_executor());
 
-    this->mtx2->move_to(dense_mtx.get());
+    this->mtx2->move_to(dense_mtx);
 
     // clang-format off
     GKO_ASSERT_MTX_NEAR(dense_mtx,
@@ -581,7 +581,7 @@ TYPED_TEST(Sellp, ConvertsWithSliceSizeAndStrideFactorToCsr)
     using Csr = typename TestFixture::Csr;
     auto csr_mtx = Csr::create(this->mtx2->get_executor());
 
-    this->mtx2->convert_to(csr_mtx.get());
+    this->mtx2->convert_to(csr_mtx);
 
     // clang-format off
     GKO_ASSERT_MTX_NEAR(csr_mtx,
@@ -596,7 +596,7 @@ TYPED_TEST(Sellp, MovesWithSliceSizeAndStrideFactorToCsr)
     using Csr = typename TestFixture::Csr;
     auto csr_mtx = Csr::create(this->mtx2->get_executor());
 
-    this->mtx2->move_to(csr_mtx.get());
+    this->mtx2->move_to(csr_mtx);
 
     // clang-format off
     GKO_ASSERT_MTX_NEAR(csr_mtx,
@@ -673,7 +673,7 @@ TYPED_TEST(Sellp, AppliesToComplex)
     auto x = Vec::create(exec, gko::dim<2>{2,2});
     // clang-format on
 
-    this->mtx1->apply(b.get(), x.get());
+    this->mtx1->apply(b, x);
 
     GKO_ASSERT_MTX_NEAR(
         x,
@@ -698,7 +698,7 @@ TYPED_TEST(Sellp, AppliesToMixedComplex)
     auto x = Vec::create(exec, gko::dim<2>{2,2});
     // clang-format on
 
-    this->mtx1->apply(b.get(), x.get());
+    this->mtx1->apply(b, x);
 
     GKO_ASSERT_MTX_NEAR(
         x,
@@ -728,7 +728,7 @@ TYPED_TEST(Sellp, AdvancedAppliesToComplex)
     auto beta = gko::initialize<Dense>({2.0}, this->exec);
     // clang-format on
 
-    this->mtx1->apply(alpha.get(), b.get(), beta.get(), x.get());
+    this->mtx1->apply(alpha, b, beta, x);
 
     GKO_ASSERT_MTX_NEAR(
         x,
@@ -758,7 +758,7 @@ TYPED_TEST(Sellp, AdvancedAppliesToMixedComplex)
     auto beta = gko::initialize<MixedDense>({2.0}, this->exec);
     // clang-format on
 
-    this->mtx1->apply(alpha.get(), b.get(), beta.get(), x.get());
+    this->mtx1->apply(alpha, b, beta, x);
 
     GKO_ASSERT_MTX_NEAR(
         x,

--- a/reference/test/matrix/sparsity_csr.cpp
+++ b/reference/test/matrix/sparsity_csr.cpp
@@ -95,7 +95,7 @@ TYPED_TEST(SparsityCsr, CanBeCreatedFromExistingCsrMatrix)
 
     auto mtx = Mtx::create(this->exec, std::move(csr_mtx));
 
-    GKO_ASSERT_MTX_NEAR(comp_mtx.get(), mtx.get(), 0.0);
+    GKO_ASSERT_MTX_NEAR(comp_mtx, mtx, 0.0);
 }
 
 
@@ -110,7 +110,7 @@ TYPED_TEST(SparsityCsr, CanBeCreatedFromExistingDenseMatrix)
 
     auto mtx = Mtx::create(this->exec, std::move(dense_mtx));
 
-    GKO_ASSERT_MTX_NEAR(comp_mtx.get(), mtx.get(), 0.0);
+    GKO_ASSERT_MTX_NEAR(comp_mtx, mtx, 0.0);
 }
 
 

--- a/reference/test/matrix/sparsity_csr_kernels.cpp
+++ b/reference/test/matrix/sparsity_csr_kernels.cpp
@@ -168,7 +168,7 @@ TYPED_TEST(SparsityCsr, AppliesToDenseVector)
     auto x = gko::initialize<Vec>({2.0, 1.0, 4.0}, this->exec);
     auto y = Vec::create(this->exec, gko::dim<2>{2, 1});
 
-    this->mtx->apply(x.get(), y.get());
+    this->mtx->apply(x, y);
 
     EXPECT_EQ(y->at(0), T{7.0});
     EXPECT_EQ(y->at(1), T{1.0});
@@ -182,7 +182,7 @@ TYPED_TEST(SparsityCsr, AppliesToMixedDenseVector)
     auto x = gko::initialize<Vec>({2.0, 1.0, 4.0}, this->exec);
     auto y = Vec::create(this->exec, gko::dim<2>{2, 1});
 
-    this->mtx->apply(x.get(), y.get());
+    this->mtx->apply(x, y);
 
     EXPECT_EQ(y->at(0), T{7.0});
     EXPECT_EQ(y->at(1), T{1.0});
@@ -197,7 +197,7 @@ TYPED_TEST(SparsityCsr, AppliesToDenseMatrix)
         {I<T>{2.0, 3.0}, I<T>{1.0, -1.5}, I<T>{4.0, 2.5}}, this->exec);
     auto y = Vec::create(this->exec, gko::dim<2>{2});
 
-    this->mtx->apply(x.get(), y.get());
+    this->mtx->apply(x, y);
 
     EXPECT_EQ(y->at(0, 0), T{7.0});
     EXPECT_EQ(y->at(1, 0), T{1.0});
@@ -215,7 +215,7 @@ TYPED_TEST(SparsityCsr, AppliesLinearCombinationToDenseVector)
     auto x = gko::initialize<Vec>({2.0, 1.0, 4.0}, this->exec);
     auto y = gko::initialize<Vec>({1.0, 2.0}, this->exec);
 
-    this->mtx->apply(alpha.get(), x.get(), beta.get(), y.get());
+    this->mtx->apply(alpha, x, beta, y);
 
     EXPECT_EQ(y->at(0), T{-5.0});
     EXPECT_EQ(y->at(1), T{3.0});
@@ -231,7 +231,7 @@ TYPED_TEST(SparsityCsr, AppliesLinearCombinationToMixedDenseVector)
     auto x = gko::initialize<Vec>({2.0, 1.0, 4.0}, this->exec);
     auto y = gko::initialize<Vec>({1.0, 2.0}, this->exec);
 
-    this->mtx->apply(alpha.get(), x.get(), beta.get(), y.get());
+    this->mtx->apply(alpha, x, beta, y);
 
     EXPECT_EQ(y->at(0), T{-5.0});
     EXPECT_EQ(y->at(1), T{3.0});
@@ -249,7 +249,7 @@ TYPED_TEST(SparsityCsr, AppliesLinearCombinationToDenseMatrix)
     auto y =
         gko::initialize<Vec>({I<T>{1.0, 0.5}, I<T>{2.0, -1.5}}, this->exec);
 
-    this->mtx->apply(alpha.get(), x.get(), beta.get(), y.get());
+    this->mtx->apply(alpha, x, beta, y);
 
     EXPECT_EQ(y->at(0, 0), T{-5.0});
     EXPECT_EQ(y->at(1, 0), T{3.0});
@@ -266,7 +266,7 @@ TYPED_TEST(SparsityCsr, AppliesToComplex)
                                   this->exec);
     auto y = Vec::create(this->exec, gko::dim<2>{2, 1});
 
-    this->mtx->apply(x.get(), y.get());
+    this->mtx->apply(x, y);
 
     EXPECT_EQ(y->at(0), T(7.0, 14.0));
     EXPECT_EQ(y->at(1), T(1.0, 2.0));
@@ -282,7 +282,7 @@ TYPED_TEST(SparsityCsr, AppliesToMixedComplex)
                                   this->exec);
     auto y = Vec::create(this->exec, gko::dim<2>{2, 1});
 
-    this->mtx->apply(x.get(), y.get());
+    this->mtx->apply(x, y);
 
     EXPECT_EQ(y->at(0), T(7.0, 14.0));
     EXPECT_EQ(y->at(1), T(1.0, 2.0));
@@ -301,7 +301,7 @@ TYPED_TEST(SparsityCsr, AppliesLinearCombinationToComplex)
     auto y =
         gko::initialize<ComplexVec>({T{1.0, 2.0}, T{2.0, 4.0}}, this->exec);
 
-    this->mtx->apply(alpha.get(), x.get(), beta.get(), y.get());
+    this->mtx->apply(alpha, x, beta, y);
 
     EXPECT_EQ(y->at(0), T(-5.0, -10.0));
     EXPECT_EQ(y->at(1), T(3.0, 6.0));
@@ -321,7 +321,7 @@ TYPED_TEST(SparsityCsr, AppliesLinearCombinationToMixedComplex)
     auto y =
         gko::initialize<ComplexVec>({T{1.0, 2.0}, T{2.0, 4.0}}, this->exec);
 
-    this->mtx->apply(alpha.get(), x.get(), beta.get(), y.get());
+    this->mtx->apply(alpha, x, beta, y);
 
     EXPECT_EQ(y->at(0), T(-5.0, -10.0));
     EXPECT_EQ(y->at(1), T(3.0, 6.0));
@@ -334,7 +334,7 @@ TYPED_TEST(SparsityCsr, ApplyFailsOnWrongInnerDimension)
     auto x = Vec::create(this->exec, gko::dim<2>{2});
     auto y = Vec::create(this->exec, gko::dim<2>{2});
 
-    ASSERT_THROW(this->mtx->apply(x.get(), y.get()), gko::DimensionMismatch);
+    ASSERT_THROW(this->mtx->apply(x, y), gko::DimensionMismatch);
 }
 
 
@@ -344,7 +344,7 @@ TYPED_TEST(SparsityCsr, ApplyFailsOnWrongNumberOfRows)
     auto x = Vec::create(this->exec, gko::dim<2>{3, 2});
     auto y = Vec::create(this->exec, gko::dim<2>{3, 2});
 
-    ASSERT_THROW(this->mtx->apply(x.get(), y.get()), gko::DimensionMismatch);
+    ASSERT_THROW(this->mtx->apply(x, y), gko::DimensionMismatch);
 }
 
 
@@ -354,7 +354,7 @@ TYPED_TEST(SparsityCsr, ApplyFailsOnWrongNumberOfCols)
     auto x = Vec::create(this->exec, gko::dim<2>{3});
     auto y = Vec::create(this->exec, gko::dim<2>{2});
 
-    ASSERT_THROW(this->mtx->apply(x.get(), y.get()), gko::DimensionMismatch);
+    ASSERT_THROW(this->mtx->apply(x, y), gko::DimensionMismatch);
 }
 
 
@@ -432,13 +432,13 @@ TYPED_TEST(SparsityCsr, RemovesDiagonalElementsForFullRankMatrix)
     // clang-format on
     auto tmp_mtx =
         Mtx::create(this->exec, mtx_s->get_size(), mtx_s->get_num_nonzeros());
-    tmp_mtx->copy_from(mtx2.get());
+    tmp_mtx->copy_from(mtx2);
 
     gko::kernels::reference::sparsity_csr::remove_diagonal_elements(
         this->exec, mtx2->get_const_row_ptrs(), mtx2->get_const_col_idxs(),
         tmp_mtx.get());
 
-    GKO_ASSERT_MTX_NEAR(tmp_mtx.get(), mtx_s.get(), 0.0);
+    GKO_ASSERT_MTX_NEAR(tmp_mtx, mtx_s, 0.0);
 }
 
 
@@ -455,13 +455,13 @@ TYPED_TEST(SparsityCsr, RemovesDiagonalElementsForIncompleteRankMatrix)
     // clang-format on
     auto tmp_mtx =
         Mtx::create(this->exec, mtx_s->get_size(), mtx_s->get_num_nonzeros());
-    tmp_mtx->copy_from(mtx2.get());
+    tmp_mtx->copy_from(mtx2);
 
     gko::kernels::reference::sparsity_csr::remove_diagonal_elements(
         this->exec, mtx2->get_const_row_ptrs(), mtx2->get_const_col_idxs(),
         tmp_mtx.get());
 
-    GKO_ASSERT_MTX_NEAR(tmp_mtx.get(), mtx_s.get(), 0.0);
+    GKO_ASSERT_MTX_NEAR(tmp_mtx, mtx_s, 0.0);
 }
 
 
@@ -479,7 +479,7 @@ TYPED_TEST(SparsityCsr, SquareMtxIsConvertibleToAdjacencyMatrix)
 
     auto adj_mat = mtx2->to_adjacency_matrix();
 
-    GKO_ASSERT_MTX_NEAR(adj_mat.get(), mtx_s.get(), 0.0);
+    GKO_ASSERT_MTX_NEAR(adj_mat, mtx_s, 0.0);
 }
 
 

--- a/reference/test/multigrid/fixed_coarsening_kernels.cpp
+++ b/reference/test/multigrid/fixed_coarsening_kernels.cpp
@@ -269,7 +269,7 @@ TYPED_TEST(FixedCoarsening, CoarseFineRestrictApply)
     auto fixed_coarsening = this->fixed_coarsening_factory->generate(this->mtx);
     using Vec = typename TestFixture::Vec;
     using value_type = typename TestFixture::value_type;
-    auto x = Vec::create_with_config_of(gko::lend(this->coarse_b));
+    auto x = Vec::create_with_config_of(this->coarse_b);
 
     fixed_coarsening->get_restrict_op()->apply(this->fine_b.get(), x.get());
 

--- a/reference/test/multigrid/fixed_coarsening_kernels.cpp
+++ b/reference/test/multigrid/fixed_coarsening_kernels.cpp
@@ -211,7 +211,7 @@ TYPED_TEST(FixedCoarsening, CanBeMoved)
     auto copy =
         this->fixed_coarsening_factory->generate(Mtx::create(this->exec));
 
-    copy->copy_from(std::move(this->mg_level));
+    copy->move_from(this->mg_level);
     auto copy_mtx = copy->get_system_matrix();
     auto copy_coarse = copy->get_coarse_op();
 

--- a/reference/test/multigrid/fixed_coarsening_kernels.cpp
+++ b/reference/test/multigrid/fixed_coarsening_kernels.cpp
@@ -153,20 +153,6 @@ protected:
              {{0, 0, 5}, {0, 1, -3}, {1, 0, -3}, {1, 1, 5}, {2, 2, 5}}});
     }
 
-    static void assert_same_matrices(const Mtx* m1, const Mtx* m2)
-    {
-        ASSERT_EQ(m1->get_size()[0], m2->get_size()[0]);
-        ASSERT_EQ(m1->get_size()[1], m2->get_size()[1]);
-        ASSERT_EQ(m1->get_num_stored_elements(), m2->get_num_stored_elements());
-        for (gko::size_type i = 0; i < m1->get_size()[0] + 1; i++) {
-            ASSERT_EQ(m1->get_const_row_ptrs()[i], m2->get_const_row_ptrs()[i]);
-        }
-        for (gko::size_type i = 0; i < m1->get_num_stored_elements(); ++i) {
-            EXPECT_EQ(m1->get_const_values()[i], m2->get_const_values()[i]);
-            EXPECT_EQ(m1->get_const_col_idxs()[i], m2->get_const_col_idxs()[i]);
-        }
-    }
-
     static void assert_same_coarse_rows(const index_type* m1,
                                         const index_type* m2,
                                         gko::size_type len)
@@ -207,14 +193,14 @@ TYPED_TEST(FixedCoarsening, CanBeCopied)
     auto copy =
         this->fixed_coarsening_factory->generate(Mtx::create(this->exec));
 
-    copy->copy_from(this->mg_level.get());
+    copy->copy_from(this->mg_level);
     auto copy_mtx = copy->get_system_matrix();
     auto copy_coarse = copy->get_coarse_op();
 
-    this->assert_same_matrices(static_cast<const Mtx*>(copy_mtx.get()),
-                               this->mtx.get());
-    this->assert_same_matrices(static_cast<const Mtx*>(copy_coarse.get()),
-                               this->coarse.get());
+    GKO_ASSERT_MTX_NEAR(static_cast<const Mtx*>(copy_mtx.get()), this->mtx,
+                        0.0);
+    GKO_ASSERT_MTX_NEAR(static_cast<const Mtx*>(copy_coarse.get()),
+                        this->coarse, 0.0);
 }
 
 
@@ -229,10 +215,10 @@ TYPED_TEST(FixedCoarsening, CanBeMoved)
     auto copy_mtx = copy->get_system_matrix();
     auto copy_coarse = copy->get_coarse_op();
 
-    this->assert_same_matrices(static_cast<const Mtx*>(copy_mtx.get()),
-                               this->mtx.get());
-    this->assert_same_matrices(static_cast<const Mtx*>(copy_coarse.get()),
-                               this->coarse.get());
+    GKO_ASSERT_MTX_NEAR(static_cast<const Mtx*>(copy_mtx.get()), this->mtx,
+                        0.0);
+    GKO_ASSERT_MTX_NEAR(static_cast<const Mtx*>(copy_coarse.get()),
+                        this->coarse, 0.0);
 }
 
 
@@ -244,10 +230,10 @@ TYPED_TEST(FixedCoarsening, CanBeCloned)
     auto clone_mtx = clone->get_system_matrix();
     auto clone_coarse = clone->get_coarse_op();
 
-    this->assert_same_matrices(static_cast<const Mtx*>(clone_mtx.get()),
-                               this->mtx.get());
-    this->assert_same_matrices(static_cast<const Mtx*>(clone_coarse.get()),
-                               this->coarse.get());
+    GKO_ASSERT_MTX_NEAR(static_cast<const Mtx*>(clone_mtx.get()), this->mtx,
+                        0.0);
+    GKO_ASSERT_MTX_NEAR(static_cast<const Mtx*>(clone_coarse.get()),
+                        this->coarse, 0.0);
 }
 
 
@@ -271,7 +257,7 @@ TYPED_TEST(FixedCoarsening, CoarseFineRestrictApply)
     using value_type = typename TestFixture::value_type;
     auto x = Vec::create_with_config_of(this->coarse_b);
 
-    fixed_coarsening->get_restrict_op()->apply(this->fine_b.get(), x.get());
+    fixed_coarsening->get_restrict_op()->apply(this->fine_b, x);
 
     GKO_ASSERT_MTX_NEAR(x, this->restrict_ans, r<value_type>::value);
 }
@@ -283,7 +269,7 @@ TYPED_TEST(FixedCoarsening, CoarseFineProlongApply)
     auto fixed_coarsening = this->fixed_coarsening_factory->generate(this->mtx);
     auto x = gko::clone(this->fine_x);
 
-    fixed_coarsening->get_prolong_op()->apply(this->coarse_b.get(), x.get());
+    fixed_coarsening->get_prolong_op()->apply(this->coarse_b, x);
 
     GKO_ASSERT_MTX_NEAR(x, this->prolong_applyans, r<value_type>::value);
 }
@@ -302,7 +288,7 @@ TYPED_TEST(FixedCoarsening, Apply)
          I<VT>({0.0, 0.0}), I<VT>({0.0, 0.0})},
         exec);
 
-    fixed_coarsening->apply(b.get(), x.get());
+    fixed_coarsening->apply(b, x);
 
     GKO_ASSERT_MTX_NEAR(x, answer, r<VT>::value);
 }
@@ -323,7 +309,7 @@ TYPED_TEST(FixedCoarsening, AdvancedApply)
          I<VT>({0.0, 0.0}), I<VT>({0.0, 4.0})},
         exec);
 
-    fixed_coarsening->apply(alpha.get(), b.get(), beta.get(), x.get());
+    fixed_coarsening->apply(alpha, b, beta, x);
 
     GKO_ASSERT_MTX_NEAR(x, answer, r<VT>::value);
 }

--- a/reference/test/multigrid/fixed_coarsening_kernels.cpp
+++ b/reference/test/multigrid/fixed_coarsening_kernels.cpp
@@ -197,10 +197,8 @@ TYPED_TEST(FixedCoarsening, CanBeCopied)
     auto copy_mtx = copy->get_system_matrix();
     auto copy_coarse = copy->get_coarse_op();
 
-    GKO_ASSERT_MTX_NEAR(static_cast<const Mtx*>(copy_mtx.get()), this->mtx,
-                        0.0);
-    GKO_ASSERT_MTX_NEAR(static_cast<const Mtx*>(copy_coarse.get()),
-                        this->coarse, 0.0);
+    GKO_ASSERT_MTX_NEAR(gko::as<Mtx>(copy_mtx), this->mtx, 0.0);
+    GKO_ASSERT_MTX_NEAR(gko::as<Mtx>(copy_coarse), this->coarse, 0.0);
 }
 
 
@@ -215,10 +213,8 @@ TYPED_TEST(FixedCoarsening, CanBeMoved)
     auto copy_mtx = copy->get_system_matrix();
     auto copy_coarse = copy->get_coarse_op();
 
-    GKO_ASSERT_MTX_NEAR(static_cast<const Mtx*>(copy_mtx.get()), this->mtx,
-                        0.0);
-    GKO_ASSERT_MTX_NEAR(static_cast<const Mtx*>(copy_coarse.get()),
-                        this->coarse, 0.0);
+    GKO_ASSERT_MTX_NEAR(gko::as<Mtx>(copy_mtx), this->mtx, 0.0);
+    GKO_ASSERT_MTX_NEAR(gko::as<Mtx>(copy_coarse), this->coarse, 0.0);
 }
 
 
@@ -230,10 +226,8 @@ TYPED_TEST(FixedCoarsening, CanBeCloned)
     auto clone_mtx = clone->get_system_matrix();
     auto clone_coarse = clone->get_coarse_op();
 
-    GKO_ASSERT_MTX_NEAR(static_cast<const Mtx*>(clone_mtx.get()), this->mtx,
-                        0.0);
-    GKO_ASSERT_MTX_NEAR(static_cast<const Mtx*>(clone_coarse.get()),
-                        this->coarse, 0.0);
+    GKO_ASSERT_MTX_NEAR(gko::as<Mtx>(clone_mtx), this->mtx, 0.0);
+    GKO_ASSERT_MTX_NEAR(gko::as<Mtx>(clone_coarse), this->coarse, 0.0);
 }
 
 

--- a/reference/test/multigrid/pgm_kernels.cpp
+++ b/reference/test/multigrid/pgm_kernels.cpp
@@ -383,7 +383,7 @@ TYPED_TEST(Pgm, CoarseFineRestrictApply)
     auto pgm = this->pgm_factory->generate(this->mtx);
     using Vec = typename TestFixture::Vec;
     using value_type = typename TestFixture::value_type;
-    auto x = Vec::create_with_config_of(gko::lend(this->coarse_b));
+    auto x = Vec::create_with_config_of(this->coarse_b);
 
     pgm->get_restrict_op()->apply(this->fine_b.get(), x.get());
 

--- a/reference/test/multigrid/pgm_kernels.cpp
+++ b/reference/test/multigrid/pgm_kernels.cpp
@@ -228,17 +228,17 @@ TYPED_TEST(Pgm, CanBeCopied)
     using MgLevel = typename TestFixture::MgLevel;
     auto copy = this->pgm_factory->generate(Mtx::create(this->exec));
 
-    copy->copy_from(this->mg_level.get());
+    copy->copy_from(this->mg_level);
     auto copy_mtx = copy->get_system_matrix();
     auto copy_agg = copy->get_const_agg();
     auto copy_coarse = copy->get_coarse_op();
 
-    this->assert_same_matrices(static_cast<const Mtx*>(copy_mtx.get()),
-                               this->mtx.get());
+    GKO_ASSERT_MTX_NEAR(static_cast<const Mtx*>(copy_mtx.get()), this->mtx,
+                        0.0);
     this->assert_same_agg(copy_agg, this->agg.get_data(),
                           this->agg.get_num_elems());
-    this->assert_same_matrices(static_cast<const Mtx*>(copy_coarse.get()),
-                               this->coarse.get());
+    GKO_ASSERT_MTX_NEAR(static_cast<const Mtx*>(copy_coarse.get()),
+                        this->coarse, 0.0);
 }
 
 
@@ -253,12 +253,12 @@ TYPED_TEST(Pgm, CanBeMoved)
     auto copy_agg = copy->get_const_agg();
     auto copy_coarse = copy->get_coarse_op();
 
-    this->assert_same_matrices(static_cast<const Mtx*>(copy_mtx.get()),
-                               this->mtx.get());
+    GKO_ASSERT_MTX_NEAR(static_cast<const Mtx*>(copy_mtx.get()), this->mtx,
+                        0.0);
     this->assert_same_agg(copy_agg, this->agg.get_data(),
                           this->agg.get_num_elems());
-    this->assert_same_matrices(static_cast<const Mtx*>(copy_coarse.get()),
-                               this->coarse.get());
+    GKO_ASSERT_MTX_NEAR(static_cast<const Mtx*>(copy_coarse.get()),
+                        this->coarse, 0.0);
 }
 
 
@@ -271,12 +271,12 @@ TYPED_TEST(Pgm, CanBeCloned)
     auto clone_agg = clone->get_const_agg();
     auto clone_coarse = clone->get_coarse_op();
 
-    this->assert_same_matrices(static_cast<const Mtx*>(clone_mtx.get()),
-                               this->mtx.get());
+    GKO_ASSERT_MTX_NEAR(static_cast<const Mtx*>(clone_mtx.get()), this->mtx,
+                        0.0);
     this->assert_same_agg(clone_agg, this->agg.get_data(),
                           this->agg.get_num_elems());
-    this->assert_same_matrices(static_cast<const Mtx*>(clone_coarse.get()),
-                               this->coarse.get());
+    GKO_ASSERT_MTX_NEAR(static_cast<const Mtx*>(clone_coarse.get()),
+                        this->coarse, 0.0);
 }
 
 
@@ -385,7 +385,7 @@ TYPED_TEST(Pgm, CoarseFineRestrictApply)
     using value_type = typename TestFixture::value_type;
     auto x = Vec::create_with_config_of(this->coarse_b);
 
-    pgm->get_restrict_op()->apply(this->fine_b.get(), x.get());
+    pgm->get_restrict_op()->apply(this->fine_b, x);
 
     GKO_ASSERT_MTX_NEAR(x, this->restrict_ans, r<value_type>::value);
 }
@@ -399,8 +399,7 @@ TYPED_TEST(Pgm, CoarseFineProlongApplyadd)
     auto one = gko::initialize<Vec>({value_type{1.0}}, this->exec);
     auto x = gko::clone(this->fine_x);
 
-    pgm->get_prolong_op()->apply(one.get(), this->coarse_b.get(), one.get(),
-                                 x.get());
+    pgm->get_prolong_op()->apply(one, this->coarse_b, one, x);
 
     GKO_ASSERT_MTX_NEAR(x, this->prolong_ans, r<value_type>::value);
 }
@@ -412,7 +411,7 @@ TYPED_TEST(Pgm, CoarseFineProlongApply)
     auto pgm = this->pgm_factory->generate(this->mtx);
     auto x = gko::clone(this->fine_x);
 
-    pgm->get_prolong_op()->apply(this->coarse_b.get(), x.get());
+    pgm->get_prolong_op()->apply(this->coarse_b, x);
 
     GKO_ASSERT_MTX_NEAR(x, this->prolong_applyans, r<value_type>::value);
 }
@@ -431,7 +430,7 @@ TYPED_TEST(Pgm, Apply)
          I<VT>({17.0, -5.0}), I<VT>({-23.0, 5.0})},
         exec);
 
-    pgm->apply(b.get(), x.get());
+    pgm->apply(b, x);
 
     GKO_ASSERT_MTX_NEAR(x, answer, r<VT>::value);
 }
@@ -452,7 +451,7 @@ TYPED_TEST(Pgm, AdvancedApply)
          I<VT>({17.0, -5.0}), I<VT>({-23.0, 9.0})},
         exec);
 
-    pgm->apply(alpha.get(), b.get(), beta.get(), x.get());
+    pgm->apply(alpha, b, beta, x);
 
     GKO_ASSERT_MTX_NEAR(x, answer, r<VT>::value);
 }

--- a/reference/test/multigrid/pgm_kernels.cpp
+++ b/reference/test/multigrid/pgm_kernels.cpp
@@ -248,7 +248,7 @@ TYPED_TEST(Pgm, CanBeMoved)
     using MgLevel = typename TestFixture::MgLevel;
     auto copy = this->pgm_factory->generate(Mtx::create(this->exec));
 
-    copy->copy_from(std::move(this->mg_level));
+    copy->move_from(this->mg_level);
     auto copy_mtx = copy->get_system_matrix();
     auto copy_agg = copy->get_const_agg();
     auto copy_coarse = copy->get_coarse_op();

--- a/reference/test/multigrid/pgm_kernels.cpp
+++ b/reference/test/multigrid/pgm_kernels.cpp
@@ -233,12 +233,10 @@ TYPED_TEST(Pgm, CanBeCopied)
     auto copy_agg = copy->get_const_agg();
     auto copy_coarse = copy->get_coarse_op();
 
-    GKO_ASSERT_MTX_NEAR(static_cast<const Mtx*>(copy_mtx.get()), this->mtx,
-                        0.0);
+    GKO_ASSERT_MTX_NEAR(gko::as<Mtx>(copy_mtx), this->mtx, 0.0);
     this->assert_same_agg(copy_agg, this->agg.get_data(),
                           this->agg.get_num_elems());
-    GKO_ASSERT_MTX_NEAR(static_cast<const Mtx*>(copy_coarse.get()),
-                        this->coarse, 0.0);
+    GKO_ASSERT_MTX_NEAR(gko::as<Mtx>(copy_coarse), this->coarse, 0.0);
 }
 
 
@@ -253,12 +251,10 @@ TYPED_TEST(Pgm, CanBeMoved)
     auto copy_agg = copy->get_const_agg();
     auto copy_coarse = copy->get_coarse_op();
 
-    GKO_ASSERT_MTX_NEAR(static_cast<const Mtx*>(copy_mtx.get()), this->mtx,
-                        0.0);
+    GKO_ASSERT_MTX_NEAR(gko::as<Mtx>(copy_mtx), this->mtx, 0.0);
     this->assert_same_agg(copy_agg, this->agg.get_data(),
                           this->agg.get_num_elems());
-    GKO_ASSERT_MTX_NEAR(static_cast<const Mtx*>(copy_coarse.get()),
-                        this->coarse, 0.0);
+    GKO_ASSERT_MTX_NEAR(gko::as<Mtx>(copy_coarse), this->coarse, 0.0);
 }
 
 
@@ -271,12 +267,10 @@ TYPED_TEST(Pgm, CanBeCloned)
     auto clone_agg = clone->get_const_agg();
     auto clone_coarse = clone->get_coarse_op();
 
-    GKO_ASSERT_MTX_NEAR(static_cast<const Mtx*>(clone_mtx.get()), this->mtx,
-                        0.0);
+    GKO_ASSERT_MTX_NEAR(gko::as<Mtx>(clone_mtx), this->mtx, 0.0);
     this->assert_same_agg(clone_agg, this->agg.get_data(),
                           this->agg.get_num_elems());
-    GKO_ASSERT_MTX_NEAR(static_cast<const Mtx*>(clone_coarse.get()),
-                        this->coarse, 0.0);
+    GKO_ASSERT_MTX_NEAR(gko::as<Mtx>(clone_coarse), this->coarse, 0.0);
 }
 
 

--- a/reference/test/preconditioner/ic.cpp
+++ b/reference/test/preconditioner/ic.cpp
@@ -184,7 +184,7 @@ TYPED_TEST(Ic, CanBeCopied)
     auto copied =
         ic_prec_type::build().on(this->exec)->generate(lh_l_composition);
 
-    copied->copy_from(ic.get());
+    copied->copy_from(ic);
 
     ASSERT_EQ(before_l_solver, copied->get_l_solver());
     ASSERT_EQ(before_lh_solver, copied->get_lh_solver());
@@ -268,7 +268,7 @@ TYPED_TEST(Ic, SolvesSingleRhs)
     auto preconditioner =
         ic_prec_type::build().on(this->exec)->generate(this->mtx);
 
-    preconditioner->apply(b.get(), x.get());
+    preconditioner->apply(b, x);
 
     GKO_ASSERT_MTX_NEAR(x, l({3.0, -2.0, 4.0}), this->tol);
 }
@@ -284,7 +284,7 @@ TYPED_TEST(Ic, SolvesSingleRhsMixed)
     auto preconditioner =
         ic_prec_type::build().on(this->exec)->generate(this->mtx);
 
-    preconditioner->apply(b.get(), x.get());
+    preconditioner->apply(b, x);
 
     GKO_ASSERT_MTX_NEAR(x, l({3.0, -2.0, 4.0}), this->tol);
 }
@@ -301,7 +301,7 @@ TYPED_TEST(Ic, SolvesSingleRhsComplex)
     auto preconditioner =
         ic_prec_type::build().on(this->exec)->generate(this->mtx);
 
-    preconditioner->apply(b.get(), x.get());
+    preconditioner->apply(b, x);
 
     GKO_ASSERT_MTX_NEAR(x, l({T{3.0, 6.0}, T{-2.0, -4.0}, T{4.0, 8.0}}),
                         this->tol);
@@ -320,7 +320,7 @@ TYPED_TEST(Ic, SolvesSingleRhsComplexMixed)
     auto preconditioner =
         ic_prec_type::build().on(this->exec)->generate(this->mtx);
 
-    preconditioner->apply(b.get(), x.get());
+    preconditioner->apply(b, x);
 
     GKO_ASSERT_MTX_NEAR(x, l({T{3.0, 6.0}, T{-2.0, -4.0}, T{4.0, 8.0}}),
                         this->tol);
@@ -338,7 +338,7 @@ TYPED_TEST(Ic, AdvancedSolvesSingleRhs)
     auto preconditioner =
         ic_prec_type::build().on(this->exec)->generate(this->mtx);
 
-    preconditioner->apply(alpha.get(), b.get(), beta.get(), x.get());
+    preconditioner->apply(alpha, b, beta, x);
 
     GKO_ASSERT_MTX_NEAR(x, l({5.0, -6.0, 5.0}), this->tol);
 }
@@ -356,7 +356,7 @@ TYPED_TEST(Ic, AdvancedSolvesSingleRhsMixed)
     auto preconditioner =
         ic_prec_type::build().on(this->exec)->generate(this->mtx);
 
-    preconditioner->apply(alpha.get(), b.get(), beta.get(), x.get());
+    preconditioner->apply(alpha, b, beta, x);
 
     GKO_ASSERT_MTX_NEAR(x, l({5.0, -6.0, 5.0}), this->tol);
 }
@@ -377,7 +377,7 @@ TYPED_TEST(Ic, AdvancedSolvesSingleRhsComplex)
     auto preconditioner =
         ic_prec_type::build().on(this->exec)->generate(this->mtx);
 
-    preconditioner->apply(alpha.get(), b.get(), beta.get(), x.get());
+    preconditioner->apply(alpha, b, beta, x);
 
     GKO_ASSERT_MTX_NEAR(x, l({T{5.0, 10.0}, T{-6.0, -12.0}, T{5.0, 10.0}}),
                         this->tol);
@@ -400,7 +400,7 @@ TYPED_TEST(Ic, AdvancedSolvesSingleRhsComplexMixed)
     auto preconditioner =
         ic_prec_type::build().on(this->exec)->generate(this->mtx);
 
-    preconditioner->apply(alpha.get(), b.get(), beta.get(), x.get());
+    preconditioner->apply(alpha, b, beta, x);
 
     GKO_ASSERT_MTX_NEAR(x, l({T{5.0, 10.0}, T{-6.0, -12.0}, T{5.0, 10.0}}),
                         this->tol);
@@ -417,7 +417,7 @@ TYPED_TEST(Ic, SolvesMultipleRhs)
     auto preconditioner =
         ic_prec_type::build().on(this->exec)->generate(this->mtx);
 
-    preconditioner->apply(b.get(), x.get());
+    preconditioner->apply(b, x);
 
     GKO_ASSERT_MTX_NEAR(
         x, l({{3.0, 6.0, 9.0}, {-2.0, -4.0, -6.0}, {4.0, 8.0, 12.0}}),

--- a/reference/test/preconditioner/ic.cpp
+++ b/reference/test/preconditioner/ic.cpp
@@ -205,7 +205,7 @@ TYPED_TEST(Ic, CanBeMoved)
     auto moved =
         ic_prec_type::build().on(this->exec)->generate(lh_l_composition);
 
-    moved->copy_from(std::move(ic));
+    moved->move_from(ic);
 
     ASSERT_EQ(before_l_solver, moved->get_l_solver());
     ASSERT_EQ(before_lh_solver, moved->get_lh_solver());

--- a/reference/test/preconditioner/ilu.cpp
+++ b/reference/test/preconditioner/ilu.cpp
@@ -225,7 +225,7 @@ TYPED_TEST(Ilu, CanBeMoved)
     auto moved =
         ilu_prec_type::build().on(this->exec)->generate(u_l_composition);
 
-    moved->copy_from(std::move(ilu));
+    moved->move_from(ilu);
 
     ASSERT_EQ(before_l_solver.get(), moved->get_l_solver().get());
     ASSERT_EQ(before_u_solver.get(), moved->get_u_solver().get());

--- a/reference/test/preconditioner/ilu.cpp
+++ b/reference/test/preconditioner/ilu.cpp
@@ -183,9 +183,9 @@ TYPED_TEST(Ilu, SetsCorrectMatrices)
     std::unique_ptr<Mtx> converted_l_factor{Mtx::create(this->exec)};
     std::unique_ptr<Mtx> converted_u_factor{Mtx::create(this->exec)};
     gko::as<gko::ConvertibleTo<Mtx>>(internal_l_factor.get())
-        ->convert_to(converted_l_factor.get());
+        ->convert_to(converted_l_factor);
     gko::as<gko::ConvertibleTo<Mtx>>(internal_u_factor.get())
-        ->convert_to(converted_u_factor.get());
+        ->convert_to(converted_u_factor);
     GKO_ASSERT_MTX_NEAR(converted_l_factor, this->l_factor, 0);
     GKO_ASSERT_MTX_NEAR(converted_u_factor, this->u_factor, 0);
 }
@@ -205,7 +205,7 @@ TYPED_TEST(Ilu, CanBeCopied)
     auto copied =
         ilu_prec_type::build().on(this->exec)->generate(u_l_composition);
 
-    copied->copy_from(ilu.get());
+    copied->copy_from(ilu);
 
     ASSERT_EQ(before_l_solver.get(), copied->get_l_solver().get());
     ASSERT_EQ(before_u_solver.get(), copied->get_u_solver().get());
@@ -295,15 +295,15 @@ TYPED_TEST(Ilu, SolvesCustomTypeDefaultFactorySingleRhs)
     using Mtx = typename TestFixture::Mtx;
     const auto b = gko::initialize<Mtx>({1.0, 3.0, 6.0}, this->exec);
     auto x = Mtx::create(this->exec, gko::dim<2>{3, 1});
-    x->copy_from(b.get());
+    x->copy_from(b);
 
     auto preconditioner =
         ilu_prec_type::build().on(this->exec)->generate(this->mtx);
-    preconditioner->apply(b.get(), x.get());
+    preconditioner->apply(b, x);
 
     // Since it uses Bicgstab with default parmeters, the result will not be
     // accurate
-    GKO_ASSERT_MTX_NEAR(x.get(), l({-0.125, 0.25, 1.0}), 1e-1);
+    GKO_ASSERT_MTX_NEAR(x, l({-0.125, 0.25, 1.0}), 1e-1);
 }
 
 
@@ -313,16 +313,15 @@ TYPED_TEST(Ilu, SolvesSingleRhsWithParIlu)
     using value_type = typename TestFixture::value_type;
     const auto b = gko::initialize<Mtx>({1.0, 3.0, 6.0}, this->exec);
     auto x = Mtx::create(this->exec, gko::dim<2>{3, 1});
-    x->copy_from(b.get());
+    x->copy_from(b);
     auto par_ilu_fact =
         gko::factorization::ParIlu<value_type>::build().on(this->exec);
     auto par_ilu = gko::share(par_ilu_fact->generate(this->mtx));
 
     auto preconditioner = this->ilu_pre_factory->generate(par_ilu);
-    preconditioner->apply(b.get(), x.get());
+    preconditioner->apply(b, x);
 
-    GKO_ASSERT_MTX_NEAR(x.get(), l({-0.125, 0.25, 1.0}),
-                        r<TypeParam>::value * 1e+1);
+    GKO_ASSERT_MTX_NEAR(x, l({-0.125, 0.25, 1.0}), r<TypeParam>::value * 1e+1);
 }
 
 
@@ -331,14 +330,13 @@ TYPED_TEST(Ilu, SolvesSingleRhsWithComposition)
     using Mtx = typename TestFixture::Mtx;
     const auto b = gko::initialize<Mtx>({1.0, 3.0, 6.0}, this->exec);
     auto x = Mtx::create(this->exec, gko::dim<2>{3, 1});
-    x->copy_from(b.get());
+    x->copy_from(b);
 
     auto preconditioner =
         this->ilu_pre_factory->generate(this->l_u_composition);
-    preconditioner->apply(b.get(), x.get());
+    preconditioner->apply(b, x);
 
-    GKO_ASSERT_MTX_NEAR(x.get(), l({-0.125, 0.25, 1.0}),
-                        r<TypeParam>::value * 1e+1);
+    GKO_ASSERT_MTX_NEAR(x, l({-0.125, 0.25, 1.0}), r<TypeParam>::value * 1e+1);
 }
 
 
@@ -347,13 +345,12 @@ TYPED_TEST(Ilu, SolvesSingleRhsWithMtx)
     using Mtx = typename TestFixture::Mtx;
     const auto b = gko::initialize<Mtx>({1.0, 3.0, 6.0}, this->exec);
     auto x = Mtx::create(this->exec, gko::dim<2>{3, 1});
-    x->copy_from(b.get());
+    x->copy_from(b);
 
     auto preconditioner = this->ilu_pre_factory->generate(this->mtx);
-    preconditioner->apply(b.get(), x.get());
+    preconditioner->apply(b, x);
 
-    GKO_ASSERT_MTX_NEAR(x.get(), l({-0.125, 0.25, 1.0}),
-                        r<TypeParam>::value * 1e+1);
+    GKO_ASSERT_MTX_NEAR(x, l({-0.125, 0.25, 1.0}), r<TypeParam>::value * 1e+1);
 }
 
 
@@ -363,13 +360,13 @@ TYPED_TEST(Ilu, SolvesSingleRhsWithMixedMtx)
         gko::next_precision<typename TestFixture::value_type>>;
     const auto b = gko::initialize<Mtx>({1.0, 3.0, 6.0}, this->exec);
     auto x = Mtx::create(this->exec, gko::dim<2>{3, 1});
-    x->copy_from(b.get());
+    x->copy_from(b);
 
     auto preconditioner = this->ilu_pre_factory->generate(this->mtx);
-    preconditioner->apply(b.get(), x.get());
+    preconditioner->apply(b, x);
 
     GKO_ASSERT_MTX_NEAR(
-        x.get(), l({-0.125, 0.25, 1.0}),
+        x, l({-0.125, 0.25, 1.0}),
         (r_mixed<TypeParam, typename Mtx::value_type>()) * 1e+1);
 }
 
@@ -381,13 +378,12 @@ TYPED_TEST(Ilu, SolvesSingleRhsWithComplexMtx)
     const auto b = gko::initialize<Mtx>(
         {T{1.0, 2.0}, T{3.0, 6.0}, T{6.0, 12.0}}, this->exec);
     auto x = Mtx::create(this->exec, gko::dim<2>{3, 1});
-    x->copy_from(b.get());
+    x->copy_from(b);
 
     auto preconditioner = this->ilu_pre_factory->generate(this->mtx);
-    preconditioner->apply(b.get(), x.get());
+    preconditioner->apply(b, x);
 
-    GKO_ASSERT_MTX_NEAR(x.get(),
-                        l({T{-0.125, -0.25}, T{0.25, 0.5}, T{1.0, 2.0}}),
+    GKO_ASSERT_MTX_NEAR(x, l({T{-0.125, -0.25}, T{0.25, 0.5}, T{1.0, 2.0}}),
                         r<TypeParam>::value * 1e+1);
 }
 
@@ -400,13 +396,13 @@ TYPED_TEST(Ilu, SolvesSingleRhsWithMixedComplexMtx)
     const auto b = gko::initialize<Mtx>(
         {T{1.0, 2.0}, T{3.0, 6.0}, T{6.0, 12.0}}, this->exec);
     auto x = Mtx::create(this->exec, gko::dim<2>{3, 1});
-    x->copy_from(b.get());
+    x->copy_from(b);
 
     auto preconditioner = this->ilu_pre_factory->generate(this->mtx);
-    preconditioner->apply(b.get(), x.get());
+    preconditioner->apply(b, x);
 
     GKO_ASSERT_MTX_NEAR(
-        x.get(), l({T{-0.125, -0.25}, T{0.25, 0.5}, T{1.0, 2.0}}),
+        x, l({T{-0.125, -0.25}, T{0.25, 0.5}, T{1.0, 2.0}}),
         (r_mixed<TypeParam, typename Mtx::value_type>()) * 1e+1);
 }
 
@@ -416,13 +412,13 @@ TYPED_TEST(Ilu, SolvesReverseSingleRhs)
     using Mtx = typename TestFixture::Mtx;
     const auto b = gko::initialize<Mtx>({1.0, 3.0, 6.0}, this->exec);
     auto x = Mtx::create(this->exec, gko::dim<2>{3, 1});
-    x->copy_from(b.get());
+    x->copy_from(b);
     auto preconditioner =
         this->ilu_rev_pre_factory->generate(this->l_u_composition);
 
-    preconditioner->apply(b.get(), x.get());
+    preconditioner->apply(b, x);
 
-    GKO_ASSERT_MTX_NEAR(x.get(), l({-0.625, 0.875, 1.75}),
+    GKO_ASSERT_MTX_NEAR(x, l({-0.625, 0.875, 1.75}),
                         r<TypeParam>::value * 1e+1);
 }
 
@@ -440,10 +436,9 @@ TYPED_TEST(Ilu, SolvesAdvancedSingleRhs)
     auto preconditioner =
         this->ilu_pre_factory->generate(this->l_u_composition);
 
-    preconditioner->apply(alpha_linop.get(), b.get(), beta_linop.get(),
-                          x.get());
+    preconditioner->apply(alpha_linop, b, beta_linop, x);
 
-    GKO_ASSERT_MTX_NEAR(x.get(), l({-7.0, 2.0, -1.0}), r<TypeParam>::value);
+    GKO_ASSERT_MTX_NEAR(x, l({-7.0, 2.0, -1.0}), r<TypeParam>::value);
 }
 
 
@@ -460,10 +455,9 @@ TYPED_TEST(Ilu, SolvesAdvancedSingleRhsMixed)
     auto preconditioner =
         this->ilu_pre_factory->generate(this->l_u_composition);
 
-    preconditioner->apply(alpha_linop.get(), b.get(), beta_linop.get(),
-                          x.get());
+    preconditioner->apply(alpha_linop, b, beta_linop, x);
 
-    GKO_ASSERT_MTX_NEAR(x.get(), l({-7.0, 2.0, -1.0}),
+    GKO_ASSERT_MTX_NEAR(x, l({-7.0, 2.0, -1.0}),
                         (r_mixed<TypeParam, typename Mtx::value_type>()));
 }
 
@@ -489,10 +483,9 @@ TYPED_TEST(Ilu, SolvesAdvancedSingleRhsComplex)
     auto preconditioner =
         this->ilu_pre_factory->generate(this->l_u_composition);
 
-    preconditioner->apply(alpha_linop.get(), b.get(), beta_linop.get(),
-                          x.get());
+    preconditioner->apply(alpha_linop, b, beta_linop, x);
 
-    GKO_ASSERT_MTX_NEAR(x.get(),
+    GKO_ASSERT_MTX_NEAR(x,
                         l({complex_type{-7.0, 14.0}, complex_type{2.0, -4.0},
                            complex_type{-1.0, 2.0}}),
                         r<TypeParam>::value);
@@ -520,11 +513,10 @@ TYPED_TEST(Ilu, SolvesAdvancedSingleRhsMixedComplex)
     auto preconditioner =
         this->ilu_pre_factory->generate(this->l_u_composition);
 
-    preconditioner->apply(alpha_linop.get(), b.get(), beta_linop.get(),
-                          x.get());
+    preconditioner->apply(alpha_linop, b, beta_linop, x);
 
     GKO_ASSERT_MTX_NEAR(
-        x.get(),
+        x,
         l({complex_type{-7.0, 14.0}, complex_type{2.0, -4.0},
            complex_type{-1.0, 2.0}}),
         (r_mixed<TypeParam, typename MixedDenseComplex::value_type>()));
@@ -544,11 +536,9 @@ TYPED_TEST(Ilu, SolvesAdvancedReverseSingleRhs)
     auto preconditioner =
         this->ilu_rev_pre_factory->generate(this->l_u_composition);
 
-    preconditioner->apply(alpha_linop.get(), b.get(), beta_linop.get(),
-                          x.get());
+    preconditioner->apply(alpha_linop, b, beta_linop, x);
 
-    GKO_ASSERT_MTX_NEAR(x.get(), l({-7.75, 6.25, 1.5}),
-                        r<TypeParam>::value * 1e+1);
+    GKO_ASSERT_MTX_NEAR(x, l({-7.75, 6.25, 1.5}), r<TypeParam>::value * 1e+1);
 }
 
 
@@ -559,13 +549,13 @@ TYPED_TEST(Ilu, SolvesMultipleRhs)
     const auto b = gko::initialize<Mtx>(
         {I<T>{1.0, 8.0}, I<T>{3.0, 21.0}, I<T>{6.0, 24.0}}, this->exec);
     auto x = Mtx::create(this->exec, gko::dim<2>{3, 2});
-    x->copy_from(b.get());
+    x->copy_from(b);
     auto preconditioner =
         this->ilu_pre_factory->generate(this->l_u_composition);
 
-    preconditioner->apply(b.get(), x.get());
+    preconditioner->apply(b, x);
 
-    GKO_ASSERT_MTX_NEAR(x.get(), l({{-0.125, 2.0}, {0.25, 3.0}, {1.0, 1.0}}),
+    GKO_ASSERT_MTX_NEAR(x, l({{-0.125, 2.0}, {0.25, 3.0}, {1.0, 1.0}}),
                         r<TypeParam>::value * 1e+1);
 }
 
@@ -577,24 +567,23 @@ TYPED_TEST(Ilu, SolvesDifferentNumberOfRhs)
     const auto b1 = gko::initialize<Mtx>({-3.0, 6.0, 9.0}, this->exec);
     auto x11 = Mtx::create(this->exec, gko::dim<2>{3, 1});
     auto x12 = Mtx::create(this->exec, gko::dim<2>{3, 1});
-    x11->copy_from(b1.get());
-    x12->copy_from(b1.get());
+    x11->copy_from(b1);
+    x12->copy_from(b1);
     const auto b2 = gko::initialize<Mtx>(
         {I<T>{1.0, 8.0}, I<T>{3.0, 21.0}, I<T>{6.0, 24.0}}, this->exec);
     auto x2 = Mtx::create(this->exec, gko::dim<2>{3, 2});
-    x2->copy_from(b2.get());
+    x2->copy_from(b2);
     auto preconditioner =
         this->ilu_pre_factory->generate(this->l_u_composition);
 
-    preconditioner->apply(b1.get(), x11.get());
-    preconditioner->apply(b2.get(), x2.get());
-    preconditioner->apply(b1.get(), x12.get());
+    preconditioner->apply(b1, x11);
+    preconditioner->apply(b2, x2);
+    preconditioner->apply(b1, x12);
 
-    GKO_ASSERT_MTX_NEAR(x11.get(), l({-3.0, 2.0, 1.0}),
+    GKO_ASSERT_MTX_NEAR(x11, l({-3.0, 2.0, 1.0}), r<TypeParam>::value * 1e+1);
+    GKO_ASSERT_MTX_NEAR(x2, l({{-0.125, 2.0}, {0.25, 3.0}, {1.0, 1.0}}),
                         r<TypeParam>::value * 1e+1);
-    GKO_ASSERT_MTX_NEAR(x2.get(), l({{-0.125, 2.0}, {0.25, 3.0}, {1.0, 1.0}}),
-                        r<TypeParam>::value * 1e+1);
-    GKO_ASSERT_MTX_NEAR(x12.get(), x11.get(), r<TypeParam>::value * 1e+1);
+    GKO_ASSERT_MTX_NEAR(x12, x11, r<TypeParam>::value * 1e+1);
 }
 
 
@@ -618,14 +607,14 @@ TEST_F(DefaultIlu, SolvesDefaultSingleRhs)
 {
     const auto b = gko::initialize<Mtx>({1.0, 3.0, 6.0}, this->exec);
     auto x = Mtx::create(this->exec, gko::dim<2>{3, 1});
-    x->copy_from(b.get());
+    x->copy_from(b);
 
     auto preconditioner =
         default_ilu_prec_type::build().on(this->exec)->generate(this->mtx);
-    preconditioner->apply(b.get(), x.get());
+    preconditioner->apply(b, x);
 
     // Since it uses TRS per default, the result should be accurate
-    GKO_ASSERT_MTX_NEAR(x.get(), l({-0.125, 0.25, 1.0}), 1e-14);
+    GKO_ASSERT_MTX_NEAR(x, l({-0.125, 0.25, 1.0}), 1e-14);
 }
 
 
@@ -640,11 +629,11 @@ TEST_F(DefaultIlu, CanBeUsedAsPreconditioner)
             ->generate(this->mtx);
     auto x = Mtx::create(this->exec, gko::dim<2>{3, 1});
     const auto b = gko::initialize<Mtx>({1.0, 3.0, 6.0}, this->exec);
-    x->copy_from(b.get());
+    x->copy_from(b);
 
-    solver->apply(b.get(), x.get());
+    solver->apply(b, x);
 
-    GKO_ASSERT_MTX_NEAR(x.get(), l({-0.125, 0.25, 1.0}), 1e-14);
+    GKO_ASSERT_MTX_NEAR(x, l({-0.125, 0.25, 1.0}), 1e-14);
 }
 
 
@@ -661,11 +650,11 @@ TEST_F(DefaultIlu, CanBeUsedAsGeneratedPreconditioner)
             ->generate(this->mtx);
     auto x = Mtx::create(this->exec, gko::dim<2>{3, 1});
     const auto b = gko::initialize<Mtx>({1.0, 3.0, 6.0}, this->exec);
-    x->copy_from(b.get());
+    x->copy_from(b);
 
-    solver->apply(b.get(), x.get());
+    solver->apply(b, x);
 
-    GKO_ASSERT_MTX_NEAR(x.get(), l({-0.125, 0.25, 1.0}), 1e-14);
+    GKO_ASSERT_MTX_NEAR(x, l({-0.125, 0.25, 1.0}), 1e-14);
 }
 
 

--- a/reference/test/preconditioner/isai_kernels.cpp
+++ b/reference/test/preconditioner/isai_kernels.cpp
@@ -203,14 +203,14 @@ protected:
         upper_isai_factory = UpperIsai::build().on(exec);
         general_isai_factory = GeneralIsai::build().on(exec);
         spd_isai_factory = SpdIsai::build().on(exec);
-        a_dense->convert_to(lend(a_csr));
-        a_dense_inv->convert_to(lend(a_csr_inv));
-        l_dense->convert_to(lend(l_csr));
-        l_dense_inv->convert_to(lend(l_csr_inv));
-        u_dense->convert_to(lend(u_csr));
-        u_dense_inv->convert_to(lend(u_csr_inv));
-        spd_dense->convert_to(lend(spd_csr));
-        spd_dense_inv->convert_to(lend(spd_csr_inv));
+        a_dense->convert_to(a_csr);
+        a_dense_inv->convert_to(a_csr_inv);
+        l_dense->convert_to(l_csr);
+        l_dense_inv->convert_to(l_csr_inv);
+        u_dense->convert_to(u_csr);
+        u_dense_inv->convert_to(u_csr_inv);
+        spd_dense->convert_to(spd_csr);
+        spd_dense_inv->convert_to(spd_csr_inv);
         l_csr_longrow = read<Csr>("isai_l.mtx");
         l_csr_longrow_e = read<Csr>("isai_l_excess.mtx");
         l_csr_longrow_e_rhs = read<Dense>("isai_l_excess_rhs.mtx");
@@ -333,7 +333,7 @@ TYPED_TEST(Isai, KernelGenerateA)
     using Csr = typename TestFixture::Csr;
     using value_type = typename TestFixture::value_type;
     using index_type = typename TestFixture::index_type;
-    auto result = this->clone_allocations(lend(this->a_csr));
+    auto result = this->clone_allocations(this->a_csr.get());
     auto num_rows = result->get_size()[0];
     gko::array<index_type> a1(this->exec, num_rows + 1);
     gko::array<index_type> a2(this->exec, num_rows + 1);
@@ -342,7 +342,7 @@ TYPED_TEST(Isai, KernelGenerateA)
     std::fill_n(zeros.get_data(), num_rows + 1, 0);
 
     gko::kernels::reference::isai::generate_general_inverse(
-        this->exec, lend(this->a_csr), lend(result), a1.get_data(),
+        this->exec, this->a_csr.get(), result.get(), a1.get_data(),
         a2.get_data(), false);
 
     GKO_ASSERT_MTX_EQ_SPARSITY(result, this->a_csr_inv);
@@ -358,8 +358,8 @@ TYPED_TEST(Isai, KernelGenerateA2)
     using Csr = typename TestFixture::Csr;
     using value_type = typename TestFixture::value_type;
     using index_type = typename TestFixture::index_type;
-    auto a_transpose = this->transpose(lend(this->a_csr));
-    auto result = this->clone_allocations(lend(a_transpose));
+    auto a_transpose = this->transpose(this->a_csr.get());
+    auto result = this->clone_allocations(a_transpose.get());
     auto num_rows = result->get_size()[0];
     gko::array<index_type> a1(this->exec, num_rows + 1);
     gko::array<index_type> a2(this->exec, num_rows + 1);
@@ -368,10 +368,10 @@ TYPED_TEST(Isai, KernelGenerateA2)
     std::fill_n(zeros.get_data(), num_rows + 1, 0);
 
     gko::kernels::reference::isai::generate_general_inverse(
-        this->exec, lend(a_transpose), lend(result), a1.get_data(),
+        this->exec, a_transpose.get(), result.get(), a1.get_data(),
         a2.get_data(), false);
 
-    const auto expected = this->transpose(lend(this->a_csr_inv));
+    const auto expected = this->transpose(this->a_csr_inv.get());
     GKO_ASSERT_MTX_EQ_SPARSITY(result, expected);
     GKO_ASSERT_MTX_NEAR(result, expected, r<value_type>::value);
     // no row above the size limit -> zero array
@@ -385,7 +385,7 @@ TYPED_TEST(Isai, KernelGenerateAsparse)
     using Csr = typename TestFixture::Csr;
     using value_type = typename TestFixture::value_type;
     using index_type = typename TestFixture::index_type;
-    auto result = this->clone_allocations(lend(this->a_sparse));
+    auto result = this->clone_allocations(this->a_sparse.get());
     auto num_rows = result->get_size()[0];
     gko::array<index_type> a1(this->exec, num_rows + 1);
     gko::array<index_type> a2(this->exec, num_rows + 1);
@@ -394,7 +394,7 @@ TYPED_TEST(Isai, KernelGenerateAsparse)
     std::fill_n(zeros.get_data(), num_rows + 1, 0);
 
     gko::kernels::reference::isai::generate_general_inverse(
-        this->exec, lend(this->a_sparse), lend(result), a1.get_data(),
+        this->exec, this->a_sparse.get(), result.get(), a1.get_data(),
         a2.get_data(), false);
 
     GKO_ASSERT_MTX_EQ_SPARSITY(result, this->a_sparse_inv);
@@ -410,7 +410,7 @@ TYPED_TEST(Isai, KernelGenerateALongrow)
     using Csr = typename TestFixture::Csr;
     using value_type = typename TestFixture::value_type;
     using index_type = typename TestFixture::index_type;
-    auto result = this->clone_allocations(lend(this->a_csr_longrow));
+    auto result = this->clone_allocations(this->a_csr_longrow.get());
     auto num_rows = result->get_size()[0];
     gko::array<index_type> a1(this->exec, num_rows + 1);
     gko::array<index_type> a2(this->exec, num_rows + 1);
@@ -426,7 +426,7 @@ TYPED_TEST(Isai, KernelGenerateALongrow)
     std::fill_n(a2_expect.get_data() + 36, 65, 509);
 
     gko::kernels::reference::isai::generate_general_inverse(
-        this->exec, lend(this->a_csr_longrow), lend(result), a1.get_data(),
+        this->exec, this->a_csr_longrow.get(), result.get(), a1.get_data(),
         a2.get_data(), false);
 
     GKO_ASSERT_MTX_EQ_SPARSITY(result, this->a_csr_longrow_inv_partial);
@@ -457,9 +457,9 @@ TYPED_TEST(Isai, KernelGenerateExcessALongrow)
     auto result_rhs = Dense::create(this->exec, gko::dim<2>(122, 1));
 
     gko::kernels::reference::isai::generate_excess_system(
-        this->exec, lend(this->a_csr_longrow), lend(this->a_csr_longrow),
-        a1.get_const_data(), a2.get_const_data(), lend(result),
-        lend(result_rhs), 0, num_rows);
+        this->exec, this->a_csr_longrow.get(), this->a_csr_longrow.get(),
+        a1.get_const_data(), a2.get_const_data(), result.get(),
+        result_rhs.get(), 0, num_rows);
 
     GKO_ASSERT_MTX_EQ_SPARSITY(result, this->a_csr_longrow_e);
     GKO_ASSERT_MTX_NEAR(result, this->a_csr_longrow_e, 0);
@@ -472,7 +472,7 @@ TYPED_TEST(Isai, KernelGenerateL1)
     using Csr = typename TestFixture::Csr;
     using value_type = typename TestFixture::value_type;
     using index_type = typename TestFixture::index_type;
-    auto result = this->clone_allocations(lend(this->l_csr));
+    auto result = this->clone_allocations(this->l_csr.get());
     auto num_rows = result->get_size()[0];
     gko::array<index_type> a1(this->exec, num_rows + 1);
     gko::array<index_type> a2(this->exec, num_rows + 1);
@@ -481,7 +481,7 @@ TYPED_TEST(Isai, KernelGenerateL1)
     std::fill_n(zeros.get_data(), num_rows + 1, 0);
 
     gko::kernels::reference::isai::generate_tri_inverse(
-        this->exec, lend(this->l_csr), lend(result), a1.get_data(),
+        this->exec, this->l_csr.get(), result.get(), a1.get_data(),
         a2.get_data(), true);
 
     GKO_ASSERT_MTX_EQ_SPARSITY(result, this->l_csr_inv);
@@ -497,8 +497,8 @@ TYPED_TEST(Isai, KernelGenerateL2)
     using Csr = typename TestFixture::Csr;
     using value_type = typename TestFixture::value_type;
     using index_type = typename TestFixture::index_type;
-    const auto l_mtx = this->transpose(lend(this->u_csr));
-    auto result = this->clone_allocations(lend(l_mtx));
+    const auto l_mtx = this->transpose(this->u_csr.get());
+    auto result = this->clone_allocations(l_mtx.get());
     auto num_rows = result->get_size()[0];
     gko::array<index_type> a1(this->exec, num_rows + 1);
     gko::array<index_type> a2(this->exec, num_rows + 1);
@@ -507,10 +507,10 @@ TYPED_TEST(Isai, KernelGenerateL2)
     std::fill_n(zeros.get_data(), num_rows + 1, 0);
 
     gko::kernels::reference::isai::generate_tri_inverse(
-        this->exec, lend(l_mtx), lend(result), a1.get_data(), a2.get_data(),
+        this->exec, l_mtx.get(), result.get(), a1.get_data(), a2.get_data(),
         true);
 
-    const auto expected = this->transpose(lend(this->u_csr_inv));
+    const auto expected = this->transpose(this->u_csr_inv.get());
     GKO_ASSERT_MTX_EQ_SPARSITY(result, expected);
     GKO_ASSERT_MTX_NEAR(result, expected, r<value_type>::value);
     // no row above the size limit -> zero array
@@ -524,7 +524,7 @@ TYPED_TEST(Isai, KernelGenerateLsparse1)
     using Csr = typename TestFixture::Csr;
     using value_type = typename TestFixture::value_type;
     using index_type = typename TestFixture::index_type;
-    auto result = this->clone_allocations(lend(this->l_sparse));
+    auto result = this->clone_allocations(this->l_sparse.get());
     auto num_rows = result->get_size()[0];
     gko::array<index_type> a1(this->exec, num_rows + 1);
     gko::array<index_type> a2(this->exec, num_rows + 1);
@@ -533,7 +533,7 @@ TYPED_TEST(Isai, KernelGenerateLsparse1)
     std::fill_n(zeros.get_data(), num_rows + 1, 0);
 
     gko::kernels::reference::isai::generate_tri_inverse(
-        this->exec, lend(this->l_sparse), lend(result), a1.get_data(),
+        this->exec, this->l_sparse.get(), result.get(), a1.get_data(),
         a2.get_data(), true);
 
     GKO_ASSERT_MTX_EQ_SPARSITY(result, this->l_sparse_inv);
@@ -549,7 +549,7 @@ TYPED_TEST(Isai, KernelGenerateLsparse2)
     using Csr = typename TestFixture::Csr;
     using value_type = typename TestFixture::value_type;
     using index_type = typename TestFixture::index_type;
-    auto result = this->clone_allocations(lend(this->l_sparse2));
+    auto result = this->clone_allocations(this->l_sparse2.get());
     auto num_rows = result->get_size()[0];
     gko::array<index_type> a1(this->exec, num_rows + 1);
     gko::array<index_type> a2(this->exec, num_rows + 1);
@@ -558,7 +558,7 @@ TYPED_TEST(Isai, KernelGenerateLsparse2)
     std::fill_n(zeros.get_data(), num_rows + 1, 0);
 
     gko::kernels::reference::isai::generate_tri_inverse(
-        this->exec, lend(this->l_sparse2), lend(result), a1.get_data(),
+        this->exec, this->l_sparse2.get(), result.get(), a1.get_data(),
         a2.get_data(), true);
 
     GKO_ASSERT_MTX_EQ_SPARSITY(result, this->l_sparse2_inv);
@@ -574,8 +574,8 @@ TYPED_TEST(Isai, KernelGenerateLsparse3)
     using Csr = typename TestFixture::Csr;
     using value_type = typename TestFixture::value_type;
     using index_type = typename TestFixture::index_type;
-    const auto l_mtx = this->transpose(lend(this->u_sparse));
-    auto result = this->clone_allocations(lend(l_mtx));
+    const auto l_mtx = this->transpose(this->u_sparse.get());
+    auto result = this->clone_allocations(l_mtx.get());
     auto num_rows = result->get_size()[0];
     gko::array<index_type> a1(this->exec, num_rows + 1);
     gko::array<index_type> a2(this->exec, num_rows + 1);
@@ -584,7 +584,7 @@ TYPED_TEST(Isai, KernelGenerateLsparse3)
     std::fill_n(zeros.get_data(), num_rows + 1, 0);
 
     gko::kernels::reference::isai::generate_tri_inverse(
-        this->exec, lend(l_mtx), lend(result), a1.get_data(), a2.get_data(),
+        this->exec, l_mtx.get(), result.get(), a1.get_data(), a2.get_data(),
         true);
 
     // Results in a slightly different version than u_sparse_inv->transpose()
@@ -607,7 +607,7 @@ TYPED_TEST(Isai, KernelGenerateLLongrow)
     using Csr = typename TestFixture::Csr;
     using value_type = typename TestFixture::value_type;
     using index_type = typename TestFixture::index_type;
-    auto result = this->clone_allocations(lend(this->l_csr_longrow));
+    auto result = this->clone_allocations(this->l_csr_longrow.get());
     auto num_rows = result->get_size()[0];
     gko::array<index_type> a1(this->exec, num_rows + 1);
     gko::array<index_type> a2(this->exec, num_rows + 1);
@@ -625,7 +625,7 @@ TYPED_TEST(Isai, KernelGenerateLLongrow)
     a2_expect.get_data()[35] = 248;
 
     gko::kernels::reference::isai::generate_tri_inverse(
-        this->exec, lend(this->l_csr_longrow), lend(result), a1.get_data(),
+        this->exec, this->l_csr_longrow.get(), result.get(), a1.get_data(),
         a2.get_data(), true);
 
     GKO_ASSERT_MTX_EQ_SPARSITY(result, this->l_csr_longrow_inv_partial);
@@ -658,9 +658,9 @@ TYPED_TEST(Isai, KernelGenerateExcessLLongrow)
     auto result_rhs = Dense::create(this->exec, gko::dim<2>(66, 1));
 
     gko::kernels::reference::isai::generate_excess_system(
-        this->exec, lend(this->l_csr_longrow), lend(this->l_csr_longrow),
-        a1.get_const_data(), a2.get_const_data(), lend(result),
-        lend(result_rhs), 0, num_rows);
+        this->exec, this->l_csr_longrow.get(), this->l_csr_longrow.get(),
+        a1.get_const_data(), a2.get_const_data(), result.get(),
+        result_rhs.get(), 0, num_rows);
 
     GKO_ASSERT_MTX_EQ_SPARSITY(result, this->l_csr_longrow_e);
     GKO_ASSERT_MTX_NEAR(result, this->l_csr_longrow_e, 0);
@@ -673,8 +673,8 @@ TYPED_TEST(Isai, KernelGenerateU1)
     using Csr = typename TestFixture::Csr;
     using value_type = typename TestFixture::value_type;
     using index_type = typename TestFixture::index_type;
-    const auto u_mtx = this->transpose(lend(this->l_csr));
-    auto result = this->clone_allocations(lend(u_mtx));
+    const auto u_mtx = this->transpose(this->l_csr.get());
+    auto result = this->clone_allocations(u_mtx.get());
     auto num_rows = result->get_size()[0];
     gko::array<index_type> a1(this->exec, num_rows + 1);
     gko::array<index_type> a2(this->exec, num_rows + 1);
@@ -683,10 +683,10 @@ TYPED_TEST(Isai, KernelGenerateU1)
     std::fill_n(zeros.get_data(), num_rows + 1, 0);
 
     gko::kernels::reference::isai::generate_tri_inverse(
-        this->exec, lend(u_mtx), lend(result), a1.get_data(), a2.get_data(),
+        this->exec, u_mtx.get(), result.get(), a1.get_data(), a2.get_data(),
         false);
 
-    auto expected = this->transpose(lend(this->l_csr_inv));
+    auto expected = this->transpose(this->l_csr_inv.get());
     GKO_ASSERT_MTX_EQ_SPARSITY(result, expected);
     GKO_ASSERT_MTX_NEAR(result, expected, r<value_type>::value);
     // no row above the size limit -> zero array
@@ -700,7 +700,7 @@ TYPED_TEST(Isai, KernelGenerateU2)
     using Csr = typename TestFixture::Csr;
     using value_type = typename TestFixture::value_type;
     using index_type = typename TestFixture::index_type;
-    auto result = this->clone_allocations(lend(this->u_csr));
+    auto result = this->clone_allocations(this->u_csr.get());
     auto num_rows = result->get_size()[0];
     gko::array<index_type> a1(this->exec, num_rows + 1);
     gko::array<index_type> a2(this->exec, num_rows + 1);
@@ -709,7 +709,7 @@ TYPED_TEST(Isai, KernelGenerateU2)
     std::fill_n(zeros.get_data(), num_rows + 1, 0);
 
     gko::kernels::reference::isai::generate_tri_inverse(
-        this->exec, lend(this->u_csr), lend(result), a1.get_data(),
+        this->exec, this->u_csr.get(), result.get(), a1.get_data(),
         a2.get_data(), false);
 
     GKO_ASSERT_MTX_EQ_SPARSITY(result, this->u_csr_inv);
@@ -725,8 +725,8 @@ TYPED_TEST(Isai, KernelGenerateUsparse1)
     using Csr = typename TestFixture::Csr;
     using value_type = typename TestFixture::value_type;
     using index_type = typename TestFixture::index_type;
-    const auto u_mtx = this->transpose(lend(this->l_sparse));
-    auto result = this->clone_allocations(lend(u_mtx));
+    const auto u_mtx = this->transpose(this->l_sparse.get());
+    auto result = this->clone_allocations(u_mtx.get());
     auto num_rows = result->get_size()[0];
     gko::array<index_type> a1(this->exec, num_rows + 1);
     gko::array<index_type> a2(this->exec, num_rows + 1);
@@ -735,10 +735,10 @@ TYPED_TEST(Isai, KernelGenerateUsparse1)
     std::fill_n(zeros.get_data(), num_rows + 1, 0);
 
     gko::kernels::reference::isai::generate_tri_inverse(
-        this->exec, lend(u_mtx), lend(result), a1.get_data(), a2.get_data(),
+        this->exec, u_mtx.get(), result.get(), a1.get_data(), a2.get_data(),
         false);
 
-    const auto expected = this->transpose(lend(this->l_sparse_inv));
+    const auto expected = this->transpose(this->l_sparse_inv.get());
     GKO_ASSERT_MTX_EQ_SPARSITY(result, expected);
     GKO_ASSERT_MTX_NEAR(result, expected, r<value_type>::value);
     // no row above the size limit -> zero array
@@ -753,7 +753,7 @@ TYPED_TEST(Isai, KernelGenerateUsparse2)
     using value_type = typename TestFixture::value_type;
     using index_type = typename TestFixture::index_type;
     const auto u_mtx = this->transpose(this->l_sparse2.get());
-    auto result = this->clone_allocations(lend(u_mtx));
+    auto result = this->clone_allocations(u_mtx.get());
     auto num_rows = result->get_size()[0];
     gko::array<index_type> a1(this->exec, num_rows + 1);
     gko::array<index_type> a2(this->exec, num_rows + 1);
@@ -762,7 +762,7 @@ TYPED_TEST(Isai, KernelGenerateUsparse2)
     std::fill_n(zeros.get_data(), num_rows + 1, 0);
 
     gko::kernels::reference::isai::generate_tri_inverse(
-        this->exec, lend(u_mtx), lend(result), a1.get_data(), a2.get_data(),
+        this->exec, u_mtx.get(), result.get(), a1.get_data(), a2.get_data(),
         false);
 
     // Results in a slightly different version than l_sparse2_inv->transpose()
@@ -785,7 +785,7 @@ TYPED_TEST(Isai, KernelGenerateUsparse3)
     using Csr = typename TestFixture::Csr;
     using value_type = typename TestFixture::value_type;
     using index_type = typename TestFixture::index_type;
-    auto result = this->clone_allocations(lend(this->u_sparse));
+    auto result = this->clone_allocations(this->u_sparse.get());
     auto num_rows = result->get_size()[0];
     gko::array<index_type> a1(this->exec, num_rows + 1);
     gko::array<index_type> a2(this->exec, num_rows + 1);
@@ -794,7 +794,7 @@ TYPED_TEST(Isai, KernelGenerateUsparse3)
     std::fill_n(zeros.get_data(), num_rows + 1, 0);
 
     gko::kernels::reference::isai::generate_tri_inverse(
-        this->exec, lend(this->u_sparse), lend(result), a1.get_data(),
+        this->exec, this->u_sparse.get(), result.get(), a1.get_data(),
         a2.get_data(), false);
 
     GKO_ASSERT_MTX_EQ_SPARSITY(result, this->u_sparse_inv);
@@ -810,7 +810,7 @@ TYPED_TEST(Isai, KernelGenerateULongrow)
     using Csr = typename TestFixture::Csr;
     using value_type = typename TestFixture::value_type;
     using index_type = typename TestFixture::index_type;
-    auto result = this->clone_allocations(lend(this->u_csr_longrow));
+    auto result = this->clone_allocations(this->u_csr_longrow.get());
     auto num_rows = result->get_size()[0];
     gko::array<index_type> a1(this->exec, num_rows + 1);
     gko::array<index_type> a2(this->exec, num_rows + 1);
@@ -824,7 +824,7 @@ TYPED_TEST(Isai, KernelGenerateULongrow)
     std::fill_n(a2_expect.get_data() + 3, 33, 153);
 
     gko::kernels::reference::isai::generate_tri_inverse(
-        this->exec, lend(this->u_csr_longrow), lend(result), a1.get_data(),
+        this->exec, this->u_csr_longrow.get(), result.get(), a1.get_data(),
         a2.get_data(), false);
 
     GKO_ASSERT_MTX_EQ_SPARSITY(result, this->u_csr_longrow_inv_partial);
@@ -853,9 +853,9 @@ TYPED_TEST(Isai, KernelGenerateExcessULongrow)
     auto result_rhs = Dense::create(this->exec, gko::dim<2>(33, 1));
 
     gko::kernels::reference::isai::generate_excess_system(
-        this->exec, lend(this->u_csr_longrow), lend(this->u_csr_longrow),
-        a1.get_const_data(), a2.get_const_data(), lend(result),
-        lend(result_rhs), 0, num_rows);
+        this->exec, this->u_csr_longrow.get(), this->u_csr_longrow.get(),
+        a1.get_const_data(), a2.get_const_data(), result.get(),
+        result_rhs.get(), 0, num_rows);
 
     GKO_ASSERT_MTX_EQ_SPARSITY(result, this->u_csr_longrow_e);
     GKO_ASSERT_MTX_NEAR(result, this->u_csr_longrow_e, 0);
@@ -868,7 +868,7 @@ TYPED_TEST(Isai, KernelGenerateSpd)
     using Csr = typename TestFixture::Csr;
     using value_type = typename TestFixture::value_type;
     using index_type = typename TestFixture::index_type;
-    auto result = this->clone_allocations(lend(this->spd_csr_inv));
+    auto result = this->clone_allocations(this->spd_csr_inv.get());
     auto num_rows = result->get_size()[0];
     gko::array<index_type> a1(this->exec, num_rows + 1);
     gko::array<index_type> a2(this->exec, num_rows + 1);
@@ -877,7 +877,7 @@ TYPED_TEST(Isai, KernelGenerateSpd)
     std::fill_n(zeros.get_data(), num_rows + 1, 0);
 
     gko::kernels::reference::isai::generate_general_inverse(
-        this->exec, lend(this->spd_csr), lend(result), a1.get_data(),
+        this->exec, this->spd_csr.get(), result.get(), a1.get_data(),
         a2.get_data(), true);
 
     GKO_ASSERT_MTX_EQ_SPARSITY(result, this->spd_csr_inv);
@@ -893,7 +893,7 @@ TYPED_TEST(Isai, KernelGenerateSpdsparse)
     using Csr = typename TestFixture::Csr;
     using value_type = typename TestFixture::value_type;
     using index_type = typename TestFixture::index_type;
-    auto result = this->clone_allocations(lend(this->spd_sparse_inv));
+    auto result = this->clone_allocations(this->spd_sparse_inv.get());
     auto num_rows = result->get_size()[0];
     gko::array<index_type> a1(this->exec, num_rows + 1);
     gko::array<index_type> a2(this->exec, num_rows + 1);
@@ -902,7 +902,7 @@ TYPED_TEST(Isai, KernelGenerateSpdsparse)
     std::fill_n(zeros.get_data(), num_rows + 1, 0);
 
     gko::kernels::reference::isai::generate_general_inverse(
-        this->exec, lend(this->spd_sparse), lend(result), a1.get_data(),
+        this->exec, this->spd_sparse.get(), result.get(), a1.get_data(),
         a2.get_data(), true);
 
     GKO_ASSERT_MTX_EQ_SPARSITY(result, this->spd_sparse_inv);
@@ -918,7 +918,7 @@ TYPED_TEST(Isai, KernelGenerateSpdLongrow)
     using Csr = typename TestFixture::Csr;
     using value_type = typename TestFixture::value_type;
     using index_type = typename TestFixture::index_type;
-    auto result = this->clone_allocations(lend(this->spd_csr_longrow_inv));
+    auto result = this->clone_allocations(this->spd_csr_longrow_inv.get());
     auto num_rows = result->get_size()[0];
     gko::array<index_type> a1(this->exec, num_rows + 1);
     gko::array<index_type> a2(this->exec, num_rows + 1);
@@ -932,7 +932,7 @@ TYPED_TEST(Isai, KernelGenerateSpdLongrow)
     std::fill_n(a2_expect.get_data() + 36, 65, 338);
 
     gko::kernels::reference::isai::generate_general_inverse(
-        this->exec, lend(this->spd_csr_longrow), lend(result), a1.get_data(),
+        this->exec, this->spd_csr_longrow.get(), result.get(), a1.get_data(),
         a2.get_data(), true);
 
     GKO_ASSERT_MTX_EQ_SPARSITY(result, this->spd_csr_longrow_inv_partial);
@@ -961,9 +961,9 @@ TYPED_TEST(Isai, KernelGenerateExcessSpdLongrow)
     auto result_rhs = Dense::create(this->exec, gko::dim<2>(36, 1));
 
     gko::kernels::reference::isai::generate_excess_system(
-        this->exec, lend(this->spd_csr_longrow),
-        lend(this->spd_csr_longrow_inv_partial), a1.get_const_data(),
-        a2.get_const_data(), lend(result), lend(result_rhs), 0, num_rows);
+        this->exec, this->spd_csr_longrow.get(),
+        this->spd_csr_longrow_inv_partial.get(), a1.get_const_data(),
+        a2.get_const_data(), result.get(), result_rhs.get(), 0, num_rows);
 
     GKO_ASSERT_MTX_EQ_SPARSITY(result, this->spd_csr_longrow_e);
     GKO_ASSERT_MTX_NEAR(result, this->spd_csr_longrow_e, 0);
@@ -1302,10 +1302,10 @@ TYPED_TEST(Isai, ApplyWithAMtx)
     using Dense = typename TestFixture::Dense;
     using T = typename TestFixture::value_type;
     const auto vec = gko::initialize<Dense>({18., 16., 12.}, this->exec);
-    auto result = Dense::create_with_config_of(lend(vec));
+    auto result = Dense::create_with_config_of(vec);
     const auto a_isai = this->general_isai_factory->generate(this->a_dense);
 
-    a_isai->apply(lend(vec), lend(result));
+    a_isai->apply(vec, result);
 
     GKO_ASSERT_MTX_NEAR(result, l({-0.625, 3.5, 7.875}), r<T>::value);
 }
@@ -1316,10 +1316,10 @@ TYPED_TEST(Isai, ApplyWithLMtx)
     using Dense = typename TestFixture::Dense;
     using T = typename TestFixture::value_type;
     const auto vec = gko::initialize<Dense>({18., 16., 12.}, this->exec);
-    auto result = Dense::create_with_config_of(lend(vec));
+    auto result = Dense::create_with_config_of(vec);
     const auto l_isai = this->lower_isai_factory->generate(this->l_dense);
 
-    l_isai->apply(lend(vec), lend(result));
+    l_isai->apply(vec, result);
 
     GKO_ASSERT_MTX_NEAR(result, l({9., -3.5, -24.5}), r<T>::value);
 }
@@ -1330,10 +1330,10 @@ TYPED_TEST(Isai, ApplyWithUMtx)
     using Dense = typename TestFixture::Dense;
     using T = typename TestFixture::value_type;
     const auto vec = gko::initialize<Dense>({18., 16., 12.}, this->exec);
-    auto result = Dense::create_with_config_of(lend(vec));
+    auto result = Dense::create_with_config_of(vec);
     const auto u_isai = this->upper_isai_factory->generate(this->u_dense);
 
-    u_isai->apply(lend(vec), lend(result));
+    u_isai->apply(vec, result);
 
     GKO_ASSERT_MTX_NEAR(result, l({6.125, -5., 1.5}), r<T>::value);
 }
@@ -1344,10 +1344,10 @@ TYPED_TEST(Isai, ApplyWithSpdComposition)
     using Dense = typename TestFixture::Dense;
     using T = typename TestFixture::value_type;
     const auto vec = gko::initialize<Dense>({18., 16., 12.}, this->exec);
-    auto result = Dense::create_with_config_of(lend(vec));
+    auto result = Dense::create_with_config_of(vec);
     const auto spd_isai = this->spd_isai_factory->generate(this->spd_dense);
 
-    spd_isai->apply(lend(vec), lend(result));
+    spd_isai->apply(vec, result);
 
     GKO_ASSERT_MTX_NEAR(result, l({502., 110., -26.}), r<T>::value);
 }
@@ -1363,7 +1363,7 @@ TYPED_TEST(Isai, AdvancedApplyAMtx)
     auto result = gko::initialize<Dense>({2., -3., 1.}, this->exec);
     const auto a_isai = this->general_isai_factory->generate(this->a_dense);
 
-    a_isai->apply(lend(alpha), lend(vec), lend(beta), lend(result));
+    a_isai->apply(alpha, vec, beta, result);
 
     GKO_ASSERT_MTX_NEAR(result, l({-9.875, 22.5, 19.625}), r<T>::value);
 }
@@ -1379,7 +1379,7 @@ TYPED_TEST(Isai, AdvancedApplyLMtx)
     auto result = gko::initialize<Dense>({2., -3., 1.}, this->exec);
     const auto l_isai = this->lower_isai_factory->generate(this->l_dense);
 
-    l_isai->apply(lend(alpha), lend(vec), lend(beta), lend(result));
+    l_isai->apply(alpha, vec, beta, result);
 
     GKO_ASSERT_MTX_NEAR(result, l({19., 1.5, -77.5}), r<T>::value);
 }
@@ -1395,7 +1395,7 @@ TYPED_TEST(Isai, AdvancedApplyUMtx)
     auto result = gko::initialize<Dense>({2., -3., 1.}, this->exec);
     const auto u_isai = this->upper_isai_factory->generate(this->u_dense);
 
-    u_isai->apply(lend(alpha), lend(vec), lend(beta), lend(result));
+    u_isai->apply(alpha, vec, beta, result);
 
     GKO_ASSERT_MTX_NEAR(result, l({10.375, -3., 0.5}), r<T>::value);
 }
@@ -1411,7 +1411,7 @@ TYPED_TEST(Isai, AdvancedApplySpdComposition)
     auto result = gko::initialize<Dense>({2., -3., 1.}, this->exec);
     const auto spd_isai = this->spd_isai_factory->generate(this->spd_dense);
 
-    spd_isai->apply(lend(alpha), lend(vec), lend(beta), lend(result));
+    spd_isai->apply(alpha, vec, beta, result);
 
     GKO_ASSERT_MTX_NEAR(result, l({1498., 342., -82.}), r<T>::value);
 }
@@ -1426,14 +1426,14 @@ TYPED_TEST(Isai, UseWithIluPreconditioner)
     using UpperIsai = typename TestFixture::UpperIsai;
     const auto vec = gko::initialize<Dense>({128, -64, 32}, this->exec);
     auto result = Dense::create(this->exec, vec->get_size());
-    auto mtx = gko::share(Dense::create_with_config_of(lend(this->l_dense)));
-    this->l_dense->apply(lend(this->u_dense), lend(mtx));
+    auto mtx = gko::share(Dense::create_with_config_of(this->l_dense));
+    this->l_dense->apply(this->u_dense, mtx);
     auto ilu_factory = gko::preconditioner::Ilu<LowerIsai, UpperIsai, false,
                                                 index_type>::build()
                            .on(this->exec);
     auto ilu = ilu_factory->generate(mtx);
 
-    ilu->apply(lend(vec), lend(result));
+    ilu->apply(vec, result);
 
     GKO_ASSERT_MTX_NEAR(result, l({25., -40., -4.}), r<T>::value);
 }

--- a/reference/test/preconditioner/isai_kernels.cpp
+++ b/reference/test/preconditioner/isai_kernels.cpp
@@ -249,8 +249,7 @@ protected:
         return std::move(result);
     }
 
-    std::unique_ptr<Csr> clone_allocations(
-        gko::pointer_param<const Csr> csr_mtx)
+    std::unique_ptr<Csr> clone_allocations(gko::ptr_param<const Csr> csr_mtx)
     {
         const auto num_elems = csr_mtx->get_num_stored_elements();
         auto sparsity = csr_mtx->clone();
@@ -260,7 +259,7 @@ protected:
         return sparsity;
     }
 
-    std::unique_ptr<Csr> transpose(gko::pointer_param<const Csr> mtx)
+    std::unique_ptr<Csr> transpose(gko::ptr_param<const Csr> mtx)
     {
         return gko::as<Csr>(mtx->transpose());
     }

--- a/reference/test/preconditioner/isai_kernels.cpp
+++ b/reference/test/preconditioner/isai_kernels.cpp
@@ -249,7 +249,8 @@ protected:
         return std::move(result);
     }
 
-    std::unique_ptr<Csr> clone_allocations(const Csr* csr_mtx)
+    std::unique_ptr<Csr> clone_allocations(
+        gko::pointer_param<const Csr> csr_mtx)
     {
         const auto num_elems = csr_mtx->get_num_stored_elements();
         auto sparsity = csr_mtx->clone();
@@ -259,7 +260,7 @@ protected:
         return sparsity;
     }
 
-    std::unique_ptr<Csr> transpose(const Csr* mtx)
+    std::unique_ptr<Csr> transpose(gko::pointer_param<const Csr> mtx)
     {
         return gko::as<Csr>(mtx->transpose());
     }
@@ -333,7 +334,7 @@ TYPED_TEST(Isai, KernelGenerateA)
     using Csr = typename TestFixture::Csr;
     using value_type = typename TestFixture::value_type;
     using index_type = typename TestFixture::index_type;
-    auto result = this->clone_allocations(this->a_csr.get());
+    auto result = this->clone_allocations(this->a_csr);
     auto num_rows = result->get_size()[0];
     gko::array<index_type> a1(this->exec, num_rows + 1);
     gko::array<index_type> a2(this->exec, num_rows + 1);
@@ -358,8 +359,8 @@ TYPED_TEST(Isai, KernelGenerateA2)
     using Csr = typename TestFixture::Csr;
     using value_type = typename TestFixture::value_type;
     using index_type = typename TestFixture::index_type;
-    auto a_transpose = this->transpose(this->a_csr.get());
-    auto result = this->clone_allocations(a_transpose.get());
+    auto a_transpose = this->transpose(this->a_csr);
+    auto result = this->clone_allocations(a_transpose);
     auto num_rows = result->get_size()[0];
     gko::array<index_type> a1(this->exec, num_rows + 1);
     gko::array<index_type> a2(this->exec, num_rows + 1);
@@ -371,7 +372,7 @@ TYPED_TEST(Isai, KernelGenerateA2)
         this->exec, a_transpose.get(), result.get(), a1.get_data(),
         a2.get_data(), false);
 
-    const auto expected = this->transpose(this->a_csr_inv.get());
+    const auto expected = this->transpose(this->a_csr_inv);
     GKO_ASSERT_MTX_EQ_SPARSITY(result, expected);
     GKO_ASSERT_MTX_NEAR(result, expected, r<value_type>::value);
     // no row above the size limit -> zero array
@@ -385,7 +386,7 @@ TYPED_TEST(Isai, KernelGenerateAsparse)
     using Csr = typename TestFixture::Csr;
     using value_type = typename TestFixture::value_type;
     using index_type = typename TestFixture::index_type;
-    auto result = this->clone_allocations(this->a_sparse.get());
+    auto result = this->clone_allocations(this->a_sparse);
     auto num_rows = result->get_size()[0];
     gko::array<index_type> a1(this->exec, num_rows + 1);
     gko::array<index_type> a2(this->exec, num_rows + 1);
@@ -410,7 +411,7 @@ TYPED_TEST(Isai, KernelGenerateALongrow)
     using Csr = typename TestFixture::Csr;
     using value_type = typename TestFixture::value_type;
     using index_type = typename TestFixture::index_type;
-    auto result = this->clone_allocations(this->a_csr_longrow.get());
+    auto result = this->clone_allocations(this->a_csr_longrow);
     auto num_rows = result->get_size()[0];
     gko::array<index_type> a1(this->exec, num_rows + 1);
     gko::array<index_type> a2(this->exec, num_rows + 1);
@@ -472,7 +473,7 @@ TYPED_TEST(Isai, KernelGenerateL1)
     using Csr = typename TestFixture::Csr;
     using value_type = typename TestFixture::value_type;
     using index_type = typename TestFixture::index_type;
-    auto result = this->clone_allocations(this->l_csr.get());
+    auto result = this->clone_allocations(this->l_csr);
     auto num_rows = result->get_size()[0];
     gko::array<index_type> a1(this->exec, num_rows + 1);
     gko::array<index_type> a2(this->exec, num_rows + 1);
@@ -497,8 +498,8 @@ TYPED_TEST(Isai, KernelGenerateL2)
     using Csr = typename TestFixture::Csr;
     using value_type = typename TestFixture::value_type;
     using index_type = typename TestFixture::index_type;
-    const auto l_mtx = this->transpose(this->u_csr.get());
-    auto result = this->clone_allocations(l_mtx.get());
+    const auto l_mtx = this->transpose(this->u_csr);
+    auto result = this->clone_allocations(l_mtx);
     auto num_rows = result->get_size()[0];
     gko::array<index_type> a1(this->exec, num_rows + 1);
     gko::array<index_type> a2(this->exec, num_rows + 1);
@@ -510,7 +511,7 @@ TYPED_TEST(Isai, KernelGenerateL2)
         this->exec, l_mtx.get(), result.get(), a1.get_data(), a2.get_data(),
         true);
 
-    const auto expected = this->transpose(this->u_csr_inv.get());
+    const auto expected = this->transpose(this->u_csr_inv);
     GKO_ASSERT_MTX_EQ_SPARSITY(result, expected);
     GKO_ASSERT_MTX_NEAR(result, expected, r<value_type>::value);
     // no row above the size limit -> zero array
@@ -524,7 +525,7 @@ TYPED_TEST(Isai, KernelGenerateLsparse1)
     using Csr = typename TestFixture::Csr;
     using value_type = typename TestFixture::value_type;
     using index_type = typename TestFixture::index_type;
-    auto result = this->clone_allocations(this->l_sparse.get());
+    auto result = this->clone_allocations(this->l_sparse);
     auto num_rows = result->get_size()[0];
     gko::array<index_type> a1(this->exec, num_rows + 1);
     gko::array<index_type> a2(this->exec, num_rows + 1);
@@ -549,7 +550,7 @@ TYPED_TEST(Isai, KernelGenerateLsparse2)
     using Csr = typename TestFixture::Csr;
     using value_type = typename TestFixture::value_type;
     using index_type = typename TestFixture::index_type;
-    auto result = this->clone_allocations(this->l_sparse2.get());
+    auto result = this->clone_allocations(this->l_sparse2);
     auto num_rows = result->get_size()[0];
     gko::array<index_type> a1(this->exec, num_rows + 1);
     gko::array<index_type> a2(this->exec, num_rows + 1);
@@ -574,8 +575,8 @@ TYPED_TEST(Isai, KernelGenerateLsparse3)
     using Csr = typename TestFixture::Csr;
     using value_type = typename TestFixture::value_type;
     using index_type = typename TestFixture::index_type;
-    const auto l_mtx = this->transpose(this->u_sparse.get());
-    auto result = this->clone_allocations(l_mtx.get());
+    const auto l_mtx = this->transpose(this->u_sparse);
+    auto result = this->clone_allocations(l_mtx);
     auto num_rows = result->get_size()[0];
     gko::array<index_type> a1(this->exec, num_rows + 1);
     gko::array<index_type> a2(this->exec, num_rows + 1);
@@ -607,7 +608,7 @@ TYPED_TEST(Isai, KernelGenerateLLongrow)
     using Csr = typename TestFixture::Csr;
     using value_type = typename TestFixture::value_type;
     using index_type = typename TestFixture::index_type;
-    auto result = this->clone_allocations(this->l_csr_longrow.get());
+    auto result = this->clone_allocations(this->l_csr_longrow);
     auto num_rows = result->get_size()[0];
     gko::array<index_type> a1(this->exec, num_rows + 1);
     gko::array<index_type> a2(this->exec, num_rows + 1);
@@ -673,8 +674,8 @@ TYPED_TEST(Isai, KernelGenerateU1)
     using Csr = typename TestFixture::Csr;
     using value_type = typename TestFixture::value_type;
     using index_type = typename TestFixture::index_type;
-    const auto u_mtx = this->transpose(this->l_csr.get());
-    auto result = this->clone_allocations(u_mtx.get());
+    const auto u_mtx = this->transpose(this->l_csr);
+    auto result = this->clone_allocations(u_mtx);
     auto num_rows = result->get_size()[0];
     gko::array<index_type> a1(this->exec, num_rows + 1);
     gko::array<index_type> a2(this->exec, num_rows + 1);
@@ -686,7 +687,7 @@ TYPED_TEST(Isai, KernelGenerateU1)
         this->exec, u_mtx.get(), result.get(), a1.get_data(), a2.get_data(),
         false);
 
-    auto expected = this->transpose(this->l_csr_inv.get());
+    auto expected = this->transpose(this->l_csr_inv);
     GKO_ASSERT_MTX_EQ_SPARSITY(result, expected);
     GKO_ASSERT_MTX_NEAR(result, expected, r<value_type>::value);
     // no row above the size limit -> zero array
@@ -700,7 +701,7 @@ TYPED_TEST(Isai, KernelGenerateU2)
     using Csr = typename TestFixture::Csr;
     using value_type = typename TestFixture::value_type;
     using index_type = typename TestFixture::index_type;
-    auto result = this->clone_allocations(this->u_csr.get());
+    auto result = this->clone_allocations(this->u_csr);
     auto num_rows = result->get_size()[0];
     gko::array<index_type> a1(this->exec, num_rows + 1);
     gko::array<index_type> a2(this->exec, num_rows + 1);
@@ -725,8 +726,8 @@ TYPED_TEST(Isai, KernelGenerateUsparse1)
     using Csr = typename TestFixture::Csr;
     using value_type = typename TestFixture::value_type;
     using index_type = typename TestFixture::index_type;
-    const auto u_mtx = this->transpose(this->l_sparse.get());
-    auto result = this->clone_allocations(u_mtx.get());
+    const auto u_mtx = this->transpose(this->l_sparse);
+    auto result = this->clone_allocations(u_mtx);
     auto num_rows = result->get_size()[0];
     gko::array<index_type> a1(this->exec, num_rows + 1);
     gko::array<index_type> a2(this->exec, num_rows + 1);
@@ -738,7 +739,7 @@ TYPED_TEST(Isai, KernelGenerateUsparse1)
         this->exec, u_mtx.get(), result.get(), a1.get_data(), a2.get_data(),
         false);
 
-    const auto expected = this->transpose(this->l_sparse_inv.get());
+    const auto expected = this->transpose(this->l_sparse_inv);
     GKO_ASSERT_MTX_EQ_SPARSITY(result, expected);
     GKO_ASSERT_MTX_NEAR(result, expected, r<value_type>::value);
     // no row above the size limit -> zero array
@@ -752,8 +753,8 @@ TYPED_TEST(Isai, KernelGenerateUsparse2)
     using Csr = typename TestFixture::Csr;
     using value_type = typename TestFixture::value_type;
     using index_type = typename TestFixture::index_type;
-    const auto u_mtx = this->transpose(this->l_sparse2.get());
-    auto result = this->clone_allocations(u_mtx.get());
+    const auto u_mtx = this->transpose(this->l_sparse2);
+    auto result = this->clone_allocations(u_mtx);
     auto num_rows = result->get_size()[0];
     gko::array<index_type> a1(this->exec, num_rows + 1);
     gko::array<index_type> a2(this->exec, num_rows + 1);
@@ -785,7 +786,7 @@ TYPED_TEST(Isai, KernelGenerateUsparse3)
     using Csr = typename TestFixture::Csr;
     using value_type = typename TestFixture::value_type;
     using index_type = typename TestFixture::index_type;
-    auto result = this->clone_allocations(this->u_sparse.get());
+    auto result = this->clone_allocations(this->u_sparse);
     auto num_rows = result->get_size()[0];
     gko::array<index_type> a1(this->exec, num_rows + 1);
     gko::array<index_type> a2(this->exec, num_rows + 1);
@@ -810,7 +811,7 @@ TYPED_TEST(Isai, KernelGenerateULongrow)
     using Csr = typename TestFixture::Csr;
     using value_type = typename TestFixture::value_type;
     using index_type = typename TestFixture::index_type;
-    auto result = this->clone_allocations(this->u_csr_longrow.get());
+    auto result = this->clone_allocations(this->u_csr_longrow);
     auto num_rows = result->get_size()[0];
     gko::array<index_type> a1(this->exec, num_rows + 1);
     gko::array<index_type> a2(this->exec, num_rows + 1);
@@ -868,7 +869,7 @@ TYPED_TEST(Isai, KernelGenerateSpd)
     using Csr = typename TestFixture::Csr;
     using value_type = typename TestFixture::value_type;
     using index_type = typename TestFixture::index_type;
-    auto result = this->clone_allocations(this->spd_csr_inv.get());
+    auto result = this->clone_allocations(this->spd_csr_inv);
     auto num_rows = result->get_size()[0];
     gko::array<index_type> a1(this->exec, num_rows + 1);
     gko::array<index_type> a2(this->exec, num_rows + 1);
@@ -893,7 +894,7 @@ TYPED_TEST(Isai, KernelGenerateSpdsparse)
     using Csr = typename TestFixture::Csr;
     using value_type = typename TestFixture::value_type;
     using index_type = typename TestFixture::index_type;
-    auto result = this->clone_allocations(this->spd_sparse_inv.get());
+    auto result = this->clone_allocations(this->spd_sparse_inv);
     auto num_rows = result->get_size()[0];
     gko::array<index_type> a1(this->exec, num_rows + 1);
     gko::array<index_type> a2(this->exec, num_rows + 1);
@@ -918,7 +919,7 @@ TYPED_TEST(Isai, KernelGenerateSpdLongrow)
     using Csr = typename TestFixture::Csr;
     using value_type = typename TestFixture::value_type;
     using index_type = typename TestFixture::index_type;
-    auto result = this->clone_allocations(this->spd_csr_longrow_inv.get());
+    auto result = this->clone_allocations(this->spd_csr_longrow_inv);
     auto num_rows = result->get_size()[0];
     gko::array<index_type> a1(this->exec, num_rows + 1);
     gko::array<index_type> a2(this->exec, num_rows + 1);

--- a/reference/test/preconditioner/jacobi.cpp
+++ b/reference/test/preconditioner/jacobi.cpp
@@ -193,14 +193,14 @@ TYPED_TEST(Jacobi, CanBeCloned)
 {
     auto bj_clone = clone(this->bj);
 
-    this->assert_same_precond(lend(bj_clone), lend(this->bj));
+    this->assert_same_precond(bj_clone.get(), this->bj.get());
 }
 
 
 TYPED_TEST(Jacobi, CanBeClonedWithAdaptvePrecision)
 {
     auto bj_clone = clone(this->adaptive_bj);
-    this->assert_same_precond(lend(bj_clone), lend(this->adaptive_bj));
+    this->assert_same_precond(bj_clone.get(), this->adaptive_bj.get());
 }
 
 
@@ -216,9 +216,9 @@ TYPED_TEST(Jacobi, CanBeCopied)
                     .on(this->exec)
                     ->generate(Mtx::create(this->exec));
 
-    copy->copy_from(lend(this->bj));
+    copy->copy_from(this->bj);
 
-    this->assert_same_precond(lend(copy), lend(this->bj));
+    this->assert_same_precond(copy.get(), this->bj.get());
 }
 
 
@@ -234,9 +234,9 @@ TYPED_TEST(Jacobi, CanBeCopiedWithAdaptivePrecision)
                     .on(this->exec)
                     ->generate(Mtx::create(this->exec));
 
-    copy->copy_from(lend(this->adaptive_bj));
+    copy->copy_from(this->adaptive_bj);
 
-    this->assert_same_precond(lend(copy), lend(this->adaptive_bj));
+    this->assert_same_precond(copy.get(), this->adaptive_bj.get());
 }
 
 
@@ -255,7 +255,7 @@ TYPED_TEST(Jacobi, CanBeMoved)
 
     copy->copy_from(give(this->bj));
 
-    this->assert_same_precond(lend(copy), lend(tmp));
+    this->assert_same_precond(copy.get(), tmp.get());
 }
 
 
@@ -274,7 +274,7 @@ TYPED_TEST(Jacobi, CanBeMovedWithAdaptivePrecision)
 
     copy->copy_from(give(this->adaptive_bj));
 
-    this->assert_same_precond(lend(copy), lend(tmp));
+    this->assert_same_precond(copy.get(), tmp.get());
 }
 
 
@@ -316,7 +316,7 @@ TYPED_TEST(Jacobi, ScalarJacobiConvertsToDense)
     gko::matrix_data<value_type, index_type> data;
     auto csr = gko::share(
         gko::matrix::Csr<value_type, index_type>::create(this->exec));
-    csr->copy_from(gko::lend(this->mtx));
+    csr->copy_from(this->mtx);
     auto scalar_j = this->scalar_j_factory->generate(csr);
 
     auto dense_j = gko::matrix::Dense<value_type>::create(this->exec);
@@ -343,7 +343,7 @@ TYPED_TEST(Jacobi, ScalarJacobiCanBeTransposed)
     gko::matrix_data<value_type, index_type> data;
     auto csr = gko::share(
         gko::matrix::Csr<value_type, index_type>::create(this->exec));
-    csr->copy_from(gko::lend(this->mtx));
+    csr->copy_from(this->mtx);
     auto scalar_j = this->scalar_j_factory->generate(csr);
 
     auto dense_j = gko::matrix::Dense<value_type>::create(this->exec);
@@ -460,7 +460,7 @@ TYPED_TEST(Jacobi, ScalarJacobiGeneratesCorrectMatrixData)
     using tpl = typename decltype(data)::nonzero_type;
     auto csr = gko::share(
         gko::matrix::Csr<value_type, index_type>::create(this->exec));
-    csr->copy_from(gko::lend(this->mtx));
+    csr->copy_from(this->mtx);
     auto scalar_j = this->scalar_j_factory->generate(csr);
 
     scalar_j->write(data);
@@ -513,7 +513,7 @@ TYPED_TEST(Jacobi, ScalarJacobiGeneratesOnDifferentPrecision)
     using Bj = typename TestFixture::Bj;
     auto csr =
         gko::share(gko::matrix::Csr<next_type, index_type>::create(this->exec));
-    csr->copy_from(gko::lend(this->mtx));
+    csr->copy_from(this->mtx);
     std::shared_ptr<Bj> bj{};
 
     ASSERT_NO_THROW(bj = this->scalar_j_factory->generate(csr));

--- a/reference/test/preconditioner/jacobi.cpp
+++ b/reference/test/preconditioner/jacobi.cpp
@@ -124,8 +124,8 @@ protected:
         }
     }
 
-    void assert_same_precond(gko::pointer_param<const Bj> a,
-                             gko::pointer_param<const Bj> b)
+    void assert_same_precond(gko::ptr_param<const Bj> a,
+                             gko::ptr_param<const Bj> b)
     {
         ASSERT_EQ(a->get_size()[0], b->get_size()[0]);
         ASSERT_EQ(a->get_size()[1], b->get_size()[1]);

--- a/reference/test/preconditioner/jacobi.cpp
+++ b/reference/test/preconditioner/jacobi.cpp
@@ -124,7 +124,8 @@ protected:
         }
     }
 
-    void assert_same_precond(const Bj* a, const Bj* b)
+    void assert_same_precond(gko::pointer_param<const Bj> a,
+                             gko::pointer_param<const Bj> b)
     {
         ASSERT_EQ(a->get_size()[0], b->get_size()[0]);
         ASSERT_EQ(a->get_size()[1], b->get_size()[1]);
@@ -193,14 +194,14 @@ TYPED_TEST(Jacobi, CanBeCloned)
 {
     auto bj_clone = clone(this->bj);
 
-    this->assert_same_precond(bj_clone.get(), this->bj.get());
+    this->assert_same_precond(bj_clone, this->bj);
 }
 
 
 TYPED_TEST(Jacobi, CanBeClonedWithAdaptvePrecision)
 {
     auto bj_clone = clone(this->adaptive_bj);
-    this->assert_same_precond(bj_clone.get(), this->adaptive_bj.get());
+    this->assert_same_precond(bj_clone, this->adaptive_bj);
 }
 
 
@@ -218,7 +219,7 @@ TYPED_TEST(Jacobi, CanBeCopied)
 
     copy->copy_from(this->bj);
 
-    this->assert_same_precond(copy.get(), this->bj.get());
+    this->assert_same_precond(copy, this->bj);
 }
 
 
@@ -236,7 +237,7 @@ TYPED_TEST(Jacobi, CanBeCopiedWithAdaptivePrecision)
 
     copy->copy_from(this->adaptive_bj);
 
-    this->assert_same_precond(copy.get(), this->adaptive_bj.get());
+    this->assert_same_precond(copy, this->adaptive_bj);
 }
 
 
@@ -255,7 +256,7 @@ TYPED_TEST(Jacobi, CanBeMoved)
 
     copy->copy_from(give(this->bj));
 
-    this->assert_same_precond(copy.get(), tmp.get());
+    this->assert_same_precond(copy.get(), tmp);
 }
 
 
@@ -274,7 +275,7 @@ TYPED_TEST(Jacobi, CanBeMovedWithAdaptivePrecision)
 
     copy->copy_from(give(this->adaptive_bj));
 
-    this->assert_same_precond(copy.get(), tmp.get());
+    this->assert_same_precond(copy.get(), tmp);
 }
 
 
@@ -320,7 +321,7 @@ TYPED_TEST(Jacobi, ScalarJacobiConvertsToDense)
     auto scalar_j = this->scalar_j_factory->generate(csr);
 
     auto dense_j = gko::matrix::Dense<value_type>::create(this->exec);
-    dense_j->copy_from(scalar_j.get());
+    dense_j->copy_from(scalar_j);
     auto j_val = scalar_j->get_blocks();
 
     for (auto i = 0; i < dense_j->get_size()[0]; ++i) {

--- a/reference/test/preconditioner/jacobi.cpp
+++ b/reference/test/preconditioner/jacobi.cpp
@@ -254,7 +254,7 @@ TYPED_TEST(Jacobi, CanBeMoved)
                     .on(this->exec)
                     ->generate(Mtx::create(this->exec));
 
-    copy->copy_from(give(this->bj));
+    copy->move_from(this->bj);
 
     this->assert_same_precond(copy.get(), tmp);
 }
@@ -273,7 +273,7 @@ TYPED_TEST(Jacobi, CanBeMovedWithAdaptivePrecision)
                     .on(this->exec)
                     ->generate(Mtx::create(this->exec));
 
-    copy->copy_from(give(this->adaptive_bj));
+    copy->move_from(this->adaptive_bj);
 
     this->assert_same_precond(copy.get(), tmp);
 }

--- a/reference/test/preconditioner/jacobi_kernels.cpp
+++ b/reference/test/preconditioner/jacobi_kernels.cpp
@@ -1096,7 +1096,7 @@ TYPED_TEST(Jacobi, ConvertsToDense)
     using value_type = typename TestFixture::value_type;
     auto dense = Vec::create(this->exec);
 
-    dense->copy_from(this->bj_factory->generate(this->mtx));
+    dense->move_from(this->bj_factory->generate(this->mtx));
 
     // clang-format off
     GKO_ASSERT_MTX_NEAR(dense,
@@ -1116,7 +1116,7 @@ TYPED_TEST(Jacobi, ConvertsToDenseWithAdaptivePrecision)
     auto half_tol = std::sqrt(r<value_type>::value);
     auto dense = Vec::create(this->exec);
 
-    dense->copy_from(this->adaptive_bj_factory->generate(this->mtx));
+    dense->move_from(this->adaptive_bj_factory->generate(this->mtx));
 
     // clang-format off
     GKO_ASSERT_MTX_NEAR(dense,
@@ -1135,7 +1135,7 @@ TYPED_TEST(Jacobi, ConvertsEmptyToDense)
     auto empty = gko::share(Vec::create(this->exec));
     auto res = Vec::create(this->exec);
 
-    res->copy_from(TestFixture::Bj::build().on(this->exec)->generate(empty));
+    res->move_from(TestFixture::Bj::build().on(this->exec)->generate(empty));
 
     ASSERT_FALSE(res->get_size());
 }

--- a/reference/test/preconditioner/jacobi_kernels.cpp
+++ b/reference/test/preconditioner/jacobi_kernels.cpp
@@ -652,7 +652,7 @@ TYPED_TEST(Jacobi, AppliesToVector)
     auto b = gko::initialize<Vec>({4.0, -1.0, -2.0, 4.0, -1.0}, this->exec);
     auto bj = this->bj_factory->generate(this->mtx);
 
-    bj->apply(b.get(), x.get());
+    bj->apply(b, x);
 
     GKO_ASSERT_MTX_NEAR(x, l({1.0, 0.0, 0.0, 1.0, 0.0}), r<value_type>::value);
 }
@@ -666,7 +666,7 @@ TYPED_TEST(Jacobi, ScalarJacobiAppliesToVector)
     auto b = gko::initialize<Vec>({4.0, -1.0, -2.0, 4.0, -1.0}, this->exec);
     auto sj = this->scalar_j_factory->generate(this->mtx);
 
-    sj->apply(b.get(), x.get());
+    sj->apply(b, x);
 
     GKO_ASSERT_MTX_NEAR(x, l({1.0, -0.25, -0.5, 1.0, -0.25}),
                         r<value_type>::value);
@@ -681,7 +681,7 @@ TYPED_TEST(Jacobi, AppliesToMixedVector)
     auto b = gko::initialize<Vec>({4.0, -1.0, -2.0, 4.0, -1.0}, this->exec);
     auto bj = this->bj_factory->generate(this->mtx);
 
-    bj->apply(b.get(), x.get());
+    bj->apply(b, x);
 
     GKO_ASSERT_MTX_NEAR(
         x, l({1.0, 0.0, 0.0, 1.0, 0.0}),
@@ -703,7 +703,7 @@ TYPED_TEST(Jacobi, AppliesToComplexVector)
         this->exec);
     auto bj = this->bj_factory->generate(this->mtx);
 
-    bj->apply(b.get(), x.get());
+    bj->apply(b, x);
 
     GKO_ASSERT_MTX_NEAR(
         x,
@@ -728,7 +728,7 @@ TYPED_TEST(Jacobi, AppliesToMixedComplexVector)
         this->exec);
     auto bj = this->bj_factory->generate(this->mtx);
 
-    bj->apply(b.get(), x.get());
+    bj->apply(b, x);
 
     GKO_ASSERT_MTX_NEAR(
         x,
@@ -747,7 +747,7 @@ TYPED_TEST(Jacobi, AppliesToVectorWithAdaptivePrecision)
     auto b = gko::initialize<Vec>({4.0, -1.0, -2.0, 4.0, -1.0}, this->exec);
     auto bj = this->adaptive_bj_factory->generate(this->mtx);
 
-    bj->apply(b.get(), x.get());
+    bj->apply(b, x);
 
     GKO_ASSERT_MTX_NEAR(x, l({1.0, 0.0, 0.0, 1.0, 0.0}), half_tol);
 }
@@ -769,7 +769,7 @@ TYPED_TEST(Jacobi, AppliesToVectorWithAdaptivePrecisionAndSmallBlocks)
                   .on(this->exec)
                   ->generate(this->mtx);
 
-    bj->apply(b.get(), x.get());
+    bj->apply(b, x);
 
     GKO_ASSERT_MTX_NEAR(x, l({1.0, 0.0, 0.0, 1.0, 0.0}), half_tol);
 }
@@ -792,7 +792,7 @@ TYPED_TEST(Jacobi, AppliesToMultipleVectors)
                              this->exec);
     auto bj = this->bj_factory->generate(this->mtx);
 
-    bj->apply(b.get(), x.get());
+    bj->apply(b, x);
 
     GKO_ASSERT_MTX_NEAR(
         x, l({{1.0, 0.0}, {0.0, 1.0}, {0.0, 0.0}, {1.0, 0.0}, {0.0, 1.0}}),
@@ -817,7 +817,7 @@ TYPED_TEST(Jacobi, ScalarJacobiAppliesToMultipleVectors)
                              this->exec);
     auto sj = this->scalar_j_factory->generate(this->mtx);
 
-    sj->apply(b.get(), x.get());
+    sj->apply(b, x);
 
     GKO_ASSERT_MTX_NEAR(
         x,
@@ -844,7 +844,7 @@ TYPED_TEST(Jacobi, AppliesToMultipleVectorsWithAdaptivePrecision)
                              this->exec);
     auto bj = this->adaptive_bj_factory->generate(this->mtx);
 
-    bj->apply(b.get(), x.get());
+    bj->apply(b, x);
 
     GKO_ASSERT_MTX_NEAR(
         x, l({{1.0, 0.0}, {0.0, 1.0}, {0.0, 0.0}, {1.0, 0.0}, {0.0, 1.0}}),
@@ -877,7 +877,7 @@ TYPED_TEST(Jacobi, AppliesToMultipleVectorsWithAdaptivePrecisionAndSmallBlocks)
                   .on(this->exec)
                   ->generate(this->mtx);
 
-    bj->apply(b.get(), x.get());
+    bj->apply(b, x);
 
     GKO_ASSERT_MTX_NEAR(
         x, l({{1.0, 0.0}, {0.0, 1.0}, {0.0, 0.0}, {1.0, 0.0}, {0.0, 1.0}}),
@@ -895,7 +895,7 @@ TYPED_TEST(Jacobi, AppliesLinearCombinationToVector)
     auto beta = gko::initialize<Vec>({-1.0}, this->exec);
     auto bj = this->bj_factory->generate(this->mtx);
 
-    bj->apply(alpha.get(), b.get(), beta.get(), x.get());
+    bj->apply(alpha, b, beta, x);
 
     GKO_ASSERT_MTX_NEAR(x, l({1.0, 1.0, -2.0, 4.0, -3.0}),
                         r<value_type>::value);
@@ -912,7 +912,7 @@ TYPED_TEST(Jacobi, ScalarJacobiAppliesLinearCombinationToVector)
     auto beta = gko::initialize<Vec>({-1.0}, this->exec);
     auto sj = this->scalar_j_factory->generate(this->mtx);
 
-    sj->apply(alpha.get(), b.get(), beta.get(), x.get());
+    sj->apply(alpha, b, beta, x);
 
     GKO_ASSERT_MTX_NEAR(x, l({1.0, 0.5, -3.0, 4.0, -3.5}),
                         r<value_type>::value);
@@ -929,7 +929,7 @@ TYPED_TEST(Jacobi, AppliesLinearCombinationToMixedVector)
     auto beta = gko::initialize<Vec>({-1.0}, this->exec);
     auto bj = this->bj_factory->generate(this->mtx);
 
-    bj->apply(alpha.get(), b.get(), beta.get(), x.get());
+    bj->apply(alpha, b, beta, x);
 
     GKO_ASSERT_MTX_NEAR(
         x, l({1.0, 1.0, -2.0, 4.0, -3.0}),
@@ -953,7 +953,7 @@ TYPED_TEST(Jacobi, AppliesLinearCombinationToComplexVector)
     auto beta = gko::initialize<Dense>({-1.0}, this->exec);
     auto bj = this->bj_factory->generate(this->mtx);
 
-    bj->apply(alpha.get(), b.get(), beta.get(), x.get());
+    bj->apply(alpha, b, beta, x);
 
     GKO_ASSERT_MTX_NEAR(x,
                         l({T{1.0, 2.0}, T{1.0, 2.0}, T{-2.0, -4.0}, T{4.0, 8.0},
@@ -978,7 +978,7 @@ TYPED_TEST(Jacobi, AppliesLinearCombinationToMixedComplexVector)
     auto beta = gko::initialize<MixedDense>({-1.0}, this->exec);
     auto bj = this->bj_factory->generate(this->mtx);
 
-    bj->apply(alpha.get(), b.get(), beta.get(), x.get());
+    bj->apply(alpha, b, beta, x);
 
     GKO_ASSERT_MTX_NEAR(
         x,
@@ -999,7 +999,7 @@ TYPED_TEST(Jacobi, AppliesLinearCombinationToVectorWithAdaptivePrecision)
     auto beta = gko::initialize<Vec>({-1.0}, this->exec);
     auto bj = this->adaptive_bj_factory->generate(this->mtx);
 
-    bj->apply(alpha.get(), b.get(), beta.get(), x.get());
+    bj->apply(alpha, b, beta, x);
 
     GKO_ASSERT_MTX_NEAR(x, l({1.0, 1.0, -2.0, 4.0, -3.0}), half_tol);
 }
@@ -1025,7 +1025,7 @@ TYPED_TEST(Jacobi, AppliesLinearCombinationToMultipleVectors)
     auto beta = gko::initialize<Vec>({-1.0}, this->exec);
     auto bj = this->bj_factory->generate(this->mtx);
 
-    bj->apply(alpha.get(), b.get(), beta.get(), x.get());
+    bj->apply(alpha, b, beta, x);
 
     GKO_ASSERT_MTX_NEAR(
         x, l({{1.0, -0.5}, {1.0, 2.5}, {-2.0, -1.0}, {4.0, 1.0}, {-3.0, 0.5}}),
@@ -1053,7 +1053,7 @@ TYPED_TEST(Jacobi, ScalarAppliesLinearCombinationToMultipleVectors)
     auto beta = gko::initialize<Vec>({-1.0}, this->exec);
     auto sj = this->scalar_j_factory->generate(this->mtx);
 
-    sj->apply(alpha.get(), b.get(), beta.get(), x.get());
+    sj->apply(alpha, b, beta, x);
 
     GKO_ASSERT_MTX_NEAR(
         x, l({{1.0, -1.5}, {0.5, 2.5}, {-3.0, -1.0}, {4.0, 0.0}, {-3.5, 0.5}}),
@@ -1082,7 +1082,7 @@ TYPED_TEST(Jacobi,
     auto beta = gko::initialize<Vec>({-1.0}, this->exec);
     auto bj = this->adaptive_bj_factory->generate(this->mtx);
 
-    bj->apply(alpha.get(), b.get(), beta.get(), x.get());
+    bj->apply(alpha, b, beta, x);
 
     GKO_ASSERT_MTX_NEAR(
         x, l({{1.0, -0.5}, {1.0, 2.5}, {-2.0, -1.0}, {4.0, 1.0}, {-3.0, 0.5}}),

--- a/reference/test/reorder/rcm.cpp
+++ b/reference/test/reorder/rcm.cpp
@@ -105,7 +105,7 @@ TYPED_TEST(Rcm, CanBeCopied)
     auto rcm = this->rcm_factory->generate(this->id3_mtx);
     auto rcm_copy = this->rcm_factory->generate(this->not_id3_mtx);
 
-    rcm_copy->copy_from(rcm.get());
+    rcm_copy->copy_from(rcm);
 
     ASSERT_EQ(rcm_copy->get_permutation()->get_const_permutation()[0], 2);
     ASSERT_EQ(rcm_copy->get_permutation()->get_const_permutation()[1], 1);
@@ -118,7 +118,7 @@ TYPED_TEST(Rcm, CanBeMoved)
     auto rcm = this->rcm_factory->generate(this->id3_mtx);
     auto rcm_move = this->rcm_factory->generate(this->not_id3_mtx);
 
-    rcm->move_to(rcm_move.get());
+    rcm->move_to(rcm_move);
 
     ASSERT_EQ(rcm_move->get_permutation()->get_const_permutation()[0], 2);
     ASSERT_EQ(rcm_move->get_permutation()->get_const_permutation()[1], 1);

--- a/reference/test/reorder/scaled_reordered.cpp
+++ b/reference/test/reorder/scaled_reordered.cpp
@@ -262,7 +262,7 @@ TYPED_TEST(ScaledReordered, CanBeCopied)
     auto before_inner_operator = scaled_reordered->get_inner_operator();
     auto copied = SR::build().on(this->exec)->generate(this->rcm_mtx);
 
-    copied->copy_from(scaled_reordered.get());
+    copied->copy_from(scaled_reordered);
 
     ASSERT_EQ(before_system_matrix, copied->get_system_matrix());
     ASSERT_EQ(before_inner_operator, copied->get_inner_operator());
@@ -283,7 +283,7 @@ TYPED_TEST(ScaledReordered, CanBeMoved)
     auto before_inner_operator = scaled_reordered->get_inner_operator();
     auto moved = SR::build().on(this->exec)->generate(this->rcm_mtx);
 
-    moved->copy_from(std::move(scaled_reordered.get()));
+    moved->move_from(scaled_reordered);
 
     ASSERT_EQ(before_system_matrix, moved->get_system_matrix());
     ASSERT_EQ(before_inner_operator, moved->get_inner_operator());
@@ -316,9 +316,9 @@ TYPED_TEST(ScaledReordered, AppliesWithoutOperators)
     using Vec = typename TestFixture::Vec;
     auto scaled_reordered_fact = SR::build().on(this->exec);
     auto scaled_reordered = scaled_reordered_fact->generate(this->rcm_mtx);
-    auto res = Vec::create_with_config_of(this->b.get());
+    auto res = Vec::create_with_config_of(this->b);
 
-    scaled_reordered->apply(this->b.get(), res.get());
+    scaled_reordered->apply(this->b, res);
 
     GKO_ASSERT_MTX_NEAR(res, this->b, this->tol);
 }
@@ -331,11 +331,11 @@ TYPED_TEST(ScaledReordered, AppliesWithOnlyRowScaling)
     auto scaled_reordered_fact =
         SR::build().with_row_scaling(this->diag2).on(this->exec);
     auto scaled_reordered = scaled_reordered_fact->generate(this->rcm_mtx);
-    auto res = Vec::create_with_config_of(this->b.get());
+    auto res = Vec::create_with_config_of(this->b);
     auto expected_result = this->b->clone();
-    this->diag2->apply(this->b.get(), expected_result.get());
+    this->diag2->apply(this->b, expected_result);
 
-    scaled_reordered->apply(this->b.get(), res.get());
+    scaled_reordered->apply(this->b, res);
 
     GKO_ASSERT_MTX_NEAR(res, expected_result, this->tol);
 }
@@ -348,11 +348,11 @@ TYPED_TEST(ScaledReordered, AppliesWithOnlyColScaling)
     auto scaled_reordered_fact =
         SR::build().with_col_scaling(this->diag2).on(this->exec);
     auto scaled_reordered = scaled_reordered_fact->generate(this->rcm_mtx);
-    auto res = Vec::create_with_config_of(this->b.get());
+    auto res = Vec::create_with_config_of(this->b);
     auto expected_result = this->b->clone();
-    this->diag2->apply(this->b.get(), expected_result.get());
+    this->diag2->apply(this->b, expected_result);
 
-    scaled_reordered->apply(this->b.get(), res.get());
+    scaled_reordered->apply(this->b, res);
 
     GKO_ASSERT_MTX_NEAR(res, expected_result, this->tol);
 }
@@ -367,12 +367,12 @@ TYPED_TEST(ScaledReordered, AppliesWithRowAndColScaling)
                                      .with_col_scaling(this->diag3)
                                      .on(this->exec);
     auto scaled_reordered = scaled_reordered_fact->generate(this->rcm_mtx);
-    auto res = Vec::create_with_config_of(this->b.get());
+    auto res = Vec::create_with_config_of(this->b);
     auto expected_result = this->b->clone();
-    this->diag2->apply(this->b.get(), expected_result.get());
-    this->diag3->apply(expected_result.get(), expected_result.get());
+    this->diag2->apply(this->b, expected_result);
+    this->diag3->apply(expected_result, expected_result);
 
-    scaled_reordered->apply(this->b.get(), res.get());
+    scaled_reordered->apply(this->b, res);
 
     GKO_ASSERT_MTX_NEAR(res, expected_result, this->tol);
 }
@@ -385,9 +385,9 @@ TYPED_TEST(ScaledReordered, AppliesWithRcmReordering)
     auto scaled_reordered_fact =
         SR::build().with_reordering(this->rcm_factory).on(this->exec);
     auto scaled_reordered = scaled_reordered_fact->generate(this->rcm_mtx);
-    auto res = Vec::create_with_config_of(this->b.get());
+    auto res = Vec::create_with_config_of(this->b);
 
-    scaled_reordered->apply(this->b.get(), res.get());
+    scaled_reordered->apply(this->b, res);
 
     GKO_ASSERT_MTX_NEAR(res, this->b, this->tol);
 }
@@ -401,7 +401,7 @@ TYPED_TEST(ScaledReordered, SolvesSingleRhsWithOnlyInnerOperator)
     auto scaled_reordered = scaled_reordered_fact->generate(this->rcm_mtx);
     auto res = this->b->clone();
 
-    scaled_reordered->apply(this->b.get(), res.get());
+    scaled_reordered->apply(this->b, res);
 
     GKO_ASSERT_MTX_NEAR(res, this->x, 15 * this->tol);
 }
@@ -417,7 +417,7 @@ TYPED_TEST(ScaledReordered, SolvesSingleRhsWithRowScaling)
     auto scaled_reordered = scaled_reordered_fact->generate(this->rcm_mtx);
     auto res = this->b->clone();
 
-    scaled_reordered->apply(this->b.get(), res.get());
+    scaled_reordered->apply(this->b, res);
 
     GKO_ASSERT_MTX_NEAR(res, this->x, 15 * this->tol);
 }
@@ -433,7 +433,7 @@ TYPED_TEST(ScaledReordered, SolvesSingleRhsWithColScaling)
     auto scaled_reordered = scaled_reordered_fact->generate(this->rcm_mtx);
     auto res = this->b->clone();
 
-    scaled_reordered->apply(this->b.get(), res.get());
+    scaled_reordered->apply(this->b, res);
 
     GKO_ASSERT_MTX_NEAR(res, this->x, 15 * this->tol);
 }
@@ -449,7 +449,7 @@ TYPED_TEST(ScaledReordered, SolvesSingleRhsWithRcmReordering)
     auto scaled_reordered = scaled_reordered_fact->generate(this->rcm_mtx);
     auto res = this->b->clone();
 
-    scaled_reordered->apply(this->b.get(), res.get());
+    scaled_reordered->apply(this->b, res);
 
     GKO_ASSERT_MTX_NEAR(res, this->x, 15 * this->tol);
 }
@@ -467,7 +467,7 @@ TYPED_TEST(ScaledReordered, SolvesSingleRhsWithScalingAndRcmReordering)
     auto scaled_reordered = scaled_reordered_fact->generate(this->rcm_mtx);
     auto res = this->b->clone();
 
-    scaled_reordered->apply(this->b.get(), res.get());
+    scaled_reordered->apply(this->b, res);
 
     GKO_ASSERT_MTX_NEAR(res, this->x, 15 * this->tol);
 }
@@ -489,7 +489,7 @@ TYPED_TEST(ScaledReordered, SolvesSingleRhsWithScalingAndRcmReorderingMixed)
     auto b = gko::initialize<Vec>({10.3, 16.5, 11.9, 10., 7.1}, this->exec);
     auto res = b->clone();
 
-    scaled_reordered->apply(b.get(), res.get());
+    scaled_reordered->apply(b, res);
 
     GKO_ASSERT_MTX_NEAR(res, x, 1e-5);
 }
@@ -510,7 +510,7 @@ TYPED_TEST(ScaledReordered, AdvancedSolvesSingleRhsWithScalingAndRcmReordering)
     auto scaled_reordered = scaled_reordered_fact->generate(this->rcm_mtx);
     auto res = this->b->clone();
 
-    scaled_reordered->apply(alpha.get(), this->b.get(), beta.get(), res.get());
+    scaled_reordered->apply(alpha, this->b, beta, res);
 
     GKO_ASSERT_MTX_NEAR(res, l({-8.3, -12.5, -5.9, -2., 2.9}), 15 * this->tol);
 }
@@ -536,7 +536,7 @@ TYPED_TEST(ScaledReordered,
     auto b = gko::initialize<Vec>({10.3, 16.5, 11.9, 10., 7.1}, this->exec);
     auto res = b->clone();
 
-    scaled_reordered->apply(alpha.get(), b.get(), beta.get(), res.get());
+    scaled_reordered->apply(alpha, b, beta, res);
 
     GKO_ASSERT_MTX_NEAR(res, l({-8.3, -12.5, -5.9, -2., 2.9}), 1e-5);
 }
@@ -563,7 +563,7 @@ TYPED_TEST(ScaledReordered, SolvesMultipleRhs)
         this->exec);
     auto res = b->clone();
 
-    scaled_reordered->apply(b.get(), res.get());
+    scaled_reordered->apply(b, res);
 
     GKO_ASSERT_MTX_NEAR(res, x, 15 * this->tol);
 }

--- a/reference/test/solver/bicg_kernels.cpp
+++ b/reference/test/solver/bicg_kernels.cpp
@@ -299,7 +299,7 @@ TYPED_TEST(Bicg, SolvesStencilSystem)
     auto b = gko::initialize<Mtx>({-1.0, 3.0, 1.0}, this->exec);
     auto x = gko::initialize<Mtx>({0.0, 0.0, 0.0}, this->exec);
 
-    solver->apply(b.get(), x.get());
+    solver->apply(b, x);
 
     GKO_ASSERT_MTX_NEAR(x, l({1.0, 3.0, 2.0}), r<value_type>::value);
 }
@@ -313,7 +313,7 @@ TYPED_TEST(Bicg, SolvesStencilSystemMixed)
     auto b = gko::initialize<Mtx>({-1.0, 3.0, 1.0}, this->exec);
     auto x = gko::initialize<Mtx>({0.0, 0.0, 0.0}, this->exec);
 
-    solver->apply(b.get(), x.get());
+    solver->apply(b, x);
 
     GKO_ASSERT_MTX_NEAR(x, l({1.0, 3.0, 2.0}),
                         (r_mixed<value_type, TypeParam>()));
@@ -332,7 +332,7 @@ TYPED_TEST(Bicg, SolvesStencilSystemComplex)
         {value_type{0.0, 0.0}, value_type{0.0, 0.0}, value_type{0.0, 0.0}},
         this->exec);
 
-    solver->apply(b.get(), x.get());
+    solver->apply(b, x);
 
     GKO_ASSERT_MTX_NEAR(x,
                         l({value_type{1.0, -2.0}, value_type{3.0, -6.0},
@@ -354,7 +354,7 @@ TYPED_TEST(Bicg, SolvesStencilSystemMixedComplex)
         {value_type{0.0, 0.0}, value_type{0.0, 0.0}, value_type{0.0, 0.0}},
         this->exec);
 
-    solver->apply(b.get(), x.get());
+    solver->apply(b, x);
 
     GKO_ASSERT_MTX_NEAR(x,
                         l({value_type{1.0, -2.0}, value_type{3.0, -6.0},
@@ -374,7 +374,7 @@ TYPED_TEST(Bicg, SolvesMultipleStencilSystems)
     auto x = gko::initialize<Mtx>(
         {I<T>{0.0, 0.0}, I<T>{0.0, 0.0}, I<T>{0.0, 0.0}}, this->exec);
 
-    solver->apply(b.get(), x.get());
+    solver->apply(b, x);
 
     GKO_ASSERT_MTX_NEAR(x, l({{1.0, 1.0}, {3.0, 1.0}, {2.0, 1.0}}),
                         r<value_type>::value);
@@ -391,7 +391,7 @@ TYPED_TEST(Bicg, SolvesStencilSystemUsingAdvancedApply)
     auto b = gko::initialize<Mtx>({-1.0, 3.0, 1.0}, this->exec);
     auto x = gko::initialize<Mtx>({0.5, 1.0, 2.0}, this->exec);
 
-    solver->apply(alpha.get(), b.get(), beta.get(), x.get());
+    solver->apply(alpha, b, beta, x);
 
     GKO_ASSERT_MTX_NEAR(x, l({1.5, 5.0, 2.0}), r<value_type>::value);
 }
@@ -407,7 +407,7 @@ TYPED_TEST(Bicg, SolvesStencilSystemUsingAdvancedApplyMixed)
     auto b = gko::initialize<Mtx>({-1.0, 3.0, 1.0}, this->exec);
     auto x = gko::initialize<Mtx>({0.5, 1.0, 2.0}, this->exec);
 
-    solver->apply(alpha.get(), b.get(), beta.get(), x.get());
+    solver->apply(alpha, b, beta, x);
 
     GKO_ASSERT_MTX_NEAR(x, l({1.5, 5.0, 2.0}),
                         (r_mixed<value_type, TypeParam>()));
@@ -429,7 +429,7 @@ TYPED_TEST(Bicg, SolvesStencilSystemUsingAdvancedApplyComplex)
         {value_type{0.5, -1.0}, value_type{1.0, -2.0}, value_type{2.0, -4.0}},
         this->exec);
 
-    solver->apply(alpha.get(), b.get(), beta.get(), x.get());
+    solver->apply(alpha, b, beta, x);
 
     GKO_ASSERT_MTX_NEAR(x,
                         l({value_type{1.5, -3.0}, value_type{5.0, -10.0},
@@ -454,7 +454,7 @@ TYPED_TEST(Bicg, SolvesStencilSystemUsingAdvancedApplyMixedComplex)
         {value_type{0.5, -1.0}, value_type{1.0, -2.0}, value_type{2.0, -4.0}},
         this->exec);
 
-    solver->apply(alpha.get(), b.get(), beta.get(), x.get());
+    solver->apply(alpha, b, beta, x);
 
     GKO_ASSERT_MTX_NEAR(x,
                         l({value_type{1.5, -3.0}, value_type{5.0, -10.0},
@@ -476,7 +476,7 @@ TYPED_TEST(Bicg, SolvesMultipleStencilSystemsUsingAdvancedApply)
     auto x = gko::initialize<Mtx>(
         {I<T>{0.5, 1.0}, I<T>{1.0, 2.0}, I<T>{2.0, 3.0}}, this->exec);
 
-    solver->apply(alpha.get(), b.get(), beta.get(), x.get());
+    solver->apply(alpha, b, beta, x);
 
     GKO_ASSERT_MTX_NEAR(x, l({{1.5, 1.0}, {5.0, 0.0}, {2.0, -1.0}}),
                         r<value_type>::value * 1e1);
@@ -493,7 +493,7 @@ TYPED_TEST(Bicg, SolvesBigDenseSystem1)
         this->exec);
     auto x = gko::initialize<Mtx>({0.0, 0.0, 0.0, 0.0, 0.0, 0.0}, this->exec);
 
-    solver->apply(b.get(), x.get());
+    solver->apply(b, x);
 
     GKO_ASSERT_MTX_NEAR(x, l({81.0, 55.0, 45.0, 5.0, 85.0, -10.0}),
                         r<value_type>::value * 1e2);
@@ -510,7 +510,7 @@ TYPED_TEST(Bicg, SolvesBigDenseSystem2)
         this->exec);
     auto x = gko::initialize<Mtx>({0.0, 0.0, 0.0, 0.0, 0.0, 0.0}, this->exec);
 
-    solver->apply(b.get(), x.get());
+    solver->apply(b, x);
 
     GKO_ASSERT_MTX_NEAR(x, l({33.0, -56.0, 81.0, -30.0, 21.0, 40.0}),
                         r<value_type>::value * 1e2);
@@ -527,7 +527,7 @@ TYPED_TEST(Bicg, SolvesBigDenseSystemImplicitResNormCrit)
         this->exec);
     auto x = gko::initialize<Mtx>({0.0, 0.0, 0.0, 0.0, 0.0, 0.0}, this->exec);
 
-    solver->apply(b.get(), x.get());
+    solver->apply(b, x);
 
     GKO_ASSERT_MTX_NEAR(x, l({33.0, -56.0, 81.0, -30.0, 21.0, 40.0}),
                         r<value_type>::value * 1e2);
@@ -542,23 +542,9 @@ TYPED_TEST(Bicg, SolvesNonSymmetricStencilSystem)
     auto b = gko::initialize<Mtx>({13.0, 7.0, 1.0}, this->exec);
     auto x = gko::initialize<Mtx>({0.0, 0.0, 0.0}, this->exec);
 
-    solver->apply(b.get(), x.get());
+    solver->apply(b, x);
 
     GKO_ASSERT_MTX_NEAR(x, l({1.0, 3.0, 2.0}), r<value_type>::value * 1e2);
-}
-
-
-template <typename T>
-gko::remove_complex<T> infNorm(gko::matrix::Dense<T>* mat, size_t col = 0)
-{
-    using std::abs;
-    using no_cpx_t = gko::remove_complex<T>;
-    no_cpx_t norm = 0.0;
-    for (size_t i = 0; i < mat->get_size()[0]; ++i) {
-        no_cpx_t absEntry = abs(mat->at(i, col));
-        if (norm < absEntry) norm = absEntry;
-    }
-    return norm;
 }
 
 
@@ -589,9 +575,9 @@ TYPED_TEST(Bicg, SolvesMultipleDenseSystemForDivergenceCheck)
         xc->at(i, 1) = x2->at(i);
     }
 
-    solver->apply(b1.get(), x1.get());
-    solver->apply(b2.get(), x2.get());
-    solver->apply(bc.get(), xc.get());
+    solver->apply(b1, x1);
+    solver->apply(b2, x2);
+    solver->apply(bc, xc);
     auto mergedRes = Mtx::create(this->exec, gko::dim<2>{b1->get_size()[0], 2});
     for (size_t i = 0; i < mergedRes->get_size()[0]; ++i) {
         mergedRes->at(i, 0) = x1->at(i);
@@ -602,22 +588,22 @@ TYPED_TEST(Bicg, SolvesMultipleDenseSystemForDivergenceCheck)
     auto beta = gko::initialize<Mtx>({-1.0}, this->exec);
 
     auto residual1 = Mtx::create(this->exec, b1->get_size());
-    residual1->copy_from(b1.get());
+    residual1->copy_from(b1);
     auto residual2 = Mtx::create(this->exec, b2->get_size());
-    residual2->copy_from(b2.get());
+    residual2->copy_from(b2);
     auto residualC = Mtx::create(this->exec, bc->get_size());
-    residualC->copy_from(bc.get());
+    residualC->copy_from(bc);
 
-    this->mtx_big->apply(alpha.get(), x1.get(), beta.get(), residual1.get());
-    this->mtx_big->apply(alpha.get(), x2.get(), beta.get(), residual2.get());
-    this->mtx_big->apply(alpha.get(), xc.get(), beta.get(), residualC.get());
+    this->mtx_big->apply(alpha, x1, beta, residual1);
+    this->mtx_big->apply(alpha, x2, beta, residual2);
+    this->mtx_big->apply(alpha, xc, beta, residualC);
 
-    auto normS1 = infNorm(residual1.get());
-    auto normS2 = infNorm(residual2.get());
-    auto normC1 = infNorm(residualC.get(), 0);
-    auto normC2 = infNorm(residualC.get(), 1);
-    auto normB1 = infNorm(b1.get());
-    auto normB2 = infNorm(b2.get());
+    auto normS1 = inf_norm(residual1);
+    auto normS2 = inf_norm(residual2);
+    auto normC1 = inf_norm(residualC, 0);
+    auto normC2 = inf_norm(residualC, 1);
+    auto normB1 = inf_norm(b1);
+    auto normB2 = inf_norm(b2);
 
     // make sure that all combined solutions are as good or better than the
     // single solutions
@@ -639,7 +625,7 @@ TYPED_TEST(Bicg, SolvesTransposedNonSymmetricStencilSystem)
     auto b = gko::initialize<Mtx>({13.0, 7.0, 1.0}, this->exec);
     auto x = gko::initialize<Mtx>({0.0, 0.0, 0.0}, this->exec);
 
-    solver->transpose()->apply(b.get(), x.get());
+    solver->transpose()->apply(b, x);
 
     GKO_ASSERT_MTX_NEAR(x, l({1.0, 3.0, 2.0}), r<value_type>::value * 1e2);
 }
@@ -654,7 +640,7 @@ TYPED_TEST(Bicg, SolvesConjTransposedNonSymmetricStencilSystem)
     auto b = gko::initialize<Mtx>({13.0, 7.0, 1.0}, this->exec);
     auto x = gko::initialize<Mtx>({0.0, 0.0, 0.0}, this->exec);
 
-    solver->conj_transpose()->apply(b.get(), x.get());
+    solver->conj_transpose()->apply(b, x);
 
     GKO_ASSERT_MTX_NEAR(x, l({1.0, 3.0, 2.0}), r<value_type>::value * 1e2);
 }

--- a/reference/test/solver/bicgstab_kernels.cpp
+++ b/reference/test/solver/bicgstab_kernels.cpp
@@ -414,7 +414,7 @@ TYPED_TEST(Bicgstab, SolvesDenseSystem)
     auto b = gko::initialize<Mtx>({-1.0, 3.0, 1.0}, this->exec);
     auto x = gko::initialize<Mtx>({0.0, 0.0, 0.0}, this->exec);
 
-    solver->apply(b.get(), x.get());
+    solver->apply(b, x);
 
     GKO_ASSERT_MTX_NEAR(x, l({-4.0, -1.0, 4.0}), r<value_type>::value);
 }
@@ -428,7 +428,7 @@ TYPED_TEST(Bicgstab, SolvesDenseSystemMixed)
     auto b = gko::initialize<Mtx>({-1.0, 3.0, 1.0}, this->exec);
     auto x = gko::initialize<Mtx>({0.0, 0.0, 0.0}, this->exec);
 
-    solver->apply(b.get(), x.get());
+    solver->apply(b, x);
 
     GKO_ASSERT_MTX_NEAR(x, l({-4.0, -1.0, 4.0}),
                         (r_mixed<value_type, TypeParam>()));
@@ -447,7 +447,7 @@ TYPED_TEST(Bicgstab, SolvesDenseSystemComplex)
         {value_type{0.0, 0.0}, value_type{0.0, 0.0}, value_type{0.0, 0.0}},
         this->exec);
 
-    solver->apply(b.get(), x.get());
+    solver->apply(b, x);
 
     GKO_ASSERT_MTX_NEAR(x,
                         l({value_type{-4.0, 8.0}, value_type{-1.0, 2.0},
@@ -469,7 +469,7 @@ TYPED_TEST(Bicgstab, SolvesDenseSystemMixedComplex)
         {value_type{0.0, 0.0}, value_type{0.0, 0.0}, value_type{0.0, 0.0}},
         this->exec);
 
-    solver->apply(b.get(), x.get());
+    solver->apply(b, x);
 
     GKO_ASSERT_MTX_NEAR(x,
                         l({value_type{-4.0, 8.0}, value_type{-1.0, 2.0},
@@ -490,7 +490,7 @@ TYPED_TEST(Bicgstab, SolvesMultipleDenseSystems)
     auto x = gko::initialize<Mtx>(
         {I<T>{0.0, 0.0}, I<T>{0.0, 0.0}, I<T>{0.0, 0.0}}, this->exec);
 
-    solver->apply(b.get(), x.get());
+    solver->apply(b, x);
 
     GKO_ASSERT_MTX_NEAR(x, l({{-4.0, 1.0}, {-1.0, 2.0}, {4.0, -1.0}}),
                         half_tol);
@@ -509,7 +509,7 @@ TYPED_TEST(Bicgstab, SolvesMultipleDenseSystemsWithImplicitResNormCrit)
     auto x = gko::initialize<Mtx>(
         {I<T>{0.0, 0.0}, I<T>{0.0, 0.0}, I<T>{0.0, 0.0}}, this->exec);
 
-    solver->apply(b.get(), x.get());
+    solver->apply(b, x);
 
     GKO_ASSERT_MTX_NEAR(x, l({{-4.0, 1.0}, {-1.0, 2.0}, {4.0, -1.0}}),
                         half_tol);
@@ -526,7 +526,7 @@ TYPED_TEST(Bicgstab, SolvesDenseSystemUsingAdvancedApply)
     auto b = gko::initialize<Mtx>({-1.0, 3.0, 1.0}, this->exec);
     auto x = gko::initialize<Mtx>({0.5, 1.0, 2.0}, this->exec);
 
-    solver->apply(alpha.get(), b.get(), beta.get(), x.get());
+    solver->apply(alpha, b, beta, x);
 
     GKO_ASSERT_MTX_NEAR(x, l({-8.5, -3.0, 6.0}), r<value_type>::value);
 }
@@ -542,7 +542,7 @@ TYPED_TEST(Bicgstab, SolvesDenseSystemUsingAdvancedApplyMixed)
     auto b = gko::initialize<Mtx>({-1.0, 3.0, 1.0}, this->exec);
     auto x = gko::initialize<Mtx>({0.5, 1.0, 2.0}, this->exec);
 
-    solver->apply(alpha.get(), b.get(), beta.get(), x.get());
+    solver->apply(alpha, b, beta, x);
 
     GKO_ASSERT_MTX_NEAR(x, l({-8.5, -3.0, 6.0}),
                         (r_mixed<value_type, TypeParam>()));
@@ -564,7 +564,7 @@ TYPED_TEST(Bicgstab, SolvesDenseSystemUsingAdvancedApplyComplex)
         {value_type{0.5, -1.0}, value_type{1.0, -2.0}, value_type{2.0, -4.0}},
         this->exec);
 
-    solver->apply(alpha.get(), b.get(), beta.get(), x.get());
+    solver->apply(alpha, b, beta, x);
 
     GKO_ASSERT_MTX_NEAR(x,
                         l({value_type{-8.5, 17.0}, value_type{-3.0, 6.0},
@@ -589,7 +589,7 @@ TYPED_TEST(Bicgstab, SolvesDenseSystemUsingAdvancedApplyMixedComplex)
         {value_type{0.5, -1.0}, value_type{1.0, -2.0}, value_type{2.0, -4.0}},
         this->exec);
 
-    solver->apply(alpha.get(), b.get(), beta.get(), x.get());
+    solver->apply(alpha, b, beta, x);
 
     GKO_ASSERT_MTX_NEAR(x,
                         l({value_type{-8.5, 17.0}, value_type{-3.0, 6.0},
@@ -612,7 +612,7 @@ TYPED_TEST(Bicgstab, SolvesMultipleDenseSystemsUsingAdvancedApply)
     auto x = gko::initialize<Mtx>(
         {I<T>{0.5, 1.0}, I<T>{1.0, 2.0}, I<T>{2.0, 3.0}}, this->exec);
 
-    solver->apply(alpha.get(), b.get(), beta.get(), x.get());
+    solver->apply(alpha, b, beta, x);
 
     GKO_ASSERT_MTX_NEAR(x, l({{-8.5, 1.0}, {-3.0, 2.0}, {6.0, -5.0}}),
                         half_tol);
@@ -638,7 +638,7 @@ TYPED_TEST(Bicgstab, SolvesBigDenseSystemForDivergenceCheck1)
         gko::initialize<Mtx>({0.0, -9.0, -2.0, 8.0, -5.0, -6.0}, this->exec);
     auto x = gko::initialize<Mtx>({0.0, 0.0, 0.0, 0.0, 0.0, 0.0}, this->exec);
 
-    solver->apply(b.get(), x.get());
+    solver->apply(b, x);
 
     GKO_ASSERT_MTX_NEAR(
         x,
@@ -666,27 +666,13 @@ TYPED_TEST(Bicgstab, SolvesBigDenseSystemForDivergenceCheck2)
         gko::initialize<Mtx>({9.0, -4.0, -6.0, -10.0, 1.0, 10.0}, this->exec);
     auto x = gko::initialize<Mtx>({0.0, 0.0, 0.0, 0.0, 0.0, 0.0}, this->exec);
 
-    solver->apply(b.get(), x.get());
+    solver->apply(b, x);
 
     GKO_ASSERT_MTX_NEAR(
         x,
         l({0.13517641417299162, 0.75117689075221139, 0.47572853185155239,
            -0.50927993095367852, 0.13463333820848167, 0.23126768306576015}),
         half_tol * 1e-1);
-}
-
-
-template <typename T>
-gko::remove_complex<T> infNorm(gko::matrix::Dense<T>* mat, size_t col = 0)
-{
-    using std::abs;
-    using no_cpx_t = gko::remove_complex<T>;
-    no_cpx_t norm = 0.0;
-    for (size_t i = 0; i < mat->get_size()[0]; ++i) {
-        no_cpx_t absEntry = abs(mat->at(i, col));
-        if (norm < absEntry) norm = absEntry;
-    }
-    return norm;
 }
 
 
@@ -723,9 +709,9 @@ TYPED_TEST(Bicgstab, SolvesMultipleDenseSystemsDivergenceCheck)
         xc->at(i, 1) = x2->at(i);
     }
 
-    solver->apply(b1.get(), x1.get());
-    solver->apply(b2.get(), x2.get());
-    solver->apply(bc.get(), xc.get());
+    solver->apply(b1, x1);
+    solver->apply(b2, x2);
+    solver->apply(bc, xc);
     auto testMtx =
         gko::initialize<Mtx>({I<T>{0., 0.}, I<T>{0., 0.}, I<T>{0., 0.},
                               I<T>{0., 0.}, I<T>{0., 0.}, I<T>{0., 0.}},
@@ -745,16 +731,16 @@ TYPED_TEST(Bicgstab, SolvesMultipleDenseSystemsDivergenceCheck)
     auto residualC = gko::initialize<Mtx>({0.}, this->exec);
     residualC->copy_from(bc->clone());
 
-    locmtx->apply(alpha.get(), x1.get(), beta.get(), residual1.get());
-    locmtx->apply(alpha.get(), x2.get(), beta.get(), residual2.get());
-    locmtx->apply(alpha.get(), xc.get(), beta.get(), residualC.get());
+    locmtx->apply(alpha, x1, beta, residual1);
+    locmtx->apply(alpha, x2, beta, residual2);
+    locmtx->apply(alpha, xc, beta, residualC);
 
-    auto normS1 = infNorm(residual1.get());
-    auto normS2 = infNorm(residual2.get());
-    auto normC1 = infNorm(residualC.get(), 0);
-    auto normC2 = infNorm(residualC.get(), 1);
-    auto normB1 = infNorm(bc.get(), 0);
-    auto normB2 = infNorm(bc.get(), 1);
+    auto normS1 = inf_norm(residual1);
+    auto normS2 = inf_norm(residual2);
+    auto normC1 = inf_norm(residualC, 0);
+    auto normC2 = inf_norm(residualC, 1);
+    auto normB1 = inf_norm(bc, 0);
+    auto normB2 = inf_norm(bc, 1);
 
     // make sure that all combined solutions are as good or better than the
     // single solutions
@@ -776,7 +762,7 @@ TYPED_TEST(Bicgstab, SolvesTransposedDenseSystem)
     auto b = gko::initialize<Mtx>({-1.0, 3.0, 1.0}, this->exec);
     auto x = gko::initialize<Mtx>({0.0, 0.0, 0.0}, this->exec);
 
-    solver->transpose()->apply(b.get(), x.get());
+    solver->transpose()->apply(b, x);
 
     GKO_ASSERT_MTX_NEAR(x, l({-4.0, -1.0, 4.0}), half_tol);
 }
@@ -791,7 +777,7 @@ TYPED_TEST(Bicgstab, SolvesConjTransposedDenseSystem)
     auto b = gko::initialize<Mtx>({-1.0, 3.0, 1.0}, this->exec);
     auto x = gko::initialize<Mtx>({0.0, 0.0, 0.0}, this->exec);
 
-    solver->conj_transpose()->apply(b.get(), x.get());
+    solver->conj_transpose()->apply(b, x);
 
     GKO_ASSERT_MTX_NEAR(x, l({-4.0, -1.0, 4.0}), half_tol);
 }

--- a/reference/test/solver/bicgstab_kernels.cpp
+++ b/reference/test/solver/bicgstab_kernels.cpp
@@ -725,11 +725,11 @@ TYPED_TEST(Bicgstab, SolvesMultipleDenseSystemsDivergenceCheck)
     auto alpha = gko::initialize<Mtx>({1.0}, this->exec);
     auto beta = gko::initialize<Mtx>({-1.0}, this->exec);
     auto residual1 = gko::initialize<Mtx>({0.}, this->exec);
-    residual1->copy_from(b1->clone());
+    residual1->copy_from(b1);
     auto residual2 = gko::initialize<Mtx>({0.}, this->exec);
-    residual2->copy_from(b2->clone());
+    residual2->copy_from(b2);
     auto residualC = gko::initialize<Mtx>({0.}, this->exec);
-    residualC->copy_from(bc->clone());
+    residualC->copy_from(bc);
 
     locmtx->apply(alpha, x1, beta, residual1);
     locmtx->apply(alpha, x2, beta, residual2);

--- a/reference/test/solver/cb_gmres_kernels.cpp
+++ b/reference/test/solver/cb_gmres_kernels.cpp
@@ -195,7 +195,7 @@ TYPED_TEST(CbGmres, SolvesStencilSystem)
     auto b = gko::initialize<Mtx>({13.0, 7.0, 1.0}, this->exec);
     auto x = gko::initialize<Mtx>({0.0, 0.0, 0.0}, this->exec);
 
-    solver->apply(b.get(), x.get());
+    solver->apply(b, x);
 
     GKO_ASSERT_MTX_NEAR(x, l({1.0, 3.0, 2.0}), this->assert_precision());
 }
@@ -209,7 +209,7 @@ TYPED_TEST(CbGmres, SolvesStencilSystemMixed)
     auto b = gko::initialize<Mtx>({13.0, 7.0, 1.0}, this->exec);
     auto x = gko::initialize<Mtx>({0.0, 0.0, 0.0}, this->exec);
 
-    solver->apply(b.get(), x.get());
+    solver->apply(b, x);
 
     GKO_ASSERT_MTX_NEAR(
         x, l({1.0, 3.0, 2.0}),
@@ -230,7 +230,7 @@ TYPED_TEST(CbGmres, SolvesStencilSystemComplex)
         {value_type{0.0, 0.0}, value_type{0.0, 0.0}, value_type{0.0, 0.0}},
         this->exec);
 
-    solver->apply(b.get(), x.get());
+    solver->apply(b, x);
 
     GKO_ASSERT_MTX_NEAR(x,
                         l({value_type{1.0, -2.0}, value_type{3.0, -6.0},
@@ -253,7 +253,7 @@ TYPED_TEST(CbGmres, SolvesStencilSystemMixedComplex)
         {value_type{0.0, 0.0}, value_type{0.0, 0.0}, value_type{0.0, 0.0}},
         this->exec);
 
-    solver->apply(b.get(), x.get());
+    solver->apply(b, x);
 
     GKO_ASSERT_MTX_NEAR(
         x,
@@ -286,7 +286,7 @@ TYPED_TEST(CbGmres, SolvesStencilSystem2)
     auto b = gko::initialize<Mtx>({33.0, 20.0, 20.0}, this->exec);
     auto x = gko::initialize<Mtx>({0.0, 0.0, 0.0}, this->exec);
 
-    solver->apply(b.get(), x.get());
+    solver->apply(b, x);
 
     GKO_ASSERT_MTX_NEAR(x, l({1.0, 4.0, 8.0}), 8 * this->assert_precision());
 }
@@ -302,7 +302,7 @@ TYPED_TEST(CbGmres, SolvesMultipleStencilSystems)
     auto x = gko::initialize<Mtx>(
         {I<T>{0.0, 0.0}, I<T>{0.0, 0.0}, I<T>{0.0, 0.0}}, this->exec);
 
-    solver->apply(b.get(), x.get());
+    solver->apply(b, x);
 
     GKO_ASSERT_MTX_NEAR(x, l({I<T>{1.0, 1.0}, I<T>{3.0, 1.0}, I<T>{2.0, 1.0}}),
                         this->assert_precision());
@@ -319,7 +319,7 @@ TYPED_TEST(CbGmres, SolvesStencilSystemUsingAdvancedApply)
     auto b = gko::initialize<Mtx>({13.0, 7.0, 1.0}, this->exec);
     auto x = gko::initialize<Mtx>({0.5, 1.0, 2.0}, this->exec);
 
-    solver->apply(alpha.get(), b.get(), beta.get(), x.get());
+    solver->apply(alpha, b, beta, x);
 
     GKO_ASSERT_MTX_NEAR(x, l({1.5, 5.0, 2.0}), this->assert_precision());
 }
@@ -335,7 +335,7 @@ TYPED_TEST(CbGmres, SolvesStencilSystemUsingAdvancedApplyMixed)
     auto b = gko::initialize<Mtx>({13.0, 7.0, 1.0}, this->exec);
     auto x = gko::initialize<Mtx>({0.5, 1.0, 2.0}, this->exec);
 
-    solver->apply(alpha.get(), b.get(), beta.get(), x.get());
+    solver->apply(alpha, b, beta, x);
 
     GKO_ASSERT_MTX_NEAR(
         x, l({1.5, 5.0, 2.0}),
@@ -359,7 +359,7 @@ TYPED_TEST(CbGmres, SolvesStencilSystemUsingAdvancedApplyComplex)
         {value_type{0.5, -1.0}, value_type{1.0, -2.0}, value_type{2.0, -4.0}},
         this->exec);
 
-    solver->apply(alpha.get(), b.get(), beta.get(), x.get());
+    solver->apply(alpha, b, beta, x);
 
     GKO_ASSERT_MTX_NEAR(x,
                         l({value_type{1.5, -3.0}, value_type{5.0, -10.0},
@@ -385,7 +385,7 @@ TYPED_TEST(CbGmres, SolvesStencilSystemUsingAdvancedApplyMixedComplex)
         {value_type{0.5, -1.0}, value_type{1.0, -2.0}, value_type{2.0, -4.0}},
         this->exec);
 
-    solver->apply(alpha.get(), b.get(), beta.get(), x.get());
+    solver->apply(alpha, b, beta, x);
 
     GKO_ASSERT_MTX_NEAR(
         x,
@@ -407,7 +407,7 @@ TYPED_TEST(CbGmres, SolvesMultipleStencilSystemsUsingAdvancedApply)
     auto x = gko::initialize<Mtx>(
         {I<T>{0.5, 1.0}, I<T>{1.0, 2.0}, I<T>{2.0, 3.0}}, this->exec);
 
-    solver->apply(alpha.get(), b.get(), beta.get(), x.get());
+    solver->apply(alpha, b, beta, x);
 
     GKO_ASSERT_MTX_NEAR(x, l({I<T>{1.5, 1.0}, I<T>{5.0, 0.0}, I<T>{2.0, -1.0}}),
                         this->assert_precision());
@@ -424,7 +424,7 @@ TYPED_TEST(CbGmres, SolvesBigDenseSystem1)
         this->exec);
     auto x = gko::initialize<Mtx>({0.0, 0.0, 0.0, 0.0, 0.0, 0.0}, this->exec);
 
-    solver->apply(b.get(), x.get());
+    solver->apply(b, x);
 
     GKO_ASSERT_MTX_NEAR(x, l({52.7, 85.4, 134.2, -250.0, -16.8, 35.3}),
                         this->assert_precision());
@@ -441,25 +441,10 @@ TYPED_TEST(CbGmres, SolvesBigDenseSystem2)
         this->exec);
     auto x = gko::initialize<Mtx>({0.0, 0.0, 0.0, 0.0, 0.0, 0.0}, this->exec);
 
-    solver->apply(b.get(), x.get());
+    solver->apply(b, x);
 
     GKO_ASSERT_MTX_NEAR(x, l({33.0, -56.0, 81.0, -30.0, 21.0, 40.0}),
                         this->assert_precision());
-}
-
-
-template <typename T>
-gko::remove_complex<T> inf_norm(gko::matrix::Dense<T>* mat, size_t col = 0)
-{
-    using std::abs;
-    auto host_data = clone(mat->get_executor()->get_master(), mat);
-    using no_cpx_t = gko::remove_complex<T>;
-    no_cpx_t norm = 0.0;
-    for (size_t i = 0; i < host_data->get_size()[0]; ++i) {
-        no_cpx_t abs_entry = abs(host_data->at(i, col));
-        if (norm < abs_entry) norm = abs_entry;
-    }
-    return norm;
 }
 
 
@@ -490,9 +475,9 @@ TYPED_TEST(CbGmres, SolvesMultipleDenseSystemForDivergenceCheck)
         xc->at(i, 1) = x2->at(i);
     }
 
-    solver->apply(b1.get(), x1.get());
-    solver->apply(b2.get(), x2.get());
-    solver->apply(bc.get(), xc.get());
+    solver->apply(b1, x1);
+    solver->apply(b2, x2);
+    solver->apply(bc, xc);
     auto mergedRes = Mtx::create(this->exec, gko::dim<2>{b1->get_size()[0], 2});
     for (size_t i = 0; i < mergedRes->get_size()[0]; ++i) {
         mergedRes->at(i, 0) = x1->at(i);
@@ -503,22 +488,22 @@ TYPED_TEST(CbGmres, SolvesMultipleDenseSystemForDivergenceCheck)
     auto beta = gko::initialize<Mtx>({-1.0}, this->exec);
 
     auto residual1 = Mtx::create(this->exec, b1->get_size());
-    residual1->copy_from(b1.get());
+    residual1->copy_from(b1);
     auto residual2 = Mtx::create(this->exec, b2->get_size());
-    residual2->copy_from(b2.get());
+    residual2->copy_from(b2);
     auto residualC = Mtx::create(this->exec, bc->get_size());
-    residualC->copy_from(bc.get());
+    residualC->copy_from(bc);
 
-    this->mtx_big->apply(alpha.get(), x1.get(), beta.get(), residual1.get());
-    this->mtx_big->apply(alpha.get(), x2.get(), beta.get(), residual2.get());
-    this->mtx_big->apply(alpha.get(), xc.get(), beta.get(), residualC.get());
+    this->mtx_big->apply(alpha, x1, beta, residual1);
+    this->mtx_big->apply(alpha, x2, beta, residual2);
+    this->mtx_big->apply(alpha, xc, beta, residualC);
 
-    auto normS1 = inf_norm(residual1.get());
-    auto normS2 = inf_norm(residual2.get());
-    auto normC1 = inf_norm(residualC.get(), 0);
-    auto normC2 = inf_norm(residualC.get(), 1);
-    auto normB1 = inf_norm(b1.get());
-    auto normB2 = inf_norm(b2.get());
+    auto normS1 = inf_norm(residual1);
+    auto normS2 = inf_norm(residual2);
+    auto normC1 = inf_norm(residualC, 0);
+    auto normC2 = inf_norm(residualC, 1);
+    auto normB1 = inf_norm(b1);
+    auto normB2 = inf_norm(b2);
 
     // make sure that all combined solutions are as good or better than the
     // single solutions
@@ -554,7 +539,7 @@ TYPED_TEST(CbGmres, SolvesBigDenseSystem1WithRestart)
         {-13945.16, 11205.66, 16132.96, 24342.18, -10910.98}, this->exec);
     auto x = gko::initialize<Mtx>({0.0, 0.0, 0.0, 0.0, 0.0}, this->exec);
 
-    solver->apply(b.get(), x.get());
+    solver->apply(b, x);
 
     GKO_ASSERT_MTX_NEAR(x, l({-140.20, -142.20, 48.80, -17.70, -19.60}),
                         half_tol);
@@ -587,7 +572,7 @@ TYPED_TEST(CbGmres, SolvesWithPreconditioner)
         this->exec);
     auto x = gko::initialize<Mtx>({0.0, 0.0, 0.0, 0.0, 0.0, 0.0}, this->exec);
 
-    solver->apply(b.get(), x.get());
+    solver->apply(b, x);
 
     GKO_ASSERT_MTX_NEAR(x, l({33.0, -56.0, 81.0, -30.0, 21.0, 40.0}),
                         4 * this->assert_precision());

--- a/reference/test/solver/cg_kernels.cpp
+++ b/reference/test/solver/cg_kernels.cpp
@@ -260,7 +260,7 @@ TYPED_TEST(Cg, SolvesStencilSystem)
     auto b = gko::initialize<Mtx>({-1.0, 3.0, 1.0}, this->exec);
     auto x = gko::initialize<Mtx>({0.0, 0.0, 0.0}, this->exec);
 
-    solver->apply(b.get(), x.get());
+    solver->apply(b, x);
 
     GKO_ASSERT_MTX_NEAR(x, l({1.0, 3.0, 2.0}), r<value_type>::value);
 }
@@ -274,7 +274,7 @@ TYPED_TEST(Cg, SolvesStencilSystemMixed)
     auto b = gko::initialize<Mtx>({-1.0, 3.0, 1.0}, this->exec);
     auto x = gko::initialize<Mtx>({0.0, 0.0, 0.0}, this->exec);
 
-    solver->apply(b.get(), x.get());
+    solver->apply(b, x);
 
     GKO_ASSERT_MTX_NEAR(x, l({1.0, 3.0, 2.0}),
                         (r_mixed<value_type, TypeParam>()));
@@ -293,7 +293,7 @@ TYPED_TEST(Cg, SolvesStencilSystemComplex)
         {value_type{0.0, 0.0}, value_type{0.0, 0.0}, value_type{0.0, 0.0}},
         this->exec);
 
-    solver->apply(b.get(), x.get());
+    solver->apply(b, x);
 
     GKO_ASSERT_MTX_NEAR(x,
                         l({value_type{1.0, -2.0}, value_type{3.0, -6.0},
@@ -315,7 +315,7 @@ TYPED_TEST(Cg, SolvesStencilSystemMixedComplex)
         {value_type{0.0, 0.0}, value_type{0.0, 0.0}, value_type{0.0, 0.0}},
         this->exec);
 
-    solver->apply(b.get(), x.get());
+    solver->apply(b, x);
 
     GKO_ASSERT_MTX_NEAR(x,
                         l({value_type{1.0, -2.0}, value_type{3.0, -6.0},
@@ -335,7 +335,7 @@ TYPED_TEST(Cg, SolvesMultipleStencilSystems)
     auto x = gko::initialize<Mtx>(
         {I<T>{0.0, 0.0}, I<T>{0.0, 0.0}, I<T>{0.0, 0.0}}, this->exec);
 
-    solver->apply(b.get(), x.get());
+    solver->apply(b, x);
 
     GKO_ASSERT_MTX_NEAR(x, l({{1.0, 1.0}, {3.0, 1.0}, {2.0, 1.0}}),
                         r<value_type>::value);
@@ -352,7 +352,7 @@ TYPED_TEST(Cg, SolvesStencilSystemUsingAdvancedApply)
     auto b = gko::initialize<Mtx>({-1.0, 3.0, 1.0}, this->exec);
     auto x = gko::initialize<Mtx>({0.5, 1.0, 2.0}, this->exec);
 
-    solver->apply(alpha.get(), b.get(), beta.get(), x.get());
+    solver->apply(alpha, b, beta, x);
 
     GKO_ASSERT_MTX_NEAR(x, l({1.5, 5.0, 2.0}), r<value_type>::value);
 }
@@ -368,7 +368,7 @@ TYPED_TEST(Cg, SolvesStencilSystemUsingAdvancedApplyMixed)
     auto b = gko::initialize<Mtx>({-1.0, 3.0, 1.0}, this->exec);
     auto x = gko::initialize<Mtx>({0.5, 1.0, 2.0}, this->exec);
 
-    solver->apply(alpha.get(), b.get(), beta.get(), x.get());
+    solver->apply(alpha, b, beta, x);
 
     GKO_ASSERT_MTX_NEAR(x, l({1.5, 5.0, 2.0}),
                         (r_mixed<value_type, TypeParam>()));
@@ -390,7 +390,7 @@ TYPED_TEST(Cg, SolvesStencilSystemUsingAdvancedApplyComplex)
         {value_type{0.5, -1.0}, value_type{1.0, -2.0}, value_type{2.0, -4.0}},
         this->exec);
 
-    solver->apply(alpha.get(), b.get(), beta.get(), x.get());
+    solver->apply(alpha, b, beta, x);
 
     GKO_ASSERT_MTX_NEAR(x,
                         l({value_type{1.5, -3.0}, value_type{5.0, -10.0},
@@ -415,7 +415,7 @@ TYPED_TEST(Cg, SolvesStencilSystemUsingAdvancedApplyMixedComplex)
         {value_type{0.5, -1.0}, value_type{1.0, -2.0}, value_type{2.0, -4.0}},
         this->exec);
 
-    solver->apply(alpha.get(), b.get(), beta.get(), x.get());
+    solver->apply(alpha, b, beta, x);
 
     GKO_ASSERT_MTX_NEAR(x,
                         l({value_type{1.5, -3.0}, value_type{5.0, -10.0},
@@ -437,7 +437,7 @@ TYPED_TEST(Cg, SolvesMultipleStencilSystemsUsingAdvancedApply)
     auto x = gko::initialize<Mtx>(
         {I<T>{0.5, 1.0}, I<T>{1.0, 2.0}, I<T>{2.0, 3.0}}, this->exec);
 
-    solver->apply(alpha.get(), b.get(), beta.get(), x.get());
+    solver->apply(alpha, b, beta, x);
 
     GKO_ASSERT_MTX_NEAR(x, l({{1.5, 1.0}, {5.0, 0.0}, {2.0, -1.0}}),
                         r<value_type>::value * 1e1);
@@ -454,7 +454,7 @@ TYPED_TEST(Cg, SolvesBigDenseSystem1)
         this->exec);
     auto x = gko::initialize<Mtx>({0.0, 0.0, 0.0, 0.0, 0.0, 0.0}, this->exec);
 
-    solver->apply(b.get(), x.get());
+    solver->apply(b, x);
 
     GKO_ASSERT_MTX_NEAR(x, l({81.0, 55.0, 45.0, 5.0, 85.0, -10.0}),
                         r<value_type>::value * 1e2);
@@ -471,7 +471,7 @@ TYPED_TEST(Cg, SolvesBigDenseSystem2)
         this->exec);
     auto x = gko::initialize<Mtx>({0.0, 0.0, 0.0, 0.0, 0.0, 0.0}, this->exec);
 
-    solver->apply(b.get(), x.get());
+    solver->apply(b, x);
 
     GKO_ASSERT_MTX_NEAR(x, l({33.0, -56.0, 81.0, -30.0, 21.0, 40.0}),
                         r<value_type>::value * 1e2);
@@ -488,24 +488,10 @@ TYPED_TEST(Cg, SolvesBigDenseSystem3)
         this->exec);
     auto x = gko::initialize<Mtx>({0.0, 0.0, 0.0, 0.0, 0.0, 0.0}, this->exec);
 
-    solver->apply(b.get(), x.get());
+    solver->apply(b, x);
 
     GKO_ASSERT_MTX_NEAR(x, l({33.0, -56.0, 81.0, -30.0, 21.0, 40.0}),
                         r<value_type>::value * 1e2);
-}
-
-
-template <typename T>
-gko::remove_complex<T> infNorm(gko::matrix::Dense<T>* mat, size_t col = 0)
-{
-    using std::abs;
-    using no_cpx_t = gko::remove_complex<T>;
-    no_cpx_t norm = 0.0;
-    for (size_t i = 0; i < mat->get_size()[0]; ++i) {
-        no_cpx_t absEntry = abs(mat->at(i, col));
-        if (norm < absEntry) norm = absEntry;
-    }
-    return norm;
 }
 
 
@@ -536,9 +522,9 @@ TYPED_TEST(Cg, SolvesMultipleDenseSystemForDivergenceCheck)
         xc->at(i, 1) = x2->at(i);
     }
 
-    solver->apply(b1.get(), x1.get());
-    solver->apply(b2.get(), x2.get());
-    solver->apply(bc.get(), xc.get());
+    solver->apply(b1, x1);
+    solver->apply(b2, x2);
+    solver->apply(bc, xc);
     auto mergedRes = Mtx::create(this->exec, gko::dim<2>{b1->get_size()[0], 2});
     for (size_t i = 0; i < mergedRes->get_size()[0]; ++i) {
         mergedRes->at(i, 0) = x1->at(i);
@@ -549,22 +535,22 @@ TYPED_TEST(Cg, SolvesMultipleDenseSystemForDivergenceCheck)
     auto beta = gko::initialize<Mtx>({-1.0}, this->exec);
 
     auto residual1 = Mtx::create(this->exec, b1->get_size());
-    residual1->copy_from(b1.get());
+    residual1->copy_from(b1);
     auto residual2 = Mtx::create(this->exec, b2->get_size());
-    residual2->copy_from(b2.get());
+    residual2->copy_from(b2);
     auto residualC = Mtx::create(this->exec, bc->get_size());
-    residualC->copy_from(bc.get());
+    residualC->copy_from(bc);
 
-    this->mtx_big->apply(alpha.get(), x1.get(), beta.get(), residual1.get());
-    this->mtx_big->apply(alpha.get(), x2.get(), beta.get(), residual2.get());
-    this->mtx_big->apply(alpha.get(), xc.get(), beta.get(), residualC.get());
+    this->mtx_big->apply(alpha, x1, beta, residual1);
+    this->mtx_big->apply(alpha, x2, beta, residual2);
+    this->mtx_big->apply(alpha, xc, beta, residualC);
 
-    auto normS1 = infNorm(residual1.get());
-    auto normS2 = infNorm(residual2.get());
-    auto normC1 = infNorm(residualC.get(), 0);
-    auto normC2 = infNorm(residualC.get(), 1);
-    auto normB1 = infNorm(b1.get());
-    auto normB2 = infNorm(b2.get());
+    auto normS1 = inf_norm(residual1);
+    auto normS2 = inf_norm(residual2);
+    auto normC1 = inf_norm(residualC, 0);
+    auto normC2 = inf_norm(residualC, 1);
+    auto normB1 = inf_norm(b1);
+    auto normB2 = inf_norm(b2);
 
     // make sure that all combined solutions are as good or better than the
     // single solutions
@@ -587,7 +573,7 @@ TYPED_TEST(Cg, SolvesTransposedBigDenseSystem)
         this->exec);
     auto x = gko::initialize<Mtx>({0.0, 0.0, 0.0, 0.0, 0.0, 0.0}, this->exec);
 
-    solver->transpose()->apply(b.get(), x.get());
+    solver->transpose()->apply(b, x);
 
     GKO_ASSERT_MTX_NEAR(x, l({81.0, 55.0, 45.0, 5.0, 85.0, -10.0}),
                         r<value_type>::value * 1e2);
@@ -604,7 +590,7 @@ TYPED_TEST(Cg, SolvesConjTransposedBigDenseSystem)
         this->exec);
     auto x = gko::initialize<Mtx>({0.0, 0.0, 0.0, 0.0, 0.0, 0.0}, this->exec);
 
-    solver->conj_transpose()->apply(b.get(), x.get());
+    solver->conj_transpose()->apply(b, x);
 
     GKO_ASSERT_MTX_NEAR(x, l({81.0, 55.0, 45.0, 5.0, 85.0, -10.0}),
                         r<value_type>::value * 1e2);

--- a/reference/test/solver/cgs_kernels.cpp
+++ b/reference/test/solver/cgs_kernels.cpp
@@ -324,7 +324,7 @@ TYPED_TEST(Cgs, SolvesDenseSystem)
     auto b = gko::initialize<Mtx>({-1.0, 3.0, 1.0}, this->exec);
     auto x = gko::initialize<Mtx>({0.0, 0.0, 0.0}, this->exec);
 
-    solver->apply(b.get(), x.get());
+    solver->apply(b, x);
 
     GKO_ASSERT_MTX_NEAR(x, l({-4.0, -1.0, 4.0}), r<value_type>::value);
 }
@@ -338,7 +338,7 @@ TYPED_TEST(Cgs, SolvesDenseSystemMixed)
     auto b = gko::initialize<Mtx>({-1.0, 3.0, 1.0}, this->exec);
     auto x = gko::initialize<Mtx>({0.0, 0.0, 0.0}, this->exec);
 
-    solver->apply(b.get(), x.get());
+    solver->apply(b, x);
 
     GKO_ASSERT_MTX_NEAR(x, l({-4.0, -1.0, 4.0}),
                         (r_mixed<value_type, TypeParam>()));
@@ -357,7 +357,7 @@ TYPED_TEST(Cgs, SolvesDenseSystemComplex)
         {value_type{0.0, 0.0}, value_type{0.0, 0.0}, value_type{0.0, 0.0}},
         this->exec);
 
-    solver->apply(b.get(), x.get());
+    solver->apply(b, x);
 
     GKO_ASSERT_MTX_NEAR(x,
                         l({value_type{-4.0, 8.0}, value_type{-1.0, 2.0},
@@ -379,7 +379,7 @@ TYPED_TEST(Cgs, SolvesDenseSystemMixedComplex)
         {value_type{0.0, 0.0}, value_type{0.0, 0.0}, value_type{0.0, 0.0}},
         this->exec);
 
-    solver->apply(b.get(), x.get());
+    solver->apply(b, x);
 
     GKO_ASSERT_MTX_NEAR(x,
                         l({value_type{-4.0, 8.0}, value_type{-1.0, 2.0},
@@ -400,7 +400,7 @@ TYPED_TEST(Cgs, SolvesMultipleDenseSystem)
     auto x = gko::initialize<Mtx>(
         {I<T>{0.0, 0.0}, I<T>{0.0, 0.0}, I<T>{0.0, 0.0}}, this->exec);
 
-    solver->apply(b.get(), x.get());
+    solver->apply(b, x);
 
     GKO_ASSERT_MTX_NEAR(x, l({{-4.0, 1.0}, {-1.0, 2.0}, {4.0, -1.0}}),
                         half_tol);
@@ -417,7 +417,7 @@ TYPED_TEST(Cgs, SolvesDenseSystemUsingAdvancedApply)
     auto b = gko::initialize<Mtx>({-1.0, 3.0, 1.0}, this->exec);
     auto x = gko::initialize<Mtx>({0.5, 1.0, 2.0}, this->exec);
 
-    solver->apply(alpha.get(), b.get(), beta.get(), x.get());
+    solver->apply(alpha, b, beta, x);
 
     GKO_ASSERT_MTX_NEAR(x, l({-8.5, -3.0, 6.0}), r<value_type>::value * 1e1);
 }
@@ -433,7 +433,7 @@ TYPED_TEST(Cgs, SolvesDenseSystemUsingAdvancedApplyMixed)
     auto b = gko::initialize<Mtx>({-1.0, 3.0, 1.0}, this->exec);
     auto x = gko::initialize<Mtx>({0.5, 1.0, 2.0}, this->exec);
 
-    solver->apply(alpha.get(), b.get(), beta.get(), x.get());
+    solver->apply(alpha, b, beta, x);
 
     GKO_ASSERT_MTX_NEAR(x, l({-8.5, -3.0, 6.0}),
                         (r_mixed<value_type, TypeParam>()) * 1e1);
@@ -455,7 +455,7 @@ TYPED_TEST(Cgs, SolvesDenseSystemUsingAdvancedApplyComplex)
         {value_type{0.5, -1.0}, value_type{1.0, -2.0}, value_type{2.0, -4.0}},
         this->exec);
 
-    solver->apply(alpha.get(), b.get(), beta.get(), x.get());
+    solver->apply(alpha, b, beta, x);
 
     GKO_ASSERT_MTX_NEAR(x,
                         l({value_type{-8.5, 17.0}, value_type{-3.0, 6.0},
@@ -480,7 +480,7 @@ TYPED_TEST(Cgs, SolvesDenseSystemUsingAdvancedApplyMixedComplex)
         {value_type{0.5, -1.0}, value_type{1.0, -2.0}, value_type{2.0, -4.0}},
         this->exec);
 
-    solver->apply(alpha.get(), b.get(), beta.get(), x.get());
+    solver->apply(alpha, b, beta, x);
 
     GKO_ASSERT_MTX_NEAR(x,
                         l({value_type{-8.5, 17.0}, value_type{-3.0, 6.0},
@@ -503,7 +503,7 @@ TYPED_TEST(Cgs, SolvesMultipleDenseSystemsUsingAdvancedApply)
     auto x = gko::initialize<Mtx>(
         {I<T>{0.5, 1.0}, I<T>{1.0, 2.0}, I<T>{2.0, 3.0}}, this->exec);
 
-    solver->apply(alpha.get(), b.get(), beta.get(), x.get());
+    solver->apply(alpha, b, beta, x);
 
     GKO_ASSERT_MTX_NEAR(x, l({{-8.5, 1.0}, {-3.0, 2.0}, {6.0, -5.0}}),
                         half_tol);
@@ -519,7 +519,7 @@ TYPED_TEST(Cgs, SolvesBigDenseSystem1)
         {764.0, -4032.0, -11855.0, 7111.0, -12765.0, -4589}, this->exec);
     auto x = gko::initialize<Mtx>({0.0, 0.0, 0.0, 0.0, 0.0, 0.0}, this->exec);
 
-    solver->apply(b.get(), x.get());
+    solver->apply(b, x);
 
     GKO_ASSERT_MTX_NEAR(x, l({-13.0, -49.0, 69.0, -33.0, -82.0, -39.0}),
                         r<value_type>::value * 1e3);
@@ -535,7 +535,7 @@ TYPED_TEST(Cgs, SolvesBigDenseSystemWithImplicitResNormCrit)
         {17356.0, 5466.0, 748.0, -456.0, 3434.0, -7020.0}, this->exec);
     auto x = gko::initialize<Mtx>({0.0, 0.0, 0.0, 0.0, 0.0, 0.0}, this->exec);
 
-    solver->apply(b.get(), x.get());
+    solver->apply(b, x);
 
     GKO_ASSERT_MTX_NEAR(x, l({-58.0, 98.0, -16.0, -58.0, 2.0, 76.0}),
                         r<value_type>::value * 1e2);
@@ -551,24 +551,10 @@ TYPED_TEST(Cgs, SolvesBigDenseSystem2)
         {17356.0, 5466.0, 748.0, -456.0, 3434.0, -7020.0}, this->exec);
     auto x = gko::initialize<Mtx>({0.0, 0.0, 0.0, 0.0, 0.0, 0.0}, this->exec);
 
-    solver->apply(b.get(), x.get());
+    solver->apply(b, x);
 
     GKO_ASSERT_MTX_NEAR(x, l({-58.0, 98.0, -16.0, -58.0, 2.0, 76.0}),
                         r<value_type>::value * 1e2);
-}
-
-
-template <typename T>
-gko::remove_complex<T> infNorm(gko::matrix::Dense<T>* mat, size_t col = 0)
-{
-    using std::abs;
-    using no_cpx_t = gko::remove_complex<T>;
-    no_cpx_t norm = 0.0;
-    for (size_t i = 0; i < mat->get_size()[0]; ++i) {
-        no_cpx_t absEntry = abs(mat->at(i, col));
-        if (norm < absEntry) norm = absEntry;
-    }
-    return norm;
 }
 
 
@@ -597,9 +583,9 @@ TYPED_TEST(Cgs, SolvesMultipleDenseSystems)
         xc->at(i, 1) = x2->at(i);
     }
 
-    solver->apply(b1.get(), x1.get());
-    solver->apply(b2.get(), x2.get());
-    solver->apply(bc.get(), xc.get());
+    solver->apply(b1, x1);
+    solver->apply(b2, x2);
+    solver->apply(bc, xc);
     auto mergedRes = Mtx::create(this->exec, gko::dim<2>{b1->get_size()[0], 2});
     for (size_t i = 0; i < mergedRes->get_size()[0]; ++i) {
         mergedRes->at(i, 0) = x1->at(i);
@@ -610,22 +596,22 @@ TYPED_TEST(Cgs, SolvesMultipleDenseSystems)
     auto beta = gko::initialize<Mtx>({-1.0}, this->exec);
 
     auto residual1 = Mtx::create(this->exec, b1->get_size());
-    residual1->copy_from(b1.get());
+    residual1->copy_from(b1);
     auto residual2 = Mtx::create(this->exec, b2->get_size());
-    residual2->copy_from(b2.get());
+    residual2->copy_from(b2);
     auto residualC = Mtx::create(this->exec, bc->get_size());
-    residualC->copy_from(bc.get());
+    residualC->copy_from(bc);
 
-    this->mtx_big->apply(alpha.get(), x1.get(), beta.get(), residual1.get());
-    this->mtx_big->apply(alpha.get(), x2.get(), beta.get(), residual2.get());
-    this->mtx_big->apply(alpha.get(), xc.get(), beta.get(), residualC.get());
+    this->mtx_big->apply(alpha, x1, beta, residual1);
+    this->mtx_big->apply(alpha, x2, beta, residual2);
+    this->mtx_big->apply(alpha, xc, beta, residualC);
 
-    auto normS1 = infNorm(residual1.get());
-    auto normS2 = infNorm(residual2.get());
-    auto normC1 = infNorm(residualC.get(), 0);
-    auto normC2 = infNorm(residualC.get(), 1);
-    auto normB1 = infNorm(b1.get());
-    auto normB2 = infNorm(b2.get());
+    auto normS1 = inf_norm(residual1);
+    auto normS2 = inf_norm(residual2);
+    auto normC1 = inf_norm(residualC, 0);
+    auto normC2 = inf_norm(residualC, 1);
+    auto normB1 = inf_norm(b1);
+    auto normB2 = inf_norm(b2);
 
     // make sure that all combined solutions are as good or better than the
     // single solutions
@@ -647,7 +633,7 @@ TYPED_TEST(Cgs, SolvesTransposedBigDenseSystem)
         {764.0, -4032.0, -11855.0, 7111.0, -12765.0, -4589}, this->exec);
     auto x = gko::initialize<Mtx>({0.0, 0.0, 0.0, 0.0, 0.0, 0.0}, this->exec);
 
-    solver->transpose()->apply(b.get(), x.get());
+    solver->transpose()->apply(b, x);
 
     GKO_ASSERT_MTX_NEAR(x, l({-13.0, -49.0, 69.0, -33.0, -82.0, -39.0}),
                         r<value_type>::value * 1e3);
@@ -664,7 +650,7 @@ TYPED_TEST(Cgs, SolvesConjTransposedBigDenseSystem)
         {764.0, -4032.0, -11855.0, 7111.0, -12765.0, -4589}, this->exec);
     auto x = gko::initialize<Mtx>({0.0, 0.0, 0.0, 0.0, 0.0, 0.0}, this->exec);
 
-    solver->conj_transpose()->apply(b.get(), x.get());
+    solver->conj_transpose()->apply(b, x);
 
     GKO_ASSERT_MTX_NEAR(x, l({-13.0, -49.0, 69.0, -33.0, -82.0, -39.0}),
                         r<value_type>::value * 1e3);

--- a/reference/test/solver/direct.cpp
+++ b/reference/test/solver/direct.cpp
@@ -86,7 +86,7 @@ protected:
             mtx->get_size()[0], nrhs, dist, rng, this->exec);
         x_ref = x->clone();
         b = x->clone();
-        mtx->apply(x.get(), b.get());
+        mtx->apply(x, b);
     }
 
     std::default_random_engine rng;
@@ -107,7 +107,7 @@ TYPED_TEST(Direct, SolvesAni1SingleRhs)
     using value_type = typename TestFixture::value_type;
     this->setup(gko::matrices::location_ani1_mtx);
 
-    this->solver->apply(this->b.get(), this->x.get());
+    this->solver->apply(this->b, this->x);
 
     GKO_ASSERT_MTX_NEAR(this->x, this->x_ref, r<value_type>::value);
 }
@@ -119,7 +119,7 @@ TYPED_TEST(Direct, SolvesAni1AmdMultipleRhs)
     using value_type = typename TestFixture::value_type;
     this->setup(gko::matrices::location_ani1_amd_mtx, 3);
 
-    this->solver->apply(this->b.get(), this->x.get());
+    this->solver->apply(this->b, this->x);
 
     GKO_ASSERT_MTX_NEAR(this->x, this->x_ref, r<value_type>::value);
 }

--- a/reference/test/solver/fcg_kernels.cpp
+++ b/reference/test/solver/fcg_kernels.cpp
@@ -273,7 +273,7 @@ TYPED_TEST(Fcg, SolvesStencilSystem)
     auto b = gko::initialize<Mtx>({-1.0, 3.0, 1.0}, this->exec);
     auto x = gko::initialize<Mtx>({0.0, 0.0, 0.0}, this->exec);
 
-    solver->apply(b.get(), x.get());
+    solver->apply(b, x);
 
     GKO_ASSERT_MTX_NEAR(x, l({1.0, 3.0, 2.0}), r<value_type>::value);
 }
@@ -287,7 +287,7 @@ TYPED_TEST(Fcg, SolvesStencilSystemMixed)
     auto b = gko::initialize<Mtx>({-1.0, 3.0, 1.0}, this->exec);
     auto x = gko::initialize<Mtx>({0.0, 0.0, 0.0}, this->exec);
 
-    solver->apply(b.get(), x.get());
+    solver->apply(b, x);
 
     GKO_ASSERT_MTX_NEAR(x, l({1.0, 3.0, 2.0}),
                         (r_mixed<value_type, TypeParam>()));
@@ -306,7 +306,7 @@ TYPED_TEST(Fcg, SolvesStencilSystemComplex)
         {value_type{0.0, 0.0}, value_type{0.0, 0.0}, value_type{0.0, 0.0}},
         this->exec);
 
-    solver->apply(b.get(), x.get());
+    solver->apply(b, x);
 
     GKO_ASSERT_MTX_NEAR(x,
                         l({value_type{1.0, -2.0}, value_type{3.0, -6.0},
@@ -328,7 +328,7 @@ TYPED_TEST(Fcg, SolvesStencilSystemMixedComplex)
         {value_type{0.0, 0.0}, value_type{0.0, 0.0}, value_type{0.0, 0.0}},
         this->exec);
 
-    solver->apply(b.get(), x.get());
+    solver->apply(b, x);
 
     GKO_ASSERT_MTX_NEAR(x,
                         l({value_type{1.0, -2.0}, value_type{3.0, -6.0},
@@ -348,7 +348,7 @@ TYPED_TEST(Fcg, SolvesMultipleStencilSystems)
     auto x = gko::initialize<Mtx>(
         {I<T>{0.0, 0.0}, I<T>{0.0, 0.0}, I<T>{0.0, 0.0}}, this->exec);
 
-    solver->apply(b.get(), x.get());
+    solver->apply(b, x);
 
     GKO_ASSERT_MTX_NEAR(x, l({{1.0, 1.0}, {3.0, 1.0}, {2.0, 1.0}}),
                         r<value_type>::value);
@@ -365,7 +365,7 @@ TYPED_TEST(Fcg, SolvesStencilSystemUsingAdvancedApply)
     auto b = gko::initialize<Mtx>({-1.0, 3.0, 1.0}, this->exec);
     auto x = gko::initialize<Mtx>({0.5, 1.0, 2.0}, this->exec);
 
-    solver->apply(alpha.get(), b.get(), beta.get(), x.get());
+    solver->apply(alpha, b, beta, x);
 
     GKO_ASSERT_MTX_NEAR(x, l({1.5, 5.0, 2.0}), r<value_type>::value);
 }
@@ -381,7 +381,7 @@ TYPED_TEST(Fcg, SolvesStencilSystemUsingAdvancedApplyMixed)
     auto b = gko::initialize<Mtx>({-1.0, 3.0, 1.0}, this->exec);
     auto x = gko::initialize<Mtx>({0.5, 1.0, 2.0}, this->exec);
 
-    solver->apply(alpha.get(), b.get(), beta.get(), x.get());
+    solver->apply(alpha, b, beta, x);
 
     GKO_ASSERT_MTX_NEAR(x, l({1.5, 5.0, 2.0}),
                         (r_mixed<value_type, TypeParam>()));
@@ -403,7 +403,7 @@ TYPED_TEST(Fcg, SolvesStencilSystemUsingAdvancedApplyComplex)
         {value_type{0.5, -1.0}, value_type{1.0, -2.0}, value_type{2.0, -4.0}},
         this->exec);
 
-    solver->apply(alpha.get(), b.get(), beta.get(), x.get());
+    solver->apply(alpha, b, beta, x);
 
     GKO_ASSERT_MTX_NEAR(x,
                         l({value_type{1.5, -3.0}, value_type{5.0, -10.0},
@@ -428,7 +428,7 @@ TYPED_TEST(Fcg, SolvesStencilSystemUsingAdvancedApplyMixedComplex)
         {value_type{0.5, -1.0}, value_type{1.0, -2.0}, value_type{2.0, -4.0}},
         this->exec);
 
-    solver->apply(alpha.get(), b.get(), beta.get(), x.get());
+    solver->apply(alpha, b, beta, x);
 
     GKO_ASSERT_MTX_NEAR(x,
                         l({value_type{1.5, -3.0}, value_type{5.0, -10.0},
@@ -450,7 +450,7 @@ TYPED_TEST(Fcg, SolvesMultipleStencilSystemsUsingAdvancedApply)
     auto x = gko::initialize<Mtx>(
         {I<T>{0.5, 1.0}, I<T>{1.0, 2.0}, I<T>{2.0, 3.0}}, this->exec);
 
-    solver->apply(alpha.get(), b.get(), beta.get(), x.get());
+    solver->apply(alpha, b, beta, x);
 
     GKO_ASSERT_MTX_NEAR(x, l({{1.5, 1.0}, {5.0, 0.0}, {2.0, -1.0}}),
                         r<value_type>::value * 1e1);
@@ -467,7 +467,7 @@ TYPED_TEST(Fcg, SolvesBigDenseSystem1)
         this->exec);
     auto x = gko::initialize<Mtx>({0.0, 0.0, 0.0, 0.0, 0.0, 0.0}, this->exec);
 
-    solver->apply(b.get(), x.get());
+    solver->apply(b, x);
 
     GKO_ASSERT_MTX_NEAR(x, l({81.0, 55.0, 45.0, 5.0, 85.0, -10.0}),
                         r<value_type>::value * 1e3);
@@ -484,7 +484,7 @@ TYPED_TEST(Fcg, SolvesBigDenseSystemWithImplicitResNormCrit)
         this->exec);
     auto x = gko::initialize<Mtx>({0.0, 0.0, 0.0, 0.0, 0.0, 0.0}, this->exec);
 
-    solver->apply(b.get(), x.get());
+    solver->apply(b, x);
 
     GKO_ASSERT_MTX_NEAR(x, l({33.0, -56.0, 81.0, -30.0, 21.0, 40.0}),
                         r<value_type>::value * 1e3);
@@ -501,24 +501,10 @@ TYPED_TEST(Fcg, SolvesBigDenseSystem2)
         this->exec);
     auto x = gko::initialize<Mtx>({0.0, 0.0, 0.0, 0.0, 0.0, 0.0}, this->exec);
 
-    solver->apply(b.get(), x.get());
+    solver->apply(b, x);
 
     GKO_ASSERT_MTX_NEAR(x, l({33.0, -56.0, 81.0, -30.0, 21.0, 40.0}),
                         r<value_type>::value * 1e3);
-}
-
-
-template <typename T>
-gko::remove_complex<T> infNorm(gko::matrix::Dense<T>* mat, size_t col = 0)
-{
-    using std::abs;
-    using no_cpx_t = gko::remove_complex<T>;
-    no_cpx_t norm = 0.0;
-    for (size_t i = 0; i < mat->get_size()[0]; ++i) {
-        no_cpx_t absEntry = abs(mat->at(i, col));
-        if (norm < absEntry) norm = absEntry;
-    }
-    return norm;
 }
 
 
@@ -549,9 +535,9 @@ TYPED_TEST(Fcg, SolvesMultipleBigDenseSystems)
         xc->at(i, 1) = x2->at(i);
     }
 
-    solver->apply(b1.get(), x1.get());
-    solver->apply(b2.get(), x2.get());
-    solver->apply(bc.get(), xc.get());
+    solver->apply(b1, x1);
+    solver->apply(b2, x2);
+    solver->apply(bc, xc);
     auto mergedRes = Mtx::create(this->exec, gko::dim<2>{b1->get_size()[0], 2});
     for (size_t i = 0; i < mergedRes->get_size()[0]; ++i) {
         mergedRes->at(i, 0) = x1->at(i);
@@ -562,22 +548,22 @@ TYPED_TEST(Fcg, SolvesMultipleBigDenseSystems)
     auto beta = gko::initialize<Mtx>({-1.0}, this->exec);
 
     auto residual1 = Mtx::create(this->exec, b1->get_size());
-    residual1->copy_from(b1.get());
+    residual1->copy_from(b1);
     auto residual2 = Mtx::create(this->exec, b2->get_size());
-    residual2->copy_from(b2.get());
+    residual2->copy_from(b2);
     auto residualC = Mtx::create(this->exec, bc->get_size());
-    residualC->copy_from(bc.get());
+    residualC->copy_from(bc);
 
-    this->mtx_big->apply(alpha.get(), x1.get(), beta.get(), residual1.get());
-    this->mtx_big->apply(alpha.get(), x2.get(), beta.get(), residual2.get());
-    this->mtx_big->apply(alpha.get(), xc.get(), beta.get(), residualC.get());
+    this->mtx_big->apply(alpha, x1, beta, residual1);
+    this->mtx_big->apply(alpha, x2, beta, residual2);
+    this->mtx_big->apply(alpha, xc, beta, residualC);
 
-    double normS1 = infNorm(residual1.get());
-    double normS2 = infNorm(residual2.get());
-    double normC1 = infNorm(residualC.get(), 0);
-    double normC2 = infNorm(residualC.get(), 1);
-    double normB1 = infNorm(b1.get());
-    double normB2 = infNorm(b2.get());
+    double normS1 = inf_norm(residual1);
+    double normS2 = inf_norm(residual2);
+    double normC1 = inf_norm(residualC, 0);
+    double normC2 = inf_norm(residualC, 1);
+    double normB1 = inf_norm(b1);
+    double normB2 = inf_norm(b2);
 
     // make sure that all combined solutions are as good or better than the
     // single solutions
@@ -600,7 +586,7 @@ TYPED_TEST(Fcg, SolvesTransposedBigDenseSystem)
         this->exec);
     auto x = gko::initialize<Mtx>({0.0, 0.0, 0.0, 0.0, 0.0, 0.0}, this->exec);
 
-    solver->transpose()->apply(b.get(), x.get());
+    solver->transpose()->apply(b, x);
 
     GKO_ASSERT_MTX_NEAR(x, l({81.0, 55.0, 45.0, 5.0, 85.0, -10.0}),
                         r<value_type>::value * 1e3);
@@ -617,7 +603,7 @@ TYPED_TEST(Fcg, SolvesConjTransposedBigDenseSystem)
         this->exec);
     auto x = gko::initialize<Mtx>({0.0, 0.0, 0.0, 0.0, 0.0, 0.0}, this->exec);
 
-    solver->conj_transpose()->apply(b.get(), x.get());
+    solver->conj_transpose()->apply(b, x);
 
     GKO_ASSERT_MTX_NEAR(x, l({81.0, 55.0, 45.0, 5.0, 85.0, -10.0}),
                         r<value_type>::value * 1e3);

--- a/reference/test/solver/gmres_kernels.cpp
+++ b/reference/test/solver/gmres_kernels.cpp
@@ -212,8 +212,8 @@ TYPED_TEST(Gmres, KernelRestart)
     using Mtx = typename TestFixture::Mtx;
     const value_type nan =
         std::numeric_limits<gko::remove_complex<value_type>>::quiet_NaN();
-    this->small_residual->copy_from(this->small_b.get());
-    this->small_residual->compute_norm2(this->small_residual_norm.get());
+    this->small_residual->copy_from(this->small_b);
+    this->small_residual->compute_norm2(this->small_residual_norm);
     this->small_residual_norm_collection->fill(nan);
     this->small_krylov_bases->fill(9999);
     std::fill_n(this->small_final_iter_nums.get_data(),
@@ -414,7 +414,7 @@ TYPED_TEST(Gmres, SolvesStencilSystem)
     auto b = gko::initialize<Mtx>({13.0, 7.0, 1.0}, this->exec);
     auto x = gko::initialize<Mtx>({0.0, 0.0, 0.0}, this->exec);
 
-    solver->apply(b.get(), x.get());
+    solver->apply(b, x);
 
     GKO_ASSERT_MTX_NEAR(x, l({1.0, 3.0, 2.0}), r<value_type>::value * 1e1);
 }
@@ -428,7 +428,7 @@ TYPED_TEST(Gmres, SolvesStencilSystemMixed)
     auto b = gko::initialize<Mtx>({13.0, 7.0, 1.0}, this->exec);
     auto x = gko::initialize<Mtx>({0.0, 0.0, 0.0}, this->exec);
 
-    solver->apply(b.get(), x.get());
+    solver->apply(b, x);
 
     GKO_ASSERT_MTX_NEAR(x, l({1.0, 3.0, 2.0}),
                         (r_mixed<value_type, TypeParam>()));
@@ -448,7 +448,7 @@ TYPED_TEST(Gmres, SolvesStencilSystemComplex)
         {value_type{0.0, 0.0}, value_type{0.0, 0.0}, value_type{0.0, 0.0}},
         this->exec);
 
-    solver->apply(b.get(), x.get());
+    solver->apply(b, x);
 
     GKO_ASSERT_MTX_NEAR(x,
                         l({value_type{1.0, -2.0}, value_type{3.0, -6.0},
@@ -471,7 +471,7 @@ TYPED_TEST(Gmres, SolvesStencilSystemMixedComplex)
         {value_type{0.0, 0.0}, value_type{0.0, 0.0}, value_type{0.0, 0.0}},
         this->exec);
 
-    solver->apply(b.get(), x.get());
+    solver->apply(b, x);
 
     GKO_ASSERT_MTX_NEAR(x,
                         l({value_type{1.0, -2.0}, value_type{3.0, -6.0},
@@ -491,7 +491,7 @@ TYPED_TEST(Gmres, SolvesMultipleStencilSystems)
     auto x = gko::initialize<Mtx>(
         {I<T>{0.0, 0.0}, I<T>{0.0, 0.0}, I<T>{0.0, 0.0}}, this->exec);
 
-    solver->apply(b.get(), x.get());
+    solver->apply(b, x);
 
     GKO_ASSERT_MTX_NEAR(x, l({{1.0, 1.0}, {3.0, 1.0}, {2.0, 1.0}}),
                         r<value_type>::value * 1e1);
@@ -508,7 +508,7 @@ TYPED_TEST(Gmres, SolvesStencilSystemUsingAdvancedApply)
     auto b = gko::initialize<Mtx>({13.0, 7.0, 1.0}, this->exec);
     auto x = gko::initialize<Mtx>({0.5, 1.0, 2.0}, this->exec);
 
-    solver->apply(alpha.get(), b.get(), beta.get(), x.get());
+    solver->apply(alpha, b, beta, x);
 
     GKO_ASSERT_MTX_NEAR(x, l({1.5, 5.0, 2.0}), r<value_type>::value * 1e1);
 }
@@ -524,7 +524,7 @@ TYPED_TEST(Gmres, SolvesStencilSystemUsingAdvancedApplyMixed)
     auto b = gko::initialize<Mtx>({13.0, 7.0, 1.0}, this->exec);
     auto x = gko::initialize<Mtx>({0.5, 1.0, 2.0}, this->exec);
 
-    solver->apply(alpha.get(), b.get(), beta.get(), x.get());
+    solver->apply(alpha, b, beta, x);
 
     GKO_ASSERT_MTX_NEAR(x, l({1.5, 5.0, 2.0}),
                         (r_mixed<value_type, TypeParam>()));
@@ -547,7 +547,7 @@ TYPED_TEST(Gmres, SolvesStencilSystemUsingAdvancedApplyComplex)
         {value_type{0.5, -1.0}, value_type{1.0, -2.0}, value_type{2.0, -4.0}},
         this->exec);
 
-    solver->apply(alpha.get(), b.get(), beta.get(), x.get());
+    solver->apply(alpha, b, beta, x);
 
     GKO_ASSERT_MTX_NEAR(x,
                         l({value_type{1.5, -3.0}, value_type{5.0, -10.0},
@@ -573,7 +573,7 @@ TYPED_TEST(Gmres, SolvesStencilSystemUsingAdvancedApplyMixedComplex)
         {value_type{0.5, -1.0}, value_type{1.0, -2.0}, value_type{2.0, -4.0}},
         this->exec);
 
-    solver->apply(alpha.get(), b.get(), beta.get(), x.get());
+    solver->apply(alpha, b, beta, x);
 
     GKO_ASSERT_MTX_NEAR(x,
                         l({value_type{1.5, -3.0}, value_type{5.0, -10.0},
@@ -595,7 +595,7 @@ TYPED_TEST(Gmres, SolvesMultipleStencilSystemsUsingAdvancedApply)
     auto x = gko::initialize<Mtx>(
         {I<T>{0.5, 1.0}, I<T>{1.0, 2.0}, I<T>{2.0, 3.0}}, this->exec);
 
-    solver->apply(alpha.get(), b.get(), beta.get(), x.get());
+    solver->apply(alpha, b, beta, x);
 
     GKO_ASSERT_MTX_NEAR(x, l({{1.5, 1.0}, {5.0, 0.0}, {2.0, -1.0}}),
                         r<value_type>::value * 1e1);
@@ -612,7 +612,7 @@ TYPED_TEST(Gmres, SolvesBigDenseSystem1)
         this->exec);
     auto x = gko::initialize<Mtx>({0.0, 0.0, 0.0, 0.0, 0.0, 0.0}, this->exec);
 
-    solver->apply(b.get(), x.get());
+    solver->apply(b, x);
 
     GKO_ASSERT_MTX_NEAR(x, l({52.7, 85.4, 134.2, -250.0, -16.8, 35.3}),
                         r<value_type>::value * 1e3);
@@ -629,7 +629,7 @@ TYPED_TEST(Gmres, SolvesBigDenseSystem2)
         this->exec);
     auto x = gko::initialize<Mtx>({0.0, 0.0, 0.0, 0.0, 0.0, 0.0}, this->exec);
 
-    solver->apply(b.get(), x.get());
+    solver->apply(b, x);
 
     GKO_ASSERT_MTX_NEAR(x, l({33.0, -56.0, 81.0, -30.0, 21.0, 40.0}),
                         r<value_type>::value * 1e3);
@@ -646,21 +646,7 @@ TYPED_TEST(Gmres, SolveWithImplicitResNormCritIsDisabled)
         this->exec);
     auto x = gko::initialize<Mtx>({0.0, 0.0, 0.0, 0.0, 0.0, 0.0}, this->exec);
 
-    ASSERT_THROW(solver->apply(b.get(), x.get()), gko::NotSupported);
-}
-
-
-template <typename T>
-gko::remove_complex<T> infNorm(gko::matrix::Dense<T>* mat, size_t col = 0)
-{
-    using std::abs;
-    using no_cpx_t = gko::remove_complex<T>;
-    no_cpx_t norm = 0.0;
-    for (size_t i = 0; i < mat->get_size()[0]; ++i) {
-        no_cpx_t absEntry = abs(mat->at(i, col));
-        if (norm < absEntry) norm = absEntry;
-    }
-    return norm;
+    ASSERT_THROW(solver->apply(b, x), gko::NotSupported);
 }
 
 
@@ -691,9 +677,9 @@ TYPED_TEST(Gmres, SolvesMultipleDenseSystemForDivergenceCheck)
         xc->at(i, 1) = x2->at(i);
     }
 
-    solver->apply(b1.get(), x1.get());
-    solver->apply(b2.get(), x2.get());
-    solver->apply(bc.get(), xc.get());
+    solver->apply(b1, x1);
+    solver->apply(b2, x2);
+    solver->apply(bc, xc);
     auto mergedRes = Mtx::create(this->exec, gko::dim<2>{b1->get_size()[0], 2});
     for (size_t i = 0; i < mergedRes->get_size()[0]; ++i) {
         mergedRes->at(i, 0) = x1->at(i);
@@ -707,16 +693,16 @@ TYPED_TEST(Gmres, SolvesMultipleDenseSystemForDivergenceCheck)
     auto residual2 = gko::clone(this->exec, b2);
     auto residualC = gko::clone(this->exec, bc);
 
-    this->mtx_big->apply(alpha.get(), x1.get(), beta.get(), residual1.get());
-    this->mtx_big->apply(alpha.get(), x2.get(), beta.get(), residual2.get());
-    this->mtx_big->apply(alpha.get(), xc.get(), beta.get(), residualC.get());
+    this->mtx_big->apply(alpha, x1, beta, residual1);
+    this->mtx_big->apply(alpha, x2, beta, residual2);
+    this->mtx_big->apply(alpha, xc, beta, residualC);
 
-    auto normS1 = infNorm(residual1.get());
-    auto normS2 = infNorm(residual2.get());
-    auto normC1 = infNorm(residualC.get(), 0);
-    auto normC2 = infNorm(residualC.get(), 1);
-    auto normB1 = infNorm(b1.get());
-    auto normB2 = infNorm(b2.get());
+    auto normS1 = inf_norm(residual1);
+    auto normS2 = inf_norm(residual2);
+    auto normC1 = inf_norm(residualC, 0);
+    auto normC2 = inf_norm(residualC, 1);
+    auto normB1 = inf_norm(b1);
+    auto normB2 = inf_norm(b2);
 
     // make sure that all combined solutions are as good or better than the
     // single solutions
@@ -750,7 +736,7 @@ TYPED_TEST(Gmres, SolvesBigDenseSystem1WithRestart)
         {-13945.16, 11205.66, 16132.96, 24342.18, -10910.98}, this->exec);
     auto x = gko::initialize<Mtx>({0.0, 0.0, 0.0, 0.0, 0.0}, this->exec);
 
-    solver->apply(b.get(), x.get());
+    solver->apply(b, x);
 
     GKO_ASSERT_MTX_NEAR(x, l({-140.20, -142.20, 48.80, -17.70, -19.60}),
                         half_tol * 1e2);
@@ -781,7 +767,7 @@ TYPED_TEST(Gmres, SolvesWithPreconditioner)
         this->exec);
     auto x = gko::initialize<Mtx>({0.0, 0.0, 0.0, 0.0, 0.0, 0.0}, this->exec);
 
-    solver->apply(b.get(), x.get());
+    solver->apply(b, x);
 
     GKO_ASSERT_MTX_NEAR(x, l({33.0, -56.0, 81.0, -30.0, 21.0, 40.0}),
                         r<value_type>::value * 1e3);
@@ -798,7 +784,7 @@ TYPED_TEST(Gmres, SolvesTransposedBigDenseSystem)
         this->exec);
     auto x = gko::initialize<Mtx>({0.0, 0.0, 0.0, 0.0, 0.0, 0.0}, this->exec);
 
-    solver->transpose()->apply(b.get(), x.get());
+    solver->transpose()->apply(b, x);
 
     GKO_ASSERT_MTX_NEAR(x, l({52.7, 85.4, 134.2, -250.0, -16.8, 35.3}),
                         r<value_type>::value * 1e3);
@@ -816,7 +802,7 @@ TYPED_TEST(Gmres, SolvesConjTransposedBigDenseSystem)
         this->exec);
     auto x = gko::initialize<Mtx>({0.0, 0.0, 0.0, 0.0, 0.0, 0.0}, this->exec);
 
-    solver->conj_transpose()->apply(b.get(), x.get());
+    solver->conj_transpose()->apply(b, x);
 
     GKO_ASSERT_MTX_NEAR(x, l({52.7, 85.4, 134.2, -250.0, -16.8, 35.3}),
                         r<value_type>::value * 1e3);

--- a/reference/test/solver/idr_kernels.cpp
+++ b/reference/test/solver/idr_kernels.cpp
@@ -468,11 +468,11 @@ TYPED_TEST(Idr, SolvesMultipleDenseSystemsDivergenceCheck)
     auto alpha = gko::initialize<Mtx>({1.0}, this->exec);
     auto beta = gko::initialize<Mtx>({-1.0}, this->exec);
     auto residual1 = gko::initialize<Mtx>({0.}, this->exec);
-    residual1->copy_from(b1->clone());
+    residual1->copy_from(b1);
     auto residual2 = gko::initialize<Mtx>({0.}, this->exec);
-    residual2->copy_from(b2->clone());
+    residual2->copy_from(b2);
     auto residualC = gko::initialize<Mtx>({0.}, this->exec);
-    residualC->copy_from(bc->clone());
+    residualC->copy_from(bc);
 
     locmtx->apply(alpha, x1, beta, residual1);
     locmtx->apply(alpha, x2, beta, residual2);

--- a/reference/test/solver/idr_kernels.cpp
+++ b/reference/test/solver/idr_kernels.cpp
@@ -106,7 +106,7 @@ TYPED_TEST(Idr, SolvesDenseSystem)
     auto b = gko::initialize<Mtx>({-1.0, 3.0, 1.0}, this->exec);
     auto x = gko::initialize<Mtx>({0.0, 0.0, 0.0}, this->exec);
 
-    solver->apply(b.get(), x.get());
+    solver->apply(b, x);
 
     GKO_ASSERT_MTX_NEAR(x, l({-4.0, -1.0, 4.0}), r<value_type>::value * 1e1);
 }
@@ -120,7 +120,7 @@ TYPED_TEST(Idr, SolvesDenseSystemMixed)
     auto b = gko::initialize<Mtx>({-1.0, 3.0, 1.0}, this->exec);
     auto x = gko::initialize<Mtx>({0.0, 0.0, 0.0}, this->exec);
 
-    solver->apply(b.get(), x.get());
+    solver->apply(b, x);
 
     GKO_ASSERT_MTX_NEAR(x, l({-4.0, -1.0, 4.0}),
                         (r_mixed<value_type, TypeParam>()) * 1e1);
@@ -139,7 +139,7 @@ TYPED_TEST(Idr, SolvesDenseSystemComplex)
         {value_type{0.0, 0.0}, value_type{0.0, 0.0}, value_type{0.0, 0.0}},
         this->exec);
 
-    solver->apply(b.get(), x.get());
+    solver->apply(b, x);
 
     GKO_ASSERT_MTX_NEAR(x,
                         l({value_type{-4.0, 8.0}, value_type{-1.0, 2.0},
@@ -161,7 +161,7 @@ TYPED_TEST(Idr, SolvesDenseSystemMixedComplex)
         {value_type{0.0, 0.0}, value_type{0.0, 0.0}, value_type{0.0, 0.0}},
         this->exec);
 
-    solver->apply(b.get(), x.get());
+    solver->apply(b, x);
 
     GKO_ASSERT_MTX_NEAR(x,
                         l({value_type{-4.0, 8.0}, value_type{-1.0, 2.0},
@@ -193,7 +193,7 @@ TYPED_TEST(Idr, SolvesDenseSystemWithComplexSubSpace)
     auto b = gko::initialize<Mtx>({-1.0, 3.0, 1.0}, this->exec);
     auto x = gko::initialize<Mtx>({0.0, 0.0, 0.0}, this->exec);
 
-    solver->apply(b.get(), x.get());
+    solver->apply(b, x);
 
     GKO_ASSERT_MTX_NEAR(x, l({-4.0, -1.0, 4.0}), half_tol);
 }
@@ -211,7 +211,7 @@ TYPED_TEST(Idr, SolvesMultipleDenseSystems)
     auto x = gko::initialize<Mtx>(
         {I<T>{0.0, 0.0}, I<T>{0.0, 0.0}, I<T>{0.0, 0.0}}, this->exec);
 
-    solver->apply(b.get(), x.get());
+    solver->apply(b, x);
 
     GKO_ASSERT_MTX_NEAR(x, l({{-4.0, 1.0}, {-1.0, 2.0}, {4.0, -1.0}}),
                         half_tol);
@@ -244,7 +244,7 @@ TYPED_TEST(Idr, SolvesMultipleDenseSystemsWithComplexSubspace)
     auto x = gko::initialize<Mtx>(
         {I<T>{0.0, 0.0}, I<T>{0.0, 0.0}, I<T>{0.0, 0.0}}, this->exec);
 
-    solver->apply(b.get(), x.get());
+    solver->apply(b, x);
 
     GKO_ASSERT_MTX_NEAR(x, l({{-4.0, 1.0}, {-1.0, 2.0}, {4.0, -1.0}}),
                         half_tol);
@@ -261,7 +261,7 @@ TYPED_TEST(Idr, SolvesDenseSystemUsingAdvancedApply)
     auto b = gko::initialize<Mtx>({-1.0, 3.0, 1.0}, this->exec);
     auto x = gko::initialize<Mtx>({0.5, 1.0, 2.0}, this->exec);
 
-    solver->apply(alpha.get(), b.get(), beta.get(), x.get());
+    solver->apply(alpha, b, beta, x);
 
     GKO_ASSERT_MTX_NEAR(x, l({-8.5, -3.0, 6.0}), r<value_type>::value * 1e1);
 }
@@ -277,7 +277,7 @@ TYPED_TEST(Idr, SolvesDenseSystemUsingAdvancedApplyMixed)
     auto b = gko::initialize<Mtx>({-1.0, 3.0, 1.0}, this->exec);
     auto x = gko::initialize<Mtx>({0.5, 1.0, 2.0}, this->exec);
 
-    solver->apply(alpha.get(), b.get(), beta.get(), x.get());
+    solver->apply(alpha, b, beta, x);
 
     GKO_ASSERT_MTX_NEAR(x, l({-8.5, -3.0, 6.0}),
                         (r_mixed<value_type, TypeParam>()) * 1e1);
@@ -299,7 +299,7 @@ TYPED_TEST(Idr, SolvesDenseSystemUsingAdvancedApplyComplex)
         {value_type{0.5, -1.0}, value_type{1.0, -2.0}, value_type{2.0, -4.0}},
         this->exec);
 
-    solver->apply(alpha.get(), b.get(), beta.get(), x.get());
+    solver->apply(alpha, b, beta, x);
 
     GKO_ASSERT_MTX_NEAR(x,
                         l({value_type{-8.5, 17.0}, value_type{-3.0, 6.0},
@@ -324,7 +324,7 @@ TYPED_TEST(Idr, SolvesDenseSystemUsingAdvancedApplyMixedComplex)
         {value_type{0.5, -1.0}, value_type{1.0, -2.0}, value_type{2.0, -4.0}},
         this->exec);
 
-    solver->apply(alpha.get(), b.get(), beta.get(), x.get());
+    solver->apply(alpha, b, beta, x);
 
     GKO_ASSERT_MTX_NEAR(x,
                         l({value_type{-8.5, 17.0}, value_type{-3.0, 6.0},
@@ -347,7 +347,7 @@ TYPED_TEST(Idr, SolvesMultipleDenseSystemsUsingAdvancedApply)
     auto x = gko::initialize<Mtx>(
         {I<T>{0.5, 1.0}, I<T>{1.0, 2.0}, I<T>{2.0, 3.0}}, this->exec);
 
-    solver->apply(alpha.get(), b.get(), beta.get(), x.get());
+    solver->apply(alpha, b, beta, x);
 
     GKO_ASSERT_MTX_NEAR(x, l({{-8.5, 1.0}, {-3.0, 2.0}, {6.0, -5.0}}),
                         half_tol);
@@ -373,7 +373,7 @@ TYPED_TEST(Idr, SolvesBigDenseSystemForDivergenceCheck1)
         gko::initialize<Mtx>({0.0, -9.0, -2.0, 8.0, -5.0, -6.0}, this->exec);
     auto x = gko::initialize<Mtx>({0.0, 0.0, 0.0, 0.0, 0.0, 0.0}, this->exec);
 
-    solver->apply(b.get(), x.get());
+    solver->apply(b, x);
 
     auto one_op = gko::initialize<gko::matrix::Dense<value_type>>(
         {gko::one<value_type>()}, this->exec);
@@ -381,7 +381,7 @@ TYPED_TEST(Idr, SolvesBigDenseSystemForDivergenceCheck1)
         {-gko::one<value_type>()}, this->exec);
     auto resnorm = gko::matrix::Dense<gko::remove_complex<value_type>>::create(
         this->exec, gko::dim<2>{1, 1});
-    locmtx->apply(neg_one_op.get(), x.get(), one_op.get(), b.get());
+    locmtx->apply(neg_one_op, x, one_op, b);
 
     GKO_ASSERT_MTX_NEAR(
         x,
@@ -409,27 +409,13 @@ TYPED_TEST(Idr, SolvesBigDenseSystemForDivergenceCheck2)
         gko::initialize<Mtx>({9.0, -4.0, -6.0, -10.0, 1.0, 10.0}, this->exec);
     auto x = gko::initialize<Mtx>({0.0, 0.0, 0.0, 0.0, 0.0, 0.0}, this->exec);
 
-    solver->apply(b.get(), x.get());
+    solver->apply(b, x);
 
     GKO_ASSERT_MTX_NEAR(
         x,
         l({0.13517641417299162, 0.75117689075221139, 0.47572853185155239,
            -0.50927993095367852, 0.13463333820848167, 0.23126768306576015}),
         half_tol * 1e-1);
-}
-
-
-template <typename T>
-gko::remove_complex<T> infNorm(gko::matrix::Dense<T>* mat, size_t col = 0)
-{
-    using std::abs;
-    using no_cpx_t = gko::remove_complex<T>;
-    no_cpx_t norm = 0.0;
-    for (size_t i = 0; i < mat->get_size()[0]; ++i) {
-        no_cpx_t absEntry = abs(mat->at(i, col));
-        if (norm < absEntry) norm = absEntry;
-    }
-    return norm;
 }
 
 
@@ -466,9 +452,9 @@ TYPED_TEST(Idr, SolvesMultipleDenseSystemsDivergenceCheck)
         xc->at(i, 1) = x2->at(i);
     }
 
-    solver->apply(b1.get(), x1.get());
-    solver->apply(b2.get(), x2.get());
-    solver->apply(bc.get(), xc.get());
+    solver->apply(b1, x1);
+    solver->apply(b2, x2);
+    solver->apply(bc, xc);
     auto testMtx =
         gko::initialize<Mtx>({I<T>{0., 0.}, I<T>{0., 0.}, I<T>{0., 0.},
                               I<T>{0., 0.}, I<T>{0., 0.}, I<T>{0., 0.}},
@@ -488,16 +474,16 @@ TYPED_TEST(Idr, SolvesMultipleDenseSystemsDivergenceCheck)
     auto residualC = gko::initialize<Mtx>({0.}, this->exec);
     residualC->copy_from(bc->clone());
 
-    locmtx->apply(alpha.get(), x1.get(), beta.get(), residual1.get());
-    locmtx->apply(alpha.get(), x2.get(), beta.get(), residual2.get());
-    locmtx->apply(alpha.get(), xc.get(), beta.get(), residualC.get());
+    locmtx->apply(alpha, x1, beta, residual1);
+    locmtx->apply(alpha, x2, beta, residual2);
+    locmtx->apply(alpha, xc, beta, residualC);
 
-    auto normS1 = infNorm(residual1.get());
-    auto normS2 = infNorm(residual2.get());
-    auto normC1 = infNorm(residualC.get(), 0);
-    auto normC2 = infNorm(residualC.get(), 1);
-    auto normB1 = infNorm(bc.get(), 0);
-    auto normB2 = infNorm(bc.get(), 1);
+    auto normS1 = inf_norm(residual1);
+    auto normS2 = inf_norm(residual2);
+    auto normC1 = inf_norm(residualC, 0);
+    auto normC2 = inf_norm(residualC, 1);
+    auto normB1 = inf_norm(bc, 0);
+    auto normB2 = inf_norm(bc, 1);
 
     // make sure that all combined solutions are as good or better than the
     // single solutions
@@ -519,7 +505,7 @@ TYPED_TEST(Idr, SolvesTransposedDenseSystem)
     auto b = gko::initialize<Mtx>({-1.0, 3.0, 1.0}, this->exec);
     auto x = gko::initialize<Mtx>({0.0, 0.0, 0.0}, this->exec);
 
-    solver->transpose()->apply(b.get(), x.get());
+    solver->transpose()->apply(b, x);
 
     GKO_ASSERT_MTX_NEAR(x, l({-4.0, -1.0, 4.0}), half_tol);
 }
@@ -534,7 +520,7 @@ TYPED_TEST(Idr, SolvesConjTransposedDenseSystem)
     auto b = gko::initialize<Mtx>({-1.0, 3.0, 1.0}, this->exec);
     auto x = gko::initialize<Mtx>({0.0, 0.0, 0.0}, this->exec);
 
-    solver->conj_transpose()->apply(b.get(), x.get());
+    solver->conj_transpose()->apply(b, x);
 
     GKO_ASSERT_MTX_NEAR(x, l({-4.0, -1.0, 4.0}), half_tol);
 }

--- a/reference/test/solver/ir_kernels.cpp
+++ b/reference/test/solver/ir_kernels.cpp
@@ -481,8 +481,8 @@ TYPED_TEST(Ir, ApplyWithGivenInitialGuessModeIsEquivalentToRef)
         } else {
             ref_x = gko::initialize<Mtx>({0.0, 0.0, 0.0}, this->exec);
         }
-        solver->apply(lend(b), lend(x));
-        ref_solver->apply(lend(b), lend(ref_x));
+        solver->apply(b, x);
+        ref_solver->apply(b, ref_x);
 
         GKO_ASSERT_MTX_NEAR(x, ref_x, 0.0);
     }

--- a/reference/test/solver/ir_kernels.cpp
+++ b/reference/test/solver/ir_kernels.cpp
@@ -108,7 +108,7 @@ TYPED_TEST(Ir, SolvesTriangularSystem)
     auto b = gko::initialize<Mtx>({3.9, 9.0, 2.2}, this->exec);
     auto x = gko::initialize<Mtx>({0.0, 0.0, 0.0}, this->exec);
 
-    solver->apply(b.get(), x.get());
+    solver->apply(b, x);
 
     GKO_ASSERT_MTX_NEAR(x, l({1.0, 3.0, 2.0}), r<value_type>::value * 1e1);
 }
@@ -122,7 +122,7 @@ TYPED_TEST(Ir, SolvesTriangularSystemMixed)
     auto b = gko::initialize<Mtx>({3.9, 9.0, 2.2}, this->exec);
     auto x = gko::initialize<Mtx>({0.0, 0.0, 0.0}, this->exec);
 
-    solver->apply(b.get(), x.get());
+    solver->apply(b, x);
 
     GKO_ASSERT_MTX_NEAR(x, l({1.0, 3.0, 2.0}),
                         (r_mixed<value_type, TypeParam>()) * 1e1);
@@ -141,7 +141,7 @@ TYPED_TEST(Ir, SolvesTriangularSystemComplex)
         {value_type{0.0, 0.0}, value_type{0.0, 0.0}, value_type{0.0, 0.0}},
         this->exec);
 
-    solver->apply(b.get(), x.get());
+    solver->apply(b, x);
 
     GKO_ASSERT_MTX_NEAR(x,
                         l({value_type{1.0, -2.0}, value_type{3.0, -6.0},
@@ -163,7 +163,7 @@ TYPED_TEST(Ir, SolvesTriangularSystemMixedComplex)
         {value_type{0.0, 0.0}, value_type{0.0, 0.0}, value_type{0.0, 0.0}},
         this->exec);
 
-    solver->apply(b.get(), x.get());
+    solver->apply(b, x);
 
     GKO_ASSERT_MTX_NEAR(x,
                         l({value_type{1.0, -2.0}, value_type{3.0, -6.0},
@@ -197,7 +197,7 @@ TYPED_TEST(Ir, SolvesTriangularSystemWithIterativeInnerSolver)
     auto b = gko::initialize<Mtx>({3.9, 9.0, 2.2}, this->exec);
     auto x = gko::initialize<Mtx>({0.0, 0.0, 0.0}, this->exec);
 
-    solver_factory->generate(this->mtx)->apply(b.get(), x.get());
+    solver_factory->generate(this->mtx)->apply(b, x);
 
     GKO_ASSERT_MTX_NEAR(x, l({1.0, 3.0, 2.0}), r<value_type>::value * 1e1);
 }
@@ -214,7 +214,7 @@ TYPED_TEST(Ir, SolvesMultipleTriangularSystems)
     auto x = gko::initialize<Mtx>(
         {I<T>{0.0, 0.0}, I<T>{0.0, 0.0}, I<T>{0.0, 0.0}}, this->exec);
 
-    solver->apply(b.get(), x.get());
+    solver->apply(b, x);
 
     GKO_ASSERT_MTX_NEAR(x, l({{1.0, 1.0}, {3.0, 1.0}, {2.0, 1.0}}),
                         r<value_type>::value * 1e1);
@@ -231,7 +231,7 @@ TYPED_TEST(Ir, SolvesTriangularSystemUsingAdvancedApply)
     auto b = gko::initialize<Mtx>({3.9, 9.0, 2.2}, this->exec);
     auto x = gko::initialize<Mtx>({0.5, 1.0, 2.0}, this->exec);
 
-    solver->apply(alpha.get(), b.get(), beta.get(), x.get());
+    solver->apply(alpha, b, beta, x);
 
     GKO_ASSERT_MTX_NEAR(x, l({1.5, 5.0, 2.0}), r<value_type>::value * 1e1);
 }
@@ -247,7 +247,7 @@ TYPED_TEST(Ir, SolvesTriangularSystemUsingAdvancedApplyMixed)
     auto b = gko::initialize<Mtx>({3.9, 9.0, 2.2}, this->exec);
     auto x = gko::initialize<Mtx>({0.5, 1.0, 2.0}, this->exec);
 
-    solver->apply(alpha.get(), b.get(), beta.get(), x.get());
+    solver->apply(alpha, b, beta, x);
 
     GKO_ASSERT_MTX_NEAR(x, l({1.5, 5.0, 2.0}), r<value_type>::value * 1e1);
 }
@@ -268,7 +268,7 @@ TYPED_TEST(Ir, SolvesTriangularSystemUsingAdvancedApplyComplex)
         {value_type{0.5, -1.0}, value_type{1.0, -2.0}, value_type{2.0, -4.0}},
         this->exec);
 
-    solver->apply(alpha.get(), b.get(), beta.get(), x.get());
+    solver->apply(alpha, b, beta, x);
 
     GKO_ASSERT_MTX_NEAR(x,
                         l({value_type{1.5, -3.0}, value_type{5.0, -10.0},
@@ -293,7 +293,7 @@ TYPED_TEST(Ir, SolvesTriangularSystemUsingAdvancedApplyMixedComplex)
         {value_type{0.5, -1.0}, value_type{1.0, -2.0}, value_type{2.0, -4.0}},
         this->exec);
 
-    solver->apply(alpha.get(), b.get(), beta.get(), x.get());
+    solver->apply(alpha, b, beta, x);
 
     GKO_ASSERT_MTX_NEAR(x,
                         l({value_type{1.5, -3.0}, value_type{5.0, -10.0},
@@ -315,7 +315,7 @@ TYPED_TEST(Ir, SolvesMultipleStencilSystemsUsingAdvancedApply)
     auto x = gko::initialize<Mtx>(
         {I<T>{0.5, 1.0}, I<T>{1.0, 2.0}, I<T>{2.0, 3.0}}, this->exec);
 
-    solver->apply(alpha.get(), b.get(), beta.get(), x.get());
+    solver->apply(alpha, b, beta, x);
 
     GKO_ASSERT_MTX_NEAR(x, l({{1.5, 1.0}, {5.0, 0.0}, {2.0, -1.0}}),
                         r<value_type>::value * 1e1);
@@ -330,7 +330,7 @@ TYPED_TEST(Ir, SolvesTransposedTriangularSystem)
     auto b = gko::initialize<Mtx>({3.9, 9.0, 2.2}, this->exec);
     auto x = gko::initialize<Mtx>({0.0, 0.0, 0.0}, this->exec);
 
-    solver->transpose()->apply(b.get(), x.get());
+    solver->transpose()->apply(b, x);
 
     GKO_ASSERT_MTX_NEAR(x, l({1.0, 3.0, 2.0}), r<value_type>::value * 1e1);
 }
@@ -344,7 +344,7 @@ TYPED_TEST(Ir, SolvesConjTransposedTriangularSystem)
     auto b = gko::initialize<Mtx>({3.9, 9.0, 2.2}, this->exec);
     auto x = gko::initialize<Mtx>({0.0, 0.0, 0.0}, this->exec);
 
-    solver->conj_transpose()->apply(b.get(), x.get());
+    solver->conj_transpose()->apply(b, x);
 
     GKO_ASSERT_MTX_NEAR(x, l({1.0, 3.0, 2.0}), r<value_type>::value * 1e1);
 }
@@ -367,7 +367,7 @@ TYPED_TEST(Ir, RichardsonSolvesTriangularSystem)
     auto b = gko::initialize<Mtx>({3.9, 9.0, 2.2}, this->exec);
     auto x = gko::initialize<Mtx>({0.0, 0.0, 0.0}, this->exec);
 
-    solver->apply(b.get(), x.get());
+    solver->apply(b, x);
 
     GKO_ASSERT_MTX_NEAR(x, l({1.0, 3.0, 2.0}), r<value_type>::value * 1e1);
 }
@@ -398,7 +398,7 @@ TYPED_TEST(Ir, RichardsonSolvesTriangularSystemWithIterativeInnerSolver)
     auto b = gko::initialize<Mtx>({3.9, 9.0, 2.2}, this->exec);
     auto x = gko::initialize<Mtx>({0.0, 0.0, 0.0}, this->exec);
 
-    solver_factory->generate(this->mtx)->apply(b.get(), x.get());
+    solver_factory->generate(this->mtx)->apply(b, x);
 
     GKO_ASSERT_MTX_NEAR(x, l({1.0, 3.0, 2.0}), r<value_type>::value * 1e1);
 }
@@ -421,7 +421,7 @@ TYPED_TEST(Ir, RichardsonTransposedSolvesTriangularSystem)
     auto b = gko::initialize<Mtx>({3.9, 9.0, 2.2}, this->exec);
     auto x = gko::initialize<Mtx>({0.0, 0.0, 0.0}, this->exec);
 
-    solver->transpose()->apply(b.get(), x.get());
+    solver->transpose()->apply(b, x);
 
     GKO_ASSERT_MTX_NEAR(x, l({1.0, 3.0, 2.0}), r<value_type>::value * 1e1);
 }
@@ -444,7 +444,7 @@ TYPED_TEST(Ir, RichardsonConjTransposedSolvesTriangularSystem)
     auto b = gko::initialize<Mtx>({3.9, 9.0, 2.2}, this->exec);
     auto x = gko::initialize<Mtx>({0.0, 0.0, 0.0}, this->exec);
 
-    solver->conj_transpose()->apply(b.get(), x.get());
+    solver->conj_transpose()->apply(b, x);
 
     GKO_ASSERT_MTX_NEAR(x, l({1.0, 3.0, 2.0}), r<value_type>::value * 1e1);
 }

--- a/reference/test/solver/lower_trs.cpp
+++ b/reference/test/solver/lower_trs.cpp
@@ -97,7 +97,7 @@ TYPED_TEST(LowerTrs, CanBeCopied)
     auto copy =
         Solver::build().on(this->exec)->generate(Mtx::create(this->exec));
 
-    copy->copy_from(gko::lend(this->solver));
+    copy->copy_from(this->solver);
     auto copy_mtx = copy->get_system_matrix();
 
     ASSERT_EQ(copy->get_size(), gko::dim<2>(3, 3));

--- a/reference/test/solver/lower_trs.cpp
+++ b/reference/test/solver/lower_trs.cpp
@@ -112,7 +112,7 @@ TYPED_TEST(LowerTrs, CanBeMoved)
     auto copy =
         Solver::build().on(this->exec)->generate(Mtx::create(this->exec));
 
-    copy->copy_from(std::move(this->solver));
+    copy->move_from(this->solver);
     auto copy_mtx = copy->get_system_matrix();
 
     ASSERT_EQ(copy->get_size(), gko::dim<2>(3, 3));

--- a/reference/test/solver/lower_trs.cpp
+++ b/reference/test/solver/lower_trs.cpp
@@ -101,7 +101,7 @@ TYPED_TEST(LowerTrs, CanBeCopied)
     auto copy_mtx = copy->get_system_matrix();
 
     ASSERT_EQ(copy->get_size(), gko::dim<2>(3, 3));
-    GKO_ASSERT_MTX_NEAR(copy_mtx.get(), this->csr_mtx.get(), 0);
+    GKO_ASSERT_MTX_NEAR(copy_mtx, this->csr_mtx, 0);
 }
 
 
@@ -116,7 +116,7 @@ TYPED_TEST(LowerTrs, CanBeMoved)
     auto copy_mtx = copy->get_system_matrix();
 
     ASSERT_EQ(copy->get_size(), gko::dim<2>(3, 3));
-    GKO_ASSERT_MTX_NEAR(copy_mtx.get(), this->csr_mtx.get(), 0);
+    GKO_ASSERT_MTX_NEAR(copy_mtx, this->csr_mtx, 0);
 }
 
 
@@ -127,7 +127,7 @@ TYPED_TEST(LowerTrs, CanBeCloned)
     auto clone_mtx = clone->get_system_matrix();
 
     ASSERT_EQ(clone->get_size(), gko::dim<2>(3, 3));
-    GKO_ASSERT_MTX_NEAR(clone_mtx.get(), this->csr_mtx.get(), 0);
+    GKO_ASSERT_MTX_NEAR(clone_mtx, this->csr_mtx, 0);
 }
 
 

--- a/reference/test/solver/lower_trs_kernels.cpp
+++ b/reference/test/solver/lower_trs_kernels.cpp
@@ -124,7 +124,7 @@ TYPED_TEST(LowerTrs, SolvesTriangularSystem)
     auto x = gko::initialize<Mtx>({0.0, 0.0, 0.0}, this->exec);
     auto solver = this->lower_trs_factory->generate(this->mtx);
 
-    solver->apply(b.get(), x.get());
+    solver->apply(b, x);
 
     GKO_ASSERT_MTX_NEAR(x, l({1.0, -1.0, 2.0}), r<value_type>::value);
 }
@@ -139,7 +139,7 @@ TYPED_TEST(LowerTrs, SolvesTriangularSystemMixed)
     auto x = gko::initialize<Mtx>({0.0, 0.0, 0.0}, this->exec);
     auto solver = this->lower_trs_factory->generate(this->mtx);
 
-    solver->apply(b.get(), x.get());
+    solver->apply(b, x);
 
     GKO_ASSERT_MTX_NEAR(x, l({1.0, -1.0, 2.0}),
                         (r_mixed<value_type, other_value_type>()));
@@ -159,7 +159,7 @@ TYPED_TEST(LowerTrs, SolvesTriangularSystemComplex)
         this->exec);
     auto solver = this->lower_trs_factory->generate(this->mtx);
 
-    solver->apply(b.get(), x.get());
+    solver->apply(b, x);
 
     GKO_ASSERT_MTX_NEAR(x,
                         l({value_type{1.0, -2.0}, value_type{-1.0, 2.0},
@@ -182,7 +182,7 @@ TYPED_TEST(LowerTrs, SolvesTriangularSystemMixedComplex)
         this->exec);
     auto solver = this->lower_trs_factory->generate(this->mtx);
 
-    solver->apply(b.get(), x.get());
+    solver->apply(b, x);
 
     GKO_ASSERT_MTX_NEAR(x,
                         l({value_type{1.0, -2.0}, value_type{-1.0, 2.0},
@@ -202,7 +202,7 @@ TYPED_TEST(LowerTrs, SolvesMultipleTriangularSystems)
         {I<T>{0.0, 0.0}, I<T>{0.0, 0.0}, I<T>{0.0, 0.0}}, this->exec);
     auto solver = this->lower_trs_factory_mrhs->generate(this->mtx);
 
-    solver->apply(b.get(), x.get());
+    solver->apply(b, x);
 
     GKO_ASSERT_MTX_NEAR(x, l({{3.0, 4.0}, {-8.0, -12.0}, {14.0, 19.0}}),
                         r<value_type>::value);
@@ -217,7 +217,7 @@ TYPED_TEST(LowerTrs, SolvesNonUnitTriangularSystem)
     auto x = gko::initialize<Mtx>({0.0, 0.0, 0.0}, this->exec);
     auto solver = this->lower_trs_factory->generate(this->mtx2);
 
-    solver->apply(b.get(), x.get());
+    solver->apply(b, x);
 
     GKO_ASSERT_MTX_NEAR(x, l({1.0, 3.0, -1.0}), r<value_type>::value);
 }
@@ -233,7 +233,7 @@ TYPED_TEST(LowerTrs, SolvesTriangularSystemUsingAdvancedApply)
     auto x = gko::initialize<Mtx>({1.0, -1.0, 1.0}, this->exec);
     auto solver = this->lower_trs_factory->generate(this->mtx);
 
-    solver->apply(alpha.get(), b.get(), beta.get(), x.get());
+    solver->apply(alpha, b, beta, x);
 
     GKO_ASSERT_MTX_NEAR(x, l({1.0, -1.0, 3.0}), r<value_type>::value);
 }
@@ -250,7 +250,7 @@ TYPED_TEST(LowerTrs, SolvesTriangularSystemUsingAdvancedApplyMixed)
     auto x = gko::initialize<Mtx>({1.0, -1.0, 1.0}, this->exec);
     auto solver = this->lower_trs_factory->generate(this->mtx);
 
-    solver->apply(alpha.get(), b.get(), beta.get(), x.get());
+    solver->apply(alpha, b, beta, x);
 
     GKO_ASSERT_MTX_NEAR(x, l({1.0, -1.0, 3.0}),
                         (r_mixed<value_type, other_value_type>()));
@@ -272,7 +272,7 @@ TYPED_TEST(LowerTrs, SolvesTriangularSystemUsingAdvancedApplyComplex)
         this->exec);
     auto solver = this->lower_trs_factory->generate(this->mtx);
 
-    solver->apply(alpha.get(), b.get(), beta.get(), x.get());
+    solver->apply(alpha, b, beta, x);
 
     GKO_ASSERT_MTX_NEAR(x,
                         l({value_type{1.0, -2.0}, value_type{-1.0, 2.0},
@@ -297,7 +297,7 @@ TYPED_TEST(LowerTrs, SolvesTriangularSystemUsingAdvancedApplyMixedComplex)
         this->exec);
     auto solver = this->lower_trs_factory->generate(this->mtx);
 
-    solver->apply(alpha.get(), b.get(), beta.get(), x.get());
+    solver->apply(alpha, b, beta, x);
 
     GKO_ASSERT_MTX_NEAR(x,
                         l({value_type{1.0, -2.0}, value_type{-1.0, 2.0},
@@ -319,7 +319,7 @@ TYPED_TEST(LowerTrs, SolvesMultipleTriangularSystemsUsingAdvancedApply)
         {I<T>{1.0, 2.0}, I<T>{-1.0, -1.0}, I<T>{0.0, -2.0}}, this->exec);
     auto solver = this->lower_trs_factory_mrhs->generate(this->mtx);
 
-    solver->apply(alpha.get(), b.get(), beta.get(), x.get());
+    solver->apply(alpha, b, beta, x);
 
     GKO_ASSERT_MTX_NEAR(x, l({{-1.0, 0.0}, {6.0, 10.0}, {-14.0, -23.0}}),
                         r<value_type>::value);
@@ -335,7 +335,7 @@ TYPED_TEST(LowerTrs, SolvesBigDenseSystem)
     auto x = gko::initialize<Mtx>({0.0, 0.0, 0.0, 0.0, 0.0}, this->exec);
     auto solver = this->lower_trs_factory->generate(this->mtx_big_lower);
 
-    solver->apply(b.get(), x.get());
+    solver->apply(b, x);
 
     GKO_ASSERT_MTX_NEAR(x, l({-1.0, 4.0, 9.0, 3.0, -2.0}),
                         r<value_type>::value * 1e3);
@@ -351,7 +351,7 @@ TYPED_TEST(LowerTrs, SolvesBigDenseSystemWithUnitDiagonal)
     auto x = gko::initialize<Mtx>({0.0, 0.0, 0.0, 0.0, 0.0}, this->exec);
     auto solver = this->lower_trs_factory_unit->generate(this->mtx_big_lower);
 
-    solver->apply(b.get(), x.get());
+    solver->apply(b, x);
 
     GKO_ASSERT_MTX_NEAR(x, l({-1.0, 4.0, 9.0, 3.0, -2.0}),
                         r<value_type>::value * 1e3);
@@ -367,7 +367,7 @@ TYPED_TEST(LowerTrs, SolveBigDenseSystemIgnoresNonTriangleEntries)
     auto x = gko::initialize<Mtx>({0.0, 0.0, 0.0, 0.0, 0.0}, this->exec);
     auto solver = this->lower_trs_factory->generate(this->mtx_big_general);
 
-    solver->apply(b.get(), x.get());
+    solver->apply(b, x);
 
     GKO_ASSERT_MTX_NEAR(x, l({-1.0, 4.0, 9.0, 3.0, -2.0}),
                         r<value_type>::value * 1e3);
@@ -382,7 +382,7 @@ TYPED_TEST(LowerTrs, SolvesTransposedTriangularSystem)
     auto x = gko::initialize<Mtx>({0.0, 0.0, 0.0}, this->exec);
     auto solver = this->lower_trs_factory->generate(this->mtx);
 
-    solver->transpose()->apply(b.get(), x.get());
+    solver->transpose()->apply(b, x);
 
     GKO_ASSERT_MTX_NEAR(x, l({0.0, 0.0, 1.0}), r<value_type>::value);
 }
@@ -396,7 +396,7 @@ TYPED_TEST(LowerTrs, SolvesConjTransposedTriangularSystem)
     auto x = gko::initialize<Mtx>({0.0, 0.0, 0.0}, this->exec);
     auto solver = this->lower_trs_factory->generate(this->mtx);
 
-    solver->conj_transpose()->apply(b.get(), x.get());
+    solver->conj_transpose()->apply(b, x);
 
     GKO_ASSERT_MTX_NEAR(x, l({0.0, 0.0, 1.0}), r<value_type>::value);
 }

--- a/reference/test/solver/multigrid_kernels.cpp
+++ b/reference/test/solver/multigrid_kernels.cpp
@@ -499,7 +499,7 @@ TYPED_TEST(Multigrid, VCycleIndividual)
     //        2   3
     //          v
     global_step = 0;
-    solver->apply(gko::lend(this->b), gko::lend(this->x));
+    solver->apply(this->b, this->x);
 
     this->assert_same_step(mg_level.at(0).get(), {0}, {4});
     this->assert_same_step(mg_level.at(1).get(), {2}, {3});
@@ -537,7 +537,7 @@ TYPED_TEST(Multigrid, VCycleSame)
     //        2   4
     //          3
     global_step = 0;
-    solver->apply(gko::lend(this->b), gko::lend(this->x));
+    solver->apply(this->b, this->x);
 
     this->assert_same_step(mg_level.at(0).get(), {0}, {6});
     this->assert_same_step(mg_level.at(1).get(), {2}, {4});
@@ -585,7 +585,7 @@ TYPED_TEST(Multigrid, WCycleIndividual)
     //           4   5     8   9             15  16    19  20
     //             v         v                 v         v
     global_step = 0;
-    solver->apply(gko::lend(this->b2), gko::lend(this->x2));
+    solver->apply(this->b2, this->x2);
 
     this->assert_same_step(mg_level.at(0).get(), {0}, {23});
     this->assert_same_step(mg_level.at(1).get(), {2, 13}, {11, 22});
@@ -638,7 +638,7 @@ TYPED_TEST(Multigrid, WCycleIndividualMidUsePost)
     //           4   5   7   8           13  14  16  17
     //             v       v               v       v
     global_step = 0;
-    solver->apply(gko::lend(this->b2), gko::lend(this->x2));
+    solver->apply(this->b2, this->x2);
 
     this->assert_same_step(mg_level.at(0).get(), {0}, {20});
     this->assert_same_step(mg_level.at(1).get(), {2, 11}, {10, 19});
@@ -690,7 +690,7 @@ TYPED_TEST(Multigrid, WCycleIndividualMidUsePre)
     //           4   5   7   8           14  15  17  18
     //             v       v               v       v
     global_step = 0;
-    solver->apply(gko::lend(this->b2), gko::lend(this->x2));
+    solver->apply(this->b2, this->x2);
 
     this->assert_same_step(mg_level.at(0).get(), {0}, {21});
     this->assert_same_step(mg_level.at(1).get(), {2, 12}, {10, 20});
@@ -742,7 +742,7 @@ TYPED_TEST(Multigrid, WCycleIndividualMidUseStandalone)
     //           4   5   7   8           13  14  16  17
     //             v       v               v       v
     global_step = 0;
-    solver->apply(gko::lend(this->b2), gko::lend(this->x2));
+    solver->apply(this->b2, this->x2);
 
     this->assert_same_step(mg_level.at(0).get(), {0}, {20});
     this->assert_same_step(mg_level.at(1).get(), {2, 11}, {10, 19});
@@ -789,7 +789,7 @@ TYPED_TEST(Multigrid, WCycleSame)
     //           4   6     9   11            18  20    23  25
     //             5         10                19        24
     global_step = 0;
-    solver->apply(gko::lend(this->b2), gko::lend(this->x2));
+    solver->apply(this->b2, this->x2);
 
     this->assert_same_step(mg_level.at(0).get(), {0}, {29});
     this->assert_same_step(mg_level.at(1).get(), {2, 16}, {13, 27});
@@ -839,7 +839,7 @@ TYPED_TEST(Multigrid, WCycleSameMidUsePost)
     //           4   6   8   10          16  18  20  22
     //             5       9               17      21
     global_step = 0;
-    solver->apply(gko::lend(this->b2), gko::lend(this->x2));
+    solver->apply(this->b2, this->x2);
 
     this->assert_same_step(mg_level.at(0).get(), {0}, {26});
     this->assert_same_step(mg_level.at(1).get(), {2, 14}, {12, 24});
@@ -887,7 +887,7 @@ TYPED_TEST(Multigrid, WCycleSameMidUsePre)
     //           4   6   8   10          16  18  20  22
     //             5       9               17      21
     global_step = 0;
-    solver->apply(gko::lend(this->b2), gko::lend(this->x2));
+    solver->apply(this->b2, this->x2);
 
     this->assert_same_step(mg_level.at(0).get(), {0}, {26});
     this->assert_same_step(mg_level.at(1).get(), {2, 14}, {12, 24});
@@ -937,7 +937,7 @@ TYPED_TEST(Multigrid, FCycleIndividual)
     //           4   5     8   9             15  16
     //             v         v                 v
     global_step = 0;
-    solver->apply(gko::lend(this->b2), gko::lend(this->x2));
+    solver->apply(this->b2, this->x2);
 
     this->assert_same_step(mg_level.at(0).get(), {0}, {19});
     this->assert_same_step(mg_level.at(1).get(), {2, 13}, {11, 18});
@@ -990,7 +990,7 @@ TYPED_TEST(Multigrid, FCycleIndividualMidUsePost)
     //           4   5   7   8           13  14
     //             v       v               v
     global_step = 0;
-    solver->apply(gko::lend(this->b2), gko::lend(this->x2));
+    solver->apply(this->b2, this->x2);
 
     this->assert_same_step(mg_level.at(0).get(), {0}, {17});
     this->assert_same_step(mg_level.at(1).get(), {2, 11}, {10, 16});
@@ -1041,7 +1041,7 @@ TYPED_TEST(Multigrid, FCycleIndividualMidUsePre)
     //           4   5   7   8           14  15
     //             v       v               v
     global_step = 0;
-    solver->apply(gko::lend(this->b2), gko::lend(this->x2));
+    solver->apply(this->b2, this->x2);
 
     this->assert_same_step(mg_level.at(0).get(), {0}, {18});
     this->assert_same_step(mg_level.at(1).get(), {2, 12}, {10, 17});
@@ -1092,7 +1092,7 @@ TYPED_TEST(Multigrid, FCycleIndividualMidUseStandalone)
     //           4   5   7   8           13  14
     //             v       v               v
     global_step = 0;
-    solver->apply(gko::lend(this->b2), gko::lend(this->x2));
+    solver->apply(this->b2, this->x2);
 
     this->assert_same_step(mg_level.at(0).get(), {0}, {17});
     this->assert_same_step(mg_level.at(1).get(), {2, 11}, {10, 16});
@@ -1139,7 +1139,7 @@ TYPED_TEST(Multigrid, FCycleSame)
     //           4   6     9   11            18  20
     //             5         10                19
     global_step = 0;
-    solver->apply(gko::lend(this->b2), gko::lend(this->x2));
+    solver->apply(this->b2, this->x2);
 
     this->assert_same_step(mg_level.at(0).get(), {0}, {24});
     this->assert_same_step(mg_level.at(1).get(), {2, 16}, {13, 22});
@@ -1186,7 +1186,7 @@ TYPED_TEST(Multigrid, FCycleSameMidUsePost)
     //           4   6   8   10          16  18
     //             5       9               17
     global_step = 0;
-    solver->apply(gko::lend(this->b2), gko::lend(this->x2));
+    solver->apply(this->b2, this->x2);
 
     this->assert_same_step(mg_level.at(0).get(), {0}, {22});
     this->assert_same_step(mg_level.at(1).get(), {2, 14}, {12, 20});
@@ -1233,7 +1233,7 @@ TYPED_TEST(Multigrid, FCycleSameMidUsePre)
     //           4   6   8   10          16  18
     //             5       9               17
     global_step = 0;
-    solver->apply(gko::lend(this->b2), gko::lend(this->x2));
+    solver->apply(this->b2, this->x2);
 
     this->assert_same_step(mg_level.at(0).get(), {0}, {22});
     this->assert_same_step(mg_level.at(1).get(), {2, 14}, {12, 20});
@@ -1263,7 +1263,7 @@ TYPED_TEST(Multigrid, CanChangeCycle)
     // change v cycle to f cycle
     global_step = 0;
     solver->set_cycle(gko::solver::multigrid::cycle::f);
-    solver->apply(gko::lend(this->b), gko::lend(this->x));
+    solver->apply(this->b, this->x);
 
     ASSERT_EQ(original, gko::solver::multigrid::cycle::v);
     ASSERT_EQ(solver->get_cycle(), gko::solver::multigrid::cycle::f);

--- a/reference/test/solver/multigrid_kernels.cpp
+++ b/reference/test/solver/multigrid_kernels.cpp
@@ -323,7 +323,7 @@ protected:
           x2(gko::initialize<Mtx>({0.0, 0.0, 0.0, 0.0, 0.0, 0.0}, exec))
     {}
 
-    static void assert_same_step(gko::pointer_param<const gko::LinOp> lo,
+    static void assert_same_step(gko::ptr_param<const gko::LinOp> lo,
                                  std::vector<int> v2)
     {
         auto v1 = dynamic_cast<const DummyFactory*>(lo.get())->get_step();
@@ -331,7 +331,7 @@ protected:
     }
 
     static void assert_same_step(
-        gko::pointer_param<const gko::multigrid::MultigridLevel> rp,
+        gko::ptr_param<const gko::multigrid::MultigridLevel> rp,
         std::vector<int> rstr, std::vector<int> prlg)
     {
         auto dummy = dynamic_cast<const DummyRPFactory*>(rp.get());

--- a/reference/test/solver/multigrid_kernels.cpp
+++ b/reference/test/solver/multigrid_kernels.cpp
@@ -323,31 +323,22 @@ protected:
           x2(gko::initialize<Mtx>({0.0, 0.0, 0.0, 0.0, 0.0, 0.0}, exec))
     {}
 
-    static void assert_same_step(const gko::LinOp* lo, std::vector<int> v2)
+    static void assert_same_step(gko::pointer_param<const gko::LinOp> lo,
+                                 std::vector<int> v2)
     {
-        auto v1 = dynamic_cast<const DummyFactory*>(lo)->get_step();
+        auto v1 = dynamic_cast<const DummyFactory*>(lo.get())->get_step();
         assert_same_vector(v1, v2);
     }
 
-    static void assert_same_step(const gko::multigrid::MultigridLevel* rp,
-                                 std::vector<int> rstr, std::vector<int> prlg)
+    static void assert_same_step(
+        gko::pointer_param<const gko::multigrid::MultigridLevel> rp,
+        std::vector<int> rstr, std::vector<int> prlg)
     {
-        auto dummy = dynamic_cast<const DummyRPFactory*>(rp);
+        auto dummy = dynamic_cast<const DummyRPFactory*>(rp.get());
         auto v = dummy->get_rstr_step();
         assert_same_vector(v, rstr);
         v = dummy->get_prlg_step();
         assert_same_vector(v, prlg);
-    }
-
-    static void assert_same_matrices(const Mtx* m1, const Mtx* m2)
-    {
-        ASSERT_EQ(m1->get_size()[0], m2->get_size()[0]);
-        ASSERT_EQ(m1->get_size()[1], m2->get_size()[1]);
-        for (gko::size_type i = 0; i < m1->get_size()[0]; ++i) {
-            for (gko::size_type j = 0; j < m2->get_size()[1]; ++j) {
-                EXPECT_EQ(m1->at(i, j), m2->at(i, j));
-            }
-        }
     }
 
     std::unique_ptr<typename Solver::Factory> get_multigrid_factory(
@@ -501,10 +492,10 @@ TYPED_TEST(Multigrid, VCycleIndividual)
     global_step = 0;
     solver->apply(this->b, this->x);
 
-    this->assert_same_step(mg_level.at(0).get(), {0}, {4});
-    this->assert_same_step(mg_level.at(1).get(), {2}, {3});
-    this->assert_same_step(pre_smoother.at(1).get(), {1});
-    this->assert_same_step(post_smoother.at(0).get(), {5});
+    this->assert_same_step(mg_level.at(0), {0}, {4});
+    this->assert_same_step(mg_level.at(1), {2}, {3});
+    this->assert_same_step(pre_smoother.at(1), {1});
+    this->assert_same_step(post_smoother.at(0), {5});
 }
 
 
@@ -539,11 +530,11 @@ TYPED_TEST(Multigrid, VCycleSame)
     global_step = 0;
     solver->apply(this->b, this->x);
 
-    this->assert_same_step(mg_level.at(0).get(), {0}, {6});
-    this->assert_same_step(mg_level.at(1).get(), {2}, {4});
+    this->assert_same_step(mg_level.at(0), {0}, {6});
+    this->assert_same_step(mg_level.at(1), {2}, {4});
     // all uses pre_smoother
-    this->assert_same_step(pre_smoother.at(1).get(), {1, 5});
-    this->assert_same_step(coarsest_solver.get(), {3});
+    this->assert_same_step(pre_smoother.at(1), {1, 5});
+    this->assert_same_step(coarsest_solver, {3});
 }
 
 
@@ -587,14 +578,13 @@ TYPED_TEST(Multigrid, WCycleIndividual)
     global_step = 0;
     solver->apply(this->b2, this->x2);
 
-    this->assert_same_step(mg_level.at(0).get(), {0}, {23});
-    this->assert_same_step(mg_level.at(1).get(), {2, 13}, {11, 22});
-    this->assert_same_step(mg_level.at(2).get(), {4, 8, 15, 19},
-                           {5, 9, 16, 20});
-    this->assert_same_step(pre_smoother.at(1).get(), {1, 12});
-    this->assert_same_step(pre_smoother.at(2).get(), {3, 7, 14, 18});
-    this->assert_same_step(post_smoother.at(0).get(), {24});
-    this->assert_same_step(post_smoother.at(2).get(), {6, 10, 17, 21});
+    this->assert_same_step(mg_level.at(0), {0}, {23});
+    this->assert_same_step(mg_level.at(1), {2, 13}, {11, 22});
+    this->assert_same_step(mg_level.at(2), {4, 8, 15, 19}, {5, 9, 16, 20});
+    this->assert_same_step(pre_smoother.at(1), {1, 12});
+    this->assert_same_step(pre_smoother.at(2), {3, 7, 14, 18});
+    this->assert_same_step(post_smoother.at(0), {24});
+    this->assert_same_step(post_smoother.at(2), {6, 10, 17, 21});
 }
 
 
@@ -640,14 +630,13 @@ TYPED_TEST(Multigrid, WCycleIndividualMidUsePost)
     global_step = 0;
     solver->apply(this->b2, this->x2);
 
-    this->assert_same_step(mg_level.at(0).get(), {0}, {20});
-    this->assert_same_step(mg_level.at(1).get(), {2, 11}, {10, 19});
-    this->assert_same_step(mg_level.at(2).get(), {4, 7, 13, 16},
-                           {5, 8, 14, 17});
-    this->assert_same_step(pre_smoother.at(1).get(), {1});
-    this->assert_same_step(pre_smoother.at(2).get(), {3, 12});
-    this->assert_same_step(post_smoother.at(0).get(), {21});
-    this->assert_same_step(post_smoother.at(2).get(), {6, 9, 15, 18});
+    this->assert_same_step(mg_level.at(0), {0}, {20});
+    this->assert_same_step(mg_level.at(1), {2, 11}, {10, 19});
+    this->assert_same_step(mg_level.at(2), {4, 7, 13, 16}, {5, 8, 14, 17});
+    this->assert_same_step(pre_smoother.at(1), {1});
+    this->assert_same_step(pre_smoother.at(2), {3, 12});
+    this->assert_same_step(post_smoother.at(0), {21});
+    this->assert_same_step(post_smoother.at(2), {6, 9, 15, 18});
 }
 
 
@@ -692,14 +681,13 @@ TYPED_TEST(Multigrid, WCycleIndividualMidUsePre)
     global_step = 0;
     solver->apply(this->b2, this->x2);
 
-    this->assert_same_step(mg_level.at(0).get(), {0}, {21});
-    this->assert_same_step(mg_level.at(1).get(), {2, 12}, {10, 20});
-    this->assert_same_step(mg_level.at(2).get(), {4, 7, 14, 17},
-                           {5, 8, 15, 18});
-    this->assert_same_step(pre_smoother.at(1).get(), {1, 11});
-    this->assert_same_step(pre_smoother.at(2).get(), {3, 6, 13, 16});
-    this->assert_same_step(post_smoother.at(0).get(), {22});
-    this->assert_same_step(post_smoother.at(2).get(), {9, 19});
+    this->assert_same_step(mg_level.at(0), {0}, {21});
+    this->assert_same_step(mg_level.at(1), {2, 12}, {10, 20});
+    this->assert_same_step(mg_level.at(2), {4, 7, 14, 17}, {5, 8, 15, 18});
+    this->assert_same_step(pre_smoother.at(1), {1, 11});
+    this->assert_same_step(pre_smoother.at(2), {3, 6, 13, 16});
+    this->assert_same_step(post_smoother.at(0), {22});
+    this->assert_same_step(post_smoother.at(2), {9, 19});
 }
 
 
@@ -744,15 +732,14 @@ TYPED_TEST(Multigrid, WCycleIndividualMidUseStandalone)
     global_step = 0;
     solver->apply(this->b2, this->x2);
 
-    this->assert_same_step(mg_level.at(0).get(), {0}, {20});
-    this->assert_same_step(mg_level.at(1).get(), {2, 11}, {10, 19});
-    this->assert_same_step(mg_level.at(2).get(), {4, 7, 13, 16},
-                           {5, 8, 14, 17});
-    this->assert_same_step(pre_smoother.at(1).get(), {1});
-    this->assert_same_step(pre_smoother.at(2).get(), {3, 12});
-    this->assert_same_step(post_smoother.at(0).get(), {21});
-    this->assert_same_step(post_smoother.at(2).get(), {9, 18});
-    this->assert_same_step(mid_smoother.at(2).get(), {6, 15});
+    this->assert_same_step(mg_level.at(0), {0}, {20});
+    this->assert_same_step(mg_level.at(1), {2, 11}, {10, 19});
+    this->assert_same_step(mg_level.at(2), {4, 7, 13, 16}, {5, 8, 14, 17});
+    this->assert_same_step(pre_smoother.at(1), {1});
+    this->assert_same_step(pre_smoother.at(2), {3, 12});
+    this->assert_same_step(post_smoother.at(0), {21});
+    this->assert_same_step(post_smoother.at(2), {9, 18});
+    this->assert_same_step(mid_smoother.at(2), {6, 15});
 }
 
 
@@ -791,15 +778,13 @@ TYPED_TEST(Multigrid, WCycleSame)
     global_step = 0;
     solver->apply(this->b2, this->x2);
 
-    this->assert_same_step(mg_level.at(0).get(), {0}, {29});
-    this->assert_same_step(mg_level.at(1).get(), {2, 16}, {13, 27});
-    this->assert_same_step(mg_level.at(2).get(), {4, 9, 18, 23},
-                           {6, 11, 20, 25});
+    this->assert_same_step(mg_level.at(0), {0}, {29});
+    this->assert_same_step(mg_level.at(1), {2, 16}, {13, 27});
+    this->assert_same_step(mg_level.at(2), {4, 9, 18, 23}, {6, 11, 20, 25});
     // all uses pre_smoother
-    this->assert_same_step(pre_smoother.at(1).get(), {1, 14, 15, 28});
-    this->assert_same_step(pre_smoother.at(2).get(),
-                           {3, 7, 8, 12, 17, 21, 22, 26});
-    this->assert_same_step(coarsest_solver.get(), {5, 10, 19, 24});
+    this->assert_same_step(pre_smoother.at(1), {1, 14, 15, 28});
+    this->assert_same_step(pre_smoother.at(2), {3, 7, 8, 12, 17, 21, 22, 26});
+    this->assert_same_step(coarsest_solver, {5, 10, 19, 24});
 }
 
 
@@ -841,14 +826,13 @@ TYPED_TEST(Multigrid, WCycleSameMidUsePost)
     global_step = 0;
     solver->apply(this->b2, this->x2);
 
-    this->assert_same_step(mg_level.at(0).get(), {0}, {26});
-    this->assert_same_step(mg_level.at(1).get(), {2, 14}, {12, 24});
-    this->assert_same_step(mg_level.at(2).get(), {4, 8, 16, 20},
-                           {6, 10, 18, 22});
+    this->assert_same_step(mg_level.at(0), {0}, {26});
+    this->assert_same_step(mg_level.at(1), {2, 14}, {12, 24});
+    this->assert_same_step(mg_level.at(2), {4, 8, 16, 20}, {6, 10, 18, 22});
     // all use pre_smoother
-    this->assert_same_step(pre_smoother.at(1).get(), {1, 13, 25});
-    this->assert_same_step(pre_smoother.at(2).get(), {3, 7, 11, 15, 19, 23});
-    this->assert_same_step(coarsest_solver.get(), {5, 9, 17, 21});
+    this->assert_same_step(pre_smoother.at(1), {1, 13, 25});
+    this->assert_same_step(pre_smoother.at(2), {3, 7, 11, 15, 19, 23});
+    this->assert_same_step(coarsest_solver, {5, 9, 17, 21});
 }
 
 
@@ -889,14 +873,13 @@ TYPED_TEST(Multigrid, WCycleSameMidUsePre)
     global_step = 0;
     solver->apply(this->b2, this->x2);
 
-    this->assert_same_step(mg_level.at(0).get(), {0}, {26});
-    this->assert_same_step(mg_level.at(1).get(), {2, 14}, {12, 24});
-    this->assert_same_step(mg_level.at(2).get(), {4, 8, 16, 20},
-                           {6, 10, 18, 22});
+    this->assert_same_step(mg_level.at(0), {0}, {26});
+    this->assert_same_step(mg_level.at(1), {2, 14}, {12, 24});
+    this->assert_same_step(mg_level.at(2), {4, 8, 16, 20}, {6, 10, 18, 22});
     // all use pre_smoother
-    this->assert_same_step(pre_smoother.at(1).get(), {1, 13, 25});
-    this->assert_same_step(pre_smoother.at(2).get(), {3, 7, 11, 15, 19, 23});
-    this->assert_same_step(coarsest_solver.get(), {5, 9, 17, 21});
+    this->assert_same_step(pre_smoother.at(1), {1, 13, 25});
+    this->assert_same_step(pre_smoother.at(2), {3, 7, 11, 15, 19, 23});
+    this->assert_same_step(coarsest_solver, {5, 9, 17, 21});
 }
 
 
@@ -939,14 +922,14 @@ TYPED_TEST(Multigrid, FCycleIndividual)
     global_step = 0;
     solver->apply(this->b2, this->x2);
 
-    this->assert_same_step(mg_level.at(0).get(), {0}, {19});
-    this->assert_same_step(mg_level.at(1).get(), {2, 13}, {11, 18});
-    this->assert_same_step(mg_level.at(2).get(), {4, 8, 15}, {5, 9, 16});
-    this->assert_same_step(pre_smoother.at(1).get(), {1, 12});
-    this->assert_same_step(pre_smoother.at(2).get(), {3, 7, 14});
-    // this->assert_same_step(mid_smoother.at(0).get(), {7});
-    this->assert_same_step(post_smoother.at(0).get(), {20});
-    this->assert_same_step(post_smoother.at(2).get(), {6, 10, 17});
+    this->assert_same_step(mg_level.at(0), {0}, {19});
+    this->assert_same_step(mg_level.at(1), {2, 13}, {11, 18});
+    this->assert_same_step(mg_level.at(2), {4, 8, 15}, {5, 9, 16});
+    this->assert_same_step(pre_smoother.at(1), {1, 12});
+    this->assert_same_step(pre_smoother.at(2), {3, 7, 14});
+    // this->assert_same_step(mid_smoother.at(0), {7});
+    this->assert_same_step(post_smoother.at(0), {20});
+    this->assert_same_step(post_smoother.at(2), {6, 10, 17});
 }
 
 
@@ -992,13 +975,13 @@ TYPED_TEST(Multigrid, FCycleIndividualMidUsePost)
     global_step = 0;
     solver->apply(this->b2, this->x2);
 
-    this->assert_same_step(mg_level.at(0).get(), {0}, {17});
-    this->assert_same_step(mg_level.at(1).get(), {2, 11}, {10, 16});
-    this->assert_same_step(mg_level.at(2).get(), {4, 7, 13}, {5, 8, 14});
-    this->assert_same_step(pre_smoother.at(1).get(), {1});
-    this->assert_same_step(pre_smoother.at(2).get(), {3, 12});
-    this->assert_same_step(post_smoother.at(0).get(), {18});
-    this->assert_same_step(post_smoother.at(2).get(), {6, 9, 15});
+    this->assert_same_step(mg_level.at(0), {0}, {17});
+    this->assert_same_step(mg_level.at(1), {2, 11}, {10, 16});
+    this->assert_same_step(mg_level.at(2), {4, 7, 13}, {5, 8, 14});
+    this->assert_same_step(pre_smoother.at(1), {1});
+    this->assert_same_step(pre_smoother.at(2), {3, 12});
+    this->assert_same_step(post_smoother.at(0), {18});
+    this->assert_same_step(post_smoother.at(2), {6, 9, 15});
 }
 
 
@@ -1043,13 +1026,13 @@ TYPED_TEST(Multigrid, FCycleIndividualMidUsePre)
     global_step = 0;
     solver->apply(this->b2, this->x2);
 
-    this->assert_same_step(mg_level.at(0).get(), {0}, {18});
-    this->assert_same_step(mg_level.at(1).get(), {2, 12}, {10, 17});
-    this->assert_same_step(mg_level.at(2).get(), {4, 7, 14}, {5, 8, 15});
-    this->assert_same_step(pre_smoother.at(1).get(), {1, 11});
-    this->assert_same_step(pre_smoother.at(2).get(), {3, 6, 13});
-    this->assert_same_step(post_smoother.at(0).get(), {19});
-    this->assert_same_step(post_smoother.at(2).get(), {9, 16});
+    this->assert_same_step(mg_level.at(0), {0}, {18});
+    this->assert_same_step(mg_level.at(1), {2, 12}, {10, 17});
+    this->assert_same_step(mg_level.at(2), {4, 7, 14}, {5, 8, 15});
+    this->assert_same_step(pre_smoother.at(1), {1, 11});
+    this->assert_same_step(pre_smoother.at(2), {3, 6, 13});
+    this->assert_same_step(post_smoother.at(0), {19});
+    this->assert_same_step(post_smoother.at(2), {9, 16});
 }
 
 
@@ -1094,14 +1077,14 @@ TYPED_TEST(Multigrid, FCycleIndividualMidUseStandalone)
     global_step = 0;
     solver->apply(this->b2, this->x2);
 
-    this->assert_same_step(mg_level.at(0).get(), {0}, {17});
-    this->assert_same_step(mg_level.at(1).get(), {2, 11}, {10, 16});
-    this->assert_same_step(mg_level.at(2).get(), {4, 7, 13}, {5, 8, 14});
-    this->assert_same_step(pre_smoother.at(1).get(), {1});
-    this->assert_same_step(pre_smoother.at(2).get(), {3, 12});
-    this->assert_same_step(post_smoother.at(0).get(), {18});
-    this->assert_same_step(post_smoother.at(2).get(), {9, 15});
-    this->assert_same_step(mid_smoother.at(2).get(), {6});
+    this->assert_same_step(mg_level.at(0), {0}, {17});
+    this->assert_same_step(mg_level.at(1), {2, 11}, {10, 16});
+    this->assert_same_step(mg_level.at(2), {4, 7, 13}, {5, 8, 14});
+    this->assert_same_step(pre_smoother.at(1), {1});
+    this->assert_same_step(pre_smoother.at(2), {3, 12});
+    this->assert_same_step(post_smoother.at(0), {18});
+    this->assert_same_step(post_smoother.at(2), {9, 15});
+    this->assert_same_step(mid_smoother.at(2), {6});
 }
 
 
@@ -1141,12 +1124,12 @@ TYPED_TEST(Multigrid, FCycleSame)
     global_step = 0;
     solver->apply(this->b2, this->x2);
 
-    this->assert_same_step(mg_level.at(0).get(), {0}, {24});
-    this->assert_same_step(mg_level.at(1).get(), {2, 16}, {13, 22});
-    this->assert_same_step(mg_level.at(2).get(), {4, 9, 18}, {6, 11, 20});
-    this->assert_same_step(pre_smoother.at(1).get(), {1, 14, 15, 23});
-    this->assert_same_step(pre_smoother.at(2).get(), {3, 7, 8, 12, 17, 21});
-    this->assert_same_step(coarsest_solver.get(), {5, 10, 19});
+    this->assert_same_step(mg_level.at(0), {0}, {24});
+    this->assert_same_step(mg_level.at(1), {2, 16}, {13, 22});
+    this->assert_same_step(mg_level.at(2), {4, 9, 18}, {6, 11, 20});
+    this->assert_same_step(pre_smoother.at(1), {1, 14, 15, 23});
+    this->assert_same_step(pre_smoother.at(2), {3, 7, 8, 12, 17, 21});
+    this->assert_same_step(coarsest_solver, {5, 10, 19});
 }
 
 
@@ -1188,13 +1171,13 @@ TYPED_TEST(Multigrid, FCycleSameMidUsePost)
     global_step = 0;
     solver->apply(this->b2, this->x2);
 
-    this->assert_same_step(mg_level.at(0).get(), {0}, {22});
-    this->assert_same_step(mg_level.at(1).get(), {2, 14}, {12, 20});
-    this->assert_same_step(mg_level.at(2).get(), {4, 8, 16}, {6, 10, 18});
+    this->assert_same_step(mg_level.at(0), {0}, {22});
+    this->assert_same_step(mg_level.at(1), {2, 14}, {12, 20});
+    this->assert_same_step(mg_level.at(2), {4, 8, 16}, {6, 10, 18});
     // all use pre_smoother
-    this->assert_same_step(pre_smoother.at(1).get(), {1, 13, 21});
-    this->assert_same_step(pre_smoother.at(2).get(), {3, 7, 11, 15, 19});
-    this->assert_same_step(coarsest_solver.get(), {5, 9, 17});
+    this->assert_same_step(pre_smoother.at(1), {1, 13, 21});
+    this->assert_same_step(pre_smoother.at(2), {3, 7, 11, 15, 19});
+    this->assert_same_step(coarsest_solver, {5, 9, 17});
 }
 
 
@@ -1235,13 +1218,13 @@ TYPED_TEST(Multigrid, FCycleSameMidUsePre)
     global_step = 0;
     solver->apply(this->b2, this->x2);
 
-    this->assert_same_step(mg_level.at(0).get(), {0}, {22});
-    this->assert_same_step(mg_level.at(1).get(), {2, 14}, {12, 20});
-    this->assert_same_step(mg_level.at(2).get(), {4, 8, 16}, {6, 10, 18});
+    this->assert_same_step(mg_level.at(0), {0}, {22});
+    this->assert_same_step(mg_level.at(1), {2, 14}, {12, 20});
+    this->assert_same_step(mg_level.at(2), {4, 8, 16}, {6, 10, 18});
     // all use pre_smoother
-    this->assert_same_step(pre_smoother.at(1).get(), {1, 13, 21});
-    this->assert_same_step(pre_smoother.at(2).get(), {3, 7, 11, 15, 19});
-    this->assert_same_step(coarsest_solver.get(), {5, 9, 17});
+    this->assert_same_step(pre_smoother.at(1), {1, 13, 21});
+    this->assert_same_step(pre_smoother.at(2), {3, 7, 11, 15, 19});
+    this->assert_same_step(coarsest_solver, {5, 9, 17});
 }
 
 
@@ -1267,11 +1250,11 @@ TYPED_TEST(Multigrid, CanChangeCycle)
 
     ASSERT_EQ(original, gko::solver::multigrid::cycle::v);
     ASSERT_EQ(solver->get_cycle(), gko::solver::multigrid::cycle::f);
-    this->assert_same_step(mg_level.at(0).get(), {0}, {11});
-    this->assert_same_step(mg_level.at(1).get(), {2, 7}, {4, 9});
+    this->assert_same_step(mg_level.at(0), {0}, {11});
+    this->assert_same_step(mg_level.at(1), {2, 7}, {4, 9});
     // all uses pre_smoother
-    this->assert_same_step(pre_smoother.at(1).get(), {1, 5, 6, 10});
-    this->assert_same_step(coarsest_solver.get(), {3, 8});
+    this->assert_same_step(pre_smoother.at(1), {1, 5, 6, 10});
+    this->assert_same_step(coarsest_solver, {3, 8});
 }
 
 
@@ -1305,8 +1288,8 @@ TYPED_TEST(Multigrid, ZeroGuessIgnoresInput)
 
     // putting zero to normal multigrid is the same behavior as using zero guess
     // in multigrid
-    normal_mg->apply(b.get(), zero.get());
-    zeroguess_mg->apply(b.get(), x.get());
+    normal_mg->apply(b, zero);
+    zeroguess_mg->apply(b, x);
 
     GKO_ASSERT_MTX_NEAR(zero, x, r<value_type>::value);
 }
@@ -1322,7 +1305,7 @@ TYPED_TEST(Multigrid, SolvesStencilSystemByVCycle)
     auto b = gko::initialize<Mtx>({-1.0, 3.0, 1.0}, this->exec);
     auto x = gko::initialize<Mtx>({0.0, 0.0, 0.0}, this->exec);
 
-    solver->apply(b.get(), x.get());
+    solver->apply(b, x);
 
     GKO_ASSERT_MTX_NEAR(x, l({1.0, 3.0, 2.0}), r<value_type>::value);
 }
@@ -1338,7 +1321,7 @@ TYPED_TEST(Multigrid, SolvesStencilSystemByWCycle)
     auto b = gko::initialize<Mtx>({-1.0, 3.0, 1.0}, this->exec);
     auto x = gko::initialize<Mtx>({0.0, 0.0, 0.0}, this->exec);
 
-    solver->apply(b.get(), x.get());
+    solver->apply(b, x);
 
     GKO_ASSERT_MTX_NEAR(x, l({1.0, 3.0, 2.0}), r<value_type>::value);
 }
@@ -1354,7 +1337,7 @@ TYPED_TEST(Multigrid, SolvesStencilSystemByFCycle)
     auto b = gko::initialize<Mtx>({-1.0, 3.0, 1.0}, this->exec);
     auto x = gko::initialize<Mtx>({0.0, 0.0, 0.0}, this->exec);
 
-    solver->apply(b.get(), x.get());
+    solver->apply(b, x);
 
     GKO_ASSERT_MTX_NEAR(x, l({1.0, 3.0, 2.0}), r<value_type>::value);
 }

--- a/reference/test/solver/upper_trs.cpp
+++ b/reference/test/solver/upper_trs.cpp
@@ -97,7 +97,7 @@ TYPED_TEST(UpperTrs, CanBeCopied)
     auto copy =
         Solver::build().on(this->exec)->generate(Mtx::create(this->exec));
 
-    copy->copy_from(gko::lend(this->upper_trs_solver));
+    copy->copy_from(this->upper_trs_solver);
     auto copy_mtx = copy->get_system_matrix();
 
     ASSERT_EQ(copy->get_size(), gko::dim<2>(3, 3));

--- a/reference/test/solver/upper_trs.cpp
+++ b/reference/test/solver/upper_trs.cpp
@@ -110,7 +110,7 @@ TYPED_TEST(UpperTrs, CanBeMoved)
     using Mtx = typename TestFixture::Mtx;
     auto copy = this->upper_trs_factory->generate(Mtx::create(this->exec));
 
-    copy->copy_from(std::move(this->upper_trs_solver));
+    copy->move_from(this->upper_trs_solver);
     auto copy_mtx = copy->get_system_matrix();
 
     ASSERT_EQ(copy->get_size(), gko::dim<2>(3, 3));

--- a/reference/test/solver/upper_trs.cpp
+++ b/reference/test/solver/upper_trs.cpp
@@ -101,7 +101,7 @@ TYPED_TEST(UpperTrs, CanBeCopied)
     auto copy_mtx = copy->get_system_matrix();
 
     ASSERT_EQ(copy->get_size(), gko::dim<2>(3, 3));
-    GKO_ASSERT_MTX_NEAR(copy_mtx.get(), this->csr_mtx.get(), 0);
+    GKO_ASSERT_MTX_NEAR(copy_mtx, this->csr_mtx, 0);
 }
 
 
@@ -114,7 +114,7 @@ TYPED_TEST(UpperTrs, CanBeMoved)
     auto copy_mtx = copy->get_system_matrix();
 
     ASSERT_EQ(copy->get_size(), gko::dim<2>(3, 3));
-    GKO_ASSERT_MTX_NEAR(copy_mtx.get(), this->csr_mtx.get(), 0);
+    GKO_ASSERT_MTX_NEAR(copy_mtx, this->csr_mtx, 0);
 }
 
 
@@ -125,7 +125,7 @@ TYPED_TEST(UpperTrs, CanBeCloned)
     auto clone_mtx = clone->get_system_matrix();
 
     ASSERT_EQ(clone->get_size(), gko::dim<2>(3, 3));
-    GKO_ASSERT_MTX_NEAR(clone_mtx.get(), this->csr_mtx.get(), 0);
+    GKO_ASSERT_MTX_NEAR(clone_mtx, this->csr_mtx, 0);
 }
 
 

--- a/reference/test/solver/upper_trs_kernels.cpp
+++ b/reference/test/solver/upper_trs_kernels.cpp
@@ -124,7 +124,7 @@ TYPED_TEST(UpperTrs, SolvesTriangularSystem)
     auto x = gko::initialize<Mtx>({0.0, 0.0, 0.0}, this->exec);
     auto solver = this->upper_trs_factory->generate(this->mtx);
 
-    solver->apply(b.get(), x.get());
+    solver->apply(b, x);
 
     GKO_ASSERT_MTX_NEAR(x, l({13.0, -4.0, 3.0}), r<value_type>::value);
 }
@@ -139,7 +139,7 @@ TYPED_TEST(UpperTrs, SolvesTriangularSystemMixed)
     auto x = gko::initialize<Mtx>({0.0, 0.0, 0.0}, this->exec);
     auto solver = this->upper_trs_factory->generate(this->mtx);
 
-    solver->apply(b.get(), x.get());
+    solver->apply(b, x);
 
     GKO_ASSERT_MTX_NEAR(x, l({13.0, -4.0, 3.0}),
                         (r_mixed<value_type, other_value_type>()));
@@ -159,7 +159,7 @@ TYPED_TEST(UpperTrs, SolvesTriangularSystemComplex)
         this->exec);
     auto solver = this->upper_trs_factory->generate(this->mtx);
 
-    solver->apply(b.get(), x.get());
+    solver->apply(b, x);
 
     GKO_ASSERT_MTX_NEAR(x,
                         l({value_type{13.0, -26.0}, value_type{-4.0, 8.0},
@@ -182,7 +182,7 @@ TYPED_TEST(UpperTrs, SolvesTriangularSystemMixedComplex)
         this->exec);
     auto solver = this->upper_trs_factory->generate(this->mtx);
 
-    solver->apply(b.get(), x.get());
+    solver->apply(b, x);
 
     GKO_ASSERT_MTX_NEAR(x,
                         l({value_type{13.0, -26.0}, value_type{-4.0, 8.0},
@@ -202,7 +202,7 @@ TYPED_TEST(UpperTrs, SolvesMultipleTriangularSystems)
         {I<T>{0.0, 0.0}, I<T>{0.0, 0.0}, I<T>{0.0, 0.0}}, this->exec);
     auto solver = this->upper_trs_factory_mrhs->generate(this->mtx);
 
-    solver->apply(b.get(), x.get());
+    solver->apply(b, x);
 
     GKO_ASSERT_MTX_NEAR(x, l({{13.0, -6.0}, {-4.0, 3.0}, {3.0, -1.0}}),
                         r<value_type>::value);
@@ -218,7 +218,7 @@ TYPED_TEST(UpperTrs, SolvesNonUnitTriangularSystem)
     auto x = gko::initialize<Mtx>({0.0, 0.0, 0.0}, this->exec);
     auto solver = this->upper_trs_factory->generate(this->mtx2);
 
-    solver->apply(b.get(), x.get());
+    solver->apply(b, x);
 
     GKO_ASSERT_MTX_NEAR(x, l({1.0, 3.0, -1.0}), r<value_type>::value);
 }
@@ -234,7 +234,7 @@ TYPED_TEST(UpperTrs, SolvesTriangularSystemUsingAdvancedApply)
     auto x = gko::initialize<Mtx>({1.0, -1.0, 1.0}, this->exec);
     auto solver = this->upper_trs_factory->generate(this->mtx);
 
-    solver->apply(alpha.get(), b.get(), beta.get(), x.get());
+    solver->apply(alpha, b, beta, x);
 
     GKO_ASSERT_MTX_NEAR(x, l({25.0, -7.0, 5.0}), r<value_type>::value);
 }
@@ -251,7 +251,7 @@ TYPED_TEST(UpperTrs, SolvesTriangularSystemUsingAdvancedApplyMixed)
     auto x = gko::initialize<Mtx>({1.0, -1.0, 1.0}, this->exec);
     auto solver = this->upper_trs_factory->generate(this->mtx);
 
-    solver->apply(alpha.get(), b.get(), beta.get(), x.get());
+    solver->apply(alpha, b, beta, x);
 
     GKO_ASSERT_MTX_NEAR(x, l({25.0, -7.0, 5.0}),
                         (r_mixed<value_type, other_value_type>()));
@@ -273,7 +273,7 @@ TYPED_TEST(UpperTrs, SolvesTriangularSystemUsingAdvancedApplyComplex)
         this->exec);
     auto solver = this->upper_trs_factory->generate(this->mtx);
 
-    solver->apply(alpha.get(), b.get(), beta.get(), x.get());
+    solver->apply(alpha, b, beta, x);
 
     GKO_ASSERT_MTX_NEAR(x,
                         l({value_type{25.0, -50.0}, value_type{-7.0, 14.0},
@@ -298,7 +298,7 @@ TYPED_TEST(UpperTrs, SolvesTriangularSystemUsingAdvancedApplyMixedComplex)
         this->exec);
     auto solver = this->upper_trs_factory->generate(this->mtx);
 
-    solver->apply(alpha.get(), b.get(), beta.get(), x.get());
+    solver->apply(alpha, b, beta, x);
 
     GKO_ASSERT_MTX_NEAR(x,
                         l({value_type{25.0, -50.0}, value_type{-7.0, 14.0},
@@ -320,7 +320,7 @@ TYPED_TEST(UpperTrs, SolvesMultipleTriangularSystemsUsingAdvancedApply)
         {I<T>{1.0, 2.0}, I<T>{-1.0, -1.0}, I<T>{1.0, -2.0}}, this->exec);
     auto solver = this->upper_trs_factory_mrhs->generate(this->mtx);
 
-    solver->apply(alpha.get(), b.get(), beta.get(), x.get());
+    solver->apply(alpha, b, beta, x);
 
     GKO_ASSERT_MTX_NEAR(x, l({{-9.0, -6.0}, {1.0, 2.0}, {0.0, -7.0}}),
                         r<value_type>::value);
@@ -336,7 +336,7 @@ TYPED_TEST(UpperTrs, SolvesBigDenseSystem)
     auto x = gko::initialize<Mtx>({0.0, 0.0, 0.0, 0.0, 0.0}, this->exec);
     auto solver = this->upper_trs_factory->generate(this->mtx_big_upper);
 
-    solver->apply(b.get(), x.get());
+    solver->apply(b, x);
 
     GKO_ASSERT_MTX_NEAR(x, l({-1.0, 4.0, 9.0, 3.0, -2.0}),
                         r<value_type>::value * 1e3);
@@ -352,7 +352,7 @@ TYPED_TEST(UpperTrs, SolvesBigDenseSystemWithUnitDiagonal)
     auto x = gko::initialize<Mtx>({0.0, 0.0, 0.0, 0.0, 0.0}, this->exec);
     auto solver = this->upper_trs_factory_unit->generate(this->mtx_big_upper);
 
-    solver->apply(b.get(), x.get());
+    solver->apply(b, x);
 
     GKO_ASSERT_MTX_NEAR(x, l({-1.0, 4.0, 9.0, 3.0, -2.0}),
                         r<value_type>::value * 1e3);
@@ -368,7 +368,7 @@ TYPED_TEST(UpperTrs, SolveBigDenseSystemIgnoresNonTriangleEntries)
     auto x = gko::initialize<Mtx>({0.0, 0.0, 0.0, 0.0, 0.0}, this->exec);
     auto solver = this->upper_trs_factory->generate(this->mtx_big_general);
 
-    solver->apply(b.get(), x.get());
+    solver->apply(b, x);
 
     GKO_ASSERT_MTX_NEAR(x, l({-1.0, 4.0, 9.0, 3.0, -2.0}),
                         r<value_type>::value * 1e3);
@@ -383,7 +383,7 @@ TYPED_TEST(UpperTrs, SolvesTransposedTriangularSystem)
     auto x = gko::initialize<Mtx>({0.0, 0.0, 0.0}, this->exec);
     auto solver = this->upper_trs_factory->generate(this->mtx);
 
-    solver->transpose()->apply(b.get(), x.get());
+    solver->transpose()->apply(b, x);
 
     GKO_ASSERT_MTX_NEAR(x, l({4.0, -10.0, 19.0}), r<value_type>::value);
 }
@@ -397,7 +397,7 @@ TYPED_TEST(UpperTrs, SolvesConjTransposedTriangularSystem)
     auto x = gko::initialize<Mtx>({0.0, 0.0, 0.0}, this->exec);
     auto solver = this->upper_trs_factory->generate(this->mtx);
 
-    solver->conj_transpose()->apply(b.get(), x.get());
+    solver->conj_transpose()->apply(b, x);
 
     GKO_ASSERT_MTX_NEAR(x, l({4.0, -10.0, 19.0}), r<value_type>::value);
 }

--- a/reference/test/stop/residual_norm_kernels.cpp
+++ b/reference/test/stop/residual_norm_kernels.cpp
@@ -151,30 +151,24 @@ TYPED_TEST(ResidualNorm, WaitsTillResidualGoal)
     {
         auto res_norm = gko::initialize<NormVector>({10.0}, this->exec_);
         auto rhs_norm = gko::initialize<NormVector>({100.0}, this->exec_);
-        gko::as<Mtx>(rhs)->compute_norm2(rhs_norm.get());
+        gko::as<Mtx>(rhs)->compute_norm2(rhs_norm);
         constexpr gko::uint8 RelativeStoppingId{1};
         bool one_changed{};
         gko::array<gko::stopping_status> stop_status(this->exec_, 1);
         stop_status.get_data()[0].reset();
 
-        ASSERT_FALSE(
-            rhs_criterion->update()
-                .residual_norm(res_norm.get())
-                .check(RelativeStoppingId, true, &stop_status, &one_changed));
+        ASSERT_FALSE(rhs_criterion->update().residual_norm(res_norm).check(
+            RelativeStoppingId, true, &stop_status, &one_changed));
 
         res_norm->at(0) = r<TypeParam>::value * 1.1 * rhs_norm->at(0);
-        ASSERT_FALSE(
-            rhs_criterion->update()
-                .residual_norm(res_norm.get())
-                .check(RelativeStoppingId, true, &stop_status, &one_changed));
+        ASSERT_FALSE(rhs_criterion->update().residual_norm(res_norm).check(
+            RelativeStoppingId, true, &stop_status, &one_changed));
         ASSERT_EQ(stop_status.get_data()[0].has_converged(), false);
         ASSERT_EQ(one_changed, false);
 
         res_norm->at(0) = r<TypeParam>::value * 0.9 * rhs_norm->at(0);
-        ASSERT_TRUE(
-            rhs_criterion->update()
-                .residual_norm(res_norm.get())
-                .check(RelativeStoppingId, true, &stop_status, &one_changed));
+        ASSERT_TRUE(rhs_criterion->update().residual_norm(res_norm).check(
+            RelativeStoppingId, true, &stop_status, &one_changed));
         ASSERT_EQ(stop_status.get_data()[0].has_converged(), true);
         ASSERT_EQ(one_changed, true);
     }
@@ -186,24 +180,18 @@ TYPED_TEST(ResidualNorm, WaitsTillResidualGoal)
         gko::array<gko::stopping_status> stop_status(this->exec_, 1);
         stop_status.get_data()[0].reset();
 
-        ASSERT_FALSE(
-            rel_criterion->update()
-                .residual_norm(res_norm.get())
-                .check(RelativeStoppingId, true, &stop_status, &one_changed));
+        ASSERT_FALSE(rel_criterion->update().residual_norm(res_norm).check(
+            RelativeStoppingId, true, &stop_status, &one_changed));
 
         res_norm->at(0) = r<TypeParam>::value * 1.1 * init_res_val;
-        ASSERT_FALSE(
-            rel_criterion->update()
-                .residual_norm(res_norm.get())
-                .check(RelativeStoppingId, true, &stop_status, &one_changed));
+        ASSERT_FALSE(rel_criterion->update().residual_norm(res_norm).check(
+            RelativeStoppingId, true, &stop_status, &one_changed));
         ASSERT_EQ(stop_status.get_data()[0].has_converged(), false);
         ASSERT_EQ(one_changed, false);
 
         res_norm->at(0) = r<TypeParam>::value * 0.9 * init_res_val;
-        ASSERT_TRUE(
-            rel_criterion->update()
-                .residual_norm(res_norm.get())
-                .check(RelativeStoppingId, true, &stop_status, &one_changed));
+        ASSERT_TRUE(rel_criterion->update().residual_norm(res_norm).check(
+            RelativeStoppingId, true, &stop_status, &one_changed));
         ASSERT_EQ(stop_status.get_data()[0].has_converged(), true);
         ASSERT_EQ(one_changed, true);
     }
@@ -214,24 +202,18 @@ TYPED_TEST(ResidualNorm, WaitsTillResidualGoal)
         gko::array<gko::stopping_status> stop_status(this->exec_, 1);
         stop_status.get_data()[0].reset();
 
-        ASSERT_FALSE(
-            abs_criterion->update()
-                .residual_norm(res_norm.get())
-                .check(RelativeStoppingId, true, &stop_status, &one_changed));
+        ASSERT_FALSE(abs_criterion->update().residual_norm(res_norm).check(
+            RelativeStoppingId, true, &stop_status, &one_changed));
 
         res_norm->at(0) = r<TypeParam>::value * 1.1;
-        ASSERT_FALSE(
-            abs_criterion->update()
-                .residual_norm(res_norm.get())
-                .check(RelativeStoppingId, true, &stop_status, &one_changed));
+        ASSERT_FALSE(abs_criterion->update().residual_norm(res_norm).check(
+            RelativeStoppingId, true, &stop_status, &one_changed));
         ASSERT_EQ(stop_status.get_data()[0].has_converged(), false);
         ASSERT_EQ(one_changed, false);
 
         res_norm->at(0) = r<TypeParam>::value * 0.9;
-        ASSERT_TRUE(
-            abs_criterion->update()
-                .residual_norm(res_norm.get())
-                .check(RelativeStoppingId, true, &stop_status, &one_changed));
+        ASSERT_TRUE(abs_criterion->update().residual_norm(res_norm).check(
+            RelativeStoppingId, true, &stop_status, &one_changed));
         ASSERT_EQ(stop_status.get_data()[0].has_converged(), true);
         ASSERT_EQ(one_changed, true);
     }
@@ -258,17 +240,15 @@ TYPED_TEST(ResidualNorm, SelfCalulatesThrowWithoutMatrix)
     {
         auto solution = gko::initialize<Mtx>({rhs_val - T{10.0}}, this->exec_);
         auto rhs_norm = gko::initialize<NormVector>({100.0}, this->exec_);
-        gko::as<Mtx>(rhs)->compute_norm2(rhs_norm.get());
+        gko::as<Mtx>(rhs)->compute_norm2(rhs_norm);
         constexpr gko::uint8 RelativeStoppingId{1};
         bool one_changed{};
         gko::array<gko::stopping_status> stop_status(this->exec_, 1);
         stop_status.get_data()[0].reset();
 
-        ASSERT_THROW(
-            rhs_criterion->update()
-                .solution(solution.get())
-                .check(RelativeStoppingId, true, &stop_status, &one_changed),
-            gko::NotSupported);
+        ASSERT_THROW(rhs_criterion->update().solution(solution).check(
+                         RelativeStoppingId, true, &stop_status, &one_changed),
+                     gko::NotSupported);
     }
     {
         T initial_norm = 100.0;
@@ -279,11 +259,9 @@ TYPED_TEST(ResidualNorm, SelfCalulatesThrowWithoutMatrix)
         gko::array<gko::stopping_status> stop_status(this->exec_, 1);
         stop_status.get_data()[0].reset();
 
-        ASSERT_THROW(
-            rel_criterion->update()
-                .solution(solution.get())
-                .check(RelativeStoppingId, true, &stop_status, &one_changed),
-            gko::NotSupported);
+        ASSERT_THROW(rel_criterion->update().solution(solution).check(
+                         RelativeStoppingId, true, &stop_status, &one_changed),
+                     gko::NotSupported);
     }
     {
         auto solution = gko::initialize<Mtx>({rhs_val - T{100.0}}, this->exec_);
@@ -292,11 +270,9 @@ TYPED_TEST(ResidualNorm, SelfCalulatesThrowWithoutMatrix)
         gko::array<gko::stopping_status> stop_status(this->exec_, 1);
         stop_status.get_data()[0].reset();
 
-        ASSERT_THROW(
-            abs_criterion->update()
-                .solution(solution.get())
-                .check(RelativeStoppingId, true, &stop_status, &one_changed),
-            gko::NotSupported);
+        ASSERT_THROW(abs_criterion->update().solution(solution).check(
+                         RelativeStoppingId, true, &stop_status, &one_changed),
+                     gko::NotSupported);
     }
 }
 
@@ -320,11 +296,9 @@ TYPED_TEST(ResidualNorm, RelativeSelfCalulatesThrowWithoutRhs)
     gko::array<gko::stopping_status> stop_status(this->exec_, 1);
     stop_status.get_data()[0].reset();
 
-    ASSERT_THROW(
-        rel_criterion->update()
-            .solution(solution.get())
-            .check(RelativeStoppingId, true, &stop_status, &one_changed),
-        gko::NotSupported);
+    ASSERT_THROW(rel_criterion->update().solution(solution).check(
+                     RelativeStoppingId, true, &stop_status, &one_changed),
+                 gko::NotSupported);
 }
 
 
@@ -349,30 +323,24 @@ TYPED_TEST(ResidualNorm, SelfCalulatesAndWaitsTillResidualGoal)
     {
         auto solution = gko::initialize<Mtx>({rhs_val - T{10.0}}, this->exec_);
         auto rhs_norm = gko::initialize<NormVector>({100.0}, this->exec_);
-        gko::as<Mtx>(rhs)->compute_norm2(rhs_norm.get());
+        gko::as<Mtx>(rhs)->compute_norm2(rhs_norm);
         constexpr gko::uint8 RelativeStoppingId{1};
         bool one_changed{};
         gko::array<gko::stopping_status> stop_status(this->exec_, 1);
         stop_status.get_data()[0].reset();
 
-        ASSERT_FALSE(
-            rhs_criterion->update()
-                .solution(solution.get())
-                .check(RelativeStoppingId, true, &stop_status, &one_changed));
+        ASSERT_FALSE(rhs_criterion->update().solution(solution).check(
+            RelativeStoppingId, true, &stop_status, &one_changed));
 
         solution->at(0) = rhs_val - r<T>::value * T{1.1} * rhs_norm->at(0);
-        ASSERT_FALSE(
-            rhs_criterion->update()
-                .solution(solution.get())
-                .check(RelativeStoppingId, true, &stop_status, &one_changed));
+        ASSERT_FALSE(rhs_criterion->update().solution(solution).check(
+            RelativeStoppingId, true, &stop_status, &one_changed));
         ASSERT_EQ(stop_status.get_data()[0].has_converged(), false);
         ASSERT_EQ(one_changed, false);
 
         solution->at(0) = rhs_val - r<T>::value * T{0.5} * rhs_norm->at(0);
-        ASSERT_TRUE(
-            rhs_criterion->update()
-                .solution(solution.get())
-                .check(RelativeStoppingId, true, &stop_status, &one_changed));
+        ASSERT_TRUE(rhs_criterion->update().solution(solution).check(
+            RelativeStoppingId, true, &stop_status, &one_changed));
         ASSERT_EQ(stop_status.get_data()[0].has_converged(), true);
         ASSERT_EQ(one_changed, true);
     }
@@ -385,24 +353,18 @@ TYPED_TEST(ResidualNorm, SelfCalulatesAndWaitsTillResidualGoal)
         gko::array<gko::stopping_status> stop_status(this->exec_, 1);
         stop_status.get_data()[0].reset();
 
-        ASSERT_FALSE(
-            rel_criterion->update()
-                .solution(solution.get())
-                .check(RelativeStoppingId, true, &stop_status, &one_changed));
+        ASSERT_FALSE(rel_criterion->update().solution(solution).check(
+            RelativeStoppingId, true, &stop_status, &one_changed));
 
         solution->at(0) = rhs_val - r<T>::value * T{1.1} * initial_norm;
-        ASSERT_FALSE(
-            rel_criterion->update()
-                .solution(solution.get())
-                .check(RelativeStoppingId, true, &stop_status, &one_changed));
+        ASSERT_FALSE(rel_criterion->update().solution(solution).check(
+            RelativeStoppingId, true, &stop_status, &one_changed));
         ASSERT_EQ(stop_status.get_data()[0].has_converged(), false);
         ASSERT_EQ(one_changed, false);
 
         solution->at(0) = rhs_val - r<T>::value * T{0.5} * initial_norm;
-        ASSERT_TRUE(
-            rel_criterion->update()
-                .solution(solution.get())
-                .check(RelativeStoppingId, true, &stop_status, &one_changed));
+        ASSERT_TRUE(rel_criterion->update().solution(solution).check(
+            RelativeStoppingId, true, &stop_status, &one_changed));
         ASSERT_EQ(stop_status.get_data()[0].has_converged(), true);
         ASSERT_EQ(one_changed, true);
     }
@@ -413,24 +375,18 @@ TYPED_TEST(ResidualNorm, SelfCalulatesAndWaitsTillResidualGoal)
         gko::array<gko::stopping_status> stop_status(this->exec_, 1);
         stop_status.get_data()[0].reset();
 
-        ASSERT_FALSE(
-            abs_criterion->update()
-                .solution(solution.get())
-                .check(RelativeStoppingId, true, &stop_status, &one_changed));
+        ASSERT_FALSE(abs_criterion->update().solution(solution).check(
+            RelativeStoppingId, true, &stop_status, &one_changed));
 
         solution->at(0) = rhs_val - r<T>::value * T{1.2};
-        ASSERT_FALSE(
-            abs_criterion->update()
-                .solution(solution.get())
-                .check(RelativeStoppingId, true, &stop_status, &one_changed));
+        ASSERT_FALSE(abs_criterion->update().solution(solution).check(
+            RelativeStoppingId, true, &stop_status, &one_changed));
         ASSERT_EQ(stop_status.get_data()[0].has_converged(), false);
         ASSERT_EQ(one_changed, false);
 
         solution->at(0) = rhs_val - r<T>::value * T{0.5};
-        ASSERT_TRUE(
-            abs_criterion->update()
-                .solution(solution.get())
-                .check(RelativeStoppingId, true, &stop_status, &one_changed));
+        ASSERT_TRUE(abs_criterion->update().solution(solution).check(
+            RelativeStoppingId, true, &stop_status, &one_changed));
         ASSERT_EQ(stop_status.get_data()[0].has_converged(), true);
         ASSERT_EQ(one_changed, true);
     }
@@ -457,31 +413,25 @@ TYPED_TEST(ResidualNorm, WaitsTillResidualGoalMultipleRHS)
             gko::initialize<NormVector>({I<T_nc>{100.0, 100.0}}, this->exec_);
         auto rhs_norm =
             gko::initialize<NormVector>({I<T_nc>{100.0, 100.0}}, this->exec_);
-        gko::as<Mtx>(rhs)->compute_norm2(rhs_norm.get());
+        gko::as<Mtx>(rhs)->compute_norm2(rhs_norm);
         bool one_changed{};
         constexpr gko::uint8 RelativeStoppingId{1};
         gko::array<gko::stopping_status> stop_status(this->exec_, 2);
         stop_status.get_data()[0].reset();
         stop_status.get_data()[1].reset();
 
-        ASSERT_FALSE(
-            rhs_criterion->update()
-                .residual_norm(res_norm.get())
-                .check(RelativeStoppingId, true, &stop_status, &one_changed));
+        ASSERT_FALSE(rhs_criterion->update().residual_norm(res_norm).check(
+            RelativeStoppingId, true, &stop_status, &one_changed));
 
         res_norm->at(0, 0) = r<TypeParam>::value * 0.9 * rhs_norm->at(0, 0);
-        ASSERT_FALSE(
-            rhs_criterion->update()
-                .residual_norm(res_norm.get())
-                .check(RelativeStoppingId, true, &stop_status, &one_changed));
+        ASSERT_FALSE(rhs_criterion->update().residual_norm(res_norm).check(
+            RelativeStoppingId, true, &stop_status, &one_changed));
         ASSERT_EQ(stop_status.get_data()[0].has_converged(), true);
         ASSERT_EQ(one_changed, true);
 
         res_norm->at(0, 1) = r<TypeParam>::value * 0.9 * rhs_norm->at(0, 1);
-        ASSERT_TRUE(
-            rhs_criterion->update()
-                .residual_norm(res_norm.get())
-                .check(RelativeStoppingId, true, &stop_status, &one_changed));
+        ASSERT_TRUE(rhs_criterion->update().residual_norm(res_norm).check(
+            RelativeStoppingId, true, &stop_status, &one_changed));
         ASSERT_EQ(stop_status.get_data()[1].has_converged(), true);
         ASSERT_EQ(one_changed, true);
     }
@@ -494,24 +444,18 @@ TYPED_TEST(ResidualNorm, WaitsTillResidualGoalMultipleRHS)
         stop_status.get_data()[0].reset();
         stop_status.get_data()[1].reset();
 
-        ASSERT_FALSE(
-            rel_criterion->update()
-                .residual_norm(res_norm.get())
-                .check(RelativeStoppingId, true, &stop_status, &one_changed));
+        ASSERT_FALSE(rel_criterion->update().residual_norm(res_norm).check(
+            RelativeStoppingId, true, &stop_status, &one_changed));
 
         res_norm->at(0, 0) = r<TypeParam>::value * 0.9 * res_norm->at(0, 0);
-        ASSERT_FALSE(
-            rel_criterion->update()
-                .residual_norm(res_norm.get())
-                .check(RelativeStoppingId, true, &stop_status, &one_changed));
+        ASSERT_FALSE(rel_criterion->update().residual_norm(res_norm).check(
+            RelativeStoppingId, true, &stop_status, &one_changed));
         ASSERT_EQ(stop_status.get_data()[0].has_converged(), true);
         ASSERT_EQ(one_changed, true);
 
         res_norm->at(0, 1) = r<TypeParam>::value * 0.9 * res_norm->at(0, 1);
-        ASSERT_TRUE(
-            rel_criterion->update()
-                .residual_norm(res_norm.get())
-                .check(RelativeStoppingId, true, &stop_status, &one_changed));
+        ASSERT_TRUE(rel_criterion->update().residual_norm(res_norm).check(
+            RelativeStoppingId, true, &stop_status, &one_changed));
         ASSERT_EQ(stop_status.get_data()[1].has_converged(), true);
         ASSERT_EQ(one_changed, true);
     }
@@ -524,24 +468,18 @@ TYPED_TEST(ResidualNorm, WaitsTillResidualGoalMultipleRHS)
         stop_status.get_data()[0].reset();
         stop_status.get_data()[1].reset();
 
-        ASSERT_FALSE(
-            abs_criterion->update()
-                .residual_norm(res_norm.get())
-                .check(RelativeStoppingId, true, &stop_status, &one_changed));
+        ASSERT_FALSE(abs_criterion->update().residual_norm(res_norm).check(
+            RelativeStoppingId, true, &stop_status, &one_changed));
 
         res_norm->at(0, 0) = r<TypeParam>::value * 0.9;
-        ASSERT_FALSE(
-            abs_criterion->update()
-                .residual_norm(res_norm.get())
-                .check(RelativeStoppingId, true, &stop_status, &one_changed));
+        ASSERT_FALSE(abs_criterion->update().residual_norm(res_norm).check(
+            RelativeStoppingId, true, &stop_status, &one_changed));
         ASSERT_EQ(stop_status.get_data()[0].has_converged(), true);
         ASSERT_EQ(one_changed, true);
 
         res_norm->at(0, 1) = r<TypeParam>::value * 0.9;
-        ASSERT_TRUE(
-            abs_criterion->update()
-                .residual_norm(res_norm.get())
-                .check(RelativeStoppingId, true, &stop_status, &one_changed));
+        ASSERT_TRUE(abs_criterion->update().residual_norm(res_norm).check(
+            RelativeStoppingId, true, &stop_status, &one_changed));
         ASSERT_EQ(stop_status.get_data()[1].has_converged(), true);
         ASSERT_EQ(one_changed, true);
     }
@@ -600,24 +538,18 @@ TYPED_TEST(ResidualNormWithInitialResnorm, WaitsTillResidualGoal)
     gko::array<gko::stopping_status> stop_status(this->exec_, 1);
     stop_status.get_data()[0].reset();
 
-    ASSERT_FALSE(
-        criterion->update()
-            .residual_norm(res_norm.get())
-            .check(RelativeStoppingId, true, &stop_status, &one_changed));
+    ASSERT_FALSE(criterion->update().residual_norm(res_norm).check(
+        RelativeStoppingId, true, &stop_status, &one_changed));
 
     res_norm->at(0) = r<TypeParam>::value * 1.1 * init_res_val;
-    ASSERT_FALSE(
-        criterion->update()
-            .residual_norm(res_norm.get())
-            .check(RelativeStoppingId, true, &stop_status, &one_changed));
+    ASSERT_FALSE(criterion->update().residual_norm(res_norm).check(
+        RelativeStoppingId, true, &stop_status, &one_changed));
     ASSERT_EQ(stop_status.get_data()[0].has_converged(), false);
     ASSERT_EQ(one_changed, false);
 
     res_norm->at(0) = r<TypeParam>::value * 0.9 * init_res_val;
-    ASSERT_TRUE(
-        criterion->update()
-            .residual_norm(res_norm.get())
-            .check(RelativeStoppingId, true, &stop_status, &one_changed));
+    ASSERT_TRUE(criterion->update().residual_norm(res_norm).check(
+        RelativeStoppingId, true, &stop_status, &one_changed));
     ASSERT_EQ(stop_status.get_data()[0].has_converged(), true);
     ASSERT_EQ(one_changed, true);
 }
@@ -643,17 +575,17 @@ TYPED_TEST(ResidualNormWithInitialResnorm,
     gko::array<gko::stopping_status> stop_status(this->exec_, 1);
     stop_status.get_data()[0].reset();
 
-    ASSERT_FALSE(criterion->update().solution(x.get()).check(
+    ASSERT_FALSE(criterion->update().solution(x).check(
         RelativeStoppingId, true, &stop_status, &one_changed));
 
     x->at(0) = rhs_val - r<T>::value * T{1.1} * initial_res;
-    ASSERT_FALSE(criterion->update().solution(x.get()).check(
+    ASSERT_FALSE(criterion->update().solution(x).check(
         RelativeStoppingId, true, &stop_status, &one_changed));
     ASSERT_EQ(stop_status.get_data()[0].has_converged(), false);
     ASSERT_EQ(one_changed, false);
 
     x->at(0) = rhs_val - r<T>::value * T{0.5} * initial_res;
-    ASSERT_TRUE(criterion->update().solution(x.get()).check(
+    ASSERT_TRUE(criterion->update().solution(x).check(
         RelativeStoppingId, true, &stop_status, &one_changed));
     ASSERT_EQ(stop_status.get_data()[0].has_converged(), true);
     ASSERT_EQ(one_changed, true);
@@ -678,24 +610,18 @@ TYPED_TEST(ResidualNormWithInitialResnorm, WaitsTillResidualGoalMultipleRHS)
     stop_status.get_data()[0].reset();
     stop_status.get_data()[1].reset();
 
-    ASSERT_FALSE(
-        criterion->update()
-            .residual_norm(res_norm.get())
-            .check(RelativeStoppingId, true, &stop_status, &one_changed));
+    ASSERT_FALSE(criterion->update().residual_norm(res_norm).check(
+        RelativeStoppingId, true, &stop_status, &one_changed));
 
     res_norm->at(0, 0) = r<TypeParam>::value * 0.9 * res_norm->at(0, 0);
-    ASSERT_FALSE(
-        criterion->update()
-            .residual_norm(res_norm.get())
-            .check(RelativeStoppingId, true, &stop_status, &one_changed));
+    ASSERT_FALSE(criterion->update().residual_norm(res_norm).check(
+        RelativeStoppingId, true, &stop_status, &one_changed));
     ASSERT_EQ(stop_status.get_data()[0].has_converged(), true);
     ASSERT_EQ(one_changed, true);
 
     res_norm->at(0, 1) = r<TypeParam>::value * 0.9 * res_norm->at(0, 1);
-    ASSERT_TRUE(
-        criterion->update()
-            .residual_norm(res_norm.get())
-            .check(RelativeStoppingId, true, &stop_status, &one_changed));
+    ASSERT_TRUE(criterion->update().residual_norm(res_norm).check(
+        RelativeStoppingId, true, &stop_status, &one_changed));
     ASSERT_EQ(stop_status.get_data()[1].has_converged(), true);
     ASSERT_EQ(one_changed, true);
 }
@@ -761,7 +687,7 @@ TYPED_TEST(ResidualNormWithRhsNorm, WaitsTillResidualGoal)
     auto initial_res = gko::initialize<Mtx>({100.0}, this->exec_);
     std::shared_ptr<gko::LinOp> rhs = gko::initialize<Mtx>({10.0}, this->exec_);
     auto rhs_norm = gko::initialize<NormVector>({I<T_nc>{0.0}}, this->exec_);
-    gko::as<Mtx>(rhs)->compute_norm2(rhs_norm.get());
+    gko::as<Mtx>(rhs)->compute_norm2(rhs_norm);
     auto res_norm = gko::initialize<NormVector>({100.0}, this->exec_);
     auto criterion =
         this->factory_->generate(nullptr, rhs, nullptr, initial_res.get());
@@ -770,24 +696,18 @@ TYPED_TEST(ResidualNormWithRhsNorm, WaitsTillResidualGoal)
     gko::array<gko::stopping_status> stop_status(this->exec_, 1);
     stop_status.get_data()[0].reset();
 
-    ASSERT_FALSE(
-        criterion->update()
-            .residual_norm(res_norm.get())
-            .check(RelativeStoppingId, true, &stop_status, &one_changed));
+    ASSERT_FALSE(criterion->update().residual_norm(res_norm).check(
+        RelativeStoppingId, true, &stop_status, &one_changed));
 
     res_norm->at(0) = r<TypeParam>::value * 1.1 * rhs_norm->at(0);
-    ASSERT_FALSE(
-        criterion->update()
-            .residual_norm(res_norm.get())
-            .check(RelativeStoppingId, true, &stop_status, &one_changed));
+    ASSERT_FALSE(criterion->update().residual_norm(res_norm).check(
+        RelativeStoppingId, true, &stop_status, &one_changed));
     ASSERT_EQ(stop_status.get_data()[0].has_converged(), false);
     ASSERT_EQ(one_changed, false);
 
     res_norm->at(0) = r<TypeParam>::value * 0.9 * rhs_norm->at(0);
-    ASSERT_TRUE(
-        criterion->update()
-            .residual_norm(res_norm.get())
-            .check(RelativeStoppingId, true, &stop_status, &one_changed));
+    ASSERT_TRUE(criterion->update().residual_norm(res_norm).check(
+        RelativeStoppingId, true, &stop_status, &one_changed));
     ASSERT_EQ(stop_status.get_data()[0].has_converged(), true);
     ASSERT_EQ(one_changed, true);
 }
@@ -806,7 +726,7 @@ TYPED_TEST(ResidualNormWithRhsNorm, WaitsTillResidualGoalMultipleRHS)
         gko::initialize<Mtx>({I<T>{10.0, 10.0}}, this->exec_);
     auto rhs_norm =
         gko::initialize<NormVector>({I<T_nc>{0.0, 0.0}}, this->exec_);
-    gko::as<Mtx>(rhs)->compute_norm2(rhs_norm.get());
+    gko::as<Mtx>(rhs)->compute_norm2(rhs_norm);
     auto criterion = this->factory_->generate(nullptr, rhs, nullptr, res.get());
     bool one_changed{};
     constexpr gko::uint8 RelativeStoppingId{1};
@@ -814,24 +734,18 @@ TYPED_TEST(ResidualNormWithRhsNorm, WaitsTillResidualGoalMultipleRHS)
     stop_status.get_data()[0].reset();
     stop_status.get_data()[1].reset();
 
-    ASSERT_FALSE(
-        criterion->update()
-            .residual_norm(res_norm.get())
-            .check(RelativeStoppingId, true, &stop_status, &one_changed));
+    ASSERT_FALSE(criterion->update().residual_norm(res_norm).check(
+        RelativeStoppingId, true, &stop_status, &one_changed));
 
     res_norm->at(0, 0) = r<TypeParam>::value * 0.9 * rhs_norm->at(0, 0);
-    ASSERT_FALSE(
-        criterion->update()
-            .residual_norm(res_norm.get())
-            .check(RelativeStoppingId, true, &stop_status, &one_changed));
+    ASSERT_FALSE(criterion->update().residual_norm(res_norm).check(
+        RelativeStoppingId, true, &stop_status, &one_changed));
     ASSERT_EQ(stop_status.get_data()[0].has_converged(), true);
     ASSERT_EQ(one_changed, true);
 
     res_norm->at(0, 1) = r<TypeParam>::value * 0.9 * rhs_norm->at(0, 1);
-    ASSERT_TRUE(
-        criterion->update()
-            .residual_norm(res_norm.get())
-            .check(RelativeStoppingId, true, &stop_status, &one_changed));
+    ASSERT_TRUE(criterion->update().residual_norm(res_norm).check(
+        RelativeStoppingId, true, &stop_status, &one_changed));
     ASSERT_EQ(stop_status.get_data()[1].has_converged(), true);
     ASSERT_EQ(one_changed, true);
 }
@@ -926,7 +840,7 @@ TYPED_TEST(ImplicitResidualNorm, WaitsTillResidualGoal)
     std::shared_ptr<gko::LinOp> rhs = gko::initialize<Mtx>({10.0}, this->exec_);
     auto res_norm = gko::initialize<Mtx>({100.0}, this->exec_);
     auto rhs_norm = gko::initialize<NormVector>({I<T_nc>{0.0}}, this->exec_);
-    gko::as<Mtx>(rhs)->compute_norm2(rhs_norm.get());
+    gko::as<Mtx>(rhs)->compute_norm2(rhs_norm);
     auto criterion =
         this->factory_->generate(nullptr, rhs, nullptr, initial_res.get());
     bool one_changed{};
@@ -934,24 +848,18 @@ TYPED_TEST(ImplicitResidualNorm, WaitsTillResidualGoal)
     gko::array<gko::stopping_status> stop_status(this->exec_, 1);
     stop_status.get_data()[0].reset();
 
-    ASSERT_FALSE(
-        criterion->update()
-            .implicit_sq_residual_norm(res_norm.get())
-            .check(RelativeStoppingId, true, &stop_status, &one_changed));
+    ASSERT_FALSE(criterion->update().implicit_sq_residual_norm(res_norm).check(
+        RelativeStoppingId, true, &stop_status, &one_changed));
 
     res_norm->at(0) = std::pow(r<TypeParam>::value * 1.1 * rhs_norm->at(0), 2);
-    ASSERT_FALSE(
-        criterion->update()
-            .implicit_sq_residual_norm(res_norm.get())
-            .check(RelativeStoppingId, true, &stop_status, &one_changed));
+    ASSERT_FALSE(criterion->update().implicit_sq_residual_norm(res_norm).check(
+        RelativeStoppingId, true, &stop_status, &one_changed));
     ASSERT_EQ(stop_status.get_data()[0].has_converged(), false);
     ASSERT_EQ(one_changed, false);
 
     res_norm->at(0) = std::pow(r<TypeParam>::value * 0.9 * rhs_norm->at(0), 2);
-    ASSERT_TRUE(
-        criterion->update()
-            .implicit_sq_residual_norm(res_norm.get())
-            .check(RelativeStoppingId, true, &stop_status, &one_changed));
+    ASSERT_TRUE(criterion->update().implicit_sq_residual_norm(res_norm).check(
+        RelativeStoppingId, true, &stop_status, &one_changed));
     ASSERT_EQ(stop_status.get_data()[0].has_converged(), true);
     ASSERT_EQ(one_changed, true);
 }
@@ -969,7 +877,7 @@ TYPED_TEST(ImplicitResidualNorm, WaitsTillResidualGoalMultipleRHS)
         gko::initialize<Mtx>({I<T>{10.0, 10.0}}, this->exec_);
     auto rhs_norm =
         gko::initialize<NormVector>({I<T_nc>{0.0, 0.0}}, this->exec_);
-    gko::as<Mtx>(rhs)->compute_norm2(rhs_norm.get());
+    gko::as<Mtx>(rhs)->compute_norm2(rhs_norm);
     auto criterion = this->factory_->generate(nullptr, rhs, nullptr, res.get());
     bool one_changed{};
     constexpr gko::uint8 RelativeStoppingId{1};
@@ -977,26 +885,20 @@ TYPED_TEST(ImplicitResidualNorm, WaitsTillResidualGoalMultipleRHS)
     stop_status.get_data()[0].reset();
     stop_status.get_data()[1].reset();
 
-    ASSERT_FALSE(
-        criterion->update()
-            .implicit_sq_residual_norm(res_norm.get())
-            .check(RelativeStoppingId, true, &stop_status, &one_changed));
+    ASSERT_FALSE(criterion->update().implicit_sq_residual_norm(res_norm).check(
+        RelativeStoppingId, true, &stop_status, &one_changed));
 
     res_norm->at(0, 0) =
         std::pow(r<TypeParam>::value * 0.9 * rhs_norm->at(0, 0), 2);
-    ASSERT_FALSE(
-        criterion->update()
-            .implicit_sq_residual_norm(res_norm.get())
-            .check(RelativeStoppingId, true, &stop_status, &one_changed));
+    ASSERT_FALSE(criterion->update().implicit_sq_residual_norm(res_norm).check(
+        RelativeStoppingId, true, &stop_status, &one_changed));
     ASSERT_EQ(stop_status.get_data()[0].has_converged(), true);
     ASSERT_EQ(one_changed, true);
 
     res_norm->at(0, 1) =
         std::pow(r<TypeParam>::value * 0.9 * rhs_norm->at(0, 1), 2);
-    ASSERT_TRUE(
-        criterion->update()
-            .implicit_sq_residual_norm(res_norm.get())
-            .check(RelativeStoppingId, true, &stop_status, &one_changed));
+    ASSERT_TRUE(criterion->update().implicit_sq_residual_norm(res_norm).check(
+        RelativeStoppingId, true, &stop_status, &one_changed));
     ASSERT_EQ(stop_status.get_data()[1].has_converged(), true);
     ASSERT_EQ(one_changed, true);
 }
@@ -1067,24 +969,18 @@ TYPED_TEST(ResidualNormWithAbsolute, WaitsTillResidualGoal)
     gko::array<gko::stopping_status> stop_status(this->exec_, 1);
     stop_status.get_data()[0].reset();
 
-    ASSERT_FALSE(
-        criterion->update()
-            .residual_norm(res_norm.get())
-            .check(RelativeStoppingId, true, &stop_status, &one_changed));
+    ASSERT_FALSE(criterion->update().residual_norm(res_norm).check(
+        RelativeStoppingId, true, &stop_status, &one_changed));
 
     res_norm->at(0) = r<TypeParam>::value * 1.1;
-    ASSERT_FALSE(
-        criterion->update()
-            .residual_norm(res_norm.get())
-            .check(RelativeStoppingId, true, &stop_status, &one_changed));
+    ASSERT_FALSE(criterion->update().residual_norm(res_norm).check(
+        RelativeStoppingId, true, &stop_status, &one_changed));
     ASSERT_EQ(stop_status.get_data()[0].has_converged(), false);
     ASSERT_EQ(one_changed, false);
 
     res_norm->at(0) = r<TypeParam>::value * 0.9;
-    ASSERT_TRUE(
-        criterion->update()
-            .residual_norm(res_norm.get())
-            .check(RelativeStoppingId, true, &stop_status, &one_changed));
+    ASSERT_TRUE(criterion->update().residual_norm(res_norm).check(
+        RelativeStoppingId, true, &stop_status, &one_changed));
     ASSERT_EQ(stop_status.get_data()[0].has_converged(), true);
     ASSERT_EQ(one_changed, true);
 }
@@ -1108,24 +1004,18 @@ TYPED_TEST(ResidualNormWithAbsolute, WaitsTillResidualGoalMultipleRHS)
     stop_status.get_data()[0].reset();
     stop_status.get_data()[1].reset();
 
-    ASSERT_FALSE(
-        criterion->update()
-            .residual_norm(res_norm.get())
-            .check(RelativeStoppingId, true, &stop_status, &one_changed));
+    ASSERT_FALSE(criterion->update().residual_norm(res_norm).check(
+        RelativeStoppingId, true, &stop_status, &one_changed));
 
     res_norm->at(0, 0) = r<TypeParam>::value * 0.9;
-    ASSERT_FALSE(
-        criterion->update()
-            .residual_norm(res_norm.get())
-            .check(RelativeStoppingId, true, &stop_status, &one_changed));
+    ASSERT_FALSE(criterion->update().residual_norm(res_norm).check(
+        RelativeStoppingId, true, &stop_status, &one_changed));
     ASSERT_EQ(stop_status.get_data()[0].has_converged(), true);
     ASSERT_EQ(one_changed, true);
 
     res_norm->at(0, 1) = r<TypeParam>::value * 0.9;
-    ASSERT_TRUE(
-        criterion->update()
-            .residual_norm(res_norm.get())
-            .check(RelativeStoppingId, true, &stop_status, &one_changed));
+    ASSERT_TRUE(criterion->update().residual_norm(res_norm).check(
+        RelativeStoppingId, true, &stop_status, &one_changed));
     ASSERT_EQ(stop_status.get_data()[1].has_converged(), true);
     ASSERT_EQ(one_changed, true);
 }

--- a/reference/test/utils/assertions_test.cpp
+++ b/reference/test/utils/assertions_test.cpp
@@ -58,7 +58,7 @@ TYPED_TEST(MatricesNear, CanPassAnyMatrixType)
         {{1.0, 2.0, 3.0}, {0.0, 4.0, 0.0}}, exec);
 
     auto csr_mtx = gko::matrix::Csr<TypeParam>::create(exec);
-    csr_mtx->copy_from(mtx.get());
+    csr_mtx->copy_from(mtx);
 
     GKO_EXPECT_MTX_NEAR(csr_mtx, mtx, 0.0);
     GKO_ASSERT_MTX_NEAR(csr_mtx, mtx, 0.0);

--- a/test/base/kernel_launch_generic.cpp
+++ b/test/base/kernel_launch_generic.cpp
@@ -115,7 +115,7 @@ public:
         }
         zero_dense->fill(0.0);
         zero_dense2->fill(0.0);
-        iota_dense->copy_from(ref_iota_dense.get());
+        iota_dense->copy_from(ref_iota_dense);
         zero_array.set_executor(exec);
         iota_array.set_executor(exec);
         iota_transp_array.set_executor(exec);

--- a/test/distributed/matrix_kernels.cpp
+++ b/test/distributed/matrix_kernels.cpp
@@ -70,15 +70,20 @@ protected:
 
     Matrix() : engine(42) {}
 
-    void validate(const gko::experimental::distributed::Partition<
-                      local_index_type, global_index_type>* row_partition,
-                  const gko::experimental::distributed::Partition<
-                      local_index_type, global_index_type>* col_partition,
-                  const gko::experimental::distributed::Partition<
-                      local_index_type, global_index_type>* d_row_partition,
-                  const gko::experimental::distributed::Partition<
-                      local_index_type, global_index_type>* d_col_partition,
-                  gko::device_matrix_data<value_type, global_index_type> input)
+    void validate(
+        gko::pointer_param<const gko::experimental::distributed::Partition<
+            local_index_type, global_index_type>>
+            row_partition,
+        gko::pointer_param<const gko::experimental::distributed::Partition<
+            local_index_type, global_index_type>>
+            col_partition,
+        gko::pointer_param<const gko::experimental::distributed::Partition<
+            local_index_type, global_index_type>>
+            d_row_partition,
+        gko::pointer_param<const gko::experimental::distributed::Partition<
+            local_index_type, global_index_type>>
+            d_col_partition,
+        gko::device_matrix_data<value_type, global_index_type> input)
     {
         gko::device_matrix_data<value_type, global_index_type> d_input{exec,
                                                                        input};
@@ -108,17 +113,17 @@ protected:
             gko::array<global_index_type> d_local_to_global_col{exec};
 
             gko::kernels::reference::distributed_matrix::build_local_nonlocal(
-                ref, input, row_partition, col_partition, part, local_row_idxs,
-                local_col_idxs, local_values, non_local_row_idxs,
-                non_local_col_idxs, non_local_values, gather_idxs, recv_sizes,
-                local_to_global_col);
+                ref, input, row_partition.get(), col_partition.get(), part,
+                local_row_idxs, local_col_idxs, local_values,
+                non_local_row_idxs, non_local_col_idxs, non_local_values,
+                gather_idxs, recv_sizes, local_to_global_col);
             gko::kernels::EXEC_NAMESPACE::distributed_matrix::
-                build_local_nonlocal(exec, d_input, d_row_partition,
-                                     d_col_partition, part, d_local_row_idxs,
-                                     d_local_col_idxs, d_local_values,
-                                     d_non_local_row_idxs, d_non_local_col_idxs,
-                                     d_non_local_values, d_gather_idxs,
-                                     d_recv_sizes, d_local_to_global_col);
+                build_local_nonlocal(
+                    exec, d_input, d_row_partition.get(), d_col_partition.get(),
+                    part, d_local_row_idxs, d_local_col_idxs, d_local_values,
+                    d_non_local_row_idxs, d_non_local_col_idxs,
+                    d_non_local_values, d_gather_idxs, d_recv_sizes,
+                    d_local_to_global_col);
 
             GKO_ASSERT_ARRAY_EQ(local_row_idxs, d_local_row_idxs);
             GKO_ASSERT_ARRAY_EQ(local_col_idxs, d_local_col_idxs);
@@ -156,7 +161,7 @@ TYPED_TEST(Matrix, BuildsDiagOffdiagEmptyIsSameAsRef)
                                                                  num_parts);
 
     this->validate(
-        partition.get(), partition.get(), d_partition.get(), d_partition.get(),
+        partition, partition, d_partition, d_partition,
         gko::device_matrix_data<value_type, global_index_type>{this->ref});
 }
 
@@ -191,8 +196,7 @@ TYPED_TEST(Matrix, BuildsLocalSmallIsEquivalentToRef)
                                                                  mapping,
                                                                  num_parts);
 
-    this->validate(partition.get(), partition.get(), d_partition.get(),
-                   d_partition.get(), input);
+    this->validate(partition, partition, d_partition, d_partition, input);
 }
 
 
@@ -227,8 +231,7 @@ TYPED_TEST(Matrix, BuildsLocalIsEquivalentToRef)
                                                                  mapping,
                                                                  num_parts);
 
-    this->validate(partition.get(), partition.get(), d_partition.get(),
-                   d_partition.get(), input);
+    this->validate(partition, partition, d_partition, d_partition, input);
 }
 
 
@@ -261,8 +264,7 @@ TYPED_TEST(Matrix, BuildsDiagOffdiagEmptyWithColPartitionIsSameAsRef)
                                                                  num_parts);
 
     this->validate(
-        row_partition.get(), col_partition.get(), d_row_partition.get(),
-        d_col_partition.get(),
+        row_partition, col_partition, d_row_partition, d_col_partition,
         gko::device_matrix_data<value_type, global_index_type>{this->ref});
 }
 
@@ -311,8 +313,8 @@ TYPED_TEST(Matrix, BuildsLocalSmallWithColPartitionIsEquivalentToRef)
                                                                  col_mapping,
                                                                  num_parts);
 
-    this->validate(row_partition.get(), col_partition.get(),
-                   d_row_partition.get(), d_col_partition.get(), input);
+    this->validate(row_partition, col_partition, d_row_partition,
+                   d_col_partition, input);
 }
 
 
@@ -361,6 +363,6 @@ TYPED_TEST(Matrix, BuildsLocalWithColPartitionIsEquivalentToRef)
                                                                  col_mapping,
                                                                  num_parts);
 
-    this->validate(row_partition.get(), col_partition.get(),
-                   d_row_partition.get(), d_col_partition.get(), input);
+    this->validate(row_partition, col_partition, d_row_partition,
+                   d_col_partition, input);
 }

--- a/test/distributed/matrix_kernels.cpp
+++ b/test/distributed/matrix_kernels.cpp
@@ -71,16 +71,16 @@ protected:
     Matrix() : engine(42) {}
 
     void validate(
-        gko::pointer_param<const gko::experimental::distributed::Partition<
+        gko::ptr_param<const gko::experimental::distributed::Partition<
             local_index_type, global_index_type>>
             row_partition,
-        gko::pointer_param<const gko::experimental::distributed::Partition<
+        gko::ptr_param<const gko::experimental::distributed::Partition<
             local_index_type, global_index_type>>
             col_partition,
-        gko::pointer_param<const gko::experimental::distributed::Partition<
+        gko::ptr_param<const gko::experimental::distributed::Partition<
             local_index_type, global_index_type>>
             d_row_partition,
-        gko::pointer_param<const gko::experimental::distributed::Partition<
+        gko::ptr_param<const gko::experimental::distributed::Partition<
             local_index_type, global_index_type>>
             d_col_partition,
         gko::device_matrix_data<value_type, global_index_type> input)

--- a/test/distributed/vector_kernels.cpp
+++ b/test/distributed/vector_kernels.cpp
@@ -71,10 +71,10 @@ protected:
     Vector() : engine(42) {}
 
     void validate(
-        gko::pointer_param<const gko::experimental::distributed::Partition<
+        gko::ptr_param<const gko::experimental::distributed::Partition<
             local_index_type, global_index_type>>
             partition,
-        gko::pointer_param<const gko::experimental::distributed::Partition<
+        gko::ptr_param<const gko::experimental::distributed::Partition<
             local_index_type, global_index_type>>
             d_partition,
         const gko::device_matrix_data<value_type, global_index_type>& input)

--- a/test/distributed/vector_kernels.cpp
+++ b/test/distributed/vector_kernels.cpp
@@ -70,11 +70,14 @@ protected:
 
     Vector() : engine(42) {}
 
-    void validate(const gko::experimental::distributed::Partition<
-                      local_index_type, global_index_type>* partition,
-                  const gko::experimental::distributed::Partition<
-                      local_index_type, global_index_type>* d_partition,
-                  gko::device_matrix_data<value_type, global_index_type> input)
+    void validate(
+        gko::pointer_param<const gko::experimental::distributed::Partition<
+            local_index_type, global_index_type>>
+            partition,
+        gko::pointer_param<const gko::experimental::distributed::Partition<
+            local_index_type, global_index_type>>
+            d_partition,
+        const gko::device_matrix_data<value_type, global_index_type>& input)
     {
         gko::device_matrix_data<value_type, global_index_type> d_input{exec,
                                                                        input};
@@ -88,9 +91,9 @@ protected:
             auto d_output = gko::clone(exec, output);
 
             gko::kernels::reference::distributed_vector::build_local(
-                ref, input, partition, part, output.get());
+                ref, input, partition.get(), part, output.get());
             gko::kernels::EXEC_NAMESPACE::distributed_vector::build_local(
-                exec, d_input, d_partition, part, d_output.get());
+                exec, d_input, d_partition.get(), part, d_output.get());
 
             GKO_ASSERT_MTX_NEAR(output, d_output, 0);
         }
@@ -141,7 +144,7 @@ TYPED_TEST(Vector, BuildsLocalEmptyIsEquivalentToRef)
                                                                  num_parts);
 
     this->validate(
-        partition.get(), d_partition.get(),
+        partition, d_partition,
         gko::device_matrix_data<value_type, global_index_type>{this->ref});
 }
 
@@ -177,7 +180,7 @@ TYPED_TEST(Vector, BuildsLocalSmallIsEquivalentToRef)
                                                                  mapping,
                                                                  num_parts);
 
-    this->validate(partition.get(), d_partition.get(), input);
+    this->validate(partition, d_partition, input);
 }
 
 
@@ -212,5 +215,5 @@ TYPED_TEST(Vector, BuildsLocalIsEquivalentToRef)
                                                                  mapping,
                                                                  num_parts);
 
-    this->validate(partition.get(), d_partition.get(), input);
+    this->validate(partition, d_partition, input);
 }

--- a/test/factorization/ic_kernels.cpp
+++ b/test/factorization/ic_kernels.cpp
@@ -88,8 +88,8 @@ TEST_F(Ic, ComputeICIsEquivalentToRefSorted)
 
 TEST_F(Ic, ComputeICIsEquivalentToRefUnsorted)
 {
-    gko::test::unsort_matrix(gko::lend(mtx), rand_engine);
-    dmtx->copy_from(gko::lend(mtx));
+    gko::test::unsort_matrix(mtx.get(), rand_engine);
+    dmtx->copy_from(mtx.get());
 
     auto fact = gko::factorization::Ic<>::build().on(ref)->generate(mtx);
     auto dfact = gko::factorization::Ic<>::build().on(exec)->generate(dmtx);

--- a/test/factorization/ic_kernels.cpp
+++ b/test/factorization/ic_kernels.cpp
@@ -88,8 +88,8 @@ TEST_F(Ic, ComputeICIsEquivalentToRefSorted)
 
 TEST_F(Ic, ComputeICIsEquivalentToRefUnsorted)
 {
-    gko::test::unsort_matrix(mtx.get(), rand_engine);
-    dmtx->copy_from(mtx.get());
+    gko::test::unsort_matrix(mtx, rand_engine);
+    dmtx->copy_from(mtx);
 
     auto fact = gko::factorization::Ic<>::build().on(ref)->generate(mtx);
     auto dfact = gko::factorization::Ic<>::build().on(exec)->generate(dmtx);

--- a/test/factorization/ilu_kernels.cpp
+++ b/test/factorization/ilu_kernels.cpp
@@ -88,8 +88,8 @@ TEST_F(Ilu, ComputeILUIsEquivalentToRefSorted)
 
 TEST_F(Ilu, ComputeILUIsEquivalentToRefUnsorted)
 {
-    gko::test::unsort_matrix(gko::lend(mtx), rand_engine);
-    dmtx->copy_from(gko::lend(mtx));
+    gko::test::unsort_matrix(mtx.get(), rand_engine);
+    dmtx->copy_from(mtx.get());
 
     auto fact = gko::factorization::Ilu<>::build().on(ref)->generate(mtx);
     auto dfact = gko::factorization::Ilu<>::build().on(exec)->generate(dmtx);

--- a/test/factorization/ilu_kernels.cpp
+++ b/test/factorization/ilu_kernels.cpp
@@ -88,8 +88,8 @@ TEST_F(Ilu, ComputeILUIsEquivalentToRefSorted)
 
 TEST_F(Ilu, ComputeILUIsEquivalentToRefUnsorted)
 {
-    gko::test::unsort_matrix(mtx.get(), rand_engine);
-    dmtx->copy_from(mtx.get());
+    gko::test::unsort_matrix(mtx, rand_engine);
+    dmtx->copy_from(mtx);
 
     auto fact = gko::factorization::Ilu<>::build().on(ref)->generate(mtx);
     auto dfact = gko::factorization::Ilu<>::build().on(exec)->generate(dmtx);

--- a/test/factorization/lu_kernels.cpp
+++ b/test/factorization/lu_kernels.cpp
@@ -114,9 +114,9 @@ protected:
         drow_descs = row_descs;
         dmtx_lu = gko::clone(exec, mtx_lu);
         mtx_lu_sparsity = sparsity_pattern_type::create(ref);
-        mtx_lu_sparsity->copy_from(mtx_lu.get());
+        mtx_lu_sparsity->copy_from(mtx_lu);
         dmtx_lu_sparsity = sparsity_pattern_type::create(exec);
-        dmtx_lu_sparsity->copy_from(mtx_lu_sparsity.get());
+        dmtx_lu_sparsity->copy_from(mtx_lu_sparsity);
     }
 
     gko::size_type num_rows;

--- a/test/factorization/par_ic_kernels.cpp
+++ b/test/factorization/par_ic_kernels.cpp
@@ -87,22 +87,22 @@ protected:
         {
             mtx_l_ani = Csr::create(ref, mtx_ani->get_size());
             gko::matrix::CsrBuilder<value_type, index_type> l_builder(
-                lend(mtx_l_ani));
+                mtx_l_ani.get());
             gko::kernels::reference::factorization::initialize_row_ptrs_l(
-                ref, lend(mtx_ani), mtx_l_ani->get_row_ptrs());
+                ref, mtx_ani.get(), mtx_l_ani->get_row_ptrs());
             auto l_nnz =
                 mtx_l_ani->get_const_row_ptrs()[mtx_ani->get_size()[0]];
             l_builder.get_col_idx_array().resize_and_reset(l_nnz);
             l_builder.get_value_array().resize_and_reset(l_nnz);
             gko::kernels::reference::factorization::initialize_l(
-                ref, lend(mtx_ani), lend(mtx_l_ani), false);
+                ref, mtx_ani.get(), mtx_l_ani.get(), false);
             mtx_l_ani_init = gko::clone(ref, mtx_l_ani);
             gko::kernels::reference::par_ic_factorization::init_factor(
-                ref, lend(mtx_l_ani_init));
+                ref, mtx_l_ani_init.get());
         }
-        dmtx_ani->copy_from(lend(mtx_ani));
-        dmtx_l_ani->copy_from(lend(mtx_l_ani));
-        dmtx_l_ani_init->copy_from(lend(mtx_l_ani_init));
+        dmtx_ani->copy_from(mtx_ani);
+        dmtx_l_ani->copy_from(mtx_l_ani);
+        dmtx_l_ani_init->copy_from(mtx_l_ani_init);
     }
 
     gko::dim<2> mtx_size;
@@ -141,7 +141,7 @@ TYPED_TEST(ParIc, KernelComputeFactorIsEquivalentToRef)
     using Coo = typename TestFixture::Coo;
     auto square_size = this->mtx_ani->get_size();
     auto mtx_l_coo = Coo::create(this->ref, square_size);
-    this->mtx_l_ani->convert_to(lend(mtx_l_coo));
+    this->mtx_l_ani->convert_to(mtx_l_coo);
     auto dmtx_l_coo = gko::clone(this->exec, mtx_l_coo);
 
     gko::kernels::reference::par_ic_factorization::compute_factor(

--- a/test/factorization/par_ic_kernels.cpp
+++ b/test/factorization/par_ic_kernels.cpp
@@ -87,7 +87,7 @@ protected:
         {
             mtx_l_ani = Csr::create(ref, mtx_ani->get_size());
             gko::matrix::CsrBuilder<value_type, index_type> l_builder(
-                mtx_l_ani.get());
+                mtx_l_ani);
             gko::kernels::reference::factorization::initialize_row_ptrs_l(
                 ref, mtx_ani.get(), mtx_l_ani->get_row_ptrs());
             auto l_nnz =

--- a/test/factorization/par_ict_kernels.cpp
+++ b/test/factorization/par_ict_kernels.cpp
@@ -101,18 +101,18 @@ protected:
         {
             mtx_l_ani = Csr::create(ref, mtx_ani->get_size());
             gko::matrix::CsrBuilder<value_type, index_type> l_builder(
-                lend(mtx_l_ani));
+                mtx_l_ani.get());
             gko::kernels::reference::factorization::initialize_row_ptrs_l(
-                ref, lend(mtx_ani), mtx_l_ani->get_row_ptrs());
+                ref, mtx_ani.get(), mtx_l_ani->get_row_ptrs());
             auto l_nnz =
                 mtx_l_ani->get_const_row_ptrs()[mtx_ani->get_size()[0]];
             l_builder.get_col_idx_array().resize_and_reset(l_nnz);
             l_builder.get_value_array().resize_and_reset(l_nnz);
             gko::kernels::reference::factorization::initialize_l(
-                ref, lend(mtx_ani), lend(mtx_l_ani), true);
+                ref, mtx_ani.get(), mtx_l_ani.get(), true);
         }
-        dmtx_ani->copy_from(lend(mtx_ani));
-        dmtx_l_ani->copy_from(lend(mtx_l_ani));
+        dmtx_ani->copy_from(mtx_ani);
+        dmtx_l_ani->copy_from(mtx_l_ani);
     }
 
     const gko::dim<2> mtx_size;
@@ -139,7 +139,7 @@ TYPED_TEST(ParIct, KernelAddCandidatesIsEquivalentToRef)
     auto mtx_llh = Csr::create(this->ref, this->mtx_size);
     this->mtx_l->apply(this->mtx_l->conj_transpose().get(), mtx_llh.get());
     auto dmtx_llh = Csr::create(this->exec, this->mtx_size);
-    dmtx_llh->copy_from(lend(mtx_llh));
+    dmtx_llh->copy_from(mtx_llh);
     auto res_mtx_l = Csr::create(this->ref, this->mtx_size);
     auto dres_mtx_l = Csr::create(this->exec, this->mtx_size);
 

--- a/test/factorization/par_ict_kernels.cpp
+++ b/test/factorization/par_ict_kernels.cpp
@@ -101,7 +101,7 @@ protected:
         {
             mtx_l_ani = Csr::create(ref, mtx_ani->get_size());
             gko::matrix::CsrBuilder<value_type, index_type> l_builder(
-                mtx_l_ani.get());
+                mtx_l_ani);
             gko::kernels::reference::factorization::initialize_row_ptrs_l(
                 ref, mtx_ani.get(), mtx_l_ani->get_row_ptrs());
             auto l_nnz =
@@ -137,7 +137,7 @@ TYPED_TEST(ParIct, KernelAddCandidatesIsEquivalentToRef)
     using Csr = typename TestFixture::Csr;
     using value_type = typename TestFixture::value_type;
     auto mtx_llh = Csr::create(this->ref, this->mtx_size);
-    this->mtx_l->apply(this->mtx_l->conj_transpose().get(), mtx_llh.get());
+    this->mtx_l->apply(this->mtx_l->conj_transpose(), mtx_llh);
     auto dmtx_llh = Csr::create(this->exec, this->mtx_size);
     dmtx_llh->copy_from(mtx_llh);
     auto res_mtx_l = Csr::create(this->ref, this->mtx_size);
@@ -161,9 +161,9 @@ TYPED_TEST(ParIct, KernelComputeFactorIsEquivalentToRef)
     using Coo = typename TestFixture::Coo;
     auto square_size = this->mtx_ani->get_size();
     auto mtx_l_coo = Coo::create(this->ref, square_size);
-    this->mtx_l_ani->convert_to(mtx_l_coo.get());
+    this->mtx_l_ani->convert_to(mtx_l_coo);
     auto dmtx_l_coo = Coo::create(this->exec, square_size);
-    dmtx_l_coo->copy_from(mtx_l_coo.get());
+    dmtx_l_coo->copy_from(mtx_l_coo);
 
     gko::kernels::reference::par_ict_factorization::compute_factor(
         this->ref, this->mtx_ani.get(), this->mtx_l_ani.get(), mtx_l_coo.get());

--- a/test/factorization/par_ilu_kernels.cpp
+++ b/test/factorization/par_ilu_kernels.cpp
@@ -166,9 +166,9 @@ protected:
                     gko::size_type iterations = 0)
     {
         auto coo = Coo::create(ref);
-        mtx->convert_to(coo.get());
+        mtx->convert_to(coo);
         auto dcoo = Coo::create(exec);
-        dmtx->convert_to(dcoo.get());
+        dmtx->convert_to(dcoo);
         initialize_lu(l, u, dl, du);
         auto u_transpose_mtx = gko::as<Csr>(u->transpose());
         auto u_transpose_dmtx = gko::as<Csr>(du->transpose());

--- a/test/factorization/par_ilut_kernels.cpp
+++ b/test/factorization/par_ilut_kernels.cpp
@@ -134,9 +134,9 @@ protected:
             mtx_l_ani = Csr::create(ref, mtx_ani->get_size());
             mtx_u_ani = Csr::create(ref, mtx_ani->get_size());
             gko::matrix::CsrBuilder<value_type, index_type> l_builder(
-                mtx_l_ani.get());
+                mtx_l_ani);
             gko::matrix::CsrBuilder<value_type, index_type> u_builder(
-                mtx_u_ani.get());
+                mtx_u_ani);
             gko::kernels::reference::factorization::initialize_row_ptrs_l_u(
                 ref, mtx_ani.get(), mtx_l_ani->get_row_ptrs(),
                 mtx_u_ani->get_row_ptrs());
@@ -155,10 +155,10 @@ protected:
             gko::kernels::reference::csr::transpose(ref, mtx_u_ani.get(),
                                                     mtx_ut_ani.get());
         }
-        dmtx_ani->copy_from(mtx_ani.get());
-        dmtx_l_ani->copy_from(mtx_l_ani.get());
-        dmtx_u_ani->copy_from(mtx_u_ani.get());
-        dmtx_ut_ani->copy_from(mtx_ut_ani.get());
+        dmtx_ani->copy_from(mtx_ani);
+        dmtx_l_ani->copy_from(mtx_l_ani);
+        dmtx_u_ani->copy_from(mtx_u_ani);
+        dmtx_ut_ani->copy_from(mtx_ut_ani);
     }
 
     template <typename Mtx>
@@ -410,9 +410,9 @@ TYPED_TEST(ParIlut, KernelAddCandidatesIsEquivalentToRef)
     using value_type = typename TestFixture::value_type;
     auto square_size = this->mtx_square->get_size();
     auto mtx_lu = Csr::create(this->ref, square_size);
-    this->mtx_l2->apply(this->mtx_u.get(), mtx_lu.get());
+    this->mtx_l2->apply(this->mtx_u, mtx_lu);
     auto dmtx_lu = Csr::create(this->exec, square_size);
-    dmtx_lu->copy_from(mtx_lu.get());
+    dmtx_lu->copy_from(mtx_lu);
     auto res_mtx_l = Csr::create(this->ref, square_size);
     auto res_mtx_u = Csr::create(this->ref, square_size);
     auto dres_mtx_l = Csr::create(this->exec, square_size);
@@ -439,12 +439,12 @@ TYPED_TEST(ParIlut, KernelComputeLUIsEquivalentToRef)
     auto square_size = this->mtx_ani->get_size();
     auto mtx_l_coo = Coo::create(this->ref, square_size);
     auto mtx_u_coo = Coo::create(this->ref, square_size);
-    this->mtx_l_ani->convert_to(mtx_l_coo.get());
-    this->mtx_u_ani->convert_to(mtx_u_coo.get());
+    this->mtx_l_ani->convert_to(mtx_l_coo);
+    this->mtx_u_ani->convert_to(mtx_u_coo);
     auto dmtx_l_coo = Coo::create(this->exec, square_size);
     auto dmtx_u_coo = Coo::create(this->exec, square_size);
-    dmtx_l_coo->copy_from(mtx_l_coo.get());
-    dmtx_u_coo->copy_from(mtx_u_coo.get());
+    dmtx_l_coo->copy_from(mtx_l_coo);
+    dmtx_u_coo->copy_from(mtx_u_coo);
 
     gko::kernels::reference::par_ilut_factorization::compute_l_u_factors(
         this->ref, this->mtx_ani.get(), this->mtx_l_ani.get(), mtx_l_coo.get(),

--- a/test/matrix/coo_kernels.cpp
+++ b/test/matrix/coo_kernels.cpp
@@ -85,8 +85,8 @@ protected:
 
     void unsort_mtx()
     {
-        gko::test::unsort_matrix(mtx.get(), rand_engine);
-        dmtx->copy_from(mtx.get());
+        gko::test::unsort_matrix(mtx, rand_engine);
+        dmtx->copy_from(mtx);
     }
 
     std::default_random_engine rand_engine;
@@ -109,8 +109,8 @@ TEST_F(Coo, SimpleApplyIsEquivalentToRef)
 {
     set_up_apply_data();
 
-    mtx->apply(y.get(), expected.get());
-    dmtx->apply(dy.get(), dresult.get());
+    mtx->apply(y, expected);
+    dmtx->apply(dy, dresult);
 
     GKO_ASSERT_MTX_NEAR(dresult, expected, r<value_type>::value);
 }
@@ -121,13 +121,13 @@ TEST_F(Coo, SimpleApplyDoesntOverwritePadding)
     set_up_apply_data();
     auto dresult_padded =
         Vec::create(exec, dresult->get_size(), dresult->get_stride() + 1);
-    dresult_padded->copy_from(dresult.get());
+    dresult_padded->copy_from(dresult);
     value_type padding_val{1234.0};
-    exec->copy_from(exec->get_master().get(), 1, &padding_val,
+    exec->copy_from(exec->get_master(), 1, &padding_val,
                     dresult_padded->get_values() + 1);
 
-    mtx->apply(y.get(), expected.get());
-    dmtx->apply(dy.get(), dresult_padded.get());
+    mtx->apply(y, expected);
+    dmtx->apply(dy, dresult_padded);
 
     GKO_ASSERT_MTX_NEAR(dresult_padded, expected, r<value_type>::value);
     ASSERT_EQ(exec->copy_val_to_host(dresult_padded->get_values() + 1), 1234.0);
@@ -139,8 +139,8 @@ TEST_F(Coo, SimpleApplyIsEquivalentToRefUnsorted)
     set_up_apply_data();
     unsort_mtx();
 
-    mtx->apply(y.get(), expected.get());
-    dmtx->apply(dy.get(), dresult.get());
+    mtx->apply(y, expected);
+    dmtx->apply(dy, dresult);
 
     GKO_ASSERT_MTX_NEAR(dresult, expected, r<value_type>::value);
 }
@@ -150,8 +150,8 @@ TEST_F(Coo, AdvancedApplyIsEquivalentToRef)
 {
     set_up_apply_data();
 
-    mtx->apply(alpha.get(), y.get(), beta.get(), expected.get());
-    dmtx->apply(dalpha.get(), dy.get(), dbeta.get(), dresult.get());
+    mtx->apply(alpha, y, beta, expected);
+    dmtx->apply(dalpha, dy, dbeta, dresult);
 
     GKO_ASSERT_MTX_NEAR(dresult, expected, r<value_type>::value);
 }
@@ -162,13 +162,13 @@ TEST_F(Coo, AdvancedApplyDoesntOverwritePadding)
     set_up_apply_data();
     auto dresult_padded =
         Vec::create(exec, dresult->get_size(), dresult->get_stride() + 1);
-    dresult_padded->copy_from(dresult.get());
+    dresult_padded->copy_from(dresult);
     value_type padding_val{1234.0};
-    exec->copy_from(exec->get_master().get(), 1, &padding_val,
+    exec->copy_from(exec->get_master(), 1, &padding_val,
                     dresult_padded->get_values() + 1);
 
-    mtx->apply(alpha.get(), y.get(), beta.get(), expected.get());
-    dmtx->apply(dalpha.get(), dy.get(), dbeta.get(), dresult_padded.get());
+    mtx->apply(alpha, y, beta, expected);
+    dmtx->apply(dalpha, dy, dbeta, dresult_padded);
 
     GKO_ASSERT_MTX_NEAR(dresult_padded, expected, r<value_type>::value);
     ASSERT_EQ(exec->copy_val_to_host(dresult_padded->get_values() + 1), 1234.0);
@@ -179,8 +179,8 @@ TEST_F(Coo, SimpleApplyAddIsEquivalentToRef)
 {
     set_up_apply_data();
 
-    mtx->apply2(y.get(), expected.get());
-    dmtx->apply2(dy.get(), dresult.get());
+    mtx->apply2(y, expected);
+    dmtx->apply2(dy, dresult);
 
     GKO_ASSERT_MTX_NEAR(dresult, expected, r<value_type>::value);
 }
@@ -190,8 +190,8 @@ TEST_F(Coo, AdvancedApplyAddIsEquivalentToRef)
 {
     set_up_apply_data();
 
-    mtx->apply2(alpha.get(), y.get(), expected.get());
-    dmtx->apply2(dalpha.get(), dy.get(), dresult.get());
+    mtx->apply2(alpha, y, expected);
+    dmtx->apply2(dalpha, dy, dresult);
 
     GKO_ASSERT_MTX_NEAR(dresult, expected, r<value_type>::value);
 }
@@ -201,8 +201,8 @@ TEST_F(Coo, SimpleApplyToDenseMatrixIsEquivalentToRef)
 {
     set_up_apply_data(3);
 
-    mtx->apply(y.get(), expected.get());
-    dmtx->apply(dy.get(), dresult.get());
+    mtx->apply(y, expected);
+    dmtx->apply(dy, dresult);
 
     GKO_ASSERT_MTX_NEAR(dresult, expected, r<value_type>::value);
 }
@@ -212,8 +212,8 @@ TEST_F(Coo, AdvancedApplyToDenseMatrixIsEquivalentToRef)
 {
     set_up_apply_data(4);
 
-    mtx->apply(alpha.get(), y.get(), beta.get(), expected.get());
-    dmtx->apply(dalpha.get(), dy.get(), dbeta.get(), dresult.get());
+    mtx->apply(alpha, y, beta, expected);
+    dmtx->apply(dalpha, dy, dbeta, dresult);
 
     GKO_ASSERT_MTX_NEAR(dresult, expected, r<value_type>::value);
 }
@@ -223,8 +223,8 @@ TEST_F(Coo, SimpleApplyAddToDenseMatrixIsEquivalentToRef)
 {
     set_up_apply_data(5);
 
-    mtx->apply2(y.get(), expected.get());
-    dmtx->apply2(dy.get(), dresult.get());
+    mtx->apply2(y, expected);
+    dmtx->apply2(dy, dresult);
 
     GKO_ASSERT_MTX_NEAR(dresult, expected, r<value_type>::value);
 }
@@ -235,8 +235,8 @@ TEST_F(Coo, SimpleApplyAddToDenseMatrixIsEquivalentToRefUnsorted)
     set_up_apply_data(6);
     unsort_mtx();
 
-    mtx->apply2(y.get(), expected.get());
-    dmtx->apply2(dy.get(), dresult.get());
+    mtx->apply2(y, expected);
+    dmtx->apply2(dy, dresult);
 
     GKO_ASSERT_MTX_NEAR(dresult, expected, r<value_type>::value);
 }
@@ -246,8 +246,8 @@ TEST_F(Coo, SimpleApplyAddToLargeDenseMatrixIsEquivalentToRef)
 {
     set_up_apply_data(33);
 
-    mtx->apply2(y.get(), expected.get());
-    dmtx->apply2(dy.get(), dresult.get());
+    mtx->apply2(y, expected);
+    dmtx->apply2(dy, dresult);
 
     GKO_ASSERT_MTX_NEAR(dresult, expected, r<value_type>::value);
 }
@@ -257,8 +257,8 @@ TEST_F(Coo, AdvancedApplyAddToDenseMatrixIsEquivalentToRef)
 {
     set_up_apply_data(7);
 
-    mtx->apply2(alpha.get(), y.get(), expected.get());
-    dmtx->apply2(dalpha.get(), dy.get(), dresult.get());
+    mtx->apply2(alpha, y, expected);
+    dmtx->apply2(dalpha, dy, dresult);
 
     GKO_ASSERT_MTX_NEAR(dresult, expected, r<value_type>::value);
 }
@@ -268,8 +268,8 @@ TEST_F(Coo, AdvancedApplyAddToLargeDenseMatrixIsEquivalentToRef)
 {
     set_up_apply_data(33);
 
-    mtx->apply2(y.get(), expected.get());
-    dmtx->apply2(dy.get(), dresult.get());
+    mtx->apply2(y, expected);
+    dmtx->apply2(dy, dresult);
 
     GKO_ASSERT_MTX_NEAR(dresult, expected, r<value_type>::value);
 }
@@ -283,8 +283,8 @@ TEST_F(Coo, ApplyToComplexIsEquivalentToRef)
     auto complex_x = gen_mtx<ComplexVec>(532, 3);
     auto dcomplex_x = gko::clone(exec, complex_x);
 
-    mtx->apply(complex_b.get(), complex_x.get());
-    dmtx->apply(dcomplex_b.get(), dcomplex_x.get());
+    mtx->apply(complex_b, complex_x);
+    dmtx->apply(dcomplex_b, dcomplex_x);
 
     GKO_ASSERT_MTX_NEAR(dcomplex_x, complex_x, r<value_type>::value);
 }
@@ -298,8 +298,8 @@ TEST_F(Coo, AdvancedApplyToComplexIsEquivalentToRef)
     auto complex_x = gen_mtx<ComplexVec>(532, 3);
     auto dcomplex_x = gko::clone(exec, complex_x);
 
-    mtx->apply(alpha.get(), complex_b.get(), beta.get(), complex_x.get());
-    dmtx->apply(dalpha.get(), dcomplex_b.get(), dbeta.get(), dcomplex_x.get());
+    mtx->apply(alpha, complex_b, beta, complex_x);
+    dmtx->apply(dalpha, dcomplex_b, dbeta, dcomplex_x);
 
     GKO_ASSERT_MTX_NEAR(dcomplex_x, complex_x, r<value_type>::value);
 }
@@ -313,8 +313,8 @@ TEST_F(Coo, ApplyAddToComplexIsEquivalentToRef)
     auto complex_x = gen_mtx<ComplexVec>(532, 3);
     auto dcomplex_x = gko::clone(exec, complex_x);
 
-    mtx->apply2(alpha.get(), complex_b.get(), complex_x.get());
-    dmtx->apply2(dalpha.get(), dcomplex_b.get(), dcomplex_x.get());
+    mtx->apply2(alpha, complex_b, complex_x);
+    dmtx->apply2(dalpha, dcomplex_b, dcomplex_x);
 
     GKO_ASSERT_MTX_NEAR(dcomplex_x, complex_x, r<value_type>::value);
 }
@@ -326,10 +326,10 @@ TEST_F(Coo, ConvertToDenseIsEquivalentToRef)
     auto dense_mtx = gko::matrix::Dense<value_type>::create(ref);
     auto ddense_mtx = gko::matrix::Dense<value_type>::create(exec);
 
-    mtx->convert_to(dense_mtx.get());
-    dmtx->convert_to(ddense_mtx.get());
+    mtx->convert_to(dense_mtx);
+    dmtx->convert_to(ddense_mtx);
 
-    GKO_ASSERT_MTX_NEAR(dense_mtx.get(), ddense_mtx.get(), 0);
+    GKO_ASSERT_MTX_NEAR(dense_mtx, ddense_mtx, 0);
 }
 
 
@@ -340,11 +340,11 @@ TEST_F(Coo, ConvertToCsrIsEquivalentToRef)
     auto csr_mtx = gko::matrix::Csr<value_type>::create(ref);
     auto dcsr_mtx = gko::matrix::Csr<value_type>::create(exec);
 
-    mtx->convert_to(dense_mtx.get());
-    dense_mtx->convert_to(csr_mtx.get());
-    dmtx->convert_to(dcsr_mtx.get());
+    mtx->convert_to(dense_mtx);
+    dense_mtx->convert_to(csr_mtx);
+    dmtx->convert_to(dcsr_mtx);
 
-    GKO_ASSERT_MTX_NEAR(csr_mtx.get(), dcsr_mtx.get(), 0);
+    GKO_ASSERT_MTX_NEAR(csr_mtx, dcsr_mtx, 0);
 }
 
 
@@ -355,7 +355,7 @@ TEST_F(Coo, ExtractDiagonalIsEquivalentToRef)
     auto diag = mtx->extract_diagonal();
     auto ddiag = dmtx->extract_diagonal();
 
-    GKO_ASSERT_MTX_NEAR(diag.get(), ddiag.get(), 0);
+    GKO_ASSERT_MTX_NEAR(diag, ddiag, 0);
 }
 
 

--- a/test/matrix/csr_kernels.cpp
+++ b/test/matrix/csr_kernels.cpp
@@ -73,9 +73,9 @@ protected:
         x = gen_mtx<Mtx>(40, 25);
         alpha = gko::initialize<Vec>({2.0}, ref);
         dx = Mtx::create(exec);
-        dx->copy_from(x.get());
+        dx->copy_from(x);
         dalpha = Vec::create(exec);
-        dalpha->copy_from(alpha.get());
+        dalpha->copy_from(alpha);
     }
 
     std::default_random_engine rand_engine;
@@ -91,8 +91,8 @@ TEST_F(Csr, ScaleIsEquivalentToRef)
 {
     set_up_apply_data();
 
-    x->scale(alpha.get());
-    dx->scale(dalpha.get());
+    x->scale(alpha);
+    dx->scale(dalpha);
 
     GKO_ASSERT_MTX_NEAR(dx, x, r<value_type>::value);
 }
@@ -102,8 +102,8 @@ TEST_F(Csr, InvScaleIsEquivalentToRef)
 {
     set_up_apply_data();
 
-    x->inv_scale(alpha.get());
-    dx->inv_scale(dalpha.get());
+    x->inv_scale(alpha);
+    dx->inv_scale(dalpha);
 
     GKO_ASSERT_MTX_NEAR(dx, x, r<value_type>::value);
 }

--- a/test/matrix/csr_kernels2.cpp
+++ b/test/matrix/csr_kernels2.cpp
@@ -99,7 +99,7 @@ protected:
         mtx2 = Mtx::create(ref);
         mtx2->copy_from(gen_mtx<Mtx>(mtx_size[0], mtx_size[1], 5));
         dmtx2 = Mtx::create(exec);
-        dmtx2->copy_from(mtx2.get());
+        dmtx2->copy_from(mtx2);
     }
 
     template <typename Mtx>
@@ -154,9 +154,9 @@ protected:
         alpha = gko::initialize<Vec>({2.0}, ref);
         beta = gko::initialize<Vec>({-1.0}, ref);
         dmtx = Mtx::create(exec, strategy);
-        dmtx->copy_from(mtx.get());
+        dmtx->copy_from(mtx);
         square_dmtx = Mtx::create(exec, strategy);
-        square_dmtx->copy_from(square_mtx.get());
+        square_dmtx->copy_from(square_mtx);
         dresult = gko::clone(exec, expected);
         dy = gko::clone(exec, y);
         dalpha = gko::clone(exec, alpha);
@@ -182,13 +182,13 @@ protected:
         complex_mtx->copy_from(
             gen_mtx<ComplexVec>(mtx_size[0], mtx_size[1], 1));
         complex_dmtx = ComplexMtx::create(exec, strategy);
-        complex_dmtx->copy_from(complex_mtx.get());
+        complex_dmtx->copy_from(complex_mtx);
     }
 
     void unsort_mtx()
     {
-        gko::test::unsort_matrix(mtx.get(), rand_engine);
-        dmtx->copy_from(mtx.get());
+        gko::test::unsort_matrix(mtx, rand_engine);
+        dmtx->copy_from(mtx);
     }
 
     const gko::dim<2> mtx_size;
@@ -229,8 +229,8 @@ TEST_F(Csr, SimpleApplyIsEquivalentToRefWithClassical)
 {
     set_up_apply_data<Mtx::classical>();
 
-    mtx->apply(y.get(), expected.get());
-    dmtx->apply(dy.get(), dresult.get());
+    mtx->apply(y, expected);
+    dmtx->apply(dy, dresult);
 
     GKO_ASSERT_MTX_NEAR(dresult, expected, r<value_type>::value);
 }
@@ -241,8 +241,8 @@ TEST_F(Csr, SimpleApplyIsEquivalentToRefWithClassicalUnsorted)
     set_up_apply_data<Mtx::classical>();
     unsort_mtx();
 
-    mtx->apply(y.get(), expected.get());
-    dmtx->apply(dy.get(), dresult.get());
+    mtx->apply(y, expected);
+    dmtx->apply(dy, dresult);
 
     GKO_ASSERT_MTX_NEAR(dresult, expected, r<value_type>::value);
 }
@@ -252,8 +252,8 @@ TEST_F(Csr, AdvancedApplyIsEquivalentToRefWithClassical)
 {
     set_up_apply_data<Mtx::classical>();
 
-    mtx->apply(alpha.get(), y.get(), beta.get(), expected.get());
-    dmtx->apply(dalpha.get(), dy.get(), dbeta.get(), dresult.get());
+    mtx->apply(alpha, y, beta, expected);
+    dmtx->apply(dalpha, dy, dbeta, dresult);
 
     GKO_ASSERT_MTX_NEAR(dresult, expected, r<value_type>::value);
 }
@@ -263,8 +263,8 @@ TEST_F(Csr, SimpleApplyToDenseMatrixIsEquivalentToRefWithClassical)
 {
     set_up_apply_data<Mtx::classical>(3);
 
-    mtx->apply(y.get(), expected.get());
-    dmtx->apply(dy.get(), dresult.get());
+    mtx->apply(y, expected);
+    dmtx->apply(dy, dresult);
 
     GKO_ASSERT_MTX_NEAR(dresult, expected, r<value_type>::value);
 }
@@ -274,8 +274,8 @@ TEST_F(Csr, AdvancedApplyToDenseMatrixIsEquivalentToRefWithClassical)
 {
     set_up_apply_data<Mtx::classical>(3);
 
-    mtx->apply(alpha.get(), y.get(), beta.get(), expected.get());
-    dmtx->apply(dalpha.get(), dy.get(), dbeta.get(), dresult.get());
+    mtx->apply(alpha, y, beta, expected);
+    dmtx->apply(dalpha, dy, dbeta, dresult);
 
     GKO_ASSERT_MTX_NEAR(dresult, expected, r<value_type>::value);
 }
@@ -289,8 +289,8 @@ TEST_F(Csr, SimpleApplyIsEquivalentToRefWithLoadBalance)
 {
     set_up_apply_data<Mtx::load_balance>();
 
-    mtx->apply(y.get(), expected.get());
-    dmtx->apply(dy.get(), dresult.get());
+    mtx->apply(y, expected);
+    dmtx->apply(dy, dresult);
 
     GKO_ASSERT_MTX_NEAR(dresult, expected, r<value_type>::value);
 }
@@ -301,8 +301,8 @@ TEST_F(Csr, SimpleApplyIsEquivalentToRefWithLoadBalanceUnsorted)
     set_up_apply_data<Mtx::load_balance>();
     unsort_mtx();
 
-    mtx->apply(y.get(), expected.get());
-    dmtx->apply(dy.get(), dresult.get());
+    mtx->apply(y, expected);
+    dmtx->apply(dy, dresult);
 
     GKO_ASSERT_MTX_NEAR(dresult, expected, r<value_type>::value);
 }
@@ -312,8 +312,8 @@ TEST_F(Csr, AdvancedApplyIsEquivalentToRefWithLoadBalance)
 {
     set_up_apply_data<Mtx::load_balance>();
 
-    mtx->apply(alpha.get(), y.get(), beta.get(), expected.get());
-    dmtx->apply(dalpha.get(), dy.get(), dbeta.get(), dresult.get());
+    mtx->apply(alpha, y, beta, expected);
+    dmtx->apply(dalpha, dy, dbeta, dresult);
 
     GKO_ASSERT_MTX_NEAR(dresult, expected, r<value_type>::value);
 }
@@ -323,8 +323,8 @@ TEST_F(Csr, SimpleApplyIsEquivalentToRefWithSparselib)
 {
     set_up_apply_data<Mtx::sparselib>();
 
-    mtx->apply(y.get(), expected.get());
-    dmtx->apply(dy.get(), dresult.get());
+    mtx->apply(y, expected);
+    dmtx->apply(dy, dresult);
 
     GKO_ASSERT_MTX_NEAR(dresult, expected, r<value_type>::value);
 }
@@ -335,8 +335,8 @@ TEST_F(Csr, SimpleApplyIsEquivalentToRefWithSparselibUnsorted)
     set_up_apply_data<Mtx::sparselib>();
     unsort_mtx();
 
-    mtx->apply(y.get(), expected.get());
-    dmtx->apply(dy.get(), dresult.get());
+    mtx->apply(y, expected);
+    dmtx->apply(dy, dresult);
 
     GKO_ASSERT_MTX_NEAR(dresult, expected, r<value_type>::value);
 }
@@ -346,8 +346,8 @@ TEST_F(Csr, AdvancedApplyIsEquivalentToRefWithSparselib)
 {
     set_up_apply_data<Mtx::sparselib>();
 
-    mtx->apply(alpha.get(), y.get(), beta.get(), expected.get());
-    dmtx->apply(dalpha.get(), dy.get(), dbeta.get(), dresult.get());
+    mtx->apply(alpha, y, beta, expected);
+    dmtx->apply(dalpha, dy, dbeta, dresult);
 
     GKO_ASSERT_MTX_NEAR(dresult, expected, r<value_type>::value);
 }
@@ -357,8 +357,8 @@ TEST_F(Csr, SimpleApplyIsEquivalentToRefWithMergePath)
 {
     set_up_apply_data<Mtx::merge_path>();
 
-    mtx->apply(y.get(), expected.get());
-    dmtx->apply(dy.get(), dresult.get());
+    mtx->apply(y, expected);
+    dmtx->apply(dy, dresult);
 
     GKO_ASSERT_MTX_NEAR(dresult, expected, r<value_type>::value);
 }
@@ -369,8 +369,8 @@ TEST_F(Csr, SimpleApplyIsEquivalentToRefWithMergePathUnsorted)
     set_up_apply_data<Mtx::merge_path>();
     unsort_mtx();
 
-    mtx->apply(y.get(), expected.get());
-    dmtx->apply(dy.get(), dresult.get());
+    mtx->apply(y, expected);
+    dmtx->apply(dy, dresult);
 
     GKO_ASSERT_MTX_NEAR(dresult, expected, r<value_type>::value);
 }
@@ -380,8 +380,8 @@ TEST_F(Csr, AdvancedApplyIsEquivalentToRefWithMergePath)
 {
     set_up_apply_data<Mtx::merge_path>();
 
-    mtx->apply(alpha.get(), y.get(), beta.get(), expected.get());
-    dmtx->apply(dalpha.get(), dy.get(), dbeta.get(), dresult.get());
+    mtx->apply(alpha, y, beta, expected);
+    dmtx->apply(dalpha, dy, dbeta, dresult);
 
     GKO_ASSERT_MTX_NEAR(dresult, expected, r<value_type>::value);
 }
@@ -391,8 +391,8 @@ TEST_F(Csr, SimpleApplyIsEquivalentToRefWithAutomatical)
 {
     set_up_apply_data<Mtx::automatical>();
 
-    mtx->apply(y.get(), expected.get());
-    dmtx->apply(dy.get(), dresult.get());
+    mtx->apply(y, expected);
+    dmtx->apply(dy, dresult);
 
     GKO_ASSERT_MTX_NEAR(dresult, expected, r<value_type>::value);
 }
@@ -403,8 +403,8 @@ TEST_F(Csr, SimpleApplyIsEquivalentToRefWithAutomaticalUnsorted)
     set_up_apply_data<Mtx::automatical>();
     unsort_mtx();
 
-    mtx->apply(y.get(), expected.get());
-    dmtx->apply(dy.get(), dresult.get());
+    mtx->apply(y, expected);
+    dmtx->apply(dy, dresult);
 
     GKO_ASSERT_MTX_NEAR(dresult, expected, r<value_type>::value);
 }
@@ -414,8 +414,8 @@ TEST_F(Csr, SimpleApplyToDenseMatrixIsEquivalentToRefWithLoadBalance)
 {
     set_up_apply_data<Mtx::load_balance>(3);
 
-    mtx->apply(y.get(), expected.get());
-    dmtx->apply(dy.get(), dresult.get());
+    mtx->apply(y, expected);
+    dmtx->apply(dy, dresult);
 
     GKO_ASSERT_MTX_NEAR(dresult, expected, r<value_type>::value);
 }
@@ -425,8 +425,8 @@ TEST_F(Csr, AdvancedApplyToDenseMatrixIsEquivalentToRefWithLoadBalance)
 {
     set_up_apply_data<Mtx::load_balance>(3);
 
-    mtx->apply(alpha.get(), y.get(), beta.get(), expected.get());
-    dmtx->apply(dalpha.get(), dy.get(), dbeta.get(), dresult.get());
+    mtx->apply(alpha, y, beta, expected);
+    dmtx->apply(dalpha, dy, dbeta, dresult);
 
     GKO_ASSERT_MTX_NEAR(dresult, expected, r<value_type>::value);
 }
@@ -436,8 +436,8 @@ TEST_F(Csr, SimpleApplyToDenseMatrixIsEquivalentToRefWithMergePath)
 {
     set_up_apply_data<Mtx::merge_path>(3);
 
-    mtx->apply(y.get(), expected.get());
-    dmtx->apply(dy.get(), dresult.get());
+    mtx->apply(y, expected);
+    dmtx->apply(dy, dresult);
 
     GKO_ASSERT_MTX_NEAR(dresult, expected, r<value_type>::value);
 }
@@ -447,8 +447,8 @@ TEST_F(Csr, AdvancedApplyToDenseMatrixIsEquivalentToRefWithMergePath)
 {
     set_up_apply_data<Mtx::merge_path>(3);
 
-    mtx->apply(alpha.get(), y.get(), beta.get(), expected.get());
-    dmtx->apply(dalpha.get(), dy.get(), dbeta.get(), dresult.get());
+    mtx->apply(alpha, y, beta, expected);
+    dmtx->apply(dalpha, dy, dbeta, dresult);
 
     GKO_ASSERT_MTX_NEAR(dresult, expected, r<value_type>::value);
 }
@@ -490,8 +490,8 @@ TEST_F(Csr, AdvancedApplyToCsrMatrixIsEquivalentToRef)
     auto trans = mtx->transpose();
     auto d_trans = dmtx->transpose();
 
-    mtx->apply(alpha.get(), trans.get(), beta.get(), square_mtx.get());
-    dmtx->apply(dalpha.get(), d_trans.get(), dbeta.get(), square_dmtx.get());
+    mtx->apply(alpha, trans, beta, square_mtx);
+    dmtx->apply(dalpha, d_trans, dbeta, square_dmtx);
 
     GKO_ASSERT_MTX_NEAR(square_dmtx, square_mtx, r<value_type>::value);
     GKO_ASSERT_MTX_EQ_SPARSITY(square_dmtx, square_mtx);
@@ -505,8 +505,8 @@ TEST_F(Csr, SimpleApplyToCsrMatrixIsEquivalentToRef)
     auto trans = mtx->transpose();
     auto d_trans = dmtx->transpose();
 
-    mtx->apply(trans.get(), square_mtx.get());
-    dmtx->apply(d_trans.get(), square_dmtx.get());
+    mtx->apply(trans, square_mtx);
+    dmtx->apply(d_trans, square_dmtx);
 
     GKO_ASSERT_MTX_NEAR(square_dmtx, square_mtx, r<value_type>::value);
     GKO_ASSERT_MTX_EQ_SPARSITY(square_dmtx, square_mtx);
@@ -520,10 +520,10 @@ TEST_F(Csr, SimpleApplyToSparseCsrMatrixIsEquivalentToRef)
     auto mtx2 =
         gen_mtx<Mtx>(mtx->get_size()[1], square_mtx->get_size()[1], 0, 10);
     auto dmtx2 = Mtx::create(exec, mtx2->get_size());
-    dmtx2->copy_from(mtx2.get());
+    dmtx2->copy_from(mtx2);
 
-    mtx->apply(mtx2.get(), square_mtx.get());
-    dmtx->apply(dmtx2.get(), square_dmtx.get());
+    mtx->apply(mtx2, square_mtx);
+    dmtx->apply(dmtx2, square_dmtx);
 
     GKO_ASSERT_MTX_EQ_SPARSITY(square_dmtx, square_mtx);
     GKO_ASSERT_MTX_NEAR(square_dmtx, square_mtx, r<value_type>::value);
@@ -540,8 +540,8 @@ TEST_F(Csr, SimpleApplySparseToSparseCsrMatrixIsEquivalentToRef)
     auto dmtx1 = gko::clone(exec, mtx1);
     auto dmtx2 = gko::clone(exec, mtx2);
 
-    mtx1->apply(mtx2.get(), square_mtx.get());
-    dmtx1->apply(dmtx2.get(), square_dmtx.get());
+    mtx1->apply(mtx2, square_mtx);
+    dmtx1->apply(dmtx2, square_dmtx);
 
     GKO_ASSERT_MTX_EQ_SPARSITY(square_dmtx, square_mtx);
     GKO_ASSERT_MTX_NEAR(square_dmtx, square_mtx, r<value_type>::value);
@@ -559,10 +559,10 @@ TEST_F(Csr, SimpleApplyToEmptyCsrMatrixIsEquivalentToRef)
     auto mtx2 =
         gen_mtx<Mtx>(mtx->get_size()[1], square_mtx->get_size()[1], 0, 0);
     auto dmtx2 = Mtx::create(exec, mtx2->get_size());
-    dmtx2->copy_from(mtx2.get());
+    dmtx2->copy_from(mtx2);
 
-    mtx->apply(mtx2.get(), square_mtx.get());
-    dmtx->apply(dmtx2.get(), square_dmtx.get());
+    mtx->apply(mtx2, square_mtx);
+    dmtx->apply(dmtx2, square_dmtx);
 
     GKO_ASSERT_MTX_EQ_SPARSITY(square_dmtx, square_mtx);
     GKO_ASSERT_MTX_NEAR(square_dmtx, square_mtx, r<value_type>::value);
@@ -584,8 +584,8 @@ TEST_F(Csr, AdvancedApplyToIdentityMatrixIsEquivalentToRef)
     auto did =
         gko::matrix::Identity<Mtx::value_type>::create(exec, mtx_size[1]);
 
-    a->apply(alpha.get(), id.get(), beta.get(), b.get());
-    da->apply(dalpha.get(), did.get(), dbeta.get(), db.get());
+    a->apply(alpha, id, beta, b);
+    da->apply(dalpha, did, dbeta, db);
 
     GKO_ASSERT_MTX_NEAR(b, db, r<value_type>::value);
     GKO_ASSERT_MTX_EQ_SPARSITY(b, db);
@@ -601,8 +601,8 @@ TEST_F(Csr, ApplyToComplexIsEquivalentToRef)
     auto complex_x = gen_mtx<ComplexVec>(this->mtx_size[0], 3, 1);
     auto dcomplex_x = gko::clone(exec, complex_x);
 
-    mtx->apply(complex_b.get(), complex_x.get());
-    dmtx->apply(dcomplex_b.get(), dcomplex_x.get());
+    mtx->apply(complex_b, complex_x);
+    dmtx->apply(dcomplex_b, dcomplex_x);
 
     GKO_ASSERT_MTX_NEAR(dcomplex_x, complex_x, r<value_type>::value);
 }
@@ -616,8 +616,8 @@ TEST_F(Csr, AdvancedApplyToComplexIsEquivalentToRef)
     auto complex_x = gen_mtx<ComplexVec>(this->mtx_size[0], 3, 1);
     auto dcomplex_x = gko::clone(exec, complex_x);
 
-    mtx->apply(alpha.get(), complex_b.get(), beta.get(), complex_x.get());
-    dmtx->apply(dalpha.get(), dcomplex_b.get(), dbeta.get(), dcomplex_x.get());
+    mtx->apply(alpha, complex_b, beta, complex_x);
+    dmtx->apply(dalpha, dcomplex_b, dbeta, dcomplex_x);
 
     GKO_ASSERT_MTX_NEAR(dcomplex_x, complex_x, r<value_type>::value);
 }
@@ -681,10 +681,10 @@ TEST_F(Csr, ConvertToDenseIsEquivalentToRef)
     auto dense_mtx = gko::matrix::Dense<value_type>::create(ref);
     auto ddense_mtx = gko::matrix::Dense<value_type>::create(exec);
 
-    mtx->convert_to(dense_mtx.get());
-    dmtx->convert_to(ddense_mtx.get());
+    mtx->convert_to(dense_mtx);
+    dmtx->convert_to(ddense_mtx);
 
-    GKO_ASSERT_MTX_NEAR(dense_mtx.get(), ddense_mtx.get(), 0);
+    GKO_ASSERT_MTX_NEAR(dense_mtx, ddense_mtx, 0);
 }
 
 
@@ -694,10 +694,10 @@ TEST_F(Csr, MoveToDenseIsEquivalentToRef)
     auto dense_mtx = gko::matrix::Dense<value_type>::create(ref);
     auto ddense_mtx = gko::matrix::Dense<value_type>::create(exec);
 
-    mtx->move_to(dense_mtx.get());
-    dmtx->move_to(ddense_mtx.get());
+    mtx->move_to(dense_mtx);
+    dmtx->move_to(ddense_mtx);
 
-    GKO_ASSERT_MTX_NEAR(dense_mtx.get(), ddense_mtx.get(), 0);
+    GKO_ASSERT_MTX_NEAR(dense_mtx, ddense_mtx, 0);
 }
 
 
@@ -707,10 +707,10 @@ TEST_F(Csr, ConvertToEllIsEquivalentToRef)
     auto ell_mtx = gko::matrix::Ell<value_type>::create(ref);
     auto dell_mtx = gko::matrix::Ell<value_type>::create(exec);
 
-    mtx->convert_to(ell_mtx.get());
-    dmtx->convert_to(dell_mtx.get());
+    mtx->convert_to(ell_mtx);
+    dmtx->convert_to(dell_mtx);
 
-    GKO_ASSERT_MTX_NEAR(ell_mtx.get(), dell_mtx.get(), 0);
+    GKO_ASSERT_MTX_NEAR(ell_mtx, dell_mtx, 0);
 }
 
 
@@ -720,10 +720,10 @@ TEST_F(Csr, MoveToEllIsEquivalentToRef)
     auto ell_mtx = gko::matrix::Ell<value_type>::create(ref);
     auto dell_mtx = gko::matrix::Ell<value_type>::create(exec);
 
-    mtx->move_to(ell_mtx.get());
-    dmtx->move_to(dell_mtx.get());
+    mtx->move_to(ell_mtx);
+    dmtx->move_to(dell_mtx);
 
-    GKO_ASSERT_MTX_NEAR(ell_mtx.get(), dell_mtx.get(), 0);
+    GKO_ASSERT_MTX_NEAR(ell_mtx, dell_mtx, 0);
 }
 
 
@@ -733,10 +733,10 @@ TEST_F(Csr, ConvertToSparsityCsrIsEquivalentToRef)
     auto sparsity_mtx = gko::matrix::SparsityCsr<value_type>::create(ref);
     auto d_sparsity_mtx = gko::matrix::SparsityCsr<value_type>::create(exec);
 
-    mtx->convert_to(sparsity_mtx.get());
-    dmtx->convert_to(d_sparsity_mtx.get());
+    mtx->convert_to(sparsity_mtx);
+    dmtx->convert_to(d_sparsity_mtx);
 
-    GKO_ASSERT_MTX_NEAR(sparsity_mtx.get(), d_sparsity_mtx.get(), 0);
+    GKO_ASSERT_MTX_NEAR(sparsity_mtx, d_sparsity_mtx, 0);
 }
 
 
@@ -746,10 +746,10 @@ TEST_F(Csr, MoveToSparsityCsrIsEquivalentToRef)
     auto sparsity_mtx = gko::matrix::SparsityCsr<value_type>::create(ref);
     auto d_sparsity_mtx = gko::matrix::SparsityCsr<value_type>::create(exec);
 
-    mtx->move_to(sparsity_mtx.get());
-    dmtx->move_to(d_sparsity_mtx.get());
+    mtx->move_to(sparsity_mtx);
+    dmtx->move_to(d_sparsity_mtx);
 
-    GKO_ASSERT_MTX_NEAR(sparsity_mtx.get(), d_sparsity_mtx.get(), 0);
+    GKO_ASSERT_MTX_NEAR(sparsity_mtx, d_sparsity_mtx, 0);
 }
 
 
@@ -759,10 +759,10 @@ TEST_F(Csr, ConvertToCooIsEquivalentToRef)
     auto coo_mtx = gko::matrix::Coo<value_type>::create(ref);
     auto dcoo_mtx = gko::matrix::Coo<value_type>::create(exec);
 
-    mtx->convert_to(coo_mtx.get());
-    dmtx->convert_to(dcoo_mtx.get());
+    mtx->convert_to(coo_mtx);
+    dmtx->convert_to(dcoo_mtx);
 
-    GKO_ASSERT_MTX_NEAR(coo_mtx.get(), dcoo_mtx.get(), 0);
+    GKO_ASSERT_MTX_NEAR(coo_mtx, dcoo_mtx, 0);
 }
 
 
@@ -772,10 +772,10 @@ TEST_F(Csr, MoveToCooIsEquivalentToRef)
     auto coo_mtx = gko::matrix::Coo<value_type>::create(ref);
     auto dcoo_mtx = gko::matrix::Coo<value_type>::create(exec);
 
-    mtx->move_to(coo_mtx.get());
-    dmtx->move_to(dcoo_mtx.get());
+    mtx->move_to(coo_mtx);
+    dmtx->move_to(dcoo_mtx);
 
-    GKO_ASSERT_MTX_NEAR(coo_mtx.get(), dcoo_mtx.get(), 0);
+    GKO_ASSERT_MTX_NEAR(coo_mtx, dcoo_mtx, 0);
 }
 
 
@@ -785,10 +785,10 @@ TEST_F(Csr, ConvertToSellpIsEquivalentToRef)
     auto sellp_mtx = gko::matrix::Sellp<value_type>::create(ref);
     auto dsellp_mtx = gko::matrix::Sellp<value_type>::create(exec);
 
-    mtx->convert_to(sellp_mtx.get());
-    dmtx->convert_to(dsellp_mtx.get());
+    mtx->convert_to(sellp_mtx);
+    dmtx->convert_to(dsellp_mtx);
 
-    GKO_ASSERT_MTX_NEAR(sellp_mtx.get(), dsellp_mtx.get(), 0);
+    GKO_ASSERT_MTX_NEAR(sellp_mtx, dsellp_mtx, 0);
 }
 
 
@@ -798,10 +798,10 @@ TEST_F(Csr, MoveToSellpIsEquivalentToRef)
     auto sellp_mtx = gko::matrix::Sellp<value_type>::create(ref);
     auto dsellp_mtx = gko::matrix::Sellp<value_type>::create(exec);
 
-    mtx->move_to(sellp_mtx.get());
-    dmtx->move_to(dsellp_mtx.get());
+    mtx->move_to(sellp_mtx);
+    dmtx->move_to(dsellp_mtx);
 
-    GKO_ASSERT_MTX_NEAR(sellp_mtx.get(), dsellp_mtx.get(), 0);
+    GKO_ASSERT_MTX_NEAR(sellp_mtx, dsellp_mtx, 0);
 }
 
 
@@ -810,7 +810,7 @@ TEST_F(Csr, ConvertsEmptyToSellp)
     auto dempty_mtx = Mtx::create(exec);
     auto dsellp_mtx = gko::matrix::Sellp<value_type>::create(exec);
 
-    dempty_mtx->convert_to(dsellp_mtx.get());
+    dempty_mtx->convert_to(dsellp_mtx);
 
     ASSERT_EQ(exec->copy_val_to_host(dsellp_mtx->get_const_slice_sets()), 0);
     ASSERT_FALSE(dsellp_mtx->get_size());
@@ -826,10 +826,10 @@ TEST_F(Csr, ConvertToHybridIsEquivalentToRef)
     auto dhybrid_mtx = Hybrid_type::create(
         exec, std::make_shared<Hybrid_type::column_limit>(2));
 
-    mtx->convert_to(hybrid_mtx.get());
-    dmtx->convert_to(dhybrid_mtx.get());
+    mtx->convert_to(hybrid_mtx);
+    dmtx->convert_to(dhybrid_mtx);
 
-    GKO_ASSERT_MTX_NEAR(hybrid_mtx.get(), dhybrid_mtx.get(), 0);
+    GKO_ASSERT_MTX_NEAR(hybrid_mtx, dhybrid_mtx, 0);
 }
 
 
@@ -842,10 +842,10 @@ TEST_F(Csr, MoveToHybridIsEquivalentToRef)
     auto dhybrid_mtx = Hybrid_type::create(
         exec, std::make_shared<Hybrid_type::column_limit>(2));
 
-    mtx->move_to(hybrid_mtx.get());
-    dmtx->move_to(dhybrid_mtx.get());
+    mtx->move_to(hybrid_mtx);
+    dmtx->move_to(dhybrid_mtx);
 
-    GKO_ASSERT_MTX_NEAR(hybrid_mtx.get(), dhybrid_mtx.get(), 0);
+    GKO_ASSERT_MTX_NEAR(hybrid_mtx, dhybrid_mtx, 0);
 }
 
 
@@ -988,7 +988,7 @@ TEST_F(Csr, ExtractDiagonalIsEquivalentToRef)
     auto diag = mtx->extract_diagonal();
     auto ddiag = dmtx->extract_diagonal();
 
-    GKO_ASSERT_MTX_NEAR(diag.get(), ddiag.get(), 0);
+    GKO_ASSERT_MTX_NEAR(diag, ddiag, 0);
 }
 
 
@@ -1230,10 +1230,10 @@ TEST_F(Csr, AddScaledIdentityToNonSquare)
 {
     set_up_apply_data<Mtx::classical>();
     gko::utils::ensure_all_diagonal_entries(mtx.get());
-    dmtx->copy_from(mtx.get());
+    dmtx->copy_from(mtx);
 
-    mtx->add_scaled_identity(alpha.get(), beta.get());
-    dmtx->add_scaled_identity(dalpha.get(), dbeta.get());
+    mtx->add_scaled_identity(alpha, beta);
+    dmtx->add_scaled_identity(dalpha, dbeta);
 
     GKO_ASSERT_MTX_NEAR(mtx, dmtx, r<value_type>::value);
 }

--- a/test/matrix/csr_kernels2.cpp
+++ b/test/matrix/csr_kernels2.cpp
@@ -97,7 +97,7 @@ protected:
     void set_up_mat_data()
     {
         mtx2 = Mtx::create(ref);
-        mtx2->copy_from(gen_mtx<Mtx>(mtx_size[0], mtx_size[1], 5));
+        mtx2->move_from(gen_mtx<Mtx>(mtx_size[0], mtx_size[1], 5));
         dmtx2 = Mtx::create(exec);
         dmtx2->copy_from(mtx2);
     }
@@ -146,9 +146,9 @@ protected:
         std::shared_ptr<StrategyType> strategy;
         set_up_strategy<Mtx>(strategy);
         mtx = Mtx::create(ref, strategy);
-        mtx->copy_from(gen_mtx<Vec>(mtx_size[0], mtx_size[1], 1));
+        mtx->move_from(gen_mtx<Vec>(mtx_size[0], mtx_size[1], 1));
         square_mtx = Mtx::create(ref, strategy);
-        square_mtx->copy_from(gen_mtx<Vec>(mtx_size[0], mtx_size[0], 1));
+        square_mtx->move_from(gen_mtx<Vec>(mtx_size[0], mtx_size[0], 1));
         expected = gen_mtx<Vec>(mtx_size[0], num_vectors, 1);
         y = gen_mtx<Vec>(mtx_size[1], num_vectors, 1);
         alpha = gko::initialize<Vec>({2.0}, ref);
@@ -179,7 +179,7 @@ protected:
         std::shared_ptr<StrategyType> strategy;
         set_up_strategy<ComplexMtx>(strategy);
         complex_mtx = ComplexMtx::create(ref, strategy);
-        complex_mtx->copy_from(
+        complex_mtx->move_from(
             gen_mtx<ComplexVec>(mtx_size[0], mtx_size[1], 1));
         complex_dmtx = ComplexMtx::create(exec, strategy);
         complex_dmtx->copy_from(complex_mtx);

--- a/test/matrix/dense_kernels.cpp
+++ b/test/matrix/dense_kernels.cpp
@@ -161,7 +161,7 @@ protected:
     std::unique_ptr<ConvertedType> convert(InputType&& input)
     {
         auto result = ConvertedType::create(input->get_executor());
-        input->convert_to(result.get());
+        input->convert_to(result);
         return result;
     }
 
@@ -195,8 +195,8 @@ TEST_F(Dense, SingleVectorComputeDotIsEquivalentToRef)
 {
     set_up_vector_data(1);
 
-    x->compute_dot(y.get(), result.get());
-    dx->compute_dot(dy.get(), dresult.get());
+    x->compute_dot(y, result);
+    dx->compute_dot(dy, dresult);
 
     GKO_ASSERT_MTX_NEAR(dresult, result, r<value_type>::value);
 }
@@ -206,8 +206,8 @@ TEST_F(Dense, MultipleVectorComputeDotIsEquivalentToRef)
 {
     set_up_vector_data(20);
 
-    x->compute_dot(y.get(), result.get());
-    dx->compute_dot(dy.get(), dresult.get());
+    x->compute_dot(y, result);
+    dx->compute_dot(dy, dresult);
 
     GKO_ASSERT_MTX_NEAR(dresult, result, r<value_type>::value);
 }
@@ -217,8 +217,8 @@ TEST_F(Dense, SingleVectorComputeConjDotIsEquivalentToRef)
 {
     set_up_vector_data(1);
 
-    x->compute_conj_dot(y.get(), result.get());
-    dx->compute_conj_dot(dy.get(), dresult.get());
+    x->compute_conj_dot(y, result);
+    dx->compute_conj_dot(dy, dresult);
 
     GKO_ASSERT_MTX_NEAR(dresult, result, r<value_type>::value);
 }
@@ -228,8 +228,8 @@ TEST_F(Dense, MultipleVectorComputeConjDotIsEquivalentToRef)
 {
     set_up_vector_data(20);
 
-    x->compute_conj_dot(y.get(), result.get());
-    dx->compute_conj_dot(dy.get(), dresult.get());
+    x->compute_conj_dot(y, result);
+    dx->compute_conj_dot(dy, dresult);
 
     GKO_ASSERT_MTX_NEAR(dresult, result, r<value_type>::value);
 }
@@ -242,8 +242,8 @@ TEST_F(Dense, SingleVectorComputeNorm2IsEquivalentToRef)
     auto norm_expected = NormVector::create(this->ref, norm_size);
     auto dnorm = NormVector::create(this->exec, norm_size);
 
-    x->compute_norm2(norm_expected.get());
-    dx->compute_norm2(dnorm.get());
+    x->compute_norm2(norm_expected);
+    dx->compute_norm2(dnorm);
 
     GKO_ASSERT_MTX_NEAR(norm_expected, dnorm, r<value_type>::value);
 }
@@ -256,8 +256,8 @@ TEST_F(Dense, MultipleVectorComputeNorm2IsEquivalentToRef)
     auto norm_expected = NormVector::create(this->ref, norm_size);
     auto dnorm = NormVector::create(this->exec, norm_size);
 
-    x->compute_norm2(norm_expected.get());
-    dx->compute_norm2(dnorm.get());
+    x->compute_norm2(norm_expected);
+    dx->compute_norm2(dnorm);
 
     GKO_ASSERT_MTX_NEAR(norm_expected, dnorm, r<value_type>::value);
 }
@@ -267,8 +267,8 @@ TEST_F(Dense, SimpleApplyIsEquivalentToRef)
 {
     set_up_apply_data();
 
-    x->apply(y.get(), result.get());
-    dx->apply(dy.get(), dresult.get());
+    x->apply(y, result);
+    dx->apply(dy, dresult);
 
     GKO_ASSERT_MTX_NEAR(dresult, result, r<value_type>::value);
 }
@@ -278,8 +278,8 @@ TEST_F(Dense, SimpleApplyMixedIsEquivalentToRef)
 {
     set_up_apply_data();
 
-    x->apply(convert<MixedMtx>(y).get(), convert<MixedMtx>(result).get());
-    dx->apply(convert<MixedMtx>(dy).get(), convert<MixedMtx>(dresult).get());
+    x->apply(convert<MixedMtx>(y), convert<MixedMtx>(result));
+    dx->apply(convert<MixedMtx>(dy), convert<MixedMtx>(dresult));
 
     GKO_ASSERT_MTX_NEAR(dresult, result, 1e-7);
 }
@@ -289,8 +289,8 @@ TEST_F(Dense, AdvancedApplyIsEquivalentToRef)
 {
     set_up_apply_data();
 
-    x->apply(alpha.get(), y.get(), beta.get(), result.get());
-    dx->apply(dalpha.get(), dy.get(), dbeta.get(), dresult.get());
+    x->apply(alpha, y, beta, result);
+    dx->apply(dalpha, dy, dbeta, dresult);
 
     GKO_ASSERT_MTX_NEAR(dresult, result, r<value_type>::value);
 }
@@ -300,10 +300,10 @@ TEST_F(Dense, AdvancedApplyMixedIsEquivalentToRef)
 {
     set_up_apply_data();
 
-    x->apply(convert<MixedMtx>(alpha).get(), convert<MixedMtx>(y).get(),
-             convert<MixedMtx>(beta).get(), convert<MixedMtx>(result).get());
-    dx->apply(convert<MixedMtx>(dalpha).get(), convert<MixedMtx>(dy).get(),
-              convert<MixedMtx>(dbeta).get(), convert<MixedMtx>(dresult).get());
+    x->apply(convert<MixedMtx>(alpha), convert<MixedMtx>(y),
+             convert<MixedMtx>(beta), convert<MixedMtx>(result));
+    dx->apply(convert<MixedMtx>(dalpha), convert<MixedMtx>(dy),
+              convert<MixedMtx>(dbeta), convert<MixedMtx>(dresult));
 
     GKO_ASSERT_MTX_NEAR(dresult, result, 1e-7);
 }
@@ -317,8 +317,8 @@ TEST_F(Dense, ApplyToComplexIsEquivalentToRef)
     auto complex_x = gen_mtx<ComplexMtx>(x->get_size()[0], 1);
     auto dcomplex_x = gko::clone(exec, complex_x);
 
-    x->apply(complex_b.get(), complex_x.get());
-    dx->apply(dcomplex_b.get(), dcomplex_x.get());
+    x->apply(complex_b, complex_x);
+    dx->apply(dcomplex_b, dcomplex_x);
 
     GKO_ASSERT_MTX_NEAR(dcomplex_x, complex_x, r<value_type>::value);
 }
@@ -332,8 +332,8 @@ TEST_F(Dense, ApplyToMixedComplexIsEquivalentToRef)
     auto complex_x = gen_mtx<ComplexMtx>(x->get_size()[0], 1);
     auto dcomplex_x = gko::clone(exec, complex_x);
 
-    x->apply(complex_b.get(), complex_x.get());
-    dx->apply(dcomplex_b.get(), dcomplex_x.get());
+    x->apply(complex_b, complex_x);
+    dx->apply(dcomplex_b, dcomplex_x);
 
     GKO_ASSERT_MTX_NEAR(dcomplex_x, complex_x, 2e-7);
 }
@@ -347,8 +347,8 @@ TEST_F(Dense, AdvancedApplyToComplexIsEquivalentToRef)
     auto complex_x = gen_mtx<ComplexMtx>(x->get_size()[0], 1);
     auto dcomplex_x = gko::clone(exec, complex_x);
 
-    x->apply(alpha.get(), complex_b.get(), beta.get(), complex_x.get());
-    dx->apply(dalpha.get(), dcomplex_b.get(), dbeta.get(), dcomplex_x.get());
+    x->apply(alpha, complex_b, beta, complex_x);
+    dx->apply(dalpha, dcomplex_b, dbeta, dcomplex_x);
 
     GKO_ASSERT_MTX_NEAR(dcomplex_x, complex_x, r<value_type>::value);
 }
@@ -362,10 +362,10 @@ TEST_F(Dense, AdvancedApplyToMixedComplexIsEquivalentToRef)
     auto complex_x = gen_mtx<ComplexMtx>(x->get_size()[0], 1);
     auto dcomplex_x = gko::clone(exec, complex_x);
 
-    x->apply(convert<MixedMtx>(alpha).get(), complex_b.get(),
-             convert<MixedMtx>(beta).get(), complex_x.get());
-    dx->apply(convert<MixedMtx>(dalpha).get(), dcomplex_b.get(),
-              convert<MixedMtx>(dbeta).get(), dcomplex_x.get());
+    x->apply(convert<MixedMtx>(alpha), complex_b, convert<MixedMtx>(beta),
+             complex_x);
+    dx->apply(convert<MixedMtx>(dalpha), dcomplex_b, convert<MixedMtx>(dbeta),
+              dcomplex_x);
 
     GKO_ASSERT_MTX_NEAR(dcomplex_x, complex_x, 2e-7);
 }
@@ -381,8 +381,8 @@ TEST_F(Dense, ComputeDotComplexIsEquivalentToRef)
     auto result = ComplexMtx::create(ref, gko::dim<2>{1, 2});
     auto dresult = ComplexMtx::create(exec, gko::dim<2>{1, 2});
 
-    complex_b->compute_dot(complex_x.get(), result.get());
-    dcomplex_b->compute_dot(dcomplex_x.get(), dresult.get());
+    complex_b->compute_dot(complex_x, result);
+    dcomplex_b->compute_dot(dcomplex_x, dresult);
 
     GKO_ASSERT_MTX_NEAR(result, dresult, r<value_type>::value * 2);
 }
@@ -398,8 +398,8 @@ TEST_F(Dense, ComputeConjDotComplexIsEquivalentToRef)
     auto result = ComplexMtx::create(ref, gko::dim<2>{1, 2});
     auto dresult = ComplexMtx::create(exec, gko::dim<2>{1, 2});
 
-    complex_b->compute_conj_dot(complex_x.get(), result.get());
-    dcomplex_b->compute_conj_dot(dcomplex_x.get(), dresult.get());
+    complex_b->compute_conj_dot(complex_x, result);
+    dcomplex_b->compute_conj_dot(dcomplex_x, dresult);
 
     GKO_ASSERT_MTX_NEAR(result, dresult, r<value_type>::value * 2);
 }
@@ -411,12 +411,12 @@ TEST_F(Dense, ConvertToCooIsEquivalentToRef)
     auto coo_mtx = gko::matrix::Coo<value_type>::create(ref);
     auto dcoo_mtx = gko::matrix::Coo<value_type>::create(exec);
 
-    x->convert_to(coo_mtx.get());
-    dx->convert_to(dcoo_mtx.get());
+    x->convert_to(coo_mtx);
+    dx->convert_to(dcoo_mtx);
 
     ASSERT_EQ(dcoo_mtx->get_num_stored_elements(),
               coo_mtx->get_num_stored_elements());
-    GKO_ASSERT_MTX_NEAR(dcoo_mtx.get(), coo_mtx.get(), 0);
+    GKO_ASSERT_MTX_NEAR(dcoo_mtx, coo_mtx, 0);
 }
 
 
@@ -426,12 +426,12 @@ TEST_F(Dense, MoveToCooIsEquivalentToRef)
     auto coo_mtx = gko::matrix::Coo<value_type>::create(ref);
     auto dcoo_mtx = gko::matrix::Coo<value_type>::create(exec);
 
-    x->move_to(coo_mtx.get());
-    dx->move_to(dcoo_mtx.get());
+    x->move_to(coo_mtx);
+    dx->move_to(dcoo_mtx);
 
     ASSERT_EQ(dcoo_mtx->get_num_stored_elements(),
               coo_mtx->get_num_stored_elements());
-    GKO_ASSERT_MTX_NEAR(dcoo_mtx.get(), coo_mtx.get(), 0);
+    GKO_ASSERT_MTX_NEAR(dcoo_mtx, coo_mtx, 0);
 }
 
 
@@ -441,10 +441,10 @@ TEST_F(Dense, ConvertToCsrIsEquivalentToRef)
     auto csr_mtx = gko::matrix::Csr<value_type>::create(ref);
     auto dcsr_mtx = gko::matrix::Csr<value_type>::create(exec);
 
-    x->convert_to(csr_mtx.get());
-    dx->convert_to(dcsr_mtx.get());
+    x->convert_to(csr_mtx);
+    dx->convert_to(dcsr_mtx);
 
-    GKO_ASSERT_MTX_NEAR(dcsr_mtx.get(), csr_mtx.get(), 0);
+    GKO_ASSERT_MTX_NEAR(dcsr_mtx, csr_mtx, 0);
 }
 
 
@@ -454,10 +454,10 @@ TEST_F(Dense, MoveToCsrIsEquivalentToRef)
     auto csr_mtx = gko::matrix::Csr<value_type>::create(ref);
     auto dcsr_mtx = gko::matrix::Csr<value_type>::create(exec);
 
-    x->move_to(csr_mtx.get());
-    dx->move_to(dcsr_mtx.get());
+    x->move_to(csr_mtx);
+    dx->move_to(dcsr_mtx);
 
-    GKO_ASSERT_MTX_NEAR(dcsr_mtx.get(), csr_mtx.get(), 0);
+    GKO_ASSERT_MTX_NEAR(dcsr_mtx, csr_mtx, 0);
 }
 
 
@@ -467,10 +467,10 @@ TEST_F(Dense, ConvertToSparsityCsrIsEquivalentToRef)
     auto sparsity_mtx = gko::matrix::SparsityCsr<value_type>::create(ref);
     auto d_sparsity_mtx = gko::matrix::SparsityCsr<value_type>::create(exec);
 
-    x->convert_to(sparsity_mtx.get());
-    dx->convert_to(d_sparsity_mtx.get());
+    x->convert_to(sparsity_mtx);
+    dx->convert_to(d_sparsity_mtx);
 
-    GKO_ASSERT_MTX_NEAR(d_sparsity_mtx.get(), sparsity_mtx.get(), 0);
+    GKO_ASSERT_MTX_NEAR(d_sparsity_mtx, sparsity_mtx, 0);
 }
 
 
@@ -480,10 +480,10 @@ TEST_F(Dense, MoveToSparsityCsrIsEquivalentToRef)
     auto sparsity_mtx = gko::matrix::SparsityCsr<value_type>::create(ref);
     auto d_sparsity_mtx = gko::matrix::SparsityCsr<value_type>::create(exec);
 
-    x->move_to(sparsity_mtx.get());
-    dx->move_to(d_sparsity_mtx.get());
+    x->move_to(sparsity_mtx);
+    dx->move_to(d_sparsity_mtx);
 
-    GKO_ASSERT_MTX_NEAR(d_sparsity_mtx.get(), sparsity_mtx.get(), 0);
+    GKO_ASSERT_MTX_NEAR(d_sparsity_mtx, sparsity_mtx, 0);
 }
 
 
@@ -493,10 +493,10 @@ TEST_F(Dense, ConvertToEllIsEquivalentToRef)
     auto ell_mtx = gko::matrix::Ell<value_type>::create(ref);
     auto dell_mtx = gko::matrix::Ell<value_type>::create(exec);
 
-    x->convert_to(ell_mtx.get());
-    dx->convert_to(dell_mtx.get());
+    x->convert_to(ell_mtx);
+    dx->convert_to(dell_mtx);
 
-    GKO_ASSERT_MTX_NEAR(dell_mtx.get(), ell_mtx.get(), 0);
+    GKO_ASSERT_MTX_NEAR(dell_mtx, ell_mtx, 0);
 }
 
 
@@ -506,10 +506,10 @@ TEST_F(Dense, MoveToEllIsEquivalentToRef)
     auto ell_mtx = gko::matrix::Ell<value_type>::create(ref);
     auto dell_mtx = gko::matrix::Ell<value_type>::create(exec);
 
-    x->move_to(ell_mtx.get());
-    dx->move_to(dell_mtx.get());
+    x->move_to(ell_mtx);
+    dx->move_to(dell_mtx);
 
-    GKO_ASSERT_MTX_NEAR(dell_mtx.get(), ell_mtx.get(), 0);
+    GKO_ASSERT_MTX_NEAR(dell_mtx, ell_mtx, 0);
 }
 
 
@@ -522,10 +522,10 @@ TEST_F(Dense, ConvertToHybridIsEquivalentToRef)
     auto drmtx = Mtx::create(ref);
     auto domtx = Mtx::create(exec);
 
-    rmtx->convert_to(srmtx.get());
-    omtx->convert_to(somtx.get());
-    srmtx->convert_to(drmtx.get());
-    somtx->convert_to(domtx.get());
+    rmtx->convert_to(srmtx);
+    omtx->convert_to(somtx);
+    srmtx->convert_to(drmtx);
+    somtx->convert_to(domtx);
 
     GKO_ASSERT_MTX_NEAR(drmtx, domtx, 0);
     GKO_ASSERT_MTX_NEAR(srmtx, somtx, 0);
@@ -542,10 +542,10 @@ TEST_F(Dense, MoveToHybridIsEquivalentToRef)
     auto drmtx = Mtx::create(ref);
     auto domtx = Mtx::create(exec);
 
-    rmtx->move_to(srmtx.get());
-    omtx->move_to(somtx.get());
-    srmtx->move_to(drmtx.get());
-    somtx->move_to(domtx.get());
+    rmtx->move_to(srmtx);
+    omtx->move_to(somtx);
+    srmtx->move_to(drmtx);
+    somtx->move_to(domtx);
 
     GKO_ASSERT_MTX_NEAR(drmtx, domtx, 0);
     GKO_ASSERT_MTX_NEAR(srmtx, somtx, 0);
@@ -559,8 +559,8 @@ TEST_F(Dense, ConvertToSellpIsEquivalentToRef)
     auto sellp_mtx = gko::matrix::Sellp<value_type>::create(ref);
     auto dsellp_mtx = gko::matrix::Sellp<value_type>::create(exec);
 
-    x->convert_to(sellp_mtx.get());
-    dx->convert_to(dsellp_mtx.get());
+    x->convert_to(sellp_mtx);
+    dx->convert_to(dsellp_mtx);
 
     GKO_ASSERT_MTX_NEAR(sellp_mtx, dsellp_mtx, 0);
 }
@@ -572,8 +572,8 @@ TEST_F(Dense, MoveToSellpIsEquivalentToRef)
     auto sellp_mtx = gko::matrix::Sellp<value_type>::create(ref);
     auto dsellp_mtx = gko::matrix::Sellp<value_type>::create(exec);
 
-    x->move_to(sellp_mtx.get());
-    dx->move_to(dsellp_mtx.get());
+    x->move_to(sellp_mtx);
+    dx->move_to(dsellp_mtx);
 
     GKO_ASSERT_MTX_NEAR(sellp_mtx, dsellp_mtx, 0);
 }
@@ -584,7 +584,7 @@ TEST_F(Dense, ConvertsEmptyToSellp)
     auto dempty_mtx = Mtx::create(exec);
     auto dsellp_mtx = gko::matrix::Sellp<value_type>::create(exec);
 
-    dempty_mtx->convert_to(dsellp_mtx.get());
+    dempty_mtx->convert_to(dsellp_mtx);
 
     ASSERT_EQ(exec->copy_val_to_host(dsellp_mtx->get_const_slice_sets()), 0);
     ASSERT_FALSE(dsellp_mtx->get_size());
@@ -651,8 +651,8 @@ TEST_F(Dense, IsTransposableIntoDenseCrossExecutor)
     auto dtrans = Mtx::create(ref, gko::transpose(sub_x->get_size()),
                               sub_x->get_size()[0] + 4);
 
-    sub_x->transpose(trans.get());
-    sub_dx->transpose(dtrans.get());
+    sub_x->transpose(trans);
+    sub_dx->transpose(dtrans);
 
     GKO_ASSERT_MTX_NEAR(dtrans, trans, 0);
 }
@@ -687,8 +687,8 @@ TEST_F(Dense, IsConjugateTransposableIntoDenseCrossExecutor)
     auto dtrans = ComplexMtx::create(ref, gko::transpose(sub_x->get_size()),
                                      sub_x->get_size()[0] + 4);
 
-    sub_x->conj_transpose(trans.get());
-    sub_dx->conj_transpose(dtrans.get());
+    sub_x->conj_transpose(trans);
+    sub_dx->conj_transpose(dtrans);
 
     GKO_ASSERT_MTX_NEAR(dtrans, trans, 0);
 }
@@ -705,9 +705,9 @@ TEST_F(Dense, CopyRespectsStride)
     value_type val = 1234567.0;
     auto original_data = result->get_values();
     auto padding_ptr = original_data + dx->get_size()[1];
-    exec->copy_from(ref.get(), 1, &val, padding_ptr);
+    exec->copy_from(ref, 1, &val, padding_ptr);
 
-    dx->convert_to(result.get());
+    dx->convert_to(result);
 
     GKO_ASSERT_MTX_NEAR(result, dx, 0);
     ASSERT_EQ(result->get_stride(), stride);
@@ -746,8 +746,8 @@ TEST_F(Dense, SingleVectorScaleIsEquivalentToRef)
 {
     set_up_vector_data(1);
 
-    x->scale(alpha.get());
-    dx->scale(dalpha.get());
+    x->scale(alpha);
+    dx->scale(dalpha);
 
     GKO_ASSERT_MTX_NEAR(dx, x, r<value_type>::value);
 }
@@ -757,8 +757,8 @@ TEST_F(Dense, SingleVectorInvScaleIsEquivalentToRef)
 {
     set_up_vector_data(1);
 
-    x->inv_scale(alpha.get());
-    dx->inv_scale(dalpha.get());
+    x->inv_scale(alpha);
+    dx->inv_scale(dalpha);
 
     GKO_ASSERT_MTX_NEAR(dx, x, r<value_type>::value);
 }
@@ -768,8 +768,8 @@ TEST_F(Dense, SingleVectorComplexScaleIsEquivalentToRef)
 {
     set_up_vector_data(1);
 
-    c_x->scale(c_alpha.get());
-    dc_x->scale(dc_alpha.get());
+    c_x->scale(c_alpha);
+    dc_x->scale(dc_alpha);
 
     GKO_ASSERT_MTX_NEAR(dc_x, c_x, r<value_type>::value);
 }
@@ -779,8 +779,8 @@ TEST_F(Dense, SingleVectorComplexInvScaleIsEquivalentToRef)
 {
     set_up_vector_data(1);
 
-    c_x->inv_scale(c_alpha.get());
-    dc_x->inv_scale(dc_alpha.get());
+    c_x->inv_scale(c_alpha);
+    dc_x->inv_scale(dc_alpha);
 
     GKO_ASSERT_MTX_NEAR(dc_x, c_x, r<value_type>::value);
 }
@@ -790,8 +790,8 @@ TEST_F(Dense, SingleVectorComplexRealScaleIsEquivalentToRef)
 {
     set_up_vector_data(1);
 
-    c_x->scale(alpha.get());
-    dc_x->scale(dalpha.get());
+    c_x->scale(alpha);
+    dc_x->scale(dalpha);
 
     GKO_ASSERT_MTX_NEAR(dc_x, c_x, r<value_type>::value);
 }
@@ -801,8 +801,8 @@ TEST_F(Dense, SingleVectorComplexRealInvScaleIsEquivalentToRef)
 {
     set_up_vector_data(1);
 
-    c_x->inv_scale(alpha.get());
-    dc_x->inv_scale(dalpha.get());
+    c_x->inv_scale(alpha);
+    dc_x->inv_scale(dalpha);
 
     GKO_ASSERT_MTX_NEAR(dc_x, c_x, r<value_type>::value);
 }
@@ -812,8 +812,8 @@ TEST_F(Dense, MultipleVectorScaleIsEquivalentToRef)
 {
     set_up_vector_data(20);
 
-    x->scale(alpha.get());
-    dx->scale(dalpha.get());
+    x->scale(alpha);
+    dx->scale(dalpha);
 
     GKO_ASSERT_MTX_NEAR(dx, x, r<value_type>::value);
 }
@@ -823,8 +823,8 @@ TEST_F(Dense, MultipleVectorInvScaleIsEquivalentToRef)
 {
     set_up_vector_data(20);
 
-    x->inv_scale(alpha.get());
-    dx->inv_scale(dalpha.get());
+    x->inv_scale(alpha);
+    dx->inv_scale(dalpha);
 
     GKO_ASSERT_MTX_NEAR(dx, x, r<value_type>::value);
 }
@@ -834,8 +834,8 @@ TEST_F(Dense, MultipleVectorComplexScaleIsEquivalentToRef)
 {
     set_up_vector_data(20);
 
-    c_x->scale(c_alpha.get());
-    dc_x->scale(dc_alpha.get());
+    c_x->scale(c_alpha);
+    dc_x->scale(dc_alpha);
 
     GKO_ASSERT_MTX_NEAR(dc_x, c_x, r<value_type>::value);
 }
@@ -845,8 +845,8 @@ TEST_F(Dense, MultipleVectorComplexInvScaleIsEquivalentToRef)
 {
     set_up_vector_data(20);
 
-    c_x->inv_scale(c_alpha.get());
-    dc_x->inv_scale(dc_alpha.get());
+    c_x->inv_scale(c_alpha);
+    dc_x->inv_scale(dc_alpha);
 
     GKO_ASSERT_MTX_NEAR(dc_x, c_x, r<value_type>::value);
 }
@@ -856,8 +856,8 @@ TEST_F(Dense, MultipleVectorComplexRealScaleIsEquivalentToRef)
 {
     set_up_vector_data(20);
 
-    c_x->scale(alpha.get());
-    dc_x->scale(dalpha.get());
+    c_x->scale(alpha);
+    dc_x->scale(dalpha);
 
     GKO_ASSERT_MTX_NEAR(dc_x, c_x, r<value_type>::value);
 }
@@ -867,8 +867,8 @@ TEST_F(Dense, MultipleVectorComplexRealInvScaleIsEquivalentToRef)
 {
     set_up_vector_data(20);
 
-    c_x->inv_scale(alpha.get());
-    dc_x->inv_scale(dalpha.get());
+    c_x->inv_scale(alpha);
+    dc_x->inv_scale(dalpha);
 
     GKO_ASSERT_MTX_NEAR(dc_x, c_x, r<value_type>::value);
 }
@@ -878,8 +878,8 @@ TEST_F(Dense, MultipleVectorScaleWithDifferentAlphaIsEquivalentToRef)
 {
     set_up_vector_data(20, true);
 
-    x->scale(alpha.get());
-    dx->scale(dalpha.get());
+    x->scale(alpha);
+    dx->scale(dalpha);
 
     GKO_ASSERT_MTX_NEAR(dx, x, r<value_type>::value);
 }
@@ -889,8 +889,8 @@ TEST_F(Dense, MultipleVectorInvScaleWithDifferentAlphaIsEquivalentToRef)
 {
     set_up_vector_data(20, true);
 
-    x->inv_scale(alpha.get());
-    dx->inv_scale(dalpha.get());
+    x->inv_scale(alpha);
+    dx->inv_scale(dalpha);
 
     GKO_ASSERT_MTX_NEAR(dx, x, r<value_type>::value);
 }
@@ -900,8 +900,8 @@ TEST_F(Dense, MultipleVectorComplexScaleWithDifferentAlphaIsEquivalentToRef)
 {
     set_up_vector_data(20, true);
 
-    c_x->scale(c_alpha.get());
-    dc_x->scale(dc_alpha.get());
+    c_x->scale(c_alpha);
+    dc_x->scale(dc_alpha);
 
     GKO_ASSERT_MTX_NEAR(dc_x, c_x, r<value_type>::value);
 }
@@ -911,8 +911,8 @@ TEST_F(Dense, MultipleVectorComplexInvScaleWithDifferentAlphaIsEquivalentToRef)
 {
     set_up_vector_data(20, true);
 
-    c_x->inv_scale(c_alpha.get());
-    dc_x->inv_scale(dc_alpha.get());
+    c_x->inv_scale(c_alpha);
+    dc_x->inv_scale(dc_alpha);
 
     GKO_ASSERT_MTX_NEAR(dc_x, c_x, r<value_type>::value);
 }
@@ -922,8 +922,8 @@ TEST_F(Dense, MultipleVectorComplexRealScaleWithDifferentAlphaIsEquivalentToRef)
 {
     set_up_vector_data(20, true);
 
-    c_x->scale(alpha.get());
-    dc_x->scale(dalpha.get());
+    c_x->scale(alpha);
+    dc_x->scale(dalpha);
 
     GKO_ASSERT_MTX_NEAR(dc_x, c_x, r<value_type>::value);
 }
@@ -934,8 +934,8 @@ TEST_F(Dense,
 {
     set_up_vector_data(20, true);
 
-    c_x->inv_scale(alpha.get());
-    dc_x->inv_scale(dalpha.get());
+    c_x->inv_scale(alpha);
+    dc_x->inv_scale(dalpha);
 
     GKO_ASSERT_MTX_NEAR(dc_x, c_x, r<value_type>::value);
 }
@@ -945,8 +945,8 @@ TEST_F(Dense, SingleVectorAddScaledIsEquivalentToRef)
 {
     set_up_vector_data(1);
 
-    x->add_scaled(alpha.get(), y.get());
-    dx->add_scaled(dalpha.get(), dy.get());
+    x->add_scaled(alpha, y);
+    dx->add_scaled(dalpha, dy);
 
     GKO_ASSERT_MTX_NEAR(dx, x, r<value_type>::value);
 }
@@ -956,8 +956,8 @@ TEST_F(Dense, SingleVectorSubtractScaledIsEquivalentToRef)
 {
     set_up_vector_data(1);
 
-    x->sub_scaled(alpha.get(), y.get());
-    dx->sub_scaled(dalpha.get(), dy.get());
+    x->sub_scaled(alpha, y);
+    dx->sub_scaled(dalpha, dy);
 
     GKO_ASSERT_MTX_NEAR(dx, x, r<value_type>::value);
 }
@@ -967,8 +967,8 @@ TEST_F(Dense, SingleVectorComplexAddScaledIsEquivalentToRef)
 {
     set_up_vector_data(1);
 
-    c_x->add_scaled(c_alpha.get(), c_y.get());
-    dc_x->add_scaled(dc_alpha.get(), dc_y.get());
+    c_x->add_scaled(c_alpha, c_y);
+    dc_x->add_scaled(dc_alpha, dc_y);
 
     GKO_ASSERT_MTX_NEAR(dc_x, c_x, r<value_type>::value);
 }
@@ -978,8 +978,8 @@ TEST_F(Dense, SingleVectorComplexSubtractScaledIsEquivalentToRef)
 {
     set_up_vector_data(1);
 
-    c_x->sub_scaled(c_alpha.get(), c_y.get());
-    dc_x->sub_scaled(dc_alpha.get(), dc_y.get());
+    c_x->sub_scaled(c_alpha, c_y);
+    dc_x->sub_scaled(dc_alpha, dc_y);
 
     GKO_ASSERT_MTX_NEAR(dc_x, c_x, r<value_type>::value);
 }
@@ -989,8 +989,8 @@ TEST_F(Dense, SingleVectorComplexRealAddScaledIsEquivalentToRef)
 {
     set_up_vector_data(1);
 
-    c_x->add_scaled(alpha.get(), c_y.get());
-    dc_x->add_scaled(dalpha.get(), dc_y.get());
+    c_x->add_scaled(alpha, c_y);
+    dc_x->add_scaled(dalpha, dc_y);
 
     GKO_ASSERT_MTX_NEAR(dc_x, c_x, r<value_type>::value);
 }
@@ -1000,8 +1000,8 @@ TEST_F(Dense, SingleVectorComplexRealSubtractScaledIsEquivalentToRef)
 {
     set_up_vector_data(1);
 
-    c_x->sub_scaled(alpha.get(), c_y.get());
-    dc_x->sub_scaled(dalpha.get(), dc_y.get());
+    c_x->sub_scaled(alpha, c_y);
+    dc_x->sub_scaled(dalpha, dc_y);
 
     GKO_ASSERT_MTX_NEAR(dc_x, c_x, r<value_type>::value);
 }
@@ -1011,8 +1011,8 @@ TEST_F(Dense, MultipleVectorAddScaledIsEquivalentToRef)
 {
     set_up_vector_data(20);
 
-    x->add_scaled(alpha.get(), y.get());
-    dx->add_scaled(dalpha.get(), dy.get());
+    x->add_scaled(alpha, y);
+    dx->add_scaled(dalpha, dy);
 
     GKO_ASSERT_MTX_NEAR(dx, x, r<value_type>::value);
 }
@@ -1022,8 +1022,8 @@ TEST_F(Dense, MultipleVectorSubtractScaledIsEquivalentToRef)
 {
     set_up_vector_data(20);
 
-    x->sub_scaled(alpha.get(), y.get());
-    dx->sub_scaled(dalpha.get(), dy.get());
+    x->sub_scaled(alpha, y);
+    dx->sub_scaled(dalpha, dy);
 
     GKO_ASSERT_MTX_NEAR(dx, x, r<value_type>::value);
 }
@@ -1033,8 +1033,8 @@ TEST_F(Dense, MultipleVectorComplexAddScaledIsEquivalentToRef)
 {
     set_up_vector_data(20);
 
-    c_x->add_scaled(c_alpha.get(), c_y.get());
-    dc_x->add_scaled(dc_alpha.get(), dc_y.get());
+    c_x->add_scaled(c_alpha, c_y);
+    dc_x->add_scaled(dc_alpha, dc_y);
 
     GKO_ASSERT_MTX_NEAR(dc_x, c_x, r<value_type>::value);
 }
@@ -1044,8 +1044,8 @@ TEST_F(Dense, MultipleVectorComplexSubtractScaledIsEquivalentToRef)
 {
     set_up_vector_data(20);
 
-    c_x->sub_scaled(c_alpha.get(), c_y.get());
-    dc_x->sub_scaled(dc_alpha.get(), dc_y.get());
+    c_x->sub_scaled(c_alpha, c_y);
+    dc_x->sub_scaled(dc_alpha, dc_y);
 
     GKO_ASSERT_MTX_NEAR(dc_x, c_x, r<value_type>::value);
 }
@@ -1055,8 +1055,8 @@ TEST_F(Dense, MultipleVectorComplexRealAddScaledIsEquivalentToRef)
 {
     set_up_vector_data(20);
 
-    c_x->add_scaled(alpha.get(), c_y.get());
-    dc_x->add_scaled(dalpha.get(), dc_y.get());
+    c_x->add_scaled(alpha, c_y);
+    dc_x->add_scaled(dalpha, dc_y);
 
     GKO_ASSERT_MTX_NEAR(dc_x, c_x, r<value_type>::value);
 }
@@ -1066,8 +1066,8 @@ TEST_F(Dense, MultipleVectorComplexRealSubtractScaledIsEquivalentToRef)
 {
     set_up_vector_data(20);
 
-    c_x->sub_scaled(alpha.get(), c_y.get());
-    dc_x->sub_scaled(dalpha.get(), dc_y.get());
+    c_x->sub_scaled(alpha, c_y);
+    dc_x->sub_scaled(dalpha, dc_y);
 
     GKO_ASSERT_MTX_NEAR(dc_x, c_x, r<value_type>::value);
 }
@@ -1077,8 +1077,8 @@ TEST_F(Dense, MultipleVectorAddScaledWithDifferentAlphaIsEquivalentToRef)
 {
     set_up_vector_data(20, true);
 
-    x->add_scaled(alpha.get(), y.get());
-    dx->add_scaled(dalpha.get(), dy.get());
+    x->add_scaled(alpha, y);
+    dx->add_scaled(dalpha, dy);
 
     GKO_ASSERT_MTX_NEAR(dx, x, r<value_type>::value);
 }
@@ -1088,8 +1088,8 @@ TEST_F(Dense, MultipleVectorSubtractScaledWithDifferentAlphaIsEquivalentToRef)
 {
     set_up_vector_data(20, true);
 
-    x->sub_scaled(alpha.get(), y.get());
-    dx->sub_scaled(dalpha.get(), dy.get());
+    x->sub_scaled(alpha, y);
+    dx->sub_scaled(dalpha, dy);
 
     GKO_ASSERT_MTX_NEAR(dx, x, r<value_type>::value);
 }
@@ -1099,8 +1099,8 @@ TEST_F(Dense, MultipleVectorComplexAddScaledWithDifferentAlphaIsEquivalentToRef)
 {
     set_up_vector_data(20, true);
 
-    c_x->add_scaled(c_alpha.get(), c_y.get());
-    dc_x->add_scaled(dc_alpha.get(), dc_y.get());
+    c_x->add_scaled(c_alpha, c_y);
+    dc_x->add_scaled(dc_alpha, dc_y);
 
     GKO_ASSERT_MTX_NEAR(dc_x, c_x, r<value_type>::value);
 }
@@ -1111,8 +1111,8 @@ TEST_F(Dense,
 {
     set_up_vector_data(20, true);
 
-    c_x->sub_scaled(c_alpha.get(), c_y.get());
-    dc_x->sub_scaled(dc_alpha.get(), dc_y.get());
+    c_x->sub_scaled(c_alpha, c_y);
+    dc_x->sub_scaled(dc_alpha, dc_y);
 
     GKO_ASSERT_MTX_NEAR(dc_x, c_x, r<value_type>::value);
 }
@@ -1123,8 +1123,8 @@ TEST_F(Dense,
 {
     set_up_vector_data(20, true);
 
-    c_x->add_scaled(alpha.get(), c_y.get());
-    dc_x->add_scaled(dalpha.get(), dc_y.get());
+    c_x->add_scaled(alpha, c_y);
+    dc_x->add_scaled(dalpha, dc_y);
 
     GKO_ASSERT_MTX_NEAR(dc_x, c_x, r<value_type>::value);
 }
@@ -1136,8 +1136,8 @@ TEST_F(
 {
     set_up_vector_data(20, true);
 
-    c_x->sub_scaled(alpha.get(), c_y.get());
-    dc_x->sub_scaled(dalpha.get(), dc_y.get());
+    c_x->sub_scaled(alpha, c_y);
+    dc_x->sub_scaled(dalpha, dc_y);
 
     GKO_ASSERT_MTX_NEAR(dc_x, c_x, r<value_type>::value);
 }
@@ -1156,8 +1156,8 @@ TEST_F(Dense, AddsScaledDiagIsEquivalentToRef)
     auto ddiag = gko::clone(this->exec, diag);
     auto dalpha = gko::clone(this->exec, alpha);
 
-    mat->add_scaled(alpha.get(), diag.get());
-    dmat->add_scaled(dalpha.get(), ddiag.get());
+    mat->add_scaled(alpha, diag);
+    dmat->add_scaled(dalpha, ddiag);
 
     GKO_ASSERT_MTX_NEAR(mat, dmat, r<value_type>::value);
 }
@@ -1176,8 +1176,8 @@ TEST_F(Dense, SubtractScaledDiagIsEquivalentToRef)
     auto ddiag = gko::clone(this->exec, diag);
     auto dalpha = gko::clone(this->exec, alpha);
 
-    mat->sub_scaled(alpha.get(), diag.get());
-    dmat->sub_scaled(dalpha.get(), ddiag.get());
+    mat->sub_scaled(alpha, diag);
+    dmat->sub_scaled(dalpha, ddiag);
 
     GKO_ASSERT_MTX_NEAR(mat, dmat, r<value_type>::value);
 }
@@ -1190,7 +1190,7 @@ TEST_F(Dense, CanGatherRows)
     auto r_gather = x->row_gather(rgather_idxs.get());
     auto dr_gather = dx->row_gather(rgather_idxs.get());
 
-    GKO_ASSERT_MTX_NEAR(r_gather.get(), dr_gather.get(), 0);
+    GKO_ASSERT_MTX_NEAR(r_gather, dr_gather, 0);
 }
 
 
@@ -1207,10 +1207,10 @@ TEST_F(Dense, CanGatherRowsIntoDenseCrossExecutor)
     // test make_temporary_clone and non-default stride
     auto dr_gather = Mtx::create(ref, gather_size, sub_x->get_size()[1] + 2);
 
-    sub_x->row_gather(rgather_idxs.get(), r_gather.get());
-    sub_dx->row_gather(rgather_idxs.get(), dr_gather.get());
+    sub_x->row_gather(rgather_idxs.get(), r_gather);
+    sub_dx->row_gather(rgather_idxs.get(), dr_gather);
 
-    GKO_ASSERT_MTX_NEAR(r_gather.get(), dr_gather.get(), 0);
+    GKO_ASSERT_MTX_NEAR(r_gather, dr_gather, 0);
 }
 
 
@@ -1226,14 +1226,12 @@ TEST_F(Dense, CanAdvancedGatherRowsIntoDenseCrossExecutor)
     auto r_gather = gen_mtx<Mtx>(gather_size[0], gather_size[1]);
     // test make_temporary_clone and non-default stride
     auto dr_gather = Mtx::create(ref, gather_size, sub_x->get_size()[1] + 2);
-    dr_gather->copy_from(r_gather.get());
+    dr_gather->copy_from(r_gather);
 
-    sub_x->row_gather(alpha.get(), rgather_idxs.get(), beta.get(),
-                      r_gather.get());
-    sub_dx->row_gather(dalpha.get(), rgather_idxs.get(), dbeta.get(),
-                       dr_gather.get());
+    sub_x->row_gather(alpha, rgather_idxs.get(), beta, r_gather);
+    sub_dx->row_gather(dalpha, rgather_idxs.get(), dbeta, dr_gather);
 
-    GKO_ASSERT_MTX_NEAR(r_gather.get(), dr_gather.get(), 0);
+    GKO_ASSERT_MTX_NEAR(r_gather, dr_gather, 0);
 }
 
 
@@ -1251,10 +1249,10 @@ TEST_F(Dense, CanGatherRowsIntoMixedDenseCrossExecutor)
     auto dr_gather =
         MixedMtx::create(ref, gather_size, sub_x->get_size()[1] + 2);
 
-    sub_x->row_gather(rgather_idxs.get(), r_gather.get());
-    sub_dx->row_gather(rgather_idxs.get(), dr_gather.get());
+    sub_x->row_gather(rgather_idxs.get(), r_gather);
+    sub_dx->row_gather(rgather_idxs.get(), dr_gather);
 
-    GKO_ASSERT_MTX_NEAR(r_gather.get(), dr_gather.get(), 0);
+    GKO_ASSERT_MTX_NEAR(r_gather, dr_gather, 0);
 }
 
 
@@ -1271,14 +1269,12 @@ TEST_F(Dense, CanAdvancedGatherRowsIntoMixedDenseCrossExecutor)
     // test make_temporary_clone and non-default stride
     auto dr_gather =
         MixedMtx::create(ref, gather_size, sub_x->get_size()[1] + 2);
-    dr_gather->copy_from(r_gather.get());
+    dr_gather->copy_from(r_gather);
 
-    sub_x->row_gather(alpha.get(), rgather_idxs.get(), beta.get(),
-                      r_gather.get());
-    sub_dx->row_gather(alpha.get(), rgather_idxs.get(), beta.get(),
-                       dr_gather.get());
+    sub_x->row_gather(alpha, rgather_idxs.get(), beta, r_gather);
+    sub_dx->row_gather(alpha, rgather_idxs.get(), beta, dr_gather);
 
-    GKO_ASSERT_MTX_NEAR(r_gather.get(), dr_gather.get(), 0);
+    GKO_ASSERT_MTX_NEAR(r_gather, dr_gather, 0);
 }
 
 
@@ -1302,8 +1298,8 @@ TEST_F(Dense, IsPermutableIntoDenseCrossExecutor)
     auto dpermuted =
         Mtx::create(ref, square->get_size(), square->get_size()[1] + 2);
 
-    square->permute(rpermute_idxs.get(), permuted.get());
-    dsquare->permute(rpermute_idxs.get(), dpermuted.get());
+    square->permute(rpermute_idxs.get(), permuted);
+    dsquare->permute(rpermute_idxs.get(), dpermuted);
 
     GKO_ASSERT_MTX_NEAR(permuted, dpermuted, 0);
 }
@@ -1329,8 +1325,8 @@ TEST_F(Dense, IsInversePermutableIntoDenseCrossExecutor)
     auto dpermuted =
         Mtx::create(ref, square->get_size(), square->get_size()[1] + 2);
 
-    square->inverse_permute(rpermute_idxs.get(), permuted.get());
-    dsquare->inverse_permute(rpermute_idxs.get(), dpermuted.get());
+    square->inverse_permute(rpermute_idxs.get(), permuted);
+    dsquare->inverse_permute(rpermute_idxs.get(), dpermuted);
 
     GKO_ASSERT_MTX_NEAR(permuted, dpermuted, 0);
 }
@@ -1355,8 +1351,8 @@ TEST_F(Dense, IsRowPermutableIntoDenseCrossExecutor)
     // test make_temporary_clone and non-default stride
     auto dpermuted = Mtx::create(ref, x->get_size(), x->get_size()[1] + 2);
 
-    x->row_permute(rpermute_idxs.get(), permuted.get());
-    dx->row_permute(rpermute_idxs.get(), dpermuted.get());
+    x->row_permute(rpermute_idxs.get(), permuted);
+    dx->row_permute(rpermute_idxs.get(), dpermuted);
 
     GKO_ASSERT_MTX_NEAR(permuted, dpermuted, 0);
 }
@@ -1381,8 +1377,8 @@ TEST_F(Dense, IsColPermutableIntoDenseCrossExecutor)
     // test make_temporary_clone and non-default stride
     auto dpermuted = Mtx::create(ref, x->get_size(), x->get_size()[1] + 2);
 
-    x->column_permute(cpermute_idxs.get(), permuted.get());
-    dx->column_permute(cpermute_idxs.get(), dpermuted.get());
+    x->column_permute(cpermute_idxs.get(), permuted);
+    dx->column_permute(cpermute_idxs.get(), dpermuted);
 
     GKO_ASSERT_MTX_NEAR(permuted, dpermuted, 0);
 }
@@ -1407,8 +1403,8 @@ TEST_F(Dense, IsInverseRowPermutableIntoDenseCrossExecutor)
     // test make_temporary_clone and non-default stride
     auto dpermuted = Mtx::create(ref, x->get_size(), x->get_size()[1] + 2);
 
-    x->inverse_row_permute(rpermute_idxs.get(), permuted.get());
-    dx->inverse_row_permute(rpermute_idxs.get(), dpermuted.get());
+    x->inverse_row_permute(rpermute_idxs.get(), permuted);
+    dx->inverse_row_permute(rpermute_idxs.get(), dpermuted);
 
     GKO_ASSERT_MTX_NEAR(permuted, dpermuted, 0);
 }
@@ -1433,8 +1429,8 @@ TEST_F(Dense, IsInverseColPermutableIntoDenseCrossExecutor)
     // test make_temporary_clone and non-default stride
     auto dpermuted = Mtx::create(ref, x->get_size(), x->get_size()[1] + 2);
 
-    x->inverse_column_permute(cpermute_idxs.get(), permuted.get());
-    dx->inverse_column_permute(cpermute_idxs.get(), dpermuted.get());
+    x->inverse_column_permute(cpermute_idxs.get(), permuted);
+    dx->inverse_column_permute(cpermute_idxs.get(), dpermuted);
 
     GKO_ASSERT_MTX_NEAR(permuted, dpermuted, 0);
 }
@@ -1447,7 +1443,7 @@ TEST_F(Dense, ExtractDiagonalOnTallSkinnyIsEquivalentToRef)
     auto diag = x->extract_diagonal();
     auto ddiag = dx->extract_diagonal();
 
-    GKO_ASSERT_MTX_NEAR(diag.get(), ddiag.get(), 0);
+    GKO_ASSERT_MTX_NEAR(diag, ddiag, 0);
 }
 
 
@@ -1458,10 +1454,10 @@ TEST_F(Dense, ExtractDiagonalOnTallSkinnyIntoDenseCrossExecutor)
     // test make_temporary_clone
     auto ddiag = Diagonal::create(ref, x->get_size()[1]);
 
-    x->extract_diagonal(diag.get());
-    dx->extract_diagonal(ddiag.get());
+    x->extract_diagonal(diag);
+    dx->extract_diagonal(ddiag);
 
-    GKO_ASSERT_MTX_NEAR(diag.get(), ddiag.get(), 0);
+    GKO_ASSERT_MTX_NEAR(diag, ddiag, 0);
 }
 
 
@@ -1472,7 +1468,7 @@ TEST_F(Dense, ExtractDiagonalOnShortFatIsEquivalentToRef)
     auto diag = y->extract_diagonal();
     auto ddiag = dy->extract_diagonal();
 
-    GKO_ASSERT_MTX_NEAR(diag.get(), ddiag.get(), 0);
+    GKO_ASSERT_MTX_NEAR(diag, ddiag, 0);
 }
 
 
@@ -1483,10 +1479,10 @@ TEST_F(Dense, ExtractDiagonalOnShortFatIntoDenseCrossExecutor)
     // test make_temporary_clone
     auto ddiag = Diagonal::create(ref, y->get_size()[0]);
 
-    y->extract_diagonal(diag.get());
-    dy->extract_diagonal(ddiag.get());
+    y->extract_diagonal(diag);
+    dy->extract_diagonal(ddiag);
 
-    GKO_ASSERT_MTX_NEAR(diag.get(), ddiag.get(), 0);
+    GKO_ASSERT_MTX_NEAR(diag, ddiag, 0);
 }
 
 
@@ -1499,8 +1495,8 @@ TEST_F(Dense, ComputeDotIsEquivalentToRef)
     auto ddot = Mtx::create(ref, dot_size);
 
     // all parameters are on ref to check cross-executor calls
-    x->compute_dot(y.get(), dot_expected.get());
-    dx->compute_dot(y.get(), ddot.get());
+    x->compute_dot(y, dot_expected);
+    dx->compute_dot(y, ddot);
 
     GKO_ASSERT_MTX_NEAR(ddot, dot_expected, r<value_type>::value * 2);
 }
@@ -1516,8 +1512,8 @@ TEST_F(Dense, ComputeDotWithPreallocatedTmpIsEquivalentToRef)
     gko::array<char> tmp{exec, 12345};
 
     // all parameters are on ref to check cross-executor calls
-    x->compute_dot(y.get(), dot_expected.get());
-    dx->compute_dot(y.get(), ddot.get(), tmp);
+    x->compute_dot(y, dot_expected);
+    dx->compute_dot(y, ddot, tmp);
 
     GKO_ASSERT_MTX_NEAR(ddot, dot_expected, r<value_type>::value);
 }
@@ -1533,8 +1529,8 @@ TEST_F(Dense, ComputeDotWithTmpIsEquivalentToRef)
     gko::array<char> tmp{exec};
 
     // all parameters are on ref to check cross-executor calls
-    x->compute_dot(y.get(), dot_expected.get());
-    dx->compute_dot(y.get(), ddot.get(), tmp);
+    x->compute_dot(y, dot_expected);
+    dx->compute_dot(y, ddot, tmp);
 
     GKO_ASSERT_MTX_NEAR(ddot, dot_expected, r<value_type>::value);
 }
@@ -1549,8 +1545,8 @@ TEST_F(Dense, ComputeConjDotIsEquivalentToRef)
     auto ddot = Mtx::create(ref, dot_size);
 
     // all parameters are on ref to check cross-executor calls
-    x->compute_conj_dot(y.get(), dot_expected.get());
-    dx->compute_conj_dot(y.get(), ddot.get());
+    x->compute_conj_dot(y, dot_expected);
+    dx->compute_conj_dot(y, ddot);
 
     GKO_ASSERT_MTX_NEAR(ddot, dot_expected, r<value_type>::value * 2);
 }
@@ -1566,8 +1562,8 @@ TEST_F(Dense, ComputeConjDotWithPreallocatedTmpIsEquivalentToRef)
     gko::array<char> tmp{exec, 12345};
 
     // all parameters are on ref to check cross-executor calls
-    x->compute_conj_dot(y.get(), dot_expected.get());
-    dx->compute_conj_dot(y.get(), ddot.get(), tmp);
+    x->compute_conj_dot(y, dot_expected);
+    dx->compute_conj_dot(y, ddot, tmp);
 
     GKO_ASSERT_MTX_NEAR(ddot, dot_expected, r<value_type>::value);
 }
@@ -1583,8 +1579,8 @@ TEST_F(Dense, ComputeConjDotWithTmpIsEquivalentToRef)
     gko::array<char> tmp{ref};
 
     // all parameters are on ref to check cross-executor calls
-    x->compute_conj_dot(y.get(), dot_expected.get());
-    dx->compute_conj_dot(y.get(), ddot.get(), tmp);
+    x->compute_conj_dot(y, dot_expected);
+    dx->compute_conj_dot(y, ddot, tmp);
 
     GKO_ASSERT_MTX_NEAR(ddot, dot_expected, r<value_type>::value);
 }
@@ -1599,8 +1595,8 @@ TEST_F(Dense, ComputeNorm1IsEquivalentToRef)
     auto dnorm = NormVector::create(exec, norm_size);
 
     // all parameters are on ref to check cross-executor calls
-    x->compute_norm1(norm_expected.get());
-    dx->compute_norm1(dnorm.get());
+    x->compute_norm1(norm_expected);
+    dx->compute_norm1(dnorm);
 
     GKO_ASSERT_MTX_NEAR(norm_expected, dnorm, r<value_type>::value);
 }
@@ -1616,8 +1612,8 @@ TEST_F(Dense, ComputeNorm1WithPreallocatedTmpIsEquivalentToRef)
     gko::array<char> tmp{exec, 12345};
 
     // all parameters are on ref to check cross-executor calls
-    x->compute_norm1(norm_expected.get());
-    dx->compute_norm1(dnorm.get(), tmp);
+    x->compute_norm1(norm_expected);
+    dx->compute_norm1(dnorm, tmp);
 
     GKO_ASSERT_MTX_NEAR(norm_expected, dnorm, r<value_type>::value);
 }
@@ -1633,8 +1629,8 @@ TEST_F(Dense, ComputeNorm1WithTmpIsEquivalentToRef)
     gko::array<char> tmp{ref};
 
     // all parameters are on ref to check cross-executor calls
-    x->compute_norm1(norm_expected.get());
-    dx->compute_norm1(dnorm.get(), tmp);
+    x->compute_norm1(norm_expected);
+    dx->compute_norm1(dnorm, tmp);
 
     GKO_ASSERT_MTX_NEAR(norm_expected, dnorm, r<value_type>::value);
 }
@@ -1649,8 +1645,8 @@ TEST_F(Dense, ComputeNorm2IsEquivalentToRef)
     auto dnorm = NormVector::create(ref, norm_size);
 
     // all parameters are on ref to check cross-executor calls
-    x->compute_norm1(norm_expected.get());
-    dx->compute_norm1(dnorm.get());
+    x->compute_norm1(norm_expected);
+    dx->compute_norm1(dnorm);
 
     GKO_ASSERT_MTX_NEAR(norm_expected, dnorm, r<value_type>::value);
 }
@@ -1666,8 +1662,8 @@ TEST_F(Dense, ComputeNorm2WithPreallocatedTmpIsEquivalentToRef)
     gko::array<char> tmp{ref};
 
     // all parameters are on ref to check cross-executor calls
-    x->compute_norm1(norm_expected.get());
-    dx->compute_norm1(dnorm.get(), tmp);
+    x->compute_norm1(norm_expected);
+    dx->compute_norm1(dnorm, tmp);
 
     GKO_ASSERT_MTX_NEAR(norm_expected, dnorm, r<value_type>::value);
 }
@@ -1683,8 +1679,8 @@ TEST_F(Dense, ComputeNorm2WithTmpIsEquivalentToRef)
     gko::array<char> tmp{exec, 12345};
 
     // all parameters are on ref to check cross-executor calls
-    x->compute_norm1(norm_expected.get());
-    dx->compute_norm1(dnorm.get(), tmp);
+    x->compute_norm1(norm_expected);
+    dx->compute_norm1(dnorm, tmp);
 
     GKO_ASSERT_MTX_NEAR(norm_expected, dnorm, r<value_type>::value);
 }
@@ -1719,8 +1715,8 @@ TEST_F(Dense, OutplaceAbsoluteMatrixIntoDenseCrossExecutor)
     // test make_temporary_clone and non-default stride
     auto dabs_x = NormVector::create(ref, x->get_size(), x->get_size()[1] + 2);
 
-    x->compute_absolute(abs_x.get());
-    dx->compute_absolute(dabs_x.get());
+    x->compute_absolute(abs_x);
+    dx->compute_absolute(dabs_x);
 
     GKO_ASSERT_MTX_NEAR(abs_x, dabs_x, r<value_type>::value);
 }
@@ -1745,8 +1741,8 @@ TEST_F(Dense, MakeComplexIntoDenseCrossExecutor)
     auto dcomplex_x =
         ComplexMtx::create(ref, x->get_size(), x->get_size()[1] + 2);
 
-    x->make_complex(complex_x.get());
-    dx->make_complex(dcomplex_x.get());
+    x->make_complex(complex_x);
+    dx->make_complex(dcomplex_x);
 
     GKO_ASSERT_MTX_NEAR(complex_x, dcomplex_x, 0);
 }
@@ -1770,8 +1766,8 @@ TEST_F(Dense, GetRealIntoDenseCrossExecutor)
     // test make_temporary_clone and non-default stride
     auto dreal_x = Mtx::create(ref, x->get_size(), x->get_size()[1] + 2);
 
-    x->get_real(real_x.get());
-    dx->get_real(dreal_x.get());
+    x->get_real(real_x);
+    dx->get_real(dreal_x);
 
     GKO_ASSERT_MTX_NEAR(real_x, dreal_x, 0);
 }
@@ -1795,8 +1791,8 @@ TEST_F(Dense, GetImagIntoDenseCrossExecutor)
     // test make_temporary_clone and non-default stride
     auto dimag_x = Mtx::create(ref, x->get_size(), x->get_size()[1] + 2);
 
-    x->get_imag(imag_x.get());
-    dx->get_imag(dimag_x.get());
+    x->get_imag(imag_x);
+    dx->get_imag(dimag_x);
 
     GKO_ASSERT_MTX_NEAR(imag_x, dimag_x, 0);
 }
@@ -1806,8 +1802,8 @@ TEST_F(Dense, AddScaledIdentityToNonSquare)
 {
     set_up_apply_data();
 
-    x->add_scaled_identity(alpha.get(), beta.get());
-    dx->add_scaled_identity(dalpha.get(), dbeta.get());
+    x->add_scaled_identity(alpha, beta);
+    dx->add_scaled_identity(dalpha, dbeta);
 
     GKO_ASSERT_MTX_NEAR(x, dx, r<value_type>::value);
 }
@@ -1817,8 +1813,8 @@ TEST_F(Dense, AddScaledIdentityToNonSquareOnDifferentExecutor)
 {
     set_up_apply_data();
 
-    x->add_scaled_identity(alpha.get(), beta.get());
-    dx->add_scaled_identity(alpha.get(), beta.get());
+    x->add_scaled_identity(alpha, beta);
+    dx->add_scaled_identity(alpha, beta);
 
     GKO_ASSERT_MTX_NEAR(x, dx, r<value_type>::value);
 }

--- a/test/matrix/diagonal_kernels.cpp
+++ b/test/matrix/diagonal_kernels.cpp
@@ -162,8 +162,8 @@ TEST_F(Diagonal, ApplyToDenseIsEquivalentToRef)
 {
     set_up_apply_data();
 
-    diag->apply(dense1.get(), denseexpected1.get());
-    ddiag->apply(ddense1.get(), denseresult1.get());
+    diag->apply(dense1, denseexpected1);
+    ddiag->apply(ddense1, denseresult1);
 
     GKO_ASSERT_MTX_NEAR(denseexpected1, denseresult1, r<value_type>::value);
 }
@@ -173,8 +173,8 @@ TEST_F(Diagonal, RightApplyToDenseIsEquivalentToRef)
 {
     set_up_apply_data();
 
-    diag->rapply(dense2.get(), denseexpected2.get());
-    ddiag->rapply(ddense2.get(), denseresult2.get());
+    diag->rapply(dense2, denseexpected2);
+    ddiag->rapply(ddense2, denseresult2);
 
     GKO_ASSERT_MTX_NEAR(denseexpected2, denseresult2, r<value_type>::value);
 }
@@ -184,8 +184,8 @@ TEST_F(Diagonal, InverseApplyToDenseIsEquivalentToRef)
 {
     set_up_apply_data();
 
-    diag->inverse_apply(dense1.get(), denseexpected1.get());
-    ddiag->inverse_apply(ddense1.get(), denseresult1.get());
+    diag->inverse_apply(dense1, denseexpected1);
+    ddiag->inverse_apply(ddense1, denseresult1);
 
     GKO_ASSERT_MTX_NEAR(denseexpected2, denseresult2, r<value_type>::value);
 }
@@ -195,8 +195,8 @@ TEST_F(Diagonal, ApplyToCsrIsEquivalentToRef)
 {
     set_up_apply_data();
 
-    diag->apply(csr1.get(), csrexpected1.get());
-    ddiag->apply(dcsr1.get(), csrresult1.get());
+    diag->apply(csr1, csrexpected1);
+    ddiag->apply(dcsr1, csrresult1);
 
     GKO_ASSERT_MTX_NEAR(csrexpected1, csrresult1, r<value_type>::value);
 }
@@ -206,8 +206,8 @@ TEST_F(Diagonal, RightApplyToCsrIsEquivalentToRef)
 {
     set_up_apply_data();
 
-    diag->rapply(csr2.get(), csrexpected2.get());
-    ddiag->rapply(dcsr2.get(), csrresult2.get());
+    diag->rapply(csr2, csrexpected2);
+    ddiag->rapply(dcsr2, csrresult2);
 
     GKO_ASSERT_MTX_NEAR(csrexpected2, csrresult2, r<value_type>::value);
 }
@@ -217,8 +217,8 @@ TEST_F(Diagonal, InverseApplyToCsrIsEquivalentToRef)
 {
     set_up_apply_data();
 
-    diag->inverse_apply(csr1.get(), csrexpected1.get());
-    ddiag->inverse_apply(dcsr1.get(), csrresult1.get());
+    diag->inverse_apply(csr1, csrexpected1);
+    ddiag->inverse_apply(dcsr1, csrresult1);
 
     GKO_ASSERT_MTX_NEAR(csrexpected2, csrresult2, r<value_type>::value);
 }
@@ -228,8 +228,8 @@ TEST_F(Diagonal, ConvertToCsrIsEquivalentToRef)
 {
     set_up_apply_data();
 
-    diag->convert_to(csr1.get());
-    ddiag->convert_to(dcsr1.get());
+    diag->convert_to(csr1);
+    ddiag->convert_to(dcsr1);
 
     GKO_ASSERT_MTX_NEAR(csr1, dcsr1, 0);
 }

--- a/test/matrix/ell_kernels.cpp
+++ b/test/matrix/ell_kernels.cpp
@@ -80,10 +80,10 @@ protected:
         mtx->copy_from(gen_mtx(num_rows, num_cols));
         expected = gen_mtx(num_rows, num_vectors);
         expected2 = Vec2::create(ref);
-        expected2->copy_from(expected.get());
+        expected2->copy_from(expected);
         y = gen_mtx(num_cols, num_vectors);
         y2 = Vec2::create(ref);
-        y2->copy_from(y.get());
+        y2->copy_from(y);
         alpha = gko::initialize<Vec>({2.0}, ref);
         alpha2 = gko::initialize<Vec2>({2.0}, ref);
         beta = gko::initialize<Vec>({-1.0}, ref);
@@ -130,8 +130,8 @@ TEST_F(Ell, SimpleApplyIsEquivalentToRef)
 {
     set_up_apply_data();
 
-    mtx->apply(y.get(), expected.get());
-    dmtx->apply(dy.get(), dresult.get());
+    mtx->apply(y, expected);
+    dmtx->apply(dy, dresult);
 
     GKO_ASSERT_MTX_NEAR(dresult, expected, r<value_type>::value);
 }
@@ -142,8 +142,8 @@ TEST_F(Ell, MixedSimpleApplyIsEquivalentToRef1)
     SKIP_IF_SINGLE_MODE;
     set_up_apply_data();
 
-    mtx->apply(y2.get(), expected2.get());
-    dmtx->apply(dy2.get(), dresult2.get());
+    mtx->apply(y2, expected2);
+    dmtx->apply(dy2, dresult2);
 
     GKO_ASSERT_MTX_NEAR(dresult2, expected2, 1e-6);
 }
@@ -154,8 +154,8 @@ TEST_F(Ell, MixedSimpleApplyIsEquivalentToRef2)
     SKIP_IF_SINGLE_MODE;
     set_up_apply_data();
 
-    mtx->apply(y2.get(), expected.get());
-    dmtx->apply(dy2.get(), dresult.get());
+    mtx->apply(y2, expected);
+    dmtx->apply(dy2, dresult);
 
     GKO_ASSERT_MTX_NEAR(dresult, expected, 1e-14);
 }
@@ -166,8 +166,8 @@ TEST_F(Ell, MixedSimpleApplyIsEquivalentToRef3)
     SKIP_IF_SINGLE_MODE;
     set_up_apply_data();
 
-    mtx->apply(y.get(), expected2.get());
-    dmtx->apply(dy.get(), dresult2.get());
+    mtx->apply(y, expected2);
+    dmtx->apply(dy, dresult2);
 
     GKO_ASSERT_MTX_NEAR(dresult2, expected2, 1e-6);
 }
@@ -177,8 +177,8 @@ TEST_F(Ell, AdvancedApplyIsEquivalentToRef)
 {
     set_up_apply_data();
 
-    mtx->apply(alpha.get(), y.get(), beta.get(), expected.get());
-    dmtx->apply(dalpha.get(), dy.get(), dbeta.get(), dresult.get());
+    mtx->apply(alpha, y, beta, expected);
+    dmtx->apply(dalpha, dy, dbeta, dresult);
 
     GKO_ASSERT_MTX_NEAR(dresult, expected, r<value_type>::value);
 }
@@ -189,8 +189,8 @@ TEST_F(Ell, MixedAdvancedApplyIsEquivalentToRef1)
     SKIP_IF_SINGLE_MODE;
     set_up_apply_data();
 
-    mtx->apply(alpha2.get(), y2.get(), beta2.get(), expected2.get());
-    dmtx->apply(dalpha2.get(), dy2.get(), dbeta2.get(), dresult2.get());
+    mtx->apply(alpha2, y2, beta2, expected2);
+    dmtx->apply(dalpha2, dy2, dbeta2, dresult2);
 
     GKO_ASSERT_MTX_NEAR(dresult2, expected2, 1e-6);
 }
@@ -201,8 +201,8 @@ TEST_F(Ell, MixedAdvancedApplyIsEquivalentToRef2)
     SKIP_IF_SINGLE_MODE;
     set_up_apply_data();
 
-    mtx->apply(alpha2.get(), y2.get(), beta.get(), expected.get());
-    dmtx->apply(dalpha2.get(), dy2.get(), dbeta.get(), dresult.get());
+    mtx->apply(alpha2, y2, beta, expected);
+    dmtx->apply(dalpha2, dy2, dbeta, dresult);
 
     GKO_ASSERT_MTX_NEAR(dresult, expected, 1e-14);
 }
@@ -213,8 +213,8 @@ TEST_F(Ell, MixedAdvancedApplyIsEquivalentToRef3)
     SKIP_IF_SINGLE_MODE;
     set_up_apply_data();
 
-    mtx->apply(alpha.get(), y.get(), beta2.get(), expected2.get());
-    dmtx->apply(dalpha.get(), dy.get(), dbeta2.get(), dresult2.get());
+    mtx->apply(alpha, y, beta2, expected2);
+    dmtx->apply(dalpha, dy, dbeta2, dresult2);
 
     GKO_ASSERT_MTX_NEAR(dresult2, expected2, 1e-6);
 }
@@ -224,8 +224,8 @@ TEST_F(Ell, SimpleApplyWithStrideIsEquivalentToRef)
 {
     set_up_apply_data(size[0], size[1], 1, num_els_rowwise, ell_stride);
 
-    mtx->apply(y.get(), expected.get());
-    dmtx->apply(dy.get(), dresult.get());
+    mtx->apply(y, expected);
+    dmtx->apply(dy, dresult);
 
     GKO_ASSERT_MTX_NEAR(dresult, expected, r<value_type>::value);
 }
@@ -236,8 +236,8 @@ TEST_F(Ell, MixedSimpleApplyWithStrideIsEquivalentToRef1)
     SKIP_IF_SINGLE_MODE;
     set_up_apply_data(size[0], size[1], 1, num_els_rowwise, ell_stride);
 
-    mtx->apply(y2.get(), expected2.get());
-    dmtx->apply(dy2.get(), dresult2.get());
+    mtx->apply(y2, expected2);
+    dmtx->apply(dy2, dresult2);
 
     GKO_ASSERT_MTX_NEAR(dresult2, expected2, 1e-6);
 }
@@ -248,8 +248,8 @@ TEST_F(Ell, MixedSimpleApplyWithStrideIsEquivalentToRef2)
     SKIP_IF_SINGLE_MODE;
     set_up_apply_data(size[0], size[1], 1, num_els_rowwise, ell_stride);
 
-    mtx->apply(y2.get(), expected.get());
-    dmtx->apply(dy2.get(), dresult.get());
+    mtx->apply(y2, expected);
+    dmtx->apply(dy2, dresult);
 
     GKO_ASSERT_MTX_NEAR(dresult, expected, 1e-14);
 }
@@ -260,8 +260,8 @@ TEST_F(Ell, MixedSimpleApplyWithStrideIsEquivalentToRef3)
     SKIP_IF_SINGLE_MODE;
     set_up_apply_data(size[0], size[1], 1, num_els_rowwise, ell_stride);
 
-    mtx->apply(y.get(), expected2.get());
-    dmtx->apply(dy.get(), dresult2.get());
+    mtx->apply(y, expected2);
+    dmtx->apply(dy, dresult2);
 
     GKO_ASSERT_MTX_NEAR(dresult2, expected2, 1e-6);
 }
@@ -270,8 +270,8 @@ TEST_F(Ell, MixedSimpleApplyWithStrideIsEquivalentToRef3)
 TEST_F(Ell, AdvancedApplyWithStrideIsEquivalentToRef)
 {
     set_up_apply_data(size[0], size[1], 1, num_els_rowwise, ell_stride);
-    mtx->apply(alpha.get(), y.get(), beta.get(), expected.get());
-    dmtx->apply(dalpha.get(), dy.get(), dbeta.get(), dresult.get());
+    mtx->apply(alpha, y, beta, expected);
+    dmtx->apply(dalpha, dy, dbeta, dresult);
 
     GKO_ASSERT_MTX_NEAR(dresult, expected, r<value_type>::value);
 }
@@ -282,8 +282,8 @@ TEST_F(Ell, MixedAdvancedApplyWithStrideIsEquivalentToRef1)
     SKIP_IF_SINGLE_MODE;
     set_up_apply_data(size[0], size[1], 1, num_els_rowwise, ell_stride);
 
-    mtx->apply(alpha2.get(), y2.get(), beta2.get(), expected2.get());
-    dmtx->apply(dalpha2.get(), dy2.get(), dbeta2.get(), dresult2.get());
+    mtx->apply(alpha2, y2, beta2, expected2);
+    dmtx->apply(dalpha2, dy2, dbeta2, dresult2);
 
     GKO_ASSERT_MTX_NEAR(dresult2, expected2, 1e-6);
 }
@@ -294,8 +294,8 @@ TEST_F(Ell, MixedAdvancedApplyWithStrideIsEquivalentToRef2)
     SKIP_IF_SINGLE_MODE;
     set_up_apply_data(size[0], size[1], 1, num_els_rowwise, ell_stride);
 
-    mtx->apply(alpha2.get(), y2.get(), beta.get(), expected.get());
-    dmtx->apply(dalpha2.get(), dy2.get(), dbeta.get(), dresult.get());
+    mtx->apply(alpha2, y2, beta, expected);
+    dmtx->apply(dalpha2, dy2, dbeta, dresult);
 
     GKO_ASSERT_MTX_NEAR(dresult, expected, 1e-14);
 }
@@ -306,8 +306,8 @@ TEST_F(Ell, MixedAdvancedApplyWithStrideIsEquivalentToRef3)
     SKIP_IF_SINGLE_MODE;
     set_up_apply_data(size[0], size[1], 1, num_els_rowwise, ell_stride);
 
-    mtx->apply(alpha.get(), y.get(), beta2.get(), expected2.get());
-    dmtx->apply(dalpha.get(), dy.get(), dbeta2.get(), dresult2.get());
+    mtx->apply(alpha, y, beta2, expected2);
+    dmtx->apply(dalpha, dy, dbeta2, dresult2);
 
     GKO_ASSERT_MTX_NEAR(dresult2, expected2, 1e-6);
 }
@@ -317,8 +317,8 @@ TEST_F(Ell, SimpleApplyWithStrideToDenseMatrixIsEquivalentToRef)
 {
     set_up_apply_data(size[0], size[1], 3, num_els_rowwise, ell_stride);
 
-    mtx->apply(y.get(), expected.get());
-    dmtx->apply(dy.get(), dresult.get());
+    mtx->apply(y, expected);
+    dmtx->apply(dy, dresult);
 
     GKO_ASSERT_MTX_NEAR(dresult, expected, r<value_type>::value);
 }
@@ -329,8 +329,8 @@ TEST_F(Ell, MixedSimpleApplyWithStrideToDenseMatrixIsEquivalentToRef1)
     SKIP_IF_SINGLE_MODE;
     set_up_apply_data(size[0], size[1], 4, num_els_rowwise, ell_stride);
 
-    mtx->apply(y2.get(), expected2.get());
-    dmtx->apply(dy2.get(), dresult2.get());
+    mtx->apply(y2, expected2);
+    dmtx->apply(dy2, dresult2);
 
     GKO_ASSERT_MTX_NEAR(dresult2, expected2, 1e-6);
 }
@@ -341,8 +341,8 @@ TEST_F(Ell, MixedSimpleApplyWithStrideToDenseMatrixIsEquivalentToRef2)
     SKIP_IF_SINGLE_MODE;
     set_up_apply_data(size[0], size[1], 5, num_els_rowwise, ell_stride);
 
-    mtx->apply(y2.get(), expected.get());
-    dmtx->apply(dy2.get(), dresult.get());
+    mtx->apply(y2, expected);
+    dmtx->apply(dy2, dresult);
 
     GKO_ASSERT_MTX_NEAR(dresult, expected, 1e-14);
 }
@@ -353,8 +353,8 @@ TEST_F(Ell, MixedSimpleApplyWithStrideToDenseMatrixIsEquivalentToRef3)
     SKIP_IF_SINGLE_MODE;
     set_up_apply_data(size[0], size[1], 6, num_els_rowwise, ell_stride);
 
-    mtx->apply(y.get(), expected2.get());
-    dmtx->apply(dy.get(), dresult2.get());
+    mtx->apply(y, expected2);
+    dmtx->apply(dy, dresult2);
 
     GKO_ASSERT_MTX_NEAR(dresult2, expected2, 1e-6);
 }
@@ -364,8 +364,8 @@ TEST_F(Ell, AdvancedApplyWithStrideToDenseMatrixIsEquivalentToRef)
 {
     set_up_apply_data(size[0], size[1], 3, num_els_rowwise, ell_stride);
 
-    mtx->apply(alpha.get(), y.get(), beta.get(), expected.get());
-    dmtx->apply(dalpha.get(), dy.get(), dbeta.get(), dresult.get());
+    mtx->apply(alpha, y, beta, expected);
+    dmtx->apply(dalpha, dy, dbeta, dresult);
 
     GKO_ASSERT_MTX_NEAR(dresult, expected, r<value_type>::value);
 }
@@ -376,8 +376,8 @@ TEST_F(Ell, MixedAdvancedApplyWithStrideToDenseMatrixIsEquivalentToRef1)
     SKIP_IF_SINGLE_MODE;
     set_up_apply_data(size[0], size[1], 4, num_els_rowwise, ell_stride);
 
-    mtx->apply(alpha2.get(), y2.get(), beta2.get(), expected2.get());
-    dmtx->apply(dalpha2.get(), dy2.get(), dbeta2.get(), dresult2.get());
+    mtx->apply(alpha2, y2, beta2, expected2);
+    dmtx->apply(dalpha2, dy2, dbeta2, dresult2);
 
     GKO_ASSERT_MTX_NEAR(dresult2, expected2, 1e-6);
 }
@@ -388,8 +388,8 @@ TEST_F(Ell, MixedAdvancedApplyWithStrideToDenseMatrixIsEquivalentToRef2)
     SKIP_IF_SINGLE_MODE;
     set_up_apply_data(size[0], size[1], 5, num_els_rowwise, ell_stride);
 
-    mtx->apply(alpha2.get(), y2.get(), beta.get(), expected.get());
-    dmtx->apply(dalpha2.get(), dy2.get(), dbeta.get(), dresult.get());
+    mtx->apply(alpha2, y2, beta, expected);
+    dmtx->apply(dalpha2, dy2, dbeta, dresult);
 
     GKO_ASSERT_MTX_NEAR(dresult, expected, 1e-14);
 }
@@ -400,8 +400,8 @@ TEST_F(Ell, MixedAdvancedApplyWithStrideToDenseMatrixIsEquivalentToRef3)
     SKIP_IF_SINGLE_MODE;
     set_up_apply_data(size[0], size[1], 6, num_els_rowwise, ell_stride);
 
-    mtx->apply(alpha.get(), y.get(), beta2.get(), expected2.get());
-    dmtx->apply(dalpha.get(), dy.get(), dbeta2.get(), dresult2.get());
+    mtx->apply(alpha, y, beta2, expected2);
+    dmtx->apply(dalpha, dy, dbeta2, dresult2);
 
     GKO_ASSERT_MTX_NEAR(dresult2, expected2, 1e-6);
 }
@@ -411,8 +411,8 @@ TEST_F(Ell, SimpleApplyByAtomicIsEquivalentToRef)
 {
     set_up_apply_data(10, 10000);
 
-    mtx->apply(y.get(), expected.get());
-    dmtx->apply(dy.get(), dresult.get());
+    mtx->apply(y, expected);
+    dmtx->apply(dy, dresult);
 
     GKO_ASSERT_MTX_NEAR(dresult, expected, r<value_type>::value * 10);
 }
@@ -422,8 +422,8 @@ TEST_F(Ell, AdvancedByAtomicApplyIsEquivalentToRef)
 {
     set_up_apply_data(10, 10000);
 
-    mtx->apply(alpha.get(), y.get(), beta.get(), expected.get());
-    dmtx->apply(dalpha.get(), dy.get(), dbeta.get(), dresult.get());
+    mtx->apply(alpha, y, beta, expected);
+    dmtx->apply(dalpha, dy, dbeta, dresult);
 
     GKO_ASSERT_MTX_NEAR(dresult, expected, r<value_type>::value * 10);
 }
@@ -433,8 +433,8 @@ TEST_F(Ell, SimpleApplyByAtomicToDenseMatrixIsEquivalentToRef)
 {
     set_up_apply_data(10, 10000, 3);
 
-    mtx->apply(y.get(), expected.get());
-    dmtx->apply(dy.get(), dresult.get());
+    mtx->apply(y, expected);
+    dmtx->apply(dy, dresult);
 
     GKO_ASSERT_MTX_NEAR(dresult, expected, r<value_type>::value * 10);
 }
@@ -444,8 +444,8 @@ TEST_F(Ell, AdvancedByAtomicToDenseMatrixApplyIsEquivalentToRef)
 {
     set_up_apply_data(10, 10000, 3);
 
-    mtx->apply(alpha.get(), y.get(), beta.get(), expected.get());
-    dmtx->apply(dalpha.get(), dy.get(), dbeta.get(), dresult.get());
+    mtx->apply(alpha, y, beta, expected);
+    dmtx->apply(dalpha, dy, dbeta, dresult);
 
     GKO_ASSERT_MTX_NEAR(dresult, expected, r<value_type>::value * 10);
 }
@@ -455,8 +455,8 @@ TEST_F(Ell, SimpleApplyOnSmallMatrixIsEquivalentToRef)
 {
     set_up_apply_data(1, 10);
 
-    mtx->apply(y.get(), expected.get());
-    dmtx->apply(dy.get(), dresult.get());
+    mtx->apply(y, expected);
+    dmtx->apply(dy, dresult);
 
     GKO_ASSERT_MTX_NEAR(dresult, expected, 5 * r<value_type>::value);
 }
@@ -466,8 +466,8 @@ TEST_F(Ell, AdvancedApplyOnSmallMatrixToDenseMatrixIsEquivalentToRef)
 {
     set_up_apply_data(1, 10, 3);
 
-    mtx->apply(alpha.get(), y.get(), beta.get(), expected.get());
-    dmtx->apply(dalpha.get(), dy.get(), dbeta.get(), dresult.get());
+    mtx->apply(alpha, y, beta, expected);
+    dmtx->apply(dalpha, dy, dbeta, dresult);
 
     GKO_ASSERT_MTX_NEAR(dresult, expected, r<value_type>::value);
 }
@@ -477,8 +477,8 @@ TEST_F(Ell, SimpleApplyOnSmallMatrixToDenseMatrixIsEquivalentToRef)
 {
     set_up_apply_data(1, 10, 3);
 
-    mtx->apply(y.get(), expected.get());
-    dmtx->apply(dy.get(), dresult.get());
+    mtx->apply(y, expected);
+    dmtx->apply(dy, dresult);
 
     GKO_ASSERT_MTX_NEAR(dresult, expected, r<value_type>::value);
 }
@@ -488,8 +488,8 @@ TEST_F(Ell, AdvancedApplyOnSmallMatrixIsEquivalentToRef)
 {
     set_up_apply_data(1, 10);
 
-    mtx->apply(alpha.get(), y.get(), beta.get(), expected.get());
-    dmtx->apply(dalpha.get(), dy.get(), dbeta.get(), dresult.get());
+    mtx->apply(alpha, y, beta, expected);
+    dmtx->apply(dalpha, dy, dbeta, dresult);
 
     GKO_ASSERT_MTX_NEAR(dresult, expected, r<value_type>::value * 5);
 }
@@ -503,8 +503,8 @@ TEST_F(Ell, ApplyToComplexIsEquivalentToRef)
     auto complex_x = gen_mtx<ComplexVec>(size[0], 3);
     auto dcomplex_x = gko::clone(exec, complex_x);
 
-    mtx->apply(complex_b.get(), complex_x.get());
-    dmtx->apply(dcomplex_b.get(), dcomplex_x.get());
+    mtx->apply(complex_b, complex_x);
+    dmtx->apply(dcomplex_b, dcomplex_x);
 
     GKO_ASSERT_MTX_NEAR(dcomplex_x, complex_x, r<value_type>::value);
 }
@@ -518,8 +518,8 @@ TEST_F(Ell, AdvancedApplyToComplexIsEquivalentToRef)
     auto complex_x = gen_mtx<ComplexVec>(size[0], 3);
     auto dcomplex_x = gko::clone(exec, complex_x);
 
-    mtx->apply(alpha.get(), complex_b.get(), beta.get(), complex_x.get());
-    dmtx->apply(dalpha.get(), dcomplex_b.get(), dbeta.get(), dcomplex_x.get());
+    mtx->apply(alpha, complex_b, beta, complex_x);
+    dmtx->apply(dalpha, dcomplex_b, dbeta, dcomplex_x);
 
     GKO_ASSERT_MTX_NEAR(dcomplex_x, complex_x, r<value_type>::value);
 }
@@ -532,10 +532,10 @@ TEST_F(Ell, ConvertToDenseIsEquivalentToRef)
     auto dense_mtx = gko::matrix::Dense<value_type>::create(ref);
     auto ddense_mtx = gko::matrix::Dense<value_type>::create(exec);
 
-    mtx->convert_to(dense_mtx.get());
-    dmtx->convert_to(ddense_mtx.get());
+    mtx->convert_to(dense_mtx);
+    dmtx->convert_to(ddense_mtx);
 
-    GKO_ASSERT_MTX_NEAR(dense_mtx.get(), ddense_mtx.get(), 0);
+    GKO_ASSERT_MTX_NEAR(dense_mtx, ddense_mtx, 0);
 }
 
 
@@ -546,10 +546,10 @@ TEST_F(Ell, ConvertToCsrIsEquivalentToRef)
     auto csr_mtx = gko::matrix::Csr<value_type>::create(ref);
     auto dcsr_mtx = gko::matrix::Csr<value_type>::create(exec);
 
-    mtx->convert_to(csr_mtx.get());
-    dmtx->convert_to(dcsr_mtx.get());
+    mtx->convert_to(csr_mtx);
+    dmtx->convert_to(dcsr_mtx);
 
-    GKO_ASSERT_MTX_NEAR(csr_mtx.get(), dcsr_mtx.get(), 0);
+    GKO_ASSERT_MTX_NEAR(csr_mtx, dcsr_mtx, 0);
 }
 
 
@@ -575,7 +575,7 @@ TEST_F(Ell, ExtractDiagonalIsEquivalentToRef)
     auto diag = mtx->extract_diagonal();
     auto ddiag = dmtx->extract_diagonal();
 
-    GKO_ASSERT_MTX_NEAR(diag.get(), ddiag.get(), 0);
+    GKO_ASSERT_MTX_NEAR(diag, ddiag, 0);
 }
 
 

--- a/test/matrix/ell_kernels.cpp
+++ b/test/matrix/ell_kernels.cpp
@@ -77,7 +77,7 @@ protected:
     {
         mtx = Mtx::create(ref, gko::dim<2>{}, num_stored_elements_per_row,
                           stride);
-        mtx->copy_from(gen_mtx(num_rows, num_cols));
+        mtx->move_from(gen_mtx(num_rows, num_cols));
         expected = gen_mtx(num_rows, num_vectors);
         expected2 = Vec2::create(ref);
         expected2->copy_from(expected);

--- a/test/matrix/fbcsr_kernels.cpp
+++ b/test/matrix/fbcsr_kernels.cpp
@@ -140,7 +140,7 @@ TYPED_TEST(Fbcsr, TransposeIsEquivalentToRefSortedBS7)
     auto rsorted2 = gko::test::generate_random_fbcsr<value_type, index_type>(
         this->ref, rand_brows, rand_bcols, block_size, false, false,
         std::default_random_engine(43));
-    drand->copy_from(gko::lend(rsorted2));
+    drand->copy_from(rsorted2);
 
     auto trans = gko::as<Mtx>(rsorted2->transpose());
     auto dtrans = gko::as<Mtx>(drand->transpose());

--- a/test/matrix/fbcsr_kernels.cpp
+++ b/test/matrix/fbcsr_kernels.cpp
@@ -77,7 +77,7 @@ protected:
         return gko::test::detail::get_rand_value<T>(distb, engine);
     }
 
-    void generate_sin(gko::pointer_param<Dense> x)
+    void generate_sin(gko::ptr_param<Dense> x)
     {
         value_type* const xarr = x->get_values();
         for (index_type i = 0; i < x->get_size()[0] * x->get_size()[1]; i++) {

--- a/test/matrix/fbcsr_kernels.cpp
+++ b/test/matrix/fbcsr_kernels.cpp
@@ -77,7 +77,7 @@ protected:
         return gko::test::detail::get_rand_value<T>(distb, engine);
     }
 
-    void generate_sin(Dense* const x)
+    void generate_sin(gko::pointer_param<Dense> x)
     {
         value_type* const xarr = x->get_values();
         for (index_type i = 0; i < x->get_size()[0] * x->get_size()[1]; i++) {
@@ -158,14 +158,14 @@ TYPED_TEST(Fbcsr, SpmvIsEquivalentToRefSorted)
     auto drand = gko::clone(this->exec, this->rsorted);
     auto x =
         Dense::create(this->ref, gko::dim<2>(this->rsorted->get_size()[1], 1));
-    this->generate_sin(x.get());
+    this->generate_sin(x);
     auto dx = gko::clone(this->exec, x);
     auto prod =
         Dense::create(this->ref, gko::dim<2>(this->rsorted->get_size()[0], 1));
     auto dprod = Dense::create(this->exec, prod->get_size());
 
-    drand->apply(dx.get(), dprod.get());
-    this->rsorted->apply(x.get(), prod.get());
+    drand->apply(dx, dprod);
+    this->rsorted->apply(x, prod);
 
     const double tol = r<value_type>::value;
     GKO_ASSERT_MTX_NEAR(prod, dprod, 5 * tol);
@@ -180,14 +180,14 @@ TYPED_TEST(Fbcsr, SpmvMultiIsEquivalentToRefSorted)
     auto drand = gko::clone(this->exec, this->rsorted);
     auto x =
         Dense::create(this->ref, gko::dim<2>(this->rsorted->get_size()[1], 3));
-    this->generate_sin(x.get());
+    this->generate_sin(x);
     auto dx = gko::clone(this->exec, x);
     auto prod =
         Dense::create(this->ref, gko::dim<2>(this->rsorted->get_size()[0], 3));
     auto dprod = Dense::create(this->exec, prod->get_size());
 
-    drand->apply(dx.get(), dprod.get());
-    this->rsorted->apply(x.get(), prod.get());
+    drand->apply(dx, dprod);
+    this->rsorted->apply(x, prod);
 
     const double tol = r<value_type>::value;
     GKO_ASSERT_MTX_NEAR(prod, dprod, 5 * tol);
@@ -203,11 +203,11 @@ TYPED_TEST(Fbcsr, AdvancedSpmvIsEquivalentToRefSorted)
     auto drand = gko::clone(this->exec, this->rsorted);
     auto x =
         Dense::create(this->ref, gko::dim<2>(this->rsorted->get_size()[1], 1));
-    this->generate_sin(x.get());
+    this->generate_sin(x);
     auto dx = gko::clone(this->exec, x);
     auto prod =
         Dense::create(this->ref, gko::dim<2>(this->rsorted->get_size()[0], 1));
-    this->generate_sin(prod.get());
+    this->generate_sin(prod);
     auto dprod = gko::clone(this->exec, prod);
     auto alpha = Dense::create(this->ref, gko::dim<2>(1, 1));
     alpha->at(0, 0) = static_cast<real_type>(2.4) + this->get_random_value();
@@ -216,8 +216,8 @@ TYPED_TEST(Fbcsr, AdvancedSpmvIsEquivalentToRefSorted)
     auto dalpha = gko::clone(this->exec, alpha);
     auto dbeta = gko::clone(this->exec, beta);
 
-    drand->apply(dalpha.get(), dx.get(), dbeta.get(), dprod.get());
-    this->rsorted->apply(alpha.get(), x.get(), beta.get(), prod.get());
+    drand->apply(dalpha, dx, dbeta, dprod);
+    this->rsorted->apply(alpha, x, beta, prod);
 
     const double tol = r<value_type>::value;
     GKO_ASSERT_MTX_NEAR(prod, dprod, 5 * tol);
@@ -233,11 +233,11 @@ TYPED_TEST(Fbcsr, AdvancedSpmvMultiIsEquivalentToRefSorted)
     auto drand = gko::clone(this->exec, this->rsorted);
     auto x =
         Dense::create(this->ref, gko::dim<2>(this->rsorted->get_size()[1], 3));
-    this->generate_sin(x.get());
+    this->generate_sin(x);
     auto dx = gko::clone(this->exec, x);
     auto prod =
         Dense::create(this->ref, gko::dim<2>(this->rsorted->get_size()[0], 3));
-    this->generate_sin(prod.get());
+    this->generate_sin(prod);
     auto dprod = gko::clone(this->exec, prod);
     auto alpha = Dense::create(this->ref, gko::dim<2>(1, 1));
     alpha->at(0, 0) = static_cast<real_type>(2.4) + this->get_random_value();
@@ -246,8 +246,8 @@ TYPED_TEST(Fbcsr, AdvancedSpmvMultiIsEquivalentToRefSorted)
     auto dalpha = gko::clone(this->exec, alpha);
     auto dbeta = gko::clone(this->exec, beta);
 
-    drand->apply(dalpha.get(), dx.get(), dbeta.get(), dprod.get());
-    this->rsorted->apply(alpha.get(), x.get(), beta.get(), prod.get());
+    drand->apply(dalpha, dx, dbeta, dprod);
+    this->rsorted->apply(alpha, x, beta, prod);
 
     const double tol = r<value_type>::value;
     GKO_ASSERT_MTX_NEAR(prod, dprod, 5 * tol);

--- a/test/matrix/fft_kernels.cpp
+++ b/test/matrix/fft_kernels.cpp
@@ -70,7 +70,7 @@ protected:
             n, cols, std::uniform_int_distribution<>(1, cols),
             std::normal_distribution<>(-1.0, 1.0), rand_engine, ref);
         ddata = Vec::create(exec);
-        ddata->copy_from(this->data.get());
+        ddata->copy_from(this->data);
         data_strided = data->create_submatrix({0, n}, {0, subcols});
         ddata_strided = ddata->create_submatrix({0, n}, {0, subcols});
         out = data->clone();
@@ -129,8 +129,8 @@ TYPED_TEST(Fft, Apply1DIsEqualToReference)
 {
     using T = typename TestFixture::value_type;
 
-    this->fft->apply(this->data.get(), this->out.get());
-    this->dfft->apply(this->ddata.get(), this->dout.get());
+    this->fft->apply(this->data, this->out);
+    this->dfft->apply(this->ddata, this->dout);
 
     GKO_ASSERT_MTX_NEAR(this->out, this->dout, r<T>::value);
 }
@@ -140,8 +140,8 @@ TYPED_TEST(Fft, ApplyStrided1DIsEqualToReference)
 {
     using T = typename TestFixture::value_type;
 
-    this->fft->apply(this->data_strided.get(), this->out_strided.get());
-    this->dfft->apply(this->ddata_strided.get(), this->dout_strided.get());
+    this->fft->apply(this->data_strided, this->out_strided);
+    this->dfft->apply(this->ddata_strided, this->dout_strided);
 
     GKO_ASSERT_MTX_NEAR(this->out_strided, this->dout_strided, r<T>::value);
 }
@@ -151,8 +151,8 @@ TYPED_TEST(Fft, Apply1DInverseIsEqualToReference)
 {
     using T = typename TestFixture::value_type;
 
-    this->ifft->apply(this->data.get(), this->out.get());
-    this->difft->apply(this->ddata.get(), this->dout.get());
+    this->ifft->apply(this->data, this->out);
+    this->difft->apply(this->ddata, this->dout);
 
     GKO_ASSERT_MTX_NEAR(this->out, this->dout, r<T>::value);
 }
@@ -162,8 +162,8 @@ TYPED_TEST(Fft, ApplyStrided1DInverseIsEqualToReference)
 {
     using T = typename TestFixture::value_type;
 
-    this->ifft->apply(this->data_strided.get(), this->out_strided.get());
-    this->difft->apply(this->ddata_strided.get(), this->dout_strided.get());
+    this->ifft->apply(this->data_strided, this->out_strided);
+    this->difft->apply(this->ddata_strided, this->dout_strided);
 
     GKO_ASSERT_MTX_NEAR(this->out_strided, this->dout_strided, r<T>::value);
 }
@@ -173,8 +173,8 @@ TYPED_TEST(Fft, Apply2DIsEqualToReference)
 {
     using T = typename TestFixture::value_type;
 
-    this->fft2->apply(this->data.get(), this->out.get());
-    this->dfft2->apply(this->ddata.get(), this->dout.get());
+    this->fft2->apply(this->data, this->out);
+    this->dfft2->apply(this->ddata, this->dout);
 
     GKO_ASSERT_MTX_NEAR(this->out, this->dout, r<T>::value);
 }
@@ -184,8 +184,8 @@ TYPED_TEST(Fft, ApplyStrided2DIsEqualToReference)
 {
     using T = typename TestFixture::value_type;
 
-    this->fft2->apply(this->data_strided.get(), this->out_strided.get());
-    this->dfft2->apply(this->ddata_strided.get(), this->dout_strided.get());
+    this->fft2->apply(this->data_strided, this->out_strided);
+    this->dfft2->apply(this->ddata_strided, this->dout_strided);
 
     GKO_ASSERT_MTX_NEAR(this->out_strided, this->dout_strided, r<T>::value);
 }
@@ -195,8 +195,8 @@ TYPED_TEST(Fft, Apply2DInverseIsEqualToReference)
 {
     using T = typename TestFixture::value_type;
 
-    this->ifft2->apply(this->data.get(), this->out.get());
-    this->difft2->apply(this->ddata.get(), this->dout.get());
+    this->ifft2->apply(this->data, this->out);
+    this->difft2->apply(this->ddata, this->dout);
 
     GKO_ASSERT_MTX_NEAR(this->out, this->dout, r<T>::value);
 }
@@ -206,8 +206,8 @@ TYPED_TEST(Fft, ApplyStrided2DInverseIsEqualToReference)
 {
     using T = typename TestFixture::value_type;
 
-    this->ifft2->apply(this->data_strided.get(), this->out_strided.get());
-    this->difft2->apply(this->ddata_strided.get(), this->dout_strided.get());
+    this->ifft2->apply(this->data_strided, this->out_strided);
+    this->difft2->apply(this->ddata_strided, this->dout_strided);
 
     GKO_ASSERT_MTX_NEAR(this->out_strided, this->dout_strided, r<T>::value);
 }
@@ -217,8 +217,8 @@ TYPED_TEST(Fft, Apply3DIsEqualToReference)
 {
     using T = typename TestFixture::value_type;
 
-    this->fft3->apply(this->data.get(), this->out.get());
-    this->dfft3->apply(this->ddata.get(), this->dout.get());
+    this->fft3->apply(this->data, this->out);
+    this->dfft3->apply(this->ddata, this->dout);
 
     GKO_ASSERT_MTX_NEAR(this->out, this->dout, r<T>::value);
 }
@@ -228,8 +228,8 @@ TYPED_TEST(Fft, ApplyStrided3DIsEqualToReference)
 {
     using T = typename TestFixture::value_type;
 
-    this->fft3->apply(this->data_strided.get(), this->out_strided.get());
-    this->dfft3->apply(this->ddata_strided.get(), this->dout_strided.get());
+    this->fft3->apply(this->data_strided, this->out_strided);
+    this->dfft3->apply(this->ddata_strided, this->dout_strided);
 
     GKO_ASSERT_MTX_NEAR(this->out_strided, this->dout_strided, r<T>::value);
 }
@@ -239,8 +239,8 @@ TYPED_TEST(Fft, Apply3DInverseIsEqualToReference)
 {
     using T = typename TestFixture::value_type;
 
-    this->ifft3->apply(this->data.get(), this->out.get());
-    this->difft3->apply(this->ddata.get(), this->dout.get());
+    this->ifft3->apply(this->data, this->out);
+    this->difft3->apply(this->ddata, this->dout);
 
     GKO_ASSERT_MTX_NEAR(this->out, this->dout, r<T>::value);
 }
@@ -250,8 +250,8 @@ TYPED_TEST(Fft, ApplyStrided3DInverseIsEqualToReference)
 {
     using T = typename TestFixture::value_type;
 
-    this->ifft3->apply(this->data_strided.get(), this->out_strided.get());
-    this->difft3->apply(this->ddata_strided.get(), this->dout_strided.get());
+    this->ifft3->apply(this->data_strided, this->out_strided);
+    this->difft3->apply(this->ddata_strided, this->dout_strided);
 
     GKO_ASSERT_MTX_NEAR(this->out_strided, this->dout_strided, r<T>::value);
 }

--- a/test/matrix/hybrid_kernels.cpp
+++ b/test/matrix/hybrid_kernels.cpp
@@ -80,7 +80,7 @@ protected:
                                std::make_shared<Mtx::automatic>())
     {
         mtx = Mtx::create(ref, strategy);
-        mtx->copy_from(gen_mtx(532, 231, 1));
+        mtx->move_from(gen_mtx(532, 231, 1));
         expected = gen_mtx(532, num_vectors, 1);
         y = gen_mtx(231, num_vectors, 1);
         alpha = gko::initialize<Vec>({2.0}, ref);
@@ -200,7 +200,7 @@ TEST_F(Hybrid, ConvertEmptyCooToCsrIsEquivalentToRef)
 {
     auto balanced_mtx =
         Mtx::create(ref, std::make_shared<Mtx::column_limit>(4));
-    balanced_mtx->copy_from(gen_mtx(400, 200, 4, 4));
+    balanced_mtx->move_from(gen_mtx(400, 200, 4, 4));
     auto dbalanced_mtx =
         Mtx::create(exec, std::make_shared<Mtx::column_limit>(4));
     dbalanced_mtx->copy_from(balanced_mtx);

--- a/test/matrix/hybrid_kernels.cpp
+++ b/test/matrix/hybrid_kernels.cpp
@@ -86,7 +86,7 @@ protected:
         alpha = gko::initialize<Vec>({2.0}, ref);
         beta = gko::initialize<Vec>({-1.0}, ref);
         dmtx = Mtx::create(exec, strategy);
-        dmtx->copy_from(mtx.get());
+        dmtx->copy_from(mtx);
         dresult = gko::clone(exec, expected);
         dy = gko::clone(exec, y);
         dalpha = gko::clone(exec, alpha);
@@ -126,8 +126,8 @@ TEST_F(Hybrid, SimpleApplyIsEquivalentToRef)
 {
     set_up_apply_data();
 
-    mtx->apply(y.get(), expected.get());
-    dmtx->apply(dy.get(), dresult.get());
+    mtx->apply(y, expected);
+    dmtx->apply(dy, dresult);
 
     GKO_ASSERT_MTX_NEAR(dresult, expected, r<value_type>::value);
 }
@@ -137,8 +137,8 @@ TEST_F(Hybrid, AdvancedApplyIsEquivalentToRef)
 {
     set_up_apply_data();
 
-    mtx->apply(alpha.get(), y.get(), beta.get(), expected.get());
-    dmtx->apply(dalpha.get(), dy.get(), dbeta.get(), dresult.get());
+    mtx->apply(alpha, y, beta, expected);
+    dmtx->apply(dalpha, dy, dbeta, dresult);
 
     GKO_ASSERT_MTX_NEAR(dresult, expected, r<value_type>::value);
 }
@@ -148,8 +148,8 @@ TEST_F(Hybrid, SimpleApplyToDenseMatrixIsEquivalentToRef)
 {
     set_up_apply_data(3);
 
-    mtx->apply(y.get(), expected.get());
-    dmtx->apply(dy.get(), dresult.get());
+    mtx->apply(y, expected);
+    dmtx->apply(dy, dresult);
 
     GKO_ASSERT_MTX_NEAR(dresult, expected, r<value_type>::value);
 }
@@ -159,8 +159,8 @@ TEST_F(Hybrid, AdvancedApplyToDenseMatrixIsEquivalentToRef)
 {
     set_up_apply_data(3);
 
-    mtx->apply(alpha.get(), y.get(), beta.get(), expected.get());
-    dmtx->apply(dalpha.get(), dy.get(), dbeta.get(), dresult.get());
+    mtx->apply(alpha, y, beta, expected);
+    dmtx->apply(dalpha, dy, dbeta, dresult);
 
     GKO_ASSERT_MTX_NEAR(dresult, expected, r<value_type>::value);
 }
@@ -174,8 +174,8 @@ TEST_F(Hybrid, ApplyToComplexIsEquivalentToRef)
     auto complex_x = gen_mtx<ComplexVec>(532, 3, 1);
     auto dcomplex_x = gko::clone(exec, complex_x);
 
-    mtx->apply(complex_b.get(), complex_x.get());
-    dmtx->apply(dcomplex_b.get(), dcomplex_x.get());
+    mtx->apply(complex_b, complex_x);
+    dmtx->apply(dcomplex_b, dcomplex_x);
 
     GKO_ASSERT_MTX_NEAR(dcomplex_x, complex_x, r<value_type>::value);
 }
@@ -189,8 +189,8 @@ TEST_F(Hybrid, AdvancedApplyToComplexIsEquivalentToRef)
     auto complex_x = gen_mtx<ComplexVec>(532, 3, 1);
     auto dcomplex_x = gko::clone(exec, complex_x);
 
-    mtx->apply(alpha.get(), complex_b.get(), beta.get(), complex_x.get());
-    dmtx->apply(dalpha.get(), dcomplex_b.get(), dbeta.get(), dcomplex_x.get());
+    mtx->apply(alpha, complex_b, beta, complex_x);
+    dmtx->apply(dalpha, dcomplex_b, dbeta, dcomplex_x);
 
     GKO_ASSERT_MTX_NEAR(dcomplex_x, complex_x, r<value_type>::value);
 }
@@ -200,17 +200,17 @@ TEST_F(Hybrid, ConvertEmptyCooToCsrIsEquivalentToRef)
 {
     auto balanced_mtx =
         Mtx::create(ref, std::make_shared<Mtx::column_limit>(4));
-    balanced_mtx->copy_from(gen_mtx(400, 200, 4, 4).get());
+    balanced_mtx->copy_from(gen_mtx(400, 200, 4, 4));
     auto dbalanced_mtx =
         Mtx::create(exec, std::make_shared<Mtx::column_limit>(4));
-    dbalanced_mtx->copy_from(balanced_mtx.get());
+    dbalanced_mtx->copy_from(balanced_mtx);
     auto csr_mtx = gko::matrix::Csr<value_type>::create(ref);
     auto dcsr_mtx = gko::matrix::Csr<value_type>::create(exec);
 
-    balanced_mtx->convert_to(csr_mtx.get());
-    dbalanced_mtx->convert_to(dcsr_mtx.get());
+    balanced_mtx->convert_to(csr_mtx);
+    dbalanced_mtx->convert_to(dcsr_mtx);
 
-    GKO_ASSERT_MTX_NEAR(csr_mtx.get(), dcsr_mtx.get(), 1e-14);
+    GKO_ASSERT_MTX_NEAR(csr_mtx, dcsr_mtx, 1e-14);
 }
 
 
@@ -230,10 +230,10 @@ TEST_F(Hybrid, ConvertWithEmptyFirstAndLastRowToCsrIsEquivalentToRef)
     auto csr_mtx = gko::matrix::Csr<value_type>::create(ref);
     auto dcsr_mtx = gko::matrix::Csr<value_type>::create(exec);
 
-    balanced_mtx->convert_to(csr_mtx.get());
-    dbalanced_mtx->convert_to(dcsr_mtx.get());
+    balanced_mtx->convert_to(csr_mtx);
+    dbalanced_mtx->convert_to(dcsr_mtx);
 
-    GKO_ASSERT_MTX_NEAR(csr_mtx.get(), dcsr_mtx.get(), 1e-14);
+    GKO_ASSERT_MTX_NEAR(csr_mtx, dcsr_mtx, 1e-14);
 }
 
 
@@ -243,10 +243,10 @@ TEST_F(Hybrid, ConvertToCsrIsEquivalentToRef)
     auto csr_mtx = gko::matrix::Csr<value_type>::create(ref);
     auto dcsr_mtx = gko::matrix::Csr<value_type>::create(exec);
 
-    mtx->convert_to(csr_mtx.get());
-    dmtx->convert_to(dcsr_mtx.get());
+    mtx->convert_to(csr_mtx);
+    dmtx->convert_to(dcsr_mtx);
 
-    GKO_ASSERT_MTX_NEAR(csr_mtx.get(), dcsr_mtx.get(), 0);
+    GKO_ASSERT_MTX_NEAR(csr_mtx, dcsr_mtx, 0);
 }
 
 
@@ -256,10 +256,10 @@ TEST_F(Hybrid, MoveToCsrIsEquivalentToRef)
     auto csr_mtx = gko::matrix::Csr<value_type>::create(ref);
     auto dcsr_mtx = gko::matrix::Csr<value_type>::create(exec);
 
-    mtx->move_to(csr_mtx.get());
-    dmtx->move_to(dcsr_mtx.get());
+    mtx->move_to(csr_mtx);
+    dmtx->move_to(dcsr_mtx);
 
-    GKO_ASSERT_MTX_NEAR(csr_mtx.get(), dcsr_mtx.get(), 0);
+    GKO_ASSERT_MTX_NEAR(csr_mtx, dcsr_mtx, 0);
 }
 
 
@@ -270,7 +270,7 @@ TEST_F(Hybrid, ExtractDiagonalIsEquivalentToRef)
     auto diag = mtx->extract_diagonal();
     auto ddiag = dmtx->extract_diagonal();
 
-    GKO_ASSERT_MTX_NEAR(diag.get(), ddiag.get(), 0);
+    GKO_ASSERT_MTX_NEAR(diag, ddiag, 0);
 }
 
 

--- a/test/matrix/matrix.cpp
+++ b/test/matrix/matrix.cpp
@@ -80,11 +80,11 @@ struct SimpleMatrixTest {
                          typename MtxType::index_type>& data)
     {}
 
-    static void check_property(const matrix_type*) {}
+    static void check_property(gko::pointer_param<const matrix_type>) {}
 
     static bool supports_strides() { return true; }
 
-    static void assert_empty_state(const matrix_type* mtx)
+    static void assert_empty_state(gko::pointer_param<const matrix_type> mtx)
     {
         ASSERT_FALSE(mtx->get_size());
     }
@@ -94,7 +94,7 @@ struct DenseWithDefaultStride
     : SimpleMatrixTest<gko::matrix::Dense<matrix_value_type>> {
     static bool preserves_zeros() { return false; }
 
-    static void assert_empty_state(const matrix_type* mtx)
+    static void assert_empty_state(gko::pointer_param<const matrix_type> mtx)
     {
         ASSERT_FALSE(mtx->get_size());
         ASSERT_EQ(mtx->get_stride(), 0);
@@ -110,12 +110,12 @@ struct DenseWithCustomStride : DenseWithDefaultStride {
         return matrix_type::create(exec, size, size[0] + 10);
     }
 
-    static void check_property(const matrix_type* mtx)
+    static void check_property(gko::pointer_param<const matrix_type> mtx)
     {
         ASSERT_EQ(mtx->get_stride(), mtx->get_size()[0] + 10);
     }
 
-    static void assert_empty_state(const matrix_type* mtx)
+    static void assert_empty_state(gko::pointer_param<const matrix_type> mtx)
     {
         ASSERT_FALSE(mtx->get_size());
         ASSERT_EQ(mtx->get_stride(), 0);
@@ -125,7 +125,7 @@ struct DenseWithCustomStride : DenseWithDefaultStride {
 };
 
 struct Coo : SimpleMatrixTest<gko::matrix::Coo<matrix_value_type, int>> {
-    static void assert_empty_state(const matrix_type* mtx)
+    static void assert_empty_state(gko::pointer_param<const matrix_type> mtx)
     {
         ASSERT_FALSE(mtx->get_size());
         ASSERT_EQ(mtx->get_num_stored_elements(), 0);
@@ -136,7 +136,7 @@ struct Coo : SimpleMatrixTest<gko::matrix::Coo<matrix_value_type, int>> {
 };
 
 struct CsrBase : SimpleMatrixTest<gko::matrix::Csr<matrix_value_type, int>> {
-    static void assert_empty_state(const matrix_type* mtx)
+    static void assert_empty_state(gko::pointer_param<const matrix_type> mtx)
     {
         ASSERT_FALSE(mtx->get_size());
         ASSERT_EQ(mtx->get_num_stored_elements(), 0);
@@ -150,7 +150,7 @@ struct CsrBase : SimpleMatrixTest<gko::matrix::Csr<matrix_value_type, int>> {
 };
 
 struct CsrWithDefaultStrategy : CsrBase {
-    static void assert_empty_state(const matrix_type* mtx)
+    static void assert_empty_state(gko::pointer_param<const matrix_type> mtx)
     {
         CsrBase::assert_empty_state(mtx);
         auto first_strategy = mtx->create_default()->get_strategy();
@@ -172,13 +172,13 @@ struct CsrWithClassicalStrategy : CsrBase {
                                    std::make_shared<matrix_type::classical>());
     }
 
-    static void check_property(const matrix_type* mtx)
+    static void check_property(gko::pointer_param<const matrix_type> mtx)
     {
         ASSERT_TRUE(dynamic_cast<const matrix_type::classical*>(
             mtx->get_strategy().get()));
     }
 
-    static void assert_empty_state(const matrix_type* mtx)
+    static void assert_empty_state(gko::pointer_param<const matrix_type> mtx)
     {
         CsrBase::assert_empty_state(mtx);
         ASSERT_TRUE(dynamic_cast<const matrix_type::classical*>(
@@ -194,13 +194,13 @@ struct CsrWithMergePathStrategy : CsrBase {
                                    std::make_shared<matrix_type::merge_path>());
     }
 
-    static void check_property(const matrix_type* mtx)
+    static void check_property(gko::pointer_param<const matrix_type> mtx)
     {
         ASSERT_TRUE(dynamic_cast<const matrix_type::merge_path*>(
             mtx->get_strategy().get()));
     }
 
-    static void assert_empty_state(const matrix_type* mtx)
+    static void assert_empty_state(gko::pointer_param<const matrix_type> mtx)
     {
         CsrBase::assert_empty_state(mtx);
         ASSERT_TRUE(dynamic_cast<const matrix_type::merge_path*>(
@@ -216,13 +216,13 @@ struct CsrWithSparselibStrategy : CsrBase {
                                    std::make_shared<matrix_type::sparselib>());
     }
 
-    static void check_property(const matrix_type* mtx)
+    static void check_property(gko::pointer_param<const matrix_type> mtx)
     {
         ASSERT_TRUE(dynamic_cast<const matrix_type::sparselib*>(
             mtx->get_strategy().get()));
     }
 
-    static void assert_empty_state(const matrix_type* mtx)
+    static void assert_empty_state(gko::pointer_param<const matrix_type> mtx)
     {
         CsrBase::assert_empty_state(mtx);
         ASSERT_TRUE(dynamic_cast<const matrix_type::sparselib*>(
@@ -239,13 +239,13 @@ struct CsrWithLoadBalanceStrategy : CsrBase {
                                        gko::EXEC_TYPE::create(0, exec)));
     }
 
-    static void check_property(const matrix_type* mtx)
+    static void check_property(gko::pointer_param<const matrix_type> mtx)
     {
         ASSERT_TRUE(dynamic_cast<const matrix_type::load_balance*>(
             mtx->get_strategy().get()));
     }
 
-    static void assert_empty_state(const matrix_type* mtx)
+    static void assert_empty_state(gko::pointer_param<const matrix_type> mtx)
     {
         CsrBase::assert_empty_state(mtx);
         ASSERT_TRUE(dynamic_cast<const matrix_type::load_balance*>(
@@ -262,13 +262,13 @@ struct CsrWithAutomaticalStrategy : CsrBase {
                                        gko::EXEC_TYPE::create(0, exec)));
     }
 
-    static void check_property(const matrix_type* mtx)
+    static void check_property(gko::pointer_param<const matrix_type> mtx)
     {
         ASSERT_TRUE(dynamic_cast<const matrix_type::automatical*>(
             mtx->get_strategy().get()));
     }
 
-    static void assert_empty_state(const matrix_type* mtx)
+    static void assert_empty_state(gko::pointer_param<const matrix_type> mtx)
     {
         CsrBase::assert_empty_state(mtx);
         ASSERT_TRUE(dynamic_cast<const matrix_type::automatical*>(
@@ -281,7 +281,7 @@ struct CsrWithAutomaticalStrategy : CsrBase {
 
 
 struct Ell : SimpleMatrixTest<gko::matrix::Ell<matrix_value_type, int>> {
-    static void assert_empty_state(const matrix_type* mtx)
+    static void assert_empty_state(gko::pointer_param<const matrix_type> mtx)
     {
         ASSERT_FALSE(mtx->get_size());
         ASSERT_EQ(mtx->get_num_stored_elements_per_row(), 0);
@@ -305,12 +305,12 @@ struct Fbcsr : SimpleMatrixTest<gko::matrix::Fbcsr<matrix_value_type, int>> {
         return matrix_type::create(exec, size, 0, block_size);
     }
 
-    static void check_property(const matrix_type* mtx)
+    static void check_property(gko::pointer_param<const matrix_type> mtx)
     {
         ASSERT_EQ(mtx->get_block_size(), block_size);
     }
 
-    static void assert_empty_state(const matrix_type* mtx)
+    static void assert_empty_state(gko::pointer_param<const matrix_type> mtx)
     {
         ASSERT_FALSE(mtx->get_size());
         ASSERT_EQ(mtx->get_block_size(), block_size);
@@ -331,7 +331,7 @@ struct Fbcsr : SimpleMatrixTest<gko::matrix::Fbcsr<matrix_value_type, int>> {
 
 struct SellpBase
     : SimpleMatrixTest<gko::matrix::Sellp<matrix_value_type, int>> {
-    static void assert_empty_state(const matrix_type* mtx)
+    static void assert_empty_state(gko::pointer_param<const matrix_type> mtx)
     {
         ASSERT_FALSE(mtx->get_size());
         ASSERT_EQ(mtx->get_num_stored_elements(), 0);
@@ -348,13 +348,13 @@ struct SellpBase
 
 
 struct SellpDefaultParameters : SellpBase {
-    static void check_property(const matrix_type* mtx)
+    static void check_property(gko::pointer_param<const matrix_type> mtx)
     {
         ASSERT_EQ(mtx->get_stride_factor(), 1);
         ASSERT_EQ(mtx->get_slice_size(), 64);
     }
 
-    static void assert_empty_state(const matrix_type* mtx)
+    static void assert_empty_state(gko::pointer_param<const matrix_type> mtx)
     {
         SellpBase::assert_empty_state(mtx);
         ASSERT_EQ(mtx->get_stride_factor(), 1);
@@ -369,13 +369,13 @@ struct Sellp32Factor2 : SellpBase {
         return matrix_type::create(exec, size, 32, 2, 0);
     }
 
-    static void check_property(const matrix_type* mtx)
+    static void check_property(gko::pointer_param<const matrix_type> mtx)
     {
         ASSERT_EQ(mtx->get_stride_factor(), 2);
         ASSERT_EQ(mtx->get_slice_size(), 32);
     }
 
-    static void assert_empty_state(const matrix_type* mtx)
+    static void assert_empty_state(gko::pointer_param<const matrix_type> mtx)
     {
         SellpBase::assert_empty_state(mtx);
         ASSERT_EQ(mtx->get_stride_factor(), 2);
@@ -386,7 +386,7 @@ struct Sellp32Factor2 : SellpBase {
 
 struct HybridBase
     : SimpleMatrixTest<gko::matrix::Hybrid<matrix_value_type, int>> {
-    static void assert_empty_state(const matrix_type* mtx)
+    static void assert_empty_state(gko::pointer_param<const matrix_type> mtx)
     {
         ASSERT_FALSE(mtx->get_size());
         ASSERT_FALSE(mtx->get_coo()->get_size());
@@ -405,14 +405,14 @@ struct HybridBase
 
 
 struct HybridDefaultStrategy : HybridBase {
-    static void check_property(const matrix_type* mtx)
+    static void check_property(gko::pointer_param<const matrix_type> mtx)
     {
         auto strategy = dynamic_cast<const matrix_type::automatic*>(
             mtx->get_strategy().get());
         ASSERT_TRUE(strategy);
     }
 
-    static void assert_empty_state(const matrix_type* mtx)
+    static void assert_empty_state(gko::pointer_param<const matrix_type> mtx)
     {
         HybridBase::assert_empty_state(mtx);
         check_property(mtx);
@@ -427,7 +427,7 @@ struct HybridColumnLimitStrategy : HybridBase {
             exec, size, 0, std::make_shared<matrix_type::column_limit>(10));
     }
 
-    static void check_property(const matrix_type* mtx)
+    static void check_property(gko::pointer_param<const matrix_type> mtx)
     {
         auto strategy = dynamic_cast<const matrix_type::column_limit*>(
             mtx->get_strategy().get());
@@ -435,7 +435,7 @@ struct HybridColumnLimitStrategy : HybridBase {
         ASSERT_EQ(strategy->get_num_columns(), 10);
     }
 
-    static void assert_empty_state(const matrix_type* mtx)
+    static void assert_empty_state(gko::pointer_param<const matrix_type> mtx)
     {
         HybridBase::assert_empty_state(mtx);
         check_property(mtx);
@@ -450,7 +450,7 @@ struct HybridImbalanceLimitStrategy : HybridBase {
             exec, size, 0, std::make_shared<matrix_type::imbalance_limit>(0.5));
     }
 
-    static void check_property(const matrix_type* mtx)
+    static void check_property(gko::pointer_param<const matrix_type> mtx)
     {
         auto strategy = dynamic_cast<const matrix_type::imbalance_limit*>(
             mtx->get_strategy().get());
@@ -458,7 +458,7 @@ struct HybridImbalanceLimitStrategy : HybridBase {
         ASSERT_EQ(strategy->get_percentage(), 0.5);
     }
 
-    static void assert_empty_state(const matrix_type* mtx)
+    static void assert_empty_state(gko::pointer_param<const matrix_type> mtx)
     {
         HybridBase::assert_empty_state(mtx);
         check_property(mtx);
@@ -474,7 +474,7 @@ struct HybridImbalanceBoundedLimitStrategy : HybridBase {
             std::make_shared<matrix_type::imbalance_bounded_limit>(0.5, 0.01));
     }
 
-    static void check_property(const matrix_type* mtx)
+    static void check_property(gko::pointer_param<const matrix_type> mtx)
     {
         auto strategy =
             dynamic_cast<const matrix_type::imbalance_bounded_limit*>(
@@ -484,7 +484,7 @@ struct HybridImbalanceBoundedLimitStrategy : HybridBase {
         ASSERT_EQ(strategy->get_ratio(), 0.01);
     }
 
-    static void assert_empty_state(const matrix_type* mtx)
+    static void assert_empty_state(gko::pointer_param<const matrix_type> mtx)
     {
         HybridBase::assert_empty_state(mtx);
         check_property(mtx);
@@ -500,14 +500,14 @@ struct HybridMinStorageStrategy : HybridBase {
             std::make_shared<matrix_type::minimal_storage_limit>());
     }
 
-    static void check_property(const matrix_type* mtx)
+    static void check_property(gko::pointer_param<const matrix_type> mtx)
     {
         auto strategy = dynamic_cast<const matrix_type::minimal_storage_limit*>(
             mtx->get_strategy().get());
         ASSERT_TRUE(strategy);
     }
 
-    static void assert_empty_state(const matrix_type* mtx)
+    static void assert_empty_state(gko::pointer_param<const matrix_type> mtx)
     {
         HybridBase::assert_empty_state(mtx);
         check_property(mtx);
@@ -522,14 +522,14 @@ struct HybridAutomaticStrategy : HybridBase {
                                    std::make_shared<matrix_type::automatic>());
     }
 
-    static void check_property(const matrix_type* mtx)
+    static void check_property(gko::pointer_param<const matrix_type> mtx)
     {
         auto strategy = dynamic_cast<const matrix_type::automatic*>(
             mtx->get_strategy().get());
         ASSERT_TRUE(strategy);
     }
 
-    static void assert_empty_state(const matrix_type* mtx)
+    static void assert_empty_state(gko::pointer_param<const matrix_type> mtx)
     {
         HybridBase::assert_empty_state(mtx);
         check_property(mtx);
@@ -548,7 +548,7 @@ struct SparsityCsr
         }
     }
 
-    static void assert_empty_state(const matrix_type* mtx)
+    static void assert_empty_state(gko::pointer_param<const matrix_type> mtx)
     {
         ASSERT_FALSE(mtx->get_size());
         ASSERT_EQ(mtx->get_num_nonzeros(), 0);
@@ -737,8 +737,8 @@ protected:
     {
         auto guarded_fn = [&](auto mtx) {
             try {
-                T::check_property(mtx.ref.get());
-                T::check_property(mtx.dev.get());
+                T::check_property(mtx.ref);
+                T::check_property(mtx.dev);
                 fn(std::move(mtx));
             } catch (std::exception& e) {
                 FAIL() << e.what();
@@ -885,8 +885,8 @@ TYPED_TEST(Matrix, SpMVIsEquivalentToRef)
 {
     this->forall_matrix_scenarios([&](auto mtx) {
         this->forall_vector_scenarios(mtx, [&](auto b, auto x) {
-            mtx.ref->apply(b.ref.get(), x.ref.get());
-            mtx.dev->apply(b.dev.get(), x.dev.get());
+            mtx.ref->apply(b.ref, x.ref);
+            mtx.dev->apply(b.dev, x.dev);
 
             GKO_ASSERT_MTX_NEAR(x.ref, x.dev, this->tol());
         });
@@ -901,10 +901,8 @@ TYPED_TEST(Matrix, AdvancedSpMVIsEquivalentToRef)
             auto alpha = this->gen_scalar();
             auto beta = this->gen_scalar();
 
-            mtx.ref->apply(alpha.ref.get(), b.ref.get(), alpha.ref.get(),
-                           x.ref.get());
-            mtx.dev->apply(alpha.dev.get(), b.dev.get(), alpha.dev.get(),
-                           x.dev.get());
+            mtx.ref->apply(alpha.ref, b.ref, alpha.ref, x.ref);
+            mtx.dev->apply(alpha.dev, b.dev, alpha.dev, x.dev);
 
             GKO_ASSERT_MTX_NEAR(x.ref, x.dev, this->tol());
         });
@@ -919,8 +917,8 @@ TYPED_TEST(Matrix, MixedSpMVIsEquivalentToRef)
     this->forall_matrix_scenarios([&](auto mtx) {
         this->template forall_vector_scenarios<MixedVec>(
             mtx, [&](auto b, auto x) {
-                mtx.ref->apply(b.ref.get(), x.ref.get());
-                mtx.dev->apply(b.dev.get(), x.dev.get());
+                mtx.ref->apply(b.ref, x.ref);
+                mtx.dev->apply(b.dev, x.dev);
 
                 GKO_ASSERT_MTX_NEAR(x.ref, x.dev, this->mixed_tol());
             });
@@ -937,10 +935,8 @@ TYPED_TEST(Matrix, MixedAdvancedSpMVIsEquivalentToRef)
                 auto alpha = this->template gen_scalar<MixedVec>();
                 auto beta = this->template gen_scalar<MixedVec>();
 
-                mtx.ref->apply(alpha.ref.get(), b.ref.get(), alpha.ref.get(),
-                               x.ref.get());
-                mtx.dev->apply(alpha.dev.get(), b.dev.get(), alpha.dev.get(),
-                               x.dev.get());
+                mtx.ref->apply(alpha.ref, b.ref, alpha.ref, x.ref);
+                mtx.dev->apply(alpha.dev, b.dev, alpha.dev, x.dev);
 
                 GKO_ASSERT_MTX_NEAR(x.ref, x.dev, this->mixed_tol());
             });
@@ -958,8 +954,8 @@ TYPED_TEST(Matrix, ConvertToCsrIsEquivalentToRef)
         auto ref_result = Csr::create(this->ref);
         auto dev_result = Csr::create(this->exec);
 
-        mtx.ref->convert_to(ref_result.get());
-        mtx.dev->convert_to(dev_result.get());
+        mtx.ref->convert_to(ref_result);
+        mtx.dev->convert_to(dev_result);
 
         GKO_ASSERT_MTX_NEAR(ref_result, dev_result, 0.0);
         GKO_ASSERT_MTX_EQ_SPARSITY(ref_result, dev_result);
@@ -976,8 +972,8 @@ TYPED_TEST(Matrix, MoveToCsrIsEquivalentToRef)
         auto ref_result = Csr::create(this->ref);
         auto dev_result = Csr::create(this->exec);
 
-        mtx.ref->move_to(ref_result.get());
-        mtx.dev->move_to(dev_result.get());
+        mtx.ref->move_to(ref_result);
+        mtx.dev->move_to(dev_result);
 
         GKO_ASSERT_MTX_NEAR(ref_result, dev_result, 0.0);
         GKO_ASSERT_MTX_EQ_SPARSITY(ref_result, dev_result);
@@ -999,8 +995,8 @@ TYPED_TEST(Matrix, ConvertFromCsrIsEquivalentToRef)
         auto ref_result = TestConfig::create(this->ref, data.size);
         auto dev_result = TestConfig::create(this->exec, data.size);
 
-        ref_src->convert_to(ref_result.get());
-        dev_src->convert_to(dev_result.get());
+        ref_src->convert_to(ref_result);
+        dev_src->convert_to(dev_result);
 
         GKO_ASSERT_MTX_NEAR(ref_result, dev_result, 0.0);
         GKO_ASSERT_MTX_EQ_SPARSITY(ref_result, dev_result);
@@ -1022,8 +1018,8 @@ TYPED_TEST(Matrix, MoveFromCsrIsEquivalentToRef)
         auto ref_result = TestConfig::create(this->ref, data.size);
         auto dev_result = TestConfig::create(this->exec, data.size);
 
-        ref_src->move_to(ref_result.get());
-        dev_src->move_to(dev_result.get());
+        ref_src->move_to(ref_result);
+        dev_src->move_to(dev_result);
 
         GKO_ASSERT_MTX_NEAR(ref_result, dev_result, 0.0);
         GKO_ASSERT_MTX_EQ_SPARSITY(ref_result, dev_result);
@@ -1052,8 +1048,8 @@ TYPED_TEST(Matrix, ConvertToDenseIsEquivalentToRef)
         auto dev_padding = dev_padded->create_submatrix(rows, pad_cols);
         auto orig_padding = ref_padding->clone();
 
-        mtx.ref->convert_to(ref_result.get());
-        mtx.dev->convert_to(dev_result.get());
+        mtx.ref->convert_to(ref_result);
+        mtx.dev->convert_to(dev_result);
 
         GKO_ASSERT_MTX_NEAR(ref_result, dev_result, 0.0);
         ASSERT_EQ(ref_result->get_stride(), stride);
@@ -1072,8 +1068,8 @@ TYPED_TEST(Matrix, MoveToDenseIsEquivalentToRef)
         auto ref_result = Dense::create(this->ref);
         auto dev_result = Dense::create(this->exec);
 
-        mtx.ref->move_to(ref_result.get());
-        mtx.dev->move_to(dev_result.get());
+        mtx.ref->move_to(ref_result);
+        mtx.dev->move_to(dev_result);
 
         GKO_ASSERT_MTX_NEAR(ref_result, dev_result, 0.0);
     });
@@ -1096,8 +1092,8 @@ TYPED_TEST(Matrix, ConvertFromDenseIsEquivalentToRef)
         auto ref_result = TestConfig::create(this->ref, data.size);
         auto dev_result = TestConfig::create(this->exec, data.size);
 
-        ref_src->convert_to(ref_result.get());
-        dev_src->convert_to(dev_result.get());
+        ref_src->convert_to(ref_result);
+        dev_src->convert_to(dev_result);
 
         GKO_ASSERT_MTX_NEAR(ref_result, dev_result, 0.0);
         GKO_ASSERT_MTX_EQ_SPARSITY(ref_result, dev_result);
@@ -1121,8 +1117,8 @@ TYPED_TEST(Matrix, MoveFromDenseIsEquivalentToRef)
         auto ref_result = TestConfig::create(this->ref, data.size);
         auto dev_result = TestConfig::create(this->exec, data.size);
 
-        ref_src->move_to(ref_result.get());
-        dev_src->move_to(dev_result.get());
+        ref_src->move_to(ref_result);
+        dev_src->move_to(dev_result);
 
         GKO_ASSERT_MTX_NEAR(ref_result, dev_result, 0.0);
         GKO_ASSERT_MTX_EQ_SPARSITY(ref_result, dev_result);
@@ -1231,7 +1227,7 @@ TYPED_TEST(Matrix, MoveAssignIsCorrect)
         ASSERT_EQ(&result, mtx2.get());
         GKO_ASSERT_MTX_NEAR(mtx2, orig_mtx, 0.0);
         GKO_ASSERT_MTX_EQ_SPARSITY(mtx2, orig_mtx);
-        TestConfig::assert_empty_state(mtx.get());
+        TestConfig::assert_empty_state(mtx);
     });
 }
 
@@ -1269,6 +1265,6 @@ TYPED_TEST(Matrix, MoveAssignToDifferentExecutorIsCorrect)
         ASSERT_EQ(&result, mtx2.get());
         GKO_ASSERT_MTX_NEAR(mtx2, orig_mtx, 0.0);
         GKO_ASSERT_MTX_EQ_SPARSITY(mtx2, orig_mtx);
-        TestConfig::assert_empty_state(mtx.get());
+        TestConfig::assert_empty_state(mtx);
     });
 }

--- a/test/matrix/matrix.cpp
+++ b/test/matrix/matrix.cpp
@@ -80,11 +80,11 @@ struct SimpleMatrixTest {
                          typename MtxType::index_type>& data)
     {}
 
-    static void check_property(gko::pointer_param<const matrix_type>) {}
+    static void check_property(gko::ptr_param<const matrix_type>) {}
 
     static bool supports_strides() { return true; }
 
-    static void assert_empty_state(gko::pointer_param<const matrix_type> mtx)
+    static void assert_empty_state(gko::ptr_param<const matrix_type> mtx)
     {
         ASSERT_FALSE(mtx->get_size());
     }
@@ -94,7 +94,7 @@ struct DenseWithDefaultStride
     : SimpleMatrixTest<gko::matrix::Dense<matrix_value_type>> {
     static bool preserves_zeros() { return false; }
 
-    static void assert_empty_state(gko::pointer_param<const matrix_type> mtx)
+    static void assert_empty_state(gko::ptr_param<const matrix_type> mtx)
     {
         ASSERT_FALSE(mtx->get_size());
         ASSERT_EQ(mtx->get_stride(), 0);
@@ -110,12 +110,12 @@ struct DenseWithCustomStride : DenseWithDefaultStride {
         return matrix_type::create(exec, size, size[0] + 10);
     }
 
-    static void check_property(gko::pointer_param<const matrix_type> mtx)
+    static void check_property(gko::ptr_param<const matrix_type> mtx)
     {
         ASSERT_EQ(mtx->get_stride(), mtx->get_size()[0] + 10);
     }
 
-    static void assert_empty_state(gko::pointer_param<const matrix_type> mtx)
+    static void assert_empty_state(gko::ptr_param<const matrix_type> mtx)
     {
         ASSERT_FALSE(mtx->get_size());
         ASSERT_EQ(mtx->get_stride(), 0);
@@ -125,7 +125,7 @@ struct DenseWithCustomStride : DenseWithDefaultStride {
 };
 
 struct Coo : SimpleMatrixTest<gko::matrix::Coo<matrix_value_type, int>> {
-    static void assert_empty_state(gko::pointer_param<const matrix_type> mtx)
+    static void assert_empty_state(gko::ptr_param<const matrix_type> mtx)
     {
         ASSERT_FALSE(mtx->get_size());
         ASSERT_EQ(mtx->get_num_stored_elements(), 0);
@@ -136,7 +136,7 @@ struct Coo : SimpleMatrixTest<gko::matrix::Coo<matrix_value_type, int>> {
 };
 
 struct CsrBase : SimpleMatrixTest<gko::matrix::Csr<matrix_value_type, int>> {
-    static void assert_empty_state(gko::pointer_param<const matrix_type> mtx)
+    static void assert_empty_state(gko::ptr_param<const matrix_type> mtx)
     {
         ASSERT_FALSE(mtx->get_size());
         ASSERT_EQ(mtx->get_num_stored_elements(), 0);
@@ -150,7 +150,7 @@ struct CsrBase : SimpleMatrixTest<gko::matrix::Csr<matrix_value_type, int>> {
 };
 
 struct CsrWithDefaultStrategy : CsrBase {
-    static void assert_empty_state(gko::pointer_param<const matrix_type> mtx)
+    static void assert_empty_state(gko::ptr_param<const matrix_type> mtx)
     {
         CsrBase::assert_empty_state(mtx);
         auto first_strategy = mtx->create_default()->get_strategy();
@@ -172,13 +172,13 @@ struct CsrWithClassicalStrategy : CsrBase {
                                    std::make_shared<matrix_type::classical>());
     }
 
-    static void check_property(gko::pointer_param<const matrix_type> mtx)
+    static void check_property(gko::ptr_param<const matrix_type> mtx)
     {
         ASSERT_TRUE(dynamic_cast<const matrix_type::classical*>(
             mtx->get_strategy().get()));
     }
 
-    static void assert_empty_state(gko::pointer_param<const matrix_type> mtx)
+    static void assert_empty_state(gko::ptr_param<const matrix_type> mtx)
     {
         CsrBase::assert_empty_state(mtx);
         ASSERT_TRUE(dynamic_cast<const matrix_type::classical*>(
@@ -194,13 +194,13 @@ struct CsrWithMergePathStrategy : CsrBase {
                                    std::make_shared<matrix_type::merge_path>());
     }
 
-    static void check_property(gko::pointer_param<const matrix_type> mtx)
+    static void check_property(gko::ptr_param<const matrix_type> mtx)
     {
         ASSERT_TRUE(dynamic_cast<const matrix_type::merge_path*>(
             mtx->get_strategy().get()));
     }
 
-    static void assert_empty_state(gko::pointer_param<const matrix_type> mtx)
+    static void assert_empty_state(gko::ptr_param<const matrix_type> mtx)
     {
         CsrBase::assert_empty_state(mtx);
         ASSERT_TRUE(dynamic_cast<const matrix_type::merge_path*>(
@@ -216,13 +216,13 @@ struct CsrWithSparselibStrategy : CsrBase {
                                    std::make_shared<matrix_type::sparselib>());
     }
 
-    static void check_property(gko::pointer_param<const matrix_type> mtx)
+    static void check_property(gko::ptr_param<const matrix_type> mtx)
     {
         ASSERT_TRUE(dynamic_cast<const matrix_type::sparselib*>(
             mtx->get_strategy().get()));
     }
 
-    static void assert_empty_state(gko::pointer_param<const matrix_type> mtx)
+    static void assert_empty_state(gko::ptr_param<const matrix_type> mtx)
     {
         CsrBase::assert_empty_state(mtx);
         ASSERT_TRUE(dynamic_cast<const matrix_type::sparselib*>(
@@ -239,13 +239,13 @@ struct CsrWithLoadBalanceStrategy : CsrBase {
                                        gko::EXEC_TYPE::create(0, exec)));
     }
 
-    static void check_property(gko::pointer_param<const matrix_type> mtx)
+    static void check_property(gko::ptr_param<const matrix_type> mtx)
     {
         ASSERT_TRUE(dynamic_cast<const matrix_type::load_balance*>(
             mtx->get_strategy().get()));
     }
 
-    static void assert_empty_state(gko::pointer_param<const matrix_type> mtx)
+    static void assert_empty_state(gko::ptr_param<const matrix_type> mtx)
     {
         CsrBase::assert_empty_state(mtx);
         ASSERT_TRUE(dynamic_cast<const matrix_type::load_balance*>(
@@ -262,13 +262,13 @@ struct CsrWithAutomaticalStrategy : CsrBase {
                                        gko::EXEC_TYPE::create(0, exec)));
     }
 
-    static void check_property(gko::pointer_param<const matrix_type> mtx)
+    static void check_property(gko::ptr_param<const matrix_type> mtx)
     {
         ASSERT_TRUE(dynamic_cast<const matrix_type::automatical*>(
             mtx->get_strategy().get()));
     }
 
-    static void assert_empty_state(gko::pointer_param<const matrix_type> mtx)
+    static void assert_empty_state(gko::ptr_param<const matrix_type> mtx)
     {
         CsrBase::assert_empty_state(mtx);
         ASSERT_TRUE(dynamic_cast<const matrix_type::automatical*>(
@@ -281,7 +281,7 @@ struct CsrWithAutomaticalStrategy : CsrBase {
 
 
 struct Ell : SimpleMatrixTest<gko::matrix::Ell<matrix_value_type, int>> {
-    static void assert_empty_state(gko::pointer_param<const matrix_type> mtx)
+    static void assert_empty_state(gko::ptr_param<const matrix_type> mtx)
     {
         ASSERT_FALSE(mtx->get_size());
         ASSERT_EQ(mtx->get_num_stored_elements_per_row(), 0);
@@ -305,12 +305,12 @@ struct Fbcsr : SimpleMatrixTest<gko::matrix::Fbcsr<matrix_value_type, int>> {
         return matrix_type::create(exec, size, 0, block_size);
     }
 
-    static void check_property(gko::pointer_param<const matrix_type> mtx)
+    static void check_property(gko::ptr_param<const matrix_type> mtx)
     {
         ASSERT_EQ(mtx->get_block_size(), block_size);
     }
 
-    static void assert_empty_state(gko::pointer_param<const matrix_type> mtx)
+    static void assert_empty_state(gko::ptr_param<const matrix_type> mtx)
     {
         ASSERT_FALSE(mtx->get_size());
         ASSERT_EQ(mtx->get_block_size(), block_size);
@@ -331,7 +331,7 @@ struct Fbcsr : SimpleMatrixTest<gko::matrix::Fbcsr<matrix_value_type, int>> {
 
 struct SellpBase
     : SimpleMatrixTest<gko::matrix::Sellp<matrix_value_type, int>> {
-    static void assert_empty_state(gko::pointer_param<const matrix_type> mtx)
+    static void assert_empty_state(gko::ptr_param<const matrix_type> mtx)
     {
         ASSERT_FALSE(mtx->get_size());
         ASSERT_EQ(mtx->get_num_stored_elements(), 0);
@@ -348,13 +348,13 @@ struct SellpBase
 
 
 struct SellpDefaultParameters : SellpBase {
-    static void check_property(gko::pointer_param<const matrix_type> mtx)
+    static void check_property(gko::ptr_param<const matrix_type> mtx)
     {
         ASSERT_EQ(mtx->get_stride_factor(), 1);
         ASSERT_EQ(mtx->get_slice_size(), 64);
     }
 
-    static void assert_empty_state(gko::pointer_param<const matrix_type> mtx)
+    static void assert_empty_state(gko::ptr_param<const matrix_type> mtx)
     {
         SellpBase::assert_empty_state(mtx);
         ASSERT_EQ(mtx->get_stride_factor(), 1);
@@ -369,13 +369,13 @@ struct Sellp32Factor2 : SellpBase {
         return matrix_type::create(exec, size, 32, 2, 0);
     }
 
-    static void check_property(gko::pointer_param<const matrix_type> mtx)
+    static void check_property(gko::ptr_param<const matrix_type> mtx)
     {
         ASSERT_EQ(mtx->get_stride_factor(), 2);
         ASSERT_EQ(mtx->get_slice_size(), 32);
     }
 
-    static void assert_empty_state(gko::pointer_param<const matrix_type> mtx)
+    static void assert_empty_state(gko::ptr_param<const matrix_type> mtx)
     {
         SellpBase::assert_empty_state(mtx);
         ASSERT_EQ(mtx->get_stride_factor(), 2);
@@ -386,7 +386,7 @@ struct Sellp32Factor2 : SellpBase {
 
 struct HybridBase
     : SimpleMatrixTest<gko::matrix::Hybrid<matrix_value_type, int>> {
-    static void assert_empty_state(gko::pointer_param<const matrix_type> mtx)
+    static void assert_empty_state(gko::ptr_param<const matrix_type> mtx)
     {
         ASSERT_FALSE(mtx->get_size());
         ASSERT_FALSE(mtx->get_coo()->get_size());
@@ -405,14 +405,14 @@ struct HybridBase
 
 
 struct HybridDefaultStrategy : HybridBase {
-    static void check_property(gko::pointer_param<const matrix_type> mtx)
+    static void check_property(gko::ptr_param<const matrix_type> mtx)
     {
         auto strategy = dynamic_cast<const matrix_type::automatic*>(
             mtx->get_strategy().get());
         ASSERT_TRUE(strategy);
     }
 
-    static void assert_empty_state(gko::pointer_param<const matrix_type> mtx)
+    static void assert_empty_state(gko::ptr_param<const matrix_type> mtx)
     {
         HybridBase::assert_empty_state(mtx);
         check_property(mtx);
@@ -427,7 +427,7 @@ struct HybridColumnLimitStrategy : HybridBase {
             exec, size, 0, std::make_shared<matrix_type::column_limit>(10));
     }
 
-    static void check_property(gko::pointer_param<const matrix_type> mtx)
+    static void check_property(gko::ptr_param<const matrix_type> mtx)
     {
         auto strategy = dynamic_cast<const matrix_type::column_limit*>(
             mtx->get_strategy().get());
@@ -435,7 +435,7 @@ struct HybridColumnLimitStrategy : HybridBase {
         ASSERT_EQ(strategy->get_num_columns(), 10);
     }
 
-    static void assert_empty_state(gko::pointer_param<const matrix_type> mtx)
+    static void assert_empty_state(gko::ptr_param<const matrix_type> mtx)
     {
         HybridBase::assert_empty_state(mtx);
         check_property(mtx);
@@ -450,7 +450,7 @@ struct HybridImbalanceLimitStrategy : HybridBase {
             exec, size, 0, std::make_shared<matrix_type::imbalance_limit>(0.5));
     }
 
-    static void check_property(gko::pointer_param<const matrix_type> mtx)
+    static void check_property(gko::ptr_param<const matrix_type> mtx)
     {
         auto strategy = dynamic_cast<const matrix_type::imbalance_limit*>(
             mtx->get_strategy().get());
@@ -458,7 +458,7 @@ struct HybridImbalanceLimitStrategy : HybridBase {
         ASSERT_EQ(strategy->get_percentage(), 0.5);
     }
 
-    static void assert_empty_state(gko::pointer_param<const matrix_type> mtx)
+    static void assert_empty_state(gko::ptr_param<const matrix_type> mtx)
     {
         HybridBase::assert_empty_state(mtx);
         check_property(mtx);
@@ -474,7 +474,7 @@ struct HybridImbalanceBoundedLimitStrategy : HybridBase {
             std::make_shared<matrix_type::imbalance_bounded_limit>(0.5, 0.01));
     }
 
-    static void check_property(gko::pointer_param<const matrix_type> mtx)
+    static void check_property(gko::ptr_param<const matrix_type> mtx)
     {
         auto strategy =
             dynamic_cast<const matrix_type::imbalance_bounded_limit*>(
@@ -484,7 +484,7 @@ struct HybridImbalanceBoundedLimitStrategy : HybridBase {
         ASSERT_EQ(strategy->get_ratio(), 0.01);
     }
 
-    static void assert_empty_state(gko::pointer_param<const matrix_type> mtx)
+    static void assert_empty_state(gko::ptr_param<const matrix_type> mtx)
     {
         HybridBase::assert_empty_state(mtx);
         check_property(mtx);
@@ -500,14 +500,14 @@ struct HybridMinStorageStrategy : HybridBase {
             std::make_shared<matrix_type::minimal_storage_limit>());
     }
 
-    static void check_property(gko::pointer_param<const matrix_type> mtx)
+    static void check_property(gko::ptr_param<const matrix_type> mtx)
     {
         auto strategy = dynamic_cast<const matrix_type::minimal_storage_limit*>(
             mtx->get_strategy().get());
         ASSERT_TRUE(strategy);
     }
 
-    static void assert_empty_state(gko::pointer_param<const matrix_type> mtx)
+    static void assert_empty_state(gko::ptr_param<const matrix_type> mtx)
     {
         HybridBase::assert_empty_state(mtx);
         check_property(mtx);
@@ -522,14 +522,14 @@ struct HybridAutomaticStrategy : HybridBase {
                                    std::make_shared<matrix_type::automatic>());
     }
 
-    static void check_property(gko::pointer_param<const matrix_type> mtx)
+    static void check_property(gko::ptr_param<const matrix_type> mtx)
     {
         auto strategy = dynamic_cast<const matrix_type::automatic*>(
             mtx->get_strategy().get());
         ASSERT_TRUE(strategy);
     }
 
-    static void assert_empty_state(gko::pointer_param<const matrix_type> mtx)
+    static void assert_empty_state(gko::ptr_param<const matrix_type> mtx)
     {
         HybridBase::assert_empty_state(mtx);
         check_property(mtx);
@@ -548,7 +548,7 @@ struct SparsityCsr
         }
     }
 
-    static void assert_empty_state(gko::pointer_param<const matrix_type> mtx)
+    static void assert_empty_state(gko::ptr_param<const matrix_type> mtx)
     {
         ASSERT_FALSE(mtx->get_size());
         ASSERT_EQ(mtx->get_num_nonzeros(), 0);

--- a/test/matrix/sellp_kernels.cpp
+++ b/test/matrix/sellp_kernels.cpp
@@ -107,8 +107,8 @@ TEST_F(Sellp, SimpleApplyIsEquivalentToRef)
 {
     set_up_apply_matrix();
 
-    mtx->apply(y.get(), expected.get());
-    dmtx->apply(dy.get(), dresult.get());
+    mtx->apply(y, expected);
+    dmtx->apply(dy, dresult);
 
     GKO_ASSERT_MTX_NEAR(dresult, expected, r<value_type>::value);
 }
@@ -118,8 +118,8 @@ TEST_F(Sellp, AdvancedApplyIsEquivalentToRef)
 {
     set_up_apply_matrix();
 
-    mtx->apply(alpha.get(), y.get(), beta.get(), expected.get());
-    dmtx->apply(dalpha.get(), dy.get(), dbeta.get(), dresult.get());
+    mtx->apply(alpha, y, beta, expected);
+    dmtx->apply(dalpha, dy, dbeta, dresult);
 
     GKO_ASSERT_MTX_NEAR(dresult, expected, r<value_type>::value);
 }
@@ -129,8 +129,8 @@ TEST_F(Sellp, SimpleApplyWithSliceSizeAndStrideFactorIsEquivalentToRef)
 {
     set_up_apply_matrix(1, 32, 2);
 
-    mtx->apply(y.get(), expected.get());
-    dmtx->apply(dy.get(), dresult.get());
+    mtx->apply(y, expected);
+    dmtx->apply(dy, dresult);
 
     GKO_ASSERT_MTX_NEAR(dresult, expected, r<value_type>::value);
 }
@@ -140,8 +140,8 @@ TEST_F(Sellp, AdvancedApplyWithSliceSizeAndStrideFActorIsEquivalentToRef)
 {
     set_up_apply_matrix(1, 32, 2);
 
-    mtx->apply(alpha.get(), y.get(), beta.get(), expected.get());
-    dmtx->apply(dalpha.get(), dy.get(), dbeta.get(), dresult.get());
+    mtx->apply(alpha, y, beta, expected);
+    dmtx->apply(dalpha, dy, dbeta, dresult);
 
     GKO_ASSERT_MTX_NEAR(dresult, expected, r<value_type>::value);
 }
@@ -151,8 +151,8 @@ TEST_F(Sellp, SimpleApplyMultipleRHSIsEquivalentToRef)
 {
     set_up_apply_matrix(3);
 
-    mtx->apply(y.get(), expected.get());
-    dmtx->apply(dy.get(), dresult.get());
+    mtx->apply(y, expected);
+    dmtx->apply(dy, dresult);
 
     GKO_ASSERT_MTX_NEAR(dresult, expected, r<value_type>::value);
 }
@@ -162,8 +162,8 @@ TEST_F(Sellp, AdvancedApplyMultipleRHSIsEquivalentToRef)
 {
     set_up_apply_matrix(4);
 
-    mtx->apply(alpha.get(), y.get(), beta.get(), expected.get());
-    dmtx->apply(dalpha.get(), dy.get(), dbeta.get(), dresult.get());
+    mtx->apply(alpha, y, beta, expected);
+    dmtx->apply(dalpha, dy, dbeta, dresult);
 
     GKO_ASSERT_MTX_NEAR(dresult, expected, r<value_type>::value);
 }
@@ -174,8 +174,8 @@ TEST_F(Sellp,
 {
     set_up_apply_matrix(5, 2);
 
-    mtx->apply(y.get(), expected.get());
-    dmtx->apply(dy.get(), dresult.get());
+    mtx->apply(y, expected);
+    dmtx->apply(dy, dresult);
 
     GKO_ASSERT_MTX_NEAR(dresult, expected, r<value_type>::value);
 }
@@ -186,8 +186,8 @@ TEST_F(Sellp,
 {
     set_up_apply_matrix(6, 2);
 
-    mtx->apply(alpha.get(), y.get(), beta.get(), expected.get());
-    dmtx->apply(dalpha.get(), dy.get(), dbeta.get(), dresult.get());
+    mtx->apply(alpha, y, beta, expected);
+    dmtx->apply(dalpha, dy, dbeta, dresult);
 
     GKO_ASSERT_MTX_NEAR(dresult, expected, r<value_type>::value);
 }
@@ -201,8 +201,8 @@ TEST_F(Sellp, ApplyToComplexIsEquivalentToRef)
     auto complex_x = gen_mtx<ComplexVec>(532, 3);
     auto dcomplex_x = gko::clone(exec, complex_x);
 
-    mtx->apply(complex_b.get(), complex_x.get());
-    dmtx->apply(dcomplex_b.get(), dcomplex_x.get());
+    mtx->apply(complex_b, complex_x);
+    dmtx->apply(dcomplex_b, dcomplex_x);
 
     GKO_ASSERT_MTX_NEAR(dcomplex_x, complex_x, r<value_type>::value);
 }
@@ -216,8 +216,8 @@ TEST_F(Sellp, AdvancedApplyToComplexIsEquivalentToRef)
     auto complex_x = gen_mtx<ComplexVec>(532, 3);
     auto dcomplex_x = gko::clone(exec, complex_x);
 
-    mtx->apply(alpha.get(), complex_b.get(), beta.get(), complex_x.get());
-    dmtx->apply(dalpha.get(), dcomplex_b.get(), dbeta.get(), dcomplex_x.get());
+    mtx->apply(alpha, complex_b, beta, complex_x);
+    dmtx->apply(dalpha, dcomplex_b, dbeta, dcomplex_x);
 
     GKO_ASSERT_MTX_NEAR(dcomplex_x, complex_x, r<value_type>::value);
 }
@@ -229,10 +229,10 @@ TEST_F(Sellp, ConvertToDenseIsEquivalentToRef)
     auto dense_mtx = gko::matrix::Dense<value_type>::create(ref);
     auto ddense_mtx = gko::matrix::Dense<value_type>::create(exec);
 
-    mtx->convert_to(dense_mtx.get());
-    dmtx->convert_to(ddense_mtx.get());
+    mtx->convert_to(dense_mtx);
+    dmtx->convert_to(ddense_mtx);
 
-    GKO_ASSERT_MTX_NEAR(dense_mtx.get(), ddense_mtx.get(), 0);
+    GKO_ASSERT_MTX_NEAR(dense_mtx, ddense_mtx, 0);
 }
 
 
@@ -242,10 +242,10 @@ TEST_F(Sellp, ConvertToCsrIsEquivalentToRef)
     auto csr_mtx = gko::matrix::Csr<value_type>::create(ref);
     auto dcsr_mtx = gko::matrix::Csr<value_type>::create(exec);
 
-    mtx->convert_to(csr_mtx.get());
-    dmtx->convert_to(dcsr_mtx.get());
+    mtx->convert_to(csr_mtx);
+    dmtx->convert_to(dcsr_mtx);
 
-    GKO_ASSERT_MTX_NEAR(csr_mtx.get(), dcsr_mtx.get(), 0);
+    GKO_ASSERT_MTX_NEAR(csr_mtx, dcsr_mtx, 0);
 }
 
 
@@ -255,10 +255,10 @@ TEST_F(Sellp, ConvertEmptyToDenseIsEquivalentToRef)
     auto dense_mtx = gko::matrix::Dense<value_type>::create(ref);
     auto ddense_mtx = gko::matrix::Dense<value_type>::create(exec);
 
-    empty->convert_to(dense_mtx.get());
-    dempty->convert_to(ddense_mtx.get());
+    empty->convert_to(dense_mtx);
+    dempty->convert_to(ddense_mtx);
 
-    GKO_ASSERT_MTX_NEAR(dense_mtx.get(), ddense_mtx.get(), 0);
+    GKO_ASSERT_MTX_NEAR(dense_mtx, ddense_mtx, 0);
 }
 
 
@@ -268,10 +268,10 @@ TEST_F(Sellp, ConvertEmptyToCsrIsEquivalentToRef)
     auto csr_mtx = gko::matrix::Csr<value_type>::create(ref);
     auto dcsr_mtx = gko::matrix::Csr<value_type>::create(exec);
 
-    empty->convert_to(csr_mtx.get());
-    dempty->convert_to(dcsr_mtx.get());
+    empty->convert_to(csr_mtx);
+    dempty->convert_to(dcsr_mtx);
 
-    GKO_ASSERT_MTX_NEAR(csr_mtx.get(), dcsr_mtx.get(), 0);
+    GKO_ASSERT_MTX_NEAR(csr_mtx, dcsr_mtx, 0);
 }
 
 
@@ -282,7 +282,7 @@ TEST_F(Sellp, ExtractDiagonalIsEquivalentToRef)
     auto diag = mtx->extract_diagonal();
     auto ddiag = dmtx->extract_diagonal();
 
-    GKO_ASSERT_MTX_NEAR(diag.get(), ddiag.get(), 0);
+    GKO_ASSERT_MTX_NEAR(diag, ddiag, 0);
 }
 
 
@@ -293,7 +293,7 @@ TEST_F(Sellp, ExtractDiagonalWithSliceSizeAndStrideFactorIsEquivalentToRef)
     auto diag = mtx->extract_diagonal();
     auto ddiag = dmtx->extract_diagonal();
 
-    GKO_ASSERT_MTX_NEAR(diag.get(), ddiag.get(), 0);
+    GKO_ASSERT_MTX_NEAR(diag, ddiag, 0);
 }
 
 

--- a/test/mpi/distributed/matrix.cpp
+++ b/test/mpi/distributed/matrix.cpp
@@ -141,7 +141,7 @@ TYPED_TEST(MatrixCreation, ReadsDistributedGlobalData)
         {{0, 2}, {4, 0}}, {{5, 0}, {0, 7}}, {{9}}};
     auto rank = this->dist_mat->get_communicator().rank();
 
-    this->dist_mat->read_distributed(this->mat_input, this->row_part.get());
+    this->dist_mat->read_distributed(this->mat_input, this->row_part);
 
     GKO_ASSERT_MTX_NEAR(gko::as<csr>(this->dist_mat->get_local_matrix()),
                         res_local[rank], 0);
@@ -159,8 +159,7 @@ TYPED_TEST(MatrixCreation, ReadsDistributedLocalData)
         {{0, 2}, {4, 0}}, {{5, 0}, {0, 7}}, {{9}}};
     auto rank = this->dist_mat->get_communicator().rank();
 
-    this->dist_mat->read_distributed(this->dist_input[rank],
-                                     this->row_part.get());
+    this->dist_mat->read_distributed(this->dist_input[rank], this->row_part);
 
     GKO_ASSERT_MTX_NEAR(gko::as<csr>(this->dist_mat->get_local_matrix()),
                         res_local[rank], 0);
@@ -178,8 +177,8 @@ TYPED_TEST(MatrixCreation, ReadsDistributedWithColPartition)
         {{1, 0}, {3, 4}}, {{0, 0, 6}, {8, 7, 0}}, {{10, 9}}};
     auto rank = this->dist_mat->get_communicator().rank();
 
-    this->dist_mat->read_distributed(this->mat_input, this->row_part.get(),
-                                     this->col_part.get());
+    this->dist_mat->read_distributed(this->mat_input, this->row_part,
+                                     this->col_part);
 
     GKO_ASSERT_MTX_NEAR(gko::as<csr>(this->dist_mat->get_local_matrix()),
                         res_local[rank], 0);
@@ -238,8 +237,7 @@ public:
              {2, 2, 6}, {3, 3, 8}, {3, 4, 7}, {4, 0, 9}, {4, 4, 10}}
             // clang-format on
         };
-        dist_mat->read_distributed(mat_input, this->row_part.get(),
-                                   this->col_part.get());
+        dist_mat->read_distributed(mat_input, this->row_part, this->col_part);
         csr_mat->read(mat_input);
 
         alpha = gko::test::generate_random_matrix<dense_vec_type>(
@@ -276,7 +274,7 @@ public:
             this->exec, gather_idxs.begin(), gather_idxs.end());
         auto gathered_local = dense->row_gather(&gather_idxs_view);
 
-        GKO_ASSERT_MTX_NEAR(dist->get_local_vector(), gathered_local.get(),
+        GKO_ASSERT_MTX_NEAR(dist->get_local_vector(), gathered_local,
                             r<value_type>::value);
     }
 
@@ -311,14 +309,14 @@ public:
         col_part_large =
             part_type::build_from_mapping(exec, col_mapping, num_parts);
 
-        dist_mat_large->read_distributed(mat_md, row_part_large.get(),
-                                         col_part_large.get());
+        dist_mat_large->read_distributed(mat_md, row_part_large,
+                                         col_part_large);
         csr_mat->read(mat_md);
 
-        x->read_distributed(vec_md, col_part_large.get());
+        x->read_distributed(vec_md, col_part_large);
         dense_x->read(vec_md);
 
-        y->read_distributed(vec_md, row_part_large.get());
+        y->read_distributed(vec_md, row_part_large);
         dense_y->read(vec_md);
     }
 
@@ -355,10 +353,10 @@ TYPED_TEST(Matrix, CanApplyToSingleVector)
         I<I<value_type>>{{1}, {2}, {3}, {4}, {5}}};
     I<I<value_type>> result[3] = {{{10}, {18}}, {{28}, {67}}, {{59}}};
     auto rank = this->comm.rank();
-    this->x->read_distributed(vec_md, this->col_part.get());
-    this->y->read_distributed(vec_md, this->row_part.get());
+    this->x->read_distributed(vec_md, this->col_part);
+    this->y->read_distributed(vec_md, this->row_part);
 
-    this->dist_mat->apply(this->x.get(), this->y.get());
+    this->dist_mat->apply(this->x, this->y);
 
     GKO_ASSERT_MTX_NEAR(this->y->get_local_vector(), result[rank], 0);
 }
@@ -373,10 +371,10 @@ TYPED_TEST(Matrix, CanApplyToMultipleVectors)
     I<I<value_type>> result[3] = {
         {{10, 110}, {18, 198}}, {{28, 308}, {67, 737}}, {{59, 649}}};
     auto rank = this->comm.rank();
-    this->x->read_distributed(vec_md, this->col_part.get());
-    this->y->read_distributed(vec_md, this->row_part.get());
+    this->x->read_distributed(vec_md, this->col_part);
+    this->y->read_distributed(vec_md, this->row_part);
 
-    this->dist_mat->apply(this->x.get(), this->y.get());
+    this->dist_mat->apply(this->x, this->y);
 
     GKO_ASSERT_MTX_NEAR(this->y->get_local_vector(), result[rank], 0);
 }
@@ -393,11 +391,10 @@ TYPED_TEST(Matrix, CanAdvancedApplyToSingleVector)
     auto rank = this->comm.rank();
     this->alpha = gko::initialize<dense_vec_type>({2.0}, this->exec);
     this->beta = gko::initialize<dense_vec_type>({-3.0}, this->exec);
-    this->x->read_distributed(vec_md, this->col_part.get());
-    this->y->read_distributed(vec_md, this->row_part.get());
+    this->x->read_distributed(vec_md, this->col_part);
+    this->y->read_distributed(vec_md, this->row_part);
 
-    this->dist_mat->apply(this->alpha.get(), this->x.get(), this->beta.get(),
-                          this->y.get());
+    this->dist_mat->apply(this->alpha, this->x, this->beta, this->y);
 
     GKO_ASSERT_MTX_NEAR(this->y->get_local_vector(), result[rank], 0);
 }
@@ -407,8 +404,8 @@ TYPED_TEST(Matrix, CanApplyToSingleVectorLarge)
 {
     this->init_large(100, 1);
 
-    this->dist_mat_large->apply(this->x.get(), this->y.get());
-    this->csr_mat->apply(this->dense_x.get(), this->dense_y.get());
+    this->dist_mat_large->apply(this->x, this->y);
+    this->csr_mat->apply(this->dense_x, this->dense_y);
 
     this->assert_local_vector_equal_to_global_vector(
         this->y.get(), this->dense_y.get(), this->row_part_large.get(),
@@ -420,8 +417,8 @@ TYPED_TEST(Matrix, CanApplyToMultipleVectorsLarge)
 {
     this->init_large(100, 17);
 
-    this->dist_mat_large->apply(this->x.get(), this->y.get());
-    this->csr_mat->apply(this->dense_x.get(), this->dense_y.get());
+    this->dist_mat_large->apply(this->x, this->y);
+    this->csr_mat->apply(this->dense_x, this->dense_y);
 
     this->assert_local_vector_equal_to_global_vector(
         this->y.get(), this->dense_y.get(), this->row_part_large.get(),
@@ -433,10 +430,8 @@ TYPED_TEST(Matrix, CanAdvancedApplyToMultipleVectorsLarge)
 {
     this->init_large(100, 17);
 
-    this->dist_mat_large->apply(this->alpha.get(), this->x.get(),
-                                this->beta.get(), this->y.get());
-    this->csr_mat->apply(this->alpha.get(), this->dense_x.get(),
-                         this->beta.get(), this->dense_y.get());
+    this->dist_mat_large->apply(this->alpha, this->x, this->beta, this->y);
+    this->csr_mat->apply(this->alpha, this->dense_x, this->beta, this->dense_y);
 
     this->assert_local_vector_equal_to_global_vector(
         this->y.get(), this->dense_y.get(), this->row_part_large.get(),
@@ -460,8 +455,8 @@ TYPED_TEST(Matrix, CanConvertToNextPrecision)
                         ? gko::remove_complex<T>{0}
                         : gko::remove_complex<T>{r<OtherT>::value};
 
-    this->dist_mat->convert_to(tmp.get());
-    tmp->convert_to(res.get());
+    this->dist_mat->convert_to(tmp);
+    tmp->convert_to(res);
 
     GKO_ASSERT_MTX_NEAR(gko::as<csr>(this->dist_mat->get_local_matrix()),
                         gko::as<csr>(res->get_local_matrix()), residual);
@@ -487,8 +482,8 @@ TYPED_TEST(Matrix, CanMoveToNextPrecision)
                         ? gko::remove_complex<T>{0}
                         : gko::remove_complex<T>{r<OtherT>::value};
 
-    this->dist_mat->move_to(tmp.get());
-    tmp->convert_to(res.get());
+    this->dist_mat->move_to(tmp);
+    tmp->convert_to(res);
 
     GKO_ASSERT_MTX_NEAR(gko::as<csr>(clone_dist_mat->get_local_matrix()),
                         gko::as<csr>(res->get_local_matrix()), residual);
@@ -576,7 +571,7 @@ TEST_F(MatrixGpuAwareCheck, ApplyCopiesToHostOnlyIfNecessary)
 {
     auto transfer_count_before = logger->get_transfer_count();
 
-    mat->apply(x.get(), y.get());
+    mat->apply(x, y);
 
     ASSERT_EQ(logger->get_transfer_count() > transfer_count_before,
               needs_transfers(exec));
@@ -587,7 +582,7 @@ TEST_F(MatrixGpuAwareCheck, AdvancedApplyCopiesToHostOnlyIfNecessary)
 {
     auto transfer_count_before = logger->get_transfer_count();
 
-    mat->apply(alpha.get(), x.get(), beta.get(), y.get());
+    mat->apply(alpha, x, beta, y);
 
     ASSERT_EQ(logger->get_transfer_count() > transfer_count_before,
               needs_transfers(exec));

--- a/test/mpi/distributed/vector.cpp
+++ b/test/mpi/distributed/vector.cpp
@@ -147,7 +147,7 @@ TYPED_TEST(VectorCreation, CanReadGlobalMatrixData)
         {{8, 9}, {10, 11}},
     };
 
-    vec->read_distributed(this->md, this->part.get());
+    vec->read_distributed(this->md, this->part);
 
     GKO_ASSERT_EQUAL_DIMENSIONS(vec->get_size(), gko::dim<2>(6, 2));
     GKO_ASSERT_EQUAL_DIMENSIONS(vec->get_local_vector()->get_size(),
@@ -164,7 +164,7 @@ TYPED_TEST(VectorCreation, CanReadGlobalMatrixDataSomeEmpty)
     auto vec = TestFixture::dist_vec_type::create(this->exec, this->comm);
     auto rank = this->comm.rank();
 
-    vec->read_distributed(this->md, part.get());
+    vec->read_distributed(this->md, part);
 
     GKO_ASSERT_EQUAL_DIMENSIONS(vec->get_size(), gko::dim<2>(6, 2));
     if (rank == 1) {
@@ -205,7 +205,7 @@ TYPED_TEST(VectorCreation, CanReadGlobalDeviceMatrixData)
         {{8, 9}, {10, 11}},
     };
 
-    vec->read_distributed(md, part.get());
+    vec->read_distributed(md, part);
 
     GKO_ASSERT_EQUAL_DIMENSIONS(vec->get_size(), gko::dim<2>(6, 2));
     GKO_ASSERT_EQUAL_DIMENSIONS(vec->get_local_vector()->get_size(),
@@ -231,7 +231,7 @@ TYPED_TEST(VectorCreation, CanReadGlobalMatrixDataScattered)
         {{4, 5}, {8, 9}},
     };
 
-    vec->read_distributed(md, part.get());
+    vec->read_distributed(md, part);
 
     GKO_ASSERT_EQUAL_DIMENSIONS(vec->get_size(), gko::dim<2>(6, 2));
     GKO_ASSERT_EQUAL_DIMENSIONS(vec->get_local_vector()->get_size(),
@@ -259,7 +259,7 @@ TYPED_TEST(VectorCreation, CanReadLocalMatrixData)
         {{8, 9}, {10, 11}},
     };
 
-    vec->read_distributed(md[rank], part.get());
+    vec->read_distributed(md[rank], part);
 
     GKO_ASSERT_EQUAL_DIMENSIONS(vec->get_size(), gko::dim<2>(6, 2));
     GKO_ASSERT_EQUAL_DIMENSIONS(vec->get_local_vector()->get_size(),
@@ -289,7 +289,7 @@ TYPED_TEST(VectorCreation, CanReadLocalMatrixDataSomeEmpty)
     auto vec = TestFixture::dist_vec_type::create(this->exec, this->comm);
     auto rank = this->comm.rank();
 
-    vec->read_distributed(md[rank], part.get());
+    vec->read_distributed(md[rank], part);
 
     GKO_ASSERT_EQUAL_DIMENSIONS(vec->get_size(), gko::dim<2>(6, 2));
     if (rank == 1) {
@@ -319,7 +319,7 @@ TYPED_TEST(VectorCreation, CanCreateFromLocalVectorAndSize)
     auto clone_local_vec = gko::clone(local_vec);
 
     auto vec = dist_vec_type::create(this->exec, this->comm, gko::dim<2>{6, 2},
-                                     local_vec.get());
+                                     local_vec);
 
     GKO_ASSERT_EQUAL_DIMENSIONS(vec, gko::dim<2>(6, 2));
     GKO_ASSERT_MTX_NEAR(vec->get_local_vector(), clone_local_vec, 0);
@@ -334,7 +334,7 @@ TYPED_TEST(VectorCreation, CanCreateFromLocalVectorWithoutSize)
     local_vec->read(this->md_localized[this->comm.rank()]);
     auto clone_local_vec = gko::clone(local_vec);
 
-    auto vec = dist_vec_type::create(this->exec, this->comm, local_vec.get());
+    auto vec = dist_vec_type::create(this->exec, this->comm, local_vec);
 
     GKO_ASSERT_EQUAL_DIMENSIONS(vec, gko::dim<2>(6, 2));
     GKO_ASSERT_MTX_NEAR(vec->get_local_vector(), clone_local_vec, 0);
@@ -370,7 +370,7 @@ TYPED_TEST(VectorCreationHelpers, CanCreateWithConfigOf)
 {
     using vec_type = typename TestFixture::vec_type;
 
-    auto new_vector = vec_type::create_with_config_of(this->src.get());
+    auto new_vector = vec_type::create_with_config_of(this->src);
 
     GKO_ASSERT_EQUAL_DIMENSIONS(new_vector->get_size(), this->src->get_size());
     GKO_ASSERT_EQUAL_DIMENSIONS(new_vector->get_local_vector()->get_size(),
@@ -386,7 +386,7 @@ TYPED_TEST(VectorCreationHelpers, CanCreateWithTypeOfDefaultParameter)
 {
     using vec_type = typename TestFixture::vec_type;
 
-    auto new_vector = vec_type::create_with_type_of(this->src.get(), this->ref);
+    auto new_vector = vec_type::create_with_type_of(this->src, this->ref);
 
     GKO_ASSERT_EQUAL_DIMENSIONS(new_vector->get_size(), gko::dim<2>{});
     GKO_ASSERT_EQUAL_DIMENSIONS(new_vector->get_local_vector()->get_size(),
@@ -405,9 +405,8 @@ TYPED_TEST(VectorCreationHelpers, CanCreateWithTypeOf)
                                 new_local_size[1]};
     gko::size_type new_stride{14};
 
-    auto new_vector = vec_type::create_with_type_of(this->src.get(), this->ref,
-                                                    new_global_size,
-                                                    new_local_size, new_stride);
+    auto new_vector = vec_type::create_with_type_of(
+        this->src, this->ref, new_global_size, new_local_size, new_stride);
 
     GKO_ASSERT_EQUAL_DIMENSIONS(new_vector->get_size(), new_global_size);
     GKO_ASSERT_EQUAL_DIMENSIONS(new_vector->get_local_vector()->get_size(),
@@ -468,7 +467,7 @@ public:
             engine);
         dense_x->read(md_x);
         auto tmp_x = dist_vec_type::create(ref, comm);
-        tmp_x->read_distributed(md_x, part.get());
+        tmp_x->read_distributed(md_x, part);
         x = gko::clone(exec, tmp_x);
 
         auto md_y = gko::test::generate_random_matrix_data<value_type,
@@ -479,7 +478,7 @@ public:
             engine);
         dense_y->read(md_y);
         auto tmp_y = dist_vec_type::create(ref, comm);
-        tmp_y->read_distributed(md_y, part.get());
+        tmp_y->read_distributed(md_y, part);
         y = gko::clone(exec, tmp_y);
     }
 
@@ -523,8 +522,8 @@ TYPED_TEST(VectorReductions, ComputesDotProductIsSameAsDense)
     using value_type = typename TestFixture::value_type;
     this->init_result();
 
-    this->x->compute_dot(this->y.get(), this->res.get());
-    this->dense_x->compute_dot(this->dense_y.get(), this->dense_res.get());
+    this->x->compute_dot(this->y, this->res);
+    this->dense_x->compute_dot(this->dense_y, this->dense_res);
 
     GKO_ASSERT_MTX_NEAR(this->res, this->dense_res, r<value_type>::value);
 }
@@ -535,9 +534,8 @@ TYPED_TEST(VectorReductions, ComputesDotProductWithTmpIsSameAsDense)
     using value_type = typename TestFixture::value_type;
     this->init_result();
 
-    this->x->compute_dot(this->y.get(), this->res.get(), this->tmp);
-    this->dense_x->compute_dot(this->dense_y.get(), this->dense_res.get(),
-                               this->dense_tmp);
+    this->x->compute_dot(this->y, this->res, this->tmp);
+    this->dense_x->compute_dot(this->dense_y, this->dense_res, this->dense_tmp);
 
     GKO_ASSERT_MTX_NEAR(this->res, this->dense_res, r<value_type>::value);
 }
@@ -548,8 +546,8 @@ TYPED_TEST(VectorReductions, ComputesConjDotProductIsSameAsDense)
     using value_type = typename TestFixture::value_type;
     this->init_result();
 
-    this->x->compute_conj_dot(this->y.get(), this->res.get());
-    this->dense_x->compute_conj_dot(this->dense_y.get(), this->dense_res.get());
+    this->x->compute_conj_dot(this->y, this->res);
+    this->dense_x->compute_conj_dot(this->dense_y, this->dense_res);
 
     GKO_ASSERT_MTX_NEAR(this->res, this->dense_res, r<value_type>::value);
 }
@@ -560,8 +558,8 @@ TYPED_TEST(VectorReductions, ComputesConjDotProductWithTmpIsSameAsDense)
     using value_type = typename TestFixture::value_type;
     this->init_result();
 
-    this->x->compute_conj_dot(this->y.get(), this->res.get(), this->tmp);
-    this->dense_x->compute_conj_dot(this->dense_y.get(), this->dense_res.get(),
+    this->x->compute_conj_dot(this->y, this->res, this->tmp);
+    this->dense_x->compute_conj_dot(this->dense_y, this->dense_res,
                                     this->dense_tmp);
 
     GKO_ASSERT_MTX_NEAR(this->res, this->dense_res, r<value_type>::value);
@@ -573,8 +571,8 @@ TYPED_TEST(VectorReductions, ComputesNorm2IsSameAsDense)
     using value_type = typename TestFixture::value_type;
     this->init_result();
 
-    this->x->compute_norm2(this->real_res.get());
-    this->dense_x->compute_norm2(this->dense_real_res.get());
+    this->x->compute_norm2(this->real_res);
+    this->dense_x->compute_norm2(this->dense_real_res);
 
     GKO_ASSERT_MTX_NEAR(this->real_res, this->dense_real_res,
                         r<value_type>::value);
@@ -586,8 +584,8 @@ TYPED_TEST(VectorReductions, ComputesNorm2WithTmpIsSameAsDense)
     using value_type = typename TestFixture::value_type;
     this->init_result();
 
-    this->x->compute_norm2(this->real_res.get(), this->tmp);
-    this->dense_x->compute_norm2(this->dense_real_res.get(), this->dense_tmp);
+    this->x->compute_norm2(this->real_res, this->tmp);
+    this->dense_x->compute_norm2(this->dense_real_res, this->dense_tmp);
 
     GKO_ASSERT_MTX_NEAR(this->real_res, this->dense_real_res,
                         r<value_type>::value);
@@ -599,8 +597,8 @@ TYPED_TEST(VectorReductions, ComputesNorm1IsSameAsDense)
     using value_type = typename TestFixture::value_type;
     this->init_result();
 
-    this->x->compute_norm1(this->real_res.get());
-    this->dense_x->compute_norm1(this->dense_real_res.get());
+    this->x->compute_norm1(this->real_res);
+    this->dense_x->compute_norm1(this->dense_real_res);
 
     GKO_ASSERT_MTX_NEAR(this->real_res, this->dense_real_res,
                         r<value_type>::value);
@@ -612,8 +610,8 @@ TYPED_TEST(VectorReductions, ComputesNorm1WithTmpIsSameAsDense)
     using value_type = typename TestFixture::value_type;
     this->init_result();
 
-    this->x->compute_norm1(this->real_res.get(), this->tmp);
-    this->dense_x->compute_norm1(this->dense_real_res.get(), this->dense_tmp);
+    this->x->compute_norm1(this->real_res, this->tmp);
+    this->dense_x->compute_norm1(this->dense_real_res, this->dense_tmp);
 
     GKO_ASSERT_MTX_NEAR(this->real_res, this->dense_real_res,
                         r<value_type>::value);
@@ -625,7 +623,7 @@ TYPED_TEST(VectorReductions, ComputeDotCopiesToHostOnlyIfNecessary)
     this->init_result();
     auto transfer_count_before = this->logger->get_transfer_count();
 
-    this->x->compute_dot(this->y.get(), this->res.get());
+    this->x->compute_dot(this->y, this->res);
 
     ASSERT_EQ(this->logger->get_transfer_count() > transfer_count_before,
               needs_transfers(this->exec));
@@ -637,7 +635,7 @@ TYPED_TEST(VectorReductions, ComputeConjDotCopiesToHostOnlyIfNecessary)
     this->init_result();
     auto transfer_count_before = this->logger->get_transfer_count();
 
-    this->x->compute_conj_dot(this->y.get(), this->res.get());
+    this->x->compute_conj_dot(this->y, this->res);
 
     ASSERT_EQ(this->logger->get_transfer_count() > transfer_count_before,
               needs_transfers(this->exec));
@@ -649,7 +647,7 @@ TYPED_TEST(VectorReductions, ComputeNorm2CopiesToHostOnlyIfNecessary)
     this->init_result();
     auto transfer_count_before = this->logger->get_transfer_count();
 
-    this->x->compute_norm2(this->real_res.get());
+    this->x->compute_norm2(this->real_res);
 
     ASSERT_EQ(this->logger->get_transfer_count() > transfer_count_before,
               needs_transfers(this->exec));
@@ -661,7 +659,7 @@ TYPED_TEST(VectorReductions, ComputeNorm1CopiesToHostOnlyIfNecessary)
     this->init_result();
     auto transfer_count_before = this->logger->get_transfer_count();
 
-    this->x->compute_norm1(this->real_res.get());
+    this->x->compute_norm1(this->real_res);
 
     ASSERT_EQ(this->logger->get_transfer_count() > transfer_count_before,
               needs_transfers(this->exec));
@@ -704,8 +702,7 @@ public:
                                                           local_size[1]),
             std::normal_distribution<gko::remove_complex<vtype>>(), engine,
             exec);
-        dist =
-            DistVectorType::create(exec, comm, size, gko::clone(local).get());
+        dist = DistVectorType::create(exec, comm, size, gko::clone(local));
     }
 
     void init_vectors()
@@ -755,7 +752,7 @@ TYPED_TEST(VectorLocalOps, ApplyNotSupported)
     auto c = dist_vec_type::create(this->exec, this->comm, gko::dim<2>{2, 2},
                                    gko::dim<2>{2, 2});
 
-    ASSERT_THROW(a->apply(b.get(), c.get()), gko::NotSupported);
+    ASSERT_THROW(a->apply(b, c), gko::NotSupported);
 }
 
 
@@ -773,8 +770,7 @@ TYPED_TEST(VectorLocalOps, AdvancedApplyNotSupported)
     auto e = dist_vec_type::create(this->exec, this->comm, gko::dim<2>{2, 2},
                                    gko::dim<2>{2, 2});
 
-    ASSERT_THROW(a->apply(b.get(), c.get(), d.get(), e.get()),
-                 gko::NotSupported);
+    ASSERT_THROW(a->apply(b, c, d, e), gko::NotSupported);
 }
 
 
@@ -787,8 +783,8 @@ TYPED_TEST(VectorLocalOps, ConvertsToPrecision)
     auto tmp = OtherVector::create(this->exec, this->comm);
     this->init_vectors();
 
-    this->local_x->convert_to(local_tmp.get());
-    this->x->convert_to(tmp.get());
+    this->local_x->convert_to(local_tmp);
+    this->x->convert_to(tmp);
 
     GKO_ASSERT_MTX_NEAR(tmp->get_local_vector(), local_tmp, 0.0);
 }
@@ -803,8 +799,8 @@ TYPED_TEST(VectorLocalOps, MovesToPrecision)
     auto tmp = OtherVector::create(this->exec, this->comm);
     this->init_vectors();
 
-    this->local_x->move_to(local_tmp.get());
-    this->x->move_to(tmp.get());
+    this->local_x->move_to(local_tmp);
+    this->x->move_to(tmp);
 
     GKO_ASSERT_MTX_NEAR(tmp->get_local_vector(), local_tmp, 0.0);
 }
@@ -854,8 +850,8 @@ TYPED_TEST(VectorLocalOps, MakeComplexInplaceSameAsLocal)
     this->init_vectors();
     this->init_complex_vectors();
 
-    this->x->make_complex(this->complex.get());
-    this->local_x->make_complex(this->local_complex.get());
+    this->x->make_complex(this->complex);
+    this->local_x->make_complex(this->local_complex);
 
     GKO_ASSERT_MTX_NEAR(this->complex->get_local_vector(), this->local_complex,
                         0.0);
@@ -879,8 +875,8 @@ TYPED_TEST(VectorLocalOps, GetRealInplaceSameAsLocal)
     this->init_vectors();
     this->init_complex_vectors();
 
-    this->complex->get_real(this->real.get());
-    this->local_complex->get_real(this->local_real.get());
+    this->complex->get_real(this->real);
+    this->local_complex->get_real(this->local_real);
 
     GKO_ASSERT_MTX_NEAR(this->real->get_local_vector(), this->local_real, 0.0);
 }
@@ -901,8 +897,8 @@ TYPED_TEST(VectorLocalOps, GetImagInplaceSameAsLocal)
 {
     this->init_complex_vectors();
 
-    this->complex->get_imag(this->real.get());
-    this->local_complex->get_imag(this->local_real.get());
+    this->complex->get_imag(this->real);
+    this->local_complex->get_imag(this->local_real);
 
     GKO_ASSERT_MTX_NEAR(this->real->get_local_vector(), this->local_real, 0.0);
 }
@@ -928,8 +924,8 @@ TYPED_TEST(VectorLocalOps, ScaleSameAsLocal)
     using value_type = typename TestFixture::value_type;
     this->init_vectors();
 
-    this->x->scale(this->alpha.get());
-    this->local_x->scale(this->alpha.get());
+    this->x->scale(this->alpha);
+    this->local_x->scale(this->alpha);
 
     GKO_ASSERT_MTX_NEAR(this->x->get_local_vector(), this->local_x,
                         r<value_type>::value);
@@ -941,8 +937,8 @@ TYPED_TEST(VectorLocalOps, InvScaleSameAsLocal)
     using value_type = typename TestFixture::value_type;
     this->init_vectors();
 
-    this->x->inv_scale(this->alpha.get());
-    this->local_x->inv_scale(this->alpha.get());
+    this->x->inv_scale(this->alpha);
+    this->local_x->inv_scale(this->alpha);
 
     GKO_ASSERT_MTX_NEAR(this->x->get_local_vector(), this->local_x,
                         r<value_type>::value);
@@ -954,8 +950,8 @@ TYPED_TEST(VectorLocalOps, AddScaleSameAsLocal)
     using value_type = typename TestFixture::value_type;
     this->init_vectors();
 
-    this->x->add_scaled(this->alpha.get(), this->y.get());
-    this->local_x->add_scaled(this->alpha.get(), this->local_y.get());
+    this->x->add_scaled(this->alpha, this->y);
+    this->local_x->add_scaled(this->alpha, this->local_y);
 
     GKO_ASSERT_MTX_NEAR(this->x->get_local_vector(), this->local_x,
                         r<value_type>::value);
@@ -967,8 +963,8 @@ TYPED_TEST(VectorLocalOps, SubScaleSameAsLocal)
     using value_type = typename TestFixture::value_type;
     this->init_vectors();
 
-    this->x->sub_scaled(this->alpha.get(), this->y.get());
-    this->local_x->sub_scaled(this->alpha.get(), this->local_y.get());
+    this->x->sub_scaled(this->alpha, this->y);
+    this->local_x->sub_scaled(this->alpha, this->local_y);
 
     GKO_ASSERT_MTX_NEAR(this->x->get_local_vector(), this->local_x,
                         r<value_type>::value);

--- a/test/multigrid/fixed_coarsening_kernels.cpp
+++ b/test/multigrid/fixed_coarsening_kernels.cpp
@@ -156,7 +156,7 @@ TEST_F(FixedCoarsening, GenerateMgLevelIsEquivalentToRef)
 TEST_F(FixedCoarsening, GenerateMgLevelIsEquivalentToRefOnUnsortedMatrix)
 {
     initialize_data(243);
-    gko::test::unsort_matrix(gko::lend(system_mtx), rand_engine);
+    gko::test::unsort_matrix(system_mtx.get(), rand_engine);
     d_system_mtx = gko::clone(exec, system_mtx);
     auto mg_level_factory =
         gko::multigrid::FixedCoarsening<value_type, int>::build()

--- a/test/multigrid/fixed_coarsening_kernels.cpp
+++ b/test/multigrid/fixed_coarsening_kernels.cpp
@@ -100,10 +100,10 @@ protected:
         restrict_op = Csr::create(ref, gko::dim<2>(c_dim, m), c_dim);
 
         d_restrict_op = Csr::create(exec);
-        d_restrict_op->copy_from(restrict_op.get());
+        d_restrict_op->copy_from(restrict_op);
         auto system_dense = gen_mtx(m, m);
         system_mtx = Csr::create(ref);
-        system_dense->convert_to(system_mtx.get());
+        system_dense->convert_to(system_mtx);
 
         d_system_mtx = gko::clone(exec, system_mtx);
     }
@@ -156,7 +156,7 @@ TEST_F(FixedCoarsening, GenerateMgLevelIsEquivalentToRef)
 TEST_F(FixedCoarsening, GenerateMgLevelIsEquivalentToRefOnUnsortedMatrix)
 {
     initialize_data(243);
-    gko::test::unsort_matrix(system_mtx.get(), rand_engine);
+    gko::test::unsort_matrix(system_mtx, rand_engine);
     d_system_mtx = gko::clone(exec, system_mtx);
     auto mg_level_factory =
         gko::multigrid::FixedCoarsening<value_type, int>::build()

--- a/test/multigrid/pgm_kernels.cpp
+++ b/test/multigrid/pgm_kernels.cpp
@@ -307,7 +307,7 @@ TEST_F(Pgm, GenerateMgLevelIsEquivalentToRef)
 TEST_F(Pgm, GenerateMgLevelIsEquivalentToRefOnUnsortedMatrix)
 {
     initialize_data();
-    gko::test::unsort_matrix(gko::lend(system_mtx), rand_engine);
+    gko::test::unsort_matrix(system_mtx.get(), rand_engine);
     d_system_mtx = gko::clone(exec, system_mtx);
     auto mg_level_factory = gko::multigrid::Pgm<value_type, int>::build()
                                 .with_deterministic(true)

--- a/test/multigrid/pgm_kernels.cpp
+++ b/test/multigrid/pgm_kernels.cpp
@@ -307,7 +307,7 @@ TEST_F(Pgm, GenerateMgLevelIsEquivalentToRef)
 TEST_F(Pgm, GenerateMgLevelIsEquivalentToRefOnUnsortedMatrix)
 {
     initialize_data();
-    gko::test::unsort_matrix(system_mtx.get(), rand_engine);
+    gko::test::unsort_matrix(system_mtx, rand_engine);
     d_system_mtx = gko::clone(exec, system_mtx);
     auto mg_level_factory = gko::multigrid::Pgm<value_type, int>::build()
                                 .with_deterministic(true)

--- a/test/preconditioner/isai_kernels.cpp
+++ b/test/preconditioner/isai_kernels.cpp
@@ -477,7 +477,7 @@ TEST_F(Isai, IsaiScaleExcessSolutionIsEquivalentToRef)
     auto e_rhs = Dense::create(ref, gko::dim<2>(e_dim, 1));
     std::fill_n(e_rhs->get_values(), e_dim, 123456);
     auto de_rhs = gko::clone(exec, e_rhs);
-    d_inverse->copy_from(lend(inverse));
+    d_inverse->copy_from(inverse);
 
     gko::kernels::reference::isai::scale_excess_solution(
         ref, a1.get_const_data(), e_rhs.get(), 0, num_rows);
@@ -524,7 +524,7 @@ TEST_F(Isai, IsaiScatterExcessSolutionLIsEquivalentToRef)
     auto e_rhs = Dense::create(ref, gko::dim<2>(e_dim, 1));
     std::fill_n(e_rhs->get_values(), e_dim, 123456);
     auto de_rhs = gko::clone(exec, e_rhs);
-    d_inverse->copy_from(lend(inverse));
+    d_inverse->copy_from(inverse);
 
     gko::kernels::reference::isai::scatter_excess_solution(
         ref, a1.get_const_data(), e_rhs.get(), inverse.get(), 0, num_rows);
@@ -550,7 +550,7 @@ TEST_F(Isai, IsaiScatterExcessSolutionUIsEquivalentToRef)
     std::fill_n(e_rhs->get_values(), e_dim, 123456);
     auto de_rhs = gko::clone(exec, e_rhs);
     // overwrite -1 values with inverse
-    d_inverse->copy_from(lend(inverse));
+    d_inverse->copy_from(inverse);
 
     gko::kernels::reference::isai::scatter_excess_solution(
         ref, a1.get_const_data(), e_rhs.get(), inverse.get(), 0, num_rows);
@@ -576,7 +576,7 @@ TEST_F(Isai, IsaiScatterExcessSolutionAIsEquivalentToRef)
     std::fill_n(e_rhs->get_values(), e_dim, 123456);
     auto de_rhs = gko::clone(exec, e_rhs);
     // overwrite -1 values with inverse
-    d_inverse->copy_from(lend(inverse));
+    d_inverse->copy_from(inverse);
 
     gko::kernels::reference::isai::scatter_excess_solution(
         ref, a1.get_const_data(), e_rhs.get(), inverse.get(), 0, num_rows);
@@ -602,7 +602,7 @@ TEST_F(Isai, IsaiScatterExcessSolutionSpdIsEquivalentToRef)
     std::fill_n(e_rhs->get_values(), e_dim, 123456);
     auto de_rhs = gko::clone(exec, e_rhs);
     // overwrite -1 values with inverse
-    d_inverse->copy_from(lend(inverse));
+    d_inverse->copy_from(inverse);
 
     gko::kernels::reference::isai::scatter_excess_solution(
         ref, a1.get_const_data(), e_rhs.get(), inverse.get(), 0, num_rows);
@@ -628,7 +628,7 @@ TEST_F(Isai, IsaiScatterPartialExcessSolutionIsEquivalentToRef)
     std::fill_n(e_rhs->get_values(), e_dim, 123456);
     auto de_rhs = gko::clone(exec, e_rhs);
     // overwrite -1 values with inverse
-    d_inverse->copy_from(lend(inverse));
+    d_inverse->copy_from(inverse);
 
     gko::kernels::reference::isai::scatter_excess_solution(
         ref, a1.get_const_data(), e_rhs.get(), inverse.get(), 5u, 10u);

--- a/test/preconditioner/isai_kernels.cpp
+++ b/test/preconditioner/isai_kernels.cpp
@@ -88,15 +88,15 @@ protected:
             auto dense_mtx = gko::test::generate_random_matrix<Dense>(
                 n, n, nz_dist, val_dist, rand_engine, ref, gko::dim<2>{n, n});
             ensure_diagonal(dense_mtx.get());
-            mtx->copy_from(dense_mtx.get());
+            mtx->copy_from(dense_mtx);
         } else if (type == matrix_type::spd) {
             auto dense_mtx = gko::test::generate_random_band_matrix<Dense>(
                 n, row_limit / 4, row_limit / 4, val_dist, rand_engine, ref,
                 gko::dim<2>{n, n});
             auto transp = gko::as<Dense>(dense_mtx->transpose());
             auto spd_mtx = Dense::create(ref, gko::dim<2>{n, n});
-            dense_mtx->apply(transp.get(), spd_mtx.get());
-            mtx->copy_from(spd_mtx.get());
+            dense_mtx->apply(transp, spd_mtx);
+            mtx->copy_from(spd_mtx);
         } else {
             mtx = gko::test::generate_random_triangular_matrix<Csr>(
                 n, true, for_lower_tm, nz_dist, val_dist, rand_engine, ref,

--- a/test/preconditioner/jacobi_kernels.cpp
+++ b/test/preconditioner/jacobi_kernels.cpp
@@ -631,7 +631,7 @@ TEST_F(Jacobi, PreconditionerEquivalentToRefWithFullPrecision)
     auto bj = bj_factory->generate(mtx);
     auto d_bj = d_bj_factory->generate(mtx);
 
-    GKO_ASSERT_MTX_NEAR(lend(d_bj), lend(bj), 1e-13);
+    GKO_ASSERT_MTX_NEAR(d_bj, bj, 1e-13);
 }
 
 
@@ -644,7 +644,7 @@ TEST_F(Jacobi, PreconditionerEquivalentToRefWithReducedPrecision)
     auto bj = bj_factory->generate(mtx);
     auto d_bj = d_bj_factory->generate(mtx);
 
-    GKO_ASSERT_MTX_NEAR(lend(d_bj), lend(bj), 1e-7);
+    GKO_ASSERT_MTX_NEAR(d_bj, bj, 1e-7);
 }
 
 
@@ -657,7 +657,7 @@ TEST_F(Jacobi, PreconditionerEquivalentToRefWithCustomReducedPrecision)
     auto bj = bj_factory->generate(mtx);
     auto d_bj = d_bj_factory->generate(mtx);
 
-    GKO_ASSERT_MTX_NEAR(lend(d_bj), lend(bj), 1e-6);
+    GKO_ASSERT_MTX_NEAR(d_bj, bj, 1e-6);
 }
 
 
@@ -670,7 +670,7 @@ TEST_F(Jacobi, PreconditionerEquivalentToRefWithQuarteredPrecision)
     auto bj = bj_factory->generate(mtx);
     auto d_bj = d_bj_factory->generate(mtx);
 
-    GKO_ASSERT_MTX_NEAR(lend(d_bj), lend(bj), 1e-3);
+    GKO_ASSERT_MTX_NEAR(d_bj, bj, 1e-3);
 }
 
 
@@ -683,7 +683,7 @@ TEST_F(Jacobi, PreconditionerEquivalentToRefWithCustomQuarteredPrecision)
     auto bj = bj_factory->generate(mtx);
     auto d_bj = d_bj_factory->generate(mtx);
 
-    GKO_ASSERT_MTX_NEAR(lend(d_bj), lend(bj), 1e-1);
+    GKO_ASSERT_MTX_NEAR(d_bj, bj, 1e-1);
 }
 
 
@@ -696,7 +696,7 @@ TEST_F(Jacobi, PreconditionerEquivalentToRefWithAdaptivePrecision)
     auto bj = bj_factory->generate(mtx);
     auto d_bj = d_bj_factory->generate(mtx);
 
-    GKO_ASSERT_MTX_NEAR(lend(d_bj), lend(bj), 1e-1);
+    GKO_ASSERT_MTX_NEAR(d_bj, bj, 1e-1);
 }
 
 

--- a/test/preconditioner/jacobi_kernels.cpp
+++ b/test/preconditioner/jacobi_kernels.cpp
@@ -354,7 +354,7 @@ TEST_F(Jacobi, TransposedPreconditionerEquivalentToRefWithMPW)
 
     auto bj = bj_factory->generate(mtx);
     auto d_bj = d_bj_factory->generate(mtx);
-    d_bj->copy_from(bj.get());
+    d_bj->copy_from(bj);
 
     GKO_ASSERT_MTX_NEAR(gko::as<Bj>(d_bj->transpose()),
                         gko::as<Bj>(bj->transpose()), 1e-14);
@@ -368,7 +368,7 @@ TEST_F(Jacobi, ConjTransposedPreconditionerEquivalentToRefWithMPW)
 
     auto bj = bj_factory->generate(mtx);
     auto d_bj = d_bj_factory->generate(mtx);
-    d_bj->copy_from(bj.get());
+    d_bj->copy_from(bj);
 
     GKO_ASSERT_MTX_NEAR(gko::as<Bj>(d_bj->conj_transpose()),
                         gko::as<Bj>(bj->conj_transpose()), 1e-14);
@@ -381,8 +381,8 @@ TEST_F(Jacobi, ApplyEquivalentToRefWithBlockSize32)
     auto bj = bj_factory->generate(mtx);
     auto d_bj = d_bj_factory->generate(mtx);
 
-    bj->apply(b.get(), x.get());
-    d_bj->apply(d_b.get(), d_x.get());
+    bj->apply(b, x);
+    d_bj->apply(d_b, d_x);
 
     GKO_ASSERT_MTX_NEAR(d_x, x, 1e-12);
 }
@@ -398,8 +398,8 @@ TEST_F(Jacobi, ApplyEquivalentToRefWithBlockSize64)
     auto bj = bj_factory->generate(mtx);
     auto d_bj = d_bj_factory->generate(mtx);
 
-    bj->apply(b.get(), x.get());
-    d_bj->apply(d_b.get(), d_x.get());
+    bj->apply(b, x);
+    d_bj->apply(d_b, d_x);
 
     GKO_ASSERT_MTX_NEAR(d_x, x, 1e-12);
 }
@@ -413,8 +413,8 @@ TEST_F(Jacobi, ApplyEquivalentToRefWithDifferentBlockSize)
     auto bj = bj_factory->generate(mtx);
     auto d_bj = d_bj_factory->generate(mtx);
 
-    bj->apply(b.get(), x.get());
-    d_bj->apply(d_b.get(), d_x.get());
+    bj->apply(b, x);
+    d_bj->apply(d_b, d_x);
 
     GKO_ASSERT_MTX_NEAR(d_x, x, 1e-12);
 }
@@ -427,8 +427,8 @@ TEST_F(Jacobi, ApplyEquivalentToRef)
     auto bj = bj_factory->generate(mtx);
     auto d_bj = d_bj_factory->generate(mtx);
 
-    bj->apply(b.get(), x.get());
-    d_bj->apply(d_b.get(), d_x.get());
+    bj->apply(b, x);
+    d_bj->apply(d_b, d_x);
 
     GKO_ASSERT_MTX_NEAR(d_x, x, 1e-12);
 }
@@ -446,7 +446,7 @@ TEST_F(Jacobi, ScalarApplyEquivalentToRef)
     auto dense_smtx = gko::share(Vec::create(ref));
     dense_smtx->read(dense_data);
     auto smtx = gko::share(Mtx::create(ref));
-    smtx->copy_from(dense_smtx.get());
+    smtx->copy_from(dense_smtx);
     auto sb = gko::share(gko::test::generate_random_matrix<Vec>(
         dim, 3, std::uniform_int_distribution<>(1, 1),
         std::normal_distribution<>(0.0, 1.0), engine, ref));
@@ -455,16 +455,16 @@ TEST_F(Jacobi, ScalarApplyEquivalentToRef)
     auto d_smtx = gko::share(Mtx::create(exec));
     auto d_sb = gko::share(Vec::create(exec));
     auto d_sx = gko::share(Vec::create(exec, sb->get_size()));
-    d_smtx->copy_from(smtx.get());
-    d_sb->copy_from(sb.get());
+    d_smtx->copy_from(smtx);
+    d_sb->copy_from(sb);
 
     auto sj = Bj::build().with_max_block_size(1u).on(ref)->generate(smtx);
     auto d_sj = Bj::build().with_max_block_size(1u).on(exec)->generate(d_smtx);
 
-    sj->apply(sb.get(), sx.get());
-    d_sj->apply(d_sb.get(), d_sx.get());
+    sj->apply(sb, sx);
+    d_sj->apply(d_sb, d_sx);
 
-    GKO_ASSERT_MTX_NEAR(sx.get(), d_sx.get(), 1e-12);
+    GKO_ASSERT_MTX_NEAR(sx, d_sx, 1e-12);
 }
 
 
@@ -479,8 +479,8 @@ TEST_F(Jacobi, LinearCombinationApplyEquivalentToRef)
     auto bj = bj_factory->generate(mtx);
     auto d_bj = d_bj_factory->generate(mtx);
 
-    bj->apply(alpha.get(), b.get(), beta.get(), x.get());
-    d_bj->apply(d_alpha.get(), d_b.get(), d_beta.get(), d_x.get());
+    bj->apply(alpha, b, beta, x);
+    d_bj->apply(d_alpha, d_b, d_beta, d_x);
 
     GKO_ASSERT_MTX_NEAR(d_x, x, 1e-12);
 }
@@ -498,7 +498,7 @@ TEST_F(Jacobi, ScalarLinearCombinationApplyEquivalentToRef)
     auto dense_smtx = gko::share(Vec::create(ref));
     dense_smtx->read(dense_data);
     auto smtx = gko::share(Mtx::create(ref));
-    smtx->copy_from(dense_smtx.get());
+    smtx->copy_from(dense_smtx);
     auto sb = gko::share(gko::test::generate_random_matrix<Vec>(
         dim, 3, std::uniform_int_distribution<>(1, 1),
         std::normal_distribution<>(0.0, 1.0), engine, ref, gko::dim<2>(dim, 3),
@@ -519,10 +519,10 @@ TEST_F(Jacobi, ScalarLinearCombinationApplyEquivalentToRef)
     auto sj = Bj::build().with_max_block_size(1u).on(ref)->generate(smtx);
     auto d_sj = Bj::build().with_max_block_size(1u).on(exec)->generate(d_smtx);
 
-    sj->apply(alpha.get(), sb.get(), beta.get(), sx.get());
-    d_sj->apply(d_alpha.get(), d_sb.get(), d_beta.get(), d_sx.get());
+    sj->apply(alpha, sb, beta, sx);
+    d_sj->apply(d_alpha, d_sb, d_beta, d_sx);
 
-    GKO_ASSERT_MTX_NEAR(sx.get(), d_sx.get(), 1e-12);
+    GKO_ASSERT_MTX_NEAR(sx, d_sx, 1e-12);
 }
 
 
@@ -533,8 +533,8 @@ TEST_F(Jacobi, ApplyToMultipleVectorsEquivalentToRef)
     auto bj = bj_factory->generate(mtx);
     auto d_bj = d_bj_factory->generate(mtx);
 
-    bj->apply(b.get(), x.get());
-    d_bj->apply(d_b.get(), d_x.get());
+    bj->apply(b, x);
+    d_bj->apply(d_b, d_x);
 
     GKO_ASSERT_MTX_NEAR(d_x, x, 1e-12);
 }
@@ -551,8 +551,8 @@ TEST_F(Jacobi, LinearCombinationApplyToMultipleVectorsEquivalentToRef)
     auto bj = bj_factory->generate(mtx);
     auto d_bj = d_bj_factory->generate(mtx);
 
-    bj->apply(alpha.get(), b.get(), beta.get(), x.get());
-    d_bj->apply(d_alpha.get(), d_b.get(), d_beta.get(), d_x.get());
+    bj->apply(alpha, b, beta, x);
+    d_bj->apply(d_alpha, d_b, d_beta, d_x);
 
     GKO_ASSERT_MTX_NEAR(d_x, x, 1e-12);
 }
@@ -708,7 +708,7 @@ TEST_F(Jacobi, TransposedPreconditionerEquivalentToRefWithAdaptivePrecision)
 
     auto bj = bj_factory->generate(mtx);
     auto d_bj = d_bj_factory->generate(mtx);
-    d_bj->copy_from(bj.get());
+    d_bj->copy_from(bj);
 
     GKO_ASSERT_MTX_NEAR(gko::as<Bj>(d_bj->transpose()),
                         gko::as<Bj>(bj->transpose()), 0);
@@ -723,7 +723,7 @@ TEST_F(Jacobi, ConjTransposedPreconditionerEquivalentToRefWithAdaptivePrecision)
 
     auto bj = bj_factory->generate(mtx);
     auto d_bj = d_bj_factory->generate(mtx);
-    d_bj->copy_from(bj.get());
+    d_bj->copy_from(bj);
 
     GKO_ASSERT_MTX_NEAR(gko::as<Bj>(d_bj->conj_transpose()),
                         gko::as<Bj>(bj->conj_transpose()), 0);
@@ -738,8 +738,8 @@ TEST_F(Jacobi, ApplyEquivalentToRefWithFullPrecision)
     auto bj = bj_factory->generate(mtx);
     auto d_bj = d_bj_factory->generate(mtx);
 
-    bj->apply(b.get(), x.get());
-    d_bj->apply(d_b.get(), d_x.get());
+    bj->apply(b, x);
+    d_bj->apply(d_b, d_x);
 
     GKO_ASSERT_MTX_NEAR(d_x, x, 1e-12);
 }
@@ -753,8 +753,8 @@ TEST_F(Jacobi, ApplyEquivalentToRefWithReducedPrecision)
     auto bj = bj_factory->generate(mtx);
     auto d_bj = d_bj_factory->generate(mtx);
 
-    bj->apply(b.get(), x.get());
-    d_bj->apply(d_b.get(), d_x.get());
+    bj->apply(b, x);
+    d_bj->apply(d_b, d_x);
 
     GKO_ASSERT_MTX_NEAR(d_x, x, 1e-6);
 }
@@ -768,8 +768,8 @@ TEST_F(Jacobi, ApplyEquivalentToRefWithCustomReducedPrecision)
     auto bj = bj_factory->generate(mtx);
     auto d_bj = d_bj_factory->generate(mtx);
 
-    bj->apply(b.get(), x.get());
-    d_bj->apply(d_b.get(), d_x.get());
+    bj->apply(b, x);
+    d_bj->apply(d_b, d_x);
 
     GKO_ASSERT_MTX_NEAR(d_x, x, 1e-5);
 }
@@ -783,8 +783,8 @@ TEST_F(Jacobi, ApplyEquivalentToRefWithQuarteredPrecision)
     auto bj = bj_factory->generate(mtx);
     auto d_bj = d_bj_factory->generate(mtx);
 
-    bj->apply(b.get(), x.get());
-    d_bj->apply(d_b.get(), d_x.get());
+    bj->apply(b, x);
+    d_bj->apply(d_b, d_x);
 
     GKO_ASSERT_MTX_NEAR(d_x, x, 1e-2);
 }
@@ -798,8 +798,8 @@ TEST_F(Jacobi, ApplyEquivalentToRefWithCustomReducedAndReducedPrecision)
     auto bj = bj_factory->generate(mtx);
     auto d_bj = d_bj_factory->generate(mtx);
 
-    bj->apply(b.get(), x.get());
-    d_bj->apply(d_b.get(), d_x.get());
+    bj->apply(b, x);
+    d_bj->apply(d_b, d_x);
 
     GKO_ASSERT_MTX_NEAR(d_x, x, 1e-2);
 }
@@ -813,8 +813,8 @@ TEST_F(Jacobi, ApplyEquivalentToRefWithCustomQuarteredPrecision)
     auto bj = bj_factory->generate(mtx);
     auto d_bj = d_bj_factory->generate(mtx);
 
-    bj->apply(b.get(), x.get());
-    d_bj->apply(d_b.get(), d_x.get());
+    bj->apply(b, x);
+    d_bj->apply(d_b, d_x);
 
     GKO_ASSERT_MTX_NEAR(d_x, x, 1e-6);
 }
@@ -828,8 +828,8 @@ TEST_F(Jacobi, ApplyEquivalentToRefWithAdaptivePrecision)
     auto bj = bj_factory->generate(mtx);
     auto d_bj = d_bj_factory->generate(mtx);
 
-    bj->apply(b.get(), x.get());
-    d_bj->apply(d_b.get(), d_x.get());
+    bj->apply(b, x);
+    d_bj->apply(d_b, d_x);
 
     GKO_ASSERT_MTX_NEAR(d_x, x, 1e-1);
 }
@@ -847,8 +847,8 @@ TEST_F(Jacobi, LinearCombinationApplyEquivalentToRefWithAdaptivePrecision)
     auto bj = bj_factory->generate(mtx);
     auto d_bj = d_bj_factory->generate(mtx);
 
-    bj->apply(b.get(), x.get());
-    d_bj->apply(d_b.get(), d_x.get());
+    bj->apply(b, x);
+    d_bj->apply(d_b, d_x);
 
     GKO_ASSERT_MTX_NEAR(d_x, x, 1e-6);
 }
@@ -862,8 +862,8 @@ TEST_F(Jacobi, ApplyToMultipleVectorsEquivalentToRefWithFullPrecision)
     auto bj = bj_factory->generate(mtx);
     auto d_bj = d_bj_factory->generate(mtx);
 
-    bj->apply(b.get(), x.get());
-    d_bj->apply(d_b.get(), d_x.get());
+    bj->apply(b, x);
+    d_bj->apply(d_b, d_x);
 
     GKO_ASSERT_MTX_NEAR(d_x, x, 1e-12);
 }
@@ -877,8 +877,8 @@ TEST_F(Jacobi, ApplyToMultipleVectorsEquivalentToRefWithReducedPrecision)
     auto bj = bj_factory->generate(mtx);
     auto d_bj = d_bj_factory->generate(mtx);
 
-    bj->apply(b.get(), x.get());
-    d_bj->apply(d_b.get(), d_x.get());
+    bj->apply(b, x);
+    d_bj->apply(d_b, d_x);
 
     GKO_ASSERT_MTX_NEAR(d_x, x, 1e-6);
 }
@@ -892,8 +892,8 @@ TEST_F(Jacobi, ApplyToMultipleVectorsEquivalentToRefWithAdaptivePrecision)
     auto bj = bj_factory->generate(mtx);
     auto d_bj = d_bj_factory->generate(mtx);
 
-    bj->apply(b.get(), x.get());
-    d_bj->apply(d_b.get(), d_x.get());
+    bj->apply(b, x);
+    d_bj->apply(d_b, d_x);
 
     GKO_ASSERT_MTX_NEAR(d_x, x, 1e-1);
 }
@@ -913,8 +913,8 @@ TEST_F(
     auto bj = bj_factory->generate(mtx);
     auto d_bj = d_bj_factory->generate(mtx);
 
-    bj->apply(b.get(), x.get());
-    d_bj->apply(d_b.get(), d_x.get());
+    bj->apply(b, x);
+    d_bj->apply(d_b, d_x);
 
     GKO_ASSERT_MTX_NEAR(d_x, x, 1e-6);
 }

--- a/test/solver/bicg_kernels.cpp
+++ b/test/solver/bicg_kernels.cpp
@@ -74,7 +74,7 @@ protected:
             std::uniform_int_distribution<>(num_cols, num_cols),
             std::normal_distribution<value_type>(-1.0, 1.0), rand_engine, ref);
         auto result = Mtx::create(ref, gko::dim<2>{num_rows, num_cols}, stride);
-        result->copy_from(tmp_mtx.get());
+        result->copy_from(tmp_mtx);
         return result;
     }
 
@@ -256,8 +256,8 @@ TEST_F(Bicg, ApplyWithSpdMatrixIsEquivalentToRef)
     auto solver = bicg_factory->generate(std::move(mtx));
     auto d_solver = d_bicg_factory->generate(std::move(d_mtx));
 
-    solver->apply(b.get(), x.get());
-    d_solver->apply(d_b.get(), d_x.get());
+    solver->apply(b, x);
+    d_solver->apply(d_b, d_x);
 
     GKO_ASSERT_MTX_NEAR(d_x, x, ::r<value_type>::value * 1000);
 }
@@ -288,8 +288,8 @@ TEST_F(Bicg, ApplyWithSuiteSparseMatrixIsEquivalentToRef)
     auto solver = bicg_factory->generate(std::move(mtx_ani));
     auto d_solver = d_bicg_factory->generate(std::move(d_mtx_ani));
 
-    solver->apply(b.get(), x.get());
-    d_solver->apply(d_b.get(), d_x.get());
+    solver->apply(b, x);
+    d_solver->apply(d_b, d_x);
 
     GKO_ASSERT_MTX_NEAR(d_x, x, ::r<value_type>::value * 100);
 }

--- a/test/solver/bicgstab_kernels.cpp
+++ b/test/solver/bicgstab_kernels.cpp
@@ -95,7 +95,7 @@ protected:
             std::uniform_int_distribution<>(num_cols, num_cols),
             std::normal_distribution<value_type>(-1.0, 1.0), rand_engine, ref);
         auto result = Mtx::create(ref, gko::dim<2>{num_rows, num_cols}, stride);
-        result->copy_from(tmp_mtx.get());
+        result->copy_from(tmp_mtx);
         return result;
     }
 
@@ -290,8 +290,8 @@ TEST_F(Bicgstab, BicgstabApplyOneRHSIsEquivalentToRef)
     auto d_b = gko::clone(exec, b);
     auto d_x = gko::clone(exec, x);
 
-    ref_solver->apply(b.get(), x.get());
-    exec_solver->apply(d_b.get(), d_x.get());
+    ref_solver->apply(b, x);
+    exec_solver->apply(d_b, d_x);
 
     GKO_ASSERT_MTX_NEAR(d_x, x, ::r<value_type>::value * 1000);
 }
@@ -308,8 +308,8 @@ TEST_F(Bicgstab, BicgstabApplyMultipleRHSIsEquivalentToRef)
     auto d_b = gko::clone(exec, b);
     auto d_x = gko::clone(exec, x);
 
-    ref_solver->apply(b.get(), x.get());
-    exec_solver->apply(d_b.get(), d_x.get());
+    ref_solver->apply(b, x);
+    exec_solver->apply(d_b, d_x);
 
     GKO_ASSERT_MTX_NEAR(d_x, x, ::r<value_type>::value * 2000);
 }

--- a/test/solver/cb_gmres_kernels.cpp
+++ b/test/solver/cb_gmres_kernels.cpp
@@ -111,7 +111,7 @@ protected:
         int n = 43;
         x = gen_mtx(m, n);
         y = gen_mtx(default_krylov_dim_mixed, n);
-        before_preconditioner = Mtx::create_with_config_of(x.get());
+        before_preconditioner = Mtx::create_with_config_of(x);
         b = gen_mtx(m, n);
         arnoldi_norm = gen_mtx(3, n);
         gko::dim<3> krylov_bases_dim(default_krylov_dim_mixed + 1, m, n);
@@ -147,7 +147,7 @@ protected:
         }
 
         d_x = gko::clone(exec, x);
-        d_before_preconditioner = Mtx::create_with_config_of(d_x.get());
+        d_before_preconditioner = Mtx::create_with_config_of(d_x);
         d_y = gko::clone(exec, y);
         d_b = gko::clone(exec, b);
         d_arnoldi_norm = gko::clone(exec, arnoldi_norm);

--- a/test/solver/cg_kernels.cpp
+++ b/test/solver/cg_kernels.cpp
@@ -67,7 +67,7 @@ protected:
             std::uniform_int_distribution<>(num_cols, num_cols),
             std::normal_distribution<value_type>(-1.0, 1.0), rand_engine, ref);
         auto result = Mtx::create(ref, gko::dim<2>{num_rows, num_cols}, stride);
-        result->copy_from(tmp_mtx.get());
+        result->copy_from(tmp_mtx);
         return result;
     }
 
@@ -220,8 +220,8 @@ TEST_F(Cg, ApplyIsEquivalentToRef)
     auto solver = cg_factory->generate(std::move(mtx));
     auto d_solver = d_cg_factory->generate(std::move(d_mtx));
 
-    solver->apply(b.get(), x.get());
-    d_solver->apply(d_b.get(), d_x.get());
+    solver->apply(b, x);
+    d_solver->apply(d_b, d_x);
 
     GKO_ASSERT_MTX_NEAR(d_x, x, ::r<value_type>::value * 1000);
 }

--- a/test/solver/cgs_kernels.cpp
+++ b/test/solver/cgs_kernels.cpp
@@ -93,7 +93,7 @@ protected:
             std::uniform_int_distribution<>(num_cols, num_cols),
             std::normal_distribution<value_type>(-1.0, 1.0), rand_engine, ref);
         auto result = Mtx::create(ref, gko::dim<2>{num_rows, num_cols}, stride);
-        result->copy_from(tmp_mtx.get());
+        result->copy_from(tmp_mtx);
         return result;
     }
 
@@ -281,8 +281,8 @@ TEST_F(Cgs, CgsApplyOneRHSIsEquivalentToRef)
     auto d_b = gko::clone(exec, b);
     auto d_x = gko::clone(exec, x);
 
-    ref_solver->apply(b.get(), x.get());
-    exec_solver->apply(d_b.get(), d_x.get());
+    ref_solver->apply(b, x);
+    exec_solver->apply(d_b, d_x);
 
     GKO_ASSERT_MTX_NEAR(d_b, b, ::r<value_type>::value * 1e3);
     GKO_ASSERT_MTX_NEAR(d_x, x, ::r<value_type>::value * 1e3);
@@ -300,8 +300,8 @@ TEST_F(Cgs, CgsApplyMultipleRHSIsEquivalentToRef)
     auto d_b = gko::clone(exec, b);
     auto d_x = gko::clone(exec, x);
 
-    ref_solver->apply(b.get(), x.get());
-    exec_solver->apply(d_b.get(), d_x.get());
+    ref_solver->apply(b, x);
+    exec_solver->apply(d_b, d_x);
 
     GKO_ASSERT_MTX_NEAR(d_b, b, ::r<value_type>::value * 5e3);
     GKO_ASSERT_MTX_NEAR(d_x, x, ::r<value_type>::value * 5e3);

--- a/test/solver/direct.cpp
+++ b/test/solver/direct.cpp
@@ -155,8 +155,8 @@ TYPED_TEST(Direct, ApplyToSingleRhsIsEquivalentToRef)
     auto solver = this->factory->generate(this->mtx);
     auto dsolver = this->dfactory->generate(this->dmtx);
 
-    solver->apply(this->input.get(), this->output.get());
-    dsolver->apply(this->dinput.get(), this->doutput.get());
+    solver->apply(this->input, this->output);
+    dsolver->apply(this->dinput, this->doutput);
 
     GKO_ASSERT_MTX_NEAR(this->output, this->doutput,
                         100 * r<value_type>::value);
@@ -170,8 +170,8 @@ TYPED_TEST(Direct, ApplyToMultipleRhsIsEquivalentToRef)
     auto solver = this->factory->generate(this->mtx);
     auto dsolver = this->dfactory->generate(this->dmtx);
 
-    solver->apply(this->input.get(), this->output.get());
-    dsolver->apply(this->dinput.get(), this->doutput.get());
+    solver->apply(this->input, this->output);
+    dsolver->apply(this->dinput, this->doutput);
 
     GKO_ASSERT_MTX_NEAR(this->output, this->doutput,
                         100 * r<value_type>::value);
@@ -185,10 +185,8 @@ TYPED_TEST(Direct, AdvancedApplyToSingleRhsIsEquivalentToRef)
     auto solver = this->factory->generate(this->mtx);
     auto dsolver = this->dfactory->generate(this->dmtx);
 
-    solver->apply(this->alpha.get(), this->input.get(), this->beta.get(),
-                  this->output.get());
-    dsolver->apply(this->dalpha.get(), this->dinput.get(), this->dbeta.get(),
-                   this->doutput.get());
+    solver->apply(this->alpha, this->input, this->beta, this->output);
+    dsolver->apply(this->dalpha, this->dinput, this->dbeta, this->doutput);
 
     GKO_ASSERT_MTX_NEAR(this->output, this->doutput,
                         100 * r<value_type>::value);
@@ -202,10 +200,8 @@ TYPED_TEST(Direct, AdvancedApplyToMultipleRhsIsEquivalentToRef)
     auto solver = this->factory->generate(this->mtx);
     auto dsolver = this->dfactory->generate(this->dmtx);
 
-    solver->apply(this->alpha.get(), this->input.get(), this->beta.get(),
-                  this->output.get());
-    dsolver->apply(this->dalpha.get(), this->dinput.get(), this->dbeta.get(),
-                   this->doutput.get());
+    solver->apply(this->alpha, this->input, this->beta, this->output);
+    dsolver->apply(this->dalpha, this->dinput, this->dbeta, this->doutput);
 
     GKO_ASSERT_MTX_NEAR(this->output, this->doutput,
                         100 * r<value_type>::value);

--- a/test/solver/fcg_kernels.cpp
+++ b/test/solver/fcg_kernels.cpp
@@ -68,7 +68,7 @@ protected:
             std::uniform_int_distribution<>(num_cols, num_cols),
             std::normal_distribution<value_type>(-1.0, 1.0), rand_engine, ref);
         auto result = Mtx::create(ref, gko::dim<2>{num_rows, num_cols}, stride);
-        result->copy_from(tmp_mtx.get());
+        result->copy_from(tmp_mtx);
         return result;
     }
 
@@ -229,8 +229,8 @@ TEST_F(Fcg, ApplyIsEquivalentToRef)
     auto solver = fcg_factory->generate(std::move(mtx));
     auto d_solver = d_fcg_factory->generate(std::move(d_mtx));
 
-    solver->apply(b.get(), x.get());
-    d_solver->apply(d_b.get(), d_x.get());
+    solver->apply(b, x);
+    d_solver->apply(d_b, d_x);
 
     GKO_ASSERT_MTX_NEAR(d_x, x, ::r<value_type>::value * 1000);
 }

--- a/test/solver/gmres_kernels.cpp
+++ b/test/solver/gmres_kernels.cpp
@@ -104,7 +104,7 @@ protected:
 #endif
         x = gen_mtx(m, nrhs);
         y = gen_mtx(gko::solver::default_krylov_dim, nrhs);
-        before_preconditioner = Mtx::create_with_config_of(x.get());
+        before_preconditioner = Mtx::create_with_config_of(x);
         b = gen_mtx(m, nrhs);
         krylov_bases = gen_mtx(m * (gko::solver::default_krylov_dim + 1), nrhs);
         hessenberg = gen_mtx(gko::solver::default_krylov_dim + 1,
@@ -126,7 +126,7 @@ protected:
         }
 
         d_x = gko::clone(exec, x);
-        d_before_preconditioner = Mtx::create_with_config_of(d_x.get());
+        d_before_preconditioner = Mtx::create_with_config_of(d_x);
         d_y = gko::clone(exec, y);
         d_b = gko::clone(exec, b);
         d_krylov_bases = gko::clone(exec, krylov_bases);
@@ -201,8 +201,8 @@ TEST_F(Gmres, GmresKernelInitializeIsEquivalentToRef)
 TEST_F(Gmres, GmresKernelRestartIsEquivalentToRef)
 {
     initialize_data();
-    residual->compute_norm2(residual_norm.get());
-    d_residual_norm->copy_from(residual_norm.get());
+    residual->compute_norm2(residual_norm);
+    d_residual_norm->copy_from(residual_norm);
 
     gko::kernels::reference::gmres::restart(
         ref, residual.get(), residual_norm.get(),
@@ -316,8 +316,8 @@ TEST_F(Gmres, GmresApplyOneRHSIsEquivalentToRef)
     auto d_b = gko::clone(exec, b);
     auto d_x = gko::clone(exec, x);
 
-    ref_solver->apply(b.get(), x.get());
-    exec_solver->apply(d_b.get(), d_x.get());
+    ref_solver->apply(b, x);
+    exec_solver->apply(d_b, d_x);
 
     GKO_ASSERT_MTX_NEAR(d_b, b, 0);
     GKO_ASSERT_MTX_NEAR(d_x, x, r<value_type>::value * 1e2);
@@ -335,8 +335,8 @@ TEST_F(Gmres, GmresApplyMultipleRHSIsEquivalentToRef)
     auto d_b = gko::clone(exec, b);
     auto d_x = gko::clone(exec, x);
 
-    ref_solver->apply(b.get(), x.get());
-    exec_solver->apply(d_b.get(), d_x.get());
+    ref_solver->apply(b, x);
+    exec_solver->apply(d_b, d_x);
 
     GKO_ASSERT_MTX_NEAR(d_b, b, 0);
     GKO_ASSERT_MTX_NEAR(d_x, x, r<value_type>::value * 1e3);

--- a/test/solver/idr_kernels.cpp
+++ b/test/solver/idr_kernels.cpp
@@ -275,8 +275,8 @@ TEST_F(Idr, IdrIterationOneRHSIsEquivalentToRef)
     auto ref_solver = ref_idr_factory->generate(mtx);
     auto exec_solver = exec_idr_factory->generate(d_mtx);
 
-    ref_solver->apply(b.get(), x.get());
-    exec_solver->apply(d_b.get(), d_x.get());
+    ref_solver->apply(b, x);
+    exec_solver->apply(d_b, d_x);
 
     GKO_ASSERT_MTX_NEAR(d_b, b, rr<value_type>::value * 10);
     GKO_ASSERT_MTX_NEAR(d_x, x, rr<value_type>::value * 10);
@@ -303,8 +303,8 @@ TEST_F(Idr, IdrIterationWithComplexSubspaceOneRHSIsEquivalentToRef)
     auto ref_solver = ref_idr_factory->generate(mtx);
     auto exec_solver = exec_idr_factory->generate(d_mtx);
 
-    ref_solver->apply(b.get(), x.get());
-    exec_solver->apply(d_b.get(), d_x.get());
+    ref_solver->apply(b, x);
+    exec_solver->apply(d_b, d_x);
 
     GKO_ASSERT_MTX_NEAR(d_b, b, rr<value_type>::value * 100);
     GKO_ASSERT_MTX_NEAR(d_x, x, rr<value_type>::value * 100);
@@ -317,8 +317,8 @@ TEST_F(Idr, IdrIterationMultipleRHSIsEquivalentToRef)
     auto exec_solver = exec_idr_factory->generate(d_mtx);
     auto ref_solver = ref_idr_factory->generate(mtx);
 
-    ref_solver->apply(b.get(), x.get());
-    exec_solver->apply(d_b.get(), d_x.get());
+    ref_solver->apply(b, x);
+    exec_solver->apply(d_b, d_x);
 
     GKO_ASSERT_MTX_NEAR(d_b, b, rr<value_type>::value * 500);
     GKO_ASSERT_MTX_NEAR(d_x, x, rr<value_type>::value * 500);
@@ -345,8 +345,8 @@ TEST_F(Idr, IdrIterationWithComplexSubspaceMultipleRHSIsEquivalentToRef)
     auto exec_solver = exec_idr_factory->generate(d_mtx);
     auto ref_solver = ref_idr_factory->generate(mtx);
 
-    ref_solver->apply(b.get(), x.get());
-    exec_solver->apply(d_b.get(), d_x.get());
+    ref_solver->apply(b, x);
+    exec_solver->apply(d_b, d_x);
 
     GKO_ASSERT_MTX_NEAR(d_b, b, rr<value_type>::value * 100);
     GKO_ASSERT_MTX_NEAR(d_x, x, rr<value_type>::value * 100);

--- a/test/solver/ir_kernels.cpp
+++ b/test/solver/ir_kernels.cpp
@@ -116,8 +116,8 @@ TEST_F(Ir, ApplyIsEquivalentToRef)
     auto solver = ir_factory->generate(std::move(mtx));
     auto d_solver = d_ir_factory->generate(std::move(d_mtx));
 
-    solver->apply(lend(b), lend(x));
-    d_solver->apply(lend(d_b), lend(d_x));
+    solver->apply(b, x);
+    d_solver->apply(d_b, d_x);
 
     GKO_ASSERT_MTX_NEAR(d_x, x, r<value_type>::value);
 }
@@ -157,8 +157,8 @@ TEST_F(Ir, ApplyWithIterativeInnerSolverIsEquivalentToRef)
     auto solver = ir_factory->generate(std::move(mtx));
     auto d_solver = d_ir_factory->generate(std::move(d_mtx));
 
-    solver->apply(lend(b), lend(x));
-    d_solver->apply(lend(d_b), lend(d_x));
+    solver->apply(b, x);
+    d_solver->apply(d_b, d_x);
 
     // Note: r<value_type>::value * 150 instead of r<value_type>::value, as
     // the difference in the inner gmres iteration gets amplified by the
@@ -193,8 +193,8 @@ TEST_F(Ir, RichardsonApplyIsEquivalentToRef)
     auto solver = ir_factory->generate(std::move(mtx));
     auto d_solver = d_ir_factory->generate(std::move(d_mtx));
 
-    solver->apply(lend(b), lend(x));
-    d_solver->apply(lend(d_b), lend(d_x));
+    solver->apply(b, x);
+    d_solver->apply(d_b, d_x);
 
     GKO_ASSERT_MTX_NEAR(d_x, x, r<value_type>::value);
 }
@@ -235,8 +235,8 @@ TEST_F(Ir, RichardsonApplyWithIterativeInnerSolverIsEquivalentToRef)
     auto solver = ir_factory->generate(std::move(mtx));
     auto d_solver = d_ir_factory->generate(std::move(d_mtx));
 
-    solver->apply(lend(b), lend(x));
-    d_solver->apply(lend(d_b), lend(d_x));
+    solver->apply(b, x);
+    d_solver->apply(d_b, d_x);
 
     // Note: r<value_type>::value * 1e2 instead of r<value_type>::value, as
     // the difference in the inner gmres iteration gets amplified by the
@@ -271,8 +271,8 @@ TEST_F(Ir, ApplyWithGivenInitialGuessModeIsEquivalentToRef)
         auto solver = ir_factory->generate(mtx);
         auto d_solver = d_ir_factory->generate(d_mtx);
 
-        solver->apply(lend(b), lend(x));
-        d_solver->apply(lend(d_b), lend(d_x));
+        solver->apply(b, x);
+        d_solver->apply(d_b, d_x);
 
         GKO_ASSERT_MTX_NEAR(d_x, x, r<value_type>::value);
     }

--- a/test/solver/ir_kernels.cpp
+++ b/test/solver/ir_kernels.cpp
@@ -66,7 +66,7 @@ protected:
             std::uniform_int_distribution<>(num_cols, num_cols),
             std::normal_distribution<value_type>(-1.0, 1.0), rand_engine, ref);
         auto result = Mtx::create(ref, gko::dim<2>{num_rows, num_cols}, stride);
-        result->copy_from(tmp_mtx.get());
+        result->copy_from(tmp_mtx);
         return result;
     }
 

--- a/test/solver/lower_trs_kernels.cpp
+++ b/test/solver/lower_trs_kernels.cpp
@@ -116,8 +116,8 @@ TEST_F(LowerTrs, ApplyFullDenseMtxIsEquivalentToRef)
     auto solver = lower_trs_factory->generate(mtx);
     auto d_solver = d_lower_trs_factory->generate(dmtx);
 
-    solver->apply(b.get(), x.get());
-    d_solver->apply(db.get(), dx.get());
+    solver->apply(b, x);
+    d_solver->apply(db, dx);
 
     GKO_ASSERT_MTX_NEAR(dx, x, 1e-14);
 }
@@ -133,8 +133,8 @@ TEST_F(LowerTrs, ApplyFullDenseMtxUnitDiagIsEquivalentToRef)
     auto solver = lower_trs_factory->generate(mtx);
     auto d_solver = d_lower_trs_factory->generate(dmtx);
 
-    solver->apply(b.get(), x.get());
-    d_solver->apply(db.get(), dx.get());
+    solver->apply(b, x);
+    d_solver->apply(db, dx);
 
     GKO_ASSERT_MTX_NEAR(dx, x, 1e-14);
 }
@@ -148,8 +148,8 @@ TEST_F(LowerTrs, ApplyFullSparseMtxIsEquivalentToRef)
     auto solver = lower_trs_factory->generate(mtx);
     auto d_solver = d_lower_trs_factory->generate(dmtx);
 
-    solver->apply(b.get(), x.get());
-    d_solver->apply(db.get(), dx.get());
+    solver->apply(b, x);
+    d_solver->apply(db, dx);
 
     GKO_ASSERT_MTX_NEAR(dx, x, 1e-14);
 }
@@ -165,8 +165,8 @@ TEST_F(LowerTrs, ApplyFullSparseMtxUnitDiagIsEquivalentToRef)
     auto solver = lower_trs_factory->generate(mtx);
     auto d_solver = d_lower_trs_factory->generate(dmtx);
 
-    solver->apply(b.get(), x.get());
-    d_solver->apply(db.get(), dx.get());
+    solver->apply(b, x);
+    d_solver->apply(db, dx);
 
     GKO_ASSERT_MTX_NEAR(dx, x, 1e-14);
 }
@@ -180,8 +180,8 @@ TEST_F(LowerTrs, ApplyTriangularDenseMtxIsEquivalentToRef)
     auto solver = lower_trs_factory->generate(mtx_l);
     auto d_solver = d_lower_trs_factory->generate(dmtx_l);
 
-    solver->apply(b.get(), x.get());
-    d_solver->apply(db.get(), dx.get());
+    solver->apply(b, x);
+    d_solver->apply(db, dx);
 
     GKO_ASSERT_MTX_NEAR(dx, x, 1e-14);
 }
@@ -197,8 +197,8 @@ TEST_F(LowerTrs, ApplyTriangularDenseMtxUnitDiagIsEquivalentToRef)
     auto solver = lower_trs_factory->generate(mtx_l);
     auto d_solver = d_lower_trs_factory->generate(dmtx_l);
 
-    solver->apply(b.get(), x.get());
-    d_solver->apply(db.get(), dx.get());
+    solver->apply(b, x);
+    d_solver->apply(db, dx);
 
     GKO_ASSERT_MTX_NEAR(dx, x, 1e-14);
 }
@@ -212,8 +212,8 @@ TEST_F(LowerTrs, ApplyTriangularSparseMtxIsEquivalentToRef)
     auto solver = lower_trs_factory->generate(mtx_l);
     auto d_solver = d_lower_trs_factory->generate(dmtx_l);
 
-    solver->apply(b.get(), x.get());
-    d_solver->apply(db.get(), dx.get());
+    solver->apply(b, x);
+    d_solver->apply(db, dx);
 
     GKO_ASSERT_MTX_NEAR(dx, x, 1e-14);
 }
@@ -229,8 +229,8 @@ TEST_F(LowerTrs, ApplyTriangularSparseMtxUnitDiagIsEquivalentToRef)
     auto solver = lower_trs_factory->generate(mtx_l);
     auto d_solver = d_lower_trs_factory->generate(dmtx_l);
 
-    solver->apply(b.get(), x.get());
-    d_solver->apply(db.get(), dx.get());
+    solver->apply(b, x);
+    d_solver->apply(db, dx);
 
     GKO_ASSERT_MTX_NEAR(dx, x, 1e-14);
 }
@@ -244,8 +244,8 @@ TEST_F(LowerTrs, ApplyFullDenseMtxMultipleRhsIsEquivalentToRef)
     auto solver = lower_trs_factory->generate(mtx);
     auto d_solver = d_lower_trs_factory->generate(dmtx);
 
-    solver->apply(b.get(), x.get());
-    d_solver->apply(db.get(), dx.get());
+    solver->apply(b, x);
+    d_solver->apply(db, dx);
 
     GKO_ASSERT_MTX_NEAR(dx, x, 1e-14);
 }
@@ -261,8 +261,8 @@ TEST_F(LowerTrs, ApplyFullDenseMtxUnitDiagMultipleRhsIsEquivalentToRef)
     auto solver = lower_trs_factory->generate(mtx);
     auto d_solver = d_lower_trs_factory->generate(dmtx);
 
-    solver->apply(b.get(), x.get());
-    d_solver->apply(db.get(), dx.get());
+    solver->apply(b, x);
+    d_solver->apply(db, dx);
 
     GKO_ASSERT_MTX_NEAR(dx, x, 1e-14);
 }
@@ -276,8 +276,8 @@ TEST_F(LowerTrs, ApplyFullSparseMtxMultipleRhsIsEquivalentToRef)
     auto solver = lower_trs_factory->generate(mtx);
     auto d_solver = d_lower_trs_factory->generate(dmtx);
 
-    solver->apply(b.get(), x.get());
-    d_solver->apply(db.get(), dx.get());
+    solver->apply(b, x);
+    d_solver->apply(db, dx);
 
     GKO_ASSERT_MTX_NEAR(dx, x, 1e-14);
 }
@@ -293,8 +293,8 @@ TEST_F(LowerTrs, ApplyFullSparseMtxUnitDiagMultipleRhsIsEquivalentToRef)
     auto solver = lower_trs_factory->generate(mtx);
     auto d_solver = d_lower_trs_factory->generate(dmtx);
 
-    solver->apply(b.get(), x.get());
-    d_solver->apply(db.get(), dx.get());
+    solver->apply(b, x);
+    d_solver->apply(db, dx);
 
     GKO_ASSERT_MTX_NEAR(dx, x, 1e-14);
 }
@@ -308,8 +308,8 @@ TEST_F(LowerTrs, ApplyTriangularDenseMtxMultipleRhsIsEquivalentToRef)
     auto solver = lower_trs_factory->generate(mtx_l);
     auto d_solver = d_lower_trs_factory->generate(dmtx_l);
 
-    solver->apply(b.get(), x.get());
-    d_solver->apply(db.get(), dx.get());
+    solver->apply(b, x);
+    d_solver->apply(db, dx);
 
     GKO_ASSERT_MTX_NEAR(dx, x, 1e-14);
 }
@@ -325,8 +325,8 @@ TEST_F(LowerTrs, ApplyTriangularDenseMtxUnitDiagMultipleRhsIsEquivalentToRef)
     auto solver = lower_trs_factory->generate(mtx_l);
     auto d_solver = d_lower_trs_factory->generate(dmtx_l);
 
-    solver->apply(b.get(), x.get());
-    d_solver->apply(db.get(), dx.get());
+    solver->apply(b, x);
+    d_solver->apply(db, dx);
 
     GKO_ASSERT_MTX_NEAR(dx, x, 1e-14);
 }
@@ -340,8 +340,8 @@ TEST_F(LowerTrs, ApplyTriangularSparseMtxMultipleRhsIsEquivalentToRef)
     auto solver = lower_trs_factory->generate(mtx_l);
     auto d_solver = d_lower_trs_factory->generate(dmtx_l);
 
-    solver->apply(b.get(), x.get());
-    d_solver->apply(db.get(), dx.get());
+    solver->apply(b, x);
+    d_solver->apply(db, dx);
 
     GKO_ASSERT_MTX_NEAR(dx, x, 1e-14);
 }
@@ -358,8 +358,8 @@ TEST_F(LowerTrs, ApplyTriangularSparseMtxUnitDiagMultipleRhsIsEquivalentToRef)
     auto solver = lower_trs_factory->generate(mtx_l);
     auto d_solver = d_lower_trs_factory->generate(dmtx_l);
 
-    solver->apply(b.get(), x.get());
-    d_solver->apply(db.get(), dx.get());
+    solver->apply(b, x);
+    d_solver->apply(db, dx);
 
     GKO_ASSERT_MTX_NEAR(dx, x, 1e-14);
 }
@@ -377,8 +377,8 @@ TEST_F(LowerTrs, ClassicalApplyFullDenseMtxIsEquivalentToRef)
     auto solver = lower_trs_factory->generate(mtx);
     auto d_solver = d_lower_trs_factory->generate(dmtx);
 
-    solver->apply(b.get(), x.get());
-    d_solver->apply(db.get(), dx.get());
+    solver->apply(b, x);
+    d_solver->apply(db, dx);
 
     GKO_ASSERT_MTX_NEAR(dx, x, 1e-14);
 }
@@ -395,8 +395,8 @@ TEST_F(LowerTrs, ClassicalApplyFullDenseMtxUnitDiagIsEquivalentToRef)
     auto solver = lower_trs_factory->generate(mtx);
     auto d_solver = d_lower_trs_factory->generate(dmtx);
 
-    solver->apply(b.get(), x.get());
-    d_solver->apply(db.get(), dx.get());
+    solver->apply(b, x);
+    d_solver->apply(db, dx);
 
     GKO_ASSERT_MTX_NEAR(dx, x, 1e-14);
 }
@@ -411,8 +411,8 @@ TEST_F(LowerTrs, ClassicalApplyFullSparseMtxIsEquivalentToRef)
     auto solver = lower_trs_factory->generate(mtx);
     auto d_solver = d_lower_trs_factory->generate(dmtx);
 
-    solver->apply(b.get(), x.get());
-    d_solver->apply(db.get(), dx.get());
+    solver->apply(b, x);
+    d_solver->apply(db, dx);
 
     GKO_ASSERT_MTX_NEAR(dx, x, 1e-14);
 }
@@ -429,8 +429,8 @@ TEST_F(LowerTrs, ClassicalApplyFullSparseMtxUnitDiagIsEquivalentToRef)
     auto solver = lower_trs_factory->generate(mtx);
     auto d_solver = d_lower_trs_factory->generate(dmtx);
 
-    solver->apply(b.get(), x.get());
-    d_solver->apply(db.get(), dx.get());
+    solver->apply(b, x);
+    d_solver->apply(db, dx);
 
     GKO_ASSERT_MTX_NEAR(dx, x, 1e-14);
 }
@@ -445,8 +445,8 @@ TEST_F(LowerTrs, ClassicalApplyTriangularDenseMtxIsEquivalentToRef)
     auto solver = lower_trs_factory->generate(mtx_l);
     auto d_solver = d_lower_trs_factory->generate(dmtx_l);
 
-    solver->apply(b.get(), x.get());
-    d_solver->apply(db.get(), dx.get());
+    solver->apply(b, x);
+    d_solver->apply(db, dx);
 
     GKO_ASSERT_MTX_NEAR(dx, x, 1e-14);
 }
@@ -463,8 +463,8 @@ TEST_F(LowerTrs, ClassicalApplyTriangularDenseMtxUnitDiagIsEquivalentToRef)
     auto solver = lower_trs_factory->generate(mtx_l);
     auto d_solver = d_lower_trs_factory->generate(dmtx_l);
 
-    solver->apply(b.get(), x.get());
-    d_solver->apply(db.get(), dx.get());
+    solver->apply(b, x);
+    d_solver->apply(db, dx);
 
     GKO_ASSERT_MTX_NEAR(dx, x, 1e-14);
 }
@@ -479,8 +479,8 @@ TEST_F(LowerTrs, ClassicalApplyTriangularSparseMtxIsEquivalentToRef)
     auto solver = lower_trs_factory->generate(mtx_l);
     auto d_solver = d_lower_trs_factory->generate(dmtx_l);
 
-    solver->apply(b.get(), x.get());
-    d_solver->apply(db.get(), dx.get());
+    solver->apply(b, x);
+    d_solver->apply(db, dx);
 
     GKO_ASSERT_MTX_NEAR(dx, x, 1e-14);
 }
@@ -497,8 +497,8 @@ TEST_F(LowerTrs, ClassicalApplyTriangularSparseMtxUnitDiagIsEquivalentToRef)
     auto solver = lower_trs_factory->generate(mtx_l);
     auto d_solver = d_lower_trs_factory->generate(dmtx_l);
 
-    solver->apply(b.get(), x.get());
-    d_solver->apply(db.get(), dx.get());
+    solver->apply(b, x);
+    d_solver->apply(db, dx);
 
     GKO_ASSERT_MTX_NEAR(dx, x, 1e-14);
 }
@@ -513,8 +513,8 @@ TEST_F(LowerTrs, ClassicalApplyFullDenseMtxMultipleRhsIsEquivalentToRef)
     auto solver = lower_trs_factory->generate(mtx);
     auto d_solver = d_lower_trs_factory->generate(dmtx);
 
-    solver->apply(b.get(), x.get());
-    d_solver->apply(db.get(), dx.get());
+    solver->apply(b, x);
+    d_solver->apply(db, dx);
 
     GKO_ASSERT_MTX_NEAR(dx, x, 1e-14);
 }
@@ -531,8 +531,8 @@ TEST_F(LowerTrs, ClassicalApplyFullDenseMtxUnitDiagMultipleRhsIsEquivalentToRef)
     auto solver = lower_trs_factory->generate(mtx);
     auto d_solver = d_lower_trs_factory->generate(dmtx);
 
-    solver->apply(b.get(), x.get());
-    d_solver->apply(db.get(), dx.get());
+    solver->apply(b, x);
+    d_solver->apply(db, dx);
 
     GKO_ASSERT_MTX_NEAR(dx, x, 1e-14);
 }
@@ -547,8 +547,8 @@ TEST_F(LowerTrs, ClassicalApplyFullSparseMtxMultipleRhsIsEquivalentToRef)
     auto solver = lower_trs_factory->generate(mtx);
     auto d_solver = d_lower_trs_factory->generate(dmtx);
 
-    solver->apply(b.get(), x.get());
-    d_solver->apply(db.get(), dx.get());
+    solver->apply(b, x);
+    d_solver->apply(db, dx);
 
     GKO_ASSERT_MTX_NEAR(dx, x, 1e-14);
 }
@@ -566,8 +566,8 @@ TEST_F(LowerTrs,
     auto solver = lower_trs_factory->generate(mtx);
     auto d_solver = d_lower_trs_factory->generate(dmtx);
 
-    solver->apply(b.get(), x.get());
-    d_solver->apply(db.get(), dx.get());
+    solver->apply(b, x);
+    d_solver->apply(db, dx);
 
     GKO_ASSERT_MTX_NEAR(dx, x, 1e-14);
 }
@@ -582,8 +582,8 @@ TEST_F(LowerTrs, ClassicalApplyTriangularDenseMtxMultipleRhsIsEquivalentToRef)
     auto solver = lower_trs_factory->generate(mtx_l);
     auto d_solver = d_lower_trs_factory->generate(dmtx_l);
 
-    solver->apply(b.get(), x.get());
-    d_solver->apply(db.get(), dx.get());
+    solver->apply(b, x);
+    d_solver->apply(db, dx);
 
     GKO_ASSERT_MTX_NEAR(dx, x, 1e-14);
 }
@@ -601,8 +601,8 @@ TEST_F(LowerTrs,
     auto solver = lower_trs_factory->generate(mtx_l);
     auto d_solver = d_lower_trs_factory->generate(dmtx_l);
 
-    solver->apply(b.get(), x.get());
-    d_solver->apply(db.get(), dx.get());
+    solver->apply(b, x);
+    d_solver->apply(db, dx);
 
     GKO_ASSERT_MTX_NEAR(dx, x, 1e-14);
 }
@@ -617,8 +617,8 @@ TEST_F(LowerTrs, ClassicalApplyTriangularSparseMtxMultipleRhsIsEquivalentToRef)
     auto solver = lower_trs_factory->generate(mtx_l);
     auto d_solver = d_lower_trs_factory->generate(dmtx_l);
 
-    solver->apply(b.get(), x.get());
-    d_solver->apply(db.get(), dx.get());
+    solver->apply(b, x);
+    d_solver->apply(db, dx);
 
     GKO_ASSERT_MTX_NEAR(dx, x, 1e-14);
 }
@@ -637,8 +637,8 @@ TEST_F(LowerTrs,
     auto solver = lower_trs_factory->generate(mtx_l);
     auto d_solver = d_lower_trs_factory->generate(dmtx_l);
 
-    solver->apply(b.get(), x.get());
-    d_solver->apply(db.get(), dx.get());
+    solver->apply(b, x);
+    d_solver->apply(db, dx);
 
     GKO_ASSERT_MTX_NEAR(dx, x, 1e-14);
 }

--- a/test/solver/solver.cpp
+++ b/test/solver/solver.cpp
@@ -116,13 +116,13 @@ struct SimpleSolverTest {
     }
 
     static const gko::LinOp* get_preconditioner(
-        gko::pointer_param<const solver_type> solver)
+        gko::ptr_param<const solver_type> solver)
     {
         return solver->get_preconditioner().get();
     }
 
     static const gko::stop::CriterionFactory* get_stop_criterion_factory(
-        gko::pointer_param<const solver_type> solver)
+        gko::ptr_param<const solver_type> solver)
     {
         return solver->get_stop_criterion_factory().get();
     }
@@ -209,7 +209,7 @@ struct Ir : SimpleSolverTest<gko::solver::Ir<solver_value_type>> {
     }
 
     static const gko::LinOp* get_preconditioner(
-        gko::pointer_param<const solver_type> solver)
+        gko::ptr_param<const solver_type> solver)
     {
         return solver->get_solver().get();
     }
@@ -342,13 +342,13 @@ struct LowerTrs : SimpleSolverTest<gko::solver::LowerTrs<solver_value_type>> {
     }
 
     static const gko::LinOp* get_preconditioner(
-        gko::pointer_param<const solver_type> solver)
+        gko::ptr_param<const solver_type> solver)
     {
         return nullptr;
     }
 
     static const gko::stop::CriterionFactory* get_stop_criterion_factory(
-        gko::pointer_param<const solver_type> solver)
+        gko::ptr_param<const solver_type> solver)
     {
         return nullptr;
     }
@@ -393,13 +393,13 @@ struct UpperTrs : SimpleSolverTest<gko::solver::UpperTrs<solver_value_type>> {
     }
 
     static const gko::LinOp* get_preconditioner(
-        gko::pointer_param<const solver_type> solver)
+        gko::ptr_param<const solver_type> solver)
     {
         return nullptr;
     }
 
     static const gko::stop::CriterionFactory* get_stop_criterion_factory(
-        gko::pointer_param<const solver_type> solver)
+        gko::ptr_param<const solver_type> solver)
     {
         return nullptr;
     }
@@ -871,7 +871,7 @@ protected:
     }
 
 
-    void assert_empty_state(gko::pointer_param<const SolverType> solver,
+    void assert_empty_state(gko::ptr_param<const SolverType> solver,
                             std::shared_ptr<const gko::Executor> expected_exec)
     {
         ASSERT_FALSE(solver->get_size());

--- a/test/solver/upper_trs_kernels.cpp
+++ b/test/solver/upper_trs_kernels.cpp
@@ -116,8 +116,8 @@ TEST_F(UpperTrs, ApplyFullDenseMtxIsEquivalentToRef)
     auto solver = upper_trs_factory->generate(mtx);
     auto d_solver = d_upper_trs_factory->generate(dmtx);
 
-    solver->apply(b.get(), x.get());
-    d_solver->apply(db.get(), dx.get());
+    solver->apply(b, x);
+    d_solver->apply(db, dx);
 
     GKO_ASSERT_MTX_NEAR(dx, x, 1e-14);
 }
@@ -133,8 +133,8 @@ TEST_F(UpperTrs, ApplyFullDenseMtxUnitDiagIsEquivalentToRef)
     auto solver = upper_trs_factory->generate(mtx);
     auto d_solver = d_upper_trs_factory->generate(dmtx);
 
-    solver->apply(b.get(), x.get());
-    d_solver->apply(db.get(), dx.get());
+    solver->apply(b, x);
+    d_solver->apply(db, dx);
 
     GKO_ASSERT_MTX_NEAR(dx, x, 1e-14);
 }
@@ -148,8 +148,8 @@ TEST_F(UpperTrs, ApplyFullSparseMtxIsEquivalentToRef)
     auto solver = upper_trs_factory->generate(mtx);
     auto d_solver = d_upper_trs_factory->generate(dmtx);
 
-    solver->apply(b.get(), x.get());
-    d_solver->apply(db.get(), dx.get());
+    solver->apply(b, x);
+    d_solver->apply(db, dx);
 
     GKO_ASSERT_MTX_NEAR(dx, x, 1e-14);
 }
@@ -165,8 +165,8 @@ TEST_F(UpperTrs, ApplyFullSparseMtxUnitDiagIsEquivalentToRef)
     auto solver = upper_trs_factory->generate(mtx);
     auto d_solver = d_upper_trs_factory->generate(dmtx);
 
-    solver->apply(b.get(), x.get());
-    d_solver->apply(db.get(), dx.get());
+    solver->apply(b, x);
+    d_solver->apply(db, dx);
 
     GKO_ASSERT_MTX_NEAR(dx, x, 1e-14);
 }
@@ -180,8 +180,8 @@ TEST_F(UpperTrs, ApplyTriangularDenseMtxIsEquivalentToRef)
     auto solver = upper_trs_factory->generate(mtx_u);
     auto d_solver = d_upper_trs_factory->generate(dmtx_u);
 
-    solver->apply(b.get(), x.get());
-    d_solver->apply(db.get(), dx.get());
+    solver->apply(b, x);
+    d_solver->apply(db, dx);
 
     GKO_ASSERT_MTX_NEAR(dx, x, 1e-14);
 }
@@ -197,8 +197,8 @@ TEST_F(UpperTrs, ApplyTriangularDenseMtxUnitDiagIsEquivalentToRef)
     auto solver = upper_trs_factory->generate(mtx_u);
     auto d_solver = d_upper_trs_factory->generate(dmtx_u);
 
-    solver->apply(b.get(), x.get());
-    d_solver->apply(db.get(), dx.get());
+    solver->apply(b, x);
+    d_solver->apply(db, dx);
 
     GKO_ASSERT_MTX_NEAR(dx, x, 1e-14);
 }
@@ -212,8 +212,8 @@ TEST_F(UpperTrs, ApplyTriangularSparseMtxIsEquivalentToRef)
     auto solver = upper_trs_factory->generate(mtx_u);
     auto d_solver = d_upper_trs_factory->generate(dmtx_u);
 
-    solver->apply(b.get(), x.get());
-    d_solver->apply(db.get(), dx.get());
+    solver->apply(b, x);
+    d_solver->apply(db, dx);
 
     GKO_ASSERT_MTX_NEAR(dx, x, 1e-14);
 }
@@ -229,8 +229,8 @@ TEST_F(UpperTrs, ApplyTriangularSparseMtxUnitDiagIsEquivalentToRef)
     auto solver = upper_trs_factory->generate(mtx_u);
     auto d_solver = d_upper_trs_factory->generate(dmtx_u);
 
-    solver->apply(b.get(), x.get());
-    d_solver->apply(db.get(), dx.get());
+    solver->apply(b, x);
+    d_solver->apply(db, dx);
 
     GKO_ASSERT_MTX_NEAR(dx, x, 1e-14);
 }
@@ -244,8 +244,8 @@ TEST_F(UpperTrs, ApplyFullDenseMtxMultipleRhsIsEquivalentToRef)
     auto solver = upper_trs_factory->generate(mtx);
     auto d_solver = d_upper_trs_factory->generate(dmtx);
 
-    solver->apply(b.get(), x.get());
-    d_solver->apply(db.get(), dx.get());
+    solver->apply(b, x);
+    d_solver->apply(db, dx);
 
     GKO_ASSERT_MTX_NEAR(dx, x, 1e-14);
 }
@@ -261,8 +261,8 @@ TEST_F(UpperTrs, ApplyFullDenseMtxUnitDiagMultipleRhsIsEquivalentToRef)
     auto solver = upper_trs_factory->generate(mtx);
     auto d_solver = d_upper_trs_factory->generate(dmtx);
 
-    solver->apply(b.get(), x.get());
-    d_solver->apply(db.get(), dx.get());
+    solver->apply(b, x);
+    d_solver->apply(db, dx);
 
     GKO_ASSERT_MTX_NEAR(dx, x, 1e-14);
 }
@@ -276,8 +276,8 @@ TEST_F(UpperTrs, ApplyFullSparseMtxMultipleRhsIsEquivalentToRef)
     auto solver = upper_trs_factory->generate(mtx);
     auto d_solver = d_upper_trs_factory->generate(dmtx);
 
-    solver->apply(b.get(), x.get());
-    d_solver->apply(db.get(), dx.get());
+    solver->apply(b, x);
+    d_solver->apply(db, dx);
 
     GKO_ASSERT_MTX_NEAR(dx, x, 1e-14);
 }
@@ -293,8 +293,8 @@ TEST_F(UpperTrs, ApplyFullSparseMtxUnitDiagMultipleRhsIsEquivalentToRef)
     auto solver = upper_trs_factory->generate(mtx);
     auto d_solver = d_upper_trs_factory->generate(dmtx);
 
-    solver->apply(b.get(), x.get());
-    d_solver->apply(db.get(), dx.get());
+    solver->apply(b, x);
+    d_solver->apply(db, dx);
 
     GKO_ASSERT_MTX_NEAR(dx, x, 1e-14);
 }
@@ -308,8 +308,8 @@ TEST_F(UpperTrs, ApplyTriangularDenseMtxMultipleRhsIsEquivalentToRef)
     auto solver = upper_trs_factory->generate(mtx_u);
     auto d_solver = d_upper_trs_factory->generate(dmtx_u);
 
-    solver->apply(b.get(), x.get());
-    d_solver->apply(db.get(), dx.get());
+    solver->apply(b, x);
+    d_solver->apply(db, dx);
 
     GKO_ASSERT_MTX_NEAR(dx, x, 1e-14);
 }
@@ -325,8 +325,8 @@ TEST_F(UpperTrs, ApplyTriangularDenseMtxUnitDiagMultipleRhsIsEquivalentToRef)
     auto solver = upper_trs_factory->generate(mtx_u);
     auto d_solver = d_upper_trs_factory->generate(dmtx_u);
 
-    solver->apply(b.get(), x.get());
-    d_solver->apply(db.get(), dx.get());
+    solver->apply(b, x);
+    d_solver->apply(db, dx);
 
     GKO_ASSERT_MTX_NEAR(dx, x, 1e-14);
 }
@@ -340,8 +340,8 @@ TEST_F(UpperTrs, ApplyTriangularSparseMtxMultipleRhsIsEquivalentToRef)
     auto solver = upper_trs_factory->generate(mtx_u);
     auto d_solver = d_upper_trs_factory->generate(dmtx_u);
 
-    solver->apply(b.get(), x.get());
-    d_solver->apply(db.get(), dx.get());
+    solver->apply(b, x);
+    d_solver->apply(db, dx);
 
     GKO_ASSERT_MTX_NEAR(dx, x, 1e-14);
 }
@@ -358,8 +358,8 @@ TEST_F(UpperTrs, ApplyTriangularSparseMtxUnitDiagMultipleRhsIsEquivalentToRef)
     auto solver = upper_trs_factory->generate(mtx_u);
     auto d_solver = d_upper_trs_factory->generate(dmtx_u);
 
-    solver->apply(b.get(), x.get());
-    d_solver->apply(db.get(), dx.get());
+    solver->apply(b, x);
+    d_solver->apply(db, dx);
 
     GKO_ASSERT_MTX_NEAR(dx, x, 1e-14);
 }
@@ -377,8 +377,8 @@ TEST_F(UpperTrs, ClassicalApplyFullDenseMtxIsEquivalentToRef)
     auto solver = upper_trs_factory->generate(mtx);
     auto d_solver = d_upper_trs_factory->generate(dmtx);
 
-    solver->apply(b.get(), x.get());
-    d_solver->apply(db.get(), dx.get());
+    solver->apply(b, x);
+    d_solver->apply(db, dx);
 
     GKO_ASSERT_MTX_NEAR(dx, x, 1e-14);
 }
@@ -395,8 +395,8 @@ TEST_F(UpperTrs, ClassicalApplyFullDenseMtxUnitDiagIsEquivalentToRef)
     auto solver = upper_trs_factory->generate(mtx);
     auto d_solver = d_upper_trs_factory->generate(dmtx);
 
-    solver->apply(b.get(), x.get());
-    d_solver->apply(db.get(), dx.get());
+    solver->apply(b, x);
+    d_solver->apply(db, dx);
 
     GKO_ASSERT_MTX_NEAR(dx, x, 1e-14);
 }
@@ -411,8 +411,8 @@ TEST_F(UpperTrs, ClassicalApplyFullSparseMtxIsEquivalentToRef)
     auto solver = upper_trs_factory->generate(mtx);
     auto d_solver = d_upper_trs_factory->generate(dmtx);
 
-    solver->apply(b.get(), x.get());
-    d_solver->apply(db.get(), dx.get());
+    solver->apply(b, x);
+    d_solver->apply(db, dx);
 
     GKO_ASSERT_MTX_NEAR(dx, x, 1e-14);
 }
@@ -429,8 +429,8 @@ TEST_F(UpperTrs, ClassicalApplyFullSparseMtxUnitDiagIsEquivalentToRef)
     auto solver = upper_trs_factory->generate(mtx);
     auto d_solver = d_upper_trs_factory->generate(dmtx);
 
-    solver->apply(b.get(), x.get());
-    d_solver->apply(db.get(), dx.get());
+    solver->apply(b, x);
+    d_solver->apply(db, dx);
 
     GKO_ASSERT_MTX_NEAR(dx, x, 1e-14);
 }
@@ -445,8 +445,8 @@ TEST_F(UpperTrs, ClassicalApplyTriangularDenseMtxIsEquivalentToRef)
     auto solver = upper_trs_factory->generate(mtx_u);
     auto d_solver = d_upper_trs_factory->generate(dmtx_u);
 
-    solver->apply(b.get(), x.get());
-    d_solver->apply(db.get(), dx.get());
+    solver->apply(b, x);
+    d_solver->apply(db, dx);
 
     GKO_ASSERT_MTX_NEAR(dx, x, 1e-14);
 }
@@ -463,8 +463,8 @@ TEST_F(UpperTrs, ClassicalApplyTriangularDenseMtxUnitDiagIsEquivalentToRef)
     auto solver = upper_trs_factory->generate(mtx_u);
     auto d_solver = d_upper_trs_factory->generate(dmtx_u);
 
-    solver->apply(b.get(), x.get());
-    d_solver->apply(db.get(), dx.get());
+    solver->apply(b, x);
+    d_solver->apply(db, dx);
 
     GKO_ASSERT_MTX_NEAR(dx, x, 1e-14);
 }
@@ -479,8 +479,8 @@ TEST_F(UpperTrs, ClassicalApplyTriangularSparseMtxIsEquivalentToRef)
     auto solver = upper_trs_factory->generate(mtx_u);
     auto d_solver = d_upper_trs_factory->generate(dmtx_u);
 
-    solver->apply(b.get(), x.get());
-    d_solver->apply(db.get(), dx.get());
+    solver->apply(b, x);
+    d_solver->apply(db, dx);
 
     GKO_ASSERT_MTX_NEAR(dx, x, 1e-14);
 }
@@ -497,8 +497,8 @@ TEST_F(UpperTrs, ClassicalApplyTriangularSparseMtxUnitDiagIsEquivalentToRef)
     auto solver = upper_trs_factory->generate(mtx_u);
     auto d_solver = d_upper_trs_factory->generate(dmtx_u);
 
-    solver->apply(b.get(), x.get());
-    d_solver->apply(db.get(), dx.get());
+    solver->apply(b, x);
+    d_solver->apply(db, dx);
 
     GKO_ASSERT_MTX_NEAR(dx, x, 1e-14);
 }
@@ -513,8 +513,8 @@ TEST_F(UpperTrs, ClassicalApplyFullDenseMtxMultipleRhsIsEquivalentToRef)
     auto solver = upper_trs_factory->generate(mtx);
     auto d_solver = d_upper_trs_factory->generate(dmtx);
 
-    solver->apply(b.get(), x.get());
-    d_solver->apply(db.get(), dx.get());
+    solver->apply(b, x);
+    d_solver->apply(db, dx);
 
     GKO_ASSERT_MTX_NEAR(dx, x, 1e-14);
 }
@@ -531,8 +531,8 @@ TEST_F(UpperTrs, ClassicalApplyFullDenseMtxUnitDiagMultipleRhsIsEquivalentToRef)
     auto solver = upper_trs_factory->generate(mtx);
     auto d_solver = d_upper_trs_factory->generate(dmtx);
 
-    solver->apply(b.get(), x.get());
-    d_solver->apply(db.get(), dx.get());
+    solver->apply(b, x);
+    d_solver->apply(db, dx);
 
     GKO_ASSERT_MTX_NEAR(dx, x, 1e-14);
 }
@@ -547,8 +547,8 @@ TEST_F(UpperTrs, ClassicalApplyFullSparseMtxMultipleRhsIsEquivalentToRef)
     auto solver = upper_trs_factory->generate(mtx);
     auto d_solver = d_upper_trs_factory->generate(dmtx);
 
-    solver->apply(b.get(), x.get());
-    d_solver->apply(db.get(), dx.get());
+    solver->apply(b, x);
+    d_solver->apply(db, dx);
 
     GKO_ASSERT_MTX_NEAR(dx, x, 1e-14);
 }
@@ -566,8 +566,8 @@ TEST_F(UpperTrs,
     auto solver = upper_trs_factory->generate(mtx);
     auto d_solver = d_upper_trs_factory->generate(dmtx);
 
-    solver->apply(b.get(), x.get());
-    d_solver->apply(db.get(), dx.get());
+    solver->apply(b, x);
+    d_solver->apply(db, dx);
 
     GKO_ASSERT_MTX_NEAR(dx, x, 1e-14);
 }
@@ -582,8 +582,8 @@ TEST_F(UpperTrs, ClassicalApplyTriangularDenseMtxMultipleRhsIsEquivalentToRef)
     auto solver = upper_trs_factory->generate(mtx_u);
     auto d_solver = d_upper_trs_factory->generate(dmtx_u);
 
-    solver->apply(b.get(), x.get());
-    d_solver->apply(db.get(), dx.get());
+    solver->apply(b, x);
+    d_solver->apply(db, dx);
 
     GKO_ASSERT_MTX_NEAR(dx, x, 1e-14);
 }
@@ -601,8 +601,8 @@ TEST_F(UpperTrs,
     auto solver = upper_trs_factory->generate(mtx_u);
     auto d_solver = d_upper_trs_factory->generate(dmtx_u);
 
-    solver->apply(b.get(), x.get());
-    d_solver->apply(db.get(), dx.get());
+    solver->apply(b, x);
+    d_solver->apply(db, dx);
 
     GKO_ASSERT_MTX_NEAR(dx, x, 1e-14);
 }
@@ -617,8 +617,8 @@ TEST_F(UpperTrs, ClassicalApplyTriangularSparseMtxMultipleRhsIsEquivalentToRef)
     auto solver = upper_trs_factory->generate(mtx_u);
     auto d_solver = d_upper_trs_factory->generate(dmtx_u);
 
-    solver->apply(b.get(), x.get());
-    d_solver->apply(db.get(), dx.get());
+    solver->apply(b, x);
+    d_solver->apply(db, dx);
 
     GKO_ASSERT_MTX_NEAR(dx, x, 1e-14);
 }
@@ -637,8 +637,8 @@ TEST_F(UpperTrs,
     auto solver = upper_trs_factory->generate(mtx_u);
     auto d_solver = d_upper_trs_factory->generate(dmtx_u);
 
-    solver->apply(b.get(), x.get());
-    d_solver->apply(db.get(), dx.get());
+    solver->apply(b, x);
+    d_solver->apply(db, dx);
 
     GKO_ASSERT_MTX_NEAR(dx, x, 1e-14);
 }

--- a/test/stop/residual_norm_kernels.cpp
+++ b/test/stop/residual_norm_kernels.cpp
@@ -104,33 +104,27 @@ TYPED_TEST(ResidualNorm, WaitsTillResidualGoal)
     {
         auto res_norm = gko::initialize<NormVector>({10.0}, this->exec);
         auto rhs_norm = gko::initialize<NormVector>({100.0}, this->exec);
-        gko::as<Mtx>(rhs)->compute_norm2(rhs_norm.get());
+        gko::as<Mtx>(rhs)->compute_norm2(rhs_norm);
         constexpr gko::uint8 RelativeStoppingId{1};
         bool one_changed{};
         gko::array<gko::stopping_status> stop_status(this->ref, 1);
         stop_status.get_data()[0].reset();
         stop_status.set_executor(this->exec);
 
-        ASSERT_FALSE(
-            criterion->update()
-                .residual_norm(res_norm.get())
-                .check(RelativeStoppingId, true, &stop_status, &one_changed));
+        ASSERT_FALSE(criterion->update().residual_norm(res_norm).check(
+            RelativeStoppingId, true, &stop_status, &one_changed));
 
         write(res_norm, 0, 0, r<TypeParam>::value * 1.1 * read(res_norm, 0, 0));
-        ASSERT_FALSE(
-            criterion->update()
-                .residual_norm(res_norm.get())
-                .check(RelativeStoppingId, true, &stop_status, &one_changed));
+        ASSERT_FALSE(criterion->update().residual_norm(res_norm).check(
+            RelativeStoppingId, true, &stop_status, &one_changed));
         stop_status.set_executor(this->ref);
         ASSERT_FALSE(stop_status.get_data()[0].has_converged());
         ASSERT_FALSE(one_changed);
         stop_status.set_executor(this->exec);
 
         write(res_norm, 0, 0, r<TypeParam>::value * 0.9 * read(res_norm, 0, 0));
-        ASSERT_TRUE(
-            criterion->update()
-                .residual_norm(res_norm.get())
-                .check(RelativeStoppingId, true, &stop_status, &one_changed));
+        ASSERT_TRUE(criterion->update().residual_norm(res_norm).check(
+            RelativeStoppingId, true, &stop_status, &one_changed));
         stop_status.set_executor(this->ref);
         ASSERT_TRUE(stop_status.get_data()[0].has_converged());
         ASSERT_TRUE(one_changed);
@@ -144,26 +138,20 @@ TYPED_TEST(ResidualNorm, WaitsTillResidualGoal)
         stop_status.get_data()[0].reset();
         stop_status.set_executor(this->exec);
 
-        ASSERT_FALSE(
-            rel_criterion->update()
-                .residual_norm(res_norm.get())
-                .check(RelativeStoppingId, true, &stop_status, &one_changed));
+        ASSERT_FALSE(rel_criterion->update().residual_norm(res_norm).check(
+            RelativeStoppingId, true, &stop_status, &one_changed));
 
         write(res_norm, 0, 0, r<TypeParam>::value * 1.1 * read(res_norm, 0, 0));
-        ASSERT_FALSE(
-            rel_criterion->update()
-                .residual_norm(res_norm.get())
-                .check(RelativeStoppingId, true, &stop_status, &one_changed));
+        ASSERT_FALSE(rel_criterion->update().residual_norm(res_norm).check(
+            RelativeStoppingId, true, &stop_status, &one_changed));
         stop_status.set_executor(this->ref);
         ASSERT_FALSE(stop_status.get_data()[0].has_converged());
         ASSERT_FALSE(one_changed);
         stop_status.set_executor(this->exec);
 
         write(res_norm, 0, 0, r<TypeParam>::value * 0.9 * read(res_norm, 0, 0));
-        ASSERT_TRUE(
-            rel_criterion->update()
-                .residual_norm(res_norm.get())
-                .check(RelativeStoppingId, true, &stop_status, &one_changed));
+        ASSERT_TRUE(rel_criterion->update().residual_norm(res_norm).check(
+            RelativeStoppingId, true, &stop_status, &one_changed));
         stop_status.set_executor(this->ref);
         ASSERT_TRUE(stop_status.get_data()[0].has_converged());
         ASSERT_TRUE(one_changed);
@@ -177,26 +165,20 @@ TYPED_TEST(ResidualNorm, WaitsTillResidualGoal)
         stop_status.get_data()[0].reset();
         stop_status.set_executor(this->exec);
 
-        ASSERT_FALSE(
-            abs_criterion->update()
-                .residual_norm(res_norm.get())
-                .check(RelativeStoppingId, true, &stop_status, &one_changed));
+        ASSERT_FALSE(abs_criterion->update().residual_norm(res_norm).check(
+            RelativeStoppingId, true, &stop_status, &one_changed));
 
         write(res_norm, 0, 0, r<TypeParam>::value * 1.1);
-        ASSERT_FALSE(
-            abs_criterion->update()
-                .residual_norm(res_norm.get())
-                .check(RelativeStoppingId, true, &stop_status, &one_changed));
+        ASSERT_FALSE(abs_criterion->update().residual_norm(res_norm).check(
+            RelativeStoppingId, true, &stop_status, &one_changed));
         stop_status.set_executor(this->ref);
         ASSERT_FALSE(stop_status.get_data()[0].has_converged());
         ASSERT_FALSE(one_changed);
         stop_status.set_executor(this->exec);
 
         write(res_norm, 0, 0, r<TypeParam>::value * 0.9);
-        ASSERT_TRUE(
-            abs_criterion->update()
-                .residual_norm(res_norm.get())
-                .check(RelativeStoppingId, true, &stop_status, &one_changed));
+        ASSERT_TRUE(abs_criterion->update().residual_norm(res_norm).check(
+            RelativeStoppingId, true, &stop_status, &one_changed));
         stop_status.set_executor(this->ref);
         ASSERT_TRUE(stop_status.get_data()[0].has_converged());
         ASSERT_TRUE(one_changed);
@@ -224,7 +206,7 @@ TYPED_TEST(ResidualNorm, WaitsTillResidualGoalMultipleRHS)
             gko::initialize<NormVector>({I<T_nc>{100.0, 100.0}}, this->exec);
         auto rhs_norm =
             gko::initialize<NormVector>({I<T_nc>{100.0, 100.0}}, this->exec);
-        gko::as<Mtx>(rhs)->compute_norm2(rhs_norm.get());
+        gko::as<Mtx>(rhs)->compute_norm2(rhs_norm);
         bool one_changed{};
         constexpr gko::uint8 RelativeStoppingId{1};
         gko::array<gko::stopping_status> stop_status(this->ref, 2);
@@ -232,26 +214,20 @@ TYPED_TEST(ResidualNorm, WaitsTillResidualGoalMultipleRHS)
         stop_status.get_data()[1].reset();
         stop_status.set_executor(this->exec);
 
-        ASSERT_FALSE(
-            criterion->update()
-                .residual_norm(res_norm.get())
-                .check(RelativeStoppingId, true, &stop_status, &one_changed));
+        ASSERT_FALSE(criterion->update().residual_norm(res_norm).check(
+            RelativeStoppingId, true, &stop_status, &one_changed));
 
         write(res_norm, 0, 0, r<TypeParam>::value * 0.9 * read(rhs_norm, 0, 0));
-        ASSERT_FALSE(
-            criterion->update()
-                .residual_norm(res_norm.get())
-                .check(RelativeStoppingId, true, &stop_status, &one_changed));
+        ASSERT_FALSE(criterion->update().residual_norm(res_norm).check(
+            RelativeStoppingId, true, &stop_status, &one_changed));
         stop_status.set_executor(this->ref);
         ASSERT_TRUE(stop_status.get_data()[0].has_converged());
         ASSERT_TRUE(one_changed);
         stop_status.set_executor(this->exec);
 
         write(res_norm, 0, 1, r<TypeParam>::value * 0.9 * read(rhs_norm, 0, 1));
-        ASSERT_TRUE(
-            criterion->update()
-                .residual_norm(res_norm.get())
-                .check(RelativeStoppingId, true, &stop_status, &one_changed));
+        ASSERT_TRUE(criterion->update().residual_norm(res_norm).check(
+            RelativeStoppingId, true, &stop_status, &one_changed));
         stop_status.set_executor(this->ref);
         ASSERT_TRUE(stop_status.get_data()[1].has_converged());
         ASSERT_TRUE(one_changed);
@@ -267,26 +243,20 @@ TYPED_TEST(ResidualNorm, WaitsTillResidualGoalMultipleRHS)
         stop_status.get_data()[1].reset();
         stop_status.set_executor(this->exec);
 
-        ASSERT_FALSE(
-            rel_criterion->update()
-                .residual_norm(res_norm.get())
-                .check(RelativeStoppingId, true, &stop_status, &one_changed));
+        ASSERT_FALSE(rel_criterion->update().residual_norm(res_norm).check(
+            RelativeStoppingId, true, &stop_status, &one_changed));
 
         write(res_norm, 0, 0, r<TypeParam>::value * 0.9 * read(res_norm, 0, 0));
-        ASSERT_FALSE(
-            rel_criterion->update()
-                .residual_norm(res_norm.get())
-                .check(RelativeStoppingId, true, &stop_status, &one_changed));
+        ASSERT_FALSE(rel_criterion->update().residual_norm(res_norm).check(
+            RelativeStoppingId, true, &stop_status, &one_changed));
         stop_status.set_executor(this->ref);
         ASSERT_TRUE(stop_status.get_data()[0].has_converged());
         ASSERT_TRUE(one_changed);
         stop_status.set_executor(this->exec);
 
         write(res_norm, 0, 1, r<TypeParam>::value * 0.9 * read(res_norm, 0, 1));
-        ASSERT_TRUE(
-            rel_criterion->update()
-                .residual_norm(res_norm.get())
-                .check(RelativeStoppingId, true, &stop_status, &one_changed));
+        ASSERT_TRUE(rel_criterion->update().residual_norm(res_norm).check(
+            RelativeStoppingId, true, &stop_status, &one_changed));
         stop_status.set_executor(this->ref);
         ASSERT_TRUE(stop_status.get_data()[1].has_converged());
         ASSERT_TRUE(one_changed);
@@ -302,26 +272,20 @@ TYPED_TEST(ResidualNorm, WaitsTillResidualGoalMultipleRHS)
         stop_status.get_data()[1].reset();
         stop_status.set_executor(this->exec);
 
-        ASSERT_FALSE(
-            abs_criterion->update()
-                .residual_norm(res_norm.get())
-                .check(RelativeStoppingId, true, &stop_status, &one_changed));
+        ASSERT_FALSE(abs_criterion->update().residual_norm(res_norm).check(
+            RelativeStoppingId, true, &stop_status, &one_changed));
 
         write(res_norm, 0, 0, r<TypeParam>::value * 0.9);
-        ASSERT_FALSE(
-            abs_criterion->update()
-                .residual_norm(res_norm.get())
-                .check(RelativeStoppingId, true, &stop_status, &one_changed));
+        ASSERT_FALSE(abs_criterion->update().residual_norm(res_norm).check(
+            RelativeStoppingId, true, &stop_status, &one_changed));
         stop_status.set_executor(this->ref);
         ASSERT_TRUE(stop_status.get_data()[0].has_converged());
         ASSERT_TRUE(one_changed);
         stop_status.set_executor(this->exec);
 
         write(res_norm, 0, 1, r<TypeParam>::value * 0.9);
-        ASSERT_TRUE(
-            abs_criterion->update()
-                .residual_norm(res_norm.get())
-                .check(RelativeStoppingId, true, &stop_status, &one_changed));
+        ASSERT_TRUE(abs_criterion->update().residual_norm(res_norm).check(
+            RelativeStoppingId, true, &stop_status, &one_changed));
         stop_status.set_executor(this->ref);
         ASSERT_TRUE(stop_status.get_data()[1].has_converged());
         ASSERT_TRUE(one_changed);
@@ -366,26 +330,20 @@ TYPED_TEST(ResidualNormWithInitialResnorm, WaitsTillResidualGoal)
     stop_status.get_data()[0].reset();
     stop_status.set_executor(this->exec);
 
-    ASSERT_FALSE(
-        criterion->update()
-            .residual_norm(res_norm.get())
-            .check(RelativeStoppingId, true, &stop_status, &one_changed));
+    ASSERT_FALSE(criterion->update().residual_norm(res_norm).check(
+        RelativeStoppingId, true, &stop_status, &one_changed));
 
     write(res_norm, 0, 0, r<TypeParam>::value * 1.1 * read(res_norm, 0, 0));
-    ASSERT_FALSE(
-        criterion->update()
-            .residual_norm(res_norm.get())
-            .check(RelativeStoppingId, true, &stop_status, &one_changed));
+    ASSERT_FALSE(criterion->update().residual_norm(res_norm).check(
+        RelativeStoppingId, true, &stop_status, &one_changed));
     stop_status.set_executor(this->ref);
     ASSERT_FALSE(stop_status.get_data()[0].has_converged());
     ASSERT_FALSE(one_changed);
     stop_status.set_executor(this->exec);
 
     write(res_norm, 0, 0, r<TypeParam>::value * 0.9 * read(res_norm, 0, 0));
-    ASSERT_TRUE(
-        criterion->update()
-            .residual_norm(res_norm.get())
-            .check(RelativeStoppingId, true, &stop_status, &one_changed));
+    ASSERT_TRUE(criterion->update().residual_norm(res_norm).check(
+        RelativeStoppingId, true, &stop_status, &one_changed));
     stop_status.set_executor(this->ref);
     ASSERT_TRUE(stop_status.get_data()[0].has_converged());
     ASSERT_TRUE(one_changed);
@@ -412,26 +370,20 @@ TYPED_TEST(ResidualNormWithInitialResnorm, WaitsTillResidualGoalMultipleRHS)
     stop_status.get_data()[1].reset();
     stop_status.set_executor(this->exec);
 
-    ASSERT_FALSE(
-        criterion->update()
-            .residual_norm(res_norm.get())
-            .check(RelativeStoppingId, true, &stop_status, &one_changed));
+    ASSERT_FALSE(criterion->update().residual_norm(res_norm).check(
+        RelativeStoppingId, true, &stop_status, &one_changed));
 
     write(res_norm, 0, 0, r<TypeParam>::value * 0.9 * read(res_norm, 0, 0));
-    ASSERT_FALSE(
-        criterion->update()
-            .residual_norm(res_norm.get())
-            .check(RelativeStoppingId, true, &stop_status, &one_changed));
+    ASSERT_FALSE(criterion->update().residual_norm(res_norm).check(
+        RelativeStoppingId, true, &stop_status, &one_changed));
     stop_status.set_executor(this->ref);
     ASSERT_TRUE(stop_status.get_data()[0].has_converged());
     ASSERT_TRUE(one_changed);
     stop_status.set_executor(this->exec);
 
     write(res_norm, 0, 1, r<TypeParam>::value * 0.9 * read(res_norm, 0, 1));
-    ASSERT_TRUE(
-        criterion->update()
-            .residual_norm(res_norm.get())
-            .check(RelativeStoppingId, true, &stop_status, &one_changed));
+    ASSERT_TRUE(criterion->update().residual_norm(res_norm).check(
+        RelativeStoppingId, true, &stop_status, &one_changed));
     stop_status.set_executor(this->ref);
     ASSERT_TRUE(stop_status.get_data()[1].has_converged());
     ASSERT_TRUE(one_changed);
@@ -469,7 +421,7 @@ TYPED_TEST(ResidualNormWithRhsNorm, WaitsTillResidualGoal)
     auto initial_res = gko::initialize<Mtx>({100.0}, this->exec);
     std::shared_ptr<gko::LinOp> rhs = gko::initialize<Mtx>({10.0}, this->exec);
     auto rhs_norm = gko::initialize<NormVector>({I<T_nc>{0.0}}, this->exec);
-    gko::as<Mtx>(rhs)->compute_norm2(rhs_norm.get());
+    gko::as<Mtx>(rhs)->compute_norm2(rhs_norm);
     auto res_norm = gko::initialize<NormVector>({100.0}, this->exec);
     auto criterion =
         this->factory->generate(nullptr, rhs, nullptr, initial_res.get());
@@ -479,26 +431,20 @@ TYPED_TEST(ResidualNormWithRhsNorm, WaitsTillResidualGoal)
     stop_status.get_data()[0].reset();
     stop_status.set_executor(this->exec);
 
-    ASSERT_FALSE(
-        criterion->update()
-            .residual_norm(res_norm.get())
-            .check(RelativeStoppingId, true, &stop_status, &one_changed));
+    ASSERT_FALSE(criterion->update().residual_norm(res_norm).check(
+        RelativeStoppingId, true, &stop_status, &one_changed));
 
     write(res_norm, 0, 0, r<TypeParam>::value * 1.1 * read(rhs_norm, 0, 0));
-    ASSERT_FALSE(
-        criterion->update()
-            .residual_norm(res_norm.get())
-            .check(RelativeStoppingId, true, &stop_status, &one_changed));
+    ASSERT_FALSE(criterion->update().residual_norm(res_norm).check(
+        RelativeStoppingId, true, &stop_status, &one_changed));
     stop_status.set_executor(this->ref);
     ASSERT_FALSE(stop_status.get_data()[0].has_converged());
     ASSERT_FALSE(one_changed);
     stop_status.set_executor(this->exec);
 
     write(res_norm, 0, 0, r<TypeParam>::value * 0.9 * read(rhs_norm, 0, 0));
-    ASSERT_TRUE(
-        criterion->update()
-            .residual_norm(res_norm.get())
-            .check(RelativeStoppingId, true, &stop_status, &one_changed));
+    ASSERT_TRUE(criterion->update().residual_norm(res_norm).check(
+        RelativeStoppingId, true, &stop_status, &one_changed));
     stop_status.set_executor(this->ref);
     ASSERT_TRUE(stop_status.get_data()[0].has_converged());
     ASSERT_TRUE(one_changed);
@@ -519,7 +465,7 @@ TYPED_TEST(ResidualNormWithRhsNorm, WaitsTillResidualGoalMultipleRHS)
         gko::initialize<Mtx>({I<T>{10.0, 10.0}}, this->exec);
     auto rhs_norm =
         gko::initialize<NormVector>({I<T_nc>{0.0, 0.0}}, this->exec);
-    gko::as<Mtx>(rhs)->compute_norm2(rhs_norm.get());
+    gko::as<Mtx>(rhs)->compute_norm2(rhs_norm);
     auto criterion = this->factory->generate(nullptr, rhs, nullptr, res.get());
     bool one_changed{};
     constexpr gko::uint8 RelativeStoppingId{1};
@@ -528,26 +474,20 @@ TYPED_TEST(ResidualNormWithRhsNorm, WaitsTillResidualGoalMultipleRHS)
     stop_status.get_data()[1].reset();
     stop_status.set_executor(this->exec);
 
-    ASSERT_FALSE(
-        criterion->update()
-            .residual_norm(res_norm.get())
-            .check(RelativeStoppingId, true, &stop_status, &one_changed));
+    ASSERT_FALSE(criterion->update().residual_norm(res_norm).check(
+        RelativeStoppingId, true, &stop_status, &one_changed));
 
     write(res_norm, 0, 0, r<TypeParam>::value * 0.9 * read(rhs_norm, 0, 0));
-    ASSERT_FALSE(
-        criterion->update()
-            .residual_norm(res_norm.get())
-            .check(RelativeStoppingId, true, &stop_status, &one_changed));
+    ASSERT_FALSE(criterion->update().residual_norm(res_norm).check(
+        RelativeStoppingId, true, &stop_status, &one_changed));
     stop_status.set_executor(this->ref);
     ASSERT_TRUE(stop_status.get_data()[0].has_converged());
     ASSERT_TRUE(one_changed);
     stop_status.set_executor(this->exec);
 
     write(res_norm, 0, 1, r<TypeParam>::value * 0.9 * read(rhs_norm, 0, 1));
-    ASSERT_TRUE(
-        criterion->update()
-            .residual_norm(res_norm.get())
-            .check(RelativeStoppingId, true, &stop_status, &one_changed));
+    ASSERT_TRUE(criterion->update().residual_norm(res_norm).check(
+        RelativeStoppingId, true, &stop_status, &one_changed));
     stop_status.set_executor(this->ref);
     ASSERT_TRUE(stop_status.get_data()[1].has_converged());
     ASSERT_TRUE(one_changed);
@@ -586,7 +526,7 @@ TYPED_TEST(ImplicitResidualNorm, WaitsTillResidualGoal)
     std::shared_ptr<gko::LinOp> rhs = gko::initialize<Mtx>({10.0}, this->exec);
     auto res_norm = gko::initialize<Mtx>({100.0}, this->exec);
     auto rhs_norm = gko::initialize<NormVector>({I<T_nc>{0.0}}, this->exec);
-    gko::as<Mtx>(rhs)->compute_norm2(rhs_norm.get());
+    gko::as<Mtx>(rhs)->compute_norm2(rhs_norm);
     auto criterion =
         this->factory->generate(nullptr, rhs, nullptr, initial_res.get());
     bool one_changed{};
@@ -595,17 +535,13 @@ TYPED_TEST(ImplicitResidualNorm, WaitsTillResidualGoal)
     stop_status.get_data()[0].reset();
     stop_status.set_executor(this->exec);
 
-    ASSERT_FALSE(
-        criterion->update()
-            .implicit_sq_residual_norm(res_norm.get())
-            .check(RelativeStoppingId, true, &stop_status, &one_changed));
+    ASSERT_FALSE(criterion->update().implicit_sq_residual_norm(res_norm).check(
+        RelativeStoppingId, true, &stop_status, &one_changed));
 
     write(res_norm, 0, 0,
           std::pow(r<TypeParam>::value * 1.1 * read(rhs_norm, 0, 0), 2));
-    ASSERT_FALSE(
-        criterion->update()
-            .implicit_sq_residual_norm(res_norm.get())
-            .check(RelativeStoppingId, true, &stop_status, &one_changed));
+    ASSERT_FALSE(criterion->update().implicit_sq_residual_norm(res_norm).check(
+        RelativeStoppingId, true, &stop_status, &one_changed));
     stop_status.set_executor(this->ref);
     ASSERT_FALSE(stop_status.get_data()[0].has_converged());
     ASSERT_FALSE(one_changed);
@@ -613,10 +549,8 @@ TYPED_TEST(ImplicitResidualNorm, WaitsTillResidualGoal)
 
     write(res_norm, 0, 0,
           std::pow(r<TypeParam>::value * 0.9 * read(rhs_norm, 0, 0), 2));
-    ASSERT_TRUE(
-        criterion->update()
-            .implicit_sq_residual_norm(res_norm.get())
-            .check(RelativeStoppingId, true, &stop_status, &one_changed));
+    ASSERT_TRUE(criterion->update().implicit_sq_residual_norm(res_norm).check(
+        RelativeStoppingId, true, &stop_status, &one_changed));
     stop_status.set_executor(this->ref);
     ASSERT_TRUE(stop_status.get_data()[0].has_converged());
     ASSERT_TRUE(one_changed);
@@ -636,7 +570,7 @@ TYPED_TEST(ImplicitResidualNorm, WaitsTillResidualGoalMultipleRHS)
         gko::initialize<Mtx>({I<T>{10.0, 10.0}}, this->exec);
     auto rhs_norm =
         gko::initialize<NormVector>({I<T_nc>{0.0, 0.0}}, this->exec);
-    gko::as<Mtx>(rhs)->compute_norm2(rhs_norm.get());
+    gko::as<Mtx>(rhs)->compute_norm2(rhs_norm);
     auto criterion = this->factory->generate(nullptr, rhs, nullptr, res.get());
     bool one_changed{};
     constexpr gko::uint8 RelativeStoppingId{1};
@@ -645,17 +579,13 @@ TYPED_TEST(ImplicitResidualNorm, WaitsTillResidualGoalMultipleRHS)
     stop_status.get_data()[1].reset();
     stop_status.set_executor(this->exec);
 
-    ASSERT_FALSE(
-        criterion->update()
-            .implicit_sq_residual_norm(res_norm.get())
-            .check(RelativeStoppingId, true, &stop_status, &one_changed));
+    ASSERT_FALSE(criterion->update().implicit_sq_residual_norm(res_norm).check(
+        RelativeStoppingId, true, &stop_status, &one_changed));
 
     write(res_norm, 0, 0,
           std::pow(r<TypeParam>::value * 0.9 * read(rhs_norm, 0, 0), 2));
-    ASSERT_FALSE(
-        criterion->update()
-            .implicit_sq_residual_norm(res_norm.get())
-            .check(RelativeStoppingId, true, &stop_status, &one_changed));
+    ASSERT_FALSE(criterion->update().implicit_sq_residual_norm(res_norm).check(
+        RelativeStoppingId, true, &stop_status, &one_changed));
     stop_status.set_executor(this->ref);
     ASSERT_TRUE(stop_status.get_data()[0].has_converged());
     ASSERT_TRUE(one_changed);
@@ -663,10 +593,8 @@ TYPED_TEST(ImplicitResidualNorm, WaitsTillResidualGoalMultipleRHS)
 
     write(res_norm, 0, 1,
           std::pow(r<TypeParam>::value * 0.9 * read(rhs_norm, 0, 1), 2));
-    ASSERT_TRUE(
-        criterion->update()
-            .implicit_sq_residual_norm(res_norm.get())
-            .check(RelativeStoppingId, true, &stop_status, &one_changed));
+    ASSERT_TRUE(criterion->update().implicit_sq_residual_norm(res_norm).check(
+        RelativeStoppingId, true, &stop_status, &one_changed));
     stop_status.set_executor(this->ref);
     ASSERT_TRUE(stop_status.get_data()[1].has_converged());
     ASSERT_TRUE(one_changed);
@@ -710,26 +638,20 @@ TYPED_TEST(ResidualNormWithAbsolute, WaitsTillResidualGoal)
     stop_status.get_data()[0].reset();
     stop_status.set_executor(this->exec);
 
-    ASSERT_FALSE(
-        criterion->update()
-            .residual_norm(res_norm.get())
-            .check(RelativeStoppingId, true, &stop_status, &one_changed));
+    ASSERT_FALSE(criterion->update().residual_norm(res_norm).check(
+        RelativeStoppingId, true, &stop_status, &one_changed));
 
     write(res_norm, 0, 0, r<TypeParam>::value * 1.1);
-    ASSERT_FALSE(
-        criterion->update()
-            .residual_norm(res_norm.get())
-            .check(RelativeStoppingId, true, &stop_status, &one_changed));
+    ASSERT_FALSE(criterion->update().residual_norm(res_norm).check(
+        RelativeStoppingId, true, &stop_status, &one_changed));
     stop_status.set_executor(this->ref);
     ASSERT_FALSE(stop_status.get_data()[0].has_converged());
     ASSERT_FALSE(one_changed);
     stop_status.set_executor(this->exec);
 
     write(res_norm, 0, 0, r<TypeParam>::value * 0.9);
-    ASSERT_TRUE(
-        criterion->update()
-            .residual_norm(res_norm.get())
-            .check(RelativeStoppingId, true, &stop_status, &one_changed));
+    ASSERT_TRUE(criterion->update().residual_norm(res_norm).check(
+        RelativeStoppingId, true, &stop_status, &one_changed));
     stop_status.set_executor(this->ref);
     ASSERT_TRUE(stop_status.get_data()[0].has_converged());
     ASSERT_TRUE(one_changed);
@@ -756,26 +678,20 @@ TYPED_TEST(ResidualNormWithAbsolute, WaitsTillResidualGoalMultipleRHS)
     stop_status.get_data()[1].reset();
     stop_status.set_executor(this->exec);
 
-    ASSERT_FALSE(
-        criterion->update()
-            .residual_norm(res_norm.get())
-            .check(RelativeStoppingId, true, &stop_status, &one_changed));
+    ASSERT_FALSE(criterion->update().residual_norm(res_norm).check(
+        RelativeStoppingId, true, &stop_status, &one_changed));
 
     write(res_norm, 0, 0, r<TypeParam>::value * 0.9);
-    ASSERT_FALSE(
-        criterion->update()
-            .residual_norm(res_norm.get())
-            .check(RelativeStoppingId, true, &stop_status, &one_changed));
+    ASSERT_FALSE(criterion->update().residual_norm(res_norm).check(
+        RelativeStoppingId, true, &stop_status, &one_changed));
     stop_status.set_executor(this->ref);
     ASSERT_TRUE(stop_status.get_data()[0].has_converged());
     ASSERT_TRUE(one_changed);
     stop_status.set_executor(this->exec);
 
     write(res_norm, 0, 1, r<TypeParam>::value * 0.9);
-    ASSERT_TRUE(
-        criterion->update()
-            .residual_norm(res_norm.get())
-            .check(RelativeStoppingId, true, &stop_status, &one_changed));
+    ASSERT_TRUE(criterion->update().residual_norm(res_norm).check(
+        RelativeStoppingId, true, &stop_status, &one_changed));
     stop_status.set_executor(this->ref);
     ASSERT_TRUE(stop_status.get_data()[1].has_converged());
     ASSERT_TRUE(one_changed);

--- a/test/test_install/CMakeLists.txt
+++ b/test/test_install/CMakeLists.txt
@@ -30,7 +30,7 @@ target_compile_features(test_install PUBLIC cxx_std_14)
 target_compile_definitions(test_install PRIVATE HAS_REFERENCE=${HAS_REFERENCE})
 target_link_libraries(test_install PRIVATE Ginkgo::ginkgo)
 if(GINKGO_BUILD_MPI)
-    find_package(MPI REQUIRED)
+    find_package(MPI 3.1 COMPONENTS CXX REQUIRED)
     target_link_libraries(test_install PRIVATE MPI::MPI_CXX)
 endif()
 

--- a/test/test_install/test_install.cpp
+++ b/test/test_install/test_install.cpp
@@ -46,8 +46,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <vector>
 
 
-void assert_similar_matrices(gko::pointer_param<const gko::matrix::Dense<>> m1,
-                             gko::pointer_param<const gko::matrix::Dense<>> m2,
+void assert_similar_matrices(gko::ptr_param<const gko::matrix::Dense<>> m1,
+                             gko::ptr_param<const gko::matrix::Dense<>> m2,
                              double prec)
 {
     assert(m1->get_size()[0] == m2->get_size()[0]);
@@ -63,8 +63,8 @@ void assert_similar_matrices(gko::pointer_param<const gko::matrix::Dense<>> m1,
 template <typename Mtx>
 void check_spmv(std::shared_ptr<gko::Executor> exec,
                 const gko::matrix_data<double>& A_raw,
-                gko::pointer_param<const gko::matrix::Dense<>> b,
-                gko::pointer_param<gko::matrix::Dense<>> x)
+                gko::ptr_param<const gko::matrix::Dense<>> b,
+                gko::ptr_param<gko::matrix::Dense<>> x)
 {
     auto test = Mtx::create(exec);
 #if HAS_REFERENCE
@@ -93,8 +93,8 @@ void check_spmv(std::shared_ptr<gko::Executor> exec,
 template <typename Solver>
 void check_solver(std::shared_ptr<gko::Executor> exec,
                   const gko::matrix_data<double>& A_raw,
-                  gko::pointer_param<const gko::matrix::Dense<>> b,
-                  gko::pointer_param<gko::matrix::Dense<>> x)
+                  gko::ptr_param<const gko::matrix::Dense<>> b,
+                  gko::ptr_param<gko::matrix::Dense<>> x)
 {
     using Mtx = gko::matrix::Csr<>;
     auto A = gko::share(Mtx::create(exec, std::make_shared<Mtx::classical>()));

--- a/test/test_install/test_install.cpp
+++ b/test/test_install/test_install.cpp
@@ -68,7 +68,7 @@ void check_spmv(std::shared_ptr<gko::Executor> exec,
 #if HAS_REFERENCE
     auto x_clone = gko::clone(x);
     test->read(A_raw);
-    test->apply(b, gko::lend(x_clone));
+    test->apply(b, x_clone);
     // x_clone has the device result if using HIP or CUDA, otherwise it is
     // reference only
 
@@ -78,11 +78,11 @@ void check_spmv(std::shared_ptr<gko::Executor> exec,
     auto test_ref = Mtx::create(exec_ref);
     auto x_ref = gko::clone(exec_ref, x);
     test_ref->read(A_raw);
-    test_ref->apply(b, gko::lend(x_ref));
+    test_ref->apply(b, x_ref);
 
     // Actually check that `x_clone` is similar to `x_ref`
-    auto x_clone_ref = gko::clone(exec_ref, gko::lend(x_clone));
-    assert_similar_matrices(gko::lend(x_clone_ref), gko::lend(x_ref), 1e-14);
+    auto x_clone_ref = gko::clone(exec_ref, x_clone);
+    assert_similar_matrices(x_clone_ref.get(), x_ref.get(), 1e-14);
 #endif  // defined(HAS_HIP) || defined(HAS_CUDA)
 #endif  // HAS_REFERENCE
 }
@@ -110,7 +110,7 @@ void check_solver(std::shared_ptr<gko::Executor> exec,
 #if HAS_REFERENCE
     A->read(A_raw);
     auto x_clone = gko::clone(x);
-    solver_gen->generate(A)->apply(b, gko::lend(x_clone));
+    solver_gen->generate(A)->apply(b, x_clone);
     // x_clone has the device result if using HIP or CUDA, otherwise it is
     // reference only
 
@@ -130,11 +130,11 @@ void check_solver(std::shared_ptr<gko::Executor> exec,
                     .on(exec_ref))
             .on(exec_ref);
     auto x_ref = gko::clone(exec_ref, x);
-    solver_gen->generate(A_ref)->apply(b, gko::lend(x_ref));
+    solver_gen->generate(A_ref)->apply(b, x_ref);
 
     // Actually check that `x_clone` is similar to `x_ref`
-    auto x_clone_ref = gko::clone(exec_ref, gko::lend(x_clone));
-    assert_similar_matrices(gko::lend(x_clone_ref), gko::lend(x_ref), 1e-12);
+    auto x_clone_ref = gko::clone(exec_ref, x_clone);
+    assert_similar_matrices(x_clone_ref.get(), x_ref.get(), 1e-12);
 #endif  // defined(HAS_HIP) || defined(HAS_CUDA)
 #endif  // HAS_REFERENCE
 }
@@ -351,7 +351,7 @@ int main()
     // core/matrix/coo.hpp
     {
         using Mtx = gko::matrix::Coo<>;
-        check_spmv<Mtx>(exec, A_raw, gko::lend(b), gko::lend(x));
+        check_spmv<Mtx>(exec, A_raw, b.get(), x.get());
     }
 
     // core/matrix/csr.hpp
@@ -363,19 +363,19 @@ int main()
     // core/matrix/dense.hpp
     {
         using Mtx = gko::matrix::Dense<>;
-        check_spmv<Mtx>(exec, A_raw, gko::lend(b), gko::lend(x));
+        check_spmv<Mtx>(exec, A_raw, b.get(), x.get());
     }
 
     // core/matrix/ell.hpp
     {
         using Mtx = gko::matrix::Ell<>;
-        check_spmv<Mtx>(exec, A_raw, gko::lend(b), gko::lend(x));
+        check_spmv<Mtx>(exec, A_raw, b.get(), x.get());
     }
 
     // core/matrix/hybrid.hpp
     {
         using Mtx = gko::matrix::Hybrid<>;
-        check_spmv<Mtx>(exec, A_raw, gko::lend(b), gko::lend(x));
+        check_spmv<Mtx>(exec, A_raw, b.get(), x.get());
     }
 
     // core/matrix/identity.hpp
@@ -399,7 +399,7 @@ int main()
     // core/matrix/sellp.hpp
     {
         using Mtx = gko::matrix::Sellp<>;
-        check_spmv<Mtx>(exec, A_raw, gko::lend(b), gko::lend(x));
+        check_spmv<Mtx>(exec, A_raw, b.get(), x.get());
     }
 
     // core/matrix/sparsity_csr.hpp
@@ -433,37 +433,37 @@ int main()
     // core/solver/bicgstab.hpp
     {
         using Solver = gko::solver::Bicgstab<>;
-        check_solver<Solver>(exec, A_raw, gko::lend(b), gko::lend(x));
+        check_solver<Solver>(exec, A_raw, b.get(), x.get());
     }
 
     // core/solver/cb_gmres.hpp
     {
         using Solver = gko::solver::CbGmres<>;
-        check_solver<Solver>(exec, A_raw, gko::lend(b), gko::lend(x));
+        check_solver<Solver>(exec, A_raw, b.get(), x.get());
     }
 
     // core/solver/cg.hpp
     {
         using Solver = gko::solver::Cg<>;
-        check_solver<Solver>(exec, A_raw, gko::lend(b), gko::lend(x));
+        check_solver<Solver>(exec, A_raw, b.get(), x.get());
     }
 
     // core/solver/cgs.hpp
     {
         using Solver = gko::solver::Cgs<>;
-        check_solver<Solver>(exec, A_raw, gko::lend(b), gko::lend(x));
+        check_solver<Solver>(exec, A_raw, b.get(), x.get());
     }
 
     // core/solver/fcg.hpp
     {
         using Solver = gko::solver::Fcg<>;
-        check_solver<Solver>(exec, A_raw, gko::lend(b), gko::lend(x));
+        check_solver<Solver>(exec, A_raw, b.get(), x.get());
     }
 
     // core/solver/gmres.hpp
     {
         using Solver = gko::solver::Gmres<>;
-        check_solver<Solver>(exec, A_raw, gko::lend(b), gko::lend(x));
+        check_solver<Solver>(exec, A_raw, b.get(), x.get());
     }
 
     // core/solver/ir.hpp

--- a/test/test_install/test_install.cpp
+++ b/test/test_install/test_install.cpp
@@ -46,8 +46,9 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <vector>
 
 
-void assert_similar_matrices(const gko::matrix::Dense<>* m1,
-                             const gko::matrix::Dense<>* m2, double prec)
+void assert_similar_matrices(gko::pointer_param<const gko::matrix::Dense<>> m1,
+                             gko::pointer_param<const gko::matrix::Dense<>> m2,
+                             double prec)
 {
     assert(m1->get_size()[0] == m2->get_size()[0]);
     assert(m1->get_size()[1] == m2->get_size()[1]);
@@ -62,7 +63,8 @@ void assert_similar_matrices(const gko::matrix::Dense<>* m1,
 template <typename Mtx>
 void check_spmv(std::shared_ptr<gko::Executor> exec,
                 const gko::matrix_data<double>& A_raw,
-                const gko::matrix::Dense<>* b, gko::matrix::Dense<>* x)
+                gko::pointer_param<const gko::matrix::Dense<>> b,
+                gko::pointer_param<gko::matrix::Dense<>> x)
 {
     auto test = Mtx::create(exec);
 #if HAS_REFERENCE
@@ -82,7 +84,7 @@ void check_spmv(std::shared_ptr<gko::Executor> exec,
 
     // Actually check that `x_clone` is similar to `x_ref`
     auto x_clone_ref = gko::clone(exec_ref, x_clone);
-    assert_similar_matrices(x_clone_ref.get(), x_ref.get(), 1e-14);
+    assert_similar_matrices(x_clone_ref, x_ref, 1e-14);
 #endif  // defined(HAS_HIP) || defined(HAS_CUDA)
 #endif  // HAS_REFERENCE
 }
@@ -91,7 +93,8 @@ void check_spmv(std::shared_ptr<gko::Executor> exec,
 template <typename Solver>
 void check_solver(std::shared_ptr<gko::Executor> exec,
                   const gko::matrix_data<double>& A_raw,
-                  const gko::matrix::Dense<>* b, gko::matrix::Dense<>* x)
+                  gko::pointer_param<const gko::matrix::Dense<>> b,
+                  gko::pointer_param<gko::matrix::Dense<>> x)
 {
     using Mtx = gko::matrix::Csr<>;
     auto A = gko::share(Mtx::create(exec, std::make_shared<Mtx::classical>()));
@@ -134,7 +137,7 @@ void check_solver(std::shared_ptr<gko::Executor> exec,
 
     // Actually check that `x_clone` is similar to `x_ref`
     auto x_clone_ref = gko::clone(exec_ref, x_clone);
-    assert_similar_matrices(x_clone_ref.get(), x_ref.get(), 1e-12);
+    assert_similar_matrices(x_clone_ref, x_ref, 1e-12);
 #endif  // defined(HAS_HIP) || defined(HAS_CUDA)
 #endif  // HAS_REFERENCE
 }
@@ -351,7 +354,7 @@ int main()
     // core/matrix/coo.hpp
     {
         using Mtx = gko::matrix::Coo<>;
-        check_spmv<Mtx>(exec, A_raw, b.get(), x.get());
+        check_spmv<Mtx>(exec, A_raw, b, x);
     }
 
     // core/matrix/csr.hpp
@@ -363,19 +366,19 @@ int main()
     // core/matrix/dense.hpp
     {
         using Mtx = gko::matrix::Dense<>;
-        check_spmv<Mtx>(exec, A_raw, b.get(), x.get());
+        check_spmv<Mtx>(exec, A_raw, b, x);
     }
 
     // core/matrix/ell.hpp
     {
         using Mtx = gko::matrix::Ell<>;
-        check_spmv<Mtx>(exec, A_raw, b.get(), x.get());
+        check_spmv<Mtx>(exec, A_raw, b, x);
     }
 
     // core/matrix/hybrid.hpp
     {
         using Mtx = gko::matrix::Hybrid<>;
-        check_spmv<Mtx>(exec, A_raw, b.get(), x.get());
+        check_spmv<Mtx>(exec, A_raw, b, x);
     }
 
     // core/matrix/identity.hpp
@@ -399,7 +402,7 @@ int main()
     // core/matrix/sellp.hpp
     {
         using Mtx = gko::matrix::Sellp<>;
-        check_spmv<Mtx>(exec, A_raw, b.get(), x.get());
+        check_spmv<Mtx>(exec, A_raw, b, x);
     }
 
     // core/matrix/sparsity_csr.hpp
@@ -433,37 +436,37 @@ int main()
     // core/solver/bicgstab.hpp
     {
         using Solver = gko::solver::Bicgstab<>;
-        check_solver<Solver>(exec, A_raw, b.get(), x.get());
+        check_solver<Solver>(exec, A_raw, b, x);
     }
 
     // core/solver/cb_gmres.hpp
     {
         using Solver = gko::solver::CbGmres<>;
-        check_solver<Solver>(exec, A_raw, b.get(), x.get());
+        check_solver<Solver>(exec, A_raw, b, x);
     }
 
     // core/solver/cg.hpp
     {
         using Solver = gko::solver::Cg<>;
-        check_solver<Solver>(exec, A_raw, b.get(), x.get());
+        check_solver<Solver>(exec, A_raw, b, x);
     }
 
     // core/solver/cgs.hpp
     {
         using Solver = gko::solver::Cgs<>;
-        check_solver<Solver>(exec, A_raw, b.get(), x.get());
+        check_solver<Solver>(exec, A_raw, b, x);
     }
 
     // core/solver/fcg.hpp
     {
         using Solver = gko::solver::Fcg<>;
-        check_solver<Solver>(exec, A_raw, b.get(), x.get());
+        check_solver<Solver>(exec, A_raw, b, x);
     }
 
     // core/solver/gmres.hpp
     {
         using Solver = gko::solver::Gmres<>;
-        check_solver<Solver>(exec, A_raw, b.get(), x.get());
+        check_solver<Solver>(exec, A_raw, b, x);
     }
 
     // core/solver/ir.hpp


### PR DESCRIPTION
This adds a pointer_param class which can be converted to from all types of pointers, as a replacement for raw pointer parameters.

TODO:
- [x] ~~Consider checking for `nullptr`~~ This is probably more suitable for a narrower focus nonnull_pointer_param, see also #37

Closes #179