### PR TITLE
Fix ROCm 6.1 issues

### DIFF
--- a/common/cuda_hip/components/sorting.hpp
+++ b/common/cuda_hip/components/sorting.hpp
@@ -118,9 +118,9 @@ struct bitonic_warp {
             // workaround for ROCm 6.x segfaults on gfx906
 #ifdef GKO_COMPILING_CUDA
             auto other = __shfl_xor_sync(config::full_lane_mask, els[i],
-                                         num_threads / 2);
+                                         num_threads / 2, num_threads);
 #else
-            auto other = __shfl_xor(els[i], num_threads / 2);
+            auto other = __shfl_xor(els[i], num_threads / 2, num_threads);
 #endif
             bitonic_cas(els[i], other, new_reverse);
         }

--- a/common/cuda_hip/components/sorting.hpp
+++ b/common/cuda_hip/components/sorting.hpp
@@ -113,11 +113,15 @@ struct bitonic_warp {
 
     __forceinline__ __device__ static void merge(ValueType* els, bool reverse)
     {
-        auto tile =
-            group::tiled_partition<num_threads>(group::this_thread_block());
         auto new_reverse = reverse != upper_half();
         for (int i = 0; i < num_local; ++i) {
-            auto other = tile.shfl_xor(els[i], num_threads / 2);
+            // workaround for ROCm 6.x segfaults on gfx906
+#ifdef GKO_COMPILING_CUDA
+            auto other = __shfl_xor_sync(config::full_lane_mask, els[i],
+                                         num_threads / 2);
+#else
+            auto other = __shfl_xor(els[i], num_threads / 2);
+#endif
             bitonic_cas(els[i], other, new_reverse);
         }
         half::merge(els, reverse);

--- a/include/ginkgo/core/base/types.hpp
+++ b/include/ginkgo/core/base/types.hpp
@@ -51,29 +51,7 @@
 #endif
 
 
-#if (defined(__CUDA_ARCH__) && defined(__APPLE__)) || \
-    defined(__HIP_DEVICE_COMPILE__)
-
-#ifdef NDEBUG
-#define GKO_ASSERT(condition) ((void)0)
-#else  // NDEBUG
-// Poor man's assertions on GPUs for MACs. They won't terminate the program
-// but will at least print something on the screen
-#define GKO_ASSERT(condition)                                               \
-    ((condition)                                                            \
-         ? ((void)0)                                                        \
-         : ((void)printf("%s: %d: %s: Assertion `" #condition "' failed\n", \
-                         __FILE__, __LINE__, __func__)))
-#endif  // NDEBUG
-
-#else  // (defined(__CUDA_ARCH__) && defined(__APPLE__)) ||
-       // defined(__HIP_DEVICE_COMPILE__)
-
-// Handle assertions normally on other systems
 #define GKO_ASSERT(condition) assert(condition)
-
-#endif  // (defined(__CUDA_ARCH__) && defined(__APPLE__)) ||
-        // defined(__HIP_DEVICE_COMPILE__)
 
 
 // Handle deprecated notices correctly on different systems


### PR DESCRIPTION
The CSR lookup tests and all usages of the lookup functionality fails with ROCm 6.1 for some reason. These workarounds were only necessary in older ROCm versions anyways.

TODO:
- [x] Fix sorting segfault
- [x] Fix ParILUT segfault (probably related to the sorting segfault)
- [x] Fix searching hang (not a hang, just a slow test)