### PR TITLE
use more general default selector in multigrid

### DIFF
--- a/core/solver/multigrid.cpp
+++ b/core/solver/multigrid.cpp
@@ -880,16 +880,12 @@ Multigrid::Multigrid(const Multigrid::Factory* factory,
           stop::combine(factory->get_parameters().criteria)},
       parameters_{factory->get_parameters()}
 {
+    this->validate();
     if (!parameters_.level_selector) {
-        if (parameters_.mg_level.size() == 1) {
-            level_selector_ = [](const size_type, const LinOp*) {
-                return size_type{0};
-            };
-        } else if (parameters_.mg_level.size() > 1) {
-            level_selector_ = [](const size_type level, const LinOp*) {
-                return level;
-            };
-        }
+        auto num = parameters_.mg_level.size();
+        level_selector_ = [num](const size_type level, const LinOp*) {
+            return (level < num) ? level : num - 1;
+        };
     } else {
         level_selector_ = parameters_.level_selector;
     }
@@ -903,7 +899,7 @@ Multigrid::Multigrid(const Multigrid::Factory* factory,
         solver_selector_ = parameters_.solver_selector;
     }
 
-    this->validate();
+
     this->set_default_initial_guess(parameters_.default_initial_guess);
     if (this->get_system_matrix()->get_size()[0] != 0) {
         // generate on the existed matrix

--- a/core/solver/multigrid.cpp
+++ b/core/solver/multigrid.cpp
@@ -882,9 +882,9 @@ Multigrid::Multigrid(const Multigrid::Factory* factory,
 {
     this->validate();
     if (!parameters_.level_selector) {
-        auto num = parameters_.mg_level.size();
-        level_selector_ = [num](const size_type level, const LinOp*) {
-            return (level < num) ? level : num - 1;
+        auto mg_level_size = parameters_.mg_level.size();
+        level_selector_ = [mg_level_size](const size_type level, const LinOp*) {
+            return (level < mg_level_size) ? level : mg_level_size - 1;
         };
     } else {
         level_selector_ = parameters_.level_selector;

--- a/include/ginkgo/core/solver/multigrid.hpp
+++ b/include/ginkgo/core/solver/multigrid.hpp
@@ -203,9 +203,10 @@ public:
         /**
          * Custom selector size_type (size_type level, const LinOp* fine_matrix)
          * Selector function returns the element index in the vector for any
-         * given level index and the matrix of the fine level.
-         * For each level, this function is used to select the smoothers
-         * and multigrid level generation from the respective lists.
+         * given level index and the matrix of the fine level. The level 0 is
+         * the finest level and it is ascending when going to coarser levels.
+         * For each level, this function is used to select the smoothers and
+         * multigrid level generation from the respective lists.
          * For example,
          * ```
          * [](size_type level, const LinOp* fine_matrix) {

--- a/include/ginkgo/core/solver/multigrid.hpp
+++ b/include/ginkgo/core/solver/multigrid.hpp
@@ -222,9 +222,8 @@ public:
          * >= 3 and the number of rows of fine matrix > 1024, or the 2-idx
          * elements otherwise.
          *
-         * default selector:
-         *     use the first factory when mg_level size = 1
-         *     use the level as the index when mg_level size > 1
+         * default selector: use the level as the index when the level <
+         *   #mg_level and reuse the last one when the level >= #mg_level
          */
         std::function<size_type(const size_type, const LinOp*)>
             GKO_FACTORY_PARAMETER_SCALAR(level_selector, nullptr);


### PR DESCRIPTION
This PR changes the multigrid selector to more general one.
use level as index when level < #mg_level and reuse the last one when level >= #mg_level