### PR TITLE
Allow running CI in rootless containers

### DIFF
--- a/.gitlab/scripts.yml
+++ b/.gitlab/scripts.yml
@@ -21,6 +21,8 @@
     - .before_script_template
   script:
     - mkdir -p ${CI_JOB_NAME} && cd ${CI_JOB_NAME}
+    - mkdir install_prefix
+    - export INSTALL_PREFIX=`pwd`/install_prefix
     - if [ -n "${CUDA_ARCH}" ]; then
       export CUDA_ARCH_STR=-DGINKGO_CUDA_ARCHITECTURES=${CUDA_ARCH};
       fi
@@ -35,6 +37,7 @@
     - cmake ${CI_PROJECT_DIR}${CI_PROJECT_DIR_SUFFIX}
         -GNinja
         -DCMAKE_BUILD_TYPE=${BUILD_TYPE}
+        -DCMAKE_INSTALL_PREFIX=${INSTALL_PREFIX}
         -DCMAKE_CXX_FLAGS="${CXX_FLAGS}" -DBUILD_SHARED_LIBS=${BUILD_SHARED_LIBS}
         ${EXTRA_CMAKE_FLAGS} ${CUDA_ARCH_STR}
         -DGINKGO_COMPILER_FLAGS=${GKO_COMPILER_FLAGS}
@@ -61,6 +64,8 @@
     - .before_script_template
   script:
     - mkdir -p ${CI_JOB_NAME} && cd ${CI_JOB_NAME}
+    - mkdir install_prefix
+    - export INSTALL_PREFIX=`pwd`/install_prefix
     - if [ -n "${CUDA_ARCH}" ]; then
       export CUDA_ARCH_STR=-DGINKGO_CUDA_ARCHITECTURES=${CUDA_ARCH};
       fi
@@ -77,6 +82,7 @@
     - export CC=${C_COMPILER} CXX=${CXX_COMPILER} CUDAHOSTCXX=${CXX_COMPILER} CUDACXX=${CUDA_COMPILER}
     - cmake ${CI_PROJECT_DIR}${CI_PROJECT_DIR_SUFFIX}
         -GNinja -DCMAKE_BUILD_TYPE=${BUILD_TYPE}
+        -DCMAKE_INSTALL_PREFIX=${INSTALL_PREFIX}
         -DCMAKE_CXX_FLAGS="${CXX_FLAGS}" -DBUILD_SHARED_LIBS=${BUILD_SHARED_LIBS}
         ${EXTRA_CMAKE_FLAGS} ${CUDA_ARCH_STR}
         -DGINKGO_COMPILER_FLAGS=${GKO_COMPILER_FLAGS}
@@ -125,7 +131,7 @@
       fi
     - if [ -n "${SYCL_DEVICE_TYPE}" ]; then unset SYCL_DEVICE_TYPE; fi
     - if [ -n "${SYCL_DEVICE_FILTER}" ]; then unset SYCL_DEVICE_FILTER; fi
-    - LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH ninja test_pkgconfig
+    - PKG_CONFIG_PATH=${INSTALL_PREFIX}/lib/pkgconfig:$PKG_CONFIG_PATH LD_LIBRARY_PATH=${INSTALL_PREFIX}/lib:$LD_LIBRARY_PATH ninja test_pkgconfig
   dependencies: []
 
 


### PR DESCRIPTION
This uses a custom install prefix instead of the default `/usr/local` for CI jobs, allowing them to be run by rootless containers (more precisely, containers running without `--fakeroot`)