### PR TITLE
Segmented ranges

### DIFF
--- a/core/base/integer_range.hpp
+++ b/core/base/integer_range.hpp
@@ -171,16 +171,14 @@ private:
 
 template <typename IndexType>
 class irange_strided : public random_access_range<integer_iterator<IndexType>> {
+    using base = random_access_range<integer_iterator<IndexType>>;
+
 public:
     using index_type = IndexType;
-    using iterator =
-        typename random_access_range<integer_iterator<IndexType>>::iterator;
-    using value_type =
-        typename random_access_range<integer_iterator<IndexType>>::value_type;
-    using reference =
-        typename random_access_range<integer_iterator<IndexType>>::reference;
-    using difference_type = typename random_access_range<
-        integer_iterator<IndexType>>::difference_type;
+    using iterator = typename base::iterator;
+    using value_type = typename base::value_type;
+    using reference = typename base::reference;
+    using difference_type = typename base::difference_type;
 
     explicit irange_strided(index_type begin, index_type end, index_type stride)
         : random_access_range<integer_iterator<IndexType>>{
@@ -214,16 +212,14 @@ public:
 
 template <typename IndexType>
 class irange : public random_access_range<integer_iterator<IndexType>> {
+    using base = random_access_range<integer_iterator<IndexType>>;
+
 public:
     using index_type = IndexType;
-    using iterator =
-        typename random_access_range<integer_iterator<IndexType>>::iterator;
-    using value_type =
-        typename random_access_range<integer_iterator<IndexType>>::value_type;
-    using reference =
-        typename random_access_range<integer_iterator<IndexType>>::reference;
-    using difference_type = typename random_access_range<
-        integer_iterator<IndexType>>::difference_type;
+    using iterator = typename base::iterator;
+    using value_type = typename base::value_type;
+    using reference = typename base::reference;
+    using difference_type = typename base::difference_type;
 
     explicit irange(index_type begin, index_type end)
         : random_access_range<integer_iterator<IndexType>>{iterator{begin, 1},

--- a/core/base/integer_range.hpp
+++ b/core/base/integer_range.hpp
@@ -1,0 +1,344 @@
+// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+//
+// SPDX-License-Identifier: BSD-3-Clause
+
+#ifndef GKO_CORE_BASE_INTEGER_RANGE_HPP_
+#define GKO_CORE_BASE_INTEGER_RANGE_HPP_
+
+
+#include <cassert>
+#include <iterator>
+#include <type_traits>
+
+
+namespace gko {
+
+
+namespace detail {
+
+
+template <typename Group>
+struct group_traits {};
+
+
+struct sycl_group_traits {
+    template <typename Group>
+    constexpr static std::size_t get_size(Group g)
+    {
+        return g.get_local_linear_range();
+    }
+
+    template <typename Group>
+    constexpr static std::size_t get_count(Group g)
+    {
+        return g.get_group_linear_range();
+    }
+
+    template <typename Group>
+    constexpr static std::size_t get_local_id(Group g)
+    {
+        return g.get_local_linear_id();
+    }
+
+    template <typename Group>
+    constexpr static std::size_t get_group_id(Group g)
+    {
+        return g.get_group_linear_id();
+    }
+};
+
+
+/*template <int dimension>
+struct group_traits<sycl::h_item<dimension>> : sycl_group_traits {};
+
+
+template <int dimension>
+struct group_traits<sycl::subgroup<dimension>> : sycl_group_traits {};
+
+
+template <int dimension>
+struct group_traits<sycl::group<dimension>> : sycl_group_traits {};
+
+
+template <int subwarp_size>
+struct group_traits<cooperative_groups::tiled_partition<subwarp_size>>
+    : cuda_group_traits {};*/
+
+
+}  // namespace detail
+
+
+template <typename IndexType>
+class integer_iterator {
+    static_assert(std::is_signed<IndexType>::value &&
+                      std::is_integral<IndexType>::value,
+                  "Can only use integer_iterator with signed integral types!");
+
+public:
+    using index_type = IndexType;
+
+    // iterator_traits requirements
+    using iterator_category = std::random_access_iterator_tag;
+    using value_type = index_type;
+    using difference_type = index_type;
+    using pointer = const index_type*;
+    using reference = index_type;  // we shouldn't hand out references to
+                                   // the index for lifetime safety
+
+    /** Initializes the iterator to the given index. */
+    constexpr explicit integer_iterator(index_type i, index_type stride = 1)
+        : idx_{i}, stride_{stride}
+    {
+        assert(stride > 0);
+    }
+
+    // Iterator requirements
+    /** Initializes the iterator to 0. */
+    constexpr integer_iterator() : idx_{} {}
+
+    // RandomAccessIterator requirements
+    /** Iterator advance. */
+    constexpr integer_iterator& operator+=(difference_type n)
+    {
+        idx_ += n * stride_;
+        return *this;
+    }
+
+    /** Iterator advance. */
+    constexpr friend integer_iterator operator+(integer_iterator a,
+                                                difference_type n)
+    {
+        return a += n;
+    }
+
+    /** Pre-increment. */
+    constexpr integer_iterator& operator++() { return *this += 1; }
+
+    /** Post-increment. */
+    constexpr integer_iterator operator++(int)
+    {
+        auto tmp{*this};
+        operator++();
+        return tmp;
+    }
+
+    // InputIterator requirements
+    /** Equality. */
+    constexpr friend bool operator==(integer_iterator a, integer_iterator b)
+    {
+        return (*a == *b);
+    }
+
+    /** Dereference. */
+    constexpr reference operator*() const { return idx_; }
+
+    // BidirectionalIterator requirements
+    /** Pre-decrement. */
+    constexpr integer_iterator& operator--() { return *this -= 1; }
+
+    /** Post-decrement. */
+    constexpr integer_iterator operator--(int)
+    {
+        auto tmp{*this};
+        operator--();
+        return tmp;
+    }
+
+    /** Iterator backwards advance. */
+    constexpr integer_iterator& operator-=(difference_type n)
+    {
+        idx_ += -n;
+        return *this;
+    }
+
+    /** Iterator backwards advance. */
+    constexpr friend integer_iterator operator-(integer_iterator a,
+                                                difference_type n)
+    {
+        return a + -n;
+    }
+
+    /** Iterator difference. */
+    constexpr friend difference_type operator-(integer_iterator a,
+                                               integer_iterator b)
+    {
+        assert(a.stride_ == b.stride_);
+        assert((*a - *b) % a.stride_ == 0);
+        return (*a - *b) / a.stride_;
+    }
+
+    /** Subscript. */
+    constexpr reference operator[](difference_type n) const
+    {
+        return *(*this + n);
+    }
+
+    // Boilerplate comparison operators
+    /** non-equality */
+    constexpr friend bool operator!=(integer_iterator a, integer_iterator b)
+    {
+        return !(a == b);
+    }
+
+    /** reverse advance */
+    constexpr friend integer_iterator operator+(difference_type n,
+                                                integer_iterator a)
+    {
+        return a + n;
+    }
+
+    /** less than */
+    constexpr friend bool operator<(integer_iterator a, integer_iterator b)
+    {
+        return b - a > 0;
+    }
+
+    /** greater than */
+    constexpr friend bool operator>(integer_iterator a, integer_iterator b)
+    {
+        return b < a;
+    }
+
+    /** greater equal */
+    constexpr friend bool operator>=(integer_iterator a, integer_iterator b)
+    {
+        return !(a < b);
+    }
+
+    /** less equal */
+    constexpr friend bool operator<=(integer_iterator a, integer_iterator b)
+    {
+        return !(a > b);
+    }
+
+private:
+    index_type idx_;
+    index_type stride_;
+};
+
+
+template <typename IndexType>
+class irange_strided {
+    static_assert(std::is_signed<IndexType>::value &&
+                      std::is_integral<IndexType>::value,
+                  "Can only use irange with signed integral types!");
+
+public:
+    using index_type = IndexType;
+    using value_type = index_type;
+    using iterator = integer_iterator<index_type>;
+
+    explicit irange_strided(index_type begin, index_type end, index_type stride)
+        : begin_{begin},
+          end_{begin + (end - begin) / stride * stride +
+               ((end - begin) % stride != 0 ? stride : 0)},
+          stride_{stride}
+    {
+        assert(end >= begin);
+        assert(stride > 0);
+    }
+
+    constexpr index_type begin_index() const { return begin_; }
+
+    constexpr index_type end_index() const { return end_; }
+
+    constexpr index_type stride() const { return stride_; }
+
+    constexpr index_type size() const
+    {
+        return (end_index() - begin_index()) / stride();
+    }
+
+    constexpr bool empty() const { return size() == 0; }
+
+    constexpr iterator begin() const
+    {
+        return iterator{begin_index(), stride()};
+    }
+
+    constexpr iterator end() const { return iterator{end_index(), stride()}; }
+
+    constexpr friend bool operator==(irange_strided lhs, irange_strided rhs)
+    {
+        return lhs.begin() == rhs.begin() && lhs.end() == rhs.end() &&
+               lhs.stride() == rhs.stride();
+    }
+
+    constexpr friend bool operator!=(irange_strided lhs, irange_strided rhs)
+    {
+        return !(lhs == rhs);
+    }
+
+private:
+    index_type begin_;
+    index_type end_;
+    index_type stride_;
+};
+
+
+template <typename IndexType>
+class irange {
+    static_assert(std::is_signed<IndexType>::value &&
+                      std::is_integral<IndexType>::value,
+                  "Can only use irange with signed integral types!");
+
+public:
+    using index_type = IndexType;
+    using value_type = index_type;
+    using iterator = integer_iterator<index_type>;
+
+    explicit irange(index_type begin, index_type end) : begin_{begin}, end_{end}
+    {
+        assert(end >= begin);
+    }
+
+    explicit irange(index_type end) : irange{0, end} {}
+
+    constexpr index_type begin_index() const { return begin_; }
+
+    constexpr index_type end_index() const { return end_; }
+
+    constexpr index_type size() const { return end_index() - begin_index(); }
+
+    constexpr bool empty() const { return size() == 0; }
+
+    constexpr iterator begin() const { return iterator{begin_index()}; }
+
+    constexpr iterator end() const { return iterator{end_index()}; }
+
+    template <typename Group>
+    constexpr irange_strided<index_type> striped(Group g) const
+    {
+        return striped(detail::group_traits<Group>::get_local_id(g),
+                       detail::group_traits<Group>::get_size(g));
+    }
+
+    constexpr irange_strided<index_type> striped(index_type local_index,
+                                                 index_type group_size) const
+    {
+        assert(local_index >= 0);
+        assert(local_index < group_size);
+        return irange_strided<index_type>{begin_ + local_index, end_,
+                                          group_size};
+    }
+
+    constexpr friend bool operator==(irange lhs, irange rhs)
+    {
+        return lhs.begin() == rhs.begin() && lhs.end() == rhs.end();
+    }
+
+    constexpr friend bool operator!=(irange lhs, irange rhs)
+    {
+        return !(lhs == rhs);
+    }
+
+private:
+    index_type begin_;
+    index_type end_;
+};
+
+
+}  // namespace gko
+
+
+#endif  // GKO_CORE_BASE_INTEGER_RANGE_HPP_

--- a/core/base/integer_range.hpp
+++ b/core/base/integer_range.hpp
@@ -14,268 +14,6 @@
 namespace gko {
 
 
-namespace detail {
-
-
-template <typename Group>
-struct group_traits {};
-
-
-struct sycl_group_traits {
-    template <typename Group>
-    constexpr static std::size_t get_size(Group g)
-    {
-        return g.get_local_linear_range();
-    }
-
-    template <typename Group>
-    constexpr static std::size_t get_count(Group g)
-    {
-        return g.get_group_linear_range();
-    }
-
-    template <typename Group>
-    constexpr static std::size_t get_local_id(Group g)
-    {
-        return g.get_local_linear_id();
-    }
-
-    template <typename Group>
-    constexpr static std::size_t get_group_id(Group g)
-    {
-        return g.get_group_linear_id();
-    }
-};
-
-
-/*template <int dimension>
-struct group_traits<sycl::h_item<dimension>> : sycl_group_traits {};
-
-
-template <int dimension>
-struct group_traits<sycl::subgroup<dimension>> : sycl_group_traits {};
-
-
-template <int dimension>
-struct group_traits<sycl::group<dimension>> : sycl_group_traits {};
-
-
-template <int subwarp_size>
-struct group_traits<cooperative_groups::tiled_partition<subwarp_size>>
-    : cuda_group_traits {};*/
-
-
-}  // namespace detail
-
-
-template <typename IndexType>
-class integer_iterator {
-    static_assert(std::is_signed<IndexType>::value &&
-                      std::is_integral<IndexType>::value,
-                  "Can only use integer_iterator with signed integral types!");
-
-public:
-    using index_type = IndexType;
-
-    // iterator_traits requirements
-    using iterator_category = std::random_access_iterator_tag;
-    using value_type = index_type;
-    using difference_type = index_type;
-    using pointer = const index_type*;
-    using reference = index_type;  // we shouldn't hand out references to
-                                   // the index for lifetime safety
-
-    /** Initializes the iterator to the given index. */
-    constexpr explicit integer_iterator(index_type i, index_type stride = 1)
-        : idx_{i}, stride_{stride}
-    {
-        assert(stride > 0);
-    }
-
-    // Iterator requirements
-    /** Initializes the iterator to 0. */
-    constexpr integer_iterator() : idx_{} {}
-
-    // RandomAccessIterator requirements
-    /** Iterator advance. */
-    constexpr integer_iterator& operator+=(difference_type n)
-    {
-        idx_ += n * stride_;
-        return *this;
-    }
-
-    /** Iterator advance. */
-    constexpr friend integer_iterator operator+(integer_iterator a,
-                                                difference_type n)
-    {
-        return a += n;
-    }
-
-    /** Pre-increment. */
-    constexpr integer_iterator& operator++() { return *this += 1; }
-
-    /** Post-increment. */
-    constexpr integer_iterator operator++(int)
-    {
-        auto tmp{*this};
-        operator++();
-        return tmp;
-    }
-
-    // InputIterator requirements
-    /** Equality. */
-    constexpr friend bool operator==(integer_iterator a, integer_iterator b)
-    {
-        return (*a == *b);
-    }
-
-    /** Dereference. */
-    constexpr reference operator*() const { return idx_; }
-
-    // BidirectionalIterator requirements
-    /** Pre-decrement. */
-    constexpr integer_iterator& operator--() { return *this -= 1; }
-
-    /** Post-decrement. */
-    constexpr integer_iterator operator--(int)
-    {
-        auto tmp{*this};
-        operator--();
-        return tmp;
-    }
-
-    /** Iterator backwards advance. */
-    constexpr integer_iterator& operator-=(difference_type n)
-    {
-        idx_ += -n;
-        return *this;
-    }
-
-    /** Iterator backwards advance. */
-    constexpr friend integer_iterator operator-(integer_iterator a,
-                                                difference_type n)
-    {
-        return a + -n;
-    }
-
-    /** Iterator difference. */
-    constexpr friend difference_type operator-(integer_iterator a,
-                                               integer_iterator b)
-    {
-        assert(a.stride_ == b.stride_);
-        assert((*a - *b) % a.stride_ == 0);
-        return (*a - *b) / a.stride_;
-    }
-
-    /** Subscript. */
-    constexpr reference operator[](difference_type n) const
-    {
-        return *(*this + n);
-    }
-
-    // Boilerplate comparison operators
-    /** non-equality */
-    constexpr friend bool operator!=(integer_iterator a, integer_iterator b)
-    {
-        return !(a == b);
-    }
-
-    /** reverse advance */
-    constexpr friend integer_iterator operator+(difference_type n,
-                                                integer_iterator a)
-    {
-        return a + n;
-    }
-
-    /** less than */
-    constexpr friend bool operator<(integer_iterator a, integer_iterator b)
-    {
-        return b - a > 0;
-    }
-
-    /** greater than */
-    constexpr friend bool operator>(integer_iterator a, integer_iterator b)
-    {
-        return b < a;
-    }
-
-    /** greater equal */
-    constexpr friend bool operator>=(integer_iterator a, integer_iterator b)
-    {
-        return !(a < b);
-    }
-
-    /** less equal */
-    constexpr friend bool operator<=(integer_iterator a, integer_iterator b)
-    {
-        return !(a > b);
-    }
-
-private:
-    index_type idx_;
-    index_type stride_;
-};
-
-
-template <typename IndexType>
-class irange_strided {
-    static_assert(std::is_signed<IndexType>::value &&
-                      std::is_integral<IndexType>::value,
-                  "Can only use irange with signed integral types!");
-
-public:
-    using index_type = IndexType;
-    using value_type = index_type;
-    using iterator = integer_iterator<index_type>;
-
-    explicit irange_strided(index_type begin, index_type end, index_type stride)
-        : begin_{begin},
-          end_{begin + (end - begin) / stride * stride +
-               ((end - begin) % stride != 0 ? stride : 0)},
-          stride_{stride}
-    {
-        assert(end >= begin);
-        assert(stride > 0);
-    }
-
-    constexpr index_type begin_index() const { return begin_; }
-
-    constexpr index_type end_index() const { return end_; }
-
-    constexpr index_type stride() const { return stride_; }
-
-    constexpr index_type size() const
-    {
-        return (end_index() - begin_index()) / stride();
-    }
-
-    constexpr bool empty() const { return size() == 0; }
-
-    constexpr iterator begin() const
-    {
-        return iterator{begin_index(), stride()};
-    }
-
-    constexpr iterator end() const { return iterator{end_index(), stride()}; }
-
-    constexpr friend bool operator==(irange_strided lhs, irange_strided rhs)
-    {
-        return lhs.begin() == rhs.begin() && lhs.end() == rhs.end() &&
-               lhs.stride() == rhs.stride();
-    }
-
-    constexpr friend bool operator!=(irange_strided lhs, irange_strided rhs)
-    {
-        return !(lhs == rhs);
-    }
-
-private:
-    index_type begin_;
-    index_type end_;
-    index_type stride_;
-};
-
-
 template <typename IndexType>
 class irange {
     static_assert(std::is_signed<IndexType>::value &&
@@ -285,7 +23,138 @@ class irange {
 public:
     using index_type = IndexType;
     using value_type = index_type;
-    using iterator = integer_iterator<index_type>;
+
+    class iterator {
+    public:
+        using index_type = IndexType;
+
+        // iterator_traits requirements
+        using iterator_category = std::random_access_iterator_tag;
+        using value_type = index_type;
+        using difference_type = index_type;
+        using pointer = index_type*;
+        using reference = index_type;  // we shouldn't hand out references to
+                                       // the index for lifetime safety
+
+        /** Initializes the iterator to the given index. */
+        constexpr explicit iterator(IndexType i) : idx_{i} {}
+
+        // Iterator requirements
+        /** Initializes the iterator to 0. */
+        constexpr iterator() : idx_{} {}
+
+        // RandomAccessIterator requirements
+        /** Iterator advance. */
+        constexpr iterator& operator+=(difference_type n)
+        {
+            idx_ += n;
+            return *this;
+        }
+
+        /** Iterator advance. */
+        constexpr friend iterator operator+(iterator a, difference_type n)
+        {
+            return iterator{*a + n};
+        }
+
+        /** Pre-increment. */
+        constexpr iterator& operator++() { return *this += 1; }
+
+        /** Post-increment. */
+        constexpr iterator operator++(int)
+        {
+            auto tmp{*this};
+            operator++();
+            return tmp;
+        }
+
+        // InputIterator requirements
+        /** Equality. */
+        constexpr friend bool operator==(iterator a, iterator b)
+        {
+            return (*a == *b);
+        }
+
+        /** Dereference. */
+        constexpr reference operator*() const { return idx_; }
+
+        // BidirectionalIterator requirements
+        /** Pre-decrement. */
+        constexpr iterator& operator--() { return *this -= 1; }
+
+        /** Post-decrement. */
+        constexpr iterator operator--(int)
+        {
+            auto tmp{*this};
+            operator--();
+            return tmp;
+        }
+
+        /** Iterator backwards advance. */
+        constexpr iterator& operator-=(difference_type n)
+        {
+            idx_ += -n;
+            return *this;
+        }
+
+        /** Iterator backwards advance. */
+        constexpr friend iterator operator-(iterator a, difference_type n)
+        {
+            return a + -n;
+        }
+
+        /** Iterator difference. */
+        constexpr friend difference_type operator-(iterator a, iterator b)
+        {
+            return *a - *b;
+        }
+
+        /** Subscript. */
+        constexpr reference operator[](difference_type n) const
+        {
+            return *(*this + n);
+        }
+
+        // Boilerplate comparison operators
+        /** non-equality */
+        constexpr friend bool operator!=(iterator a, iterator b)
+        {
+            return !(a == b);
+        }
+
+        /** reverse advance */
+        constexpr friend iterator operator+(difference_type n, iterator a)
+        {
+            return a + n;
+        }
+
+        /** less than */
+        constexpr friend bool operator<(iterator a, iterator b)
+        {
+            return b - a > 0;
+        }
+
+        /** greater than */
+        constexpr friend bool operator>(iterator a, iterator b)
+        {
+            return b < a;
+        }
+
+        /** greater equal */
+        constexpr friend bool operator>=(iterator a, iterator b)
+        {
+            return !(a < b);
+        }
+
+        /** less equal */
+        constexpr friend bool operator<=(iterator a, iterator b)
+        {
+            return !(a > b);
+        }
+
+    private:
+        index_type idx_;
+    };
 
     explicit irange(index_type begin, index_type end) : begin_{begin}, end_{end}
     {
@@ -296,6 +165,11 @@ public:
 
     constexpr index_type begin_index() const { return begin_; }
 
+    constexpr index_type mid_index() const
+    {
+        return begin_index() + size() / 2;
+    }
+
     constexpr index_type end_index() const { return end_; }
 
     constexpr index_type size() const { return end_index() - begin_index(); }
@@ -304,23 +178,13 @@ public:
 
     constexpr iterator begin() const { return iterator{begin_index()}; }
 
+    constexpr iterator mid() const { return iterator{mid_index()}; }
+
     constexpr iterator end() const { return iterator{end_index()}; }
 
-    template <typename Group>
-    constexpr irange_strided<index_type> striped(Group g) const
-    {
-        return striped(detail::group_traits<Group>::get_local_id(g),
-                       detail::group_traits<Group>::get_size(g));
-    }
+    constexpr irange lower_half() const { return irange{*begin(), *mid()}; }
 
-    constexpr irange_strided<index_type> striped(index_type local_index,
-                                                 index_type group_size) const
-    {
-        assert(local_index >= 0);
-        assert(local_index < group_size);
-        return irange_strided<index_type>{begin_ + local_index, end_,
-                                          group_size};
-    }
+    constexpr irange upper_half() const { return irange{*mid(), *end()}; }
 
     constexpr friend bool operator==(irange lhs, irange rhs)
     {
@@ -335,6 +199,88 @@ public:
 private:
     index_type begin_;
     index_type end_;
+};
+
+
+template <typename IndexType>
+class irange_strided {
+public:
+    using index_type = IndexType;
+
+    // tag type to facilitate the i < end comparison
+    struct iterator_sentinel {
+        index_type end;
+    };
+
+    class iterator {
+    public:
+        // iterator_traits requirements
+        using iterator_category = std::forward_iterator_tag;
+        using value_type = index_type;
+        using difference_type = index_type;
+        using pointer = index_type*;
+        using reference = index_type;  // we shouldn't hand out references to
+                                       // the index for lifetime safety
+
+        constexpr explicit iterator(index_type i, index_type stride)
+            : idx_{i}, stride_{stride}
+        {}
+
+        constexpr iterator& operator++()
+        {
+            idx_ += stride_;
+            return *this;
+        }
+
+        constexpr friend bool operator!=(iterator lhs, iterator_sentinel rhs)
+        {
+            return lhs.idx_ < rhs.end;
+        }
+
+        constexpr friend bool operator!=(iterator_sentinel lhs, iterator rhs)
+        {
+            return rhs != lhs;
+        }
+
+        constexpr friend bool operator==(iterator lhs, iterator_sentinel rhs)
+        {
+            return !(lhs != rhs);
+        }
+
+        constexpr friend bool operator==(iterator_sentinel lhs, iterator rhs)
+        {
+            return !(lhs != rhs);
+        }
+
+        constexpr const IndexType& operator*() const { return idx_; }
+
+    private:
+        index_type idx_;
+        index_type stride_;
+    };
+
+    explicit constexpr irange_strided(index_type begin, index_type end,
+                                      index_type stride)
+        : begin_{begin}, end_{end}, stride_{stride}
+    {
+        assert(end >= begin);
+        assert(stride > 0);
+    }
+
+    constexpr index_type begin_index() const { return begin_; }
+
+    constexpr index_type end_index() const { return end_; }
+
+    constexpr index_type stride() const { return stride_; }
+
+    constexpr iterator begin() const { return iterator{begin_, stride_}; }
+
+    constexpr iterator_sentinel end() const { return iterator_sentinel{end_}; }
+
+private:
+    index_type begin_;
+    index_type end_;
+    index_type stride_;
 };
 
 

--- a/core/base/integer_range.hpp
+++ b/core/base/integer_range.hpp
@@ -14,6 +14,268 @@
 namespace gko {
 
 
+namespace detail {
+
+
+template <typename Group>
+struct group_traits {};
+
+
+struct sycl_group_traits {
+    template <typename Group>
+    constexpr static std::size_t get_size(Group g)
+    {
+        return g.get_local_linear_range();
+    }
+
+    template <typename Group>
+    constexpr static std::size_t get_count(Group g)
+    {
+        return g.get_group_linear_range();
+    }
+
+    template <typename Group>
+    constexpr static std::size_t get_local_id(Group g)
+    {
+        return g.get_local_linear_id();
+    }
+
+    template <typename Group>
+    constexpr static std::size_t get_group_id(Group g)
+    {
+        return g.get_group_linear_id();
+    }
+};
+
+
+/*template <int dimension>
+struct group_traits<sycl::h_item<dimension>> : sycl_group_traits {};
+
+
+template <int dimension>
+struct group_traits<sycl::subgroup<dimension>> : sycl_group_traits {};
+
+
+template <int dimension>
+struct group_traits<sycl::group<dimension>> : sycl_group_traits {};
+
+
+template <int subwarp_size>
+struct group_traits<cooperative_groups::tiled_partition<subwarp_size>>
+    : cuda_group_traits {};*/
+
+
+}  // namespace detail
+
+
+template <typename IndexType>
+class integer_iterator {
+    static_assert(std::is_signed<IndexType>::value &&
+                      std::is_integral<IndexType>::value,
+                  "Can only use integer_iterator with signed integral types!");
+
+public:
+    using index_type = IndexType;
+
+    // iterator_traits requirements
+    using iterator_category = std::random_access_iterator_tag;
+    using value_type = index_type;
+    using difference_type = index_type;
+    using pointer = const index_type*;
+    using reference = index_type;  // we shouldn't hand out references to
+                                   // the index for lifetime safety
+
+    /** Initializes the iterator to the given index. */
+    constexpr explicit integer_iterator(index_type i, index_type stride = 1)
+        : idx_{i}, stride_{stride}
+    {
+        assert(stride > 0);
+    }
+
+    // Iterator requirements
+    /** Initializes the iterator to 0. */
+    constexpr integer_iterator() : idx_{} {}
+
+    // RandomAccessIterator requirements
+    /** Iterator advance. */
+    constexpr integer_iterator& operator+=(difference_type n)
+    {
+        idx_ += n * stride_;
+        return *this;
+    }
+
+    /** Iterator advance. */
+    constexpr friend integer_iterator operator+(integer_iterator a,
+                                                difference_type n)
+    {
+        return a += n;
+    }
+
+    /** Pre-increment. */
+    constexpr integer_iterator& operator++() { return *this += 1; }
+
+    /** Post-increment. */
+    constexpr integer_iterator operator++(int)
+    {
+        auto tmp{*this};
+        operator++();
+        return tmp;
+    }
+
+    // InputIterator requirements
+    /** Equality. */
+    constexpr friend bool operator==(integer_iterator a, integer_iterator b)
+    {
+        return (*a == *b);
+    }
+
+    /** Dereference. */
+    constexpr reference operator*() const { return idx_; }
+
+    // BidirectionalIterator requirements
+    /** Pre-decrement. */
+    constexpr integer_iterator& operator--() { return *this -= 1; }
+
+    /** Post-decrement. */
+    constexpr integer_iterator operator--(int)
+    {
+        auto tmp{*this};
+        operator--();
+        return tmp;
+    }
+
+    /** Iterator backwards advance. */
+    constexpr integer_iterator& operator-=(difference_type n)
+    {
+        idx_ += -n;
+        return *this;
+    }
+
+    /** Iterator backwards advance. */
+    constexpr friend integer_iterator operator-(integer_iterator a,
+                                                difference_type n)
+    {
+        return a + -n;
+    }
+
+    /** Iterator difference. */
+    constexpr friend difference_type operator-(integer_iterator a,
+                                               integer_iterator b)
+    {
+        assert(a.stride_ == b.stride_);
+        assert((*a - *b) % a.stride_ == 0);
+        return (*a - *b) / a.stride_;
+    }
+
+    /** Subscript. */
+    constexpr reference operator[](difference_type n) const
+    {
+        return *(*this + n);
+    }
+
+    // Boilerplate comparison operators
+    /** non-equality */
+    constexpr friend bool operator!=(integer_iterator a, integer_iterator b)
+    {
+        return !(a == b);
+    }
+
+    /** reverse advance */
+    constexpr friend integer_iterator operator+(difference_type n,
+                                                integer_iterator a)
+    {
+        return a + n;
+    }
+
+    /** less than */
+    constexpr friend bool operator<(integer_iterator a, integer_iterator b)
+    {
+        return b - a > 0;
+    }
+
+    /** greater than */
+    constexpr friend bool operator>(integer_iterator a, integer_iterator b)
+    {
+        return b < a;
+    }
+
+    /** greater equal */
+    constexpr friend bool operator>=(integer_iterator a, integer_iterator b)
+    {
+        return !(a < b);
+    }
+
+    /** less equal */
+    constexpr friend bool operator<=(integer_iterator a, integer_iterator b)
+    {
+        return !(a > b);
+    }
+
+private:
+    index_type idx_;
+    index_type stride_;
+};
+
+
+template <typename IndexType>
+class irange_strided {
+    static_assert(std::is_signed<IndexType>::value &&
+                      std::is_integral<IndexType>::value,
+                  "Can only use irange with signed integral types!");
+
+public:
+    using index_type = IndexType;
+    using value_type = index_type;
+    using iterator = integer_iterator<index_type>;
+
+    explicit irange_strided(index_type begin, index_type end, index_type stride)
+        : begin_{begin},
+          end_{begin + (end - begin) / stride * stride +
+               ((end - begin) % stride != 0 ? stride : 0)},
+          stride_{stride}
+    {
+        assert(end >= begin);
+        assert(stride > 0);
+    }
+
+    constexpr index_type begin_index() const { return begin_; }
+
+    constexpr index_type end_index() const { return end_; }
+
+    constexpr index_type stride() const { return stride_; }
+
+    constexpr index_type size() const
+    {
+        return (end_index() - begin_index()) / stride();
+    }
+
+    constexpr bool empty() const { return size() == 0; }
+
+    constexpr iterator begin() const
+    {
+        return iterator{begin_index(), stride()};
+    }
+
+    constexpr iterator end() const { return iterator{end_index(), stride()}; }
+
+    constexpr friend bool operator==(irange_strided lhs, irange_strided rhs)
+    {
+        return lhs.begin() == rhs.begin() && lhs.end() == rhs.end() &&
+               lhs.stride() == rhs.stride();
+    }
+
+    constexpr friend bool operator!=(irange_strided lhs, irange_strided rhs)
+    {
+        return !(lhs == rhs);
+    }
+
+private:
+    index_type begin_;
+    index_type end_;
+    index_type stride_;
+};
+
+
 template <typename IndexType>
 class irange {
     static_assert(std::is_signed<IndexType>::value &&
@@ -23,138 +285,7 @@ class irange {
 public:
     using index_type = IndexType;
     using value_type = index_type;
-
-    class iterator {
-    public:
-        using index_type = IndexType;
-
-        // iterator_traits requirements
-        using iterator_category = std::random_access_iterator_tag;
-        using value_type = index_type;
-        using difference_type = index_type;
-        using pointer = index_type*;
-        using reference = index_type;  // we shouldn't hand out references to
-                                       // the index for lifetime safety
-
-        /** Initializes the iterator to the given index. */
-        constexpr explicit iterator(IndexType i) : idx_{i} {}
-
-        // Iterator requirements
-        /** Initializes the iterator to 0. */
-        constexpr iterator() : idx_{} {}
-
-        // RandomAccessIterator requirements
-        /** Iterator advance. */
-        constexpr iterator& operator+=(difference_type n)
-        {
-            idx_ += n;
-            return *this;
-        }
-
-        /** Iterator advance. */
-        constexpr friend iterator operator+(iterator a, difference_type n)
-        {
-            return iterator{*a + n};
-        }
-
-        /** Pre-increment. */
-        constexpr iterator& operator++() { return *this += 1; }
-
-        /** Post-increment. */
-        constexpr iterator operator++(int)
-        {
-            auto tmp{*this};
-            operator++();
-            return tmp;
-        }
-
-        // InputIterator requirements
-        /** Equality. */
-        constexpr friend bool operator==(iterator a, iterator b)
-        {
-            return (*a == *b);
-        }
-
-        /** Dereference. */
-        constexpr reference operator*() const { return idx_; }
-
-        // BidirectionalIterator requirements
-        /** Pre-decrement. */
-        constexpr iterator& operator--() { return *this -= 1; }
-
-        /** Post-decrement. */
-        constexpr iterator operator--(int)
-        {
-            auto tmp{*this};
-            operator--();
-            return tmp;
-        }
-
-        /** Iterator backwards advance. */
-        constexpr iterator& operator-=(difference_type n)
-        {
-            idx_ += -n;
-            return *this;
-        }
-
-        /** Iterator backwards advance. */
-        constexpr friend iterator operator-(iterator a, difference_type n)
-        {
-            return a + -n;
-        }
-
-        /** Iterator difference. */
-        constexpr friend difference_type operator-(iterator a, iterator b)
-        {
-            return *a - *b;
-        }
-
-        /** Subscript. */
-        constexpr reference operator[](difference_type n) const
-        {
-            return *(*this + n);
-        }
-
-        // Boilerplate comparison operators
-        /** non-equality */
-        constexpr friend bool operator!=(iterator a, iterator b)
-        {
-            return !(a == b);
-        }
-
-        /** reverse advance */
-        constexpr friend iterator operator+(difference_type n, iterator a)
-        {
-            return a + n;
-        }
-
-        /** less than */
-        constexpr friend bool operator<(iterator a, iterator b)
-        {
-            return b - a > 0;
-        }
-
-        /** greater than */
-        constexpr friend bool operator>(iterator a, iterator b)
-        {
-            return b < a;
-        }
-
-        /** greater equal */
-        constexpr friend bool operator>=(iterator a, iterator b)
-        {
-            return !(a < b);
-        }
-
-        /** less equal */
-        constexpr friend bool operator<=(iterator a, iterator b)
-        {
-            return !(a > b);
-        }
-
-    private:
-        index_type idx_;
-    };
+    using iterator = integer_iterator<index_type>;
 
     explicit irange(index_type begin, index_type end) : begin_{begin}, end_{end}
     {
@@ -165,11 +296,6 @@ public:
 
     constexpr index_type begin_index() const { return begin_; }
 
-    constexpr index_type mid_index() const
-    {
-        return begin_index() + size() / 2;
-    }
-
     constexpr index_type end_index() const { return end_; }
 
     constexpr index_type size() const { return end_index() - begin_index(); }
@@ -178,13 +304,23 @@ public:
 
     constexpr iterator begin() const { return iterator{begin_index()}; }
 
-    constexpr iterator mid() const { return iterator{mid_index()}; }
-
     constexpr iterator end() const { return iterator{end_index()}; }
 
-    constexpr irange lower_half() const { return irange{*begin(), *mid()}; }
+    template <typename Group>
+    constexpr irange_strided<index_type> striped(Group g) const
+    {
+        return striped(detail::group_traits<Group>::get_local_id(g),
+                       detail::group_traits<Group>::get_size(g));
+    }
 
-    constexpr irange upper_half() const { return irange{*mid(), *end()}; }
+    constexpr irange_strided<index_type> striped(index_type local_index,
+                                                 index_type group_size) const
+    {
+        assert(local_index >= 0);
+        assert(local_index < group_size);
+        return irange_strided<index_type>{begin_ + local_index, end_,
+                                          group_size};
+    }
 
     constexpr friend bool operator==(irange lhs, irange rhs)
     {
@@ -199,88 +335,6 @@ public:
 private:
     index_type begin_;
     index_type end_;
-};
-
-
-template <typename IndexType>
-class irange_strided {
-public:
-    using index_type = IndexType;
-
-    // tag type to facilitate the i < end comparison
-    struct iterator_sentinel {
-        index_type end;
-    };
-
-    class iterator {
-    public:
-        // iterator_traits requirements
-        using iterator_category = std::forward_iterator_tag;
-        using value_type = index_type;
-        using difference_type = index_type;
-        using pointer = index_type*;
-        using reference = index_type;  // we shouldn't hand out references to
-                                       // the index for lifetime safety
-
-        constexpr explicit iterator(index_type i, index_type stride)
-            : idx_{i}, stride_{stride}
-        {}
-
-        constexpr iterator& operator++()
-        {
-            idx_ += stride_;
-            return *this;
-        }
-
-        constexpr friend bool operator!=(iterator lhs, iterator_sentinel rhs)
-        {
-            return lhs.idx_ < rhs.end;
-        }
-
-        constexpr friend bool operator!=(iterator_sentinel lhs, iterator rhs)
-        {
-            return rhs != lhs;
-        }
-
-        constexpr friend bool operator==(iterator lhs, iterator_sentinel rhs)
-        {
-            return !(lhs != rhs);
-        }
-
-        constexpr friend bool operator==(iterator_sentinel lhs, iterator rhs)
-        {
-            return !(lhs != rhs);
-        }
-
-        constexpr const IndexType& operator*() const { return idx_; }
-
-    private:
-        index_type idx_;
-        index_type stride_;
-    };
-
-    explicit constexpr irange_strided(index_type begin, index_type end,
-                                      index_type stride)
-        : begin_{begin}, end_{end}, stride_{stride}
-    {
-        assert(end >= begin);
-        assert(stride > 0);
-    }
-
-    constexpr index_type begin_index() const { return begin_; }
-
-    constexpr index_type end_index() const { return end_; }
-
-    constexpr index_type stride() const { return stride_; }
-
-    constexpr iterator begin() const { return iterator{begin_, stride_}; }
-
-    constexpr iterator_sentinel end() const { return iterator_sentinel{end_}; }
-
-private:
-    index_type begin_;
-    index_type end_;
-    index_type stride_;
 };
 
 

--- a/core/base/iterator_boilerplate.hpp
+++ b/core/base/iterator_boilerplate.hpp
@@ -1,0 +1,105 @@
+// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+//
+// SPDX-License-Identifier: BSD-3-Clause
+
+#ifndef GKO_CORE_BASE_ITERATOR_BOILERPLATE_HPP_
+#define GKO_CORE_BASE_ITERATOR_BOILERPLATE_HPP_
+
+
+/**
+ * Implements all `random_access_iterator` operations for _iterator in terms of
+ * the already implemented advance `operator +=(difference_type)`, the
+ * difference operator `operator-(_iterator, _iterator)` and the deference
+ * operator `operator*()`
+ */
+#define GKO_RANDOM_ACCESS_ITERATOR_BOILERPLATE(_iterator)                      \
+    /** InputIterator requirements */                                          \
+    /** Equality. */                                                           \
+    constexpr friend bool operator==(_iterator a, _iterator b)                 \
+    {                                                                          \
+        return a - b == 0;                                                     \
+    }                                                                          \
+                                                                               \
+    /** non-equality */                                                        \
+    constexpr friend bool operator!=(_iterator a, _iterator b)                 \
+    {                                                                          \
+        return !(a == b);                                                      \
+    }                                                                          \
+                                                                               \
+    /* BidirectionalIterator requirements*/                                    \
+    /** Pre-increment. */                                                      \
+    constexpr _iterator& operator++() { return *this += 1; }                   \
+                                                                               \
+    /** Post-increment. */                                                     \
+    constexpr _iterator operator++(int)                                        \
+    {                                                                          \
+        auto tmp{*this};                                                       \
+        operator++();                                                          \
+        return tmp;                                                            \
+    }                                                                          \
+                                                                               \
+    /** Pre-decrement. */                                                      \
+    constexpr _iterator& operator--() { return *this -= 1; }                   \
+                                                                               \
+    /** Post-decrement. */                                                     \
+    constexpr _iterator operator--(int)                                        \
+    {                                                                          \
+        auto tmp{*this};                                                       \
+        operator--();                                                          \
+        return tmp;                                                            \
+    }                                                                          \
+                                                                               \
+    /** RandomAccessIterator requirements */                                   \
+    /** Iterator advance. */                                                   \
+    constexpr friend _iterator operator+(_iterator a, difference_type n)       \
+    {                                                                          \
+        return a += n;                                                         \
+    }                                                                          \
+                                                                               \
+    /** reverse advance */                                                     \
+    constexpr friend _iterator operator+(difference_type n, _iterator a)       \
+    {                                                                          \
+        return a + n;                                                          \
+    }                                                                          \
+                                                                               \
+    /** Iterator backwards advance. */                                         \
+    constexpr _iterator& operator-=(difference_type n) { return *this += -n; } \
+                                                                               \
+    /** Iterator backwards advance. */                                         \
+    constexpr friend _iterator operator-(_iterator a, difference_type n)       \
+    {                                                                          \
+        return a + -n;                                                         \
+    }                                                                          \
+                                                                               \
+    /** Subscript. */                                                          \
+    constexpr reference operator[](difference_type n) const                    \
+    {                                                                          \
+        return *(*this + n);                                                   \
+    }                                                                          \
+                                                                               \
+    /** less than */                                                           \
+    constexpr friend bool operator<(_iterator a, _iterator b)                  \
+    {                                                                          \
+        return b - a > 0;                                                      \
+    }                                                                          \
+                                                                               \
+    /** greater than */                                                        \
+    constexpr friend bool operator>(_iterator a, _iterator b)                  \
+    {                                                                          \
+        return b < a;                                                          \
+    }                                                                          \
+                                                                               \
+    /** greater equal */                                                       \
+    constexpr friend bool operator>=(_iterator a, _iterator b)                 \
+    {                                                                          \
+        return !(a < b);                                                       \
+    }                                                                          \
+                                                                               \
+    /** less equal */                                                          \
+    constexpr friend bool operator<=(_iterator a, _iterator b)                 \
+    {                                                                          \
+        return !(a > b);                                                       \
+    }
+
+
+#endif  // GKO_CORE_BASE_ITERATOR_BOILERPLATE_HPP_

--- a/core/base/iterator_factory.hpp
+++ b/core/base/iterator_factory.hpp
@@ -15,6 +15,7 @@
 
 
 #include "core/base/copy_assignable.hpp"
+#include "core/base/iterator_boilerplate.hpp"
 
 
 namespace gko {
@@ -130,7 +131,7 @@ public:
     using iterator_category = std::random_access_iterator_tag;
     using index_sequence = std::index_sequence_for<Iterators...>;
 
-    explicit zip_iterator() = default;
+    zip_iterator() = default;
 
     explicit zip_iterator(Iterators... its) : iterators_{its...} {}
 
@@ -138,57 +139,6 @@ public:
     {
         forall([i](auto& it) { it += i; });
         return *this;
-    }
-
-    zip_iterator& operator-=(difference_type i)
-    {
-        forall([i](auto& it) { it -= i; });
-        return *this;
-    }
-
-    zip_iterator& operator++()
-    {
-        forall([](auto& it) { it++; });
-        return *this;
-    }
-
-    zip_iterator operator++(int)
-    {
-        auto tmp = *this;
-        ++(*this);
-        return tmp;
-    }
-
-    zip_iterator& operator--()
-    {
-        forall([](auto& it) { it--; });
-        return *this;
-    }
-
-    zip_iterator operator--(int)
-    {
-        auto tmp = *this;
-        --(*this);
-        return tmp;
-    }
-
-    zip_iterator operator+(difference_type i) const
-    {
-        auto tmp = *this;
-        tmp += i;
-        return tmp;
-    }
-
-    friend zip_iterator operator+(difference_type i, const zip_iterator& iter)
-    {
-        return iter + i;
-    }
-
-    zip_iterator operator-(difference_type i) const
-    {
-        auto tmp = *this;
-        tmp -= i;
-        return tmp;
     }
 
     difference_type operator-(const zip_iterator& other) const
@@ -202,40 +152,7 @@ public:
         return deref_impl(std::index_sequence_for<Iterators...>{});
     }
 
-    reference operator[](difference_type i) const { return *(*this + i); }
-
-    bool operator==(const zip_iterator& other) const
-    {
-        return forall_check_consistent(
-            other, [](const auto& a, const auto& b) { return a == b; });
-    }
-
-    bool operator!=(const zip_iterator& other) const
-    {
-        return !(*this == other);
-    }
-
-    bool operator<(const zip_iterator& other) const
-    {
-        return forall_check_consistent(
-            other, [](const auto& a, const auto& b) { return a < b; });
-    }
-
-    bool operator<=(const zip_iterator& other) const
-    {
-        return forall_check_consistent(
-            other, [](const auto& a, const auto& b) { return a <= b; });
-    }
-
-    bool operator>(const zip_iterator& other) const
-    {
-        return !(*this <= other);
-    }
-
-    bool operator>=(const zip_iterator& other) const
-    {
-        return !(*this < other);
-    }
+    GKO_RANDOM_ACCESS_ITERATOR_BOILERPLATE(zip_iterator)
 
 private:
     template <std::size_t... idxs>
@@ -373,46 +290,6 @@ public:
         return *this;
     }
 
-    permute_iterator& operator-=(difference_type i) { return *this += -i; }
-
-    permute_iterator& operator++() { return *this += 1; }
-
-    permute_iterator operator++(int)
-    {
-        auto tmp = *this;
-        ++(*this);
-        return tmp;
-    }
-
-    permute_iterator& operator--() { return *this -= 1; }
-
-    permute_iterator operator--(int)
-    {
-        auto tmp = *this;
-        --(*this);
-        return tmp;
-    }
-
-    permute_iterator operator+(difference_type i) const
-    {
-        auto tmp = *this;
-        tmp += i;
-        return tmp;
-    }
-
-    friend permute_iterator operator+(difference_type i,
-                                      const permute_iterator& iter)
-    {
-        return iter + i;
-    }
-
-    permute_iterator operator-(difference_type i) const
-    {
-        auto tmp = *this;
-        tmp -= i;
-        return tmp;
-    }
-
     difference_type operator-(const permute_iterator& other) const
     {
         return idx_ - other.idx_;
@@ -420,37 +297,7 @@ public:
 
     reference operator*() const { return it_[perm_(idx_)]; }
 
-    reference operator[](difference_type i) const { return *(*this + i); }
-
-    bool operator==(const permute_iterator& other) const
-    {
-        return idx_ == other.idx_;
-    }
-
-    bool operator!=(const permute_iterator& other) const
-    {
-        return !(*this == other);
-    }
-
-    bool operator<(const permute_iterator& other) const
-    {
-        return idx_ < other.idx_;
-    }
-
-    bool operator<=(const permute_iterator& other) const
-    {
-        return idx_ <= other.idx_;
-    }
-
-    bool operator>(const permute_iterator& other) const
-    {
-        return !(*this <= other);
-    }
-
-    bool operator>=(const permute_iterator& other) const
-    {
-        return !(*this < other);
-    }
+    GKO_RANDOM_ACCESS_ITERATOR_BOILERPLATE(permute_iterator);
 
 private:
     IteratorType it_;

--- a/core/base/segmented_range.hpp
+++ b/core/base/segmented_range.hpp
@@ -1,0 +1,462 @@
+// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+//
+// SPDX-License-Identifier: BSD-3-Clause
+
+#ifndef GKO_CORE_BASE_SEGMENTED_RANGE_HPP_
+#define GKO_CORE_BASE_SEGMENTED_RANGE_HPP_
+
+
+#include <iterator>
+#include <type_traits>
+
+
+#include "core/base/integer_range.hpp"
+#include "core/base/iterator_boilerplate.hpp"
+
+
+namespace gko {
+
+
+template <typename ValueIterator,
+          typename IndexIterator = integer_iterator<
+              typename std::iterator_traits<ValueIterator>::difference_type>>
+class indexed_iterator {
+public:
+    using value_iterator = ValueIterator;
+    using index_iterator = IndexIterator;
+
+private:
+    using value_traits = std::iterator_traits<value_iterator>;
+    using index_traits = std::iterator_traits<index_iterator>;
+
+public:
+    using value_type = typename value_traits::value_type;
+    using index_type = typename index_traits::value_type;
+    using difference_type = typename index_traits::difference_type;
+    using pointer = typename value_traits::pointer;
+    using reference = typename value_traits::reference;
+    using iterator_category = std::random_access_iterator_tag;
+
+    constexpr explicit indexed_iterator(value_iterator value_it,
+                                        index_iterator index_it)
+        : value_it_{value_it}, index_it_{index_it}
+    {}
+
+    constexpr indexed_iterator() : indexed_iterator{{}, {}} {}
+
+    constexpr indexed_iterator& operator+=(difference_type n)
+    {
+        index_it_ += n;
+        return *this;
+    }
+
+    constexpr difference_type index() const { return *index_it_; }
+
+    constexpr reference operator*() const { return value_it_[index()]; }
+
+    constexpr friend difference_type operator-(indexed_iterator a,
+                                               indexed_iterator b)
+    {
+        return a.index_it_ - b.index_it_;
+    }
+
+    GKO_RANDOM_ACCESS_ITERATOR_BOILERPLATE(indexed_iterator);
+
+private:
+    value_iterator value_it_;
+    index_iterator index_it_;
+};
+
+
+template <typename ValueIterator,
+          typename IndexIterator = integer_iterator<
+              typename std::iterator_traits<ValueIterator>::difference_type>>
+class enumerating_indexed_iterator
+    : public indexed_iterator<ValueIterator, IndexIterator> {
+private:
+    using base = indexed_iterator<ValueIterator, IndexIterator>;
+
+public:
+    using base_value_type = typename base::value_type;
+    using index_type = typename base::value_type;
+
+    struct enumerated {
+        index_type index;
+        base_value_type value;
+
+        constexpr explicit enumerated(index_type index, base_value_type value)
+            : index{index}, value{value}
+        {}
+
+        constexpr friend bool operator==(enumerated a, enumerated b)
+        {
+            return a.index == b.index && a.value == b.value;
+        }
+
+        constexpr friend bool operator!=(enumerated a, enumerated b)
+        {
+            return !(a == b);
+        }
+    };
+
+    using value_type = enumerated;
+    using difference_type = typename base::difference_type;
+    using pointer = const enumerated*;
+    using reference = value_type;  // we shouldn't hand out references to
+                                   // the enumerated struct for lifetime safety
+    using iterator_category = std::random_access_iterator_tag;
+
+    using base::indexed_iterator;
+
+    constexpr enumerating_indexed_iterator& operator+=(difference_type n)
+    {
+        this->base::operator+=(n);
+        return *this;
+    }
+
+    constexpr reference operator*() const
+    {
+        return enumerated{this->index(), this->base::operator*()};
+    }
+
+    // override all boilerplate operators, in particular operator[]
+    GKO_RANDOM_ACCESS_ITERATOR_BOILERPLATE(enumerating_indexed_iterator);
+};
+
+
+template <typename ValueIterator, typename IndexIterator>
+class indexed_range : public random_access_range<
+                          indexed_iterator<ValueIterator, IndexIterator>> {
+    using base =
+        random_access_range<indexed_iterator<ValueIterator, IndexIterator>>;
+
+public:
+    using value_iterator = ValueIterator;
+    using index_iterator = IndexIterator;
+    using iterator = typename base::iterator;
+    using value_type = typename base::value_type;
+    using reference = typename base::reference;
+    using difference_type = typename base::difference_type;
+
+    constexpr explicit indexed_range(value_iterator value_it,
+                                     index_iterator begin_index_it,
+                                     index_iterator end_index_it)
+        : base{iterator{value_it, begin_index_it},
+               iterator{value_it, end_index_it}}
+    {}
+
+    constexpr friend bool operator==(indexed_range lhs, indexed_range rhs)
+    {
+        return lhs.begin() == rhs.begin() && lhs.end() == rhs.end();
+    }
+
+    constexpr friend bool operator!=(indexed_range lhs, indexed_range rhs)
+    {
+        return !(lhs == rhs);
+    }
+};
+
+
+template <typename ValueIterator, typename IndexIterator>
+class enumerating_indexed_range
+    : public random_access_range<
+          enumerating_indexed_iterator<ValueIterator, IndexIterator>> {
+    using base = random_access_range<
+        enumerating_indexed_iterator<ValueIterator, IndexIterator>>;
+
+public:
+    using value_iterator = ValueIterator;
+    using index_iterator = IndexIterator;
+    using iterator = typename base::iterator;
+    using value_type = typename base::value_type;
+    using reference = typename base::reference;
+    using difference_type = typename base::difference_type;
+
+    constexpr explicit enumerating_indexed_range(value_iterator value_it,
+                                                 index_iterator begin_index_it,
+                                                 index_iterator end_index_it)
+        : base{iterator{value_it, begin_index_it},
+               iterator{value_it, end_index_it}}
+    {}
+
+    constexpr friend bool operator==(enumerating_indexed_range lhs,
+                                     enumerating_indexed_range rhs)
+    {
+        return lhs.begin() == rhs.begin() && lhs.end() == rhs.end();
+    }
+
+    constexpr friend bool operator!=(enumerating_indexed_range lhs,
+                                     enumerating_indexed_range rhs)
+    {
+        return !(lhs == rhs);
+    }
+};
+
+
+template <typename IndexIterator>
+class segmented_range_iterator {
+public:
+    using index_iterator = IndexIterator;
+
+private:
+    using index_traits = std::iterator_traits<index_iterator>;
+
+public:
+    using index_type = typename index_traits::value_type;
+    using value_type = irange<index_type>;
+    using difference_type = typename index_traits::difference_type;
+    using pointer = const value_type*;
+    using reference = value_type;  // we shouldn't hand out references to
+                                   // the segment for lifetime safety
+    using iterator_category = std::random_access_iterator_tag;
+
+    constexpr explicit segmented_range_iterator(index_iterator begins_it,
+                                                index_iterator ends_it)
+        : begins_it_{begins_it}, ends_it_{ends_it}
+    {}
+
+    constexpr segmented_range_iterator& operator+=(difference_type n)
+    {
+        begins_it_ += n;
+        ends_it_ += n;
+        return *this;
+    }
+
+    constexpr reference operator*() const
+    {
+        return value_type{*begins_it_, *ends_it_};
+    }
+
+    constexpr friend difference_type operator-(segmented_range_iterator a,
+                                               segmented_range_iterator b)
+    {
+        assert(a.begins_it - b.begins_it == a.ends_it_ - b.ends_it_);
+        return a.begins_it - b.begins_it;
+    }
+
+    GKO_RANDOM_ACCESS_ITERATOR_BOILERPLATE(segmented_range_iterator);
+
+private:
+    index_iterator begins_it_;
+    index_iterator ends_it_;
+};
+
+
+template <typename IndexIterator>
+class segmented_range
+    : public random_access_range<segmented_range_iterator<IndexIterator>> {
+    using base = random_access_range<segmented_range_iterator<IndexIterator>>;
+
+public:
+    using index_iterator = IndexIterator;
+    using iterator = typename base::iterator;
+    using value_type = typename base::value_type;
+    using reference = typename base::reference;
+    using difference_type = typename base::difference_type;
+
+    constexpr explicit segmented_range(index_iterator begins_it,
+                                       index_iterator ends_it,
+                                       difference_type num_segments)
+        : base{iterator{begins_it, ends_it},
+               iterator{begins_it + num_segments, ends_it + num_segments}}
+    {}
+
+    constexpr friend bool operator==(segmented_range lhs, segmented_range rhs)
+    {
+        return lhs.begin() == rhs.begin() && lhs.end() == rhs.end();
+    }
+
+    constexpr friend bool operator!=(segmented_range lhs, segmented_range rhs)
+    {
+        return !(lhs == rhs);
+    }
+};
+
+
+template <typename ValueIterator, typename IndexIterator>
+class segmented_enumerating_value_range_iterator {
+public:
+    using value_iterator = ValueIterator;
+    using index_iterator = IndexIterator;
+
+private:
+    using value_traits = std::iterator_traits<index_iterator>;
+    using index_traits = std::iterator_traits<index_iterator>;
+
+public:
+    using index_type = typename index_traits::value_type;
+    using index_range = irange<index_type>;
+    using value_type =
+        enumerating_indexed_range<value_iterator,
+                                  typename index_range::iterator>;
+    using difference_type = typename index_traits::difference_type;
+    using pointer = const value_type*;
+    using reference = value_type;  // we shouldn't hand out references to
+                                   // the segment for lifetime safety
+    using iterator_category = std::random_access_iterator_tag;
+
+    constexpr explicit segmented_enumerating_value_range_iterator(
+        value_iterator value_it, index_iterator begins_it,
+        index_iterator ends_it)
+        : value_it_{value_it}, begins_it_{begins_it}, ends_it_{ends_it}
+    {}
+
+    constexpr segmented_enumerating_value_range_iterator& operator+=(
+        difference_type n)
+    {
+        begins_it_ += n;
+        ends_it_ += n;
+        return *this;
+    }
+
+    constexpr reference operator*() const
+    {
+        index_range range{*begins_it_, *ends_it_};
+        return value_type{value_it_, range.begin(), range.end()};
+    }
+
+    constexpr friend difference_type operator-(
+        segmented_enumerating_value_range_iterator a,
+        segmented_enumerating_value_range_iterator b)
+    {
+        assert(a.value_it_ == b.value_it_);
+        assert(a.begins_it - b.begins_it == a.ends_it_ - b.ends_it_);
+        return a.begins_it - b.begins_it;
+    }
+
+    GKO_RANDOM_ACCESS_ITERATOR_BOILERPLATE(
+        segmented_enumerating_value_range_iterator);
+
+private:
+    value_iterator value_it_;
+    index_iterator begins_it_;
+    index_iterator ends_it_;
+};
+
+
+template <typename ValueIterator, typename IndexIterator>
+class segmented_value_range_iterator {
+public:
+    using value_iterator = ValueIterator;
+    using index_iterator = IndexIterator;
+
+private:
+    using value_traits = std::iterator_traits<index_iterator>;
+    using index_traits = std::iterator_traits<index_iterator>;
+
+public:
+    using index_type = typename index_traits::value_type;
+    using index_range = irange<index_type>;
+    using value_type =
+        indexed_range<value_iterator, typename index_range::iterator>;
+    using difference_type = typename index_traits::difference_type;
+    using pointer = const value_type*;
+    using reference = value_type;  // we shouldn't hand out references to
+                                   // the segment for lifetime safety
+    using enumerating_type =
+        segmented_enumerating_value_range_iterator<value_iterator,
+                                                   index_iterator>;
+    using iterator_category = std::random_access_iterator_tag;
+
+    constexpr explicit segmented_value_range_iterator(value_iterator value_it,
+                                                      index_iterator begins_it,
+                                                      index_iterator ends_it)
+        : value_it_{value_it}, begins_it_{begins_it}, ends_it_{ends_it}
+    {}
+
+    constexpr segmented_value_range_iterator& operator+=(difference_type n)
+    {
+        begins_it_ += n;
+        ends_it_ += n;
+        return *this;
+    }
+
+    constexpr enumerating_type as_enumerating() const
+    {
+        return enumerating_type{value_it_, begins_it_, ends_it_};
+    }
+
+    constexpr reference operator*() const
+    {
+        index_range range{*begins_it_, *ends_it_};
+        return value_type{value_it_, range.begin(), range.end()};
+    }
+
+    constexpr friend difference_type operator-(segmented_value_range_iterator a,
+                                               segmented_value_range_iterator b)
+    {
+        assert(a.value_it_ == b.value_it_);
+        assert(a.begins_it - b.begins_it == a.ends_it_ - b.ends_it_);
+        return a.begins_it - b.begins_it;
+    }
+
+    GKO_RANDOM_ACCESS_ITERATOR_BOILERPLATE(segmented_value_range_iterator);
+
+private:
+    value_iterator value_it_;
+    index_iterator begins_it_;
+    index_iterator ends_it_;
+};
+
+
+template <typename ValueIterator, typename IndexIterator>
+class segmented_value_range
+    : public random_access_range<
+          segmented_value_range_iterator<ValueIterator, IndexIterator>> {
+    using base = random_access_range<
+        segmented_value_range_iterator<ValueIterator, IndexIterator>>;
+
+public:
+    using value_iterator = ValueIterator;
+    using index_iterator = IndexIterator;
+    using iterator = typename base::iterator;
+    using value_type = typename base::value_type;
+    using reference = typename base::reference;
+    using difference_type = typename base::difference_type;
+    using enumerating_iterator =
+        segmented_enumerating_value_range_iterator<ValueIterator,
+                                                   IndexIterator>;
+    using enumerating_value_type = typename enumerating_iterator::value_type;
+
+    constexpr explicit segmented_value_range(value_iterator value_it,
+                                             index_iterator begins_it,
+                                             index_iterator ends_it,
+                                             difference_type num_segments)
+        : base{iterator{value_it, begins_it, ends_it},
+               iterator{value_it, begins_it + num_segments,
+                        ends_it + num_segments}}
+    {}
+
+    constexpr enumerating_iterator enumerate_begin() const
+    {
+        return this->begin().as_enumerating();
+    }
+
+    constexpr enumerating_iterator enumerate_end() const
+    {
+        return this->end().as_enumerating();
+    }
+
+    constexpr enumerating_value_type enumerate(difference_type n) const
+    {
+        return this->enumerate_begin()[n];
+    }
+
+    constexpr friend bool operator==(segmented_value_range lhs,
+                                     segmented_value_range rhs)
+    {
+        return lhs.begin() == rhs.begin() && lhs.end() == rhs.end();
+    }
+
+    constexpr friend bool operator!=(segmented_value_range lhs,
+                                     segmented_value_range rhs)
+    {
+        return !(lhs == rhs);
+    }
+};
+
+
+}  // namespace gko
+
+
+#endif  // GKO_CORE_BASE_SEGMENTED_RANGE_HPP_

--- a/core/test/base/CMakeLists.txt
+++ b/core/test/base/CMakeLists.txt
@@ -14,6 +14,7 @@ ginkgo_create_test(exception EXECUTABLE_NAME exception_test) # exception collide
 ginkgo_create_test(exception_helpers)
 ginkgo_create_test(extended_float)
 ginkgo_create_test(executor)
+ginkgo_create_test(integer_range)
 ginkgo_create_test(iterator_factory)
 ginkgo_create_test(lin_op)
 ginkgo_create_test(math)

--- a/core/test/base/CMakeLists.txt
+++ b/core/test/base/CMakeLists.txt
@@ -26,6 +26,7 @@ ginkgo_create_test(polymorphic_object)
 ginkgo_create_test(range)
 ginkgo_create_test(range_accessors)
 ginkgo_create_test(sanitizers ADDITIONAL_LIBRARIES Threads::Threads)
+ginkgo_create_test(segmented_range)
 ginkgo_create_test(types)
 ginkgo_create_test(utils)
 ginkgo_create_test(version EXECUTABLE_NAME version_test) # version collides with C++ stdlib header

--- a/core/test/base/integer_range.cpp
+++ b/core/test/base/integer_range.cpp
@@ -16,10 +16,14 @@ TEST(IRange, KnowsItsProperties)
     ASSERT_EQ(range.size(), 10);
     ASSERT_EQ(range.begin_index(), 0);
     ASSERT_EQ(range.end_index(), 10);
+    ASSERT_EQ(range.mid_index(), 5);
     ASSERT_EQ(*range.begin(), 0);
+    ASSERT_EQ(*range.mid(), 5);
     // For other iterators, this would be illegal, but it is allowed for
     // irange::iterator
     ASSERT_EQ(*range.end(), 10);
+    ASSERT_EQ(range.lower_half(), gko::irange<int>(0, 5));
+    ASSERT_EQ(range.upper_half(), gko::irange<int>(5, 10));
     ASSERT_TRUE(range == gko::irange<int>(0, 10));
     ASSERT_TRUE(range != gko::irange<int>(1, 10));
     ASSERT_TRUE(range != gko::irange<int>(0, 9));
@@ -96,19 +100,10 @@ TEST(IRangeStrided, KnowsItsProperties)
     gko::irange_strided<int> range{0, 4, 3};
 
     ASSERT_EQ(range.begin_index(), 0);
-    ASSERT_EQ(range.end_index(), 6);
+    ASSERT_EQ(range.end_index(), 4);
     ASSERT_EQ(range.stride(), 3);
     ASSERT_EQ(*range.begin(), 0);
-    ASSERT_EQ(*range.end(), 6);
-}
-
-
-TEST(IRangeStrided, EndComputationIsCorrect)
-{
-    ASSERT_EQ(gko::irange_strided<int>(0, 3, 3).end_index(), 3);
-    ASSERT_EQ(gko::irange_strided<int>(0, 4, 3).end_index(), 6);
-    ASSERT_EQ(gko::irange_strided<int>(0, 5, 3).end_index(), 6);
-    ASSERT_EQ(gko::irange_strided<int>(0, 6, 3).end_index(), 6);
+    ASSERT_EQ(range.end().end, 4);
 }
 
 
@@ -142,48 +137,3 @@ TEST(IRangeStridedIterator, RangeFor)
 
     ASSERT_EQ(v, std::vector<int>({1, 3, 5, 7, 9}));
 }
-
-
-#ifndef NDEBUG
-
-
-bool check_assertion_exit_code(int exit_code)
-{
-#ifdef _MSC_VER
-    // MSVC picks up the exit code incorrectly,
-    // so we can only check that it exits
-    return true;
-#else
-    return exit_code != 0;
-#endif
-}
-
-
-TEST(DeathTest, Assertions)
-{
-    // integer_iterator
-    // stride > 0
-    EXPECT_EXIT((void)(gko::integer_iterator<int>{0, 0}),
-                check_assertion_exit_code, "");
-    // a.stride_ == b.stride_
-    EXPECT_EXIT((void)(gko::integer_iterator<int>{0, 1} -
-                       gko::integer_iterator<int>{0, 2}),
-                check_assertion_exit_code, "");
-    // (*a - *b) % a.stride_ == 0
-    EXPECT_EXIT((void)(gko::integer_iterator<int>{0, 2} -
-                       gko::integer_iterator<int>{1, 2}),
-                check_assertion_exit_code, "");
-    // irange
-    // end >= begin
-    EXPECT_EXIT((void)(gko::irange<int>{1, 0}), check_assertion_exit_code, "");
-    // irange_strided
-    // end >= begin
-    EXPECT_EXIT((void)(gko::irange_strided<int>{1, 0, 1}),
-                check_assertion_exit_code, "");
-    // stride > 0
-    EXPECT_EXIT((void)(gko::irange_strided<int>{0, 1, 0}),
-                check_assertion_exit_code, "");
-}
-
-
-#endif

--- a/core/test/base/integer_range.cpp
+++ b/core/test/base/integer_range.cpp
@@ -1,0 +1,189 @@
+// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+//
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include <gtest/gtest.h>
+
+
+#include "core/base/integer_range.hpp"
+
+
+TEST(IRange, KnowsItsProperties)
+{
+    gko::irange<int> range(0, 10);
+
+    ASSERT_FALSE(range.empty());
+    ASSERT_EQ(range.size(), 10);
+    ASSERT_EQ(range.begin_index(), 0);
+    ASSERT_EQ(range.end_index(), 10);
+    ASSERT_EQ(*range.begin(), 0);
+    // For other iterators, this would be illegal, but it is allowed for
+    // irange::iterator
+    ASSERT_EQ(*range.end(), 10);
+    ASSERT_TRUE(range == gko::irange<int>(0, 10));
+    ASSERT_TRUE(range != gko::irange<int>(1, 10));
+    ASSERT_TRUE(range != gko::irange<int>(0, 9));
+    ASSERT_FALSE(range != gko::irange<int>(0, 10));
+    ASSERT_FALSE(range == gko::irange<int>(1, 10));
+    ASSERT_FALSE(range == gko::irange<int>(0, 9));
+    // test single-argument constructor
+    ASSERT_TRUE(range == gko::irange<int>(10));
+    ASSERT_TRUE(gko::irange<int>{0}.empty());
+}
+
+
+TEST(IRangeIterator, IteratorProperties)
+{
+    gko::irange<int> range(0, 10);
+
+    auto it = range.begin();
+    it += 4;
+    ASSERT_EQ(*it, 4);
+    it -= 4;
+    ASSERT_EQ(*it, 0);
+    ASSERT_EQ(*it++, 0);
+    ASSERT_EQ(*++it, 2);
+    ASSERT_EQ(*it--, 2);
+    ASSERT_EQ(*--it, 0);
+    ASSERT_EQ(*(it + 1), 1);
+    ASSERT_EQ(*(it - -1), 1);
+    ASSERT_EQ(it[2], 2);
+    ASSERT_EQ((it + 4) - it, 4);
+    ASSERT_TRUE(it == it);
+    ASSERT_TRUE(it != (it + 1));
+    ASSERT_TRUE(it < (it + 1));
+    ASSERT_TRUE(it <= (it + 1));
+    ASSERT_TRUE(it <= it);
+    ASSERT_TRUE((it + 1) > it);
+    ASSERT_TRUE((it + 1) >= it);
+    ASSERT_TRUE(it >= it);
+    ASSERT_FALSE(it != it);
+    ASSERT_FALSE(it == (it + 1));
+    ASSERT_FALSE(it > it);
+    ASSERT_FALSE(it > (it + 1));
+    ASSERT_FALSE(it < it);
+    ASSERT_FALSE((it + 1) < it);
+    ASSERT_FALSE(it >= (it + 1));
+    ASSERT_FALSE((it + 1) <= it);
+}
+
+
+TEST(IRangeIterator, RangeFor)
+{
+    std::vector<int> v;
+
+    for (auto i : gko::irange<int>(1, 4)) {
+        v.push_back(i);
+    }
+
+    ASSERT_EQ(v, std::vector<int>({1, 2, 3}));
+}
+
+
+TEST(IRangeIterator, WorksInAlgorithm)
+{
+    gko::irange<int> range(1, 15);
+
+    auto it = std::lower_bound(range.begin(), range.end(), 10);
+
+    ASSERT_EQ(*it, 10);
+    ASSERT_EQ(it - range.begin(), 9);
+}
+
+
+TEST(IRangeStrided, KnowsItsProperties)
+{
+    gko::irange_strided<int> range{0, 4, 3};
+
+    ASSERT_EQ(range.begin_index(), 0);
+    ASSERT_EQ(range.end_index(), 6);
+    ASSERT_EQ(range.stride(), 3);
+    ASSERT_EQ(*range.begin(), 0);
+    ASSERT_EQ(*range.end(), 6);
+}
+
+
+TEST(IRangeStrided, EndComputationIsCorrect)
+{
+    ASSERT_EQ(gko::irange_strided<int>(0, 3, 3).end_index(), 3);
+    ASSERT_EQ(gko::irange_strided<int>(0, 4, 3).end_index(), 6);
+    ASSERT_EQ(gko::irange_strided<int>(0, 5, 3).end_index(), 6);
+    ASSERT_EQ(gko::irange_strided<int>(0, 6, 3).end_index(), 6);
+}
+
+
+TEST(IRangeStridedIterator, IteratorProperties)
+{
+    gko::irange_strided<int> range{0, 4, 3};
+
+    auto it = range.begin();
+    auto end = range.end();
+    ASSERT_EQ(*it, 0);
+    ASSERT_EQ(*++it, 3);
+    ASSERT_TRUE(it != end);
+    ASSERT_TRUE(end != it);
+    ASSERT_FALSE(it == end);
+    ASSERT_FALSE(end == it);
+    ++it;
+    ASSERT_TRUE(it == end);
+    ASSERT_TRUE(end == it);
+    ASSERT_FALSE(it != end);
+    ASSERT_FALSE(end != it);
+}
+
+
+TEST(IRangeStridedIterator, RangeFor)
+{
+    std::vector<int> v;
+
+    for (auto i : gko::irange_strided<int>(1, 10, 2)) {
+        v.push_back(i);
+    }
+
+    ASSERT_EQ(v, std::vector<int>({1, 3, 5, 7, 9}));
+}
+
+
+#ifndef NDEBUG
+
+
+bool check_assertion_exit_code(int exit_code)
+{
+#ifdef _MSC_VER
+    // MSVC picks up the exit code incorrectly,
+    // so we can only check that it exits
+    return true;
+#else
+    return exit_code != 0;
+#endif
+}
+
+
+TEST(DeathTest, Assertions)
+{
+    // integer_iterator
+    // stride > 0
+    EXPECT_EXIT((void)(gko::integer_iterator<int>{0, 0}),
+                check_assertion_exit_code, "");
+    // a.stride_ == b.stride_
+    EXPECT_EXIT((void)(gko::integer_iterator<int>{0, 1} -
+                       gko::integer_iterator<int>{0, 2}),
+                check_assertion_exit_code, "");
+    // (*a - *b) % a.stride_ == 0
+    EXPECT_EXIT((void)(gko::integer_iterator<int>{0, 2} -
+                       gko::integer_iterator<int>{1, 2}),
+                check_assertion_exit_code, "");
+    // irange
+    // end >= begin
+    EXPECT_EXIT((void)(gko::irange<int>{1, 0}), check_assertion_exit_code, "");
+    // irange_strided
+    // end >= begin
+    EXPECT_EXIT((void)(gko::irange_strided<int>{1, 0, 1}),
+                check_assertion_exit_code, "");
+    // stride > 0
+    EXPECT_EXIT((void)(gko::irange_strided<int>{0, 1, 0}),
+                check_assertion_exit_code, "");
+}
+
+
+#endif

--- a/core/test/base/integer_range.cpp
+++ b/core/test/base/integer_range.cpp
@@ -6,6 +6,7 @@
 
 
 #include "core/base/integer_range.hpp"
+#include "core/test/utils/death_test_helpers.hpp"
 
 
 TEST(IRange, KnowsItsProperties)
@@ -147,42 +148,25 @@ TEST(IRangeStridedIterator, RangeFor)
 #ifndef NDEBUG
 
 
-bool check_assertion_exit_code(int exit_code)
-{
-#ifdef _MSC_VER
-    // MSVC picks up the exit code incorrectly,
-    // so we can only check that it exits
-    return true;
-#else
-    return exit_code != 0;
-#endif
-}
-
-
 TEST(DeathTest, Assertions)
 {
     // integer_iterator
     // stride > 0
-    EXPECT_EXIT((void)(gko::integer_iterator<int>{0, 0}),
-                check_assertion_exit_code, "");
+    EXPECT_ASSERT_FAILURE(gko::integer_iterator<int>(0, 0));
     // a.stride_ == b.stride_
-    EXPECT_EXIT((void)(gko::integer_iterator<int>{0, 1} -
-                       gko::integer_iterator<int>{0, 2}),
-                check_assertion_exit_code, "");
+    EXPECT_ASSERT_FAILURE(gko::integer_iterator<int>(0, 1) -
+                          gko::integer_iterator<int>(0, 2));
     // (*a - *b) % a.stride_ == 0
-    EXPECT_EXIT((void)(gko::integer_iterator<int>{0, 2} -
-                       gko::integer_iterator<int>{1, 2}),
-                check_assertion_exit_code, "");
+    EXPECT_ASSERT_FAILURE(gko::integer_iterator<int>(0, 2) -
+                          gko::integer_iterator<int>(1, 2));
     // irange
     // end >= begin
-    EXPECT_EXIT((void)(gko::irange<int>{1, 0}), check_assertion_exit_code, "");
+    EXPECT_ASSERT_FAILURE(gko::irange<int>(1, 0));
     // irange_strided
     // end >= begin
-    EXPECT_EXIT((void)(gko::irange_strided<int>{1, 0, 1}),
-                check_assertion_exit_code, "");
+    EXPECT_ASSERT_FAILURE(gko::irange_strided<int>(1, 0, 1));
     // stride > 0
-    EXPECT_EXIT((void)(gko::irange_strided<int>{0, 1, 0}),
-                check_assertion_exit_code, "");
+    EXPECT_ASSERT_FAILURE(gko::irange_strided<int>(0, 1, 0));
 }
 
 

--- a/core/test/base/integer_range.cpp
+++ b/core/test/base/integer_range.cpp
@@ -33,6 +33,29 @@ TEST(IRange, KnowsItsProperties)
 }
 
 
+TEST(IRange, RangeFor)
+{
+    std::vector<int> v;
+
+    for (auto i : gko::irange<int>(1, 4)) {
+        v.push_back(i);
+    }
+
+    ASSERT_EQ(v, std::vector<int>({1, 2, 3}));
+}
+
+
+TEST(IRange, WorksInAlgorithm)
+{
+    gko::irange<int> range(1, 15);
+
+    auto it = std::lower_bound(range.begin(), range.end(), 10);
+
+    ASSERT_EQ(*it, 10);
+    ASSERT_EQ(it - range.begin(), 9);
+}
+
+
 TEST(IRangeIterator, IteratorProperties)
 {
     gko::irange<int> range(0, 10);
@@ -66,29 +89,6 @@ TEST(IRangeIterator, IteratorProperties)
     ASSERT_FALSE((it + 1) < it);
     ASSERT_FALSE(it >= (it + 1));
     ASSERT_FALSE((it + 1) <= it);
-}
-
-
-TEST(IRangeIterator, RangeFor)
-{
-    std::vector<int> v;
-
-    for (auto i : gko::irange<int>(1, 4)) {
-        v.push_back(i);
-    }
-
-    ASSERT_EQ(v, std::vector<int>({1, 2, 3}));
-}
-
-
-TEST(IRangeIterator, WorksInAlgorithm)
-{
-    gko::irange<int> range(1, 15);
-
-    auto it = std::lower_bound(range.begin(), range.end(), 10);
-
-    ASSERT_EQ(*it, 10);
-    ASSERT_EQ(it - range.begin(), 9);
 }
 
 

--- a/core/test/base/segmented_range.cpp
+++ b/core/test/base/segmented_range.cpp
@@ -1,0 +1,247 @@
+// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+//
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include <iterator>
+#include <numeric>
+#include <vector>
+
+
+#include <gtest/gtest.h>
+
+
+#include "core/base/segmented_range.hpp"
+
+
+TEST(IndexedIterator, IteratorProperties)
+{
+    using iterator_type =
+        gko::indexed_iterator<std::vector<int>::const_iterator,
+                              gko::irange<int>::iterator>;
+    gko::irange_strided<int> range(0, 10, 2);
+    std::vector<int> values(10);
+    std::iota(values.begin(), values.end(), 1);
+
+    auto it = iterator_type{values.begin(), range.begin()};
+    it += 4;
+    ASSERT_EQ(*it, 9);
+    it -= 4;
+    ASSERT_EQ(*it, 1);
+    ASSERT_EQ(*it++, 1);
+    ASSERT_EQ(*++it, 5);
+    ASSERT_EQ(*it--, 5);
+    ASSERT_EQ(*--it, 1);
+    ASSERT_EQ(*(it + 1), 3);
+    ASSERT_EQ(*(it - -1), 3);
+    ASSERT_EQ(it[2], 5);
+    ASSERT_EQ((it + 4) - it, 4);
+    ASSERT_TRUE(it == it);
+    ASSERT_TRUE(it != (it + 1));
+    ASSERT_TRUE(it < (it + 1));
+    ASSERT_TRUE(it <= (it + 1));
+    ASSERT_TRUE(it <= it);
+    ASSERT_TRUE((it + 1) > it);
+    ASSERT_TRUE((it + 1) >= it);
+    ASSERT_TRUE(it >= it);
+    ASSERT_FALSE(it != it);
+    ASSERT_FALSE(it == (it + 1));
+    ASSERT_FALSE(it > it);
+    ASSERT_FALSE(it > (it + 1));
+    ASSERT_FALSE(it < it);
+    ASSERT_FALSE((it + 1) < it);
+    ASSERT_FALSE(it >= (it + 1));
+    ASSERT_FALSE((it + 1) <= it);
+}
+
+
+TEST(IndexedRange, RangeForLoop)
+{
+    gko::irange_strided<int> index_range(0, 10, 2);
+    std::vector<int> values(10);
+    std::iota(values.begin(), values.end(), 1);
+    std::vector<int> result;
+    gko::indexed_range<std::vector<int>::const_iterator,
+                       gko::irange<int>::iterator>
+        range{values.begin(), index_range.begin(), index_range.end()};
+
+    for (auto value : range) {
+        result.push_back(value);
+    }
+
+    ASSERT_EQ(result, std::vector<int>({1, 3, 5, 7, 9}));
+}
+
+
+TEST(IndexedRange, WorksInAlgorithm)
+{
+    gko::irange_strided<int> index_range(0, 10, 2);
+    std::vector<int> values(10);
+    std::iota(values.begin(), values.end(), 1);
+    std::vector<int> result;
+    gko::indexed_range<std::vector<int>::const_iterator,
+                       gko::irange<int>::iterator>
+        range{values.begin(), index_range.begin(), index_range.end()};
+
+    auto it = std::lower_bound(range.begin(), range.end(), 6);
+
+    ASSERT_EQ(*it, 7);
+    ASSERT_EQ(it - range.begin(), 3);
+}
+
+
+TEST(EnumeratingIndexedIterator, IteratorProperties)
+{
+    using iterator_type =
+        gko::enumerating_indexed_iterator<std::vector<int>::const_iterator,
+                                          gko::irange<int>::iterator>;
+    using tuple_type = typename iterator_type::enumerated;
+    gko::irange_strided<int> range(0, 10, 2);
+    std::vector<int> values(10);
+    std::iota(values.begin(), values.end(), 1);
+
+    auto it = iterator_type{values.begin(), range.begin()};
+    it += 4;
+    ASSERT_EQ(*it, tuple_type(8, 9));
+    it -= 4;
+    ASSERT_EQ(*it, tuple_type(0, 1));
+    ASSERT_EQ(*it++, tuple_type(0, 1));
+    ASSERT_EQ(*++it, tuple_type(4, 5));
+    ASSERT_EQ(*it--, tuple_type(4, 5));
+    ASSERT_EQ(*--it, tuple_type(0, 1));
+    ASSERT_EQ(*(it + 1), tuple_type(2, 3));
+    ASSERT_EQ(*(it - -1), tuple_type(2, 3));
+    ASSERT_EQ(it[2], tuple_type(4, 5));
+    ASSERT_EQ((it + 4) - it, 4);
+    ASSERT_TRUE(it == it);
+    ASSERT_TRUE(it != (it + 1));
+    ASSERT_TRUE(it < (it + 1));
+    ASSERT_TRUE(it <= (it + 1));
+    ASSERT_TRUE(it <= it);
+    ASSERT_TRUE((it + 1) > it);
+    ASSERT_TRUE((it + 1) >= it);
+    ASSERT_TRUE(it >= it);
+    ASSERT_FALSE(it != it);
+    ASSERT_FALSE(it == (it + 1));
+    ASSERT_FALSE(it > it);
+    ASSERT_FALSE(it > (it + 1));
+    ASSERT_FALSE(it < it);
+    ASSERT_FALSE((it + 1) < it);
+    ASSERT_FALSE(it >= (it + 1));
+    ASSERT_FALSE((it + 1) <= it);
+}
+
+
+TEST(EnumeratingIndexedRange, RangeForLoop)
+{
+    using range_type =
+        gko::enumerating_indexed_range<std::vector<int>::const_iterator,
+                                       gko::irange<int>::iterator>;
+    using iterator_type = typename range_type::iterator;
+    using tuple_type = typename iterator_type::enumerated;
+    gko::irange_strided<int> index_range(0, 10, 2);
+    std::vector<int> values(10);
+    std::iota(values.begin(), values.end(), 1);
+    std::vector<int> result;
+    range_type range{values.begin(), index_range.begin(), index_range.end()};
+
+    for (auto tuple : range) {
+        ASSERT_EQ(tuple.value, tuple.index + 1);
+        result.push_back(tuple.value);
+    }
+
+    ASSERT_EQ(result, std::vector<int>({1, 3, 5, 7, 9}));
+}
+
+
+TEST(EnumeratingIndexedRange, WorksInAlgorithm)
+{
+    using range_type =
+        gko::enumerating_indexed_range<std::vector<int>::const_iterator,
+                                       gko::irange<int>::iterator>;
+    using iterator_type = typename range_type::iterator;
+    using tuple_type = typename iterator_type::enumerated;
+    gko::irange_strided<int> index_range(0, 10, 2);
+    std::vector<int> values(10);
+    std::iota(values.begin(), values.end(), 1);
+    std::vector<tuple_type> result;
+    range_type range{values.begin(), index_range.begin(), index_range.end()};
+
+    std::copy(range.begin(), range.end(), std::back_inserter(result));
+
+    ASSERT_EQ(result, std::vector<tuple_type>(
+                          {tuple_type{0, 1}, tuple_type{2, 3}, tuple_type{4, 5},
+                           tuple_type{6, 7}, tuple_type{8, 9}}));
+}
+
+
+TEST(SegmentedRange, Works)
+{
+    std::vector<int> begins{3, 1, 4, 9};
+    std::vector<int> ends{3, 10, 6, 10};
+    std::vector<std::vector<int>> result_indices(begins.size());
+    gko::segmented_range<std::vector<int>::iterator> range{
+        begins.begin(), ends.begin(), static_cast<int>(begins.size())};
+
+    for (auto row : gko::irange<int>(begins.size())) {
+        for (auto nz : range[row]) {
+            result_indices[row].push_back(nz);
+        }
+    }
+
+    ASSERT_EQ(result_indices,
+              std::vector<std::vector<int>>(
+                  {{}, {1, 2, 3, 4, 5, 6, 7, 8, 9}, {4, 5}, {9}}));
+}
+
+
+TEST(SegmentedValueRange, Works)
+{
+    std::vector<int> begins{3, 1, 4, 9};
+    std::vector<int> ends{3, 10, 6, 10};
+    std::vector<int> values(ends.back());
+    std::iota(values.begin(), values.end(), 1);
+    std::vector<std::vector<int>> result_values(begins.size());
+    gko::segmented_value_range<std::vector<int>::iterator,
+                               std::vector<int>::iterator>
+        range{values.begin(), begins.begin(), ends.begin(),
+              static_cast<int>(begins.size())};
+
+    for (auto row : gko::irange<int>(begins.size())) {
+        for (auto nz : range[row]) {
+            result_values[row].push_back(nz);
+        }
+    }
+
+    ASSERT_EQ(result_values,
+              std::vector<std::vector<int>>(
+                  {{}, {2, 3, 4, 5, 6, 7, 8, 9, 10}, {5, 6}, {10}}));
+}
+
+
+TEST(SegmentedEnumeratedValueRange, Works)
+{
+    std::vector<int> begins{3, 1, 4, 9};
+    std::vector<int> ends{3, 10, 6, 10};
+    std::vector<int> values(ends.back());
+    std::iota(values.begin(), values.end(), 1);
+    std::vector<std::vector<int>> result_values(begins.size());
+    std::vector<std::vector<int>> result_indices(begins.size());
+    gko::segmented_value_range<std::vector<int>::iterator,
+                               std::vector<int>::iterator>
+        range{values.begin(), begins.begin(), ends.begin(),
+              static_cast<int>(begins.size())};
+
+    for (auto row : gko::irange<int>(begins.size())) {
+        for (auto tuple : range.enumerate(row)) {
+            result_values[row].push_back(tuple.value);
+            result_indices[row].push_back(tuple.index);
+        }
+    }
+
+    ASSERT_EQ(result_indices,
+              std::vector<std::vector<int>>(
+                  {{}, {1, 2, 3, 4, 5, 6, 7, 8, 9}, {4, 5}, {9}}));
+    ASSERT_EQ(result_values,
+              std::vector<std::vector<int>>(
+                  {{}, {2, 3, 4, 5, 6, 7, 8, 9, 10}, {5, 6}, {10}}));
+}

--- a/core/test/utils/death_test_helpers.hpp
+++ b/core/test/utils/death_test_helpers.hpp
@@ -1,0 +1,25 @@
+// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+//
+// SPDX-License-Identifier: BSD-3-Clause
+
+#ifndef GKO_CORE_TEST_UTILS_DEATH_TEST_HELPERS_HPP_
+#define GKO_CORE_TEST_UTILS_DEATH_TEST_HELPERS_HPP_
+
+
+inline bool check_assertion_exit_code(int exit_code)
+{
+#ifdef _MSC_VER
+    // MSVC picks up the exit code incorrectly,
+    // so we can only check that it exits
+    return true;
+#else
+    return exit_code != 0;
+#endif
+}
+
+
+#define EXPECT_ASSERT_FAILURE(_expression, ...) \
+    EXPECT_EXIT((void)(_expression), check_assertion_exit_code, "")
+
+
+#endif  // GKO_CORE_TEST_UTILS_DEATH_TEST_HELPERS_HPP_


### PR DESCRIPTION
This PR adds a bunch of utility abstractions for simplifying common iteration patterns in Ginkgo.

1. `irange`: Similar to the Python `range([start, ] stop[, step])` function, the `irange` provides a range that can be used in range-for loops (and the corresponding iterators in standard library algorithms):
```cpp
for (int i = 0; i < size; i++)
for (auto j = begin; j < end; j += step)
// becomes
for (auto i : irange<int>(size))
for (auto j : irange<int>(begin, end, step))
// or with C++17 CTAD
for (auto i : irange(size))
for (auto j : irange(begin, end, step))
```
The range-for loop has the added advantage that the iteration variable can be made `const`, which prevents accidentally incrementing the wrong variable, e.g. in a nested loop. The compiler generates 100% identical code for this thanks to inlining, constant folding and common subexpression elimination.

2. `(enumerating_)indexed_iterator` is pretty similar to `permuting_iterator`, but its intended usage is slightly different - it is mainly intended to provide strided access to an array, e.g. when stepping through a Csr matrix row with a whole warp, assigning nonzeros in a striped fashion. The `enumerating_` variant returns a struct `(index, value)`. The type is unlikely to be used directly, but used as additional functionality in the following segmented range abstraction.

3. `segmented_((enumerating_)value_)range` provides a range-of-ranges abstraction that can cover most of our typical Csr `row_ptrs` access patterns. The final result is intended to look as follows:
```cpp
const auto begin = row_ptrs[row];
const auto end = row_ptrs[row + 1];
for (auto nz = begin; nz < end; nz++) {
    const auto col = cols[nz];
    const auto val = vals[nz];
    // ...
}
// with C++17 CTAD and structured bindings
csr_view{row_ptrs, cols, vals, num_rows}; // the actual type will probably differ
for (auto [nz, col, value] : csr_view.enumerate(row)) {
    // ...
}
```
Additionally, I am planning to make coalesced/striped work assignment more clear with some small helpers that turn regular ranges into strided ranges based on the warp/subgroup lane and size:
```cpp
const auto begin = row_ptrs[row];
const auto end = row_ptrs[row + 1];
for (auto nz = begin + subwarp.thread_rank(); nz < end; nz += subwarp.size()) {
    const auto col = cols[nz];
    const auto val = vals[nz];
    // ...
}
// with C++17 CTAD and structured bindings
csr_view{row_ptrs, cols, vals, num_rows}; // the actual type will probably differ
for (auto [nz, col, value] : csr_view.enumerate(row).striped(subwarp)) {
    // ...
}
```
Similarly, we can provide a `blocked(subwarp)` function, which assigns a consecutive block of indices to each thread, when that is useful. The inspiration for this approach comes from cub's [striped and blocked work assignment strategies](https://nvidia.github.io/cccl/cub/index.html#flexible-data-arrangement)

TODO:
- [ ] more comprehensive tests
- [ ] device tests to check compilation
- [ ] strided ranges with group support