### PR TITLE
Accept only unique_ptr for distributed vector constructors

### DIFF
--- a/benchmark/solver/distributed/solver.cpp
+++ b/benchmark/solver/distributed/solver.cpp
@@ -56,11 +56,9 @@ struct Generator : public DistributedDefaultSystemGenerator<SolverGenerator> {
     {
         return Vec::create(
             exec, comm, gko::dim<2>{system_matrix->get_size()[0], FLAGS_nrhs},
-            gko::as<typename LocalGenerator::Vec>(
-                local_generator.generate_rhs(
-                    exec, gko::as<Mtx>(system_matrix)->get_local_matrix().get(),
-                    config))
-                .get());
+            local_generator.generate_rhs(
+                exec, gko::as<Mtx>(system_matrix)->get_local_matrix().get(),
+                config));
     }
 
     std::unique_ptr<Vec> generate_initial_guess(
@@ -69,11 +67,9 @@ struct Generator : public DistributedDefaultSystemGenerator<SolverGenerator> {
     {
         return Vec::create(
             exec, comm, gko::dim<2>{rhs->get_size()[0], FLAGS_nrhs},
-            gko::as<typename LocalGenerator::Vec>(
-                local_generator.generate_initial_guess(
-                    exec, gko::as<Mtx>(system_matrix)->get_local_matrix().get(),
-                    rhs->get_local_vector()))
-                .get());
+            local_generator.generate_initial_guess(
+                exec, gko::as<Mtx>(system_matrix)->get_local_matrix().get(),
+                rhs->get_local_vector()));
     }
 };
 

--- a/benchmark/utils/generator.hpp
+++ b/benchmark/utils/generator.hpp
@@ -279,8 +279,9 @@ struct DistributedDefaultSystemGenerator {
         auto global_rows = local->get_size()[0];
         comm.all_reduce(gko::ReferenceExecutor::create(), &global_rows, 1,
                         MPI_SUM);
-        return Vec::create(
-            exec, comm, gko::dim<2>{global_rows, local->get_size()[1]}, local);
+        return Vec::create(exec, comm,
+                           gko::dim<2>{global_rows, local->get_size()[1]},
+                           std::move(local));
     }
 
     gko::experimental::mpi::communicator comm;

--- a/core/distributed/vector.cpp
+++ b/core/distributed/vector.cpp
@@ -102,7 +102,7 @@ Vector<ValueType>::Vector(std::shared_ptr<const Executor> exec,
 template <typename ValueType>
 Vector<ValueType>::Vector(std::shared_ptr<const Executor> exec,
                           mpi::communicator comm, dim<2> global_size,
-                          ptr_param<local_vector_type> local_vector)
+                          std::unique_ptr<local_vector_type> local_vector)
     : EnableDistributedLinOp<Vector<ValueType>>{exec, global_size},
       DistributedBase{comm},
       local_{exec}
@@ -114,7 +114,7 @@ Vector<ValueType>::Vector(std::shared_ptr<const Executor> exec,
 template <typename ValueType>
 Vector<ValueType>::Vector(std::shared_ptr<const Executor> exec,
                           mpi::communicator comm,
-                          ptr_param<local_vector_type> local_vector)
+                          std::unique_ptr<local_vector_type> local_vector)
     : EnableDistributedLinOp<Vector<ValueType>>{exec, {}},
       DistributedBase{comm},
       local_{exec}
@@ -587,8 +587,7 @@ Vector<ValueType>::create_real_view() const
 
     return real_type::create(this->get_executor(), this->get_communicator(),
                              dim<2>{num_global_rows, num_cols},
-                             const_cast<typename real_type::local_vector_type*>(
-                                 local_.create_real_view().get()));
+                             local_.create_real_view());
 }
 
 

--- a/core/distributed/vector.cpp
+++ b/core/distributed/vector.cpp
@@ -129,17 +129,12 @@ std::unique_ptr<const Vector<ValueType>> Vector<ValueType>::create_const(
     std::shared_ptr<const Executor> exec, mpi::communicator comm,
     dim<2> global_size, std::unique_ptr<const local_vector_type> local_vector)
 {
-    auto non_const_local_vector = local_vector_type::create(
-        local_vector->get_executor(), local_vector->get_size(),
-        detail::array_const_cast(
-            make_const_array_view(local_vector->get_executor(),
-                                  local_vector->get_num_stored_elements(),
-                                  local_vector->get_const_values())),
-        local_vector->get_stride());
+    auto non_const_local_vector =
+        const_cast<local_vector_type*>(local_vector.release());
 
-    return std::unique_ptr<const Vector<ValueType>>(
-        new Vector<ValueType>(std::move(exec), std::move(comm), global_size,
-                              std::move(non_const_local_vector)));
+    return std::unique_ptr<const Vector<ValueType>>(new Vector<ValueType>(
+        std::move(exec), std::move(comm), global_size,
+        std::unique_ptr<local_vector_type>{non_const_local_vector}));
 }
 
 

--- a/include/ginkgo/core/distributed/vector.hpp
+++ b/include/ginkgo/core/distributed/vector.hpp
@@ -475,12 +475,11 @@ public:
 
     /**
      * Creates a constant (immutable) distributed Vector from a constant local
-     * vector.The global size will be deduced from the local sizes, which will
+     * vector. The global size will be deduced from the local sizes, which will
      * incur a collective communication.
      *
      * @param exec  Executor associated with this vector
      * @param comm  Communicator associated with this vector
-     * @param global_size  The global size of the vector
      * @param local_vector  The underlying local vector, of which a view is
      *                      created
      */

--- a/include/ginkgo/core/distributed/vector.hpp
+++ b/include/ginkgo/core/distributed/vector.hpp
@@ -458,6 +458,36 @@ public:
 
     size_type get_stride() const noexcept { return local_.get_stride(); }
 
+    /**
+     * Creates a constant (immutable) distributed Vector from a constant local
+     * vector.
+     *
+     * @param exec  Executor associated with this vector
+     * @param comm  Communicator associated with this vector
+     * @param global_size  The global size of the vector
+     * @param local_vector  The underlying local vector, of which a view is
+     *                      created
+     */
+    static std::unique_ptr<const Vector> create_const(
+        std::shared_ptr<const Executor> exec, mpi::communicator comm,
+        dim<2> global_size,
+        std::unique_ptr<const local_vector_type> local_vector);
+
+    /**
+     * Creates a constant (immutable) distributed Vector from a constant local
+     * vector.The global size will be deduced from the local sizes, which will
+     * incur a collective communication.
+     *
+     * @param exec  Executor associated with this vector
+     * @param comm  Communicator associated with this vector
+     * @param global_size  The global size of the vector
+     * @param local_vector  The underlying local vector, of which a view is
+     *                      created
+     */
+    static std::unique_ptr<const Vector> create_const(
+        std::shared_ptr<const Executor> exec, mpi::communicator comm,
+        std::unique_ptr<const local_vector_type> local_vector);
+
 protected:
     /**
      * Creates an empty distributed vector with a specified size

--- a/include/ginkgo/core/distributed/vector.hpp
+++ b/include/ginkgo/core/distributed/vector.hpp
@@ -488,8 +488,10 @@ protected:
      * Creates a distributed vector from local vectors with a specified size.
      *
      * @note  The data form the local_vector will be moved into the new
-     *        distributed vector. This means, access to local_vector
-     *        will be invalid after this call.
+     *        distributed vector. You could either move in a std::unique_ptr
+     *        directly, copy a local vector with gko::clone, or create a
+     *        unique non-owining view of a given local vector with
+     *        gko::make_dense_view.
      *
      * @param exec  Executor associated with this vector
      * @param comm  Communicator associated with this vector
@@ -498,7 +500,7 @@ protected:
      *                      into this
      */
     Vector(std::shared_ptr<const Executor> exec, mpi::communicator comm,
-           dim<2> global_size, ptr_param<local_vector_type> local_vector);
+           dim<2> global_size, std::unique_ptr<local_vector_type> local_vector);
 
     /**
      * Creates a distributed vector from local vectors. The global size will
@@ -506,16 +508,18 @@ protected:
      * communication.
      *
      * @note  The data form the local_vector will be moved into the new
-     *        distributed vector. This means, access to local_vector
-     *        will be invalid after this call.
+     *        distributed vector. You could either move in a std::unique_ptr
+     *        directly, copy a local vector with gko::clone, or create a
+     *        unique non-owining view of a given local vector with
+     *        gko::make_dense_view.
      *
      * @param exec  Executor associated with this vector
      * @param comm  Communicator associated with this vector
      * @param local_vector  The underlying local vector, the data will be moved
-     *                      into this
+     *                      into this.
      */
     Vector(std::shared_ptr<const Executor> exec, mpi::communicator comm,
-           ptr_param<local_vector_type> local_vector);
+           std::unique_ptr<local_vector_type> local_vector);
 
     void resize(dim<2> global_size, dim<2> local_size);
 

--- a/test/mpi/distributed/vector.cpp
+++ b/test/mpi/distributed/vector.cpp
@@ -337,6 +337,39 @@ TYPED_TEST(VectorCreation, CanCreateFromLocalVectorWithoutSize)
 }
 
 
+TYPED_TEST(VectorCreation, CanConstCreateFromLocalVectorAndSize)
+{
+    using dist_vec_type = typename TestFixture::dist_vec_type;
+    using dense_type = typename TestFixture::dense_type;
+    auto local_vec = dense_type::create(this->exec);
+    local_vec->read(this->md_localized[this->comm.rank()]);
+
+    auto vec = dist_vec_type::create_const(
+        this->exec, this->comm, gko::dim<2>{6, 2}, gko::clone(local_vec));
+
+    ASSERT_TRUE(std::is_const<
+                typename std::remove_reference<decltype(*vec)>::type>::value);
+    GKO_ASSERT_EQUAL_DIMENSIONS(vec, gko::dim<2>(6, 2));
+    GKO_ASSERT_MTX_NEAR(vec->get_local_vector(), local_vec, 0);
+}
+
+
+TYPED_TEST(VectorCreation, CanConstCreateFromLocalVectorWithoutSize)
+{
+    using dist_vec_type = typename TestFixture::dist_vec_type;
+    using dense_type = typename TestFixture::dense_type;
+    auto local_vec = dense_type::create(this->exec);
+    local_vec->read(this->md_localized[this->comm.rank()]);
+
+    auto vec = dist_vec_type::create_const(this->exec, this->comm,
+                                           gko::clone(local_vec));
+
+    ASSERT_TRUE(std::is_const<
+                typename std::remove_reference<decltype(*vec)>::type>::value);
+    GKO_ASSERT_EQUAL_DIMENSIONS(vec, gko::dim<2>(6, 2));
+    GKO_ASSERT_MTX_NEAR(vec->get_local_vector(), local_vec, 0);
+}
+
 template <typename ValueType>
 class VectorCreationHelpers : public CommonMpiTestFixture {
 public:

--- a/test/mpi/distributed/vector.cpp
+++ b/test/mpi/distributed/vector.cpp
@@ -313,13 +313,12 @@ TYPED_TEST(VectorCreation, CanCreateFromLocalVectorAndSize)
     using dense_type = typename TestFixture::dense_type;
     auto local_vec = dense_type::create(this->exec);
     local_vec->read(this->md_localized[this->comm.rank()]);
-    auto clone_local_vec = gko::clone(local_vec);
 
     auto vec = dist_vec_type::create(this->exec, this->comm, gko::dim<2>{6, 2},
-                                     local_vec);
+                                     gko::clone(local_vec));
 
     GKO_ASSERT_EQUAL_DIMENSIONS(vec, gko::dim<2>(6, 2));
-    GKO_ASSERT_MTX_NEAR(vec->get_local_vector(), clone_local_vec, 0);
+    GKO_ASSERT_MTX_NEAR(vec->get_local_vector(), local_vec, 0);
 }
 
 
@@ -329,12 +328,12 @@ TYPED_TEST(VectorCreation, CanCreateFromLocalVectorWithoutSize)
     using dense_type = typename TestFixture::dense_type;
     auto local_vec = dense_type::create(this->exec);
     local_vec->read(this->md_localized[this->comm.rank()]);
-    auto clone_local_vec = gko::clone(local_vec);
 
-    auto vec = dist_vec_type::create(this->exec, this->comm, local_vec);
+    auto vec =
+        dist_vec_type::create(this->exec, this->comm, gko::clone(local_vec));
 
     GKO_ASSERT_EQUAL_DIMENSIONS(vec, gko::dim<2>(6, 2));
-    GKO_ASSERT_MTX_NEAR(vec->get_local_vector(), clone_local_vec, 0);
+    GKO_ASSERT_MTX_NEAR(vec->get_local_vector(), local_vec, 0);
 }
 
 


### PR DESCRIPTION
Inspired by #1279 I decided to clear up the ownership transfer in the distributed vector constructor. Currently, distributed vectors can be created from existing local vectors by passing them as raw pointers to the constructor. But the constructor will move from the passed in pointer, so this is potentially unsafe. 
One argument in favor of raw pointers was that working with views of local vectors would be simpler (I think?). Since now there is a helper function to create a view of a dense vector, this can now be done as easily with a `unique_ptr` parameter.

To make this work, I had to add `create_const` functions, but I guess that might be useful anyway.