### PR TITLE
Add executor `get_description` function

### DIFF
--- a/benchmark/blas/blas.cpp
+++ b/benchmark/blas/blas.cpp
@@ -104,8 +104,8 @@ Parameters for a benchmark case are:
     initialize_argument_parsing(&argc, &argv, header, format);
 
     std::string extra_information = "The operations are " + FLAGS_operations;
-    print_general_information(extra_information);
     auto exec = executor_factory.at(FLAGS_executor)(FLAGS_gpu_timer);
+    print_general_information(extra_information, exec);
 
     auto test_cases = json::parse(get_input_stream());
 

--- a/benchmark/blas/distributed/multi_vector.cpp
+++ b/benchmark/blas/distributed/multi_vector.cpp
@@ -41,13 +41,13 @@ Parameters for a benchmark case are:
     std::string format = Generator::get_example_config();
     initialize_argument_parsing(&argc, &argv, header, format, do_print);
 
+    auto exec = executor_factory_mpi.at(FLAGS_executor)(comm.get());
+
     if (do_print) {
         std::string extra_information =
             "The operations are " + FLAGS_operations;
-        print_general_information(extra_information);
+        print_general_information(extra_information, exec);
     }
-
-    auto exec = executor_factory_mpi.at(FLAGS_executor)(comm.get());
 
     std::string json_input = broadcast_json_input(get_input_stream(), comm);
     auto test_cases = json::parse(json_input);

--- a/benchmark/conversion/conversion.cpp
+++ b/benchmark/conversion/conversion.cpp
@@ -163,9 +163,9 @@ int main(int argc, char* argv[])
 
     std::string extra_information =
         std::string() + "The formats are " + FLAGS_formats;
-    print_general_information(extra_information);
 
     auto exec = executor_factory.at(FLAGS_executor)(FLAGS_gpu_timer);
+    print_general_information(extra_information, exec);
     auto formats = split(FLAGS_formats, ',');
 
     auto test_cases = json::parse(get_input_stream());

--- a/benchmark/preconditioner/preconditioner.cpp
+++ b/benchmark/preconditioner/preconditioner.cpp
@@ -275,9 +275,9 @@ int main(int argc, char* argv[])
 
     std::string extra_information =
         "Running with preconditioners: " + FLAGS_preconditioners;
-    print_general_information(extra_information);
 
     auto exec = get_executor(FLAGS_gpu_timer);
+    print_general_information(extra_information, exec);
     auto& engine = get_engine();
 
     auto preconditioners = split(FLAGS_preconditioners, ',');

--- a/benchmark/solver/distributed/solver.cpp
+++ b/benchmark/solver/distributed/solver.cpp
@@ -91,7 +91,7 @@ int main(int argc, char* argv[])
         ss_rel_res_goal.str() + "\nThe number of right hand sides is " +
         std::to_string(FLAGS_nrhs);
     if (do_print) {
-        print_general_information(extra_information);
+        print_general_information(extra_information, exec);
     }
 
     std::set<std::string> supported_solvers = {"cg", "fcg", "cgs", "bicgstab",

--- a/benchmark/solver/solver.cpp
+++ b/benchmark/solver/solver.cpp
@@ -43,9 +43,9 @@ int main(int argc, char* argv[])
         std::to_string(FLAGS_max_iters) + " iterations and residual goal of " +
         ss_rel_res_goal.str() + "\nThe number of right hand sides is " +
         std::to_string(FLAGS_nrhs);
-    print_general_information(extra_information);
 
     auto exec = get_executor(FLAGS_gpu_timer);
+    print_general_information(extra_information, exec);
 
     json test_cases;
     if (!FLAGS_overhead) {

--- a/benchmark/sparse_blas/sparse_blas.cpp
+++ b/benchmark/sparse_blas/sparse_blas.cpp
@@ -166,7 +166,7 @@ int main(int argc, char* argv[])
     auto test_cases = json::parse(get_input_stream());
 
     std::string extra_information = "The operations are " + FLAGS_operations;
-    print_general_information(extra_information);
+    print_general_information(extra_information, exec);
 
     run_test_cases(SparseBlasBenchmark{}, exec,
                    get_timer(exec, FLAGS_gpu_timer), test_cases);

--- a/benchmark/spmv/distributed/spmv.cpp
+++ b/benchmark/spmv/distributed/spmv.cpp
@@ -49,15 +49,15 @@ int main(int argc, char* argv[])
     initialize_argument_parsing_matrix(&argc, &argv, header, format, "",
                                        do_print);
 
+    auto exec = executor_factory_mpi.at(FLAGS_executor)(comm.get());
+
     if (do_print) {
         std::string extra_information =
             "The formats are [" + FLAGS_local_formats + "]x[" +
             FLAGS_non_local_formats + "]\n" +
             "The number of right hand sides is " + std::to_string(FLAGS_nrhs);
-        print_general_information(extra_information);
+        print_general_information(extra_information, exec);
     }
-
-    auto exec = executor_factory_mpi.at(FLAGS_executor)(comm.get());
 
     auto local_formats = split(FLAGS_local_formats, ',');
     auto non_local_formats = split(FLAGS_non_local_formats, ',');

--- a/benchmark/spmv/spmv.cpp
+++ b/benchmark/spmv/spmv.cpp
@@ -26,9 +26,10 @@ int main(int argc, char* argv[])
     std::string extra_information = "The formats are " + FLAGS_formats +
                                     "\nThe number of right hand sides is " +
                                     std::to_string(FLAGS_nrhs);
-    print_general_information(extra_information);
 
     auto exec = executor_factory.at(FLAGS_executor)(FLAGS_gpu_timer);
+
+    print_general_information(extra_information, exec);
 
     auto test_cases = json::parse(get_input_stream());
 

--- a/benchmark/test/reference/blas.profile.stderr
+++ b/benchmark/test/reference/blas.profile.stderr
@@ -1,4 +1,4 @@
-Running on reference(0)
+Running on ReferenceExecutor
 Running with 0 warm iterations and 1 running iterations
 The random seed for right hand sides is 42
 The operations are copy,axpy,scal

--- a/benchmark/test/reference/blas.simple.stderr
+++ b/benchmark/test/reference/blas.simple.stderr
@@ -1,4 +1,4 @@
-Running on reference(0)
+Running on ReferenceExecutor
 Running with 2 warm iterations and 10 running iterations
 The random seed for right hand sides is 42
 The operations are copy,axpy,scal

--- a/benchmark/test/reference/conversion.all.stderr
+++ b/benchmark/test/reference/conversion.all.stderr
@@ -1,4 +1,4 @@
-Running on reference(0)
+Running on ReferenceExecutor
 Running with 2 warm iterations and 10 running iterations
 The random seed for right hand sides is 42
 The formats are coo,csr,ell,sellp,hybrid

--- a/benchmark/test/reference/conversion.matrix.stderr
+++ b/benchmark/test/reference/conversion.matrix.stderr
@@ -1,4 +1,4 @@
-Running on reference(0)
+Running on ReferenceExecutor
 Running with 2 warm iterations and 10 running iterations
 The random seed for right hand sides is 42
 The formats are coo,csr

--- a/benchmark/test/reference/conversion.profile.stderr
+++ b/benchmark/test/reference/conversion.profile.stderr
@@ -1,4 +1,4 @@
-Running on reference(0)
+Running on ReferenceExecutor
 Running with 0 warm iterations and 1 running iterations
 The random seed for right hand sides is 42
 The formats are coo,csr

--- a/benchmark/test/reference/conversion.simple.stderr
+++ b/benchmark/test/reference/conversion.simple.stderr
@@ -1,4 +1,4 @@
-Running on reference(0)
+Running on ReferenceExecutor
 Running with 2 warm iterations and 10 running iterations
 The random seed for right hand sides is 42
 The formats are coo,csr

--- a/benchmark/test/reference/distributed_solver.matrix.stderr
+++ b/benchmark/test/reference/distributed_solver.matrix.stderr
@@ -1,4 +1,4 @@
-Running on reference(0)
+Running on ReferenceExecutor
 Running with 2 warm iterations and 1 running iterations
 The random seed for right hand sides is 42
 Running cg with 1000 iterations and residual goal of 1.000000e-06

--- a/benchmark/test/reference/distributed_solver.profile.stderr
+++ b/benchmark/test/reference/distributed_solver.profile.stderr
@@ -1,4 +1,4 @@
-Running on reference(0)
+Running on ReferenceExecutor
 Running with 0 warm iterations and 1 running iterations
 The random seed for right hand sides is 42
 Running cg with 1000 iterations and residual goal of 1.000000e-06

--- a/benchmark/test/reference/distributed_solver.simple.stderr
+++ b/benchmark/test/reference/distributed_solver.simple.stderr
@@ -1,4 +1,4 @@
-Running on reference(0)
+Running on ReferenceExecutor
 Running with 2 warm iterations and 1 running iterations
 The random seed for right hand sides is 42
 Running cg with 1000 iterations and residual goal of 1.000000e-06

--- a/benchmark/test/reference/multi_vector_distributed.profile.stderr
+++ b/benchmark/test/reference/multi_vector_distributed.profile.stderr
@@ -1,4 +1,4 @@
-Running on reference(0)
+Running on ReferenceExecutor
 Running with 0 warm iterations and 1 running iterations
 The random seed for right hand sides is 42
 The operations are copy,axpy,scal

--- a/benchmark/test/reference/multi_vector_distributed.simple.stderr
+++ b/benchmark/test/reference/multi_vector_distributed.simple.stderr
@@ -1,4 +1,4 @@
-Running on reference(0)
+Running on ReferenceExecutor
 Running with 2 warm iterations and 10 running iterations
 The random seed for right hand sides is 42
 The operations are copy,axpy,scal

--- a/benchmark/test/reference/preconditioner.matrix.stderr
+++ b/benchmark/test/reference/preconditioner.matrix.stderr
@@ -1,4 +1,4 @@
-Running on reference(0)
+Running on ReferenceExecutor
 Running with 2 warm iterations and 10 running iterations
 The random seed for right hand sides is 42
 Running with preconditioners: none

--- a/benchmark/test/reference/preconditioner.precond.stderr
+++ b/benchmark/test/reference/preconditioner.precond.stderr
@@ -1,4 +1,4 @@
-Running on reference(0)
+Running on ReferenceExecutor
 Running with 2 warm iterations and 10 running iterations
 The random seed for right hand sides is 42
 Running with preconditioners: jacobi

--- a/benchmark/test/reference/preconditioner.profile.stderr
+++ b/benchmark/test/reference/preconditioner.profile.stderr
@@ -1,4 +1,4 @@
-Running on reference(0)
+Running on ReferenceExecutor
 Running with 0 warm iterations and 1 running iterations
 The random seed for right hand sides is 42
 Running with preconditioners: none

--- a/benchmark/test/reference/preconditioner.reordered.stderr
+++ b/benchmark/test/reference/preconditioner.reordered.stderr
@@ -1,4 +1,4 @@
-Running on reference(0)
+Running on ReferenceExecutor
 Running with 2 warm iterations and 10 running iterations
 The random seed for right hand sides is 42
 Running with preconditioners: none

--- a/benchmark/test/reference/preconditioner.simple.stderr
+++ b/benchmark/test/reference/preconditioner.simple.stderr
@@ -1,4 +1,4 @@
-Running on reference(0)
+Running on ReferenceExecutor
 Running with 2 warm iterations and 10 running iterations
 The random seed for right hand sides is 42
 Running with preconditioners: none

--- a/benchmark/test/reference/solver.matrix.stderr
+++ b/benchmark/test/reference/solver.matrix.stderr
@@ -1,4 +1,4 @@
-Running on reference(0)
+Running on ReferenceExecutor
 Running with 2 warm iterations and 1 running iterations
 The random seed for right hand sides is 42
 Running cg with 1000 iterations and residual goal of 1.000000e-06

--- a/benchmark/test/reference/solver.profile.stderr
+++ b/benchmark/test/reference/solver.profile.stderr
@@ -1,4 +1,4 @@
-Running on reference(0)
+Running on ReferenceExecutor
 Running with 0 warm iterations and 1 running iterations
 The random seed for right hand sides is 42
 Running cg with 1000 iterations and residual goal of 1.000000e-06

--- a/benchmark/test/reference/solver.reordered.stderr
+++ b/benchmark/test/reference/solver.reordered.stderr
@@ -1,4 +1,4 @@
-Running on reference(0)
+Running on ReferenceExecutor
 Running with 2 warm iterations and 1 running iterations
 The random seed for right hand sides is 42
 Running cg with 1000 iterations and residual goal of 1.000000e-06

--- a/benchmark/test/reference/solver.simple.stderr
+++ b/benchmark/test/reference/solver.simple.stderr
@@ -1,4 +1,4 @@
-Running on reference(0)
+Running on ReferenceExecutor
 Running with 2 warm iterations and 1 running iterations
 The random seed for right hand sides is 42
 Running cg with 1000 iterations and residual goal of 1.000000e-06

--- a/benchmark/test/reference/sparse_blas.matrix.stderr
+++ b/benchmark/test/reference/sparse_blas.matrix.stderr
@@ -1,4 +1,4 @@
-Running on reference(0)
+Running on ReferenceExecutor
 Running with 2 warm iterations and 10 running iterations
 The random seed for right hand sides is 42
 The operations are transpose

--- a/benchmark/test/reference/sparse_blas.profile.stderr
+++ b/benchmark/test/reference/sparse_blas.profile.stderr
@@ -1,4 +1,4 @@
-Running on reference(0)
+Running on ReferenceExecutor
 Running with 0 warm iterations and 1 running iterations
 The random seed for right hand sides is 42
 The operations are transpose

--- a/benchmark/test/reference/sparse_blas.reordered.stderr
+++ b/benchmark/test/reference/sparse_blas.reordered.stderr
@@ -1,4 +1,4 @@
-Running on reference(0)
+Running on ReferenceExecutor
 Running with 2 warm iterations and 10 running iterations
 The random seed for right hand sides is 42
 The operations are symbolic_cholesky

--- a/benchmark/test/reference/sparse_blas.simple.stderr
+++ b/benchmark/test/reference/sparse_blas.simple.stderr
@@ -1,4 +1,4 @@
-Running on reference(0)
+Running on ReferenceExecutor
 Running with 2 warm iterations and 10 running iterations
 The random seed for right hand sides is 42
 The operations are transpose

--- a/benchmark/test/reference/spmv.matrix.stderr
+++ b/benchmark/test/reference/spmv.matrix.stderr
@@ -1,4 +1,4 @@
-Running on reference(0)
+Running on ReferenceExecutor
 Running with 2 warm iterations and 10 running iterations
 The random seed for right hand sides is 42
 The formats are coo

--- a/benchmark/test/reference/spmv.profile.stderr
+++ b/benchmark/test/reference/spmv.profile.stderr
@@ -1,4 +1,4 @@
-Running on reference(0)
+Running on ReferenceExecutor
 Running with 0 warm iterations and 1 running iterations
 The random seed for right hand sides is 42
 The formats are coo

--- a/benchmark/test/reference/spmv.reordered.stderr
+++ b/benchmark/test/reference/spmv.reordered.stderr
@@ -1,4 +1,4 @@
-Running on reference(0)
+Running on ReferenceExecutor
 Running with 2 warm iterations and 10 running iterations
 The random seed for right hand sides is 42
 The formats are coo

--- a/benchmark/test/reference/spmv.simple.stderr
+++ b/benchmark/test/reference/spmv.simple.stderr
@@ -1,4 +1,4 @@
-Running on reference(0)
+Running on ReferenceExecutor
 Running with 2 warm iterations and 10 running iterations
 The random seed for right hand sides is 42
 The formats are coo

--- a/benchmark/test/reference/spmv_distributed.profile.stderr
+++ b/benchmark/test/reference/spmv_distributed.profile.stderr
@@ -1,4 +1,4 @@
-Running on reference(0)
+Running on ReferenceExecutor
 Running with 0 warm iterations and 1 running iterations
 The random seed for right hand sides is 42
 The formats are [csr]x[csr]

--- a/benchmark/test/reference/spmv_distributed.simple.stderr
+++ b/benchmark/test/reference/spmv_distributed.simple.stderr
@@ -1,4 +1,4 @@
-Running on reference(0)
+Running on ReferenceExecutor
 Running with 2 warm iterations and 10 running iterations
 The random seed for right hand sides is 42
 The formats are [csr]x[csr]

--- a/benchmark/utils/general.hpp
+++ b/benchmark/utils/general.hpp
@@ -168,11 +168,11 @@ void initialize_argument_parsing(int* argc, char** argv[], std::string& header,
  *
  * @param extra  describes benchmark specific extra parameters to output
  */
-void print_general_information(const std::string& extra)
+void print_general_information(const std::string& extra,
+                               std::shared_ptr<const gko::Executor> exec)
 {
     std::clog << gko::version_info::get() << std::endl
-              << "Running on " << FLAGS_executor << "(" << FLAGS_device_id
-              << ")\n"
+              << "Running on " << exec->get_description() << std::endl
               << "Running with " << FLAGS_warmup << " warm iterations and ";
     if (FLAGS_repetitions == "auto") {
         std::clog << "adaptively determined repetititions with "

--- a/core/device_hooks/cuda_hooks.cpp
+++ b/core/device_hooks/cuda_hooks.cpp
@@ -148,6 +148,9 @@ scoped_device_id_guard CudaExecutor::get_scoped_device_id_guard() const
     GKO_NOT_COMPILED(cuda);
 
 
+std::string CudaExecutor::get_description() const GKO_NOT_COMPILED(cuda);
+
+
 std::string CudaError::get_error(int64)
 {
     return "ginkgo CUDA module is not compiled";

--- a/core/device_hooks/dpcpp_hooks.cpp
+++ b/core/device_hooks/dpcpp_hooks.cpp
@@ -91,6 +91,9 @@ scoped_device_id_guard DpcppExecutor::get_scoped_device_id_guard() const
     GKO_NOT_COMPILED(dpcpp);
 
 
+std::string DpcppExecutor::get_description() const GKO_NOT_COMPILED(dpcpp);
+
+
 int DpcppExecutor::get_num_devices(std::string) { return 0; }
 
 

--- a/core/device_hooks/hip_hooks.cpp
+++ b/core/device_hooks/hip_hooks.cpp
@@ -147,6 +147,9 @@ scoped_device_id_guard HipExecutor::get_scoped_device_id_guard() const
     GKO_NOT_COMPILED(hip);
 
 
+std::string HipExecutor::get_description() const GKO_NOT_COMPILED(hip);
+
+
 std::string HipError::get_error(int64)
 {
     return "ginkgo HIP module is not compiled";

--- a/core/device_hooks/omp_hooks.cpp
+++ b/core/device_hooks/omp_hooks.cpp
@@ -24,6 +24,9 @@ scoped_device_id_guard::scoped_device_id_guard(const OmpExecutor* exec,
     GKO_NOT_COMPILED(omp);
 
 
+std::string OmpExecutor::get_description() const GKO_NOT_COMPILED(omp);
+
+
 int OmpExecutor::get_num_omp_threads() { return 1; }
 
 

--- a/core/test/gtest/environments.hpp
+++ b/core/test/gtest/environments.hpp
@@ -17,6 +17,7 @@
 #include <ginkgo/core/base/mpi.hpp>
 
 #include "core/test/gtest/resources.hpp"
+#include "test/utils/executor.hpp"
 
 
 #ifdef GKO_COMPILING_OMP
@@ -43,60 +44,27 @@ class DeviceEnvironment : public ::testing::Environment {
 public:
     explicit DeviceEnvironment(int rank) : rank_(rank) { print_environment(); }
 
-#ifdef GKO_COMPILING_OMP
     void print_environment() const
     {
+        auto ref = gko::ReferenceExecutor::create();
+#ifdef GKO_COMPILING_OMP
         if (ResourceEnvironment::omp_threads > 0) {
             omp_set_num_threads(ResourceEnvironment::omp_threads);
         }
-        std::stringstream ss;
-        ss << "Rank " << rank_ << ": OMP threads " << omp_get_max_threads()
-           << std::endl;
-        std::cerr << ss.str();
-    }
+        std::shared_ptr<gko::OmpExecutor> exec;
 #elif defined(GKO_COMPILING_CUDA)
-    void print_environment() const
-    {
-        auto device_id = ResourceEnvironment::cuda_device_id;
-        std::stringstream ss;
-        ss << "Rank " << rank_ << ": CUDA device "
-           << gko::kernels::cuda::get_device_name(device_id) << " ID "
-           << device_id << std::endl;
-        std::cerr << ss.str();
-    }
-
-    void TearDown() override
-    {
-        gko::kernels::cuda::reset_device(ResourceEnvironment::cuda_device_id);
-    }
+        std::shared_ptr<gko::CudaExecutor> exec;
 #elif defined(GKO_COMPILING_HIP)
-    void print_environment() const
-    {
-        auto device_id = ResourceEnvironment::hip_device_id;
-        std::stringstream ss;
-        ss << "Rank " << rank_ << ": HIP device "
-           << gko::kernels::hip::get_device_name(device_id) << " ID "
-           << device_id << std::endl;
-        std::cerr << ss.str();
-    }
-
-    void TearDown() override
-    {
-        gko::kernels::hip::reset_device(ResourceEnvironment::hip_device_id);
-    }
+        std::shared_ptr<gko::HipExecutor> exec;
 #elif defined(GKO_COMPILING_DPCPP)
-    void print_environment() const
-    {
-        auto device_id = ResourceEnvironment::sycl_device_id;
-        std::stringstream ss;
-        ss << "Rank " << rank_ << ": SYCL device "
-           << gko::kernels::dpcpp::get_device_name(device_id) << " ID "
-           << device_id << std::endl;
-        std::cerr << ss.str();
-    }
+        std::shared_ptr<gko::DpcppExecutor> exec;
 #else
-    void print_environment() const {}
+        std::shared_ptr<gko::ReferenceExecutor> exec;
 #endif
+        init_executor(ref, exec);
+        std::cerr << "Rank " << rank_ << ": " << exec->get_description()
+                  << std::endl;
+    }
 
 private:
     int rank_;

--- a/cuda/base/executor.cpp
+++ b/cuda/base/executor.cpp
@@ -19,6 +19,7 @@
 #include "common/cuda_hip/base/config.hpp"
 #include "cuda/base/cublas_bindings.hpp"
 #include "cuda/base/cusparse_handle.hpp"
+#include "cuda/base/device.hpp"
 #include "cuda/base/scoped_device_id.hpp"
 
 
@@ -175,6 +176,14 @@ void CudaExecutor::synchronize() const
 scoped_device_id_guard CudaExecutor::get_scoped_device_id_guard() const
 {
     return {this, this->get_device_id()};
+}
+
+
+std::string CudaExecutor::get_description() const
+{
+    return "CudaExecutor on device " + std::to_string(this->get_device_id()) +
+           " (" + gko::kernels::cuda::get_device_name(this->get_device_id()) +
+           ") with host " + this->get_master()->get_description();
 }
 
 

--- a/dpcpp/base/executor.dp.cpp
+++ b/dpcpp/base/executor.dp.cpp
@@ -162,6 +162,17 @@ scoped_device_id_guard DpcppExecutor::get_scoped_device_id_guard() const
 }
 
 
+std::string DpcppExecutor::get_description() const
+{
+    return "DpcppExecutor on device " + std::to_string(this->get_device_id()) +
+           " (" +
+           this->get_queue()
+               ->get_device()
+               .get_info<sycl::info::device::name>() +
+           ") with host " + this->get_master()->get_description();
+}
+
+
 int DpcppExecutor::get_num_devices(std::string device_type)
 {
     return detail::get_devices(device_type).size();

--- a/hip/base/executor.hip.cpp
+++ b/hip/base/executor.hip.cpp
@@ -12,6 +12,7 @@
 
 #include "common/cuda_hip/base/config.hpp"
 #include "common/cuda_hip/base/runtime.hpp"
+#include "hip/base/device.hpp"
 #include "hip/base/hipblas_bindings.hip.hpp"
 #include "hip/base/hipsparse_bindings.hip.hpp"
 #include "hip/base/scoped_device_id.hip.hpp"
@@ -170,6 +171,14 @@ void HipExecutor::synchronize() const
 scoped_device_id_guard HipExecutor::get_scoped_device_id_guard() const
 {
     return {this, this->get_device_id()};
+}
+
+
+std::string HipExecutor::get_description() const
+{
+    return "HipExecutor on device " + std::to_string(this->get_device_id()) +
+           " (" + gko::kernels::hip::get_device_name(this->get_device_id()) +
+           ") with host " + this->get_master()->get_description();
 }
 
 

--- a/include/ginkgo/core/base/executor.hpp
+++ b/include/ginkgo/core/base/executor.hpp
@@ -865,6 +865,9 @@ public:
 
     virtual scoped_device_id_guard get_scoped_device_id_guard() const = 0;
 
+    /** @return a textual representation of the executor and its device. */
+    virtual std::string get_description() const = 0;
+
 protected:
     /**
      * A struct that abstracts the executor info for different executors
@@ -1368,6 +1371,8 @@ public:
 
     scoped_device_id_guard get_scoped_device_id_guard() const override;
 
+    std::string get_description() const override;
+
 protected:
     OmpExecutor(std::shared_ptr<CpuAllocatorBase> alloc)
         : alloc_{std::move(alloc)}
@@ -1425,6 +1430,8 @@ public:
     {
         return {this, 0};
     }
+
+    std::string get_description() const override { return "ReferenceExecutor"; }
 
     void run(const Operation& op) const override
     {
@@ -1531,6 +1538,8 @@ public:
     void synchronize() const override;
 
     scoped_device_id_guard get_scoped_device_id_guard() const override;
+
+    std::string get_description() const override;
 
     /**
      * Get the CUDA device id of the device associated to this executor.
@@ -1752,6 +1761,8 @@ public:
 
     scoped_device_id_guard get_scoped_device_id_guard() const override;
 
+    std::string get_description() const override;
+
     /**
      * Get the HIP device id of the device associated to this executor.
      */
@@ -1952,6 +1963,8 @@ public:
     void synchronize() const override;
 
     scoped_device_id_guard get_scoped_device_id_guard() const override;
+
+    std::string get_description() const override;
 
     /**
      * Get the DPCPP device id of the device associated to this executor.

--- a/omp/base/executor.cpp
+++ b/omp/base/executor.cpp
@@ -20,4 +20,11 @@ int OmpExecutor::get_num_omp_threads()
 }
 
 
+std::string OmpExecutor::get_description() const
+{
+    return "OmpExecutor (" + std::to_string(this->get_num_omp_threads()) +
+           " threads)";
+}
+
+
 }  // namespace gko

--- a/test/base/batch_multi_vector_kernels.cpp
+++ b/test/base/batch_multi_vector_kernels.cpp
@@ -16,7 +16,7 @@
 #include "core/test/utils.hpp"
 #include "core/test/utils/assertions.hpp"
 #include "core/test/utils/batch_helpers.hpp"
-#include "test/utils/executor.hpp"
+#include "test/utils/common_fixture.hpp"
 
 
 class MultiVector : public CommonTestFixture {

--- a/test/base/device_matrix_data_kernels.cpp
+++ b/test/base/device_matrix_data_kernels.cpp
@@ -16,7 +16,7 @@
 
 #include "core/test/utils.hpp"
 #include "core/test/utils/assertions.hpp"
-#include "test/utils/executor.hpp"
+#include "test/utils/common_fixture.hpp"
 
 
 template <typename ValueIndexType>

--- a/test/base/executor.cpp
+++ b/test/base/executor.cpp
@@ -11,6 +11,7 @@
 #include <ginkgo/core/base/executor.hpp>
 
 #include "core/test/utils/assertions.hpp"
+#include "test/utils/common_fixture.hpp"
 
 
 namespace reference {

--- a/test/base/index_range.cpp
+++ b/test/base/index_range.cpp
@@ -12,7 +12,7 @@
 
 #include "common/unified/base/kernel_launch.hpp"
 #include "core/test/utils.hpp"
-#include "test/utils/executor.hpp"
+#include "test/utils/common_fixture.hpp"
 
 
 class IndexRange : public CommonTestFixture {

--- a/test/base/kernel_launch_generic.cpp
+++ b/test/base/kernel_launch_generic.cpp
@@ -18,7 +18,7 @@
 #include "common/unified/base/kernel_launch_solver.hpp"
 #include "core/base/array_access.hpp"
 #include "core/test/utils.hpp"
-#include "test/utils/executor.hpp"
+#include "test/utils/common_fixture.hpp"
 
 
 using gko::dim;

--- a/test/base/timer.cpp
+++ b/test/base/timer.cpp
@@ -10,7 +10,7 @@
 #include <ginkgo/core/base/timer.hpp>
 
 #include "core/test/utils/assertions.hpp"
-#include "test/utils/executor.hpp"
+#include "test/utils/common_fixture.hpp"
 
 
 class Timer : public CommonTestFixture {

--- a/test/components/absolute_array_kernels.cpp
+++ b/test/components/absolute_array_kernels.cpp
@@ -13,7 +13,7 @@
 #include <ginkgo/core/base/array.hpp>
 
 #include "core/test/utils.hpp"
-#include "test/utils/executor.hpp"
+#include "test/utils/common_fixture.hpp"
 
 
 class AbsoluteArray : public CommonTestFixture {

--- a/test/components/fill_array_kernels.cpp
+++ b/test/components/fill_array_kernels.cpp
@@ -13,7 +13,7 @@
 #include <ginkgo/core/base/array.hpp>
 
 #include "core/test/utils.hpp"
-#include "test/utils/executor.hpp"
+#include "test/utils/common_fixture.hpp"
 
 
 template <typename T>

--- a/test/components/format_conversion_kernels.cpp
+++ b/test/components/format_conversion_kernels.cpp
@@ -11,7 +11,7 @@
 #include <gtest/gtest.h>
 
 #include "core/test/utils.hpp"
-#include "test/utils/executor.hpp"
+#include "test/utils/common_fixture.hpp"
 
 
 template <typename IndexType>

--- a/test/components/precision_conversion_kernels.cpp
+++ b/test/components/precision_conversion_kernels.cpp
@@ -13,7 +13,7 @@
 #include <ginkgo/core/base/array.hpp>
 
 #include "core/test/utils.hpp"
-#include "test/utils/executor.hpp"
+#include "test/utils/common_fixture.hpp"
 
 
 #if !(GINKGO_COMMON_SINGLE_MODE)

--- a/test/components/prefix_sum_kernels.cpp
+++ b/test/components/prefix_sum_kernels.cpp
@@ -15,7 +15,7 @@
 #include <ginkgo/core/base/array.hpp>
 
 #include "core/test/utils.hpp"
-#include "test/utils/executor.hpp"
+#include "test/utils/common_fixture.hpp"
 
 
 template <typename T>

--- a/test/components/reduce_array_kernels.cpp
+++ b/test/components/reduce_array_kernels.cpp
@@ -13,7 +13,7 @@
 #include <ginkgo/core/base/array.hpp>
 
 #include "core/test/utils.hpp"
-#include "test/utils/executor.hpp"
+#include "test/utils/common_fixture.hpp"
 
 
 template <typename T>

--- a/test/distributed/index_map_kernels.cpp
+++ b/test/distributed/index_map_kernels.cpp
@@ -18,7 +18,7 @@
 
 #include "core/distributed/partition_kernels.hpp"
 #include "core/test/utils.hpp"
-#include "test/utils/executor.hpp"
+#include "test/utils/common_fixture.hpp"
 
 
 using comm_index_type = gko::experimental::distributed::comm_index_type;

--- a/test/distributed/matrix_kernels.cpp
+++ b/test/distributed/matrix_kernels.cpp
@@ -13,7 +13,7 @@
 #include <ginkgo/core/base/executor.hpp>
 
 #include "core/test/utils.hpp"
-#include "test/utils/executor.hpp"
+#include "test/utils/common_fixture.hpp"
 
 
 using comm_index_type = gko::experimental::distributed::comm_index_type;

--- a/test/distributed/partition_helper_kernels.cpp
+++ b/test/distributed/partition_helper_kernels.cpp
@@ -10,7 +10,7 @@
 #include "core/base/iterator_factory.hpp"
 #include "core/distributed/partition_helpers_kernels.hpp"
 #include "core/test/utils.hpp"
-#include "test/utils/executor.hpp"
+#include "test/utils/common_fixture.hpp"
 
 
 using gko::experimental::distributed::comm_index_type;

--- a/test/distributed/partition_kernels.cpp
+++ b/test/distributed/partition_kernels.cpp
@@ -15,7 +15,7 @@
 #include <ginkgo/core/distributed/partition.hpp>
 
 #include "core/test/utils.hpp"
-#include "test/utils/executor.hpp"
+#include "test/utils/common_fixture.hpp"
 
 
 using comm_index_type = gko::experimental::distributed::comm_index_type;

--- a/test/distributed/vector_kernels.cpp
+++ b/test/distributed/vector_kernels.cpp
@@ -15,7 +15,7 @@
 #include <ginkgo/core/base/matrix_data.hpp>
 
 #include "core/test/utils.hpp"
-#include "test/utils/executor.hpp"
+#include "test/utils/common_fixture.hpp"
 
 
 using comm_index_type = gko::experimental::distributed::comm_index_type;

--- a/test/factorization/cholesky_kernels.cpp
+++ b/test/factorization/cholesky_kernels.cpp
@@ -24,7 +24,7 @@
 #include "core/test/utils/assertions.hpp"
 #include "core/utils/matrix_utils.hpp"
 #include "matrices/config.hpp"
-#include "test/utils/executor.hpp"
+#include "test/utils/common_fixture.hpp"
 
 
 namespace {

--- a/test/factorization/ic_kernels.cpp
+++ b/test/factorization/ic_kernels.cpp
@@ -16,7 +16,7 @@
 #include "core/test/utils.hpp"
 #include "core/test/utils/unsort_matrix.hpp"
 #include "matrices/config.hpp"
-#include "test/utils/executor.hpp"
+#include "test/utils/common_fixture.hpp"
 
 
 class Ic : public CommonTestFixture {

--- a/test/factorization/ilu_kernels.cpp
+++ b/test/factorization/ilu_kernels.cpp
@@ -16,7 +16,7 @@
 #include "core/test/utils.hpp"
 #include "core/test/utils/unsort_matrix.hpp"
 #include "matrices/config.hpp"
-#include "test/utils/executor.hpp"
+#include "test/utils/common_fixture.hpp"
 
 
 class Ilu : public CommonTestFixture {

--- a/test/factorization/lu_kernels.cpp
+++ b/test/factorization/lu_kernels.cpp
@@ -27,7 +27,7 @@
 #include "core/test/utils.hpp"
 #include "core/test/utils/assertions.hpp"
 #include "matrices/config.hpp"
-#include "test/utils/executor.hpp"
+#include "test/utils/common_fixture.hpp"
 
 
 template <typename ValueIndexType>

--- a/test/factorization/par_ic_kernels.cpp
+++ b/test/factorization/par_ic_kernels.cpp
@@ -23,7 +23,7 @@
 #include "core/matrix/csr_kernels.hpp"
 #include "core/test/utils.hpp"
 #include "matrices/config.hpp"
-#include "test/utils/executor.hpp"
+#include "test/utils/common_fixture.hpp"
 
 
 template <typename ValueIndexType>

--- a/test/factorization/par_ict_kernels.cpp
+++ b/test/factorization/par_ict_kernels.cpp
@@ -23,7 +23,7 @@
 #include "core/matrix/csr_kernels.hpp"
 #include "core/test/utils.hpp"
 #include "matrices/config.hpp"
-#include "test/utils/executor.hpp"
+#include "test/utils/common_fixture.hpp"
 
 
 template <typename ValueIndexType>

--- a/test/factorization/par_ilu_kernels.cpp
+++ b/test/factorization/par_ilu_kernels.cpp
@@ -22,7 +22,7 @@
 #include "core/factorization/factorization_kernels.hpp"
 #include "core/test/utils.hpp"
 #include "matrices/config.hpp"
-#include "test/utils/executor.hpp"
+#include "test/utils/common_fixture.hpp"
 
 
 template <typename ValueIndexType>

--- a/test/factorization/par_ilut_kernels.cpp
+++ b/test/factorization/par_ilut_kernels.cpp
@@ -23,7 +23,7 @@
 #include "core/matrix/csr_kernels.hpp"
 #include "core/test/utils.hpp"
 #include "matrices/config.hpp"
-#include "test/utils/executor.hpp"
+#include "test/utils/common_fixture.hpp"
 
 
 template <typename ValueIndexType>

--- a/test/log/profiler_hook.cpp
+++ b/test/log/profiler_hook.cpp
@@ -8,7 +8,7 @@
 
 #include <ginkgo/core/log/profiler_hook.hpp>
 
-#include "test/utils/executor.hpp"
+#include "test/utils/common_fixture.hpp"
 
 
 class ProfilerHook : public CommonTestFixture {

--- a/test/matrix/batch_csr_kernels.cpp
+++ b/test/matrix/batch_csr_kernels.cpp
@@ -19,7 +19,7 @@
 #include "core/test/utils/array_generator.hpp"
 #include "core/test/utils/assertions.hpp"
 #include "core/test/utils/batch_helpers.hpp"
-#include "test/utils/executor.hpp"
+#include "test/utils/common_fixture.hpp"
 
 
 class Csr : public CommonTestFixture {

--- a/test/matrix/batch_dense_kernels.cpp
+++ b/test/matrix/batch_dense_kernels.cpp
@@ -19,7 +19,7 @@
 #include "core/test/utils/array_generator.hpp"
 #include "core/test/utils/assertions.hpp"
 #include "core/test/utils/batch_helpers.hpp"
-#include "test/utils/executor.hpp"
+#include "test/utils/common_fixture.hpp"
 
 
 class Dense : public CommonTestFixture {

--- a/test/matrix/batch_ell_kernels.cpp
+++ b/test/matrix/batch_ell_kernels.cpp
@@ -18,7 +18,7 @@
 #include "core/test/utils.hpp"
 #include "core/test/utils/assertions.hpp"
 #include "core/test/utils/batch_helpers.hpp"
-#include "test/utils/executor.hpp"
+#include "test/utils/common_fixture.hpp"
 
 
 class Ell : public CommonTestFixture {

--- a/test/matrix/coo_kernels.cpp
+++ b/test/matrix/coo_kernels.cpp
@@ -18,7 +18,7 @@
 
 #include "core/test/utils.hpp"
 #include "core/test/utils/unsort_matrix.hpp"
-#include "test/utils/executor.hpp"
+#include "test/utils/common_fixture.hpp"
 
 
 class Coo : public CommonTestFixture {

--- a/test/matrix/csr_kernels.cpp
+++ b/test/matrix/csr_kernels.cpp
@@ -18,7 +18,7 @@
 #include "core/base/array_access.hpp"
 #include "core/components/fill_array_kernels.hpp"
 #include "core/test/utils.hpp"
-#include "test/utils/executor.hpp"
+#include "test/utils/common_fixture.hpp"
 
 
 class Csr : public CommonTestFixture {

--- a/test/matrix/csr_kernels2.cpp
+++ b/test/matrix/csr_kernels2.cpp
@@ -27,7 +27,7 @@
 #include "core/test/utils/assertions.hpp"
 #include "core/test/utils/unsort_matrix.hpp"
 #include "core/utils/matrix_utils.hpp"
-#include "test/utils/executor.hpp"
+#include "test/utils/common_fixture.hpp"
 
 
 class Csr : public CommonTestFixture {

--- a/test/matrix/dense_kernels.cpp
+++ b/test/matrix/dense_kernels.cpp
@@ -26,7 +26,7 @@
 
 #include "core/components/fill_array_kernels.hpp"
 #include "core/test/utils.hpp"
-#include "test/utils/executor.hpp"
+#include "test/utils/common_fixture.hpp"
 
 
 class Dense : public CommonTestFixture {

--- a/test/matrix/diagonal_kernels.cpp
+++ b/test/matrix/diagonal_kernels.cpp
@@ -15,7 +15,7 @@
 #include <ginkgo/core/matrix/dense.hpp>
 
 #include "core/test/utils.hpp"
-#include "test/utils/executor.hpp"
+#include "test/utils/common_fixture.hpp"
 
 
 class Diagonal : public CommonTestFixture {

--- a/test/matrix/ell_kernels.cpp
+++ b/test/matrix/ell_kernels.cpp
@@ -17,7 +17,7 @@
 #include <ginkgo/core/matrix/ell.hpp>
 
 #include "core/test/utils.hpp"
-#include "test/utils/executor.hpp"
+#include "test/utils/common_fixture.hpp"
 
 
 class Ell : public CommonTestFixture {

--- a/test/matrix/fbcsr_kernels.cpp
+++ b/test/matrix/fbcsr_kernels.cpp
@@ -14,7 +14,7 @@
 #include "core/test/matrix/fbcsr_sample.hpp"
 #include "core/test/utils.hpp"
 #include "core/test/utils/fb_matrix_generator.hpp"
-#include "test/utils/executor.hpp"
+#include "test/utils/common_fixture.hpp"
 
 
 template <typename T>

--- a/test/matrix/fft_kernels.cpp
+++ b/test/matrix/fft_kernels.cpp
@@ -13,7 +13,7 @@
 #include <ginkgo/core/matrix/fft.hpp>
 
 #include "core/test/utils.hpp"
-#include "test/utils/executor.hpp"
+#include "test/utils/common_fixture.hpp"
 
 
 template <typename ValueType>

--- a/test/matrix/hybrid_kernels.cpp
+++ b/test/matrix/hybrid_kernels.cpp
@@ -15,7 +15,7 @@
 #include <ginkgo/core/matrix/diagonal.hpp>
 
 #include "core/test/utils.hpp"
-#include "test/utils/executor.hpp"
+#include "test/utils/common_fixture.hpp"
 
 
 class Hybrid : public CommonTestFixture {

--- a/test/matrix/matrix.cpp
+++ b/test/matrix/matrix.cpp
@@ -22,7 +22,7 @@
 #include <ginkgo/core/matrix/sparsity_csr.hpp>
 
 #include "core/test/utils.hpp"
-#include "test/utils/executor.hpp"
+#include "test/utils/common_fixture.hpp"
 
 
 #if GINKGO_COMMON_SINGLE_MODE

--- a/test/matrix/permutation_kernels.cpp
+++ b/test/matrix/permutation_kernels.cpp
@@ -11,7 +11,7 @@
 #include <ginkgo/core/matrix/permutation.hpp>
 
 #include "core/test/utils.hpp"
-#include "test/utils/executor.hpp"
+#include "test/utils/common_fixture.hpp"
 
 
 class Permutation : public CommonTestFixture {

--- a/test/matrix/scaled_permutation_kernels.cpp
+++ b/test/matrix/scaled_permutation_kernels.cpp
@@ -10,7 +10,7 @@
 #include <ginkgo/core/matrix/scaled_permutation.hpp>
 
 #include "core/test/utils.hpp"
-#include "test/utils/executor.hpp"
+#include "test/utils/common_fixture.hpp"
 
 
 class ScaledPermutation : public CommonTestFixture {

--- a/test/matrix/sellp_kernels.cpp
+++ b/test/matrix/sellp_kernels.cpp
@@ -16,7 +16,7 @@
 #include <ginkgo/core/matrix/diagonal.hpp>
 
 #include "core/test/utils.hpp"
-#include "test/utils/executor.hpp"
+#include "test/utils/common_fixture.hpp"
 
 
 class Sellp : public CommonTestFixture {

--- a/test/matrix/sparsity_csr_kernels.cpp
+++ b/test/matrix/sparsity_csr_kernels.cpp
@@ -19,7 +19,7 @@
 #include "core/test/utils/assertions.hpp"
 #include "core/test/utils/matrix_generator.hpp"
 #include "core/test/utils/unsort_matrix.hpp"
-#include "test/utils/executor.hpp"
+#include "test/utils/common_fixture.hpp"
 
 
 namespace {

--- a/test/mpi/matrix.cpp
+++ b/test/mpi/matrix.cpp
@@ -20,7 +20,7 @@
 #include <ginkgo/core/matrix/csr.hpp>
 
 #include "core/test/utils.hpp"
-#include "test/utils/mpi/executor.hpp"
+#include "test/utils/mpi/common_fixture.hpp"
 
 
 #ifndef GKO_COMPILING_DPCPP

--- a/test/mpi/multigrid/pgm.cpp
+++ b/test/mpi/multigrid/pgm.cpp
@@ -19,7 +19,7 @@
 #include <ginkgo/core/multigrid/pgm.hpp>
 
 #include "core/test/utils.hpp"
-#include "test/utils/mpi/executor.hpp"
+#include "test/utils/mpi/common_fixture.hpp"
 
 
 #if GINKGO_DPCPP_SINGLE_MODE

--- a/test/mpi/partition_helpers.cpp
+++ b/test/mpi/partition_helpers.cpp
@@ -6,7 +6,7 @@
 #include <ginkgo/core/distributed/partition_helpers.hpp>
 
 #include "core/test/utils.hpp"
-#include "test/utils/mpi/executor.hpp"
+#include "test/utils/mpi/common_fixture.hpp"
 
 
 using comm_index_type = gko::experimental::distributed::comm_index_type;

--- a/test/mpi/preconditioner/schwarz.cpp
+++ b/test/mpi/preconditioner/schwarz.cpp
@@ -29,7 +29,7 @@
 #include "core/test/utils.hpp"
 #include "core/test/utils/matrix_generator.hpp"
 #include "core/utils/matrix_utils.hpp"
-#include "test/utils/mpi/executor.hpp"
+#include "test/utils/mpi/common_fixture.hpp"
 
 
 #if GINKGO_DPCPP_SINGLE_MODE

--- a/test/mpi/solver/solver.cpp
+++ b/test/mpi/solver/solver.cpp
@@ -31,7 +31,7 @@
 #include "core/test/utils.hpp"
 #include "core/test/utils/matrix_generator.hpp"
 #include "core/utils/matrix_utils.hpp"
-#include "test/utils/mpi/executor.hpp"
+#include "test/utils/mpi/common_fixture.hpp"
 
 
 #if GINKGO_DPCPP_SINGLE_MODE

--- a/test/mpi/vector.cpp
+++ b/test/mpi/vector.cpp
@@ -17,7 +17,7 @@
 #include <ginkgo/core/log/logger.hpp>
 
 #include "core/test/utils.hpp"
-#include "test/utils/mpi/executor.hpp"
+#include "test/utils/mpi/common_fixture.hpp"
 
 
 bool needs_transfers(std::shared_ptr<const gko::Executor> exec)

--- a/test/multigrid/fixed_coarsening_kernels.cpp
+++ b/test/multigrid/fixed_coarsening_kernels.cpp
@@ -26,7 +26,7 @@
 #include "core/test/utils/matrix_generator.hpp"
 #include "core/test/utils/unsort_matrix.hpp"
 #include "core/utils/matrix_utils.hpp"
-#include "test/utils/executor.hpp"
+#include "test/utils/common_fixture.hpp"
 
 
 class FixedCoarsening : public CommonTestFixture {

--- a/test/multigrid/pgm_kernels.cpp
+++ b/test/multigrid/pgm_kernels.cpp
@@ -25,7 +25,7 @@
 #include "core/test/utils/matrix_generator.hpp"
 #include "core/test/utils/unsort_matrix.hpp"
 #include "core/utils/matrix_utils.hpp"
-#include "test/utils/executor.hpp"
+#include "test/utils/common_fixture.hpp"
 
 
 class Pgm : public CommonTestFixture {

--- a/test/preconditioner/batch_jacobi_kernels.cpp
+++ b/test/preconditioner/batch_jacobi_kernels.cpp
@@ -22,7 +22,7 @@
 #include "core/test/utils.hpp"
 #include "core/test/utils/assertions.hpp"
 #include "core/test/utils/batch_helpers.hpp"
-#include "test/utils/executor.hpp"
+#include "test/utils/common_fixture.hpp"
 
 
 namespace detail {

--- a/test/preconditioner/isai_kernels.cpp
+++ b/test/preconditioner/isai_kernels.cpp
@@ -18,7 +18,7 @@
 
 #include "core/test/utils.hpp"
 #include "matrices/config.hpp"
-#include "test/utils/executor.hpp"
+#include "test/utils/common_fixture.hpp"
 
 
 enum struct matrix_type { lower, upper, general, spd };

--- a/test/preconditioner/jacobi_kernels.cpp
+++ b/test/preconditioner/jacobi_kernels.cpp
@@ -13,7 +13,7 @@
 #include "core/test/utils.hpp"
 #include "core/test/utils/unsort_matrix.hpp"
 #include "core/utils/matrix_utils.hpp"
-#include "test/utils/executor.hpp"
+#include "test/utils/common_fixture.hpp"
 
 
 class Jacobi : public CommonTestFixture {

--- a/test/reorder/amd.cpp
+++ b/test/reorder/amd.cpp
@@ -15,7 +15,7 @@
 #include "core/test/utils.hpp"
 #include "core/test/utils/unsort_matrix.hpp"
 #include "matrices/config.hpp"
-#include "test/utils/executor.hpp"
+#include "test/utils/common_fixture.hpp"
 
 
 template <typename ValueIndexType>

--- a/test/reorder/mc64.cpp
+++ b/test/reorder/mc64.cpp
@@ -8,7 +8,7 @@
 #include <ginkgo/core/reorder/mc64.hpp>
 
 #include "core/test/utils/assertions.hpp"
-#include "test/utils/executor.hpp"
+#include "test/utils/common_fixture.hpp"
 
 
 namespace {

--- a/test/reorder/nested_dissection.cpp
+++ b/test/reorder/nested_dissection.cpp
@@ -11,7 +11,7 @@
 
 #include "core/test/utils.hpp"
 #include "matrices/config.hpp"
-#include "test/utils/executor.hpp"
+#include "test/utils/common_fixture.hpp"
 
 
 template <typename IndexType>

--- a/test/reorder/rcm.cpp
+++ b/test/reorder/rcm.cpp
@@ -19,7 +19,7 @@
 #include "core/test/utils.hpp"
 #include "core/test/utils/assertions.hpp"
 #include "matrices/config.hpp"
-#include "test/utils/executor.hpp"
+#include "test/utils/common_fixture.hpp"
 
 
 class Rcm : public CommonTestFixture {

--- a/test/solver/batch_bicgstab_kernels.cpp
+++ b/test/solver/batch_bicgstab_kernels.cpp
@@ -20,7 +20,7 @@
 #include "core/matrix/batch_dense_kernels.hpp"
 #include "core/test/utils.hpp"
 #include "core/test/utils/batch_helpers.hpp"
-#include "test/utils/executor.hpp"
+#include "test/utils/common_fixture.hpp"
 
 
 class BatchBicgstab : public CommonTestFixture {

--- a/test/solver/batch_cg_kernels.cpp
+++ b/test/solver/batch_cg_kernels.cpp
@@ -19,7 +19,7 @@
 #include "core/matrix/batch_dense_kernels.hpp"
 #include "core/test/utils.hpp"
 #include "core/test/utils/batch_helpers.hpp"
-#include "test/utils/executor.hpp"
+#include "test/utils/common_fixture.hpp"
 
 
 class BatchCg : public CommonTestFixture {

--- a/test/solver/bicg_kernels.cpp
+++ b/test/solver/bicg_kernels.cpp
@@ -19,7 +19,7 @@
 #include "core/test/utils.hpp"
 #include "core/utils/matrix_utils.hpp"
 #include "matrices/config.hpp"
-#include "test/utils/executor.hpp"
+#include "test/utils/common_fixture.hpp"
 
 
 class Bicg : public CommonTestFixture {

--- a/test/solver/bicgstab_kernels.cpp
+++ b/test/solver/bicgstab_kernels.cpp
@@ -19,7 +19,7 @@
 
 #include "core/test/utils.hpp"
 #include "core/utils/matrix_utils.hpp"
-#include "test/utils/executor.hpp"
+#include "test/utils/common_fixture.hpp"
 
 
 class Bicgstab : public CommonTestFixture {

--- a/test/solver/cb_gmres_kernels.cpp
+++ b/test/solver/cb_gmres_kernels.cpp
@@ -20,7 +20,7 @@
 
 #include "core/solver/cb_gmres_accessor.hpp"
 #include "core/test/utils.hpp"
-#include "test/utils/executor.hpp"
+#include "test/utils/common_fixture.hpp"
 
 
 class CbGmres : public CommonTestFixture {

--- a/test/solver/cg_kernels.cpp
+++ b/test/solver/cg_kernels.cpp
@@ -18,7 +18,7 @@
 
 #include "core/test/utils.hpp"
 #include "core/utils/matrix_utils.hpp"
-#include "test/utils/executor.hpp"
+#include "test/utils/common_fixture.hpp"
 
 
 class Cg : public CommonTestFixture {

--- a/test/solver/cgs_kernels.cpp
+++ b/test/solver/cgs_kernels.cpp
@@ -18,7 +18,7 @@
 
 #include "core/test/utils.hpp"
 #include "core/utils/matrix_utils.hpp"
-#include "test/utils/executor.hpp"
+#include "test/utils/common_fixture.hpp"
 
 
 class Cgs : public CommonTestFixture {

--- a/test/solver/direct.cpp
+++ b/test/solver/direct.cpp
@@ -23,7 +23,7 @@
 #include "core/test/utils.hpp"
 #include "core/test/utils/assertions.hpp"
 #include "matrices/config.hpp"
-#include "test/utils/executor.hpp"
+#include "test/utils/common_fixture.hpp"
 
 
 namespace {

--- a/test/solver/fcg_kernels.cpp
+++ b/test/solver/fcg_kernels.cpp
@@ -18,7 +18,7 @@
 
 #include "core/test/utils.hpp"
 #include "core/utils/matrix_utils.hpp"
-#include "test/utils/executor.hpp"
+#include "test/utils/common_fixture.hpp"
 
 
 class Fcg : public CommonTestFixture {

--- a/test/solver/gcr_kernels.cpp
+++ b/test/solver/gcr_kernels.cpp
@@ -19,7 +19,7 @@
 
 #include "core/test/utils.hpp"
 #include "core/utils/matrix_utils.hpp"
-#include "test/utils/executor.hpp"
+#include "test/utils/common_fixture.hpp"
 
 
 class Gcr : public CommonTestFixture {

--- a/test/solver/gmres_kernels.cpp
+++ b/test/solver/gmres_kernels.cpp
@@ -19,7 +19,7 @@
 
 #include "core/solver/common_gmres_kernels.hpp"
 #include "core/test/utils.hpp"
-#include "test/utils/executor.hpp"
+#include "test/utils/common_fixture.hpp"
 
 
 class Gmres : public CommonTestFixture {

--- a/test/solver/idr_kernels.cpp
+++ b/test/solver/idr_kernels.cpp
@@ -27,7 +27,7 @@
 #include <ginkgo/core/stop/residual_norm.hpp>
 
 #include "core/test/utils.hpp"
-#include "test/utils/executor.hpp"
+#include "test/utils/common_fixture.hpp"
 
 
 // use another alias to avoid conflict name in the Idr

--- a/test/solver/ir_kernels.cpp
+++ b/test/solver/ir_kernels.cpp
@@ -17,7 +17,7 @@
 #include <ginkgo/core/stop/iteration.hpp>
 
 #include "core/test/utils.hpp"
-#include "test/utils/executor.hpp"
+#include "test/utils/common_fixture.hpp"
 
 
 class Ir : public CommonTestFixture {

--- a/test/solver/lower_trs_kernels.cpp
+++ b/test/solver/lower_trs_kernels.cpp
@@ -15,7 +15,7 @@
 
 #include "core/test/utils.hpp"
 #include "core/utils/matrix_utils.hpp"
-#include "test/utils/executor.hpp"
+#include "test/utils/common_fixture.hpp"
 
 
 class LowerTrs : public CommonTestFixture {

--- a/test/solver/multigrid_kernels.cpp
+++ b/test/solver/multigrid_kernels.cpp
@@ -16,7 +16,7 @@
 #include <ginkgo/core/stop/residual_norm.hpp>
 
 #include "core/test/utils.hpp"
-#include "test/utils/executor.hpp"
+#include "test/utils/common_fixture.hpp"
 
 
 class Multigrid : public CommonTestFixture {

--- a/test/solver/solver.cpp
+++ b/test/solver/solver.cpp
@@ -31,7 +31,7 @@
 
 #include "core/test/utils.hpp"
 #include "core/utils/matrix_utils.hpp"
-#include "test/utils/executor.hpp"
+#include "test/utils/common_fixture.hpp"
 
 
 #if GINKGO_COMMON_SINGLE_MODE

--- a/test/solver/upper_trs_kernels.cpp
+++ b/test/solver/upper_trs_kernels.cpp
@@ -15,7 +15,7 @@
 
 #include "core/test/utils.hpp"
 #include "core/utils/matrix_utils.hpp"
-#include "test/utils/executor.hpp"
+#include "test/utils/common_fixture.hpp"
 
 
 class UpperTrs : public CommonTestFixture {

--- a/test/stop/combined_kernels.cpp
+++ b/test/stop/combined_kernels.cpp
@@ -7,7 +7,7 @@
 #include <ginkgo/core/stop/combined.hpp>
 #include <ginkgo/core/stop/iteration.hpp>
 
-#include "test/utils/executor.hpp"
+#include "test/utils/common_fixture.hpp"
 
 
 constexpr gko::size_type test_iterations = 10;

--- a/test/stop/criterion_kernels.cpp
+++ b/test/stop/criterion_kernels.cpp
@@ -7,7 +7,7 @@
 #include <ginkgo/core/stop/criterion.hpp>
 #include <ginkgo/core/stop/iteration.hpp>
 
-#include "test/utils/executor.hpp"
+#include "test/utils/common_fixture.hpp"
 
 
 constexpr gko::size_type test_iterations = 10;

--- a/test/stop/residual_norm_kernels.cpp
+++ b/test/stop/residual_norm_kernels.cpp
@@ -8,7 +8,7 @@
 #include <ginkgo/core/stop/residual_norm.hpp>
 
 #include "core/test/utils.hpp"
-#include "test/utils/executor.hpp"
+#include "test/utils/common_fixture.hpp"
 
 
 template <typename Mtx>

--- a/test/utils/common_fixture.hpp
+++ b/test/utils/common_fixture.hpp
@@ -9,13 +9,10 @@
 #include <memory>
 #include <stdexcept>
 
-
 #include <gtest/gtest.h>
-
 
 #include <ginkgo/core/base/executor.hpp>
 #include <ginkgo/core/base/stream.hpp>
-
 
 #include "core/test/gtest/resources.hpp"
 #include "test/utils/executor.hpp"

--- a/test/utils/common_fixture.hpp
+++ b/test/utils/common_fixture.hpp
@@ -1,0 +1,82 @@
+// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+//
+// SPDX-License-Identifier: BSD-3-Clause
+
+#ifndef GKO_TEST_UTILS_COMMON_FIXTURE_HPP_
+#define GKO_TEST_UTILS_COMMON_FIXTURE_HPP_
+
+
+#include <memory>
+#include <stdexcept>
+
+
+#include <gtest/gtest.h>
+
+
+#include <ginkgo/core/base/executor.hpp>
+#include <ginkgo/core/base/stream.hpp>
+
+
+#include "core/test/gtest/resources.hpp"
+#include "test/utils/executor.hpp"
+
+
+#if GINKGO_COMMON_SINGLE_MODE
+#define SKIP_IF_SINGLE_MODE GTEST_SKIP() << "Skip due to single mode"
+#else
+#define SKIP_IF_SINGLE_MODE                                                  \
+    static_assert(true,                                                      \
+                  "This assert is used to counter the false positive extra " \
+                  "semi-colon warnings")
+#endif
+
+
+class CommonTestFixture : public ::testing::Test {
+public:
+#if GINKGO_COMMON_SINGLE_MODE
+    using value_type = float;
+#else
+    using value_type = double;
+#endif
+    using index_type = int;
+
+    CommonTestFixture()
+        :
+#if defined(GKO_TEST_NONDEFAULT_STREAM) && defined(GKO_COMPILING_CUDA)
+          stream(ResourceEnvironment::cuda_device_id),
+#endif
+#if defined(GKO_TEST_NONDEFAULT_STREAM) && defined(GKO_COMPILING_HIP)
+          stream(ResourceEnvironment::hip_device_id),
+#endif
+          ref{gko::ReferenceExecutor::create()}
+    {
+#if defined(GKO_COMPILING_CUDA) || defined(GKO_COMPILING_HIP)
+        init_executor(ref, exec, stream.get());
+#else
+        init_executor(ref, exec);
+#endif
+        // set device-id test-wide since some test call device
+        // kernels directly
+        guard = exec->get_scoped_device_id_guard();
+    }
+
+    void TearDown() final
+    {
+        if (exec != nullptr) {
+            ASSERT_NO_THROW(exec->synchronize());
+        }
+    }
+
+#ifdef GKO_COMPILING_CUDA
+    gko::cuda_stream stream;
+#endif
+#ifdef GKO_COMPILING_HIP
+    gko::hip_stream stream;
+#endif
+    std::shared_ptr<gko::ReferenceExecutor> ref;
+    std::shared_ptr<gko::EXEC_TYPE> exec;
+    gko::scoped_device_id_guard guard;
+};
+
+
+#endif  // GKO_TEST_UTILS_COMMON_FIXTURE_HPP_

--- a/test/utils/executor.hpp
+++ b/test/utils/executor.hpp
@@ -17,16 +17,6 @@
 #include "core/test/gtest/resources.hpp"
 
 
-#if GINKGO_COMMON_SINGLE_MODE
-#define SKIP_IF_SINGLE_MODE GTEST_SKIP() << "Skip due to single mode"
-#else
-#define SKIP_IF_SINGLE_MODE                                                  \
-    static_assert(true,                                                      \
-                  "This assert is used to counter the false positive extra " \
-                  "semi-colon warnings")
-#endif
-
-
 inline void init_executor(std::shared_ptr<gko::ReferenceExecutor>,
                           std::shared_ptr<gko::ReferenceExecutor>& exec)
 {
@@ -81,54 +71,6 @@ inline void init_executor(std::shared_ptr<gko::ReferenceExecutor> ref,
         throw std::runtime_error{"No suitable DPC++ devices"};
     }
 }
-
-
-class CommonTestFixture : public ::testing::Test {
-public:
-#if GINKGO_COMMON_SINGLE_MODE
-    using value_type = float;
-#else
-    using value_type = double;
-#endif
-    using index_type = int;
-
-    CommonTestFixture()
-        :
-#if defined(GKO_TEST_NONDEFAULT_STREAM) && defined(GKO_COMPILING_CUDA)
-          stream(ResourceEnvironment::cuda_device_id),
-#endif
-#if defined(GKO_TEST_NONDEFAULT_STREAM) && defined(GKO_COMPILING_HIP)
-          stream(ResourceEnvironment::hip_device_id),
-#endif
-          ref{gko::ReferenceExecutor::create()}
-    {
-#if defined(GKO_COMPILING_CUDA) || defined(GKO_COMPILING_HIP)
-        init_executor(ref, exec, stream.get());
-#else
-        init_executor(ref, exec);
-#endif
-        // set device-id test-wide since some test call device
-        // kernels directly
-        guard = exec->get_scoped_device_id_guard();
-    }
-
-    void TearDown() final
-    {
-        if (exec != nullptr) {
-            ASSERT_NO_THROW(exec->synchronize());
-        }
-    }
-
-#ifdef GKO_COMPILING_CUDA
-    gko::cuda_stream stream;
-#endif
-#ifdef GKO_COMPILING_HIP
-    gko::hip_stream stream;
-#endif
-    std::shared_ptr<gko::ReferenceExecutor> ref;
-    std::shared_ptr<gko::EXEC_TYPE> exec;
-    gko::scoped_device_id_guard guard;
-};
 
 
 #endif  // GKO_TEST_UTILS_EXECUTOR_HPP_

--- a/test/utils/mpi/common_fixture.hpp
+++ b/test/utils/mpi/common_fixture.hpp
@@ -2,8 +2,8 @@
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
-#ifndef GKO_TEST_UTILS_MPI_EXECUTOR_HPP_
-#define GKO_TEST_UTILS_MPI_EXECUTOR_HPP_
+#ifndef GKO_TEST_UTILS_MPI_COMMON_FIXTURE_HPP_
+#define GKO_TEST_UTILS_MPI_COMMON_FIXTURE_HPP_
 
 
 #include <memory>
@@ -64,4 +64,4 @@ public:
 };
 
 
-#endif  // GKO_TEST_UTILS_MPI_EXECUTOR_HPP_
+#endif  // GKO_TEST_UTILS_MPI_COMMON_FIXTURE_HPP_


### PR DESCRIPTION
This adds a function that prints a textual representation of the device used by an executor, and uses it in tests/benchmarks