### PR TITLE
Fix HIP deprecation warnings

### DIFF
--- a/benchmark/utils/hip_linops.hip.cpp
+++ b/benchmark/utils/hip_linops.hip.cpp
@@ -36,9 +36,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <memory>
 
 
-#include <hipsparse.h>
-
-
 #include "benchmark/utils/sparselib_linops.hpp"
 #include "benchmark/utils/types.hpp"
 #include "hip/base/hipsparse_bindings.hip.hpp"

--- a/cmake/hip.cmake
+++ b/cmake/hip.cmake
@@ -207,7 +207,7 @@ set(GINKGO_HIPCC_OPTIONS ${GINKGO_HIP_COMPILER_FLAGS} "-std=c++14 -DGKO_COMPILIN
 set(GINKGO_HIP_NVCC_OPTIONS ${GINKGO_HIP_NVCC_COMPILER_FLAGS} ${GINKGO_HIP_NVCC_ARCH} ${GINKGO_HIP_NVCC_ADDITIONAL_FLAGS})
 set(GINKGO_HIP_CLANG_OPTIONS ${GINKGO_HIP_CLANG_COMPILER_FLAGS} ${GINKGO_AMD_ARCH_FLAGS})
 if(GINKGO_HIP_AMD_UNSAFE_ATOMIC AND HIP_VERSION VERSION_GREATER_EQUAL 5)
-    list(APPEND GINKGO_HIP_CLANG_OPTIONS -munsafe-fp-atomics)
+    list(APPEND GINKGO_HIP_CLANG_OPTIONS "-munsafe-fp-atomics -Wno-unused-command-line-argument")
 endif()
 # HIP's cmake support secretly carries around global state to remember
 # whether we created any shared libraries, and sets PIC flags accordingly.

--- a/hip/base/exception.hip.cpp
+++ b/hip/base/exception.hip.cpp
@@ -37,9 +37,15 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
 #include <hip/hip_runtime.h>
+#if HIP_VERSION >= 50200000
+#include <hipblas/hipblas.h>
+#include <hiprand/hiprand.h>
+#include <hipsparse/hipsparse.h>
+#else
 #include <hipblas.h>
 #include <hiprand.h>
 #include <hipsparse.h>
+#endif
 
 
 #include <ginkgo/core/base/types.hpp>

--- a/hip/base/hipblas_bindings.hip.hpp
+++ b/hip/base/hipblas_bindings.hip.hpp
@@ -34,7 +34,12 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define GKO_HIP_BASE_HIPBLAS_BINDINGS_HIP_HPP_
 
 
+#include <hip/hip_runtime.h>
+#if HIP_VERSION >= 50200000
+#include <hipblas/hipblas.h>
+#else
 #include <hipblas.h>
+#endif
 
 
 #include <ginkgo/core/base/exception_helpers.hpp>

--- a/hip/base/hiprand_bindings.hip.hpp
+++ b/hip/base/hiprand_bindings.hip.hpp
@@ -34,7 +34,12 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define GKO_HIP_BASE_HIPRAND_BINDINGS_HIP_HPP_
 
 
+#include <hip/hip_runtime.h>
+#if HIP_VERSION >= 50200000
+#include <hiprand/hiprand.h>
+#else
 #include <hiprand.h>
+#endif
 
 
 #include <ginkgo/core/base/exception_helpers.hpp>

--- a/hip/base/hipsparse_bindings.hip.hpp
+++ b/hip/base/hipsparse_bindings.hip.hpp
@@ -34,7 +34,12 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define GKO_HIP_BASE_HIPSPARSE_BINDINGS_HIP_HPP_
 
 
+#include <hip/hip_runtime.h>
+#if HIP_VERSION >= 50200000
+#include <hipsparse/hipsparse.h>
+#else
 #include <hipsparse.h>
+#endif
 
 
 #include <ginkgo/core/base/exception_helpers.hpp>

--- a/hip/base/hipsparse_block_bindings.hip.hpp
+++ b/hip/base/hipsparse_block_bindings.hip.hpp
@@ -34,7 +34,12 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define GKO_HIP_BASE_HIPSPARSE_BLOCK_BINDINGS_HIP_HPP_
 
 
+#include <hip/hip_runtime.h>
+#if HIP_VERSION >= 50200000
+#include <hipsparse/hipsparse.h>
+#else
 #include <hipsparse.h>
+#endif
 
 
 #include <ginkgo/core/base/exception_helpers.hpp>

--- a/hip/base/pointer_mode_guard.hip.hpp
+++ b/hip/base/pointer_mode_guard.hip.hpp
@@ -38,8 +38,13 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
 #include <hip/hip_runtime.h>
+#if HIP_VERSION >= 50200000
+#include <hipblas/hipblas.h>
+#include <hipsparse/hipsparse.h>
+#else
 #include <hipblas.h>
 #include <hipsparse.h>
+#endif
 
 
 #include <ginkgo/core/base/exception_helpers.hpp>

--- a/hip/base/roctx.hip.cpp
+++ b/hip/base/roctx.hip.cpp
@@ -37,7 +37,11 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
 #if GINKGO_HIP_PLATFORM_HCC && GKO_HAVE_ROCTX
+#if HIP_VERSION >= 50200000
+#include <roctracer/roctx.h>
+#else
 #include <roctx.h>
+#endif
 #endif
 
 

--- a/hip/base/types.hip.hpp
+++ b/hip/base/types.hip.hpp
@@ -43,7 +43,11 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <hip/hip_complex.h>
 #include <hip/hip_fp16.h>
 #include <hip/hip_runtime.h>
+#if HIP_VERSION >= 50200000
+#include <hipblas/hipblas.h>
+#else
 #include <hipblas.h>
+#endif
 #include <thrust/complex.h>
 
 

--- a/hip/matrix/fft_kernels.hip.cpp
+++ b/hip/matrix/fft_kernels.hip.cpp
@@ -36,7 +36,12 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <array>
 
 
+#include <hip/hip_runtime.h>
+#if HIP_VERSION >= 50200000
+#include <hipfft/hipfft.h>
+#else
 #include <hipfft.h>
+#endif
 
 
 #include <ginkgo/core/base/exception_helpers.hpp>

--- a/hip/solver/common_trs_kernels.hip.hpp
+++ b/hip/solver/common_trs_kernels.hip.hpp
@@ -39,7 +39,11 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
 #include <hip/hip_runtime.h>
+#if HIP_VERSION >= 50200000
+#include <hipsparse/hipsparse.h>
+#else
 #include <hipsparse.h>
+#endif
 
 
 #include <ginkgo/core/base/exception_helpers.hpp>

--- a/hip/solver/lower_trs_kernels.hip.cpp
+++ b/hip/solver/lower_trs_kernels.hip.cpp
@@ -37,7 +37,11 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
 #include <hip/hip_runtime.h>
+#if HIP_VERSION >= 50200000
+#include <hipsparse/hipsparse.h>
+#else
 #include <hipsparse.h>
+#endif
 
 
 #include <ginkgo/core/base/exception_helpers.hpp>

--- a/hip/solver/upper_trs_kernels.hip.cpp
+++ b/hip/solver/upper_trs_kernels.hip.cpp
@@ -37,7 +37,11 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
 #include <hip/hip_runtime.h>
+#if HIP_VERSION >= 50200000
+#include <hipsparse/hipsparse.h>
+#else
 #include <hipsparse.h>
+#endif
 
 
 #include <ginkgo/core/base/exception_helpers.hpp>

--- a/hip/test/base/exception_helpers.hip.cpp
+++ b/hip/test/base/exception_helpers.hip.cpp
@@ -34,9 +34,15 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
 #include <hip/hip_runtime.h>
+#if HIP_VERSION >= 50200000
+#include <hipblas/hipblas.h>
+#include <hiprand/hiprand.h>
+#include <hipsparse/hipsparse.h>
+#else
 #include <hipblas.h>
 #include <hiprand.h>
 #include <hipsparse.h>
+#endif
 
 
 #include <gtest/gtest.h>

--- a/hip/test/matrix/fft_kernels.hip.cpp
+++ b/hip/test/matrix/fft_kernels.hip.cpp
@@ -33,7 +33,12 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <ginkgo/core/matrix/fft.hpp>
 
 
+#include <hip/hip_runtime.h>
+#if HIP_VERSION >= 50200000
+#include <hipfft/hipfft.h>
+#else
 #include <hipfft.h>
+#endif
 
 
 #include <gtest/gtest.h>


### PR DESCRIPTION
This fixes most warnings present in current ROCm builds:
* use `hipsparse/hipsparse.h` instead of `hipsparse.h`, similar for other includes
* hide warnings related to `-funsafe-fp-atomics` in the depfile generation