### PR TITLE
Fix stride for GCR initialization

### DIFF
--- a/common/unified/solver/gcr_kernels.cpp
+++ b/common/unified/solver/gcr_kernels.cpp
@@ -27,7 +27,7 @@ void initialize(std::shared_ptr<const DefaultExecutor> exec,
                 stopping_status* stop_status)
 {
     if (b->get_size()) {
-        run_kernel_solver(
+        run_kernel(
             exec,
             [] GKO_KERNEL(auto row, auto col, auto b, auto residual,
                           auto stop) {
@@ -36,8 +36,7 @@ void initialize(std::shared_ptr<const DefaultExecutor> exec,
                 }
                 residual(row, col) = b(row, col);
             },
-            b->get_size(), b->get_stride(), default_stride(b),
-            default_stride(residual), stop_status);
+            b->get_size(), b, residual, stop_status);
     } else {
         run_kernel(
             exec, [] GKO_KERNEL(auto col, auto stop) { stop[col].reset(); },

--- a/test/solver/gcr_kernels.cpp
+++ b/test/solver/gcr_kernels.cpp
@@ -157,6 +157,22 @@ TEST_F(Gcr, GcrKernelInitializeIsEquivalentToRef)
 }
 
 
+TEST_F(Gcr, GcrKernelInitializeWithStrideIsEquivalentToRef)
+{
+    initialize_data();
+    auto d_b_strided = Mtx::create(exec, b->get_size(), b->get_stride() + 2);
+    d_b_strided->copy_from(d_b);
+
+    gko::kernels::reference::gcr::initialize(ref, b.get(), residual.get(),
+                                             stop_status.get_data());
+    gko::kernels::GKO_DEVICE_NAMESPACE::gcr::initialize(
+        exec, d_b_strided.get(), d_residual.get(), d_stop_status.get_data());
+
+    GKO_ASSERT_MTX_NEAR(d_residual, residual, r<value_type>::value);
+    GKO_ASSERT_ARRAY_EQ(d_stop_status, stop_status);
+}
+
+
 TEST_F(Gcr, GcrKernelRestartIsEquivalentToRef)
 {
     initialize_data();


### PR DESCRIPTION
Noticed by @nbeams, the GCR initialization kernel uses an incorrect stride. This fixes it and adds a test for the behavior.