### PR TITLE
fix the additional residual computation when passing residual criterion

### DIFF
--- a/core/solver/ir.cpp
+++ b/core/solver/ir.cpp
@@ -240,6 +240,8 @@ void Ir<ValueType>::apply_dense_impl(const VectorType* dense_b,
             if (stop_criterion->update()
                     .num_iterations(iter)
                     .solution(dense_x)
+                    // we have the residual check later
+                    .ignore_residual_check(true)
                     .check(relative_stopping_id, false, &stop_status,
                            &one_changed)) {
                 break;

--- a/core/test/solver/ir.cpp
+++ b/core/test/solver/ir.cpp
@@ -40,7 +40,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
 #include <ginkgo/core/base/executor.hpp>
-#include <ginkgo/core/log/stream.hpp>
+#include <ginkgo/core/log/profiler_hook.hpp>
 #include <ginkgo/core/matrix/dense.hpp>
 #include <ginkgo/core/stop/combined.hpp>
 #include <ginkgo/core/stop/iteration.hpp>
@@ -51,22 +51,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
 namespace {
-
-
-int count_occurrence(const std::string& str, const std::string& substr)
-{
-    int occurrence = 0;
-    std::string::size_type pos = 0;
-    while (pos < str.length()) {
-        // no overlapped cases
-        pos = str.find(substr, pos);
-        if (pos != std::string::npos) {
-            pos += substr.length();
-            occurrence++;
-        }
-    }
-    return occurrence;
-}
 
 
 template <typename T>
@@ -475,6 +459,25 @@ TYPED_TEST(Ir, SmootherBuildWithFactory)
 }
 
 
+struct TestSummaryWriter : gko::log::ProfilerHook::SummaryWriter {
+    void write(const std::vector<gko::log::ProfilerHook::summary_entry>& e,
+               gko::int64 overhead_ns) override
+    {
+        int matched = 0;
+        for (const auto& data : e) {
+            if (data.name == "residual_norm::residual_norm") {
+                matched++;
+                // Contains make_residual_norm 3 times: The last 4-th iteration
+                // exits due to iteration limit.
+                EXPECT_EQ(data.count, 3);
+            }
+        }
+        // ensure matching once
+        EXPECT_EQ(matched, 1);
+    }
+};
+
+
 TYPED_TEST(Ir, RunResidualNormCheckCorrectTimes)
 {
     using value_type = typename TestFixture::value_type;
@@ -482,17 +485,14 @@ TYPED_TEST(Ir, RunResidualNormCheckCorrectTimes)
     using Mtx = typename TestFixture::Mtx;
     auto b = gko::initialize<Mtx>({2, -1.0, 1.0}, this->exec);
     auto x = gko::initialize<Mtx>({0.0, 0.0, 0.0}, this->exec);
-    std::stringstream out;
-    auto logger = gko::share(gko::log::Stream<TypeParam>::create(
-        gko::log::Logger::operation_launched_mask, out));
+    auto logger = gko::share(gko::log::ProfilerHook::create_summary(
+        std::make_unique<TestSummaryWriter>()));
     this->exec->add_logger(logger);
 
     // solver reaches the iteration limit
     this->solver->apply(b, x);
 
-    // Contains make_residual_norm 3 times: check in initialization and two
-    // iterations. The last iteration exits due to iteration limit.
-    ASSERT_EQ(count_occurrence(out.str(), "make_residual_norm"), 3);
+    // The assertions happen in the destructor of `logger`
 }
 
 

--- a/core/test/stop/criterion.cpp
+++ b/core/test/stop/criterion.cpp
@@ -110,6 +110,17 @@ protected:
 };
 
 
+TEST_F(Criterion, DefaultUpdateStatus)
+{
+    EXPECT_EQ(criterion->update().num_iterations_, 0);
+    EXPECT_EQ(criterion->update().ignore_residual_check_, false);
+    EXPECT_EQ(criterion->update().residual_, nullptr);
+    EXPECT_EQ(criterion->update().residual_norm_, nullptr);
+    EXPECT_EQ(criterion->update().implicit_sq_residual_norm_, nullptr);
+    EXPECT_EQ(criterion->update().solution_, nullptr);
+}
+
+
 TEST_F(Criterion, CanLogCheck)
 {
     auto before_logger = *logger;

--- a/include/ginkgo/core/stop/criterion.hpp
+++ b/include/ginkgo/core/stop/criterion.hpp
@@ -125,6 +125,7 @@ public:
     mutable _type* _name##_ {}
 
         GKO_UPDATER_REGISTER_PARAMETER(size_type, num_iterations);
+        // ignore_residual_check default is false
         GKO_UPDATER_REGISTER_PARAMETER(bool, ignore_residual_check);
         GKO_UPDATER_REGISTER_PTR_PARAMETER(const LinOp, residual);
         GKO_UPDATER_REGISTER_PTR_PARAMETER(const LinOp, residual_norm);

--- a/include/ginkgo/core/stop/criterion.hpp
+++ b/include/ginkgo/core/stop/criterion.hpp
@@ -68,7 +68,9 @@ public:
      * Criterion's check function. The pattern used is a Builder, except Updater
      * builds a function's arguments before calling the function itself, and
      * does not build an object. This allows calling a Criterion's check in the
-     * form of: stop_criterion->update() .num_iterations(num_iterations)
+     * form of: stop_criterion->update()
+     *   .num_iterations(num_iterations)
+     *   .ignore_residual_check(ignore_residual_check)
      *   .residual_norm(residual_norm)
      *   .implicit_sq_residual_norm(implicit_sq_residual_norm)
      *   .residual(residual)
@@ -123,6 +125,7 @@ public:
     mutable _type* _name##_ {}
 
         GKO_UPDATER_REGISTER_PARAMETER(size_type, num_iterations);
+        GKO_UPDATER_REGISTER_PARAMETER(bool, ignore_residual_check);
         GKO_UPDATER_REGISTER_PTR_PARAMETER(const LinOp, residual);
         GKO_UPDATER_REGISTER_PTR_PARAMETER(const LinOp, residual_norm);
         GKO_UPDATER_REGISTER_PTR_PARAMETER(const LinOp,

--- a/reference/test/stop/residual_norm_kernels.cpp
+++ b/reference/test/stop/residual_norm_kernels.cpp
@@ -135,6 +135,26 @@ TYPED_TEST(ResidualNorm, CanCreateCriterionWithNeededInput)
 }
 
 
+TYPED_TEST(ResidualNorm, CanIgorneResidualNorm)
+{
+    using Mtx = typename TestFixture::Mtx;
+    std::shared_ptr<gko::LinOp> scalar =
+        gko::initialize<Mtx>({1.0}, this->exec_);
+    auto criterion =
+        this->rhs_factory_->generate(nullptr, scalar, nullptr, nullptr);
+    constexpr gko::uint8 RelativeStoppingId{1};
+    bool one_changed{};
+    gko::array<gko::stopping_status> stop_status(this->exec_, 1);
+    stop_status.get_data()[0].reset();
+
+    ASSERT_FALSE(criterion->update().ignore_residual_check(true).check(
+        RelativeStoppingId, true, &stop_status, &one_changed));
+    ASSERT_THROW(criterion->update().check(RelativeStoppingId, true,
+                                           &stop_status, &one_changed),
+                 gko::NotSupported);
+}
+
+
 TYPED_TEST(ResidualNorm, WaitsTillResidualGoal)
 {
     using Mtx = typename TestFixture::Mtx;


### PR DESCRIPTION
In #981, splitting the criterion for iteration and the residual check when users only pass the iteration criterion.
However, it will compute the residual norm from the solution in the iteration update when users pass the residual check.

It fixes the issue by only computing the residual from the solution in the finalized ste