### PR TITLE
fix median condition for benchmark timer

### DIFF
--- a/benchmark/utils/timer_impl.hpp
+++ b/benchmark/utils/timer_impl.hpp
@@ -111,7 +111,8 @@ public:
             return copy.back();
         } else if (method == "median") {
             auto mid = copy.size() / 2;
-            if (copy.size() % 2) {
+            if (copy.size() % 2 == 0) {
+                // contains even elements
                 return (copy.at(mid) + copy.at(mid - 1)) / 2;
             } else {
                 return copy.at(mid);


### PR DESCRIPTION
This PR fixes the condition for even/odd number of elements in median computation.
I thought `if(a % 2)` was for even value second time 😢  but even should use `if (a % 2 == 0)`
