### PR TITLE
update multigrid usage in test/mpi/solver

### DIFF
--- a/test/matrix/csr_kernels2.cpp
+++ b/test/matrix/csr_kernels2.cpp
@@ -34,7 +34,6 @@ class Csr : public CommonTestFixture {
 protected:
     using Arr = gko::array<int>;
     using Vec = gko::matrix::Dense<value_type>;
-    using Vec2 = gko::matrix::Dense<gko::next_precision_base<value_type>>;
     using Mtx = gko::matrix::Csr<value_type>;
     using ComplexVec = gko::matrix::Dense<std::complex<value_type>>;
     using ComplexMtx = gko::matrix::Csr<std::complex<value_type>>;
@@ -123,27 +122,17 @@ protected:
         square_mtx = Mtx::create(ref, strategy);
         square_mtx->move_from(gen_mtx<Vec>(mtx_size[0], mtx_size[0], 1));
         expected = gen_mtx<Vec>(mtx_size[0], num_vectors, 1);
-        expected2 = Vec2::create(ref);
-        expected2->copy_from(expected);
         y = gen_mtx<Vec>(mtx_size[1], num_vectors, 1);
-        y2 = Vec2::create(ref);
-        y2->copy_from(y);
         alpha = gko::initialize<Vec>({2.0}, ref);
-        alpha2 = gko::initialize<Vec2>({2.0}, ref);
         beta = gko::initialize<Vec>({-1.0}, ref);
-        beta2 = gko::initialize<Vec2>({-1.0}, ref);
         dmtx = Mtx::create(exec, strategy);
         dmtx->copy_from(mtx);
         dsquare_mtx = Mtx::create(exec, strategy);
         dsquare_mtx->copy_from(square_mtx);
         dresult = gko::clone(exec, expected);
-        dresult2 = gko::clone(exec, expected2);
         dy = gko::clone(exec, y);
-        dy2 = gko::clone(exec, y2);
         dalpha = gko::clone(exec, alpha);
-        dalpha2 = gko::clone(exec, alpha2);
         dbeta = gko::clone(exec, beta);
-        dbeta2 = gko::clone(exec, beta2);
 
         std::vector<int> tmp(mtx->get_size()[0], 0);
         auto rng = std::default_random_engine{};
@@ -196,26 +185,18 @@ protected:
     std::unique_ptr<ComplexMtx> complex_mtx;
     std::unique_ptr<Mtx> square_mtx;
     std::unique_ptr<Vec> expected;
-    std::unique_ptr<Vec2> expected2;
     std::unique_ptr<Vec> y;
-    std::unique_ptr<Vec2> y2;
     std::unique_ptr<Vec> alpha;
-    std::unique_ptr<Vec2> alpha2;
     std::unique_ptr<Vec> beta;
-    std::unique_ptr<Vec2> beta2;
 
     std::unique_ptr<Mtx> dmtx;
     std::unique_ptr<Mtx> dmtx2;
     std::unique_ptr<ComplexMtx> dcomplex_mtx;
     std::unique_ptr<Mtx> dsquare_mtx;
     std::unique_ptr<Vec> dresult;
-    std::unique_ptr<Vec2> dresult2;
     std::unique_ptr<Vec> dy;
-    std::unique_ptr<Vec2> dy2;
     std::unique_ptr<Vec> dalpha;
-    std::unique_ptr<Vec2> dalpha2;
     std::unique_ptr<Vec> dbeta;
-    std::unique_ptr<Vec2> dbeta2;
     std::unique_ptr<Arr> rpermute_idxs;
     std::unique_ptr<Arr> cpermute_idxs;
     std::unique_ptr<Perm> rpermutation;

--- a/test/mpi/solver/solver.cpp
+++ b/test/mpi/solver/solver.cpp
@@ -138,11 +138,7 @@ struct CgWithMg : SimpleSolverTest<gko::solver::Cg<solver_value_type>> {
                         16u)  // necessary since the test matrices have less
                               // rows than the default value
                     .with_criteria(
-                        gko::stop::Iteration::build().with_max_iters(
-                            iteration_count()),
-                        gko::stop::ResidualNorm<value_type>::build()
-                            .with_baseline(gko::stop::mode::absolute)
-                            .with_reduction_factor(2 * reduction_factor())));
+                        gko::stop::Iteration::build().with_max_iters(1u)));
     }
 
     static bool blacklisted(const std::string& test)


### PR DESCRIPTION
This PR change the multigrid preconditioner setting in the test/mpi/solver
The original preconditioner criterion also check the absolute residual norm. 
However, it will lead no update on the result from preconditioner when it meets the criterion already with initial input.
It makes the all thing stays the same in Cg from that point.
Thus, the previous CgWithMg will run until reaching iteration limit, which leads long time execution

It use the syntex from wiki cg 
![image](https://github.com/user-attachments/assets/b4092a54-55fa-4bb2-a60f-b11c85d0596b)

Assume the following $z_2$ is equal to $z_1$ when $z_1$ is initial guess and meet the criterion 
$Mz_2 = r_2$
$\beta_1 = \frac{r_2'z_2}{r_1'z_1}$
$r_2'z_2 = (r_1-\alpha A p_1)'z_1 = r_1'z_1 - \frac{r_1'z_1}{p_1'Ap_1}(Ap_1)'z_1$
$= r_1'z_1 - \frac{r_1'z_1}{p_1'A(z_1+\beta_0p_0)}(p_1'A'z_1)$

$p_1'Ap_0 = 0$ and A is symmetric
Thus, we get it to

$r_1'z_1 -\frac{r_1'z_1}{p_1'Az_1}(p_1'Az_1) = r_1'z_1 - r_1'z_1 = 0$

Other than this, I also delete the unused part which is mentioned in #1736 