### PR TITLE
Fix OpenMPI check in cross-compiling mode

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -248,7 +248,6 @@ if(GINKGO_BUILD_MPI)
         ${Ginkgo_SOURCE_DIR}/cmake/openmpi_test.cpp
                 COMPILE_DEFINITIONS -DCHECK_HAS_OPEN_MPI=1
         LINK_LIBRARIES MPI::MPI_CXX
-                OUTPUT_VARIABLE output
         )
     if(uses_openmpi)
         try_compile(valid_openmpi_version

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -242,14 +242,22 @@ if(GINKGO_BUILD_MPI)
         set(GINKGO_HAVE_GPU_AWARE_MPI OFF)
     endif()
 
-    try_run(uses_openmpi gko_result_unused
+    # use try_compile instead of try_run to prevent cross-compiling issues
+    try_compile(uses_openmpi
         ${Ginkgo_BINARY_DIR}
         ${Ginkgo_SOURCE_DIR}/cmake/openmpi_test.cpp
+                COMPILE_DEFINITIONS -DCHECK_HAS_OPEN_MPI=1
         LINK_LIBRARIES MPI::MPI_CXX
-        RUN_OUTPUT_VARIABLE openmpi_version
+                OUTPUT_VARIABLE output
         )
     if(uses_openmpi)
-        if(openmpi_version VERSION_LESS "4.1")
+        try_compile(valid_openmpi_version
+                    ${Ginkgo_BINARY_DIR}
+                    ${Ginkgo_SOURCE_DIR}/cmake/openmpi_test.cpp
+                    COMPILE_DEFINITIONS -DCHECK_OPEN_MPI_VERSION=1
+                    LINK_LIBRARIES MPI::MPI_CXX
+        )
+        if(NOT valid_openmpi_version)
             message(WARNING
                 "OpenMPI v4.0.x has a bug that forces us to use blocking communication in our distributed "
                 "matrix class. To enable faster, non-blocking communication, consider updating your OpenMPI version or "

--- a/cmake/openmpi_test.cpp
+++ b/cmake/openmpi_test.cpp
@@ -39,12 +39,12 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 int main()
 {
 #if CHECK_HAS_OPEN_MPI && defined(OPEN_MPI) && OPEN_MPI
-    static_assert(true);
-#elif CHECK_OPEN_MPI_VERSION
+    static_assert(true, "Check availability of OpenMPI");
+#elif CHECK_OPEN_MPI_VERSION && defined(OPEN_MPI) && OPEN_MPI
     static_assert(OMPI_MAJOR_VERSION > 4 ||
-                  (OMPI_MAJOR_VERSION == 4 && OMPI_MINOR_VERSION >= 1));
+                      (OMPI_MAJOR_VERSION == 4 && OMPI_MINOR_VERSION >= 1),
+                  "Check OpenMPI version.");
 #else
-    static_assert(false);
+    static_assert(false, "No OpenMPI available");
 #endif
-    return 1;
 }

--- a/cmake/openmpi_test.cpp
+++ b/cmake/openmpi_test.cpp
@@ -38,11 +38,13 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 int main()
 {
-#if defined(OPEN_MPI) && OPEN_MPI
-    std::printf("%d.%d.%d", OMPI_MAJOR_VERSION, OMPI_MINOR_VERSION,
-                OMPI_RELEASE_VERSION);
-    return 1;
+#if CHECK_HAS_OPEN_MPI && defined(OPEN_MPI) && OPEN_MPI
+    static_assert(true);
+#elif CHECK_OPEN_MPI_VERSION
+    static_assert(OMPI_MAJOR_VERSION > 4 ||
+                  (OMPI_MAJOR_VERSION == 4 && OMPI_MINOR_VERSION >= 1));
 #else
-    return 0;
+    static_assert(false);
 #endif
+    return 1;
 }


### PR DESCRIPTION
This PR replaces try-run with try-compile in OpenMPI check.

try-run can't be run in cross-compiling mode, which happens for example on Macs. So, the sufficient OpenMPI version check has been re-written to run at compile time.
