### PR TITLE
fixup checking out branch for CI

### DIFF
--- a/.github/bot-pr-format-base.sh
+++ b/.github/bot-pr-format-base.sh
@@ -9,10 +9,6 @@ git remote add fork "$HEAD_URL"
 git fetch fork "$HEAD_BRANCH"
 git fetch origin "$BASE_BRANCH"
 
-# checkout current PR head
-LOCAL_BRANCH=format-tmp-$HEAD_BRANCH
-git checkout -b $LOCAL_BRANCH fork/$HEAD_BRANCH
-
 git config user.email "ginkgo.library@gmail.com"
 git config user.name "ginkgo-bot"
 


### PR DESCRIPTION
This PR fixes a mistake I made merging #1461. The issue was that the `bot_pr_format_base.sh` script tried to create the same branch twice.