### PR TITLE
Add a job to sync github repo with Codehub 

### DIFF
--- a/.github/workflows/github-to-codehub-push-sync.yml
+++ b/.github/workflows/github-to-codehub-push-sync.yml
@@ -1,0 +1,24 @@
+name: Codehub-sync
+
+on:
+  push:
+    branches:
+      - 'main'
+      - 'develop'
+      - 'releases/**'
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+'
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    name: CASTIEL2 Codehub Sync
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+    - uses: cniethammer/git-repo-sync@cb1067d118c0c209bcded585b5c78e581bb0dfec
+      with:
+        target-url: 'https://codehub.hlrs.de/coes/microcard2/ginkgo.git'
+        target-username: ${{ secrets.CODEHUB_TOKEN_NAME }}
+        target-token: ${{ secrets.CODEHUB_TOKEN }}

--- a/.github/workflows/github-to-codehub-push-sync.yml
+++ b/.github/workflows/github-to-codehub-push-sync.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - 'main'
       - 'develop'
-      - 'releases/**'
+      - 'release/**'
     tags:
       - 'v[0-9]+.[0-9]+.[0-9]+'
 


### PR DESCRIPTION
This PR adds a github sync workflow to sync the github repo to codehub when the main/develop/release branches have been updated for easy CI/CD within the [CASTIEL-2 project](https://eurohpc-ju.europa.eu/research-innovation/our-projects/castiel-2_en). 

The objective is that eventually Ginkgo will be automatically deployed on the EU supercomputers and available to users through Easybuild and [EESSI](https://www.eessi.io/)