### PR TITLE
Use shared storage for ELL and COO in Hybrid

### DIFF
--- a/include/ginkgo/core/matrix/hybrid.hpp
+++ b/include/ginkgo/core/matrix/hybrid.hpp
@@ -674,11 +674,9 @@ protected:
      * @param exec  Executor associated to the matrix
      * @param strategy  strategy of deciding the Hybrid config
      */
-    Hybrid(
-        std::shared_ptr<const Executor> exec,
-        std::shared_ptr<strategy_type> strategy = std::make_shared<automatic>())
-        : Hybrid(std::move(exec), dim<2>{}, std::move(strategy))
-    {}
+    Hybrid(std::shared_ptr<const Executor> exec,
+           std::shared_ptr<strategy_type> strategy =
+               std::make_shared<automatic>());
 
     /**
      * Creates an uninitialized Hybrid matrix of the specified size and method.
@@ -689,11 +687,9 @@ protected:
      * @param size  size of the matrix
      * @param strategy  strategy of deciding the Hybrid config
      */
-    Hybrid(
-        std::shared_ptr<const Executor> exec, const dim<2>& size,
-        std::shared_ptr<strategy_type> strategy = std::make_shared<automatic>())
-        : Hybrid(std::move(exec), size, size[1], std::move(strategy))
-    {}
+    Hybrid(std::shared_ptr<const Executor> exec, const dim<2>& size,
+           std::shared_ptr<strategy_type> strategy =
+               std::make_shared<automatic>());
 
     /**
      * Creates an uninitialized Hybrid matrix of the specified size and method.
@@ -705,13 +701,10 @@ protected:
      *                                      row
      * @param strategy  strategy of deciding the Hybrid config
      */
-    Hybrid(
-        std::shared_ptr<const Executor> exec, const dim<2>& size,
-        size_type num_stored_elements_per_row,
-        std::shared_ptr<strategy_type> strategy = std::make_shared<automatic>())
-        : Hybrid(std::move(exec), size, num_stored_elements_per_row, size[0],
-                 {}, std::move(strategy))
-    {}
+    Hybrid(std::shared_ptr<const Executor> exec, const dim<2>& size,
+           size_type num_stored_elements_per_row,
+           std::shared_ptr<strategy_type> strategy =
+               std::make_shared<automatic>());
 
     /**
      * Creates an uninitialized Hybrid matrix of the specified size and method.
@@ -725,10 +718,7 @@ protected:
      */
     Hybrid(std::shared_ptr<const Executor> exec, const dim<2>& size,
            size_type num_stored_elements_per_row, size_type stride,
-           std::shared_ptr<strategy_type> strategy)
-        : Hybrid(std::move(exec), size, num_stored_elements_per_row, stride, {},
-                 std::move(strategy))
-    {}
+           std::shared_ptr<strategy_type> strategy);
 
     /**
      * Creates an uninitialized Hybrid matrix of the specified size and method.
@@ -741,17 +731,14 @@ protected:
      * @param num_nonzeros  number of nonzeros
      * @param strategy  strategy of deciding the Hybrid config
      */
-    Hybrid(
-        std::shared_ptr<const Executor> exec, const dim<2>& size,
-        size_type num_stored_elements_per_row, size_type stride,
-        size_type num_nonzeros = {},
-        std::shared_ptr<strategy_type> strategy = std::make_shared<automatic>())
-        : EnableLinOp<Hybrid>(exec, size),
-          ell_(ell_type::create(exec, size, num_stored_elements_per_row,
-                                stride)),
-          coo_(coo_type::create(exec, size, num_nonzeros)),
-          strategy_(std::move(strategy))
-    {}
+    Hybrid(std::shared_ptr<const Executor> exec, const dim<2>& size,
+           size_type num_stored_elements_per_row, size_type stride,
+           size_type num_nonzeros = {},
+           std::shared_ptr<strategy_type> strategy =
+               std::make_shared<automatic>());
+
+    void setup_alias(dim<2> new_size, size_type ell_row_nnz,
+                     size_type ell_stride, size_type coo_nnz);
 
     /**
      * Resizes the matrix to the given dimensions and storage sizes.
@@ -759,9 +746,6 @@ protected:
      * @param new_size  the new matrix dimensions
      * @param ell_row_nnz  the number of non-zeros per row stored in ELL
      * @param coo_nnz  the number of non-zeros stored in COO
-     *
-     * @see Ell::resize(dim<2>, size_type)
-     * @see Coo::resize(dim<2>, size_type)
      */
     void resize(dim<2> new_size, size_type ell_row_nnz, size_type coo_nnz);
 
@@ -771,8 +755,10 @@ protected:
                     LinOp* x) const override;
 
 private:
-    std::unique_ptr<ell_type> ell_;
+    array<value_type> value_storage_;
+    array<index_type> index_storage_;
     std::unique_ptr<coo_type> coo_;
+    std::unique_ptr<ell_type> ell_;
     std::shared_ptr<strategy_type> strategy_;
 };
 

--- a/reference/test/matrix/dense_kernels.cpp
+++ b/reference/test/matrix/dense_kernels.cpp
@@ -1423,7 +1423,7 @@ TYPED_TEST(Dense, MovesToHybridWithStrideAutomatically)
     using T = typename TestFixture::value_type;
     using Hybrid = typename gko::matrix::Hybrid<T, gko::int32>;
     auto hybrid_mtx =
-        Hybrid::create(this->mtx4->get_executor(), gko::dim<2>{2, 3}, 0, 3);
+        Hybrid::create(this->mtx4->get_executor(), gko::dim<2>{2, 3}, 0, 3, 4);
 
     this->mtx4->move_to(hybrid_mtx);
     auto v = hybrid_mtx->get_const_coo_values();
@@ -1457,7 +1457,7 @@ TYPED_TEST(Dense, ConvertsToHybridWithStrideAutomatically)
     using T = typename TestFixture::value_type;
     using Hybrid = typename gko::matrix::Hybrid<T, gko::int32>;
     auto hybrid_mtx =
-        Hybrid::create(this->mtx4->get_executor(), gko::dim<2>{2, 3}, 0, 3);
+        Hybrid::create(this->mtx4->get_executor(), gko::dim<2>{2, 3}, 0, 3, 4);
 
     this->mtx4->convert_to(hybrid_mtx);
     auto v = hybrid_mtx->get_const_coo_values();
@@ -1469,8 +1469,8 @@ TYPED_TEST(Dense, ConvertsToHybridWithStrideAutomatically)
     ASSERT_EQ(hybrid_mtx->get_size(), gko::dim<2>(2, 3));
     ASSERT_EQ(hybrid_mtx->get_ell_num_stored_elements(), 0);
     ASSERT_EQ(hybrid_mtx->get_coo_num_stored_elements(), 4);
-    EXPECT_EQ(n, 0);
-    EXPECT_EQ(p, 3);
+    EXPECT_EQ(hybrid_mtx->get_ell_num_stored_elements_per_row(), 0);
+    EXPECT_EQ(hybrid_mtx->get_ell_stride(), 3);
     EXPECT_EQ(r[0], 0);
     EXPECT_EQ(r[1], 0);
     EXPECT_EQ(r[2], 0);
@@ -1491,7 +1491,7 @@ TYPED_TEST(Dense, MovesToHybridWithStrideAndCooLengthByColumns2)
     using T = typename TestFixture::value_type;
     using Hybrid = typename gko::matrix::Hybrid<T, gko::int32>;
     auto hybrid_mtx =
-        Hybrid::create(this->mtx4->get_executor(), gko::dim<2>{2, 3}, 2, 3, 3,
+        Hybrid::create(this->mtx4->get_executor(), gko::dim<2>{2, 3}, 2, 3, 1,
                        std::make_shared<typename Hybrid::column_limit>(2));
 
     this->mtx4->move_to(hybrid_mtx);
@@ -1528,7 +1528,7 @@ TYPED_TEST(Dense, ConvertsToHybridWithStrideAndCooLengthByColumns2)
     using T = typename TestFixture::value_type;
     using Hybrid = typename gko::matrix::Hybrid<T, gko::int32>;
     auto hybrid_mtx =
-        Hybrid::create(this->mtx4->get_executor(), gko::dim<2>{2, 3}, 2, 3, 3,
+        Hybrid::create(this->mtx4->get_executor(), gko::dim<2>{2, 3}, 2, 3, 1,
                        std::make_shared<typename Hybrid::column_limit>(2));
 
     this->mtx4->convert_to(hybrid_mtx);
@@ -1565,7 +1565,7 @@ TYPED_TEST(Dense, MovesToHybridWithStrideByPercent40)
     using T = typename TestFixture::value_type;
     using Hybrid = typename gko::matrix::Hybrid<T, gko::int32>;
     auto hybrid_mtx =
-        Hybrid::create(this->mtx4->get_executor(), gko::dim<2>{2, 3}, 1, 3,
+        Hybrid::create(this->mtx4->get_executor(), gko::dim<2>{2, 3}, 1, 3, 2,
                        std::make_shared<typename Hybrid::imbalance_limit>(0.4));
 
     this->mtx4->move_to(hybrid_mtx);
@@ -1602,7 +1602,7 @@ TYPED_TEST(Dense, ConvertsToHybridWithStrideByPercent40)
     using T = typename TestFixture::value_type;
     using Hybrid = typename gko::matrix::Hybrid<T, gko::int32>;
     auto hybrid_mtx =
-        Hybrid::create(this->mtx4->get_executor(), gko::dim<2>{2, 3}, 1, 3,
+        Hybrid::create(this->mtx4->get_executor(), gko::dim<2>{2, 3}, 1, 3, 2,
                        std::make_shared<typename Hybrid::imbalance_limit>(0.4));
 
     this->mtx4->convert_to(hybrid_mtx);


### PR DESCRIPTION
Currently the only thing preventing reusable reads working via int-to-float-to-int conversions like in #1338 is the fact that Hybrid uses two separate allocations to store the values for the ELL and COO parts. This PR uses a shared storage and views into it instead.

To fix the tests, I also had to make sure that they specify the correct input dimensions, because ELL and COO can no longer be reallocated separately.