### PR TITLE
Fix various warnings

### DIFF
--- a/common/unified/matrix/csr_kernels.cpp
+++ b/common/unified/matrix/csr_kernels.cpp
@@ -326,8 +326,8 @@ void row_wise_absolute_sum(std::shared_ptr<const DefaultExecutor> exec,
                 sum_ptr[row] += abs(value_ptr[k]);
             }
         },
-        sum.get_num_elems(), orig->get_const_row_ptrs(),
-        orig->get_const_values(), sum.get_data());
+        sum.get_size(), orig->get_const_row_ptrs(), orig->get_const_values(),
+        sum.get_data());
 }
 
 GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(

--- a/hip/base/device.hip.cpp
+++ b/hip/base/device.hip.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -20,7 +20,7 @@ namespace hip {
 void reset_device(int device_id)
 {
     gko::detail::hip_scoped_device_id_guard guard{device_id};
-    hipDeviceReset();
+    (void)hipDeviceReset();
 }
 
 

--- a/hip/base/memory.hip.cpp
+++ b/hip/base/memory.hip.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -30,7 +30,7 @@ namespace gko {
         const auto error_code = _operation;                                \
         if (error_code != hipSuccess) {                                    \
             int device_id{-1};                                             \
-            hipGetDevice(&device_id);                                      \
+            (void)hipGetDevice(&device_id);                                \
             std::cerr << "Unrecoverable HIP error on device " << device_id \
                       << " in " << __func__ << ": "                        \
                       << hipGetErrorName(error_code) << ": "               \

--- a/hip/base/stream.hip.cpp
+++ b/hip/base/stream.hip.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -29,7 +29,7 @@ hip_stream::~hip_stream()
 {
     if (stream_) {
         detail::hip_scoped_device_id_guard g(device_id_);
-        hipStreamDestroy(stream_);
+        (void)hipStreamDestroy(stream_);
     }
 }
 

--- a/hip/test/base/hip_executor.hip.cpp
+++ b/hip/test/base/hip_executor.hip.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -51,7 +51,7 @@ public:
 
     void run(std::shared_ptr<const gko::HipExecutor>) const override
     {
-        hipGetDevice(&value);
+        GKO_ASSERT_NO_HIP_ERRORS(hipGetDevice(&value));
     }
 
     int& value;
@@ -124,7 +124,7 @@ TEST_F(HipExecutor, CanInstantiateTwoExecutorsOnOneDevice)
 TEST_F(HipExecutor, MasterKnowsNumberOfDevices)
 {
     int count = 0;
-    hipGetDeviceCount(&count);
+    GKO_ASSERT_NO_HIP_ERRORS(hipGetDeviceCount(&count));
 
     auto num_devices = gko::HipExecutor::get_num_devices();
 

--- a/hip/test/base/scoped_device_id.hip.cpp
+++ b/hip/test/base/scoped_device_id.hip.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -30,7 +30,7 @@ TEST_F(ScopedDeviceIdGuard, SetsId)
     gko::detail::hip_scoped_device_id_guard g{new_device_id};
 
     int device_id;
-    hipGetDevice(&device_id);
+    GKO_ASSERT_NO_HIP_ERRORS(hipGetDevice(&device_id));
     ASSERT_EQ(device_id, new_device_id);
 }
 
@@ -45,7 +45,7 @@ TEST_F(ScopedDeviceIdGuard, ResetsId)
     }
 
     int device_id;
-    hipGetDevice(&device_id);
+    GKO_ASSERT_NO_HIP_ERRORS(hipGetDevice(&device_id));
     ASSERT_EQ(device_id, old_device_id);
 }
 


### PR DESCRIPTION
These popped up repeatedly. They appear because HIP uses `[[nodiscard]]` and we deprecated `get_num_elems()`