### PR TITLE
WIP read_distributed with pre-existing data

### DIFF
--- a/include/ginkgo/core/distributed/matrix.hpp
+++ b/include/ginkgo/core/distributed/matrix.hpp
@@ -299,6 +299,29 @@ public:
             partition);
 
     /**
+     * Reads a matrix that is split into local data that only operates on local
+     * DOFs and non_local_data that needs input from non-local DOFs.
+     *
+     * local_data and non_local_data must have the same number of rows.
+     * Additionally, it is assumed that no column of non_local_data is
+     * completely zero. The number of columns in non_local_data must the same as
+     * the number of receiving indices in the communication pattern.
+     *
+     * @param local_data  The matrix data for the local block.
+     * @param non_local_data  The matrix data for the non-local block.
+     * @param sparse_comm  The communication pattern
+     */
+    void read_distributed(
+        const device_matrix_data<value_type, local_index_type>& local_data,
+        const device_matrix_data<value_type, local_index_type>& non_local_data,
+        const std::vector<comm_index_type>& send_offsets,
+        const std::vector<comm_index_type>& send_sizes,
+        const std::vector<comm_index_type>& recv_offsets,
+        const std::vector<comm_index_type>& recv_sizes,
+        const array<local_index_type>& gather_idxs);
+
+
+    /**
      * Reads a square matrix from the matrix_data structure and a global
      * partition.
      *


### PR DESCRIPTION
This PR adds a version of read_distributed that works on existing local data and non_local_data and comm_pattern.