### PR TITLE
Add csr lookup implementation without storage

### DIFF
--- a/common/cuda_hip/matrix/csr_kernels.hpp.inc
+++ b/common/cuda_hip/matrix/csr_kernels.hpp.inc
@@ -1140,6 +1140,13 @@ __global__ __launch_bounds__(default_block_size) void build_csr_lookup(
         }
         return;
     }
+    // if hash lookup is not allowed, we are done here
+    if (!csr_lookup_allowed(allowed, sparsity_type::hash)) {
+        if (lane == 0) {
+            row_desc[row] = static_cast<int64>(sparsity_type::none);
+        }
+        return;
+    }
     // sparse hashmap storage
     // we need at least one unfilled entry to avoid infinite loops on search
     GKO_ASSERT(row_len < available_storage);

--- a/common/unified/matrix/csr_kernels.cpp
+++ b/common/unified/matrix/csr_kernels.cpp
@@ -264,8 +264,10 @@ void build_lookup_offsets(std::shared_ptr<const DefaultExecutor> exec,
                 if (csr_lookup_allowed(allowed, sparsity_type::bitmap) &&
                     bitmap_storage <= hashmap_storage) {
                     storage_offsets[row] = bitmap_storage;
-                } else {
+                } else if (csr_lookup_allowed(allowed, sparsity_type::hash)) {
                     storage_offsets[row] = hashmap_storage;
+                } else {
+                    storage_offsets[row] = 0;
                 }
             }
         },

--- a/core/matrix/csr_lookup.hpp
+++ b/core/matrix/csr_lookup.hpp
@@ -316,17 +316,7 @@ private:
 
     GKO_ATTRIBUTES GKO_INLINE IndexType lookup_search(IndexType col) const
     {
-        // binary search through the column indices
-        auto length = row_nnz;
-        IndexType offset{};
-        while (length > 0) {
-            auto half_length = length / 2;
-            auto mid = offset + half_length;
-            // this finds the first index with column index >= col
-            auto pred = local_cols[mid] >= col;
-            length = pred ? half_length : length - (half_length + 1);
-            offset = pred ? offset : mid + 1;
-        }
+        const auto offset = lookup_search_unsafe(col);
         return offset < row_nnz && local_cols[offset] == col
                    ? offset
                    : invalid_index<IndexType>();

--- a/omp/matrix/csr_kernels.cpp
+++ b/omp/matrix/csr_kernels.cpp
@@ -1367,6 +1367,7 @@ void build_lookup(std::shared_ptr<const DefaultExecutor> exec,
                   const IndexType* storage_offsets, int64* row_desc,
                   int32* storage)
 {
+    using matrix::csr::sparsity_type;
 #pragma omp parallel for
     for (size_type row = 0; row < num_rows; row++) {
         const auto row_begin = row_ptrs[row];
@@ -1386,8 +1387,12 @@ void build_lookup(std::shared_ptr<const DefaultExecutor> exec,
                 row_desc[row], local_storage, local_cols);
         }
         if (!done) {
-            csr_lookup_build_hash(row_len, available_storage, row_desc[row],
-                                  local_storage, local_cols);
+            if (csr_lookup_allowed(allowed, sparsity_type::hash)) {
+                csr_lookup_build_hash(row_len, available_storage, row_desc[row],
+                                      local_storage, local_cols);
+            } else {
+                row_desc[row] = static_cast<int64>(sparsity_type::none);
+            }
         }
     }
 }

--- a/test/matrix/csr_kernels.cpp
+++ b/test/matrix/csr_kernels.cpp
@@ -209,7 +209,8 @@ TYPED_TEST(CsrLookup, BuildLookupWorks)
     for (auto allowed :
          {sparsity_type::full | sparsity_type::bitmap | sparsity_type::hash,
           sparsity_type::bitmap | sparsity_type::hash,
-          sparsity_type::full | sparsity_type::hash, sparsity_type::hash}) {
+          sparsity_type::full | sparsity_type::hash, sparsity_type::hash,
+          sparsity_type::none}) {
         // check that storage offsets are calculated correctly
         // otherwise things might crash
         gko::kernels::reference::csr::build_lookup_offsets(


### PR DESCRIPTION
This adds another binary search-based pattern lookup mode that works without storage. This seems like a more sensible default fall-back than a hashtable.