### PR TITLE
Remove version numbers from benchmark test output

### DIFF
--- a/benchmark/test/reference/blas.profile.stderr
+++ b/benchmark/test/reference/blas.profile.stderr
@@ -1,5 +1,3 @@
-This is Ginkgo 1.7.0 (develop)
-    running with core module 1.7.0 (develop)
 Running on reference(0)
 Running with 0 warm iterations and 1 running iterations
 The random seed for right hand sides is 42

--- a/benchmark/test/reference/blas.simple.stderr
+++ b/benchmark/test/reference/blas.simple.stderr
@@ -1,5 +1,3 @@
-This is Ginkgo 1.7.0 (develop)
-    running with core module 1.7.0 (develop)
 Running on reference(0)
 Running with 2 warm iterations and 10 running iterations
 The random seed for right hand sides is 42

--- a/benchmark/test/reference/conversion.all.stderr
+++ b/benchmark/test/reference/conversion.all.stderr
@@ -1,5 +1,3 @@
-This is Ginkgo 1.7.0 (develop)
-    running with core module 1.7.0 (develop)
 Running on reference(0)
 Running with 2 warm iterations and 10 running iterations
 The random seed for right hand sides is 42

--- a/benchmark/test/reference/conversion.matrix.stderr
+++ b/benchmark/test/reference/conversion.matrix.stderr
@@ -1,5 +1,3 @@
-This is Ginkgo 1.7.0 (develop)
-    running with core module 1.7.0 (develop)
 Running on reference(0)
 Running with 2 warm iterations and 10 running iterations
 The random seed for right hand sides is 42

--- a/benchmark/test/reference/conversion.profile.stderr
+++ b/benchmark/test/reference/conversion.profile.stderr
@@ -1,5 +1,3 @@
-This is Ginkgo 1.7.0 (develop)
-    running with core module 1.7.0 (develop)
 Running on reference(0)
 Running with 0 warm iterations and 1 running iterations
 The random seed for right hand sides is 42

--- a/benchmark/test/reference/conversion.simple.stderr
+++ b/benchmark/test/reference/conversion.simple.stderr
@@ -1,5 +1,3 @@
-This is Ginkgo 1.7.0 (develop)
-    running with core module 1.7.0 (develop)
 Running on reference(0)
 Running with 2 warm iterations and 10 running iterations
 The random seed for right hand sides is 42

--- a/benchmark/test/reference/distributed_solver.matrix.stderr
+++ b/benchmark/test/reference/distributed_solver.matrix.stderr
@@ -1,5 +1,3 @@
-This is Ginkgo 1.7.0 (develop)
-    running with core module 1.7.0 (develop)
 Running on reference(0)
 Running with 2 warm iterations and 1 running iterations
 The random seed for right hand sides is 42

--- a/benchmark/test/reference/distributed_solver.profile.stderr
+++ b/benchmark/test/reference/distributed_solver.profile.stderr
@@ -1,5 +1,3 @@
-This is Ginkgo 1.7.0 (develop)
-    running with core module 1.7.0 (develop)
 Running on reference(0)
 Running with 0 warm iterations and 1 running iterations
 The random seed for right hand sides is 42

--- a/benchmark/test/reference/distributed_solver.simple.stderr
+++ b/benchmark/test/reference/distributed_solver.simple.stderr
@@ -1,5 +1,3 @@
-This is Ginkgo 1.7.0 (develop)
-    running with core module 1.7.0 (develop)
 Running on reference(0)
 Running with 2 warm iterations and 1 running iterations
 The random seed for right hand sides is 42

--- a/benchmark/test/reference/matrix_statistics.matrix.stderr
+++ b/benchmark/test/reference/matrix_statistics.matrix.stderr
@@ -1,4 +1,2 @@
-This is Ginkgo 1.7.0 (develop)
-    running with core module 1.7.0 (develop)
 Running test case <filename>
 Matrix is of size (36, 36), 208

--- a/benchmark/test/reference/matrix_statistics.simple.stderr
+++ b/benchmark/test/reference/matrix_statistics.simple.stderr
@@ -1,4 +1,2 @@
-This is Ginkgo 1.7.0 (develop)
-    running with core module 1.7.0 (develop)
 Running test case stencil(100, 7pt)
 Matrix is of size (125, 125), 725

--- a/benchmark/test/reference/multi_vector_distributed.profile.stderr
+++ b/benchmark/test/reference/multi_vector_distributed.profile.stderr
@@ -1,5 +1,3 @@
-This is Ginkgo 1.7.0 (develop)
-    running with core module 1.7.0 (develop)
 Running on reference(0)
 Running with 0 warm iterations and 1 running iterations
 The random seed for right hand sides is 42

--- a/benchmark/test/reference/multi_vector_distributed.simple.stderr
+++ b/benchmark/test/reference/multi_vector_distributed.simple.stderr
@@ -1,5 +1,3 @@
-This is Ginkgo 1.7.0 (develop)
-    running with core module 1.7.0 (develop)
 Running on reference(0)
 Running with 2 warm iterations and 10 running iterations
 The random seed for right hand sides is 42

--- a/benchmark/test/reference/preconditioner.matrix.stderr
+++ b/benchmark/test/reference/preconditioner.matrix.stderr
@@ -1,5 +1,3 @@
-This is Ginkgo 1.7.0 (develop)
-    running with core module 1.7.0 (develop)
 Running on reference(0)
 Running with 2 warm iterations and 10 running iterations
 The random seed for right hand sides is 42

--- a/benchmark/test/reference/preconditioner.profile.stderr
+++ b/benchmark/test/reference/preconditioner.profile.stderr
@@ -1,5 +1,3 @@
-This is Ginkgo 1.7.0 (develop)
-    running with core module 1.7.0 (develop)
 Running on reference(0)
 Running with 0 warm iterations and 1 running iterations
 The random seed for right hand sides is 42

--- a/benchmark/test/reference/preconditioner.reordered.stderr
+++ b/benchmark/test/reference/preconditioner.reordered.stderr
@@ -1,5 +1,3 @@
-This is Ginkgo 1.7.0 (develop)
-    running with core module 1.7.0 (develop)
 Running on reference(0)
 Running with 2 warm iterations and 10 running iterations
 The random seed for right hand sides is 42

--- a/benchmark/test/reference/preconditioner.simple.stderr
+++ b/benchmark/test/reference/preconditioner.simple.stderr
@@ -1,5 +1,3 @@
-This is Ginkgo 1.7.0 (develop)
-    running with core module 1.7.0 (develop)
 Running on reference(0)
 Running with 2 warm iterations and 10 running iterations
 The random seed for right hand sides is 42

--- a/benchmark/test/reference/solver.matrix.stderr
+++ b/benchmark/test/reference/solver.matrix.stderr
@@ -1,5 +1,3 @@
-This is Ginkgo 1.7.0 (develop)
-    running with core module 1.7.0 (develop)
 Running on reference(0)
 Running with 2 warm iterations and 1 running iterations
 The random seed for right hand sides is 42

--- a/benchmark/test/reference/solver.profile.stderr
+++ b/benchmark/test/reference/solver.profile.stderr
@@ -1,5 +1,3 @@
-This is Ginkgo 1.7.0 (develop)
-    running with core module 1.7.0 (develop)
 Running on reference(0)
 Running with 0 warm iterations and 1 running iterations
 The random seed for right hand sides is 42

--- a/benchmark/test/reference/solver.reordered.stderr
+++ b/benchmark/test/reference/solver.reordered.stderr
@@ -1,5 +1,3 @@
-This is Ginkgo 1.7.0 (develop)
-    running with core module 1.7.0 (develop)
 Running on reference(0)
 Running with 2 warm iterations and 1 running iterations
 The random seed for right hand sides is 42

--- a/benchmark/test/reference/solver.simple.stderr
+++ b/benchmark/test/reference/solver.simple.stderr
@@ -1,5 +1,3 @@
-This is Ginkgo 1.7.0 (develop)
-    running with core module 1.7.0 (develop)
 Running on reference(0)
 Running with 2 warm iterations and 1 running iterations
 The random seed for right hand sides is 42

--- a/benchmark/test/reference/sparse_blas.matrix.stderr
+++ b/benchmark/test/reference/sparse_blas.matrix.stderr
@@ -1,5 +1,3 @@
-This is Ginkgo 1.7.0 (develop)
-    running with core module 1.7.0 (develop)
 Running on reference(0)
 Running with 2 warm iterations and 10 running iterations
 The random seed for right hand sides is 42

--- a/benchmark/test/reference/sparse_blas.profile.stderr
+++ b/benchmark/test/reference/sparse_blas.profile.stderr
@@ -1,5 +1,3 @@
-This is Ginkgo 1.7.0 (develop)
-    running with core module 1.7.0 (develop)
 Running on reference(0)
 Running with 0 warm iterations and 1 running iterations
 The random seed for right hand sides is 42

--- a/benchmark/test/reference/sparse_blas.reordered.stderr
+++ b/benchmark/test/reference/sparse_blas.reordered.stderr
@@ -1,5 +1,3 @@
-This is Ginkgo 1.7.0 (develop)
-    running with core module 1.7.0 (develop)
 Running on reference(0)
 Running with 2 warm iterations and 10 running iterations
 The random seed for right hand sides is 42

--- a/benchmark/test/reference/sparse_blas.simple.stderr
+++ b/benchmark/test/reference/sparse_blas.simple.stderr
@@ -1,5 +1,3 @@
-This is Ginkgo 1.7.0 (develop)
-    running with core module 1.7.0 (develop)
 Running on reference(0)
 Running with 2 warm iterations and 10 running iterations
 The random seed for right hand sides is 42

--- a/benchmark/test/reference/spmv.matrix.stderr
+++ b/benchmark/test/reference/spmv.matrix.stderr
@@ -1,5 +1,3 @@
-This is Ginkgo 1.7.0 (develop)
-    running with core module 1.7.0 (develop)
 Running on reference(0)
 Running with 2 warm iterations and 10 running iterations
 The random seed for right hand sides is 42

--- a/benchmark/test/reference/spmv.profile.stderr
+++ b/benchmark/test/reference/spmv.profile.stderr
@@ -1,5 +1,3 @@
-This is Ginkgo 1.7.0 (develop)
-    running with core module 1.7.0 (develop)
 Running on reference(0)
 Running with 0 warm iterations and 1 running iterations
 The random seed for right hand sides is 42

--- a/benchmark/test/reference/spmv.reordered.stderr
+++ b/benchmark/test/reference/spmv.reordered.stderr
@@ -1,5 +1,3 @@
-This is Ginkgo 1.7.0 (develop)
-    running with core module 1.7.0 (develop)
 Running on reference(0)
 Running with 2 warm iterations and 10 running iterations
 The random seed for right hand sides is 42

--- a/benchmark/test/reference/spmv.simple.stderr
+++ b/benchmark/test/reference/spmv.simple.stderr
@@ -1,5 +1,3 @@
-This is Ginkgo 1.7.0 (develop)
-    running with core module 1.7.0 (develop)
 Running on reference(0)
 Running with 2 warm iterations and 10 running iterations
 The random seed for right hand sides is 42

--- a/benchmark/test/reference/spmv_distributed.profile.stderr
+++ b/benchmark/test/reference/spmv_distributed.profile.stderr
@@ -1,5 +1,3 @@
-This is Ginkgo 1.7.0 (develop)
-    running with core module 1.7.0 (develop)
 Running on reference(0)
 Running with 0 warm iterations and 1 running iterations
 The random seed for right hand sides is 42

--- a/benchmark/test/reference/spmv_distributed.simple.stderr
+++ b/benchmark/test/reference/spmv_distributed.simple.stderr
@@ -1,5 +1,3 @@
-This is Ginkgo 1.7.0 (develop)
-    running with core module 1.7.0 (develop)
 Running on reference(0)
 Running with 2 warm iterations and 10 running iterations
 The random seed for right hand sides is 42

--- a/benchmark/test/test_framework.py.in
+++ b/benchmark/test/test_framework.py.in
@@ -22,8 +22,7 @@ denumberify_paths = [
     "rhs_norm",
     "max_relative_norm2",
 ]
-detypenameify_key_starts = [
-    "generate(", "apply(", "advanced_apply(", "copy(", "check("]
+detypenameify_key_starts = ["generate(", "apply(", "advanced_apply(", "copy(", "check("]
 empty_string_paths = ["filename"]
 empty_array_paths = [
     "recurrent_residuals",
@@ -149,7 +148,9 @@ def compare_output_impl(
         )
     )
     ignore_patterns = [
-        "    the .* module is",  # version numbers
+        "This is Ginkgo",  # version numbers + tag
+        "    the .* module is",  # version numbers + tag
+        "    running with core module",  # version numbers + tag
         "DEBUG: (begin|end  ) (allocate|free)",  # allocations
     ]
     typename_patterns = [
@@ -178,8 +179,7 @@ def compare_output_impl(
         ignore_patterns=ignore_patterns,
         replace_patterns=typename_patterns,
     )
-    expected_stdout_processed = sanitize_json_text(
-        open(expected_stdout).read())
+    expected_stdout_processed = sanitize_json_text(open(expected_stdout).read())
     expected_stderr_processed = sanitize_text(
         open(expected_stderr).read(),
         ignore_patterns=ignore_patterns,
@@ -190,8 +190,7 @@ def compare_output_impl(
         print("FAIL: stdout differs")
         print(
             "\n".join(
-                difflib.unified_diff(
-                    expected_stdout_processed, result_stdout_processed)
+                difflib.unified_diff(expected_stdout_processed, result_stdout_processed)
             )
         )
         failed = True
@@ -199,8 +198,7 @@ def compare_output_impl(
         print("FAIL: stderr differs")
         print(
             "\n".join(
-                difflib.unified_diff(
-                    expected_stderr_processed, result_stderr_processed)
+                difflib.unified_diff(expected_stderr_processed, result_stderr_processed)
             )
         )
         failed = True


### PR DESCRIPTION
This makes the benchmark test output agnostic of version and tag

Closes #1452 