### PR TITLE
TSAN fixes

### DIFF
--- a/common/unified/multigrid/pgm_kernels.cpp
+++ b/common/unified/multigrid/pgm_kernels.cpp
@@ -24,31 +24,6 @@ namespace pgm {
 
 
 template <typename IndexType>
-void match_edge(std::shared_ptr<const DefaultExecutor> exec,
-                const array<IndexType>& strongest_neighbor,
-                array<IndexType>& agg)
-{
-    run_kernel(
-        exec,
-        [] GKO_KERNEL(auto tidx, auto strongest_neighbor_vals, auto agg_vals) {
-            if (agg_vals[tidx] != -1) {
-                return;
-            }
-            auto neighbor = strongest_neighbor_vals[tidx];
-            if (neighbor != -1 && strongest_neighbor_vals[neighbor] == tidx &&
-                tidx <= neighbor) {
-                // Use the smaller index as agg point
-                agg_vals[tidx] = tidx;
-                agg_vals[neighbor] = tidx;
-            }
-        },
-        agg.get_size(), strongest_neighbor.get_const_data(), agg.get_data());
-}
-
-GKO_INSTANTIATE_FOR_EACH_INDEX_TYPE(GKO_DECLARE_PGM_MATCH_EDGE_KERNEL);
-
-
-template <typename IndexType>
 void count_unagg(std::shared_ptr<const DefaultExecutor> exec,
                  const array<IndexType>& agg, IndexType* num_unagg)
 {

--- a/core/test/utils/batch_helpers.hpp
+++ b/core/test/utils/batch_helpers.hpp
@@ -105,7 +105,7 @@ std::unique_ptr<MatrixType> generate_3pt_stencil_batch_matrix(
         {}};
     for (int row = 0; row < num_rows; ++row) {
         if (row > 0) {
-            data.nonzeros.emplace_back(row - 1, row, value_type{-1.0});
+            data.nonzeros.emplace_back(row, row - 1, value_type{-1.0});
         }
         data.nonzeros.emplace_back(row, row, value_type{6.0});
         if (row < num_rows - 1) {

--- a/dpcpp/components/atomic.dp.hpp
+++ b/dpcpp/components/atomic.dp.hpp
@@ -278,6 +278,31 @@ __dpct_inline__ T atomic_max(T* __restrict__ addr, T val)
 }
 
 
+template <sycl::access::address_space addressSpace = atomic::global_space,
+          typename T>
+__dpct_inline__ void store(
+    T* __restrict__ addr, T val,
+    sycl::memory_order memoryOrder = sycl::memory_order::relaxed)
+{
+    sycl::atomic_ref<T, sycl::memory_order::relaxed,
+                     atomic::memory_scope_v<addressSpace>, addressSpace>
+        obj(*addr);
+    obj.store(val, memoryOrder);
+}
+
+
+template <sycl::access::address_space addressSpace = atomic::global_space,
+          typename T>
+__dpct_inline__ T load(T* __restrict__ addr, sycl::memory_order memoryOrder =
+                                                 sycl::memory_order::relaxed)
+{
+    sycl::atomic_ref<T, sycl::memory_order::relaxed,
+                     atomic::memory_scope_v<addressSpace>, addressSpace>
+        obj(*addr);
+    return obj.load(memoryOrder);
+}
+
+
 }  // namespace dpcpp
 }  // namespace kernels
 }  // namespace gko

--- a/omp/components/atomic.hpp
+++ b/omp/components/atomic.hpp
@@ -100,6 +100,18 @@ inline void store(float* addr, float val)
     *addr = val;
 }
 
+inline void store(int32* addr, int32 val)
+{
+#pragma omp atomic write
+    *addr = val;
+}
+
+inline void store(int64* addr, int64 val)
+{
+#pragma omp atomic write
+    *addr = val;
+}
+
 inline void store(half* addr, half val)
 {
     auto uint_addr = copy_cast<uint16_t*>(addr);
@@ -129,6 +141,22 @@ inline float load(float* addr)
 inline double load(double* addr)
 {
     double val;
+#pragma omp atomic read
+    val = *addr;
+    return val;
+}
+
+inline int32 load(int32* addr)
+{
+    float val;
+#pragma omp atomic read
+    val = *addr;
+    return val;
+}
+
+inline int64 load(int64* addr)
+{
+    float val;
 #pragma omp atomic read
     val = *addr;
     return val;

--- a/omp/components/atomic.hpp
+++ b/omp/components/atomic.hpp
@@ -52,7 +52,7 @@ inline ResultType copy_cast(const ValueType& val)
 
 
 template <>
-void atomic_add(half& out, half val)
+inline void atomic_add(half& out, half val)
 {
 #ifdef __NVCOMPILER
 // NVC++ uses atomic capture on uint16 leads the following error.
@@ -82,6 +82,72 @@ void atomic_add(half& out, half val)
         }
     } while (assumed != old);
 #endif
+}
+
+
+// There is an error in Clang 17 which prevents us from merging the
+// implementation of double and float. The compiler will throw an error if the
+// templated version is implemented. GCC doesn't throw an error.
+inline void store(double* addr, double val)
+{
+#pragma omp atomic write
+    *addr = val;
+}
+
+inline void store(float* addr, float val)
+{
+#pragma omp atomic write
+    *addr = val;
+}
+
+inline void store(half* addr, half val)
+{
+    auto uint_addr = copy_cast<uint16_t*>(addr);
+    auto uint_val = copy_cast<uint16_t>(val);
+#pragma omp atomic write
+    *uint_addr = uint_val;
+}
+
+template <typename T>
+inline void store(std::complex<T>* addr, std::complex<T> val)
+{
+    auto values = reinterpret_cast<T*>(addr);
+    store(values + 0, real(val));
+    store(values + 1, imag(val));
+}
+
+
+// Same issue as with the store_helper
+inline float load(float* addr)
+{
+    float val;
+#pragma omp atomic read
+    val = *addr;
+    return val;
+}
+
+inline double load(double* addr)
+{
+    double val;
+#pragma omp atomic read
+    val = *addr;
+    return val;
+}
+
+inline half load(half* addr)
+{
+    uint16_t uint_val;
+    auto uint_addr = copy_cast<uint16_t*>(addr);
+#pragma omp atomic read
+    uint_val = *uint_addr;
+    return copy_cast<half>(uint_val);
+}
+
+template <typename T>
+inline std::complex<T> load(std::complex<T>* addr)
+{
+    auto values = reinterpret_cast<T*>(addr);
+    return {load(values + 0), load(values + 1)};
 }
 
 

--- a/omp/factorization/par_ic_kernels.cpp
+++ b/omp/factorization/par_ic_kernels.cpp
@@ -9,6 +9,7 @@
 #include <ginkgo/core/matrix/csr.hpp>
 
 #include "core/base/utils.hpp"
+#include "omp/components/atomic.hpp"
 
 
 namespace gko {
@@ -76,7 +77,8 @@ void compute_factor(std::shared_ptr<const DefaultExecutor> exec,
                     auto l_col = l_col_idxs[l_begin];
                     auto lh_row = l_col_idxs[lh_begin];
                     if (l_col == lh_row && l_col < col) {
-                        sum += l_vals[l_begin] * conj(l_vals[lh_begin]);
+                        sum += load(l_vals + l_begin) *
+                               conj(load(l_vals + lh_begin));
                     }
                     l_begin += (l_col <= lh_row);
                     lh_begin += (lh_row <= l_col);
@@ -85,11 +87,11 @@ void compute_factor(std::shared_ptr<const DefaultExecutor> exec,
                 if (row == col) {
                     new_val = sqrt(new_val);
                 } else {
-                    auto diag = l_vals[l_row_ptrs[col + 1] - 1];
+                    auto diag = load(l_vals + l_row_ptrs[col + 1] - 1);
                     new_val = new_val / diag;
                 }
                 if (is_finite(new_val)) {
-                    l_vals[l_nz] = new_val;
+                    store(l_vals + l_nz, new_val);
                 }
             }
         }

--- a/omp/matrix/sparsity_csr_kernels.cpp
+++ b/omp/matrix/sparsity_csr_kernels.cpp
@@ -183,11 +183,14 @@ void is_sorted_by_column_index(
     bool local_is_sorted = true;
 #pragma omp parallel for shared(local_is_sorted)
     for (size_type i = 0; i < size[0]; ++i) {
-#pragma omp flush(local_is_sorted)
         // Skip comparison if any thread detects that it is not sorted
-        if (local_is_sorted) {
+        bool sync_local_is_sorted = true;
+#pragma omp atomic read
+        sync_local_is_sorted = local_is_sorted;
+        if (sync_local_is_sorted) {
             for (auto idx = row_ptrs[i] + 1; idx < row_ptrs[i + 1]; ++idx) {
                 if (col_idxs[idx - 1] > col_idxs[idx]) {
+#pragma omp atomic write
                     local_is_sorted = false;
                     break;
                 }

--- a/omp/solver/multigrid_kernels.cpp
+++ b/omp/solver/multigrid_kernels.cpp
@@ -84,9 +84,10 @@ void kcycle_check_stop(std::shared_ptr<const DefaultExecutor> exec,
                        const ValueType rel_tol, bool& is_stop)
 {
     is_stop = true;
-#pragma omp parallel for
+#pragma omp parallel for shared(is_stop)
     for (size_type i = 0; i < old_norm->get_size()[1]; i++) {
         if (new_norm->at(0, i) > rel_tol * old_norm->at(0, i)) {
+#pragma omp atomic write
             is_stop = false;
         }
     }

--- a/reference/test/solver/batch_bicgstab_kernels.cpp
+++ b/reference/test/solver/batch_bicgstab_kernels.cpp
@@ -62,7 +62,7 @@ protected:
     }
 
     std::shared_ptr<const gko::ReferenceExecutor> exec;
-    const real_type eps = 1e-3;
+    const real_type eps = 5e-3;
     const gko::size_type num_batch_items = 2;
     const int num_rows = 15;
     const int num_rhs = 1;
@@ -147,7 +147,7 @@ TYPED_TEST(BatchBicgstab, CanSolveDenseSystem)
     using real_type = gko::remove_complex<value_type>;
     using Solver = typename TestFixture::solver_type;
     using Mtx = typename TestFixture::Mtx;
-    const real_type tol = 1e-4;
+    const real_type tol = 1e-3;
     const int max_iters = 1000;
     auto solver_factory =
         Solver::build()
@@ -227,7 +227,7 @@ TYPED_TEST(BatchBicgstab, CanSolveEllSystem)
     using real_type = gko::remove_complex<value_type>;
     using Solver = typename TestFixture::solver_type;
     using Mtx = typename TestFixture::EllMtx;
-    const real_type tol = 1e-4;
+    const real_type tol = 1e-3;
     const int max_iters = 1000;
     auto solver_factory =
         Solver::build()
@@ -263,7 +263,7 @@ TYPED_TEST(BatchBicgstab, CanSolveCsrSystem)
     using real_type = gko::remove_complex<value_type>;
     using Solver = typename TestFixture::solver_type;
     using Mtx = typename TestFixture::CsrMtx;
-    const real_type tol = 1e-4;
+    const real_type tol = 1e-3;
     const int max_iters = 1000;
     auto solver_factory =
         Solver::build()


### PR DESCRIPTION
This PR includes fixes for errors reported by the TSAN. The changes include:

- RCM: locking the write mutex when checking the queue size 
- SparsityCsr: using atomic load/store when checking of other threads report that the matrix is unsorted
- Par IC/ILU (t): use atomic load/stores in the same way as the CUDA/HIP implementations
- MG: 'fix' a write-after-write race in the kcycle stopping criteria. Honestly, I don't think this is necessary, but it stops TSAN from complaining.
- Batch Solvers: fixed the generation of the 3pt stencil matrix for tests, which caused data races.
- NOT FIXED: the PGM contains data races in the `match_edge` function. I didn't fix this, since that would require to extract the common kernels implementations into each backend, which I found a bit overkill. There is also a data race in the non-deterministic part of `assign_to_exist_agg`, but I ignored that, since it is marked as non-deterministic anyway.