### PR TITLE
Only run update_ginkgo_header once

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,4 +41,5 @@ repos:
     entry: dev_tools/scripts/update_ginkgo_header.sh
     language: script
     types: [header]
+    pass_filenames: false
     files: ^include/ginkgo/core


### PR DESCRIPTION
This PR allows us to run update_ginkgo_header only once.

Originally, it will be called as many as the number of changed file `include/ginkgo/core`. (with given filename)
Then, the ginkgo.hpp/ginkgo.hpp.tmp encounter race condition.
`pass_filenames: false` only run the hooks once without filename. ([ref](https://stackoverflow.com/questions/57199833/run-pre-commit-com-hook-once-not-for-every-file-if-a-matched-file-is-detected))