### PR TITLE
disable half precision in msys2 (mingw)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,9 +44,9 @@ option(GINKGO_FAST_TESTS "Reduces the input size for a few tests known to be tim
 option(GINKGO_TEST_NONDEFAULT_STREAM "Uses non-default streams in CUDA and HIP tests" OFF)
 option(GINKGO_MIXED_PRECISION "Instantiate true mixed-precision kernels (otherwise they will be conversion-based using implicit temporary storage)" OFF)
 option(GINKGO_ENABLE_HALF "Enable the use of half precision" ON)
-# We do not support half precision in MSVC.
-if(MSVC)
-    message(STATUS "We do not support half precision in MSVC.")
+# We do not support half precision in MSVC and msys2 (MINGW).
+if(MSVC OR MINGW)
+    message(STATUS "We do not support half precision in MSVC and MINGW.")
     set(GINKGO_ENABLE_HALF OFF CACHE BOOL "Enable the use of half precision" FORCE)
 endif()
 option(GINKGO_SKIP_DEPENDENCY_UPDATE

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -26,7 +26,7 @@ Ginkgo adds the following additional switches to control what is being built:
     Enabling this flag increases the library size, but improves performance of
     mixed-precision kernels.
 *   `-DGINKGO_ENABLE_HALF={ON, OFF}` enable half precision support in Ginkgo, default is `ON`.
-    It is `OFF` when the compiler is MSVC. If compiling is done with the CUDA backend before CUDA 12.2, 
+    It is `OFF` when the compiler is MSVC or MSYS2 system. If compiling is done with the CUDA backend before CUDA 12.2, 
     we only support half precision after compute capability 5.3. CUDA 12.2+ compilers waive the compute capbility limitation.
 *   `-DGINKGO_BUILD_TESTS={ON, OFF}` builds Ginkgo's tests
     (will download googletest), default is `ON`.


### PR DESCRIPTION
As https://github.com/ginkgo-project/ginkgo/issues/1749, we do not support half precision in MSVC and MSYS2(MINGW) in Windows.
This PR disables it on these platforms