### PR TITLE
Support for Kokkos Threads

### DIFF
--- a/include/ginkgo/extensions/kokkos/spaces.hpp
+++ b/include/ginkgo/extensions/kokkos/spaces.hpp
@@ -47,7 +47,11 @@ template <typename MemorySpace>
 struct compatible_space<MemorySpace, OmpExecutor>
     : compatible_space<MemorySpace, ReferenceExecutor> {};
 #endif
-
+#ifdef KOKKOS_ENABLE_THREADS
+template <typename MemorySpace>
+struct compatible_space<MemorySpace, OmpExecutor>
+    : compatible_space<MemorySpace, ReferenceExecutor> {};
+#endif
 #ifdef KOKKOS_ENABLE_CUDA
 template <typename MemorySpace>
 struct compatible_space<MemorySpace, CudaExecutor> {
@@ -162,6 +166,12 @@ inline std::shared_ptr<Executor> create_default_host_executor()
         return OmpExecutor::create();
     }
 #endif
+#ifdef KOKKOS_ENABLE_THREADS
+    if constexpr (std::is_same_v<Kokkos::DefaultHostExecutionSpace,
+                                 Kokkos::Threads>) {
+        return OmpExecutor::create();
+    }
+#endif
     GKO_NOT_IMPLEMENTED;
 }
 
@@ -200,6 +210,11 @@ inline std::shared_ptr<Executor> create_executor(ExecSpace ex, MemorySpace = {})
 #endif
 #ifdef KOKKOS_ENABLE_OPENMP
     if constexpr (std::is_same_v<ExecSpace, Kokkos::OpenMP>) {
+        return OmpExecutor::create();
+    }
+#endif
+#ifdef KOKKOS_ENABLE_THREADS
+    if constexpr (std::is_same_v<ExecSpace, Kokkos::Threads>) {
         return OmpExecutor::create();
     }
 #endif

--- a/include/ginkgo/extensions/kokkos/spaces.hpp
+++ b/include/ginkgo/extensions/kokkos/spaces.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 

--- a/include/ginkgo/extensions/kokkos/spaces.hpp
+++ b/include/ginkgo/extensions/kokkos/spaces.hpp
@@ -47,11 +47,6 @@ template <typename MemorySpace>
 struct compatible_space<MemorySpace, OmpExecutor>
     : compatible_space<MemorySpace, ReferenceExecutor> {};
 #endif
-#ifdef KOKKOS_ENABLE_THREADS
-template <typename MemorySpace>
-struct compatible_space<MemorySpace, OmpExecutor>
-    : compatible_space<MemorySpace, ReferenceExecutor> {};
-#endif
 #ifdef KOKKOS_ENABLE_CUDA
 template <typename MemorySpace>
 struct compatible_space<MemorySpace, CudaExecutor> {
@@ -160,15 +155,15 @@ inline std::shared_ptr<Executor> create_default_host_executor()
         return ReferenceExecutor::create();
     }
 #endif
-#ifdef KOKKOS_ENABLE_OPENMP
-    if constexpr (std::is_same_v<Kokkos::DefaultHostExecutionSpace,
-                                 Kokkos::OpenMP>) {
-        return OmpExecutor::create();
-    }
-#endif
 #ifdef KOKKOS_ENABLE_THREADS
     if constexpr (std::is_same_v<Kokkos::DefaultHostExecutionSpace,
                                  Kokkos::Threads>) {
+        return ReferenceExecutor::create();
+    }
+#endif
+#ifdef KOKKOS_ENABLE_OPENMP
+    if constexpr (std::is_same_v<Kokkos::DefaultHostExecutionSpace,
+                                 Kokkos::OpenMP>) {
         return OmpExecutor::create();
     }
 #endif
@@ -215,7 +210,7 @@ inline std::shared_ptr<Executor> create_executor(ExecSpace ex, MemorySpace = {})
 #endif
 #ifdef KOKKOS_ENABLE_THREADS
     if constexpr (std::is_same_v<ExecSpace, Kokkos::Threads>) {
-        return OmpExecutor::create();
+        return ReferenceExecutor::create();
     }
 #endif
 #ifdef KOKKOS_ENABLE_CUDA


### PR DESCRIPTION
Currently, only `Kokkos::omp` is supported. This PR enables `Kokkos::Threads` as possible memory space and maps to Ginkgos openmp executor. 

I added separate `#ifdef `checks even though using `#if defined(KOKKOS_ENABLE_OMP) || defined(KOKKOS_ENABLE_THREADS) ` would be more concise, but it allows to treat the Kokkos::Threads case differently if required.