### PR TITLE
Annotate solver iterations in ProfilerHook

### DIFF
--- a/core/log/profiler_hook.cpp
+++ b/core/log/profiler_hook.cpp
@@ -291,7 +291,8 @@ void ProfilerHook::on_iteration_complete(
     const LinOp* solution, const LinOp* residual_norm,
     const LinOp* implicit_sq_residual_norm) const
 {
-    if (dynamic_cast<const solver::IterativeBase*>(solver)) {
+    if (num_iterations > 0 &&
+        dynamic_cast<const solver::IterativeBase*>(solver)) {
         this->end_hook_("iteration", profile_event_category::solver);
         this->begin_hook_("iteration", profile_event_category::solver);
     }

--- a/core/solver/ir.cpp
+++ b/core/solver/ir.cpp
@@ -163,7 +163,8 @@ std::unique_ptr<LinOp> Ir<ValueType>::conj_transpose() const
 template <typename ValueType>
 void Ir<ValueType>::apply_impl(const LinOp* b, LinOp* x) const
 {
-    this->apply_with_initial_guess(b, x, this->get_default_initial_guess());
+    this->apply_with_initial_guess_impl(b, x,
+                                        this->get_default_initial_guess());
 }
 
 
@@ -279,8 +280,8 @@ template <typename ValueType>
 void Ir<ValueType>::apply_impl(const LinOp* alpha, const LinOp* b,
                                const LinOp* beta, LinOp* x) const
 {
-    this->apply_with_initial_guess(alpha, b, beta, x,
-                                   this->get_default_initial_guess());
+    this->apply_with_initial_guess_impl(alpha, b, beta, x,
+                                        this->get_default_initial_guess());
 }
 
 template <typename ValueType>

--- a/core/solver/multigrid.cpp
+++ b/core/solver/multigrid.cpp
@@ -576,7 +576,8 @@ void Multigrid::generate()
 
 void Multigrid::apply_impl(const LinOp* b, LinOp* x) const
 {
-    this->apply_with_initial_guess(b, x, this->get_default_initial_guess());
+    this->apply_with_initial_guess_impl(b, x,
+                                        this->get_default_initial_guess());
 }
 
 
@@ -607,8 +608,8 @@ void Multigrid::apply_with_initial_guess_impl(const LinOp* b, LinOp* x,
 void Multigrid::apply_impl(const LinOp* alpha, const LinOp* b,
                            const LinOp* beta, LinOp* x) const
 {
-    this->apply_with_initial_guess(alpha, b, beta, x,
-                                   this->get_default_initial_guess());
+    this->apply_with_initial_guess_impl(alpha, b, beta, x,
+                                        this->get_default_initial_guess());
 }
 
 

--- a/core/test/log/profiler_hook.cpp
+++ b/core/test/log/profiler_hook.cpp
@@ -206,7 +206,7 @@ TEST(ProfilerHook, LogsIteration)
     auto solver =
         gko::solver::Ir<>::build()
             .with_criteria(
-                gko::stop::Iteration::build().with_max_iters(0u).on(exec))
+                gko::stop::Iteration::build().with_max_iters(1u).on(exec))
             .on(exec)
             ->generate(mtx);
     logger->set_object_name(solver, "solver");

--- a/cuda/base/executor.cpp
+++ b/cuda/base/executor.cpp
@@ -308,7 +308,9 @@ void init_nvtx()
     NAMED_CATEGORY(object);
     NAMED_CATEGORY(linop);
     NAMED_CATEGORY(factory);
+    NAMED_CATEGORY(solver);
     NAMED_CATEGORY(criterion);
+    NAMED_CATEGORY(user);
     NAMED_CATEGORY(internal);
 #undef NAMED_CATEGORY
 }

--- a/include/ginkgo/core/log/profiler_hook.hpp
+++ b/include/ginkgo/core/log/profiler_hook.hpp
@@ -58,6 +58,8 @@ enum class profile_event_category {
     linop,
     /** LinOpFactory events. */
     factory,
+    /** Solver events. */
+    solver,
     /** Stopping criterion events. */
     criterion,
     /** User-defined events. */
@@ -176,6 +178,18 @@ public:
         const uint8& stopping_id, const bool& set_finalized,
         const array<stopping_status>* status, const bool& one_changed,
         const bool& all_stopped) const override;
+
+    /* Internal solver events */
+    void on_iteration_complete(
+        const LinOp* solver, const size_type& num_iterations,
+        const LinOp* residual, const LinOp* solution = nullptr,
+        const LinOp* residual_norm = nullptr) const override;
+
+    void on_iteration_complete(
+        const LinOp* solver, const size_type& num_iterations,
+        const LinOp* residual, const LinOp* solution,
+        const LinOp* residual_norm,
+        const LinOp* implicit_sq_residual_norm) const override;
 
     bool needs_propagation() const override;
 


### PR DESCRIPTION
following a discussion in #1288, this annotates iterations by special-casing the ProfilerHook behavior for IterativeBase