### PR TITLE
Use sparse communicator in distributed::Matrix

### DIFF
--- a/include/ginkgo/core/distributed/matrix.hpp
+++ b/include/ginkgo/core/distributed/matrix.hpp
@@ -523,7 +523,10 @@ protected:
      *                 shared values is automatically extracted.
      * @return  MPI request for the non-blocking communication.
      */
-    mpi::request communicate(const local_vector_type* local_b) const;
+    [[deprecated(
+        "The pre-C++17 interface of the distributed::Matrix is "
+        "deprecated, please update your C++ standard to 17. ")]] mpi::request
+    communicate(const local_vector_type* local_b) const;
 #endif
 
     void apply_impl(const LinOp* b, LinOp* x) const override;

--- a/include/ginkgo/core/distributed/matrix.hpp
+++ b/include/ginkgo/core/distributed/matrix.hpp
@@ -17,6 +17,7 @@
 #include <ginkgo/core/distributed/base.hpp>
 #include <ginkgo/core/distributed/index_map.hpp>
 #include <ginkgo/core/distributed/lin_op.hpp>
+#include <ginkgo/core/distributed/sparse_communicator.hpp>
 
 
 namespace gko {
@@ -513,6 +514,7 @@ protected:
                     ptr_param<const LinOp> local_matrix_template,
                     ptr_param<const LinOp> non_local_matrix_template);
 
+#if !GINKGO_HAVE_CXX17
     /**
      * Starts a non-blocking communication of the values of b that are shared
      * with other processors.
@@ -522,6 +524,7 @@ protected:
      * @return  MPI request for the non-blocking communication.
      */
     mpi::request communicate(const local_vector_type* local_b) const;
+#endif
 
     void apply_impl(const LinOp* b, LinOp* x) const override;
 
@@ -529,11 +532,15 @@ protected:
                     LinOp* x) const override;
 
 private:
+#if GINKGO_HAVE_CXX17
+    sparse_communicator spcomm_;
+#else
     std::vector<comm_index_type> send_offsets_;
     std::vector<comm_index_type> send_sizes_;
     std::vector<comm_index_type> recv_offsets_;
     std::vector<comm_index_type> recv_sizes_;
     array<local_index_type> gather_idxs_;
+#endif
     gko::detail::DenseCache<value_type> one_scalar_;
     gko::detail::DenseCache<value_type> host_send_buffer_;
     gko::detail::DenseCache<value_type> host_recv_buffer_;


### PR DESCRIPTION
Based on: #1546 

This PR enables using the sparse-communicator in the `distributed::Matrix`. It is only available if the C++17 standard is used, otherwise the old implementation will be used. But I will also deprecate the old implementation, so we won't maintain two separate code paths.


PR Stack:

- [ ] #1545 
- [ ] #1543
- [ ] #1579
- [ ] #1544 
- [ ] #1548 
- [ ] #1546 
- [ ] #1549 