### PR TITLE
Add a two-level Schwarz preconditioner

### DIFF
--- a/core/distributed/preconditioner/schwarz.cpp
+++ b/core/distributed/preconditioner/schwarz.cpp
@@ -183,6 +183,15 @@ void Schwarz<ValueType, LocalIndexType, GlobalIndexType>::generate(
         this->set_solver(
             gko::share(parameters_.local_solver->generate(local_matrix)));
     }
+
+    auto dist_mat =
+        as<experimental::distributed::Matrix<ValueType, LocalIndexType,
+                                             GlobalIndexType>>(system_matrix);
+
+    if (parameters_.coarse_solver_factory) {
+        this->coarse_solver_ = as<multigrid::MultigridLevel>(
+            share(parameters_.coarse_solver_factory->generate(dist_mat)));
+    }
 }
 
 

--- a/core/distributed/preconditioner/schwarz.cpp
+++ b/core/distributed/preconditioner/schwarz.cpp
@@ -59,6 +59,17 @@ Schwarz<ValueType, LocalIndexType, GlobalIndexType>::parse(
     if (auto& obj = config.get("l1_smoother")) {
         params.with_l1_smoother(obj.get_boolean());
     }
+    if (auto& obj = config.get("galerkin_ops")) {
+        params.with_galerkin_ops(
+            gko::config::parse_or_get_factory<const LinOpFactory>(
+                obj, context, td_for_child));
+    }
+    if (auto& obj = config.get("coarse_solver")) {
+        params.with_coarse_solver(
+            gko::config::parse_or_get_factory<const LinOpFactory>(
+                obj, context, td_for_child));
+    }
+
     return params;
 }
 

--- a/core/distributed/preconditioner/schwarz.cpp
+++ b/core/distributed/preconditioner/schwarz.cpp
@@ -99,25 +99,11 @@ void Schwarz<ValueType, LocalIndexType, GlobalIndexType>::apply_dense_impl(
     if (this->coarse_solver_ != nullptr && this->galerkin_ops_ != nullptr) {
         auto restrict = this->galerkin_ops_->get_restrict_op();
         auto prolong = this->galerkin_ops_->get_prolong_op();
-        auto coarse =
-            as<experimental::distributed::Matrix<ValueType, LocalIndexType,
-                                                 GlobalIndexType>>(
-                this->galerkin_ops_->get_coarse_op());
-        auto comm = coarse->get_communicator();
 
-        auto cs_ncols = dense_x->get_size()[1];
-        auto cs_local_nrows = coarse->get_local_matrix()->get_size()[0];
-        auto cs_global_nrows = coarse->get_size()[0];
-        auto cs_local_size = dim<2>(cs_local_nrows, cs_ncols);
-        auto cs_global_size = dim<2>(cs_global_nrows, cs_ncols);
-        auto csol = dist_vec::create(exec, comm, cs_global_size, cs_local_size,
-                                     dense_x->get_stride());
-        restrict->apply(dense_b, csol);
-        auto tmp = csol->clone();
-        this->coarse_solver_->apply(csol, tmp);
-        auto one = gko::initialize<Vector>({0.5}, exec);
-        auto zero = gko::initialize<Vector>({0.5}, exec);
-        prolong->apply(one, tmp, zero, dense_x);
+        restrict->apply(dense_b, this->csol_);
+        this->coarse_solver_->apply(this->csol_, this->csol_);
+        prolong->apply(this->half_.get(), this->csol_.get(), this->half_.get(),
+                       dense_x);
     }
 }
 
@@ -157,6 +143,8 @@ template <typename ValueType, typename LocalIndexType, typename GlobalIndexType>
 void Schwarz<ValueType, LocalIndexType, GlobalIndexType>::generate(
     std::shared_ptr<const LinOp> system_matrix)
 {
+    using Vector = matrix::Dense<ValueType>;
+    using dist_vec = experimental::distributed::Vector<ValueType>;
     if (parameters_.local_solver && parameters_.generated_local_solver) {
         GKO_INVALID_STATE(
             "Provided both a generated solver and a solver factory");
@@ -226,8 +214,25 @@ void Schwarz<ValueType, LocalIndexType, GlobalIndexType>::generate(
     if (parameters_.galerkin_ops_factory && parameters_.coarse_solver_factory) {
         this->galerkin_ops_ = as<multigrid::MultigridLevel>(
             share(parameters_.galerkin_ops_factory->generate(dist_mat)));
-        this->coarse_solver_ = parameters_.coarse_solver_factory->generate(
-            this->galerkin_ops_->get_coarse_op());
+        auto coarse =
+            as<experimental::distributed::Matrix<ValueType, LocalIndexType,
+                                                 GlobalIndexType>>(
+                this->galerkin_ops_->get_coarse_op());
+        auto exec = coarse->get_executor();
+        auto comm = coarse->get_communicator();
+        this->coarse_solver_ =
+            parameters_.coarse_solver_factory->generate(coarse);
+        // TODO: Set correct rhs and stride.
+        auto cs_ncols = 1;  // dense_x->get_size()[1];
+        auto cs_local_nrows = coarse->get_local_matrix()->get_size()[0];
+        auto cs_global_nrows = coarse->get_size()[0];
+        auto cs_local_size = dim<2>(cs_local_nrows, cs_ncols);
+        auto cs_global_size = dim<2>(cs_global_nrows, cs_ncols);
+        this->csol_ = gko::share(dist_vec::create(exec, comm, cs_global_size,
+                                                  cs_local_size,
+                                                  1 /*dense_x->get_stride()*/));
+        // this->temp_ = this->csol->clone();
+        this->half_ = gko::share(gko::initialize<Vector>({0.5}, exec));
     }
 }
 

--- a/core/distributed/preconditioner/schwarz.cpp
+++ b/core/distributed/preconditioner/schwarz.cpp
@@ -102,8 +102,7 @@ void Schwarz<ValueType, LocalIndexType, GlobalIndexType>::apply_dense_impl(
 
         restrict->apply(dense_b, this->csol_);
         this->coarse_solver_->apply(this->csol_, this->csol_);
-        prolong->apply(this->half_.get(), this->csol_.get(), this->half_.get(),
-                       dense_x);
+        prolong->apply(this->half_, this->csol_, this->half_, dense_x);
     }
 }
 

--- a/core/test/config/preconditioner.cpp
+++ b/core/test/config/preconditioner.cpp
@@ -11,6 +11,7 @@
 #include <ginkgo/core/config/config.hpp>
 #include <ginkgo/core/distributed/preconditioner/schwarz.hpp>
 #include <ginkgo/core/matrix/dense.hpp>
+#include <ginkgo/core/multigrid/pgm.hpp>
 #include <ginkgo/core/preconditioner/gauss_seidel.hpp>
 #include <ginkgo/core/preconditioner/ic.hpp>
 #include <ginkgo/core/preconditioner/ilu.hpp>
@@ -402,6 +403,7 @@ struct GaussSeidel
 
 #if GINKGO_BUILD_MPI
 
+using DummyMgLevel = gko::multigrid::Pgm<float, int>;
 
 struct Schwarz
     : PreconditionerConfigTest<
@@ -428,17 +430,34 @@ struct Schwarz
             param.with_local_solver(
                 detail::registry_accessor::get_data<gko::LinOpFactory>(
                     reg, "solver"));
+            config_map["coarse_solver"] = pnode{"solver"};
+            param.with_coarse_solver(
+                detail::registry_accessor::get_data<gko::LinOpFactory>(
+                    reg, "solver"));
+            config_map["coarse_level"] = pnode{"c_level"};
+            param.with_coarse_level(
+                detail::registry_accessor::get_data<gko::LinOpFactory>(
+                    reg, "c_level"));
         } else {
             config_map["local_solver"] =
                 pnode{{{"type", pnode{"solver::Ir"}},
                        {"value_type", pnode{"float32"}}}};
             param.with_local_solver(DummyIr::build().on(exec));
+            config_map["coarse_solver"] =
+                pnode{{{"type", pnode{"solver::Ir"}},
+                       {"value_type", pnode{"float32"}}}};
+            param.with_coarse_solver(DummyIr::build().on(exec));
+            config_map["coarse_level"] =
+                pnode{{{"type", pnode{"multigrid::Pgm"}}}};
+            param.with_coarse_level(DummyMgLevel::build().on(exec));
         }
         config_map["generated_local_solver"] = pnode{"linop"};
         param.with_generated_local_solver(
             detail::registry_accessor::get_data<gko::LinOp>(reg, "linop"));
         config_map["l1_smoother"] = pnode{true};
         param.with_l1_smoother(true);
+        config_map["coarse_weight"] = pnode{0.1};
+        param.with_coarse_weight(0.1);
     }
 
     template <bool from_reg, typename AnswerType>
@@ -449,14 +468,25 @@ struct Schwarz
 
         if (from_reg) {
             ASSERT_EQ(res_param.local_solver, ans_param.local_solver);
+            ASSERT_EQ(res_param.coarse_solver, ans_param.coarse_solver);
+            ASSERT_EQ(res_param.coarse_level, ans_param.coarse_level);
         } else {
             ASSERT_NE(
                 std::dynamic_pointer_cast<const typename DummyIr::Factory>(
                     res_param.local_solver),
                 nullptr);
+            ASSERT_NE(
+                std::dynamic_pointer_cast<const typename DummyIr::Factory>(
+                    res_param.coarse_solver),
+                nullptr);
+            ASSERT_NE(
+                std::dynamic_pointer_cast<const typename DummyMgLevel::Factory>(
+                    res_param.coarse_level),
+                nullptr);
         }
         ASSERT_EQ(res_param.generated_local_solver,
                   ans_param.generated_local_solver);
+        ASSERT_EQ(res_param.coarse_weight, ans_param.coarse_weight);
     }
 };
 
@@ -477,9 +507,11 @@ protected:
           u_solver(DummyIr::build().on(exec)),
           factorization(DummyIr::build().on(exec)),
           linop(gko::matrix::Dense<>::create(exec)),
+          coarse_level(DummyMgLevel::build().on(exec)),
           reg()
     {
         reg.emplace("solver", solver_factory);
+        reg.emplace("c_level", coarse_level);
         reg.emplace("l_solver", l_solver);
         reg.emplace("u_solver", u_solver);
         reg.emplace("factorization", factorization);
@@ -492,6 +524,7 @@ protected:
     std::shared_ptr<typename DummyIr::Factory> l_solver;
     std::shared_ptr<typename DummyIr::Factory> u_solver;
     std::shared_ptr<typename DummyIr::Factory> factorization;
+    std::shared_ptr<typename DummyMgLevel::Factory> coarse_level;
     std::shared_ptr<gko::LinOp> linop;
     registry reg;
 };

--- a/core/test/config/preconditioner.cpp
+++ b/core/test/config/preconditioner.cpp
@@ -457,7 +457,7 @@ struct Schwarz
         config_map["l1_smoother"] = pnode{true};
         param.with_l1_smoother(true);
         config_map["coarse_weight"] = pnode{0.1};
-        param.with_coarse_weight(0.1);
+        param.with_coarse_weight(decltype(param.coarse_weight){0.1});
     }
 
     template <bool from_reg, typename AnswerType>

--- a/core/test/config/preconditioner.cpp
+++ b/core/test/config/preconditioner.cpp
@@ -31,6 +31,8 @@ using namespace gko::config;
 
 using DummyIr = gko::solver::Ir<float>;
 
+using DummyMgLevel = gko::multigrid::Pgm<float, int>;
+
 
 template <typename ChangedType, typename DefaultType>
 struct PreconditionerConfigTest {
@@ -402,8 +404,6 @@ struct GaussSeidel
 
 
 #if GINKGO_BUILD_MPI
-
-using DummyMgLevel = gko::multigrid::Pgm<float, int>;
 
 struct Schwarz
     : PreconditionerConfigTest<

--- a/core/test/mpi/distributed/preconditioner/schwarz.cpp
+++ b/core/test/mpi/distributed/preconditioner/schwarz.cpp
@@ -15,9 +15,6 @@
 #include "core/test/utils.hpp"
 
 
-namespace {
-
-
 template <typename ValueLocalGlobalIndexType>
 class SchwarzFactory : public ::testing::Test {
 protected:
@@ -45,8 +42,8 @@ protected:
     {
         schwarz = Schwarz::build()
                       .with_local_solver(jacobi_factory)
-                      .with_galerkin_ops_factory(pgm_factory)
-                      .with_coarse_solver_factory(pgm_factory)
+                      .with_galerkin_ops(pgm_factory)
+                      .with_coarse_solver(cg_factory)
                       .on(exec)
                       ->generate(mtx);
     }
@@ -64,10 +61,10 @@ protected:
         ASSERT_EQ(a->get_size(), b->get_size());
         ASSERT_EQ(a->get_parameters().local_solver,
                   b->get_parameters().local_solver);
-        ASSERT_EQ(a->get_parameters().galerkin_ops_factory,
-                  b->get_parameters().galerkin_ops_factory);
-        ASSERT_EQ(a->get_parameters().coarse_solver_factory,
-                  b->get_parameters().coarse_solver_factory);
+        ASSERT_EQ(a->get_parameters().galerkin_ops,
+                  b->get_parameters().galerkin_ops);
+        ASSERT_EQ(a->get_parameters().coarse_solver,
+                  b->get_parameters().coarse_solver);
     }
 
     std::shared_ptr<const gko::Executor> exec;
@@ -97,15 +94,13 @@ TYPED_TEST(SchwarzFactory, CanSetLocalFactory)
 
 TYPED_TEST(SchwarzFactory, CanSetGalerkinOpsFactory)
 {
-    ASSERT_EQ(this->schwarz->get_parameters().galerkin_ops_factory,
-              this->pgm_factory);
+    ASSERT_EQ(this->schwarz->get_parameters().galerkin_ops, this->pgm_factory);
 }
 
 
 TYPED_TEST(SchwarzFactory, CanSetCoarseSolverFactory)
 {
-    ASSERT_EQ(this->schwarz->get_parameters().coarse_solver_factory,
-              this->cg_factory);
+    ASSERT_EQ(this->schwarz->get_parameters().coarse_solver, this->cg_factory);
 }
 
 
@@ -129,8 +124,8 @@ TYPED_TEST(SchwarzFactory, CanBeCopied)
     auto cg = gko::share(Cg::build().on(this->exec));
     auto copy = Schwarz::build()
                     .with_local_solver(bj)
-                    .with_galerkin_ops_factory(pgm)
-                    .with_coarse_solver_factory(cg)
+                    .with_galerkin_ops(pgm)
+                    .with_coarse_solver(cg)
                     .on(this->exec)
                     ->generate(Mtx::create(this->exec, MPI_COMM_WORLD));
 
@@ -153,8 +148,8 @@ TYPED_TEST(SchwarzFactory, CanBeMoved)
     auto cg = gko::share(Cg::build().on(this->exec));
     auto copy = Schwarz::build()
                     .with_local_solver(bj)
-                    .with_galerkin_ops_factory(pgm)
-                    .with_coarse_solver_factory(cg)
+                    .with_galerkin_ops(pgm)
+                    .with_coarse_solver(cg)
                     .on(this->exec)
                     ->generate(Mtx::create(this->exec, MPI_COMM_WORLD));
 
@@ -170,8 +165,8 @@ TYPED_TEST(SchwarzFactory, CanBeCleared)
 
     ASSERT_EQ(this->schwarz->get_size(), gko::dim<2>(0, 0));
     ASSERT_EQ(this->schwarz->get_parameters().local_solver, nullptr);
-    ASSERT_EQ(this->schwarz->get_parameters().galerkin_ops_factory, nullptr);
-    ASSERT_EQ(this->schwarz->get_parameters().coarse_solver_factory, nullptr);
+    ASSERT_EQ(this->schwarz->get_parameters().galerkin_ops, nullptr);
+    ASSERT_EQ(this->schwarz->get_parameters().coarse_solver, nullptr);
 }
 
 
@@ -209,6 +204,3 @@ TYPED_TEST(SchwarzFactory, ApplyUsesInitialGuessAsLocalSolver)
     ASSERT_EQ(schwarz_with_jacobi->apply_uses_initial_guess(), false);
     ASSERT_EQ(schwarz_with_cg->apply_uses_initial_guess(), true);
 }
-
-
-}  // namespace

--- a/core/test/mpi/distributed/preconditioner/schwarz.cpp
+++ b/core/test/mpi/distributed/preconditioner/schwarz.cpp
@@ -44,7 +44,7 @@ protected:
                       .with_local_solver(jacobi_factory)
                       .with_coarse_level(pgm_factory)
                       .with_coarse_solver(cg_factory)
-                      .with_coarse_weight(0.4)
+                      .with_coarse_weight(value_type{0.4})
                       .on(exec)
                       ->generate(mtx);
     }
@@ -109,7 +109,9 @@ TYPED_TEST(SchwarzFactory, CanSetCoarseSolverFactory)
 
 TYPED_TEST(SchwarzFactory, CanSetCoarseWeight)
 {
-    ASSERT_EQ(this->schwarz->get_parameters().coarse_weight, 0.4);
+    using value_type = typename TestFixture::value_type;
+
+    ASSERT_EQ(this->schwarz->get_parameters().coarse_weight, value_type{0.4});
 }
 
 
@@ -123,6 +125,7 @@ TYPED_TEST(SchwarzFactory, CanBeCloned)
 
 TYPED_TEST(SchwarzFactory, CanBeCopied)
 {
+    using value_type = typename TestFixture::value_type;
     using Jacobi = typename TestFixture::Jacobi;
     using Pgm = typename TestFixture::Pgm;
     using Cg = typename TestFixture::Cg;
@@ -135,7 +138,7 @@ TYPED_TEST(SchwarzFactory, CanBeCopied)
                     .with_local_solver(bj)
                     .with_coarse_level(pgm)
                     .with_coarse_solver(cg)
-                    .with_coarse_weight(0.4)
+                    .with_coarse_weight(value_type{0.4})
                     .on(this->exec)
                     ->generate(Mtx::create(this->exec, MPI_COMM_WORLD));
 
@@ -147,6 +150,7 @@ TYPED_TEST(SchwarzFactory, CanBeCopied)
 
 TYPED_TEST(SchwarzFactory, CanBeMoved)
 {
+    using value_type = typename TestFixture::value_type;
     using Jacobi = typename TestFixture::Jacobi;
     using Pgm = typename TestFixture::Pgm;
     using Cg = typename TestFixture::Cg;
@@ -160,7 +164,7 @@ TYPED_TEST(SchwarzFactory, CanBeMoved)
                     .with_local_solver(bj)
                     .with_coarse_level(pgm)
                     .with_coarse_solver(cg)
-                    .with_coarse_weight(0.4)
+                    .with_coarse_weight(value_type{0.4})
                     .on(this->exec)
                     ->generate(Mtx::create(this->exec, MPI_COMM_WORLD));
 
@@ -172,13 +176,14 @@ TYPED_TEST(SchwarzFactory, CanBeMoved)
 
 TYPED_TEST(SchwarzFactory, CanBeCleared)
 {
+    using value_type = typename TestFixture::value_type;
     this->schwarz->clear();
 
     ASSERT_EQ(this->schwarz->get_size(), gko::dim<2>(0, 0));
     ASSERT_EQ(this->schwarz->get_parameters().local_solver, nullptr);
     ASSERT_EQ(this->schwarz->get_parameters().coarse_level, nullptr);
     ASSERT_EQ(this->schwarz->get_parameters().coarse_solver, nullptr);
-    ASSERT_EQ(this->schwarz->get_parameters().coarse_weight, -1);
+    ASSERT_EQ(this->schwarz->get_parameters().coarse_weight, value_type{-1});
 }
 
 

--- a/core/test/mpi/distributed/preconditioner/schwarz.cpp
+++ b/core/test/mpi/distributed/preconditioner/schwarz.cpp
@@ -7,6 +7,7 @@
 #include <ginkgo/config.hpp>
 #include <ginkgo/core/distributed/preconditioner/schwarz.hpp>
 #include <ginkgo/core/matrix/csr.hpp>
+#include <ginkgo/core/multigrid/pgm.hpp>
 #include <ginkgo/core/preconditioner/jacobi.hpp>
 #include <ginkgo/core/solver/cg.hpp>
 #include <ginkgo/core/stop/iteration.hpp>
@@ -29,6 +30,7 @@ protected:
     using Schwarz = gko::experimental::distributed::preconditioner::Schwarz<
         value_type, local_index_type, global_index_type>;
     using Jacobi = gko::preconditioner::Jacobi<value_type, local_index_type>;
+    using Pgm = gko::multigrid::Pgm<value_type, local_index_type>;
     using Mtx =
         gko::experimental::distributed::Matrix<value_type, local_index_type,
                                                global_index_type>;
@@ -36,10 +38,12 @@ protected:
     SchwarzFactory()
         : exec(gko::ReferenceExecutor::create()),
           jacobi_factory(Jacobi::build().on(exec)),
+          pgm_factory(Pgm::build().on(exec)),
           mtx(Mtx::create(exec, MPI_COMM_WORLD))
     {
         schwarz = Schwarz::build()
                       .with_local_solver(jacobi_factory)
+                      .with_coarse_solver_factory(pgm_factory)
                       .on(exec)
                       ->generate(mtx);
     }
@@ -57,11 +61,14 @@ protected:
         ASSERT_EQ(a->get_size(), b->get_size());
         ASSERT_EQ(a->get_parameters().local_solver,
                   b->get_parameters().local_solver);
+        ASSERT_EQ(a->get_parameters().coarse_solver_factory,
+                  b->get_parameters().coarse_solver_factory);
     }
 
     std::shared_ptr<const gko::Executor> exec;
     std::unique_ptr<Schwarz> schwarz;
     std::shared_ptr<typename Jacobi::Factory> jacobi_factory;
+    std::shared_ptr<typename Pgm::Factory> pgm_factory;
     std::shared_ptr<Mtx> mtx;
 };
 
@@ -82,6 +89,13 @@ TYPED_TEST(SchwarzFactory, CanSetLocalFactory)
 }
 
 
+TYPED_TEST(SchwarzFactory, CanSetCoarseSolverFactory)
+{
+    ASSERT_EQ(this->schwarz->get_parameters().coarse_solver_factory,
+              this->pgm_factory);
+}
+
+
 TYPED_TEST(SchwarzFactory, CanBeCloned)
 {
     auto schwarz_clone = clone(this->schwarz);
@@ -93,10 +107,14 @@ TYPED_TEST(SchwarzFactory, CanBeCloned)
 TYPED_TEST(SchwarzFactory, CanBeCopied)
 {
     using Jacobi = typename TestFixture::Jacobi;
+    using Pgm = typename TestFixture::Pgm;
     using Schwarz = typename TestFixture::Schwarz;
     using Mtx = typename TestFixture::Mtx;
+    auto bj = gko::share(Jacobi::build().on(this->exec));
+    auto pgm = gko::share(Pgm::build().on(this->exec));
     auto copy = Schwarz::build()
-                    .with_local_solver(Jacobi::build())
+                    .with_local_solver(bj)
+                    .with_coarse_solver_factory(pgm)
                     .on(this->exec)
                     ->generate(Mtx::create(this->exec, MPI_COMM_WORLD));
 
@@ -109,11 +127,15 @@ TYPED_TEST(SchwarzFactory, CanBeCopied)
 TYPED_TEST(SchwarzFactory, CanBeMoved)
 {
     using Jacobi = typename TestFixture::Jacobi;
+    using Pgm = typename TestFixture::Pgm;
     using Schwarz = typename TestFixture::Schwarz;
     using Mtx = typename TestFixture::Mtx;
     auto tmp = clone(this->schwarz);
+    auto bj = gko::share(Jacobi::build().on(this->exec));
+    auto pgm = gko::share(Pgm::build().on(this->exec));
     auto copy = Schwarz::build()
-                    .with_local_solver(Jacobi::build())
+                    .with_local_solver(bj)
+                    .with_coarse_solver_factory(pgm)
                     .on(this->exec)
                     ->generate(Mtx::create(this->exec, MPI_COMM_WORLD));
 
@@ -129,6 +151,7 @@ TYPED_TEST(SchwarzFactory, CanBeCleared)
 
     ASSERT_EQ(this->schwarz->get_size(), gko::dim<2>(0, 0));
     ASSERT_EQ(this->schwarz->get_parameters().local_solver, nullptr);
+    ASSERT_EQ(this->schwarz->get_parameters().coarse_solver_factory, nullptr);
 }
 
 

--- a/core/test/mpi/distributed/preconditioner/schwarz.cpp
+++ b/core/test/mpi/distributed/preconditioner/schwarz.cpp
@@ -42,7 +42,7 @@ protected:
     {
         schwarz = Schwarz::build()
                       .with_local_solver(jacobi_factory)
-                      .with_galerkin_ops(pgm_factory)
+                      .with_coarse_level(pgm_factory)
                       .with_coarse_solver(cg_factory)
                       .on(exec)
                       ->generate(mtx);
@@ -61,8 +61,8 @@ protected:
         ASSERT_EQ(a->get_size(), b->get_size());
         ASSERT_EQ(a->get_parameters().local_solver,
                   b->get_parameters().local_solver);
-        ASSERT_EQ(a->get_parameters().galerkin_ops,
-                  b->get_parameters().galerkin_ops);
+        ASSERT_EQ(a->get_parameters().coarse_level,
+                  b->get_parameters().coarse_level);
         ASSERT_EQ(a->get_parameters().coarse_solver,
                   b->get_parameters().coarse_solver);
     }
@@ -94,7 +94,7 @@ TYPED_TEST(SchwarzFactory, CanSetLocalFactory)
 
 TYPED_TEST(SchwarzFactory, CanSetGalerkinOpsFactory)
 {
-    ASSERT_EQ(this->schwarz->get_parameters().galerkin_ops, this->pgm_factory);
+    ASSERT_EQ(this->schwarz->get_parameters().coarse_level, this->pgm_factory);
 }
 
 
@@ -124,7 +124,7 @@ TYPED_TEST(SchwarzFactory, CanBeCopied)
     auto cg = gko::share(Cg::build().on(this->exec));
     auto copy = Schwarz::build()
                     .with_local_solver(bj)
-                    .with_galerkin_ops(pgm)
+                    .with_coarse_level(pgm)
                     .with_coarse_solver(cg)
                     .on(this->exec)
                     ->generate(Mtx::create(this->exec, MPI_COMM_WORLD));
@@ -148,7 +148,7 @@ TYPED_TEST(SchwarzFactory, CanBeMoved)
     auto cg = gko::share(Cg::build().on(this->exec));
     auto copy = Schwarz::build()
                     .with_local_solver(bj)
-                    .with_galerkin_ops(pgm)
+                    .with_coarse_level(pgm)
                     .with_coarse_solver(cg)
                     .on(this->exec)
                     ->generate(Mtx::create(this->exec, MPI_COMM_WORLD));
@@ -165,7 +165,7 @@ TYPED_TEST(SchwarzFactory, CanBeCleared)
 
     ASSERT_EQ(this->schwarz->get_size(), gko::dim<2>(0, 0));
     ASSERT_EQ(this->schwarz->get_parameters().local_solver, nullptr);
-    ASSERT_EQ(this->schwarz->get_parameters().galerkin_ops, nullptr);
+    ASSERT_EQ(this->schwarz->get_parameters().coarse_level, nullptr);
     ASSERT_EQ(this->schwarz->get_parameters().coarse_solver, nullptr);
 }
 

--- a/core/test/mpi/distributed/preconditioner/schwarz.cpp
+++ b/core/test/mpi/distributed/preconditioner/schwarz.cpp
@@ -31,6 +31,7 @@ protected:
         value_type, local_index_type, global_index_type>;
     using Jacobi = gko::preconditioner::Jacobi<value_type, local_index_type>;
     using Pgm = gko::multigrid::Pgm<value_type, local_index_type>;
+    using Cg = gko::solver::Cg<value_type>;
     using Mtx =
         gko::experimental::distributed::Matrix<value_type, local_index_type,
                                                global_index_type>;
@@ -39,10 +40,12 @@ protected:
         : exec(gko::ReferenceExecutor::create()),
           jacobi_factory(Jacobi::build().on(exec)),
           pgm_factory(Pgm::build().on(exec)),
+          cg_factory(Cg::build().on(exec)),
           mtx(Mtx::create(exec, MPI_COMM_WORLD))
     {
         schwarz = Schwarz::build()
                       .with_local_solver(jacobi_factory)
+                      .with_galerkin_ops_factory(pgm_factory)
                       .with_coarse_solver_factory(pgm_factory)
                       .on(exec)
                       ->generate(mtx);
@@ -61,6 +64,8 @@ protected:
         ASSERT_EQ(a->get_size(), b->get_size());
         ASSERT_EQ(a->get_parameters().local_solver,
                   b->get_parameters().local_solver);
+        ASSERT_EQ(a->get_parameters().galerkin_ops_factory,
+                  b->get_parameters().galerkin_ops_factory);
         ASSERT_EQ(a->get_parameters().coarse_solver_factory,
                   b->get_parameters().coarse_solver_factory);
     }
@@ -69,6 +74,7 @@ protected:
     std::unique_ptr<Schwarz> schwarz;
     std::shared_ptr<typename Jacobi::Factory> jacobi_factory;
     std::shared_ptr<typename Pgm::Factory> pgm_factory;
+    std::shared_ptr<typename Cg::Factory> cg_factory;
     std::shared_ptr<Mtx> mtx;
 };
 
@@ -89,10 +95,17 @@ TYPED_TEST(SchwarzFactory, CanSetLocalFactory)
 }
 
 
+TYPED_TEST(SchwarzFactory, CanSetGalerkinOpsFactory)
+{
+    ASSERT_EQ(this->schwarz->get_parameters().galerkin_ops_factory,
+              this->pgm_factory);
+}
+
+
 TYPED_TEST(SchwarzFactory, CanSetCoarseSolverFactory)
 {
     ASSERT_EQ(this->schwarz->get_parameters().coarse_solver_factory,
-              this->pgm_factory);
+              this->cg_factory);
 }
 
 
@@ -108,13 +121,16 @@ TYPED_TEST(SchwarzFactory, CanBeCopied)
 {
     using Jacobi = typename TestFixture::Jacobi;
     using Pgm = typename TestFixture::Pgm;
+    using Cg = typename TestFixture::Cg;
     using Schwarz = typename TestFixture::Schwarz;
     using Mtx = typename TestFixture::Mtx;
     auto bj = gko::share(Jacobi::build().on(this->exec));
     auto pgm = gko::share(Pgm::build().on(this->exec));
+    auto cg = gko::share(Cg::build().on(this->exec));
     auto copy = Schwarz::build()
                     .with_local_solver(bj)
-                    .with_coarse_solver_factory(pgm)
+                    .with_galerkin_ops_factory(pgm)
+                    .with_coarse_solver_factory(cg)
                     .on(this->exec)
                     ->generate(Mtx::create(this->exec, MPI_COMM_WORLD));
 
@@ -128,14 +144,17 @@ TYPED_TEST(SchwarzFactory, CanBeMoved)
 {
     using Jacobi = typename TestFixture::Jacobi;
     using Pgm = typename TestFixture::Pgm;
+    using Cg = typename TestFixture::Cg;
     using Schwarz = typename TestFixture::Schwarz;
     using Mtx = typename TestFixture::Mtx;
     auto tmp = clone(this->schwarz);
     auto bj = gko::share(Jacobi::build().on(this->exec));
     auto pgm = gko::share(Pgm::build().on(this->exec));
+    auto cg = gko::share(Cg::build().on(this->exec));
     auto copy = Schwarz::build()
                     .with_local_solver(bj)
-                    .with_coarse_solver_factory(pgm)
+                    .with_galerkin_ops_factory(pgm)
+                    .with_coarse_solver_factory(cg)
                     .on(this->exec)
                     ->generate(Mtx::create(this->exec, MPI_COMM_WORLD));
 
@@ -151,6 +170,7 @@ TYPED_TEST(SchwarzFactory, CanBeCleared)
 
     ASSERT_EQ(this->schwarz->get_size(), gko::dim<2>(0, 0));
     ASSERT_EQ(this->schwarz->get_parameters().local_solver, nullptr);
+    ASSERT_EQ(this->schwarz->get_parameters().galerkin_ops_factory, nullptr);
     ASSERT_EQ(this->schwarz->get_parameters().coarse_solver_factory, nullptr);
 }
 

--- a/core/test/mpi/distributed/preconditioner/schwarz.cpp
+++ b/core/test/mpi/distributed/preconditioner/schwarz.cpp
@@ -44,6 +44,7 @@ protected:
                       .with_local_solver(jacobi_factory)
                       .with_coarse_level(pgm_factory)
                       .with_coarse_solver(cg_factory)
+                      .with_coarse_weight(0.4)
                       .on(exec)
                       ->generate(mtx);
     }
@@ -65,10 +66,8 @@ protected:
                   b->get_parameters().coarse_level);
         ASSERT_EQ(a->get_parameters().coarse_solver,
                   b->get_parameters().coarse_solver);
-        ASSERT_EQ(a->get_parameters().coarse_correction.mode,
-                  b->get_parameters().coarse_correction.mode);
-        ASSERT_EQ(a->get_parameters().coarse_correction.weight,
-                  b->get_parameters().coarse_correction.weight);
+        ASSERT_EQ(a->get_parameters().coarse_weight,
+                  b->get_parameters().coarse_weight);
     }
 
     std::shared_ptr<const gko::Executor> exec;
@@ -108,39 +107,9 @@ TYPED_TEST(SchwarzFactory, CanSetCoarseSolverFactory)
 }
 
 
-TYPED_TEST(SchwarzFactory, CanSetAdditiveCorrectionType)
+TYPED_TEST(SchwarzFactory, CanSetCoarseWeight)
 {
-    using vtype = typename TestFixture::value_type;
-
-    ASSERT_EQ(this->schwarz->get_parameters().coarse_correction.mode,
-              gko::experimental::distributed::preconditioner::
-                  coarse_correction_mode::additive);
-    ASSERT_EQ(this->schwarz->get_parameters().coarse_correction.weight, 1.0);
-}
-
-
-TYPED_TEST(SchwarzFactory, CanSetMultiplicativeCorrectionType)
-{
-    using Schwarz = typename TestFixture::Schwarz;
-    using vtype = typename TestFixture::value_type;
-    auto schwarz =
-        Schwarz::build()
-            .with_local_solver(this->jacobi_factory)
-            .with_coarse_correction(
-                gko::experimental::distributed::preconditioner::
-                    coarse_correction_type(
-                        gko::experimental::distributed::preconditioner::
-                            coarse_correction_mode::multiplicative,
-                        0.4))
-            .with_coarse_level(this->pgm_factory)
-            .with_coarse_solver(this->cg_factory)
-            .on(this->exec)
-            ->generate(this->mtx);
-
-    ASSERT_EQ(schwarz->get_parameters().coarse_correction.mode,
-              gko::experimental::distributed::preconditioner::
-                  coarse_correction_mode::multiplicative);
-    ASSERT_EQ(schwarz->get_parameters().coarse_correction.weight, 0.4);
+    ASSERT_EQ(this->schwarz->get_parameters().coarse_weight, 0.4);
 }
 
 
@@ -166,6 +135,7 @@ TYPED_TEST(SchwarzFactory, CanBeCopied)
                     .with_local_solver(bj)
                     .with_coarse_level(pgm)
                     .with_coarse_solver(cg)
+                    .with_coarse_weight(0.4)
                     .on(this->exec)
                     ->generate(Mtx::create(this->exec, MPI_COMM_WORLD));
 
@@ -190,6 +160,7 @@ TYPED_TEST(SchwarzFactory, CanBeMoved)
                     .with_local_solver(bj)
                     .with_coarse_level(pgm)
                     .with_coarse_solver(cg)
+                    .with_coarse_weight(0.4)
                     .on(this->exec)
                     ->generate(Mtx::create(this->exec, MPI_COMM_WORLD));
 
@@ -207,6 +178,7 @@ TYPED_TEST(SchwarzFactory, CanBeCleared)
     ASSERT_EQ(this->schwarz->get_parameters().local_solver, nullptr);
     ASSERT_EQ(this->schwarz->get_parameters().coarse_level, nullptr);
     ASSERT_EQ(this->schwarz->get_parameters().coarse_solver, nullptr);
+    ASSERT_EQ(this->schwarz->get_parameters().coarse_weight, -1);
 }
 
 

--- a/examples/distributed-solver/distributed-solver.cpp
+++ b/examples/distributed-solver/distributed-solver.cpp
@@ -209,12 +209,11 @@ int main(int argc, char* argv[])
     if (schw_type == "multi-level") {
         Ainv =
             solver::build()
-                .with_preconditioner(
-                    schwarz::build()
-                        .with_local_solver(local_solver)
-                        .with_galerkin_ops_factory(pgm_fac)
-                        .with_coarse_solver_factory(coarse_solver)
-                        .on(exec))
+                .with_preconditioner(schwarz::build()
+                                         .with_local_solver(local_solver)
+                                         .with_galerkin_ops(pgm_fac)
+                                         .with_coarse_solver(coarse_solver)
+                                         .on(exec))
                 .with_criteria(
                     gko::stop::Iteration::build().with_max_iters(num_iters).on(
                         exec),

--- a/examples/distributed-solver/distributed-solver.cpp
+++ b/examples/distributed-solver/distributed-solver.cpp
@@ -211,7 +211,7 @@ int main(int argc, char* argv[])
             solver::build()
                 .with_preconditioner(
                     schwarz::build()
-                        .with_local_solver_factory(local_solver)
+                        .with_local_solver(local_solver)
                         .with_galerkin_ops_factory(pgm_fac)
                         .with_coarse_solver_factory(coarse_solver)
                         .on(exec))
@@ -228,11 +228,7 @@ int main(int argc, char* argv[])
         Ainv =
             solver::build()
                 .with_preconditioner(
-                    schwarz::build()
-                        .with_local_solver_factory(local_solver)
-                        .with_galerkin_ops_factory(pgm_fac)
-                        .with_coarse_solver_factory(coarse_solver)
-                        .on(exec))
+                    schwarz::build().with_local_solver(local_solver).on(exec))
                 .with_criteria(
                     gko::stop::Iteration::build().with_max_iters(num_iters).on(
                         exec),

--- a/examples/distributed-solver/distributed-solver.cpp
+++ b/examples/distributed-solver/distributed-solver.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -211,7 +211,7 @@ int main(int argc, char* argv[])
             solver::build()
                 .with_preconditioner(schwarz::build()
                                          .with_local_solver(local_solver)
-                                         .with_galerkin_ops(pgm_fac)
+                                         .with_coarse_level(pgm_fac)
                                          .with_coarse_solver(coarse_solver)
                                          .on(exec))
                 .with_criteria(

--- a/examples/distributed-solver/distributed-solver.cpp
+++ b/examples/distributed-solver/distributed-solver.cpp
@@ -64,7 +64,8 @@ int main(int argc, char* argv[])
     // - The executor, defaults to reference.
     // - The number of grid points, defaults to 100.
     // - The number of iterations, defaults to 1000.
-    // - One-level or two-level preconditioner, defaults to one-level.
+    // - One-level, two-level preconditioner, and no preconditioner, defaults to
+    // one-level.
     if (argc == 2 && (std::string(argv[1]) == "--help")) {
         if (rank == 0) {
             std::cerr << "Usage: " << argv[0]
@@ -214,6 +215,9 @@ int main(int argc, char* argv[])
     std::shared_ptr<const gko::log::Convergence<ValueType>> logger =
         gko::log::Convergence<ValueType>::create();
     std::shared_ptr<gko::LinOp> Ainv{};
+    // The benefit of the two-level Schwarz preconditioner is generally
+    // observable (in runtime and in number of iterations) usually for larger
+    // problem sizes and for larger number of ranks.
     if (schw_type == "two-level") {
         Ainv =
             solver::build()

--- a/include/ginkgo/core/distributed/preconditioner/schwarz.hpp
+++ b/include/ginkgo/core/distributed/preconditioner/schwarz.hpp
@@ -39,13 +39,18 @@ namespace preconditioner {
  * generalizes the Block Jacobi preconditioner, incorporating options for
  * different local subdomain solvers and overlaps between the subdomains.
  *
+ * A L1 smoother variant is also available, which updates the local matrix with
+ * the sums of the non-local matrix row sums.
+ *
  * See Iterative Methods for Sparse Linear Systems (Y. Saad) for a general
  * treatment and variations of the method.
  *
  * A Two-level variant is also available. To enable two-level preconditioning,
  * you need to specify a LinOpFactory that can generate a
- * multigrid::MultigridLevel. Currently, only multiplicative coarse correction
- * is supported.
+ * multigrid::MultigridLevel and a solver for the coarse level solution.
+ * Currently, only additive coarse correction is supported with an optional
+ * weighting between the local and the coarse solutions, for cases when the
+ * coarse solutions might tend to overcorrect.
  * - See Smith, Bjorstad, Gropp, Domain Decomposition, 1996, Cambridge
  * University Press.
  *

--- a/include/ginkgo/core/distributed/preconditioner/schwarz.hpp
+++ b/include/ginkgo/core/distributed/preconditioner/schwarz.hpp
@@ -20,7 +20,6 @@
 #include <ginkgo/core/distributed/matrix.hpp>
 #include <ginkgo/core/distributed/vector.hpp>
 #include <ginkgo/core/distributed/vector_cache.hpp>
-#include <ginkgo/core/multigrid/multigrid_level.hpp>
 #include <ginkgo/core/solver/solver_base.hpp>
 
 
@@ -112,9 +111,9 @@ public:
         /**
          * Coarse weighting.
          *
-         * By default the coarse and the local solutions are added together. A
-         * weighting can instead be provided if the coarse solution tends to
-         * over-correct.
+         * By default the coarse and the local solutions are added together
+         * (when the coarse weight is < 0). A weighting can instead be provided
+         * if the coarse solution tends to over-correct.
          */
         double GKO_FACTORY_PARAMETER_SCALAR(coarse_weight, double{-1.0});
 
@@ -166,7 +165,6 @@ protected:
      */
     explicit Schwarz(std::shared_ptr<const Executor> exec)
         : EnableLinOp<Schwarz>(std::move(exec))
-
     {}
 
     /**

--- a/include/ginkgo/core/distributed/preconditioner/schwarz.hpp
+++ b/include/ginkgo/core/distributed/preconditioner/schwarz.hpp
@@ -189,8 +189,9 @@ private:
 
     detail::VectorCache<ValueType> cache_;
 
-    std::shared_ptr<const multigrid::MultigridLevel> coarse_solver_;
-    std::shared_ptr<const multigrid::MultigridLevel> galerkin_ops_;
+    std::shared_ptr<const LinOp> coarse_solver_;
+    std::shared_ptr<LinOp> csol_;
+    std::shared_ptr<const LinOp> half_;
 };
 
 

--- a/include/ginkgo/core/distributed/preconditioner/schwarz.hpp
+++ b/include/ginkgo/core/distributed/preconditioner/schwarz.hpp
@@ -34,6 +34,26 @@ namespace distributed {
  */
 namespace preconditioner {
 
+/**
+ * The mode for the multi-level coarse correction
+ *
+ * - additive:       Additively incorporate the coarse level correction.
+ * - multiplicative: Multiplicatively incorporate the coarse level correction.
+ *
+ * See Domain Decomposition, Smith, Bjorstad, Gropp, Cambridge University Press,
+ * 1996.
+ */
+enum class coarse_correction_mode { additive, multiplicative };
+
+struct coarse_correction_type {
+    explicit coarse_correction_type(coarse_correction_mode m, double w)
+        : mode(m), weight(w)
+    {}
+
+    coarse_correction_mode mode;
+    double weight;
+};
+
 
 /**
  * A Schwarz preconditioner is a simple domain decomposition preconditioner that
@@ -114,17 +134,20 @@ public:
             coarse_level);
 
         /**
-         * Weighting for the coarse solution
-         */
-        ValueType GKO_FACTORY_PARAMETER(coarse_weight, value_type{0.5});
-
-        /**
          * Coarse solver factory.
          *
          * TODO: Set default
          */
         std::shared_ptr<const LinOpFactory> GKO_DEFERRED_FACTORY_PARAMETER(
             coarse_solver);
+
+        /**
+         * Coarse correction type: Additive or multiplicative and their
+         * respective weights.
+         */
+        coarse_correction_type GKO_FACTORY_PARAMETER_SCALAR(
+            coarse_correction,
+            coarse_correction_type(coarse_correction_mode::additive, 1.0));
     };
     GKO_ENABLE_LIN_OP_FACTORY(Schwarz, parameters, Factory);
     GKO_ENABLE_BUILD_METHOD(Factory);

--- a/include/ginkgo/core/distributed/preconditioner/schwarz.hpp
+++ b/include/ginkgo/core/distributed/preconditioner/schwarz.hpp
@@ -20,6 +20,7 @@
 #include <ginkgo/core/distributed/matrix.hpp>
 #include <ginkgo/core/distributed/vector.hpp>
 #include <ginkgo/core/distributed/vector_cache.hpp>
+#include <ginkgo/core/multigrid/multigrid_level.hpp>
 
 
 namespace gko {
@@ -99,6 +100,12 @@ public:
          * local solver.
          */
         bool GKO_FACTORY_PARAMETER_SCALAR(l1_smoother, false);
+
+        /**
+         * Coarse solver factory.
+         */
+        std::shared_ptr<const LinOpFactory> GKO_FACTORY_PARAMETER_SCALAR(
+            coarse_solver_factory, nullptr);
     };
     GKO_ENABLE_LIN_OP_FACTORY(Schwarz, parameters, Factory);
     GKO_ENABLE_BUILD_METHOD(Factory);
@@ -131,6 +138,7 @@ protected:
      */
     explicit Schwarz(std::shared_ptr<const Executor> exec)
         : EnableLinOp<Schwarz>(std::move(exec))
+
     {}
 
     /**
@@ -173,6 +181,8 @@ private:
     std::shared_ptr<const LinOp> local_solver_;
 
     detail::VectorCache<ValueType> cache_;
+
+    std::shared_ptr<const multigrid::MultigridLevel> coarse_solver_;
 };
 
 

--- a/include/ginkgo/core/distributed/preconditioner/schwarz.hpp
+++ b/include/ginkgo/core/distributed/preconditioner/schwarz.hpp
@@ -105,6 +105,9 @@ public:
          * sum of the non-local matrix entries. The diagonal matrix
          * is then added to the system matrix when generating the
          * local solver.
+         *
+         * Note: The L1 smoother will not be used for the coarse level matrix
+         * generation, and the original system matrix will still be used.
          */
         bool GKO_FACTORY_PARAMETER_SCALAR(l1_smoother, false);
 

--- a/include/ginkgo/core/distributed/preconditioner/schwarz.hpp
+++ b/include/ginkgo/core/distributed/preconditioner/schwarz.hpp
@@ -103,14 +103,25 @@ public:
         bool GKO_FACTORY_PARAMETER_SCALAR(l1_smoother, false);
 
         /**
-         * Operator factory to generate the triplet (prolong_op, coarse_op,
-         * restrict_op).
+         * Operator factory list to generate the triplet (prolong_op, coarse_op,
+         * restrict_op), `A_c = R * A * P`
+         *
+         * Note: The linop factory must generate the triplet (R, A_c, P). For
+         * example, any coarse level generator from multigrid::MultigridLevel
+         * can be used.
          */
         std::shared_ptr<const LinOpFactory> GKO_DEFERRED_FACTORY_PARAMETER(
-            galerkin_ops);
+            coarse_level);
+
+        /**
+         * Weighting for the coarse solution
+         */
+        ValueType GKO_FACTORY_PARAMETER(coarse_weight, value_type{0.5});
 
         /**
          * Coarse solver factory.
+         *
+         * TODO: Set default
          */
         std::shared_ptr<const LinOpFactory> GKO_DEFERRED_FACTORY_PARAMETER(
             coarse_solver);
@@ -191,9 +202,10 @@ private:
     detail::VectorCache<ValueType> cache_;
     detail::VectorCache<ValueType> csol_cache_;
 
-    std::shared_ptr<const LinOp> galerkin_ops_;
+    std::shared_ptr<const LinOp> coarse_level_;
     std::shared_ptr<const LinOp> coarse_solver_;
-    std::shared_ptr<const LinOp> half_;
+    std::shared_ptr<const matrix::Dense<ValueType>> coarse_weight_;
+    std::shared_ptr<const matrix::Dense<ValueType>> local_weight_;
 };
 
 

--- a/include/ginkgo/core/distributed/preconditioner/schwarz.hpp
+++ b/include/ginkgo/core/distributed/preconditioner/schwarz.hpp
@@ -102,6 +102,13 @@ public:
         bool GKO_FACTORY_PARAMETER_SCALAR(l1_smoother, false);
 
         /**
+         * Operator factory to generate the triplet (prolong_op, coarse_op,
+         * restrict_op).
+         */
+        std::shared_ptr<const LinOpFactory> GKO_FACTORY_PARAMETER_SCALAR(
+            galerkin_ops_factory, nullptr);
+
+        /**
          * Coarse solver factory.
          */
         std::shared_ptr<const LinOpFactory> GKO_FACTORY_PARAMETER_SCALAR(
@@ -183,6 +190,7 @@ private:
     detail::VectorCache<ValueType> cache_;
 
     std::shared_ptr<const multigrid::MultigridLevel> coarse_solver_;
+    std::shared_ptr<const multigrid::MultigridLevel> galerkin_ops_;
 };
 
 

--- a/include/ginkgo/core/distributed/preconditioner/schwarz.hpp
+++ b/include/ginkgo/core/distributed/preconditioner/schwarz.hpp
@@ -112,10 +112,10 @@ public:
          * Coarse weighting.
          *
          * By default the coarse and the local solutions are added together
-         * (when the coarse weight is < 0). A weighting can instead be provided
-         * if the coarse solution tends to over-correct.
+         * (when the coarse weight is < 0 or > 1). A weighting can instead be
+         * provided if the coarse solution tends to over-correct.
          */
-        double GKO_FACTORY_PARAMETER_SCALAR(coarse_weight, double{-1.0});
+        ValueType GKO_FACTORY_PARAMETER_SCALAR(coarse_weight, ValueType{-1.0});
 
         /**
          * Operator factory list to generate the triplet (prolong_op, coarse_op,
@@ -212,6 +212,7 @@ private:
     detail::VectorCache<ValueType> cache_;
     // Used in apply for two-level method
     detail::VectorCache<ValueType> csol_cache_;
+    detail::VectorCache<ValueType> crhs_cache_;
 
     std::shared_ptr<const LinOp> coarse_level_;
     std::shared_ptr<const LinOp> coarse_solver_;

--- a/include/ginkgo/core/distributed/preconditioner/schwarz.hpp
+++ b/include/ginkgo/core/distributed/preconditioner/schwarz.hpp
@@ -189,10 +189,10 @@ private:
     std::shared_ptr<const LinOp> local_solver_;
 
     detail::VectorCache<ValueType> cache_;
+    detail::VectorCache<ValueType> csol_cache_;
 
     std::shared_ptr<const LinOp> galerkin_ops_;
     std::shared_ptr<const LinOp> coarse_solver_;
-    std::shared_ptr<LinOp> csol_;
     std::shared_ptr<const LinOp> half_;
 };
 

--- a/include/ginkgo/core/distributed/preconditioner/schwarz.hpp
+++ b/include/ginkgo/core/distributed/preconditioner/schwarz.hpp
@@ -21,6 +21,7 @@
 #include <ginkgo/core/distributed/vector.hpp>
 #include <ginkgo/core/distributed/vector_cache.hpp>
 #include <ginkgo/core/multigrid/multigrid_level.hpp>
+#include <ginkgo/core/solver/solver_base.hpp>
 
 
 namespace gko {
@@ -105,14 +106,14 @@ public:
          * Operator factory to generate the triplet (prolong_op, coarse_op,
          * restrict_op).
          */
-        std::shared_ptr<const LinOpFactory> GKO_FACTORY_PARAMETER_SCALAR(
-            galerkin_ops_factory, nullptr);
+        std::shared_ptr<const LinOpFactory> GKO_DEFERRED_FACTORY_PARAMETER(
+            galerkin_ops);
 
         /**
          * Coarse solver factory.
          */
-        std::shared_ptr<const LinOpFactory> GKO_FACTORY_PARAMETER_SCALAR(
-            coarse_solver_factory, nullptr);
+        std::shared_ptr<const LinOpFactory> GKO_DEFERRED_FACTORY_PARAMETER(
+            coarse_solver);
     };
     GKO_ENABLE_LIN_OP_FACTORY(Schwarz, parameters, Factory);
     GKO_ENABLE_BUILD_METHOD(Factory);
@@ -189,6 +190,7 @@ private:
 
     detail::VectorCache<ValueType> cache_;
 
+    std::shared_ptr<const LinOp> galerkin_ops_;
     std::shared_ptr<const LinOp> coarse_solver_;
     std::shared_ptr<LinOp> csol_;
     std::shared_ptr<const LinOp> half_;

--- a/include/ginkgo/core/distributed/vector.hpp
+++ b/include/ginkgo/core/distributed/vector.hpp
@@ -538,7 +538,7 @@ public:
      * @note  The data form the local_vector will be moved into the new
      *        distributed vector. You could either move in a std::unique_ptr
      *        directly, copy a local vector with gko::clone, or create a
-     *        unique non-owining view of a given local vector with
+     *        unique non-owning view of a given local vector with
      *        gko::make_dense_view.
      *
      * @param exec  Executor associated with this vector
@@ -561,7 +561,7 @@ public:
      * @note  The data form the local_vector will be moved into the new
      *        distributed vector. You could either move in a std::unique_ptr
      *        directly, copy a local vector with gko::clone, or create a
-     *        unique non-owining view of a given local vector with
+     *        unique non-owning view of a given local vector with
      *        gko::make_dense_view.
      *
      * @param exec  Executor associated with this vector

--- a/test/mpi/preconditioner/schwarz.cpp
+++ b/test/mpi/preconditioner/schwarz.cpp
@@ -20,6 +20,7 @@
 #include <ginkgo/core/log/logger.hpp>
 #include <ginkgo/core/matrix/csr.hpp>
 #include <ginkgo/core/matrix/dense.hpp>
+#include <ginkgo/core/multigrid/pgm.hpp>
 #include <ginkgo/core/preconditioner/jacobi.hpp>
 #include <ginkgo/core/solver/bicgstab.hpp>
 #include <ginkgo/core/solver/cg.hpp>
@@ -52,6 +53,9 @@ protected:
     using solver_type = gko::solver::Bicgstab<value_type>;
     using local_prec_type =
         gko::preconditioner::Jacobi<value_type, local_index_type>;
+    using coarse_solver_type =
+        gko::preconditioner::Jacobi<value_type, local_index_type>;
+    using galerkin_ops_type = gko::multigrid::Pgm<value_type, local_index_type>;
     using local_matrix_type = gko::matrix::Csr<value_type, local_index_type>;
     using non_dist_matrix_type =
         gko::matrix::Csr<value_type, global_index_type>;
@@ -118,6 +122,8 @@ protected:
     std::shared_ptr<gko::LinOpFactory> non_dist_solver_factory;
     std::shared_ptr<gko::LinOpFactory> dist_solver_factory;
     std::shared_ptr<gko::LinOpFactory> local_solver_factory;
+    std::shared_ptr<gko::LinOpFactory> pgm_factory;
+    std::shared_ptr<gko::LinOpFactory> coarse_solver_factory;
 
     void assert_equal_to_non_distributed_vector(
         std::shared_ptr<dist_vec_type> dist_vec,
@@ -251,6 +257,28 @@ TYPED_TEST(SchwarzPreconditioner, CanApplyPreconditioner)
 
     auto precond_factory = prec::build()
                                .with_local_solver(this->local_solver_factory)
+                               .on(this->exec);
+    auto local_precond =
+        this->local_solver_factory->generate(this->non_dist_mat);
+    auto precond = precond_factory->generate(this->dist_mat);
+
+    precond->apply(this->dist_b.get(), this->dist_x.get());
+    local_precond->apply(this->non_dist_b.get(), this->non_dist_x.get());
+
+    this->assert_equal_to_non_distributed_vector(this->dist_x,
+                                                 this->non_dist_x);
+}
+
+
+TYPED_TEST(SchwarzPreconditioner, CanApplyMultilevelPreconditioner)
+{
+    using value_type = typename TestFixture::value_type;
+    using prec = typename TestFixture::dist_prec_type;
+
+    auto precond_factory = prec::build()
+                               .with_local_solver(this->local_solver_factory)
+                               .with_coarse_solver(this->coarse_solver_factory)
+                               .with_galerkin_ops(this->pgm_factory)
                                .on(this->exec);
     auto local_precond =
         this->local_solver_factory->generate(this->non_dist_mat);

--- a/test/mpi/preconditioner/schwarz.cpp
+++ b/test/mpi/preconditioner/schwarz.cpp
@@ -55,7 +55,7 @@ protected:
         gko::preconditioner::Jacobi<value_type, local_index_type>;
     using coarse_solver_type =
         gko::preconditioner::Jacobi<value_type, local_index_type>;
-    using galerkin_ops_type = gko::multigrid::Pgm<value_type, local_index_type>;
+    using coarse_level_type = gko::multigrid::Pgm<value_type, local_index_type>;
     using local_matrix_type = gko::matrix::Csr<value_type, local_index_type>;
     using non_dist_matrix_type =
         gko::matrix::Csr<value_type, global_index_type>;
@@ -278,7 +278,7 @@ TYPED_TEST(SchwarzPreconditioner, CanApplyMultilevelPreconditioner)
     auto precond_factory = prec::build()
                                .with_local_solver(this->local_solver_factory)
                                .with_coarse_solver(this->coarse_solver_factory)
-                               .with_galerkin_ops(this->pgm_factory)
+                               .with_coarse_level(this->pgm_factory)
                                .on(this->exec);
     auto local_precond =
         this->local_solver_factory->generate(this->non_dist_mat);


### PR DESCRIPTION
This PR uses the distributed coarse level generation from PGM to use as a coarse level for the additive Schwarz preconditioner. The only requirement is that the galerkin product generator ($RAP$) generate a `multigrid::MultigridLevel` which is a triplet of `restrict`, `prolong` and `coarse` operators. The user additionally also needs to set the solver for the coarse level.

### TODO

~~+ [ ] Add options to switch between multiplicative and additive~~
~~+ [ ] Options for arbitrary number of levels.~~

### Possible issues
1. The coarse level solve significantly reduces the number of iterations, but can be extremely expensive. Maybe makes sense to apply coarse solve, only a few times instead of every preconditioner apply (need to be careful of consistency of preconditioner apply) ? 
2. Weighting between the local solver solution and the coarse solution is unclear. 
3. Though the coarse solve and the local solve are independent, we have no way of performing them in parallel. This will probably require a rewrite of the apply interface to enable asynchronicity, in addition to support for multiple streams/queues.