### PR TITLE
Enable mixed precision dispatch in distributed matrix with ScalarCache, GenericDenseCache, and GenericVectorCache

### DIFF
--- a/benchmark/test/reference/distributed_solver.profile.stderr
+++ b/benchmark/test/reference/distributed_solver.profile.stderr
@@ -62,8 +62,6 @@ DEBUG: end   copy
 DEBUG: begin copy
 DEBUG: end   copy
 DEBUG: end   copy(<typename>)
-DEBUG: begin dense::fill
-DEBUG: end   dense::fill
 DEBUG: begin components::aos_to_soa
 DEBUG: end   components::aos_to_soa
 DEBUG: begin distributed_matrix::separate_local_nonlocal
@@ -148,6 +146,8 @@ DEBUG: begin advanced_apply(<typename>)
 DEBUG: begin csr::advanced_spmv
 DEBUG: end   csr::advanced_spmv
 DEBUG: end   advanced_apply(<typename>)
+DEBUG: begin dense::fill
+DEBUG: end   dense::fill
 DEBUG: begin advanced_apply(<typename>)
 DEBUG: begin csr::advanced_spmv
 DEBUG: end   csr::advanced_spmv

--- a/benchmark/test/reference/spmv_distributed.profile.stderr
+++ b/benchmark/test/reference/spmv_distributed.profile.stderr
@@ -78,8 +78,6 @@ DEBUG: end   copy
 DEBUG: begin copy
 DEBUG: end   copy
 DEBUG: end   copy(<typename>)
-DEBUG: begin dense::fill
-DEBUG: end   dense::fill
 DEBUG: begin components::aos_to_soa
 DEBUG: end   components::aos_to_soa
 DEBUG: begin distributed_matrix::separate_local_nonlocal
@@ -128,6 +126,8 @@ DEBUG: begin apply(<typename>)
 DEBUG: begin csr::spmv
 DEBUG: end   csr::spmv
 DEBUG: end   apply(<typename>)
+DEBUG: begin dense::fill
+DEBUG: end   dense::fill
 DEBUG: begin advanced_apply(<typename>)
 DEBUG: begin csr::advanced_spmv
 DEBUG: end   csr::advanced_spmv

--- a/benchmark/test/reference/spmv_distributed.profile.stdout
+++ b/benchmark/test/reference/spmv_distributed.profile.stdout
@@ -5,7 +5,7 @@
         "comm_pattern": "stencil",
         "spmv": {
             "csr-csr": {
-                "storage": 11476,
+                "storage": 11452,
                 "time": 1.0,
                 "repetitions": 1,
                 "completed": true

--- a/benchmark/test/reference/spmv_distributed.simple.stdout
+++ b/benchmark/test/reference/spmv_distributed.simple.stdout
@@ -5,7 +5,7 @@
         "comm_pattern": "stencil",
         "spmv": {
             "csr-csr": {
-                "storage": 11476,
+                "storage": 11452,
                 "max_relative_norm2": 1.0,
                 "time": 1.0,
                 "repetitions": 10,

--- a/benchmark/test/reference/spmv_distributed_dcomplex.simple.stdout
+++ b/benchmark/test/reference/spmv_distributed_dcomplex.simple.stdout
@@ -5,7 +5,7 @@
         "comm_pattern": "stencil",
         "spmv": {
             "csr-csr": {
-                "storage": 17300,
+                "storage": 17252,
                 "max_relative_norm2": 1.0,
                 "time": 1.0,
                 "repetitions": 10,

--- a/core/base/dense_cache.cpp
+++ b/core/base/dense_cache.cpp
@@ -12,6 +12,7 @@
 #include <ginkgo/core/base/executor.hpp>
 #include <ginkgo/core/matrix/dense.hpp>
 
+#include "core/base/dense_cache_accessor.hpp"
 
 namespace gko {
 namespace detail {
@@ -35,6 +36,13 @@ void DenseCache<ValueType>::init_from(
         vec->get_executor() != template_vec->get_executor()) {
         vec = matrix::Dense<ValueType>::create_with_config_of(template_vec);
     }
+}
+
+
+const array<char>& GenericDenseCacheAccessor::get_workspace(
+    const GenericDenseCache& cache)
+{
+    return cache.workspace;
 }
 
 
@@ -73,6 +81,26 @@ std::shared_ptr<matrix::Dense<ValueType>> GenericDenseCache::get(
         make_array_view(exec, size[0] * size[1],
                         reinterpret_cast<ValueType*>(workspace.get_data())),
         size[1]);
+}
+
+
+std::shared_ptr<const Executor> ScalarCacheAccessor::get_executor(
+    const ScalarCache& cache)
+{
+    return cache.exec;
+}
+
+
+double ScalarCacheAccessor::get_value(const ScalarCache& cache)
+{
+    return cache.value;
+}
+
+
+const std::map<std::string, std::shared_ptr<const gko::LinOp>>&
+ScalarCacheAccessor::get_scalars(const ScalarCache& cache)
+{
+    return cache.scalars;
 }
 
 

--- a/core/base/dense_cache.cpp
+++ b/core/base/dense_cache.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -32,8 +32,51 @@ void DenseCache<ValueType>::init_from(
 }
 
 
+GenericDenseCache::GenericDenseCache(const GenericDenseCache&) {}
+
+
+GenericDenseCache::GenericDenseCache(GenericDenseCache&&) noexcept {}
+
+
+GenericDenseCache& GenericDenseCache::operator=(const GenericDenseCache&)
+{
+    return *this;
+}
+
+
+GenericDenseCache& GenericDenseCache::operator=(GenericDenseCache&&) noexcept
+{
+    return *this;
+}
+
+
+template <typename ValueType>
+std::shared_ptr<matrix::Dense<ValueType>> GenericDenseCache::get(
+    std::shared_ptr<const Executor> exec, dim<2> size) const
+{
+    if (exec != workspace.get_executor() ||
+        size[0] * size[1] * sizeof(ValueType) > workspace.get_size()) {
+        auto new_workspace =
+            gko::array<char>(exec, size[0] * size[1] * sizeof(ValueType));
+        // We use swap here, otherwise array copy/move between different
+        // executor will keep the original executor.
+        std::swap(workspace, new_workspace);
+    }
+    return matrix::Dense<ValueType>::create(
+        exec, size,
+        make_array_view(exec, size[0] * size[1],
+                        reinterpret_cast<ValueType*>(workspace.get_data())),
+        size[1]);
+}
+
+
 #define GKO_DECLARE_DENSE_CACHE(_type) struct DenseCache<_type>
 GKO_INSTANTIATE_FOR_EACH_VALUE_TYPE(GKO_DECLARE_DENSE_CACHE);
+
+#define GKO_DECLARE_GENERIC_DENSE_CACHE_GET(_type)                       \
+    std::shared_ptr<matrix::Dense<_type>> GenericDenseCache::get<_type>( \
+        std::shared_ptr<const Executor>, dim<2>) const
+GKO_INSTANTIATE_FOR_EACH_VALUE_TYPE(GKO_DECLARE_GENERIC_DENSE_CACHE_GET);
 
 
 }  // namespace detail

--- a/core/base/dense_cache_accessor.hpp
+++ b/core/base/dense_cache_accessor.hpp
@@ -6,7 +6,6 @@
 #define GKO_CORE_BASE_DENSE_CACHE_ACCESSOR_HPP_
 
 
-#include <iostream>
 #include <map>
 #include <string>
 

--- a/core/base/dense_cache_accessor.hpp
+++ b/core/base/dense_cache_accessor.hpp
@@ -1,0 +1,51 @@
+// SPDX-FileCopyrightText: 2025 The Ginkgo authors
+//
+// SPDX-License-Identifier: BSD-3-Clause
+
+#ifndef GKO_CORE_BASE_DENSE_CACHE_ACCESSOR_HPP_
+#define GKO_CORE_BASE_DENSE_CACHE_ACCESSOR_HPP_
+
+
+#include <iostream>
+#include <map>
+#include <string>
+
+#include <ginkgo/core/base/array.hpp>
+#include <ginkgo/core/base/dense_cache.hpp>
+#include <ginkgo/core/base/executor.hpp>
+#include <ginkgo/core/base/lin_op.hpp>
+
+
+namespace gko {
+namespace detail {
+
+
+// helper to access private member for testing
+class GenericDenseCacheAccessor {
+public:
+    // access to the workspace
+    static const array<char>& get_workspace(const GenericDenseCache& cache);
+};
+
+
+// helper to access private member for testing
+class ScalarCacheAccessor {
+public:
+    // access to the executor
+    static std::shared_ptr<const Executor> get_executor(
+        const ScalarCache& cache);
+
+    // access to the value
+    static double get_value(const ScalarCache& cache);
+
+    // access to the scalars
+    static const std::map<std::string, std::shared_ptr<const gko::LinOp>>&
+    get_scalars(const ScalarCache& cache);
+};
+
+
+}  // namespace detail
+}  // namespace gko
+
+
+#endif  // GKO_CORE_BASE_DENSE_CACHE_ACCESSOR_HPP_

--- a/core/distributed/vector_cache.cpp
+++ b/core/distributed/vector_cache.cpp
@@ -8,6 +8,9 @@
 #include <ginkgo/core/distributed/vector.hpp>
 #include <ginkgo/core/matrix/dense.hpp>
 
+#include "core/distributed/vector_cache_accessor.hpp"
+
+
 namespace gko {
 namespace experimental {
 namespace distributed {
@@ -47,8 +50,71 @@ void VectorCache<ValueType>::init_from(
 }
 
 
+GenericVectorCache::GenericVectorCache(const GenericVectorCache&) {}
+
+
+GenericVectorCache::GenericVectorCache(GenericVectorCache&&) noexcept {}
+
+
+GenericVectorCache& GenericVectorCache::operator=(const GenericVectorCache&)
+{
+    return *this;
+}
+
+
+GenericVectorCache& GenericVectorCache::operator=(GenericVectorCache&&) noexcept
+{
+    return *this;
+}
+
+
+void GenericVectorCache::init(std::shared_ptr<const Executor> exec,
+                              dim<2> global_size, dim<2> local_size) const
+{
+    exec_ = exec;
+    global_size_ = global_size;
+    local_size_ = local_size;
+}
+
+template <typename ValueType>
+std::shared_ptr<Vector<ValueType>> GenericVectorCache::get(
+    gko::experimental::mpi::communicator comm) const
+{
+    auto required_size = local_size_[0] * local_size_[1] * sizeof(ValueType);
+    if (exec_ != workspace.get_executor() ||
+        required_size > workspace.get_size()) {
+        auto new_workspace = gko::array<char>(exec_, required_size);
+        // We use swap here, otherwise array copy/move between different
+        // executor will keep the original executor.
+        std::swap(workspace, new_workspace);
+    }
+    return Vector<ValueType>::create(
+        exec_, comm, global_size_,
+        matrix::Dense<ValueType>::create(
+            exec_, local_size_,
+            make_array_view(exec_, local_size_[0] * local_size_[1],
+                            reinterpret_cast<ValueType*>(workspace.get_data())),
+            local_size_[1]));
+}
+
+
+const array<char>& GenericVectorCacheAccessor::get_workspace(
+    const GenericVectorCache& cache)
+{
+    return cache.workspace;
+}
+
+
 #define GKO_DECLARE_VECTOR_CACHE(_type) class VectorCache<_type>
 GKO_INSTANTIATE_FOR_EACH_VALUE_TYPE(GKO_DECLARE_VECTOR_CACHE);
+
+class GenericVectorCache;
+
+#define GKO_DECLARE_GENERIC_VECTOR_CACHE_GET(_type)         \
+    std::shared_ptr<Vector<_type>> GenericVectorCache::get( \
+        gko::experimental::mpi::communicator comm) const
+
+GKO_INSTANTIATE_FOR_EACH_VALUE_TYPE(GKO_DECLARE_GENERIC_VECTOR_CACHE_GET);
 
 
 }  // namespace detail

--- a/core/distributed/vector_cache_accessor.hpp
+++ b/core/distributed/vector_cache_accessor.hpp
@@ -6,13 +6,12 @@
 #define GKO_CORE_DISTRIBUTED_VECTOR_CACHE_ACCESSOR_HPP_
 
 
-#include <iostream>
-#include <map>
-#include <string>
-
+#include <ginkgo/config.hpp>
 #include <ginkgo/core/base/array.hpp>
-#include <ginkgo/core/base/executor.hpp>
 #include <ginkgo/core/distributed/vector_cache.hpp>
+
+
+#if GINKGO_BUILD_MPI
 
 
 namespace gko {
@@ -25,7 +24,9 @@ namespace detail {
 class GenericVectorCacheAccessor {
 public:
     // access to the workspace
-    static const array<char>& get_workspace(const GenericVectorCache& cache);
+    static const array<char>& get_workspace(
+        const gko::experimental::distributed::detail::GenericVectorCache&
+            cache);
 };
 
 
@@ -35,4 +36,5 @@ public:
 }  // namespace gko
 
 
+#endif
 #endif  // GKO_CORE_DISTRIBUTED_VECTOR_CACHE_ACCESSOR_HPP_

--- a/core/distributed/vector_cache_accessor.hpp
+++ b/core/distributed/vector_cache_accessor.hpp
@@ -1,0 +1,38 @@
+// SPDX-FileCopyrightText: 2025 The Ginkgo authors
+//
+// SPDX-License-Identifier: BSD-3-Clause
+
+#ifndef GKO_CORE_DISTRIBUTED_VECTOR_CACHE_ACCESSOR_HPP_
+#define GKO_CORE_DISTRIBUTED_VECTOR_CACHE_ACCESSOR_HPP_
+
+
+#include <iostream>
+#include <map>
+#include <string>
+
+#include <ginkgo/core/base/array.hpp>
+#include <ginkgo/core/base/executor.hpp>
+#include <ginkgo/core/distributed/vector_cache.hpp>
+
+
+namespace gko {
+namespace experimental {
+namespace distributed {
+namespace detail {
+
+
+// helper to access private member for testing
+class GenericVectorCacheAccessor {
+public:
+    // access to the workspace
+    static const array<char>& get_workspace(const GenericVectorCache& cache);
+};
+
+
+}  // namespace detail
+}  // namespace distributed
+}  // namespace experimental
+}  // namespace gko
+
+
+#endif  // GKO_CORE_DISTRIBUTED_VECTOR_CACHE_ACCESSOR_HPP_

--- a/core/test/base/dense_cache.cpp
+++ b/core/test/base/dense_cache.cpp
@@ -303,7 +303,7 @@ TYPED_TEST(GenericDenseCache, GenericCanInitWithSizeAndType)
     GKO_ASSERT_EQUAL_DIMENSIONS(second_buffer->get_size(), this->size);
     ASSERT_EQ(second_buffer->get_executor(), this->ref);
     if (sizeof(another_type) > sizeof(value_type)) {
-        // the requring workspace will be bigger if the type is larger.
+        // the requiring workspace will be bigger if the type is larger.
         ASSERT_NE(
             array_ptr,
             generic_accessor::get_workspace(this->cache).get_const_data());

--- a/core/test/base/dense_cache.cpp
+++ b/core/test/base/dense_cache.cpp
@@ -310,6 +310,7 @@ TYPED_TEST(GenericDenseCache, GenericCanInitWithDifferentExecutor)
 
     auto second_buffer =
         this->cache.template get<value_type>(another_ref, this->size);
+
     ASSERT_NE(second_buffer, nullptr);
     GKO_ASSERT_EQUAL_DIMENSIONS(second_buffer->get_size(), this->size);
     ASSERT_EQ(second_buffer->get_executor(), another_ref);
@@ -322,6 +323,7 @@ TYPED_TEST(GenericDenseCache, WorkspaceIsNotCopied)
 {
     using value_type = typename TestFixture::value_type;
     auto buffer = this->cache.template get<value_type>(this->ref, this->size);
+
     gko::detail::GenericDenseCache cache(this->cache);
 
     ASSERT_EQ(cache.workspace.get_size(), 0);
@@ -333,6 +335,7 @@ TYPED_TEST(GenericDenseCache, WorkspaceIsNotMoved)
 {
     using value_type = typename TestFixture::value_type;
     auto buffer = this->cache.template get<value_type>(this->ref, this->size);
+
     gko::detail::GenericDenseCache cache(std::move(this->cache));
 
     ASSERT_EQ(cache.workspace.get_size(), 0);
@@ -345,6 +348,7 @@ TYPED_TEST(GenericDenseCache, WorkspaceIsNotCopyAssigned)
     using value_type = typename TestFixture::value_type;
     auto buffer = this->cache.template get<value_type>(this->ref, this->size);
     gko::detail::GenericDenseCache cache;
+
     cache = this->cache;
 
     ASSERT_EQ(cache.workspace.get_size(), 0);
@@ -357,6 +361,7 @@ TYPED_TEST(GenericDenseCache, WorkspaceIsNotMoveAssigned)
     using value_type = typename TestFixture::value_type;
     auto buffer = this->cache.template get<value_type>(this->ref, this->size);
     gko::detail::GenericDenseCache cache;
+
     cache = std::move(this->cache);
 
     ASSERT_EQ(cache.workspace.get_size(), 0);

--- a/core/test/base/dense_cache.cpp
+++ b/core/test/base/dense_cache.cpp
@@ -7,8 +7,8 @@
 #include <ginkgo/core/base/dense_cache.hpp>
 #include <ginkgo/core/matrix/dense.hpp>
 
+#include "core/base/dense_cache_accessor.hpp"
 #include "core/test/utils.hpp"
-
 
 template <typename ValueType>
 class DenseCache : public ::testing::Test {
@@ -191,6 +191,9 @@ TYPED_TEST(DenseCache, VectorIsNotMoveAssigned)
 }
 
 
+using generic_accessor = gko::detail::GenericDenseCacheAccessor;
+
+
 template <typename ValueType>
 class GenericDenseCache : public ::testing::Test {
 protected:
@@ -223,8 +226,9 @@ TYPED_TEST(GenericDenseCache, SecondInitWithSameSizeIsNoOp)
 {
     using value_type = typename TestFixture::value_type;
     auto buffer = this->cache.template get<value_type>(this->ref, this->size);
-    auto array_ptr = this->cache.workspace.get_const_data();
-    auto array_size = this->cache.workspace.get_size();
+    auto array_ptr =
+        generic_accessor::get_workspace(this->cache).get_const_data();
+    auto array_size = generic_accessor::get_workspace(this->cache).get_size();
 
     auto second_buffer =
         this->cache.template get<value_type>(this->ref, this->size);
@@ -232,8 +236,10 @@ TYPED_TEST(GenericDenseCache, SecondInitWithSameSizeIsNoOp)
     ASSERT_NE(second_buffer, nullptr);
     GKO_ASSERT_EQUAL_DIMENSIONS(second_buffer->get_size(), this->size);
     ASSERT_EQ(second_buffer->get_executor(), this->ref);
-    ASSERT_EQ(array_ptr, this->cache.workspace.get_const_data());
-    ASSERT_EQ(array_size, this->cache.workspace.get_size());
+    ASSERT_EQ(array_ptr,
+              generic_accessor::get_workspace(this->cache).get_const_data());
+    ASSERT_EQ(array_size,
+              generic_accessor::get_workspace(this->cache).get_size());
 }
 
 
@@ -242,8 +248,9 @@ TYPED_TEST(GenericDenseCache, SecondInitWithTheSmallEqSizeIsNoOp)
     using value_type = typename TestFixture::value_type;
     gko::dim<2> second_size{7, 4};
     auto buffer = this->cache.template get<value_type>(this->ref, this->size);
-    auto array_ptr = this->cache.workspace.get_const_data();
-    auto array_size = this->cache.workspace.get_size();
+    auto array_ptr =
+        generic_accessor::get_workspace(this->cache).get_const_data();
+    auto array_size = generic_accessor::get_workspace(this->cache).get_size();
 
     auto second_buffer =
         this->cache.template get<value_type>(this->ref, second_size);
@@ -251,8 +258,10 @@ TYPED_TEST(GenericDenseCache, SecondInitWithTheSmallEqSizeIsNoOp)
     ASSERT_NE(second_buffer, nullptr);
     GKO_ASSERT_EQUAL_DIMENSIONS(second_buffer->get_size(), second_size);
     ASSERT_EQ(second_buffer->get_executor(), this->ref);
-    ASSERT_EQ(array_ptr, this->cache.workspace.get_const_data());
-    ASSERT_EQ(array_size, this->cache.workspace.get_size());
+    ASSERT_EQ(array_ptr,
+              generic_accessor::get_workspace(this->cache).get_const_data());
+    ASSERT_EQ(array_size,
+              generic_accessor::get_workspace(this->cache).get_size());
 }
 
 
@@ -261,8 +270,9 @@ TYPED_TEST(GenericDenseCache, SecondInitWithTheLargerSizeRecreate)
     using value_type = typename TestFixture::value_type;
     gko::dim<2> second_size{7, 5};
     auto buffer = this->cache.template get<value_type>(this->ref, this->size);
-    auto array_ptr = this->cache.workspace.get_const_data();
-    auto array_size = this->cache.workspace.get_size();
+    auto array_ptr =
+        generic_accessor::get_workspace(this->cache).get_const_data();
+    auto array_size = generic_accessor::get_workspace(this->cache).get_size();
 
     auto second_buffer =
         this->cache.template get<value_type>(this->ref, second_size);
@@ -270,8 +280,10 @@ TYPED_TEST(GenericDenseCache, SecondInitWithTheLargerSizeRecreate)
     ASSERT_NE(second_buffer, nullptr);
     GKO_ASSERT_EQUAL_DIMENSIONS(second_buffer->get_size(), second_size);
     ASSERT_EQ(second_buffer->get_executor(), this->ref);
-    ASSERT_NE(array_ptr, this->cache.workspace.get_const_data());
-    ASSERT_GT(this->cache.workspace.get_size(), array_size);
+    ASSERT_NE(array_ptr,
+              generic_accessor::get_workspace(this->cache).get_const_data());
+    ASSERT_GT(generic_accessor::get_workspace(this->cache).get_size(),
+              array_size);
 }
 
 
@@ -280,8 +292,9 @@ TYPED_TEST(GenericDenseCache, GenericCanInitWithSizeAndType)
     using value_type = typename TestFixture::value_type;
     using another_type = gko::next_precision<value_type>;
     auto buffer = this->cache.template get<value_type>(this->ref, this->size);
-    auto array_ptr = this->cache.workspace.get_const_data();
-    auto array_size = this->cache.workspace.get_size();
+    auto array_ptr =
+        generic_accessor::get_workspace(this->cache).get_const_data();
+    auto array_size = generic_accessor::get_workspace(this->cache).get_size();
 
     auto second_buffer =
         this->cache.template get<another_type>(this->ref, this->size);
@@ -291,11 +304,17 @@ TYPED_TEST(GenericDenseCache, GenericCanInitWithSizeAndType)
     ASSERT_EQ(second_buffer->get_executor(), this->ref);
     if (sizeof(another_type) > sizeof(value_type)) {
         // the requring workspace will be bigger if the type is larger.
-        ASSERT_NE(array_ptr, this->cache.workspace.get_const_data());
-        ASSERT_GT(this->cache.workspace.get_size(), array_size);
+        ASSERT_NE(
+            array_ptr,
+            generic_accessor::get_workspace(this->cache).get_const_data());
+        ASSERT_GT(generic_accessor::get_workspace(this->cache).get_size(),
+                  array_size);
     } else {
-        ASSERT_EQ(array_ptr, this->cache.workspace.get_const_data());
-        ASSERT_EQ(array_size, this->cache.workspace.get_size());
+        ASSERT_EQ(
+            array_ptr,
+            generic_accessor::get_workspace(this->cache).get_const_data());
+        ASSERT_EQ(array_size,
+                  generic_accessor::get_workspace(this->cache).get_size());
     }
 }
 
@@ -305,8 +324,9 @@ TYPED_TEST(GenericDenseCache, GenericCanInitWithDifferentExecutor)
     using value_type = typename TestFixture::value_type;
     auto another_ref = gko::ReferenceExecutor::create();
     auto buffer = this->cache.template get<value_type>(this->ref, this->size);
-    auto array_ptr = this->cache.workspace.get_const_data();
-    auto array_size = this->cache.workspace.get_size();
+    auto array_ptr =
+        generic_accessor::get_workspace(this->cache).get_const_data();
+    auto array_size = generic_accessor::get_workspace(this->cache).get_size();
 
     auto second_buffer =
         this->cache.template get<value_type>(another_ref, this->size);
@@ -315,7 +335,8 @@ TYPED_TEST(GenericDenseCache, GenericCanInitWithDifferentExecutor)
     GKO_ASSERT_EQUAL_DIMENSIONS(second_buffer->get_size(), this->size);
     ASSERT_EQ(second_buffer->get_executor(), another_ref);
     // Different executor always regenerate different workspace
-    ASSERT_NE(array_ptr, this->cache.workspace.get_const_data());
+    ASSERT_NE(array_ptr,
+              generic_accessor::get_workspace(this->cache).get_const_data());
 }
 
 
@@ -326,8 +347,8 @@ TYPED_TEST(GenericDenseCache, WorkspaceIsNotCopied)
 
     gko::detail::GenericDenseCache cache(this->cache);
 
-    ASSERT_EQ(cache.workspace.get_size(), 0);
-    ASSERT_EQ(cache.workspace.get_executor(), nullptr);
+    ASSERT_EQ(generic_accessor::get_workspace(cache).get_size(), 0);
+    ASSERT_EQ(generic_accessor::get_workspace(cache).get_executor(), nullptr);
 }
 
 
@@ -338,8 +359,8 @@ TYPED_TEST(GenericDenseCache, WorkspaceIsNotMoved)
 
     gko::detail::GenericDenseCache cache(std::move(this->cache));
 
-    ASSERT_EQ(cache.workspace.get_size(), 0);
-    ASSERT_EQ(cache.workspace.get_executor(), nullptr);
+    ASSERT_EQ(generic_accessor::get_workspace(cache).get_size(), 0);
+    ASSERT_EQ(generic_accessor::get_workspace(cache).get_executor(), nullptr);
 }
 
 
@@ -351,8 +372,8 @@ TYPED_TEST(GenericDenseCache, WorkspaceIsNotCopyAssigned)
 
     cache = this->cache;
 
-    ASSERT_EQ(cache.workspace.get_size(), 0);
-    ASSERT_EQ(cache.workspace.get_executor(), nullptr);
+    ASSERT_EQ(generic_accessor::get_workspace(cache).get_size(), 0);
+    ASSERT_EQ(generic_accessor::get_workspace(cache).get_executor(), nullptr);
 }
 
 
@@ -364,9 +385,12 @@ TYPED_TEST(GenericDenseCache, WorkspaceIsNotMoveAssigned)
 
     cache = std::move(this->cache);
 
-    ASSERT_EQ(cache.workspace.get_size(), 0);
-    ASSERT_EQ(cache.workspace.get_executor(), nullptr);
+    ASSERT_EQ(generic_accessor::get_workspace(cache).get_size(), 0);
+    ASSERT_EQ(generic_accessor::get_workspace(cache).get_executor(), nullptr);
 }
+
+
+using scalar_accessor = gko::detail::ScalarCacheAccessor;
 
 
 template <typename ValueType>
@@ -392,9 +416,9 @@ TYPED_TEST(ScalarCache, CanInitWithExecutorAndValue)
 
     gko::detail::ScalarCache cache(this->ref, 1.0);
 
-    ASSERT_EQ(this->cache.exec, this->ref);
-    ASSERT_EQ(this->cache.value, 1.0);
-    ASSERT_EQ(this->cache.scalars.size(), 0);
+    ASSERT_EQ(scalar_accessor::get_executor(this->cache), this->ref);
+    ASSERT_EQ(scalar_accessor::get_value(this->cache), 1.0);
+    ASSERT_EQ(scalar_accessor::get_scalars(this->cache).size(), 0);
 }
 
 
@@ -407,7 +431,7 @@ TYPED_TEST(ScalarCache, CanGetScalar)
     ASSERT_NE(scalar, nullptr);
     GKO_ASSERT_EQUAL_DIMENSIONS(scalar->get_size(), gko::dim<2>(1, 1));
     ASSERT_EQ(scalar->at(0, 0), static_cast<value_type>(this->value));
-    ASSERT_EQ(this->cache.scalars.size(), 1);
+    ASSERT_EQ(scalar_accessor::get_scalars(this->cache).size(), 1);
 }
 
 
@@ -427,7 +451,7 @@ TYPED_TEST(ScalarCache, CanGetScalarWithDifferentType)
     GKO_ASSERT_EQUAL_DIMENSIONS(another_scalar->get_size(), gko::dim<2>(1, 1));
     ASSERT_EQ(another_scalar->at(0, 0), static_cast<another_type>(this->value));
     // have two for different value type now
-    ASSERT_EQ(this->cache.scalars.size(), 2);
+    ASSERT_EQ(scalar_accessor::get_scalars(this->cache).size(), 2);
 }
 
 
@@ -438,10 +462,12 @@ TYPED_TEST(ScalarCache, VectorIsNotCopied)
 
     gko::detail::ScalarCache cache(this->cache);
 
-    ASSERT_EQ(cache.scalars.size(), 0);
-    ASSERT_EQ(cache.value, this->cache.value);
-    ASSERT_EQ(cache.exec, this->cache.exec);
-    ASSERT_EQ(this->cache.scalars.size(), 1);
+    ASSERT_EQ(scalar_accessor::get_scalars(cache).size(), 0);
+    ASSERT_EQ(scalar_accessor::get_value(cache),
+              scalar_accessor::get_value(this->cache));
+    ASSERT_EQ(scalar_accessor::get_executor(cache),
+              scalar_accessor::get_executor(this->cache));
+    ASSERT_EQ(scalar_accessor::get_scalars(this->cache).size(), 1);
 }
 
 
@@ -452,13 +478,13 @@ TYPED_TEST(ScalarCache, VectorIsNotMoved)
 
     gko::detail::ScalarCache cache(std::move(this->cache));
 
-    ASSERT_EQ(cache.scalars.size(), 0);
-    ASSERT_EQ(cache.value, this->value);
-    ASSERT_EQ(cache.exec, this->ref);
+    ASSERT_EQ(scalar_accessor::get_scalars(cache).size(), 0);
+    ASSERT_EQ(scalar_accessor::get_value(cache), this->value);
+    ASSERT_EQ(scalar_accessor::get_executor(cache), this->ref);
     // The original one is cleared
-    ASSERT_EQ(this->cache.value, 0.0);
-    ASSERT_EQ(this->cache.exec, nullptr);
-    ASSERT_EQ(this->cache.scalars.size(), 0);
+    ASSERT_EQ(scalar_accessor::get_value(this->cache), 0.0);
+    ASSERT_EQ(scalar_accessor::get_executor(this->cache), nullptr);
+    ASSERT_EQ(scalar_accessor::get_scalars(this->cache).size(), 0);
 }
 
 
@@ -470,10 +496,12 @@ TYPED_TEST(ScalarCache, VectorIsNotCopyAssigned)
 
     cache = this->cache;
 
-    ASSERT_EQ(cache.scalars.size(), 0);
-    ASSERT_EQ(cache.value, this->cache.value);
-    ASSERT_EQ(cache.exec, this->cache.exec);
-    ASSERT_EQ(this->cache.scalars.size(), 1);
+    ASSERT_EQ(scalar_accessor::get_scalars(cache).size(), 0);
+    ASSERT_EQ(scalar_accessor::get_value(cache),
+              scalar_accessor::get_value(this->cache));
+    ASSERT_EQ(scalar_accessor::get_executor(cache),
+              scalar_accessor::get_executor(this->cache));
+    ASSERT_EQ(scalar_accessor::get_scalars(this->cache).size(), 1);
 }
 
 
@@ -485,11 +513,11 @@ TYPED_TEST(ScalarCache, VectorIsNotMoveAssigned)
 
     cache = std::move(this->cache);
 
-    ASSERT_EQ(cache.scalars.size(), 0);
-    ASSERT_EQ(cache.value, this->value);
-    ASSERT_EQ(cache.exec, this->ref);
+    ASSERT_EQ(scalar_accessor::get_scalars(cache).size(), 0);
+    ASSERT_EQ(scalar_accessor::get_value(cache), this->value);
+    ASSERT_EQ(scalar_accessor::get_executor(cache), this->ref);
     // The original one is cleared
-    ASSERT_EQ(this->cache.value, 0.0);
-    ASSERT_EQ(this->cache.exec, nullptr);
-    ASSERT_EQ(this->cache.scalars.size(), 0);
+    ASSERT_EQ(scalar_accessor::get_value(this->cache), 0.0);
+    ASSERT_EQ(scalar_accessor::get_executor(this->cache), nullptr);
+    ASSERT_EQ(scalar_accessor::get_scalars(this->cache).size(), 0);
 }

--- a/core/test/mpi/distributed/vector_cache.cpp
+++ b/core/test/mpi/distributed/vector_cache.cpp
@@ -359,10 +359,9 @@ TYPED_TEST(GenericVectorCache, GenericCanInitWithSize)
 {
     using value_type = typename TestFixture::value_type;
 
-    this->cache.init(this->ref, this->default_global_size,
-                     this->default_local_size);
-    // only initialize when knowning the type
-    auto buffer = this->cache.template get<value_type>(this->comm);
+    auto buffer = this->cache.template get<value_type>(
+        this->ref, this->comm, this->default_global_size,
+        this->default_local_size);
 
     ASSERT_NE(buffer, nullptr);
     GKO_ASSERT_EQUAL_DIMENSIONS(buffer->get_size(), this->default_global_size);
@@ -376,14 +375,16 @@ TYPED_TEST(GenericVectorCache, GenericCanInitWithSize)
 TYPED_TEST(GenericVectorCache, SecondInitWithSameSizeIsNoOp)
 {
     using value_type = typename TestFixture::value_type;
-    this->cache.init(this->ref, this->default_global_size,
-                     this->default_local_size);
-    auto buffer = this->cache.template get<value_type>(this->comm);
+    auto buffer = this->cache.template get<value_type>(
+        this->ref, this->comm, this->default_global_size,
+        this->default_local_size);
     auto array_ptr =
         generic_accessor::get_workspace(this->cache).get_const_data();
     auto array_size = generic_accessor::get_workspace(this->cache).get_size();
 
-    auto second_buffer = this->cache.template get<value_type>(this->comm);
+    auto second_buffer = this->cache.template get<value_type>(
+        this->ref, this->comm, this->default_global_size,
+        this->default_local_size);
 
     ASSERT_NE(second_buffer, nullptr);
     GKO_ASSERT_EQUAL_DIMENSIONS(second_buffer->get_size(),
@@ -402,17 +403,17 @@ TYPED_TEST(GenericVectorCache, SecondInitWithSameSizeIsNoOp)
 TYPED_TEST(GenericVectorCache, SecondInitWithTheSmallEqSizeIsNoOp)
 {
     using value_type = typename TestFixture::value_type;
-    gko::dim<2> second_local_size{1, 1};
-    gko::dim<2> second_global_size{this->num_ranks, 1};
-    this->cache.init(this->ref, this->default_global_size,
-                     this->default_local_size);
-    auto buffer = this->cache.template get<value_type>(this->comm);
+    gko::dim<2> second_local_size(1, 1);
+    gko::dim<2> second_global_size(this->num_ranks, 1);
+    auto buffer = this->cache.template get<value_type>(
+        this->ref, this->comm, this->default_global_size,
+        this->default_local_size);
     auto array_ptr =
         generic_accessor::get_workspace(this->cache).get_const_data();
     auto array_size = generic_accessor::get_workspace(this->cache).get_size();
 
-    this->cache.init(this->ref, second_global_size, second_local_size);
-    auto second_buffer = this->cache.template get<value_type>(this->comm);
+    auto second_buffer = this->cache.template get<value_type>(
+        this->ref, this->comm, second_global_size, second_local_size);
 
     ASSERT_NE(second_buffer, nullptr);
     GKO_ASSERT_EQUAL_DIMENSIONS(second_buffer->get_size(), second_global_size);
@@ -430,18 +431,18 @@ TYPED_TEST(GenericVectorCache, SecondInitWithTheSmallEqSizeIsNoOp)
 TYPED_TEST(GenericVectorCache, SecondInitWithTheLargerSizeRecreate)
 {
     using value_type = typename TestFixture::value_type;
-    gko::dim<2> second_local_size{this->rank + 2, 3};
-    gko::dim<2> second_global_size{this->num_ranks * (this->num_ranks + 3) / 2,
-                                   3};
-    this->cache.init(this->ref, this->default_global_size,
-                     this->default_local_size);
-    auto buffer = this->cache.template get<value_type>(this->comm);
+    gko::dim<2> second_local_size(this->rank + 2, 3);
+    gko::dim<2> second_global_size(this->num_ranks * (this->num_ranks + 3) / 2,
+                                   3);
+    auto buffer = this->cache.template get<value_type>(
+        this->ref, this->comm, this->default_global_size,
+        this->default_local_size);
     auto array_ptr =
         generic_accessor::get_workspace(this->cache).get_const_data();
     auto array_size = generic_accessor::get_workspace(this->cache).get_size();
 
-    this->cache.init(this->ref, second_global_size, second_local_size);
-    auto second_buffer = this->cache.template get<value_type>(this->comm);
+    auto second_buffer = this->cache.template get<value_type>(
+        this->ref, this->comm, second_global_size, second_local_size);
 
     ASSERT_NE(second_buffer, nullptr);
     GKO_ASSERT_EQUAL_DIMENSIONS(second_buffer->get_size(), second_global_size);
@@ -460,14 +461,16 @@ TYPED_TEST(GenericVectorCache, GenericCanInitWithSizeAndType)
 {
     using value_type = typename TestFixture::value_type;
     using another_type = gko::next_precision<value_type>;
-    this->cache.init(this->ref, this->default_global_size,
-                     this->default_local_size);
-    auto buffer = this->cache.template get<value_type>(this->comm);
+    auto buffer = this->cache.template get<value_type>(
+        this->ref, this->comm, this->default_global_size,
+        this->default_local_size);
     auto array_ptr =
         generic_accessor::get_workspace(this->cache).get_const_data();
     auto array_size = generic_accessor::get_workspace(this->cache).get_size();
 
-    auto second_buffer = this->cache.template get<another_type>(this->comm);
+    auto second_buffer = this->cache.template get<another_type>(
+        this->ref, this->comm, this->default_global_size,
+        this->default_local_size);
 
     ASSERT_NE(second_buffer, nullptr);
     GKO_ASSERT_EQUAL_DIMENSIONS(second_buffer->get_size(),
@@ -497,16 +500,16 @@ TYPED_TEST(GenericVectorCache, GenericCanInitWithDifferentExecutor)
 {
     using value_type = typename TestFixture::value_type;
     auto another_ref = gko::ReferenceExecutor::create();
-    this->cache.init(this->ref, this->default_global_size,
-                     this->default_local_size);
-    auto buffer = this->cache.template get<value_type>(this->comm);
+    auto buffer = this->cache.template get<value_type>(
+        this->ref, this->comm, this->default_global_size,
+        this->default_local_size);
     auto array_ptr =
         generic_accessor::get_workspace(this->cache).get_const_data();
     auto array_size = generic_accessor::get_workspace(this->cache).get_size();
 
-    this->cache.init(another_ref, this->default_global_size,
-                     this->default_local_size);
-    auto second_buffer = this->cache.template get<value_type>(this->comm);
+    auto second_buffer = this->cache.template get<value_type>(
+        another_ref, this->comm, this->default_global_size,
+        this->default_local_size);
 
     ASSERT_NE(second_buffer, nullptr);
     GKO_ASSERT_EQUAL_DIMENSIONS(second_buffer->get_size(),
@@ -524,9 +527,9 @@ TYPED_TEST(GenericVectorCache, GenericCanInitWithDifferentExecutor)
 TYPED_TEST(GenericVectorCache, WorkspaceIsNotCopied)
 {
     using value_type = typename TestFixture::value_type;
-    this->cache.init(this->ref, this->default_global_size,
-                     this->default_local_size);
-    auto buffer = this->cache.template get<value_type>(this->comm);
+    auto buffer = this->cache.template get<value_type>(
+        this->ref, this->comm, this->default_global_size,
+        this->default_local_size);
 
     gko::experimental::distributed::detail::GenericVectorCache cache(
         this->cache);
@@ -539,9 +542,9 @@ TYPED_TEST(GenericVectorCache, WorkspaceIsNotCopied)
 TYPED_TEST(GenericVectorCache, WorkspaceIsNotMoved)
 {
     using value_type = typename TestFixture::value_type;
-    this->cache.init(this->ref, this->default_global_size,
-                     this->default_local_size);
-    auto buffer = this->cache.template get<value_type>(this->comm);
+    auto buffer = this->cache.template get<value_type>(
+        this->ref, this->comm, this->default_global_size,
+        this->default_local_size);
 
     gko::experimental::distributed::detail::GenericVectorCache cache(
         std::move(this->cache));
@@ -554,9 +557,9 @@ TYPED_TEST(GenericVectorCache, WorkspaceIsNotMoved)
 TYPED_TEST(GenericVectorCache, WorkspaceIsNotCopyAssigned)
 {
     using value_type = typename TestFixture::value_type;
-    this->cache.init(this->ref, this->default_global_size,
-                     this->default_local_size);
-    auto buffer = this->cache.template get<value_type>(this->comm);
+    auto buffer = this->cache.template get<value_type>(
+        this->ref, this->comm, this->default_global_size,
+        this->default_local_size);
     gko::experimental::distributed::detail::GenericVectorCache cache;
 
     cache = this->cache;
@@ -569,9 +572,9 @@ TYPED_TEST(GenericVectorCache, WorkspaceIsNotCopyAssigned)
 TYPED_TEST(GenericVectorCache, WorkspaceIsNotMoveAssigned)
 {
     using value_type = typename TestFixture::value_type;
-    this->cache.init(this->ref, this->default_global_size,
-                     this->default_local_size);
-    auto buffer = this->cache.template get<value_type>(this->comm);
+    auto buffer = this->cache.template get<value_type>(
+        this->ref, this->comm, this->default_global_size,
+        this->default_local_size);
     gko::experimental::distributed::detail::GenericVectorCache cache;
 
     cache = std::move(this->cache);

--- a/core/test/mpi/distributed/vector_cache.cpp
+++ b/core/test/mpi/distributed/vector_cache.cpp
@@ -480,7 +480,7 @@ TYPED_TEST(GenericVectorCache, GenericCanInitWithSizeAndType)
     ASSERT_EQ(second_buffer->get_communicator(), this->comm);
     ASSERT_EQ(second_buffer->get_executor(), this->ref);
     if (sizeof(another_type) > sizeof(value_type)) {
-        // the requring workspace will be bigger if the type is larger.
+        // the requiring workspace will be bigger if the type is larger.
         ASSERT_NE(
             array_ptr,
             generic_accessor::get_workspace(this->cache).get_const_data());

--- a/core/test/mpi/distributed/vector_cache.cpp
+++ b/core/test/mpi/distributed/vector_cache.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -10,6 +10,7 @@
 #include <ginkgo/core/distributed/vector.hpp>
 #include <ginkgo/core/distributed/vector_cache.hpp>
 
+#include "core/distributed/vector_cache_accessor.hpp"
 #include "core/test/utils.hpp"
 
 
@@ -23,19 +24,19 @@ protected:
         : comm(gko::experimental::mpi::communicator(MPI_COMM_WORLD)),
           ref(gko::ReferenceExecutor::create()),
           rank(comm.rank()),
-          num(comm.size()),
+          num_ranks(comm.size()),
           default_local_size(rank + 1, 3),
-          default_global_size((num + 1) * num / 2, 3),
+          default_global_size((num_ranks + 1) * num_ranks / 2, 3),
           default_vector(vector_type::create(this->ref, this->comm,
                                              this->default_global_size,
                                              this->default_local_size))
     {}
 
-    std::shared_ptr<gko::ReferenceExecutor> ref;
     gko::experimental::distributed::detail::VectorCache<value_type> cache;
     gko::experimental::mpi::communicator comm;
+    std::shared_ptr<gko::ReferenceExecutor> ref;
     int rank;
-    int num;
+    int num_ranks;
     gko::dim<2> default_local_size;
     gko::dim<2> default_global_size;
     std::unique_ptr<vector_type> default_vector;
@@ -93,7 +94,7 @@ TYPED_TEST(VectorCache, SecondInitWithDifferentGlobalSizeInitializes)
     auto local_val_ptr = this->cache->get_local_vector()->get_const_values();
     // generate different global size
     gko::dim<2> second_local_size(2 * (this->rank + 1), 3);
-    gko::dim<2> second_global_size((this->num + 1) * this->num, 3);
+    gko::dim<2> second_global_size((this->num_ranks + 1) * this->num_ranks, 3);
 
     this->cache.init(this->ref, this->comm, second_global_size,
                      second_local_size);
@@ -203,7 +204,7 @@ TYPED_TEST(VectorCache,
     auto first_ptr = this->cache.get();
     auto local_val_ptr = this->cache->get_local_vector()->get_const_values();
     gko::dim<2> second_local_size(2 * (this->rank + 1), 3);
-    gko::dim<2> second_global_size((this->num + 1) * this->num, 3);
+    gko::dim<2> second_global_size((this->num_ranks + 1) * this->num_ranks, 3);
     auto vector = vector_type::create(this->ref, this->comm, second_global_size,
                                       second_local_size);
 
@@ -320,4 +321,261 @@ TYPED_TEST(VectorCache, VectorIsNotMoveAssigned)
                                 this->default_global_size);
     GKO_ASSERT_EQUAL_DIMENSIONS(this->cache->get_local_vector()->get_size(),
                                 this->default_local_size);
+}
+
+
+using generic_accessor =
+    gko::experimental::distributed::detail::GenericVectorCacheAccessor;
+
+
+template <typename ValueType>
+class GenericVectorCache : public ::testing::Test {
+protected:
+    using value_type = ValueType;
+
+    GenericVectorCache()
+        : comm(gko::experimental::mpi::communicator(MPI_COMM_WORLD)),
+          ref(gko::ReferenceExecutor::create()),
+          rank(comm.rank()),
+          num_ranks(comm.size()),
+          default_local_size(rank + 1, 3),
+          default_global_size((num_ranks + 1) * num_ranks / 2, 3)
+    {}
+
+    gko::experimental::mpi::communicator comm;
+    std::shared_ptr<gko::ReferenceExecutor> ref;
+    int rank;
+    int num_ranks;
+    gko::dim<2> default_local_size;
+    gko::dim<2> default_global_size;
+    gko::experimental::distributed::detail::GenericVectorCache cache;
+};
+
+TYPED_TEST_SUITE(GenericVectorCache, gko::test::ValueTypes,
+                 TypenameNameGenerator);
+
+
+TYPED_TEST(GenericVectorCache, GenericCanInitWithSize)
+{
+    using value_type = typename TestFixture::value_type;
+
+    this->cache.init(this->ref, this->default_global_size,
+                     this->default_local_size);
+    // only initialize when knowning the type
+    auto buffer = this->cache.template get<value_type>(this->comm);
+
+    ASSERT_NE(buffer, nullptr);
+    GKO_ASSERT_EQUAL_DIMENSIONS(buffer->get_size(), this->default_global_size);
+    GKO_ASSERT_EQUAL_DIMENSIONS(buffer->get_local_vector()->get_size(),
+                                this->default_local_size);
+    ASSERT_EQ(buffer->get_communicator(), this->comm);
+    ASSERT_EQ(buffer->get_executor(), this->ref);
+}
+
+
+TYPED_TEST(GenericVectorCache, SecondInitWithSameSizeIsNoOp)
+{
+    using value_type = typename TestFixture::value_type;
+    this->cache.init(this->ref, this->default_global_size,
+                     this->default_local_size);
+    auto buffer = this->cache.template get<value_type>(this->comm);
+    auto array_ptr =
+        generic_accessor::get_workspace(this->cache).get_const_data();
+    auto array_size = generic_accessor::get_workspace(this->cache).get_size();
+
+    auto second_buffer = this->cache.template get<value_type>(this->comm);
+
+    ASSERT_NE(second_buffer, nullptr);
+    GKO_ASSERT_EQUAL_DIMENSIONS(second_buffer->get_size(),
+                                this->default_global_size);
+    GKO_ASSERT_EQUAL_DIMENSIONS(second_buffer->get_local_vector()->get_size(),
+                                this->default_local_size);
+    ASSERT_EQ(second_buffer->get_communicator(), this->comm);
+    ASSERT_EQ(second_buffer->get_executor(), this->ref);
+    ASSERT_EQ(array_ptr,
+              generic_accessor::get_workspace(this->cache).get_const_data());
+    ASSERT_EQ(array_size,
+              generic_accessor::get_workspace(this->cache).get_size());
+}
+
+
+TYPED_TEST(GenericVectorCache, SecondInitWithTheSmallEqSizeIsNoOp)
+{
+    using value_type = typename TestFixture::value_type;
+    gko::dim<2> second_local_size{1, 1};
+    gko::dim<2> second_global_size{this->num_ranks, 1};
+    this->cache.init(this->ref, this->default_global_size,
+                     this->default_local_size);
+    auto buffer = this->cache.template get<value_type>(this->comm);
+    auto array_ptr =
+        generic_accessor::get_workspace(this->cache).get_const_data();
+    auto array_size = generic_accessor::get_workspace(this->cache).get_size();
+
+    this->cache.init(this->ref, second_global_size, second_local_size);
+    auto second_buffer = this->cache.template get<value_type>(this->comm);
+
+    ASSERT_NE(second_buffer, nullptr);
+    GKO_ASSERT_EQUAL_DIMENSIONS(second_buffer->get_size(), second_global_size);
+    GKO_ASSERT_EQUAL_DIMENSIONS(second_buffer->get_local_vector()->get_size(),
+                                second_local_size);
+    ASSERT_EQ(second_buffer->get_communicator(), this->comm);
+    ASSERT_EQ(second_buffer->get_executor(), this->ref);
+    ASSERT_EQ(array_ptr,
+              generic_accessor::get_workspace(this->cache).get_const_data());
+    ASSERT_EQ(array_size,
+              generic_accessor::get_workspace(this->cache).get_size());
+}
+
+
+TYPED_TEST(GenericVectorCache, SecondInitWithTheLargerSizeRecreate)
+{
+    using value_type = typename TestFixture::value_type;
+    gko::dim<2> second_local_size{this->rank + 2, 3};
+    gko::dim<2> second_global_size{this->num_ranks * (this->num_ranks + 3) / 2,
+                                   3};
+    this->cache.init(this->ref, this->default_global_size,
+                     this->default_local_size);
+    auto buffer = this->cache.template get<value_type>(this->comm);
+    auto array_ptr =
+        generic_accessor::get_workspace(this->cache).get_const_data();
+    auto array_size = generic_accessor::get_workspace(this->cache).get_size();
+
+    this->cache.init(this->ref, second_global_size, second_local_size);
+    auto second_buffer = this->cache.template get<value_type>(this->comm);
+
+    ASSERT_NE(second_buffer, nullptr);
+    GKO_ASSERT_EQUAL_DIMENSIONS(second_buffer->get_size(), second_global_size);
+    GKO_ASSERT_EQUAL_DIMENSIONS(second_buffer->get_local_vector()->get_size(),
+                                second_local_size);
+    ASSERT_EQ(second_buffer->get_communicator(), this->comm);
+    ASSERT_EQ(second_buffer->get_executor(), this->ref);
+    ASSERT_NE(array_ptr,
+              generic_accessor::get_workspace(this->cache).get_const_data());
+    ASSERT_GT(generic_accessor::get_workspace(this->cache).get_size(),
+              array_size);
+}
+
+
+TYPED_TEST(GenericVectorCache, GenericCanInitWithSizeAndType)
+{
+    using value_type = typename TestFixture::value_type;
+    using another_type = gko::next_precision<value_type>;
+    this->cache.init(this->ref, this->default_global_size,
+                     this->default_local_size);
+    auto buffer = this->cache.template get<value_type>(this->comm);
+    auto array_ptr =
+        generic_accessor::get_workspace(this->cache).get_const_data();
+    auto array_size = generic_accessor::get_workspace(this->cache).get_size();
+
+    auto second_buffer = this->cache.template get<another_type>(this->comm);
+
+    ASSERT_NE(second_buffer, nullptr);
+    GKO_ASSERT_EQUAL_DIMENSIONS(second_buffer->get_size(),
+                                this->default_global_size);
+    GKO_ASSERT_EQUAL_DIMENSIONS(second_buffer->get_local_vector()->get_size(),
+                                this->default_local_size);
+    ASSERT_EQ(second_buffer->get_communicator(), this->comm);
+    ASSERT_EQ(second_buffer->get_executor(), this->ref);
+    if (sizeof(another_type) > sizeof(value_type)) {
+        // the requring workspace will be bigger if the type is larger.
+        ASSERT_NE(
+            array_ptr,
+            generic_accessor::get_workspace(this->cache).get_const_data());
+        ASSERT_GT(generic_accessor::get_workspace(this->cache).get_size(),
+                  array_size);
+    } else {
+        ASSERT_EQ(
+            array_ptr,
+            generic_accessor::get_workspace(this->cache).get_const_data());
+        ASSERT_EQ(array_size,
+                  generic_accessor::get_workspace(this->cache).get_size());
+    }
+}
+
+
+TYPED_TEST(GenericVectorCache, GenericCanInitWithDifferentExecutor)
+{
+    using value_type = typename TestFixture::value_type;
+    auto another_ref = gko::ReferenceExecutor::create();
+    this->cache.init(this->ref, this->default_global_size,
+                     this->default_local_size);
+    auto buffer = this->cache.template get<value_type>(this->comm);
+    auto array_ptr =
+        generic_accessor::get_workspace(this->cache).get_const_data();
+    auto array_size = generic_accessor::get_workspace(this->cache).get_size();
+
+    this->cache.init(another_ref, this->default_global_size,
+                     this->default_local_size);
+    auto second_buffer = this->cache.template get<value_type>(this->comm);
+
+    ASSERT_NE(second_buffer, nullptr);
+    GKO_ASSERT_EQUAL_DIMENSIONS(second_buffer->get_size(),
+                                this->default_global_size);
+    GKO_ASSERT_EQUAL_DIMENSIONS(second_buffer->get_local_vector()->get_size(),
+                                this->default_local_size);
+    ASSERT_EQ(second_buffer->get_communicator(), this->comm);
+    ASSERT_EQ(second_buffer->get_executor(), another_ref);
+    // Different executor always regenerate different workspace
+    ASSERT_NE(array_ptr,
+              generic_accessor::get_workspace(this->cache).get_const_data());
+}
+
+
+TYPED_TEST(GenericVectorCache, WorkspaceIsNotCopied)
+{
+    using value_type = typename TestFixture::value_type;
+    this->cache.init(this->ref, this->default_global_size,
+                     this->default_local_size);
+    auto buffer = this->cache.template get<value_type>(this->comm);
+
+    gko::experimental::distributed::detail::GenericVectorCache cache(
+        this->cache);
+
+    ASSERT_EQ(generic_accessor::get_workspace(cache).get_size(), 0);
+    ASSERT_EQ(generic_accessor::get_workspace(cache).get_executor(), nullptr);
+}
+
+
+TYPED_TEST(GenericVectorCache, WorkspaceIsNotMoved)
+{
+    using value_type = typename TestFixture::value_type;
+    this->cache.init(this->ref, this->default_global_size,
+                     this->default_local_size);
+    auto buffer = this->cache.template get<value_type>(this->comm);
+
+    gko::experimental::distributed::detail::GenericVectorCache cache(
+        std::move(this->cache));
+
+    ASSERT_EQ(generic_accessor::get_workspace(cache).get_size(), 0);
+    ASSERT_EQ(generic_accessor::get_workspace(cache).get_executor(), nullptr);
+}
+
+
+TYPED_TEST(GenericVectorCache, WorkspaceIsNotCopyAssigned)
+{
+    using value_type = typename TestFixture::value_type;
+    this->cache.init(this->ref, this->default_global_size,
+                     this->default_local_size);
+    auto buffer = this->cache.template get<value_type>(this->comm);
+    gko::experimental::distributed::detail::GenericVectorCache cache;
+
+    cache = this->cache;
+
+    ASSERT_EQ(generic_accessor::get_workspace(cache).get_size(), 0);
+    ASSERT_EQ(generic_accessor::get_workspace(cache).get_executor(), nullptr);
+}
+
+
+TYPED_TEST(GenericVectorCache, WorkspaceIsNotMoveAssigned)
+{
+    using value_type = typename TestFixture::value_type;
+    this->cache.init(this->ref, this->default_global_size,
+                     this->default_local_size);
+    auto buffer = this->cache.template get<value_type>(this->comm);
+    gko::experimental::distributed::detail::GenericVectorCache cache;
+
+    cache = std::move(this->cache);
+
+    ASSERT_EQ(generic_accessor::get_workspace(cache).get_size(), 0);
+    ASSERT_EQ(generic_accessor::get_workspace(cache).get_executor(), nullptr);
 }

--- a/include/ginkgo/core/base/dense_cache.hpp
+++ b/include/ginkgo/core/base/dense_cache.hpp
@@ -116,7 +116,6 @@ struct GenericDenseCache {
     GenericDenseCache(GenericDenseCache&&) noexcept;
     GenericDenseCache& operator=(const GenericDenseCache&);
     GenericDenseCache& operator=(GenericDenseCache&&) noexcept;
-    mutable array<char> workspace;
 
     /**
      * Pointer access to the underlying vector with specific type.
@@ -126,6 +125,9 @@ struct GenericDenseCache {
     template <typename ValueType>
     std::shared_ptr<matrix::Dense<ValueType>> get(
         std::shared_ptr<const Executor> exec, dim<2> size) const;
+
+private:
+    mutable array<char> workspace;
 };
 
 
@@ -146,10 +148,6 @@ struct ScalarCache {
     ScalarCache(ScalarCache&& other) noexcept;
     ScalarCache& operator=(const ScalarCache& other);
     ScalarCache& operator=(ScalarCache&& other) noexcept;
-    std::shared_ptr<const Executor> exec;
-    double value;
-    mutable std::map<std::string, std::shared_ptr<const gko::LinOp>> scalars;
-
 
     /**
      * Pointer access to the underlying vector with specific type.
@@ -158,6 +156,11 @@ struct ScalarCache {
      */
     template <typename ValueType>
     std::shared_ptr<const matrix::Dense<ValueType>> get() const;
+
+private:
+    std::shared_ptr<const Executor> exec;
+    double value;
+    mutable std::map<std::string, std::shared_ptr<const gko::LinOp>> scalars;
 };
 
 

--- a/include/ginkgo/core/base/dense_cache.hpp
+++ b/include/ginkgo/core/base/dense_cache.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -8,6 +8,8 @@
 
 #include <memory>
 
+#include <ginkgo/core/base/array.hpp>
+#include <ginkgo/core/base/dim.hpp>
 #include <ginkgo/core/base/executor.hpp>
 
 
@@ -87,6 +89,36 @@ struct DenseCache {
      * @return  Pointer to the stored vector.
      */
     matrix::Dense<ValueType>* get() const { return vec.get(); }
+};
+
+
+/**
+ * Manages a workspace to give Dense Vector with different value_type. The
+ * workspace is buffered and reused internally to avoid repeated allocations.
+ * Copying an instance will only yield an empty object since copying the cached
+ * vector would not make sense. The stored object is always mutable, so the
+ * cache can be used in a const-context.
+ *
+ * @internal  The struct is present to wrap cache-like buffer storage that will
+ *            not be copied when the outer object gets copied.
+ */
+struct GenericDenseCache {
+    GenericDenseCache() = default;
+    ~GenericDenseCache() = default;
+    GenericDenseCache(const GenericDenseCache&);
+    GenericDenseCache(GenericDenseCache&&) noexcept;
+    GenericDenseCache& operator=(const GenericDenseCache&);
+    GenericDenseCache& operator=(GenericDenseCache&&) noexcept;
+    mutable array<char> workspace;
+
+    /**
+     * Pointer access to the underlying vector with specific type.
+     *
+     * @return  Pointer to the vector view.
+     */
+    template <typename ValueType>
+    std::shared_ptr<matrix::Dense<ValueType>> get(
+        std::shared_ptr<const Executor> exec, dim<2> size) const;
 };
 
 

--- a/include/ginkgo/core/base/dense_cache.hpp
+++ b/include/ginkgo/core/base/dense_cache.hpp
@@ -99,6 +99,10 @@ struct DenseCache {
 };
 
 
+// helper to access private member for testing
+class GenericDenseCacheAccessor;
+
+
 /**
  * Manages a workspace to give Dense Vector with different value_type. The
  * workspace is buffered and reused internally to avoid repeated allocations.
@@ -110,6 +114,8 @@ struct DenseCache {
  *            not be copied when the outer object gets copied.
  */
 struct GenericDenseCache {
+    friend class GenericDenseCacheAccessor;
+
     GenericDenseCache() = default;
     ~GenericDenseCache() = default;
     GenericDenseCache(const GenericDenseCache&);
@@ -131,6 +137,10 @@ private:
 };
 
 
+// helper to access private member for testing.
+class ScalarCacheAccessor;
+
+
 /**
  * Manages a map to store Dense Scalar with different value_type by a
  * user-specified value. The workspace is buffered and reused internally to
@@ -142,6 +152,8 @@ private:
  *            not be copied when the outer object gets copied.
  */
 struct ScalarCache {
+    friend class ScalarCacheAccessor;
+
     ScalarCache(std::shared_ptr<const Executor> executor, double scalar_value);
     ~ScalarCache() = default;
     ScalarCache(const ScalarCache& other);

--- a/include/ginkgo/core/base/precision_dispatch.hpp
+++ b/include/ginkgo/core/base/precision_dispatch.hpp
@@ -395,6 +395,39 @@ void precision_dispatch(Function fn, Args*... linops)
 }
 
 
+template <typename ValueType, typename Function>
+void mixed_precision_dispatch(Function fn, const LinOp* in, LinOp* out)
+{
+#ifdef GINKGO_MIXED_PRECISION
+    using fst_type = Vector<ValueType>;
+    using snd_type = Vector<next_precision<ValueType, 2>>;
+    using trd_type = Vector<next_precision<ValueType, 3>>;
+    auto dispatch_out_vector = [&](auto vector_in) {
+        if (auto vector_out = dynamic_cast<fst_type*>(out)) {
+            fn(vector_in, vector_out);
+        } else if (auto vector_out = dynamic_cast<snd_type*>(out)) {
+            fn(vector_in, vector_out);
+        } else if (auto vector_out = dynamic_cast<trd_type*>(out)) {
+            fn(vector_in, vector_out);
+        } else {
+            GKO_NOT_SUPPORTED(out);
+        }
+    };
+    if (auto vector_in = dynamic_cast<const fst_type*>(in)) {
+        dispatch_out_vector(vector_in);
+    } else if (auto vector_in = dynamic_cast<const snd_type*>(in)) {
+        dispatch_out_vector(vector_in);
+    } else if (auto vector_in = dynamic_cast<const trd_type*>(in)) {
+        dispatch_out_vector(vector_in);
+    } else {
+        GKO_NOT_SUPPORTED(in);
+    }
+#else
+    precision_dispatch<ValueType>(fn, in, out);
+#endif
+}
+
+
 /**
  * Calls the given function with the given LinOps temporarily converted to
  * experimental::distributed::Vector<ValueType>* as parameters.
@@ -424,6 +457,27 @@ void precision_dispatch_real_complex(Function fn, const LinOp* in, LinOp* out)
            dynamic_cast<Vector*>(dense_out->create_real_view().get()));
     } else {
         distributed::precision_dispatch<ValueType>(fn, in, out);
+    }
+}
+
+
+template <typename ValueType, typename Function>
+void mixed_precision_dispatch_real_complex(Function fn, const LinOp* in,
+                                           LinOp* out)
+{
+    auto complex_to_real = !(
+        is_complex<ValueType>() ||
+        dynamic_cast<const ConvertibleTo<experimental::distributed::Vector<>>*>(
+            in));
+    if (complex_to_real) {
+        distributed::mixed_precision_dispatch<to_complex<ValueType>>(
+            [&fn](auto vector_in, auto vector_out) {
+                fn(vector_in->create_real_view().get(),
+                   vector_out->create_real_view().get());
+            },
+            in, out);
+    } else {
+        distributed::mixed_precision_dispatch<ValueType>(fn, in, out);
     }
 }
 

--- a/include/ginkgo/core/base/precision_dispatch.hpp
+++ b/include/ginkgo/core/base/precision_dispatch.hpp
@@ -423,7 +423,8 @@ void mixed_precision_dispatch(Function fn, const LinOp* in, LinOp* out)
         GKO_NOT_SUPPORTED(in);
     }
 #else
-    precision_dispatch<ValueType>(fn, in, out);
+    // avoid ambiguous
+    distributed::precision_dispatch<ValueType>(fn, in, out);
 #endif
 }
 

--- a/include/ginkgo/core/distributed/matrix.hpp
+++ b/include/ginkgo/core/distributed/matrix.hpp
@@ -699,7 +699,7 @@ protected:
 private:
     std::shared_ptr<RowGatherer<LocalIndexType>> row_gatherer_;
     index_map<local_index_type, global_index_type> imap_;
-    gko::detail::DenseCache<value_type> one_scalar_;
+    gko::detail::ScalarCache one_scalar_;
     detail::VectorCache<value_type> recv_buffer_;
     detail::VectorCache<value_type> host_recv_buffer_;
     std::shared_ptr<LinOp> local_mtx_;

--- a/include/ginkgo/core/distributed/matrix.hpp
+++ b/include/ginkgo/core/distributed/matrix.hpp
@@ -700,8 +700,8 @@ private:
     std::shared_ptr<RowGatherer<LocalIndexType>> row_gatherer_;
     index_map<local_index_type, global_index_type> imap_;
     gko::detail::ScalarCache one_scalar_;
-    detail::VectorCache<value_type> recv_buffer_;
-    detail::VectorCache<value_type> host_recv_buffer_;
+    detail::GenericVectorCache recv_buffer_;
+    detail::GenericVectorCache host_recv_buffer_;
     std::shared_ptr<LinOp> local_mtx_;
     std::shared_ptr<LinOp> non_local_mtx_;
 };

--- a/include/ginkgo/core/distributed/vector_cache.hpp
+++ b/include/ginkgo/core/distributed/vector_cache.hpp
@@ -123,36 +123,28 @@ public:
     GenericVectorCache& operator=(GenericVectorCache&&) noexcept;
 
     /**
-     * Initializes the buffered vector configuration.
-     *
-     * @param exec  Executor associated with the buffered vector
-     * @param global_size  Global size of the buffered vector
-     * @param local_size  Processor-local size of the buffered vector, uses
-     *                    local_size[1] as the stride
-     */
-    void init(std::shared_ptr<const Executor> exec, dim<2> global_size,
-              dim<2> local_size) const;
-
-    /**
-     * Pointer access to the underlying vector with specific type.
-     * Initializes the buffered vector, if
-     * - the current vector is null,
+     * Pointer access to the distributed vector view with specific type on the
+     * underlying workspace Initializes the workspace, if
+     * - the workspace is null,
      * - the sizes differ,
      * - the executor differs.
      *
+     * @param exec  Executor associated with the buffered vector
      * @param comm  Communicator associated with the buffered vector
+     * @param global_size  Global size of the buffered vector
+     * @param local_size  Processor-local size of the buffered vector, uses
+     *                    local_size[1] as the stride
      *
      * @return  Pointer to the vector view.
      */
     template <typename ValueType>
     std::shared_ptr<Vector<ValueType>> get(
-        gko::experimental::mpi::communicator comm) const;
+        std::shared_ptr<const Executor> exec,
+        gko::experimental::mpi::communicator comm, dim<2> global_size,
+        dim<2> local_size) const;
 
 private:
     mutable array<char> workspace;
-    mutable std::shared_ptr<const Executor> exec_;
-    mutable dim<2> global_size_;
-    mutable dim<2> local_size_;
 };
 
 


### PR DESCRIPTION
This PR enables the mixed precision dispatch in distributed matrix.
Moreover, it adds the `ScalarCache` to handle the scalar with user-specified value but with different type (mainly for one scalar) and the `GenericDenseCache` and `GenericVectorCache` to reuse the workspace for Dense view with different value type for the communication buffer. 
Both them will prepare the data during the get not initialized.

Although it is based on the distributed rowGatherer now, it is not required.
