### PR TITLE
fix the casting issue in mixed multigrid

### DIFF
--- a/core/solver/multigrid.cpp
+++ b/core/solver/multigrid.cpp
@@ -486,7 +486,7 @@ void MultigridState::run_cycle(multigrid::cycle cycle, size_type level,
 
     auto r = r_list.at(level);
     auto g = g_list.at(level);
-    auto e = as<VectorType>(e_list.at(level));
+    auto e = e_list.at(level);
     // get mg_level
     auto mg_level = multigrid->get_mg_level_list().at(level);
     // get the pre_smoother
@@ -537,7 +537,7 @@ void MultigridState::run_cycle(multigrid::cycle cycle, size_type level,
     // next level
     if (level + 1 == total_level) {
         // the coarsest solver use the last level valuetype
-        e->fill(zero<value_type>());
+        as<VectorType>(e)->fill(zero<value_type>());
     }
     auto next_level_matrix =
         (level + 1 < total_level)


### PR DESCRIPTION
The vector e uses the precision of next level, so we can not cast the vector e to the precision of the current level.
We can only do it in the last level because the coarsest solver uses the same precision as the last level.