### PR TITLE
Simplify the testing types

### DIFF
--- a/core/test/base/array.cpp
+++ b/core/test/base/array.cpp
@@ -40,7 +40,7 @@ protected:
     gko::array<T> x;
 };
 
-TYPED_TEST_SUITE(Array, gko::test::ValueAndIndexTypes, TypenameNameGenerator);
+TYPED_TEST_SUITE(Array, gko::test::ComplexAndPODTypes, TypenameNameGenerator);
 
 
 TYPED_TEST(Array, CanBeCreatedWithoutAnExecutor)

--- a/core/test/base/iterator_factory.cpp
+++ b/core/test/base/iterator_factory.cpp
@@ -366,7 +366,7 @@ protected:
     using value_type = ValueType;
 };
 
-TYPED_TEST_SUITE(PermuteIterator, gko::test::ValueAndIndexTypes,
+TYPED_TEST_SUITE(PermuteIterator, gko::test::ComplexAndPODTypes,
                  TypenameNameGenerator);
 
 

--- a/core/test/mpi/base/bindings.cpp
+++ b/core/test/mpi/base/bindings.cpp
@@ -24,7 +24,10 @@ protected:
     std::shared_ptr<gko::Executor> ref;
 };
 
-TYPED_TEST_SUITE(MpiBindings, gko::test::PODTypes, TypenameNameGenerator);
+using TestTypes = gko::test::merge_type_list_t<gko::test::RealValueTypes,
+                                               gko::test::IndexTypes>;
+
+TYPED_TEST_SUITE(MpiBindings, TestTypes, TypenameNameGenerator);
 
 
 TYPED_TEST(MpiBindings, CanSetADefaultwindow)

--- a/core/test/solver/cb_gmres.cpp
+++ b/core/test/solver/cb_gmres.cpp
@@ -85,17 +85,11 @@ using st_i = st_helper_type<st_enum::integer>;
 using st_ir1 = st_helper_type<st_enum::ireduce1>;
 using st_ir2 = st_helper_type<st_enum::ireduce2>;
 
-using TestTypes =
-    ::testing::Types<std::tuple<double, st_keep>, std::tuple<double, st_r1>,
-                     std::tuple<double, st_r2>, std::tuple<double, st_i>,
-                     std::tuple<double, st_ir1>, std::tuple<double, st_ir2>,
-                     std::tuple<float, st_keep>, std::tuple<float, st_r1>,
-                     std::tuple<float, st_r2>, std::tuple<float, st_i>,
-                     std::tuple<float, st_ir1>, std::tuple<float, st_ir2>,
-                     std::tuple<std::complex<double>, st_keep>,
-                     std::tuple<std::complex<double>, st_r1>,
-                     std::tuple<std::complex<double>, st_r2>,
-                     std::tuple<std::complex<float>, st_keep>>;
+using TestTypes = gko::test::merge_type_list_t<
+    gko::test::cartesian_type_product_t<
+        gko::test::ValueTypes, ::testing::Types<st_keep, st_r1, st_r2>>,
+    gko::test::cartesian_type_product_t<
+        gko::test::RealValueTypes, ::testing::Types<st_i, st_ir1, st_ir2>>>;
 
 TYPED_TEST_SUITE(CbGmres, TestTypes, PairTypenameNameGenerator);
 

--- a/core/test/utils.hpp
+++ b/core/test/utils.hpp
@@ -173,13 +173,13 @@ using ValueTypes = merge_type_list_t<RealValueTypes, ComplexValueTypes>;
 
 using IndexTypes = ::testing::Types<int32, int64>;
 
+using IntegerTypes = merge_type_list_t<IndexTypes, ::testing::Types<size_type>>;
+
 using LocalGlobalIndexTypes =
     ::testing::Types<std::tuple<int32, int32>, std::tuple<int32, int64>,
                      std::tuple<int64, int64>>;
 
-using PODTypes =
-    merge_type_list_t<merge_type_list_t<RealValueTypes, IndexTypes>,
-                      ::testing::Types<size_type>>;
+using PODTypes = merge_type_list_t<RealValueTypes, IntegerTypes>;
 
 using ComplexAndPODTypes = merge_type_list_t<ComplexValueTypes, PODTypes>;
 

--- a/core/test/utils.hpp
+++ b/core/test/utils.hpp
@@ -33,10 +33,8 @@ namespace detail {
 
 
 /**
- * This structure creates a cartesian product of the types in the left list with
- * the types of the right list and stores the combination in a std::tuple. The
- * resulting type is a list (it will be the same type wrapper as the left and
- * right list) of `std::tuple`.
+ * @see cartesian_type_product_t for details.
+ *
  * The wrapper / list type needs to be a structure that can take an arbitrary
  * amount of types. An example for this wrapper is std::tuple, but a simple
  * `template<typename... Args> struct wrapper {};` also works.
@@ -54,17 +52,6 @@ namespace detail {
  * parameter pack Result, which will be wrapped in the original OuterWrapper
  * after all parameters from the LeftList have been processed (in the last
  * specialization).
- *
- * Example:
- * ```
- * // Here, we use std::tuple as the outer type wrapper.
- * using left_list = std::tuple<a1, a2, a3>;
- * using right_list = std::tuple<b1, b2>;
- * using result = typename cartesian_type_product<left_list, right_list>::type;
- * // result = std::tuple<std::tuple<a1, b1>, std::tuple<a1, b2>,
- * //                     std::tuple<a2, b1>, std::tuple<a2, b2>,
- * //                     std::tuple<a3, b1>, std::tuple<a3, b2>>;
- * ```
  */
 template <typename LeftList, typename RightList, typename... Result>
 struct cartesian_type_product {};
@@ -87,25 +74,11 @@ struct cartesian_type_product<OuterWrapper<>, OuterWrapper<RightArgs...>,
 
 
 /**
- * This structure expects the left list to have all elements of the type
- * std::tuple and the right list of elements you want to add to those tuples. It
- * creates a new list where it adds all combinations of the std::tuple with the
- * new element list as a new member of the std::tuple to the right side.
+ * @see add_to_cartesian_type_product_t for details.
  *
- * It can be used to create a cartesian product with more than two lists by
- * using the cartesian_type_product initially for the left argument, followed by
- * this structure for each additional list.
- * Example:
- * ```
- * template<typename... Args>
- * using t = std::tuple<Args>;  // use this alias to increase readability
- * using left_combinations = t<t<a1, b1>, t<a1, b2>>;
- * using right_new = t<n1, n2>;
- * using new_list =
- *     typename add_to_cartesian_type_product<left_combinations,
- *                                            right_new>::type;
- * // new_list = t<t<a1, b1, n1>, t<a1, b1, n2>, t<a1, b2, n1>, t<a1, b2, n2>>;
- * ```
+ * Uses a similar technique to cartesian_type_product.
+ * It also uses the parameter pack Result to store the interim results, which
+ * will be put in the OuterWrapper after all inputs have been processed.
  */
 template <typename ExistingCombinationList, typename NewElementList,
           typename... Result>
@@ -133,19 +106,7 @@ struct add_to_cartesian_type_product<
 
 
 /**
- * Does the same as add_to_cartesian_type_product with the only difference that
- * the new element will be added to the left side. The template parameter order
- * is also flipped, so the new list is now on the left side.
- * Example:
- * ```
- * template<typename... Args> using t = std::tuple<Args>;
- * using right_combinations = t<t<a1, b1>, t<a1, b2>>;
- * using left_new = t<n1, n2>;
- * using new_list =
- *     typename add_to_cartesian_type_product_left<left_new,
- *                                                 right_combinations>::type;
- * // new_list = t<t<n1, a1, b1>, t<n2, a1, b1>, t<n1, a1, b2>, t<n2, a1, b2>>;
- * ```
+ * @see add_to_cartesian_type_product_left_t for details.
  */
 template <typename NewElementList, typename ExistingCombinationList,
           typename... Result>
@@ -173,11 +134,7 @@ struct add_to_cartesian_type_product_left<OuterWrapper<NewElementArgs...>,
 
 
 /**
- * Merges two lists into a single list.
- * The left and right list need to use the same type wrapper, which will also be
- * the resulting wrapper containing elements of both lists. The order of the
- * left and right list are preserved. The resulting list will have all elements
- * of the left list, followed by all elements of the right list.
+ * @see merge_type_lists_t for details.
  */
 template <typename FirstList, typename SecondList>
 struct merge_type_list {};
@@ -190,15 +147,7 @@ struct merge_type_list<OuterWrapper<Args1...>, OuterWrapper<Args2...>> {
 
 
 /**
- * This structure can change the outer type wrapper to the new, given one.
- * Example:
- * ```
- * template <typename... Args>
- * struct type_wrapper {};
- * using old_list = std::tuple<int, double, short>;
- * using new_list = typename change_outer_wrapper<type_wrapper, old_list>::type;
- * // new_list = type_wrapper<int, double, short>;
- * ```
+ * @see change_outer_wrapper_t for details.
  */
 template <template <typename...> class NewOuterWrapper,
           typename OldOuterWrapper>
@@ -212,20 +161,14 @@ struct change_outer_wrapper<NewOuterWrapper, OldOuterWrapper<Args...>> {
 
 
 /**
- * Creates a type list (the outer wrapper stays the same) where each original
- * type is wrapped into the given NewInnerWrapper. Example:
- * ```
- * using new_type =
- *     typename add_internal_wrapper<std::complex,
- *                                   std::tuple<float, double>>::type;
- * // new_type = std::tuple<std::complex<float>, std::complex<double>>;
+ * @see add_inner_wrapper_t for details.
  */
 template <template <typename...> class NewInnerWrapper, typename ListType>
-struct add_internal_wrapper {};
+struct add_inner_wrapper {};
 
 template <template <typename...> class NewInnerWrapper,
           template <typename...> class OuterWrapper, typename... Args>
-struct add_internal_wrapper<NewInnerWrapper, OuterWrapper<Args...>> {
+struct add_inner_wrapper<NewInnerWrapper, OuterWrapper<Args...>> {
     using type = OuterWrapper<NewInnerWrapper<Args>...>;
 };
 
@@ -251,7 +194,7 @@ struct add_internal_wrapper<NewInnerWrapper, OuterWrapper<Args...>> {
  *
  * @tparam LeftList  A wrapper type (like std::tuple) containing the list of
  *                   types that you want to create the cartesian product with.
- *                   The paremeters of this list will be the left type in the
+ *                   The parameters of this list will be the left type in the
  *                   resulting `std::tuple`
  * @tparam RightList  Similar to the LeftList. Must use the same outer wrapper
  *                    as the LeftList.
@@ -267,8 +210,8 @@ using cartesian_type_product_t =
  * This structure expects the left list to have all elements of the type
  * std::tuple (as it is returned from cartesian_type_product_t) and the right
  * list of elements you want to add to those tuples.
- * creates a new list where it adds all combinations of the std::tuple with the
- * new element list as a new member of the std::tuple to the right side.
+ * It creates a new list where it adds all combinations of the std::tuple with
+ * the new element list as a new member of the std::tuple to the right side.
  * Example:
  * ```
  * template<typename... Args>
@@ -359,7 +302,7 @@ using change_outer_wrapper_t =
  * Example:
  * ```
  * using new_type =
- *     add_internal_wrapper<std::complex, std::tuple<float, double>>;
+ *     add_inner_wrapper<std::complex, std::tuple<float, double>>;
  * // new_type = std::tuple<std::complex<float>, std::complex<double>>;
  * ```
  *
@@ -368,8 +311,8 @@ using change_outer_wrapper_t =
  * @tparam ListType  The list of types where you want to add a wrapper to each
  */
 template <template <typename...> class NewInnerWrapper, typename ListType>
-using add_internal_wrapper_t =
-    typename detail::add_internal_wrapper<NewInnerWrapper, ListType>::type;
+using add_inner_wrapper_t =
+    typename detail::add_inner_wrapper<NewInnerWrapper, ListType>::type;
 
 
 using RealValueTypes =
@@ -379,7 +322,7 @@ using RealValueTypes =
     ::testing::Types<float, double>;
 #endif
 
-using ComplexValueTypes = add_internal_wrapper_t<std::complex, RealValueTypes>;
+using ComplexValueTypes = add_inner_wrapper_t<std::complex, RealValueTypes>;
 
 using ValueTypes = merge_type_list_t<RealValueTypes, ComplexValueTypes>;
 

--- a/core/test/utils.hpp
+++ b/core/test/utils.hpp
@@ -32,6 +32,40 @@ namespace test {
 namespace detail {
 
 
+/**
+ * This structure creates a cartesian product of the types in the left list with
+ * the types of the right list and stores the combination in a std::tuple. The
+ * resulting type is a list (it will be the same type wrapper as the left and
+ * right list) of `std::tuple`.
+ * The wrapper / list type needs to be a structure that can take an arbitrary
+ * amount of types. An example for this wrapper is std::tuple, but a simple
+ * `template<typename... Args> struct wrapper {};` also works.
+ * Both the left and right list need to use the same wrapper, otherwise, the
+ * type specialization fails.
+ *
+ * This structure uses partial specialization to:
+ * - remove the OuterWrapper of both the left and right list;
+ * - extracts a single element of the left list and combines it with all
+ *   elements of the right list;
+ * - after no elements remain in the left list, put all generated combinations
+ *   together and wrap them in an OuterWrapper again
+ *
+ * This structure uses inheritance to store the combinations it creates in the
+ * parameter pack Result, which will be wrapped in the original OuterWrapper
+ * after all parameters from the LeftList have been processed (in the last
+ * specialization).
+ *
+ * Example:
+ * ```
+ * // Here, we use std::tuple as the outer type wrapper.
+ * using left_list = std::tuple<a1, a2, a3>;
+ * using right_list = std::tuple<b1, b2>;
+ * using result = typename cartesian_type_product<left_list, right_list>::type;
+ * // result = std::tuple<std::tuple<a1, b1>, std::tuple<a1, b2>,
+ * //                     std::tuple<a2, b1>, std::tuple<a2, b2>,
+ * //                     std::tuple<a3, b1>, std::tuple<a3, b2>>;
+ * ```
+ */
 template <typename LeftList, typename RightList, typename... Result>
 struct cartesian_type_product {};
 
@@ -51,6 +85,28 @@ struct cartesian_type_product<OuterWrapper<>, OuterWrapper<RightArgs...>,
     using type = OuterWrapper<Result...>;
 };
 
+
+/**
+ * This structure expects the left list to have all elements of the type
+ * std::tuple and the right list of elements you want to add to those tuples. It
+ * creates a new list where it adds all combinations of the std::tuple with the
+ * new element list as a new member of the std::tuple to the right side.
+ *
+ * It can be used to create a cartesian product with more than two lists by
+ * using the cartesian_type_product initially for the left argument, followed by
+ * this structure for each additional list.
+ * Example:
+ * ```
+ * template<typename... Args>
+ * using t = std::tuple<Args>;  // use this alias to increase readability
+ * using left_combinations = t<t<a1, b1>, t<a1, b2>>;
+ * using right_new = t<n1, n2>;
+ * using new_list =
+ *     typename add_to_cartesian_type_product<left_combinations,
+ *                                            right_new>::type;
+ * // new_list = t<t<a1, b1, n1>, t<a1, b1, n2>, t<a1, b2, n1>, t<a1, b2, n2>>;
+ * ```
+ */
 template <typename ExistingCombinationList, typename NewElementList,
           typename... Result>
 struct add_to_cartesian_type_product {};
@@ -75,6 +131,22 @@ struct add_to_cartesian_type_product<
     using type = OuterWrapper<Result...>;
 };
 
+
+/**
+ * Does the same as add_to_cartesian_type_product with the only difference that
+ * the new element will be added to the left side. The template parameter order
+ * is also flipped, so the new list is now on the left side.
+ * Example:
+ * ```
+ * template<typename... Args> using t = std::tuple<Args>;
+ * using right_combinations = t<t<a1, b1>, t<a1, b2>>;
+ * using left_new = t<n1, n2>;
+ * using new_list =
+ *     typename add_to_cartesian_type_product_left<left_new,
+ *                                                 right_combinations>::type;
+ * // new_list = t<t<n1, a1, b1>, t<n2, a1, b1>, t<n1, a1, b2>, t<n2, a1, b2>>;
+ * ```
+ */
 template <typename NewElementList, typename ExistingCombinationList,
           typename... Result>
 struct add_to_cartesian_type_product_left {};
@@ -99,6 +171,14 @@ struct add_to_cartesian_type_product_left<OuterWrapper<NewElementArgs...>,
     using type = OuterWrapper<Result...>;
 };
 
+
+/**
+ * Merges two lists into a single list.
+ * The left and right list need to use the same type wrapper, which will also be
+ * the resulting wrapper containing elements of both lists. The order of the
+ * left and right list are preserved. The resulting list will have all elements
+ * of the left list, followed by all elements of the right list.
+ */
 template <typename FirstList, typename SecondList>
 struct merge_type_list {};
 
@@ -109,6 +189,17 @@ struct merge_type_list<OuterWrapper<Args1...>, OuterWrapper<Args2...>> {
 };
 
 
+/**
+ * This structure can change the outer type wrapper to the new, given one.
+ * Example:
+ * ```
+ * template <typename... Args>
+ * struct type_wrapper {};
+ * using old_list = std::tuple<int, double, short>;
+ * using new_list = typename change_outer_wrapper<type_wrapper, old_list>::type;
+ * // new_list = type_wrapper<int, double, short>;
+ * ```
+ */
 template <template <typename...> class NewOuterWrapper,
           typename OldOuterWrapper>
 struct change_outer_wrapper {};
@@ -120,6 +211,15 @@ struct change_outer_wrapper<NewOuterWrapper, OldOuterWrapper<Args...>> {
 };
 
 
+/**
+ * Creates a type list (the outer wrapper stays the same) where each original
+ * type is wrapped into the given NewInnerWrapper. Example:
+ * ```
+ * using new_type =
+ *     typename add_internal_wrapper<std::complex,
+ *                                   std::tuple<float, double>>::type;
+ * // new_type = std::tuple<std::complex<float>, std::complex<double>>;
+ */
 template <template <typename...> class NewInnerWrapper, typename ListType>
 struct add_internal_wrapper {};
 
@@ -133,31 +233,143 @@ struct add_internal_wrapper<NewInnerWrapper, OuterWrapper<Args...>> {
 }  // namespace detail
 
 
+/**
+ * This type alias creates a cartesian product of the types in the left list
+ * with the types of the right list and stores the combination in a std::tuple.
+ * The resulting type is a list (it will be the same type wrapper as the left
+ * and right list) of `std::tuple`.
+ * Example:
+ * ```
+ * // Here, we use std::tuple as the outer type wrapper.
+ * using left_list = std::tuple<a1, a2, a3>;
+ * using right_list = std::tuple<b1, b2>;
+ * using result = cartesian_type_product_t<left_list, right_list>;
+ * // result = std::tuple<std::tuple<a1, b1>, std::tuple<a1, b2>,
+ * //                     std::tuple<a2, b1>, std::tuple<a2, b2>,
+ * //                     std::tuple<a3, b1>, std::tuple<a3, b2>>;
+ * ```
+ *
+ * @tparam LeftList  A wrapper type (like std::tuple) containing the list of
+ *                   types that you want to create the cartesian product with.
+ *                   The paremeters of this list will be the left type in the
+ *                   resulting `std::tuple`
+ * @tparam RightList  Similar to the LeftList. Must use the same outer wrapper
+ *                    as the LeftList.
+ */
 template <typename LeftList, typename RightList>
 using cartesian_type_product_t =
     typename detail::cartesian_type_product<LeftList, RightList>::type;
 
+/**
+ * This type alias is intended to be used with cartesian_type_product_t in order
+ * to create a more than two dimensional cartesian product by adding one element
+ * to the result per call.
+ * This structure expects the left list to have all elements of the type
+ * std::tuple (as it is returned from cartesian_type_product_t) and the right
+ * list of elements you want to add to those tuples.
+ * creates a new list where it adds all combinations of the std::tuple with the
+ * new element list as a new member of the std::tuple to the right side.
+ * Example:
+ * ```
+ * template<typename... Args>
+ * using t = std::tuple<Args>;  // use this alias to increase readability
+ * using left_combinations = t<t<a1, b1>, t<a1, b2>>;
+ * using right_new = t<n1, n2>;
+ * using new_list =
+ *     add_to_cartesian_type_product_t<left_combinations, right_new>;
+ * // new_list = t<t<a1, b1, n1>, t<a1, b1, n2>, t<a1, b2, n1>, t<a1, b2, n2>>;
+ * ```
+ *
+ * @tparam ExistingCombinationList  An outer type wrapper containing different
+ *                                  std::tuples that you want to add elements to
+ * @tparam NewElementList  The list of new elements (using the same outer
+ *                         wrapper as ExistingCombinationList) you want to
+ *                         create all possible combinations with. These elements
+ *                         will be added to the right of each std::tuple
+ */
 template <typename ExistingCombinationList, typename NewElementList>
 using add_to_cartesian_type_product_t =
     typename detail::add_to_cartesian_type_product<ExistingCombinationList,
                                                    NewElementList>::type;
 
+/**
+ * This type alias is very similar to add_to_cartesian_type_product_t. It only
+ * differs in where the new element is added to the `std::tuple`, which is to
+ * the left here, and the order of the parameter.
+ * Example:
+ * ```
+ * template<typename... Args> using t = std::tuple<Args>;
+ * using right_combinations = t<t<a1, b1>, t<a1, b2>>;
+ * using left_new = t<n1, n2>;
+ * using new_list =
+ *     add_to_cartesian_type_product_left_t<left_new, right_combinations>;
+ * // new_list = t<t<n1, a1, b1>, t<n2, a1, b1>, t<n1, a1, b2>, t<n2, a1, b2>>;
+ * ```
+ *
+ * @tparam NewElementList  The list of new elements (using the same outer
+ *                         wrapper as ExistingCombinationList) you want to
+ *                         create all possible combinations with. These elements
+ *                         will be added to the left of each std::tuple
+ * @tparam ExistingCombinationList  An outer type wrapper containing different
+ *                                  std::tuples that you want to add elements to
+ */
 template <typename NewElementList, typename ExistingCombinationList>
 using add_to_cartesian_type_product_left_t =
     typename detail::add_to_cartesian_type_product_left<
         NewElementList, ExistingCombinationList>::type;
 
+/**
+ * Merges two lists into a single list.
+ * The left and right list need to use the same type wrapper, which will also be
+ * the resulting wrapper containing elements of both lists. The order of the
+ * left and right list are preserved. The resulting list will have all elements
+ * of the left list, followed by all elements of the right list.
+ *
+ * @tparam FirstList  The first list of types
+ * @tparam SecondList  The second list of types. The type wrapper needs to be
+ *                     the same as for FirstList.
+ */
 template <typename FirstList, typename SecondList>
 using merge_type_list_t =
     typename detail::merge_type_list<FirstList, SecondList>::type;
 
-template <template <typename...> class NewInnerWrapper, typename ListType>
-using add_internal_wrapper_t =
-    typename detail::add_internal_wrapper<NewInnerWrapper, ListType>::type;
-
+/**
+ * This type alias can change the outer type wrapper to the new, given one.
+ * Example:
+ * ```
+ * template <typename... Args>
+ * struct type_wrapper {};
+ * using old_list = std::tuple<int, double, short>;
+ * using new_list = change_outer_wrapper_t<type_wrapper, old_list>;
+ * // new_list = type_wrapper<int, double, short>;
+ * ```
+ *
+ * @tparam NewOuterWrapper  the new wrapper you want to use as the new outer
+ *                          wrapper
+ * @tparam ListType  The list of types where you want to replace the outer
+ *                   wrapper.
+ */
 template <template <typename...> class NewOuterWrapper, typename ListType>
 using change_outer_wrapper_t =
     typename detail::change_outer_wrapper<NewOuterWrapper, ListType>::type;
+
+/**
+ * Creates a type list (the outer wrapper stays the same) where each original
+ * type is wrapped into the given NewInnerWrapper.
+ * Example:
+ * ```
+ * using new_type =
+ *     add_internal_wrapper<std::complex, std::tuple<float, double>>;
+ * // new_type = std::tuple<std::complex<float>, std::complex<double>>;
+ * ```
+ *
+ * @tparam NewInnerWrapper  the new wrapper you want to use to wrap each type
+ *                          in the list
+ * @tparam ListType  The list of types where you want to add a wrapper to each
+ */
+template <template <typename...> class NewInnerWrapper, typename ListType>
+using add_internal_wrapper_t =
+    typename detail::add_internal_wrapper<NewInnerWrapper, ListType>::type;
 
 
 using RealValueTypes =

--- a/core/test/utils.hpp
+++ b/core/test/utils.hpp
@@ -203,6 +203,7 @@ template <typename LeftList, typename RightList>
 using cartesian_type_product_t =
     typename detail::cartesian_type_product<LeftList, RightList>::type;
 
+
 /**
  * This type alias is intended to be used with cartesian_type_product_t in order
  * to create a more than two dimensional cartesian product by adding one element
@@ -235,6 +236,7 @@ using add_to_cartesian_type_product_t =
     typename detail::add_to_cartesian_type_product<ExistingCombinationList,
                                                    NewElementList>::type;
 
+
 /**
  * This type alias is very similar to add_to_cartesian_type_product_t. It only
  * differs in where the new element is added to the `std::tuple`, which is to
@@ -261,6 +263,7 @@ using add_to_cartesian_type_product_left_t =
     typename detail::add_to_cartesian_type_product_left<
         NewElementList, ExistingCombinationList>::type;
 
+
 /**
  * Merges two lists into a single list.
  * The left and right list need to use the same type wrapper, which will also be
@@ -275,6 +278,7 @@ using add_to_cartesian_type_product_left_t =
 template <typename FirstList, typename SecondList>
 using merge_type_list_t =
     typename detail::merge_type_list<FirstList, SecondList>::type;
+
 
 /**
  * This type alias can change the outer type wrapper to the new, given one.
@@ -295,6 +299,7 @@ using merge_type_list_t =
 template <template <typename...> class NewOuterWrapper, typename ListType>
 using change_outer_wrapper_t =
     typename detail::change_outer_wrapper<NewOuterWrapper, ListType>::type;
+
 
 /**
  * Creates a type list (the outer wrapper stays the same) where each original

--- a/core/test/utils/CMakeLists.txt
+++ b/core/test/utils/CMakeLists.txt
@@ -1,3 +1,4 @@
+ginkgo_create_test(utils_test)
 ginkgo_create_test(array_generator_test)
 ginkgo_create_test(assertions_test)
 ginkgo_create_test(matrix_generator_test)

--- a/core/test/utils/utils_test.cpp
+++ b/core/test/utils/utils_test.cpp
@@ -11,9 +11,6 @@
 #include <gtest/gtest.h>
 
 
-namespace {
-
-
 using i_type = std::integral_constant<int, 42>;
 using t_type = std::tuple<int>;
 
@@ -317,6 +314,3 @@ TEST(TypeListHelper, AddToCartesianTypeProductLeftEmpty)
         gko::test::add_to_cartesian_type_product_left_t<tuple_empty, tlist3>,
         tuple_empty>();
 }
-
-
-}  // namespace

--- a/core/test/utils/utils_test.cpp
+++ b/core/test/utils/utils_test.cpp
@@ -2,15 +2,13 @@
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
+#include "core/test/utils.hpp"
+
 #include <complex>
 #include <tuple>
 #include <type_traits>
 
-
 #include <gtest/gtest.h>
-
-
-#include "core/test/utils.hpp"
 
 
 namespace {

--- a/core/test/utils/utils_test.cpp
+++ b/core/test/utils/utils_test.cpp
@@ -1,0 +1,236 @@
+// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+//
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include <complex>
+#include <tuple>
+#include <type_traits>
+
+
+#include <gtest/gtest.h>
+
+
+#include "core/test/utils.hpp"
+
+
+namespace {
+
+
+using i_type = std::integral_constant<int, 42>;
+using t_type = std::tuple<int>;
+
+using testing_types1 = testing::Types<double>;
+using testing_types2 = testing::Types<t_type, int>;
+using testing_types3 = testing::Types<i_type, short, float>;
+
+using tuple_types1 = std::tuple<double>;
+using tuple_types2 = std::tuple<t_type, int>;
+using tuple_types3 = std::tuple<i_type, short, float>;
+
+template <typename... Args>
+struct type_list {};
+
+
+TEST(TypeListHelper, ChangeOuterWrapper1)
+{
+    testing::StaticAssertTypeEq<
+        gko::test::change_outer_wrapper_t<std::tuple, testing_types1>,
+        tuple_types1>();
+    testing::StaticAssertTypeEq<
+        gko::test::change_outer_wrapper_t<std::tuple, testing_types2>,
+        tuple_types2>();
+    testing::StaticAssertTypeEq<
+        gko::test::change_outer_wrapper_t<std::tuple, testing_types3>,
+        tuple_types3>();
+    testing::StaticAssertTypeEq<
+        gko::test::change_outer_wrapper_t<testing::Types, tuple_types1>,
+        testing_types1>();
+    testing::StaticAssertTypeEq<
+        gko::test::change_outer_wrapper_t<testing::Types, tuple_types2>,
+        testing_types2>();
+    testing::StaticAssertTypeEq<
+        gko::test::change_outer_wrapper_t<testing::Types, tuple_types3>,
+        testing_types3>();
+}
+
+
+TEST(TypeListHelper, ChangeOuterWrapper2)
+{
+    using alternative_list1 = type_list<i_type, t_type, double>;
+    using expected_ow2 = testing::Types<i_type, t_type, double>;
+
+    testing::StaticAssertTypeEq<
+        gko::test::change_outer_wrapper_t<testing::Types, alternative_list1>,
+        expected_ow2>();
+}
+
+
+TEST(TypeListHelper, AddInternalWrapperTuple)
+{
+    using expected_iw1 = testing::Types<std::tuple<i_type>, std::tuple<short>,
+                                        std::tuple<float>>;
+    testing::StaticAssertTypeEq<
+        gko::test::add_internal_wrapper_t<std::tuple, testing_types3>,
+        expected_iw1>();
+    testing::StaticAssertTypeEq<
+        gko::test::add_internal_wrapper_t<std::tuple, tuple_types3>,
+        gko::test::change_outer_wrapper_t<std::tuple, expected_iw1>>();
+}
+
+
+TEST(TypeListHelper, AddInternalWrapperComplex)
+{
+    using expected_iw2 = testing::Types<std::complex<double>>;
+
+    testing::StaticAssertTypeEq<
+        gko::test::add_internal_wrapper_t<std::complex, testing_types1>,
+        expected_iw2>();
+    testing::StaticAssertTypeEq<
+        gko::test::add_internal_wrapper_t<std::complex, tuple_types1>,
+        gko::test::change_outer_wrapper_t<std::tuple, expected_iw2>>();
+}
+
+
+TEST(TypeListHelper, MergeTypeListLarge)
+{
+    using expected_m1 = testing::Types<i_type, short, float, t_type, int>;
+
+    testing::StaticAssertTypeEq<
+        gko::test::merge_type_list_t<testing_types3, testing_types2>,
+        expected_m1>();
+    testing::StaticAssertTypeEq<
+        gko::test::merge_type_list_t<tuple_types3, tuple_types2>,
+        gko::test::change_outer_wrapper_t<std::tuple, expected_m1>>();
+}
+
+
+TEST(TypeListHelper, MergeTypeListEmpty)
+{
+    using expected_m2 = testing::Types<double>;
+
+    testing::StaticAssertTypeEq<
+        gko::test::merge_type_list_t<testing_types1, testing::Types<>>,
+        expected_m2>();
+    testing::StaticAssertTypeEq<
+        gko::test::merge_type_list_t<tuple_types1, std::tuple<>>,
+        gko::test::change_outer_wrapper_t<std::tuple, expected_m2>>();
+    testing::StaticAssertTypeEq<
+        gko::test::merge_type_list_t<testing::Types<>, testing_types1>,
+        expected_m2>();
+    testing::StaticAssertTypeEq<
+        gko::test::merge_type_list_t<std::tuple<>, tuple_types1>,
+        gko::test::change_outer_wrapper_t<std::tuple, expected_m2>>();
+}
+
+
+TEST(TypeListHelper, CartesianTypeProductLarge)
+{
+    using expected_c1 =
+        testing::Types<std::tuple<t_type, i_type>, std::tuple<t_type, short>,
+                       std::tuple<t_type, float>, std::tuple<int, i_type>,
+                       std::tuple<int, short>, std::tuple<int, float>>;
+
+    testing::StaticAssertTypeEq<
+        gko::test::cartesian_type_product_t<testing_types2, testing_types3>,
+        expected_c1>();
+    testing::StaticAssertTypeEq<
+        gko::test::cartesian_type_product_t<tuple_types2, tuple_types3>,
+        gko::test::change_outer_wrapper_t<std::tuple, expected_c1>>();
+}
+
+
+TEST(TypeListHelper, CartesianTypeProductSmall)
+{
+    using expected_c2 =
+        testing::Types<std::tuple<double, t_type>, std::tuple<double, int>>;
+
+    testing::StaticAssertTypeEq<
+        gko::test::cartesian_type_product_t<testing_types1, testing_types2>,
+        expected_c2>();
+    testing::StaticAssertTypeEq<
+        gko::test::cartesian_type_product_t<tuple_types1, tuple_types2>,
+        gko::test::change_outer_wrapper_t<std::tuple, expected_c2>>();
+}
+
+
+TEST(TypeListHelper, AddToCartesianTypeProductLarge)
+{
+    using list1 =
+        testing::Types<std::tuple<double, int>, std::tuple<double, short>,
+                       std::tuple<float, int>, std::tuple<float, short>>;
+    using list2 = testing::Types<long, char>;
+    using tlist1 = gko::test::change_outer_wrapper_t<std::tuple, list1>;
+    using tlist2 = std::tuple<long, char>;
+    using expected_a1 = testing::Types<
+        std::tuple<double, int, long>, std::tuple<double, int, char>,
+        std::tuple<double, short, long>, std::tuple<double, short, char>,
+        std::tuple<float, int, long>, std::tuple<float, int, char>,
+        std::tuple<float, short, long>, std::tuple<float, short, char>>;
+
+    testing::StaticAssertTypeEq<
+        gko::test::add_to_cartesian_type_product_t<list1, list2>,
+        expected_a1>();
+    testing::StaticAssertTypeEq<
+        gko::test::add_to_cartesian_type_product_t<tlist1, tlist2>,
+        gko::test::change_outer_wrapper_t<std::tuple, expected_a1>>();
+}
+
+
+TEST(TypeListHelper, AddToCartesianTypeProductSmall)
+{
+    using list3 = testing::Types<std::tuple<long>>;
+    using list4 = testing::Types<double>;
+    using tlist3 = std::tuple<std::tuple<long>>;
+    using tlist4 = std::tuple<double>;
+    using expected_a2 = testing::Types<std::tuple<long, double>>;
+
+    testing::StaticAssertTypeEq<
+        gko::test::add_to_cartesian_type_product_t<list3, list4>,
+        expected_a2>();
+    testing::StaticAssertTypeEq<
+        gko::test::add_to_cartesian_type_product_t<tlist3, tlist4>,
+        gko::test::change_outer_wrapper_t<std::tuple, expected_a2>>();
+}
+
+
+TEST(TypeListHelper, AddToCartesianTypeProductLeftLarge)
+{
+    using list1 = testing::Types<long, char>;
+    using list2 =
+        testing::Types<std::tuple<double, int>, std::tuple<double, short>,
+                       std::tuple<float, int>, std::tuple<float, short>>;
+    using tlist1 = std::tuple<long, char>;
+    using tlist2 = gko::test::change_outer_wrapper_t<std::tuple, list2>;
+    using expected_a1 = testing::Types<
+        std::tuple<long, double, int>, std::tuple<char, double, int>,
+        std::tuple<long, double, short>, std::tuple<char, double, short>,
+        std::tuple<long, float, int>, std::tuple<char, float, int>,
+        std::tuple<long, float, short>, std::tuple<char, float, short>>;
+
+    testing::StaticAssertTypeEq<
+        gko::test::add_to_cartesian_type_product_left_t<list1, list2>,
+        expected_a1>();
+    testing::StaticAssertTypeEq<
+        gko::test::add_to_cartesian_type_product_left_t<tlist1, tlist2>,
+        gko::test::change_outer_wrapper_t<std::tuple, expected_a1>>();
+}
+
+
+TEST(TypeListHelper, AddToCartesianTypeProductLeftSmall)
+{
+    using list3 = testing::Types<double>;
+    using list4 = testing::Types<std::tuple<long>>;
+    using tlist3 = std::tuple<double>;
+    using tlist4 = std::tuple<std::tuple<long>>;
+    using expected_a2 = testing::Types<std::tuple<double, long>>;
+
+    testing::StaticAssertTypeEq<
+        gko::test::add_to_cartesian_type_product_left_t<list3, list4>,
+        expected_a2>();
+    testing::StaticAssertTypeEq<
+        gko::test::add_to_cartesian_type_product_left_t<tlist3, tlist4>,
+        gko::test::change_outer_wrapper_t<std::tuple, expected_a2>>();
+}
+
+
+}  // namespace

--- a/core/test/utils/utils_test.cpp
+++ b/core/test/utils/utils_test.cpp
@@ -22,16 +22,18 @@ using t_type = std::tuple<int>;
 using testing_types1 = testing::Types<double>;
 using testing_types2 = testing::Types<t_type, int>;
 using testing_types3 = testing::Types<i_type, short, float>;
+using testing_empty = testing::Types<>;
 
 using tuple_types1 = std::tuple<double>;
 using tuple_types2 = std::tuple<t_type, int>;
 using tuple_types3 = std::tuple<i_type, short, float>;
+using tuple_empty = std::tuple<>;
 
 template <typename... Args>
 struct type_list {};
 
 
-TEST(TypeListHelper, ChangeOuterWrapper1)
+TEST(TypeListHelper, ChangeOuterWrapperPredefined)
 {
     testing::StaticAssertTypeEq<
         gko::test::change_outer_wrapper_t<std::tuple, testing_types1>,
@@ -54,14 +56,28 @@ TEST(TypeListHelper, ChangeOuterWrapper1)
 }
 
 
-TEST(TypeListHelper, ChangeOuterWrapper2)
+TEST(TypeListHelper, ChangeOuterWrapperCustomType)
 {
-    using alternative_list1 = type_list<i_type, t_type, double>;
-    using expected_ow2 = testing::Types<i_type, t_type, double>;
+    using type_list1 = type_list<i_type, t_type, double>;
+    using testing_list1 = testing::Types<i_type, t_type, double>;
 
     testing::StaticAssertTypeEq<
-        gko::test::change_outer_wrapper_t<testing::Types, alternative_list1>,
-        expected_ow2>();
+        gko::test::change_outer_wrapper_t<testing::Types, type_list1>,
+        testing_list1>();
+    testing::StaticAssertTypeEq<
+        gko::test::change_outer_wrapper_t<type_list, testing_list1>,
+        type_list1>();
+}
+
+
+TEST(TypeListHelper, ChangeOuterWrapperEmpty)
+{
+    testing::StaticAssertTypeEq<
+        gko::test::change_outer_wrapper_t<testing::Types, tuple_empty>,
+        testing_empty>();
+    testing::StaticAssertTypeEq<
+        gko::test::change_outer_wrapper_t<std::tuple, testing_empty>,
+        tuple_empty>();
 }
 
 
@@ -69,11 +85,12 @@ TEST(TypeListHelper, AddInternalWrapperTuple)
 {
     using expected_iw1 = testing::Types<std::tuple<i_type>, std::tuple<short>,
                                         std::tuple<float>>;
+
     testing::StaticAssertTypeEq<
-        gko::test::add_internal_wrapper_t<std::tuple, testing_types3>,
+        gko::test::add_inner_wrapper_t<std::tuple, testing_types3>,
         expected_iw1>();
     testing::StaticAssertTypeEq<
-        gko::test::add_internal_wrapper_t<std::tuple, tuple_types3>,
+        gko::test::add_inner_wrapper_t<std::tuple, tuple_types3>,
         gko::test::change_outer_wrapper_t<std::tuple, expected_iw1>>();
 }
 
@@ -83,11 +100,21 @@ TEST(TypeListHelper, AddInternalWrapperComplex)
     using expected_iw2 = testing::Types<std::complex<double>>;
 
     testing::StaticAssertTypeEq<
-        gko::test::add_internal_wrapper_t<std::complex, testing_types1>,
+        gko::test::add_inner_wrapper_t<std::complex, testing_types1>,
         expected_iw2>();
     testing::StaticAssertTypeEq<
-        gko::test::add_internal_wrapper_t<std::complex, tuple_types1>,
+        gko::test::add_inner_wrapper_t<std::complex, tuple_types1>,
         gko::test::change_outer_wrapper_t<std::tuple, expected_iw2>>();
+}
+
+
+TEST(TypeListHelper, AddInternalWrapperEmpty)
+{
+    testing::StaticAssertTypeEq<
+        gko::test::add_inner_wrapper_t<std::tuple, testing_empty>,
+        testing_empty>();
+    testing::StaticAssertTypeEq<
+        gko::test::add_inner_wrapper_t<std::tuple, tuple_empty>, tuple_empty>();
 }
 
 
@@ -106,20 +133,18 @@ TEST(TypeListHelper, MergeTypeListLarge)
 
 TEST(TypeListHelper, MergeTypeListEmpty)
 {
-    using expected_m2 = testing::Types<double>;
-
     testing::StaticAssertTypeEq<
         gko::test::merge_type_list_t<testing_types1, testing::Types<>>,
-        expected_m2>();
+        testing_types1>();
     testing::StaticAssertTypeEq<
         gko::test::merge_type_list_t<tuple_types1, std::tuple<>>,
-        gko::test::change_outer_wrapper_t<std::tuple, expected_m2>>();
+        tuple_types1>();
     testing::StaticAssertTypeEq<
         gko::test::merge_type_list_t<testing::Types<>, testing_types1>,
-        expected_m2>();
+        testing_types1>();
     testing::StaticAssertTypeEq<
         gko::test::merge_type_list_t<std::tuple<>, tuple_types1>,
-        gko::test::change_outer_wrapper_t<std::tuple, expected_m2>>();
+        tuple_types1>();
 }
 
 
@@ -150,6 +175,29 @@ TEST(TypeListHelper, CartesianTypeProductSmall)
     testing::StaticAssertTypeEq<
         gko::test::cartesian_type_product_t<tuple_types1, tuple_types2>,
         gko::test::change_outer_wrapper_t<std::tuple, expected_c2>>();
+}
+
+
+TEST(TypeListHelper, CartesianTypeProductEmpty)
+{
+    testing::StaticAssertTypeEq<
+        gko::test::cartesian_type_product_t<testing_empty, testing_types2>,
+        testing_empty>();
+    testing::StaticAssertTypeEq<
+        gko::test::cartesian_type_product_t<testing_types1, testing_empty>,
+        testing_empty>();
+    testing::StaticAssertTypeEq<
+        gko::test::cartesian_type_product_t<testing_empty, testing_empty>,
+        testing_empty>();
+    testing::StaticAssertTypeEq<
+        gko::test::cartesian_type_product_t<tuple_empty, tuple_types2>,
+        tuple_empty>();
+    testing::StaticAssertTypeEq<
+        gko::test::cartesian_type_product_t<tuple_types1, tuple_empty>,
+        tuple_empty>();
+    testing::StaticAssertTypeEq<
+        gko::test::cartesian_type_product_t<tuple_empty, tuple_empty>,
+        tuple_empty>();
 }
 
 
@@ -193,6 +241,26 @@ TEST(TypeListHelper, AddToCartesianTypeProductSmall)
 }
 
 
+TEST(TypeListHelper, AddToCartesianTypeProductEmpty)
+{
+    using list3 = testing::Types<std::tuple<long>>;
+    using tlist3 = std::tuple<std::tuple<long>>;
+
+    testing::StaticAssertTypeEq<
+        gko::test::add_to_cartesian_type_product_t<list3, testing_empty>,
+        testing_empty>();
+    testing::StaticAssertTypeEq<gko::test::add_to_cartesian_type_product_t<
+                                    testing_empty, testing_types1>,
+                                testing_empty>();
+    testing::StaticAssertTypeEq<
+        gko::test::add_to_cartesian_type_product_t<tlist3, tuple_empty>,
+        tuple_empty>();
+    testing::StaticAssertTypeEq<
+        gko::test::add_to_cartesian_type_product_t<tuple_empty, tuple_types1>,
+        tuple_empty>();
+}
+
+
 TEST(TypeListHelper, AddToCartesianTypeProductLeftLarge)
 {
     using list1 = testing::Types<long, char>;
@@ -230,6 +298,26 @@ TEST(TypeListHelper, AddToCartesianTypeProductLeftSmall)
     testing::StaticAssertTypeEq<
         gko::test::add_to_cartesian_type_product_left_t<tlist3, tlist4>,
         gko::test::change_outer_wrapper_t<std::tuple, expected_a2>>();
+}
+
+
+TEST(TypeListHelper, AddToCartesianTypeProductLeftEmpty)
+{
+    using list3 = testing::Types<std::tuple<long>>;
+    using tlist3 = std::tuple<std::tuple<long>>;
+
+    testing::StaticAssertTypeEq<gko::test::add_to_cartesian_type_product_left_t<
+                                    testing_types1, testing_empty>,
+                                testing_empty>();
+    testing::StaticAssertTypeEq<
+        gko::test::add_to_cartesian_type_product_left_t<testing_empty, list3>,
+        testing_empty>();
+    testing::StaticAssertTypeEq<gko::test::add_to_cartesian_type_product_left_t<
+                                    tuple_types1, tuple_empty>,
+                                tuple_empty>();
+    testing::StaticAssertTypeEq<
+        gko::test::add_to_cartesian_type_product_left_t<tuple_empty, tlist3>,
+        tuple_empty>();
 }
 
 

--- a/cuda/test/base/array.cpp
+++ b/cuda/test/base/array.cpp
@@ -32,7 +32,7 @@ protected:
     gko::array<T> x;
 };
 
-TYPED_TEST_SUITE(Array, gko::test::ValueAndIndexTypes, TypenameNameGenerator);
+TYPED_TEST_SUITE(Array, gko::test::ComplexAndPODTypes, TypenameNameGenerator);
 
 
 TYPED_TEST(Array, CanCreateTemporaryCloneOnDifferentExecutor)

--- a/reference/test/base/array.cpp
+++ b/reference/test/base/array.cpp
@@ -28,7 +28,7 @@ protected:
     gko::array<T> x;
 };
 
-TYPED_TEST_SUITE(Array, gko::test::ValueAndIndexTypes, TypenameNameGenerator);
+TYPED_TEST_SUITE(Array, gko::test::ComplexAndPODTypes, TypenameNameGenerator);
 
 
 TYPED_TEST(Array, CanBeFilledWithValue)

--- a/reference/test/components/fill_array_kernels.cpp
+++ b/reference/test/components/fill_array_kernels.cpp
@@ -40,7 +40,7 @@ protected:
     gko::array<value_type> seqs;
 };
 
-TYPED_TEST_SUITE(FillArray, gko::test::ValueAndIndexTypes,
+TYPED_TEST_SUITE(FillArray, gko::test::ComplexAndPODTypes,
                  TypenameNameGenerator);
 
 

--- a/reference/test/components/prefix_sum_kernels.cpp
+++ b/reference/test/components/prefix_sum_kernels.cpp
@@ -35,10 +35,7 @@ protected:
     std::vector<index_type> expected;
 };
 
-using PrefixSumIndexTypes =
-    ::testing::Types<gko::int32, gko::int64, gko::size_type>;
-
-TYPED_TEST_SUITE(PrefixSum, PrefixSumIndexTypes, TypenameNameGenerator);
+TYPED_TEST_SUITE(PrefixSum, gko::test::IntegerTypes, TypenameNameGenerator);
 
 
 TYPED_TEST(PrefixSum, Works)

--- a/reference/test/components/reduce_array_kernels.cpp
+++ b/reference/test/components/reduce_array_kernels.cpp
@@ -31,7 +31,7 @@ protected:
     gko::array<value_type> vals;
 };
 
-TYPED_TEST_SUITE(ReduceArray, gko::test::ValueAndIndexTypes,
+TYPED_TEST_SUITE(ReduceArray, gko::test::ComplexAndPODTypes,
                  TypenameNameGenerator);
 
 

--- a/reference/test/solver/cb_gmres_kernels.cpp
+++ b/reference/test/solver/cb_gmres_kernels.cpp
@@ -134,17 +134,11 @@ using st_i = st_helper_type<st_enum::integer>;
 using st_ir1 = st_helper_type<st_enum::ireduce1>;
 using st_ir2 = st_helper_type<st_enum::ireduce2>;
 
-using TestTypes =
-    ::testing::Types<std::tuple<double, st_keep>, std::tuple<double, st_r1>,
-                     std::tuple<double, st_r2>, std::tuple<double, st_i>,
-                     std::tuple<double, st_ir1>, std::tuple<double, st_ir2>,
-                     std::tuple<float, st_keep>, std::tuple<float, st_r1>,
-                     std::tuple<float, st_r2>, std::tuple<float, st_i>,
-                     std::tuple<float, st_ir1>, std::tuple<float, st_ir2>,
-                     std::tuple<std::complex<double>, st_keep>,
-                     std::tuple<std::complex<double>, st_r1>,
-                     std::tuple<std::complex<double>, st_r2>,
-                     std::tuple<std::complex<float>, st_keep>>;
+using TestTypes = gko::test::merge_type_list_t<
+    gko::test::cartesian_type_product_t<
+        gko::test::ValueTypes, ::testing::Types<st_keep, st_r1, st_r2>>,
+    gko::test::cartesian_type_product_t<
+        gko::test::RealValueTypes, ::testing::Types<st_i, st_ir1, st_ir2>>>;
 
 TYPED_TEST_SUITE(CbGmres, TestTypes, PairTypenameNameGenerator);
 

--- a/test/components/fill_array_kernels.cpp
+++ b/test/components/fill_array_kernels.cpp
@@ -36,7 +36,7 @@ protected:
     gko::array<value_type> seqs;
 };
 
-TYPED_TEST_SUITE(FillArray, gko::test::ValueAndIndexTypes,
+TYPED_TEST_SUITE(FillArray, gko::test::ComplexAndPODTypes,
                  TypenameNameGenerator);
 
 

--- a/test/components/prefix_sum_kernels.cpp
+++ b/test/components/prefix_sum_kernels.cpp
@@ -39,10 +39,7 @@ protected:
     gko::array<index_type> dvals;
 };
 
-using PrefixSumIndexTypes =
-    ::testing::Types<gko::int32, gko::int64, gko::size_type>;
-
-TYPED_TEST_SUITE(PrefixSum, PrefixSumIndexTypes, TypenameNameGenerator);
+TYPED_TEST_SUITE(PrefixSum, gko::test::IntegerTypes, TypenameNameGenerator);
 
 
 TYPED_TEST(PrefixSum, EqualsReference)

--- a/test/components/reduce_array_kernels.cpp
+++ b/test/components/reduce_array_kernels.cpp
@@ -38,7 +38,7 @@ protected:
     gko::array<value_type> dvals;
 };
 
-TYPED_TEST_SUITE(ReduceArray, gko::test::ValueAndIndexTypes,
+TYPED_TEST_SUITE(ReduceArray, gko::test::ComplexAndPODTypes,
                  TypenameNameGenerator);
 
 

--- a/test/factorization/cholesky_kernels.cpp
+++ b/test/factorization/cholesky_kernels.cpp
@@ -115,14 +115,12 @@ using Types = gko::test::ValueIndexTypes;
 #elif defined(GKO_COMPILING_CUDA)
 // CUDA doesn't support long indices for sorting, and the triangular solvers
 // seem broken
-using Types = ::testing::Types<std::tuple<float, gko::int32>,
-                               std::tuple<double, gko::int32>,
-                               std::tuple<std::complex<float>, gko::int32>,
-                               std::tuple<std::complex<double>, gko::int32>>;
+using Types = gko::test::cartesian_type_product_t<gko::test::ValueTypes,
+                                                  ::testing::Types<gko::int32>>;
 #else
 // HIP only supports real types and int32
-using Types = ::testing::Types<std::tuple<float, gko::int32>,
-                               std::tuple<double, gko::int32>>;
+using Types = gko::test::cartesian_type_product_t<gko::test::RealValueTypes,
+                                                  ::testing::Types<gko::int32>>;
 #endif
 
 TYPED_TEST_SUITE(CholeskySymbolic, Types, PairTypenameNameGenerator);

--- a/test/factorization/lu_kernels.cpp
+++ b/test/factorization/lu_kernels.cpp
@@ -131,14 +131,12 @@ using Types = gko::test::ValueIndexTypes;
 #elif defined(GKO_COMPILING_CUDA)
 // CUDA don't support long indices for sorting, and the triangular solvers
 // seem broken
-using Types = ::testing::Types<std::tuple<float, gko::int32>,
-                               std::tuple<double, gko::int32>,
-                               std::tuple<std::complex<float>, gko::int32>,
-                               std::tuple<std::complex<double>, gko::int32>>;
+using Types = gko::test::cartesian_type_product_t<gko::test::ValueTypes,
+                                                  ::testing::Types<gko::int32>>;
 #else
 // HIP only supports real types and int32
-using Types = ::testing::Types<std::tuple<float, gko::int32>,
-                               std::tuple<double, gko::int32>>;
+using Types = gko::test::cartesian_type_product_t<gko::test::RealValueTypes,
+                                                  ::testing::Types<gko::int32>>;
 #endif
 
 TYPED_TEST_SUITE(Lu, Types, PairTypenameNameGenerator);

--- a/test/solver/direct.cpp
+++ b/test/solver/direct.cpp
@@ -106,14 +106,12 @@ using Types = gko::test::ValueIndexTypes;
 #elif defined(GKO_COMPILING_CUDA)
 // CUDA don't support long indices for sorting, and the triangular solvers
 // seem broken
-using Types = ::testing::Types<std::tuple<float, gko::int32>,
-                               std::tuple<double, gko::int32>,
-                               std::tuple<std::complex<float>, gko::int32>,
-                               std::tuple<std::complex<double>, gko::int32>>;
+using Types = gko::test::cartesian_type_product_t<gko::test::ValueTypes,
+                                                  ::testing::Types<gko::int32>>;
 #else
 // HIP only supports real types and int32
-using Types = ::testing::Types<std::tuple<float, gko::int32>,
-                               std::tuple<double, gko::int32>>;
+using Types = gko::test::cartesian_type_product_t<gko::test::RealValueTypes,
+                                                  ::testing::Types<gko::int32>>;
 #endif
 
 TYPED_TEST_SUITE(Direct, Types, PairTypenameNameGenerator);


### PR DESCRIPTION
Add template-type functions to combine and merge type lists. As a result, the GINKGO_DPCPP_SINGLE_MODE only needs to be present once.

Additionally, change the typen name ValueAndIndexType to ComplexAndPODTypes (because gko::size_type is not an IndexType).

TODO:
- [x] Add documentation to the type helper
- [x] go through all existing tests and use the wrapper in all cases we define types on our own (example: CB-Gmres)