### PR TITLE
Reusable permutation and transpose

### DIFF
--- a/core/matrix/csr.cpp
+++ b/core/matrix/csr.cpp
@@ -671,6 +671,12 @@ transform_reusable(const Csr<ValueType, IndexType>* input, gko::dim<2> out_size,
 
 
 template <typename ValueType, typename IndexType>
+Csr<ValueType, IndexType>::permuting_reuse_info::permuting_reuse_info()
+    : permuting_reuse_info{nullptr}
+{}
+
+
+template <typename ValueType, typename IndexType>
 Csr<ValueType, IndexType>::permuting_reuse_info::permuting_reuse_info(
     std::unique_ptr<Permutation<index_type>> value_permutation)
     : value_permutation{std::move(value_permutation)}
@@ -681,6 +687,9 @@ template <typename ValueType, typename IndexType>
 void Csr<ValueType, IndexType>::permuting_reuse_info::update_values(
     ptr_param<const Csr> input, ptr_param<Csr> output) const
 {
+    if (!value_permutation) {
+        GKO_NOT_SUPPORTED(value_permutation);
+    }
     input->create_const_value_view()->permute(
         value_permutation, output->create_value_view(), permute_mode::rows);
 }

--- a/core/test/matrix/csr.cpp
+++ b/core/test/matrix/csr.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -8,6 +8,7 @@
 #include <ginkgo/core/matrix/csr.hpp>
 
 #include "core/test/utils.hpp"
+#include "ginkgo/core/base/exception.hpp"
 
 
 namespace {
@@ -416,6 +417,15 @@ TYPED_TEST(Csr, GeneratesCorrectMatrixData)
     EXPECT_EQ(data.nonzeros[1], tpl(0, 1, value_type{3.0}));
     EXPECT_EQ(data.nonzeros[2], tpl(0, 2, value_type{2.0}));
     EXPECT_EQ(data.nonzeros[3], tpl(1, 1, value_type{5.0}));
+}
+
+
+TYPED_TEST(Csr, PermutingReuseInfoDefaultUpdateException)
+{
+    using Mtx = typename TestFixture::Mtx;
+    typename Mtx::permuting_reuse_info reuse;
+
+    ASSERT_THROW(reuse.update_values(this->mtx, this->mtx), gko::NotSupported);
 }
 
 

--- a/include/ginkgo/core/base/precision_dispatch.hpp
+++ b/include/ginkgo/core/base/precision_dispatch.hpp
@@ -87,7 +87,7 @@ void precision_dispatch(Function fn, Args*... linops)
  * Calls the given function with the given LinOps temporarily converted to
  * matrix::Dense<ValueType>* as parameters.
  * If ValueType is real and both input vectors are complex, uses
- * matrix::Dense::get_real_view() to convert them into real matrices after
+ * matrix::Dense::create_real_view() to convert them into real matrices after
  * precision conversion.
  *
  * @see precision_dispatch()
@@ -121,7 +121,7 @@ void precision_dispatch_real_complex(Function fn, const LinOp* in, LinOp* out)
  * Calls the given function with the given LinOps temporarily converted to
  * matrix::Dense<ValueType>* as parameters.
  * If ValueType is real and both `in` and `out` are complex, uses
- * matrix::Dense::get_real_view() to convert them into real matrices after
+ * matrix::Dense::create_real_view() to convert them into real matrices after
  * precision conversion.
  *
  * @see precision_dispatch()

--- a/include/ginkgo/core/matrix/csr.hpp
+++ b/include/ginkgo/core/matrix/csr.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -47,6 +47,9 @@ class Fbcsr;
 
 template <typename ValueType, typename IndexType>
 class CsrBuilder;
+
+template <typename IndexType>
+class Permutation;
 
 
 namespace detail {
@@ -755,6 +758,42 @@ public:
     std::unique_ptr<LinOp> conj_transpose() const override;
 
     /**
+     * A struct describing a transformation of the matrix that reorders the
+     * values of the matrix into the transformed matrix.
+     */
+    struct permuting_reuse_info {
+        /** Creates a reuse info structure from its value permutation. */
+        permuting_reuse_info(
+            std::unique_ptr<Permutation<index_type>> value_permutation);
+
+        /**
+         * Propagates the values from an input matrix to the transformed matrix.
+         * The output matrix needs to have been computed using the
+         * transformation that was also used to generate this reuse data.
+         * Internally, this permutes the input value vector into the output
+         * value vector.
+         */
+        void update_values(ptr_param<const Csr> input,
+                           ptr_param<Csr> output) const;
+
+        std::unique_ptr<Permutation<IndexType>> value_permutation;
+    };
+
+    /**
+     * Computes the necessary data to update a transposed matrix from its
+     * original matrix.
+     * ```
+     * auto [transposed, reuse] = matrix->transpose_reuse();
+     * change_values(matrix);
+     * reuse->update_values(matrix, transposed);
+     * ```
+     * @return the reuse info struct that can be used to update values in the
+     *         transposed matrix.
+     */
+    std::pair<std::unique_ptr<Csr>, permuting_reuse_info> transpose_reuse()
+        const;
+
+    /**
      * Creates a permuted copy $A'$ of this matrix $A$ with the given
      * permutation $P$. By default, this computes a symmetric permutation
      * (permute_mode::symmetric). For the effect of the different permutation
@@ -766,7 +805,9 @@ public:
      *              If permute_mode::rows is set, the rows will be permuted.
      *              If permute_mode::columns is set, the columns will be
      *              permuted.
-     * @return  The permuted matrix.
+     * @return an std::pair consisting of the transposed matrix and the reuse
+     *         info struct that can be used to update values in the transposed
+     *         matrix.
      */
     std::unique_ptr<Csr> permute(
         ptr_param<const Permutation<index_type>> permutation,
@@ -786,6 +827,53 @@ public:
      * @return  The permuted matrix.
      */
     std::unique_ptr<Csr> permute(
+        ptr_param<const Permutation<index_type>> row_permutation,
+        ptr_param<const Permutation<index_type>> column_permutation,
+        bool invert = false) const;
+
+    /**
+     * Computes the operations necessary to propagate changed values from a
+     * matrix A to a permuted matrix.
+     * The semantics of this function match those of
+     * permute(ptr_param<const Permutation<index_type>>, permute_mode).
+     * Updating values works as follows:
+     * ```
+     * auto [permuted, reuse] = matrix->permute_reuse(permutation, mode);
+     * change_values(matrix);
+     * reuse->update_values(matrix, permuted);
+     * ```
+     * @param permutation  The input permutation.
+     * @param mode  The permutation mode. If permute_mode::inverse is set, we
+     *              use the inverse permutation $P^{-1}$ instead of $P$.
+     *              If permute_mode::rows is set, the rows will be permuted.
+     *              If permute_mode::columns is set, the columns will be
+     *              permuted.
+     * @return an std::pair consisting of the permuted matrix and the reuse info
+     *         that can be used to update values in the permuted matrix.
+     */
+    std::pair<std::unique_ptr<Csr>, permuting_reuse_info> permute_reuse(
+        ptr_param<const Permutation<index_type>> permutation,
+        permute_mode mode = permute_mode::symmetric) const;
+
+    /**
+     * Computes the operations necessary to propagate changed values from a
+     * matrix A to a permuted matrix.
+     * The semantics of this function match those of
+     * permute(ptr_param<const Permutation<index_type>>, ptr_param<const
+     * Permutation<index_type>>, bool). Updating values works as follows:
+     * ```
+     * auto [permuted, reuse] = matrix->permute_reuse(row_perm, col_perm, inv);
+     * change_values(matrix);
+     * reuse->update_values(matrix, permuted);
+     * ```
+     * @param row_permutation  The permutation $P$ to apply to the rows
+     * @param column_permutation  The permutation $Q$ to apply to the columns
+     * @param invert  If set to `false`, uses the input permutations, otherwise
+     *                uses their inverses $P^{-1}, Q^{-1}$
+     * @return an std::pair consisting of the permuted matrix and the reuse info
+     *         that can be used to update values in the permuted matrix.
+     */
+    std::pair<std::unique_ptr<Csr>, permuting_reuse_info> permute_reuse(
         ptr_param<const Permutation<index_type>> row_permutation,
         ptr_param<const Permutation<index_type>> column_permutation,
         bool invert = false) const;
@@ -877,6 +965,18 @@ public:
     {
         return values_.get_const_data();
     }
+
+    /**
+     * Creates a Dense view of the value array of this matrix as a column
+     * vector of dimensions nnz x 1.
+     */
+    std::unique_ptr<Dense<ValueType>> create_value_view();
+
+    /**
+     * Creates a const Dense view of the value array of this matrix as a column
+     * vector of dimensions nnz x 1.
+     */
+    std::unique_ptr<const Dense<ValueType>> create_const_value_view() const;
 
     /**
      * Returns the column indexes of the matrix.

--- a/include/ginkgo/core/matrix/csr.hpp
+++ b/include/ginkgo/core/matrix/csr.hpp
@@ -762,6 +762,9 @@ public:
      * values of the matrix into the transformed matrix.
      */
     struct permuting_reuse_info {
+        /** Creates an empty reuse info. */
+        explicit permuting_reuse_info();
+
         /** Creates a reuse info structure from its value permutation. */
         permuting_reuse_info(
             std::unique_ptr<Permutation<index_type>> value_permutation);
@@ -805,9 +808,7 @@ public:
      *              If permute_mode::rows is set, the rows will be permuted.
      *              If permute_mode::columns is set, the columns will be
      *              permuted.
-     * @return an std::pair consisting of the transposed matrix and the reuse
-     *         info struct that can be used to update values in the transposed
-     *         matrix.
+     * @return  The permuted matrix.
      */
     std::unique_ptr<Csr> permute(
         ptr_param<const Permutation<index_type>> permutation,

--- a/test/matrix/csr_kernels2.cpp
+++ b/test/matrix/csr_kernels2.cpp
@@ -679,6 +679,7 @@ TEST_F(Csr, TransposeReuseIsEquivalentToRef)
 
 TEST_F(Csr, TransposeReuse64IsEquivalentToRef)
 {
+    SKIP_IF_SINGLE_MODE;
     using Mtx64 = gko::matrix::Csr<value_type, gko::int64>;
     set_up_apply_data<Mtx::classical>();
     auto mtx = gen_mtx<Mtx64>(123, 234, 0);

--- a/test/matrix/csr_kernels2.cpp
+++ b/test/matrix/csr_kernels2.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -32,7 +32,7 @@
 
 class Csr : public CommonTestFixture {
 protected:
-    using Arr = gko::array<int>;
+    using Arr = gko::array<index_type>;
     using Vec = gko::matrix::Dense<value_type>;
     using Mtx = gko::matrix::Csr<value_type>;
     using ComplexVec = gko::matrix::Dense<std::complex<value_type>>;
@@ -478,10 +478,10 @@ TEST_F(Csr, AdvancedApplyToCsrMatrixIsEquivalentToRef)
 {
     set_up_apply_data<Mtx::classical>();
     auto trans = mtx->transpose();
-    auto d_trans = dmtx->transpose();
+    auto dtrans = dmtx->transpose();
 
     mtx->apply(alpha, trans, beta, square_mtx);
-    dmtx->apply(dalpha, d_trans, dbeta, dsquare_mtx);
+    dmtx->apply(dalpha, dtrans, dbeta, dsquare_mtx);
 
     GKO_ASSERT_MTX_NEAR(dsquare_mtx, square_mtx, r<value_type>::value);
     GKO_ASSERT_MTX_EQ_SPARSITY(dsquare_mtx, square_mtx);
@@ -493,10 +493,10 @@ TEST_F(Csr, SimpleApplyToCsrMatrixIsEquivalentToRef)
 {
     set_up_apply_data<Mtx::classical>();
     auto trans = mtx->transpose();
-    auto d_trans = dmtx->transpose();
+    auto dtrans = dmtx->transpose();
 
     mtx->apply(trans, square_mtx);
-    dmtx->apply(d_trans, dsquare_mtx);
+    dmtx->apply(dtrans, dsquare_mtx);
 
     GKO_ASSERT_MTX_NEAR(dsquare_mtx, square_mtx, r<value_type>::value);
     GKO_ASSERT_MTX_EQ_SPARSITY(dsquare_mtx, square_mtx);
@@ -635,10 +635,10 @@ TEST_F(Csr, TransposeIsEquivalentToRef)
     set_up_apply_data<Mtx::classical>();
 
     auto trans = gko::as<Mtx>(mtx->transpose());
-    auto d_trans = gko::as<Mtx>(dmtx->transpose());
+    auto dtrans = gko::as<Mtx>(dmtx->transpose());
 
-    GKO_ASSERT_MTX_NEAR(d_trans, trans, 0.0);
-    ASSERT_TRUE(d_trans->is_sorted_by_column_index());
+    GKO_ASSERT_MTX_NEAR(dtrans, trans, 0.0);
+    ASSERT_TRUE(dtrans->is_sorted_by_column_index());
 }
 
 
@@ -649,10 +649,55 @@ TEST_F(Csr, Transpose64IsEquivalentToRef)
     auto dmtx = gko::clone(exec, mtx);
 
     auto trans = gko::as<Mtx64>(mtx->transpose());
-    auto d_trans = gko::as<Mtx64>(dmtx->transpose());
+    auto dtrans = gko::as<Mtx64>(dmtx->transpose());
 
-    GKO_ASSERT_MTX_NEAR(d_trans, trans, 0.0);
-    ASSERT_TRUE(d_trans->is_sorted_by_column_index());
+    GKO_ASSERT_MTX_NEAR(dtrans, trans, 0.0);
+    ASSERT_TRUE(dtrans->is_sorted_by_column_index());
+}
+
+
+TEST_F(Csr, TransposeReuseIsEquivalentToRef)
+{
+    set_up_apply_data<Mtx::classical>();
+
+    auto [trans, reuse] = mtx->transpose_reuse();
+    auto [dtrans, dreuse] = dmtx->transpose_reuse();
+
+    GKO_ASSERT_MTX_NEAR(dtrans, trans, 0);
+    ASSERT_TRUE(dtrans->is_sorted_by_column_index());
+    GKO_ASSERT_MTX_EQ_SPARSITY(dreuse.value_permutation,
+                               reuse.value_permutation);
+    // test that the value permutation works: modify input values
+    mtx->create_value_view()->scale(alpha);
+    dmtx->create_value_view()->scale(dalpha);
+    reuse.update_values(mtx, trans);
+    dreuse.update_values(dmtx, dtrans);
+    GKO_ASSERT_MTX_NEAR(gko::as<Mtx>(mtx->transpose()), trans, 0);
+    GKO_ASSERT_MTX_NEAR(gko::as<Mtx>(dmtx->transpose()), dtrans, 0);
+}
+
+
+TEST_F(Csr, TransposeReuse64IsEquivalentToRef)
+{
+    using Mtx64 = gko::matrix::Csr<value_type, gko::int64>;
+    set_up_apply_data<Mtx::classical>();
+    auto mtx = gen_mtx<Mtx64>(123, 234, 0);
+    auto dmtx = gko::clone(exec, mtx);
+
+    auto [trans, reuse] = mtx->transpose_reuse();
+    auto [dtrans, dreuse] = dmtx->transpose_reuse();
+
+    GKO_ASSERT_MTX_NEAR(dtrans, trans, 0);
+    ASSERT_TRUE(dtrans->is_sorted_by_column_index());
+    GKO_ASSERT_MTX_EQ_SPARSITY(dreuse.value_permutation,
+                               reuse.value_permutation);
+    // test that the value permutation works: modify input values
+    mtx->create_value_view()->scale(alpha);
+    dmtx->create_value_view()->scale(dalpha);
+    reuse.update_values(mtx, trans);
+    dreuse.update_values(dmtx, dtrans);
+    GKO_ASSERT_MTX_NEAR(gko::as<Mtx64>(mtx->transpose()), trans, 0);
+    GKO_ASSERT_MTX_NEAR(gko::as<Mtx64>(dmtx->transpose()), dtrans, 0);
 }
 
 
@@ -661,10 +706,10 @@ TEST_F(Csr, ConjugateTransposeIsEquivalentToRef)
     set_up_apply_complex_data<ComplexMtx::classical>();
 
     auto trans = gko::as<ComplexMtx>(complex_mtx->conj_transpose());
-    auto d_trans = gko::as<ComplexMtx>(dcomplex_mtx->conj_transpose());
+    auto dtrans = gko::as<ComplexMtx>(dcomplex_mtx->conj_transpose());
 
-    GKO_ASSERT_MTX_NEAR(d_trans, trans, 0.0);
-    ASSERT_TRUE(d_trans->is_sorted_by_column_index());
+    GKO_ASSERT_MTX_NEAR(dtrans, trans, 0.0);
+    ASSERT_TRUE(dtrans->is_sorted_by_column_index());
 }
 
 
@@ -675,10 +720,10 @@ TEST_F(Csr, ConjugateTranspose64IsEquivalentToRef)
     auto dmtx = gko::clone(exec, mtx);
 
     auto trans = gko::as<Mtx64>(mtx->transpose());
-    auto d_trans = gko::as<Mtx64>(dmtx->transpose());
+    auto dtrans = gko::as<Mtx64>(dmtx->transpose());
 
-    GKO_ASSERT_MTX_NEAR(d_trans, trans, 0.0);
-    ASSERT_TRUE(d_trans->is_sorted_by_column_index());
+    GKO_ASSERT_MTX_NEAR(dtrans, trans, 0.0);
+    ASSERT_TRUE(dtrans->is_sorted_by_column_index());
 }
 
 
@@ -876,6 +921,38 @@ TEST_F(Csr, IsGenericPermutable)
 }
 
 
+TEST_F(Csr, IsGenericReusePermutable)
+{
+    using gko::matrix::permute_mode;
+    set_up_apply_data<Mtx::classical>();
+
+    for (auto mode :
+         {permute_mode::none, permute_mode::rows, permute_mode::columns,
+          permute_mode::symmetric, permute_mode::inverse_rows,
+          permute_mode::inverse_columns, permute_mode::inverse_symmetric}) {
+        SCOPED_TRACE(mode);
+        auto [permuted, reuse] = square_mtx->permute_reuse(rpermutation, mode);
+        auto [dpermuted, dreuse] =
+            dsquare_mtx->permute_reuse(rpermutation, mode);
+
+        GKO_ASSERT_MTX_NEAR(permuted, dpermuted, 0);
+        GKO_ASSERT_MTX_EQ_SPARSITY(permuted, dpermuted);
+        ASSERT_TRUE(dpermuted->is_sorted_by_column_index());
+        GKO_ASSERT_MTX_EQ_SPARSITY(reuse.value_permutation,
+                                   dreuse.value_permutation);
+        // test that the value permutation works: modify input values
+        square_mtx->create_value_view()->scale(alpha);
+        dsquare_mtx->create_value_view()->scale(dalpha);
+        reuse.update_values(square_mtx, permuted);
+        dreuse.update_values(dsquare_mtx, dpermuted);
+        GKO_ASSERT_MTX_NEAR(square_mtx->permute(rpermutation, mode), permuted,
+                            0);
+        GKO_ASSERT_MTX_NEAR(dsquare_mtx->permute(rpermutation, mode), dpermuted,
+                            0);
+    }
+}
+
+
 TEST_F(Csr, IsColPermutableHypersparse)
 {
     using gko::matrix::permute_mode;
@@ -921,7 +998,6 @@ TEST_F(Csr, IsGenericPermutableRectangular)
 
 TEST_F(Csr, IsNonsymmPermutable)
 {
-    using gko::matrix::permute_mode;
     set_up_apply_data<Mtx::classical>();
 
     for (auto invert : {false, true}) {
@@ -932,6 +1008,36 @@ TEST_F(Csr, IsNonsymmPermutable)
         GKO_ASSERT_MTX_NEAR(permuted, dpermuted, 0);
         GKO_ASSERT_MTX_EQ_SPARSITY(permuted, dpermuted);
         ASSERT_TRUE(dpermuted->is_sorted_by_column_index());
+    }
+}
+
+
+TEST_F(Csr, IsNonsymmReusePermutable)
+{
+    using gko::matrix::permute_mode;
+    set_up_apply_data<Mtx::classical>();
+
+    for (auto invert : {false, true}) {
+        SCOPED_TRACE(invert);
+        auto [permuted, reuse] =
+            mtx->permute_reuse(rpermutation, cpermutation, invert);
+        auto [dpermuted, dreuse] =
+            dmtx->permute_reuse(rpermutation, cpermutation, invert);
+
+        GKO_ASSERT_MTX_NEAR(permuted, dpermuted, 0);
+        GKO_ASSERT_MTX_EQ_SPARSITY(permuted, dpermuted);
+        ASSERT_TRUE(dpermuted->is_sorted_by_column_index());
+        GKO_ASSERT_MTX_EQ_SPARSITY(reuse.value_permutation,
+                                   dreuse.value_permutation);
+        // test that the value permutation works: modify input values
+        mtx->create_value_view()->scale(alpha);
+        dmtx->create_value_view()->scale(dalpha);
+        reuse.update_values(mtx, permuted);
+        dreuse.update_values(dmtx, dpermuted);
+        GKO_ASSERT_MTX_NEAR(mtx->permute(rpermutation, cpermutation, invert),
+                            permuted, 0);
+        GKO_ASSERT_MTX_NEAR(dmtx->permute(rpermutation, cpermutation, invert),
+                            dpermuted, 0);
     }
 }
 
@@ -1027,6 +1133,7 @@ TEST_F(Csr, IsPermutable)
     auto permuted = gko::as<Mtx>(square_mtx->permute(rpermute_idxs.get()));
     auto dpermuted = gko::as<Mtx>(dsquare_mtx->permute(rpermute_idxs.get()));
 
+    ASSERT_TRUE(dpermuted->is_sorted_by_column_index());
     GKO_ASSERT_MTX_EQ_SPARSITY(permuted, dpermuted);
     GKO_ASSERT_MTX_NEAR(permuted, dpermuted, 0);
 }
@@ -1041,6 +1148,7 @@ TEST_F(Csr, IsInversePermutable)
     auto dpermuted =
         gko::as<Mtx>(dsquare_mtx->inverse_permute(rpermute_idxs.get()));
 
+    ASSERT_TRUE(dpermuted->is_sorted_by_column_index());
     GKO_ASSERT_MTX_EQ_SPARSITY(permuted, dpermuted);
     GKO_ASSERT_MTX_NEAR(permuted, dpermuted, 0);
 }
@@ -1053,6 +1161,7 @@ TEST_F(Csr, IsRowPermutable)
     auto r_permute = gko::as<Mtx>(mtx->row_permute(rpermute_idxs.get()));
     auto dr_permute = gko::as<Mtx>(dmtx->row_permute(rpermute_idxs.get()));
 
+    ASSERT_TRUE(dr_permute->is_sorted_by_column_index());
     GKO_ASSERT_MTX_EQ_SPARSITY(r_permute, dr_permute);
     GKO_ASSERT_MTX_NEAR(r_permute, dr_permute, 0);
 }
@@ -1080,6 +1189,7 @@ TEST_F(Csr, IsInverseRowPermutable)
     auto d_inverse_r_permute =
         gko::as<Mtx>(dmtx->inverse_row_permute(rpermute_idxs.get()));
 
+    ASSERT_TRUE(d_inverse_r_permute->is_sorted_by_column_index());
     GKO_ASSERT_MTX_EQ_SPARSITY(inverse_r_permute, d_inverse_r_permute);
     GKO_ASSERT_MTX_NEAR(inverse_r_permute, d_inverse_r_permute, 0);
 }


### PR DESCRIPTION
As a tool for implementing reusable factories, this adds reusable functionality for all Csr permutation and transpose functions.

It also takes a first step towards making `Permutation` the default representation of a reordering.

Closes #1157 