### PR TITLE
Print pre-commit install non-default output

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -372,6 +372,15 @@ if(GINKGO_DEVEL_TOOLS)
                 "Failed to install the git hooks via pre-commit. Please check the error message:\n"
                 "${pre-commit-output}\n${pre-commit-error}")
     endif()
+    if(pre-commit-output MATCHES "^Running in migration mode with existing hooks")
+        message(WARNING
+                "An existing git hook was encountered during `pre-commit install`. The old git hook "
+                "will also be executed. Consider removing it with `pre-commit install -f`")
+    elseif(NOT pre-commit-output MATCHES "^pre-commit installed at")
+        message(WARNING
+                "`pre-commit install` did not exit normally. Please check the output message:\n"
+                "${pre-commit-output}")
+    endif()
 
     add_custom_target(format
                       COMMAND bash -c "${PRE_COMMIT} run"


### PR DESCRIPTION
This PR adds a message if `pre-commit install`  exits with non-default output. The default output should be:
```
pre-commit installed at <path>
```
Anything else might indicate an issue, for example if already another pre-commit hook exists. 

I decided against issuing a warning specific for the pre-commit legacy mode, since I hope that this can be more generic.