### PR TITLE
Move CI job and fix cuda12.2 cusparse matrix, coo exception, workspace reallcation

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -662,9 +662,6 @@ cudamemcheck:
     - .default_variables
     - .deploy_condition
     - .use_gko_cuda110-mvapich-gnu9-llvm9
-  tags:
-    - private_ci
-    - nvidia-gpu
   script:
     - ctest -V -S cmake/CTestScript.cmake -DCTEST_BUILD_CONFIGURATION=RelWithDebInfo
       -DCTEST_MEMORYCHECK_TYPE=CudaMemcheck

--- a/.gitlab/image.yml
+++ b/.gitlab/image.yml
@@ -1,7 +1,6 @@
 .use_status-job-settings:
   image: ginkgohub/cpu:openmpi-gnu9-llvm8
   tags:
-    - private_ci
     - status-jobs
 
 .use_gko-nocuda-openmpi-gnu9-llvm8:
@@ -13,33 +12,32 @@
 .use_gko-nocuda-nompi-gnu9-llvm8:
   image: ginkgohub/cpu:openmpi-gnu9-llvm8
   tags:
-    - private_ci
     - cpu
-    - amdci
+    - tum
 
 .use_gko_cuda110-mvapich-gnu9-llvm9:
   image: ginkgohub/cuda:110-mvapich2-gnu9-llvm9-intel2020
   tags:
-    - private_ci
-    - nvidia-gpu
+    - tum
+    - nvidia-gpus-p100
 
 .use_gko_cuda114-openmpi-gnu10-llvm12:
   image: ginkgohub/cuda:114-openmpi-gnu10-llvm12
   tags:
-    - private_ci
-    - nvidia-gpu
+    - tum
+    - nvidia-gpus-p100
 
 .use_gko_nvhpc233-cuda120-openmpi-gnu12-llvm16:
   image: ginkgohub/nvhpc:233-cuda120-openmpi-gnu12-llvm16
   tags:
-    - private_ci
-    - nvidia-gpu
+    - tum
+    - nvidia-gpus
 
 .use_gko_nvhpc227-cuda117-openmpi-gnu11-llvm14:
   image: ginkgohub/nvhpc:227-cuda117-openmpi-gnu11-llvm14
   tags:
-    - private_ci
-    - nvidia-gpu
+    - tum
+    - nvidia-gpus-p100
 
 .use_gko-rocm45-nompi-gnu8-llvm8:
   image: ginkgohub/rocm:45-mvapich2-gnu8-llvm8

--- a/common/cuda_hip/matrix/coo_kernels.cpp
+++ b/common/cuda_hip/matrix/coo_kernels.cpp
@@ -267,6 +267,9 @@ void spmv2(std::shared_ptr<const DefaultExecutor> exec,
     const dim3 coo_block(config::warp_size, warps_in_block, 1);
     const auto nwarps = host_kernel::calculate_nwarps(exec, nnz);
 
+    if (nwarps <= 0 || b_ncols <= 0) {
+        return;
+    }
 // not support 16 bit atomic
 #if !(defined(CUDA_VERSION) && (__CUDA_ARCH__ >= 700))
     if constexpr (sizeof(remove_complex<ValueType>) == sizeof(int16)) {
@@ -274,31 +277,29 @@ void spmv2(std::shared_ptr<const DefaultExecutor> exec,
     } else
 #endif
     {
-        if (nwarps > 0 && b_ncols > 0) {
-            // TODO: b_ncols needs to be tuned for ROCm.
-            if (b_ncols < 4) {
-                const dim3 coo_grid(ceildiv(nwarps, warps_in_block), b_ncols);
-                int num_lines = ceildiv(nnz, nwarps * config::warp_size);
+        // TODO: b_ncols needs to be tuned for ROCm.
+        if (b_ncols < 4) {
+            const dim3 coo_grid(ceildiv(nwarps, warps_in_block), b_ncols);
+            int num_lines = ceildiv(nnz, nwarps * config::warp_size);
 
-                abstract_spmv<<<coo_grid, coo_block, 0, exec->get_stream()>>>(
-                    nnz, num_lines, as_device_type(a->get_const_values()),
-                    a->get_const_col_idxs(),
-                    as_device_type(a->get_const_row_idxs()),
-                    as_device_type(b->get_const_values()), b->get_stride(),
-                    as_device_type(c->get_values()), c->get_stride());
-            } else {
-                int num_elems = ceildiv(nnz, nwarps * config::warp_size) *
-                                config::warp_size;
-                const dim3 coo_grid(ceildiv(nwarps, warps_in_block),
-                                    ceildiv(b_ncols, config::warp_size));
+            abstract_spmv<<<coo_grid, coo_block, 0, exec->get_stream()>>>(
+                nnz, num_lines, as_device_type(a->get_const_values()),
+                a->get_const_col_idxs(),
+                as_device_type(a->get_const_row_idxs()),
+                as_device_type(b->get_const_values()), b->get_stride(),
+                as_device_type(c->get_values()), c->get_stride());
+        } else {
+            int num_elems =
+                ceildiv(nnz, nwarps * config::warp_size) * config::warp_size;
+            const dim3 coo_grid(ceildiv(nwarps, warps_in_block),
+                                ceildiv(b_ncols, config::warp_size));
 
-                abstract_spmm<<<coo_grid, coo_block, 0, exec->get_stream()>>>(
-                    nnz, num_elems, as_device_type(a->get_const_values()),
-                    a->get_const_col_idxs(),
-                    as_device_type(a->get_const_row_idxs()), b_ncols,
-                    as_device_type(b->get_const_values()), b->get_stride(),
-                    as_device_type(c->get_values()), c->get_stride());
-            }
+            abstract_spmm<<<coo_grid, coo_block, 0, exec->get_stream()>>>(
+                nnz, num_elems, as_device_type(a->get_const_values()),
+                a->get_const_col_idxs(),
+                as_device_type(a->get_const_row_idxs()), b_ncols,
+                as_device_type(b->get_const_values()), b->get_stride(),
+                as_device_type(c->get_values()), c->get_stride());
         }
     }
 }
@@ -318,6 +319,9 @@ void advanced_spmv2(std::shared_ptr<const DefaultExecutor> exec,
     const dim3 coo_block(config::warp_size, warps_in_block, 1);
     const auto b_ncols = b->get_size()[1];
 
+    if (nwarps <= 0 || b_ncols <= 0) {
+        return;
+    }
     // not support 16 bit atomic
 #if !(defined(CUDA_VERSION) && (__CUDA_ARCH__ >= 700))
     if constexpr (sizeof(remove_complex<ValueType>) == sizeof(int16)) {
@@ -325,33 +329,29 @@ void advanced_spmv2(std::shared_ptr<const DefaultExecutor> exec,
     } else
 #endif
     {
-        if (nwarps > 0 && b_ncols > 0) {
-            // TODO: b_ncols needs to be tuned for ROCm.
-            if (b_ncols < 4) {
-                int num_lines = ceildiv(nnz, nwarps * config::warp_size);
-                const dim3 coo_grid(ceildiv(nwarps, warps_in_block), b_ncols);
+        // TODO: b_ncols needs to be tuned for ROCm.
+        if (b_ncols < 4) {
+            int num_lines = ceildiv(nnz, nwarps * config::warp_size);
+            const dim3 coo_grid(ceildiv(nwarps, warps_in_block), b_ncols);
 
-                abstract_spmv<<<coo_grid, coo_block, 0, exec->get_stream()>>>(
-                    nnz, num_lines, as_device_type(alpha->get_const_values()),
-                    as_device_type(a->get_const_values()),
-                    a->get_const_col_idxs(),
-                    as_device_type(a->get_const_row_idxs()),
-                    as_device_type(b->get_const_values()), b->get_stride(),
-                    as_device_type(c->get_values()), c->get_stride());
-            } else {
-                int num_elems = ceildiv(nnz, nwarps * config::warp_size) *
-                                config::warp_size;
-                const dim3 coo_grid(ceildiv(nwarps, warps_in_block),
-                                    ceildiv(b_ncols, config::warp_size));
+            abstract_spmv<<<coo_grid, coo_block, 0, exec->get_stream()>>>(
+                nnz, num_lines, as_device_type(alpha->get_const_values()),
+                as_device_type(a->get_const_values()), a->get_const_col_idxs(),
+                as_device_type(a->get_const_row_idxs()),
+                as_device_type(b->get_const_values()), b->get_stride(),
+                as_device_type(c->get_values()), c->get_stride());
+        } else {
+            int num_elems =
+                ceildiv(nnz, nwarps * config::warp_size) * config::warp_size;
+            const dim3 coo_grid(ceildiv(nwarps, warps_in_block),
+                                ceildiv(b_ncols, config::warp_size));
 
-                abstract_spmm<<<coo_grid, coo_block, 0, exec->get_stream()>>>(
-                    nnz, num_elems, as_device_type(alpha->get_const_values()),
-                    as_device_type(a->get_const_values()),
-                    a->get_const_col_idxs(),
-                    as_device_type(a->get_const_row_idxs()), b_ncols,
-                    as_device_type(b->get_const_values()), b->get_stride(),
-                    as_device_type(c->get_values()), c->get_stride());
-            }
+            abstract_spmm<<<coo_grid, coo_block, 0, exec->get_stream()>>>(
+                nnz, num_elems, as_device_type(alpha->get_const_values()),
+                as_device_type(a->get_const_values()), a->get_const_col_idxs(),
+                as_device_type(a->get_const_row_idxs()), b_ncols,
+                as_device_type(b->get_const_values()), b->get_stride(),
+                as_device_type(c->get_values()), c->get_stride());
         }
     }
 }

--- a/dpcpp/matrix/coo_kernels.dp.cpp
+++ b/dpcpp/matrix/coo_kernels.dp.cpp
@@ -290,32 +290,33 @@ void spmv2(std::shared_ptr<const DpcppExecutor> exec,
     const dim3 coo_block(config::warp_size, warps_in_block, 1);
     const auto nwarps = host_kernel::calculate_nwarps(exec, nnz);
 
+    if (nwarps <= 0 || b_ncols <= 0) {
+        return;
+    }
     // not support 16 bit atomic
     if constexpr (sizeof(remove_complex<ValueType>) == sizeof(int16)) {
         GKO_NOT_SUPPORTED(c);
     } else {
-        if (nwarps > 0) {
-            if (b_ncols < 4) {
-                const dim3 coo_grid(ceildiv(nwarps, warps_in_block), b_ncols);
-                int num_lines = ceildiv(nnz, nwarps * config::warp_size);
-                abstract_spmv(coo_grid, coo_block, 0, exec->get_queue(), nnz,
-                              num_lines, as_device_type(a->get_const_values()),
-                              a->get_const_col_idxs(), a->get_const_row_idxs(),
-                              as_device_type(b->get_const_values()),
-                              b->get_stride(), as_device_type(c->get_values()),
-                              c->get_stride());
-            } else {
-                int num_elems = ceildiv(nnz, nwarps * config::warp_size) *
-                                config::warp_size;
-                const dim3 coo_grid(ceildiv(nwarps, warps_in_block),
-                                    ceildiv(b_ncols, config::warp_size));
-                abstract_spmm(coo_grid, coo_block, 0, exec->get_queue(), nnz,
-                              num_elems, as_device_type(a->get_const_values()),
-                              a->get_const_col_idxs(), a->get_const_row_idxs(),
-                              b_ncols, as_device_type(b->get_const_values()),
-                              b->get_stride(), as_device_type(c->get_values()),
-                              c->get_stride());
-            }
+        if (b_ncols < 4) {
+            const dim3 coo_grid(ceildiv(nwarps, warps_in_block), b_ncols);
+            int num_lines = ceildiv(nnz, nwarps * config::warp_size);
+            abstract_spmv(coo_grid, coo_block, 0, exec->get_queue(), nnz,
+                          num_lines, as_device_type(a->get_const_values()),
+                          a->get_const_col_idxs(), a->get_const_row_idxs(),
+                          as_device_type(b->get_const_values()),
+                          b->get_stride(), as_device_type(c->get_values()),
+                          c->get_stride());
+        } else {
+            int num_elems =
+                ceildiv(nnz, nwarps * config::warp_size) * config::warp_size;
+            const dim3 coo_grid(ceildiv(nwarps, warps_in_block),
+                                ceildiv(b_ncols, config::warp_size));
+            abstract_spmm(coo_grid, coo_block, 0, exec->get_queue(), nnz,
+                          num_elems, as_device_type(a->get_const_values()),
+                          a->get_const_col_idxs(), a->get_const_row_idxs(),
+                          b_ncols, as_device_type(b->get_const_values()),
+                          b->get_stride(), as_device_type(c->get_values()),
+                          c->get_stride());
         }
     }
 }
@@ -335,34 +336,35 @@ void advanced_spmv2(std::shared_ptr<const DpcppExecutor> exec,
     const dim3 coo_block(config::warp_size, warps_in_block, 1);
     const auto b_ncols = b->get_size()[1];
 
+    if (nwarps <= 0 || b_ncols <= 0) {
+        return;
+    }
     // not support 16 bit atomic
     if constexpr (sizeof(remove_complex<ValueType>) == sizeof(int16)) {
         GKO_NOT_SUPPORTED(c);
     } else {
-        if (nwarps > 0) {
-            if (b_ncols < 4) {
-                int num_lines = ceildiv(nnz, nwarps * config::warp_size);
-                const dim3 coo_grid(ceildiv(nwarps, warps_in_block), b_ncols);
-                abstract_spmv(
-                    coo_grid, coo_block, 0, exec->get_queue(), nnz, num_lines,
-                    as_device_type(alpha->get_const_values()),
-                    as_device_type(a->get_const_values()),
-                    a->get_const_col_idxs(), a->get_const_row_idxs(),
-                    as_device_type(b->get_const_values()), b->get_stride(),
-                    as_device_type(c->get_values()), c->get_stride());
-            } else {
-                int num_elems = ceildiv(nnz, nwarps * config::warp_size) *
-                                config::warp_size;
-                const dim3 coo_grid(ceildiv(nwarps, warps_in_block),
-                                    ceildiv(b_ncols, config::warp_size));
-                abstract_spmm(
-                    coo_grid, coo_block, 0, exec->get_queue(), nnz, num_elems,
-                    as_device_type(alpha->get_const_values()),
-                    as_device_type(a->get_const_values()),
-                    a->get_const_col_idxs(), a->get_const_row_idxs(), b_ncols,
-                    as_device_type(b->get_const_values()), b->get_stride(),
-                    as_device_type(c->get_values()), c->get_stride());
-            }
+        if (b_ncols < 4) {
+            int num_lines = ceildiv(nnz, nwarps * config::warp_size);
+            const dim3 coo_grid(ceildiv(nwarps, warps_in_block), b_ncols);
+            abstract_spmv(coo_grid, coo_block, 0, exec->get_queue(), nnz,
+                          num_lines, as_device_type(alpha->get_const_values()),
+                          as_device_type(a->get_const_values()),
+                          a->get_const_col_idxs(), a->get_const_row_idxs(),
+                          as_device_type(b->get_const_values()),
+                          b->get_stride(), as_device_type(c->get_values()),
+                          c->get_stride());
+        } else {
+            int num_elems =
+                ceildiv(nnz, nwarps * config::warp_size) * config::warp_size;
+            const dim3 coo_grid(ceildiv(nwarps, warps_in_block),
+                                ceildiv(b_ncols, config::warp_size));
+            abstract_spmm(coo_grid, coo_block, 0, exec->get_queue(), nnz,
+                          num_elems, as_device_type(alpha->get_const_values()),
+                          as_device_type(a->get_const_values()),
+                          a->get_const_col_idxs(), a->get_const_row_idxs(),
+                          b_ncols, as_device_type(b->get_const_values()),
+                          b->get_stride(), as_device_type(c->get_values()),
+                          c->get_stride());
         }
     }
 }


### PR DESCRIPTION
This PR extracts some part from #1841 . This PR does not add the spack availability or more jobs.

- move the job from amdci to tum
  - ~~cuda below 11.8 only check build not test now because current setup can not always get the gpu supported by these compiler~~
  - ~~cudamemcheck task uses cuda12 docker image and compute-sanitizer not cuda11 with the same reason. TODO: check whether it work or not~~
  - some old cuda jobs can be moved to P100 now, so we do not have above changes
  - wait for cuda memcheck from https://gitlab.com/ginkgo-project/ginkgo-public-ci/-/jobs/10059330364
- fix coo exception on empty matrix
- fix row gatherer workspace reallocation
- fix cuda12.2 csr does not accept nullptr as row ptr in the beginning.
- use csr for non-local matrix in the test because some of backend does not support Coo spmv on 16bit operation