### PR TITLE
avoid cyclic ownership with GPU timers

### DIFF
--- a/dpcpp/base/timer.dp.cpp
+++ b/dpcpp/base/timer.dp.cpp
@@ -15,12 +15,11 @@ namespace gko {
 
 
 DpcppTimer::DpcppTimer(std::shared_ptr<const DpcppExecutor> exec)
-    : exec_{std::move(exec)}
+    : queue_{exec->get_queue()}
 {
-    if (!exec_->get_queue()
-             ->template has_property<
-                 sycl::property::queue::enable_profiling>()) {
-        GKO_NOT_SUPPORTED(exec_);
+    if (!queue_->template has_property<
+            sycl::property::queue::enable_profiling>()) {
+        GKO_NOT_SUPPORTED(exec);
     }
 }
 
@@ -35,10 +34,9 @@ void DpcppTimer::init_time_point(time_point& time)
 void DpcppTimer::record(time_point& time)
 {
     GKO_ASSERT(time.type_ == time_point::type::dpcpp);
-    *time.data_.dpcpp_event =
-        exec_->get_queue()->submit([&](sycl::handler& cgh) {
-            cgh.parallel_for(1, [=](sycl::id<1> id) {});
-        });
+    *time.data_.dpcpp_event = queue_->submit([&](sycl::handler& cgh) {
+        cgh.parallel_for(1, [=](sycl::id<1> id) {});
+    });
 }
 
 

--- a/include/ginkgo/core/base/timer.hpp
+++ b/include/ginkgo/core/base/timer.hpp
@@ -160,6 +160,7 @@ protected:
 
 /**
  * A timer using events for timing on a CudaExecutor.
+ *
  * @note When using a CudaExecutor with a custom stream, make sure that the
  *       stream's lifetime is longer than the lifetime of this timer.
  */
@@ -185,6 +186,7 @@ private:
 
 /**
  * A timer using events for timing on a HipExecutor.
+ *
  * @note When using a HipExecutor with a custom stream, make sure that the
  *       stream's lifetime is longer than the lifetime of this timer.
  */

--- a/include/ginkgo/core/base/timer.hpp
+++ b/include/ginkgo/core/base/timer.hpp
@@ -158,7 +158,11 @@ protected:
 };
 
 
-/** A timer using events for timing on a CudaExecutor. */
+/**
+ * A timer using events for timing on a CudaExecutor.
+ * @note When using a CudaExecutor with a custom stream, make sure that the
+ *       stream's lifetime is longer than the lifetime of this timer.
+ */
 class CudaTimer : public Timer {
 public:
     void record(time_point& time) override;
@@ -174,11 +178,16 @@ protected:
     void init_time_point(time_point& time) override;
 
 private:
-    std::shared_ptr<const CudaExecutor> exec_;
+    int device_id_;
+    CUstream_st* stream_;
 };
 
 
-/** A timer using events for timing on a HipExecutor. */
+/**
+ * A timer using events for timing on a HipExecutor.
+ * @note When using a HipExecutor with a custom stream, make sure that the
+ *       stream's lifetime is longer than the lifetime of this timer.
+ */
 class HipTimer : public Timer {
 public:
     void record(time_point& time) override;
@@ -194,7 +203,8 @@ protected:
     void init_time_point(time_point& time) override;
 
 private:
-    std::shared_ptr<const HipExecutor> exec_;
+    int device_id_;
+    GKO_HIP_STREAM_STRUCT* stream_;
 };
 
 
@@ -214,7 +224,7 @@ protected:
     void init_time_point(time_point& time) override;
 
 private:
-    std::shared_ptr<const DpcppExecutor> exec_;
+    sycl::queue* queue_;
 };
 
 

--- a/test/base/timer.cpp
+++ b/test/base/timer.cpp
@@ -63,3 +63,13 @@ TEST_F(Timer, Works)
 
     ASSERT_GT(timer->difference(start, stop), std::chrono::seconds{1});
 }
+
+
+TEST_F(Timer, DoesntOwnExecutor)
+{
+    const auto old_use_count = this->exec.use_count();
+
+    auto timer = gko::Timer::create_for_executor(this->exec);
+
+    ASSERT_EQ(this->exec.use_count(), old_use_count);
+}


### PR DESCRIPTION
Discovered by @MarcelKoch, `ProfilerHook::create(_nested)_summary` doesn't work with GPU timers because they keep the executor alive via a cyclic dependency. This breaks up the dependency by storing device ID and stream explicitly.

Previously, attaching a ProfilerHook logger with a GPU timer lead to a dependency graph like this:

```mermaid
graph TD;
Executor --> ProfilerHook;
ProfilerHook --> CudaTimer;
CudaTimer -->|stream, device_id| Executor;
```

The new dependency graph removes the cycle


```mermaid
graph TD;
Executor --> ProfilerHook;
ProfilerHook --> CudaTimer;
CudaTimer --> stream;
CudaTimer --> device_id;
```