### PR TITLE
workaround for hanging issue on A770 action

### DIFF
--- a/.github/workflows/intel.yml
+++ b/.github/workflows/intel.yml
@@ -29,16 +29,17 @@ jobs:
     steps:
     - name: Checkout the latest code (shallow clone)
       uses: actions/checkout@v4
-
+    # We set -fsycl-default-sub-group-size=16 to avoid the A770 hanging issue.
+    # The default configuration makes that A770 hangs during running the kernel without specifying sub-group size
     - name: configure
       run: |
         source /etc/profile
-        module load intel-oneapi-compilers intel-oneapi-dpl intel-oneapi-mkl cmake
+        module load intel-oneapi-compilers intel-oneapi-dpl intel-oneapi-mkl cmake ninja
         mkdir build
         cd build
-        cmake .. -DCMAKE_INSTALL_PREFIX=install_ginkgo -DCMAKE_CXX_FLAGS="-Wpedantic -ffp-model=precise" -DCMAKE_CXX_COMPILER=${{ matrix.config.compiler }} -DCMAKE_BUILD_TYPE=${{ matrix.config.build_type }} -DGINKGO_MIXED_PRECISION=${{ matrix.config.mixed }} -DGINKGO_BUILD_CUDA=OFF -DGINKGO_BUILD_HIP=OFF -DGINKGO_BUILD_MPI=OFF -DGINKGO_DPCPP_SINGLE_MODE=ON
-        make -j8
-        ONEAPI_DEVICE_SELECTOR=level_zero:gpu ctest -j10 --output-on-failure
+        cmake .. -GNinja -DCMAKE_INSTALL_PREFIX=install_ginkgo -DCMAKE_CXX_FLAGS="-Wpedantic -ffp-model=precise -fsycl-default-sub-group-size=16 -Wno-unused-command-line-argument -Wno-deprecated" -DCMAKE_CXX_COMPILER=${{ matrix.config.compiler }} -DCMAKE_BUILD_TYPE=${{ matrix.config.build_type }} -DGINKGO_MIXED_PRECISION=${{ matrix.config.mixed }} -DGINKGO_BUILD_CUDA=OFF -DGINKGO_BUILD_HIP=OFF -DGINKGO_BUILD_MPI=OFF -DGINKGO_DPCPP_SINGLE_MODE=ON
+        ninja dpcpp/test/base/executor -j2
+        ONEAPI_DEVICE_SELECTOR=level_zero:gpu dpcpp/test/base/executor
  
     - name: install
       run: |

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -339,7 +339,7 @@ build/nocuda-nomixed/nompi/clang/omp/debug/static:
     MIXED_PRECISION: "OFF"
 
 # spack oneapi 2023.1
-build/icpx20231/igpu/release/shared:
+build/icpx20231/gpu/release/shared:
   extends:
     - .build_and_test_template
     - .default_variables
@@ -372,7 +372,7 @@ build/icpx20231/igpu/release/shared:
 #     ONEAPI_DEVICE_SELECTOR: "level_zero:gpu"
 
 # It gives two available backends of GPU on tests
-build/icpx/igpu/release/static:
+build/icpx/gpu/release/static:
   extends:
     - .build_and_test_template
     - .default_variables
@@ -383,7 +383,7 @@ build/icpx/igpu/release/static:
     CXX_FLAGS: "-Wpedantic -ffp-model=precise"
     BUILD_SYCL: "ON"
     BUILD_TYPE: "Release"
-    BUILD_SHARED_LIBS: "OF"
+    BUILD_SHARED_LIBS: "OFF"
     DPCPP_SINGLE_MODE: "ON"
     ONEAPI_DEVICE_SELECTOR: "*:gpu"
     BUILD_HWLOC: "OFF"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -344,7 +344,6 @@ build/icpx20231/igpu/release/shared:
     - .build_and_test_template
     - .default_variables
     - .quick_test_condition
-    - .disable_job_condition
     - .use_gko-oneapi20231-igpu
   variables:
     CXX_COMPILER: "icpx"
@@ -378,7 +377,6 @@ build/icpx/igpu/release/static:
     - .build_and_test_template
     - .default_variables
     - .full_test_condition
-    - .disable_job_condition
     - .use_gko-oneapi-igpu
   variables:
     CXX_COMPILER: "dpcpp"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -372,7 +372,7 @@ build/icpx20231/gpu/release/shared:
 #     ONEAPI_DEVICE_SELECTOR: "level_zero:gpu"
 
 # It gives two available backends of GPU on tests
-build/icpx/gpu/release/static:
+build/dpcpp/gpu/release/shared:
   extends:
     - .build_and_test_template
     - .default_variables
@@ -383,7 +383,8 @@ build/icpx/gpu/release/static:
     CXX_FLAGS: "-Wpedantic -ffp-model=precise"
     BUILD_SYCL: "ON"
     BUILD_TYPE: "Release"
-    BUILD_SHARED_LIBS: "OFF"
+    # static builds take too long
+    BUILD_SHARED_LIBS: "ON"
     DPCPP_SINGLE_MODE: "ON"
     ONEAPI_DEVICE_SELECTOR: "*:gpu"
     BUILD_HWLOC: "OFF"

--- a/.gitlab/image.yml
+++ b/.gitlab/image.yml
@@ -50,17 +50,14 @@
 .use_gko-oneapi-igpu:
   image: ginkgohub/oneapi:latest
   tags:
-    - private_ci
-    - intel-igpu
+    - intel-gpus
 
 .use_gko-oneapi20231-igpu:
   image: ginkgohub/spack-oneapi:20231-openmpi
   tags:
-    - private_ci
-    - intel-igpu
+    - intel-gpus
 
 .use_gko-oneapi-dgpu:
   image: ginkgohub/oneapi:latest
   tags:
-    - private_ci
-    - intel-dgpu
+    - intel-gpus

--- a/dpcpp/base/executor.dp.cpp
+++ b/dpcpp/base/executor.dp.cpp
@@ -279,7 +279,11 @@ void DpcppExecutor::set_device_property(dpcpp_queue_property property)
     // `wait()` would be needed after every call to a DPC++ function or kernel.
     // For example, without `in_order`, doing a copy, a kernel, and a copy, will
     // not necessarily happen in that order by default, which we need to avoid.
-    auto* queue = new sycl::queue{device, detail::get_property_list(property)};
+    // We need to create the context for each device. Otherwise, we get -999
+    // Unknown PI error after second device.
+    // Ref: https://github.com/intel/llvm/issues/10982
+    auto* queue = new sycl::queue{sycl::context(device), device,
+                                  detail::get_property_list(property)};
     queue_ = std::move(queue_manager<sycl::queue>{queue, detail::delete_queue});
 }
 

--- a/dpcpp/preconditioner/sor_kernels.dp.cpp
+++ b/dpcpp/preconditioner/sor_kernels.dp.cpp
@@ -31,14 +31,18 @@ void initialize_weighted_l(
                         1, 1};
 
     auto inv_weight = one(weight) / weight;
+    const auto in_row_ptrs = system_matrix->get_const_row_ptrs();
+    const auto in_col_idxs = system_matrix->get_const_col_idxs();
+    const auto in_values = system_matrix->get_const_values();
+    const auto l_row_ptrs = l_mtx->get_const_row_ptrs();
+    const auto l_col_idxs = l_mtx->get_col_idxs();
+    const auto l_values = l_mtx->get_values();
 
     exec->get_queue()->parallel_for(
         sycl_nd_range(grid_dim, block_size), [=](sycl::nd_item<3> item_ct1) {
             factorization::helpers::initialize_l(
-                num_rows, system_matrix->get_const_row_ptrs(),
-                system_matrix->get_const_col_idxs(),
-                system_matrix->get_const_values(), l_mtx->get_const_row_ptrs(),
-                l_mtx->get_col_idxs(), l_mtx->get_values(),
+                num_rows, in_row_ptrs, in_col_idxs, in_values, l_row_ptrs,
+                l_col_idxs, l_values,
                 factorization::helpers::triangular_mtx_closure(
                     [inv_weight](auto val) { return val * inv_weight; },
                     factorization::helpers::identity{}),
@@ -67,15 +71,21 @@ void initialize_weighted_l_u(
     auto inv_two_minus_weight =
         one(weight) / (static_cast<remove_complex<ValueType>>(2.0) - weight);
 
+    const auto in_row_ptrs = system_matrix->get_const_row_ptrs();
+    const auto in_col_idxs = system_matrix->get_const_col_idxs();
+    const auto in_values = system_matrix->get_const_values();
+    const auto l_row_ptrs = l_mtx->get_const_row_ptrs();
+    const auto l_col_idxs = l_mtx->get_col_idxs();
+    const auto l_values = l_mtx->get_values();
+    const auto u_row_ptrs = u_mtx->get_const_row_ptrs();
+    const auto u_col_idxs = u_mtx->get_col_idxs();
+    const auto u_values = u_mtx->get_values();
+
     exec->get_queue()->parallel_for(
         sycl_nd_range(grid_dim, block_size), [=](sycl::nd_item<3> item_ct1) {
             factorization::helpers::initialize_l_u(
-                num_rows, system_matrix->get_const_row_ptrs(),
-                system_matrix->get_const_col_idxs(),
-                system_matrix->get_const_values(), l_mtx->get_const_row_ptrs(),
-                l_mtx->get_col_idxs(), l_mtx->get_values(),
-                u_mtx->get_const_row_ptrs(), u_mtx->get_col_idxs(),
-                u_mtx->get_values(),
+                num_rows, in_row_ptrs, in_col_idxs, in_values, l_row_ptrs,
+                l_col_idxs, l_values, u_row_ptrs, u_col_idxs, u_values,
                 factorization::helpers::triangular_mtx_closure(
                     [inv_weight](auto val) { return val * inv_weight; },
                     factorization::helpers::identity{}),

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -101,6 +101,8 @@ if(GINKGO_BUILD_TESTS)
                      "${executor}"
                      WORKING_DIRECTORY
                      "${CMAKE_CURRENT_SOURCE_DIR}/${example}")
+            # Prevent performance issues with high core counts
+            set_property(TEST example_${example}_${executor} PROPERTY ENVIRONMENT OMP_NUM_THREADS=4)
         endforeach()
     endforeach()
 
@@ -115,6 +117,8 @@ if(GINKGO_BUILD_TESTS)
                      "${CMAKE_CURRENT_SOURCE_DIR}/file-config-solver/data/A.mtx"
                      WORKING_DIRECTORY
                      "$<TARGET_FILE_DIR:ginkgo>")
+            # Prevent performance issues with high core counts
+            set_property(TEST example_file-config-solver_${config_name}_${executor} PROPERTY ENVIRONMENT OMP_NUM_THREADS=4)
         endforeach()    
     endforeach()
         

--- a/test/factorization/factorization_kernels.cpp
+++ b/test/factorization/factorization_kernels.cpp
@@ -53,7 +53,7 @@ TEST_F(Factorization, InitializeRowPtrsLSameAsRef)
 }
 
 
-TEST_F(Factorization, InitializeLWithoutSqrtSameAsRef)
+TEST_F(Factorization, InitializeLSameAsRef)
 {
     gko::array<index_type> l_ptrs{ref, mtx->get_size()[0] + 1};
     gko::kernels::reference::factorization::initialize_row_ptrs_l(
@@ -73,6 +73,7 @@ TEST_F(Factorization, InitializeLWithoutSqrtSameAsRef)
         gko::kernels::GKO_DEVICE_NAMESPACE::factorization::initialize_l(
             exec, dmtx.get(), dl_mtx.get(), diag_sqrt);
 
-        GKO_ASSERT_MTX_NEAR(l_mtx, dl_mtx, 0.0);
+        GKO_ASSERT_MTX_NEAR(l_mtx, dl_mtx,
+                            diag_sqrt ? r<value_type>::value : 0.0);
     }
 }

--- a/test/preconditioner/sor_kernels.cpp
+++ b/test/preconditioner/sor_kernels.cpp
@@ -46,11 +46,17 @@ protected:
         d_mtx->read(md);
 
         result_l->read(md_l);
-        result_l->scale(gko::initialize<Dense>({0.0}, ref));
+        std::fill_n(result_l->get_col_idxs(),
+                    result_l->get_num_stored_elements(), -1);
+        std::fill_n(result_l->get_values(), result_l->get_num_stored_elements(),
+                    gko::nan<value_type>());
         d_result_l = gko::clone(exec, result_l);
 
         result_u->read(md_u);
-        result_u->scale(gko::initialize<Dense>({0.0}, ref));
+        std::fill_n(result_u->get_col_idxs(),
+                    result_u->get_num_stored_elements(), -1);
+        std::fill_n(result_u->get_values(), result_u->get_num_stored_elements(),
+                    gko::nan<value_type>());
         d_result_u = gko::clone(exec, result_u);
     }
 
@@ -73,6 +79,7 @@ TEST_F(Sor, InitializeWeightedLFactorIsSameAsReference)
     gko::kernels::GKO_DEVICE_NAMESPACE::sor::initialize_weighted_l(
         exec, d_mtx.get(), 1.24, d_result_l.get());
 
+    GKO_ASSERT_MTX_EQ_SPARSITY(result_l, d_result_l);
     GKO_ASSERT_MTX_NEAR(result_l, d_result_l, r<value_type>::value);
 }
 
@@ -84,6 +91,8 @@ TEST_F(Sor, InitializeWeightedLAndUFactorIsSameAsReference)
     gko::kernels::GKO_DEVICE_NAMESPACE::sor::initialize_weighted_l_u(
         exec, d_mtx.get(), 1.24, d_result_l.get(), d_result_u.get());
 
+    GKO_ASSERT_MTX_EQ_SPARSITY(result_l, d_result_l);
+    GKO_ASSERT_MTX_EQ_SPARSITY(result_u, d_result_u);
     GKO_ASSERT_MTX_NEAR(result_l, d_result_l, r<value_type>::value);
     GKO_ASSERT_MTX_NEAR(result_u, d_result_u, r<value_type>::value);
 }


### PR DESCRIPTION
The default sub-group size 8 for most kernels (I assume) is available on A770, but it can not run or terminiate successfully with this kind of kernels. It might be from some mismatch between driver/kernel/compiler.
We pass the `-fsycl-default-sub-group-size=16` such that it does not hang for now.
Interestingly, the cooperative group with sub-group size 8 works for now.
I was inspired by that because job with 8 hangs but job with 16 works. 