### PR TITLE
Add complex type support for hipBLAS GEAM

### DIFF
--- a/hip/base/hipblas_bindings.hip.hpp
+++ b/hip/base/hipblas_bindings.hip.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -119,7 +119,9 @@ GKO_BIND_HIPBLAS_GEMM(ValueType, detail::not_implemented);
 
 GKO_BIND_HIPBLAS_GEAM(float, hipblasSgeam);
 GKO_BIND_HIPBLAS_GEAM(double, hipblasDgeam);
-// Hipblas does not provide geam complex version yet.
+GKO_BIND_HIPBLAS_GEAM(std::complex<float>, hipblasCgeam);
+GKO_BIND_HIPBLAS_GEAM(std::complex<double>, hipblasZgeam);
+
 template <typename ValueType>
 GKO_BIND_HIPBLAS_GEAM(ValueType, detail::not_implemented);
 

--- a/test/matrix/dense_kernels.cpp
+++ b/test/matrix/dense_kernels.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -656,10 +656,6 @@ TEST_F(Dense, IsTransposableIntoDenseCrossExecutor)
 }
 
 
-// HIP doesn't support complex in all our supported versions yet
-#ifndef GKO_COMPILING_HIP
-
-
 TEST_F(Dense, IsConjugateTransposable)
 {
     set_up_apply_data();
@@ -690,9 +686,6 @@ TEST_F(Dense, IsConjugateTransposableIntoDenseCrossExecutor)
 
     GKO_ASSERT_MTX_NEAR(dtrans, trans, 0);
 }
-
-
-#endif
 
 
 TEST_F(Dense, CopyRespectsStride)

--- a/test/matrix/fbcsr_kernels.cpp
+++ b/test/matrix/fbcsr_kernels.cpp
@@ -60,11 +60,8 @@ protected:
     }
 };
 
-#ifdef GKO_COMPILING_HIP
-TYPED_TEST_SUITE(Fbcsr, gko::test::RealValueTypes, TypenameNameGenerator);
-#else
 TYPED_TEST_SUITE(Fbcsr, gko::test::ValueTypes, TypenameNameGenerator);
-#endif
+
 
 TYPED_TEST(Fbcsr, CanWriteFromMatrixOnDevice)
 {


### PR DESCRIPTION
`cgeam` and `zgeam` were added to hipBLAS in [ROCm 3.6.0](https://github.com/ROCm/hipBLAS/blob/develop/CHANGELOG.md#hipblas-0300-for-rocm-360), so we can expand the hipBLAS bindings.

(Needed over in #1814)