### PR TITLE
Fix typos and update ignore list

### DIFF
--- a/.github/_typos.toml
+++ b/.github/_typos.toml
@@ -4,7 +4,10 @@ extend-exclude = ["third_party/*", "*.svg"]
 [default.extend-words]
 dout = "dout"
 nd = "nd"
+ans = "ans"
 tht = "tht"
+thr = "thr"
+iy = "iy"
 automatical = "automatical"
 strat = "strat"
 entrie = "entrie"

--- a/dev_tools/oneapi/add_host_function.sh
+++ b/dev_tools/oneapi/add_host_function.sh
@@ -67,7 +67,7 @@ SCOPE_END=".*\}.*"
 CHECK_GLOBAL_KEYWORD=".*${GLOBAL_KEYWORD}.*"
 FUNCTION_HANDLE=""
 DURING_FUNCNAME="false"
-ANAYSIS_FUNC=" *(template *<(.*)>)?.* (.*)\((.*)\)"
+ANALYSIS_FUNC=" *(template *<(.*)>)?.* (.*)\((.*)\)"
 START_BLOCK_REX="^( *\/\*| *\/\/)"
 END_BLOCK_REX="\*\/$| *\/\/"
 IN_BLOCK=0
@@ -147,7 +147,7 @@ while IFS='' read -r line || [ -n "$line" ]; do
                 # remove additional space
                 FUNCTION_HANDLE=$(echo "${FUNCTION_HANDLE}" | sed -E 's/ +/ /g;')
 
-                if [[ "${FUNCTION_HANDLE}" =~ $ANAYSIS_FUNC ]]; then
+                if [[ "${FUNCTION_HANDLE}" =~ $ANALYSIS_FUNC ]]; then
                     TEMPLATE="${BASH_REMATCH[1]}"
                     TEMPLATE_CONTENT="${BASH_REMATCH[2]}"
                     NAME="${BASH_REMATCH[3]}"

--- a/omp/factorization/par_ilu_kernels.cpp
+++ b/omp/factorization/par_ilu_kernels.cpp
@@ -32,7 +32,7 @@ void compute_l_u_factors(std::shared_ptr<const OmpExecutor> exec,
                          matrix::Csr<ValueType, IndexType>* u_factor)
 {
     // If `iterations` is set to `Auto`, we do 3 fix-point sweeps as
-    // experiements indicate this works well for many problems.
+    // experiments indicate this works well for many problems.
     iterations = (iterations == 0) ? 3 : iterations;
     const auto col_idxs = system_matrix->get_const_col_idxs();
     const auto row_idxs = system_matrix->get_const_row_idxs();

--- a/omp/reorder/rcm_kernels.cpp
+++ b/omp/reorder/rcm_kernels.cpp
@@ -145,7 +145,7 @@ struct UbfsLinearQueue {
                     break;
                 }
 
-                // No measureable effect on performance.
+                // No measurable effect on performance.
                 GKO_MM_PAUSE();
             }
 


### PR DESCRIPTION
This PR fixes some remaining typos in our code base. Additionally, it updates the ignore list since updating typos to version >= 1.20 caused several false positives.