### PR TITLE
Remove old variable in CMake `gko_rename_cache`

### DIFF
--- a/cmake/rename.cmake
+++ b/cmake/rename.cmake
@@ -5,7 +5,8 @@ macro(gko_rename_cache deprecated actual type doc_string)
             message("actual ${actual} and deprecated ${deprecated}")
             if("${${actual}}" STREQUAL "${${deprecated}}")
                 # They are the same, so only throw warning
-                message(WARNING "${deprecated} was deprecated, please only use ${actual} instead.")
+                message(WARNING "${deprecated} was deprecated, please only use ${actual} instead. We removed the old variable.")
+                unset(${deprecated} CACHE)
             else()
                 # They are different
                 message(FATAL_ERROR "Both ${deprecated} and ${actual} were specified differently, please only use ${actual} instead.")
@@ -13,9 +14,9 @@ macro(gko_rename_cache deprecated actual type doc_string)
         else()
             # Only set `deprecated`, move it to `actual`.
             message(WARNING "${deprecated} was deprecated, please use ${actual} instead.  "
-                "We copy ${${deprecated}} to ${actual} and remove the old variable")
+                "We copied ${${deprecated}} to ${actual} and removed the old variable.")
             set(${actual} ${${deprecated}} CACHE ${type} "${doc_string}")
-            unset(${${deprecated}} CACHE)
+            unset(${deprecated} CACHE)
         endif()
     endif()
 endmacro()

--- a/cmake/rename.cmake
+++ b/cmake/rename.cmake
@@ -13,8 +13,9 @@ macro(gko_rename_cache deprecated actual type doc_string)
         else()
             # Only set `deprecated`, move it to `actual`.
             message(WARNING "${deprecated} was deprecated, please use ${actual} instead.  "
-                "We copy ${${deprecated}} to ${actual}")
+                "We copy ${${deprecated}} to ${actual} and remove the old variable")
             set(${actual} ${${deprecated}} CACHE ${type} "${doc_string}")
+            unset(${${deprecated}} CACHE)
         endif()
     endif()
 endmacro()


### PR DESCRIPTION
I wanted to propose this change to get rid of warning messages on my long-standing repositories, be creative in thinking of potential negative side-effects this might have!

This removes the old variable from cache instead of leaving it around, which leads to the error message only being shown once instead of continuously. Removing variables from cache requires modifying the `CMakeCache.txt`, which isn't something we need to ask of them.