### PR TITLE
support properly when disable half precision

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -26,7 +26,8 @@ Ginkgo adds the following additional switches to control what is being built:
     Enabling this flag increases the library size, but improves performance of
     mixed-precision kernels.
 *   `-DGINKGO_ENABLE_HALF={ON, OFF}` enable half precision support in Ginkgo, default is `ON`.
-    It is `OFF` when the compiler is MSVC.
+    It is `OFF` when the compiler is MSVC. If compiling is done with the CUDA backend before CUDA 12.2, 
+    we only support half precision after compute capability 5.3. CUDA 12.2+ compilers waive the compute capbility limitation.
 *   `-DGINKGO_BUILD_TESTS={ON, OFF}` builds Ginkgo's tests
     (will download googletest), default is `ON`.
 *   `-DGINKGO_FAST_TESTS={ON, OFF}` reduces the input sizes for a few slow tests

--- a/common/cuda_hip/base/math.hpp
+++ b/common/cuda_hip/base/math.hpp
@@ -104,6 +104,9 @@ struct is_complex_or_scalar_impl<thrust::complex<T>>
 }  // namespace gko
 
 
+#if GINKGO_ENABLE_HALF
+
+
 GKO_THRUST_NAEMSPACE_PREFIX
 namespace thrust {
 
@@ -184,6 +187,9 @@ __device__ __forceinline__ bool is_finite(const thrust::complex<__half>& value)
 
 
 }  // namespace gko
+
+
+#endif  // GINKGO_ENABLE_HALF
 
 
 #endif  // GKO_COMMON_CUDA_HIP_BASE_MATH_HPP_


### PR DESCRIPTION
Nvidia GPU before compute capability 5.3 does not support IEEE FP16 (half) precision operation.
However, cuda 12.2+ relax these some limitation, so we still support these GPUs with `GINKGO_ENABLE_HALF=ON` after cuda 12.2.
We only support these GPUs with `GINKGO_ENABLE_HALF=OFF` before cuda 12.2

- [x] wait for the check on the real GPU below the requirment