### PR TITLE
Add benchmark work estimate for simple Cg solve

### DIFF
--- a/core/matrix/csr.cpp
+++ b/core/matrix/csr.cpp
@@ -40,8 +40,8 @@ namespace csr {
 namespace {
 
 
-GKO_REGISTER_OPERATION(spmv, csr::spmv);
-GKO_REGISTER_OPERATION(advanced_spmv, csr::advanced_spmv);
+GKO_REGISTER_OPERATION_WITH_WORK_ESTIMATE(spmv, csr::spmv);
+GKO_REGISTER_OPERATION_WITH_WORK_ESTIMATE(advanced_spmv, csr::advanced_spmv);
 GKO_REGISTER_OPERATION(spgemm, csr::spgemm);
 GKO_REGISTER_OPERATION(advanced_spgemm, csr::advanced_spgemm);
 GKO_REGISTER_OPERATION(spgeam, csr::spgeam);

--- a/core/matrix/dense_kernels.hpp
+++ b/core/matrix/dense_kernels.hpp
@@ -530,6 +530,16 @@ memory_bound_work_estimate compute_conj_dot_dispatch(
 }
 
 
+template <typename ValueType>
+memory_bound_work_estimate compute_norm2_dispatch(
+    const matrix::Dense<ValueType>* x,
+    matrix::Dense<remove_complex<ValueType>>* result, array<char>& tmp)
+{
+    const auto num_elements = x->get_size()[0] * x->get_size()[1];
+    return memory_bound_work_estimate{num_elements * sizeof(ValueType), 0};
+}
+
+
 }  // namespace dense
 }  // namespace work_estimate
 }  // namespace kernels

--- a/core/matrix/dense_kernels.hpp
+++ b/core/matrix/dense_kernels.hpp
@@ -482,9 +482,9 @@ namespace dense {
 
 
 template <typename ValueType>
-kernel_work_estimate simple_apply(const matrix::Dense<ValueType>* a,
-                                  const matrix::Dense<ValueType>* b,
-                                  matrix::Dense<ValueType>* c)
+compute_bound_work_estimate simple_apply(const matrix::Dense<ValueType>* a,
+                                         const matrix::Dense<ValueType>* b,
+                                         matrix::Dense<ValueType>* c)
 {
     const auto a_rows = a->get_size()[0];
     const auto a_cols = a->get_size()[1];
@@ -494,8 +494,8 @@ kernel_work_estimate simple_apply(const matrix::Dense<ValueType>* a,
 
 
 template <typename InValueType, typename OutValueType>
-kernel_work_estimate copy(const matrix::Dense<InValueType>* input,
-                          matrix::Dense<OutValueType>* output)
+memory_bound_work_estimate copy(const matrix::Dense<InValueType>* input,
+                                matrix::Dense<OutValueType>* output)
 {
     const auto memsize = input->get_size()[0] * input->get_size()[1];
     return memory_bound_work_estimate{memsize * sizeof(InValueType),
@@ -504,7 +504,7 @@ kernel_work_estimate copy(const matrix::Dense<InValueType>* input,
 
 
 template <typename ValueType>
-kernel_work_estimate fill(matrix::Dense<ValueType>* mat, ValueType value)
+memory_bound_work_estimate fill(matrix::Dense<ValueType>* mat, ValueType value)
 {
     return memory_bound_work_estimate{
         0, mat->get_size()[0] * mat->get_size()[1] * sizeof(ValueType)};
@@ -512,13 +512,21 @@ kernel_work_estimate fill(matrix::Dense<ValueType>* mat, ValueType value)
 
 
 template <typename ValueType>
-kernel_work_estimate compute_dot_dispatch(const matrix::Dense<ValueType>* x,
-                                          const matrix::Dense<ValueType>* y,
-                                          matrix::Dense<ValueType>* result,
-                                          array<char>& tmp)
+memory_bound_work_estimate compute_dot_dispatch(
+    const matrix::Dense<ValueType>* x, const matrix::Dense<ValueType>* y,
+    matrix::Dense<ValueType>* result, array<char>& tmp)
 {
     const auto num_elements = x->get_size()[0] * x->get_size()[1];
     return memory_bound_work_estimate{2 * num_elements * sizeof(ValueType), 0};
+}
+
+
+template <typename ValueType>
+memory_bound_work_estimate compute_conj_dot_dispatch(
+    const matrix::Dense<ValueType>* x, const matrix::Dense<ValueType>* y,
+    matrix::Dense<ValueType>* result, array<char>& tmp)
+{
+    return compute_dot_dispatch(x, y, result, tmp);
 }
 
 

--- a/core/solver/cg.cpp
+++ b/core/solver/cg.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -24,9 +24,9 @@ namespace cg {
 namespace {
 
 
-GKO_REGISTER_OPERATION(initialize, cg::initialize);
-GKO_REGISTER_OPERATION(step_1, cg::step_1);
-GKO_REGISTER_OPERATION(step_2, cg::step_2);
+GKO_REGISTER_OPERATION_WITH_WORK_ESTIMATE(initialize, cg::initialize);
+GKO_REGISTER_OPERATION_WITH_WORK_ESTIMATE(step_1, cg::step_1);
+GKO_REGISTER_OPERATION_WITH_WORK_ESTIMATE(step_2, cg::step_2);
 
 
 }  // anonymous namespace

--- a/core/solver/cg_kernels.hpp
+++ b/core/solver/cg_kernels.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -15,6 +15,7 @@
 #include <ginkgo/core/stop/stopping_status.hpp>
 
 #include "core/base/kernel_declaration.hpp"
+#include "ginkgo/core/base/work_estimate.hpp"
 
 
 namespace gko {
@@ -66,6 +67,51 @@ GKO_DECLARE_FOR_ALL_EXECUTOR_NAMESPACES(cg, GKO_DECLARE_ALL_AS_TEMPLATES);
 #undef GKO_DECLARE_ALL_AS_TEMPLATES
 
 
+namespace work_estimate::cg {
+
+
+template <typename ValueType>
+memory_bound_work_estimate initialize(
+    const matrix::Dense<ValueType>* b, matrix::Dense<ValueType>* r,
+    matrix::Dense<ValueType>* z, matrix::Dense<ValueType>* p,
+    matrix::Dense<ValueType>* q, matrix::Dense<ValueType>* prev_rho,
+    matrix::Dense<ValueType>* rho, array<stopping_status>* stop_status)
+{
+    const auto num_values = b->get_size()[0] * b->get_size()[1];
+    return memory_bound_work_estimate{num_values * sizeof(ValueType),
+                                      6 * num_values * sizeof(ValueType)};
+}
+
+
+template <typename ValueType>
+memory_bound_work_estimate step_1(matrix::Dense<ValueType>* p,
+                                  const matrix::Dense<ValueType>* z,
+                                  const matrix::Dense<ValueType>* rho,
+                                  const matrix::Dense<ValueType>* prev_rho,
+                                  const array<stopping_status>* stop_status)
+{
+    const auto num_values = p->get_size()[0] * p->get_size()[1];
+    return memory_bound_work_estimate{2 * num_values * sizeof(ValueType),
+                                      num_values * sizeof(ValueType)};
+}
+
+
+template <typename ValueType>
+memory_bound_work_estimate step_2(matrix::Dense<ValueType>* x,
+                                  matrix::Dense<ValueType>* r,
+                                  const matrix::Dense<ValueType>* p,
+                                  const matrix::Dense<ValueType>* q,
+                                  const matrix::Dense<ValueType>* beta,
+                                  const matrix::Dense<ValueType>* rho,
+                                  const array<stopping_status>* stop_status)
+{
+    const auto num_values = x->get_size()[0] * x->get_size()[1];
+    return memory_bound_work_estimate{4 * num_values * sizeof(ValueType),
+                                      2 * num_values * sizeof(ValueType)};
+}
+
+
+}  // namespace work_estimate::cg
 }  // namespace kernels
 }  // namespace gko
 


### PR DESCRIPTION
As a starting point and example for adding work estimates to kernels, this adds the necessary operations to all non-trivial kernels in a simple unpreconditioned Cg solve.

Example output for the simple-solver example in a debug build

Runtime summary
|                            name                             |  total   | total (self) | count |   avg    | avg (self) | performance |
|-------------------------------------------------------------|---------:|-------------:|------:|---------:|-----------:|------------:|
| total                                                       |   2.5 ms |     832.3 us |     1 |   2.5 ms |   832.3 us |             |
| apply(gko::solver::Cg<double>)                              |   1.6 ms |      17.9 us |     1 |   1.6 ms |    17.9 us |             |
| iteration                                                   |   1.5 ms |     508.1 us |    19 |  81.2 us |    26.7 us |             |
| check(gko::stop::Combined)                                  | 305.9 us |      91.0 us |    20 |  15.3 us |     4.6 us |             |
| apply(gko::matrix::Identity<double>)                        | 268.0 us |     101.2 us |    20 |  13.4 us |     5.1 us |             |
| apply(gko::matrix::Csr<double, int>)                        | 235.1 us |     122.9 us |    19 |  12.4 us |     6.5 us |             |
| check(gko::stop::ResidualNorm<double>)                      | 193.1 us |     148.3 us |    20 |   9.7 us |     7.4 us |             |
| copy(gko::matrix::Dense<double>,gko::matrix::Dense<double>) | 166.8 us |     142.7 us |    20 |   8.3 us |     7.1 us |             |
| csr::spmv                                                   | 112.2 us |     112.2 us |    19 |   5.9 us |     5.9 us |  363.2 MB/s |
| advanced_apply(gko::matrix::Csr<double, int>)               |  67.1 us |      38.8 us |     2 |  33.5 us |    19.4 us |             |
| dense::compute_conj_dot_dispatch                            |  58.1 us |      58.1 us |    39 |   1.5 us |     1.5 us |  204.1 MB/s |
| generate(gko::solver::Cg<double>::Factory)                  |  50.3 us |      50.3 us |     1 |  50.3 us |    50.3 us |             |
| cg::step_2                                                  |  46.8 us |      46.8 us |    19 |   2.5 us |     2.5 us |  370.7 MB/s |
| cg::step_1                                                  |  43.6 us |      43.6 us |    19 |   2.3 us |     2.3 us |  198.6 MB/s |
| dense::compute_norm2_dispatch                               |  36.7 us |      36.7 us |    22 |   1.7 us |     1.7 us |   91.1 MB/s |
| csr::advanced_spmv                                          |  28.3 us |      28.3 us |     2 |  14.1 us |    14.1 us |  162.3 MB/s |
| dense::copy                                                 |  24.1 us |      24.1 us |    20 |   1.2 us |     1.2 us |  252.0 MB/s |
| check(gko::stop::Iteration)                                 |  21.7 us |      21.7 us |    20 |   1.1 us |     1.1 us |             |
| allocate                                                    |  18.5 us |      18.5 us |    31 | 598.0 ns |   598.0 ns |             |
| residual_norm::residual_norm                                |  17.2 us |      17.2 us |    20 | 858.0 ns |   858.0 ns |             |
| components::aos_to_soa                                      |  16.9 us |      16.9 us |     3 |   5.6 us |     5.6 us |             |
| cg::initialize                                              |  15.0 us |      15.0 us |     1 |  15.0 us |    15.0 us |   70.7 MB/s |
| components::convert_idxs_to_ptrs                            |  13.5 us |      13.5 us |     1 |  13.5 us |    13.5 us |             |
| free                                                        |  13.3 us |      13.3 us |    31 | 430.0 ns |   430.0 ns |             |
| dense::fill                                                 |  13.2 us |      13.2 us |     4 |   3.3 us |     3.3 us |   24.3 MB/s |
| components::fill_array                                      |   6.3 us |       6.3 us |     1 |   6.3 us |     6.3 us |             |
| dense::fill_in_matrix_data                                  |   3.9 us |       3.9 us |     2 |   1.9 us |     1.9 us |             |

Overhead estimate 482.5 us

Work estimates available for 14.9 % of runtime