### PR TITLE
Update tpls for v1.10

### DIFF
--- a/extensions/test/config/CMakeLists.txt
+++ b/extensions/test/config/CMakeLists.txt
@@ -5,7 +5,7 @@ if(NOT yaml-cpp_FOUND)
     FetchContent_Declare(
         yaml-cpp
         GIT_REPOSITORY https://github.com/jbeder/yaml-cpp.git
-        GIT_TAG 0.8.0
+        GIT_TAG 2f86d13775d119edbb69af52e5f566fd65c6953b
     )
 
     # Turn off additional tool in yaml-cpp

--- a/third_party/gflags/CMakeLists.txt
+++ b/third_party/gflags/CMakeLists.txt
@@ -3,7 +3,7 @@ include(FetchContent)
 FetchContent_Declare(
     gflags
     GIT_REPOSITORY https://github.com/gflags/gflags.git
-    GIT_TAG a738fdf9338412f83ab3f26f31ac11ed3f3ec4bd
+    GIT_TAG 52e94563eba1968783864942fedf6e87e3c611f4
 )
 # need to set the variables in CACHE due to CMP0077
 set(GFLAGS_BUILD_TESTING OFF CACHE INTERNAL "")


### PR DESCRIPTION
These updates are due to deprecated CMake required versions in the TPLs.