### PR TITLE
Fix: remove early return in communicate

### DIFF
--- a/core/distributed/matrix.cpp
+++ b/core/distributed/matrix.cpp
@@ -7,6 +7,7 @@
 
 #include <ginkgo/core/base/precision_dispatch.hpp>
 #include <ginkgo/core/distributed/vector.hpp>
+#include <ginkgo/core/matrix/coo.hpp>
 #include <ginkgo/core/matrix/csr.hpp>
 
 
@@ -81,12 +82,14 @@ Matrix<ValueType, LocalIndexType, GlobalIndexType>::Matrix(
       gather_idxs_{exec},
       recv_gather_idxs_{exec},
       non_local_to_global_{exec},
-      one_scalar_{}
+      one_scalar_{},
+      non_local_mtx_(::gko::matrix::Coo<ValueType, LocalIndexType>::create(
+          exec, dim<2>{local_linop->get_size()[0], 0}))
 {
     this->set_size(size);
     one_scalar_.init(exec, dim<2>{1, 1});
     one_scalar_->fill(one<value_type>());
-    local_mtx_ = local_linop;
+    local_mtx_ = std::move(local_linop);
 }
 
 

--- a/core/test/mpi/distributed/matrix.cpp
+++ b/core/test/mpi/distributed/matrix.cpp
@@ -262,6 +262,7 @@ TYPED_TEST(MatrixBuilder, BuildLocalOnly)
     using dist_mtx_type = typename TestFixture::dist_mtx_type;
     using dist_vec_type = typename TestFixture::dist_vec_type;
     using custom_type = CustomLinOp<value_type, index_type>;
+    using empty_non_local_type = gko::matrix::Coo<value_type, index_type>;
     auto local_n = this->comm.rank() + 1;
     // global_size = 1 + 2 + ... + num_rank
     auto global_n = ((1 + this->comm.size()) * this->comm.size()) / 2;
@@ -277,7 +278,8 @@ TYPED_TEST(MatrixBuilder, BuildLocalOnly)
         custom_type::create(this->ref, gko::dim<2>(local_n, local_n)));
 
     ASSERT_NO_THROW(gko::as<custom_type>(mat->get_local_matrix()));
-    ASSERT_EQ(mat->get_non_local_matrix(), nullptr);
+    ASSERT_NE(mat->get_non_local_matrix(), nullptr);
+    ASSERT_NO_THROW(gko::as<empty_non_local_type>(mat->get_non_local_matrix()));
     GKO_ASSERT_EQUAL_DIMENSIONS(mat->get_local_matrix()->get_size(),
                                 gko::dim<2>(local_n, local_n));
     GKO_ASSERT_EQUAL_DIMENSIONS(mat->get_local_size(),


### PR DESCRIPTION
This PR removes the early return in the `distributed::Matrix::communicate`. It is not possible to return early there because the MPI calls have to be executed by all processes, even if a process might not send anything.

I've also removed an `if` in the matrix apply, since IMO it complicated the control flow a bit.