### PR TITLE
Draft: Interface for 'local-only' matrices

### DIFF
--- a/include/ginkgo/core/distributed/lin_op.hpp
+++ b/include/ginkgo/core/distributed/lin_op.hpp
@@ -109,6 +109,30 @@ protected:
 };
 
 
+class ConsistentOp : public EnableLinOp<ConsistentOp> {
+protected:
+    void apply_impl(const LinOp* b, LinOp* x) const override
+    {
+        // need to run both statements through precision dispatch
+        local_op->apply_impl(as<LocalVector>(b)->get_dense(),
+                             as<LocalVector>(x)->get_dense());
+        as<LocalVector>(x)->make_consistent();
+    }
+
+    void apply_impl(const LinOp* alpha, const LinOp* b, const LinOp* beta,
+                    LinOp* x) const override
+    {
+        // need to run both statements through precision dispatch
+        local_op->apply(alpha, as<LocalVector>(b)->get_dense(), beta,
+                        as<LocalVector>(x)->get_dense());
+        as<LocalVector>(x)->make_consistent();
+    }
+
+private:
+    std::unique_ptr<LinOp> local_op;
+};
+
+
 }  // namespace experimental
 }  // namespace gko
 

--- a/include/ginkgo/core/distributed/local_vector.hpp
+++ b/include/ginkgo/core/distributed/local_vector.hpp
@@ -27,7 +27,7 @@ class LocalVector : public EnableDistributedLinOp<LocalVector<ValueType>>,
      *
      * After this call all DOFs have the values of the corresponding global
      * DOFs. Considering a distributed operator that can be written as A = sum_i
-     * R_i^T D_i A_i R_i, then the corresponding global vectors are u = sum_i
+     * R_i^T A_i R_i, then the corresponding global vectors are u = sum_i
      * R_i^T D_i u_i. The local vector can then be recovered by u_j = R_j u.
      * This operation combines these two steps into one as u_j = R_j sum_i R_i^T
      * D_i u_i, which eliminates the need for a global vector.

--- a/include/ginkgo/core/distributed/local_vector.hpp
+++ b/include/ginkgo/core/distributed/local_vector.hpp
@@ -1,0 +1,66 @@
+#ifndef GINKGO_LOCAL_VECTOR_HPP
+#define GINKGO_LOCAL_VECTOR_HPP
+
+#include <ginkgo/core/distributed/base.hpp>
+#include <ginkgo/core/distributed/lin_op.hpp>
+#include <ginkgo/core/distributed/sharing_info.hpp>
+#include <ginkgo/core/matrix/dense.hpp>
+
+
+namespace gko {
+namespace experimental {
+namespace distributed {
+
+/**
+ * Distributed vector that relies only on local information.
+ *
+ * Name subject to change
+ */
+template <typename ValueType>
+class LocalVector : public EnableDistributedLinOp<LocalVector<ValueType>>,
+                    public distributed::DistributedBase {
+    LocalVector(std::shared_ptr<const Executor> exec, mpi::communicator comm,
+                std::shared_ptr<sharing_info<ValueType, int32>> comm_info);
+
+    /**
+     * Updates shared DOFs with the values from their shared ranks.
+     *
+     * After this call all DOFs have the values of the corresponding global
+     * DOFs. Considering a distributed operator that can be written as A = sum_i
+     * R_i^T D_i A_i R_i, then the corresponding global vectors are u = sum_i
+     * R_i^T D_i u_i. The local vector can then be recovered by u_j = R_j u.
+     * This operation combines these two steps into one as u_j = R_j sum_i R_i^T
+     * D_i u_i, which eliminates the need for a global vector.
+     * TODO: has to be blocking, but could be made non-blocking by partitioning
+     * the DOFs by owned/non-owned
+     */
+    void make_consistent();
+
+    /**
+     * point-wise operation the same as dense
+     */
+
+    /**
+     * reductions use weights defined in sharing_info to
+     * - remove (zero-out) non-owned DOFs
+     * - scale by sqrt(1/#Owned)
+     */
+
+    /**
+     * Return views to the underlying dense vector
+     */
+    std::unique_ptr<const matrix::Dense<ValueType>> get_dense() const;
+    std::unique_ptr<matrix::Dense<ValueType>> get_dense();
+
+private:
+    std::unique_ptr<matrix::Dense<ValueType>> data;
+    std::shared_ptr<const sharing_info<ValueType, int32>> comm_info;
+};
+
+
+}  // namespace distributed
+}  // namespace experimental
+}  // namespace gko
+
+
+#endif  // GINKGO_LOCAL_VECTOR_HPP

--- a/include/ginkgo/core/distributed/sharing_info.hpp
+++ b/include/ginkgo/core/distributed/sharing_info.hpp
@@ -22,11 +22,12 @@ enum class sharing_mode { set, add };
  *
  * Alternatively, this could be a SOA.
  */
+template <typename LocalIndexType>
 struct shared_idx {
     // index within this rank
-    int local_idx;
+    LocalIndexType local_idx;
     // the index within the local indices of the remote_rank
-    int remote_idx;
+    LocalIndexType remote_idx;
     // rank that shares the local DOF
     int remote_rank;
 };
@@ -47,7 +48,8 @@ struct sharing_info {
     /**
      * Extracts communication pattern from a list of shared DOFs.
      */
-    sharing_info(mpi::communicator comm, const array<shared_idx>& shared_idxs,
+    sharing_info(mpi::communicator comm,
+                 const array<shared_idx<LocalIndexType>>& shared_idxs,
                  sharing_mode mode);
 
     /**

--- a/include/ginkgo/core/distributed/sharing_info.hpp
+++ b/include/ginkgo/core/distributed/sharing_info.hpp
@@ -1,0 +1,125 @@
+#ifndef GINKGO_SHARING_INFO_HPP
+#define GINKGO_SHARING_INFO_HPP
+
+
+namespace gko {
+namespace experimental {
+namespace distributed {
+
+
+/**
+ * Describes how received values should be handled.
+ *
+ * Ideally, this could also be a user defined binary operation.
+ * But that requires being able to pass this through to kernels, which we don't
+ * support atm.
+ */
+enum class sharing_mode { set, add };
+
+
+/**
+ * Struct to describe a shared DOF.
+ *
+ * Alternatively, this could be a SOA.
+ */
+struct shared_idx {
+    // index within this rank
+    int local_idx;
+    // the index within the local indices of the remote_rank
+    int remote_idx;
+    // rank that shares the local DOF
+    int remote_rank;
+};
+
+
+/**
+ * Holds the necessary information for a decomposition of DOFs without relying
+ * on global data. It consists of
+ * - send/recv sizes, offsets, indices
+ * - weights for shared DOFs
+ * - transformation to combine received DOFs with existing DOFs
+ *
+ * It can be constructed from purely local information, i.e. which local DOF
+ * corresponds to which DOF on other processes (in their local numbering).
+ */
+template <typename ValueType, typename LocalIndexType>
+struct sharing_info {
+    /**
+     * Extracts communication pattern from a list of shared DOFs.
+     */
+    sharing_info(mpi::communicator comm, const array<shared_idx>& shared_idxs,
+                 sharing_mode mode);
+
+    /**
+     * Does the all-to-all communication on the given input and output vectors.
+     * This handles the different supported sharing modes, and updates the
+     * buffers accordingly. Could also be made into a two parameter function, by
+     * using send=recv
+     */
+    template <typename SendType, typename RecvType>
+    void communicate(mpi::communicator comm,
+                     const matrix::Dense<SendType>* send,
+                     matrix::Dense<RecvType>* recv) const;
+
+    /**
+     * Returns the weight for a receiving DOF. If idx is not received then
+     * it returns 1.0.
+     */
+    ValueType get_weight(LocalIndexType idx) const;
+
+    /**
+     * contains all necessary data for an all-to-all_v communication,
+     * and gather/scatter indices
+     */
+    struct all_to_all_t {
+        all_to_all_t(mpi::communicator comm,
+                     const array<shared_idx>& shared_idxs);
+
+        // default variable all-to-all data
+        std::vector<int> send_sizes;
+        std::vector<int> send_offsets;
+        std::vector<int> recv_sizes;
+        std::vector<int> recv_offsets;
+
+        /**
+         * DOFs to send. These are dofs that are shared with other ranks,
+         * but this rank owns them.
+         */
+        gko::array<LocalIndexType> send_idxs;
+        /**
+         * DOFs to send. These are dofs that are shared with other ranks,
+         * but other ranks own them. May overlap with send_idxs.
+         */
+        gko::array<LocalIndexType> recv_idxs;
+    };
+    all_to_all_t all_to_all;
+
+    /**
+     * Stores the multiplicity of the receiving DOFs.
+     * The multiplicity is stored as 1/sqrt(#Owners), if the mode is `add`.
+     * If the mode is `set` then the value will always be 0, as no receiving DOF
+     * is owned by this rank.
+     */
+    struct multiplicity_t {
+        /**
+         * maybe a better storage scheme using bitmaps would be possible
+         */
+        gko::array<LocalIndexType> idxs;
+        gko::array<ValueType> weights;
+
+        /**
+         * strictly only needs the recv_idxs
+         */
+        multiplicity_t(const array<shared_idx>& shared_idxs, sharing_mode mode);
+    };
+    multiplicity_t multiplicity;
+
+    sharing_mode mode;
+};
+
+
+}  // namespace distributed
+}  // namespace experimental
+}  // namespace gko
+
+#endif  // GINKGO_SHARING_INFO_HPP

--- a/include/ginkgo/ginkgo.hpp
+++ b/include/ginkgo/ginkgo.hpp
@@ -74,6 +74,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <ginkgo/core/distributed/base.hpp>
 #include <ginkgo/core/distributed/lin_op.hpp>
+#include <ginkgo/core/distributed/local_vector.hpp>
 #include <ginkgo/core/distributed/matrix.hpp>
 #include <ginkgo/core/distributed/partition.hpp>
 #include <ginkgo/core/distributed/polymorphic_object.hpp>


### PR DESCRIPTION
This PR shows the bare interface for 'local-only' matrices, without any implementation details. 

In contrast to our current distributed `Vector` and `Matrix`, this format does not need any global information. Instead, the key element is describing the communication in terms of shared indices. These are indices that appear in more than one local index set. It is not necessary that these indices have unique global indices, all that we require is that the relation between local indices and which rank also shares them and the indices local to their numbering.

This supports both unique and shared ownership of the shared DOFs. More concretely, a DOF that appears in the local index set of multiple ranks may be exclusively owned by one rank or equally by all ranks. The difference is currently realized as an enum, but it might be useful in the future to allow more arbitrary weighting between the ranks. At the moment, the ownership for all shared DOFs has to be the same, but that might be relaxed.

The distributed operator is very simple. It just applies the local operator and then issues a communication update to the result vector.

The distributed vector is a bit more complicated. It has a routine to update the shared DOFs with the values from other ranks. This is called making the vector consistent. Assuming a consistent vector, this step only has to happen if non-pointwise operations are executed. In all other cases, e.g. vector additions, scaling, the vector stays consistent. Additionally, the vector reductions have to be handled with special care. In the case of exclusive ownership, non-owned DOFs have to be set to zero, while in the shared ownership mode, the DOFs have to be scaled by `sqrt(1/#Owners)` to compensate for adding the same values multiple times.

Usage example for an overlapping domain decomposition:
```
auto shared_idxs = /* compute shared idxs */;
auto info = std::make_shared<sharing_info<value_type>>(comm, shared_idxs, sharing_mode::set);

auto x = LocalVector<>create(exec, comm, info);
auto y = LocalVector<>create(exec, comm, info);
/* fill x and y like Dense */

auto A = Csr<>create(exec);
/* fill A as usual */

auto local_cg = Cg<>::build().on(exec)->generate(A);

auto cg = Cg<>::build().with_generated_preconditioner(
    ConsistentOp::create(exec, local_cg))
  .on(exec)->generate(ConsistentOp::create(exec, A));
cg->apply(x, y);
```


I'm open to any criticism, or suggestions on this topic.

TODO:

- [ ] find better names
- [ ] evaluate reordering and non-blocking option
- [ ] evaluate user functions for sharing mode