### PR TITLE
Add symbolic LU and Cholesky benchmark

### DIFF
--- a/benchmark/conversions/conversions.cpp
+++ b/benchmark/conversions/conversions.cpp
@@ -150,6 +150,11 @@ int main(int argc, char* argv[])
         } catch (std::exception& e) {
             std::cerr << "Error setting up matrix data, what(): " << e.what()
                       << std::endl;
+            if (FLAGS_keep_errors) {
+                rapidjson::Value msg_value;
+                msg_value.SetString(e.what(), allocator);
+                add_or_set_member(test_case, "error", msg_value, allocator);
+            }
             continue;
         }
         std::clog << "Matrix is of size (" << data.size[0] << ", "

--- a/benchmark/solver/solver_common.hpp
+++ b/benchmark/solver/solver_common.hpp
@@ -676,6 +676,11 @@ void run_solver_benchmarks(std::shared_ptr<gko::Executor> exec,
         } catch (const std::exception& e) {
             std::cerr << "Error setting up solver, what(): " << e.what()
                       << std::endl;
+            if (FLAGS_keep_errors) {
+                rapidjson::Value msg_value;
+                msg_value.SetString(e.what(), allocator);
+                add_or_set_member(test_case, "error", msg_value, allocator);
+            }
         }
     }
 }

--- a/benchmark/sparse_blas/operations.cpp
+++ b/benchmark/sparse_blas/operations.cpp
@@ -38,6 +38,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
 #include "benchmark/sparse_blas/operations.hpp"
+#include "benchmark/utils/json.hpp"
 #include "core/factorization/elimination_forest.hpp"
 #include "core/factorization/symbolic.hpp"
 #include "core/matrix/csr_kernels.hpp"
@@ -631,6 +632,13 @@ public:
 
     void run() override { gko::factorization::symbolic_lu(mtx_, result_); }
 
+    void write_stats(rapidjson::Value& object,
+                     rapidjson::MemoryPoolAllocator<>& allocator) override
+    {
+        add_or_set_member(object, "factor_nonzeros",
+                          result_->get_num_stored_elements(), allocator);
+    }
+
 private:
     const Mtx* mtx_;
     std::unique_ptr<Mtx> result_;
@@ -654,6 +662,13 @@ public:
     void run() override
     {
         gko::factorization::symbolic_cholesky(mtx_, result_, forest_);
+    }
+
+    void write_stats(rapidjson::Value& object,
+                     rapidjson::MemoryPoolAllocator<>& allocator) override
+    {
+        add_or_set_member(object, "factor_nonzeros",
+                          result_->get_num_stored_elements(), allocator);
     }
 
 private:

--- a/benchmark/sparse_blas/operations.cpp
+++ b/benchmark/sparse_blas/operations.cpp
@@ -569,11 +569,11 @@ private:
 };
 
 
-bool validate_factorization(const Mtx* input, const Mtx* factors)
+bool validate_symbolic_factorization(const Mtx* input, const Mtx* factors)
 {
     const auto host_exec = input->get_executor()->get_master();
-    const auto host_input = gko::clone(host_exec, input);
-    const auto host_factors = gko::clone(host_exec, factors);
+    const auto host_input = gko::make_temporary_clone(host_exec, input);
+    const auto host_factors = gko::make_temporary_clone(host_exec, factors);
     const auto num_rows = input->get_size()[0];
     const auto in_row_ptrs = host_input->get_const_row_ptrs();
     const auto in_cols = host_input->get_const_col_idxs();
@@ -621,7 +621,8 @@ public:
 
     std::pair<bool, double> validate() const override
     {
-        return std::make_pair(validate_factorization(mtx_, result_.get()), 0.0);
+        return std::make_pair(
+            validate_symbolic_factorization(mtx_, result_.get()), 0.0);
     }
 
     gko::size_type get_flops() const override { return 0; }
@@ -642,7 +643,8 @@ public:
 
     std::pair<bool, double> validate() const override
     {
-        return std::make_pair(validate_factorization(mtx_, result_.get()), 0.0);
+        return std::make_pair(
+            validate_symbolic_factorization(mtx_, result_.get()), 0.0);
     }
 
     gko::size_type get_flops() const override { return 0; }

--- a/benchmark/sparse_blas/operations.cpp
+++ b/benchmark/sparse_blas/operations.cpp
@@ -31,12 +31,15 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ******************************<GINKGO LICENSE>*******************************/
 
 #include <map>
+#include <unordered_set>
 
 
 #include <gflags/gflags.h>
 
 
 #include "benchmark/sparse_blas/operations.hpp"
+#include "core/factorization/elimination_forest.hpp"
+#include "core/factorization/symbolic.hpp"
 #include "core/matrix/csr_kernels.hpp"
 #include "core/matrix/csr_lookup.hpp"
 #include "core/test/utils/unsort_matrix.hpp"
@@ -566,6 +569,98 @@ private:
 };
 
 
+bool validate_factorization(const Mtx* input, const Mtx* factors)
+{
+    const auto host_exec = input->get_executor()->get_master();
+    const auto host_input = gko::clone(host_exec, input);
+    const auto host_factors = gko::clone(host_exec, factors);
+    const auto num_rows = input->get_size()[0];
+    const auto in_row_ptrs = host_input->get_const_row_ptrs();
+    const auto in_cols = host_input->get_const_col_idxs();
+    const auto factor_row_ptrs = host_factors->get_const_row_ptrs();
+    const auto factor_cols = host_factors->get_const_col_idxs();
+    std::unordered_set<itype> columns;
+    for (itype row = 0; row < num_rows; row++) {
+        const auto in_begin = in_cols + in_row_ptrs[row];
+        const auto in_end = in_cols + in_row_ptrs[row + 1];
+        const auto factor_begin = factor_cols + factor_row_ptrs[row];
+        const auto factor_end = factor_cols + factor_row_ptrs[row + 1];
+        columns.clear();
+        // the factor needs to contain the original matrix
+        // plus the diagonal if that was missing
+        columns.insert(in_begin, in_end);
+        columns.insert(row);
+        for (auto col_it = factor_begin; col_it < factor_end; ++col_it) {
+            const auto col = *col_it;
+            if (col >= row) {
+                break;
+            }
+            const auto dep_begin = factor_cols + factor_row_ptrs[col];
+            const auto dep_end = factor_cols + factor_row_ptrs[col + 1];
+            // insert the upper triangular part of the row
+            const auto dep_diag = std::find(dep_begin, dep_end, col);
+            columns.insert(dep_diag, dep_end);
+        }
+        // the factor should contain exactly these columns, no more
+        if (factor_end - factor_begin != columns.size()) {
+            return false;
+        }
+        for (auto col_it = factor_begin; col_it < factor_end; ++col_it) {
+            if (columns.find(*col_it) == columns.end()) {
+                return false;
+            }
+        }
+    }
+    return true;
+}
+
+
+class SymbolicLuOperation : public BenchmarkOperation {
+public:
+    explicit SymbolicLuOperation(const Mtx* mtx) : mtx_{mtx}, result_{} {}
+
+    std::pair<bool, double> validate() const override
+    {
+        return std::make_pair(validate_factorization(mtx_, result_.get()), 0.0);
+    }
+
+    gko::size_type get_flops() const override { return 0; }
+
+    gko::size_type get_memory() const override { return 0; }
+
+    void run() override { gko::factorization::symbolic_lu(mtx_, result_); }
+
+private:
+    const Mtx* mtx_;
+    std::unique_ptr<Mtx> result_;
+};
+
+
+class SymbolicCholeskyOperation : public BenchmarkOperation {
+public:
+    explicit SymbolicCholeskyOperation(const Mtx* mtx) : mtx_{mtx}, result_{} {}
+
+    std::pair<bool, double> validate() const override
+    {
+        return std::make_pair(validate_factorization(mtx_, result_.get()), 0.0);
+    }
+
+    gko::size_type get_flops() const override { return 0; }
+
+    gko::size_type get_memory() const override { return 0; }
+
+    void run() override
+    {
+        gko::factorization::symbolic_cholesky(mtx_, result_, forest_);
+    }
+
+private:
+    const Mtx* mtx_;
+    std::unique_ptr<Mtx> result_;
+    std::unique_ptr<gko::factorization::elimination_forest<itype>> forest_;
+};
+
+
 const std::map<std::string,
                std::function<std::unique_ptr<BenchmarkOperation>(const Mtx*)>>
     operation_map{
@@ -587,8 +682,14 @@ const std::map<std::string,
          [](const Mtx* mtx) {
              return std::make_unique<GenerateLookupOperation>(mtx);
          }},
-        {"lookup", [](const Mtx* mtx) {
-             return std::make_unique<LookupOperation>(mtx);
+        {"lookup",
+         [](const Mtx* mtx) { return std::make_unique<LookupOperation>(mtx); }},
+        {"symbolic_lu",
+         [](const Mtx* mtx) {
+             return std::make_unique<SymbolicLuOperation>(mtx);
+         }},
+        {"symbolic_cholesky", [](const Mtx* mtx) {
+             return std::make_unique<SymbolicCholeskyOperation>(mtx);
          }}};
 
 

--- a/benchmark/sparse_blas/operations.hpp
+++ b/benchmark/sparse_blas/operations.hpp
@@ -36,6 +36,9 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <tuple>
 
 
+#include <rapidjson/document.h>
+
+
 #include "benchmark/utils/types.hpp"
 
 
@@ -58,7 +61,7 @@ public:
      * Sets up all necessary data for a following call to
      * BenchmarkOperation::run.
      */
-    virtual void prepare(){};
+    virtual void prepare() {}
 
     /**
      * Computes the error between a reference solution and the solution provided
@@ -71,6 +74,14 @@ public:
      * Executes the operation to be benchmarked.
      */
     virtual void run() = 0;
+
+
+    /**
+     * Allows the operation to write arbitrary information to the JSON output.
+     */
+    virtual void write_stats(rapidjson::Value& object,
+                             rapidjson::MemoryPoolAllocator<>& allocator)
+    {}
 };
 
 

--- a/benchmark/sparse_blas/sparse_blas.cpp
+++ b/benchmark/sparse_blas/sparse_blas.cpp
@@ -125,6 +125,7 @@ void apply_sparse_blas(const char* operation_name,
             op->run();
             exec->remove_logger(gen_logger);
         }
+        op->write_stats(test_case[operation_name], allocator);
 
         add_or_set_member(test_case[operation_name], "completed", true,
                           allocator);

--- a/benchmark/sparse_blas/sparse_blas.cpp
+++ b/benchmark/sparse_blas/sparse_blas.cpp
@@ -207,6 +207,11 @@ int main(int argc, char* argv[])
         } catch (const std::exception& e) {
             std::cerr << "Error setting up matrix data, what(): " << e.what()
                       << std::endl;
+            if (FLAGS_keep_errors) {
+                rapidjson::Value msg_value;
+                msg_value.SetString(e.what(), allocator);
+                add_or_set_member(test_case, "error", msg_value, allocator);
+            }
         }
     }
 

--- a/benchmark/sparse_blas/sparse_blas.cpp
+++ b/benchmark/sparse_blas/sparse_blas.cpp
@@ -184,7 +184,10 @@ int main(int argc, char* argv[])
             std::clog << "Matrix is of size (" << data.size[0] << ", "
                       << data.size[1] << "), " << data.nonzeros.size()
                       << std::endl;
-            add_or_set_member(test_case, "size", data.size[0], allocator);
+            add_or_set_member(test_case, "rows", data.size[0], allocator);
+            add_or_set_member(test_case, "cols", data.size[1], allocator);
+            add_or_set_member(test_case, "nonzeros", data.nonzeros.size(),
+                              allocator);
 
             auto mtx = Mtx::create(exec, data.size, data.nonzeros.size());
             mtx->read(data);

--- a/benchmark/sparse_blas/sparse_blas.cpp
+++ b/benchmark/sparse_blas/sparse_blas.cpp
@@ -57,22 +57,12 @@ const auto benchmark_name = "sparse_blas";
 
 using mat_data = gko::matrix_data<etype, itype>;
 
+DEFINE_string(operations, "spgemm,spgeam,transpose",
+              "Comma-separated list of operations to be benchmarked. Can be "
+              "spgemm, spgeam, transpose, sort, is_sorted, generate_lookup, "
+              "lookup, symbolic_lu, symbolic_cholesky");
 
-const std::map<std::string,
-               const std::function<std::shared_ptr<Mtx::strategy_type>()>>
-    strategy_map{
-        {"classical", [] { return std::make_shared<Mtx::classical>(); }},
-        {"sparselib", [] { return std::make_shared<Mtx::sparselib>(); }}};
-
-DEFINE_string(
-    operations, "spgemm,spgeam,transpose",
-    "Comma-separated list of operations to be benchmarked. Can be "
-    "spgemm, spgeam, transpose, sort, is_sorted, generate_lookup, lookup");
-
-DEFINE_string(strategies, "classical,sparselib",
-              "Comma-separated list of CSR strategies: classical, sparselib");
-
-DEFINE_bool(validate_results, false,
+DEFINE_bool(validate, false,
             "Check for correct sparsity pattern and compute the L2 norm "
             "against the ReferenceExecutor solution.");
 
@@ -117,7 +107,7 @@ void apply_sparse_blas(const char* operation_name,
         add_or_set_member(test_case[operation_name], "repetitions", repetitions,
                           allocator);
 
-        if (FLAGS_validate_results) {
+        if (FLAGS_validate) {
             auto validation_result = op->validate();
             add_or_set_member(test_case[operation_name], "correct",
                               validation_result.first, allocator);
@@ -175,7 +165,6 @@ int main(int argc, char* argv[])
 
     auto& allocator = test_cases.GetAllocator();
 
-    auto strategies = split(FLAGS_strategies, ',');
     auto operations = split(FLAGS_operations, ',');
 
     for (auto& test_case : test_cases.GetArray()) {
@@ -197,20 +186,16 @@ int main(int argc, char* argv[])
                       << std::endl;
             add_or_set_member(test_case, "size", data.size[0], allocator);
 
-            for (const auto& strategy_name : strategies) {
-                auto mtx = Mtx::create(exec, data.size, data.nonzeros.size(),
-                                       strategy_map.at(strategy_name)());
-                mtx->read(data);
-                for (const auto& operation_name : operations) {
-                    const auto name = operation_name + "-" + strategy_name;
-                    if (FLAGS_overwrite ||
-                        !sp_blas_case.HasMember(name.c_str())) {
-                        apply_sparse_blas(operation_name.c_str(), exec,
-                                          mtx.get(), sp_blas_case, allocator);
-                        std::clog << "Current state:" << std::endl
-                                  << test_cases << std::endl;
-                        backup_results(test_cases);
-                    }
+            auto mtx = Mtx::create(exec, data.size, data.nonzeros.size());
+            mtx->read(data);
+            for (const auto& operation_name : operations) {
+                if (FLAGS_overwrite ||
+                    !sp_blas_case.HasMember(operation_name.c_str())) {
+                    apply_sparse_blas(operation_name.c_str(), exec, mtx.get(),
+                                      sp_blas_case, allocator);
+                    std::clog << "Current state:" << std::endl
+                              << test_cases << std::endl;
+                    backup_results(test_cases);
                 }
             }
             // write the output if we have no strategies

--- a/benchmark/spmv/spmv_common.hpp
+++ b/benchmark/spmv/spmv_common.hpp
@@ -239,6 +239,11 @@ void run_spmv_benchmark(std::shared_ptr<gko::Executor> exec,
         } catch (const std::exception& e) {
             std::cerr << "Error setting up matrix data, what(): " << e.what()
                       << std::endl;
+            if (FLAGS_keep_errors) {
+                rapidjson::Value msg_value;
+                msg_value.SetString(e.what(), allocator);
+                add_or_set_member(test_case, "error", msg_value, allocator);
+            }
         }
     }
 }

--- a/benchmark/utils/general.hpp
+++ b/benchmark/utils/general.hpp
@@ -58,6 +58,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <rapidjson/prettywriter.h>
 
 
+#include "benchmark/utils/json.hpp"
 #include "benchmark/utils/timer.hpp"
 #include "benchmark/utils/types.hpp"
 #include "core/distributed/helpers.hpp"
@@ -185,59 +186,6 @@ std::default_random_engine& get_engine()
 {
     static std::default_random_engine engine(FLAGS_seed);
     return engine;
-}
-
-
-// helper for writing out rapidjson Values
-std::ostream& operator<<(std::ostream& os, const rapidjson::Value& value)
-{
-    rapidjson::OStreamWrapper jos(os);
-    rapidjson::PrettyWriter<rapidjson::OStreamWrapper, rapidjson::UTF8<>,
-                            rapidjson::UTF8<>, rapidjson::CrtAllocator,
-                            rapidjson::kWriteNanAndInfFlag>
-        writer(jos);
-    value.Accept(writer);
-    return os;
-}
-
-
-// helper for setting rapidjson object members
-template <typename T, typename NameType, typename Allocator>
-std::enable_if_t<
-    !std::is_same<typename std::decay<T>::type, gko::size_type>::value, void>
-add_or_set_member(rapidjson::Value& object, NameType&& name, T&& value,
-                  Allocator&& allocator)
-{
-    if (object.HasMember(name)) {
-        object[name] = std::forward<T>(value);
-    } else {
-        auto n = rapidjson::Value(name, allocator);
-        object.AddMember(n, std::forward<T>(value), allocator);
-    }
-}
-
-
-/**
-   @internal This is required to fix some MacOS problems (and possibly other
-   compilers). There is no explicit RapidJSON constructor for `std::size_t` so a
-   conversion to a known constructor is required to solve any ambiguity. See the
-   last comments of https://github.com/ginkgo-project/ginkgo/issues/270.
- */
-template <typename T, typename NameType, typename Allocator>
-std::enable_if_t<
-    std::is_same<typename std::decay<T>::type, gko::size_type>::value, void>
-add_or_set_member(rapidjson::Value& object, NameType&& name, T&& value,
-                  Allocator&& allocator)
-{
-    if (object.HasMember(name)) {
-        object[name] =
-            std::forward<std::uint64_t>(static_cast<std::uint64_t>(value));
-    } else {
-        auto n = rapidjson::Value(name, allocator);
-        object.AddMember(
-            n, std::forward<std::uint64_t>(static_cast<std::uint64_t>(value)),
-            allocator);
-    }
 }
 
 

--- a/benchmark/utils/general.hpp
+++ b/benchmark/utils/general.hpp
@@ -86,7 +86,7 @@ DEFINE_string(double_buffer, "",
 DEFINE_bool(detailed, true,
             "If set, performs several runs to obtain more detailed results");
 
-DEFINE_bool(keep_errors, false,
+DEFINE_bool(keep_errors, true,
             "If set, writes exception messages during the execution into the "
             "JSON output");
 

--- a/benchmark/utils/json.hpp
+++ b/benchmark/utils/json.hpp
@@ -1,0 +1,102 @@
+/*******************************<GINKGO LICENSE>******************************
+Copyright (c) 2017-2023, the Ginkgo authors
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+******************************<GINKGO LICENSE>*******************************/
+
+#ifndef GKO_BENCHMARK_UTILS_JSON_HPP_
+#define GKO_BENCHMARK_UTILS_JSON_HPP_
+
+
+#include <ginkgo/ginkgo.hpp>
+
+
+#include <type_traits>
+
+
+#include <rapidjson/document.h>
+#include <rapidjson/istreamwrapper.h>
+#include <rapidjson/ostreamwrapper.h>
+#include <rapidjson/prettywriter.h>
+
+
+// helper for setting rapidjson object members
+template <typename T, typename NameType, typename Allocator>
+std::enable_if_t<
+    !std::is_same<typename std::decay<T>::type, gko::size_type>::value, void>
+add_or_set_member(rapidjson::Value& object, NameType&& name, T&& value,
+                  Allocator&& allocator)
+{
+    if (object.HasMember(name)) {
+        object[name] = std::forward<T>(value);
+    } else {
+        auto n = rapidjson::Value(name, allocator);
+        object.AddMember(n, std::forward<T>(value), allocator);
+    }
+}
+
+
+/**
+   @internal This is required to fix some MacOS problems (and possibly other
+   compilers). There is no explicit RapidJSON constructor for `std::size_t` so a
+   conversion to a known constructor is required to solve any ambiguity. See the
+   last comments of https://github.com/ginkgo-project/ginkgo/issues/270.
+ */
+template <typename T, typename NameType, typename Allocator>
+std::enable_if_t<
+    std::is_same<typename std::decay<T>::type, gko::size_type>::value, void>
+add_or_set_member(rapidjson::Value& object, NameType&& name, T&& value,
+                  Allocator&& allocator)
+{
+    if (object.HasMember(name)) {
+        object[name] =
+            std::forward<std::uint64_t>(static_cast<std::uint64_t>(value));
+    } else {
+        auto n = rapidjson::Value(name, allocator);
+        object.AddMember(
+            n, std::forward<std::uint64_t>(static_cast<std::uint64_t>(value)),
+            allocator);
+    }
+}
+
+
+// helper for writing out rapidjson Values
+inline std::ostream& operator<<(std::ostream& os, const rapidjson::Value& value)
+{
+    rapidjson::OStreamWrapper jos(os);
+    rapidjson::PrettyWriter<rapidjson::OStreamWrapper, rapidjson::UTF8<>,
+                            rapidjson::UTF8<>, rapidjson::CrtAllocator,
+                            rapidjson::kWriteNanAndInfFlag>
+        writer(jos);
+    value.Accept(writer);
+    return os;
+}
+
+
+#endif  // GKO_BENCHMARK_UTILS_JSON_HPP_


### PR DESCRIPTION
Together with a generic validation tool for factorizations. 
Also removes the `strategy` parameter (we don't use strategies for `sparse_blas` algorithms), renames `validate_results` to `validate` and allows operations to output their own custom stats (in this case for the amount of fill-in).
Finally, I added prefix_sum benchmarks to BLAS, which highlighted a horrible performance on CUDA. ~~replacing them by Thrust gives us at least 100x speedup even with the overflow check.~~ See #1303 