### PR TITLE
clean unused sycl version switch and change the badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <div align="center">
 
-[![License](https://img.shields.io/github/license/ginkgo-project/ginkgo.svg)](./LICENSE)|[![c++ standard](https://img.shields.io/badge/c%2B%2B-14-blue.svg)](https://en.wikipedia.org/wiki/C%2B%2B#Standardization)|[![Documentation](https://img.shields.io/badge/Documentation-latest-blue.svg)](https://ginkgo-project.github.io/ginkgo-generated-documentation/doc/develop/)|[![DOI](https://joss.theoj.org/papers/10.21105/joss.02260/status.svg)](https://doi.org/10.21105/joss.02260)
+[![License](https://img.shields.io/github/license/ginkgo-project/ginkgo.svg)](./LICENSE)|[![c++ standard](https://img.shields.io/badge/c%2B%2B-17-blue.svg)](https://en.wikipedia.org/wiki/C%2B%2B#Standardization)|[![Documentation](https://img.shields.io/badge/Documentation-latest-blue.svg)](https://ginkgo-project.github.io/ginkgo-generated-documentation/doc/develop/)|[![DOI](https://joss.theoj.org/papers/10.21105/joss.02260/status.svg)](https://doi.org/10.21105/joss.02260)
 |:-:|:-:|:-:|:-:|
 
 

--- a/dpcpp/base/executor.dp.cpp
+++ b/dpcpp/base/executor.dp.cpp
@@ -254,15 +254,8 @@ void DpcppExecutor::set_device_property(dpcpp_queue_property property)
     }
     this->get_exec_info().max_workgroup_size = static_cast<int>(
         device.get_info<sycl::info::device::max_work_group_size>());
-// They change the max_work_item_size with template parameter Dimension after
-// major version 6 and adding the default = 3 is not in the same release.
-#if GINKGO_DPCPP_MAJOR_VERSION >= 6
     auto max_workitem_sizes =
         device.get_info<sycl::info::device::max_work_item_sizes<3>>();
-#else
-    auto max_workitem_sizes =
-        device.get_info<sycl::info::device::max_work_item_sizes>();
-#endif
     // Get the max dimension of a sycl::id object
     auto max_work_item_dimensions =
         device.get_info<sycl::info::device::max_work_item_dimensions>();
@@ -273,13 +266,8 @@ void DpcppExecutor::set_device_property(dpcpp_queue_property property)
 
     // Get the hardware threads per eu
     if (device.has(sycl::aspect::ext_intel_gpu_hw_threads_per_eu)) {
-#if GINKGO_DPCPP_MAJOR_VERSION >= 6
         this->get_exec_info().num_pu_per_cu = device.get_info<
             sycl::ext::intel::info::device::gpu_hw_threads_per_eu>();
-#else
-        this->get_exec_info().num_pu_per_cu = device.get_info<
-            sycl::info::device::ext_intel_gpu_hw_threads_per_eu>();
-#endif
     } else {
         // To make the usage still valid.
         // TODO: check the value for other vendor gpu or cpu.

--- a/dpcpp/components/cooperative_groups.dp.hpp
+++ b/dpcpp/components/cooperative_groups.dp.hpp
@@ -451,9 +451,6 @@ __dpct_inline__ grid_group this_grid(sycl::nd_item<3>& group)
 
 
 // Enable group can directly use group function
-#if GINKGO_DPCPP_MAJOR_VERSION < 6
-inline namespace cl {
-#endif
 namespace sycl {
 namespace detail {
 
@@ -480,9 +477,6 @@ struct group_scope<
 }  // namespace spirv
 }  // namespace detail
 }  // namespace sycl
-#if GINKGO_DPCPP_MAJOR_VERSION < 6
-}  // namespace cl
-#endif
 
 
 #endif  // GKO_DPCPP_COMPONENTS_COOPERATIVE_GROUPS_DP_HPP_

--- a/include/ginkgo/core/base/fwd_decls.hpp
+++ b/include/ginkgo/core/base/fwd_decls.hpp
@@ -32,9 +32,6 @@ struct ihipEvent_t;
 #endif
 
 
-// after intel/llvm September'22 release, which uses major version 6, they
-// introduce another inline namespace _V1.
-#if GINKGO_DPCPP_MAJOR_VERSION >= 6
 namespace sycl {
 inline namespace _V1 {
 
@@ -45,18 +42,6 @@ class event;
 
 }  // namespace _V1
 }  // namespace sycl
-#else  // GINKGO_DPCPP_MAJOR_VERSION < 6
-inline namespace cl {
-namespace sycl {
-
-
-class queue;
-class event;
-
-
-}  // namespace sycl
-}  // namespace cl
-#endif
 
 
 #endif  // GKO_PUBLIC_CORE_BASE_FWD_DECLS_HPP_


### PR DESCRIPTION
We support oneapi from 2023.1, whose __LIBSYCL_MAJOR_VERSION is already 6 (6.1.0 for __LIBSYCL).
This PR delete the dispatch before 6.
Also, change the c++14 badge to c++17 badge