### PR TITLE
Fix PAPI segmentation fault

### DIFF
--- a/include/ginkgo/core/log/papi.hpp
+++ b/include/ginkgo/core/log/papi.hpp
@@ -209,8 +209,9 @@ public:
            const Logger::mask_type& enabled_events = Logger::all_events_mask)
     {
         return std::shared_ptr<Papi>(new Papi(enabled_events), [](auto logger) {
-            papi_sde_shutdown(logger->get_handle());
+            auto handle = logger->get_handle();
             delete logger;
+            papi_sde_shutdown(handle);
         });
     }
 
@@ -223,8 +224,9 @@ public:
         const Logger::mask_type& enabled_events = Logger::all_events_mask)
     {
         return std::shared_ptr<Papi>(new Papi(enabled_events), [](auto logger) {
-            papi_sde_shutdown(logger->get_handle());
+            auto handle = logger->get_handle();
             delete logger;
+            papi_sde_shutdown(handle);
         });
     }
 

--- a/include/ginkgo/core/log/papi.hpp
+++ b/include/ginkgo/core/log/papi.hpp
@@ -208,11 +208,7 @@ public:
     create(std::shared_ptr<const gko::Executor>,
            const Logger::mask_type& enabled_events = Logger::all_events_mask)
     {
-        return std::shared_ptr<Papi>(new Papi(enabled_events), [](auto logger) {
-            auto handle = logger->get_handle();
-            delete logger;
-            papi_sde_shutdown(handle);
-        });
+        return Papi::create(enabled_events);
     }
 
     /**


### PR DESCRIPTION
This PR destroys the logger before shutdown papi_sde_shutdown. It sometimes lead to segmentation faults before.
papi_sde_shutdown seems to unregister the counter during shutdown such that the `~papi_queue` reach the invalid memory.
I don't know whether papi_sde_shutdown always unregister counter in different versions/for different types, so I only reorder the destruction.