### PR TITLE
fix format_header usage

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,12 +27,14 @@ repos:
   - id: format-headers
     name: format headers
     entry: env CLANG_FORMAT=dev_tools/scripts/clang-format.sh dev_tools/scripts/format_header.sh
+    require_serial: true
     language: system
     types_or: [c, c++, cuda]
     exclude: |
         (?x)^(
           third_party/SuiteSparse/AMD/.*|
-          third_party/identify_stream_usage/.*
+          third_party/identify_stream_usage/.*|
+          include/ginkgo/ginkgo.hpp
         )$
   - id: update-ginkgo-header
     name: update ginkgo header


### PR DESCRIPTION
This PR fixes the format_header usage in pre-commit.
Sorry for another pr.
I only tested one file so I did not have the issue before.

format_header uses some file to cache content, so it can not run in parallel.
The main ginkgo header does not fit the regroup.
format_header changes it (failed) -> update ginkgo header changes it back (failed)
no file is changed in the end though