### PR TITLE
Fix wrong ballot result on H100 during 12.2 - 12.4 (or before 12.5.1)

### DIFF
--- a/common/cuda_hip/components/bitvector.hpp
+++ b/common/cuda_hip/components/bitvector.hpp
@@ -49,7 +49,7 @@ __global__ __launch_bounds__(default_block_size) void from_predicate(
         group::tiled_partition<block_size>(group::this_thread_block());
     const auto i = static_cast<IndexType>(subwarp_base + subwarp.thread_rank());
     const auto bit = i < size ? predicate(i) : false;
-    const auto mask = subwarp.ballot(bit);
+    const auto mask = group::ballot(subwarp, bit);
     if (subwarp.thread_rank() == 0) {
         bits[subwarp_id] = mask;
         popcounts[subwarp_id] = gko::detail::popcount(mask);

--- a/common/cuda_hip/factorization/cholesky_kernels.cpp
+++ b/common/cuda_hip/factorization/cholesky_kernels.cpp
@@ -143,7 +143,7 @@ __global__ __launch_bounds__(default_block_size) void symbolic_factorize(
         const auto next_node =
             nz < lower_end - 1 ? postorder_cols[nz + 1] : diag_postorder;
         bool pred = node < next_node;
-        auto mask = subwarp.ballot(pred);
+        auto mask = group::ballot(subwarp, pred);
         while (mask) {
             if (pred) {
                 const auto out_nz = out_base + popcnt(mask & prefix_mask);
@@ -152,7 +152,7 @@ __global__ __launch_bounds__(default_block_size) void symbolic_factorize(
                 pred = node < next_node;
             }
             out_base += popcnt(mask);
-            mask = subwarp.ballot(pred);
+            mask = group::ballot(subwarp, pred);
         }
     }
     // add diagonal entry

--- a/common/cuda_hip/factorization/factorization_kernels.cpp
+++ b/common/cuda_hip/factorization/factorization_kernels.cpp
@@ -187,7 +187,7 @@ __launch_bounds__(default_block_size) void add_missing_diagonal_elements(
                     thread_is_active ? old_col_idxs[old_idx] : IndexType{};
                 // automatically false if thread is not active
                 bool diagonal_add_required = !diagonal_added && row < col_idx;
-                auto ballot = subwarp_grp.ballot(diagonal_add_required);
+                auto ballot = group::ballot(subwarp_grp, diagonal_add_required);
 
                 if (ballot) {
                     auto first_subwarp_idx = ffs(ballot) - 1;

--- a/common/cuda_hip/factorization/par_ilut_filter_kernels.hpp
+++ b/common/cuda_hip/factorization/par_ilut_filter_kernels.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -50,7 +50,7 @@ __device__ void abstract_filter_impl(const IndexType* row_ptrs,
     for (IndexType step = 0; step < num_steps; ++step) {
         auto idx = begin + lane + step * subwarp_size;
         auto keep = idx < end && pred(idx, begin, end);
-        auto mask = subwarp.ballot(keep);
+        auto mask = group::ballot(subwarp, keep);
         step_cb(row, idx, keep, popcnt(mask), popcnt(mask & lane_prefix_mask));
     }
     finish_cb(row, lane);

--- a/common/cuda_hip/factorization/par_ilut_spgeam_kernels.cpp
+++ b/common/cuda_hip/factorization/par_ilut_spgeam_kernels.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -74,10 +74,10 @@ __global__ __launch_bounds__(default_block_size) void tri_spgeam_nnz(
             IndexType out_nz, bool valid) {
             auto col = min(a_col, lu_col);
             // count the number of unique elements being merged
-            l_count +=
-                popcnt(subwarp.ballot(col <= row && a_col != lu_col && valid));
-            u_count +=
-                popcnt(subwarp.ballot(col >= row && a_col != lu_col && valid));
+            l_count += popcnt(
+                group::ballot(subwarp, col <= row && a_col != lu_col && valid));
+            u_count += popcnt(
+                group::ballot(subwarp, col >= row && a_col != lu_col && valid));
             return true;
         });
     if (subwarp.thread_rank() == 0) {
@@ -172,7 +172,8 @@ __global__ __launch_bounds__(default_block_size) void tri_spgeam_init(
         auto lu_cur_val = subwarp.shfl(lu_val, merge_result.b_idx);
         auto valid = out_begin + lane < out_size;
         // check if the previous thread has matching columns
-        auto equal_mask = subwarp.ballot(a_cur_col == lu_cur_col && valid);
+        auto equal_mask =
+            group::ballot(subwarp, a_cur_col == lu_cur_col && valid);
         auto prev_equal_mask = equal_mask << 1 | skip_first;
         skip_first = bool(equal_mask >> (subwarp_size - 1));
         auto prev_equal = bool(prev_equal_mask & lanemask_eq);
@@ -197,9 +198,9 @@ __global__ __launch_bounds__(default_block_size) void tri_spgeam_init(
         // determine which threads will write output to L or U
         auto use_lpu = lpu_cur_col == r_col;
         auto l_new_advance_mask =
-            subwarp.ballot(r_col <= row && !prev_equal && valid);
+            group::ballot(subwarp, r_col <= row && !prev_equal && valid);
         auto u_new_advance_mask =
-            subwarp.ballot(r_col >= row && !prev_equal && valid);
+            group::ballot(subwarp, r_col >= row && !prev_equal && valid);
         // store values
         if (!prev_equal && valid) {
             auto diag =
@@ -222,7 +223,7 @@ __global__ __launch_bounds__(default_block_size) void tri_spgeam_init(
         auto a_advance = merge_result.a_advance;
         auto lu_advance = merge_result.b_advance;
         auto lpu_advance =
-            popcnt(subwarp.ballot(use_lpu && !prev_equal && valid));
+            popcnt(group::ballot(subwarp, use_lpu && !prev_equal && valid));
         auto l_new_advance = popcnt(l_new_advance_mask);
         auto u_new_advance = popcnt(u_new_advance_mask);
         a_begin += a_advance;

--- a/common/cuda_hip/factorization/par_ilut_sweep_kernels.cpp
+++ b/common/cuda_hip/factorization/par_ilut_sweep_kernels.cpp
@@ -10,6 +10,7 @@
 
 #include "common/cuda_hip/base/math.hpp"
 #include "common/cuda_hip/base/runtime.hpp"
+#include "common/cuda_hip/components/cooperative_groups.hpp"
 #include "common/cuda_hip/components/intrinsics.hpp"
 #include "common/cuda_hip/components/memory.hpp"
 #include "common/cuda_hip/components/merging.hpp"
@@ -105,7 +106,7 @@ __global__ __launch_bounds__(default_block_size) void sweep(
                        load_relaxed(ut_vals + (ut_idx + ut_col_begin));
             }
             // remember the transposed element
-            auto found_transp = subwarp.ballot(ut_row == row);
+            auto found_transp = group::ballot(subwarp, ut_row == row);
             if (found_transp) {
                 ut_nz =
                     subwarp.shfl(ut_idx + ut_col_begin, ffs(found_transp) - 1);

--- a/common/cuda_hip/matrix/csr_kernels.template.cpp
+++ b/common/cuda_hip/matrix/csr_kernels.template.cpp
@@ -609,7 +609,7 @@ __global__ __launch_bounds__(default_block_size) void spgeam_nnz(
         a_col_idxs + a_begin, a_size, b_col_idxs + b_begin, b_size, subwarp,
         [&](IndexType, IndexType a_col, IndexType, IndexType b_col, IndexType,
             bool valid) {
-            count += popcnt(subwarp.ballot(a_col != b_col && valid));
+            count += popcnt(group::ballot(subwarp, a_col != b_col && valid));
             return true;
         });
 
@@ -657,7 +657,7 @@ __global__ __launch_bounds__(default_block_size) void spgeam(
         [&](IndexType a_nz, IndexType a_col, IndexType b_nz, IndexType b_col,
             IndexType, bool valid) {
             auto c_col = min(a_col, b_col);
-            auto equal_mask = subwarp.ballot(a_col == b_col && valid);
+            auto equal_mask = group::ballot(subwarp, a_col == b_col && valid);
             // check if the elements in the previous merge step are
             // equal
             auto prev_equal_mask = equal_mask << 1 | skip_first;

--- a/common/cuda_hip/preconditioner/isai_kernels.cpp
+++ b/common/cuda_hip/preconditioner/isai_kernels.cpp
@@ -149,10 +149,11 @@ __forceinline__ __device__ void generic_generate(
                 i_col_idxs + i_row_begin, i_row_size, subwarp,
                 [&](IndexType, IndexType m_idx, IndexType i_idx,
                     config::lane_mask_type, bool valid) {
-                    rhs_one_idx += popcnt(subwarp.ballot(
+                    rhs_one_idx += popcnt(group::ballot(
+                        subwarp,
                         valid &&
-                        i_col_idxs[i_transposed_row_begin + m_idx] < row &&
-                        col == row));
+                            i_col_idxs[i_transposed_row_begin + m_idx] < row &&
+                            col == row));
                 });
         }
 

--- a/cuda/components/cooperative_groups.cuh
+++ b/cuda/components/cooperative_groups.cuh
@@ -386,12 +386,13 @@ __device__ __forceinline__ thread_block_tile<Size, void> tiled_partition(
  * on so forth. They are shifted but not masked. cuda 12.1.1 and cuda 12.5.1
  * does not have the issue.
  */
-template <typename Group>
-__device__ __forceinline__ auto ballot(const Group& g, int predicate)
+template <unsigned Size, typename Parent>
+__device__ __forceinline__ auto ballot(const thread_block_tile<Size, Parent>& g,
+                                       int predicate)
 {
 #if CUDA_VERSION >= 12020 && CUDA_VERSION < 12051
     constexpr auto subwarp_mask =
-        ~config::lane_mask_type{} >> (config::warp_size - g.size());
+        ~config::lane_mask_type{} >> (config::warp_size - Size);
     return subwarp_mask & g.ballot(predicate);
 #else
     return g.ballot(predicate);

--- a/cuda/test/components/cooperative_groups.cu
+++ b/cuda/test/components/cooperative_groups.cu
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -109,9 +109,9 @@ __global__ void cg_ballot(bool* s)
 {
     auto group =
         group::tiled_partition<config::warp_size>(group::this_thread_block());
-    test_assert(s, group.ballot(false) == 0);
-    test_assert(s, group.ballot(true) == ~config::lane_mask_type{});
-    test_assert(s, group.ballot(threadIdx.x < 4) == 0xf);
+    test_assert(s, group::ballot(group, false) == 0);
+    test_assert(s, group::ballot(group, true) == ~config::lane_mask_type{});
+    test_assert(s, group::ballot(group, threadIdx.x < 4) == 0xf);
 }
 
 TEST_F(CooperativeGroups, Ballot) { test(cg_ballot); }
@@ -205,17 +205,18 @@ __global__ void cg_subwarp_ballot(bool* s)
     auto group =
         group::tiled_partition<subwarp_size>(group::this_thread_block());
     auto i = group.thread_rank();
-    test_assert(s, !test_grp || group.ballot(!test_grp) == 0);
-    test_assert(s, !test_grp || group.ballot(test_grp) == full_mask);
-    test_assert(s, !test_grp || group.ballot(i < 4 || !test_grp) == 0xf);
+    test_assert(s, !test_grp || group::ballot(group, !test_grp) == 0);
+    test_assert(s, !test_grp || group::ballot(group, test_grp) == full_mask);
+    test_assert(s,
+                !test_grp || group::ballot(group, i < 4 || !test_grp) == 0xf);
     if (test_grp) {
-        test_assert(s, group.ballot(false) == 0);
-        test_assert(s, group.ballot(true) == full_mask);
-        test_assert(s, group.ballot(i < 4) == 0xf);
+        test_assert(s, group::ballot(group, false) == 0);
+        test_assert(s, group::ballot(group, true) == full_mask);
+        test_assert(s, group::ballot(group, i < 4) == 0xf);
     } else {
-        test_assert(s, group.ballot(true) == full_mask);
-        test_assert(s, group.ballot(i < 4) == 0xf);
-        test_assert(s, group.ballot(false) == 0);
+        test_assert(s, group::ballot(group, true) == full_mask);
+        test_assert(s, group::ballot(group, i < 4) == 0xf);
+        test_assert(s, group::ballot(group, false) == 0);
     }
 }
 

--- a/dpcpp/components/cooperative_groups.dp.hpp
+++ b/dpcpp/components/cooperative_groups.dp.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -443,6 +443,14 @@ private:
 __dpct_inline__ grid_group this_grid(sycl::nd_item<3>& group)
 {
     return grid_group(group);
+}
+
+
+// just provide the same interface as cuda/hip
+template <typename Group>
+__dpct_inline__ auto ballot(const Group& g, int predicate)
+{
+    return g.ballot(predicate);
 }
 
 

--- a/dpcpp/components/merging.dp.hpp
+++ b/dpcpp/components/merging.dp.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -12,6 +12,7 @@
 
 #include "core/base/utils.hpp"
 #include "dpcpp/base/dpct.hpp"
+#include "dpcpp/components/cooperative_groups.dp.hpp"
 #include "dpcpp/components/intrinsics.dp.hpp"
 #include "dpcpp/components/searching.dp.hpp"
 
@@ -94,7 +95,7 @@ __dpct_inline__ detail::merge_result<ValueType> group_merge_step(ValueType a,
     auto a_val = group.shfl(a, a_idx);
     auto b_val = group.shfl(b, b_idx);
     auto cmp = a_val < b_val;
-    auto a_advance = popcnt(group.ballot(cmp));
+    auto a_advance = popcnt(group::ballot(group, cmp));
     auto b_advance = int(group.size()) - a_advance;
 
     return {a_val, b_val, a_idx, b_idx, a_advance, b_advance};
@@ -211,7 +212,7 @@ __dpct_inline__ void group_match(const ValueType* __restrict__ a,
         a, a_size, b, b_size, group,
         [&](IndexType a_idx, ValueType a_val, IndexType b_idx, ValueType b_val,
             IndexType, bool valid) {
-            auto matchmask = group.ballot(a_val == b_val && valid);
+            auto matchmask = group::ballot(group, a_val == b_val && valid);
             match_fn(a_val, a_idx, b_idx, matchmask, a_val == b_val && valid);
             return a_idx < a_size && b_idx < b_size;
         });

--- a/dpcpp/components/searching.dp.hpp
+++ b/dpcpp/components/searching.dp.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -10,6 +10,7 @@
 
 #include "dpcpp/base/config.hpp"
 #include "dpcpp/base/dpct.hpp"
+#include "dpcpp/components/cooperative_groups.dp.hpp"
 #include "dpcpp/components/intrinsics.dp.hpp"
 
 
@@ -169,7 +170,7 @@ __dpct_inline__ IndexType group_wide_search(IndexType offset, IndexType length,
      */
     auto base_idx = (group_pos - 1) * group.size() + 1;
     auto idx = base_idx + group.thread_rank();
-    auto pos = ffs(group.ballot(idx >= length || p(offset + idx))) - 1;
+    auto pos = ffs(group::ballot(group, idx >= length || p(offset + idx))) - 1;
     return offset + base_idx + pos;
 }
 
@@ -205,7 +206,7 @@ __dpct_inline__ IndexType group_ary_search(IndexType offset, IndexType length,
     while (length > group.size()) {
         auto stride = length / group.size();
         auto idx = offset + group.thread_rank() * stride;
-        auto mask = group.ballot(p(idx));
+        auto mask = group::ballot(group, p(idx));
         // if the mask is 0, the partition point is in the last block
         // if the mask is ~0, the partition point is in the first block
         // otherwise, we go to the last block that returned a 0.
@@ -217,7 +218,7 @@ __dpct_inline__ IndexType group_ary_search(IndexType offset, IndexType length,
     auto idx = offset + group.thread_rank();
     // if the mask is 0, the partition point is at the end
     // otherwise it is the first set bit
-    auto mask = group.ballot(idx >= end || p(idx));
+    auto mask = group::ballot(group, idx >= end || p(idx));
     auto pos = mask == 0 ? group.size() : ffs(mask) - 1;
     return offset + pos;
 }

--- a/dpcpp/factorization/factorization_kernels.dp.cpp
+++ b/dpcpp/factorization/factorization_kernels.dp.cpp
@@ -203,7 +203,7 @@ void add_missing_diagonal_elements(
                     thread_is_active ? old_col_idxs[old_idx] : IndexType{};
                 // automatically false if thread is not active
                 bool diagonal_add_required = !diagonal_added && row < col_idx;
-                auto ballot = subwarp_grp.ballot(diagonal_add_required);
+                auto ballot = group::ballot(subwarp_grp, diagonal_add_required);
 
                 if (ballot) {
                     auto first_subwarp_idx = ffs(ballot) - 1;

--- a/dpcpp/factorization/par_ilut_filter_kernels.hpp.inc
+++ b/dpcpp/factorization/par_ilut_filter_kernels.hpp.inc
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -29,7 +29,7 @@ void abstract_filter_impl(const IndexType* row_ptrs, IndexType num_rows,
     for (IndexType step = 0; step < num_steps; ++step) {
         auto idx = begin + lane + step * subgroup_size;
         auto keep = idx < end && pred(idx, begin, end);
-        auto mask = subwarp.ballot(keep);
+        auto mask = group::ballot(subwarp, keep);
         step_cb(row, idx, keep, popcnt(mask), popcnt(mask & lane_prefix_mask));
     }
     finish_cb(row, lane);

--- a/dpcpp/factorization/par_ilut_sweep_kernel.dp.cpp
+++ b/dpcpp/factorization/par_ilut_sweep_kernel.dp.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -108,7 +108,7 @@ void sweep(const IndexType* __restrict__ a_row_ptrs,
                        ut_vals[ut_idx + ut_col_begin];
             }
             // remember the transposed element
-            auto found_transp = subwarp.ballot(ut_row == row);
+            auto found_transp = group::ballot(subwarp, ut_row == row);
             if (found_transp) {
                 ut_nz =
                     subwarp.shfl(ut_idx + ut_col_begin, ffs(found_transp) - 1);

--- a/dpcpp/preconditioner/isai_kernels.dp.cpp
+++ b/dpcpp/preconditioner/isai_kernels.dp.cpp
@@ -156,10 +156,11 @@ __dpct_inline__ void generic_generate(
                 i_col_idxs + i_row_begin, i_row_size, subwarp,
                 [&](IndexType, IndexType m_idx, IndexType i_idx,
                     config::lane_mask_type, bool valid) {
-                    rhs_one_idx += popcnt(subwarp.ballot(
+                    rhs_one_idx += popcnt(group::ballot(
+                        subwarp,
                         valid &&
-                        i_col_idxs[i_transposed_row_begin + m_idx] < row &&
-                        col == row));
+                            i_col_idxs[i_transposed_row_begin + m_idx] < row &&
+                            col == row));
                 });
         }
 

--- a/dpcpp/test/components/cooperative_groups.dp.cpp
+++ b/dpcpp/test/components/cooperative_groups.dp.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -186,9 +186,11 @@ void cg_ballot(bool* s, sycl::nd_item<3> item_ct1)
     auto active = gko::detail::mask<sg_size, config::lane_mask_type>();
     auto i = int(group.thread_rank());
 
-    s[i] = group.ballot(false) == 0;
-    s[i + sg_size] = group.ballot(true) == (~config::lane_mask_type{} & active);
-    s[i + sg_size * 2] = group.ballot(item_ct1.get_local_id(2) < 4) == 0xf;
+    s[i] = group::ballot(group, false) == 0;
+    s[i + sg_size] =
+        group::ballot(group, true) == (~config::lane_mask_type{} & active);
+    s[i + sg_size * 2] =
+        group::ballot(group, item_ct1.get_local_id(2) < 4) == 0xf;
 }
 
 GKO_ENABLE_DEFAULT_HOST_CONFIG_TYPE(cg_ballot, cg_ballot)

--- a/hip/components/cooperative_groups.hip.hpp
+++ b/hip/components/cooperative_groups.hip.hpp
@@ -524,12 +524,13 @@ __device__ inline grid_group this_grid() { return {}; }
  * on so forth. They are shifted but not masked. cuda 12.1.1 and cuda 12.5.1
  * does not have the issue.
  */
-template <typename Group>
-__device__ __forceinline__ auto ballot(const Group& g, int predicate)
+template <unsigned Size>
+__device__ __forceinline__ auto ballot(const thread_block_tile<Size>& g,
+                                       int predicate)
 {
 #if defined(CUDA_VERSION) && CUDA_VERSION >= 12020 && CUDA_VERSION < 12051
     constexpr auto subwarp_mask =
-        ~config::lane_mask_type{} >> (config::warp_size - g.size());
+        ~config::lane_mask_type{} >> (config::warp_size - Size);
     return subwarp_mask & g.ballot(predicate);
 #else
     return g.ballot(predicate);

--- a/hip/components/cooperative_groups.hip.hpp
+++ b/hip/components/cooperative_groups.hip.hpp
@@ -515,6 +515,28 @@ private:
 __device__ inline grid_group this_grid() { return {}; }
 
 
+/**
+ * During cuda12.2 - cuda12.4, compiler might have some optimization issue on
+ * ballot on H100. The ballot result on subwarp might keep the result from the
+ * other subwarp in the same warp. For example with subwarp size = 8, subwarp 0
+ * will get the result from (subwarp 3, subwarp 2, subwarp 1, subwarp 0),
+ * subwarp 1 will get the result from (subwarp 3, subwarp 2, subwarp 1), and so
+ * on so forth. They are shifted but not masked. cuda 12.1.1 and cuda 12.5.1
+ * does not have the issue.
+ */
+template <typename Group>
+__device__ __forceinline__ auto ballot(const Group& g, int predicate)
+{
+#if defined(CUDA_VERSION) && CUDA_VERSION >= 12020 && CUDA_VERSION < 12051
+    constexpr auto subwarp_mask =
+        ~config::lane_mask_type{} >> (config::warp_size - g.size());
+    return subwarp_mask & g.ballot(predicate);
+#else
+    return g.ballot(predicate);
+#endif
+}
+
+
 }  // namespace group
 }  // namespace hip
 }  // namespace kernels

--- a/hip/test/components/cooperative_groups.hip.cpp
+++ b/hip/test/components/cooperative_groups.hip.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -120,9 +120,9 @@ __global__ void cg_ballot(bool* s)
 {
     auto group =
         group::tiled_partition<config::warp_size>(group::this_thread_block());
-    test_assert(s, group.ballot(false) == 0);
-    test_assert(s, group.ballot(true) == ~config::lane_mask_type{});
-    test_assert(s, group.ballot(threadIdx.x < 4) == 0xf);
+    test_assert(s, group::ballot(group, false) == 0);
+    test_assert(s, group::ballot(group, true) == ~config::lane_mask_type{});
+    test_assert(s, group::ballot(group, threadIdx.x < 4) == 0xf);
 }
 
 
@@ -223,17 +223,18 @@ __global__ void cg_subwarp_ballot(bool* s)
     auto group =
         group::tiled_partition<subwarp_size>(group::this_thread_block());
     auto i = group.thread_rank();
-    test_assert(s, !test_grp || group.ballot(!test_grp) == 0);
-    test_assert(s, !test_grp || group.ballot(test_grp) == full_mask);
-    test_assert(s, !test_grp || group.ballot(i < 4 || !test_grp) == 0xf);
+    test_assert(s, !test_grp || group::ballot(group, !test_grp) == 0);
+    test_assert(s, !test_grp || group::ballot(group, test_grp) == full_mask);
+    test_assert(s,
+                !test_grp || group::ballot(group, i < 4 || !test_grp) == 0xf);
     if (test_grp) {
-        test_assert(s, group.ballot(false) == 0);
-        test_assert(s, group.ballot(true) == full_mask);
-        test_assert(s, group.ballot(i < 4) == 0xf);
+        test_assert(s, group::ballot(group, false) == 0);
+        test_assert(s, group::ballot(group, true) == full_mask);
+        test_assert(s, group::ballot(group, i < 4) == 0xf);
     } else {
-        test_assert(s, group.ballot(true) == full_mask);
-        test_assert(s, group.ballot(i < 4) == 0xf);
-        test_assert(s, group.ballot(false) == 0);
+        test_assert(s, group::ballot(group, true) == full_mask);
+        test_assert(s, group::ballot(group, i < 4) == 0xf);
+        test_assert(s, group::ballot(group, false) == 0);
     }
 }
 


### PR DESCRIPTION
This PR gives the workaround to fix the wrong ballot result on H100.
It has the issue cuda/12.2.2, cuda/12.3.2, cuda/12.4.1 but passes cuda/12.1.1 and cuda/12.5.1.
The ballot issue on H100: the subwarp ballot result will contains the other subwarp result.
They are shifted but not masked
For example with subwarp size = 8,
subwarp 0 gets result (subwarp 3, subwarp 2, subwarp 1, subwarp 0)
subwarp 1 gets result (subwarp 3, subwarp 2, subwarp 1)
...

It is only observed on H100.
Unfortunately, the simple kernel checking subwarp ballot result does not reproduce this issue.
I would guess it might be from optimization.

It is raised during merging step of spgeam when generating symmetric sparsity in cholesky check.
The following is the issue record and is modified to use 8 as subwarp size such that I can ensure whether it misses shift or mask. Thus, the popcnt can be larger than the subwarp size.
```
tid: 0 0(subwarp rank) 0 (predicate) popcnt: 19 ballot: 4177034270 (11111000'11111000'01111100'00011110)
tid: 1 1 1 popcnt: 19 ballot: 4177034270
tid: 2 2 1 popcnt: 19 ballot: 4177034270
tid: 3 3 1 popcnt: 19 ballot: 4177034270
tid: 4 4 1 popcnt: 19 ballot: 4177034270
tid: 5 5 0 popcnt: 19 ballot: 4177034270
tid: 6 6 0 popcnt: 19 ballot: 4177034270
tid: 7 7 0 popcnt: 19 ballot: 4177034270
tid: 8 0 0 popcnt: 15 ballot: 16316540 (11111000'11111000'01111100)
tid: 9 1 0 popcnt: 15 ballot: 16316540
tid: 10 2 1 popcnt: 15 ballot: 16316540
tid: 11 3 1 popcnt: 15 ballot: 16316540
tid: 12 4 1 popcnt: 15 ballot: 16316540
tid: 13 5 1 popcnt: 15 ballot: 16316540
tid: 14 6 1 popcnt: 15 ballot: 16316540
tid: 15 7 0 popcnt: 15 ballot: 16316540
tid: 16 0 0 popcnt: 10 ballot: 63736 (11111000'11111000)
tid: 17 1 0 popcnt: 10 ballot: 63736
tid: 18 2 0 popcnt: 10 ballot: 63736
tid: 19 3 1 popcnt: 10 ballot: 63736
tid: 20 4 1 popcnt: 10 ballot: 63736
tid: 21 5 1 popcnt: 10 ballot: 63736
tid: 22 6 1 popcnt: 10 ballot: 63736
tid: 23 7 1 popcnt: 10 ballot: 63736
tid: 24 0 0 popcnt: 5 ballot: 248 (11111000)
tid: 25 1 0 popcnt: 5 ballot: 248
tid: 26 2 0 popcnt: 5 ballot: 248
tid: 27 3 1 popcnt: 5 ballot: 248
tid: 28 4 1 popcnt: 5 ballot: 248
tid: 29 5 1 popcnt: 5 ballot: 248
tid: 30 6 1 popcnt: 5 ballot: 248
tid: 31 7 1 popcnt: 5 ballot: 248
```

Workaround is to apply the mask again for certain versions. `ballot(group, predicate)` not `group.predicate` in our code
Because I am guessing it is related to optimization, I still use the same code in other versions to leave the same condition of optimization there.