### PR TITLE
Use configs files from develop in CI

### DIFF
--- a/.github/bot-pr-format-base.sh
+++ b/.github/bot-pr-format-base.sh
@@ -13,6 +13,7 @@ git config user.email "ginkgo.library@gmail.com"
 git config user.name "ginkgo-bot"
 
 # save scripts from develop
+cp .clang-format .pre-commit-config.yaml /tmp
 pushd dev_tools/scripts || exit 1
 cp add_license.sh format_header.sh update_ginkgo_header.sh /tmp
 popd || exit 1
@@ -22,6 +23,8 @@ LOCAL_BRANCH=format-tmp-$HEAD_BRANCH
 git checkout -b $LOCAL_BRANCH fork/$HEAD_BRANCH
 
 # restore files from develop
+cp /tmp/.clang-format .
+cp /tmp/.pre-commit-config .
 cp /tmp/add_license.sh dev_tools/scripts/
 cp /tmp/format_header.sh dev_tools/scripts/
 cp /tmp/update_ginkgo_header.sh dev_tools/scripts/

--- a/.github/format-rebase.sh
+++ b/.github/format-rebase.sh
@@ -9,7 +9,8 @@ DIFF_COMMAND="git diff --name-only --no-renames --diff-filter=AM HEAD~ | grep -E
 
 # do the formatting rebase
 git rebase --rebase-merges --empty=drop --no-keep-empty \
-    --exec "cp /tmp/add_license.sh /tmp/format_header.sh /tmp/update_ginkgo_header.sh dev_tools/scripts/ && \
+    --exec "cp /tmp/.clang-format /tmp/.pre-commit-config.yaml . && \
+            cp /tmp/add_license.sh /tmp/format_header.sh /tmp/update_ginkgo_header.sh dev_tools/scripts/ && \
             dev_tools/scripts/add_license.sh && dev_tools/scripts/update_ginkgo_header.sh && \
             for f in \$($DIFF_COMMAND | grep -E '$FORMAT_HEADER_REGEX'); do dev_tools/scripts/format_header.sh \$f; done && \
             pipx run pre-commit run && \


### PR DESCRIPTION
This PR changes our formatting CI to use the config files from develop. We already use the dev_tool scripts from develop, so this makes it more consistent.