### PR TITLE
Fix the reference behavior on factorization algorithm

### DIFF
--- a/core/factorization/ic.cpp
+++ b/core/factorization/ic.cpp
@@ -102,9 +102,10 @@ std::unique_ptr<Composition<ValueType>> Ic<ValueType, IndexType>::generate(
         local_system_matrix.get(), false));
 
     std::shared_ptr<const matrix_type> ic;
-    // Compute LC factorization
+    // Compute IC factorization
     if (parameters_.algorithm == incomplete_algorithm::syncfree ||
-        exec == exec->get_master()) {
+        (!std::dynamic_pointer_cast<const ReferenceExecutor>(exec) &&
+         exec == exec->get_master())) {
         std::unique_ptr<gko::factorization::elimination_forest<IndexType>>
             forest;
         const auto nnz = local_system_matrix->get_num_stored_elements();

--- a/core/factorization/ilu.cpp
+++ b/core/factorization/ilu.cpp
@@ -98,9 +98,10 @@ std::unique_ptr<Composition<ValueType>> Ilu<ValueType, IndexType>::generate_l_u(
         local_system_matrix.get(), false));
 
     std::shared_ptr<const matrix_type> ilu;
-    // Compute LU factorization
+    // Compute ILU factorization
     if (parameters_.algorithm == incomplete_algorithm::syncfree ||
-        exec == exec->get_master()) {
+        (!std::dynamic_pointer_cast<const ReferenceExecutor>(exec) &&
+         exec == exec->get_master())) {
         const auto nnz = local_system_matrix->get_num_stored_elements();
         const auto num_rows = local_system_matrix->get_size()[0];
         auto factors = share(

--- a/include/ginkgo/core/factorization/ic.hpp
+++ b/include/ginkgo/core/factorization/ic.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -103,10 +103,10 @@ public:
 
         /**
          * Select the implementation which is supposed to be used for
-         * the incomplete factorization. This only matters for the CUDA and HIP
-         * executor where the choice is between the Ginkgo (syncfree) and the
-         * cuSPARSE/hipSPARSE/reference (sparselib) implementation. Default is
-         * sparselib.
+         * the incomplete factorization. This only matters for the
+         * CUDA/HIP/REFERENCE executor where the choice is between the Ginkgo
+         * (syncfree) and the cuSPARSE/hipSPARSE/reference (sparselib)
+         * implementation. Default is sparselib.
          */
         incomplete_algorithm GKO_FACTORY_PARAMETER_SCALAR(
             algorithm, incomplete_algorithm::sparselib);

--- a/include/ginkgo/core/factorization/ilu.hpp
+++ b/include/ginkgo/core/factorization/ilu.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -98,10 +98,10 @@ public:
 
         /**
          * Select the implementation which is supposed to be used for
-         * the incomplete factorization. This only matters for the CUDA and HIP
-         * executor where the choice is between the Ginkgo (syncfree) and the
-         * cuSPARSE/hipSPARSE/reference (sparselib) implementation. Default is
-         * sparselib.
+         * the incomplete factorization. This only matters for the
+         * CUDA/HIP/REFERENCE executor where the choice is between the Ginkgo
+         * (syncfree) and the cuSPARSE/hipSPARSE/reference (sparselib)
+         * implementation. Default is sparselib.
          */
         incomplete_algorithm GKO_FACTORY_PARAMETER_SCALAR(
             algorithm, incomplete_algorithm::sparselib);

--- a/reference/test/factorization/ilu_kernels.cpp
+++ b/reference/test/factorization/ilu_kernels.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -11,6 +11,7 @@
 
 #include <ginkgo/core/base/executor.hpp>
 #include <ginkgo/core/factorization/ilu.hpp>
+#include <ginkgo/core/log/logger.hpp>
 #include <ginkgo/core/matrix/coo.hpp>
 #include <ginkgo/core/matrix/csr.hpp>
 #include <ginkgo/core/matrix/dense.hpp>
@@ -18,7 +19,18 @@
 #include "core/test/utils.hpp"
 
 
-namespace {
+struct CheckOperationLogger : gko::log::Logger {
+    void on_operation_launched(const gko::Executor*,
+                               const gko::Operation* op) const override
+    {
+        std::string s = op->get_name();
+        if (s.find("sparselib") != std::string::npos) {
+            contains_sparselib = true;
+        }
+    }
+
+    mutable bool contains_sparselib = false;
+};
 
 
 class DummyLinOp : public gko::EnableLinOp<DummyLinOp>,
@@ -147,7 +159,7 @@ protected:
         mtx_csr_small2 = std::move(tmp_csr2);
     }
 
-    std::shared_ptr<const gko::ReferenceExecutor> ref;
+    std::shared_ptr<gko::ReferenceExecutor> ref;
     std::shared_ptr<const gko::Executor> exec;
     std::shared_ptr<const Dense> identity;
     std::shared_ptr<const Dense> lower_triangular;
@@ -226,6 +238,40 @@ TYPED_TEST(Ilu, SetUStrategy)
     ASSERT_EQ(factory->get_parameters().u_strategy, u_strategy);
     ASSERT_EQ(ilu->get_u_factor()->get_strategy()->get_name(),
               u_strategy->get_name());
+}
+
+
+TYPED_TEST(Ilu, UsesSyncFreeAlgorithm)
+{
+    using value_type = typename TestFixture::value_type;
+    using index_type = typename TestFixture::index_type;
+    auto logger = std::make_shared<CheckOperationLogger>();
+    this->ref->add_logger(logger);
+
+    auto fact =
+        gko::factorization::Ilu<value_type, index_type>::build()
+            .with_algorithm(gko::factorization::incomplete_algorithm::syncfree)
+            .on(this->ref)
+            ->generate(this->mtx_small);
+
+    ASSERT_FALSE(logger->contains_sparselib);
+}
+
+
+TYPED_TEST(Ilu, UsesSparseLibAlgorithm)
+{
+    using value_type = typename TestFixture::value_type;
+    using index_type = typename TestFixture::index_type;
+    auto logger = std::make_shared<CheckOperationLogger>();
+    this->ref->add_logger(logger);
+
+    auto fact =
+        gko::factorization::Ilu<value_type, index_type>::build()
+            .with_algorithm(gko::factorization::incomplete_algorithm::sparselib)
+            .on(this->ref)
+            ->generate(this->mtx_small);
+
+    ASSERT_TRUE(logger->contains_sparselib);
 }
 
 
@@ -565,6 +611,3 @@ TYPED_TEST(Ilu, GenerateForReverseCsrSmall)
     GKO_ASSERT_MTX_NEAR(l_factor, this->small_l_expected, r<value_type>::value);
     GKO_ASSERT_MTX_NEAR(u_factor, this->small_u_expected, r<value_type>::value);
 }
-
-
-}  // namespace

--- a/test/factorization/ic_kernels.cpp
+++ b/test/factorization/ic_kernels.cpp
@@ -13,11 +13,26 @@
 #include <ginkgo/core/base/executor.hpp>
 #include <ginkgo/core/factorization/ic.hpp>
 #include <ginkgo/core/factorization/par_ic.hpp>
+#include <ginkgo/core/log/logger.hpp>
 
 #include "core/test/utils.hpp"
 #include "core/test/utils/unsort_matrix.hpp"
 #include "matrices/config.hpp"
 #include "test/utils/common_fixture.hpp"
+
+
+struct CheckOperationLogger : gko::log::Logger {
+    void on_operation_launched(const gko::Executor*,
+                               const gko::Operation* op) const override
+    {
+        std::string s = op->get_name();
+        if (s.find("sparselib") != std::string::npos) {
+            contains_sparselib = true;
+        }
+    }
+
+    mutable bool contains_sparselib = false;
+};
 
 
 class Ic : public CommonTestFixture {
@@ -36,6 +51,41 @@ protected:
     std::shared_ptr<Csr> mtx;
     std::shared_ptr<Csr> dmtx;
 };
+
+
+TEST_F(Ic, UsesSyncFreeAlgorithm)
+{
+    auto logger = std::make_shared<CheckOperationLogger>();
+    exec->add_logger(logger);
+
+    auto dfact =
+        gko::factorization::Ic<>::build()
+            .with_algorithm(gko::factorization::incomplete_algorithm::syncfree)
+            .on(exec)
+            ->generate(dmtx);
+
+    ASSERT_FALSE(logger->contains_sparselib);
+}
+
+
+TEST_F(Ic, UsesSparseLibAlgorithm)
+{
+    auto logger = std::make_shared<CheckOperationLogger>();
+    exec->add_logger(logger);
+
+    auto dfact =
+        gko::factorization::Ic<>::build()
+            .with_algorithm(gko::factorization::incomplete_algorithm::sparselib)
+            .on(exec)
+            ->generate(dmtx);
+
+#ifdef GKO_COMPILING_OMP
+    // OMP does not have sparselib algorithm
+    ASSERT_FALSE(logger->contains_sparselib);
+#else
+    ASSERT_TRUE(logger->contains_sparselib);
+#endif
+}
 
 
 TEST_F(Ic, ComputeICBySyncfreeIsEquivalentToRefSorted)

--- a/test/factorization/ilu_kernels.cpp
+++ b/test/factorization/ilu_kernels.cpp
@@ -13,11 +13,26 @@
 #include <ginkgo/core/base/executor.hpp>
 #include <ginkgo/core/factorization/ilu.hpp>
 #include <ginkgo/core/factorization/par_ilu.hpp>
+#include <ginkgo/core/log/logger.hpp>
 
 #include "core/test/utils.hpp"
 #include "core/test/utils/unsort_matrix.hpp"
 #include "matrices/config.hpp"
 #include "test/utils/common_fixture.hpp"
+
+
+struct CheckOperationLogger : gko::log::Logger {
+    void on_operation_launched(const gko::Executor*,
+                               const gko::Operation* op) const override
+    {
+        std::string s = op->get_name();
+        if (s.find("sparselib") != std::string::npos) {
+            contains_sparselib = true;
+        }
+    }
+
+    mutable bool contains_sparselib = false;
+};
 
 
 class Ilu : public CommonTestFixture {
@@ -36,6 +51,41 @@ protected:
     std::shared_ptr<Csr> mtx;
     std::shared_ptr<Csr> dmtx;
 };
+
+
+TEST_F(Ilu, UsesSyncFreeAlgorithm)
+{
+    auto logger = std::make_shared<CheckOperationLogger>();
+    exec->add_logger(logger);
+
+    auto dfact =
+        gko::factorization::Ilu<>::build()
+            .with_algorithm(gko::factorization::incomplete_algorithm::syncfree)
+            .on(exec)
+            ->generate(dmtx);
+
+    ASSERT_FALSE(logger->contains_sparselib);
+}
+
+
+TEST_F(Ilu, UsesSparseLibAlgorithm)
+{
+    auto logger = std::make_shared<CheckOperationLogger>();
+    exec->add_logger(logger);
+
+    auto dfact =
+        gko::factorization::Ilu<>::build()
+            .with_algorithm(gko::factorization::incomplete_algorithm::sparselib)
+            .on(exec)
+            ->generate(dmtx);
+
+#ifdef GKO_COMPILING_OMP
+    // OMP does not have sparselib algorithm
+    ASSERT_FALSE(logger->contains_sparselib);
+#else
+    ASSERT_TRUE(logger->contains_sparselib);
+#endif
+}
 
 
 TEST_F(Ilu, ComputeILUBySyncfreeIsEquivalentToRefSorted)


### PR DESCRIPTION
In https://github.com/ginkgo-project/ginkgo/pull/1783, we fallback the algorithm to syncfree when sparselib is unsupported.
We also have sparselib implementation in reference so we should use that when algorithm is sparselib.