### PR TITLE
Add `with_loggers` function to factories

### DIFF
--- a/core/test/base/lin_op.cpp
+++ b/core/test/base/lin_op.cpp
@@ -413,6 +413,25 @@ TEST_F(EnableLinOpFactory, FactoryGenerateIsLogged)
 }
 
 
+TEST_F(EnableLinOpFactory, WithLoggersWorksAndPropagates)
+{
+    auto before_logger = *logger;
+    auto factory =
+        DummyLinOpWithFactory<>::build().with_loggers(logger).on(ref);
+    auto op = factory->generate(DummyLinOp::create(ref, gko::dim<2>{3, 5}));
+    op->apply(op, op);
+
+    ASSERT_EQ(logger->linop_factory_generate_started,
+              before_logger.linop_factory_generate_started + 1);
+    ASSERT_EQ(logger->linop_factory_generate_completed,
+              before_logger.linop_factory_generate_completed + 1);
+    ASSERT_EQ(logger->linop_apply_started,
+              before_logger.linop_apply_started + 1);
+    ASSERT_EQ(logger->linop_apply_completed,
+              before_logger.linop_apply_completed + 1);
+}
+
+
 TEST_F(EnableLinOpFactory, CopiesLinOpToOtherExecutor)
 {
     auto ref2 = gko::ReferenceExecutor::create();

--- a/include/ginkgo/core/base/abstract_factory.hpp
+++ b/include/ginkgo/core/base/abstract_factory.hpp
@@ -238,11 +238,6 @@ public:
     using factory = Factory;
 
     /**
-     * Loggers to be attached to the factory and generated object.
-     */
-    std::vector<std::shared_ptr<const log::Logger>> loggers{};
-
-    /**
      * Provides the loggers to be added to the factory and its generated
      * objects in a fluent interface.
      */
@@ -271,6 +266,11 @@ public:
 
 protected:
     GKO_ENABLE_SELF(ConcreteParametersType);
+
+    /**
+     * Loggers to be attached to the factory and generated object.
+     */
+    std::vector<std::shared_ptr<const log::Logger>> loggers{};
 };
 
 

--- a/include/ginkgo/core/base/abstract_factory.hpp
+++ b/include/ginkgo/core/base/abstract_factory.hpp
@@ -238,6 +238,22 @@ public:
     using factory = Factory;
 
     /**
+     * Loggers to be attached to the factory and generated object.
+     */
+    std::vector<std::shared_ptr<const log::Logger>> loggers{};
+
+    /**
+     * Provides the loggers to be added to the factory and its generated
+     * objects in a fluent interface.
+     */
+    template <typename... Args>
+    ConcreteParametersType& with_loggers(Args&&... _value)
+    {
+        this->loggers = {std::forward<Args>(_value)...};
+        return *self();
+    }
+
+    /**
      * Creates a new factory on the specified executor.
      *
      * @param exec  the executor where the factory will be created
@@ -246,7 +262,11 @@ public:
      */
     std::unique_ptr<Factory> on(std::shared_ptr<const Executor> exec) const
     {
-        return std::unique_ptr<Factory>(new Factory(exec, *self()));
+        auto factory = std::unique_ptr<Factory>(new Factory(exec, *self()));
+        for (auto& logger : loggers) {
+            factory->add_logger(logger);
+        };
+        return factory;
     }
 
 protected:


### PR DESCRIPTION
Pulled out of #1336, this adds `with_loggers` to all factories, the loggers already get forwarded correctly to the products.

Closes #1140 