### PR TITLE
Extend iteration complete event

### DIFF
--- a/benchmark/utils/loggers.hpp
+++ b/benchmark/utils/loggers.hpp
@@ -172,21 +172,13 @@ template <typename ValueType>
 struct ResidualLogger : gko::log::Logger {
     using rc_vtype = gko::remove_complex<ValueType>;
 
-    // TODO2.0: Remove when deprecating simple overload
-    void on_iteration_complete(const gko::LinOp* solver,
-                               const gko::size_type& it,
+    void on_iteration_complete(const gko::LinOp*, const gko::size_type&,
                                const gko::LinOp* residual,
                                const gko::LinOp* solution,
-                               const gko::LinOp* residual_norm) const override
-    {
-        on_iteration_complete(solver, it, residual, solution, residual_norm,
-                              nullptr);
-    }
-
-    void on_iteration_complete(
-        const gko::LinOp*, const gko::size_type&, const gko::LinOp* residual,
-        const gko::LinOp* solution, const gko::LinOp* residual_norm,
-        const gko::LinOp* implicit_sq_residual_norm) const override
+                               const gko::LinOp* residual_norm,
+                               const gko::LinOp* implicit_sq_residual_norm,
+                               const gko::array<gko::stopping_status>* status,
+                               bool all_stopped) const override
     {
         timestamps.PushBack(std::chrono::duration<double>(
                                 std::chrono::steady_clock::now() - start)
@@ -264,7 +256,9 @@ struct IterationLogger : gko::log::Logger {
     void on_iteration_complete(const gko::LinOp*,
                                const gko::size_type& num_iterations,
                                const gko::LinOp*, const gko::LinOp*,
-                               const gko::LinOp*) const override
+                               const gko::LinOp*, const gko::LinOp*,
+                               const gko::array<gko::stopping_status>*,
+                               bool) const override
     {
         this->num_iters = num_iterations;
     }

--- a/benchmark/utils/loggers.hpp
+++ b/benchmark/utils/loggers.hpp
@@ -172,9 +172,11 @@ template <typename ValueType>
 struct ResidualLogger : gko::log::Logger {
     using rc_vtype = gko::remove_complex<ValueType>;
 
-    void on_iteration_complete(const gko::LinOp*, const gko::size_type&,
-                               const gko::LinOp* residual,
+    void on_iteration_complete(const gko::LinOp*,
+                               const gko::LinOp* right_hand_side,
                                const gko::LinOp* solution,
+                               const gko::size_type&,
+                               const gko::LinOp* residual,
                                const gko::LinOp* residual_norm,
                                const gko::LinOp* implicit_sq_residual_norm,
                                const gko::array<gko::stopping_status>* status,
@@ -253,10 +255,11 @@ private:
 
 // Logs the number of iteration executed
 struct IterationLogger : gko::log::Logger {
-    void on_iteration_complete(const gko::LinOp*,
+    void on_iteration_complete(const gko::LinOp*, const gko::LinOp*,
+                               const gko::LinOp*,
                                const gko::size_type& num_iterations,
                                const gko::LinOp*, const gko::LinOp*,
-                               const gko::LinOp*, const gko::LinOp*,
+                               const gko::LinOp*,
                                const gko::array<gko::stopping_status>*,
                                bool) const override
     {

--- a/core/log/convergence.cpp
+++ b/core/log/convergence.cpp
@@ -114,10 +114,12 @@ void Convergence<ValueType>::on_iteration_complete(
                                            dim<2>{1, residual->get_size()[1]});
                     dense_r->compute_norm2(this->residual_norm_);
                 });
-        } else if (dynamic_cast<const solver::SolverBase*>(solver) &&
+        } else if (dynamic_cast<const solver::detail::SolverBaseLinOp*>(
+                       solver) &&
                    b != nullptr && x != nullptr) {
-            auto system_mtx = dynamic_cast<const solver::SolverBase*>(solver)
-                                  ->get_system_matrix();
+            auto system_mtx =
+                dynamic_cast<const solver::detail::SolverBaseLinOp*>(solver)
+                    ->get_system_matrix();
             using Vector = matrix::Dense<ValueType>;
             using NormVector = matrix::Dense<remove_complex<ValueType>>;
             detail::vector_dispatch<ValueType>(b, [&](const auto* dense_b) {

--- a/core/log/convergence.cpp
+++ b/core/log/convergence.cpp
@@ -36,6 +36,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <ginkgo/core/base/array.hpp>
 #include <ginkgo/core/base/math.hpp>
 #include <ginkgo/core/distributed/vector.hpp>
+#include <ginkgo/core/solver/solver_base.hpp>
 #include <ginkgo/core/stop/criterion.hpp>
 #include <ginkgo/core/stop/stopping_status.hpp>
 
@@ -85,6 +86,7 @@ void Convergence<ValueType>::on_iteration_complete(
     const bool stopped) const
 {
     if (stopped) {
+        // TODO need to throw if not solver or x
         array<stopping_status> tmp(status->get_executor()->get_master(),
                                    *status);
         this->convergence_status_ = true;

--- a/core/log/convergence.cpp
+++ b/core/log/convergence.cpp
@@ -86,7 +86,6 @@ void Convergence<ValueType>::on_iteration_complete(
     const bool stopped) const
 {
     if (stopped) {
-        // TODO need to throw if not solver or x
         array<stopping_status> tmp(status->get_executor()->get_master(),
                                    *status);
         this->convergence_status_ = true;

--- a/core/log/papi.cpp
+++ b/core/log/papi.cpp
@@ -274,10 +274,10 @@ void Papi<ValueType>::on_criterion_check_completed(
 
 template <typename ValueType>
 void Papi<ValueType>::on_iteration_complete(
-    const LinOp* solver, const size_type& num_iterations, const LinOp* residual,
-    const LinOp* x, const LinOp* residual_norm,
-    const LinOp* implicit_resnorm_sq, const array<stopping_status>* status,
-    bool stopped) const
+    const LinOp* solver, const LinOp* b, const LinOp* x,
+    const size_type& num_iterations, const LinOp* residual, const LinOp* x,
+    const LinOp* residual_norm, const LinOp* implicit_resnorm_sq,
+    const array<stopping_status>* status, bool stopped) const
 {
     iteration_complete.get_counter(solver) = num_iterations;
 }
@@ -290,8 +290,9 @@ void Papi<ValueType>::on_iteration_complete(const LinOp* solver,
                                             const LinOp* solution,
                                             const LinOp* residual_norm) const
 {
-    this->on_iteration_complete(solver, num_iterations, residual, solution,
-                                residual_norm, nullptr, nullptr, false);
+    this->on_iteration_complete(solver, nullptr, solution, num_iterations,
+                                residual, residual_norm, nullptr, nullptr,
+                                false);
 }
 
 
@@ -301,8 +302,9 @@ void Papi<ValueType>::on_iteration_complete(
     const LinOp* solution, const LinOp* residual_norm,
     const LinOp* implicit_sq_residual_norm) const
 {
-    this->on_iteration_complete(solver, num_iterations, residual, solution,
-                                residual_norm, nullptr, nullptr, false);
+    this->on_iteration_complete(solver, nullptr, solution, num_iterations,
+                                residual, residual_norm, nullptr, nullptr,
+                                false);
 }
 
 

--- a/core/log/papi.cpp
+++ b/core/log/papi.cpp
@@ -274,8 +274,8 @@ void Papi<ValueType>::on_criterion_check_completed(
 
 template <typename ValueType>
 void Papi<ValueType>::on_iteration_complete(
-    const LinOp* solver, const LinOp* b, const LinOp* x,
-    const size_type& num_iterations, const LinOp* residual, const LinOp* x,
+    const LinOp* solver, const LinOp* b, const LinOp* solution,
+    const size_type& num_iterations, const LinOp* residual,
     const LinOp* residual_norm, const LinOp* implicit_resnorm_sq,
     const array<stopping_status>* status, bool stopped) const
 {
@@ -303,8 +303,8 @@ void Papi<ValueType>::on_iteration_complete(
     const LinOp* implicit_sq_residual_norm) const
 {
     this->on_iteration_complete(solver, nullptr, solution, num_iterations,
-                                residual, residual_norm, nullptr, nullptr,
-                                false);
+                                residual, residual_norm,
+                                implicit_sq_residual_norm, nullptr, false);
 }
 
 

--- a/core/log/papi.cpp
+++ b/core/log/papi.cpp
@@ -273,6 +273,17 @@ void Papi<ValueType>::on_criterion_check_completed(
 
 
 template <typename ValueType>
+void Papi<ValueType>::on_iteration_complete(
+    const LinOp* solver, const size_type& num_iterations, const LinOp* residual,
+    const LinOp* x, const LinOp* residual_norm,
+    const LinOp* implicit_resnorm_sq, const array<stopping_status>* status,
+    bool stopped) const
+{
+    iteration_complete.get_counter(solver) = num_iterations;
+}
+
+
+template <typename ValueType>
 void Papi<ValueType>::on_iteration_complete(const LinOp* solver,
                                             const size_type& num_iterations,
                                             const LinOp* residual,
@@ -280,7 +291,7 @@ void Papi<ValueType>::on_iteration_complete(const LinOp* solver,
                                             const LinOp* residual_norm) const
 {
     this->on_iteration_complete(solver, num_iterations, residual, solution,
-                                residual_norm, nullptr);
+                                residual_norm, nullptr, nullptr, false);
 }
 
 
@@ -290,7 +301,8 @@ void Papi<ValueType>::on_iteration_complete(
     const LinOp* solution, const LinOp* residual_norm,
     const LinOp* implicit_sq_residual_norm) const
 {
-    iteration_complete.get_counter(solver) = num_iterations;
+    this->on_iteration_complete(solver, num_iterations, residual, solution,
+                                residual_norm, nullptr, nullptr, false);
 }
 
 

--- a/core/log/profiler_hook.cpp
+++ b/core/log/profiler_hook.cpp
@@ -275,24 +275,14 @@ void ProfilerHook::on_criterion_check_completed(
 }
 
 
-void ProfilerHook::on_iteration_complete(const LinOp* solver,
-                                         const size_type& num_iterations,
-                                         const LinOp* residual,
-                                         const LinOp* solution,
-                                         const LinOp* residual_norm) const
-{
-    this->on_iteration_complete(solver, num_iterations, residual, solution,
-                                residual_norm, nullptr);
-}
-
-
 void ProfilerHook::on_iteration_complete(
-    const LinOp* solver, const size_type& num_iterations, const LinOp* residual,
-    const LinOp* solution, const LinOp* residual_norm,
-    const LinOp* implicit_sq_residual_norm) const
+    const LinOp* solver, const LinOp* right_hand_side, const LinOp* solution,
+    const size_type& num_iterations, const LinOp* residual,
+    const LinOp* residual_norm, const LinOp* implicit_sq_residual_norm,
+    const array<stopping_status>* status, bool stopped) const
 {
     if (num_iterations > 0 &&
-        dynamic_cast<const solver::IterativeBase*>(solver)) {
+        dynamic_cast<const solver::IterativeBase*>(solver) && !stopped) {
         this->end_hook_("iteration", profile_event_category::solver);
         this->begin_hook_("iteration", profile_event_category::solver);
     }

--- a/core/log/record.cpp
+++ b/core/log/record.cpp
@@ -295,7 +295,7 @@ void Record::on_iteration_complete(const LinOp* solver,
                                    const LinOp* residual_norm) const
 {
     this->on_iteration_complete(solver, num_iterations, residual, solution,
-                                residual_norm, nullptr);
+                                residual_norm, nullptr, nullptr, false);
 }
 
 
@@ -305,11 +305,22 @@ void Record::on_iteration_complete(const LinOp* solver,
                                    const LinOp* residual_norm,
                                    const LinOp* implicit_sq_residual_norm) const
 {
+    this->on_iteration_complete(solver, num_iterations, residual, solution,
+                                residual_norm, nullptr, nullptr, false);
+}
+void Record::on_iteration_complete(const LinOp* solver,
+                                   const size_type& num_iterations,
+                                   const LinOp* residual, const LinOp* x,
+                                   const LinOp* residual_norm,
+                                   const LinOp* implicit_resnorm_sq,
+                                   const array<stopping_status>* status,
+                                   bool stopped) const
+{
     append_deque(
         data_.iteration_completed,
         (std::unique_ptr<iteration_complete_data>(new iteration_complete_data{
-            solver, num_iterations, residual, solution, residual_norm,
-            implicit_sq_residual_norm})));
+            solver, num_iterations, residual, x, residual_norm,
+            implicit_resnorm_sq, status, stopped})));
 }
 
 

--- a/core/log/record.cpp
+++ b/core/log/record.cpp
@@ -308,6 +308,8 @@ void Record::on_iteration_complete(const LinOp* solver,
     this->on_iteration_complete(solver, num_iterations, residual, solution,
                                 residual_norm, nullptr, nullptr, false);
 }
+
+
 void Record::on_iteration_complete(const LinOp* solver,
                                    const size_type& num_iterations,
                                    const LinOp* residual, const LinOp* x,

--- a/core/log/record.cpp
+++ b/core/log/record.cpp
@@ -294,8 +294,9 @@ void Record::on_iteration_complete(const LinOp* solver,
                                    const LinOp* residual, const LinOp* solution,
                                    const LinOp* residual_norm) const
 {
-    this->on_iteration_complete(solver, num_iterations, residual, solution,
-                                residual_norm, nullptr, nullptr, false);
+    this->on_iteration_complete(solver, nullptr, solution, num_iterations,
+                                residual, residual_norm, nullptr, nullptr,
+                                false);
 }
 
 
@@ -305,24 +306,23 @@ void Record::on_iteration_complete(const LinOp* solver,
                                    const LinOp* residual_norm,
                                    const LinOp* implicit_sq_residual_norm) const
 {
-    this->on_iteration_complete(solver, num_iterations, residual, solution,
-                                residual_norm, nullptr, nullptr, false);
+    this->on_iteration_complete(solver, nullptr, solution, num_iterations,
+                                residual, residual_norm,
+                                implicit_sq_residual_norm, nullptr, false);
 }
 
 
-void Record::on_iteration_complete(const LinOp* solver,
-                                   const size_type& num_iterations,
-                                   const LinOp* residual, const LinOp* x,
-                                   const LinOp* residual_norm,
-                                   const LinOp* implicit_resnorm_sq,
-                                   const array<stopping_status>* status,
-                                   bool stopped) const
+void Record::on_iteration_complete(
+    const LinOp* solver, const LinOp* right_hand_side, const LinOp* solution,
+    const size_type& num_iterations, const LinOp* residual,
+    const LinOp* residual_norm, const LinOp* implicit_resnorm_sq,
+    const array<stopping_status>* status, bool stopped) const
 {
     append_deque(
         data_.iteration_completed,
         (std::unique_ptr<iteration_complete_data>(new iteration_complete_data{
-            solver, num_iterations, residual, x, residual_norm,
-            implicit_resnorm_sq, status, stopped})));
+            solver, right_hand_side, solution, num_iterations, residual,
+            residual_norm, implicit_resnorm_sq, status, stopped})));
 }
 
 

--- a/core/log/stream.cpp
+++ b/core/log/stream.cpp
@@ -487,31 +487,6 @@ void Stream<ValueType>::on_iteration_complete(
 }
 
 
-template <typename ValueType>
-void Stream<ValueType>::on_iteration_complete(const LinOp* solver,
-                                              const size_type& num_iterations,
-                                              const LinOp* residual,
-                                              const LinOp* solution,
-                                              const LinOp* residual_norm) const
-{
-    this->on_iteration_complete(solver, nullptr, solution, num_iterations,
-                                residual, residual_norm, nullptr, nullptr,
-                                false);
-}
-
-
-template <typename ValueType>
-void Stream<ValueType>::on_iteration_complete(
-    const LinOp* solver, const size_type& num_iterations, const LinOp* residual,
-    const LinOp* solution, const LinOp* residual_norm,
-    const LinOp* implicit_sq_residual_norm) const
-{
-    this->on_iteration_complete(solver, nullptr, solution, num_iterations,
-                                residual, residual_norm,
-                                implicit_sq_residual_norm, nullptr, false);
-}
-
-
 #define GKO_DECLARE_STREAM(_type) class Stream<_type>
 GKO_INSTANTIATE_FOR_EACH_VALUE_TYPE(GKO_DECLARE_STREAM);
 

--- a/core/log/stream.cpp
+++ b/core/log/stream.cpp
@@ -444,13 +444,14 @@ void Stream<ValueType>::on_criterion_check_completed(
 
 template <typename ValueType>
 void Stream<ValueType>::on_iteration_complete(
-    const LinOp* solver, const size_type& num_iterations, const LinOp* residual,
-    const LinOp* solution, const LinOp* residual_norm,
-    const LinOp* implicit_resnorm_sq, const array<stopping_status>* status,
-    bool stopped) const
+    const LinOp* solver, const LinOp* right_hand_side, const LinOp* solution,
+    const size_type& num_iterations, const LinOp* residual,
+    const LinOp* residual_norm, const LinOp* implicit_resnorm_sq,
+    const array<stopping_status>* status, bool stopped) const
 {
     *os_ << prefix_ << "iteration " << num_iterations
          << " completed with solver " << demangle_name(solver)
+         << " and right-hand-side " << demangle_name(right_hand_side)
          << " with residual " << demangle_name(residual) << ", solution "
          << demangle_name(solution) << ", residual_norm "
          << demangle_name(residual_norm) << " and implicit_sq_residual_norm "
@@ -463,10 +464,8 @@ void Stream<ValueType>::on_iteration_complete(
     if (verbose_) {
         *os_ << demangle_name(residual)
              << as<gko::matrix::Dense<ValueType>>(residual) << std::endl;
-        if (solution != nullptr) {
-            *os_ << demangle_name(solution)
-                 << as<gko::matrix::Dense<ValueType>>(solution) << std::endl;
-        }
+        *os_ << demangle_name(solution)
+             << as<gko::matrix::Dense<ValueType>>(solution) << std::endl;
         if (residual_norm != nullptr) {
             *os_ << demangle_name(residual_norm)
                  << as<gko::matrix::Dense<ValueType>>(residual_norm)
@@ -482,6 +481,8 @@ void Stream<ValueType>::on_iteration_complete(
                                        *status);
             *os_ << tmp.get_const_data();
         }
+        *os_ << demangle_name(right_hand_side)
+             << as<gko::matrix::Dense<ValueType>>(right_hand_side) << std::endl;
     }
 }
 
@@ -493,8 +494,9 @@ void Stream<ValueType>::on_iteration_complete(const LinOp* solver,
                                               const LinOp* solution,
                                               const LinOp* residual_norm) const
 {
-    this->on_iteration_complete(solver, num_iterations, residual, solution,
-                                residual_norm, nullptr, nullptr, false);
+    this->on_iteration_complete(solver, nullptr, solution, num_iterations,
+                                residual, residual_norm, nullptr, nullptr,
+                                false);
 }
 
 
@@ -504,8 +506,9 @@ void Stream<ValueType>::on_iteration_complete(
     const LinOp* solution, const LinOp* residual_norm,
     const LinOp* implicit_sq_residual_norm) const
 {
-    this->on_iteration_complete(solver, num_iterations, residual, solution,
-                                residual_norm, nullptr, nullptr, false);
+    this->on_iteration_complete(solver, nullptr, solution, num_iterations,
+                                residual, residual_norm,
+                                implicit_sq_residual_norm, nullptr, false);
 }
 
 

--- a/core/log/stream.cpp
+++ b/core/log/stream.cpp
@@ -443,29 +443,23 @@ void Stream<ValueType>::on_criterion_check_completed(
 
 
 template <typename ValueType>
-void Stream<ValueType>::on_iteration_complete(const LinOp* solver,
-                                              const size_type& num_iterations,
-                                              const LinOp* residual,
-                                              const LinOp* solution,
-                                              const LinOp* residual_norm) const
-{
-    this->on_iteration_complete(solver, num_iterations, residual, solution,
-                                residual_norm, nullptr);
-}
-
-
-template <typename ValueType>
 void Stream<ValueType>::on_iteration_complete(
     const LinOp* solver, const size_type& num_iterations, const LinOp* residual,
     const LinOp* solution, const LinOp* residual_norm,
-    const LinOp* implicit_sq_residual_norm) const
+    const LinOp* implicit_resnorm_sq, const array<stopping_status>* status,
+    bool stopped) const
 {
     *os_ << prefix_ << "iteration " << num_iterations
          << " completed with solver " << demangle_name(solver)
          << " with residual " << demangle_name(residual) << ", solution "
          << demangle_name(solution) << ", residual_norm "
          << demangle_name(residual_norm) << " and implicit_sq_residual_norm "
-         << demangle_name(implicit_sq_residual_norm) << std::endl;
+         << demangle_name(implicit_resnorm_sq);
+    if (status) {
+        *os_ << ". Stopped the iteration process " << std::boolalpha << stopped;
+    }
+    *os_ << std::endl;
+
     if (verbose_) {
         *os_ << demangle_name(residual)
              << as<gko::matrix::Dense<ValueType>>(residual) << std::endl;
@@ -478,12 +472,40 @@ void Stream<ValueType>::on_iteration_complete(
                  << as<gko::matrix::Dense<ValueType>>(residual_norm)
                  << std::endl;
         }
-        if (implicit_sq_residual_norm != nullptr) {
-            *os_ << demangle_name(implicit_sq_residual_norm)
-                 << as<gko::matrix::Dense<ValueType>>(implicit_sq_residual_norm)
+        if (implicit_resnorm_sq != nullptr) {
+            *os_ << demangle_name(implicit_resnorm_sq)
+                 << as<gko::matrix::Dense<ValueType>>(implicit_resnorm_sq)
                  << std::endl;
         }
+        if (status != nullptr) {
+            array<stopping_status> tmp(status->get_executor()->get_master(),
+                                       *status);
+            *os_ << tmp.get_const_data();
+        }
     }
+}
+
+
+template <typename ValueType>
+void Stream<ValueType>::on_iteration_complete(const LinOp* solver,
+                                              const size_type& num_iterations,
+                                              const LinOp* residual,
+                                              const LinOp* solution,
+                                              const LinOp* residual_norm) const
+{
+    this->on_iteration_complete(solver, num_iterations, residual, solution,
+                                residual_norm, nullptr, nullptr, false);
+}
+
+
+template <typename ValueType>
+void Stream<ValueType>::on_iteration_complete(
+    const LinOp* solver, const size_type& num_iterations, const LinOp* residual,
+    const LinOp* solution, const LinOp* residual_norm,
+    const LinOp* implicit_sq_residual_norm) const
+{
+    this->on_iteration_complete(solver, num_iterations, residual, solution,
+                                residual_norm, nullptr, nullptr, false);
 }
 
 

--- a/core/solver/bicg.cpp
+++ b/core/solver/bicg.cpp
@@ -210,14 +210,16 @@ void Bicg<ValueType>::apply_dense_impl(const matrix::Dense<ValueType>* dense_b,
         z->compute_conj_dot(r2, rho, reduction_tmp);
 
         ++iter;
-        this->template log<log::Logger::iteration_complete>(
-            this, iter, r, dense_x, nullptr, rho);
-        if (stop_criterion->update()
+        bool all_stopped =
+            stop_criterion->update()
                 .num_iterations(iter)
                 .residual(r)
                 .implicit_sq_residual_norm(rho)
                 .solution(dense_x)
-                .check(RelativeStoppingId, true, &stop_status, &one_changed)) {
+                .check(RelativeStoppingId, true, &stop_status, &one_changed);
+        this->template log<log::Logger::iteration_complete>(
+            this, iter, r, dense_x, nullptr, rho, &stop_status, all_stopped);
+        if (all_stopped) {
             break;
         }
 

--- a/core/solver/bicg.cpp
+++ b/core/solver/bicg.cpp
@@ -218,7 +218,8 @@ void Bicg<ValueType>::apply_dense_impl(const matrix::Dense<ValueType>* dense_b,
                 .solution(dense_x)
                 .check(RelativeStoppingId, true, &stop_status, &one_changed);
         this->template log<log::Logger::iteration_complete>(
-            this, iter, r, dense_x, nullptr, rho, &stop_status, all_stopped);
+            this, dense_b, dense_x, iter, r, nullptr, rho, &stop_status,
+            all_stopped);
         if (all_stopped) {
             break;
         }

--- a/core/solver/bicgstab.cpp
+++ b/core/solver/bicgstab.cpp
@@ -182,7 +182,8 @@ void Bicgstab<ValueType>::apply_dense_impl(const VectorType* dense_b,
                 .solution(dense_x)
                 .check(RelativeStoppingId, true, &stop_status, &one_changed);
         this->template log<log::Logger::iteration_complete>(
-            this, iter, r, dense_x, nullptr, rho, &stop_status, all_stopped);
+            this, dense_b, dense_x, iter, r, nullptr, rho, &stop_status,
+            all_stopped);
         if (all_stopped) {
             break;
         }
@@ -219,7 +220,8 @@ void Bicgstab<ValueType>::apply_dense_impl(const VectorType* dense_b,
                                               &stop_status));
         }
         this->template log<log::Logger::iteration_complete>(
-            this, iter, r, dense_x, nullptr, rho, &stop_status, all_stopped);
+            this, dense_b, dense_x, iter, r, nullptr, rho, &stop_status,
+            all_stopped);
         if (all_stopped) {
             break;
         }

--- a/core/solver/cb_gmres.cpp
+++ b/core/solver/cb_gmres.cpp
@@ -325,11 +325,12 @@ void CbGmres<ValueType>::apply_dense_impl(
 
         while (true) {
             ++total_iter;
-            this->template log<log::Logger::iteration_complete>(
-                this, total_iter, residual.get(), dense_x, residual_norm.get());
             // In the beginning, only force a fraction of the total iterations
             if (forced_iterations < forced_limit &&
                 forced_iterations < total_iter / forced_iteration_fraction) {
+                this->template log<log::Logger::iteration_complete>(
+                    this, total_iter, residual.get(), dense_x,
+                    residual_norm.get(), nullptr, &stop_status, false);
                 ++forced_iterations;
             } else {
                 bool all_changed = stop_criterion->update()
@@ -339,6 +340,9 @@ void CbGmres<ValueType>::apply_dense_impl(
                                        .solution(dense_x)
                                        .check(RelativeStoppingId, true,
                                               &stop_status, &one_changed);
+                this->template log<log::Logger::iteration_complete>(
+                    this, total_iter, residual.get(), dense_x,
+                    residual_norm.get(), nullptr, &stop_status, all_changed);
                 if (one_changed || all_changed) {
                     host_stop_status = stop_status;
                     bool host_array_changed{false};

--- a/core/solver/cb_gmres.cpp
+++ b/core/solver/cb_gmres.cpp
@@ -329,7 +329,7 @@ void CbGmres<ValueType>::apply_dense_impl(
             if (forced_iterations < forced_limit &&
                 forced_iterations < total_iter / forced_iteration_fraction) {
                 this->template log<log::Logger::iteration_complete>(
-                    this, total_iter, residual.get(), dense_x,
+                    this, dense_b, dense_x, total_iter, residual.get(),
                     residual_norm.get(), nullptr, &stop_status, false);
                 ++forced_iterations;
             } else {
@@ -341,7 +341,7 @@ void CbGmres<ValueType>::apply_dense_impl(
                                        .check(RelativeStoppingId, true,
                                               &stop_status, &one_changed);
                 this->template log<log::Logger::iteration_complete>(
-                    this, total_iter, residual.get(), dense_x,
+                    this, dense_b, dense_x, total_iter, residual.get(),
                     residual_norm.get(), nullptr, &stop_status, all_changed);
                 if (one_changed || all_changed) {
                     host_stop_status = stop_status;

--- a/core/solver/cg.cpp
+++ b/core/solver/cg.cpp
@@ -161,14 +161,16 @@ void Cg<ValueType>::apply_dense_impl(const VectorType* dense_b,
         r->compute_conj_dot(z, rho, reduction_tmp);
 
         ++iter;
-        this->template log<log::Logger::iteration_complete>(
-            this, iter, r, dense_x, nullptr, rho);
-        if (stop_criterion->update()
+        bool all_stopped =
+            stop_criterion->update()
                 .num_iterations(iter)
                 .residual(r)
                 .implicit_sq_residual_norm(rho)
                 .solution(dense_x)
-                .check(RelativeStoppingId, true, &stop_status, &one_changed)) {
+                .check(RelativeStoppingId, true, &stop_status, &one_changed);
+        this->template log<log::Logger::iteration_complete>(
+            this, iter, r, dense_x, nullptr, rho, &stop_status, all_stopped);
+        if (all_stopped) {
             break;
         }
 

--- a/core/solver/cg.cpp
+++ b/core/solver/cg.cpp
@@ -169,7 +169,8 @@ void Cg<ValueType>::apply_dense_impl(const VectorType* dense_b,
                 .solution(dense_x)
                 .check(RelativeStoppingId, true, &stop_status, &one_changed);
         this->template log<log::Logger::iteration_complete>(
-            this, iter, r, dense_x, nullptr, rho, &stop_status, all_stopped);
+            this, dense_b, dense_x, iter, r, nullptr, rho, &stop_status,
+            all_stopped);
         if (all_stopped) {
             break;
         }

--- a/core/solver/cgs.cpp
+++ b/core/solver/cgs.cpp
@@ -170,14 +170,16 @@ void Cgs<ValueType>::apply_dense_impl(const VectorType* dense_b,
         r->compute_conj_dot(r_tld, rho, reduction_tmp);
 
         ++iter;
-        this->template log<log::Logger::iteration_complete>(
-            this, iter, r, dense_x, nullptr, rho);
-        if (stop_criterion->update()
+        bool all_stopped =
+            stop_criterion->update()
                 .num_iterations(iter)
                 .residual(r)
                 .implicit_sq_residual_norm(rho)
                 .solution(dense_x)
-                .check(RelativeStoppingId, true, &stop_status, &one_changed)) {
+                .check(RelativeStoppingId, true, &stop_status, &one_changed);
+        this->template log<log::Logger::iteration_complete>(
+            this, iter, r, dense_x, nullptr, rho, &stop_status, all_stopped);
+        if (all_stopped) {
             break;
         }
 

--- a/core/solver/cgs.cpp
+++ b/core/solver/cgs.cpp
@@ -178,7 +178,8 @@ void Cgs<ValueType>::apply_dense_impl(const VectorType* dense_b,
                 .solution(dense_x)
                 .check(RelativeStoppingId, true, &stop_status, &one_changed);
         this->template log<log::Logger::iteration_complete>(
-            this, iter, r, dense_x, nullptr, rho, &stop_status, all_stopped);
+            this, dense_b, dense_x, iter, r, nullptr, rho, &stop_status,
+            all_stopped);
         if (all_stopped) {
             break;
         }

--- a/core/solver/fcg.cpp
+++ b/core/solver/fcg.cpp
@@ -164,14 +164,16 @@ void Fcg<ValueType>::apply_dense_impl(const VectorType* dense_b,
         t->compute_conj_dot(z, rho_t, reduction_tmp);
 
         ++iter;
-        this->template log<log::Logger::iteration_complete>(
-            this, iter, r, dense_x, nullptr, rho);
-        if (stop_criterion->update()
+        bool all_stopped =
+            stop_criterion->update()
                 .num_iterations(iter)
                 .residual(r)
                 .implicit_sq_residual_norm(rho)
                 .solution(dense_x)
-                .check(RelativeStoppingId, true, &stop_status, &one_changed)) {
+                .check(RelativeStoppingId, true, &stop_status, &one_changed);
+        this->template log<log::Logger::iteration_complete>(
+            this, iter, r, dense_x, nullptr, rho, &stop_status, all_stopped);
+        if (all_stopped) {
             break;
         }
 

--- a/core/solver/fcg.cpp
+++ b/core/solver/fcg.cpp
@@ -172,7 +172,8 @@ void Fcg<ValueType>::apply_dense_impl(const VectorType* dense_b,
                 .solution(dense_x)
                 .check(RelativeStoppingId, true, &stop_status, &one_changed);
         this->template log<log::Logger::iteration_complete>(
-            this, iter, r, dense_x, nullptr, rho, &stop_status, all_stopped);
+            this, dense_b, dense_x, iter, r, nullptr, rho, &stop_status,
+            all_stopped);
         if (all_stopped) {
             break;
         }

--- a/core/solver/gcr.cpp
+++ b/core/solver/gcr.cpp
@@ -206,16 +206,22 @@ void Gcr<ValueType>::apply_dense_impl(const VectorType* dense_b,
         ++total_iter;
         // compute residual norm
         residual->compute_norm2(residual_norm, reduction_tmp);
-        // Log current iteration
-        this->template log<log::Logger::iteration_complete>(
-            this, total_iter, residual, dense_x, residual_norm);
-        // Check stopping criterion
-        if (stop_criterion->update()
+
+        // Should the iteration stop?
+        auto all_stopped =
+            stop_criterion->update()
                 .num_iterations(total_iter)
                 .residual(residual)
                 .residual_norm(residual_norm)
                 .solution(dense_x)
-                .check(RelativeStoppingId, true, &stop_status, &one_changed)) {
+                .check(RelativeStoppingId, true, &stop_status, &one_changed);
+
+        // Log current iteration
+        this->template log<log::Logger::iteration_complete>(
+            this, dense_b, dense_x, total_iter, residual, residual_norm,
+            nullptr, &stop_status, all_stopped);
+        // Check stopping criterion
+        if (all_stopped) {
             break;
         }
 

--- a/core/solver/gmres.cpp
+++ b/core/solver/gmres.cpp
@@ -251,14 +251,17 @@ void Gmres<ValueType>::apply_dense_impl(const VectorType* dense_b,
      */
     while (true) {
         ++total_iter;
-        this->template log<log::Logger::iteration_complete>(
-            this, total_iter, residual, dense_x, residual_norm);
-        if (stop_criterion->update()
+        bool all_stopped =
+            stop_criterion->update()
                 .num_iterations(total_iter)
                 .residual(residual)
                 .residual_norm(residual_norm)
                 .solution(dense_x)
-                .check(RelativeStoppingId, false, &stop_status, &one_changed)) {
+                .check(RelativeStoppingId, false, &stop_status, &one_changed);
+        this->template log<log::Logger::iteration_complete>(
+            this, total_iter, residual, dense_x, residual_norm, nullptr,
+            &stop_status, all_stopped);
+        if (all_stopped) {
             break;
         }
 

--- a/core/solver/gmres.cpp
+++ b/core/solver/gmres.cpp
@@ -259,8 +259,8 @@ void Gmres<ValueType>::apply_dense_impl(const VectorType* dense_b,
                 .solution(dense_x)
                 .check(RelativeStoppingId, false, &stop_status, &one_changed);
         this->template log<log::Logger::iteration_complete>(
-            this, total_iter, residual, dense_x, residual_norm, nullptr,
-            &stop_status, all_stopped);
+            this, dense_b, dense_x, total_iter, residual, residual_norm,
+            nullptr, &stop_status, all_stopped);
         if (all_stopped) {
             break;
         }

--- a/core/solver/idr.cpp
+++ b/core/solver/idr.cpp
@@ -205,15 +205,18 @@ void Idr<ValueType>::iterate(const VectorType* dense_b,
      */
     while (true) {
         ++total_iter;
-        this->template log<log::Logger::iteration_complete>(this, total_iter,
-                                                            residual, dense_x);
 
-        if (stop_criterion->update()
+        bool all_stopped =
+            stop_criterion->update()
                 .num_iterations(total_iter)
                 .residual(residual)
                 .residual_norm(residual_norm)
                 .solution(dense_x)
-                .check(RelativeStoppingId, true, &stop_status, &one_changed)) {
+                .check(RelativeStoppingId, true, &stop_status, &one_changed);
+        this->template log<log::Logger::iteration_complete>(
+            this, total_iter, residual, dense_x, nullptr, nullptr, &stop_status,
+            all_stopped);
+        if (all_stopped) {
             break;
         }
 

--- a/core/solver/idr.cpp
+++ b/core/solver/idr.cpp
@@ -214,8 +214,8 @@ void Idr<ValueType>::iterate(const VectorType* dense_b,
                 .solution(dense_x)
                 .check(RelativeStoppingId, true, &stop_status, &one_changed);
         this->template log<log::Logger::iteration_complete>(
-            this, total_iter, residual, dense_x, nullptr, nullptr, &stop_status,
-            all_stopped);
+            this, dense_b, dense_x, total_iter, residual, nullptr, nullptr,
+            &stop_status, all_stopped);
         if (all_stopped) {
             break;
         }

--- a/core/solver/ir.cpp
+++ b/core/solver/ir.cpp
@@ -232,7 +232,7 @@ void Ir<ValueType>::apply_dense_impl(const VectorType* dense_b,
                                    .check(relative_stopping_id, true,
                                           &stop_status, &one_changed);
             this->template log<log::Logger::iteration_complete>(
-                this, iter, residual_ptr, dense_x, nullptr, nullptr,
+                this, dense_b, dense_x, iter, residual_ptr, nullptr, nullptr,
                 &stop_status, all_stopped);
             if (all_stopped) {
                 break;
@@ -248,7 +248,7 @@ void Ir<ValueType>::apply_dense_impl(const VectorType* dense_b,
                                           &stop_status, &one_changed);
             if (all_stopped) {
                 this->template log<log::Logger::iteration_complete>(
-                    this, iter, nullptr, dense_x, nullptr, nullptr,
+                    this, dense_b, dense_x, iter, nullptr, nullptr, nullptr,
                     &stop_status, all_stopped);
                 break;
             }
@@ -264,7 +264,7 @@ void Ir<ValueType>::apply_dense_impl(const VectorType* dense_b,
                               .check(relative_stopping_id, true, &stop_status,
                                      &one_changed);
             this->template log<log::Logger::iteration_complete>(
-                this, iter, residual_ptr, dense_x, nullptr, nullptr,
+                this, dense_b, dense_x, iter, residual_ptr, nullptr, nullptr,
                 &stop_status, all_stopped);
             if (all_stopped) {
                 break;

--- a/core/solver/multigrid.cpp
+++ b/core/solver/multigrid.cpp
@@ -691,9 +691,8 @@ void Multigrid::apply_dense_impl(const VectorType* b, VectorType* x,
 
         while (true) {
             ++iter;
-            this->template log<log::Logger::iteration_complete>(this, iter,
-                                                                nullptr, x);
-            if (stop_criterion->update()
+            bool all_stopped =
+                stop_criterion->update()
                     .num_iterations(iter)
                     // TODO: combine the out-of-cycle residual computation
                     // currently, the residual will computed additionally in
@@ -701,7 +700,11 @@ void Multigrid::apply_dense_impl(const VectorType* b, VectorType* x,
                     // residual check.
                     .solution(x)
                     .check(RelativeStoppingId, true, &stop_status,
-                           &one_changed)) {
+                           &one_changed);
+            this->template log<log::Logger::iteration_complete>(
+                this, iter, nullptr, x, nullptr, nullptr, &stop_status,
+                all_stopped);
+            if (all_stopped) {
                 break;
             }
             auto mode = multigrid::cycle_mode::first_of_cycle |

--- a/core/solver/multigrid.cpp
+++ b/core/solver/multigrid.cpp
@@ -702,7 +702,7 @@ void Multigrid::apply_dense_impl(const VectorType* b, VectorType* x,
                     .check(RelativeStoppingId, true, &stop_status,
                            &one_changed);
             this->template log<log::Logger::iteration_complete>(
-                this, iter, nullptr, x, nullptr, nullptr, &stop_status,
+                this, b, x, iter, nullptr, nullptr, nullptr, &stop_status,
                 all_stopped);
             if (all_stopped) {
                 break;

--- a/core/test/log/convergence.cpp
+++ b/core/test/log/convergence.cpp
@@ -83,9 +83,7 @@ TYPED_TEST_SUITE(Convergence, gko::test::ValueTypes, TypenameNameGenerator);
 
 TYPED_TEST(Convergence, CanGetEmptyData)
 {
-    auto logger = gko::log::Convergence<TypeParam>::create(
-        gko::log::Logger::criterion_events_mask |
-        gko::log::Logger::iteration_complete_mask);
+    auto logger = gko::log::Convergence<TypeParam>::create();
 
     ASSERT_EQ(logger->has_converged(), false);
     ASSERT_EQ(logger->get_num_iterations(), 0);
@@ -99,9 +97,7 @@ TYPED_TEST(Convergence, CanLogData)
 {
     using Dense = gko::matrix::Dense<TypeParam>;
     using AbsoluteDense = gko::matrix::Dense<gko::remove_complex<TypeParam>>;
-    auto logger = gko::log::Convergence<TypeParam>::create(
-        gko::log::Logger::criterion_events_mask |
-        gko::log::Logger::iteration_complete_mask);
+    auto logger = gko::log::Convergence<TypeParam>::create();
 
     logger->template on<gko::log::Logger::iteration_complete>(
         this->system.get(), this->rhs.get(), this->solution.get(), 100,
@@ -122,9 +118,7 @@ TYPED_TEST(Convergence, CanLogData)
 
 TYPED_TEST(Convergence, DoesNotLogIfNotStopped)
 {
-    auto logger = gko::log::Convergence<TypeParam>::create(
-        gko::log::Logger::criterion_events_mask |
-        gko::log::Logger::iteration_complete_mask);
+    auto logger = gko::log::Convergence<TypeParam>::create();
 
     logger->template on<gko::log::Logger::iteration_complete>(
         this->system.get(), this->rhs.get(), this->solution.get(), 100,
@@ -141,9 +135,7 @@ TYPED_TEST(Convergence, DoesNotLogIfNotStopped)
 TYPED_TEST(Convergence, CanComputeResidualNormFromResidual)
 {
     using AbsoluteDense = gko::matrix::Dense<gko::remove_complex<TypeParam>>;
-    auto logger = gko::log::Convergence<TypeParam>::create(
-        gko::log::Logger::criterion_events_mask |
-        gko::log::Logger::iteration_complete_mask);
+    auto logger = gko::log::Convergence<TypeParam>::create();
 
     logger->template on<gko::log::Logger::iteration_complete>(
         this->system.get(), this->rhs.get(), this->solution.get(), 100,
@@ -157,9 +149,7 @@ TYPED_TEST(Convergence, CanComputeResidualNormFromResidual)
 TYPED_TEST(Convergence, CanComputeResidualNormFromSolution)
 {
     using AbsoluteDense = gko::matrix::Dense<gko::remove_complex<TypeParam>>;
-    auto logger = gko::log::Convergence<TypeParam>::create(
-        gko::log::Logger::criterion_events_mask |
-        gko::log::Logger::iteration_complete_mask);
+    auto logger = gko::log::Convergence<TypeParam>::create();
 
     logger->template on<gko::log::Logger::iteration_complete>(
         this->system.get(), this->rhs.get(), this->solution.get(), 100, nullptr,

--- a/core/test/log/convergence.cpp
+++ b/core/test/log/convergence.cpp
@@ -93,10 +93,10 @@ TYPED_TEST(Convergence, CanLogData)
     auto logger = gko::log::Convergence<TypeParam>::create(
         gko::log::Logger::criterion_events_mask);
 
-    logger->template on<gko::log::Logger::criterion_check_completed>(
-        nullptr, 100, this->residual.get(), this->residual_norm.get(),
-        this->implicit_sq_resnorm.get(), this->solution.get(), 0, false,
-        &this->status, false, true);
+    logger->template on<gko::log::Logger::iteration_complete>(
+        nullptr, 100, this->residual.get(), this->solution.get(),
+        this->residual_norm.get(), this->implicit_sq_resnorm.get(),
+        &this->status, true);
 
     ASSERT_EQ(logger->has_converged(), true);
     ASSERT_EQ(logger->get_num_iterations(), 100);
@@ -115,10 +115,10 @@ TYPED_TEST(Convergence, DoesNotLogIfNotStopped)
     auto logger = gko::log::Convergence<TypeParam>::create(
         gko::log::Logger::criterion_events_mask);
 
-    logger->template on<gko::log::Logger::criterion_check_completed>(
-        nullptr, 100, this->residual.get(), this->residual_norm.get(),
-        this->implicit_sq_resnorm.get(), this->solution.get(), 0, false,
-        &this->status, false, false);
+    logger->template on<gko::log::Logger::iteration_complete>(
+        nullptr, 100, this->residual.get(), this->solution.get(),
+        this->residual_norm.get(), this->implicit_sq_resnorm.get(),
+        &this->status, false);
 
     ASSERT_EQ(logger->has_converged(), false);
     ASSERT_EQ(logger->get_num_iterations(), 0);
@@ -133,9 +133,9 @@ TYPED_TEST(Convergence, CanComputeResidualNorm)
     auto logger = gko::log::Convergence<TypeParam>::create(
         gko::log::Logger::criterion_events_mask);
 
-    logger->template on<gko::log::Logger::criterion_check_completed>(
-        nullptr, 100, this->residual.get(), nullptr, nullptr, nullptr, 0, false,
-        &this->status, false, true);
+    logger->template on<gko::log::Logger::iteration_complete>(
+        nullptr, 100, this->residual.get(), nullptr, nullptr, nullptr,
+        &this->status, true);
 
     GKO_ASSERT_MTX_NEAR(gko::as<AbsoluteDense>(logger->get_residual_norm()),
                         this->residual_norm, r<TypeParam>::value);

--- a/core/test/log/convergence.cpp
+++ b/core/test/log/convergence.cpp
@@ -76,7 +76,8 @@ TYPED_TEST_SUITE(Convergence, gko::test::ValueTypes, TypenameNameGenerator);
 TYPED_TEST(Convergence, CanGetEmptyData)
 {
     auto logger = gko::log::Convergence<TypeParam>::create(
-        gko::log::Logger::criterion_events_mask);
+        gko::log::Logger::criterion_events_mask |
+        gko::log::Logger::iteration_complete_mask);
 
     ASSERT_EQ(logger->has_converged(), false);
     ASSERT_EQ(logger->get_num_iterations(), 0);
@@ -91,7 +92,8 @@ TYPED_TEST(Convergence, CanLogData)
     using Dense = gko::matrix::Dense<TypeParam>;
     using AbsoluteDense = gko::matrix::Dense<gko::remove_complex<TypeParam>>;
     auto logger = gko::log::Convergence<TypeParam>::create(
-        gko::log::Logger::criterion_events_mask);
+        gko::log::Logger::criterion_events_mask |
+        gko::log::Logger::iteration_complete_mask);
 
     logger->template on<gko::log::Logger::iteration_complete>(
         nullptr, 100, this->residual.get(), this->solution.get(),
@@ -113,7 +115,8 @@ TYPED_TEST(Convergence, CanLogData)
 TYPED_TEST(Convergence, DoesNotLogIfNotStopped)
 {
     auto logger = gko::log::Convergence<TypeParam>::create(
-        gko::log::Logger::criterion_events_mask);
+        gko::log::Logger::criterion_events_mask |
+        gko::log::Logger::iteration_complete_mask);
 
     logger->template on<gko::log::Logger::iteration_complete>(
         nullptr, 100, this->residual.get(), this->solution.get(),
@@ -131,7 +134,8 @@ TYPED_TEST(Convergence, CanComputeResidualNorm)
 {
     using AbsoluteDense = gko::matrix::Dense<gko::remove_complex<TypeParam>>;
     auto logger = gko::log::Convergence<TypeParam>::create(
-        gko::log::Logger::criterion_events_mask);
+        gko::log::Logger::criterion_events_mask |
+        gko::log::Logger::iteration_complete_mask);
 
     logger->template on<gko::log::Logger::iteration_complete>(
         nullptr, 100, this->residual.get(), nullptr, nullptr, nullptr,

--- a/core/test/log/profiler_hook.cpp
+++ b/core/test/log/profiler_hook.cpp
@@ -413,7 +413,7 @@ TEST(ProfilerHookTableSummaryWriter, SummaryWorks)
     entries.push_back({"long", 120'000'000'000, 60'000'000'000, 1});
     entries.push_back({"eternal", 86'400'000'000'000, 86'400'000'000'000, 1});
     const auto expected = R"(Test header
-Overhead estimate 1.0 s
+Overhead estimate 1.0 s 
 |   name   | total  | total (self) | count |   avg    | avg (self) |
 |----------|-------:|-------------:|------:|---------:|-----------:|
 | eternal  | 1.0 d  |       1.0 d  |     1 |   1.0 d  |     1.0 d  |

--- a/core/test/log/profiler_hook.cpp
+++ b/core/test/log/profiler_hook.cpp
@@ -187,12 +187,8 @@ TEST(ProfilerHook, LogsIteration)
     std::vector<std::string> expected{"begin:apply(solver)",
                                       "begin:iteration",
                                       "end:iteration",
-                                      "begin:iteration",
-                                      "end:iteration",
                                       "end:apply(solver)",
                                       "begin:advanced_apply(solver)",
-                                      "begin:iteration",
-                                      "end:iteration",
                                       "begin:iteration",
                                       "end:iteration",
                                       "end:advanced_apply(solver)"};
@@ -417,7 +413,7 @@ TEST(ProfilerHookTableSummaryWriter, SummaryWorks)
     entries.push_back({"long", 120'000'000'000, 60'000'000'000, 1});
     entries.push_back({"eternal", 86'400'000'000'000, 86'400'000'000'000, 1});
     const auto expected = R"(Test header
-Overhead estimate 1.0 s 
+Overhead estimate 1.0 s
 |   name   | total  | total (self) | count |   avg    | avg (self) |
 |----------|-------:|-------------:|------:|---------:|-----------:|
 | eternal  | 1.0 d  |       1.0 d  |     1 |   1.0 d  |     1.0 d  |

--- a/core/test/log/record.cpp
+++ b/core/test/log/record.cpp
@@ -573,6 +573,7 @@ TEST(Record, CatchesIterations)
                 gko::stop::Iteration::build().with_max_iters(3u).on(exec))
             .on(exec);
     auto solver = factory->generate(gko::initialize<Dense>({1.1}, exec));
+    auto right_hand_side = gko::initialize<Dense>({-5.5}, exec);
     auto residual = gko::initialize<Dense>({-4.4}, exec);
     auto solution = gko::initialize<Dense>({-2.2}, exec);
     auto residual_norm = gko::initialize<Dense>({-3.3}, exec);
@@ -583,9 +584,9 @@ TEST(Record, CatchesIterations)
     stop_status.get_data()->converge(RelativeStoppingId);
 
     logger->on<gko::log::Logger::iteration_complete>(
-        solver.get(), num_iters, residual.get(), solution.get(),
-        residual_norm.get(), implicit_sq_residual_norm.get(), &stop_status,
-        true);
+        solver.get(), right_hand_side.get(), solution.get(), num_iters,
+        residual.get(), residual_norm.get(), implicit_sq_residual_norm.get(),
+        &stop_status, true);
 
     stop_status.get_data()->reset();
     stop_status.get_data()->stop(RelativeStoppingId);
@@ -593,6 +594,8 @@ TEST(Record, CatchesIterations)
     ASSERT_NE(data->solver.get(), nullptr);
     ASSERT_EQ(data->num_iterations, num_iters);
     GKO_ASSERT_MTX_NEAR(gko::as<Dense>(data->residual.get()), residual, 0);
+    GKO_ASSERT_MTX_NEAR(gko::as<Dense>(data->right_hand_side.get()),
+                        right_hand_side, 0);
     GKO_ASSERT_MTX_NEAR(gko::as<Dense>(data->solution.get()), solution, 0);
     GKO_ASSERT_MTX_NEAR(gko::as<Dense>(data->residual_norm.get()),
                         residual_norm, 0);

--- a/core/test/log/record.cpp
+++ b/core/test/log/record.cpp
@@ -577,12 +577,18 @@ TEST(Record, CatchesIterations)
     auto solution = gko::initialize<Dense>({-2.2}, exec);
     auto residual_norm = gko::initialize<Dense>({-3.3}, exec);
     auto implicit_sq_residual_norm = gko::initialize<Dense>({-3.5}, exec);
-
+    constexpr gko::uint8 RelativeStoppingId{42};
+    gko::array<gko::stopping_status> stop_status(exec, 1);
+    stop_status.get_data()->reset();
+    stop_status.get_data()->converge(RelativeStoppingId);
 
     logger->on<gko::log::Logger::iteration_complete>(
         solver.get(), num_iters, residual.get(), solution.get(),
-        residual_norm.get(), implicit_sq_residual_norm.get());
+        residual_norm.get(), implicit_sq_residual_norm.get(), &stop_status,
+        true);
 
+    stop_status.get_data()->reset();
+    stop_status.get_data()->stop(RelativeStoppingId);
     auto& data = logger->get().iteration_completed.back();
     ASSERT_NE(data->solver.get(), nullptr);
     ASSERT_EQ(data->num_iterations, num_iters);
@@ -592,6 +598,11 @@ TEST(Record, CatchesIterations)
                         residual_norm, 0);
     GKO_ASSERT_MTX_NEAR(gko::as<Dense>(data->implicit_sq_residual_norm.get()),
                         implicit_sq_residual_norm, 0);
+    ASSERT_EQ(data->status.get_const_data()->has_stopped(), true);
+    ASSERT_EQ(data->status.get_const_data()->get_id(),
+              stop_status.get_const_data()->get_id());
+    ASSERT_EQ(data->status.get_const_data()->is_finalized(), true);
+    ASSERT_TRUE(data->all_stopped);
 }
 
 

--- a/core/test/log/stream.cpp
+++ b/core/test/log/stream.cpp
@@ -743,7 +743,7 @@ TYPED_TEST(Stream, CatchesCriterionCheckCompletedWithVerbose)
 }
 
 
-TYPED_TEST(Stream, CatchesIterations)
+TYPED_TEST(Stream, CatchesIterationsWithoutStoppingStatus)
 {
     using Dense = gko::matrix::Dense<TypeParam>;
     auto exec = gko::ReferenceExecutor::create();
@@ -762,12 +762,43 @@ TYPED_TEST(Stream, CatchesIterations)
 
     logger->template on<gko::log::Logger::iteration_complete>(
         solver.get(), num_iters, residual.get(), solution.get(),
-        residual_norm.get(), implicit_sq_residual_norm.get());
+        residual_norm.get(), implicit_sq_residual_norm.get(), nullptr, false);
 
     GKO_ASSERT_STR_CONTAINS(out.str(),
                             "iteration " + std::to_string(num_iters));
     GKO_ASSERT_STR_CONTAINS(out.str(), ptrstream_solver.str());
     GKO_ASSERT_STR_CONTAINS(out.str(), ptrstream_residual.str());
+}
+
+
+TYPED_TEST(Stream, CatchesIterationsWithStoppingStatus)
+{
+    using Dense = gko::matrix::Dense<TypeParam>;
+    auto exec = gko::ReferenceExecutor::create();
+    std::stringstream out;
+    auto logger = gko::log::Stream<TypeParam>::create(
+        gko::log::Logger::iteration_complete_mask, out);
+    auto solver = Dense::create(exec);
+    auto residual = Dense::create(exec);
+    auto solution = Dense::create(exec);
+    auto residual_norm = Dense::create(exec);
+    auto implicit_sq_residual_norm = Dense::create(exec);
+    std::stringstream ptrstream_solver;
+    ptrstream_solver << solver.get();
+    std::stringstream ptrstream_residual;
+    ptrstream_residual << residual.get();
+    gko::array<gko::stopping_status> stop_status(exec, 1);
+
+    logger->template on<gko::log::Logger::iteration_complete>(
+        solver.get(), num_iters, residual.get(), solution.get(),
+        residual_norm.get(), implicit_sq_residual_norm.get(), &stop_status,
+        true);
+
+    GKO_ASSERT_STR_CONTAINS(out.str(),
+                            "iteration " + std::to_string(num_iters));
+    GKO_ASSERT_STR_CONTAINS(out.str(), ptrstream_solver.str());
+    GKO_ASSERT_STR_CONTAINS(out.str(), ptrstream_residual.str());
+    GKO_ASSERT_STR_CONTAINS(out.str(), "Stopped the iteration process true");
 }
 
 
@@ -788,15 +819,17 @@ TYPED_TEST(Stream, CatchesIterationsWithVerbose)
     auto residual = gko::initialize<Dense>({-4.4}, exec);
     auto solution = gko::initialize<Dense>({-2.2}, exec);
     auto residual_norm = gko::initialize<Dense>({-3.3}, exec);
+    gko::array<gko::stopping_status> stop_status(exec, 1);
 
     logger->template on<gko::log::Logger::iteration_complete>(
         solver.get(), num_iters, residual.get(), solution.get(),
-        residual_norm.get());
+        residual_norm.get(), nullptr, &stop_status, true);
 
     auto os = out.str();
     GKO_ASSERT_STR_CONTAINS(os, "-4.4");
     GKO_ASSERT_STR_CONTAINS(os, "-2.2");
     GKO_ASSERT_STR_CONTAINS(os, "-3.3");
+    GKO_ASSERT_STR_CONTAINS(os, "Finalized:")
 }
 
 

--- a/examples/adaptiveprecision-blockjacobi/adaptiveprecision-blockjacobi.cpp
+++ b/examples/adaptiveprecision-blockjacobi/adaptiveprecision-blockjacobi.cpp
@@ -106,22 +106,16 @@ int main(int argc, char* argv[])
 
     // copy b again
     b->copy_from(host_x);
-    const RealValueType reduction_factor = 1e-7;
-    auto iter_stop = gko::share(
-        gko::stop::Iteration::build().with_max_iters(10000u).on(exec));
-    auto tol_stop = gko::share(gko::stop::ResidualNorm<ValueType>::build()
-                                   .with_reduction_factor(reduction_factor)
-                                   .on(exec));
-
-    std::shared_ptr<const gko::log::Convergence<ValueType>> logger =
-        gko::log::Convergence<ValueType>::create();
-    iter_stop->add_logger(logger);
-    tol_stop->add_logger(logger);
 
     // Create solver factory
+    const RealValueType reduction_factor = 1e-7;
     auto solver_gen =
         cg::build()
-            .with_criteria(iter_stop, tol_stop)
+            .with_criteria(
+                gko::stop::Iteration::build().with_max_iters(10000u).on(exec),
+                gko::stop::ResidualNorm<ValueType>::build()
+                    .with_reduction_factor(reduction_factor)
+                    .on(exec))
             // Add preconditioner, these 2 lines are the only
             // difference from the simple solver example
             .with_preconditioner(bj::build()
@@ -131,9 +125,10 @@ int main(int argc, char* argv[])
                                      .on(exec))
             .on(exec);
     // Create solver
+    std::shared_ptr<const gko::log::Convergence<ValueType>> logger =
+        gko::log::Convergence<ValueType>::create();
     solver_gen->add_logger(logger);
     auto solver = solver_gen->generate(A);
-
 
     // Solve system
     exec->synchronize();
@@ -143,10 +138,8 @@ int main(int argc, char* argv[])
     auto toc = std::chrono::steady_clock::now();
     time += std::chrono::duration_cast<std::chrono::nanoseconds>(toc - tic);
 
-    // Calculate residual
-    auto res = gko::initialize<real_vec>({0.0}, exec);
-    A->apply(one, x, neg_one, b);
-    b->compute_norm2(res);
+    // Get residual
+    auto res = gko::as<real_vec>(logger->get_residual_norm());
     auto impl_res = gko::as<real_vec>(logger->get_implicit_sq_resnorm());
 
     std::cout << "Initial residual norm sqrt(r^T r):\n";

--- a/examples/custom-logger/custom-logger.cpp
+++ b/examples/custom-logger/custom-logger.cpp
@@ -121,24 +121,17 @@ struct ResidualLogger : gko::log::Logger {
     using gko_dense = gko::matrix::Dense<ValueType>;
     using gko_real_dense = gko::matrix::Dense<RealValueType>;
 
-    // This overload is necessary to avoid interface breaks for Ginkgo 2.0
-    void on_iteration_complete(const gko::LinOp* solver,
-                               const gko::size_type& iteration,
-                               const gko::LinOp* residual,
-                               const gko::LinOp* solution,
-                               const gko::LinOp* residual_norm) const override
-    {
-        this->on_iteration_complete(solver, iteration, residual, solution,
-                                    residual_norm, nullptr);
-    }
 
     // Customize the logging hook which is called everytime an iteration is
     // completed
-    void on_iteration_complete(
-        const gko::LinOp*, const gko::size_type& iteration,
-        const gko::LinOp* residual, const gko::LinOp* solution,
-        const gko::LinOp* residual_norm,
-        const gko::LinOp* implicit_sq_residual_norm) const override
+    void on_iteration_complete(const gko::LinOp* solver, const gko::LinOp* b,
+                               const gko::LinOp* solution,
+                               const gko::size_type& iteration,
+                               const gko::LinOp* residual,
+                               const gko::LinOp* residual_norm,
+                               const gko::LinOp* implicit_sq_residual_norm,
+                               const gko::array<gko::stopping_status>*,
+                               bool) const override
     {
         // If the solver shares a residual norm, log its value
         if (residual_norm) {
@@ -156,6 +149,9 @@ struct ResidualLogger : gko::log::Logger {
 
         // If the solver shares the current solution vector
         if (solution) {
+            // Extract the matrix from the solver
+            auto matrix = gko::as<gko::solver::detail::SolverBaseLinOp>(solver)
+                              ->get_system_matrix();
             // Store the matrix's executor
             auto exec = matrix->get_executor();
             // Create a scalar containing the value 1.0
@@ -163,7 +159,7 @@ struct ResidualLogger : gko::log::Logger {
             // Create a scalar containing the value -1.0
             auto neg_one = gko::initialize<gko_dense>({-1.0}, exec);
             // Instantiate a temporary result variable
-            auto res = gko::clone(b);
+            auto res = gko::as<gko_dense>(gko::clone(b));
             // Compute the real residual vector by calling apply on the system
             // matrix
             matrix->apply(one, solution, neg_one, res);
@@ -192,18 +188,12 @@ struct ResidualLogger : gko::log::Logger {
         iterations.push_back(iteration);
     }
 
-    // Construct the logger and store the system matrix and b vectors
-    ResidualLogger(const gko::LinOp* matrix, const gko_dense* b)
-        : gko::log::Logger(gko::log::Logger::iteration_complete_mask),
-          matrix{matrix},
-          b{b}
+    // Construct the logger
+    ResidualLogger()
+        : gko::log::Logger(gko::log::Logger::iteration_complete_mask)
     {}
 
 private:
-    // Pointer to the system matrix
-    const gko::LinOp* matrix;
-    // Pointer to the right hand sides
-    const gko_dense* b;
     // Vector which stores all the recurrent residual norms
     mutable std::vector<RealValueType> recurrent_norms{};
     // Vector which stores all the real residual norms
@@ -309,7 +299,7 @@ int main(int argc, char* argv[])
             .on(exec);
 
     // Instantiate a ResidualLogger logger.
-    auto logger = std::make_shared<ResidualLogger<ValueType>>(A.get(), b.get());
+    auto logger = std::make_shared<ResidualLogger<ValueType>>();
 
     // Add the previously created logger to the solver factory. The logger
     // will be automatically propagated to all solvers created from this

--- a/examples/ir-ilu-preconditioned-solver/ir-ilu-preconditioned-solver.cpp
+++ b/examples/ir-ilu-preconditioned-solver/ir-ilu-preconditioned-solver.cpp
@@ -144,11 +144,6 @@ int main(int argc, char* argv[])
                                    .with_reduction_factor(reduction_factor)
                                    .on(exec));
 
-    std::shared_ptr<const gko::log::Convergence<ValueType>> logger =
-        gko::log::Convergence<ValueType>::create();
-    iter_stop->add_logger(logger);
-    tol_stop->add_logger(logger);
-
     // Use preconditioner inside GMRES solver factory
     // Generating a solver factory tied to a specific preconditioner makes sense
     // if there are several very similar systems to solve, and the same
@@ -161,6 +156,11 @@ int main(int argc, char* argv[])
 
     // Generate preconditioned solver for a specific target system
     auto ilu_gmres = ilu_gmres_factory->generate(A);
+
+    // Add logger
+    std::shared_ptr<const gko::log::Convergence<ValueType>> logger =
+        gko::log::Convergence<ValueType>::create();
+    ilu_gmres->add_logger(logger);
 
     // Warmup run
     ilu_gmres->apply(b, x);
@@ -181,12 +181,8 @@ int main(int argc, char* argv[])
     std::cout << "Solution (x):\n";
     write(std::cout, x);
 
-    // Calculate residual
-    auto one = gko::initialize<vec>({1.0}, exec);
-    auto neg_one = gko::initialize<vec>({-1.0}, exec);
-    auto res = gko::initialize<real_vec>({0.0}, exec);
-    A->apply(one, x, neg_one, b);
-    b->compute_norm2(res);
+    // Get residual
+    auto res = gko::as<vec>(logger->get_residual_norm());
 
     std::cout << "GMRES iteration count:     " << logger->get_num_iterations()
               << "\n";

--- a/examples/simple-solver-logging/simple-solver-logging.cpp
+++ b/examples/simple-solver-logging/simple-solver-logging.cpp
@@ -182,8 +182,7 @@ int main(int argc, char* argv[])
     std::cout << "Solution (x):\n";
     write(std::cout, x);
     std::cout << "Residual norm sqrt(r^T r):\n";
-    write(std::cout,
-          gko::as<vec>(convergence_logger->get_residual_norm()));
+    write(std::cout, gko::as<vec>(convergence_logger->get_residual_norm()));
     std::cout << "Number of iterations "
               << convergence_logger->get_num_iterations() << std::endl;
     std::cout << "Convergence status " << std::boolalpha

--- a/include/ginkgo/core/log/convergence.hpp
+++ b/include/ginkgo/core/log/convergence.hpp
@@ -80,9 +80,9 @@ public:
         const array<stopping_status>* status, const bool& one_changed,
         const bool& all_stopped) const override;
 
-    void on_iteration_complete(const LinOp* solver,
-                               const size_type& num_iterations,
-                               const LinOp* residual, const LinOp* x,
+    void on_iteration_complete(const LinOp* solver, const LinOp* b,
+                               const LinOp* x, const size_type& num_iterations,
+                               const LinOp* residual,
                                const LinOp* residual_norm,
                                const LinOp* implicit_resnorm_sq,
                                const array<stopping_status>* status,

--- a/include/ginkgo/core/log/convergence.hpp
+++ b/include/ginkgo/core/log/convergence.hpp
@@ -105,7 +105,8 @@ public:
     [[deprecated(
         "use single-parameter create")]] static std::unique_ptr<Convergence>
     create(std::shared_ptr<const Executor>,
-           const mask_type& enabled_events = Logger::all_events_mask)
+           const mask_type& enabled_events = Logger::criterion_events_mask |
+                                             Logger::iteration_complete_mask)
     {
         return std::unique_ptr<Convergence>(new Convergence(enabled_events));
     }
@@ -124,7 +125,8 @@ public:
      * shouldn't be a problem.
      */
     static std::unique_ptr<Convergence> create(
-        const mask_type& enabled_events = Logger::all_events_mask)
+        const mask_type& enabled_events = Logger::criterion_events_mask |
+                                          Logger::iteration_complete_mask)
     {
         return std::unique_ptr<Convergence>(new Convergence(enabled_events));
     }
@@ -188,7 +190,8 @@ protected:
      */
     [[deprecated("use single-parameter constructor")]] explicit Convergence(
         std::shared_ptr<const gko::Executor>,
-        const mask_type& enabled_events = Logger::all_events_mask)
+        const mask_type& enabled_events = Logger::criterion_events_mask |
+                                          Logger::iteration_complete_mask)
         : Logger(enabled_events)
     {}
 
@@ -199,7 +202,8 @@ protected:
      *                        events.
      */
     explicit Convergence(
-        const mask_type& enabled_events = Logger::all_events_mask)
+        const mask_type& enabled_events = Logger::criterion_events_mask |
+                                          Logger::iteration_complete_mask)
         : Logger(enabled_events)
     {}
 

--- a/include/ginkgo/core/log/convergence.hpp
+++ b/include/ginkgo/core/log/convergence.hpp
@@ -80,6 +80,14 @@ public:
         const array<stopping_status>* status, const bool& one_changed,
         const bool& all_stopped) const override;
 
+    void on_iteration_complete(const LinOp* solver,
+                               const size_type& num_iterations,
+                               const LinOp* residual, const LinOp* x,
+                               const LinOp* residual_norm,
+                               const LinOp* implicit_resnorm_sq,
+                               const array<stopping_status>* status,
+                               bool stopped) const override;
+
     /**
      * Creates a convergence logger. This dynamically allocates the memory,
      * constructs the object and returns an std::unique_ptr to this object.

--- a/include/ginkgo/core/log/logger.hpp
+++ b/include/ginkgo/core/log/logger.hpp
@@ -427,9 +427,10 @@ protected:
      * Register the `iteration_complete` event which logs every completed
      * iterations.
      *
+     * @param solver  the solver executing the iteration
      * @param it  the current iteration count
      * @param r  the residual (optional)
-     * @param x  the solution vector (optional)
+     * @param x  the solution vector
      * @param tau  the residual norm (optional)
      * @param implicit_tau_sq  the residual norm (optional)
      * @param status  the stopping status of the right hand sides (optional)

--- a/include/ginkgo/core/log/logger.hpp
+++ b/include/ginkgo/core/log/logger.hpp
@@ -125,7 +125,8 @@ public:
      */
 #define GKO_LOGGER_REGISTER_EVENT(_id, _event_name, ...)             \
 protected:                                                           \
-    virtual void on_##_event_name(__VA_ARGS__) const {}              \
+    virtual void on_##_event_name(__VA_ARGS__) const                 \
+    {}                                                               \
                                                                      \
 public:                                                              \
     template <size_type Event, typename... Params>                   \
@@ -408,7 +409,7 @@ protected:
      * @param set_finalized  whether this finalizes the iteration
      * @param status  the stopping status of the right hand sides
      * @param one_changed  whether at least one right hand side converged or not
-     * @param all_converged  whether all right hand sides
+     * @param all_converged  whether all right hand sides are converged
      */
     virtual void on_criterion_check_completed(
         const stop::Criterion* criterion, const size_type& it, const LinOp* r,
@@ -427,6 +428,26 @@ protected:
      * iterations.
      *
      * @param it  the current iteration count
+     * @param r  the residual (optional)
+     * @param x  the solution vector (optional)
+     * @param tau  the residual norm (optional)
+     * @param implicit_tau_sq  the residual norm (optional)
+     * @param status  the stopping status of the right hand sides (optional)
+     * @param stopped  whether all right hand sides have stopped (invalid if
+     *                 status is not provided)
+     */
+    GKO_LOGGER_REGISTER_EVENT(21, iteration_complete, const LinOp* solver,
+                              const size_type& it, const LinOp* r,
+                              const LinOp* x, const LinOp* tau,
+                              const LinOp* implicit_tau_sq,
+                              const array<stopping_status>* status,
+                              bool stopped)
+protected:
+    /**
+     * Register the `iteration_complete` event which logs every completed
+     * iterations.
+     *
+     * @param it  the current iteration count
      * @param r  the residual
      * @param x  the solution vector (optional)
      * @param tau  the residual norm (optional)
@@ -435,11 +456,17 @@ protected:
      * deprecated. Please use the one with the additional implicit_tau_sq
      * parameter as below.
      */
-    GKO_LOGGER_REGISTER_EVENT(21, iteration_complete, const LinOp* solver,
-                              const size_type& it, const LinOp* r,
-                              const LinOp* x = nullptr,
-                              const LinOp* tau = nullptr)
-protected:
+    [[deprecated(
+        "Please use the version with the additional implicit_tau_sq, status "
+        "and stopped parameter.")]] virtual void
+    on_iteration_complete(const LinOp* solver, const size_type& it,
+                          const LinOp* r, const LinOp* x = nullptr,
+                          const LinOp* tau = nullptr) const
+    {
+        this->on_iteration_complete(solver, it, r, x, tau, nullptr, nullptr,
+                                    false);
+    }
+
     /**
      * Register the `iteration_complete` event which logs every completed
      * iterations.
@@ -450,13 +477,17 @@ protected:
      * @param tau  the residual norm (optional)
      * @param implicit_tau_sq  the implicit residual norm squared (optional)
      */
-    virtual void on_iteration_complete(const LinOp* solver, const size_type& it,
-                                       const LinOp* r, const LinOp* x,
-                                       const LinOp* tau,
-                                       const LinOp* implicit_tau_sq) const
+    [[deprecated(
+        "Please use the version with the additional status and stopped "
+        "parameter.")]] virtual void
+    on_iteration_complete(const LinOp* solver, const size_type& it,
+                          const LinOp* r, const LinOp* x, const LinOp* tau,
+                          const LinOp* implicit_tau_sq) const
     {
-        this->on_iteration_complete(solver, it, r, x, tau);
+        this->on_iteration_complete(solver, it, r, x, tau, implicit_tau_sq,
+                                    nullptr, false);
     }
+
 
 public:
     /**

--- a/include/ginkgo/core/log/logger.hpp
+++ b/include/ginkgo/core/log/logger.hpp
@@ -428,9 +428,10 @@ protected:
      * iterations.
      *
      * @param solver  the solver executing the iteration
+     * @param b  the right-hand-side vector
+     * @param x  the solution vector
      * @param it  the current iteration count
      * @param r  the residual (optional)
-     * @param x  the solution vector
      * @param tau  the residual norm (optional)
      * @param implicit_tau_sq  the residual norm (optional)
      * @param status  the stopping status of the right hand sides (optional)
@@ -438,9 +439,9 @@ protected:
      *                 status is not provided)
      */
     GKO_LOGGER_REGISTER_EVENT(21, iteration_complete, const LinOp* solver,
+                              const LinOp* b, const LinOp* x,
                               const size_type& it, const LinOp* r,
-                              const LinOp* x, const LinOp* tau,
-                              const LinOp* implicit_tau_sq,
+                              const LinOp* tau, const LinOp* implicit_tau_sq,
                               const array<stopping_status>* status,
                               bool stopped)
 protected:
@@ -464,8 +465,8 @@ protected:
                           const LinOp* r, const LinOp* x = nullptr,
                           const LinOp* tau = nullptr) const
     {
-        this->on_iteration_complete(solver, it, r, x, tau, nullptr, nullptr,
-                                    false);
+        this->on_iteration_complete(solver, nullptr, x, it, r, tau, nullptr,
+                                    nullptr, false);
     }
 
     /**
@@ -485,8 +486,8 @@ protected:
                           const LinOp* r, const LinOp* x, const LinOp* tau,
                           const LinOp* implicit_tau_sq) const
     {
-        this->on_iteration_complete(solver, it, r, x, tau, implicit_tau_sq,
-                                    nullptr, false);
+        this->on_iteration_complete(solver, nullptr, x, it, r, tau,
+                                    implicit_tau_sq, nullptr, false);
     }
 
 

--- a/include/ginkgo/core/log/logger.hpp
+++ b/include/ginkgo/core/log/logger.hpp
@@ -125,8 +125,7 @@ public:
      */
 #define GKO_LOGGER_REGISTER_EVENT(_id, _event_name, ...)             \
 protected:                                                           \
-    virtual void on_##_event_name(__VA_ARGS__) const                 \
-    {}                                                               \
+    virtual void on_##_event_name(__VA_ARGS__) const {}              \
                                                                      \
 public:                                                              \
     template <size_type Event, typename... Params>                   \

--- a/include/ginkgo/core/log/logger.hpp
+++ b/include/ginkgo/core/log/logger.hpp
@@ -432,7 +432,7 @@ protected:
      * @param x  the solution vector
      * @param it  the current iteration count
      * @param r  the residual (optional)
-     * @param tau  the residual norm (optional)
+     * @param tau  the implicit residual norm squared (optional)
      * @param implicit_tau_sq  the residual norm (optional)
      * @param status  the stopping status of the right hand sides (optional)
      * @param stopped  whether all right hand sides have stopped (invalid if

--- a/include/ginkgo/core/log/logger.hpp
+++ b/include/ginkgo/core/log/logger.hpp
@@ -490,7 +490,6 @@ protected:
                                     implicit_tau_sq, nullptr, false);
     }
 
-
 public:
     /**
      * PolymorphicObject's move started event.

--- a/include/ginkgo/core/log/papi.hpp
+++ b/include/ginkgo/core/log/papi.hpp
@@ -180,9 +180,9 @@ public:
         const bool& one_changed, const bool& all_converged) const override;
 
     /* Internal solver events */
-    void on_iteration_complete(const LinOp* solver,
-                               const size_type& num_iterations,
-                               const LinOp* residual, const LinOp* x,
+    void on_iteration_complete(const LinOp* solver, const LinOp* b,
+                               const LinOp* x, const size_type& num_iterations,
+                               const LinOp* residual,
                                const LinOp* residual_norm,
                                const LinOp* implicit_resnorm_sq,
                                const array<stopping_status>* status,

--- a/include/ginkgo/core/log/papi.hpp
+++ b/include/ginkgo/core/log/papi.hpp
@@ -180,6 +180,14 @@ public:
         const bool& one_changed, const bool& all_converged) const override;
 
     /* Internal solver events */
+    void on_iteration_complete(const LinOp* solver,
+                               const size_type& num_iterations,
+                               const LinOp* residual, const LinOp* x,
+                               const LinOp* residual_norm,
+                               const LinOp* implicit_resnorm_sq,
+                               const array<stopping_status>* status,
+                               bool stopped) const override;
+
     void on_iteration_complete(
         const LinOp* solver, const size_type& num_iterations,
         const LinOp* residual, const LinOp* solution = nullptr,

--- a/include/ginkgo/core/log/profiler_hook.hpp
+++ b/include/ginkgo/core/log/profiler_hook.hpp
@@ -181,15 +181,11 @@ public:
 
     /* Internal solver events */
     void on_iteration_complete(
-        const LinOp* solver, const size_type& num_iterations,
-        const LinOp* residual, const LinOp* solution = nullptr,
-        const LinOp* residual_norm = nullptr) const override;
-
-    void on_iteration_complete(
-        const LinOp* solver, const size_type& num_iterations,
-        const LinOp* residual, const LinOp* solution,
-        const LinOp* residual_norm,
-        const LinOp* implicit_sq_residual_norm) const override;
+        const LinOp* solver, const LinOp* right_hand_side,
+        const LinOp* solution, const size_type& num_iterations,
+        const LinOp* residual, const LinOp* residual_norm,
+        const LinOp* implicit_sq_residual_norm,
+        const array<stopping_status>* status, bool stopped) const override;
 
     bool needs_propagation() const override;
 

--- a/include/ginkgo/core/log/record.hpp
+++ b/include/ginkgo/core/log/record.hpp
@@ -58,17 +58,19 @@ namespace log {
  */
 struct iteration_complete_data {
     std::unique_ptr<const LinOp> solver;
+    std::unique_ptr<const LinOp> right_hand_side;
+    std::unique_ptr<const LinOp> solution;
     const size_type num_iterations;
     std::unique_ptr<const LinOp> residual;
-    std::unique_ptr<const LinOp> solution;
     std::unique_ptr<const LinOp> residual_norm;
     std::unique_ptr<const LinOp> implicit_sq_residual_norm;
     array<stopping_status> status;
     bool all_stopped;
 
-    iteration_complete_data(const LinOp* solver, const size_type num_iterations,
+    iteration_complete_data(const LinOp* solver, const LinOp* right_hand_side,
+                            const LinOp* solution,
+                            const size_type num_iterations,
                             const LinOp* residual = nullptr,
-                            const LinOp* solution = nullptr,
                             const LinOp* residual_norm = nullptr,
                             const LinOp* implicit_sq_residual_norm = nullptr,
                             const gko::array<stopping_status>* status = nullptr,
@@ -76,11 +78,10 @@ struct iteration_complete_data {
         : num_iterations{num_iterations}, all_stopped(all_stopped)
     {
         this->solver = solver->clone();
+        this->right_hand_side = right_hand_side->clone();
+        this->solution = solution->clone();
         if (residual != nullptr) {
             this->residual = residual->clone();
-        }
-        if (solution != nullptr) {
-            this->solution = solution->clone();
         }
         if (residual_norm != nullptr) {
             this->residual_norm = residual_norm->clone();
@@ -393,13 +394,11 @@ public:
         const bool& one_changed, const bool& all_converged) const override;
 
     /* Internal solver events */
-    void on_iteration_complete(const LinOp* solver,
-                               const size_type& num_iterations,
-                               const LinOp* residual, const LinOp* x,
-                               const LinOp* residual_norm,
-                               const LinOp* implicit_resnorm_sq,
-                               const array<stopping_status>* status,
-                               bool stopped) const override;
+    void on_iteration_complete(
+        const LinOp* solver, const LinOp* right_hand_side, const LinOp* x,
+        const size_type& num_iterations, const LinOp* residual,
+        const LinOp* residual_norm, const LinOp* implicit_resnorm_sq,
+        const array<stopping_status>* status, bool stopped) const override;
 
     void on_iteration_complete(
         const LinOp* solver, const size_type& num_iterations,

--- a/include/ginkgo/core/log/record.hpp
+++ b/include/ginkgo/core/log/record.hpp
@@ -63,18 +63,17 @@ struct iteration_complete_data {
     std::unique_ptr<const LinOp> solution;
     std::unique_ptr<const LinOp> residual_norm;
     std::unique_ptr<const LinOp> implicit_sq_residual_norm;
+    array<stopping_status> status;
+    bool all_stopped;
 
     iteration_complete_data(const LinOp* solver, const size_type num_iterations,
                             const LinOp* residual = nullptr,
                             const LinOp* solution = nullptr,
                             const LinOp* residual_norm = nullptr,
-                            const LinOp* implicit_sq_residual_norm = nullptr)
-        : solver{nullptr},
-          num_iterations{num_iterations},
-          residual{nullptr},
-          solution{nullptr},
-          residual_norm{nullptr},
-          implicit_sq_residual_norm{nullptr}
+                            const LinOp* implicit_sq_residual_norm = nullptr,
+                            const gko::array<stopping_status>* status = nullptr,
+                            bool all_stopped = false)
+        : num_iterations{num_iterations}, all_stopped(all_stopped)
     {
         this->solver = solver->clone();
         if (residual != nullptr) {
@@ -89,6 +88,9 @@ struct iteration_complete_data {
         if (implicit_sq_residual_norm != nullptr) {
             this->implicit_sq_residual_norm =
                 implicit_sq_residual_norm->clone();
+        }
+        if (status != nullptr) {
+            this->status = *status;
         }
     }
 };
@@ -391,6 +393,14 @@ public:
         const bool& one_changed, const bool& all_converged) const override;
 
     /* Internal solver events */
+    void on_iteration_complete(const LinOp* solver,
+                               const size_type& num_iterations,
+                               const LinOp* residual, const LinOp* x,
+                               const LinOp* residual_norm,
+                               const LinOp* implicit_resnorm_sq,
+                               const array<stopping_status>* status,
+                               bool stopped) const override;
+
     void on_iteration_complete(
         const LinOp* solver, const size_type& num_iterations,
         const LinOp* residual, const LinOp* solution = nullptr,

--- a/include/ginkgo/core/log/stream.hpp
+++ b/include/ginkgo/core/log/stream.hpp
@@ -156,9 +156,9 @@ public:
         const bool& one_changed, const bool& all_converged) const override;
 
     /* Internal solver events */
-    void on_iteration_complete(const LinOp* solver,
-                               const size_type& num_iterations,
-                               const LinOp* residual, const LinOp* x,
+    void on_iteration_complete(const LinOp* solver, const LinOp* b,
+                               const LinOp* x, const size_type& num_iterations,
+                               const LinOp* residual,
                                const LinOp* residual_norm,
                                const LinOp* implicit_resnorm_sq,
                                const array<stopping_status>* status,

--- a/include/ginkgo/core/log/stream.hpp
+++ b/include/ginkgo/core/log/stream.hpp
@@ -164,17 +164,6 @@ public:
                                const array<stopping_status>* status,
                                bool stopped) const override;
 
-    void on_iteration_complete(
-        const LinOp* solver, const size_type& num_iterations,
-        const LinOp* residual, const LinOp* solution = nullptr,
-        const LinOp* residual_norm = nullptr) const override;
-
-    void on_iteration_complete(
-        const LinOp* solver, const size_type& num_iterations,
-        const LinOp* residual, const LinOp* solution,
-        const LinOp* residual_norm,
-        const LinOp* implicit_sq_residual_norm) const override;
-
     /**
      * Creates a Stream logger. This dynamically allocates the memory,
      * constructs the object and returns an std::unique_ptr to this object.

--- a/include/ginkgo/core/log/stream.hpp
+++ b/include/ginkgo/core/log/stream.hpp
@@ -156,6 +156,14 @@ public:
         const bool& one_changed, const bool& all_converged) const override;
 
     /* Internal solver events */
+    void on_iteration_complete(const LinOp* solver,
+                               const size_type& num_iterations,
+                               const LinOp* residual, const LinOp* x,
+                               const LinOp* residual_norm,
+                               const LinOp* implicit_resnorm_sq,
+                               const array<stopping_status>* status,
+                               bool stopped) const override;
+
     void on_iteration_complete(
         const LinOp* solver, const size_type& num_iterations,
         const LinOp* residual, const LinOp* solution = nullptr,

--- a/test/solver/solver.cpp
+++ b/test/solver/solver.cpp
@@ -542,12 +542,12 @@ struct DummyLogger : gko::log::Logger {
     DummyLogger() : gko::log::Logger(gko::log::Logger::iteration_complete_mask)
     {}
 
-    void on_iteration_complete(const gko::LinOp* solver,
-                               const gko::size_type& it, const gko::LinOp* r,
-                               const gko::LinOp* x ,
-                               const gko::LinOp* tau,
+    void on_iteration_complete(const gko::LinOp* solver, const gko::LinOp* b,
+                               const gko::LinOp* x, const gko::size_type& it,
+                               const gko::LinOp* r, const gko::LinOp* tau,
                                const gko::LinOp* implicit_tau,
-                               const gko::array<gko::stopping_status>* status, bool all_stopped) const override
+                               const gko::array<gko::stopping_status>* status,
+                               bool all_stopped) const override
     {
         iteration_complete = it;
     }

--- a/test/solver/solver.cpp
+++ b/test/solver/solver.cpp
@@ -544,10 +544,12 @@ struct DummyLogger : gko::log::Logger {
 
     void on_iteration_complete(const gko::LinOp* solver,
                                const gko::size_type& it, const gko::LinOp* r,
-                               const gko::LinOp* x = nullptr,
-                               const gko::LinOp* tau = nullptr) const override
+                               const gko::LinOp* x ,
+                               const gko::LinOp* tau,
+                               const gko::LinOp* implicit_tau,
+                               const gko::array<gko::stopping_status>* status, bool all_stopped) const override
     {
-        iteration_complete++;
+        iteration_complete = it;
     }
 
     mutable int iteration_complete = 0;
@@ -1216,6 +1218,6 @@ TYPED_TEST(Solver, LogsIterationComplete)
         solver->apply(b, x);
 
         ASSERT_EQ(this->logger->iteration_complete,
-                  before_logger.iteration_complete + num_iteration + 1);
+                  before_logger.iteration_complete + num_iteration);
     }
 }


### PR DESCRIPTION
This PR extends the `iteration_complete` to also capture the stopping status at the end of the iteration. More specifically, it add the two parameters `const gko::array<stopping_status>* status, bool all_stopped` to the function. The other two overloads are marked as deprecated and just call the new overload. All of our loggers support the new overload.

The big difference to our current state is that this PR allows attaching the `Convergence` logger directly to the solver. IMO, this is much more user-friendly. I changed the examples to reflect this.

Evaluate:
- [x] rename event to `iteration_completed` to fit in the naming scheme
- [x] capture the right-hand-side in the event. This would allow reconstructing the residual if necessary (e.g. multigrid)
- [x] perhaps only the `gko::array<stopping_status>* status` is enough. I'm not sure if the `all_stopped` gives additional information