### PR TITLE
Add a CSR batched matrix format, CUDA, HIP and DPCPP kernels

### DIFF
--- a/common/cuda_hip/matrix/batch_csr_kernel_launcher.hpp.inc
+++ b/common/cuda_hip/matrix/batch_csr_kernel_launcher.hpp.inc
@@ -34,7 +34,18 @@ template <typename ValueType, typename IndexType>
 void simple_apply(std::shared_ptr<const DefaultExecutor> exec,
                   const batch::matrix::Csr<ValueType, IndexType>* mat,
                   const batch::MultiVector<ValueType>* b,
-                  batch::MultiVector<ValueType>* x) GKO_NOT_IMPLEMENTED;
+                  batch::MultiVector<ValueType>* x)
+{
+    const auto num_blocks = mat->get_num_batch_items();
+    const auto b_ub = get_batch_struct(b);
+    const auto x_ub = get_batch_struct(x);
+    const auto mat_ub = get_batch_struct(mat);
+    if (b->get_common_size()[1] > 1) {
+        GKO_NOT_IMPLEMENTED;
+    }
+    simple_apply_kernel<<<num_blocks, default_block_size, 0,
+                          exec->get_stream()>>>(mat_ub, b_ub, x_ub);
+}
 
 
 GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INT32_TYPE(
@@ -47,7 +58,21 @@ void advanced_apply(std::shared_ptr<const DefaultExecutor> exec,
                     const batch::matrix::Csr<ValueType, IndexType>* mat,
                     const batch::MultiVector<ValueType>* b,
                     const batch::MultiVector<ValueType>* beta,
-                    batch::MultiVector<ValueType>* x) GKO_NOT_IMPLEMENTED;
+                    batch::MultiVector<ValueType>* x)
+{
+    const auto num_blocks = mat->get_num_batch_items();
+    const auto b_ub = get_batch_struct(b);
+    const auto x_ub = get_batch_struct(x);
+    const auto mat_ub = get_batch_struct(mat);
+    const auto alpha_ub = get_batch_struct(alpha);
+    const auto beta_ub = get_batch_struct(beta);
+    if (b->get_common_size()[1] > 1) {
+        GKO_NOT_IMPLEMENTED;
+    }
+    advanced_apply_kernel<<<num_blocks, default_block_size, 0,
+                            exec->get_stream()>>>(alpha_ub, mat_ub, b_ub,
+                                                  beta_ub, x_ub);
+}
 
 GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INT32_TYPE(
     GKO_DECLARE_BATCH_CSR_ADVANCED_APPLY_KERNEL);

--- a/common/cuda_hip/matrix/batch_csr_kernel_launcher.hpp.inc
+++ b/common/cuda_hip/matrix/batch_csr_kernel_launcher.hpp.inc
@@ -1,34 +1,7 @@
-/*******************************<GINKGO LICENSE>******************************
-Copyright (c) 2017-2023, the Ginkgo authors
-All rights reserved.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions
-are met:
-
-1. Redistributions of source code must retain the above copyright
-notice, this list of conditions and the following disclaimer.
-
-2. Redistributions in binary form must reproduce the above copyright
-notice, this list of conditions and the following disclaimer in the
-documentation and/or other materials provided with the distribution.
-
-3. Neither the name of the copyright holder nor the names of its
-contributors may be used to endorse or promote products derived from
-this software without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
-IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
-TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-******************************<GINKGO LICENSE>*******************************/
+// Copyright (c) 2017-2023, the Ginkgo authors
+// SPDX-FileCopyrightText: 2017-2023 The Ginkgo authors
+//
+// SPDX-License-Identifier: BSD-3-Clause
 
 template <typename ValueType, typename IndexType>
 void simple_apply(std::shared_ptr<const DefaultExecutor> exec,

--- a/common/cuda_hip/matrix/batch_csr_kernel_launcher.hpp.inc
+++ b/common/cuda_hip/matrix/batch_csr_kernel_launcher.hpp.inc
@@ -1,0 +1,53 @@
+/*******************************<GINKGO LICENSE>******************************
+Copyright (c) 2017-2023, the Ginkgo authors
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+******************************<GINKGO LICENSE>*******************************/
+
+template <typename ValueType, typename IndexType>
+void simple_apply(std::shared_ptr<const DefaultExecutor> exec,
+                  const batch::matrix::Csr<ValueType, IndexType>* mat,
+                  const batch::MultiVector<ValueType>* b,
+                  batch::MultiVector<ValueType>* x) GKO_NOT_IMPLEMENTED;
+
+
+GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INT32_TYPE(
+    GKO_DECLARE_BATCH_CSR_SIMPLE_APPLY_KERNEL);
+
+
+template <typename ValueType, typename IndexType>
+void advanced_apply(std::shared_ptr<const DefaultExecutor> exec,
+                    const batch::MultiVector<ValueType>* alpha,
+                    const batch::matrix::Csr<ValueType, IndexType>* mat,
+                    const batch::MultiVector<ValueType>* b,
+                    const batch::MultiVector<ValueType>* beta,
+                    batch::MultiVector<ValueType>* x) GKO_NOT_IMPLEMENTED;
+
+GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INT32_TYPE(
+    GKO_DECLARE_BATCH_CSR_ADVANCED_APPLY_KERNEL);

--- a/common/cuda_hip/matrix/batch_csr_kernel_launcher.hpp.inc
+++ b/common/cuda_hip/matrix/batch_csr_kernel_launcher.hpp.inc
@@ -1,4 +1,3 @@
-// Copyright (c) 2017-2023, the Ginkgo authors
 // SPDX-FileCopyrightText: 2017-2023 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause

--- a/common/cuda_hip/matrix/batch_csr_kernels.hpp.inc
+++ b/common/cuda_hip/matrix/batch_csr_kernels.hpp.inc
@@ -1,35 +1,7 @@
-/*******************************<GINKGO LICENSE>******************************
-Copyright (c) 2017-2023, the Ginkgo authors
-All rights reserved.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions
-are met:
-
-1. Redistributions of source code must retain the above copyright
-notice, this list of conditions and the following disclaimer.
-
-2. Redistributions in binary form must reproduce the above copyright
-notice, this list of conditions and the following disclaimer in the
-documentation and/or other materials provided with the distribution.
-
-3. Neither the name of the copyright holder nor the names of its
-contributors may be used to endorse or promote products derived from
-this software without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
-IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
-TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-******************************<GINKGO LICENSE>*******************************/
-
+// Copyright (c) 2017-2023, the Ginkgo authors
+// SPDX-FileCopyrightText: 2017-2023 The Ginkgo authors
+//
+// SPDX-License-Identifier: BSD-3-Clause
 
 template <typename ValueType, typename IndexType>
 __device__ __forceinline__ void simple_apply(

--- a/common/cuda_hip/matrix/batch_csr_kernels.hpp.inc
+++ b/common/cuda_hip/matrix/batch_csr_kernels.hpp.inc
@@ -39,14 +39,13 @@ __device__ __forceinline__ void simple_apply(
     const auto num_rows = mat.num_rows;
     const auto val = mat.values;
     const auto col = mat.col_idxs;
-    for (int tidx = threadIdx.x; tidx < num_rows; tidx += blockDim.x) {
+    for (int row = threadIdx.x; row < num_rows; row += blockDim.x) {
         auto temp = zero<ValueType>();
-        for (auto nnz = mat.row_ptrs[tidx]; nnz < mat.row_ptrs[tidx + 1];
-             nnz++) {
+        for (auto nnz = mat.row_ptrs[row]; nnz < mat.row_ptrs[row + 1]; nnz++) {
             const auto col_idx = col[nnz];
             temp += val[nnz] * b[col_idx];
         }
-        x[tidx] = temp;
+        x[row] = temp;
     }
 }
 
@@ -90,14 +89,13 @@ __device__ __forceinline__ void advanced_apply(
     const auto num_rows = mat.num_rows;
     const auto val = mat.values;
     const auto col = mat.col_idxs;
-    for (int tidx = threadIdx.x; tidx < num_rows; tidx += blockDim.x) {
+    for (int row = threadIdx.x; row < num_rows; row += blockDim.x) {
         auto temp = zero<ValueType>();
-        for (auto nnz = mat.row_ptrs[tidx]; nnz < mat.row_ptrs[tidx + 1];
-             nnz++) {
+        for (auto nnz = mat.row_ptrs[row]; nnz < mat.row_ptrs[row + 1]; nnz++) {
             const auto col_idx = col[nnz];
             temp += alpha * val[nnz] * b[col_idx];
         }
-        x[tidx] = temp + beta * x[tidx];
+        x[row] = temp + beta * x[row];
     }
 }
 

--- a/common/cuda_hip/matrix/batch_csr_kernels.hpp.inc
+++ b/common/cuda_hip/matrix/batch_csr_kernels.hpp.inc
@@ -1,0 +1,144 @@
+/*******************************<GINKGO LICENSE>******************************
+Copyright (c) 2017-2023, the Ginkgo authors
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+******************************<GINKGO LICENSE>*******************************/
+
+
+template <typename ValueType, typename IndexType>
+__device__ __forceinline__ void simple_apply(
+    const gko::batch::matrix::csr::batch_item<const ValueType, IndexType>& mat,
+    const ValueType* const __restrict__ b, ValueType* const __restrict__ x)
+{
+    const auto num_rows = mat.num_rows;
+    const auto val = mat.values;
+    const auto col = mat.col_idxs;
+    for (int tidx = threadIdx.x; tidx < num_rows; tidx += blockDim.x) {
+        auto temp = zero<ValueType>();
+        for (auto nnz = mat.row_ptrs[tidx]; nnz < mat.row_ptrs[tidx + 1];
+             nnz++) {
+            const auto col_idx = col[nnz];
+            temp += val[nnz] * b[col_idx];
+        }
+        x[tidx] = temp;
+    }
+}
+
+template <typename ValueType, typename IndexType>
+__global__ __launch_bounds__(
+    default_block_size,
+    sm_oversubscription) void simple_apply_kernel(const gko::batch::matrix::
+                                                      csr::uniform_batch<
+                                                          const ValueType,
+                                                          IndexType>
+                                                          mat,
+                                                  const gko::batch::
+                                                      multi_vector::
+                                                          uniform_batch<
+                                                              const ValueType>
+                                                              b,
+                                                  const gko::batch::
+                                                      multi_vector::
+                                                          uniform_batch<
+                                                              ValueType>
+                                                              x)
+{
+    for (size_type batch_id = blockIdx.x; batch_id < mat.num_batch_items;
+         batch_id += gridDim.x) {
+        const auto mat_b =
+            gko::batch::matrix::extract_batch_item(mat, batch_id);
+        const auto b_b = gko::batch::extract_batch_item(b, batch_id);
+        const auto x_b = gko::batch::extract_batch_item(x, batch_id);
+        simple_apply(mat_b, b_b.values, x_b.values);
+    }
+}
+
+
+template <typename ValueType, typename IndexType>
+__device__ __forceinline__ void advanced_apply(
+    const ValueType alpha,
+    const gko::batch::matrix::csr::batch_item<const ValueType, IndexType>& mat,
+    const ValueType* const __restrict__ b, const ValueType beta,
+    ValueType* const __restrict__ x)
+{
+    const auto num_rows = mat.num_rows;
+    const auto val = mat.values;
+    const auto col = mat.col_idxs;
+    for (int tidx = threadIdx.x; tidx < num_rows; tidx += blockDim.x) {
+        auto temp = zero<ValueType>();
+        for (auto nnz = mat.row_ptrs[tidx]; nnz < mat.row_ptrs[tidx + 1];
+             nnz++) {
+            const auto col_idx = col[nnz];
+            temp += alpha * val[nnz] * b[col_idx];
+        }
+        x[tidx] = temp + beta * x[tidx];
+    }
+}
+
+template <typename ValueType, typename IndexType>
+__global__ __launch_bounds__(
+    default_block_size,
+    sm_oversubscription) void advanced_apply_kernel(const gko::batch::
+                                                        multi_vector::
+                                                            uniform_batch<
+                                                                const ValueType>
+                                                                alpha,
+                                                    const gko::batch::matrix::
+                                                        csr::uniform_batch<
+                                                            const ValueType,
+                                                            IndexType>
+                                                            mat,
+                                                    const gko::batch::
+                                                        multi_vector::
+                                                            uniform_batch<
+                                                                const ValueType>
+                                                                b,
+                                                    const gko::batch::
+                                                        multi_vector::
+                                                            uniform_batch<
+                                                                const ValueType>
+                                                                beta,
+                                                    const gko::batch::
+                                                        multi_vector::
+                                                            uniform_batch<
+                                                                ValueType>
+                                                                x)
+{
+    for (size_type batch_id = blockIdx.x; batch_id < mat.num_batch_items;
+         batch_id += gridDim.x) {
+        const auto mat_b =
+            gko::batch::matrix::extract_batch_item(mat, batch_id);
+        const auto b_b = gko::batch::extract_batch_item(b, batch_id);
+        const auto x_b = gko::batch::extract_batch_item(x, batch_id);
+        const auto alpha_b = gko::batch::extract_batch_item(alpha, batch_id);
+        const auto beta_b = gko::batch::extract_batch_item(beta, batch_id);
+        advanced_apply(alpha_b.values[0], mat_b, b_b.values, beta_b.values[0],
+                       x_b.values);
+    }
+}

--- a/common/cuda_hip/matrix/batch_csr_kernels.hpp.inc
+++ b/common/cuda_hip/matrix/batch_csr_kernels.hpp.inc
@@ -1,4 +1,3 @@
-// Copyright (c) 2017-2023, the Ginkgo authors
 // SPDX-FileCopyrightText: 2017-2023 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -40,6 +40,7 @@ target_sources(ginkgo
     log/vtune.cpp
     log/record.cpp
     log/stream.cpp
+    matrix/batch_csr.cpp
     matrix/batch_dense.cpp
     matrix/batch_ell.cpp
     matrix/batch_identity.cpp

--- a/core/device_hooks/common_kernels.inc.cpp
+++ b/core/device_hooks/common_kernels.inc.cpp
@@ -29,6 +29,7 @@
 #include "core/factorization/par_ict_kernels.hpp"
 #include "core/factorization/par_ilu_kernels.hpp"
 #include "core/factorization/par_ilut_kernels.hpp"
+#include "core/matrix/batch_csr_kernels.hpp"
 #include "core/matrix/batch_dense_kernels.hpp"
 #include "core/matrix/batch_ell_kernels.hpp"
 #include "core/matrix/coo_kernels.hpp"
@@ -279,6 +280,16 @@ GKO_STUB_VALUE_TYPE(GKO_DECLARE_BATCH_MULTI_VECTOR_COPY_KERNEL);
 
 
 }  // namespace batch_multi_vector
+
+
+namespace batch_csr {
+
+
+GKO_STUB_VALUE_AND_INT32_TYPE(GKO_DECLARE_BATCH_CSR_SIMPLE_APPLY_KERNEL);
+GKO_STUB_VALUE_AND_INT32_TYPE(GKO_DECLARE_BATCH_CSR_ADVANCED_APPLY_KERNEL);
+
+
+}  // namespace batch_csr
 
 
 namespace batch_dense {

--- a/core/matrix/batch_csr.cpp
+++ b/core/matrix/batch_csr.cpp
@@ -1,34 +1,6 @@
-/*******************************<GINKGO LICENSE>******************************
-Copyright (c) 2017-2023, the Ginkgo authors
-All rights reserved.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions
-are met:
-
-1. Redistributions of source code must retain the above copyright
-notice, this list of conditions and the following disclaimer.
-
-2. Redistributions in binary form must reproduce the above copyright
-notice, this list of conditions and the following disclaimer in the
-documentation and/or other materials provided with the distribution.
-
-3. Neither the name of the copyright holder nor the names of its
-contributors may be used to endorse or promote products derived from
-this software without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
-IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
-TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-******************************<GINKGO LICENSE>*******************************/
+// SPDX-FileCopyrightText: 2017-2023 The Ginkgo authors
+//
+// SPDX-License-Identifier: BSD-3-Clause
 
 #include <ginkgo/core/matrix/batch_csr.hpp>
 

--- a/core/matrix/batch_csr.cpp
+++ b/core/matrix/batch_csr.cpp
@@ -1,0 +1,237 @@
+/*******************************<GINKGO LICENSE>******************************
+Copyright (c) 2017-2023, the Ginkgo authors
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+******************************<GINKGO LICENSE>*******************************/
+
+#include <ginkgo/core/matrix/batch_csr.hpp>
+
+
+#include <algorithm>
+#include <type_traits>
+
+
+#include <ginkgo/core/base/array.hpp>
+#include <ginkgo/core/base/exception.hpp>
+#include <ginkgo/core/base/exception_helpers.hpp>
+#include <ginkgo/core/base/executor.hpp>
+#include <ginkgo/core/base/math.hpp>
+#include <ginkgo/core/base/utils.hpp>
+#include <ginkgo/core/matrix/csr.hpp>
+
+
+#include "core/matrix/batch_csr_kernels.hpp"
+
+
+namespace gko {
+namespace batch {
+namespace matrix {
+namespace csr {
+namespace {
+
+
+GKO_REGISTER_OPERATION(simple_apply, batch_csr::simple_apply);
+GKO_REGISTER_OPERATION(advanced_apply, batch_csr::advanced_apply);
+
+
+}  // namespace
+}  // namespace csr
+
+
+template <typename ValueType, typename IndexType>
+std::unique_ptr<gko::matrix::Csr<ValueType, IndexType>>
+Csr<ValueType, IndexType>::create_view_for_item(size_type item_id)
+{
+    auto exec = this->get_executor();
+    auto num_rows = this->get_common_size()[0];
+    auto mat = unbatch_type::create(
+        exec, this->get_common_size(),
+        make_array_view(exec, this->get_num_elements_per_item(),
+                        this->get_values_for_item(item_id)),
+        make_array_view(exec, this->get_num_elements_per_item(),
+                        this->get_col_idxs()),
+        make_array_view(exec, num_rows + 1, this->get_row_ptrs()));
+    return mat;
+}
+
+
+template <typename ValueType, typename IndexType>
+std::unique_ptr<const gko::matrix::Csr<ValueType, IndexType>>
+Csr<ValueType, IndexType>::create_const_view_for_item(size_type item_id) const
+{
+    auto exec = this->get_executor();
+    auto num_rows = this->get_common_size()[0];
+    auto mat = unbatch_type::create_const(
+        exec, this->get_common_size(),
+        make_const_array_view(exec, this->get_num_elements_per_item(),
+                              this->get_const_values_for_item(item_id)),
+        make_const_array_view(exec, this->get_num_elements_per_item(),
+                              this->get_const_col_idxs()),
+        make_const_array_view(exec, num_rows + 1, this->get_const_row_ptrs()));
+    return mat;
+}
+
+
+template <typename ValueType, typename IndexType>
+std::unique_ptr<const Csr<ValueType, IndexType>>
+Csr<ValueType, IndexType>::create_const(
+    std::shared_ptr<const Executor> exec, const batch_dim<2>& sizes,
+    gko::detail::const_array_view<ValueType>&& values,
+    gko::detail::const_array_view<IndexType>&& col_idxs,
+    gko::detail::const_array_view<IndexType>&& row_ptrs)
+{
+    // cast const-ness away, but return a const object afterwards,
+    // so we can ensure that no modifications take place.
+    return std::unique_ptr<const Csr>(
+        new Csr{exec, sizes, gko::detail::array_const_cast(std::move(values)),
+                gko::detail::array_const_cast(std::move(col_idxs)),
+                gko::detail::array_const_cast(std::move(row_ptrs))});
+}
+
+
+template <typename ValueType, typename IndexType>
+Csr<ValueType, IndexType>::Csr(std::shared_ptr<const Executor> exec,
+                               const batch_dim<2>& size,
+                               size_type num_nnz_per_item)
+    : EnableBatchLinOp<Csr<ValueType, IndexType>>(exec, size),
+      values_(exec, num_nnz_per_item * size.get_num_batch_items()),
+      col_idxs_(exec, num_nnz_per_item),
+      row_ptrs_(exec, size.get_common_size()[0] + 1)
+{
+    row_ptrs_.fill(0);
+}
+
+
+template <typename ValueType, typename IndexType>
+Csr<ValueType, IndexType>* Csr<ValueType, IndexType>::apply(
+    ptr_param<const MultiVector<ValueType>> b,
+    ptr_param<MultiVector<ValueType>> x)
+{
+    this->validate_application_parameters(b.get(), x.get());
+    auto exec = this->get_executor();
+    this->apply_impl(make_temporary_clone(exec, b).get(),
+                     make_temporary_clone(exec, x).get());
+    return this;
+}
+
+
+template <typename ValueType, typename IndexType>
+const Csr<ValueType, IndexType>* Csr<ValueType, IndexType>::apply(
+    ptr_param<const MultiVector<ValueType>> b,
+    ptr_param<MultiVector<ValueType>> x) const
+{
+    this->validate_application_parameters(b.get(), x.get());
+    auto exec = this->get_executor();
+    this->apply_impl(make_temporary_clone(exec, b).get(),
+                     make_temporary_clone(exec, x).get());
+    return this;
+}
+
+
+template <typename ValueType, typename IndexType>
+Csr<ValueType, IndexType>* Csr<ValueType, IndexType>::apply(
+    ptr_param<const MultiVector<ValueType>> alpha,
+    ptr_param<const MultiVector<ValueType>> b,
+    ptr_param<const MultiVector<ValueType>> beta,
+    ptr_param<MultiVector<ValueType>> x)
+{
+    this->validate_application_parameters(alpha.get(), b.get(), beta.get(),
+                                          x.get());
+    auto exec = this->get_executor();
+    this->apply_impl(make_temporary_clone(exec, alpha).get(),
+                     make_temporary_clone(exec, b).get(),
+                     make_temporary_clone(exec, beta).get(),
+                     make_temporary_clone(exec, x).get());
+    return this;
+}
+
+
+template <typename ValueType, typename IndexType>
+const Csr<ValueType, IndexType>* Csr<ValueType, IndexType>::apply(
+    ptr_param<const MultiVector<ValueType>> alpha,
+    ptr_param<const MultiVector<ValueType>> b,
+    ptr_param<const MultiVector<ValueType>> beta,
+    ptr_param<MultiVector<ValueType>> x) const
+{
+    this->validate_application_parameters(alpha.get(), b.get(), beta.get(),
+                                          x.get());
+    auto exec = this->get_executor();
+    this->apply_impl(make_temporary_clone(exec, alpha).get(),
+                     make_temporary_clone(exec, b).get(),
+                     make_temporary_clone(exec, beta).get(),
+                     make_temporary_clone(exec, x).get());
+    return this;
+}
+
+
+template <typename ValueType, typename IndexType>
+void Csr<ValueType, IndexType>::apply_impl(const MultiVector<ValueType>* b,
+                                           MultiVector<ValueType>* x) const
+{
+    this->get_executor()->run(csr::make_simple_apply(this, b, x));
+}
+
+
+template <typename ValueType, typename IndexType>
+void Csr<ValueType, IndexType>::apply_impl(const MultiVector<ValueType>* alpha,
+                                           const MultiVector<ValueType>* b,
+                                           const MultiVector<ValueType>* beta,
+                                           MultiVector<ValueType>* x) const
+{
+    this->get_executor()->run(
+        csr::make_advanced_apply(alpha, this, b, beta, x));
+}
+
+
+template <typename ValueType, typename IndexType>
+void Csr<ValueType, IndexType>::convert_to(
+    Csr<next_precision<ValueType>, IndexType>* result) const
+{
+    result->values_ = this->values_;
+    result->col_idxs_ = this->col_idxs_;
+    result->row_ptrs_ = this->row_ptrs_;
+    result->set_size(this->get_size());
+}
+
+
+template <typename ValueType, typename IndexType>
+void Csr<ValueType, IndexType>::move_to(
+    Csr<next_precision<ValueType>, IndexType>* result)
+{
+    this->convert_to(result);
+}
+
+
+#define GKO_DECLARE_BATCH_CSR_MATRIX(ValueType) class Csr<ValueType, int32>
+GKO_INSTANTIATE_FOR_EACH_VALUE_TYPE(GKO_DECLARE_BATCH_CSR_MATRIX);
+
+
+}  // namespace matrix
+}  // namespace batch
+}  // namespace gko

--- a/core/matrix/batch_csr_kernels.hpp
+++ b/core/matrix/batch_csr_kernels.hpp
@@ -1,45 +1,15 @@
-/*******************************<GINKGO LICENSE>******************************
-Copyright (c) 2017-2023, the Ginkgo authors
-All rights reserved.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions
-are met:
-
-1. Redistributions of source code must retain the above copyright
-notice, this list of conditions and the following disclaimer.
-
-2. Redistributions in binary form must reproduce the above copyright
-notice, this list of conditions and the following disclaimer in the
-documentation and/or other materials provided with the distribution.
-
-3. Neither the name of the copyright holder nor the names of its
-contributors may be used to endorse or promote products derived from
-this software without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
-IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
-TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-******************************<GINKGO LICENSE>*******************************/
+// SPDX-FileCopyrightText: 2017-2023 The Ginkgo authors
+//
+// SPDX-License-Identifier: BSD-3-Clause
 
 #ifndef GKO_CORE_MATRIX_BATCH_CSR_KERNELS_HPP_
 #define GKO_CORE_MATRIX_BATCH_CSR_KERNELS_HPP_
 
 
-#include <ginkgo/core/matrix/batch_csr.hpp>
-
-
 #include <ginkgo/core/base/batch_multi_vector.hpp>
 #include <ginkgo/core/base/math.hpp>
 #include <ginkgo/core/base/types.hpp>
+#include <ginkgo/core/matrix/batch_csr.hpp>
 
 
 #include "core/base/kernel_declaration.hpp"

--- a/core/matrix/batch_csr_kernels.hpp
+++ b/core/matrix/batch_csr_kernels.hpp
@@ -6,10 +6,12 @@
 #define GKO_CORE_MATRIX_BATCH_CSR_KERNELS_HPP_
 
 
+#include <ginkgo/core/matrix/batch_csr.hpp>
+
+
 #include <ginkgo/core/base/batch_multi_vector.hpp>
 #include <ginkgo/core/base/math.hpp>
 #include <ginkgo/core/base/types.hpp>
-#include <ginkgo/core/matrix/batch_csr.hpp>
 
 
 #include "core/base/kernel_declaration.hpp"

--- a/core/matrix/batch_csr_kernels.hpp
+++ b/core/matrix/batch_csr_kernels.hpp
@@ -1,0 +1,84 @@
+/*******************************<GINKGO LICENSE>******************************
+Copyright (c) 2017-2023, the Ginkgo authors
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+******************************<GINKGO LICENSE>*******************************/
+
+#ifndef GKO_CORE_MATRIX_BATCH_CSR_KERNELS_HPP_
+#define GKO_CORE_MATRIX_BATCH_CSR_KERNELS_HPP_
+
+
+#include <ginkgo/core/matrix/batch_csr.hpp>
+
+
+#include <ginkgo/core/base/batch_multi_vector.hpp>
+#include <ginkgo/core/base/math.hpp>
+#include <ginkgo/core/base/types.hpp>
+
+
+#include "core/base/kernel_declaration.hpp"
+
+
+namespace gko {
+namespace kernels {
+
+
+#define GKO_DECLARE_BATCH_CSR_SIMPLE_APPLY_KERNEL(_vtype, _itype)  \
+    void simple_apply(std::shared_ptr<const DefaultExecutor> exec, \
+                      const batch::matrix::Csr<_vtype, _itype>* a, \
+                      const batch::MultiVector<_vtype>* b,         \
+                      batch::MultiVector<_vtype>* c)
+
+#define GKO_DECLARE_BATCH_CSR_ADVANCED_APPLY_KERNEL(_vtype, _itype)  \
+    void advanced_apply(std::shared_ptr<const DefaultExecutor> exec, \
+                        const batch::MultiVector<_vtype>* alpha,     \
+                        const batch::matrix::Csr<_vtype, _itype>* a, \
+                        const batch::MultiVector<_vtype>* b,         \
+                        const batch::MultiVector<_vtype>* beta,      \
+                        batch::MultiVector<_vtype>* c)
+
+#define GKO_DECLARE_ALL_AS_TEMPLATES                                 \
+    template <typename ValueType, typename IndexType>                \
+    GKO_DECLARE_BATCH_CSR_SIMPLE_APPLY_KERNEL(ValueType, IndexType); \
+    template <typename ValueType, typename IndexType>                \
+    GKO_DECLARE_BATCH_CSR_ADVANCED_APPLY_KERNEL(ValueType, IndexType)
+
+
+GKO_DECLARE_FOR_ALL_EXECUTOR_NAMESPACES(batch_csr,
+                                        GKO_DECLARE_ALL_AS_TEMPLATES);
+
+
+#undef GKO_DECLARE_ALL_AS_TEMPLATES
+
+
+}  // namespace kernels
+}  // namespace gko
+
+
+#endif  // GKO_CORE_MATRIX_BATCH_CSR_KERNELS_HPP_

--- a/core/matrix/batch_struct.hpp
+++ b/core/matrix/batch_struct.hpp
@@ -30,7 +30,6 @@ struct batch_item {
     ValueType* values;
     const index_type* col_idxs;
     const index_type* row_ptrs;
-    index_type stride;
     index_type num_rows;
     index_type num_cols;
 };
@@ -49,7 +48,6 @@ struct uniform_batch {
     const index_type* col_idxs;
     const index_type* row_ptrs;
     size_type num_batch_items;
-    index_type stride;
     index_type num_rows;
     index_type num_cols;
     index_type num_nnz_per_item;
@@ -155,7 +153,7 @@ template <typename ValueType, typename IndexType>
 GKO_ATTRIBUTES GKO_INLINE csr::batch_item<const ValueType, const IndexType>
 to_const(const csr::batch_item<ValueType, IndexType>& b)
 {
-    return {b.values, b.col_idxs, b.row_ptrs, b.stride, b.num_rows, b.num_cols};
+    return {b.values, b.col_idxs, b.row_ptrs, b.num_rows, b.num_cols};
 }
 
 
@@ -163,8 +161,8 @@ template <typename ValueType, typename IndexType>
 GKO_ATTRIBUTES GKO_INLINE csr::uniform_batch<const ValueType, const IndexType>
 to_const(const csr::uniform_batch<ValueType, IndexType>& ub)
 {
-    return {ub.values, ub.col_idxs, ub.row_ptrs, ub.num_batch_items,
-            ub.stride, ub.num_rows, ub.num_cols, ub.num_nnz_per_item};
+    return {ub.values,   ub.col_idxs, ub.row_ptrs,        ub.num_batch_items,
+            ub.num_rows, ub.num_cols, ub.num_nnz_per_item};
 }
 
 
@@ -173,28 +171,20 @@ GKO_ATTRIBUTES GKO_INLINE csr::batch_item<ValueType, IndexType>
 extract_batch_item(const csr::uniform_batch<ValueType, IndexType>& batch,
                    const size_type batch_idx)
 {
-    return {batch.values + batch_idx * batch.num_nnz_per_item,
-            batch.col_idxs,
-            batch.row_ptrs,
-            batch.stride,
-            batch.num_rows,
-            batch.num_cols};
+    return {batch.values + batch_idx * batch.num_nnz_per_item, batch.col_idxs,
+            batch.row_ptrs, batch.num_rows, batch.num_cols};
 }
 
 template <typename ValueType, typename IndexType>
 GKO_ATTRIBUTES GKO_INLINE csr::batch_item<ValueType, IndexType>
 extract_batch_item(ValueType* const batch_values,
                    IndexType* const batch_col_idxs,
-                   IndexType* const batch_row_ptrs, const int stride,
-                   const int num_rows, const int num_cols, int num_nnz_per_item,
+                   IndexType* const batch_row_ptrs, const int num_rows,
+                   const int num_cols, int num_nnz_per_item,
                    const size_type batch_idx)
 {
-    return {batch_values + batch_idx * num_nnz_per_item,
-            batch_col_idxs,
-            batch_row_ptrs,
-            stride,
-            num_rows,
-            num_cols};
+    return {batch_values + batch_idx * num_nnz_per_item, batch_col_idxs,
+            batch_row_ptrs, num_rows, num_cols};
 }
 
 

--- a/core/matrix/batch_struct.hpp
+++ b/core/matrix/batch_struct.hpp
@@ -8,6 +8,7 @@
 
 #include <ginkgo/core/base/array.hpp>
 #include <ginkgo/core/base/types.hpp>
+#include <ginkgo/core/matrix/batch_csr.hpp>
 #include <ginkgo/core/matrix/batch_dense.hpp>
 #include <ginkgo/core/matrix/batch_ell.hpp>
 
@@ -15,6 +16,54 @@
 namespace gko {
 namespace batch {
 namespace matrix {
+namespace csr {
+
+
+/**
+ * Encapsulates one matrix from a batch of csr matrices.
+ */
+template <typename ValueType, typename IndexType>
+struct batch_item {
+    using value_type = ValueType;
+    using index_type = IndexType;
+
+    ValueType* values;
+    const index_type* col_idxs;
+    const index_type* row_ptrs;
+    index_type stride;
+    index_type num_rows;
+    index_type num_cols;
+};
+
+
+/**
+ * A 'simple' structure to store a global uniform batch of csr matrices.
+ */
+template <typename ValueType, typename IndexType>
+struct uniform_batch {
+    using value_type = ValueType;
+    using index_type = IndexType;
+    using entry_type = batch_item<value_type, index_type>;
+
+    ValueType* values;
+    const index_type* col_idxs;
+    const index_type* row_ptrs;
+    size_type num_batch_items;
+    index_type stride;
+    index_type num_rows;
+    index_type num_cols;
+    index_type num_nnz_per_item;
+
+    inline size_type get_single_item_num_nnz() const
+    {
+        return static_cast<size_type>(num_nnz_per_item);
+    }
+};
+
+
+}  // namespace csr
+
+
 namespace dense {
 
 
@@ -100,6 +149,53 @@ struct uniform_batch {
 
 
 }  // namespace ell
+
+
+template <typename ValueType, typename IndexType>
+GKO_ATTRIBUTES GKO_INLINE csr::batch_item<const ValueType, const IndexType>
+to_const(const csr::batch_item<ValueType, IndexType>& b)
+{
+    return {b.values, b.col_idxs, b.row_ptrs, b.stride, b.num_rows, b.num_cols};
+}
+
+
+template <typename ValueType, typename IndexType>
+GKO_ATTRIBUTES GKO_INLINE csr::uniform_batch<const ValueType, const IndexType>
+to_const(const csr::uniform_batch<ValueType, IndexType>& ub)
+{
+    return {ub.values, ub.col_idxs, ub.row_ptrs, ub.num_batch_items,
+            ub.stride, ub.num_rows, ub.num_cols, ub.num_nnz_per_item};
+}
+
+
+template <typename ValueType, typename IndexType>
+GKO_ATTRIBUTES GKO_INLINE csr::batch_item<ValueType, IndexType>
+extract_batch_item(const csr::uniform_batch<ValueType, IndexType>& batch,
+                   const size_type batch_idx)
+{
+    return {batch.values + batch_idx * batch.num_nnz_per_item,
+            batch.col_idxs,
+            batch.row_ptrs,
+            batch.stride,
+            batch.num_rows,
+            batch.num_cols};
+}
+
+template <typename ValueType, typename IndexType>
+GKO_ATTRIBUTES GKO_INLINE csr::batch_item<ValueType, IndexType>
+extract_batch_item(ValueType* const batch_values,
+                   IndexType* const batch_col_idxs,
+                   IndexType* const batch_row_ptrs, const int stride,
+                   const int num_rows, const int num_cols, int num_nnz_per_item,
+                   const size_type batch_idx)
+{
+    return {batch_values + batch_idx * num_nnz_per_item,
+            batch_col_idxs,
+            batch_row_ptrs,
+            stride,
+            num_rows,
+            num_cols};
+}
 
 
 template <typename ValueType>

--- a/core/matrix/csr.cpp
+++ b/core/matrix/csr.cpp
@@ -485,8 +485,9 @@ void Csr<ValueType, IndexType>::read(device_mat_data&& data)
     auto arrays = data.empty_out();
     this->row_ptrs_.resize_and_reset(size[0] + 1);
     this->set_size(size);
-    this->values_ = std::move(arrays.values);
-    this->col_idxs_ = std::move(arrays.col_idxs);
+    // Need to copy instead of move, as move into view data is not supported.
+    this->values_ = arrays.values;
+    this->col_idxs_ = arrays.col_idxs;
     const auto row_idxs = std::move(arrays.row_idxs);
     auto local_row_idxs = make_temporary_clone(exec, &row_idxs);
     exec->run(csr::make_convert_idxs_to_ptrs(local_row_idxs->get_const_data(),

--- a/core/matrix/csr.cpp
+++ b/core/matrix/csr.cpp
@@ -489,7 +489,7 @@ void Csr<ValueType, IndexType>::read(device_mat_data&& data)
     if (this->values_.is_owning()) {
         this->values_ = std::move(arrays.values);
     } else {
-        if (this->values_.get_num_elems() == arrays.values.get_num_elems()) {
+        if (this->values_.get_size() == arrays.values.get_size()) {
             this->values_ = arrays.values;
         } else {
             GKO_INVALID_STATE("Input values view is of incorrect size!");
@@ -498,8 +498,7 @@ void Csr<ValueType, IndexType>::read(device_mat_data&& data)
     if (this->col_idxs_.is_owning()) {
         this->col_idxs_ = std::move(arrays.col_idxs);
     } else {
-        if (this->col_idxs_.get_num_elems() ==
-            arrays.col_idxs.get_num_elems()) {
+        if (this->col_idxs_.get_size() == arrays.col_idxs.get_size()) {
             this->col_idxs_ = arrays.col_idxs;
         } else {
             GKO_INVALID_STATE("Input col_idxs view is of incorrect size!");

--- a/core/matrix/csr.cpp
+++ b/core/matrix/csr.cpp
@@ -485,25 +485,8 @@ void Csr<ValueType, IndexType>::read(device_mat_data&& data)
     auto arrays = data.empty_out();
     this->row_ptrs_.resize_and_reset(size[0] + 1);
     this->set_size(size);
-    // Need to copy instead of move, as move into view data is not supported.
-    if (this->values_.is_owning()) {
-        this->values_ = std::move(arrays.values);
-    } else {
-        if (this->values_.get_size() == arrays.values.get_size()) {
-            this->values_ = arrays.values;
-        } else {
-            GKO_INVALID_STATE("Input values view is of incorrect size!");
-        }
-    }
-    if (this->col_idxs_.is_owning()) {
-        this->col_idxs_ = std::move(arrays.col_idxs);
-    } else {
-        if (this->col_idxs_.get_size() == arrays.col_idxs.get_size()) {
-            this->col_idxs_ = arrays.col_idxs;
-        } else {
-            GKO_INVALID_STATE("Input col_idxs view is of incorrect size!");
-        }
-    }
+    this->values_ = std::move(arrays.values);
+    this->col_idxs_ = std::move(arrays.col_idxs);
     const auto row_idxs = std::move(arrays.row_idxs);
     auto local_row_idxs = make_temporary_clone(exec, &row_idxs);
     exec->run(csr::make_convert_idxs_to_ptrs(local_row_idxs->get_const_data(),

--- a/core/solver/batch_dispatch.hpp
+++ b/core/solver/batch_dispatch.hpp
@@ -261,6 +261,10 @@ public:
                            mat_)) {
             auto mat_item = device::get_batch_struct(batch_mat);
             dispatch_on_logger(mat_item, b_item, x_item, log_data);
+        } else if (auto batch_mat = dynamic_cast<
+                       const batch::matrix::Csr<ValueType, int32>*>(mat_)) {
+            auto mat_item = device::get_batch_struct(batch_mat);
+            dispatch_on_logger(mat_item, b_item, x_item, log_data);
         } else {
             GKO_NOT_SUPPORTED(mat_);
         }

--- a/core/test/matrix/CMakeLists.txt
+++ b/core/test/matrix/CMakeLists.txt
@@ -1,3 +1,4 @@
+ginkgo_create_test(batch_csr)
 ginkgo_create_test(batch_dense)
 ginkgo_create_test(batch_ell)
 ginkgo_create_test(batch_identity)

--- a/core/test/matrix/batch_csr.cpp
+++ b/core/test/matrix/batch_csr.cpp
@@ -301,7 +301,7 @@ TYPED_TEST(Csr, CanBeConstructedFromCsrMatricesByDuplication)
     auto m =
         gko::batch::create_from_item<BatchCsrMtx>(this->exec, 3, mat1.get(), 2);
 
-    GKO_ASSERT_BATCH_MTX_NEAR(bat_m.get(), m.get(), 1e-14);
+    GKO_ASSERT_BATCH_MTX_NEAR(bat_m.get(), m.get(), 0.);
 }
 
 
@@ -324,7 +324,7 @@ TYPED_TEST(Csr, CanBeConstructedByDuplicatingCsrMatrices)
 
     auto m2 = gko::batch::duplicate<BatchCsrMtx>(this->exec, 3, m.get(), 2);
 
-    GKO_ASSERT_BATCH_MTX_NEAR(m2.get(), m_ref.get(), 1e-14);
+    GKO_ASSERT_BATCH_MTX_NEAR(m2.get(), m_ref.get(), 0.);
 }
 
 
@@ -349,7 +349,6 @@ TYPED_TEST(Csr, CanBeListConstructed)
     using value_type = typename TestFixture::value_type;
     using index_type = typename TestFixture::index_type;
     using BatchCsrMtx = typename TestFixture::BatchCsrMtx;
-    using CsrMtx = typename TestFixture::CsrMtx;
 
     auto m = gko::batch::initialize<BatchCsrMtx>({{0.0, -1.0}, {0.0, -5.0}},
                                                  this->exec, 1);
@@ -452,7 +451,6 @@ TYPED_TEST(Csr, ThrowsForDataWithDifferentNnz)
 {
     using value_type = typename TestFixture::value_type;
     using index_type = typename TestFixture::index_type;
-    using BatchCsrMtx = typename TestFixture::BatchCsrMtx;
     auto vec_data = std::vector<gko::matrix_data<value_type, index_type>>{};
     vec_data.emplace_back(
         gko::matrix_data<value_type, index_type>({2, 3}, {
@@ -474,7 +472,6 @@ TYPED_TEST(Csr, ThrowsForDataWithDifferentSparsity)
 {
     using value_type = typename TestFixture::value_type;
     using index_type = typename TestFixture::index_type;
-    using BatchCsrMtx = typename TestFixture::BatchCsrMtx;
     auto vec_data = std::vector<gko::matrix_data<value_type, index_type>>{};
     vec_data.emplace_back(
         gko::matrix_data<value_type, index_type>({2, 3}, {

--- a/core/test/matrix/batch_csr.cpp
+++ b/core/test/matrix/batch_csr.cpp
@@ -1,0 +1,549 @@
+/*******************************<GINKGO LICENSE>******************************
+Copyright (c) 2017-2023, the Ginkgo authors
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+******************************<GINKGO LICENSE>*******************************/
+
+#include <ginkgo/core/matrix/batch_csr.hpp>
+
+
+#include <gtest/gtest.h>
+
+
+#include <ginkgo/core/base/batch_multi_vector.hpp>
+#include <ginkgo/core/base/executor.hpp>
+#include <ginkgo/core/matrix/csr.hpp>
+
+
+#include "core/base/batch_utilities.hpp"
+#include "core/test/utils.hpp"
+#include "core/test/utils/batch_helpers.hpp"
+
+
+template <typename T>
+class Csr : public ::testing::Test {
+protected:
+    using value_type = T;
+    using index_type = gko::int32;
+    using BatchCsrMtx = gko::batch::matrix::Csr<value_type, index_type>;
+    using CsrMtx = gko::matrix::Csr<value_type, index_type>;
+    using size_type = gko::size_type;
+    Csr()
+        : exec(gko::ReferenceExecutor::create()),
+          mtx(gko::batch::initialize<BatchCsrMtx>(
+              // clang-format off
+              {{{-1.0, 2.0, 3.0},
+                {-1.5, 2.5, 3.5}},
+               {{1.0, 2.5, 3.0},
+                {1.0, 2.0, 3.0}}},
+              // clang-format on
+              exec, 6)),
+          sp_mtx(gko::batch::initialize<BatchCsrMtx>(
+              // clang-format off
+              {{{-1.0, 0.0, 0.0},
+                {0.0, 2.5, 3.5}},
+               {{1.0, 0.0, 0.0},
+                {0.0, 2.0, 3.0}}},
+              // clang-format on
+              exec, 3)),
+          csr_mtx(gko::initialize<CsrMtx>(
+              // clang-format off
+              {{1.0, 2.5, 3.0},
+               {1.0, 2.0, 3.0}},
+              // clang-format on
+              exec, gko::dim<2>(2, 3))),
+          sp_csr_mtx(gko::initialize<CsrMtx>(
+              // clang-format off
+              {{1.0, 0.0, 0.0},
+               {0.0, 2.0, 3.0}},
+              // clang-format on
+              exec, gko::dim<2>(2, 3)))
+    {}
+
+    static void assert_equal_to_original_sparse_mtx(const BatchCsrMtx* m)
+    {
+        ASSERT_EQ(m->get_num_batch_items(), 2);
+        ASSERT_EQ(m->get_common_size(), gko::dim<2>(2, 3));
+        ASSERT_EQ(m->get_num_stored_elements(), 2 * 3);
+        EXPECT_EQ(m->get_const_values()[0], value_type{-1.0});
+        EXPECT_EQ(m->get_const_values()[1], value_type{2.5});
+        EXPECT_EQ(m->get_const_values()[2], value_type{3.5});
+        EXPECT_EQ(m->get_const_values()[3], value_type{1.0});
+        EXPECT_EQ(m->get_const_values()[4], value_type{2.0});
+        EXPECT_EQ(m->get_const_values()[5], value_type{3.0});
+        EXPECT_EQ(m->get_const_col_idxs()[0], index_type{0});
+        EXPECT_EQ(m->get_const_col_idxs()[1], index_type{1});
+        EXPECT_EQ(m->get_const_col_idxs()[2], index_type{2});
+        EXPECT_EQ(m->get_const_row_ptrs()[0], index_type{0});
+        EXPECT_EQ(m->get_const_row_ptrs()[1], index_type{1});
+        EXPECT_EQ(m->get_const_row_ptrs()[2], index_type{3});
+    }
+
+    static void assert_equal_to_original_mtx(const BatchCsrMtx* m)
+    {
+        ASSERT_EQ(m->get_num_batch_items(), 2);
+        ASSERT_EQ(m->get_common_size(), gko::dim<2>(2, 3));
+        ASSERT_EQ(m->get_num_stored_elements(), 2 * 6);
+        EXPECT_EQ(m->get_const_values()[0], value_type{-1.0});
+        EXPECT_EQ(m->get_const_values()[1], value_type{2.0});
+        EXPECT_EQ(m->get_const_values()[2], value_type{3.0});
+        EXPECT_EQ(m->get_const_values()[3], value_type{-1.5});
+        EXPECT_EQ(m->get_const_values()[4], value_type{2.5});
+        EXPECT_EQ(m->get_const_values()[5], value_type{3.5});
+        EXPECT_EQ(m->get_const_values()[6], value_type{1.0});
+        EXPECT_EQ(m->get_const_values()[7], value_type{2.5});
+        EXPECT_EQ(m->get_const_values()[8], value_type{3.0});
+        EXPECT_EQ(m->get_const_values()[9], value_type{1.0});
+        EXPECT_EQ(m->get_const_values()[10], value_type{2.0});
+        EXPECT_EQ(m->get_const_values()[11], value_type{3.0});
+        EXPECT_EQ(m->get_const_col_idxs()[0], index_type{0});
+        EXPECT_EQ(m->get_const_col_idxs()[1], index_type{1});
+        EXPECT_EQ(m->get_const_col_idxs()[2], index_type{2});
+        EXPECT_EQ(m->get_const_col_idxs()[3], index_type{0});
+        EXPECT_EQ(m->get_const_col_idxs()[4], index_type{1});
+        EXPECT_EQ(m->get_const_col_idxs()[5], index_type{2});
+        EXPECT_EQ(m->get_const_row_ptrs()[0], index_type{0});
+        EXPECT_EQ(m->get_const_row_ptrs()[1], index_type{3});
+        EXPECT_EQ(m->get_const_row_ptrs()[2], index_type{6});
+    }
+
+    static void assert_empty(BatchCsrMtx* m)
+    {
+        ASSERT_EQ(m->get_num_batch_items(), 0);
+        ASSERT_EQ(m->get_num_stored_elements(), 0);
+    }
+
+    std::shared_ptr<const gko::Executor> exec;
+    std::unique_ptr<BatchCsrMtx> mtx;
+    std::unique_ptr<BatchCsrMtx> sp_mtx;
+    std::unique_ptr<CsrMtx> csr_mtx;
+    std::unique_ptr<CsrMtx> sp_csr_mtx;
+};
+
+TYPED_TEST_SUITE(Csr, gko::test::ValueTypes, TypenameNameGenerator);
+
+
+TYPED_TEST(Csr, KnowsItsSizeAndValues)
+{
+    this->assert_equal_to_original_mtx(this->mtx.get());
+}
+
+
+TYPED_TEST(Csr, SparseMtxKnowsItsSizeAndValues)
+{
+    this->assert_equal_to_original_sparse_mtx(this->sp_mtx.get());
+}
+
+
+// TYPED_TEST(Csr, CanBeEmpty)
+// {
+//     using BatchCsrMtx = typename TestFixture::BatchCsrMtx;
+
+//     auto empty = BatchCsrMtx::create(this->exec);
+
+//     this->assert_empty(empty.get());
+//     ASSERT_EQ(empty->get_const_values(), nullptr);
+// }
+
+
+// TYPED_TEST(Csr, CanGetValuesForEntry)
+// {
+//     using value_type = typename TestFixture::value_type;
+
+//     ASSERT_EQ(this->mtx->get_values_for_item(1)[0], value_type{1.0});
+// }
+
+
+// TYPED_TEST(Csr, CanCreateCsrItemView)
+// {
+//     GKO_ASSERT_MTX_NEAR(this->mtx->create_view_for_item(1), this->csr_mtx,
+//     0.0);
+// }
+
+
+// TYPED_TEST(Csr, CanCreateSpCsrItemView)
+// {
+//     GKO_ASSERT_MTX_NEAR(this->sp_mtx->create_view_for_item(1),
+//     this->sp_csr_mtx,
+//                         0.0);
+// }
+
+
+// TYPED_TEST(Csr, CanBeCopied)
+// {
+//     using BatchCsrMtx = typename TestFixture::BatchCsrMtx;
+
+//     auto mtx_copy = BatchCsrMtx::create(this->exec);
+
+//     mtx_copy->copy_from(this->mtx.get());
+
+//     this->assert_equal_to_original_mtx(this->mtx.get());
+//     this->mtx->get_values()[0] = 7;
+//     this->assert_equal_to_original_mtx(mtx_copy.get());
+// }
+
+
+// TYPED_TEST(Csr, CanBeMoved)
+// {
+//     using BatchCsrMtx = typename TestFixture::BatchCsrMtx;
+
+//     auto mtx_copy = BatchCsrMtx::create(this->exec);
+
+//     this->mtx->move_to(mtx_copy);
+
+//     this->assert_equal_to_original_mtx(mtx_copy.get());
+// }
+
+
+// TYPED_TEST(Csr, CanBeCloned)
+// {
+//     auto mtx_clone = this->mtx->clone();
+
+//     this->assert_equal_to_original_mtx(
+//         dynamic_cast<decltype(this->mtx.get())>(mtx_clone.get()));
+// }
+
+
+// TYPED_TEST(Csr, CanBeCleared)
+// {
+//     this->mtx->clear();
+
+//     this->assert_empty(this->mtx.get());
+// }
+
+
+// TYPED_TEST(Csr, CanBeConstructedWithSize)
+// {
+//     using BatchCsrMtx = typename TestFixture::BatchCsrMtx;
+
+//     auto m = BatchCsrMtx::create(this->exec,
+//                                  gko::batch_dim<2>(2, gko::dim<2>{5, 3}));
+
+//     ASSERT_EQ(m->get_num_batch_items(), 2);
+//     ASSERT_EQ(m->get_common_size(), gko::dim<2>(5, 3));
+//     ASSERT_EQ(m->get_num_stored_elements(), 0);
+// }
+
+
+// TYPED_TEST(Csr, CanBeConstructedWithSizeAndNnz)
+// {
+//     using BatchCsrMtx = typename TestFixture::BatchCsrMtx;
+
+//     auto m = BatchCsrMtx::create(this->exec,
+//                                  gko::batch_dim<2>(2, gko::dim<2>{5, 3}), 5);
+
+//     ASSERT_EQ(m->get_num_batch_items(), 2);
+//     ASSERT_EQ(m->get_common_size(), gko::dim<2>(5, 3));
+//     ASSERT_EQ(m->get_num_stored_elements(), 10);
+// }
+
+
+// TYPED_TEST(Csr, CanBeConstructedFromExistingData)
+// {
+//     using value_type = typename TestFixture::value_type;
+//     using index_type = typename TestFixture::index_type;
+//     using BatchCsrMtx = typename TestFixture::BatchCsrMtx;
+//     value_type values[] = {-1.0, 2.5, 3.5, 1.0, 2.0, 3.0};
+//     index_type col_idxs[] = {0, 1, 2};
+//     index_type row_ptrs[] = {0, 1, 3};
+
+//     auto m = BatchCsrMtx::create(
+//         this->exec, gko::batch_dim<2>(2, gko::dim<2>(2, 3)),
+//         gko::array<value_type>::view(this->exec, 6, values),
+//         gko::array<index_type>::view(this->exec, 3, col_idxs),
+//         gko::array<index_type>::view(this->exec, 3, row_ptrs));
+
+//     this->assert_equal_to_original_sparse_mtx(m.get());
+// }
+
+
+// TYPED_TEST(Csr, CanBeConstructedFromExistingConstData)
+// {
+//     using value_type = typename TestFixture::value_type;
+//     using index_type = typename TestFixture::index_type;
+//     using BatchCsrMtx = typename TestFixture::BatchCsrMtx;
+//     value_type values[] = {-1.0, 2.5, 3.5, 1.0, 2.0, 3.0};
+//     index_type col_idxs[] = {0, 1, 2};
+//     index_type row_ptrs[] = {0, 1, 3};
+
+//     auto m = BatchCsrMtx::create_const(
+//         this->exec, gko::batch_dim<2>(2, gko::dim<2>(2, 3)),
+//         gko::array<value_type>::const_view(this->exec, 6, values),
+//         gko::array<index_type>::const_view(this->exec, 3, col_idxs),
+//         gko::array<index_type>::const_view(this->exec, 3, row_ptrs));
+
+//     this->assert_equal_to_original_sparse_mtx(m.get());
+// }
+
+
+// TYPED_TEST(Csr, CanBeConstructedFromCsrMatrices)
+// {
+//     using BatchCsrMtx = typename TestFixture::BatchCsrMtx;
+//     using CsrMtx = typename TestFixture::CsrMtx;
+//     auto mat1 = gko::initialize<CsrMtx>({{-1.0, 0.0, 0.0}, {0.0, 2.5, 3.5}},
+//                                         this->exec);
+//     auto mat2 =
+//         gko::initialize<CsrMtx>({{1.0, 0.0, 0.0}, {0.0, 2.0, 3.0}},
+//         this->exec);
+
+//     auto m = gko::batch::create_from_item<BatchCsrMtx>(
+//         this->exec, std::vector<CsrMtx*>{mat1.get(), mat2.get()});
+
+//     this->assert_equal_to_original_sparse_mtx(m.get());
+// }
+
+
+// TYPED_TEST(Csr, CanBeConstructedFromCsrMatricesByDuplication)
+// {
+//     using BatchCsrMtx = typename TestFixture::BatchCsrMtx;
+//     using CsrMtx = typename TestFixture::CsrMtx;
+//     auto mat1 =
+//         gko::initialize<CsrMtx>({{1.0, 0.0, 0.0}, {0.0, 2.0, 0.0}},
+//         this->exec);
+//     auto bat_m = gko::batch::create_from_item<BatchCsrMtx>(
+//         this->exec, std::vector<CsrMtx*>{mat1.get(), mat1.get(),
+//         mat1.get()});
+
+//     auto m =
+//         gko::batch::create_from_item<BatchCsrMtx>(this->exec, 3, mat1.get());
+
+//     GKO_ASSERT_BATCH_MTX_NEAR(bat_m.get(), m.get(), 1e-14);
+// }
+
+
+// TYPED_TEST(Csr, CanBeConstructedByDuplicatingCsrMatrices)
+// {
+//     using BatchCsrMtx = typename TestFixture::BatchCsrMtx;
+//     using CsrMtx = typename TestFixture::CsrMtx;
+//     auto mat1 = gko::initialize<CsrMtx>({{-1.0, 0.0, 0.0}, {0.0, 2.5, 0.0}},
+//                                         this->exec);
+//     auto mat2 =
+//         gko::initialize<CsrMtx>({{1.0, 0.0, 0.0}, {0.0, 2.0, 0.0}},
+//         this->exec);
+
+//     auto m = gko::batch::create_from_item<BatchCsrMtx>(
+//         this->exec, std::vector<CsrMtx*>{mat1.get(), mat2.get()});
+//     auto m_ref = gko::batch::create_from_item<BatchCsrMtx>(
+//         this->exec, std::vector<CsrMtx*>{mat1.get(), mat2.get(), mat1.get(),
+//                                          mat2.get(), mat1.get(),
+//                                          mat2.get()});
+
+//     auto m2 = gko::batch::duplicate<BatchCsrMtx>(this->exec, 3, m.get());
+
+//     GKO_ASSERT_BATCH_MTX_NEAR(m2.get(), m_ref.get(), 1e-14);
+// }
+
+
+// TYPED_TEST(Csr, CanBeUnbatchedIntoCsrMatrices)
+// {
+//     using BatchCsrMtx = typename TestFixture::BatchCsrMtx;
+//     using CsrMtx = typename TestFixture::CsrMtx;
+//     auto mat1 = gko::initialize<CsrMtx>({{-1.0, 0.0, 0.0}, {0.0, 2.5, 3.5}},
+//                                         this->exec);
+//     auto mat2 =
+//         gko::initialize<CsrMtx>({{1.0, 0.0, 0.0}, {0.0, 2.0, 3.0}},
+//         this->exec);
+
+//     auto csr_mats = gko::batch::unbatch<BatchCsrMtx>(this->sp_mtx.get());
+
+//     GKO_ASSERT_MTX_NEAR(csr_mats[0].get(), mat1.get(), 0.);
+//     GKO_ASSERT_MTX_NEAR(csr_mats[1].get(), mat2.get(), 0.);
+// }
+
+
+// TYPED_TEST(Csr, CanBeListConstructed)
+// {
+//     using value_type = typename TestFixture::value_type;
+//     using index_type = typename TestFixture::index_type;
+//     using BatchCsrMtx = typename TestFixture::BatchCsrMtx;
+//     using CsrMtx = typename TestFixture::CsrMtx;
+
+//     auto m = gko::batch::initialize<BatchCsrMtx>({{0.0, -1.0}, {0.0, -5.0}},
+//                                                  this->exec);
+
+//     ASSERT_EQ(m->get_num_batch_items(), 2);
+//     ASSERT_EQ(m->get_common_size(), gko::dim<2>(2, 1));
+//     ASSERT_EQ(m->get_num_stored_elements(), 2);
+//     EXPECT_EQ(m->get_values()[0], value_type{-1.0});
+//     EXPECT_EQ(m->get_values()[1], value_type{-5.0});
+//     EXPECT_EQ(m->get_col_idxs()[0], index_type{0});
+//     EXPECT_EQ(m->get_row_ptrs()[0], index_type{0});
+//     EXPECT_EQ(m->get_row_ptrs()[1], index_type{1});
+//     EXPECT_EQ(m->get_row_ptrs()[2], index_type{1});
+// }
+
+
+// TYPED_TEST(Csr, CanBeListConstructedByCopies)
+// {
+//     using value_type = typename TestFixture::value_type;
+//     using index_type = typename TestFixture::index_type;
+//     using BatchCsrMtx = typename TestFixture::BatchCsrMtx;
+
+//     auto m = gko::batch::initialize<BatchCsrMtx>(2, I<value_type>({0.0,
+//     -1.0}),
+//                                                  this->exec, 1);
+
+//     ASSERT_EQ(m->get_num_batch_items(), 2);
+//     ASSERT_EQ(m->get_common_size(), gko::dim<2>(2, 1));
+//     ASSERT_EQ(m->get_num_stored_elements(), 2);
+//     EXPECT_EQ(m->get_values()[0], value_type{-1.0});
+//     EXPECT_EQ(m->get_values()[1], value_type{-1.0});
+//     EXPECT_EQ(m->get_col_idxs()[0], index_type{0});
+//     EXPECT_EQ(m->get_row_ptrs()[0], index_type{0});
+//     EXPECT_EQ(m->get_row_ptrs()[1], index_type{1});
+//     EXPECT_EQ(m->get_row_ptrs()[2], index_type{1});
+// }
+
+
+// TYPED_TEST(Csr, CanBeDoubleListConstructed)
+// {
+//     using value_type = typename TestFixture::value_type;
+//     using index_type = typename TestFixture::index_type;
+//     using BatchCsrMtx = typename TestFixture::BatchCsrMtx;
+//     using T = value_type;
+
+//     auto m = gko::batch::initialize<BatchCsrMtx>(
+//         // clang-format off
+//         {{I<T>{1.0, 0.0, 0.0},
+//           I<T>{2.0, 0.0, 3.0},
+//           I<T>{3.0, 6.0, 0.0}},
+//          {I<T>{1.0, 0.0, 0.0},
+//           I<T>{3.0, 0.0, -2.0},
+//           I<T>{5.0, 8.0, 0.0}}},
+//         // clang-format on
+//         this->exec, 2);
+
+//     ASSERT_EQ(m->get_num_batch_items(), 2);
+//     ASSERT_EQ(m->get_common_size(), gko::dim<2>(3, 3));
+//     ASSERT_EQ(m->get_num_stored_elements(), 2 * 5);
+//     EXPECT_EQ(m->get_values()[0], value_type{1.0});
+//     EXPECT_EQ(m->get_values()[1], value_type{2.0});
+//     EXPECT_EQ(m->get_values()[2], value_type{3.0});
+//     EXPECT_EQ(m->get_values()[3], value_type{3.0});
+//     EXPECT_EQ(m->get_values()[4], value_type{6.0});
+//     EXPECT_EQ(m->get_values()[5], value_type{1.0});
+//     EXPECT_EQ(m->get_values()[6], value_type{3.0});
+//     EXPECT_EQ(m->get_values()[7], value_type{-2.0});
+//     EXPECT_EQ(m->get_values()[8], value_type{5.0});
+//     EXPECT_EQ(m->get_values()[9], value_type{8.0});
+//     EXPECT_EQ(m->get_col_idxs()[0], index_type{0});
+//     EXPECT_EQ(m->get_col_idxs()[1], index_type{0});
+//     EXPECT_EQ(m->get_col_idxs()[2], index_type{2});
+//     EXPECT_EQ(m->get_col_idxs()[3], index_type{0});
+//     EXPECT_EQ(m->get_col_idxs()[4], index_type{1});
+//     EXPECT_EQ(m->get_row_ptrs()[0], index_type{0});
+//     EXPECT_EQ(m->get_row_ptrs()[1], index_type{1});
+//     EXPECT_EQ(m->get_row_ptrs()[2], index_type{3});
+//     EXPECT_EQ(m->get_row_ptrs()[3], index_type{5});
+// }
+
+
+// TYPED_TEST(Csr, CanBeReadFromMatrixData)
+// {
+//     using value_type = typename TestFixture::value_type;
+//     using index_type = typename TestFixture::index_type;
+//     using BatchCsrMtx = typename TestFixture::BatchCsrMtx;
+//     auto vec_data = std::vector<gko::matrix_data<value_type, index_type>>{};
+//     vec_data.emplace_back(gko::matrix_data<value_type, index_type>(
+//         {2, 3}, {{0, 0, -1.0}, {1, 1, 2.5}, {1, 2, 3.5}}));
+//     vec_data.emplace_back(gko::matrix_data<value_type, index_type>(
+//         {2, 3}, {{0, 0, 1.0}, {1, 1, 2.0}, {1, 2, 3.0}}));
+
+//     auto m = gko::batch::read<value_type, index_type,
+//     BatchCsrMtx>(this->exec,
+//                                                                    vec_data);
+
+//     this->assert_equal_to_original_sparse_mtx(m.get());
+// }
+
+
+// TYPED_TEST(Csr, ThrowsForDataWithDifferentNnz)
+// {
+//     using value_type = typename TestFixture::value_type;
+//     using index_type = typename TestFixture::index_type;
+//     using BatchCsrMtx = typename TestFixture::BatchCsrMtx;
+//     auto vec_data = std::vector<gko::matrix_data<value_type, index_type>>{};
+//     vec_data.emplace_back(
+//         gko::matrix_data<value_type, index_type>({2, 3}, {
+//                                                              {0, 0, -1.0},
+//                                                              {1, 1, 2.5},
+//                                                              {1, 2, 0.5},
+//                                                              {2, 2, -3.0},
+//                                                          }));
+//     vec_data.emplace_back(gko::matrix_data<value_type, index_type>(
+//         {2, 3}, {{0, 0, 1.0}, {1, 1, 2.0}, {1, 2, 3.0}}));
+
+//     EXPECT_THROW(
+//         gko::batch::detail::assert_same_sparsity_in_batched_data(vec_data),
+//         gko::NotImplemented);
+// }
+
+
+// TYPED_TEST(Csr, ThrowsForDataWithDifferentSparsity)
+// {
+//     using value_type = typename TestFixture::value_type;
+//     using index_type = typename TestFixture::index_type;
+//     using BatchCsrMtx = typename TestFixture::BatchCsrMtx;
+//     auto vec_data = std::vector<gko::matrix_data<value_type, index_type>>{};
+//     vec_data.emplace_back(
+//         gko::matrix_data<value_type, index_type>({2, 3}, {
+//                                                              {0, 0, -1.0},
+//                                                              {1, 1, 2.5},
+//                                                              {2, 2, -3.0},
+//                                                          }));
+//     vec_data.emplace_back(gko::matrix_data<value_type, index_type>(
+//         {2, 3}, {{0, 0, 1.0}, {1, 1, 2.0}, {1, 2, 3.0}}));
+
+//     EXPECT_THROW(
+//         gko::batch::detail::assert_same_sparsity_in_batched_data(vec_data),
+//         gko::NotImplemented);
+// }
+
+
+// TYPED_TEST(Csr, GeneratesCorrectMatrixData)
+// {
+//     using value_type = typename TestFixture::value_type;
+//     using index_type = typename TestFixture::index_type;
+//     using BatchCsrMtx = typename TestFixture::BatchCsrMtx;
+//     using tpl = typename gko::matrix_data<TypeParam>::nonzero_type;
+
+//     auto data = gko::batch::write<value_type, index_type, BatchCsrMtx>(
+//         this->sp_mtx.get());
+
+//     ASSERT_EQ(data[0].size, gko::dim<2>(2, 3));
+//     ASSERT_EQ(data[0].nonzeros.size(), 3);
+//     EXPECT_EQ(data[0].nonzeros[0], tpl(0, 0, value_type{-1.0}));
+//     EXPECT_EQ(data[0].nonzeros[1], tpl(1, 1, value_type{2.5}));
+//     EXPECT_EQ(data[0].nonzeros[2], tpl(1, 2, value_type{3.5}));
+//     ASSERT_EQ(data[1].size, gko::dim<2>(2, 3));
+//     ASSERT_EQ(data[1].nonzeros.size(), 3);
+//     EXPECT_EQ(data[1].nonzeros[0], tpl(0, 0, value_type{1.0}));
+//     EXPECT_EQ(data[1].nonzeros[1], tpl(1, 1, value_type{2.0}));
+//     EXPECT_EQ(data[1].nonzeros[2], tpl(1, 2, value_type{3.0}));
+// }

--- a/core/test/matrix/batch_csr.cpp
+++ b/core/test/matrix/batch_csr.cpp
@@ -161,389 +161,382 @@ TYPED_TEST(Csr, SparseMtxKnowsItsSizeAndValues)
 }
 
 
-// TYPED_TEST(Csr, CanBeEmpty)
-// {
-//     using BatchCsrMtx = typename TestFixture::BatchCsrMtx;
+TYPED_TEST(Csr, CanBeEmpty)
+{
+    using BatchCsrMtx = typename TestFixture::BatchCsrMtx;
 
-//     auto empty = BatchCsrMtx::create(this->exec);
+    auto empty = BatchCsrMtx::create(this->exec);
 
-//     this->assert_empty(empty.get());
-//     ASSERT_EQ(empty->get_const_values(), nullptr);
-// }
+    this->assert_empty(empty.get());
+    ASSERT_EQ(empty->get_const_values(), nullptr);
+}
 
 
-// TYPED_TEST(Csr, CanGetValuesForEntry)
-// {
-//     using value_type = typename TestFixture::value_type;
+TYPED_TEST(Csr, CanGetValuesForEntry)
+{
+    using value_type = typename TestFixture::value_type;
 
-//     ASSERT_EQ(this->mtx->get_values_for_item(1)[0], value_type{1.0});
-// }
+    ASSERT_EQ(this->mtx->get_values_for_item(1)[0], value_type{1.0});
+}
 
 
-// TYPED_TEST(Csr, CanCreateCsrItemView)
-// {
-//     GKO_ASSERT_MTX_NEAR(this->mtx->create_view_for_item(1), this->csr_mtx,
-//     0.0);
-// }
+TYPED_TEST(Csr, CanCreateCsrItemView)
+{
+    GKO_ASSERT_MTX_NEAR(this->mtx->create_view_for_item(1), this->csr_mtx, 0.0);
+}
 
 
-// TYPED_TEST(Csr, CanCreateSpCsrItemView)
-// {
-//     GKO_ASSERT_MTX_NEAR(this->sp_mtx->create_view_for_item(1),
-//     this->sp_csr_mtx,
-//                         0.0);
-// }
+TYPED_TEST(Csr, CanCreateSpCsrItemView)
+{
+    GKO_ASSERT_MTX_NEAR(this->sp_mtx->create_view_for_item(1), this->sp_csr_mtx,
+                        0.0);
+}
 
 
-// TYPED_TEST(Csr, CanBeCopied)
-// {
-//     using BatchCsrMtx = typename TestFixture::BatchCsrMtx;
+TYPED_TEST(Csr, CanBeCopied)
+{
+    using BatchCsrMtx = typename TestFixture::BatchCsrMtx;
 
-//     auto mtx_copy = BatchCsrMtx::create(this->exec);
+    auto mtx_copy = BatchCsrMtx::create(this->exec);
 
-//     mtx_copy->copy_from(this->mtx.get());
+    mtx_copy->copy_from(this->mtx.get());
 
-//     this->assert_equal_to_original_mtx(this->mtx.get());
-//     this->mtx->get_values()[0] = 7;
-//     this->assert_equal_to_original_mtx(mtx_copy.get());
-// }
+    this->assert_equal_to_original_mtx(this->mtx.get());
+    this->mtx->get_values()[0] = 7;
+    this->assert_equal_to_original_mtx(mtx_copy.get());
+}
 
 
-// TYPED_TEST(Csr, CanBeMoved)
-// {
-//     using BatchCsrMtx = typename TestFixture::BatchCsrMtx;
+TYPED_TEST(Csr, CanBeMoved)
+{
+    using BatchCsrMtx = typename TestFixture::BatchCsrMtx;
 
-//     auto mtx_copy = BatchCsrMtx::create(this->exec);
+    auto mtx_copy = BatchCsrMtx::create(this->exec);
 
-//     this->mtx->move_to(mtx_copy);
+    this->mtx->move_to(mtx_copy);
 
-//     this->assert_equal_to_original_mtx(mtx_copy.get());
-// }
+    this->assert_equal_to_original_mtx(mtx_copy.get());
+}
 
 
-// TYPED_TEST(Csr, CanBeCloned)
-// {
-//     auto mtx_clone = this->mtx->clone();
+TYPED_TEST(Csr, CanBeCloned)
+{
+    auto mtx_clone = this->mtx->clone();
 
-//     this->assert_equal_to_original_mtx(
-//         dynamic_cast<decltype(this->mtx.get())>(mtx_clone.get()));
-// }
+    this->assert_equal_to_original_mtx(
+        dynamic_cast<decltype(this->mtx.get())>(mtx_clone.get()));
+}
 
 
-// TYPED_TEST(Csr, CanBeCleared)
-// {
-//     this->mtx->clear();
+TYPED_TEST(Csr, CanBeCleared)
+{
+    this->mtx->clear();
 
-//     this->assert_empty(this->mtx.get());
-// }
+    this->assert_empty(this->mtx.get());
+}
 
 
-// TYPED_TEST(Csr, CanBeConstructedWithSize)
-// {
-//     using BatchCsrMtx = typename TestFixture::BatchCsrMtx;
+TYPED_TEST(Csr, CanBeConstructedWithSize)
+{
+    using BatchCsrMtx = typename TestFixture::BatchCsrMtx;
 
-//     auto m = BatchCsrMtx::create(this->exec,
-//                                  gko::batch_dim<2>(2, gko::dim<2>{5, 3}));
+    auto m = BatchCsrMtx::create(this->exec,
+                                 gko::batch_dim<2>(2, gko::dim<2>{5, 3}));
 
-//     ASSERT_EQ(m->get_num_batch_items(), 2);
-//     ASSERT_EQ(m->get_common_size(), gko::dim<2>(5, 3));
-//     ASSERT_EQ(m->get_num_stored_elements(), 0);
-// }
+    ASSERT_EQ(m->get_num_batch_items(), 2);
+    ASSERT_EQ(m->get_common_size(), gko::dim<2>(5, 3));
+    ASSERT_EQ(m->get_num_stored_elements(), 0);
+}
 
 
-// TYPED_TEST(Csr, CanBeConstructedWithSizeAndNnz)
-// {
-//     using BatchCsrMtx = typename TestFixture::BatchCsrMtx;
+TYPED_TEST(Csr, CanBeConstructedWithSizeAndNnz)
+{
+    using BatchCsrMtx = typename TestFixture::BatchCsrMtx;
 
-//     auto m = BatchCsrMtx::create(this->exec,
-//                                  gko::batch_dim<2>(2, gko::dim<2>{5, 3}), 5);
+    auto m = BatchCsrMtx::create(this->exec,
+                                 gko::batch_dim<2>(2, gko::dim<2>{5, 3}), 5);
 
-//     ASSERT_EQ(m->get_num_batch_items(), 2);
-//     ASSERT_EQ(m->get_common_size(), gko::dim<2>(5, 3));
-//     ASSERT_EQ(m->get_num_stored_elements(), 10);
-// }
-
-
-// TYPED_TEST(Csr, CanBeConstructedFromExistingData)
-// {
-//     using value_type = typename TestFixture::value_type;
-//     using index_type = typename TestFixture::index_type;
-//     using BatchCsrMtx = typename TestFixture::BatchCsrMtx;
-//     value_type values[] = {-1.0, 2.5, 3.5, 1.0, 2.0, 3.0};
-//     index_type col_idxs[] = {0, 1, 2};
-//     index_type row_ptrs[] = {0, 1, 3};
-
-//     auto m = BatchCsrMtx::create(
-//         this->exec, gko::batch_dim<2>(2, gko::dim<2>(2, 3)),
-//         gko::array<value_type>::view(this->exec, 6, values),
-//         gko::array<index_type>::view(this->exec, 3, col_idxs),
-//         gko::array<index_type>::view(this->exec, 3, row_ptrs));
-
-//     this->assert_equal_to_original_sparse_mtx(m.get());
-// }
-
-
-// TYPED_TEST(Csr, CanBeConstructedFromExistingConstData)
-// {
-//     using value_type = typename TestFixture::value_type;
-//     using index_type = typename TestFixture::index_type;
-//     using BatchCsrMtx = typename TestFixture::BatchCsrMtx;
-//     value_type values[] = {-1.0, 2.5, 3.5, 1.0, 2.0, 3.0};
-//     index_type col_idxs[] = {0, 1, 2};
-//     index_type row_ptrs[] = {0, 1, 3};
-
-//     auto m = BatchCsrMtx::create_const(
-//         this->exec, gko::batch_dim<2>(2, gko::dim<2>(2, 3)),
-//         gko::array<value_type>::const_view(this->exec, 6, values),
-//         gko::array<index_type>::const_view(this->exec, 3, col_idxs),
-//         gko::array<index_type>::const_view(this->exec, 3, row_ptrs));
-
-//     this->assert_equal_to_original_sparse_mtx(m.get());
-// }
-
-
-// TYPED_TEST(Csr, CanBeConstructedFromCsrMatrices)
-// {
-//     using BatchCsrMtx = typename TestFixture::BatchCsrMtx;
-//     using CsrMtx = typename TestFixture::CsrMtx;
-//     auto mat1 = gko::initialize<CsrMtx>({{-1.0, 0.0, 0.0}, {0.0, 2.5, 3.5}},
-//                                         this->exec);
-//     auto mat2 =
-//         gko::initialize<CsrMtx>({{1.0, 0.0, 0.0}, {0.0, 2.0, 3.0}},
-//         this->exec);
-
-//     auto m = gko::batch::create_from_item<BatchCsrMtx>(
-//         this->exec, std::vector<CsrMtx*>{mat1.get(), mat2.get()});
-
-//     this->assert_equal_to_original_sparse_mtx(m.get());
-// }
-
-
-// TYPED_TEST(Csr, CanBeConstructedFromCsrMatricesByDuplication)
-// {
-//     using BatchCsrMtx = typename TestFixture::BatchCsrMtx;
-//     using CsrMtx = typename TestFixture::CsrMtx;
-//     auto mat1 =
-//         gko::initialize<CsrMtx>({{1.0, 0.0, 0.0}, {0.0, 2.0, 0.0}},
-//         this->exec);
-//     auto bat_m = gko::batch::create_from_item<BatchCsrMtx>(
-//         this->exec, std::vector<CsrMtx*>{mat1.get(), mat1.get(),
-//         mat1.get()});
-
-//     auto m =
-//         gko::batch::create_from_item<BatchCsrMtx>(this->exec, 3, mat1.get());
-
-//     GKO_ASSERT_BATCH_MTX_NEAR(bat_m.get(), m.get(), 1e-14);
-// }
-
-
-// TYPED_TEST(Csr, CanBeConstructedByDuplicatingCsrMatrices)
-// {
-//     using BatchCsrMtx = typename TestFixture::BatchCsrMtx;
-//     using CsrMtx = typename TestFixture::CsrMtx;
-//     auto mat1 = gko::initialize<CsrMtx>({{-1.0, 0.0, 0.0}, {0.0, 2.5, 0.0}},
-//                                         this->exec);
-//     auto mat2 =
-//         gko::initialize<CsrMtx>({{1.0, 0.0, 0.0}, {0.0, 2.0, 0.0}},
-//         this->exec);
-
-//     auto m = gko::batch::create_from_item<BatchCsrMtx>(
-//         this->exec, std::vector<CsrMtx*>{mat1.get(), mat2.get()});
-//     auto m_ref = gko::batch::create_from_item<BatchCsrMtx>(
-//         this->exec, std::vector<CsrMtx*>{mat1.get(), mat2.get(), mat1.get(),
-//                                          mat2.get(), mat1.get(),
-//                                          mat2.get()});
-
-//     auto m2 = gko::batch::duplicate<BatchCsrMtx>(this->exec, 3, m.get());
-
-//     GKO_ASSERT_BATCH_MTX_NEAR(m2.get(), m_ref.get(), 1e-14);
-// }
-
-
-// TYPED_TEST(Csr, CanBeUnbatchedIntoCsrMatrices)
-// {
-//     using BatchCsrMtx = typename TestFixture::BatchCsrMtx;
-//     using CsrMtx = typename TestFixture::CsrMtx;
-//     auto mat1 = gko::initialize<CsrMtx>({{-1.0, 0.0, 0.0}, {0.0, 2.5, 3.5}},
-//                                         this->exec);
-//     auto mat2 =
-//         gko::initialize<CsrMtx>({{1.0, 0.0, 0.0}, {0.0, 2.0, 3.0}},
-//         this->exec);
-
-//     auto csr_mats = gko::batch::unbatch<BatchCsrMtx>(this->sp_mtx.get());
-
-//     GKO_ASSERT_MTX_NEAR(csr_mats[0].get(), mat1.get(), 0.);
-//     GKO_ASSERT_MTX_NEAR(csr_mats[1].get(), mat2.get(), 0.);
-// }
-
-
-// TYPED_TEST(Csr, CanBeListConstructed)
-// {
-//     using value_type = typename TestFixture::value_type;
-//     using index_type = typename TestFixture::index_type;
-//     using BatchCsrMtx = typename TestFixture::BatchCsrMtx;
-//     using CsrMtx = typename TestFixture::CsrMtx;
-
-//     auto m = gko::batch::initialize<BatchCsrMtx>({{0.0, -1.0}, {0.0, -5.0}},
-//                                                  this->exec);
-
-//     ASSERT_EQ(m->get_num_batch_items(), 2);
-//     ASSERT_EQ(m->get_common_size(), gko::dim<2>(2, 1));
-//     ASSERT_EQ(m->get_num_stored_elements(), 2);
-//     EXPECT_EQ(m->get_values()[0], value_type{-1.0});
-//     EXPECT_EQ(m->get_values()[1], value_type{-5.0});
-//     EXPECT_EQ(m->get_col_idxs()[0], index_type{0});
-//     EXPECT_EQ(m->get_row_ptrs()[0], index_type{0});
-//     EXPECT_EQ(m->get_row_ptrs()[1], index_type{1});
-//     EXPECT_EQ(m->get_row_ptrs()[2], index_type{1});
-// }
-
-
-// TYPED_TEST(Csr, CanBeListConstructedByCopies)
-// {
-//     using value_type = typename TestFixture::value_type;
-//     using index_type = typename TestFixture::index_type;
-//     using BatchCsrMtx = typename TestFixture::BatchCsrMtx;
-
-//     auto m = gko::batch::initialize<BatchCsrMtx>(2, I<value_type>({0.0,
-//     -1.0}),
-//                                                  this->exec, 1);
-
-//     ASSERT_EQ(m->get_num_batch_items(), 2);
-//     ASSERT_EQ(m->get_common_size(), gko::dim<2>(2, 1));
-//     ASSERT_EQ(m->get_num_stored_elements(), 2);
-//     EXPECT_EQ(m->get_values()[0], value_type{-1.0});
-//     EXPECT_EQ(m->get_values()[1], value_type{-1.0});
-//     EXPECT_EQ(m->get_col_idxs()[0], index_type{0});
-//     EXPECT_EQ(m->get_row_ptrs()[0], index_type{0});
-//     EXPECT_EQ(m->get_row_ptrs()[1], index_type{1});
-//     EXPECT_EQ(m->get_row_ptrs()[2], index_type{1});
-// }
-
-
-// TYPED_TEST(Csr, CanBeDoubleListConstructed)
-// {
-//     using value_type = typename TestFixture::value_type;
-//     using index_type = typename TestFixture::index_type;
-//     using BatchCsrMtx = typename TestFixture::BatchCsrMtx;
-//     using T = value_type;
-
-//     auto m = gko::batch::initialize<BatchCsrMtx>(
-//         // clang-format off
-//         {{I<T>{1.0, 0.0, 0.0},
-//           I<T>{2.0, 0.0, 3.0},
-//           I<T>{3.0, 6.0, 0.0}},
-//          {I<T>{1.0, 0.0, 0.0},
-//           I<T>{3.0, 0.0, -2.0},
-//           I<T>{5.0, 8.0, 0.0}}},
-//         // clang-format on
-//         this->exec, 2);
-
-//     ASSERT_EQ(m->get_num_batch_items(), 2);
-//     ASSERT_EQ(m->get_common_size(), gko::dim<2>(3, 3));
-//     ASSERT_EQ(m->get_num_stored_elements(), 2 * 5);
-//     EXPECT_EQ(m->get_values()[0], value_type{1.0});
-//     EXPECT_EQ(m->get_values()[1], value_type{2.0});
-//     EXPECT_EQ(m->get_values()[2], value_type{3.0});
-//     EXPECT_EQ(m->get_values()[3], value_type{3.0});
-//     EXPECT_EQ(m->get_values()[4], value_type{6.0});
-//     EXPECT_EQ(m->get_values()[5], value_type{1.0});
-//     EXPECT_EQ(m->get_values()[6], value_type{3.0});
-//     EXPECT_EQ(m->get_values()[7], value_type{-2.0});
-//     EXPECT_EQ(m->get_values()[8], value_type{5.0});
-//     EXPECT_EQ(m->get_values()[9], value_type{8.0});
-//     EXPECT_EQ(m->get_col_idxs()[0], index_type{0});
-//     EXPECT_EQ(m->get_col_idxs()[1], index_type{0});
-//     EXPECT_EQ(m->get_col_idxs()[2], index_type{2});
-//     EXPECT_EQ(m->get_col_idxs()[3], index_type{0});
-//     EXPECT_EQ(m->get_col_idxs()[4], index_type{1});
-//     EXPECT_EQ(m->get_row_ptrs()[0], index_type{0});
-//     EXPECT_EQ(m->get_row_ptrs()[1], index_type{1});
-//     EXPECT_EQ(m->get_row_ptrs()[2], index_type{3});
-//     EXPECT_EQ(m->get_row_ptrs()[3], index_type{5});
-// }
-
-
-// TYPED_TEST(Csr, CanBeReadFromMatrixData)
-// {
-//     using value_type = typename TestFixture::value_type;
-//     using index_type = typename TestFixture::index_type;
-//     using BatchCsrMtx = typename TestFixture::BatchCsrMtx;
-//     auto vec_data = std::vector<gko::matrix_data<value_type, index_type>>{};
-//     vec_data.emplace_back(gko::matrix_data<value_type, index_type>(
-//         {2, 3}, {{0, 0, -1.0}, {1, 1, 2.5}, {1, 2, 3.5}}));
-//     vec_data.emplace_back(gko::matrix_data<value_type, index_type>(
-//         {2, 3}, {{0, 0, 1.0}, {1, 1, 2.0}, {1, 2, 3.0}}));
-
-//     auto m = gko::batch::read<value_type, index_type,
-//     BatchCsrMtx>(this->exec,
-//                                                                    vec_data);
-
-//     this->assert_equal_to_original_sparse_mtx(m.get());
-// }
-
-
-// TYPED_TEST(Csr, ThrowsForDataWithDifferentNnz)
-// {
-//     using value_type = typename TestFixture::value_type;
-//     using index_type = typename TestFixture::index_type;
-//     using BatchCsrMtx = typename TestFixture::BatchCsrMtx;
-//     auto vec_data = std::vector<gko::matrix_data<value_type, index_type>>{};
-//     vec_data.emplace_back(
-//         gko::matrix_data<value_type, index_type>({2, 3}, {
-//                                                              {0, 0, -1.0},
-//                                                              {1, 1, 2.5},
-//                                                              {1, 2, 0.5},
-//                                                              {2, 2, -3.0},
-//                                                          }));
-//     vec_data.emplace_back(gko::matrix_data<value_type, index_type>(
-//         {2, 3}, {{0, 0, 1.0}, {1, 1, 2.0}, {1, 2, 3.0}}));
-
-//     EXPECT_THROW(
-//         gko::batch::detail::assert_same_sparsity_in_batched_data(vec_data),
-//         gko::NotImplemented);
-// }
-
-
-// TYPED_TEST(Csr, ThrowsForDataWithDifferentSparsity)
-// {
-//     using value_type = typename TestFixture::value_type;
-//     using index_type = typename TestFixture::index_type;
-//     using BatchCsrMtx = typename TestFixture::BatchCsrMtx;
-//     auto vec_data = std::vector<gko::matrix_data<value_type, index_type>>{};
-//     vec_data.emplace_back(
-//         gko::matrix_data<value_type, index_type>({2, 3}, {
-//                                                              {0, 0, -1.0},
-//                                                              {1, 1, 2.5},
-//                                                              {2, 2, -3.0},
-//                                                          }));
-//     vec_data.emplace_back(gko::matrix_data<value_type, index_type>(
-//         {2, 3}, {{0, 0, 1.0}, {1, 1, 2.0}, {1, 2, 3.0}}));
-
-//     EXPECT_THROW(
-//         gko::batch::detail::assert_same_sparsity_in_batched_data(vec_data),
-//         gko::NotImplemented);
-// }
-
-
-// TYPED_TEST(Csr, GeneratesCorrectMatrixData)
-// {
-//     using value_type = typename TestFixture::value_type;
-//     using index_type = typename TestFixture::index_type;
-//     using BatchCsrMtx = typename TestFixture::BatchCsrMtx;
-//     using tpl = typename gko::matrix_data<TypeParam>::nonzero_type;
-
-//     auto data = gko::batch::write<value_type, index_type, BatchCsrMtx>(
-//         this->sp_mtx.get());
-
-//     ASSERT_EQ(data[0].size, gko::dim<2>(2, 3));
-//     ASSERT_EQ(data[0].nonzeros.size(), 3);
-//     EXPECT_EQ(data[0].nonzeros[0], tpl(0, 0, value_type{-1.0}));
-//     EXPECT_EQ(data[0].nonzeros[1], tpl(1, 1, value_type{2.5}));
-//     EXPECT_EQ(data[0].nonzeros[2], tpl(1, 2, value_type{3.5}));
-//     ASSERT_EQ(data[1].size, gko::dim<2>(2, 3));
-//     ASSERT_EQ(data[1].nonzeros.size(), 3);
-//     EXPECT_EQ(data[1].nonzeros[0], tpl(0, 0, value_type{1.0}));
-//     EXPECT_EQ(data[1].nonzeros[1], tpl(1, 1, value_type{2.0}));
-//     EXPECT_EQ(data[1].nonzeros[2], tpl(1, 2, value_type{3.0}));
-// }
+    ASSERT_EQ(m->get_num_batch_items(), 2);
+    ASSERT_EQ(m->get_common_size(), gko::dim<2>(5, 3));
+    ASSERT_EQ(m->get_num_stored_elements(), 10);
+}
+
+
+TYPED_TEST(Csr, CanBeConstructedFromExistingData)
+{
+    using value_type = typename TestFixture::value_type;
+    using index_type = typename TestFixture::index_type;
+    using BatchCsrMtx = typename TestFixture::BatchCsrMtx;
+    value_type values[] = {-1.0, 2.5, 3.5, 1.0, 2.0, 3.0};
+    index_type col_idxs[] = {0, 1, 2};
+    index_type row_ptrs[] = {0, 1, 3};
+
+    auto m = BatchCsrMtx::create(
+        this->exec, gko::batch_dim<2>(2, gko::dim<2>(2, 3)),
+        gko::array<value_type>::view(this->exec, 6, values),
+        gko::array<index_type>::view(this->exec, 3, col_idxs),
+        gko::array<index_type>::view(this->exec, 3, row_ptrs));
+
+    this->assert_equal_to_original_sparse_mtx(m.get());
+}
+
+
+TYPED_TEST(Csr, CanBeConstructedFromExistingConstData)
+{
+    using value_type = typename TestFixture::value_type;
+    using index_type = typename TestFixture::index_type;
+    using BatchCsrMtx = typename TestFixture::BatchCsrMtx;
+    value_type values[] = {-1.0, 2.5, 3.5, 1.0, 2.0, 3.0};
+    index_type col_idxs[] = {0, 1, 2};
+    index_type row_ptrs[] = {0, 1, 3};
+
+    auto m = BatchCsrMtx::create_const(
+        this->exec, gko::batch_dim<2>(2, gko::dim<2>(2, 3)),
+        gko::array<value_type>::const_view(this->exec, 6, values),
+        gko::array<index_type>::const_view(this->exec, 3, col_idxs),
+        gko::array<index_type>::const_view(this->exec, 3, row_ptrs));
+
+    this->assert_equal_to_original_sparse_mtx(m.get());
+}
+
+
+TYPED_TEST(Csr, CanBeConstructedFromCsrMatrices)
+{
+    using BatchCsrMtx = typename TestFixture::BatchCsrMtx;
+    using CsrMtx = typename TestFixture::CsrMtx;
+    auto mat1 = gko::initialize<CsrMtx>({{-1.0, 0.0, 0.0}, {0.0, 2.5, 3.5}},
+                                        this->exec);
+    auto mat2 =
+        gko::initialize<CsrMtx>({{1.0, 0.0, 0.0}, {0.0, 2.0, 3.0}}, this->exec);
+
+    auto m = gko::batch::create_from_item<BatchCsrMtx>(
+        this->exec, std::vector<CsrMtx*>{mat1.get(), mat2.get()}, 3);
+
+    this->assert_equal_to_original_sparse_mtx(m.get());
+}
+
+
+TYPED_TEST(Csr, CanBeConstructedFromCsrMatricesByDuplication)
+{
+    using BatchCsrMtx = typename TestFixture::BatchCsrMtx;
+    using CsrMtx = typename TestFixture::CsrMtx;
+    auto mat1 =
+        gko::initialize<CsrMtx>({{1.0, 0.0, 0.0}, {0.0, 2.0, 0.0}}, this->exec);
+    auto bat_m = gko::batch::create_from_item<BatchCsrMtx>(
+        this->exec, std::vector<CsrMtx*>{mat1.get(), mat1.get(), mat1.get()},
+        2);
+
+    auto m =
+        gko::batch::create_from_item<BatchCsrMtx>(this->exec, 3, mat1.get(), 2);
+
+    GKO_ASSERT_BATCH_MTX_NEAR(bat_m.get(), m.get(), 1e-14);
+}
+
+
+TYPED_TEST(Csr, CanBeConstructedByDuplicatingCsrMatrices)
+{
+    using BatchCsrMtx = typename TestFixture::BatchCsrMtx;
+    using CsrMtx = typename TestFixture::CsrMtx;
+    auto mat1 = gko::initialize<CsrMtx>({{-1.0, 0.0, 0.0}, {0.0, 2.5, 0.0}},
+                                        this->exec);
+    auto mat2 =
+        gko::initialize<CsrMtx>({{1.0, 0.0, 0.0}, {0.0, 2.0, 0.0}}, this->exec);
+
+    auto m = gko::batch::create_from_item<BatchCsrMtx>(
+        this->exec, std::vector<CsrMtx*>{mat1.get(), mat2.get()}, 2);
+    auto m_ref = gko::batch::create_from_item<BatchCsrMtx>(
+        this->exec,
+        std::vector<CsrMtx*>{mat1.get(), mat2.get(), mat1.get(), mat2.get(),
+                             mat1.get(), mat2.get()},
+        2);
+
+    auto m2 = gko::batch::duplicate<BatchCsrMtx>(this->exec, 3, m.get(), 2);
+
+    GKO_ASSERT_BATCH_MTX_NEAR(m2.get(), m_ref.get(), 1e-14);
+}
+
+
+TYPED_TEST(Csr, CanBeUnbatchedIntoCsrMatrices)
+{
+    using BatchCsrMtx = typename TestFixture::BatchCsrMtx;
+    using CsrMtx = typename TestFixture::CsrMtx;
+    auto mat1 = gko::initialize<CsrMtx>({{-1.0, 0.0, 0.0}, {0.0, 2.5, 3.5}},
+                                        this->exec);
+    auto mat2 =
+        gko::initialize<CsrMtx>({{1.0, 0.0, 0.0}, {0.0, 2.0, 3.0}}, this->exec);
+
+    auto csr_mats = gko::batch::unbatch<BatchCsrMtx>(this->sp_mtx.get());
+
+    GKO_ASSERT_MTX_NEAR(csr_mats[0].get(), mat1.get(), 0.);
+    GKO_ASSERT_MTX_NEAR(csr_mats[1].get(), mat2.get(), 0.);
+}
+
+
+TYPED_TEST(Csr, CanBeListConstructed)
+{
+    using value_type = typename TestFixture::value_type;
+    using index_type = typename TestFixture::index_type;
+    using BatchCsrMtx = typename TestFixture::BatchCsrMtx;
+    using CsrMtx = typename TestFixture::CsrMtx;
+
+    auto m = gko::batch::initialize<BatchCsrMtx>({{0.0, -1.0}, {0.0, -5.0}},
+                                                 this->exec, 1);
+
+    ASSERT_EQ(m->get_num_batch_items(), 2);
+    ASSERT_EQ(m->get_common_size(), gko::dim<2>(2, 1));
+    ASSERT_EQ(m->get_num_stored_elements(), 2);
+    EXPECT_EQ(m->get_values()[0], value_type{-1.0});
+    EXPECT_EQ(m->get_values()[1], value_type{-5.0});
+    EXPECT_EQ(m->get_col_idxs()[0], index_type{0});
+    EXPECT_EQ(m->get_row_ptrs()[0], index_type{0});
+    EXPECT_EQ(m->get_row_ptrs()[1], index_type{0});
+    EXPECT_EQ(m->get_row_ptrs()[2], index_type{1});
+}
+
+
+TYPED_TEST(Csr, CanBeListConstructedByCopies)
+{
+    using value_type = typename TestFixture::value_type;
+    using index_type = typename TestFixture::index_type;
+    using BatchCsrMtx = typename TestFixture::BatchCsrMtx;
+
+    auto m = gko::batch::initialize<BatchCsrMtx>(2, I<value_type>({0.0, -1.0}),
+                                                 this->exec, 1);
+
+    ASSERT_EQ(m->get_num_batch_items(), 2);
+    ASSERT_EQ(m->get_common_size(), gko::dim<2>(2, 1));
+    ASSERT_EQ(m->get_num_stored_elements(), 2);
+    EXPECT_EQ(m->get_values()[0], value_type{-1.0});
+    EXPECT_EQ(m->get_values()[1], value_type{-1.0});
+    EXPECT_EQ(m->get_col_idxs()[0], index_type{0});
+    EXPECT_EQ(m->get_row_ptrs()[0], index_type{0});
+    EXPECT_EQ(m->get_row_ptrs()[1], index_type{0});
+    EXPECT_EQ(m->get_row_ptrs()[2], index_type{1});
+}
+
+
+TYPED_TEST(Csr, CanBeDoubleListConstructed)
+{
+    using value_type = typename TestFixture::value_type;
+    using index_type = typename TestFixture::index_type;
+    using BatchCsrMtx = typename TestFixture::BatchCsrMtx;
+    using T = value_type;
+
+    auto m = gko::batch::initialize<BatchCsrMtx>(
+        // clang-format off
+        {{I<T>{1.0, 0.0, 0.0},
+          I<T>{2.0, 0.0, 3.0},
+          I<T>{3.0, 6.0, 0.0}},
+         {I<T>{1.0, 0.0, 0.0},
+          I<T>{3.0, 0.0, -2.0},
+          I<T>{5.0, 8.0, 0.0}}},
+        // clang-format on
+        this->exec, 5);
+
+    ASSERT_EQ(m->get_num_batch_items(), 2);
+    ASSERT_EQ(m->get_common_size(), gko::dim<2>(3, 3));
+    ASSERT_EQ(m->get_num_stored_elements(), 2 * 5);
+    EXPECT_EQ(m->get_values()[0], value_type{1.0});
+    EXPECT_EQ(m->get_values()[1], value_type{2.0});
+    EXPECT_EQ(m->get_values()[2], value_type{3.0});
+    EXPECT_EQ(m->get_values()[3], value_type{3.0});
+    EXPECT_EQ(m->get_values()[4], value_type{6.0});
+    EXPECT_EQ(m->get_values()[5], value_type{1.0});
+    EXPECT_EQ(m->get_values()[6], value_type{3.0});
+    EXPECT_EQ(m->get_values()[7], value_type{-2.0});
+    EXPECT_EQ(m->get_values()[8], value_type{5.0});
+    EXPECT_EQ(m->get_values()[9], value_type{8.0});
+    EXPECT_EQ(m->get_col_idxs()[0], index_type{0});
+    EXPECT_EQ(m->get_col_idxs()[1], index_type{0});
+    EXPECT_EQ(m->get_col_idxs()[2], index_type{2});
+    EXPECT_EQ(m->get_col_idxs()[3], index_type{0});
+    EXPECT_EQ(m->get_col_idxs()[4], index_type{1});
+    EXPECT_EQ(m->get_row_ptrs()[0], index_type{0});
+    EXPECT_EQ(m->get_row_ptrs()[1], index_type{1});
+    EXPECT_EQ(m->get_row_ptrs()[2], index_type{3});
+    EXPECT_EQ(m->get_row_ptrs()[3], index_type{5});
+}
+
+
+TYPED_TEST(Csr, CanBeReadFromMatrixData)
+{
+    using value_type = typename TestFixture::value_type;
+    using index_type = typename TestFixture::index_type;
+    using BatchCsrMtx = typename TestFixture::BatchCsrMtx;
+    auto vec_data = std::vector<gko::matrix_data<value_type, index_type>>{};
+    vec_data.emplace_back(gko::matrix_data<value_type, index_type>(
+        {2, 3}, {{0, 0, -1.0}, {1, 1, 2.5}, {1, 2, 3.5}}));
+    vec_data.emplace_back(gko::matrix_data<value_type, index_type>(
+        {2, 3}, {{0, 0, 1.0}, {1, 1, 2.0}, {1, 2, 3.0}}));
+
+    auto m = gko::batch::read<value_type, index_type, BatchCsrMtx>(this->exec,
+                                                                   vec_data, 3);
+
+    this->assert_equal_to_original_sparse_mtx(m.get());
+}
+
+
+TYPED_TEST(Csr, ThrowsForDataWithDifferentNnz)
+{
+    using value_type = typename TestFixture::value_type;
+    using index_type = typename TestFixture::index_type;
+    using BatchCsrMtx = typename TestFixture::BatchCsrMtx;
+    auto vec_data = std::vector<gko::matrix_data<value_type, index_type>>{};
+    vec_data.emplace_back(
+        gko::matrix_data<value_type, index_type>({2, 3}, {
+                                                             {0, 0, -1.0},
+                                                             {1, 1, 2.5},
+                                                             {1, 2, 0.5},
+                                                             {2, 2, -3.0},
+                                                         }));
+    vec_data.emplace_back(gko::matrix_data<value_type, index_type>(
+        {2, 3}, {{0, 0, 1.0}, {1, 1, 2.0}, {1, 2, 3.0}}));
+
+    EXPECT_THROW(
+        gko::batch::detail::assert_same_sparsity_in_batched_data(vec_data),
+        gko::NotImplemented);
+}
+
+
+TYPED_TEST(Csr, ThrowsForDataWithDifferentSparsity)
+{
+    using value_type = typename TestFixture::value_type;
+    using index_type = typename TestFixture::index_type;
+    using BatchCsrMtx = typename TestFixture::BatchCsrMtx;
+    auto vec_data = std::vector<gko::matrix_data<value_type, index_type>>{};
+    vec_data.emplace_back(
+        gko::matrix_data<value_type, index_type>({2, 3}, {
+                                                             {0, 0, -1.0},
+                                                             {1, 1, 2.5},
+                                                             {2, 2, -3.0},
+                                                         }));
+    vec_data.emplace_back(gko::matrix_data<value_type, index_type>(
+        {2, 3}, {{0, 0, 1.0}, {1, 1, 2.0}, {1, 2, 3.0}}));
+
+    EXPECT_THROW(
+        gko::batch::detail::assert_same_sparsity_in_batched_data(vec_data),
+        gko::NotImplemented);
+}
+
+
+TYPED_TEST(Csr, GeneratesCorrectMatrixData)
+{
+    using value_type = typename TestFixture::value_type;
+    using index_type = typename TestFixture::index_type;
+    using BatchCsrMtx = typename TestFixture::BatchCsrMtx;
+    using tpl = typename gko::matrix_data<TypeParam>::nonzero_type;
+
+    auto data = gko::batch::write<value_type, index_type, BatchCsrMtx>(
+        this->sp_mtx.get());
+
+    ASSERT_EQ(data[0].size, gko::dim<2>(2, 3));
+    ASSERT_EQ(data[0].nonzeros.size(), 3);
+    EXPECT_EQ(data[0].nonzeros[0], tpl(0, 0, value_type{-1.0}));
+    EXPECT_EQ(data[0].nonzeros[1], tpl(1, 1, value_type{2.5}));
+    EXPECT_EQ(data[0].nonzeros[2], tpl(1, 2, value_type{3.5}));
+    ASSERT_EQ(data[1].size, gko::dim<2>(2, 3));
+    ASSERT_EQ(data[1].nonzeros.size(), 3);
+    EXPECT_EQ(data[1].nonzeros[0], tpl(0, 0, value_type{1.0}));
+    EXPECT_EQ(data[1].nonzeros[1], tpl(1, 1, value_type{2.0}));
+    EXPECT_EQ(data[1].nonzeros[2], tpl(1, 2, value_type{3.0}));
+}

--- a/core/test/matrix/batch_csr.cpp
+++ b/core/test/matrix/batch_csr.cpp
@@ -1,34 +1,6 @@
-/*******************************<GINKGO LICENSE>******************************
-Copyright (c) 2017-2023, the Ginkgo authors
-All rights reserved.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions
-are met:
-
-1. Redistributions of source code must retain the above copyright
-notice, this list of conditions and the following disclaimer.
-
-2. Redistributions in binary form must reproduce the above copyright
-notice, this list of conditions and the following disclaimer in the
-documentation and/or other materials provided with the distribution.
-
-3. Neither the name of the copyright holder nor the names of its
-contributors may be used to endorse or promote products derived from
-this software without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
-IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
-TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-******************************<GINKGO LICENSE>*******************************/
+// SPDX-FileCopyrightText: 2017-2023 The Ginkgo authors
+//
+// SPDX-License-Identifier: BSD-3-Clause
 
 #include <ginkgo/core/matrix/batch_csr.hpp>
 

--- a/core/test/matrix/batch_csr.cpp
+++ b/core/test/matrix/batch_csr.cpp
@@ -447,47 +447,6 @@ TYPED_TEST(Csr, CanBeReadFromMatrixData)
 }
 
 
-TYPED_TEST(Csr, ThrowsForDataWithDifferentNnz)
-{
-    using value_type = typename TestFixture::value_type;
-    using index_type = typename TestFixture::index_type;
-    auto vec_data = std::vector<gko::matrix_data<value_type, index_type>>{};
-    vec_data.emplace_back(
-        gko::matrix_data<value_type, index_type>({2, 3}, {
-                                                             {0, 0, -1.0},
-                                                             {1, 1, 2.5},
-                                                             {1, 2, 0.5},
-                                                             {2, 2, -3.0},
-                                                         }));
-    vec_data.emplace_back(gko::matrix_data<value_type, index_type>(
-        {2, 3}, {{0, 0, 1.0}, {1, 1, 2.0}, {1, 2, 3.0}}));
-
-    EXPECT_THROW(
-        gko::batch::detail::assert_same_sparsity_in_batched_data(vec_data),
-        gko::NotImplemented);
-}
-
-
-TYPED_TEST(Csr, ThrowsForDataWithDifferentSparsity)
-{
-    using value_type = typename TestFixture::value_type;
-    using index_type = typename TestFixture::index_type;
-    auto vec_data = std::vector<gko::matrix_data<value_type, index_type>>{};
-    vec_data.emplace_back(
-        gko::matrix_data<value_type, index_type>({2, 3}, {
-                                                             {0, 0, -1.0},
-                                                             {1, 1, 2.5},
-                                                             {2, 2, -3.0},
-                                                         }));
-    vec_data.emplace_back(gko::matrix_data<value_type, index_type>(
-        {2, 3}, {{0, 0, 1.0}, {1, 1, 2.0}, {1, 2, 3.0}}));
-
-    EXPECT_THROW(
-        gko::batch::detail::assert_same_sparsity_in_batched_data(vec_data),
-        gko::NotImplemented);
-}
-
-
 TYPED_TEST(Csr, GeneratesCorrectMatrixData)
 {
     using value_type = typename TestFixture::value_type;

--- a/cuda/CMakeLists.txt
+++ b/cuda/CMakeLists.txt
@@ -38,6 +38,7 @@ target_sources(ginkgo_cuda
     factorization/par_ilut_select_kernel.cu
     factorization/par_ilut_spgeam_kernel.cu
     factorization/par_ilut_sweep_kernel.cu
+    matrix/batch_csr_kernels.cu
     matrix/batch_dense_kernels.cu
     matrix/batch_ell_kernels.cu
     matrix/coo_kernels.cu

--- a/cuda/matrix/batch_csr_kernels.cu
+++ b/cuda/matrix/batch_csr_kernels.cu
@@ -1,0 +1,85 @@
+/*******************************<GINKGO LICENSE>******************************
+Copyright (c) 2017-2023, the Ginkgo authors
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+******************************<GINKGO LICENSE>*******************************/
+
+#include "core/matrix/batch_csr_kernels.hpp"
+
+
+#include <thrust/functional.h>
+
+
+#include <ginkgo/core/base/batch_multi_vector.hpp>
+#include <ginkgo/core/base/types.hpp>
+#include <ginkgo/core/matrix/batch_csr.hpp>
+
+
+#include "core/base/batch_struct.hpp"
+#include "core/matrix/batch_struct.hpp"
+#include "cuda/base/batch_struct.hpp"
+#include "cuda/base/config.hpp"
+#include "cuda/base/thrust.cuh"
+#include "cuda/components/cooperative_groups.cuh"
+#include "cuda/components/reduction.cuh"
+#include "cuda/components/thread_ids.cuh"
+#include "cuda/components/uninitialized_array.hpp"
+#include "cuda/matrix/batch_struct.hpp"
+
+
+namespace gko {
+namespace kernels {
+namespace cuda {
+/**
+ * @brief The Csr matrix format namespace.
+ * @ref Csr
+ * @ingroup batch_csr
+ */
+namespace batch_csr {
+
+
+constexpr auto default_block_size = 256;
+constexpr int sm_oversubscription = 4;
+
+// clang-format off
+
+// NOTE: DO NOT CHANGE THE ORDERING OF THE INCLUDES
+
+// #include "common/cuda_hip/matrix/batch_csr_kernels.hpp.inc"
+
+
+#include "common/cuda_hip/matrix/batch_csr_kernel_launcher.hpp.inc"
+
+// clang-format on
+
+
+}  // namespace batch_csr
+}  // namespace cuda
+}  // namespace kernels
+}  // namespace gko

--- a/cuda/matrix/batch_csr_kernels.cu
+++ b/cuda/matrix/batch_csr_kernels.cu
@@ -71,7 +71,7 @@ constexpr int sm_oversubscription = 4;
 
 // NOTE: DO NOT CHANGE THE ORDERING OF THE INCLUDES
 
-// #include "common/cuda_hip/matrix/batch_csr_kernels.hpp.inc"
+#include "common/cuda_hip/matrix/batch_csr_kernels.hpp.inc"
 
 
 #include "common/cuda_hip/matrix/batch_csr_kernel_launcher.hpp.inc"

--- a/cuda/matrix/batch_csr_kernels.cu
+++ b/cuda/matrix/batch_csr_kernels.cu
@@ -1,34 +1,6 @@
-/*******************************<GINKGO LICENSE>******************************
-Copyright (c) 2017-2023, the Ginkgo authors
-All rights reserved.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions
-are met:
-
-1. Redistributions of source code must retain the above copyright
-notice, this list of conditions and the following disclaimer.
-
-2. Redistributions in binary form must reproduce the above copyright
-notice, this list of conditions and the following disclaimer in the
-documentation and/or other materials provided with the distribution.
-
-3. Neither the name of the copyright holder nor the names of its
-contributors may be used to endorse or promote products derived from
-this software without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
-IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
-TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-******************************<GINKGO LICENSE>*******************************/
+// SPDX-FileCopyrightText: 2017-2023 The Ginkgo authors
+//
+// SPDX-License-Identifier: BSD-3-Clause
 
 #include "core/matrix/batch_csr_kernels.hpp"
 

--- a/cuda/matrix/batch_struct.hpp
+++ b/cuda/matrix/batch_struct.hpp
@@ -33,6 +33,43 @@ namespace cuda {
 
 
 /**
+ * Generates an immutable uniform batch struct from a batch of csr matrices.
+ */
+template <typename ValueType, typename IndexType>
+inline batch::matrix::csr::uniform_batch<const cuda_type<ValueType>,
+                                         const IndexType>
+get_batch_struct(const batch::matrix::Csr<ValueType, IndexType>* const op)
+{
+    return {as_cuda_type(op->get_const_values()),
+            op->get_const_col_idxs(),
+            op->get_const_row_ptrs(),
+            op->get_num_batch_items(),
+            static_cast<IndexType>(op->get_common_size()[1]),
+            static_cast<IndexType>(op->get_common_size()[0]),
+            static_cast<IndexType>(op->get_common_size()[1]),
+            static_cast<IndexType>(op->get_num_elements_per_item())};
+}
+
+
+/**
+ * Generates a uniform batch struct from a batch of csr matrices.
+ */
+template <typename ValueType, typename IndexType>
+inline batch::matrix::csr::uniform_batch<cuda_type<ValueType>, IndexType>
+get_batch_struct(batch::matrix::Csr<ValueType, IndexType>* const op)
+{
+    return {as_cuda_type(op->get_values()),
+            op->get_col_idxs(),
+            op->get_row_ptrs(),
+            op->get_num_batch_items(),
+            static_cast<IndexType>(op->get_common_size()[1]),
+            static_cast<IndexType>(op->get_common_size()[0]),
+            static_cast<IndexType>(op->get_common_size()[1]),
+            static_cast<IndexType>(op->get_num_elements_per_item())};
+}
+
+
+/**
  * Generates an immutable uniform batch struct from a batch of dense matrices.
  */
 template <typename ValueType>

--- a/cuda/matrix/batch_struct.hpp
+++ b/cuda/matrix/batch_struct.hpp
@@ -44,7 +44,6 @@ get_batch_struct(const batch::matrix::Csr<ValueType, IndexType>* const op)
             op->get_const_col_idxs(),
             op->get_const_row_ptrs(),
             op->get_num_batch_items(),
-            static_cast<IndexType>(op->get_common_size()[1]),
             static_cast<IndexType>(op->get_common_size()[0]),
             static_cast<IndexType>(op->get_common_size()[1]),
             static_cast<IndexType>(op->get_num_elements_per_item())};
@@ -62,7 +61,6 @@ get_batch_struct(batch::matrix::Csr<ValueType, IndexType>* const op)
             op->get_col_idxs(),
             op->get_row_ptrs(),
             op->get_num_batch_items(),
-            static_cast<IndexType>(op->get_common_size()[1]),
             static_cast<IndexType>(op->get_common_size()[0]),
             static_cast<IndexType>(op->get_common_size()[1]),
             static_cast<IndexType>(op->get_num_elements_per_item())};

--- a/cuda/solver/batch_bicgstab_kernels.cu
+++ b/cuda/solver/batch_bicgstab_kernels.cu
@@ -48,6 +48,7 @@ namespace batch_bicgstab {
 
 #include "common/cuda_hip/base/batch_multi_vector_kernels.hpp.inc"
 #include "common/cuda_hip/components/uninitialized_array.hpp.inc"
+#include "common/cuda_hip/matrix/batch_csr_kernels.hpp.inc"
 #include "common/cuda_hip/matrix/batch_dense_kernels.hpp.inc"
 #include "common/cuda_hip/matrix/batch_ell_kernels.hpp.inc"
 #include "common/cuda_hip/solver/batch_bicgstab_kernels.hpp.inc"

--- a/dpcpp/CMakeLists.txt
+++ b/dpcpp/CMakeLists.txt
@@ -36,6 +36,7 @@ target_sources(ginkgo_dpcpp
     factorization/par_ilut_select_kernel.dp.cpp
     factorization/par_ilut_spgeam_kernel.dp.cpp
     factorization/par_ilut_sweep_kernel.dp.cpp
+    matrix/batch_csr_kernels.dp.cpp
     matrix/batch_dense_kernels.dp.cpp
     matrix/batch_ell_kernels.dp.cpp
     matrix/coo_kernels.dp.cpp

--- a/dpcpp/matrix/batch_csr_kernels.dp.cpp
+++ b/dpcpp/matrix/batch_csr_kernels.dp.cpp
@@ -97,17 +97,18 @@ void simple_apply(std::shared_ptr<const DefaultExecutor> exec,
     // Launch a kernel that has nbatches blocks, each block has max group size
     exec->get_queue()->submit([&](sycl::handler& cgh) {
         cgh.parallel_for(
-            sycl_nd_range(grid, block), [=
-        ](sycl::nd_item<3> item_ct1) [[sycl::reqd_sub_group_size(
-                                            config::warp_size)]] {
-                auto group = item_ct1.get_group();
-                auto group_id = group.get_group_linear_id();
-                const auto mat_b =
-                    batch::matrix::extract_batch_item(mat_ub, group_id);
-                const auto b_b = batch::extract_batch_item(b_ub, group_id);
-                const auto x_b = batch::extract_batch_item(x_ub, group_id);
-                simple_apply_kernel(mat_b, b_b.values, x_b.values, item_ct1);
-            });
+            sycl_nd_range(grid, block),
+            [=](sycl::nd_item<3> item_ct1)
+                [[sycl::reqd_sub_group_size(config::warp_size)]] {
+                    auto group = item_ct1.get_group();
+                    auto group_id = group.get_group_linear_id();
+                    const auto mat_b =
+                        batch::matrix::extract_batch_item(mat_ub, group_id);
+                    const auto b_b = batch::extract_batch_item(b_ub, group_id);
+                    const auto x_b = batch::extract_batch_item(x_ub, group_id);
+                    simple_apply_kernel(mat_b, b_b.values, x_b.values,
+                                        item_ct1);
+                });
     });
 }
 
@@ -145,22 +146,23 @@ void advanced_apply(std::shared_ptr<const DefaultExecutor> exec,
     // Launch a kernel that has nbatches blocks, each block has max group size
     exec->get_queue()->submit([&](sycl::handler& cgh) {
         cgh.parallel_for(
-            sycl_nd_range(grid, block), [=
-        ](sycl::nd_item<3> item_ct1) [[sycl::reqd_sub_group_size(
-                                            config::warp_size)]] {
-                auto group = item_ct1.get_group();
-                auto group_id = group.get_group_linear_id();
-                const auto mat_b =
-                    batch::matrix::extract_batch_item(mat_ub, group_id);
-                const auto b_b = batch::extract_batch_item(b_ub, group_id);
-                const auto x_b = batch::extract_batch_item(x_ub, group_id);
-                const auto alpha_b =
-                    batch::extract_batch_item(alpha_ub, group_id);
-                const auto beta_b =
-                    batch::extract_batch_item(beta_ub, group_id);
-                advanced_apply_kernel(alpha_b.values[0], mat_b, b_b.values,
-                                      beta_b.values[0], x_b.values, item_ct1);
-            });
+            sycl_nd_range(grid, block),
+            [=](sycl::nd_item<3> item_ct1)
+                [[sycl::reqd_sub_group_size(config::warp_size)]] {
+                    auto group = item_ct1.get_group();
+                    auto group_id = group.get_group_linear_id();
+                    const auto mat_b =
+                        batch::matrix::extract_batch_item(mat_ub, group_id);
+                    const auto b_b = batch::extract_batch_item(b_ub, group_id);
+                    const auto x_b = batch::extract_batch_item(x_ub, group_id);
+                    const auto alpha_b =
+                        batch::extract_batch_item(alpha_ub, group_id);
+                    const auto beta_b =
+                        batch::extract_batch_item(beta_ub, group_id);
+                    advanced_apply_kernel(alpha_b.values[0], mat_b, b_b.values,
+                                          beta_b.values[0], x_b.values,
+                                          item_ct1);
+                });
     });
 }
 

--- a/dpcpp/matrix/batch_csr_kernels.dp.cpp
+++ b/dpcpp/matrix/batch_csr_kernels.dp.cpp
@@ -1,0 +1,98 @@
+/*******************************<GINKGO LICENSE>******************************
+Copyright (c) 2017-2023, the Ginkgo authors
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+******************************<GINKGO LICENSE>*******************************/
+
+#include "core/matrix/batch_csr_kernels.hpp"
+
+
+#include <algorithm>
+
+
+#include <CL/sycl.hpp>
+
+
+#include <ginkgo/core/base/batch_multi_vector.hpp>
+#include <ginkgo/core/matrix/batch_csr.hpp>
+
+
+#include "core/base/batch_struct.hpp"
+#include "core/matrix/batch_struct.hpp"
+#include "dpcpp/base/batch_struct.hpp"
+#include "dpcpp/base/dim3.dp.hpp"
+#include "dpcpp/base/dpct.hpp"
+#include "dpcpp/base/helper.hpp"
+#include "dpcpp/components/cooperative_groups.dp.hpp"
+#include "dpcpp/components/intrinsics.dp.hpp"
+#include "dpcpp/components/reduction.dp.hpp"
+#include "dpcpp/components/thread_ids.dp.hpp"
+#include "dpcpp/matrix/batch_struct.hpp"
+
+
+namespace gko {
+namespace kernels {
+namespace dpcpp {
+/**
+ * @brief The Csr matrix format namespace.
+ * @ref Csr
+ * @ingroup batch_csr
+ */
+namespace batch_csr {
+
+
+// #include "dpcpp/matrix/batch_csr_kernels.hpp.inc"
+
+
+template <typename ValueType, typename IndexType>
+void simple_apply(std::shared_ptr<const DefaultExecutor> exec,
+                  const batch::matrix::Csr<ValueType, IndexType>* mat,
+                  const batch::MultiVector<ValueType>* b,
+                  batch::MultiVector<ValueType>* x) GKO_NOT_IMPLEMENTED;
+
+GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INT32_TYPE(
+    GKO_DECLARE_BATCH_CSR_SIMPLE_APPLY_KERNEL);
+
+
+template <typename ValueType, typename IndexType>
+void advanced_apply(std::shared_ptr<const DefaultExecutor> exec,
+                    const batch::MultiVector<ValueType>* alpha,
+                    const batch::matrix::Csr<ValueType, IndexType>* mat,
+                    const batch::MultiVector<ValueType>* b,
+                    const batch::MultiVector<ValueType>* beta,
+                    batch::MultiVector<ValueType>* x) GKO_NOT_IMPLEMENTED;
+
+GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INT32_TYPE(
+    GKO_DECLARE_BATCH_CSR_ADVANCED_APPLY_KERNEL);
+
+
+}  // namespace batch_csr
+}  // namespace dpcpp
+}  // namespace kernels
+}  // namespace gko

--- a/dpcpp/matrix/batch_csr_kernels.dp.cpp
+++ b/dpcpp/matrix/batch_csr_kernels.dp.cpp
@@ -67,14 +67,49 @@ namespace dpcpp {
 namespace batch_csr {
 
 
-// #include "dpcpp/matrix/batch_csr_kernels.hpp.inc"
+#include "dpcpp/matrix/batch_csr_kernels.hpp.inc"
 
 
 template <typename ValueType, typename IndexType>
 void simple_apply(std::shared_ptr<const DefaultExecutor> exec,
                   const batch::matrix::Csr<ValueType, IndexType>* mat,
                   const batch::MultiVector<ValueType>* b,
-                  batch::MultiVector<ValueType>* x) GKO_NOT_IMPLEMENTED;
+                  batch::MultiVector<ValueType>* x)
+{
+    const size_type num_rows = mat->get_common_size()[0];
+    const size_type num_cols = mat->get_common_size()[1];
+
+    const auto num_batch_items = mat->get_num_batch_items();
+    auto device = exec->get_queue()->get_device();
+    // TODO: use runtime selection of group size based on num_rows.
+    auto group_size =
+        device.get_info<sycl::info::device::max_work_group_size>();
+
+    const dim3 block(group_size);
+    const dim3 grid(num_batch_items);
+    const auto x_ub = get_batch_struct(x);
+    const auto b_ub = get_batch_struct(b);
+    const auto mat_ub = get_batch_struct(mat);
+    if (b_ub.num_rhs > 1) {
+        GKO_NOT_IMPLEMENTED;
+    }
+
+    // Launch a kernel that has nbatches blocks, each block has max group size
+    exec->get_queue()->submit([&](sycl::handler& cgh) {
+        cgh.parallel_for(
+            sycl_nd_range(grid, block), [=
+        ](sycl::nd_item<3> item_ct1) [[sycl::reqd_sub_group_size(
+                                            config::warp_size)]] {
+                auto group = item_ct1.get_group();
+                auto group_id = group.get_group_linear_id();
+                const auto mat_b =
+                    batch::matrix::extract_batch_item(mat_ub, group_id);
+                const auto b_b = batch::extract_batch_item(b_ub, group_id);
+                const auto x_b = batch::extract_batch_item(x_ub, group_id);
+                simple_apply_kernel(mat_b, b_b.values, x_b.values, item_ct1);
+            });
+    });
+}
 
 GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INT32_TYPE(
     GKO_DECLARE_BATCH_CSR_SIMPLE_APPLY_KERNEL);
@@ -86,7 +121,48 @@ void advanced_apply(std::shared_ptr<const DefaultExecutor> exec,
                     const batch::matrix::Csr<ValueType, IndexType>* mat,
                     const batch::MultiVector<ValueType>* b,
                     const batch::MultiVector<ValueType>* beta,
-                    batch::MultiVector<ValueType>* x) GKO_NOT_IMPLEMENTED;
+                    batch::MultiVector<ValueType>* x)
+{
+    const auto mat_ub = get_batch_struct(mat);
+    const auto b_ub = get_batch_struct(b);
+    const auto x_ub = get_batch_struct(x);
+    const auto alpha_ub = get_batch_struct(alpha);
+    const auto beta_ub = get_batch_struct(beta);
+
+    if (b_ub.num_rhs > 1) {
+        GKO_NOT_IMPLEMENTED;
+    }
+
+    const auto num_batch_items = mat_ub.num_batch_items;
+    auto device = exec->get_queue()->get_device();
+    // TODO: use runtime selection of group size based on num_rows.
+    auto group_size =
+        device.get_info<sycl::info::device::max_work_group_size>();
+
+    const dim3 block(group_size);
+    const dim3 grid(num_batch_items);
+
+    // Launch a kernel that has nbatches blocks, each block has max group size
+    exec->get_queue()->submit([&](sycl::handler& cgh) {
+        cgh.parallel_for(
+            sycl_nd_range(grid, block), [=
+        ](sycl::nd_item<3> item_ct1) [[sycl::reqd_sub_group_size(
+                                            config::warp_size)]] {
+                auto group = item_ct1.get_group();
+                auto group_id = group.get_group_linear_id();
+                const auto mat_b =
+                    batch::matrix::extract_batch_item(mat_ub, group_id);
+                const auto b_b = batch::extract_batch_item(b_ub, group_id);
+                const auto x_b = batch::extract_batch_item(x_ub, group_id);
+                const auto alpha_b =
+                    batch::extract_batch_item(alpha_ub, group_id);
+                const auto beta_b =
+                    batch::extract_batch_item(beta_ub, group_id);
+                advanced_apply_kernel(alpha_b.values[0], mat_b, b_b.values,
+                                      beta_b.values[0], x_b.values, item_ct1);
+            });
+    });
+}
 
 GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INT32_TYPE(
     GKO_DECLARE_BATCH_CSR_ADVANCED_APPLY_KERNEL);

--- a/dpcpp/matrix/batch_csr_kernels.dp.cpp
+++ b/dpcpp/matrix/batch_csr_kernels.dp.cpp
@@ -1,34 +1,6 @@
-/*******************************<GINKGO LICENSE>******************************
-Copyright (c) 2017-2023, the Ginkgo authors
-All rights reserved.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions
-are met:
-
-1. Redistributions of source code must retain the above copyright
-notice, this list of conditions and the following disclaimer.
-
-2. Redistributions in binary form must reproduce the above copyright
-notice, this list of conditions and the following disclaimer in the
-documentation and/or other materials provided with the distribution.
-
-3. Neither the name of the copyright holder nor the names of its
-contributors may be used to endorse or promote products derived from
-this software without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
-IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
-TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-******************************<GINKGO LICENSE>*******************************/
+// SPDX-FileCopyrightText: 2017-2023 The Ginkgo authors
+//
+// SPDX-License-Identifier: BSD-3-Clause
 
 #include "core/matrix/batch_csr_kernels.hpp"
 

--- a/dpcpp/matrix/batch_csr_kernels.hpp.inc
+++ b/dpcpp/matrix/batch_csr_kernels.hpp.inc
@@ -37,8 +37,8 @@ __dpct_inline__ void advanced_apply_kernel(
         auto temp = zero<ValueType>();
         for (auto nnz = mat.row_ptrs[row]; nnz < mat.row_ptrs[row + 1]; nnz++) {
             const auto col_idx = col[nnz];
-            temp += alpha * val[nnz] * b[col_idx];
+            temp += val[nnz] * b[col_idx];
         }
-        x[row] = temp + beta * x[row];
+        x[row] = alpha * temp + beta * x[row];
     }
 }

--- a/dpcpp/matrix/batch_csr_kernels.hpp.inc
+++ b/dpcpp/matrix/batch_csr_kernels.hpp.inc
@@ -1,34 +1,6 @@
-/*******************************<GINKGO LICENSE>******************************
-Copyright (c) 2017-2023, the Ginkgo authors
-All rights reserved.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions
-are met:
-
-1. Redistributions of source code must retain the above copyright
-notice, this list of conditions and the following disclaimer.
-
-2. Redistributions in binary form must reproduce the above copyright
-notice, this list of conditions and the following disclaimer in the
-documentation and/or other materials provided with the distribution.
-
-3. Neither the name of the copyright holder nor the names of its
-contributors may be used to endorse or promote products derived from
-this software without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
-IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
-TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-******************************<GINKGO LICENSE>*******************************/
+// SPDX-FileCopyrightText: 2017-2023 The Ginkgo authors
+//
+// SPDX-License-Identifier: BSD-3-Clause
 
 template <typename ValueType, typename IndexType>
 __dpct_inline__ void simple_apply_kernel(

--- a/dpcpp/matrix/batch_csr_kernels.hpp.inc
+++ b/dpcpp/matrix/batch_csr_kernels.hpp.inc
@@ -1,0 +1,84 @@
+/*******************************<GINKGO LICENSE>******************************
+Copyright (c) 2017-2023, the Ginkgo authors
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+******************************<GINKGO LICENSE>*******************************/
+
+template <typename ValueType, typename IndexType>
+__dpct_inline__ void simple_apply_kernel(
+    const gko::batch::matrix::csr::batch_item<const ValueType, IndexType>& mat,
+    const ValueType* b, ValueType* x, sycl::nd_item<3>& item_ct1)
+{
+    const auto num_rows = mat.num_rows;
+    const auto val = mat.values;
+    const auto col = mat.col_idxs;
+    for (int tidx = item_ct1.get_local_linear_id(); tidx < num_rows;
+         tidx += item_ct1.get_local_range().size()) {
+        auto temp = zero<ValueType>();
+        for (auto nnz = mat.row_ptrs[tidx]; nnz < mat.row_ptrs[tidx + 1];
+             nnz++) {
+            const auto col_idx = col[nnz];
+            temp += val[nnz] * b[col_idx];
+        }
+        c[tidx] = temp;
+    }
+}
+
+
+template <typename ValueType, typename IndexType>
+__dpct_inline__ void advanced_apply_kernel(
+    const ValueType alpha,
+    const gko::batch::matrix::csr::batch_item<const ValueType, IndexType>& mat,
+    const ValueType* b, const ValueType beta, ValueType* x,
+    sycl::nd_item<3>& item_ct1)
+{
+    auto sg = item_ct1.get_sub_group();
+
+    for (int row = sg.get_group_id(); row < mat.num_rows;
+         row += sg.get_group_range().size()) {
+        const int row_start = mat.row_ptrs[row];
+        const int row_end = mat.row_ptrs[row + 1];
+
+        ValueType temp = zero<ValueType>();
+        for (int i = sg.get_local_id() + row_start; i < row_end;
+             i += sg.get_local_range().size()) {
+            const int col = mat.col_idxs[i];
+            const ValueType val = mat.values[i];
+            temp += val * b[col];
+        }
+
+        temp = ::gko::kernels::dpcpp::reduce(
+            sg, temp, [](ValueType a, ValueType b) { return a + b; });
+
+
+        if (sg.get_local_id() == 0) {
+            c[row] = alpha * temp + beta * c[row];
+        }
+    }
+}

--- a/dpcpp/matrix/batch_csr_kernels.hpp.inc
+++ b/dpcpp/matrix/batch_csr_kernels.hpp.inc
@@ -38,15 +38,14 @@ __dpct_inline__ void simple_apply_kernel(
     const auto num_rows = mat.num_rows;
     const auto val = mat.values;
     const auto col = mat.col_idxs;
-    for (int tidx = item_ct1.get_local_linear_id(); tidx < num_rows;
-         tidx += item_ct1.get_local_range().size()) {
+    for (int row = item_ct1.get_local_linear_id(); row < num_rows;
+         row += item_ct1.get_local_range().size()) {
         auto temp = zero<ValueType>();
-        for (auto nnz = mat.row_ptrs[tidx]; nnz < mat.row_ptrs[tidx + 1];
-             nnz++) {
+        for (auto nnz = mat.row_ptrs[row]; nnz < mat.row_ptrs[row + 1]; nnz++) {
             const auto col_idx = col[nnz];
             temp += val[nnz] * b[col_idx];
         }
-        c[tidx] = temp;
+        x[row] = temp;
     }
 }
 
@@ -58,27 +57,16 @@ __dpct_inline__ void advanced_apply_kernel(
     const ValueType* b, const ValueType beta, ValueType* x,
     sycl::nd_item<3>& item_ct1)
 {
-    auto sg = item_ct1.get_sub_group();
-
-    for (int row = sg.get_group_id(); row < mat.num_rows;
-         row += sg.get_group_range().size()) {
-        const int row_start = mat.row_ptrs[row];
-        const int row_end = mat.row_ptrs[row + 1];
-
-        ValueType temp = zero<ValueType>();
-        for (int i = sg.get_local_id() + row_start; i < row_end;
-             i += sg.get_local_range().size()) {
-            const int col = mat.col_idxs[i];
-            const ValueType val = mat.values[i];
-            temp += val * b[col];
+    const auto num_rows = mat.num_rows;
+    const auto val = mat.values;
+    const auto col = mat.col_idxs;
+    for (int row = item_ct1.get_local_linear_id(); row < num_rows;
+         row += item_ct1.get_local_range().size()) {
+        auto temp = zero<ValueType>();
+        for (auto nnz = mat.row_ptrs[row]; nnz < mat.row_ptrs[row + 1]; nnz++) {
+            const auto col_idx = col[nnz];
+            temp += alpha * val[nnz] * b[col_idx];
         }
-
-        temp = ::gko::kernels::dpcpp::reduce(
-            sg, temp, [](ValueType a, ValueType b) { return a + b; });
-
-
-        if (sg.get_local_id() == 0) {
-            c[row] = alpha * temp + beta * c[row];
-        }
+        x[row] = temp + beta * x[row];
     }
 }

--- a/dpcpp/matrix/batch_struct.hpp
+++ b/dpcpp/matrix/batch_struct.hpp
@@ -32,6 +32,42 @@ namespace dpcpp {
 
 
 /**
+ * Generates an immutable uniform batch struct from a batch of csr matrices.
+ */
+template <typename ValueType, typename IndexType>
+inline batch::matrix::csr::uniform_batch<const ValueType, const IndexType>
+get_batch_struct(const batch::matrix::Csr<ValueType, IndexType>* const op)
+{
+    return {op->get_const_values(),
+            op->get_const_col_idxs(),
+            op->get_const_row_ptrs(),
+            op->get_num_batch_items(),
+            static_cast<IndexType>(op->get_common_size()[1]),
+            static_cast<IndexType>(op->get_common_size()[0]),
+            static_cast<IndexType>(op->get_common_size()[1]),
+            static_cast<IndexType>(op->get_num_elements_per_item())};
+}
+
+
+/**
+ * Generates a uniform batch struct from a batch of csr matrices.
+ */
+template <typename ValueType, typename IndexType>
+inline batch::matrix::csr::uniform_batch<ValueType, IndexType> get_batch_struct(
+    batch::matrix::Csr<ValueType, IndexType>* const op)
+{
+    return {op->get_values(),
+            op->get_col_idxs(),
+            op->get_row_ptrs(),
+            op->get_num_batch_items(),
+            static_cast<IndexType>(op->get_common_size()[1]),
+            static_cast<IndexType>(op->get_common_size()[0]),
+            static_cast<IndexType>(op->get_common_size()[1]),
+            static_cast<IndexType>(op->get_num_elements_per_item())};
+}
+
+
+/**
  * Generates an immutable uniform batch struct from a batch of dense matrices.
  */
 template <typename ValueType>

--- a/dpcpp/matrix/batch_struct.hpp
+++ b/dpcpp/matrix/batch_struct.hpp
@@ -42,7 +42,6 @@ get_batch_struct(const batch::matrix::Csr<ValueType, IndexType>* const op)
             op->get_const_col_idxs(),
             op->get_const_row_ptrs(),
             op->get_num_batch_items(),
-            static_cast<IndexType>(op->get_common_size()[1]),
             static_cast<IndexType>(op->get_common_size()[0]),
             static_cast<IndexType>(op->get_common_size()[1]),
             static_cast<IndexType>(op->get_num_elements_per_item())};
@@ -60,7 +59,6 @@ inline batch::matrix::csr::uniform_batch<ValueType, IndexType> get_batch_struct(
             op->get_col_idxs(),
             op->get_row_ptrs(),
             op->get_num_batch_items(),
-            static_cast<IndexType>(op->get_common_size()[1]),
             static_cast<IndexType>(op->get_common_size()[0]),
             static_cast<IndexType>(op->get_common_size()[1]),
             static_cast<IndexType>(op->get_num_elements_per_item())};

--- a/dpcpp/solver/batch_bicgstab_kernels.dp.cpp
+++ b/dpcpp/solver/batch_bicgstab_kernels.dp.cpp
@@ -40,6 +40,7 @@ namespace batch_bicgstab {
 
 
 #include "dpcpp/base/batch_multi_vector_kernels.hpp.inc"
+#include "dpcpp/matrix/batch_csr_kernels.hpp.inc"
 #include "dpcpp/matrix/batch_dense_kernels.hpp.inc"
 #include "dpcpp/matrix/batch_ell_kernels.hpp.inc"
 #include "dpcpp/solver/batch_bicgstab_kernels.hpp.inc"
@@ -90,9 +91,10 @@ public:
                 slm_values(sycl::range<1>(shared_size), cgh);
 
             cgh.parallel_for(
-                sycl_nd_range(grid, block),
-                [=](sycl::nd_item<3> item_ct1) [[intel::reqd_sub_group_size(
-                    subgroup_size)]] [[intel::kernel_args_restrict]] {
+                sycl_nd_range(grid, block), [=
+            ](sycl::nd_item<3> item_ct1) [[intel::reqd_sub_group_size(
+                                                subgroup_size)]] [
+                                                [intel::kernel_args_restrict]] {
                     auto batch_id = item_ct1.get_group_linear_id();
                     const auto mat_global_entry =
                         gko::batch::matrix::extract_batch_item(mat, batch_id);

--- a/dpcpp/solver/batch_bicgstab_kernels.dp.cpp
+++ b/dpcpp/solver/batch_bicgstab_kernels.dp.cpp
@@ -91,10 +91,9 @@ public:
                 slm_values(sycl::range<1>(shared_size), cgh);
 
             cgh.parallel_for(
-                sycl_nd_range(grid, block), [=
-            ](sycl::nd_item<3> item_ct1) [[intel::reqd_sub_group_size(
-                                                subgroup_size)]] [
-                                                [intel::kernel_args_restrict]] {
+                sycl_nd_range(grid, block),
+                [=](sycl::nd_item<3> item_ct1) [[intel::reqd_sub_group_size(
+                    subgroup_size)]] [[intel::kernel_args_restrict]] {
                     auto batch_id = item_ct1.get_group_linear_id();
                     const auto mat_global_entry =
                         gko::batch::matrix::extract_batch_item(mat, batch_id);

--- a/hip/CMakeLists.txt
+++ b/hip/CMakeLists.txt
@@ -35,6 +35,7 @@ set(GINKGO_HIP_SOURCES
     factorization/par_ilut_select_kernel.hip.cpp
     factorization/par_ilut_spgeam_kernel.hip.cpp
     factorization/par_ilut_sweep_kernel.hip.cpp
+    matrix/batch_csr_kernels.hip.cpp
     matrix/batch_dense_kernels.hip.cpp
     matrix/batch_ell_kernels.hip.cpp
     matrix/coo_kernels.hip.cpp

--- a/hip/matrix/batch_csr_kernels.hip.cpp
+++ b/hip/matrix/batch_csr_kernels.hip.cpp
@@ -1,0 +1,86 @@
+/*******************************<GINKGO LICENSE>******************************
+Copyright (c) 2017-2023, the Ginkgo authors
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+******************************<GINKGO LICENSE>*******************************/
+
+#include "core/matrix/batch_csr_kernels.hpp"
+
+
+#include <hip/hip_runtime.h>
+#include <thrust/functional.h>
+
+
+#include <ginkgo/core/base/batch_multi_vector.hpp>
+#include <ginkgo/core/base/types.hpp>
+#include <ginkgo/core/matrix/batch_csr.hpp>
+
+
+#include "core/base/batch_struct.hpp"
+#include "core/matrix/batch_struct.hpp"
+#include "hip/base/batch_struct.hip.hpp"
+#include "hip/base/config.hip.hpp"
+#include "hip/base/thrust.hip.hpp"
+#include "hip/components/cooperative_groups.hip.hpp"
+#include "hip/components/reduction.hip.hpp"
+#include "hip/components/thread_ids.hip.hpp"
+#include "hip/components/uninitialized_array.hip.hpp"
+#include "hip/matrix/batch_struct.hip.hpp"
+
+
+namespace gko {
+namespace kernels {
+namespace hip {
+/**
+ * @brief The Csr matrix format namespace.
+ * @ref Csr
+ * @ingroup batch_csr
+ */
+namespace batch_csr {
+
+
+constexpr auto default_block_size = 256;
+constexpr int sm_oversubscription = 4;
+
+// clang-format off
+
+// NOTE: DO NOT CHANGE THE ORDERING OF THE INCLUDES
+
+// #include "common/cuda_hip/matrix/batch_csr_kernels.hpp.inc"
+
+
+#include "common/cuda_hip/matrix/batch_csr_kernel_launcher.hpp.inc"
+
+// clang-format on
+
+
+}  // namespace batch_csr
+}  // namespace hip
+}  // namespace kernels
+}  // namespace gko

--- a/hip/matrix/batch_csr_kernels.hip.cpp
+++ b/hip/matrix/batch_csr_kernels.hip.cpp
@@ -72,7 +72,7 @@ constexpr int sm_oversubscription = 4;
 
 // NOTE: DO NOT CHANGE THE ORDERING OF THE INCLUDES
 
-// #include "common/cuda_hip/matrix/batch_csr_kernels.hpp.inc"
+#include "common/cuda_hip/matrix/batch_csr_kernels.hpp.inc"
 
 
 #include "common/cuda_hip/matrix/batch_csr_kernel_launcher.hpp.inc"

--- a/hip/matrix/batch_csr_kernels.hip.cpp
+++ b/hip/matrix/batch_csr_kernels.hip.cpp
@@ -1,34 +1,6 @@
-/*******************************<GINKGO LICENSE>******************************
-Copyright (c) 2017-2023, the Ginkgo authors
-All rights reserved.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions
-are met:
-
-1. Redistributions of source code must retain the above copyright
-notice, this list of conditions and the following disclaimer.
-
-2. Redistributions in binary form must reproduce the above copyright
-notice, this list of conditions and the following disclaimer in the
-documentation and/or other materials provided with the distribution.
-
-3. Neither the name of the copyright holder nor the names of its
-contributors may be used to endorse or promote products derived from
-this software without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
-IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
-TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-******************************<GINKGO LICENSE>*******************************/
+// SPDX-FileCopyrightText: 2017-2023 The Ginkgo authors
+//
+// SPDX-License-Identifier: BSD-3-Clause
 
 #include "core/matrix/batch_csr_kernels.hpp"
 

--- a/hip/matrix/batch_struct.hip.hpp
+++ b/hip/matrix/batch_struct.hip.hpp
@@ -33,6 +33,43 @@ namespace hip {
 
 
 /**
+ * Generates an immutable uniform batch struct from a batch of csr matrices.
+ */
+template <typename ValueType, typename IndexType>
+inline batch::matrix::csr::uniform_batch<const hip_type<ValueType>,
+                                         const IndexType>
+get_batch_struct(const batch::matrix::Csr<ValueType, IndexType>* const op)
+{
+    return {as_hip_type(op->get_const_values()),
+            op->get_const_col_idxs(),
+            op->get_const_row_ptrs(),
+            op->get_num_batch_items(),
+            static_cast<IndexType>(op->get_common_size()[1]),
+            static_cast<IndexType>(op->get_common_size()[0]),
+            static_cast<IndexType>(op->get_common_size()[1]),
+            static_cast<IndexType>(op->get_num_elements_per_item())};
+}
+
+
+/**
+ * Generates a uniform batch struct from a batch of csr matrices.
+ */
+template <typename ValueType, typename IndexType>
+inline batch::matrix::csr::uniform_batch<hip_type<ValueType>, IndexType>
+get_batch_struct(batch::matrix::Csr<ValueType, IndexType>* const op)
+{
+    return {as_hip_type(op->get_values()),
+            op->get_col_idxs(),
+            op->get_row_ptrs(),
+            op->get_num_batch_items(),
+            static_cast<IndexType>(op->get_common_size()[1]),
+            static_cast<IndexType>(op->get_common_size()[0]),
+            static_cast<IndexType>(op->get_common_size()[1]),
+            static_cast<IndexType>(op->get_num_elements_per_item())};
+}
+
+
+/**
  * Generates an immutable uniform batch struct from a batch of dense matrices.
  */
 template <typename ValueType>

--- a/hip/matrix/batch_struct.hip.hpp
+++ b/hip/matrix/batch_struct.hip.hpp
@@ -44,7 +44,6 @@ get_batch_struct(const batch::matrix::Csr<ValueType, IndexType>* const op)
             op->get_const_col_idxs(),
             op->get_const_row_ptrs(),
             op->get_num_batch_items(),
-            static_cast<IndexType>(op->get_common_size()[1]),
             static_cast<IndexType>(op->get_common_size()[0]),
             static_cast<IndexType>(op->get_common_size()[1]),
             static_cast<IndexType>(op->get_num_elements_per_item())};
@@ -62,7 +61,6 @@ get_batch_struct(batch::matrix::Csr<ValueType, IndexType>* const op)
             op->get_col_idxs(),
             op->get_row_ptrs(),
             op->get_num_batch_items(),
-            static_cast<IndexType>(op->get_common_size()[1]),
             static_cast<IndexType>(op->get_common_size()[0]),
             static_cast<IndexType>(op->get_common_size()[1]),
             static_cast<IndexType>(op->get_num_elements_per_item())};

--- a/hip/solver/batch_bicgstab_kernels.hip.cpp
+++ b/hip/solver/batch_bicgstab_kernels.hip.cpp
@@ -47,6 +47,7 @@ namespace batch_bicgstab {
 
 #include "common/cuda_hip/base/batch_multi_vector_kernels.hpp.inc"
 #include "common/cuda_hip/components/uninitialized_array.hpp.inc"
+#include "common/cuda_hip/matrix/batch_csr_kernels.hpp.inc"
 #include "common/cuda_hip/matrix/batch_dense_kernels.hpp.inc"
 #include "common/cuda_hip/matrix/batch_ell_kernels.hpp.inc"
 #include "common/cuda_hip/solver/batch_bicgstab_kernels.hpp.inc"

--- a/include/ginkgo/core/matrix/batch_csr.hpp
+++ b/include/ginkgo/core/matrix/batch_csr.hpp
@@ -55,15 +55,12 @@ namespace matrix {
 
 
 /**
- * Csr is a sparse matrix format that stores the same number of nonzeros in each
- * row, enabling coalesced accesses. It is suitable for sparsity patterns that
- * have a similar number of nonzeros in every row. The values are stored in a
- * column-major fashion similar to the monolithic gko::matrix::Csr class.
+ * Csr is a general sparse matrix format that stores the column indices for each
+ * nonzero entry and a cumulative sum of the number of nonzeros in each row. It
+ * is one of the most popular sparse matrix formats due to its versatility and
+ * ability to store a wide range of sparsity patterns in an efficient fashion.
  *
- * Similar to the monolithic gko::matrix::Csr class, invalid_index<IndexType> is
- * used as the column index for padded zero entries.
- *
- * @note It is also assumed that the sparsity pattern of all the items in the
+ * @note It is assumed that the sparsity pattern of all the items in the
  * batch is the same and therefore only a single copy of the sparsity pattern is
  * stored.
  *
@@ -236,7 +233,9 @@ public:
 
     /**
      * Creates a constant (immutable) batch csr matrix from a constant
-     * array. The column indices array needs to be the same for all batch items.
+     * array. Only a single sparsity pattern (column indices and row pointers)
+     * is stored and hence the user needs to ensure that each batch item has the
+     * same sparsity pattern.
      *
      * @param exec  the executor to create the matrix on
      * @param size  the dimensions of the matrix
@@ -304,6 +303,11 @@ private:
      * @param size  size of the matrix
      * @param num_nonzeros_per_item  number of nonzeros in each item of the
      * batch matrix
+     *
+     * @internal It is necessary to pass in the correct nnz_per_item to ensure
+     * that the arrays are allocated correctly. An incorrect value will result
+     * in a runtime failure when the user tries to use any batch matrix
+     * utilities such as create_view_from_item etc.
      */
     Csr(std::shared_ptr<const Executor> exec,
         const batch_dim<2>& size = batch_dim<2>{},

--- a/include/ginkgo/core/matrix/batch_csr.hpp
+++ b/include/ginkgo/core/matrix/batch_csr.hpp
@@ -221,8 +221,8 @@ public:
      *       significantly more memory efficient than the non-constant version,
      *       so always prefer this version.
      */
-    const value_type* get_const_values_for_item(size_type batch_id) const
-        noexcept
+    const value_type* get_const_values_for_item(
+        size_type batch_id) const noexcept
     {
         GKO_ASSERT(batch_id < this->get_num_batch_items());
         GKO_ASSERT(values_.get_num_elems() >=

--- a/include/ginkgo/core/matrix/batch_csr.hpp
+++ b/include/ginkgo/core/matrix/batch_csr.hpp
@@ -156,7 +156,7 @@ public:
      */
     size_type get_num_stored_elements() const noexcept
     {
-        return values_.get_num_elems();
+        return values_.get_size();
     }
 
     /**
@@ -180,7 +180,7 @@ public:
     value_type* get_values_for_item(size_type batch_id) noexcept
     {
         GKO_ASSERT(batch_id < this->get_num_batch_items());
-        GKO_ASSERT(values_.get_num_elems() >=
+        GKO_ASSERT(values_.get_size() >=
                    batch_id * this->get_num_elements_per_item());
         return values_.get_data() +
                batch_id * this->get_num_elements_per_item();
@@ -197,7 +197,7 @@ public:
         size_type batch_id) const noexcept
     {
         GKO_ASSERT(batch_id < this->get_num_batch_items());
-        GKO_ASSERT(values_.get_num_elems() >=
+        GKO_ASSERT(values_.get_size() >=
                    batch_id * this->get_num_elements_per_item());
         return values_.get_const_data() +
                batch_id * this->get_num_elements_per_item();
@@ -314,11 +314,9 @@ private:
         auto max_num_elems = this->get_common_size()[0] *
                              this->get_common_size()[1] *
                              this->get_num_batch_items();
-        GKO_ASSERT(values_.get_num_elems() <= max_num_elems);
-        GKO_ASSERT_EQ(row_ptrs_.get_num_elems(),
-                      this->get_common_size()[0] + 1);
-        GKO_ASSERT_EQ(this->get_num_elements_per_item(),
-                      col_idxs_.get_num_elems());
+        GKO_ASSERT(values_.get_size() <= max_num_elems);
+        GKO_ASSERT_EQ(row_ptrs_.get_size(), this->get_common_size()[0] + 1);
+        GKO_ASSERT_EQ(this->get_num_elements_per_item(), col_idxs_.get_size());
     }
 
     void apply_impl(const MultiVector<value_type>* b,

--- a/include/ginkgo/core/matrix/batch_csr.hpp
+++ b/include/ginkgo/core/matrix/batch_csr.hpp
@@ -1,0 +1,367 @@
+/*******************************<GINKGO LICENSE>******************************
+Copyright (c) 2017-2023, the Ginkgo authors
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+******************************<GINKGO LICENSE>*******************************/
+
+#ifndef GKO_PUBLIC_CORE_MATRIX_BATCH_CSR_HPP_
+#define GKO_PUBLIC_CORE_MATRIX_BATCH_CSR_HPP_
+
+
+#include <initializer_list>
+#include <vector>
+
+
+#include <ginkgo/core/base/array.hpp>
+#include <ginkgo/core/base/batch_lin_op.hpp>
+#include <ginkgo/core/base/batch_multi_vector.hpp>
+#include <ginkgo/core/base/executor.hpp>
+#include <ginkgo/core/base/mtx_io.hpp>
+#include <ginkgo/core/base/range_accessors.hpp>
+#include <ginkgo/core/base/types.hpp>
+#include <ginkgo/core/base/utils.hpp>
+#include <ginkgo/core/matrix/csr.hpp>
+
+
+namespace gko {
+namespace batch {
+namespace matrix {
+
+
+/**
+ * Csr is a sparse matrix format that stores the same number of nonzeros in each
+ * row, enabling coalesced accesses. It is suitable for sparsity patterns that
+ * have a similar number of nonzeros in every row. The values are stored in a
+ * column-major fashion similar to the monolithic gko::matrix::Csr class.
+ *
+ * Similar to the monolithic gko::matrix::Csr class, invalid_index<IndexType> is
+ * used as the column index for padded zero entries.
+ *
+ * @note It is also assumed that the sparsity pattern of all the items in the
+ * batch is the same and therefore only a single copy of the sparsity pattern is
+ * stored.
+ *
+ * @note Currently only IndexType of int32 is supported.
+ *
+ * @tparam ValueType  value precision of matrix elements
+ * @tparam IndexType  index precision of matrix elements
+ *
+ * @ingroup batch_csr
+ * @ingroup mat_formats
+ * @ingroup BatchLinOp
+ */
+template <typename ValueType = default_precision, typename IndexType = int32>
+class Csr final
+    : public EnableBatchLinOp<Csr<ValueType, IndexType>>,
+      public EnableCreateMethod<Csr<ValueType, IndexType>>,
+      public ConvertibleTo<Csr<next_precision<ValueType>, IndexType>> {
+    friend class EnableCreateMethod<Csr>;
+    friend class EnablePolymorphicObject<Csr, BatchLinOp>;
+    friend class Csr<to_complex<ValueType>, IndexType>;
+    friend class Csr<next_precision<ValueType>, IndexType>;
+    static_assert(std::is_same<IndexType, int32>::value,
+                  "IndexType must be a 32 bit integer");
+
+public:
+    using EnableBatchLinOp<Csr>::convert_to;
+    using EnableBatchLinOp<Csr>::move_to;
+
+    using value_type = ValueType;
+    using index_type = IndexType;
+    using unbatch_type = gko::matrix::Csr<value_type, index_type>;
+    using absolute_type = remove_complex<Csr>;
+    using complex_type = to_complex<Csr>;
+
+    void convert_to(
+        Csr<next_precision<ValueType>, IndexType>* result) const override;
+
+    void move_to(Csr<next_precision<ValueType>, IndexType>* result) override;
+
+    /**
+     * Creates a mutable view (of matrix::Csr type) of one item of the
+     * batch::matrix::Csr<value_type> object. Does not perform any deep
+     * copies, but only returns a view of the data.
+     *
+     * @param item_id  The index of the batch item
+     *
+     * @return  a batch::matrix::Csr object with the data from the batch item
+     * at the given index.
+     */
+    std::unique_ptr<unbatch_type> create_view_for_item(size_type item_id);
+
+    /**
+     * @copydoc create_view_for_item(size_type)
+     */
+    std::unique_ptr<const unbatch_type> create_const_view_for_item(
+        size_type item_id) const;
+
+    /**
+     * Returns a pointer to the array of values of the matrix
+     *
+     * @return the pointer to the array of values
+     */
+    value_type* get_values() noexcept { return values_.get_data(); }
+
+    /**
+     * @copydoc get_values()
+     *
+     * @note This is the constant version of the function, which can be
+     *       significantly more memory efficient than the non-constant version,
+     *       so always prefer this version.
+     */
+    const value_type* get_const_values() const noexcept
+    {
+        return values_.get_const_data();
+    }
+
+    /**
+     * Returns a pointer to the array of column indices of the matrix
+     *
+     * @return the pointer to the array of column indices
+     */
+    index_type* get_col_idxs() noexcept { return col_idxs_.get_data(); }
+
+    /**
+     * @copydoc get_col_idxs()
+     *
+     * @note This is the constant version of the function, which can be
+     *       significantly more memory efficient than the non-constant version,
+     *       so always prefer this version.
+     */
+    const index_type* get_const_col_idxs() const noexcept
+    {
+        return col_idxs_.get_const_data();
+    }
+
+    /**
+     * Returns a pointer to the array of row pointers of the matrix
+     *
+     * @return the pointer to the array of row pointers
+     */
+    index_type* get_row_ptrs() noexcept { return row_ptrs_.get_data(); }
+
+    /**
+     * @copydoc get_row_ptrs()
+     *
+     * @note This is the constant version of the function, which can be
+     *       significantly more memory efficient than the non-constant version,
+     *       so always prefer this version.
+     */
+    const index_type* get_const_row_ptrs() const noexcept
+    {
+        return row_ptrs_.get_const_data();
+    }
+
+    /**
+     * Returns the number of elements explicitly stored in the batch matrix,
+     * cumulative across all the batch items.
+     *
+     * @return the number of elements explicitly stored in the vector,
+     *         cumulative across all the batch items
+     */
+    size_type get_num_stored_elements() const noexcept
+    {
+        return values_.get_num_elems();
+    }
+
+    /**
+     * Returns the number of stored elements in each batch item.
+     *
+     * @return the number of stored elements per batch item.
+     */
+    size_type get_num_elements_per_item() const noexcept
+    {
+        return this->get_num_stored_elements() / this->get_num_batch_items();
+    }
+
+    /**
+     * Returns a pointer to the array of values of the matrix for a
+     * specific batch item.
+     *
+     * @param batch_id  the id of the batch item.
+     *
+     * @return the pointer to the array of values
+     */
+    value_type* get_values_for_item(size_type batch_id) noexcept
+    {
+        GKO_ASSERT(batch_id < this->get_num_batch_items());
+        GKO_ASSERT(values_.get_num_elems() >=
+                   batch_id * this->get_num_elements_per_item());
+        return values_.get_data() +
+               batch_id * this->get_num_elements_per_item();
+    }
+
+    /**
+     * @copydoc get_values_for_item(size_type)
+     *
+     * @note This is the constant version of the function, which can be
+     *       significantly more memory efficient than the non-constant version,
+     *       so always prefer this version.
+     */
+    const value_type* get_const_values_for_item(size_type batch_id) const
+        noexcept
+    {
+        GKO_ASSERT(batch_id < this->get_num_batch_items());
+        GKO_ASSERT(values_.get_num_elems() >=
+                   batch_id * this->get_num_elements_per_item());
+        return values_.get_const_data() +
+               batch_id * this->get_num_elements_per_item();
+    }
+
+    /**
+     * Creates a constant (immutable) batch csr matrix from a constant
+     * array. The column indices array needs to be the same for all batch items.
+     *
+     * @param exec  the executor to create the matrix on
+     * @param size  the dimensions of the matrix
+     * @param num_elems_per_row  the number of elements to be stored in each row
+     * @param values  the value array of the matrix
+     * @param col_idxs the col_idxs array of a single batch item of the matrix.
+     * @param row_ptrs  the row_ptrs array of a single batch item of the matrix.
+     *
+     * @return A smart pointer to the constant matrix wrapping the input
+     * array (if it resides on the same executor as the matrix) or a copy of the
+     * array on the correct executor.
+     */
+    static std::unique_ptr<const Csr> create_const(
+        std::shared_ptr<const Executor> exec, const batch_dim<2>& sizes,
+        gko::detail::const_array_view<value_type>&& values,
+        gko::detail::const_array_view<index_type>&& col_idxs,
+        gko::detail::const_array_view<index_type>&& row_ptrs);
+
+    /**
+     * Apply the matrix to a multi-vector. Represents the matrix vector
+     * multiplication, x = A * b, where x and b are both multi-vectors.
+     *
+     * @param b  the multi-vector to be applied to
+     * @param x  the output multi-vector
+     */
+    Csr* apply(ptr_param<const MultiVector<value_type>> b,
+               ptr_param<MultiVector<value_type>> x);
+
+    /**
+     * Apply the matrix to a multi-vector with a linear combination of the given
+     * input vector. Represents the matrix vector multiplication, x = alpha * A
+     * * b + beta * x, where x and b are both multi-vectors.
+     *
+     * @param alpha  the scalar to scale the matrix-vector product with
+     * @param b      the multi-vector to be applied to
+     * @param beta   the scalar to scale the x vector with
+     * @param x      the output multi-vector
+     */
+    Csr* apply(ptr_param<const MultiVector<value_type>> alpha,
+               ptr_param<const MultiVector<value_type>> b,
+               ptr_param<const MultiVector<value_type>> beta,
+               ptr_param<MultiVector<value_type>> x);
+
+    /**
+     * @copydoc apply(const MultiVector<value_type>*, MultiVector<value_type>*)
+     */
+    const Csr* apply(ptr_param<const MultiVector<value_type>> b,
+                     ptr_param<MultiVector<value_type>> x) const;
+
+    /**
+     * @copydoc apply(const MultiVector<value_type>*, const
+     * MultiVector<value_type>*, const MultiVector<value_type>*,
+     * MultiVector<value_type>*)
+     */
+    const Csr* apply(ptr_param<const MultiVector<value_type>> alpha,
+                     ptr_param<const MultiVector<value_type>> b,
+                     ptr_param<const MultiVector<value_type>> beta,
+                     ptr_param<MultiVector<value_type>> x) const;
+
+private:
+    /**
+     * Creates an uninitialized Csr matrix of the specified size.
+     *
+     * @param exec  Executor associated to the matrix
+     * @param size  size of the matrix
+     * @param num_nonzeros_per_item  number of nonzeros in each item of the
+     * batch matrix
+     */
+    Csr(std::shared_ptr<const Executor> exec,
+        const batch_dim<2>& size = batch_dim<2>{},
+        size_type num_nonzeros_per_item = {});
+
+    /**
+     * Creates a Csr matrix from an already allocated (and initialized)
+     * array. The column indices array needs to be the same for all batch items.
+     *
+     * @tparam ValuesArray  type of array of values
+     *
+     * @param exec  Executor associated to the matrix
+     * @param size  size of the matrix
+     * @param values  array of matrix values
+     * @param col_idxs  the col_idxs array of a single batch item of the matrix.
+     * @param row_ptrs  the row_ptrs array of a single batch item of the matrix.
+     *
+     * @note If `values` is not an rvalue, not an array of ValueType, or is on
+     *       the wrong executor, an internal copy will be created, and the
+     *       original array data will not be used in the matrix.
+     */
+    template <typename ValuesArray, typename ColIdxsArray,
+              typename RowPtrsArray>
+    Csr(std::shared_ptr<const Executor> exec, const batch_dim<2>& size,
+        ValuesArray&& values, ColIdxsArray&& col_idxs, RowPtrsArray&& row_ptrs)
+        : EnableBatchLinOp<Csr>(exec, size),
+          values_{exec, std::forward<ValuesArray>(values)},
+          col_idxs_{exec, std::forward<ColIdxsArray>(col_idxs)},
+          row_ptrs_{exec, std::forward<RowPtrsArray>(row_ptrs)}
+    {
+        // Ensure that the value and col_idxs arrays have the correct size
+        auto max_num_elems = this->get_common_size()[0] *
+                             this->get_common_size()[1] *
+                             this->get_num_batch_items();
+        GKO_ASSERT(values_.get_num_elems() <= max_num_elems);
+        GKO_ASSERT_EQ(row_ptrs_.get_num_elems(),
+                      this->get_common_size()[0] + 1);
+        GKO_ASSERT_EQ(this->get_num_elements_per_item(),
+                      col_idxs_.get_num_elems());
+    }
+
+    void apply_impl(const MultiVector<value_type>* b,
+                    MultiVector<value_type>* x) const;
+
+    void apply_impl(const MultiVector<value_type>* alpha,
+                    const MultiVector<value_type>* b,
+                    const MultiVector<value_type>* beta,
+                    MultiVector<value_type>* x) const;
+
+    array<value_type> values_;
+    array<index_type> col_idxs_;
+    array<index_type> row_ptrs_;
+};
+
+
+}  // namespace matrix
+}  // namespace batch
+}  // namespace gko
+
+
+#endif  // GKO_PUBLIC_CORE_MATRIX_BATCH_CSR_HPP_

--- a/include/ginkgo/core/matrix/batch_csr.hpp
+++ b/include/ginkgo/core/matrix/batch_csr.hpp
@@ -1,34 +1,6 @@
-/*******************************<GINKGO LICENSE>******************************
-Copyright (c) 2017-2023, the Ginkgo authors
-All rights reserved.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions
-are met:
-
-1. Redistributions of source code must retain the above copyright
-notice, this list of conditions and the following disclaimer.
-
-2. Redistributions in binary form must reproduce the above copyright
-notice, this list of conditions and the following disclaimer in the
-documentation and/or other materials provided with the distribution.
-
-3. Neither the name of the copyright holder nor the names of its
-contributors may be used to endorse or promote products derived from
-this software without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
-IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
-TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-******************************<GINKGO LICENSE>*******************************/
+// SPDX-FileCopyrightText: 2017-2023 The Ginkgo authors
+//
+// SPDX-License-Identifier: BSD-3-Clause
 
 #ifndef GKO_PUBLIC_CORE_MATRIX_BATCH_CSR_HPP_
 #define GKO_PUBLIC_CORE_MATRIX_BATCH_CSR_HPP_

--- a/include/ginkgo/ginkgo.hpp
+++ b/include/ginkgo/ginkgo.hpp
@@ -81,6 +81,7 @@
 #include <ginkgo/core/log/record.hpp>
 #include <ginkgo/core/log/stream.hpp>
 
+#include <ginkgo/core/matrix/batch_csr.hpp>
 #include <ginkgo/core/matrix/batch_dense.hpp>
 #include <ginkgo/core/matrix/batch_ell.hpp>
 #include <ginkgo/core/matrix/batch_identity.hpp>

--- a/omp/CMakeLists.txt
+++ b/omp/CMakeLists.txt
@@ -23,6 +23,7 @@ target_sources(ginkgo_omp
     factorization/par_ict_kernels.cpp
     factorization/par_ilu_kernels.cpp
     factorization/par_ilut_kernels.cpp
+    matrix/batch_csr_kernels.cpp
     matrix/batch_dense_kernels.cpp
     matrix/batch_ell_kernels.cpp
     matrix/coo_kernels.cpp

--- a/omp/matrix/batch_csr_kernels.cpp
+++ b/omp/matrix/batch_csr_kernels.cpp
@@ -1,15 +1,43 @@
-// SPDX-FileCopyrightText: 2017-2023 The Ginkgo authors
-//
-// SPDX-License-Identifier: BSD-3-Clause
+/*******************************<GINKGO LICENSE>******************************
+Copyright (c) 2017-2023, the Ginkgo authors
+All rights reserved.
 
-#include "core/matrix/batch_ell_kernels.hpp"
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+******************************<GINKGO LICENSE>*******************************/
+
+#include "core/matrix/batch_csr_kernels.hpp"
 
 
 #include <algorithm>
 
 
 #include <ginkgo/core/base/batch_multi_vector.hpp>
-#include <ginkgo/core/matrix/batch_ell.hpp>
+#include <ginkgo/core/matrix/batch_csr.hpp>
 
 
 #include "core/base/batch_struct.hpp"
@@ -22,19 +50,19 @@ namespace gko {
 namespace kernels {
 namespace omp {
 /**
- * @brief The Ell matrix format namespace.
- * @ref Ell
- * @ingroup batch_ell
+ * @brief The Csr matrix format namespace.
+ * @ref Csr
+ * @ingroup batch_csr
  */
-namespace batch_ell {
+namespace batch_csr {
 
 
-#include "reference/matrix/batch_ell_kernels.hpp.inc"
+#include "reference/matrix/batch_csr_kernels.hpp.inc"
 
 
 template <typename ValueType, typename IndexType>
 void simple_apply(std::shared_ptr<const DefaultExecutor> exec,
-                  const batch::matrix::Ell<ValueType, IndexType>* mat,
+                  const batch::matrix::Csr<ValueType, IndexType>* mat,
                   const batch::MultiVector<ValueType>* b,
                   batch::MultiVector<ValueType>* x)
 {
@@ -51,13 +79,13 @@ void simple_apply(std::shared_ptr<const DefaultExecutor> exec,
 }
 
 GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INT32_TYPE(
-    GKO_DECLARE_BATCH_ELL_SIMPLE_APPLY_KERNEL);
+    GKO_DECLARE_BATCH_CSR_SIMPLE_APPLY_KERNEL);
 
 
 template <typename ValueType, typename IndexType>
 void advanced_apply(std::shared_ptr<const DefaultExecutor> exec,
                     const batch::MultiVector<ValueType>* alpha,
-                    const batch::matrix::Ell<ValueType, IndexType>* mat,
+                    const batch::matrix::Csr<ValueType, IndexType>* mat,
                     const batch::MultiVector<ValueType>* b,
                     const batch::MultiVector<ValueType>* beta,
                     batch::MultiVector<ValueType>* x)
@@ -80,10 +108,10 @@ void advanced_apply(std::shared_ptr<const DefaultExecutor> exec,
 }
 
 GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INT32_TYPE(
-    GKO_DECLARE_BATCH_ELL_ADVANCED_APPLY_KERNEL);
+    GKO_DECLARE_BATCH_CSR_ADVANCED_APPLY_KERNEL);
 
 
-}  // namespace batch_ell
+}  // namespace batch_csr
 }  // namespace omp
 }  // namespace kernels
 }  // namespace gko

--- a/omp/matrix/batch_csr_kernels.cpp
+++ b/omp/matrix/batch_csr_kernels.cpp
@@ -1,34 +1,6 @@
-/*******************************<GINKGO LICENSE>******************************
-Copyright (c) 2017-2023, the Ginkgo authors
-All rights reserved.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions
-are met:
-
-1. Redistributions of source code must retain the above copyright
-notice, this list of conditions and the following disclaimer.
-
-2. Redistributions in binary form must reproduce the above copyright
-notice, this list of conditions and the following disclaimer in the
-documentation and/or other materials provided with the distribution.
-
-3. Neither the name of the copyright holder nor the names of its
-contributors may be used to endorse or promote products derived from
-this software without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
-IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
-TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-******************************<GINKGO LICENSE>*******************************/
+// SPDX-FileCopyrightText: 2017-2023 The Ginkgo authors
+//
+// SPDX-License-Identifier: BSD-3-Clause
 
 #include "core/matrix/batch_csr_kernels.hpp"
 

--- a/omp/solver/batch_bicgstab_kernels.cpp
+++ b/omp/solver/batch_bicgstab_kernels.cpp
@@ -26,6 +26,7 @@ constexpr int max_num_rhs = 1;
 
 
 #include "reference/base/batch_multi_vector_kernels.hpp.inc"
+#include "reference/matrix/batch_csr_kernels.hpp.inc"
 #include "reference/matrix/batch_dense_kernels.hpp.inc"
 #include "reference/matrix/batch_ell_kernels.hpp.inc"
 #include "reference/solver/batch_bicgstab_kernels.hpp.inc"

--- a/reference/CMakeLists.txt
+++ b/reference/CMakeLists.txt
@@ -25,6 +25,7 @@ target_sources(ginkgo_reference
     factorization/par_ict_kernels.cpp
     factorization/par_ilu_kernels.cpp
     factorization/par_ilut_kernels.cpp
+    matrix/batch_csr_kernels.cpp
     matrix/batch_dense_kernels.cpp
     matrix/batch_ell_kernels.cpp
     matrix/coo_kernels.cpp

--- a/reference/matrix/batch_csr_kernels.cpp
+++ b/reference/matrix/batch_csr_kernels.cpp
@@ -1,0 +1,115 @@
+/*******************************<GINKGO LICENSE>******************************
+Copyright (c) 2017-2023, the Ginkgo authors
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+******************************<GINKGO LICENSE>*******************************/
+
+#include "core/matrix/batch_csr_kernels.hpp"
+
+
+#include <algorithm>
+
+
+#include <ginkgo/core/base/batch_multi_vector.hpp>
+#include <ginkgo/core/matrix/batch_csr.hpp>
+
+
+#include "core/base/batch_struct.hpp"
+#include "core/matrix/batch_struct.hpp"
+#include "reference/base/batch_struct.hpp"
+#include "reference/matrix/batch_struct.hpp"
+
+
+namespace gko {
+namespace kernels {
+namespace reference {
+/**
+ * @brief The Csr matrix format namespace.
+ * @ref Csr
+ * @ingroup batch_csr
+ */
+namespace batch_csr {
+
+
+#include "reference/matrix/batch_csr_kernels.hpp.inc"
+
+
+template <typename ValueType, typename IndexType>
+void simple_apply(std::shared_ptr<const DefaultExecutor> exec,
+                  const batch::matrix::Csr<ValueType, IndexType>* mat,
+                  const batch::MultiVector<ValueType>* b,
+                  batch::MultiVector<ValueType>* x)
+{
+    const auto b_ub = host::get_batch_struct(b);
+    const auto x_ub = host::get_batch_struct(x);
+    const auto mat_ub = host::get_batch_struct(mat);
+    for (size_type batch = 0; batch < x->get_num_batch_items(); ++batch) {
+        const auto mat_item = batch::matrix::extract_batch_item(mat_ub, batch);
+        const auto b_item = batch::extract_batch_item(b_ub, batch);
+        const auto x_item = batch::extract_batch_item(x_ub, batch);
+        simple_apply_kernel(mat_item, b_item, x_item);
+    }
+}
+
+GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INT32_TYPE(
+    GKO_DECLARE_BATCH_CSR_SIMPLE_APPLY_KERNEL);
+
+
+template <typename ValueType, typename IndexType>
+void advanced_apply(std::shared_ptr<const DefaultExecutor> exec,
+                    const batch::MultiVector<ValueType>* alpha,
+                    const batch::matrix::Csr<ValueType, IndexType>* mat,
+                    const batch::MultiVector<ValueType>* b,
+                    const batch::MultiVector<ValueType>* beta,
+                    batch::MultiVector<ValueType>* x)
+{
+    const auto b_ub = host::get_batch_struct(b);
+    const auto x_ub = host::get_batch_struct(x);
+    const auto mat_ub = host::get_batch_struct(mat);
+    const auto alpha_ub = host::get_batch_struct(alpha);
+    const auto beta_ub = host::get_batch_struct(beta);
+    for (size_type batch = 0; batch < x->get_num_batch_items(); ++batch) {
+        const auto mat_item = batch::matrix::extract_batch_item(mat_ub, batch);
+        const auto b_item = batch::extract_batch_item(b_ub, batch);
+        const auto x_item = batch::extract_batch_item(x_ub, batch);
+        const auto alpha_item = batch::extract_batch_item(alpha_ub, batch);
+        const auto beta_item = batch::extract_batch_item(beta_ub, batch);
+        advanced_apply_kernel(alpha_item.values[0], mat_item, b_item,
+                              beta_item.values[0], x_item);
+    }
+}
+
+GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INT32_TYPE(
+    GKO_DECLARE_BATCH_CSR_ADVANCED_APPLY_KERNEL);
+
+
+}  // namespace batch_csr
+}  // namespace reference
+}  // namespace kernels
+}  // namespace gko

--- a/reference/matrix/batch_csr_kernels.cpp
+++ b/reference/matrix/batch_csr_kernels.cpp
@@ -1,34 +1,6 @@
-/*******************************<GINKGO LICENSE>******************************
-Copyright (c) 2017-2023, the Ginkgo authors
-All rights reserved.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions
-are met:
-
-1. Redistributions of source code must retain the above copyright
-notice, this list of conditions and the following disclaimer.
-
-2. Redistributions in binary form must reproduce the above copyright
-notice, this list of conditions and the following disclaimer in the
-documentation and/or other materials provided with the distribution.
-
-3. Neither the name of the copyright holder nor the names of its
-contributors may be used to endorse or promote products derived from
-this software without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
-IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
-TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-******************************<GINKGO LICENSE>*******************************/
+// SPDX-FileCopyrightText: 2017-2023 The Ginkgo authors
+//
+// SPDX-License-Identifier: BSD-3-Clause
 
 #include "core/matrix/batch_csr_kernels.hpp"
 

--- a/reference/matrix/batch_csr_kernels.hpp.inc
+++ b/reference/matrix/batch_csr_kernels.hpp.inc
@@ -1,34 +1,6 @@
-/*******************************<GINKGO LICENSE>******************************
-Copyright (c) 2017-2023, the Ginkgo authors
-All rights reserved.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions
-are met:
-
-1. Redistributions of source code must retain the above copyright
-notice, this list of conditions and the following disclaimer.
-
-2. Redistributions in binary form must reproduce the above copyright
-notice, this list of conditions and the following disclaimer in the
-documentation and/or other materials provided with the distribution.
-
-3. Neither the name of the copyright holder nor the names of its
-contributors may be used to endorse or promote products derived from
-this software without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
-IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
-TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-******************************<GINKGO LICENSE>*******************************/
+// SPDX-FileCopyrightText: 2017-2023 The Ginkgo authors
+//
+// SPDX-License-Identifier: BSD-3-Clause
 
 template <typename ValueType, typename IndexType>
 inline void simple_apply_kernel(

--- a/reference/matrix/batch_csr_kernels.hpp.inc
+++ b/reference/matrix/batch_csr_kernels.hpp.inc
@@ -1,0 +1,76 @@
+/*******************************<GINKGO LICENSE>******************************
+Copyright (c) 2017-2023, the Ginkgo authors
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+******************************<GINKGO LICENSE>*******************************/
+
+template <typename ValueType, typename IndexType>
+inline void simple_apply_kernel(
+    const gko::batch::matrix::csr::batch_item<const ValueType, IndexType>& a,
+    const gko::batch::multi_vector::batch_item<const ValueType>& b,
+    const gko::batch::multi_vector::batch_item<ValueType>& c)
+{
+    for (int row = 0; row < a.num_rows; ++row) {
+        for (int j = 0; j < b.num_rhs; ++j) {
+            c.values[row * c.stride + j] = zero<ValueType>();
+        }
+        for (auto k = a.row_ptrs[row]; k < a.row_ptrs[row + 1]; ++k) {
+            auto val = a.values[k];
+            auto col = a.col_idxs[k];
+            for (int j = 0; j < b.num_rhs; ++j) {
+                c.values[row * c.stride + j] +=
+                    val * b.values[col * b.stride + j];
+            }
+        }
+    }
+}
+
+
+template <typename ValueType, typename IndexType>
+inline void advanced_apply_kernel(
+    const ValueType alpha,
+    const gko::batch::matrix::csr::batch_item<const ValueType, IndexType>& a,
+    const gko::batch::multi_vector::batch_item<const ValueType>& b,
+    const ValueType beta,
+    const gko::batch::multi_vector::batch_item<ValueType>& c)
+{
+    for (int row = 0; row < a.num_rows; ++row) {
+        for (int j = 0; j < c.num_rhs; ++j) {
+            c.values[row * c.stride + j] *= beta;
+        }
+        for (int k = a.row_ptrs[row]; k < a.row_ptrs[row + 1]; ++k) {
+            const auto val = a.values[k];
+            const auto col = a.col_idxs[k];
+            for (int j = 0; j < c.num_rhs; ++j) {
+                c.values[row * c.stride + j] +=
+                    alpha * val * b.values[col * b.stride + j];
+            }
+        }
+    }
+}

--- a/reference/matrix/batch_struct.hpp
+++ b/reference/matrix/batch_struct.hpp
@@ -47,7 +47,6 @@ get_batch_struct(const batch::matrix::Csr<ValueType, IndexType>* const op)
             op->get_const_col_idxs(),
             op->get_const_row_ptrs(),
             op->get_num_batch_items(),
-            static_cast<IndexType>(op->get_common_size()[1]),
             static_cast<IndexType>(op->get_common_size()[0]),
             static_cast<IndexType>(op->get_common_size()[1]),
             static_cast<IndexType>(op->get_num_elements_per_item())};
@@ -65,7 +64,6 @@ inline batch::matrix::csr::uniform_batch<ValueType, IndexType> get_batch_struct(
             op->get_col_idxs(),
             op->get_row_ptrs(),
             op->get_num_batch_items(),
-            static_cast<IndexType>(op->get_common_size()[1]),
             static_cast<IndexType>(op->get_common_size()[0]),
             static_cast<IndexType>(op->get_common_size()[1]),
             static_cast<IndexType>(op->get_num_elements_per_item())};

--- a/reference/matrix/batch_struct.hpp
+++ b/reference/matrix/batch_struct.hpp
@@ -10,6 +10,7 @@
 
 
 #include <ginkgo/core/base/types.hpp>
+#include <ginkgo/core/matrix/batch_csr.hpp>
 #include <ginkgo/core/matrix/batch_dense.hpp>
 #include <ginkgo/core/matrix/batch_ell.hpp>
 
@@ -33,6 +34,42 @@ namespace host {
  * A specialization is needed for every format of every kind of linear algebra
  * object. These are intended to be called on the host.
  */
+
+
+/**
+ * Generates an immutable uniform batch struct from a batch of csr matrices.
+ */
+template <typename ValueType, typename IndexType>
+inline batch::matrix::csr::uniform_batch<const ValueType, const IndexType>
+get_batch_struct(const batch::matrix::Csr<ValueType, IndexType>* const op)
+{
+    return {op->get_const_values(),
+            op->get_const_col_idxs(),
+            op->get_const_row_ptrs(),
+            op->get_num_batch_items(),
+            static_cast<IndexType>(op->get_common_size()[1]),
+            static_cast<IndexType>(op->get_common_size()[0]),
+            static_cast<IndexType>(op->get_common_size()[1]),
+            static_cast<IndexType>(op->get_num_elements_per_item())};
+}
+
+
+/**
+ * Generates a uniform batch struct from a batch of csr matrices.
+ */
+template <typename ValueType, typename IndexType>
+inline batch::matrix::csr::uniform_batch<ValueType, IndexType> get_batch_struct(
+    batch::matrix::Csr<ValueType, IndexType>* const op)
+{
+    return {op->get_values(),
+            op->get_col_idxs(),
+            op->get_row_ptrs(),
+            op->get_num_batch_items(),
+            static_cast<IndexType>(op->get_common_size()[1]),
+            static_cast<IndexType>(op->get_common_size()[0]),
+            static_cast<IndexType>(op->get_common_size()[1]),
+            static_cast<IndexType>(op->get_num_elements_per_item())};
+}
 
 
 /**

--- a/reference/solver/batch_bicgstab_kernels.cpp
+++ b/reference/solver/batch_bicgstab_kernels.cpp
@@ -28,6 +28,7 @@ constexpr int max_num_rhs = 1;
 
 
 #include "reference/base/batch_multi_vector_kernels.hpp.inc"
+#include "reference/matrix/batch_csr_kernels.hpp.inc"
 #include "reference/matrix/batch_dense_kernels.hpp.inc"
 #include "reference/matrix/batch_ell_kernels.hpp.inc"
 #include "reference/solver/batch_bicgstab_kernels.hpp.inc"

--- a/reference/test/matrix/CMakeLists.txt
+++ b/reference/test/matrix/CMakeLists.txt
@@ -1,3 +1,4 @@
+ginkgo_create_test(batch_csr_kernels)
 ginkgo_create_test(batch_dense_kernels)
 ginkgo_create_test(batch_ell_kernels)
 ginkgo_create_test(coo_kernels)

--- a/reference/test/matrix/batch_csr_kernels.cpp
+++ b/reference/test/matrix/batch_csr_kernels.cpp
@@ -1,0 +1,258 @@
+/*******************************<GINKGO LICENSE>******************************
+Copyright (c) 2017-2023, the Ginkgo authors
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+******************************<GINKGO LICENSE>*******************************/
+
+#include <ginkgo/core/matrix/batch_csr.hpp>
+
+
+#include <complex>
+#include <memory>
+#include <random>
+
+
+#include <gtest/gtest.h>
+
+
+#include <ginkgo/core/base/batch_multi_vector.hpp>
+#include <ginkgo/core/base/exception.hpp>
+#include <ginkgo/core/base/executor.hpp>
+#include <ginkgo/core/base/math.hpp>
+#include <ginkgo/core/matrix/csr.hpp>
+#include <ginkgo/core/matrix/dense.hpp>
+
+
+#include "core/matrix/batch_csr_kernels.hpp"
+#include "core/test/utils.hpp"
+
+
+template <typename T>
+class Csr : public ::testing::Test {
+protected:
+    using value_type = T;
+    using size_type = gko::size_type;
+    using BMtx = gko::batch::matrix::Csr<value_type>;
+    using BMVec = gko::batch::MultiVector<value_type>;
+    using CsrMtx = gko::matrix::Csr<value_type>;
+    using DenseMtx = gko::matrix::Dense<value_type>;
+    Csr()
+        : exec(gko::ReferenceExecutor::create()),
+          mtx_0(gko::batch::initialize<BMtx>(
+              {{I<T>({1.0, -1.0, 1.5}), I<T>({-2.0, 2.0, 3.0})},
+               {{1.0, -2.0, -0.5}, {1.0, -2.5, 4.0}}},
+              exec, 6)),
+          mtx_00(gko::initialize<CsrMtx>(
+              {I<T>({1.0, -1.0, 1.5}), I<T>({-2.0, 2.0, 3.0})}, exec)),
+          mtx_01(gko::initialize<CsrMtx>(
+              {I<T>({1.0, -2.0, -0.5}), I<T>({1.0, -2.5, 4.0})}, exec)),
+          b_0(gko::batch::initialize<BMVec>(
+              {{I<T>({1.0, 0.0, 1.0}), I<T>({2.0, 0.0, 1.0}),
+                I<T>({1.0, 0.0, 2.0})},
+               {I<T>({-1.0, 1.0, 1.0}), I<T>({1.0, -1.0, 1.0}),
+                I<T>({1.0, 0.0, 2.0})}},
+              exec)),
+          b_00(gko::initialize<DenseMtx>(
+              {I<T>({1.0, 0.0, 1.0}), I<T>({2.0, 0.0, 1.0}),
+               I<T>({1.0, 0.0, 2.0})},
+              exec)),
+          b_01(gko::initialize<DenseMtx>(
+              {I<T>({-1.0, 1.0, 1.0}), I<T>({1.0, -1.0, 1.0}),
+               I<T>({1.0, 0.0, 2.0})},
+              exec)),
+          x_0(gko::batch::initialize<BMVec>(
+              {{I<T>({2.0, 0.0, 1.0}), I<T>({2.0, 0.0, 2.0})},
+               {I<T>({-2.0, 1.0, 1.0}), I<T>({1.0, -1.0, -1.0})}},
+              exec)),
+          x_00(gko::initialize<DenseMtx>(
+              {I<T>({2.0, 0.0, 1.0}), I<T>({2.0, 0.0, 2.0})}, exec)),
+          x_01(gko::initialize<DenseMtx>(
+              {I<T>({-2.0, 1.0, 1.0}), I<T>({1.0, -1.0, -1.0})}, exec))
+    {}
+
+    std::shared_ptr<const gko::ReferenceExecutor> exec;
+    std::unique_ptr<BMtx> mtx_0;
+    std::unique_ptr<CsrMtx> mtx_00;
+    std::unique_ptr<CsrMtx> mtx_01;
+    std::unique_ptr<BMVec> b_0;
+    std::unique_ptr<DenseMtx> b_00;
+    std::unique_ptr<DenseMtx> b_01;
+    std::unique_ptr<BMVec> x_0;
+    std::unique_ptr<DenseMtx> x_00;
+    std::unique_ptr<DenseMtx> x_01;
+
+    std::ranlux48 rand_engine;
+};
+
+
+TYPED_TEST_SUITE(Csr, gko::test::ValueTypes, TypenameNameGenerator);
+
+
+TYPED_TEST(Csr, AppliesToBatchMultiVector)
+{
+    using T = typename TestFixture::value_type;
+
+    this->mtx_0->apply(this->b_0.get(), this->x_0.get());
+
+    this->mtx_00->apply(this->b_00.get(), this->x_00.get());
+    this->mtx_01->apply(this->b_01.get(), this->x_01.get());
+    auto res = gko::batch::unbatch<gko::batch::MultiVector<T>>(this->x_0.get());
+    GKO_ASSERT_MTX_NEAR(res[0].get(), this->x_00.get(), r<T>::value);
+    GKO_ASSERT_MTX_NEAR(res[1].get(), this->x_01.get(), r<T>::value);
+}
+
+
+TYPED_TEST(Csr, ConstAppliesToBatchMultiVector)
+{
+    using T = typename TestFixture::value_type;
+    using BMtx = typename TestFixture::BMtx;
+
+    static_cast<const BMtx*>(this->mtx_0.get())->apply(this->b_0, this->x_0);
+
+    this->mtx_00->apply(this->b_00.get(), this->x_00.get());
+    this->mtx_01->apply(this->b_01.get(), this->x_01.get());
+    auto res = gko::batch::unbatch<gko::batch::MultiVector<T>>(this->x_0.get());
+    GKO_ASSERT_MTX_NEAR(res[0].get(), this->x_00.get(), r<T>::value);
+    GKO_ASSERT_MTX_NEAR(res[1].get(), this->x_01.get(), r<T>::value);
+}
+
+
+TYPED_TEST(Csr, AppliesLinearCombinationToBatchMultiVector)
+{
+    using BMtx = typename TestFixture::BMtx;
+    using BMVec = typename TestFixture::BMVec;
+    using DenseMtx = typename TestFixture::DenseMtx;
+    using T = typename TestFixture::value_type;
+    auto alpha = gko::batch::initialize<BMVec>({{1.5}, {-1.0}}, this->exec);
+    auto beta = gko::batch::initialize<BMVec>({{2.5}, {-4.0}}, this->exec);
+    auto alpha0 = gko::initialize<DenseMtx>({1.5}, this->exec);
+    auto alpha1 = gko::initialize<DenseMtx>({-1.0}, this->exec);
+    auto beta0 = gko::initialize<DenseMtx>({2.5}, this->exec);
+    auto beta1 = gko::initialize<DenseMtx>({-4.0}, this->exec);
+
+    this->mtx_0->apply(alpha.get(), this->b_0.get(), beta.get(),
+                       this->x_0.get());
+
+    this->mtx_00->apply(alpha0.get(), this->b_00.get(), beta0.get(),
+                        this->x_00.get());
+    this->mtx_01->apply(alpha1.get(), this->b_01.get(), beta1.get(),
+                        this->x_01.get());
+    auto res = gko::batch::unbatch<gko::batch::MultiVector<T>>(this->x_0.get());
+    GKO_ASSERT_MTX_NEAR(res[0].get(), this->x_00.get(), r<T>::value);
+    GKO_ASSERT_MTX_NEAR(res[1].get(), this->x_01.get(), r<T>::value);
+}
+
+
+TYPED_TEST(Csr, ConstAppliesLinearCombinationToBatchMultiVector)
+{
+    using BMtx = typename TestFixture::BMtx;
+    using BMVec = typename TestFixture::BMVec;
+    using DenseMtx = typename TestFixture::DenseMtx;
+    using T = typename TestFixture::value_type;
+    auto alpha = gko::batch::initialize<BMVec>({{1.5}, {-1.0}}, this->exec);
+    auto beta = gko::batch::initialize<BMVec>({{2.5}, {-4.0}}, this->exec);
+    auto alpha0 = gko::initialize<DenseMtx>({1.5}, this->exec);
+    auto alpha1 = gko::initialize<DenseMtx>({-1.0}, this->exec);
+    auto beta0 = gko::initialize<DenseMtx>({2.5}, this->exec);
+    auto beta1 = gko::initialize<DenseMtx>({-4.0}, this->exec);
+
+    static_cast<const BMtx*>(this->mtx_0.get())
+        ->apply(alpha.get(), this->b_0.get(), beta.get(), this->x_0.get());
+
+    this->mtx_00->apply(alpha0.get(), this->b_00.get(), beta0.get(),
+                        this->x_00.get());
+    this->mtx_01->apply(alpha1.get(), this->b_01.get(), beta1.get(),
+                        this->x_01.get());
+    auto res = gko::batch::unbatch<gko::batch::MultiVector<T>>(this->x_0.get());
+    GKO_ASSERT_MTX_NEAR(res[0].get(), this->x_00.get(), r<T>::value);
+    GKO_ASSERT_MTX_NEAR(res[1].get(), this->x_01.get(), r<T>::value);
+}
+
+
+TYPED_TEST(Csr, ApplyFailsOnWrongNumberOfResultCols)
+{
+    using BMVec = typename TestFixture::BMVec;
+    auto res = BMVec::create(this->exec, gko::batch_dim<2>{2, gko::dim<2>{2}});
+
+    ASSERT_THROW(this->mtx_0->apply(this->b_0.get(), res.get()),
+                 gko::DimensionMismatch);
+}
+
+
+TYPED_TEST(Csr, ApplyFailsOnWrongNumberOfResultRows)
+{
+    using BMVec = typename TestFixture::BMVec;
+    auto res = BMVec::create(this->exec, gko::batch_dim<2>{2, gko::dim<2>{3}});
+
+    ASSERT_THROW(this->mtx_0->apply(this->b_0.get(), res.get()),
+                 gko::DimensionMismatch);
+}
+
+
+TYPED_TEST(Csr, ApplyFailsOnWrongInnerDimension)
+{
+    using BMVec = typename TestFixture::BMVec;
+    auto res =
+        BMVec::create(this->exec, gko::batch_dim<2>{2, gko::dim<2>{2, 3}});
+
+    ASSERT_THROW(this->mtx_0->apply(res.get(), this->x_0.get()),
+                 gko::DimensionMismatch);
+}
+
+
+TYPED_TEST(Csr, AdvancedApplyFailsOnWrongInnerDimension)
+{
+    using BMVec = typename TestFixture::BMVec;
+    auto res =
+        BMVec::create(this->exec, gko::batch_dim<2>{2, gko::dim<2>{2, 3}});
+    auto alpha =
+        BMVec::create(this->exec, gko::batch_dim<2>{2, gko::dim<2>{1, 1}});
+    auto beta =
+        BMVec::create(this->exec, gko::batch_dim<2>{2, gko::dim<2>{1, 1}});
+
+    ASSERT_THROW(
+        this->mtx_0->apply(alpha.get(), res.get(), beta.get(), this->x_0.get()),
+        gko::DimensionMismatch);
+}
+
+
+TYPED_TEST(Csr, AdvancedApplyFailsOnWrongAlphaDimension)
+{
+    using BMVec = typename TestFixture::BMVec;
+    auto res =
+        BMVec::create(this->exec, gko::batch_dim<2>{2, gko::dim<2>{3, 3}});
+    auto alpha =
+        BMVec::create(this->exec, gko::batch_dim<2>{2, gko::dim<2>{2, 1}});
+    auto beta =
+        BMVec::create(this->exec, gko::batch_dim<2>{2, gko::dim<2>{1, 1}});
+
+    ASSERT_THROW(
+        this->mtx_0->apply(alpha.get(), res.get(), beta.get(), this->x_0.get()),
+        gko::DimensionMismatch);
+}

--- a/reference/test/matrix/batch_csr_kernels.cpp
+++ b/reference/test/matrix/batch_csr_kernels.cpp
@@ -116,7 +116,6 @@ TYPED_TEST(Csr, ConstAppliesToBatchMultiVector)
 
 TYPED_TEST(Csr, AppliesLinearCombinationToBatchMultiVector)
 {
-    using BMtx = typename TestFixture::BMtx;
     using BMVec = typename TestFixture::BMVec;
     using DenseMtx = typename TestFixture::DenseMtx;
     using T = typename TestFixture::value_type;

--- a/reference/test/matrix/batch_csr_kernels.cpp
+++ b/reference/test/matrix/batch_csr_kernels.cpp
@@ -1,34 +1,6 @@
-/*******************************<GINKGO LICENSE>******************************
-Copyright (c) 2017-2023, the Ginkgo authors
-All rights reserved.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions
-are met:
-
-1. Redistributions of source code must retain the above copyright
-notice, this list of conditions and the following disclaimer.
-
-2. Redistributions in binary form must reproduce the above copyright
-notice, this list of conditions and the following disclaimer in the
-documentation and/or other materials provided with the distribution.
-
-3. Neither the name of the copyright holder nor the names of its
-contributors may be used to endorse or promote products derived from
-this software without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
-IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
-TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-******************************<GINKGO LICENSE>*******************************/
+// SPDX-FileCopyrightText: 2017-2023 The Ginkgo authors
+//
+// SPDX-License-Identifier: BSD-3-Clause
 
 #include <ginkgo/core/matrix/batch_csr.hpp>
 

--- a/reference/test/matrix/batch_csr_kernels.cpp
+++ b/reference/test/matrix/batch_csr_kernels.cpp
@@ -37,13 +37,13 @@ protected:
     Csr()
         : exec(gko::ReferenceExecutor::create()),
           mtx_0(gko::batch::initialize<BMtx>(
-              {{I<T>({1.0, -1.0, 1.5}), I<T>({-2.0, 2.0, 3.0})},
-               {{1.0, -2.0, -0.5}, {1.0, -2.5, 4.0}}},
-              exec, 6)),
+              {{I<T>({1.0, -1.0, 0.0}), I<T>({-2.0, 2.0, 3.0})},
+               {{1.0, -2.0, 0.0}, {1.0, -2.5, 4.0}}},
+              exec, 5)),
           mtx_00(gko::initialize<CsrMtx>(
-              {I<T>({1.0, -1.0, 1.5}), I<T>({-2.0, 2.0, 3.0})}, exec)),
+              {I<T>({1.0, -1.0, 0.0}), I<T>({-2.0, 2.0, 3.0})}, exec)),
           mtx_01(gko::initialize<CsrMtx>(
-              {I<T>({1.0, -2.0, -0.5}), I<T>({1.0, -2.5, 4.0})}, exec)),
+              {I<T>({1.0, -2.0, 0.0}), I<T>({1.0, -2.5, 4.0})}, exec)),
           b_0(gko::batch::initialize<BMVec>(
               {{I<T>({1.0, 0.0, 1.0}), I<T>({2.0, 0.0, 1.0}),
                 I<T>({1.0, 0.0, 2.0})},
@@ -81,7 +81,6 @@ protected:
 
     std::ranlux48 rand_engine;
 };
-
 
 TYPED_TEST_SUITE(Csr, gko::test::ValueTypes, TypenameNameGenerator);
 

--- a/test/matrix/CMakeLists.txt
+++ b/test/matrix/CMakeLists.txt
@@ -1,3 +1,4 @@
+ginkgo_create_common_test(batch_csr_kernels DISABLE_EXECUTORS dpcpp cuda hip)
 ginkgo_create_common_test(batch_dense_kernels)
 ginkgo_create_common_test(batch_ell_kernels)
 ginkgo_create_common_device_test(csr_kernels)

--- a/test/matrix/CMakeLists.txt
+++ b/test/matrix/CMakeLists.txt
@@ -1,4 +1,4 @@
-ginkgo_create_common_test(batch_csr_kernels DISABLE_EXECUTORS dpcpp cuda hip)
+ginkgo_create_common_test(batch_csr_kernels DISABLE_EXECUTORS dpcpp)
 ginkgo_create_common_test(batch_dense_kernels)
 ginkgo_create_common_test(batch_ell_kernels)
 ginkgo_create_common_device_test(csr_kernels)

--- a/test/matrix/CMakeLists.txt
+++ b/test/matrix/CMakeLists.txt
@@ -1,4 +1,4 @@
-ginkgo_create_common_test(batch_csr_kernels DISABLE_EXECUTORS dpcpp)
+ginkgo_create_common_test(batch_csr_kernels)
 ginkgo_create_common_test(batch_dense_kernels)
 ginkgo_create_common_test(batch_ell_kernels)
 ginkgo_create_common_device_test(csr_kernels)

--- a/test/matrix/batch_csr_kernels.cpp
+++ b/test/matrix/batch_csr_kernels.cpp
@@ -1,34 +1,6 @@
-/*******************************<GINKGO LICENSE>******************************
-Copyright (c) 2017-2023, the Ginkgo authors
-All rights reserved.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions
-are met:
-
-1. Redistributions of source code must retain the above copyright
-notice, this list of conditions and the following disclaimer.
-
-2. Redistributions in binary form must reproduce the above copyright
-notice, this list of conditions and the following disclaimer in the
-documentation and/or other materials provided with the distribution.
-
-3. Neither the name of the copyright holder nor the names of its
-contributors may be used to endorse or promote products derived from
-this software without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
-IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
-TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-******************************<GINKGO LICENSE>*******************************/
+// SPDX-FileCopyrightText: 2017-2023 The Ginkgo authors
+//
+// SPDX-License-Identifier: BSD-3-Clause
 
 #include "core/matrix/batch_csr_kernels.hpp"
 

--- a/test/matrix/batch_csr_kernels.cpp
+++ b/test/matrix/batch_csr_kernels.cpp
@@ -1,0 +1,143 @@
+/*******************************<GINKGO LICENSE>******************************
+Copyright (c) 2017-2023, the Ginkgo authors
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+******************************<GINKGO LICENSE>*******************************/
+
+#include "core/matrix/batch_csr_kernels.hpp"
+
+
+#include <memory>
+#include <random>
+
+
+#include <gtest/gtest.h>
+
+
+#include <ginkgo/core/base/array.hpp>
+#include <ginkgo/core/base/batch_multi_vector.hpp>
+#include <ginkgo/core/base/math.hpp>
+#include <ginkgo/core/matrix/batch_csr.hpp>
+
+
+#include "core/base/batch_utilities.hpp"
+#include "core/test/utils.hpp"
+#include "core/test/utils/assertions.hpp"
+#include "core/test/utils/batch_helpers.hpp"
+#include "test/utils/executor.hpp"
+
+
+class Csr : public CommonTestFixture {
+protected:
+    using BMtx = gko::batch::matrix::Csr<value_type, gko::int32>;
+    using BMVec = gko::batch::MultiVector<value_type>;
+
+    Csr() : rand_engine(15) {}
+
+    template <typename BMtxType>
+    std::unique_ptr<BMtxType> gen_mtx(const gko::size_type num_batch_items,
+                                      gko::size_type num_rows,
+                                      gko::size_type num_cols,
+                                      int num_elems_per_row)
+    {
+        return gko::test::generate_random_batch_matrix<BMtxType>(
+            num_batch_items, num_rows, num_cols,
+            std::uniform_int_distribution<>(num_elems_per_row,
+                                            num_elems_per_row),
+            std::normal_distribution<>(-1.0, 1.0), rand_engine, ref,
+            num_elems_per_row * num_rows);
+    }
+
+    std::unique_ptr<BMVec> gen_mvec(const gko::size_type num_batch_items,
+                                    gko::size_type num_rows,
+                                    gko::size_type num_cols)
+    {
+        return gko::test::generate_random_batch_matrix<BMVec>(
+            num_batch_items, num_rows, num_cols,
+            std::uniform_int_distribution<>(num_cols, num_cols),
+            std::normal_distribution<>(-1.0, 1.0), rand_engine, ref);
+    }
+
+    void set_up_apply_data(gko::size_type num_vecs = 1,
+                           int num_elems_per_row = 5)
+    {
+        const gko::size_type num_rows = 252;
+        const gko::size_type num_cols = 32;
+        GKO_ASSERT(num_elems_per_row <= num_cols);
+        mat = gen_mtx<BMtx>(batch_size, num_rows, num_cols, num_elems_per_row);
+        y = gen_mvec(batch_size, num_cols, num_vecs);
+        alpha = gen_mvec(batch_size, 1, 1);
+        beta = gen_mvec(batch_size, 1, 1);
+        dmat = gko::clone(exec, mat);
+        dy = gko::clone(exec, y);
+        dalpha = gko::clone(exec, alpha);
+        dbeta = gko::clone(exec, beta);
+        expected = BMVec::create(
+            ref,
+            gko::batch_dim<2>(batch_size, gko::dim<2>{num_rows, num_vecs}));
+        expected->fill(gko::one<value_type>());
+        dresult = gko::clone(exec, expected);
+    }
+
+    std::ranlux48 rand_engine;
+
+    const gko::size_type batch_size = 11;
+    std::unique_ptr<BMtx> mat;
+    std::unique_ptr<BMVec> y;
+    std::unique_ptr<BMVec> alpha;
+    std::unique_ptr<BMVec> beta;
+    std::unique_ptr<BMVec> expected;
+    std::unique_ptr<BMVec> dresult;
+    std::unique_ptr<BMtx> dmat;
+    std::unique_ptr<BMVec> dy;
+    std::unique_ptr<BMVec> dalpha;
+    std::unique_ptr<BMVec> dbeta;
+};
+
+
+TEST_F(Csr, SingleVectorApplyIsEquivalentToRef)
+{
+    set_up_apply_data(1);
+
+    mat->apply(y.get(), expected.get());
+    dmat->apply(dy.get(), dresult.get());
+
+    GKO_ASSERT_BATCH_MTX_NEAR(dresult, expected, r<value_type>::value);
+}
+
+
+TEST_F(Csr, SingleVectorAdvancedApplyIsEquivalentToRef)
+{
+    set_up_apply_data(1);
+
+    mat->apply(alpha.get(), y.get(), beta.get(), expected.get());
+    dmat->apply(dalpha.get(), dy.get(), dbeta.get(), dresult.get());
+
+    GKO_ASSERT_BATCH_MTX_NEAR(dresult, expected, r<value_type>::value);
+}

--- a/test/matrix/batch_csr_kernels.cpp
+++ b/test/matrix/batch_csr_kernels.cpp
@@ -77,7 +77,7 @@ protected:
         dresult = gko::clone(exec, expected);
     }
 
-    std::ranlux48 rand_engine;
+    std::default_random_engine rand_engine;
 
     const gko::size_type batch_size = 11;
     std::unique_ptr<BMtx> mat;


### PR DESCRIPTION
This PR adds a batched Csr matrix format, that stores the same sparsity pattern for all entries, but different values for each batch. Only simple and advanced apply to `batch::MultiVector` are supported for now.

### TODO

+ [x] Add CUDA/HIP kernels
+ [x] Add DPCPP kernels
+ [x] Add to batch::Bicgstab dispatch
+ [x] Update docs