### PR TITLE
Rename test binaries that collide with C++ standard library header names

### DIFF
--- a/cmake/create_test.cmake
+++ b/cmake/create_test.cmake
@@ -1,5 +1,5 @@
 set(gko_test_resource_args "RESOURCE_LOCAL_CORES;RESOURCE_TYPE")
-set(gko_test_single_args "MPI_SIZE;${gko_test_resource_args}")
+set(gko_test_single_args "MPI_SIZE;EXECUTABLE_NAME;${gko_test_resource_args}")
 set(gko_test_multi_args "DISABLE_EXECUTORS;ADDITIONAL_LIBRARIES;ADDITIONAL_INCLUDES")
 set(gko_test_option_args "NO_RESOURCES")
 
@@ -80,9 +80,13 @@ endfunction()
 function(ginkgo_add_test test_name test_target_name)
     cmake_parse_arguments(PARSE_ARGV 2 add_test "" "${gko_test_single_args}" "${gko_test_multi_args}")
     file(RELATIVE_PATH REL_BINARY_DIR ${PROJECT_BINARY_DIR} ${CMAKE_CURRENT_BINARY_DIR})
-    set_target_properties(${test_target_name} PROPERTIES OUTPUT_NAME ${test_name})
+    set(test_binary_name ${test_name})
+    if (add_test_EXECUTABLE_NAME)
+        set(test_binary_name ${add_test_EXECUTABLE_NAME})
+    endif()
+    set_target_properties(${test_target_name} PROPERTIES OUTPUT_NAME ${test_binary_name})
     if (add_test_MPI_SIZE)
-        add_test(NAME ${REL_BINARY_DIR}/${test_name}
+        add_test(NAME ${REL_BINARY_DIR}/${test_binary_name}
                  COMMAND
                      ${MPIEXEC_EXECUTABLE}
                      ${MPIEXEC_NUMPROC_FLAG}
@@ -90,12 +94,12 @@ function(ginkgo_add_test test_name test_target_name)
                      "$<TARGET_FILE:${test_target_name}>"
                  WORKING_DIRECTORY "$<TARGET_FILE_DIR:ginkgo>")
     else()
-        add_test(NAME ${REL_BINARY_DIR}/${test_name}
+        add_test(NAME ${REL_BINARY_DIR}/${test_binary_name}
                  COMMAND ${test_target_name}
                  WORKING_DIRECTORY "$<TARGET_FILE_DIR:ginkgo>")
     endif()
 
-    ginkgo_add_resource_requirement(${REL_BINARY_DIR}/${test_name} ${ARGN})
+    ginkgo_add_resource_requirement(${REL_BINARY_DIR}/${test_binary_name} ${ARGN})
 
     set(test_preload)
     if (GINKGO_TEST_NONDEFAULT_STREAM AND GINKGO_BUILD_CUDA)
@@ -105,7 +109,7 @@ function(ginkgo_add_test test_name test_target_name)
         set(test_preload $<TARGET_FILE:identify_stream_usage_hip>:${test_preload})
     endif()
     if(test_preload)
-        set_tests_properties(${REL_BINARY_DIR}/${test_name} PROPERTIES ENVIRONMENT LD_PRELOAD=${test_preload})
+        set_tests_properties(${REL_BINARY_DIR}/${test_binary_name} PROPERTIES ENVIRONMENT LD_PRELOAD=${test_preload})
     endif()
 endfunction()
 

--- a/core/test/base/CMakeLists.txt
+++ b/core/test/base/CMakeLists.txt
@@ -1,6 +1,6 @@
 ginkgo_create_test(abstract_factory)
 ginkgo_create_test(allocator)
-ginkgo_create_test(array)
+ginkgo_create_test(array EXECUTABLE_NAME array_test) # array collides with C++ stdlib header
 ginkgo_create_test(batch_dim)
 ginkgo_create_test(batch_lin_op)
 ginkgo_create_test(batch_multi_vector)
@@ -10,7 +10,7 @@ ginkgo_create_test(composition)
 ginkgo_create_test(deferred_factory)
 ginkgo_create_test(dense_cache)
 ginkgo_create_test(dim)
-ginkgo_create_test(exception)
+ginkgo_create_test(exception EXECUTABLE_NAME exception_test) # exception collides with C++ stdlib header
 ginkgo_create_test(exception_helpers)
 ginkgo_create_test(extended_float)
 ginkgo_create_test(executor)
@@ -27,4 +27,4 @@ ginkgo_create_test(range_accessors)
 ginkgo_create_test(sanitizers ADDITIONAL_LIBRARIES Threads::Threads)
 ginkgo_create_test(types)
 ginkgo_create_test(utils)
-ginkgo_create_test(version)
+ginkgo_create_test(version EXECUTABLE_NAME version_test) # version collides with C++ stdlib header

--- a/cuda/test/base/CMakeLists.txt
+++ b/cuda/test/base/CMakeLists.txt
@@ -1,4 +1,4 @@
-ginkgo_create_test(array RESOURCE_TYPE cudagpu)
+ginkgo_create_test(array EXECUTABLE_NAME array_test RESOURCE_TYPE cudagpu) # array collides with C++ stdlib header
 ginkgo_create_cuda_test(cuda_executor)
 ginkgo_create_test(index_set RESOURCE_TYPE cudagpu)
 if(GINKGO_HAVE_HWLOC)

--- a/reference/test/base/CMakeLists.txt
+++ b/reference/test/base/CMakeLists.txt
@@ -1,4 +1,4 @@
-ginkgo_create_test(array)
+ginkgo_create_test(array EXECUTABLE_NAME array_test) # array collides with C++ stdlib header
 ginkgo_create_test(batch_multi_vector_kernels)
 ginkgo_create_test(combination)
 ginkgo_create_test(composition)


### PR DESCRIPTION
This gets rid of all the `CPATH` issues we've been having from time to time by renaming all test binaries that match a C++ standard library header name.

Fixes #1530 