### PR TITLE
Fix Ginkgo version in CITATION.cff

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -26,11 +26,12 @@ authors:
 - family-names: "Riemer"
   given-names: "Lukas"
 - family-names: "Tsai"
-  given-names: "Yuhsiang"
+  given-names: "Yu-Hsiang"
 title: "Ginkgo: A Modern Linear Operator Algebra Framework for High Performance Computing"
-version: 1.5.0
-date-released: 2022-11-12
+version: 1.8.0
+date-released: 2024-06-13
 url: "https://github.com/ginkgo-project/ginkgo"
+license: BSD-3-Clause
 preferred-citation:
   type: article
   authors:


### PR DESCRIPTION
The version in CITATION.cff is not the most recent, this PR bumps the version to the latest released version 1.8.0.