### PR TITLE
Add pregenerated local solver as factory param

### DIFF
--- a/core/distributed/preconditioner/schwarz.cpp
+++ b/core/distributed/preconditioner/schwarz.cpp
@@ -102,14 +102,23 @@ template <typename ValueType, typename LocalIndexType, typename GlobalIndexType>
 void Schwarz<ValueType, LocalIndexType, GlobalIndexType>::generate(
     std::shared_ptr<const LinOp> system_matrix)
 {
-    if (parameters_.local_solver) {
+    if (parameters_.local_solver && !parameters_.generated_local_solvers) {
         this->local_solver_ = parameters_.local_solver->generate(
             as<experimental::distributed::Matrix<ValueType, LocalIndexType,
                                                  GlobalIndexType>>(
                 system_matrix)
                 ->get_local_matrix());
+    } else if (parameters_.generated_local_solvers &&
+               !parameters_.local_solver) {
+        this->local_solver_ = parameters_.generated_local_solvers;
+    } else if (!parameters_.generated_local_ && !parameters_.local_solver) {
+        throw ::gko::InvalidStateError(
+            __FILE__, __LINE__, __func__,
+            "Requires either a generated solver or an solver factory");
     } else {
-        GKO_NOT_IMPLEMENTED;
+        throw ::gko::InvalidStateError(
+            __FILE__, __LINE__, __func__,
+            "Provided both a generated solver and a solver factory");
     }
 }
 

--- a/core/distributed/preconditioner/schwarz.cpp
+++ b/core/distributed/preconditioner/schwarz.cpp
@@ -102,24 +102,28 @@ template <typename ValueType, typename LocalIndexType, typename GlobalIndexType>
 void Schwarz<ValueType, LocalIndexType, GlobalIndexType>::generate(
     std::shared_ptr<const LinOp> system_matrix)
 {
-    if (parameters_.local_solver && !parameters_.generated_local_solver) {
+    if (parameters_.local_solver != nullptr &&
+        parameters_.generated_local_solver != nullptr) {
+        throw ::gko::InvalidStateError(
+            __FILE__, __LINE__, __func__,
+            "Provided both a generated solver and a solver factory");
+    }
+
+    if (parameters_.local_solver == nullptr &&
+        parameters_.generated_local_solver == nullptr) {
+        throw ::gko::InvalidStateError(
+            __FILE__, __LINE__, __func__,
+            "Requires either a generated solver or an solver factory");
+    }
+
+    if (parameters_.local_solver) {
         this->local_solver_ = parameters_.local_solver->generate(
             as<experimental::distributed::Matrix<ValueType, LocalIndexType,
                                                  GlobalIndexType>>(
                 system_matrix)
                 ->get_local_matrix());
-    } else if (parameters_.generated_local_solver &&
-               !parameters_.local_solver) {
-        this->local_solver_ = parameters_.generated_local_solver;
-    } else if (!parameters_.generated_local_solver &&
-               !parameters_.local_solver) {
-        throw ::gko::InvalidStateError(
-            __FILE__, __LINE__, __func__,
-            "Requires either a generated solver or an solver factory");
     } else {
-        throw ::gko::InvalidStateError(
-            __FILE__, __LINE__, __func__,
-            "Provided both a generated solver and a solver factory");
+        this->local_solver_ = parameters_.generated_local_solver;
     }
 }
 

--- a/core/distributed/preconditioner/schwarz.cpp
+++ b/core/distributed/preconditioner/schwarz.cpp
@@ -102,16 +102,17 @@ template <typename ValueType, typename LocalIndexType, typename GlobalIndexType>
 void Schwarz<ValueType, LocalIndexType, GlobalIndexType>::generate(
     std::shared_ptr<const LinOp> system_matrix)
 {
-    if (parameters_.local_solver && !parameters_.generated_local_solvers) {
+    if (parameters_.local_solver && !parameters_.generated_local_solver) {
         this->local_solver_ = parameters_.local_solver->generate(
             as<experimental::distributed::Matrix<ValueType, LocalIndexType,
                                                  GlobalIndexType>>(
                 system_matrix)
                 ->get_local_matrix());
-    } else if (parameters_.generated_local_solvers &&
+    } else if (parameters_.generated_local_solver &&
                !parameters_.local_solver) {
-        this->local_solver_ = parameters_.generated_local_solvers;
-    } else if (!parameters_.generated_local_ && !parameters_.local_solver) {
+        this->local_solver_ = parameters_.generated_local_solver;
+    } else if (!parameters_.generated_local_solver &&
+               !parameters_.local_solver) {
         throw ::gko::InvalidStateError(
             __FILE__, __LINE__, __func__,
             "Requires either a generated solver or an solver factory");

--- a/core/distributed/preconditioner/schwarz.cpp
+++ b/core/distributed/preconditioner/schwarz.cpp
@@ -102,17 +102,13 @@ template <typename ValueType, typename LocalIndexType, typename GlobalIndexType>
 void Schwarz<ValueType, LocalIndexType, GlobalIndexType>::generate(
     std::shared_ptr<const LinOp> system_matrix)
 {
-    if (parameters_.local_solver != nullptr &&
-        parameters_.generated_local_solver != nullptr) {
-        throw ::gko::InvalidStateError(
-            __FILE__, __LINE__, __func__,
+    if (parameters_.local_solver && parameters_.generated_local_solver) {
+        GKO_INVALID_STATE(
             "Provided both a generated solver and a solver factory");
     }
 
-    if (parameters_.local_solver == nullptr &&
-        parameters_.generated_local_solver == nullptr) {
-        throw ::gko::InvalidStateError(
-            __FILE__, __LINE__, __func__,
+    if (!parameters_.local_solver && !parameters_.generated_local_solver) {
+        GKO_INVALID_STATE(
             "Requires either a generated solver or an solver factory");
     }
 

--- a/include/ginkgo/core/distributed/preconditioner/schwarz.hpp
+++ b/include/ginkgo/core/distributed/preconditioner/schwarz.hpp
@@ -99,7 +99,7 @@ public:
         /**
          * Generated Inner solvers.
          */
-        std::shared_ptr<const LinOp> GKO_FACTORY_PARAMETER(
+        std::shared_ptr<const LinOp> GKO_FACTORY_PARAMETER_SCALAR(
             generated_local_solver, nullptr);
     };
     GKO_ENABLE_LIN_OP_FACTORY(Schwarz, parameters, Factory);
@@ -136,7 +136,6 @@ protected:
      */
     void generate(std::shared_ptr<const LinOp> system_matrix);
 
-
     void apply_impl(const LinOp* b, LinOp* x) const override;
 
     template <typename VectorType>
@@ -146,6 +145,13 @@ protected:
                     LinOp* x) const override;
 
 private:
+    /**
+     * Sets the solver operator used as the local solver.
+     *
+     * @param new_solver  the new local solver
+     */
+    void set_solver(std::shared_ptr<const LinOp> new_solver);
+
     std::shared_ptr<const LinOp> local_solver_;
 };
 

--- a/include/ginkgo/core/distributed/preconditioner/schwarz.hpp
+++ b/include/ginkgo/core/distributed/preconditioner/schwarz.hpp
@@ -95,6 +95,11 @@ public:
          * Local solver factory.
          */
         GKO_DEFERRED_FACTORY_PARAMETER(local_solver, LinOpFactory);
+        /**
+         * Generated Inner solvers.
+         */
+        std::shared_ptr<const LinOp> GKO_FACTORY_PARAMETER(
+            generated_local_solver, nullptr);
     };
     GKO_ENABLE_LIN_OP_FACTORY(Schwarz, parameters, Factory);
     GKO_ENABLE_BUILD_METHOD(Factory);

--- a/include/ginkgo/core/distributed/preconditioner/schwarz.hpp
+++ b/include/ginkgo/core/distributed/preconditioner/schwarz.hpp
@@ -95,6 +95,7 @@ public:
          * Local solver factory.
          */
         GKO_DEFERRED_FACTORY_PARAMETER(local_solver, LinOpFactory);
+
         /**
          * Generated Inner solvers.
          */

--- a/test/mpi/preconditioner/schwarz.cpp
+++ b/test/mpi/preconditioner/schwarz.cpp
@@ -258,10 +258,11 @@ TYPED_TEST(SchwarzPreconditioner, CanApplyPreconditionedSolverWithPregenSolver)
     using cg = typename TestFixture::solver_type;
     using prec = typename TestFixture::dist_prec_type;
 
-    auto local_solver = gko::share(local_prec_type::build()
-                                       .with_max_block_size(1u)
-                                       .on(this->exec)
-                                       ->generate(this->dist_mat->get_local_matrix()));
+    auto local_solver =
+        gko::share(local_prec_type::build()
+                       .with_max_block_size(1u)
+                       .on(this->exec)
+                       ->generate(this->dist_mat->get_local_matrix()));
     auto precond = prec::build()
                        .with_local_solver(this->local_solver_factory)
                        .on(this->exec)

--- a/test/mpi/preconditioner/schwarz.cpp
+++ b/test/mpi/preconditioner/schwarz.cpp
@@ -203,43 +203,43 @@ TYPED_TEST(SchwarzPreconditioner, GenerateFailsIfInvalidState)
 }
 
 
-// TYPED_TEST(SchwarzPreconditioner, CanApplyPreconditionedSolver)
-// {
-//     using value_type = typename TestFixture::value_type;
-//     using csr = typename TestFixture::local_matrix_type;
-//     using cg = typename TestFixture::solver_type;
-//     using prec = typename TestFixture::dist_prec_type;
-//     constexpr double tolerance = 1e-20;
-//     auto iter_stop = gko::share(
-//         gko::stop::Iteration::build().with_max_iters(200u).on(this->exec));
-//     auto tol_stop = gko::share(
-//         gko::stop::ResidualNorm<value_type>::build()
-//             .with_reduction_factor(
-//                 static_cast<gko::remove_complex<value_type>>(tolerance))
-//             .on(this->exec));
-//     this->dist_solver_factory =
-//         cg::build()
-//             .with_preconditioner(
-//                 prec::build()
-//                     .with_local_solver(this->local_solver_factory)
-//                     .on(this->exec))
-//             .with_criteria(iter_stop, tol_stop)
-//             .on(this->exec);
-//     auto dist_solver = this->dist_solver_factory->generate(this->dist_mat);
-//     this->non_dist_solver_factory =
-//         cg::build()
-//             .with_preconditioner(this->local_solver_factory)
-//             .with_criteria(iter_stop, tol_stop)
-//             .on(this->exec);
-//     auto non_dist_solver =
-//         this->non_dist_solver_factory->generate(this->non_dist_mat);
-//
-//     dist_solver->apply(this->dist_b.get(), this->dist_x.get());
-//     dist_solver->apply(this->non_dist_b.get(), this->non_dist_x.get());
-//
-//     this->assert_equal_to_non_distributed_vector(this->dist_x,
-//                                                  this->non_dist_x);
-// }
+TYPED_TEST(SchwarzPreconditioner, CanApplyPreconditionedSolver)
+{
+    using value_type = typename TestFixture::value_type;
+    using csr = typename TestFixture::local_matrix_type;
+    using cg = typename TestFixture::solver_type;
+    using prec = typename TestFixture::dist_prec_type;
+    constexpr double tolerance = 1e-20;
+    auto iter_stop = gko::share(
+        gko::stop::Iteration::build().with_max_iters(200u).on(this->exec));
+    auto tol_stop = gko::share(
+        gko::stop::ResidualNorm<value_type>::build()
+            .with_reduction_factor(
+                static_cast<gko::remove_complex<value_type>>(tolerance))
+            .on(this->exec));
+    this->dist_solver_factory =
+        cg::build()
+            .with_preconditioner(
+                prec::build()
+                    .with_local_solver(this->local_solver_factory)
+                    .on(this->exec))
+            .with_criteria(iter_stop, tol_stop)
+            .on(this->exec);
+    auto dist_solver = this->dist_solver_factory->generate(this->dist_mat);
+    this->non_dist_solver_factory =
+        cg::build()
+            .with_preconditioner(this->local_solver_factory)
+            .with_criteria(iter_stop, tol_stop)
+            .on(this->exec);
+    auto non_dist_solver =
+        this->non_dist_solver_factory->generate(this->non_dist_mat);
+
+    dist_solver->apply(this->dist_b.get(), this->dist_x.get());
+    non_dist_solver->apply(this->non_dist_b.get(), this->non_dist_x.get());
+
+    this->assert_equal_to_non_distributed_vector(this->dist_x,
+                                                 this->non_dist_x);
+}
 
 
 TYPED_TEST(SchwarzPreconditioner, CanApplyPreconditionedSolverWithPregenSolver)

--- a/test/mpi/preconditioner/schwarz.cpp
+++ b/test/mpi/preconditioner/schwarz.cpp
@@ -196,7 +196,12 @@ TYPED_TEST(SchwarzPreconditioner, GenerateFailsIfInvalidState)
                        .on(this->exec);
 
     ASSERT_THROW(schwarz->generate(this->dist_mat), gko::InvalidStateError);
+}
 
+
+TYPED_TEST(SchwarzPreconditioner, GenerateFailsIfNoSolverProvided)
+{
+    using prec = typename TestFixture::dist_prec_type;
     auto schwarz_no_solver = prec::build().on(this->exec);
     ASSERT_THROW(schwarz_no_solver->generate(this->dist_mat),
                  gko::InvalidStateError);
@@ -260,21 +265,19 @@ TYPED_TEST(SchwarzPreconditioner, CanApplyPreconditionedSolverWithPregenSolver)
                        .with_local_solver(this->local_solver_factory)
                        .on(this->exec)
                        ->generate(this->dist_mat);
-
     auto precond_pregen = prec::build()
                               .with_generated_local_solver(local_solver)
                               .on(this->exec)
                               ->generate(this->dist_mat);
-
     auto dist_x = gko::share(this->dist_x->clone());
     auto dist_x_pregen = gko::share(this->dist_x->clone());
 
     precond->apply(this->dist_b.get(), dist_x.get());
     precond->apply(this->dist_b.get(), dist_x_pregen.get());
 
-    GKO_ASSERT_MTX_NEAR(
-        dist_x->get_local_vector(), dist_x_pregen->get_local_vector(),
-        r<value_type>::value);
+    GKO_ASSERT_MTX_NEAR(dist_x->get_local_vector(),
+                        dist_x_pregen->get_local_vector(),
+                        r<value_type>::value);
 }
 
 

--- a/test/mpi/preconditioner/schwarz.cpp
+++ b/test/mpi/preconditioner/schwarz.cpp
@@ -217,35 +217,54 @@ TYPED_TEST(SchwarzPreconditioner, CanApplyPreconditionedSolver)
                                                  this->non_dist_x);
 }
 
-TYPED_TEST(SchwarzPreconditioner, CanApplyPreconditionedSolverWithPregenSolver)
+
+TYPED_TEST(SchwarzPreconditioner, GenerateFailsIfPregenSolverAndSolverFactoryArePresent)
 {
-    using value_type = typename TestFixture::value_type;
-    using csr = typename TestFixture::local_matrix_type;
-    using cg = typename TestFixture::solver_type;
     using prec = typename TestFixture::dist_prec_type;
-    constexpr double tolerance = 1e-20;
-    auto iter_stop = gko::share(
-        gko::stop::Iteration::build().with_max_iters(200u).on(this->exec));
-    auto tol_stop = gko::share(
-        gko::stop::ResidualNorm<value_type>::build()
-            .with_reduction_factor(
-                static_cast<gko::remove_complex<value_type>>(tolerance))
-            .on(this->exec));
-    this->non_dist_solver_factory =
-        cg::build()
-            .with_preconditioner(this->local_solver_factory)
-            .with_criteria(iter_stop, tol_stop)
-            .on(this->exec);
     auto local_solver =
-        this->non_dist_solver_factory->generate(this->non_dist_mat);
-    this->dist_solver_factory =
-        cg::build()
-            .with_preconditioner(prec::build()
-                                     .with_generated_local_solver(local_solver)
-                                     .on(this->exec))
-            .with_criteria(iter_stop, tol_stop)
-            .on(this->exec);
+        gko::share(this->non_dist_solver_factory->generate(this->non_dist_mat));
+
+    auto schwarz = prec::build()
+                    .with_local_solver(this->local_solver_factory)
+                    .with_generated_local_solver(local_solver)
+                    .on(this->exec);
+
+    ASSERT_THROW(schwarz->generate(this->dist_mat), gko::InvalidStateError);
+
+    auto schwarz_no_solver = prec::build().on(this->exec);
+    ASSERT_THROW(schwarz_no_solver->generate(this->dist_mat), gko::InvalidStateError);
 }
+
+
+// TYPED_TEST(SchwarzPreconditioner, CanApplyPreconditionedSolverWithPregenSolver)
+// {
+//     using value_type = typename TestFixture::value_type;
+//     using csr = typename TestFixture::local_matrix_type;
+//     using cg = typename TestFixture::solver_type;
+//     using prec = typename TestFixture::dist_prec_type;
+//     constexpr double tolerance = 1e-20;
+//     auto iter_stop = gko::share(
+//         gko::stop::Iteration::build().with_max_iters(200u).on(this->exec));
+//     auto tol_stop = gko::share(
+//         gko::stop::ResidualNorm<value_type>::build()
+//             .with_reduction_factor(
+//                 static_cast<gko::remove_complex<value_type>>(tolerance))
+//             .on(this->exec));
+//     this->non_dist_solver_factory =
+//         cg::build()
+//             .with_preconditioner(this->local_solver_factory)
+//             .with_criteria(iter_stop, tol_stop)
+//             .on(this->exec);
+//     auto local_solver =
+//         this->non_dist_solver_factory->generate(this->non_dist_mat);
+//     this->dist_solver_factory =
+//         cg::build()
+//             .with_preconditioner(prec::build()
+//                                      .with_generated_local_solver(local_solver.get())
+//                                      .on(this->exec))
+//             .with_criteria(iter_stop, tol_stop)
+//             .on(this->exec);
+// }
 
 
 TYPED_TEST(SchwarzPreconditioner, CanApplyPreconditioner)

--- a/test/mpi/preconditioner/schwarz.cpp
+++ b/test/mpi/preconditioner/schwarz.cpp
@@ -203,6 +203,7 @@ TYPED_TEST(SchwarzPreconditioner, GenerateFailsIfNoSolverProvided)
 {
     using prec = typename TestFixture::dist_prec_type;
     auto schwarz_no_solver = prec::build().on(this->exec);
+
     ASSERT_THROW(schwarz_no_solver->generate(this->dist_mat),
                  gko::InvalidStateError);
 }
@@ -260,7 +261,7 @@ TYPED_TEST(SchwarzPreconditioner, CanApplyPreconditionedSolverWithPregenSolver)
     auto local_solver = gko::share(local_prec_type::build()
                                        .with_max_block_size(1u)
                                        .on(this->exec)
-                                       ->generate(this->non_dist_mat));
+                                       ->generate(this->dist_mat->get_local_matrix()));
     auto precond = prec::build()
                        .with_local_solver(this->local_solver_factory)
                        .on(this->exec)
@@ -273,7 +274,7 @@ TYPED_TEST(SchwarzPreconditioner, CanApplyPreconditionedSolverWithPregenSolver)
     auto dist_x_pregen = gko::share(this->dist_x->clone());
 
     precond->apply(this->dist_b.get(), dist_x.get());
-    precond->apply(this->dist_b.get(), dist_x_pregen.get());
+    precond_pregen->apply(this->dist_b.get(), dist_x_pregen.get());
 
     GKO_ASSERT_MTX_NEAR(dist_x->get_local_vector(),
                         dist_x_pregen->get_local_vector(),


### PR DESCRIPTION
This PR adds a factory parameter to the Schwarz preconditioner to pass in a fully generated solver. This can be useful in situations where one wants to reuse a pre-generated solver/ preconditioner.