### PR TITLE
Remove templated matrix constructors

### DIFF
--- a/benchmark/utils/overhead_linop.hpp
+++ b/benchmark/utils/overhead_linop.hpp
@@ -135,7 +135,7 @@ protected:
                 parameters_.preconditioner->generate(system_matrix_));
         } else {
             set_preconditioner(matrix::Identity<ValueType>::create(
-                this->get_executor(), this->get_size()));
+                this->get_executor(), this->get_size()[0]));
         }
         stop_criterion_factory_ =
             stop::combine(std::move(parameters_.criteria));

--- a/core/base/batch_multi_vector.cpp
+++ b/core/base/batch_multi_vector.cpp
@@ -100,6 +100,20 @@ MultiVector<ValueType>::MultiVector(std::shared_ptr<const Executor> exec,
 
 
 template <typename ValueType>
+MultiVector<ValueType>::MultiVector(std::shared_ptr<const Executor> exec,
+                                    const batch_dim<2>& size,
+                                    array<value_type> values)
+    : EnablePolymorphicObject<MultiVector<ValueType>>(exec),
+      batch_size_(size),
+      values_{exec, std::move(values)}
+{
+    // Ensure that the values array has the correct size
+    auto num_elems = compute_num_elems(size);
+    GKO_ENSURE_IN_BOUNDS(num_elems, values_.get_size() + 1);
+}
+
+
+template <typename ValueType>
 std::unique_ptr<MultiVector<ValueType>>
 MultiVector<ValueType>::create_with_config_of(
     ptr_param<const MultiVector> other)
@@ -109,6 +123,24 @@ MultiVector<ValueType>::create_with_config_of(
     // CUDA 10.1.
     // Otherwise, it results in a compile error.
     return (*other).create_with_same_config();
+}
+
+
+template <typename ValueType>
+std::unique_ptr<MultiVector<ValueType>> MultiVector<ValueType>::create(
+    std::shared_ptr<const Executor> exec, const batch_dim<2>& size)
+{
+    return std::unique_ptr<MultiVector<ValueType>>{new MultiVector{exec, size}};
+}
+
+
+template <typename ValueType>
+std::unique_ptr<MultiVector<ValueType>> MultiVector<ValueType>::create(
+    std::shared_ptr<const Executor> exec, const batch_dim<2>& size,
+    array<value_type> values)
+{
+    return std::unique_ptr<MultiVector<ValueType>>{
+        new MultiVector{exec, size, std::move(values)}};
 }
 
 

--- a/core/base/device_matrix_data.cpp
+++ b/core/base/device_matrix_data.cpp
@@ -50,6 +50,21 @@ device_matrix_data<ValueType, IndexType>::device_matrix_data(
 
 
 template <typename ValueType, typename IndexType>
+device_matrix_data<ValueType, IndexType>::device_matrix_data(
+    std::shared_ptr<const Executor> exec, dim<2> size,
+    array<index_type> row_idxs, array<index_type> col_idxs,
+    array<value_type> values)
+    : size_{size},
+      row_idxs_{exec, std::move(row_idxs)},
+      col_idxs_{exec, std::move(col_idxs)},
+      values_{exec, std::move(values)}
+{
+    GKO_ASSERT_EQ(values_.get_size(), row_idxs_.get_size());
+    GKO_ASSERT_EQ(values_.get_size(), col_idxs_.get_size());
+}
+
+
+template <typename ValueType, typename IndexType>
 matrix_data<ValueType, IndexType>
 device_matrix_data<ValueType, IndexType>::copy_to_host() const
 {

--- a/core/base/perturbation.cpp
+++ b/core/base/perturbation.cpp
@@ -68,6 +68,46 @@ Perturbation<ValueType>::Perturbation(Perturbation&& other)
 
 
 template <typename ValueType>
+Perturbation<ValueType>::Perturbation(std::shared_ptr<const Executor> exec)
+    : EnableLinOp<Perturbation>(std::move(exec))
+{}
+
+
+template <typename ValueType>
+Perturbation<ValueType>::Perturbation(std::shared_ptr<const LinOp> scalar,
+                                      std::shared_ptr<const LinOp> basis)
+    : Perturbation(std::move(scalar),
+                   // basis can not be std::move(basis). Otherwise, Program
+                   // deletes basis before applying conjugate transpose
+                   basis,
+                   std::move((as<gko::Transposable>(basis))->conj_transpose()))
+{}
+
+
+template <typename ValueType>
+Perturbation<ValueType>::Perturbation(std::shared_ptr<const LinOp> scalar,
+                                      std::shared_ptr<const LinOp> basis,
+                                      std::shared_ptr<const LinOp> projector)
+    : EnableLinOp<Perturbation>(basis->get_executor(),
+                                gko::dim<2>{basis->get_size()[0]}),
+      scalar_{std::move(scalar)},
+      basis_{std::move(basis)},
+      projector_{std::move(projector)}
+{
+    this->validate_perturbation();
+}
+
+
+template <typename ValueType>
+void Perturbation<ValueType>::validate_perturbation()
+{
+    GKO_ASSERT_CONFORMANT(basis_, projector_);
+    GKO_ASSERT_CONFORMANT(projector_, basis_);
+    GKO_ASSERT_EQUAL_DIMENSIONS(scalar_, dim<2>(1, 1));
+}
+
+
+template <typename ValueType>
 void Perturbation<ValueType>::apply_impl(const LinOp* b, LinOp* x) const
 {
     // x = (I + scalar * basis * projector) * b

--- a/core/base/perturbation.cpp
+++ b/core/base/perturbation.cpp
@@ -99,6 +99,32 @@ Perturbation<ValueType>::Perturbation(std::shared_ptr<const LinOp> scalar,
 
 
 template <typename ValueType>
+std::unique_ptr<Perturbation<ValueType>> Perturbation<ValueType>::create(
+    std::shared_ptr<const Executor> exec)
+{
+    return std::unique_ptr<Perturbation>{new Perturbation{exec}};
+}
+
+
+template <typename ValueType>
+std::unique_ptr<Perturbation<ValueType>> Perturbation<ValueType>::create(
+    std::shared_ptr<const LinOp> scalar, std::shared_ptr<const LinOp> basis)
+{
+    return std::unique_ptr<Perturbation>{new Perturbation{scalar, basis}};
+}
+
+
+template <typename ValueType>
+std::unique_ptr<Perturbation<ValueType>> Perturbation<ValueType>::create(
+    std::shared_ptr<const LinOp> scalar, std::shared_ptr<const LinOp> basis,
+    std::shared_ptr<const LinOp> projector)
+{
+    return std::unique_ptr<Perturbation>{
+        new Perturbation{scalar, basis, projector}};
+}
+
+
+template <typename ValueType>
 void Perturbation<ValueType>::validate_perturbation()
 {
     GKO_ASSERT_CONFORMANT(basis_, projector_);

--- a/core/distributed/matrix.cpp
+++ b/core/distributed/matrix.cpp
@@ -31,15 +31,9 @@ GKO_REGISTER_OPERATION(build_local_nonlocal,
 template <typename ValueType, typename LocalIndexType, typename GlobalIndexType>
 Matrix<ValueType, LocalIndexType, GlobalIndexType>::Matrix(
     std::shared_ptr<const Executor> exec, mpi::communicator comm)
-    : Matrix(exec, comm, with_matrix_type<gko::matrix::Csr>())
-{}
-
-
-template <typename ValueType, typename LocalIndexType, typename GlobalIndexType>
-Matrix<ValueType, LocalIndexType, GlobalIndexType>::Matrix(
-    std::shared_ptr<const Executor> exec, mpi::communicator comm,
-    ptr_param<const LinOp> local_matrix_template)
-    : Matrix(exec, comm, local_matrix_template, local_matrix_template)
+    : Matrix(exec, comm,
+             gko::matrix::Csr<ValueType, LocalIndexType>::create(exec),
+             gko::matrix::Csr<ValueType, LocalIndexType>::create(exec))
 {}
 
 
@@ -69,6 +63,37 @@ Matrix<ValueType, LocalIndexType, GlobalIndexType>::Matrix(
             non_local_mtx_.get())));
     one_scalar_.init(exec, dim<2>{1, 1});
     one_scalar_->fill(one<value_type>());
+}
+
+
+template <typename ValueType, typename LocalIndexType, typename GlobalIndexType>
+std::unique_ptr<Matrix<ValueType, LocalIndexType, GlobalIndexType>>
+Matrix<ValueType, LocalIndexType, GlobalIndexType>::create(
+    std::shared_ptr<const Executor> exec, mpi::communicator comm)
+{
+    return std::unique_ptr<Matrix>{new Matrix{exec, comm}};
+}
+
+
+template <typename ValueType, typename LocalIndexType, typename GlobalIndexType>
+std::unique_ptr<Matrix<ValueType, LocalIndexType, GlobalIndexType>>
+Matrix<ValueType, LocalIndexType, GlobalIndexType>::create(
+    std::shared_ptr<const Executor> exec, mpi::communicator comm,
+    ptr_param<const LinOp> matrix_template)
+{
+    return create(exec, comm, matrix_template, matrix_template);
+}
+
+
+template <typename ValueType, typename LocalIndexType, typename GlobalIndexType>
+std::unique_ptr<Matrix<ValueType, LocalIndexType, GlobalIndexType>>
+Matrix<ValueType, LocalIndexType, GlobalIndexType>::create(
+    std::shared_ptr<const Executor> exec, mpi::communicator comm,
+    ptr_param<const LinOp> local_matrix_template,
+    ptr_param<const LinOp> non_local_matrix_template)
+{
+    return std::unique_ptr<Matrix>{new Matrix{exec, comm, local_matrix_template,
+                                              non_local_matrix_template}};
 }
 
 

--- a/core/distributed/partition.cpp
+++ b/core/distributed/partition.cpp
@@ -29,6 +29,37 @@ GKO_REGISTER_OPERATION(has_ordered_parts, partition::has_ordered_parts);
 
 
 template <typename LocalIndexType, typename GlobalIndexType>
+Partition<LocalIndexType, GlobalIndexType>::Partition(
+    std::shared_ptr<const Executor> exec, comm_index_type num_parts,
+    size_type num_ranges)
+    : EnablePolymorphicObject<Partition>{exec},
+      num_parts_{num_parts},
+      num_empty_parts_{0},
+      size_{0},
+      offsets_{exec, num_ranges + 1},
+      starting_indices_{exec, num_ranges},
+      part_sizes_{exec, static_cast<size_type>(num_parts)},
+      part_ids_{exec, num_ranges}
+{
+    offsets_.fill(0);
+    starting_indices_.fill(0);
+    part_sizes_.fill(0);
+    part_ids_.fill(0);
+}
+
+
+template <typename LocalIndexType, typename GlobalIndexType>
+std::unique_ptr<Partition<LocalIndexType, GlobalIndexType>>
+Partition<LocalIndexType, GlobalIndexType>::create(
+    std::shared_ptr<const Executor> exec, comm_index_type num_parts,
+    size_type num_ranges)
+{
+    return std::unique_ptr<Partition>{
+        new Partition{exec, num_parts, num_ranges}};
+}
+
+
+template <typename LocalIndexType, typename GlobalIndexType>
 std::unique_ptr<Partition<LocalIndexType, GlobalIndexType>>
 Partition<LocalIndexType, GlobalIndexType>::build_from_mapping(
     std::shared_ptr<const Executor> exec, const array<comm_index_type>& mapping,

--- a/core/distributed/vector.cpp
+++ b/core/distributed/vector.cpp
@@ -95,6 +95,45 @@ Vector<ValueType>::Vector(std::shared_ptr<const Executor> exec,
     local_vector->move_to(&local_);
 }
 
+template <typename ValueType>
+std::unique_ptr<Vector<ValueType>> Vector<ValueType>::create(
+    std::shared_ptr<const Executor> exec, mpi::communicator comm,
+    dim<2> global_size, dim<2> local_size, size_type stride)
+{
+    return std::unique_ptr<Vector>{
+        new Vector{exec, comm, global_size, local_size, stride}};
+}
+
+
+template <typename ValueType>
+std::unique_ptr<Vector<ValueType>> Vector<ValueType>::create(
+    std::shared_ptr<const Executor> exec, mpi::communicator comm,
+    dim<2> global_size, dim<2> local_size)
+{
+    return std::unique_ptr<Vector>{
+        new Vector{exec, comm, global_size, local_size}};
+}
+
+
+template <typename ValueType>
+std::unique_ptr<Vector<ValueType>> Vector<ValueType>::create(
+    std::shared_ptr<const Executor> exec, mpi::communicator comm,
+    dim<2> global_size, std::unique_ptr<local_vector_type> local_vector)
+{
+    return std::unique_ptr<Vector>{
+        new Vector{exec, comm, global_size, std::move(local_vector)}};
+}
+
+
+template <typename ValueType>
+std::unique_ptr<Vector<ValueType>> Vector<ValueType>::create(
+    std::shared_ptr<const Executor> exec, mpi::communicator comm,
+    std::unique_ptr<local_vector_type> local_vector)
+{
+    return std::unique_ptr<Vector>{
+        new Vector{exec, comm, std::move(local_vector)}};
+}
+
 
 template <typename ValueType>
 std::unique_ptr<const Vector<ValueType>> Vector<ValueType>::create_const(

--- a/core/factorization/symbolic.cpp
+++ b/core/factorization/symbolic.cpp
@@ -110,7 +110,7 @@ void symbolic_lu_near_symm(
         // compute A + A^T symbolically
         const auto scalar = gko::initialize<scalar_type>({one<float>()}, exec);
         const auto symm_mtx = as<float_matrix_type>(float_mtx->transpose());
-        const auto id = id_type::create(exec, size);
+        const auto id = id_type::create(exec, size[0]);
         float_mtx->apply(scalar, id, scalar, symm_mtx);
         // compute Cholesky factorization
         std::unique_ptr<elimination_forest<IndexType>> forest;

--- a/core/matrix/batch_csr.cpp
+++ b/core/matrix/batch_csr.cpp
@@ -76,6 +76,27 @@ Csr<ValueType, IndexType>::create_const_view_for_item(size_type item_id) const
 
 
 template <typename ValueType, typename IndexType>
+std::unique_ptr<Csr<ValueType, IndexType>> Csr<ValueType, IndexType>::create(
+    std::shared_ptr<const Executor> exec, const batch_dim<2>& size,
+    size_type num_nonzeros_per_item)
+{
+    return std::unique_ptr<Csr>{new Csr{exec, size, num_nonzeros_per_item}};
+}
+
+
+template <typename ValueType, typename IndexType>
+std::unique_ptr<Csr<ValueType, IndexType>> Csr<ValueType, IndexType>::create(
+    std::shared_ptr<const Executor> exec, const batch_dim<2>& size,
+    array<value_type> values, array<index_type> col_idxs,
+    array<index_type> row_ptrs)
+{
+    return std::unique_ptr<Csr>{new Csr{exec, size, std::move(values),
+                                        std::move(col_idxs),
+                                        std::move(row_ptrs)}};
+}
+
+
+template <typename ValueType, typename IndexType>
 std::unique_ptr<const Csr<ValueType, IndexType>>
 Csr<ValueType, IndexType>::create_const(
     std::shared_ptr<const Executor> exec, const batch_dim<2>& sizes,

--- a/core/matrix/batch_identity.cpp
+++ b/core/matrix/batch_identity.cpp
@@ -35,6 +35,14 @@ Identity<ValueType>::Identity(std::shared_ptr<const Executor> exec,
 
 
 template <typename ValueType>
+std::unique_ptr<Identity<ValueType>> Identity<ValueType>::create(
+    std::shared_ptr<const Executor> exec, const batch_dim<2>& size)
+{
+    return std::unique_ptr<Identity>{new Identity{exec, size}};
+}
+
+
+template <typename ValueType>
 Identity<ValueType>* Identity<ValueType>::apply(
     ptr_param<const MultiVector<ValueType>> b,
     ptr_param<MultiVector<ValueType>> x)

--- a/core/matrix/coo.cpp
+++ b/core/matrix/coo.cpp
@@ -52,6 +52,122 @@ GKO_REGISTER_OPERATION(aos_to_soa, components::aos_to_soa);
 
 
 template <typename ValueType, typename IndexType>
+std::unique_ptr<Coo<ValueType, IndexType>> Coo<ValueType, IndexType>::create(
+    std::shared_ptr<const Executor> exec, const dim<2>& size,
+    size_type num_nonzeros)
+{
+    return std::unique_ptr<Coo>{new Coo{exec, size, num_nonzeros}};
+}
+
+
+template <typename ValueType, typename IndexType>
+std::unique_ptr<Coo<ValueType, IndexType>> Coo<ValueType, IndexType>::create(
+    std::shared_ptr<const Executor> exec, const dim<2>& size,
+    array<value_type> values, array<index_type> col_idxs,
+    array<index_type> row_idxs)
+{
+    return std::unique_ptr<Coo>{new Coo{exec, size, std::move(values),
+                                        std::move(col_idxs),
+                                        std::move(row_idxs)}};
+}
+
+
+template <typename ValueType, typename IndexType>
+std::unique_ptr<const Coo<ValueType, IndexType>>
+Coo<ValueType, IndexType>::create_const(
+    std::shared_ptr<const Executor> exec, const dim<2>& size,
+    gko::detail::const_array_view<ValueType>&& values,
+    gko::detail::const_array_view<IndexType>&& col_idxs,
+    gko::detail::const_array_view<IndexType>&& row_idxs)
+{
+    // cast const-ness away, but return a const object afterwards,
+    // so we can ensure that no modifications take place.
+    return create(exec, size, gko::detail::array_const_cast(std::move(values)),
+                  gko::detail::array_const_cast(std::move(col_idxs)),
+                  gko::detail::array_const_cast(std::move(row_idxs)));
+}
+
+
+template <typename ValueType, typename IndexType>
+Coo<ValueType, IndexType>::Coo(std::shared_ptr<const Executor> exec,
+                               const dim<2>& size, size_type num_nonzeros)
+    : EnableLinOp<Coo>(exec, size),
+      values_(exec, num_nonzeros),
+      col_idxs_(exec, num_nonzeros),
+      row_idxs_(exec, num_nonzeros)
+{}
+
+
+template <typename ValueType, typename IndexType>
+Coo<ValueType, IndexType>::Coo(std::shared_ptr<const Executor> exec,
+                               const dim<2>& size, array<value_type> values,
+                               array<index_type> col_idxs,
+                               array<index_type> row_idxs)
+    : EnableLinOp<Coo>(exec, size),
+      values_{exec, std::move(values)},
+      col_idxs_{exec, std::move(col_idxs)},
+      row_idxs_{exec, std::move(row_idxs)}
+{
+    GKO_ASSERT_EQ(values_.get_size(), col_idxs_.get_size());
+    GKO_ASSERT_EQ(values_.get_size(), row_idxs_.get_size());
+}
+
+
+template <typename ValueType, typename IndexType>
+LinOp* Coo<ValueType, IndexType>::apply2(ptr_param<const LinOp> b,
+                                         ptr_param<LinOp> x)
+{
+    this->validate_application_parameters(b.get(), x.get());
+    auto exec = this->get_executor();
+    this->apply2_impl(make_temporary_clone(exec, b).get(),
+                      make_temporary_clone(exec, x).get());
+    return this;
+}
+
+
+template <typename ValueType, typename IndexType>
+const LinOp* Coo<ValueType, IndexType>::apply2(ptr_param<const LinOp> b,
+                                               ptr_param<LinOp> x) const
+{
+    this->validate_application_parameters(b.get(), x.get());
+    auto exec = this->get_executor();
+    this->apply2_impl(make_temporary_clone(exec, b).get(),
+                      make_temporary_clone(exec, x).get());
+    return this;
+}
+
+
+template <typename ValueType, typename IndexType>
+LinOp* Coo<ValueType, IndexType>::apply2(ptr_param<const LinOp> alpha,
+                                         ptr_param<const LinOp> b,
+                                         ptr_param<LinOp> x)
+{
+    this->validate_application_parameters(b.get(), x.get());
+    GKO_ASSERT_EQUAL_DIMENSIONS(alpha, dim<2>(1, 1));
+    auto exec = this->get_executor();
+    this->apply2_impl(make_temporary_clone(exec, alpha).get(),
+                      make_temporary_clone(exec, b).get(),
+                      make_temporary_clone(exec, x).get());
+    return this;
+}
+
+
+template <typename ValueType, typename IndexType>
+const LinOp* Coo<ValueType, IndexType>::apply2(ptr_param<const LinOp> alpha,
+                                               ptr_param<const LinOp> b,
+                                               ptr_param<LinOp> x) const
+{
+    this->validate_application_parameters(b.get(), x.get());
+    GKO_ASSERT_EQUAL_DIMENSIONS(alpha, dim<2>(1, 1));
+    auto exec = this->get_executor();
+    this->apply2_impl(make_temporary_clone(exec, alpha).get(),
+                      make_temporary_clone(exec, b).get(),
+                      make_temporary_clone(exec, x).get());
+    return this;
+}
+
+
+template <typename ValueType, typename IndexType>
 void Coo<ValueType, IndexType>::apply_impl(const LinOp* b, LinOp* x) const
 {
     precision_dispatch_real_complex<ValueType>(

--- a/core/matrix/csr.cpp
+++ b/core/matrix/csr.cpp
@@ -121,20 +121,6 @@ Csr<ValueType, IndexType>::create_const(
 
 
 template <typename ValueType, typename IndexType>
-std::unique_ptr<const Csr<ValueType, IndexType>>
-Csr<ValueType, IndexType>::create_const(
-    std::shared_ptr<const Executor> exec, const dim<2>& size,
-    gko::detail::const_array_view<ValueType>&& values,
-    gko::detail::const_array_view<IndexType>&& col_idxs,
-    gko::detail::const_array_view<IndexType>&& row_ptrs)
-{
-    return Csr::create_const(exec, size, std::move(values), std::move(col_idxs),
-                             std::move(row_ptrs),
-                             Csr::make_default_strategy(exec));
-}
-
-
-template <typename ValueType, typename IndexType>
 std::unique_ptr<Csr<ValueType, IndexType>> Csr<ValueType, IndexType>::create(
     std::shared_ptr<const Executor> exec,
     std::shared_ptr<strategy_type> strategy)
@@ -156,15 +142,6 @@ std::unique_ptr<Csr<ValueType, IndexType>> Csr<ValueType, IndexType>::create(
 template <typename ValueType, typename IndexType>
 std::unique_ptr<Csr<ValueType, IndexType>> Csr<ValueType, IndexType>::create(
     std::shared_ptr<const Executor> exec, const dim<2>& size,
-    size_type num_nonzeros)
-{
-    return std::unique_ptr<Csr>{new Csr{exec, size, num_nonzeros}};
-}
-
-
-template <typename ValueType, typename IndexType>
-std::unique_ptr<Csr<ValueType, IndexType>> Csr<ValueType, IndexType>::create(
-    std::shared_ptr<const Executor> exec, const dim<2>& size,
     array<value_type> values, array<index_type> col_idxs,
     array<index_type> row_ptrs, std::shared_ptr<strategy_type> strategy)
 {
@@ -175,45 +152,19 @@ std::unique_ptr<Csr<ValueType, IndexType>> Csr<ValueType, IndexType>::create(
 
 
 template <typename ValueType, typename IndexType>
-std::unique_ptr<Csr<ValueType, IndexType>> Csr<ValueType, IndexType>::create(
-    std::shared_ptr<const Executor> exec, const dim<2>& size,
-    array<value_type> values, array<index_type> col_idxs,
-    array<index_type> row_ptrs)
-{
-    return std::unique_ptr<Csr>{new Csr{exec, size, std::move(values),
-                                        std::move(col_idxs),
-                                        std::move(row_ptrs)}};
-}
-
-
-template <typename ValueType, typename IndexType>
-Csr<ValueType, IndexType>::Csr(std::shared_ptr<const Executor> exec,
-                               std::shared_ptr<strategy_type> strategy)
-    : Csr(std::move(exec), dim<2>{}, {}, std::move(strategy))
-{}
-
-
-template <typename ValueType, typename IndexType>
 Csr<ValueType, IndexType>::Csr(std::shared_ptr<const Executor> exec,
                                const dim<2>& size, size_type num_nonzeros,
                                std::shared_ptr<strategy_type> strategy)
     : EnableLinOp<Csr>(exec, size),
+      strategy_(strategy ? strategy->copy() : Csr::make_default_strategy(exec)),
       values_(exec, num_nonzeros),
       col_idxs_(exec, num_nonzeros),
       row_ptrs_(exec, size[0] + 1),
-      srow_(exec, strategy->clac_size(num_nonzeros)),
-      strategy_(strategy->copy())
+      srow_(exec, strategy_->clac_size(num_nonzeros))
 {
     row_ptrs_.fill(0);
     this->make_srow();
 }
-
-
-template <typename ValueType, typename IndexType>
-Csr<ValueType, IndexType>::Csr(std::shared_ptr<const Executor> exec,
-                               const dim<2>& size, size_type num_nonzeros)
-    : Csr{exec, size, num_nonzeros, Csr::make_default_strategy(exec)}
-{}
 
 
 template <typename ValueType, typename IndexType>
@@ -223,30 +174,16 @@ Csr<ValueType, IndexType>::Csr(std::shared_ptr<const Executor> exec,
                                array<index_type> row_ptrs,
                                std::shared_ptr<strategy_type> strategy)
     : EnableLinOp<Csr>(exec, size),
+      strategy_(strategy ? strategy->copy() : Csr::make_default_strategy(exec)),
       values_{exec, std::move(values)},
       col_idxs_{exec, std::move(col_idxs)},
       row_ptrs_{exec, std::move(row_ptrs)},
-      srow_(exec),
-      strategy_(strategy->copy())
+      srow_(exec)
 {
     GKO_ASSERT_EQ(values_.get_size(), col_idxs_.get_size());
     GKO_ASSERT_EQ(this->get_size()[0] + 1, row_ptrs_.get_size());
     this->make_srow();
 }
-
-
-template <typename ValueType, typename IndexType>
-Csr<ValueType, IndexType>::Csr(std::shared_ptr<const Executor> exec,
-                               const dim<2>& size, array<value_type> values,
-                               array<index_type> col_idxs,
-                               array<index_type> row_ptrs)
-    : Csr{exec,
-          size,
-          std::move(values),
-          std::move(col_idxs),
-          std::move(row_ptrs),
-          Csr::make_default_strategy(exec)}
-{}
 
 
 template <typename ValueType, typename IndexType>

--- a/core/matrix/dense.cpp
+++ b/core/matrix/dense.cpp
@@ -1982,14 +1982,6 @@ std::unique_ptr<Dense<ValueType>> Dense<ValueType>::create_submatrix_impl(
 
 template <typename ValueType>
 std::unique_ptr<Dense<ValueType>> Dense<ValueType>::create(
-    std::shared_ptr<const Executor> exec, const dim<2>& size)
-{
-    return std::unique_ptr<Dense>{new Dense{exec, size}};
-}
-
-
-template <typename ValueType>
-std::unique_ptr<Dense<ValueType>> Dense<ValueType>::create(
     std::shared_ptr<const Executor> exec, const dim<2>& size, size_type stride)
 {
     return std::unique_ptr<Dense>{new Dense{exec, size, stride}};
@@ -2020,17 +2012,10 @@ std::unique_ptr<const Dense<ValueType>> Dense<ValueType>::create_const(
 
 template <typename ValueType>
 Dense<ValueType>::Dense(std::shared_ptr<const Executor> exec,
-                        const dim<2>& size)
-    : Dense(std::move(exec), size, size[1])
-{}
-
-
-template <typename ValueType>
-Dense<ValueType>::Dense(std::shared_ptr<const Executor> exec,
                         const dim<2>& size, size_type stride)
     : EnableLinOp<Dense>(exec, size),
-      values_(exec, size[0] * stride),
-      stride_(stride)
+      stride_(stride == 0 ? size[1] : stride),
+      values_(exec, size[0] * stride_)
 {}
 
 

--- a/core/matrix/dense.cpp
+++ b/core/matrix/dense.cpp
@@ -1980,6 +1980,75 @@ std::unique_ptr<Dense<ValueType>> Dense<ValueType>::create_submatrix_impl(
 }
 
 
+template <typename ValueType>
+std::unique_ptr<Dense<ValueType>> Dense<ValueType>::create(
+    std::shared_ptr<const Executor> exec, const dim<2>& size)
+{
+    return std::unique_ptr<Dense>{new Dense{exec, size}};
+}
+
+
+template <typename ValueType>
+std::unique_ptr<Dense<ValueType>> Dense<ValueType>::create(
+    std::shared_ptr<const Executor> exec, const dim<2>& size, size_type stride)
+{
+    return std::unique_ptr<Dense>{new Dense{exec, size, stride}};
+}
+
+
+template <typename ValueType>
+std::unique_ptr<Dense<ValueType>> Dense<ValueType>::create(
+    std::shared_ptr<const Executor> exec, const dim<2>& size,
+    array<value_type> values, size_type stride)
+{
+    return std::unique_ptr<Dense>{
+        new Dense{exec, size, std::move(values), stride}};
+}
+
+
+template <typename ValueType>
+std::unique_ptr<const Dense<ValueType>> Dense<ValueType>::create_const(
+    std::shared_ptr<const Executor> exec, const dim<2>& size,
+    gko::detail::const_array_view<ValueType>&& values, size_type stride)
+{
+    // cast const-ness away, but return a const object afterwards,
+    // so we can ensure that no modifications take place.
+    return std::unique_ptr<const Dense>{new Dense{
+        exec, size, gko::detail::array_const_cast(std::move(values)), stride}};
+}
+
+
+template <typename ValueType>
+Dense<ValueType>::Dense(std::shared_ptr<const Executor> exec,
+                        const dim<2>& size)
+    : Dense(std::move(exec), size, size[1])
+{}
+
+
+template <typename ValueType>
+Dense<ValueType>::Dense(std::shared_ptr<const Executor> exec,
+                        const dim<2>& size, size_type stride)
+    : EnableLinOp<Dense>(exec, size),
+      values_(exec, size[0] * stride),
+      stride_(stride)
+{}
+
+
+template <typename ValueType>
+Dense<ValueType>::Dense(std::shared_ptr<const Executor> exec,
+                        const dim<2>& size, array<value_type> values,
+                        size_type stride)
+    : EnableLinOp<Dense>(exec, size),
+      values_{exec, std::move(values)},
+      stride_{stride}
+{
+    if (size[0] > 0 && size[1] > 0) {
+        GKO_ENSURE_IN_BOUNDS((size[0] - 1) * stride + size[1] - 1,
+                             values_.get_size());
+    }
+}
+
+
 #define GKO_DECLARE_DENSE_MATRIX(_type) class Dense<_type>
 GKO_INSTANTIATE_FOR_EACH_VALUE_TYPE(GKO_DECLARE_DENSE_MATRIX);
 

--- a/core/matrix/diagonal.cpp
+++ b/core/matrix/diagonal.cpp
@@ -328,12 +328,6 @@ Diagonal<ValueType>::compute_absolute() const
 
 
 template <typename ValueType>
-Diagonal<ValueType>::Diagonal(std::shared_ptr<const Executor> exec)
-    : Diagonal(std::move(exec), size_type{})
-{}
-
-
-template <typename ValueType>
 Diagonal<ValueType>::Diagonal(std::shared_ptr<const Executor> exec,
                               size_type size)
     : EnableLinOp<Diagonal>(exec, dim<2>{size}), values_(exec, size)
@@ -347,14 +341,6 @@ Diagonal<ValueType>::Diagonal(std::shared_ptr<const Executor> exec,
       values_{exec, std::move(values)}
 {
     GKO_ENSURE_IN_BOUNDS(size - 1, values_.get_size());
-}
-
-
-template <typename ValueType>
-std::unique_ptr<Diagonal<ValueType>> Diagonal<ValueType>::create(
-    std::shared_ptr<const Executor> exec)
-{
-    return std::unique_ptr<Diagonal>{new Diagonal{exec}};
 }
 
 

--- a/core/matrix/diagonal.cpp
+++ b/core/matrix/diagonal.cpp
@@ -327,6 +327,67 @@ Diagonal<ValueType>::compute_absolute() const
 }
 
 
+template <typename ValueType>
+Diagonal<ValueType>::Diagonal(std::shared_ptr<const Executor> exec)
+    : Diagonal(std::move(exec), size_type{})
+{}
+
+
+template <typename ValueType>
+Diagonal<ValueType>::Diagonal(std::shared_ptr<const Executor> exec,
+                              size_type size)
+    : EnableLinOp<Diagonal>(exec, dim<2>{size}), values_(exec, size)
+{}
+
+
+template <typename ValueType>
+Diagonal<ValueType>::Diagonal(std::shared_ptr<const Executor> exec,
+                              const size_type size, array<value_type> values)
+    : EnableLinOp<Diagonal>(exec, dim<2>(size)),
+      values_{exec, std::move(values)}
+{
+    GKO_ENSURE_IN_BOUNDS(size - 1, values_.get_size());
+}
+
+
+template <typename ValueType>
+std::unique_ptr<Diagonal<ValueType>> Diagonal<ValueType>::create(
+    std::shared_ptr<const Executor> exec)
+{
+    return std::unique_ptr<Diagonal>{new Diagonal{exec}};
+}
+
+
+template <typename ValueType>
+std::unique_ptr<Diagonal<ValueType>> Diagonal<ValueType>::create(
+    std::shared_ptr<const Executor> exec, size_type size)
+{
+    return std::unique_ptr<Diagonal>{new Diagonal{exec, size}};
+}
+
+
+template <typename ValueType>
+std::unique_ptr<Diagonal<ValueType>> Diagonal<ValueType>::create(
+    std::shared_ptr<const Executor> exec, const size_type size,
+    array<value_type> values)
+{
+    return std::unique_ptr<Diagonal>{
+        new Diagonal{exec, size, std::move(values)}};
+}
+
+
+template <typename ValueType>
+std::unique_ptr<const Diagonal<ValueType>> Diagonal<ValueType>::create_const(
+    std::shared_ptr<const Executor> exec, size_type size,
+    gko::detail::const_array_view<ValueType>&& values)
+{
+    // cast const-ness away, but return a const object afterwards,
+    // so we can ensure that no modifications take place.
+    return std::unique_ptr<const Diagonal>{new Diagonal{
+        exec, size, gko::detail::array_const_cast(std::move(values))}};
+}
+
+
 #define GKO_DECLARE_DIAGONAL_MATRIX(value_type) class Diagonal<value_type>
 GKO_INSTANTIATE_FOR_EACH_VALUE_TYPE(GKO_DECLARE_DIAGONAL_MATRIX);
 

--- a/core/matrix/ell.cpp
+++ b/core/matrix/ell.cpp
@@ -335,24 +335,6 @@ Ell<ValueType, IndexType>::compute_absolute() const
 
 template <typename ValueType, typename IndexType>
 std::unique_ptr<Ell<ValueType, IndexType>> Ell<ValueType, IndexType>::create(
-    std::shared_ptr<const Executor> exec, const dim<2>& size)
-{
-    return std::unique_ptr<Ell>{new Ell{exec, size}};
-}
-
-
-template <typename ValueType, typename IndexType>
-std::unique_ptr<Ell<ValueType, IndexType>> Ell<ValueType, IndexType>::create(
-    std::shared_ptr<const Executor> exec, const dim<2>& size,
-    size_type num_stored_elements_per_row)
-{
-    return std::unique_ptr<Ell>{
-        new Ell{exec, size, num_stored_elements_per_row}};
-}
-
-
-template <typename ValueType, typename IndexType>
-std::unique_ptr<Ell<ValueType, IndexType>> Ell<ValueType, IndexType>::create(
     std::shared_ptr<const Executor> exec, const dim<2>& size,
     size_type num_stored_elements_per_row, size_type stride)
 {
@@ -392,29 +374,14 @@ Ell<ValueType, IndexType>::create_const(
 
 template <typename ValueType, typename IndexType>
 Ell<ValueType, IndexType>::Ell(std::shared_ptr<const Executor> exec,
-                               const dim<2>& size)
-    : Ell(std::move(exec), size, size[1])
-{}
-
-
-template <typename ValueType, typename IndexType>
-Ell<ValueType, IndexType>::Ell(std::shared_ptr<const Executor> exec,
-                               const dim<2>& size,
-                               size_type num_stored_elements_per_row)
-    : Ell(std::move(exec), size, num_stored_elements_per_row, size[0])
-{}
-
-
-template <typename ValueType, typename IndexType>
-Ell<ValueType, IndexType>::Ell(std::shared_ptr<const Executor> exec,
                                const dim<2>& size,
                                size_type num_stored_elements_per_row,
                                size_type stride)
     : EnableLinOp<Ell>(exec, size),
-      values_(exec, stride * num_stored_elements_per_row),
-      col_idxs_(exec, stride * num_stored_elements_per_row),
-      num_stored_elements_per_row_(num_stored_elements_per_row),
-      stride_(stride)
+      stride_(stride == 0 ? size[0] : stride),
+      values_(exec, stride_ * num_stored_elements_per_row),
+      col_idxs_(exec, stride_ * num_stored_elements_per_row),
+      num_stored_elements_per_row_(num_stored_elements_per_row)
 {}
 
 

--- a/core/matrix/ell.cpp
+++ b/core/matrix/ell.cpp
@@ -333,6 +333,108 @@ Ell<ValueType, IndexType>::compute_absolute() const
 }
 
 
+template <typename ValueType, typename IndexType>
+std::unique_ptr<Ell<ValueType, IndexType>> Ell<ValueType, IndexType>::create(
+    std::shared_ptr<const Executor> exec, const dim<2>& size)
+{
+    return std::unique_ptr<Ell>{new Ell{exec, size}};
+}
+
+
+template <typename ValueType, typename IndexType>
+std::unique_ptr<Ell<ValueType, IndexType>> Ell<ValueType, IndexType>::create(
+    std::shared_ptr<const Executor> exec, const dim<2>& size,
+    size_type num_stored_elements_per_row)
+{
+    return std::unique_ptr<Ell>{
+        new Ell{exec, size, num_stored_elements_per_row}};
+}
+
+
+template <typename ValueType, typename IndexType>
+std::unique_ptr<Ell<ValueType, IndexType>> Ell<ValueType, IndexType>::create(
+    std::shared_ptr<const Executor> exec, const dim<2>& size,
+    size_type num_stored_elements_per_row, size_type stride)
+{
+    return std::unique_ptr<Ell>{
+        new Ell{exec, size, num_stored_elements_per_row, stride}};
+}
+
+
+template <typename ValueType, typename IndexType>
+std::unique_ptr<Ell<ValueType, IndexType>> Ell<ValueType, IndexType>::create(
+    std::shared_ptr<const Executor> exec, const dim<2>& size,
+    array<value_type> values, array<index_type> col_idxs,
+    size_type num_stored_elements_per_row, size_type stride)
+{
+    return std::unique_ptr<Ell>{new Ell{exec, size, std::move(values),
+                                        std::move(col_idxs),
+                                        num_stored_elements_per_row, stride}};
+}
+
+
+template <typename ValueType, typename IndexType>
+std::unique_ptr<const Ell<ValueType, IndexType>>
+Ell<ValueType, IndexType>::create_const(
+    std::shared_ptr<const Executor> exec, const dim<2>& size,
+    gko::detail::const_array_view<ValueType>&& values,
+    gko::detail::const_array_view<IndexType>&& col_idxs,
+    size_type num_stored_elements_per_row, size_type stride)
+{
+    // cast const-ness away, but return a const object afterwards,
+    // so we can ensure that no modifications take place.
+    return std::unique_ptr<const Ell>{
+        new Ell{exec, size, gko::detail::array_const_cast(std::move(values)),
+                gko::detail::array_const_cast(std::move(col_idxs)),
+                num_stored_elements_per_row, stride}};
+}
+
+
+template <typename ValueType, typename IndexType>
+Ell<ValueType, IndexType>::Ell(std::shared_ptr<const Executor> exec,
+                               const dim<2>& size)
+    : Ell(std::move(exec), size, size[1])
+{}
+
+
+template <typename ValueType, typename IndexType>
+Ell<ValueType, IndexType>::Ell(std::shared_ptr<const Executor> exec,
+                               const dim<2>& size,
+                               size_type num_stored_elements_per_row)
+    : Ell(std::move(exec), size, num_stored_elements_per_row, size[0])
+{}
+
+
+template <typename ValueType, typename IndexType>
+Ell<ValueType, IndexType>::Ell(std::shared_ptr<const Executor> exec,
+                               const dim<2>& size,
+                               size_type num_stored_elements_per_row,
+                               size_type stride)
+    : EnableLinOp<Ell>(exec, size),
+      values_(exec, stride * num_stored_elements_per_row),
+      col_idxs_(exec, stride * num_stored_elements_per_row),
+      num_stored_elements_per_row_(num_stored_elements_per_row),
+      stride_(stride)
+{}
+
+
+template <typename ValueType, typename IndexType>
+Ell<ValueType, IndexType>::Ell(std::shared_ptr<const Executor> exec,
+                               const dim<2>& size, array<value_type> values,
+                               array<index_type> col_idxs,
+                               size_type num_stored_elements_per_row,
+                               size_type stride)
+    : EnableLinOp<Ell>(exec, size),
+      values_{exec, std::move(values)},
+      col_idxs_{exec, std::move(col_idxs)},
+      num_stored_elements_per_row_{num_stored_elements_per_row},
+      stride_{stride}
+{
+    GKO_ASSERT_EQ(num_stored_elements_per_row_ * stride_, values_.get_size());
+    GKO_ASSERT_EQ(num_stored_elements_per_row_ * stride_, col_idxs_.get_size());
+}
+
+
 #define GKO_DECLARE_ELL_MATRIX(ValueType, IndexType) \
     class Ell<ValueType, IndexType>
 GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(GKO_DECLARE_ELL_MATRIX);

--- a/core/matrix/fbcsr.cpp
+++ b/core/matrix/fbcsr.cpp
@@ -389,6 +389,97 @@ Fbcsr<ValueType, IndexType>::compute_absolute() const
 }
 
 
+template <typename ValueType, typename IndexType>
+std::unique_ptr<Fbcsr<ValueType, IndexType>>
+Fbcsr<ValueType, IndexType>::create(std::shared_ptr<const Executor> exec,
+                                    int block_size)
+{
+    return std::unique_ptr<Fbcsr>{new Fbcsr{exec, block_size}};
+}
+
+
+template <typename ValueType, typename IndexType>
+std::unique_ptr<Fbcsr<ValueType, IndexType>>
+Fbcsr<ValueType, IndexType>::create(std::shared_ptr<const Executor> exec,
+                                    const dim<2>& size, size_type num_nonzeros,
+                                    int block_size)
+{
+    return std::unique_ptr<Fbcsr>{
+        new Fbcsr{exec, size, num_nonzeros, block_size}};
+}
+
+
+template <typename ValueType, typename IndexType>
+std::unique_ptr<Fbcsr<ValueType, IndexType>>
+Fbcsr<ValueType, IndexType>::create(std::shared_ptr<const Executor> exec,
+                                    const dim<2>& size, int block_size,
+                                    array<value_type> values,
+                                    array<index_type> col_idxs,
+                                    array<index_type> row_ptrs)
+{
+    return std::unique_ptr<Fbcsr>{
+        new Fbcsr{exec, size, block_size, std::move(values),
+                  std::move(col_idxs), std::move(row_ptrs)}};
+}
+
+
+template <typename ValueType, typename IndexType>
+std::unique_ptr<const Fbcsr<ValueType, IndexType>>
+Fbcsr<ValueType, IndexType>::create_const(
+    std::shared_ptr<const Executor> exec, const dim<2>& size, int blocksize,
+    gko::detail::const_array_view<ValueType>&& values,
+    gko::detail::const_array_view<IndexType>&& col_idxs,
+    gko::detail::const_array_view<IndexType>&& row_ptrs)
+{
+    // cast const-ness away, but return a const object afterwards,
+    // so we can ensure that no modifications take place.
+    return std::unique_ptr<const Fbcsr>{new Fbcsr{
+        exec, size, blocksize, gko::detail::array_const_cast(std::move(values)),
+        gko::detail::array_const_cast(std::move(col_idxs)),
+        gko::detail::array_const_cast(std::move(row_ptrs))}};
+}
+
+
+template <typename ValueType, typename IndexType>
+Fbcsr<ValueType, IndexType>::Fbcsr(std::shared_ptr<const Executor> exec,
+                                   int block_size)
+    : Fbcsr(std::move(exec), dim<2>{}, {}, block_size)
+{}
+
+
+template <typename ValueType, typename IndexType>
+Fbcsr<ValueType, IndexType>::Fbcsr(std::shared_ptr<const Executor> exec,
+                                   const dim<2>& size, size_type num_nonzeros,
+                                   int block_size)
+    : EnableLinOp<Fbcsr>(exec, size),
+      bs_{block_size},
+      values_(exec, num_nonzeros),
+      col_idxs_(exec,
+                detail::get_num_blocks(block_size * block_size, num_nonzeros)),
+      row_ptrs_(exec, detail::get_num_blocks(block_size, size[0]) + 1)
+{
+    GKO_ASSERT_BLOCK_SIZE_CONFORMANT(size[1], bs_);
+    row_ptrs_.fill(0);
+}
+
+
+template <typename ValueType, typename IndexType>
+Fbcsr<ValueType, IndexType>::Fbcsr(std::shared_ptr<const Executor> exec,
+                                   const dim<2>& size, int block_size,
+                                   array<value_type> values,
+                                   array<index_type> col_idxs,
+                                   array<index_type> row_ptrs)
+    : EnableLinOp<Fbcsr>(exec, size),
+      bs_{block_size},
+      values_{exec, std::move(values)},
+      col_idxs_{exec, std::move(col_idxs)},
+      row_ptrs_{exec, std::move(row_ptrs)}
+{
+    GKO_ASSERT_EQ(values_.get_size(), col_idxs_.get_size() * bs_ * bs_);
+    GKO_ASSERT_EQ(this->get_size()[0] / bs_ + 1, row_ptrs_.get_size());
+}
+
+
 #define GKO_DECLARE_FBCSR_MATRIX(ValueType, IndexType) \
     class Fbcsr<ValueType, IndexType>
 GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(GKO_DECLARE_FBCSR_MATRIX);

--- a/core/matrix/fft.cpp
+++ b/core/matrix/fft.cpp
@@ -183,11 +183,6 @@ void Fft::apply_impl(const LinOp* alpha, const LinOp* b, const LinOp* beta,
 }
 
 
-Fft::Fft(std::shared_ptr<const Executor> exec)
-    : EnableLinOp<Fft>(exec), buffer_{exec}, inverse_{}
-{}
-
-
 Fft::Fft(std::shared_ptr<const Executor> exec, size_type size, bool inverse)
     : EnableLinOp<Fft>(exec, dim<2>{size}), buffer_{exec}, inverse_{inverse}
 {}
@@ -304,16 +299,6 @@ std::unique_ptr<Fft2> Fft2::create(std::shared_ptr<const Executor> exec,
 }
 
 
-Fft2::Fft2(std::shared_ptr<const Executor> exec)
-    : EnableLinOp<Fft2>(exec), buffer_{exec}, fft_size_{}, inverse_{}
-{}
-
-
-Fft2::Fft2(std::shared_ptr<const Executor> exec, size_type size)
-    : Fft2{exec, size, size}
-{}
-
-
 Fft2::Fft2(std::shared_ptr<const Executor> exec, size_type size1,
            size_type size2, bool inverse)
     : EnableLinOp<Fft2>(exec, dim<2>{size1 * size2}),
@@ -425,16 +410,6 @@ std::unique_ptr<Fft3> Fft3::create(std::shared_ptr<const Executor> exec,
 {
     return std::unique_ptr<Fft3>{new Fft3{exec, size1, size2, size3, inverse}};
 }
-
-
-Fft3::Fft3(std::shared_ptr<const Executor> exec)
-    : EnableLinOp<Fft3>(exec), buffer_{exec}, fft_size_{}, inverse_{}
-{}
-
-
-Fft3::Fft3(std::shared_ptr<const Executor> exec, size_type size)
-    : Fft3{exec, size, size, size}
-{}
 
 
 Fft3::Fft3(std::shared_ptr<const Executor> exec, size_type size1,

--- a/core/matrix/fft.cpp
+++ b/core/matrix/fft.cpp
@@ -183,6 +183,29 @@ void Fft::apply_impl(const LinOp* alpha, const LinOp* b, const LinOp* beta,
 }
 
 
+Fft::Fft(std::shared_ptr<const Executor> exec)
+    : EnableLinOp<Fft>(exec), buffer_{exec}, inverse_{}
+{}
+
+
+Fft::Fft(std::shared_ptr<const Executor> exec, size_type size, bool inverse)
+    : EnableLinOp<Fft>(exec, dim<2>{size}), buffer_{exec}, inverse_{inverse}
+{}
+
+
+std::unique_ptr<Fft> Fft::create(std::shared_ptr<const Executor> exec)
+{
+    return std::unique_ptr<Fft>{new Fft{exec}};
+}
+
+
+std::unique_ptr<Fft> Fft::create(std::shared_ptr<const Executor> exec,
+                                 size_type size, bool inverse)
+{
+    return std::unique_ptr<Fft>{new Fft{exec, size, inverse}};
+}
+
+
 std::unique_ptr<LinOp> Fft2::transpose() const
 {
     return Fft2::create(this->get_executor(), fft_size_[0], fft_size_[1],
@@ -258,6 +281,46 @@ void Fft2::apply_impl(const LinOp* alpha, const LinOp* b, const LinOp* beta,
         dense_x->add_scaled(alpha, clone_x);
     }
 }
+
+
+std::unique_ptr<Fft2> Fft2::create(std::shared_ptr<const Executor> exec)
+{
+    return std::unique_ptr<Fft2>{new Fft2{exec}};
+}
+
+
+std::unique_ptr<Fft2> Fft2::create(std::shared_ptr<const Executor> exec,
+                                   size_type size)
+{
+    return std::unique_ptr<Fft2>{new Fft2{exec, size}};
+}
+
+
+std::unique_ptr<Fft2> Fft2::create(std::shared_ptr<const Executor> exec,
+                                   size_type size1, size_type size2,
+                                   bool inverse)
+{
+    return std::unique_ptr<Fft2>{new Fft2{exec, size1, size2, inverse}};
+}
+
+
+Fft2::Fft2(std::shared_ptr<const Executor> exec)
+    : EnableLinOp<Fft2>(exec), buffer_{exec}, fft_size_{}, inverse_{}
+{}
+
+
+Fft2::Fft2(std::shared_ptr<const Executor> exec, size_type size)
+    : Fft2{exec, size, size}
+{}
+
+
+Fft2::Fft2(std::shared_ptr<const Executor> exec, size_type size1,
+           size_type size2, bool inverse)
+    : EnableLinOp<Fft2>(exec, dim<2>{size1 * size2}),
+      buffer_{exec},
+      fft_size_{size1, size2},
+      inverse_{inverse}
+{}
 
 
 std::unique_ptr<LinOp> Fft3::transpose() const
@@ -341,6 +404,46 @@ void Fft3::apply_impl(const LinOp* alpha, const LinOp* b, const LinOp* beta,
         dense_x->add_scaled(alpha, clone_x);
     }
 }
+
+
+std::unique_ptr<Fft3> Fft3::create(std::shared_ptr<const Executor> exec)
+{
+    return std::unique_ptr<Fft3>{new Fft3{exec}};
+}
+
+
+std::unique_ptr<Fft3> Fft3::create(std::shared_ptr<const Executor> exec,
+                                   size_type size)
+{
+    return std::unique_ptr<Fft3>{new Fft3{exec, size}};
+}
+
+
+std::unique_ptr<Fft3> Fft3::create(std::shared_ptr<const Executor> exec,
+                                   size_type size1, size_type size2,
+                                   size_type size3, bool inverse)
+{
+    return std::unique_ptr<Fft3>{new Fft3{exec, size1, size2, size3, inverse}};
+}
+
+
+Fft3::Fft3(std::shared_ptr<const Executor> exec)
+    : EnableLinOp<Fft3>(exec), buffer_{exec}, fft_size_{}, inverse_{}
+{}
+
+
+Fft3::Fft3(std::shared_ptr<const Executor> exec, size_type size)
+    : Fft3{exec, size, size, size}
+{}
+
+
+Fft3::Fft3(std::shared_ptr<const Executor> exec, size_type size1,
+           size_type size2, size_type size3, bool inverse)
+    : EnableLinOp<Fft3>(exec, dim<2>{size1 * size2 * size3}),
+      buffer_{exec},
+      fft_size_{size1, size2, size3},
+      inverse_{inverse}
+{}
 
 
 }  // namespace matrix

--- a/core/matrix/hybrid.cpp
+++ b/core/matrix/hybrid.cpp
@@ -104,6 +104,113 @@ Hybrid<ValueType, IndexType>::Hybrid(Hybrid&& other)
 
 
 template <typename ValueType, typename IndexType>
+Hybrid<ValueType, IndexType>::Hybrid(std::shared_ptr<const Executor> exec,
+                                     std::shared_ptr<strategy_type> strategy)
+    : Hybrid(std::move(exec), dim<2>{}, std::move(strategy))
+{}
+
+
+template <typename ValueType, typename IndexType>
+Hybrid<ValueType, IndexType>::Hybrid(std::shared_ptr<const Executor> exec,
+                                     const dim<2>& size,
+                                     std::shared_ptr<strategy_type> strategy)
+    : Hybrid(std::move(exec), size, size[1], std::move(strategy))
+{}
+
+
+template <typename ValueType, typename IndexType>
+Hybrid<ValueType, IndexType>::Hybrid(std::shared_ptr<const Executor> exec,
+                                     const dim<2>& size,
+                                     size_type num_stored_elements_per_row,
+                                     std::shared_ptr<strategy_type> strategy)
+    : Hybrid(std::move(exec), size, num_stored_elements_per_row, size[0], {},
+             std::move(strategy))
+{}
+
+
+template <typename ValueType, typename IndexType>
+Hybrid<ValueType, IndexType>::Hybrid(std::shared_ptr<const Executor> exec,
+                                     const dim<2>& size,
+                                     size_type num_stored_elements_per_row,
+                                     size_type stride,
+                                     std::shared_ptr<strategy_type> strategy)
+    : Hybrid(std::move(exec), size, num_stored_elements_per_row, stride, {},
+             std::move(strategy))
+{}
+
+
+template <typename ValueType, typename IndexType>
+Hybrid<ValueType, IndexType>::Hybrid(std::shared_ptr<const Executor> exec,
+                                     const dim<2>& size,
+                                     size_type num_stored_elements_per_row,
+                                     size_type stride, size_type num_nonzeros,
+                                     std::shared_ptr<strategy_type> strategy)
+    : EnableLinOp<Hybrid>(exec, size),
+      ell_(ell_type::create(exec, size, num_stored_elements_per_row, stride)),
+      coo_(coo_type::create(exec, size, num_nonzeros)),
+      strategy_(std::move(strategy))
+{}
+
+
+template <typename ValueType, typename IndexType>
+std::unique_ptr<Hybrid<ValueType, IndexType>>
+Hybrid<ValueType, IndexType>::create(std::shared_ptr<const Executor> exec,
+                                     std::shared_ptr<strategy_type> strategy)
+{
+    return std::unique_ptr<Hybrid>{new Hybrid{exec, strategy}};
+}
+
+
+template <typename ValueType, typename IndexType>
+std::unique_ptr<Hybrid<ValueType, IndexType>>
+Hybrid<ValueType, IndexType>::create(std::shared_ptr<const Executor> exec,
+                                     const dim<2>& size,
+                                     std::shared_ptr<strategy_type> strategy)
+{
+    return std::unique_ptr<Hybrid>{new Hybrid{exec, size, strategy}};
+}
+
+
+template <typename ValueType, typename IndexType>
+std::unique_ptr<Hybrid<ValueType, IndexType>>
+Hybrid<ValueType, IndexType>::create(std::shared_ptr<const Executor> exec,
+                                     const dim<2>& size,
+                                     size_type num_stored_elements_per_row,
+                                     std::shared_ptr<strategy_type> strategy)
+{
+    return std::unique_ptr<Hybrid>{
+        new Hybrid{exec, size, num_stored_elements_per_row, strategy}};
+}
+
+
+template <typename ValueType, typename IndexType>
+std::unique_ptr<Hybrid<ValueType, IndexType>>
+Hybrid<ValueType, IndexType>::create(std::shared_ptr<const Executor> exec,
+                                     const dim<2>& size,
+                                     size_type num_stored_elements_per_row,
+                                     size_type stride,
+                                     std::shared_ptr<strategy_type> strategy)
+{
+    return std::unique_ptr<Hybrid>{
+        new Hybrid{exec, size, num_stored_elements_per_row, stride, strategy}};
+}
+
+
+template <typename ValueType, typename IndexType>
+std::unique_ptr<Hybrid<ValueType, IndexType>>
+Hybrid<ValueType, IndexType>::create(std::shared_ptr<const Executor> exec,
+                                     const dim<2>& size,
+                                     size_type num_stored_elements_per_row,
+                                     size_type stride, size_type num_nonzeros,
+                                     std::shared_ptr<strategy_type> strategy)
+{
+    return std::unique_ptr<Hybrid>{new Hybrid{exec, size,
+                                              num_stored_elements_per_row,
+                                              stride, num_nonzeros, strategy}};
+}
+
+
+template <typename ValueType, typename IndexType>
 void Hybrid<ValueType, IndexType>::apply_impl(const LinOp* b, LinOp* x) const
 {
     precision_dispatch_real_complex<ValueType>(

--- a/core/matrix/hybrid.cpp
+++ b/core/matrix/hybrid.cpp
@@ -105,42 +105,6 @@ Hybrid<ValueType, IndexType>::Hybrid(Hybrid&& other)
 
 template <typename ValueType, typename IndexType>
 Hybrid<ValueType, IndexType>::Hybrid(std::shared_ptr<const Executor> exec,
-                                     std::shared_ptr<strategy_type> strategy)
-    : Hybrid(std::move(exec), dim<2>{}, std::move(strategy))
-{}
-
-
-template <typename ValueType, typename IndexType>
-Hybrid<ValueType, IndexType>::Hybrid(std::shared_ptr<const Executor> exec,
-                                     const dim<2>& size,
-                                     std::shared_ptr<strategy_type> strategy)
-    : Hybrid(std::move(exec), size, size[1], std::move(strategy))
-{}
-
-
-template <typename ValueType, typename IndexType>
-Hybrid<ValueType, IndexType>::Hybrid(std::shared_ptr<const Executor> exec,
-                                     const dim<2>& size,
-                                     size_type num_stored_elements_per_row,
-                                     std::shared_ptr<strategy_type> strategy)
-    : Hybrid(std::move(exec), size, num_stored_elements_per_row, size[0], {},
-             std::move(strategy))
-{}
-
-
-template <typename ValueType, typename IndexType>
-Hybrid<ValueType, IndexType>::Hybrid(std::shared_ptr<const Executor> exec,
-                                     const dim<2>& size,
-                                     size_type num_stored_elements_per_row,
-                                     size_type stride,
-                                     std::shared_ptr<strategy_type> strategy)
-    : Hybrid(std::move(exec), size, num_stored_elements_per_row, stride, {},
-             std::move(strategy))
-{}
-
-
-template <typename ValueType, typename IndexType>
-Hybrid<ValueType, IndexType>::Hybrid(std::shared_ptr<const Executor> exec,
                                      const dim<2>& size,
                                      size_type num_stored_elements_per_row,
                                      size_type stride, size_type num_nonzeros,
@@ -148,7 +112,7 @@ Hybrid<ValueType, IndexType>::Hybrid(std::shared_ptr<const Executor> exec,
     : EnableLinOp<Hybrid>(exec, size),
       ell_(ell_type::create(exec, size, num_stored_elements_per_row, stride)),
       coo_(coo_type::create(exec, size, num_nonzeros)),
-      strategy_(std::move(strategy))
+      strategy_(strategy ? std::move(strategy) : std::make_shared<automatic>())
 {}
 
 
@@ -157,7 +121,7 @@ std::unique_ptr<Hybrid<ValueType, IndexType>>
 Hybrid<ValueType, IndexType>::create(std::shared_ptr<const Executor> exec,
                                      std::shared_ptr<strategy_type> strategy)
 {
-    return std::unique_ptr<Hybrid>{new Hybrid{exec, strategy}};
+    return std::unique_ptr<Hybrid>{new Hybrid{exec, {}, 0, 0, 0, strategy}};
 }
 
 
@@ -167,7 +131,7 @@ Hybrid<ValueType, IndexType>::create(std::shared_ptr<const Executor> exec,
                                      const dim<2>& size,
                                      std::shared_ptr<strategy_type> strategy)
 {
-    return std::unique_ptr<Hybrid>{new Hybrid{exec, size, strategy}};
+    return std::unique_ptr<Hybrid>{new Hybrid{exec, size, 0, 0, 0, strategy}};
 }
 
 
@@ -179,7 +143,7 @@ Hybrid<ValueType, IndexType>::create(std::shared_ptr<const Executor> exec,
                                      std::shared_ptr<strategy_type> strategy)
 {
     return std::unique_ptr<Hybrid>{
-        new Hybrid{exec, size, num_stored_elements_per_row, strategy}};
+        new Hybrid{exec, size, num_stored_elements_per_row, 0, 0, strategy}};
 }
 
 
@@ -191,8 +155,8 @@ Hybrid<ValueType, IndexType>::create(std::shared_ptr<const Executor> exec,
                                      size_type stride,
                                      std::shared_ptr<strategy_type> strategy)
 {
-    return std::unique_ptr<Hybrid>{
-        new Hybrid{exec, size, num_stored_elements_per_row, stride, strategy}};
+    return std::unique_ptr<Hybrid>{new Hybrid{
+        exec, size, num_stored_elements_per_row, stride, 0, strategy}};
 }
 
 

--- a/core/matrix/identity.cpp
+++ b/core/matrix/identity.cpp
@@ -60,14 +60,6 @@ std::unique_ptr<LinOp> Identity<ValueType>::conj_transpose() const
 
 
 template <typename ValueType>
-Identity<ValueType>::Identity(std::shared_ptr<const Executor> exec, dim<2> size)
-    : EnableLinOp<Identity>(exec, size)
-{
-    GKO_ASSERT_IS_SQUARE_MATRIX(this);
-}
-
-
-template <typename ValueType>
 Identity<ValueType>::Identity(std::shared_ptr<const Executor> exec,
                               size_type size)
     : EnableLinOp<Identity>(exec, dim<2>{size})
@@ -78,7 +70,8 @@ template <typename ValueType>
 std::unique_ptr<Identity<ValueType>> Identity<ValueType>::create(
     std::shared_ptr<const Executor> exec, dim<2> size)
 {
-    return std::unique_ptr<Identity>{new Identity{exec, size}};
+    GKO_ASSERT_IS_SQUARE_MATRIX(size);
+    return std::unique_ptr<Identity>{new Identity{exec, size[0]}};
 }
 
 

--- a/core/matrix/identity.cpp
+++ b/core/matrix/identity.cpp
@@ -59,6 +59,37 @@ std::unique_ptr<LinOp> Identity<ValueType>::conj_transpose() const
 }
 
 
+template <typename ValueType>
+Identity<ValueType>::Identity(std::shared_ptr<const Executor> exec, dim<2> size)
+    : EnableLinOp<Identity>(exec, size)
+{
+    GKO_ASSERT_IS_SQUARE_MATRIX(this);
+}
+
+
+template <typename ValueType>
+Identity<ValueType>::Identity(std::shared_ptr<const Executor> exec,
+                              size_type size)
+    : EnableLinOp<Identity>(exec, dim<2>{size})
+{}
+
+
+template <typename ValueType>
+std::unique_ptr<Identity<ValueType>> Identity<ValueType>::create(
+    std::shared_ptr<const Executor> exec, dim<2> size)
+{
+    return std::unique_ptr<Identity>{new Identity{exec, size}};
+}
+
+
+template <typename ValueType>
+std::unique_ptr<Identity<ValueType>> Identity<ValueType>::create(
+    std::shared_ptr<const Executor> exec, size_type size)
+{
+    return std::unique_ptr<Identity>{new Identity{exec, size}};
+}
+
+
 #define GKO_DECLARE_IDENTITY_MATRIX(_type) class Identity<_type>
 GKO_INSTANTIATE_FOR_EACH_VALUE_TYPE(GKO_DECLARE_IDENTITY_MATRIX);
 #define GKO_DECLARE_IDENTITY_FACTORY(_type) class IdentityFactory<_type>

--- a/core/matrix/permutation.cpp
+++ b/core/matrix/permutation.cpp
@@ -199,51 +199,6 @@ Permutation<IndexType>::Permutation(std::shared_ptr<const Executor> exec,
 
 
 template <typename IndexType>
-Permutation<IndexType>::Permutation(std::shared_ptr<const Executor> exec,
-                                    const dim<2>& size)
-    : Permutation{exec, size[0]}
-{
-    GKO_ASSERT_IS_SQUARE_MATRIX(size);
-}
-
-
-template <typename IndexType>
-Permutation<IndexType>::Permutation(std::shared_ptr<const Executor> exec,
-                                    const dim<2>& size,
-                                    const mask_type& enabled_permute)
-    : Permutation{exec, size[0]}
-{
-    GKO_ASSERT_EQ(enabled_permute, row_permute);
-    GKO_ASSERT_IS_SQUARE_MATRIX(size);
-}
-
-
-template <typename IndexType>
-Permutation<IndexType>::Permutation(std::shared_ptr<const Executor> exec,
-                                    const dim<2>& size,
-                                    array<IndexType> permutation_indices)
-    : Permutation{exec, array<IndexType>{exec, std::move(permutation_indices)}}
-{
-    GKO_ASSERT_EQ(size[0], permutation_.get_size());
-    GKO_ASSERT_IS_SQUARE_MATRIX(size);
-}
-
-
-template <typename IndexType>
-Permutation<IndexType>::Permutation(std::shared_ptr<const Executor> exec,
-                                    const dim<2>& size,
-                                    array<index_type> permutation_indices,
-                                    const mask_type& enabled_permute)
-    : Permutation{std::move(exec),
-                  array<IndexType>{exec, std::move(permutation_indices)}}
-{
-    GKO_ASSERT_EQ(enabled_permute, row_permute);
-    GKO_ASSERT_EQ(size[0], permutation_.get_size());
-    GKO_ASSERT_IS_SQUARE_MATRIX(size);
-}
-
-
-template <typename IndexType>
 size_type Permutation<IndexType>::get_permutation_size() const noexcept
 {
     return this->get_size()[0];

--- a/core/matrix/row_gatherer.cpp
+++ b/core/matrix/row_gatherer.cpp
@@ -16,12 +16,6 @@ namespace matrix {
 
 
 template <typename IndexType>
-RowGatherer<IndexType>::RowGatherer(std::shared_ptr<const Executor> exec)
-    : RowGatherer(std::move(exec), dim<2>{})
-{}
-
-
-template <typename IndexType>
 RowGatherer<IndexType>::RowGatherer(std::shared_ptr<const Executor> exec,
                                     const dim<2>& size)
     : EnableLinOp<RowGatherer>(exec, size), row_idxs_(exec, size[0])
@@ -35,14 +29,6 @@ RowGatherer<IndexType>::RowGatherer(std::shared_ptr<const Executor> exec,
     : EnableLinOp<RowGatherer>(exec, size), row_idxs_{exec, std::move(row_idxs)}
 {
     GKO_ASSERT_EQ(size[0], row_idxs_.get_size());
-}
-
-
-template <typename IndexType>
-std::unique_ptr<RowGatherer<IndexType>> RowGatherer<IndexType>::create(
-    std::shared_ptr<const Executor> exec)
-{
-    return std::unique_ptr<RowGatherer>{new RowGatherer{exec}};
 }
 
 

--- a/core/matrix/scaled_permutation.cpp
+++ b/core/matrix/scaled_permutation.cpp
@@ -53,8 +53,8 @@ std::unique_ptr<ScaledPermutation<ValueType, IndexType>>
 ScaledPermutation<ValueType, IndexType>::create(
     std::shared_ptr<const Executor> exec, size_type size)
 {
-    return std::unique_ptr<ScaledPermutation>(
-        new ScaledPermutation{exec, size});
+    return std::unique_ptr<ScaledPermutation>{
+        new ScaledPermutation{exec, size}};
 }
 
 
@@ -79,8 +79,8 @@ ScaledPermutation<ValueType, IndexType>::create(
     std::shared_ptr<const Executor> exec, array<value_type> scaling_factors,
     array<index_type> permutation_indices)
 {
-    return std::unique_ptr<ScaledPermutation>(new ScaledPermutation{
-        exec, std::move(scaling_factors), std::move(permutation_indices)});
+    return std::unique_ptr<ScaledPermutation>{new ScaledPermutation{
+        exec, std::move(scaling_factors), std::move(permutation_indices)}};
 }
 
 

--- a/core/matrix/sellp.cpp
+++ b/core/matrix/sellp.cpp
@@ -107,14 +107,6 @@ Sellp<ValueType, IndexType>::Sellp(Sellp&& other) : Sellp(other.get_executor())
 
 template <typename ValueType, typename IndexType>
 Sellp<ValueType, IndexType>::Sellp(std::shared_ptr<const Executor> exec,
-                                   const dim<2>& size)
-    : Sellp(std::move(exec), size,
-            ceildiv(size[0], default_slice_size) * size[1])
-{}
-
-
-template <typename ValueType, typename IndexType>
-Sellp<ValueType, IndexType>::Sellp(std::shared_ptr<const Executor> exec,
                                    const dim<2>& size, size_type total_cols)
     : Sellp(std::move(exec), size, default_slice_size, default_stride_factor,
             total_cols)
@@ -136,15 +128,6 @@ Sellp<ValueType, IndexType>::Sellp(std::shared_ptr<const Executor> exec,
 {
     slice_sets_.fill(0);
     slice_lengths_.fill(0);
-}
-
-
-template <typename ValueType, typename IndexType>
-std::unique_ptr<Sellp<ValueType, IndexType>>
-Sellp<ValueType, IndexType>::create(std::shared_ptr<const Executor> exec,
-                                    const dim<2>& size)
-{
-    return std::unique_ptr<Sellp>{new Sellp{exec, size}};
 }
 
 

--- a/core/matrix/sellp.cpp
+++ b/core/matrix/sellp.cpp
@@ -106,6 +106,70 @@ Sellp<ValueType, IndexType>::Sellp(Sellp&& other) : Sellp(other.get_executor())
 
 
 template <typename ValueType, typename IndexType>
+Sellp<ValueType, IndexType>::Sellp(std::shared_ptr<const Executor> exec,
+                                   const dim<2>& size)
+    : Sellp(std::move(exec), size,
+            ceildiv(size[0], default_slice_size) * size[1])
+{}
+
+
+template <typename ValueType, typename IndexType>
+Sellp<ValueType, IndexType>::Sellp(std::shared_ptr<const Executor> exec,
+                                   const dim<2>& size, size_type total_cols)
+    : Sellp(std::move(exec), size, default_slice_size, default_stride_factor,
+            total_cols)
+{}
+
+
+template <typename ValueType, typename IndexType>
+Sellp<ValueType, IndexType>::Sellp(std::shared_ptr<const Executor> exec,
+                                   const dim<2>& size, size_type slice_size,
+                                   size_type stride_factor,
+                                   size_type total_cols)
+    : EnableLinOp<Sellp>(exec, size),
+      values_(exec, slice_size * total_cols),
+      col_idxs_(exec, slice_size * total_cols),
+      slice_lengths_(exec, ceildiv(size[0], slice_size)),
+      slice_sets_(exec, ceildiv(size[0], slice_size) + 1),
+      slice_size_(slice_size),
+      stride_factor_(stride_factor)
+{
+    slice_sets_.fill(0);
+    slice_lengths_.fill(0);
+}
+
+
+template <typename ValueType, typename IndexType>
+std::unique_ptr<Sellp<ValueType, IndexType>>
+Sellp<ValueType, IndexType>::create(std::shared_ptr<const Executor> exec,
+                                    const dim<2>& size)
+{
+    return std::unique_ptr<Sellp>{new Sellp{exec, size}};
+}
+
+
+template <typename ValueType, typename IndexType>
+std::unique_ptr<Sellp<ValueType, IndexType>>
+Sellp<ValueType, IndexType>::create(std::shared_ptr<const Executor> exec,
+                                    const dim<2>& size, size_type total_cols)
+{
+    return std::unique_ptr<Sellp>{new Sellp{exec, size, total_cols}};
+}
+
+
+template <typename ValueType, typename IndexType>
+std::unique_ptr<Sellp<ValueType, IndexType>>
+Sellp<ValueType, IndexType>::create(std::shared_ptr<const Executor> exec,
+                                    const dim<2>& size, size_type slice_size,
+                                    size_type stride_factor,
+                                    size_type total_cols)
+{
+    return std::unique_ptr<Sellp>{
+        new Sellp{exec, size, slice_size, stride_factor, total_cols}};
+}
+
+
+template <typename ValueType, typename IndexType>
 void Sellp<ValueType, IndexType>::apply_impl(const LinOp* b, LinOp* x) const
 {
     precision_dispatch_real_complex<ValueType>(

--- a/core/matrix/sparsity_csr.cpp
+++ b/core/matrix/sparsity_csr.cpp
@@ -127,6 +127,75 @@ SparsityCsr<ValueType, IndexType>::SparsityCsr(
 
 
 template <typename ValueType, typename IndexType>
+SparsityCsr<ValueType, IndexType>::SparsityCsr(
+    std::shared_ptr<const Executor> exec, const dim<2>& size,
+    size_type num_nonzeros)
+    : EnableLinOp<SparsityCsr>(exec, size),
+      col_idxs_(exec, num_nonzeros),
+      row_ptrs_(exec, size[0] + 1),
+      value_(exec, {one<ValueType>()})
+{
+    row_ptrs_.fill(0);
+}
+
+
+template <typename ValueType, typename IndexType>
+SparsityCsr<ValueType, IndexType>::SparsityCsr(
+    std::shared_ptr<const Executor> exec, const dim<2>& size,
+    array<index_type> col_idxs, array<index_type> row_ptrs, value_type value)
+    : EnableLinOp<SparsityCsr>(exec, size),
+      col_idxs_{exec, std::move(col_idxs)},
+      row_ptrs_{exec, std::move(row_ptrs)},
+      value_{exec, {value}}
+{
+    GKO_ASSERT_EQ(this->get_size()[0] + 1, row_ptrs_.get_size());
+}
+
+
+template <typename ValueType, typename IndexType>
+SparsityCsr<ValueType, IndexType>::SparsityCsr(
+    std::shared_ptr<const Executor> exec, std::shared_ptr<const LinOp> matrix)
+    : EnableLinOp<SparsityCsr>(exec, matrix->get_size())
+{
+    auto tmp_ = copy_and_convert_to<SparsityCsr>(exec, matrix);
+    this->copy_from(tmp_);
+}
+
+
+template <typename ValueType, typename IndexType>
+std::unique_ptr<SparsityCsr<ValueType, IndexType>>
+SparsityCsr<ValueType, IndexType>::create(std::shared_ptr<const Executor> exec,
+                                          const dim<2>& size,
+                                          size_type num_nonzeros)
+{
+    return std::unique_ptr<SparsityCsr>{
+        new SparsityCsr{exec, size, num_nonzeros}};
+}
+
+
+template <typename ValueType, typename IndexType>
+std::unique_ptr<SparsityCsr<ValueType, IndexType>>
+SparsityCsr<ValueType, IndexType>::create(std::shared_ptr<const Executor> exec,
+                                          const dim<2>& size,
+                                          array<index_type> col_idxs,
+                                          array<index_type> row_ptrs,
+                                          value_type value)
+{
+    return std::unique_ptr<SparsityCsr>{new SparsityCsr{
+        exec, size, std::move(col_idxs), std::move(row_ptrs), value}};
+}
+
+
+template <typename ValueType, typename IndexType>
+std::unique_ptr<SparsityCsr<ValueType, IndexType>>
+SparsityCsr<ValueType, IndexType>::create(std::shared_ptr<const Executor> exec,
+                                          std::shared_ptr<const LinOp> matrix)
+{
+    return std::unique_ptr<SparsityCsr>{new SparsityCsr{exec, matrix}};
+}
+
+
+template <typename ValueType, typename IndexType>
 void SparsityCsr<ValueType, IndexType>::convert_to(
     Csr<ValueType, IndexType>* result) const
 {

--- a/core/test/matrix/identity.cpp
+++ b/core/test/matrix/identity.cpp
@@ -2,6 +2,11 @@
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
+// force-top: on
+#include <ginkgo/core/base/types.hpp>
+// force-top: off
+
+
 #include <ginkgo/core/matrix/identity.hpp>
 
 
@@ -50,6 +55,9 @@ TYPED_TEST(Identity, CanBeConstructedWithSize)
 }
 
 
+GKO_BEGIN_DISABLE_DEPRECATION_WARNINGS
+
+
 TYPED_TEST(Identity, CanBeConstructedWithSquareSize)
 {
     using Id = typename TestFixture::Id;
@@ -66,6 +74,9 @@ TYPED_TEST(Identity, FailsConstructionWithRectangularSize)
     ASSERT_THROW(Id::create(this->exec, gko::dim<2>(5, 4)),
                  gko::DimensionMismatch);
 }
+
+
+GKO_END_DISABLE_DEPRECATION_WARNINGS
 
 
 template <typename T>

--- a/core/test/utils/unsort_matrix_test.cpp
+++ b/core/test/utils/unsort_matrix_test.cpp
@@ -53,18 +53,20 @@ protected:
      */
     std::unique_ptr<Csr> get_sorted_csr()
     {
-        return Csr::create(exec, gko::dim<2>{5, 5},
-                           I<value_type>{1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
-                           I<index_type>{0, 1, 0, 1, 2, 3, 2, 2, 3, 4},
-                           I<index_type>{0, 2, 2, 6, 7, 10});
+        return Csr::create(
+            exec, gko::dim<2>{5, 5},
+            gko::array<value_type>{exec, {1, 2, 3, 4, 5, 6, 7, 8, 9, 10}},
+            gko::array<index_type>{exec, {0, 1, 0, 1, 2, 3, 2, 2, 3, 4}},
+            gko::array<index_type>{exec, {0, 2, 2, 6, 7, 10}});
     }
 
     std::unique_ptr<Coo> get_sorted_coo()
     {
-        return Coo::create(exec, gko::dim<2>{5, 5},
-                           I<value_type>{1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
-                           I<index_type>{0, 1, 0, 1, 2, 3, 2, 2, 3, 4},
-                           I<index_type>{0, 0, 2, 2, 2, 2, 3, 4, 4, 4});
+        return Coo::create(
+            exec, gko::dim<2>{5, 5},
+            gko::array<value_type>{exec, {1, 2, 3, 4, 5, 6, 7, 8, 9, 10}},
+            gko::array<index_type>{exec, {0, 1, 0, 1, 2, 3, 2, 2, 3, 4}},
+            gko::array<index_type>{exec, {0, 0, 2, 2, 2, 2, 3, 4, 4, 4}});
     }
 
     bool is_coo_matrix_sorted(gko::ptr_param<Coo> mtx)

--- a/include/ginkgo/core/base/batch_multi_vector.hpp
+++ b/include/ginkgo/core/base/batch_multi_vector.hpp
@@ -350,6 +350,9 @@ public:
      * Executor>, const batch_dim<2>&, array<value_type>)
      */
     template <typename InputValueType>
+    GKO_DEPRECATED(
+        "explicitly construct the gko::array argument instead of passing an "
+        "initializer list")
     static std::unique_ptr<MultiVector> create(
         std::shared_ptr<const Executor> exec, const batch_dim<2>& size,
         std::initializer_list<InputValueType> values)

--- a/include/ginkgo/core/base/batch_multi_vector.hpp
+++ b/include/ginkgo/core/base/batch_multi_vector.hpp
@@ -322,6 +322,8 @@ public:
      *
      * @param exec  Executor associated to the vector
      * @param size  size of the batch multi vector
+     *
+     * @return A smart pointer to the newly created matrix.
      */
     static std::unique_ptr<MultiVector> create(
         std::shared_ptr<const Executor> exec,
@@ -330,8 +332,6 @@ public:
     /**
      * Creates a MultiVector from an already allocated (and
      * initialized) array.
-     *
-     * @tparam ValuesArray  type of array of values
      *
      * @param exec  Executor associated to the vector
      * @param size  sizes of the batch matrices in a batch_dim object

--- a/include/ginkgo/core/base/batch_multi_vector.hpp
+++ b/include/ginkgo/core/base/batch_multi_vector.hpp
@@ -53,9 +53,7 @@ template <typename ValueType = default_precision>
 class MultiVector
     : public EnablePolymorphicObject<MultiVector<ValueType>>,
       public EnablePolymorphicAssignment<MultiVector<ValueType>>,
-      public EnableCreateMethod<MultiVector<ValueType>>,
       public ConvertibleTo<MultiVector<next_precision<ValueType>>> {
-    friend class EnableCreateMethod<MultiVector>;
     friend class EnablePolymorphicObject<MultiVector>;
     friend class MultiVector<to_complex<ValueType>>;
     friend class MultiVector<next_precision<ValueType>>;
@@ -319,6 +317,47 @@ public:
         ptr_param<MultiVector<remove_complex<ValueType>>> result) const;
 
     /**
+     * Creates an uninitialized multi-vector of the specified
+     * size.
+     *
+     * @param exec  Executor associated to the vector
+     * @param size  size of the batch multi vector
+     */
+    static std::unique_ptr<MultiVector> create(
+        std::shared_ptr<const Executor> exec,
+        const batch_dim<2>& size = batch_dim<2>{});
+
+    /**
+     * Creates a MultiVector from an already allocated (and
+     * initialized) array.
+     *
+     * @tparam ValuesArray  type of array of values
+     *
+     * @param exec  Executor associated to the vector
+     * @param size  sizes of the batch matrices in a batch_dim object
+     * @param values  array of values
+     *
+     * @note If `values` is not an rvalue, not an array of ValueType, or is on
+     *       the wrong executor, an internal copy will be created, and the
+     *       original array data will not be used in the vector.
+     */
+    static std::unique_ptr<MultiVector> create(
+        std::shared_ptr<const Executor> exec, const batch_dim<2>& size,
+        array<value_type> values);
+
+    /**
+     * @copydoc std::unique_ptr<MultiVector> create(std::shared_ptr<const
+     * Executor>, const batch_dim<2>&, array<value_type>)
+     */
+    template <typename InputValueType>
+    static std::unique_ptr<MultiVector> create(
+        std::shared_ptr<const Executor> exec, const batch_dim<2>& size,
+        std::initializer_list<InputValueType> values)
+    {
+        return create(exec, size, array<index_type>{exec, std::move(values)});
+    }
+
+    /**
      * Creates a constant (immutable) batch multi-vector from a constant
      * array.
      *
@@ -331,7 +370,7 @@ public:
      * array (if it resides on the same executor as the vector) or a copy of the
      * array on the correct executor.
      */
-    static std::unique_ptr<const MultiVector<ValueType>> create_const(
+    static std::unique_ptr<const MultiVector> create_const(
         std::shared_ptr<const Executor> exec, const batch_dim<2>& sizes,
         gko::detail::const_array_view<ValueType>&& values);
 
@@ -357,41 +396,11 @@ protected:
      */
     void set_size(const batch_dim<2>& value) noexcept;
 
-    /**
-     * Creates an uninitialized multi-vector of the specified
-     * size.
-     *
-     * @param exec  Executor associated to the vector
-     * @param size  size of the batch multi vector
-     */
     MultiVector(std::shared_ptr<const Executor> exec,
                 const batch_dim<2>& size = batch_dim<2>{});
 
-    /**
-     * Creates a MultiVector from an already allocated (and
-     * initialized) array.
-     *
-     * @tparam ValuesArray  type of array of values
-     *
-     * @param exec  Executor associated to the vector
-     * @param size  sizes of the batch matrices in a batch_dim object
-     * @param values  array of values
-     *
-     * @note If `values` is not an rvalue, not an array of ValueType, or is on
-     *       the wrong executor, an internal copy will be created, and the
-     *       original array data will not be used in the vector.
-     */
-    template <typename ValuesArray>
     MultiVector(std::shared_ptr<const Executor> exec, const batch_dim<2>& size,
-                ValuesArray&& values)
-        : EnablePolymorphicObject<MultiVector<ValueType>>(exec),
-          batch_size_(size),
-          values_{exec, std::forward<ValuesArray>(values)}
-    {
-        // Ensure that the values array has the correct size
-        auto num_elems = compute_num_elems(size);
-        GKO_ENSURE_IN_BOUNDS(num_elems, values_.get_size() + 1);
-    }
+                array<value_type> values);
 
     /**
      * Creates a MultiVector with the same configuration as the

--- a/include/ginkgo/core/base/device_matrix_data.hpp
+++ b/include/ginkgo/core/base/device_matrix_data.hpp
@@ -80,6 +80,9 @@ public:
      */
     template <typename InputValueType, typename RowIndexType,
               typename ColIndexType>
+    GKO_DEPRECATED(
+        "explicitly construct the gko::array arguments instead of passing "
+        "initializer lists")
     device_matrix_data(std::shared_ptr<const Executor> exec, dim<2> size,
                        std::initializer_list<RowIndexType> row_idxs,
                        std::initializer_list<ColIndexType> col_idxs,

--- a/include/ginkgo/core/base/device_matrix_data.hpp
+++ b/include/ginkgo/core/base/device_matrix_data.hpp
@@ -70,19 +70,25 @@ public:
      * @param col_idxs  the array containing the matrix column indices
      * @param row_idxs  the array containing the matrix row indices
      */
-    template <typename ValueArray, typename RowIndexArray,
-              typename ColIndexArray>
     device_matrix_data(std::shared_ptr<const Executor> exec, dim<2> size,
-                       RowIndexArray&& row_idxs, ColIndexArray&& col_idxs,
-                       ValueArray&& values)
-        : size_{size},
-          row_idxs_{exec, std::forward<RowIndexArray>(row_idxs)},
-          col_idxs_{exec, std::forward<ColIndexArray>(col_idxs)},
-          values_{exec, std::forward<ValueArray>(values)}
-    {
-        GKO_ASSERT_EQ(values_.get_size(), row_idxs_.get_size());
-        GKO_ASSERT_EQ(values_.get_size(), col_idxs_.get_size());
-    }
+                       array<index_type> row_idxs, array<index_type> col_idxs,
+                       array<value_type> values);
+
+    /**
+     * @copydoc device_matrix_data(std::shared_ptr<const Executor>, dim<2>,
+     * array<index_type>, array<index_type>, array<value_type>)
+     */
+    template <typename InputValueType, typename RowIndexType,
+              typename ColIndexType>
+    device_matrix_data(std::shared_ptr<const Executor> exec, dim<2> size,
+                       std::initializer_list<RowIndexType> row_idxs,
+                       std::initializer_list<ColIndexType> col_idxs,
+                       std::initializer_list<InputValueType> values)
+        : device_matrix_data{exec, size,
+                             array<index_type>{exec, std::move(row_idxs)},
+                             array<index_type>{exec, std::move(col_idxs)},
+                             array<value_type>{exec, std::move(values)}}
+    {}
 
     /**
      * Copies the device_matrix_data entries to the host to return a regular

--- a/include/ginkgo/core/base/perturbation.hpp
+++ b/include/ginkgo/core/base/perturbation.hpp
@@ -82,15 +82,13 @@ public:
 
     Perturbation(Perturbation&& other);
 
-protected:
     /**
      * Creates an empty perturbation operator (0x0 operator).
      *
      * @param exec  Executor associated to the perturbation
      */
-    explicit Perturbation(std::shared_ptr<const Executor> exec)
-        : EnableLinOp<Perturbation>(std::move(exec))
-    {}
+    static std::unique_ptr<Perturbation> create(
+        std::shared_ptr<const Executor> exec);
 
     /**
      * Creates a perturbation with scalar and basis by setting projector to the
@@ -100,15 +98,9 @@ protected:
      * @param scalar  scaling of the movement
      * @param basis  the direction basis
      */
-    explicit Perturbation(std::shared_ptr<const LinOp> scalar,
-                          std::shared_ptr<const LinOp> basis)
-        : Perturbation(
-              std::move(scalar),
-              // basis can not be std::move(basis). Otherwise, Program deletes
-              // basis before applying conjugate transpose
-              basis,
-              std::move((as<gko::Transposable>(basis))->conj_transpose()))
-    {}
+    static std::unique_ptr<Perturbation> create(
+        std::shared_ptr<const LinOp> scalar,
+        std::shared_ptr<const LinOp> basis);
 
     /**
      * Creates a perturbation of scalar, basis and projector.
@@ -117,17 +109,19 @@ protected:
      * @param basis  the direction basis
      * @param projector  decides the coefficient of basis
      */
+    static std::unique_ptr<Perturbation> create(
+        std::shared_ptr<const LinOp> scalar, std::shared_ptr<const LinOp> basis,
+        std::shared_ptr<const LinOp> projector);
+
+protected:
+    explicit Perturbation(std::shared_ptr<const Executor> exec);
+
+    explicit Perturbation(std::shared_ptr<const LinOp> scalar,
+                          std::shared_ptr<const LinOp> basis);
+
     explicit Perturbation(std::shared_ptr<const LinOp> scalar,
                           std::shared_ptr<const LinOp> basis,
-                          std::shared_ptr<const LinOp> projector)
-        : EnableLinOp<Perturbation>(basis->get_executor(),
-                                    gko::dim<2>{basis->get_size()[0]}),
-          scalar_{std::move(scalar)},
-          basis_{std::move(basis)},
-          projector_{std::move(projector)}
-    {
-        this->validate_perturbation();
-    }
+                          std::shared_ptr<const LinOp> projector);
 
     void apply_impl(const LinOp* b, LinOp* x) const override;
 
@@ -139,12 +133,7 @@ protected:
      * parameters for the `apply`. scalar must be 1 by 1. The dimension of basis
      * should be same as the dimension of conjugate transpose of projector.
      */
-    void validate_perturbation()
-    {
-        GKO_ASSERT_CONFORMANT(basis_, projector_);
-        GKO_ASSERT_CONFORMANT(projector_, basis_);
-        GKO_ASSERT_EQUAL_DIMENSIONS(scalar_, dim<2>(1, 1));
-    }
+    void validate_perturbation();
 
 private:
     std::shared_ptr<const LinOp> basis_;

--- a/include/ginkgo/core/base/perturbation.hpp
+++ b/include/ginkgo/core/base/perturbation.hpp
@@ -86,6 +86,8 @@ public:
      * Creates an empty perturbation operator (0x0 operator).
      *
      * @param exec  Executor associated to the perturbation
+     *
+     * @return A smart pointer to the newly created perturbation.
      */
     static std::unique_ptr<Perturbation> create(
         std::shared_ptr<const Executor> exec);
@@ -97,6 +99,8 @@ public:
      *
      * @param scalar  scaling of the movement
      * @param basis  the direction basis
+     *
+     * @return A smart pointer to the newly created perturbation.
      */
     static std::unique_ptr<Perturbation> create(
         std::shared_ptr<const LinOp> scalar,
@@ -108,6 +112,8 @@ public:
      * @param scalar  scaling of the movement
      * @param basis  the direction basis
      * @param projector  decides the coefficient of basis
+     *
+     * @return A smart pointer to the newly created perturbation.
      */
     static std::unique_ptr<Perturbation> create(
         std::shared_ptr<const LinOp> scalar, std::shared_ptr<const LinOp> basis,

--- a/include/ginkgo/core/distributed/matrix.hpp
+++ b/include/ginkgo/core/distributed/matrix.hpp
@@ -392,6 +392,8 @@ public:
      * @param exec  Executor associated with this matrix.
      * @param comm  Communicator associated with this matrix.
      *              The default is the MPI_COMM_WORLD.
+     *
+     * @return A smart pointer to the newly created matrix.
      */
     static std::unique_ptr<Matrix> create(std::shared_ptr<const Executor> exec,
                                           mpi::communicator comm);
@@ -413,6 +415,8 @@ public:
      * @param matrix_template  the local matrices will be constructed with the
      *                         same type as `create` returns. It should be the
      *                         return value of make_matrix_template.
+     *
+     * @return A smart pointer to the newly created matrix.
      */
     template <typename MatrixType,
               typename = std::enable_if_t<detail::is_matrix_type_builder<
@@ -451,6 +455,8 @@ public:
      *                                   constructed with the same type as
      *                                   `create` returns. It should be the
      *                                   return value of make_matrix_template.
+     *
+     * @return A smart pointer to the newly created matrix.
      */
     template <typename LocalMatrixType, typename NonLocalMatrixType,
               typename = std::enable_if_t<
@@ -482,6 +488,8 @@ public:
      * @param comm  Communicator associated with this matrix.
      * @param matrix_template  the local matrices will be constructed with the
      *                         same runtime type.
+     *
+     * @return A smart pointer to the newly created matrix.
      */
     static std::unique_ptr<Matrix> create(
         std::shared_ptr<const Executor> exec, mpi::communicator comm,
@@ -500,6 +508,8 @@ public:
      *                               with the same runtime type.
      * @param non_local_matrix_template  the non-local matrix will be
      *                                   constructed with the same runtime type.
+     *
+     * @return A smart pointer to the newly created matrix.
      */
     static std::unique_ptr<Matrix> create(
         std::shared_ptr<const Executor> exec, mpi::communicator comm,

--- a/include/ginkgo/core/distributed/partition.hpp
+++ b/include/ginkgo/core/distributed/partition.hpp
@@ -76,20 +76,16 @@ namespace distributed {
  * @ingroup distributed
  */
 template <typename LocalIndexType = int32, typename GlobalIndexType = int64>
-class Partition
-    : public EnablePolymorphicObject<
-          Partition<LocalIndexType, GlobalIndexType>>,
-      public EnablePolymorphicAssignment<
-          Partition<LocalIndexType, GlobalIndexType>>,
-      public EnableCreateMethod<Partition<LocalIndexType, GlobalIndexType>> {
-    friend class EnableCreateMethod<Partition>;
+class Partition : public EnablePolymorphicObject<
+                      Partition<LocalIndexType, GlobalIndexType>>,
+                  public EnablePolymorphicAssignment<
+                      Partition<LocalIndexType, GlobalIndexType>> {
     friend class EnablePolymorphicObject<Partition>;
     static_assert(sizeof(GlobalIndexType) >= sizeof(LocalIndexType),
                   "GlobalIndexType must be at least as large as "
                   "LocalIndexType");
 
 public:
-    using EnableCreateMethod<Partition>::create;
     using EnablePolymorphicAssignment<Partition>::convert_to;
     using EnablePolymorphicAssignment<Partition>::move_to;
 
@@ -257,26 +253,8 @@ public:
         global_index_type global_size);
 
 private:
-    /**
-     * Creates a partition stored on the given executor with the given number of
-     * consecutive ranges and parts.
-     */
     Partition(std::shared_ptr<const Executor> exec,
-              comm_index_type num_parts = 0, size_type num_ranges = 0)
-        : EnablePolymorphicObject<Partition>{exec},
-          num_parts_{num_parts},
-          num_empty_parts_{0},
-          size_{0},
-          offsets_{exec, num_ranges + 1},
-          starting_indices_{exec, num_ranges},
-          part_sizes_{exec, static_cast<size_type>(num_parts)},
-          part_ids_{exec, num_ranges}
-    {
-        offsets_.fill(0);
-        starting_indices_.fill(0);
-        part_sizes_.fill(0);
-        part_ids_.fill(0);
-    }
+              comm_index_type num_parts = 0, size_type num_ranges = 0);
 
     /**
      * Finalizes the construction in the create_* methods, by computing the

--- a/include/ginkgo/core/distributed/partition.hpp
+++ b/include/ginkgo/core/distributed/partition.hpp
@@ -256,6 +256,10 @@ private:
     Partition(std::shared_ptr<const Executor> exec,
               comm_index_type num_parts = 0, size_type num_ranges = 0);
 
+    static std::unique_ptr<Partition> create(
+        std::shared_ptr<const Executor> exec, comm_index_type num_parts = 0,
+        size_type num_ranges = 0);
+
     /**
      * Finalizes the construction in the create_* methods, by computing the
      * range_starting_indices_ and part_sizes_ based on the current

--- a/include/ginkgo/core/distributed/vector.hpp
+++ b/include/ginkgo/core/distributed/vector.hpp
@@ -58,11 +58,9 @@ class Partition;
 template <typename ValueType = double>
 class Vector
     : public EnableDistributedLinOp<Vector<ValueType>>,
-      public EnableCreateMethod<Vector<ValueType>>,
       public ConvertibleTo<Vector<next_precision<ValueType>>>,
       public EnableAbsoluteComputation<remove_complex<Vector<ValueType>>>,
       public DistributedBase {
-    friend class EnableCreateMethod<Vector>;
     friend class EnableDistributedPolymorphicObject<Vector, LinOp>;
     friend class Vector<to_complex<ValueType>>;
     friend class Vector<remove_complex<ValueType>>;
@@ -475,6 +473,73 @@ public:
     std::unique_ptr<real_type> create_real_view();
 
     size_type get_stride() const noexcept { return local_.get_stride(); }
+
+    /**
+     * Creates an empty distributed vector with a specified size
+     *
+     * @param exec  Executor associated with vector
+     * @param comm  Communicator associated with vector
+     * @param global_size  Global size of the vector
+     * @param local_size  Processor-local size of the vector
+     * @param stride  Stride of the local vector.
+     */
+    static std::unique_ptr<Vector> create(std::shared_ptr<const Executor> exec,
+                                          mpi::communicator comm,
+                                          dim<2> global_size, dim<2> local_size,
+                                          size_type stride);
+
+    /**
+     * Creates an empty distributed vector with a specified size
+     *
+     * @param exec  Executor associated with vector
+     * @param comm  Communicator associated with vector
+     * @param global_size  Global size of the vector
+     * @param local_size  Processor-local size of the vector, uses local_size[1]
+     *                    as the stride
+     */
+    static std::unique_ptr<Vector> create(std::shared_ptr<const Executor> exec,
+                                          mpi::communicator comm,
+                                          dim<2> global_size = {},
+                                          dim<2> local_size = {});
+
+    /**
+     * Creates a distributed vector from local vectors with a specified size.
+     *
+     * @note  The data form the local_vector will be moved into the new
+     *        distributed vector. You could either move in a std::unique_ptr
+     *        directly, copy a local vector with gko::clone, or create a
+     *        unique non-owining view of a given local vector with
+     *        gko::make_dense_view.
+     *
+     * @param exec  Executor associated with this vector
+     * @param comm  Communicator associated with this vector
+     * @param global_size  The global size of the vector
+     * @param local_vector  The underlying local vector, the data will be moved
+     *                      into this
+     */
+    static std::unique_ptr<Vector> create(
+        std::shared_ptr<const Executor> exec, mpi::communicator comm,
+        dim<2> global_size, std::unique_ptr<local_vector_type> local_vector);
+
+    /**
+     * Creates a distributed vector from local vectors. The global size will
+     * be deduced from the local sizes, which will incur a collective
+     * communication.
+     *
+     * @note  The data form the local_vector will be moved into the new
+     *        distributed vector. You could either move in a std::unique_ptr
+     *        directly, copy a local vector with gko::clone, or create a
+     *        unique non-owining view of a given local vector with
+     *        gko::make_dense_view.
+     *
+     * @param exec  Executor associated with this vector
+     * @param comm  Communicator associated with this vector
+     * @param local_vector  The underlying local vector, the data will be moved
+     *                      into this.
+     */
+    static std::unique_ptr<Vector> create(
+        std::shared_ptr<const Executor> exec, mpi::communicator comm,
+        std::unique_ptr<local_vector_type> local_vector);
 
     /**
      * Creates a constant (immutable) distributed Vector from a constant local

--- a/include/ginkgo/core/distributed/vector.hpp
+++ b/include/ginkgo/core/distributed/vector.hpp
@@ -482,6 +482,8 @@ public:
      * @param global_size  Global size of the vector
      * @param local_size  Processor-local size of the vector
      * @param stride  Stride of the local vector.
+     *
+     * @return A smart pointer to the newly created vector.
      */
     static std::unique_ptr<Vector> create(std::shared_ptr<const Executor> exec,
                                           mpi::communicator comm,
@@ -496,6 +498,8 @@ public:
      * @param global_size  Global size of the vector
      * @param local_size  Processor-local size of the vector, uses local_size[1]
      *                    as the stride
+     *
+     * @return A smart pointer to the newly created vector.
      */
     static std::unique_ptr<Vector> create(std::shared_ptr<const Executor> exec,
                                           mpi::communicator comm,
@@ -516,6 +520,8 @@ public:
      * @param global_size  The global size of the vector
      * @param local_vector  The underlying local vector, the data will be moved
      *                      into this
+     *
+     * @return A smart pointer to the newly created vector.
      */
     static std::unique_ptr<Vector> create(
         std::shared_ptr<const Executor> exec, mpi::communicator comm,
@@ -536,6 +542,8 @@ public:
      * @param comm  Communicator associated with this vector
      * @param local_vector  The underlying local vector, the data will be moved
      *                      into this.
+     *
+     * @return A smart pointer to the newly created vector.
      */
     static std::unique_ptr<Vector> create(
         std::shared_ptr<const Executor> exec, mpi::communicator comm,
@@ -550,6 +558,8 @@ public:
      * @param global_size  The global size of the vector
      * @param local_vector  The underlying local vector, of which a view is
      *                      created
+     *
+     * @return A smart pointer to the newly created vector.
      */
     static std::unique_ptr<const Vector> create_const(
         std::shared_ptr<const Executor> exec, mpi::communicator comm,
@@ -565,71 +575,24 @@ public:
      * @param comm  Communicator associated with this vector
      * @param local_vector  The underlying local vector, of which a view is
      *                      created
+     *
+     * @return A smart pointer to the newly created vector.
      */
     static std::unique_ptr<const Vector> create_const(
         std::shared_ptr<const Executor> exec, mpi::communicator comm,
         std::unique_ptr<const local_vector_type> local_vector);
 
 protected:
-    /**
-     * Creates an empty distributed vector with a specified size
-     *
-     * @param exec  Executor associated with vector
-     * @param comm  Communicator associated with vector
-     * @param global_size  Global size of the vector
-     * @param local_size  Processor-local size of the vector
-     * @param stride  Stride of the local vector.
-     */
     Vector(std::shared_ptr<const Executor> exec, mpi::communicator comm,
            dim<2> global_size, dim<2> local_size, size_type stride);
 
-    /**
-     * Creates an empty distributed vector with a specified size
-     *
-     * @param exec  Executor associated with vector
-     * @param comm  Communicator associated with vector
-     * @param global_size  Global size of the vector
-     * @param local_size  Processor-local size of the vector, uses local_size[1]
-     *                    as the stride
-     */
     explicit Vector(std::shared_ptr<const Executor> exec,
                     mpi::communicator comm, dim<2> global_size = {},
                     dim<2> local_size = {});
 
-    /**
-     * Creates a distributed vector from local vectors with a specified size.
-     *
-     * @note  The data form the local_vector will be moved into the new
-     *        distributed vector. You could either move in a std::unique_ptr
-     *        directly, copy a local vector with gko::clone, or create a
-     *        unique non-owining view of a given local vector with
-     *        gko::make_dense_view.
-     *
-     * @param exec  Executor associated with this vector
-     * @param comm  Communicator associated with this vector
-     * @param global_size  The global size of the vector
-     * @param local_vector  The underlying local vector, the data will be moved
-     *                      into this
-     */
     Vector(std::shared_ptr<const Executor> exec, mpi::communicator comm,
            dim<2> global_size, std::unique_ptr<local_vector_type> local_vector);
 
-    /**
-     * Creates a distributed vector from local vectors. The global size will
-     * be deduced from the local sizes, which will incur a collective
-     * communication.
-     *
-     * @note  The data form the local_vector will be moved into the new
-     *        distributed vector. You could either move in a std::unique_ptr
-     *        directly, copy a local vector with gko::clone, or create a
-     *        unique non-owining view of a given local vector with
-     *        gko::make_dense_view.
-     *
-     * @param exec  Executor associated with this vector
-     * @param comm  Communicator associated with this vector
-     * @param local_vector  The underlying local vector, the data will be moved
-     *                      into this.
-     */
     Vector(std::shared_ptr<const Executor> exec, mpi::communicator comm,
            std::unique_ptr<local_vector_type> local_vector);
 

--- a/include/ginkgo/core/log/convergence.hpp
+++ b/include/ginkgo/core/log/convergence.hpp
@@ -69,10 +69,6 @@ public:
      *                        events.
      *
      * @return an std::unique_ptr to the the constructed object
-     *
-     * @internal here I cannot use EnableCreateMethod due to complex circular
-     * dependencies. At the same time, this method is short enough that it
-     * shouldn't be a problem.
      */
     GKO_DEPRECATED("use single-parameter create")
     static std::unique_ptr<Convergence> create(
@@ -91,10 +87,6 @@ public:
      *                        events.
      *
      * @return an std::unique_ptr to the the constructed object
-     *
-     * @internal here I cannot use EnableCreateMethod due to complex circular
-     * dependencies. At the same time, this method is short enough that it
-     * shouldn't be a problem.
      */
     static std::unique_ptr<Convergence> create(
         const mask_type& enabled_events = Logger::criterion_events_mask |

--- a/include/ginkgo/core/log/record.hpp
+++ b/include/ginkgo/core/log/record.hpp
@@ -404,10 +404,6 @@ public:
      *                     memory overhead of this logger.
      *
      * @return an std::unique_ptr to the the constructed object
-     *
-     * @internal here I cannot use EnableCreateMethod due to complex circular
-     * dependencies. At the same time, this method is short enough that it
-     * shouldn't be a problem.
      */
     GKO_DEPRECATED("use two-parameter create")
     static std::unique_ptr<Record> create(
@@ -431,10 +427,6 @@ public:
      *                     memory overhead of this logger.
      *
      * @return an std::unique_ptr to the the constructed object
-     *
-     * @internal here I cannot use EnableCreateMethod due to complex circular
-     * dependencies. At the same time, this method is short enough that it
-     * shouldn't be a problem.
      */
     static std::unique_ptr<Record> create(
         const mask_type& enabled_events = Logger::all_events_mask,

--- a/include/ginkgo/core/log/stream.hpp
+++ b/include/ginkgo/core/log/stream.hpp
@@ -166,10 +166,6 @@ public:
      *                 which can give a large output.
      *
      * @return an std::unique_ptr to the the constructed object
-     *
-     * @internal here I cannot use EnableCreateMethod due to complex circular
-     * dependencies. At the same time, this method is short enough that it
-     * shouldn't be a problem.
      */
     GKO_DEPRECATED("use three-parameter create")
     static std::unique_ptr<Stream> create(
@@ -193,10 +189,6 @@ public:
      *                 which can give a large output.
      *
      * @return an std::unique_ptr to the the constructed object
-     *
-     * @internal here I cannot use EnableCreateMethod due to complex circular
-     * dependencies. At the same time, this method is short enough that it
-     * shouldn't be a problem.
      */
     static std::unique_ptr<Stream> create(
         const Logger::mask_type& enabled_events = Logger::all_events_mask,

--- a/include/ginkgo/core/matrix/batch_csr.hpp
+++ b/include/ginkgo/core/matrix/batch_csr.hpp
@@ -212,6 +212,8 @@ public:
      * that the arrays are allocated correctly. An incorrect value will result
      * in a runtime failure when the user tries to use any batch matrix
      * utilities such as create_view_from_item etc.
+     *
+     * @return A smart pointer to the newly created matrix.
      */
     static std::unique_ptr<Csr> create(
         std::shared_ptr<const Executor> exec,
@@ -231,6 +233,8 @@ public:
      * @note If `values` is not an rvalue, not an array of ValueType, or is on
      *       the wrong executor, an internal copy will be created, and the
      *       original array data will not be used in the matrix.
+     *
+     * @return A smart pointer to the newly created matrix.
      */
     static std::unique_ptr<Csr> create(std::shared_ptr<const Executor> exec,
                                        const batch_dim<2>& size,
@@ -271,6 +275,8 @@ public:
      * @return A smart pointer to the constant matrix wrapping the input
      * array (if it resides on the same executor as the matrix) or a copy of the
      * array on the correct executor.
+     *
+     * @return A smart pointer to the newly created matrix.
      */
     static std::unique_ptr<const Csr> create_const(
         std::shared_ptr<const Executor> exec, const batch_dim<2>& sizes,

--- a/include/ginkgo/core/matrix/batch_csr.hpp
+++ b/include/ginkgo/core/matrix/batch_csr.hpp
@@ -249,6 +249,9 @@ public:
      */
     template <typename InputValueType, typename ColIndexType,
               typename RowPtrType>
+    GKO_DEPRECATED(
+        "explicitly construct the gko::array arguments instead of passing "
+        "initializer lists")
     static std::unique_ptr<Csr> create(
         std::shared_ptr<const Executor> exec, const batch_dim<2>& size,
         std::initializer_list<InputValueType> values,

--- a/include/ginkgo/core/matrix/batch_dense.hpp
+++ b/include/ginkgo/core/matrix/batch_dense.hpp
@@ -228,6 +228,8 @@ public:
      *
      * @param exec  Executor associated to the matrix
      * @param size  size of the matrix
+     *
+     * @return A smart pointer to the newly created matrix.
      */
     static std::unique_ptr<Dense> create(
         std::shared_ptr<const Executor> exec,
@@ -237,8 +239,6 @@ public:
      * Creates a Dense matrix from an already allocated (and initialized)
      * array.
      *
-     * @tparam ValuesArray  type of array of values
-     *
      * @param exec  Executor associated to the matrix
      * @param size  sizes of the batch matrices in a batch_dim object
      * @param values  array of matrix values
@@ -246,6 +246,8 @@ public:
      * @note If `values` is not an rvalue, not an array of ValueType, or is on
      *       the wrong executor, an internal copy will be created, and the
      *       original array data will not be used in the matrix.
+     *
+     * @return A smart pointer to the newly created matrix.
      */
     static std::unique_ptr<Dense> create(std::shared_ptr<const Executor> exec,
                                          const batch_dim<2>& size,
@@ -274,6 +276,8 @@ public:
      * @return A smart pointer to the constant matrix wrapping the input
      * array (if it resides on the same executor as the matrix) or a copy of the
      * array on the correct executor.
+     *
+     * @return A smart pointer to the newly created matrix.
      */
     static std::unique_ptr<const Dense> create_const(
         std::shared_ptr<const Executor> exec, const batch_dim<2>& sizes,
@@ -358,29 +362,9 @@ private:
                size.get_common_size()[1];
     }
 
-    /**
-     * Creates an uninitialized Dense matrix of the specified size.
-     *
-     * @param exec  Executor associated to the matrix
-     * @param size  size of the matrix
-     */
     Dense(std::shared_ptr<const Executor> exec,
           const batch_dim<2>& size = batch_dim<2>{});
 
-    /**
-     * Creates a Dense matrix from an already allocated (and initialized)
-     * array.
-     *
-     * @tparam ValuesArray  type of array of values
-     *
-     * @param exec  Executor associated to the matrix
-     * @param size  sizes of the batch matrices in a batch_dim object
-     * @param values  array of matrix values
-     *
-     * @note If `values` is not an rvalue, not an array of ValueType, or is on
-     *       the wrong executor, an internal copy will be created, and the
-     *       original array data will not be used in the matrix.
-     */
     Dense(std::shared_ptr<const Executor> exec, const batch_dim<2>& size,
           array<value_type> values);
 

--- a/include/ginkgo/core/matrix/batch_dense.hpp
+++ b/include/ginkgo/core/matrix/batch_dense.hpp
@@ -258,6 +258,9 @@ public:
      * const batch_dim<2>&, array<value_type>)
      */
     template <typename InputValueType>
+    GKO_DEPRECATED(
+        "explicitly construct the gko::array argument instead of passing an"
+        "initializer list")
     static std::unique_ptr<Dense> create(
         std::shared_ptr<const Executor> exec, const batch_dim<2>& size,
         std::initializer_list<InputValueType> values)

--- a/include/ginkgo/core/matrix/batch_dense.hpp
+++ b/include/ginkgo/core/matrix/batch_dense.hpp
@@ -47,9 +47,7 @@ namespace matrix {
  */
 template <typename ValueType = default_precision>
 class Dense final : public EnableBatchLinOp<Dense<ValueType>>,
-                    public EnableCreateMethod<Dense<ValueType>>,
                     public ConvertibleTo<Dense<next_precision<ValueType>>> {
-    friend class EnableCreateMethod<Dense>;
     friend class EnablePolymorphicObject<Dense, BatchLinOp>;
     friend class Dense<to_complex<ValueType>>;
     friend class Dense<next_precision<ValueType>>;
@@ -226,6 +224,46 @@ public:
     }
 
     /**
+     * Creates an uninitialized Dense matrix of the specified size.
+     *
+     * @param exec  Executor associated to the matrix
+     * @param size  size of the matrix
+     */
+    static std::unique_ptr<Dense> create(
+        std::shared_ptr<const Executor> exec,
+        const batch_dim<2>& size = batch_dim<2>{});
+
+    /**
+     * Creates a Dense matrix from an already allocated (and initialized)
+     * array.
+     *
+     * @tparam ValuesArray  type of array of values
+     *
+     * @param exec  Executor associated to the matrix
+     * @param size  sizes of the batch matrices in a batch_dim object
+     * @param values  array of matrix values
+     *
+     * @note If `values` is not an rvalue, not an array of ValueType, or is on
+     *       the wrong executor, an internal copy will be created, and the
+     *       original array data will not be used in the matrix.
+     */
+    static std::unique_ptr<Dense> create(std::shared_ptr<const Executor> exec,
+                                         const batch_dim<2>& size,
+                                         array<value_type> values);
+
+    /**
+     * @copydoc std::unique_ptr<Dense> create(std::shared_ptr<const Executor>,
+     * const batch_dim<2>&, array<value_type>)
+     */
+    template <typename InputValueType>
+    static std::unique_ptr<Dense> create(
+        std::shared_ptr<const Executor> exec, const batch_dim<2>& size,
+        std::initializer_list<InputValueType> values)
+    {
+        return create(exec, size, array<value_type>{exec, std::move(values)});
+    }
+
+    /**
      * Creates a constant (immutable) batch dense matrix from a constant
      * array.
      *
@@ -237,7 +275,7 @@ public:
      * array (if it resides on the same executor as the matrix) or a copy of the
      * array on the correct executor.
      */
-    static std::unique_ptr<const Dense<value_type>> create_const(
+    static std::unique_ptr<const Dense> create_const(
         std::shared_ptr<const Executor> exec, const batch_dim<2>& sizes,
         gko::detail::const_array_view<ValueType>&& values);
 
@@ -343,16 +381,8 @@ private:
      *       the wrong executor, an internal copy will be created, and the
      *       original array data will not be used in the matrix.
      */
-    template <typename ValuesArray>
     Dense(std::shared_ptr<const Executor> exec, const batch_dim<2>& size,
-          ValuesArray&& values)
-        : EnableBatchLinOp<Dense>(exec, size),
-          values_{exec, std::forward<ValuesArray>(values)}
-    {
-        // Ensure that the values array has the correct size
-        auto num_elems = compute_num_elems(size);
-        GKO_ENSURE_IN_BOUNDS(num_elems, values_.get_size() + 1);
-    }
+          array<value_type> values);
 
     void apply_impl(const MultiVector<value_type>* b,
                     MultiVector<value_type>* x) const;

--- a/include/ginkgo/core/matrix/batch_ell.hpp
+++ b/include/ginkgo/core/matrix/batch_ell.hpp
@@ -52,9 +52,7 @@ namespace matrix {
 template <typename ValueType = default_precision, typename IndexType = int32>
 class Ell final
     : public EnableBatchLinOp<Ell<ValueType, IndexType>>,
-      public EnableCreateMethod<Ell<ValueType, IndexType>>,
       public ConvertibleTo<Ell<next_precision<ValueType>, IndexType>> {
-    friend class EnableCreateMethod<Ell>;
     friend class EnablePolymorphicObject<Ell, BatchLinOp>;
     friend class Ell<to_complex<ValueType>, IndexType>;
     friend class Ell<next_precision<ValueType>, IndexType>;
@@ -224,6 +222,57 @@ public:
     }
 
     /**
+     * Creates an uninitialized Ell matrix of the specified size.
+     *
+     * @param exec  Executor associated to the matrix
+     * @param size  size of the matrix
+     * @param num_elems_per_row  the number of elements to be stored in each row
+     */
+    static std::unique_ptr<Ell> create(
+        std::shared_ptr<const Executor> exec,
+        const batch_dim<2>& size = batch_dim<2>{},
+        const IndexType num_elems_per_row = 0);
+
+    /**
+     * Creates a Ell matrix from an already allocated (and initialized)
+     * array. The column indices array needs to be the same for all batch items.
+     *
+     * @tparam ValuesArray  type of array of values
+     *
+     * @param exec  Executor associated to the matrix
+     * @param size  size of the matrix
+     * @param num_elems_per_row  the number of elements to be stored in each row
+     * @param values  array of matrix values
+     * @param col_idxs the col_idxs array of a single batch item of the matrix.
+     *
+     * @note If `values` is not an rvalue, not an array of ValueType, or is on
+     *       the wrong executor, an internal copy will be created, and the
+     *       original array data will not be used in the matrix.
+     */
+    static std::unique_ptr<Ell> create(std::shared_ptr<const Executor> exec,
+                                       const batch_dim<2>& size,
+                                       const IndexType num_elems_per_row,
+                                       array<value_type> values,
+                                       array<index_type> col_idxs);
+
+    /**
+     * @copydoc std::unique_ptr<Ell> create(std::shared_ptr<const Executor>,
+     * const batch_dim<2>&, const IndexType, array<value_type>,
+     * array<index_type>)
+     */
+    template <typename InputValueType, typename ColIndexType>
+    static std::unique_ptr<Ell> create(
+        std::shared_ptr<const Executor> exec, const batch_dim<2>& size,
+        const IndexType num_elems_per_row,
+        std::initializer_list<InputValueType> values,
+        std::initializer_list<ColIndexType> col_idxs)
+    {
+        return create(exec, size, num_elems_per_row,
+                      array<value_type>{exec, std::move(values)},
+                      array<index_type>{exec, std::move(col_idxs)});
+    }
+
+    /**
      * Creates a constant (immutable) batch ell matrix from a constant
      * array. The column indices array needs to be the same for all batch items.
      *
@@ -314,48 +363,13 @@ private:
                num_elems_per_row;
     }
 
-    /**
-     * Creates an uninitialized Ell matrix of the specified size.
-     *
-     * @param exec  Executor associated to the matrix
-     * @param size  size of the matrix
-     * @param num_elems_per_row  the number of elements to be stored in each row
-     */
     Ell(std::shared_ptr<const Executor> exec,
         const batch_dim<2>& size = batch_dim<2>{},
         const IndexType num_elems_per_row = 0);
 
-    /**
-     * Creates a Ell matrix from an already allocated (and initialized)
-     * array. The column indices array needs to be the same for all batch items.
-     *
-     * @tparam ValuesArray  type of array of values
-     *
-     * @param exec  Executor associated to the matrix
-     * @param size  size of the matrix
-     * @param num_elems_per_row  the number of elements to be stored in each row
-     * @param values  array of matrix values
-     * @param col_idxs the col_idxs array of a single batch item of the matrix.
-     *
-     * @note If `values` is not an rvalue, not an array of ValueType, or is on
-     *       the wrong executor, an internal copy will be created, and the
-     *       original array data will not be used in the matrix.
-     */
-    template <typename ValuesArray, typename IndicesArray>
     Ell(std::shared_ptr<const Executor> exec, const batch_dim<2>& size,
-        const IndexType num_elems_per_row, ValuesArray&& values,
-        IndicesArray&& col_idxs)
-        : EnableBatchLinOp<Ell>(exec, size),
-          num_elems_per_row_{num_elems_per_row},
-          values_{exec, std::forward<ValuesArray>(values)},
-          col_idxs_{exec, std::forward<IndicesArray>(col_idxs)}
-    {
-        // Ensure that the value and col_idxs arrays have the correct size
-        auto num_elems = this->get_common_size()[0] * num_elems_per_row *
-                         this->get_num_batch_items();
-        GKO_ASSERT_EQ(num_elems, values_.get_size());
-        GKO_ASSERT_EQ(this->get_num_elements_per_item(), col_idxs_.get_size());
-    }
+        const IndexType num_elems_per_row, array<value_type> values,
+        array<index_type> col_idxs);
 
     void apply_impl(const MultiVector<value_type>* b,
                     MultiVector<value_type>* x) const;

--- a/include/ginkgo/core/matrix/batch_ell.hpp
+++ b/include/ginkgo/core/matrix/batch_ell.hpp
@@ -263,6 +263,9 @@ public:
      * array<index_type>)
      */
     template <typename InputValueType, typename ColIndexType>
+    GKO_DEPRECATED(
+        "explicitly construct the gko::array arguments instead of passing "
+        "initializer lists")
     static std::unique_ptr<Ell> create(
         std::shared_ptr<const Executor> exec, const batch_dim<2>& size,
         const IndexType num_elems_per_row,

--- a/include/ginkgo/core/matrix/batch_ell.hpp
+++ b/include/ginkgo/core/matrix/batch_ell.hpp
@@ -227,6 +227,8 @@ public:
      * @param exec  Executor associated to the matrix
      * @param size  size of the matrix
      * @param num_elems_per_row  the number of elements to be stored in each row
+     *
+     * @return A smart pointer to the newly created matrix.
      */
     static std::unique_ptr<Ell> create(
         std::shared_ptr<const Executor> exec,
@@ -237,8 +239,6 @@ public:
      * Creates a Ell matrix from an already allocated (and initialized)
      * array. The column indices array needs to be the same for all batch items.
      *
-     * @tparam ValuesArray  type of array of values
-     *
      * @param exec  Executor associated to the matrix
      * @param size  size of the matrix
      * @param num_elems_per_row  the number of elements to be stored in each row
@@ -248,6 +248,8 @@ public:
      * @note If `values` is not an rvalue, not an array of ValueType, or is on
      *       the wrong executor, an internal copy will be created, and the
      *       original array data will not be used in the matrix.
+     *
+     * @return A smart pointer to the newly created matrix.
      */
     static std::unique_ptr<Ell> create(std::shared_ptr<const Executor> exec,
                                        const batch_dim<2>& size,
@@ -285,6 +287,8 @@ public:
      * @return A smart pointer to the constant matrix wrapping the input
      * array (if it resides on the same executor as the matrix) or a copy of the
      * array on the correct executor.
+     *
+     * @return A smart pointer to the newly created matrix.
      */
     static std::unique_ptr<const Ell> create_const(
         std::shared_ptr<const Executor> exec, const batch_dim<2>& sizes,

--- a/include/ginkgo/core/matrix/batch_identity.hpp
+++ b/include/ginkgo/core/matrix/batch_identity.hpp
@@ -84,6 +84,8 @@ public:
      *
      * @param exec  Executor associated to the matrix
      * @param size  size of the batch matrices in a batch_dim object
+     *
+     * @return A smart pointer to the newly created matrix.
      */
     static std::unique_ptr<Identity> create(
         std::shared_ptr<const Executor> exec,

--- a/include/ginkgo/core/matrix/batch_identity.hpp
+++ b/include/ginkgo/core/matrix/batch_identity.hpp
@@ -29,9 +29,7 @@ namespace matrix {
  * @ingroup BatchLinOp
  */
 template <typename ValueType = default_precision>
-class Identity final : public EnableBatchLinOp<Identity<ValueType>>,
-                       public EnableCreateMethod<Identity<ValueType>> {
-    friend class EnableCreateMethod<Identity>;
+class Identity final : public EnableBatchLinOp<Identity<ValueType>> {
     friend class EnablePolymorphicObject<Identity, BatchLinOp>;
 
 public:
@@ -81,14 +79,17 @@ public:
                           ptr_param<const MultiVector<value_type>> b,
                           ptr_param<const MultiVector<value_type>> beta,
                           ptr_param<MultiVector<value_type>> x) const;
-
-private:
     /**
      * Creates an Identity matrix of the specified size.
      *
      * @param exec  Executor associated to the matrix
      * @param size  size of the batch matrices in a batch_dim object
      */
+    static std::unique_ptr<Identity> create(
+        std::shared_ptr<const Executor> exec,
+        const batch_dim<2>& size = batch_dim<2>{});
+
+private:
     Identity(std::shared_ptr<const Executor> exec,
              const batch_dim<2>& size = batch_dim<2>{});
 

--- a/include/ginkgo/core/matrix/coo.hpp
+++ b/include/ginkgo/core/matrix/coo.hpp
@@ -256,6 +256,9 @@ public:
      */
     template <typename InputValueType, typename InputColumnIndexType,
               typename InputRowIndexType>
+    GKO_DEPRECATED(
+        "explicitly construct the gko::array argument instead of passing "
+        "initializer lists")
     static std::unique_ptr<Coo> create(
         std::shared_ptr<const Executor> exec, const dim<2>& size,
         std::initializer_list<InputValueType> values,

--- a/include/ginkgo/core/matrix/coo.hpp
+++ b/include/ginkgo/core/matrix/coo.hpp
@@ -228,10 +228,6 @@ public:
      * Creates a COO matrix from already allocated (and initialized) row
      * index, column index and value arrays.
      *
-     * @tparam ValuesArray  type of `values` array
-     * @tparam ColIdxsArray  type of `col_idxs` array
-     * @tparam RowIdxArray  type of `row_idxs` array
-     *
      * @param exec  Executor associated to the matrix
      * @param size  size of the matrix
      * @param values  array of matrix values
@@ -254,6 +250,10 @@ public:
                                        array<index_type> col_idxs,
                                        array<index_type> row_idxs);
 
+    /**
+     * @copydoc std::unique_ptr<Coo> create(std::shared_ptr<const Executor>,
+     * const dim<2>&, array<value_type>, array<index_type>, array<index_type>)
+     */
     template <typename InputValueType, typename InputColumnIndexType,
               typename InputRowIndexType>
     static std::unique_ptr<Coo> create(

--- a/include/ginkgo/core/matrix/csr.hpp
+++ b/include/ginkgo/core/matrix/csr.hpp
@@ -1040,6 +1040,9 @@ public:
      */
     template <typename InputValueType, typename InputColumnIndexType,
               typename InputRowPtrType>
+    GKO_DEPRECATED(
+        "explicitly construct the gko::array argument instead of passing "
+        "initializer lists")
     static std::unique_ptr<Csr> create(
         std::shared_ptr<const Executor> exec, const dim<2>& size,
         std::initializer_list<InputValueType> values,

--- a/include/ginkgo/core/matrix/csr.hpp
+++ b/include/ginkgo/core/matrix/csr.hpp
@@ -987,43 +987,31 @@ public:
      *
      * @param exec  Executor associated to the matrix
      * @param strategy  the strategy of CSR
+     *
+     * @return A smart pointer to the newly created matrix.
      */
     static std::unique_ptr<Csr> create(std::shared_ptr<const Executor> exec,
                                        std::shared_ptr<strategy_type> strategy);
 
     /**
-     * Creates an uninitialized CSR matrix of the specified size with a user
-     * chosen strategy.
+     * Creates an uninitialized CSR matrix of the specified size.
      *
      * @param exec  Executor associated to the matrix
      * @param size  size of the matrix
      * @param num_nonzeros  number of nonzeros
-     * @param strategy  the strategy of CSR
-     */
-    static std::unique_ptr<Csr> create(std::shared_ptr<const Executor> exec,
-                                       const dim<2>& size,
-                                       size_type num_nonzeros,
-                                       std::shared_ptr<strategy_type> strategy);
-
-    /**
-     * Creates an uninitialized CSR matrix of the specified size with a
-     * default strategy.
+     * @param strategy  the strategy of CSR, or the default strategy if set to
+     *                  nullptr
      *
-     * @param exec  Executor associated to the matrix
-     * @param size  size of the matrix
-     * @param num_nonzeros  number of nonzeros
+     * @return A smart pointer to the newly created matrix.
      */
-    static std::unique_ptr<Csr> create(std::shared_ptr<const Executor> exec,
-                                       const dim<2>& size = {},
-                                       size_type num_nonzeros = {});
+    static std::unique_ptr<Csr> create(
+        std::shared_ptr<const Executor> exec, const dim<2>& size = {},
+        size_type num_nonzeros = {},
+        std::shared_ptr<strategy_type> strategy = nullptr);
 
     /**
      * Creates a CSR matrix from already allocated (and initialized) row
      * pointer, column index and value arrays.
-     *
-     * @tparam ValuesArray  type of `values` array
-     * @tparam ColIdxsArray  type of `col_idxs` array
-     * @tparam RowPtrsArray  type of `row_ptrs` array
      *
      * @param exec  Executor associated to the matrix
      * @param size  size of the matrix
@@ -1037,39 +1025,18 @@ public:
      *       is on the wrong executor, an internal copy of that array will be
      *       created, and the original array data will not be used in the
      *       matrix.
+     *
+     * @return A smart pointer to the newly created matrix.
      */
-    static std::unique_ptr<Csr> create(std::shared_ptr<const Executor> exec,
-                                       const dim<2>& size,
-                                       array<value_type> values,
-                                       array<index_type> col_idxs,
-                                       array<index_type> row_ptrs,
-                                       std::shared_ptr<strategy_type> strategy);
+    static std::unique_ptr<Csr> create(
+        std::shared_ptr<const Executor> exec, const dim<2>& size,
+        array<value_type> values, array<index_type> col_idxs,
+        array<index_type> row_ptrs,
+        std::shared_ptr<strategy_type> strategy = nullptr);
 
     /**
-     * Creates a CSR matrix from already allocated (and initialized) row
-     * pointer, column index and value arrays.
-     *
-     * @param exec  Executor associated to the matrix
-     * @param size  size of the matrix
-     * @param values  array of matrix values
-     * @param col_idxs  array of column indexes
-     * @param row_ptrs  array of row pointers
-     *
-     * @note If one of `row_ptrs`, `col_idxs` or `values` is not an rvalue, not
-     *       an array of IndexType, IndexType and ValueType, respectively, or
-     *       is on the wrong executor, an internal copy of that array will be
-     *       created, and the original array data will not be used in the
-     *       matrix.
-     */
-    static std::unique_ptr<Csr> create(std::shared_ptr<const Executor> exec,
-                                       const dim<2>& size,
-                                       array<value_type> values,
-                                       array<index_type> col_idxs,
-                                       array<index_type> row_idxs);
-
-    /**
-     * @copydoc create(std::shared_ptr<const Executor>, const dim<2>&,
-     * array<value_type>, array<index_type>, array<index_type>)
+     * @copydoc std::unique_ptr<Csr> create(std::shared_ptr<const Executor>,
+     * const dim<2>&, array<value_type>, array<index_type>, array<index_type>)
      */
     template <typename InputValueType, typename InputColumnIndexType,
               typename InputRowPtrType>
@@ -1096,22 +1063,15 @@ public:
      * @returns A smart pointer to the constant matrix wrapping the input arrays
      *          (if they reside on the same executor as the matrix) or a copy of
      *          these arrays on the correct executor.
+     *
+     * @return A smart pointer to the newly created matrix.
      */
     static std::unique_ptr<const Csr> create_const(
         std::shared_ptr<const Executor> exec, const dim<2>& size,
         gko::detail::const_array_view<ValueType>&& values,
         gko::detail::const_array_view<IndexType>&& col_idxs,
         gko::detail::const_array_view<IndexType>&& row_ptrs,
-        std::shared_ptr<strategy_type> strategy);
-
-    /**
-     * This is version of create_const with a default strategy.
-     */
-    static std::unique_ptr<const Csr> create_const(
-        std::shared_ptr<const Executor> exec, const dim<2>& size,
-        gko::detail::const_array_view<ValueType>&& values,
-        gko::detail::const_array_view<IndexType>&& col_idxs,
-        gko::detail::const_array_view<IndexType>&& row_ptrs);
+        std::shared_ptr<strategy_type> strategy = nullptr);
 
     /**
      * Creates a submatrix from this Csr matrix given row and column index_set
@@ -1168,22 +1128,14 @@ public:
     Csr(Csr&&);
 
 protected:
-    Csr(std::shared_ptr<const Executor> exec,
-        std::shared_ptr<strategy_type> strategy);
-
-    Csr(std::shared_ptr<const Executor> exec, const dim<2>& size,
-        size_type num_nonzeros, std::shared_ptr<strategy_type> strategy);
-
     Csr(std::shared_ptr<const Executor> exec, const dim<2>& size = {},
-        size_type num_nonzeros = {});
+        size_type num_nonzeros = {},
+        std::shared_ptr<strategy_type> strategy = nullptr);
 
     Csr(std::shared_ptr<const Executor> exec, const dim<2>& size,
         array<value_type> values, array<index_type> col_idxs,
-        array<index_type> row_ptrs, std::shared_ptr<strategy_type> strategy);
-
-    Csr(std::shared_ptr<const Executor> exec, const dim<2>& size,
-        array<value_type> values, array<index_type> col_idxs,
-        array<index_type> row_ptrs);
+        array<index_type> row_ptrs,
+        std::shared_ptr<strategy_type> strategy = nullptr);
 
     void apply_impl(const LinOp* b, LinOp* x) const override;
 
@@ -1338,11 +1290,11 @@ protected:
     virtual void inv_scale_impl(const LinOp* alpha);
 
 private:
+    std::shared_ptr<strategy_type> strategy_;
     array<value_type> values_;
     array<index_type> col_idxs_;
     array<index_type> row_ptrs_;
     array<index_type> srow_;
-    std::shared_ptr<strategy_type> strategy_;
 
     void add_scaled_identity_impl(const LinOp* a, const LinOp* b) override;
 };

--- a/include/ginkgo/core/matrix/dense.hpp
+++ b/include/ginkgo/core/matrix/dense.hpp
@@ -1133,26 +1133,18 @@ public:
      *
      * @param exec  Executor associated to the matrix
      * @param size  size of the matrix
-     */
-    static std::unique_ptr<Dense> create(std::shared_ptr<const Executor> exec,
-                                         const dim<2>& size = dim<2>{});
-
-    /**
-     * Creates an uninitialized Dense matrix of the specified size.
-     *
-     * @param exec  Executor associated to the matrix
-     * @param size  size of the matrix
      * @param stride  stride of the rows (i.e. offset between the first
      *                  elements of two consecutive rows, expressed as the
      *                  number of matrix elements)
+     *
+     * @return A smart pointer to the newly created matrix.
      */
     static std::unique_ptr<Dense> create(std::shared_ptr<const Executor> exec,
-                                         const dim<2>& size, size_type stride);
+                                         const dim<2>& size = {},
+                                         size_type stride = 0);
 
     /**
      * Creates a Dense matrix from an already allocated (and initialized) array.
-     *
-     * @tparam ValuesArray  type of array of values
      *
      * @param exec  Executor associated to the matrix
      * @param size  size of the matrix
@@ -1164,12 +1156,18 @@ public:
      * @note If `values` is not an rvalue, not an array of ValueType, or is on
      *       the wrong executor, an internal copy will be created, and the
      *       original array data will not be used in the matrix.
+     *
+     * @return A smart pointer to the newly created matrix.
      */
     static std::unique_ptr<Dense> create(std::shared_ptr<const Executor> exec,
                                          const dim<2>& size,
                                          array<value_type> values,
                                          size_type stride);
 
+    /**
+     * @copydoc std::unique_ptr<Dense> create(std::shared_ptr<const Executor>,
+     * const dim<2>&, array<value_type>, size_type)
+     */
     template <typename InputValueType>
     static std::unique_ptr<Dense> create(
         std::shared_ptr<const Executor> exec, const dim<2>& size,
@@ -1221,10 +1219,8 @@ public:
     Dense(Dense&&);
 
 protected:
-    Dense(std::shared_ptr<const Executor> exec, const dim<2>& size = dim<2>{});
-
-    Dense(std::shared_ptr<const Executor> exec, const dim<2>& size,
-          size_type stride);
+    Dense(std::shared_ptr<const Executor> exec, const dim<2>& size = {},
+          size_type stride = 0);
 
     Dense(std::shared_ptr<const Executor> exec, const dim<2>& size,
           array<value_type> values, size_type stride);
@@ -1452,8 +1448,8 @@ protected:
                          Dense<OutputType>* row_collection) const;
 
 private:
-    array<value_type> values_;
     size_type stride_;
+    array<value_type> values_;
 
     void add_scaled_identity_impl(const LinOp* a, const LinOp* b) override;
 };

--- a/include/ginkgo/core/matrix/dense.hpp
+++ b/include/ginkgo/core/matrix/dense.hpp
@@ -1169,6 +1169,9 @@ public:
      * const dim<2>&, array<value_type>, size_type)
      */
     template <typename InputValueType>
+    GKO_DEPRECATED(
+        "explicitly construct the gko::array argument instead of passing an"
+        "initializer list")
     static std::unique_ptr<Dense> create(
         std::shared_ptr<const Executor> exec, const dim<2>& size,
         std::initializer_list<InputValueType> values, size_type stride)

--- a/include/ginkgo/core/matrix/dense.hpp
+++ b/include/ginkgo/core/matrix/dense.hpp
@@ -1135,7 +1135,8 @@ public:
      * @param size  size of the matrix
      * @param stride  stride of the rows (i.e. offset between the first
      *                  elements of two consecutive rows, expressed as the
-     *                  number of matrix elements)
+     *                  number of matrix elements).
+     *                  If it is set to 0, size[1] will be used instead.
      *
      * @return A smart pointer to the newly created matrix.
      */

--- a/include/ginkgo/core/matrix/diagonal.hpp
+++ b/include/ginkgo/core/matrix/diagonal.hpp
@@ -163,27 +163,19 @@ public:
     void write(mat_data32& data) const override;
 
     /**
-     * Creates an empty Diagonal matrix.
-     *
-     * @param exec  Executor associated to the matrix
-     */
-    static std::unique_ptr<Diagonal> create(
-        std::shared_ptr<const Executor> exec);
-
-    /**
      * Creates an Diagonal matrix of the specified size.
      *
      * @param exec  Executor associated to the matrix
      * @param size  size of the matrix
+     *
+     * @return A smart pointer to the newly created matrix.
      */
     static std::unique_ptr<Diagonal> create(
-        std::shared_ptr<const Executor> exec, size_type size);
+        std::shared_ptr<const Executor> exec, size_type size = 0);
 
     /**
      * Creates a Diagonal matrix from an already allocated (and initialized)
      * array.
-     *
-     * @tparam ValuesArray  type of array of values
      *
      * @param exec  Executor associated to the matrix
      * @param size  size of the matrix
@@ -192,11 +184,17 @@ public:
      * @note If `values` is not an rvalue, not an array of ValueType, or is on
      *       the wrong executor, an internal copy will be created, and the
      *       original array data will not be used in the matrix.
+     *
+     * @return A smart pointer to the newly created matrix.
      */
     static std::unique_ptr<Diagonal> create(
         std::shared_ptr<const Executor> exec, const size_type size,
         array<value_type> values);
 
+    /**
+     * @copydoc std::unique_ptr<Diagonal> create(std::shared_ptr<const
+     * Executor>, const size_type, array<value_type>)
+     */
     template <typename InputValueType>
     static std::unique_ptr<Diagonal> create(
         std::shared_ptr<const Executor> exec, const size_type size,
@@ -220,9 +218,7 @@ public:
         gko::detail::const_array_view<ValueType>&& values);
 
 protected:
-    explicit Diagonal(std::shared_ptr<const Executor> exec);
-
-    Diagonal(std::shared_ptr<const Executor> exec, size_type size);
+    Diagonal(std::shared_ptr<const Executor> exec, size_type size = 0);
 
     Diagonal(std::shared_ptr<const Executor> exec, const size_type size,
              array<value_type> values);

--- a/include/ginkgo/core/matrix/diagonal.hpp
+++ b/include/ginkgo/core/matrix/diagonal.hpp
@@ -196,6 +196,9 @@ public:
      * Executor>, const size_type, array<value_type>)
      */
     template <typename InputValueType>
+    GKO_DEPRECATED(
+        "explicitly construct the gko::array argument instead of passing an"
+        "initializer list")
     static std::unique_ptr<Diagonal> create(
         std::shared_ptr<const Executor> exec, const size_type size,
         std::initializer_list<InputValueType> values)

--- a/include/ginkgo/core/matrix/ell.hpp
+++ b/include/ginkgo/core/matrix/ell.hpp
@@ -223,49 +223,22 @@ public:
 
     /**
      * Creates an uninitialized Ell matrix of the specified size.
-     *    (The stride is set to the number of rows of the matrix.
-     *     The num_stored_elements_per_row is set to the number of cols of the
-     * matrix.)
-     *
-     * @param exec  Executor associated to the matrix
-     * @param size  size of the matrix
-     */
-    static std::unique_ptr<Ell> create(std::shared_ptr<const Executor> exec,
-                                       const dim<2>& size = dim<2>{});
-
-    /**
-     * Creates an uninitialized Ell matrix of the specified size.
-     *    (The stride is set to the number of rows of the matrix.)
-     *
-     * @param exec  Executor associated to the matrix
-     * @param size  size of the matrix
-     * @param num_stored_elements_per_row   the number of stored elements per
-     *                                      row
-     */
-    static std::unique_ptr<Ell> create(std::shared_ptr<const Executor> exec,
-                                       const dim<2>& size,
-                                       size_type num_stored_elements_per_row);
-
-    /**
-     * Creates an uninitialized Ell matrix of the specified size.
      *
      * @param exec  Executor associated to the matrix
      * @param size  size of the matrix
      * @param num_stored_elements_per_row   the number of stored elements per
      *                                      row
      * @param stride                stride of the rows
+     *
+     * @return A smart pointer to the newly created matrix.
      */
-    static std::unique_ptr<Ell> create(std::shared_ptr<const Executor> exec,
-                                       const dim<2>& size,
-                                       size_type num_stored_elements_per_row,
-                                       size_type stride);
+    static std::unique_ptr<Ell> create(
+        std::shared_ptr<const Executor> exec, const dim<2>& size = {},
+        size_type num_stored_elements_per_row = 0, size_type stride = 0);
 
     /**
      * Creates an ELL matrix from already allocated (and initialized)
      * column index and value arrays.
-     *
-     * @tparam ValuesArray  type of `values` array
-     * @tparam ColIdxsArray  type of `col_idxs` array
      *
      * @param exec  Executor associated to the matrix
      * @param size  size of the matrix
@@ -279,6 +252,8 @@ public:
      *       IndexType and ValueType, respectively, or is on the wrong executor,
      *       an internal copy of that array will be created, and the original
      *       array data will not be used in the matrix.
+     *
+     * @return A smart pointer to the newly created matrix.
      */
     static std::unique_ptr<Ell> create(std::shared_ptr<const Executor> exec,
                                        const dim<2>& size,
@@ -350,13 +325,8 @@ public:
     Ell(Ell&&);
 
 protected:
-    Ell(std::shared_ptr<const Executor> exec, const dim<2>& size = dim<2>{});
-
-    Ell(std::shared_ptr<const Executor> exec, const dim<2>& size,
-        size_type num_stored_elements_per_row);
-
-    Ell(std::shared_ptr<const Executor> exec, const dim<2>& size,
-        size_type num_stored_elements_per_row, size_type stride);
+    Ell(std::shared_ptr<const Executor> exec, const dim<2>& size = {},
+        size_type num_stored_elements_per_row = 0, size_type stride = 0);
 
     Ell(std::shared_ptr<const Executor> exec, const dim<2>& size,
         array<value_type> values, array<index_type> col_idxs,
@@ -384,10 +354,10 @@ protected:
     }
 
 private:
-    array<value_type> values_;
-    array<index_type> col_idxs_;
     size_type num_stored_elements_per_row_;
     size_type stride_;
+    array<value_type> values_;
+    array<index_type> col_idxs_;
 };
 
 

--- a/include/ginkgo/core/matrix/ell.hpp
+++ b/include/ginkgo/core/matrix/ell.hpp
@@ -268,6 +268,9 @@ public:
      * size_type)
      */
     template <typename InputValueType, typename InputColumnIndexType>
+    GKO_DEPRECATED(
+        "explicitly construct the gko::array argument instead of passing "
+        "initializer lists")
     static std::unique_ptr<Ell> create(
         std::shared_ptr<const Executor> exec, const dim<2>& size,
         std::initializer_list<InputValueType> values,

--- a/include/ginkgo/core/matrix/ell.hpp
+++ b/include/ginkgo/core/matrix/ell.hpp
@@ -226,9 +226,9 @@ public:
      *
      * @param exec  Executor associated to the matrix
      * @param size  size of the matrix
-     * @param num_stored_elements_per_row   the number of stored elements per
-     *                                      row
-     * @param stride                stride of the rows
+     * @param num_stored_elements_per_row  the number of stored elements per row
+     * @param stride  stride of the columns. If it is set to 0, size[0] will be
+     *                used instead.
      *
      * @return A smart pointer to the newly created matrix.
      */

--- a/include/ginkgo/core/matrix/ell.hpp
+++ b/include/ginkgo/core/matrix/ell.hpp
@@ -50,7 +50,6 @@ class Hybrid;
  */
 template <typename ValueType = default_precision, typename IndexType = int32>
 class Ell : public EnableLinOp<Ell<ValueType, IndexType>>,
-            public EnableCreateMethod<Ell<ValueType, IndexType>>,
             public ConvertibleTo<Ell<next_precision<ValueType>, IndexType>>,
             public ConvertibleTo<Dense<ValueType>>,
             public ConvertibleTo<Csr<ValueType, IndexType>>,
@@ -59,7 +58,6 @@ class Ell : public EnableLinOp<Ell<ValueType, IndexType>>,
             public WritableToMatrixData<ValueType, IndexType>,
             public EnableAbsoluteComputation<
                 remove_complex<Ell<ValueType, IndexType>>> {
-    friend class EnableCreateMethod<Ell>;
     friend class EnablePolymorphicObject<Ell, LinOp>;
     friend class Dense<ValueType>;
     friend class Coo<ValueType, IndexType>;
@@ -224,6 +222,88 @@ public:
     }
 
     /**
+     * Creates an uninitialized Ell matrix of the specified size.
+     *    (The stride is set to the number of rows of the matrix.
+     *     The num_stored_elements_per_row is set to the number of cols of the
+     * matrix.)
+     *
+     * @param exec  Executor associated to the matrix
+     * @param size  size of the matrix
+     */
+    static std::unique_ptr<Ell> create(std::shared_ptr<const Executor> exec,
+                                       const dim<2>& size = dim<2>{});
+
+    /**
+     * Creates an uninitialized Ell matrix of the specified size.
+     *    (The stride is set to the number of rows of the matrix.)
+     *
+     * @param exec  Executor associated to the matrix
+     * @param size  size of the matrix
+     * @param num_stored_elements_per_row   the number of stored elements per
+     *                                      row
+     */
+    static std::unique_ptr<Ell> create(std::shared_ptr<const Executor> exec,
+                                       const dim<2>& size,
+                                       size_type num_stored_elements_per_row);
+
+    /**
+     * Creates an uninitialized Ell matrix of the specified size.
+     *
+     * @param exec  Executor associated to the matrix
+     * @param size  size of the matrix
+     * @param num_stored_elements_per_row   the number of stored elements per
+     *                                      row
+     * @param stride                stride of the rows
+     */
+    static std::unique_ptr<Ell> create(std::shared_ptr<const Executor> exec,
+                                       const dim<2>& size,
+                                       size_type num_stored_elements_per_row,
+                                       size_type stride);
+
+    /**
+     * Creates an ELL matrix from already allocated (and initialized)
+     * column index and value arrays.
+     *
+     * @tparam ValuesArray  type of `values` array
+     * @tparam ColIdxsArray  type of `col_idxs` array
+     *
+     * @param exec  Executor associated to the matrix
+     * @param size  size of the matrix
+     * @param values  array of matrix values
+     * @param col_idxs  array of column indexes
+     * @param num_stored_elements_per_row   the number of stored elements per
+     *                                      row
+     * @param stride  stride of the rows
+     *
+     * @note If one of `col_idxs` or `values` is not an rvalue, not an array of
+     *       IndexType and ValueType, respectively, or is on the wrong executor,
+     *       an internal copy of that array will be created, and the original
+     *       array data will not be used in the matrix.
+     */
+    static std::unique_ptr<Ell> create(std::shared_ptr<const Executor> exec,
+                                       const dim<2>& size,
+                                       array<value_type> values,
+                                       array<index_type> col_idxs,
+                                       size_type num_stored_elements_per_row,
+                                       size_type stride);
+
+    /**
+     * @copydoc create(std::shared_ptr<const Executor>, const dim<2>&,
+     * array<value_type>, array<index_type>, size_type, size_type)
+     */
+    template <typename InputValueType, typename InputColumnIndexType>
+    static std::unique_ptr<Ell> create(
+        std::shared_ptr<const Executor> exec, const dim<2>& size,
+        std::initializer_list<InputValueType> values,
+        std::initializer_list<InputColumnIndexType> col_idxs,
+        size_type num_stored_elements_per_row, size_type stride)
+    {
+        return create(exec, size, array<value_type>{exec, std::move(values)},
+                      array<index_type>{exec, std::move(col_idxs)},
+                      num_stored_elements_per_row, stride);
+    }
+
+    /**
      * Creates a constant (immutable) Ell matrix from a set of constant arrays.
      *
      * @param exec  the executor to create the matrix on
@@ -240,15 +320,7 @@ public:
         std::shared_ptr<const Executor> exec, const dim<2>& size,
         gko::detail::const_array_view<ValueType>&& values,
         gko::detail::const_array_view<IndexType>&& col_idxs,
-        size_type num_stored_elements_per_row, size_type stride)
-    {
-        // cast const-ness away, but return a const object afterwards,
-        // so we can ensure that no modifications take place.
-        return std::unique_ptr<const Ell>(new Ell{
-            exec, size, gko::detail::array_const_cast(std::move(values)),
-            gko::detail::array_const_cast(std::move(col_idxs)),
-            num_stored_elements_per_row, stride});
-    }
+        size_type num_stored_elements_per_row, size_type stride);
 
     /**
      * Copy-assigns an Ell matrix. Preserves the executor, reallocates the
@@ -277,87 +349,17 @@ public:
     Ell(Ell&&);
 
 protected:
-    /**
-     * Creates an uninitialized Ell matrix of the specified size.
-     *    (The stride is set to the number of rows of the matrix.
-     *     The num_stored_elements_per_row is set to the number of cols of the
-     * matrix.)
-     *
-     * @param exec  Executor associated to the matrix
-     * @param size  size of the matrix
-     */
-    Ell(std::shared_ptr<const Executor> exec, const dim<2>& size = dim<2>{})
-        : Ell(std::move(exec), size, size[1])
-    {}
+    Ell(std::shared_ptr<const Executor> exec, const dim<2>& size = dim<2>{});
 
-    /**
-     * Creates an uninitialized Ell matrix of the specified size.
-     *    (The stride is set to the number of rows of the matrix.)
-     *
-     * @param exec  Executor associated to the matrix
-     * @param size  size of the matrix
-     * @param num_stored_elements_per_row   the number of stored elements per
-     *                                      row
-     */
     Ell(std::shared_ptr<const Executor> exec, const dim<2>& size,
-        size_type num_stored_elements_per_row)
-        : Ell(std::move(exec), size, num_stored_elements_per_row, size[0])
-    {}
+        size_type num_stored_elements_per_row);
 
-    /**
-     * Creates an uninitialized Ell matrix of the specified size.
-     *
-     * @param exec  Executor associated to the matrix
-     * @param size  size of the matrix
-     * @param num_stored_elements_per_row   the number of stored elements per
-     *                                      row
-     * @param stride                stride of the rows
-     */
     Ell(std::shared_ptr<const Executor> exec, const dim<2>& size,
-        size_type num_stored_elements_per_row, size_type stride)
-        : EnableLinOp<Ell>(exec, size),
-          values_(exec, stride * num_stored_elements_per_row),
-          col_idxs_(exec, stride * num_stored_elements_per_row),
-          num_stored_elements_per_row_(num_stored_elements_per_row),
-          stride_(stride)
-    {}
+        size_type num_stored_elements_per_row, size_type stride);
 
-
-    /**
-     * Creates an ELL matrix from already allocated (and initialized)
-     * column index and value arrays.
-     *
-     * @tparam ValuesArray  type of `values` array
-     * @tparam ColIdxsArray  type of `col_idxs` array
-     *
-     * @param exec  Executor associated to the matrix
-     * @param size  size of the matrix
-     * @param values  array of matrix values
-     * @param col_idxs  array of column indexes
-     * @param num_stored_elements_per_row   the number of stored elements per
-     *                                      row
-     * @param stride  stride of the rows
-     *
-     * @note If one of `col_idxs` or `values` is not an rvalue, not an array of
-     *       IndexType and ValueType, respectively, or is on the wrong executor,
-     *       an internal copy of that array will be created, and the original
-     *       array data will not be used in the matrix.
-     */
-    template <typename ValuesArray, typename ColIdxsArray>
     Ell(std::shared_ptr<const Executor> exec, const dim<2>& size,
-        ValuesArray&& values, ColIdxsArray&& col_idxs,
-        size_type num_stored_elements_per_row, size_type stride)
-        : EnableLinOp<Ell>(exec, size),
-          values_{exec, std::forward<ValuesArray>(values)},
-          col_idxs_{exec, std::forward<ColIdxsArray>(col_idxs)},
-          num_stored_elements_per_row_{num_stored_elements_per_row},
-          stride_{stride}
-    {
-        GKO_ASSERT_EQ(num_stored_elements_per_row_ * stride_,
-                      values_.get_size());
-        GKO_ASSERT_EQ(num_stored_elements_per_row_ * stride_,
-                      col_idxs_.get_size());
-    }
+        array<value_type> values, array<index_type> col_idxs,
+        size_type num_stored_elements_per_row, size_type stride);
 
     /**
      * Resizes the matrix to the given dimensions and row nonzero count.

--- a/include/ginkgo/core/matrix/ell.hpp
+++ b/include/ginkgo/core/matrix/ell.hpp
@@ -288,8 +288,9 @@ public:
                                        size_type stride);
 
     /**
-     * @copydoc create(std::shared_ptr<const Executor>, const dim<2>&,
-     * array<value_type>, array<index_type>, size_type, size_type)
+     * @copydoc std::unique_ptr<Ell> create(std::shared_ptr<const Executor>,
+     * const dim<2>&, array<value_type>, array<index_type>, size_type,
+     * size_type)
      */
     template <typename InputValueType, typename InputColumnIndexType>
     static std::unique_ptr<Ell> create(

--- a/include/ginkgo/core/matrix/fbcsr.hpp
+++ b/include/ginkgo/core/matrix/fbcsr.hpp
@@ -354,9 +354,9 @@ public:
                                          array<index_type> row_ptrs);
 
     /**
-     * @copydoc create(std::shared_ptr<const Executor>, const dim<2>& size, int
-     * block_size, array<value_type> values, array<index_type> col_idxs,
-     * array<index_type>)
+     * @copydoc std::unique_ptr<Fbcsr> create(std::shared_ptr<const Executor>,
+     * const dim<2>& size, int block_size, array<value_type> values,
+     * array<index_type> col_idxs, array<index_type>)
      */
     template <typename InputValueType, typename InputColumnIndexType,
               typename InputRowPtrType>

--- a/include/ginkgo/core/matrix/fbcsr.hpp
+++ b/include/ginkgo/core/matrix/fbcsr.hpp
@@ -363,6 +363,9 @@ public:
      */
     template <typename InputValueType, typename InputColumnIndexType,
               typename InputRowPtrType>
+    GKO_DEPRECATED(
+        "explicitly construct the gko::array argument instead of passing "
+        "initializer lists")
     static std::unique_ptr<Fbcsr> create(
         std::shared_ptr<const Executor> exec, const dim<2>& size,
         int block_size, std::initializer_list<InputValueType> values,

--- a/include/ginkgo/core/matrix/fbcsr.hpp
+++ b/include/ginkgo/core/matrix/fbcsr.hpp
@@ -97,7 +97,6 @@ inline IndexType get_num_blocks(const int block_size, const IndexType size)
  */
 template <typename ValueType = default_precision, typename IndexType = int32>
 class Fbcsr : public EnableLinOp<Fbcsr<ValueType, IndexType>>,
-              public EnableCreateMethod<Fbcsr<ValueType, IndexType>>,
               public ConvertibleTo<Fbcsr<next_precision<ValueType>, IndexType>>,
               public ConvertibleTo<Dense<ValueType>>,
               public ConvertibleTo<Csr<ValueType, IndexType>>,
@@ -108,7 +107,6 @@ class Fbcsr : public EnableLinOp<Fbcsr<ValueType, IndexType>>,
               public Transposable,
               public EnableAbsoluteComputation<
                   remove_complex<Fbcsr<ValueType, IndexType>>> {
-    friend class EnableCreateMethod<Fbcsr>;
     friend class EnablePolymorphicObject<Fbcsr, LinOp>;
     friend class Csr<ValueType, IndexType>;
     friend class Dense<ValueType>;
@@ -305,6 +303,76 @@ public:
     }
 
     /**
+     * Creates an uninitialized FBCSR matrix with the given block size.
+     *
+     * @param exec  Executor associated to the matrix
+     * @param block_size  The desired size of the dense square nonzero blocks;
+     *                    defaults to 1.
+     */
+    static std::unique_ptr<Fbcsr> create(std::shared_ptr<const Executor> exec,
+                                         int block_size = 1);
+
+    /**
+     * Creates an uninitialized FBCSR matrix of the specified size.
+     *
+     * @param exec  Executor associated to the matrix
+     * @param size  size of the matrix
+     * @param num_nonzeros  number of stored nonzeros. It needs to be a multiple
+     *                      of block_size * block_size.
+     * @param block_size  size of the small dense square blocks
+     */
+    static std::unique_ptr<Fbcsr> create(std::shared_ptr<const Executor> exec,
+                                         const dim<2>& size,
+                                         size_type num_nonzeros,
+                                         int block_size);
+
+    /**
+     * Creates a FBCSR matrix from already allocated (and initialized) row
+     * pointer, column index and value arrays.
+     *
+     * @tparam ValuesArray  type of `values` array
+     * @tparam ColIdxsArray  type of `col_idxs` array
+     * @tparam RowPtrsArray  type of `row_ptrs` array
+     *
+     * @param exec  Executor associated to the matrix
+     * @param size  size of the matrix
+     * @param block_size  Size of the small square dense nonzero blocks
+     * @param values  array of matrix values
+     * @param col_idxs  array of column indexes
+     * @param row_ptrs  array of row pointers
+     *
+     * @note If one of `row_ptrs`, `col_idxs` or `values` is not an rvalue, not
+     *       an array of IndexType, IndexType and ValueType, respectively, or
+     *       is on the wrong executor, an internal copy of that array will be
+     *       created, and the original array data will not be used in the
+     *       matrix.
+     */
+    static std::unique_ptr<Fbcsr> create(std::shared_ptr<const Executor> exec,
+                                         const dim<2>& size, int block_size,
+                                         array<value_type> values,
+                                         array<index_type> col_idxs,
+                                         array<index_type> row_ptrs);
+
+    /**
+     * @copydoc create(std::shared_ptr<const Executor>, const dim<2>& size, int
+     * block_size, array<value_type> values, array<index_type> col_idxs,
+     * array<index_type>)
+     */
+    template <typename InputValueType, typename InputColumnIndexType,
+              typename InputRowPtrType>
+    static std::unique_ptr<Fbcsr> create(
+        std::shared_ptr<const Executor> exec, const dim<2>& size,
+        int block_size, std::initializer_list<InputValueType> values,
+        std::initializer_list<InputColumnIndexType> col_idxs,
+        std::initializer_list<InputRowPtrType> row_ptrs)
+    {
+        return create(exec, size, block_size,
+                      array<value_type>{exec, std::move(values)},
+                      array<index_type>{exec, std::move(col_idxs)},
+                      array<index_type>{exec, std::move(row_ptrs)});
+    }
+
+    /**
      * Creates a constant (immutable) Fbcsr matrix from a constant array.
      *
      * @param exec  the executor to create the matrix on
@@ -321,16 +389,7 @@ public:
         std::shared_ptr<const Executor> exec, const dim<2>& size, int blocksize,
         gko::detail::const_array_view<ValueType>&& values,
         gko::detail::const_array_view<IndexType>&& col_idxs,
-        gko::detail::const_array_view<IndexType>&& row_ptrs)
-    {
-        // cast const-ness away, but return a const object afterwards,
-        // so we can ensure that no modifications take place.
-        return std::unique_ptr<const Fbcsr>(
-            new Fbcsr{exec, size, blocksize,
-                      gko::detail::array_const_cast(std::move(values)),
-                      gko::detail::array_const_cast(std::move(col_idxs)),
-                      gko::detail::array_const_cast(std::move(row_ptrs))});
-    }
+        gko::detail::const_array_view<IndexType>&& row_ptrs);
 
     /**
      * Copy-assigns an Fbcsr matrix. Preserves the executor, copies data and
@@ -358,74 +417,14 @@ public:
     Fbcsr(Fbcsr&&);
 
 protected:
-    /**
-     * Creates an uninitialized FBCSR matrix with the given block size.
-     *
-     * @param exec  Executor associated to the matrix
-     * @param block_size  The desired size of the dense square nonzero blocks;
-     *                    defaults to 1.
-     */
-    Fbcsr(std::shared_ptr<const Executor> exec, int block_size = 1)
-        : Fbcsr(std::move(exec), dim<2>{}, {}, block_size)
-    {}
+    Fbcsr(std::shared_ptr<const Executor> exec, int block_size = 1);
 
-    /**
-     * Creates an uninitialized FBCSR matrix of the specified size.
-     *
-     * @param exec  Executor associated to the matrix
-     * @param size  size of the matrix
-     * @param num_nonzeros  number of stored nonzeros. It needs to be a multiple
-     *                      of block_size * block_size.
-     * @param block_size  size of the small dense square blocks
-     */
     Fbcsr(std::shared_ptr<const Executor> exec, const dim<2>& size,
-          size_type num_nonzeros, int block_size)
-        : EnableLinOp<Fbcsr>(exec, size),
-          bs_{block_size},
-          values_(exec, num_nonzeros),
-          col_idxs_(exec, detail::get_num_blocks(block_size * block_size,
-                                                 num_nonzeros)),
-          row_ptrs_(exec, detail::get_num_blocks(block_size, size[0]) + 1)
-    {
-        GKO_ASSERT_BLOCK_SIZE_CONFORMANT(size[1], bs_);
-        row_ptrs_.fill(0);
-    }
+          size_type num_nonzeros, int block_size);
 
-    /**
-     * Creates a FBCSR matrix from already allocated (and initialized) row
-     * pointer, column index and value arrays.
-     *
-     * @tparam ValuesArray  type of `values` array
-     * @tparam ColIdxsArray  type of `col_idxs` array
-     * @tparam RowPtrsArray  type of `row_ptrs` array
-     *
-     * @param exec  Executor associated to the matrix
-     * @param size  size of the matrix
-     * @param block_size  Size of the small square dense nonzero blocks
-     * @param values  array of matrix values
-     * @param col_idxs  array of column indexes
-     * @param row_ptrs  array of row pointers
-     *
-     * @note If one of `row_ptrs`, `col_idxs` or `values` is not an rvalue, not
-     *       an array of IndexType, IndexType and ValueType, respectively, or
-     *       is on the wrong executor, an internal copy of that array will be
-     *       created, and the original array data will not be used in the
-     *       matrix.
-     */
-    template <typename ValuesArray, typename ColIdxsArray,
-              typename RowPtrsArray>
     Fbcsr(std::shared_ptr<const Executor> exec, const dim<2>& size,
-          int block_size, ValuesArray&& values, ColIdxsArray&& col_idxs,
-          RowPtrsArray&& row_ptrs)
-        : EnableLinOp<Fbcsr>(exec, size),
-          bs_{block_size},
-          values_{exec, std::forward<ValuesArray>(values)},
-          col_idxs_{exec, std::forward<ColIdxsArray>(col_idxs)},
-          row_ptrs_{exec, std::forward<RowPtrsArray>(row_ptrs)}
-    {
-        GKO_ASSERT_EQ(values_.get_size(), col_idxs_.get_size() * bs_ * bs_);
-        GKO_ASSERT_EQ(this->get_size()[0] / bs_ + 1, row_ptrs_.get_size());
-    }
+          int block_size, array<value_type> values, array<index_type> col_idxs,
+          array<index_type> row_ptrs);
 
     void apply_impl(const LinOp* b, LinOp* x) const override;
 

--- a/include/ginkgo/core/matrix/fbcsr.hpp
+++ b/include/ginkgo/core/matrix/fbcsr.hpp
@@ -308,6 +308,8 @@ public:
      * @param exec  Executor associated to the matrix
      * @param block_size  The desired size of the dense square nonzero blocks;
      *                    defaults to 1.
+     *
+     * @return A smart pointer to the newly created matrix.
      */
     static std::unique_ptr<Fbcsr> create(std::shared_ptr<const Executor> exec,
                                          int block_size = 1);
@@ -320,6 +322,8 @@ public:
      * @param num_nonzeros  number of stored nonzeros. It needs to be a multiple
      *                      of block_size * block_size.
      * @param block_size  size of the small dense square blocks
+     *
+     * @return A smart pointer to the newly created matrix.
      */
     static std::unique_ptr<Fbcsr> create(std::shared_ptr<const Executor> exec,
                                          const dim<2>& size,
@@ -330,22 +334,21 @@ public:
      * Creates a FBCSR matrix from already allocated (and initialized) row
      * pointer, column index and value arrays.
      *
-     * @tparam ValuesArray  type of `values` array
-     * @tparam ColIdxsArray  type of `col_idxs` array
-     * @tparam RowPtrsArray  type of `row_ptrs` array
-     *
      * @param exec  Executor associated to the matrix
      * @param size  size of the matrix
      * @param block_size  Size of the small square dense nonzero blocks
-     * @param values  array of matrix values
-     * @param col_idxs  array of column indexes
-     * @param row_ptrs  array of row pointers
+     * @param values  the value array of the matrix, stored in column-major
+     *                order for each block
+     * @param col_idxs  the block column index array of the matrix
+     * @param row_ptrs  the block row pointer array of the matrix
      *
      * @note If one of `row_ptrs`, `col_idxs` or `values` is not an rvalue, not
      *       an array of IndexType, IndexType and ValueType, respectively, or
      *       is on the wrong executor, an internal copy of that array will be
      *       created, and the original array data will not be used in the
      *       matrix.
+     *
+     * @return A smart pointer to the newly created matrix.
      */
     static std::unique_ptr<Fbcsr> create(std::shared_ptr<const Executor> exec,
                                          const dim<2>& size, int block_size,
@@ -355,8 +358,8 @@ public:
 
     /**
      * @copydoc std::unique_ptr<Fbcsr> create(std::shared_ptr<const Executor>,
-     * const dim<2>& size, int block_size, array<value_type> values,
-     * array<index_type> col_idxs, array<index_type>)
+     * const dim<2>&, int, array<value_type>, array<index_type>,
+     * array<index_type>)
      */
     template <typename InputValueType, typename InputColumnIndexType,
               typename InputRowPtrType>
@@ -378,7 +381,8 @@ public:
      * @param exec  the executor to create the matrix on
      * @param size  the dimensions of the matrix
      * @param blocksize  the block size of the matrix
-     * @param values  the value array of the matrix
+     * @param values  the value array of the matrix, stored in column-major
+     *                order for each block
      * @param col_idxs  the block column index array of the matrix
      * @param row_ptrs  the block row pointer array of the matrix
      * @returns A smart pointer to the constant matrix wrapping the input arrays

--- a/include/ginkgo/core/matrix/fft.hpp
+++ b/include/ginkgo/core/matrix/fft.hpp
@@ -43,14 +43,12 @@ namespace matrix {
  * @ingroup LinOp
  */
 class Fft : public EnableLinOp<Fft>,
-            public EnableCreateMethod<Fft>,
             public WritableToMatrixData<std::complex<float>, int32>,
             public WritableToMatrixData<std::complex<float>, int64>,
             public WritableToMatrixData<std::complex<double>, int32>,
             public WritableToMatrixData<std::complex<double>, int64>,
             public Transposable {
     friend class EnablePolymorphicObject<Fft, LinOp>;
-    friend class EnableCreateMethod<Fft>;
 
 public:
     using EnableLinOp<Fft>::convert_to;
@@ -76,15 +74,12 @@ public:
 
     bool is_inverse() const;
 
-protected:
     /**
      * Creates an empty Fourier matrix.
      *
      * @param exec  Executor associated to the matrix
      */
-    explicit Fft(std::shared_ptr<const Executor> exec)
-        : EnableLinOp<Fft>(exec), buffer_{exec}, inverse_{}
-    {}
+    static std::unique_ptr<Fft> create(std::shared_ptr<const Executor> exec);
 
     /**
      * Creates an Fourier matrix with the given dimensions.
@@ -92,10 +87,15 @@ protected:
      * @param size  size of the matrix
      * @param inverse  true to compute an inverse DFT instead of a normal DFT
      */
+    static std::unique_ptr<Fft> create(std::shared_ptr<const Executor> exec,
+                                       size_type size = 0,
+                                       bool inverse = false);
+
+protected:
+    explicit Fft(std::shared_ptr<const Executor> exec);
+
     Fft(std::shared_ptr<const Executor> exec, size_type size,
-        bool inverse = false)
-        : EnableLinOp<Fft>(exec, dim<2>{size}), buffer_{exec}, inverse_{inverse}
-    {}
+        bool inverse = false);
 
     void apply_impl(const LinOp* b, LinOp* x) const override;
 
@@ -139,14 +139,12 @@ private:
  * @ingroup LinOp
  */
 class Fft2 : public EnableLinOp<Fft2>,
-             public EnableCreateMethod<Fft2>,
              public WritableToMatrixData<std::complex<float>, int32>,
              public WritableToMatrixData<std::complex<float>, int64>,
              public WritableToMatrixData<std::complex<double>, int32>,
              public WritableToMatrixData<std::complex<double>, int64>,
              public Transposable {
     friend class EnablePolymorphicObject<Fft2, LinOp>;
-    friend class EnableCreateMethod<Fft2>;
 
 public:
     using EnableLinOp<Fft2>::convert_to;
@@ -172,24 +170,20 @@ public:
 
     bool is_inverse() const;
 
-protected:
     /**
      * Creates an empty Fourier matrix.
      *
      * @param exec  Executor associated to the matrix
      */
-    explicit Fft2(std::shared_ptr<const Executor> exec)
-        : EnableLinOp<Fft2>(exec), buffer_{exec}, fft_size_{}, inverse_{}
-    {}
+    static std::unique_ptr<Fft2> create(std::shared_ptr<const Executor> exec);
 
     /**
      * Creates an Fourier matrix with the given dimensions.
      *
      * @param size  size of both FFT dimensions
      */
-    Fft2(std::shared_ptr<const Executor> exec, size_type size)
-        : Fft2{exec, size, size}
-    {}
+    static std::unique_ptr<Fft2> create(std::shared_ptr<const Executor> exec,
+                                        size_type size);
 
     /**
      * Creates an Fourier matrix with the given dimensions.
@@ -198,13 +192,17 @@ protected:
      * @param size2  size of the second FFT dimension
      * @param inverse  true to compute an inverse DFT instead of a normal DFT
      */
+    static std::unique_ptr<Fft2> create(std::shared_ptr<const Executor> exec,
+                                        size_type size1, size_type size2,
+                                        bool inverse = false);
+
+protected:
+    explicit Fft2(std::shared_ptr<const Executor> exec);
+
+    Fft2(std::shared_ptr<const Executor> exec, size_type size);
+
     Fft2(std::shared_ptr<const Executor> exec, size_type size1, size_type size2,
-         bool inverse = false)
-        : EnableLinOp<Fft2>(exec, dim<2>{size1 * size2}),
-          buffer_{exec},
-          fft_size_{size1, size2},
-          inverse_{inverse}
-    {}
+         bool inverse = false);
 
     void apply_impl(const LinOp* b, LinOp* x) const override;
 
@@ -251,14 +249,12 @@ private:
  * @ingroup LinOp
  */
 class Fft3 : public EnableLinOp<Fft3>,
-             public EnableCreateMethod<Fft3>,
              public WritableToMatrixData<std::complex<float>, int32>,
              public WritableToMatrixData<std::complex<float>, int64>,
              public WritableToMatrixData<std::complex<double>, int32>,
              public WritableToMatrixData<std::complex<double>, int64>,
              public Transposable {
     friend class EnablePolymorphicObject<Fft3, LinOp>;
-    friend class EnableCreateMethod<Fft3>;
 
 public:
     using EnableLinOp<Fft3>::convert_to;
@@ -284,24 +280,20 @@ public:
 
     bool is_inverse() const;
 
-protected:
     /**
      * Creates an empty Fourier matrix.
      *
      * @param exec  Executor associated to the matrix
      */
-    explicit Fft3(std::shared_ptr<const Executor> exec)
-        : EnableLinOp<Fft3>(exec), buffer_{exec}, fft_size_{}, inverse_{}
-    {}
+    static std::unique_ptr<Fft3> create(std::shared_ptr<const Executor> exec);
 
     /**
      * Creates an Fourier matrix with the given dimensions.
      *
      * @param size  size of all FFT dimensions
      */
-    Fft3(std::shared_ptr<const Executor> exec, size_type size)
-        : Fft3{exec, size, size, size}
-    {}
+    static std::unique_ptr<Fft3> create(std::shared_ptr<const Executor> exec,
+                                        size_type size);
 
     /**
      * Creates an Fourier matrix with the given dimensions.
@@ -311,13 +303,17 @@ protected:
      * @param size3  size of the third FFT dimension
      * @param inverse  true to compute an inverse DFT instead of a normal DFT
      */
+    static std::unique_ptr<Fft3> create(std::shared_ptr<const Executor> exec,
+                                        size_type size1, size_type size2,
+                                        size_type size3, bool inverse = false);
+
+protected:
+    explicit Fft3(std::shared_ptr<const Executor> exec);
+
+    Fft3(std::shared_ptr<const Executor> exec, size_type size);
+
     Fft3(std::shared_ptr<const Executor> exec, size_type size1, size_type size2,
-         size_type size3, bool inverse = false)
-        : EnableLinOp<Fft3>(exec, dim<2>{size1 * size2 * size3}),
-          buffer_{exec},
-          fft_size_{size1, size2, size3},
-          inverse_{inverse}
-    {}
+         size_type size3, bool inverse = false);
 
     void apply_impl(const LinOp* b, LinOp* x) const override;
 

--- a/include/ginkgo/core/matrix/fft.hpp
+++ b/include/ginkgo/core/matrix/fft.hpp
@@ -78,6 +78,8 @@ public:
      * Creates an empty Fourier matrix.
      *
      * @param exec  Executor associated to the matrix
+     *
+     * @return A smart pointer to the newly created matrix.
      */
     static std::unique_ptr<Fft> create(std::shared_ptr<const Executor> exec);
 
@@ -86,15 +88,15 @@ public:
      *
      * @param size  size of the matrix
      * @param inverse  true to compute an inverse DFT instead of a normal DFT
+     *
+     * @return A smart pointer to the newly created matrix.
      */
     static std::unique_ptr<Fft> create(std::shared_ptr<const Executor> exec,
                                        size_type size = 0,
                                        bool inverse = false);
 
 protected:
-    explicit Fft(std::shared_ptr<const Executor> exec);
-
-    Fft(std::shared_ptr<const Executor> exec, size_type size,
+    Fft(std::shared_ptr<const Executor> exec, size_type size = 0,
         bool inverse = false);
 
     void apply_impl(const LinOp* b, LinOp* x) const override;
@@ -174,6 +176,8 @@ public:
      * Creates an empty Fourier matrix.
      *
      * @param exec  Executor associated to the matrix
+     *
+     * @return A smart pointer to the newly created matrix.
      */
     static std::unique_ptr<Fft2> create(std::shared_ptr<const Executor> exec);
 
@@ -181,6 +185,8 @@ public:
      * Creates an Fourier matrix with the given dimensions.
      *
      * @param size  size of both FFT dimensions
+     *
+     * @return A smart pointer to the newly created matrix.
      */
     static std::unique_ptr<Fft2> create(std::shared_ptr<const Executor> exec,
                                         size_type size);
@@ -191,18 +197,16 @@ public:
      * @param size1  size of the first FFT dimension
      * @param size2  size of the second FFT dimension
      * @param inverse  true to compute an inverse DFT instead of a normal DFT
+     *
+     * @return A smart pointer to the newly created matrix.
      */
     static std::unique_ptr<Fft2> create(std::shared_ptr<const Executor> exec,
                                         size_type size1, size_type size2,
                                         bool inverse = false);
 
 protected:
-    explicit Fft2(std::shared_ptr<const Executor> exec);
-
-    Fft2(std::shared_ptr<const Executor> exec, size_type size);
-
-    Fft2(std::shared_ptr<const Executor> exec, size_type size1, size_type size2,
-         bool inverse = false);
+    Fft2(std::shared_ptr<const Executor> exec, size_type size1 = 0,
+         size_type size2 = 0, bool inverse = false);
 
     void apply_impl(const LinOp* b, LinOp* x) const override;
 
@@ -284,6 +288,8 @@ public:
      * Creates an empty Fourier matrix.
      *
      * @param exec  Executor associated to the matrix
+     *
+     * @return A smart pointer to the newly created matrix.
      */
     static std::unique_ptr<Fft3> create(std::shared_ptr<const Executor> exec);
 
@@ -291,6 +297,8 @@ public:
      * Creates an Fourier matrix with the given dimensions.
      *
      * @param size  size of all FFT dimensions
+     *
+     * @return A smart pointer to the newly created matrix.
      */
     static std::unique_ptr<Fft3> create(std::shared_ptr<const Executor> exec,
                                         size_type size);
@@ -302,18 +310,16 @@ public:
      * @param size2  size of the second FFT dimension
      * @param size3  size of the third FFT dimension
      * @param inverse  true to compute an inverse DFT instead of a normal DFT
+     *
+     * @return A smart pointer to the newly created matrix.
      */
     static std::unique_ptr<Fft3> create(std::shared_ptr<const Executor> exec,
                                         size_type size1, size_type size2,
                                         size_type size3, bool inverse = false);
 
 protected:
-    explicit Fft3(std::shared_ptr<const Executor> exec);
-
-    Fft3(std::shared_ptr<const Executor> exec, size_type size);
-
-    Fft3(std::shared_ptr<const Executor> exec, size_type size1, size_type size2,
-         size_type size3, bool inverse = false);
+    Fft3(std::shared_ptr<const Executor> exec, size_type size1 = 0,
+         size_type size2 = 0, size_type size3 = 0, bool inverse = false);
 
     void apply_impl(const LinOp* b, LinOp* x) const override;
 

--- a/include/ginkgo/core/matrix/hybrid.hpp
+++ b/include/ginkgo/core/matrix/hybrid.hpp
@@ -42,7 +42,6 @@ class Csr;
 template <typename ValueType = default_precision, typename IndexType = int32>
 class Hybrid
     : public EnableLinOp<Hybrid<ValueType, IndexType>>,
-      public EnableCreateMethod<Hybrid<ValueType, IndexType>>,
       public ConvertibleTo<Hybrid<next_precision<ValueType>, IndexType>>,
       public ConvertibleTo<Dense<ValueType>>,
       public ConvertibleTo<Csr<ValueType, IndexType>>,
@@ -51,7 +50,6 @@ class Hybrid
       public WritableToMatrixData<ValueType, IndexType>,
       public EnableAbsoluteComputation<
           remove_complex<Hybrid<ValueType, IndexType>>> {
-    friend class EnableCreateMethod<Hybrid>;
     friend class EnablePolymorphicObject<Hybrid, LinOp>;
     friend class Dense<ValueType>;
     friend class Csr<ValueType, IndexType>;
@@ -612,6 +610,82 @@ public:
     std::shared_ptr<typename HybType::strategy_type> get_strategy() const;
 
     /**
+     * Creates an uninitialized Hybrid matrix of specified method.
+     *    (ell_num_stored_elements_per_row is set to the number of cols of the
+     * matrix. ell_stride is set to the number of rows of the matrix.)
+     *
+     * @param exec  Executor associated to the matrix
+     * @param strategy  strategy of deciding the Hybrid config
+     */
+    static std::unique_ptr<Hybrid> create(
+        std::shared_ptr<const Executor> exec,
+        std::shared_ptr<strategy_type> strategy =
+            std::make_shared<automatic>());
+
+    /**
+     * Creates an uninitialized Hybrid matrix of the specified size and method.
+     *    (ell_num_stored_elements_per_row is set to the number of cols of the
+     * matrix. ell_stride is set to the number of rows of the matrix.)
+     *
+     * @param exec  Executor associated to the matrix
+     * @param size  size of the matrix
+     * @param strategy  strategy of deciding the Hybrid config
+     */
+    static std::unique_ptr<Hybrid> create(
+        std::shared_ptr<const Executor> exec, const dim<2>& size,
+        std::shared_ptr<strategy_type> strategy =
+            std::make_shared<automatic>());
+
+    /**
+     * Creates an uninitialized Hybrid matrix of the specified size and method.
+     *    (ell_stride is set to the number of rows of the matrix.)
+     *
+     * @param exec  Executor associated to the matrix
+     * @param size  size of the matrix
+     * @param num_stored_elements_per_row   the number of stroed elements per
+     *                                      row
+     * @param strategy  strategy of deciding the Hybrid config
+     */
+    static std::unique_ptr<Hybrid> create(
+        std::shared_ptr<const Executor> exec, const dim<2>& size,
+        size_type num_stored_elements_per_row,
+        std::shared_ptr<strategy_type> strategy =
+            std::make_shared<automatic>());
+
+    /**
+     * Creates an uninitialized Hybrid matrix of the specified size and method.
+     *
+     * @param exec  Executor associated to the matrix
+     * @param size  size of the matrix
+     * @param num_stored_elements_per_row   the number of stored elements per
+     *                                      row
+     * @param stride  stride of the rows
+     * @param strategy  strategy of deciding the Hybrid config
+     */
+    static std::unique_ptr<Hybrid> create(
+        std::shared_ptr<const Executor> exec, const dim<2>& size,
+        size_type num_stored_elements_per_row, size_type stride,
+        std::shared_ptr<strategy_type> strategy);
+
+    /**
+     * Creates an uninitialized Hybrid matrix of the specified size and method.
+     *
+     * @param exec  Executor associated to the matrix
+     * @param size  size of the matrix
+     * @param num_stored_elements_per_row   the number of stored elements per
+     *                                      row
+     * @param stride  stride of the rows
+     * @param num_nonzeros  number of nonzeros
+     * @param strategy  strategy of deciding the Hybrid config
+     */
+    static std::unique_ptr<Hybrid> create(
+        std::shared_ptr<const Executor> exec, const dim<2>& size,
+        size_type num_stored_elements_per_row, size_type stride,
+        size_type num_nonzeros = {},
+        std::shared_ptr<strategy_type> strategy =
+            std::make_shared<automatic>());
+
+    /**
      * Copy-assigns a Hybrid matrix. Preserves the executor, copy-assigns the
      * Ell and Coo matrices.
      */
@@ -638,92 +712,28 @@ public:
     Hybrid(Hybrid&&);
 
 protected:
-    /**
-     * Creates an uninitialized Hybrid matrix of specified method.
-     *    (ell_num_stored_elements_per_row is set to the number of cols of the
-     * matrix. ell_stride is set to the number of rows of the matrix.)
-     *
-     * @param exec  Executor associated to the matrix
-     * @param strategy  strategy of deciding the Hybrid config
-     */
-    Hybrid(
-        std::shared_ptr<const Executor> exec,
-        std::shared_ptr<strategy_type> strategy = std::make_shared<automatic>())
-        : Hybrid(std::move(exec), dim<2>{}, std::move(strategy))
-    {}
+    Hybrid(std::shared_ptr<const Executor> exec,
+           std::shared_ptr<strategy_type> strategy =
+               std::make_shared<automatic>());
 
-    /**
-     * Creates an uninitialized Hybrid matrix of the specified size and method.
-     *    (ell_num_stored_elements_per_row is set to the number of cols of the
-     * matrix. ell_stride is set to the number of rows of the matrix.)
-     *
-     * @param exec  Executor associated to the matrix
-     * @param size  size of the matrix
-     * @param strategy  strategy of deciding the Hybrid config
-     */
-    Hybrid(
-        std::shared_ptr<const Executor> exec, const dim<2>& size,
-        std::shared_ptr<strategy_type> strategy = std::make_shared<automatic>())
-        : Hybrid(std::move(exec), size, size[1], std::move(strategy))
-    {}
+    Hybrid(std::shared_ptr<const Executor> exec, const dim<2>& size,
+           std::shared_ptr<strategy_type> strategy =
+               std::make_shared<automatic>());
 
-    /**
-     * Creates an uninitialized Hybrid matrix of the specified size and method.
-     *    (ell_stride is set to the number of rows of the matrix.)
-     *
-     * @param exec  Executor associated to the matrix
-     * @param size  size of the matrix
-     * @param num_stored_elements_per_row   the number of stroed elements per
-     *                                      row
-     * @param strategy  strategy of deciding the Hybrid config
-     */
-    Hybrid(
-        std::shared_ptr<const Executor> exec, const dim<2>& size,
-        size_type num_stored_elements_per_row,
-        std::shared_ptr<strategy_type> strategy = std::make_shared<automatic>())
-        : Hybrid(std::move(exec), size, num_stored_elements_per_row, size[0],
-                 {}, std::move(strategy))
-    {}
+    Hybrid(std::shared_ptr<const Executor> exec, const dim<2>& size,
+           size_type num_stored_elements_per_row,
+           std::shared_ptr<strategy_type> strategy =
+               std::make_shared<automatic>());
 
-    /**
-     * Creates an uninitialized Hybrid matrix of the specified size and method.
-     *
-     * @param exec  Executor associated to the matrix
-     * @param size  size of the matrix
-     * @param num_stored_elements_per_row   the number of stored elements per
-     *                                      row
-     * @param stride  stride of the rows
-     * @param strategy  strategy of deciding the Hybrid config
-     */
     Hybrid(std::shared_ptr<const Executor> exec, const dim<2>& size,
            size_type num_stored_elements_per_row, size_type stride,
-           std::shared_ptr<strategy_type> strategy)
-        : Hybrid(std::move(exec), size, num_stored_elements_per_row, stride, {},
-                 std::move(strategy))
-    {}
+           std::shared_ptr<strategy_type> strategy);
 
-    /**
-     * Creates an uninitialized Hybrid matrix of the specified size and method.
-     *
-     * @param exec  Executor associated to the matrix
-     * @param size  size of the matrix
-     * @param num_stored_elements_per_row   the number of stored elements per
-     *                                      row
-     * @param stride  stride of the rows
-     * @param num_nonzeros  number of nonzeros
-     * @param strategy  strategy of deciding the Hybrid config
-     */
-    Hybrid(
-        std::shared_ptr<const Executor> exec, const dim<2>& size,
-        size_type num_stored_elements_per_row, size_type stride,
-        size_type num_nonzeros = {},
-        std::shared_ptr<strategy_type> strategy = std::make_shared<automatic>())
-        : EnableLinOp<Hybrid>(exec, size),
-          ell_(ell_type::create(exec, size, num_stored_elements_per_row,
-                                stride)),
-          coo_(coo_type::create(exec, size, num_nonzeros)),
-          strategy_(std::move(strategy))
-    {}
+    Hybrid(std::shared_ptr<const Executor> exec, const dim<2>& size,
+           size_type num_stored_elements_per_row, size_type stride,
+           size_type num_nonzeros = {},
+           std::shared_ptr<strategy_type> strategy =
+               std::make_shared<automatic>());
 
     /**
      * Resizes the matrix to the given dimensions and storage sizes.

--- a/include/ginkgo/core/matrix/hybrid.hpp
+++ b/include/ginkgo/core/matrix/hybrid.hpp
@@ -616,6 +616,8 @@ public:
      *
      * @param exec  Executor associated to the matrix
      * @param strategy  strategy of deciding the Hybrid config
+     *
+     * @return A smart pointer to the newly created matrix.
      */
     static std::unique_ptr<Hybrid> create(
         std::shared_ptr<const Executor> exec,
@@ -630,6 +632,8 @@ public:
      * @param exec  Executor associated to the matrix
      * @param size  size of the matrix
      * @param strategy  strategy of deciding the Hybrid config
+     *
+     * @return A smart pointer to the newly created matrix.
      */
     static std::unique_ptr<Hybrid> create(
         std::shared_ptr<const Executor> exec, const dim<2>& size,
@@ -645,6 +649,8 @@ public:
      * @param num_stored_elements_per_row   the number of stroed elements per
      *                                      row
      * @param strategy  strategy of deciding the Hybrid config
+     *
+     * @return A smart pointer to the newly created matrix.
      */
     static std::unique_ptr<Hybrid> create(
         std::shared_ptr<const Executor> exec, const dim<2>& size,
@@ -661,6 +667,8 @@ public:
      *                                      row
      * @param stride  stride of the rows
      * @param strategy  strategy of deciding the Hybrid config
+     *
+     * @return A smart pointer to the newly created matrix.
      */
     static std::unique_ptr<Hybrid> create(
         std::shared_ptr<const Executor> exec, const dim<2>& size,
@@ -677,6 +685,8 @@ public:
      * @param stride  stride of the rows
      * @param num_nonzeros  number of nonzeros
      * @param strategy  strategy of deciding the Hybrid config
+     *
+     * @return A smart pointer to the newly created matrix.
      */
     static std::unique_ptr<Hybrid> create(
         std::shared_ptr<const Executor> exec, const dim<2>& size,
@@ -712,26 +722,9 @@ public:
     Hybrid(Hybrid&&);
 
 protected:
-    Hybrid(std::shared_ptr<const Executor> exec,
-           std::shared_ptr<strategy_type> strategy =
-               std::make_shared<automatic>());
-
-    Hybrid(std::shared_ptr<const Executor> exec, const dim<2>& size,
-           std::shared_ptr<strategy_type> strategy =
-               std::make_shared<automatic>());
-
-    Hybrid(std::shared_ptr<const Executor> exec, const dim<2>& size,
-           size_type num_stored_elements_per_row,
-           std::shared_ptr<strategy_type> strategy =
-               std::make_shared<automatic>());
-
-    Hybrid(std::shared_ptr<const Executor> exec, const dim<2>& size,
-           size_type num_stored_elements_per_row, size_type stride,
-           std::shared_ptr<strategy_type> strategy);
-
-    Hybrid(std::shared_ptr<const Executor> exec, const dim<2>& size,
-           size_type num_stored_elements_per_row, size_type stride,
-           size_type num_nonzeros = {},
+    Hybrid(std::shared_ptr<const Executor> exec, const dim<2>& size = {},
+           size_type num_stored_elements_per_row = 0, size_type stride = 0,
+           size_type num_nonzeros = 0,
            std::shared_ptr<strategy_type> strategy =
                std::make_shared<automatic>());
 

--- a/include/ginkgo/core/matrix/identity.hpp
+++ b/include/ginkgo/core/matrix/identity.hpp
@@ -32,11 +32,8 @@ namespace matrix {
  * @ingroup LinOp
  */
 template <typename ValueType = default_precision>
-class Identity : public EnableLinOp<Identity<ValueType>>,
-                 public EnableCreateMethod<Identity<ValueType>>,
-                 public Transposable {
+class Identity : public EnableLinOp<Identity<ValueType>>, public Transposable {
     friend class EnablePolymorphicObject<Identity, LinOp>;
-    friend class EnableCreateMethod<Identity>;
 
 public:
     using EnableLinOp<Identity>::convert_to;
@@ -49,36 +46,27 @@ public:
 
     std::unique_ptr<LinOp> conj_transpose() const override;
 
-
-protected:
-    /**
-     * Creates an empty Identity matrix.
-     *
-     * @param exec  Executor associated to the matrix
-     */
-    explicit Identity(std::shared_ptr<const Executor> exec)
-        : EnableLinOp<Identity>(exec)
-    {}
-
     /**
      * Creates an Identity matrix of the specified size.
      *
      * @param size  size of the matrix (must be square)
      */
-    Identity(std::shared_ptr<const Executor> exec, dim<2> size)
-        : EnableLinOp<Identity>(exec, size)
-    {
-        GKO_ASSERT_IS_SQUARE_MATRIX(this);
-    }
+    GKO_DEPRECATED("use the version taking a size_type instead of dim<2>")
+    static std::unique_ptr<Identity> create(
+        std::shared_ptr<const Executor> exec, dim<2> size);
 
     /**
      * Creates an Identity matrix of the specified size.
      *
      * @param size  size of the matrix
      */
-    Identity(std::shared_ptr<const Executor> exec, size_type size)
-        : EnableLinOp<Identity>(exec, dim<2>{size})
-    {}
+    static std::unique_ptr<Identity> create(
+        std::shared_ptr<const Executor> exec, size_type size = 0);
+
+protected:
+    explicit Identity(std::shared_ptr<const Executor> exec, size_type size = 0);
+
+    explicit Identity(std::shared_ptr<const Executor> exec, dim<2> size);
 
     void apply_impl(const LinOp* b, LinOp* x) const override;
 

--- a/include/ginkgo/core/matrix/identity.hpp
+++ b/include/ginkgo/core/matrix/identity.hpp
@@ -66,8 +66,6 @@ public:
 protected:
     explicit Identity(std::shared_ptr<const Executor> exec, size_type size = 0);
 
-    explicit Identity(std::shared_ptr<const Executor> exec, dim<2> size);
-
     void apply_impl(const LinOp* b, LinOp* x) const override;
 
     void apply_impl(const LinOp* alpha, const LinOp* b, const LinOp* beta,

--- a/include/ginkgo/core/matrix/permutation.hpp
+++ b/include/ginkgo/core/matrix/permutation.hpp
@@ -110,9 +110,7 @@ static constexpr mask_type inverse_permute = mask_type{1 << 3};
  */
 template <typename IndexType = int32>
 class Permutation : public EnableLinOp<Permutation<IndexType>>,
-                    public EnableCreateMethod<Permutation<IndexType>>,
                     public WritableToMatrixData<default_precision, IndexType> {
-    friend class EnableCreateMethod<Permutation>;
     friend class EnablePolymorphicObject<Permutation, LinOp>;
 
 public:
@@ -180,6 +178,53 @@ public:
     void write(gko::matrix_data<value_type, index_type>& data) const override;
 
     /**
+     * Creates an uninitialized Permutation arrays on the specified executor.
+     *
+     * @param exec  Executor associated to the LinOp
+     */
+    static std::unique_ptr<Permutation> create(
+        std::shared_ptr<const Executor> exec, size_type size = 0);
+
+    /**
+     * Creates a Permutation matrix from an already allocated (and initialized)
+     * row and column permutation arrays.
+     *
+     * @param exec  Executor associated to the matrix
+     * @param size  size of the permutation array.
+     * @param permutation_indices array of permutation array
+     * @param enabled_permute  mask for the type of permutation to apply.
+     *
+     * @note If `permutation_indices` is not an rvalue, not an array of
+     * IndexType, or is on the wrong executor, an internal copy will be created,
+     * and the original array data will not be used in the matrix.
+     */
+    static std::unique_ptr<Permutation> create(
+        std::shared_ptr<const Executor> exec,
+        array<IndexType> permutation_indices);
+
+    GKO_DEPRECATED(
+        "dim<2> is no longer supported as a dimension parameter, use size_type "
+        "instead")
+    static std::unique_ptr<Permutation> create(
+        std::shared_ptr<const Executor> exec, const dim<2>& size);
+
+    GKO_DEPRECATED("permute mask is no longer supported")
+    static std::unique_ptr<Permutation> create(
+        std::shared_ptr<const Executor> exec, const dim<2>& size,
+        const mask_type& enabled_permute);
+
+    GKO_DEPRECATED("use the overload without dimensions")
+    static std::unique_ptr<Permutation> create(
+        std::shared_ptr<const Executor> exec, const dim<2>& size,
+        array<IndexType> permutation_indices);
+
+    GKO_DEPRECATED("permute mask is no longer supported")
+    static std::unique_ptr<Permutation> create(
+        std::shared_ptr<const Executor> exec, const dim<2>& size,
+        array<index_type> permutation_indices,
+        const mask_type& enabled_permute);
+
+    /**
      * Creates a constant (immutable) Permutation matrix from a constant array.
      *
      * @param exec  the executor to create the matrix on
@@ -211,26 +256,8 @@ public:
         gko::detail::const_array_view<IndexType>&& perm_idxs);
 
 protected:
-    /**
-     * Creates an uninitialized Permutation arrays on the specified executor.
-     *
-     * @param exec  Executor associated to the LinOp
-     */
     Permutation(std::shared_ptr<const Executor> exec, size_type = 0);
 
-    /**
-     * Creates a Permutation matrix from an already allocated (and initialized)
-     * row and column permutation arrays.
-     *
-     * @param exec  Executor associated to the matrix
-     * @param size  size of the permutation array.
-     * @param permutation_indices array of permutation array
-     * @param enabled_permute  mask for the type of permutation to apply.
-     *
-     * @note If `permutation_indices` is not an rvalue, not an array of
-     * IndexType, or is on the wrong executor, an internal copy will be created,
-     * and the original array data will not be used in the matrix.
-     */
     Permutation(std::shared_ptr<const Executor> exec,
                 array<IndexType> permutation_indices);
 
@@ -243,30 +270,14 @@ protected:
     Permutation(std::shared_ptr<const Executor> exec, const dim<2>& size,
                 const mask_type& enabled_permute);
 
-    template <typename IndicesArray>
     GKO_DEPRECATED("use the overload without dimensions")
     Permutation(std::shared_ptr<const Executor> exec, const dim<2>& size,
-                IndicesArray&& permutation_indices)
-        : Permutation{exec, array<IndexType>{exec, std::forward<IndicesArray>(
-                                                       permutation_indices)}}
-    {
-        GKO_ASSERT_EQ(size[0], permutation_.get_size());
-        GKO_ASSERT_IS_SQUARE_MATRIX(size);
-    }
+                array<IndexType> permutation_indices);
 
-    template <typename IndicesArray>
     GKO_DEPRECATED("permute mask is no longer supported")
     Permutation(std::shared_ptr<const Executor> exec, const dim<2>& size,
-                IndicesArray&& permutation_indices,
-                const mask_type& enabled_permute)
-        : Permutation{std::move(exec),
-                      array<IndexType>{exec, std::forward<IndicesArray>(
-                                                 permutation_indices)}}
-    {
-        GKO_ASSERT_EQ(enabled_permute, row_permute);
-        GKO_ASSERT_EQ(size[0], permutation_.get_size());
-        GKO_ASSERT_IS_SQUARE_MATRIX(size);
-    }
+                array<index_type> permutation_indices,
+                const mask_type& enabled_permute);
 
     void apply_impl(const LinOp* in, LinOp* out) const override;
 

--- a/include/ginkgo/core/matrix/permutation.hpp
+++ b/include/ginkgo/core/matrix/permutation.hpp
@@ -181,6 +181,8 @@ public:
      * Creates an uninitialized Permutation arrays on the specified executor.
      *
      * @param exec  Executor associated to the LinOp
+     *
+     * @return A smart pointer to the newly created matrix.
      */
     static std::unique_ptr<Permutation> create(
         std::shared_ptr<const Executor> exec, size_type size = 0);
@@ -197,6 +199,8 @@ public:
      * @note If `permutation_indices` is not an rvalue, not an array of
      * IndexType, or is on the wrong executor, an internal copy will be created,
      * and the original array data will not be used in the matrix.
+     *
+     * @return A smart pointer to the newly created matrix.
      */
     static std::unique_ptr<Permutation> create(
         std::shared_ptr<const Executor> exec,
@@ -260,24 +264,6 @@ protected:
 
     Permutation(std::shared_ptr<const Executor> exec,
                 array<IndexType> permutation_indices);
-
-    GKO_DEPRECATED(
-        "dim<2> is no longer supported as a dimension parameter, use size_type "
-        "instead")
-    Permutation(std::shared_ptr<const Executor> exec, const dim<2>& size);
-
-    GKO_DEPRECATED("permute mask is no longer supported")
-    Permutation(std::shared_ptr<const Executor> exec, const dim<2>& size,
-                const mask_type& enabled_permute);
-
-    GKO_DEPRECATED("use the overload without dimensions")
-    Permutation(std::shared_ptr<const Executor> exec, const dim<2>& size,
-                array<IndexType> permutation_indices);
-
-    GKO_DEPRECATED("permute mask is no longer supported")
-    Permutation(std::shared_ptr<const Executor> exec, const dim<2>& size,
-                array<index_type> permutation_indices,
-                const mask_type& enabled_permute);
 
     void apply_impl(const LinOp* in, LinOp* out) const override;
 

--- a/include/ginkgo/core/matrix/row_gatherer.hpp
+++ b/include/ginkgo/core/matrix/row_gatherer.hpp
@@ -41,9 +41,7 @@ namespace matrix {
  * @ingroup LinOp
  */
 template <typename IndexType = int32>
-class RowGatherer : public EnableLinOp<RowGatherer<IndexType>>,
-                    public EnableCreateMethod<RowGatherer<IndexType>> {
-    friend class EnableCreateMethod<RowGatherer>;
+class RowGatherer : public EnableLinOp<RowGatherer<IndexType>> {
     friend class EnablePolymorphicObject<RowGatherer, LinOp>;
 
 public:
@@ -69,6 +67,39 @@ public:
     }
 
     /**
+     * Creates an uninitialized RowGatherer arrays on the specified executor.
+     *
+     * @param exec  Executor associated to the LinOp
+     */
+    static std::unique_ptr<RowGatherer> create(
+        std::shared_ptr<const Executor> exec);
+
+    /**
+     * Creates uninitialized RowGatherer arrays of the specified size.
+     *
+     * @param exec  Executor associated to the matrix
+     * @param size  size of the RowGatherable matrix
+     */
+    static std::unique_ptr<RowGatherer> create(
+        std::shared_ptr<const Executor> exec, const dim<2>& size);
+
+    /**
+     * Creates a RowGatherer matrix from an already allocated (and initialized)
+     * row gathering array
+     *
+     * @param exec  Executor associated to the matrix
+     * @param size  size of the rowgatherer array.
+     * @param row_idxs array of rowgatherer array
+     *
+     * @note If `row_idxs` is not an rvalue, not an array of
+     * IndexType, or is on the wrong executor, an internal copy will be created,
+     * and the original array data will not be used in the matrix.
+     */
+    static std::unique_ptr<RowGatherer> create(
+        std::shared_ptr<const Executor> exec, const dim<2>& size,
+        array<index_type> row_idxs);
+
+    /**
      * Creates a constant (immutable) RowGatherer matrix from a constant array.
      *
      * @param exec  the executor to create the matrix on
@@ -80,56 +111,15 @@ public:
      */
     static std::unique_ptr<const RowGatherer> create_const(
         std::shared_ptr<const Executor> exec, const dim<2>& size,
-        gko::detail::const_array_view<IndexType>&& row_idxs)
-    {
-        // cast const-ness away, but return a const object afterwards,
-        // so we can ensure that no modifications take place.
-        return std::unique_ptr<const RowGatherer>(new RowGatherer{
-            exec, size, gko::detail::array_const_cast(std::move(row_idxs))});
-    }
+        gko::detail::const_array_view<IndexType>&& row_idxs);
 
 protected:
-    /**
-     * Creates an uninitialized RowGatherer arrays on the specified executor.
-     *
-     * @param exec  Executor associated to the LinOp
-     */
-    RowGatherer(std::shared_ptr<const Executor> exec)
-        : RowGatherer(std::move(exec), dim<2>{})
-    {}
+    RowGatherer(std::shared_ptr<const Executor> exec);
 
-    /**
-     * Creates uninitialized RowGatherer arrays of the specified size.
-     *
-     * @param exec  Executor associated to the matrix
-     * @param size  size of the RowGatherable matrix
-     */
-    RowGatherer(std::shared_ptr<const Executor> exec, const dim<2>& size)
-        : EnableLinOp<RowGatherer>(exec, size), row_idxs_(exec, size[0])
-    {}
+    RowGatherer(std::shared_ptr<const Executor> exec, const dim<2>& size);
 
-    /**
-     * Creates a RowGatherer matrix from an already allocated (and initialized)
-     * row gathering array
-     *
-     * @tparam IndicesArray  type of array of indices
-     *
-     * @param exec  Executor associated to the matrix
-     * @param size  size of the rowgatherer array.
-     * @param row_idxs array of rowgatherer array
-     *
-     * @note If `row_idxs` is not an rvalue, not an array of
-     * IndexType, or is on the wrong executor, an internal copy will be created,
-     * and the original array data will not be used in the matrix.
-     */
-    template <typename IndicesArray>
     RowGatherer(std::shared_ptr<const Executor> exec, const dim<2>& size,
-                IndicesArray&& row_idxs)
-        : EnableLinOp<RowGatherer>(exec, size),
-          row_idxs_{exec, std::forward<IndicesArray>(row_idxs)}
-    {
-        GKO_ASSERT_EQ(size[0], row_idxs_.get_size());
-    }
+                array<index_type> row_idxs);
 
     void apply_impl(const LinOp* in, LinOp* out) const override;
 

--- a/include/ginkgo/core/matrix/row_gatherer.hpp
+++ b/include/ginkgo/core/matrix/row_gatherer.hpp
@@ -67,21 +67,15 @@ public:
     }
 
     /**
-     * Creates an uninitialized RowGatherer arrays on the specified executor.
-     *
-     * @param exec  Executor associated to the LinOp
-     */
-    static std::unique_ptr<RowGatherer> create(
-        std::shared_ptr<const Executor> exec);
-
-    /**
      * Creates uninitialized RowGatherer arrays of the specified size.
      *
      * @param exec  Executor associated to the matrix
      * @param size  size of the RowGatherable matrix
+     *
+     * @return A smart pointer to the newly created matrix.
      */
     static std::unique_ptr<RowGatherer> create(
-        std::shared_ptr<const Executor> exec, const dim<2>& size);
+        std::shared_ptr<const Executor> exec, const dim<2>& size = {});
 
     /**
      * Creates a RowGatherer matrix from an already allocated (and initialized)
@@ -94,6 +88,8 @@ public:
      * @note If `row_idxs` is not an rvalue, not an array of
      * IndexType, or is on the wrong executor, an internal copy will be created,
      * and the original array data will not be used in the matrix.
+     *
+     * @return A smart pointer to the newly created matrix.
      */
     static std::unique_ptr<RowGatherer> create(
         std::shared_ptr<const Executor> exec, const dim<2>& size,
@@ -114,9 +110,7 @@ public:
         gko::detail::const_array_view<IndexType>&& row_idxs);
 
 protected:
-    RowGatherer(std::shared_ptr<const Executor> exec);
-
-    RowGatherer(std::shared_ptr<const Executor> exec, const dim<2>& size);
+    RowGatherer(std::shared_ptr<const Executor> exec, const dim<2>& size = {});
 
     RowGatherer(std::shared_ptr<const Executor> exec, const dim<2>& size,
                 array<index_type> row_idxs);

--- a/include/ginkgo/core/matrix/scaled_permutation.hpp
+++ b/include/ginkgo/core/matrix/scaled_permutation.hpp
@@ -109,6 +109,8 @@ public:
      *
      * @param exec  Executor associated to the matrix
      * @param size  dimensions of the (square) scaled permutation matrix
+     *
+     * @return A smart pointer to the newly created matrix.
      */
     static std::unique_ptr<ScaledPermutation> create(
         std::shared_ptr<const Executor> exec, size_type size = 0);
@@ -118,7 +120,8 @@ public:
      * The permutation will be copied, the scaling factors are all set to 1.0.
      *
      * @param permutation  the permutation
-     * @return  the scaled permutation.
+     *
+     * @return A smart pointer to the newly created matrix.
      */
     static std::unique_ptr<ScaledPermutation> create(
         ptr_param<const Permutation<IndexType>> permutation);
@@ -129,6 +132,8 @@ public:
      * @param exec  Executor associated to the matrix
      * @param permutation_indices  array of permutation indices
      * @param scaling_factors  array of scaling factors
+     *
+     * @return A smart pointer to the newly created matrix.
      */
     static std::unique_ptr<ScaledPermutation> create(
         std::shared_ptr<const Executor> exec, array<value_type> scaling_factors,

--- a/include/ginkgo/core/matrix/sellp.hpp
+++ b/include/ginkgo/core/matrix/sellp.hpp
@@ -272,26 +272,17 @@ public:
 
     /**
      * Creates an uninitialized Sellp matrix of the specified size.
-     *    (The total_cols is set to be the number of slice times the number
-     *     of cols of the matrix.)
-     *
-     * @param exec  Executor associated to the matrix
-     * @param size  size of the matrix
-     */
-    static std::unique_ptr<Sellp> create(std::shared_ptr<const Executor> exec,
-                                         const dim<2>& size = dim<2>{});
-
-    /**
-     * Creates an uninitialized Sellp matrix of the specified size.
-     *    (The slice_size and stride_factor are set to the default values.)
+     * (The slice_size and stride_factor are set to the default values.)
      *
      * @param exec  Executor associated to the matrix
      * @param size  size of the matrix
      * @param total_cols   number of the sum of all cols in every slice.
+     *
+     * @return A smart pointer to the newly created matrix.
      */
     static std::unique_ptr<Sellp> create(std::shared_ptr<const Executor> exec,
-                                         const dim<2>& size,
-                                         size_type total_cols);
+                                         const dim<2>& size = {},
+                                         size_type total_cols = 0);
 
     /**
      * Creates an uninitialized Sellp matrix of the specified size.
@@ -302,6 +293,8 @@ public:
      * @param stride_factor  factor for the stride in each slice (strides
      *                        should be multiples of the stride_factor)
      * @param total_cols   number of the sum of all cols in every slice.
+     *
+     * @return A smart pointer to the newly created matrix.
      */
     static std::unique_ptr<Sellp> create(std::shared_ptr<const Executor> exec,
                                          const dim<2>& size,
@@ -336,10 +329,8 @@ public:
     Sellp(Sellp&&);
 
 protected:
-    Sellp(std::shared_ptr<const Executor> exec, const dim<2>& size = dim<2>{});
-
-    Sellp(std::shared_ptr<const Executor> exec, const dim<2>& size,
-          size_type total_cols);
+    Sellp(std::shared_ptr<const Executor> exec, const dim<2>& size = {},
+          size_type total_cols = {});
 
     Sellp(std::shared_ptr<const Executor> exec, const dim<2>& size,
           size_type slice_size, size_type stride_factor, size_type total_cols);

--- a/include/ginkgo/core/matrix/sellp.hpp
+++ b/include/ginkgo/core/matrix/sellp.hpp
@@ -41,7 +41,6 @@ class Csr;
  */
 template <typename ValueType = default_precision, typename IndexType = int32>
 class Sellp : public EnableLinOp<Sellp<ValueType, IndexType>>,
-              public EnableCreateMethod<Sellp<ValueType, IndexType>>,
               public ConvertibleTo<Sellp<next_precision<ValueType>, IndexType>>,
               public ConvertibleTo<Dense<ValueType>>,
               public ConvertibleTo<Csr<ValueType, IndexType>>,
@@ -50,7 +49,6 @@ class Sellp : public EnableLinOp<Sellp<ValueType, IndexType>>,
               public WritableToMatrixData<ValueType, IndexType>,
               public EnableAbsoluteComputation<
                   remove_complex<Sellp<ValueType, IndexType>>> {
-    friend class EnableCreateMethod<Sellp>;
     friend class EnablePolymorphicObject<Sellp, LinOp>;
     friend class Dense<ValueType>;
     friend class Csr<ValueType, IndexType>;
@@ -273,6 +271,45 @@ public:
     }
 
     /**
+     * Creates an uninitialized Sellp matrix of the specified size.
+     *    (The total_cols is set to be the number of slice times the number
+     *     of cols of the matrix.)
+     *
+     * @param exec  Executor associated to the matrix
+     * @param size  size of the matrix
+     */
+    static std::unique_ptr<Sellp> create(std::shared_ptr<const Executor> exec,
+                                         const dim<2>& size = dim<2>{});
+
+    /**
+     * Creates an uninitialized Sellp matrix of the specified size.
+     *    (The slice_size and stride_factor are set to the default values.)
+     *
+     * @param exec  Executor associated to the matrix
+     * @param size  size of the matrix
+     * @param total_cols   number of the sum of all cols in every slice.
+     */
+    static std::unique_ptr<Sellp> create(std::shared_ptr<const Executor> exec,
+                                         const dim<2>& size,
+                                         size_type total_cols);
+
+    /**
+     * Creates an uninitialized Sellp matrix of the specified size.
+     *
+     * @param exec  Executor associated to the matrix
+     * @param size  size of the matrix
+     * @param slice_size  number of rows in each slice
+     * @param stride_factor  factor for the stride in each slice (strides
+     *                        should be multiples of the stride_factor)
+     * @param total_cols   number of the sum of all cols in every slice.
+     */
+    static std::unique_ptr<Sellp> create(std::shared_ptr<const Executor> exec,
+                                         const dim<2>& size,
+                                         size_type slice_size,
+                                         size_type stride_factor,
+                                         size_type total_cols);
+
+    /**
      * Copy-assigns a Sellp matrix. Preserves the executor, copies the data and
      * parameters.
      */
@@ -299,56 +336,13 @@ public:
     Sellp(Sellp&&);
 
 protected:
-    /**
-     * Creates an uninitialized Sellp matrix of the specified size.
-     *    (The total_cols is set to be the number of slice times the number
-     *     of cols of the matrix.)
-     *
-     * @param exec  Executor associated to the matrix
-     * @param size  size of the matrix
-     */
-    Sellp(std::shared_ptr<const Executor> exec, const dim<2>& size = dim<2>{})
-        : Sellp(std::move(exec), size,
-                ceildiv(size[0], default_slice_size) * size[1])
-    {}
+    Sellp(std::shared_ptr<const Executor> exec, const dim<2>& size = dim<2>{});
 
-    /**
-     * Creates an uninitialized Sellp matrix of the specified size.
-     *    (The slice_size and stride_factor are set to the default values.)
-     *
-     * @param exec  Executor associated to the matrix
-     * @param size  size of the matrix
-     * @param total_cols   number of the sum of all cols in every slice.
-     */
     Sellp(std::shared_ptr<const Executor> exec, const dim<2>& size,
-          size_type total_cols)
-        : Sellp(std::move(exec), size, default_slice_size,
-                default_stride_factor, total_cols)
-    {}
+          size_type total_cols);
 
-    /**
-     * Creates an uninitialized Sellp matrix of the specified size.
-     *
-     * @param exec  Executor associated to the matrix
-     * @param size  size of the matrix
-     * @param slice_size  number of rows in each slice
-     * @param stride_factor  factor for the stride in each slice (strides
-     *                        should be multiples of the stride_factor)
-     * @param total_cols   number of the sum of all cols in every slice.
-     */
     Sellp(std::shared_ptr<const Executor> exec, const dim<2>& size,
-          size_type slice_size, size_type stride_factor, size_type total_cols)
-        : EnableLinOp<Sellp>(exec, size),
-          values_(exec, slice_size * total_cols),
-          col_idxs_(exec, slice_size * total_cols),
-          slice_lengths_(exec, ceildiv(size[0], slice_size)),
-          slice_sets_(exec, ceildiv(size[0], slice_size) + 1),
-          slice_size_(slice_size),
-          stride_factor_(stride_factor)
-    {
-        slice_sets_.fill(0);
-        slice_lengths_.fill(0);
-    }
+          size_type slice_size, size_type stride_factor, size_type total_cols);
 
     void apply_impl(const LinOp* b, LinOp* x) const override;
 

--- a/include/ginkgo/core/matrix/sparsity_csr.hpp
+++ b/include/ginkgo/core/matrix/sparsity_csr.hpp
@@ -223,6 +223,9 @@ public:
      * value_type)
      */
     template <typename ColIndexType, typename RowPtrType>
+    GKO_DEPRECATED(
+        "explicitly construct the gko::array argument instead of passing "
+        "initializer lists")
     static std::unique_ptr<SparsityCsr> create(
         std::shared_ptr<const Executor> exec, const dim<2>& size,
         std::initializer_list<ColIndexType> col_idxs,

--- a/include/ginkgo/core/reorder/scaled_reordered.hpp
+++ b/include/ginkgo/core/reorder/scaled_reordered.hpp
@@ -148,7 +148,7 @@ protected:
                 parameters_.inner_operator->generate(system_matrix_);
         } else {
             inner_operator_ = gko::matrix::Identity<value_type>::create(
-                exec, this->get_size());
+                exec, this->get_size()[0]);
         }
     }
 

--- a/include/ginkgo/core/solver/ir.hpp
+++ b/include/ginkgo/core/solver/ir.hpp
@@ -222,7 +222,7 @@ protected:
                 parameters_.solver->generate(this->get_system_matrix()));
         } else {
             this->set_solver(matrix::Identity<ValueType>::create(
-                this->get_executor(), this->get_size()));
+                this->get_executor(), this->get_size()[0]));
         }
         this->set_default_initial_guess(parameters_.default_initial_guess);
         relaxation_factor_ = gko::initialize<matrix::Dense<ValueType>>(

--- a/reference/test/base/utils.cpp
+++ b/reference/test/base/utils.cpp
@@ -38,13 +38,16 @@ protected:
     ConvertToWithSorting()
         : ref{gko::ReferenceExecutor::create()},
           mtx{gko::initialize<Dense>({{1, 2, 3}, {6, 0, 7}, {-1, 8, 0}}, ref)},
-          unsorted_coo{Coo::create(ref, gko::dim<2>{3, 3},
-                                   I<value_type>{1, 3, 2, 7, 6, -1, 8},
-                                   I<index_type>{0, 2, 1, 2, 0, 0, 1},
-                                   I<index_type>{0, 0, 0, 1, 1, 2, 2})},
-          unsorted_csr{Csr::create(
-              ref, gko::dim<2>{3, 3}, I<value_type>{1, 3, 2, 7, 6, -1, 8},
-              I<index_type>{0, 2, 1, 2, 0, 0, 1}, I<index_type>{0, 3, 5, 7})}
+          unsorted_coo{
+              Coo::create(ref, gko::dim<2>{3, 3},
+                          gko::array<value_type>{ref, {1, 3, 2, 7, 6, -1, 8}},
+                          gko::array<index_type>{ref, {0, 2, 1, 2, 0, 0, 1}},
+                          gko::array<index_type>{ref, {0, 0, 0, 1, 1, 2, 2}})},
+          unsorted_csr{
+              Csr::create(ref, gko::dim<2>{3, 3},
+                          gko::array<value_type>{ref, {1, 3, 2, 7, 6, -1, 8}},
+                          gko::array<index_type>{ref, {0, 2, 1, 2, 0, 0, 1}},
+                          gko::array<index_type>{ref, {0, 3, 5, 7}})}
 
     {}
 

--- a/reference/test/distributed/matrix_kernels.cpp
+++ b/reference/test/distributed/matrix_kernels.cpp
@@ -86,7 +86,9 @@ protected:
         std::vector<gko::array<comm_index_type>> ref_recv_sizes;
 
         auto input = gko::device_matrix_data<value_type, global_index_type>{
-            ref, size, input_rows, input_cols, input_vals};
+            ref, size, gko::array<global_index_type>{ref, input_rows},
+            gko::array<global_index_type>{ref, input_cols},
+            gko::array<value_type>{ref, input_vals}};
         this->recv_sizes.resize_and_reset(
             static_cast<gko::size_type>(row_partition->get_num_parts()));
         for (auto entry : local_entries) {
@@ -139,9 +141,9 @@ protected:
     {
         return gko::device_matrix_data<value_type, global_index_type>{
             this->ref, gko::dim<2>{7, 7},
-            I<global_index_type>{0, 0, 2, 3, 3, 4, 4, 5, 5, 6},
-            I<global_index_type>{0, 3, 2, 0, 3, 4, 6, 4, 5, 5},
-            I<value_type>{1, 2, 5, 6, 7, 8, 9, 10, 11, 12}};
+            gko::array<global_index_type>{ref, {0, 0, 2, 3, 3, 4, 4, 5, 5, 6}},
+            gko::array<global_index_type>{ref, {0, 3, 2, 0, 3, 4, 6, 4, 5, 5}},
+            gko::array<value_type>{ref, {1, 2, 5, 6, 7, 8, 9, 10, 11, 12}}};
     }
 
     gko::device_matrix_data<value_type, global_index_type>
@@ -149,9 +151,12 @@ protected:
     {
         return gko::device_matrix_data<value_type, global_index_type>{
             this->ref, gko::dim<2>{7, 7},
-            I<global_index_type>{0, 0, 1, 1, 2, 3, 3, 4, 4, 5, 5, 6},
-            I<global_index_type>{0, 3, 1, 2, 2, 0, 3, 4, 6, 4, 5, 5},
-            I<value_type>{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12}};
+            gko::array<global_index_type>{ref,
+                                          {0, 0, 1, 1, 2, 3, 3, 4, 4, 5, 5, 6}},
+            gko::array<global_index_type>{ref,
+                                          {0, 3, 1, 2, 2, 0, 3, 4, 6, 4, 5, 5}},
+            gko::array<value_type>{ref,
+                                   {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12}}};
     }
 
     std::shared_ptr<const gko::ReferenceExecutor> ref;

--- a/reference/test/distributed/vector_kernels.cpp
+++ b/reference/test/distributed/vector_kernels.cpp
@@ -48,7 +48,9 @@ protected:
     {
         std::vector<I<I<value_type>>> ref_outputs;
         auto input = gko::device_matrix_data<value_type, global_index_type>{
-            ref, size, input_rows, input_cols, input_vals};
+            ref, size, gko::array<global_index_type>{ref, input_rows},
+            gko::array<global_index_type>{ref, input_cols},
+            gko::array<value_type>{ref, input_vals}};
         for (auto entry : output_entries) {
             ref_outputs.emplace_back(entry);
         }

--- a/reference/test/factorization/par_ilu_kernels.cpp
+++ b/reference/test/factorization/par_ilu_kernels.cpp
@@ -194,9 +194,9 @@ TYPED_TEST(ParIlu, KernelAddDiagonalElementsEmpty)
     using Csr = typename TestFixture::Csr;
     auto expected_mtx =
         Csr::create(this->ref, this->empty_csr->get_size(),
-                    std::initializer_list<value_type>{0., 0., 0.},
-                    std::initializer_list<index_type>{0, 1, 2},
-                    std::initializer_list<index_type>{0, 1, 2, 3});
+                    gko::array<value_type>{this->ref, {0., 0., 0.}},
+                    gko::array<index_type>{this->ref, {0, 1, 2}},
+                    gko::array<index_type>{this->ref, {0, 1, 2, 3}});
     auto empty_mtx = this->empty_csr->clone();
 
     gko::kernels::reference::factorization::add_diagonal_elements(
@@ -209,15 +209,16 @@ TYPED_TEST(ParIlu, KernelAddDiagonalElementsEmpty)
 
 TYPED_TEST(ParIlu, KernelAddDiagonalElementsNonSquare)
 {
+    using index_type = typename TestFixture::index_type;
+    using value_type = typename TestFixture::value_type;
     using Csr = typename TestFixture::Csr;
     auto matrix = gko::initialize<Csr>(
         {{0., 0., 0.}, {1., 0., 0.}, {1., 1., 1.}, {1., 1., 1.}}, this->ref);
-    auto exp_values = {0., 1., 0., 1., 1., 1., 1., 1., 1.};
-    auto exp_col_idxs = {0, 0, 1, 0, 1, 2, 0, 1, 2};
-    auto exp_row_ptrs = {0, 1, 3, 6, 9};
-    auto expected_mtx =
-        Csr::create(this->ref, matrix->get_size(), std::move(exp_values),
-                    std::move(exp_col_idxs), std::move(exp_row_ptrs));
+    auto expected_mtx = Csr::create(
+        this->ref, matrix->get_size(),
+        gko::array<value_type>{this->ref, {0., 1., 0., 1., 1., 1., 1., 1., 1.}},
+        gko::array<index_type>{this->ref, {0, 0, 1, 0, 1, 2, 0, 1, 2}},
+        gko::array<index_type>{this->ref, {0, 1, 3, 6, 9}});
 
     gko::kernels::reference::factorization::add_diagonal_elements(
         this->ref, matrix.get(), true);
@@ -229,14 +230,15 @@ TYPED_TEST(ParIlu, KernelAddDiagonalElementsNonSquare)
 
 TYPED_TEST(ParIlu, KernelAddDiagonalElementsNonSquare2)
 {
+    using index_type = typename TestFixture::index_type;
+    using value_type = typename TestFixture::value_type;
     using Csr = typename TestFixture::Csr;
     auto matrix = gko::initialize<Csr>({{1., 0., 0.}, {1., 0., 0.}}, this->ref);
-    auto exp_values = {1., 1., 0.};
-    auto exp_col_idxs = {0, 0, 1};
-    auto exp_row_ptrs = {0, 1, 3};
     auto expected_mtx =
-        Csr::create(this->ref, matrix->get_size(), std::move(exp_values),
-                    std::move(exp_col_idxs), std::move(exp_row_ptrs));
+        Csr::create(this->ref, matrix->get_size(),
+                    gko::array<value_type>{this->ref, {1., 1., 0.}},
+                    gko::array<index_type>{this->ref, {0, 0, 1}},
+                    gko::array<index_type>{this->ref, {0, 1, 3}});
 
     gko::kernels::reference::factorization::add_diagonal_elements(
         this->ref, matrix.get(), true);
@@ -248,6 +250,8 @@ TYPED_TEST(ParIlu, KernelAddDiagonalElementsNonSquare2)
 
 TYPED_TEST(ParIlu, KernelAddDiagonalElementsUnsorted)
 {
+    using index_type = typename TestFixture::index_type;
+    using value_type = typename TestFixture::value_type;
     using Csr = typename TestFixture::Csr;
     auto size = gko::dim<2>{3, 3};
     /* matrix:
@@ -255,17 +259,16 @@ TYPED_TEST(ParIlu, KernelAddDiagonalElementsUnsorted)
     1 0 3
     1 2 0
     */
-    auto mtx_values = {3., 2., 1., 3., 1., 2., 1.};
-    auto mtx_col_idxs = {2, 1, 0, 2, 0, 1, 0};
-    auto mtx_row_ptrs = {0, 3, 5, 7};
-    auto matrix = Csr::create(this->ref, size, std::move(mtx_values),
-                              std::move(mtx_col_idxs), std::move(mtx_row_ptrs));
-    auto exp_values = {1., 2., 3., 1., 0., 3., 1., 2., 0.};
-    auto exp_col_idxs = {0, 1, 2, 0, 1, 2, 0, 1, 2};
-    auto exp_row_ptrs = {0, 3, 6, 9};
-    auto expected_mtx =
-        Csr::create(this->ref, size, std::move(exp_values),
-                    std::move(exp_col_idxs), std::move(exp_row_ptrs));
+    auto matrix = Csr::create(
+        this->ref, size,
+        gko::array<value_type>{this->ref, {3., 2., 1., 3., 1., 2., 1.}},
+        gko::array<index_type>{this->ref, {2, 1, 0, 2, 0, 1, 0}},
+        gko::array<index_type>{this->ref, {0, 3, 5, 7}});
+    auto expected_mtx = Csr::create(
+        this->ref, size,
+        gko::array<value_type>{this->ref, {1., 2., 3., 1., 0., 3., 1., 2., 0.}},
+        gko::array<index_type>{this->ref, {0, 1, 2, 0, 1, 2, 0, 1, 2}},
+        gko::array<index_type>{this->ref, {0, 3, 6, 9}});
 
     gko::kernels::reference::factorization::add_diagonal_elements(
         this->ref, matrix.get(), false);

--- a/reference/test/matrix/dense_kernels.cpp
+++ b/reference/test/matrix/dense_kernels.cpp
@@ -477,7 +477,8 @@ TYPED_TEST(Dense, AddsScaledDiag)
     using Mtx = typename TestFixture::Mtx;
     using T = typename TestFixture::value_type;
     auto alpha = gko::initialize<Mtx>({2.0}, this->exec);
-    auto diag = gko::matrix::Diagonal<T>::create(this->exec, 2, I<T>{3.0, 2.0});
+    auto diag = gko::matrix::Diagonal<T>::create(
+        this->exec, 2, gko::array<T>{this->exec, {3.0, 2.0}});
 
     this->mtx2->add_scaled(alpha, diag);
 
@@ -493,7 +494,8 @@ TYPED_TEST(Dense, SubtractsScaledDiag)
     using Mtx = typename TestFixture::Mtx;
     using T = typename TestFixture::value_type;
     auto alpha = gko::initialize<Mtx>({-2.0}, this->exec);
-    auto diag = gko::matrix::Diagonal<T>::create(this->exec, 2, I<T>{3.0, 2.0});
+    auto diag = gko::matrix::Diagonal<T>::create(
+        this->exec, 2, gko::array<T>{this->exec, {3.0, 2.0}});
 
     this->mtx2->sub_scaled(alpha, diag);
 

--- a/reference/test/multigrid/fixed_coarsening_kernels.cpp
+++ b/reference/test/multigrid/fixed_coarsening_kernels.cpp
@@ -318,12 +318,14 @@ TYPED_TEST(FixedCoarsening, GenerateMgLevelOnUnsortedCsrMatrix)
      *  0 -3  0  5  0
      *  0 -2 -2  0  5
      */
-    auto mtx_values = {-3, -3, 5, -3, -2, -1, 5, -3, -1, 5, -3, 5, -2, -2, 5};
-    auto mtx_col_idxs = {1, 2, 0, 0, 3, 4, 1, 0, 4, 2, 1, 3, 1, 2, 4};
-    auto mtx_row_ptrs = {0, 3, 7, 10, 12, 15};
-    auto matrix = gko::share(
-        Mtx::create(this->exec, gko::dim<2>{5, 5}, std::move(mtx_values),
-                    std::move(mtx_col_idxs), std::move(mtx_row_ptrs)));
+    auto matrix = gko::share(Mtx::create(
+        this->exec, gko::dim<2>{5, 5},
+        gko::array<value_type>{
+            this->exec,
+            {-3, -3, 5, -3, -2, -1, 5, -3, -1, 5, -3, 5, -2, -2, 5}},
+        gko::array<index_type>{this->exec,
+                               {1, 2, 0, 0, 3, 4, 1, 0, 4, 2, 1, 3, 1, 2, 4}},
+        gko::array<index_type>{this->exec, {0, 3, 7, 10, 12, 15}}));
     auto prolong_op = gko::share(Mtx::create(this->exec, gko::dim<2>{5, 3}, 0));
     // 0-2-3
     prolong_op->read({{5, 3}, {{0, 0, 1}, {2, 1, 1}, {3, 2, 1}}});
@@ -357,12 +359,15 @@ TYPED_TEST(FixedCoarsening, GenerateMgLevelOnUnsortedCooMatrix)
      *  0 -3  0  5  0
      *  0 -2 -2  0  5
      */
-    auto mtx_values = {-3, -3, 5, -3, -2, -1, 5, -3, -1, 5, -3, 5, -2, -2, 5};
-    auto mtx_col_idxs = {1, 2, 0, 0, 3, 4, 1, 0, 4, 2, 1, 3, 1, 2, 4};
-    auto mtx_row_idxs = {0, 0, 0, 1, 1, 1, 1, 2, 2, 2, 3, 3, 4, 4, 4};
-    auto matrix = gko::share(
-        CooMtx::create(this->exec, gko::dim<2>{5, 5}, std::move(mtx_values),
-                       std::move(mtx_col_idxs), std::move(mtx_row_idxs)));
+    auto matrix = gko::share(CooMtx::create(
+        this->exec, gko::dim<2>{5, 5},
+        gko::array<value_type>{
+            this->exec,
+            {-3, -3, 5, -3, -2, -1, 5, -3, -1, 5, -3, 5, -2, -2, 5}},
+        gko::array<index_type>{this->exec,
+                               {1, 2, 0, 0, 3, 4, 1, 0, 4, 2, 1, 3, 1, 2, 4}},
+        gko::array<index_type>{this->exec,
+                               {0, 0, 0, 1, 1, 1, 1, 2, 2, 2, 3, 3, 4, 4, 4}}));
     auto prolong_op = gko::share(Mtx::create(this->exec, gko::dim<2>{5, 3}, 0));
     // 0-2-3
     prolong_op->read({{5, 3}, {{0, 0, 1}, {2, 1, 1}, {3, 2, 1}}});

--- a/reference/test/multigrid/pgm_kernels.cpp
+++ b/reference/test/multigrid/pgm_kernels.cpp
@@ -518,12 +518,14 @@ TYPED_TEST(Pgm, GenerateMgLevelOnUnsortedMatrix)
      *  0 -3  0  5  0
      *  0 -2 -2  0  5
      */
-    auto mtx_values = {-3, -3, 5, -3, -2, -1, 5, -3, -1, 5, 5, -3, -2, -2, 5};
-    auto mtx_col_idxs = {1, 2, 0, 0, 3, 4, 1, 0, 4, 2, 1, 3, 1, 2, 4};
-    auto mtx_row_ptrs = {0, 3, 7, 10, 12, 15};
-    auto matrix = gko::share(
-        Mtx::create(this->exec, gko::dim<2>{5, 5}, std::move(mtx_values),
-                    std::move(mtx_col_idxs), std::move(mtx_row_ptrs)));
+    auto matrix = gko::share(Mtx::create(
+        this->exec, gko::dim<2>{5, 5},
+        gko::array<value_type>{
+            this->exec,
+            {-3, -3, 5, -3, -2, -1, 5, -3, -1, 5, 5, -3, -2, -2, 5}},
+        gko::array<index_type>{this->exec,
+                               {1, 2, 0, 0, 3, 4, 1, 0, 4, 2, 1, 3, 1, 2, 4}},
+        gko::array<index_type>{this->exec, {0, 3, 7, 10, 12, 15}}));
     auto prolong_op = gko::share(Mtx::create(this->exec, gko::dim<2>{5, 2}, 0));
     // 0-2-4, 1-3
     prolong_op->read(

--- a/reference/test/preconditioner/isai_kernels.cpp
+++ b/reference/test/preconditioner/isai_kernels.cpp
@@ -89,85 +89,104 @@ protected:
           u_csr_inv{Csr::create(exec)},
           spd_csr{Csr::create(exec)},
           spd_csr_inv{Csr::create(exec)},
-          l_sparse{Csr::create(exec, gko::dim<2>(4, 4),
-                               I<value_type>{-1., 2., 4., 5., -4., 8., -8.},
-                               I<index_type>{0, 0, 1, 1, 2, 2, 3},
-                               I<index_type>{0, 1, 3, 5, 7})},
-          l_s_unsorted{Csr::create(exec, gko::dim<2>(4, 4),
-                                   I<value_type>{-1., 4., 2., 5., -4., -8., 8.},
-                                   I<index_type>{0, 1, 0, 1, 2, 3, 2},
-                                   I<index_type>{0, 1, 3, 5, 7})},
+          l_sparse{Csr::create(
+              exec, gko::dim<2>(4, 4),
+              gko::array<value_type>{exec, {-1., 2., 4., 5., -4., 8., -8.}},
+              gko::array<index_type>{exec, {0, 0, 1, 1, 2, 2, 3}},
+              gko::array<index_type>{exec, {0, 1, 3, 5, 7}})},
+          l_s_unsorted{Csr::create(
+              exec, gko::dim<2>(4, 4),
+              gko::array<value_type>{exec, {-1., 4., 2., 5., -4., -8., 8.}},
+              gko::array<index_type>{exec, {0, 1, 0, 1, 2, 3, 2}},
+              gko::array<index_type>{exec, {0, 1, 3, 5, 7}})},
           l_sparse_inv{
               Csr::create(exec, gko::dim<2>(4, 4),
-                          I<value_type>{-1., .5, .25, .3125, -.25, -.25, -.125},
-                          I<index_type>{0, 0, 1, 1, 2, 2, 3},
-                          I<index_type>{0, 1, 3, 5, 7})},
-          l_sparse_inv2{Csr::create(exec, gko::dim<2>(4, 4),
-                                    I<value_type>{-1., .5, .25, .625, .3125,
-                                                  -.25, .3125, -.25, -.125},
-                                    I<index_type>{0, 0, 1, 0, 1, 2, 1, 2, 3},
-                                    I<index_type>{0, 1, 3, 6, 9})},
-          l_sparse_inv3{
-              Csr::create(exec, gko::dim<2>(4, 4),
-                          I<value_type>{-1., .5, .25, .625, .3125, -.25, .625,
-                                        .3125, -.25, -.125},
-                          I<index_type>{0, 0, 1, 0, 1, 2, 0, 1, 2, 3},
-                          I<index_type>{0, 1, 3, 6, 10})},
-          l_sparse2{Csr::create(exec, gko::dim<2>(4, 4),
-                                I<value_type>{-2, 1, 4, 1, -2, 1, -1, 1, 2},
-                                I<index_type>{0, 0, 1, 1, 2, 0, 1, 2, 3},
-                                I<index_type>{0, 1, 3, 5, 9})},
-          l_sparse2_inv{Csr::create(exec, gko::dim<2>(4, 4),
-                                    I<value_type>{-.5, .125, .25, .125, -.5,
-                                                  .28125, .0625, 0.25, 0.5},
-                                    I<index_type>{0, 0, 1, 1, 2, 0, 1, 2, 3},
-                                    I<index_type>{0, 1, 3, 5, 9})},
-          u_sparse{
-              Csr::create(exec, gko::dim<2>(4, 4),
-                          I<value_type>{-2., 1., -1., 1., 4., 1., -2., 1., 2.},
-                          I<index_type>{0, 1, 2, 3, 1, 2, 2, 3, 3},
-                          I<index_type>{0, 4, 6, 8, 9})},
-          u_s_unsorted{
-              Csr::create(exec, gko::dim<2>(4, 4),
-                          I<value_type>{-2., -1., 1., 1., 1., 4., -2., 1., 2.},
-                          I<index_type>{0, 2, 1, 3, 2, 1, 2, 3, 3},
-                          I<index_type>{0, 4, 6, 8, 9})},
+                          gko::array<value_type>{
+                              exec, {-1., .5, .25, .3125, -.25, -.25, -.125}},
+                          gko::array<index_type>{exec, {0, 0, 1, 1, 2, 2, 3}},
+                          gko::array<index_type>{exec, {0, 1, 3, 5, 7}})},
+          l_sparse_inv2{Csr::create(
+              exec, gko::dim<2>(4, 4),
+              gko::array<value_type>{
+                  exec, {-1., .5, .25, .625, .3125, -.25, .3125, -.25, -.125}},
+              gko::array<index_type>{exec, {0, 0, 1, 0, 1, 2, 1, 2, 3}},
+              gko::array<index_type>{exec, {0, 1, 3, 6, 9}})},
+          l_sparse_inv3{Csr::create(
+              exec, gko::dim<2>(4, 4),
+              gko::array<value_type>{
+                  exec,
+                  {-1., .5, .25, .625, .3125, -.25, .625, .3125, -.25, -.125}},
+              gko::array<index_type>{exec, {0, 0, 1, 0, 1, 2, 0, 1, 2, 3}},
+              gko::array<index_type>{exec, {0, 1, 3, 6, 10}})},
+          l_sparse2{Csr::create(
+              exec, gko::dim<2>(4, 4),
+              gko::array<value_type>{exec, {-2, 1, 4, 1, -2, 1, -1, 1, 2}},
+              gko::array<index_type>{exec, {0, 0, 1, 1, 2, 0, 1, 2, 3}},
+              gko::array<index_type>{exec, {0, 1, 3, 5, 9}})},
+          l_sparse2_inv{Csr::create(
+              exec, gko::dim<2>(4, 4),
+              gko::array<value_type>{
+                  exec, {-.5, .125, .25, .125, -.5, .28125, .0625, 0.25, 0.5}},
+              gko::array<index_type>{exec, {0, 0, 1, 1, 2, 0, 1, 2, 3}},
+              gko::array<index_type>{exec, {0, 1, 3, 5, 9}})},
+          u_sparse{Csr::create(
+              exec, gko::dim<2>(4, 4),
+              gko::array<value_type>{exec,
+                                     {-2., 1., -1., 1., 4., 1., -2., 1., 2.}},
+              gko::array<index_type>{exec, {0, 1, 2, 3, 1, 2, 2, 3, 3}},
+              gko::array<index_type>{exec, {0, 4, 6, 8, 9}})},
+          u_s_unsorted{Csr::create(
+              exec, gko::dim<2>(4, 4),
+              gko::array<value_type>{exec,
+                                     {-2., -1., 1., 1., 1., 4., -2., 1., 2.}},
+              gko::array<index_type>{exec, {0, 2, 1, 3, 2, 1, 2, 3, 3}},
+              gko::array<index_type>{exec, {0, 4, 6, 8, 9}})},
           u_sparse_inv{Csr::create(
               exec, gko::dim<2>(4, 4),
-              I<value_type>{-.5, .125, .3125, .09375, .25, .125, -.5, .25, .5},
-              I<index_type>{0, 1, 2, 3, 1, 2, 2, 3, 3},
-              I<index_type>{0, 4, 6, 8, 9})},
-          u_sparse_inv2{Csr::create(exec, gko::dim<2>(4, 4),
-                                    I<value_type>{-.5, .125, .3125, .09375, .25,
-                                                  .125, -.0625, -.5, .25, .5},
-                                    I<index_type>{0, 1, 2, 3, 1, 2, 3, 2, 3, 3},
-                                    I<index_type>{0, 4, 7, 9, 10})},
-          a_sparse{
-              Csr::create(exec, gko::dim<2>{4, 4},
-                          I<value_type>{1., 4., 1., 4., 2., 1., 2., 1., 1.},
-                          I<index_type>{0, 3, 0, 1, 3, 1, 2, 2, 3},
-                          I<index_type>{0, 2, 5, 7, 9})},
-          a_s_unsorted{
-              Csr::create(exec, gko::dim<2>{4, 4},
-                          I<value_type>{4., 1., 1., 2., 4., 2., 1., 1., 1.},
-                          I<index_type>{3, 0, 0, 3, 1, 2, 1, 2, 3},
-                          I<index_type>{0, 2, 5, 7, 9})},
+              gko::array<value_type>{
+                  exec, {-.5, .125, .3125, .09375, .25, .125, -.5, .25, .5}},
+              gko::array<index_type>{exec, {0, 1, 2, 3, 1, 2, 2, 3, 3}},
+              gko::array<index_type>{exec, {0, 4, 6, 8, 9}})},
+          u_sparse_inv2{Csr::create(
+              exec, gko::dim<2>(4, 4),
+              gko::array<value_type>{
+                  exec,
+                  {-.5, .125, .3125, .09375, .25, .125, -.0625, -.5, .25, .5}},
+              gko::array<index_type>{exec, {0, 1, 2, 3, 1, 2, 3, 2, 3, 3}},
+              gko::array<index_type>{exec, {0, 4, 7, 9, 10}})},
+          a_sparse{Csr::create(
+              exec, gko::dim<2>{4, 4},
+              gko::array<value_type>{exec,
+                                     {1., 4., 1., 4., 2., 1., 2., 1., 1.}},
+              gko::array<index_type>{exec, {0, 3, 0, 1, 3, 1, 2, 2, 3}},
+              gko::array<index_type>{exec, {0, 2, 5, 7, 9}})},
+          a_s_unsorted{Csr::create(
+              exec, gko::dim<2>{4, 4},
+              gko::array<value_type>{exec,
+                                     {4., 1., 1., 2., 4., 2., 1., 1., 1.}},
+              gko::array<index_type>{exec, {3, 0, 0, 3, 1, 2, 1, 2, 3}},
+              gko::array<index_type>{exec, {0, 2, 5, 7, 9}})},
           a_sparse_inv{Csr::create(
               exec, gko::dim<2>{4, 4},
-              I<value_type>{1., -4, -.25, .25, .5, -.125, .5, -.5, 1},
-              I<index_type>{0, 3, 0, 1, 3, 1, 2, 2, 3},
-              I<index_type>{0, 2, 5, 7, 9})},
-          spd_sparse{Csr::create(exec, gko::dim<2>{4, 4},
-                                 I<value_type>{.25, -.25, -.25, .5, 4., 4.},
-                                 I<index_type>{0, 1, 0, 1, 2, 3},
-                                 I<index_type>{0, 2, 4, 5, 6})},
-          spd_s_unsorted{Csr::create(exec, gko::dim<2>{4, 4},
-                                     I<value_type>{-.25, .25, .5, -.25, 4., 4.},
-                                     I<index_type>{1, 0, 1, 0, 2, 3},
-                                     I<index_type>{0, 2, 4, 5, 6})},
-          spd_sparse_inv{Csr::create(
-              exec, gko::dim<2>{4, 4}, I<value_type>{2., 2., 2., .5, .5},
-              I<index_type>{0, 0, 1, 2, 3}, I<index_type>{0, 1, 3, 4, 5})}
+              gko::array<value_type>{
+                  exec, {1., -4., -.25, .25, .5, -.125, .5, -.5, 1.}},
+              gko::array<index_type>{exec, {0, 3, 0, 1, 3, 1, 2, 2, 3}},
+              gko::array<index_type>{exec, {0, 2, 5, 7, 9}})},
+          spd_sparse{Csr::create(
+              exec, gko::dim<2>{4, 4},
+              gko::array<value_type>{exec, {.25, -.25, -.25, .5, 4., 4.}},
+              gko::array<index_type>{exec, {0, 1, 0, 1, 2, 3}},
+              gko::array<index_type>{exec, {0, 2, 4, 5, 6}})},
+          spd_s_unsorted{Csr::create(
+              exec, gko::dim<2>{4, 4},
+              gko::array<value_type>{exec, {-.25, .25, .5, -.25, 4., 4.}},
+              gko::array<index_type>{exec, {1, 0, 1, 0, 2, 3}},
+              gko::array<index_type>{exec, {0, 2, 4, 5, 6}})},
+          spd_sparse_inv{
+              Csr::create(exec, gko::dim<2>{4, 4},
+                          gko::array<value_type>{exec, {2., 2., 2., .5, .5}},
+                          gko::array<index_type>{exec, {0, 0, 1, 2, 3}},
+                          gko::array<index_type>{exec, {0, 1, 3, 4, 5}})}
     {
         lower_isai_factory = LowerIsai::build().on(exec);
         upper_isai_factory = UpperIsai::build().on(exec);
@@ -562,8 +581,10 @@ TYPED_TEST(Isai, KernelGenerateLsparse3)
     // (only one value changes compared to u_sparse_inv->transpose())
     const auto expected = Csr::create(
         this->exec, gko::dim<2>(4, 4),
-        I<value_type>{-.5, .125, .25, .3125, .125, -.5, .125, .25, .5},
-        I<index_type>{0, 0, 1, 0, 1, 2, 0, 2, 3}, I<index_type>{0, 1, 3, 6, 9});
+        gko::array<value_type>{
+            this->exec, {-.5, .125, .25, .3125, .125, -.5, .125, .25, .5}},
+        gko::array<index_type>{this->exec, {0, 0, 1, 0, 1, 2, 0, 2, 3}},
+        gko::array<index_type>{this->exec, {0, 1, 3, 6, 9}});
     GKO_ASSERT_MTX_EQ_SPARSITY(result, expected);
     GKO_ASSERT_MTX_NEAR(result, expected, r<value_type>::value);
     // no row above the size limit -> zero array
@@ -740,8 +761,10 @@ TYPED_TEST(Isai, KernelGenerateUsparse2)
     // (only one value changes compared to l_sparse2_inv->transpose())
     const auto expected = Csr::create(
         this->exec, gko::dim<2>(4, 4),
-        I<value_type>{-.5, .125, .3125, .25, .125, .0625, -.5, .25, .5},
-        I<index_type>{0, 1, 3, 1, 2, 3, 2, 3, 3}, I<index_type>{0, 3, 6, 8, 9});
+        gko::array<value_type>{
+            this->exec, {-.5, .125, .3125, .25, .125, .0625, -.5, .25, .5}},
+        gko::array<index_type>{this->exec, {0, 1, 3, 1, 2, 3, 2, 3, 3}},
+        gko::array<index_type>{this->exec, {0, 3, 6, 8, 9}});
     GKO_ASSERT_MTX_EQ_SPARSITY(result, expected);
     GKO_ASSERT_MTX_NEAR(result, expected, r<value_type>::value);
     // no row above the size limit -> zero array
@@ -947,18 +970,22 @@ TYPED_TEST(Isai, KernelScatterExcessSolution)
     using Dense = typename TestFixture::Dense;
     using value_type = typename TestFixture::value_type;
     using index_type = typename TestFixture::index_type;
-    gko::array<index_type> ptrs{this->exec, I<index_type>{0, 0, 2, 2, 5, 7, 7}};
-    auto mtx = Csr::create(this->exec, gko::dim<2>{6, 6},
-                           I<value_type>{1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
-                           I<index_type>{0, 0, 1, 0, 0, 1, 2, 0, 1, 0},
-                           I<index_type>{0, 1, 3, 4, 7, 9, 10});
-    auto expect =
-        Csr::create(this->exec, gko::dim<2>{6, 6},
-                    I<value_type>{1, 11, 12, 4, 13, 14, 15, 16, 17, 10},
-                    I<index_type>{0, 0, 1, 0, 0, 1, 2, 0, 1, 0},
-                    I<index_type>{0, 1, 3, 4, 7, 9, 10});
-    auto sol = Dense::create(this->exec, gko::dim<2>(7, 1),
-                             I<value_type>{11, 12, 13, 14, 15, 16, 17}, 1);
+    gko::array<index_type> ptrs{
+        this->exec, gko::array<index_type>{this->exec, {0, 0, 2, 2, 5, 7, 7}}};
+    auto mtx = Csr::create(
+        this->exec, gko::dim<2>{6, 6},
+        gko::array<value_type>{this->exec, {1, 2, 3, 4, 5, 6, 7, 8, 9, 10}},
+        gko::array<index_type>{this->exec, {0, 0, 1, 0, 0, 1, 2, 0, 1, 0}},
+        gko::array<index_type>{this->exec, {0, 1, 3, 4, 7, 9, 10}});
+    auto expect = Csr::create(
+        this->exec, gko::dim<2>{6, 6},
+        gko::array<value_type>{this->exec,
+                               {1, 11, 12, 4, 13, 14, 15, 16, 17, 10}},
+        gko::array<index_type>{this->exec, {0, 0, 1, 0, 0, 1, 2, 0, 1, 0}},
+        gko::array<index_type>{this->exec, {0, 1, 3, 4, 7, 9, 10}});
+    auto sol = Dense::create(
+        this->exec, gko::dim<2>(7, 1),
+        gko::array<value_type>{this->exec, {11, 12, 13, 14, 15, 16, 17}}, 1);
 
     gko::kernels::reference::isai::scatter_excess_solution(
         this->exec, ptrs.get_const_data(), sol.get(), mtx.get(), 0, 6);


### PR DESCRIPTION
This removes all templated array constructors and replaces them by versions that are based on array conversion constructors. This doesn't have any performance impacts except for the case when we pass in an lvalue (non-temporary/moved) that lives on another executor than the object we are constructing, where it leads to an additional allocation and copy on the source executor. That seems like an unimportant case to me, so I'm fine with the change making the interface simpler.

One thing this does have to change is the initialization from `initializer_list`. I'm honestly not sure whether this was explicitly designed to work, accidentally worked or something in between, I definitely had to dig why it works (the initializer list is being forwarded to the `array(exec, init_list)` constructor. If it was intended, we can't really change it, but it seems more like of a coincidental thing to me?

EDIT: I dug some more, this was introduced in fcd8effa6a38e4d1388d589b22808808ad5d8843, where it seems intentionally intended for arrays only, and first used with `initializer_list` in https://github.com/ginkgo-project/ginkgo/pull/659, where it didn't come up in the discussion, so this kind of underlines the coincidental thing to me.