### PR TITLE
Fix FindPAPI with non-implicit include path

### DIFF
--- a/cmake/Modules/FindPAPI.cmake
+++ b/cmake/Modules/FindPAPI.cmake
@@ -87,6 +87,7 @@ if(PAPI_INCLUDE_DIR)
                 gko_result_unused
                 "${PROJECT_BINARY_DIR}"
                 "${PROJECT_BINARY_DIR}/papi_${component}_detect.c"
+                CMAKE_FLAGS -DINCLUDE_DIRECTORIES=${PAPI_INCLUDE_DIR}
                 LINK_LIBRARIES ${PAPI_LIBRARY}
                 )
 


### PR DESCRIPTION
When `papi.h` is installed in a path that is not available by default (i.e. without specifying `-I /path/to/include`), the feature detection fails. To fix this, we need to forward the include path to the `try_run` invocation.