### PR TITLE
fix MSVC `__cplusplus` by `_MSVC_LANG`

### DIFF
--- a/include/ginkgo/core/base/std_extensions.hpp
+++ b/include/ginkgo/core/base/std_extensions.hpp
@@ -45,7 +45,8 @@ using void_t = typename detail::make_void<Ts...>::type;
 // Disable deprecation warnings when using standard > C++14
 inline bool uncaught_exception() noexcept
 {
-#if __cplusplus > 201402L
+// MSVC uses _MSVC_LANG as __cplusplus
+#if (defined(_MSVC_LANG) && _MSVC_LANG > 201402L) || __cplusplus > 201402L
     return std::uncaught_exceptions() > 0;
 #else
     return std::uncaught_exception();


### PR DESCRIPTION
As #1495 mentioned, MSVC does not update `__cplusplus` as the other compiler by default, which results in the issue mentioned in #1331 (`std::uncaught_exception` is not a member of `std` when standard > c++17)
They use `_MSVC_LANG` for `__cplusplus` purpose. 