### PR TITLE
Fix mean computation for zero sized ranks

### DIFF
--- a/common/unified/matrix/dense_kernels.template.cpp
+++ b/common/unified/matrix/dense_kernels.template.cpp
@@ -261,7 +261,7 @@ void compute_mean(std::shared_ptr<const DefaultExecutor> exec,
             return x(i, j) * inv_total_size;
         },
         GKO_KERNEL_REDUCE_SUM(ValueType), result->get_values(), x->get_size(),
-        tmp, x, ValueType_nc{1.} / x->get_size()[0]);
+        tmp, x, ValueType_nc{1.} / std::max(1ul, x->get_size()[0]));
 }
 
 

--- a/common/unified/matrix/dense_kernels.template.cpp
+++ b/common/unified/matrix/dense_kernels.template.cpp
@@ -261,7 +261,7 @@ void compute_mean(std::shared_ptr<const DefaultExecutor> exec,
             return x(i, j) * inv_total_size;
         },
         GKO_KERNEL_REDUCE_SUM(ValueType), result->get_values(), x->get_size(),
-        tmp, x, ValueType_nc{1.} / std::max(1ul, x->get_size()[0]));
+        tmp, x, ValueType_nc{1.} / std::max<size_type>(1, x->get_size()[0]));
 }
 
 

--- a/reference/matrix/dense_kernels.cpp
+++ b/reference/matrix/dense_kernels.cpp
@@ -371,8 +371,6 @@ void compute_mean(std::shared_ptr<const ReferenceExecutor> exec,
                   const matrix::Dense<ValueType>* x,
                   matrix::Dense<ValueType>* result, array<char>&)
 {
-    GKO_ASSERT_EQ(result->get_size()[0], 1);
-
     using ValueType_nc = gko::remove_complex<ValueType>;
     for (size_type j = 0; j < x->get_size()[1]; ++j) {
         result->at(0, j) = zero<ValueType>();

--- a/reference/matrix/dense_kernels.cpp
+++ b/reference/matrix/dense_kernels.cpp
@@ -371,10 +371,14 @@ void compute_mean(std::shared_ptr<const ReferenceExecutor> exec,
                   const matrix::Dense<ValueType>* x,
                   matrix::Dense<ValueType>* result, array<char>&)
 {
+    GKO_ASSERT_EQ(result->get_size()[0], 1);
+
     using ValueType_nc = gko::remove_complex<ValueType>;
     for (size_type j = 0; j < x->get_size()[1]; ++j) {
         result->at(0, j) = zero<ValueType>();
     }
+
+    if (x->get_size()[0] == 0) return;
 
     for (size_type i = 0; i < x->get_size()[1]; ++i) {
         for (size_type j = 0; j < x->get_size()[0]; ++j) {

--- a/reference/test/matrix/dense_kernels.cpp
+++ b/reference/test/matrix/dense_kernels.cpp
@@ -691,14 +691,6 @@ TYPED_TEST(Dense, ComputesMean)
     GKO_EXPECT_NEAR(result->at(0, 2), T{1.0}, r<T>::value * 10);
 }
 
-TYPED_TEST(Dense, ComputesMeanFailsOnZeroRowResults)
-{
-    using Mtx = typename TestFixture::Mtx;
-    using T = typename TestFixture::value_type;
-    auto result = Mtx::create(this->exec, gko::dim<2>{0, 1});
-
-    ASSERT_THROW(this->mtx4->compute_mean(result), gko::ValueMismatch);
-}
 
 TYPED_TEST(Dense, ComputesMeanFailsOnWrongResultSize)
 {

--- a/reference/test/matrix/dense_kernels.cpp
+++ b/reference/test/matrix/dense_kernels.cpp
@@ -691,6 +691,14 @@ TYPED_TEST(Dense, ComputesMean)
     GKO_EXPECT_NEAR(result->at(0, 2), T{1.0}, r<T>::value * 10);
 }
 
+TYPED_TEST(Dense, ComputesMeanFailsOnZeroRowResults)
+{
+    using Mtx = typename TestFixture::Mtx;
+    using T = typename TestFixture::value_type;
+    auto result = Mtx::create(this->exec, gko::dim<2>{0, 1});
+
+    ASSERT_THROW(this->mtx4->compute_mean(result), gko::ValueMismatch);
+}
 
 TYPED_TEST(Dense, ComputesMeanFailsOnWrongResultSize)
 {


### PR DESCRIPTION
This PR makes sure to not  divide by zero when calculating the mean of a distributed vector. This otherwise might occur if some ranks hold a local vector of length zero after repartitioning a matrix or vector.