### PR TITLE
only use mkl dense gemm when all value pointers are valid

### DIFF
--- a/dpcpp/matrix/dense_kernels.dp.cpp
+++ b/dpcpp/matrix/dense_kernels.dp.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -223,7 +223,8 @@ void simple_apply(std::shared_ptr<const DefaultExecutor> exec,
     using namespace oneapi::mkl;
     if constexpr (onemkl::is_supported<ValueType>::value) {
         if (b->get_stride() != 0 && c->get_stride() != 0) {
-            if (a->get_size()[1] > 0) {
+            if (a->get_size()[1] > 0 && a->get_const_values() &&
+                b->get_const_values() && c->get_const_values()) {
                 oneapi::mkl::blas::row_major::gemm(
                     *exec->get_queue(), transpose::nontrans,
                     transpose::nontrans, c->get_size()[0], c->get_size()[1],
@@ -253,7 +254,8 @@ void apply(std::shared_ptr<const DefaultExecutor> exec,
     using namespace oneapi::mkl;
     if constexpr (onemkl::is_supported<ValueType>::value) {
         if (b->get_stride() != 0 && c->get_stride() != 0) {
-            if (a->get_size()[1] > 0) {
+            if (a->get_size()[1] > 0 && a->get_const_values() &&
+                b->get_const_values() && c->get_const_values()) {
                 oneapi::mkl::blas::row_major::gemm(
                     *exec->get_queue(), transpose::nontrans,
                     transpose::nontrans, c->get_size()[0], c->get_size()[1],


### PR DESCRIPTION
We notice an page fault error from accessing nullptr in mkl dense gemm.
The issue happens when we pass empty matrix (nullptr) and only with single right hand side, but the routine seems to still access the pointer.
It only happens with rolling version of intel runtime library, which starts throwing error on page fault I guess, not long-term-support channel with icpx/oneMKL 2023.1.0 and 2025.0.4.
We simply avoid this issue by only calling mkl gemm when all data pointer are vaild.