### PR TITLE
Fix the work resource for checking diag

### DIFF
--- a/core/test/utils/matrix_utils_test.cpp
+++ b/core/test/utils/matrix_utils_test.cpp
@@ -355,29 +355,38 @@ TEST(MatrixUtils, ModifyToEnsureAllDiagonalEntries)
     using T = float;
     using Csr = gko::matrix::Csr<T, int>;
     auto exec = gko::ReferenceExecutor::create();
+    auto check_all_diag = [](const Csr* csr) {
+        const auto rowptrs = csr->get_const_row_ptrs();
+        const auto colidxs = csr->get_const_col_idxs();
+        const auto ndiag =
+            static_cast<int>(std::min(csr->get_size()[0], csr->get_size()[1]));
+        bool all_diags = true;
+        for (int i = 0; i < ndiag; i++) {
+            bool has_diag = false;
+            for (int j = rowptrs[i]; j < rowptrs[i + 1]; j++) {
+                if (colidxs[j] == i) {
+                    has_diag = true;
+                    break;
+                }
+            }
+            if (!has_diag) {
+                all_diags = false;
+                break;
+            }
+        }
+        return all_diags;
+    };
     auto b = gko::initialize<Csr>(
         {I<T>{2.0, 0.0, 1.1, 0.0}, I<T>{1.0, 2.4, 0.0, -1.0},
          I<T>{0.0, -4.0, 2.2, -2.0}, I<T>{0.0, -3.0, 1.5, 1.0}},
         exec);
+    // ensure it misses some diag
+    bool prev_check = check_all_diag(b.get());
 
     gko::utils::ensure_all_diagonal_entries(b.get());
 
-    const auto rowptrs = b->get_const_row_ptrs();
-    const auto colidxs = b->get_const_col_idxs();
-    bool all_diags = true;
-    for (int i = 0; i < 3; i++) {
-        bool has_diag = false;
-        for (int j = rowptrs[i]; j < rowptrs[i + 1]; j++) {
-            if (colidxs[j] == i) {
-                has_diag = true;
-            }
-        }
-        if (!has_diag) {
-            all_diags = false;
-            break;
-        }
-    }
-    ASSERT_TRUE(all_diags);
+    ASSERT_FALSE(prev_check);
+    ASSERT_TRUE(check_all_diag(b.get()));
 }
 
 

--- a/core/test/utils/matrix_utils_test.cpp
+++ b/core/test/utils/matrix_utils_test.cpp
@@ -376,10 +376,9 @@ TEST(MatrixUtils, ModifyToEnsureAllDiagonalEntries)
         }
         return all_diags;
     };
-    auto b = gko::initialize<Csr>(
-        {I<T>{2.0, 0.0, 1.1, 0.0}, I<T>{1.0, 2.4, 0.0, -1.0},
-         I<T>{0.0, -4.0, 2.2, -2.0}, I<T>{0.0, -3.0, 1.5, 1.0}},
-        exec);
+    auto b = gko::initialize<Csr>({I<T>{2.0, 0.0, 1.1}, I<T>{1.0, 0.0, 0.0},
+                                   I<T>{0.0, -4.0, 2.2}, I<T>{0.0, -3.0, 1.5}},
+                                  exec);
     // ensure it misses some diag
     bool prev_check = check_all_diag(b.get());
 

--- a/core/utils/matrix_utils.hpp
+++ b/core/utils/matrix_utils.hpp
@@ -301,9 +301,10 @@ void ensure_all_diagonal_entries(MtxType* mtx)
     using index_type = typename MtxType::index_type;
     matrix_data<value_type, index_type> mdata;
     mtx->write(mdata);
-    const auto nrows = static_cast<index_type>(mtx->get_size()[0]);
-    mdata.nonzeros.reserve(mtx->get_num_stored_elements() + nrows);
-    for (index_type i = 0; i < nrows; i++) {
+    const auto ndiag = static_cast<index_type>(
+        std::min(mtx->get_size()[0], mtx->get_size()[1]));
+    mdata.nonzeros.reserve(mtx->get_num_stored_elements() + ndiag);
+    for (index_type i = 0; i < ndiag; i++) {
         mdata.nonzeros.push_back({i, i, zero<value_type>()});
     }
     mdata.sum_duplicates();

--- a/dpcpp/matrix/csr_kernels.dp.cpp
+++ b/dpcpp/matrix/csr_kernels.dp.cpp
@@ -2436,15 +2436,14 @@ void check_diagonal_entries_exist(
     std::shared_ptr<const DpcppExecutor> exec,
     const matrix::Csr<ValueType, IndexType>* const mtx, bool& has_all_diags)
 {
-    const size_type num_subgroup = mtx->get_size()[0];
-    if (num_subgroup > 0) {
-        const size_type num_blocks =
-            num_subgroup / (default_block_size / config::warp_size);
+    const auto num_diag = static_cast<IndexType>(
+        std::min(mtx->get_size()[0], mtx->get_size()[1]));
+    if (num_diag > 0) {
+        const IndexType num_blocks =
+            ceildiv(num_diag, default_block_size / config::warp_size);
         array<bool> has_diags(exec, {true});
         kernel::check_diagonal_entries(
-            num_blocks, default_block_size, 0, exec->get_queue(),
-            static_cast<IndexType>(
-                std::min(mtx->get_size()[0], mtx->get_size()[1])),
+            num_blocks, default_block_size, 0, exec->get_queue(), num_diag,
             mtx->get_const_row_ptrs(), mtx->get_const_col_idxs(),
             has_diags.get_data());
         has_all_diags = exec->copy_val_to_host(has_diags.get_const_data());

--- a/hip/matrix/csr_kernels.template.hip.cpp
+++ b/hip/matrix/csr_kernels.template.hip.cpp
@@ -1119,16 +1119,15 @@ void check_diagonal_entries_exist(
     std::shared_ptr<const HipExecutor> exec,
     const matrix::Csr<ValueType, IndexType>* const mtx, bool& has_all_diags)
 {
-    const size_type num_warps = mtx->get_size()[0];
-    if (num_warps > 0) {
-        const size_type num_blocks =
-            num_warps / (default_block_size / config::warp_size);
+    const auto num_diag = static_cast<IndexType>(
+        std::min(mtx->get_size()[0], mtx->get_size()[1]));
+    if (num_diag > 0) {
+        const IndexType num_blocks =
+            ceildiv(num_diag, default_block_size / config::warp_size);
         array<bool> has_diags(exec, {true});
         kernel::check_diagonal_entries<<<num_blocks, default_block_size, 0,
                                          exec->get_stream()>>>(
-            static_cast<IndexType>(
-                std::min(mtx->get_size()[0], mtx->get_size()[1])),
-            mtx->get_const_row_ptrs(), mtx->get_const_col_idxs(),
+            num_diag, mtx->get_const_row_ptrs(), mtx->get_const_col_idxs(),
             has_diags.get_data());
         has_all_diags = exec->copy_val_to_host(has_diags.get_const_data());
     } else {

--- a/test/matrix/csr_kernels2.cpp
+++ b/test/matrix/csr_kernels2.cpp
@@ -1315,10 +1315,12 @@ TEST_F(Csr, CanDetectMissingDiagonalEntry)
 {
     using T = double;
     using Csr = Mtx;
-    auto ref_mtx = gen_mtx<Csr>(103, 98, 10);
+    auto ref_mtx = gen_mtx<Csr>(103, 104, 10);
     const auto rowptrs = ref_mtx->get_row_ptrs();
     const auto colidxs = ref_mtx->get_col_idxs();
-    const int testrow = 15;
+    gko::utils::ensure_all_diagonal_entries(ref_mtx.get());
+    // Choose the last row to ensure that kernel assign enough work
+    const int testrow = 102;
     gko::utils::remove_diagonal_entry_from_row(ref_mtx.get(), testrow);
     auto mtx = gko::clone(exec, ref_mtx);
     bool has_diags = true;


### PR DESCRIPTION
This PR assigns correct and enough work resources for checking diag.
Not enough work resources lead the kernel not to consider the tail part of the matrix.
It fixes the `ensure_all_diag` from test utils, which may assign out-of-range indexes previously.
It also uses the initial matrix with some missing diag to indeed verify the test for `ensure_all_diag`
I am also thinking about where to ensure the index is not out of range.

The failed tests before fix: https://gitlab.com/ginkgo-project/ginkgo-public-ci/-/pipelines/1048097860