### PR TITLE
Support reordering in all benchmarks

### DIFF
--- a/benchmark/blas/distributed/multi_vector.cpp
+++ b/benchmark/blas/distributed/multi_vector.cpp
@@ -38,6 +38,9 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <iostream>
 
 
+#define GKO_BENCHMARK_DISTRIBUTED
+
+
 #include "benchmark/blas/blas_common.hpp"
 #include "benchmark/utils/general.hpp"
 #include "benchmark/utils/generator.hpp"

--- a/benchmark/conversion/conversion.cpp
+++ b/benchmark/conversion/conversion.cpp
@@ -118,6 +118,8 @@ struct ConversionBenchmark : Benchmark<gko::device_matrix_data<etype, itype>> {
     {
         gko::matrix_data<etype, itype> data;
         data = Generator::generate_matrix_data(test_case);
+        // no reordering here, as it doesn't impact conversions beyond
+        // dense-sparse conversions
         std::clog << "Matrix is of size (" << data.size[0] << ", "
                   << data.size[1] << "), " << data.nonzeros.size() << std::endl;
         test_case["rows"] = data.size[0];

--- a/benchmark/matrix_statistics/matrix_statistics.cpp
+++ b/benchmark/matrix_statistics/matrix_statistics.cpp
@@ -186,6 +186,7 @@ struct MatrixStatistics : Benchmark<empty_state> {
                       json& test_case) const override
     {
         auto data = Generator::generate_matrix_data(test_case);
+        // no reordering here, as it doesn't change statistics
         std::clog << "Matrix is of size (" << data.size[0] << ", "
                   << data.size[1] << "), " << data.nonzeros.size() << std::endl;
         test_case["rows"] = data.size[0];

--- a/benchmark/preconditioner/preconditioner.cpp
+++ b/benchmark/preconditioner/preconditioner.cpp
@@ -183,6 +183,7 @@ struct PreconditionerBenchmark : Benchmark<preconditioner_benchmark_state> {
     {
         preconditioner_benchmark_state state;
         auto data = Generator::generate_matrix_data(test_case);
+        reorder(data, test_case);
 
         state.system_matrix =
             formats::matrix_factory(FLAGS_formats, exec, data);

--- a/benchmark/solver/distributed/solver.cpp
+++ b/benchmark/solver/distributed/solver.cpp
@@ -39,6 +39,9 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <set>
 
 
+#define GKO_BENCHMARK_DISTRIBUTED
+
+
 #include "benchmark/solver/solver_common.hpp"
 #include "benchmark/utils/general_matrix.hpp"
 #include "benchmark/utils/generator.hpp"

--- a/benchmark/solver/solver_common.hpp
+++ b/benchmark/solver/solver_common.hpp
@@ -435,8 +435,7 @@ struct SolverBenchmark : Benchmark<solver_benchmark_state<Generator>> {
             state.x = generator.initialize({0.0}, exec);
         } else {
             auto data = generator.generate_matrix_data(test_case);
-            auto permutation =
-                reorder(data, test_case, generator.is_distributed());
+            auto permutation = reorder(data, test_case);
 
             state.system_matrix = generator.generate_matrix_with_format(
                 exec, test_case["optimal"]["spmv"].get<std::string>(), data);

--- a/benchmark/sparse_blas/sparse_blas.cpp
+++ b/benchmark/sparse_blas/sparse_blas.cpp
@@ -114,7 +114,7 @@ struct SparseBlasBenchmark : Benchmark<std::unique_ptr<Mtx>> {
                                json& test_case) const override
     {
         auto data = Generator::generate_matrix_data(test_case);
-        data.ensure_row_major_order();
+        reorder(data, test_case);
         std::clog << "Matrix is of size (" << data.size[0] << ", "
                   << data.size[1] << "), " << data.nonzeros.size() << std::endl;
         test_case["rows"] = data.size[0];

--- a/benchmark/spmv/distributed/spmv.cpp
+++ b/benchmark/spmv/distributed/spmv.cpp
@@ -43,6 +43,9 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <typeinfo>
 
 
+#define GKO_BENCHMARK_DISTRIBUTED
+
+
 #include "benchmark/spmv/spmv_common.hpp"
 #include "benchmark/utils/general_matrix.hpp"
 #include "benchmark/utils/generator.hpp"

--- a/benchmark/spmv/spmv_common.hpp
+++ b/benchmark/spmv/spmv_common.hpp
@@ -36,6 +36,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "benchmark/utils/formats.hpp"
 #include "benchmark/utils/general.hpp"
+#include "benchmark/utils/general_matrix.hpp"
 #include "benchmark/utils/iteration_control.hpp"
 #include "benchmark/utils/loggers.hpp"
 #include "benchmark/utils/runner.hpp"
@@ -104,6 +105,7 @@ struct SpmvBenchmark : Benchmark<spmv_benchmark_state<Generator>> {
     {
         spmv_benchmark_state<Generator> state;
         state.data = generator.generate_matrix_data(test_case);
+        reorder(state.data, test_case, generator.is_distributed());
 
         auto nrhs = FLAGS_nrhs;
         state.b = generator.create_multi_vector_random(

--- a/benchmark/spmv/spmv_common.hpp
+++ b/benchmark/spmv/spmv_common.hpp
@@ -105,7 +105,7 @@ struct SpmvBenchmark : Benchmark<spmv_benchmark_state<Generator>> {
     {
         spmv_benchmark_state<Generator> state;
         state.data = generator.generate_matrix_data(test_case);
-        reorder(state.data, test_case, generator.is_distributed());
+        reorder(state.data, test_case);
 
         auto nrhs = FLAGS_nrhs;
         state.b = generator.create_multi_vector_random(

--- a/benchmark/test/preconditioner.py
+++ b/benchmark/test/preconditioner.py
@@ -43,3 +43,11 @@ test_framework.compare_output(
     expected_stdout="preconditioner.profile.stdout",
     expected_stderr="preconditioner.profile.stderr",
 )
+
+# stdin
+test_framework.compare_output(
+    ["-reorder", "amd"],
+    expected_stdout="preconditioner.reordered.stdout",
+    expected_stderr="preconditioner.reordered.stderr",
+    stdin='[{"size": 100, "stencil": "7pt"}]',
+)

--- a/benchmark/test/reference/preconditioner.reordered.stderr
+++ b/benchmark/test/reference/preconditioner.reordered.stderr
@@ -1,0 +1,9 @@
+This is Ginkgo 1.7.0 (develop)
+    running with core module 1.7.0 (develop)
+Running on reference(0)
+Running with 2 warm iterations and 10 running iterations
+The random seed for right hand sides is 42
+Running with preconditioners: none
+Running test case stencil(100, 7pt)
+Matrix is of size (125, 125), 725
+	Running preconditioner: none

--- a/benchmark/test/reference/preconditioner.reordered.stdout
+++ b/benchmark/test/reference/preconditioner.reordered.stdout
@@ -1,0 +1,33 @@
+[
+    {
+        "size": 100,
+        "stencil": "7pt",
+        "preconditioner": {
+            "none": {
+                "generate": {
+                    "components": {
+                        "generate(<typename>)": 1.0,
+                        "overhead": 1.0
+                    },
+                    "time": 1.0,
+                    "repetitions": 10
+                },
+                "apply": {
+                    "components": {
+                        "apply(<typename>)": 1.0,
+                        "copy(<typename>)": 1.0,
+                        "dense::copy": 1.0,
+                        "overhead": 1.0
+                    },
+                    "time": 1.0,
+                    "repetitions": 10
+                },
+                "completed": true
+            }
+        },
+        "reordered": "amd",
+        "rows": 125,
+        "cols": 125,
+        "nonzeros": 725
+    }
+]

--- a/benchmark/test/reference/solver.reordered.stderr
+++ b/benchmark/test/reference/solver.reordered.stderr
@@ -1,0 +1,10 @@
+This is Ginkgo 1.7.0 (develop)
+    running with core module 1.7.0 (develop)
+Running on reference(0)
+Running with 2 warm iterations and 1 running iterations
+The random seed for right hand sides is 42
+Running cg with 1000 iterations and residual goal of 1.000000e-06
+The number of right hand sides is 1
+Running test case stencil(100, 7pt)
+Matrix is of size (125, 125)
+	Running solver: cg

--- a/benchmark/test/reference/solver.reordered.stdout
+++ b/benchmark/test/reference/solver.reordered.stdout
@@ -1,0 +1,57 @@
+[
+    {
+        "size": 100,
+        "stencil": "7pt",
+        "optimal": {
+            "spmv": "csr"
+        },
+        "solver": {
+            "cg": {
+                "recurrent_residuals": [],
+                "true_residuals": [],
+                "implicit_residuals": [],
+                "iteration_timestamps": [],
+                "rhs_norm": 1.0,
+                "generate": {
+                    "components": {
+                        "generate(<typename>)": 1.0,
+                        "free": 1.0,
+                        "overhead": 1.0
+                    },
+                    "time": 1.0
+                },
+                "apply": {
+                    "components": {
+                        "apply(<typename>)": 1.0,
+                        "iteration": 1.0,
+                        "allocate": 1.0,
+                        "dense::fill": 1.0,
+                        "cg::initialize": 1.0,
+                        "advanced_apply(<typename>)": 1.0,
+                        "csr::advanced_spmv": 1.0,
+                        "dense::compute_norm2_dispatch": 1.0,
+                        "copy(<typename>)": 1.0,
+                        "dense::copy": 1.0,
+                        "dense::compute_conj_dot_dispatch": 1.0,
+                        "check(<typename>)": 1.0,
+                        "residual_norm::residual_norm": 1.0,
+                        "cg::step_1": 1.0,
+                        "csr::spmv": 1.0,
+                        "cg::step_2": 1.0,
+                        "free": 1.0,
+                        "overhead": 1.0
+                    },
+                    "iterations": 7,
+                    "time": 1.0
+                },
+                "preconditioner": {},
+                "residual_norm": 1.0,
+                "repetitions": 1,
+                "completed": true
+            }
+        },
+        "reordered": "amd",
+        "rows": 125,
+        "cols": 125
+    }
+]

--- a/benchmark/test/reference/sparse_blas.reordered.stderr
+++ b/benchmark/test/reference/sparse_blas.reordered.stderr
@@ -1,0 +1,9 @@
+This is Ginkgo 1.7.0 (develop)
+    running with core module 1.7.0 (develop)
+Running on reference(0)
+Running with 2 warm iterations and 10 running iterations
+The random seed for right hand sides is 42
+The operations are symbolic_cholesky
+Running test case stencil(100, 7pt)
+Matrix is of size (125, 125), 725
+	Running sparse_blas: symbolic_cholesky

--- a/benchmark/test/reference/sparse_blas.reordered.stdout
+++ b/benchmark/test/reference/sparse_blas.reordered.stdout
@@ -1,0 +1,32 @@
+[
+    {
+        "size": 100,
+        "stencil": "7pt",
+        "sparse_blas": {
+            "symbolic_cholesky": {
+                "time": 1.0,
+                "flops": 1.0,
+                "bandwidth": 1.0,
+                "repetitions": 10,
+                "components": {
+                    "compute_elim_forest": 1.0,
+                    "allocate": 1.0,
+                    "free": 1.0,
+                    "components::fill_array": 1.0,
+                    "cholesky::symbolic_count": 1.0,
+                    "components::prefix_sum_nonnegative": 1.0,
+                    "copy": 1.0,
+                    "cholesky::symbolic_factorize": 1.0,
+                    "csr::sort_by_column_index": 1.0,
+                    "overhead": 1.0
+                },
+                "factor_nonzeros": 1324,
+                "completed": true
+            }
+        },
+        "reordered": "amd",
+        "rows": 125,
+        "cols": 125,
+        "nonzeros": 725
+    }
+]

--- a/benchmark/test/reference/spmv.reordered.stderr
+++ b/benchmark/test/reference/spmv.reordered.stderr
@@ -1,0 +1,10 @@
+This is Ginkgo 1.7.0 (develop)
+    running with core module 1.7.0 (develop)
+Running on reference(0)
+Running with 2 warm iterations and 10 running iterations
+The random seed for right hand sides is 42
+The formats are coo
+The number of right hand sides is 1
+Running test case stencil(100, 7pt)
+Matrix is of size (125, 125), 725
+	Running spmv: coo

--- a/benchmark/test/reference/spmv.reordered.stdout
+++ b/benchmark/test/reference/spmv.reordered.stdout
@@ -1,0 +1,22 @@
+[
+    {
+        "size": 100,
+        "stencil": "7pt",
+        "spmv": {
+            "coo": {
+                "storage": 11600,
+                "max_relative_norm2": 1.0,
+                "time": 1.0,
+                "repetitions": 10,
+                "completed": true
+            }
+        },
+        "reordered": "amd",
+        "rows": 125,
+        "cols": 125,
+        "nonzeros": 725,
+        "optimal": {
+            "spmv": "coo"
+        }
+    }
+]

--- a/benchmark/test/solver.py
+++ b/benchmark/test/solver.py
@@ -43,3 +43,11 @@ test_framework.compare_output(
     expected_stdout="solver.profile.stdout",
     expected_stderr="solver.profile.stderr",
 )
+
+# reordering
+test_framework.compare_output(
+    ["-reorder", "amd"],
+    expected_stdout="solver.reordered.stdout",
+    expected_stderr="solver.reordered.stderr",
+    stdin='[{"size": 100, "stencil": "7pt", "optimal": {"spmv": "csr"}}]',
+)

--- a/benchmark/test/sparse_blas.py
+++ b/benchmark/test/sparse_blas.py
@@ -4,7 +4,8 @@ import test_framework
 # check that all input modes work:
 # parameter
 test_framework.compare_output(
-    ["-operations", "transpose", "-input", '[{"size": 100, "stencil": "7pt"}]'],
+    ["-operations", "transpose", "-input",
+        '[{"size": 100, "stencil": "7pt"}]'],
     expected_stdout="sparse_blas.simple.stdout",
     expected_stderr="sparse_blas.simple.stderr",
 )
@@ -54,4 +55,12 @@ test_framework.compare_output(
     ],
     expected_stdout="sparse_blas.profile.stdout",
     expected_stderr="sparse_blas.profile.stderr",
+)
+
+# reordering
+test_framework.compare_output(
+    ["-operations", "symbolic_cholesky", "-reorder", "amd"],
+    expected_stdout="sparse_blas.reordered.stdout",
+    expected_stderr="sparse_blas.reordered.stderr",
+    stdin='[{"size": 100, "stencil": "7pt"}]',
 )

--- a/benchmark/test/spmv.py
+++ b/benchmark/test/spmv.py
@@ -43,3 +43,11 @@ test_framework.compare_output(
     expected_stdout="spmv.profile.stdout",
     expected_stderr="spmv.profile.stderr",
 )
+
+# stdin
+test_framework.compare_output(
+    ["-reorder", "amd"],
+    expected_stdout="spmv.reordered.stdout",
+    expected_stderr="spmv.reordered.stderr",
+    stdin='[{"size": 100, "stencil": "7pt"}]',
+)

--- a/benchmark/utils/generator.hpp
+++ b/benchmark/utils/generator.hpp
@@ -52,20 +52,25 @@ struct DefaultSystemGenerator {
     using value_type = ValueType;
     using Vec = vec<ValueType>;
 
+    static bool is_distributed() { return false; }
+
     static gko::matrix_data<ValueType, IndexType> generate_matrix_data(
         const json& config)
     {
+        gko::matrix_data<ValueType, IndexType> data;
         if (config.contains("filename")) {
             std::ifstream in(config["filename"].get<std::string>());
-            return gko::read_generic_raw<ValueType, IndexType>(in);
+            data = gko::read_generic_raw<ValueType, IndexType>(in);
         } else if (config.contains("stencil")) {
-            return generate_stencil<ValueType, IndexType>(
+            data = generate_stencil<ValueType, IndexType>(
                 config["stencil"].get<std::string>(),
                 config["size"].get<gko::int64>());
         } else {
             throw std::runtime_error(
                 "No known way to generate matrix data found.");
         }
+        data.ensure_row_major_order();
+        return data;
     }
 
     static std::string get_example_config()
@@ -188,16 +193,19 @@ struct DistributedDefaultSystemGenerator {
     using Mtx = dist_mtx<value_type, local_index_type, index_type>;
     using Vec = dist_vec<value_type>;
 
+    static bool is_distributed() { return true; }
+
     gko::matrix_data<value_type, index_type> generate_matrix_data(
         const json& config) const
     {
+        gko::matrix_data<value_type, index_type> data;
         if (config.contains("filename")) {
             std::ifstream in(config["filename"].get<std::string>());
-            return gko::read_generic_raw<value_type, index_type>(in);
+            data = gko::read_generic_raw<value_type, index_type>(in);
         } else if (config.contains("stencil")) {
             auto local_size = static_cast<global_itype>(
                 config["size"].get<gko::int64>() / comm.size());
-            return generate_stencil<value_type, index_type>(
+            data = generate_stencil<value_type, index_type>(
                 config["stencil"].get<std::string>(), comm, local_size,
                 config["comm_pattern"].get<std::string>() ==
                     std::string("optimal"));
@@ -205,6 +213,8 @@ struct DistributedDefaultSystemGenerator {
             throw std::runtime_error(
                 "No known way to generate matrix data found.");
         }
+        data.ensure_row_major_order();
+        return data;
     }
 
     static std::string get_example_config()
@@ -238,15 +248,6 @@ struct DistributedDefaultSystemGenerator {
         } else {
             throw std::runtime_error("No known way to describe config.");
         }
-    }
-
-    std::shared_ptr<gko::LinOp> generate_matrix_with_optimal_format(
-        std::shared_ptr<gko::Executor> exec, json& config) const
-    {
-        auto data = generate_matrix_data(config);
-        return generate_matrix_with_format(
-            std::move(exec), config["optimal"]["spmv"].get<std::string>(),
-            data);
     }
 
     std::shared_ptr<gko::LinOp> generate_matrix_with_format(

--- a/benchmark/utils/generator.hpp
+++ b/benchmark/utils/generator.hpp
@@ -52,8 +52,6 @@ struct DefaultSystemGenerator {
     using value_type = ValueType;
     using Vec = vec<ValueType>;
 
-    static bool is_distributed() { return false; }
-
     static gko::matrix_data<ValueType, IndexType> generate_matrix_data(
         const json& config)
     {
@@ -192,8 +190,6 @@ struct DistributedDefaultSystemGenerator {
 
     using Mtx = dist_mtx<value_type, local_index_type, index_type>;
     using Vec = dist_vec<value_type>;
-
-    static bool is_distributed() { return true; }
 
     gko::matrix_data<value_type, index_type> generate_matrix_data(
         const json& config) const


### PR DESCRIPTION
This adds another `reorder` parameter to the input JSON, allowing users to specify a reordering algorithm to be applied on the matrix before proceeding. The reordering time itself is not being measured in the benchmark (Should it be?). I am also a bit unsure where to document this.

For consistency, I also added a new interface for RCM that creates a `Permutation`

Fixes #1374 