### PR TITLE
Add row and col scaling functions to distributed matrix

### DIFF
--- a/core/distributed/matrix.cpp
+++ b/core/distributed/matrix.cpp
@@ -510,16 +510,27 @@ void Matrix<ValueType, LocalIndexType, GlobalIndexType>::col_scale(
     ptr_param<const global_vector_type> scaling_factors)
 {
     GKO_ASSERT_CONFORMANT(this, scaling_factors.get());
+    GKO_ASSERT_EQ(scaling_factors->get_size()[1], 1);
     auto exec = this->get_executor();
     auto comm = this->get_communicator();
     size_type n_local_cols = local_mtx_->get_size()[1];
     size_type n_non_local_cols = non_local_mtx_->get_size()[1];
+    std::unique_ptr<global_vector_type> scaling_factors_single_stride;
+    auto stride = scaling_factors->get_stride();
+    if (stride != 1) {
+        scaling_factors_single_stride = global_vector_type::create(exec, comm);
+        scaling_factors_single_stride->copy_from(scaling_factors.get());
+    }
+    const auto scale_values =
+        stride == 1 ? scaling_factors->get_const_local_values()
+                    : scaling_factors_single_stride->get_const_local_values();
     const auto scale_diag = gko::matrix::Diagonal<ValueType>::create_const(
         exec, n_local_cols,
-        make_const_array_view(exec, n_local_cols,
-                              scaling_factors->get_const_local_values()));
+        make_const_array_view(exec, n_local_cols, scale_values));
 
-    auto req = this->communicate(scaling_factors->get_local_vector());
+    auto req = this->communicate(
+        stride == 1 ? scaling_factors->get_local_vector()
+                    : scaling_factors_single_stride->get_local_vector());
     scale_diag->rapply(local_mtx_, local_mtx_);
     req.wait();
     if (n_non_local_cols > 0) {
@@ -542,12 +553,22 @@ void Matrix<ValueType, LocalIndexType, GlobalIndexType>::row_scale(
     ptr_param<const global_vector_type> scaling_factors)
 {
     GKO_ASSERT_EQUAL_ROWS(this, scaling_factors.get());
+    GKO_ASSERT_EQ(scaling_factors->get_size()[1], 1);
     auto exec = this->get_executor();
+    auto comm = this->get_communicator();
     size_type n_local_rows = local_mtx_->get_size()[0];
+    std::unique_ptr<global_vector_type> scaling_factors_single_stride;
+    auto stride = scaling_factors->get_stride();
+    if (stride != 1) {
+        scaling_factors_single_stride = global_vector_type::create(exec, comm);
+        scaling_factors_single_stride->copy_from(scaling_factors.get());
+    }
+    const auto scale_values =
+        stride == 1 ? scaling_factors->get_const_local_values()
+                    : scaling_factors_single_stride->get_const_local_values();
     const auto scale_diag = gko::matrix::Diagonal<ValueType>::create_const(
         exec, n_local_rows,
-        make_const_array_view(exec, n_local_rows,
-                              scaling_factors->get_const_local_values()));
+        make_const_array_view(exec, n_local_rows, scale_values));
 
     scale_diag->apply(local_mtx_, local_mtx_);
     scale_diag->apply(non_local_mtx_, non_local_mtx_);

--- a/core/distributed/matrix.cpp
+++ b/core/distributed/matrix.cpp
@@ -8,6 +8,7 @@
 #include <ginkgo/core/distributed/vector.hpp>
 #include <ginkgo/core/matrix/coo.hpp>
 #include <ginkgo/core/matrix/csr.hpp>
+#include <ginkgo/core/matrix/diagonal.hpp>
 
 #include "core/distributed/matrix_kernels.hpp"
 
@@ -501,6 +502,55 @@ void Matrix<ValueType, LocalIndexType, GlobalIndexType>::apply_impl(
                                   one_scalar_.get(), local_x);
         },
         alpha, b, beta, x);
+}
+
+
+template <typename ValueType, typename LocalIndexType, typename GlobalIndexType>
+void Matrix<ValueType, LocalIndexType, GlobalIndexType>::col_scale(
+    ptr_param<const global_vector_type> scaling_factors)
+{
+    GKO_ASSERT_CONFORMANT(this, scaling_factors.get());
+    auto exec = this->get_executor();
+    auto comm = this->get_communicator();
+    size_type n_local_cols = local_mtx_->get_size()[1];
+    size_type n_non_local_cols = non_local_mtx_->get_size()[1];
+    const auto scale_diag = gko::matrix::Diagonal<ValueType>::create_const(
+        exec, n_local_cols,
+        make_const_array_view(exec, n_local_cols,
+                              scaling_factors->get_const_local_values()));
+
+    auto req = this->communicate(scaling_factors->get_local_vector());
+    scale_diag->rapply(local_mtx_, local_mtx_);
+    req.wait();
+    if (n_non_local_cols > 0) {
+        auto use_host_buffer = mpi::requires_host_buffer(exec, comm);
+        if (use_host_buffer) {
+            recv_buffer_->copy_from(host_recv_buffer_.get());
+        }
+        const auto non_local_scale_diag =
+            gko::matrix::Diagonal<ValueType>::create_const(
+                exec, n_non_local_cols,
+                make_const_array_view(exec, n_non_local_cols,
+                                      recv_buffer_->get_const_values()));
+        non_local_scale_diag->rapply(non_local_mtx_, non_local_mtx_);
+    }
+}
+
+
+template <typename ValueType, typename LocalIndexType, typename GlobalIndexType>
+void Matrix<ValueType, LocalIndexType, GlobalIndexType>::row_scale(
+    ptr_param<const global_vector_type> scaling_factors)
+{
+    GKO_ASSERT_EQUAL_ROWS(this, scaling_factors.get());
+    auto exec = this->get_executor();
+    size_type n_local_rows = local_mtx_->get_size()[0];
+    const auto scale_diag = gko::matrix::Diagonal<ValueType>::create_const(
+        exec, n_local_rows,
+        make_const_array_view(exec, n_local_rows,
+                              scaling_factors->get_const_local_values()));
+
+    scale_diag->apply(local_mtx_, local_mtx_);
+    scale_diag->apply(non_local_mtx_, non_local_mtx_);
 }
 
 

--- a/include/ginkgo/core/distributed/matrix.hpp
+++ b/include/ginkgo/core/distributed/matrix.hpp
@@ -575,6 +575,24 @@ public:
         std::vector<comm_index_type> recv_offsets,
         array<local_index_type> recv_gather_idxs);
 
+    /**
+     * Scales the columns of the matrix by the respective entries of the vector.
+     * The vector's row partition has to be the same as the matrix's column
+     * partition. The scaling is done in-place.
+     *
+     * @param scaling_factors  The vector containing the scaling factors.
+     */
+    void col_scale(ptr_param<const global_vector_type> scaling_factors);
+
+    /**
+     * Scales the rows of the matrix by the respective entries of the vector.
+     * The vector and the matrix have to have the same row partition.
+     * The scaling is done in-place.
+     *
+     * @param scaling_factors  The vector containing the scaling factors.
+     */
+    void row_scale(ptr_param<const global_vector_type> scaling_factors);
+
 protected:
     explicit Matrix(std::shared_ptr<const Executor> exec,
                     mpi::communicator comm);

--- a/test/mpi/matrix.cpp
+++ b/test/mpi/matrix.cpp
@@ -587,7 +587,7 @@ TYPED_TEST(Matrix, CanColScaleWithStride)
 
     this->dist_mat->col_scale(col_scaling_factors);
 
-    GKO_ASSERT_EQ(col_scaling_factors->get_stride(), 2);
+    ASSERT_EQ(col_scaling_factors->get_stride(), 2);
     GKO_ASSERT_MTX_NEAR(gko::as<csr>(this->dist_mat->get_local_matrix()),
                         res_col_scale_local[rank], 0);
     GKO_ASSERT_MTX_NEAR(gko::as<csr>(this->dist_mat->get_non_local_matrix()),
@@ -615,7 +615,7 @@ TYPED_TEST(Matrix, CanRowScaleWithStride)
 
     this->dist_mat->row_scale(row_scaling_factors);
 
-    GKO_ASSERT_EQ(row_scaling_factors->get_stride(), 2);
+    ASSERT_EQ(row_scaling_factors->get_stride(), 2);
     GKO_ASSERT_MTX_NEAR(gko::as<csr>(this->dist_mat->get_local_matrix()),
                         res_row_scale_local[rank], 0);
     GKO_ASSERT_MTX_NEAR(gko::as<csr>(this->dist_mat->get_non_local_matrix()),


### PR DESCRIPTION
This PR adds a `row_scale` and a `col_scale` function to the distributed matrix. This functionality is needed in openCARP.

- The row scaling is straight forward, with a distributed vector of scaling coefficients that has the same row partitioning as the matrix, we can just scale the rows of local and non-local matrices with the local vectors.
- For column scaling, we need to communicate the non-local scaling coefficients to scale the columns of the non-local matrices. This can be simply done with the matrix's `communicate`.