### PR TITLE
Remove spurious space in examples/custom-stopping-criterion/doc/kind

### DIFF
--- a/examples/custom-stopping-criterion/doc/kind
+++ b/examples/custom-stopping-criterion/doc/kind
@@ -1,1 +1,1 @@
-stopping-criteria 
+stopping-criteria


### PR DESCRIPTION
With a space at the end of the file, building Gingko fails with this error:

```
[677/1178] Generating examples.hpp
FAILED: doc/examples/examples.hpp /build/ginkgo-hpc-git/src/build/doc/examples/examples.hpp
cd /build/ginkgo-hpc-git/src/build/doc/examples && /usr/bin/perl /build/ginkgo-hpc-git/src/ginkgo/doc/scripts/examples.pl /build/ginkgo-hpc-git/src/ginkgo/doc/examples/examples.hpp.in /build/ginkgo-hpc-git/src/ginkgo/examples/adaptiveprecision-blockjacobi /build/ginkgo-hpc-git/src/ginkgo/examples/batched-solver /build/ginkgo-hpc-git/src/ginkgo/examples/cb-gmres /build/ginkgo-hpc-git/src/ginkgo/examples/custom-logger /build/ginkgo-hpc-git/src/ginkgo/examples/custom-matrix-format /build/ginkgo-hpc-git/src/ginkgo/examples/custom-stopping-criterion /build/ginkgo-hpc-git/src/ginkgo/examples/distributed-solver /build/ginkgo-hpc-git/src/ginkgo/examples/external-lib-interfacing /build/ginkgo-hpc-git/src/ginkgo/examples/file-config-solver /build/ginkgo-hpc-git/src/ginkgo/examples/ginkgo-overhead /build/ginkgo-hpc-git/src/ginkgo/examples/ginkgo-ranges /build/ginkgo-hpc-git/src/ginkgo/examples/heat-equation /build/ginkgo-hpc-git/src/ginkgo/examples/ilu-preconditioned-solver /build/ginkgo-hpc-git/src/ginkgo/examples/inverse-iteration /build/ginkgo-hpc-git/src/ginkgo/examples/ir-ilu-preconditioned-solver /build/ginkgo-hpc-git/src/ginkgo/examples/iterative-refinement /build/ginkgo-hpc-git/src/ginkgo/examples/kokkos-assembly /build/ginkgo-hpc-git/src/ginkgo/examples/minimal-cuda-solver /build/ginkgo-hpc-git/src/ginkgo/examples/mixed-multigrid-preconditioned-solver /build/ginkgo-hpc-git/src/ginkgo/examples/mixed-multigrid-solver /build/ginkgo-hpc-git/src/ginkgo/examples/mixed-precision-ir /build/ginkgo-hpc-git/src/ginkgo/examples/mixed-spmv /build/ginkgo-hpc-git/src/ginkgo/examples/multigrid-preconditioned-solver /build/ginkgo-hpc-git/src/ginkgo/examples/multigrid-preconditioned-solver-customized /build/ginkgo-hpc-git/src/ginkgo/examples/nine-pt-stencil-solver /build/ginkgo-hpc-git/src/ginkgo/examples/papi-logging /build/ginkgo-hpc-git/src/ginkgo/examples/par-ilu-convergence /build/ginkgo-hpc-git/src/ginkgo/examples/performance-debugging /build/ginkgo-hpc-git/src/ginkgo/examples/poisson-solver /build/ginkgo-hpc-git/src/ginkgo/examples/preconditioned-solver /build/ginkgo-hpc-git/src/ginkgo/examples/preconditioner-export /build/ginkgo-hpc-git/src/ginkgo/examples/reordered-preconditioned-solver /build/ginkgo-hpc-git/src/ginkgo/examples/schroedinger-splitting /build/ginkgo-hpc-git/src/ginkgo/examples/simple-solver /build/ginkgo-hpc-git/src/ginkgo/examples/simple-solver-logging /build/ginkgo-hpc-git/src/ginkgo/examples/three-pt-stencil-solver > /build/ginkgo-hpc-git/src/build/doc/examples/examples.hpp
Unknown kind 'stopping-criteria ' in file /build/ginkgo-hpc-git/src/ginkgo/examples/custom-stopping-criterion/doc/kind at /build/ginkgo-hpc-git/src/ginkgo/doc/scripts/examples.pl line 90.
```

Fixes f132fb16246b5f4ba9d95c991d9872af69c30d56