### PR TITLE
update the intel ci job

### DIFF
--- a/.github/workflows/intel.yml
+++ b/.github/workflows/intel.yml
@@ -32,20 +32,21 @@ jobs:
 
     - name: configure
       run: |
-        spack load intel-oneapi-compilers intel-oneapi-dpl intel-oneapi-mkl intel-oneapi-tbb cmake
-        spack find --loaded
+        source /etc/profile
+        module load intel-oneapi-compilers intel-oneapi-dpl intel-oneapi-mkl intel-oneapi-tbb cmake
         mkdir build
         cd build
-        cmake .. -DCMAKE_INSTALL_PREFIX=install_ginkgo -DCMAKE_CXX_FLAGS="-Wpedantic -ffp-model=precise" -DCMAKE_CXX_COMPILER=${{ matrix.config.compiler }} -DCMAKE_BUILD_TYPE=${{ matrix.config.build_type }} -DGINKGO_MIXED_PRECISION=${{ matrix.config.mixed }} -DGINKGO_DPCPP_SINGLE_MODE=ON
+        cmake .. -DCMAKE_INSTALL_PREFIX=install_ginkgo -DCMAKE_CXX_FLAGS="-Wpedantic -ffp-model=precise" -DCMAKE_CXX_COMPILER=${{ matrix.config.compiler }} -DCMAKE_BUILD_TYPE=${{ matrix.config.build_type }} -DGINKGO_MIXED_PRECISION=${{ matrix.config.mixed }} -DGINKGO_BUILD_CUDA=OFF -DGINKGO_BUILD_HIP=OFF -DGINKGO_BUILD_MPI=OFF -DGINKGO_DPCPP_SINGLE_MODE=ON
         make -j8
         ONEAPI_DEVICE_SELECTOR=level_zero:gpu ctest -j10 --output-on-failure
 
     - name: install
       run: |
-        spack load intel-oneapi-compilers intel-oneapi-dpl intel-oneapi-mkl intel-oneapi-tbb cmake
+        source /etc/profile
+        module load intel-oneapi-compilers intel-oneapi-dpl intel-oneapi-mkl intel-oneapi-tbb cmake
         cd build
-        SYCL_DEVICE_FILTER=level_zero make install
+        SYCL_DEVICE_FILTER=level_zero:gpu make install
         export GINKGO_PATH="$(pwd)/install_ginkgo/lib"
         export LIBRARY_PATH=${GINKGO_PATH}:$LIBRARY_PATH
         export LD_LIBRARY_PATH=${GINKGO_PATH}:$LD_LIBRARY_PATH
-        SYCL_DEVICE_FILTER=level_zero make test_install
+        SYCL_DEVICE_FILTER=level_zero:gpu make test_install

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -604,7 +604,7 @@ build/icpx20231/igpu/release/shared:
     BUILD_TYPE: "Release"
     BUILD_SHARED_LIBS: "ON"
     DPCPP_SINGLE_MODE: "ON"
-    ONEAPI_DEVICE_SELECTOR: "*:gpu"
+    ONEAPI_DEVICE_SELECTOR: "opencl:gpu"
     BUILD_HWLOC: "OFF"
 
 # TODO: Enable when debug shared library size issues are fixed
@@ -624,7 +624,7 @@ build/icpx20231/igpu/release/shared:
 #     ONEAPI_DEVICE_SELECTOR: "level_zero:gpu"
 
 # It gives two available backends of GPU on tests
-build/dpcpp/dgpu/release/static:
+build/icpx/igpu/release/static:
   extends:
     - .build_and_test_template
     - .default_variables
@@ -638,21 +638,6 @@ build/dpcpp/dgpu/release/static:
     BUILD_SHARED_LIBS: "OF"
     DPCPP_SINGLE_MODE: "ON"
     ONEAPI_DEVICE_SELECTOR: "*:gpu"
-    BUILD_HWLOC: "OFF"
-
-build/icpx/dgpu/release/shared:
-  extends:
-    - .build_and_test_template
-    - .default_variables
-    - .quick_test_condition
-    - .use_gko-oneapi-dgpu
-  variables:
-    CXX_COMPILER: "icpx"
-    CXX_FLAGS: "-Wpedantic -ffp-model=precise"
-    BUILD_SYCL: "ON"
-    BUILD_TYPE: "Release"
-    DPCPP_SINGLE_MODE: "ON"
-    ONEAPI_DEVICE_SELECTOR: "opencl:gpu"
     BUILD_HWLOC: "OFF"
 
 # Job with important warnings as error

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -590,15 +590,15 @@ build/dpcpp/2022-1/cpu/release/shared:
     BUILD_HWLOC: "OFF"
     # This job is not in exclusive mode
 
-# It gives two available backends of GPU on tests
-build/dpcpp/igpu/release/shared:
+# spack oneapi 2023.1
+build/icpx20231/igpu/release/shared:
   extends:
     - .build_and_test_template
     - .default_variables
     - .quick_test_condition
-    - .use_gko-oneapi-igpu
+    - .use_gko-oneapi20231-igpu
   variables:
-    CXX_COMPILER: "dpcpp"
+    CXX_COMPILER: "icpx"
     CXX_FLAGS: "-Wpedantic -ffp-model=precise"
     BUILD_SYCL: "ON"
     BUILD_TYPE: "Release"
@@ -640,22 +640,7 @@ build/dpcpp/dgpu/release/static:
     ONEAPI_DEVICE_SELECTOR: "*:gpu"
     BUILD_HWLOC: "OFF"
 
-build/dpcpp/level_zero_dgpu/release/shared:
-  extends:
-    - .build_and_test_template
-    - .default_variables
-    - .quick_test_condition
-    - .use_gko-oneapi-dgpu
-  variables:
-    CXX_COMPILER: "dpcpp"
-    CXX_FLAGS: "-Wpedantic -ffp-model=precise"
-    BUILD_SYCL: "ON"
-    BUILD_TYPE: "Release"
-    DPCPP_SINGLE_MODE: "ON"
-    ONEAPI_DEVICE_SELECTOR: "level_zero:gpu"
-    BUILD_HWLOC: "OFF"
-
-build/icpx/level_zero_dgpu/release/shared:
+build/icpx/dgpu/release/shared:
   extends:
     - .build_and_test_template
     - .default_variables
@@ -667,7 +652,7 @@ build/icpx/level_zero_dgpu/release/shared:
     BUILD_SYCL: "ON"
     BUILD_TYPE: "Release"
     DPCPP_SINGLE_MODE: "ON"
-    ONEAPI_DEVICE_SELECTOR: "level_zero:gpu"
+    ONEAPI_DEVICE_SELECTOR: "opencl:gpu"
     BUILD_HWLOC: "OFF"
 
 # Job with important warnings as error

--- a/.gitlab/image.yml
+++ b/.gitlab/image.yml
@@ -92,6 +92,12 @@
     - private_ci
     - intel-igpu
 
+.use_gko-oneapi20231-igpu:
+  image: ginkgohub/spack-oneapi:20231-openmpi
+  tags:
+    - private_ci
+    - intel-igpu
+
 .use_gko-oneapi-dgpu:
   image: ginkgohub/oneapi:latest
   tags:

--- a/.gitlab/image.yml
+++ b/.gitlab/image.yml
@@ -87,7 +87,7 @@
     - fairrs
 
 .use_gko-oneapi-igpu:
-  image: ginkgohub/oneapi:latest
+  image: ginkgohub/oneapi:2024.0.2.20231213
   tags:
     - private_ci
     - intel-igpu
@@ -99,7 +99,7 @@
     - intel-igpu
 
 .use_gko-oneapi-dgpu:
-  image: ginkgohub/oneapi:latest
+  image: ginkgohub/oneapi:2024.0.2.20231213
   tags:
     - private_ci
     - intel-dgpu


### PR DESCRIPTION
It updates the intel github action job script and remove the gitlab level_zero part

TODO:
- [x] change the oneapi 2023.1 image when the corresponding pr is merged