### PR TITLE
Use fixed clang format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -3,13 +3,13 @@ Language:        Cpp
 # BasedOnStyle:  Google
 AccessModifierOffset: -4
 AlignAfterOpenBracket: Align
-AlignConsecutiveAssignments: false
-AlignConsecutiveDeclarations: false
+AlignConsecutiveAssignments: None
+AlignConsecutiveDeclarations: None
 AlignEscapedNewlines: Left
 AlignOperands:   true
 AlignTrailingComments: true
 AllowAllParametersOfDeclarationOnNextLine: true
-AllowShortBlocksOnASingleLine: false
+AllowShortBlocksOnASingleLine: Never
 AllowShortCaseLabelsOnASingleLine: false
 AllowShortFunctionsOnASingleLine: All
 AllowShortIfStatementsOnASingleLine: true
@@ -17,12 +17,12 @@ AllowShortLoopsOnASingleLine: true
 AlwaysBreakAfterDefinitionReturnType: None
 AlwaysBreakAfterReturnType: None
 AlwaysBreakBeforeMultilineStrings: true
-AlwaysBreakTemplateDeclarations: true
+AlwaysBreakTemplateDeclarations: Yes
 BinPackArguments: true
 BinPackParameters: true
 BraceWrapping:
   AfterClass:      false
-  AfterControlStatement: false
+  AfterControlStatement: Never
   AfterEnum:       false
   AfterFunction:   true
   AfterNamespace:  false
@@ -88,7 +88,7 @@ PenaltyExcessCharacter: 1000000
 PenaltyReturnTypeOnItsOwnLine: 200
 PointerAlignment: Left
 ReflowComments:  true
-SortIncludes:    true
+SortIncludes:    CaseInsensitive
 SortUsingDeclarations: true
 SpaceAfterCStyleCast: false
 SpaceAfterTemplateKeyword: true
@@ -101,7 +101,7 @@ SpacesInContainerLiterals: true
 SpacesInCStyleCastParentheses: false
 SpacesInParentheses: false
 SpacesInSquareBrackets: false
-Standard:        Cpp11
+Standard:        c++14
 TabWidth:        8
 UseTab:          Never
 ...

--- a/.github/bot-pr-format-base.sh
+++ b/.github/bot-pr-format-base.sh
@@ -1,24 +1,25 @@
 #!/usr/bin/env bash
 
-source .github/bot-pr-base.sh
+cp .github/bot-pr-base.sh /tmp
+source /tmp/bot-pr-base.sh
 
-echo "Retrieving PR file list"
-PR_FILES=$(bot_get_all_changed_files ${PR_URL})
-NUM=$(echo "${PR_FILES}" | wc -l)
-echo "PR has ${NUM} changed files"
-
-TO_FORMAT="$(echo "$PR_FILES" | grep -E $EXTENSION_REGEX || true)"
+echo "Set-up working tree"
 
 git remote add fork "$HEAD_URL"
 git fetch fork "$HEAD_BRANCH"
+git fetch origin "$BASE_BRANCH"
+
+# checkout current PR head
+LOCAL_BRANCH=format-tmp-$HEAD_BRANCH
+git checkout -b $LOCAL_BRANCH fork/$HEAD_BRANCH
 
 git config user.email "ginkgo.library@gmail.com"
 git config user.name "ginkgo-bot"
 
 # save scripts from develop
-pushd dev_tools/scripts
+pushd dev_tools/scripts || exit 1
 cp add_license.sh format_header.sh update_ginkgo_header.sh /tmp
-popd
+popd || exit 1
 
 # checkout current PR head
 LOCAL_BRANCH=format-tmp-$HEAD_BRANCH
@@ -28,12 +29,3 @@ git checkout -b $LOCAL_BRANCH fork/$HEAD_BRANCH
 cp /tmp/add_license.sh dev_tools/scripts/
 cp /tmp/format_header.sh dev_tools/scripts/
 cp /tmp/update_ginkgo_header.sh dev_tools/scripts/
-
-# format files
-dev_tools/scripts/add_license.sh
-dev_tools/scripts/update_ginkgo_header.sh
-for f in $(echo "$TO_FORMAT" | grep -E $FORMAT_HEADER_REGEX); do dev_tools/scripts/format_header.sh "$f"; done
-for f in $(echo "$TO_FORMAT" | grep -E $FORMAT_REGEX); do "$CLANG_FORMAT" -i -style=file "$f"; done
-
-# restore formatting scripts so they don't appear in the diff
-git checkout -- dev_tools/scripts/*.sh

--- a/.github/check-format.sh
+++ b/.github/check-format.sh
@@ -3,13 +3,22 @@
 cp .github/bot-pr-format-base.sh /tmp
 source /tmp/bot-pr-format-base.sh
 
+echo -n "Run Pre-Commit checks"
+
+pipx run pre-commit run --show-diff-on-failure --color=always --from-ref "origin/$BASE_BRANCH" --to-ref HEAD || true
+
+echo -n "Collecting information on changed files"
+
 # check for changed files, replace newlines by \n
 LIST_FILES=$(git diff --name-only | sed '$!s/$/\\n/' | tr -d '\n')
+echo -n .
 
 git diff > /tmp/format.patch
 mv /tmp/format.patch .
+echo -n .
 
 bot_delete_comments_matching "Error: The following files need to be formatted"
+echo -n .
 
 if [[ "$LIST_FILES" != "" ]]; then
   MESSAGE="The following files need to be formatted:\n"'```'"\n$LIST_FILES\n"'```'
@@ -17,3 +26,4 @@ if [[ "$LIST_FILES" != "" ]]; then
   MESSAGE="$MESSAGE($JOB_URL) or run "'`format!` if you have write access to Ginkgo'
   bot_error "$MESSAGE"
 fi
+echo .

--- a/.github/format-rebase.sh
+++ b/.github/format-rebase.sh
@@ -12,7 +12,7 @@ git rebase --rebase-merges --empty=drop --no-keep-empty \
     --exec "cp /tmp/add_license.sh /tmp/format_header.sh /tmp/update_ginkgo_header.sh dev_tools/scripts/ && \
             dev_tools/scripts/add_license.sh && dev_tools/scripts/update_ginkgo_header.sh && \
             for f in \$($DIFF_COMMAND | grep -E '$FORMAT_HEADER_REGEX'); do dev_tools/scripts/format_header.sh \$f; done && \
-            pipx run pre-commit run --files $TO_FORMAT && \
+            pipx run pre-commit run && \
             git checkout dev_tools/scripts && (git diff >> /tmp/difflog; true) && (git diff --quiet || git commit -a --amend --no-edit --allow-empty)" \
     base/$BASE_BRANCH 2>&1 || bot_error "Rebase failed, see the related [Action]($JOB_URL) for details"
 

--- a/.github/format-rebase.sh
+++ b/.github/format-rebase.sh
@@ -1,25 +1,7 @@
 #!/usr/bin/env bash
 
-source .github/bot-pr-base.sh
-
-git remote add base "$BASE_URL"
-git remote add fork "$HEAD_URL"
-
-git remote -v
-
-git fetch base $BASE_BRANCH
-git fetch fork $HEAD_BRANCH
-
-git config user.email "$USER_EMAIL"
-git config user.name "$USER_NAME"
-
-LOCAL_BRANCH=rebase-tmp-$HEAD_BRANCH
-git checkout -b $LOCAL_BRANCH fork/$HEAD_BRANCH
-
-# save scripts from develop
-pushd dev_tools/scripts
-cp add_license.sh format_header.sh update_ginkgo_header.sh /tmp
-popd
+cp .github/bot-pr-format-base.sh /tmp
+source /tmp/bot-pr-format-base.sh
 
 bot_delete_comments_matching "Error: Rebase failed"
 
@@ -30,7 +12,7 @@ git rebase --rebase-merges --empty=drop --no-keep-empty \
     --exec "cp /tmp/add_license.sh /tmp/format_header.sh /tmp/update_ginkgo_header.sh dev_tools/scripts/ && \
             dev_tools/scripts/add_license.sh && dev_tools/scripts/update_ginkgo_header.sh && \
             for f in \$($DIFF_COMMAND | grep -E '$FORMAT_HEADER_REGEX'); do dev_tools/scripts/format_header.sh \$f; done && \
-            for f in \$($DIFF_COMMAND | grep -E '$FORMAT_REGEX'); do $CLANG_FORMAT -i \$f; done && \
+            pipx run pre-commit run --files $TO_FORMAT && \
             git checkout dev_tools/scripts && (git diff >> /tmp/difflog; true) && (git diff --quiet || git commit -a --amend --no-edit --allow-empty)" \
     base/$BASE_BRANCH 2>&1 || bot_error "Rebase failed, see the related [Action]($JOB_URL) for details"
 

--- a/.github/format.sh
+++ b/.github/format.sh
@@ -3,11 +3,29 @@
 cp .github/bot-pr-format-base.sh /tmp
 source /tmp/bot-pr-format-base.sh
 
+echo "Retrieving PR file list"
+PR_FILES=$(bot_get_all_changed_files ${PR_URL})
+NUM=$(echo "${PR_FILES}" | wc -l)
+echo "PR has ${NUM} changed files"
+
+TO_FORMAT="$(echo "$PR_FILES" | grep -E $EXTENSION_REGEX || true)"
+
+# format files
+dev_tools/scripts/add_license.sh
+dev_tools/scripts/update_ginkgo_header.sh
+for f in $(echo "$TO_FORMAT" | grep -E $FORMAT_HEADER_REGEX); do dev_tools/scripts/format_header.sh "$f"; done
+pipx run pre-commit run --files $TO_FORMAT || true
+
+# restore formatting scripts so they don't appear in the diff
+git checkout -- dev_tools/scripts/*.sh
+
 # check for changed files, replace newlines by \n
-LIST_FILES=$(git diff --name-only | sed '$!s/$/\\n/' | tr -d '\n')
+CHANGES=$(git diff --name-only | sed '$!s/$/\\n/' | tr -d '\n')
+
+echo "$CHANGES"
 
 # commit changes if necessary
-if [[ "$LIST_FILES" != "" ]]; then
+if [[ "$CHANGES" != "" ]]; then
   git commit -a -m "Format files
 
 Co-authored-by: $USER_COMBINED"

--- a/.github/workflows/bot-pr-comment.yml
+++ b/.github/workflows/bot-pr-comment.yml
@@ -1,7 +1,9 @@
+name: OnCommentPR
+
 on:
   issue_comment:
     types: [created]
-name: OnCommentPR
+
 jobs:
   label:
     runs-on: ubuntu-latest
@@ -15,25 +17,12 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.BOT_TOKEN }}
       run: cp --preserve .github/label.sh /tmp && /tmp/label.sh
+
   check_format:
     name: check-format
-    runs-on: ubuntu-22.04
     if: github.event.issue.pull_request != '' && github.event.comment.body == 'check-format!' && (github.event.comment.author_association == 'COLLABORATOR' || github.event.comment.author_association == 'MEMBER' || github.event.comment.author_association == 'OWNER')
-    steps:
-    - name: Checkout the latest code (shallow clone)
-      uses: actions/checkout@v3
-      with:
-        ref: develop
-    - name: Check for formatting changes
-      env:
-        GITHUB_TOKEN: ${{ secrets.BOT_TOKEN }}
-      run: cp --preserve .github/check-format.sh /tmp && /tmp/check-format.sh
-    - name: Upload code formatting patch
-      if: failure()
-      uses: actions/upload-artifact@v3
-      with:
-          name: patch
-          path: format.patch
+    uses: ./.github/workflows/check-formatting.yml
+
   format:
     name: format
     runs-on: ubuntu-22.04
@@ -48,6 +37,7 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.BOT_TOKEN }}
       run: cp --preserve .github/format.sh /tmp && /tmp/format.sh
+
   rebase:
     name: rebase
     if: github.event.issue.pull_request != '' && github.event.comment.body == 'rebase!' && (github.event.comment.author_association == 'COLLABORATOR' || github.event.comment.author_association == 'MEMBER' || github.event.comment.author_association == 'OWNER')
@@ -63,6 +53,7 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.BOT_TOKEN }}
       run: cp --preserve .github/rebase.sh /tmp && /tmp/rebase.sh
+
   format-rebase:
     name: format-rebase
     if: github.event.issue.pull_request != '' && github.event.comment.body == 'format-rebase!' && (github.event.comment.author_association == 'COLLABORATOR' || github.event.comment.author_association == 'MEMBER' || github.event.comment.author_association == 'OWNER')

--- a/.github/workflows/bot-pr-updated.yml
+++ b/.github/workflows/bot-pr-updated.yml
@@ -1,29 +1,18 @@
+name: OnSyncPR
+
 on:
   pull_request_target:
     types: [opened,synchronize]
-name: OnSyncPR
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
   cancel-in-progress: true
+
 jobs:
   check-format:
-    runs-on: ubuntu-22.04
     if: github.event.pull_request.author_association == 'COLLABORATOR' || github.event.pull_request.author_association == 'MEMBER' || github.event.pull_request.author_association == 'OWNER'
-    steps:
-      - name: Checkout the latest code (shallow clone)
-        uses: actions/checkout@v3
-        with:
-          ref: develop
-      - name: Check for formatting changes
-        env:
-          GITHUB_TOKEN: ${{ secrets.BOT_TOKEN }}
-        run: cp .github/check-format.sh /tmp && /tmp/check-format.sh
-      - name: Upload code formatting patch
-        if: failure()
-        uses: actions/upload-artifact@v3
-        with:
-          name: patch
-          path: format.patch
+    uses: ./.github/workflows/check-formatting.yml
+
   abidiff:
     runs-on: ubuntu-latest
     if: github.event.pull_request.author_association == 'COLLABORATOR' || github.event.pull_request.author_association == 'MEMBER' || github.event.pull_request.author_association == 'OWNER'
@@ -58,8 +47,9 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@v3
         with:
-            name: abi
-            path: abi.diff
+          name: abi
+          path: abi.diff
+
   check-wiki-changelog:
     runs-on: ubuntu-latest
     if: github.event.pull_request.author_association == 'COLLABORATOR' || github.event.pull_request.author_association == 'MEMBER' || github.event.pull_request.author_association == 'OWNER'

--- a/.github/workflows/check-formatting.yml
+++ b/.github/workflows/check-formatting.yml
@@ -1,0 +1,22 @@
+name: Check formatting
+on:
+  workflow_call:
+
+jobs:
+  pre-commit:
+    name: Run pre-commit hooks
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout the latest code (shallow clone)
+        uses: actions/checkout@v4
+      - name: Run Pre-Commit checks
+        run: cp .github/check-format.sh /tmp && /tmp/check-format.sh
+        id: pre-commit
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Upload code formatting patch
+        if: ${{ failure() && steps.pre-commit.outcome == 'failure' }}
+        uses: actions/upload-artifact@v3
+        with:
+          name: patch
+          path: format.patch

--- a/.github/workflows/check-formatting.yml
+++ b/.github/workflows/check-formatting.yml
@@ -1,6 +1,5 @@
 name: Check formatting
-on:
-  workflow_call:
+on: workflow_call
 
 jobs:
   pre-commit:
@@ -15,7 +14,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Upload code formatting patch
-        if: ${{ failure() && steps.pre-commit.outcome == 'failure' }}
+        if: ${{ failure() }}
         uses: actions/upload-artifact@v3
         with:
           name: patch

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,7 @@
+repos:
+-   repo: https://github.com/pre-commit/mirrors-clang-format
+    rev: 'v14.0.0'  # The default in Ubuntu 22.04, which is used in our CI
+    hooks:
+        -   id: clang-format
+            types_or: [c, c++, cuda, inc]
+            exclude: third_party/SuiteSparse/AMD/.*

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -354,6 +354,13 @@ if(GINKGO_BUILD_BENCHMARKS)
 endif()
 
 if(GINKGO_DEVEL_TOOLS)
+    find_program(PRE_COMMIT pre-commit)
+    if(${PRE_COMMIT} STREQUAL "PRE_COMMIT-NOTFOUND")
+        message(FATAL_ERROR "The pre-commit command was not found. It is necessary if you want to commit changes to Ginkgo. "
+                "If that is not the case, set GINKGO_DEVEL_TOOLS=OFF. "
+                "Otherwise install pre-commit via pipx (or pip) using:\n"
+                "    pipx install pre-commit")
+    endif()
     add_custom_target(add_license
         COMMAND ${Ginkgo_SOURCE_DIR}/dev_tools/scripts/add_license.sh
         WORKING_DIRECTORY ${Ginkgo_SOURCE_DIR})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -355,19 +355,33 @@ endif()
 
 if(GINKGO_DEVEL_TOOLS)
     find_program(PRE_COMMIT pre-commit)
-    if(${PRE_COMMIT} STREQUAL "PRE_COMMIT-NOTFOUND")
+    if(NOT PRE_COMMIT)
         message(FATAL_ERROR "The pre-commit command was not found. It is necessary if you want to commit changes to Ginkgo. "
                 "If that is not the case, set GINKGO_DEVEL_TOOLS=OFF. "
                 "Otherwise install pre-commit via pipx (or pip) using:\n"
                 "    pipx install pre-commit")
     endif()
-    add_custom_target(add_license
-        COMMAND ${Ginkgo_SOURCE_DIR}/dev_tools/scripts/add_license.sh
-        WORKING_DIRECTORY ${Ginkgo_SOURCE_DIR})
-    # if git-cmake-format can not build format target, do not add the dependencies
-    if(TARGET format)
-        add_dependencies(format add_license)
+
+    execute_process(COMMAND "${PRE_COMMIT}" "install"
+                    WORKING_DIRECTORY ${Ginkgo_SOURCE_DIR}
+                    RESULT_VARIABLE pre-commit-result
+                    OUTPUT_VARIABLE pre-commit-output
+                    ERROR_VARIABLE pre-commit-error)
+    if(pre-commit-result)
+        message(FATAL_ERROR
+                "Failed to install the git hooks via pre-commit. Please check the error message:\n"
+                "${pre-commit-output}\n${pre-commit-error}")
     endif()
+
+    add_custom_target(format
+                      COMMAND bash -c "${PRE_COMMIT} run"
+                      WORKING_DIRECTORY ${Ginkgo_SOURCE_DIR}
+                      VERBATIM)
+
+    add_custom_target(add_license
+                      COMMAND ${Ginkgo_SOURCE_DIR}/dev_tools/scripts/add_license.sh
+                      WORKING_DIRECTORY ${Ginkgo_SOURCE_DIR})
+    add_dependencies(format add_license)
 endif()
 
 # MacOS needs to install bash, gnu-sed, findutils and coreutils

--- a/core/test/base/deferred_factory.cpp
+++ b/core/test/base/deferred_factory.cpp
@@ -86,8 +86,8 @@ struct test_impl<gko::xstd::void_t<decltype(T(std::declval<Args>()...))>, T,
 
 // specialization for DF2 with_factory_list
 template <typename... Args>
-struct test_impl<gko::xstd::void_t<decltype(DF2::param{}.with_factory_list(
-                     std::declval<Args>()...))>,
+struct test_impl<gko::xstd::void_t<decltype(
+                     DF2::param{}.with_factory_list(std::declval<Args>()...))>,
                  DummyFlag, Args...> : std::true_type {};
 
 // test the object can be constructable or not with Args.

--- a/dpcpp/factorization/par_ilut_filter_kernels.hpp.inc
+++ b/dpcpp/factorization/par_ilut_filter_kernels.hpp.inc
@@ -115,12 +115,13 @@ void threshold_filter_nnz(dim3 grid, dim3 block,
                           remove_complex<ValueType> threshold, IndexType* nnz,
                           bool lower)
 {
-    queue->parallel_for(
-        sycl_nd_range(grid, block), [=
-    ](sycl::nd_item<3> item_ct1) [[sycl::reqd_sub_group_size(subgroup_size)]] {
-            threshold_filter_nnz<subgroup_size>(
-                row_ptrs, vals, num_rows, threshold, nnz, lower, item_ct1);
-        });
+    queue->parallel_for(sycl_nd_range(grid, block),
+                        [=](sycl::nd_item<3> item_ct1)
+                            [[sycl::reqd_sub_group_size(subgroup_size)]] {
+                                threshold_filter_nnz<subgroup_size>(
+                                    row_ptrs, vals, num_rows, threshold, nnz,
+                                    lower, item_ct1);
+                            });
 }
 
 
@@ -152,14 +153,15 @@ void threshold_filter(dim3 grid, dim3 block, size_type dynamic_shared_memory,
                       const IndexType* new_row_ptrs, IndexType* new_row_idxs,
                       IndexType* new_col_idxs, ValueType* new_vals, bool lower)
 {
-    queue->parallel_for(
-        sycl_nd_range(grid, block), [=
-    ](sycl::nd_item<3> item_ct1) [[sycl::reqd_sub_group_size(subgroup_size)]] {
-            threshold_filter<subgroup_size>(
-                old_row_ptrs, old_col_idxs, old_vals, num_rows, threshold,
-                new_row_ptrs, new_row_idxs, new_col_idxs, new_vals, lower,
-                item_ct1);
-        });
+    queue->parallel_for(sycl_nd_range(grid, block),
+                        [=](sycl::nd_item<3> item_ct1)
+                            [[sycl::reqd_sub_group_size(subgroup_size)]] {
+                                threshold_filter<subgroup_size>(
+                                    old_row_ptrs, old_col_idxs, old_vals,
+                                    num_rows, threshold, new_row_ptrs,
+                                    new_row_idxs, new_col_idxs, new_vals, lower,
+                                    item_ct1);
+                            });
 }
 
 
@@ -183,12 +185,13 @@ void bucket_filter_nnz(dim3 grid, dim3 block, size_type dynamic_shared_memory,
                        const BucketType* buckets, IndexType num_rows,
                        BucketType bucket, IndexType* nnz)
 {
-    queue->parallel_for(
-        sycl_nd_range(grid, block), [=
-    ](sycl::nd_item<3> item_ct1) [[sycl::reqd_sub_group_size(subgroup_size)]] {
-            bucket_filter_nnz<subgroup_size>(row_ptrs, buckets, num_rows,
-                                             bucket, nnz, item_ct1);
-        });
+    queue->parallel_for(sycl_nd_range(grid, block),
+                        [=](sycl::nd_item<3> item_ct1)
+                            [[sycl::reqd_sub_group_size(subgroup_size)]] {
+                                bucket_filter_nnz<subgroup_size>(
+                                    row_ptrs, buckets, num_rows, bucket, nnz,
+                                    item_ct1);
+                            });
 }
 
 
@@ -222,13 +225,15 @@ void bucket_filter(dim3 grid, dim3 block, size_type dynamic_shared_memory,
                    IndexType* new_row_idxs, IndexType* new_col_idxs,
                    ValueType* new_vals)
 {
-    queue->parallel_for(
-        sycl_nd_range(grid, block), [=
-    ](sycl::nd_item<3> item_ct1) [[sycl::reqd_sub_group_size(subgroup_size)]] {
-            bucket_filter<subgroup_size>(
-                old_row_ptrs, old_col_idxs, old_vals, buckets, num_rows, bucket,
-                new_row_ptrs, new_row_idxs, new_col_idxs, new_vals, item_ct1);
-        });
+    queue->parallel_for(sycl_nd_range(grid, block),
+                        [=](sycl::nd_item<3> item_ct1)
+                            [[sycl::reqd_sub_group_size(subgroup_size)]] {
+                                bucket_filter<subgroup_size>(
+                                    old_row_ptrs, old_col_idxs, old_vals,
+                                    buckets, num_rows, bucket, new_row_ptrs,
+                                    new_row_idxs, new_col_idxs, new_vals,
+                                    item_ct1);
+                            });
 }
 
 

--- a/dpcpp/factorization/par_ilut_select_kernels.hpp.inc
+++ b/dpcpp/factorization/par_ilut_select_kernels.hpp.inc
@@ -68,13 +68,13 @@ void build_searchtree(dim3 grid, dim3 block, size_type dynamic_shared_memory,
                        sycl::access::target::local>
             sh_samples_acc_ct1(sycl::range<1>(1024 /*sample_size*/), cgh);
 
-        cgh.parallel_for(
-            sycl_nd_range(grid, block), [=
-        ](sycl::nd_item<3> item_ct1) [[sycl::reqd_sub_group_size(
-                                            config::warp_size)]] {
-                build_searchtree(input, size, tree_output, item_ct1,
-                                 sh_samples_acc_ct1.get_pointer());
-            });
+        cgh.parallel_for(sycl_nd_range(grid, block),
+                         [=](sycl::nd_item<3> item_ct1)
+                             [[sycl::reqd_sub_group_size(config::warp_size)]] {
+                                 build_searchtree(
+                                     input, size, tree_output, item_ct1,
+                                     sh_samples_acc_ct1.get_pointer());
+                             });
     });
 }
 
@@ -256,12 +256,13 @@ void block_prefix_sum(dim3 grid, dim3 block, size_type dynamic_shared_memory,
                               cgh);
 
         cgh.parallel_for(
-            sycl_nd_range(grid, block), [=
-        ](sycl::nd_item<3> item_ct1) [[sycl::reqd_sub_group_size(
-                                            config::warp_size)]] {
-                block_prefix_sum(counters, totals, num_blocks, item_ct1,
-                                 (IndexType*)warp_sums_acc_ct1.get_pointer());
-            });
+            sycl_nd_range(grid, block),
+            [=](sycl::nd_item<3> item_ct1)
+                [[sycl::reqd_sub_group_size(config::warp_size)]] {
+                    block_prefix_sum(
+                        counters, totals, num_blocks, item_ct1,
+                        (IndexType*)warp_sums_acc_ct1.get_pointer());
+                });
     });
 }
 
@@ -363,12 +364,12 @@ void basecase_select(dim3 grid, dim3 block, size_type dynamic_shared_memory,
             sh_local_acc_ct1(sycl::range<1>(1024 /*basecase_size*/), cgh);
 
         cgh.parallel_for(
-            sycl_nd_range(grid, block), [=
-        ](sycl::nd_item<3> item_ct1) [[sycl::reqd_sub_group_size(
-                                            config::warp_size)]] {
-                basecase_select(input, size, rank, out, item_ct1,
-                                (ValueType*)sh_local_acc_ct1.get_pointer());
-            });
+            sycl_nd_range(grid, block),
+            [=](sycl::nd_item<3> item_ct1)
+                [[sycl::reqd_sub_group_size(config::warp_size)]] {
+                    basecase_select(input, size, rank, out, item_ct1,
+                                    (ValueType*)sh_local_acc_ct1.get_pointer());
+                });
     });
 }
 
@@ -403,12 +404,11 @@ template <typename IndexType>
 void find_bucket(dim3 grid, dim3 block, size_type dynamic_shared_memory,
                  sycl::queue* queue, IndexType* prefix_sum, IndexType rank)
 {
-    queue->parallel_for(
-        sycl_nd_range(grid, block), [=
-    ](sycl::nd_item<3> item_ct1) [[sycl::reqd_sub_group_size(
-                                        config::warp_size)]] {
-            find_bucket(prefix_sum, rank, item_ct1);
-        });
+    queue->parallel_for(sycl_nd_range(grid, block),
+                        [=](sycl::nd_item<3> item_ct1)
+                            [[sycl::reqd_sub_group_size(config::warp_size)]] {
+                                find_bucket(prefix_sum, rank, item_ct1);
+                            });
 }
 
 

--- a/dpcpp/solver/common_gmres_kernels.dp.inc
+++ b/dpcpp/solver/common_gmres_kernels.dp.inc
@@ -6,13 +6,14 @@
 // Must be called with at least `max(stride_b * num_rows, krylov_dim *
 // num_cols)` threads in total.
 template <size_type block_size, typename ValueType>
-void initialize_kernel(
-    size_type num_rows, size_type num_cols, size_type krylov_dim,
-    const ValueType *__restrict__ b, size_type stride_b,
-    ValueType *__restrict__ residual, size_type stride_residual,
-    ValueType *__restrict__ givens_sin, size_type stride_sin,
-    ValueType *__restrict__ givens_cos, size_type stride_cos,
-    stopping_status *__restrict__ stop_status, sycl::nd_item<3> item_ct1)
+void initialize_kernel(size_type num_rows, size_type num_cols,
+                       size_type krylov_dim, const ValueType* __restrict__ b,
+                       size_type stride_b, ValueType* __restrict__ residual,
+                       size_type stride_residual,
+                       ValueType* __restrict__ givens_sin, size_type stride_sin,
+                       ValueType* __restrict__ givens_cos, size_type stride_cos,
+                       stopping_status* __restrict__ stop_status,
+                       sycl::nd_item<3> item_ct1)
 {
     const auto global_id = thread::get_thread_id_flat(item_ct1);
 
@@ -39,15 +40,15 @@ void initialize_kernel(
 
 template <size_type block_size, typename ValueType>
 void initialize_kernel(dim3 grid, dim3 block, size_type dynamic_shared_memory,
-                         sycl::queue *queue, size_type num_rows,
-                         size_type num_cols, size_type krylov_dim,
-                         const ValueType *b, size_type stride_b,
-                         ValueType *residual, size_type stride_residual,
-                         ValueType *givens_sin, size_type stride_sin,
-                         ValueType *givens_cos, size_type stride_cos,
-                         stopping_status *stop_status)
+                       sycl::queue* queue, size_type num_rows,
+                       size_type num_cols, size_type krylov_dim,
+                       const ValueType* b, size_type stride_b,
+                       ValueType* residual, size_type stride_residual,
+                       ValueType* givens_sin, size_type stride_sin,
+                       ValueType* givens_cos, size_type stride_cos,
+                       stopping_status* stop_status)
 {
-    queue->submit([&](sycl::handler &cgh) {
+    queue->submit([&](sycl::handler& cgh) {
         cgh.parallel_for(
             sycl_nd_range(grid, block), [=](sycl::nd_item<3> item_ct1) {
                 initialize_kernel<block_size>(
@@ -61,12 +62,12 @@ void initialize_kernel(dim3 grid, dim3 block, size_type dynamic_shared_memory,
 
 template <typename ValueType>
 void calculate_sin_and_cos_kernel(size_type col_idx, size_type num_cols,
-                                  size_type iter, const ValueType &this_hess,
-                                  const ValueType &next_hess,
-                                  ValueType *givens_sin, size_type stride_sin,
-                                  ValueType *givens_cos, size_type stride_cos,
-                                  ValueType &register_sin,
-                                  ValueType &register_cos)
+                                  size_type iter, const ValueType& this_hess,
+                                  const ValueType& next_hess,
+                                  ValueType* givens_sin, size_type stride_sin,
+                                  ValueType* givens_cos, size_type stride_cos,
+                                  ValueType& register_sin,
+                                  ValueType& register_cos)
 {
     if (is_zero(this_hess)) {
         register_cos = zero<ValueType>();
@@ -89,10 +90,10 @@ void calculate_sin_and_cos_kernel(size_type col_idx, size_type num_cols,
 template <typename ValueType>
 void calculate_residual_norm_kernel(size_type col_idx, size_type num_cols,
                                     size_type iter,
-                                    const ValueType &register_sin,
-                                    const ValueType &register_cos,
-                                    remove_complex<ValueType> *residual_norm,
-                                    ValueType *residual_norm_collection,
+                                    const ValueType& register_sin,
+                                    const ValueType& register_cos,
+                                    remove_complex<ValueType>* residual_norm,
+                                    ValueType* residual_norm_collection,
                                     size_type stride_residual_norm_collection)
 {
     const auto this_rnc =
@@ -112,13 +113,13 @@ void calculate_residual_norm_kernel(size_type col_idx, size_type num_cols,
 template <size_type block_size, typename ValueType>
 void givens_rotation_kernel(
     size_type num_rows, size_type num_cols, size_type iter,
-    ValueType *__restrict__ hessenberg_iter, size_type stride_hessenberg,
-    ValueType *__restrict__ givens_sin, size_type stride_sin,
-    ValueType *__restrict__ givens_cos, size_type stride_cos,
-    remove_complex<ValueType> *__restrict__ residual_norm,
-    ValueType *__restrict__ residual_norm_collection,
+    ValueType* __restrict__ hessenberg_iter, size_type stride_hessenberg,
+    ValueType* __restrict__ givens_sin, size_type stride_sin,
+    ValueType* __restrict__ givens_cos, size_type stride_cos,
+    remove_complex<ValueType>* __restrict__ residual_norm,
+    ValueType* __restrict__ residual_norm_collection,
     size_type stride_residual_norm_collection,
-    const stopping_status *__restrict__ stop_status, sycl::nd_item<3> item_ct1)
+    const stopping_status* __restrict__ stop_status, sycl::nd_item<3> item_ct1)
 {
     const auto col_idx = thread::get_thread_id_flat(item_ct1);
 
@@ -167,18 +168,18 @@ void givens_rotation_kernel(
 
 template <size_type block_size, typename ValueType>
 void givens_rotation_kernel(dim3 grid, dim3 block,
-                            size_type dynamic_shared_memory, sycl::queue *queue,
+                            size_type dynamic_shared_memory, sycl::queue* queue,
                             size_type num_rows, size_type num_cols,
-                            size_type iter, ValueType *hessenberg_iter,
-                            size_type stride_hessenberg, ValueType *givens_sin,
-                            size_type stride_sin, ValueType *givens_cos,
+                            size_type iter, ValueType* hessenberg_iter,
+                            size_type stride_hessenberg, ValueType* givens_sin,
+                            size_type stride_sin, ValueType* givens_cos,
                             size_type stride_cos,
-                            remove_complex<ValueType> *residual_norm,
-                            ValueType *residual_norm_collection,
+                            remove_complex<ValueType>* residual_norm,
+                            ValueType* residual_norm_collection,
                             size_type stride_residual_norm_collection,
-                            const stopping_status *stop_status)
+                            const stopping_status* stop_status)
 {
-    queue->submit([&](sycl::handler &cgh) {
+    queue->submit([&](sycl::handler& cgh) {
         cgh.parallel_for(
             sycl_nd_range(grid, block), [=](sycl::nd_item<3> item_ct1) {
                 givens_rotation_kernel<block_size>(
@@ -195,11 +196,11 @@ void givens_rotation_kernel(dim3 grid, dim3 block,
 template <size_type block_size, typename ValueType>
 void solve_upper_triangular_kernel(
     size_type num_cols, size_type num_rhs,
-    const ValueType *__restrict__ residual_norm_collection,
+    const ValueType* __restrict__ residual_norm_collection,
     size_type stride_residual_norm_collection,
-    const ValueType *__restrict__ hessenberg, size_type stride_hessenberg,
-    ValueType *__restrict__ y, size_type stride_y,
-    const size_type *__restrict__ final_iter_nums, sycl::nd_item<3> item_ct1)
+    const ValueType* __restrict__ hessenberg, size_type stride_hessenberg,
+    ValueType* __restrict__ y, size_type stride_y,
+    const size_type* __restrict__ final_iter_nums, sycl::nd_item<3> item_ct1)
 {
     const auto col_idx = thread::get_thread_id_flat(item_ct1);
 
@@ -225,14 +226,14 @@ void solve_upper_triangular_kernel(
 
 template <size_type block_size, typename ValueType>
 void solve_upper_triangular_kernel(
-    dim3 grid, dim3 block, size_type dynamic_shared_memory, sycl::queue *queue,
+    dim3 grid, dim3 block, size_type dynamic_shared_memory, sycl::queue* queue,
     size_type num_cols, size_type num_rhs,
-    const ValueType *residual_norm_collection,
-    size_type stride_residual_norm_collection, const ValueType *hessenberg,
-    size_type stride_hessenberg, ValueType *y, size_type stride_y,
-    const size_type *final_iter_nums)
+    const ValueType* residual_norm_collection,
+    size_type stride_residual_norm_collection, const ValueType* hessenberg,
+    size_type stride_hessenberg, ValueType* y, size_type stride_y,
+    const size_type* final_iter_nums)
 {
-    queue->submit([&](sycl::handler &cgh) {
+    queue->submit([&](sycl::handler& cgh) {
         cgh.parallel_for(
             sycl_nd_range(grid, block), [=](sycl::nd_item<3> item_ct1) {
                 solve_upper_triangular_kernel<block_size>(

--- a/examples/kokkos_assembly/kokkos_assembly.cpp
+++ b/examples/kokkos_assembly/kokkos_assembly.cpp
@@ -8,8 +8,8 @@
 
 
 #include <omp.h>
-#include <Kokkos_Core.hpp>
 #include <ginkgo/ginkgo.hpp>
+#include <Kokkos_Core.hpp>
 
 
 // Creates a stencil matrix in CSR format for the given number of discretization

--- a/include/ginkgo/core/log/papi.hpp
+++ b/include/ginkgo/core/log/papi.hpp
@@ -16,6 +16,8 @@
 #include <iostream>
 #include <map>
 #include <mutex>
+
+
 #include <sde_lib.h>
 
 

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -3,10 +3,7 @@ if(GINKGO_BUILD_TESTS AND (NOT GTest_FOUND))
     add_subdirectory(gtest)
 endif()
 
-if(GINKGO_DEVEL_TOOLS)
-    set(GCF_IGNORE_LIST "third_party" CACHE STRING "Ignore directories for GCF")
-    add_subdirectory(git-cmake-format)
-else()
+if(NOT GINKGO_DEVEL_TOOLS)
     add_subdirectory(dummy-hook)
 endif()
 


### PR DESCRIPTION
This PR enables us to force users to use the same version of clang-format as our CI. This is done by requiring contributors to install [pre-commit](https://pre-commit.com/) (which can be done easily through pip/pipx). pre-commit allows us to fix the used version of clang-format, so that contributors will use exactly the same version as our CI.

If pre-commit can't be detected during cmake an error is thrown. Otherwise, the pre-commit hooks are installed.

Since this replaces our git-cmake-format, I have removed it.

To see it in action: here is an PR in a fork that shows the CI use cases https://github.com/MarcelKoch/ginkgo/pull/9

# Warning

For those using git-worktrees, if one working tree is updated with this PR it will overwrite the git hooks for all working trees (I don't think you can have different hooks for different working trees). The easy fix is of course to just update all used working trees accordingly.