### PR TITLE
Fix the msvc failure on json config

### DIFF
--- a/dev_tools/scripts/format_header.sh
+++ b/dev_tools/scripts/format_header.sh
@@ -15,6 +15,8 @@ convert_header () {
             fi
         elif [ "${header_file}" = "matrices/config.hpp" ]; then
             echo "#include \"${header_file}\""
+        elif [ "${header_file}" = "extensions/test/config/file_location.hpp" ]; then
+            echo "#include \"${header_file}\""
 	    elif [[ "${header_file}" =~ ${jacobi_regex} ]]; then
             echo "#include \"${header_file}\""
         else

--- a/extensions/test/config/CMakeLists.txt
+++ b/extensions/test/config/CMakeLists.txt
@@ -1,5 +1,6 @@
 ginkgo_create_test(json_config ADDITIONAL_LIBRARIES nlohmann_json::nlohmann_json)
-# set the working directory to the current binary folder for file test
-file(RELATIVE_PATH REL_BINARY_DIR ${PROJECT_BINARY_DIR} ${CMAKE_CURRENT_BINARY_DIR})
-set_tests_properties("${REL_BINARY_DIR}/json_config" PROPERTIES WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}")
-configure_file(test.json test.json COPYONLY)
+
+# prepare the testing file and generate location
+configure_file("${Ginkgo_SOURCE_DIR}/extensions/test/config/file_location.hpp.in"
+    "${Ginkgo_BINARY_DIR}/extensions/test/config/file_location.hpp" @ONLY)
+configure_file(test.json "${Ginkgo_BINARY_DIR}/extensions/test/config/test.json")

--- a/extensions/test/config/file_location.hpp.in
+++ b/extensions/test/config/file_location.hpp.in
@@ -1,0 +1,23 @@
+// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+//
+// SPDX-License-Identifier: BSD-3-Clause
+
+#ifndef GKO_EXTENSIONS_TEST_CONFIG_FILE_LOCATION_HPP_
+#define GKO_EXTENSIONS_TEST_CONFIG_FILE_LOCATION_HPP_
+
+
+namespace gko {
+namespace ext {
+namespace config {
+
+
+const char* location_test_json =
+    "@Ginkgo_BINARY_DIR@/extensions/test/config/test.json";
+
+
+}  // namespace config
+}  // namespace ext
+}  // namespace gko
+
+
+#endif  // GKO_EXTENSIONS_TEST_CONFIG_FILE_LOCATION_HPP_

--- a/extensions/test/config/json_config.cpp
+++ b/extensions/test/config/json_config.cpp
@@ -14,6 +14,7 @@
 
 
 #include "core/test/utils.hpp"
+#include "extensions/test/config/file_location.hpp"
 
 
 TEST(JsonConfig, ThrowIfInvalid)
@@ -77,7 +78,8 @@ TEST(JsonConfig, ReadInput)
 
 TEST(JsonConfig, ReadInputFromFile)
 {
-    auto ptree = gko::ext::config::parse_json_file("test.json");
+    auto ptree =
+        gko::ext::config::parse_json_file(gko::ext::config::location_test_json);
 
     auto& child_array = ptree.get("array").get_array();
     auto& child_map = ptree.get("map").get_map();


### PR DESCRIPTION
Sorry for another pr on this. I thought the failure from msvc cuda, which is now always failed.
To avoid setting the lib path in msvc, gko makes all test works in the library path (dll location).
I changed the working directory to access testing file in #1607  However, it can not find the dll path now.
follow the `matrices/config.hpp.in` to pass the file path