### PR TITLE
Fix the mismatch type of VectorCache and index_map

### DIFF
--- a/core/distributed/index_map.cpp
+++ b/core/distributed/index_map.cpp
@@ -192,7 +192,7 @@ index_map<LocalIndexType, GlobalIndexType>::index_map(
 }
 
 
-#define GKO_DECLARE_INDEX_MAP(_ltype, _gtype) struct index_map<_ltype, _gtype>
+#define GKO_DECLARE_INDEX_MAP(_ltype, _gtype) class index_map<_ltype, _gtype>
 
 GKO_INSTANTIATE_FOR_EACH_LOCAL_GLOBAL_INDEX_TYPE(GKO_DECLARE_INDEX_MAP);
 

--- a/include/ginkgo/core/distributed/index_map.hpp
+++ b/include/ginkgo/core/distributed/index_map.hpp
@@ -65,7 +65,8 @@ enum class index_space {
  * \tparam GlobalIndexType  type for global indices
  */
 template <typename LocalIndexType, typename GlobalIndexType = int64>
-struct index_map {
+class index_map {
+public:
     using partition_type = Partition<LocalIndexType, GlobalIndexType>;
 
     /**

--- a/include/ginkgo/core/distributed/vector_cache.hpp
+++ b/include/ginkgo/core/distributed/vector_cache.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -33,7 +33,8 @@ namespace detail {
  *            not be copied when the outer object gets copied.
  */
 template <typename ValueType>
-struct VectorCache {
+class VectorCache {
+public:
     VectorCache() = default;
     ~VectorCache() = default;
     VectorCache(const VectorCache&) {}

--- a/include/ginkgo/core/matrix/dense.hpp
+++ b/include/ginkgo/core/matrix/dense.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 


### PR DESCRIPTION
Thanks for @greole report, we mismatch class and struct of `VectorCache` and `index_map`.
This PR fixes the mismatch part.