### PR TITLE
Release/1.8.0

### DIFF
--- a/.github/mirror.sh
+++ b/.github/mirror.sh
@@ -1,7 +1,5 @@
 #!/usr/bin/env bash
 
-BRANCH_NAME=${BRANCH_NAME##*/}
-
 git remote add fork "git@github.com:${GITHUB_REPO}.git"
 git remote add gitlab "git@gitlab.com:ginkgo-project/ginkgo-public-ci.git"
 

--- a/.github/workflows/mirror.yml
+++ b/.github/workflows/mirror.yml
@@ -15,5 +15,5 @@ jobs:
         run: cp --preserve .github/mirror.sh /tmp && /tmp/mirror.sh
         env:
           BOT_KEY: ${{ secrets.GITLAB_MIRROR_PRIV_KEY }}
-          BRANCH_NAME: ${{ github.ref }}
+          BRANCH_NAME: ${{ github.ref_name }}
           GITHUB_REPO: ${{ github.repository }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,127 @@ git log --first-parent
 
 Please visit our wiki [Changelog](https://github.com/ginkgo-project/ginkgo/wiki/Changelog) for unreleased changes.
 
+## Version 1.8.0
+
+The Ginkgo team is proud to announce the new Ginkgo minor release 1.8.0. This
+release brings new features such as:
+- A brand new file-based configuration for Ginkgo objects: you can now construct
+  Ginkgo objects (solvers, preconditioners, ...) from a JSON configuration file.
+  This simplifies interfacing to Ginkgo as well as exploring different settings
+  to solve a problem.
+- Expand the batched feature set with: the Batched CSR Matrix format, batched CG
+  solver, batched (Block-)Jacobi preconditioner, usage example and other
+  features such as scaling,
+- New Distributed Multigrid and the PGM coarsening method,
+- New CUDA and HIP kernels for Reverse Cuthill McKee (RCM) reordering
+- Better Ginkgo and Kokkos interaction thanks to a mapping from simple Ginkgo
+  types to native Kokkos types
+
+and more!
+
+If you face an issue, please first check our [known issues page](https://github.com/ginkgo-project/ginkgo/wiki/Known-Issues) and the [open issues list](https://github.com/ginkgo-project/ginkgo/issues) and if you do not find a solution, feel free to [open a new issue](https://github.com/ginkgo-project/ginkgo/issues/new/choose) or ask a question using the [github discussions](https://github.com/ginkgo-project/ginkgo/discussions).
+
+Supported systems and requirements:
++ For all platforms, CMake 3.16+
++ C++14 compliant compiler
++ Linux and macOS
+  + GCC: 5.5+
+  + clang: 3.9+
+  + Intel compiler: 2019+
+  + Apple Clang: 14.0 is tested. Earlier versions might also work.
+  + NVHPC: 22.7+
+  + Cray Compiler: 14.0.1+
+  + CUDA module: CMake 3.18+, and CUDA 10.1+ or NVHPC 22.7+
+  + HIP module: CMake 3.21+, and ROCm 4.5+
+  + DPC++ module: Intel oneAPI 2023.1+ with oneMKL and oneDPL. Set the CXX compiler to `dpcpp` or `icpx`.
+  + MPI: standard version 3.1+, ideally GPU Aware, for best performance
++ Windows
+  + MinGW: GCC 5.5+
+  + Microsoft Visual Studio: VS 2019+
+  + CUDA module: CUDA 10.1+, Microsoft Visual Studio
+  + OpenMP module: MinGW.
+
+### Version support changes
++ The Ginkgo license header now uses the SPDX format. [#1404](https://github.com/ginkgo-project/ginkgo/pull/1404)
++ Ginkgo changes the oneapi support to 2023.1+ [#1396](https://github.com/ginkgo-project/ginkgo/pull/1396)
++ Ginkgo's HIP backend now requires CMake 3.21 [#1334](https://github.com/ginkgo-project/ginkgo/pull/1334)
+
+### Interface changes
+
++ The `gko::dim` single-parameter constructor is now `explicit` to avoid accidental conversion from integers [#1474](https://github.com/ginkgo-project/ginkgo/pull/1474)
++ The CMake option `GINKGO_BUILD_HWLOC` is now set to `OFF` by default, and if it is set to `ON`, then `HWLOC` is required to be available [#1513](https://github.com/ginkgo-project/ginkgo/pull/1513).
+
+### Behavior changes
+
++ `gko::write_raw` now defaults to writing sparse output unless otherwise specified [#1533](https://github.com/ginkgo-project/ginkgo/pull/1533)
++ Ginkgo now adheres to the `--prefix` option for `cmake --install`, instead of overwriting it [#1534](https://github.com/ginkgo-project/ginkgo/pull/1534)
+
+### Deprecations
+
++ `array::get_num_elems()` has been renamed to `get_size()` [#1400](https://github.com/ginkgo-project/ginkgo/pull/1400)
++ `matrix_data::ensure_row_major_order()` has been renamed to `sort_row_major()` [#1400](https://github.com/ginkgo-project/ginkgo/pull/1400)
++ `device_matrix_data::get_num_elems()` has been renamed to `get_num_stored_elements()` [#1400](https://github.com/ginkgo-project/ginkgo/pull/1400)
++ The CMake parameter `GINKGO_COMPILER_FLAGS` has been superseded by `CMAKE_CXX_FLAGS`, and `GINKGO_CUDA_COMPILER_FLAGS` has been superseded by `CMAKE_CUDA_FLAGS` [#1535](https://github.com/ginkgo-project/ginkgo/pull/1535)
++ The `std::initializer_list` overloads of matrix `create` methods and constructors are deprecated in favor of explicit `array` parameters [#1433](https://github.com/ginkgo-project/ginkgo/pull/1433)
+
+### Summary of previous deprecations
++ The `device_reset` parameter of CUDA and HIP executors no longer has an effect, and its `allocation_mode` parameters have been deprecated in favor of the `Allocator` interface.
++ The CMake parameter `GINKGO_BUILD_DPCPP` has been deprecated in favor of `GINKGO_BUILD_SYCL`.
++ The `gko::reorder::Rcm` interface has been deprecated in favor of `gko::experimental::reorder::Rcm` based on `Permutation`.
++ The Permutation class' `permute_mask` functionality.
++ Multiple functions with typos (`set_complex_subpsace()`, range functions such as `conj_operaton` etc).
++ `gko::lend()` is not necessary anymore.
++ The classes `RelativeResidualNorm` and `AbsoluteResidualNorm` are deprecated in favor of `ResidualNorm`.
++ The class `AmgxPgm` is deprecated in favor of `Pgm`.
++ Default constructors for the CSR `load_balance` and `automatical` strategies
++ The PolymorphicObject's move-semantic `copy_from` variant
++ The templated `SolverBase` class.
++ The class `MachineTopology` is deprecated in favor of `machine_topology`.
++ Logger constructors and create functions with the `executor` parameter.
++ The virtual, protected, Dense functions `compute_norm1_impl`, `add_scaled_impl`, etc.
++ Logger events for solvers and criterion without the additional `implicit_tau_sq` parameter.
++ The global `gko::solver::default_krylov_dim`, use instead `gko::solver::gmres_default_krylov_dim`.
+
+### Added features
++ Add a batched CG solver [#1598](https://github.com/ginkgo-project/ginkgo/pull/1598), [#1609](https://github.com/ginkgo-project/ginkgo/pull/1609)
++ Add a batched Jacobi (scalar/block) preconditioner, [#1542](https://github.com/ginkgo-project/ginkgo/pull/1542), [#1600](https://github.com/ginkgo-project/ginkgo/pull/1600)
++ Add an example for batched iterative solver [#1553](https://github.com/ginkgo-project/ginkgo/pull/1553)
++ Add `add_scaled_identity` and `scale_add` for batch matrix formats. [#1528](https://github.com/ginkgo-project/ginkgo/pull/1528)
++ Add scaling for batch objects (matrix formats and multi-vectors). [#1527](https://github.com/ginkgo-project/ginkgo/pull/1527)
++ Add a `batch::Csr` matrix format class and core and support for batched spmv kernels on CUDA, HIP and SYCL. [#1450](https://github.com/ginkgo-project/ginkgo/pull/1450)
++ Add a script for comparing benchmark JSON outputs [#1467](https://github.com/ginkgo-project/ginkgo/pull/1467)
++ Add an example for reordered preconditioned linear solver [#1465](https://github.com/ginkgo-project/ginkgo/pull/1465)
++ Add single-value access functions `load_value` and `store_value` to `array` [#1485](https://github.com/ginkgo-project/ginkgo/pull/1485)
++ Add the `BlockOperator` format to represent block-matrices [#1435](https://github.com/ginkgo-project/ginkgo/pull/1435)
++ Add CUDA and HIP kernels for Reverse Cuthill McKee (RCM) reordering [#1503](https://github.com/ginkgo-project/ginkgo/pull/1503)
++ Add FileConfig [#1389](https://github.com/ginkgo-project/ginkgo/pull/1389), [#1392](https://github.com/ginkgo-project/ginkgo/pull/1392), [#1395](https://github.com/ginkgo-project/ginkgo/pull/1395), [#1479](https://github.com/ginkgo-project/ginkgo/pull/1479), [#1480](https://github.com/ginkgo-project/ginkgo/pull/1480), [#1607](https://github.com/ginkgo-project/ginkgo/pull/1607)
++ Add Distributed Multigrid [#1269](https://github.com/ginkgo-project/ginkgo/pull/1269) and coarsening method PGM [#1403](https://github.com/ginkgo-project/ginkgo/pull/1403)
++ Add a mapping from simple Ginkgo types to native Kokkos types [#1358](https://github.com/ginkgo-project/ginkgo/pull/1358)
++ Add a segmented array class [#1545](https://github.com/ginkgo-project/ginkgo/pull/1545)
++ Add a class for mapping between global and local indexing [#1543](https://github.com/ginkgo-project/ginkgo/pull/1543)
+
+### Improvements
+
++ Ginkgo installation now has separate `Ginkgo_Runtime` and `Ginkgo_Development` components for easier packaging [#1502](https://github.com/ginkgo-project/ginkgo/pull/1502)
++ The HIP backend now supports complex number operations for sparse matrices based on hipSPARSE [#1538](https://github.com/ginkgo-project/ginkgo/pull/1538)
++ The `create` functions are now documented explicitly instead of using the `EnableCreateMethod` mixin [#1433](https://github.com/ginkgo-project/ginkgo/pull/1433)
++ The `solver` benchmark now supports Ginkgo's binary format for right-hand side vector inputs [#1584](https://github.com/ginkgo-project/ginkgo/pull/1584)
++ The build system now uses native HIP support for CMake, which also provides support for ROCm 6.0 [#1334](https://github.com/ginkgo-project/ginkgo/pull/1334)
++ The Multigrid solver generated from `distributed::Matrix` will use a global scalar Jacobi smoother and a GMRES solver as coarse grid solver [#1612](https://github.com/ginkgo-project/ginkgo/pull/1612)
+
+### Fixes
+
++ Compilation with libc++ was fixed [#1463](https://github.com/ginkgo-project/ginkgo/pull/1463)
++ Fix the `__cplusplus` by `_MSVC_LANG` in MSVC [#1496](https://github.com/ginkgo-project/ginkgo/pull/1496)
++ `Coo::read(const T&)` and `Csr::read(const T&)` will no longer overwrite the locally stored arrays and instead copy directly into them [#1476](https://github.com/ginkgo-project/ginkgo/pull/1476)
++ Fix the interaction of `ProfilerHook::create(_nested)_summary`, executors and GPU timers, which lead to the summary not being printed [#1509](https://github.com/ginkgo-project/ginkgo/pull/1509)
++ Fix compilation in environments where `CPATH` contains the current working directory [#1531](https://github.com/ginkgo-project/ginkgo/pull/1531)
++ Fix read from matrix-market files with CR line endings [#1557](https://github.com/ginkgo-project/ginkgo/pull/1557)
++ Fix undefined behavior that shows up with libstdc++ debug builds [#1176](https://github.com/ginkgo-project/ginkgo/pull/1176)
++ Fix for CUDA 12.4 bug and METIS detection [#1569](https://github.com/ginkgo-project/ginkgo/pull/1569)
++ Fix the pkgconfig installation with DESTDIR [#1597](https://github.com/ginkgo-project/ginkgo/pull/1597)
++ Fix various issues causing build or test failures [#1619](https://github.com/ginkgo-project/ginkgo/pull/1619)
+
 ## Version 1.7.0
 
 The Ginkgo team is proud to announce the new Ginkgo minor release 1.7.0. This release brings new features such as:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.16)
 
-project(Ginkgo LANGUAGES CXX VERSION 1.8.0 DESCRIPTION "A numerical linear algebra library targeting many-core architectures")
+project(Ginkgo LANGUAGES CXX VERSION 1.9.0 DESCRIPTION "A numerical linear algebra library targeting many-core architectures")
 set(Ginkgo_VERSION_TAG "develop")
 set(PROJECT_VERSION_TAG ${Ginkgo_VERSION_TAG})
 # Cuda and Hip also look for Threads. Set it before any find_package to ensure the Threads setting is not changed.

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ following:
 
 ### Windows
 
-*   _cmake 3.13+_
+*   _cmake 3.16+_
 *   C++14 compliant 64-bit compiler:
     *   _MinGW : gcc 5.5+_
     *   _Microsoft Visual Studio : VS 2019+_

--- a/examples/adaptiveprecision-blockjacobi/CMakeLists.txt
+++ b/examples/adaptiveprecision-blockjacobi/CMakeLists.txt
@@ -3,7 +3,7 @@ project(adaptiveprecision-blockjacobi)
 
 # We only need to find Ginkgo if we build this example stand-alone
 if (NOT GINKGO_BUILD_EXAMPLES)
-    find_package(Ginkgo 1.8.0 REQUIRED)
+    find_package(Ginkgo 1.9.0 REQUIRED)
 endif()
 
 add_executable(adaptiveprecision-blockjacobi adaptiveprecision-blockjacobi.cpp)

--- a/examples/batched-solver/CMakeLists.txt
+++ b/examples/batched-solver/CMakeLists.txt
@@ -3,7 +3,7 @@ project(batched-solver)
 
 # We only need to find Ginkgo if we build this example stand-alone
 if (NOT GINKGO_BUILD_EXAMPLES)
-    find_package(Ginkgo 1.8.0 REQUIRED)
+    find_package(Ginkgo 1.9.0 REQUIRED)
 endif()
 
 add_executable(batched-solver batched-solver.cpp)

--- a/examples/build-setup.sh
+++ b/examples/build-setup.sh
@@ -3,7 +3,7 @@
 # copy libraries
 LIBRARY_NAMES="ginkgo ginkgo_reference ginkgo_omp ginkgo_cuda ginkgo_hip ginkgo_dpcpp ginkgo_device"
 SUFFIXES=".so .dylib .dll d.so d.dylib d.dll"
-VERSION="1.8.0"
+VERSION="1.9.0"
 for name in ${LIBRARY_NAMES}; do
     for suffix in ${SUFFIXES}; do
         cp ${BUILD_DIR}/lib/lib${name}${suffix}.${VERSION} \

--- a/examples/cb-gmres/CMakeLists.txt
+++ b/examples/cb-gmres/CMakeLists.txt
@@ -3,7 +3,7 @@ project(cb-gmres)
 
 # We only need to find Ginkgo if we build this example stand-alone
 if (NOT GINKGO_BUILD_EXAMPLES)
-    find_package(Ginkgo 1.8.0 REQUIRED)
+    find_package(Ginkgo 1.9.0 REQUIRED)
 endif()
 
 add_executable(cb-gmres cb-gmres.cpp)

--- a/examples/custom-logger/CMakeLists.txt
+++ b/examples/custom-logger/CMakeLists.txt
@@ -3,7 +3,7 @@ project(custom-logger)
 
 # We only need to find Ginkgo if we build this example stand-alone
 if (NOT GINKGO_BUILD_EXAMPLES)
-    find_package(Ginkgo 1.8.0 REQUIRED)
+    find_package(Ginkgo 1.9.0 REQUIRED)
 endif()
 
 add_executable(custom-logger custom-logger.cpp)

--- a/examples/custom-matrix-format/CMakeLists.txt
+++ b/examples/custom-matrix-format/CMakeLists.txt
@@ -3,7 +3,7 @@ project(custom-matrix-format CXX CUDA)
 
 # We only need to find Ginkgo if we build this example stand-alone
 if (NOT GINKGO_BUILD_EXAMPLES)
-    find_package(Ginkgo 1.8.0 REQUIRED)
+    find_package(Ginkgo 1.9.0 REQUIRED)
     find_package(OpenMP 3.0 REQUIRED)
 endif()
 

--- a/examples/custom-stopping-criterion/CMakeLists.txt
+++ b/examples/custom-stopping-criterion/CMakeLists.txt
@@ -3,7 +3,7 @@ project(custom-stopping-criterion)
 
 # We only need to find Ginkgo if we build this example stand-alone
 if (NOT GINKGO_BUILD_EXAMPLES)
-    find_package(Ginkgo 1.8.0 REQUIRED)
+    find_package(Ginkgo 1.9.0 REQUIRED)
     set(THREADS_PREFER_PTHREAD_FLAG ON)
     find_package(Threads REQUIRED)
 endif()

--- a/examples/ginkgo-overhead/CMakeLists.txt
+++ b/examples/ginkgo-overhead/CMakeLists.txt
@@ -3,7 +3,7 @@ project(ginkgo-overhead)
 
 # We only need to find Ginkgo if we build this example stand-alone
 if (NOT GINKGO_BUILD_EXAMPLES)
-    find_package(Ginkgo 1.8.0 REQUIRED)
+    find_package(Ginkgo 1.9.0 REQUIRED)
 endif()
 
 add_executable(ginkgo-overhead ginkgo-overhead.cpp)

--- a/examples/ginkgo-ranges/CMakeLists.txt
+++ b/examples/ginkgo-ranges/CMakeLists.txt
@@ -3,7 +3,7 @@ project(ginkgo-ranges)
 
 # We only need to find Ginkgo if we build this example stand-alone
 if (NOT GINKGO_BUILD_EXAMPLES)
-    find_package(Ginkgo 1.8.0 REQUIRED)
+    find_package(Ginkgo 1.9.0 REQUIRED)
 endif()
 add_executable(ginkgo-ranges ginkgo-ranges.cpp)
 target_link_libraries(ginkgo-ranges Ginkgo::ginkgo)

--- a/examples/heat-equation/CMakeLists.txt
+++ b/examples/heat-equation/CMakeLists.txt
@@ -3,7 +3,7 @@ project(heat-equation)
 
 # We only need to find Ginkgo if we build this example stand-alone
 if (NOT GINKGO_BUILD_EXAMPLES)
-    find_package(Ginkgo 1.8.0 REQUIRED)
+    find_package(Ginkgo 1.9.0 REQUIRED)
 endif()
 find_package(OpenCV REQUIRED)
 

--- a/examples/ilu-preconditioned-solver/CMakeLists.txt
+++ b/examples/ilu-preconditioned-solver/CMakeLists.txt
@@ -3,7 +3,7 @@ project(ilu-preconditioned-solver)
 
 # We only need to find Ginkgo if we build this example stand-alone
 if (NOT GINKGO_BUILD_EXAMPLES)
-    find_package(Ginkgo 1.8.0 REQUIRED)
+    find_package(Ginkgo 1.9.0 REQUIRED)
 endif()
 
 add_executable(ilu-preconditioned-solver ilu-preconditioned-solver.cpp)

--- a/examples/inverse-iteration/CMakeLists.txt
+++ b/examples/inverse-iteration/CMakeLists.txt
@@ -3,7 +3,7 @@ project(inverse-iteration)
 
 # We only need to find Ginkgo if we build this example stand-alone
 if (NOT GINKGO_BUILD_EXAMPLES)
-    find_package(Ginkgo 1.8.0 REQUIRED)
+    find_package(Ginkgo 1.9.0 REQUIRED)
 endif()
 
 add_executable(inverse-iteration inverse-iteration.cpp)

--- a/examples/ir-ilu-preconditioned-solver/CMakeLists.txt
+++ b/examples/ir-ilu-preconditioned-solver/CMakeLists.txt
@@ -3,7 +3,7 @@ project(ir-ilu-preconditioned-solver)
 
 # We only need to find Ginkgo if we build this example stand-alone
 if (NOT GINKGO_BUILD_EXAMPLES)
-    find_package(Ginkgo 1.8.0 REQUIRED)
+    find_package(Ginkgo 1.9.0 REQUIRED)
 endif()
 
 add_executable(ir-ilu-preconditioned-solver ir-ilu-preconditioned-solver.cpp)

--- a/examples/iterative-refinement/CMakeLists.txt
+++ b/examples/iterative-refinement/CMakeLists.txt
@@ -3,7 +3,7 @@ project(iterative-refinement)
 
 # We only need to find Ginkgo if we build this example stand-alone
 if (NOT GINKGO_BUILD_EXAMPLES)
-    find_package(Ginkgo 1.8.0 REQUIRED)
+    find_package(Ginkgo 1.9.0 REQUIRED)
 endif()
 
 add_executable(iterative-refinement iterative-refinement.cpp)

--- a/examples/kokkos-assembly/CMakeLists.txt
+++ b/examples/kokkos-assembly/CMakeLists.txt
@@ -3,7 +3,7 @@ project(kokkos-assembly CXX)
 
 # We only need to find Ginkgo if we build this example stand-alone
 if(NOT GINKGO_BUILD_EXAMPLES)
-    find_package(Ginkgo 1.8.0 REQUIRED)
+    find_package(Ginkgo 1.9.0 REQUIRED)
 endif()
 find_package(Kokkos 4.1.00 REQUIRED)
 

--- a/examples/minimal-cuda-solver/CMakeLists.txt
+++ b/examples/minimal-cuda-solver/CMakeLists.txt
@@ -3,7 +3,7 @@ project(minimal-cuda-solver)
 
 # We only need to find Ginkgo if we build this example stand-alone
 if (NOT GINKGO_BUILD_EXAMPLES)
-    find_package(Ginkgo 1.8.0 REQUIRED)
+    find_package(Ginkgo 1.9.0 REQUIRED)
 endif()
 
 add_executable(minimal-cuda-solver minimal-cuda-solver.cpp)

--- a/examples/mixed-multigrid-preconditioned-solver/CMakeLists.txt
+++ b/examples/mixed-multigrid-preconditioned-solver/CMakeLists.txt
@@ -3,7 +3,7 @@ project(mixed-multigrid-preconditioned-solver)
 
 # We only need to find Ginkgo if we build this example stand-alone
 if (NOT GINKGO_BUILD_EXAMPLES)
-    find_package(Ginkgo 1.8.0 REQUIRED)
+    find_package(Ginkgo 1.9.0 REQUIRED)
 endif()
 
 add_executable(mixed-multigrid-preconditioned-solver mixed-multigrid-preconditioned-solver.cpp)

--- a/examples/mixed-multigrid-solver/CMakeLists.txt
+++ b/examples/mixed-multigrid-solver/CMakeLists.txt
@@ -3,7 +3,7 @@ project(mixed-multigrid-solver)
 
 # We only need to find Ginkgo if we build this example stand-alone
 if (NOT GINKGO_BUILD_EXAMPLES)
-    find_package(Ginkgo 1.8.0 REQUIRED)
+    find_package(Ginkgo 1.9.0 REQUIRED)
 endif()
 
 add_executable(mixed-multigrid-solver mixed-multigrid-solver.cpp)

--- a/examples/mixed-precision-ir/CMakeLists.txt
+++ b/examples/mixed-precision-ir/CMakeLists.txt
@@ -3,7 +3,7 @@ project(mixed-precision-ir)
 
 # We only need to find Ginkgo if we build this example stand-alone
 if (NOT GINKGO_BUILD_EXAMPLES)
-    find_package(Ginkgo 1.8.0 REQUIRED)
+    find_package(Ginkgo 1.9.0 REQUIRED)
 endif()
 
 add_executable(mixed-precision-ir mixed-precision-ir.cpp)

--- a/examples/mixed-spmv/CMakeLists.txt
+++ b/examples/mixed-spmv/CMakeLists.txt
@@ -3,7 +3,7 @@ project(mixed-spmv)
 
 # We only need to find Ginkgo if we build this example stand-alone
 if (NOT GINKGO_BUILD_EXAMPLES)
-    find_package(Ginkgo 1.8.0 REQUIRED)
+    find_package(Ginkgo 1.9.0 REQUIRED)
 endif()
 
 add_executable(mixed-spmv mixed-spmv.cpp)

--- a/examples/multigrid-preconditioned-solver-customized/CMakeLists.txt
+++ b/examples/multigrid-preconditioned-solver-customized/CMakeLists.txt
@@ -3,7 +3,7 @@ project(multigrid-preconditioned-solver-customized)
 
 # We only need to find Ginkgo if we build this example stand-alone
 if (NOT GINKGO_BUILD_EXAMPLES)
-    find_package(Ginkgo 1.8.0 REQUIRED)
+    find_package(Ginkgo 1.9.0 REQUIRED)
 endif()
 
 add_executable(multigrid-preconditioned-solver-customized multigrid-preconditioned-solver-customized.cpp)

--- a/examples/multigrid-preconditioned-solver/CMakeLists.txt
+++ b/examples/multigrid-preconditioned-solver/CMakeLists.txt
@@ -3,7 +3,7 @@ project(multigrid-preconditioned-solver)
 
 # We only need to find Ginkgo if we build this example stand-alone
 if (NOT GINKGO_BUILD_EXAMPLES)
-    find_package(Ginkgo 1.8.0 REQUIRED)
+    find_package(Ginkgo 1.9.0 REQUIRED)
 endif()
 
 add_executable(multigrid-preconditioned-solver multigrid-preconditioned-solver.cpp)

--- a/examples/nine-pt-stencil-solver/CMakeLists.txt
+++ b/examples/nine-pt-stencil-solver/CMakeLists.txt
@@ -3,7 +3,7 @@ project(nine-pt-stencil-solver)
 
 # We only need to find Ginkgo if we build this example stand-alone
 if (NOT GINKGO_BUILD_EXAMPLES)
-    find_package(Ginkgo 1.8.0 REQUIRED)
+    find_package(Ginkgo 1.9.0 REQUIRED)
 endif()
 
 add_executable(nine-pt-stencil-solver nine-pt-stencil-solver.cpp)

--- a/examples/papi-logging/CMakeLists.txt
+++ b/examples/papi-logging/CMakeLists.txt
@@ -3,7 +3,7 @@ project(papi-logging)
 
 # We only need to find Ginkgo if we build this example stand-alone
 if (NOT GINKGO_BUILD_EXAMPLES)
-    find_package(Ginkgo 1.8.0 REQUIRED)
+    find_package(Ginkgo 1.9.0 REQUIRED)
 endif()
 
 if (NOT GINKGO_HAVE_PAPI_SDE)

--- a/examples/par-ilu-convergence/CMakeLists.txt
+++ b/examples/par-ilu-convergence/CMakeLists.txt
@@ -3,7 +3,7 @@ project(par-ilu-convergence)
 
 # We only need to find Ginkgo if we build this example stand-alone
 if (NOT GINKGO_BUILD_EXAMPLES)
-    find_package(Ginkgo 1.8.0 REQUIRED)
+    find_package(Ginkgo 1.9.0 REQUIRED)
 endif()
 
 add_executable(par-ilu-convergence par-ilu-convergence.cpp)

--- a/examples/performance-debugging/CMakeLists.txt
+++ b/examples/performance-debugging/CMakeLists.txt
@@ -3,7 +3,7 @@ project(performance-debugging)
 
 # We only need to find Ginkgo if we build this example stand-alone
 if (NOT GINKGO_BUILD_EXAMPLES)
-    find_package(Ginkgo 1.8.0 REQUIRED)
+    find_package(Ginkgo 1.9.0 REQUIRED)
 endif()
 
 add_executable(performance-debugging performance-debugging.cpp)

--- a/examples/poisson-solver/CMakeLists.txt
+++ b/examples/poisson-solver/CMakeLists.txt
@@ -3,7 +3,7 @@ project(poisson-solver)
 
 # We only need to find Ginkgo if we build this example stand-alone
 if (NOT GINKGO_BUILD_EXAMPLES)
-    find_package(Ginkgo 1.8.0 REQUIRED)
+    find_package(Ginkgo 1.9.0 REQUIRED)
 endif()
 
 add_executable(poisson-solver poisson-solver.cpp)

--- a/examples/preconditioned-solver/CMakeLists.txt
+++ b/examples/preconditioned-solver/CMakeLists.txt
@@ -3,7 +3,7 @@ project(preconditioned-solver)
 
 # We only need to find Ginkgo if we build this example stand-alone
 if (NOT GINKGO_BUILD_EXAMPLES)
-    find_package(Ginkgo 1.8.0 REQUIRED)
+    find_package(Ginkgo 1.9.0 REQUIRED)
 endif()
 add_executable(preconditioned-solver preconditioned-solver.cpp)
 target_link_libraries(preconditioned-solver Ginkgo::ginkgo)

--- a/examples/preconditioner-export/CMakeLists.txt
+++ b/examples/preconditioner-export/CMakeLists.txt
@@ -3,7 +3,7 @@ project(preconditioner-export)
 
 # We only need to find Ginkgo if we build this example stand-alone
 if (NOT GINKGO_BUILD_EXAMPLES)
-    find_package(Ginkgo 1.8.0 REQUIRED)
+    find_package(Ginkgo 1.9.0 REQUIRED)
 endif()
 
 add_executable(preconditioner-export preconditioner-export.cpp)

--- a/examples/reordered-preconditioned-solver/CMakeLists.txt
+++ b/examples/reordered-preconditioned-solver/CMakeLists.txt
@@ -3,7 +3,7 @@ project(reordered-preconditioned-solver)
 
 # We only need to find Ginkgo if we build this example stand-alone
 if (NOT GINKGO_BUILD_EXAMPLES)
-    find_package(Ginkgo 1.8.0 REQUIRED)
+    find_package(Ginkgo 1.9.0 REQUIRED)
 endif()
 add_executable(reordered-preconditioned-solver reordered-preconditioned-solver.cpp)
 target_link_libraries(reordered-preconditioned-solver Ginkgo::ginkgo)

--- a/examples/schroedinger-splitting/CMakeLists.txt
+++ b/examples/schroedinger-splitting/CMakeLists.txt
@@ -3,7 +3,7 @@ project(schroedinger-splitting)
 
 # We only need to find Ginkgo if we build this example stand-alone
 if (NOT GINKGO_BUILD_EXAMPLES)
-    find_package(Ginkgo 1.8.0 REQUIRED)
+    find_package(Ginkgo 1.9.0 REQUIRED)
 endif()
 find_package(OpenCV REQUIRED)
 

--- a/examples/simple-solver-logging/CMakeLists.txt
+++ b/examples/simple-solver-logging/CMakeLists.txt
@@ -3,7 +3,7 @@ project(simple-solver-logging)
 
 # We only need to find Ginkgo if we build this example stand-alone
 if (NOT GINKGO_BUILD_EXAMPLES)
-    find_package(Ginkgo 1.8.0 REQUIRED)
+    find_package(Ginkgo 1.9.0 REQUIRED)
 endif()
 
 add_executable(simple-solver-logging simple-solver-logging.cpp)

--- a/examples/simple-solver/CMakeLists.txt
+++ b/examples/simple-solver/CMakeLists.txt
@@ -3,7 +3,7 @@ project(simple-solver)
 
 # We only need to find Ginkgo if we build this example stand-alone
 if (NOT GINKGO_BUILD_EXAMPLES)
-    find_package(Ginkgo 1.8.0 REQUIRED)
+    find_package(Ginkgo 1.9.0 REQUIRED)
 endif()
 
 add_executable(simple-solver simple-solver.cpp)

--- a/examples/three-pt-stencil-solver/CMakeLists.txt
+++ b/examples/three-pt-stencil-solver/CMakeLists.txt
@@ -3,7 +3,7 @@ project(three-pt-stencil-solver)
 
 # We only need to find Ginkgo if we build this example stand-alone
 if (NOT GINKGO_BUILD_EXAMPLES)
-    find_package(Ginkgo 1.8.0 REQUIRED)
+    find_package(Ginkgo 1.9.0 REQUIRED)
 endif()
 
 add_executable(three-pt-stencil-solver three-pt-stencil-solver.cpp)


### PR DESCRIPTION
Release 1.8.0 to develop

+ Pushes the Changelog, see `CHANGELOG.md`
+ Fix mirror to gitlab's branch name detection
+ Move develop 1.9.0 from now on.