### PR TITLE
Show correct line numbers in generated source lines for common tests

### DIFF
--- a/cmake/create_test.cmake
+++ b/cmake/create_test.cmake
@@ -419,6 +419,11 @@ function(ginkgo_create_common_device_test test_name)
         "${gko_test_multi_args}"
     )
     ginkgo_build_test_name(${test_name} test_target_name ${ARGN})
+    # the line number 5 here needs to match the line number that
+    # /*@GKO_PREPROCESSOR_FILENAME_HELPER@*/ is placed in the source file
+    set(GKO_PREPROCESSOR_FILENAME_HELPER
+        "*/\n#line 5 \"${CMAKE_CURRENT_SOURCE_DIR}/${test_name}.cpp\"\n/*"
+    )
     if(
         GINKGO_BUILD_SYCL
         AND NOT ("dpcpp" IN_LIST common_device_test_DISABLE_EXECUTORS)
@@ -429,7 +434,7 @@ function(ginkgo_create_common_device_test test_name)
             PRIVATE ${GINKGO_DPCPP_FLAGS}
         )
         # We need to use a new file to avoid sycl setting in other backends because add_sycl_to_target will change the source property.
-        configure_file(${test_name}.cpp ${test_name}.dp.cpp COPYONLY)
+        configure_file(${test_name}.cpp ${test_name}.dp.cpp @ONLY)
         gko_add_sycl_to_target(TARGET ${test_target_name}_dpcpp SOURCES ${test_name}.dp.cpp)
         target_link_options(
             ${test_target_name}_dpcpp
@@ -448,7 +453,7 @@ function(ginkgo_create_common_device_test test_name)
         AND NOT ("cuda" IN_LIST common_device_test_DISABLE_EXECUTORS)
     )
         # need to make a separate file for this, since we can't set conflicting properties on the same file
-        configure_file(${test_name}.cpp ${test_name}.cu COPYONLY)
+        configure_file(${test_name}.cpp ${test_name}.cu @ONLY)
         ginkgo_create_cuda_test_internal(${test_name}_cuda ${CMAKE_CURRENT_BINARY_DIR}/${test_name}.cu ${test_target_name}_cuda ${ARGN})
         target_compile_definitions(
             ${test_target_name}_cuda
@@ -460,7 +465,7 @@ function(ginkgo_create_common_device_test test_name)
         AND NOT ("hip" IN_LIST common_device_test_DISABLE_EXECUTORS)
     )
         # need to make a separate file for this, since we can't set conflicting properties on the same file
-        configure_file(${test_name}.cpp ${test_name}.hip.cpp COPYONLY)
+        configure_file(${test_name}.cpp ${test_name}.hip.cpp @ONLY)
         ginkgo_create_hip_test_internal(${test_name}_hip ${CMAKE_CURRENT_BINARY_DIR}/${test_name}.hip.cpp ${test_target_name}_hip ${ARGN})
         target_compile_definitions(
             ${test_target_name}_hip

--- a/test/base/index_range.cpp
+++ b/test/base/index_range.cpp
@@ -1,6 +1,8 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
+
+/*@GKO_PREPROCESSOR_FILENAME_HELPER@*/
 
 #include "core/base/index_range.hpp"
 

--- a/test/base/intrinsics.cpp
+++ b/test/base/intrinsics.cpp
@@ -2,6 +2,8 @@
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
+/*@GKO_PREPROCESSOR_FILENAME_HELPER@*/
+
 #include "core/base/intrinsics.hpp"
 
 #include <memory>

--- a/test/base/iterator_factory.cpp
+++ b/test/base/iterator_factory.cpp
@@ -1,6 +1,8 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
+
+/*@GKO_PREPROCESSOR_FILENAME_HELPER@*/
 
 #include "core/base/iterator_factory.hpp"
 

--- a/test/base/kernel_launch_generic.cpp
+++ b/test/base/kernel_launch_generic.cpp
@@ -1,6 +1,8 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
+
+/*@GKO_PREPROCESSOR_FILENAME_HELPER@*/
 
 #include <algorithm>
 #include <memory>

--- a/test/base/segmented_range.cpp
+++ b/test/base/segmented_range.cpp
@@ -1,6 +1,8 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
+
+/*@GKO_PREPROCESSOR_FILENAME_HELPER@*/
 
 #include "core/base/segmented_range.hpp"
 

--- a/test/components/range_minimum_query_kernels.cpp
+++ b/test/components/range_minimum_query_kernels.cpp
@@ -2,6 +2,8 @@
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
+/*@GKO_PREPROCESSOR_FILENAME_HELPER@*/
+
 #include "core/components/range_minimum_query_kernels.hpp"
 
 #include <limits>

--- a/test/matrix/csr_kernels.cpp
+++ b/test/matrix/csr_kernels.cpp
@@ -2,6 +2,8 @@
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
+/*@GKO_PREPROCESSOR_FILENAME_HELPER@*/
+
 #include "core/matrix/csr_kernels.hpp"
 
 #include <algorithm>


### PR DESCRIPTION
For CUDA/HIP and DPCPP, we create separate copies of the source files using configure_file(...) to apply different CMake file properties to them. For the compiler to report error messages with the correct source file name, this adds a #line preprocessor statement to the top of these generated files.