### PR TITLE
Add reordering algorithms to sparse_blas benchmark

### DIFF
--- a/benchmark/sparse_blas/operations.cpp
+++ b/benchmark/sparse_blas/operations.cpp
@@ -796,10 +796,9 @@ private:
 
 const std::map<std::string,
                std::function<std::unique_ptr<BenchmarkOperation>(const Mtx*)>>
-    operation_map
-{
-    {"spgemm",
-     [](const Mtx* mtx) { return std::make_unique<SpgemmOperation>(mtx); }},
+    operation_map{
+        {"spgemm",
+         [](const Mtx* mtx) { return std::make_unique<SpgemmOperation>(mtx); }},
         {"spgeam",
          [](const Mtx* mtx) { return std::make_unique<SpgeamOperation>(mtx); }},
         {"transpose",
@@ -834,17 +833,18 @@ const std::map<std::string,
          [](const Mtx* mtx) {
              return std::make_unique<ReorderRcmOperation>(mtx);
          }},
-        {"reorder_amd", [](const Mtx* mtx) {
+        {"reorder_amd",
+         [](const Mtx* mtx) {
              return std::make_unique<ReorderApproxMinDegOperation>(mtx);
          }},
+        {"reorder_nd",
+         [](const Mtx* mtx) -> std::unique_ptr<BenchmarkOperation> {
 #if GKO_HAVE_METIS
-    {
-        "reorder_nd", [](const Mtx* mtx) {
-            return std::make_unique<ReorderNestedDissectionOperation>(mtx);
-        }
-    }
+             return std::make_unique<ReorderNestedDissectionOperation>(mtx);
+#else
+             GKO_NOT_COMPILED(METIS);
 #endif
-};
+         }}};
 
 
 std::unique_ptr<BenchmarkOperation> get_operation(std::string name,

--- a/benchmark/sparse_blas/sparse_blas.cpp
+++ b/benchmark/sparse_blas/sparse_blas.cpp
@@ -57,11 +57,17 @@ const auto benchmark_name = "sparse_blas";
 
 using mat_data = gko::matrix_data<etype, itype>;
 
-DEFINE_string(
-    operations, "spgemm,spgeam,transpose",
+const char* operations_string =
     "Comma-separated list of operations to be benchmarked. Can be "
     "spgemm, spgeam, transpose, sort, is_sorted, generate_lookup, "
-    "lookup, symbolic_lu, symbolic_cholesky, symbolic_cholesky_symmetric");
+    "lookup, symbolic_lu, symbolic_cholesky, "
+    "symbolic_cholesky_symmetric, reorder_rcm, "
+#if GKO_HAVE_METIS
+    "reorder_nd, "
+#endif
+    "reorder_amd";
+
+DEFINE_string(operations, "spgemm,spgeam,transpose", operations_string);
 
 DEFINE_bool(validate, false,
             "Check for correct sparsity pattern and compute the L2 norm "


### PR DESCRIPTION
We need a way to benchmark RCM, ND and AMD. I believe the straightforward solution is to use the `sparse_blas` benchmark, The operations happen exclusively on the CPU, so the executor choice has only minor impact on the actual algorithm, but it highlights the cost of the data movement involved, so it might still be useful to have executors involved here.