### PR TITLE
Make dim constructor explicit

### DIFF
--- a/benchmark/matrix_generator/matrix_generator.cpp
+++ b/benchmark/matrix_generator/matrix_generator.cpp
@@ -87,7 +87,7 @@ gko::matrix_data<etype, itype> generate_block_diagonal(
     auto block = gko::matrix_data<etype, itype>(
         gko::dim<2>(block_size),
         std::uniform_real_distribution<rc_etype>(-1.0, 1.0), engine);
-    return gko::matrix_data<etype, itype>::diag(num_blocks, block);
+    return gko::matrix_data<etype, itype>::diag(gko::dim<2>{num_blocks}, block);
 }
 
 

--- a/benchmark/preconditioner/preconditioner.cpp
+++ b/benchmark/preconditioner/preconditioner.cpp
@@ -159,9 +159,10 @@ struct PreconditionerBenchmark : Benchmark<preconditioner_benchmark_state> {
 
         state.system_matrix =
             formats::matrix_factory(FLAGS_formats, exec, data);
-        state.b = Generator::create_multi_vector_random(exec, data.size[0]);
-        state.x = Generator::create_multi_vector(exec, data.size[0],
-                                                 gko::zero<etype>());
+        state.b = Generator::create_multi_vector_random(
+            exec, gko::dim<2>{data.size[0]});
+        state.x = Generator::create_multi_vector(
+            exec, gko::dim<2>{data.size[0]}, gko::zero<etype>());
 
         std::clog << "Matrix is of size (" << data.size[0] << ", "
                   << data.size[1] << "), " << data.nonzeros.size() << std::endl;

--- a/core/matrix/permutation.cpp
+++ b/core/matrix/permutation.cpp
@@ -128,14 +128,15 @@ Permutation<IndexType>::create_const(
 template <typename IndexType>
 Permutation<IndexType>::Permutation(std::shared_ptr<const Executor> exec,
                                     size_type size)
-    : EnableLinOp<Permutation>(exec, size), permutation_{exec, size}
+    : EnableLinOp<Permutation>(exec, dim<2>{size}), permutation_{exec, size}
 {}
 
 
 template <typename IndexType>
 Permutation<IndexType>::Permutation(std::shared_ptr<const Executor> exec,
                                     array<index_type> permutation_indices)
-    : EnableLinOp<Permutation>(exec, permutation_indices.get_num_elems()),
+    : EnableLinOp<Permutation>(exec,
+                               dim<2>{permutation_indices.get_num_elems()}),
       permutation_{exec, std::move(permutation_indices)}
 {}
 

--- a/include/ginkgo/core/base/dim.hpp
+++ b/include/ginkgo/core/base/dim.hpp
@@ -31,11 +31,16 @@ struct dim {
     using dimension_type = DimensionType;
 
     /**
+     * Creates a dimension object with all dimensions set to zero.
+     */
+    constexpr GKO_ATTRIBUTES dim() : dim{dimension_type{}} {}
+
+    /**
      * Creates a dimension object with all dimensions set to the same value.
      *
      * @param size  the size of each dimension
      */
-    constexpr GKO_ATTRIBUTES dim(const dimension_type& size = dimension_type{})
+    explicit constexpr GKO_ATTRIBUTES dim(const dimension_type& size)
         : first_{size}, rest_{size}
     {}
 
@@ -52,7 +57,8 @@ struct dim {
      * @param first  first dimension
      * @param rest  other dimensions
      */
-    template <typename... Rest>
+    template <typename... Rest,
+              std::enable_if_t<sizeof...(Rest) >= 1>* = nullptr>
     constexpr GKO_ATTRIBUTES dim(const dimension_type& first,
                                  const Rest&... rest)
         : first_{first}, rest_{static_cast<dimension_type>(rest)...}
@@ -113,6 +119,19 @@ struct dim {
     friend constexpr GKO_ATTRIBUTES bool operator==(const dim& x, const dim& y)
     {
         return x.first_ == y.first_ && x.rest_ == y.rest_;
+    }
+
+    /**
+     * Checks if two dim objects are not equal.
+     *
+     * @param x  first object
+     * @param y  second object
+     *
+     * @return false if and only if all dimensions of both objects are equal.
+     */
+    friend constexpr GKO_ATTRIBUTES bool operator!=(const dim& x, const dim& y)
+    {
+        return !(x == y);
     }
 
     /**
@@ -195,6 +214,11 @@ struct dim<1u, DimensionType> {
         return x.first_ == y.first_;
     }
 
+    friend constexpr GKO_ATTRIBUTES bool operator!=(const dim& x, const dim& y)
+    {
+        return !(x == y);
+    }
+
     friend constexpr GKO_ATTRIBUTES dim operator*(const dim& x, const dim& y)
     {
         return dim(x.first_ * y.first_);
@@ -213,26 +237,6 @@ private:
 
     dimension_type first_;
 };
-
-
-/**
- * Checks if two dim objects are different.
- *
- * @tparam Dimensionality  number of dimensions of the dim objects
- * @tparam DimensionType  datatype used to represent each dimension
- *
- * @param x  first object
- * @param y  second object
- *
- * @return `!(x == y)`
- */
-template <size_type Dimensionality, typename DimensionType>
-constexpr GKO_ATTRIBUTES GKO_INLINE bool operator!=(
-    const dim<Dimensionality, DimensionType>& x,
-    const dim<Dimensionality, DimensionType>& y)
-{
-    return !(x == y);
-}
 
 
 /**

--- a/include/ginkgo/core/base/dim.hpp
+++ b/include/ginkgo/core/base/dim.hpp
@@ -57,8 +57,8 @@ struct dim {
      * @param first  first dimension
      * @param rest  other dimensions
      */
-    template <typename... Rest,
-              std::enable_if_t<sizeof...(Rest) >= 1>* = nullptr>
+    template <typename... Rest, std::enable_if_t<sizeof...(Rest) ==
+                                                 Dimensionality - 1>* = nullptr>
     constexpr GKO_ATTRIBUTES dim(const dimension_type& first,
                                  const Rest&... rest)
         : first_{first}, rest_{static_cast<dimension_type>(rest)...}

--- a/test/matrix/matrix.cpp
+++ b/test/matrix/matrix.cpp
@@ -1234,7 +1234,7 @@ TYPED_TEST(Matrix, DeviceReadMoveIsEquivalentToHostRef)
         dev_result->read(std::move(ref_device_data));
 
         ASSERT_EQ(ref_device_data.get_size(), gko::dim<2>{});
-        ASSERT_EQ(ref_device_data.get_num_elems(), gko::dim<2>{});
+        ASSERT_EQ(ref_device_data.get_num_elems(), 0);
         GKO_ASSERT_MTX_NEAR(ref_result, dev_result, 0.0);
         GKO_ASSERT_MTX_EQ_SPARSITY(ref_result, dev_result);
     });


### PR DESCRIPTION
To avoid things like `dim<2>{1, 2} == 3` working accidentally, we need to make the single-parameter constructor `explicit`.