### PR TITLE
Automatically use current year for license

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,7 @@ repos:
   # The official reuse hook only supports calling lint, so we need our own hook
   - id: reuse-annotate
     name: reuse-annotate
-    entry: reuse annotate --license BSD-3-Clause --copyright 'The Ginkgo authors' --year 2024 --style c --merge-copyright
+    entry: reuse annotate --license BSD-3-Clause --copyright 'The Ginkgo authors' --style c --merge-copyright
     language: python
     additional_dependencies: [reuse]
     types_or: [c, c++, cuda, inc]


### PR DESCRIPTION
From @tcojean suggestion, this now uses the current year for the license. The documentation of reuse is not helpful here, since it doesn't clearly describe that it will use the current year if the `--year` option is *not* given.