### PR TITLE
Uniform handling of disabled deprecation warnings

### DIFF
--- a/core/reorder/nested_dissection.cpp
+++ b/core/reorder/nested_dissection.cpp
@@ -183,8 +183,7 @@ std::unique_ptr<LinOp> NestedDissection<ValueType, IndexType>::generate_impl(
                             inv_permutation.get_data()));
     permutation.set_executor(exec);
     // we discard the inverse permutation
-    return permutation_type::create(exec, dim<2>{num_rows, num_rows},
-                                    std::move(permutation));
+    return permutation_type::create(exec, std::move(permutation));
 }
 
 

--- a/core/reorder/rcm.cpp
+++ b/core/reorder/rcm.cpp
@@ -81,9 +81,6 @@ void rcm_reorder(const matrix::SparsityCsr<ValueType, IndexType>* mtx,
 }
 
 
-GKO_BEGIN_DISABLE_DEPRECATION_WARNINGS
-
-
 template <typename ValueType, typename IndexType>
 Rcm<ValueType, IndexType>::Rcm(std::shared_ptr<const Executor> exec)
     : EnablePolymorphicObject<Rcm, ReorderingBase<IndexType>>(std::move(exec))
@@ -154,9 +151,6 @@ Rcm<ValueType, IndexType>::Rcm(const Factory* factory,
 
 #define GKO_DECLARE_RCM(ValueType, IndexType) class Rcm<ValueType, IndexType>
 GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(GKO_DECLARE_RCM);
-
-
-GKO_END_DISABLE_DEPRECATION_WARNINGS
 
 
 }  // namespace reorder

--- a/core/reorder/rcm.cpp
+++ b/core/reorder/rcm.cpp
@@ -81,15 +81,7 @@ void rcm_reorder(const matrix::SparsityCsr<ValueType, IndexType>* mtx,
 }
 
 
-#if defined(__GNUC__) || defined(__clang__)
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-
-#endif
-#ifdef _MSC_VER
-#pragma warning(push)
-#pragma warning(disable : 5211, 4973, 4974)
-#endif
+GKO_BEGIN_DISABLE_DEPRECATION_WARNINGS
 
 
 template <typename ValueType, typename IndexType>
@@ -164,12 +156,7 @@ Rcm<ValueType, IndexType>::Rcm(const Factory* factory,
 GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(GKO_DECLARE_RCM);
 
 
-#if defined(__GNUC__) || defined(__clang__)
-#pragma GCC diagnostic pop
-#endif
-#ifdef _MSC_VER
-#pragma warning(pop)
-#endif
+GKO_END_DISABLE_DEPRECATION_WARNINGS
 
 
 }  // namespace reorder

--- a/core/test/log/logger.cpp
+++ b/core/test/log/logger.cpp
@@ -30,18 +30,13 @@ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ******************************<GINKGO LICENSE>*******************************/
 
+// force-top: on
+#include <ginkgo/core/base/types.hpp>
+GKO_BEGIN_DISABLE_DEPRECATION_WARNINGS
+// force-top: off
+
+
 #include <ginkgo/core/log/logger.hpp>
-
-
-#if defined(__GNUC__) || defined(__clang__)
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-
-#endif
-#ifdef _MSC_VER
-#pragma warning(push)
-#pragma warning(disable : 5211, 4973, 4974)
-#endif
 
 
 #include <memory>
@@ -362,9 +357,4 @@ TEST(IterationCompleteOverload, CanLogCurrent)
 }  // namespace
 
 
-#if defined(__GNUC__) || defined(__clang__)
-#pragma GCC diagnostic pop
-#endif
-#ifdef _MSC_VER
-#pragma warning(pop)
-#endif
+GKO_END_DISABLE_DEPRECATION_WARNINGS

--- a/core/test/preconditioner/ic.cpp
+++ b/core/test/preconditioner/ic.cpp
@@ -33,15 +33,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <ginkgo/core/preconditioner/ic.hpp>
 
 
-#if defined(__GNUC__) || defined(__clang__)
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-
-#endif
-#ifdef _MSC_VER
-#pragma warning(push)
-#pragma warning(disable : 5211, 4973, 4974)
-#endif
+GKO_BEGIN_DISABLE_DEPRECATION_WARNINGS
 
 
 #include <memory>

--- a/core/test/preconditioner/ic.cpp
+++ b/core/test/preconditioner/ic.cpp
@@ -129,3 +129,6 @@ TEST_F(IcFactory, DeferredFactoryParameter)
 
 
 }  // namespace
+
+
+GKO_END_DISABLE_DEPRECATION_WARNINGS

--- a/core/test/preconditioner/ilu.cpp
+++ b/core/test/preconditioner/ilu.cpp
@@ -147,3 +147,6 @@ TEST_F(IluFactory, DeferredFactoryParameter)
 
 
 }  // namespace
+
+
+GKO_END_DISABLE_DEPRECATION_WARNINGS

--- a/core/test/preconditioner/ilu.cpp
+++ b/core/test/preconditioner/ilu.cpp
@@ -33,15 +33,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <ginkgo/core/preconditioner/ilu.hpp>
 
 
-#if defined(__GNUC__) || defined(__clang__)
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-
-#endif
-#ifdef _MSC_VER
-#pragma warning(push)
-#pragma warning(disable : 5211, 4973, 4974)
-#endif
+GKO_BEGIN_DISABLE_DEPRECATION_WARNINGS
 
 
 #include <memory>

--- a/core/test/reorder/rcm.cpp
+++ b/core/test/reorder/rcm.cpp
@@ -33,15 +33,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <ginkgo/core/reorder/rcm.hpp>
 
 
-#if defined(__GNUC__) || defined(__clang__)
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-
-#endif
-#ifdef _MSC_VER
-#pragma warning(push)
-#pragma warning(disable : 5211, 4973, 4974)
-#endif
+GKO_BEGIN_DISABLE_DEPRECATION_WARNINGS
 
 
 #include <memory>

--- a/core/test/reorder/rcm.cpp
+++ b/core/test/reorder/rcm.cpp
@@ -33,9 +33,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <ginkgo/core/reorder/rcm.hpp>
 
 
-GKO_BEGIN_DISABLE_DEPRECATION_WARNINGS
-
-
 #include <memory>
 
 
@@ -49,6 +46,7 @@ GKO_BEGIN_DISABLE_DEPRECATION_WARNINGS
 
 
 namespace {
+
 
 class Rcm : public ::testing::Test {
 protected:
@@ -65,6 +63,7 @@ protected:
     std::shared_ptr<const gko::Executor> exec;
     std::unique_ptr<reorder_type::Factory> rcm_factory;
 };
+
 
 TEST_F(Rcm, RcmFactoryKnowsItsExecutor)
 {
@@ -91,5 +90,6 @@ TEST_F(Rcm, NewInterfaceSetParameters)
     ASSERT_EQ(param.skip_symmetrize, true);
     ASSERT_EQ(param.strategy, gko::reorder::starting_strategy::minimum_degree);
 }
+
 
 }  // namespace

--- a/core/test/reorder/scaled_reordered.cpp
+++ b/core/test/reorder/scaled_reordered.cpp
@@ -46,15 +46,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <ginkgo/core/solver/bicgstab.hpp>
 
 
-#if defined(__GNUC__) || defined(__clang__)
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-
-#endif
-#ifdef _MSC_VER
-#pragma warning(push)
-#pragma warning(disable : 5211, 4973, 4974)
-#endif
+GKO_BEGIN_DISABLE_DEPRECATION_WARNINGS
 
 
 namespace {
@@ -145,9 +137,4 @@ TEST_F(ScaledReorderedFactory, CanSetColScaling)
 }  // namespace
 
 
-#if defined(__GNUC__) || defined(__clang__)
-#pragma GCC diagnostic pop
-#endif
-#ifdef _MSC_VER
-#pragma warning(pop)
-#endif
+GKO_END_DISABLE_DEPRECATION_WARNINGS

--- a/cuda/test/reorder/rcm_kernels.cpp
+++ b/cuda/test/reorder/rcm_kernels.cpp
@@ -33,15 +33,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <ginkgo/core/reorder/rcm.hpp>
 
 
-#if defined(__GNUC__) || defined(__clang__)
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-
-#endif
-#ifdef _MSC_VER
-#pragma warning(push)
-#pragma warning(disable : 5211, 4973, 4974)
-#endif
+GKO_BEGIN_DISABLE_DEPRECATION_WARNINGS
 
 
 #include <gtest/gtest.h>

--- a/cuda/test/reorder/rcm_kernels.cpp
+++ b/cuda/test/reorder/rcm_kernels.cpp
@@ -33,9 +33,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <ginkgo/core/reorder/rcm.hpp>
 
 
-GKO_BEGIN_DISABLE_DEPRECATION_WARNINGS
-
-
 #include <gtest/gtest.h>
 
 

--- a/include/ginkgo/core/base/array.hpp
+++ b/include/ginkgo/core/base/array.hpp
@@ -160,7 +160,7 @@ private:
 
 
 template <typename ValueType>
-using ConstArrayView [[deprecated("please use const_array_view")]] =
+using ConstArrayView GKO_DEPRECATED("please use const_array_view") =
     const_array_view<ValueType>;
 
 
@@ -714,7 +714,7 @@ private:
 
 
 template <typename ValueType>
-using Array [[deprecated("please use array")]] = array<ValueType>;
+using Array GKO_DEPRECATED("please use array") = array<ValueType>;
 
 
 /**

--- a/include/ginkgo/core/base/executor.hpp
+++ b/include/ginkgo/core/base/executor.hpp
@@ -1307,24 +1307,20 @@ public:
      *
      * @param device_reset  whether to allow a device reset or not
      */
-    [[deprecated(
+    GKO_DEPRECATED(
         "device_reset is no longer supported, call "
-        "cudaDeviceReset/hipDeviceReset manually")]] void
-    set_device_reset(bool device_reset)
-    {}
+        "cudaDeviceReset/hipDeviceReset manually")
+    void set_device_reset(bool device_reset) {}
 
     /**
      * Returns the current status of the device reset boolean for this executor.
      *
      * @return the current status of the device reset boolean for this executor.
      */
-    [[deprecated(
+    GKO_DEPRECATED(
         "device_reset is no longer supported, call "
-        "cudaDeviceReset/hipDeviceReset manually")]] bool
-    get_device_reset()
-    {
-        return false;
-    }
+        "cudaDeviceReset/hipDeviceReset manually")
+    bool get_device_reset() { return false; }
 
 protected:
     /**
@@ -1334,11 +1330,10 @@ protected:
      */
     EnableDeviceReset() {}
 
-    [[deprecated(
+    GKO_DEPRECATED(
         "device_reset is no longer supported, call "
-        "cudaDeviceReset/hipDeviceReset manually")]] EnableDeviceReset(bool
-                                                                           device_reset)
-    {}
+        "cudaDeviceReset/hipDeviceReset manually")
+    EnableDeviceReset(bool device_reset) {}
 };
 
 
@@ -1530,13 +1525,14 @@ public:
      *                    on. See @allocation_mode for more details
      * @param stream  the stream to execute operations on.
      */
-    [[deprecated(
+    GKO_DEPRECATED(
         "device_reset is deprecated entirely, call cudaDeviceReset directly. "
         "alloc_mode was replaced by the Allocator type "
-        "hierarchy.")]] static std::shared_ptr<CudaExecutor>
-    create(int device_id, std::shared_ptr<Executor> master, bool device_reset,
-           allocation_mode alloc_mode = default_cuda_alloc_mode,
-           CUstream_st* stream = nullptr);
+        "hierarchy.")
+    static std::shared_ptr<CudaExecutor> create(
+        int device_id, std::shared_ptr<Executor> master, bool device_reset,
+        allocation_mode alloc_mode = default_cuda_alloc_mode,
+        CUstream_st* stream = nullptr);
 
     /**
      * Creates a new CudaExecutor with a custom allocator and device stream.
@@ -1743,13 +1739,14 @@ public:
      * @param alloc_mode  the allocation mode that the executor should operate
      *                    on. See @allocation_mode for more details
      */
-    [[deprecated(
+    GKO_DEPRECATED(
         "device_reset is deprecated entirely, call hipDeviceReset directly. "
         "alloc_mode was replaced by the Allocator type "
-        "hierarchy.")]] static std::shared_ptr<HipExecutor>
-    create(int device_id, std::shared_ptr<Executor> master, bool device_reset,
-           allocation_mode alloc_mode = default_hip_alloc_mode,
-           GKO_HIP_STREAM_STRUCT* stream = nullptr);
+        "hierarchy.")
+    static std::shared_ptr<HipExecutor> create(
+        int device_id, std::shared_ptr<Executor> master, bool device_reset,
+        allocation_mode alloc_mode = default_hip_alloc_mode,
+        GKO_HIP_STREAM_STRUCT* stream = nullptr);
 
     static std::shared_ptr<HipExecutor> create(
         int device_id, std::shared_ptr<Executor> master,

--- a/include/ginkgo/core/base/machine_topology.hpp
+++ b/include/ginkgo/core/base/machine_topology.hpp
@@ -415,7 +415,7 @@ private:
 };
 
 
-using MachineTopology [[deprecated("please use machine_topology")]] =
+using MachineTopology GKO_DEPRECATED("please use machine_topology") =
     machine_topology;
 
 

--- a/include/ginkgo/core/base/polymorphic_object.hpp
+++ b/include/ginkgo/core/base/polymorphic_object.hpp
@@ -182,14 +182,13 @@ public:
      * @tparam Deleter  the deleter of the unique_ptr parameter
      */
     template <typename Derived, typename Deleter>
-    [[deprecated(
+    GKO_DEPRECATED(
         "This function will be removed in a future release, the replacement "
         "will copy instead of move. If a move is intended, use move_from "
-        "instead.")]] std::
-        enable_if_t<
-            std::is_base_of<PolymorphicObject, std::decay_t<Derived>>::value,
-            PolymorphicObject>*
-        copy_from(std::unique_ptr<Derived, Deleter>&& other)
+        "instead.")
+    std::enable_if_t<
+        std::is_base_of<PolymorphicObject, std::decay_t<Derived>>::value,
+        PolymorphicObject>* copy_from(std::unique_ptr<Derived, Deleter>&& other)
     {
         this->template log<log::Logger::polymorphic_object_move_started>(
             exec_.get(), other.get(), this);
@@ -409,14 +408,13 @@ public:
     }
 
     template <typename Derived>
-    [[deprecated(
+    GKO_DEPRECATED(
         "This function will be removed in a future release, the replacement "
         "will copy instead of move. If a move in intended, use move_to "
-        "instead.")]] std::
-        enable_if_t<
-            std::is_base_of<PolymorphicObject, std::decay_t<Derived>>::value,
-            AbstractObject>*
-        copy_from(std::unique_ptr<Derived>&& other)
+        "instead.")
+    std::enable_if_t<
+        std::is_base_of<PolymorphicObject, std::decay_t<Derived>>::value,
+        AbstractObject>* copy_from(std::unique_ptr<Derived>&& other)
     {
         return static_cast<AbstractObject*>(
             this->PolymorphicBase::copy_from(std::move(other)));

--- a/include/ginkgo/core/base/range.hpp
+++ b/include/ginkgo/core/base/range.hpp
@@ -618,9 +618,8 @@ struct implement_binary_operation<operation_kind::range_by_scalar,
                                              _operation_name)                \
     namespace accessor {                                                     \
     template <typename Operand>                                              \
-    struct [[deprecated(                                                     \
-        "Please use " #_operation_name)]] _operation_deprecated_name         \
-        : _operation_name<Operand>{};                                        \
+    struct GKO_DEPRECATED("Please use " #_operation_name)                    \
+        _operation_deprecated_name : _operation_name<Operand> {};            \
     }                                                                        \
     static_assert(true,                                                      \
                   "This assert is used to counter the false positive extra " \
@@ -864,7 +863,7 @@ GKO_BIND_UNARY_RANGE_OPERATION_TO_OPERATOR(transpose_operation, transpose);
 
 
 #define GKO_DEPRECATED_SIMPLE_BINARY_OPERATION(_deprecated_name, _name) \
-    struct [[deprecated("Please use " #_name)]] _deprecated_name : _name {}
+    struct GKO_DEPRECATED("Please use " #_name) _deprecated_name : _name {}
 
 #define GKO_DEFINE_SIMPLE_BINARY_OPERATION(_name, ...)                         \
     struct _name {                                                             \

--- a/include/ginkgo/core/base/types.hpp
+++ b/include/ginkgo/core/base/types.hpp
@@ -89,11 +89,26 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
 // Handle deprecated notices correctly on different systems
-#if defined(_WIN32) || defined(__CYGWIN__)
-#define GKO_DEPRECATED(msg) __declspec(deprecated(msg))
+// clang-format off
+#define GKO_DEPRECATED(_msg) [[deprecated(_msg)]]
+#ifdef __NVCOMPILER
+#define GKO_BEGIN_DISABLE_DEPRECATION_WARNINGS _Pragma("diag_suppress 1445")
+#define GKO_END_DISABLE_DEPRECATION_WARNINGS _Pragma("diag_warning 1445")
+#elif defined(__GNUC__) || defined(__clang__)
+#define GKO_BEGIN_DISABLE_DEPRECATION_WARNINGS                      \
+    _Pragma("GCC diagnostic push")                                  \
+    _Pragma("GCC diagnostic ignored \"-Wdeprecated-declarations\"")
+#define GKO_END_DISABLE_DEPRECATION_WARNINGS _Pragma("GCC diagnostic pop")
+#elif defined(_MSC_VER)
+#define GKO_BEGIN_DISABLE_DEPRECATION_WARNINGS        \
+    _Pragma("warning(push)")                          \
+    _Pragma("warning(disable : 5211 4973 4974 4996)")
+#define GKO_END_DISABLE_DEPRECATION_WARNINGS _Pragma("warning(pop)")
 #else
-#define GKO_DEPRECATED(msg) __attribute__((deprecated(msg)))
-#endif  // defined(_WIN32) || defined(__CYGWIN__)
+#define GKO_BEGIN_DISABLE_DEPRECATION_WARNINGS
+#define GKO_END_DISABLE_DEPRECATION_WARNINGS
+#endif
+// clang-format on
 
 
 namespace gko {

--- a/include/ginkgo/core/base/utils_helper.hpp
+++ b/include/ginkgo/core/base/utils_helper.hpp
@@ -294,9 +294,9 @@ inline typename std::remove_reference<OwningPointer>::type&& give(
  *       same as calling .get() on the smart pointer.
  */
 template <typename Pointer>
-[[deprecated("no longer necessary, just pass the object without lend")]] inline
-    typename std::enable_if<detail::have_ownership_s<Pointer>::value,
-                            detail::pointee<Pointer>*>::type
+GKO_DEPRECATED("no longer necessary, just pass the object without lend")
+inline typename std::enable_if<detail::have_ownership_s<Pointer>::value,
+                               detail::pointee<Pointer>*>::type
     lend(const Pointer& p)
 {
     return p.get();
@@ -313,9 +313,9 @@ template <typename Pointer>
  *       returns `p`.
  */
 template <typename Pointer>
-[[deprecated("no longer necessary, just pass the object without lend")]] inline
-    typename std::enable_if<!detail::have_ownership_s<Pointer>::value,
-                            detail::pointee<Pointer>*>::type
+GKO_DEPRECATED("no longer necessary, just pass the object without lend")
+inline typename std::enable_if<!detail::have_ownership_s<Pointer>::value,
+                               detail::pointee<Pointer>*>::type
     lend(const Pointer& p)
 {
     return p;

--- a/include/ginkgo/core/log/convergence.hpp
+++ b/include/ginkgo/core/log/convergence.hpp
@@ -102,11 +102,11 @@ public:
      * dependencies. At the same time, this method is short enough that it
      * shouldn't be a problem.
      */
-    [[deprecated(
-        "use single-parameter create")]] static std::unique_ptr<Convergence>
-    create(std::shared_ptr<const Executor>,
-           const mask_type& enabled_events = Logger::criterion_events_mask |
-                                             Logger::iteration_complete_mask)
+    GKO_DEPRECATED("use single-parameter create")
+    static std::unique_ptr<Convergence> create(
+        std::shared_ptr<const Executor>,
+        const mask_type& enabled_events = Logger::criterion_events_mask |
+                                          Logger::iteration_complete_mask)
     {
         return std::unique_ptr<Convergence>(new Convergence(enabled_events));
     }
@@ -188,7 +188,8 @@ protected:
      * @param enabled_events  the events enabled for this logger. By default all
      *                        events.
      */
-    [[deprecated("use single-parameter constructor")]] explicit Convergence(
+    GKO_DEPRECATED("use single-parameter constructor")
+    explicit Convergence(
         std::shared_ptr<const gko::Executor>,
         const mask_type& enabled_events = Logger::criterion_events_mask |
                                           Logger::iteration_complete_mask)

--- a/include/ginkgo/core/log/logger.hpp
+++ b/include/ginkgo/core/log/logger.hpp
@@ -462,12 +462,12 @@ protected:
      * @warning This on_iteration_complete function that this macro declares is
      * deprecated. Please use the version with the stopping information.
      */
-    [[deprecated(
+    GKO_DEPRECATED(
         "Please use the version with the additional stopping "
-        "information.")]] virtual void
-    on_iteration_complete(const LinOp* solver, const size_type& it,
-                          const LinOp* r, const LinOp* x = nullptr,
-                          const LinOp* tau = nullptr) const
+        "information.")
+    virtual void on_iteration_complete(const LinOp* solver, const size_type& it,
+                                       const LinOp* r, const LinOp* x = nullptr,
+                                       const LinOp* tau = nullptr) const
     {}
 
     /**
@@ -483,28 +483,17 @@ protected:
      * @warning This on_iteration_complete function that this macro declares is
      * deprecated. Please use the version with the stopping information.
      */
-    [[deprecated(
+    GKO_DEPRECATED(
         "Please use the version with the additional stopping "
-        "information.")]] virtual void
-    on_iteration_complete(const LinOp* solver, const size_type& it,
-                          const LinOp* r, const LinOp* x, const LinOp* tau,
-                          const LinOp* implicit_tau_sq) const
+        "information.")
+    virtual void on_iteration_complete(const LinOp* solver, const size_type& it,
+                                       const LinOp* r, const LinOp* x,
+                                       const LinOp* tau,
+                                       const LinOp* implicit_tau_sq) const
     {
-#if defined(__GNUC__) || defined(__clang__)
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-#endif
-#ifdef _MSC_VER
-#pragma warning(push)
-#pragma warning(disable : 5211, 4973, 4974)
-#endif
+        GKO_BEGIN_DISABLE_DEPRECATION_WARNINGS
         this->on_iteration_complete(solver, it, r, x, tau);
-#if defined(__GNUC__) || defined(__clang__)
-#pragma GCC diagnostic pop
-#endif
-#ifdef _MSC_VER
-#pragma warning(pop)
-#endif
+        GKO_END_DISABLE_DEPRECATION_WARNINGS
     }
 
     /**
@@ -529,27 +518,9 @@ protected:
                                        const array<stopping_status>* status,
                                        bool stopped) const
     {
-#if defined(__GNUC__) || defined(__clang__)
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-#endif  // defined(__GNUC__) || defined(__clang__)
-#ifdef __NVCOMPILER
-#pragma diag_suppress 1445
-#endif  // __NVCOMPILER
-#ifdef _MSC_VER
-#pragma warning(push)
-#pragma warning(disable : 5211, 4973, 4974)
-#endif  // _MSC_VER
+        GKO_BEGIN_DISABLE_DEPRECATION_WARNINGS
         this->on_iteration_complete(solver, it, r, x, tau, implicit_tau_sq);
-#if defined(__GNUC__) || defined(__clang__)
-#pragma GCC diagnostic pop
-#endif  // defined(__GNUC__) || defined(__clang__)
-#ifdef __NVCOMPILER
-#pragma diag_warning 1445
-#endif  // __NVCOMPILER
-#ifdef _MSC_VER
-#pragma warning(pop)
-#endif  // _MSC_VER
+        GKO_END_DISABLE_DEPRECATION_WARNINGS
     }
 
 public:
@@ -716,9 +687,9 @@ protected:
      *                           logs every event except linop's apply started
      *                           event.
      */
-    [[deprecated("use single-parameter constructor")]] explicit Logger(
-        std::shared_ptr<const gko::Executor> exec,
-        const mask_type& enabled_events = all_events_mask)
+    GKO_DEPRECATED("use single-parameter constructor")
+    explicit Logger(std::shared_ptr<const gko::Executor> exec,
+                    const mask_type& enabled_events = all_events_mask)
         : Logger{enabled_events}
     {}
 

--- a/include/ginkgo/core/log/papi.hpp
+++ b/include/ginkgo/core/log/papi.hpp
@@ -40,11 +40,11 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #if GKO_HAVE_PAPI_SDE
 
 
-#include <sde_lib.h>
 #include <cstddef>
 #include <iostream>
 #include <map>
 #include <mutex>
+#include <sde_lib.h>
 
 
 #include <ginkgo/core/base/polymorphic_object.hpp>

--- a/include/ginkgo/core/log/papi.hpp
+++ b/include/ginkgo/core/log/papi.hpp
@@ -40,11 +40,11 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #if GKO_HAVE_PAPI_SDE
 
 
+#include <sde_lib.h>
 #include <cstddef>
 #include <iostream>
 #include <map>
 #include <mutex>
-#include <sde_lib.h>
 
 
 #include <ginkgo/core/base/polymorphic_object.hpp>
@@ -183,17 +183,18 @@ public:
                                const array<stopping_status>* status,
                                bool stopped) const override;
 
-    [[deprecated(
+    GKO_DEPRECATED(
         "Please use the version with the additional stopping "
-        "information.")]] void
-    on_iteration_complete(const LinOp* solver, const size_type& num_iterations,
-                          const LinOp* residual, const LinOp* solution,
-                          const LinOp* residual_norm) const override;
+        "information.")
+    void on_iteration_complete(const LinOp* solver,
+                               const size_type& num_iterations,
+                               const LinOp* residual, const LinOp* solution,
+                               const LinOp* residual_norm) const override;
 
-    [[deprecated(
+    GKO_DEPRECATED(
         "Please use the version with the additional stopping "
-        "information.")]] void
-    on_iteration_complete(
+        "information.")
+    void on_iteration_complete(
         const LinOp* solver, const size_type& num_iterations,
         const LinOp* residual, const LinOp* solution,
         const LinOp* residual_norm,
@@ -204,9 +205,10 @@ public:
      *
      * @param enabled_events  the events enabled for this Logger
      */
-    [[deprecated("use single-parameter create")]] static std::shared_ptr<Papi>
-    create(std::shared_ptr<const gko::Executor>,
-           const Logger::mask_type& enabled_events = Logger::all_events_mask)
+    GKO_DEPRECATED("use single-parameter create")
+    static std::shared_ptr<Papi> create(
+        std::shared_ptr<const gko::Executor>,
+        const Logger::mask_type& enabled_events = Logger::all_events_mask)
     {
         return Papi::create(enabled_events);
     }
@@ -242,7 +244,8 @@ public:
     const papi_handle_t get_handle() const { return papi_handle; }
 
 protected:
-    [[deprecated("use single-parameter constructor")]] explicit Papi(
+    GKO_DEPRECATED("use single-parameter constructor")
+    explicit Papi(
         std::shared_ptr<const gko::Executor> exec,
         const Logger::mask_type& enabled_events = Logger::all_events_mask)
         : Papi(enabled_events)

--- a/include/ginkgo/core/log/profiler_hook.hpp
+++ b/include/ginkgo/core/log/profiler_hook.hpp
@@ -188,17 +188,18 @@ public:
         const LinOp* implicit_sq_residual_norm,
         const array<stopping_status>* status, bool stopped) const override;
 
-    [[deprecated(
+    GKO_DEPRECATED(
         "Please use the version with the additional stopping "
-        "information.")]] void
-    on_iteration_complete(const LinOp* solver, const size_type& num_iterations,
-                          const LinOp* residual, const LinOp* solution,
-                          const LinOp* residual_norm) const override;
+        "information.")
+    void on_iteration_complete(const LinOp* solver,
+                               const size_type& num_iterations,
+                               const LinOp* residual, const LinOp* solution,
+                               const LinOp* residual_norm) const override;
 
-    [[deprecated(
+    GKO_DEPRECATED(
         "Please use the version with the additional stopping "
-        "information.")]] void
-    on_iteration_complete(
+        "information.")
+    void on_iteration_complete(
         const LinOp* solver, const size_type& num_iterations,
         const LinOp* residual, const LinOp* solution,
         const LinOp* residual_norm,

--- a/include/ginkgo/core/log/record.hpp
+++ b/include/ginkgo/core/log/record.hpp
@@ -402,17 +402,18 @@ public:
         const LinOp* residual_norm, const LinOp* implicit_resnorm_sq,
         const array<stopping_status>* status, bool stopped) const override;
 
-    [[deprecated(
+    GKO_DEPRECATED(
         "Please use the version with the additional stopping "
-        "information.")]] void
-    on_iteration_complete(const LinOp* solver, const size_type& num_iterations,
-                          const LinOp* residual, const LinOp* solution,
-                          const LinOp* residual_norm) const override;
+        "information.")
+    void on_iteration_complete(const LinOp* solver,
+                               const size_type& num_iterations,
+                               const LinOp* residual, const LinOp* solution,
+                               const LinOp* residual_norm) const override;
 
-    [[deprecated(
+    GKO_DEPRECATED(
         "Please use the version with the additional stopping "
-        "information.")]] void
-    on_iteration_complete(
+        "information.")
+    void on_iteration_complete(
         const LinOp* solver, const size_type& num_iterations,
         const LinOp* residual, const LinOp* solution,
         const LinOp* residual_norm,
@@ -436,10 +437,11 @@ public:
      * dependencies. At the same time, this method is short enough that it
      * shouldn't be a problem.
      */
-    [[deprecated("use two-parameter create")]] static std::unique_ptr<Record>
-    create(std::shared_ptr<const Executor> exec,
-           const mask_type& enabled_events = Logger::all_events_mask,
-           size_type max_storage = 1)
+    GKO_DEPRECATED("use two-parameter create")
+    static std::unique_ptr<Record> create(
+        std::shared_ptr<const Executor> exec,
+        const mask_type& enabled_events = Logger::all_events_mask,
+        size_type max_storage = 1)
     {
         return std::unique_ptr<Record>(new Record(enabled_events, max_storage));
     }
@@ -493,10 +495,10 @@ protected:
      *                     storage. It is advised to control this to reduce
      *                     memory overhead of this logger.
      */
-    [[deprecated("use two-parameter constructor")]] explicit Record(
-        std::shared_ptr<const gko::Executor> exec,
-        const mask_type& enabled_events = Logger::all_events_mask,
-        size_type max_storage = 0)
+    GKO_DEPRECATED("use two-parameter constructor")
+    explicit Record(std::shared_ptr<const gko::Executor> exec,
+                    const mask_type& enabled_events = Logger::all_events_mask,
+                    size_type max_storage = 0)
         : Record(enabled_events, max_storage)
     {}
 

--- a/include/ginkgo/core/log/stream.hpp
+++ b/include/ginkgo/core/log/stream.hpp
@@ -164,17 +164,18 @@ public:
                                const array<stopping_status>* status,
                                bool stopped) const override;
 
-    [[deprecated(
+    GKO_DEPRECATED(
         "Please use the version with the additional stopping "
-        "information.")]] void
-    on_iteration_complete(const LinOp* solver, const size_type& num_iterations,
-                          const LinOp* residual, const LinOp* solution,
-                          const LinOp* residual_norm) const override;
+        "information.")
+    void on_iteration_complete(const LinOp* solver,
+                               const size_type& num_iterations,
+                               const LinOp* residual, const LinOp* solution,
+                               const LinOp* residual_norm) const override;
 
-    [[deprecated(
+    GKO_DEPRECATED(
         "Please use the version with the additional stopping "
-        "information.")]] void
-    on_iteration_complete(
+        "information.")
+    void on_iteration_complete(
         const LinOp* solver, const size_type& num_iterations,
         const LinOp* residual, const LinOp* solution,
         const LinOp* residual_norm,
@@ -198,10 +199,11 @@ public:
      * dependencies. At the same time, this method is short enough that it
      * shouldn't be a problem.
      */
-    [[deprecated("use three-parameter create")]] static std::unique_ptr<Stream>
-    create(std::shared_ptr<const Executor> exec,
-           const Logger::mask_type& enabled_events = Logger::all_events_mask,
-           std::ostream& os = std::cout, bool verbose = false)
+    GKO_DEPRECATED("use three-parameter create")
+    static std::unique_ptr<Stream> create(
+        std::shared_ptr<const Executor> exec,
+        const Logger::mask_type& enabled_events = Logger::all_events_mask,
+        std::ostream& os = std::cout, bool verbose = false)
     {
         return std::unique_ptr<Stream>(new Stream(enabled_events, os, verbose));
     }
@@ -243,7 +245,8 @@ protected:
      *                 includes always printing residuals and other information
      *                 which can give a large output.
      */
-    [[deprecated("use three-parameter constructor")]] explicit Stream(
+    GKO_DEPRECATED("use three-parameter constructor")
+    explicit Stream(
         std::shared_ptr<const gko::Executor> exec,
         const Logger::mask_type& enabled_events = Logger::all_events_mask,
         std::ostream& os = std::cerr, bool verbose = false)

--- a/include/ginkgo/core/matrix/permutation.hpp
+++ b/include/ginkgo/core/matrix/permutation.hpp
@@ -119,10 +119,10 @@ std::ostream& operator<<(std::ostream& stream, permute_mode mode);
 using mask_type = gko::uint64;
 
 static constexpr mask_type row_permute = mask_type{1};
-[[deprecated("permute mask is no longer supported")]] static constexpr mask_type
-    column_permute = mask_type{1 << 2};
-[[deprecated("permute mask is no longer supported")]] static constexpr mask_type
-    inverse_permute = mask_type{1 << 3};
+GKO_DEPRECATED("permute mask is no longer supported")
+static constexpr mask_type column_permute = mask_type{1 << 2};
+GKO_DEPRECATED("permute mask is no longer supported")
+static constexpr mask_type inverse_permute = mask_type{1 << 3};
 
 /**
  * Permutation is a matrix format that represents a permutation matrix,
@@ -174,14 +174,14 @@ public:
      * @return the number of elements explicitly stored in the permutation
      * array.
      */
-    [[deprecated("use get_size()[0] instead")]] size_type get_permutation_size()
-        const noexcept;
+    GKO_DEPRECATED("use get_size()[0] instead")
+    size_type get_permutation_size() const noexcept;
 
-    [[deprecated("permute mask is no longer supported")]] mask_type
-    get_permute_mask() const;
+    GKO_DEPRECATED("permute mask is no longer supported")
+    mask_type get_permute_mask() const;
 
-    [[deprecated("permute mask is no longer supported")]] void set_permute_mask(
-        mask_type permute_mask);
+    GKO_DEPRECATED("permute mask is no longer supported")
+    void set_permute_mask(mask_type permute_mask);
 
     /**
      * Returns the inverse permutation.
@@ -218,12 +218,11 @@ public:
      *          (if it resides on the same executor as the matrix) or a copy of
      *          the array on the correct executor.
      */
-    [[deprecated(
-        "use create_const without size and permute mask")]] static std::
-        unique_ptr<const Permutation>
-        create_const(std::shared_ptr<const Executor> exec, size_type size,
-                     gko::detail::const_array_view<IndexType>&& perm_idxs,
-                     mask_type enabled_permute = row_permute);
+    GKO_DEPRECATED("use create_const without size and permute mask")
+    static std::unique_ptr<const Permutation> create_const(
+        std::shared_ptr<const Executor> exec, size_type size,
+        gko::detail::const_array_view<IndexType>&& perm_idxs,
+        mask_type enabled_permute = row_permute);
     /**
      * Creates a constant (immutable) Permutation matrix from a constant array.
      *
@@ -263,19 +262,19 @@ protected:
     Permutation(std::shared_ptr<const Executor> exec,
                 array<IndexType> permutation_indices);
 
-    [[deprecated(
+    GKO_DEPRECATED(
         "dim<2> is no longer supported as a dimension parameter, use size_type "
-        "instead")]] Permutation(std::shared_ptr<const Executor> exec,
-                                 const dim<2>& size);
+        "instead")
+    Permutation(std::shared_ptr<const Executor> exec, const dim<2>& size);
 
-    [[deprecated("permute mask is no longer supported")]] Permutation(
-        std::shared_ptr<const Executor> exec, const dim<2>& size,
-        const mask_type& enabled_permute);
+    GKO_DEPRECATED("permute mask is no longer supported")
+    Permutation(std::shared_ptr<const Executor> exec, const dim<2>& size,
+                const mask_type& enabled_permute);
 
     template <typename IndicesArray>
-    [[deprecated("use the overload without dimensions")]] Permutation(
-        std::shared_ptr<const Executor> exec, const dim<2>& size,
-        IndicesArray&& permutation_indices)
+    GKO_DEPRECATED("use the overload without dimensions")
+    Permutation(std::shared_ptr<const Executor> exec, const dim<2>& size,
+                IndicesArray&& permutation_indices)
         : Permutation{exec, array<IndexType>{exec, std::forward<IndicesArray>(
                                                        permutation_indices)}}
     {
@@ -284,9 +283,10 @@ protected:
     }
 
     template <typename IndicesArray>
-    [[deprecated("permute mask is no longer supported")]] Permutation(
-        std::shared_ptr<const Executor> exec, const dim<2>& size,
-        IndicesArray&& permutation_indices, const mask_type& enabled_permute)
+    GKO_DEPRECATED("permute mask is no longer supported")
+    Permutation(std::shared_ptr<const Executor> exec, const dim<2>& size,
+                IndicesArray&& permutation_indices,
+                const mask_type& enabled_permute)
         : Permutation{std::move(exec),
                       array<IndexType>{exec, std::forward<IndicesArray>(
                                                  permutation_indices)}}

--- a/include/ginkgo/core/multigrid/pgm.hpp
+++ b/include/ginkgo/core/multigrid/pgm.hpp
@@ -196,10 +196,9 @@ private:
 
 
 template <typename ValueType = default_precision, typename IndexType = int32>
-using AmgxPgm
-    [[deprecated("This class is deprecated and will be removed in the next "
-                 "major release. Please use Pgm instead.")]] =
-        Pgm<ValueType, IndexType>;
+using AmgxPgm GKO_DEPRECATED(
+    "This class is deprecated and will be removed in the next "
+    "major release. Please use Pgm instead.") = Pgm<ValueType, IndexType>;
 
 
 }  // namespace multigrid

--- a/include/ginkgo/core/preconditioner/ic.hpp
+++ b/include/ginkgo/core/preconditioner/ic.hpp
@@ -134,8 +134,8 @@ public:
          */
         std::shared_ptr<const LinOpFactory> factorization_factory{};
 
-        [[deprecated("use with_l_solver instead")]] parameters_type&
-        with_l_solver_factory(
+        GKO_DEPRECATED("use with_l_solver instead")
+        parameters_type& with_l_solver_factory(
             deferred_factory_parameter<const typename l_solver_type::Factory>
                 solver)
         {
@@ -157,8 +157,8 @@ public:
             return *this;
         }
 
-        [[deprecated("use with_factorization instead")]] parameters_type&
-        with_factorization_factory(
+        GKO_DEPRECATED("use with_factorization instead")
+        parameters_type& with_factorization_factory(
             deferred_factory_parameter<const LinOpFactory> factorization)
         {
             return with_factorization(std::move(factorization));

--- a/include/ginkgo/core/preconditioner/ilu.hpp
+++ b/include/ginkgo/core/preconditioner/ilu.hpp
@@ -151,8 +151,8 @@ public:
          */
         std::shared_ptr<const LinOpFactory> factorization_factory{};
 
-        [[deprecated("use with_l_solver instead")]] parameters_type&
-        with_l_solver_factory(
+        GKO_DEPRECATED("use with_l_solver instead")
+        parameters_type& with_l_solver_factory(
             deferred_factory_parameter<const typename l_solver_type::Factory>
                 solver)
         {
@@ -174,8 +174,8 @@ public:
             return *this;
         }
 
-        [[deprecated("use with_u_solver instead")]] parameters_type&
-        with_u_solver_factory(
+        GKO_DEPRECATED("use with_u_solver instead")
+        parameters_type& with_u_solver_factory(
             deferred_factory_parameter<const typename u_solver_type::Factory>
                 solver)
         {
@@ -197,8 +197,8 @@ public:
             return *this;
         }
 
-        [[deprecated("use with_factorization instead")]] parameters_type&
-        with_factorization_factory(
+        GKO_DEPRECATED("use with_factorization instead")
+        parameters_type& with_factorization_factory(
             deferred_factory_parameter<const LinOpFactory> factorization)
         {
             return with_factorization(std::move(factorization));

--- a/include/ginkgo/core/reorder/rcm.hpp
+++ b/include/ginkgo/core/reorder/rcm.hpp
@@ -97,7 +97,7 @@ enum class starting_strategy { minimum_degree, pseudo_peripheral };
  * @ingroup reorder
  */
 template <typename ValueType = default_precision, typename IndexType = int32>
-class [[deprecated("use gko::experimental::reorder::Rcm instead")]] Rcm
+class GKO_DEPRECATED("use gko::experimental::reorder::Rcm instead") Rcm
     : public EnablePolymorphicObject<Rcm<ValueType, IndexType>,
                                      ReorderingBase<IndexType>>,
       public EnablePolymorphicAssignment<Rcm<ValueType, IndexType>>

--- a/include/ginkgo/core/reorder/rcm.hpp
+++ b/include/ginkgo/core/reorder/rcm.hpp
@@ -97,11 +97,9 @@ enum class starting_strategy { minimum_degree, pseudo_peripheral };
  * @ingroup reorder
  */
 template <typename ValueType = default_precision, typename IndexType = int32>
-class GKO_DEPRECATED("use gko::experimental::reorder::Rcm instead") Rcm
-    : public EnablePolymorphicObject<Rcm<ValueType, IndexType>,
-                                     ReorderingBase<IndexType>>,
-      public EnablePolymorphicAssignment<Rcm<ValueType, IndexType>>
-{
+class Rcm : public EnablePolymorphicObject<Rcm<ValueType, IndexType>,
+                                           ReorderingBase<IndexType>>,
+            public EnablePolymorphicAssignment<Rcm<ValueType, IndexType>> {
     friend class EnablePolymorphicObject<Rcm, ReorderingBase<IndexType>>;
 
 public:

--- a/include/ginkgo/core/solver/idr.hpp
+++ b/include/ginkgo/core/solver/idr.hpp
@@ -164,8 +164,8 @@ public:
      * @param other  the new complex_subspace parameter
      * @deprecated Please use set_complex_subspace instead
      */
-    [[deprecated("Use set_complex_subspace instead")]] void
-    set_complex_subpsace(const bool other)
+    GKO_DEPRECATED("Use set_complex_subspace instead")
+    void set_complex_subpsace(const bool other)
     {
         this->set_complex_subspace(other);
     }

--- a/include/ginkgo/core/solver/solver_base.hpp
+++ b/include/ginkgo/core/solver/solver_base.hpp
@@ -49,14 +49,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <ginkgo/core/stop/criterion.hpp>
 
 
-#if defined(__GNUC__) || defined(__clang__)
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-#endif
-#ifdef _MSC_VER
-#pragma warning(push)
-#pragma warning(disable : 5211, 4973, 4974)
-#endif
+GKO_BEGIN_DISABLE_DEPRECATION_WARNINGS
 
 
 namespace gko {
@@ -537,10 +530,9 @@ private:
 template <typename MatrixType>
 class
     // clang-format off
-    [[deprecated("This class will be replaced by the template-less detail::SolverBaseLinOp in a future release")]] SolverBase
+    GKO_DEPRECATED("This class will be replaced by the template-less detail::SolverBaseLinOp in a future release") SolverBase
     // clang-format on
-    : public detail::SolverBaseLinOp
-{
+    : public detail::SolverBaseLinOp {
 public:
     using detail::SolverBaseLinOp::SolverBaseLinOp;
 
@@ -898,10 +890,7 @@ struct enable_preconditioned_iterative_solver_factory_parameters
 }  // namespace gko
 
 
-#if defined(__GNUC__) || defined(__clang__)
-#pragma GCC diagnostic pop
-#endif
-#ifdef _MSC_VER
-#pragma warning(pop)
-#endif
+GKO_END_DISABLE_DEPRECATION_WARNINGS
+
+
 #endif  // GKO_PUBLIC_CORE_SOLVER_SOLVER_BASE_HPP_

--- a/include/ginkgo/core/stop/residual_norm.hpp
+++ b/include/ginkgo/core/stop/residual_norm.hpp
@@ -240,13 +240,7 @@ protected:
 // The following classes are deprecated, but they internally reference
 // themselves. To reduce unnecessary warnings, we disable deprecation warnings
 // for the definition of these classes.
-#if defined(__GNUC__) || defined(__clang__)
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-#elif defined(_MSC_BUILD) || defined(__INTEL_LLVM_COMPILER)
-#pragma warning(push)
-#pragma warning(disable : 4996)
-#endif
+GKO_BEGIN_DISABLE_DEPRECATION_WARNINGS
 
 
 /**
@@ -269,11 +263,10 @@ protected:
  * @ingroup stop
  */
 template <typename ValueType = default_precision>
-class [[deprecated(
+class GKO_DEPRECATED(
     "Please use the class ResidualNorm with the factory parameter baseline = "
-    "mode::initial_resnorm")]] ResidualNormReduction
-    : public ResidualNormBase<ValueType>
-{
+    "mode::initial_resnorm") ResidualNormReduction
+    : public ResidualNormBase<ValueType> {
 public:
     using ComplexVector = matrix::Dense<to_complex<ValueType>>;
     using NormVector = matrix::Dense<remove_complex<ValueType>>;
@@ -326,11 +319,10 @@ protected:
  * @ingroup stop
  */
 template <typename ValueType = default_precision>
-class [[deprecated(
+class GKO_DEPRECATED(
     "Please use the class ResidualNorm with the factory parameter baseline = "
-    "mode::rhs_norm")]] RelativeResidualNorm
-    : public ResidualNormBase<ValueType>
-{
+    "mode::rhs_norm") RelativeResidualNorm
+    : public ResidualNormBase<ValueType> {
 public:
     using ComplexVector = matrix::Dense<to_complex<ValueType>>;
     using NormVector = matrix::Dense<remove_complex<ValueType>>;
@@ -381,11 +373,10 @@ protected:
  * @ingroup stop
  */
 template <typename ValueType = default_precision>
-class [[deprecated(
+class GKO_DEPRECATED(
     "Please use the class ResidualNorm with the factory parameter baseline = "
-    "mode::absolute")]] AbsoluteResidualNorm
-    : public ResidualNormBase<ValueType>
-{
+    "mode::absolute") AbsoluteResidualNorm
+    : public ResidualNormBase<ValueType> {
 public:
     using NormVector = matrix::Dense<remove_complex<ValueType>>;
     using Vector = matrix::Dense<ValueType>;
@@ -417,11 +408,7 @@ protected:
 };
 
 
-#if defined(__GNUC__) || defined(__clang__)
-#pragma GCC diagnostic pop
-#elif defined(_MSC_BUILD) || defined(__INTEL_LLVM_COMPILER)
-#pragma warning(pop)
-#endif
+GKO_END_DISABLE_DEPRECATION_WARNINGS
 
 
 }  // namespace stop

--- a/omp/test/reorder/rcm_kernels.cpp
+++ b/omp/test/reorder/rcm_kernels.cpp
@@ -33,15 +33,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <ginkgo/core/reorder/rcm.hpp>
 
 
-#if defined(__GNUC__) || defined(__clang__)
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-
-#endif
-#ifdef _MSC_VER
-#pragma warning(push)
-#pragma warning(disable : 5211, 4973, 4974)
-#endif
+GKO_BEGIN_DISABLE_DEPRECATION_WARNINGS
 
 
 #include <algorithm>

--- a/omp/test/reorder/rcm_kernels.cpp
+++ b/omp/test/reorder/rcm_kernels.cpp
@@ -33,9 +33,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <ginkgo/core/reorder/rcm.hpp>
 
 
-GKO_BEGIN_DISABLE_DEPRECATION_WARNINGS
-
-
 #include <algorithm>
 #include <deque>
 #include <fstream>

--- a/reference/test/reorder/rcm.cpp
+++ b/reference/test/reorder/rcm.cpp
@@ -33,17 +33,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <ginkgo/core/reorder/rcm.hpp>
 
 
-#if defined(__GNUC__) || defined(__clang__)
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-
-#endif
-#ifdef _MSC_VER
-#pragma warning(push)
-#pragma warning(disable : 5211, 4973, 4974)
-#endif
-
-
 #include <algorithm>
 #include <fstream>
 #include <memory>
@@ -60,6 +49,9 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "core/test/utils.hpp"
 #include "core/test/utils/assertions.hpp"
+
+
+GKO_BEGIN_DISABLE_DEPRECATION_WARNINGS
 
 
 namespace {

--- a/reference/test/reorder/rcm.cpp
+++ b/reference/test/reorder/rcm.cpp
@@ -51,9 +51,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "core/test/utils/assertions.hpp"
 
 
-GKO_BEGIN_DISABLE_DEPRECATION_WARNINGS
-
-
 namespace {
 
 
@@ -72,12 +69,12 @@ protected:
           rcm_factory(reorder_type::build().on(exec)),
           // clang-format off
           id3_mtx(gko::initialize<CsrMtx>(
-              {{1.0, 0.0, 0.0}, 
-              {0.0, 1.0, 0.0}, 
+              {{1.0, 0.0, 0.0},
+              {0.0, 1.0, 0.0},
               {0.0, 0.0, 1.0}}, exec)),
           not_id3_mtx(gko::initialize<CsrMtx>(
-              {{1.0, 0.0, 1.0}, 
-              {0.0, 1.0, 0.0}, 
+              {{1.0, 0.0, 1.0},
+              {0.0, 1.0, 0.0},
               {1.0, 0.0, 1.0}}, exec)),
           // clang-format on
           reorder_op(rcm_factory->generate(id3_mtx))

--- a/reference/test/reorder/rcm_kernels.cpp
+++ b/reference/test/reorder/rcm_kernels.cpp
@@ -50,15 +50,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "core/test/utils/assertions.hpp"
 
 
-#if defined(__GNUC__) || defined(__clang__)
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-
-#endif
-#ifdef _MSC_VER
-#pragma warning(push)
-#pragma warning(disable : 5211, 4973, 4974)
-#endif
+GKO_BEGIN_DISABLE_DEPRECATION_WARNINGS
 
 
 namespace {
@@ -191,9 +183,4 @@ TEST_F(Rcm, NewInterfaceWorksOnNonsymmetric)
 }  // namespace
 
 
-#if defined(__GNUC__) || defined(__clang__)
-#pragma GCC diagnostic pop
-#endif
-#ifdef _MSC_VER
-#pragma warning(pop)
-#endif
+GKO_END_DISABLE_DEPRECATION_WARNINGS

--- a/reference/test/reorder/rcm_kernels.cpp
+++ b/reference/test/reorder/rcm_kernels.cpp
@@ -50,9 +50,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "core/test/utils/assertions.hpp"
 
 
-GKO_BEGIN_DISABLE_DEPRECATION_WARNINGS
-
-
 namespace {
 
 
@@ -181,6 +178,3 @@ TEST_F(Rcm, NewInterfaceWorksOnNonsymmetric)
 
 
 }  // namespace
-
-
-GKO_END_DISABLE_DEPRECATION_WARNINGS

--- a/reference/test/reorder/scaled_reordered.cpp
+++ b/reference/test/reorder/scaled_reordered.cpp
@@ -54,15 +54,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "core/test/utils.hpp"
 
 
-#if defined(__GNUC__) || defined(__clang__)
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-
-#endif
-#ifdef _MSC_VER
-#pragma warning(push)
-#pragma warning(disable : 5211, 4973, 4974)
-#endif
+GKO_BEGIN_DISABLE_DEPRECATION_WARNINGS
 
 
 namespace {
@@ -581,9 +573,4 @@ TYPED_TEST(ScaledReordered, SolvesMultipleRhs)
 }  // namespace
 
 
-#if defined(__GNUC__) || defined(__clang__)
-#pragma GCC diagnostic pop
-#endif
-#ifdef _MSC_VER
-#pragma warning(pop)
-#endif
+GKO_END_DISABLE_DEPRECATION_WARNINGS


### PR DESCRIPTION
We keep copy-pasting the same (or slightly different) pragmas for disabling deprecation warnings throughout many files, instead I propose that we keep around a single pair of macros for dealing with them.