### PR TITLE
Update defaults for distributed multigrid

### DIFF
--- a/common/cuda_hip/matrix/csr_kernels.hpp.inc
+++ b/common/cuda_hip/matrix/csr_kernels.hpp.inc
@@ -1298,7 +1298,7 @@ void spgeam(std::shared_ptr<const DefaultExecutor> exec,
 {
     auto total_nnz =
         a->get_num_stored_elements() + b->get_num_stored_elements();
-    auto nnz_per_row = total_nnz / a->get_size()[0];
+    auto nnz_per_row = a->get_size()[0] ? total_nnz / a->get_size()[0] : 0;
     select_spgeam(
         spgeam_kernels(),
         [&](int compiled_subwarp_size) {

--- a/core/multigrid/pgm.cpp
+++ b/core/multigrid/pgm.cpp
@@ -90,6 +90,12 @@ std::shared_ptr<matrix::Csr<ValueType, IndexType>> generate_coarse(
     gko::array<IndexType> col_idxs(exec, nnz);
     gko::array<ValueType> vals(exec, nnz);
     exec->copy_from(exec, nnz, fine_csr->get_const_values(), vals.get_data());
+
+    if (nnz == 0) {
+        return matrix::Csr<ValueType, IndexType>::create(
+            exec, dim<2>(num_agg, non_local_num_agg));
+    }
+
     // map row_ptrs to coarse row index
     exec->run(pgm::make_map_row(num, fine_csr->get_const_row_ptrs(),
                                 agg.get_const_data(), row_idxs.get_data()));

--- a/core/solver/multigrid.cpp
+++ b/core/solver/multigrid.cpp
@@ -180,7 +180,7 @@ namespace detail {
  * @note it should only be used internally
  */
 struct MultigridState {
-    MultigridState() : nrhs{0} {}
+    MultigridState() : nrhs{static_cast<size_type>(-1)} {}
 
     /**
      * Generate the cache for later usage.
@@ -695,7 +695,7 @@ void Multigrid::apply_impl(const LinOp* b, LinOp* x) const
 void Multigrid::apply_with_initial_guess_impl(const LinOp* b, LinOp* x,
                                               initial_guess_mode guess) const
 {
-    if (!this->get_system_matrix()) {
+    if (!this->get_system_matrix() || !this->get_system_matrix()->get_size()) {
         return;
     }
 
@@ -729,7 +729,7 @@ void Multigrid::apply_with_initial_guess_impl(const LinOp* alpha,
                                               LinOp* x,
                                               initial_guess_mode guess) const
 {
-    if (!this->get_system_matrix()) {
+    if (!this->get_system_matrix() || !this->get_system_matrix()->get_size()) {
         return;
     }
 

--- a/test/matrix/csr_kernels2.cpp
+++ b/test/matrix/csr_kernels2.cpp
@@ -607,6 +607,23 @@ TEST_F(Csr, AdvancedApplyToIdentityMatrixIsEquivalentToRef)
 }
 
 
+TEST_F(Csr, AdvancedApplyZeroToIdentityMatrixIsEquivalentToRef)
+{
+    set_up_apply_data<Mtx::classical>();
+    auto a = Mtx::create(ref);
+    auto b = Mtx::create(ref);
+    auto da = gko::clone(exec, a);
+    auto db = gko::clone(exec, b);
+    auto id = gko::matrix::Identity<Mtx::value_type>::create(ref);
+    auto did = gko::matrix::Identity<Mtx::value_type>::create(exec);
+
+    a->apply(alpha, id, beta, b);
+    da->apply(dalpha, did, dbeta, db);
+
+    GKO_ASSERT_MTX_NEAR(b, db, 0);
+}
+
+
 TEST_F(Csr, ApplyToComplexIsEquivalentToRef)
 {
     set_up_apply_data<Mtx::classical>();


### PR DESCRIPTION
This PR updates the defaults for distributed multigrid for the smoother and the coarse solver. It also adds a test for the distributed pgm preconditioned solver