### PR TITLE
Minimal stopping criteria config

### DIFF
--- a/core/config/config_helper.cpp
+++ b/core/config/config_helper.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -43,7 +43,9 @@ parse_or_get_factory<const stop::CriterionFactory>(const pnode& config,
     if (config.get_tag() == pnode::tag_t::string) {
         return detail::registry_accessor::get_data<stop::CriterionFactory>(
             context, config.get_string());
-    } else if (config.get_tag() == pnode::tag_t::map) {
+    }
+
+    if (config.get_tag() == pnode::tag_t::map) {
         static std::map<std::string,
                         std::function<deferred_factory_parameter<
                             gko::stop::CriterionFactory>(
@@ -55,9 +57,89 @@ parse_or_get_factory<const stop::CriterionFactory>(const pnode& config,
                  {"ImplicitResidualNorm", configure_implicit_residual}}};
         return criterion_map.at(config.get("type").get_string())(config,
                                                                  context, td);
-    } else {
-        GKO_INVALID_STATE("The type of config is not valid.");
     }
+
+    GKO_INVALID_STATE(
+        "Criteria must either be defined as a string or an array.");
+}
+
+
+std::vector<deferred_factory_parameter<const stop::CriterionFactory>>
+parse_minimal_criteria(const pnode& config, const registry& context,
+                       const type_descriptor& td)
+{
+    auto map_time = [](const pnode& config, const registry& context,
+                       const type_descriptor& td) {
+        pnode time_config{{{"time_limit", config.get("time")}}};
+        return configure_time(time_config, context, td);
+    };
+    auto map_iteration = [](const pnode& config, const registry& context,
+                            const type_descriptor& td) {
+        pnode iter_config{{{"max_iters", config.get("iteration")}}};
+        return configure_iter(iter_config, context, td);
+    };
+    auto create_residual_mapping = [](const std::string& key,
+                                      const std::string& baseline,
+                                      auto configure_fn) {
+        return std::make_pair(
+            key, [=](const pnode& config, const registry& context,
+                     const type_descriptor& td) {
+                pnode res_config{{{"baseline", pnode{baseline}},
+                                  {"reduction_factor", config.get(key)}}};
+                return configure_fn(res_config, context, td);
+            });
+    };
+    std::map<
+        std::string,
+        std::function<deferred_factory_parameter<gko::stop::CriterionFactory>(
+            const pnode&, const registry&, type_descriptor)>>
+        criterion_map{
+            {{"time", map_time},
+             {"iteration", map_iteration},
+             create_residual_mapping("relative_residual_norm", "rhs_norm",
+                                     configure_residual),
+             create_residual_mapping("initial_residual_norm", "initial_resnorm",
+                                     configure_residual),
+             create_residual_mapping("absolute_residual_norm", "absolute",
+                                     configure_residual),
+             create_residual_mapping("relative_implicit_residual_norm",
+                                     "rhs_norm", configure_implicit_residual),
+             create_residual_mapping("initial_implicit_residual_norm",
+                                     "initial_resnorm",
+                                     configure_implicit_residual),
+             create_residual_mapping("absolute_implicit_residual_norm",
+                                     "absolute", configure_implicit_residual)}};
+
+    std::vector<deferred_factory_parameter<const stop::CriterionFactory>> res;
+    for (const auto& it : config.get_map()) {
+        res.emplace_back(criterion_map.at(it.first)(config, context, td));
+    }
+    return res;
+}
+
+
+std::vector<deferred_factory_parameter<const stop::CriterionFactory>>
+parse_or_get_criteria(const pnode& config, const registry& context,
+                      const type_descriptor& td)
+{
+    if (config.get_tag() == pnode::tag_t::array ||
+        (config.get_tag() == pnode::tag_t::map && config.get("type"))) {
+        return parse_or_get_factory_vector<const stop::CriterionFactory>(
+            config, context, td);
+    }
+
+    if (config.get_tag() == pnode::tag_t::map) {
+        return parse_minimal_criteria(config, context, td);
+    }
+
+    if (config.get_tag() == pnode::tag_t::string) {
+        return {detail::registry_accessor::get_data<stop::CriterionFactory>(
+            context, config.get_string())};
+    }
+
+    GKO_INVALID_STATE(
+        "Criteria must either be defined as a string, an array,"
+        "or an map.");
 }
 
 }  // namespace config

--- a/core/config/config_helper.cpp
+++ b/core/config/config_helper.cpp
@@ -12,6 +12,7 @@
 
 #include "core/config/registry_accessor.hpp"
 #include "core/config/stop_config.hpp"
+#include "type_descriptor_helper.hpp"
 
 namespace gko {
 namespace config {
@@ -110,9 +111,15 @@ parse_minimal_criteria(const pnode& config, const registry& context,
              create_residual_mapping("absolute_implicit_residual_norm",
                                      "absolute", configure_implicit_residual)}};
 
+    type_descriptor updated_td = update_type(config, td);
+
     std::vector<deferred_factory_parameter<const stop::CriterionFactory>> res;
     for (const auto& it : config.get_map()) {
-        res.emplace_back(criterion_map.at(it.first)(config, context, td));
+        if (it.first == "value_type") {
+            continue;
+        }
+        res.emplace_back(
+            criterion_map.at(it.first)(config, context, updated_td));
     }
     return res;
 }

--- a/core/config/config_helper.hpp
+++ b/core/config/config_helper.hpp
@@ -142,8 +142,8 @@ parse_or_get_factory<const stop::CriterionFactory>(const pnode& config,
                                                    const type_descriptor& td);
 
 /**
- * parse or get an std::vector of criteria.
- * A stored single criterion will be converted to an std::vector.
+ * parse or get a std::vector of criteria.
+ * A stored single criterion will be converted to a std::vector.
  */
 std::vector<deferred_factory_parameter<const stop::CriterionFactory>>
 parse_or_get_criteria(const pnode& config, const registry& context,

--- a/core/config/config_helper.hpp
+++ b/core/config/config_helper.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -140,6 +140,15 @@ deferred_factory_parameter<const stop::CriterionFactory>
 parse_or_get_factory<const stop::CriterionFactory>(const pnode& config,
                                                    const registry& context,
                                                    const type_descriptor& td);
+
+/**
+ * parse or get an std::vector of criteria.
+ * A stored single criterion will be converted to an std::vector.
+ */
+std::vector<deferred_factory_parameter<const stop::CriterionFactory>>
+parse_or_get_criteria(const pnode& config, const registry& context,
+                      const type_descriptor& td);
+
 
 /**
  * give a vector of factory by calling parse_or_get_factory.

--- a/core/config/solver_config.hpp
+++ b/core/config/solver_config.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -27,8 +27,7 @@ inline void common_solver_parse(SolverParam& params, const pnode& config,
     }
     if (auto& obj = config.get("criteria")) {
         params.with_criteria(
-            gko::config::parse_or_get_factory_vector<
-                const stop::CriterionFactory>(obj, context, td_for_child));
+            gko::config::parse_or_get_criteria(obj, context, td_for_child));
     }
     if (auto& obj = config.get("preconditioner")) {
         params.with_preconditioner(

--- a/core/test/config/config.cpp
+++ b/core/test/config/config.cpp
@@ -125,11 +125,106 @@ TEST_F(Config, GenerateObjectWithCustomBuild)
 
 TEST_F(Config, GenerateCriteriaFromMinimalConfig)
 {
+    // the map is ordered, since this allows for easier comparison in the test
+    pnode minimal_stop{{
+        {"absolute_implicit_residual_norm", pnode{0.01}},
+        {"absolute_residual_norm", pnode{0.01}},
+        {"initial_implicit_residual_norm", pnode{0.01}},
+        {"initial_residual_norm", pnode{0.01}},
+        {"iteration", pnode{10}},
+        {"relative_implicit_residual_norm", pnode{0.01}},
+        {"relative_residual_norm", pnode{0.01}},
+        {"time", pnode{100}},
+    }};
+
+    pnode p{{{"criteria", minimal_stop}}};
+    auto obj = std::dynamic_pointer_cast<gko::solver::Cg<float>::Factory>(
+        parse<LinOpFactoryType::Cg>(p, registry(),
+                                    type_descriptor{"float32", "void"})
+            .on(this->exec));
+
+    ASSERT_NE(obj, nullptr);
+    auto criteria = obj->get_parameters().criteria;
+    ASSERT_EQ(criteria.size(), minimal_stop.get_map().size());
+    try {
+        throw std::runtime_error("Criteria does not exist");
+    } catch (...) {
+    }
+    {
+        SCOPED_TRACE("Absolute Implicit Residual Criterion");
+        auto res = std::dynamic_pointer_cast<
+            const gko::stop::ImplicitResidualNorm<float>::Factory>(criteria[0]);
+        ASSERT_NE(res, nullptr);
+        EXPECT_EQ(res->get_parameters().baseline, gko::stop::mode::absolute);
+        EXPECT_EQ(res->get_parameters().reduction_factor, 0.01f);
+    }
+    {
+        SCOPED_TRACE("Absolute Residual Criterion");
+        auto res = std::dynamic_pointer_cast<
+            const gko::stop::ResidualNorm<float>::Factory>(criteria[1]);
+        ASSERT_NE(res, nullptr);
+        EXPECT_EQ(res->get_parameters().baseline, gko::stop::mode::absolute);
+        EXPECT_EQ(res->get_parameters().reduction_factor, 0.01f);
+    }
+    {
+        SCOPED_TRACE("Initial Implicit Residual Criterion");
+        auto res = std::dynamic_pointer_cast<
+            const gko::stop::ImplicitResidualNorm<float>::Factory>(criteria[2]);
+        ASSERT_NE(res, nullptr);
+        EXPECT_EQ(res->get_parameters().baseline,
+                  gko::stop::mode::initial_resnorm);
+        EXPECT_EQ(res->get_parameters().reduction_factor, 0.01f);
+    }
+    {
+        SCOPED_TRACE("Initial Residual Criterion");
+        auto res = std::dynamic_pointer_cast<
+            const gko::stop::ResidualNorm<float>::Factory>(criteria[3]);
+        ASSERT_NE(res, nullptr);
+        EXPECT_EQ(res->get_parameters().baseline,
+                  gko::stop::mode::initial_resnorm);
+        EXPECT_EQ(res->get_parameters().reduction_factor, 0.01f);
+    }
+    {
+        SCOPED_TRACE("Iteration Criterion");
+        auto it =
+            std::dynamic_pointer_cast<const gko::stop::Iteration::Factory>(
+                criteria[4]);
+        ASSERT_NE(it, nullptr);
+        EXPECT_EQ(it->get_parameters().max_iters, 10);
+    }
+    {
+        SCOPED_TRACE("Relative Implicit Residual Criterion");
+        auto res = std::dynamic_pointer_cast<
+            const gko::stop::ImplicitResidualNorm<float>::Factory>(criteria[5]);
+        ASSERT_NE(res, nullptr);
+        EXPECT_EQ(res->get_parameters().baseline, gko::stop::mode::rhs_norm);
+        EXPECT_EQ(res->get_parameters().reduction_factor, 0.01f);
+    }
+    {
+        SCOPED_TRACE("Relative Residual Criterion");
+        auto res = std::dynamic_pointer_cast<
+            const gko::stop::ResidualNorm<float>::Factory>(criteria[6]);
+        ASSERT_NE(res, nullptr);
+        EXPECT_EQ(res->get_parameters().baseline, gko::stop::mode::rhs_norm);
+        EXPECT_EQ(res->get_parameters().reduction_factor, 0.01f);
+    }
+    {
+        SCOPED_TRACE("Time Criterion");
+        using namespace std::chrono_literals;
+        auto time = std::dynamic_pointer_cast<const gko::stop::Time::Factory>(
+            criteria[7]);
+        ASSERT_NE(time, nullptr);
+        EXPECT_EQ(time->get_parameters().time_limit, 100ns);
+    }
+}
+
+
+TEST_F(Config, GenerateCriteriaFromMinimalConfigWithValueType)
+{
     auto reg = registry();
     reg.emplace("precond", this->mtx);
     pnode minimal_stop{{
-        {"iteration", pnode{10}},
-        {"relative_implicit_residual_norm", pnode{0.01}},
+        {"value_type", pnode{"float64"}},
         {"relative_residual_norm", pnode{0.01}},
         {"time", pnode{100}},
     }};
@@ -141,36 +236,20 @@ TEST_F(Config, GenerateCriteriaFromMinimalConfig)
 
     ASSERT_NE(obj, nullptr);
     auto criteria = obj->get_parameters().criteria;
-    ASSERT_EQ(criteria.size(), minimal_stop.get_map().size());
-    {
-        SCOPED_TRACE("Iteration Criterion");
-        auto it =
-            std::dynamic_pointer_cast<const gko::stop::Iteration::Factory>(
-                criteria[0]);
-        ASSERT_NE(it, nullptr);
-        EXPECT_EQ(it->get_parameters().max_iters, 10);
-    }
-    {
-        SCOPED_TRACE("Implicit Residual Criterion");
-        auto res = std::dynamic_pointer_cast<
-            const gko::stop::ImplicitResidualNorm<float>::Factory>(criteria[1]);
-        ASSERT_NE(res, nullptr);
-        EXPECT_EQ(res->get_parameters().baseline, gko::stop::mode::rhs_norm);
-        EXPECT_EQ(res->get_parameters().reduction_factor, 0.01f);
-    }
+    ASSERT_EQ(criteria.size(), minimal_stop.get_map().size() - 1);
     {
         SCOPED_TRACE("Residual Criterion");
         auto res = std::dynamic_pointer_cast<
-            const gko::stop::ResidualNorm<float>::Factory>(criteria[2]);
+            const gko::stop::ResidualNorm<double>::Factory>(criteria[0]);
         ASSERT_NE(res, nullptr);
         EXPECT_EQ(res->get_parameters().baseline, gko::stop::mode::rhs_norm);
-        EXPECT_EQ(res->get_parameters().reduction_factor, 0.01f);
+        EXPECT_EQ(res->get_parameters().reduction_factor, 0.01);
     }
     {
         SCOPED_TRACE("Time Criterion");
         using namespace std::chrono_literals;
         auto time = std::dynamic_pointer_cast<const gko::stop::Time::Factory>(
-            criteria[3]);
+            criteria[1]);
         ASSERT_NE(time, nullptr);
         EXPECT_EQ(time->get_parameters().time_limit, 100ns);
     }

--- a/include/ginkgo/core/config/config.hpp
+++ b/include/ginkgo/core/config/config.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -87,8 +87,29 @@ class pnode;
  *    interpreted as a 1-element array. This means the following configurations
  *    are equivalent if the key expects an array value: `"<key>": [{object}]`
  *    and `"<key>": {object}`.
+ * 9. The stopping criteria for a solver can alternatively be defined through a
+ *    simple key-value map, where each key corresponds to a single criterion.
+ *    The available keys are:
+ *    - "iteration": <integer>, corresponds to gko::stop::Iteration
+ *    - "relative_residual_norm": <floating point>, corresponds to
+ *      gko::stop::ResidualNorm build with gko::stop::mode::rhs_norm
+ *    - "initial_residual_norm": <floating point>, corresponds to
+ *      gko::stop::ResidualNorm build with gko::stop::mode::initial_resnorm
+ *    - "absolute_residual_norm": <floating point>, corresponds to
+ *      gko::stop::ResidualNorm build with gko::stop::mode::absolute
+ *    - "relative_implicit_residual_norm": <floating point>, corresponds to
+ *      gko::stop::ImplicitResidualNorm build with gko::stop::mode::rhs_norm
+ *    - "initial_implicit_residual_norm": <floating point>, corresponds to
+ *      gko::stop::ImplicitResidualNorm build with
+ *      gko::stop::mode::initial_resnorm
+ *    - "absolute_implicit_residual_norm": <floating point>, corresponds to
+ *      gko::stop::ImplicitResidualNorm build with gko::stop::mode::absolute
+ *    - "time": <integer>, corresponds to gko::stop::Time
+ *    The simplified definition also allows for setting the `ValueType` template
+ *    parameter as discussed in 4. and 5.
  *
- * All configurations need to specify the resulting type by the field:
+ * All configurations (except the simplified stopping criteria) need to specify
+ * the resulting type by the field:
  * ```
  * "type": "some_supported_ginkgo_type"
  * ```
@@ -114,6 +135,14 @@ class pnode;
  * set to 20, and a combined stopping criteria, consisting of an Iteration
  * criteria with maximal 10 iterations, and a ResidualNorm criteria with a
  * reduction factor of 1e-6.
+ *
+ * The criteria parameter can alternatively be defined as
+ * ```
+ * "criteria": {
+ *   "iteration": 10,
+ *   "relative_residual_norm": 1e-6
+ * }
+ * ```
  *
  * By default, the factory will use the value type double, and index type
  * int32 when creating templated types. This can be changed by passing in a
@@ -150,15 +179,13 @@ class pnode;
  *                base.
  * @param context  The registry which stores the building function map and the
  *                 storage for generated objects.
- * @param type_descriptor  The default value and index type. If any object that
- *                         is created as part of this configuration has a
- *                         templated type, then the value and/or index type from
- *                         the descriptor will be used. Any definition of the
- *                         value and/or index type within the config will take
- *                         precedence over the descriptor. If `void` is used for
- *                         one or both of the types, then the corresponding type
- *                         has to be defined in the config, otherwise the
- *                         parsing will fail.
+ * @param td  The default value and index type. If any object that
+ *            is created as part of this configuration has a templated type,
+ *            then the value and/or index type from the descriptor will be used.
+ *            Any definition of the value and/or index type within the config
+ *            will take precedence over the descriptor. If `void` is used for
+ *            one or both of the types, then the corresponding type has to be
+ *            defined in the config, otherwise the parsing will fail.
  *
  * @return a deferred_factory_parameter which creates an LinOpFactory after
  *         `.on(exec)` is called on it.

--- a/include/ginkgo/core/config/config.hpp
+++ b/include/ginkgo/core/config/config.hpp
@@ -108,6 +108,10 @@ class pnode;
  *    The simplified definition also allows for setting the `ValueType` template
  *    parameter as discussed in 4. and 5.
  *
+ * @note The formatting for the example snippets is oriented on the JSON format.
+ *       For all supported configuration formats check the headers in
+ *       extension/config
+ *
  * All configurations (except the simplified stopping criteria) need to specify
  * the resulting type by the field:
  * ```
@@ -155,20 +159,20 @@ class pnode;
  * will lead to a GMRES solver that uses `float` as its value type.
  * Additionally, the config can be used to set these types through the fields:
  * ```
- * value_type: "some_value_type"
+ * "value_type": "some_value_type"
  * ```
  * These types take precedence over the type descriptor and they are used for
  * every created object beginning from the config level they are defined on and
  * every deeper nested level, until a new type is defined. So, considering the
  * following example
  * ```
- * type: "solver::Ir",
- * value_type: "float32"
- * solver: {
- *   type: "solver::Gmres",
- *   preconditioner: {
- *     type: "preconditioner::Jacobi"
- *     value_type: "float64"
+ * "type": "solver::Ir",
+ * "value_type": "float32"
+ * "solver": {
+ *   "type": "solver::Gmres",
+ *   "preconditioner": {
+ *     "type": "preconditioner::Jacobi"
+ *     "value_type": "float64"
  *   }
  * }
  * ```


### PR DESCRIPTION
This PR adds a minimal specification for configuring stopping criteria. The test now contains an example for this configuration. Since the main implementation to configure the criteria is already implemented, this adds only a bit of dispatching.

This is intended to continue the discussion in #1392, while not blocking the release.

Todo:
- [x] discuss the specification
- [x] test all allowed key-value pairs

The stopping criteria can now be defined as:
```yaml
criteria:
  value_type: float32 # optional 
  # only one of the following is required 
  relative_residual_norm: 1e-6
  initial_residual_norm: 1e-6
  absolute_residual_norm: 1e-6
  relative_implicit_residual_norm: 1e-6
  initial_implicit_residual_norm: 1e-6
  absolute_implicit_residual_norm: 1e-6
  time: 1000
```