### PR TITLE
Add logger for benchmark work estimate output

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -42,6 +42,7 @@ target_sources(${ginkgo_core}
     base/segmented_array.cpp
     base/timer.cpp
     base/version.cpp
+    base/work_estimate.cpp
     components/range_minimum_query.cpp
     config/config.cpp
     config/config_helper.cpp

--- a/core/base/work_estimate.cpp
+++ b/core/base/work_estimate.cpp
@@ -1,0 +1,68 @@
+// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
+//
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include <ginkgo/core/base/work_estimate.hpp>
+
+
+namespace gko {
+
+
+compute_bound_work_estimate operator+(compute_bound_work_estimate a,
+                                      compute_bound_work_estimate b)
+{
+    return {a.flops + b.flops};
+}
+
+
+compute_bound_work_estimate& compute_bound_work_estimate::operator+=(
+    compute_bound_work_estimate other)
+{
+    *this = *this + other;
+    return *this;
+}
+
+
+memory_bound_work_estimate operator+(memory_bound_work_estimate a,
+                                     memory_bound_work_estimate b)
+{
+    return {a.bytes_read + b.bytes_read, a.bytes_written + b.bytes_written};
+}
+
+
+memory_bound_work_estimate& memory_bound_work_estimate::operator+=(
+    memory_bound_work_estimate other)
+{
+    *this = *this + other;
+    return *this;
+}
+
+
+custom_work_estimate operator+(custom_work_estimate a, custom_work_estimate b)
+{
+    GKO_ASSERT(a.operation_count_name == b.operation_count_name);
+    return {a.operation_count_name, a.operations + b.operations};
+}
+
+
+custom_work_estimate& custom_work_estimate::operator+=(
+    custom_work_estimate other)
+{
+    *this = *this + other;
+    return *this;
+}
+
+
+kernel_work_estimate operator+(kernel_work_estimate a, kernel_work_estimate b)
+{
+    // this fails with std::bad_variant_access if the two estimates are of
+    // different types
+    return std::visit(
+        [b](auto a) -> kernel_work_estimate {
+            return a + std::get<decltype(a)>(b);
+        },
+        a);
+}
+
+
+}  // namespace gko

--- a/core/components/prefix_sum_kernels.hpp
+++ b/core/components/prefix_sum_kernels.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -10,6 +10,7 @@
 
 #include <ginkgo/core/base/executor.hpp>
 #include <ginkgo/core/base/types.hpp>
+#include <ginkgo/core/base/work_estimate.hpp>
 
 #include "core/base/kernel_declaration.hpp"
 
@@ -53,6 +54,19 @@ GKO_DECLARE_FOR_ALL_EXECUTOR_NAMESPACES(components,
 #undef GKO_DECLARE_ALL_AS_TEMPLATES
 
 
+namespace work_estimate::components {
+
+
+template <typename IndexType>
+kernel_work_estimate prefix_sum_nonnegative(IndexType* counts,
+                                            size_type num_entries)
+{
+    return memory_bound_work_estimate{num_entries * sizeof(IndexType),
+                                      num_entries * sizeof(IndexType)};
+}
+
+
+}  // namespace work_estimate::components
 }  // namespace kernels
 }  // namespace gko
 

--- a/core/factorization/ic.cpp
+++ b/core/factorization/ic.cpp
@@ -103,7 +103,8 @@ std::unique_ptr<Composition<ValueType>> Ic<ValueType, IndexType>::generate(
 
     std::shared_ptr<const matrix_type> ic;
     // Compute LC factorization
-    if (parameters_.algorithm == incomplete_algorithm::syncfree) {
+    if (parameters_.algorithm == incomplete_algorithm::syncfree ||
+        exec == exec->get_master()) {
         std::unique_ptr<gko::factorization::elimination_forest<IndexType>>
             forest;
         const auto nnz = local_system_matrix->get_num_stored_elements();
@@ -143,11 +144,6 @@ std::unique_ptr<Composition<ValueType>> Ic<ValueType, IndexType>::generate(
             diag_idxs.get_const_data(), transpose_idxs.get_const_data(),
             *forest, factors.get(), false, tmp));
         ic = factors;
-    } else if (std::dynamic_pointer_cast<const OmpExecutor>(exec) &&
-               !std::dynamic_pointer_cast<const ReferenceExecutor>(exec)) {
-        GKO_INVALID_STATE(
-            "OmpExecutor does not support sparselib algorithm. Please use "
-            "syncfree algorithm.");
     } else {
         exec->run(
             ic_factorization::make_sparselib_ic(local_system_matrix.get()));

--- a/core/log/profiler_hook_summary.cpp
+++ b/core/log/profiler_hook_summary.cpp
@@ -393,6 +393,7 @@ ProfilerHook::nested_summary_entry build_tree(const nested_summary& summary)
         entry.name = summary.names[summary_node.name_id];
         entry.elapsed = summary_node.elapsed;
         entry.count = summary_node.count;
+        entry.work_estimate = summary_node.work_estimate;
         const auto child_range = child_ranges[summary_node.node_id];
         for (auto i = child_range.first; i < child_range.second; i++) {
             entry.children.emplace_back();

--- a/core/matrix/csr.cpp
+++ b/core/matrix/csr.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -83,8 +83,8 @@ GKO_REGISTER_OPERATION(is_sorted_by_column_index,
                        csr::is_sorted_by_column_index);
 GKO_REGISTER_OPERATION(extract_diagonal, csr::extract_diagonal);
 GKO_REGISTER_OPERATION(fill_array, components::fill_array);
-GKO_REGISTER_OPERATION(prefix_sum_nonnegative,
-                       components::prefix_sum_nonnegative);
+GKO_REGISTER_OPERATION_WITH_WORK_ESTIMATE(prefix_sum_nonnegative,
+                                          components::prefix_sum_nonnegative);
 GKO_REGISTER_OPERATION(inplace_absolute_array,
                        components::inplace_absolute_array);
 GKO_REGISTER_OPERATION(outplace_absolute_array,

--- a/core/matrix/dense.cpp
+++ b/core/matrix/dense.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -40,17 +40,18 @@ namespace dense {
 namespace {
 
 
-GKO_REGISTER_OPERATION(simple_apply, dense::simple_apply);
+GKO_REGISTER_OPERATION_WITH_WORK_ESTIMATE(simple_apply, dense::simple_apply);
 GKO_REGISTER_OPERATION(apply, dense::apply);
-GKO_REGISTER_OPERATION(copy, dense::copy);
-GKO_REGISTER_OPERATION(fill, dense::fill);
+GKO_REGISTER_OPERATION_WITH_WORK_ESTIMATE(copy, dense::copy);
+GKO_REGISTER_OPERATION_WITH_WORK_ESTIMATE(fill, dense::fill);
 GKO_REGISTER_OPERATION(scale, dense::scale);
 GKO_REGISTER_OPERATION(inv_scale, dense::inv_scale);
 GKO_REGISTER_OPERATION(add_scaled, dense::add_scaled);
 GKO_REGISTER_OPERATION(sub_scaled, dense::sub_scaled);
 GKO_REGISTER_OPERATION(add_scaled_diag, dense::add_scaled_diag);
 GKO_REGISTER_OPERATION(sub_scaled_diag, dense::sub_scaled_diag);
-GKO_REGISTER_OPERATION(compute_dot, dense::compute_dot_dispatch);
+GKO_REGISTER_OPERATION_WITH_WORK_ESTIMATE(compute_dot,
+                                          dense::compute_dot_dispatch);
 GKO_REGISTER_OPERATION(compute_conj_dot, dense::compute_conj_dot_dispatch);
 GKO_REGISTER_OPERATION(compute_norm2, dense::compute_norm2_dispatch);
 GKO_REGISTER_OPERATION(compute_norm1, dense::compute_norm1);

--- a/core/matrix/ell.cpp
+++ b/core/matrix/ell.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -42,8 +42,8 @@ GKO_REGISTER_OPERATION(convert_to_csr, ell::convert_to_csr);
 GKO_REGISTER_OPERATION(count_nonzeros_per_row, ell::count_nonzeros_per_row);
 GKO_REGISTER_OPERATION(extract_diagonal, ell::extract_diagonal);
 GKO_REGISTER_OPERATION(fill_array, components::fill_array);
-GKO_REGISTER_OPERATION(prefix_sum_nonnegative,
-                       components::prefix_sum_nonnegative);
+GKO_REGISTER_OPERATION_WITH_WORK_ESTIMATE(prefix_sum_nonnegative,
+                                          components::prefix_sum_nonnegative);
 GKO_REGISTER_OPERATION(inplace_absolute_array,
                        components::inplace_absolute_array);
 GKO_REGISTER_OPERATION(outplace_absolute_array,

--- a/core/matrix/hybrid.cpp
+++ b/core/matrix/hybrid.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -42,8 +42,8 @@ GKO_REGISTER_OPERATION(compute_coo_row_ptrs, hybrid::compute_coo_row_ptrs);
 GKO_REGISTER_OPERATION(convert_idxs_to_ptrs, components::convert_idxs_to_ptrs);
 GKO_REGISTER_OPERATION(convert_to_csr, hybrid::convert_to_csr);
 GKO_REGISTER_OPERATION(fill_array, components::fill_array);
-GKO_REGISTER_OPERATION(prefix_sum_nonnegative,
-                       components::prefix_sum_nonnegative);
+GKO_REGISTER_OPERATION_WITH_WORK_ESTIMATE(prefix_sum_nonnegative,
+                                          components::prefix_sum_nonnegative);
 GKO_REGISTER_OPERATION(inplace_absolute_array,
                        components::inplace_absolute_array);
 GKO_REGISTER_OPERATION(outplace_absolute_array,

--- a/core/matrix/sellp.cpp
+++ b/core/matrix/sellp.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -31,8 +31,8 @@ namespace {
 GKO_REGISTER_OPERATION(spmv, sellp::spmv);
 GKO_REGISTER_OPERATION(advanced_spmv, sellp::advanced_spmv);
 GKO_REGISTER_OPERATION(convert_idxs_to_ptrs, components::convert_idxs_to_ptrs);
-GKO_REGISTER_OPERATION(prefix_sum_nonnegative,
-                       components::prefix_sum_nonnegative);
+GKO_REGISTER_OPERATION_WITH_WORK_ESTIMATE(prefix_sum_nonnegative,
+                                          components::prefix_sum_nonnegative);
 GKO_REGISTER_OPERATION(compute_slice_sets, sellp::compute_slice_sets);
 GKO_REGISTER_OPERATION(fill_in_matrix_data, sellp::fill_in_matrix_data);
 GKO_REGISTER_OPERATION(fill_in_dense, sellp::fill_in_dense);

--- a/core/test/log/profiler_hook.cpp
+++ b/core/test/log/profiler_hook.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -10,6 +10,7 @@
 #include <gtest/gtest.h>
 
 #include <ginkgo/core/base/executor.hpp>
+#include <ginkgo/core/base/work_estimate.hpp>
 #include <ginkgo/core/log/profiler_hook.hpp>
 #include <ginkgo/core/solver/ir.hpp>
 #include <ginkgo/core/stop/iteration.hpp>
@@ -17,16 +18,44 @@
 #include "core/test/utils.hpp"
 
 
+std::string to_string(gko::memory_bound_work_estimate work)
+{
+    return "MB(" + std::to_string(work.bytes_read) + "," +
+           std::to_string(work.bytes_written) + ")";
+}
+
+std::string to_string(gko::compute_bound_work_estimate work)
+{
+    return "MB(" + std::to_string(work.flops) + ")";
+}
+
+std::string to_string(gko::custom_work_estimate work)
+{
+    return work.operation_count_name + "(" + std::to_string(work.operations) +
+           ")";
+}
+
+
 std::pair<gko::log::ProfilerHook::hook_function,
-          gko::log::ProfilerHook::hook_function>
+          gko::log::ProfilerHook::work_estimate_hook_function>
 make_hooks(std::vector<std::string>& output)
 {
     return std::make_pair(
         [&output](const char* msg, gko::log::profile_event_category) {
             output.push_back(std::string{"begin:"} + msg);
         },
-        [&output](const char* msg, gko::log::profile_event_category) {
-            output.push_back(std::string{"end:"} + msg);
+        [&output](const char* msg, gko::log::profile_event_category,
+                  std::optional<gko::kernel_work_estimate> work) {
+            if (work.has_value()) {
+                output.push_back(
+                    std::string{"end:"} + msg + "(" +
+                    std::visit([](auto work) { return to_string(work); },
+                               *work) +
+                    ")");
+
+            } else {
+                output.push_back(std::string{"end:"} + msg);
+            }
         });
 }
 
@@ -43,15 +72,21 @@ public:
 
     void run(std::shared_ptr<const gko::CudaExecutor>) const override {}
 
+    std::optional<gko::kernel_work_estimate> get_work_estimate() const override
+    {
+        return gko::memory_bound_work_estimate{100, 1};
+    }
+
     const char* get_name() const noexcept override { return "op"; }
 };
 
 
 TEST(ProfilerHook, LogsAllocateCopyOperation)
 {
-    std::vector<std::string> expected{
-        "begin:allocate", "end:allocate", "begin:copy", "end:copy",
-        "begin:op",       "end:op",       "begin:free", "end:free"};
+    std::vector<std::string> expected{"begin:allocate", "end:allocate",
+                                      "begin:copy",     "end:copy(MB(4,4))",
+                                      "begin:op",       "end:op(MB(100,1))",
+                                      "begin:free",     "end:free"};
     std::vector<std::string> output;
     auto hooks = make_hooks(output);
     auto exec = gko::ReferenceExecutor::create();
@@ -110,15 +145,15 @@ TEST(ProfilerHook, LogsPolymorphicObjectLinOp)
                                       "end:move(obj_copy,obj)",
                                       "begin:apply(obj)",
                                       "begin:op",
-                                      "end:op",
+                                      "end:op(MB(100,1))",
                                       "end:apply(obj)",
                                       "begin:advanced_apply(obj)",
                                       "begin:op",
-                                      "end:op",
+                                      "end:op(MB(100,1))",
                                       "end:advanced_apply(obj)",
                                       "begin:generate(obj_factory)",
                                       "begin:op",
-                                      "end:op",
+                                      "end:op(MB(100,1))",
                                       "end:generate(obj_factory)",
                                       "begin:check(nullptr)",
                                       "end:check(nullptr)"};
@@ -387,9 +422,7 @@ TEST(ProfilerHookTableSummaryWriter, SummaryWorks)
     entries.push_back({"medium", 1ms, 500us, 4});  // check division by count
     entries.push_back({"long", 120s, 60s, 1});
     entries.push_back({"eternal", 24h, 24h, 1});
-    // clang-format off
     const auto expected = R"(Test header
-Overhead estimate 1.0 ns
 |   name   | total  | total (self) | count |   avg    | avg (self) |
 |----------|-------:|-------------:|------:|---------:|-----------:|
 | eternal  | 1.0 d  |       1.0 d  |     1 |   1.0 d  |     1.0 d  |
@@ -398,8 +431,49 @@ Overhead estimate 1.0 ns
 | shortish | 1.2 us |       1.0 us |     1 |   1.2 us |     1.0 us |
 | short    | 1.0 ns |       0.0 ns |     1 |   1.0 ns |     0.0 ns |
 | empty    | 0.0 ns |       0.0 ns |     0 |   0.0 ns |     0.0 ns |
+Overhead estimate 1.0 ns
 )";
-    // clang-format on
+
+    writer.write(entries, 1ns);
+
+    ASSERT_EQ(ss.str(), expected);
+}
+
+
+TEST(ProfilerHookTableSummaryWriter, SummaryWorksWithWorkEstimate)
+{
+    using gko::log::ProfilerHook;
+    using mb_estimate = gko::memory_bound_work_estimate;
+    using cb_estimate = gko::compute_bound_work_estimate;
+    using cust_estimate = gko::custom_work_estimate;
+    using namespace std::chrono_literals;
+    std::stringstream ss;
+    ProfilerHook::TableSummaryWriter writer(ss, "Test header", true);
+    std::vector<ProfilerHook::summary_entry> entries;
+    entries.push_back({"total", 2s, 0ns, 1});
+    entries.push_back({"a", 1s, 1s, 1, mb_estimate{1, 0}});
+    entries.push_back({"b", 1ms, 1ms, 1, mb_estimate{1, 0}});
+    entries.push_back({"c", 1us, 1us, 1, mb_estimate{1, 0}});
+    entries.push_back({"d", 1ns, 1ns, 1, mb_estimate{1, 2}});
+    entries.push_back({"h", 1ns, 1ns, 1, mb_estimate{1000, 0}});
+    entries.push_back({"e", 1ns, 1ns, 1, mb_estimate{999'900, 0}});
+    entries.push_back({"f", 1ns, 1ns, 1, mb_estimate{999'990, 0}});
+    entries.push_back({"g", 1ns, 1ns, 1, cust_estimate{"NOPs", 1000'000}});
+    const auto expected = R"(Test header
+| name  | total  | total (self) | count |  avg   | avg (self) |  performance   |
+|-------|-------:|-------------:|------:|-------:|-----------:|---------------:|
+| total | 2.0 s  |       0.0 ns |     1 | 2.0 s  |     0.0 ns |                |
+| a     | 1.0 s  |       1.0 s  |     1 | 1.0 s  |     1.0 s  |       1.0  B/s |
+| b     | 1.0 ms |       1.0 ms |     1 | 1.0 ms |     1.0 ms |       1.0 kB/s |
+| c     | 1.0 us |       1.0 us |     1 | 1.0 us |     1.0 us |       1.0 MB/s |
+| d     | 1.0 ns |       1.0 ns |     1 | 1.0 ns |     1.0 ns |       3.0 GB/s |
+| h     | 1.0 ns |       1.0 ns |     1 | 1.0 ns |     1.0 ns |       1.0 TB/s |
+| e     | 1.0 ns |       1.0 ns |     1 | 1.0 ns |     1.0 ns |     999.9 TB/s |
+| f     | 1.0 ns |       1.0 ns |     1 | 1.0 ns |     1.0 ns |    1000.0 TB/s |
+| g     | 1.0 ns |       1.0 ns |     1 | 1.0 ns |     1.0 ns | 1000.0 TNOPs/s |
+Overhead estimate 1.0 ns
+Work estimates available for 50.1 % of runtime
+)";
 
     writer.write(entries, 1ns);
 
@@ -417,16 +491,16 @@ TEST(ProfilerHookTableSummaryWriter, NestedSummaryWorks)
         "root",
         2us,
         1,
-        {ProfilerHook::nested_summary_entry{"foo", 100ns, 5, {}},
+        {},
+        {ProfilerHook::nested_summary_entry{"foo", 100ns, 5},
          ProfilerHook::nested_summary_entry{
              "bar",
              1000ns,
              2,
-             {ProfilerHook::nested_summary_entry{"child", 100ns, 2, {}}}},
-         ProfilerHook::nested_summary_entry{"baz", 1ns, 2, {}}}};
-    // clang-format off
+             {},
+             {ProfilerHook::nested_summary_entry{"child", 100ns, 2}}},
+         ProfilerHook::nested_summary_entry{"baz", 1ns, 2}}};
     const auto expected = R"(Test header
-Overhead estimate 1.0 ns
 |    name    |  total   | fraction | count |   avg    |
 |------------|---------:|---------:|------:|---------:|
 | root       |   2.0 us |  100.0 % |     1 |   2.0 us |
@@ -436,8 +510,49 @@ Overhead estimate 1.0 ns
 |   (self)   | 899.0 ns |   45.0 % |     1 | 899.0 ns |
 |   foo      | 100.0 ns |    5.0 % |     5 |  20.0 ns |
 |   baz      |   1.0 ns |    0.1 % |     2 |   0.0 ns |
+Overhead estimate 1.0 ns
 )";
-    // clang-format on
+
+    writer.write_nested(entry, 1ns);
+
+    ASSERT_EQ(ss.str(), expected);
+}
+
+
+TEST(ProfilerHookTableSummaryWriter, NestedSummaryWorksWithWorkEstimate)
+{
+    using gko::log::ProfilerHook;
+    using namespace std::chrono_literals;
+    std::stringstream ss;
+    ProfilerHook::TableSummaryWriter writer(ss, "Test header", true);
+    ProfilerHook::nested_summary_entry entry{
+        "root",
+        2us,
+        1,
+        {},
+        {ProfilerHook::nested_summary_entry{
+             "foo", 100ns, 5, gko::custom_work_estimate{"Foos", 100}},
+         ProfilerHook::nested_summary_entry{
+             "bar",
+             1000ns,
+             2,
+             gko::compute_bound_work_estimate{900},
+             {ProfilerHook::nested_summary_entry{
+                 "child", 100ns, 2, gko::memory_bound_work_estimate{100, 0}}}},
+         ProfilerHook::nested_summary_entry{"baz", 1ns, 2}}};
+    const auto expected = R"(Test header
+|    name    |  total   | fraction | count |   avg    | performance  |
+|------------|---------:|---------:|------:|---------:|-------------:|
+| root       |   2.0 us |  100.0 % |     1 |   2.0 us |              |
+|   bar      |   1.0 us |   50.0 % |     2 | 500.0 ns | 1.0 GFLOPS/s |
+|     (self) | 900.0 ns |   90.0 % |     2 | 450.0 ns |              |
+|     child  | 100.0 ns |   10.0 % |     2 |  50.0 ns |     1.0 GB/s |
+|   (self)   | 899.0 ns |   45.0 % |     1 | 899.0 ns |              |
+|   foo      | 100.0 ns |    5.0 % |     5 |  20.0 ns |  1.0 GFoos/s |
+|   baz      |   1.0 ns |    0.1 % |     2 |   0.0 ns |              |
+Overhead estimate 1.0 ns
+Work estimates available for 55.0 % of runtime
+)";
 
     writer.write_nested(entry, 1ns);
 

--- a/dev_tools/scripts/update_ginkgo_header.sh
+++ b/dev_tools/scripts/update_ginkgo_header.sh
@@ -111,12 +111,6 @@ while IFS='' read -r line; do
             fi
 
             CURRENT_FOLDER="$(dirname "${file}")"
-            # add newline between different include folder
-            if [ "${READING_FIRST_LINE}" != true ] && \
-               [ "${CURRENT_FOLDER}" != "${PREVIOUS_FOLDER}" ]
-            then
-                echo -e "${END}" >> "${GINKGO_HEADER_TMP}"
-            fi
             PREVIOUS_FOLDER="${CURRENT_FOLDER}"
             echo -n "#include <${file}>" >> "${GINKGO_HEADER_TMP}"
             echo -e "${END}" >> "${GINKGO_HEADER_TMP}"

--- a/include/ginkgo/core/base/executor.hpp
+++ b/include/ginkgo/core/base/executor.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -23,6 +23,7 @@
 #include <ginkgo/core/base/memory.hpp>
 #include <ginkgo/core/base/scoped_device_id_guard.hpp>
 #include <ginkgo/core/base/types.hpp>
+#include <ginkgo/core/base/work_estimate.hpp>
 #include <ginkgo/core/log/logger.hpp>
 #include <ginkgo/core/synthesizer/containers.hpp>
 
@@ -273,6 +274,16 @@ public:
      * @return the operation's name
      */
     virtual const char* get_name() const noexcept;
+
+    /**
+     * Returns a work estimate for this operation.
+     *
+     * @return a work estimate for this operation, if available
+     */
+    virtual std::optional<kernel_work_estimate> get_work_estimate() const
+    {
+        return {};
+    }
 };
 
 
@@ -295,7 +306,8 @@ public:
      * Creates a RegisteredOperation object from a functor and a name.
      *
      * @param name  the name to be used for this operation
-     * @param op  a functor object which will be called with the executor.
+     * @param num_params  the number of parameters of the operation
+     * @param op  a functor object which will be called with the executor
      */
     RegisteredOperation(const char* name, Closure op)
         : name_(name), op_(std::move(op))
@@ -334,6 +346,34 @@ private:
 };
 
 
+template <typename OperationClosure, typename EstimateClosure>
+class RegisteredOperationWithWorkEstimate
+    : public RegisteredOperation<OperationClosure> {
+public:
+    /**
+     * Creates a RegisteredOperationWithWorkEstimate object from an operation
+     * and estimate functor and a name.
+     *
+     * @param name  the name to be used for this operation
+     * @param op  a functor object which will be called with the executor
+     * @param estimate  a functor object which will provide the work estimate
+     */
+    RegisteredOperationWithWorkEstimate(const char* name, OperationClosure op,
+                                        EstimateClosure estimate)
+        : RegisteredOperation<OperationClosure>{name, std::move(op)},
+          estimate_{std::move(estimate)}
+    {}
+
+    std::optional<kernel_work_estimate> get_work_estimate() const override
+    {
+        return estimate_();
+    }
+
+private:
+    EstimateClosure estimate_;
+};
+
+
 template <typename Closure>
 RegisteredOperation<Closure> make_register_operation(const char* name,
                                                      Closure op)
@@ -342,7 +382,62 @@ RegisteredOperation<Closure> make_register_operation(const char* name,
 }
 
 
+template <typename OperationClosure, typename EstimateClosure>
+RegisteredOperationWithWorkEstimate<OperationClosure, EstimateClosure>
+make_register_operation_with_estimate(const char* name, int num_params,
+                                      OperationClosure op,
+                                      EstimateClosure estimate)
+{
+    return RegisteredOperationWithWorkEstimate<OperationClosure,
+                                               EstimateClosure>{
+        name, std::move(op), std::move(estimate)};
+}
+
+
 }  // namespace detail
+
+
+/**
+ * Internal helper macro that provides the generic lambda to dispatch a kernel.
+ */
+#define GKO_REGISTER_OPERATION_GENERIC_LAMBDA(_name, _kernel, _args)          \
+    [&_args...](auto exec) {                                                  \
+        using exec_type = decltype(exec);                                     \
+        if (std::is_same<                                                     \
+                exec_type,                                                    \
+                std::shared_ptr<const ::gko::ReferenceExecutor>>::value) {    \
+            ::gko::kernels::reference::_kernel(                               \
+                std::dynamic_pointer_cast<const ::gko::ReferenceExecutor>(    \
+                    exec),                                                    \
+                std::forward<Args>(args)...);                                 \
+        } else if (std::is_same<                                              \
+                       exec_type,                                             \
+                       std::shared_ptr<const ::gko::OmpExecutor>>::value) {   \
+            ::gko::kernels::omp::_kernel(                                     \
+                std::dynamic_pointer_cast<const ::gko::OmpExecutor>(exec),    \
+                std::forward<Args>(args)...);                                 \
+        } else if (std::is_same<                                              \
+                       exec_type,                                             \
+                       std::shared_ptr<const ::gko::CudaExecutor>>::value) {  \
+            ::gko::kernels::cuda::_kernel(                                    \
+                std::dynamic_pointer_cast<const ::gko::CudaExecutor>(exec),   \
+                std::forward<Args>(args)...);                                 \
+        } else if (std::is_same<                                              \
+                       exec_type,                                             \
+                       std::shared_ptr<const ::gko::HipExecutor>>::value) {   \
+            ::gko::kernels::hip::_kernel(                                     \
+                std::dynamic_pointer_cast<const ::gko::HipExecutor>(exec),    \
+                std::forward<Args>(args)...);                                 \
+        } else if (std::is_same<                                              \
+                       exec_type,                                             \
+                       std::shared_ptr<const ::gko::DpcppExecutor>>::value) { \
+            ::gko::kernels::dpcpp::_kernel(                                   \
+                std::dynamic_pointer_cast<const ::gko::DpcppExecutor>(exec),  \
+                std::forward<Args>(args)...);                                 \
+        } else {                                                              \
+            GKO_NOT_IMPLEMENTED;                                              \
+        }                                                                     \
+    }
 
 
 /**
@@ -416,60 +511,16 @@ RegisteredOperation<Closure> make_register_operation(const char* name,
  *
  * @ingroup Executor
  */
-#define GKO_REGISTER_OPERATION(_name, _kernel)                                 \
-    template <typename... Args>                                                \
-    auto make_##_name(Args&&... args)                                          \
-    {                                                                          \
-        return ::gko::detail::make_register_operation(                         \
-            #_kernel, [&args...](auto exec) {                                  \
-                using exec_type = decltype(exec);                              \
-                if (std::is_same<                                              \
-                        exec_type,                                             \
-                        std::shared_ptr<const ::gko::ReferenceExecutor>>::     \
-                        value) {                                               \
-                    ::gko::kernels::reference::_kernel(                        \
-                        std::dynamic_pointer_cast<                             \
-                            const ::gko::ReferenceExecutor>(exec),             \
-                        std::forward<Args>(args)...);                          \
-                } else if (std::is_same<                                       \
-                               exec_type,                                      \
-                               std::shared_ptr<const ::gko::OmpExecutor>>::    \
-                               value) {                                        \
-                    ::gko::kernels::omp::_kernel(                              \
-                        std::dynamic_pointer_cast<const ::gko::OmpExecutor>(   \
-                            exec),                                             \
-                        std::forward<Args>(args)...);                          \
-                } else if (std::is_same<                                       \
-                               exec_type,                                      \
-                               std::shared_ptr<const ::gko::CudaExecutor>>::   \
-                               value) {                                        \
-                    ::gko::kernels::cuda::_kernel(                             \
-                        std::dynamic_pointer_cast<const ::gko::CudaExecutor>(  \
-                            exec),                                             \
-                        std::forward<Args>(args)...);                          \
-                } else if (std::is_same<                                       \
-                               exec_type,                                      \
-                               std::shared_ptr<const ::gko::HipExecutor>>::    \
-                               value) {                                        \
-                    ::gko::kernels::hip::_kernel(                              \
-                        std::dynamic_pointer_cast<const ::gko::HipExecutor>(   \
-                            exec),                                             \
-                        std::forward<Args>(args)...);                          \
-                } else if (std::is_same<                                       \
-                               exec_type,                                      \
-                               std::shared_ptr<const ::gko::DpcppExecutor>>::  \
-                               value) {                                        \
-                    ::gko::kernels::dpcpp::_kernel(                            \
-                        std::dynamic_pointer_cast<const ::gko::DpcppExecutor>( \
-                            exec),                                             \
-                        std::forward<Args>(args)...);                          \
-                } else {                                                       \
-                    GKO_NOT_IMPLEMENTED;                                       \
-                }                                                              \
-            });                                                                \
-    }                                                                          \
-    static_assert(true,                                                        \
-                  "This assert is used to counter the false positive extra "   \
+#define GKO_REGISTER_OPERATION(_name, _kernel)                               \
+    template <typename... Args>                                              \
+    auto make_##_name(Args&&... args)                                        \
+    {                                                                        \
+        return ::gko::detail::make_register_operation(                       \
+            #_kernel,                                                        \
+            GKO_REGISTER_OPERATION_GENERIC_LAMBDA(_name, _kernel, args));    \
+    }                                                                        \
+    static_assert(true,                                                      \
+                  "This assert is used to counter the false positive extra " \
                   "semi-colon warnings")
 
 
@@ -520,6 +571,22 @@ RegisteredOperation<Closure> make_register_operation(const char* name,
     }                                                                        \
     static_assert(true,                                                      \
                   "This assert is used to counter the false positive extra " \
+                  "semi-colon warnings")
+
+
+#define GKO_REGISTER_OPERATION_WITH_WORK_ESTIMATE(_name, _kernel)              \
+    template <typename... Args>                                                \
+    auto make_##_name(Args&&... args)                                          \
+    {                                                                          \
+        return ::gko::detail::make_register_operation_with_estimate(           \
+            #_kernel, sizeof...(Args),                                         \
+            GKO_REGISTER_OPERATION_GENERIC_LAMBDA(_name, _kernel, args), [&] { \
+                return ::gko::kernels::work_estimate::_kernel(                 \
+                    std::forward<Args>(args)...);                              \
+            });                                                                \
+    }                                                                          \
+    static_assert(true,                                                        \
+                  "This assert is used to counter the false positive extra "   \
                   "semi-colon warnings")
 
 

--- a/include/ginkgo/core/base/work_estimate.hpp
+++ b/include/ginkgo/core/base/work_estimate.hpp
@@ -1,0 +1,63 @@
+// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
+//
+// SPDX-License-Identifier: BSD-3-Clause
+
+#ifndef GKO_PUBLIC_CORE_BASE_WORK_ESTIMATE_HPP_
+#define GKO_PUBLIC_CORE_BASE_WORK_ESTIMATE_HPP_
+
+
+#include <variant>
+
+#include <ginkgo/core/base/types.hpp>
+
+
+namespace gko {
+
+
+/** Work estimate for a kernel that is likely compute-bound. */
+struct compute_bound_work_estimate {
+    size_type flops;
+
+    friend compute_bound_work_estimate operator+(compute_bound_work_estimate a,
+                                                 compute_bound_work_estimate b);
+
+    compute_bound_work_estimate& operator+=(compute_bound_work_estimate other);
+};
+
+
+/** Work estimate for a kernel that is likely memory-bound. */
+struct memory_bound_work_estimate {
+    size_type bytes_read;
+    size_type bytes_written;
+
+    friend memory_bound_work_estimate operator+(memory_bound_work_estimate a,
+                                                memory_bound_work_estimate b);
+
+    memory_bound_work_estimate& operator+=(memory_bound_work_estimate other);
+};
+
+
+/** Work estimate based on a custom operation count. */
+struct custom_work_estimate {
+    std::string operation_count_name;
+    size_type operations;
+
+    friend custom_work_estimate operator+(custom_work_estimate a,
+                                          custom_work_estimate b);
+
+    custom_work_estimate& operator+=(custom_work_estimate other);
+};
+
+
+using kernel_work_estimate =
+    std::variant<compute_bound_work_estimate, memory_bound_work_estimate,
+                 custom_work_estimate>;
+
+
+kernel_work_estimate operator+(kernel_work_estimate a, kernel_work_estimate b);
+
+
+}  // namespace gko
+
+
+#endif  // GKO_PUBLIC_CORE_BASE_WORK_ESTIMATE_HPP_

--- a/include/ginkgo/ginkgo.hpp
+++ b/include/ginkgo/ginkgo.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -7,8 +7,6 @@
 
 
 #include <ginkgo/config.hpp>
-
-
 #include <ginkgo/core/base/abstract_factory.hpp>
 #include <ginkgo/core/base/array.hpp>
 #include <ginkgo/core/base/batch_dim.hpp>
@@ -53,24 +51,19 @@
 #include <ginkgo/core/base/utils.hpp>
 #include <ginkgo/core/base/utils_helper.hpp>
 #include <ginkgo/core/base/version.hpp>
-
 #include <ginkgo/core/config/config.hpp>
 #include <ginkgo/core/config/property_tree.hpp>
 #include <ginkgo/core/config/registry.hpp>
 #include <ginkgo/core/config/type_descriptor.hpp>
-
 #include <ginkgo/core/distributed/assembly.hpp>
 #include <ginkgo/core/distributed/base.hpp>
 #include <ginkgo/core/distributed/index_map.hpp>
 #include <ginkgo/core/distributed/matrix.hpp>
 #include <ginkgo/core/distributed/partition.hpp>
 #include <ginkgo/core/distributed/partition_helpers.hpp>
-
 #include <ginkgo/core/distributed/preconditioner/schwarz.hpp>
-
 #include <ginkgo/core/distributed/vector.hpp>
 #include <ginkgo/core/distributed/vector_cache.hpp>
-
 #include <ginkgo/core/factorization/cholesky.hpp>
 #include <ginkgo/core/factorization/factorization.hpp>
 #include <ginkgo/core/factorization/ic.hpp>
@@ -81,7 +74,6 @@
 #include <ginkgo/core/factorization/par_ict.hpp>
 #include <ginkgo/core/factorization/par_ilu.hpp>
 #include <ginkgo/core/factorization/par_ilut.hpp>
-
 #include <ginkgo/core/log/batch_logger.hpp>
 #include <ginkgo/core/log/convergence.hpp>
 #include <ginkgo/core/log/logger.hpp>
@@ -91,7 +83,6 @@
 #include <ginkgo/core/log/record.hpp>
 #include <ginkgo/core/log/solver_progress.hpp>
 #include <ginkgo/core/log/stream.hpp>
-
 #include <ginkgo/core/matrix/batch_csr.hpp>
 #include <ginkgo/core/matrix/batch_dense.hpp>
 #include <ginkgo/core/matrix/batch_ell.hpp>
@@ -110,11 +101,9 @@
 #include <ginkgo/core/matrix/scaled_permutation.hpp>
 #include <ginkgo/core/matrix/sellp.hpp>
 #include <ginkgo/core/matrix/sparsity_csr.hpp>
-
 #include <ginkgo/core/multigrid/fixed_coarsening.hpp>
 #include <ginkgo/core/multigrid/multigrid_level.hpp>
 #include <ginkgo/core/multigrid/pgm.hpp>
-
 #include <ginkgo/core/preconditioner/batch_jacobi.hpp>
 #include <ginkgo/core/preconditioner/gauss_seidel.hpp>
 #include <ginkgo/core/preconditioner/ic.hpp>
@@ -123,14 +112,12 @@
 #include <ginkgo/core/preconditioner/jacobi.hpp>
 #include <ginkgo/core/preconditioner/sor.hpp>
 #include <ginkgo/core/preconditioner/utils.hpp>
-
 #include <ginkgo/core/reorder/amd.hpp>
 #include <ginkgo/core/reorder/mc64.hpp>
 #include <ginkgo/core/reorder/nested_dissection.hpp>
 #include <ginkgo/core/reorder/rcm.hpp>
 #include <ginkgo/core/reorder/reordering_base.hpp>
 #include <ginkgo/core/reorder/scaled_reordered.hpp>
-
 #include <ginkgo/core/solver/batch_bicgstab.hpp>
 #include <ginkgo/core/solver/batch_cg.hpp>
 #include <ginkgo/core/solver/batch_solver_base.hpp>
@@ -150,7 +137,6 @@
 #include <ginkgo/core/solver/solver_traits.hpp>
 #include <ginkgo/core/solver/triangular.hpp>
 #include <ginkgo/core/solver/workspace.hpp>
-
 #include <ginkgo/core/stop/batch_stop_enum.hpp>
 #include <ginkgo/core/stop/combined.hpp>
 #include <ginkgo/core/stop/criterion.hpp>
@@ -158,7 +144,6 @@
 #include <ginkgo/core/stop/residual_norm.hpp>
 #include <ginkgo/core/stop/stopping_status.hpp>
 #include <ginkgo/core/stop/time.hpp>
-
 #include <ginkgo/core/synthesizer/containers.hpp>
 
 

--- a/include/ginkgo/ginkgo.hpp
+++ b/include/ginkgo/ginkgo.hpp
@@ -51,6 +51,7 @@
 #include <ginkgo/core/base/utils.hpp>
 #include <ginkgo/core/base/utils_helper.hpp>
 #include <ginkgo/core/base/version.hpp>
+#include <ginkgo/core/base/work_estimate.hpp>
 #include <ginkgo/core/config/config.hpp>
 #include <ginkgo/core/config/property_tree.hpp>
 #include <ginkgo/core/config/registry.hpp>

--- a/include/ginkgo/ginkgo.hpp.in
+++ b/include/ginkgo/ginkgo.hpp.in
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -7,8 +7,6 @@
 
 
 #include <ginkgo/config.hpp>
-
-
 #PUBLIC_HEADER_PLACE_HOLDER
 
 


### PR DESCRIPTION
This adds another optional column to the `ProfilerHook::create_(nested_)summary` logger that computes memory bandwidths/FLOPS/custom rates for kernels with work estimates.