### PR TITLE
Copy device_matrix_data into arrays

### DIFF
--- a/core/matrix/coo.cpp
+++ b/core/matrix/coo.cpp
@@ -185,11 +185,11 @@ void Coo<ValueType, IndexType>::read(const mat_data& data)
     auto size = data.size;
     auto exec = this->get_executor();
     this->set_size(size);
-    row_idxs_.resize_and_reset(data.nonzeros.size());
-    col_idxs_.resize_and_reset(data.nonzeros.size());
-    values_.resize_and_reset(data.nonzeros.size());
-    device_mat_data view{exec, size, row_idxs_.as_view(), col_idxs_.as_view(),
-                         values_.as_view()};
+    this->row_idxs_.resize_and_reset(data.nonzeros.size());
+    this->col_idxs_.resize_and_reset(data.nonzeros.size());
+    this->values_.resize_and_reset(data.nonzeros.size());
+    device_mat_data view{exec, size, this->row_idxs_.as_view(),
+                         this->col_idxs_.as_view(), this->values_.as_view()};
     const auto host_data =
         make_array_view(exec->get_master(), data.nonzeros.size(),
                         const_cast<matrix_data_entry<ValueType, IndexType>*>(
@@ -203,6 +203,9 @@ template <typename ValueType, typename IndexType>
 void Coo<ValueType, IndexType>::read(const device_mat_data& data)
 {
     this->set_size(data.get_size());
+    // copy the arrays from device matrix data into the arrays of
+    // this. Compared to the read(device_mat_data&&) version, the internal
+    // arrays keep their current ownership status
     this->values_ = make_const_array_view(data.get_executor(),
                                           data.get_num_stored_elements(),
                                           data.get_const_values());

--- a/core/matrix/csr.cpp
+++ b/core/matrix/csr.cpp
@@ -426,12 +426,16 @@ void Csr<ValueType, IndexType>::read(const mat_data& data)
 {
     auto size = data.size;
     auto exec = this->get_executor();
-    row_ptrs_.resize_and_reset(size[0] + 1);
-    col_idxs_.resize_and_reset(data.nonzeros.size());
-    values_.resize_and_reset(data.nonzeros.size());
+    this->set_size(size);
+    this->row_ptrs_.resize_and_reset(size[0] + 1);
+    this->col_idxs_.resize_and_reset(data.nonzeros.size());
+    this->values_.resize_and_reset(data.nonzeros.size());
+    // the device matrix data contains views on the column indices
+    // and values array of this matrix, and an owning array for the
+    // row indices (which doesn't exist in this matrix)
     device_mat_data view{exec, size,
                          array<IndexType>{exec, data.nonzeros.size()},
-                         col_idxs_.as_view(), values_.as_view()};
+                         this->col_idxs_.as_view(), this->values_.as_view()};
     const auto host_data =
         make_array_view(exec->get_master(), data.nonzeros.size(),
                         const_cast<matrix_data_entry<ValueType, IndexType>*>(
@@ -440,7 +444,7 @@ void Csr<ValueType, IndexType>::read(const mat_data& data)
         csr::make_aos_to_soa(*make_temporary_clone(exec, &host_data), view));
     exec->run(csr::make_convert_idxs_to_ptrs(view.get_const_row_idxs(),
                                              view.get_num_stored_elements(),
-                                             size[0], get_row_ptrs()));
+                                             size[0], this->get_row_ptrs()));
     this->make_srow();
 }
 
@@ -452,6 +456,9 @@ void Csr<ValueType, IndexType>::read(const device_mat_data& data)
     auto exec = this->get_executor();
     this->row_ptrs_.resize_and_reset(size[0] + 1);
     this->set_size(size);
+    // copy the column indices and values array from the device matrix data
+    // into this. Compared to the read(device_mat_data&&) version, the internal
+    // arrays keep their current ownership status.
     this->values_ = make_const_array_view(data.get_executor(),
                                           data.get_num_stored_elements(),
                                           data.get_const_values());
@@ -476,7 +483,7 @@ void Csr<ValueType, IndexType>::read(device_mat_data&& data)
     auto size = data.get_size();
     auto exec = this->get_executor();
     auto arrays = data.empty_out();
-    this->row_ptrs_ = array<IndexType>{exec, size[0] + 1};
+    this->row_ptrs_.resize_and_reset(size[0] + 1);
     this->set_size(size);
     this->values_ = std::move(arrays.values);
     this->col_idxs_ = std::move(arrays.col_idxs);

--- a/core/matrix/csr.cpp
+++ b/core/matrix/csr.cpp
@@ -95,6 +95,7 @@ GKO_REGISTER_OPERATION(inv_scale, csr::inv_scale);
 GKO_REGISTER_OPERATION(add_scaled_identity, csr::add_scaled_identity);
 GKO_REGISTER_OPERATION(check_diagonal_entries,
                        csr::check_diagonal_entries_exist);
+GKO_REGISTER_OPERATION(aos_to_soa, components::aos_to_soa);
 
 
 }  // anonymous namespace
@@ -423,15 +424,49 @@ void Csr<ValueType, IndexType>::move_to(Fbcsr<ValueType, IndexType>* result)
 template <typename ValueType, typename IndexType>
 void Csr<ValueType, IndexType>::read(const mat_data& data)
 {
-    this->read(device_mat_data::create_from_host(this->get_executor(), data));
+    auto size = data.size;
+    auto exec = this->get_executor();
+    row_ptrs_.resize_and_reset(size[0] + 1);
+    col_idxs_.resize_and_reset(data.nonzeros.size());
+    values_.resize_and_reset(data.nonzeros.size());
+    device_mat_data view{exec, size,
+                         array<IndexType>{exec, data.nonzeros.size()},
+                         col_idxs_.as_view(), values_.as_view()};
+    const auto host_data =
+        make_array_view(exec->get_master(), data.nonzeros.size(),
+                        const_cast<matrix_data_entry<ValueType, IndexType>*>(
+                            data.nonzeros.data()));
+    exec->run(
+        csr::make_aos_to_soa(*make_temporary_clone(exec, &host_data), view));
+    exec->run(csr::make_convert_idxs_to_ptrs(view.get_const_row_idxs(),
+                                             view.get_num_stored_elements(),
+                                             size[0], get_row_ptrs()));
+    this->make_srow();
 }
 
 
 template <typename ValueType, typename IndexType>
 void Csr<ValueType, IndexType>::read(const device_mat_data& data)
 {
-    // make a copy, read the data in
-    this->read(device_mat_data{this->get_executor(), data});
+    auto size = data.get_size();
+    auto exec = this->get_executor();
+    this->row_ptrs_.resize_and_reset(size[0] + 1);
+    this->set_size(size);
+    this->values_ = make_const_array_view(data.get_executor(),
+                                          data.get_num_stored_elements(),
+                                          data.get_const_values());
+    this->col_idxs_ = make_const_array_view(data.get_executor(),
+                                            data.get_num_stored_elements(),
+                                            data.get_const_col_idxs());
+    const auto row_idxs = make_const_array_view(data.get_executor(),
+                                                data.get_num_stored_elements(),
+                                                data.get_const_row_idxs())
+                              .copy_to_array();
+    auto local_row_idxs = make_temporary_clone(exec, &row_idxs);
+    exec->run(csr::make_convert_idxs_to_ptrs(local_row_idxs->get_const_data(),
+                                             local_row_idxs->get_size(),
+                                             size[0], this->get_row_ptrs()));
+    this->make_srow();
 }
 
 
@@ -441,7 +476,7 @@ void Csr<ValueType, IndexType>::read(device_mat_data&& data)
     auto size = data.get_size();
     auto exec = this->get_executor();
     auto arrays = data.empty_out();
-    this->row_ptrs_.resize_and_reset(size[0] + 1);
+    this->row_ptrs_ = array<IndexType>{exec, size[0] + 1};
     this->set_size(size);
     this->values_ = std::move(arrays.values);
     this->col_idxs_ = std::move(arrays.col_idxs);

--- a/core/test/base/array.cpp
+++ b/core/test/base/array.cpp
@@ -523,7 +523,8 @@ TYPED_TEST(Array, CopyViewToArray)
 TYPED_TEST(Array, CopyArrayToView)
 {
     TypeParam data[] = {1, 2, 3};
-    auto view = gko::make_array_view(this->exec, 3, data);
+    auto view = gko::make_array_view(this->exec, 2, data);
+    gko::array<TypeParam> array_size1(this->exec, {5});
     gko::array<TypeParam> array_size2(this->exec, {5, 4});
     gko::array<TypeParam> array_size4(this->exec, {5, 4, 2, 1});
 
@@ -531,12 +532,49 @@ TYPED_TEST(Array, CopyArrayToView)
 
     EXPECT_EQ(data[0], TypeParam{5});
     EXPECT_EQ(data[1], TypeParam{4});
-    EXPECT_EQ(data[2], TypeParam{3});
-    EXPECT_EQ(view.get_size(), 3);
+    EXPECT_EQ(view.get_size(), 2);
     EXPECT_EQ(array_size2.get_size(), 2);
+    ASSERT_THROW(view = array_size1, gko::OutOfBoundsError);
     ASSERT_THROW(view = array_size4, gko::OutOfBoundsError);
 }
 
+
+TYPED_TEST(Array, CopyConstViewToArray)
+{
+    TypeParam data[] = {1, 2, 3, 4};
+    auto const_view = gko::make_const_array_view(this->exec, 4, data);
+    gko::array<TypeParam> array(this->exec, {5, 4, 2});
+
+    array = const_view;
+
+    EXPECT_EQ(array.get_data()[0], TypeParam{1});
+    EXPECT_EQ(array.get_data()[1], TypeParam{2});
+    EXPECT_EQ(array.get_data()[2], TypeParam{3});
+    EXPECT_EQ(array.get_data()[3], TypeParam{4});
+    EXPECT_EQ(array.get_size(), 4);
+    ASSERT_EQ(const_view.get_size(), 4);
+}
+
+
+TYPED_TEST(Array, CopyConstViewToView)
+{
+    TypeParam data1[] = {1, 2, 3, 4};
+    TypeParam data2[] = {5, 4, 2};
+    auto view = gko::make_array_view(this->exec, 3, data2);
+    auto const_view2 = gko::make_const_array_view(this->exec, 2, data1);
+    auto const_view3 = gko::make_const_array_view(this->exec, 3, data1);
+    auto const_view4 = gko::make_const_array_view(this->exec, 4, data1);
+
+    view = const_view3;
+
+    EXPECT_EQ(view.get_data()[0], TypeParam{1});
+    EXPECT_EQ(view.get_data()[1], TypeParam{2});
+    EXPECT_EQ(view.get_data()[2], TypeParam{3});
+    EXPECT_EQ(view.get_size(), 3);
+    EXPECT_EQ(const_view3.get_size(), 3);
+    ASSERT_THROW(view = const_view2, gko::ValueMismatch);
+    ASSERT_THROW(view = const_view4, gko::ValueMismatch);
+}
 
 TYPED_TEST(Array, MoveArrayToArray)
 {

--- a/core/test/base/array.cpp
+++ b/core/test/base/array.cpp
@@ -524,7 +524,6 @@ TYPED_TEST(Array, CopyArrayToView)
 {
     TypeParam data[] = {1, 2, 3};
     auto view = gko::make_array_view(this->exec, 2, data);
-    gko::array<TypeParam> array_size1(this->exec, {5});
     gko::array<TypeParam> array_size2(this->exec, {5, 4});
     gko::array<TypeParam> array_size4(this->exec, {5, 4, 2, 1});
 
@@ -534,7 +533,6 @@ TYPED_TEST(Array, CopyArrayToView)
     EXPECT_EQ(data[1], TypeParam{4});
     EXPECT_EQ(view.get_size(), 2);
     EXPECT_EQ(array_size2.get_size(), 2);
-    ASSERT_THROW(view = array_size1, gko::OutOfBoundsError);
     ASSERT_THROW(view = array_size4, gko::OutOfBoundsError);
 }
 
@@ -546,6 +544,7 @@ TYPED_TEST(Array, CopyConstViewToArray)
     gko::array<TypeParam> array(this->exec, {5, 4, 2});
 
     array = const_view;
+    data[1] = 7;
 
     EXPECT_EQ(array.get_data()[0], TypeParam{1});
     EXPECT_EQ(array.get_data()[1], TypeParam{2});
@@ -561,19 +560,18 @@ TYPED_TEST(Array, CopyConstViewToView)
     TypeParam data1[] = {1, 2, 3, 4};
     TypeParam data2[] = {5, 4, 2};
     auto view = gko::make_array_view(this->exec, 3, data2);
-    auto const_view2 = gko::make_const_array_view(this->exec, 2, data1);
     auto const_view3 = gko::make_const_array_view(this->exec, 3, data1);
     auto const_view4 = gko::make_const_array_view(this->exec, 4, data1);
 
     view = const_view3;
+    data1[1] = 7;
 
     EXPECT_EQ(view.get_data()[0], TypeParam{1});
     EXPECT_EQ(view.get_data()[1], TypeParam{2});
     EXPECT_EQ(view.get_data()[2], TypeParam{3});
     EXPECT_EQ(view.get_size(), 3);
     EXPECT_EQ(const_view3.get_size(), 3);
-    ASSERT_THROW(view = const_view2, gko::ValueMismatch);
-    ASSERT_THROW(view = const_view4, gko::ValueMismatch);
+    ASSERT_THROW(view = const_view4, gko::OutOfBoundsError);
 }
 
 TYPED_TEST(Array, MoveArrayToArray)

--- a/core/test/matrix/coo.cpp
+++ b/core/test/matrix/coo.cpp
@@ -197,6 +197,26 @@ TYPED_TEST(Coo, CanBeReadFromMatrixData)
 }
 
 
+TYPED_TEST(Coo, CanBeReadFromMatrixDataIntoViews)
+{
+    using Mtx = typename TestFixture::Mtx;
+    using value_type = typename TestFixture::value_type;
+    using index_type = typename TestFixture::index_type;
+    auto row_idxs = gko::array<index_type>(this->exec, 4);
+    auto col_idxs = gko::array<index_type>(this->exec, 4);
+    auto values = gko::array<value_type>(this->exec, 4);
+    auto m = Mtx::create(this->exec, gko::dim<2>{2, 3}, values.as_view(),
+                         col_idxs.as_view(), row_idxs.as_view());
+
+    m->read({{2, 3}, {{0, 0, 1.0}, {0, 1, 3.0}, {0, 2, 2.0}, {1, 1, 5.0}}});
+
+    this->assert_equal_to_original_mtx(m);
+    ASSERT_EQ(row_idxs.get_data(), m->get_row_idxs());
+    ASSERT_EQ(col_idxs.get_data(), m->get_col_idxs());
+    ASSERT_EQ(values.get_data(), m->get_values());
+}
+
+
 TYPED_TEST(Coo, CanBeReadFromMatrixAssemblyData)
 {
     using Mtx = typename TestFixture::Mtx;
@@ -212,6 +232,112 @@ TYPED_TEST(Coo, CanBeReadFromMatrixAssemblyData)
     m->read(data);
 
     this->assert_equal_to_original_mtx(m);
+}
+
+
+TYPED_TEST(Coo, CanBeReadFromDeviceMatrixData)
+{
+    using Mtx = typename TestFixture::Mtx;
+    using value_type = typename TestFixture::value_type;
+    using index_type = typename TestFixture::index_type;
+    auto m = Mtx::create(this->exec);
+    gko::matrix_assembly_data<value_type, index_type> data(gko::dim<2>{2, 3});
+    data.set_value(0, 0, 1.0);
+    data.set_value(0, 1, 3.0);
+    data.set_value(0, 2, 2.0);
+    data.set_value(1, 1, 5.0);
+    auto device_data =
+        gko::device_matrix_data<value_type, index_type>::create_from_host(
+            this->exec, data.get_ordered_data());
+
+    m->read(device_data);
+
+    this->assert_equal_to_original_mtx(m);
+    ASSERT_EQ(device_data.get_num_stored_elements(),
+              m->get_num_stored_elements());
+    GKO_ASSERT_EQUAL_DIMENSIONS(&device_data, m);
+}
+
+
+TYPED_TEST(Coo, CanBeReadFromDeviceMatrixDataIntoViews)
+{
+    using Mtx = typename TestFixture::Mtx;
+    using value_type = typename TestFixture::value_type;
+    using index_type = typename TestFixture::index_type;
+    auto row_idxs = gko::array<index_type>(this->exec, 4);
+    auto col_idxs = gko::array<index_type>(this->exec, 4);
+    auto values = gko::array<value_type>(this->exec, 4);
+    auto m = Mtx::create(this->exec, gko::dim<2>{2, 3}, values.as_view(),
+                         col_idxs.as_view(), row_idxs.as_view());
+    gko::matrix_assembly_data<value_type, index_type> data(gko::dim<2>{2, 3});
+    data.set_value(0, 0, 1.0);
+    data.set_value(0, 1, 3.0);
+    data.set_value(0, 2, 2.0);
+    data.set_value(1, 1, 5.0);
+    auto device_data =
+        gko::device_matrix_data<value_type, index_type>::create_from_host(
+            this->exec, data.get_ordered_data());
+
+    m->read(device_data);
+
+    this->assert_equal_to_original_mtx(m);
+    ASSERT_EQ(row_idxs.get_data(), m->get_row_idxs());
+    ASSERT_EQ(col_idxs.get_data(), m->get_col_idxs());
+    ASSERT_EQ(values.get_data(), m->get_values());
+}
+
+
+TYPED_TEST(Coo, CanBeReadFromMovedDeviceMatrixData)
+{
+    using Mtx = typename TestFixture::Mtx;
+    using value_type = typename TestFixture::value_type;
+    using index_type = typename TestFixture::index_type;
+    auto m = Mtx::create(this->exec);
+    gko::matrix_assembly_data<value_type, index_type> data(gko::dim<2>{2, 3});
+    data.set_value(0, 0, 1.0);
+    data.set_value(0, 1, 3.0);
+    data.set_value(0, 2, 2.0);
+    data.set_value(1, 1, 5.0);
+    auto device_data =
+        gko::device_matrix_data<value_type, index_type>::create_from_host(
+            this->exec, data.get_ordered_data());
+
+    m->read(std::move(device_data));
+
+    this->assert_equal_to_original_mtx(m);
+    GKO_ASSERT_EQUAL_DIMENSIONS(&device_data, gko::dim<2>{});
+    ASSERT_EQ(device_data.get_num_stored_elements(), 0);
+}
+
+
+TYPED_TEST(Coo, CanBeReadFromMovedDeviceMatrixDataIntoViews)
+{
+    using Mtx = typename TestFixture::Mtx;
+    using value_type = typename TestFixture::value_type;
+    using index_type = typename TestFixture::index_type;
+    auto row_idxs = gko::array<index_type>(this->exec, 4);
+    auto col_idxs = gko::array<index_type>(this->exec, 4);
+    auto values = gko::array<value_type>(this->exec, 4);
+    row_idxs.fill(0);
+    col_idxs.fill(0);
+    values.fill(gko::zero<value_type>());
+    auto m = Mtx::create(this->exec, gko::dim<2>{2, 3}, values.as_view(),
+                         col_idxs.as_view(), row_idxs.as_view());
+    gko::matrix_assembly_data<value_type, index_type> data(gko::dim<2>{2, 3});
+    data.set_value(0, 0, 1.0);
+    data.set_value(0, 1, 3.0);
+    data.set_value(0, 2, 2.0);
+    data.set_value(1, 1, 5.0);
+    auto device_data =
+        gko::device_matrix_data<value_type, index_type>::create_from_host(
+            this->exec, data.get_ordered_data());
+
+    m->read(std::move(device_data));
+
+    this->assert_equal_to_original_mtx(m);
+    ASSERT_NE(row_idxs.get_data(), m->get_row_idxs());
+    ASSERT_NE(col_idxs.get_data(), m->get_col_idxs());
+    ASSERT_NE(values.get_data(), m->get_values());
 }
 
 

--- a/core/test/matrix/csr.cpp
+++ b/core/test/matrix/csr.cpp
@@ -9,6 +9,7 @@
 
 
 #include "core/test/utils.hpp"
+#include "ginkgo/core/base/device_matrix_data.hpp"
 
 
 namespace {
@@ -50,14 +51,9 @@ protected:
     std::shared_ptr<const gko::Executor> exec;
     std::unique_ptr<Mtx> mtx;
 
-    void assert_equal_to_original_mtx(gko::ptr_param<const Mtx> m)
+    void assert_equal_to_original_mtx(const index_type* r, const index_type* c,
+                                      const value_type* v)
     {
-        auto v = m->get_const_values();
-        auto c = m->get_const_col_idxs();
-        auto r = m->get_const_row_ptrs();
-        auto s = m->get_const_srow();
-        ASSERT_EQ(m->get_size(), gko::dim<2>(2, 3));
-        ASSERT_EQ(m->get_num_stored_elements(), 4);
         EXPECT_EQ(r[0], 0);
         EXPECT_EQ(r[1], 3);
         EXPECT_EQ(r[2], 4);
@@ -69,6 +65,17 @@ protected:
         EXPECT_EQ(v[1], value_type{3.0});
         EXPECT_EQ(v[2], value_type{2.0});
         EXPECT_EQ(v[3], value_type{5.0});
+    }
+
+    void assert_equal_to_original_mtx(gko::ptr_param<const Mtx> m)
+    {
+        auto v = m->get_const_values();
+        auto c = m->get_const_col_idxs();
+        auto r = m->get_const_row_ptrs();
+        auto s = m->get_const_srow();
+        ASSERT_EQ(m->get_size(), gko::dim<2>(2, 3));
+        ASSERT_EQ(m->get_num_stored_elements(), 4);
+        assert_equal_to_original_mtx(r, c, v);
         EXPECT_EQ(s[0], 0);
     }
 
@@ -211,6 +218,27 @@ TYPED_TEST(Csr, CanBeReadFromMatrixData)
 }
 
 
+TYPED_TEST(Csr, CanBeReadFromMatrixDataIntoViews)
+{
+    using Mtx = typename TestFixture::Mtx;
+    using value_type = typename TestFixture::value_type;
+    using index_type = typename TestFixture::index_type;
+    auto row_ptrs = gko::array<index_type>(this->exec, 3);
+    auto col_idxs = gko::array<index_type>(this->exec, 4);
+    auto values = gko::array<value_type>(this->exec, 4);
+    auto m = Mtx::create(this->exec, gko::dim<2>{2, 3}, values.as_view(),
+                         col_idxs.as_view(), row_ptrs.as_view(),
+                         std::make_shared<typename Mtx::load_balance>(2));
+
+    m->read({{2, 3}, {{0, 0, 1.0}, {0, 1, 3.0}, {0, 2, 2.0}, {1, 1, 5.0}}});
+
+    this->assert_equal_to_original_mtx(m);
+    ASSERT_EQ(row_ptrs.get_data(), m->get_row_ptrs());
+    ASSERT_EQ(col_idxs.get_data(), m->get_col_idxs());
+    ASSERT_EQ(values.get_data(), m->get_values());
+}
+
+
 TYPED_TEST(Csr, CanBeReadFromMatrixAssemblyData)
 {
     using Mtx = typename TestFixture::Mtx;
@@ -227,6 +255,116 @@ TYPED_TEST(Csr, CanBeReadFromMatrixAssemblyData)
     m->read(data);
 
     this->assert_equal_to_original_mtx(m);
+}
+
+
+TYPED_TEST(Csr, CanBeReadFromDeviceMatrixData)
+{
+    using Mtx = typename TestFixture::Mtx;
+    using value_type = typename TestFixture::value_type;
+    using index_type = typename TestFixture::index_type;
+    auto m = Mtx::create(this->exec,
+                         std::make_shared<typename Mtx::load_balance>(2));
+    gko::matrix_assembly_data<value_type, index_type> data(gko::dim<2>{2, 3});
+    data.set_value(0, 0, 1.0);
+    data.set_value(0, 1, 3.0);
+    data.set_value(0, 2, 2.0);
+    data.set_value(1, 1, 5.0);
+    auto device_data =
+        gko::device_matrix_data<value_type, index_type>::create_from_host(
+            this->exec, data.get_ordered_data());
+
+    m->read(device_data);
+
+    this->assert_equal_to_original_mtx(m);
+    ASSERT_EQ(device_data.get_num_stored_elements(),
+              m->get_num_stored_elements());
+    GKO_ASSERT_EQUAL_DIMENSIONS(&device_data, m);
+}
+
+
+TYPED_TEST(Csr, CanBeReadFromDeviceMatrixDataIntoViews)
+{
+    using Mtx = typename TestFixture::Mtx;
+    using value_type = typename TestFixture::value_type;
+    using index_type = typename TestFixture::index_type;
+    auto row_ptrs = gko::array<index_type>(this->exec, 3);
+    auto col_idxs = gko::array<index_type>(this->exec, 4);
+    auto values = gko::array<value_type>(this->exec, 4);
+    auto m = Mtx::create(this->exec, gko::dim<2>{2, 3}, values.as_view(),
+                         col_idxs.as_view(), row_ptrs.as_view(),
+                         std::make_shared<typename Mtx::load_balance>(2));
+    gko::matrix_assembly_data<value_type, index_type> data(m->get_size());
+    data.set_value(0, 0, 1.0);
+    data.set_value(0, 1, 3.0);
+    data.set_value(0, 2, 2.0);
+    data.set_value(1, 1, 5.0);
+    auto device_data =
+        gko::device_matrix_data<value_type, index_type>::create_from_host(
+            this->exec, data.get_ordered_data());
+
+    m->read(device_data);
+
+    this->assert_equal_to_original_mtx(m);
+    ASSERT_EQ(row_ptrs.get_data(), m->get_row_ptrs());
+    ASSERT_EQ(col_idxs.get_data(), m->get_col_idxs());
+    ASSERT_EQ(values.get_data(), m->get_values());
+}
+
+
+TYPED_TEST(Csr, CanBeReadFromMovedDeviceMatrixData)
+{
+    using Mtx = typename TestFixture::Mtx;
+    using value_type = typename TestFixture::value_type;
+    using index_type = typename TestFixture::index_type;
+    auto m = Mtx::create(this->exec,
+                         std::make_shared<typename Mtx::load_balance>(2));
+    gko::matrix_assembly_data<value_type, index_type> data(gko::dim<2>{2, 3});
+    data.set_value(0, 0, 1.0);
+    data.set_value(0, 1, 3.0);
+    data.set_value(0, 2, 2.0);
+    data.set_value(1, 1, 5.0);
+    auto device_data =
+        gko::device_matrix_data<value_type, index_type>::create_from_host(
+            this->exec, data.get_ordered_data());
+
+    m->read(std::move(device_data));
+
+    this->assert_equal_to_original_mtx(m);
+    GKO_ASSERT_EQUAL_DIMENSIONS(&device_data, gko::dim<2>{});
+    ASSERT_EQ(device_data.get_num_stored_elements(), 0);
+}
+
+
+TYPED_TEST(Csr, CanBeReadFromMovedDeviceMatrixDataIntoViews)
+{
+    using Mtx = typename TestFixture::Mtx;
+    using value_type = typename TestFixture::value_type;
+    using index_type = typename TestFixture::index_type;
+    auto row_ptrs = gko::array<index_type>(this->exec, 3);
+    auto col_idxs = gko::array<index_type>(this->exec, 4);
+    auto values = gko::array<value_type>(this->exec, 4);
+    row_ptrs.fill(0);
+    col_idxs.fill(0);
+    values.fill(gko::zero<value_type>());
+    auto m = Mtx::create(this->exec, gko::dim<2>{2, 3}, values.as_view(),
+                         col_idxs.as_view(), row_ptrs.as_view(),
+                         std::make_shared<typename Mtx::load_balance>(2));
+    gko::matrix_assembly_data<value_type, index_type> data(m->get_size());
+    data.set_value(0, 0, 1.0);
+    data.set_value(0, 1, 3.0);
+    data.set_value(0, 2, 2.0);
+    data.set_value(1, 1, 5.0);
+    auto device_data =
+        gko::device_matrix_data<value_type, index_type>::create_from_host(
+            this->exec, data.get_ordered_data());
+
+    m->read(std::move(device_data));
+
+    this->assert_equal_to_original_mtx(m);
+    ASSERT_NE(row_ptrs.get_data(), m->get_row_ptrs());
+    ASSERT_NE(col_idxs.get_data(), m->get_col_idxs());
+    ASSERT_NE(values.get_data(), m->get_values());
 }
 
 

--- a/core/test/matrix/csr.cpp
+++ b/core/test/matrix/csr.cpp
@@ -8,8 +8,10 @@
 #include <gtest/gtest.h>
 
 
+#include <ginkgo/core/base/device_matrix_data.hpp>
+
+
 #include "core/test/utils.hpp"
-#include "ginkgo/core/base/device_matrix_data.hpp"
 
 
 namespace {

--- a/include/ginkgo/core/base/array.hpp
+++ b/include/ginkgo/core/base/array.hpp
@@ -551,7 +551,7 @@ public:
     }
 
     /**
-     * Copies or converts data from a const_array_view.
+     * Copies data from a const_array_view.
      *
      * In the case of an array target, the array is resized to match the
      * source's size. In the case of a view target, if the dimensions are not
@@ -564,14 +564,10 @@ public:
      * executor, it will inherit the executor of other.
      *
      * @param other  the const_array_view to copy from
-     * @tparam OtherValueType  the value type of `other`
      *
      * @return this
      */
-    template <typename OtherValueType>
-    std::enable_if_t<std::is_convertible<OtherValueType, ValueType>::value,
-                     array>&
-    operator=(const detail::const_array_view<OtherValueType>& other)
+    array& operator=(const detail::const_array_view<ValueType>& other)
     {
         if (this->exec_ == nullptr) {
             this->exec_ = other.get_executor();
@@ -587,20 +583,15 @@ public:
         } else {
             GKO_ENSURE_COMPATIBLE_BOUNDS(other.get_size(), this->get_size());
         }
-        array<OtherValueType> tmp{this->exec_};
-        const OtherValueType* source = other.get_const_data();
-        // if we are on different executors: copy, then convert
+        array tmp{this->exec_};
+        const ValueType* source = other.get_const_data();
+        // if we are on different executors: copy
         if (this->exec_ != other.get_executor()) {
             tmp = other.copy_to_array();
             source = tmp.get_const_data();
         }
-        if (std::is_same<OtherValueType, ValueType>::value) {
-            exec_->copy_from(other.get_executor(), other.get_size(),
-                             other.get_const_data(), this->get_data());
-        } else {
-            detail::convert_data(this->exec_, other.get_size(), source,
-                                 this->get_data());
-        }
+        exec_->copy_from(other.get_executor(), other.get_size(), source,
+                         this->get_data());
         return *this;
     }
 

--- a/include/ginkgo/core/base/array.hpp
+++ b/include/ginkgo/core/base/array.hpp
@@ -551,6 +551,60 @@ public:
     }
 
     /**
+     * Copies or converts data from a const_array_view.
+     *
+     * In the case of an array target, the array is resized to match the
+     * source's size. In the case of a view target, if the dimensions are not
+     * compatible a gko::OutOfBoundsError is thrown.
+     *
+     * This does not invoke the constructors of the elements, instead they are
+     * copied as POD types.
+     *
+     * The executor of this is preserved. In case this does not have an assigned
+     * executor, it will inherit the executor of other.
+     *
+     * @param other  the const_array_view to copy from
+     * @tparam OtherValueType  the value type of `other`
+     *
+     * @return this
+     */
+    template <typename OtherValueType>
+    std::enable_if_t<std::is_convertible<OtherValueType, ValueType>::value,
+                     array>&
+    operator=(const detail::const_array_view<OtherValueType>& other)
+    {
+        if (this->exec_ == nullptr) {
+            this->exec_ = other.get_executor();
+            this->data_ = data_manager{nullptr, default_deleter{this->exec_}};
+        }
+        if (other.get_executor() == nullptr) {
+            this->clear();
+            return *this;
+        }
+
+        if (this->is_owning()) {
+            this->resize_and_reset(other.get_size());
+        } else {
+            GKO_ENSURE_COMPATIBLE_BOUNDS(other.get_size(), this->get_size());
+        }
+        array<OtherValueType> tmp{this->exec_};
+        const OtherValueType* source = other.get_const_data();
+        // if we are on different executors: copy, then convert
+        if (this->exec_ != other.get_executor()) {
+            tmp = other.copy_to_array();
+            source = tmp.get_const_data();
+        }
+        if (std::is_same<OtherValueType, ValueType>::value) {
+            exec_->copy_from(other.get_executor(), other.get_size(),
+                             other.get_const_data(), this->get_data());
+        } else {
+            detail::convert_data(this->exec_, other.get_size(), source,
+                                 this->get_data());
+        }
+        return *this;
+    }
+
+    /**
      * Deallocates all data used by the array.
      *
      * The array is left in a valid, but empty state, so the same array can be


### PR DESCRIPTION
This PR changes the behavior for the `read(const device_matrix_data&)` overload for `Coo` and `Csr`. 

Currently, the `const &` read overload copies the input device_matrix_data and moves it into the `&&` overload. The `&&` overload will cause the internal arrays of the matrix to use the arrays of the device_matrix_data. This means that if the matrix was created from views, the matrix after the read will have owning arrays. 

For the `&&` overload this is justified, since here the matrix takes ownership of the input data. But for the `const &` it's unexpected, since no ownership is transferred. So, this PR makes the `const &` copy the input device matrix data directly into the matrix's arrays. The ownership property of the internal arrays will thus be preserved.

~**Note:** The behavior of the `&&` overload is a bit inconsistent across our matrix types. For `Coo` and `Csr` the `&&` overload will result in the matrix arrays having ownership. But for all other matrix types, the ownership property is not changed. Maybe we should consolidate that.~ I was under the impression that device_matrix_data always owns its arrays. But that is not the case. The device_matrix_data can also be constructed from array, which might be views.