### PR TITLE
Add integer range

### DIFF
--- a/.github/workflows/osx.yml
+++ b/.github/workflows/osx.yml
@@ -52,8 +52,10 @@ jobs:
     - name: configure
       run: |
         mkdir build
+        mkdir install
+        export INSTALL_PREFIX=`pwd`/install
         cd build
-        cmake .. -DCMAKE_CXX_FLAGS=-Wpedantic -DBUILD_SHARED_LIBS=${{ matrix.config.shared }} -DCMAKE_BUILD_TYPE=${{ matrix.config.build_type }} -DGINKGO_MIXED_PRECISION=${{ matrix.config.mixed }}
+        cmake .. -DCMAKE_CXX_FLAGS=-Wpedantic -DBUILD_SHARED_LIBS=${{ matrix.config.shared }} -DCMAKE_INSTALL_PREFIX=${INSTALL_PREFIX} -DCMAKE_BUILD_TYPE=${{ matrix.config.build_type }} -DGINKGO_MIXED_PRECISION=${{ matrix.config.mixed }}
         make -j8
         ctest -j10 --output-on-failure
 

--- a/core/base/index_range.hpp
+++ b/core/base/index_range.hpp
@@ -19,7 +19,8 @@ namespace gko {
 
 /**
  * An index_iterator represents an iteration through an integer
- * range. Each increment of the iterator increments the integer it represents.
+ * range/interval `[begin, end)`. Each increment of the iterator increments the
+ * integer it represents.
  *
  * @tparam IndexType  the type of the index, it must be a signed integer type.
  */

--- a/core/base/index_range.hpp
+++ b/core/base/index_range.hpp
@@ -1,0 +1,237 @@
+// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+//
+// SPDX-License-Identifier: BSD-3-Clause
+
+#ifndef GKO_CORE_BASE_INDEX_RANGE_HPP_
+#define GKO_CORE_BASE_INDEX_RANGE_HPP_
+
+
+#include <cassert>
+#include <iterator>
+#include <type_traits>
+
+
+#include "core/base/iterator_range.hpp"
+
+
+namespace gko {
+
+
+/**
+ * An index_iterator represents an iteration through an integer
+ * range. Each increment of the iterator increments the integer it represents.
+ *
+ * @tparam IndexType  the type of the index, it must be a signed integer type.
+ */
+template <typename IndexType>
+class index_iterator {
+    static_assert(std::is_signed<IndexType>::value &&
+                      std::is_integral<IndexType>::value,
+                  "Can only use index_iterator with signed integral types!");
+
+public:
+    using index_type = IndexType;
+
+    // iterator_traits requirements
+    using iterator_category = std::random_access_iterator_tag;
+    using value_type = index_type;
+    using difference_type = index_type;
+    using pointer = const index_type*;
+    using reference = index_type;  // we shouldn't hand out references to
+                                   // the index for lifetime safety
+
+    /** Initializes the iterator to the given index. */
+    constexpr explicit index_iterator(index_type i) : idx_{i} {}
+
+    constexpr index_iterator() : index_iterator{0} {}
+
+    // RandomAccessIterator requirements
+    /** Iterator advance. */
+    constexpr index_iterator& operator+=(difference_type n)
+    {
+        idx_ += n;
+        return *this;
+    }
+
+    /** Dereference. */
+    constexpr reference operator*() const { return idx_; }
+
+    /** Iterator difference. */
+    constexpr friend difference_type operator-(index_iterator a,
+                                               index_iterator b)
+    {
+        return *a - *b;
+    }
+
+    // InputIterator requirements
+    /** Equality. */
+    constexpr friend bool operator==(index_iterator a, index_iterator b)
+    {
+        return a - b == 0;
+    }
+
+    /** non-equality */
+    constexpr friend bool operator!=(index_iterator a, index_iterator b)
+    {
+        return !(a == b);
+    }
+
+    // BidirectionalIterator requirements
+    /** Pre-increment. */
+    constexpr index_iterator& operator++() { return *this += 1; }
+
+    /** Post-increment. */
+    constexpr index_iterator operator++(int)
+    {
+        auto tmp{*this};
+        operator++();
+        return tmp;
+    }
+
+    /** Pre-decrement. */
+    constexpr index_iterator& operator--() { return *this -= 1; }
+
+    /** Post-decrement. */
+    constexpr index_iterator operator--(int)
+    {
+        auto tmp{*this};
+        operator--();
+        return tmp;
+    }
+
+    // RandomAccessIterator requirements
+    /** Iterator advance. */
+    constexpr friend index_iterator operator+(index_iterator a,
+                                              difference_type n)
+    {
+        return a += n;
+    }
+
+    /** reverse advance */
+    constexpr friend index_iterator operator+(difference_type n,
+                                              index_iterator a)
+    {
+        return a + n;
+    }
+
+    /** Iterator backwards advance. */
+    constexpr index_iterator& operator-=(difference_type n)
+    {
+        return *this += -n;
+    }
+
+    /** Iterator backwards advance. */
+    constexpr friend index_iterator operator-(index_iterator a,
+                                              difference_type n)
+    {
+        return a + -n;
+    }
+
+    /** Subscript. */
+    constexpr reference operator[](difference_type n) const
+    {
+        return *(*this + n);
+    }
+
+    /** less than */
+    constexpr friend bool operator<(index_iterator a, index_iterator b)
+    {
+        return b - a > 0;
+    }
+
+    /** greater than */
+    constexpr friend bool operator>(index_iterator a, index_iterator b)
+    {
+        return b < a;
+    }
+
+    /** greater equal */
+    constexpr friend bool operator>=(index_iterator a, index_iterator b)
+    {
+        return !(a < b);
+    }
+
+    /** less equal */
+    constexpr friend bool operator<=(index_iterator a, index_iterator b)
+    {
+        return !(a > b);
+    }
+
+private:
+    index_type idx_;
+};
+
+
+/**
+ * Represents an index range that will be iterated through in order.
+ * The following two loops are equivalent (assuming begin <= end):
+ * ```cpp
+ * for (int i = begin; i < end; i++);
+ * for (auto i : irange<int>{begin, end});
+ * ```
+ *
+ * @tparam IndexType  the type of the indices.
+ */
+template <typename IndexType>
+class irange : public iterator_range<index_iterator<IndexType>> {
+public:
+    using index_type = IndexType;
+    using iterator = index_iterator<index_type>;
+
+    /**
+     * Constructs an index range consisting of the values in [begin, end).
+     *
+     * @param begin  the first index in the range
+     * @param end  one past the last index in the range. It must not be smaller
+     *             than `begin`.
+     */
+    constexpr explicit irange(index_type begin, index_type end)
+        : iterator_range<iterator>{iterator{begin}, iterator{end}}
+    {
+        assert(begin <= end);
+    }
+
+    /**
+     * Constructs an index range consisting of the values in [0, end).
+     *
+     * @param end  one past the last index in the range. It must not be a
+     *             negative number.
+     */
+    constexpr explicit irange(index_type end) : irange{0, end} {}
+
+    /** @return the first index in this range. */
+    constexpr index_type begin_index() const { return *this->begin(); }
+
+    /** @return one past the last index in this range. */
+    constexpr index_type end_index() const { return *this->end(); }
+
+    /**
+     * Compares two ranges for equality.
+     *
+     * @param lhs  the first range
+     * @param rhs  the second range
+     * @return true iff both ranges have the same begin and end index.
+     */
+    constexpr friend bool operator==(irange lhs, irange rhs)
+    {
+        return lhs.begin() == rhs.begin() && lhs.end() == rhs.end();
+    }
+
+    /**
+     * Compares two ranges for inequality.
+     *
+     * @param lhs  the first range
+     * @param rhs  the second range
+     * @return false iff both ranges have the same begin and end index.
+     */
+    constexpr friend bool operator!=(irange lhs, irange rhs)
+    {
+        return !(lhs == rhs);
+    }
+};
+
+
+}  // namespace gko
+
+
+#endif  // GKO_CORE_BASE_INDEX_RANGE_HPP_

--- a/core/base/iterator_range.hpp
+++ b/core/base/iterator_range.hpp
@@ -1,0 +1,48 @@
+// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+//
+// SPDX-License-Identifier: BSD-3-Clause
+
+#ifndef GKO_CORE_BASE_ITERATOR_RANGE_HPP_
+#define GKO_CORE_BASE_ITERATOR_RANGE_HPP_
+
+
+namespace gko {
+
+
+/**
+ * An iterator_range represents a pair of iterators to be used in a range-for
+ * loop.
+ *
+ * @tparam Iterator  the iterator type
+ */
+template <typename Iterator>
+class iterator_range {
+public:
+    using iterator = Iterator;
+
+    /**
+     * Constructs a range `[begin, end)` from its begin and end iterator.
+     *
+     * @param begin  points to the first element
+     * @param end  points past the last element
+     */
+    constexpr explicit iterator_range(iterator begin, iterator end)
+        : begin_{begin}, end_{end}
+    {}
+
+    /** @return the iterator pointing to the first element. */
+    constexpr iterator begin() const { return begin_; }
+
+    /** @return the iterator pointing past the last element. */
+    constexpr iterator end() const { return end_; }
+
+private:
+    iterator begin_;
+    iterator end_;
+};
+
+
+}  // namespace gko
+
+
+#endif  // GKO_CORE_BASE_ITERATOR_RANGE_HPP_

--- a/core/test/base/CMakeLists.txt
+++ b/core/test/base/CMakeLists.txt
@@ -14,6 +14,7 @@ ginkgo_create_test(exception EXECUTABLE_NAME exception_test) # exception collide
 ginkgo_create_test(exception_helpers)
 ginkgo_create_test(extended_float)
 ginkgo_create_test(executor)
+ginkgo_create_test(index_range)
 ginkgo_create_test(iterator_factory)
 ginkgo_create_test(lin_op)
 ginkgo_create_test(math)

--- a/core/test/base/index_range.cpp
+++ b/core/test/base/index_range.cpp
@@ -29,6 +29,15 @@ TEST(IRange, KnowsItsProperties)
 }
 
 
+TEST(IRange, SingleParameterConstructor)
+{
+    gko::irange<int> range(10);
+
+    ASSERT_EQ(range.begin_index(), 0);
+    ASSERT_EQ(range.end_index(), 10);
+}
+
+
 TEST(IRange, RangeFor)
 {
     std::vector<int> v;

--- a/core/test/base/index_range.cpp
+++ b/core/test/base/index_range.cpp
@@ -1,0 +1,114 @@
+// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+//
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include <gtest/gtest.h>
+
+
+#include "core/base/index_range.hpp"
+
+
+TEST(IRange, KnowsItsProperties)
+{
+    gko::irange<int> range(0, 10);
+
+    ASSERT_EQ(range.begin_index(), 0);
+    ASSERT_EQ(range.end_index(), 10);
+    ASSERT_EQ(*range.begin(), 0);
+    // For other iterators, this would be illegal, but it is allowed for
+    // irange::iterator
+    ASSERT_EQ(*range.end(), 10);
+    ASSERT_TRUE(range == gko::irange<int>(0, 10));
+    ASSERT_TRUE(range != gko::irange<int>(1, 10));
+    ASSERT_TRUE(range != gko::irange<int>(0, 9));
+    ASSERT_FALSE(range != gko::irange<int>(0, 10));
+    ASSERT_FALSE(range == gko::irange<int>(1, 10));
+    ASSERT_FALSE(range == gko::irange<int>(0, 9));
+    // test single-argument constructor
+    ASSERT_TRUE(range == gko::irange<int>(10));
+}
+
+
+TEST(IRange, RangeFor)
+{
+    std::vector<int> v;
+
+    for (auto i : gko::irange<int>(1, 4)) {
+        v.push_back(i);
+    }
+
+    ASSERT_EQ(v, std::vector<int>({1, 2, 3}));
+}
+
+
+TEST(IRange, WorksInAlgorithm)
+{
+    gko::irange<int> range(1, 15);
+
+    auto it = std::lower_bound(range.begin(), range.end(), 10);
+
+    ASSERT_EQ(*it, 10);
+    ASSERT_EQ(it - range.begin(), 9);
+}
+
+
+TEST(IRangeIterator, IteratorProperties)
+{
+    gko::irange<int> range(0, 10);
+
+    auto it = range.begin();
+    it += 4;
+    ASSERT_EQ(*it, 4);
+    it -= 4;
+    ASSERT_EQ(*it, 0);
+    ASSERT_EQ(*it++, 0);
+    ASSERT_EQ(*++it, 2);
+    ASSERT_EQ(*it--, 2);
+    ASSERT_EQ(*--it, 0);
+    ASSERT_EQ(*(it + 1), 1);
+    ASSERT_EQ(*(it - -1), 1);
+    ASSERT_EQ(it[2], 2);
+    ASSERT_EQ((it + 4) - it, 4);
+    ASSERT_TRUE(it == it);
+    ASSERT_TRUE(it != (it + 1));
+    ASSERT_TRUE(it < (it + 1));
+    ASSERT_TRUE(it <= (it + 1));
+    ASSERT_TRUE(it <= it);
+    ASSERT_TRUE((it + 1) > it);
+    ASSERT_TRUE((it + 1) >= it);
+    ASSERT_TRUE(it >= it);
+    ASSERT_FALSE(it != it);
+    ASSERT_FALSE(it == (it + 1));
+    ASSERT_FALSE(it > it);
+    ASSERT_FALSE(it > (it + 1));
+    ASSERT_FALSE(it < it);
+    ASSERT_FALSE((it + 1) < it);
+    ASSERT_FALSE(it >= (it + 1));
+    ASSERT_FALSE((it + 1) <= it);
+}
+
+
+#ifndef NDEBUG
+
+
+bool check_assertion_exit_code(int exit_code)
+{
+#ifdef _MSC_VER
+    // MSVC picks up the exit code incorrectly,
+    // so we can only check that it exits
+    return true;
+#else
+    return exit_code != 0;
+#endif
+}
+
+
+TEST(DeathTest, Assertions)
+{
+    // irange
+    // end >= begin
+    EXPECT_EXIT((void)gko::irange<int>(1, 0), check_assertion_exit_code, "");
+}
+
+
+#endif

--- a/test/base/CMakeLists.txt
+++ b/test/base/CMakeLists.txt
@@ -1,5 +1,6 @@
 ginkgo_create_common_test(batch_multi_vector_kernels)
 ginkgo_create_common_and_reference_test(device_matrix_data_kernels)
+ginkgo_create_common_device_test(index_range)
 ginkgo_create_common_device_test(kernel_launch_generic)
 ginkgo_create_common_and_reference_test(executor)
 ginkgo_create_common_and_reference_test(timer)

--- a/test/base/index_range.cpp
+++ b/test/base/index_range.cpp
@@ -40,9 +40,11 @@ void run_range_for(std::shared_ptr<gko::EXEC_TYPE> exec,
         1, result_array, static_cast<int>(result_array.get_size()));
 }
 
-TEST_F(IndexRange, RunsRangeFor)
+
+TEST_F(IndexRange, KernelRunsRangeFor)
 {
-    for (auto i : gko::irange<int>{static_cast<int>(result_array.get_size())}) {
+    auto size = static_cast<int>(result_array.get_size());
+    for (int i = 0; i < size; i++) {
         expected_array.get_data()[i] = i * i;
     }
 

--- a/test/base/index_range.cpp
+++ b/test/base/index_range.cpp
@@ -1,0 +1,52 @@
+// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+//
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include <memory>
+
+
+#include <gtest/gtest.h>
+
+
+#include <ginkgo/core/base/array.hpp>
+
+
+#include "common/unified/base/kernel_launch.hpp"
+#include "core/base/index_range.hpp"
+#include "core/test/utils.hpp"
+#include "test/utils/executor.hpp"
+
+
+class IndexRange : public CommonTestFixture {
+public:
+    IndexRange() : result_array{exec, 16}, expected_array{ref, 16} {}
+
+    gko::array<int> result_array;
+    gko::array<int> expected_array;
+};
+
+
+// nvcc doesn't like device lambdas declared in complex classes, move it out
+void run_range_for(std::shared_ptr<gko::EXEC_TYPE> exec,
+                   gko::array<int>& result_array)
+{
+    gko::kernels::EXEC_NAMESPACE::run_kernel(
+        exec,
+        [] GKO_KERNEL(auto i, auto result, auto size) {
+            for (auto i : gko::irange<int>{size}) {
+                result[i] = i * i;
+            }
+        },
+        1, result_array, static_cast<int>(result_array.get_size()));
+}
+
+TEST_F(IndexRange, RunsRangeFor)
+{
+    for (auto i : gko::irange<int>{static_cast<int>(result_array.get_size())}) {
+        expected_array.get_data()[i] = i * i;
+    }
+
+    run_range_for(exec, result_array);
+
+    GKO_ASSERT_ARRAY_EQ(result_array, expected_array);
+}


### PR DESCRIPTION
Pulled out of the other PRs #1601 #1582, this adds a simple integer range similar to Python's `range`, only without stride support for now. It allows writing range-for loops `for (auto i : irange<int>{100})` with a slight advantage in const-correctness, since `i` can also be `const` in this context, and slightly more succinct code. With C++17 CTAD, we will also be able to omit the `<int>` in most cases.