### PR TITLE
Fixes read for skew-symmetric matrices

### DIFF
--- a/core/base/mtx_io.cpp
+++ b/core/base/mtx_io.cpp
@@ -405,7 +405,9 @@ private:
             matrix_data<ValueType, IndexType>& data) const override
         {
             data.nonzeros.emplace_back(row, col, entry);
-            data.nonzeros.emplace_back(col, row, -entry);
+            if (row != col) {
+                data.nonzeros.emplace_back(col, row, -entry);
+            }
         }
 
         /**

--- a/core/test/base/mtx_io.cpp
+++ b/core/test/base/mtx_io.cpp
@@ -330,6 +330,28 @@ TEST(MtxReader, ReadsSparseRealSkewSymetricMtx)
 }
 
 
+TEST(MtxReader, ReadsSparseRealSkewSymetricMtxWithExplicitDiagonal)
+{
+    using tpl = gko::matrix_data<double, gko::int32>::nonzero_type;
+    std::istringstream iss(
+        "%%MatrixMarket matrix coordinate real skew-symmetric\n"
+        "3 3 3\n"
+        "1 1 0.0\n"
+        "2 1 2.0\n"
+        "3 1 3.0\n");
+
+    auto data = gko::read_raw<double, gko::int32>(iss);
+
+    ASSERT_EQ(data.size, gko::dim<2>(3, 3));
+    auto& v = data.nonzeros;
+    ASSERT_EQ(v[0], tpl(0, 0, 0.0));
+    ASSERT_EQ(v[1], tpl(0, 1, -2.0));
+    ASSERT_EQ(v[2], tpl(0, 2, -3.0));
+    ASSERT_EQ(v[3], tpl(1, 0, 2.0));
+    ASSERT_EQ(v[4], tpl(2, 0, 3.0));
+}
+
+
 TEST(MtxReader, ReadsSparsePatternMtx)
 {
     using tpl = gko::matrix_data<double, gko::int32>::nonzero_type;


### PR DESCRIPTION
This PR adds a check preventing the duplication of diagonal entries during the skew-symmetric read. Of course, the diagonal element can only be zero, but even duplicating that leads to issues somewhere in our code. This is helpful if the matrix should explicitly contain the diagonal entries.