### PR TITLE
fix missing $ in CI_COMMIT_TAG

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -25,7 +25,7 @@ include:
   # [1] https://gitlab.com/gitlab-org/gitlab/-/issues/194023#note_1225906002
   - local: '.gitlab/add-interrupt.yml'
     rules:
-      - if: $CI_COMMIT_BRANCH != "master" && $CI_COMMIT_BRANCH != "develop" && CI_COMMIT_TAG !~ /^v\d+\.\d+\.\d+/
+      - if: $CI_COMMIT_BRANCH != "master" && $CI_COMMIT_BRANCH != "develop" && $CI_COMMIT_TAG !~ /^v\d+\.\d+\.\d+/
 
 sync:
   stage: sync


### PR DESCRIPTION
This PR fix the missing $ in CI_COMMIT_TAG.
It was not captured by gitlab before.
the old one does not create a pipeline now https://gitlab.com/ginkgo-project/ginkgo-public-ci/-/pipelines/972242549
`include:rule if invalid expression syntax`