### PR TITLE
Rename log propagate mode and fix warnings

### DIFF
--- a/core/test/log/logger.cpp
+++ b/core/test/log/logger.cpp
@@ -212,7 +212,7 @@ TEST(DummyLogged, PropagatesEventsWhenPropagating)
 TEST(DummyLogged, DoesNotPropagateEventsWhenDisabled)
 {
     auto exec = gko::ReferenceExecutor::create();
-    exec->set_log_propagation_mode(gko::log_propagate_mode::never);
+    exec->set_log_propagation_mode(gko::log_propagation_mode::never);
     auto l = std::shared_ptr<DummyLogger>(
         new DummyLogger(true, gko::log::Logger::iteration_complete_mask));
     DummyLoggedClass c{exec};

--- a/core/test/log/papi.cpp
+++ b/core/test/log/papi.cpp
@@ -77,7 +77,7 @@ protected:
     const std::string init(const gko::log::Logger::mask_type& event,
                            const std::string& event_name, U* ptr)
     {
-        logger = gko::log::Papi<T>::create(exec, event);
+        logger = gko::log::Papi<T>::create(event);
         std::ostringstream os;
         os << "sde:::" << logger->get_handle_name() << "::" << event_name
            << "::" << reinterpret_cast<gko::uintptr>(ptr);

--- a/core/test/mpi/distributed/matrix.cpp
+++ b/core/test/mpi/distributed/matrix.cpp
@@ -202,7 +202,8 @@ protected:
     gko::experimental::mpi::communicator comm;
 };
 
-TYPED_TEST_SUITE(MatrixBuilder, gko::test::ValueLocalGlobalIndexTypes);
+TYPED_TEST_SUITE(MatrixBuilder, gko::test::ValueLocalGlobalIndexTypes,
+                 TupleTypenameNameGenerator);
 
 
 TYPED_TEST(MatrixBuilder, BuildWithLocal)

--- a/core/test/mpi/distributed/preconditioner/schwarz.cpp
+++ b/core/test/mpi/distributed/preconditioner/schwarz.cpp
@@ -79,7 +79,8 @@ protected:
         std::copy(std::begin(vals), std::end(vals), arr);
     }
 
-    void assert_same_precond(const Schwarz* a, const Schwarz* b)
+    void assert_same_precond(gko::ptr_param<const Schwarz> a,
+                             gko::ptr_param<const Schwarz> b)
     {
         ASSERT_EQ(a->get_size(), b->get_size());
         ASSERT_EQ(a->get_parameters().local_solver_factory,
@@ -92,7 +93,8 @@ protected:
     std::shared_ptr<Mtx> mtx;
 };
 
-TYPED_TEST_SUITE(SchwarzFactory, gko::test::ValueLocalGlobalIndexTypes);
+TYPED_TEST_SUITE(SchwarzFactory, gko::test::ValueLocalGlobalIndexTypes,
+                 TupleTypenameNameGenerator);
 
 
 TYPED_TEST(SchwarzFactory, KnowsItsExecutor)
@@ -112,7 +114,7 @@ TYPED_TEST(SchwarzFactory, CanBeCloned)
 {
     auto schwarz_clone = clone(this->schwarz);
 
-    this->assert_same_precond(lend(schwarz_clone), lend(this->schwarz));
+    this->assert_same_precond(schwarz_clone, this->schwarz);
 }
 
 
@@ -127,9 +129,9 @@ TYPED_TEST(SchwarzFactory, CanBeCopied)
                     .on(this->exec)
                     ->generate(Mtx::create(this->exec, MPI_COMM_WORLD));
 
-    copy->copy_from(lend(this->schwarz));
+    copy->copy_from(this->schwarz);
 
-    this->assert_same_precond(lend(copy), lend(this->schwarz));
+    this->assert_same_precond(copy, this->schwarz);
 }
 
 
@@ -145,9 +147,9 @@ TYPED_TEST(SchwarzFactory, CanBeMoved)
                     .on(this->exec)
                     ->generate(Mtx::create(this->exec, MPI_COMM_WORLD));
 
-    copy->move_from(gko::lend(this->schwarz));
+    copy->move_from(this->schwarz);
 
-    this->assert_same_precond(lend(copy), lend(tmp));
+    this->assert_same_precond(copy, tmp);
 }
 
 

--- a/examples/papi-logging/papi-logging.cpp
+++ b/examples/papi-logging/papi-logging.cpp
@@ -196,8 +196,8 @@ int main(int argc, char* argv[])
 
     // Create a PAPI logger and add it to relevant LinOps
     auto logger = gko::log::Papi<ValueType>::create(
-        exec, gko::log::Logger::linop_apply_completed_mask |
-                  gko::log::Logger::linop_advanced_apply_completed_mask);
+        gko::log::Logger::linop_apply_completed_mask |
+        gko::log::Logger::linop_advanced_apply_completed_mask);
     solver->add_logger(logger);
     A->add_logger(logger);
 

--- a/include/ginkgo/core/base/executor.hpp
+++ b/include/ginkgo/core/base/executor.hpp
@@ -58,7 +58,7 @@ namespace gko {
 
 
 /** How Logger events are propagated to their Executor. */
-enum class log_propagate_mode {
+enum class log_propagation_mode {
     /**
      * Events only get reported at loggers attached to the triggering object.
      * (Except for allocation/free, copy and Operations, since they happen at
@@ -903,9 +903,9 @@ public:
      * executor.
      * @see Logger::needs_propagation()
      */
-    void set_log_propagation_mode(log_propagate_mode mode)
+    void set_log_propagation_mode(log_propagation_mode mode)
     {
-        log_propagate_mode_ = mode;
+        log_propagation_mode_ = mode;
     }
 
     /**
@@ -913,12 +913,12 @@ public:
      * should be logged at propagating loggers attached to this executor, and
      * there is at least one such propagating logger.
      * @see Logger::needs_propagation()
-     * @see Executor::set_log_propagation_mode(log_propagate_mode)
+     * @see Executor::set_log_propagation_mode(log_propagation_mode)
      */
     bool should_propagate_log() const
     {
         return this->propagating_logger_refcount_.load() > 0 &&
-               log_propagate_mode_ == log_propagate_mode::automatic;
+               log_propagation_mode_ == log_propagation_mode::automatic;
     }
 
     /**
@@ -1153,7 +1153,7 @@ protected:
 
     exec_info exec_info_;
 
-    log_propagate_mode log_propagate_mode_{log_propagate_mode::automatic};
+    log_propagation_mode log_propagation_mode_{log_propagation_mode::automatic};
 
     std::atomic<int> propagating_logger_refcount_{};
 

--- a/reference/test/distributed/matrix_kernels.cpp
+++ b/reference/test/distributed/matrix_kernels.cpp
@@ -195,7 +195,8 @@ protected:
     gko::array<global_index_type> non_local_to_global;
 };
 
-TYPED_TEST_SUITE(Matrix, gko::test::ValueLocalGlobalIndexTypes);
+TYPED_TEST_SUITE(Matrix, gko::test::ValueLocalGlobalIndexTypes,
+                 TupleTypenameNameGenerator);
 
 
 TYPED_TEST(Matrix, BuildsLocalNonLocalEmpty)

--- a/reference/test/distributed/vector_kernels.cpp
+++ b/reference/test/distributed/vector_kernels.cpp
@@ -97,7 +97,8 @@ protected:
     std::shared_ptr<const gko::ReferenceExecutor> ref;
 };
 
-TYPED_TEST_SUITE(Vector, gko::test::ValueLocalGlobalIndexTypes);
+TYPED_TEST_SUITE(Vector, gko::test::ValueLocalGlobalIndexTypes,
+                 TupleTypenameNameGenerator);
 
 
 TYPED_TEST(Vector, BuildsLocalEmpty)

--- a/reference/test/log/papi.cpp
+++ b/reference/test/log/papi.cpp
@@ -73,7 +73,7 @@ protected:
     const std::string init(const gko::log::Logger::mask_type& event,
                            const std::string& event_name, U* ptr)
     {
-        logger = gko::log::Papi<T>::create(exec, event);
+        logger = gko::log::Papi<T>::create(event);
         std::ostringstream os;
         os << "sde:::" << logger->get_handle_name() << "::" << event_name << "_"
            << reinterpret_cast<gko::uintptr>(ptr);

--- a/test/distributed/matrix_kernels.cpp
+++ b/test/distributed/matrix_kernels.cpp
@@ -137,7 +137,8 @@ protected:
     std::default_random_engine engine;
 };
 
-TYPED_TEST_SUITE(Matrix, gko::test::ValueLocalGlobalIndexTypes);
+TYPED_TEST_SUITE(Matrix, gko::test::ValueLocalGlobalIndexTypes,
+                 TupleTypenameNameGenerator);
 
 
 TYPED_TEST(Matrix, BuildsDiagOffdiagEmptyIsSameAsRef)

--- a/test/distributed/vector_kernels.cpp
+++ b/test/distributed/vector_kernels.cpp
@@ -99,7 +99,8 @@ protected:
     std::default_random_engine engine;
 };
 
-TYPED_TEST_SUITE(Vector, gko::test::ValueLocalGlobalIndexTypes);
+TYPED_TEST_SUITE(Vector, gko::test::ValueLocalGlobalIndexTypes,
+                 TupleTypenameNameGenerator);
 
 
 template <typename ValueType, typename IndexType, typename NonzeroDistribution,

--- a/test/mpi/distributed/vector.cpp
+++ b/test/mpi/distributed/vector.cpp
@@ -127,7 +127,8 @@ public:
     std::default_random_engine engine;
 };
 
-TYPED_TEST_SUITE(VectorCreation, gko::test::ValueLocalGlobalIndexTypes);
+TYPED_TEST_SUITE(VectorCreation, gko::test::ValueLocalGlobalIndexTypes,
+                 TupleTypenameNameGenerator);
 
 
 #ifndef GKO_COMPILING_DPCPP
@@ -392,7 +393,8 @@ public:
     std::unique_ptr<vec_type> dst;
 };
 
-TYPED_TEST_SUITE(VectorCreationHelpers, gko::test::ValueTypes);
+TYPED_TEST_SUITE(VectorCreationHelpers, gko::test::ValueTypes,
+                 TypenameNameGenerator);
 
 
 TYPED_TEST(VectorCreationHelpers, CanCreateWithConfigOf)
@@ -543,7 +545,8 @@ public:
     std::default_random_engine engine;
 };
 
-TYPED_TEST_SUITE(VectorReductions, gko::test::ValueTypes);
+TYPED_TEST_SUITE(VectorReductions, gko::test::ValueTypes,
+                 TypenameNameGenerator);
 
 
 TYPED_TEST(VectorReductions, ComputesDotProductIsSameAsDense)
@@ -768,7 +771,7 @@ public:
     std::default_random_engine engine;
 };
 
-TYPED_TEST_SUITE(VectorLocalOps, gko::test::ValueTypes);
+TYPED_TEST_SUITE(VectorLocalOps, gko::test::ValueTypes, TypenameNameGenerator);
 
 
 TYPED_TEST(VectorLocalOps, ApplyNotSupported)

--- a/test/test_install/test_install.cpp
+++ b/test/test_install/test_install.cpp
@@ -466,7 +466,7 @@ int main()
     // core/solver/gcr.hpp
     {
         using Solver = gko::solver::Gcr<>;
-        check_solver<Solver>(exec, A_raw, gko::lend(b), gko::lend(x));
+        check_solver<Solver>(exec, A_raw, b, x);
     }
 
     // core/solver/gmres.hpp


### PR DESCRIPTION
The function is called `get_log_propagation_mode`, but the enum is called `log_propagate_mode`, we can make that more consistent. Also we have a few warnings that can be addressed easily, so I included them in this PR.