### PR TITLE
need sycl::ctz for Aurora 2023.12.30.002

### DIFF
--- a/dpcpp/components/intrinsics.dp.hpp
+++ b/dpcpp/components/intrinsics.dp.hpp
@@ -39,13 +39,13 @@ __dpct_inline__ int popcnt(uint64 mask) { return sycl::popcount(mask); }
  */
 __dpct_inline__ int ffs(uint32 mask)
 {
-    return (mask == 0) ? 0 : (sycl::ext::intel::ctz(mask) + 1);
+    return (mask == 0) ? 0 : (sycl::ctz(mask) + 1);
 }
 
 /** @copydoc ffs */
 __dpct_inline__ int ffs(uint64 mask)
 {
-    return (mask == 0) ? 0 : (sycl::ext::intel::ctz(mask) + 1);
+    return (mask == 0) ? 0 : (sycl::ctz(mask) + 1);
 }
 
 


### PR DESCRIPTION
When building on Aurora, sycl::ext::intel::ctz is OK for oneapi/eng-compiler/2023.10.15.002, but not for oneapi/eng-compiler/2023.12.30.002 (build will fail)
For oneapi/eng-compiler/2023.12.30.002, need sycl::ext::intel::ctz -> sycl::ctz
sycl::ctz is fine for 2023.10.15.002

I am unable to test any on other SYCL platform.
