### PR TITLE
add more method for timer output

### DIFF
--- a/benchmark/blas/blas_common.hpp
+++ b/benchmark/blas/blas_common.hpp
@@ -425,7 +425,7 @@ void apply_blas(const char* operation_name, std::shared_ptr<gko::Executor> exec,
         for (auto _ : ic.run()) {
             op->run();
         }
-        const auto runtime = ic.compute_average_time();
+        const auto runtime = ic.compute_time(FLAGS_timer_output);
         const auto flops = static_cast<double>(op->get_flops());
         const auto mem = static_cast<double>(op->get_memory());
         const auto repetitions = ic.get_num_repetitions();

--- a/benchmark/blas/blas_common.hpp
+++ b/benchmark/blas/blas_common.hpp
@@ -425,7 +425,7 @@ void apply_blas(const char* operation_name, std::shared_ptr<gko::Executor> exec,
         for (auto _ : ic.run()) {
             op->run();
         }
-        const auto runtime = ic.compute_time(FLAGS_timer_output);
+        const auto runtime = ic.compute_time(FLAGS_timer_method);
         const auto flops = static_cast<double>(op->get_flops());
         const auto mem = static_cast<double>(op->get_memory());
         const auto repetitions = ic.get_num_repetitions();

--- a/benchmark/conversions/conversions.cpp
+++ b/benchmark/conversions/conversions.cpp
@@ -87,7 +87,7 @@ void convert_matrix(const gko::LinOp* matrix_from, const char* format_to,
             matrix_to->copy_from(matrix_from);
         }
         add_or_set_member(conversion_case[conversion_name], "time",
-                          ic.compute_average_time(), allocator);
+                          ic.compute_time(FLAGS_timer_output), allocator);
         add_or_set_member(conversion_case[conversion_name], "repetitions",
                           ic.get_num_repetitions(), allocator);
 

--- a/benchmark/conversions/conversions.cpp
+++ b/benchmark/conversions/conversions.cpp
@@ -87,7 +87,7 @@ void convert_matrix(const gko::LinOp* matrix_from, const char* format_to,
             matrix_to->copy_from(matrix_from);
         }
         add_or_set_member(conversion_case[conversion_name], "time",
-                          ic.compute_time(FLAGS_timer_output), allocator);
+                          ic.compute_time(FLAGS_timer_method), allocator);
         add_or_set_member(conversion_case[conversion_name], "repetitions",
                           ic.get_num_repetitions(), allocator);
 

--- a/benchmark/preconditioner/preconditioner.cpp
+++ b/benchmark/preconditioner/preconditioner.cpp
@@ -178,7 +178,7 @@ void run_preconditioner(const char* precond_name,
             }
 
             add_or_set_member(this_precond_data["generate"], "time",
-                              ic_gen.compute_time(FLAGS_timer_output),
+                              ic_gen.compute_time(FLAGS_timer_method),
                               allocator);
             add_or_set_member(this_precond_data["generate"], "repetitions",
                               ic_gen.get_num_repetitions(), allocator);
@@ -188,7 +188,7 @@ void run_preconditioner(const char* precond_name,
             }
 
             add_or_set_member(this_precond_data["apply"], "time",
-                              ic_apply.compute_time(FLAGS_timer_output),
+                              ic_apply.compute_time(FLAGS_timer_method),
                               allocator);
             add_or_set_member(this_precond_data["apply"], "repetitions",
                               ic_apply.get_num_repetitions(), allocator);

--- a/benchmark/preconditioner/preconditioner.cpp
+++ b/benchmark/preconditioner/preconditioner.cpp
@@ -178,7 +178,8 @@ void run_preconditioner(const char* precond_name,
             }
 
             add_or_set_member(this_precond_data["generate"], "time",
-                              ic_gen.compute_average_time(), allocator);
+                              ic_gen.compute_time(FLAGS_timer_output),
+                              allocator);
             add_or_set_member(this_precond_data["generate"], "repetitions",
                               ic_gen.get_num_repetitions(), allocator);
 
@@ -187,7 +188,8 @@ void run_preconditioner(const char* precond_name,
             }
 
             add_or_set_member(this_precond_data["apply"], "time",
-                              ic_apply.compute_average_time(), allocator);
+                              ic_apply.compute_time(FLAGS_timer_output),
+                              allocator);
             add_or_set_member(this_precond_data["apply"], "repetitions",
                               ic_apply.get_num_repetitions(), allocator);
         }

--- a/benchmark/run_all_benchmarks.sh
+++ b/benchmark/run_all_benchmarks.sh
@@ -233,7 +233,7 @@ run_conversion_benchmarks() {
     cp "$1" "$1.imd" # make sure we're not loosing the original input
     ./conversions/conversions${BENCH_SUFFIX} --backup="$1.bkp" --double_buffer="$1.bkp2" \
                 --executor="${EXECUTOR}" --formats="${FORMATS}" \
-                --device_id="${DEVICE_ID}" --gpu_timer=${GPU_TIMER} --timer_output=${TIMER_OUTPUT} \
+                --device_id="${DEVICE_ID}" --gpu_timer=${GPU_TIMER} --timer_method=${TIMER_OUTPUT} \
                 --repetitions="${REPETITIONS}" \
                 --ell_imbalance_limit="${ELL_IMBALANCE_LIMIT}" \
                 <"$1.imd" 2>&1 >"$1"
@@ -251,7 +251,7 @@ run_spmv_benchmarks() {
     cp "$1" "$1.imd" # make sure we're not loosing the original input
     ./spmv/spmv${BENCH_SUFFIX} --backup="$1.bkp" --double_buffer="$1.bkp2" \
                 --executor="${EXECUTOR}" --formats="${FORMATS}" \
-                --device_id="${DEVICE_ID}" --gpu_timer=${GPU_TIMER} --timer_output=${TIMER_OUTPUT} \
+                --device_id="${DEVICE_ID}" --gpu_timer=${GPU_TIMER} --timer_method=${TIMER_OUTPUT} \
                 --repetitions="${REPETITIONS}" \
                 --ell_imbalance_limit="${ELL_IMBALANCE_LIMIT}" \
                 <"$1.imd" 2>&1 >"$1"
@@ -272,7 +272,7 @@ run_solver_benchmarks() {
                     --preconditioners="${PRECONDS}" \
                     --max_iters=${SOLVERS_MAX_ITERATIONS} --rel_res_goal=${SOLVERS_PRECISION} \
                     ${SOLVERS_RHS_FLAG} ${DETAILED_STR} ${SOLVERS_INITIAL_GUESS_FLAG} \
-                    --gpu_timer=${GPU_TIMER} --timer_output=${TIMER_OUTPUT} \
+                    --gpu_timer=${GPU_TIMER} --timer_method=${TIMER_OUTPUT} \
                     --jacobi_max_block_size=${SOLVERS_JACOBI_MAX_BS} --device_id="${DEVICE_ID}" \
                     --gmres_restart="${SOLVERS_GMRES_RESTART}" \
                     --repetitions="${SOLVER_REPETITIONS}" \
@@ -301,7 +301,7 @@ run_preconditioner_benchmarks() {
                 --executor="${EXECUTOR}" --preconditioners="jacobi" \
                 --jacobi_max_block_size="${bsize}" \
                 --jacobi_storage="${prec}" \
-                --device_id="${DEVICE_ID}" --gpu_timer=${GPU_TIMER} --timer_output=${TIMER_OUTPUT} \
+                --device_id="${DEVICE_ID}" --gpu_timer=${GPU_TIMER} --timer_method=${TIMER_OUTPUT} \
                 --repetitions="${REPETITIONS}" \
                 <"$1.imd" 2>&1 >"$1"
             keep_latest "$1" "$1.bkp" "$1.bkp2" "$1.imd"

--- a/benchmark/run_all_benchmarks.sh
+++ b/benchmark/run_all_benchmarks.sh
@@ -155,6 +155,11 @@ if [ ! "${GPU_TIMER}" ]; then
     print_default GPU_TIMER
 fi
 
+if [ ! "${TIMER_OUTPUT}" ]; then
+    TIMER_OUTPUT="average"
+    print_default TIMER_OUTPUT
+fi
+
 # Control whether to run detailed benchmarks or not.
 # Default setting is detailed=false. To activate, set DETAILED=1.
 if  [ ! "${DETAILED}" ] || [ "${DETAILED}" -eq 0 ]; then
@@ -228,7 +233,7 @@ run_conversion_benchmarks() {
     cp "$1" "$1.imd" # make sure we're not loosing the original input
     ./conversions/conversions${BENCH_SUFFIX} --backup="$1.bkp" --double_buffer="$1.bkp2" \
                 --executor="${EXECUTOR}" --formats="${FORMATS}" \
-                --device_id="${DEVICE_ID}" --gpu_timer=${GPU_TIMER} \
+                --device_id="${DEVICE_ID}" --gpu_timer=${GPU_TIMER} --timer_output=${TIMER_OUTPUT} \
                 --repetitions="${REPETITIONS}" \
                 --ell_imbalance_limit="${ELL_IMBALANCE_LIMIT}" \
                 <"$1.imd" 2>&1 >"$1"
@@ -246,7 +251,7 @@ run_spmv_benchmarks() {
     cp "$1" "$1.imd" # make sure we're not loosing the original input
     ./spmv/spmv${BENCH_SUFFIX} --backup="$1.bkp" --double_buffer="$1.bkp2" \
                 --executor="${EXECUTOR}" --formats="${FORMATS}" \
-                --device_id="${DEVICE_ID}" --gpu_timer=${GPU_TIMER} \
+                --device_id="${DEVICE_ID}" --gpu_timer=${GPU_TIMER} --timer_output=${TIMER_OUTPUT} \
                 --repetitions="${REPETITIONS}" \
                 --ell_imbalance_limit="${ELL_IMBALANCE_LIMIT}" \
                 <"$1.imd" 2>&1 >"$1"
@@ -267,7 +272,7 @@ run_solver_benchmarks() {
                     --preconditioners="${PRECONDS}" \
                     --max_iters=${SOLVERS_MAX_ITERATIONS} --rel_res_goal=${SOLVERS_PRECISION} \
                     ${SOLVERS_RHS_FLAG} ${DETAILED_STR} ${SOLVERS_INITIAL_GUESS_FLAG} \
-                    --gpu_timer=${GPU_TIMER} \
+                    --gpu_timer=${GPU_TIMER} --timer_output=${TIMER_OUTPUT} \
                     --jacobi_max_block_size=${SOLVERS_JACOBI_MAX_BS} --device_id="${DEVICE_ID}" \
                     --gmres_restart="${SOLVERS_GMRES_RESTART}" \
                     --repetitions="${SOLVER_REPETITIONS}" \
@@ -296,7 +301,7 @@ run_preconditioner_benchmarks() {
                 --executor="${EXECUTOR}" --preconditioners="jacobi" \
                 --jacobi_max_block_size="${bsize}" \
                 --jacobi_storage="${prec}" \
-                --device_id="${DEVICE_ID}" --gpu_timer=${GPU_TIMER} \
+                --device_id="${DEVICE_ID}" --gpu_timer=${GPU_TIMER} --timer_output=${TIMER_OUTPUT} \
                 --repetitions="${REPETITIONS}" \
                 <"$1.imd" 2>&1 >"$1"
             keep_latest "$1" "$1.bkp" "$1.bkp2" "$1.imd"

--- a/benchmark/solver/solver_common.hpp
+++ b/benchmark/solver/solver_common.hpp
@@ -565,9 +565,11 @@ void solve_system(const std::string& solver_name,
                               allocator);
         }
         add_or_set_member(solver_json["generate"], "time",
-                          generate_timer->compute_average_time(), allocator);
+                          generate_timer->compute_time(FLAGS_timer_output),
+                          allocator);
         add_or_set_member(solver_json["apply"], "time",
-                          apply_timer->compute_average_time(), allocator);
+                          apply_timer->compute_time(FLAGS_timer_output),
+                          allocator);
         add_or_set_member(solver_json, "repetitions",
                           apply_timer->get_num_repetitions(), allocator);
 

--- a/benchmark/solver/solver_common.hpp
+++ b/benchmark/solver/solver_common.hpp
@@ -565,10 +565,10 @@ void solve_system(const std::string& solver_name,
                               allocator);
         }
         add_or_set_member(solver_json["generate"], "time",
-                          generate_timer->compute_time(FLAGS_timer_output),
+                          generate_timer->compute_time(FLAGS_timer_method),
                           allocator);
         add_or_set_member(solver_json["apply"], "time",
-                          apply_timer->compute_time(FLAGS_timer_output),
+                          apply_timer->compute_time(FLAGS_timer_method),
                           allocator);
         add_or_set_member(solver_json, "repetitions",
                           apply_timer->get_num_repetitions(), allocator);

--- a/benchmark/sparse_blas/sparse_blas.cpp
+++ b/benchmark/sparse_blas/sparse_blas.cpp
@@ -104,7 +104,7 @@ void apply_sparse_blas(const char* operation_name,
         for (auto _ : ic.run()) {
             op->run();
         }
-        const auto runtime = ic.compute_time(FLAGS_timer_output);
+        const auto runtime = ic.compute_time(FLAGS_timer_method);
         const auto flops = static_cast<double>(op->get_flops());
         const auto mem = static_cast<double>(op->get_memory());
         const auto repetitions = ic.get_num_repetitions();

--- a/benchmark/sparse_blas/sparse_blas.cpp
+++ b/benchmark/sparse_blas/sparse_blas.cpp
@@ -104,7 +104,7 @@ void apply_sparse_blas(const char* operation_name,
         for (auto _ : ic.run()) {
             op->run();
         }
-        const auto runtime = ic.compute_average_time();
+        const auto runtime = ic.compute_time(FLAGS_timer_output);
         const auto flops = static_cast<double>(op->get_flops());
         const auto mem = static_cast<double>(op->get_memory());
         const auto repetitions = ic.get_num_repetitions();

--- a/benchmark/spmv/spmv_common.hpp
+++ b/benchmark/spmv/spmv_common.hpp
@@ -116,8 +116,8 @@ void apply_spmv(const char* format_name, std::shared_ptr<gko::Executor> exec,
             for (auto _ : ic_tuning.run()) {
                 system_matrix->apply(b, x_clone);
             }
-            tuning_case["time"].PushBack(ic_tuning.compute_average_time(),
-                                         allocator);
+            tuning_case["time"].PushBack(
+                ic_tuning.compute_time(FLAGS_timer_output), allocator);
             tuning_case["values"].PushBack(val, allocator);
         }
         // We put back the flag to false to use the default (non-tuned) values
@@ -131,7 +131,7 @@ void apply_spmv(const char* format_name, std::shared_ptr<gko::Executor> exec,
             system_matrix->apply(b, x_clone);
         }
         add_or_set_member(spmv_case[format_name], "time",
-                          ic.compute_average_time(), allocator);
+                          ic.compute_time(FLAGS_timer_output), allocator);
         add_or_set_member(spmv_case[format_name], "repetitions",
                           ic.get_num_repetitions(), allocator);
 

--- a/benchmark/spmv/spmv_common.hpp
+++ b/benchmark/spmv/spmv_common.hpp
@@ -117,7 +117,7 @@ void apply_spmv(const char* format_name, std::shared_ptr<gko::Executor> exec,
                 system_matrix->apply(b, x_clone);
             }
             tuning_case["time"].PushBack(
-                ic_tuning.compute_time(FLAGS_timer_output), allocator);
+                ic_tuning.compute_time(FLAGS_timer_method), allocator);
             tuning_case["values"].PushBack(val, allocator);
         }
         // We put back the flag to false to use the default (non-tuned) values
@@ -131,7 +131,7 @@ void apply_spmv(const char* format_name, std::shared_ptr<gko::Executor> exec,
             system_matrix->apply(b, x_clone);
         }
         add_or_set_member(spmv_case[format_name], "time",
-                          ic.compute_time(FLAGS_timer_output), allocator);
+                          ic.compute_time(FLAGS_timer_method), allocator);
         add_or_set_member(spmv_case[format_name], "repetitions",
                           ic.get_num_repetitions(), allocator);
 

--- a/benchmark/utils/general.hpp
+++ b/benchmark/utils/general.hpp
@@ -115,9 +115,10 @@ DEFINE_uint32(max_repetitions, std::numeric_limits<unsigned int>::max(),
               "If 'repetitions = auto' is used, the maximal number of"
               " repetitions for a single benchmark.");
 
-DEFINE_double(repetition_growth_factor, 1.5,
-              "If 'repetitions = auto' is used, the factor with which the"
-              " repetitions between two timings increase.");
+DEFINE_double(
+    repetition_growth_factor, 1.5,
+    "The factor with which the repetitions between two timings increase. If it "
+    "is lower than or equal to 1, the timing region is always 1 repetition.");
 
 
 /**
@@ -689,6 +690,11 @@ private:
                     stopped = true;
                     next_timing = static_cast<IndexType>(std::ceil(
                         next_timing * FLAGS_repetition_growth_factor));
+                    // If repetition_growth_factor <= 1, next_timing will be
+                    // next iteration.
+                    if (next_timing <= cur_info->cur_it) {
+                        next_timing = cur_info->cur_it + 1;
+                    }
                 }
                 return *this;
             }

--- a/benchmark/utils/general.hpp
+++ b/benchmark/utils/general.hpp
@@ -581,10 +581,25 @@ public:
         return status_run_.managed_timer.timer;
     }
 
-    double compute_average_time() const
+    /**
+     * Compute the time from the given statistical method
+     *
+     * @param method  the statistical method. If the timer does not have the
+     *                same iteration as the IterationControl, it can only use
+     *                average from the IterationControl.
+     *
+     * @return the statistical time
+     */
+    double compute_time(const std::string& method = "average") const
     {
-        return status_run_.managed_timer.get_total_time() /
-               get_num_repetitions();
+        if (status_run_.managed_timer.timer->get_num_repetitions() ==
+            this->get_num_repetitions()) {
+            return status_run_.managed_timer.compute_time(method);
+        } else {
+            assert(method == "average");
+            return status_run_.managed_timer.get_total_time() /
+                   this->get_num_repetitions();
+        }
     }
 
     IndexType get_num_repetitions() const { return status_run_.cur_it; }
@@ -610,6 +625,11 @@ private:
         void clear() { timer->clear(); }
 
         double get_total_time() const { return timer->get_total_time(); }
+
+        double compute_time(const std::string& method = "average") const
+        {
+            return timer->compute_time(method);
+        }
     };
 
     /**

--- a/benchmark/utils/general.hpp
+++ b/benchmark/utils/general.hpp
@@ -615,10 +615,10 @@ private:
                 timer->tic();
             }
         }
-        void toc()
+        void toc(unsigned int num = 1)
         {
             if (manage_timings) {
-                timer->toc();
+                timer->toc(num);
             }
         }
 
@@ -684,7 +684,8 @@ private:
             {
                 cur_info->cur_it++;
                 if (cur_info->cur_it >= next_timing && !stopped) {
-                    cur_info->managed_timer.toc();
+                    cur_info->managed_timer.toc(
+                        static_cast<unsigned>(cur_info->cur_it - start_timing));
                     stopped = true;
                     next_timing = static_cast<IndexType>(std::ceil(
                         next_timing * FLAGS_repetition_growth_factor));
@@ -715,15 +716,18 @@ private:
                 if (!is_finished && stopped) {
                     stopped = false;
                     cur_info->managed_timer.tic();
+                    start_timing = cur_info->cur_it;
                 } else if (is_finished && !stopped) {
-                    cur_info->managed_timer.toc();
+                    cur_info->managed_timer.toc(
+                        static_cast<unsigned>(cur_info->cur_it - start_timing));
                     stopped = true;
                 }
                 return !is_finished;
             }
 
             status* cur_info;
-            IndexType next_timing = 1;  //!< next iteration to stop timing
+            IndexType next_timing = 1;   //!< next iteration to stop timing
+            IndexType start_timing = 0;  //!< iteration for starting timing
             bool stopped = true;
         };
 

--- a/benchmark/utils/timer.hpp
+++ b/benchmark/utils/timer.hpp
@@ -51,6 +51,10 @@ DEFINE_bool(gpu_timer, false,
             "use gpu timer based on event. It is valid only when "
             "executor is cuda or hip");
 
+DEFINE_string(timer_output, "average",
+              "The statistical method for output of timer. Available options: "
+              "average, median, best, worst");
+
 
 /**
  * Get the timer. If the executor does not support gpu timer, still return the

--- a/benchmark/utils/timer.hpp
+++ b/benchmark/utils/timer.hpp
@@ -51,9 +51,11 @@ DEFINE_bool(gpu_timer, false,
             "use gpu timer based on event. It is valid only when "
             "executor is cuda or hip");
 
-DEFINE_string(timer_output, "average",
-              "The statistical method for output of timer. Available options: "
-              "average, median, best, worst");
+DEFINE_string(
+    timer_method, "average",
+    "The statistical method for output of timer. Available options: "
+    "average, median, min, max. Note. If repetition_growth_factor > 1, the "
+    "overhead operations may be different among repetitions");
 
 
 /**

--- a/benchmark/utils/timer_impl.hpp
+++ b/benchmark/utils/timer_impl.hpp
@@ -63,13 +63,18 @@ public:
 
     /**
      * Finish the timer
+     *
+     * @param num  the number of operation for the timing range
      */
-    void toc()
+    void toc(unsigned int num = 1)
     {
         assert(tic_called_ == true);
-        auto sec = this->toc_impl();
+        assert(num > 0);
+        auto sec = this->toc_impl() / num;
         tic_called_ = false;
-        this->add_record(sec);
+        for (unsigned int i = 0; i < num; i++) {
+            this->add_record(sec);
+        }
     }
 
     /**

--- a/benchmark/utils/timer_impl.hpp
+++ b/benchmark/utils/timer_impl.hpp
@@ -64,7 +64,7 @@ public:
     /**
      * Finish the timer
      *
-     * @param num  the number of operation for the timing range
+     * @param num  the number of repetitions for the timing range
      */
     void toc(unsigned int num = 1)
     {
@@ -105,9 +105,9 @@ public:
         }
         auto copy = duration_sec_;
         std::sort(copy.begin(), copy.end());
-        if (method == "best") {
+        if (method == "min") {
             return copy.front();
-        } else if (method == "worst") {
+        } else if (method == "max") {
             return copy.back();
         } else if (method == "median") {
             auto mid = copy.size() / 2;

--- a/benchmark/utils/timer_impl.hpp
+++ b/benchmark/utils/timer_impl.hpp
@@ -87,13 +87,31 @@ public:
     std::int64_t get_num_repetitions() const { return duration_sec_.size(); }
 
     /**
-     * Compute the average time of repetitions in seconds
+     * Compute the time from the given statistical method
      *
-     * @return the average time in seconds
+     * @param method  the statistical method
+     *
+     * @return the statistical time
      */
-    double compute_average_time() const
+    double compute_time(const std::string& method = "average") const
     {
-        return this->get_total_time() / this->get_num_repetitions();
+        if (method == "average") {
+            return this->get_total_time() / this->get_num_repetitions();
+        }
+        auto copy = duration_sec_;
+        std::sort(copy.begin(), copy.end());
+        if (method == "best") {
+            return copy.front();
+        } else if (method == "worst") {
+            return copy.back();
+        } else if (method == "median") {
+            auto mid = copy.size() / 2;
+            if (copy.size() % 2) {
+                return (copy.at(mid) + copy.at(mid - 1)) / 2;
+            } else {
+                return copy.at(mid);
+            }
+        }
     }
 
     /**


### PR DESCRIPTION
This PR adds more statistical methods like average, median, best, and worst to compute the time result.

When the timing use x iteration which is more than 1 iteration, timer will record the average time x times.
Handle repetition_growth_factor <=1 case such that next_timing always be next iteration.
User can set it to get the same overhead operation in each repetitions
