### PR TITLE
Change write_raw default to sparse output format

### DIFF
--- a/core/test/base/mtx_io.cpp
+++ b/core/test/base/mtx_io.cpp
@@ -642,7 +642,7 @@ TEST(MatrixData, WritesDoubleRealMatrixToMatrixMarketArray)
     // clang-format on
     std::ostringstream oss{};
 
-    write_raw(oss, data);
+    write_raw(oss, data, gko::layout_type::array);
 
     ASSERT_EQ(oss.str(),
               "%%MatrixMarket matrix array real general\n"
@@ -666,7 +666,7 @@ TEST(MatrixData, WritesFloatRealMatrixToMatrixMarketCoordinate)
     // clang-format on
     std::ostringstream oss{};
 
-    write_raw(oss, data, gko::layout_type::coordinate);
+    write_raw(oss, data);
 
     ASSERT_EQ(oss.str(),
               "%%MatrixMarket matrix coordinate real general\n"
@@ -689,7 +689,7 @@ TEST(MatrixData, WritesDoubleRealMatrixToMatrixMarketArrayWith64Index)
     // clang-format on
     std::ostringstream oss{};
 
-    write_raw(oss, data);
+    write_raw(oss, data, gko::layout_type::array);
 
     ASSERT_EQ(oss.str(),
               "%%MatrixMarket matrix array real general\n"
@@ -713,7 +713,7 @@ TEST(MatrixData, WritesFloatRealMatrixToMatrixMarketCoordinateWith64Index)
     // clang-format on
     std::ostringstream oss{};
 
-    write_raw(oss, data, gko::layout_type::coordinate);
+    write_raw(oss, data);
 
     ASSERT_EQ(oss.str(),
               "%%MatrixMarket matrix coordinate real general\n"
@@ -736,7 +736,7 @@ TEST(MatrixData, WritesComplexDoubleMatrixToMatrixMarketArray)
     // clang-format on
     std::ostringstream oss{};
 
-    write_raw(oss, data);
+    write_raw(oss, data, gko::layout_type::array);
 
     ASSERT_EQ(oss.str(),
               "%%MatrixMarket matrix array complex general\n"
@@ -760,7 +760,7 @@ TEST(MatrixData, WritesComplexFloatMatrixToMatrixMarketCoordinate)
     // clang-format on
     std::ostringstream oss{};
 
-    write_raw(oss, data, gko::layout_type::coordinate);
+    write_raw(oss, data);
 
     ASSERT_EQ(oss.str(),
               "%%MatrixMarket matrix coordinate complex general\n"
@@ -783,7 +783,7 @@ TEST(MatrixData, WritesComplexDoubleMatrixToMatrixMarketArrayWith64Index)
     // clang-format on
     std::ostringstream oss{};
 
-    write_raw(oss, data);
+    write_raw(oss, data, gko::layout_type::array);
 
     ASSERT_EQ(oss.str(),
               "%%MatrixMarket matrix array complex general\n"
@@ -807,7 +807,7 @@ TEST(MatrixData, WritesComplexFloatMatrixToMatrixMarketCoordinateWith64Index)
     // clang-format on
     std::ostringstream oss{};
 
-    write_raw(oss, data, gko::layout_type::coordinate);
+    write_raw(oss, data);
 
     ASSERT_EQ(oss.str(),
               "%%MatrixMarket matrix coordinate complex general\n"

--- a/include/ginkgo/core/base/mtx_io.hpp
+++ b/include/ginkgo/core/base/mtx_io.hpp
@@ -118,7 +118,7 @@ enum class layout_type {
  */
 template <typename ValueType, typename IndexType>
 void write_raw(std::ostream& os, const matrix_data<ValueType, IndexType>& data,
-               layout_type layout = layout_type::array);
+               layout_type layout = layout_type::coordinate);
 
 
 /**


### PR DESCRIPTION
This leads to a much better worst-case storage size (roughly 3x overhead instead of linear overhead) at the cost of slightly worse best case storage requirement.

Since this is only a utility function, it shouldn't matter much.