### PR TITLE
Fall back to ILU/IC sparselib algorithm with CPU executors

### DIFF
--- a/core/factorization/ic.cpp
+++ b/core/factorization/ic.cpp
@@ -103,7 +103,8 @@ std::unique_ptr<Composition<ValueType>> Ic<ValueType, IndexType>::generate(
 
     std::shared_ptr<const matrix_type> ic;
     // Compute LC factorization
-    if (parameters_.algorithm == incomplete_algorithm::syncfree) {
+    if (parameters_.algorithm == incomplete_algorithm::syncfree ||
+        exec == exec->get_master()) {
         std::unique_ptr<gko::factorization::elimination_forest<IndexType>>
             forest;
         const auto nnz = local_system_matrix->get_num_stored_elements();
@@ -143,11 +144,6 @@ std::unique_ptr<Composition<ValueType>> Ic<ValueType, IndexType>::generate(
             diag_idxs.get_const_data(), transpose_idxs.get_const_data(),
             *forest, factors.get(), false, tmp));
         ic = factors;
-    } else if (std::dynamic_pointer_cast<const OmpExecutor>(exec) &&
-               !std::dynamic_pointer_cast<const ReferenceExecutor>(exec)) {
-        GKO_INVALID_STATE(
-            "OmpExecutor does not support sparselib algorithm. Please use "
-            "syncfree algorithm.");
     } else {
         exec->run(
             ic_factorization::make_sparselib_ic(local_system_matrix.get()));

--- a/test/factorization/ic_kernels.cpp
+++ b/test/factorization/ic_kernels.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -149,22 +149,6 @@ TEST_F(Ic, SetsCorrectStrategy)
 }
 
 
-#ifdef GKO_COMPILING_OMP
-
-
-TEST_F(Ic, OmpComputeICBySparselibShouldThrow)
-{
-    ASSERT_THROW(gko::factorization::Ic<>::build()
-                     .with_skip_sorting(true)
-                     .on(exec)
-                     ->generate(dmtx),
-                 gko::InvalidStateError);
-}
-
-
-#else
-
-
 TEST_F(Ic, ComputeICIsEquivalentToRefSorted)
 {
     auto fact = gko::factorization::Ic<>::build()
@@ -196,5 +180,3 @@ TEST_F(Ic, ComputeICIsEquivalentToRefUnsorted)
     GKO_ASSERT_MTX_EQ_SPARSITY(fact->get_l_factor(), dfact->get_l_factor());
     GKO_ASSERT_MTX_EQ_SPARSITY(fact->get_lt_factor(), dfact->get_lt_factor());
 }
-
-#endif

--- a/test/factorization/ilu_kernels.cpp
+++ b/test/factorization/ilu_kernels.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -153,22 +153,6 @@ TEST_F(Ilu, SetsCorrectStrategy)
 }
 
 
-#ifdef GKO_COMPILING_OMP
-
-
-TEST_F(Ilu, OmpComputeILUBySparselibShouldThrow)
-{
-    ASSERT_THROW(gko::factorization::Ilu<>::build()
-                     .with_skip_sorting(true)
-                     .on(exec)
-                     ->generate(dmtx),
-                 gko::InvalidStateError);
-}
-
-
-#else
-
-
 TEST_F(Ilu, ComputeILUIsEquivalentToRefSorted)
 {
     auto fact = gko::factorization::Ilu<>::build()
@@ -200,6 +184,3 @@ TEST_F(Ilu, ComputeILUIsEquivalentToRefUnsorted)
     GKO_ASSERT_MTX_EQ_SPARSITY(fact->get_l_factor(), dfact->get_l_factor());
     GKO_ASSERT_MTX_EQ_SPARSITY(fact->get_u_factor(), dfact->get_u_factor());
 }
-
-
-#endif


### PR DESCRIPTION
There is no reason to make the distinction between algorithms when we only have a single one available. This issue was found when running the custom multigrid example with OpenMP