### PR TITLE
Remove .cpp include in CB-GMRES test

### DIFF
--- a/core/test/solver/cb_gmres.cpp
+++ b/core/test/solver/cb_gmres.cpp
@@ -46,7 +46,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <ginkgo/core/stop/residual_norm.hpp>
 
 
-#include "core/solver/cb_gmres.cpp"
 #include "core/test/utils.hpp"
 
 


### PR DESCRIPTION
Remove the `#include "core/solver/cb_gmres.cpp"` that was included in the core CB-GMRES test.
This does not (yet) lead to compiler errors, however, when adding non-templated functions in `core/solver/cb_gmres.cpp`, it fails (with confusing error messages).