### PR TITLE
Fix batch ell const apply infinite loop

### DIFF
--- a/core/matrix/batch_ell.cpp
+++ b/core/matrix/batch_ell.cpp
@@ -134,10 +134,7 @@ Ell<ValueType, IndexType>* Ell<ValueType, IndexType>::apply(
     ptr_param<const MultiVector<ValueType>> b,
     ptr_param<MultiVector<ValueType>> x)
 {
-    this->validate_application_parameters(b.get(), x.get());
-    auto exec = this->get_executor();
-    this->apply_impl(make_temporary_clone(exec, b).get(),
-                     make_temporary_clone(exec, x).get());
+    static_cast<const Ell*>(this)->apply(b, x);
     return this;
 }
 
@@ -147,7 +144,10 @@ const Ell<ValueType, IndexType>* Ell<ValueType, IndexType>::apply(
     ptr_param<const MultiVector<ValueType>> b,
     ptr_param<MultiVector<ValueType>> x) const
 {
-    this->apply(b, x);
+    this->validate_application_parameters(b.get(), x.get());
+    auto exec = this->get_executor();
+    this->apply_impl(make_temporary_clone(exec, b).get(),
+                     make_temporary_clone(exec, x).get());
     return this;
 }
 
@@ -159,13 +159,7 @@ Ell<ValueType, IndexType>* Ell<ValueType, IndexType>::apply(
     ptr_param<const MultiVector<ValueType>> beta,
     ptr_param<MultiVector<ValueType>> x)
 {
-    this->validate_application_parameters(alpha.get(), b.get(), beta.get(),
-                                          x.get());
-    auto exec = this->get_executor();
-    this->apply_impl(make_temporary_clone(exec, alpha).get(),
-                     make_temporary_clone(exec, b).get(),
-                     make_temporary_clone(exec, beta).get(),
-                     make_temporary_clone(exec, x).get());
+    static_cast<const Ell*>(this)->apply(alpha, b, beta, x);
     return this;
 }
 
@@ -177,7 +171,13 @@ const Ell<ValueType, IndexType>* Ell<ValueType, IndexType>::apply(
     ptr_param<const MultiVector<ValueType>> beta,
     ptr_param<MultiVector<ValueType>> x) const
 {
-    this->apply(alpha, b, beta, x);
+    this->validate_application_parameters(alpha.get(), b.get(), beta.get(),
+                                          x.get());
+    auto exec = this->get_executor();
+    this->apply_impl(make_temporary_clone(exec, alpha).get(),
+                     make_temporary_clone(exec, b).get(),
+                     make_temporary_clone(exec, beta).get(),
+                     make_temporary_clone(exec, x).get());
     return this;
 }
 

--- a/reference/test/matrix/batch_ell_kernels.cpp
+++ b/reference/test/matrix/batch_ell_kernels.cpp
@@ -128,6 +128,21 @@ TYPED_TEST(Ell, AppliesToBatchMultiVector)
 }
 
 
+TYPED_TEST(Ell, ConstAppliesToBatchMultiVector)
+{
+    using T = typename TestFixture::value_type;
+    using BMtx = typename TestFixture::BMtx;
+
+    static_cast<const BMtx*>(this->mtx_0.get())->apply(this->b_0, this->x_0);
+
+    this->mtx_00->apply(this->b_00.get(), this->x_00.get());
+    this->mtx_01->apply(this->b_01.get(), this->x_01.get());
+    auto res = gko::batch::unbatch<gko::batch::MultiVector<T>>(this->x_0.get());
+    GKO_ASSERT_MTX_NEAR(res[0].get(), this->x_00.get(), r<T>::value);
+    GKO_ASSERT_MTX_NEAR(res[1].get(), this->x_01.get(), r<T>::value);
+}
+
+
 TYPED_TEST(Ell, AppliesLinearCombinationToBatchMultiVector)
 {
     using BMtx = typename TestFixture::BMtx;
@@ -143,6 +158,32 @@ TYPED_TEST(Ell, AppliesLinearCombinationToBatchMultiVector)
 
     this->mtx_0->apply(alpha.get(), this->b_0.get(), beta.get(),
                        this->x_0.get());
+
+    this->mtx_00->apply(alpha0.get(), this->b_00.get(), beta0.get(),
+                        this->x_00.get());
+    this->mtx_01->apply(alpha1.get(), this->b_01.get(), beta1.get(),
+                        this->x_01.get());
+    auto res = gko::batch::unbatch<gko::batch::MultiVector<T>>(this->x_0.get());
+    GKO_ASSERT_MTX_NEAR(res[0].get(), this->x_00.get(), r<T>::value);
+    GKO_ASSERT_MTX_NEAR(res[1].get(), this->x_01.get(), r<T>::value);
+}
+
+
+TYPED_TEST(Ell, ConstAppliesLinearCombinationToBatchMultiVector)
+{
+    using BMtx = typename TestFixture::BMtx;
+    using BMVec = typename TestFixture::BMVec;
+    using DenseMtx = typename TestFixture::DenseMtx;
+    using T = typename TestFixture::value_type;
+    auto alpha = gko::batch::initialize<BMVec>({{1.5}, {-1.0}}, this->exec);
+    auto beta = gko::batch::initialize<BMVec>({{2.5}, {-4.0}}, this->exec);
+    auto alpha0 = gko::initialize<DenseMtx>({1.5}, this->exec);
+    auto alpha1 = gko::initialize<DenseMtx>({-1.0}, this->exec);
+    auto beta0 = gko::initialize<DenseMtx>({2.5}, this->exec);
+    auto beta1 = gko::initialize<DenseMtx>({-4.0}, this->exec);
+
+    static_cast<const BMtx*>(this->mtx_0.get())
+        ->apply(alpha.get(), this->b_0.get(), beta.get(), this->x_0.get());
 
     this->mtx_00->apply(alpha0.get(), this->b_00.get(), beta0.get(),
                         this->x_00.get());


### PR DESCRIPTION
This PR fixes the infinite loop of `const apply` call, which is raised by sonarcloud
I also reverse the calling path between `const apply` and `apply`.
`apply` will call `const apply` now not `const apply` called `apply`