### PR TITLE
Fix circular dep check by using the same preference Threads 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,8 @@ cmake_minimum_required(VERSION 3.16)
 project(Ginkgo LANGUAGES C CXX VERSION 1.7.0 DESCRIPTION "A numerical linear algebra library targeting many-core architectures")
 set(Ginkgo_VERSION_TAG "develop")
 set(PROJECT_VERSION_TAG ${Ginkgo_VERSION_TAG})
+# Cuda and Hip also look for Threads. Set it before any find_package to ensure the Threads setting is not changed.
+set(THREADS_PREFER_PTHREAD_FLAG ON)
 
 # Determine which modules can be compiled
 include(cmake/hip_path.cmake)
@@ -98,7 +100,7 @@ endif()
 if(GINKGO_BUILD_OMP)
     find_package(OpenMP 3.0 REQUIRED)
 endif()
-set(THREADS_PREFER_PTHREAD_FLAG ON)
+
 find_package(Threads REQUIRED)
 include(cmake/build_type_helpers.cmake)
 

--- a/cmake/GinkgoConfig.cmake.in
+++ b/cmake/GinkgoConfig.cmake.in
@@ -139,6 +139,9 @@ set(GINKGO_HAVE_VTUNE "@GINKGO_HAVE_VTUNE@")
 set(GINKGO_HAVE_METIS "@GINKGO_HAVE_METIS@")
 set(VTune_PATH "@VTune_PATH@")
 
+# ensure Threads settings 
+set(THREADS_PREFER_PTHREAD_FLAG ON)
+
 # NOTE: we do not export benchmarks, examples, tests or devel tools
 #     so `third_party` libraries are currently unneeded.
 

--- a/core/base/mixed_precision_types.hpp
+++ b/core/base/mixed_precision_types.hpp
@@ -75,7 +75,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #else
 
 #define GKO_INSTANTIATE_FOR_EACH_MIXED_VALUE_TYPE_SPLIT1(_macro, ...) \
-    template _macro(float, float, float, __VA_ARGS__);
+    template _macro(float, float, float, __VA_ARGS__)
 
 #define GKO_INSTANTIATE_FOR_EACH_MIXED_VALUE_TYPE_SPLIT2(_macro, ...) \
     template _macro(double, double, double, __VA_ARGS__)


### PR DESCRIPTION
It fixes the compilation error in the circular dependence check.

The issue happens when Threads uses the `-lpthread` not `-pthread`.
FindHIP also uses FindCUDA from cmake but faces the compilation issue.
Also, the hip link is `target_link_libraries(ginkgo_hip PUBLIC /usr/local/cuda/lib64/libcudart_static.a;Threads::Threads;dl;/usr/lib/x86_64-linux-gnu/librt.so )` from FindCUDA in HIP but I think cmake does not guarantee the linking order is the same as providing. 
Either `-pthread /usr/.../libcudart_static.a` or `/usr/.../libcudart_static.a -lpthread` works in hip test linking.
It's not the issue in cuda because cuda has another `-lpthread` in the end.

Compilation twice solves the issue because we have set `set(THREADS_PREFER_PTHREAD_FLAG ON)`, then it will change the Threads in the second round.
Note. It's hard to reproduce because it usually uses `-pthread` in the end for the first compile, unlike the CI job. Maybe we do not find the actual reason yet.

The first generations and second generations give different Threads target.
It can be found by the several texts after `get_target_property(GINKGO_LIBS_INTERFACE_DEFS Threads::Threads` by using `--debug-find --trace-expand` with `cmake` command

TODO:
- [x] revert the job dependency 