### PR TITLE
fallback to our spmv when cusparse on single strided vector if SM>=70 and cuda>=11.6

### DIFF
--- a/cuda/matrix/csr_kernels.cu
+++ b/cuda/matrix/csr_kernels.cu
@@ -383,6 +383,14 @@ bool try_general_sparselib_spmv(std::shared_ptr<const CudaExecutor> exec,
         cusparse::destroy(vecb);
         cusparse::destroy(vecc);
     } else {
+#if CUDA_VERSION >= 11060
+        if (b->get_size()[1] == 1 && exec->get_major_version() >= 7) {
+            // cusparseSpMM seems to take the single strided vector as column
+            // major without considering stride and row major (SM >= 70 and
+            // cuda 11.6)
+            return false;
+        }
+#endif  // CUDA_VERSION >= 11060
         cusparseSpMMAlg_t alg = CUSPARSE_SPMM_CSR_ALG2;
         auto vecb =
             cusparse::create_dnmat(b->get_size(), b->get_stride(), b_val);


### PR DESCRIPTION
This PR fallbacks to our spmv when single strided vector if SM>=70 and nvcc>=11.6
cusparse SpMM has the issue when SM >= 70 and nvcc >= 11.6. It considers single row-major strided vector as column vector.
It's found by #1212 and #1292

from #1212 , SpMM buffer size uses the same amount for single strided vector as single vector and the modification behavior of padding.
> SM61(V11.6.124): single_vector 44, with stride 6672, multiple vector 6672
SM80(V11.6.112, V11.7.99): single_vector 44, with stride 44, multiple vector 6672
padding comparison in 10 * 10 matrix. The first 6 elements of padding are changed (10 = 3 * 3 + 1) in stride = 3 vectors
component-wise relative error is:
	1.0863312916722774	1.5682268241366939	
	0.8845321836579475	0.48366594856360329	
	1.8114900341559925	0.94033609142098684
	0	0

I also test cuda V11.4.152 on V100 and A100, and 11.5.119 on V100. The single strided vector tests are passed.
V11.6.124 on V100 also gave the wrong result on single strided vector tests from sparselib.
closes #1212 