### PR TITLE
Fix GCC 7.5 issue with distributed::Matrix

### DIFF
--- a/include/ginkgo/core/base/std_extensions.hpp
+++ b/include/ginkgo/core/base/std_extensions.hpp
@@ -27,8 +27,24 @@ namespace gko {
  * @ingroup xstd
  */
 namespace xstd {
+namespace detail {
+
+
 template <typename... Ts>
-using void_t = std::void_t<Ts...>;
+struct make_void {
+    using type = void;
+};
+
+
+}  // namespace detail
+
+
+/**
+ * Use the custom implementation, since the std::void_t used in
+ * is_matrix_type_builder seems to trigger a compiler bug in GCC 7.5.
+ */
+template <typename... Ts>
+using void_t = typename detail::make_void<Ts...>::type;
 
 
 GKO_DEPRECATED("use std::uncaught_exceptions")

--- a/include/ginkgo/core/distributed/matrix.hpp
+++ b/include/ginkgo/core/distributed/matrix.hpp
@@ -14,6 +14,7 @@
 
 #include <ginkgo/core/base/dense_cache.hpp>
 #include <ginkgo/core/base/mpi.hpp>
+#include <ginkgo/core/base/std_extensions.hpp>
 #include <ginkgo/core/distributed/base.hpp>
 #include <ginkgo/core/distributed/index_map.hpp>
 #include <ginkgo/core/distributed/lin_op.hpp>
@@ -55,7 +56,7 @@ struct is_matrix_type_builder : std::false_type {};
 template <typename Builder, typename ValueType, typename IndexType>
 struct is_matrix_type_builder<
     Builder, ValueType, IndexType,
-    std::void_t<
+    xstd::void_t<
         decltype(std::declval<Builder>().template create<ValueType, IndexType>(
             std::declval<std::shared_ptr<const Executor>>()))>>
     : std::true_type {};


### PR DESCRIPTION
This PR uses the xstd::void_t again in is_matrix_type_builder. I think there is a bug in GCC 7.5 bug when std::void_t is used for is_matrix_type_builder. I wasn't able to reproduce this issue to actually find out if it's a bug or not, but since this is not an issue in newer gcc version, I don't think it's worth to put more effort into it.