### PR TITLE
Deprecate the `master` branch

### DIFF
--- a/.gitlab/rules.yml
+++ b/.gitlab/rules.yml
@@ -5,8 +5,8 @@
 
 .pr_condition:
   rules:
-    # Exclude `develop`, `master`, and tags with `when: never`
-    - if: $CI_COMMIT_BRANCH == "develop" || $CI_COMMIT_BRANCH == "master" || $CI_COMMIT_TAG
+    # Exclude `develop`, `main`, and tags with `when: never`
+    - if: $CI_COMMIT_BRANCH == "develop" || $CI_COMMIT_BRANCH == "main" || $CI_COMMIT_BRANCH == "master" || $CI_COMMIT_TAG
       when: never
     # Run only when the `RUN_CI_TAG` variable is set
     - if: $RUN_CI_TAG
@@ -16,7 +16,7 @@
 .pr_trigger_condition:
   rules:
     # Exclude `develop`, `master`, and tags with `when: never`
-    - if: $CI_COMMIT_BRANCH == "develop" || $CI_COMMIT_BRANCH == "master" || $CI_COMMIT_TAG
+    - if: $CI_COMMIT_BRANCH == "develop" || $CI_COMMIT_BRANCH == "main" || $CI_COMMIT_BRANCH == "master" || $CI_COMMIT_TAG
       when: never
     # Run only for quick pipelines and when the `RUN_CI_TAG` variable is set
     - if: $RUN_CI_TAG && $STATUS_CONTEXT == "quick"
@@ -26,13 +26,13 @@
 .full_test_condition:
   rules:
     # Run only when the `RUN_CI_TAG` variable is set and this is a full pipeline, or for `master`, `develop` or tags.
-    - if: $RUN_CI_TAG && ($STATUS_CONTEXT == "full" || $CI_COMMIT_BRANCH == "master" || $CI_COMMIT_BRANCH == "develop" || $CI_COMMIT_TAG)
+    - if: $RUN_CI_TAG && ($STATUS_CONTEXT == "full" || $CI_COMMIT_BRANCH == "main" || $CI_COMMIT_BRANCH == "develop" || $CI_COMMIT_TAG)
   dependencies: []
 
 
 .full_test_short_lived_condition:
   rules:
-    - if: $CI_COMMIT_BRANCH == "develop" || $CI_COMMIT_BRANCH == "master" || $CI_COMMIT_TAG
+    - if: $CI_COMMIT_BRANCH == "develop" || $CI_COMMIT_BRANCH == "main" || $CI_COMMIT_BRANCH == "master"  || $CI_COMMIT_TAG
       when: never
     - if: $RUN_CI_TAG && $STATUS_CONTEXT == "full"
   dependencies: []
@@ -40,13 +40,15 @@
 
 .quick_test_condition:
   rules:
+    - if: $RUN_CI_TAG && $CI_COMMIT_BRANCH == "master"
+      when: never
     - if: $RUN_CI_TAG && $STATUS_CONTEXT == null
   dependencies: []
 
 
 .deploy_condition:
   rules:
-    - if: $RUN_CI_TAG && ($CI_COMMIT_BRANCH == "master" || $CI_COMMIT_BRANCH == "develop" || $CI_COMMIT_TAG) && $CI_PIPELINE_SOURCE != "schedule"
+    - if: $RUN_CI_TAG && ($CI_COMMIT_BRANCH == "main" || $CI_COMMIT_BRANCH == "develop" || $CI_COMMIT_TAG) && $CI_PIPELINE_SOURCE != "schedule"
   dependencies: []
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,17 @@ cmake_minimum_required(VERSION 3.16)
 project(Ginkgo LANGUAGES CXX VERSION 1.9.0 DESCRIPTION "A numerical linear algebra library targeting many-core architectures")
 set(Ginkgo_VERSION_TAG "develop")
 set(PROJECT_VERSION_TAG ${Ginkgo_VERSION_TAG})
+if(Ginkgo_VERSION_TAG STREQUAL "master")
+    set(GINKGO_VERSION_TAG_DEPRECATED ON)
+else()
+    set(GINKGO_VERSION_TAG_DEPRECATED OFF)
+endif()
+if(GINKGO_VERSION_TAG_DEPRECATED)
+    message(
+            WARNING
+            "The branch ${Ginkgo_VERSION_TAG} is deprecated and will stop receiving updates after 2025. "
+            "Please use the main branch for the latest release, or the develop branch for the latest development updates.")
+endif()
 # Cuda and Hip also look for Threads. Set it before any find_package to ensure the Threads setting is not changed.
 set(THREADS_PREFER_PTHREAD_FLAG ON)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -151,8 +151,8 @@ improvements from code reviews.
 ### Creating, Reviewing and Merging Pull Requests
 
 * The `develop` branch is the default branch to submit PR's to. From time to
-  time, we merge the `develop` branch to the `master` branch and create tags on
-  the `master` to create new releases of Ginkgo. Therefore, all pull requests
+  time, we merge the `develop` branch to the `main` branch and create tags on
+  the `main` to create new releases of Ginkgo. Therefore, all pull requests
   must be merged into `develop`.
 * Please have a look at the labels and make sure to add the relevant labels.
 * You can mark the PR as a `WIP` if you are still working on it, `Ready for

--- a/include/ginkgo/config.hpp.in
+++ b/include/ginkgo/config.hpp.in
@@ -13,6 +13,16 @@
 #define GKO_VERSION_STR @Ginkgo_VERSION_MAJOR@, @Ginkgo_VERSION_MINOR@, @Ginkgo_VERSION_PATCH@
 // clang-format on
 
+
+// clang-format off
+#cmakedefine01 GINKGO_VERSION_TAG_DEPRECATED
+#if GINKGO_VERSION_TAG_DEPRECATED
+#pragma message ("The branch " GKO_VERSION_TAG " is deprecated and will stop receiving updates after 2025. " \
+ "Please use the main branch for the latest release, or the develop branch for the latest development updates.")
+#endif
+// clang-format on
+
+
 /*
  * Controls the amount of messages output by Ginkgo.
  * 0 disables all output (except for test, benchmarks and examples).


### PR DESCRIPTION
This PR adds warnings when the `master` branch is used. The `master` branch will not be updated after 2025. It will produce both CMake warnings and compiler messages (the `#warning` directive is only available in c++23).

The main reason for deprecating the master branch is that the release process is more complicated with the master branch. The develop and master branch have no common history, so merging develop into master will reapply every commit in develop since the 1.0 release.