### PR TITLE
Relax METIS requirements for shared builds and update version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@ if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.18)
     cmake_policy(SET CMP0104 OLD)
 endif()
 
-project(Ginkgo LANGUAGES C CXX VERSION 1.5.0 DESCRIPTION "A numerical linear algebra library targeting many-core architectures")
+project(Ginkgo LANGUAGES C CXX VERSION 1.6.0 DESCRIPTION "A numerical linear algebra library targeting many-core architectures")
 set(Ginkgo_VERSION_TAG "develop")
 set(PROJECT_VERSION_TAG ${Ginkgo_VERSION_TAG})
 

--- a/cmake/GinkgoConfig.cmake.in
+++ b/cmake/GinkgoConfig.cmake.in
@@ -200,7 +200,7 @@ if(GINKGO_HAVE_VTUNE)
     find_package(VTune REQUIRED)
 endif()
 
-if(GINKGO_HAVE_METIS)
+if((NOT GINKGO_BUILD_SHARED_LIBS) AND GINKGO_HAVE_METIS)
     find_package(METIS REQUIRED)
 endif()
 

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -113,15 +113,15 @@ if(GINKGO_HAVE_PAPI_SDE)
 endif()
 
 if(GINKGO_HAVE_TAU)
-    target_link_libraries(ginkgo PUBLIC perfstubs)
+    target_link_libraries(ginkgo PRIVATE perfstubs)
 endif()
 
 if(GINKGO_HAVE_VTUNE)
-    target_link_libraries(ginkgo PUBLIC VTune::ITT)
+    target_link_libraries(ginkgo PRIVATE VTune::ITT)
 endif()
 
 if(GINKGO_HAVE_METIS)
-    target_link_libraries(ginkgo PUBLIC METIS::METIS)
+    target_link_libraries(ginkgo PRIVATE METIS::METIS)
 endif()
 
 if(GINKGO_BUILD_MPI)

--- a/core/reorder/nested_dissection.cpp
+++ b/core/reorder/nested_dissection.cpp
@@ -37,15 +37,13 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
 #include <ginkgo/core/base/executor.hpp>
+#include <ginkgo/core/base/temporary_clone.hpp>
 #include <ginkgo/core/matrix/sparsity_csr.hpp>
 
 
 #if GKO_HAVE_METIS
 #include GKO_METIS_HEADER
 #endif
-
-
-#include <ginkgo/core/base/temporary_clone.hpp>
 
 
 #include "core/base/allocator.hpp"

--- a/examples/adaptiveprecision-blockjacobi/CMakeLists.txt
+++ b/examples/adaptiveprecision-blockjacobi/CMakeLists.txt
@@ -3,7 +3,7 @@ project(adaptiveprecision-blockjacobi)
 
 # We only need to find Ginkgo if we build this example stand-alone
 if (NOT GINKGO_BUILD_EXAMPLES)
-    find_package(Ginkgo 1.5.0 REQUIRED)
+    find_package(Ginkgo 1.6.0 REQUIRED)
 endif()
 
 add_executable(adaptiveprecision-blockjacobi adaptiveprecision-blockjacobi.cpp)

--- a/examples/build-setup.sh
+++ b/examples/build-setup.sh
@@ -3,7 +3,7 @@
 # copy libraries
 LIBRARY_NAMES="ginkgo ginkgo_reference ginkgo_omp ginkgo_cuda ginkgo_hip ginkgo_dpcpp ginkgo_device"
 SUFFIXES=".so .dylib .dll d.so d.dylib d.dll"
-VERSION="1.5.0"
+VERSION="1.6.0"
 for name in ${LIBRARY_NAMES}; do
     for suffix in ${SUFFIXES}; do
         cp ${BUILD_DIR}/lib/lib${name}${suffix}.${VERSION} \

--- a/examples/cb-gmres/CMakeLists.txt
+++ b/examples/cb-gmres/CMakeLists.txt
@@ -3,7 +3,7 @@ project(cb-gmres)
 
 # We only need to find Ginkgo if we build this example stand-alone
 if (NOT GINKGO_BUILD_EXAMPLES)
-    find_package(Ginkgo 1.5.0 REQUIRED)
+    find_package(Ginkgo 1.6.0 REQUIRED)
 endif()
 
 add_executable(cb-gmres cb-gmres.cpp)

--- a/examples/custom-logger/CMakeLists.txt
+++ b/examples/custom-logger/CMakeLists.txt
@@ -3,7 +3,7 @@ project(custom-logger)
 
 # We only need to find Ginkgo if we build this example stand-alone
 if (NOT GINKGO_BUILD_EXAMPLES)
-    find_package(Ginkgo 1.5.0 REQUIRED)
+    find_package(Ginkgo 1.6.0 REQUIRED)
 endif()
 
 add_executable(custom-logger custom-logger.cpp)

--- a/examples/custom-matrix-format/CMakeLists.txt
+++ b/examples/custom-matrix-format/CMakeLists.txt
@@ -3,7 +3,7 @@ project(custom-matrix-format CXX CUDA)
 
 # We only need to find Ginkgo if we build this example stand-alone
 if (NOT GINKGO_BUILD_EXAMPLES)
-    find_package(Ginkgo 1.5.0 REQUIRED)
+    find_package(Ginkgo 1.6.0 REQUIRED)
     find_package(OpenMP 3.0 REQUIRED)
 endif()
 

--- a/examples/custom-stopping-criterion/CMakeLists.txt
+++ b/examples/custom-stopping-criterion/CMakeLists.txt
@@ -3,7 +3,7 @@ project(custom-stopping-criterion)
 
 # We only need to find Ginkgo if we build this example stand-alone
 if (NOT GINKGO_BUILD_EXAMPLES)
-    find_package(Ginkgo 1.5.0 REQUIRED)
+    find_package(Ginkgo 1.6.0 REQUIRED)
     set(THREADS_PREFER_PTHREAD_FLAG ON)
     find_package(Threads REQUIRED)
 endif()

--- a/examples/ginkgo-overhead/CMakeLists.txt
+++ b/examples/ginkgo-overhead/CMakeLists.txt
@@ -3,7 +3,7 @@ project(ginkgo-overhead)
 
 # We only need to find Ginkgo if we build this example stand-alone
 if (NOT GINKGO_BUILD_EXAMPLES)
-    find_package(Ginkgo 1.5.0 REQUIRED)
+    find_package(Ginkgo 1.6.0 REQUIRED)
 endif()
 
 add_executable(ginkgo-overhead ginkgo-overhead.cpp)

--- a/examples/ginkgo-ranges/CMakeLists.txt
+++ b/examples/ginkgo-ranges/CMakeLists.txt
@@ -3,7 +3,7 @@ project(ginkgo-ranges)
 
 # We only need to find Ginkgo if we build this example stand-alone
 if (NOT GINKGO_BUILD_EXAMPLES)
-    find_package(Ginkgo 1.5.0 REQUIRED)
+    find_package(Ginkgo 1.6.0 REQUIRED)
 endif()
 add_executable(ginkgo-ranges ginkgo-ranges.cpp)
 target_link_libraries(ginkgo-ranges Ginkgo::ginkgo)

--- a/examples/heat-equation/CMakeLists.txt
+++ b/examples/heat-equation/CMakeLists.txt
@@ -3,7 +3,7 @@ project(heat-equation)
 
 # We only need to find Ginkgo if we build this example stand-alone
 if (NOT GINKGO_BUILD_EXAMPLES)
-    find_package(Ginkgo 1.5.0 REQUIRED)
+    find_package(Ginkgo 1.6.0 REQUIRED)
 endif()
 find_package(OpenCV REQUIRED)
 

--- a/examples/ilu-preconditioned-solver/CMakeLists.txt
+++ b/examples/ilu-preconditioned-solver/CMakeLists.txt
@@ -3,7 +3,7 @@ project(ilu-preconditioned-solver)
 
 # We only need to find Ginkgo if we build this example stand-alone
 if (NOT GINKGO_BUILD_EXAMPLES)
-    find_package(Ginkgo 1.5.0 REQUIRED)
+    find_package(Ginkgo 1.6.0 REQUIRED)
 endif()
 
 add_executable(ilu-preconditioned-solver ilu-preconditioned-solver.cpp)

--- a/examples/inverse-iteration/CMakeLists.txt
+++ b/examples/inverse-iteration/CMakeLists.txt
@@ -3,7 +3,7 @@ project(inverse-iteration)
 
 # We only need to find Ginkgo if we build this example stand-alone
 if (NOT GINKGO_BUILD_EXAMPLES)
-    find_package(Ginkgo 1.5.0 REQUIRED)
+    find_package(Ginkgo 1.6.0 REQUIRED)
 endif()
 
 add_executable(inverse-iteration inverse-iteration.cpp)

--- a/examples/ir-ilu-preconditioned-solver/CMakeLists.txt
+++ b/examples/ir-ilu-preconditioned-solver/CMakeLists.txt
@@ -3,7 +3,7 @@ project(ir-ilu-preconditioned-solver)
 
 # We only need to find Ginkgo if we build this example stand-alone
 if (NOT GINKGO_BUILD_EXAMPLES)
-    find_package(Ginkgo 1.5.0 REQUIRED)
+    find_package(Ginkgo 1.6.0 REQUIRED)
 endif()
 
 add_executable(ir-ilu-preconditioned-solver ir-ilu-preconditioned-solver.cpp)

--- a/examples/iterative-refinement/CMakeLists.txt
+++ b/examples/iterative-refinement/CMakeLists.txt
@@ -3,7 +3,7 @@ project(iterative-refinement)
 
 # We only need to find Ginkgo if we build this example stand-alone
 if (NOT GINKGO_BUILD_EXAMPLES)
-    find_package(Ginkgo 1.5.0 REQUIRED)
+    find_package(Ginkgo 1.6.0 REQUIRED)
 endif()
 
 add_executable(iterative-refinement iterative-refinement.cpp)

--- a/examples/kokkos_assembly/CMakeLists.txt
+++ b/examples/kokkos_assembly/CMakeLists.txt
@@ -3,7 +3,7 @@ project(kokkos-assembly CXX)
 
 # We only need to find Ginkgo if we build this example stand-alone
 if(NOT GINKGO_BUILD_EXAMPLES)
-    find_package(Ginkgo 1.5.0 REQUIRED)
+    find_package(Ginkgo 1.6.0 REQUIRED)
 endif()
 
 find_package(Kokkos REQUIRED)

--- a/examples/minimal-cuda-solver/CMakeLists.txt
+++ b/examples/minimal-cuda-solver/CMakeLists.txt
@@ -3,7 +3,7 @@ project(minimal-cuda-solver)
 
 # We only need to find Ginkgo if we build this example stand-alone
 if (NOT GINKGO_BUILD_EXAMPLES)
-    find_package(Ginkgo 1.5.0 REQUIRED)
+    find_package(Ginkgo 1.6.0 REQUIRED)
 endif()
 
 add_executable(minimal-cuda-solver minimal-cuda-solver.cpp)

--- a/examples/mixed-multigrid-preconditioned-solver/CMakeLists.txt
+++ b/examples/mixed-multigrid-preconditioned-solver/CMakeLists.txt
@@ -3,7 +3,7 @@ project(mixed-multigrid-preconditioned-solver)
 
 # We only need to find Ginkgo if we build this example stand-alone
 if (NOT GINKGO_BUILD_EXAMPLES)
-    find_package(Ginkgo 1.5.0 REQUIRED)
+    find_package(Ginkgo 1.6.0 REQUIRED)
 endif()
 
 add_executable(mixed-multigrid-preconditioned-solver mixed-multigrid-preconditioned-solver.cpp)

--- a/examples/mixed-multigrid-solver/CMakeLists.txt
+++ b/examples/mixed-multigrid-solver/CMakeLists.txt
@@ -3,7 +3,7 @@ project(mixed-multigrid-solver)
 
 # We only need to find Ginkgo if we build this example stand-alone
 if (NOT GINKGO_BUILD_EXAMPLES)
-    find_package(Ginkgo 1.5.0 REQUIRED)
+    find_package(Ginkgo 1.6.0 REQUIRED)
 endif()
 
 add_executable(mixed-multigrid-solver mixed-multigrid-solver.cpp)

--- a/examples/mixed-precision-ir/CMakeLists.txt
+++ b/examples/mixed-precision-ir/CMakeLists.txt
@@ -3,7 +3,7 @@ project(mixed-precision-ir)
 
 # We only need to find Ginkgo if we build this example stand-alone
 if (NOT GINKGO_BUILD_EXAMPLES)
-    find_package(Ginkgo 1.5.0 REQUIRED)
+    find_package(Ginkgo 1.6.0 REQUIRED)
 endif()
 
 add_executable(mixed-precision-ir mixed-precision-ir.cpp)

--- a/examples/mixed-spmv/CMakeLists.txt
+++ b/examples/mixed-spmv/CMakeLists.txt
@@ -3,7 +3,7 @@ project(mixed-spmv)
 
 # We only need to find Ginkgo if we build this example stand-alone
 if (NOT GINKGO_BUILD_EXAMPLES)
-    find_package(Ginkgo 1.5.0 REQUIRED)
+    find_package(Ginkgo 1.6.0 REQUIRED)
 endif()
 
 add_executable(mixed-spmv mixed-spmv.cpp)

--- a/examples/multigrid-preconditioned-solver-customized/CMakeLists.txt
+++ b/examples/multigrid-preconditioned-solver-customized/CMakeLists.txt
@@ -3,7 +3,7 @@ project(multigrid-preconditioned-solver-customized)
 
 # We only need to find Ginkgo if we build this example stand-alone
 if (NOT GINKGO_BUILD_EXAMPLES)
-    find_package(Ginkgo 1.5.0 REQUIRED)
+    find_package(Ginkgo 1.6.0 REQUIRED)
 endif()
 
 add_executable(multigrid-preconditioned-solver-customized multigrid-preconditioned-solver-customized.cpp)

--- a/examples/multigrid-preconditioned-solver/CMakeLists.txt
+++ b/examples/multigrid-preconditioned-solver/CMakeLists.txt
@@ -3,7 +3,7 @@ project(multigrid-preconditioned-solver)
 
 # We only need to find Ginkgo if we build this example stand-alone
 if (NOT GINKGO_BUILD_EXAMPLES)
-    find_package(Ginkgo 1.5.0 REQUIRED)
+    find_package(Ginkgo 1.6.0 REQUIRED)
 endif()
 
 add_executable(multigrid-preconditioned-solver multigrid-preconditioned-solver.cpp)

--- a/examples/nine-pt-stencil-solver/CMakeLists.txt
+++ b/examples/nine-pt-stencil-solver/CMakeLists.txt
@@ -3,7 +3,7 @@ project(nine-pt-stencil-solver)
 
 # We only need to find Ginkgo if we build this example stand-alone
 if (NOT GINKGO_BUILD_EXAMPLES)
-    find_package(Ginkgo 1.5.0 REQUIRED)
+    find_package(Ginkgo 1.6.0 REQUIRED)
 endif()
 
 add_executable(nine-pt-stencil-solver nine-pt-stencil-solver.cpp)

--- a/examples/papi-logging/CMakeLists.txt
+++ b/examples/papi-logging/CMakeLists.txt
@@ -3,7 +3,7 @@ project(papi-logging)
 
 # We only need to find Ginkgo if we build this example stand-alone
 if (NOT GINKGO_BUILD_EXAMPLES)
-    find_package(Ginkgo 1.5.0 REQUIRED)
+    find_package(Ginkgo 1.6.0 REQUIRED)
 endif()
 
 if (NOT GINKGO_HAVE_PAPI_SDE)

--- a/examples/par-ilu-convergence/CMakeLists.txt
+++ b/examples/par-ilu-convergence/CMakeLists.txt
@@ -3,7 +3,7 @@ project(par-ilu-convergence)
 
 # We only need to find Ginkgo if we build this example stand-alone
 if (NOT GINKGO_BUILD_EXAMPLES)
-    find_package(Ginkgo 1.5.0 REQUIRED)
+    find_package(Ginkgo 1.6.0 REQUIRED)
 endif()
 
 add_executable(par-ilu-convergence par-ilu-convergence.cpp)

--- a/examples/performance-debugging/CMakeLists.txt
+++ b/examples/performance-debugging/CMakeLists.txt
@@ -3,7 +3,7 @@ project(performance-debugging)
 
 # We only need to find Ginkgo if we build this example stand-alone
 if (NOT GINKGO_BUILD_EXAMPLES)
-    find_package(Ginkgo 1.5.0 REQUIRED)
+    find_package(Ginkgo 1.6.0 REQUIRED)
 endif()
 
 add_executable(performance-debugging performance-debugging.cpp)

--- a/examples/poisson-solver/CMakeLists.txt
+++ b/examples/poisson-solver/CMakeLists.txt
@@ -3,7 +3,7 @@ project(poisson-solver)
 
 # We only need to find Ginkgo if we build this example stand-alone
 if (NOT GINKGO_BUILD_EXAMPLES)
-    find_package(Ginkgo 1.5.0 REQUIRED)
+    find_package(Ginkgo 1.6.0 REQUIRED)
 endif()
 
 add_executable(poisson-solver poisson-solver.cpp)

--- a/examples/preconditioned-solver/CMakeLists.txt
+++ b/examples/preconditioned-solver/CMakeLists.txt
@@ -3,7 +3,7 @@ project(preconditioned-solver)
 
 # We only need to find Ginkgo if we build this example stand-alone
 if (NOT GINKGO_BUILD_EXAMPLES)
-    find_package(Ginkgo 1.5.0 REQUIRED)
+    find_package(Ginkgo 1.6.0 REQUIRED)
 endif()
 add_executable(preconditioned-solver preconditioned-solver.cpp)
 target_link_libraries(preconditioned-solver Ginkgo::ginkgo)

--- a/examples/preconditioner-export/CMakeLists.txt
+++ b/examples/preconditioner-export/CMakeLists.txt
@@ -3,7 +3,7 @@ project(preconditioner-export)
 
 # We only need to find Ginkgo if we build this example stand-alone
 if (NOT GINKGO_BUILD_EXAMPLES)
-    find_package(Ginkgo 1.5.0 REQUIRED)
+    find_package(Ginkgo 1.6.0 REQUIRED)
 endif()
 
 add_executable(preconditioner-export preconditioner-export.cpp)

--- a/examples/schroedinger-splitting/CMakeLists.txt
+++ b/examples/schroedinger-splitting/CMakeLists.txt
@@ -3,7 +3,7 @@ project(schroedinger-splitting)
 
 # We only need to find Ginkgo if we build this example stand-alone
 if (NOT GINKGO_BUILD_EXAMPLES)
-    find_package(Ginkgo 1.5.0 REQUIRED)
+    find_package(Ginkgo 1.6.0 REQUIRED)
 endif()
 find_package(OpenCV REQUIRED)
 

--- a/examples/simple-solver-logging/CMakeLists.txt
+++ b/examples/simple-solver-logging/CMakeLists.txt
@@ -3,7 +3,7 @@ project(simple-solver-logging)
 
 # We only need to find Ginkgo if we build this example stand-alone
 if (NOT GINKGO_BUILD_EXAMPLES)
-    find_package(Ginkgo 1.5.0 REQUIRED)
+    find_package(Ginkgo 1.6.0 REQUIRED)
 endif()
 
 add_executable(simple-solver-logging simple-solver-logging.cpp)

--- a/examples/simple-solver/CMakeLists.txt
+++ b/examples/simple-solver/CMakeLists.txt
@@ -3,7 +3,7 @@ project(simple-solver)
 
 # We only need to find Ginkgo if we build this example stand-alone
 if (NOT GINKGO_BUILD_EXAMPLES)
-    find_package(Ginkgo 1.5.0 REQUIRED)
+    find_package(Ginkgo 1.6.0 REQUIRED)
 endif()
 
 add_executable(simple-solver simple-solver.cpp)

--- a/examples/three-pt-stencil-solver/CMakeLists.txt
+++ b/examples/three-pt-stencil-solver/CMakeLists.txt
@@ -3,7 +3,7 @@ project(three-pt-stencil-solver)
 
 # We only need to find Ginkgo if we build this example stand-alone
 if (NOT GINKGO_BUILD_EXAMPLES)
-    find_package(Ginkgo 1.5.0 REQUIRED)
+    find_package(Ginkgo 1.6.0 REQUIRED)
 endif()
 
 add_executable(three-pt-stencil-solver three-pt-stencil-solver.cpp)

--- a/include/ginkgo/core/reorder/nested_dissection.hpp
+++ b/include/ginkgo/core/reorder/nested_dissection.hpp
@@ -34,9 +34,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define GKO_PUBLIC_CORE_REORDER_NESTED_DISSECTION_HPP_
 
 
-#include <unordered_map>
-
-
 #include <ginkgo/config.hpp>
 
 
@@ -44,6 +41,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
 #include <memory>
+#include <unordered_map>
 
 
 #include <ginkgo/core/base/abstract_factory.hpp>


### PR DESCRIPTION
From the issues @nbeams reported, it would be easier if we searched for METIS only where absolutely required (static builds), this reduces the likelihood we accidentally call another FindMETIS.cmake module. Additionally, this bumps the CMake library version to make it possible to identify post-release Ginkgo.