### PR TITLE
Makes Gitlab CI Interruptible

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -25,7 +25,7 @@ include:
   # [1] https://gitlab.com/gitlab-org/gitlab/-/issues/194023#note_1225906002
   - local: '.gitlab/add-interrupt.yml'
     rules:
-      - if: $CI_COMMIT_BRANCH != "master" && $CI_COMMIT_BRANCH != "develop"
+      - if: $CI_COMMIT_BRANCH != "master" && $CI_COMMIT_BRANCH != "develop" && CI_COMMIT_TAG !~ /^v\d+\.\d+\.\d+/
 
 sync:
   stage: sync
@@ -779,15 +779,15 @@ sonarqube_cov_:
     - PR_ID=$(curl -s "https://api.github.com/search/issues?q=sha:${CI_COMMIT_SHA}"
       | jq '.items[0].number')
     - if [[ "${PR_ID}" != "null" ]]; then
-        target_branch=$(curl -s
-          "https://api.github.com/repos/ginkgo-project/ginkgo/pulls/${PR_ID}" | jq
-          '.base.ref' | sed 's/"//g');
-        sonar_branching="-Dsonar.pullrequest.branch=${CI_COMMIT_REF_NAME}
-          -Dsonar.pullrequest.base=${target_branch}
-          -Dsonar.pullrequest.key=${PR_ID}";
+      target_branch=$(curl -s
+      "https://api.github.com/repos/ginkgo-project/ginkgo/pulls/${PR_ID}" | jq
+      '.base.ref' | sed 's/"//g');
+      sonar_branching="-Dsonar.pullrequest.branch=${CI_COMMIT_REF_NAME}
+      -Dsonar.pullrequest.base=${target_branch}
+      -Dsonar.pullrequest.key=${PR_ID}";
       else
-        sonar_branching="-Dsonar.branch.name=${CI_COMMIT_REF_NAME}
-        -Dsonar.branch.target=develop";
+      sonar_branching="-Dsonar.branch.name=${CI_COMMIT_REF_NAME}
+      -Dsonar.branch.target=develop";
       fi
     - ctest -S cmake/CTestScript.cmake -DCTEST_BUILD_CONFIGURATION=COVERAGE
       -DGINKGO_SONARQUBE_TEST=ON
@@ -831,13 +831,13 @@ gh-pages:
     # build docs
     - mkdir -p ${CI_JOB_NAME} && pushd ${CI_JOB_NAME}
     - cmake ${CI_PROJECT_DIR}
-        -DCMAKE_C_COMPILER=${C_COMPILER} -DCMAKE_CXX_COMPILER=${CXX_COMPILER}
-        -DCMAKE_CUDA_COMPILER=${CUDA_COMPILER} -DCMAKE_BUILD_TYPE=${BUILD_TYPE}
-        -DBUILD_SHARED_LIBS=ON ${EXTRA_CMAKE_FLAGS} -DGINKGO_DEVEL_TOOLS=OFF
-        -DGINKGO_BUILD_REFERENCE=OFF -DGINKGO_BUILD_OMP=OFF -DGINKGO_BUILD_CUDA=OFF
-        -DGINKGO_BUILD_HIP=OFF -DGINKGO_BUILD_DPCPP=OFF -DGINKGO_BUILD_MPI=OFF
-        -DGINKGO_BUILD_TESTS=OFF -DGINKGO_BUILD_EXAMPLES=OFF
-        -DGINKGO_BUILD_DOC=ON -DGINKGO_DOC_GENERATE_PDF=ON
+      -DCMAKE_C_COMPILER=${C_COMPILER} -DCMAKE_CXX_COMPILER=${CXX_COMPILER}
+      -DCMAKE_CUDA_COMPILER=${CUDA_COMPILER} -DCMAKE_BUILD_TYPE=${BUILD_TYPE}
+      -DBUILD_SHARED_LIBS=ON ${EXTRA_CMAKE_FLAGS} -DGINKGO_DEVEL_TOOLS=OFF
+      -DGINKGO_BUILD_REFERENCE=OFF -DGINKGO_BUILD_OMP=OFF -DGINKGO_BUILD_CUDA=OFF
+      -DGINKGO_BUILD_HIP=OFF -DGINKGO_BUILD_DPCPP=OFF -DGINKGO_BUILD_MPI=OFF
+      -DGINKGO_BUILD_TESTS=OFF -DGINKGO_BUILD_EXAMPLES=OFF
+      -DGINKGO_BUILD_DOC=ON -DGINKGO_DOC_GENERATE_PDF=ON
     - make usr
     - make pdf
     - popd
@@ -854,7 +854,7 @@ gh-pages:
     - git diff --quiet HEAD ||
       (git commit -m "Update documentation from ginkgo-project/ginkgo@${CURRENT_SHA}" && git push)
   dependencies: null
-  needs: []
+  needs: [ ]
 
 
 threadsanitizer:
@@ -867,10 +867,10 @@ threadsanitizer:
   script:
     - LD_PRELOAD=/usr/local/lib/libomp.so
       CC=clang CXX=clang++
-        ctest -V -S cmake/CTestScript.cmake -DCTEST_BUILD_CONFIGURATION=TSAN
-        -DCTEST_MEMORYCHECK_TYPE=ThreadSanitizer
-        -DCTEST_MEMORYCHECK_SANITIZER_OPTIONS=ignore_noninstrumented_modules=1
-        --timeout 6000
+      ctest -V -S cmake/CTestScript.cmake -DCTEST_BUILD_CONFIGURATION=TSAN
+      -DCTEST_MEMORYCHECK_TYPE=ThreadSanitizer
+      -DCTEST_MEMORYCHECK_SANITIZER_OPTIONS=ignore_noninstrumented_modules=1
+      --timeout 6000
 
 leaksanitizer:
   stage: QoS_tools
@@ -933,7 +933,7 @@ new-issue-on-failure:
     refs:
       - develop
       - master
-  dependencies: []
+  dependencies: [ ]
 
 
 ## Benchmark SpMV

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -779,15 +779,15 @@ sonarqube_cov_:
     - PR_ID=$(curl -s "https://api.github.com/search/issues?q=sha:${CI_COMMIT_SHA}"
       | jq '.items[0].number')
     - if [[ "${PR_ID}" != "null" ]]; then
-      target_branch=$(curl -s
-      "https://api.github.com/repos/ginkgo-project/ginkgo/pulls/${PR_ID}" | jq
-      '.base.ref' | sed 's/"//g');
-      sonar_branching="-Dsonar.pullrequest.branch=${CI_COMMIT_REF_NAME}
-      -Dsonar.pullrequest.base=${target_branch}
-      -Dsonar.pullrequest.key=${PR_ID}";
+        target_branch=$(curl -s
+          "https://api.github.com/repos/ginkgo-project/ginkgo/pulls/${PR_ID}" | jq
+          '.base.ref' | sed 's/"//g');
+        sonar_branching="-Dsonar.pullrequest.branch=${CI_COMMIT_REF_NAME}
+          -Dsonar.pullrequest.base=${target_branch}
+          -Dsonar.pullrequest.key=${PR_ID}";
       else
-      sonar_branching="-Dsonar.branch.name=${CI_COMMIT_REF_NAME}
-      -Dsonar.branch.target=develop";
+        sonar_branching="-Dsonar.branch.name=${CI_COMMIT_REF_NAME}
+        -Dsonar.branch.target=develop";
       fi
     - ctest -S cmake/CTestScript.cmake -DCTEST_BUILD_CONFIGURATION=COVERAGE
       -DGINKGO_SONARQUBE_TEST=ON
@@ -831,13 +831,13 @@ gh-pages:
     # build docs
     - mkdir -p ${CI_JOB_NAME} && pushd ${CI_JOB_NAME}
     - cmake ${CI_PROJECT_DIR}
-      -DCMAKE_C_COMPILER=${C_COMPILER} -DCMAKE_CXX_COMPILER=${CXX_COMPILER}
-      -DCMAKE_CUDA_COMPILER=${CUDA_COMPILER} -DCMAKE_BUILD_TYPE=${BUILD_TYPE}
-      -DBUILD_SHARED_LIBS=ON ${EXTRA_CMAKE_FLAGS} -DGINKGO_DEVEL_TOOLS=OFF
-      -DGINKGO_BUILD_REFERENCE=OFF -DGINKGO_BUILD_OMP=OFF -DGINKGO_BUILD_CUDA=OFF
-      -DGINKGO_BUILD_HIP=OFF -DGINKGO_BUILD_DPCPP=OFF -DGINKGO_BUILD_MPI=OFF
-      -DGINKGO_BUILD_TESTS=OFF -DGINKGO_BUILD_EXAMPLES=OFF
-      -DGINKGO_BUILD_DOC=ON -DGINKGO_DOC_GENERATE_PDF=ON
+        -DCMAKE_C_COMPILER=${C_COMPILER} -DCMAKE_CXX_COMPILER=${CXX_COMPILER}
+        -DCMAKE_CUDA_COMPILER=${CUDA_COMPILER} -DCMAKE_BUILD_TYPE=${BUILD_TYPE}
+        -DBUILD_SHARED_LIBS=ON ${EXTRA_CMAKE_FLAGS} -DGINKGO_DEVEL_TOOLS=OFF
+        -DGINKGO_BUILD_REFERENCE=OFF -DGINKGO_BUILD_OMP=OFF -DGINKGO_BUILD_CUDA=OFF
+        -DGINKGO_BUILD_HIP=OFF -DGINKGO_BUILD_DPCPP=OFF -DGINKGO_BUILD_MPI=OFF
+        -DGINKGO_BUILD_TESTS=OFF -DGINKGO_BUILD_EXAMPLES=OFF
+        -DGINKGO_BUILD_DOC=ON -DGINKGO_DOC_GENERATE_PDF=ON
     - make usr
     - make pdf
     - popd
@@ -854,7 +854,7 @@ gh-pages:
     - git diff --quiet HEAD ||
       (git commit -m "Update documentation from ginkgo-project/ginkgo@${CURRENT_SHA}" && git push)
   dependencies: null
-  needs: [ ]
+  needs: []
 
 
 threadsanitizer:
@@ -867,10 +867,10 @@ threadsanitizer:
   script:
     - LD_PRELOAD=/usr/local/lib/libomp.so
       CC=clang CXX=clang++
-      ctest -V -S cmake/CTestScript.cmake -DCTEST_BUILD_CONFIGURATION=TSAN
-      -DCTEST_MEMORYCHECK_TYPE=ThreadSanitizer
-      -DCTEST_MEMORYCHECK_SANITIZER_OPTIONS=ignore_noninstrumented_modules=1
-      --timeout 6000
+        ctest -V -S cmake/CTestScript.cmake -DCTEST_BUILD_CONFIGURATION=TSAN
+        -DCTEST_MEMORYCHECK_TYPE=ThreadSanitizer
+        -DCTEST_MEMORYCHECK_SANITIZER_OPTIONS=ignore_noninstrumented_modules=1
+        --timeout 6000
 
 leaksanitizer:
   stage: QoS_tools
@@ -933,7 +933,7 @@ new-issue-on-failure:
     refs:
       - develop
       - master
-  dependencies: [ ]
+  dependencies: []
 
 
 ## Benchmark SpMV

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -819,6 +819,7 @@ sonarqube_cov:
 # Deploy documentation to github-pages
 gh-pages:
   stage: deploy
+  interruptible: false
   extends:
     - .default_variables
     - .deploy_condition
@@ -922,6 +923,7 @@ cudamemcheck:
 
 new-issue-on-failure:
   stage: on-failure
+  interruptible: false
   extends:
     - .default_variables
     - .use_status-job-settings

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -19,6 +19,13 @@ include:
   - local: '.gitlab/rules.yml'
   - local: '.gitlab/scripts.yml'
   - local: '.gitlab/variables.yml'
+  # This is a workaround to conditionally make the branch pipelines
+  # interruptible, because the flag does not directly support rules [1].
+  #
+  # [1] https://gitlab.com/gitlab-org/gitlab/-/issues/194023#note_1225906002
+  - local: '.gitlab/add-interrupt.yml'
+    rules:
+      - if: $CI_COMMIT_BRANCH != "master" && $CI_COMMIT_BRANCH != "develop"
 
 sync:
   stage: sync

--- a/.gitlab/add-interrupt.yml
+++ b/.gitlab/add-interrupt.yml
@@ -1,0 +1,2 @@
+default:
+  interruptible: true


### PR DESCRIPTION
This PR makes our Gitlab CI interruptible, similar to the setup that we have for github. Only CI that does not run on master/develop branch can be interrupted.