### PR TITLE
Shut up ABI diff bot

### DIFF
--- a/.github/abidiff.sh
+++ b/.github/abidiff.sh
@@ -6,4 +6,4 @@ popd
 
 bot_delete_comments_matching "Note: This PR changes the Ginkgo ABI"
 
-abidiff build-old/lib/libginkgod.so build-new/lib/libginkgod.so &> abi.diff || (bot_comment "Note: This PR changes the Ginkgo ABI:\n\`\`\`\n$(head -n2 abi.diff | tr '\n' ';' | sed 's/;/\\n/g')\`\`\`\nFor details check the full ABI diff under **Artifacts** [here]($JOB_URL)")
+abidiff build-old/lib/libginkgod.so build-new/lib/libginkgod.so &> abi.diff || true # (bot_comment "Note: This PR changes the Ginkgo ABI:\n\`\`\`\n$(head -n2 abi.diff | tr '\n' ';' | sed 's/;/\\n/g')\`\`\`\nFor details check the full ABI diff under **Artifacts** [here]($JOB_URL)")


### PR DESCRIPTION
It gives way too many false positives, maybe we can reenable it after #715 