### PR TITLE
Draft: MPI Logging Events

### DIFF
--- a/core/log/logger.cpp
+++ b/core/log/logger.cpp
@@ -86,8 +86,6 @@ constexpr Logger::mask_type
     Logger::mpi_point_to_point_communication_completed_mask;
 constexpr Logger::mask_type Logger::mpi_collective_communication_started_mask;
 constexpr Logger::mask_type Logger::mpi_collective_communication_completed_mask;
-constexpr Logger::mask_type Logger::mpi_reduction_started_mask;
-constexpr Logger::mask_type Logger::mpi_reduction_completed_mask;
 
 constexpr Logger::mask_type Logger::mpi_point_to_point_events_mask;
 constexpr Logger::mask_type Logger::mpi_collective_events_mask;

--- a/core/log/logger.cpp
+++ b/core/log/logger.cpp
@@ -76,8 +76,7 @@ constexpr Logger::mask_type Logger::criterion_check_completed_mask;
 
 constexpr Logger::mask_type Logger::iteration_complete_mask;
 
-constexpr Logger::mask_type Logger::mpi_blocking_communication_mask;
-constexpr Logger::mask_type Logger::mpi_non_blocking_communication_mask;
+constexpr Logger::mpi_mode_mask_type Logger::all_mpi_modes_mask;
 
 constexpr Logger::mask_type
     Logger::mpi_point_to_point_communication_started_mask;

--- a/core/log/logger.cpp
+++ b/core/log/logger.cpp
@@ -76,6 +76,22 @@ constexpr Logger::mask_type Logger::criterion_check_completed_mask;
 
 constexpr Logger::mask_type Logger::iteration_complete_mask;
 
+constexpr Logger::mask_type Logger::mpi_blocking_communication_mask;
+constexpr Logger::mask_type Logger::mpi_non_blocking_communication_mask;
+
+constexpr Logger::mask_type
+    Logger::mpi_point_to_point_communication_started_mask;
+constexpr Logger::mask_type
+    Logger::mpi_point_to_point_communication_completed_mask;
+constexpr Logger::mask_type Logger::mpi_collective_communication_started_mask;
+constexpr Logger::mask_type Logger::mpi_collective_communication_completed_mask;
+constexpr Logger::mask_type Logger::mpi_reduction_started_mask;
+constexpr Logger::mask_type Logger::mpi_reduction_completed_mask;
+
+constexpr Logger::mask_type Logger::mpi_point_to_point_events_mask;
+constexpr Logger::mask_type Logger::mpi_collective_events_mask;
+constexpr Logger::mask_type Logger::mpi_events_mask;
+
 
 }  // namespace log
 }  // namespace gko

--- a/core/log/logger.cpp
+++ b/core/log/logger.cpp
@@ -78,6 +78,8 @@ constexpr Logger::mask_type Logger::iteration_complete_mask;
 
 constexpr Logger::mpi_mode_mask_type Logger::all_mpi_modes_mask;
 
+constexpr int Logger::unspecified_mpi_rank;
+
 constexpr Logger::mask_type
     Logger::mpi_point_to_point_communication_started_mask;
 constexpr Logger::mask_type

--- a/core/log/profiler_hook.cpp
+++ b/core/log/profiler_hook.cpp
@@ -303,9 +303,9 @@ std::string build_mpi_name(mpi_mode mode, const char* name)
 {
     switch (mode) {
     case mpi_mode::blocking:
-        return std::string("blocking_") + name;
+        return std::string("mpi::blocking::") + name;
     case mpi_mode::non_blocking:
-        return std::string("non_blocking_") + name;
+        return std::string("mpi::non_blocking::") + name;
     }
 }
 

--- a/core/log/profiler_hook.cpp
+++ b/core/log/profiler_hook.cpp
@@ -299,6 +299,83 @@ void ProfilerHook::on_iteration_complete(
 }
 
 
+std::string build_mpi_name(mpi_mode mode, const char* name)
+{
+    switch (mode) {
+    case mpi_mode::blocking:
+        return std::string("blocking_") + name;
+    case mpi_mode::non_blocking:
+        return std::string("non_blocking_") + name;
+    }
+}
+
+
+void ProfilerHook::on_mpi_point_to_point_communication_started(
+    mpi_mode mode, const char* name, const void* comm, const uintptr& loc,
+    int size, const void* type, int source_rank, int destination_rank, int tag,
+    const void* req) const
+{
+    this->begin_hook_(build_mpi_name(mode, name).c_str(),
+                      profile_event_category::mpi);
+}
+
+
+void ProfilerHook::on_mpi_point_to_point_communication_completed(
+    mpi_mode mode, const char* name, const void* comm, const uintptr& loc,
+    int size, const void* type, int source_rank, int destination_rank, int tag,
+    const void* req) const
+{
+    this->end_hook_(build_mpi_name(mode, name).c_str(),
+                    profile_event_category::mpi);
+}
+
+
+void ProfilerHook::on_mpi_collective_communication_started(
+    mpi_mode mode, const char* name, const void* comm, const uintptr& send_loc,
+    int send_size, const int* send_sizes, const int* send_displacements,
+    const void* send_type, const uintptr& recv_loc, int recv_size,
+    const int* recv_sizes, const int* recv_displacements, const void* recv_type,
+    int root_rank, const void* req) const
+{
+    this->begin_hook_(build_mpi_name(mode, name).c_str(),
+                      profile_event_category::mpi);
+}
+
+
+void ProfilerHook::on_mpi_collective_communication_completed(
+    mpi_mode mode, const char* name, const void* comm, const uintptr& send_loc,
+    int send_size, const int* send_sizes, const int* send_displacements,
+    const void* send_type, const uintptr& recv_loc, int recv_size,
+    const int* recv_sizes, const int* recv_displacements, const void* recv_type,
+    int root_rank, const void* req) const
+{
+    this->end_hook_(build_mpi_name(mode, name).c_str(),
+                    profile_event_category::mpi);
+}
+
+
+void ProfilerHook::on_mpi_reduction_started(
+    mpi_mode mode, const char* name, const void* comm,
+    const uintptr& send_buffer, const uintptr& recv_buffer, int size,
+    const void* type, const void* operation, int root_rank,
+    const void* req) const
+{
+    this->begin_hook_(build_mpi_name(mode, name).c_str(),
+                      profile_event_category::mpi);
+}
+
+
+void ProfilerHook::on_mpi_reduction_completed(
+    mpi_mode mode, const char* name, const void* comm,
+    const uintptr& send_buffer, const uintptr& recv_buffer, int size,
+    const void* type, const void* operation, int root_rank,
+    const void* req) const
+{
+    this->end_hook_(build_mpi_name(mode, name).c_str(),
+                    profile_event_category::mpi);
+}
+
+
 bool ProfilerHook::needs_propagation() const { return true; }
 
 

--- a/core/log/record.cpp
+++ b/core/log/record.cpp
@@ -315,11 +315,12 @@ void Record::on_iteration_complete(const LinOp* solver,
 
 
 void Record::on_mpi_point_to_point_communication_started(
-    bool is_blocking, const char* name, const void* comm, const uintptr& loc,
+    mpi_mode mode, const char* name, const void* comm, const uintptr& loc,
     const int size, const void* type, int source_rank, int destination_rank,
     int tag, const void* req) const
 {
-    mpi::communicator comm_wrapper(*reinterpret_cast<const MPI_Comm*>(comm));
+    experimental::mpi::communicator comm_wrapper(
+        *reinterpret_cast<const MPI_Comm*>(comm));
     source_rank = source_rank == Logger::unspecified_mpi_rank
                       ? comm_wrapper.rank()
                       : source_rank;
@@ -330,20 +331,20 @@ void Record::on_mpi_point_to_point_communication_started(
     append_deque(
         data_.mpi_point_to_point_communication_started,
         std::unique_ptr<mpi_point_to_point_data>(new mpi_point_to_point_data{
-            is_blocking, std::string(name),
-            *reinterpret_cast<const MPI_Comm*>(comm), loc, size,
-            *reinterpret_cast<const MPI_Datatype*>(type), source_rank,
-            destination_rank, tag,
+            mode, std::string(name), *reinterpret_cast<const MPI_Comm*>(comm),
+            loc, size, *reinterpret_cast<const MPI_Datatype*>(type),
+            source_rank, destination_rank, tag,
             *reinterpret_cast<const MPI_Request*>(req)}));
 }
 
 
 void Record::on_mpi_point_to_point_communication_completed(
-    bool is_blocking, const char* name, const void* comm, const uintptr& loc,
+    mpi_mode mode, const char* name, const void* comm, const uintptr& loc,
     const int size, const void* type, int source_rank, int destination_rank,
     const int tag, const void* req) const
 {
-    mpi::communicator comm_wrapper(*reinterpret_cast<const MPI_Comm*>(comm));
+    experimental::mpi::communicator comm_wrapper(
+        *reinterpret_cast<const MPI_Comm*>(comm));
     source_rank = source_rank == Logger::unspecified_mpi_rank
                       ? comm_wrapper.rank()
                       : source_rank;
@@ -354,10 +355,9 @@ void Record::on_mpi_point_to_point_communication_completed(
     append_deque(
         data_.mpi_point_to_point_communication_completed,
         std::unique_ptr<mpi_point_to_point_data>(new mpi_point_to_point_data{
-            is_blocking, std::string(name),
-            *reinterpret_cast<const MPI_Comm*>(comm), loc, size,
-            *reinterpret_cast<const MPI_Datatype*>(type), source_rank,
-            destination_rank, tag,
+            mode, std::string(name), *reinterpret_cast<const MPI_Comm*>(comm),
+            loc, size, *reinterpret_cast<const MPI_Datatype*>(type),
+            source_rank, destination_rank, tag,
             *reinterpret_cast<const MPI_Request*>(req)}));
 }
 
@@ -372,22 +372,21 @@ std::vector<int> copy_mpi_data(int size, const int* data)
 
 
 void Record::on_mpi_collective_communication_started(
-    bool is_blocking, const char* name, const void* comm,
-    const uintptr& send_loc, int send_size, const int* send_sizes,
-    const int* send_displacements, const void* send_type,
-    const uintptr& recv_loc, int recv_size, const int* recv_sizes,
-    const int* recv_displacements, const void* recv_type, int root_rank,
-    const void* req) const
+    mpi_mode mode, const char* name, const void* comm, const uintptr& send_loc,
+    int send_size, const int* send_sizes, const int* send_displacements,
+    const void* send_type, const uintptr& recv_loc, int recv_size,
+    const int* recv_sizes, const int* recv_displacements, const void* recv_type,
+    int root_rank, const void* req) const
 {
-    auto comm_size =
-        mpi::communicator(*reinterpret_cast<const MPI_Comm*>(comm)).size();
+    auto comm_size = experimental::mpi::communicator(
+                         *reinterpret_cast<const MPI_Comm*>(comm))
+                         .size();
 
     append_deque(
         data_.mpi_collective_communication_started,
         std::make_unique<mpi_collective_data>(mpi_collective_data{
-            is_blocking, std::string(name),
-            *reinterpret_cast<const MPI_Comm*>(comm), send_loc, send_size,
-            copy_mpi_data(comm_size, send_sizes),
+            mode, std::string(name), *reinterpret_cast<const MPI_Comm*>(comm),
+            send_loc, send_size, copy_mpi_data(comm_size, send_sizes),
             copy_mpi_data(comm_size + 1, send_displacements),
             *reinterpret_cast<const MPI_Datatype*>(send_type), recv_loc,
             recv_size, copy_mpi_data(comm_size, recv_sizes),
@@ -398,22 +397,21 @@ void Record::on_mpi_collective_communication_started(
 
 
 void Record::on_mpi_collective_communication_completed(
-    bool is_blocking, const char* name, const void* comm,
-    const uintptr& send_loc, int send_size, const int* send_sizes,
-    const int* send_displacements, const void* send_type,
-    const uintptr& recv_loc, int recv_size, const int* recv_sizes,
-    const int* recv_displacements, const void* recv_type, int root_rank,
-    const void* req) const
+    mpi_mode mode, const char* name, const void* comm, const uintptr& send_loc,
+    int send_size, const int* send_sizes, const int* send_displacements,
+    const void* send_type, const uintptr& recv_loc, int recv_size,
+    const int* recv_sizes, const int* recv_displacements, const void* recv_type,
+    int root_rank, const void* req) const
 {
-    auto comm_size =
-        mpi::communicator(*reinterpret_cast<const MPI_Comm*>(comm)).size();
+    auto comm_size = experimental::mpi::communicator(
+                         *reinterpret_cast<const MPI_Comm*>(comm))
+                         .size();
 
     append_deque(
         data_.mpi_collective_communication_started,
         std::make_unique<mpi_collective_data>(mpi_collective_data{
-            is_blocking, std::string(name),
-            *reinterpret_cast<const MPI_Comm*>(comm), send_loc, send_size,
-            copy_mpi_data(comm_size, send_sizes),
+            mode, std::string(name), *reinterpret_cast<const MPI_Comm*>(comm),
+            send_loc, send_size, copy_mpi_data(comm_size, send_sizes),
             copy_mpi_data(comm_size + 1, send_displacements),
             *reinterpret_cast<const MPI_Datatype*>(send_type), recv_loc,
             recv_size, copy_mpi_data(comm_size, recv_sizes),
@@ -423,7 +421,7 @@ void Record::on_mpi_collective_communication_completed(
 }
 
 
-void Record::on_mpi_reduction_started(bool is_blocking, const char* name,
+void Record::on_mpi_reduction_started(mpi_mode mode, const char* name,
                                       const void* comm,
                                       const uintptr& send_buffer,
                                       const uintptr& recv_buffer, int size,
@@ -432,7 +430,7 @@ void Record::on_mpi_reduction_started(bool is_blocking, const char* name,
 {
     append_deque(data_.mpi_collective_communication_started,
                  std::make_unique<mpi_collective_data>(mpi_collective_data{
-                     is_blocking,
+                     mode,
                      std::string(name),
                      *reinterpret_cast<const MPI_Comm*>(comm),
                      send_buffer,
@@ -451,7 +449,7 @@ void Record::on_mpi_reduction_started(bool is_blocking, const char* name,
 }
 
 
-void Record::on_mpi_reduction_completed(bool is_blocking, const char* name,
+void Record::on_mpi_reduction_completed(mpi_mode mode, const char* name,
                                         const void* comm,
                                         const uintptr& send_buffer,
                                         const uintptr& recv_buffer, int size,
@@ -460,7 +458,7 @@ void Record::on_mpi_reduction_completed(bool is_blocking, const char* name,
 {
     append_deque(data_.mpi_collective_communication_started,
                  std::make_unique<mpi_collective_data>(mpi_collective_data{
-                     is_blocking,
+                     mode,
                      std::string(name),
                      *reinterpret_cast<const MPI_Comm*>(comm),
                      send_buffer,

--- a/core/log/record.cpp
+++ b/core/log/record.cpp
@@ -314,166 +314,86 @@ void Record::on_iteration_complete(const LinOp* solver,
 }
 
 
-void Record::on_mpi_point_to_point_communication_started(
-    mpi_mode mode, const char* name, const void* comm, const uintptr& loc,
-    const int size, const void* type, int source_rank, int destination_rank,
-    int tag, const void* req) const
+void Record::on_mpi_point_to_point_communication_started(const Executor* exec,
+                                                         mpi::mode mode,
+                                                         const char* name,
+                                                         const void* comm,
+                                                         mpi::pt2pt data) const
 {
     experimental::mpi::communicator comm_wrapper(
         *reinterpret_cast<const MPI_Comm*>(comm));
-    source_rank = source_rank == Logger::unspecified_mpi_rank
-                      ? comm_wrapper.rank()
-                      : source_rank;
-    destination_rank = destination_rank == Logger::unspecified_mpi_rank
-                           ? comm_wrapper.rank()
-                           : destination_rank;
 
     append_deque(
         data_.mpi_point_to_point_communication_started,
         std::unique_ptr<mpi_point_to_point_data>(new mpi_point_to_point_data{
-            mode, std::string(name), *reinterpret_cast<const MPI_Comm*>(comm),
-            loc, size, *reinterpret_cast<const MPI_Datatype*>(type),
-            source_rank, destination_rank, tag,
-            *reinterpret_cast<const MPI_Request*>(req)}));
+            exec,
+            mode,
+            std::string(name),
+            *reinterpret_cast<const MPI_Comm*>(comm),
+            {data, 1}}));
 }
 
 
 void Record::on_mpi_point_to_point_communication_completed(
-    mpi_mode mode, const char* name, const void* comm, const uintptr& loc,
-    const int size, const void* type, int source_rank, int destination_rank,
-    const int tag, const void* req) const
+    const Executor* exec, mpi::mode mode, const char* name, const void* comm,
+    mpi::pt2pt data) const
 {
     experimental::mpi::communicator comm_wrapper(
         *reinterpret_cast<const MPI_Comm*>(comm));
-    source_rank = source_rank == Logger::unspecified_mpi_rank
-                      ? comm_wrapper.rank()
-                      : source_rank;
-    destination_rank = destination_rank == Logger::unspecified_mpi_rank
-                           ? comm_wrapper.rank()
-                           : destination_rank;
 
     append_deque(
-        data_.mpi_point_to_point_communication_completed,
+        data_.mpi_point_to_point_communication_started,
         std::unique_ptr<mpi_point_to_point_data>(new mpi_point_to_point_data{
-            mode, std::string(name), *reinterpret_cast<const MPI_Comm*>(comm),
-            loc, size, *reinterpret_cast<const MPI_Datatype*>(type),
-            source_rank, destination_rank, tag,
-            *reinterpret_cast<const MPI_Request*>(req)}));
+            exec,
+            mode,
+            std::string(name),
+            *reinterpret_cast<const MPI_Comm*>(comm),
+            {data, 1}}));
 }
 
-std::vector<int> copy_mpi_data(int size, const int* data)
-{
-    if (data) {
-        return std::vector<int>(data, data + size);
-    } else {
-        return {};
+
+struct to_recorded {
+    template <typename Base>
+    mpi::recorded_coll operator()(Base&& base)
+    {
+        return mpi::recorded<std::decay_t<Base>>{std::forward<Base>(base),
+                                                 num_procs};
     }
-}
+    int num_procs;
+};
 
 
-void Record::on_mpi_collective_communication_started(
-    mpi_mode mode, const char* name, const void* comm, const uintptr& send_loc,
-    int send_size, const int* send_sizes, const int* send_displacements,
-    const void* send_type, const uintptr& recv_loc, int recv_size,
-    const int* recv_sizes, const int* recv_displacements, const void* recv_type,
-    int root_rank, const void* req) const
+void Record::on_mpi_collective_communication_started(const Executor* exec,
+                                                     mpi::mode mode,
+                                                     const char* name,
+                                                     const void* comm,
+                                                     const mpi::coll data) const
 {
     auto comm_size = experimental::mpi::communicator(
                          *reinterpret_cast<const MPI_Comm*>(comm))
                          .size();
 
-    append_deque(
-        data_.mpi_collective_communication_started,
-        std::make_unique<mpi_collective_data>(mpi_collective_data{
-            mode, std::string(name), *reinterpret_cast<const MPI_Comm*>(comm),
-            send_loc, send_size, copy_mpi_data(comm_size, send_sizes),
-            copy_mpi_data(comm_size + 1, send_displacements),
-            *reinterpret_cast<const MPI_Datatype*>(send_type), recv_loc,
-            recv_size, copy_mpi_data(comm_size, recv_sizes),
-            copy_mpi_data(comm_size + 1, recv_displacements),
-            *reinterpret_cast<const MPI_Datatype*>(recv_type), MPI_OP_NULL,
-            root_rank, *reinterpret_cast<const MPI_Request*>(req)}));
+    append_deque(data_.mpi_collective_communication_started,
+                 std::unique_ptr<mpi_collective_data>(new mpi_collective_data{
+                     exec, mode, std::string(name),
+                     *reinterpret_cast<const MPI_Comm*>(comm),
+                     std::visit(to_recorded{comm_size}, data)}));
 }
 
 
 void Record::on_mpi_collective_communication_completed(
-    mpi_mode mode, const char* name, const void* comm, const uintptr& send_loc,
-    int send_size, const int* send_sizes, const int* send_displacements,
-    const void* send_type, const uintptr& recv_loc, int recv_size,
-    const int* recv_sizes, const int* recv_displacements, const void* recv_type,
-    int root_rank, const void* req) const
+    const Executor* exec, mpi::mode mode, const char* name, const void* comm,
+    const mpi::coll data) const
 {
     auto comm_size = experimental::mpi::communicator(
                          *reinterpret_cast<const MPI_Comm*>(comm))
                          .size();
 
-    append_deque(
-        data_.mpi_collective_communication_started,
-        std::make_unique<mpi_collective_data>(mpi_collective_data{
-            mode, std::string(name), *reinterpret_cast<const MPI_Comm*>(comm),
-            send_loc, send_size, copy_mpi_data(comm_size, send_sizes),
-            copy_mpi_data(comm_size + 1, send_displacements),
-            *reinterpret_cast<const MPI_Datatype*>(send_type), recv_loc,
-            recv_size, copy_mpi_data(comm_size, recv_sizes),
-            copy_mpi_data(comm_size + 1, recv_displacements),
-            *reinterpret_cast<const MPI_Datatype*>(recv_type), MPI_OP_NULL,
-            root_rank, *reinterpret_cast<const MPI_Request*>(req)}));
-}
-
-
-void Record::on_mpi_reduction_started(mpi_mode mode, const char* name,
-                                      const void* comm,
-                                      const uintptr& send_buffer,
-                                      const uintptr& recv_buffer, int size,
-                                      const void* type, const void* operation,
-                                      int root_rank, const void* req) const
-{
-    append_deque(data_.mpi_collective_communication_started,
-                 std::make_unique<mpi_collective_data>(mpi_collective_data{
-                     mode,
-                     std::string(name),
+    append_deque(data_.mpi_collective_communication_completed,
+                 std::unique_ptr<mpi_collective_data>(new mpi_collective_data{
+                     exec, mode, std::string(name),
                      *reinterpret_cast<const MPI_Comm*>(comm),
-                     send_buffer,
-                     size,
-                     {},
-                     {},
-                     *reinterpret_cast<const MPI_Datatype*>(type),
-                     recv_buffer,
-                     size,
-                     {},
-                     {},
-                     *reinterpret_cast<const MPI_Datatype*>(type),
-                     *reinterpret_cast<const MPI_Op*>(operation),
-                     root_rank,
-                     *reinterpret_cast<const MPI_Request*>(req)}));
-}
-
-
-void Record::on_mpi_reduction_completed(mpi_mode mode, const char* name,
-                                        const void* comm,
-                                        const uintptr& send_buffer,
-                                        const uintptr& recv_buffer, int size,
-                                        const void* type, const void* operation,
-                                        int root_rank, const void* req) const
-{
-    append_deque(data_.mpi_collective_communication_started,
-                 std::make_unique<mpi_collective_data>(mpi_collective_data{
-                     mode,
-                     std::string(name),
-                     *reinterpret_cast<const MPI_Comm*>(comm),
-                     send_buffer,
-                     size,
-                     {},
-                     {},
-                     *reinterpret_cast<const MPI_Datatype*>(type),
-                     recv_buffer,
-                     size,
-                     {},
-                     {},
-                     *reinterpret_cast<const MPI_Datatype*>(type),
-                     *reinterpret_cast<const MPI_Op*>(operation),
-                     root_rank,
-                     *reinterpret_cast<const MPI_Request*>(req)}));
+                     std::visit(to_recorded{comm_size}, data)}));
 }
 
 

--- a/core/test/log/logger.cpp
+++ b/core/test/log/logger.cpp
@@ -231,16 +231,28 @@ struct DummyMpiLogger : gko::log::Logger {
     mutable int non_blocking_count = 0;
 
     explicit DummyMpiLogger(
-        std::shared_ptr<const gko::Executor> exec,
         const mask_type& enabled_events = Logger::mpi_events_mask)
-        : Logger(std::move(exec), enabled_events)
+        : Logger(enabled_events)
     {}
 
-
     void on_mpi_point_to_point_communication_started(
-        bool is_blocking, const char* name, const MPI_Comm* comm,
-        const gko::uintptr& loc, int size, MPI_Datatype type, int source_rank,
-        int destination_rank, int tag, const MPI_Request* req) const override
+        bool is_blocking, const char* name, const void* comm,
+        const gko::uintptr& loc, int size, const void* type, int source_rank,
+        int destination_rank, int tag, const void* req) const override
+    {
+        increase_count(is_blocking);
+    }
+
+    void on_mpi_point_to_point_communication_completed(
+        bool is_blocking, const char* name, const void* comm,
+        const gko::uintptr& loc, int size, const void* type, int source_rank,
+        int destination_rank, int tag, const void* req) const override
+    {
+        increase_count(is_blocking);
+    }
+
+protected:
+    void increase_count(bool is_blocking) const
     {
         if (is_blocking) {
             blocking_count++;
@@ -254,10 +266,10 @@ struct DummyMpiLogger : gko::log::Logger {
 TEST(DummyMpiLogger, CanLogBlockingMpiEvents)
 {
     using Logger = gko::log::Logger;
-    auto l = std::make_shared<DummyMpiLogger>(gko::ReferenceExecutor::create());
+    auto l = std::make_shared<DummyMpiLogger>();
 
     l->template on<Logger::blocking_mpi_point_to_point_communication_started>(
-        "", nullptr, 0, 0, MPI_DATATYPE_NULL, 0, 0, 0, nullptr);
+        "", nullptr, 0, 0, nullptr, 0, 0, 0, nullptr);
 
     ASSERT_EQ(l->blocking_count, 1);
 }
@@ -266,11 +278,11 @@ TEST(DummyMpiLogger, CanLogBlockingMpiEvents)
 TEST(DummyMpiLogger, CanLogNonBlockingMpiEvents)
 {
     using Logger = gko::log::Logger;
-    auto l = std::make_shared<DummyMpiLogger>(gko::ReferenceExecutor::create());
+    auto l = std::make_shared<DummyMpiLogger>();
 
     l->template on<
         Logger::non_blocking_mpi_point_to_point_communication_started>(
-        "", nullptr, 0, 0, MPI_DATATYPE_NULL, 0, 0, 0, nullptr);
+        "", nullptr, 0, 0, nullptr, 0, 0, 0, nullptr);
 
     ASSERT_EQ(l->non_blocking_count, 1);
 }
@@ -280,14 +292,14 @@ TEST(DummyMpiLogger, CanExclusivlyLogBlockingMpiEvents)
 {
     using Logger = gko::log::Logger;
     auto l = std::make_shared<DummyMpiLogger>(
-        gko::ReferenceExecutor::create(),
-        Logger::mpi_events_mask & ~Logger::mpi_non_blocking_communication_mask);
+        gko::log::detail::disable_non_blocking_mpi_events(
+            Logger::mpi_events_mask));
 
     l->template on<Logger::blocking_mpi_point_to_point_communication_started>(
-        "", nullptr, 0, 0, MPI_DATATYPE_NULL, 0, 0, 0, nullptr);
+        "", nullptr, 0, 0, nullptr, 0, 0, 0, nullptr);
     l->template on<
         Logger::non_blocking_mpi_point_to_point_communication_started>(
-        "", nullptr, 0, 0, MPI_DATATYPE_NULL, 0, 0, 0, nullptr);
+        "", nullptr, 0, 0, nullptr, 0, 0, 0, nullptr);
 
     ASSERT_EQ(l->blocking_count, 1);
     ASSERT_EQ(l->non_blocking_count, 0);
@@ -298,16 +310,33 @@ TEST(DummyMpiLogger, CanExclusivlyLogNonBlockingMpiEvents)
 {
     using Logger = gko::log::Logger;
     auto l = std::make_shared<DummyMpiLogger>(
-        gko::ReferenceExecutor::create(),
-        Logger::mpi_events_mask & ~Logger::mpi_blocking_communication_mask);
+        gko::log::detail::disable_blocking_mpi_events(Logger::mpi_events_mask));
 
     l->template on<Logger::blocking_mpi_point_to_point_communication_started>(
-        "", nullptr, 0, 0, MPI_DATATYPE_NULL, 0, 0, 0, nullptr);
+        "", nullptr, 0, 0, nullptr, 0, 0, 0, nullptr);
     l->template on<
         Logger::non_blocking_mpi_point_to_point_communication_started>(
-        "", nullptr, 0, 0, MPI_DATATYPE_NULL, 0, 0, 0, nullptr);
+        "", nullptr, 0, 0, nullptr, 0, 0, 0, nullptr);
 
     ASSERT_EQ(l->blocking_count, 0);
+    ASSERT_EQ(l->non_blocking_count, 1);
+}
+
+
+TEST(DummyMpiLogger, CanLogBlockingAndNonBlockingMpiEventsSimultaneously)
+{
+    using Logger = gko::log::Logger;
+    auto l = std::make_shared<DummyMpiLogger>(
+        Logger::blocking_mpi_point_to_point_communication_started_mask |
+        Logger::non_blocking_mpi_point_to_point_communication_completed_mask);
+
+    l->template on<Logger::blocking_mpi_point_to_point_communication_started>(
+        "", nullptr, 0, 0, nullptr, 0, 0, 0, nullptr);
+    l->template on<
+        Logger::non_blocking_mpi_point_to_point_communication_completed>(
+        "", nullptr, 0, 0, nullptr, 0, 0, 0, nullptr);
+
+    ASSERT_EQ(l->blocking_count, 1);
     ASSERT_EQ(l->non_blocking_count, 1);
 }
 

--- a/include/ginkgo/core/base/mpi.hpp
+++ b/include/ginkgo/core/base/mpi.hpp
@@ -438,8 +438,8 @@ inline std::vector<status> wait_all(std::vector<request>& req)
 
 
 template <typename T>
-struct EnableLoggingWithPropagation
-    : log::EnableLogging<EnableLoggingWithPropagation<T>> {
+class EnableLoggingWithPropagation
+    : public log::EnableLogging<EnableLoggingWithPropagation<T>> {
     struct propagator : EnablePolymorphicObject<propagator> {
         explicit propagator(std::shared_ptr<const Executor> exec)
             : EnablePolymorphicObject<propagator>(std::move(exec))
@@ -453,7 +453,7 @@ struct EnableLoggingWithPropagation
         }
     };
 
-
+protected:
     template <size_type Event, typename... Params>
     void log(std::shared_ptr<const Executor> exec, Params&&... params) const
     {

--- a/include/ginkgo/core/base/mpi.hpp
+++ b/include/ginkgo/core/base/mpi.hpp
@@ -458,9 +458,9 @@ protected:
     void log(std::shared_ptr<const Executor> exec, Params&&... params) const
     {
         log::EnableLogging<EnableLoggingWithPropagation<T>>::template log<
-            Event>(std::forward<Params>(params)...);
+            Event>(exec.get(), std::forward<Params>(params)...);
         propagator(std::move(exec))
-            .template log<Event>(std::forward<Params>(params)...);
+            .template log<Event>(exec.get(), std::forward<Params>(params)...);
     }
 };
 

--- a/include/ginkgo/core/base/mpi.hpp
+++ b/include/ginkgo/core/base/mpi.hpp
@@ -1590,20 +1590,21 @@ public:
     void scan(std::shared_ptr<const Executor> exec, const ScanType* send_buffer,
               ScanType* recv_buffer, int count, MPI_Op operation) const
     {
+        namespace log = gko::log::mpi;
         auto guard = exec->get_scoped_device_id_guard();
         auto type = type_impl<ScanType>::get_type();
-        this->template log<Logger::mpi_reduction_started>(
-            exec, mpi_mode::blocking, "scan", comm_.get(),
-            reinterpret_cast<uintptr>(send_buffer),
-            reinterpret_cast<uintptr>(recv_buffer), count, &type, &operation,
-            Logger::unspecified_mpi_rank, nullptr);
+        this->template log<Logger::mpi_collective_communication_started>(
+            exec, log::blocking{}, "scan", comm_.get(),
+            log::scan{{reinterpret_cast<uintptr>(send_buffer), count, &type},
+                      {reinterpret_cast<uintptr>(recv_buffer), count, &type},
+                      &operation});
         GKO_ASSERT_NO_MPI_ERRORS(MPI_Scan(send_buffer, recv_buffer, count, type,
                                           operation, this->get()));
-        this->template log<Logger::mpi_reduction_completed>(
-            exec, mpi_mode::blocking, "scan", comm_.get(),
-            reinterpret_cast<uintptr>(send_buffer),
-            reinterpret_cast<uintptr>(recv_buffer), count, &type, &operation,
-            Logger::unspecified_mpi_rank, nullptr);
+        this->template log<Logger::mpi_collective_communication_completed>(
+            exec, log::blocking{}, "scan", comm_.get(),
+            log::scan{{reinterpret_cast<uintptr>(send_buffer), count, &type},
+                      {reinterpret_cast<uintptr>(recv_buffer), count, &type},
+                      &operation});
     }
 
     /**

--- a/include/ginkgo/core/base/mpi.hpp
+++ b/include/ginkgo/core/base/mpi.hpp
@@ -462,8 +462,6 @@ struct EnableLoggingWithPropagation
         propagator(std::move(exec))
             .template log<Event>(std::forward<Params>(params)...);
     }
-
-    GKO_ENABLE_SELF(T);
 };
 
 

--- a/include/ginkgo/core/log/logger.hpp
+++ b/include/ginkgo/core/log/logger.hpp
@@ -143,7 +143,7 @@ struct one_to_all {
 
 struct scan {
     buffer<fixed> send;
-    uintptr_t recv_loc;
+    buffer<fixed> recv;
     void* op;
 };
 

--- a/include/ginkgo/core/log/logger.hpp
+++ b/include/ginkgo/core/log/logger.hpp
@@ -41,8 +41,24 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <vector>
 
 
+#include <ginkgo/config.hpp>
 #include <ginkgo/core/base/types.hpp>
 #include <ginkgo/core/base/utils_helper.hpp>
+
+
+#if GINKGO_BUILD_MPI
+
+
+#include <mpi.h>
+
+
+#else
+
+
+using MPI_Op = int;
+
+
+#endif
 
 
 namespace gko {
@@ -66,6 +82,11 @@ class stopping_status;
 namespace stop {
 class Criterion;
 }  // namespace stop
+
+
+namespace mpi {
+class communicator;
+}
 
 
 namespace log {
@@ -483,6 +504,77 @@ public:
                               const PolymorphicObject* input,
                               const PolymorphicObject* output)
 
+
+    static constexpr mask_type mpi_blocking_communication_mask{mask_type{1}
+                                                               << 24};
+    static constexpr mask_type mpi_non_blocking_communication_mask{mask_type{1}
+                                                                   << 25};
+
+
+#define GKO_LOGGER_REGISTER_MPI_EVENT(_id, _event_name, ...)              \
+protected:                                                                \
+    virtual void on_##_event_name(bool is_blocking, __VA_ARGS__) const {} \
+                                                                          \
+public:                                                                   \
+    template <size_type Event, typename... Params>                        \
+    std::enable_if_t<(Event == _id - 1 || Event == _id) &&                \
+                     (_id < event_count_max)>                             \
+    on(Params&&... params) const                                          \
+    {                                                                     \
+        if (enabled_events_ & mask_type{1} << _id &&                      \
+            ((Event & size_type{1} &&                                     \
+              enabled_events_ & mpi_blocking_communication_mask) ||       \
+             (!(Event & size_type{1}) &&                                  \
+              enabled_events_ & mpi_non_blocking_communication_mask))) {  \
+            this->on_##_event_name(Event& size_type{1},                   \
+                                   std::forward<Params>(params)...);      \
+        }                                                                 \
+    }                                                                     \
+    static constexpr size_type non_blocking_##_event_name{_id - 1};       \
+    static constexpr size_type blocking_##_event_name{_id};               \
+    static constexpr mask_type _event_name##_mask{mask_type{1} << _id};
+
+
+    GKO_LOGGER_REGISTER_MPI_EVENT(27, mpi_point_to_point_communication_started,
+                                  const char* name, const MPI_Comm* comm,
+                                  const uintptr& loc, int size,
+                                  MPI_Datatype type, int source_rank,
+                                  int destination_rank, int tag,
+                                  const MPI_Request* req)
+    GKO_LOGGER_REGISTER_MPI_EVENT(
+        29, mpi_point_to_point_communication_completed, const char* name,
+        const MPI_Comm* comm, const uintptr& loc, int size, MPI_Datatype type,
+        int source_rank, int destination_rank, int tag, const MPI_Request* req)
+
+    GKO_LOGGER_REGISTER_MPI_EVENT(
+        31, mpi_collective_communication_started, const char* name,
+        const MPI_Comm* comm, const uintptr& send_loc, int send_size,
+        const int* send_sizes, const int* send_displacements,
+        MPI_Datatype send_type, const uintptr& recv_loc, int recv_size,
+        const int* recv_sizes, const int* recv_displacements,
+        MPI_Datatype recv_type, int root_rank, const MPI_Request* req)
+    GKO_LOGGER_REGISTER_MPI_EVENT(
+        33, mpi_collective_communication_completed, const char* name,
+        const MPI_Comm* comm, const uintptr& send_loc, int send_size,
+        const int* send_sizes, const int* send_displacements,
+        MPI_Datatype send_type, const uintptr& recv_loc, int recv_size,
+        const int* recv_sizes, const int* recv_displacements,
+        MPI_Datatype recv_type, int root_rank, const MPI_Request* req)
+
+    GKO_LOGGER_REGISTER_MPI_EVENT(35, mpi_reduction_started, const char* name,
+                                  const MPI_Comm* comm,
+                                  const uintptr& send_buffer,
+                                  const uintptr& recv_buffer, int size,
+                                  MPI_Op operation, int root_rank,
+                                  const MPI_Request* req)
+    GKO_LOGGER_REGISTER_MPI_EVENT(37, mpi_reduction_completed, const char* name,
+                                  const MPI_Comm* comm,
+                                  const uintptr& send_buffer,
+                                  const uintptr& recv_buffer, int size,
+                                  MPI_Op operation, int root_rank,
+                                  const MPI_Request* req)
+
+
 #undef GKO_LOGGER_REGISTER_EVENT
 
     /**
@@ -530,6 +622,20 @@ public:
      */
     static constexpr mask_type criterion_events_mask =
         criterion_check_started_mask | criterion_check_completed_mask;
+
+    static constexpr mask_type mpi_point_to_point_events_mask =
+        mpi_blocking_communication_mask | mpi_non_blocking_communication_mask |
+        mpi_point_to_point_communication_started_mask |
+        mpi_point_to_point_communication_completed_mask;
+
+    static constexpr mask_type mpi_collective_events_mask =
+        mpi_blocking_communication_mask | mpi_non_blocking_communication_mask |
+        mpi_collective_communication_started_mask |
+        mpi_collective_communication_completed_mask |
+        mpi_reduction_started_mask | mpi_reduction_completed_mask;
+
+    static constexpr mask_type mpi_events_mask =
+        mpi_point_to_point_events_mask | mpi_collective_events_mask;
 
     /**
      * Returns true if this logger, when attached to an Executor, needs to be

--- a/include/ginkgo/core/log/logger.hpp
+++ b/include/ginkgo/core/log/logger.hpp
@@ -99,26 +99,18 @@ struct fixed {
 };
 
 struct variable {
-    variable(int* sizes, int* offsets) : sizes(sizes), offsets(offsets) {}
-    int* sizes;
-    int* offsets;
+    const int* sizes;
+    const int* offsets;
 };
 
 template <typename Size>
 struct buffer {
-    buffer(uintptr loc, Size size, void* type)
-        : loc(loc), size(std::move(size)), type(type)
-    {}
     uintptr loc;
     Size size;
     void* type;
 };
 
 struct pt2pt {
-    pt2pt(buffer<fixed> data, std::optional<int> source,
-          std::optional<int> dest, int tag, std::optional<void*> status = {})
-        : data(data), source(source), dest(dest), tag(tag), status(status)
-    {}
     buffer<fixed> data;
     std::optional<int> source;
     std::optional<int> dest;
@@ -128,10 +120,6 @@ struct pt2pt {
 
 template <typename Size>
 struct all_to_all {
-    all_to_all(buffer<Size> send, buffer<Size> recv, operation op = {})
-        : send(std::move(send)), recv(std::move(recv)), op(op)
-    {}
-
     buffer<Size> send;
     buffer<Size> recv;
     operation op;
@@ -139,10 +127,6 @@ struct all_to_all {
 
 template <typename Size>
 struct all_to_one {
-    all_to_one(buffer<Size> send, buffer<Size> recv, int root,
-               operation op = {})
-        : send(std::move(send)), recv(std::move(recv)), op(op)
-    {}
     buffer<Size> send;
     buffer<Size> recv;
     int root;
@@ -151,10 +135,6 @@ struct all_to_one {
 
 template <typename Size>
 struct one_to_all {
-    one_to_all(buffer<Size> send, buffer<Size> recv, int root,
-               operation op = {})
-        : send(std::move(send)), recv(std::move(recv)), op(op)
-    {}
     buffer<Size> send;
     buffer<Size> recv;
     int root;
@@ -162,9 +142,6 @@ struct one_to_all {
 };
 
 struct scan {
-    scan(buffer<fixed> send, uintptr recv_loc, void* op)
-        : send(std::move(send)), recv_loc(recv_loc), op(op)
-    {}
     buffer<fixed> send;
     uintptr_t recv_loc;
     void* op;

--- a/include/ginkgo/core/log/logger.hpp
+++ b/include/ginkgo/core/log/logger.hpp
@@ -548,12 +548,8 @@ public:                                                                   \
                      (_id < event_count_max)>                             \
     on(Params&&... params) const                                          \
     {                                                                     \
-        if (enabled_events_ & mask_type{1} << _id &&                      \
-            ((Event & size_type{1} &&                                     \
-              enabled_events_ & mpi_blocking_communication_mask) ||       \
-             (!(Event & size_type{1}) &&                                  \
-              enabled_events_ & mpi_non_blocking_communication_mask))) {  \
-            this->on_##_event_name(Event& size_type{1},                   \
+        if (enabled_events_ & (mask_type{1} << Event)) {                  \
+            this->on_##_event_name(Event == blocking_##_event_name,       \
                                    std::forward<Params>(params)...);      \
         }                                                                 \
     }                                                                     \

--- a/include/ginkgo/core/log/logger.hpp
+++ b/include/ginkgo/core/log/logger.hpp
@@ -211,8 +211,7 @@ public:
      */
 #define GKO_LOGGER_REGISTER_EVENT(_id, _event_name, ...)             \
 protected:                                                           \
-    virtual void on_##_event_name(__VA_ARGS__) const                 \
-    {}                                                               \
+    virtual void on_##_event_name(__VA_ARGS__) const {}              \
                                                                      \
 public:                                                              \
     template <size_type Event, typename... Params>                   \
@@ -580,27 +579,23 @@ public:
     // There is only one corresponding `on_xxx` function which takes a bool
     // as its first parameter to distinguish between blocking and non-blocking
     // events.
-#define GKO_LOGGER_REGISTER_MPI_EVENT(_id, _event_name, ...)            \
-protected:                                                              \
-    virtual void on_##_event_name(__VA_ARGS__) const                    \
-    {}                                                                  \
-                                                                        \
-public:                                                                 \
-    template <size_type Event, typename... Params>                      \
-    std::enable_if_t<Event == _id && (_id < event_count_max)> on(       \
-        const Executor* exec, mpi::mode mode, Params&&... params) const \
-    {                                                                   \
-        if (enabled_events_ & (mask_type{1} << Event) &&                \
-            enabled_mpi_modes_ & static_cast<uint8>(mode.index())) {    \
-            this->on_##_event_name(exec, mode,                          \
-                                   std::forward<Params>(params)...);    \
-        }                                                               \
-    }                                                                   \
-    static constexpr size_type _event_name{_id};                        \
-    static constexpr mask_type _event_name##_mask                       \
-    {                                                                   \
-        mask_type{1} << _id                                             \
-    }
+#define GKO_LOGGER_REGISTER_MPI_EVENT(_id, _event_name, ...)                \
+protected:                                                                  \
+    virtual void on_##_event_name(__VA_ARGS__) const {}                     \
+                                                                            \
+public:                                                                     \
+    template <size_type Event, typename... Params>                          \
+    std::enable_if_t<Event == _id && (_id < event_count_max)> on(           \
+        const Executor* exec, mpi::mode mode, Params&&... params) const     \
+    {                                                                       \
+        if (enabled_events_ & (mask_type{1} << Event) &&                    \
+            enabled_mpi_modes_ & (mpi_mode_mask_type{1} << mode.index())) { \
+            this->on_##_event_name(exec, mode,                              \
+                                   std::forward<Params>(params)...);        \
+        }                                                                   \
+    }                                                                       \
+    static constexpr size_type _event_name{_id};                            \
+    static constexpr mask_type _event_name##_mask { mask_type{1} << _id }
 
 
     // TODO: Perhaps use similar approach as parameters to better support
@@ -615,7 +610,6 @@ public:                                                                 \
                                   const Executor* exec, mpi::mode mode,
                                   const char* name, const void* comm,
                                   mpi::pt2pt data);
-
 
     GKO_LOGGER_REGISTER_MPI_EVENT(26, mpi_collective_communication_started,
                                   const Executor* exec, mpi::mode mode,

--- a/include/ginkgo/core/log/logger.hpp
+++ b/include/ginkgo/core/log/logger.hpp
@@ -52,12 +52,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <mpi.h>
 
 
-#else
-
-
-using MPI_Op = int;
-
-
 #endif
 
 
@@ -511,6 +505,7 @@ public:
     static constexpr mask_type mpi_non_blocking_communication_mask{mask_type{1}
                                                                    << 25};
 
+#if GINKGO_BUILD_MPI
 
 #define GKO_LOGGER_REGISTER_MPI_EVENT(_id, _event_name, ...)              \
 protected:                                                                \
@@ -575,6 +570,11 @@ public:                                                                   \
                                   MPI_Datatype type, MPI_Op operation,
                                   int root_rank, const MPI_Request* req)
 
+#undef GKO_LOGGER_REGISTER_MPI_EVENT
+
+
+#endif
+
 
 #undef GKO_LOGGER_REGISTER_EVENT
 
@@ -624,6 +624,10 @@ public:                                                                   \
     static constexpr mask_type criterion_events_mask =
         criterion_check_started_mask | criterion_check_completed_mask;
 
+
+#if GINKGO_BUILD_MPI
+
+
     static constexpr mask_type mpi_point_to_point_events_mask =
         mpi_blocking_communication_mask | mpi_non_blocking_communication_mask |
         mpi_point_to_point_communication_started_mask |
@@ -637,6 +641,9 @@ public:                                                                   \
 
     static constexpr mask_type mpi_events_mask =
         mpi_point_to_point_events_mask | mpi_collective_events_mask;
+
+
+#endif
 
     /**
      * Returns true if this logger, when attached to an Executor, needs to be

--- a/include/ginkgo/core/log/logger.hpp
+++ b/include/ginkgo/core/log/logger.hpp
@@ -504,6 +504,7 @@ public:
                               const PolymorphicObject* input,
                               const PolymorphicObject* output)
 
+    static constexpr int unspecified_mpi_rank = -1;
 
     static constexpr mask_type mpi_blocking_communication_mask{mask_type{1}
                                                                << 24};
@@ -565,14 +566,14 @@ public:                                                                   \
                                   const MPI_Comm* comm,
                                   const uintptr& send_buffer,
                                   const uintptr& recv_buffer, int size,
-                                  MPI_Op operation, int root_rank,
-                                  const MPI_Request* req)
+                                  MPI_Datatype type, MPI_Op operation,
+                                  int root_rank, const MPI_Request* req)
     GKO_LOGGER_REGISTER_MPI_EVENT(37, mpi_reduction_completed, const char* name,
                                   const MPI_Comm* comm,
                                   const uintptr& send_buffer,
                                   const uintptr& recv_buffer, int size,
-                                  MPI_Op operation, int root_rank,
-                                  const MPI_Request* req)
+                                  MPI_Datatype type, MPI_Op operation,
+                                  int root_rank, const MPI_Request* req)
 
 
 #undef GKO_LOGGER_REGISTER_EVENT

--- a/include/ginkgo/core/log/logger.hpp
+++ b/include/ginkgo/core/log/logger.hpp
@@ -580,47 +580,52 @@ public:
     // There is only one corresponding `on_xxx` function which takes a bool
     // as its first parameter to distinguish between blocking and non-blocking
     // events.
-#define GKO_LOGGER_REGISTER_MPI_EVENT(_id, _event_name, ...)               \
-protected:                                                                 \
-    virtual void on_##_event_name(__VA_ARGS__) const                       \
-    {}                                                                     \
-                                                                           \
-public:                                                                    \
-    template <size_type Event, typename... Params>                         \
-    std::enable_if_t<Event == _id && (_id < event_count_max)> on(          \
-        mpi::mode mode, Params&&... params) const                          \
-    {                                                                      \
-        if (enabled_events_ & (mask_type{1} << Event) &&                   \
-            enabled_mpi_modes_ & static_cast<uint8>(mode.index())) {       \
-            this->on_##_event_name(mode, std::forward<Params>(params)...); \
-        }                                                                  \
-    }                                                                      \
-    static constexpr size_type _event_name{_id};                           \
-    static constexpr mask_type _event_name##_mask                          \
-    {                                                                      \
-        mask_type{1} << _id                                                \
+#define GKO_LOGGER_REGISTER_MPI_EVENT(_id, _event_name, ...)            \
+protected:                                                              \
+    virtual void on_##_event_name(__VA_ARGS__) const                    \
+    {}                                                                  \
+                                                                        \
+public:                                                                 \
+    template <size_type Event, typename... Params>                      \
+    std::enable_if_t<Event == _id && (_id < event_count_max)> on(       \
+        const Executor* exec, mpi::mode mode, Params&&... params) const \
+    {                                                                   \
+        if (enabled_events_ & (mask_type{1} << Event) &&                \
+            enabled_mpi_modes_ & static_cast<uint8>(mode.index())) {    \
+            this->on_##_event_name(exec, mode,                          \
+                                   std::forward<Params>(params)...);    \
+        }                                                               \
+    }                                                                   \
+    static constexpr size_type _event_name{_id};                        \
+    static constexpr mask_type _event_name##_mask                       \
+    {                                                                   \
+        mask_type{1} << _id                                             \
     }
 
 
     // TODO: Perhaps use similar approach as parameters to better support
     // default/non-existing parameters
     GKO_LOGGER_REGISTER_MPI_EVENT(24, mpi_point_to_point_communication_started,
-                                  mpi::mode mode, const char* name,
-                                  const void* comm, mpi::pt2pt data);
+                                  const Executor* exec, mpi::mode mode,
+                                  const char* name, const void* comm,
+                                  mpi::pt2pt data);
 
     GKO_LOGGER_REGISTER_MPI_EVENT(25,
                                   mpi_point_to_point_communication_completed,
-                                  mpi::mode mode, const char* name,
-                                  const void* comm, mpi::pt2pt data);
+                                  const Executor* exec, mpi::mode mode,
+                                  const char* name, const void* comm,
+                                  mpi::pt2pt data);
 
 
     GKO_LOGGER_REGISTER_MPI_EVENT(26, mpi_collective_communication_started,
-                                  mpi::mode mode, const char* name,
-                                  const void* comm, const mpi::coll data);
+                                  const Executor* exec, mpi::mode mode,
+                                  const char* name, const void* comm,
+                                  const mpi::coll data);
 
     GKO_LOGGER_REGISTER_MPI_EVENT(27, mpi_collective_communication_completed,
-                                  mpi::mode mode, const char* name,
-                                  const void* comm, mpi::coll data);
+                                  const Executor* exec, mpi::mode mode,
+                                  const char* name, const void* comm,
+                                  mpi::coll data);
 
 #undef GKO_LOGGER_REGISTER_MPI_EVENT
 

--- a/include/ginkgo/core/log/logger.hpp
+++ b/include/ginkgo/core/log/logger.hpp
@@ -82,14 +82,14 @@ enum mpi_mode : uint8 { blocking = 1 << 0, non_blocking = 1 << 1 };
 
 
 namespace mpi {
-using operation = std::optional<void*>;
+using operation = std::optional<const void*>;
 
 struct barrier {};
 
 struct blocking {};
 
 struct non_blocking {
-    void* req;
+    const void* req;
 };
 
 using mode = std::variant<blocking, non_blocking>;
@@ -107,7 +107,7 @@ template <typename Size>
 struct buffer {
     uintptr loc;
     Size size;
-    void* type;
+    const void* type;
 };
 
 struct pt2pt {
@@ -115,7 +115,7 @@ struct pt2pt {
     std::optional<int> source;
     std::optional<int> dest;
     int tag;
-    std::optional<void*> status;
+    std::optional<const void*> status;
 };
 
 template <typename Size>
@@ -144,7 +144,7 @@ struct one_to_all {
 struct scan {
     buffer<fixed> send;
     buffer<fixed> recv;
-    void* op;
+    const void* op;
 };
 
 using coll =

--- a/include/ginkgo/core/log/profiler_hook.hpp
+++ b/include/ginkgo/core/log/profiler_hook.hpp
@@ -194,45 +194,20 @@ public:
         const LinOp* implicit_sq_residual_norm) const override;
 
     void on_mpi_point_to_point_communication_started(
-        mpi_mode mode, const char* name, const void* comm, const uintptr& loc,
-        int size, const void* type, int source_rank, int destination_rank,
-        int tag, const void* req) const override;
+        const Executor* exec, mpi::mode mode, const char* name,
+        const void* comm, mpi::pt2pt data) const override;
 
     void on_mpi_point_to_point_communication_completed(
-        mpi_mode mode, const char* name, const void* comm, const uintptr& loc,
-        int size, const void* type, int source_rank, int destination_rank,
-        int tag, const void* req) const override;
+        const Executor* exec, mpi::mode mode, const char* name,
+        const void* comm, mpi::pt2pt data) const override;
 
     void on_mpi_collective_communication_started(
-        mpi_mode mode, const char* name, const void* comm,
-        const uintptr& send_loc, int send_size, const int* send_sizes,
-        const int* send_displacements, const void* send_type,
-        const uintptr& recv_loc, int recv_size, const int* recv_sizes,
-        const int* recv_displacements, const void* recv_type, int root_rank,
-        const void* req) const override;
+        const Executor* exec, mpi::mode mode, const char* name,
+        const void* comm, const mpi::coll data) const override;
 
     void on_mpi_collective_communication_completed(
-        mpi_mode mode, const char* name, const void* comm,
-        const uintptr& send_loc, int send_size, const int* send_sizes,
-        const int* send_displacements, const void* send_type,
-        const uintptr& recv_loc, int recv_size, const int* recv_sizes,
-        const int* recv_displacements, const void* recv_type, int root_rank,
-        const void* req) const override;
-
-    void on_mpi_reduction_started(mpi_mode mode, const char* name,
-                                  const void* comm, const uintptr& send_buffer,
-                                  const uintptr& recv_buffer, int size,
-                                  const void* type, const void* operation,
-                                  int root_rank,
-                                  const void* req) const override;
-
-    void on_mpi_reduction_completed(mpi_mode mode, const char* name,
-                                    const void* comm,
-                                    const uintptr& send_buffer,
-                                    const uintptr& recv_buffer, int size,
-                                    const void* type, const void* operation,
-                                    int root_rank,
-                                    const void* req) const override;
+        const Executor* exec, mpi::mode mode, const char* name,
+        const void* comm, const mpi::coll data) const override;
 
     bool needs_propagation() const override;
 

--- a/include/ginkgo/core/log/profiler_hook.hpp
+++ b/include/ginkgo/core/log/profiler_hook.hpp
@@ -62,6 +62,8 @@ enum class profile_event_category {
     solver,
     /** Stopping criterion events. */
     criterion,
+    /** MPI events. */
+    mpi,
     /** User-defined events. */
     user,
     /** For development use. */
@@ -190,6 +192,47 @@ public:
         const LinOp* residual, const LinOp* solution,
         const LinOp* residual_norm,
         const LinOp* implicit_sq_residual_norm) const override;
+
+    void on_mpi_point_to_point_communication_started(
+        mpi_mode mode, const char* name, const void* comm, const uintptr& loc,
+        int size, const void* type, int source_rank, int destination_rank,
+        int tag, const void* req) const override;
+
+    void on_mpi_point_to_point_communication_completed(
+        mpi_mode mode, const char* name, const void* comm, const uintptr& loc,
+        int size, const void* type, int source_rank, int destination_rank,
+        int tag, const void* req) const override;
+
+    void on_mpi_collective_communication_started(
+        mpi_mode mode, const char* name, const void* comm,
+        const uintptr& send_loc, int send_size, const int* send_sizes,
+        const int* send_displacements, const void* send_type,
+        const uintptr& recv_loc, int recv_size, const int* recv_sizes,
+        const int* recv_displacements, const void* recv_type, int root_rank,
+        const void* req) const override;
+
+    void on_mpi_collective_communication_completed(
+        mpi_mode mode, const char* name, const void* comm,
+        const uintptr& send_loc, int send_size, const int* send_sizes,
+        const int* send_displacements, const void* send_type,
+        const uintptr& recv_loc, int recv_size, const int* recv_sizes,
+        const int* recv_displacements, const void* recv_type, int root_rank,
+        const void* req) const override;
+
+    void on_mpi_reduction_started(mpi_mode mode, const char* name,
+                                  const void* comm, const uintptr& send_buffer,
+                                  const uintptr& recv_buffer, int size,
+                                  const void* type, const void* operation,
+                                  int root_rank,
+                                  const void* req) const override;
+
+    void on_mpi_reduction_completed(mpi_mode mode, const char* name,
+                                    const void* comm,
+                                    const uintptr& send_buffer,
+                                    const uintptr& recv_buffer, int size,
+                                    const void* type, const void* operation,
+                                    int root_rank,
+                                    const void* req) const override;
 
     bool needs_propagation() const override;
 

--- a/include/ginkgo/core/log/record.hpp
+++ b/include/ginkgo/core/log/record.hpp
@@ -43,6 +43,15 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <ginkgo/core/stop/criterion.hpp>
 
 
+#if GINKGO_BUILD_MPI
+
+
+#include <mpi.h>
+
+
+#endif
+
+
 namespace gko {
 
 /**
@@ -226,6 +235,9 @@ struct criterion_data {
 };
 
 
+#if GINKGO_BUILD_MPI
+
+
 struct mpi_point_to_point_data {
     bool is_blocking;
     std::string operation_name;
@@ -259,6 +271,8 @@ struct mpi_collective_data {
     MPI_Request request;
 };
 
+
+#endif
 
 /**
  * Record is a Logger which logs every event to an object. The object can
@@ -445,45 +459,53 @@ public:
         const LinOp* residual_norm,
         const LinOp* implicit_sq_residual_norm) const override;
 
+
+#if GINKGO_BUILD_MPI
+
+
     void on_mpi_point_to_point_communication_started(
-        bool is_blocking, const char* name, const MPI_Comm* comm,
-        const uintptr& loc, int size, MPI_Datatype type, int source_rank,
-        int destination_rank, int tag, const MPI_Request* req) const override;
+        bool is_blocking, const char* name, const void* comm,
+        const uintptr& loc, int size, const void* type, int source_rank,
+        int destination_rank, int tag, const void* req) const override;
 
     void on_mpi_point_to_point_communication_completed(
-        bool is_blocking, const char* name, const MPI_Comm* comm,
-        const uintptr& loc, int size, MPI_Datatype type, int source_rank,
-        int destination_rank, int tag, const MPI_Request* req) const override;
+        bool is_blocking, const char* name, const void* comm,
+        const uintptr& loc, int size, const void* type, int source_rank,
+        int destination_rank, int tag, const void* req) const override;
 
     void on_mpi_collective_communication_started(
-        bool is_blocking, const char* name, const MPI_Comm* comm,
+        bool is_blocking, const char* name, const void* comm,
         const uintptr& send_loc, int send_size, const int* send_sizes,
-        const int* send_displacements, MPI_Datatype send_type,
+        const int* send_displacements, const void* send_type,
         const uintptr& recv_loc, int recv_size, const int* recv_sizes,
-        const int* recv_displacements, MPI_Datatype recv_type, int root_rank,
-        const MPI_Request* req) const override;
+        const int* recv_displacements, const void* recv_type, int root_rank,
+        const void* req) const override;
 
     void on_mpi_collective_communication_completed(
-        bool is_blocking, const char* name, const MPI_Comm* comm,
+        bool is_blocking, const char* name, const void* comm,
         const uintptr& send_loc, int send_size, const int* send_sizes,
-        const int* send_displacements, MPI_Datatype send_type,
+        const int* send_displacements, const void* send_type,
         const uintptr& recv_loc, int recv_size, const int* recv_sizes,
-        const int* recv_displacements, MPI_Datatype recv_type, int root_rank,
-        const MPI_Request* req);
+        const int* recv_displacements, const void* recv_type, int root_rank,
+        const void* req) const override;
 
     void on_mpi_reduction_started(bool is_blocking, const char* name,
-                                  const MPI_Comm* comm,
-                                  const uintptr& send_buffer,
+                                  const void* comm, const uintptr& send_buffer,
                                   const uintptr& recv_buffer, int size,
-                                  MPI_Datatype type, MPI_Op operation,
-                                  int root_rank, const MPI_Request* req);
+                                  const void* type, const void* operation,
+                                  int root_rank,
+                                  const void* req) const override;
 
     void on_mpi_reduction_completed(bool is_blocking, const char* name,
-                                    const MPI_Comm* comm,
+                                    const void* comm,
                                     const uintptr& send_buffer,
                                     const uintptr& recv_buffer, int size,
-                                    MPI_Datatype type, MPI_Op operation,
-                                    int root_rank, const MPI_Request* req);
+                                    const void* type, const void* operation,
+                                    int root_rank,
+                                    const void* req) const override;
+
+
+#endif
 
 
     /**

--- a/include/ginkgo/core/log/record.hpp
+++ b/include/ginkgo/core/log/record.hpp
@@ -239,7 +239,7 @@ struct criterion_data {
 
 
 struct mpi_point_to_point_data {
-    bool is_blocking;
+    mpi_mode mode;
     std::string operation_name;
     MPI_Comm comm;
     uintptr loc;
@@ -253,7 +253,7 @@ struct mpi_point_to_point_data {
 
 
 struct mpi_collective_data {
-    bool is_blocking;
+    mpi_mode mode;
     std::string operation_name;
     MPI_Comm comm;
     uintptr send_loc;
@@ -464,17 +464,17 @@ public:
 
 
     void on_mpi_point_to_point_communication_started(
-        bool is_blocking, const char* name, const void* comm,
-        const uintptr& loc, int size, const void* type, int source_rank,
-        int destination_rank, int tag, const void* req) const override;
+        mpi_mode mode, const char* name, const void* comm, const uintptr& loc,
+        int size, const void* type, int source_rank, int destination_rank,
+        int tag, const void* req) const override;
 
     void on_mpi_point_to_point_communication_completed(
-        bool is_blocking, const char* name, const void* comm,
-        const uintptr& loc, int size, const void* type, int source_rank,
-        int destination_rank, int tag, const void* req) const override;
+        mpi_mode mode, const char* name, const void* comm, const uintptr& loc,
+        int size, const void* type, int source_rank, int destination_rank,
+        int tag, const void* req) const override;
 
     void on_mpi_collective_communication_started(
-        bool is_blocking, const char* name, const void* comm,
+        mpi_mode mode, const char* name, const void* comm,
         const uintptr& send_loc, int send_size, const int* send_sizes,
         const int* send_displacements, const void* send_type,
         const uintptr& recv_loc, int recv_size, const int* recv_sizes,
@@ -482,21 +482,21 @@ public:
         const void* req) const override;
 
     void on_mpi_collective_communication_completed(
-        bool is_blocking, const char* name, const void* comm,
+        mpi_mode mode, const char* name, const void* comm,
         const uintptr& send_loc, int send_size, const int* send_sizes,
         const int* send_displacements, const void* send_type,
         const uintptr& recv_loc, int recv_size, const int* recv_sizes,
         const int* recv_displacements, const void* recv_type, int root_rank,
         const void* req) const override;
 
-    void on_mpi_reduction_started(bool is_blocking, const char* name,
+    void on_mpi_reduction_started(mpi_mode mode, const char* name,
                                   const void* comm, const uintptr& send_buffer,
                                   const uintptr& recv_buffer, int size,
                                   const void* type, const void* operation,
                                   int root_rank,
                                   const void* req) const override;
 
-    void on_mpi_reduction_completed(bool is_blocking, const char* name,
+    void on_mpi_reduction_completed(mpi_mode mode, const char* name,
                                     const void* comm,
                                     const uintptr& send_buffer,
                                     const uintptr& recv_buffer, int size,


### PR DESCRIPTION
This PR adds Logger events for MPI calls.

The new implementation differs from the other Logger events in Ginkgo. Normally, we have a nearly one-to-one relation between events and the functions registering the events. But for MPI events, I don't think that is the right approach, because there are so many MPI calls we would log. Creating events for each call (e.g. 1 for `send`, 1 for `recv`, 1 for `all_to_all`, 1 for `all_to_all_v`, etc.) seems prohibitive. Besides for many logging purposes, the exact function might not be relevant. For example, logging the total amount of data sent needs to know only the size argument for each MPI call.

To prevent creating too many events, I tried to categorize MPI calls along multiple axes. Currently, I'm using the following axes:
1. point-to-point vs collective
2. blocking vs non-blocking (can be extended to also contain persistent)
3. within collective: all-to-all vs all-to-one vs one-to-all vs scan vs barrier (this is related to the distinction in the MPI Docs §6.2.2)
4. within collective: fixed message sizes vs variable message sizes

Using these four axes, it is possible to model all of our current `mpi::communicator` calls. Also, this leads to (IMO) concise logging calls. For example logging an blocking recv is done with:
```
log<...>(exec, blocking{}, "recv", comm, pt2pt{ /*no send buffer*/ {}, {recv_buffer, count, &type}, rank, tag, &status});
```
A variable, blocking all gather is done with:
```
log<...>(exec, blocking{}, "all_gather", comm, all_to_all<fixed, variable>{
    {send_buffer, send_count, &type}, 
    {recv_buffer, {recv_sizes, recv_offsets}, &type
}});
```
Logging non-blocking calls is more difficult. IMO, the `*completed` event can only be logged, after the communication is complete, so after waiting on the MPI request. So, I pass-in a lambda that captures the necessary MPI call information to the request, which then calls this function after the wait has completed. For example, a non-blocking recv looks like this:
```
request req([=, comm = *this](request* req) {
    comm.template log<...>(
        exec, non_blocking{req->get()}, "recv", comm.comm_.get(),
        pt2pt{{}, {recv_buffer, count. &type}, rank, tag});
});
```

Only in 1. the distinction leads to different events. The other axes are realized using `std::variant`. In particular, each case is realized by a struct that captures only the necessary information. 

MPI Type handling:
All MPI types (e.g. `MPI_Comm`, `MPI_Op`, ...) are passed in as `void*`. My reasoning for this is to prevent including the MPI header in `logger.hpp` and conditionally enable the events. Including the MPI header would make it necessary to also link all of our device libraries against MPI (or at least the header), because `logger.hpp` gets included through `executor.hpp`.

I've also enabled MPI events for the profile hook logger and the record logger. Updating the profile hook logger was pretty easy, but the record logger requires a bit more effort. Still, I think this shows how integration into existing loggers can be done.

TODO:
- [ ] exam assembly code if logging is too expensive
- [ ] wrap all communicator calls
- [ ] figure out how to handle one-sided calls