### PR TITLE
Use quoted arguments in cmake if

### DIFF
--- a/cmake/GinkgoConfig.cmake.in
+++ b/cmake/GinkgoConfig.cmake.in
@@ -203,9 +203,9 @@ endif()
 
 # Check that the same compilers as for Ginkgo are used
 function(_ginkgo_check_compiler lang)
-    if(NOT ${CMAKE_${lang}_COMPILER} STREQUAL ${GINKGO_${lang}_COMPILER})
+    if(NOT "${CMAKE_${lang}_COMPILER}" STREQUAL "${GINKGO_${lang}_COMPILER}")
         set(_compiler_short "${CMAKE_${lang}_COMPILER_ID}:${CMAKE_${lang}_COMPILER_VERSION}")
-        if(NOT _compiler_short STREQUAL "${GINKGO_${lang}_COMPILER_SHORT}")
+        if(NOT "${_compiler_short}" STREQUAL "${GINKGO_${lang}_COMPILER_SHORT}")
             message(WARNING "The currently used ${lang} compiler: ${CMAKE_${lang}_COMPILER} does not match the compiler used to "
                             "build Ginkgo: ${GINKGO_${lang}_COMPILER}. It is encouraged to use the same compiler as Ginkgo to prevent ABI mismatch.")
         endif()


### PR DESCRIPTION
This PR adds quotes around the arguments to the if-clauses in the ginkgo compiler check. Otherwise, if one of the arguments is empty, it leads to cmake errors.