### PR TITLE
Add `array::copy_to_host` function

### DIFF
--- a/core/test/base/array.cpp
+++ b/core/test/base/array.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -216,6 +216,16 @@ TYPED_TEST(Array, CanBeCopiedToExecutorlessArray)
 
     ASSERT_EQ(a.get_executor(), this->x.get_executor());
     this->assert_equal_to_original_x(a);
+}
+
+
+TYPED_TEST(Array, CanBeCopiedToHost)
+{
+    std::vector<TypeParam> ref{5, 2};
+
+    auto vec = this->x.copy_to_host();
+
+    ASSERT_EQ(vec, ref);
 }
 
 

--- a/cuda/test/base/array.cpp
+++ b/cuda/test/base/array.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -55,6 +55,15 @@ TYPED_TEST(Array, CanCopyBackTemporaryCloneOnDifferentExecutor)
     }
 
     this->assert_equal_to_original_x(this->x);
+}
+
+
+TYPED_TEST(Array, CanCopyToHost)
+{
+    using T = TypeParam;
+    auto arr = gko::array<T>(this->exec, I<T>{4, 6});
+
+    ASSERT_EQ(arr.copy_to_host(), (std::vector<T>{4, 6}));
 }
 
 

--- a/include/ginkgo/core/base/array.hpp
+++ b/include/ginkgo/core/base/array.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -639,6 +639,20 @@ public:
         } else {
             this->clear();
         }
+    }
+
+    /**
+     * Copies the data into an std::vector.
+     *
+     * @return an std::vector containing this array's data.
+     */
+    std::vector<value_type> copy_to_host() const
+    {
+        std::vector<value_type> result(this->get_size());
+        auto view = make_array_view(this->get_executor()->get_master(),
+                                    this->get_size(), result.data());
+        view = *this;
+        return result;
     }
 
     /**


### PR DESCRIPTION
For debugging and development purposes, this makes it easier to get a host view of device data.