### PR TITLE
Discard trailing entries of a line in a MM-format file

### DIFF
--- a/core/base/mtx_io.cpp
+++ b/core/base/mtx_io.cpp
@@ -517,8 +517,8 @@ private:
                 GKO_CHECK_STREAM(content, "error when reading matrix entry " +
                                               std::to_string(i));
                 modifier->insert_entry(row - 1, col - 1, entry, data);
-                content.ignore(max_streamsize,
-                               '\n');  // discards rest of the line
+                // discards rest of the line
+                content.ignore(max_streamsize, '\n');
             }
             return data;
         }
@@ -574,7 +574,7 @@ private:
             size_type num_cols{};
             GKO_CHECK_STREAM(
                 header >> num_rows >> num_cols,
-                "error when determining matrix size, expected: rows cols nnz");
+                "error when determining matrix size, expected: rows cols");
             matrix_data<ValueType, IndexType> data(dim<2>{num_rows, num_cols});
             data.nonzeros.reserve(modifier->get_reservation_size(
                 num_rows, num_cols, num_rows * num_cols));
@@ -587,8 +587,8 @@ private:
                                          std::to_string(row) + " ," +
                                          std::to_string(col));
                     modifier->insert_entry(row, col, entry, data);
-                    content.ignore(max_streamsize,
-                                   '\n');  // discards rest of the line
+                    // discards rest of the line
+                    content.ignore(max_streamsize, '\n');
                 }
             }
             return data;

--- a/core/base/mtx_io.cpp
+++ b/core/base/mtx_io.cpp
@@ -35,6 +35,9 @@ namespace {
     }
 
 
+constexpr auto max_streamsize = std::numeric_limits<std::streamsize>::max();
+
+
 /**
  * The mtx_io class provides the functionality of reading and writing matrix
  * market format files.
@@ -514,6 +517,8 @@ private:
                 GKO_CHECK_STREAM(content, "error when reading matrix entry " +
                                               std::to_string(i));
                 modifier->insert_entry(row - 1, col - 1, entry, data);
+                content.ignore(max_streamsize,
+                               '\n');  // discards rest of the line
             }
             return data;
         }
@@ -582,6 +587,8 @@ private:
                                          std::to_string(row) + " ," +
                                          std::to_string(col));
                     modifier->insert_entry(row, col, entry, data);
+                    content.ignore(max_streamsize,
+                                   '\n');  // discards rest of the line
                 }
             }
             return data;

--- a/core/test/base/mtx_io.cpp
+++ b/core/test/base/mtx_io.cpp
@@ -231,6 +231,32 @@ TEST(MtxReader, ReadsDenseComplexFloatMtxWith64Index)
 }
 
 
+TEST(MtxReader, ReadsDenseIgnoresExtraCharactersInRow)
+{
+    using tpl = gko::matrix_data<double, gko::int32>::nonzero_type;
+    std::istringstream iss(
+        "%%MatrixMarket matrix array real general\n"
+        "2 3 -77\n"
+        "1.0\n"
+        "0.0 58\n"
+        "3.0\n"
+        "5.0\n"
+        "2.0\n"
+        "0.0\n");
+
+    auto data = gko::read_raw<double, gko::int32>(iss);
+
+    ASSERT_EQ(data.size, gko::dim<2>(2, 3));
+    auto& v = data.nonzeros;
+    ASSERT_EQ(v[0], tpl(0, 0, 1.0));
+    ASSERT_EQ(v[1], tpl(0, 1, 3.0));
+    ASSERT_EQ(v[2], tpl(0, 2, 2.0));
+    ASSERT_EQ(v[3], tpl(1, 0, 0.0));
+    ASSERT_EQ(v[4], tpl(1, 1, 5.0));
+    ASSERT_EQ(v[5], tpl(1, 2, 0.0));
+}
+
+
 TEST(MtxReader, ReadsSparseRealMtx)
 {
     using tpl = gko::matrix_data<double, gko::int32>::nonzero_type;
@@ -385,7 +411,29 @@ TEST(MtxReader, ReadsSparseComplexHermitianMtx)
 }
 
 
-TEST(MtxReader, ReadIgnoresExtraCharacters)
+TEST(MtxReader, ReadsSparseIgnoresExtraCharactersInRow)
+{
+    using tpl = gko::matrix_data<double, gko::int32>::nonzero_type;
+    std::istringstream iss(
+        "%%MatrixMarket matrix coordinate real general\n"
+        "2 3 4 abc\n"
+        "1 1 1.0 some value\n"
+        "2 2 5.0 who knows?\n"
+        "1 2 3.0\n"
+        "1 3 2.0\n");
+
+    auto data = gko::read_raw<double, gko::int32>(iss);
+
+    ASSERT_EQ(data.size, gko::dim<2>(2, 3));
+    auto& v = data.nonzeros;
+    ASSERT_EQ(v[0], tpl(0, 0, 1.0));
+    ASSERT_EQ(v[1], tpl(0, 1, 3.0));
+    ASSERT_EQ(v[2], tpl(0, 2, 2.0));
+    ASSERT_EQ(v[3], tpl(1, 1, 5.0));
+}
+
+
+TEST(MtxReader, ReadHeaderIgnoresExtraCharacters)
 {
     using tpl = gko::matrix_data<double, gko::int32>::nonzero_type;
     std::istringstream iss(


### PR DESCRIPTION
This PR will discard any character in a line of a MM-format file after the values have been read in. This addresses #1627, using multiple columns within the MM-file will now lead to an exception. However, the exception is thrown by the `read_entry` function and thus the exception message is not very helpful.