### PR TITLE
Include missing iomanip header in solver_progress.cpp test

### DIFF
--- a/core/test/log/solver_progress.cpp
+++ b/core/test/log/solver_progress.cpp
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
+#include <iomanip>
 #include <regex>
 
 #include <gtest/gtest.h>


### PR DESCRIPTION
Without this, compiling with g++ 14.2.1 fails with the following error:

```
/build/ginkgo-hpc-git/src/ginkgo/core/test/log/solver_progress.cpp: In member function ‘void SolverProgress_TableWorks_Test<gtest_TypeParam_>::TestBody()’:
/build/ginkgo-hpc-git/src/ginkgo/core/test/log/solver_progress.cpp:82:20: error: ‘setw’ is not a member of ‘std’
   82 |     ref_ss << std::setw(default_column_width) << "Iteration"
      |                    ^~~~
/build/ginkgo-hpc-git/src/ginkgo/core/test/log/solver_progress.cpp:15:1: note: ‘std::setw’ is defined in header ‘<iomanip>’; this is probably fixable by adding ‘#include <iomanip>’
   14 | #include "core/test/utils.hpp"
  +++ |+#include <iomanip>
   15 | #include "core/test/utils/assertions.hpp"
/build/ginkgo-hpc-git/src/ginkgo/core/test/log/solver_progress.cpp:83:20: error: ‘setw’ is not a member of ‘std’
   83 |            << std::setw(default_column_width) << "beta"
      |                    ^~~~
/build/ginkgo-hpc-git/src/ginkgo/core/test/log/solver_progress.cpp:83:20: note: ‘std::setw’ is defined in header ‘<iomanip>’; this is probably fixable by adding ‘#include <iomanip>’
/build/ginkgo-hpc-git/src/ginkgo/core/test/log/solver_progress.cpp:84:20: error: ‘setw’ is not a member of ‘std’
   84 |            << std::setw(default_column_width) << "prev_rho"
      |                    ^~~~
...
```