### PR TITLE
update for icpx 2024.1

### DIFF
--- a/dpcpp/components/intrinsics.dp.hpp
+++ b/dpcpp/components/intrinsics.dp.hpp
@@ -39,13 +39,13 @@ __dpct_inline__ int popcnt(uint64 mask) { return sycl::popcount(mask); }
  */
 __dpct_inline__ int ffs(uint32 mask)
 {
-    return (mask == 0) ? 0 : (sycl::ext::intel::ctz(mask) + 1);
+    return (mask == 0) ? 0 : (sycl::ctz(mask) + 1);
 }
 
 /** @copydoc ffs */
 __dpct_inline__ int ffs(uint64 mask)
 {
-    return (mask == 0) ? 0 : (sycl::ext::intel::ctz(mask) + 1);
+    return (mask == 0) ? 0 : (sycl::ctz(mask) + 1);
 }
 
 


### PR DESCRIPTION
Resolves issue blocking: https://github.com/spack/spack/pull/43431
icpx 2024.1 no longer accepts `sycl::ext::intel::ctz`
@eugeneswalker