### PR TITLE
generate the test pipeline if the build job require it with specific runner

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -2,10 +2,8 @@ stages:
   - init-status
   - sync
   - trigger_pipeline
-  - check
   - build
   - test
-  - fallback
   - code_quality
   - deploy
   - QoS_tools
@@ -85,13 +83,6 @@ trigger_pipeline:
         echo "Can not find the corresponding Pull Request"
       fi
 
-check/horeka:
-  stage: check
-  extends:
-    - .use_gko-nocuda-nompi-gnu9-llvm8
-  script: 
-    - apt update && apt install -y netcat
-    - nc -w 20 -z horeka.scc.kit.edu 22
 
 # Build jobs
 # Job with example runs.
@@ -286,7 +277,7 @@ build/cuda102/nompi/intel/cuda/debug/static:
 # cuda 11.0 and friends on HoreKa with tests
 build/cuda110/mvapich2/gcc/cuda/debug/shared:
   extends:
-    - .build_template
+    - .unified_build_template
     - .default_variables
     - .full_test_condition
     - .use_gko-cuda110-mvapich2-gnu9-llvm9-intel2020
@@ -301,25 +292,12 @@ build/cuda110/mvapich2/gcc/cuda/debug/shared:
     USE_NAME: "cuda110-mvapich2-gcc-${CI_PIPELINE_ID}"
     KEEP_CONTAINER: "ON"
     USE_SLURM: 0
-
-test/cuda110/mvapich2/gcc/cuda/debug/shared:
-  extends:
-    - .horeka_test_template
-    - .default_variables
-    - .full_test_condition
-    - .use_gko-cuda110-mvapich2-gnu9-llvm9-intel2020
-  variables:
-    USE_NAME: "cuda110-mvapich2-gcc-${CI_PIPELINE_ID}"
-    SLURM_PARTITION: "accelerated"
-    SLURM_GRES: "gpu:4"
-    SLURM_TIME: "02:00:00"
-  dependencies: null
-  needs: [ "build/cuda110/mvapich2/gcc/cuda/debug/shared" ]
+    TEST_SLURM_GRES: "gpu:4"
 
 
 build/cuda110/nompi/clang/cuda/release/static:
   extends:
-    - .build_template
+    - .unified_build_template
     - .default_variables
     - .full_test_condition
     - .use_gko-cuda110-mvapich2-gnu9-llvm9-intel2020
@@ -334,20 +312,7 @@ build/cuda110/nompi/clang/cuda/release/static:
     USE_NAME: "cuda110-nompi-clang-${CI_PIPELINE_ID}"
     KEEP_CONTAINER: "ON"
     USE_SLURM: 0
-
-test/cuda110/nompi/clang/cuda/release/static:
-  extends:
-    - .horeka_test_template
-    - .default_variables
-    - .full_test_condition
-    - .use_gko-cuda110-mvapich2-gnu9-llvm9-intel2020
-  variables:
-    USE_NAME: "cuda110-nompi-clang-${CI_PIPELINE_ID}"
-    SLURM_PARTITION: "accelerated"
-    SLURM_GRES: "gpu:1"
-    SLURM_TIME: "01:30:00"
-  dependencies: null
-  needs: [ "build/cuda110/nompi/clang/cuda/release/static" ]
+    TEST_SLURM_GRES: "gpu:1"
 
 
 build/cuda110/nompi/intel/cuda/debug/static:
@@ -366,35 +331,43 @@ build/cuda110/nompi/intel/cuda/debug/static:
     BUILD_SHARED_LIBS: "OFF"
     CUDA_ARCH: 80
     USE_NAME: "cuda110-nompi-intel-${CI_PIPELINE_ID}"
-    BUILD_KEEP_CONTAINER: "ON"
-    BUILD_USE_SLURM: 0
-    TEST_SLURM_PARTITION: "accelerated"
+    KEEP_CONTAINER: "ON"
+    USE_SLURM: 0
     TEST_SLURM_GRES: "gpu:1"
-    TEST_SLURM_TIME: "02:00:00"
-  dependencies: null
 
-fallback/cuda110/nompi/intel/cuda/debug/static:
-  stage: fallback
+
+test/generate_test_pipeline:
+  stage: test
   extends:
-    - .build_and_test_template
-    - .default_variables
-    - .quick_test_condition
-    - .use_gko-cuda110-mvapich2-gnu9-llvm9-intel2020
-  variables:
-    C_COMPILER: "icc"
-    CXX_COMPILER: "icpc"
-    BUILD_OMP: "ON"
-    BUILD_CUDA: "ON"
-    BUILD_TYPE: "Debug"
-    FAST_TESTS: "ON"
-    BUILD_SHARED_LIBS: "OFF"
-    CUDA_ARCH: 61
-  tags:
-    - private_ci
-    - nvidia-gpu
-  dependencies: null
-  needs: [ "check/horeka" ]
-  when: on_failure
+    - .use_status-job-settings
+  script:
+    - cat .gitlab/optional_job_prefix.yml > generated.yml
+    - |
+      if [ "$(ls *.job.yml)" ]; then
+        ls *.job.yml
+        cat *.job.yml >> generated.yml
+      else
+        cat .gitlab/dummy_job.yml >> generated.yml
+      fi
+    - cat generated.yml
+  needs: 
+    - job: "build/cuda110/mvapich2/gcc/cuda/debug/shared"
+      optional: true
+    - job: "build/cuda110/nompi/clang/cuda/release/static"
+      optional: true
+    - job: "build/cuda110/nompi/intel/cuda/debug/static"
+      optional: true
+  artifacts:
+    paths: 
+      - generated.yml
+  
+test/trigger:
+  stage: test
+  trigger:
+    include:
+      - artifact: generated.yml
+        job: test/generate_test_pipeline
+  needs: ["test/generate_test_pipeline"]
 
 
 # cuda 11.4 and friends
@@ -717,7 +690,6 @@ no-circular-deps:
     - .default_variables
     - .quick_test_condition
     - .use_gko-cuda101-openmpi-gnu8-llvm7-intel2019
-  needs: null
   variables:
     BUILD_OMP: "ON"
     BUILD_CUDA: "ON"
@@ -954,6 +926,9 @@ benchmark-cuda-spmv-build:
     - .default_variables
     - .use_gko-cuda110-mvapich2-gnu9-llvm9-intel2020
     - .benchmark-spmv-cuda-rules
+  tags:
+    - private_ci
+    - horeka
   stage: benchmark-build
   variables:
     BUILD_OMP: "ON"
@@ -975,6 +950,9 @@ benchmark-cuda-spmv:
     - .default_variables
     - .use_gko-cuda110-mvapich2-gnu9-llvm9-intel2020
     - .benchmark-spmv-cuda-rules
+  tags:
+    - private_ci
+    - horeka
   stage: benchmark-cuda
   variables:
     BENCHMARK_REPO: git@github.com:ginkgo-project/ginkgo-data.git

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -2,8 +2,10 @@ stages:
   - init-status
   - sync
   - trigger_pipeline
+  - check
   - build
   - test
+  - fallback
   - code_quality
   - deploy
   - QoS_tools
@@ -83,6 +85,13 @@ trigger_pipeline:
         echo "Can not find the corresponding Pull Request"
       fi
 
+check/horeka:
+  stage: check
+  extends:
+    - .use_gko-nocuda-nompi-gnu9-llvm8
+  script: 
+    - apt update && apt install -y netcat
+    - nc -w 20 -z horeka.scc.kit.edu 22
 
 # Build jobs
 # Job with example runs.
@@ -359,6 +368,7 @@ build/cuda110/nompi/intel/cuda/debug/static:
     USE_NAME: "cuda110-nompi-intel-${CI_PIPELINE_ID}"
     KEEP_CONTAINER: "ON"
     USE_SLURM: 0
+  needs: [ "check/horeka" ]
 
 test/cuda110/nompi/intel/cuda/debug/static:
   extends:
@@ -373,6 +383,29 @@ test/cuda110/nompi/intel/cuda/debug/static:
     SLURM_TIME: "02:00:00"
   dependencies: null
   needs: [ "build/cuda110/nompi/intel/cuda/debug/static" ]
+
+fallback/cuda110/nompi/intel/cuda/debug/static:
+  stage: fallback
+  extends:
+    - .build_and_test_template
+    - .default_variables
+    - .quick_test_condition
+    - .use_gko-cuda110-mvapich2-gnu9-llvm9-intel2020
+  variables:
+    C_COMPILER: "icc"
+    CXX_COMPILER: "icpc"
+    BUILD_OMP: "ON"
+    BUILD_CUDA: "ON"
+    BUILD_TYPE: "Debug"
+    FAST_TESTS: "ON"
+    BUILD_SHARED_LIBS: "OFF"
+    CUDA_ARCH: 61
+  tags:
+    - private_ci
+    - nvidia-gpu
+  dependencies: null
+  needs: [ "check/horeka" ]
+  when: on_failure
 
 
 # cuda 11.4 and friends
@@ -695,6 +728,7 @@ no-circular-deps:
     - .default_variables
     - .quick_test_condition
     - .use_gko-cuda101-openmpi-gnu8-llvm7-intel2019
+  needs: null
   variables:
     BUILD_OMP: "ON"
     BUILD_CUDA: "ON"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -352,7 +352,7 @@ test/cuda110/nompi/clang/cuda/release/static:
 
 build/cuda110/nompi/intel/cuda/debug/static:
   extends:
-    - .build_template
+    - .unified_build_template
     - .default_variables
     - .quick_test_condition
     - .use_gko-cuda110-mvapich2-gnu9-llvm9-intel2020
@@ -366,23 +366,12 @@ build/cuda110/nompi/intel/cuda/debug/static:
     BUILD_SHARED_LIBS: "OFF"
     CUDA_ARCH: 80
     USE_NAME: "cuda110-nompi-intel-${CI_PIPELINE_ID}"
-    KEEP_CONTAINER: "ON"
-    USE_SLURM: 0
-  needs: [ "check/horeka" ]
-
-test/cuda110/nompi/intel/cuda/debug/static:
-  extends:
-    - .horeka_test_template
-    - .default_variables
-    - .quick_test_condition
-    - .use_gko-cuda110-mvapich2-gnu9-llvm9-intel2020
-  variables:
-    USE_NAME: "cuda110-nompi-intel-${CI_PIPELINE_ID}"
-    SLURM_PARTITION: "accelerated"
-    SLURM_GRES: "gpu:1"
-    SLURM_TIME: "02:00:00"
+    BUILD_KEEP_CONTAINER: "ON"
+    BUILD_USE_SLURM: 0
+    TEST_SLURM_PARTITION: "accelerated"
+    TEST_SLURM_GRES: "gpu:1"
+    TEST_SLURM_TIME: "02:00:00"
   dependencies: null
-  needs: [ "build/cuda110/nompi/intel/cuda/debug/static" ]
 
 fallback/cuda110/nompi/intel/cuda/debug/static:
   stage: fallback

--- a/.gitlab/dummy_job.yml
+++ b/.gitlab/dummy_job.yml
@@ -1,0 +1,6 @@
+test/dummy_job:
+  stage: test
+  extends:
+    - .use_status-job-settings
+  script:
+    - echo "dummy job avoids the empty child pipeline issue"

--- a/.gitlab/image.yml
+++ b/.gitlab/image.yml
@@ -61,7 +61,7 @@
   image: ginkgohub/cuda:110-mvapich2-gnu9-llvm9-intel2020
   tags:
     - private_ci
-    - horeka
+    - nvidia-gpu
 
 .use_gko_cuda114-openmpi-gnu11-llvm12:
   image: ginkgohub/cuda:114-openmpi-gnu11-llvm12

--- a/.gitlab/optional_job.yml
+++ b/.gitlab/optional_job.yml
@@ -1,0 +1,15 @@
+test/%JOB_NAME%:
+  extends:
+  # do not need the full/quick condition because it is already controlled by the build job
+    - .horeka_test_template
+    - .default_variables
+    - .use_gko-cuda110-mvapich2-gnu9-llvm9-intel2020
+  tags:
+    - private_ci
+    - %RUNNER_TAG%
+  variables:
+    USE_NAME: "%CONTAINER_NAME%"
+    SLURM_PARTITION: "accelerated"
+    SLURM_GRES: "%TEST_SLURM_GRES%"
+    SLURM_TIME: "02:00:00"
+  dependencies: null

--- a/.gitlab/optional_job_prefix.yml
+++ b/.gitlab/optional_job_prefix.yml
@@ -1,0 +1,8 @@
+stages:
+    - test
+  
+include:
+  - local: '.gitlab/image.yml'
+  - local: '.gitlab/rules.yml'
+  - local: '.gitlab/scripts.yml'
+  - local: '.gitlab/variables.yml'

--- a/.gitlab/rules.yml
+++ b/.gitlab/rules.yml
@@ -28,12 +28,22 @@
     # Run only when the `RUN_CI_TAG` variable is set and this is a full pipeline, or for `master`, `develop` or tags.
     - if: $RUN_CI_TAG && ($STATUS_CONTEXT == "full" || $CI_COMMIT_BRANCH == "master" || $CI_COMMIT_BRANCH == "develop" || $CI_COMMIT_TAG)
   dependencies: []
+  needs:
+    - job: trigger_pipeline
+      optional: true
+    - job: sync
+      optional: true
 
 
 .quick_test_condition:
   rules:
     - if: $RUN_CI_TAG && $STATUS_CONTEXT == null
   dependencies: []
+  needs: 
+    - job: trigger_pipeline
+      optional: true
+    - job: sync
+      optional: true
 
 .quick_test_short_lived_condition:
   rules:

--- a/.gitlab/rules.yml
+++ b/.gitlab/rules.yml
@@ -28,22 +28,12 @@
     # Run only when the `RUN_CI_TAG` variable is set and this is a full pipeline, or for `master`, `develop` or tags.
     - if: $RUN_CI_TAG && ($STATUS_CONTEXT == "full" || $CI_COMMIT_BRANCH == "master" || $CI_COMMIT_BRANCH == "develop" || $CI_COMMIT_TAG)
   dependencies: []
-  needs:
-    - job: trigger_pipeline
-      optional: true
-    - job: sync
-      optional: true
 
 
 .quick_test_condition:
   rules:
     - if: $RUN_CI_TAG && $STATUS_CONTEXT == null
   dependencies: []
-  needs: 
-    - job: trigger_pipeline
-      optional: true
-    - job: sync
-      optional: true
 
 .quick_test_short_lived_condition:
   rules:

--- a/.gitlab/scripts.yml
+++ b/.gitlab/scripts.yml
@@ -155,6 +155,40 @@
     - popd
   cache: []
 
+.unified_build_template:
+  stage: build
+  before_script:
+    - !reference [.before_script_template, before_script]
+    # - !reference [.horeka_test_template, before_script]
+    - if [ -z "${USE_NAME}" ]; then exit 111; fi
+    - if [ -z "${TEST_SLURM_PARTITION}" ]; then exit 222; fi
+    - if [[ ! "${TEST_SLURM_GRES}" =~ "^gpu*"  ]]; then export NVIDIA_VISIBLE_DEVICES=void; fi
+  variables: !reference [.horeka_test_template, variables]
+  script:
+    - echo "RUNNER TAG ${CI_RUNNER_TAGS}"
+    - if [ "0" == "0" ]; then
+    - export CUDA_ARCH=61
+    - echo "run normal"
+    - !reference [.build_and_test_template, script]
+    - else
+    - echo "run slurm"
+    # export the build related variables
+    - if [ -n "${BUILD_KEEP_CONTAINER}" ]; then export KEEP_CONTAINER="${BUILD_KEEP_CONTAINER}"; fi
+    - if [ -n "${BUILD_USE_SLURM}" ]; then export USE_SLURM="${BUILD_USE_SLURM}"; fi
+    - !reference [.build_template, script]
+    - if [ -n "${BUILD_KEEP_CONTAINER}" ]; then unset KEEP_CONTAINER; fi
+    - if [ -n "${BUILD_USE_SLURM}" ]; then unset USE_SLURM; fi
+    # export the test related variables
+    - if [ -n "${TEST_SLURM_PARTITION}" ]; then export SLURM_PARTITION="${TEST_SLURM_PARTITION}"; fi
+    - if [ -n "${TEST_SLURM_GRES}" ]; then export SLURM_GRES="${TEST_SLURM_GRES}"; fi
+    - if [ -n "${TEST_SLURM_TIME}" ]; then export SLURM_TIME="${TEST_SLURM_TIME}"; fi
+    - !reference [.horeka_test_template, script]
+    - if [ -n "${TEST_SLURM_PARTITION}" ]; then unset SLURM_PARTITION; fi
+    - if [ -n "${TEST_SLURM_GRES}" ]; then unset SLURM_GRES; fi
+    - if [ -n "${TEST_SLURM_TIME}" ]; then unset SLURM_TIME; fi
+    - fi
+  dependencies: []
+  cache: []
 
 .horeka_benchmark_before_script_template:
   before_script:

--- a/.gitlab/scripts.yml
+++ b/.gitlab/scripts.yml
@@ -155,40 +155,35 @@
     - popd
   cache: []
 
+
 .unified_build_template:
   stage: build
   before_script:
     - !reference [.before_script_template, before_script]
-    # - !reference [.horeka_test_template, before_script]
     - if [ -z "${USE_NAME}" ]; then exit 111; fi
-    - if [ -z "${TEST_SLURM_PARTITION}" ]; then exit 222; fi
-    - if [[ ! "${TEST_SLURM_GRES}" =~ "^gpu*"  ]]; then export NVIDIA_VISIBLE_DEVICES=void; fi
-  variables: !reference [.horeka_test_template, variables]
+    - if [ -z "${TEST_SLURM_GRES}" ]; then exit 222; fi
   script:
-    - echo "RUNNER TAG ${CI_RUNNER_TAGS}"
-    - if [ "0" == "0" ]; then
-    - export CUDA_ARCH=61
-    - echo "run normal"
-    - !reference [.build_and_test_template, script]
+    - if [[ "${CI_RUNNER_TAGS}" =~ "slurm" ]]; then
+    -   !reference [.build_template, script]
+    -   if [[ "${CI_RUNNER_TAGS}" =~ "horeka" ]]; then export RUNNER_TAG=horeka; fi
+    -   export JOB_NAME="${CI_JOB_NAME#build/}"
+    -   export TEST_SLURM_GRES
+    -   export CONTAINER_NAME=${USE_NAME}
+    -   .gitlab/varsub.sh .gitlab/optional_job.yml > ${CI_JOB_NAME_SLUG}.job.yml
     - else
-    - echo "run slurm"
-    # export the build related variables
-    - if [ -n "${BUILD_KEEP_CONTAINER}" ]; then export KEEP_CONTAINER="${BUILD_KEEP_CONTAINER}"; fi
-    - if [ -n "${BUILD_USE_SLURM}" ]; then export USE_SLURM="${BUILD_USE_SLURM}"; fi
-    - !reference [.build_template, script]
-    - if [ -n "${BUILD_KEEP_CONTAINER}" ]; then unset KEEP_CONTAINER; fi
-    - if [ -n "${BUILD_USE_SLURM}" ]; then unset USE_SLURM; fi
-    # export the test related variables
-    - if [ -n "${TEST_SLURM_PARTITION}" ]; then export SLURM_PARTITION="${TEST_SLURM_PARTITION}"; fi
-    - if [ -n "${TEST_SLURM_GRES}" ]; then export SLURM_GRES="${TEST_SLURM_GRES}"; fi
-    - if [ -n "${TEST_SLURM_TIME}" ]; then export SLURM_TIME="${TEST_SLURM_TIME}"; fi
-    - !reference [.horeka_test_template, script]
-    - if [ -n "${TEST_SLURM_PARTITION}" ]; then unset SLURM_PARTITION; fi
-    - if [ -n "${TEST_SLURM_GRES}" ]; then unset SLURM_GRES; fi
-    - if [ -n "${TEST_SLURM_TIME}" ]; then unset SLURM_TIME; fi
+    -   export CUDA_ARCH=61
+    # the runner hostname is not in /etc/hosts, which leads `gethostbyname failed`
+    # we add it manually as workaround
+    -   echo "127.0.0.1   $(hostname)" >> /etc/hosts
+    -   !reference [.build_and_test_template, script]
+    -   touch ${CI_JOB_NAME_SLUG}.job.yml
     - fi
-  dependencies: []
+    - cat ${CI_JOB_NAME_SLUG}.job.yml
+  artifacts:
+    paths:
+      - ${CI_JOB_NAME_SLUG}.job.yml
   cache: []
+
 
 .horeka_benchmark_before_script_template:
   before_script:

--- a/.gitlab/varsub.sh
+++ b/.gitlab/varsub.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+# grep all %VARIABLE%
+input_file=$1
+variables=( $(grep -E -oh "%[a-zA-Z0-9_]*%" "${input_file}" | sed "s/%//g" | sort -u) )
+sed_line=""
+for var in "${variables[@]}"; do
+    if [ -z ${!var} ]; then
+        >&2 echo "${var} variable is not set"
+        exit 1
+    fi
+    sed_line="${sed_line};s/%${var}%/${!var}/g"
+done
+sed_line="${sed_line#;}"
+if [ "${sed_line}" == "" ]; then
+    cat "${input_file}"
+else
+    sed ${sed_line#;} "${input_file}"
+fi
+# add a newline to avoid the concatenate issue
+echo ""


### PR DESCRIPTION
This PR is to add the flexibility if horeka is down.

I have tried some possible way, but they do not always work as my initial thought
1. (Work) check the server status, run the two build/test jobs via slurm or the build+test in our own server
adds some fallback job if horeka is not reachable.
checks the reachability of horeka before launching the horeka related jobs.
When using `on_failure` with `needs`, the job will be skipped if one of job is skipped
Thus, the fallback can only rely on the check.
https://gitlab.com/gitlab-org/gitlab/-/issues/388866
https://gitlab.com/gitlab-org/gitlab/-/issues/36610
2. (Should Work but limit resource) unified build between docker and slurm, which select the build script from `CI_RUNNER_TAGS`
Due to current slurm runner design, it will pass the script from gitlab to runner.
Thus, it will combine build and test on gpu partition, which is not good for the resource.
Not sure it is easy or not, if scripts write gpu_scripts to cache, slurm runner will run the generated script with gpu job additionally. 
3. (Not Work)runner dyanmic tag
from https://docs.gitlab.com/ee/ci/yaml/#tags, it can support CI/CD variable.
However, it is decided when job create not run. After creating the manual job, resetting the runner_tag works but it does not affect runner selection
`private_ci` and `$RUNNER_TAG` are used in `tags`
-https://gitlab.com/ginkgo-project/ginkgo-public-ci/-/jobs/4141132266
![image](https://user-images.githubusercontent.com/19565938/233215013-3fc1d655-6fcd-433e-8075-ae11e9971fdd.png)
in the right side, the tags are still `private_ci` `status-jobs`, but the `RUNNER_TAG` is shown as `nla-gpu`
-https://gitlab.com/ginkgo-project/ginkgo-public-ci/-/jobs/4141192635
![image](https://user-images.githubusercontent.com/19565938/233215466-508b7369-9283-409d-9b7a-619c71f00862.png)
if we do not define the default `RUNNER_TAG`, it will use plain text ${RUNNER_TAG} directly and still can not be overwritten in the runner selection.
-The pipeline variable should work because it is overwrited before job creation. However, we do not know the server status before the job creation. (or, one additional pipeline to trigger the current pipeline)
-It is similar to the `rules`, after generation, the job is decided to create or not already
-rules can not depends on artifact, so we can not use artifact like variable to select job. https://gitlab.com/gitlab-org/gitlab/-/issues/215100
4. (Not work for the github status) run manual job by job according to `CI_RUNNER_TAGS`
have the corresponding test job in manual mode, if build job requires it based on `CI_RUNNER_TAGS`, run the test job via API.
However, the manual job can be allow_failure or not. if it allows failure, we will not know the status from the github status. if it doesn't allow, it will show blocked (failed/pending) if they are not executed.
5. (Work) create the child test pipeline
If build job requests the specific runner to run the test, it will write a small job into yml. Thus, each job can use different runner. The later job collects these to generate child pipeline. note. if no job is generated, it will add a dummy job to avoid empty pipeline issue. Note. to upload artifact, the host server also needs to install gitlab-runner.


TODO:
- [x] clean it up and apply it to all related jobs