### PR TITLE
Fix libc++ incompatibility

### DIFF
--- a/core/base/timer.cpp
+++ b/core/base/timer.cpp
@@ -96,7 +96,7 @@ void CpuTimer::wait(time_point& time) {}
 std::chrono::nanoseconds CpuTimer::difference_async(const time_point& start,
                                                     const time_point& stop)
 {
-    return std::chrono::duration_cast<std::chrono::nanoseconds, int64>(
+    return std::chrono::duration_cast<std::chrono::nanoseconds>(
         stop.data_.chrono - start.data_.chrono);
 }
 


### PR DESCRIPTION
This is an issue detected in https://github.com/conan-io/conan-center-index/pull/21058, which uses a different integer type for `std::chrono::nanosecond`