### PR TITLE
Some bug fixes for the next release

### DIFF
--- a/common/cuda_hip/preconditioner/isai_kernels.hpp.inc
+++ b/common/cuda_hip/preconditioner/isai_kernels.hpp.inc
@@ -119,18 +119,32 @@ __forceinline__ __device__ void generic_generate(
             auto m_row_begin = m_row_ptrs[col];
             auto m_row_size = m_row_ptrs[col + 1] - m_row_begin;
             // extract the dense submatrix consisting of the entries whose
-            // columns/rows match column indices from this row
+            // columns/rows match column indices from this row within the
+            // sparsity pattern of the original matrix (matches outside of that
+            // are zero)
             group_match<subwarp_size>(
                 m_col_idxs + m_row_begin, m_row_size, i_col_idxs + i_row_begin,
                 i_row_size, subwarp,
                 [&](IndexType, IndexType m_idx, IndexType i_idx,
                     config::lane_mask_type, bool valid) {
-                    rhs_one_idx += popcnt(subwarp.ballot(
-                        valid && m_col_idxs[m_row_begin + m_idx] < row &&
-                        col == row));
                     if (valid) {
                         dense_system(nz, i_idx) = m_values[m_row_begin + m_idx];
                     }
+                });
+            const auto i_transposed_row_begin = i_row_ptrs[col];
+            const auto i_transposed_row_size =
+                i_row_ptrs[col + 1] - i_transposed_row_begin;
+            // Loop over all matches that are within the sparsity pattern of
+            // the inverse to find the index of the one in the right-hand-side
+            group_match<subwarp_size>(
+                i_col_idxs + i_transposed_row_begin, i_transposed_row_size,
+                i_col_idxs + i_row_begin, i_row_size, subwarp,
+                [&](IndexType, IndexType m_idx, IndexType i_idx,
+                    config::lane_mask_type, bool valid) {
+                    rhs_one_idx += popcnt(subwarp.ballot(
+                        valid &&
+                        i_col_idxs[i_transposed_row_begin + m_idx] < row &&
+                        col == row));
                 });
         }
 

--- a/core/log/profiler_hook.cpp
+++ b/core/log/profiler_hook.cpp
@@ -289,6 +289,28 @@ void ProfilerHook::on_iteration_complete(
 }
 
 
+void ProfilerHook::on_iteration_complete(const LinOp* solver,
+                                         const size_type& num_iterations,
+                                         const LinOp* residual,
+                                         const LinOp* solution,
+                                         const LinOp* residual_norm) const
+{
+    on_iteration_complete(solver, nullptr, solution, num_iterations, residual,
+                          residual_norm, nullptr, nullptr, false);
+}
+
+
+void ProfilerHook::on_iteration_complete(
+    const LinOp* solver, const size_type& num_iterations, const LinOp* residual,
+    const LinOp* solution, const LinOp* residual_norm,
+    const LinOp* implicit_sq_residual_norm) const
+{
+    on_iteration_complete(solver, nullptr, solution, num_iterations, residual,
+                          residual_norm, implicit_sq_residual_norm, nullptr,
+                          false);
+}
+
+
 bool ProfilerHook::needs_propagation() const { return true; }
 
 

--- a/core/log/stream.cpp
+++ b/core/log/stream.cpp
@@ -487,6 +487,30 @@ void Stream<ValueType>::on_iteration_complete(
 }
 
 
+template <typename ValueType>
+void Stream<ValueType>::on_iteration_complete(const LinOp* solver,
+                                              const size_type& num_iterations,
+                                              const LinOp* residual,
+                                              const LinOp* solution,
+                                              const LinOp* residual_norm) const
+{
+    on_iteration_complete(solver, nullptr, solution, num_iterations, residual,
+                          residual_norm, nullptr, nullptr, false);
+}
+
+
+template <typename ValueType>
+void Stream<ValueType>::on_iteration_complete(
+    const LinOp* solver, const size_type& num_iterations, const LinOp* residual,
+    const LinOp* solution, const LinOp* residual_norm,
+    const LinOp* implicit_sq_residual_norm) const
+{
+    on_iteration_complete(solver, nullptr, solution, num_iterations, residual,
+                          residual_norm, implicit_sq_residual_norm, nullptr,
+                          false);
+}
+
+
 #define GKO_DECLARE_STREAM(_type) class Stream<_type>
 GKO_INSTANTIATE_FOR_EACH_VALUE_TYPE(GKO_DECLARE_STREAM);
 

--- a/core/preconditioner/isai.cpp
+++ b/core/preconditioner/isai.cpp
@@ -121,8 +121,7 @@ std::shared_ptr<Csr> extend_sparsity(std::shared_ptr<const Executor>& exec,
 template <isai_type IsaiType, typename ValueType, typename IndexType>
 void Isai<IsaiType, ValueType, IndexType>::generate_inverse(
     std::shared_ptr<const LinOp> input, bool skip_sorting, int power,
-    IndexType excess_limit,
-    gko::remove_complex<ValueType> excess_solver_reduction)
+    IndexType excess_limit, remove_complex<ValueType> excess_solver_reduction)
 {
     using Dense = matrix::Dense<ValueType>;
     using LowerTrs = solver::LowerTrs<ValueType, IndexType>;

--- a/core/preconditioner/isai.cpp
+++ b/core/preconditioner/isai.cpp
@@ -121,7 +121,8 @@ std::shared_ptr<Csr> extend_sparsity(std::shared_ptr<const Executor>& exec,
 template <isai_type IsaiType, typename ValueType, typename IndexType>
 void Isai<IsaiType, ValueType, IndexType>::generate_inverse(
     std::shared_ptr<const LinOp> input, bool skip_sorting, int power,
-    IndexType excess_limit)
+    IndexType excess_limit,
+    gko::remove_complex<ValueType> excess_solver_reduction)
 {
     using Dense = matrix::Dense<ValueType>;
     using LowerTrs = solver::LowerTrs<ValueType, IndexType>;
@@ -238,7 +239,8 @@ void Isai<IsaiType, ValueType, IndexType>::generate_inverse(
                             gko::stop::ResidualNorm<ValueType>::build()
                                 .with_baseline(gko::stop::mode::rhs_norm)
                                 .with_reduction_factor(
-                                    remove_complex<ValueType>{1e-6})
+                                    remove_complex<ValueType>{
+                                        excess_solver_reduction})
                                 .on(exec))
                         .on(exec);
                 excess_solution->copy_from(excess_rhs);

--- a/core/stop/combined.cpp
+++ b/core/stop/combined.cpp
@@ -37,6 +37,28 @@ namespace gko {
 namespace stop {
 
 
+Combined::Combined(std::shared_ptr<const gko::Executor> exec)
+    : EnablePolymorphicObject<Combined, Criterion>(std::move(exec))
+{}
+
+
+Combined::Combined(const Combined::Factory* factory, const CriterionArgs& args)
+    : EnablePolymorphicObject<Combined, Criterion>(factory->get_executor()),
+      parameters_{factory->get_parameters()}
+{
+    for (const auto& f : parameters_.criteria) {
+        // Ignore the nullptr from the list
+        if (f != nullptr) {
+            criteria_.push_back(f->generate(args));
+        }
+    }
+    // If the list are empty or all nullptr, throw gko::NotSupported
+    if (criteria_.size() == 0) {
+        GKO_NOT_SUPPORTED(this);
+    }
+}
+
+
 bool Combined::check_impl(uint8 stoppingId, bool setFinalized,
                           array<stopping_status>* stop_status,
                           bool* one_changed, const Updater& updater)
@@ -55,6 +77,32 @@ bool Combined::check_impl(uint8 stoppingId, bool setFinalized,
         ids++;
     }
     return one_converged;
+}
+
+
+Combined::Factory::Factory(std::shared_ptr<const ::gko::Executor> exec)
+    : Base(std::move(exec))
+{}
+
+
+Combined::Factory::Factory(std::shared_ptr<const ::gko::Executor> exec,
+                           const Combined::parameters_type& parameters)
+    : Base(std::move(exec), parameters)
+{}
+
+
+Combined::Factory& Combined::Factory::operator=(const Combined::Factory& other)
+{
+    if (this != &other) {
+        parameters_type new_parameters;
+        new_parameters.criteria.clear();
+        for (auto criterion : other.get_parameters().criteria) {
+            new_parameters.criteria.push_back(
+                gko::clone(this->get_executor(), criterion));
+        }
+        Base::operator=(Factory(this->get_executor(), new_parameters));
+    }
+    return *this;
 }
 
 

--- a/core/test/base/exception_helpers.cpp
+++ b/core/test/base/exception_helpers.cpp
@@ -321,4 +321,10 @@ TEST(KernelNotFound, ThrowsKernelNotFoundException)
 }
 
 
+TEST(InvalidState, ThrowsInvalidStateException)
+{
+    ASSERT_THROW(GKO_INVALID_STATE(""), gko::InvalidStateError);
+}
+
+
 }  // namespace

--- a/core/test/log/logger.cpp
+++ b/core/test/log/logger.cpp
@@ -196,7 +196,7 @@ TEST(DummyLogged, CanLogEvents)
 {
     auto exec = gko::ReferenceExecutor::create();
     auto l = std::make_shared<DummyLogger>(
-        new DummyLogger(false, gko::log::Logger::iteration_complete_mask));
+        false, gko::log::Logger::iteration_complete_mask);
     DummyLoggedClass c{exec};
     c.add_logger(l);
 

--- a/core/test/preconditioner/isai.cpp
+++ b/core/test/preconditioner/isai.cpp
@@ -206,6 +206,53 @@ TYPED_TEST(IsaiFactory, SetsDefaultExcessLimitCorrectly)
 }
 
 
+TYPED_TEST(IsaiFactory, SetsExcessSolverReductionCorrectly)
+{
+    using GeneralIsai = typename TestFixture::GeneralIsai;
+    using SpdIsai = typename TestFixture::SpdIsai;
+    using LowerIsai = typename TestFixture::LowerIsai;
+    using UpperIsai = typename TestFixture::UpperIsai;
+    using value_type = typename TestFixture::value_type;
+
+    auto a_isai_factory =
+        GeneralIsai::build().with_excess_solver_reduction(1e-3).on(this->exec);
+    auto spd_isai_factory =
+        SpdIsai::build().with_excess_solver_reduction(1e-3).on(this->exec);
+    auto l_isai_factory =
+        LowerIsai::build().with_excess_solver_reduction(1e-3).on(this->exec);
+    auto u_isai_factory =
+        UpperIsai::build().with_excess_solver_reduction(1e-3).on(this->exec);
+
+    ASSERT_NEAR(a_isai_factory->get_parameters().excess_solver_reduction, 1e-3,
+                r<value_type>::value);
+    ASSERT_NEAR(spd_isai_factory->get_parameters().excess_solver_reduction,
+                1e-3, r<value_type>::value);
+    ASSERT_NEAR(l_isai_factory->get_parameters().excess_solver_reduction, 1e-3,
+                r<value_type>::value);
+    ASSERT_NEAR(u_isai_factory->get_parameters().excess_solver_reduction, 1e-3,
+                r<value_type>::value);
+}
+
+
+TYPED_TEST(IsaiFactory, SetsDefaultExcessSolverReductionCorrectly)
+{
+    using value_type = typename TestFixture::value_type;
+
+    ASSERT_NEAR(
+        this->general_isai_factory->get_parameters().excess_solver_reduction,
+        1e-6, r<value_type>::value);
+    ASSERT_NEAR(
+        this->spd_isai_factory->get_parameters().excess_solver_reduction, 1e-6,
+        r<value_type>::value);
+    ASSERT_NEAR(
+        this->lower_isai_factory->get_parameters().excess_solver_reduction,
+        1e-6, r<value_type>::value);
+    ASSERT_NEAR(
+        this->upper_isai_factory->get_parameters().excess_solver_reduction,
+        1e-6, r<value_type>::value);
+}
+
+
 TYPED_TEST(IsaiFactory, CanSetExcessSolverFactoryA)
 {
     using GeneralIsai = typename TestFixture::GeneralIsai;

--- a/core/test/preconditioner/isai.cpp
+++ b/core/test/preconditioner/isai.cpp
@@ -213,15 +213,20 @@ TYPED_TEST(IsaiFactory, SetsExcessSolverReductionCorrectly)
     using LowerIsai = typename TestFixture::LowerIsai;
     using UpperIsai = typename TestFixture::UpperIsai;
     using value_type = typename TestFixture::value_type;
+    using real_type = gko::remove_complex<value_type>;
 
-    auto a_isai_factory =
-        GeneralIsai::build().with_excess_solver_reduction(1e-3).on(this->exec);
-    auto spd_isai_factory =
-        SpdIsai::build().with_excess_solver_reduction(1e-3).on(this->exec);
-    auto l_isai_factory =
-        LowerIsai::build().with_excess_solver_reduction(1e-3).on(this->exec);
-    auto u_isai_factory =
-        UpperIsai::build().with_excess_solver_reduction(1e-3).on(this->exec);
+    auto a_isai_factory = GeneralIsai::build()
+                              .with_excess_solver_reduction(real_type{1e-3})
+                              .on(this->exec);
+    auto spd_isai_factory = SpdIsai::build()
+                                .with_excess_solver_reduction(real_type{1e-3})
+                                .on(this->exec);
+    auto l_isai_factory = LowerIsai::build()
+                              .with_excess_solver_reduction(real_type{1e-3})
+                              .on(this->exec);
+    auto u_isai_factory = UpperIsai::build()
+                              .with_excess_solver_reduction(real_type{1e-3})
+                              .on(this->exec);
 
     ASSERT_NEAR(a_isai_factory->get_parameters().excess_solver_reduction, 1e-3,
                 r<value_type>::value);

--- a/core/test/utils/matrix_generator.hpp
+++ b/core/test/utils/matrix_generator.hpp
@@ -590,13 +590,13 @@ gko::matrix_data<ValueType, IndexType> generate_tridiag_inverse_matrix_data(
                                          alpha[i] * beta[j + 1] / alpha.back());
             } else if (i < j) {
                 auto sign = static_cast<ValueType>((i + j) % 2 ? -1 : 1);
-                auto val = sign * std::pow(b, j - i) * alpha[i] * beta[j + 1] /
-                           alpha.back();
+                auto val = sign * static_cast<ValueType>(std::pow(b, j - i)) *
+                           alpha[i] * beta[j + 1] / alpha.back();
                 md.nonzeros.emplace_back(i, j, val);
             } else {
                 auto sign = static_cast<ValueType>((i + j) % 2 ? -1 : 1);
-                auto val = sign * std::pow(c, i - j) * alpha[j] * beta[i + 1] /
-                           alpha.back();
+                auto val = sign * static_cast<ValueType>(std::pow(c, i - j)) *
+                           alpha[j] * beta[i + 1] / alpha.back();
                 md.nonzeros.emplace_back(i, j, val);
             }
         }

--- a/core/test/utils/matrix_generator.hpp
+++ b/core/test/utils/matrix_generator.hpp
@@ -568,6 +568,10 @@ template <typename ValueType, typename IndexType>
 gko::matrix_data<ValueType, IndexType> generate_tridiag_inverse_matrix_data(
     gko::size_type size, std::array<ValueType, 3> coeffs)
 {
+    if (size == 0) {
+        return {};
+    }
+
     auto lower = coeffs[0];
     auto diag = coeffs[1];
     auto upper = coeffs[2];

--- a/core/test/utils/matrix_generator_test.cpp
+++ b/core/test/utils/matrix_generator_test.cpp
@@ -40,6 +40,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <gtest/gtest.h>
 
 
+#include "core/base/utils.hpp"
 #include "core/test/utils.hpp"
 
 
@@ -267,6 +268,58 @@ TYPED_TEST(MatrixGenerator, CanGenerateBandMatrix)
             begin(this->band_values_sample), end(this->band_values_sample),
             20.0, 5.0, [](T& val) { return gko::imag(val); });
     }
+}
+
+
+TYPED_TEST(MatrixGenerator, CanGenerateTridiagMatrix)
+{
+    using T = typename TestFixture::value_type;
+    using Dense = typename TestFixture::mtx_type;
+    auto dist = std::normal_distribution<gko::remove_complex<T>>(0, 1);
+    auto engine = std::default_random_engine(42);
+    auto lower = gko::test::detail::get_rand_value<T>(dist, engine);
+    auto diag = gko::test::detail::get_rand_value<T>(dist, engine);
+    auto upper = gko::test::detail::get_rand_value<T>(dist, engine);
+
+    auto mtx = gko::test::generate_tridiag_matrix<Dense>(
+        50, {lower, diag, upper}, this->exec);
+
+    GKO_ASSERT_IS_SQUARE_MATRIX(mtx);
+    for (gko::size_type i = 0; i < mtx->get_size()[0]; ++i) {
+        ASSERT_EQ(mtx->at(i, i), diag);
+        if (i > 0) {
+            ASSERT_EQ(mtx->at(i, i - 1), lower);
+            ASSERT_EQ(mtx->at(i - 1, i), upper);
+        }
+    }
+}
+
+
+TYPED_TEST(MatrixGenerator, CanGenerateTridiagInverseMatrix)
+{
+    using T = typename TestFixture::value_type;
+    using Dense = typename TestFixture::mtx_type;
+    auto dist = std::normal_distribution<gko::remove_complex<T>>(0, 1);
+    auto engine = std::default_random_engine(42);
+    auto lower = gko::test::detail::get_rand_value<T>(dist, engine);
+    auto upper = gko::test::detail::get_rand_value<T>(dist, engine);
+    // make diagonally dominant
+    auto diag = std::abs(gko::test::detail::get_rand_value<T>(dist, engine)) +
+                std::abs(lower) + std::abs(upper);
+
+    auto mtx = gko::test::generate_tridiag_matrix<Dense>(
+        50, {lower, diag, upper}, this->exec);
+    auto inv_mtx = gko::test::generate_tridiag_inverse_matrix<Dense>(
+        50, {lower, diag, upper}, this->exec);
+
+    auto result = Dense::create(this->exec, mtx->get_size());
+    inv_mtx->apply(mtx, result);
+    auto id = Dense::create(this->exec, mtx->get_size());
+    id->fill(0.0);
+    for (gko::size_type i = 0; i < mtx->get_size()[0]; ++i) {
+        id->at(i, i) = gko::one<T>();
+    }
+    GKO_ASSERT_MTX_NEAR(result, id, r<T>::value * 10);
 }
 
 

--- a/dpcpp/preconditioner/isai_kernels.dp.cpp
+++ b/dpcpp/preconditioner/isai_kernels.dp.cpp
@@ -160,18 +160,32 @@ __dpct_inline__ void generic_generate(
             auto m_row_begin = m_row_ptrs[col];
             auto m_row_size = m_row_ptrs[col + 1] - m_row_begin;
             // extract the dense submatrix consisting of the entries whose
-            // columns/rows match column indices from this row
+            // columns/rows match column indices from this row within the
+            // sparsity pattern of the original matrix (matches outside of that
+            // are zero)
             group_match<subwarp_size>(
                 m_col_idxs + m_row_begin, m_row_size, i_col_idxs + i_row_begin,
                 i_row_size, subwarp,
                 [&](IndexType, IndexType m_idx, IndexType i_idx,
                     config::lane_mask_type, bool valid) {
-                    rhs_one_idx += popcnt(subwarp.ballot(
-                        valid && m_col_idxs[m_row_begin + m_idx] < row &&
-                        col == row));
                     if (valid) {
                         dense_system(nz, i_idx) = m_values[m_row_begin + m_idx];
                     }
+                });
+            const auto i_transposed_row_begin = i_row_ptrs[col];
+            const auto i_transposed_row_size =
+                i_row_ptrs[col + 1] - i_transposed_row_begin;
+            // Loop over all matches that are within the sparsity pattern of
+            // the inverse to find the index of the one in the right-hand-side
+            group_match<subwarp_size>(
+                i_col_idxs + i_transposed_row_begin, i_transposed_row_size,
+                i_col_idxs + i_row_begin, i_row_size, subwarp,
+                [&](IndexType, IndexType m_idx, IndexType i_idx,
+                    config::lane_mask_type, bool valid) {
+                    rhs_one_idx += popcnt(subwarp.ballot(
+                        valid &&
+                        i_col_idxs[i_transposed_row_begin + m_idx] < row &&
+                        col == row));
                 });
         }
 

--- a/include/ginkgo/core/base/exception.hpp
+++ b/include/ginkgo/core/base/exception.hpp
@@ -683,6 +683,24 @@ public:
 };
 
 
+class InvalidStateError : public Error {
+public:
+    /**
+     * Initializes an invalid state error.
+     *
+     * @param file  The name of the offending source file
+     * @param line  The source code line number where the error occurred
+     * @param func  The function name where the error occurred
+     * @param clarification  A message describing the invalid state
+     */
+    InvalidStateError(const std::string& file, int line,
+                      const std::string& func, const std::string& clarification)
+        : Error(file, line,
+                func + ": Invalid state encountered : " + clarification)
+    {}
+};
+
+
 }  // namespace gko
 
 

--- a/include/ginkgo/core/base/exception_helpers.hpp
+++ b/include/ginkgo/core/base/exception_helpers.hpp
@@ -706,6 +706,16 @@ inline T ensure_allocated_impl(T ptr, const std::string& file, int line,
                   "semi-colon warnings")
 
 
+#define GKO_INVALID_STATE(_message)                                          \
+    {                                                                        \
+        throw ::gko::InvalidStateError(__FILE__, __LINE__, __func__,         \
+                                       _message);                            \
+    }                                                                        \
+    static_assert(true,                                                      \
+                  "This assert is used to counter the false positive extra " \
+                  "semi-colon warnings")
+
+
 }  // namespace gko
 
 

--- a/include/ginkgo/core/log/logger.hpp
+++ b/include/ginkgo/core/log/logger.hpp
@@ -422,6 +422,77 @@ protected:
                                            one_changed, all_converged);
     }
 
+public:
+    static constexpr size_type iteration_complete{21};
+    static constexpr mask_type iteration_complete_mask{mask_type{1} << 21};
+
+    template <size_type Event, typename... Params>
+    std::enable_if_t<Event == 21 && (21 < event_count_max)> on(
+        Params&&... params) const
+    {
+        if (enabled_events_ & (mask_type{1} << 21)) {
+            this->on_iteration_complete(std::forward<Params>(params)...);
+        }
+    }
+
+protected:
+    /**
+     * Register the `iteration_complete` event which logs every completed
+     * iterations.
+     *
+     * @param it  the current iteration count
+     * @param r  the residual
+     * @param x  the solution vector (optional)
+     * @param tau  the residual norm (optional)
+     *
+     * @warning This on_iteration_complete function that this macro declares is
+     * deprecated. Please use the version with the stopping information.
+     */
+    [[deprecated(
+        "Please use the version with the additional stopping "
+        "information.")]] virtual void
+    on_iteration_complete(const LinOp* solver, const size_type& it,
+                          const LinOp* r, const LinOp* x = nullptr,
+                          const LinOp* tau = nullptr) const
+    {}
+
+    /**
+     * Register the `iteration_complete` event which logs every completed
+     * iterations.
+     *
+     * @param it  the current iteration count
+     * @param r  the residual
+     * @param x  the solution vector (optional)
+     * @param tau  the residual norm (optional)
+     * @param implicit_tau_sq  the implicit residual norm squared (optional)
+     *
+     * @warning This on_iteration_complete function that this macro declares is
+     * deprecated. Please use the version with the stopping information.
+     */
+    [[deprecated(
+        "Please use the version with the additional stopping "
+        "information.")]] virtual void
+    on_iteration_complete(const LinOp* solver, const size_type& it,
+                          const LinOp* r, const LinOp* x, const LinOp* tau,
+                          const LinOp* implicit_tau_sq) const
+    {
+#if defined(__GNUC__) || defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable : 5211, 4973, 4974)
+#endif
+        this->on_iteration_complete(solver, it, r, x, tau);
+#if defined(__GNUC__) || defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif
+    }
+
     /**
      * Register the `iteration_complete` event which logs every completed
      * iterations.
@@ -437,56 +508,28 @@ protected:
      * @param stopped  whether all right hand sides have stopped (invalid if
      *                 status is not provided)
      */
-    GKO_LOGGER_REGISTER_EVENT(21, iteration_complete, const LinOp* solver,
-                              const LinOp* b, const LinOp* x,
-                              const size_type& it, const LinOp* r,
-                              const LinOp* tau, const LinOp* implicit_tau_sq,
-                              const array<stopping_status>* status,
-                              bool stopped)
-protected:
-    /**
-     * Register the `iteration_complete` event which logs every completed
-     * iterations.
-     *
-     * @param it  the current iteration count
-     * @param r  the residual
-     * @param x  the solution vector (optional)
-     * @param tau  the residual norm (optional)
-     *
-     * @note The on_iteration_complete function that this macro declares is
-     * deprecated. Please use the one with the additional implicit_tau_sq
-     * parameter as below.
-     */
-    [[deprecated(
-        "Please use the version with the additional implicit_tau_sq, status "
-        "and stopped parameter.")]] virtual void
-    on_iteration_complete(const LinOp* solver, const size_type& it,
-                          const LinOp* r, const LinOp* x = nullptr,
-                          const LinOp* tau = nullptr) const
+    virtual void on_iteration_complete(const LinOp* solver, const LinOp* b,
+                                       const LinOp* x, const size_type& it,
+                                       const LinOp* r, const LinOp* tau,
+                                       const LinOp* implicit_tau_sq,
+                                       const array<stopping_status>* status,
+                                       bool stopped) const
     {
-        this->on_iteration_complete(solver, nullptr, x, it, r, tau, nullptr,
-                                    nullptr, false);
-    }
-
-    /**
-     * Register the `iteration_complete` event which logs every completed
-     * iterations.
-     *
-     * @param it  the current iteration count
-     * @param r  the residual
-     * @param x  the solution vector (optional)
-     * @param tau  the residual norm (optional)
-     * @param implicit_tau_sq  the implicit residual norm squared (optional)
-     */
-    [[deprecated(
-        "Please use the version with the additional status and stopped "
-        "parameter.")]] virtual void
-    on_iteration_complete(const LinOp* solver, const size_type& it,
-                          const LinOp* r, const LinOp* x, const LinOp* tau,
-                          const LinOp* implicit_tau_sq) const
-    {
-        this->on_iteration_complete(solver, nullptr, x, it, r, tau,
-                                    implicit_tau_sq, nullptr, false);
+#if defined(__GNUC__) || defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable : 5211, 4973, 4974)
+#endif
+        this->on_iteration_complete(solver, it, r, x, tau, implicit_tau_sq);
+#if defined(__GNUC__) || defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif
     }
 
 public:

--- a/include/ginkgo/core/log/papi.hpp
+++ b/include/ginkgo/core/log/papi.hpp
@@ -188,12 +188,17 @@ public:
                                const array<stopping_status>* status,
                                bool stopped) const override;
 
-    void on_iteration_complete(
-        const LinOp* solver, const size_type& num_iterations,
-        const LinOp* residual, const LinOp* solution = nullptr,
-        const LinOp* residual_norm = nullptr) const override;
+    [[deprecated(
+        "Please use the version with the additional stopping "
+        "information.")]] void
+    on_iteration_complete(const LinOp* solver, const size_type& num_iterations,
+                          const LinOp* residual, const LinOp* solution,
+                          const LinOp* residual_norm) const override;
 
-    void on_iteration_complete(
+    [[deprecated(
+        "Please use the version with the additional stopping "
+        "information.")]] void
+    on_iteration_complete(
         const LinOp* solver, const size_type& num_iterations,
         const LinOp* residual, const LinOp* solution,
         const LinOp* residual_norm,

--- a/include/ginkgo/core/log/profiler_hook.hpp
+++ b/include/ginkgo/core/log/profiler_hook.hpp
@@ -187,6 +187,22 @@ public:
         const LinOp* implicit_sq_residual_norm,
         const array<stopping_status>* status, bool stopped) const override;
 
+    [[deprecated(
+        "Please use the version with the additional stopping "
+        "information.")]] void
+    on_iteration_complete(const LinOp* solver, const size_type& num_iterations,
+                          const LinOp* residual, const LinOp* solution,
+                          const LinOp* residual_norm) const override;
+
+    [[deprecated(
+        "Please use the version with the additional stopping "
+        "information.")]] void
+    on_iteration_complete(
+        const LinOp* solver, const size_type& num_iterations,
+        const LinOp* residual, const LinOp* solution,
+        const LinOp* residual_norm,
+        const LinOp* implicit_sq_residual_norm) const override;
+
     bool needs_propagation() const override;
 
     /**

--- a/include/ginkgo/core/log/record.hpp
+++ b/include/ginkgo/core/log/record.hpp
@@ -78,8 +78,10 @@ struct iteration_complete_data {
         : num_iterations{num_iterations}, all_stopped(all_stopped)
     {
         this->solver = solver->clone();
-        this->right_hand_side = right_hand_side->clone();
         this->solution = solution->clone();
+        if (right_hand_side != nullptr) {
+            this->right_hand_side = right_hand_side->clone();
+        }
         if (residual != nullptr) {
             this->residual = residual->clone();
         }
@@ -400,12 +402,17 @@ public:
         const LinOp* residual_norm, const LinOp* implicit_resnorm_sq,
         const array<stopping_status>* status, bool stopped) const override;
 
-    void on_iteration_complete(
-        const LinOp* solver, const size_type& num_iterations,
-        const LinOp* residual, const LinOp* solution = nullptr,
-        const LinOp* residual_norm = nullptr) const override;
+    [[deprecated(
+        "Please use the version with the additional stopping "
+        "information.")]] void
+    on_iteration_complete(const LinOp* solver, const size_type& num_iterations,
+                          const LinOp* residual, const LinOp* solution,
+                          const LinOp* residual_norm) const override;
 
-    void on_iteration_complete(
+    [[deprecated(
+        "Please use the version with the additional stopping "
+        "information.")]] void
+    on_iteration_complete(
         const LinOp* solver, const size_type& num_iterations,
         const LinOp* residual, const LinOp* solution,
         const LinOp* residual_norm,

--- a/include/ginkgo/core/log/stream.hpp
+++ b/include/ginkgo/core/log/stream.hpp
@@ -164,6 +164,22 @@ public:
                                const array<stopping_status>* status,
                                bool stopped) const override;
 
+    [[deprecated(
+        "Please use the version with the additional stopping "
+        "information.")]] void
+    on_iteration_complete(const LinOp* solver, const size_type& num_iterations,
+                          const LinOp* residual, const LinOp* solution,
+                          const LinOp* residual_norm) const override;
+
+    [[deprecated(
+        "Please use the version with the additional stopping "
+        "information.")]] void
+    on_iteration_complete(
+        const LinOp* solver, const size_type& num_iterations,
+        const LinOp* residual, const LinOp* solution,
+        const LinOp* residual_norm,
+        const LinOp* implicit_sq_residual_norm) const override;
+
     /**
      * Creates a Stream logger. This dynamically allocates the memory,
      * constructs the object and returns an std::unique_ptr to this object.

--- a/include/ginkgo/core/preconditioner/isai.hpp
+++ b/include/ginkgo/core/preconditioner/isai.hpp
@@ -212,6 +212,9 @@ public:
          */
         std::shared_ptr<LinOpFactory> GKO_FACTORY_PARAMETER_SCALAR(
             excess_solver_factory, nullptr);
+
+        gko::remove_complex<value_type> GKO_FACTORY_PARAMETER_SCALAR(
+            excess_solver_reduction, 1e-6);
     };
 
     GKO_ENABLE_LIN_OP_FACTORY(Isai, parameters, Factory);
@@ -240,7 +243,8 @@ protected:
         const auto skip_sorting = parameters_.skip_sorting;
         const auto power = parameters_.sparsity_power;
         const auto excess_limit = parameters_.excess_limit;
-        generate_inverse(system_matrix, skip_sorting, power, excess_limit);
+        generate_inverse(system_matrix, skip_sorting, power, excess_limit,
+                         parameters_.excess_solver_reduction);
         if (IsaiType == isai_type::spd) {
             auto inv = share(as<Csr>(approximate_inverse_));
             auto inv_transp = share(inv->conj_transpose());
@@ -271,9 +275,10 @@ private:
      * @param skip_sorting  dictates if the sorting of the input matrix should
      *                      be skipped.
      */
-    void generate_inverse(std::shared_ptr<const LinOp> to_invert,
-                          bool skip_sorting, int power,
-                          index_type excess_limit);
+    void generate_inverse(
+        std::shared_ptr<const LinOp> to_invert, bool skip_sorting, int power,
+        index_type excess_limit,
+        gko::remove_complex<value_type> excess_solver_reduction);
 
 private:
     std::shared_ptr<LinOp> approximate_inverse_;

--- a/include/ginkgo/core/preconditioner/isai.hpp
+++ b/include/ginkgo/core/preconditioner/isai.hpp
@@ -213,9 +213,7 @@ public:
         std::shared_ptr<LinOpFactory> GKO_FACTORY_PARAMETER_SCALAR(
             excess_solver_factory, nullptr);
 
-        gko::remove_complex<value_type> GKO_FACTORY_PARAMETER_SCALAR(
-            excess_solver_reduction,
-            static_cast<gko::remove_complex<value_type>>(1e-6));
+        double GKO_FACTORY_PARAMETER_SCALAR(excess_solver_reduction, 1e-6);
     };
 
     GKO_ENABLE_LIN_OP_FACTORY(Isai, parameters, Factory);
@@ -245,7 +243,8 @@ protected:
         const auto power = parameters_.sparsity_power;
         const auto excess_limit = parameters_.excess_limit;
         generate_inverse(system_matrix, skip_sorting, power, excess_limit,
-                         parameters_.excess_solver_reduction);
+                         static_cast<remove_complex<value_type>>(
+                             parameters_.excess_solver_reduction));
         if (IsaiType == isai_type::spd) {
             auto inv = share(as<Csr>(approximate_inverse_));
             auto inv_transp = share(inv->conj_transpose());

--- a/include/ginkgo/core/preconditioner/isai.hpp
+++ b/include/ginkgo/core/preconditioner/isai.hpp
@@ -213,7 +213,9 @@ public:
         std::shared_ptr<LinOpFactory> GKO_FACTORY_PARAMETER_SCALAR(
             excess_solver_factory, nullptr);
 
-        double GKO_FACTORY_PARAMETER_SCALAR(excess_solver_reduction, 1e-6);
+        remove_complex<value_type> GKO_FACTORY_PARAMETER_SCALAR(
+            excess_solver_reduction,
+            static_cast<remove_complex<value_type>>(1e-6));
     };
 
     GKO_ENABLE_LIN_OP_FACTORY(Isai, parameters, Factory);
@@ -275,10 +277,9 @@ private:
      * @param skip_sorting  dictates if the sorting of the input matrix should
      *                      be skipped.
      */
-    void generate_inverse(
-        std::shared_ptr<const LinOp> to_invert, bool skip_sorting, int power,
-        index_type excess_limit,
-        gko::remove_complex<value_type> excess_solver_reduction);
+    void generate_inverse(std::shared_ptr<const LinOp> to_invert,
+                          bool skip_sorting, int power, index_type excess_limit,
+                          remove_complex<value_type> excess_solver_reduction);
 
 private:
     std::shared_ptr<LinOp> approximate_inverse_;

--- a/include/ginkgo/core/preconditioner/isai.hpp
+++ b/include/ginkgo/core/preconditioner/isai.hpp
@@ -214,7 +214,8 @@ public:
             excess_solver_factory, nullptr);
 
         gko::remove_complex<value_type> GKO_FACTORY_PARAMETER_SCALAR(
-            excess_solver_reduction, 1e-6);
+            excess_solver_reduction,
+            static_cast<gko::remove_complex<value_type>>(1e-6));
     };
 
     GKO_ENABLE_LIN_OP_FACTORY(Isai, parameters, Factory);

--- a/include/ginkgo/core/solver/solver_base.hpp
+++ b/include/ginkgo/core/solver/solver_base.hpp
@@ -789,8 +789,10 @@ public:
         std::shared_ptr<const stop::CriterionFactory> new_stop_factory) override
     {
         auto exec = self()->get_executor();
-        if (new_stop_factory && new_stop_factory->get_executor() != exec) {
-            new_stop_factory = gko::clone(exec, new_stop_factory);
+        if (new_stop_factory && new_stop_factory->get_executor() != exec &&
+            !exec->memory_accessible(new_stop_factory->get_executor())) {
+            GKO_INVALID_STATE(
+                "Cross-executor assignment of factories is currently broken.");
         }
         IterativeBase::set_stop_criterion_factory(new_stop_factory);
     }

--- a/include/ginkgo/core/solver/solver_base.hpp
+++ b/include/ginkgo/core/solver/solver_base.hpp
@@ -789,10 +789,8 @@ public:
         std::shared_ptr<const stop::CriterionFactory> new_stop_factory) override
     {
         auto exec = self()->get_executor();
-        if (new_stop_factory && new_stop_factory->get_executor() != exec &&
-            !exec->memory_accessible(new_stop_factory->get_executor())) {
-            GKO_INVALID_STATE(
-                "Cross-executor assignment of factories is currently broken.");
+        if (new_stop_factory && new_stop_factory->get_executor() != exec) {
+            new_stop_factory = gko::clone(exec, new_stop_factory);
         }
         IterativeBase::set_stop_criterion_factory(new_stop_factory);
     }

--- a/include/ginkgo/core/stop/combined.hpp
+++ b/include/ginkgo/core/stop/combined.hpp
@@ -56,8 +56,10 @@ class Combined : public EnablePolymorphicObject<Combined, Criterion> {
     friend class EnablePolymorphicObject<Combined, Criterion>;
 
 public:
-    GKO_CREATE_FACTORY_PARAMETERS(parameters, Factory)
-    {
+    class Factory;
+
+    struct parameters_type
+        : public ::gko::enable_parameters_type<parameters_type, Factory> {
         /**
          * Criterion factories to combine
          *
@@ -70,35 +72,48 @@ public:
         std::vector<std::shared_ptr<const CriterionFactory>>
             GKO_FACTORY_PARAMETER_VECTOR(criteria, nullptr);
     };
-    GKO_ENABLE_CRITERION_FACTORY(Combined, parameters, Factory);
-    GKO_ENABLE_BUILD_METHOD(Factory);
+
+    class Factory
+        : public ::gko::stop::EnableDefaultCriterionFactory<Factory, Combined,
+                                                            parameters_type> {
+        friend class ::gko::EnablePolymorphicObject<
+            Factory, ::gko::stop::CriterionFactory>;
+        friend class ::gko::enable_parameters_type<parameters_type, Factory>;
+
+        using Base =
+            ::gko::stop::EnableDefaultCriterionFactory<Factory, Combined,
+                                                       parameters_type>;
+
+    public:
+        explicit Factory(std::shared_ptr<const ::gko::Executor> exec);
+        explicit Factory(std::shared_ptr<const ::gko::Executor> exec,
+                         const parameters_type& parameters);
+
+        Factory(const Factory& other) = default;
+        Factory(Factory&& other) = default;
+
+        Factory& operator=(const Factory& other);
+    };
+
+    static parameters_type build() { return {}; }
+
+    const parameters_type& get_parameters() const { return parameters_; }
 
 protected:
     bool check_impl(uint8 stoppingId, bool setFinalized,
                     array<stopping_status>* stop_status, bool* one_changed,
                     const Updater&) override;
 
-    explicit Combined(std::shared_ptr<const gko::Executor> exec)
-        : EnablePolymorphicObject<Combined, Criterion>(std::move(exec))
-    {}
+    explicit Combined(std::shared_ptr<const gko::Executor> exec);
 
-    explicit Combined(const Factory* factory, const CriterionArgs& args)
-        : EnablePolymorphicObject<Combined, Criterion>(factory->get_executor()),
-          parameters_{factory->get_parameters()}
-    {
-        for (const auto& f : parameters_.criteria) {
-            // Ignore the nullptr from the list
-            if (f != nullptr) {
-                criteria_.push_back(f->generate(args));
-            }
-        }
-        // If the list are empty or all nullptr, throw gko::NotSupported
-        if (criteria_.size() == 0) {
-            GKO_NOT_SUPPORTED(this);
-        }
-    }
+    explicit Combined(const Factory* factory, const CriterionArgs& args);
 
 private:
+    friend ::gko::stop::EnableDefaultCriterionFactory<Factory, Combined,
+                                                      parameters_type>;
+
+    parameters_type parameters_;
+
     std::vector<std::unique_ptr<Criterion>> criteria_{};
 };
 

--- a/omp/preconditioner/isai_kernels.cpp
+++ b/omp/preconditioner/isai_kernels.cpp
@@ -148,18 +148,30 @@ void generic_generate(std::shared_ptr<const DefaultExecutor> exec,
                     const auto col = i_cols[i_begin + i];
                     const auto m_begin = m_row_ptrs[col];
                     const auto m_size = m_row_ptrs[col + 1] - m_begin;
+                    // Loop over all matches that are within the sparsity
+                    // pattern of the original matrix
                     forall_matching(
                         m_cols + m_begin, m_size, i_cols + i_begin, i_size,
                         [&](IndexType, IndexType m_idx, IndexType i_idx) {
-                            if (m_cols[m_idx + m_begin] < row && col == row) {
-                                rhs_one_idx++;
-                            }
                             if (tri) {
                                 dense_system(i, i_idx) =
                                     m_vals[m_idx + m_begin];
                             } else {
                                 dense_system(i_idx, i) =
                                     m_vals[m_idx + m_begin];
+                            }
+                        });
+                    const auto i_col_begin = i_row_ptrs[col];
+                    const auto i_col_size = i_row_ptrs[col + 1] - i_col_begin;
+                    // Loop over all matches that are within the sparsity
+                    // pattern of the inverse
+                    forall_matching(
+                        i_cols + i_col_begin, i_col_size, i_cols + i_begin,
+                        i_size,
+                        [&](IndexType, IndexType m_idx, IndexType i_idx) {
+                            if (i_cols[m_idx + i_col_begin] < row &&
+                                col == row) {
+                                rhs_one_idx++;
                             }
                         });
                 }

--- a/reference/test/preconditioner/isai_kernels.cpp
+++ b/reference/test/preconditioner/isai_kernels.cpp
@@ -1579,4 +1579,25 @@ TYPED_TEST(Isai, ReturnsConjTransposedCorrectInverseSpd)
 }
 
 
+TYPED_TEST(Isai, IsExactInverseOnFullSparsitySet)
+{
+    using Isai = typename TestFixture::GeneralIsai;
+    using Csr = typename TestFixture::Csr;
+    using value_type = typename TestFixture::value_type;
+    auto mtx = gko::share(gko::initialize<Csr>(
+        {{2, -1, 0, 0}, {-1, 2, -1, 0}, {0, -1, 2, -1}, {0, 0, -1, 2}},
+        this->exec));
+    auto inv_mtx = gko::initialize<Csr>({{4 / 5., 3 / 5., 2 / 5., 1 / 5.},
+                                         {3 / 5., 6 / 5., 4 / 5., 2 / 5.},
+                                         {2 / 5., 4 / 5., 6 / 5., 3 / 5.},
+                                         {1 / 5., 2 / 5., 3 / 5., 4 / 5.}},
+                                        this->exec);
+
+    auto isai =
+        Isai::build().with_sparsity_power(3).on(this->exec)->generate(mtx);
+
+    GKO_ASSERT_MTX_NEAR(inv_mtx, isai->get_approximate_inverse(),
+                        r<value_type>::value);
+}
+
 }  // namespace

--- a/reference/test/preconditioner/isai_kernels.cpp
+++ b/reference/test/preconditioner/isai_kernels.cpp
@@ -1622,4 +1622,5 @@ TYPED_TEST(Isai, IsExactInverseOnFullSparsitySetLarge)
                         5 * r<value_type>::value);
 }
 
+
 }  // namespace

--- a/test/preconditioner/isai_kernels.cpp
+++ b/test/preconditioner/isai_kernels.cpp
@@ -663,7 +663,6 @@ TEST_F(Isai, IsaiGenerateGeneralWithSparsityPower8IsEquivalentToRef)
 
     auto isai =
         Isai::build().with_sparsity_power(8).on(ref)->generate(mtx->clone());
-
     auto d_isai =
         Isai::build().with_sparsity_power(8).on(exec)->generate(d_mtx->clone());
 
@@ -671,6 +670,7 @@ TEST_F(Isai, IsaiGenerateGeneralWithSparsityPower8IsEquivalentToRef)
                         d_isai->get_approximate_inverse(),
                         r<value_type>::value);
 }
+
 
 TEST_F(Isai, IsaiGenerateGeneralSparsityPowerNIsEquivalentToRef)
 {
@@ -684,7 +684,6 @@ TEST_F(Isai, IsaiGenerateGeneralSparsityPowerNIsEquivalentToRef)
                     .with_excess_solver_reduction(r<value_type>::value)
                     .on(ref)
                     ->generate(mtx->clone());
-
     auto d_isai =
         Isai::build()
             .with_sparsity_power(static_cast<int>(d_mtx->get_size()[0]))

--- a/test/preconditioner/isai_kernels.cpp
+++ b/test/preconditioner/isai_kernels.cpp
@@ -668,7 +668,7 @@ TEST_F(Isai, IsaiGenerateGeneralWithSparsityPower8IsEquivalentToRef)
 
     GKO_ASSERT_MTX_NEAR(isai->get_approximate_inverse(),
                         d_isai->get_approximate_inverse(),
-                        r<value_type>::value);
+                        5 * r<value_type>::value);
 }
 
 
@@ -693,5 +693,5 @@ TEST_F(Isai, IsaiGenerateGeneralSparsityPowerNIsEquivalentToRef)
 
     GKO_ASSERT_MTX_NEAR(isai->get_approximate_inverse(),
                         d_isai->get_approximate_inverse(),
-                        5 * r<value_type>::value);
+                        10 * r<value_type>::value);
 }

--- a/test/preconditioner/isai_kernels.cpp
+++ b/test/preconditioner/isai_kernels.cpp
@@ -108,6 +108,20 @@ protected:
         d_inverse = gko::clone(exec, inverse);
     }
 
+    void initialize_tridiag_data(matrix_type type, gko::size_type n)
+    {
+        auto val_dist = std::uniform_real_distribution<value_type>(0., 1.);
+        mtx = Csr::create(ref);
+        auto dense_mtx = gko::test::generate_random_band_matrix<Dense>(
+            n, 1, 1, val_dist, rand_engine, ref);
+        ensure_diagonal(dense_mtx.get());
+        mtx->copy_from(dense_mtx);
+        inverse = clone_allocations(mtx.get());
+
+        d_mtx = gko::clone(exec, mtx);
+        d_inverse = gko::clone(exec, inverse);
+    }
+
     void ensure_diagonal(Dense* mtx)
     {
         for (int i = 0; i < mtx->get_size()[0]; ++i) {
@@ -637,4 +651,48 @@ TEST_F(Isai, IsaiScatterPartialExcessSolutionIsEquivalentToRef)
 
     GKO_ASSERT_MTX_NEAR(inverse, d_inverse, 0);
     ASSERT_GT(e_dim, 0);
+}
+
+
+TEST_F(Isai, IsaiGenerateGeneralWithSparsityPower8IsEquivalentToRef)
+{
+    using Isai =
+        gko::preconditioner::Isai<gko::preconditioner::isai_type::general,
+                                  value_type, index_type>;
+    initialize_tridiag_data(matrix_type::general, 65);
+
+    auto isai =
+        Isai::build().with_sparsity_power(8).on(ref)->generate(mtx->clone());
+
+    auto d_isai =
+        Isai::build().with_sparsity_power(8).on(exec)->generate(d_mtx->clone());
+
+    GKO_ASSERT_MTX_NEAR(isai->get_approximate_inverse(),
+                        d_isai->get_approximate_inverse(),
+                        r<value_type>::value);
+}
+
+TEST_F(Isai, IsaiGenerateGeneralSparsityPowerNIsEquivalentToRef)
+{
+    using Isai =
+        gko::preconditioner::Isai<gko::preconditioner::isai_type::general,
+                                  value_type, index_type>;
+    initialize_tridiag_data(matrix_type::general, 65);
+
+    auto isai = Isai::build()
+                    .with_sparsity_power(static_cast<int>(mtx->get_size()[0]))
+                    .with_excess_solver_reduction(r<value_type>::value)
+                    .on(ref)
+                    ->generate(mtx->clone());
+
+    auto d_isai =
+        Isai::build()
+            .with_sparsity_power(static_cast<int>(d_mtx->get_size()[0]))
+            .with_excess_solver_reduction(r<value_type>::value)
+            .on(exec)
+            ->generate(d_mtx->clone());
+
+    GKO_ASSERT_MTX_NEAR(isai->get_approximate_inverse(),
+                        d_isai->get_approximate_inverse(),
+                        5 * r<value_type>::value);
 }

--- a/test/solver/solver.cpp
+++ b/test/solver/solver.cpp
@@ -1029,10 +1029,6 @@ TYPED_TEST(Solver, CrossExecutorGenerateCopiesToFactoryExecutor)
 {
     using Config = typename TestFixture::Config;
     using Mtx = typename TestFixture::Mtx;
-    if (!this->ref->memory_accessible(this->exec) && Config::is_iterative()) {
-        GTEST_SKIP() << "Skipping cross-executor copy assign for type that "
-                        "stores a factory.";
-    }
     this->forall_matrix_scenarios([this](auto mtx) {
         auto solver =
             Config::build(this->ref, 0).on(this->exec)->generate(mtx.ref);
@@ -1053,25 +1049,6 @@ TYPED_TEST(Solver, CrossExecutorGenerateCopiesToFactoryExecutor)
         }
         GKO_ASSERT_MTX_NEAR(gko::as<Mtx>(solver->get_system_matrix()), mtx.ref,
                             0.0);
-    });
-}
-
-
-TYPED_TEST(Solver, CrossExecutorCloneThrows)
-{
-    using Config = typename TestFixture::Config;
-    using Mtx = typename TestFixture::Mtx;
-    this->forall_matrix_scenarios([this](auto mtx) {
-        auto solver =
-            Config::build(this->ref, 0).on(this->ref)->generate(mtx.ref);
-
-        if (Config::is_iterative() &&
-            !this->ref->memory_accessible(this->exec)) {
-            ASSERT_THROW(gko::clone(this->exec, solver),
-                         gko::InvalidStateError);
-        } else {
-            ASSERT_NO_THROW(gko::clone(this->exec, solver));
-        }
     });
 }
 
@@ -1137,10 +1114,6 @@ TYPED_TEST(Solver, CopyAssignCrossExecutor)
     using Config = typename TestFixture::Config;
     using Mtx = typename TestFixture::Mtx;
     using Precond = typename TestFixture::Precond;
-    if (!this->ref->memory_accessible(this->exec) && Config::is_iterative()) {
-        GTEST_SKIP() << "Skipping cross-executor copy assign for type that "
-                        "stores a factory.";
-    }
     this->forall_matrix_scenarios([this](auto mtx) {
         this->forall_solver_scenarios(mtx, [this](auto solver) {
             auto solver2 = Config::build(this->exec, 0)
@@ -1176,10 +1149,6 @@ TYPED_TEST(Solver, MoveAssignCrossExecutor)
     using Config = typename TestFixture::Config;
     using Mtx = typename TestFixture::Mtx;
     using Precond = typename TestFixture::Precond;
-    if (!this->ref->memory_accessible(this->exec) && Config::is_iterative()) {
-        GTEST_SKIP() << "Skipping cross-executor move assign for type that "
-                        "stores a factory.";
-    }
     this->forall_matrix_scenarios([this](auto in_mtx) {
         this->forall_solver_scenarios(in_mtx, [this](auto solver) {
             auto solver2 = Config::build(this->exec, 0)

--- a/test/solver/solver.cpp
+++ b/test/solver/solver.cpp
@@ -958,7 +958,8 @@ TYPED_TEST(Solver, ApplyDoesntAllocateRepeatedly)
 {
     this->check_residual = false;
     if (!TypeParam::will_not_allocate()) {
-        GTEST_SKIP();
+        GTEST_SKIP()
+            << "Skipping allocation test for types that will not allocate";
     }
     this->forall_matrix_scenarios([this](auto mtx) {
         this->forall_vector_and_solver_scenarios(
@@ -1029,7 +1030,8 @@ TYPED_TEST(Solver, CrossExecutorGenerateCopiesToFactoryExecutor)
     using Config = typename TestFixture::Config;
     using Mtx = typename TestFixture::Mtx;
     if (!this->ref->memory_accessible(this->exec) && Config::is_iterative()) {
-        GTEST_SKIP();
+        GTEST_SKIP() << "Skipping cross-executor copy assign for type that "
+                        "stores a factory.";
     }
     this->forall_matrix_scenarios([this](auto mtx) {
         auto solver =
@@ -1136,7 +1138,8 @@ TYPED_TEST(Solver, CopyAssignCrossExecutor)
     using Mtx = typename TestFixture::Mtx;
     using Precond = typename TestFixture::Precond;
     if (!this->ref->memory_accessible(this->exec) && Config::is_iterative()) {
-        GTEST_SKIP();
+        GTEST_SKIP() << "Skipping cross-executor copy assign for type that "
+                        "stores a factory.";
     }
     this->forall_matrix_scenarios([this](auto mtx) {
         this->forall_solver_scenarios(mtx, [this](auto solver) {
@@ -1174,7 +1177,8 @@ TYPED_TEST(Solver, MoveAssignCrossExecutor)
     using Mtx = typename TestFixture::Mtx;
     using Precond = typename TestFixture::Precond;
     if (!this->ref->memory_accessible(this->exec) && Config::is_iterative()) {
-        GTEST_SKIP();
+        GTEST_SKIP() << "Skipping cross-executor move assign for type that "
+                        "stores a factory.";
     }
     this->forall_matrix_scenarios([this](auto in_mtx) {
         this->forall_solver_scenarios(in_mtx, [this](auto solver) {

--- a/test/solver/solver.cpp
+++ b/test/solver/solver.cpp
@@ -1028,6 +1028,9 @@ TYPED_TEST(Solver, CrossExecutorGenerateCopiesToFactoryExecutor)
 {
     using Config = typename TestFixture::Config;
     using Mtx = typename TestFixture::Mtx;
+    if (!this->ref->memory_accessible(this->exec) && Config::is_iterative()) {
+        GTEST_SKIP();
+    }
     this->forall_matrix_scenarios([this](auto mtx) {
         auto solver =
             Config::build(this->ref, 0).on(this->exec)->generate(mtx.ref);
@@ -1048,6 +1051,25 @@ TYPED_TEST(Solver, CrossExecutorGenerateCopiesToFactoryExecutor)
         }
         GKO_ASSERT_MTX_NEAR(gko::as<Mtx>(solver->get_system_matrix()), mtx.ref,
                             0.0);
+    });
+}
+
+
+TYPED_TEST(Solver, CrossExecutorCloneThrows)
+{
+    using Config = typename TestFixture::Config;
+    using Mtx = typename TestFixture::Mtx;
+    this->forall_matrix_scenarios([this](auto mtx) {
+        auto solver =
+            Config::build(this->ref, 0).on(this->ref)->generate(mtx.ref);
+
+        if (Config::is_iterative() &&
+            !this->ref->memory_accessible(this->exec)) {
+            ASSERT_THROW(gko::clone(this->exec, solver),
+                         gko::InvalidStateError);
+        } else {
+            ASSERT_NO_THROW(gko::clone(this->exec, solver));
+        }
     });
 }
 
@@ -1113,6 +1135,9 @@ TYPED_TEST(Solver, CopyAssignCrossExecutor)
     using Config = typename TestFixture::Config;
     using Mtx = typename TestFixture::Mtx;
     using Precond = typename TestFixture::Precond;
+    if (!this->ref->memory_accessible(this->exec) && Config::is_iterative()) {
+        GTEST_SKIP();
+    }
     this->forall_matrix_scenarios([this](auto mtx) {
         this->forall_solver_scenarios(mtx, [this](auto solver) {
             auto solver2 = Config::build(this->exec, 0)
@@ -1148,6 +1173,9 @@ TYPED_TEST(Solver, MoveAssignCrossExecutor)
     using Config = typename TestFixture::Config;
     using Mtx = typename TestFixture::Mtx;
     using Precond = typename TestFixture::Precond;
+    if (!this->ref->memory_accessible(this->exec) && Config::is_iterative()) {
+        GTEST_SKIP();
+    }
     this->forall_matrix_scenarios([this](auto in_mtx) {
         this->forall_solver_scenarios(in_mtx, [this](auto solver) {
             auto solver2 = Config::build(this->exec, 0)

--- a/test/solver/solver.cpp
+++ b/test/solver/solver.cpp
@@ -703,6 +703,9 @@ protected:
             pair.dev->clear();
             guarded_fn(std::move(pair));
         }
+        /* Disable the test with clone, since cloning is not correctly supported
+         * for types that contain factories as members.
+         * TODO: reenable when cloning of factories is figured out
         {
             SCOPED_TRACE("Unpreconditioned solver with 0 iterations via clone");
             guarded_fn(
@@ -711,6 +714,7 @@ protected:
                                           ->generate(mtx.ref),
                                       exec});
         }
+        */
         {
             SCOPED_TRACE("Unpreconditioned solver with 0 iterations");
             guarded_fn(

--- a/test/solver/solver.cpp
+++ b/test/solver/solver.cpp
@@ -837,10 +837,10 @@ protected:
                        gen_out_vec<VecType>(op, 1, 1));
         }
         if (Config::is_iterative() &&
-            op.ref->get_size() == mtx.ref->get_size()) {
+            op.ref->get_size() == gko::transpose(mtx.ref->get_size())) {
             SCOPED_TRACE("Single vector with correct initial guess");
-            auto in = gen_in_vec<VecType>(mtx, 1, 1);
-            auto out = gen_out_vec<VecType>(mtx, 1, 1);
+            auto in = gen_in_vec<VecType>(op, 1, 1);
+            auto out = gen_out_vec<VecType>(op, 1, 1);
             mtx.ref->apply(out.ref, in.ref);
             mtx.dev->apply(out.dev, in.dev);
             guarded_fn(std::move(in), std::move(out));

--- a/test/stop/CMakeLists.txt
+++ b/test/stop/CMakeLists.txt
@@ -1,2 +1,3 @@
 ginkgo_create_common_test(criterion_kernels)
+ginkgo_create_common_test(combined_kernels)
 ginkgo_create_common_test(residual_norm_kernels)

--- a/test/stop/combined_kernels.cpp
+++ b/test/stop/combined_kernels.cpp
@@ -1,0 +1,84 @@
+/*******************************<GINKGO LICENSE>******************************
+Copyright (c) 2017-2023, the Ginkgo authors
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+******************************<GINKGO LICENSE>*******************************/
+
+#include <gtest/gtest.h>
+
+
+#include <ginkgo/core/stop/combined.hpp>
+#include <ginkgo/core/stop/iteration.hpp>
+
+
+#include "test/utils/executor.hpp"
+
+
+constexpr gko::size_type test_iterations = 10;
+
+
+class Combined : public CommonTestFixture {
+protected:
+    Combined()
+    {
+        // Actually use an iteration stopping criterion because Criterion is an
+        // abstract class
+        factory = gko::stop::Combined::build()
+                      .with_criteria(gko::stop::Iteration::build().on(ref),
+                                     gko::stop::Iteration::build().on(ref),
+                                     gko::stop::Iteration::build().on(ref))
+                      .on(ref);
+    }
+
+    std::unique_ptr<gko::stop::Combined::Factory> factory;
+};
+
+
+TEST_F(Combined, CopyPropagatesExecutor)
+{
+    auto dev_factory = gko::clone(exec, factory.get());
+
+    for (const auto& c : dev_factory->get_parameters().criteria) {
+        ASSERT_TRUE(c->get_executor());
+        ASSERT_EQ(exec.get(), c->get_executor().get());
+    }
+}
+
+
+TEST_F(Combined, MovePropagatesExecutor)
+{
+    auto dev_factory = factory->create_default(exec);
+
+    dev_factory->move_from(factory);
+
+    for (const auto& c : dev_factory->get_parameters().criteria) {
+        ASSERT_TRUE(c->get_executor());
+        ASSERT_EQ(exec.get(), c->get_executor().get());
+    }
+}


### PR DESCRIPTION
Fixes:

- #1250 at one point during the computation, the sparsity pattern of the original matrix was used, but it should have been the sparsity pattern of the approximate inverse.
- #1025 re-enables the test, but does not fix the underlying issue of breakdowns. This is handled in a different PR.
- Fixes backward compatibility of the new iteration complete event.
- Adds fallback coarse solver for DPCPP