### PR TITLE
Updating to actions/upload-artifact@v4

### DIFF
--- a/.github/workflows/bot-pr-updated.yml
+++ b/.github/workflows/bot-pr-updated.yml
@@ -46,7 +46,7 @@ jobs:
         run: old/.github/abidiff.sh
       - name: Upload ABI diff
         if: failure()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: abi
           path: abi.diff


### PR DESCRIPTION
Some actions are failing to run due to out-of-date github actions api version for artifacts.