### PR TITLE
Fixes preconditioner Benchmark

### DIFF
--- a/benchmark/preconditioner/preconditioner.cpp
+++ b/benchmark/preconditioner/preconditioner.cpp
@@ -117,8 +117,7 @@ struct PreconditionerBenchmark : Benchmark<preconditioner_benchmark_state> {
     std::vector<std::string> preconditioners;
     std::map<std::string, std::string> precond_decoder;
 
-    PreconditionerBenchmark()
-        : name{"preconditioner"}, preconditioners{split(FLAGS_preconditioners)}
+    PreconditionerBenchmark() : name{"preconditioner"}
     {
         for (auto precond : split(FLAGS_preconditioners)) {
             preconditioners.push_back(encode_parameters(precond.c_str()));

--- a/benchmark/test/preconditioner.py
+++ b/benchmark/test/preconditioner.py
@@ -31,6 +31,21 @@ test_framework.compare_output(
     expected_stderr="preconditioner.matrix.stderr",
 )
 
+# set preconditioner works
+test_framework.compare_output(
+    [
+        "-preconditioners",
+        "jacobi",
+        "-jacobi_max_block_size",
+        "32",
+        "-jacobi_storage",
+        "0,0",
+        "-input",
+        '[{"size": 100, "stencil": "7pt"}]'],
+    expected_stdout="preconditioner.precond.stdout",
+    expected_stderr="preconditioner.precond.stderr",
+)
+
 # profiler annotations
 test_framework.compare_output(
     [

--- a/benchmark/test/reference/preconditioner.precond.stderr
+++ b/benchmark/test/reference/preconditioner.precond.stderr
@@ -1,0 +1,7 @@
+Running on reference(0)
+Running with 2 warm iterations and 10 running iterations
+The random seed for right hand sides is 42
+Running with preconditioners: jacobi
+Running test case stencil(100, 7pt)
+Matrix is of size (125, 125), 725
+	Running preconditioner: jacobi-32-0,0

--- a/benchmark/test/reference/preconditioner.precond.stdout
+++ b/benchmark/test/reference/preconditioner.precond.stdout
@@ -1,0 +1,35 @@
+[
+    {
+        "size": 100,
+        "stencil": "7pt",
+        "preconditioner": {
+            "jacobi-32-0,0": {
+                "generate": {
+                    "components": {
+                        "generate(<typename>)": 1.0,
+                        "allocate": 1.0,
+                        "jacobi::find_blocks": 1.0,
+                        "jacobi::generate": 1.0,
+                        "free": 1.0,
+                        "overhead": 1.0
+                    },
+                    "time": 1.0,
+                    "repetitions": 10
+                },
+                "apply": {
+                    "components": {
+                        "apply(<typename>)": 1.0,
+                        "jacobi::simple_apply": 1.0,
+                        "overhead": 1.0
+                    },
+                    "time": 1.0,
+                    "repetitions": 10
+                },
+                "completed": true
+            }
+        },
+        "rows": 125,
+        "cols": 125,
+        "nonzeros": 725
+    }
+]


### PR DESCRIPTION
This PR fixes the preconditioner benchmark by storeing only encoded preconditioner names. The benchmark can run successfully in the current state, but it will emit some exceptions.