### PR TITLE
Use Index map in PGM

### DIFF
--- a/benchmark/test/reference/distributed_solver.profile.stderr
+++ b/benchmark/test/reference/distributed_solver.profile.stderr
@@ -36,6 +36,10 @@ DEBUG: begin components::fill_array
 DEBUG: end   components::fill_array
 DEBUG: begin components::fill_array
 DEBUG: end   components::fill_array
+DEBUG: begin components::fill_array
+DEBUG: end   components::fill_array
+DEBUG: begin components::fill_array
+DEBUG: end   components::fill_array
 DEBUG: begin copy(<typename>)
 DEBUG: begin copy
 DEBUG: end   copy
@@ -88,8 +92,6 @@ DEBUG: begin components::fill_array
 DEBUG: end   components::fill_array
 DEBUG: begin index_map::map_to_local
 DEBUG: end   index_map::map_to_local
-DEBUG: begin copy
-DEBUG: end   copy
 DEBUG: begin copy
 DEBUG: end   copy
 DEBUG: begin copy

--- a/benchmark/test/reference/spmv_distributed.profile.stderr
+++ b/benchmark/test/reference/spmv_distributed.profile.stderr
@@ -52,6 +52,10 @@ DEBUG: begin components::fill_array
 DEBUG: end   components::fill_array
 DEBUG: begin components::fill_array
 DEBUG: end   components::fill_array
+DEBUG: begin components::fill_array
+DEBUG: end   components::fill_array
+DEBUG: begin components::fill_array
+DEBUG: end   components::fill_array
 DEBUG: begin copy(<typename>)
 DEBUG: begin copy
 DEBUG: end   copy
@@ -104,8 +108,6 @@ DEBUG: begin components::fill_array
 DEBUG: end   components::fill_array
 DEBUG: begin index_map::map_to_local
 DEBUG: end   index_map::map_to_local
-DEBUG: begin copy
-DEBUG: end   copy
 DEBUG: begin copy
 DEBUG: end   copy
 DEBUG: begin copy

--- a/benchmark/test/reference/spmv_distributed.profile.stdout
+++ b/benchmark/test/reference/spmv_distributed.profile.stdout
@@ -5,7 +5,7 @@
         "comm_pattern": "stencil",
         "spmv": {
             "csr-csr": {
-                "storage": 10948,
+                "storage": 11476,
                 "time": 1.0,
                 "repetitions": 1,
                 "completed": true

--- a/benchmark/test/reference/spmv_distributed.simple.stdout
+++ b/benchmark/test/reference/spmv_distributed.simple.stdout
@@ -5,7 +5,7 @@
         "comm_pattern": "stencil",
         "spmv": {
             "csr-csr": {
-                "storage": 10948,
+                "storage": 11476,
                 "max_relative_norm2": 1.0,
                 "time": 1.0,
                 "repetitions": 10,

--- a/benchmark/test/reference/spmv_distributed_dcomplex.simple.stdout
+++ b/benchmark/test/reference/spmv_distributed_dcomplex.simple.stdout
@@ -5,7 +5,7 @@
         "comm_pattern": "stencil",
         "spmv": {
             "csr-csr": {
-                "storage": 16772,
+                "storage": 17300,
                 "max_relative_norm2": 1.0,
                 "time": 1.0,
                 "repetitions": 10,

--- a/core/distributed/matrix.cpp
+++ b/core/distributed/matrix.cpp
@@ -13,21 +13,10 @@
 #include <ginkgo/core/matrix/csr.hpp>
 #include <ginkgo/core/matrix/diagonal.hpp>
 
-#include "core/components/precision_conversion_kernels.hpp"
-#include "core/components/prefix_sum_kernels.hpp"
 #include "core/distributed/matrix_kernels.hpp"
 
 
 namespace gko {
-namespace conversion {
-namespace {
-
-
-GKO_REGISTER_OPERATION(convert, components::convert_precision);
-
-
-}  // anonymous namespace
-}  // namespace conversion
 namespace experimental {
 namespace distributed {
 namespace matrix {

--- a/core/distributed/matrix.cpp
+++ b/core/distributed/matrix.cpp
@@ -109,7 +109,6 @@ Matrix<ValueType, LocalIndexType, GlobalIndexType>::Matrix(
       recv_offsets_(comm.size() + 1),
       recv_sizes_(comm.size()),
       gather_idxs_{exec},
-      non_local_to_global_{exec},
       one_scalar_{},
       local_mtx_{local_matrix_template->clone(exec)},
       non_local_mtx_{non_local_matrix_template->clone(exec)}
@@ -136,7 +135,6 @@ Matrix<ValueType, LocalIndexType, GlobalIndexType>::Matrix(
       recv_offsets_(comm.size() + 1),
       recv_sizes_(comm.size()),
       gather_idxs_{exec},
-      non_local_to_global_{exec},
       one_scalar_{},
       non_local_mtx_(::gko::matrix::Coo<ValueType, LocalIndexType>::create(
           exec, dim<2>{local_linop->get_size()[0], 0}))
@@ -160,7 +158,6 @@ Matrix<ValueType, LocalIndexType, GlobalIndexType>::Matrix(
       recv_offsets_(comm.size() + 1),
       recv_sizes_(comm.size()),
       gather_idxs_{exec},
-      non_local_to_global_{exec},
       one_scalar_{}
 {
     this->set_size({imap_.get_global_size(), imap_.get_global_size()});
@@ -244,7 +241,6 @@ void Matrix<ValueType, LocalIndexType, GlobalIndexType>::convert_to(
     result->recv_offsets_ = this->recv_offsets_;
     result->recv_sizes_ = this->recv_sizes_;
     result->send_sizes_ = this->send_sizes_;
-    result->non_local_to_global_ = this->non_local_to_global_;
     result->set_size(this->get_size());
 }
 
@@ -264,7 +260,6 @@ void Matrix<ValueType, LocalIndexType, GlobalIndexType>::move_to(
     result->recv_offsets_ = std::move(this->recv_offsets_);
     result->recv_sizes_ = std::move(this->recv_sizes_);
     result->send_sizes_ = std::move(this->send_sizes_);
-    result->non_local_to_global_ = std::move(this->non_local_to_global_);
     result->set_size(this->get_size());
     this->set_size({});
 }
@@ -368,11 +363,6 @@ void Matrix<ValueType, LocalIndexType, GlobalIndexType>::read_distributed(
 
     auto non_local_col_idxs =
         imap_.map_to_local(global_non_local_col_idxs, index_space::non_local);
-    non_local_to_global_ =
-        make_const_array_view(
-            imap_.get_executor(), imap_.get_remote_global_idxs().get_size(),
-            imap_.get_remote_global_idxs().get_const_flat_data())
-            .copy_to_array();
 
     // read the local matrix data
     const auto num_local_rows =
@@ -663,7 +653,6 @@ Matrix<ValueType, LocalIndexType, GlobalIndexType>::operator=(
         recv_offsets_ = other.recv_offsets_;
         send_sizes_ = other.send_sizes_;
         recv_sizes_ = other.recv_sizes_;
-        non_local_to_global_ = other.non_local_to_global_;
         one_scalar_.init(this->get_executor(), dim<2>{1, 1});
         one_scalar_->fill(one<value_type>());
     }
@@ -688,7 +677,6 @@ Matrix<ValueType, LocalIndexType, GlobalIndexType>::operator=(Matrix&& other)
         recv_offsets_ = std::move(other.recv_offsets_);
         send_sizes_ = std::move(other.send_sizes_);
         recv_sizes_ = std::move(other.recv_sizes_);
-        non_local_to_global_ = std::move(other.non_local_to_global_);
         one_scalar_.init(this->get_executor(), dim<2>{1, 1});
         one_scalar_->fill(one<value_type>());
     }

--- a/core/distributed/matrix.cpp
+++ b/core/distributed/matrix.cpp
@@ -236,7 +236,7 @@ Matrix<ValueType, LocalIndexType, GlobalIndexType>::create(
     array<comm_index_type> part_ids(exec->get_master(), comm.size());
     std::iota(part_ids.get_data(), part_ids.get_data() + part_ids.get_size(),
               0);
-    auto uniform_partition =
+    auto contiguous_partition =
         share(build_partition_from_local_size<LocalIndexType, GlobalIndexType>(
             exec, comm, local_linop->get_size()[0]));
     array<global_index_type> global_recv_gather_idxs(
@@ -244,7 +244,7 @@ Matrix<ValueType, LocalIndexType, GlobalIndexType>::create(
     for (int rank = 0; rank < comm.size(); ++rank) {
         if (recv_sizes[rank] > 0) {
             auto map = index_map<LocalIndexType, GlobalIndexType>(
-                exec, uniform_partition, rank, array<GlobalIndexType>{exec});
+                exec, contiguous_partition, rank, array<GlobalIndexType>{exec});
             auto local_view = make_array_view(
                 exec, recv_sizes[rank],
                 recv_gather_idxs.get_data() + recv_offsets[rank]);
@@ -258,7 +258,7 @@ Matrix<ValueType, LocalIndexType, GlobalIndexType>::create(
     return Matrix::create(
         exec, comm,
         index_map<LocalIndexType, GlobalIndexType>(
-            exec, uniform_partition, comm.rank(), global_recv_gather_idxs),
+            exec, contiguous_partition, comm.rank(), global_recv_gather_idxs),
         std::move(local_linop), std::move(non_local_linop));
 }
 

--- a/core/multigrid/pgm.cpp
+++ b/core/multigrid/pgm.cpp
@@ -13,6 +13,8 @@
 #include <ginkgo/core/base/utils.hpp>
 #include <ginkgo/core/distributed/base.hpp>
 #include <ginkgo/core/distributed/matrix.hpp>
+#include <ginkgo/core/distributed/partition.hpp>
+#include <ginkgo/core/distributed/partition_helpers.hpp>
 #include <ginkgo/core/distributed/vector.hpp>
 #include <ginkgo/core/matrix/coo.hpp>
 #include <ginkgo/core/matrix/csr.hpp>
@@ -27,6 +29,7 @@
 #include "core/components/fill_array_kernels.hpp"
 #include "core/components/format_conversion_kernels.hpp"
 #include "core/config/config_helper.hpp"
+#include "core/distributed/index_map_kernels.hpp"
 #include "core/matrix/csr_builder.hpp"
 #include "core/multigrid/pgm_kernels.hpp"
 
@@ -52,6 +55,7 @@ GKO_REGISTER_OPERATION(fill_array, components::fill_array);
 GKO_REGISTER_OPERATION(fill_seq_array, components::fill_seq_array);
 GKO_REGISTER_OPERATION(convert_idxs_to_ptrs, components::convert_idxs_to_ptrs);
 GKO_REGISTER_OPERATION(gather_index, pgm::gather_index);
+GKO_REGISTER_OPERATION(map_to_global, index_map::map_to_global);
 
 
 }  // anonymous namespace
@@ -247,15 +251,20 @@ Pgm<ValueType, IndexType>::generate_local(
 
 
 #if GINKGO_BUILD_MPI
+
+
 template <typename ValueType, typename IndexType>
 template <typename GlobalIndexType>
-void Pgm<ValueType, IndexType>::communicate(
+array<GlobalIndexType> Pgm<ValueType, IndexType>::communicate_non_local_agg(
     std::shared_ptr<const experimental::distributed::Matrix<
         ValueType, IndexType, GlobalIndexType>>
         matrix,
-    const array<IndexType>& local_agg, array<IndexType>& non_local_agg)
+    std::shared_ptr<
+        experimental::distributed::Partition<IndexType, GlobalIndexType>>
+        coarse_partition,
+    const array<IndexType>& local_agg)
 {
-    auto exec = gko::as<LinOp>(matrix)->get_executor();
+    auto exec = matrix->get_executor();
     const auto comm = matrix->get_communicator();
     auto send_sizes = matrix->send_sizes_;
     auto recv_sizes = matrix->recv_sizes_;
@@ -270,20 +279,30 @@ void Pgm<ValueType, IndexType>::communicate(
         send_agg.get_size(), local_agg.get_const_data(),
         gather_idxs.get_const_data(), send_agg.get_data()));
 
+    // There is no index map on the coarse level yet, so map the local indices
+    // to global manually
+    array<GlobalIndexType> seng_global_agg(exec, send_agg.get_size());
+    exec->run(pgm::make_map_to_global(
+        to_device_const(coarse_partition.get()),
+        device_segmented_array<const GlobalIndexType>{}, comm.rank(), send_agg,
+        experimental::distributed::index_space::local, seng_global_agg));
+
+    array<GlobalIndexType> non_local_agg(exec, total_recv_size);
+
     auto use_host_buffer = experimental::mpi::requires_host_buffer(exec, comm);
-    array<IndexType> host_recv_buffer(exec->get_master());
-    array<IndexType> host_send_buffer(exec->get_master());
+    array<GlobalIndexType> host_recv_buffer(exec->get_master());
+    array<GlobalIndexType> host_send_buffer(exec->get_master());
     if (use_host_buffer) {
         host_recv_buffer.resize_and_reset(total_recv_size);
         host_send_buffer.resize_and_reset(total_send_size);
         exec->get_master()->copy_from(exec, total_send_size,
-                                      send_agg.get_data(),
+                                      seng_global_agg.get_data(),
                                       host_send_buffer.get_data());
     }
-    auto type = experimental::mpi::type_impl<IndexType>::get_type();
+    auto type = experimental::mpi::type_impl<GlobalIndexType>::get_type();
 
     const auto send_ptr = use_host_buffer ? host_send_buffer.get_const_data()
-                                          : send_agg.get_const_data();
+                                          : seng_global_agg.get_const_data();
     auto recv_ptr = use_host_buffer ? host_recv_buffer.get_data()
                                     : non_local_agg.get_data();
     exec->synchronize();
@@ -294,92 +313,11 @@ void Pgm<ValueType, IndexType>::communicate(
         exec->copy_from(exec->get_master(), total_recv_size, recv_ptr,
                         non_local_agg.get_data());
     }
+    return non_local_agg;
 }
+
+
 #endif
-
-
-#define GKO_ASSERT_HOST_ARRAY(array) \
-    GKO_ASSERT(array.get_executor() == array.get_executor()->get_master())
-
-
-template <typename IndexType>
-void generate_non_local_map(
-    const std::vector<experimental::distributed::comm_index_type>& recv_offsets,
-    array<IndexType>& non_local_agg, array<IndexType>& non_local_col_map,
-    array<IndexType>& renumber)
-{
-    GKO_ASSERT_HOST_ARRAY(non_local_agg);
-    GKO_ASSERT_HOST_ARRAY(non_local_col_map);
-    GKO_ASSERT_HOST_ARRAY(renumber);
-    auto exec = renumber.get_executor();
-    auto non_local_size = non_local_agg.get_size();
-    array<IndexType> part_id(exec, non_local_size);
-    array<IndexType> index(exec, non_local_size);
-
-    for (int i = 0; i + 1 < recv_offsets.size(); i++) {
-        for (auto j = recv_offsets.at(i); j < recv_offsets.at(i + 1); j++) {
-            part_id.get_data()[j] = i;
-            index.get_data()[j] = j;
-        }
-    }
-    // do it in host currently.
-    auto it = detail::make_zip_iterator(
-        part_id.get_data(), non_local_agg.get_data(), index.get_data());
-    // prepare tuple <part_id, local_agg, index>
-    // sort by <part_id, local_agg> or did segment sort
-    std::sort(it, it + non_local_size);
-
-    renumber.get_data()[0] = 0;
-    // renumber (prefix_sum) with not equal <part_id, local_agg>
-    for (int i = 1; i < non_local_size; i++) {
-        if (part_id.get_const_data()[i] != part_id.get_const_data()[i - 1] ||
-            non_local_agg.get_const_data()[i] !=
-                non_local_agg.get_const_data()[i - 1]) {
-            renumber.get_data()[i] = renumber.get_data()[i - 1] + 1;
-        } else {
-            renumber.get_data()[i] = renumber.get_data()[i - 1];
-        }
-    }
-    renumber.get_data()[non_local_size] =
-        renumber.get_data()[non_local_size - 1] + 1;
-    // create col map
-    // for each thread i, col_map[tuple[i].index] = map[i]
-    for (int i = 0; i < non_local_size; i++) {
-        non_local_col_map.get_data()[index.get_data()[i]] =
-            renumber.get_data()[i];
-    }
-}
-
-
-template <typename IndexType>
-void compute_communication(
-    const std::vector<experimental::distributed::comm_index_type> recv_offsets,
-    const array<IndexType>& non_local_agg, const array<IndexType>& renumber,
-    std::vector<experimental::distributed::comm_index_type>& new_recv_size,
-    std::vector<experimental::distributed::comm_index_type>& new_recv_offsets,
-    array<IndexType>& new_recv_gather_idxs)
-{
-    GKO_ASSERT_HOST_ARRAY(non_local_agg);
-    GKO_ASSERT_HOST_ARRAY(renumber);
-    GKO_ASSERT_HOST_ARRAY(new_recv_gather_idxs);
-    new_recv_offsets.at(0) = 0;
-    for (int i = 0; i < new_recv_size.size(); i++) {
-        new_recv_size.at(i) =
-            renumber.get_const_data()[recv_offsets.at(i + 1)] -
-            renumber.get_const_data()[recv_offsets.at(i)];
-        new_recv_offsets.at(i + 1) =
-            new_recv_offsets.at(i) + new_recv_size.at(i);
-    }
-    IndexType non_local_num_agg = new_recv_offsets.back();
-    new_recv_gather_idxs.resize_and_reset(non_local_num_agg);
-    for (int i = 0; i < non_local_agg.get_size(); i++) {
-        new_recv_gather_idxs.get_data()[renumber.get_const_data()[i]] =
-            non_local_agg.get_const_data()[i];
-    }
-}
-
-
-#undef GKO_ASSERT_HOST_ARRAY
 
 
 template <typename ValueType, typename IndexType>
@@ -441,72 +379,71 @@ void Pgm<ValueType, IndexType>::generate()
         }
 
         auto distributed_setup = [&](auto matrix) {
+            using global_index_type =
+                typename std::decay_t<decltype(*matrix)>::global_index_type;
+
             auto exec = gko::as<LinOp>(matrix)->get_executor();
             auto comm =
                 gko::as<experimental::distributed::DistributedBase>(matrix)
                     ->get_communicator();
-            auto num_rank = comm.size();
             auto pgm_local_op =
                 gko::as<const csr_type>(matrix->get_local_matrix());
             auto result = this->generate_local(pgm_local_op);
 
-            auto non_local_csr =
-                as<const csr_type>(matrix->get_non_local_matrix());
-            auto non_local_size = non_local_csr->get_size()[1];
-            array<IndexType> non_local_agg(exec, non_local_size);
-            // get agg information (prolong_row_gather row idx)
-            communicate(matrix, agg_, non_local_agg);
-            // generate non_local_col_map
-            non_local_agg.set_executor(exec->get_master());
-            array<IndexType> non_local_col_map(exec->get_master(),
-                                               non_local_size);
-            // add additional entry in tail such that the offset easily
-            // handle it.
-            array<IndexType> renumber(exec->get_master(), non_local_size + 1);
-            auto recv_offsets = matrix->recv_offsets_;
-            generate_non_local_map(recv_offsets, non_local_agg,
-                                   non_local_col_map, renumber);
+            // create the coarse partition
+            // the coarse partition will have only one range per part
+            // and only one part per rank.
+            // The global indices are ordered block-wise by rank, i.e. rank
+            // 1 owns [0, ..., N_1), rank 2 [N_1, ..., N_2), ...
+            auto coarse_local_size =
+                static_cast<int64>(std::get<1>(result)->get_size()[0]);
+            auto coarse_partition = gko::share(
+                experimental::distributed::build_partition_from_local_size<
+                    IndexType, global_index_type>(exec, comm,
+                                                  coarse_local_size));
 
-            // get new recv_size and recv_offsets
-            std::vector<experimental::distributed::comm_index_type>
-                new_recv_size(num_rank);
-            std::vector<experimental::distributed::comm_index_type>
-                new_recv_offsets(num_rank + 1);
-            array<IndexType> new_recv_gather_idxs(exec->get_master());
-            compute_communication(recv_offsets, non_local_agg, renumber,
-                                  new_recv_size, new_recv_offsets,
-                                  new_recv_gather_idxs);
+            // get the non-local aggregates as coarse global indices
+            auto non_local_agg =
+                communicate_non_local_agg(matrix, coarse_partition, agg_);
 
-            non_local_col_map.set_executor(exec);
-            IndexType non_local_num_agg = new_recv_gather_idxs.get_size();
+            // create a coarse index map based on the connection given by
+            // the non-local aggregates
+            auto coarse_imap =
+                experimental::distributed::index_map<IndexType,
+                                                     global_index_type>(
+                    exec, coarse_partition, comm.rank(), non_local_agg);
+
+            // a mapping from the fine non-local indices to the coarse
+            // non-local indices.
+            // non_local_agg already maps the fine non-local indices to
+            // coarse global indices, so mapping it with the coarse index
+            // map results in the coarse non-local indices.
+            auto non_local_map = coarse_imap.map_to_local(
+                non_local_agg,
+                experimental::distributed::index_space::non_local);
+
             // build csr from row and col map
             // unlike non-distributed version, generate_coarse uses
-            // different row and col maps.
+            // differentrow and col maps.
+            auto non_local_csr =
+                as<const csr_type>(matrix->get_non_local_matrix());
             auto result_non_local_csr = generate_coarse(
                 exec, non_local_csr.get(),
                 static_cast<IndexType>(std::get<1>(result)->get_size()[0]),
-                agg_, non_local_num_agg, non_local_col_map);
-            // use local and non-local to build coarse matrix
-            // also restriction and prolongation (Local-only-global matrix)
-            auto coarse_size =
-                static_cast<int64>(std::get<1>(result)->get_size()[0]);
-            comm.all_reduce(exec->get_master(), &coarse_size, 1, MPI_SUM);
-            new_recv_gather_idxs.set_executor(exec);
+                agg_, static_cast<IndexType>(coarse_imap.get_non_local_size()),
+                non_local_map);
 
             // setup the generated linop.
-            using global_index_type =
-                typename std::decay_t<decltype(*matrix)>::global_index_type;
             auto coarse = share(
                 experimental::distributed::
                     Matrix<ValueType, IndexType, global_index_type>::create(
-                        exec, comm, gko::dim<2>(coarse_size, coarse_size),
-                        std::get<1>(result), result_non_local_csr,
-                        new_recv_size, new_recv_offsets, new_recv_gather_idxs));
+                        exec, comm, std::move(coarse_imap), std::get<1>(result),
+                        result_non_local_csr));
             auto restrict_op = share(
                 experimental::distributed::
                     Matrix<ValueType, IndexType, global_index_type>::create(
                         exec, comm,
-                        dim<2>(coarse_size,
+                        dim<2>(coarse->get_size()[0],
                                gko::as<LinOp>(matrix)->get_size()[0]),
                         std::get<2>(result)));
             auto prolong_op = share(
@@ -514,7 +451,7 @@ void Pgm<ValueType, IndexType>::generate()
                     Matrix<ValueType, IndexType, global_index_type>::create(
                         exec, comm,
                         dim<2>(gko::as<LinOp>(matrix)->get_size()[0],
-                               coarse_size),
+                               coarse->get_size()[0]),
                         std::get<0>(result)));
             this->set_multigrid_level(prolong_op, coarse, restrict_op);
         };

--- a/include/ginkgo/core/distributed/matrix.hpp
+++ b/include/ginkgo/core/distributed/matrix.hpp
@@ -608,11 +608,9 @@ public:
      */
     static std::unique_ptr<Matrix> create(
         std::shared_ptr<const Executor> exec, mpi::communicator comm,
-        dim<2> size, std::shared_ptr<LinOp> local_linop,
-        std::shared_ptr<LinOp> non_local_linop,
-        std::vector<comm_index_type> recv_sizes,
-        std::vector<comm_index_type> recv_offsets,
-        array<local_index_type> recv_gather_idxs);
+        index_map<local_index_type, global_index_type> imap,
+        std::shared_ptr<LinOp> local_linop,
+        std::shared_ptr<LinOp> non_local_linop);
 
     /**
      * Scales the columns of the matrix by the respective entries of the vector.
@@ -646,12 +644,10 @@ protected:
                     std::shared_ptr<LinOp> local_linop);
 
     explicit Matrix(std::shared_ptr<const Executor> exec,
-                    mpi::communicator comm, dim<2> size,
+                    mpi::communicator comm,
+                    index_map<local_index_type, global_index_type> imap,
                     std::shared_ptr<LinOp> local_linop,
-                    std::shared_ptr<LinOp> non_local_linop,
-                    std::vector<comm_index_type> recv_sizes,
-                    std::vector<comm_index_type> recv_offsets,
-                    array<local_index_type> recv_gather_idxs);
+                    std::shared_ptr<LinOp> non_local_linop);
 
     /**
      * Starts a non-blocking communication of the values of b that are shared
@@ -669,6 +665,7 @@ protected:
                     LinOp* x) const override;
 
 private:
+    index_map<local_index_type, global_index_type> imap_;
     std::vector<comm_index_type> send_offsets_;
     std::vector<comm_index_type> send_sizes_;
     std::vector<comm_index_type> recv_offsets_;

--- a/include/ginkgo/core/distributed/matrix.hpp
+++ b/include/ginkgo/core/distributed/matrix.hpp
@@ -671,7 +671,6 @@ private:
     std::vector<comm_index_type> recv_offsets_;
     std::vector<comm_index_type> recv_sizes_;
     array<local_index_type> gather_idxs_;
-    array<global_index_type> non_local_to_global_;
     gko::detail::DenseCache<value_type> one_scalar_;
     gko::detail::DenseCache<value_type> host_send_buffer_;
     gko::detail::DenseCache<value_type> host_recv_buffer_;

--- a/include/ginkgo/core/distributed/matrix.hpp
+++ b/include/ginkgo/core/distributed/matrix.hpp
@@ -601,8 +601,31 @@ public:
      * @param local_linop  the local linop
      * @param non_local_linop  the non-local linop
      * @param recv_sizes  the size of non-local receiver
-     * @param recv_offset  the offset of non-local receiver
+     * @param recv_offsets  the offset of non-local receiver
      * @param recv_gather_idxs  the gathering index of non-local receiver
+     *
+     * @return A smart pointer to the newly created matrix.
+     */
+    [[deprecated(
+        "Please use the overload with an index_map instead.")]] static std::
+        unique_ptr<Matrix>
+        create(std::shared_ptr<const Executor> exec, mpi::communicator comm,
+               dim<2> size, std::shared_ptr<LinOp> local_linop,
+               std::shared_ptr<LinOp> non_local_linop,
+               std::vector<comm_index_type> recv_sizes,
+               std::vector<comm_index_type> recv_offsets,
+               array<local_index_type> recv_gather_idxs);
+
+    /**
+     * Creates distributed matrix with existent local and non-local LinOp and
+     * the corresponding mapping to collect the non-local data from the other
+     * ranks.
+     *
+     * @param exec  Executor associated with this matrix.
+     * @param comm  Communicator associated with this matrix.
+     * @param imap  The index map to define the communication pattern
+     * @param local_linop  the local linop
+     * @param non_local_linop  the non-local linop
      *
      * @return A smart pointer to the newly created matrix.
      */

--- a/include/ginkgo/core/multigrid/pgm.hpp
+++ b/include/ginkgo/core/multigrid/pgm.hpp
@@ -205,7 +205,7 @@ protected:
      * @param local_agg  the local aggregate indices
      *
      * @return  the aggregates for non-local columns. The aggregated indices are
-     *          in the new global indexing
+     *          in the new global indexing for the coarse matrix
      */
     template <typename GlobalIndexType>
     array<GlobalIndexType> communicate_non_local_agg(

--- a/include/ginkgo/core/multigrid/pgm.hpp
+++ b/include/ginkgo/core/multigrid/pgm.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -194,12 +194,28 @@ protected:
         std::shared_ptr<const matrix::Csr<ValueType, IndexType>> local_matrix);
 
 #if GINKGO_BUILD_MPI
+    /**
+     * Communicates the non-local aggregates (as global indices)
+     *
+     * @tparam GlobalIndexType  Global index type
+     *
+     * @param matrix  a distributed matrix
+     * @param coarse_partition  the coarse partition to compute the new global
+     *                          indices
+     * @param local_agg  the local aggregate indices
+     *
+     * @return  the aggregates for non-local columns. The aggregated indices are
+     *          in the new global indexing
+     */
     template <typename GlobalIndexType>
-    void communicate(std::shared_ptr<const experimental::distributed::Matrix<
-                         ValueType, IndexType, GlobalIndexType>>
-                         matrix,
-                     const array<IndexType>& local_agg,
-                     array<IndexType>& non_local_agg);
+    array<GlobalIndexType> communicate_non_local_agg(
+        std::shared_ptr<const experimental::distributed::Matrix<
+            ValueType, IndexType, GlobalIndexType>>
+            matrix,
+        std::shared_ptr<
+            experimental::distributed::Partition<IndexType, GlobalIndexType>>
+            coarse_partition,
+        const array<IndexType>& local_agg);
 #endif
 
 private:

--- a/test/mpi/matrix.cpp
+++ b/test/mpi/matrix.cpp
@@ -246,6 +246,79 @@ TYPED_TEST(MatrixCreation, BuildOnlyLocal)
 }
 
 
+GKO_BEGIN_DISABLE_DEPRECATION_WARNINGS
+
+
+TYPED_TEST(MatrixCreation, BuildFromExistingDataDeprecated)
+{
+    using value_type = typename TestFixture::value_type;
+    using csr = typename TestFixture::local_matrix_type;
+    using global_index_type = typename TestFixture::global_index_type;
+    using Partition = typename TestFixture::Partition;
+    using local_index_type = typename TestFixture::local_index_type;
+    using matrix_data = gko::matrix_data<value_type, local_index_type>;
+    using input_triple =
+        gko::detail::input_triple<value_type, local_index_type>;
+    using dist_mtx_type = typename TestFixture::dist_mtx_type;
+    using dist_vec_type = gko::experimental::distributed::Vector<value_type>;
+    using comm_index_type = gko::experimental::distributed::comm_index_type;
+    auto rank = this->comm.rank();
+    I<I<value_type>> res_local[] = {{{2, 0}, {0, 0}}, {{0, 5}, {0, 0}}, {{0}}};
+    std::array<gko::dim<2>, 3> size_local{{{2, 2}, {2, 2}, {1, 1}}};
+    std::array<matrix_data, 3> dist_input_local{
+        {{size_local[0], I<input_triple>{{0, 0, 2}}},
+         {size_local[1], I<input_triple>{{0, 1, 5}}},
+         {size_local[2]}}};
+    I<I<value_type>> res_non_local[] = {
+        {{1, 0}, {3, 4}}, {{0, 0, 6}, {8, 7, 0}}, {{10, 9}}};
+    std::array<gko::dim<2>, 3> size_non_local{{{2, 2}, {2, 3}, {1, 2}}};
+    std::array<matrix_data, 3> dist_input_non_local{
+        {{size_non_local[0], I<input_triple>{{0, 0, 1}, {1, 0, 3}, {1, 1, 4}}},
+         {size_non_local[1], I<input_triple>{{0, 2, 6}, {1, 0, 8}, {1, 1, 7}}},
+         {size_non_local[2], I<input_triple>{{0, 0, 10}, {0, 1, 9}}}}};
+    std::array<std::vector<comm_index_type>, 3> recv_sizes{
+        {{0, 1, 1}, {2, 0, 1}, {1, 1, 0}}};
+    std::array<std::vector<comm_index_type>, 3> recv_offsets{
+        {{0, 0, 1, 2}, {0, 2, 2, 3}, {0, 1, 2, 2}}};
+    std::array<gko::array<local_index_type>, 3> recv_gather_index{
+        {{this->exec, {1, 0}}, {this->exec, {0, 1, 0}}, {this->exec, {1, 0}}}};
+    auto local = gko::share(csr::create(this->exec));
+    local->read(dist_input_local[rank]);
+    auto non_local = gko::share(csr::create(this->exec));
+    non_local->read(dist_input_non_local[rank]);
+    // create vector
+    auto vec_md = gko::matrix_data<value_type, global_index_type>{
+        I<I<value_type>>{{1}, {2}, {3}, {4}, {5}}};
+    I<I<value_type>> result[3] = {{{10}, {18}}, {{28}, {67}}, {{59}}};
+    auto row_part = Partition::build_from_contiguous(
+        this->exec, gko::array<global_index_type>(
+                        this->exec, I<global_index_type>{0, 2, 4, 5}));
+    auto col_part = Partition::build_from_mapping(
+        this->exec,
+        gko::array<comm_index_type>(this->exec,
+                                    I<comm_index_type>{1, 1, 2, 0, 0}),
+        3);
+    auto x = dist_vec_type::create(this->ref, this->comm);
+    auto y = dist_vec_type::create(this->ref, this->comm);
+    x->read_distributed(vec_md, col_part);
+    y->read_distributed(vec_md, row_part);
+
+    auto mat = dist_mtx_type::create(
+        this->exec, this->comm, gko::dim<2>{5, 5}, local, non_local,
+        recv_sizes[rank], recv_offsets[rank], recv_gather_index[rank]);
+    mat->apply(x, y);
+
+    GKO_ASSERT_MTX_NEAR(gko::as<csr>(mat->get_local_matrix()), res_local[rank],
+                        0);
+    GKO_ASSERT_MTX_NEAR(gko::as<csr>(mat->get_non_local_matrix()),
+                        res_non_local[rank], 0);
+    GKO_ASSERT_MTX_NEAR(y->get_local_vector(), result[rank], 0);
+}
+
+
+GKO_END_DISABLE_DEPRECATION_WARNINGS
+
+
 TYPED_TEST(MatrixCreation, BuildFromExistingData)
 {
     using value_type = typename TestFixture::value_type;

--- a/test/mpi/matrix.cpp
+++ b/test/mpi/matrix.cpp
@@ -386,6 +386,7 @@ TYPED_TEST(MatrixCreation, BuildFromExistingData)
     GKO_ASSERT_MTX_NEAR(y->get_local_vector(), result[rank], 0);
 }
 
+
 #endif
 
 

--- a/test/mpi/matrix.cpp
+++ b/test/mpi/matrix.cpp
@@ -251,8 +251,11 @@ TYPED_TEST(MatrixCreation, BuildFromExistingData)
     using value_type = typename TestFixture::value_type;
     using csr = typename TestFixture::local_matrix_type;
     using global_index_type = typename TestFixture::global_index_type;
-    using Partition = typename TestFixture::Partition;
     using local_index_type = typename TestFixture::local_index_type;
+    using Partition = typename TestFixture::Partition;
+    using index_map_type =
+        gko::experimental::distributed::index_map<local_index_type,
+                                                  global_index_type>;
     using matrix_data = gko::matrix_data<value_type, local_index_type>;
     using input_triple =
         gko::detail::input_triple<value_type, local_index_type>;
@@ -260,25 +263,32 @@ TYPED_TEST(MatrixCreation, BuildFromExistingData)
     using dist_vec_type = gko::experimental::distributed::Vector<value_type>;
     using comm_index_type = gko::experimental::distributed::comm_index_type;
     auto rank = this->comm.rank();
-    I<I<value_type>> res_local[] = {{{2, 0}, {0, 0}}, {{0, 5}, {0, 0}}, {{0}}};
+    auto row_part = gko::share(Partition::build_from_contiguous(
+        this->exec, gko::array<global_index_type>(
+                        this->exec, I<global_index_type>{0, 2, 4, 5})));
+    auto col_part = gko::share(Partition::build_from_mapping(
+        this->exec,
+        gko::array<comm_index_type>(this->exec,
+                                    I<comm_index_type>{1, 1, 2, 0, 0}),
+        3));
+    std::array<gko::array<global_index_type>, 3> recv_connections = {
+        gko::array<global_index_type>{this->exec, {1, 2}},
+        gko::array<global_index_type>{this->exec, {3, 4, 2}},
+        gko::array<global_index_type>{this->exec, {4, 0}}};
+    index_map_type imap(this->exec, col_part, rank, recv_connections[rank]);
     std::array<gko::dim<2>, 3> size_local{{{2, 2}, {2, 2}, {1, 1}}};
     std::array<matrix_data, 3> dist_input_local{
         {{size_local[0], I<input_triple>{{0, 0, 2}}},
          {size_local[1], I<input_triple>{{0, 1, 5}}},
          {size_local[2]}}};
-    I<I<value_type>> res_non_local[] = {
-        {{1, 0}, {3, 4}}, {{0, 0, 6}, {8, 7, 0}}, {{10, 9}}};
     std::array<gko::dim<2>, 3> size_non_local{{{2, 2}, {2, 3}, {1, 2}}};
     std::array<matrix_data, 3> dist_input_non_local{
         {{size_non_local[0], I<input_triple>{{0, 0, 1}, {1, 0, 3}, {1, 1, 4}}},
          {size_non_local[1], I<input_triple>{{0, 2, 6}, {1, 0, 8}, {1, 1, 7}}},
          {size_non_local[2], I<input_triple>{{0, 0, 10}, {0, 1, 9}}}}};
-    std::array<std::vector<comm_index_type>, 3> recv_sizes{
-        {{0, 1, 1}, {2, 0, 1}, {1, 1, 0}}};
-    std::array<std::vector<comm_index_type>, 3> recv_offsets{
-        {{0, 0, 1, 2}, {0, 2, 2, 3}, {0, 1, 2, 2}}};
-    std::array<gko::array<local_index_type>, 3> recv_gather_index{
-        {{this->exec, {1, 0}}, {this->exec, {0, 1, 0}}, {this->exec, {1, 0}}}};
+    I<I<value_type>> res_local[] = {{{2, 0}, {0, 0}}, {{0, 5}, {0, 0}}, {{0}}};
+    I<I<value_type>> res_non_local[] = {
+        {{1, 0}, {3, 4}}, {{0, 0, 6}, {8, 7, 0}}, {{10, 9}}};
     auto local = gko::share(csr::create(this->exec));
     local->read(dist_input_local[rank]);
     auto non_local = gko::share(csr::create(this->exec));
@@ -287,22 +297,13 @@ TYPED_TEST(MatrixCreation, BuildFromExistingData)
     auto vec_md = gko::matrix_data<value_type, global_index_type>{
         I<I<value_type>>{{1}, {2}, {3}, {4}, {5}}};
     I<I<value_type>> result[3] = {{{10}, {18}}, {{28}, {67}}, {{59}}};
-    auto row_part = Partition::build_from_contiguous(
-        this->exec, gko::array<global_index_type>(
-                        this->exec, I<global_index_type>{0, 2, 4, 5}));
-    auto col_part = Partition::build_from_mapping(
-        this->exec,
-        gko::array<comm_index_type>(this->exec,
-                                    I<comm_index_type>{1, 1, 2, 0, 0}),
-        3);
     auto x = dist_vec_type::create(this->ref, this->comm);
     auto y = dist_vec_type::create(this->ref, this->comm);
     x->read_distributed(vec_md, col_part);
     y->read_distributed(vec_md, row_part);
 
-    auto mat = dist_mtx_type::create(
-        this->exec, this->comm, gko::dim<2>{5, 5}, local, non_local,
-        recv_sizes[rank], recv_offsets[rank], recv_gather_index[rank]);
+    auto mat =
+        dist_mtx_type::create(this->exec, this->comm, imap, local, non_local);
     mat->apply(x, y);
 
     GKO_ASSERT_MTX_NEAR(gko::as<csr>(mat->get_local_matrix()), res_local[rank],


### PR DESCRIPTION
This PR enables using an index map to create the coarse level using PGM for distributed matrices. IMO this simplifies the PGM implementation, since there is no 'manual' implementation needed anymore.
This also has some consequences for the `distributed::Matrix` class. Namely, when creating a matrix with from local and non-local parts, an index map has to be supplied, instead of the list of vectors. Again, I think this should simplify the interface. Note that currently there is no accessor to the index map, since it's not necessary. But it might be useful for consistency.

I guess this is also an interface breaking change.

Todo:
- [x] backend implementation for `gather_as_global_index`
- [x] merge #1707 