### PR TITLE
Enable compatability with kokkos 3.7 and 4.x

### DIFF
--- a/examples/kokkos_assembly/CMakeLists.txt
+++ b/examples/kokkos_assembly/CMakeLists.txt
@@ -6,7 +6,7 @@ if(NOT GINKGO_BUILD_EXAMPLES)
     find_package(Ginkgo 1.8.0 REQUIRED)
 endif()
 
-find_package(Kokkos REQUIRED)
+find_package(Kokkos 3.7 REQUIRED)
 
 add_executable(kokkos-assembly kokkos_assembly.cpp)
 target_link_libraries(kokkos-assembly Ginkgo::ginkgo Kokkos::kokkos)

--- a/examples/kokkos_assembly/kokkos_assembly.cpp
+++ b/examples/kokkos_assembly/kokkos_assembly.cpp
@@ -14,6 +14,18 @@
 #include <ginkgo/ginkgo.hpp>
 
 
+// enable compatibility with both kokkos 3.7 and 4.x
+#if KOKKOS_VERSION / 10000 < 4
+namespace Kokkos {
+
+
+using Experimental::abs;
+
+
+}
+#endif
+
+
 // Creates a stencil matrix in CSR format for the given number of discretization
 // points.
 template <typename ValueType, typename IndexType>
@@ -102,9 +114,8 @@ double calculate_error(int discretization_points,
         KOKKOS_LAMBDA(int i, double& lsum) {
             const auto h = 1.0 / (discretization_points + 1);
             const auto xi = (i + 1) * h;
-            lsum += Kokkos::Experimental::abs(
-                (v_u(i) - correct_u(xi)) /
-                Kokkos::Experimental::abs(correct_u(xi)));
+            lsum += Kokkos::abs((v_u(i) - correct_u(xi)) /
+                                Kokkos::abs(correct_u(xi)));
         },
         error);
     return error;


### PR DESCRIPTION
This PR enables building our kokkos example both with kokkos 3.7 and 4.x.