### PR TITLE
Fix handling of missing diagonal in symbolic factorizations

### DIFF
--- a/benchmark/solver/solver_common.hpp
+++ b/benchmark/solver/solver_common.hpp
@@ -64,7 +64,7 @@ DEFINE_string(solvers, "cg",
               "Supported values are: bicgstab, bicg, cb_gmres_keep, "
               "cb_gmres_reduce1, cb_gmres_reduce2, cb_gmres_integer, "
               "cb_gmres_ireduce1, cb_gmres_ireduce2, cg, cgs, fcg, gmres, idr, "
-              "lower_trs, upper_trs, overhead");
+              "lower_trs, upper_trs, symm_direct, direct, overhead");
 
 DEFINE_uint32(
     nrhs, 1,
@@ -250,6 +250,19 @@ std::unique_ptr<gko::LinOpFactory> generate_solver(
     } else if (description == "upper_trs") {
         return gko::solver::UpperTrs<etype>::build()
             .with_num_rhs(FLAGS_nrhs)
+            .on(exec);
+    } else if (description == "symm_direct") {
+        return gko::experimental::solver::Direct<etype, itype>::build()
+            .with_factorization(
+                gko::experimental::factorization::Lu<etype, itype>::build()
+                    .with_symmetric_sparsity(true)
+                    .on(exec))
+            .on(exec);
+    } else if (description == "direct") {
+        return gko::experimental::solver::Direct<etype, itype>::build()
+            .with_factorization(
+                gko::experimental::factorization::Lu<etype, itype>::build().on(
+                    exec))
             .on(exec);
     } else if (description == "overhead") {
         return add_criteria_precond_finalize<gko::Overhead<etype>>(

--- a/common/cuda_hip/factorization/cholesky_kernels.hpp.inc
+++ b/common/cuda_hip/factorization/cholesky_kernels.hpp.inc
@@ -46,7 +46,7 @@ __global__ __launch_bounds__(default_block_size) void build_postorder_cols(
     auto lower_end = row_begin;
     for (auto nz = row_begin; nz < row_end; nz++) {
         const auto col = cols[nz];
-        if (col <= row) {
+        if (col < row) {
             postorder_cols[lower_end] = inv_postorder[cols[nz]];
             lower_end++;
         }
@@ -76,22 +76,25 @@ template <int subwarp_size, typename IndexType>
 __global__
     __launch_bounds__(default_block_size) void cholesky_symbolic_count_kernel(
         IndexType num_rows, const IndexType* row_ptrs,
-        const IndexType* lower_ends, const IndexType* postorder_cols,
-        const IndexType* postorder_parent, IndexType* row_nnz)
+        const IndexType* lower_ends, const IndexType* inv_postorder,
+        const IndexType* postorder_cols, const IndexType* postorder_parent,
+        IndexType* row_nnz)
 {
     const auto row = thread::get_subwarp_id_flat<subwarp_size, IndexType>();
     if (row >= num_rows) {
         return;
     }
     const auto row_begin = row_ptrs[row];
+    const auto diag_postorder = inv_postorder[row];
     const auto lower_end = lower_ends[row];
     const auto subwarp =
         group::tiled_partition<subwarp_size>(group::this_thread_block());
     const auto lane = subwarp.thread_rank();
     IndexType count{};
-    for (auto nz = row_begin + lane; nz < lower_end - 1; nz += subwarp_size) {
+    for (auto nz = row_begin + lane; nz < lower_end; nz += subwarp_size) {
         auto node = postorder_cols[nz];
-        const auto next_node = postorder_cols[nz + 1];
+        const auto next_node =
+            nz < lower_end - 1 ? postorder_cols[nz + 1] : diag_postorder;
         while (node < next_node) {
             count++;
             node = postorder_parent[node];
@@ -110,25 +113,28 @@ template <int subwarp_size, typename IndexType>
 __global__
     __launch_bounds__(default_block_size) void cholesky_symbolic_factorize_kernel(
         IndexType num_rows, const IndexType* row_ptrs,
-        const IndexType* lower_ends, const IndexType* postorder_cols,
-        const IndexType* postorder, const IndexType* postorder_parent,
-        const IndexType* out_row_ptrs, IndexType* out_cols)
+        const IndexType* lower_ends, const IndexType* inv_postorder,
+        const IndexType* postorder_cols, const IndexType* postorder,
+        const IndexType* postorder_parent, const IndexType* out_row_ptrs,
+        IndexType* out_cols)
 {
     const auto row = thread::get_subwarp_id_flat<subwarp_size, IndexType>();
     if (row >= num_rows) {
         return;
     }
     const auto row_begin = row_ptrs[row];
+    const auto diag_postorder = inv_postorder[row];
     const auto lower_end = lower_ends[row];
     const auto subwarp =
         group::tiled_partition<subwarp_size>(group::this_thread_block());
     const auto lane = subwarp.thread_rank();
     const auto prefix_mask = (config::lane_mask_type(1) << lane) - 1;
     auto out_base = out_row_ptrs[row];
-    for (auto base = row_begin; base < lower_end - 1; base += subwarp_size) {
+    for (auto base = row_begin; base < lower_end; base += subwarp_size) {
         auto nz = base + lane;
-        auto node = nz < lower_end - 1 ? postorder_cols[nz] : -1;
-        const auto next_node = nz < lower_end - 1 ? postorder_cols[nz + 1] : -1;
+        auto node = nz < lower_end ? postorder_cols[nz] : diag_postorder;
+        const auto next_node =
+            nz < lower_end - 1 ? postorder_cols[nz + 1] : diag_postorder;
         bool pred = node < next_node;
         auto mask = subwarp.ballot(pred);
         while (mask) {

--- a/common/cuda_hip/factorization/cholesky_kernels.hpp.inc
+++ b/common/cuda_hip/factorization/cholesky_kernels.hpp.inc
@@ -85,6 +85,9 @@ __global__
         return;
     }
     const auto row_begin = row_ptrs[row];
+    // instead of relying on the input containing a diagonal, we artificially
+    // introduce the diagonal entry (in postorder indexing) as a sentinel after
+    // the last lower triangular entry.
     const auto diag_postorder = inv_postorder[row];
     const auto lower_end = lower_ends[row];
     const auto subwarp =
@@ -123,6 +126,9 @@ __global__
         return;
     }
     const auto row_begin = row_ptrs[row];
+    // instead of relying on the input containing a diagonal, we artificially
+    // introduce the diagonal entry (in postorder indexing) as a sentinel after
+    // the last lower triangular entry.
     const auto diag_postorder = inv_postorder[row];
     const auto lower_end = lower_ends[row];
     const auto subwarp =

--- a/core/factorization/symbolic.cpp
+++ b/core/factorization/symbolic.cpp
@@ -169,10 +169,11 @@ void symbolic_lu(const matrix::Csr<ValueType, IndexType>* mtx,
         const auto row_begin_it = out_col_idxs.begin() + out_row_ptrs[row];
         const auto row_end_it = out_col_idxs.end();
         std::sort(row_begin_it, row_end_it);
-        const auto row_diag_it =
-            std::lower_bound(row_begin_it, row_end_it, row);
-        assert(row_diag_it < row_end_it);
-        assert(*row_diag_it == row);
+        auto row_diag_it = std::lower_bound(row_begin_it, row_end_it, row);
+        // add diagonal if it's missing
+        if (row_diag_it == row_end_it || *row_diag_it != row) {
+            row_diag_it = out_col_idxs.insert(row_diag_it, row);
+        }
         diags[row] = std::distance(out_col_idxs.begin(), row_diag_it);
     }
     const auto out_nnz = static_cast<size_type>(out_col_idxs.size());

--- a/cuda/factorization/cholesky_kernels.cu
+++ b/cuda/factorization/cholesky_kernels.cu
@@ -115,7 +115,7 @@ void cholesky_symbolic_count(
             ceildiv(num_rows, default_block_size / config::warp_size);
         cholesky_symbolic_count_kernel<config::warp_size>
             <<<num_blocks, default_block_size>>>(num_rows, row_ptrs, lower_ends,
-                                                 postorder_cols,
+                                                 inv_postorder, postorder_cols,
                                                  postorder_parent, row_nnz);
     }
 }
@@ -149,8 +149,8 @@ void cholesky_symbolic_factorize(
         ceildiv(num_rows, default_block_size / config::warp_size);
     cholesky_symbolic_factorize_kernel<config::warp_size>
         <<<num_blocks, default_block_size>>>(
-            num_rows, row_ptrs, lower_ends, postorder_cols, postorder,
-            postorder_parent, out_row_ptrs, out_cols);
+            num_rows, row_ptrs, lower_ends, inv_postorder, postorder_cols,
+            postorder, postorder_parent, out_row_ptrs, out_cols);
 }
 
 GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(

--- a/dpcpp/factorization/cholesky_kernels.dp.cpp
+++ b/dpcpp/factorization/cholesky_kernels.dp.cpp
@@ -101,6 +101,9 @@ void cholesky_symbolic_count(
         cgh.parallel_for(sycl::range<1>{num_rows}, [=](sycl::id<1> idx_id) {
             const auto row = idx_id[0];
             const auto row_begin = row_ptrs[row];
+            // instead of relying on the input containing a diagonal, we
+            // artificially introduce the diagonal entry (in postorder indexing)
+            // as a sentinel after the last lower triangular entry.
             const auto diag_postorder = inv_postorder[row];
             const auto lower_end = lower_ends[row];
             IndexType count{};
@@ -145,6 +148,9 @@ void cholesky_symbolic_factorize(
         cgh.parallel_for(sycl::range<1>{num_rows}, [=](sycl::id<1> idx_id) {
             const auto row = idx_id[0];
             const auto row_begin = row_ptrs[row];
+            // instead of relying on the input containing a diagonal, we
+            // artificially introduce the diagonal entry (in postorder indexing)
+            // as a sentinel after the last lower triangular entry.
             const auto diag_postorder = inv_postorder[row];
             const auto lower_end = lower_ends[row];
             auto out_nz = out_row_ptrs[row];

--- a/dpcpp/factorization/cholesky_kernels.dp.cpp
+++ b/dpcpp/factorization/cholesky_kernels.dp.cpp
@@ -83,7 +83,7 @@ void cholesky_symbolic_count(
             auto lower_end = row_begin;
             for (auto nz = row_begin; nz < row_end; nz++) {
                 const auto col = cols[nz];
-                if (col <= row) {
+                if (col < row) {
                     postorder_cols[lower_end] = inv_postorder[cols[nz]];
                     lower_end++;
                 }
@@ -101,11 +101,14 @@ void cholesky_symbolic_count(
         cgh.parallel_for(sycl::range<1>{num_rows}, [=](sycl::id<1> idx_id) {
             const auto row = idx_id[0];
             const auto row_begin = row_ptrs[row];
+            const auto diag_postorder = inv_postorder[row];
             const auto lower_end = lower_ends[row];
             IndexType count{};
-            for (auto nz = row_begin; nz < lower_end - 1; ++nz) {
+            for (auto nz = row_begin; nz < lower_end; ++nz) {
                 auto node = postorder_cols[nz];
-                const auto next_node = postorder_cols[nz + 1];
+                const auto next_node = nz < lower_end - 1
+                                           ? postorder_cols[nz + 1]
+                                           : diag_postorder;
                 while (node < next_node) {
                     count++;
                     node = postorder_parent[node];
@@ -142,11 +145,14 @@ void cholesky_symbolic_factorize(
         cgh.parallel_for(sycl::range<1>{num_rows}, [=](sycl::id<1> idx_id) {
             const auto row = idx_id[0];
             const auto row_begin = row_ptrs[row];
+            const auto diag_postorder = inv_postorder[row];
             const auto lower_end = lower_ends[row];
             auto out_nz = out_row_ptrs[row];
-            for (auto nz = row_begin; nz < lower_end - 1; ++nz) {
+            for (auto nz = row_begin; nz < lower_end; ++nz) {
                 auto node = postorder_cols[nz];
-                const auto next_node = postorder_cols[nz + 1];
+                const auto next_node = nz < lower_end - 1
+                                           ? postorder_cols[nz + 1]
+                                           : diag_postorder;
                 while (node < next_node) {
                     out_cols[out_nz] = postorder[node];
                     out_nz++;

--- a/hip/factorization/cholesky_kernels.hip.cpp
+++ b/hip/factorization/cholesky_kernels.hip.cpp
@@ -115,7 +115,7 @@ void cholesky_symbolic_count(
             ceildiv(num_rows, default_block_size / config::warp_size);
         cholesky_symbolic_count_kernel<config::warp_size>
             <<<num_blocks, default_block_size>>>(num_rows, row_ptrs, lower_ends,
-                                                 postorder_cols,
+                                                 inv_postorder, postorder_cols,
                                                  postorder_parent, row_nnz);
     }
 }
@@ -149,8 +149,8 @@ void cholesky_symbolic_factorize(
         ceildiv(num_rows, default_block_size / config::warp_size);
     cholesky_symbolic_factorize_kernel<config::warp_size>
         <<<num_blocks, default_block_size>>>(
-            num_rows, row_ptrs, lower_ends, postorder_cols, postorder,
-            postorder_parent, out_row_ptrs, out_cols);
+            num_rows, row_ptrs, lower_ends, inv_postorder, postorder_cols,
+            postorder, postorder_parent, out_row_ptrs, out_cols);
 }
 
 GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(

--- a/omp/factorization/cholesky_kernels.cpp
+++ b/omp/factorization/cholesky_kernels.cpp
@@ -74,6 +74,9 @@ void cholesky_symbolic_count(
     for (IndexType row = 0; row < num_rows; row++) {
         const auto row_begin = row_ptrs[row];
         const auto row_end = row_ptrs[row + 1];
+        // instead of relying on the input containing a diagonal, we
+        // artificially introduce the diagonal entry (in postorder indexing) as
+        // a sentinel after the last lower triangular entry.
         const auto diag_postorder = inv_postorder[row];
         // transform strictly lower triangular entries into sorted postorder
         auto lower_end = row_begin;
@@ -128,6 +131,9 @@ void cholesky_symbolic_factorize(
     for (IndexType row = 0; row < num_rows; row++) {
         const auto row_begin = row_ptrs[row];
         const auto row_end = row_ptrs[row + 1];
+        // instead of relying on the input containing a diagonal, we
+        // artificially introduce the diagonal entry (in postorder indexing) as
+        // a sentinel after the last lower triangular entry.
         const auto diag_postorder = inv_postorder[row];
         const auto lower_end = lower_ends[row];
         // Now move from each node to its LCA with other nodes to cut off a path

--- a/omp/factorization/cholesky_kernels.cpp
+++ b/omp/factorization/cholesky_kernels.cpp
@@ -74,23 +74,23 @@ void cholesky_symbolic_count(
     for (IndexType row = 0; row < num_rows; row++) {
         const auto row_begin = row_ptrs[row];
         const auto row_end = row_ptrs[row + 1];
-        // transform lower triangular entries into sorted postorder
+        const auto diag_postorder = inv_postorder[row];
+        // transform strictly lower triangular entries into sorted postorder
         auto lower_end = row_begin;
         for (auto nz = row_begin; nz < row_end; nz++) {
             const auto col = cols[nz];
-            if (col <= row) {
+            if (col < row) {
                 postorder_cols[lower_end] = inv_postorder[col];
                 lower_end++;
             }
         }
         std::sort(postorder_cols + row_begin, postorder_cols + lower_end);
-        // the subtree root should be the last entry as a sentinel
-        GKO_ASSERT(postorder_cols[lower_end - 1] == inv_postorder[row]);
         // Now move from each node to its LCA with other nodes to cut off a path
         IndexType count{};
-        for (auto nz = row_begin; nz < lower_end - 1; nz++) {
+        for (auto nz = row_begin; nz < lower_end; nz++) {
             auto node = postorder_cols[nz];
-            const auto next_node = postorder_cols[nz + 1];
+            const auto next_node =
+                nz < lower_end - 1 ? postorder_cols[nz + 1] : diag_postorder;
             // move upwards until we find the LCA with next_node
             while (node < next_node) {
                 count++;
@@ -128,12 +128,14 @@ void cholesky_symbolic_factorize(
     for (IndexType row = 0; row < num_rows; row++) {
         const auto row_begin = row_ptrs[row];
         const auto row_end = row_ptrs[row + 1];
+        const auto diag_postorder = inv_postorder[row];
         const auto lower_end = lower_ends[row];
         // Now move from each node to its LCA with other nodes to cut off a path
         auto out_nz = out_row_ptrs[row];
-        for (auto nz = row_begin; nz < lower_end - 1; nz++) {
+        for (auto nz = row_begin; nz < lower_end; nz++) {
             auto node = postorder_cols[nz];
-            const auto next_node = postorder_cols[nz + 1];
+            const auto next_node =
+                nz < lower_end - 1 ? postorder_cols[nz + 1] : diag_postorder;
             // move upwards until we find the LCA with next_node
             while (node < next_node) {
                 out_cols[out_nz] = postorder[node];

--- a/reference/test/factorization/lu_kernels.cpp
+++ b/reference/test/factorization/lu_kernels.cpp
@@ -139,6 +139,32 @@ TYPED_TEST(Lu, SymbolicLUWorks)
 }
 
 
+TYPED_TEST(Lu, SymbolicLUWorksWithMissingDiagonal)
+{
+    using matrix_type = typename TestFixture::matrix_type;
+    auto mtx = gko::initialize<matrix_type>({{1, 1, 1, 0, 0, 0},
+                                             {1, 0, 1, 0, 0, 0},
+                                             {1, 1, 1, 1, 0, 0},
+                                             {0, 0, 1, 1, 1, 0},
+                                             {0, 0, 0, 1, 0, 1},
+                                             {0, 0, 0, 0, 1, 0}},
+                                            this->ref);
+    auto expected = gko::initialize<matrix_type>({{1, 1, 1, 0, 0, 0},
+                                                  {1, 1, 1, 0, 0, 0},
+                                                  {1, 1, 1, 1, 0, 0},
+                                                  {0, 0, 1, 1, 1, 0},
+                                                  {0, 0, 0, 1, 1, 1},
+                                                  {0, 0, 0, 0, 1, 1}},
+                                                 this->ref);
+
+
+    std::unique_ptr<matrix_type> lu;
+    gko::factorization::symbolic_lu(mtx.get(), lu);
+
+    GKO_ASSERT_MTX_EQ_SPARSITY(lu, expected);
+}
+
+
 TYPED_TEST(Lu, KernelInitializeWorks)
 {
     using value_type = typename TestFixture::value_type;

--- a/test/factorization/cholesky_kernels.cpp
+++ b/test/factorization/cholesky_kernels.cpp
@@ -66,6 +66,10 @@ protected:
 
     Cholesky() : tmp{ref}, dtmp{exec}
     {
+        matrices.emplace_back(
+            "example small",
+            gko::initialize<matrix_type>(
+                {{1, 0, 1, 0}, {0, 1, 0, 1}, {1, 0, 1, 0}, {0, 0, 0, 1}}, ref));
         matrices.emplace_back("example", gko::initialize<matrix_type>(
                                              {{1, 0, 1, 0, 0, 0, 0, 1, 0, 0},
                                               {0, 1, 0, 1, 0, 0, 0, 0, 0, 1},
@@ -90,6 +94,19 @@ protected:
                                                 {0, 0, 0, 0, 0, 0, 0, 0, 1, 1},
                                                 {0, 0, 0, 0, 1, 0, 1, 0, 1, 1}},
                                                ref));
+        matrices.emplace_back(
+            "missing diagonal",
+            gko::initialize<matrix_type>({{1, 0, 1, 0, 0, 0, 0, 0, 0, 0},
+                                          {0, 1, 1, 0, 0, 0, 0, 0, 0, 0},
+                                          {1, 1, 0, 1, 0, 0, 0, 0, 0, 0},
+                                          {0, 0, 1, 1, 1, 0, 0, 0, 0, 0},
+                                          {0, 0, 0, 1, 0, 1, 0, 0, 0, 0},
+                                          {0, 0, 0, 0, 1, 1, 1, 0, 0, 0},
+                                          {0, 0, 0, 0, 0, 1, 1, 1, 0, 1},
+                                          {0, 0, 0, 0, 0, 0, 1, 1, 0, 0},
+                                          {0, 0, 0, 0, 0, 0, 0, 0, 1, 1},
+                                          {0, 0, 0, 0, 0, 0, 1, 0, 1, 0}},
+                                         ref));
         std::ifstream ani1_stream{gko::matrices::location_ani1_mtx};
         matrices.emplace_back("ani1", gko::read<matrix_type>(ani1_stream, ref));
         std::ifstream ani1_amd_stream{gko::matrices::location_ani1_amd_mtx};


### PR DESCRIPTION
This artificially adds the diagonal entry for all symbolic factorizations by using a sentinel value (Cholesky) or adding the diagonal explicitly if missing (LU).

TODO:

- [x] fix cholesky sparsity pattern computation