### PR TITLE
Add a Dense batched class and kernels

### DIFF
--- a/common/cuda_hip/matrix/batch_dense_kernel_launcher.hpp.inc
+++ b/common/cuda_hip/matrix/batch_dense_kernel_launcher.hpp.inc
@@ -1,0 +1,78 @@
+/*******************************<GINKGO LICENSE>******************************
+Copyright (c) 2017-2023, the Ginkgo authors
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+******************************<GINKGO LICENSE>*******************************/
+
+
+template <typename ValueType>
+void simple_apply(std::shared_ptr<const DefaultExecutor> exec,
+                  const batch::matrix::BatchDense<ValueType>* mat,
+                  const batch::MultiVector<ValueType>* b,
+                  batch::MultiVector<ValueType>* x)
+{
+    const auto num_blocks = mat->get_num_batch_items();
+    const auto b_ub = get_batch_struct(b);
+    const auto x_ub = get_batch_struct(x);
+    const auto mat_ub = get_batch_struct(mat);
+    if (b->get_common_size()[1] > 1) {
+        GKO_NOT_IMPLEMENTED;
+    }
+    simple_apply_kernel<<<num_blocks, default_block_size, 0,
+                          exec->get_stream()>>>(mat_ub, b_ub, x_ub);
+}
+
+GKO_INSTANTIATE_FOR_EACH_VALUE_TYPE(
+    GKO_DECLARE_BATCH_DENSE_SIMPLE_APPLY_KERNEL);
+
+
+template <typename ValueType>
+void advanced_apply(std::shared_ptr<const DefaultExecutor> exec,
+                    const batch::MultiVector<ValueType>* alpha,
+                    const batch::matrix::BatchDense<ValueType>* mat,
+                    const batch::MultiVector<ValueType>* b,
+                    const batch::MultiVector<ValueType>* beta,
+                    batch::MultiVector<ValueType>* x)
+{
+    const auto num_blocks = mat->get_num_batch_items();
+    const auto b_ub = get_batch_struct(b);
+    const auto x_ub = get_batch_struct(x);
+    const auto mat_ub = get_batch_struct(mat);
+    const auto alpha_ub = get_batch_struct(alpha);
+    const auto beta_ub = get_batch_struct(beta);
+    if (b->get_common_size()[1] > 1) {
+        GKO_NOT_IMPLEMENTED;
+    }
+    advanced_apply_kernel<<<num_blocks, default_block_size, 0,
+                            exec->get_stream()>>>(alpha_ub, mat_ub, b_ub,
+                                                  beta_ub, x_ub);
+}
+
+GKO_INSTANTIATE_FOR_EACH_VALUE_TYPE(
+    GKO_DECLARE_BATCH_DENSE_ADVANCED_APPLY_KERNEL);

--- a/common/cuda_hip/matrix/batch_dense_kernel_launcher.hpp.inc
+++ b/common/cuda_hip/matrix/batch_dense_kernel_launcher.hpp.inc
@@ -33,7 +33,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 template <typename ValueType>
 void simple_apply(std::shared_ptr<const DefaultExecutor> exec,
-                  const batch::matrix::BatchDense<ValueType>* mat,
+                  const batch::matrix::Dense<ValueType>* mat,
                   const batch::MultiVector<ValueType>* b,
                   batch::MultiVector<ValueType>* x)
 {
@@ -55,7 +55,7 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_TYPE(
 template <typename ValueType>
 void advanced_apply(std::shared_ptr<const DefaultExecutor> exec,
                     const batch::MultiVector<ValueType>* alpha,
-                    const batch::matrix::BatchDense<ValueType>* mat,
+                    const batch::matrix::Dense<ValueType>* mat,
                     const batch::MultiVector<ValueType>* b,
                     const batch::MultiVector<ValueType>* beta,
                     batch::MultiVector<ValueType>* x)

--- a/common/cuda_hip/matrix/batch_dense_kernels.hpp.inc
+++ b/common/cuda_hip/matrix/batch_dense_kernels.hpp.inc
@@ -33,7 +33,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 template <typename ValueType>
 __device__ __forceinline__ void simple_apply(
-    const gko::batch::matrix::batch_dense::batch_item<const ValueType>& mat,
+    const gko::batch::matrix::dense::batch_item<const ValueType>& mat,
     const ValueType* const __restrict__ b, ValueType* const __restrict__ x)
 {
     constexpr auto tile_size = config::warp_size;
@@ -65,10 +65,9 @@ template <typename ValueType>
 __global__ __launch_bounds__(
     default_block_size,
     sm_oversubscription) void simple_apply_kernel(const gko::batch::matrix::
-                                                      batch_dense::
-                                                          uniform_batch<
-                                                              const ValueType>
-                                                              mat,
+                                                      dense::uniform_batch<
+                                                          const ValueType>
+                                                          mat,
                                                   const gko::batch::
                                                       multi_vector::
                                                           uniform_batch<
@@ -94,7 +93,7 @@ __global__ __launch_bounds__(
 template <typename ValueType>
 __device__ __forceinline__ void advanced_apply(
     const ValueType alpha,
-    const gko::batch::matrix::batch_dense::batch_item<const ValueType>& mat,
+    const gko::batch::matrix::dense::batch_item<const ValueType>& mat,
     const ValueType* const __restrict__ b, const ValueType beta,
     ValueType* const __restrict__ x)
 {
@@ -132,10 +131,9 @@ __global__ __launch_bounds__(
                                                                 const ValueType>
                                                                 alpha,
                                                     const gko::batch::matrix::
-                                                        batch_dense::
-                                                            uniform_batch<
-                                                                const ValueType>
-                                                                mat,
+                                                        dense::uniform_batch<
+                                                            const ValueType>
+                                                            mat,
                                                     const gko::batch::
                                                         multi_vector::
                                                             uniform_batch<

--- a/common/cuda_hip/matrix/batch_dense_kernels.hpp.inc
+++ b/common/cuda_hip/matrix/batch_dense_kernels.hpp.inc
@@ -52,10 +52,8 @@ __device__ __forceinline__ void simple_apply(
             temp += val * b[j];
         }
 
-#pragma unroll
-        for (int i = static_cast<int>(tile_size) / 2; i > 0; i /= 2) {
-            temp += subwarp_grp.shfl_down(temp, i);
-        }
+        // subgroup level reduction
+        temp = reduce(subgroup, temp, thrust::plus<ValueType>{});
 
         if (subwarp_grp.thread_rank() == 0) {
             x[row] = temp;
@@ -116,10 +114,8 @@ __device__ __forceinline__ void advanced_apply(
             temp += alpha * val * b[j];
         }
 
-#pragma unroll
-        for (int i = static_cast<int>(tile_size) / 2; i > 0; i /= 2) {
-            temp += subwarp_grp.shfl_down(temp, i);
-        }
+        // subgroup level reduction
+        temp = reduce(subgroup, temp, thrust::plus<ValueType>{});
 
         if (subwarp_grp.thread_rank() == 0) {
             x[row] = temp + beta * x[row];

--- a/common/cuda_hip/matrix/batch_dense_kernels.hpp.inc
+++ b/common/cuda_hip/matrix/batch_dense_kernels.hpp.inc
@@ -1,0 +1,170 @@
+/*******************************<GINKGO LICENSE>******************************
+Copyright (c) 2017-2023, the Ginkgo authors
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+******************************<GINKGO LICENSE>*******************************/
+
+
+template <typename ValueType>
+__device__ __forceinline__ void simple_apply(
+    const gko::batch::matrix::batch_dense::batch_item<const ValueType>& mat,
+    const ValueType* const __restrict__ b, ValueType* const __restrict__ x)
+{
+    constexpr auto tile_size = config::warp_size;
+
+    auto thread_block = group::this_thread_block();
+    auto subwarp_grp = group::tiled_partition<tile_size>(thread_block);
+    const auto subwarp_grp_id = static_cast<int>(threadIdx.x / tile_size);
+    const int num_subwarp_grps_per_block = ceildiv(blockDim.x, tile_size);
+
+    for (int row = subwarp_grp_id; row < mat.num_rows;
+         row += num_subwarp_grps_per_block) {
+        ValueType temp = zero<ValueType>();
+        for (int j = subwarp_grp.thread_rank(); j < mat.num_cols;
+             j += subwarp_grp.size()) {
+            const ValueType val = mat.values[row * mat.stride + j];
+            temp += val * b[j];
+        }
+
+#pragma unroll
+        for (int i = static_cast<int>(tile_size) / 2; i > 0; i /= 2) {
+            temp += subwarp_grp.shfl_down(temp, i);
+        }
+
+        if (subwarp_grp.thread_rank() == 0) {
+            x[row] = temp;
+        }
+    }
+}
+
+template <typename ValueType>
+__global__ __launch_bounds__(
+    default_block_size,
+    sm_oversubscription) void simple_apply_kernel(const gko::batch::matrix::
+                                                      batch_dense::
+                                                          uniform_batch<
+                                                              const ValueType>
+                                                              mat,
+                                                  const gko::batch::
+                                                      multi_vector::
+                                                          uniform_batch<
+                                                              const ValueType>
+                                                              b,
+                                                  const gko::batch::
+                                                      multi_vector::
+                                                          uniform_batch<
+                                                              ValueType>
+                                                              x)
+{
+    for (size_type batch_id = blockIdx.x; batch_id < mat.num_batch_items;
+         batch_id += gridDim.x) {
+        const auto mat_b =
+            gko::batch::matrix::extract_batch_item(mat, batch_id);
+        const auto b_b = gko::batch::extract_batch_item(b, batch_id);
+        const auto x_b = gko::batch::extract_batch_item(x, batch_id);
+        simple_apply(mat_b, b_b.values, x_b.values);
+    }
+}
+
+
+template <typename ValueType>
+__device__ __forceinline__ void advanced_apply(
+    const ValueType alpha,
+    const gko::batch::matrix::batch_dense::batch_item<const ValueType>& mat,
+    const ValueType* const __restrict__ b, const ValueType beta,
+    ValueType* const __restrict__ x)
+{
+    constexpr auto tile_size = config::warp_size;
+
+    auto thread_block = group::this_thread_block();
+    auto subwarp_grp = group::tiled_partition<tile_size>(thread_block);
+    const auto subwarp_grp_id = static_cast<int>(threadIdx.x / tile_size);
+    const int num_subwarp_grps_per_block = ceildiv(blockDim.x, tile_size);
+
+    for (int row = subwarp_grp_id; row < mat.num_rows;
+         row += num_subwarp_grps_per_block) {
+        ValueType temp = zero<ValueType>();
+        for (int j = subwarp_grp.thread_rank(); j < mat.num_cols;
+             j += subwarp_grp.size()) {
+            const ValueType val = mat.values[row * mat.stride + j];
+            temp += alpha * val * b[j];
+        }
+
+#pragma unroll
+        for (int i = static_cast<int>(tile_size) / 2; i > 0; i /= 2) {
+            temp += subwarp_grp.shfl_down(temp, i);
+        }
+
+        if (subwarp_grp.thread_rank() == 0) {
+            x[row] = temp + beta * x[row];
+        }
+    }
+}
+
+template <typename ValueType>
+__global__ __launch_bounds__(
+    default_block_size,
+    sm_oversubscription) void advanced_apply_kernel(const gko::batch::
+                                                        multi_vector::
+                                                            uniform_batch<
+                                                                const ValueType>
+                                                                alpha,
+                                                    const gko::batch::matrix::
+                                                        batch_dense::
+                                                            uniform_batch<
+                                                                const ValueType>
+                                                                mat,
+                                                    const gko::batch::
+                                                        multi_vector::
+                                                            uniform_batch<
+                                                                const ValueType>
+                                                                b,
+                                                    const gko::batch::
+                                                        multi_vector::
+                                                            uniform_batch<
+                                                                const ValueType>
+                                                                beta,
+                                                    const gko::batch::
+                                                        multi_vector::
+                                                            uniform_batch<
+                                                                ValueType>
+                                                                x)
+{
+    for (size_type batch_id = blockIdx.x; batch_id < mat.num_batch_items;
+         batch_id += gridDim.x) {
+        const auto mat_b =
+            gko::batch::matrix::extract_batch_item(mat, batch_id);
+        const auto b_b = gko::batch::extract_batch_item(b, batch_id);
+        const auto x_b = gko::batch::extract_batch_item(x, batch_id);
+        const auto alpha_b = gko::batch::extract_batch_item(alpha, batch_id);
+        const auto beta_b = gko::batch::extract_batch_item(beta, batch_id);
+        advanced_apply(alpha_b.values[0], mat_b, b_b.values, beta_b.values[0],
+                       x_b.values);
+    }
+}

--- a/common/cuda_hip/matrix/batch_dense_kernels.hpp.inc
+++ b/common/cuda_hip/matrix/batch_dense_kernels.hpp.inc
@@ -39,15 +39,15 @@ __device__ __forceinline__ void simple_apply(
     constexpr auto tile_size = config::warp_size;
 
     auto thread_block = group::this_thread_block();
-    auto subwarp_grp = group::tiled_partition<tile_size>(thread_block);
-    const auto subwarp_grp_id = static_cast<int>(threadIdx.x / tile_size);
-    const int num_subwarp_grps_per_block = ceildiv(blockDim.x, tile_size);
+    auto subgroup = group::tiled_partition<tile_size>(thread_block);
+    const auto subgroup_id = static_cast<int>(threadIdx.x / tile_size);
+    const int num_subgroups_per_block = ceildiv(blockDim.x, tile_size);
 
-    for (int row = subwarp_grp_id; row < mat.num_rows;
-         row += num_subwarp_grps_per_block) {
+    for (int row = subgroup_id; row < mat.num_rows;
+         row += num_subgroups_per_block) {
         ValueType temp = zero<ValueType>();
-        for (int j = subwarp_grp.thread_rank(); j < mat.num_cols;
-             j += subwarp_grp.size()) {
+        for (int j = subgroup.thread_rank(); j < mat.num_cols;
+             j += subgroup.size()) {
             const ValueType val = mat.values[row * mat.stride + j];
             temp += val * b[j];
         }
@@ -55,7 +55,7 @@ __device__ __forceinline__ void simple_apply(
         // subgroup level reduction
         temp = reduce(subgroup, temp, thrust::plus<ValueType>{});
 
-        if (subwarp_grp.thread_rank() == 0) {
+        if (subgroup.thread_rank() == 0) {
             x[row] = temp;
         }
     }
@@ -101,15 +101,15 @@ __device__ __forceinline__ void advanced_apply(
     constexpr auto tile_size = config::warp_size;
 
     auto thread_block = group::this_thread_block();
-    auto subwarp_grp = group::tiled_partition<tile_size>(thread_block);
-    const auto subwarp_grp_id = static_cast<int>(threadIdx.x / tile_size);
-    const int num_subwarp_grps_per_block = ceildiv(blockDim.x, tile_size);
+    auto subgroup = group::tiled_partition<tile_size>(thread_block);
+    const auto subgroup_id = static_cast<int>(threadIdx.x / tile_size);
+    const int num_subgroups_per_block = ceildiv(blockDim.x, tile_size);
 
-    for (int row = subwarp_grp_id; row < mat.num_rows;
-         row += num_subwarp_grps_per_block) {
+    for (int row = subgroup_id; row < mat.num_rows;
+         row += num_subgroups_per_block) {
         ValueType temp = zero<ValueType>();
-        for (int j = subwarp_grp.thread_rank(); j < mat.num_cols;
-             j += subwarp_grp.size()) {
+        for (int j = subgroup.thread_rank(); j < mat.num_cols;
+             j += subgroup.size()) {
             const ValueType val = mat.values[row * mat.stride + j];
             temp += alpha * val * b[j];
         }
@@ -117,7 +117,7 @@ __device__ __forceinline__ void advanced_apply(
         // subgroup level reduction
         temp = reduce(subgroup, temp, thrust::plus<ValueType>{});
 
-        if (subwarp_grp.thread_rank() == 0) {
+        if (subgroup.thread_rank() == 0) {
             x[row] = temp + beta * x[row];
         }
     }

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -39,6 +39,7 @@ target_sources(ginkgo
     log/vtune.cpp
     log/record.cpp
     log/stream.cpp
+    matrix/batch_dense.cpp
     matrix/coo.cpp
     matrix/csr.cpp
     matrix/dense.cpp

--- a/core/base/batch_multi_vector.cpp
+++ b/core/base/batch_multi_vector.cpp
@@ -294,11 +294,12 @@ void MultiVector<ValueType>::move_to(
 template <typename ValueType>
 void MultiVector<ValueType>::convert_to(matrix::Dense<ValueType>* result) const
 {
-    auto exec = result->get_executor() != nullptr ? result->get_executor()
-                                                  : this->get_executor();
+    auto exec = result->get_executor() == nullptr ? this->get_executor()
+                                                  : result->get_executor();
     auto tmp = gko::batch::matrix::Dense<ValueType>::create_const(
         exec, this->get_size(),
-        make_const_array_view(exec, this->get_num_stored_elements(),
+        make_const_array_view(this->get_executor(),
+                              this->get_num_stored_elements(),
                               this->get_const_values()));
     result->copy_from(tmp);
 }
@@ -307,7 +308,14 @@ void MultiVector<ValueType>::convert_to(matrix::Dense<ValueType>* result) const
 template <typename ValueType>
 void MultiVector<ValueType>::move_to(matrix::Dense<ValueType>* result)
 {
-    this->convert_to(result);
+    auto exec = result->get_executor() == nullptr ? this->get_executor()
+                                                  : result->get_executor();
+    auto tmp = gko::batch::matrix::Dense<ValueType>::create_const(
+        exec, this->get_size(),
+        make_const_array_view(this->get_executor(),
+                              this->get_num_stored_elements(),
+                              this->get_const_values()));
+    tmp->move_to(result);
 }
 
 

--- a/core/base/batch_multi_vector.cpp
+++ b/core/base/batch_multi_vector.cpp
@@ -44,6 +44,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <ginkgo/core/base/math.hpp>
 #include <ginkgo/core/base/matrix_data.hpp>
 #include <ginkgo/core/base/utils.hpp>
+#include <ginkgo/core/matrix/batch_dense.hpp>
 
 
 #include "core/base/batch_multi_vector_kernels.hpp"
@@ -72,7 +73,7 @@ namespace detail {
 
 template <typename ValueType>
 batch_dim<2> compute_batch_size(
-    const std::vector<matrix::Dense<ValueType>*>& matrices)
+    const std::vector<gko::matrix::Dense<ValueType>*>& matrices)
 {
     auto common_size = matrices[0]->get_size();
     for (size_type i = 1; i < matrices.size(); ++i) {
@@ -86,7 +87,7 @@ batch_dim<2> compute_batch_size(
 
 
 template <typename ValueType>
-std::unique_ptr<matrix::Dense<ValueType>>
+std::unique_ptr<gko::matrix::Dense<ValueType>>
 MultiVector<ValueType>::create_view_for_item(size_type item_id)
 {
     auto exec = this->get_executor();
@@ -102,7 +103,7 @@ MultiVector<ValueType>::create_view_for_item(size_type item_id)
 
 
 template <typename ValueType>
-std::unique_ptr<const matrix::Dense<ValueType>>
+std::unique_ptr<const gko::matrix::Dense<ValueType>>
 MultiVector<ValueType>::create_const_view_for_item(size_type item_id) const
 {
     auto exec = this->get_executor();
@@ -285,6 +286,27 @@ void MultiVector<ValueType>::convert_to(
 template <typename ValueType>
 void MultiVector<ValueType>::move_to(
     MultiVector<next_precision<ValueType>>* result)
+{
+    this->convert_to(result);
+}
+
+
+template <typename ValueType>
+void MultiVector<ValueType>::convert_to(
+    matrix::BatchDense<ValueType>* result) const
+{
+    auto exec = result->get_executor() != nullptr ? result->get_executor()
+                                                  : this->get_executor();
+    auto tmp = gko::batch::matrix::BatchDense<ValueType>::create_const(
+        exec, this->get_size(),
+        make_const_array_view(exec, this->get_num_stored_elements(),
+                              this->get_const_values()));
+    result->copy_from(tmp);
+}
+
+
+template <typename ValueType>
+void MultiVector<ValueType>::move_to(matrix::BatchDense<ValueType>* result)
 {
     this->convert_to(result);
 }

--- a/core/base/batch_multi_vector.cpp
+++ b/core/base/batch_multi_vector.cpp
@@ -292,12 +292,11 @@ void MultiVector<ValueType>::move_to(
 
 
 template <typename ValueType>
-void MultiVector<ValueType>::convert_to(
-    matrix::BatchDense<ValueType>* result) const
+void MultiVector<ValueType>::convert_to(matrix::Dense<ValueType>* result) const
 {
     auto exec = result->get_executor() != nullptr ? result->get_executor()
                                                   : this->get_executor();
-    auto tmp = gko::batch::matrix::BatchDense<ValueType>::create_const(
+    auto tmp = gko::batch::matrix::Dense<ValueType>::create_const(
         exec, this->get_size(),
         make_const_array_view(exec, this->get_num_stored_elements(),
                               this->get_const_values()));
@@ -306,7 +305,7 @@ void MultiVector<ValueType>::convert_to(
 
 
 template <typename ValueType>
-void MultiVector<ValueType>::move_to(matrix::BatchDense<ValueType>* result)
+void MultiVector<ValueType>::move_to(matrix::Dense<ValueType>* result)
 {
     this->convert_to(result);
 }

--- a/core/base/batch_multi_vector.cpp
+++ b/core/base/batch_multi_vector.cpp
@@ -308,14 +308,7 @@ void MultiVector<ValueType>::convert_to(matrix::Dense<ValueType>* result) const
 template <typename ValueType>
 void MultiVector<ValueType>::move_to(matrix::Dense<ValueType>* result)
 {
-    auto exec = result->get_executor() == nullptr ? this->get_executor()
-                                                  : result->get_executor();
-    auto tmp = gko::batch::matrix::Dense<ValueType>::create_const(
-        exec, this->get_size(),
-        make_const_array_view(this->get_executor(),
-                              this->get_num_stored_elements(),
-                              this->get_const_values()));
-    tmp->move_to(result);
+    this->convert_to(result);
 }
 
 

--- a/core/base/batch_multi_vector_kernels.hpp
+++ b/core/base/batch_multi_vector_kernels.hpp
@@ -39,7 +39,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <ginkgo/core/base/math.hpp>
 #include <ginkgo/core/base/types.hpp>
-#include <ginkgo/core/matrix/diagonal.hpp>
 
 
 #include "core/base/kernel_declaration.hpp"

--- a/core/base/batch_struct.hpp
+++ b/core/base/batch_struct.hpp
@@ -51,9 +51,9 @@ template <typename ValueType>
 struct batch_item {
     using value_type = ValueType;
     ValueType* values;
-    int stride;
-    int num_rows;
-    int num_rhs;
+    int32 stride;
+    int32 num_rows;
+    int32 num_rhs;
 };
 
 
@@ -67,9 +67,9 @@ struct uniform_batch {
 
     ValueType* values;
     size_type num_batch_items;
-    int stride;
-    int num_rows;
-    int num_rhs;
+    int32 stride;
+    int32 num_rows;
+    int32 num_rhs;
 
     size_type get_entry_storage() const
     {
@@ -117,8 +117,8 @@ extract_batch_item(const multi_vector::uniform_batch<ValueType>& batch,
 
 template <typename ValueType>
 GKO_ATTRIBUTES GKO_INLINE multi_vector::batch_item<ValueType>
-extract_batch_item(ValueType* const batch_values, const int stride,
-                   const int num_rows, const int num_rhs,
+extract_batch_item(ValueType* const batch_values, const int32 stride,
+                   const int32 num_rows, const int32 num_rhs,
                    const size_type batch_idx)
 {
     return {batch_values + batch_idx * stride * num_rows, stride, num_rows,

--- a/core/base/batch_utilities.hpp
+++ b/core/base/batch_utilities.hpp
@@ -109,14 +109,13 @@ std::unique_ptr<OutputType> create_from_item(
 
 
 template <typename InputType>
-auto unbatch(const InputType* batch_multivec)
+auto unbatch(const InputType* batch_object)
 {
-    auto exec = batch_multivec->get_executor();
     auto unbatched_mats =
         std::vector<std::unique_ptr<typename InputType::unbatch_type>>{};
-    for (size_type b = 0; b < batch_multivec->get_num_batch_items(); ++b) {
+    for (size_type b = 0; b < batch_object->get_num_batch_items(); ++b) {
         unbatched_mats.emplace_back(
-            batch_multivec->create_const_view_for_item(b)->clone());
+            batch_object->create_const_view_for_item(b)->clone());
     }
     return unbatched_mats;
 }

--- a/core/base/batch_utilities.hpp
+++ b/core/base/batch_utilities.hpp
@@ -51,16 +51,15 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 namespace gko {
 namespace batch {
-namespace multivector {
 
 
-template <typename ValueType>
-std::unique_ptr<batch::MultiVector<ValueType>> duplicate(
-    std::shared_ptr<const Executor> exec, size_type num_duplications,
-    const batch::MultiVector<ValueType>* input)
+template <typename OutputType>
+std::unique_ptr<OutputType> duplicate(std::shared_ptr<const Executor> exec,
+                                      size_type num_duplications,
+                                      const OutputType* input)
 {
     auto num_batch_items = input->get_num_batch_items();
-    auto tmp = batch::MultiVector<ValueType>::create(
+    auto tmp = OutputType::create(
         exec, batch_dim<2>(num_batch_items * num_duplications,
                            input->get_common_size()));
 
@@ -75,13 +74,13 @@ std::unique_ptr<batch::MultiVector<ValueType>> duplicate(
 }
 
 
-template <typename ValueType>
-std::unique_ptr<batch::MultiVector<ValueType>> create_from_dense(
+template <typename OutputType>
+std::unique_ptr<OutputType> create_from_item(
     std::shared_ptr<const Executor> exec, const size_type num_duplications,
-    const matrix::Dense<ValueType>* input)
+    const typename OutputType::unbatch_type* input)
 {
     auto num_batch_items = num_duplications;
-    auto tmp = batch::MultiVector<ValueType>::create(
+    auto tmp = OutputType::create(
         exec, batch_dim<2>(num_batch_items, input->get_size()));
 
     for (size_type b = 0; b < num_batch_items; ++b) {
@@ -92,13 +91,13 @@ std::unique_ptr<batch::MultiVector<ValueType>> create_from_dense(
 }
 
 
-template <typename ValueType>
-std::unique_ptr<batch::MultiVector<ValueType>> create_from_dense(
+template <typename OutputType>
+std::unique_ptr<OutputType> create_from_item(
     std::shared_ptr<const Executor> exec,
-    const std::vector<matrix::Dense<ValueType>*>& input)
+    const std::vector<typename OutputType::unbatch_type*>& input)
 {
     auto num_batch_items = input.size();
-    auto tmp = batch::MultiVector<ValueType>::create(
+    auto tmp = OutputType::create(
         exec, batch_dim<2>(num_batch_items, input[0]->get_size()));
 
     for (size_type b = 0; b < num_batch_items; ++b) {
@@ -109,13 +108,12 @@ std::unique_ptr<batch::MultiVector<ValueType>> create_from_dense(
 }
 
 
-template <typename ValueType>
-std::vector<std::unique_ptr<matrix::Dense<ValueType>>> unbatch(
-    const batch::MultiVector<ValueType>* batch_multivec)
+template <typename InputType>
+auto unbatch(const InputType* batch_multivec)
 {
     auto exec = batch_multivec->get_executor();
     auto unbatched_mats =
-        std::vector<std::unique_ptr<matrix::Dense<ValueType>>>{};
+        std::vector<std::unique_ptr<typename InputType::unbatch_type>>{};
     for (size_type b = 0; b < batch_multivec->get_num_batch_items(); ++b) {
         unbatched_mats.emplace_back(
             batch_multivec->create_const_view_for_item(b)->clone());
@@ -124,14 +122,14 @@ std::vector<std::unique_ptr<matrix::Dense<ValueType>>> unbatch(
 }
 
 
-template <typename ValueType, typename IndexType>
-std::unique_ptr<MultiVector<ValueType>> read(
+template <typename ValueType, typename IndexType, typename OutputType>
+std::unique_ptr<OutputType> read(
     std::shared_ptr<const Executor> exec,
     const std::vector<gko::matrix_data<ValueType, IndexType>>& data)
 {
     auto num_batch_items = data.size();
-    auto tmp = MultiVector<ValueType>::create(
-        exec, batch_dim<2>(num_batch_items, data[0].size));
+    auto tmp =
+        OutputType::create(exec, batch_dim<2>(num_batch_items, data[0].size));
 
     for (size_type b = 0; b < num_batch_items; ++b) {
         tmp->create_view_for_item(b)->read(data[b]);
@@ -141,9 +139,9 @@ std::unique_ptr<MultiVector<ValueType>> read(
 }
 
 
-template <typename ValueType, typename IndexType>
+template <typename ValueType, typename IndexType, typename OutputType>
 std::vector<gko::matrix_data<ValueType, IndexType>> write(
-    const MultiVector<ValueType>* mvec)
+    const OutputType* mvec)
 {
     auto data = std::vector<gko::matrix_data<ValueType, IndexType>>(
         mvec->get_num_batch_items());
@@ -157,7 +155,6 @@ std::vector<gko::matrix_data<ValueType, IndexType>> write(
 }
 
 
-}  // namespace multivector
 }  // namespace batch
 }  // namespace gko
 

--- a/core/device_hooks/common_kernels.inc.cpp
+++ b/core/device_hooks/common_kernels.inc.cpp
@@ -299,6 +299,16 @@ GKO_STUB_VALUE_TYPE(GKO_DECLARE_BATCH_MULTI_VECTOR_COPY_KERNEL);
 }  // namespace batch_multi_vector
 
 
+namespace batch_dense {
+
+
+GKO_STUB_VALUE_TYPE(GKO_DECLARE_BATCH_DENSE_SIMPLE_APPLY_KERNEL);
+GKO_STUB_VALUE_TYPE(GKO_DECLARE_BATCH_DENSE_ADVANCED_APPLY_KERNEL);
+
+
+}  // namespace batch_dense
+
+
 namespace dense {
 
 

--- a/core/device_hooks/common_kernels.inc.cpp
+++ b/core/device_hooks/common_kernels.inc.cpp
@@ -57,6 +57,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "core/factorization/par_ict_kernels.hpp"
 #include "core/factorization/par_ilu_kernels.hpp"
 #include "core/factorization/par_ilut_kernels.hpp"
+#include "core/matrix/batch_dense_kernels.hpp"
 #include "core/matrix/coo_kernels.hpp"
 #include "core/matrix/csr_kernels.hpp"
 #include "core/matrix/dense_kernels.hpp"

--- a/core/matrix/batch_dense.cpp
+++ b/core/matrix/batch_dense.cpp
@@ -83,6 +83,38 @@ batch_dim<2> compute_batch_size(
 
 
 template <typename ValueType>
+std::unique_ptr<gko::batch::MultiVector<ValueType>>
+Dense<ValueType>::create_multi_vector_view()
+{
+    auto exec = this->get_executor();
+    auto num_batch_items = this->get_num_batch_items();
+    auto num_rows = this->get_common_size()[0];
+    auto stride = this->get_common_size()[1];
+    auto mvec = MultiVector<ValueType>::create(
+        exec, this->get_size(),
+        make_array_view(exec, num_batch_items * num_rows * stride,
+                        this->get_values()));
+    return mvec;
+}
+
+
+template <typename ValueType>
+std::unique_ptr<const gko::batch::MultiVector<ValueType>>
+Dense<ValueType>::create_const_multi_vector_view() const
+{
+    auto exec = this->get_executor();
+    auto num_batch_items = this->get_num_batch_items();
+    auto num_rows = this->get_common_size()[0];
+    auto stride = this->get_common_size()[1];
+    auto mvec = MultiVector<ValueType>::create_const(
+        exec, this->get_size(),
+        make_const_array_view(exec, num_batch_items * num_rows * stride,
+                              this->get_const_values()));
+    return mvec;
+}
+
+
+template <typename ValueType>
 std::unique_ptr<gko::matrix::Dense<ValueType>>
 Dense<ValueType>::create_view_for_item(size_type item_id)
 {

--- a/core/matrix/batch_dense.cpp
+++ b/core/matrix/batch_dense.cpp
@@ -100,19 +100,7 @@ template <typename ValueType>
 std::unique_ptr<Dense<ValueType>> Dense<ValueType>::create_with_config_of(
     ptr_param<const Dense<ValueType>> other)
 {
-    // De-referencing `other` before calling the functions (instead of
-    // using operator `->`) is currently required to be compatible with
-    // CUDA 10.1.
-    // Otherwise, it results in a compile error.
-    return (*other).create_with_same_config();
-}
-
-
-template <typename ValueType>
-std::unique_ptr<Dense<ValueType>> Dense<ValueType>::create_with_same_config()
-    const
-{
-    return Dense<ValueType>::create(this->get_executor(), this->get_size());
+    return Dense<ValueType>::create(other->get_executor(), other->get_size());
 }
 
 

--- a/core/matrix/batch_dense.cpp
+++ b/core/matrix/batch_dense.cpp
@@ -1,0 +1,203 @@
+/*******************************<GINKGO LICENSE>******************************
+Copyright (c) 2017-2023, the Ginkgo authors
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+******************************<GINKGO LICENSE>*******************************/
+
+#include <ginkgo/core/matrix/batch_dense.hpp>
+
+
+#include <algorithm>
+#include <type_traits>
+
+
+#include <ginkgo/core/base/array.hpp>
+#include <ginkgo/core/base/exception.hpp>
+#include <ginkgo/core/base/exception_helpers.hpp>
+#include <ginkgo/core/base/executor.hpp>
+#include <ginkgo/core/base/math.hpp>
+#include <ginkgo/core/base/utils.hpp>
+
+
+#include "core/matrix/batch_dense_kernels.hpp"
+
+
+namespace gko {
+namespace batch {
+namespace matrix {
+namespace dense {
+
+
+GKO_REGISTER_OPERATION(simple_apply, batch_dense::simple_apply);
+GKO_REGISTER_OPERATION(advanced_apply, batch_dense::advanced_apply);
+
+
+}  // namespace dense
+
+
+namespace detail {
+
+
+template <typename ValueType>
+batch_dim<2> compute_batch_size(
+    const std::vector<matrix::Dense<ValueType>*>& matrices)
+{
+    auto common_size = matrices[0]->get_size();
+    for (size_type i = 1; i < matrices.size(); ++i) {
+        GKO_ASSERT_EQUAL_DIMENSIONS(common_size, matrices[i]->get_size());
+    }
+    return batch_dim<2>{matrices.size(), common_size};
+}
+
+
+}  // namespace detail
+
+
+template <typename ValueType>
+std::unique_ptr<matrix::Dense<ValueType>>
+BatchDense<ValueType>::create_view_for_item(size_type item_id)
+{
+    auto exec = this->get_executor();
+    auto num_rows = this->get_common_size()[0];
+    auto stride = this->get_common_size()[1];
+    auto mat = unbatch_type::create(
+        exec, this->get_common_size(),
+        make_array_view(exec, num_rows * stride,
+                        this->get_values_for_item(item_id)),
+        stride);
+    return mat;
+}
+
+
+template <typename ValueType>
+std::unique_ptr<const matrix::Dense<ValueType>>
+BatchDense<ValueType>::create_const_view_for_item(size_type item_id) const
+{
+    auto exec = this->get_executor();
+    auto num_rows = this->get_common_size()[0];
+    auto stride = this->get_common_size()[1];
+    auto mat = unbatch_type::create_const(
+        exec, this->get_common_size(),
+        make_const_array_view(exec, num_rows * stride,
+                              this->get_const_values_for_item(item_id)),
+        stride);
+    return mat;
+}
+
+
+template <typename ValueType>
+std::unique_ptr<BatchDense<ValueType>>
+BatchDense<ValueType>::create_with_config_of(ptr_param<const MultiVector> other)
+{
+    // De-referencing `other` before calling the functions (instead of
+    // using operator `->`) is currently required to be compatible with
+    // CUDA 10.1.
+    // Otherwise, it results in a compile error.
+    return (*other).create_with_same_config();
+}
+
+
+template <typename ValueType>
+void BatchDense<ValueType>::set_size(const batch_dim<2>& value) noexcept
+{
+    batch_size_ = value;
+}
+
+
+template <typename ValueType>
+std::unique_ptr<BatchDense<ValueType>>
+BatchDense<ValueType>::create_with_same_config() const
+{
+    return BatchDense<ValueType>::create(this->get_executor(),
+                                         this->get_size());
+}
+
+
+inline const batch_dim<2> get_col_sizes(const batch_dim<2>& sizes)
+{
+    return batch_dim<2>(sizes.get_num_batch_items(),
+                        dim<2>(1, sizes.get_common_size()[1]));
+}
+
+
+template <typename ValueType>
+void BatchDense<ValueType>::apply_impl(const MultiVector<ValueType>* b,
+                                       MultiVector<ValueType>* x) const
+{
+    GKO_ASSERT_EQUAL_DIMENSIONS(b->get_common_size(), x->get_common_size());
+    GKO_ASSERT_EQ(b->get_num_batch_items(), this->get_num_batch_items());
+    GKO_ASSERT_CONFORMANT(this->get_common_size(), b->get_common_size());
+    GKO_ASSERT_EQ(this->get_num_batch_items(), x->get_num_batch_items());
+    GKO_ASSERT_CONFORMANT(this->get_common_size(), x->get_common_size());
+    this->get_executor()->run(batch_dense::make_simple_apply(this, b, x));
+}
+
+
+template <typename ValueType>
+void BatchDense<ValueType>::apply_impl(const MultiVector<ValueType>* alpha,
+                                       const MultiVector<ValueType>* b,
+                                       const MultiVector<ValueType>* beta,
+                                       MultiVector<ValueType>* x) const
+{
+    GKO_ASSERT_EQUAL_DIMENSIONS(b->get_common_size(), x->get_common_size());
+    GKO_ASSERT_EQ(b->get_num_batch_items(), this->get_num_batch_items());
+    GKO_ASSERT_CONFORMANT(this->get_common_size(), b->get_common_size());
+    GKO_ASSERT_EQ(this->get_num_batch_items(), x->get_num_batch_items());
+    GKO_ASSERT_CONFORMANT(this->get_common_size(), x->get_common_size());
+    GKO_ASSERT_EQUAL_COLS(alpha->get_common_size(), gko::dim<2>(1, 1));
+    GKO_ASSERT_EQUAL_COLS(beta->get_common_size(), gko::dim<2>(1, 1));
+    this->get_executor()->run(
+        batch_dense::make_advanced_apply(alpha, this, b, beta, x));
+}
+
+
+template <typename ValueType>
+void BatchDense<ValueType>::convert_to(
+    BatchDense<next_precision<ValueType>>* result) const
+{
+    result->values_ = this->values_;
+    result->set_size(this->get_size());
+}
+
+
+template <typename ValueType>
+void BatchDense<ValueType>::move_to(
+    BatchDense<next_precision<ValueType>>* result)
+{
+    this->convert_to(result);
+}
+
+
+#define GKO_DECLARE_BATCH_DENSE_MATRIX(_type) class BatchDense<_type>
+GKO_INSTANTIATE_FOR_EACH_VALUE_TYPE(GKO_DECLARE_BATCH_DENSE_MATRIX);
+
+
+}  // namespace matrix
+}  // namespace batch
+}  // namespace gko

--- a/core/matrix/batch_dense.cpp
+++ b/core/matrix/batch_dense.cpp
@@ -84,7 +84,7 @@ batch_dim<2> compute_batch_size(
 
 template <typename ValueType>
 std::unique_ptr<gko::matrix::Dense<ValueType>>
-BatchDense<ValueType>::create_view_for_item(size_type item_id)
+Dense<ValueType>::create_view_for_item(size_type item_id)
 {
     auto exec = this->get_executor();
     auto num_rows = this->get_common_size()[0];
@@ -100,7 +100,7 @@ BatchDense<ValueType>::create_view_for_item(size_type item_id)
 
 template <typename ValueType>
 std::unique_ptr<const gko::matrix::Dense<ValueType>>
-BatchDense<ValueType>::create_const_view_for_item(size_type item_id) const
+Dense<ValueType>::create_const_view_for_item(size_type item_id) const
 {
     auto exec = this->get_executor();
     auto num_rows = this->get_common_size()[0];
@@ -115,9 +115,8 @@ BatchDense<ValueType>::create_const_view_for_item(size_type item_id) const
 
 
 template <typename ValueType>
-std::unique_ptr<BatchDense<ValueType>>
-BatchDense<ValueType>::create_with_config_of(
-    ptr_param<const BatchDense<ValueType>> other)
+std::unique_ptr<Dense<ValueType>> Dense<ValueType>::create_with_config_of(
+    ptr_param<const Dense<ValueType>> other)
 {
     // De-referencing `other` before calling the functions (instead of
     // using operator `->`) is currently required to be compatible with
@@ -128,23 +127,21 @@ BatchDense<ValueType>::create_with_config_of(
 
 
 template <typename ValueType>
-std::unique_ptr<BatchDense<ValueType>>
-BatchDense<ValueType>::create_with_same_config() const
+std::unique_ptr<Dense<ValueType>> Dense<ValueType>::create_with_same_config()
+    const
 {
-    return BatchDense<ValueType>::create(this->get_executor(),
-                                         this->get_size());
+    return Dense<ValueType>::create(this->get_executor(), this->get_size());
 }
 
 
 template <typename ValueType>
-std::unique_ptr<const BatchDense<ValueType>>
-BatchDense<ValueType>::create_const(
+std::unique_ptr<const Dense<ValueType>> Dense<ValueType>::create_const(
     std::shared_ptr<const Executor> exec, const batch_dim<2>& sizes,
     gko::detail::const_array_view<ValueType>&& values)
 {
     // cast const-ness away, but return a const object afterwards,
     // so we can ensure that no modifications take place.
-    return std::unique_ptr<const BatchDense>(new BatchDense{
+    return std::unique_ptr<const Dense>(new Dense{
         exec, sizes, gko::detail::array_const_cast(std::move(values))});
 }
 
@@ -157,16 +154,16 @@ inline const batch_dim<2> get_col_sizes(const batch_dim<2>& sizes)
 
 
 template <typename ValueType>
-BatchDense<ValueType>::BatchDense(std::shared_ptr<const Executor> exec,
-                                  const batch_dim<2>& size)
-    : EnableBatchLinOp<BatchDense<ValueType>>(exec, size),
+Dense<ValueType>::Dense(std::shared_ptr<const Executor> exec,
+                        const batch_dim<2>& size)
+    : EnableBatchLinOp<Dense<ValueType>>(exec, size),
       values_(exec, compute_num_elems(size))
 {}
 
 
 template <typename ValueType>
-void BatchDense<ValueType>::apply_impl(const MultiVector<ValueType>* b,
-                                       MultiVector<ValueType>* x) const
+void Dense<ValueType>::apply_impl(const MultiVector<ValueType>* b,
+                                  MultiVector<ValueType>* x) const
 {
     GKO_ASSERT_EQ(b->get_num_batch_items(), this->get_num_batch_items());
     GKO_ASSERT_EQ(this->get_num_batch_items(), x->get_num_batch_items());
@@ -179,10 +176,10 @@ void BatchDense<ValueType>::apply_impl(const MultiVector<ValueType>* b,
 
 
 template <typename ValueType>
-void BatchDense<ValueType>::apply_impl(const MultiVector<ValueType>* alpha,
-                                       const MultiVector<ValueType>* b,
-                                       const MultiVector<ValueType>* beta,
-                                       MultiVector<ValueType>* x) const
+void Dense<ValueType>::apply_impl(const MultiVector<ValueType>* alpha,
+                                  const MultiVector<ValueType>* b,
+                                  const MultiVector<ValueType>* beta,
+                                  MultiVector<ValueType>* x) const
 {
     GKO_ASSERT_EQ(b->get_num_batch_items(), this->get_num_batch_items());
     GKO_ASSERT_EQ(this->get_num_batch_items(), x->get_num_batch_items());
@@ -198,8 +195,8 @@ void BatchDense<ValueType>::apply_impl(const MultiVector<ValueType>* alpha,
 
 
 template <typename ValueType>
-void BatchDense<ValueType>::convert_to(
-    BatchDense<next_precision<ValueType>>* result) const
+void Dense<ValueType>::convert_to(
+    Dense<next_precision<ValueType>>* result) const
 {
     result->values_ = this->values_;
     result->set_size(this->get_size());
@@ -207,14 +204,13 @@ void BatchDense<ValueType>::convert_to(
 
 
 template <typename ValueType>
-void BatchDense<ValueType>::move_to(
-    BatchDense<next_precision<ValueType>>* result)
+void Dense<ValueType>::move_to(Dense<next_precision<ValueType>>* result)
 {
     this->convert_to(result);
 }
 
 
-#define GKO_DECLARE_BATCH_DENSE_MATRIX(_type) class BatchDense<_type>
+#define GKO_DECLARE_BATCH_DENSE_MATRIX(_type) class Dense<_type>
 GKO_INSTANTIATE_FOR_EACH_VALUE_TYPE(GKO_DECLARE_BATCH_DENSE_MATRIX);
 
 

--- a/core/matrix/batch_dense.cpp
+++ b/core/matrix/batch_dense.cpp
@@ -128,12 +128,7 @@ template <typename ValueType>
 void Dense<ValueType>::apply_impl(const MultiVector<ValueType>* b,
                                   MultiVector<ValueType>* x) const
 {
-    GKO_ASSERT_EQ(b->get_num_batch_items(), this->get_num_batch_items());
-    GKO_ASSERT_EQ(this->get_num_batch_items(), x->get_num_batch_items());
-
-    GKO_ASSERT_CONFORMANT(this->get_common_size(), b->get_common_size());
-    GKO_ASSERT_EQUAL_ROWS(this->get_common_size(), x->get_common_size());
-    GKO_ASSERT_EQUAL_COLS(b->get_common_size(), x->get_common_size());
+    this->validate_application_parameters(b, x);
     this->get_executor()->run(dense::make_simple_apply(this, b, x));
 }
 
@@ -144,14 +139,7 @@ void Dense<ValueType>::apply_impl(const MultiVector<ValueType>* alpha,
                                   const MultiVector<ValueType>* beta,
                                   MultiVector<ValueType>* x) const
 {
-    GKO_ASSERT_EQ(b->get_num_batch_items(), this->get_num_batch_items());
-    GKO_ASSERT_EQ(this->get_num_batch_items(), x->get_num_batch_items());
-
-    GKO_ASSERT_CONFORMANT(this->get_common_size(), b->get_common_size());
-    GKO_ASSERT_EQUAL_ROWS(this->get_common_size(), x->get_common_size());
-    GKO_ASSERT_EQUAL_COLS(b->get_common_size(), x->get_common_size());
-    GKO_ASSERT_EQUAL_DIMENSIONS(alpha->get_common_size(), gko::dim<2>(1, 1));
-    GKO_ASSERT_EQUAL_DIMENSIONS(beta->get_common_size(), gko::dim<2>(1, 1));
+    this->validate_application_parameters(alpha, b, beta, x);
     this->get_executor()->run(
         dense::make_advanced_apply(alpha, this, b, beta, x));
 }

--- a/core/matrix/batch_dense.cpp
+++ b/core/matrix/batch_dense.cpp
@@ -65,38 +65,6 @@ GKO_REGISTER_OPERATION(advanced_apply, batch_dense::advanced_apply);
 
 
 template <typename ValueType>
-std::unique_ptr<gko::batch::MultiVector<ValueType>>
-Dense<ValueType>::create_multi_vector_view()
-{
-    auto exec = this->get_executor();
-    auto num_batch_items = this->get_num_batch_items();
-    auto num_rows = this->get_common_size()[0];
-    auto stride = this->get_common_size()[1];
-    auto mvec = MultiVector<ValueType>::create(
-        exec, this->get_size(),
-        make_array_view(exec, num_batch_items * num_rows * stride,
-                        this->get_values()));
-    return mvec;
-}
-
-
-template <typename ValueType>
-std::unique_ptr<const gko::batch::MultiVector<ValueType>>
-Dense<ValueType>::create_const_multi_vector_view() const
-{
-    auto exec = this->get_executor();
-    auto num_batch_items = this->get_num_batch_items();
-    auto num_rows = this->get_common_size()[0];
-    auto stride = this->get_common_size()[1];
-    auto mvec = MultiVector<ValueType>::create_const(
-        exec, this->get_size(),
-        make_const_array_view(exec, num_batch_items * num_rows * stride,
-                              this->get_const_values()));
-    return mvec;
-}
-
-
-template <typename ValueType>
 std::unique_ptr<gko::matrix::Dense<ValueType>>
 Dense<ValueType>::create_view_for_item(size_type item_id)
 {

--- a/core/matrix/batch_dense.cpp
+++ b/core/matrix/batch_dense.cpp
@@ -168,11 +168,12 @@ template <typename ValueType>
 void BatchDense<ValueType>::apply_impl(const MultiVector<ValueType>* b,
                                        MultiVector<ValueType>* x) const
 {
-    GKO_ASSERT_EQUAL_DIMENSIONS(b->get_common_size(), x->get_common_size());
     GKO_ASSERT_EQ(b->get_num_batch_items(), this->get_num_batch_items());
-    GKO_ASSERT_CONFORMANT(this->get_common_size(), b->get_common_size());
     GKO_ASSERT_EQ(this->get_num_batch_items(), x->get_num_batch_items());
-    GKO_ASSERT_CONFORMANT(this->get_common_size(), x->get_common_size());
+
+    GKO_ASSERT_CONFORMANT(this->get_common_size(), b->get_common_size());
+    GKO_ASSERT_EQUAL_ROWS(this->get_common_size(), x->get_common_size());
+    GKO_ASSERT_EQUAL_COLS(b->get_common_size(), x->get_common_size());
     this->get_executor()->run(dense::make_simple_apply(this, b, x));
 }
 
@@ -183,13 +184,14 @@ void BatchDense<ValueType>::apply_impl(const MultiVector<ValueType>* alpha,
                                        const MultiVector<ValueType>* beta,
                                        MultiVector<ValueType>* x) const
 {
-    GKO_ASSERT_EQUAL_DIMENSIONS(b->get_common_size(), x->get_common_size());
     GKO_ASSERT_EQ(b->get_num_batch_items(), this->get_num_batch_items());
-    GKO_ASSERT_CONFORMANT(this->get_common_size(), b->get_common_size());
     GKO_ASSERT_EQ(this->get_num_batch_items(), x->get_num_batch_items());
-    GKO_ASSERT_CONFORMANT(this->get_common_size(), x->get_common_size());
-    GKO_ASSERT_EQUAL_COLS(alpha->get_common_size(), gko::dim<2>(1, 1));
-    GKO_ASSERT_EQUAL_COLS(beta->get_common_size(), gko::dim<2>(1, 1));
+
+    GKO_ASSERT_CONFORMANT(this->get_common_size(), b->get_common_size());
+    GKO_ASSERT_EQUAL_ROWS(this->get_common_size(), x->get_common_size());
+    GKO_ASSERT_EQUAL_COLS(b->get_common_size(), x->get_common_size());
+    GKO_ASSERT_EQUAL_DIMENSIONS(alpha->get_common_size(), gko::dim<2>(1, 1));
+    GKO_ASSERT_EQUAL_DIMENSIONS(beta->get_common_size(), gko::dim<2>(1, 1));
     this->get_executor()->run(
         dense::make_advanced_apply(alpha, this, b, beta, x));
 }

--- a/core/matrix/batch_dense.cpp
+++ b/core/matrix/batch_dense.cpp
@@ -43,6 +43,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <ginkgo/core/base/executor.hpp>
 #include <ginkgo/core/base/math.hpp>
 #include <ginkgo/core/base/utils.hpp>
+#include <ginkgo/core/matrix/dense.hpp>
 
 
 #include "core/matrix/batch_dense_kernels.hpp"
@@ -66,7 +67,7 @@ namespace detail {
 
 template <typename ValueType>
 batch_dim<2> compute_batch_size(
-    const std::vector<matrix::Dense<ValueType>*>& matrices)
+    const std::vector<gko::matrix::Dense<ValueType>*>& matrices)
 {
     auto common_size = matrices[0]->get_size();
     for (size_type i = 1; i < matrices.size(); ++i) {
@@ -80,7 +81,7 @@ batch_dim<2> compute_batch_size(
 
 
 template <typename ValueType>
-std::unique_ptr<matrix::Dense<ValueType>>
+std::unique_ptr<gko::matrix::Dense<ValueType>>
 BatchDense<ValueType>::create_view_for_item(size_type item_id)
 {
     auto exec = this->get_executor();
@@ -96,7 +97,7 @@ BatchDense<ValueType>::create_view_for_item(size_type item_id)
 
 
 template <typename ValueType>
-std::unique_ptr<const matrix::Dense<ValueType>>
+std::unique_ptr<const gko::matrix::Dense<ValueType>>
 BatchDense<ValueType>::create_const_view_for_item(size_type item_id) const
 {
     auto exec = this->get_executor();
@@ -113,7 +114,8 @@ BatchDense<ValueType>::create_const_view_for_item(size_type item_id) const
 
 template <typename ValueType>
 std::unique_ptr<BatchDense<ValueType>>
-BatchDense<ValueType>::create_with_config_of(ptr_param<const MultiVector> other)
+BatchDense<ValueType>::create_with_config_of(
+    ptr_param<const BatchDense<ValueType>> other)
 {
     // De-referencing `other` before calling the functions (instead of
     // using operator `->`) is currently required to be compatible with

--- a/core/matrix/batch_dense.cpp
+++ b/core/matrix/batch_dense.cpp
@@ -64,24 +64,6 @@ GKO_REGISTER_OPERATION(advanced_apply, batch_dense::advanced_apply);
 }  // namespace dense
 
 
-namespace detail {
-
-
-template <typename ValueType>
-batch_dim<2> compute_batch_size(
-    const std::vector<gko::matrix::Dense<ValueType>*>& matrices)
-{
-    auto common_size = matrices[0]->get_size();
-    for (size_type i = 1; i < matrices.size(); ++i) {
-        GKO_ASSERT_EQUAL_DIMENSIONS(common_size, matrices[i]->get_size());
-    }
-    return batch_dim<2>{matrices.size(), common_size};
-}
-
-
-}  // namespace detail
-
-
 template <typename ValueType>
 std::unique_ptr<gko::batch::MultiVector<ValueType>>
 Dense<ValueType>::create_multi_vector_view()
@@ -175,13 +157,6 @@ std::unique_ptr<const Dense<ValueType>> Dense<ValueType>::create_const(
     // so we can ensure that no modifications take place.
     return std::unique_ptr<const Dense>(new Dense{
         exec, sizes, gko::detail::array_const_cast(std::move(values))});
-}
-
-
-inline const batch_dim<2> get_col_sizes(const batch_dim<2>& sizes)
-{
-    return batch_dim<2>(sizes.get_num_batch_items(),
-                        dim<2>(1, sizes.get_common_size()[1]));
 }
 
 

--- a/core/matrix/batch_dense.cpp
+++ b/core/matrix/batch_dense.cpp
@@ -128,13 +128,6 @@ BatchDense<ValueType>::create_with_config_of(
 
 
 template <typename ValueType>
-void BatchDense<ValueType>::set_size(const batch_dim<2>& value) noexcept
-{
-    batch_size_ = value;
-}
-
-
-template <typename ValueType>
 std::unique_ptr<BatchDense<ValueType>>
 BatchDense<ValueType>::create_with_same_config() const
 {

--- a/core/matrix/batch_dense_kernels.hpp
+++ b/core/matrix/batch_dense_kernels.hpp
@@ -51,14 +51,14 @@ namespace kernels {
 
 #define GKO_DECLARE_BATCH_DENSE_SIMPLE_APPLY_KERNEL(_type)         \
     void simple_apply(std::shared_ptr<const DefaultExecutor> exec, \
-                      const batch::matrix::BatchDense<_type>* a,   \
+                      const batch::matrix::Dense<_type>* a,        \
                       const batch::MultiVector<_type>* b,          \
                       batch::MultiVector<_type>* c)
 
 #define GKO_DECLARE_BATCH_DENSE_ADVANCED_APPLY_KERNEL(_type)         \
     void advanced_apply(std::shared_ptr<const DefaultExecutor> exec, \
                         const batch::MultiVector<_type>* alpha,      \
-                        const batch::matrix::BatchDense<_type>* a,   \
+                        const batch::matrix::Dense<_type>* a,        \
                         const batch::MultiVector<_type>* b,          \
                         const batch::MultiVector<_type>* beta,       \
                         batch::MultiVector<_type>* c)

--- a/core/matrix/batch_dense_kernels.hpp
+++ b/core/matrix/batch_dense_kernels.hpp
@@ -38,7 +38,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
 #include <ginkgo/core/base/batch_multi_vector.hpp>
-#include <ginkgo/core/base/math.hpp>
 #include <ginkgo/core/base/types.hpp>
 
 

--- a/core/matrix/batch_dense_kernels.hpp
+++ b/core/matrix/batch_dense_kernels.hpp
@@ -42,6 +42,9 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <ginkgo/core/base/types.hpp>
 
 
+#include "core/base/kernel_declaration.hpp"
+
+
 namespace gko {
 namespace kernels {
 
@@ -50,7 +53,7 @@ namespace kernels {
     void simple_apply(std::shared_ptr<const DefaultExecutor> exec, \
                       const batch::matrix::BatchDense<_type>* a,   \
                       const batch::MultiVector<_type>* b,          \
-                      MultiVector<_type>* c)
+                      batch::MultiVector<_type>* c)
 
 #define GKO_DECLARE_BATCH_DENSE_ADVANCED_APPLY_KERNEL(_type)         \
     void advanced_apply(std::shared_ptr<const DefaultExecutor> exec, \

--- a/core/matrix/batch_dense_kernels.hpp
+++ b/core/matrix/batch_dense_kernels.hpp
@@ -1,0 +1,81 @@
+/*******************************<GINKGO LICENSE>******************************
+Copyright (c) 2017-2023, the Ginkgo authors
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+******************************<GINKGO LICENSE>*******************************/
+
+#ifndef GKO_CORE_MATRIX_BATCH_DENSE_KERNELS_HPP_
+#define GKO_CORE_MATRIX_BATCH_DENSE_KERNELS_HPP_
+
+
+#include <ginkgo/core/matrix/batch_dense.hpp>
+
+
+#include <ginkgo/core/base/batch_multi_vector.hpp>
+#include <ginkgo/core/base/math.hpp>
+#include <ginkgo/core/base/types.hpp>
+
+
+namespace gko {
+namespace kernels {
+
+
+#define GKO_DECLARE_BATCH_DENSE_SIMPLE_APPLY_KERNEL(_type)         \
+    void simple_apply(std::shared_ptr<const DefaultExecutor> exec, \
+                      const batch::matrix::BatchDense<_type>* a,   \
+                      const batch::MultiVector<_type>* b,          \
+                      MultiVector<_type>* c)
+
+#define GKO_DECLARE_BATCH_DENSE_ADVANCED_APPLY_KERNEL(_type)         \
+    void advanced_apply(std::shared_ptr<const DefaultExecutor> exec, \
+                        const batch::MultiVector<_type>* alpha,      \
+                        const batch::matrix::BatchDense<_type>* a,   \
+                        const batch::MultiVector<_type>* b,          \
+                        const batch::MultiVector<_type>* beta,       \
+                        batch::MultiVector<_type>* c)
+
+#define GKO_DECLARE_ALL_AS_TEMPLATES                        \
+    template <typename ValueType>                           \
+    GKO_DECLARE_BATCH_DENSE_SIMPLE_APPLY_KERNEL(ValueType); \
+    template <typename ValueType>                           \
+    GKO_DECLARE_BATCH_DENSE_ADVANCED_APPLY_KERNEL(ValueType)
+
+
+GKO_DECLARE_FOR_ALL_EXECUTOR_NAMESPACES(batch_dense,
+                                        GKO_DECLARE_ALL_AS_TEMPLATES);
+
+
+#undef GKO_DECLARE_ALL_AS_TEMPLATES
+
+
+}  // namespace kernels
+}  // namespace gko
+
+
+#endif  // GKO_CORE_MATRIX_BATCH_DENSE_KERNELS_HPP_

--- a/core/matrix/batch_struct.hpp
+++ b/core/matrix/batch_struct.hpp
@@ -30,18 +30,19 @@ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ******************************<GINKGO LICENSE>*******************************/
 
-#ifndef GKO_CORE_BASE_BATCH_STRUCT_HPP_
-#define GKO_CORE_BASE_BATCH_STRUCT_HPP_
+#ifndef GKO_CORE_MATRIX_BATCH_STRUCT_HPP_
+#define GKO_CORE_MATRIX_BATCH_STRUCT_HPP_
 
 
 #include <ginkgo/core/base/array.hpp>
-#include <ginkgo/core/base/lin_op.hpp>
 #include <ginkgo/core/base/types.hpp>
+#include <ginkgo/core/matrix/batch_dense.hpp>
 
 
 namespace gko {
 namespace batch {
-namespace multi_vector {
+namespace matrix {
+namespace batch_dense {
 
 
 /**
@@ -78,56 +79,47 @@ struct uniform_batch {
 };
 
 
-}  // namespace multi_vector
+}  // namespace batch_dense
 
 
 template <typename ValueType>
-GKO_ATTRIBUTES GKO_INLINE multi_vector::batch_item<const ValueType> to_const(
-    const multi_vector::batch_item<ValueType>& b)
+GKO_ATTRIBUTES GKO_INLINE batch_dense::batch_item<const ValueType> to_const(
+    const batch_dense::batch_item<ValueType>& b)
 {
     return {b.values, b.stride, b.num_rows, b.num_rhs};
 }
 
 
 template <typename ValueType>
-GKO_ATTRIBUTES GKO_INLINE multi_vector::uniform_batch<const ValueType> to_const(
-    const multi_vector::uniform_batch<ValueType>& ub)
+GKO_ATTRIBUTES GKO_INLINE batch_dense::uniform_batch<const ValueType> to_const(
+    const batch_dense::uniform_batch<ValueType>& ub)
 {
     return {ub.values, ub.num_batch_items, ub.stride, ub.num_rows, ub.num_rhs};
 }
 
 
-/**
- * Extract one object (matrix, vector etc.) from a batch of objects
- *
- * This overload is for batch multi-vectors.
- * These overloads are intended to be called from within a kernel.
- *
- * @param batch  The batch of objects to extract from
- * @param batch_idx  The position of the desired object in the batch
- */
 template <typename ValueType>
-GKO_ATTRIBUTES GKO_INLINE multi_vector::batch_item<ValueType>
-extract_batch_item(const multi_vector::uniform_batch<ValueType>& batch,
-                   const size_type batch_idx)
+GKO_ATTRIBUTES GKO_INLINE batch_dense::batch_item<ValueType> extract_batch_item(
+    const batch_dense::uniform_batch<ValueType>& batch,
+    const size_type batch_idx)
 {
     return {batch.values + batch_idx * batch.stride * batch.num_rows,
             batch.stride, batch.num_rows, batch.num_rhs};
 }
 
 template <typename ValueType>
-GKO_ATTRIBUTES GKO_INLINE multi_vector::batch_item<ValueType>
-extract_batch_item(ValueType* const batch_values, const int stride,
-                   const int num_rows, const int num_rhs,
-                   const size_type batch_idx)
+GKO_ATTRIBUTES GKO_INLINE batch_dense::batch_item<ValueType> extract_batch_item(
+    ValueType* const batch_values, const int stride, const int num_rows,
+    const int num_rhs, const size_type batch_idx)
 {
     return {batch_values + batch_idx * stride * num_rows, stride, num_rows,
             num_rhs};
 }
 
 
+}  // namespace matrix
 }  // namespace batch
 }  // namespace gko
 
 
-#endif  // GKO_CORE_BASE_BATCH_STRUCT_HPP_
+#endif  // GKO_CORE_MATRIX_BATCH_STRUCT_HPP_

--- a/core/matrix/batch_struct.hpp
+++ b/core/matrix/batch_struct.hpp
@@ -54,7 +54,7 @@ struct batch_item {
     ValueType* values;
     int stride;
     int num_rows;
-    int num_rhs;
+    int num_cols;
 };
 
 
@@ -70,7 +70,7 @@ struct uniform_batch {
     size_type num_batch_items;
     int stride;
     int num_rows;
-    int num_rhs;
+    int num_cols;
 
     size_type get_entry_storage() const
     {
@@ -86,7 +86,7 @@ template <typename ValueType>
 GKO_ATTRIBUTES GKO_INLINE batch_dense::batch_item<const ValueType> to_const(
     const batch_dense::batch_item<ValueType>& b)
 {
-    return {b.values, b.stride, b.num_rows, b.num_rhs};
+    return {b.values, b.stride, b.num_rows, b.num_cols};
 }
 
 
@@ -94,7 +94,7 @@ template <typename ValueType>
 GKO_ATTRIBUTES GKO_INLINE batch_dense::uniform_batch<const ValueType> to_const(
     const batch_dense::uniform_batch<ValueType>& ub)
 {
-    return {ub.values, ub.num_batch_items, ub.stride, ub.num_rows, ub.num_rhs};
+    return {ub.values, ub.num_batch_items, ub.stride, ub.num_rows, ub.num_cols};
 }
 
 
@@ -104,16 +104,16 @@ GKO_ATTRIBUTES GKO_INLINE batch_dense::batch_item<ValueType> extract_batch_item(
     const size_type batch_idx)
 {
     return {batch.values + batch_idx * batch.stride * batch.num_rows,
-            batch.stride, batch.num_rows, batch.num_rhs};
+            batch.stride, batch.num_rows, batch.num_cols};
 }
 
 template <typename ValueType>
 GKO_ATTRIBUTES GKO_INLINE batch_dense::batch_item<ValueType> extract_batch_item(
     ValueType* const batch_values, const int stride, const int num_rows,
-    const int num_rhs, const size_type batch_idx)
+    const int num_cols, const size_type batch_idx)
 {
     return {batch_values + batch_idx * stride * num_rows, stride, num_rows,
-            num_rhs};
+            num_cols};
 }
 
 

--- a/core/matrix/batch_struct.hpp
+++ b/core/matrix/batch_struct.hpp
@@ -46,7 +46,7 @@ namespace batch_dense {
 
 
 /**
- * Encapsulates one matrix from a batch of multi-vectors.
+ * Encapsulates one matrix from a batch of dense matrices.
  */
 template <typename ValueType>
 struct batch_item {
@@ -59,7 +59,7 @@ struct batch_item {
 
 
 /**
- * A 'simple' structure to store a global uniform batch of multi-vectors.
+ * A 'simple' structure to store a global uniform batch of dense matrices.
  */
 template <typename ValueType>
 struct uniform_batch {

--- a/core/matrix/batch_struct.hpp
+++ b/core/matrix/batch_struct.hpp
@@ -42,7 +42,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 namespace gko {
 namespace batch {
 namespace matrix {
-namespace batch_dense {
+namespace dense {
 
 
 /**
@@ -51,10 +51,10 @@ namespace batch_dense {
 template <typename ValueType>
 struct batch_item {
     using value_type = ValueType;
-    ValueType* values;
-    int stride;
-    int num_rows;
-    int num_cols;
+    value_type* values;
+    int32 stride;
+    int32 num_rows;
+    int32 num_cols;
 };
 
 
@@ -68,9 +68,9 @@ struct uniform_batch {
 
     ValueType* values;
     size_type num_batch_items;
-    int stride;
-    int num_rows;
-    int num_cols;
+    int32 stride;
+    int32 num_rows;
+    int32 num_cols;
 
     size_type get_entry_storage() const
     {
@@ -79,38 +79,37 @@ struct uniform_batch {
 };
 
 
-}  // namespace batch_dense
+}  // namespace dense
 
 
 template <typename ValueType>
-GKO_ATTRIBUTES GKO_INLINE batch_dense::batch_item<const ValueType> to_const(
-    const batch_dense::batch_item<ValueType>& b)
+GKO_ATTRIBUTES GKO_INLINE dense::batch_item<const ValueType> to_const(
+    const dense::batch_item<ValueType>& b)
 {
     return {b.values, b.stride, b.num_rows, b.num_cols};
 }
 
 
 template <typename ValueType>
-GKO_ATTRIBUTES GKO_INLINE batch_dense::uniform_batch<const ValueType> to_const(
-    const batch_dense::uniform_batch<ValueType>& ub)
+GKO_ATTRIBUTES GKO_INLINE dense::uniform_batch<const ValueType> to_const(
+    const dense::uniform_batch<ValueType>& ub)
 {
     return {ub.values, ub.num_batch_items, ub.stride, ub.num_rows, ub.num_cols};
 }
 
 
 template <typename ValueType>
-GKO_ATTRIBUTES GKO_INLINE batch_dense::batch_item<ValueType> extract_batch_item(
-    const batch_dense::uniform_batch<ValueType>& batch,
-    const size_type batch_idx)
+GKO_ATTRIBUTES GKO_INLINE dense::batch_item<ValueType> extract_batch_item(
+    const dense::uniform_batch<ValueType>& batch, const size_type batch_idx)
 {
     return {batch.values + batch_idx * batch.stride * batch.num_rows,
             batch.stride, batch.num_rows, batch.num_cols};
 }
 
 template <typename ValueType>
-GKO_ATTRIBUTES GKO_INLINE batch_dense::batch_item<ValueType> extract_batch_item(
-    ValueType* const batch_values, const int stride, const int num_rows,
-    const int num_cols, const size_type batch_idx)
+GKO_ATTRIBUTES GKO_INLINE dense::batch_item<ValueType> extract_batch_item(
+    ValueType* const batch_values, const int32 stride, const int32 num_rows,
+    const int32 num_cols, const size_type batch_idx)
 {
     return {batch_values + batch_idx * stride * num_rows, stride, num_rows,
             num_cols};

--- a/core/test/base/batch_dim.cpp
+++ b/core/test/base/batch_dim.cpp
@@ -85,16 +85,6 @@ TEST(BatchDim, NotEqualWorks)
 }
 
 
-TEST(BatchDim, CanGetCumulativeOffsets)
-{
-    auto d = gko::batch_dim<2>(3, gko::dim<2>(4, 2));
-
-    ASSERT_EQ(d.get_cumulative_offset(0), 0);
-    ASSERT_EQ(d.get_cumulative_offset(1), 8);
-    ASSERT_EQ(d.get_cumulative_offset(2), 16);
-}
-
-
 TEST(BatchDim, TransposesBatchDimensions)
 {
     ASSERT_EQ(gko::transpose(gko::batch_dim<2>(2, gko::dim<2>{4, 2})),

--- a/core/test/base/batch_multi_vector.cpp
+++ b/core/test/base/batch_multi_vector.cpp
@@ -412,9 +412,9 @@ TYPED_TEST(MultiVector, CanBeReadFromMatrixData)
     auto m = gko::batch::read<value_type, index_type,
                               gko::batch::MultiVector<value_type>>(this->exec,
                                                                    vec_data);
-    EXPECT_EQ(m->at(0, 0, 0), value_type{1.0});
 
     ASSERT_EQ(m->get_common_size(), gko::dim<2>(2, 2));
+    EXPECT_EQ(m->at(0, 0, 0), value_type{1.0});
     EXPECT_EQ(m->at(0, 0, 1), value_type{3.0});
     EXPECT_EQ(m->at(0, 1, 0), value_type{0.0});
     EXPECT_EQ(m->at(0, 1, 1), value_type{5.0});

--- a/core/test/base/batch_multi_vector.cpp
+++ b/core/test/base/batch_multi_vector.cpp
@@ -188,11 +188,11 @@ TYPED_TEST(MultiVector, CanBeConstructedFromExistingData)
     using size_type = gko::size_type;
     // clang-format off
     value_type data[] = {
-       1.0, 2.0,
-       -1.0,3.0,
+       1.0,  2.0,
+      -1.0,  3.0,
        4.0, -1.0,
-       3.0, 5.0,
-       1.0, 5.0,
+       3.0,  5.0,
+       1.0,  5.0,
        6.0, -3.0};
     // clang-format on
 
@@ -218,11 +218,11 @@ TYPED_TEST(MultiVector, CanBeConstructedFromExistingConstData)
     using size_type = gko::size_type;
     // clang-format off
     value_type data[] = {
-       1.0, 2.0,
-       -1.0,3.0,
+       1.0,  2.0,
+      -1.0,  3.0,
        4.0, -1.0,
-       3.0, 5.0,
-       1.0, 5.0,
+       3.0,  5.0,
+       1.0,  5.0,
        6.0, -3.0};
     // clang-format on
 
@@ -252,7 +252,7 @@ TYPED_TEST(MultiVector, CanBeConstructedFromDenseMatrices)
     auto mat2 = gko::initialize<DenseMtx>({{1.0, 2.5, 3.0}, {1.0, 2.0, 3.0}},
                                           this->exec);
 
-    auto m = gko::batch::multivector::create_from_dense(
+    auto m = gko::batch::create_from_item<gko::batch::MultiVector<value_type>>(
         this->exec, std::vector<DenseMtx*>{mat1.get(), mat2.get()});
 
     this->assert_equal_to_original_mtx(m.get());
@@ -269,10 +269,12 @@ TYPED_TEST(MultiVector, CanBeConstructedFromDenseMatricesByDuplication)
     auto mat2 = gko::initialize<DenseMtx>({{1.0, 2.5, 3.0}, {1.0, 2.0, 3.0}},
                                           this->exec);
 
-    auto bat_m = gko::batch::multivector::create_from_dense(
-        this->exec, std::vector<DenseMtx*>{mat1.get(), mat1.get(), mat1.get()});
-    auto m =
-        gko::batch::multivector::create_from_dense(this->exec, 3, mat1.get());
+    auto bat_m =
+        gko::batch::create_from_item<gko::batch::MultiVector<value_type>>(
+            this->exec,
+            std::vector<DenseMtx*>{mat1.get(), mat1.get(), mat1.get()});
+    auto m = gko::batch::create_from_item<gko::batch::MultiVector<value_type>>(
+        this->exec, 3, mat1.get());
 
     GKO_ASSERT_BATCH_MTX_NEAR(bat_m.get(), m.get(), 1e-14);
 }
@@ -287,14 +289,16 @@ TYPED_TEST(MultiVector, CanBeConstructedByDuplicatingMultiVectors)
                                           this->exec);
     auto mat2 = gko::initialize<DenseMtx>({{1.0, 2.5, 3.0}, {1.0, 2.0, 3.0}},
                                           this->exec);
-    auto m = gko::batch::multivector::create_from_dense(
+    auto m = gko::batch::create_from_item<gko::batch::MultiVector<value_type>>(
         this->exec, std::vector<DenseMtx*>{mat1.get(), mat2.get()});
-    auto m_ref = gko::batch::multivector::create_from_dense(
-        this->exec, std::vector<DenseMtx*>{mat1.get(), mat2.get(), mat1.get(),
-                                           mat2.get(), mat1.get(), mat2.get()});
+    auto m_ref =
+        gko::batch::create_from_item<gko::batch::MultiVector<value_type>>(
+            this->exec,
+            std::vector<DenseMtx*>{mat1.get(), mat2.get(), mat1.get(),
+                                   mat2.get(), mat1.get(), mat2.get()});
 
-    auto m2 =
-        gko::batch::multivector::duplicate<value_type>(this->exec, 3, m.get());
+    auto m2 = gko::batch::duplicate<gko::batch::MultiVector<value_type>>(
+        this->exec, 3, m.get());
 
     GKO_ASSERT_BATCH_MTX_NEAR(m2.get(), m_ref.get(), 1e-14);
 }
@@ -385,7 +389,8 @@ TYPED_TEST(MultiVector, CanBeUnbatchedIntoDenseMatrices)
     auto mat2 = gko::initialize<DenseMtx>({{1.0, 2.5, 3.0}, {1.0, 2.0, 3.0}},
                                           this->exec);
 
-    auto dense_mats = gko::batch::multivector::unbatch(this->mtx.get());
+    auto dense_mats = gko::batch::unbatch<gko::batch::MultiVector<value_type>>(
+        this->mtx.get());
 
     ASSERT_EQ(dense_mats.size(), 2);
     GKO_ASSERT_MTX_NEAR(dense_mats[0].get(), mat1.get(), 0.);
@@ -404,7 +409,8 @@ TYPED_TEST(MultiVector, CanBeReadFromMatrixData)
     vec_data.emplace_back(gko::matrix_data<value_type, index_type>(
         {2, 2}, {{0, 0, -1.0}, {0, 1, 0.5}, {1, 0, 0.0}, {1, 1, 9.0}}));
 
-    auto m = gko::batch::multivector::read<value_type, index_type>(this->exec,
+    auto m = gko::batch::read<value_type, index_type,
+                              gko::batch::MultiVector<value_type>>(this->exec,
                                                                    vec_data);
     EXPECT_EQ(m->at(0, 0, 0), value_type{1.0});
 
@@ -429,7 +435,8 @@ TYPED_TEST(MultiVector, CanBeReadFromSparseMatrixData)
     vec_data.emplace_back(gko::matrix_data<value_type, index_type>(
         {2, 2}, {{0, 0, -1.0}, {0, 1, 0.5}, {1, 1, 9.0}}));
 
-    auto m = gko::batch::multivector::read<value_type, index_type>(this->exec,
+    auto m = gko::batch::read<value_type, index_type,
+                              gko::batch::MultiVector<value_type>>(this->exec,
                                                                    vec_data);
 
     ASSERT_EQ(m->get_common_size(), gko::dim<2>(2, 2));
@@ -451,7 +458,8 @@ TYPED_TEST(MultiVector, GeneratesCorrectMatrixData)
     using tpl = typename gko::matrix_data<TypeParam>::nonzero_type;
 
     auto data =
-        gko::batch::multivector::write<value_type, index_type>(this->mtx.get());
+        gko::batch::write<value_type, index_type,
+                          gko::batch::MultiVector<value_type>>(this->mtx.get());
 
     ASSERT_EQ(data[0].size, gko::dim<2>(2, 3));
     ASSERT_EQ(data[0].nonzeros.size(), 6);

--- a/core/test/matrix/CMakeLists.txt
+++ b/core/test/matrix/CMakeLists.txt
@@ -1,3 +1,5 @@
+# ginkgo_create_test(batch_dense)
+#
 ginkgo_create_test(coo)
 ginkgo_create_test(coo_builder)
 ginkgo_create_test(csr)

--- a/core/test/matrix/CMakeLists.txt
+++ b/core/test/matrix/CMakeLists.txt
@@ -1,5 +1,4 @@
-# ginkgo_create_test(batch_dense)
-#
+ginkgo_create_test(batch_dense)
 ginkgo_create_test(coo)
 ginkgo_create_test(coo_builder)
 ginkgo_create_test(csr)

--- a/core/test/matrix/batch_dense.cpp
+++ b/core/test/matrix/batch_dense.cpp
@@ -48,15 +48,14 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
 template <typename T>
-class BatchDense : public ::testing::Test {
+class Dense : public ::testing::Test {
 protected:
     using value_type = T;
     using DenseMtx = gko::matrix::Dense<value_type>;
     using size_type = gko::size_type;
-    BatchDense()
+    Dense()
         : exec(gko::ReferenceExecutor::create()),
-          mtx(gko::batch::initialize<
-              gko::batch::matrix::BatchDense<value_type>>(
+          mtx(gko::batch::initialize<gko::batch::matrix::Dense<value_type>>(
               {{{-1.0, 2.0, 3.0}, {-1.5, 2.5, 3.5}},
                {{1.0, 2.5, 3.0}, {1.0, 2.0, 3.0}}},
               exec)),
@@ -66,7 +65,7 @@ protected:
 
 
     static void assert_equal_to_original_mtx(
-        gko::batch::matrix::BatchDense<value_type>* m)
+        gko::batch::matrix::Dense<value_type>* m)
     {
         ASSERT_EQ(m->get_num_batch_items(), 2);
         ASSERT_EQ(m->get_common_size(), gko::dim<2>(2, 3));
@@ -85,41 +84,41 @@ protected:
         ASSERT_EQ(m->at(1, 1, 2), value_type{3.0});
     }
 
-    static void assert_empty(gko::batch::matrix::BatchDense<value_type>* m)
+    static void assert_empty(gko::batch::matrix::Dense<value_type>* m)
     {
         ASSERT_EQ(m->get_num_batch_items(), 0);
         ASSERT_EQ(m->get_num_stored_elements(), 0);
     }
 
     std::shared_ptr<const gko::Executor> exec;
-    std::unique_ptr<gko::batch::matrix::BatchDense<value_type>> mtx;
+    std::unique_ptr<gko::batch::matrix::Dense<value_type>> mtx;
     std::unique_ptr<gko::matrix::Dense<value_type>> dense_mtx;
 };
 
-TYPED_TEST_SUITE(BatchDense, gko::test::ValueTypes);
+TYPED_TEST_SUITE(Dense, gko::test::ValueTypes);
 
 
-TYPED_TEST(BatchDense, KnowsItsSizeAndValues)
+TYPED_TEST(Dense, KnowsItsSizeAndValues)
 {
     this->assert_equal_to_original_mtx(this->mtx.get());
 }
 
 
-TYPED_TEST(BatchDense, CanBeEmpty)
+TYPED_TEST(Dense, CanBeEmpty)
 {
-    auto empty = gko::batch::matrix::BatchDense<TypeParam>::create(this->exec);
+    auto empty = gko::batch::matrix::Dense<TypeParam>::create(this->exec);
     this->assert_empty(empty.get());
 }
 
 
-TYPED_TEST(BatchDense, ReturnsNullValuesArrayWhenEmpty)
+TYPED_TEST(Dense, ReturnsNullValuesArrayWhenEmpty)
 {
-    auto empty = gko::batch::matrix::BatchDense<TypeParam>::create(this->exec);
+    auto empty = gko::batch::matrix::Dense<TypeParam>::create(this->exec);
     ASSERT_EQ(empty->get_const_values(), nullptr);
 }
 
 
-TYPED_TEST(BatchDense, CanGetValuesForEntry)
+TYPED_TEST(Dense, CanGetValuesForEntry)
 {
     using value_type = typename TestFixture::value_type;
 
@@ -127,17 +126,16 @@ TYPED_TEST(BatchDense, CanGetValuesForEntry)
 }
 
 
-TYPED_TEST(BatchDense, CanCreateDenseItemView)
+TYPED_TEST(Dense, CanCreateDenseItemView)
 {
     GKO_ASSERT_MTX_NEAR(this->mtx->create_view_for_item(1), this->dense_mtx,
                         0.0);
 }
 
 
-TYPED_TEST(BatchDense, CanBeCopied)
+TYPED_TEST(Dense, CanBeCopied)
 {
-    auto mtx_copy =
-        gko::batch::matrix::BatchDense<TypeParam>::create(this->exec);
+    auto mtx_copy = gko::batch::matrix::Dense<TypeParam>::create(this->exec);
 
     mtx_copy->copy_from(this->mtx.get());
 
@@ -148,10 +146,9 @@ TYPED_TEST(BatchDense, CanBeCopied)
 }
 
 
-TYPED_TEST(BatchDense, CanBeMoved)
+TYPED_TEST(Dense, CanBeMoved)
 {
-    auto mtx_copy =
-        gko::batch::matrix::BatchDense<TypeParam>::create(this->exec);
+    auto mtx_copy = gko::batch::matrix::Dense<TypeParam>::create(this->exec);
 
     this->mtx->move_to(mtx_copy);
 
@@ -159,7 +156,7 @@ TYPED_TEST(BatchDense, CanBeMoved)
 }
 
 
-TYPED_TEST(BatchDense, CanBeCloned)
+TYPED_TEST(Dense, CanBeCloned)
 {
     auto mtx_clone = this->mtx->clone();
 
@@ -168,7 +165,7 @@ TYPED_TEST(BatchDense, CanBeCloned)
 }
 
 
-TYPED_TEST(BatchDense, CanBeCleared)
+TYPED_TEST(Dense, CanBeCleared)
 {
     this->mtx->clear();
 
@@ -176,11 +173,11 @@ TYPED_TEST(BatchDense, CanBeCleared)
 }
 
 
-TYPED_TEST(BatchDense, CanBeConstructedWithSize)
+TYPED_TEST(Dense, CanBeConstructedWithSize)
 {
     using size_type = gko::size_type;
 
-    auto m = gko::batch::matrix::BatchDense<TypeParam>::create(
+    auto m = gko::batch::matrix::Dense<TypeParam>::create(
         this->exec, gko::batch_dim<2>(2, gko::dim<2>{5, 3}));
 
     ASSERT_EQ(m->get_num_batch_items(), 2);
@@ -189,7 +186,7 @@ TYPED_TEST(BatchDense, CanBeConstructedWithSize)
 }
 
 
-TYPED_TEST(BatchDense, CanBeConstructedFromExistingData)
+TYPED_TEST(Dense, CanBeConstructedFromExistingData)
 {
     using value_type = typename TestFixture::value_type;
     using size_type = gko::size_type;
@@ -203,7 +200,7 @@ TYPED_TEST(BatchDense, CanBeConstructedFromExistingData)
        6.0, -3.0};
     // clang-format on
 
-    auto m = gko::batch::matrix::BatchDense<TypeParam>::create(
+    auto m = gko::batch::matrix::Dense<TypeParam>::create(
         this->exec, gko::batch_dim<2>(2, gko::dim<2>(2, 2)),
         gko::array<value_type>::view(this->exec, 8, data));
 
@@ -219,7 +216,7 @@ TYPED_TEST(BatchDense, CanBeConstructedFromExistingData)
 }
 
 
-TYPED_TEST(BatchDense, CanBeConstructedFromExistingConstData)
+TYPED_TEST(Dense, CanBeConstructedFromExistingConstData)
 {
     using value_type = typename TestFixture::value_type;
     using size_type = gko::size_type;
@@ -233,7 +230,7 @@ TYPED_TEST(BatchDense, CanBeConstructedFromExistingConstData)
        6.0, -3.0};
     // clang-format on
 
-    auto m = gko::batch::matrix::BatchDense<TypeParam>::create_const(
+    auto m = gko::batch::matrix::Dense<TypeParam>::create_const(
         this->exec, gko::batch_dim<2>(2, gko::dim<2>(2, 2)),
         gko::array<value_type>::const_view(this->exec, 8, data));
 
@@ -249,7 +246,7 @@ TYPED_TEST(BatchDense, CanBeConstructedFromExistingConstData)
 }
 
 
-TYPED_TEST(BatchDense, CanBeConstructedFromDenseMatrices)
+TYPED_TEST(Dense, CanBeConstructedFromDenseMatrices)
 {
     using value_type = typename TestFixture::value_type;
     using DenseMtx = typename TestFixture::DenseMtx;
@@ -260,15 +257,15 @@ TYPED_TEST(BatchDense, CanBeConstructedFromDenseMatrices)
     auto mat2 = gko::initialize<DenseMtx>({{1.0, 2.5, 3.0}, {1.0, 2.0, 3.0}},
                                           this->exec);
 
-    auto m = gko::batch::create_from_item<
-        gko::batch::matrix::BatchDense<value_type>>(
-        this->exec, std::vector<DenseMtx*>{mat1.get(), mat2.get()});
+    auto m =
+        gko::batch::create_from_item<gko::batch::matrix::Dense<value_type>>(
+            this->exec, std::vector<DenseMtx*>{mat1.get(), mat2.get()});
 
     this->assert_equal_to_original_mtx(m.get());
 }
 
 
-TYPED_TEST(BatchDense, CanBeConstructedFromDenseMatricesByDuplication)
+TYPED_TEST(Dense, CanBeConstructedFromDenseMatricesByDuplication)
 {
     using value_type = typename TestFixture::value_type;
     using DenseMtx = typename TestFixture::DenseMtx;
@@ -279,17 +276,19 @@ TYPED_TEST(BatchDense, CanBeConstructedFromDenseMatricesByDuplication)
     auto mat2 = gko::initialize<DenseMtx>({{1.0, 2.5, 3.0}, {1.0, 2.0, 3.0}},
                                           this->exec);
 
-    auto bat_m = gko::batch::create_from_item<
-        gko::batch::matrix::BatchDense<value_type>>(
-        this->exec, std::vector<DenseMtx*>{mat1.get(), mat1.get(), mat1.get()});
-    auto m = gko::batch::create_from_item<
-        gko::batch::matrix::BatchDense<value_type>>(this->exec, 3, mat1.get());
+    auto bat_m =
+        gko::batch::create_from_item<gko::batch::matrix::Dense<value_type>>(
+            this->exec,
+            std::vector<DenseMtx*>{mat1.get(), mat1.get(), mat1.get()});
+    auto m =
+        gko::batch::create_from_item<gko::batch::matrix::Dense<value_type>>(
+            this->exec, 3, mat1.get());
 
     GKO_ASSERT_BATCH_MTX_NEAR(bat_m.get(), m.get(), 1e-14);
 }
 
 
-TYPED_TEST(BatchDense, CanBeConstructedByDuplicatingBatchDenseMatrices)
+TYPED_TEST(Dense, CanBeConstructedByDuplicatingDenseMatrices)
 {
     using value_type = typename TestFixture::value_type;
     using DenseMtx = typename TestFixture::DenseMtx;
@@ -300,22 +299,23 @@ TYPED_TEST(BatchDense, CanBeConstructedByDuplicatingBatchDenseMatrices)
     auto mat2 = gko::initialize<DenseMtx>({{1.0, 2.5, 3.0}, {1.0, 2.0, 3.0}},
                                           this->exec);
 
-    auto m = gko::batch::create_from_item<
-        gko::batch::matrix::BatchDense<value_type>>(
-        this->exec, std::vector<DenseMtx*>{mat1.get(), mat2.get()});
-    auto m_ref = gko::batch::create_from_item<
-        gko::batch::matrix::BatchDense<value_type>>(
-        this->exec, std::vector<DenseMtx*>{mat1.get(), mat2.get(), mat1.get(),
-                                           mat2.get(), mat1.get(), mat2.get()});
+    auto m =
+        gko::batch::create_from_item<gko::batch::matrix::Dense<value_type>>(
+            this->exec, std::vector<DenseMtx*>{mat1.get(), mat2.get()});
+    auto m_ref =
+        gko::batch::create_from_item<gko::batch::matrix::Dense<value_type>>(
+            this->exec,
+            std::vector<DenseMtx*>{mat1.get(), mat2.get(), mat1.get(),
+                                   mat2.get(), mat1.get(), mat2.get()});
 
-    auto m2 = gko::batch::duplicate<gko::batch::matrix::BatchDense<value_type>>(
+    auto m2 = gko::batch::duplicate<gko::batch::matrix::Dense<value_type>>(
         this->exec, 3, m.get());
 
     GKO_ASSERT_BATCH_MTX_NEAR(m2.get(), m_ref.get(), 1e-14);
 }
 
 
-TYPED_TEST(BatchDense, CanBeUnbatchedIntoDenseMatrices)
+TYPED_TEST(Dense, CanBeUnbatchedIntoDenseMatrices)
 {
     using value_type = typename TestFixture::value_type;
     using DenseMtx = typename TestFixture::DenseMtx;
@@ -326,7 +326,7 @@ TYPED_TEST(BatchDense, CanBeUnbatchedIntoDenseMatrices)
                                           this->exec);
 
     auto dense_mats =
-        gko::batch::unbatch<gko::batch::matrix::BatchDense<value_type>>(
+        gko::batch::unbatch<gko::batch::matrix::Dense<value_type>>(
             this->mtx.get());
 
     GKO_ASSERT_MTX_NEAR(dense_mats[0].get(), mat1.get(), 0.);
@@ -334,10 +334,10 @@ TYPED_TEST(BatchDense, CanBeUnbatchedIntoDenseMatrices)
 }
 
 
-TYPED_TEST(BatchDense, CanBeListConstructed)
+TYPED_TEST(Dense, CanBeListConstructed)
 {
     using value_type = typename TestFixture::value_type;
-    auto m = gko::batch::initialize<gko::batch::matrix::BatchDense<TypeParam>>(
+    auto m = gko::batch::initialize<gko::batch::matrix::Dense<TypeParam>>(
         {{1.0, 2.0}, {1.0, 3.0}}, this->exec);
 
     ASSERT_EQ(m->get_num_batch_items(), 2);
@@ -349,11 +349,11 @@ TYPED_TEST(BatchDense, CanBeListConstructed)
 }
 
 
-TYPED_TEST(BatchDense, CanBeListConstructedByCopies)
+TYPED_TEST(Dense, CanBeListConstructedByCopies)
 {
     using value_type = typename TestFixture::value_type;
 
-    auto m = gko::batch::initialize<gko::batch::matrix::BatchDense<TypeParam>>(
+    auto m = gko::batch::initialize<gko::batch::matrix::Dense<TypeParam>>(
         2, I<value_type>({1.0, 2.0}), this->exec);
 
     ASSERT_EQ(m->get_num_batch_items(), 2);
@@ -365,12 +365,12 @@ TYPED_TEST(BatchDense, CanBeListConstructedByCopies)
 }
 
 
-TYPED_TEST(BatchDense, CanBeDoubleListConstructed)
+TYPED_TEST(Dense, CanBeDoubleListConstructed)
 {
     using value_type = typename TestFixture::value_type;
     using T = value_type;
 
-    auto m = gko::batch::initialize<gko::batch::matrix::BatchDense<TypeParam>>(
+    auto m = gko::batch::initialize<gko::batch::matrix::Dense<TypeParam>>(
         {{I<T>{1.0, 1.0, 0.0}, I<T>{2.0, 4.0, 3.0}, I<T>{3.0, 6.0, 1.0}},
          {I<T>{1.0, 2.0, -1.0}, I<T>{3.0, 4.0, -2.0}, I<T>{5.0, 6.0, -3.0}}},
         this->exec);
@@ -389,7 +389,7 @@ TYPED_TEST(BatchDense, CanBeDoubleListConstructed)
 }
 
 
-TYPED_TEST(BatchDense, CanBeReadFromMatrixData)
+TYPED_TEST(Dense, CanBeReadFromMatrixData)
 {
     using value_type = typename TestFixture::value_type;
     using index_type = int;
@@ -401,8 +401,8 @@ TYPED_TEST(BatchDense, CanBeReadFromMatrixData)
         {2, 2}, {{0, 0, -1.0}, {0, 1, 0.5}, {1, 0, 0.0}, {1, 1, 9.0}}));
 
     auto m = gko::batch::read<value_type, index_type,
-                              gko::batch::matrix::BatchDense<value_type>>(
-        this->exec, vec_data);
+                              gko::batch::matrix::Dense<value_type>>(this->exec,
+                                                                     vec_data);
 
     ASSERT_EQ(m->get_common_size(), gko::dim<2>(2, 2));
     EXPECT_EQ(m->at(0, 0, 0), value_type{1.0});
@@ -416,7 +416,7 @@ TYPED_TEST(BatchDense, CanBeReadFromMatrixData)
 }
 
 
-TYPED_TEST(BatchDense, CanBeReadFromSparseMatrixData)
+TYPED_TEST(Dense, CanBeReadFromSparseMatrixData)
 {
     using value_type = typename TestFixture::value_type;
     using index_type = int;
@@ -427,8 +427,8 @@ TYPED_TEST(BatchDense, CanBeReadFromSparseMatrixData)
         {2, 2}, {{0, 0, -1.0}, {0, 1, 0.5}, {1, 1, 9.0}}));
 
     auto m = gko::batch::read<value_type, index_type,
-                              gko::batch::matrix::BatchDense<value_type>>(
-        this->exec, vec_data);
+                              gko::batch::matrix::Dense<value_type>>(this->exec,
+                                                                     vec_data);
 
     ASSERT_EQ(m->get_common_size(), gko::dim<2>(2, 2));
     EXPECT_EQ(m->at(0, 0, 0), value_type{1.0});
@@ -442,14 +442,14 @@ TYPED_TEST(BatchDense, CanBeReadFromSparseMatrixData)
 }
 
 
-TYPED_TEST(BatchDense, GeneratesCorrectMatrixData)
+TYPED_TEST(Dense, GeneratesCorrectMatrixData)
 {
     using value_type = typename TestFixture::value_type;
     using index_type = int;
     using tpl = typename gko::matrix_data<TypeParam>::nonzero_type;
 
     auto data = gko::batch::write<value_type, index_type,
-                                  gko::batch::matrix::BatchDense<value_type>>(
+                                  gko::batch::matrix::Dense<value_type>>(
         this->mtx.get());
 
     ASSERT_EQ(data[0].size, gko::dim<2>(2, 3));

--- a/core/test/matrix/batch_dense.cpp
+++ b/core/test/matrix/batch_dense.cpp
@@ -1,0 +1,520 @@
+/*******************************<GINKGO LICENSE>******************************
+Copyright (c) 2017-2023, the Ginkgo authors
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+******************************<GINKGO LICENSE>*******************************/
+
+#include <ginkgo/core/matrix/batch_dense.hpp>
+
+
+#include <gtest/gtest.h>
+
+
+#include <ginkgo/core/base/executor.hpp>
+#include <ginkgo/core/base/range.hpp>
+#include <ginkgo/core/matrix/dense.hpp>
+
+
+#include "core/test/utils.hpp"
+
+
+namespace {
+
+
+template <typename T>
+class BatchDense : public ::testing::Test {
+protected:
+    using value_type = T;
+    using DenseMtx = gko::matrix::Dense<value_type>;
+    using size_type = gko::size_type;
+    BatchDense()
+        : exec(gko::ReferenceExecutor::create()),
+          mtx(gko::batch_initialize<gko::matrix::BatchDense<value_type>>(
+              std::vector<size_type>{4, 3},
+              {{{-1.0, 2.0, 3.0}, {-1.5, 2.5, 3.5}},
+               {{1.0, 2.5, 3.0}, {1.0, 2.0, 3.0}}},
+              exec))
+    {}
+
+
+    static void assert_equal_to_original_mtx(
+        gko::matrix::BatchDense<value_type>* m)
+    {
+        ASSERT_EQ(m->get_num_batch_entries(), 2);
+        ASSERT_EQ(m->get_size().at(0), gko::dim<2>(2, 3));
+        ASSERT_EQ(m->get_size().at(0), gko::dim<2>(2, 3));
+        ASSERT_EQ(m->get_stride().at(0), 4);
+        ASSERT_EQ(m->get_stride().at(1), 3);
+        ASSERT_EQ(m->get_num_stored_elements(), (2 * 4) + (2 * 3));
+        ASSERT_EQ(m->get_num_stored_elements(0), 2 * 4);
+        ASSERT_EQ(m->get_num_stored_elements(1), 2 * 3);
+        EXPECT_EQ(m->at(0, 0, 0), value_type{-1.0});
+        EXPECT_EQ(m->at(0, 0, 1), value_type{2.0});
+        EXPECT_EQ(m->at(0, 0, 2), value_type{3.0});
+        EXPECT_EQ(m->at(0, 1, 0), value_type{-1.5});
+        EXPECT_EQ(m->at(0, 1, 1), value_type{2.5});
+        ASSERT_EQ(m->at(0, 1, 2), value_type{3.5});
+        EXPECT_EQ(m->at(1, 0, 0), value_type{1.0});
+        EXPECT_EQ(m->at(1, 0, 1), value_type{2.5});
+        EXPECT_EQ(m->at(1, 0, 2), value_type{3.0});
+        EXPECT_EQ(m->at(1, 1, 0), value_type{1.0});
+        EXPECT_EQ(m->at(1, 1, 1), value_type{2.0});
+        ASSERT_EQ(m->at(1, 1, 2), value_type{3.0});
+    }
+
+    static void assert_empty(gko::matrix::BatchDense<value_type>* m)
+    {
+        ASSERT_EQ(m->get_num_batch_entries(), 0);
+        ASSERT_EQ(m->get_num_stored_elements(), 0);
+    }
+
+    std::shared_ptr<const gko::Executor> exec;
+    std::unique_ptr<gko::matrix::BatchDense<value_type>> mtx;
+};
+
+TYPED_TEST_SUITE(BatchDense, gko::test::ValueTypes);
+
+
+TYPED_TEST(BatchDense, CanBeEmpty)
+{
+    auto empty = gko::matrix::BatchDense<TypeParam>::create(this->exec);
+    this->assert_empty(empty.get());
+}
+
+
+TYPED_TEST(BatchDense, ReturnsNullValuesArrayWhenEmpty)
+{
+    auto empty = gko::matrix::BatchDense<TypeParam>::create(this->exec);
+    ASSERT_EQ(empty->get_const_values(), nullptr);
+}
+
+
+TYPED_TEST(BatchDense, CanBeConstructedWithSize)
+{
+    using size_type = gko::size_type;
+    auto m = gko::matrix::BatchDense<TypeParam>::create(
+        this->exec,
+        std::vector<gko::dim<2>>{gko::dim<2>{2, 4}, gko::dim<2>{2, 3}});
+
+    ASSERT_EQ(m->get_num_batch_entries(), 2);
+    ASSERT_EQ(m->get_size().at(0), gko::dim<2>(2, 4));
+    ASSERT_EQ(m->get_size().at(1), gko::dim<2>(2, 3));
+    EXPECT_EQ(m->get_stride().at(0), 4);
+    EXPECT_EQ(m->get_stride().at(1), 3);
+    ASSERT_EQ(m->get_num_stored_elements(), 14);
+    ASSERT_EQ(m->get_num_stored_elements(0), 8);
+    ASSERT_EQ(m->get_num_stored_elements(1), 6);
+}
+
+
+TYPED_TEST(BatchDense, CanBeConstructedWithSizeAndStride)
+{
+    using size_type = gko::size_type;
+    auto m = gko::matrix::BatchDense<TypeParam>::create(
+        this->exec, std::vector<gko::dim<2>>{gko::dim<2>{2, 3}},
+        std::vector<size_type>{4});
+
+    ASSERT_EQ(m->get_size().at(0), gko::dim<2>(2, 3));
+    EXPECT_EQ(m->get_stride().at(0), 4);
+    ASSERT_EQ(m->get_num_stored_elements(), 8);
+}
+
+
+TYPED_TEST(BatchDense, CanBeConstructedFromExistingData)
+{
+    using value_type = typename TestFixture::value_type;
+    using size_type = gko::size_type;
+    // clang-format off
+    value_type data[] = {
+       1.0, 2.0, -1.0,
+       3.0, 4.0, -1.0,
+       3.0, 5.0, 1.0,
+       5.0, 6.0, -3.0};
+    // clang-format on
+
+    auto m = gko::matrix::BatchDense<TypeParam>::create(
+        this->exec,
+        std::vector<gko::dim<2>>{gko::dim<2>{2, 2}, gko::dim<2>{2, 2}},
+        gko::array<value_type>::view(this->exec, 12, data),
+        std::vector<size_type>{3, 3});
+
+    ASSERT_EQ(m->get_const_values(), data);
+    ASSERT_EQ(m->at(0, 0, 1), value_type{2.0});
+    ASSERT_EQ(m->at(0, 1, 2), value_type{-1.0});
+    ASSERT_EQ(m->at(1, 0, 1), value_type{5.0});
+    ASSERT_EQ(m->at(1, 1, 2), value_type{-3.0});
+}
+
+
+TYPED_TEST(BatchDense, CanBeConstructedFromExistingConstData)
+{
+    using value_type = typename TestFixture::value_type;
+    using size_type = gko::size_type;
+    // clang-format off
+    const value_type data[] = {
+       1.0, 2.0, -1.0,
+       3.0, 4.0, -1.0,
+       3.0, 5.0, 1.0,
+       5.0, 6.0, -3.0};
+    // clang-format on
+
+    auto m = gko::matrix::BatchDense<TypeParam>::create_const(
+        this->exec,
+        std::vector<gko::dim<2>>{gko::dim<2>{2, 2}, gko::dim<2>{2, 2}},
+        gko::array<value_type>::const_view(this->exec, 12, data),
+        std::vector<size_type>{3, 3});
+
+    ASSERT_EQ(m->get_const_values(), data);
+    ASSERT_EQ(m->at(0, 0, 1), value_type{2.0});
+    ASSERT_EQ(m->at(0, 1, 2), value_type{-1.0});
+    ASSERT_EQ(m->at(1, 0, 1), value_type{5.0});
+    ASSERT_EQ(m->at(1, 1, 2), value_type{-3.0});
+}
+
+
+TYPED_TEST(BatchDense, CanBeConstructedFromBatchDenseMatrices)
+{
+    using value_type = typename TestFixture::value_type;
+    using DenseMtx = typename TestFixture::DenseMtx;
+    using size_type = gko::size_type;
+    auto mat1 = gko::initialize<DenseMtx>(
+        3, {{-1.0, 2.0, 3.0}, {-1.5, 2.5, 3.5}}, this->exec);
+    auto mat2 = gko::initialize<DenseMtx>({{1.0, 2.5, 3.0}, {1.0, 2.0, 3.0}},
+                                          this->exec);
+
+    auto m = gko::matrix::BatchDense<TypeParam>::create(
+        this->exec, std::vector<DenseMtx*>{mat1.get(), mat2.get()});
+    auto m_ref = gko::matrix::BatchDense<TypeParam>::create(
+        this->exec, std::vector<DenseMtx*>{mat1.get(), mat2.get(), mat1.get(),
+                                           mat2.get(), mat1.get(), mat2.get()});
+    auto m2 =
+        gko::matrix::BatchDense<TypeParam>::create(this->exec, 3, m.get());
+
+    GKO_ASSERT_BATCH_MTX_NEAR(m2.get(), m_ref.get(), 1e-14);
+}
+
+
+TYPED_TEST(BatchDense, CanBeConstructedFromDenseMatricesByDuplication)
+{
+    using value_type = typename TestFixture::value_type;
+    using DenseMtx = typename TestFixture::DenseMtx;
+    using size_type = gko::size_type;
+    auto mat1 = gko::initialize<DenseMtx>(
+        4, {{-1.0, 2.0, 3.0}, {-1.5, 2.5, 3.5}}, this->exec);
+    auto mat2 = gko::initialize<DenseMtx>({{1.0, 2.5, 3.0}, {1.0, 2.0, 3.0}},
+                                          this->exec);
+
+    auto bat_m = gko::matrix::BatchDense<TypeParam>::create(
+        this->exec, std::vector<DenseMtx*>{mat1.get(), mat1.get(), mat1.get()});
+    auto m =
+        gko::matrix::BatchDense<TypeParam>::create(this->exec, 3, mat1.get());
+
+    GKO_ASSERT_BATCH_MTX_NEAR(bat_m.get(), m.get(), 1e-14);
+}
+
+
+TYPED_TEST(BatchDense, CanBeConstructedFromDenseMatrices)
+{
+    using value_type = typename TestFixture::value_type;
+    using DenseMtx = typename TestFixture::DenseMtx;
+    using size_type = gko::size_type;
+    auto mat1 = gko::initialize<DenseMtx>(
+        4, {{-1.0, 2.0, 3.0}, {-1.5, 2.5, 3.5}}, this->exec);
+    auto mat2 = gko::initialize<DenseMtx>({{1.0, 2.5, 3.0}, {1.0, 2.0, 3.0}},
+                                          this->exec);
+
+    auto m = gko::matrix::BatchDense<TypeParam>::create(
+        this->exec, std::vector<DenseMtx*>{mat1.get(), mat2.get()});
+
+    this->assert_equal_to_original_mtx(m.get());
+}
+
+
+TYPED_TEST(BatchDense, CanBeUnbatchedIntoDenseMatrices)
+{
+    using value_type = typename TestFixture::value_type;
+    using DenseMtx = typename TestFixture::DenseMtx;
+    using size_type = gko::size_type;
+    auto mat1 = gko::initialize<DenseMtx>(
+        4, {{-1.0, 2.0, 3.0}, {-1.5, 2.5, 3.5}}, this->exec);
+    auto mat2 = gko::initialize<DenseMtx>({{1.0, 2.5, 3.0}, {1.0, 2.0, 3.0}},
+                                          this->exec);
+
+    auto dense_mats = this->mtx->unbatch();
+
+
+    GKO_ASSERT_MTX_NEAR(dense_mats[0].get(), mat1.get(), 0.);
+    GKO_ASSERT_MTX_NEAR(dense_mats[1].get(), mat2.get(), 0.);
+}
+
+
+TYPED_TEST(BatchDense, KnowsItsSizeAndValues)
+{
+    this->assert_equal_to_original_mtx(this->mtx.get());
+}
+
+
+TYPED_TEST(BatchDense, CanBeListConstructed)
+{
+    using value_type = typename TestFixture::value_type;
+    auto m = gko::batch_initialize<gko::matrix::BatchDense<TypeParam>>(
+        {{1.0, 2.0}, {1.0, 3.0}}, this->exec);
+
+    ASSERT_EQ(m->get_num_batch_entries(), 2);
+    ASSERT_EQ(m->get_size().at(0), gko::dim<2>(2, 1));
+    ASSERT_EQ(m->get_size().at(1), gko::dim<2>(2, 1));
+    ASSERT_EQ(m->get_num_stored_elements(), 4);
+    EXPECT_EQ(m->at(0, 0), value_type{1});
+    EXPECT_EQ(m->at(0, 1), value_type{2});
+    EXPECT_EQ(m->at(1, 0), value_type{1});
+    EXPECT_EQ(m->at(1, 1), value_type{3});
+}
+
+
+TYPED_TEST(BatchDense, CanBeListConstructedWithstride)
+{
+    using value_type = typename TestFixture::value_type;
+    auto m = gko::batch_initialize<gko::matrix::BatchDense<TypeParam>>(
+        std::vector<gko::size_type>{2}, {{1.0, 2.0}}, this->exec);
+    ASSERT_EQ(m->get_num_batch_entries(), 1);
+    ASSERT_EQ(m->get_size().at(0), gko::dim<2>(2, 1));
+    ASSERT_EQ(m->get_num_stored_elements(), 4);
+    EXPECT_EQ(m->at(0, 0), value_type{1.0});
+    EXPECT_EQ(m->at(0, 1), value_type{2.0});
+}
+
+
+TYPED_TEST(BatchDense, CanBeListConstructedByCopies)
+{
+    using value_type = typename TestFixture::value_type;
+    auto m = gko::batch_initialize<gko::matrix::BatchDense<TypeParam>>(
+        2, I<value_type>({1.0, 2.0}), this->exec);
+    ASSERT_EQ(m->get_num_batch_entries(), 2);
+    ASSERT_EQ(m->get_size().at(0), gko::dim<2>(2, 1));
+    ASSERT_EQ(m->get_size().at(1), gko::dim<2>(2, 1));
+    ASSERT_EQ(m->get_num_stored_elements(), 4);
+    EXPECT_EQ(m->at(0, 0, 0), value_type{1.0});
+    EXPECT_EQ(m->at(0, 0, 1), value_type{2.0});
+    EXPECT_EQ(m->at(1, 0, 0), value_type{1.0});
+    EXPECT_EQ(m->at(1, 0, 1), value_type{2.0});
+}
+
+
+TYPED_TEST(BatchDense, CanBeDoubleListConstructed)
+{
+    using value_type = typename TestFixture::value_type;
+    using T = value_type;
+    auto m = gko::batch_initialize<gko::matrix::BatchDense<TypeParam>>(
+        {{I<T>{1.0, 1.0, 0.0}, I<T>{2.0, 4.0, 3.0}, I<T>{3.0, 6.0, 1.0}},
+         {I<T>{1.0, 2.0}, I<T>{3.0, 4.0}, I<T>{5.0, 6.0}}},
+        this->exec);
+
+    ASSERT_EQ(m->get_size().at(0), gko::dim<2>(3, 3));
+    ASSERT_EQ(m->get_size().at(1), gko::dim<2>(3, 2));
+    ASSERT_EQ(m->get_stride().at(0), 3);
+    ASSERT_EQ(m->get_stride().at(1), 2);
+    EXPECT_EQ(m->get_num_stored_elements(), 15);
+    ASSERT_EQ(m->get_num_stored_elements(0), 9);
+    ASSERT_EQ(m->get_num_stored_elements(1), 6);
+    EXPECT_EQ(m->at(0, 0), value_type{1.0});
+    EXPECT_EQ(m->at(0, 1), value_type{1.0});
+    EXPECT_EQ(m->at(0, 2), value_type{0.0});
+    ASSERT_EQ(m->at(0, 3), value_type{2.0});
+    EXPECT_EQ(m->at(0, 4), value_type{4.0});
+    EXPECT_EQ(m->at(1, 0), value_type{1.0});
+    EXPECT_EQ(m->at(1, 1), value_type{2.0});
+    EXPECT_EQ(m->at(1, 2), value_type{3.0});
+    ASSERT_EQ(m->at(1, 3), value_type{4.0});
+    EXPECT_EQ(m->at(1, 4), value_type{5.0});
+}
+
+
+TYPED_TEST(BatchDense, CanBeDoubleListConstructedWithstride)
+{
+    using value_type = typename TestFixture::value_type;
+    using T = value_type;
+    auto m = gko::batch_initialize<gko::matrix::BatchDense<TypeParam>>(
+        {4, 3},
+        {{I<T>{1.0, 1.0, 0.0}, I<T>{2.0, 4.0, 3.0}, I<T>{3.0, 6.0, 1.0}},
+         {I<T>{1.0, 2.0}, I<T>{3.0, 4.0}, I<T>{5.0, 6.0}}},
+        this->exec);
+
+    ASSERT_EQ(m->get_size().at(0), gko::dim<2>(3, 3));
+    ASSERT_EQ(m->get_size().at(1), gko::dim<2>(3, 2));
+    ASSERT_EQ(m->get_stride().at(0), 4);
+    ASSERT_EQ(m->get_stride().at(1), 3);
+    EXPECT_EQ(m->get_num_stored_elements(), 21);
+    ASSERT_EQ(m->get_num_stored_elements(0), 12);
+    ASSERT_EQ(m->get_num_stored_elements(1), 9);
+    EXPECT_EQ(m->at(0, 0), value_type{1.0});
+    EXPECT_EQ(m->at(0, 1), value_type{1.0});
+    EXPECT_EQ(m->at(0, 2), value_type{0.0});
+    ASSERT_EQ(m->at(0, 3), value_type{2.0});
+    EXPECT_EQ(m->at(0, 4), value_type{4.0});
+    EXPECT_EQ(m->at(1, 0), value_type{1.0});
+    EXPECT_EQ(m->at(1, 1), value_type{2.0});
+    EXPECT_EQ(m->at(1, 2), value_type{3.0});
+    ASSERT_EQ(m->at(1, 3), value_type{4.0});
+    EXPECT_EQ(m->at(1, 4), value_type{5.0});
+}
+
+
+TYPED_TEST(BatchDense, CanBeCopied)
+{
+    auto mtx_copy = gko::matrix::BatchDense<TypeParam>::create(this->exec);
+    mtx_copy->copy_from(this->mtx.get());
+    this->assert_equal_to_original_mtx(this->mtx.get());
+    this->mtx->at(0, 0, 0) = 7;
+    this->mtx->at(0, 1) = 7;
+    this->assert_equal_to_original_mtx(mtx_copy.get());
+}
+
+
+TYPED_TEST(BatchDense, CanBeMoved)
+{
+    auto mtx_copy = gko::matrix::BatchDense<TypeParam>::create(this->exec);
+    mtx_copy->copy_from(std::move(this->mtx));
+    this->assert_equal_to_original_mtx(mtx_copy.get());
+}
+
+
+TYPED_TEST(BatchDense, CanBeCloned)
+{
+    auto mtx_clone = this->mtx->clone();
+    this->assert_equal_to_original_mtx(
+        dynamic_cast<decltype(this->mtx.get())>(mtx_clone.get()));
+}
+
+
+TYPED_TEST(BatchDense, CanBeCleared)
+{
+    this->mtx->clear();
+    this->assert_empty(this->mtx.get());
+}
+
+
+TYPED_TEST(BatchDense, CanBeReadFromMatrixData)
+{
+    using value_type = typename TestFixture::value_type;
+    auto m = gko::matrix::BatchDense<TypeParam>::create(this->exec);
+    // clang-format off
+    m->read({gko::matrix_data<TypeParam>{{2, 3},
+                                         {{0, 0, 1.0},
+                                          {0, 1, 3.0},
+                                          {0, 2, 2.0},
+                                          {1, 0, 0.0},
+                                          {1, 1, 5.0},
+                                          {1, 2, 0.0}}},
+             gko::matrix_data<TypeParam>{{2, 2},
+                                         {{0, 0, -1.0},
+                                          {0, 1, 0.5},
+                                          {1, 0, 0.0},
+                                          {1, 1, 9.0}}}});
+    // clang-format on
+
+    ASSERT_EQ(m->get_size().at(0), gko::dim<2>(2, 3));
+    ASSERT_EQ(m->get_size().at(1), gko::dim<2>(2, 2));
+    ASSERT_EQ(m->get_num_stored_elements(), 10);
+    ASSERT_EQ(m->get_num_stored_elements(0), 6);
+    ASSERT_EQ(m->get_num_stored_elements(1), 4);
+    EXPECT_EQ(m->at(0, 0, 0), value_type{1.0});
+    EXPECT_EQ(m->at(0, 1, 0), value_type{0.0});
+    EXPECT_EQ(m->at(0, 0, 1), value_type{3.0});
+    EXPECT_EQ(m->at(0, 1, 1), value_type{5.0});
+    EXPECT_EQ(m->at(0, 0, 2), value_type{2.0});
+    EXPECT_EQ(m->at(0, 1, 2), value_type{0.0});
+    EXPECT_EQ(m->at(1, 0, 0), value_type{-1.0});
+    EXPECT_EQ(m->at(1, 0, 1), value_type{0.5});
+    EXPECT_EQ(m->at(1, 1, 0), value_type{0.0});
+    EXPECT_EQ(m->at(1, 1, 1), value_type{9.0});
+}
+
+
+TYPED_TEST(BatchDense, GeneratesCorrectMatrixData)
+{
+    using value_type = typename TestFixture::value_type;
+    using tpl = typename gko::matrix_data<TypeParam>::nonzero_type;
+    std::vector<gko::matrix_data<TypeParam>> data;
+
+    this->mtx->write(data);
+
+    ASSERT_EQ(data[0].size, gko::dim<2>(2, 3));
+    ASSERT_EQ(data[0].nonzeros.size(), 6);
+    EXPECT_EQ(data[0].nonzeros[0], tpl(0, 0, value_type{-1.0}));
+    EXPECT_EQ(data[0].nonzeros[1], tpl(0, 1, value_type{2.0}));
+    EXPECT_EQ(data[0].nonzeros[2], tpl(0, 2, value_type{3.0}));
+    EXPECT_EQ(data[0].nonzeros[3], tpl(1, 0, value_type{-1.5}));
+    EXPECT_EQ(data[0].nonzeros[4], tpl(1, 1, value_type{2.5}));
+    EXPECT_EQ(data[0].nonzeros[5], tpl(1, 2, value_type{3.5}));
+    ASSERT_EQ(data[1].size, gko::dim<2>(2, 3));
+    ASSERT_EQ(data[1].nonzeros.size(), 6);
+    EXPECT_EQ(data[1].nonzeros[0], tpl(0, 0, value_type{1.0}));
+    EXPECT_EQ(data[1].nonzeros[1], tpl(0, 1, value_type{2.5}));
+    EXPECT_EQ(data[1].nonzeros[2], tpl(0, 2, value_type{3.0}));
+    EXPECT_EQ(data[1].nonzeros[3], tpl(1, 0, value_type{1.0}));
+    EXPECT_EQ(data[1].nonzeros[4], tpl(1, 1, value_type{2.0}));
+    EXPECT_EQ(data[1].nonzeros[5], tpl(1, 2, value_type{3.0}));
+}
+
+
+TYPED_TEST(BatchDense, CanBeReadFromMatrixAssemblyData)
+{
+    using value_type = typename TestFixture::value_type;
+    auto m = gko::matrix::BatchDense<TypeParam>::create(this->exec);
+    gko::matrix_assembly_data<TypeParam> data1(gko::dim<2>{2, 3});
+    data1.set_value(0, 0, 1.0);
+    data1.set_value(0, 1, 3.0);
+    data1.set_value(0, 2, 2.0);
+    data1.set_value(1, 0, 0.0);
+    data1.set_value(1, 1, 5.0);
+    data1.set_value(1, 2, 0.0);
+    gko::matrix_assembly_data<TypeParam> data2(gko::dim<2>{2, 1});
+    data2.set_value(0, 0, 2.0);
+    data2.set_value(1, 0, 5.0);
+    auto data = std::vector<gko::matrix_assembly_data<TypeParam>>{data1, data2};
+
+    m->read(data);
+
+    ASSERT_EQ(m->get_size().at(0), gko::dim<2>(2, 3));
+    ASSERT_EQ(m->get_size().at(1), gko::dim<2>(2, 1));
+    ASSERT_EQ(m->get_num_stored_elements(), 8);
+    ASSERT_EQ(m->get_num_stored_elements(0), 6);
+    ASSERT_EQ(m->get_num_stored_elements(1), 2);
+    EXPECT_EQ(m->at(0, 0, 0), value_type{1.0});
+    EXPECT_EQ(m->at(0, 1, 0), value_type{0.0});
+    EXPECT_EQ(m->at(0, 0, 1), value_type{3.0});
+    EXPECT_EQ(m->at(0, 1, 1), value_type{5.0});
+    EXPECT_EQ(m->at(0, 0, 2), value_type{2.0});
+    ASSERT_EQ(m->at(0, 1, 2), value_type{0.0});
+    EXPECT_EQ(m->at(1, 0, 0), value_type{2.0});
+    EXPECT_EQ(m->at(1, 1, 0), value_type{5.0});
+}
+
+
+}  // namespace

--- a/core/test/matrix/batch_dense.cpp
+++ b/core/test/matrix/batch_dense.cpp
@@ -153,7 +153,7 @@ TYPED_TEST(BatchDense, CanBeMoved)
     auto mtx_copy =
         gko::batch::matrix::BatchDense<TypeParam>::create(this->exec);
 
-    mtx_copy->copy_from(std::move(this->mtx));
+    this->mtx->move_to(mtx_copy);
 
     this->assert_equal_to_original_mtx(mtx_copy.get());
 }

--- a/core/test/matrix/batch_dense.cpp
+++ b/core/test/matrix/batch_dense.cpp
@@ -138,13 +138,6 @@ TYPED_TEST(Dense, CanCreateDenseItemView)
 }
 
 
-TYPED_TEST(Dense, CanCreateMultiVectorView)
-{
-    GKO_ASSERT_BATCH_MTX_NEAR(this->mtx->create_multi_vector_view(), this->mvec,
-                              0.0);
-}
-
-
 TYPED_TEST(Dense, CanBeCopied)
 {
     auto mtx_copy = gko::batch::matrix::Dense<TypeParam>::create(this->exec);

--- a/core/test/matrix/batch_dense.cpp
+++ b/core/test/matrix/batch_dense.cpp
@@ -289,7 +289,7 @@ TYPED_TEST(Dense, CanBeConstructedFromDenseMatricesByDuplication)
         gko::batch::create_from_item<gko::batch::matrix::Dense<value_type>>(
             this->exec, 3, mat1.get());
 
-    GKO_ASSERT_BATCH_MTX_NEAR(bat_m.get(), m.get(), 1e-14);
+    GKO_ASSERT_BATCH_MTX_NEAR(bat_m.get(), m.get(), 0);
 }
 
 
@@ -316,7 +316,7 @@ TYPED_TEST(Dense, CanBeConstructedByDuplicatingDenseMatrices)
     auto m2 = gko::batch::duplicate<gko::batch::matrix::Dense<value_type>>(
         this->exec, 3, m.get());
 
-    GKO_ASSERT_BATCH_MTX_NEAR(m2.get(), m_ref.get(), 1e-14);
+    GKO_ASSERT_BATCH_MTX_NEAR(m2.get(), m_ref.get(), 0);
 }
 
 
@@ -384,13 +384,21 @@ TYPED_TEST(Dense, CanBeDoubleListConstructed)
     EXPECT_EQ(m->at(0, 0), value_type{1.0});
     EXPECT_EQ(m->at(0, 1), value_type{1.0});
     EXPECT_EQ(m->at(0, 2), value_type{0.0});
-    ASSERT_EQ(m->at(0, 3), value_type{2.0});
+    EXPECT_EQ(m->at(0, 3), value_type{2.0});
     EXPECT_EQ(m->at(0, 4), value_type{4.0});
+    EXPECT_EQ(m->at(0, 5), value_type{3.0});
+    EXPECT_EQ(m->at(0, 6), value_type{3.0});
+    EXPECT_EQ(m->at(0, 7), value_type{6.0});
+    EXPECT_EQ(m->at(0, 8), value_type{1.0});
     EXPECT_EQ(m->at(1, 0), value_type{1.0});
     EXPECT_EQ(m->at(1, 1), value_type{2.0});
     EXPECT_EQ(m->at(1, 2), value_type{-1.0});
-    ASSERT_EQ(m->at(1, 3), value_type{3.0});
+    EXPECT_EQ(m->at(1, 3), value_type{3.0});
     EXPECT_EQ(m->at(1, 4), value_type{4.0});
+    EXPECT_EQ(m->at(1, 5), value_type{-2.0});
+    EXPECT_EQ(m->at(1, 6), value_type{5.0});
+    EXPECT_EQ(m->at(1, 7), value_type{6.0});
+    EXPECT_EQ(m->at(1, 8), value_type{-3.0});
 }
 
 

--- a/core/test/matrix/batch_dense.cpp
+++ b/core/test/matrix/batch_dense.cpp
@@ -36,12 +36,15 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <gtest/gtest.h>
 
 
+#include <ginkgo/core/base/batch_multi_vector.hpp>
 #include <ginkgo/core/base/executor.hpp>
 #include <ginkgo/core/base/range.hpp>
 #include <ginkgo/core/matrix/dense.hpp>
 
 
+#include "core/base/batch_utilities.hpp"
 #include "core/test/utils.hpp"
+#include "core/test/utils/batch_helpers.hpp"
 
 
 template <typename T>
@@ -63,11 +66,11 @@ protected:
 
 
     static void assert_equal_to_original_mtx(
-        gko::matrix::BatchDense<value_type>* m)
+        gko::batch::matrix::BatchDense<value_type>* m)
     {
-        ASSERT_EQ(m->get_num_batch_entries(), 2);
+        ASSERT_EQ(m->get_num_batch_items(), 2);
         ASSERT_EQ(m->get_common_size(), gko::dim<2>(2, 3));
-        ASSERT_EQ(m->get_num_stored_elements(), 2 * (2 * 4));
+        ASSERT_EQ(m->get_num_stored_elements(), 2 * (2 * 3));
         EXPECT_EQ(m->at(0, 0, 0), value_type{-1.0});
         EXPECT_EQ(m->at(0, 0, 1), value_type{2.0});
         EXPECT_EQ(m->at(0, 0, 2), value_type{3.0});
@@ -82,17 +85,24 @@ protected:
         ASSERT_EQ(m->at(1, 1, 2), value_type{3.0});
     }
 
-    static void assert_empty(gko::matrix::BatchDense<value_type>* m)
+    static void assert_empty(gko::batch::matrix::BatchDense<value_type>* m)
     {
-        ASSERT_EQ(m->get_num_batch_entries(), 0);
+        ASSERT_EQ(m->get_num_batch_items(), 0);
         ASSERT_EQ(m->get_num_stored_elements(), 0);
     }
 
     std::shared_ptr<const gko::Executor> exec;
     std::unique_ptr<gko::batch::matrix::BatchDense<value_type>> mtx;
+    std::unique_ptr<gko::matrix::Dense<value_type>> dense_mtx;
 };
 
 TYPED_TEST_SUITE(BatchDense, gko::test::ValueTypes);
+
+
+TYPED_TEST(BatchDense, KnowsItsSizeAndValues)
+{
+    this->assert_equal_to_original_mtx(this->mtx.get());
+}
 
 
 TYPED_TEST(BatchDense, CanBeEmpty)
@@ -171,9 +181,9 @@ TYPED_TEST(BatchDense, CanBeConstructedWithSize)
     using size_type = gko::size_type;
 
     auto m = gko::batch::matrix::BatchDense<TypeParam>::create(
-        this->exec, gko::batch_dim<2>> {2, gko::dim<2>{5, 3}});
+        this->exec, gko::batch_dim<2>(2, gko::dim<2>{5, 3}));
 
-    ASSERT_EQ(m->get_num_batch_entries(), 2);
+    ASSERT_EQ(m->get_num_batch_items(), 2);
     ASSERT_EQ(m->get_common_size(), gko::dim<2>(5, 3));
     ASSERT_EQ(m->get_num_stored_elements(), 30);
 }
@@ -223,7 +233,7 @@ TYPED_TEST(BatchDense, CanBeConstructedFromExistingConstData)
        6.0, -3.0};
     // clang-format on
 
-    auto m = gko::matrix::BatchDense<TypeParam>::create_const(
+    auto m = gko::batch::matrix::BatchDense<TypeParam>::create_const(
         this->exec, gko::batch_dim<2>(2, gko::dim<2>(2, 2)),
         gko::array<value_type>::const_view(this->exec, 8, data));
 
@@ -239,17 +249,19 @@ TYPED_TEST(BatchDense, CanBeConstructedFromExistingConstData)
 }
 
 
-TYPED_TEST(BatchDense, CanBeConstructedFromBatchDenseMatrices)
+TYPED_TEST(BatchDense, CanBeConstructedFromDenseMatrices)
 {
     using value_type = typename TestFixture::value_type;
     using DenseMtx = typename TestFixture::DenseMtx;
     using size_type = gko::size_type;
+
     auto mat1 = gko::initialize<DenseMtx>({{-1.0, 2.0, 3.0}, {-1.5, 2.5, 3.5}},
                                           this->exec);
     auto mat2 = gko::initialize<DenseMtx>({{1.0, 2.5, 3.0}, {1.0, 2.0, 3.0}},
                                           this->exec);
 
-    auto m = gko::batch::multivector::create_from_dense(
+    auto m = gko::batch::create_from_item<
+        gko::batch::matrix::BatchDense<value_type>>(
         this->exec, std::vector<DenseMtx*>{mat1.get(), mat2.get()});
 
     this->assert_equal_to_original_mtx(m.get());
@@ -261,34 +273,45 @@ TYPED_TEST(BatchDense, CanBeConstructedFromDenseMatricesByDuplication)
     using value_type = typename TestFixture::value_type;
     using DenseMtx = typename TestFixture::DenseMtx;
     using size_type = gko::size_type;
+
     auto mat1 = gko::initialize<DenseMtx>(
         4, {{-1.0, 2.0, 3.0}, {-1.5, 2.5, 3.5}}, this->exec);
     auto mat2 = gko::initialize<DenseMtx>({{1.0, 2.5, 3.0}, {1.0, 2.0, 3.0}},
                                           this->exec);
 
-    auto bat_m = gko::matrix::BatchDense<TypeParam>::create(
+    auto bat_m = gko::batch::create_from_item<
+        gko::batch::matrix::BatchDense<value_type>>(
         this->exec, std::vector<DenseMtx*>{mat1.get(), mat1.get(), mat1.get()});
-    auto m =
-        gko::matrix::BatchDense<TypeParam>::create(this->exec, 3, mat1.get());
+    auto m = gko::batch::create_from_item<
+        gko::batch::matrix::BatchDense<value_type>>(this->exec, 3, mat1.get());
 
     GKO_ASSERT_BATCH_MTX_NEAR(bat_m.get(), m.get(), 1e-14);
 }
 
 
-TYPED_TEST(BatchDense, CanBeConstructedFromDenseMatrices)
+TYPED_TEST(BatchDense, CanBeConstructedByDuplicatingBatchDenseMatrices)
 {
     using value_type = typename TestFixture::value_type;
     using DenseMtx = typename TestFixture::DenseMtx;
     using size_type = gko::size_type;
-    auto mat1 = gko::initialize<DenseMtx>(
-        4, {{-1.0, 2.0, 3.0}, {-1.5, 2.5, 3.5}}, this->exec);
+
+    auto mat1 = gko::initialize<DenseMtx>({{-1.0, 2.0, 3.0}, {-1.5, 2.5, 3.5}},
+                                          this->exec);
     auto mat2 = gko::initialize<DenseMtx>({{1.0, 2.5, 3.0}, {1.0, 2.0, 3.0}},
                                           this->exec);
 
-    auto m = gko::matrix::BatchDense<TypeParam>::create(
+    auto m = gko::batch::create_from_item<
+        gko::batch::matrix::BatchDense<value_type>>(
         this->exec, std::vector<DenseMtx*>{mat1.get(), mat2.get()});
+    auto m_ref = gko::batch::create_from_item<
+        gko::batch::matrix::BatchDense<value_type>>(
+        this->exec, std::vector<DenseMtx*>{mat1.get(), mat2.get(), mat1.get(),
+                                           mat2.get(), mat1.get(), mat2.get()});
 
-    this->assert_equal_to_original_mtx(m.get());
+    auto m2 = gko::batch::duplicate<gko::batch::matrix::BatchDense<value_type>>(
+        this->exec, 3, m.get());
+
+    GKO_ASSERT_BATCH_MTX_NEAR(m2.get(), m_ref.get(), 1e-14);
 }
 
 
@@ -302,30 +325,23 @@ TYPED_TEST(BatchDense, CanBeUnbatchedIntoDenseMatrices)
     auto mat2 = gko::initialize<DenseMtx>({{1.0, 2.5, 3.0}, {1.0, 2.0, 3.0}},
                                           this->exec);
 
-    auto dense_mats = this->mtx->unbatch();
-
+    auto dense_mats =
+        gko::batch::unbatch<gko::batch::matrix::BatchDense<value_type>>(
+            this->mtx.get());
 
     GKO_ASSERT_MTX_NEAR(dense_mats[0].get(), mat1.get(), 0.);
     GKO_ASSERT_MTX_NEAR(dense_mats[1].get(), mat2.get(), 0.);
 }
 
 
-TYPED_TEST(BatchDense, KnowsItsSizeAndValues)
-{
-    this->assert_equal_to_original_mtx(this->mtx.get());
-}
-
-
 TYPED_TEST(BatchDense, CanBeListConstructed)
 {
     using value_type = typename TestFixture::value_type;
-    auto m = gko::batch_initialize<gko::matrix::BatchDense<TypeParam>>(
+    auto m = gko::batch::initialize<gko::batch::matrix::BatchDense<TypeParam>>(
         {{1.0, 2.0}, {1.0, 3.0}}, this->exec);
 
-    ASSERT_EQ(m->get_num_batch_entries(), 2);
-    ASSERT_EQ(m->get_size().at(0), gko::dim<2>(2, 1));
-    ASSERT_EQ(m->get_size().at(1), gko::dim<2>(2, 1));
-    ASSERT_EQ(m->get_num_stored_elements(), 4);
+    ASSERT_EQ(m->get_num_batch_items(), 2);
+    ASSERT_EQ(m->get_common_size(), gko::dim<2>(2, 1));
     EXPECT_EQ(m->at(0, 0), value_type{1});
     EXPECT_EQ(m->at(0, 1), value_type{2});
     EXPECT_EQ(m->at(1, 0), value_type{1});
@@ -336,12 +352,12 @@ TYPED_TEST(BatchDense, CanBeListConstructed)
 TYPED_TEST(BatchDense, CanBeListConstructedByCopies)
 {
     using value_type = typename TestFixture::value_type;
-    auto m = gko::batch_initialize<gko::matrix::BatchDense<TypeParam>>(
+
+    auto m = gko::batch::initialize<gko::batch::matrix::BatchDense<TypeParam>>(
         2, I<value_type>({1.0, 2.0}), this->exec);
-    ASSERT_EQ(m->get_num_batch_entries(), 2);
-    ASSERT_EQ(m->get_size().at(0), gko::dim<2>(2, 1));
-    ASSERT_EQ(m->get_size().at(1), gko::dim<2>(2, 1));
-    ASSERT_EQ(m->get_num_stored_elements(), 4);
+
+    ASSERT_EQ(m->get_num_batch_items(), 2);
+    ASSERT_EQ(m->get_common_size(), gko::dim<2>(2, 1));
     EXPECT_EQ(m->at(0, 0, 0), value_type{1.0});
     EXPECT_EQ(m->at(0, 0, 1), value_type{2.0});
     EXPECT_EQ(m->at(1, 0, 0), value_type{1.0});
@@ -353,18 +369,13 @@ TYPED_TEST(BatchDense, CanBeDoubleListConstructed)
 {
     using value_type = typename TestFixture::value_type;
     using T = value_type;
-    auto m = gko::batch_initialize<gko::matrix::BatchDense<TypeParam>>(
+
+    auto m = gko::batch::initialize<gko::batch::matrix::BatchDense<TypeParam>>(
         {{I<T>{1.0, 1.0, 0.0}, I<T>{2.0, 4.0, 3.0}, I<T>{3.0, 6.0, 1.0}},
-         {I<T>{1.0, 2.0}, I<T>{3.0, 4.0}, I<T>{5.0, 6.0}}},
+         {I<T>{1.0, 2.0, -1.0}, I<T>{3.0, 4.0, -2.0}, I<T>{5.0, 6.0, -3.0}}},
         this->exec);
 
-    ASSERT_EQ(m->get_size().at(0), gko::dim<2>(3, 3));
-    ASSERT_EQ(m->get_size().at(1), gko::dim<2>(3, 2));
-    ASSERT_EQ(m->get_stride().at(0), 3);
-    ASSERT_EQ(m->get_stride().at(1), 2);
-    EXPECT_EQ(m->get_num_stored_elements(), 15);
-    ASSERT_EQ(m->get_num_stored_elements(0), 9);
-    ASSERT_EQ(m->get_num_stored_elements(1), 6);
+    ASSERT_EQ(m->get_common_size(), gko::dim<2>(3, 3));
     EXPECT_EQ(m->at(0, 0), value_type{1.0});
     EXPECT_EQ(m->at(0, 1), value_type{1.0});
     EXPECT_EQ(m->at(0, 2), value_type{0.0});
@@ -372,72 +383,58 @@ TYPED_TEST(BatchDense, CanBeDoubleListConstructed)
     EXPECT_EQ(m->at(0, 4), value_type{4.0});
     EXPECT_EQ(m->at(1, 0), value_type{1.0});
     EXPECT_EQ(m->at(1, 1), value_type{2.0});
-    EXPECT_EQ(m->at(1, 2), value_type{3.0});
-    ASSERT_EQ(m->at(1, 3), value_type{4.0});
-    EXPECT_EQ(m->at(1, 4), value_type{5.0});
-}
-
-
-TYPED_TEST(BatchDense, CanBeDoubleListConstructedWithstride)
-{
-    using value_type = typename TestFixture::value_type;
-    using T = value_type;
-    auto m = gko::batch_initialize<gko::matrix::BatchDense<TypeParam>>(
-        {4, 3},
-        {{I<T>{1.0, 1.0, 0.0}, I<T>{2.0, 4.0, 3.0}, I<T>{3.0, 6.0, 1.0}},
-         {I<T>{1.0, 2.0}, I<T>{3.0, 4.0}, I<T>{5.0, 6.0}}},
-        this->exec);
-
-    ASSERT_EQ(m->get_size().at(0), gko::dim<2>(3, 3));
-    ASSERT_EQ(m->get_size().at(1), gko::dim<2>(3, 2));
-    ASSERT_EQ(m->get_stride().at(0), 4);
-    ASSERT_EQ(m->get_stride().at(1), 3);
-    EXPECT_EQ(m->get_num_stored_elements(), 21);
-    ASSERT_EQ(m->get_num_stored_elements(0), 12);
-    ASSERT_EQ(m->get_num_stored_elements(1), 9);
-    EXPECT_EQ(m->at(0, 0), value_type{1.0});
-    EXPECT_EQ(m->at(0, 1), value_type{1.0});
-    EXPECT_EQ(m->at(0, 2), value_type{0.0});
-    ASSERT_EQ(m->at(0, 3), value_type{2.0});
-    EXPECT_EQ(m->at(0, 4), value_type{4.0});
-    EXPECT_EQ(m->at(1, 0), value_type{1.0});
-    EXPECT_EQ(m->at(1, 1), value_type{2.0});
-    EXPECT_EQ(m->at(1, 2), value_type{3.0});
-    ASSERT_EQ(m->at(1, 3), value_type{4.0});
-    EXPECT_EQ(m->at(1, 4), value_type{5.0});
+    EXPECT_EQ(m->at(1, 2), value_type{-1.0});
+    ASSERT_EQ(m->at(1, 3), value_type{3.0});
+    EXPECT_EQ(m->at(1, 4), value_type{4.0});
 }
 
 
 TYPED_TEST(BatchDense, CanBeReadFromMatrixData)
 {
     using value_type = typename TestFixture::value_type;
-    auto m = gko::matrix::BatchDense<TypeParam>::create(this->exec);
-    // clang-format off
-    m->read({gko::matrix_data<TypeParam>{{2, 3},
-                                         {{0, 0, 1.0},
-                                          {0, 1, 3.0},
-                                          {0, 2, 2.0},
-                                          {1, 0, 0.0},
-                                          {1, 1, 5.0},
-                                          {1, 2, 0.0}}},
-             gko::matrix_data<TypeParam>{{2, 2},
-                                         {{0, 0, -1.0},
-                                          {0, 1, 0.5},
-                                          {1, 0, 0.0},
-                                          {1, 1, 9.0}}}});
-    // clang-format on
+    using index_type = int;
 
-    ASSERT_EQ(m->get_size().at(0), gko::dim<2>(2, 3));
-    ASSERT_EQ(m->get_size().at(1), gko::dim<2>(2, 2));
-    ASSERT_EQ(m->get_num_stored_elements(), 10);
-    ASSERT_EQ(m->get_num_stored_elements(0), 6);
-    ASSERT_EQ(m->get_num_stored_elements(1), 4);
+    auto vec_data = std::vector<gko::matrix_data<value_type, index_type>>{};
+    vec_data.emplace_back(gko::matrix_data<value_type, index_type>(
+        {2, 2}, {{0, 0, 1.0}, {0, 1, 3.0}, {1, 0, 0.0}, {1, 1, 5.0}}));
+    vec_data.emplace_back(gko::matrix_data<value_type, index_type>(
+        {2, 2}, {{0, 0, -1.0}, {0, 1, 0.5}, {1, 0, 0.0}, {1, 1, 9.0}}));
+
+    auto m = gko::batch::read<value_type, index_type,
+                              gko::batch::matrix::BatchDense<value_type>>(
+        this->exec, vec_data);
+
+    ASSERT_EQ(m->get_common_size(), gko::dim<2>(2, 2));
     EXPECT_EQ(m->at(0, 0, 0), value_type{1.0});
-    EXPECT_EQ(m->at(0, 1, 0), value_type{0.0});
     EXPECT_EQ(m->at(0, 0, 1), value_type{3.0});
+    EXPECT_EQ(m->at(0, 1, 0), value_type{0.0});
     EXPECT_EQ(m->at(0, 1, 1), value_type{5.0});
-    EXPECT_EQ(m->at(0, 0, 2), value_type{2.0});
-    EXPECT_EQ(m->at(0, 1, 2), value_type{0.0});
+    EXPECT_EQ(m->at(1, 0, 0), value_type{-1.0});
+    EXPECT_EQ(m->at(1, 0, 1), value_type{0.5});
+    EXPECT_EQ(m->at(1, 1, 0), value_type{0.0});
+    EXPECT_EQ(m->at(1, 1, 1), value_type{9.0});
+}
+
+
+TYPED_TEST(BatchDense, CanBeReadFromSparseMatrixData)
+{
+    using value_type = typename TestFixture::value_type;
+    using index_type = int;
+    auto vec_data = std::vector<gko::matrix_data<value_type, index_type>>{};
+    vec_data.emplace_back(gko::matrix_data<value_type, index_type>(
+        {2, 2}, {{0, 0, 1.0}, {0, 1, 3.0}, {1, 1, 5.0}}));
+    vec_data.emplace_back(gko::matrix_data<value_type, index_type>(
+        {2, 2}, {{0, 0, -1.0}, {0, 1, 0.5}, {1, 1, 9.0}}));
+
+    auto m = gko::batch::read<value_type, index_type,
+                              gko::batch::matrix::BatchDense<value_type>>(
+        this->exec, vec_data);
+
+    ASSERT_EQ(m->get_common_size(), gko::dim<2>(2, 2));
+    EXPECT_EQ(m->at(0, 0, 0), value_type{1.0});
+    EXPECT_EQ(m->at(0, 0, 1), value_type{3.0});
+    EXPECT_EQ(m->at(0, 1, 0), value_type{0.0});
+    EXPECT_EQ(m->at(0, 1, 1), value_type{5.0});
     EXPECT_EQ(m->at(1, 0, 0), value_type{-1.0});
     EXPECT_EQ(m->at(1, 0, 1), value_type{0.5});
     EXPECT_EQ(m->at(1, 1, 0), value_type{0.0});
@@ -448,10 +445,12 @@ TYPED_TEST(BatchDense, CanBeReadFromMatrixData)
 TYPED_TEST(BatchDense, GeneratesCorrectMatrixData)
 {
     using value_type = typename TestFixture::value_type;
+    using index_type = int;
     using tpl = typename gko::matrix_data<TypeParam>::nonzero_type;
-    std::vector<gko::matrix_data<TypeParam>> data;
 
-    this->mtx->write(data);
+    auto data = gko::batch::write<value_type, index_type,
+                                  gko::batch::matrix::BatchDense<value_type>>(
+        this->mtx.get());
 
     ASSERT_EQ(data[0].size, gko::dim<2>(2, 3));
     ASSERT_EQ(data[0].nonzeros.size(), 6);
@@ -469,38 +468,4 @@ TYPED_TEST(BatchDense, GeneratesCorrectMatrixData)
     EXPECT_EQ(data[1].nonzeros[3], tpl(1, 0, value_type{1.0}));
     EXPECT_EQ(data[1].nonzeros[4], tpl(1, 1, value_type{2.0}));
     EXPECT_EQ(data[1].nonzeros[5], tpl(1, 2, value_type{3.0}));
-}
-
-
-TYPED_TEST(BatchDense, CanBeReadFromMatrixAssemblyData)
-{
-    using value_type = typename TestFixture::value_type;
-    auto m = gko::matrix::BatchDense<TypeParam>::create(this->exec);
-    gko::matrix_assembly_data<TypeParam> data1(gko::dim<2>{2, 3});
-    data1.set_value(0, 0, 1.0);
-    data1.set_value(0, 1, 3.0);
-    data1.set_value(0, 2, 2.0);
-    data1.set_value(1, 0, 0.0);
-    data1.set_value(1, 1, 5.0);
-    data1.set_value(1, 2, 0.0);
-    gko::matrix_assembly_data<TypeParam> data2(gko::dim<2>{2, 1});
-    data2.set_value(0, 0, 2.0);
-    data2.set_value(1, 0, 5.0);
-    auto data = std::vector<gko::matrix_assembly_data<TypeParam>>{data1, data2};
-
-    m->read(data);
-
-    ASSERT_EQ(m->get_size().at(0), gko::dim<2>(2, 3));
-    ASSERT_EQ(m->get_size().at(1), gko::dim<2>(2, 1));
-    ASSERT_EQ(m->get_num_stored_elements(), 8);
-    ASSERT_EQ(m->get_num_stored_elements(0), 6);
-    ASSERT_EQ(m->get_num_stored_elements(1), 2);
-    EXPECT_EQ(m->at(0, 0, 0), value_type{1.0});
-    EXPECT_EQ(m->at(0, 1, 0), value_type{0.0});
-    EXPECT_EQ(m->at(0, 0, 1), value_type{3.0});
-    EXPECT_EQ(m->at(0, 1, 1), value_type{5.0});
-    EXPECT_EQ(m->at(0, 0, 2), value_type{2.0});
-    ASSERT_EQ(m->at(0, 1, 2), value_type{0.0});
-    EXPECT_EQ(m->at(1, 0, 0), value_type{2.0});
-    EXPECT_EQ(m->at(1, 1, 0), value_type{5.0});
 }

--- a/core/test/matrix/batch_dense.cpp
+++ b/core/test/matrix/batch_dense.cpp
@@ -59,6 +59,10 @@ protected:
               {{{-1.0, 2.0, 3.0}, {-1.5, 2.5, 3.5}},
                {{1.0, 2.5, 3.0}, {1.0, 2.0, 3.0}}},
               exec)),
+          mvec(gko::batch::initialize<gko::batch::MultiVector<value_type>>(
+              {{{-1.0, 2.0, 3.0}, {-1.5, 2.5, 3.5}},
+               {{1.0, 2.5, 3.0}, {1.0, 2.0, 3.0}}},
+              exec)),
           dense_mtx(gko::initialize<gko::matrix::Dense<value_type>>(
               {{1.0, 2.5, 3.0}, {1.0, 2.0, 3.0}}, exec))
     {}
@@ -92,6 +96,7 @@ protected:
 
     std::shared_ptr<const gko::Executor> exec;
     std::unique_ptr<gko::batch::matrix::Dense<value_type>> mtx;
+    std::unique_ptr<gko::batch::MultiVector<value_type>> mvec;
     std::unique_ptr<gko::matrix::Dense<value_type>> dense_mtx;
 };
 
@@ -130,6 +135,13 @@ TYPED_TEST(Dense, CanCreateDenseItemView)
 {
     GKO_ASSERT_MTX_NEAR(this->mtx->create_view_for_item(1), this->dense_mtx,
                         0.0);
+}
+
+
+TYPED_TEST(Dense, CanCreateMultiVectorView)
+{
+    GKO_ASSERT_BATCH_MTX_NEAR(this->mtx->create_multi_vector_view(), this->mvec,
+                              0.0);
 }
 
 

--- a/core/test/matrix/batch_dense.cpp
+++ b/core/test/matrix/batch_dense.cpp
@@ -256,7 +256,6 @@ TYPED_TEST(Dense, CanBeConstructedFromDenseMatrices)
     using value_type = typename TestFixture::value_type;
     using DenseMtx = typename TestFixture::DenseMtx;
     using size_type = gko::size_type;
-
     auto mat1 = gko::initialize<DenseMtx>({{-1.0, 2.0, 3.0}, {-1.5, 2.5, 3.5}},
                                           this->exec);
     auto mat2 = gko::initialize<DenseMtx>({{1.0, 2.5, 3.0}, {1.0, 2.0, 3.0}},
@@ -275,16 +274,15 @@ TYPED_TEST(Dense, CanBeConstructedFromDenseMatricesByDuplication)
     using value_type = typename TestFixture::value_type;
     using DenseMtx = typename TestFixture::DenseMtx;
     using size_type = gko::size_type;
-
     auto mat1 = gko::initialize<DenseMtx>(
         4, {{-1.0, 2.0, 3.0}, {-1.5, 2.5, 3.5}}, this->exec);
     auto mat2 = gko::initialize<DenseMtx>({{1.0, 2.5, 3.0}, {1.0, 2.0, 3.0}},
                                           this->exec);
-
     auto bat_m =
         gko::batch::create_from_item<gko::batch::matrix::Dense<value_type>>(
             this->exec,
             std::vector<DenseMtx*>{mat1.get(), mat1.get(), mat1.get()});
+
     auto m =
         gko::batch::create_from_item<gko::batch::matrix::Dense<value_type>>(
             this->exec, 3, mat1.get());
@@ -298,12 +296,10 @@ TYPED_TEST(Dense, CanBeConstructedByDuplicatingDenseMatrices)
     using value_type = typename TestFixture::value_type;
     using DenseMtx = typename TestFixture::DenseMtx;
     using size_type = gko::size_type;
-
     auto mat1 = gko::initialize<DenseMtx>({{-1.0, 2.0, 3.0}, {-1.5, 2.5, 3.5}},
                                           this->exec);
     auto mat2 = gko::initialize<DenseMtx>({{1.0, 2.5, 3.0}, {1.0, 2.0, 3.0}},
                                           this->exec);
-
     auto m =
         gko::batch::create_from_item<gko::batch::matrix::Dense<value_type>>(
             this->exec, std::vector<DenseMtx*>{mat1.get(), mat2.get()});
@@ -342,6 +338,7 @@ TYPED_TEST(Dense, CanBeUnbatchedIntoDenseMatrices)
 TYPED_TEST(Dense, CanBeListConstructed)
 {
     using value_type = typename TestFixture::value_type;
+
     auto m = gko::batch::initialize<gko::batch::matrix::Dense<TypeParam>>(
         {{1.0, 2.0}, {1.0, 3.0}}, this->exec);
 
@@ -406,7 +403,6 @@ TYPED_TEST(Dense, CanBeReadFromMatrixData)
 {
     using value_type = typename TestFixture::value_type;
     using index_type = int;
-
     auto vec_data = std::vector<gko::matrix_data<value_type, index_type>>{};
     vec_data.emplace_back(gko::matrix_data<value_type, index_type>(
         {2, 2}, {{0, 0, 1.0}, {0, 1, 3.0}, {1, 0, 0.0}, {1, 1, 5.0}}));

--- a/core/test/utils/assertions.hpp
+++ b/core/test/utils/assertions.hpp
@@ -720,12 +720,8 @@ template <typename Mat1, typename Mat2>
     using value_type1 = typename Mat1::value_type;
     using value_type2 = typename Mat2::value_type;
 
-    auto first_data =
-        gko::batch::write<value_type1, int,
-                          gko::batch::MultiVector<value_type1>>(first);
-    auto second_data =
-        gko::batch::write<value_type2, int,
-                          gko::batch::MultiVector<value_type2>>(second);
+    auto first_data = gko::batch::write<value_type1, int, Mat1>(first);
+    auto second_data = gko::batch::write<value_type2, int, Mat2>(second);
 
     if (first_data.size() != second_data.size()) {
         return ::testing::AssertionFailure()

--- a/core/test/utils/assertions.hpp
+++ b/core/test/utils/assertions.hpp
@@ -720,8 +720,12 @@ template <typename Mat1, typename Mat2>
     using value_type1 = typename Mat1::value_type;
     using value_type2 = typename Mat2::value_type;
 
-    auto first_data = gko::batch::multivector::write<value_type1, int>(first);
-    auto second_data = gko::batch::multivector::write<value_type2, int>(second);
+    auto first_data =
+        gko::batch::write<value_type1, int,
+                          gko::batch::MultiVector<value_type1>>(first);
+    auto second_data =
+        gko::batch::write<value_type2, int,
+                          gko::batch::MultiVector<value_type2>>(second);
 
     if (first_data.size() != second_data.size()) {
         return ::testing::AssertionFailure()

--- a/cuda/CMakeLists.txt
+++ b/cuda/CMakeLists.txt
@@ -38,6 +38,7 @@ target_sources(ginkgo_cuda
     factorization/par_ilut_select_kernel.cu
     factorization/par_ilut_spgeam_kernel.cu
     factorization/par_ilut_sweep_kernel.cu
+    matrix/batch_dense_kernels.cu
     matrix/coo_kernels.cu
     ${CSR_INSTANTIATE}
     matrix/dense_kernels.cu

--- a/cuda/base/batch_multi_vector_kernels.cu
+++ b/cuda/base/batch_multi_vector_kernels.cu
@@ -78,6 +78,7 @@ constexpr int sm_oversubscription = 4;
 
 // clang-format on
 
+
 }  // namespace batch_multi_vector
 }  // namespace cuda
 }  // namespace kernels

--- a/cuda/base/batch_struct.hpp
+++ b/cuda/base/batch_struct.hpp
@@ -54,7 +54,7 @@ namespace cuda {
  * while also shallow-casting to the required CUDA scalar type.
  *
  * A specialization is needed for every format of every kind of linear algebra
- * object. These are intended to be called on the host.
+ * object.
  */
 
 
@@ -66,9 +66,9 @@ inline batch::multi_vector::uniform_batch<const cuda_type<ValueType>>
 get_batch_struct(const batch::MultiVector<ValueType>* const op)
 {
     return {as_cuda_type(op->get_const_values()), op->get_num_batch_items(),
-            static_cast<int>(op->get_common_size()[1]),
-            static_cast<int>(op->get_common_size()[0]),
-            static_cast<int>(op->get_common_size()[1])};
+            static_cast<int32>(op->get_common_size()[1]),
+            static_cast<int32>(op->get_common_size()[0]),
+            static_cast<int32>(op->get_common_size()[1])};
 }
 
 /**
@@ -79,9 +79,9 @@ inline batch::multi_vector::uniform_batch<cuda_type<ValueType>>
 get_batch_struct(batch::MultiVector<ValueType>* const op)
 {
     return {as_cuda_type(op->get_values()), op->get_num_batch_items(),
-            static_cast<int>(op->get_common_size()[1]),
-            static_cast<int>(op->get_common_size()[0]),
-            static_cast<int>(op->get_common_size()[1])};
+            static_cast<int32>(op->get_common_size()[1]),
+            static_cast<int32>(op->get_common_size()[0]),
+            static_cast<int32>(op->get_common_size()[1])};
 }
 
 

--- a/cuda/base/batch_struct.hpp
+++ b/cuda/base/batch_struct.hpp
@@ -54,7 +54,7 @@ namespace cuda {
  * while also shallow-casting to the required CUDA scalar type.
  *
  * A specialization is needed for every format of every kind of linear algebra
- * object.
+ * object. These are intended to be called on the host.
  */
 
 

--- a/cuda/matrix/batch_dense_kernels.cu
+++ b/cuda/matrix/batch_dense_kernels.cu
@@ -77,6 +77,7 @@ constexpr int sm_oversubscription = 4;
 
 #include "common/cuda_hip/matrix/batch_dense_kernel_launcher.hpp.inc"
 
+
 // clang-format on
 
 

--- a/cuda/matrix/batch_dense_kernels.cu
+++ b/cuda/matrix/batch_dense_kernels.cu
@@ -45,7 +45,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "cuda/components/reduction.cuh"
 #include "cuda/components/thread_ids.cuh"
 #include "cuda/components/uninitialized_array.hpp"
-#include "cuda/matrix/batch_struct.hpp"
+// #include "cuda/matrix/batch_struct.hip.hpp"
 
 
 namespace gko {

--- a/cuda/matrix/batch_dense_kernels.cu
+++ b/cuda/matrix/batch_dense_kernels.cu
@@ -38,6 +38,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "core/base/batch_struct.hpp"
 #include "core/matrix/batch_struct.hpp"
+#include "cuda/base/batch_struct.hpp"
 #include "cuda/base/config.hpp"
 #include "cuda/base/cublas_bindings.hpp"
 #include "cuda/base/pointer_mode_guard.hpp"
@@ -45,7 +46,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "cuda/components/reduction.cuh"
 #include "cuda/components/thread_ids.cuh"
 #include "cuda/components/uninitialized_array.hpp"
-// #include "cuda/matrix/batch_struct.hip.hpp"
+#include "cuda/matrix/batch_struct.hpp"
 
 
 namespace gko {
@@ -60,29 +61,18 @@ namespace batch_dense {
 
 
 constexpr auto default_block_size = 256;
-constexpr int sm_multiplier = 4;
+constexpr int sm_oversubscription = 4;
+
+// clang-format off
+
+// NOTE: DO NOT CHANGE THE ORDERING OF THE INCLUDES
+
+#include "common/cuda_hip/matrix/batch_dense_kernels.hpp.inc"
 
 
-template <typename ValueType>
-void simple_apply(std::shared_ptr<const DefaultExecutor> exec,
-                  const batch::matrix::BatchDense<ValueType>* mat,
-                  const batch::MultiVector<ValueType>* b,
-                  batch::MultiVector<ValueType>* x) GKO_NOT_IMPLEMENTED;
+#include "common/cuda_hip/matrix/batch_dense_kernel_launcher.hpp.inc"
 
-GKO_INSTANTIATE_FOR_EACH_VALUE_TYPE(
-    GKO_DECLARE_BATCH_DENSE_SIMPLE_APPLY_KERNEL);
-
-
-template <typename ValueType>
-void advanced_apply(std::shared_ptr<const DefaultExecutor> exec,
-                    const batch::MultiVector<ValueType>* alpha,
-                    const batch::matrix::BatchDense<ValueType>* a,
-                    const batch::MultiVector<ValueType>* b,
-                    const batch::MultiVector<ValueType>* beta,
-                    batch::MultiVector<ValueType>* c) GKO_NOT_IMPLEMENTED;
-
-GKO_INSTANTIATE_FOR_EACH_VALUE_TYPE(
-    GKO_DECLARE_BATCH_DENSE_ADVANCED_APPLY_KERNEL);
+// clang-format on
 
 
 }  // namespace batch_dense

--- a/cuda/matrix/batch_dense_kernels.cu
+++ b/cuda/matrix/batch_dense_kernels.cu
@@ -34,7 +34,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
 #include <thrust/functional.h>
-#include <thrust/transform.h>
 
 
 #include <ginkgo/core/base/math.hpp>
@@ -44,8 +43,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "core/matrix/batch_struct.hpp"
 #include "cuda/base/batch_struct.hpp"
 #include "cuda/base/config.hpp"
-#include "cuda/base/cublas_bindings.hpp"
-#include "cuda/base/pointer_mode_guard.hpp"
 #include "cuda/base/thrust.cuh"
 #include "cuda/components/cooperative_groups.cuh"
 #include "cuda/components/reduction.cuh"

--- a/cuda/matrix/batch_dense_kernels.cu
+++ b/cuda/matrix/batch_dense_kernels.cu
@@ -58,7 +58,7 @@ namespace gko {
 namespace kernels {
 namespace cuda {
 /**
- * @brief The BatchDense matrix format namespace.
+ * @brief The Dense matrix format namespace.
  *
  * @ingroup batch_dense
  */

--- a/cuda/matrix/batch_dense_kernels.cu
+++ b/cuda/matrix/batch_dense_kernels.cu
@@ -33,6 +33,10 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "core/matrix/batch_dense_kernels.hpp"
 
 
+#include <thrust/functional.h>
+#include <thrust/transform.h>
+
+
 #include <ginkgo/core/base/math.hpp>
 
 
@@ -42,6 +46,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "cuda/base/config.hpp"
 #include "cuda/base/cublas_bindings.hpp"
 #include "cuda/base/pointer_mode_guard.hpp"
+#include "cuda/base/thrust.cuh"
 #include "cuda/components/cooperative_groups.cuh"
 #include "cuda/components/reduction.cuh"
 #include "cuda/components/thread_ids.cuh"

--- a/cuda/matrix/batch_dense_kernels.cu
+++ b/cuda/matrix/batch_dense_kernels.cu
@@ -1,0 +1,90 @@
+/*******************************<GINKGO LICENSE>******************************
+Copyright (c) 2017-2023, the Ginkgo authors
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+******************************<GINKGO LICENSE>*******************************/
+
+#include "core/matrix/batch_dense_kernels.hpp"
+
+
+#include <ginkgo/core/base/math.hpp>
+
+
+#include "core/matrix/batch_struct.hpp"
+#include "cuda/base/config.hpp"
+#include "cuda/base/cublas_bindings.hpp"
+#include "cuda/base/pointer_mode_guard.hpp"
+#include "cuda/components/cooperative_groups.cuh"
+#include "cuda/components/reduction.cuh"
+#include "cuda/components/thread_ids.cuh"
+#include "cuda/components/uninitialized_array.hpp"
+#include "cuda/matrix/batch_struct.hpp"
+
+
+namespace gko {
+namespace kernels {
+namespace cuda {
+/**
+ * @brief The BatchDense matrix format namespace.
+ *
+ * @ingroup batch_dense
+ */
+namespace batch_dense {
+
+
+constexpr auto default_block_size = 256;
+constexpr int sm_multiplier = 4;
+
+
+template <typename ValueType>
+void simple_apply(std::shared_ptr<const DefaultExecutor> exec,
+                  const batch::matrix::BatchDense<ValueType>* mat,
+                  const batch::MultiVector<ValueType>* b,
+                  MultiVector<ValueType>* x) GKO_NOT_IMPLEMENTED;
+
+GKO_INSTANTIATE_FOR_EACH_VALUE_TYPE(
+    GKO_DECLARE_BATCH_DENSE_SIMPLE_APPLY_KERNEL);
+
+
+template <typename ValueType>
+void advanced_apply(std::shared_ptr<const DefaultExecutor> exec,
+                    const batch::MultiVector<ValueType>* alpha,
+                    const batch::matrix::BatchDense<ValueType>* a,
+                    const batch::MultiVector<ValueType>* b,
+                    const batch::MultiVector<ValueType>* beta,
+                    batch::MultiVector<ValueType>* c) GKO_NOT_IMPLEMENTED;
+
+GKO_INSTANTIATE_FOR_EACH_VALUE_TYPE(
+    GKO_DECLARE_BATCH_DENSE_ADVANCED_APPLY_KERNEL);
+
+
+}  // namespace batch_dense
+}  // namespace cuda
+}  // namespace kernels
+}  // namespace gko

--- a/cuda/matrix/batch_struct.hpp
+++ b/cuda/matrix/batch_struct.hpp
@@ -58,7 +58,7 @@ namespace cuda {
  * while also shallow-casting to the required CUDA scalar type.
  *
  * A specialization is needed for every format of every kind of linear algebra
- * object. These are intended to be called on the host.
+ * object.
  */
 
 
@@ -66,13 +66,13 @@ namespace cuda {
  * Generates an immutable uniform batch struct from a batch of dense matrices.
  */
 template <typename ValueType>
-inline batch::matrix::batch_dense::uniform_batch<const cuda_type<ValueType>>
+inline batch::matrix::dense::uniform_batch<const cuda_type<ValueType>>
 get_batch_struct(const batch::matrix::Dense<ValueType>* const op)
 {
     return {as_cuda_type(op->get_const_values()), op->get_num_batch_items(),
-            static_cast<int>(op->get_common_size()[1]),
-            static_cast<int>(op->get_common_size()[0]),
-            static_cast<int>(op->get_common_size()[1])};
+            static_cast<int32>(op->get_common_size()[1]),
+            static_cast<int32>(op->get_common_size()[0]),
+            static_cast<int32>(op->get_common_size()[1])};
 }
 
 
@@ -80,13 +80,13 @@ get_batch_struct(const batch::matrix::Dense<ValueType>* const op)
  * Generates a uniform batch struct from a batch of dense matrices.
  */
 template <typename ValueType>
-inline batch::matrix::batch_dense::uniform_batch<cuda_type<ValueType>>
+inline batch::matrix::dense::uniform_batch<cuda_type<ValueType>>
 get_batch_struct(batch::matrix::Dense<ValueType>* const op)
 {
     return {as_cuda_type(op->get_values()), op->get_num_batch_items(),
-            static_cast<int>(op->get_common_size()[1]),
-            static_cast<int>(op->get_common_size()[0]),
-            static_cast<int>(op->get_common_size()[1])};
+            static_cast<int32>(op->get_common_size()[1]),
+            static_cast<int32>(op->get_common_size()[0]),
+            static_cast<int32>(op->get_common_size()[1])};
 }
 
 

--- a/cuda/matrix/batch_struct.hpp
+++ b/cuda/matrix/batch_struct.hpp
@@ -65,7 +65,7 @@ namespace cuda {
  */
 template <typename ValueType>
 inline batch::matrix::batch_dense::uniform_batch<const cuda_type<ValueType>>
-get_batch_struct(const batch::matrix::BatchDense<ValueType>* const op)
+get_batch_struct(const batch::matrix::Dense<ValueType>* const op)
 {
     return {as_cuda_type(op->get_const_values()), op->get_num_batch_items(),
             static_cast<int>(op->get_common_size()[1]),
@@ -79,7 +79,7 @@ get_batch_struct(const batch::matrix::BatchDense<ValueType>* const op)
  */
 template <typename ValueType>
 inline batch::matrix::batch_dense::uniform_batch<cuda_type<ValueType>>
-get_batch_struct(batch::matrix::BatchDense<ValueType>* const op)
+get_batch_struct(batch::matrix::Dense<ValueType>* const op)
 {
     return {as_cuda_type(op->get_values()), op->get_num_batch_items(),
             static_cast<int>(op->get_common_size()[1]),

--- a/cuda/matrix/batch_struct.hpp
+++ b/cuda/matrix/batch_struct.hpp
@@ -61,7 +61,7 @@ namespace cuda {
 
 
 /**
- * Generates an immutable uniform batch struct from a batch of multi-vectors.
+ * Generates an immutable uniform batch struct from a batch of dense matrices.
  */
 template <typename ValueType>
 inline batch::matrix::batch_dense::uniform_batch<const cuda_type<ValueType>>
@@ -75,7 +75,7 @@ get_batch_struct(const batch::matrix::Dense<ValueType>* const op)
 
 
 /**
- * Generates a uniform batch struct from a batch of multi-vectors.
+ * Generates a uniform batch struct from a batch of dense matrices.
  */
 template <typename ValueType>
 inline batch::matrix::batch_dense::uniform_batch<cuda_type<ValueType>>

--- a/cuda/matrix/batch_struct.hpp
+++ b/cuda/matrix/batch_struct.hpp
@@ -30,55 +30,67 @@ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ******************************<GINKGO LICENSE>*******************************/
 
-#include "core/matrix/batch_dense_kernels.hpp"
+#ifndef GKO_CUDA_MATRIX_BATCH_STRUCT_HPP_
+#define GKO_CUDA_MATRIX_BATCH_STRUCT_HPP_
 
 
-#include <hip/hip_runtime.h>
-
-
+#include <ginkgo/core/base/batch_multi_vector.hpp>
 #include <ginkgo/core/base/math.hpp>
-#include <ginkgo/core/base/range_accessors.hpp>
+#include <ginkgo/core/matrix/batch_dense.hpp>
 
 
 #include "core/base/batch_struct.hpp"
 #include "core/matrix/batch_struct.hpp"
-#include "hip/base/batch_struct.hpp"
-#include "hip/base/config.hip.hpp"
-#include "hip/base/hipblas_bindings.hip.hpp"
-#include "hip/base/pointer_mode_guard.hip.hpp"
-#include "hip/components/cooperative_groups.hip.hpp"
-#include "hip/components/reduction.hip.hpp"
-#include "hip/components/thread_ids.hip.hpp"
-#include "hip/components/uninitialized_array.hip.hpp"
-#include "hip/matrix/batch_struct.hip.hpp"
+#include "cuda/base/config.hpp"
+#include "cuda/base/types.hpp"
 
 
 namespace gko {
 namespace kernels {
-namespace hip {
-/**
- * @brief The BatchDense matrix format namespace.
+namespace cuda {
+
+
+/** @file batch_struct.hpp
  *
- * @ingroup batch_dense
+ * Helper functions to generate a batch struct from a batch LinOp,
+ * while also shallow-casting to the required CUDA scalar type.
+ *
+ * A specialization is needed for every format of every kind of linear algebra
+ * object. These are intended to be called on the host.
  */
-namespace batch_dense {
 
 
-constexpr auto default_block_size = 256;
-constexpr int sm_oversubscription = 4;
+/**
+ * Generates an immutable uniform batch struct from a batch of multi-vectors.
+ */
+template <typename ValueType>
+inline batch::matrix::batch_dense::uniform_batch<const cuda_type<ValueType>>
+get_batch_struct(const batch::matrix::BatchDense<ValueType>* const op)
+{
+    return {as_cuda_type(op->get_const_values()), op->get_num_batch_items(),
+            static_cast<int>(op->get_common_size()[1]),
+            static_cast<int>(op->get_common_size()[0]),
+            static_cast<int>(op->get_common_size()[1])};
+}
 
-// clang-format off
 
-// NOTE: DO NOT CHANGE THE ORDERING OF THE INCLUDES
+/**
+ * Generates a uniform batch struct from a batch of multi-vectors.
+ */
+template <typename ValueType>
+inline batch::matrix::batch_dense::uniform_batch<cuda_type<ValueType>>
+get_batch_struct(batch::matrix::BatchDense<ValueType>* const op)
+{
+    return {as_cuda_type(op->get_values()), op->get_num_batch_items(),
+            static_cast<int>(op->get_common_size()[1]),
+            static_cast<int>(op->get_common_size()[0]),
+            static_cast<int>(op->get_common_size()[1])};
+}
 
-#include "common/cuda_hip/matrix/batch_dense_kernels.hpp.inc"
 
-
-#include "common/cuda_hip/matrix/batch_dense_kernel_launcher.hpp.inc"
-
-// clang-format on
-
-}  // namespace batch_dense
-}  // namespace hip
+}  // namespace cuda
 }  // namespace kernels
 }  // namespace gko
+
+
+#endif  // GKO_CUDA_MATRIX_BATCH_STRUCT_HPP_

--- a/cuda/matrix/batch_struct.hpp
+++ b/cuda/matrix/batch_struct.hpp
@@ -37,13 +37,10 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "core/matrix/batch_struct.hpp"
 
 
-#include <ginkgo/core/base/batch_multi_vector.hpp>
-#include <ginkgo/core/base/math.hpp>
 #include <ginkgo/core/matrix/batch_dense.hpp>
 
 
 #include "core/base/batch_struct.hpp"
-#include "cuda/base/config.hpp"
 #include "cuda/base/types.hpp"
 
 

--- a/cuda/matrix/batch_struct.hpp
+++ b/cuda/matrix/batch_struct.hpp
@@ -34,13 +34,15 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define GKO_CUDA_MATRIX_BATCH_STRUCT_HPP_
 
 
+#include "core/matrix/batch_struct.hpp"
+
+
 #include <ginkgo/core/base/batch_multi_vector.hpp>
 #include <ginkgo/core/base/math.hpp>
 #include <ginkgo/core/matrix/batch_dense.hpp>
 
 
 #include "core/base/batch_struct.hpp"
-#include "core/matrix/batch_struct.hpp"
 #include "cuda/base/config.hpp"
 #include "cuda/base/types.hpp"
 

--- a/cuda/matrix/batch_struct.hpp
+++ b/cuda/matrix/batch_struct.hpp
@@ -58,7 +58,7 @@ namespace cuda {
  * while also shallow-casting to the required CUDA scalar type.
  *
  * A specialization is needed for every format of every kind of linear algebra
- * object.
+ * object. These are intended to be called on the host.
  */
 
 

--- a/dpcpp/CMakeLists.txt
+++ b/dpcpp/CMakeLists.txt
@@ -35,6 +35,7 @@ target_sources(ginkgo_dpcpp
     factorization/par_ilut_select_kernel.dp.cpp
     factorization/par_ilut_spgeam_kernel.dp.cpp
     factorization/par_ilut_sweep_kernel.dp.cpp
+    matrix/batch_dense_kernels.dp.cpp
     matrix/coo_kernels.dp.cpp
     matrix/csr_kernels.dp.cpp
     matrix/fbcsr_kernels.dp.cpp

--- a/dpcpp/base/batch_multi_vector_kernels.dp.cpp
+++ b/dpcpp/base/batch_multi_vector_kernels.dp.cpp
@@ -194,9 +194,9 @@ void compute_dot(std::shared_ptr<const DefaultExecutor> exec,
     // TODO: Remove reqd_sub_group size and use sycl::reduce_over_group
     exec->get_queue()->submit([&](sycl::handler& cgh) {
         cgh.parallel_for(
-            sycl_nd_range(grid, block), [=
-        ](sycl::nd_item<3> item_ct1) [[sycl::reqd_sub_group_size(
-                                            config::warp_size)]] {
+            sycl_nd_range(grid, block),
+            [=](sycl::nd_item<3> item_ct1) [[sycl::reqd_sub_group_size(
+                config::warp_size)]] {
                 auto group = item_ct1.get_group();
                 auto group_id = group.get_group_linear_id();
                 const auto x_b = batch::extract_batch_item(x_ub, group_id);
@@ -232,18 +232,19 @@ void compute_conj_dot(std::shared_ptr<const DefaultExecutor> exec,
 
     exec->get_queue()->submit([&](sycl::handler& cgh) {
         cgh.parallel_for(
-            sycl_nd_range(grid, block), [=
-        ](sycl::nd_item<3> item_ct1) [[sycl::reqd_sub_group_size(
-                                            config::warp_size)]] {
-                auto group = item_ct1.get_group();
-                auto group_id = group.get_group_linear_id();
-                const auto x_b = batch::extract_batch_item(x_ub, group_id);
-                const auto y_b = batch::extract_batch_item(y_ub, group_id);
-                const auto res_b = batch::extract_batch_item(res_ub, group_id);
-                compute_gen_dot_product_kernel(
-                    x_b, y_b, res_b, item_ct1,
-                    [](auto val) { return conj(val); });
-            });
+            sycl_nd_range(grid, block),
+            [=](sycl::nd_item<3> item_ct1)
+                [[sycl::reqd_sub_group_size(config::warp_size)]] {
+                    auto group = item_ct1.get_group();
+                    auto group_id = group.get_group_linear_id();
+                    const auto x_b = batch::extract_batch_item(x_ub, group_id);
+                    const auto y_b = batch::extract_batch_item(y_ub, group_id);
+                    const auto res_b =
+                        batch::extract_batch_item(res_ub, group_id);
+                    compute_gen_dot_product_kernel(
+                        x_b, y_b, res_b, item_ct1,
+                        [](auto val) { return conj(val); });
+                });
     });
 }
 
@@ -268,16 +269,17 @@ void compute_norm2(std::shared_ptr<const DefaultExecutor> exec,
     const dim3 grid(num_batches);
 
     exec->get_queue()->submit([&](sycl::handler& cgh) {
-        cgh.parallel_for(
-            sycl_nd_range(grid, block), [=
-        ](sycl::nd_item<3> item_ct1) [[sycl::reqd_sub_group_size(
-                                            config::warp_size)]] {
-                auto group = item_ct1.get_group();
-                auto group_id = group.get_group_linear_id();
-                const auto x_b = batch::extract_batch_item(x_ub, group_id);
-                const auto res_b = batch::extract_batch_item(res_ub, group_id);
-                compute_norm2_kernel(x_b, res_b, item_ct1);
-            });
+        cgh.parallel_for(sycl_nd_range(grid, block),
+                         [=](sycl::nd_item<3> item_ct1)
+                             [[sycl::reqd_sub_group_size(config::warp_size)]] {
+                                 auto group = item_ct1.get_group();
+                                 auto group_id = group.get_group_linear_id();
+                                 const auto x_b =
+                                     batch::extract_batch_item(x_ub, group_id);
+                                 const auto res_b = batch::extract_batch_item(
+                                     res_ub, group_id);
+                                 compute_norm2_kernel(x_b, res_b, item_ct1);
+                             });
     });
 }
 

--- a/dpcpp/base/batch_struct.hpp
+++ b/dpcpp/base/batch_struct.hpp
@@ -53,7 +53,7 @@ namespace dpcpp {
  * while also shallow-casting to the required DPCPP scalar type.
  *
  * A specialization is needed for every format of every kind of linear algebra
- * object. These are intended to be called on the host.
+ * object.
  */
 
 
@@ -65,9 +65,9 @@ inline batch::multi_vector::uniform_batch<const ValueType> get_batch_struct(
     const batch::MultiVector<ValueType>* const op)
 {
     return {op->get_const_values(), op->get_num_batch_items(),
-            static_cast<int>(op->get_common_size()[1]),
-            static_cast<int>(op->get_common_size()[0]),
-            static_cast<int>(op->get_common_size()[1])};
+            static_cast<int32>(op->get_common_size()[1]),
+            static_cast<int32>(op->get_common_size()[0]),
+            static_cast<int32>(op->get_common_size()[1])};
 }
 
 
@@ -79,9 +79,9 @@ inline batch::multi_vector::uniform_batch<ValueType> get_batch_struct(
     batch::MultiVector<ValueType>* const op)
 {
     return {op->get_values(), op->get_num_batch_items(),
-            static_cast<int>(op->get_common_size()[1]),
-            static_cast<int>(op->get_common_size()[0]),
-            static_cast<int>(op->get_common_size()[1])};
+            static_cast<int32>(op->get_common_size()[1]),
+            static_cast<int32>(op->get_common_size()[0]),
+            static_cast<int32>(op->get_common_size()[1])};
 }
 
 

--- a/dpcpp/base/batch_struct.hpp
+++ b/dpcpp/base/batch_struct.hpp
@@ -53,7 +53,7 @@ namespace dpcpp {
  * while also shallow-casting to the required DPCPP scalar type.
  *
  * A specialization is needed for every format of every kind of linear algebra
- * object.
+ * object. These are intended to be called on the host.
  */
 
 

--- a/dpcpp/matrix/batch_dense_kernels.dp.cpp
+++ b/dpcpp/matrix/batch_dense_kernels.dp.cpp
@@ -100,17 +100,17 @@ void simple_apply(std::shared_ptr<const DefaultExecutor> exec,
     // Launch a kernel that has nbatches blocks, each block has max group size
     (exec->get_queue())->submit([&](sycl::handler& cgh) {
         cgh.parallel_for(
-            sycl_nd_range(grid, block), [=
-        ](sycl::nd_item<3> item_ct1) [[sycl::reqd_sub_group_size(
-                                            config::warp_size)]] {
-                auto group = item_ct1.get_group();
-                auto group_id = group.get_group_linear_id();
-                const auto mat_b =
-                    batch::matrix::extract_batch_item(mat_ub, group_id);
-                const auto b_b = batch::extract_batch_item(b_ub, group_id);
-                const auto x_b = batch::extract_batch_item(x_ub, group_id);
-                simple_apply_kernel(mat_b, b_b, x_b, item_ct1);
-            });
+            sycl_nd_range(grid, block),
+            [=](sycl::nd_item<3> item_ct1)
+                [[sycl::reqd_sub_group_size(config::warp_size)]] {
+                    auto group = item_ct1.get_group();
+                    auto group_id = group.get_group_linear_id();
+                    const auto mat_b =
+                        batch::matrix::extract_batch_item(mat_ub, group_id);
+                    const auto b_b = batch::extract_batch_item(b_ub, group_id);
+                    const auto x_b = batch::extract_batch_item(x_ub, group_id);
+                    simple_apply_kernel(mat_b, b_b, x_b, item_ct1);
+                });
     });
 }
 
@@ -147,22 +147,22 @@ void advanced_apply(std::shared_ptr<const DefaultExecutor> exec,
     // Launch a kernel that has nbatches blocks, each block has max group size
     (exec->get_queue())->submit([&](sycl::handler& cgh) {
         cgh.parallel_for(
-            sycl_nd_range(grid, block), [=
-        ](sycl::nd_item<3> item_ct1) [[sycl::reqd_sub_group_size(
-                                            config::warp_size)]] {
-                auto group = item_ct1.get_group();
-                auto group_id = group.get_group_linear_id();
-                const auto mat_b =
-                    batch::matrix::extract_batch_item(mat_ub, group_id);
-                const auto b_b = batch::extract_batch_item(b_ub, group_id);
-                const auto x_b = batch::extract_batch_item(x_ub, group_id);
-                const auto alpha_b =
-                    batch::extract_batch_item(alpha_ub, group_id);
-                const auto beta_b =
-                    batch::extract_batch_item(beta_ub, group_id);
-                advanced_apply_kernel(alpha_b, mat_b, b_b, beta_b, x_b,
-                                      item_ct1);
-            });
+            sycl_nd_range(grid, block),
+            [=](sycl::nd_item<3> item_ct1)
+                [[sycl::reqd_sub_group_size(config::warp_size)]] {
+                    auto group = item_ct1.get_group();
+                    auto group_id = group.get_group_linear_id();
+                    const auto mat_b =
+                        batch::matrix::extract_batch_item(mat_ub, group_id);
+                    const auto b_b = batch::extract_batch_item(b_ub, group_id);
+                    const auto x_b = batch::extract_batch_item(x_ub, group_id);
+                    const auto alpha_b =
+                        batch::extract_batch_item(alpha_ub, group_id);
+                    const auto beta_b =
+                        batch::extract_batch_item(beta_ub, group_id);
+                    advanced_apply_kernel(alpha_b, mat_b, b_b, beta_b, x_b,
+                                          item_ct1);
+                });
     });
 }
 

--- a/dpcpp/matrix/batch_dense_kernels.dp.cpp
+++ b/dpcpp/matrix/batch_dense_kernels.dp.cpp
@@ -40,8 +40,24 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
 #include <ginkgo/core/base/array.hpp>
+#include <ginkgo/core/base/batch_multi_vector.hpp>
 #include <ginkgo/core/base/math.hpp>
-#include <ginkgo/core/base/range_accessors.hpp>
+#include <ginkgo/core/matrix/batch_dense.hpp>
+
+
+#include "core/base/batch_struct.hpp"
+#include "core/components/prefix_sum_kernels.hpp"
+#include "core/matrix/batch_struct.hpp"
+#include "dpcpp/base/batch_struct.hpp"
+#include "dpcpp/base/config.hpp"
+#include "dpcpp/base/dim3.dp.hpp"
+#include "dpcpp/base/dpct.hpp"
+#include "dpcpp/base/helper.hpp"
+#include "dpcpp/components/cooperative_groups.dp.hpp"
+#include "dpcpp/components/intrinsics.dp.hpp"
+#include "dpcpp/components/reduction.dp.hpp"
+#include "dpcpp/components/thread_ids.dp.hpp"
+#include "dpcpp/matrix/batch_struct.hpp"
 
 
 namespace gko {
@@ -55,11 +71,46 @@ namespace dpcpp {
 namespace batch_dense {
 
 
+#include "dpcpp/matrix/batch_dense_kernels.hpp.inc"
+
+
 template <typename ValueType>
 void simple_apply(std::shared_ptr<const DefaultExecutor> exec,
-                  const batch::matrix::BatchDense<ValueType>* a,
+                  const batch::matrix::BatchDense<ValueType>* mat,
                   const batch::MultiVector<ValueType>* b,
-                  batch::MultiVector<ValueType>* x) GKO_NOT_IMPLEMENTED;
+                  batch::MultiVector<ValueType>* x)
+{
+    const size_type num_rows = x->get_common_size()[0];
+    const size_type num_cols = x->get_common_size()[1];
+
+    const auto num_batch_items = x->get_num_batch_items();
+    auto device = exec->get_queue()->get_device();
+    auto group_size =
+        device.get_info<sycl::info::device::max_work_group_size>();
+
+    const dim3 block(group_size);
+    const dim3 grid(num_batch_items);
+    const auto x_ub = get_batch_struct(x);
+    const auto b_ub = get_batch_struct(b);
+    const auto mat_ub = get_batch_struct(mat);
+    if (b_ub.num_rhs > 1) {
+        GKO_NOT_IMPLEMENTED;
+    }
+
+    // Launch a kernel that has nbatches blocks, each block has max group size
+    (exec->get_queue())->submit([&](sycl::handler& cgh) {
+        cgh.parallel_for(
+            sycl_nd_range(grid, block), [=](sycl::nd_item<3> item_ct1) {
+                auto group = item_ct1.get_group();
+                auto group_id = group.get_group_linear_id();
+                const auto mat_b =
+                    batch::matrix::extract_batch_item(mat_ub, group_id);
+                const auto b_b = batch::extract_batch_item(b_ub, group_id);
+                const auto x_b = batch::extract_batch_item(x_ub, group_id);
+                simple_apply_kernel(mat_b, b_b.values, x_b.values, item_ct1);
+            });
+    });
+}
 
 GKO_INSTANTIATE_FOR_EACH_VALUE_TYPE(
     GKO_DECLARE_BATCH_DENSE_SIMPLE_APPLY_KERNEL);
@@ -68,10 +119,48 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_TYPE(
 template <typename ValueType>
 void advanced_apply(std::shared_ptr<const DefaultExecutor> exec,
                     const batch::MultiVector<ValueType>* alpha,
-                    const batch::matrix::BatchDense<ValueType>* a,
+                    const batch::matrix::BatchDense<ValueType>* mat,
                     const batch::MultiVector<ValueType>* b,
                     const batch::MultiVector<ValueType>* beta,
-                    batch::MultiVector<ValueType>* c) GKO_NOT_IMPLEMENTED;
+                    batch::MultiVector<ValueType>* x)
+{
+    const auto mat_ub = get_batch_struct(mat);
+    const auto b_ub = get_batch_struct(b);
+    const auto x_ub = get_batch_struct(x);
+    const auto alpha_ub = get_batch_struct(alpha);
+    const auto beta_ub = get_batch_struct(beta);
+
+    if (b_ub.num_rhs > 1) {
+        GKO_NOT_IMPLEMENTED;
+    }
+
+    const auto num_batch_items = mat_ub.num_batch_items;
+    auto device = exec->get_queue()->get_device();
+    auto group_size =
+        device.get_info<sycl::info::device::max_work_group_size>();
+
+    const dim3 block(group_size);
+    const dim3 grid(num_batch_items);
+
+    // Launch a kernel that has nbatches blocks, each block has max group size
+    (exec->get_queue())->submit([&](sycl::handler& cgh) {
+        cgh.parallel_for(
+            sycl_nd_range(grid, block), [=](sycl::nd_item<3> item_ct1) {
+                auto group = item_ct1.get_group();
+                auto group_id = group.get_group_linear_id();
+                const auto mat_b =
+                    batch::matrix::extract_batch_item(mat_ub, group_id);
+                const auto b_b = batch::extract_batch_item(b_ub, group_id);
+                const auto x_b = batch::extract_batch_item(x_ub, group_id);
+                const auto alpha_b =
+                    batch::extract_batch_item(alpha_ub, group_id);
+                const auto beta_b =
+                    batch::extract_batch_item(beta_ub, group_id);
+                advanced_apply_kernel(alpha_b.values[0], mat_b, b_b.values,
+                                      beta_b.values[0], x_b.values, item_ct1);
+            });
+    });
+}
 
 GKO_INSTANTIATE_FOR_EACH_VALUE_TYPE(
     GKO_DECLARE_BATCH_DENSE_ADVANCED_APPLY_KERNEL);

--- a/dpcpp/matrix/batch_dense_kernels.dp.cpp
+++ b/dpcpp/matrix/batch_dense_kernels.dp.cpp
@@ -100,17 +100,17 @@ void simple_apply(std::shared_ptr<const DefaultExecutor> exec,
     // Launch a kernel that has nbatches blocks, each block has max group size
     exec->get_queue()->submit([&](sycl::handler& cgh) {
         cgh.parallel_for(
-            sycl_nd_range(grid, block), [=
-        ](sycl::nd_item<3> item_ct1) [[sycl::reqd_sub_group_size(
-                                            config::warp_size)]] {
-                auto group = item_ct1.get_group();
-                auto group_id = group.get_group_linear_id();
-                const auto mat_b =
-                    batch::matrix::extract_batch_item(mat_ub, group_id);
-                const auto b_b = batch::extract_batch_item(b_ub, group_id);
-                const auto x_b = batch::extract_batch_item(x_ub, group_id);
-                simple_apply_kernel(mat_b, b_b, x_b, item_ct1);
-            });
+            sycl_nd_range(grid, block),
+            [=](sycl::nd_item<3> item_ct1)
+                [[sycl::reqd_sub_group_size(config::warp_size)]] {
+                    auto group = item_ct1.get_group();
+                    auto group_id = group.get_group_linear_id();
+                    const auto mat_b =
+                        batch::matrix::extract_batch_item(mat_ub, group_id);
+                    const auto b_b = batch::extract_batch_item(b_ub, group_id);
+                    const auto x_b = batch::extract_batch_item(x_ub, group_id);
+                    simple_apply_kernel(mat_b, b_b, x_b, item_ct1);
+                });
     });
 }
 
@@ -147,22 +147,22 @@ void advanced_apply(std::shared_ptr<const DefaultExecutor> exec,
     // Launch a kernel that has nbatches blocks, each block has max group size
     exec->get_queue()->submit([&](sycl::handler& cgh) {
         cgh.parallel_for(
-            sycl_nd_range(grid, block), [=
-        ](sycl::nd_item<3> item_ct1) [[sycl::reqd_sub_group_size(
-                                            config::warp_size)]] {
-                auto group = item_ct1.get_group();
-                auto group_id = group.get_group_linear_id();
-                const auto mat_b =
-                    batch::matrix::extract_batch_item(mat_ub, group_id);
-                const auto b_b = batch::extract_batch_item(b_ub, group_id);
-                const auto x_b = batch::extract_batch_item(x_ub, group_id);
-                const auto alpha_b =
-                    batch::extract_batch_item(alpha_ub, group_id);
-                const auto beta_b =
-                    batch::extract_batch_item(beta_ub, group_id);
-                advanced_apply_kernel(alpha_b, mat_b, b_b, beta_b, x_b,
-                                      item_ct1);
-            });
+            sycl_nd_range(grid, block),
+            [=](sycl::nd_item<3> item_ct1)
+                [[sycl::reqd_sub_group_size(config::warp_size)]] {
+                    auto group = item_ct1.get_group();
+                    auto group_id = group.get_group_linear_id();
+                    const auto mat_b =
+                        batch::matrix::extract_batch_item(mat_ub, group_id);
+                    const auto b_b = batch::extract_batch_item(b_ub, group_id);
+                    const auto x_b = batch::extract_batch_item(x_ub, group_id);
+                    const auto alpha_b =
+                        batch::extract_batch_item(alpha_ub, group_id);
+                    const auto beta_b =
+                        batch::extract_batch_item(beta_ub, group_id);
+                    advanced_apply_kernel(alpha_b, mat_b, b_b, beta_b, x_b,
+                                          item_ct1);
+                });
     });
 }
 

--- a/dpcpp/matrix/batch_dense_kernels.dp.cpp
+++ b/dpcpp/matrix/batch_dense_kernels.dp.cpp
@@ -64,7 +64,7 @@ namespace gko {
 namespace kernels {
 namespace dpcpp {
 /**
- * @brief The BatchDense matrix format namespace.
+ * @brief The Dense matrix format namespace.
  *
  * @ingroup batch_dense
  */
@@ -76,7 +76,7 @@ namespace batch_dense {
 
 template <typename ValueType>
 void simple_apply(std::shared_ptr<const DefaultExecutor> exec,
-                  const batch::matrix::BatchDense<ValueType>* mat,
+                  const batch::matrix::Dense<ValueType>* mat,
                   const batch::MultiVector<ValueType>* b,
                   batch::MultiVector<ValueType>* x)
 {
@@ -121,7 +121,7 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_TYPE(
 template <typename ValueType>
 void advanced_apply(std::shared_ptr<const DefaultExecutor> exec,
                     const batch::MultiVector<ValueType>* alpha,
-                    const batch::matrix::BatchDense<ValueType>* mat,
+                    const batch::matrix::Dense<ValueType>* mat,
                     const batch::MultiVector<ValueType>* b,
                     const batch::MultiVector<ValueType>* beta,
                     batch::MultiVector<ValueType>* x)

--- a/dpcpp/matrix/batch_dense_kernels.dp.cpp
+++ b/dpcpp/matrix/batch_dense_kernels.dp.cpp
@@ -1,0 +1,83 @@
+/*******************************<GINKGO LICENSE>******************************
+Copyright (c) 2017-2023, the Ginkgo authors
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+******************************<GINKGO LICENSE>*******************************/
+
+#include "core/matrix/batch_dense_kernels.hpp"
+
+
+#include <algorithm>
+
+
+#include <CL/sycl.hpp>
+
+
+#include <ginkgo/core/base/array.hpp>
+#include <ginkgo/core/base/math.hpp>
+#include <ginkgo/core/base/range_accessors.hpp>
+
+
+namespace gko {
+namespace kernels {
+namespace dpcpp {
+/**
+ * @brief The BatchDense matrix format namespace.
+ *
+ * @ingroup batch_dense
+ */
+namespace batch_dense {
+
+
+template <typename ValueType>
+void simple_apply(std::shared_ptr<const DefaultExecutor> exec,
+                  const batch::matrix::BatchDense<ValueType>* a,
+                  const batch::MultiVector<ValueType>* b,
+                  MultiVector<ValueType>* c) GKO_NOT_IMPLEMENTED;
+
+GKO_INSTANTIATE_FOR_EACH_VALUE_TYPE(
+    GKO_DECLARE_BATCH_DENSE_SIMPLE_APPLY_KERNEL);
+
+
+template <typename ValueType>
+void advanced_apply(std::shared_ptr<const DefaultExecutor> exec,
+                    const batch::MultiVector<ValueType>* alpha,
+                    const batch::matrix::BatchDense<ValueType>* a,
+                    const batch::MultiVector<ValueType>* b,
+                    const batch::MultiVector<ValueType>* beta,
+                    batch::MultiVector<ValueType>* c) GKO_NOT_IMPLEMENTED;
+
+GKO_INSTANTIATE_FOR_EACH_VALUE_TYPE(
+    GKO_DECLARE_BATCH_DENSE_ADVANCED_APPLY_KERNEL);
+
+
+}  // namespace batch_dense
+}  // namespace dpcpp
+}  // namespace kernels
+}  // namespace gko

--- a/dpcpp/matrix/batch_dense_kernels.dp.cpp
+++ b/dpcpp/matrix/batch_dense_kernels.dp.cpp
@@ -98,19 +98,19 @@ void simple_apply(std::shared_ptr<const DefaultExecutor> exec,
     }
 
     // Launch a kernel that has nbatches blocks, each block has max group size
-    (exec->get_queue())->submit([&](sycl::handler& cgh) {
+    exec->get_queue()->submit([&](sycl::handler& cgh) {
         cgh.parallel_for(
-            sycl_nd_range(grid, block),
-            [=](sycl::nd_item<3> item_ct1)
-                [[sycl::reqd_sub_group_size(config::warp_size)]] {
-                    auto group = item_ct1.get_group();
-                    auto group_id = group.get_group_linear_id();
-                    const auto mat_b =
-                        batch::matrix::extract_batch_item(mat_ub, group_id);
-                    const auto b_b = batch::extract_batch_item(b_ub, group_id);
-                    const auto x_b = batch::extract_batch_item(x_ub, group_id);
-                    simple_apply_kernel(mat_b, b_b, x_b, item_ct1);
-                });
+            sycl_nd_range(grid, block), [=
+        ](sycl::nd_item<3> item_ct1) [[sycl::reqd_sub_group_size(
+                                            config::warp_size)]] {
+                auto group = item_ct1.get_group();
+                auto group_id = group.get_group_linear_id();
+                const auto mat_b =
+                    batch::matrix::extract_batch_item(mat_ub, group_id);
+                const auto b_b = batch::extract_batch_item(b_ub, group_id);
+                const auto x_b = batch::extract_batch_item(x_ub, group_id);
+                simple_apply_kernel(mat_b, b_b, x_b, item_ct1);
+            });
     });
 }
 
@@ -145,24 +145,24 @@ void advanced_apply(std::shared_ptr<const DefaultExecutor> exec,
     const dim3 grid(num_batch_items);
 
     // Launch a kernel that has nbatches blocks, each block has max group size
-    (exec->get_queue())->submit([&](sycl::handler& cgh) {
+    exec->get_queue()->submit([&](sycl::handler& cgh) {
         cgh.parallel_for(
-            sycl_nd_range(grid, block),
-            [=](sycl::nd_item<3> item_ct1)
-                [[sycl::reqd_sub_group_size(config::warp_size)]] {
-                    auto group = item_ct1.get_group();
-                    auto group_id = group.get_group_linear_id();
-                    const auto mat_b =
-                        batch::matrix::extract_batch_item(mat_ub, group_id);
-                    const auto b_b = batch::extract_batch_item(b_ub, group_id);
-                    const auto x_b = batch::extract_batch_item(x_ub, group_id);
-                    const auto alpha_b =
-                        batch::extract_batch_item(alpha_ub, group_id);
-                    const auto beta_b =
-                        batch::extract_batch_item(beta_ub, group_id);
-                    advanced_apply_kernel(alpha_b, mat_b, b_b, beta_b, x_b,
-                                          item_ct1);
-                });
+            sycl_nd_range(grid, block), [=
+        ](sycl::nd_item<3> item_ct1) [[sycl::reqd_sub_group_size(
+                                            config::warp_size)]] {
+                auto group = item_ct1.get_group();
+                auto group_id = group.get_group_linear_id();
+                const auto mat_b =
+                    batch::matrix::extract_batch_item(mat_ub, group_id);
+                const auto b_b = batch::extract_batch_item(b_ub, group_id);
+                const auto x_b = batch::extract_batch_item(x_ub, group_id);
+                const auto alpha_b =
+                    batch::extract_batch_item(alpha_ub, group_id);
+                const auto beta_b =
+                    batch::extract_batch_item(beta_ub, group_id);
+                advanced_apply_kernel(alpha_b, mat_b, b_b, beta_b, x_b,
+                                      item_ct1);
+            });
     });
 }
 

--- a/dpcpp/matrix/batch_dense_kernels.dp.cpp
+++ b/dpcpp/matrix/batch_dense_kernels.dp.cpp
@@ -59,7 +59,7 @@ template <typename ValueType>
 void simple_apply(std::shared_ptr<const DefaultExecutor> exec,
                   const batch::matrix::BatchDense<ValueType>* a,
                   const batch::MultiVector<ValueType>* b,
-                  MultiVector<ValueType>* c) GKO_NOT_IMPLEMENTED;
+                  batch::MultiVector<ValueType>* x) GKO_NOT_IMPLEMENTED;
 
 GKO_INSTANTIATE_FOR_EACH_VALUE_TYPE(
     GKO_DECLARE_BATCH_DENSE_SIMPLE_APPLY_KERNEL);

--- a/dpcpp/matrix/batch_dense_kernels.hpp.inc
+++ b/dpcpp/matrix/batch_dense_kernels.hpp.inc
@@ -1,0 +1,91 @@
+/*******************************<GINKGO LICENSE>******************************
+Copyright (c) 2017-2023, the Ginkgo authors
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+******************************<GINKGO LICENSE>*******************************/
+
+template <typename ValueType>
+__dpct_inline__ void simple_apply_kernel(
+    const gko::batch::matrix::batch_dense::batch_item<const ValueType>& mat,
+    const ValueType* const __restrict__ b, ValueType* const __restrict__ x,
+    sycl::nd_item<3>& item_ct1)
+{
+    constexpr auto tile_size = config::warp_size;
+    auto subg =
+        group::tiled_partition<tile_size>(group::this_thread_block(item_ct1));
+    const auto subgroup = static_cast<sycl::sub_group>(subg);
+    const int subgroup_id = subgroup.get_group_id();
+    const int subgroup_size = subgroup.get_local_range().size();
+    const int num_subgroup = subgroup.get_group_range().size();
+
+    for (int row = subgroup_id; row < mat.num_rows; row += num_subgroup) {
+        ValueType temp = zero<ValueType>();
+        for (int j = subgroup.get_local_id(); j < mat.num_cols;
+             j += subgroup_size) {
+            const ValueType val = mat.values[row * mat.stride + j];
+            temp += val * b[j];
+        }
+        temp = ::gko::kernels::dpcpp::reduce(
+            subg, temp, [](ValueType v1, ValueType v2) { return v1 + v2; });
+        if (subgroup.get_local_id() == 0) {
+            x[row] = temp;
+        }
+    }
+}
+
+
+template <typename ValueType>
+__dpct_inline__ void advanced_apply_kernel(
+    const ValueType alpha,
+    const gko::batch::matrix::batch_dense::batch_item<const ValueType>& mat,
+    const ValueType* const __restrict__ b, const ValueType beta,
+    ValueType* const __restrict__ x, sycl::nd_item<3>& item_ct1)
+{
+    constexpr auto tile_size = config::warp_size;
+    auto subg =
+        group::tiled_partition<tile_size>(group::this_thread_block(item_ct1));
+    const auto subgroup = static_cast<sycl::sub_group>(subg);
+    const int subgroup_id = subgroup.get_group_id();
+    const int subgroup_size = subgroup.get_local_range().size();
+    const int num_subgroup = subgroup.get_group_range().size();
+
+    for (int row = subgroup_id; row < mat.num_rows; row += num_subgroup) {
+        ValueType temp = zero<ValueType>();
+        for (int j = subgroup.get_local_id(); j < mat.num_cols;
+             j += subgroup_size) {
+            const ValueType val = mat.values[row * mat.stride + j];
+            temp += alpha * val * b[j];
+        }
+        temp = ::gko::kernels::dpcpp::reduce(
+            subg, temp, [](ValueType v1, ValueType v2) { return v1 + v2; });
+        if (subgroup.get_local_id() == 0) {
+            x[row] = temp + beta * x[row];
+        }
+    }
+}

--- a/dpcpp/matrix/batch_dense_kernels.hpp.inc
+++ b/dpcpp/matrix/batch_dense_kernels.hpp.inc
@@ -33,7 +33,43 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 template <typename ValueType>
 __dpct_inline__ void simple_apply_kernel(
     const gko::batch::matrix::batch_dense::batch_item<const ValueType>& mat,
-    const ValueType* const __restrict__ b, ValueType* const __restrict__ x,
+    const gko::batch::multi_vector::batch_item<const ValueType>& b,
+    const gko::batch::multi_vector::batch_item<ValueType>& x,
+    sycl::nd_item<3>& item_ct1)
+{
+    constexpr auto tile_size = config::warp_size;
+    auto subg =
+        group::tiled_partition<tile_size>(group::this_thread_block(item_ct1));
+    const auto subgroup = static_cast<sycl::sub_group>(subg);
+    const int subgroup_id = subgroup.get_group_id();
+    const int subgroup_size = subgroup.get_local_range().size();
+    const int num_subgroups = subgroup.get_group_range().size();
+
+    for (int row = subgroup_id; row < mat.num_rows; row += num_subgroups) {
+        ValueType temp = zero<ValueType>();
+        for (int j = subgroup.get_local_id(); j < mat.num_cols;
+             j += subgroup_size) {
+            const ValueType val = mat.values[row * mat.stride + j];
+            temp += val * b.values[j];
+        }
+
+        temp = ::gko::kernels::dpcpp::reduce(
+            subg, temp, [](ValueType a, ValueType b) { return a + b; });
+
+        if (subgroup.get_local_id() == 0) {
+            x.values[row] = temp;
+        }
+    }
+}
+
+
+template <typename ValueType>
+__dpct_inline__ void advanced_apply_kernel(
+    const gko::batch::multi_vector::batch_item<const ValueType>& alpha,
+    const gko::batch::matrix::batch_dense::batch_item<const ValueType>& mat,
+    const gko::batch::multi_vector::batch_item<const ValueType>& b,
+    const gko::batch::multi_vector::batch_item<const ValueType>& beta,
+    const gko::batch::multi_vector::batch_item<ValueType>& x,
     sycl::nd_item<3>& item_ct1)
 {
     constexpr auto tile_size = config::warp_size;
@@ -49,43 +85,14 @@ __dpct_inline__ void simple_apply_kernel(
         for (int j = subgroup.get_local_id(); j < mat.num_cols;
              j += subgroup_size) {
             const ValueType val = mat.values[row * mat.stride + j];
-            temp += val * b[j];
+            temp += alpha.values[0] * val * b.values[j];
         }
+
         temp = ::gko::kernels::dpcpp::reduce(
-            subg, temp, [](ValueType v1, ValueType v2) { return v1 + v2; });
+            subg, temp, [](ValueType a, ValueType b) { return a + b; });
+
         if (subgroup.get_local_id() == 0) {
-            x[row] = temp;
-        }
-    }
-}
-
-
-template <typename ValueType>
-__dpct_inline__ void advanced_apply_kernel(
-    const ValueType alpha,
-    const gko::batch::matrix::batch_dense::batch_item<const ValueType>& mat,
-    const ValueType* const __restrict__ b, const ValueType beta,
-    ValueType* const __restrict__ x, sycl::nd_item<3>& item_ct1)
-{
-    constexpr auto tile_size = config::warp_size;
-    auto subg =
-        group::tiled_partition<tile_size>(group::this_thread_block(item_ct1));
-    const auto subgroup = static_cast<sycl::sub_group>(subg);
-    const int subgroup_id = subgroup.get_group_id();
-    const int subgroup_size = subgroup.get_local_range().size();
-    const int num_subgroup = subgroup.get_group_range().size();
-
-    for (int row = subgroup_id; row < mat.num_rows; row += num_subgroup) {
-        ValueType temp = zero<ValueType>();
-        for (int j = subgroup.get_local_id(); j < mat.num_cols;
-             j += subgroup_size) {
-            const ValueType val = mat.values[row * mat.stride + j];
-            temp += alpha * val * b[j];
-        }
-        temp = ::gko::kernels::dpcpp::reduce(
-            subg, temp, [](ValueType v1, ValueType v2) { return v1 + v2; });
-        if (subgroup.get_local_id() == 0) {
-            x[row] = temp + beta * x[row];
+            x.values[row] = temp + beta.values[0] * x.values[row];
         }
     }
 }

--- a/dpcpp/matrix/batch_dense_kernels.hpp.inc
+++ b/dpcpp/matrix/batch_dense_kernels.hpp.inc
@@ -32,7 +32,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 template <typename ValueType>
 __dpct_inline__ void simple_apply_kernel(
-    const gko::batch::matrix::batch_dense::batch_item<const ValueType>& mat,
+    const gko::batch::matrix::dense::batch_item<const ValueType>& mat,
     const gko::batch::multi_vector::batch_item<const ValueType>& b,
     const gko::batch::multi_vector::batch_item<ValueType>& x,
     sycl::nd_item<3>& item_ct1)
@@ -66,7 +66,7 @@ __dpct_inline__ void simple_apply_kernel(
 template <typename ValueType>
 __dpct_inline__ void advanced_apply_kernel(
     const gko::batch::multi_vector::batch_item<const ValueType>& alpha,
-    const gko::batch::matrix::batch_dense::batch_item<const ValueType>& mat,
+    const gko::batch::matrix::dense::batch_item<const ValueType>& mat,
     const gko::batch::multi_vector::batch_item<const ValueType>& b,
     const gko::batch::multi_vector::batch_item<const ValueType>& beta,
     const gko::batch::multi_vector::batch_item<ValueType>& x,

--- a/dpcpp/matrix/batch_struct.hpp
+++ b/dpcpp/matrix/batch_struct.hpp
@@ -34,12 +34,14 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define GKO_DPCPP_MATRIX_BATCH_STRUCT_HPP_
 
 
+#include "core/matrix/batch_struct.hpp"
+
+
 #include <ginkgo/core/base/batch_multi_vector.hpp>
 #include <ginkgo/core/base/math.hpp>
 
 
 #include "core/base/batch_struct.hpp"
-#include "core/matrix/batch_struct.hpp"
 #include "dpcpp/base/config.hpp"
 
 

--- a/dpcpp/matrix/batch_struct.hpp
+++ b/dpcpp/matrix/batch_struct.hpp
@@ -59,7 +59,7 @@ namespace dpcpp {
 
 
 /**
- * Generates an immutable uniform batch struct from a batch of multi-vectors.
+ * Generates an immutable uniform batch struct from a batch of dense matrices.
  */
 template <typename ValueType>
 inline batch::matrix::batch_dense::uniform_batch<const ValueType>
@@ -73,7 +73,7 @@ get_batch_struct(const batch::matrix::Dense<ValueType>* const op)
 
 
 /**
- * Generates a uniform batch struct from a batch of multi-vectors.
+ * Generates a uniform batch struct from a batch of dense matrices.
  */
 template <typename ValueType>
 inline batch::matrix::batch_dense::uniform_batch<ValueType> get_batch_struct(

--- a/dpcpp/matrix/batch_struct.hpp
+++ b/dpcpp/matrix/batch_struct.hpp
@@ -37,8 +37,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "core/matrix/batch_struct.hpp"
 
 
-#include <ginkgo/core/base/batch_multi_vector.hpp>
 #include <ginkgo/core/base/math.hpp>
+#include <ginkgo/core/matrix/batch_dense.hpp>
 
 
 #include "core/base/batch_struct.hpp"
@@ -56,7 +56,7 @@ namespace dpcpp {
  * while also shallow-casting to the required DPCPP scalar type.
  *
  * A specialization is needed for every format of every kind of linear algebra
- * object. These are intended to be called on the host.
+ * object.
  */
 
 
@@ -64,13 +64,13 @@ namespace dpcpp {
  * Generates an immutable uniform batch struct from a batch of dense matrices.
  */
 template <typename ValueType>
-inline batch::matrix::batch_dense::uniform_batch<const ValueType>
-get_batch_struct(const batch::matrix::Dense<ValueType>* const op)
+inline batch::matrix::dense::uniform_batch<const ValueType> get_batch_struct(
+    const batch::matrix::Dense<ValueType>* const op)
 {
     return {op->get_const_values(), op->get_num_batch_items(),
-            static_cast<int>(op->get_common_size()[1]),
-            static_cast<int>(op->get_common_size()[0]),
-            static_cast<int>(op->get_common_size()[1])};
+            static_cast<int32>(op->get_common_size()[1]),
+            static_cast<int32>(op->get_common_size()[0]),
+            static_cast<int32>(op->get_common_size()[1])};
 }
 
 
@@ -78,13 +78,13 @@ get_batch_struct(const batch::matrix::Dense<ValueType>* const op)
  * Generates a uniform batch struct from a batch of dense matrices.
  */
 template <typename ValueType>
-inline batch::matrix::batch_dense::uniform_batch<ValueType> get_batch_struct(
+inline batch::matrix::dense::uniform_batch<ValueType> get_batch_struct(
     batch::matrix::Dense<ValueType>* const op)
 {
     return {op->get_values(), op->get_num_batch_items(),
-            static_cast<int>(op->get_common_size()[1]),
-            static_cast<int>(op->get_common_size()[0]),
-            static_cast<int>(op->get_common_size()[1])};
+            static_cast<int32>(op->get_common_size()[1]),
+            static_cast<int32>(op->get_common_size()[0]),
+            static_cast<int32>(op->get_common_size()[1])};
 }
 
 

--- a/dpcpp/matrix/batch_struct.hpp
+++ b/dpcpp/matrix/batch_struct.hpp
@@ -56,7 +56,7 @@ namespace dpcpp {
  * while also shallow-casting to the required DPCPP scalar type.
  *
  * A specialization is needed for every format of every kind of linear algebra
- * object.
+ * object. These are intended to be called on the host.
  */
 
 

--- a/dpcpp/matrix/batch_struct.hpp
+++ b/dpcpp/matrix/batch_struct.hpp
@@ -1,0 +1,94 @@
+/*******************************<GINKGO LICENSE>******************************
+Copyright (c) 2017-2023, the Ginkgo authors
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+******************************<GINKGO LICENSE>*******************************/
+
+#ifndef GKO_DPCPP_MATRIX_BATCH_STRUCT_HPP_
+#define GKO_DPCPP_MATRIX_BATCH_STRUCT_HPP_
+
+
+#include <ginkgo/core/base/batch_multi_vector.hpp>
+#include <ginkgo/core/base/math.hpp>
+
+
+#include "core/base/batch_struct.hpp"
+#include "core/matrix/batch_struct.hpp"
+#include "dpcpp/base/config.hpp"
+
+
+namespace gko {
+namespace kernels {
+namespace dpcpp {
+
+
+/** @file batch_struct.hpp
+ *
+ * Helper functions to generate a batch struct from a batch LinOp,
+ * while also shallow-casting to the required DPCPP scalar type.
+ *
+ * A specialization is needed for every format of every kind of linear algebra
+ * object. These are intended to be called on the host.
+ */
+
+
+/**
+ * Generates an immutable uniform batch struct from a batch of multi-vectors.
+ */
+template <typename ValueType>
+inline batch::matrix::batch_dense::uniform_batch<const ValueType>
+get_batch_struct(const batch::matrix::BatchDense<ValueType>* const op)
+{
+    return {op->get_const_values(), op->get_num_batch_items(),
+            static_cast<int>(op->get_common_size()[1]),
+            static_cast<int>(op->get_common_size()[0]),
+            static_cast<int>(op->get_common_size()[1])};
+}
+
+
+/**
+ * Generates a uniform batch struct from a batch of multi-vectors.
+ */
+template <typename ValueType>
+inline batch::matrix::batch_dense::uniform_batch<ValueType> get_batch_struct(
+    batch::matrix::BatchDense<ValueType>* const op)
+{
+    return {op->get_values(), op->get_num_batch_items(),
+            static_cast<int>(op->get_common_size()[1]),
+            static_cast<int>(op->get_common_size()[0]),
+            static_cast<int>(op->get_common_size()[1])};
+}
+
+
+}  // namespace dpcpp
+}  // namespace kernels
+}  // namespace gko
+
+
+#endif  // GKO_DPCPP_MATRIX_BATCH_STRUCT_HPP_

--- a/dpcpp/matrix/batch_struct.hpp
+++ b/dpcpp/matrix/batch_struct.hpp
@@ -63,7 +63,7 @@ namespace dpcpp {
  */
 template <typename ValueType>
 inline batch::matrix::batch_dense::uniform_batch<const ValueType>
-get_batch_struct(const batch::matrix::BatchDense<ValueType>* const op)
+get_batch_struct(const batch::matrix::Dense<ValueType>* const op)
 {
     return {op->get_const_values(), op->get_num_batch_items(),
             static_cast<int>(op->get_common_size()[1]),
@@ -77,7 +77,7 @@ get_batch_struct(const batch::matrix::BatchDense<ValueType>* const op)
  */
 template <typename ValueType>
 inline batch::matrix::batch_dense::uniform_batch<ValueType> get_batch_struct(
-    batch::matrix::BatchDense<ValueType>* const op)
+    batch::matrix::Dense<ValueType>* const op)
 {
     return {op->get_values(), op->get_num_batch_items(),
             static_cast<int>(op->get_common_size()[1]),

--- a/dpcpp/matrix/batch_struct.hpp
+++ b/dpcpp/matrix/batch_struct.hpp
@@ -37,12 +37,10 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "core/matrix/batch_struct.hpp"
 
 
-#include <ginkgo/core/base/math.hpp>
 #include <ginkgo/core/matrix/batch_dense.hpp>
 
 
 #include "core/base/batch_struct.hpp"
-#include "dpcpp/base/config.hpp"
 
 
 namespace gko {

--- a/dpcpp/test/preconditioner/jacobi_kernels.dp.cpp
+++ b/dpcpp/test/preconditioner/jacobi_kernels.dp.cpp
@@ -90,7 +90,7 @@ protected:
         gko::uint32 max_block_size, int min_nnz, int max_nnz, int num_rhs = 1,
         value_type accuracy = 0.1, bool skip_sorting = true)
     {
-        std::default_random_engine engine(42);
+        std::ranlux48 engine(42);
         const auto dim = *(end(block_pointers) - 1);
         if (condition_numbers.size() == 0) {
             mtx = gko::test::generate_random_matrix<Mtx>(

--- a/dpcpp/test/preconditioner/jacobi_kernels.dp.cpp
+++ b/dpcpp/test/preconditioner/jacobi_kernels.dp.cpp
@@ -90,7 +90,7 @@ protected:
         gko::uint32 max_block_size, int min_nnz, int max_nnz, int num_rhs = 1,
         value_type accuracy = 0.1, bool skip_sorting = true)
     {
-        std::ranlux48 engine(42);
+        std::default_random_engine engine(42);
         const auto dim = *(end(block_pointers) - 1);
         if (condition_numbers.size() == 0) {
             mtx = gko::test::generate_random_matrix<Mtx>(

--- a/hip/CMakeLists.txt
+++ b/hip/CMakeLists.txt
@@ -35,6 +35,7 @@ set(GINKGO_HIP_SOURCES
     factorization/par_ilut_select_kernel.hip.cpp
     factorization/par_ilut_spgeam_kernel.hip.cpp
     factorization/par_ilut_sweep_kernel.hip.cpp
+    matrix/batch_dense_kernels.hip.cpp
     matrix/coo_kernels.hip.cpp
     ${CSR_INSTANTIATE}
     matrix/dense_kernels.hip.cpp

--- a/hip/base/batch_struct.hip.hpp
+++ b/hip/base/batch_struct.hip.hpp
@@ -54,7 +54,7 @@ namespace hip {
  * while also shallow-casting to the required Hip scalar type.
  *
  * A specialization is needed for every format of every kind of linear algebra
- * object.
+ * object. These are intended to be called on the host.
  */
 
 

--- a/hip/base/batch_struct.hip.hpp
+++ b/hip/base/batch_struct.hip.hpp
@@ -54,7 +54,7 @@ namespace hip {
  * while also shallow-casting to the required Hip scalar type.
  *
  * A specialization is needed for every format of every kind of linear algebra
- * object. These are intended to be called on the host.
+ * object.
  */
 
 
@@ -66,9 +66,9 @@ inline batch::multi_vector::uniform_batch<const hip_type<ValueType>>
 get_batch_struct(const batch::MultiVector<ValueType>* const op)
 {
     return {as_hip_type(op->get_const_values()), op->get_num_batch_items(),
-            static_cast<int>(op->get_common_size()[1]),
-            static_cast<int>(op->get_common_size()[0]),
-            static_cast<int>(op->get_common_size()[1])};
+            static_cast<int32>(op->get_common_size()[1]),
+            static_cast<int32>(op->get_common_size()[0]),
+            static_cast<int32>(op->get_common_size()[1])};
 }
 
 /**
@@ -79,9 +79,9 @@ inline batch::multi_vector::uniform_batch<hip_type<ValueType>> get_batch_struct(
     batch::MultiVector<ValueType>* const op)
 {
     return {as_hip_type(op->get_values()), op->get_num_batch_items(),
-            static_cast<int>(op->get_common_size()[1]),
-            static_cast<int>(op->get_common_size()[0]),
-            static_cast<int>(op->get_common_size()[1])};
+            static_cast<int32>(op->get_common_size()[1]),
+            static_cast<int32>(op->get_common_size()[0]),
+            static_cast<int32>(op->get_common_size()[1])};
 }
 
 

--- a/hip/matrix/batch_dense_kernels.hip.cpp
+++ b/hip/matrix/batch_dense_kernels.hip.cpp
@@ -79,7 +79,9 @@ constexpr int sm_oversubscription = 4;
 
 #include "common/cuda_hip/matrix/batch_dense_kernel_launcher.hpp.inc"
 
+
 // clang-format on
+
 
 }  // namespace batch_dense
 }  // namespace hip

--- a/hip/matrix/batch_dense_kernels.hip.cpp
+++ b/hip/matrix/batch_dense_kernels.hip.cpp
@@ -34,6 +34,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
 #include <hip/hip_runtime.h>
+#include <thrust/functional.h>
+#include <thrust/transform.h>
 
 
 #include <ginkgo/core/base/math.hpp>
@@ -42,10 +44,11 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "core/base/batch_struct.hpp"
 #include "core/matrix/batch_struct.hpp"
-#include "hip/base/batch_struct.hpp"
+#include "hip/base/batch_struct.hip.hpp"
 #include "hip/base/config.hip.hpp"
 #include "hip/base/hipblas_bindings.hip.hpp"
 #include "hip/base/pointer_mode_guard.hip.hpp"
+#include "hip/base/thrust.hip.hpp"
 #include "hip/components/cooperative_groups.hip.hpp"
 #include "hip/components/reduction.hip.hpp"
 #include "hip/components/thread_ids.hip.hpp"

--- a/hip/matrix/batch_dense_kernels.hip.cpp
+++ b/hip/matrix/batch_dense_kernels.hip.cpp
@@ -48,7 +48,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "hip/components/reduction.hip.hpp"
 #include "hip/components/thread_ids.hip.hpp"
 #include "hip/components/uninitialized_array.hip.hpp"
-#include "hip/matrix/batch_struct.hip.hpp"
+// #include "hip/matrix/batch_struct.hip.hpp"
 
 
 namespace gko {

--- a/hip/matrix/batch_dense_kernels.hip.cpp
+++ b/hip/matrix/batch_dense_kernels.hip.cpp
@@ -35,7 +35,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <hip/hip_runtime.h>
 #include <thrust/functional.h>
-#include <thrust/transform.h>
 
 
 #include <ginkgo/core/base/math.hpp>
@@ -46,8 +45,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "core/matrix/batch_struct.hpp"
 #include "hip/base/batch_struct.hip.hpp"
 #include "hip/base/config.hip.hpp"
-#include "hip/base/hipblas_bindings.hip.hpp"
-#include "hip/base/pointer_mode_guard.hip.hpp"
 #include "hip/base/thrust.hip.hpp"
 #include "hip/components/cooperative_groups.hip.hpp"
 #include "hip/components/reduction.hip.hpp"

--- a/hip/matrix/batch_dense_kernels.hip.cpp
+++ b/hip/matrix/batch_dense_kernels.hip.cpp
@@ -70,7 +70,7 @@ template <typename ValueType>
 void simple_apply(std::shared_ptr<const DefaultExecutor> exec,
                   const batch::matrix::BatchDense<ValueType>* mat,
                   const batch::MultiVector<ValueType>* b,
-                  MultiVector<ValueType>* x) GKO_NOT_IMPLEMENTED;
+                  batch::MultiVector<ValueType>* x) GKO_NOT_IMPLEMENTED;
 
 GKO_INSTANTIATE_FOR_EACH_VALUE_TYPE(
     GKO_DECLARE_BATCH_DENSE_SIMPLE_APPLY_KERNEL);

--- a/hip/matrix/batch_dense_kernels.hip.cpp
+++ b/hip/matrix/batch_dense_kernels.hip.cpp
@@ -60,7 +60,7 @@ namespace gko {
 namespace kernels {
 namespace hip {
 /**
- * @brief The BatchDense matrix format namespace.
+ * @brief The Dense matrix format namespace.
  *
  * @ingroup batch_dense
  */

--- a/hip/matrix/batch_dense_kernels.hip.cpp
+++ b/hip/matrix/batch_dense_kernels.hip.cpp
@@ -1,0 +1,94 @@
+/*******************************<GINKGO LICENSE>******************************
+Copyright (c) 2017-2023, the Ginkgo authors
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+******************************<GINKGO LICENSE>*******************************/
+
+#include "core/matrix/batch_dense_kernels.hpp"
+
+
+#include <hip/hip_runtime.h>
+
+
+#include <ginkgo/core/base/math.hpp>
+#include <ginkgo/core/base/range_accessors.hpp>
+
+
+#include "core/matrix/batch_struct.hpp"
+#include "hip/base/config.hip.hpp"
+#include "hip/base/hipblas_bindings.hip.hpp"
+#include "hip/base/pointer_mode_guard.hip.hpp"
+#include "hip/components/cooperative_groups.hip.hpp"
+#include "hip/components/reduction.hip.hpp"
+#include "hip/components/thread_ids.hip.hpp"
+#include "hip/components/uninitialized_array.hip.hpp"
+#include "hip/matrix/batch_struct.hip.hpp"
+
+
+namespace gko {
+namespace kernels {
+namespace hip {
+/**
+ * @brief The BatchDense matrix format namespace.
+ *
+ * @ingroup batch_dense
+ */
+namespace batch_dense {
+
+
+constexpr auto default_block_size = 256;
+constexpr int sm_multiplier = 4;
+
+
+template <typename ValueType>
+void simple_apply(std::shared_ptr<const DefaultExecutor> exec,
+                  const batch::matrix::BatchDense<ValueType>* mat,
+                  const batch::MultiVector<ValueType>* b,
+                  MultiVector<ValueType>* x) GKO_NOT_IMPLEMENTED;
+
+GKO_INSTANTIATE_FOR_EACH_VALUE_TYPE(
+    GKO_DECLARE_BATCH_DENSE_SIMPLE_APPLY_KERNEL);
+
+
+template <typename ValueType>
+void advanced_apply(std::shared_ptr<const DefaultExecutor> exec,
+                    const batch::MultiVector<ValueType>* alpha,
+                    const batch::matrix::BatchDense<ValueType>* a,
+                    const batch::MultiVector<ValueType>* b,
+                    const batch::MultiVector<ValueType>* beta,
+                    batch::MultiVector<ValueType>* c) GKO_NOT_IMPLEMENTED;
+
+GKO_INSTANTIATE_FOR_EACH_VALUE_TYPE(
+    GKO_DECLARE_BATCH_DENSE_ADVANCED_APPLY_KERNEL);
+
+
+}  // namespace batch_dense
+}  // namespace hip
+}  // namespace kernels
+}  // namespace gko

--- a/hip/matrix/batch_struct.hip.hpp
+++ b/hip/matrix/batch_struct.hip.hpp
@@ -58,7 +58,7 @@ namespace hip {
  * while also shallow-casting to the required HIP scalar type.
  *
  * A specialization is needed for every format of every kind of linear algebra
- * object.
+ * object. These are intended to be called on the host.
  */
 
 

--- a/hip/matrix/batch_struct.hip.hpp
+++ b/hip/matrix/batch_struct.hip.hpp
@@ -61,7 +61,7 @@ namespace hip {
 
 
 /**
- * Generates an immutable uniform batch struct from a batch of multi-vectors.
+ * Generates an immutable uniform batch struct from a batch of dense matrices.
  */
 template <typename ValueType>
 inline batch::matrix::batch_dense::uniform_batch<const hip_type<ValueType>>
@@ -75,7 +75,7 @@ get_batch_struct(const batch::matrix::Dense<ValueType>* const op)
 
 
 /**
- * Generates a uniform batch struct from a batch of multi-vectors.
+ * Generates a uniform batch struct from a batch of dense matrices.
  */
 template <typename ValueType>
 inline batch::matrix::batch_dense::uniform_batch<hip_type<ValueType>>

--- a/hip/matrix/batch_struct.hip.hpp
+++ b/hip/matrix/batch_struct.hip.hpp
@@ -41,8 +41,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "core/base/batch_struct.hpp"
 #include "core/matrix/batch_struct.hpp"
-#include "hip/base/config.hpp"
-#include "hip/base/types.hpp"
+#include "hip/base/config.hip.hpp"
+#include "hip/base/types.hip.hpp"
 
 
 namespace gko {
@@ -65,7 +65,7 @@ namespace hip {
  */
 template <typename ValueType>
 inline batch::matrix::batch_dense::uniform_batch<const hip_type<ValueType>>
-get_batch_struct(const batch::matrix::BatchDense<ValueType>* const op)
+get_batch_struct(const batch::matrix::Dense<ValueType>* const op)
 {
     return {as_hip_type(op->get_const_values()), op->get_num_batch_items(),
             static_cast<int>(op->get_common_size()[1]),
@@ -79,7 +79,7 @@ get_batch_struct(const batch::matrix::BatchDense<ValueType>* const op)
  */
 template <typename ValueType>
 inline batch::matrix::batch_dense::uniform_batch<hip_type<ValueType>>
-get_batch_struct(batch::matrix::BatchDense<ValueType>* const op)
+get_batch_struct(batch::matrix::Dense<ValueType>* const op)
 {
     return {as_hip_type(op->get_values()), op->get_num_batch_items(),
             static_cast<int>(op->get_common_size()[1]),

--- a/hip/matrix/batch_struct.hip.hpp
+++ b/hip/matrix/batch_struct.hip.hpp
@@ -58,7 +58,7 @@ namespace hip {
  * while also shallow-casting to the required HIP scalar type.
  *
  * A specialization is needed for every format of every kind of linear algebra
- * object. These are intended to be called on the host.
+ * object.
  */
 
 
@@ -66,13 +66,13 @@ namespace hip {
  * Generates an immutable uniform batch struct from a batch of dense matrices.
  */
 template <typename ValueType>
-inline batch::matrix::batch_dense::uniform_batch<const hip_type<ValueType>>
+inline batch::matrix::dense::uniform_batch<const hip_type<ValueType>>
 get_batch_struct(const batch::matrix::Dense<ValueType>* const op)
 {
     return {as_hip_type(op->get_const_values()), op->get_num_batch_items(),
-            static_cast<int>(op->get_common_size()[1]),
-            static_cast<int>(op->get_common_size()[0]),
-            static_cast<int>(op->get_common_size()[1])};
+            static_cast<int32>(op->get_common_size()[1]),
+            static_cast<int32>(op->get_common_size()[0]),
+            static_cast<int32>(op->get_common_size()[1])};
 }
 
 
@@ -80,13 +80,13 @@ get_batch_struct(const batch::matrix::Dense<ValueType>* const op)
  * Generates a uniform batch struct from a batch of dense matrices.
  */
 template <typename ValueType>
-inline batch::matrix::batch_dense::uniform_batch<hip_type<ValueType>>
+inline batch::matrix::dense::uniform_batch<hip_type<ValueType>>
 get_batch_struct(batch::matrix::Dense<ValueType>* const op)
 {
     return {as_hip_type(op->get_values()), op->get_num_batch_items(),
-            static_cast<int>(op->get_common_size()[1]),
-            static_cast<int>(op->get_common_size()[0]),
-            static_cast<int>(op->get_common_size()[1])};
+            static_cast<int32>(op->get_common_size()[1]),
+            static_cast<int32>(op->get_common_size()[0]),
+            static_cast<int32>(op->get_common_size()[1])};
 }
 
 

--- a/hip/matrix/batch_struct.hip.hpp
+++ b/hip/matrix/batch_struct.hip.hpp
@@ -37,13 +37,10 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "core/matrix/batch_struct.hpp"
 
 
-#include <ginkgo/core/base/batch_multi_vector.hpp>
-#include <ginkgo/core/base/math.hpp>
 #include <ginkgo/core/matrix/batch_dense.hpp>
 
 
 #include "core/base/batch_struct.hpp"
-#include "hip/base/config.hip.hpp"
 #include "hip/base/types.hip.hpp"
 
 

--- a/hip/matrix/batch_struct.hip.hpp
+++ b/hip/matrix/batch_struct.hip.hpp
@@ -30,8 +30,11 @@ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ******************************<GINKGO LICENSE>*******************************/
 
-#ifndef GKO_HIP_MATRIX_BATCH_STRUCT_HPP_
-#define GKO_HIP_MATRIX_BATCH_STRUCT_HPP_
+#ifndef GKO_HIP_MATRIX_BATCH_STRUCT_HIP_HPP_
+#define GKO_HIP_MATRIX_BATCH_STRUCT_HIP_HPP_
+
+
+#include "core/matrix/batch_struct.hpp"
 
 
 #include <ginkgo/core/base/batch_multi_vector.hpp>
@@ -40,7 +43,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
 #include "core/base/batch_struct.hpp"
-#include "core/matrix/batch_struct.hpp"
 #include "hip/base/config.hip.hpp"
 #include "hip/base/types.hip.hpp"
 
@@ -93,4 +95,4 @@ get_batch_struct(batch::matrix::Dense<ValueType>* const op)
 }  // namespace gko
 
 
-#endif  // GKO_HIP_MATRIX_BATCH_STRUCT_HPP_
+#endif  // GKO_HIP_MATRIX_BATCH_STRUCT_HIP_HPP_

--- a/include/ginkgo/core/base/batch_dim.hpp
+++ b/include/ginkgo/core/base/batch_dim.hpp
@@ -75,18 +75,6 @@ struct batch_dim {
     }
 
     /**
-     * Get the cumulative storage size offset
-     *
-     * @param batch_id the batch id
-     *
-     * @return the cumulative offset
-     */
-    size_type get_cumulative_offset(size_type batch_id) const
-    {
-        return batch_id * common_size_[0] * common_size_[1];
-    }
-
-    /**
      * Checks if two batch_dim objects are equal.
      *
      * @param x  first object

--- a/include/ginkgo/core/base/batch_lin_op.hpp
+++ b/include/ginkgo/core/base/batch_lin_op.hpp
@@ -40,6 +40,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
 #include <ginkgo/core/base/abstract_factory.hpp>
+#include <ginkgo/core/base/batch_multi_vector.hpp>
 #include <ginkgo/core/base/dim.hpp>
 #include <ginkgo/core/base/exception_helpers.hpp>
 #include <ginkgo/core/base/math.hpp>
@@ -109,6 +110,45 @@ public:
      * @return  size of the batch operator, a batch_dim object
      */
     const batch_dim<2>& get_size() const noexcept { return size_; }
+
+    /**
+     * Validates the sizes for the apply(b,x) operation in the
+     * concrete BatchLinOp.
+     *
+     */
+    template <typename ValueType>
+    void validate_application_parameters(const MultiVector<ValueType>* b,
+                                         MultiVector<ValueType>* x) const
+    {
+        GKO_ASSERT_EQ(b->get_num_batch_items(), this->get_num_batch_items());
+        GKO_ASSERT_EQ(this->get_num_batch_items(), x->get_num_batch_items());
+
+        GKO_ASSERT_CONFORMANT(this->get_common_size(), b->get_common_size());
+        GKO_ASSERT_EQUAL_ROWS(this->get_common_size(), x->get_common_size());
+        GKO_ASSERT_EQUAL_COLS(b->get_common_size(), x->get_common_size());
+    }
+
+    /**
+     * Validates the sizes for the apply(alpha, b , beta, x) operation in the
+     * concrete BatchLinOp.
+     *
+     */
+    template <typename ValueType>
+    void validate_application_parameters(const MultiVector<ValueType>* alpha,
+                                         const MultiVector<ValueType>* b,
+                                         const MultiVector<ValueType>* beta,
+                                         MultiVector<ValueType>* x) const
+    {
+        GKO_ASSERT_EQ(b->get_num_batch_items(), this->get_num_batch_items());
+        GKO_ASSERT_EQ(this->get_num_batch_items(), x->get_num_batch_items());
+
+        GKO_ASSERT_CONFORMANT(this->get_common_size(), b->get_common_size());
+        GKO_ASSERT_EQUAL_ROWS(this->get_common_size(), x->get_common_size());
+        GKO_ASSERT_EQUAL_COLS(b->get_common_size(), x->get_common_size());
+        GKO_ASSERT_EQUAL_DIMENSIONS(alpha->get_common_size(),
+                                    gko::dim<2>(1, 1));
+        GKO_ASSERT_EQUAL_DIMENSIONS(beta->get_common_size(), gko::dim<2>(1, 1));
+    }
 
 protected:
     /**

--- a/include/ginkgo/core/base/batch_multi_vector.hpp
+++ b/include/ginkgo/core/base/batch_multi_vector.hpp
@@ -213,8 +213,8 @@ public:
      *       significantly more memory efficient than the non-constant version,
      *       so always prefer this version.
      */
-    const value_type* get_const_values_for_item(size_type batch_id) const
-        noexcept
+    const value_type* get_const_values_for_item(
+        size_type batch_id) const noexcept
     {
         GKO_ASSERT(batch_id < this->get_num_batch_items());
         return values_.get_const_data() +

--- a/include/ginkgo/core/base/batch_multi_vector.hpp
+++ b/include/ginkgo/core/base/batch_multi_vector.hpp
@@ -202,8 +202,7 @@ public:
     value_type* get_values_for_item(size_type batch_id) noexcept
     {
         GKO_ASSERT(batch_id < this->get_num_batch_items());
-        return values_.get_data() +
-               this->get_size().get_cumulative_offset(batch_id);
+        return values_.get_data() + this->get_cumulative_offset(batch_id);
     }
 
     /**
@@ -217,8 +216,7 @@ public:
         size_type batch_id) const noexcept
     {
         GKO_ASSERT(batch_id < this->get_num_batch_items());
-        return values_.get_const_data() +
-               this->get_size().get_cumulative_offset(batch_id);
+        return values_.get_const_data() + this->get_cumulative_offset(batch_id);
     }
 
     /**
@@ -231,6 +229,19 @@ public:
     size_type get_num_stored_elements() const noexcept
     {
         return values_.get_num_elems();
+    }
+
+    /**
+     * Get the cumulative storage size offset
+     *
+     * @param batch_id the batch id
+     *
+     * @return the cumulative offset
+     */
+    size_type get_cumulative_offset(size_type batch_id) const
+    {
+        return batch_id * this->get_common_size()[0] *
+               this->get_common_size()[1];
     }
 
     /**
@@ -375,7 +386,8 @@ public:
 private:
     inline size_type compute_num_elems(const batch_dim<2>& size)
     {
-        return size.get_cumulative_offset(size.get_num_batch_items());
+        return size.get_num_batch_items() * size.get_common_size()[0] *
+               size.get_common_size()[1];
     }
 
 protected:
@@ -434,7 +446,7 @@ protected:
     size_type linearize_index(size_type batch, size_type row,
                               size_type col) const noexcept
     {
-        return batch_size_.get_cumulative_offset(batch) +
+        return this->get_cumulative_offset(batch) +
                row * batch_size_.get_common_size()[1] + col;
     }
 

--- a/include/ginkgo/core/base/batch_multi_vector.hpp
+++ b/include/ginkgo/core/base/batch_multi_vector.hpp
@@ -56,7 +56,7 @@ namespace matrix {
 
 
 template <typename ValueType>
-class BatchDense;
+class Dense;
 
 
 }
@@ -91,20 +91,20 @@ class MultiVector
       public EnablePolymorphicAssignment<MultiVector<ValueType>>,
       public EnableCreateMethod<MultiVector<ValueType>>,
       public ConvertibleTo<MultiVector<next_precision<ValueType>>>,
-      public ConvertibleTo<matrix::BatchDense<ValueType>> {
+      public ConvertibleTo<matrix::Dense<ValueType>> {
     friend class EnableCreateMethod<MultiVector>;
     friend class EnablePolymorphicObject<MultiVector>;
     friend class MultiVector<to_complex<ValueType>>;
     friend class MultiVector<next_precision<ValueType>>;
-    friend class matrix::BatchDense<ValueType>;
+    friend class matrix::Dense<ValueType>;
 
 public:
     using EnablePolymorphicAssignment<MultiVector>::convert_to;
     using EnablePolymorphicAssignment<MultiVector>::move_to;
     using ConvertibleTo<MultiVector<next_precision<ValueType>>>::convert_to;
     using ConvertibleTo<MultiVector<next_precision<ValueType>>>::move_to;
-    using ConvertibleTo<matrix::BatchDense<ValueType>>::convert_to;
-    using ConvertibleTo<matrix::BatchDense<ValueType>>::move_to;
+    using ConvertibleTo<matrix::Dense<ValueType>>::convert_to;
+    using ConvertibleTo<matrix::Dense<ValueType>>::move_to;
 
     using value_type = ValueType;
     using index_type = int32;
@@ -126,9 +126,9 @@ public:
 
     void move_to(MultiVector<next_precision<ValueType>>* result) override;
 
-    void convert_to(matrix::BatchDense<ValueType>* result) const override;
+    void convert_to(matrix::Dense<ValueType>* result) const override;
 
-    void move_to(matrix::BatchDense<ValueType>* result) override;
+    void move_to(matrix::Dense<ValueType>* result) override;
 
     /**
      * Creates a mutable view (of matrix::Dense type) of one item of the Batch

--- a/include/ginkgo/core/matrix/batch_dense.hpp
+++ b/include/ginkgo/core/matrix/batch_dense.hpp
@@ -63,7 +63,7 @@ namespace matrix {
  * each batch item are also stored consecutively in memory).
  *
  * @note Though the storage layout is the same as the multi-vector object, the
- * class semantics and the operations it aims to provide is different. Hence it
+ * class semantics and the operations it aims to provide are different. Hence it
  * is recommended to create multi-vector objects if the user means to view the
  * data as a set of vectors.
  *
@@ -123,13 +123,13 @@ public:
     create_const_multi_vector_view() const;
 
     /**
-     * Creates a mutable view (of matrix::Dense type) of one item of the
+     * Creates a mutable view (of gko::matrix::Dense type) of one item of the
      * batch::matrix::Dense<value_type> object. Does not perform any deep
      * copies, but only returns a view of the data.
      *
      * @param item_id  The index of the batch item
      *
-     * @return  a batch::matrix::Dense object with the data from the batch item
+     * @return  a gko::matrix::Dense object with the data from the batch item
      * at the given index.
      */
     std::unique_ptr<unbatch_type> create_view_for_item(size_type item_id);
@@ -168,7 +168,7 @@ public:
      *
      * @note  the method has to be called on the same Executor the matrix is
      *        stored at (e.g. trying to call this method on a GPU Dense object
-     *        from the OMP results in a runtime error)
+     *        from the OMP may result in incorrect behaviour)
      */
     value_type& at(size_type batch_id, size_type row, size_type col)
     {
@@ -197,7 +197,7 @@ public:
      *
      * @note  the method has to be called on the same Executor the matrix is
      *        stored at (e.g. trying to call this method on a GPU Dense object
-     *        from the OMP results in a runtime error)
+     *        from the OMP may result in incorrect behaviour)
      */
     ValueType& at(size_type batch_id, size_type idx) noexcept
     {
@@ -268,7 +268,7 @@ public:
      */
     static std::unique_ptr<const Dense<value_type>> create_const(
         std::shared_ptr<const Executor> exec, const batch_dim<2>& sizes,
-        gko::detail::const_array_view<ValueType>&& values);
+        detail::const_array_view<ValueType>&& values);
 
     /**
      * Apply the matrix to a multi-vector. Represents the matrix vector
@@ -343,7 +343,7 @@ protected:
     }
 
     /**
-     * Creates a Dense matrix with the same configuration as the callers
+     * Creates a Dense matrix with the same configuration as the caller's
      * matrix.
      *
      * @returns a Dense matrix with the same configuration as the caller.

--- a/include/ginkgo/core/matrix/batch_dense.hpp
+++ b/include/ginkgo/core/matrix/batch_dense.hpp
@@ -1,0 +1,341 @@
+/*******************************<GINKGO LICENSE>******************************
+Copyright (c) 2017-2023, the Ginkgo authors
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+******************************<GINKGO LICENSE>*******************************/
+
+#ifndef GKO_PUBLIC_CORE_MATRIX_BATCH_DENSE_HPP_
+#define GKO_PUBLIC_CORE_MATRIX_BATCH_DENSE_HPP_
+
+
+#include <initializer_list>
+#include <vector>
+
+
+#include <ginkgo/core/base/array.hpp>
+#include <ginkgo/core/base/batch_lin_op.hpp>
+#include <ginkgo/core/base/executor.hpp>
+#include <ginkgo/core/base/mtx_io.hpp>
+#include <ginkgo/core/base/range_accessors.hpp>
+#include <ginkgo/core/base/types.hpp>
+#include <ginkgo/core/base/utils.hpp>
+#include <ginkgo/core/matrix/dense.hpp>
+
+
+namespace gko {
+namespace batch {
+namespace matrix {
+
+
+/**
+ * BatchDense is a batch matrix format which explicitly stores all values of the
+ * matrix in each of the batches.
+ *
+ * The values in each of the batches are stored in row-major format (values
+ * belonging to the same row appear consecutive in the memory). Optionally, rows
+ * can be padded for better memory access.
+ *
+ * @tparam ValueType  precision of matrix elements
+ *
+ * @note While this format is not very useful for storing sparse matrices, it
+ *       is often suitable to store vectors, and sets of vectors.
+ * @ingroup batch_dense
+ * @ingroup mat_formats
+ * @ingroup BatchLinOp
+ */
+template <typename ValueType = default_precision>
+class BatchDense : public EnableBatchLinOp<BatchDense<ValueType>>,
+                   public EnableCreateMethod<BatchDense<ValueType>>,
+                   public ConvertibleTo<BatchDense<next_precision<ValueType>>> {
+    friend class EnableCreateMethod<BatchDense>;
+    friend class EnablePolymorphicObject<BatchDense, BatchLinOp>;
+    friend class BatchDense<to_complex<ValueType>>;
+    friend class BatchDense<next_precision<ValueType>>;
+
+public:
+    using EnableBatchLinOp<BatchDense>::convert_to;
+    using EnableBatchLinOp<BatchDense>::move_to;
+
+    using value_type = ValueType;
+    using index_type = int32;
+    using transposed_type = BatchDense<ValueType>;
+    using unbatch_type = matrix::Dense<ValueType>;
+    using absolute_type = remove_complex<BatchDense>;
+    using complex_type = to_complex<BatchDense>;
+
+    /**
+     * Creates a BatchDense matrix with the configuration of another BatchDense
+     * matrix.
+     *
+     * @param other  The other matrix whose configuration needs to copied.
+     */
+    static std::unique_ptr<BatchDense> create_with_config_of(
+        const BatchDense* other)
+    {
+        // De-referencing `other` before calling the functions (instead of
+        // using operator `->`) is currently required to be compatible with
+        // CUDA 10.1.
+        // Otherwise, it results in a compile error.
+        return (*other).create_with_same_config();
+    }
+
+    void convert_to(
+        BatchDense<next_precision<ValueType>>* result) const override;
+
+    void move_to(BatchDense<next_precision<ValueType>>* result) override;
+
+
+    /**
+     * Creates a mutable view (of matrix::Dense type) of one item of the Batch
+     * MultiVector<value_type> object. Does not perform any deep copies, but
+     * only returns a view of the data.
+     *
+     * @param item_id  The index of the batch item
+     *
+     * @return  a matrix::Dense object with the data from the batch item at the
+     *          given index.
+     */
+    std::unique_ptr<unbatch_type> create_view_for_item(size_type item_id);
+
+    /**
+     * @copydoc create_view_for_item(size_type)
+     */
+    std::unique_ptr<const unbatch_type> create_const_view_for_item(
+        size_type item_id) const;
+
+    /**
+     * Returns the batch size.
+     *
+     * @return the batch size
+     */
+    batch_dim<2> get_size() const { return batch_size_; }
+
+    /**
+     * Returns the number of batch items.
+     *
+     * @return the number of batch items
+     */
+    size_type get_num_batch_items() const
+    {
+        return batch_size_.get_num_batch_items();
+    }
+
+    /**
+     * Returns the common size of the batch items.
+     *
+     * @return the common size stored
+     */
+    dim<2> get_common_size() const { return batch_size_.get_common_size(); }
+
+    /**
+     * Returns a pointer to the array of values of the multi-vector
+     *
+     * @return the pointer to the array of values
+     */
+    value_type* get_values() noexcept { return values_.get_data(); }
+
+    /**
+     * @copydoc get_values()
+     *
+     * @note This is the constant version of the function, which can be
+     *       significantly more memory efficient than the non-constant version,
+     *       so always prefer this version.
+     */
+    const value_type* get_const_values() const noexcept
+    {
+        return values_.get_const_data();
+    }
+
+    /**
+     * Returns a pointer to the array of values of the multi-vector for a
+     * specific batch item.
+     *
+     * @param batch_id  the id of the batch item.
+     *
+     * @return the pointer to the array of values
+     */
+    value_type* get_values_for_item(size_type batch_id) noexcept
+    {
+        GKO_ASSERT(batch_id < this->get_num_batch_items());
+        return values_.get_data() +
+               this->get_size().get_cumulative_offset(batch_id);
+    }
+
+    /**
+     * @copydoc get_values_for_item(size_type)
+     *
+     * @note This is the constant version of the function, which can be
+     *       significantly more memory efficient than the non-constant version,
+     *       so always prefer this version.
+     */
+    const value_type* get_const_values_for_item(size_type batch_id) const
+        noexcept
+    {
+        GKO_ASSERT(batch_id < this->get_num_batch_items());
+        return values_.get_const_data() +
+               this->get_size().get_cumulative_offset(batch_id);
+    }
+
+    /**
+     * Returns the number of elements explicitly stored in the batch matrix,
+     * cumulative across all the batch items.
+     *
+     * @return the number of elements explicitly stored in the vector,
+     *         cumulative across all the batch items
+     */
+    size_type get_num_stored_elements() const noexcept
+    {
+        return values_.get_num_elems();
+    }
+
+
+    /**
+     * Creates a constant (immutable) batch dense matrix from a constant
+     * array.
+     *
+     * @param exec  the executor to create the vector on
+     * @param size  the dimensions of the vector
+     * @param values  the value array of the vector
+     *
+     * @return A smart pointer to the constant multi-vector wrapping the input
+     * array (if it resides on the same executor as the vector) or a copy of the
+     * array on the correct executor.
+     */
+    static std::unique_ptr<const MultiVector<value_type><ValueType>>
+    create_const(std::shared_ptr<const Executor> exec,
+                 const batch_dim<2>& sizes,
+                 gko::detail::const_array_view<ValueType>&& values);
+
+private:
+    inline size_type compute_num_elems(const batch_dim<2>& size)
+    {
+        return size.get_cumulative_offset(size.get_num_batch_items());
+    }
+
+
+    void apply(const MultiVector<value_type>* b,
+               MultiVector<value_type>* x) const
+    {
+        this->apply_impl(b, x);
+    }
+
+    void apply(const MultiVector<value_type>* alpha,
+               const MultiVector<value_type>* b,
+               const MultiVector<value_type>* beta,
+               MultiVector<value_type>* x) const
+    {
+        this->apply_impl(alpha, b, beta, x);
+    }
+
+protected:
+    /**
+     * Sets the size of the MultiVector<value_type>.
+     *
+     * @param value  the new size of the operator
+     */
+    void set_size(const batch_dim<2>& value) noexcept;
+
+    /**
+     * Creates an uninitialized BatchDense matrix of the specified size.
+     *
+     * @param exec  Executor associated to the matrix
+     * @param size  size of the matrix
+     */
+    BatchDense(std::shared_ptr<const Executor> exec,
+               const batch_dim<2>& size = batch_dim<2>{});
+
+    /**
+     * Creates a BatchDense matrix from an already allocated (and initialized)
+     * array.
+     *
+     * @tparam ValuesArray  type of array of values
+     *
+     * @param exec  Executor associated to the matrix
+     * @param size  sizes of the batch matrices in a batch_dim object
+     * @param values  array of matrix values
+     * @param strides  stride of the rows (i.e. offset between the first
+     *                  elements of two consecutive rows, expressed as the
+     *                  number of matrix elements)
+     *
+     * @note If `values` is not an rvalue, not an array of ValueType, or is on
+     *       the wrong executor, an internal copy will be created, and the
+     *       original array data will not be used in the matrix.
+     */
+    template <typename ValuesArray>
+    BatchDense(std::shared_ptr<const Executor> exec, const batch_dim<2>& size,
+               ValuesArray&& values)
+        : EnableBatchLinOp<BatchDense>(exec, size),
+          values_{exec, std::forward<ValuesArray>(values)}
+    {
+        // Ensure that the values array has the correct size
+        auto num_elems = compute_num_elems(size);
+        GKO_ENSURE_IN_BOUNDS(num_elems, values_.get_num_elems() + 1);
+    }
+
+    /**
+     * Creates a BatchDense matrix with the same configuration as the callers
+     * matrix.
+     *
+     * @returns a BatchDense matrix with the same configuration as the caller.
+     */
+    std::unique_ptr<BatchDense> create_with_same_config() const;
+
+    virtual void apply_impl(const MultiVector<value_type>* b,
+                            MultiVector<value_type>* x) const;
+
+    virtual void apply_impl(const MultiVector<value_type>* alpha,
+                            const MultiVector<value_type>* b,
+                            const MultiVector<value_type>* beta,
+                            MultiVector<value_type>* x) const;
+
+    size_type linearize_index(size_type batch, size_type row,
+                              size_type col) const noexcept
+    {
+        return batch_size_.get_cumulative_offset(batch) +
+               row * batch_size_.get_common_size()[1] + col;
+    }
+
+    size_type linearize_index(size_type batch, size_type idx) const noexcept
+    {
+        return linearize_index(batch, idx / this->get_common_size()[1],
+                               idx % this->get_common_size()[1]);
+    }
+
+private:
+    batch_dim<2> batch_size_;
+    array<value_type> values_;
+};
+
+
+}  // namespace matrix
+}  // namespace batch
+}  // namespace gko
+
+
+#endif  // GKO_PUBLIC_CORE_MATRIX_BATCH_DENSE_HPP_

--- a/include/ginkgo/core/matrix/batch_dense.hpp
+++ b/include/ginkgo/core/matrix/batch_dense.hpp
@@ -252,7 +252,7 @@ public:
      */
     static std::unique_ptr<const Dense<value_type>> create_const(
         std::shared_ptr<const Executor> exec, const batch_dim<2>& sizes,
-        detail::const_array_view<ValueType>&& values);
+        gko::detail::const_array_view<ValueType>&& values);
 
     /**
      * Apply the matrix to a multi-vector. Represents the matrix vector

--- a/include/ginkgo/core/matrix/batch_dense.hpp
+++ b/include/ginkgo/core/matrix/batch_dense.hpp
@@ -62,7 +62,7 @@ namespace matrix {
  * belonging to the same row appear consecutive in the memory and the values of
  * each batch item are also stored consecutively in memory).
  *
- * @note Though the storage layout is similar to the multi-vector object, the
+ * @note Though the storage layout is the same as the multi-vector object, the
  * class semantics and the operations it aims to provide is different. Hence it
  * is recommended to create multi-vector objects if the user means to view the
  * data as a set of vectors.

--- a/include/ginkgo/core/matrix/batch_dense.hpp
+++ b/include/ginkgo/core/matrix/batch_dense.hpp
@@ -217,8 +217,8 @@ public:
      *       significantly more memory efficient than the non-constant version,
      *       so always prefer this version.
      */
-    const value_type* get_const_values_for_item(size_type batch_id) const
-        noexcept
+    const value_type* get_const_values_for_item(
+        size_type batch_id) const noexcept
     {
         GKO_ASSERT(batch_id < this->get_num_batch_items());
         return values_.get_const_data() +

--- a/include/ginkgo/core/matrix/batch_dense.hpp
+++ b/include/ginkgo/core/matrix/batch_dense.hpp
@@ -55,7 +55,7 @@ namespace matrix {
 
 
 /**
- * BatchDense is a batch matrix format which explicitly stores all values of the
+ * Dense is a batch matrix format which explicitly stores all values of the
  * matrix in each of the batches.
  *
  * The values in each of the batches are stored in row-major format (values
@@ -71,38 +71,37 @@ namespace matrix {
  * @ingroup BatchLinOp
  */
 template <typename ValueType = default_precision>
-class BatchDense : public EnableBatchLinOp<BatchDense<ValueType>>,
-                   public EnableCreateMethod<BatchDense<ValueType>>,
-                   public ConvertibleTo<BatchDense<next_precision<ValueType>>> {
-    friend class EnableCreateMethod<BatchDense>;
-    friend class EnablePolymorphicObject<BatchDense, BatchLinOp>;
-    friend class BatchDense<to_complex<ValueType>>;
-    friend class BatchDense<next_precision<ValueType>>;
+class Dense : public EnableBatchLinOp<Dense<ValueType>>,
+              public EnableCreateMethod<Dense<ValueType>>,
+              public ConvertibleTo<Dense<next_precision<ValueType>>> {
+    friend class EnableCreateMethod<Dense>;
+    friend class EnablePolymorphicObject<Dense, BatchLinOp>;
+    friend class Dense<to_complex<ValueType>>;
+    friend class Dense<next_precision<ValueType>>;
 
 public:
-    using EnableBatchLinOp<BatchDense>::convert_to;
-    using EnableBatchLinOp<BatchDense>::move_to;
+    using EnableBatchLinOp<Dense>::convert_to;
+    using EnableBatchLinOp<Dense>::move_to;
 
     using value_type = ValueType;
     using index_type = int32;
-    using transposed_type = BatchDense<ValueType>;
+    using transposed_type = Dense<ValueType>;
     using unbatch_type = gko::matrix::Dense<ValueType>;
-    using absolute_type = remove_complex<BatchDense>;
-    using complex_type = to_complex<BatchDense>;
+    using absolute_type = remove_complex<Dense>;
+    using complex_type = to_complex<Dense>;
 
     /**
-     * Creates a BatchDense matrix with the configuration of another BatchDense
+     * Creates a Dense matrix with the configuration of another Dense
      * matrix.
      *
      * @param other  The other matrix whose configuration needs to copied.
      */
-    static std::unique_ptr<BatchDense> create_with_config_of(
-        ptr_param<const BatchDense> other);
+    static std::unique_ptr<Dense> create_with_config_of(
+        ptr_param<const Dense> other);
 
-    void convert_to(
-        BatchDense<next_precision<ValueType>>* result) const override;
+    void convert_to(Dense<next_precision<ValueType>>* result) const override;
 
-    void move_to(BatchDense<next_precision<ValueType>>* result) override;
+    void move_to(Dense<next_precision<ValueType>>* result) override;
 
 
     /**
@@ -250,7 +249,7 @@ public:
      * array (if it resides on the same executor as the vector) or a copy of the
      * array on the correct executor.
      */
-    static std::unique_ptr<const BatchDense<value_type>> create_const(
+    static std::unique_ptr<const Dense<value_type>> create_const(
         std::shared_ptr<const Executor> exec, const batch_dim<2>& sizes,
         gko::detail::const_array_view<ValueType>&& values);
 
@@ -277,16 +276,16 @@ private:
 
 protected:
     /**
-     * Creates an uninitialized BatchDense matrix of the specified size.
+     * Creates an uninitialized Dense matrix of the specified size.
      *
      * @param exec  Executor associated to the matrix
      * @param size  size of the matrix
      */
-    BatchDense(std::shared_ptr<const Executor> exec,
-               const batch_dim<2>& size = batch_dim<2>{});
+    Dense(std::shared_ptr<const Executor> exec,
+          const batch_dim<2>& size = batch_dim<2>{});
 
     /**
-     * Creates a BatchDense matrix from an already allocated (and initialized)
+     * Creates a Dense matrix from an already allocated (and initialized)
      * array.
      *
      * @tparam ValuesArray  type of array of values
@@ -303,9 +302,9 @@ protected:
      *       original array data will not be used in the matrix.
      */
     template <typename ValuesArray>
-    BatchDense(std::shared_ptr<const Executor> exec, const batch_dim<2>& size,
-               ValuesArray&& values)
-        : EnableBatchLinOp<BatchDense>(exec, size),
+    Dense(std::shared_ptr<const Executor> exec, const batch_dim<2>& size,
+          ValuesArray&& values)
+        : EnableBatchLinOp<Dense>(exec, size),
           values_{exec, std::forward<ValuesArray>(values)}
     {
         // Ensure that the values array has the correct size
@@ -314,12 +313,12 @@ protected:
     }
 
     /**
-     * Creates a BatchDense matrix with the same configuration as the callers
+     * Creates a Dense matrix with the same configuration as the callers
      * matrix.
      *
-     * @returns a BatchDense matrix with the same configuration as the caller.
+     * @returns a Dense matrix with the same configuration as the caller.
      */
-    std::unique_ptr<BatchDense> create_with_same_config() const;
+    std::unique_ptr<Dense> create_with_same_config() const;
 
     virtual void apply_impl(const MultiVector<value_type>* b,
                             MultiVector<value_type>* x) const;

--- a/include/ginkgo/core/matrix/batch_dense.hpp
+++ b/include/ginkgo/core/matrix/batch_dense.hpp
@@ -218,8 +218,8 @@ public:
      *       significantly more memory efficient than the non-constant version,
      *       so always prefer this version.
      */
-    const value_type* get_const_values_for_item(size_type batch_id) const
-        noexcept
+    const value_type* get_const_values_for_item(
+        size_type batch_id) const noexcept
     {
         GKO_ASSERT(batch_id < this->get_num_batch_items());
         return values_.get_const_data() +

--- a/include/ginkgo/core/matrix/batch_dense.hpp
+++ b/include/ginkgo/core/matrix/batch_dense.hpp
@@ -133,6 +133,7 @@ public:
      */
     size_type get_cumulative_offset(size_type batch_id) const
     {
+        GKO_ASSERT(batch_id < this->get_num_batch_items());
         return batch_id * this->get_common_size()[0] *
                this->get_common_size()[1];
     }
@@ -198,6 +199,7 @@ public:
      */
     ValueType& at(size_type batch_id, size_type idx) noexcept
     {
+        GKO_ASSERT(batch_id < this->get_num_batch_items());
         return values_.get_data()[linearize_index(batch_id, idx)];
     }
 
@@ -206,6 +208,7 @@ public:
      */
     ValueType at(size_type batch_id, size_type idx) const noexcept
     {
+        GKO_ASSERT(batch_id < this->get_num_batch_items());
         return values_.get_const_data()[linearize_index(batch_id, idx)];
     }
 

--- a/include/ginkgo/core/matrix/batch_dense.hpp
+++ b/include/ginkgo/core/matrix/batch_dense.hpp
@@ -107,22 +107,6 @@ public:
     void move_to(Dense<next_precision<ValueType>>* result) override;
 
     /**
-     * Creates a mutable view (of MultiVector type) of the data owned by the
-     * matrix::Dense object. Does not perform any deep copies, but only
-     * returns a view of the underlying data.
-     *
-     * @return  a MultiVector object with a view of the data from the batch
-     * dense matrix.
-     */
-    std::unique_ptr<MultiVector<value_type>> create_multi_vector_view();
-
-    /**
-     * @copydoc create_const_multi_vector_view()
-     */
-    std::unique_ptr<const MultiVector<value_type>>
-    create_const_multi_vector_view() const;
-
-    /**
      * Creates a mutable view (of gko::matrix::Dense type) of one item of the
      * batch::matrix::Dense<value_type> object. Does not perform any deep
      * copies, but only returns a view of the data.
@@ -234,8 +218,8 @@ public:
      *       significantly more memory efficient than the non-constant version,
      *       so always prefer this version.
      */
-    const value_type* get_const_values_for_item(
-        size_type batch_id) const noexcept
+    const value_type* get_const_values_for_item(size_type batch_id) const
+        noexcept
     {
         GKO_ASSERT(batch_id < this->get_num_batch_items());
         return values_.get_const_data() +

--- a/include/ginkgo/core/matrix/batch_dense.hpp
+++ b/include/ginkgo/core/matrix/batch_dense.hpp
@@ -40,6 +40,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <ginkgo/core/base/array.hpp>
 #include <ginkgo/core/base/batch_lin_op.hpp>
+#include <ginkgo/core/base/batch_multi_vector.hpp>
 #include <ginkgo/core/base/executor.hpp>
 #include <ginkgo/core/base/mtx_io.hpp>
 #include <ginkgo/core/base/range_accessors.hpp>
@@ -85,7 +86,7 @@ public:
     using value_type = ValueType;
     using index_type = int32;
     using transposed_type = BatchDense<ValueType>;
-    using unbatch_type = matrix::Dense<ValueType>;
+    using unbatch_type = gko::matrix::Dense<ValueType>;
     using absolute_type = remove_complex<BatchDense>;
     using complex_type = to_complex<BatchDense>;
 
@@ -227,10 +228,9 @@ public:
      * array (if it resides on the same executor as the vector) or a copy of the
      * array on the correct executor.
      */
-    static std::unique_ptr<const MultiVector<value_type><ValueType>>
-    create_const(std::shared_ptr<const Executor> exec,
-                 const batch_dim<2>& sizes,
-                 gko::detail::const_array_view<ValueType>&& values);
+    static std::unique_ptr<const MultiVector<value_type>> create_const(
+        std::shared_ptr<const Executor> exec, const batch_dim<2>& sizes,
+        gko::detail::const_array_view<ValueType>&& values);
 
 private:
     inline size_type compute_num_elems(const batch_dim<2>& size)

--- a/include/ginkgo/core/matrix/batch_dense.hpp
+++ b/include/ginkgo/core/matrix/batch_dense.hpp
@@ -97,14 +97,7 @@ public:
      * @param other  The other matrix whose configuration needs to copied.
      */
     static std::unique_ptr<BatchDense> create_with_config_of(
-        const BatchDense* other)
-    {
-        // De-referencing `other` before calling the functions (instead of
-        // using operator `->`) is currently required to be compatible with
-        // CUDA 10.1.
-        // Otherwise, it results in a compile error.
-        return (*other).create_with_same_config();
-    }
+        ptr_param<const BatchDense> other);
 
     void convert_to(
         BatchDense<next_precision<ValueType>>* result) const override;
@@ -228,7 +221,7 @@ public:
      * array (if it resides on the same executor as the vector) or a copy of the
      * array on the correct executor.
      */
-    static std::unique_ptr<const MultiVector<value_type>> create_const(
+    static std::unique_ptr<const BatchDense<value_type>> create_const(
         std::shared_ptr<const Executor> exec, const batch_dim<2>& sizes,
         gko::detail::const_array_view<ValueType>&& values);
 

--- a/include/ginkgo/ginkgo.hpp
+++ b/include/ginkgo/ginkgo.hpp
@@ -108,6 +108,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <ginkgo/core/log/record.hpp>
 #include <ginkgo/core/log/stream.hpp>
 
+#include <ginkgo/core/matrix/batch_dense.hpp>
 #include <ginkgo/core/matrix/coo.hpp>
 #include <ginkgo/core/matrix/csr.hpp>
 #include <ginkgo/core/matrix/dense.hpp>

--- a/omp/CMakeLists.txt
+++ b/omp/CMakeLists.txt
@@ -23,6 +23,7 @@ target_sources(ginkgo_omp
     factorization/par_ict_kernels.cpp
     factorization/par_ilu_kernels.cpp
     factorization/par_ilut_kernels.cpp
+    matrix/batch_dense_kernels.cpp
     matrix/coo_kernels.cpp
     matrix/csr_kernels.cpp
     matrix/dense_kernels.cpp

--- a/omp/matrix/batch_dense_kernels.cpp
+++ b/omp/matrix/batch_dense_kernels.cpp
@@ -1,0 +1,129 @@
+/*******************************<GINKGO LICENSE>******************************
+Copyright (c) 2017-2023, the Ginkgo authors
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+******************************<GINKGO LICENSE>*******************************/
+
+#include "core/matrix/batch_dense_kernels.hpp"
+
+
+#include <algorithm>
+
+
+#include <ginkgo/core/base/array.hpp>
+#include <ginkgo/core/base/math.hpp>
+
+
+#include "reference/matrix/batch_struct.hpp"
+
+
+namespace gko {
+namespace kernels {
+namespace omp {
+/**
+ * @brief The BatchDense matrix format namespace.
+ * @ref BatchDense
+ * @ingroup batch_dense
+ */
+namespace batch_dense {
+
+
+#include "reference/matrix/batch_dense_kernels.hpp.inc"
+
+
+template <typename ValueType>
+void simple_apply(std::shared_ptr<const DefaultExecutor> exec,
+                  const batch::matrix::BatchDense<ValueType>* mat,
+                  const batch::MultiVector<ValueType>* b,
+                  MultiVector<ValueType>* x)
+{
+    const auto b_ub = host::get_batch_struct(b);
+    const auto x_ub = host::get_batch_struct(x);
+    const auto mat_ub = host::get_batch_struct(mat);
+#pragma omp parallel for
+    for (size_type batch = 0; batch < x->get_num_batch_items(); ++batch) {
+        const auto mat_item = batch::extract_batch_item(mat_ub, batch);
+        const auto b_item = batch::extract_batch_item(b_ub, batch);
+        const auto x_item = batch::extract_batch_item(x_ub, batch);
+        simple_apply_kernel(mat_item, b_item, x_item);
+    }
+}
+
+GKO_INSTANTIATE_FOR_EACH_VALUE_TYPE(
+    GKO_DECLARE_BATCH_DENSE_SIMPLE_APPLY_KERNEL);
+
+
+template <typename ValueType>
+void advanced_apply(std::shared_ptr<const DefaultExecutor> exec,
+                    const batch::MultiVector<ValueType>* alpha,
+                    const batch::matrix::BatchDense<ValueType>* a,
+                    const batch::MultiVector<ValueType>* b,
+                    const batch::MultiVector<ValueType>* beta,
+                    batch::MultiVector<ValueType>* c)
+{
+    const auto b_ub = host::get_batch_struct(b);
+    const auto x_ub = host::get_batch_struct(x);
+    const auto mat_ub = host::get_batch_struct(mat);
+    const auto alpha_ub = host::get_batch_struct(alpha);
+    const auto beta_ub = host::get_batch_struct(beta);
+    if (alpha->get_num_batch_items() > 1) {
+        GKO_ASSERT(alpha->get_num_batch_items() == x->get_num_batch_items());
+        GKO_ASSERT(beta->get_num_batch_items() == x->get_num_batch_items());
+#pragma omp parallel for
+        for (size_type batch = 0; batch < x->get_num_batch_items(); ++batch) {
+            const auto mat_item = batch::extract_batch_item(mat_ub, batch);
+            const auto b_item = batch::extract_batch_item(b_ub, batch);
+            const auto x_item = batch::extract_batch_item(x_ub, batch);
+            const auto alpha_item = batch::extract_batch_item(alpha_ub, batch);
+            const auto beta_item = batch::extract_batch_item(beta_ub, batch);
+            advanced_apply_kernel(alpha_item.values[0], mat_item, b_item,
+                                  beta_item.values[0], x_item);
+        }
+    } else {
+        const auto alpha_item = batch::extract_batch_item(alpha_ub, 0);
+        const auto beta_item = batch::extract_batch_item(beta_ub, 0);
+#pragma omp parallel for
+        for (size_type batch = 0; batch < x->get_num_batch_items(); ++batch) {
+            const auto mat_item = batch::extract_batch_item(mat_ub, batch);
+            const auto b_item = batch::extract_batch_item(b_ub, batch);
+            const auto x_item = batch::extract_batch_item(x_ub, batch);
+            advanced_apply_kernel(alpha_item.values[0], mat_item, b_item,
+                                  beta_item.values[0], x_item);
+        }
+    }
+}
+
+GKO_INSTANTIATE_FOR_EACH_VALUE_TYPE(
+    GKO_DECLARE_BATCH_DENSE_ADVANCED_APPLY_KERNEL);
+
+
+}  // namespace batch_dense
+}  // namespace omp
+}  // namespace kernels
+}  // namespace gko

--- a/omp/matrix/batch_dense_kernels.cpp
+++ b/omp/matrix/batch_dense_kernels.cpp
@@ -50,8 +50,8 @@ namespace gko {
 namespace kernels {
 namespace omp {
 /**
- * @brief The BatchDense matrix format namespace.
- * @ref BatchDense
+ * @brief The Dense matrix format namespace.
+ * @ref Dense
  * @ingroup batch_dense
  */
 namespace batch_dense {
@@ -62,7 +62,7 @@ namespace batch_dense {
 
 template <typename ValueType>
 void simple_apply(std::shared_ptr<const DefaultExecutor> exec,
-                  const batch::matrix::BatchDense<ValueType>* mat,
+                  const batch::matrix::Dense<ValueType>* mat,
                   const batch::MultiVector<ValueType>* b,
                   batch::MultiVector<ValueType>* x)
 {
@@ -85,7 +85,7 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_TYPE(
 template <typename ValueType>
 void advanced_apply(std::shared_ptr<const DefaultExecutor> exec,
                     const batch::MultiVector<ValueType>* alpha,
-                    const batch::matrix::BatchDense<ValueType>* mat,
+                    const batch::matrix::Dense<ValueType>* mat,
                     const batch::MultiVector<ValueType>* b,
                     const batch::MultiVector<ValueType>* beta,
                     batch::MultiVector<ValueType>* x)

--- a/omp/matrix/batch_dense_kernels.cpp
+++ b/omp/matrix/batch_dense_kernels.cpp
@@ -40,6 +40,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <ginkgo/core/base/math.hpp>
 
 
+#include "core/base/batch_struct.hpp"
+#include "core/matrix/batch_struct.hpp"
 #include "reference/matrix/batch_struct.hpp"
 
 
@@ -61,7 +63,7 @@ template <typename ValueType>
 void simple_apply(std::shared_ptr<const DefaultExecutor> exec,
                   const batch::matrix::BatchDense<ValueType>* mat,
                   const batch::MultiVector<ValueType>* b,
-                  MultiVector<ValueType>* x)
+                  batch::MultiVector<ValueType>* x)
 {
     const auto b_ub = host::get_batch_struct(b);
     const auto x_ub = host::get_batch_struct(x);

--- a/reference/CMakeLists.txt
+++ b/reference/CMakeLists.txt
@@ -25,6 +25,7 @@ target_sources(ginkgo_reference
     factorization/par_ict_kernels.cpp
     factorization/par_ilu_kernels.cpp
     factorization/par_ilut_kernels.cpp
+    matrix/batch_dense_kernels.cpp
     matrix/coo_kernels.cpp
     matrix/csr_kernels.cpp
     matrix/dense_kernels.cpp

--- a/reference/base/batch_struct.hpp
+++ b/reference/base/batch_struct.hpp
@@ -87,34 +87,6 @@ inline batch::multi_vector::uniform_batch<ValueType> get_batch_struct(
 }
 
 
-/**
- * Generates an immutable uniform batch struct from a batch of multi-vectors.
- */
-template <typename ValueType>
-inline batch::matrix::batch_dense::uniform_batch<const ValueType>
-get_batch_struct(const batch::matrix::BatchDense<ValueType>* const op)
-{
-    return {op->get_const_values(), op->get_num_batch_items(),
-            static_cast<int>(op->get_common_size()[1]),
-            static_cast<int>(op->get_common_size()[0]),
-            static_cast<int>(op->get_common_size()[1])};
-}
-
-
-/**
- * Generates a uniform batch struct from a batch of multi-vectors.
- */
-template <typename ValueType>
-inline batch::matrix::batch_dense::uniform_batch<ValueType> get_batch_struct(
-    batch::matrix::BatchDense<ValueType>* const op)
-{
-    return {op->get_values(), op->get_num_batch_items(),
-            static_cast<int>(op->get_common_size()[1]),
-            static_cast<int>(op->get_common_size()[0]),
-            static_cast<int>(op->get_common_size()[1])};
-}
-
-
 }  // namespace host
 }  // namespace kernels
 }  // namespace gko

--- a/reference/base/batch_struct.hpp
+++ b/reference/base/batch_struct.hpp
@@ -67,9 +67,9 @@ inline batch::multi_vector::uniform_batch<const ValueType> get_batch_struct(
     const batch::MultiVector<ValueType>* const op)
 {
     return {op->get_const_values(), op->get_num_batch_items(),
-            static_cast<int>(op->get_common_size()[1]),
-            static_cast<int>(op->get_common_size()[0]),
-            static_cast<int>(op->get_common_size()[1])};
+            static_cast<int32>(op->get_common_size()[1]),
+            static_cast<int32>(op->get_common_size()[0]),
+            static_cast<int32>(op->get_common_size()[1])};
 }
 
 
@@ -81,9 +81,9 @@ inline batch::multi_vector::uniform_batch<ValueType> get_batch_struct(
     batch::MultiVector<ValueType>* const op)
 {
     return {op->get_values(), op->get_num_batch_items(),
-            static_cast<int>(op->get_common_size()[1]),
-            static_cast<int>(op->get_common_size()[0]),
-            static_cast<int>(op->get_common_size()[1])};
+            static_cast<int32>(op->get_common_size()[1]),
+            static_cast<int32>(op->get_common_size()[0]),
+            static_cast<int32>(op->get_common_size()[1])};
 }
 
 

--- a/reference/base/batch_struct.hpp
+++ b/reference/base/batch_struct.hpp
@@ -87,6 +87,34 @@ inline batch::multi_vector::uniform_batch<ValueType> get_batch_struct(
 }
 
 
+/**
+ * Generates an immutable uniform batch struct from a batch of multi-vectors.
+ */
+template <typename ValueType>
+inline batch::matrix::batch_dense::uniform_batch<const ValueType>
+get_batch_struct(const batch::matrix::BatchDense<ValueType>* const op)
+{
+    return {op->get_const_values(), op->get_num_batch_items(),
+            static_cast<int>(op->get_common_size()[1]),
+            static_cast<int>(op->get_common_size()[0]),
+            static_cast<int>(op->get_common_size()[1])};
+}
+
+
+/**
+ * Generates a uniform batch struct from a batch of multi-vectors.
+ */
+template <typename ValueType>
+inline batch::matrix::batch_dense::uniform_batch<ValueType> get_batch_struct(
+    batch::matrix::BatchDense<ValueType>* const op)
+{
+    return {op->get_values(), op->get_num_batch_items(),
+            static_cast<int>(op->get_common_size()[1]),
+            static_cast<int>(op->get_common_size()[0]),
+            static_cast<int>(op->get_common_size()[1])};
+}
+
+
 }  // namespace host
 }  // namespace kernels
 }  // namespace gko

--- a/reference/matrix/batch_dense_kernels.cpp
+++ b/reference/matrix/batch_dense_kernels.cpp
@@ -95,30 +95,14 @@ void advanced_apply(std::shared_ptr<const DefaultExecutor> exec,
     const auto mat_ub = host::get_batch_struct(mat);
     const auto alpha_ub = host::get_batch_struct(alpha);
     const auto beta_ub = host::get_batch_struct(beta);
-    if (alpha->get_num_batch_items() > 1) {
-        GKO_ASSERT(alpha->get_num_batch_items() == x->get_num_batch_items());
-        GKO_ASSERT(beta->get_num_batch_items() == x->get_num_batch_items());
-        for (size_type batch = 0; batch < x->get_num_batch_items(); ++batch) {
-            const auto mat_item =
-                batch::matrix::extract_batch_item(mat_ub, batch);
-            const auto b_item = batch::extract_batch_item(b_ub, batch);
-            const auto x_item = batch::extract_batch_item(x_ub, batch);
-            const auto alpha_item = batch::extract_batch_item(alpha_ub, batch);
-            const auto beta_item = batch::extract_batch_item(beta_ub, batch);
-            advanced_apply_kernel(alpha_item.values[0], mat_item, b_item,
-                                  beta_item.values[0], x_item);
-        }
-    } else {
-        const auto alpha_item = batch::extract_batch_item(alpha_ub, 0);
-        const auto beta_item = batch::extract_batch_item(beta_ub, 0);
-        for (size_type batch = 0; batch < x->get_num_batch_items(); ++batch) {
-            const auto mat_item =
-                batch::matrix::extract_batch_item(mat_ub, batch);
-            const auto b_item = batch::extract_batch_item(b_ub, batch);
-            const auto x_item = batch::extract_batch_item(x_ub, batch);
-            advanced_apply_kernel(alpha_item.values[0], mat_item, b_item,
-                                  beta_item.values[0], x_item);
-        }
+    for (size_type batch = 0; batch < x->get_num_batch_items(); ++batch) {
+        const auto mat_item = batch::matrix::extract_batch_item(mat_ub, batch);
+        const auto b_item = batch::extract_batch_item(b_ub, batch);
+        const auto x_item = batch::extract_batch_item(x_ub, batch);
+        const auto alpha_item = batch::extract_batch_item(alpha_ub, batch);
+        const auto beta_item = batch::extract_batch_item(beta_ub, batch);
+        advanced_apply_kernel(alpha_item.values[0], mat_item, b_item,
+                              beta_item.values[0], x_item);
     }
 }
 

--- a/reference/matrix/batch_dense_kernels.cpp
+++ b/reference/matrix/batch_dense_kernels.cpp
@@ -51,8 +51,8 @@ namespace gko {
 namespace kernels {
 namespace reference {
 /**
- * @brief The BatchDense matrix format namespace.
- * @ref BatchDense
+ * @brief The Dense matrix format namespace.
+ * @ref Dense
  * @ingroup batch_dense
  */
 namespace batch_dense {
@@ -63,7 +63,7 @@ namespace batch_dense {
 
 template <typename ValueType>
 void simple_apply(std::shared_ptr<const DefaultExecutor> exec,
-                  const batch::matrix::BatchDense<ValueType>* mat,
+                  const batch::matrix::Dense<ValueType>* mat,
                   const batch::MultiVector<ValueType>* b,
                   batch::MultiVector<ValueType>* x)
 {
@@ -85,7 +85,7 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_TYPE(
 template <typename ValueType>
 void advanced_apply(std::shared_ptr<const DefaultExecutor> exec,
                     const batch::MultiVector<ValueType>* alpha,
-                    const batch::matrix::BatchDense<ValueType>* mat,
+                    const batch::matrix::Dense<ValueType>* mat,
                     const batch::MultiVector<ValueType>* b,
                     const batch::MultiVector<ValueType>* beta,
                     batch::MultiVector<ValueType>* x)

--- a/reference/matrix/batch_dense_kernels.cpp
+++ b/reference/matrix/batch_dense_kernels.cpp
@@ -1,0 +1,128 @@
+/*******************************<GINKGO LICENSE>******************************
+Copyright (c) 2017-2023, the Ginkgo authors
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+******************************<GINKGO LICENSE>*******************************/
+
+#include "core/matrix/batch_dense_kernels.hpp"
+
+
+#include <algorithm>
+
+
+#include <ginkgo/core/base/array.hpp>
+#include <ginkgo/core/base/math.hpp>
+#include <ginkgo/core/base/range_accessors.hpp>
+
+
+#include "core/matrix/batch_struct.hpp"
+#include "reference/matrix/batch_struct.hpp"
+
+
+namespace gko {
+namespace kernels {
+namespace reference {
+/**
+ * @brief The BatchDense matrix format namespace.
+ * @ref BatchDense
+ * @ingroup batch_dense
+ */
+namespace batch_dense {
+
+
+#include "reference/matrix/batch_dense_kernels.hpp.inc"
+
+
+template <typename ValueType>
+void simple_apply(std::shared_ptr<const DefaultExecutor> exec,
+                  const batch::matrix::BatchDense<ValueType>* mat,
+                  const batch::MultiVector<ValueType>* b,
+                  MultiVector<ValueType>* x)
+{
+    const auto b_ub = host::get_batch_struct(b);
+    const auto x_ub = host::get_batch_struct(x);
+    const auto mat_ub = host::get_batch_struct(mat);
+    for (size_type batch = 0; batch < x->get_num_batch_items(); ++batch) {
+        const auto mat_item = batch::extract_batch_item(mat_ub, batch);
+        const auto b_item = batch::extract_batch_item(b_ub, batch);
+        const auto x_item = batch::extract_batch_item(x_ub, batch);
+        simple_apply_kernel(mat_item, b_item, x_item);
+    }
+}
+
+GKO_INSTANTIATE_FOR_EACH_VALUE_TYPE(
+    GKO_DECLARE_BATCH_DENSE_SIMPLE_APPLY_KERNEL);
+
+
+template <typename ValueType>
+void advanced_apply(std::shared_ptr<const DefaultExecutor> exec,
+                    const batch::MultiVector<ValueType>* alpha,
+                    const batch::matrix::BatchDense<ValueType>* a,
+                    const batch::MultiVector<ValueType>* b,
+                    const batch::MultiVector<ValueType>* beta,
+                    batch::MultiVector<ValueType>* c)
+{
+    const auto b_ub = host::get_batch_struct(b);
+    const auto x_ub = host::get_batch_struct(x);
+    const auto mat_ub = host::get_batch_struct(mat);
+    const auto alpha_ub = host::get_batch_struct(alpha);
+    const auto beta_ub = host::get_batch_struct(beta);
+    if (alpha->get_num_batch_items() > 1) {
+        GKO_ASSERT(alpha->get_num_batch_items() == x->get_num_batch_items());
+        GKO_ASSERT(beta->get_num_batch_items() == x->get_num_batch_items());
+        for (size_type batch = 0; batch < x->get_num_batch_items(); ++batch) {
+            const auto mat_item = batch::extract_batch_item(mat_ub, batch);
+            const auto b_item = batch::extract_batch_item(b_ub, batch);
+            const auto x_item = batch::extract_batch_item(x_ub, batch);
+            const auto alpha_item = batch::extract_batch_item(alpha_ub, batch);
+            const auto beta_item = batch::extract_batch_item(beta_ub, batch);
+            advanced_apply_kernel(alpha_item.values[0], mat_item, b_item,
+                                  beta_item.values[0], x_item);
+        }
+    } else {
+        const auto alpha_item = batch::extract_batch_item(alpha_ub, 0);
+        const auto beta_item = batch::extract_batch_item(beta_ub, 0);
+        for (size_type batch = 0; batch < x->get_num_batch_items(); ++batch) {
+            const auto mat_item = batch::extract_batch_item(mat_ub, batch);
+            const auto b_item = batch::extract_batch_item(b_ub, batch);
+            const auto x_item = batch::extract_batch_item(x_ub, batch);
+            advanced_apply_kernel(alpha_item.values[0], mat_item, b_item,
+                                  beta_item.values[0], x_item);
+        }
+    }
+}
+
+GKO_INSTANTIATE_FOR_EACH_VALUE_TYPE(
+    GKO_DECLARE_BATCH_DENSE_ADVANCED_APPLY_KERNEL);
+
+
+}  // namespace batch_dense
+}  // namespace reference
+}  // namespace kernels
+}  // namespace gko

--- a/reference/matrix/batch_dense_kernels.cpp
+++ b/reference/matrix/batch_dense_kernels.cpp
@@ -41,7 +41,9 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <ginkgo/core/base/range_accessors.hpp>
 
 
+#include "core/base/batch_struct.hpp"
 #include "core/matrix/batch_struct.hpp"
+#include "reference/base/batch_struct.hpp"
 #include "reference/matrix/batch_struct.hpp"
 
 
@@ -63,13 +65,13 @@ template <typename ValueType>
 void simple_apply(std::shared_ptr<const DefaultExecutor> exec,
                   const batch::matrix::BatchDense<ValueType>* mat,
                   const batch::MultiVector<ValueType>* b,
-                  MultiVector<ValueType>* x)
+                  batch::MultiVector<ValueType>* x)
 {
     const auto b_ub = host::get_batch_struct(b);
     const auto x_ub = host::get_batch_struct(x);
     const auto mat_ub = host::get_batch_struct(mat);
     for (size_type batch = 0; batch < x->get_num_batch_items(); ++batch) {
-        const auto mat_item = batch::extract_batch_item(mat_ub, batch);
+        const auto mat_item = batch::matrix::extract_batch_item(mat_ub, batch);
         const auto b_item = batch::extract_batch_item(b_ub, batch);
         const auto x_item = batch::extract_batch_item(x_ub, batch);
         simple_apply_kernel(mat_item, b_item, x_item);
@@ -83,10 +85,10 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_TYPE(
 template <typename ValueType>
 void advanced_apply(std::shared_ptr<const DefaultExecutor> exec,
                     const batch::MultiVector<ValueType>* alpha,
-                    const batch::matrix::BatchDense<ValueType>* a,
+                    const batch::matrix::BatchDense<ValueType>* mat,
                     const batch::MultiVector<ValueType>* b,
                     const batch::MultiVector<ValueType>* beta,
-                    batch::MultiVector<ValueType>* c)
+                    batch::MultiVector<ValueType>* x)
 {
     const auto b_ub = host::get_batch_struct(b);
     const auto x_ub = host::get_batch_struct(x);
@@ -97,7 +99,8 @@ void advanced_apply(std::shared_ptr<const DefaultExecutor> exec,
         GKO_ASSERT(alpha->get_num_batch_items() == x->get_num_batch_items());
         GKO_ASSERT(beta->get_num_batch_items() == x->get_num_batch_items());
         for (size_type batch = 0; batch < x->get_num_batch_items(); ++batch) {
-            const auto mat_item = batch::extract_batch_item(mat_ub, batch);
+            const auto mat_item =
+                batch::matrix::extract_batch_item(mat_ub, batch);
             const auto b_item = batch::extract_batch_item(b_ub, batch);
             const auto x_item = batch::extract_batch_item(x_ub, batch);
             const auto alpha_item = batch::extract_batch_item(alpha_ub, batch);
@@ -109,7 +112,8 @@ void advanced_apply(std::shared_ptr<const DefaultExecutor> exec,
         const auto alpha_item = batch::extract_batch_item(alpha_ub, 0);
         const auto beta_item = batch::extract_batch_item(beta_ub, 0);
         for (size_type batch = 0; batch < x->get_num_batch_items(); ++batch) {
-            const auto mat_item = batch::extract_batch_item(mat_ub, batch);
+            const auto mat_item =
+                batch::matrix::extract_batch_item(mat_ub, batch);
             const auto b_item = batch::extract_batch_item(b_ub, batch);
             const auto x_item = batch::extract_batch_item(x_ub, batch);
             advanced_apply_kernel(alpha_item.values[0], mat_item, b_item,

--- a/reference/matrix/batch_dense_kernels.hpp.inc
+++ b/reference/matrix/batch_dense_kernels.hpp.inc
@@ -71,7 +71,7 @@ inline void advanced_apply_kernel(
     } else {
         for (int row = 0; row < c.num_rows; ++row) {
             for (int col = 0; col < c.num_rhs; ++col) {
-                c.values[row * c.stride + col] *= gko::zero<ValueType>();
+                c.values[row * c.stride + col] = gko::zero<ValueType>();
             }
         }
     }

--- a/reference/matrix/batch_dense_kernels.hpp.inc
+++ b/reference/matrix/batch_dense_kernels.hpp.inc
@@ -32,9 +32,9 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 template <typename ValueType>
 inline void simple_apply_kernel(
-    const gko::batch::batch_dense::batch_item<const ValueType>& a,
-    const gko::batch::batch_multi_vector::batch_item<const ValueType>& b,
-    const gko::batch::batch_multi_vector::batch_item<ValueType>& c)
+    const gko::batch::matrix::batch_dense::batch_item<const ValueType>& a,
+    const gko::batch::multi_vector::batch_item<const ValueType>& b,
+    const gko::batch::multi_vector::batch_item<ValueType>& c)
 {
     for (int row = 0; row < c.num_rows; ++row) {
         for (int col = 0; col < c.num_rhs; ++col) {
@@ -57,10 +57,10 @@ inline void simple_apply_kernel(
 template <typename ValueType>
 inline void advanced_apply_kernel(
     const ValueType alpha,
-    const gko::batch::batch_dense::batch_item<const ValueType>& a,
-    const gko::batch::batch_multi_vector::batch_item<const ValueType>& b,
+    const gko::batch::matrix::batch_dense::batch_item<const ValueType>& a,
+    const gko::batch::multi_vector::batch_item<const ValueType>& b,
     const ValueType beta,
-    const gko::batch::batch_multi_vector::batch_item<ValueType>& c)
+    const gko::batch::multi_vector::batch_item<ValueType>& c)
 {
     if (beta != gko::zero<ValueType>()) {
         for (int row = 0; row < c.num_rows; ++row) {

--- a/reference/matrix/batch_dense_kernels.hpp.inc
+++ b/reference/matrix/batch_dense_kernels.hpp.inc
@@ -32,7 +32,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 template <typename ValueType>
 inline void simple_apply_kernel(
-    const gko::batch::matrix::batch_dense::batch_item<const ValueType>& a,
+    const gko::batch::matrix::dense::batch_item<const ValueType>& a,
     const gko::batch::multi_vector::batch_item<const ValueType>& b,
     const gko::batch::multi_vector::batch_item<ValueType>& c)
 {
@@ -57,7 +57,7 @@ inline void simple_apply_kernel(
 template <typename ValueType>
 inline void advanced_apply_kernel(
     const ValueType alpha,
-    const gko::batch::matrix::batch_dense::batch_item<const ValueType>& a,
+    const gko::batch::matrix::dense::batch_item<const ValueType>& a,
     const gko::batch::multi_vector::batch_item<const ValueType>& b,
     const ValueType beta,
     const gko::batch::multi_vector::batch_item<ValueType>& c)

--- a/reference/matrix/batch_dense_kernels.hpp.inc
+++ b/reference/matrix/batch_dense_kernels.hpp.inc
@@ -1,0 +1,88 @@
+/*******************************<GINKGO LICENSE>******************************
+Copyright (c) 2017-2023, the Ginkgo authors
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+******************************<GINKGO LICENSE>*******************************/
+
+template <typename ValueType>
+inline void simple_apply_kernel(
+    const gko::batch::batch_dense::batch_item<const ValueType>& a,
+    const gko::batch::batch_multi_vector::batch_item<const ValueType>& b,
+    const gko::batch::batch_multi_vector::batch_item<ValueType>& c)
+{
+    for (int row = 0; row < c.num_rows; ++row) {
+        for (int col = 0; col < c.num_rhs; ++col) {
+            c.values[row * c.stride + col] = gko::zero<ValueType>();
+        }
+    }
+
+    for (int row = 0; row < c.num_rows; ++row) {
+        for (int inner = 0; inner < a.num_rhs; ++inner) {
+            for (int col = 0; col < c.num_rhs; ++col) {
+                c.values[row * c.stride + col] +=
+                    a.values[row * a.stride + inner] *
+                    b.values[inner * b.stride + col];
+            }
+        }
+    }
+}
+
+
+template <typename ValueType>
+inline void advanced_apply_kernel(
+    const ValueType alpha,
+    const gko::batch::batch_dense::batch_item<const ValueType>& a,
+    const gko::batch::batch_multi_vector::batch_item<const ValueType>& b,
+    const ValueType beta,
+    const gko::batch::batch_multi_vector::batch_item<ValueType>& c)
+{
+    if (beta != gko::zero<ValueType>()) {
+        for (int row = 0; row < c.num_rows; ++row) {
+            for (int col = 0; col < c.num_rhs; ++col) {
+                c.values[row * c.stride + col] *= beta;
+            }
+        }
+    } else {
+        for (int row = 0; row < c.num_rows; ++row) {
+            for (int col = 0; col < c.num_rhs; ++col) {
+                c.values[row * c.stride + col] *= gko::zero<ValueType>();
+            }
+        }
+    }
+
+    for (int row = 0; row < c.num_rows; ++row) {
+        for (int inner = 0; inner < a.num_rhs; ++inner) {
+            for (int col = 0; col < c.num_rhs; ++col) {
+                c.values[row * c.stride + col] +=
+                    alpha * a.values[row * a.stride + inner] *
+                    b.values[inner * b.stride + col];
+            }
+        }
+    }
+}

--- a/reference/matrix/batch_dense_kernels.hpp.inc
+++ b/reference/matrix/batch_dense_kernels.hpp.inc
@@ -43,7 +43,7 @@ inline void simple_apply_kernel(
     }
 
     for (int row = 0; row < c.num_rows; ++row) {
-        for (int inner = 0; inner < a.num_rhs; ++inner) {
+        for (int inner = 0; inner < a.num_cols; ++inner) {
             for (int col = 0; col < c.num_rhs; ++col) {
                 c.values[row * c.stride + col] +=
                     a.values[row * a.stride + inner] *
@@ -77,7 +77,7 @@ inline void advanced_apply_kernel(
     }
 
     for (int row = 0; row < c.num_rows; ++row) {
-        for (int inner = 0; inner < a.num_rhs; ++inner) {
+        for (int inner = 0; inner < a.num_cols; ++inner) {
             for (int col = 0; col < c.num_rhs; ++col) {
                 c.values[row * c.stride + col] +=
                     alpha * a.values[row * a.stride + inner] *

--- a/reference/matrix/batch_struct.hpp
+++ b/reference/matrix/batch_struct.hpp
@@ -62,7 +62,7 @@ namespace host {
 
 
 /**
- * Generates an immutable uniform batch struct from a batch of multi-vectors.
+ * Generates an immutable uniform batch struct from a batch of dense matrices.
  */
 template <typename ValueType>
 inline batch::matrix::batch_dense::uniform_batch<const ValueType>
@@ -76,7 +76,7 @@ get_batch_struct(const batch::matrix::Dense<ValueType>* const op)
 
 
 /**
- * Generates a uniform batch struct from a batch of multi-vectors.
+ * Generates a uniform batch struct from a batch of dense matrices.
  */
 template <typename ValueType>
 inline batch::matrix::batch_dense::uniform_batch<ValueType> get_batch_struct(

--- a/reference/matrix/batch_struct.hpp
+++ b/reference/matrix/batch_struct.hpp
@@ -36,9 +36,11 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <ginkgo/core/base/batch_multi_vector.hpp>
 #include <ginkgo/core/base/math.hpp>
+#include <ginkgo/core/matrix/batch_dense.hpp>
 
 
 #include "core/base/batch_struct.hpp"
+#include "core/matrix/batch_struct.hpp"
 
 
 namespace gko {

--- a/reference/matrix/batch_struct.hpp
+++ b/reference/matrix/batch_struct.hpp
@@ -39,6 +39,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <ginkgo/core/base/batch_multi_vector.hpp>
 #include <ginkgo/core/base/math.hpp>
+#include <ginkgo/core/base/types.hpp>
 #include <ginkgo/core/matrix/batch_dense.hpp>
 
 
@@ -67,13 +68,13 @@ namespace host {
  * Generates an immutable uniform batch struct from a batch of dense matrices.
  */
 template <typename ValueType>
-inline batch::matrix::batch_dense::uniform_batch<const ValueType>
-get_batch_struct(const batch::matrix::Dense<ValueType>* const op)
+inline batch::matrix::dense::uniform_batch<const ValueType> get_batch_struct(
+    const batch::matrix::Dense<ValueType>* const op)
 {
     return {op->get_const_values(), op->get_num_batch_items(),
-            static_cast<int>(op->get_common_size()[1]),
-            static_cast<int>(op->get_common_size()[0]),
-            static_cast<int>(op->get_common_size()[1])};
+            static_cast<int32>(op->get_common_size()[1]),
+            static_cast<int32>(op->get_common_size()[0]),
+            static_cast<int32>(op->get_common_size()[1])};
 }
 
 
@@ -81,13 +82,13 @@ get_batch_struct(const batch::matrix::Dense<ValueType>* const op)
  * Generates a uniform batch struct from a batch of dense matrices.
  */
 template <typename ValueType>
-inline batch::matrix::batch_dense::uniform_batch<ValueType> get_batch_struct(
+inline batch::matrix::dense::uniform_batch<ValueType> get_batch_struct(
     batch::matrix::Dense<ValueType>* const op)
 {
     return {op->get_values(), op->get_num_batch_items(),
-            static_cast<int>(op->get_common_size()[1]),
-            static_cast<int>(op->get_common_size()[0]),
-            static_cast<int>(op->get_common_size()[1])};
+            static_cast<int32>(op->get_common_size()[1]),
+            static_cast<int32>(op->get_common_size()[0]),
+            static_cast<int32>(op->get_common_size()[1])};
 }
 
 

--- a/reference/matrix/batch_struct.hpp
+++ b/reference/matrix/batch_struct.hpp
@@ -66,7 +66,7 @@ namespace host {
  */
 template <typename ValueType>
 inline batch::matrix::batch_dense::uniform_batch<const ValueType>
-get_batch_struct(const batch::matrix::BatchDense<ValueType>* const op)
+get_batch_struct(const batch::matrix::Dense<ValueType>* const op)
 {
     return {op->get_const_values(), op->get_num_batch_items(),
             static_cast<int>(op->get_common_size()[1]),
@@ -80,7 +80,7 @@ get_batch_struct(const batch::matrix::BatchDense<ValueType>* const op)
  */
 template <typename ValueType>
 inline batch::matrix::batch_dense::uniform_batch<ValueType> get_batch_struct(
-    batch::matrix::BatchDense<ValueType>* const op)
+    batch::matrix::Dense<ValueType>* const op)
 {
     return {op->get_values(), op->get_num_batch_items(),
             static_cast<int>(op->get_common_size()[1]),

--- a/reference/matrix/batch_struct.hpp
+++ b/reference/matrix/batch_struct.hpp
@@ -34,13 +34,15 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define GKO_REFERENCE_MATRIX_BATCH_STRUCT_HPP_
 
 
+#include "core/matrix/batch_struct.hpp"
+
+
 #include <ginkgo/core/base/batch_multi_vector.hpp>
 #include <ginkgo/core/base/math.hpp>
 #include <ginkgo/core/matrix/batch_dense.hpp>
 
 
 #include "core/base/batch_struct.hpp"
-#include "core/matrix/batch_struct.hpp"
 
 
 namespace gko {

--- a/reference/matrix/batch_struct.hpp
+++ b/reference/matrix/batch_struct.hpp
@@ -37,8 +37,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "core/matrix/batch_struct.hpp"
 
 
-#include <ginkgo/core/base/batch_multi_vector.hpp>
-#include <ginkgo/core/base/math.hpp>
 #include <ginkgo/core/base/types.hpp>
 #include <ginkgo/core/matrix/batch_dense.hpp>
 

--- a/reference/test/base/batch_multi_vector_kernels.cpp
+++ b/reference/test/base/batch_multi_vector_kernels.cpp
@@ -140,9 +140,9 @@ TYPED_TEST(MultiVector, ScalesData)
     auto ualpha = gko::batch::unbatch<gko::batch::MultiVector<T>>(alpha.get());
 
     this->mtx_0->scale(alpha.get());
+
     this->mtx_00->scale(ualpha[0].get());
     this->mtx_01->scale(ualpha[1].get());
-
     auto res =
         gko::batch::unbatch<gko::batch::MultiVector<T>>(this->mtx_0.get());
     GKO_ASSERT_MTX_NEAR(res[0].get(), this->mtx_00.get(), 0.);
@@ -158,9 +158,9 @@ TYPED_TEST(MultiVector, ScalesDataWithScalar)
     auto ualpha = gko::batch::unbatch<gko::batch::MultiVector<T>>(alpha.get());
 
     this->mtx_1->scale(alpha.get());
+
     this->mtx_10->scale(ualpha[0].get());
     this->mtx_11->scale(ualpha[1].get());
-
     auto res =
         gko::batch::unbatch<gko::batch::MultiVector<T>>(this->mtx_1.get());
     GKO_ASSERT_MTX_NEAR(res[0].get(), this->mtx_10.get(), 0.);
@@ -196,9 +196,9 @@ TYPED_TEST(MultiVector, AddsScaled)
     auto ualpha = gko::batch::unbatch<gko::batch::MultiVector<T>>(alpha.get());
 
     this->mtx_1->add_scaled(alpha.get(), this->mtx_0.get());
+
     this->mtx_10->add_scaled(ualpha[0].get(), this->mtx_00.get());
     this->mtx_11->add_scaled(ualpha[1].get(), this->mtx_01.get());
-
     auto res =
         gko::batch::unbatch<gko::batch::MultiVector<T>>(this->mtx_1.get());
     GKO_ASSERT_MTX_NEAR(res[0].get(), this->mtx_10.get(), 0.);
@@ -214,9 +214,9 @@ TYPED_TEST(MultiVector, AddsScaledWithScalar)
     auto ualpha = gko::batch::unbatch<gko::batch::MultiVector<T>>(alpha.get());
 
     this->mtx_1->add_scaled(alpha.get(), this->mtx_0.get());
+
     this->mtx_10->add_scaled(ualpha[0].get(), this->mtx_00.get());
     this->mtx_11->add_scaled(ualpha[1].get(), this->mtx_01.get());
-
     auto res =
         gko::batch::unbatch<gko::batch::MultiVector<T>>(this->mtx_1.get());
     GKO_ASSERT_MTX_NEAR(res[0].get(), this->mtx_10.get(), 0.);
@@ -244,9 +244,9 @@ TYPED_TEST(MultiVector, ComputesDot)
     auto ures = gko::batch::unbatch<gko::batch::MultiVector<T>>(result.get());
 
     this->mtx_0->compute_dot(this->mtx_1.get(), result.get());
+
     this->mtx_00->compute_dot(this->mtx_10.get(), ures[0].get());
     this->mtx_01->compute_dot(this->mtx_11.get(), ures[1].get());
-
     auto res = gko::batch::unbatch<gko::batch::MultiVector<T>>(result.get());
     GKO_ASSERT_MTX_NEAR(res[0].get(), ures[0].get(), 0.);
     GKO_ASSERT_MTX_NEAR(res[1].get(), ures[1].get(), 0.);
@@ -256,6 +256,7 @@ TYPED_TEST(MultiVector, ComputesDot)
 TYPED_TEST(MultiVector, ComputeDotFailsOnWrongInputSize)
 {
     using Mtx = typename TestFixture::Mtx;
+
     auto result =
         Mtx::create(this->exec, gko::batch_dim<2>(2, gko::dim<2>{1, 3}));
 
@@ -285,9 +286,9 @@ TYPED_TEST(MultiVector, ComputesConjDot)
     auto ures = gko::batch::unbatch<gko::batch::MultiVector<T>>(result.get());
 
     this->mtx_0->compute_conj_dot(this->mtx_1.get(), result.get());
+
     this->mtx_00->compute_conj_dot(this->mtx_10.get(), ures[0].get());
     this->mtx_01->compute_conj_dot(this->mtx_11.get(), ures[1].get());
-
     auto res = gko::batch::unbatch<gko::batch::MultiVector<T>>(result.get());
     GKO_ASSERT_MTX_NEAR(res[0].get(), ures[0].get(), 0.);
     GKO_ASSERT_MTX_NEAR(res[1].get(), ures[1].get(), 0.);
@@ -297,6 +298,7 @@ TYPED_TEST(MultiVector, ComputesConjDot)
 TYPED_TEST(MultiVector, ComputeConjDotFailsOnWrongInputSize)
 {
     using Mtx = typename TestFixture::Mtx;
+
     auto result =
         Mtx::create(this->exec, gko::batch_dim<2>(2, gko::dim<2>{1, 3}));
 

--- a/reference/test/base/batch_multi_vector_kernels.cpp
+++ b/reference/test/base/batch_multi_vector_kernels.cpp
@@ -137,13 +137,14 @@ TYPED_TEST(MultiVector, ScalesData)
     using T = typename TestFixture::value_type;
     auto alpha = gko::batch::initialize<Mtx>(
         {{{2.0, -2.0, 1.5}}, {{3.0, -1.0, 0.25}}}, this->exec);
-    auto ualpha = gko::batch::multivector::unbatch(alpha.get());
+    auto ualpha = gko::batch::unbatch<gko::batch::MultiVector<T>>(alpha.get());
 
     this->mtx_0->scale(alpha.get());
     this->mtx_00->scale(ualpha[0].get());
     this->mtx_01->scale(ualpha[1].get());
 
-    auto res = gko::batch::multivector::unbatch(this->mtx_0.get());
+    auto res =
+        gko::batch::unbatch<gko::batch::MultiVector<T>>(this->mtx_0.get());
     GKO_ASSERT_MTX_NEAR(res[0].get(), this->mtx_00.get(), 0.);
     GKO_ASSERT_MTX_NEAR(res[1].get(), this->mtx_01.get(), 0.);
 }
@@ -154,13 +155,14 @@ TYPED_TEST(MultiVector, ScalesDataWithScalar)
     using Mtx = typename TestFixture::Mtx;
     using T = typename TestFixture::value_type;
     auto alpha = gko::batch::initialize<Mtx>({{2.0}, {-2.0}}, this->exec);
-    auto ualpha = gko::batch::multivector::unbatch(alpha.get());
+    auto ualpha = gko::batch::unbatch<gko::batch::MultiVector<T>>(alpha.get());
 
     this->mtx_1->scale(alpha.get());
     this->mtx_10->scale(ualpha[0].get());
     this->mtx_11->scale(ualpha[1].get());
 
-    auto res = gko::batch::multivector::unbatch(this->mtx_1.get());
+    auto res =
+        gko::batch::unbatch<gko::batch::MultiVector<T>>(this->mtx_1.get());
     GKO_ASSERT_MTX_NEAR(res[0].get(), this->mtx_10.get(), 0.);
     GKO_ASSERT_MTX_NEAR(res[1].get(), this->mtx_11.get(), 0.);
 }
@@ -172,13 +174,14 @@ TYPED_TEST(MultiVector, ScalesDataWithMultipleScalars)
     using T = typename TestFixture::value_type;
     auto alpha = gko::batch::initialize<Mtx>(
         {{{2.0, -2.0, -1.5}}, {{2.0, -2.0, 3.0}}}, this->exec);
-    auto ualpha = gko::batch::multivector::unbatch(alpha.get());
+    auto ualpha = gko::batch::unbatch<gko::batch::MultiVector<T>>(alpha.get());
 
     this->mtx_1->scale(alpha.get());
     this->mtx_10->scale(ualpha[0].get());
     this->mtx_11->scale(ualpha[1].get());
 
-    auto res = gko::batch::multivector::unbatch(this->mtx_1.get());
+    auto res =
+        gko::batch::unbatch<gko::batch::MultiVector<T>>(this->mtx_1.get());
     GKO_ASSERT_MTX_NEAR(res[0].get(), this->mtx_10.get(), 0.);
     GKO_ASSERT_MTX_NEAR(res[1].get(), this->mtx_11.get(), 0.);
 }
@@ -190,13 +193,14 @@ TYPED_TEST(MultiVector, AddsScaled)
     using T = typename TestFixture::value_type;
     auto alpha = gko::batch::initialize<Mtx>(
         {{{2.0, -2.0, 1.5}}, {{2.0, -2.0, 3.0}}}, this->exec);
-    auto ualpha = gko::batch::multivector::unbatch(alpha.get());
+    auto ualpha = gko::batch::unbatch<gko::batch::MultiVector<T>>(alpha.get());
 
     this->mtx_1->add_scaled(alpha.get(), this->mtx_0.get());
     this->mtx_10->add_scaled(ualpha[0].get(), this->mtx_00.get());
     this->mtx_11->add_scaled(ualpha[1].get(), this->mtx_01.get());
 
-    auto res = gko::batch::multivector::unbatch(this->mtx_1.get());
+    auto res =
+        gko::batch::unbatch<gko::batch::MultiVector<T>>(this->mtx_1.get());
     GKO_ASSERT_MTX_NEAR(res[0].get(), this->mtx_10.get(), 0.);
     GKO_ASSERT_MTX_NEAR(res[1].get(), this->mtx_11.get(), 0.);
 }
@@ -207,13 +211,14 @@ TYPED_TEST(MultiVector, AddsScaledWithScalar)
     using Mtx = typename TestFixture::Mtx;
     using T = typename TestFixture::value_type;
     auto alpha = gko::batch::initialize<Mtx>({{2.0}, {-2.0}}, this->exec);
-    auto ualpha = gko::batch::multivector::unbatch(alpha.get());
+    auto ualpha = gko::batch::unbatch<gko::batch::MultiVector<T>>(alpha.get());
 
     this->mtx_1->add_scaled(alpha.get(), this->mtx_0.get());
     this->mtx_10->add_scaled(ualpha[0].get(), this->mtx_00.get());
     this->mtx_11->add_scaled(ualpha[1].get(), this->mtx_01.get());
 
-    auto res = gko::batch::multivector::unbatch(this->mtx_1.get());
+    auto res =
+        gko::batch::unbatch<gko::batch::MultiVector<T>>(this->mtx_1.get());
     GKO_ASSERT_MTX_NEAR(res[0].get(), this->mtx_10.get(), 0.);
     GKO_ASSERT_MTX_NEAR(res[1].get(), this->mtx_11.get(), 0.);
 }
@@ -236,13 +241,13 @@ TYPED_TEST(MultiVector, ComputesDot)
     using T = typename TestFixture::value_type;
     auto result =
         Mtx::create(this->exec, gko::batch_dim<2>(2, gko::dim<2>{1, 3}));
-    auto ures = gko::batch::multivector::unbatch(result.get());
+    auto ures = gko::batch::unbatch<gko::batch::MultiVector<T>>(result.get());
 
     this->mtx_0->compute_dot(this->mtx_1.get(), result.get());
     this->mtx_00->compute_dot(this->mtx_10.get(), ures[0].get());
     this->mtx_01->compute_dot(this->mtx_11.get(), ures[1].get());
 
-    auto res = gko::batch::multivector::unbatch(result.get());
+    auto res = gko::batch::unbatch<gko::batch::MultiVector<T>>(result.get());
     GKO_ASSERT_MTX_NEAR(res[0].get(), ures[0].get(), 0.);
     GKO_ASSERT_MTX_NEAR(res[1].get(), ures[1].get(), 0.);
 }
@@ -277,13 +282,13 @@ TYPED_TEST(MultiVector, ComputesConjDot)
     using T = typename TestFixture::value_type;
     auto result =
         Mtx::create(this->exec, gko::batch_dim<2>(2, gko::dim<2>{1, 3}));
-    auto ures = gko::batch::multivector::unbatch(result.get());
+    auto ures = gko::batch::unbatch<gko::batch::MultiVector<T>>(result.get());
 
     this->mtx_0->compute_conj_dot(this->mtx_1.get(), result.get());
     this->mtx_00->compute_conj_dot(this->mtx_10.get(), ures[0].get());
     this->mtx_01->compute_conj_dot(this->mtx_11.get(), ures[1].get());
 
-    auto res = gko::batch::multivector::unbatch(result.get());
+    auto res = gko::batch::unbatch<gko::batch::MultiVector<T>>(result.get());
     GKO_ASSERT_MTX_NEAR(res[0].get(), ures[0].get(), 0.);
     GKO_ASSERT_MTX_NEAR(res[1].get(), ures[1].get(), 0.);
 }
@@ -359,8 +364,9 @@ TYPED_TEST(MultiVector, ConvertsToPrecision)
     this->mtx_1->convert_to(tmp.get());
     tmp->convert_to(res.get());
 
-    auto ures = gko::batch::multivector::unbatch(res.get());
-    auto umtx = gko::batch::multivector::unbatch(this->mtx_1.get());
+    auto ures = gko::batch::unbatch<gko::batch::MultiVector<T>>(res.get());
+    auto umtx =
+        gko::batch::unbatch<gko::batch::MultiVector<T>>(this->mtx_1.get());
     GKO_ASSERT_MTX_NEAR(umtx[0].get(), ures[0].get(), residual);
     GKO_ASSERT_MTX_NEAR(umtx[1].get(), ures[1].get(), residual);
 }
@@ -382,8 +388,9 @@ TYPED_TEST(MultiVector, MovesToPrecision)
     this->mtx_1->move_to(tmp.get());
     tmp->move_to(res.get());
 
-    auto ures = gko::batch::multivector::unbatch(res.get());
-    auto umtx = gko::batch::multivector::unbatch(this->mtx_1.get());
+    auto ures = gko::batch::unbatch<gko::batch::MultiVector<T>>(res.get());
+    auto umtx =
+        gko::batch::unbatch<gko::batch::MultiVector<T>>(this->mtx_1.get());
     GKO_ASSERT_MTX_NEAR(umtx[0].get(), ures[0].get(), residual);
     GKO_ASSERT_MTX_NEAR(umtx[1].get(), ures[1].get(), residual);
 }

--- a/reference/test/matrix/CMakeLists.txt
+++ b/reference/test/matrix/CMakeLists.txt
@@ -1,3 +1,4 @@
+ginkgo_create_test(batch_dense_kernels)
 ginkgo_create_test(coo_kernels)
 ginkgo_create_test(csr_kernels)
 ginkgo_create_test(dense_kernels)

--- a/reference/test/matrix/batch_dense_kernels.cpp
+++ b/reference/test/matrix/batch_dense_kernels.cpp
@@ -129,6 +129,33 @@ TYPED_TEST(BatchDense, AppliesToBatchMultiVector)
 }
 
 
+TYPED_TEST(BatchDense, AppliesLinearCombinationWithSameAlphaToBatchMultiVector)
+{
+    using Mtx = typename TestFixture::Mtx;
+    using MVec = typename TestFixture::MVec;
+    using DenseMtx = typename TestFixture::DenseMtx;
+    using T = typename TestFixture::value_type;
+    auto alpha = gko::batch::initialize<MVec>(2, {1.5}, this->exec);
+    auto beta = gko::batch::initialize<MVec>(2, {-4.0}, this->exec);
+    auto alpha0 = gko::initialize<DenseMtx>({1.5}, this->exec);
+    auto alpha1 = gko::initialize<DenseMtx>({1.5}, this->exec);
+    auto beta0 = gko::initialize<DenseMtx>({-4.0}, this->exec);
+    auto beta1 = gko::initialize<DenseMtx>({-4.0}, this->exec);
+
+    this->mtx_0->apply(alpha.get(), this->b_0.get(), beta.get(),
+                       this->x_0.get());
+    this->mtx_00->apply(alpha0.get(), this->b_00.get(), beta0.get(),
+                        this->x_00.get());
+    this->mtx_01->apply(alpha1.get(), this->b_01.get(), beta1.get(),
+                        this->x_01.get());
+
+    auto res = gko::batch::unbatch<gko::batch::MultiVector<T>>(this->x_0.get());
+
+    GKO_ASSERT_MTX_NEAR(res[0].get(), this->x_00.get(), 0.);
+    GKO_ASSERT_MTX_NEAR(res[1].get(), this->x_01.get(), 0.);
+}
+
+
 TYPED_TEST(BatchDense, AppliesLinearCombinationToBatchMultiVector)
 {
     using Mtx = typename TestFixture::Mtx;

--- a/reference/test/matrix/batch_dense_kernels.cpp
+++ b/reference/test/matrix/batch_dense_kernels.cpp
@@ -1,0 +1,219 @@
+/*******************************<GINKGO LICENSE>******************************
+Copyright (c) 2017-2023, the Ginkgo authors
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+******************************<GINKGO LICENSE>*******************************/
+
+#include <ginkgo/core/matrix/batch_dense.hpp>
+
+
+#include <complex>
+#include <memory>
+#include <random>
+
+
+#include <gtest/gtest.h>
+
+
+#include <ginkgo/core/base/batch_multi_vector.hpp>
+#include <ginkgo/core/base/exception.hpp>
+#include <ginkgo/core/base/executor.hpp>
+#include <ginkgo/core/base/math.hpp>
+#include <ginkgo/core/matrix/dense.hpp>
+
+
+#include "core/matrix/batch_dense_kernels.hpp"
+#include "core/test/utils.hpp"
+
+
+template <typename T>
+class BatchDense : public ::testing::Test {
+protected:
+    using value_type = T;
+    using size_type = gko::size_type;
+    using Mtx = gko::batch::matrix::BatchDense<value_type>;
+    using MVec = gko::batch::MultiVector<value_type>;
+    using DenseMtx = gko::matrix::Dense<value_type>;
+    using ComplexMtx = gko::to_complex<Mtx>;
+    using RealMtx = gko::remove_complex<Mtx>;
+    BatchDense()
+        : exec(gko::ReferenceExecutor::create()),
+          mtx_0(gko::batch::initialize<Mtx>(
+              {{I<T>({1.0, -1.0, 1.5}), I<T>({-2.0, 2.0, 3.0})},
+               {{1.0, -2.0, -0.5}, {1.0, -2.5, 4.0}}},
+              exec)),
+          mtx_00(gko::initialize<DenseMtx>(
+              {I<T>({1.0, -1.0, 1.5}), I<T>({-2.0, 2.0, 3.0})}, exec)),
+          mtx_01(gko::initialize<DenseMtx>(
+              {I<T>({1.0, -2.0, -0.5}), I<T>({1.0, -2.5, 4.0})}, exec)),
+          b_0(gko::batch::initialize<MVec>(
+              {{I<T>({1.0, 0.0, 1.0}), I<T>({2.0, 0.0, 1.0}),
+                I<T>({1.0, 0.0, 2.0})},
+               {I<T>({-1.0, 1.0, 1.0}), I<T>({1.0, -1.0, 1.0}),
+                I<T>({1.0, 0.0, 2.0})}},
+              exec)),
+          b_00(gko::initialize<DenseMtx>(
+              {I<T>({1.0, 0.0, 1.0}), I<T>({2.0, 0.0, 1.0}),
+               I<T>({1.0, 0.0, 2.0})},
+              exec)),
+          b_01(gko::initialize<DenseMtx>(
+              {I<T>({-1.0, 1.0, 1.0}), I<T>({1.0, -1.0, 1.0}),
+               I<T>({1.0, 0.0, 2.0})},
+              exec)),
+          x_0(gko::batch::initialize<MVec>(
+              {{I<T>({2.0, 0.0, 1.0}), I<T>({2.0, 0.0, 2.0})},
+               {I<T>({-2.0, 1.0, 1.0}), I<T>({1.0, -1.0, -1.0})}},
+              exec)),
+          x_00(gko::initialize<DenseMtx>(
+              {I<T>({2.0, 0.0, 1.0}), I<T>({2.0, 0.0, 2.0})}, exec)),
+          x_01(gko::initialize<DenseMtx>(
+              {I<T>({-2.0, 1.0, 1.0}), I<T>({1.0, -1.0, -1.0})}, exec))
+    {}
+
+    std::shared_ptr<const gko::ReferenceExecutor> exec;
+    std::unique_ptr<Mtx> mtx_0;
+    std::unique_ptr<DenseMtx> mtx_00;
+    std::unique_ptr<DenseMtx> mtx_01;
+    std::unique_ptr<MVec> b_0;
+    std::unique_ptr<DenseMtx> b_00;
+    std::unique_ptr<DenseMtx> b_01;
+    std::unique_ptr<MVec> x_0;
+    std::unique_ptr<DenseMtx> x_00;
+    std::unique_ptr<DenseMtx> x_01;
+
+    std::ranlux48 rand_engine;
+};
+
+
+TYPED_TEST_SUITE(BatchDense, gko::test::ValueTypes);
+
+
+TYPED_TEST(BatchDense, AppliesToBatchMultiVector)
+{
+    using T = typename TestFixture::value_type;
+
+    this->mtx_0->apply(this->b_0.get(), this->x_0.get());
+    this->mtx_00->apply(this->b_00.get(), this->x_00.get());
+    this->mtx_01->apply(this->b_01.get(), this->x_01.get());
+
+    auto res = gko::batch::unbatch<gko::batch::MultiVector<T>>(this->x_0.get());
+
+    GKO_ASSERT_MTX_NEAR(res[0].get(), this->x_00.get(), 0.);
+    GKO_ASSERT_MTX_NEAR(res[1].get(), this->x_01.get(), 0.);
+}
+
+
+TYPED_TEST(BatchDense, AppliesLinearCombinationToBatchMultiVector)
+{
+    using Mtx = typename TestFixture::Mtx;
+    using MVec = typename TestFixture::MVec;
+    using DenseMtx = typename TestFixture::DenseMtx;
+    using T = typename TestFixture::value_type;
+    auto alpha = gko::batch::initialize<MVec>({{1.5}, {-1.0}}, this->exec);
+    auto beta = gko::batch::initialize<MVec>({{2.5}, {-4.0}}, this->exec);
+    auto alpha0 = gko::initialize<DenseMtx>({1.5}, this->exec);
+    auto alpha1 = gko::initialize<DenseMtx>({-1.0}, this->exec);
+    auto beta0 = gko::initialize<DenseMtx>({2.5}, this->exec);
+    auto beta1 = gko::initialize<DenseMtx>({-4.0}, this->exec);
+
+    this->mtx_0->apply(alpha.get(), this->b_0.get(), beta.get(),
+                       this->x_0.get());
+    this->mtx_00->apply(alpha0.get(), this->b_00.get(), beta0.get(),
+                        this->x_00.get());
+    this->mtx_01->apply(alpha1.get(), this->b_01.get(), beta1.get(),
+                        this->x_01.get());
+
+    auto res = gko::batch::unbatch<gko::batch::MultiVector<T>>(this->x_0.get());
+
+    GKO_ASSERT_MTX_NEAR(res[0].get(), this->x_00.get(), 0.);
+    GKO_ASSERT_MTX_NEAR(res[1].get(), this->x_01.get(), 0.);
+}
+
+
+TYPED_TEST(BatchDense, ApplyFailsOnWrongNumberOfResultCols)
+{
+    using MVec = typename TestFixture::MVec;
+    auto res = MVec::create(this->exec, gko::batch_dim<2>{2, gko::dim<2>{2}});
+
+    ASSERT_THROW(this->mtx_0->apply(this->b_0.get(), res.get()),
+                 gko::DimensionMismatch);
+}
+
+
+TYPED_TEST(BatchDense, ApplyFailsOnWrongNumberOfResultRows)
+{
+    using MVec = typename TestFixture::MVec;
+    auto res = MVec::create(this->exec, gko::batch_dim<2>{2, gko::dim<2>{3}});
+
+    ASSERT_THROW(this->mtx_0->apply(this->b_0.get(), res.get()),
+                 gko::DimensionMismatch);
+}
+
+
+TYPED_TEST(BatchDense, ApplyFailsOnWrongInnerDimension)
+{
+    using MVec = typename TestFixture::MVec;
+    auto res =
+        MVec::create(this->exec, gko::batch_dim<2>{2, gko::dim<2>{2, 3}});
+
+    ASSERT_THROW(this->mtx_0->apply(res.get(), this->x_0.get()),
+                 gko::DimensionMismatch);
+}
+
+
+TYPED_TEST(BatchDense, AdvancedApplyFailsOnWrongInnerDimension)
+{
+    using MVec = typename TestFixture::MVec;
+    auto res =
+        MVec::create(this->exec, gko::batch_dim<2>{2, gko::dim<2>{2, 3}});
+    auto alpha =
+        MVec::create(this->exec, gko::batch_dim<2>{2, gko::dim<2>{1, 1}});
+    auto beta =
+        MVec::create(this->exec, gko::batch_dim<2>{2, gko::dim<2>{1, 1}});
+
+    ASSERT_THROW(
+        this->mtx_0->apply(alpha.get(), res.get(), beta.get(), this->x_0.get()),
+        gko::DimensionMismatch);
+}
+
+
+TYPED_TEST(BatchDense, AdvancedApplyFailsOnWrongAlphaDimension)
+{
+    using MVec = typename TestFixture::MVec;
+    auto res =
+        MVec::create(this->exec, gko::batch_dim<2>{2, gko::dim<2>{3, 3}});
+    auto alpha =
+        MVec::create(this->exec, gko::batch_dim<2>{2, gko::dim<2>{2, 1}});
+    auto beta =
+        MVec::create(this->exec, gko::batch_dim<2>{2, gko::dim<2>{1, 1}});
+
+    ASSERT_THROW(
+        this->mtx_0->apply(alpha.get(), res.get(), beta.get(), this->x_0.get()),
+        gko::DimensionMismatch);
+}

--- a/reference/test/matrix/batch_dense_kernels.cpp
+++ b/reference/test/matrix/batch_dense_kernels.cpp
@@ -53,16 +53,16 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
 template <typename T>
-class BatchDense : public ::testing::Test {
+class Dense : public ::testing::Test {
 protected:
     using value_type = T;
     using size_type = gko::size_type;
-    using Mtx = gko::batch::matrix::BatchDense<value_type>;
+    using Mtx = gko::batch::matrix::Dense<value_type>;
     using MVec = gko::batch::MultiVector<value_type>;
     using DenseMtx = gko::matrix::Dense<value_type>;
     using ComplexMtx = gko::to_complex<Mtx>;
     using RealMtx = gko::remove_complex<Mtx>;
-    BatchDense()
+    Dense()
         : exec(gko::ReferenceExecutor::create()),
           mtx_0(gko::batch::initialize<Mtx>(
               {{I<T>({1.0, -1.0, 1.5}), I<T>({-2.0, 2.0, 3.0})},
@@ -111,10 +111,10 @@ protected:
 };
 
 
-TYPED_TEST_SUITE(BatchDense, gko::test::ValueTypes);
+TYPED_TEST_SUITE(Dense, gko::test::ValueTypes);
 
 
-TYPED_TEST(BatchDense, AppliesToBatchMultiVector)
+TYPED_TEST(Dense, AppliesToBatchMultiVector)
 {
     using T = typename TestFixture::value_type;
 
@@ -129,7 +129,7 @@ TYPED_TEST(BatchDense, AppliesToBatchMultiVector)
 }
 
 
-TYPED_TEST(BatchDense, AppliesLinearCombinationWithSameAlphaToBatchMultiVector)
+TYPED_TEST(Dense, AppliesLinearCombinationWithSameAlphaToBatchMultiVector)
 {
     using Mtx = typename TestFixture::Mtx;
     using MVec = typename TestFixture::MVec;
@@ -156,7 +156,7 @@ TYPED_TEST(BatchDense, AppliesLinearCombinationWithSameAlphaToBatchMultiVector)
 }
 
 
-TYPED_TEST(BatchDense, AppliesLinearCombinationToBatchMultiVector)
+TYPED_TEST(Dense, AppliesLinearCombinationToBatchMultiVector)
 {
     using Mtx = typename TestFixture::Mtx;
     using MVec = typename TestFixture::MVec;
@@ -183,7 +183,7 @@ TYPED_TEST(BatchDense, AppliesLinearCombinationToBatchMultiVector)
 }
 
 
-TYPED_TEST(BatchDense, ApplyFailsOnWrongNumberOfResultCols)
+TYPED_TEST(Dense, ApplyFailsOnWrongNumberOfResultCols)
 {
     using MVec = typename TestFixture::MVec;
     auto res = MVec::create(this->exec, gko::batch_dim<2>{2, gko::dim<2>{2}});
@@ -193,7 +193,7 @@ TYPED_TEST(BatchDense, ApplyFailsOnWrongNumberOfResultCols)
 }
 
 
-TYPED_TEST(BatchDense, ApplyFailsOnWrongNumberOfResultRows)
+TYPED_TEST(Dense, ApplyFailsOnWrongNumberOfResultRows)
 {
     using MVec = typename TestFixture::MVec;
     auto res = MVec::create(this->exec, gko::batch_dim<2>{2, gko::dim<2>{3}});
@@ -203,7 +203,7 @@ TYPED_TEST(BatchDense, ApplyFailsOnWrongNumberOfResultRows)
 }
 
 
-TYPED_TEST(BatchDense, ApplyFailsOnWrongInnerDimension)
+TYPED_TEST(Dense, ApplyFailsOnWrongInnerDimension)
 {
     using MVec = typename TestFixture::MVec;
     auto res =
@@ -214,7 +214,7 @@ TYPED_TEST(BatchDense, ApplyFailsOnWrongInnerDimension)
 }
 
 
-TYPED_TEST(BatchDense, AdvancedApplyFailsOnWrongInnerDimension)
+TYPED_TEST(Dense, AdvancedApplyFailsOnWrongInnerDimension)
 {
     using MVec = typename TestFixture::MVec;
     auto res =
@@ -230,7 +230,7 @@ TYPED_TEST(BatchDense, AdvancedApplyFailsOnWrongInnerDimension)
 }
 
 
-TYPED_TEST(BatchDense, AdvancedApplyFailsOnWrongAlphaDimension)
+TYPED_TEST(Dense, AdvancedApplyFailsOnWrongAlphaDimension)
 {
     using MVec = typename TestFixture::MVec;
     auto res =

--- a/reference/test/matrix/batch_dense_kernels.cpp
+++ b/reference/test/matrix/batch_dense_kernels.cpp
@@ -126,32 +126,6 @@ TYPED_TEST(Dense, AppliesToBatchMultiVector)
 }
 
 
-TYPED_TEST(Dense, AppliesLinearCombinationWithSameAlphaToBatchMultiVector)
-{
-    using BMtx = typename TestFixture::BMtx;
-    using BMVec = typename TestFixture::BMVec;
-    using DenseMtx = typename TestFixture::DenseMtx;
-    using T = typename TestFixture::value_type;
-    auto alpha = gko::batch::initialize<BMVec>(2, {1.5}, this->exec);
-    auto beta = gko::batch::initialize<BMVec>(2, {-4.0}, this->exec);
-    auto alpha0 = gko::initialize<DenseMtx>({1.5}, this->exec);
-    auto alpha1 = gko::initialize<DenseMtx>({1.5}, this->exec);
-    auto beta0 = gko::initialize<DenseMtx>({-4.0}, this->exec);
-    auto beta1 = gko::initialize<DenseMtx>({-4.0}, this->exec);
-
-    this->mtx_0->apply(alpha.get(), this->b_0.get(), beta.get(),
-                       this->x_0.get());
-
-    this->mtx_00->apply(alpha0.get(), this->b_00.get(), beta0.get(),
-                        this->x_00.get());
-    this->mtx_01->apply(alpha1.get(), this->b_01.get(), beta1.get(),
-                        this->x_01.get());
-    auto res = gko::batch::unbatch<gko::batch::MultiVector<T>>(this->x_0.get());
-    GKO_ASSERT_MTX_NEAR(res[0].get(), this->x_00.get(), 0.);
-    GKO_ASSERT_MTX_NEAR(res[1].get(), this->x_01.get(), 0.);
-}
-
-
 TYPED_TEST(Dense, AppliesLinearCombinationToBatchMultiVector)
 {
     using BMtx = typename TestFixture::BMtx;

--- a/reference/test/matrix/batch_dense_kernels.cpp
+++ b/reference/test/matrix/batch_dense_kernels.cpp
@@ -107,7 +107,7 @@ protected:
     std::unique_ptr<DenseMtx> x_00;
     std::unique_ptr<DenseMtx> x_01;
 
-    std::ranlux48 rand_engine;
+    std::default_random_engine rand_engine;
 };
 
 

--- a/test/matrix/CMakeLists.txt
+++ b/test/matrix/CMakeLists.txt
@@ -1,3 +1,4 @@
+ginkgo_create_common_test(batch_dense_kernels DISABLE_EXECUTORS dpcpp hip cuda)
 ginkgo_create_common_device_test(csr_kernels)
 ginkgo_create_common_test(csr_kernels2)
 ginkgo_create_common_test(coo_kernels)

--- a/test/matrix/CMakeLists.txt
+++ b/test/matrix/CMakeLists.txt
@@ -1,4 +1,4 @@
-ginkgo_create_common_test(batch_dense_kernels DISABLE_EXECUTORS dpcpp hip cuda)
+ginkgo_create_common_test(batch_dense_kernels DISABLE_EXECUTORS dpcpp)
 ginkgo_create_common_device_test(csr_kernels)
 ginkgo_create_common_test(csr_kernels2)
 ginkgo_create_common_test(coo_kernels)

--- a/test/matrix/CMakeLists.txt
+++ b/test/matrix/CMakeLists.txt
@@ -1,4 +1,4 @@
-ginkgo_create_common_test(batch_dense_kernels DISABLE_EXECUTORS dpcpp)
+ginkgo_create_common_test(batch_dense_kernels)
 ginkgo_create_common_device_test(csr_kernels)
 ginkgo_create_common_test(csr_kernels2)
 ginkgo_create_common_test(coo_kernels)

--- a/test/matrix/batch_dense_kernels.cpp
+++ b/test/matrix/batch_dense_kernels.cpp
@@ -55,9 +55,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 class Dense : public CommonTestFixture {
 protected:
-    using vtype = double;
-    using Mtx = gko::batch::matrix::Dense<vtype>;
-    using MVec = gko::batch::MultiVector<vtype>;
+    using Mtx = gko::batch::matrix::Dense<value_type>;
+    using MVec = gko::batch::MultiVector<value_type>;
 
     Dense() : rand_engine(15) {}
 
@@ -87,7 +86,7 @@ protected:
         expected = MVec::create(
             ref,
             gko::batch_dim<2>(batch_size, gko::dim<2>{num_rows, num_vecs}));
-        expected->fill(gko::one<vtype>());
+        expected->fill(gko::one<value_type>());
         dresult = gko::clone(exec, expected);
     }
 
@@ -114,7 +113,7 @@ TEST_F(Dense, SingleVectorApplyIsEquivalentToRef)
     x->apply(y.get(), expected.get());
     dx->apply(dy.get(), dresult.get());
 
-    GKO_ASSERT_BATCH_MTX_NEAR(dresult, expected, 1e-14);
+    GKO_ASSERT_BATCH_MTX_NEAR(dresult, expected, r<value_type>::value);
 }
 
 
@@ -125,5 +124,5 @@ TEST_F(Dense, SingleVectorAdvancedApplyIsEquivalentToRef)
     x->apply(alpha.get(), y.get(), beta.get(), expected.get());
     dx->apply(dalpha.get(), dy.get(), dbeta.get(), dresult.get());
 
-    GKO_ASSERT_BATCH_MTX_NEAR(dresult, expected, 1e-14);
+    GKO_ASSERT_BATCH_MTX_NEAR(dresult, expected, r<value_type>::value);
 }

--- a/test/matrix/batch_dense_kernels.cpp
+++ b/test/matrix/batch_dense_kernels.cpp
@@ -75,11 +75,11 @@ protected:
     {
         const int num_rows = 252;
         const int num_cols = 32;
-        x = gen_mtx<BMtx>(batch_size, num_rows, num_cols);
+        mat = gen_mtx<BMtx>(batch_size, num_rows, num_cols);
         y = gen_mtx<BMVec>(batch_size, num_cols, num_vecs);
         alpha = gen_mtx<BMVec>(batch_size, 1, 1);
         beta = gen_mtx<BMVec>(batch_size, 1, 1);
-        dx = gko::clone(exec, x);
+        dmat = gko::clone(exec, mat);
         dy = gko::clone(exec, y);
         dalpha = gko::clone(exec, alpha);
         dbeta = gko::clone(exec, beta);
@@ -93,13 +93,13 @@ protected:
     std::default_random_engine rand_engine;
 
     const size_t batch_size = 11;
-    std::unique_ptr<BMtx> x;
+    std::unique_ptr<BMtx> mat;
     std::unique_ptr<BMVec> y;
     std::unique_ptr<BMVec> alpha;
     std::unique_ptr<BMVec> beta;
     std::unique_ptr<BMVec> expected;
     std::unique_ptr<BMVec> dresult;
-    std::unique_ptr<BMtx> dx;
+    std::unique_ptr<BMtx> dmat;
     std::unique_ptr<BMVec> dy;
     std::unique_ptr<BMVec> dalpha;
     std::unique_ptr<BMVec> dbeta;
@@ -110,8 +110,8 @@ TEST_F(Dense, SingleVectorApplyIsEquivalentToRef)
 {
     set_up_apply_data(1);
 
-    x->apply(y.get(), expected.get());
-    dx->apply(dy.get(), dresult.get());
+    mat->apply(y.get(), expected.get());
+    dmat->apply(dy.get(), dresult.get());
 
     GKO_ASSERT_BATCH_MTX_NEAR(dresult, expected, r<value_type>::value);
 }
@@ -121,8 +121,8 @@ TEST_F(Dense, SingleVectorAdvancedApplyIsEquivalentToRef)
 {
     set_up_apply_data(1);
 
-    x->apply(alpha.get(), y.get(), beta.get(), expected.get());
-    dx->apply(dalpha.get(), dy.get(), dbeta.get(), dresult.get());
+    mat->apply(alpha.get(), y.get(), beta.get(), expected.get());
+    dmat->apply(dalpha.get(), dy.get(), dbeta.get(), dresult.get());
 
     GKO_ASSERT_BATCH_MTX_NEAR(dresult, expected, r<value_type>::value);
 }

--- a/test/matrix/batch_dense_kernels.cpp
+++ b/test/matrix/batch_dense_kernels.cpp
@@ -1,0 +1,129 @@
+/*******************************<GINKGO LICENSE>******************************
+Copyright (c) 2017-2023, the Ginkgo authors
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+******************************<GINKGO LICENSE>*******************************/
+
+#include <ginkgo/core/matrix/batch_dense.hpp>
+
+
+#include <memory>
+#include <random>
+
+
+#include <gtest/gtest.h>
+
+
+#include <ginkgo/core/base/array.hpp>
+#include <ginkgo/core/base/batch_multi_vector.hpp>
+#include <ginkgo/core/base/math.hpp>
+
+
+#include "core/base/batch_utilities.hpp"
+#include "core/matrix/batch_dense_kernels.hpp"
+#include "core/test/utils.hpp"
+#include "core/test/utils/assertions.hpp"
+#include "core/test/utils/batch_helpers.hpp"
+#include "test/utils/executor.hpp"
+
+
+class BatchDense : public CommonTestFixture {
+protected:
+    using vtype = double;
+    using Mtx = gko::batch::matrix::BatchDense<vtype>;
+    using MVec = gko::batch::MultiVector<vtype>;
+
+    BatchDense() : rand_engine(15) {}
+
+    template <typename MtxType>
+    std::unique_ptr<MtxType> gen_mtx(const gko::size_type num_batch_items,
+                                     gko::size_type num_rows,
+                                     gko::size_type num_cols)
+    {
+        return gko::test::generate_random_batch_matrix<MtxType>(
+            num_batch_items, num_rows, num_cols,
+            std::uniform_int_distribution<>(num_cols, num_cols),
+            std::normal_distribution<>(-1.0, 1.0), rand_engine, ref);
+    }
+
+    void set_up_apply_data(gko::size_type num_vecs = 1)
+    {
+        const int num_rows = 252;
+        const int num_cols = 32;
+        x = gen_mtx<Mtx>(batch_size, num_rows, num_cols);
+        y = gen_mtx<MVec>(batch_size, num_cols, num_vecs);
+        alpha = gen_mtx<MVec>(batch_size, 1, 1);
+        beta = gen_mtx<MVec>(batch_size, 1, 1);
+        dx = gko::clone(exec, x);
+        dy = gko::clone(exec, y);
+        dalpha = gko::clone(exec, alpha);
+        dbeta = gko::clone(exec, beta);
+        expected = MVec::create(
+            ref,
+            gko::batch_dim<2>(batch_size, gko::dim<2>{num_rows, num_vecs}));
+        expected->fill(gko::one<vtype>());
+        dresult = gko::clone(exec, expected);
+    }
+
+    std::ranlux48 rand_engine;
+
+    const size_t batch_size = 11;
+    std::unique_ptr<Mtx> x;
+    std::unique_ptr<MVec> y;
+    std::unique_ptr<MVec> alpha;
+    std::unique_ptr<MVec> beta;
+    std::unique_ptr<MVec> expected;
+    std::unique_ptr<MVec> dresult;
+    std::unique_ptr<Mtx> dx;
+    std::unique_ptr<MVec> dy;
+    std::unique_ptr<MVec> dalpha;
+    std::unique_ptr<MVec> dbeta;
+};
+
+
+TEST_F(BatchDense, SingleVectorApplyIsEquivalentToRef)
+{
+    set_up_apply_data(1);
+
+    x->apply(y.get(), expected.get());
+    dx->apply(dy.get(), dresult.get());
+
+    GKO_ASSERT_BATCH_MTX_NEAR(dresult, expected, 1e-14);
+}
+
+
+TEST_F(BatchDense, SingleVectorAdvancedApplyIsEquivalentToRef)
+{
+    set_up_apply_data(1);
+
+    x->apply(alpha.get(), y.get(), beta.get(), expected.get());
+    dx->apply(dalpha.get(), dy.get(), dbeta.get(), dresult.get());
+
+    GKO_ASSERT_BATCH_MTX_NEAR(dresult, expected, 1e-14);
+}

--- a/test/matrix/batch_dense_kernels.cpp
+++ b/test/matrix/batch_dense_kernels.cpp
@@ -90,7 +90,7 @@ protected:
         dresult = gko::clone(exec, expected);
     }
 
-    std::ranlux48 rand_engine;
+    std::default_random_engine rand_engine;
 
     const size_t batch_size = 11;
     std::unique_ptr<Mtx> x;

--- a/test/matrix/batch_dense_kernels.cpp
+++ b/test/matrix/batch_dense_kernels.cpp
@@ -30,7 +30,7 @@ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ******************************<GINKGO LICENSE>*******************************/
 
-#include <ginkgo/core/matrix/batch_dense.hpp>
+#include "core/matrix/batch_dense_kernels.hpp"
 
 
 #include <memory>
@@ -43,10 +43,10 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <ginkgo/core/base/array.hpp>
 #include <ginkgo/core/base/batch_multi_vector.hpp>
 #include <ginkgo/core/base/math.hpp>
+#include <ginkgo/core/matrix/batch_dense.hpp>
 
 
 #include "core/base/batch_utilities.hpp"
-#include "core/matrix/batch_dense_kernels.hpp"
 #include "core/test/utils.hpp"
 #include "core/test/utils/assertions.hpp"
 #include "core/test/utils/batch_helpers.hpp"

--- a/test/matrix/batch_dense_kernels.cpp
+++ b/test/matrix/batch_dense_kernels.cpp
@@ -53,13 +53,13 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "test/utils/executor.hpp"
 
 
-class BatchDense : public CommonTestFixture {
+class Dense : public CommonTestFixture {
 protected:
     using vtype = double;
-    using Mtx = gko::batch::matrix::BatchDense<vtype>;
+    using Mtx = gko::batch::matrix::Dense<vtype>;
     using MVec = gko::batch::MultiVector<vtype>;
 
-    BatchDense() : rand_engine(15) {}
+    Dense() : rand_engine(15) {}
 
     template <typename MtxType>
     std::unique_ptr<MtxType> gen_mtx(const gko::size_type num_batch_items,
@@ -107,7 +107,7 @@ protected:
 };
 
 
-TEST_F(BatchDense, SingleVectorApplyIsEquivalentToRef)
+TEST_F(Dense, SingleVectorApplyIsEquivalentToRef)
 {
     set_up_apply_data(1);
 
@@ -118,7 +118,7 @@ TEST_F(BatchDense, SingleVectorApplyIsEquivalentToRef)
 }
 
 
-TEST_F(BatchDense, SingleVectorAdvancedApplyIsEquivalentToRef)
+TEST_F(Dense, SingleVectorAdvancedApplyIsEquivalentToRef)
 {
     set_up_apply_data(1);
 

--- a/test/matrix/batch_dense_kernels.cpp
+++ b/test/matrix/batch_dense_kernels.cpp
@@ -55,17 +55,17 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 class Dense : public CommonTestFixture {
 protected:
-    using Mtx = gko::batch::matrix::Dense<value_type>;
-    using MVec = gko::batch::MultiVector<value_type>;
+    using BMtx = gko::batch::matrix::Dense<value_type>;
+    using BMVec = gko::batch::MultiVector<value_type>;
 
     Dense() : rand_engine(15) {}
 
-    template <typename MtxType>
-    std::unique_ptr<MtxType> gen_mtx(const gko::size_type num_batch_items,
-                                     gko::size_type num_rows,
-                                     gko::size_type num_cols)
+    template <typename BMtxType>
+    std::unique_ptr<BMtxType> gen_mtx(const gko::size_type num_batch_items,
+                                      gko::size_type num_rows,
+                                      gko::size_type num_cols)
     {
-        return gko::test::generate_random_batch_matrix<MtxType>(
+        return gko::test::generate_random_batch_matrix<BMtxType>(
             num_batch_items, num_rows, num_cols,
             std::uniform_int_distribution<>(num_cols, num_cols),
             std::normal_distribution<>(-1.0, 1.0), rand_engine, ref);
@@ -75,15 +75,15 @@ protected:
     {
         const int num_rows = 252;
         const int num_cols = 32;
-        x = gen_mtx<Mtx>(batch_size, num_rows, num_cols);
-        y = gen_mtx<MVec>(batch_size, num_cols, num_vecs);
-        alpha = gen_mtx<MVec>(batch_size, 1, 1);
-        beta = gen_mtx<MVec>(batch_size, 1, 1);
+        x = gen_mtx<BMtx>(batch_size, num_rows, num_cols);
+        y = gen_mtx<BMVec>(batch_size, num_cols, num_vecs);
+        alpha = gen_mtx<BMVec>(batch_size, 1, 1);
+        beta = gen_mtx<BMVec>(batch_size, 1, 1);
         dx = gko::clone(exec, x);
         dy = gko::clone(exec, y);
         dalpha = gko::clone(exec, alpha);
         dbeta = gko::clone(exec, beta);
-        expected = MVec::create(
+        expected = BMVec::create(
             ref,
             gko::batch_dim<2>(batch_size, gko::dim<2>{num_rows, num_vecs}));
         expected->fill(gko::one<value_type>());
@@ -93,16 +93,16 @@ protected:
     std::default_random_engine rand_engine;
 
     const size_t batch_size = 11;
-    std::unique_ptr<Mtx> x;
-    std::unique_ptr<MVec> y;
-    std::unique_ptr<MVec> alpha;
-    std::unique_ptr<MVec> beta;
-    std::unique_ptr<MVec> expected;
-    std::unique_ptr<MVec> dresult;
-    std::unique_ptr<Mtx> dx;
-    std::unique_ptr<MVec> dy;
-    std::unique_ptr<MVec> dalpha;
-    std::unique_ptr<MVec> dbeta;
+    std::unique_ptr<BMtx> x;
+    std::unique_ptr<BMVec> y;
+    std::unique_ptr<BMVec> alpha;
+    std::unique_ptr<BMVec> beta;
+    std::unique_ptr<BMVec> expected;
+    std::unique_ptr<BMVec> dresult;
+    std::unique_ptr<BMtx> dx;
+    std::unique_ptr<BMVec> dy;
+    std::unique_ptr<BMVec> dalpha;
+    std::unique_ptr<BMVec> dbeta;
 };
 
 

--- a/test/test_install/test_install.cpp
+++ b/test/test_install/test_install.cpp
@@ -222,7 +222,7 @@ int main()
     // core/base/batch_dense.hpp
     {
         using type1 = float;
-        using batch_dense_type = gko::batch::Dense<type1>;
+        using batch_dense_type = gko::batch::matrix::Dense<type1>;
         auto test = batch_dense_type::create(exec);
     }
 

--- a/test/test_install/test_install.cpp
+++ b/test/test_install/test_install.cpp
@@ -219,6 +219,13 @@ int main()
         auto test = batch_multi_vector_type::create(exec);
     }
 
+    // core/base/batch_dense.hpp
+    {
+        using type1 = float;
+        using batch_dense_type = gko::batch::Dense<type1>;
+        auto test = batch_dense_type::create(exec);
+    }
+
     // core/base/combination.hpp
     {
         using type1 = int;


### PR DESCRIPTION
This PR adds support for the Batch Dense matrix format and currently adds very minimal functionality that is necessary.

## TODO

+ [x]  Add CUDA kernels and tests  
+ [x]  Add HIP kernels and tests 
+ [x]  Add DPCPP kernels and tests 