### PR TITLE
Fix Typo

### DIFF
--- a/core/test/base/utils.cpp
+++ b/core/test/base/utils.cpp
@@ -83,19 +83,19 @@ TEST(PointerParam, WorksForUniquePointers)
 }
 
 
-struct ClonableDerived : Base {
-    ClonableDerived(std::shared_ptr<const gko::Executor> exec = nullptr)
+struct CloneableDerived : Base {
+    CloneableDerived(std::shared_ptr<const gko::Executor> exec = nullptr)
         : executor(exec)
     {}
 
     std::unique_ptr<Base> clone()
     {
-        return std::unique_ptr<Base>(new ClonableDerived());
+        return std::unique_ptr<Base>(new CloneableDerived());
     }
 
     std::unique_ptr<Base> clone(std::shared_ptr<const gko::Executor> exec)
     {
-        return std::unique_ptr<Base>(new ClonableDerived{exec});
+        return std::unique_ptr<Base>(new CloneableDerived{exec});
     }
 
     std::shared_ptr<const gko::Executor> executor;
@@ -104,36 +104,36 @@ struct ClonableDerived : Base {
 
 TEST(Clone, ClonesUniquePointer)
 {
-    std::unique_ptr<ClonableDerived> p(new ClonableDerived());
+    std::unique_ptr<CloneableDerived> p(new CloneableDerived());
 
     auto clone = gko::clone(p);
 
     ::testing::StaticAssertTypeEq<decltype(clone),
-                                  std::unique_ptr<ClonableDerived>>();
+                                  std::unique_ptr<CloneableDerived>>();
     ASSERT_NE(p.get(), clone.get());
 }
 
 
 TEST(Clone, ClonesSharedPointer)
 {
-    std::shared_ptr<ClonableDerived> p(new ClonableDerived());
+    std::shared_ptr<CloneableDerived> p(new CloneableDerived());
 
     auto clone = gko::clone(p);
 
     ::testing::StaticAssertTypeEq<decltype(clone),
-                                  std::unique_ptr<ClonableDerived>>();
+                                  std::unique_ptr<CloneableDerived>>();
     ASSERT_NE(p.get(), clone.get());
 }
 
 
 TEST(Clone, ClonesPlainPointer)
 {
-    std::unique_ptr<ClonableDerived> p(new ClonableDerived());
+    std::unique_ptr<CloneableDerived> p(new CloneableDerived());
 
     auto clone = gko::clone(p.get());
 
     ::testing::StaticAssertTypeEq<decltype(clone),
-                                  std::unique_ptr<ClonableDerived>>();
+                                  std::unique_ptr<CloneableDerived>>();
     ASSERT_NE(p.get(), clone.get());
 }
 
@@ -141,12 +141,12 @@ TEST(Clone, ClonesPlainPointer)
 TEST(CloneTo, ClonesUniquePointer)
 {
     auto exec = gko::ReferenceExecutor::create();
-    std::unique_ptr<ClonableDerived> p(new ClonableDerived());
+    std::unique_ptr<CloneableDerived> p(new CloneableDerived());
 
     auto clone = gko::clone(exec, p);
 
     ::testing::StaticAssertTypeEq<decltype(clone),
-                                  std::unique_ptr<ClonableDerived>>();
+                                  std::unique_ptr<CloneableDerived>>();
     ASSERT_NE(p.get(), clone.get());
     ASSERT_EQ(clone->executor, exec);
 }
@@ -155,12 +155,12 @@ TEST(CloneTo, ClonesUniquePointer)
 TEST(CloneTo, ClonesSharedPointer)
 {
     auto exec = gko::ReferenceExecutor::create();
-    std::shared_ptr<ClonableDerived> p(new ClonableDerived());
+    std::shared_ptr<CloneableDerived> p(new CloneableDerived());
 
     auto clone = gko::clone(exec, p);
 
     ::testing::StaticAssertTypeEq<decltype(clone),
-                                  std::unique_ptr<ClonableDerived>>();
+                                  std::unique_ptr<CloneableDerived>>();
     ASSERT_NE(p.get(), clone.get());
     ASSERT_EQ(clone->executor, exec);
 }
@@ -169,12 +169,12 @@ TEST(CloneTo, ClonesSharedPointer)
 TEST(CloneTo, ClonesPlainPointer)
 {
     auto exec = gko::ReferenceExecutor::create();
-    std::unique_ptr<ClonableDerived> p(new ClonableDerived());
+    std::unique_ptr<CloneableDerived> p(new CloneableDerived());
 
     auto clone = gko::clone(exec, p.get());
 
     ::testing::StaticAssertTypeEq<decltype(clone),
-                                  std::unique_ptr<ClonableDerived>>();
+                                  std::unique_ptr<CloneableDerived>>();
     ASSERT_NE(p.get(), clone.get());
     ASSERT_EQ(clone->executor, exec);
 }

--- a/include/ginkgo/core/base/utils_helper.hpp
+++ b/include/ginkgo/core/base/utils_helper.hpp
@@ -173,7 +173,7 @@ template <typename Pointer>
 inline detail::cloned_type<Pointer> clone(const Pointer& p)
 {
     static_assert(detail::is_cloneable<detail::pointee<Pointer>>(),
-                  "Object is not clonable");
+                  "Object is not cloneable");
     return detail::cloned_type<Pointer>(
         static_cast<typename std::remove_cv<detail::pointee<Pointer>>::type*>(
             p->clone().release()));
@@ -200,7 +200,7 @@ inline detail::cloned_type<Pointer> clone(std::shared_ptr<const Executor> exec,
                                           const Pointer& p)
 {
     static_assert(detail::is_cloneable_to<detail::pointee<Pointer>>(),
-                  "Object is not clonable");
+                  "Object is not cloneable");
     return detail::cloned_type<Pointer>(
         static_cast<typename std::remove_cv<detail::pointee<Pointer>>::type*>(
             p->clone(std::move(exec)).release()));

--- a/include/ginkgo/core/base/utils_helper.hpp
+++ b/include/ginkgo/core/base/utils_helper.hpp
@@ -95,32 +95,32 @@ using pointee =
 
 
 template <typename T, typename = void>
-struct is_clonable_impl : std::false_type {};
+struct is_cloneable_impl : std::false_type {};
 
 template <typename T>
-struct is_clonable_impl<T, std::void_t<decltype(std::declval<T>().clone())>>
+struct is_cloneable_impl<T, std::void_t<decltype(std::declval<T>().clone())>>
     : std::true_type {};
 
 template <typename T>
-constexpr bool is_clonable()
+constexpr bool is_cloneable()
 {
-    return is_clonable_impl<std::decay_t<T>>::value;
+    return is_cloneable_impl<std::decay_t<T>>::value;
 }
 
 
 template <typename T, typename = void>
-struct is_clonable_to_impl : std::false_type {};
+struct is_cloneable_to_impl : std::false_type {};
 
 template <typename T>
-struct is_clonable_to_impl<
+struct is_cloneable_to_impl<
     T, std::void_t<decltype(std::declval<T>().clone(
            std::declval<std::shared_ptr<const Executor>>()))>>
     : std::true_type {};
 
 template <typename T>
-constexpr bool is_clonable_to()
+constexpr bool is_cloneable_to()
 {
-    return is_clonable_to_impl<std::decay_t<T>>::value;
+    return is_cloneable_to_impl<std::decay_t<T>>::value;
 }
 
 
@@ -172,7 +172,7 @@ using shared_type = std::shared_ptr<pointee<Pointer>>;
 template <typename Pointer>
 inline detail::cloned_type<Pointer> clone(const Pointer& p)
 {
-    static_assert(detail::is_clonable<detail::pointee<Pointer>>(),
+    static_assert(detail::is_cloneable<detail::pointee<Pointer>>(),
                   "Object is not clonable");
     return detail::cloned_type<Pointer>(
         static_cast<typename std::remove_cv<detail::pointee<Pointer>>::type*>(
@@ -199,7 +199,7 @@ template <typename Pointer>
 inline detail::cloned_type<Pointer> clone(std::shared_ptr<const Executor> exec,
                                           const Pointer& p)
 {
-    static_assert(detail::is_clonable_to<detail::pointee<Pointer>>(),
+    static_assert(detail::is_cloneable_to<detail::pointee<Pointer>>(),
                   "Object is not clonable");
     return detail::cloned_type<Pointer>(
         static_cast<typename std::remove_cv<detail::pointee<Pointer>>::type*>(


### PR DESCRIPTION
This PR fixes the typo `clonable -> cloneable`. This has no interface changes.