### PR TITLE
Avoid to fill fixed-value scalar in workspace repeatedly in each apply

### DIFF
--- a/core/solver/gmres.cpp
+++ b/core/solver/gmres.cpp
@@ -248,7 +248,7 @@ template <typename ValueType, typename VectorType>
 void orthogonalize_cgs2(matrix::Dense<ValueType>* hessenberg_iter,
                         VectorType* krylov_bases, VectorType* next_krylov,
                         matrix::Dense<ValueType>* hessenberg_aux,
-                        matrix::Dense<ValueType>* one_op,
+                        const matrix::Dense<ValueType>* one_op,
                         size_type restart_iter, size_type num_rows,
                         size_type num_rhs, size_type local_num_rows)
 {

--- a/core/solver/solver_boilerplate.hpp
+++ b/core/solver/solver_boilerplate.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -19,13 +19,11 @@
         GKO_SOLVER_TRAITS::_x, _template->get_size()[1])
 
 
-#define GKO_SOLVER_ONE_MINUS_ONE()                                       \
-    auto one_op = this->template create_workspace_scalar<ValueType>(     \
-        GKO_SOLVER_TRAITS::one, 1);                                      \
-    auto neg_one_op = this->template create_workspace_scalar<ValueType>( \
-        GKO_SOLVER_TRAITS::minus_one, 1);                                \
-    one_op->fill(one<ValueType>());                                      \
-    neg_one_op->fill(-one<ValueType>())
+#define GKO_SOLVER_ONE_MINUS_ONE()                                             \
+    auto one_op = this->template create_workspace_fixed_scalar<ValueType>(     \
+        GKO_SOLVER_TRAITS::one, 1, one<ValueType>());                          \
+    auto neg_one_op = this->template create_workspace_fixed_scalar<ValueType>( \
+        GKO_SOLVER_TRAITS::minus_one, 1, -one<ValueType>())
 
 #define GKO_SOLVER_STOP_REDUCTION_ARRAYS()                      \
     auto& stop_status =                                         \

--- a/include/ginkgo/core/solver/solver_base.hpp
+++ b/include/ginkgo/core/solver/solver_base.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -471,6 +471,21 @@ protected:
             [&] {
                 return matrix::Dense<ValueType>::create(
                     workspace_.get_executor(), dim<2>{1, size});
+            },
+            typeid(matrix::Dense<ValueType>), gko::dim<2>{1, size}, size);
+    }
+
+    template <typename ValueType>
+    const matrix::Dense<ValueType>* create_workspace_fixed_scalar(
+        int vector_id, size_type size, ValueType val) const
+    {
+        return workspace_.template create_or_get_op<matrix::Dense<ValueType>>(
+            vector_id,
+            [&] {
+                auto mat = matrix::Dense<ValueType>::create(
+                    workspace_.get_executor(), dim<2>{1, size});
+                mat->fill(val);
+                return mat;
             },
             typeid(matrix::Dense<ValueType>), gko::dim<2>{1, size}, size);
     }


### PR DESCRIPTION
This PR avoids to fill fixed-value scalar in workspace repeatedly in each apply especially for one and neg_one op.
Although I think one and neg_one should be in the class itself not workspace when revisiting it, it is another topic not for this PR.