### PR TITLE
pass slurm job failure (not a fix)

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -265,6 +265,8 @@ test/cuda110/mvapich2/gcc/cuda/debug/shared:
     SLURM_GRES: "gpu:4"
     SLURM_TIME: "02:00:00"
   dependencies: null
+  # FIXME: current slurm always reports failure even if all tests are passed.
+  allow_failure: yes
   needs: [ "build/cuda110/mvapich2/gcc/cuda/debug/shared" ]
 
 
@@ -298,6 +300,8 @@ test/cuda110/nompi/clang/cuda/release/static:
     SLURM_GRES: "gpu:4"
     SLURM_TIME: "01:30:00"
   dependencies: null
+  # FIXME: current slurm always reports failure even if all tests are passed.
+  allow_failure: yes
   needs: [ "build/cuda110/nompi/clang/cuda/release/static" ]
 
 
@@ -332,6 +336,8 @@ test/cuda110/nompi/intel/cuda/debug/static:
     SLURM_GRES: "gpu:4"
     SLURM_TIME: "02:00:00"
   dependencies: null
+  # FIXME: current slurm always reports failure even if all tests are passed.
+  allow_failure: yes
   needs: [ "build/cuda110/nompi/intel/cuda/debug/static" ]
 
 


### PR DESCRIPTION
slurm always reports error even if all tests are passed. It disallows the following tests in pipeline.

Because we are busy with release deadline and the following tests are sometimes useful, we just always pass it now.
but before merge, we should check the result in the pipeline.
It should be fixed or replaced by alternative way in the future