### PR TITLE
create the context for each intel device.

### DIFF
--- a/dpcpp/base/executor.dp.cpp
+++ b/dpcpp/base/executor.dp.cpp
@@ -283,7 +283,11 @@ void DpcppExecutor::set_device_property(dpcpp_queue_property property)
     // `wait()` would be needed after every call to a DPC++ function or kernel.
     // For example, without `in_order`, doing a copy, a kernel, and a copy, will
     // not necessarily happen in that order by default, which we need to avoid.
-    auto* queue = new sycl::queue{device, detail::get_property_list(property)};
+    // We need to create the context for each device. Otherwise, we get -999
+    // Unknown PI error after second device.
+    // Ref: https://github.com/intel/llvm/issues/10982
+    auto* queue = new sycl::queue{sycl::context(device), device,
+                                  detail::get_property_list(property)};
     queue_ = std::move(queue_manager<sycl::queue>{queue, detail::delete_queue});
 }
 


### PR DESCRIPTION
We get -999 Unknown PI error on the dgpu.
The issue will occur after second level_zero gpus. 
Although dgpu environment only see one, it might be considered as the second one physically.
From this https://github.com/celerity/celerity-runtime/pull/210, creating context manually should solve the issue.

TODO:
- [ ] Wait for the CI job to ensure it works
