### PR TITLE
Temporarily disable oneAPI CI jobs

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -344,6 +344,7 @@ build/icpx20231/igpu/release/shared:
     - .build_and_test_template
     - .default_variables
     - .quick_test_condition
+    - .disable_job_condition
     - .use_gko-oneapi20231-igpu
   variables:
     CXX_COMPILER: "icpx"
@@ -377,6 +378,7 @@ build/icpx/igpu/release/static:
     - .build_and_test_template
     - .default_variables
     - .full_test_condition
+    - .disable_job_condition
     - .use_gko-oneapi-igpu
   variables:
     CXX_COMPILER: "dpcpp"


### PR DESCRIPTION
The runners are down for a short while