### PR TITLE
Add Distributed Multigrid.

### DIFF
--- a/benchmark/test/reference/spmv_distributed.profile.stdout
+++ b/benchmark/test/reference/spmv_distributed.profile.stdout
@@ -5,7 +5,7 @@
         "comm_pattern": "stencil",
         "spmv": {
             "csr-csr": {
-                "storage": 6420,
+                "storage": 6564,
                 "time": 1.0,
                 "repetitions": 1,
                 "completed": true

--- a/benchmark/test/reference/spmv_distributed.simple.stdout
+++ b/benchmark/test/reference/spmv_distributed.simple.stdout
@@ -5,7 +5,7 @@
         "comm_pattern": "stencil",
         "spmv": {
             "csr-csr": {
-                "storage": 6420,
+                "storage": 6564,
                 "max_relative_norm2": 1.0,
                 "time": 1.0,
                 "repetitions": 10,

--- a/core/distributed/matrix.cpp
+++ b/core/distributed/matrix.cpp
@@ -167,7 +167,6 @@ void Matrix<ValueType, LocalIndexType, GlobalIndexType>::read_distributed(
     array<local_index_type> non_local_row_idxs{exec};
     array<local_index_type> non_local_col_idxs{exec};
     array<value_type> non_local_values{exec};
-    // array<local_index_type> recv_gather_idxs{exec};
     array<comm_index_type> recv_sizes_array{exec, num_parts};
 
     // build local, non-local matrix data and communication structures

--- a/core/distributed/matrix.cpp
+++ b/core/distributed/matrix.cpp
@@ -310,6 +310,14 @@ mpi::request Matrix<ValueType, LocalIndexType, GlobalIndexType>::communicate(
 
 
 template <typename ValueType, typename LocalIndexType, typename GlobalIndexType>
+dim<2> Matrix<ValueType, LocalIndexType, GlobalIndexType>::get_local_size()
+    const
+{
+    return local_mtx_->get_size();
+}
+
+
+template <typename ValueType, typename LocalIndexType, typename GlobalIndexType>
 void Matrix<ValueType, LocalIndexType, GlobalIndexType>::apply_impl(
     const LinOp* b, LinOp* x) const
 {

--- a/core/distributed/vector.cpp
+++ b/core/distributed/vector.cpp
@@ -326,6 +326,13 @@ void Vector<ValueType>::compute_absolute_inplace()
 
 
 template <typename ValueType>
+dim<2> Vector<ValueType>::get_local_size() const
+{
+    return local_.get_size();
+}
+
+
+template <typename ValueType>
 const typename Vector<ValueType>::local_vector_type*
 Vector<ValueType>::get_local_vector() const
 {

--- a/core/solver/multigrid.cpp
+++ b/core/solver/multigrid.cpp
@@ -225,8 +225,8 @@ struct MultigridState {
      */
     template <typename VectorType>
     void allocate_memory(int level, multigrid::cycle cycle,
-                         experimental::mpi::communicator& current_comm,
-                         experimental::mpi::communicator& next_comm,
+                         const experimental::mpi::communicator& current_comm,
+                         const experimental::mpi::communicator& next_comm,
                          size_type current_nrows, size_type next_nrows,
                          size_type current_local_nrows,
                          size_type next_local_nrows);
@@ -380,8 +380,8 @@ void MultigridState::allocate_memory(int level, multigrid::cycle cycle,
 template <typename VectorType>
 void MultigridState::allocate_memory(
     int level, multigrid::cycle cycle,
-    experimental::mpi::communicator& current_comm,
-    experimental::mpi::communicator& next_comm, size_type current_nrows,
+    const experimental::mpi::communicator& current_comm,
+    const experimental::mpi::communicator& next_comm, size_type current_nrows,
     size_type next_nrows, size_type current_local_nrows,
     size_type next_local_nrows)
 {

--- a/core/solver/multigrid.cpp
+++ b/core/solver/multigrid.cpp
@@ -308,24 +308,18 @@ void MultigridState::generate(const LinOp* system_matrix_in,
                         experimental::distributed::Vector<value_type>;
                     auto fine = mg_level->get_fine_op().get();
                     auto coarse = mg_level->get_coarse_op().get();
-                    auto current_comm =
-                        dynamic_cast<
-                            const experimental::distributed::DistributedBase*>(
-                            fine)
-                            ->get_communicator();
-                    auto next_comm =
-                        dynamic_cast<
-                            const experimental::distributed::DistributedBase*>(
-                            coarse)
-                            ->get_communicator();
+                    auto distributed_fine = dynamic_cast<
+                        const experimental::distributed::DistributedBase*>(
+                        fine);
+                    auto distributed_coarse = dynamic_cast<
+                        const experimental::distributed::DistributedBase*>(
+                        coarse);
+                    auto current_comm = distributed_fine->get_communicator();
+                    auto next_comm = distributed_coarse->get_communicator();
                     auto current_local_nrows =
-                        dynamic_cast<const experimental::distributed::
-                                         DistributedLocalSize*>(fine)
-                            ->get_local_size()[0];
+                        distributed_fine->get_local_size()[0];
                     auto next_local_nrows =
-                        dynamic_cast<const experimental::distributed::
-                                         DistributedLocalSize*>(coarse)
-                            ->get_local_size()[0];
+                        distributed_coarse->get_local_size()[0];
                     this->allocate_memory<VectorType>(
                         i, cycle, current_comm, next_comm, current_nrows,
                         next_nrows, current_local_nrows, next_local_nrows);

--- a/core/test/mpi/base/polymorphic_object.cpp
+++ b/core/test/mpi/base/polymorphic_object.cpp
@@ -116,6 +116,8 @@ struct DummyDistributedObject
         return *this;
     }
 
+    gko::dim<2> get_local_size() const override { return gko::dim<2>{0, 0}; }
+
     int x;
 };
 

--- a/core/test/mpi/distributed/CMakeLists.txt
+++ b/core/test/mpi/distributed/CMakeLists.txt
@@ -2,3 +2,4 @@ ginkgo_create_test(helpers MPI_SIZE 1)
 ginkgo_create_test(matrix MPI_SIZE 1)
 
 add_subdirectory(preconditioner)
+add_subdirectory(solver)

--- a/core/test/mpi/distributed/matrix.cpp
+++ b/core/test/mpi/distributed/matrix.cpp
@@ -39,6 +39,11 @@ public:
         : gko::EnableLinOp<CustomLinOp>(exec)
     {}
 
+    explicit CustomLinOp(std::shared_ptr<const gko::Executor> exec,
+                         gko::dim<2> size)
+        : gko::EnableLinOp<CustomLinOp>(exec, size)
+    {}
+
 protected:
     void apply_impl(const gko::LinOp* b, gko::LinOp* x) const override {}
 
@@ -247,6 +252,37 @@ TYPED_TEST(MatrixBuilder, BuildWithCustomLinOp)
     ASSERT_NO_THROW(gko::as<custom_type>(mat->get_local_matrix()));
     this->expected_interface_no_throw(mat, gko::with_matrix_type<CustomLinOp>(),
                                       gko::with_matrix_type<CustomLinOp>());
+}
+
+
+TYPED_TEST(MatrixBuilder, BuildLocalOnly)
+{
+    using value_type = typename TestFixture::value_type;
+    using index_type = typename TestFixture::local_index_type;
+    using dist_mtx_type = typename TestFixture::dist_mtx_type;
+    using dist_vec_type = typename TestFixture::dist_vec_type;
+    using custom_type = CustomLinOp<value_type, index_type>;
+    auto local_n = this->comm.rank() + 1;
+    // global_size = 1 + 2 + ... + num_rank
+    auto global_n = ((1 + this->comm.size()) * this->comm.size()) / 2;
+    auto a =
+        dist_vec_type::create(this->ref, this->comm, gko::dim<2>(global_n, 1),
+                              gko::dim<2>(local_n, 1));
+    auto b =
+        dist_vec_type::create(this->ref, this->comm, gko::dim<2>(global_n, 1),
+                              gko::dim<2>(local_n, 1));
+
+    auto mat = dist_mtx_type::create(
+        this->ref, this->comm, gko::dim<2>(global_n, global_n),
+        custom_type::create(this->ref, gko::dim<2>(local_n, local_n)));
+
+    ASSERT_NO_THROW(gko::as<custom_type>(mat->get_local_matrix()));
+    ASSERT_EQ(mat->get_non_local_matrix(), nullptr);
+    GKO_ASSERT_EQUAL_DIMENSIONS(mat->get_local_matrix()->get_size(),
+                                gko::dim<2>(local_n, local_n));
+    GKO_ASSERT_EQUAL_DIMENSIONS(mat->get_local_size(),
+                                mat->get_local_matrix()->get_size());
+    ASSERT_NO_THROW(mat->apply(a, b));
 }
 
 

--- a/core/test/mpi/distributed/solver/CMakeLists.txt
+++ b/core/test/mpi/distributed/solver/CMakeLists.txt
@@ -1,0 +1,1 @@
+ginkgo_create_test(multigrid MPI_SIZE 2)

--- a/core/test/mpi/distributed/solver/multigrid.cpp
+++ b/core/test/mpi/distributed/solver/multigrid.cpp
@@ -1,0 +1,212 @@
+// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+//
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include <gtest/gtest.h>
+
+
+#include <ginkgo/config.hpp>
+#include <ginkgo/core/distributed/matrix.hpp>
+#include <ginkgo/core/distributed/partition.hpp>
+#include <ginkgo/core/distributed/vector.hpp>
+#include <ginkgo/core/solver/cg.hpp>
+#include <ginkgo/core/solver/multigrid.hpp>
+#include <ginkgo/core/stop/iteration.hpp>
+
+
+#include "core/test/utils.hpp"
+
+
+namespace {
+
+
+using value_type = float;
+using local_index_type = int;
+using global_index_type = int;
+using dist_mtx_type =
+    gko::experimental::distributed::Matrix<value_type, local_index_type,
+                                           global_index_type>;
+using dist_vec_type = gko::experimental::distributed::Vector<value_type>;
+
+
+class DummyLinOp : public gko::EnableLinOp<DummyLinOp>,
+                   public gko::EnableCreateMethod<DummyLinOp> {
+public:
+    DummyLinOp(std::shared_ptr<const gko::Executor> exec,
+               gko::dim<2> size = gko::dim<2>{})
+        : EnableLinOp<DummyLinOp>(exec, size)
+    {}
+
+protected:
+    void apply_impl(const gko::LinOp* b, gko::LinOp* x) const override {}
+
+    void apply_impl(const gko::LinOp* alpha, const gko::LinOp* b,
+                    const gko::LinOp* beta, gko::LinOp* x) const override
+    {}
+};
+
+
+template <typename ValueType>
+class DummyMultigridLevelWithFactory
+    : public gko::EnableLinOp<DummyMultigridLevelWithFactory<ValueType>>,
+      public gko::multigrid::EnableMultigridLevel<ValueType> {
+public:
+    DummyMultigridLevelWithFactory(std::shared_ptr<const gko::Executor> exec)
+        : gko::EnableLinOp<DummyMultigridLevelWithFactory>(exec)
+    {}
+
+
+    GKO_CREATE_FACTORY_PARAMETERS(parameters, Factory){};
+    GKO_ENABLE_LIN_OP_FACTORY(DummyMultigridLevelWithFactory, parameters,
+                              Factory);
+    GKO_ENABLE_BUILD_METHOD(Factory);
+
+protected:
+    DummyMultigridLevelWithFactory(const Factory* factory,
+                                   std::shared_ptr<const gko::LinOp> op)
+        : gko::EnableLinOp<DummyMultigridLevelWithFactory>(
+              factory->get_executor(), op->get_size()),
+          gko::multigrid::EnableMultigridLevel<ValueType>(op),
+          parameters_{factory->get_parameters()},
+          op_{op}
+    {
+        auto exec = this->get_executor();
+        auto original_n =
+            dynamic_cast<
+                const gko::experimental::distributed::DistributedLocalSize*>(
+                op_.get())
+                ->get_local_size()[0];
+        gko::size_type n = original_n - 1;
+
+        auto comm = dynamic_cast<
+                        const gko::experimental::distributed::DistributedBase*>(
+                        op_.get())
+                        ->get_communicator();
+        auto original_size = op_->get_size()[0];
+        auto total_size = original_size - comm.size();
+        coarse_ =
+            dist_mtx_type::create(exec, comm, gko::dim<2>{total_size},
+                                  DummyLinOp::create(exec, gko::dim<2>{n}));
+        restrict_ = dist_mtx_type::create(
+            exec, comm, gko::dim<2>{total_size, original_size},
+            DummyLinOp::create(exec, gko::dim<2>{n, original_n}));
+        prolong_ = dist_mtx_type::create(
+            exec, comm, gko::dim<2>{original_size, total_size},
+            DummyLinOp::create(exec, gko::dim<2>{original_n, n}));
+        this->set_multigrid_level(prolong_, coarse_, restrict_);
+    }
+
+    std::shared_ptr<const gko::LinOp> op_;
+    std::shared_ptr<const gko::LinOp> coarse_;
+    std::shared_ptr<const gko::LinOp> restrict_;
+    std::shared_ptr<const gko::LinOp> prolong_;
+
+    void apply_impl(const gko::LinOp* b, gko::LinOp* x) const override {}
+
+    void apply_impl(const gko::LinOp* alpha, const gko::LinOp* b,
+                    const gko::LinOp* beta, gko::LinOp* x) const override
+    {}
+};
+
+
+class Multigrid : public ::testing::Test {
+protected:
+    using dist_vec_type = gko::experimental::distributed::Vector<value_type>;
+    using multigrid = gko::solver::Multigrid;
+    using mg_level = DummyMultigridLevelWithFactory<value_type>;
+
+
+    Multigrid()
+        : ref(gko::ReferenceExecutor::create()),
+          comm(gko::experimental::mpi::communicator(MPI_COMM_WORLD))
+    {}
+
+
+    std::shared_ptr<const gko::ReferenceExecutor> ref;
+    gko::experimental::mpi::communicator comm;
+};
+
+
+TEST_F(Multigrid, ConstructCorrect)
+{
+    auto mg_factory =
+        multigrid::build()
+            .with_max_levels(2u)
+            .with_mg_level(mg_level::build())
+            .with_pre_smoother(nullptr)
+            .with_mid_smoother(nullptr)
+            .with_criteria(gko::stop::Iteration::build().with_max_iters(1u))
+            .with_min_coarse_rows(1u)
+            .with_coarsest_solver(
+                gko::solver::Cg<value_type>::build()
+                    .with_criteria(
+                        gko::stop::Iteration::build().with_max_iters(1u))
+                    .on(this->ref))
+            .on(this->ref);
+    gko::size_type n = 5;
+    gko::size_type global_n = n * this->comm.size();
+    auto mtx = gko::share(
+        dist_mtx_type::create(this->ref, this->comm, gko::dim<2>{global_n},
+                              DummyLinOp::create(this->ref, gko::dim<2>{n})));
+
+    auto mg = mg_factory->generate(mtx);
+
+    auto mg_level = mg->get_mg_level_list();
+    auto first_n = global_n - this->comm.size();
+    auto second_n = first_n - this->comm.size();
+    ASSERT_EQ(mg_level.at(0)->get_fine_op()->get_size(), gko::dim<2>(global_n));
+    ASSERT_EQ(mg_level.at(0)->get_restrict_op()->get_size(),
+              gko::dim<2>(first_n, global_n));
+    ASSERT_EQ(mg_level.at(0)->get_prolong_op()->get_size(),
+              gko::dim<2>(global_n, first_n));
+    ASSERT_EQ(mg_level.at(0)->get_coarse_op()->get_size(),
+              gko::dim<2>(first_n));
+    ASSERT_EQ(dynamic_cast<
+                  const gko::experimental::distributed::DistributedLocalSize*>(
+                  mg_level.at(0)->get_coarse_op().get())
+                  ->get_local_size(),
+              gko::dim<2>(n - 1));
+    // next mg_level
+    ASSERT_EQ(mg_level.at(1)->get_fine_op()->get_size(), gko::dim<2>(first_n));
+    ASSERT_EQ(mg_level.at(1)->get_restrict_op()->get_size(),
+              gko::dim<2>(second_n, first_n));
+    ASSERT_EQ(mg_level.at(1)->get_prolong_op()->get_size(),
+              gko::dim<2>(first_n, second_n));
+    ASSERT_EQ(mg_level.at(1)->get_coarse_op()->get_size(),
+              gko::dim<2>(second_n));
+}
+
+
+TEST_F(Multigrid, ApplyWithoutException)
+{
+    auto mg_factory =
+        multigrid::build()
+            .with_max_levels(2u)
+            .with_mg_level(mg_level::build())
+            .with_pre_smoother(nullptr)
+            .with_mid_smoother(nullptr)
+            .with_criteria(gko::stop::Iteration::build().with_max_iters(1u))
+            .with_min_coarse_rows(1u)
+            .with_coarsest_solver(
+                gko::solver::Cg<value_type>::build()
+                    .with_criteria(
+                        gko::stop::Iteration::build().with_max_iters(1u))
+                    .on(this->ref))
+            .on(this->ref);
+    gko::size_type n = 5;
+    gko::size_type global_n = n * this->comm.size();
+    auto mtx = gko::share(
+        dist_mtx_type::create(this->ref, this->comm, gko::dim<2>{global_n},
+                              DummyLinOp::create(this->ref, gko::dim<2>{n})));
+    auto b = dist_vec_type::create(this->ref, this->comm,
+                                   gko::dim<2>{global_n, 1}, gko::dim<2>{n, 1});
+    auto x = dist_vec_type::create(this->ref, this->comm,
+                                   gko::dim<2>{global_n, 1}, gko::dim<2>{n, 1});
+
+    auto mg = mg_factory->generate(mtx);
+
+    ASSERT_NO_THROW(mg->apply(b, x));
+}
+
+
+}  // namespace

--- a/core/test/mpi/distributed/solver/multigrid.cpp
+++ b/core/test/mpi/distributed/solver/multigrid.cpp
@@ -71,17 +71,12 @@ protected:
           op_{op}
     {
         auto exec = this->get_executor();
-        auto original_n =
-            dynamic_cast<
-                const gko::experimental::distributed::DistributedLocalSize*>(
-                op_.get())
-                ->get_local_size()[0];
+        auto distributed_op = dynamic_cast<
+            const gko::experimental::distributed::DistributedBase*>(op_.get());
+        auto original_n = distributed_op->get_local_size()[0];
         gko::size_type n = original_n - 1;
 
-        auto comm = dynamic_cast<
-                        const gko::experimental::distributed::DistributedBase*>(
-                        op_.get())
-                        ->get_communicator();
+        auto comm = distributed_op->get_communicator();
         auto original_size = op_->get_size()[0];
         auto total_size = original_size - comm.size();
         coarse_ =
@@ -161,11 +156,11 @@ TEST_F(Multigrid, ConstructCorrect)
               gko::dim<2>(global_n, first_n));
     ASSERT_EQ(mg_level.at(0)->get_coarse_op()->get_size(),
               gko::dim<2>(first_n));
-    ASSERT_EQ(dynamic_cast<
-                  const gko::experimental::distributed::DistributedLocalSize*>(
-                  mg_level.at(0)->get_coarse_op().get())
-                  ->get_local_size(),
-              gko::dim<2>(n - 1));
+    ASSERT_EQ(
+        dynamic_cast<const gko::experimental::distributed::DistributedBase*>(
+            mg_level.at(0)->get_coarse_op().get())
+            ->get_local_size(),
+        gko::dim<2>(n - 1));
     // next mg_level
     ASSERT_EQ(mg_level.at(1)->get_fine_op()->get_size(), gko::dim<2>(first_n));
     ASSERT_EQ(mg_level.at(1)->get_restrict_op()->get_size(),

--- a/include/ginkgo/core/distributed/base.hpp
+++ b/include/ginkgo/core/distributed/base.hpp
@@ -67,6 +67,21 @@ private:
 };
 
 
+/**
+ * DistributedLocalSize is a feature class providing `get_local_size` which
+ * return the size of local operator.
+ */
+class DistributedLocalSize {
+public:
+    /**
+     * get the size of local operator
+     *
+     * @return the size of local operator
+     */
+    virtual dim<2> get_local_size() const = 0;
+};
+
+
 }  // namespace distributed
 }  // namespace experimental
 }  // namespace gko

--- a/include/ginkgo/core/distributed/base.hpp
+++ b/include/ginkgo/core/distributed/base.hpp
@@ -55,6 +55,13 @@ public:
      */
     mpi::communicator get_communicator() const { return comm_; }
 
+    /**
+     * get the size of local operator
+     *
+     * @return the size of local operator
+     */
+    virtual dim<2> get_local_size() const = 0;
+
 protected:
     /**
      * Creates a new DistributedBase with the specified mpi::communicator.
@@ -64,21 +71,6 @@ protected:
 
 private:
     mpi::communicator comm_;
-};
-
-
-/**
- * DistributedLocalSize is a feature class providing `get_local_size` which
- * return the size of local operator.
- */
-class DistributedLocalSize {
-public:
-    /**
-     * get the size of local operator
-     *
-     * @return the size of local operator
-     */
-    virtual dim<2> get_local_size() const = 0;
 };
 
 

--- a/include/ginkgo/core/distributed/matrix.hpp
+++ b/include/ginkgo/core/distributed/matrix.hpp
@@ -128,6 +128,21 @@ class Vector;
 
 
 /**
+ * DistributedLocalSize is a feature class providing `get_local_size` which
+ * return the size of local operator.
+ */
+class DistributedLocalSize {
+public:
+    /**
+     * get the size of local operator
+     *
+     * @return the size of local operator
+     */
+    virtual dim<2> get_local_size() const = 0;
+};
+
+
+/**
  * The Matrix class defines a (MPI-)distributed matrix.
  *
  * The matrix is stored in a row-wise distributed format.
@@ -238,7 +253,8 @@ class Matrix
           Matrix<ValueType, LocalIndexType, GlobalIndexType>>,
       public ConvertibleTo<
           Matrix<next_precision<ValueType>, LocalIndexType, GlobalIndexType>>,
-      public DistributedBase {
+      public DistributedBase,
+      public DistributedLocalSize {
     friend class EnableDistributedPolymorphicObject<Matrix, LinOp>;
     friend class Matrix<next_precision<ValueType>, LocalIndexType,
                         GlobalIndexType>;
@@ -335,6 +351,8 @@ public:
             row_partition,
         ptr_param<const Partition<local_index_type, global_index_type>>
             col_partition);
+
+    dim<2> get_local_size() const override { return local_mtx_->get_size(); }
 
     /**
      * Get read access to the stored local matrix.

--- a/include/ginkgo/core/distributed/matrix.hpp
+++ b/include/ginkgo/core/distributed/matrix.hpp
@@ -128,21 +128,6 @@ class Vector;
 
 
 /**
- * DistributedLocalSize is a feature class providing `get_local_size` which
- * return the size of local operator.
- */
-class DistributedLocalSize {
-public:
-    /**
-     * get the size of local operator
-     *
-     * @return the size of local operator
-     */
-    virtual dim<2> get_local_size() const = 0;
-};
-
-
-/**
  * The Matrix class defines a (MPI-)distributed matrix.
  *
  * The matrix is stored in a row-wise distributed format.
@@ -352,7 +337,7 @@ public:
         ptr_param<const Partition<local_index_type, global_index_type>>
             col_partition);
 
-    dim<2> get_local_size() const override { return local_mtx_->get_size(); }
+    dim<2> get_local_size() const override;
 
     /**
      * Get read access to the stored local matrix.

--- a/include/ginkgo/core/distributed/matrix.hpp
+++ b/include/ginkgo/core/distributed/matrix.hpp
@@ -518,6 +518,21 @@ public:
         ptr_param<const LinOp> local_matrix_template,
         ptr_param<const LinOp> non_local_matrix_template);
 
+    /**
+     * Creates a local-only distributed matrix with existent LinOp
+     *
+     * @note It use the input to build up the distributed matrix
+     *
+     * @param exec  Executor associated with this matrix.
+     * @param comm  Communicator associated with this matrix.
+     * @param local_linop  the local linop
+     *
+     * @return A smart pointer to the newly created matrix.
+     */
+    static std::unique_ptr<Matrix> create(std::shared_ptr<const Executor> exec,
+                                          mpi::communicator comm, dim<2> size,
+                                          std::shared_ptr<LinOp> local_linop);
+
 protected:
     explicit Matrix(std::shared_ptr<const Executor> exec,
                     mpi::communicator comm);
@@ -529,24 +544,7 @@ protected:
 
     explicit Matrix(std::shared_ptr<const Executor> exec,
                     mpi::communicator comm, dim<2> size,
-                    std::shared_ptr<LinOp> local_linop)
-        : EnableDistributedLinOp<
-              Matrix<value_type, local_index_type, global_index_type>>{exec},
-          DistributedBase{comm},
-          send_offsets_(comm.size() + 1),
-          send_sizes_(comm.size()),
-          recv_offsets_(comm.size() + 1),
-          recv_sizes_(comm.size()),
-          gather_idxs_{exec},
-          recv_gather_idxs_{exec},
-          non_local_to_global_{exec},
-          one_scalar_{}
-    {
-        this->set_size(size);
-        one_scalar_.init(exec, dim<2>{1, 1});
-        one_scalar_->fill(one<value_type>());
-        local_mtx_ = local_linop;
-    }
+                    std::shared_ptr<LinOp> local_linop);
 
     /**
      * Starts a non-blocking communication of the values of b that are shared

--- a/include/ginkgo/core/distributed/matrix.hpp
+++ b/include/ginkgo/core/distributed/matrix.hpp
@@ -238,8 +238,7 @@ class Matrix
           Matrix<ValueType, LocalIndexType, GlobalIndexType>>,
       public ConvertibleTo<
           Matrix<next_precision<ValueType>, LocalIndexType, GlobalIndexType>>,
-      public DistributedBase,
-      public DistributedLocalSize {
+      public DistributedBase {
     friend class EnableDistributedPolymorphicObject<Matrix, LinOp>;
     friend class Matrix<next_precision<ValueType>, LocalIndexType,
                         GlobalIndexType>;

--- a/include/ginkgo/core/distributed/vector.hpp
+++ b/include/ginkgo/core/distributed/vector.hpp
@@ -60,7 +60,8 @@ class Vector
     : public EnableDistributedLinOp<Vector<ValueType>>,
       public ConvertibleTo<Vector<next_precision<ValueType>>>,
       public EnableAbsoluteComputation<remove_complex<Vector<ValueType>>>,
-      public DistributedBase {
+      public DistributedBase,
+      public DistributedLocalSize {
     friend class EnableDistributedPolymorphicObject<Vector, LinOp>;
     friend class Vector<to_complex<ValueType>>;
     friend class Vector<remove_complex<ValueType>>;
@@ -166,6 +167,8 @@ public:
     std::unique_ptr<absolute_type> compute_absolute() const override;
 
     void compute_absolute_inplace() override;
+
+    dim<2> get_local_size() const override;
 
     /**
      * Creates a complex copy of the original vectors. If the original vectors

--- a/include/ginkgo/core/distributed/vector.hpp
+++ b/include/ginkgo/core/distributed/vector.hpp
@@ -60,8 +60,7 @@ class Vector
     : public EnableDistributedLinOp<Vector<ValueType>>,
       public ConvertibleTo<Vector<next_precision<ValueType>>>,
       public EnableAbsoluteComputation<remove_complex<Vector<ValueType>>>,
-      public DistributedBase,
-      public DistributedLocalSize {
+      public DistributedBase {
     friend class EnableDistributedPolymorphicObject<Vector, LinOp>;
     friend class Vector<to_complex<ValueType>>;
     friend class Vector<remove_complex<ValueType>>;

--- a/test/mpi/vector.cpp
+++ b/test/mpi/vector.cpp
@@ -122,6 +122,8 @@ TYPED_TEST(VectorCreation, CanReadGlobalMatrixData)
     GKO_ASSERT_EQUAL_DIMENSIONS(vec->get_size(), gko::dim<2>(6, 2));
     GKO_ASSERT_EQUAL_DIMENSIONS(vec->get_local_vector()->get_size(),
                                 gko::dim<2>(2, 2));
+    GKO_ASSERT_EQUAL_DIMENSIONS(vec->get_local_size(),
+                                vec->get_local_vector()->get_size());
     GKO_ASSERT_MTX_NEAR(vec->get_local_vector(), ref_data[rank], 0.0);
 }
 


### PR DESCRIPTION
This PR updates the multigrid class to handle distributed matrices and hence allows preconditioning and solution with distributed multigrid. 

## Major changes

1. Store row and column partition objects in the Matrix class to use within Multigrid.
2. Template the memory allocation and multigrid core functions on VectorType and allow dynamic switching between the two.
3. Store matrix_data object in the distributed matrix class to be able to generate coarse matrices.

Of course, as there is no coarse generation method, we cannot still use distributed multigrid automatically, but that will be added in a future PR.

## Points of discussion

1. We probably need to store the partition objects in the distributed matrix class, but I am open to other alternatives.
2. For ease, we also probably need to store the matrix_data object (or devie_matrix_data), but I am not very happy about this.

## Issues

1. The mixed precision version of distributed multigrid does not yet work and needs to be looked into.