### PR TITLE
Disable threadsanitizer temporarily

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -599,6 +599,7 @@ threadsanitizer:
     - .deploy_condition
     - .before_script_template
     - .use_gko-rocm514-nompi-gnu11-llvm11
+    - .disable_job_condition
   script:
     - LD_PRELOAD=/usr/local/lib/libomp.so
       CC=clang CXX=clang++


### PR DESCRIPTION
This PR disables the threadsanitizer CI job temporarily. In its current state, the threadsanitizer CI job has the following issues:
- it's slow. The run can take >10h. Running it locally is much faster, so some configuration might be wrong.
- false positives. Many tests fail, with either broken stack traces, or non-reproducible output.