### PR TITLE
fixed the segmentation fault on shared_ptr input

### DIFF
--- a/benchmark/utils/formats.hpp
+++ b/benchmark/utils/formats.hpp
@@ -213,9 +213,9 @@ void check_ell_admissibility(const gko::matrix_data<etype, itype>& data)
 template <typename MatrixType, typename... Args>
 auto create_matrix_type(Args&&... args)
 {
-    return [&](std::shared_ptr<const gko::Executor> exec)
+    return [=](std::shared_ptr<const gko::Executor> exec)
                -> std::unique_ptr<MatrixType> {
-        return MatrixType::create(std::move(exec), std::forward<Args>(args)...);
+        return MatrixType::create(std::move(exec), args...);
     };
 }
 

--- a/doc/examples/examples.hpp.in
+++ b/doc/examples/examples.hpp.in
@@ -66,7 +66,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *   <li> <code>-DGINKGO_BUILD_HIP=ON</code> option for AMD or NVIDIA GPUs.
  *   <li> <code>-DGINKGO_BUILD_DPCPP=ON</code> option for Intel GPUs (and
  *        possibly any other platform).
- * </ol
+ * </ol>
  *
  * <a name="graph"></a>
  * @anchor ExampleConnectionGraph


### PR DESCRIPTION
This PR fixes the issue when launching the benchmark with format csrc, csrs using shared_ptr into the constructor.
The issue can be found at https://godbolt.org/z/WaMM7Mzhq