### PR TITLE
Avoid transpose in symbolic Cholesky benchmark

### DIFF
--- a/benchmark/sparse_blas/sparse_blas.cpp
+++ b/benchmark/sparse_blas/sparse_blas.cpp
@@ -57,10 +57,11 @@ const auto benchmark_name = "sparse_blas";
 
 using mat_data = gko::matrix_data<etype, itype>;
 
-DEFINE_string(operations, "spgemm,spgeam,transpose",
-              "Comma-separated list of operations to be benchmarked. Can be "
-              "spgemm, spgeam, transpose, sort, is_sorted, generate_lookup, "
-              "lookup, symbolic_lu, symbolic_cholesky");
+DEFINE_string(
+    operations, "spgemm,spgeam,transpose",
+    "Comma-separated list of operations to be benchmarked. Can be "
+    "spgemm, spgeam, transpose, sort, is_sorted, generate_lookup, "
+    "lookup, symbolic_lu, symbolic_cholesky, symbolic_cholesky_symmetric");
 
 DEFINE_bool(validate, false,
             "Check for correct sparsity pattern and compute the L2 norm "

--- a/core/factorization/cholesky.cpp
+++ b/core/factorization/cholesky.cpp
@@ -94,7 +94,7 @@ std::unique_ptr<LinOp> Cholesky<ValueType, IndexType>::generate_impl(
     std::unique_ptr<matrix_type> factors;
     std::unique_ptr<gko::factorization::elimination_forest<IndexType>> forest;
     if (!parameters_.symbolic_factorization) {
-        gko::factorization::symbolic_cholesky(mtx.get(), factors, forest);
+        gko::factorization::symbolic_cholesky(mtx.get(), true, factors, forest);
     } else {
         const auto& symbolic = parameters_.symbolic_factorization;
         const auto factor_nnz = symbolic->get_num_nonzeros();

--- a/core/factorization/lu.cpp
+++ b/core/factorization/lu.cpp
@@ -98,7 +98,7 @@ std::unique_ptr<LinOp> Lu<ValueType, IndexType>::generate_impl(
         if (parameters_.symmetric_sparsity) {
             std::unique_ptr<gko::factorization::elimination_forest<IndexType>>
                 forest;
-            exec->run(make_symbolic_cholesky(mtx.get(), factors, forest));
+            exec->run(make_symbolic_cholesky(mtx.get(), true, factors, forest));
         } else {
             exec->run(make_symbolic_lu(mtx.get(), factors));
         }

--- a/core/factorization/symbolic.cpp
+++ b/core/factorization/symbolic.cpp
@@ -63,7 +63,6 @@ GKO_REGISTER_HOST_OPERATION(compute_elim_forest, compute_elim_forest);
 }  // namespace
 
 
-/** Computes the symbolic Cholesky factorization of the given matrix. */
 template <typename ValueType, typename IndexType>
 void symbolic_cholesky(
     const matrix::Csr<ValueType, IndexType>* mtx, bool symmetrize,
@@ -105,13 +104,6 @@ void symbolic_cholesky(
 GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(GKO_DECLARE_SYMBOLIC_CHOLESKY);
 
 
-/**
- * Computes the symbolic Cholesky factorization of the given matrix.
- * The implementation is based on fill1 algorithm introduced in Rose and Tarjan,
- * "Algorithmic Aspects of Vertex Elimination on Directed Graphs," SIAM J. Appl.
- * Math. 1978. and its formulation in Gaihre et. al,
- * "GSoFa: Scalable Sparse Symbolic LU Factorization on GPUs," arXiv 2021
- */
 template <typename ValueType, typename IndexType>
 void symbolic_lu(const matrix::Csr<ValueType, IndexType>* mtx,
                  std::unique_ptr<matrix::Csr<ValueType, IndexType>>& factors)

--- a/core/factorization/symbolic.hpp
+++ b/core/factorization/symbolic.hpp
@@ -44,14 +44,22 @@ namespace factorization {
  * Computes the symbolic Cholesky factorization of the given matrix.
  *
  * @param mtx  the input matrix
+ * @param symmetrize  should we output the pattern of L + L^T or just L?
  * @param factors  the output factors stored in a combined pattern
+ * @param forest  the elimination forest of the input matrix
  */
 template <typename ValueType, typename IndexType>
-void symbolic_cholesky(const matrix::Csr<ValueType, IndexType>*,
-                       std::unique_ptr<matrix::Csr<ValueType, IndexType>>&,
-                       std::unique_ptr<elimination_forest<IndexType>>&);
+void symbolic_cholesky(
+    const matrix::Csr<ValueType, IndexType>* mtx, bool symmetrize,
+    std::unique_ptr<matrix::Csr<ValueType, IndexType>>& factors,
+    std::unique_ptr<elimination_forest<IndexType>>& forest);
 
-/** Computes the symbolic LU factorization of the given matrix. */
+/**
+ * Computes the symbolic LU factorization of the given matrix.
+ *
+ * @param mtx  the input matrix
+ * @param factors  the output factors stored in a combined pattern
+ */
 template <typename ValueType, typename IndexType>
 void symbolic_lu(const matrix::Csr<ValueType, IndexType>* mtx,
                  std::unique_ptr<matrix::Csr<ValueType, IndexType>>& factors);

--- a/core/factorization/symbolic.hpp
+++ b/core/factorization/symbolic.hpp
@@ -44,8 +44,8 @@ namespace factorization {
  * Computes the symbolic Cholesky factorization of the given matrix.
  *
  * @param mtx  the input matrix
- * @param symmetrize  should we output the pattern of L + L^T or just L?
- * @param factors  the output factors stored in a combined pattern
+ * @param symmetrize  output the pattern of L + L^T (true) or just L (false)?
+ * @param factors  the output factor(s)
  * @param forest  the elimination forest of the input matrix
  */
 template <typename ValueType, typename IndexType>
@@ -56,6 +56,11 @@ void symbolic_cholesky(
 
 /**
  * Computes the symbolic LU factorization of the given matrix.
+ *
+ * The implementation is based on fill1 algorithm introduced in Rose and Tarjan,
+ * "Algorithmic Aspects of Vertex Elimination on Directed Graphs," SIAM J. Appl.
+ * Math. 1978. and its formulation in Gaihre et. al,
+ * "GSoFa: Scalable Sparse Symbolic LU Factorization on GPUs," arXiv 2021
  *
  * @param mtx  the input matrix
  * @param factors  the output factors stored in a combined pattern

--- a/reference/components/prefix_sum_kernels.cpp
+++ b/reference/components/prefix_sum_kernels.cpp
@@ -46,7 +46,7 @@ void prefix_sum_nonnegative(std::shared_ptr<const ReferenceExecutor> exec,
     constexpr auto max = std::numeric_limits<IndexType>::max();
     IndexType partial_sum{};
     for (size_type i = 0; i < num_entries; ++i) {
-        auto nnz = counts[i];
+        auto nnz = i < num_entries - 1 ? counts[i] : IndexType{};
         counts[i] = partial_sum;
         if (max - partial_sum < nnz) {
             throw OverflowError(

--- a/reference/test/components/prefix_sum_kernels.cpp
+++ b/reference/test/components/prefix_sum_kernels.cpp
@@ -96,6 +96,20 @@ TYPED_TEST(PrefixSum, WorksCloseToOverflow)
 }
 
 
+TYPED_TEST(PrefixSum, DoesntOverflowFromLastElement)
+{
+    constexpr auto max = std::numeric_limits<TypeParam>::max() -
+                         std::is_unsigned<TypeParam>::value;
+    std::vector<TypeParam> vals{2, max - 1};
+    std::vector<TypeParam> expected{0, 2};
+
+    gko::kernels::reference::components::prefix_sum_nonnegative(
+        this->exec, vals.data(), vals.size());
+
+    ASSERT_EQ(vals, expected);
+}
+
+
 TYPED_TEST(PrefixSum, ThrowsOnOverflow)
 {
     constexpr auto max = std::numeric_limits<TypeParam>::max();

--- a/reference/test/factorization/cholesky_kernels.cpp
+++ b/reference/test/factorization/cholesky_kernels.cpp
@@ -442,8 +442,8 @@ TYPED_TEST(Cholesky, SymbolicFactorize)
     this->forall_matrices([this] {
         std::unique_ptr<matrix_type> combined_factor;
         std::unique_ptr<elimination_forest> forest;
-        gko::factorization::symbolic_cholesky(this->mtx.get(), combined_factor,
-                                              forest);
+        gko::factorization::symbolic_cholesky(this->mtx.get(), true,
+                                              combined_factor, forest);
 
         GKO_ASSERT_MTX_EQ_SPARSITY(combined_factor, this->combined_ref);
     });
@@ -478,8 +478,8 @@ TYPED_TEST(Cholesky, KernelForestFromFactor)
     this->forall_matrices([this] {
         std::unique_ptr<matrix_type> combined_factor;
         std::unique_ptr<elimination_forest> forest_ref;
-        gko::factorization::symbolic_cholesky(this->mtx.get(), combined_factor,
-                                              forest_ref);
+        gko::factorization::symbolic_cholesky(this->mtx.get(), true,
+                                              combined_factor, forest_ref);
         elimination_forest forest{this->ref,
                                   static_cast<index_type>(this->num_rows)};
 

--- a/reference/test/factorization/cholesky_kernels.cpp
+++ b/reference/test/factorization/cholesky_kernels.cpp
@@ -450,6 +450,21 @@ TYPED_TEST(Cholesky, SymbolicFactorize)
 }
 
 
+TYPED_TEST(Cholesky, SymbolicFactorizeOnlyLower)
+{
+    using matrix_type = typename TestFixture::matrix_type;
+    using elimination_forest = typename TestFixture::elimination_forest;
+    this->forall_matrices([this] {
+        std::unique_ptr<matrix_type> l_factor;
+        std::unique_ptr<elimination_forest> forest;
+        gko::factorization::symbolic_cholesky(this->mtx.get(), false, l_factor,
+                                              forest);
+
+        GKO_ASSERT_MTX_EQ_SPARSITY(l_factor, this->l_factor_ref);
+    });
+}
+
+
 TYPED_TEST(Cholesky, KernelSymbolicCountAni1Amd)
 {
     using index_type = typename TestFixture::index_type;

--- a/reference/test/factorization/lu_kernels.cpp
+++ b/reference/test/factorization/lu_kernels.cpp
@@ -142,7 +142,8 @@ TYPED_TEST(Lu, SymbolicCholeskyWorks)
             std::unique_ptr<gko::matrix::Csr<value_type, index_type>> lu;
             std::unique_ptr<gko::factorization::elimination_forest<index_type>>
                 forest;
-            gko::factorization::symbolic_cholesky(this->mtx.get(), lu, forest);
+            gko::factorization::symbolic_cholesky(this->mtx.get(), true, lu,
+                                                  forest);
 
             GKO_ASSERT_MTX_EQ_SPARSITY(lu, this->mtx_lu);
         },

--- a/test/components/prefix_sum_kernels.cpp
+++ b/test/components/prefix_sum_kernels.cpp
@@ -109,6 +109,18 @@ TYPED_TEST(PrefixSum, WorksCloseToOverflow)
 }
 
 
+TYPED_TEST(PrefixSum, DoesntOverflowFromLastElement)
+{
+    const auto max = std::numeric_limits<TypeParam>::max();
+    gko::array<TypeParam> data{this->exec, I<TypeParam>({2, max - 1})};
+
+    gko::kernels::EXEC_NAMESPACE::components::prefix_sum_nonnegative(
+        this->exec, data.get_data(), data.get_num_elems());
+
+    GKO_ASSERT_ARRAY_EQ(data, I<TypeParam>({0, 2}));
+}
+
+
 #ifndef GKO_COMPILING_DPCPP
 // TODO implement overflow check for DPC++
 

--- a/test/factorization/cholesky_kernels.cpp
+++ b/test/factorization/cholesky_kernels.cpp
@@ -242,8 +242,9 @@ TYPED_TEST(CholeskySymbolic, SymbolicFactorize)
         std::unique_ptr<matrix_type> dfactors;
         std::unique_ptr<elimination_forest> forest;
         std::unique_ptr<elimination_forest> dforest;
-        gko::factorization::symbolic_cholesky(mtx.get(), factors, forest);
-        gko::factorization::symbolic_cholesky(mtx.get(), dfactors, dforest);
+        gko::factorization::symbolic_cholesky(mtx.get(), true, factors, forest);
+        gko::factorization::symbolic_cholesky(mtx.get(), true, dfactors,
+                                              dforest);
 
         GKO_ASSERT_MTX_EQ_SPARSITY(dfactors, factors);
         this->assert_equal_forests(*forest, *dforest, true);
@@ -261,7 +262,7 @@ TYPED_TEST(CholeskySymbolic, KernelForestFromFactorWorks)
         const auto& mtx = pair.second;
         std::unique_ptr<matrix_type> factors;
         std::unique_ptr<elimination_forest> forest;
-        gko::factorization::symbolic_cholesky(mtx.get(), factors, forest);
+        gko::factorization::symbolic_cholesky(mtx.get(), true, factors, forest);
         const auto dfactors = gko::clone(this->exec, factors);
         elimination_forest dforest{this->exec,
                                    static_cast<index_type>(mtx->get_size()[0])};


### PR DESCRIPTION
The transposition is pretty slow on OpenMP, so to have a fair performance baseline, I want to skip all the operations needed to symmetrize the matrix.