### PR TITLE
Add function to create gko::config::pnode from std::string

### DIFF
--- a/extensions/test/config/json_config.cpp
+++ b/extensions/test/config/json_config.cpp
@@ -54,12 +54,32 @@ TEST(JsonConfig, ReadInput)
 {
     const char json[] =
         R"({"item": 4,
-            "array": [3.0, 4.5], 
+            "array": [3.0, 4.5],
             "map": {"bool": false}})";
 
     auto d = nlohmann::json::parse(json);
 
     auto ptree = gko::ext::config::parse_json(d);
+
+    auto& child_array = ptree.get("array").get_array();
+    auto& child_map = ptree.get("map").get_map();
+    ASSERT_EQ(ptree.get_map().size(), 3);
+    ASSERT_EQ(ptree.get("item").get_integer(), 4);
+    ASSERT_EQ(child_array.size(), 2);
+    ASSERT_EQ(child_array.at(0).get_real(), 3.0);
+    ASSERT_EQ(child_array.at(1).get_real(), 4.5);
+    ASSERT_EQ(child_map.size(), 1);
+    ASSERT_EQ(child_map.at("bool").get_boolean(), false);
+}
+
+TEST(JsonConfig, ReadInputString)
+{
+    std::string =
+        R"({"item": 4,
+            "array": [3.0, 4.5],
+            "map": {"bool": false}})";
+
+    auto ptree = gko::ext::config::parse_json_string(d);
 
     auto& child_array = ptree.get("array").get_array();
     auto& child_map = ptree.get("map").get_map();

--- a/extensions/test/config/json_config.cpp
+++ b/extensions/test/config/json_config.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 #include <stdexcept>
+#include <string>
 
 #include <gtest/gtest.h>
 #include <nlohmann/json.hpp>
@@ -74,12 +75,11 @@ TEST(JsonConfig, ReadInput)
 
 TEST(JsonConfig, ReadInputString)
 {
-    std::string =
-        R"({"item": 4,
-            "array": [3.0, 4.5],
-            "map": {"bool": false}})";
+    std::string json_string = R"({"item": 4,
+           "array": [3.0, 4.5],
+           "map": {"bool": false}})";
 
-    auto ptree = gko::ext::config::parse_json_string(d);
+    auto ptree = gko::ext::config::parse_json_string(json_string);
 
     auto& child_array = ptree.get("array").get_array();
     auto& child_map = ptree.get("map").get_map();

--- a/include/ginkgo/extensions/config/json_config.hpp
+++ b/include/ginkgo/extensions/config/json_config.hpp
@@ -80,6 +80,13 @@ inline gko::config::pnode parse_json_file(std::string filename)
     return parse_json(nlohmann::json::parse(fstream));
 }
 
+/**
+ * parse_json_string takes a json string to generate the property tree object
+ */
+inline gko::config::pnode parse_json_string(std::string json)
+{
+    return parse_json(nlohmann::json::parse(json));
+}
 
 }  // namespace config
 }  // namespace ext


### PR DESCRIPTION
This PR adds a function to create `gko::config::pnode` directly from a `std::string`.

Motivation: We would like to use Ginkgo's file config solver within the pyGinkgo bindings. The current implementation of the config solver seems to rely on json files. However, creating temporary files is a nuisance which can cause all kinds issues and is not really necessary in our case.  Thus, just passing a `std::string`  to generate a property tree would simplify things a lot.