### PR TITLE
Reduce the DistributedBase interface

### DIFF
--- a/core/base/block_operator.cpp
+++ b/core/base/block_operator.cpp
@@ -22,9 +22,8 @@ namespace {
 template <typename Fn>
 auto dispatch_dense(Fn&& fn, LinOp* v)
 {
-    return run<matrix::Dense<float>*, matrix::Dense<double>*,
-               matrix::Dense<std::complex<float>>*,
-               matrix::Dense<std::complex<double>>*>(v, std::forward<Fn>(fn));
+    return run<matrix::Dense, float, double, std::complex<float>,
+               std::complex<double>>(v, std::forward<Fn>(fn));
 }
 
 

--- a/core/base/dispatch_helper.hpp
+++ b/core/base/dispatch_helper.hpp
@@ -16,6 +16,12 @@ namespace gko {
 namespace detail {
 
 
+template <typename T, typename MaybeConstU>
+using with_same_constness_t = std::conditional_t<
+    std::is_const<typename std::remove_reference_t<MaybeConstU>>::value,
+    const T, T>;
+
+
 /**
  *
  * @copydoc run<typename ReturnType, typename K, typename... Types, typename T,
@@ -24,7 +30,7 @@ namespace detail {
  * @note this is the end case
  */
 template <typename ReturnType, typename T, typename Func, typename... Args>
-ReturnType run_impl(T obj, Func&&, Args&&...)
+ReturnType run_impl(T* obj, Func&&, Args&&...)
 {
     GKO_NOT_SUPPORTED(obj);
 }
@@ -37,9 +43,9 @@ ReturnType run_impl(T obj, Func&&, Args&&...)
  */
 template <typename ReturnType, typename K, typename... Types, typename T,
           typename Func, typename... Args>
-ReturnType run_impl(T obj, Func&& f, Args&&... args)
+ReturnType run_impl(T* obj, Func&& f, Args&&... args)
 {
-    if (auto dobj = dynamic_cast<K>(obj)) {
+    if (auto dobj = dynamic_cast<with_same_constness_t<K, T>*>(obj)) {
         return f(dobj, std::forward<Args>(args)...);
     } else {
         return run_impl<ReturnType, Types...>(obj, std::forward<Func>(f),
@@ -140,13 +146,16 @@ ReturnType run_impl(T obj, Func&& f, Args&&... args)
  */
 template <typename K, typename... Types, typename T, typename Func,
           typename... Args>
-auto run(T obj, Func&& f, Args&&... args)
+auto run(T* obj, Func&& f, Args&&... args)
 {
 #if __cplusplus < 201703L
     // result_of_t is deprecated in C++17
-    using ReturnType = std::result_of_t<Func(K, Args...)>;
+    using ReturnType =
+        std::result_of_t<Func(detail::with_same_constness_t<K, T>*, Args...)>;
 #else
-    using ReturnType = std::invoke_result_t<Func, K, Args...>;
+    using ReturnType =
+        std::invoke_result_t<Func, detail::with_same_constness_t<K, T>*,
+                             Args...>;
 #endif
     return detail::run_impl<ReturnType, K, Types...>(
         obj, std::forward<Func>(f), std::forward<Args>(args)...);
@@ -185,6 +194,34 @@ auto run(std::shared_ptr<T> obj, Func&& f, Args&&... args)
 #endif
     return detail::run_impl<ReturnType, K, Types...>(
         obj, std::forward<Func>(f), std::forward<Args>(args)...);
+}
+
+
+/**
+ * run uses template to go through the list and select the valid
+ * template and run it.
+ *
+ * @tparam Base  the Base class with one template
+ * @tparam K  the current template type of B. pointer of const Base<K> is tried
+ *            in the conversion.
+ * @tparam ...Types  the other types will be tried in the conversion if K fails
+ * @tparam T  the type of input object waiting converted
+ * @tparam Func  the function will run if the object can be converted to pointer
+ *               of const Base<K>
+ * @tparam ...Args  the additional arguments for the Func
+ *
+ * @param obj  the input object waiting converted
+ * @param f  the function will run if obj can be converted successfully
+ * @param args  the additional arguments for the function
+ *
+ * @return  the result of f invoked with obj cast to the first matching type
+ */
+template <template <class> class K, typename... Types, typename T,
+          typename Func, typename... Args>
+auto run(T* obj, Func&& f, Args&&... args)
+{
+    return run<K<Types>...>(obj, std::forward<Func>(f),
+                            std::forward<Args>(args)...);
 }
 
 

--- a/core/distributed/helpers.hpp
+++ b/core/distributed/helpers.hpp
@@ -10,8 +10,12 @@
 
 
 #include <ginkgo/config.hpp>
+#include <ginkgo/core/distributed/matrix.hpp>
 #include <ginkgo/core/distributed/vector.hpp>
 #include <ginkgo/core/matrix/dense.hpp>
+
+
+#include "core/base/dispatch_helper.hpp"
 
 
 namespace gko {
@@ -138,6 +142,32 @@ void vector_dispatch(T* linop, F&& f, Args&&... args)
         }
     }
 }
+
+
+#if GINKGO_BUILD_MPI
+
+
+/**
+ * Specialization of run for distributed matrices.
+ */
+template <typename T, typename F, typename... Args>
+auto run_matrix(T* linop, F&& f, Args&&... args)
+{
+    using namespace gko::experimental::distributed;
+    return run<Matrix<double, int32, int32>, Matrix<double, int32, int64>,
+               Matrix<double, int64, int64>, Matrix<float, int32, int32>,
+               Matrix<float, int32, int64>, Matrix<float, int64, int64>,
+               Matrix<std::complex<double>, int32, int32>,
+               Matrix<std::complex<double>, int32, int64>,
+               Matrix<std::complex<double>, int64, int64>,
+               Matrix<std::complex<float>, int32, int32>,
+               Matrix<std::complex<float>, int32, int64>,
+               Matrix<std::complex<float>, int64, int64>>(
+        linop, std::forward<F>(f), std::forward<Args>(args)...);
+}
+
+
+#endif
 
 
 /**

--- a/core/distributed/matrix.cpp
+++ b/core/distributed/matrix.cpp
@@ -417,14 +417,6 @@ mpi::request Matrix<ValueType, LocalIndexType, GlobalIndexType>::communicate(
 
 
 template <typename ValueType, typename LocalIndexType, typename GlobalIndexType>
-dim<2> Matrix<ValueType, LocalIndexType, GlobalIndexType>::get_local_size()
-    const
-{
-    return local_mtx_->get_size();
-}
-
-
-template <typename ValueType, typename LocalIndexType, typename GlobalIndexType>
 void Matrix<ValueType, LocalIndexType, GlobalIndexType>::apply_impl(
     const LinOp* b, LinOp* x) const
 {

--- a/core/distributed/vector.cpp
+++ b/core/distributed/vector.cpp
@@ -326,13 +326,6 @@ void Vector<ValueType>::compute_absolute_inplace()
 
 
 template <typename ValueType>
-dim<2> Vector<ValueType>::get_local_size() const
-{
-    return local_.get_size();
-}
-
-
-template <typename ValueType>
 const typename Vector<ValueType>::local_vector_type*
 Vector<ValueType>::get_local_vector() const
 {

--- a/core/matrix/dense.cpp
+++ b/core/matrix/dense.cpp
@@ -1522,9 +1522,7 @@ template <typename ValueType, typename Function>
 void gather_mixed_real_complex(Function fn, LinOp* out)
 {
 #ifdef GINKGO_MIXED_PRECISION
-    using fst_type = matrix::Dense<ValueType>;
-    using snd_type = matrix::Dense<next_precision<ValueType>>;
-    run<fst_type*, snd_type*>(out, fn);
+    run<matrix::Dense, ValueType, next_precision<ValueType>>(out, fn);
 #else
     precision_dispatch<ValueType>(fn, out);
 #endif

--- a/core/matrix/permutation.cpp
+++ b/core/matrix/permutation.cpp
@@ -269,8 +269,8 @@ void dispatch_dense(const LinOp* op, Functor fn)
 {
     using matrix::Dense;
     using std::complex;
-    run<const Dense<double>*, const Dense<float>*,
-        const Dense<complex<double>>*, const Dense<complex<float>>*>(op, fn);
+    run<Dense, double, float, std::complex<double>, std::complex<float>>(op,
+                                                                         fn);
 }
 
 

--- a/core/matrix/row_gatherer.cpp
+++ b/core/matrix/row_gatherer.cpp
@@ -66,8 +66,7 @@ RowGatherer<IndexType>::create_const(
 template <typename IndexType>
 void RowGatherer<IndexType>::apply_impl(const LinOp* in, LinOp* out) const
 {
-    run<const Dense<float>*, const Dense<double>*,
-        const Dense<std::complex<float>>*, const Dense<std::complex<double>>*>(
+    run<Dense, float, double, std::complex<float>, std::complex<double>>(
         in, [&](auto gather) { gather->row_gather(&row_idxs_, out); });
 }
 
@@ -75,8 +74,7 @@ template <typename IndexType>
 void RowGatherer<IndexType>::apply_impl(const LinOp* alpha, const LinOp* in,
                                         const LinOp* beta, LinOp* out) const
 {
-    run<const Dense<float>*, const Dense<double>*,
-        const Dense<std::complex<float>>*, const Dense<std::complex<double>>*>(
+    run<Dense, float, double, std::complex<float>, std::complex<double>>(
         in,
         [&](auto gather) { gather->row_gather(alpha, &row_idxs_, beta, out); });
 }

--- a/core/multigrid/pgm.cpp
+++ b/core/multigrid/pgm.cpp
@@ -406,8 +406,8 @@ void Pgm<ValueType, IndexType>::generate()
             setup_fine_op(obj);
         } else {
             // handle other ValueTypes.
-            run<const ConvertibleTo<fst_mtx_type>,
-                const ConvertibleTo<snd_mtx_type>>(obj, convert_fine_op);
+            run<ConvertibleTo, fst_mtx_type, snd_mtx_type>(obj,
+                                                           convert_fine_op);
         }
 
         auto distributed_setup = [&](auto matrix) {
@@ -490,8 +490,7 @@ void Pgm<ValueType, IndexType>::generate()
         };
 
         // the fine op is using csr with the current ValueType
-        run<const fst_mtx_type, const snd_mtx_type>(this->get_fine_op(),
-                                                    distributed_setup);
+        run<fst_mtx_type, snd_mtx_type>(this->get_fine_op(), distributed_setup);
     } else
 #endif  // GINKGO_BUILD_MPI
     {

--- a/core/multigrid/pgm_kernels.hpp
+++ b/core/multigrid/pgm_kernels.hpp
@@ -6,9 +6,6 @@
 #define GKO_CORE_MULTIGRID_PGM_KERNELS_HPP_
 
 
-#include <ginkgo/core/multigrid/pgm.hpp>
-
-
 #include <memory>
 
 

--- a/core/solver/multigrid.cpp
+++ b/core/solver/multigrid.cpp
@@ -317,9 +317,14 @@ void MultigridState::generate(const LinOp* system_matrix_in,
                     auto current_comm = distributed_fine->get_communicator();
                     auto next_comm = distributed_coarse->get_communicator();
                     auto current_local_nrows =
-                        distributed_fine->get_local_size()[0];
+                        ::gko::detail::run_matrix(fine, [](auto* fine_mat) {
+                            return fine_mat->get_local_matrix()->get_size()[0];
+                        });
                     auto next_local_nrows =
-                        distributed_coarse->get_local_size()[0];
+                        ::gko::detail::run_matrix(coarse, [](auto* coarse_mat) {
+                            return coarse_mat->get_non_local_matrix()
+                                ->get_size()[0];
+                        });
                     this->allocate_memory<VectorType>(
                         i, cycle, current_comm, next_comm, current_nrows,
                         next_nrows, current_local_nrows, next_local_nrows);

--- a/core/test/mpi/base/polymorphic_object.cpp
+++ b/core/test/mpi/base/polymorphic_object.cpp
@@ -116,8 +116,6 @@ struct DummyDistributedObject
         return *this;
     }
 
-    gko::dim<2> get_local_size() const override { return gko::dim<2>{0, 0}; }
-
     int x;
 };
 

--- a/core/test/mpi/distributed/matrix.cpp
+++ b/core/test/mpi/distributed/matrix.cpp
@@ -282,8 +282,6 @@ TYPED_TEST(MatrixBuilder, BuildLocalOnly)
     ASSERT_NO_THROW(gko::as<empty_non_local_type>(mat->get_non_local_matrix()));
     GKO_ASSERT_EQUAL_DIMENSIONS(mat->get_local_matrix()->get_size(),
                                 gko::dim<2>(local_n, local_n));
-    GKO_ASSERT_EQUAL_DIMENSIONS(mat->get_local_size(),
-                                mat->get_local_matrix()->get_size());
     ASSERT_NO_THROW(mat->apply(a, b));
 }
 

--- a/core/test/mpi/distributed/solver/multigrid.cpp
+++ b/core/test/mpi/distributed/solver/multigrid.cpp
@@ -71,9 +71,8 @@ protected:
           op_{op}
     {
         auto exec = this->get_executor();
-        auto distributed_op = dynamic_cast<
-            const gko::experimental::distributed::DistributedBase*>(op_.get());
-        auto original_n = distributed_op->get_local_size()[0];
+        auto distributed_op = dynamic_cast<const dist_mtx_type*>(op_.get());
+        auto original_n = distributed_op->get_local_matrix()->get_size()[0];
         gko::size_type n = original_n - 1;
 
         auto comm = distributed_op->get_communicator();
@@ -156,11 +155,11 @@ TEST_F(Multigrid, ConstructCorrect)
               gko::dim<2>(global_n, first_n));
     ASSERT_EQ(mg_level.at(0)->get_coarse_op()->get_size(),
               gko::dim<2>(first_n));
-    ASSERT_EQ(
-        dynamic_cast<const gko::experimental::distributed::DistributedBase*>(
-            mg_level.at(0)->get_coarse_op().get())
-            ->get_local_size(),
-        gko::dim<2>(n - 1));
+    ASSERT_EQ(dynamic_cast<const dist_mtx_type*>(
+                  mg_level.at(0)->get_coarse_op().get())
+                  ->get_local_matrix()
+                  ->get_size(),
+              gko::dim<2>(n - 1));
     // next mg_level
     ASSERT_EQ(mg_level.at(1)->get_fine_op()->get_size(), gko::dim<2>(first_n));
     ASSERT_EQ(mg_level.at(1)->get_restrict_op()->get_size(),

--- a/cuda/multigrid/pgm_kernels.cu
+++ b/cuda/multigrid/pgm_kernels.cu
@@ -19,7 +19,6 @@
 
 #include <ginkgo/core/base/exception_helpers.hpp>
 #include <ginkgo/core/base/math.hpp>
-#include <ginkgo/core/multigrid/pgm.hpp>
 
 
 #include "cuda/base/thrust.cuh"

--- a/dpcpp/multigrid/pgm_kernels.dp.cpp
+++ b/dpcpp/multigrid/pgm_kernels.dp.cpp
@@ -16,7 +16,6 @@
 
 #include <ginkgo/core/base/exception_helpers.hpp>
 #include <ginkgo/core/base/math.hpp>
-#include <ginkgo/core/multigrid/pgm.hpp>
 
 
 #include "dpcpp/base/onedpl.hpp"

--- a/hip/multigrid/pgm_kernels.hip.cpp
+++ b/hip/multigrid/pgm_kernels.hip.cpp
@@ -17,7 +17,6 @@
 
 #include <ginkgo/core/base/exception_helpers.hpp>
 #include <ginkgo/core/base/math.hpp>
-#include <ginkgo/core/multigrid/pgm.hpp>
 
 
 #include "hip/base/thrust.hip.hpp"

--- a/include/ginkgo/core/distributed/base.hpp
+++ b/include/ginkgo/core/distributed/base.hpp
@@ -55,13 +55,6 @@ public:
      */
     mpi::communicator get_communicator() const { return comm_; }
 
-    /**
-     * get the size of local operator
-     *
-     * @return the size of local operator
-     */
-    virtual dim<2> get_local_size() const = 0;
-
 protected:
     /**
      * Creates a new DistributedBase with the specified mpi::communicator.

--- a/include/ginkgo/core/distributed/matrix.hpp
+++ b/include/ginkgo/core/distributed/matrix.hpp
@@ -347,8 +347,6 @@ public:
         ptr_param<const Partition<local_index_type, global_index_type>>
             col_partition);
 
-    dim<2> get_local_size() const override;
-
     /**
      * Get read access to the stored local matrix.
      *

--- a/include/ginkgo/core/distributed/vector.hpp
+++ b/include/ginkgo/core/distributed/vector.hpp
@@ -167,8 +167,6 @@ public:
 
     void compute_absolute_inplace() override;
 
-    dim<2> get_local_size() const override;
-
     /**
      * Creates a complex copy of the original vectors. If the original vectors
      * were real, the imaginary part of the result will be zero.

--- a/omp/multigrid/pgm_kernels.cpp
+++ b/omp/multigrid/pgm_kernels.cpp
@@ -14,7 +14,6 @@
 
 #include <ginkgo/core/base/exception_helpers.hpp>
 #include <ginkgo/core/base/math.hpp>
-#include <ginkgo/core/multigrid/pgm.hpp>
 
 
 #include "core/base/iterator_factory.hpp"

--- a/reference/multigrid/pgm_kernels.cpp
+++ b/reference/multigrid/pgm_kernels.cpp
@@ -16,7 +16,6 @@
 #include <ginkgo/core/matrix/csr.hpp>
 #include <ginkgo/core/matrix/dense.hpp>
 #include <ginkgo/core/matrix/diagonal.hpp>
-#include <ginkgo/core/multigrid/pgm.hpp>
 
 
 #include "core/base/allocator.hpp"

--- a/test/mpi/vector.cpp
+++ b/test/mpi/vector.cpp
@@ -122,8 +122,6 @@ TYPED_TEST(VectorCreation, CanReadGlobalMatrixData)
     GKO_ASSERT_EQUAL_DIMENSIONS(vec->get_size(), gko::dim<2>(6, 2));
     GKO_ASSERT_EQUAL_DIMENSIONS(vec->get_local_vector()->get_size(),
                                 gko::dim<2>(2, 2));
-    GKO_ASSERT_EQUAL_DIMENSIONS(vec->get_local_size(),
-                                vec->get_local_vector()->get_size());
     GKO_ASSERT_MTX_NEAR(vec->get_local_vector(), ref_data[rank], 0.0);
 }
 


### PR DESCRIPTION
This PR reduces the interface changes to the `DistributedBase` interface. It removes the virtual function `get_local_size`. The only place where this was used was in the multigrid solver. There it has been replaced by using the `run` dispatch with every possible distributed Matrix type.

It also makes `run` easier to use by automatically deducing the const qualifier.

Note: although this is based on #1544, it can be rebased on develop and merged before.