### PR TITLE
split the library into small pieces if need

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -192,6 +192,14 @@ option(
     "Enables mapping to Kokkos types to check the alignment of the source and target type."
     ON
 )
+option(
+    GINKGO_SPLIT_LIBRARY_NUM
+    "Split the library into small pieces to reduce the number of symbol/reference in one library. Note. We strongly suggest to use CMAKE to use Ginkgo when the number is larger than 1 because it will introduce several library"
+    1
+)
+if(${GINKGO_SPLIT_LIBRARY_NUM} LESS 1)
+    message(FATAL_ERROR "GINKGO_SPLIT_LIBRARY_NUM must be larger than 0")
+endif()
 gko_rename_cache(GINKGO_COMPILER_FLAGS CMAKE_CXX_FLAGS BOOL "Flags used by the CXX compiler during all build types.")
 gko_rename_cache(GINKGO_CUDA_COMPILER_FLAGS CMAKE_CUDA_FLAGS BOOL "Flags used by the CUDA compiler during all build types.")
 

--- a/cmake/get_info.cmake
+++ b/cmake/get_info.cmake
@@ -160,7 +160,7 @@ foreach(log_type ${log_types})
     )
     ginkgo_print_module_footer(${${log_type}} "  Enabled features:")
     ginkgo_print_foreach_variable(${${log_type}}
-        "GINKGO_MIXED_PRECISION;GINKGO_HAVE_GPU_AWARE_MPI;GINKGO_ENABLE_HALF;GINKGO_ENABLE_BFLOAT16"
+        "GINKGO_MIXED_PRECISION;GINKGO_HAVE_GPU_AWARE_MPI;GINKGO_ENABLE_HALF;GINKGO_ENABLE_BFLOAT16;GINKGO_SPLIT_LIBRARY_NUM"
     )
     ginkgo_print_module_footer(${${log_type}} "  Tests, benchmarks and examples:")
     ginkgo_print_foreach_variable(${${log_type}}

--- a/cuda/CMakeLists.txt
+++ b/cuda/CMakeLists.txt
@@ -1,5 +1,78 @@
 cmake_minimum_required(VERSION 3.18 FATAL_ERROR)
-add_library(ginkgo_cuda $<TARGET_OBJECTS:ginkgo_cuda_device> "")
+function(split_list_average input_list num_parts)
+    message("${input_list}")
+    message("${${input_list}}")
+    list(LENGTH ${input_list} total_length)
+    message("${input_list} contains ${total_length}")
+    message("generate total ${num_parts}")
+    foreach(i RANGE 1 ${num_parts})
+        message("generate ${i}")
+        math(EXPR start "${total_length} * (${i} - 1) / ${num_parts}")
+        math(EXPR end "${total_length} * ${i} / ${num_parts} - 1")
+        message("${start} - ${end}")
+        set(part "")
+        foreach(j RANGE ${start} ${end})
+            list(GET ${input_list} ${j} item)
+            list(APPEND part ${item})
+        endforeach()
+        set(part_list_var ${input_list}_${i})
+        set(${part_list_var} ${part} PARENT_SCOPE)
+    endforeach()
+endfunction()
+
+function(configure_cuda target source_list)
+    target_sources(${target} PRIVATE ${${source_list}})
+    if(CMAKE_CUDA_COMPILER_ID STREQUAL "NVIDIA")
+        # remove false positive CUDA warnings when calling one<T>() and zero<T>()
+        # and allows the usage of std::array for nvidia GPUs
+        target_compile_options(
+            ${target}
+            PRIVATE $<$<COMPILE_LANGUAGE:CUDA>:--expt-relaxed-constexpr>
+        )
+        if(MSVC)
+            target_compile_options(
+                ${target}
+                PRIVATE $<$<COMPILE_LANGUAGE:CUDA>:--extended-lambda>
+            )
+        else()
+            target_compile_options(
+                ${target}
+                PRIVATE $<$<COMPILE_LANGUAGE:CUDA>:--expt-extended-lambda>
+            )
+        endif()
+    endif()
+
+    ginkgo_compile_features(${target})
+    target_compile_definitions(
+        ${target}
+        PRIVATE GKO_COMPILING_CUDA GKO_DEVICE_NAMESPACE=cuda
+    )
+    if(GINKGO_CUDA_CUSTOM_THRUST_NAMESPACE)
+        target_compile_definitions(
+            ${target}
+            PRIVATE THRUST_CUB_WRAPPED_NAMESPACE=gko
+        )
+    endif()
+
+    # include path for generated headers like jacobi_common.hpp
+    target_include_directories(${target} PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
+    target_link_libraries(
+        ${target}
+        PRIVATE
+            CUDA::cudart
+            CUDA::cublas
+            CUDA::cusparse
+            CUDA::curand
+            CUDA::cufft
+            nvtx::nvtx
+    )
+    # NVTX3 is header-only and requires dlopen/dlclose in static builds
+    target_link_libraries(${target} PUBLIC ginkgo_device ${CMAKE_DL_LIBS})
+
+    ginkgo_default_includes(${target})
+    ginkgo_install_library(${target})
+endfunction()
+
 include(${PROJECT_SOURCE_DIR}/cmake/template_instantiation.cmake)
 add_instantiation_files(${PROJECT_SOURCE_DIR}/common/cuda_hip matrix/csr_kernels.instantiate.cpp CSR_INSTANTIATE)
 add_instantiation_files(${PROJECT_SOURCE_DIR}/common/cuda_hip matrix/fbcsr_kernels.instantiate.cpp FBCSR_INSTANTIATE)
@@ -12,33 +85,6 @@ list(
     APPEND
     GKO_UNIFIED_COMMON_SOURCES
     ${PROJECT_SOURCE_DIR}/common/unified/matrix/dense_kernels.instantiate.cpp
-)
-target_sources(
-    ginkgo_cuda
-    PRIVATE
-        base/device.cpp
-        base/exception.cpp
-        base/executor.cpp
-        base/memory.cpp
-        base/nvtx.cpp
-        base/scoped_device_id.cpp
-        base/stream.cpp
-        base/timer.cpp
-        base/version.cpp
-        ${CSR_INSTANTIATE}
-        ${FBCSR_INSTANTIATE}
-        matrix/fft_kernels.cu
-        preconditioner/batch_jacobi_kernels.cu
-        solver/batch_bicgstab_kernels.cu
-        ${BATCH_BICGSTAB_INSTANTIATE1}
-        ${BATCH_BICGSTAB_INSTANTIATE2}
-        solver/batch_cg_kernels.cu
-        ${BATCH_CG_INSTANTIATE1}
-        ${BATCH_CG_INSTANTIATE2}
-        solver/lower_trs_kernels.cu
-        solver/upper_trs_kernels.cu
-        ${GKO_UNIFIED_COMMON_SOURCES}
-        ${GKO_CUDA_HIP_COMMON_SOURCES}
 )
 if(GINKGO_JACOBI_FULL_OPTIMIZATIONS)
     set(GKO_CUDA_JACOBI_BLOCK_SIZES)
@@ -74,7 +120,55 @@ foreach(
 )
     set_source_files_properties(${source_file} PROPERTIES LANGUAGE CUDA)
 endforeach(source_file)
-target_sources(ginkgo_cuda PRIVATE ${GKO_CUDA_JACOBI_SOURCES})
+set(CUDA_SOURCES
+    base/device.cpp
+    base/exception.cpp
+    base/executor.cpp
+    base/memory.cpp
+    base/nvtx.cpp
+    base/scoped_device_id.cpp
+    base/stream.cpp
+    base/timer.cpp
+    base/version.cpp
+    ${CSR_INSTANTIATE}
+    ${FBCSR_INSTANTIATE}
+    matrix/fft_kernels.cu
+    preconditioner/batch_jacobi_kernels.cu
+    solver/batch_bicgstab_kernels.cu
+    ${BATCH_BICGSTAB_INSTANTIATE1}
+    ${BATCH_BICGSTAB_INSTANTIATE2}
+    solver/batch_cg_kernels.cu
+    ${BATCH_CG_INSTANTIATE1}
+    ${BATCH_CG_INSTANTIATE2}
+    solver/lower_trs_kernels.cu
+    solver/upper_trs_kernels.cu
+    ${GKO_UNIFIED_COMMON_SOURCES}
+    ${GKO_CUDA_HIP_COMMON_SOURCES}
+    ${GKO_CUDA_JACOBI_SOURCES}
+)
+# We still configure it ginkgo_cuda library not interface library when spliting library to reduce the effort in pkgconfig
+add_library(ginkgo_cuda $<TARGET_OBJECTS:ginkgo_cuda_device> "")
+if(${GINKGO_SPLIT_LIBRARY_NUM} GREATER 1)
+    split_list_average(CUDA_SOURCES ${GINKGO_SPLIT_LIBRARY_NUM})
+    foreach(i RANGE 1 ${GINKGO_SPLIT_LIBRARY_NUM})
+        list(LENGTH CUDA_SOURCES_${i} part_length)
+        message(
+            "CUDA_SOURCES_${i} contains ${part_length}: ${CUDA_SOURCES_${i}}"
+        )
+    endforeach()
+    foreach(i RANGE 1 ${GINKGO_SPLIT_LIBRARY_NUM})
+        add_library(ginkgo_cuda_${i} "")
+        configure_cuda(ginkgo_cuda_${i} CUDA_SOURCES_${i})
+        target_link_libraries(ginkgo_cuda INTERFACE ginkgo_cuda_${i})
+    endforeach()
+    ginkgo_compile_features(ginkgo_cuda)
+    ginkgo_default_includes(ginkgo_cuda)
+    ginkgo_install_library(ginkgo_cuda)
+else()
+    # keep the original behavior to avoid different name between target and library when num == 1
+    configure_cuda(ginkgo_cuda CUDA_SOURCES)
+endif()
+
 string(
     REPLACE
     ";"
@@ -86,56 +180,6 @@ configure_file(
     ${Ginkgo_SOURCE_DIR}/common/cuda_hip/preconditioner/jacobi_common.hpp.in
     common/cuda_hip/preconditioner/jacobi_common.hpp
 )
-
-if(CMAKE_CUDA_COMPILER_ID STREQUAL "NVIDIA")
-    # remove false positive CUDA warnings when calling one<T>() and zero<T>()
-    # and allows the usage of std::array for nvidia GPUs
-    target_compile_options(
-        ginkgo_cuda
-        PRIVATE $<$<COMPILE_LANGUAGE:CUDA>:--expt-relaxed-constexpr>
-    )
-    if(MSVC)
-        target_compile_options(
-            ginkgo_cuda
-            PRIVATE $<$<COMPILE_LANGUAGE:CUDA>:--extended-lambda>
-        )
-    else()
-        target_compile_options(
-            ginkgo_cuda
-            PRIVATE $<$<COMPILE_LANGUAGE:CUDA>:--expt-extended-lambda>
-        )
-    endif()
-endif()
-
-ginkgo_compile_features(ginkgo_cuda)
-target_compile_definitions(
-    ginkgo_cuda
-    PRIVATE GKO_COMPILING_CUDA GKO_DEVICE_NAMESPACE=cuda
-)
-if(GINKGO_CUDA_CUSTOM_THRUST_NAMESPACE)
-    target_compile_definitions(
-        ginkgo_cuda
-        PRIVATE THRUST_CUB_WRAPPED_NAMESPACE=gko
-    )
-endif()
-
-# include path for generated headers like jacobi_common.hpp
-target_include_directories(ginkgo_cuda PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
-target_link_libraries(
-    ginkgo_cuda
-    PRIVATE
-        CUDA::cudart
-        CUDA::cublas
-        CUDA::cusparse
-        CUDA::curand
-        CUDA::cufft
-        nvtx::nvtx
-)
-# NVTX3 is header-only and requires dlopen/dlclose in static builds
-target_link_libraries(ginkgo_cuda PUBLIC ginkgo_device ${CMAKE_DL_LIBS})
-
-ginkgo_default_includes(ginkgo_cuda)
-ginkgo_install_library(ginkgo_cuda)
 
 if(GINKGO_CHECK_CIRCULAR_DEPS)
     set(check_header_def "GKO_COMPILING_CUDA;GKO_DEVICE_NAMESPACE=cuda")


### PR DESCRIPTION
In #1734, when user compile ginkgo into several architectures, there will be too many symbols/references in one library.
Thus, we need to split it to different library and link later.
If someone knows nvcc specific flag to solve this issue, please let me know.
The default behavior stay the same as the previous one unless if user set `GINKGO_SPLIT_LIBRARY_NUM` > 1.
AFAIR, @nbeams mentioned that the number of libraries now in Ginkgo already gives some pain for project.
It is another reason to keep the original behavior if they do not encounter the issue.

TODO:
- [ ] if the approach is acceptable, apply it to the other parts.