### PR TITLE
Allow `zip_iterator` to be used on the device

### DIFF
--- a/core/base/iterator_factory.hpp
+++ b/core/base/iterator_factory.hpp
@@ -13,6 +13,8 @@
 #include <tuple>
 #include <utility>
 
+#include <ginkgo/core/base/types.hpp>
+
 #include "core/base/copy_assignable.hpp"
 
 
@@ -290,7 +292,7 @@ class zip_iterator_reference
         // std::tuple<int, char> t = { 1, '2' }; is not allowed.
         // converting to 'std::tuple<...>' from initializer list would use
         // explicit constructor
-        return value_type(get<idxs>(*this)...);
+        return value_type(gko::get<idxs>(*this)...);
     }
 
     template <std::size_t... idxs>
@@ -298,7 +300,7 @@ class zip_iterator_reference
                                const value_type& other)
     {
         (void)std::initializer_list<int>{
-            (get<idxs>(*this) = get<idxs>(other), 0)...};
+            (gko::get<idxs>(*this) = gko::get<idxs>(other), 0)...};
     }
 
     constexpr explicit zip_iterator_reference(Iterators... it)
@@ -509,7 +511,7 @@ private:
         auto other_it = get<0>(other.iterators_);
         auto result = fn(it, other_it);
         forall_impl(
-            other, [&](auto a, auto b) { assert(it - other_it == a - b); },
+            other, [&](auto a, auto b) { GKO_ASSERT(it - other_it == a - b); },
             index_sequence{});
         return result;
     }

--- a/core/base/iterator_factory.hpp
+++ b/core/base/iterator_factory.hpp
@@ -24,6 +24,234 @@ template <typename... Iterators>
 class zip_iterator;
 
 
+template <typename... Iterators>
+class zip_iterator_reference;
+
+
+template <typename T, typename... Ts>
+class device_tuple;
+
+
+}  // namespace detail
+}  // namespace gko
+
+
+// structured binding specializations for device_tuple, zip_iterator_reference
+namespace std {
+
+
+template <typename... Ts>
+struct tuple_size<gko::detail::device_tuple<Ts...>>
+    : integral_constant<size_t, sizeof...(Ts)> {};
+
+
+template <std::size_t I, typename... Ts>
+struct tuple_element<I, gko::detail::device_tuple<Ts...>> {
+    using type = typename tuple_element<I, tuple<Ts...>>::type;
+};
+
+
+template <typename... Iterators>
+struct tuple_size<gko::detail::zip_iterator_reference<Iterators...>>
+    : integral_constant<size_t, sizeof...(Iterators)> {};
+
+
+template <std::size_t I, typename... Iterators>
+struct tuple_element<I, gko::detail::zip_iterator_reference<Iterators...>> {
+    using type = typename iterator_traits<
+        typename tuple_element<I, tuple<Iterators...>>::type>::reference;
+};
+
+
+}  // namespace std
+
+
+namespace gko {
+
+
+/** std::get reimplementation for device_tuple. */
+template <std::size_t index, typename... Ts>
+constexpr typename std::tuple_element<index, detail::device_tuple<Ts...>>::type&
+get(detail::device_tuple<Ts...>& tuple);
+
+
+/** std::get reimplementation for const device_tuple. */
+template <std::size_t index, typename... Ts>
+constexpr const typename std::tuple_element<index,
+                                            detail::device_tuple<Ts...>>::type&
+get(const detail::device_tuple<Ts...>& tuple);
+
+
+namespace detail {
+
+
+/** simplified constexpr std::tuple reimplementation for use in device code. */
+template <typename T, typename... Ts>
+class device_tuple {
+public:
+    /** Constructs a device tuple from its elements. */
+    constexpr explicit device_tuple(T value, Ts... others)
+        : value_{value}, other_{others...}
+    {}
+
+    device_tuple() = default;
+
+    /**
+     * Copy-assigns a tuple.
+     * This is necessary to make tuples of references work, which normally cause
+     * the impliciy copy-assignment operator to be deleted.
+     */
+    constexpr device_tuple& operator=(const device_tuple& other)
+    {
+        value_ = other.value_;
+        other_ = other.other_;
+        return *this;
+    }
+
+    /** @return the index-th element in the tuple. */
+    template <std::size_t index>
+    constexpr typename std::tuple_element<index, device_tuple>::type& get()
+    {
+        if constexpr (index == 0) {
+            return value_;
+        } else {
+            return other_.template get<index - 1>();
+        }
+    }
+
+    /** @return the index-th element in the const tuple. */
+    template <std::size_t index>
+    constexpr const typename std::tuple_element<index, device_tuple>::type&
+    get() const
+    {
+        if constexpr (index == 0) {
+            return value_;
+        } else {
+            return other_.template get<index - 1>();
+        }
+    }
+
+    // comparison operators
+    constexpr friend bool operator<(const device_tuple& lhs,
+                                    const device_tuple& rhs)
+    {
+        return lhs.value_ < rhs.value_ ||
+               (lhs.value_ == rhs.value_ && lhs.other_ < rhs.other_);
+    }
+
+    constexpr friend bool operator>(const device_tuple& lhs,
+                                    const device_tuple& rhs)
+    {
+        return rhs < lhs;
+    }
+
+    constexpr friend bool operator>=(const device_tuple& lhs,
+                                     const device_tuple& rhs)
+    {
+        return !(lhs < rhs);
+    }
+
+    constexpr friend bool operator<=(const device_tuple& lhs,
+                                     const device_tuple& rhs)
+    {
+        return !(lhs > rhs);
+    }
+
+    constexpr friend bool operator==(const device_tuple& lhs,
+                                     const device_tuple& rhs)
+    {
+        return lhs.value_ == rhs.value_ && lhs.other_ == rhs.other_;
+    }
+
+    constexpr friend bool operator!=(const device_tuple& lhs,
+                                     const device_tuple& rhs)
+    {
+        return !(lhs == rhs);
+    }
+
+private:
+    T value_;
+    device_tuple<Ts...> other_;
+};
+
+
+template <typename T>
+class device_tuple<T> {
+public:
+    /** Constructs a device tuple from its elements. */
+    constexpr explicit device_tuple(T value) : value_{value} {}
+
+    device_tuple() = default;
+
+    /**
+     * Copy-assigns a tuple.
+     * This is necessary to make tuples of references work, which normally cause
+     * the impliciy copy-assignment operator to be deleted.
+     */
+    constexpr device_tuple& operator=(const device_tuple& other)
+    {
+        value_ = other.value_;
+        return *this;
+    }
+
+    /** @return the index-th element in the tuple. */
+    template <std::size_t index>
+    constexpr T& get()
+    {
+        static_assert(index == 0, "invalid index");
+        return value_;
+    }
+
+    /** @return the index-th element in the const tuple. */
+    template <std::size_t index>
+    constexpr const T& get() const
+    {
+        static_assert(index == 0, "invalid index");
+        return value_;
+    }
+
+    // comparison operators
+    constexpr friend bool operator<(const device_tuple& lhs,
+                                    const device_tuple& rhs)
+    {
+        return lhs.value_ < rhs.value_;
+    }
+
+    constexpr friend bool operator>(const device_tuple& lhs,
+                                    const device_tuple& rhs)
+    {
+        return rhs < lhs;
+    }
+
+    constexpr friend bool operator>=(const device_tuple& lhs,
+                                     const device_tuple& rhs)
+    {
+        return !(lhs < rhs);
+    }
+
+    constexpr friend bool operator<=(const device_tuple& lhs,
+                                     const device_tuple& rhs)
+    {
+        return !(lhs > rhs);
+    }
+
+    constexpr friend bool operator==(const device_tuple& lhs,
+                                     const device_tuple& rhs)
+    {
+        return lhs.value_ == rhs.value_;
+    }
+
+    constexpr friend bool operator!=(const device_tuple& lhs,
+                                     const device_tuple& rhs)
+    {
+        return !(lhs == rhs);
+    }
+
+private:
+    T value_;
+};
+
+
 /**
  * A reference-like type pointing to a tuple of elements originating from a
  * tuple of iterators. A few caveats related to its use:
@@ -45,45 +273,51 @@ class zip_iterator;
  */
 template <typename... Iterators>
 class zip_iterator_reference
-    : public std::tuple<
+    : public device_tuple<
           typename std::iterator_traits<Iterators>::reference...> {
     using ref_tuple_type =
-        std::tuple<typename std::iterator_traits<Iterators>::reference...>;
+        device_tuple<typename std::iterator_traits<Iterators>::reference...>;
     using value_type =
-        std::tuple<typename std::iterator_traits<Iterators>::value_type...>;
+        device_tuple<typename std::iterator_traits<Iterators>::value_type...>;
     using index_sequence = std::index_sequence_for<Iterators...>;
 
     friend class zip_iterator<Iterators...>;
 
     template <std::size_t... idxs>
-    value_type cast_impl(std::index_sequence<idxs...>) const
+    constexpr value_type cast_impl(std::index_sequence<idxs...>) const
     {
         // gcc 5 throws error as using uninitialized array
         // std::tuple<int, char> t = { 1, '2' }; is not allowed.
         // converting to 'std::tuple<...>' from initializer list would use
         // explicit constructor
-        return value_type(std::get<idxs>(*this)...);
+        return value_type(get<idxs>(*this)...);
     }
 
     template <std::size_t... idxs>
-    void assign_impl(std::index_sequence<idxs...>, const value_type& other)
+    constexpr void assign_impl(std::index_sequence<idxs...>,
+                               const value_type& other)
     {
         (void)std::initializer_list<int>{
-            (std::get<idxs>(*this) = std::get<idxs>(other), 0)...};
+            (get<idxs>(*this) = get<idxs>(other), 0)...};
     }
 
-    zip_iterator_reference(Iterators... it) : ref_tuple_type{*it...} {}
+    constexpr explicit zip_iterator_reference(Iterators... it)
+        : ref_tuple_type{*it...}
+    {}
 
 public:
-    operator value_type() const { return cast_impl(index_sequence{}); }
+    constexpr operator value_type() const
+    {
+        return cast_impl(index_sequence{});
+    }
 
-    zip_iterator_reference& operator=(const value_type& other)
+    constexpr zip_iterator_reference& operator=(const value_type& other)
     {
         assign_impl(index_sequence{}, other);
         return *this;
     }
 
-    value_type copy() const { return *this; }
+    constexpr value_type copy() const { return *this; }
 };
 
 
@@ -123,153 +357,156 @@ class zip_iterator {
 public:
     using difference_type = std::ptrdiff_t;
     using value_type =
-        std::tuple<typename std::iterator_traits<Iterators>::value_type...>;
+        device_tuple<typename std::iterator_traits<Iterators>::value_type...>;
     using pointer = value_type*;
     using reference = zip_iterator_reference<Iterators...>;
     using iterator_category = std::random_access_iterator_tag;
     using index_sequence = std::index_sequence_for<Iterators...>;
 
-    explicit zip_iterator() = default;
+    constexpr zip_iterator() = default;
 
-    explicit zip_iterator(Iterators... its) : iterators_{its...} {}
+    constexpr explicit zip_iterator(Iterators... its) : iterators_{its...} {}
 
-    zip_iterator& operator+=(difference_type i)
+    constexpr zip_iterator& operator+=(difference_type i)
     {
         forall([i](auto& it) { it += i; });
         return *this;
     }
 
-    zip_iterator& operator-=(difference_type i)
+    constexpr zip_iterator& operator-=(difference_type i)
     {
         forall([i](auto& it) { it -= i; });
         return *this;
     }
 
-    zip_iterator& operator++()
+    constexpr zip_iterator& operator++()
     {
         forall([](auto& it) { it++; });
         return *this;
     }
 
-    zip_iterator operator++(int)
+    constexpr zip_iterator operator++(int)
     {
         auto tmp = *this;
         ++(*this);
         return tmp;
     }
 
-    zip_iterator& operator--()
+    constexpr zip_iterator& operator--()
     {
         forall([](auto& it) { it--; });
         return *this;
     }
 
-    zip_iterator operator--(int)
+    constexpr zip_iterator operator--(int)
     {
         auto tmp = *this;
         --(*this);
         return tmp;
     }
 
-    zip_iterator operator+(difference_type i) const
+    constexpr zip_iterator operator+(difference_type i) const
     {
         auto tmp = *this;
         tmp += i;
         return tmp;
     }
 
-    friend zip_iterator operator+(difference_type i, const zip_iterator& iter)
+    constexpr friend zip_iterator operator+(difference_type i,
+                                            const zip_iterator& iter)
     {
         return iter + i;
     }
 
-    zip_iterator operator-(difference_type i) const
+    constexpr zip_iterator operator-(difference_type i) const
     {
         auto tmp = *this;
         tmp -= i;
         return tmp;
     }
 
-    difference_type operator-(const zip_iterator& other) const
+    constexpr difference_type operator-(const zip_iterator& other) const
     {
         return forall_check_consistent(
             other, [](const auto& a, const auto& b) { return a - b; });
     }
 
-    reference operator*() const
+    constexpr reference operator*() const
     {
         return deref_impl(std::index_sequence_for<Iterators...>{});
     }
 
-    reference operator[](difference_type i) const { return *(*this + i); }
+    constexpr reference operator[](difference_type i) const
+    {
+        return *(*this + i);
+    }
 
-    bool operator==(const zip_iterator& other) const
+    constexpr bool operator==(const zip_iterator& other) const
     {
         return forall_check_consistent(
             other, [](const auto& a, const auto& b) { return a == b; });
     }
 
-    bool operator!=(const zip_iterator& other) const
+    constexpr bool operator!=(const zip_iterator& other) const
     {
         return !(*this == other);
     }
 
-    bool operator<(const zip_iterator& other) const
+    constexpr bool operator<(const zip_iterator& other) const
     {
         return forall_check_consistent(
             other, [](const auto& a, const auto& b) { return a < b; });
     }
 
-    bool operator<=(const zip_iterator& other) const
+    constexpr bool operator<=(const zip_iterator& other) const
     {
         return forall_check_consistent(
             other, [](const auto& a, const auto& b) { return a <= b; });
     }
 
-    bool operator>(const zip_iterator& other) const
+    constexpr bool operator>(const zip_iterator& other) const
     {
         return !(*this <= other);
     }
 
-    bool operator>=(const zip_iterator& other) const
+    constexpr bool operator>=(const zip_iterator& other) const
     {
         return !(*this < other);
     }
 
 private:
     template <std::size_t... idxs>
-    reference deref_impl(std::index_sequence<idxs...>) const
+    constexpr reference deref_impl(std::index_sequence<idxs...>) const
     {
-        return reference{std::get<idxs>(iterators_)...};
+        return reference{get<idxs>(iterators_)...};
     }
 
     template <typename Functor>
-    void forall(Functor fn)
+    constexpr void forall(Functor fn)
     {
         forall_impl(fn, index_sequence{});
     }
 
     template <typename Functor, std::size_t... idxs>
-    void forall_impl(Functor fn, std::index_sequence<idxs...>)
+    constexpr void forall_impl(Functor fn, std::index_sequence<idxs...>)
     {
-        (void)std::initializer_list<int>{
-            (fn(std::get<idxs>(iterators_)), 0)...};
+        (void)std::initializer_list<int>{(fn(get<idxs>(iterators_)), 0)...};
     }
 
     template <typename Functor, std::size_t... idxs>
-    void forall_impl(const zip_iterator& other, Functor fn,
-                     std::index_sequence<idxs...>) const
+    constexpr void forall_impl(const zip_iterator& other, Functor fn,
+                               std::index_sequence<idxs...>) const
     {
         (void)std::initializer_list<int>{
-            (fn(std::get<idxs>(iterators_), std::get<idxs>(other.iterators_)),
-             0)...};
+            (fn(get<idxs>(iterators_), get<idxs>(other.iterators_)), 0)...};
     }
 
     template <typename Functor>
-    auto forall_check_consistent(const zip_iterator& other, Functor fn) const
+    constexpr auto forall_check_consistent(const zip_iterator& other,
+                                           Functor fn) const
     {
-        auto it = std::get<0>(iterators_);
-        auto other_it = std::get<0>(other.iterators_);
+        auto it = get<0>(iterators_);
+        auto other_it = get<0>(other.iterators_);
         auto result = fn(it, other_it);
         forall_impl(
             other, [&](auto a, auto b) { assert(it - other_it == a - b); },
@@ -277,12 +514,13 @@ private:
         return result;
     }
 
-    std::tuple<Iterators...> iterators_;
+    device_tuple<Iterators...> iterators_;
 };
 
 
 template <typename... Iterators>
-zip_iterator<std::decay_t<Iterators>...> make_zip_iterator(Iterators&&... it)
+constexpr zip_iterator<std::decay_t<Iterators>...> make_zip_iterator(
+    Iterators&&... it)
 {
     return zip_iterator<std::decay_t<Iterators>...>{
         std::forward<Iterators>(it)...};
@@ -305,8 +543,8 @@ zip_iterator<std::decay_t<Iterators>...> make_zip_iterator(Iterators&&... it)
  * @tparam Iterators  the iterator types inside the corresponding zip_iterator
  */
 template <typename... Iterators>
-void swap(zip_iterator_reference<Iterators...> a,
-          zip_iterator_reference<Iterators...> b)
+constexpr void swap(zip_iterator_reference<Iterators...> a,
+                    zip_iterator_reference<Iterators...> b)
 {
     auto tmp = a.copy();
     a = b;
@@ -318,8 +556,8 @@ void swap(zip_iterator_reference<Iterators...> a,
  * @copydoc swap(zip_iterator_reference, zip_iterator_reference)
  */
 template <typename... Iterators>
-void swap(typename zip_iterator<Iterators...>::value_type& a,
-          zip_iterator_reference<Iterators...> b)
+constexpr void swap(typename zip_iterator<Iterators...>::value_type& a,
+                    zip_iterator_reference<Iterators...> b)
 {
     auto tmp = a;
     a = b;
@@ -331,8 +569,8 @@ void swap(typename zip_iterator<Iterators...>::value_type& a,
  * @copydoc swap(zip_iterator_reference, zip_iterator_reference)
  */
 template <typename... Iterators>
-void swap(zip_iterator_reference<Iterators...> a,
-          typename zip_iterator<Iterators...>::value_type& b)
+constexpr void swap(zip_iterator_reference<Iterators...> a,
+                    typename zip_iterator<Iterators...>::value_type& b)
 {
     auto tmp = a.copy();
     a = b;
@@ -468,6 +706,25 @@ permute_iterator<IteratorType, PermutationFn> make_permute_iterator(
 
 
 }  // namespace detail
+
+
+template <std::size_t index, typename... Ts>
+constexpr typename std::tuple_element<index, detail::device_tuple<Ts...>>::type&
+get(detail::device_tuple<Ts...>& tuple)
+{
+    return tuple.template get<index>();
+}
+
+
+template <std::size_t index, typename... Ts>
+constexpr const typename std::tuple_element<index,
+                                            detail::device_tuple<Ts...>>::type&
+get(const detail::device_tuple<Ts...>& tuple)
+{
+    return tuple.template get<index>();
+}
+
+
 }  // namespace gko
 
 

--- a/core/test/base/iterator_factory.cpp
+++ b/core/test/base/iterator_factory.cpp
@@ -156,6 +156,7 @@ TYPED_TEST(ZipIterator, IteratorReferenceOperatorSmaller2)
 
 TYPED_TEST(ZipIterator, IncreasingIterator)
 {
+    using gko::get;
     using index_type = typename TestFixture::index_type;
     using value_type = typename TestFixture::value_type;
     std::vector<index_type> vec1{this->reversed_index};
@@ -182,8 +183,8 @@ TYPED_TEST(ZipIterator, IncreasingIterator)
     ASSERT_TRUE(increment_pre_2 == increment_post_2);
     ASSERT_TRUE(begin == increment_post_test++);
     ASSERT_TRUE(begin + 1 == ++increment_pre_test);
-    ASSERT_TRUE(std::get<0>(*plus_2) == vec1[2]);
-    ASSERT_TRUE(std::get<1>(*plus_2) == vec2[2]);
+    ASSERT_TRUE(get<0>(*plus_2) == vec1[2]);
+    ASSERT_TRUE(get<1>(*plus_2) == vec2[2]);
     // check other comparison operators and difference
     std::vector<gko::detail::zip_iterator<index_type*, value_type*>> its{
         begin,
@@ -257,6 +258,7 @@ TYPED_TEST(ZipIterator, IncompatibleIteratorDeathTest)
 
 TYPED_TEST(ZipIterator, DecreasingIterator)
 {
+    using gko::get;
     using index_type = typename TestFixture::index_type;
     using value_type = typename TestFixture::value_type;
     std::vector<index_type> vec1{this->reversed_index};
@@ -280,13 +282,14 @@ TYPED_TEST(ZipIterator, DecreasingIterator)
     ASSERT_TRUE(decrement_pre_2 == decrement_post_2);
     ASSERT_TRUE(iter == decrement_post_test--);
     ASSERT_TRUE(iter - 1 == --decrement_pre_test);
-    ASSERT_TRUE(std::get<0>(*minus_2) == vec1[3]);
-    ASSERT_TRUE(std::get<1>(*minus_2) == vec2[3]);
+    ASSERT_TRUE(get<0>(*minus_2) == vec1[3]);
+    ASSERT_TRUE(get<1>(*minus_2) == vec2[3]);
 }
 
 
 TYPED_TEST(ZipIterator, CorrectDereferencing)
 {
+    using gko::get;
     using index_type_it = typename TestFixture::index_type;
     using value_type_it = typename TestFixture::value_type;
     std::vector<index_type_it> vec1{this->reversed_index};
@@ -299,10 +302,10 @@ TYPED_TEST(ZipIterator, CorrectDereferencing)
     auto to_test_ref = *(begin + element_to_test);
     value_type to_test_pair = to_test_ref;  // Testing implicit conversion
 
-    ASSERT_TRUE(std::get<0>(to_test_pair) == vec1[element_to_test]);
-    ASSERT_TRUE(std::get<0>(to_test_pair) == std::get<0>(to_test_ref));
-    ASSERT_TRUE(std::get<1>(to_test_pair) == vec2[element_to_test]);
-    ASSERT_TRUE(std::get<1>(to_test_pair) == std::get<1>(to_test_ref));
+    ASSERT_TRUE(get<0>(to_test_pair) == vec1[element_to_test]);
+    ASSERT_TRUE(get<0>(to_test_pair) == get<0>(to_test_ref));
+    ASSERT_TRUE(get<1>(to_test_pair) == vec2[element_to_test]);
+    ASSERT_TRUE(get<1>(to_test_pair) == get<1>(to_test_ref));
 }
 
 

--- a/omp/distributed/index_map_kernels.cpp
+++ b/omp/distributed/index_map_kernels.cpp
@@ -58,16 +58,15 @@ void build_mapping(
     auto sort_it = detail::make_zip_iterator(
         full_remote_part_ids.begin(), recv_connections_ptr, range_ids.begin());
     std::sort(sort_it, sort_it + input_size, [](const auto& a, const auto& b) {
-        return std::tie(std::get<0>(a), std::get<1>(a)) <
-               std::tie(std::get<0>(b), std::get<1>(b));
+        return std::tie(get<0>(a), get<1>(a)) < std::tie(get<0>(b), get<1>(b));
     });
 
     // get only unique connections
-    auto unique_end = std::unique(
-        sort_it, sort_it + input_size, [](const auto& a, const auto& b) {
-            return std::tie(std::get<0>(a), std::get<1>(a)) ==
-                   std::tie(std::get<0>(b), std::get<1>(b));
-        });
+    auto unique_end = std::unique(sort_it, sort_it + input_size,
+                                  [](const auto& a, const auto& b) {
+                                      return std::tie(get<0>(a), get<1>(a)) ==
+                                             std::tie(get<0>(b), get<1>(b));
+                                  });
     auto unique_size = std::distance(sort_it, unique_end);
 
     remote_global_idxs.resize_and_reset(unique_size);

--- a/omp/distributed/partition_helpers_kernels.cpp
+++ b/omp/distributed/partition_helpers_kernels.cpp
@@ -27,10 +27,9 @@ void sort_by_range_start(
         range_start_ends.get_data() + 1, [](const auto i) { return 2 * i; });
     auto sort_it = detail::make_zip_iterator(start_it, end_it, part_ids_d);
     // TODO: use TBB or parallel std with c++17
-    std::stable_sort(sort_it, sort_it + num_parts,
-                     [](const auto& a, const auto& b) {
-                         return std::get<0>(a) < std::get<0>(b);
-                     });
+    std::stable_sort(
+        sort_it, sort_it + num_parts,
+        [](const auto& a, const auto& b) { return get<0>(a) < get<0>(b); });
 }
 
 GKO_INSTANTIATE_FOR_EACH_INDEX_TYPE(

--- a/omp/matrix/csr_kernels.cpp
+++ b/omp/matrix/csr_kernels.cpp
@@ -1155,9 +1155,8 @@ void sort_by_column_index(std::shared_ptr<const OmpExecutor> exec,
         auto row_nnz = row_ptrs[i + 1] - start_row_idx;
         auto it = detail::make_zip_iterator(col_idxs + start_row_idx,
                                             values + start_row_idx);
-        std::sort(it, it + row_nnz, [](auto t1, auto t2) {
-            return std::get<0>(t1) < std::get<0>(t2);
-        });
+        std::sort(it, it + row_nnz,
+                  [](auto t1, auto t2) { return get<0>(t1) < get<0>(t2); });
     }
 }
 

--- a/omp/matrix/fbcsr_kernels.cpp
+++ b/omp/matrix/fbcsr_kernels.cpp
@@ -398,9 +398,8 @@ void sort_by_column_index_impl(
         std::vector<IndexType> col_permute(nbnz_brow);
         std::iota(col_permute.begin(), col_permute.end(), 0);
         auto it = detail::make_zip_iterator(brow_col_idxs, col_permute.data());
-        std::sort(it, it + nbnz_brow, [](auto a, auto b) {
-            return std::get<0>(a) < std::get<0>(b);
-        });
+        std::sort(it, it + nbnz_brow,
+                  [](auto a, auto b) { return get<0>(a) < get<0>(b); });
 
         std::vector<ValueType> oldvalues(nbnz_brow * bs2);
         std::copy(brow_vals, brow_vals + nbnz_brow * bs2, oldvalues.begin());

--- a/omp/multigrid/pgm_kernels.cpp
+++ b/omp/multigrid/pgm_kernels.cpp
@@ -43,8 +43,7 @@ void sort_row_major(std::shared_ptr<const DefaultExecutor> exec, size_type nnz,
 {
     auto it = detail::make_zip_iterator(row_idxs, col_idxs, vals);
     std::stable_sort(it, it + nnz, [](auto a, auto b) {
-        return std::tie(std::get<0>(a), std::get<1>(a)) <
-               std::tie(std::get<0>(b), std::get<1>(b));
+        return std::tie(get<0>(a), get<1>(a)) < std::tie(get<0>(b), get<1>(b));
     });
 }
 

--- a/reference/distributed/partition_helpers_kernels.cpp
+++ b/reference/distributed/partition_helpers_kernels.cpp
@@ -26,10 +26,9 @@ void sort_by_range_start(
     auto end_it = detail::make_permute_iterator(
         range_start_ends.get_data() + 1, [](const auto i) { return 2 * i; });
     auto sort_it = detail::make_zip_iterator(start_it, end_it, part_ids_d);
-    std::stable_sort(sort_it, sort_it + num_parts,
-                     [](const auto& a, const auto& b) {
-                         return std::get<0>(a) < std::get<0>(b);
-                     });
+    std::stable_sort(
+        sort_it, sort_it + num_parts,
+        [](const auto& a, const auto& b) { return get<0>(a) < get<0>(b); });
 }
 
 GKO_INSTANTIATE_FOR_EACH_INDEX_TYPE(
@@ -51,9 +50,9 @@ void check_consecutive_ranges(std::shared_ptr<const DefaultExecutor> exec,
     auto range_it = detail::make_zip_iterator(start_it, end_it);
 
     if (num_parts) {
-        result = std::all_of(
-            range_it, range_it + num_parts - 1,
-            [](const auto& r) { return std::get<0>(r) == std::get<1>(r); });
+        result =
+            std::all_of(range_it, range_it + num_parts - 1,
+                        [](const auto& r) { return get<0>(r) == get<1>(r); });
     } else {
         result = true;
     }

--- a/reference/matrix/csr_kernels.cpp
+++ b/reference/matrix/csr_kernels.cpp
@@ -1128,9 +1128,8 @@ void sort_by_column_index(std::shared_ptr<const ReferenceExecutor> exec,
         auto row_nnz = row_ptrs[i + 1] - start_row_idx;
         auto it = detail::make_zip_iterator(col_idxs + start_row_idx,
                                             values + start_row_idx);
-        std::sort(it, it + row_nnz, [](auto t1, auto t2) {
-            return std::get<0>(t1) < std::get<0>(t2);
-        });
+        std::sort(it, it + row_nnz,
+                  [](auto t1, auto t2) { return get<0>(t1) < get<0>(t2); });
     }
 }
 

--- a/reference/matrix/fbcsr_kernels.cpp
+++ b/reference/matrix/fbcsr_kernels.cpp
@@ -418,9 +418,8 @@ void sort_by_column_index_impl(
         std::vector<IndexType> col_permute(nbnz_brow);
         std::iota(col_permute.begin(), col_permute.end(), 0);
         auto it = detail::make_zip_iterator(brow_col_idxs, col_permute.data());
-        std::sort(it, it + nbnz_brow, [](auto a, auto b) {
-            return std::get<0>(a) < std::get<0>(b);
-        });
+        std::sort(it, it + nbnz_brow,
+                  [](auto a, auto b) { return get<0>(a) < get<0>(b); });
 
         std::vector<ValueType> oldvalues(nbnz_brow * bs2);
         std::copy(brow_vals, brow_vals + nbnz_brow * bs2, oldvalues.begin());

--- a/reference/multigrid/pgm_kernels.cpp
+++ b/reference/multigrid/pgm_kernels.cpp
@@ -270,8 +270,7 @@ void sort_row_major(std::shared_ptr<const DefaultExecutor> exec, size_type nnz,
 {
     auto it = detail::make_zip_iterator(row_idxs, col_idxs, vals);
     std::stable_sort(it, it + nnz, [](auto a, auto b) {
-        return std::tie(std::get<0>(a), std::get<1>(a)) <
-               std::tie(std::get<0>(b), std::get<1>(b));
+        return std::tie(get<0>(a), get<1>(a)) < std::tie(get<0>(b), get<1>(b));
     });
 }
 

--- a/test/base/CMakeLists.txt
+++ b/test/base/CMakeLists.txt
@@ -1,6 +1,7 @@
 ginkgo_create_common_test(batch_multi_vector_kernels)
 ginkgo_create_common_and_reference_test(device_matrix_data_kernels)
 ginkgo_create_common_device_test(index_range)
+ginkgo_create_common_device_test(iterator_factory)
 ginkgo_create_common_device_test(kernel_launch_generic)
 ginkgo_create_common_and_reference_test(executor)
 ginkgo_create_common_and_reference_test(timer)

--- a/test/base/iterator_factory.cpp
+++ b/test/base/iterator_factory.cpp
@@ -1,0 +1,69 @@
+// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+//
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include "core/base/iterator_factory.hpp"
+
+#include <memory>
+
+#include <gtest/gtest.h>
+
+#include <ginkgo/core/base/array.hpp>
+
+#include "common/unified/base/kernel_launch.hpp"
+#include "core/test/utils.hpp"
+#include "test/utils/executor.hpp"
+
+
+class IteratorFactory : public CommonTestFixture {
+public:
+    IteratorFactory()
+        : key_array{exec, {6, 2, 3, 8, 1, 0, 2}},
+          value_array{exec, {9, 5, 7, 2, 4, 7, 2}},
+          expected_key_array{ref, {7, 1, 2, 2, 3, 6, 8}},
+          expected_value_array{ref, {7, 4, 2, 5, 7, 9, 2}}
+    {}
+
+    gko::array<int> key_array;
+    gko::array<int> value_array;
+    gko::array<int> expected_key_array;
+    gko::array<int> expected_value_array;
+};
+
+
+// nvcc doesn't like device lambdas declared in complex classes, move it out
+void run_zip_iterator(std::shared_ptr<gko::EXEC_TYPE> exec,
+                      gko::array<int>& key_array, gko::array<int>& value_array)
+{
+    gko::kernels::EXEC_NAMESPACE::run_kernel(
+        exec,
+        [] GKO_KERNEL(auto i, auto keys, auto values, auto size) {
+            auto begin = gko::detail::make_zip_iterator(keys, values);
+            auto end = begin + size;
+            using std::swap;
+            for (auto it = begin; it != end; ++it) {
+                auto min_it = it;
+                for (auto it2 = it; it2 != end; ++it2) {
+                    if (*it2 < *min_it) {
+                        min_it = it2;
+                    }
+                }
+                swap(*it, *min_it);
+            }
+            // check structured bindings
+            auto [key, value] = *begin;
+            static_assert(std::is_same<typeof(key), int>::value,
+                          "incorrect type");
+            gko::get<0>(*begin) = value;
+        },
+        1, key_array, value_array, static_cast<int>(key_array.get_size()));
+}
+
+
+TEST_F(IteratorFactory, KernelRunsZipIterator)
+{
+    run_zip_iterator(exec, key_array, value_array);
+
+    GKO_ASSERT_ARRAY_EQ(key_array, expected_key_array);
+    GKO_ASSERT_ARRAY_EQ(value_array, expected_value_array);
+}

--- a/test/base/iterator_factory.cpp
+++ b/test/base/iterator_factory.cpp
@@ -52,7 +52,8 @@ void run_zip_iterator(std::shared_ptr<gko::EXEC_TYPE> exec,
             }
             // check structured bindings
             auto [key, value] = *begin;
-            static_assert(std::is_same<typeof(key), int>::value,
+            static_assert(std::is_same<std::remove_reference_t<decltype(key)>,
+                                       int>::value,
                           "incorrect type");
             gko::get<0>(*begin) = value;
         },

--- a/test/base/iterator_factory.cpp
+++ b/test/base/iterator_factory.cpp
@@ -12,7 +12,7 @@
 
 #include "common/unified/base/kernel_launch.hpp"
 #include "core/test/utils.hpp"
-#include "test/utils/executor.hpp"
+#include "test/utils/common_fixture.hpp"
 
 
 class IteratorFactory : public CommonTestFixture {
@@ -35,7 +35,7 @@ public:
 void run_zip_iterator(std::shared_ptr<gko::EXEC_TYPE> exec,
                       gko::array<int>& key_array, gko::array<int>& value_array)
 {
-    gko::kernels::EXEC_NAMESPACE::run_kernel(
+    gko::kernels::GKO_DEVICE_NAMESPACE::run_kernel(
         exec,
         [] GKO_KERNEL(auto i, auto keys, auto values, auto size) {
             auto begin = gko::detail::make_zip_iterator(keys, values);


### PR DESCRIPTION
This replaces `std::tuple` by a custom `device_tuple` implementation to be used on the device.

TODO

- [x] Merge #1603 