### PR TITLE
`MPI_Comm` cannot expected to be a pointer

### DIFF
--- a/.github/_typos.toml
+++ b/.github/_typos.toml
@@ -1,5 +1,5 @@
 [files]
-extend-exclude = ["third_party/*", "*.svg"]
+extend-exclude = ["third_party/*", "*.svg", "*.bib", "CITING.md"]
 
 [default.extend-words]
 dout = "dout"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -92,7 +92,7 @@ trigger_pipeline:
 
 
 # cuda 11.4 and friends
-build/cuda110/nompi/gcc/cuda/release/shared:
+build/cuda110/mvapich2/gcc/cuda/release/shared:
   extends:
     - .build_and_test_template
     - .default_variables
@@ -101,6 +101,7 @@ build/cuda110/nompi/gcc/cuda/release/shared:
   variables:
     BUILD_OMP: "ON"
     BUILD_CUDA: "ON"
+    BUILD_MPI: "ON"
     BUILD_TYPE: "Release"
     FAST_TESTS: "ON"
     # fix gtest issue https://github.com/google/googletest/issues/3514

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -92,7 +92,7 @@ trigger_pipeline:
 
 
 # cuda 11.4 and friends
-build/cuda110/mvapich2/gcc/cuda/release/shared:
+build/cuda110/nompi/gcc/cuda/release/shared:
   extends:
     - .build_and_test_template
     - .default_variables
@@ -101,7 +101,7 @@ build/cuda110/mvapich2/gcc/cuda/release/shared:
   variables:
     BUILD_OMP: "ON"
     BUILD_CUDA: "ON"
-    BUILD_MPI: "ON"
+    BUILD_MPI: "OFF"
     BUILD_TYPE: "Release"
     FAST_TESTS: "ON"
     # fix gtest issue https://github.com/google/googletest/issues/3514

--- a/include/ginkgo/core/base/mpi.hpp
+++ b/include/ginkgo/core/base/mpi.hpp
@@ -567,9 +567,6 @@ public:
      */
     bool is_identical(const communicator& rhs) const
     {
-        if (!get() || !rhs.get()) {
-            return get() == rhs.get();
-        }
         if (get() == MPI_COMM_NULL || rhs.get() == MPI_COMM_NULL) {
             return get() == rhs.get();
         }
@@ -592,9 +589,6 @@ public:
      */
     bool is_congruent(const communicator& rhs) const
     {
-        if (!get() || !rhs.get()) {
-            return get() == rhs.get();
-        }
         if (get() == MPI_COMM_NULL || rhs.get() == MPI_COMM_NULL) {
             return get() == rhs.get();
         }

--- a/include/ginkgo/core/base/mpi.hpp
+++ b/include/ginkgo/core/base/mpi.hpp
@@ -567,7 +567,7 @@ public:
      */
     bool is_identical(const communicator& rhs) const
     {
-        if (get() == nullptr || rhs.get() == nullptr) {
+        if (!get() || !rhs.get()) {
             return get() == rhs.get();
         }
         if (get() == MPI_COMM_NULL || rhs.get() == MPI_COMM_NULL) {

--- a/include/ginkgo/core/base/mpi.hpp
+++ b/include/ginkgo/core/base/mpi.hpp
@@ -719,7 +719,7 @@ public:
      * Broadcast data from calling process to all ranks in the communicator
      *
      * @param exec  The executor, on which the message buffer is located.
-     * @param buffer  the buffer to broadcsat
+     * @param buffer  the buffer to broadcast
      * @param count  the number of elements to broadcast
      * @param root_rank  the rank to broadcast from
      *
@@ -742,7 +742,7 @@ public:
      * communicator
      *
      * @param exec  The executor, on which the message buffer is located.
-     * @param buffer  the buffer to broadcsat
+     * @param buffer  the buffer to broadcast
      * @param count  the number of elements to broadcast
      * @param root_rank  the rank to broadcast from
      *


### PR DESCRIPTION
Fixes an issue where it was expected that MPI_Comm is comparable to a pointer. But some implementations (like MPICH) just use a reference to an `int` and hence are not comparable to `std::nullptr_t` 