### PR TITLE
Fix return value in CUDA memory order functions

### DIFF
--- a/cuda/components/memory.cuh
+++ b/cuda/components/memory.cuh
@@ -81,7 +81,7 @@ __device__ __forceinline__ uint32 convert_generic_ptr_to_smem_ptr(void* ptr)
 }
 
 
-__device__ __forceinline__ uint32 membar_acq_rel()
+__device__ __forceinline__ void membar_acq_rel()
 {
 #if __CUDA_ARCH__ < 700
     asm volatile("membar.gl;" ::: "memory");
@@ -91,7 +91,7 @@ __device__ __forceinline__ uint32 membar_acq_rel()
 }
 
 
-__device__ __forceinline__ uint32 membar_acq_rel_shared()
+__device__ __forceinline__ void membar_acq_rel_shared()
 {
 #if __CUDA_ARCH__ < 700
     asm volatile("membar.cta;" ::: "memory");

--- a/dev_tools/scripts/generate_cuda_memory_ptx.py
+++ b/dev_tools/scripts/generate_cuda_memory_ptx.py
@@ -125,7 +125,7 @@ __device__ __forceinline__ uint32 convert_generic_ptr_to_smem_ptr(void* ptr)
 }
 
 
-__device__ __forceinline__ uint32 membar_acq_rel()
+__device__ __forceinline__ void membar_acq_rel()
 {
 #if __CUDA_ARCH__ < 700
     asm volatile("membar.gl;" ::: "memory");
@@ -135,7 +135,7 @@ __device__ __forceinline__ uint32 membar_acq_rel()
 }
 
 
-__device__ __forceinline__ uint32 membar_acq_rel_shared()
+__device__ __forceinline__ void membar_acq_rel_shared()
 {
 #if __CUDA_ARCH__ < 700
     asm volatile("membar.cta;" ::: "memory");


### PR DESCRIPTION
Remove the return value in CUDA memory order functions that aren't supposed to return anything and that didn't have a return statement.