### PR TITLE
Dense MultiVector Implementation

### DIFF
--- a/core/base/block_operator.cpp
+++ b/core/base/block_operator.cpp
@@ -33,14 +33,14 @@ auto dispatch_dense(Fn&& fn, LinOp* v)
 
 template <typename LinOpType>
 auto create_vector_blocks(LinOpType* vector,
-                          const std::vector<detail::value_span>& spans)
+                          const std::vector<local_span>& spans)
 {
     return [=](size_type i) {
         return dispatch_dense(
             [&](auto* dense) -> std::unique_ptr<LinOpType> {
                 GKO_ENSURE_IN_BOUNDS(i, spans.size());
-                return dense->create_submatrix(spans[i],
-                                               {0, dense->get_size()[1]});
+                return dense->create_subview(spans[i],
+                                             {0, dense->get_size()[1]});
             },
             const_cast<LinOp*>(vector));
     };
@@ -97,13 +97,13 @@ void validate_blocks(
 
 
 template <typename Fn>
-std::vector<detail::value_span> compute_local_spans(
+std::vector<local_span> compute_local_spans(
     size_type num_blocks,
     const std::vector<std::vector<std::shared_ptr<const LinOp>>>& blocks,
     Fn&& get_size)
 {
     validate_blocks(blocks);
-    std::vector<detail::value_span> local_spans;
+    std::vector<local_span> local_spans;
     size_type offset = 0;
     for (size_type i = 0; i < num_blocks; ++i) {
         auto local_size = get_size(i);

--- a/core/matrix/dense.cpp
+++ b/core/matrix/dense.cpp
@@ -137,380 +137,212 @@ void Dense<ValueType>::apply_impl(const LinOp* alpha, const LinOp* b,
 
 
 template <typename ValueType>
-void Dense<ValueType>::fill(const ValueType value)
+void Dense<ValueType>::inv_scale_impl(scaling_param<value_type> alpha)
 {
-    this->get_executor()->run(dense::make_fill(this->get_device_view(), value));
+    std::visit(
+        [this](auto alpha_v) {
+            auto exec = this->get_executor();
+            exec->run(dense::make_inv_scale(alpha_v->get_const_device_view(),
+                                            this->get_device_view()));
+        },
+        alpha);
 }
 
 
 template <typename ValueType>
-void Dense<ValueType>::scale(ptr_param<const LinOp> alpha)
+void Dense<ValueType>::scale_impl(scaling_param<value_type> alpha)
 {
-    auto exec = this->get_executor();
-    this->scale_impl(make_temporary_clone(exec, alpha).get());
+    std::visit(
+        [this](auto alpha_v) {
+            auto exec = this->get_executor();
+            exec->run(dense::make_scale(alpha_v->get_const_device_view(),
+                                        this->get_device_view()));
+        },
+        alpha);
 }
 
 
 template <typename ValueType>
-void Dense<ValueType>::inv_scale(ptr_param<const LinOp> alpha)
+void Dense<ValueType>::add_scaled_impl(scaling_param<value_type> alpha,
+                                       const Dense* b)
 {
-    auto exec = this->get_executor();
-    this->inv_scale_impl(make_temporary_clone(exec, alpha).get());
+    std::visit(
+        [this, b](auto alpha_v) {
+            auto exec = this->get_executor();
+            exec->run(dense::make_add_scaled(alpha_v->get_const_device_view(),
+                                             b->get_const_device_view(),
+                                             this->get_device_view()));
+        },
+        alpha);
 }
 
 
 template <typename ValueType>
-void Dense<ValueType>::add_scaled(ptr_param<const LinOp> alpha,
-                                  ptr_param<const LinOp> b)
+void Dense<ValueType>::sub_scaled_impl(scaling_param<value_type> alpha,
+                                       const Dense* b)
 {
-    auto exec = this->get_executor();
-    this->add_scaled_impl(make_temporary_clone(exec, alpha).get(),
-                          make_temporary_clone(exec, b).get());
+    std::visit(
+        [this, b](auto alpha_v) {
+            auto exec = this->get_executor();
+
+            exec->run(dense::make_sub_scaled(alpha_v->get_const_device_view(),
+                                             b->get_const_device_view(),
+                                             this->get_device_view()));
+        },
+        alpha);
 }
 
 
 template <typename ValueType>
-void Dense<ValueType>::sub_scaled(ptr_param<const LinOp> alpha,
-                                  ptr_param<const LinOp> b)
-{
-    auto exec = this->get_executor();
-    this->sub_scaled_impl(make_temporary_clone(exec, alpha).get(),
-                          make_temporary_clone(exec, b).get());
-}
-
-
-template <typename ValueType>
-void Dense<ValueType>::compute_dot(ptr_param<const LinOp> b,
-                                   ptr_param<LinOp> result) const
-{
-    auto exec = this->get_executor();
-    this->compute_dot_impl(make_temporary_clone(exec, b).get(),
-                           make_temporary_output_clone(exec, result).get());
-}
-
-
-template <typename ValueType>
-void Dense<ValueType>::compute_conj_dot(ptr_param<const LinOp> b,
-                                        ptr_param<LinOp> result) const
-{
-    auto exec = this->get_executor();
-    this->compute_conj_dot_impl(
-        make_temporary_clone(exec, b).get(),
-        make_temporary_output_clone(exec, result).get());
-}
-
-
-template <typename ValueType>
-void Dense<ValueType>::compute_norm2(ptr_param<LinOp> result) const
-{
-    auto exec = this->get_executor();
-    this->compute_norm2_impl(make_temporary_output_clone(exec, result).get());
-}
-
-
-template <typename ValueType>
-void Dense<ValueType>::compute_norm1(ptr_param<LinOp> result) const
-{
-    auto exec = this->get_executor();
-    this->compute_norm1_impl(make_temporary_output_clone(exec, result).get());
-}
-
-
-template <typename ValueType>
-void Dense<ValueType>::compute_squared_norm2(ptr_param<LinOp> result) const
-{
-    auto exec = this->get_executor();
-    this->compute_squared_norm2_impl(
-        make_temporary_output_clone(exec, result).get());
-}
-
-
-template <typename ValueType>
-void Dense<ValueType>::inv_scale_impl(const LinOp* alpha)
-{
-    GKO_ASSERT_EQUAL_ROWS(alpha, dim<2>(1, 1));
-    if (alpha->get_size()[1] != 1) {
-        // different alpha for each column
-        GKO_ASSERT_EQUAL_COLS(this, alpha);
-    }
-    auto exec = this->get_executor();
-    // if alpha is real (convertible to real) and ValueType complex
-    if (dynamic_cast<const ConvertibleTo<Dense<>>*>(alpha) &&
-        is_complex<ValueType>()) {
-        // use the real-complex kernel
-        exec->run(dense::make_inv_scale(
-            make_temporary_conversion<remove_complex<ValueType>>(alpha)
-                ->get_const_device_view(),
-            dynamic_cast<complex_type*>(this)->get_device_view()));
-        // this last cast is a no-op for complex value type and the branch is
-        // never taken for real value type
-    } else {
-        // otherwise: use the normal kernel
-        exec->run(
-            dense::make_inv_scale(make_temporary_conversion<ValueType>(alpha)
-                                      ->get_const_device_view(),
-                                  this->get_device_view()));
-    }
-}
-
-
-template <typename ValueType>
-void Dense<ValueType>::scale_impl(const LinOp* alpha)
-{
-    GKO_ASSERT_EQUAL_ROWS(alpha, dim<2>(1, 1));
-    if (alpha->get_size()[1] != 1) {
-        // different alpha for each column
-        GKO_ASSERT_EQUAL_COLS(this, alpha);
-    }
-    auto exec = this->get_executor();
-    // if alpha is real (convertible to real) and ValueType complex
-    if (dynamic_cast<const ConvertibleTo<Dense<>>*>(alpha) &&
-        is_complex<ValueType>()) {
-        // use the real-complex kernel
-        exec->run(dense::make_scale(
-            make_temporary_conversion<remove_complex<ValueType>>(alpha)
-                ->get_const_device_view(),
-            dynamic_cast<complex_type*>(this)->get_device_view()));
-        // this last cast is a no-op for complex value type and the branch is
-        // never taken for real value type
-    } else {
-        // otherwise: use the normal kernel
-        exec->run(dense::make_scale(make_temporary_conversion<ValueType>(alpha)
-                                        ->get_const_device_view(),
-                                    this->get_device_view()));
-    }
-}
-
-
-template <typename ValueType>
-void Dense<ValueType>::add_scaled_impl(const LinOp* alpha, const LinOp* b)
-{
-    GKO_ASSERT_EQUAL_ROWS(alpha, dim<2>(1, 1));
-    if (alpha->get_size()[1] != 1) {
-        // different alpha for each column
-        GKO_ASSERT_EQUAL_COLS(this, alpha);
-    }
-    GKO_ASSERT_EQUAL_DIMENSIONS(this, b);
-    auto exec = this->get_executor();
-
-    // if alpha is real and value type complex
-    if (dynamic_cast<const ConvertibleTo<Dense<>>*>(alpha) &&
-        is_complex<ValueType>()) {
-        exec->run(dense::make_add_scaled(
-            make_temporary_conversion<remove_complex<ValueType>>(alpha)
-                ->get_const_device_view(),
-            make_temporary_conversion<to_complex<ValueType>>(b)
-                ->get_const_device_view(),
-            dynamic_cast<complex_type*>(this)->get_device_view()));
-    } else {
-        if (dynamic_cast<const Diagonal<ValueType>*>(b)) {
-            exec->run(dense::make_add_scaled_diag(
-                make_temporary_conversion<ValueType>(alpha)
-                    ->get_const_device_view(),
-                dynamic_cast<const Diagonal<ValueType>*>(b),
-                this->get_device_view()));
-        } else {
-            exec->run(dense::make_add_scaled(
-                make_temporary_conversion<ValueType>(alpha)
-                    ->get_const_device_view(),
-                make_temporary_conversion<ValueType>(b)
-                    ->get_const_device_view(),
-                this->get_device_view()));
-        }
-    }
-}
-
-
-template <typename ValueType>
-void Dense<ValueType>::sub_scaled_impl(const LinOp* alpha, const LinOp* b)
-{
-    GKO_ASSERT_EQUAL_ROWS(alpha, dim<2>(1, 1));
-    if (alpha->get_size()[1] != 1) {
-        // different alpha for each column
-        GKO_ASSERT_EQUAL_COLS(this, alpha);
-    }
-    GKO_ASSERT_EQUAL_DIMENSIONS(this, b);
-    auto exec = this->get_executor();
-
-    if (dynamic_cast<const ConvertibleTo<Dense<>>*>(alpha) &&
-        is_complex<ValueType>()) {
-        exec->run(dense::make_sub_scaled(
-            make_temporary_conversion<remove_complex<ValueType>>(alpha)
-                ->get_const_device_view(),
-            make_temporary_conversion<to_complex<ValueType>>(b)
-                ->get_const_device_view(),
-            dynamic_cast<complex_type*>(this)->get_device_view()));
-    } else {
-        if (dynamic_cast<const Diagonal<ValueType>*>(b)) {
-            exec->run(dense::make_sub_scaled_diag(
-                make_temporary_conversion<ValueType>(alpha)
-                    ->get_const_device_view(),
-                dynamic_cast<const Diagonal<ValueType>*>(b),
-                this->get_device_view()));
-        } else {
-            exec->run(dense::make_sub_scaled(
-                make_temporary_conversion<ValueType>(alpha)
-                    ->get_const_device_view(),
-                make_temporary_conversion<ValueType>(b)
-                    ->get_const_device_view(),
-                this->get_device_view()));
-        }
-    }
-}
-
-
-template <typename ValueType>
-void Dense<ValueType>::compute_dot(ptr_param<const LinOp> b,
-                                   ptr_param<LinOp> result,
-                                   array<char>& tmp) const
-{
-    GKO_ASSERT_EQUAL_DIMENSIONS(this, b);
-    GKO_ASSERT_EQUAL_DIMENSIONS(result, dim<2>(1, this->get_size()[1]));
-    auto exec = this->get_executor();
-    if (tmp.get_executor() != exec) {
-        tmp.clear();
-        tmp.set_executor(exec);
-    }
-    auto local_b = make_temporary_clone(exec, b);
-    auto local_res = make_temporary_clone(exec, result);
-    auto dense_b = make_temporary_conversion<ValueType>(local_b.get());
-    auto dense_res = make_temporary_conversion<ValueType>(local_res.get());
-    exec->run(dense::make_compute_dot(this->get_const_device_view(),
-                                      dense_b->get_const_device_view(),
-                                      dense_res->get_device_view(), tmp));
-}
-
-
-template <typename ValueType>
-void Dense<ValueType>::compute_dot_impl(const LinOp* b, LinOp* result) const
-{
-    GKO_ASSERT_EQUAL_DIMENSIONS(this, b);
-    GKO_ASSERT_EQUAL_DIMENSIONS(result, dim<2>(1, this->get_size()[1]));
-    auto exec = this->get_executor();
-    auto dense_b = make_temporary_conversion<ValueType>(b);
-    auto dense_res = make_temporary_conversion<ValueType>(result);
-    array<char> tmp{exec};
-    exec->run(dense::make_compute_dot(this->get_const_device_view(),
-                                      dense_b->get_const_device_view(),
-                                      dense_res->get_device_view(), tmp));
-}
-
-
-template <typename ValueType>
-void Dense<ValueType>::compute_conj_dot(ptr_param<const LinOp> b,
-                                        ptr_param<LinOp> result,
+void Dense<ValueType>::compute_dot_impl(const Dense* b, Dense* result,
                                         array<char>& tmp) const
 {
-    GKO_ASSERT_EQUAL_DIMENSIONS(this, b);
-    GKO_ASSERT_EQUAL_DIMENSIONS(result, dim<2>(1, this->get_size()[1]));
     auto exec = this->get_executor();
     if (tmp.get_executor() != exec) {
         tmp.clear();
         tmp.set_executor(exec);
     }
-    auto local_b = make_temporary_clone(exec, b);
-    auto local_res = make_temporary_clone(exec, result);
-    auto dense_b = make_temporary_conversion<ValueType>(local_b.get());
-    auto dense_res = make_temporary_conversion<ValueType>(local_res.get());
-    exec->run(dense::make_compute_conj_dot(this->get_const_device_view(),
-                                           dense_b->get_const_device_view(),
-                                           dense_res->get_device_view(), tmp));
+    exec->run(dense::make_compute_dot(this->get_const_device_view(),
+                                      b->get_const_device_view(),
+                                      result->get_device_view(), tmp));
 }
 
 
 template <typename ValueType>
-void Dense<ValueType>::compute_conj_dot_impl(const LinOp* b,
-                                             LinOp* result) const
+void Dense<ValueType>::compute_dot_impl(const Dense* b, Dense* result) const
 {
-    GKO_ASSERT_EQUAL_DIMENSIONS(this, b);
-    GKO_ASSERT_EQUAL_DIMENSIONS(result, dim<2>(1, this->get_size()[1]));
     auto exec = this->get_executor();
-    auto dense_b = make_temporary_conversion<ValueType>(b);
-    auto dense_res = make_temporary_conversion<ValueType>(result);
     array<char> tmp{exec};
-    exec->run(dense::make_compute_conj_dot(this->get_const_device_view(),
-                                           dense_b->get_const_device_view(),
-                                           dense_res->get_device_view(), tmp));
+    exec->run(dense::make_compute_dot(this->get_const_device_view(),
+                                      b->get_const_device_view(),
+                                      result->get_device_view(), tmp));
 }
 
 
 template <typename ValueType>
-void Dense<ValueType>::compute_norm2(ptr_param<LinOp> result,
-                                     array<char>& tmp) const
-{
-    GKO_ASSERT_EQUAL_DIMENSIONS(result, dim<2>(1, this->get_size()[1]));
-    auto exec = this->get_executor();
-    if (tmp.get_executor() != exec) {
-        tmp.clear();
-        tmp.set_executor(exec);
-    }
-    auto local_result = make_temporary_clone(exec, result);
-    auto dense_res = make_temporary_conversion<remove_complex<ValueType>>(
-        local_result.get());
-    exec->run(dense::make_compute_norm2(this->get_const_device_view(),
-                                        dense_res->get_device_view(), tmp));
-}
-
-
-template <typename ValueType>
-void Dense<ValueType>::compute_norm2_impl(LinOp* result) const
-{
-    GKO_ASSERT_EQUAL_DIMENSIONS(result, dim<2>(1, this->get_size()[1]));
-    auto exec = this->get_executor();
-    auto dense_res =
-        make_temporary_conversion<remove_complex<ValueType>>(result);
-    array<char> tmp{exec};
-    exec->run(dense::make_compute_norm2(this->get_const_device_view(),
-                                        dense_res->get_device_view(), tmp));
-}
-
-
-template <typename ValueType>
-void Dense<ValueType>::compute_norm1(ptr_param<LinOp> result,
-                                     array<char>& tmp) const
-{
-    GKO_ASSERT_EQUAL_DIMENSIONS(result, dim<2>(1, this->get_size()[1]));
-    auto exec = this->get_executor();
-    if (tmp.get_executor() != exec) {
-        tmp.clear();
-        tmp.set_executor(exec);
-    }
-    auto local_result = make_temporary_clone(exec, result);
-    auto dense_res = make_temporary_conversion<remove_complex<ValueType>>(
-        local_result.get());
-    exec->run(dense::make_compute_norm1(this->get_const_device_view(),
-                                        dense_res->get_device_view(), tmp));
-}
-
-
-template <typename ValueType>
-void Dense<ValueType>::compute_norm1_impl(LinOp* result) const
-{
-    GKO_ASSERT_EQUAL_DIMENSIONS(result, dim<2>(1, this->get_size()[1]));
-    auto exec = this->get_executor();
-    auto dense_res =
-        make_temporary_conversion<remove_complex<ValueType>>(result);
-    array<char> tmp{exec};
-    exec->run(dense::make_compute_norm1(this->get_const_device_view(),
-                                        dense_res->get_device_view(), tmp));
-}
-
-
-template <typename ValueType>
-void Dense<ValueType>::compute_squared_norm2(ptr_param<LinOp> result,
+void Dense<ValueType>::compute_conj_dot_impl(const Dense* b, Dense* result,
                                              array<char>& tmp) const
 {
-    GKO_ASSERT_EQUAL_DIMENSIONS(result, dim<2>(1, this->get_size()[1]));
     auto exec = this->get_executor();
     if (tmp.get_executor() != exec) {
         tmp.clear();
         tmp.set_executor(exec);
     }
-    auto local_result = make_temporary_clone(exec, result);
-    auto dense_res = make_temporary_conversion<remove_complex<ValueType>>(
-        local_result.get());
+    exec->run(dense::make_compute_conj_dot(this->get_const_device_view(),
+                                           b->get_const_device_view(),
+                                           result->get_device_view(), tmp));
+}
+
+
+template <typename ValueType>
+void Dense<ValueType>::compute_conj_dot_impl(const Dense* b,
+                                             Dense* result) const
+{
+    auto exec = this->get_executor();
+    array<char> tmp{exec};
+    exec->run(dense::make_compute_conj_dot(this->get_const_device_view(),
+                                           b->get_const_device_view(),
+                                           result->get_device_view(), tmp));
+}
+
+
+template <typename ValueType>
+void Dense<ValueType>::compute_norm2_impl(absolute_type* result,
+                                          array<char>& tmp) const
+{
+    auto exec = this->get_executor();
+    if (tmp.get_executor() != exec) {
+        tmp.clear();
+        tmp.set_executor(exec);
+    }
+    exec->run(dense::make_compute_norm2(this->get_const_device_view(),
+                                        result->get_device_view(), tmp));
+}
+
+
+template <typename ValueType>
+void Dense<ValueType>::compute_norm2_impl(absolute_type* result) const
+{
+    auto exec = this->get_executor();
+    array<char> tmp{exec};
+    exec->run(dense::make_compute_norm2(this->get_const_device_view(),
+                                        result->get_device_view(), tmp));
+}
+
+
+template <typename ValueType>
+void Dense<ValueType>::compute_norm1_impl(absolute_type* result,
+                                          array<char>& tmp) const
+{
+    auto exec = this->get_executor();
+    if (tmp.get_executor() != exec) {
+        tmp.clear();
+        tmp.set_executor(exec);
+    }
+    exec->run(dense::make_compute_norm1(this->get_const_device_view(),
+                                        result->get_device_view(), tmp));
+}
+
+
+template <typename ValueType>
+void Dense<ValueType>::compute_norm1_impl(absolute_type* result) const
+{
+    auto exec = this->get_executor();
+    array<char> tmp{exec};
+    exec->run(dense::make_compute_norm1(this->get_const_device_view(),
+                                        result->get_device_view(), tmp));
+}
+
+
+template <typename ValueType>
+void Dense<ValueType>::compute_squared_norm2_impl(absolute_type* result,
+                                                  array<char>& tmp) const
+{
+    auto exec = this->get_executor();
+    if (tmp.get_executor() != exec) {
+        tmp.clear();
+        tmp.set_executor(exec);
+    }
     exec->run(dense::make_compute_squared_norm2(
-        this->get_const_device_view(), dense_res->get_device_view(), tmp));
+        this->get_const_device_view(), result->get_device_view(), tmp));
+}
+
+
+template <typename ValueType>
+void Dense<ValueType>::compute_squared_norm2_impl(absolute_type* result) const
+{
+    auto exec = this->get_executor();
+    array<char> tmp{exec};
+    exec->run(dense::make_compute_squared_norm2(
+        this->get_const_device_view(), result->get_device_view(), tmp));
+}
+
+
+template <typename ValueType>
+void Dense<ValueType>::add_scaled(ptr_param<const MultiVector> alpha,
+                                  ptr_param<const Diagonal<value_type>> diag)
+{
+    auto exec = this->get_executor();
+    GKO_ASSERT_EQUAL_DIMENSIONS(alpha, dim<2>(1, 1));
+    auto alpha_clone = make_temporary_clone(exec, alpha);
+    auto converted_alpha = alpha_clone->as_precision(this->get_precision());
+    exec->run(dense::make_add_scaled_diag(
+        as<Dense>(converted_alpha.get())->get_const_device_view(),
+        make_temporary_clone(exec, diag).get(), this->get_device_view()));
+}
+
+
+template <typename ValueType>
+void Dense<ValueType>::sub_scaled(ptr_param<const MultiVector> alpha,
+                                  ptr_param<const Diagonal<value_type>> diag)
+{
+    auto exec = this->get_executor();
+    GKO_ASSERT_EQUAL_DIMENSIONS(alpha, dim<2>(1, 1));
+    auto alpha_clone = make_temporary_clone(exec, alpha);
+    auto converted_alpha = alpha_clone->as_precision(this->get_precision());
+    exec->run(dense::make_sub_scaled_diag(
+        as<Dense>(converted_alpha.get())->get_const_device_view(),
+        make_temporary_clone(exec, diag).get(), this->get_device_view()));
 }
 
 
@@ -539,16 +371,6 @@ void Dense<ValueType>::compute_mean(ptr_param<LinOp> result,
 
 
 template <typename ValueType>
-void Dense<ValueType>::compute_squared_norm2_impl(LinOp* result) const
-{
-    auto exec = this->get_executor();
-    array<char> tmp{exec};
-    this->compute_squared_norm2(make_temporary_output_clone(exec, result).get(),
-                                tmp);
-}
-
-
-template <typename ValueType>
 void Dense<ValueType>::compute_mean_impl(LinOp* result) const
 {
     auto exec = this->get_executor();
@@ -562,7 +384,7 @@ Dense<ValueType>& Dense<ValueType>::operator=(const Dense& other)
 {
     if (&other != this) {
         auto old_size = this->get_size();
-        LinOp::operator=(other);
+        EnableMultiVector<Dense>::operator=(other);
         // NOTE: keep this consistent with resize(...)
         if (old_size != other.get_size()) {
             this->stride_ = this->get_size()[1];
@@ -591,7 +413,7 @@ template <typename ValueType>
 Dense<ValueType>& Dense<ValueType>::operator=(Dense<ValueType>&& other)
 {
     if (&other != this) {
-        LinOp::operator=(std::move(other));
+        EnableMultiVector<Dense>::operator=(std::move(other));
         values_ = std::move(other.values_);
         stride_ = std::exchange(other.stride_, 0);
     }
@@ -1400,6 +1222,150 @@ void Dense<ValueType>::row_gather_impl(const Dense<ValueType>* alpha,
 
 
 template <typename ValueType>
+std::unique_ptr<Dense<ValueType>> Dense<ValueType>::create_with_type_of_impl(
+    std::shared_ptr<const Executor> exec, const dim<2>& global_size,
+    const dim<2>& local_size, size_type stride) const
+{
+    GKO_ASSERT_EQUAL_DIMENSIONS(global_size, local_size);
+    return create_with_type_of_impl(std::move(exec), global_size, stride);
+}
+
+
+template <typename ValueType>
+std::unique_ptr<Dense<ValueType>> Dense<ValueType>::create_subview_impl(
+    local_span rows, local_span columns)
+{
+    return create_subview_impl(rows, columns,
+                               dim<2>(rows.length(), columns.length()));
+}
+
+template <typename ValueType>
+std::unique_ptr<const Dense<ValueType>> Dense<ValueType>::create_subview_impl(
+    local_span rows, local_span columns) const
+{
+    return const_cast<Dense&>(*this).create_subview(rows, columns);
+}
+
+template <typename ValueType>
+std::unique_ptr<Dense<ValueType>> Dense<ValueType>::create_subview_impl(
+    local_span rows, local_span columns, dim<2> global_size)
+{
+    dim<2> actual_size{rows.length(), columns.length()};
+    GKO_ASSERT_EQUAL_DIMENSIONS(actual_size, global_size);
+
+    row_major_range range_this{this->get_values(), this->get_size()[0],
+                               this->get_size()[1], this->get_stride()};
+    auto sub_range = range_this(rows, columns);
+    size_type storage_size =
+        rows.length() > 0 ? sub_range.length(1) +
+                                (sub_range.length(0) - 1) * this->get_stride()
+                          : 0;
+    return Dense::create(
+        this->get_executor(), dim<2>{sub_range.length(0), sub_range.length(1)},
+        make_array_view(this->get_executor(), storage_size, sub_range->data),
+        this->get_stride());
+}
+
+template <typename ValueType>
+std::unique_ptr<const Dense<ValueType>> Dense<ValueType>::create_subview_impl(
+    local_span rows, local_span columns, dim<2> global_size) const
+{
+    dim<2> actual_size{rows.length(), columns.length()};
+    GKO_ASSERT_EQUAL_DIMENSIONS(actual_size, global_size);
+    return const_cast<Dense&>(*this).create_subview(rows, columns);
+}
+
+
+template <typename ValueType>
+void Dense<ValueType>::fill_impl(value_type value)
+{
+    this->get_executor()->run(dense::make_fill(this->get_device_view(), value));
+}
+
+
+template <typename ValueType>
+typename Dense<ValueType>::device_view
+Dense<ValueType>::get_local_device_view_impl()
+{
+    return this->get_device_view();
+}
+
+
+template <typename ValueType>
+typename Dense<ValueType>::const_device_view
+Dense<ValueType>::get_const_local_device_view_impl() const
+{
+    return this->get_const_device_view();
+}
+
+
+template <typename ValueType>
+template <typename OtherValueType>
+gko::detail::temporary_conversion<Dense<OtherValueType>>
+Dense<ValueType>::as_precision()
+{
+    if constexpr (is_complex<ValueType>() == is_complex<OtherValueType>()) {
+        // The value types are either both real or both complex
+        return gko::detail::temporary_conversion<Dense<OtherValueType>>::create(
+            this);
+    } else if constexpr (is_complex<ValueType>() &&
+                         std::is_same_v<to_complex<OtherValueType>,
+                                        ValueType>) {
+        // The value type of this is complex and the other value type is the
+        // corresponding real value type (std::complex<double> vs double).
+        // This conversion is allowed, since the real view of this can be used
+        return gko::detail::temporary_conversion<Dense<OtherValueType>>::create(
+            this->create_real_view());
+    } else {
+        // Conversions from real to complex (or vice versa) that change the
+        // precision are not allowed.
+        GKO_NOT_IMPLEMENTED;
+    }
+}
+
+#define GKO_DECLARE_DENSE_AS_PRECISION(ValueType, OtherValueType) \
+    auto Dense<ValueType>::as_precision()                         \
+        ->gko::detail::temporary_conversion<Dense<OtherValueType>>
+#define GKO_DECLARE_DENSE_AS_PRECISION_same(ValueType) \
+    GKO_DECLARE_DENSE_AS_PRECISION(ValueType, ValueType)
+GKO_INSTANTIATE_FOR_EACH_VALUE_CONVERSION(GKO_DECLARE_DENSE_AS_PRECISION);
+GKO_INSTANTIATE_FOR_EACH_VALUE_TYPE(GKO_DECLARE_DENSE_AS_PRECISION_same);
+
+
+template <typename ValueType>
+template <typename OtherValueType>
+gko::detail::temporary_conversion<const Dense<OtherValueType>>
+Dense<ValueType>::as_precision() const
+{
+    if constexpr (is_complex<ValueType>() == is_complex<OtherValueType>()) {
+        // The value types are either both real or both complex
+        return gko::detail::temporary_conversion<
+            const Dense<OtherValueType>>::create(this);
+    } else if constexpr (is_complex<ValueType>() &&
+                         std::is_same_v<to_complex<OtherValueType>,
+                                        ValueType>) {
+        // The value type of this is complex and the other value type is the
+        // corresponding real value type (std::complex<double> vs double).
+        // This conversion is allowed, since the real view of this can be used
+        return gko::detail::temporary_conversion<
+            const Dense<OtherValueType>>::create(this->create_real_view());
+    } else {
+        // Conversions from real to complex (or vice versa) that change the
+        // precision are not allowed.
+        GKO_NOT_IMPLEMENTED;
+    }
+}
+
+#define GKO_DECLARE_DENSE_CONST_AS_PRECISION(ValueType, OtherValueType) \
+    auto Dense<ValueType>::as_precision()                               \
+        const->gko::detail::temporary_conversion<const Dense<OtherValueType>>
+#define GKO_DECLARE_DENSE_CONST_AS_PRECISION_same(ValueType) \
+    GKO_DECLARE_DENSE_CONST_AS_PRECISION(ValueType, ValueType)
+GKO_INSTANTIATE_FOR_EACH_VALUE_CONVERSION(GKO_DECLARE_DENSE_CONST_AS_PRECISION);
+GKO_INSTANTIATE_FOR_EACH_VALUE_TYPE(GKO_DECLARE_DENSE_CONST_AS_PRECISION_same);
+
+
+template <typename ValueType>
 std::unique_ptr<LinOp> Dense<ValueType>::permute(
     const array<int32>* permutation_indices) const
 {
@@ -1931,7 +1897,7 @@ std::unique_ptr<Diagonal<ValueType>> Dense<ValueType>::extract_diagonal() const
 
 
 template <typename ValueType>
-void Dense<ValueType>::compute_absolute_inplace()
+void Dense<ValueType>::compute_absolute_inplace_impl()
 {
     this->get_executor()->run(
         dense::make_inplace_absolute_dense(this->get_device_view()));
@@ -1940,7 +1906,7 @@ void Dense<ValueType>::compute_absolute_inplace()
 
 template <typename ValueType>
 std::unique_ptr<typename Dense<ValueType>::absolute_type>
-Dense<ValueType>::compute_absolute() const
+Dense<ValueType>::compute_absolute_impl() const
 {
     // do not inherit the stride
     auto result = absolute_type::create(this->get_executor(), this->get_size());
@@ -1950,9 +1916,8 @@ Dense<ValueType>::compute_absolute() const
 
 
 template <typename ValueType>
-void Dense<ValueType>::compute_absolute(ptr_param<absolute_type> output) const
+void Dense<ValueType>::compute_absolute_impl(absolute_type* output) const
 {
-    GKO_ASSERT_EQUAL_DIMENSIONS(this, output);
     auto exec = this->get_executor();
 
     exec->run(dense::make_outplace_absolute_dense(
@@ -1963,7 +1928,7 @@ void Dense<ValueType>::compute_absolute(ptr_param<absolute_type> output) const
 
 template <typename ValueType>
 std::unique_ptr<typename Dense<ValueType>::complex_type>
-Dense<ValueType>::make_complex() const
+Dense<ValueType>::make_complex_impl() const
 {
     auto result = complex_type::create(this->get_executor(), this->get_size());
     this->make_complex(result);
@@ -1972,9 +1937,8 @@ Dense<ValueType>::make_complex() const
 
 
 template <typename ValueType>
-void Dense<ValueType>::make_complex(ptr_param<complex_type> result) const
+void Dense<ValueType>::make_complex_impl(complex_type* result) const
 {
-    GKO_ASSERT_EQUAL_DIMENSIONS(this, result);
     auto exec = this->get_executor();
 
     exec->run(dense::make_make_complex(
@@ -1985,7 +1949,7 @@ void Dense<ValueType>::make_complex(ptr_param<complex_type> result) const
 
 template <typename ValueType>
 std::unique_ptr<typename Dense<ValueType>::real_type>
-Dense<ValueType>::get_real() const
+Dense<ValueType>::get_real_impl() const
 {
     auto result = real_type::create(this->get_executor(), this->get_size());
     this->get_real(result);
@@ -1994,20 +1958,18 @@ Dense<ValueType>::get_real() const
 
 
 template <typename ValueType>
-void Dense<ValueType>::get_real(ptr_param<real_type> result) const
+void Dense<ValueType>::get_real_impl(real_type* result) const
 {
-    GKO_ASSERT_EQUAL_DIMENSIONS(this, result);
     auto exec = this->get_executor();
 
-    exec->run(dense::make_get_real(
-        this->get_const_device_view(),
-        make_temporary_output_clone(exec, result)->get_device_view()));
+    exec->run(dense::make_get_real(this->get_const_device_view(),
+                                   result->get_device_view()));
 }
 
 
 template <typename ValueType>
 std::unique_ptr<typename Dense<ValueType>::real_type>
-Dense<ValueType>::get_imag() const
+Dense<ValueType>::get_imag_impl() const
 {
     auto result = real_type::create(this->get_executor(), this->get_size());
     this->get_imag(result);
@@ -2016,19 +1978,17 @@ Dense<ValueType>::get_imag() const
 
 
 template <typename ValueType>
-void Dense<ValueType>::get_imag(ptr_param<real_type> result) const
+void Dense<ValueType>::get_imag_impl(real_type* result) const
 {
-    GKO_ASSERT_EQUAL_DIMENSIONS(this, result);
     auto exec = this->get_executor();
 
-    exec->run(dense::make_get_imag(
-        this->get_const_device_view(),
-        make_temporary_output_clone(exec, result)->get_device_view()));
+    exec->run(dense::make_get_imag(this->get_const_device_view(),
+                                   result->get_device_view()));
 }
 
 
 template <typename ValueType>
-auto Dense<ValueType>::get_device_view() -> device_view
+typename Dense<ValueType>::device_view Dense<ValueType>::get_device_view()
 {
     return device_view{this->get_size(), this->get_stride(),
                        this->get_values()};
@@ -2036,7 +1996,8 @@ auto Dense<ValueType>::get_device_view() -> device_view
 
 
 template <typename ValueType>
-auto Dense<ValueType>::get_const_device_view() const -> const_device_view
+typename Dense<ValueType>::const_device_view
+Dense<ValueType>::get_const_device_view() const
 {
     return const_device_view{this->get_size(), this->get_stride(),
                              this->get_const_values()};
@@ -2059,7 +2020,7 @@ void Dense<ValueType>::add_scaled_identity_impl(const LinOp* a, const LinOp* b)
 
 template <typename ValueType>
 std::unique_ptr<typename Dense<ValueType>::real_type>
-Dense<ValueType>::create_real_view()
+Dense<ValueType>::create_real_view_impl()
 {
     const auto num_rows = this->get_size()[0];
     constexpr bool complex = is_complex<ValueType>();
@@ -2078,7 +2039,7 @@ Dense<ValueType>::create_real_view()
 
 template <typename ValueType>
 std::unique_ptr<const typename Dense<ValueType>::real_type>
-Dense<ValueType>::create_real_view() const
+Dense<ValueType>::create_real_view_impl() const
 {
     const auto num_rows = this->get_size()[0];
     constexpr bool complex = is_complex<ValueType>();
@@ -2092,24 +2053,6 @@ Dense<ValueType>::create_real_view() const
             this->get_executor(), num_rows * stride,
             reinterpret_cast<const remove_complex<ValueType>*>(
                 this->get_const_values())),
-        stride);
-}
-
-
-template <typename ValueType>
-std::unique_ptr<Dense<ValueType>> Dense<ValueType>::create_submatrix_impl(
-    const span& rows, const span& columns, const size_type stride)
-{
-    row_major_range range_this{this->get_values(), this->get_size()[0],
-                               this->get_size()[1], this->get_stride()};
-    auto sub_range = range_this(rows, columns);
-    size_type storage_size =
-        rows.length() > 0 ? sub_range.length(1) +
-                                (sub_range.length(0) - 1) * this->get_stride()
-                          : 0;
-    return Dense::create(
-        this->get_executor(), dim<2>{sub_range.length(0), sub_range.length(1)},
-        make_array_view(this->get_executor(), storage_size, sub_range->data),
         stride);
 }
 
@@ -2147,7 +2090,7 @@ std::unique_ptr<const Dense<ValueType>> Dense<ValueType>::create_const(
 template <typename ValueType>
 Dense<ValueType>::Dense(std::shared_ptr<const Executor> exec,
                         const dim<2>& size, size_type stride)
-    : LinOp(exec, size, type_to_precision<ValueType>),
+    : EnableMultiVector<Dense>(exec, size),
       stride_(stride == 0 ? size[1] : stride),
       values_(exec, size[0] * stride_)
 {}
@@ -2157,7 +2100,7 @@ template <typename ValueType>
 Dense<ValueType>::Dense(std::shared_ptr<const Executor> exec,
                         const dim<2>& size, array<value_type> values,
                         size_type stride)
-    : LinOp(exec, size, type_to_precision<ValueType>),
+    : EnableMultiVector<Dense>(exec, size),
       stride_(stride == 0 ? size[1] : stride),
       values_(exec, std::move(values))
 {

--- a/core/solver/cb_gmres.cpp
+++ b/core/solver/cb_gmres.cpp
@@ -417,8 +417,9 @@ void CbGmres<ValueType>::apply_dense_impl(
                 perform_reset = false;
                 // Restart
                 // use a view in case this is called earlier
-                auto hessenberg_view = hessenberg->create_submatrix(
-                    span{0, restart_iter}, span{0, num_rhs * (restart_iter)});
+                auto hessenberg_view = hessenberg->create_subview(
+                    local_span{0, restart_iter},
+                    local_span{0, num_rhs * (restart_iter)});
 
                 exec->run(cb_gmres::make_solve_krylov(
                     residual_norm_collection->get_const_device_view(),
@@ -460,11 +461,12 @@ void CbGmres<ValueType>::apply_dense_impl(
             // next_krylov_basis
 
             // Do Arnoldi and givens rotation
-            auto hessenberg_iter = hessenberg->create_submatrix(
-                span{0, restart_iter + 2},
-                span{num_rhs * restart_iter, num_rhs * (restart_iter + 1)});
-            auto buffer_iter = buffer->create_submatrix(
-                span{0, restart_iter + 2}, span{0, num_rhs});
+            auto hessenberg_iter = hessenberg->create_subview(
+                local_span{0, restart_iter + 2},
+                local_span{num_rhs * restart_iter,
+                           num_rhs * (restart_iter + 1)});
+            auto buffer_iter = buffer->create_subview(
+                local_span{0, restart_iter + 2}, local_span{0, num_rhs});
 
             // Start of arnoldi
             this->get_system_matrix()->apply(preconditioned_vector,
@@ -506,8 +508,8 @@ void CbGmres<ValueType>::apply_dense_impl(
         }  // closes while(true)
         // Solve x
 
-        auto hessenberg_small = hessenberg->create_submatrix(
-            span{0, restart_iter}, span{0, num_rhs * restart_iter});
+        auto hessenberg_small = hessenberg->create_subview(
+            local_span{0, restart_iter}, local_span{0, num_rhs * restart_iter});
 
         exec->run(cb_gmres::make_solve_krylov(
             residual_norm_collection->get_const_device_view(),

--- a/core/solver/idr.cpp
+++ b/core/solver/idr.cpp
@@ -250,8 +250,8 @@ void Idr<ValueType>::iterate(const VectorType* dense_b,
                 gko::detail::get_local(c)->get_const_device_view(),
                 gko::detail::get_local(u)->get_device_view(), stop_status));
 
-            auto u_k = u->create_submatrix(span{0, problem_size},
-                                           span{k * nrhs, (k + 1) * nrhs});
+            auto u_k = u->create_subview(local_span{0, problem_size},
+                                         local_span{k * nrhs, (k + 1) * nrhs});
 
             // g_k = Au_k
             this->get_system_matrix()->apply(u_k, helper);

--- a/core/test/matrix/dense.cpp
+++ b/core/test/matrix/dense.cpp
@@ -322,7 +322,7 @@ TYPED_TEST(Dense, CanCreateConstDeviceView)
 TYPED_TEST(Dense, CanCreateSubmatrix)
 {
     using value_type = typename TestFixture::value_type;
-    auto submtx = this->mtx->create_submatrix(gko::span{0, 1}, gko::span{1, 3});
+    auto submtx = this->mtx->create_subview(gko::span{0, 1}, gko::span{1, 3});
 
     EXPECT_EQ(submtx->get_size(), gko::dim<2>(1, 2));
     EXPECT_EQ(submtx->at(0, 0), value_type{2.0});
@@ -338,8 +338,8 @@ TYPED_TEST(Dense, CanCreateSubmatrixWithGlobalSize)
 {
     using value_type = typename TestFixture::value_type;
     auto submtx_orig =
-        this->mtx->create_submatrix(gko::span{0, 1}, gko::span{1, 3});
-    auto submtx = this->mtx->create_submatrix(
+        this->mtx->create_subview(gko::span{0, 1}, gko::span{1, 3});
+    auto submtx = this->mtx->create_subview(
         gko::local_span{0, 1}, gko::local_span{1, 3}, gko::dim<2>{1, 2});
 
     GKO_ASSERT_MTX_NEAR(submtx_orig, submtx, 0.0);
@@ -350,40 +350,17 @@ TYPED_TEST(Dense, CanCreateSubmatrixWithGlobalSize)
 TYPED_TEST(Dense, CreateSubmatrixWithGlobalSizeThrowsOnIncorrectSize)
 {
     EXPECT_THROW(
-        this->mtx->create_submatrix(gko::local_span{0, 1},
-                                    gko::local_span{1, 3}, gko::dim<2>{1, 20}),
+        (void)this->mtx->create_subview(
+            gko::local_span{0, 1}, gko::local_span{1, 3}, gko::dim<2>{1, 20}),
         gko::DimensionMismatch);
 }
 
 
 TYPED_TEST(Dense, CanCreateEmptySubmatrix)
 {
-    using value_type = typename TestFixture::value_type;
-    auto submtx = this->mtx->create_submatrix(gko::span{0, 0}, gko::span{1, 1});
+    auto submtx = this->mtx->create_subview(gko::span{0, 0}, gko::span{1, 1});
 
     EXPECT_EQ(submtx->get_size(), gko::dim<2>{});
-}
-
-
-TYPED_TEST(Dense, CanCreateSubmatrixWithStride)
-{
-    using value_type = typename TestFixture::value_type;
-    auto submtx =
-        this->mtx->create_submatrix(gko::span{0, 2}, gko::span{0, 2}, 3);
-
-    EXPECT_EQ(submtx->get_size(), gko::dim<2>(2, 2));
-    EXPECT_EQ(submtx->get_stride(), 3);
-    // The entry submtx->at(1, 0) points to the strided data of this->mtx
-    // which means that it is undefined. Thus it is skipped in the tests
-    EXPECT_EQ(submtx->at(0, 0), value_type{1.0});
-    EXPECT_EQ(submtx->at(0, 1), value_type{2.0});
-    EXPECT_EQ(submtx->at(1, 1), value_type{1.5});
-    EXPECT_EQ(submtx->get_num_stored_elements(), 6);
-    EXPECT_LT(std::distance(this->mtx->get_values(), submtx->get_values()),
-              this->mtx->get_num_stored_elements());
-    EXPECT_EQ(&submtx->at(0, 0), &this->mtx->at(0, 0));
-    EXPECT_EQ(&submtx->at(0, 1), &this->mtx->at(0, 1));
-    EXPECT_EQ(&submtx->at(1, 1), &this->mtx->at(1, 0));
 }
 
 
@@ -492,13 +469,17 @@ private:
         : gko::matrix::Dense<>(std::move(exec), size), data_(data)
     {}
 
-    std::unique_ptr<gko::matrix::Dense<>> create_view_of_impl() override
+protected:
+    [[nodiscard]] std::unique_ptr<Dense<>> create_subview_impl(
+        gko::local_span rows, gko::local_span columns) override
     {
-        auto view = create(this->get_executor(), {}, this->get_data());
+        auto view = std::unique_ptr<CustomDense>(
+            new CustomDense(this->get_executor(), {}, this->get_data()));
         gko::matrix::Dense<>::create_view_of_impl()->move_to(view);
         return view;
     }
 
+private:
     int data_;
 };
 

--- a/include/ginkgo/core/base/block_operator.hpp
+++ b/include/ginkgo/core/base/block_operator.hpp
@@ -13,36 +13,6 @@
 
 
 namespace gko {
-namespace detail {
-
-
-/**
- * Carbon copy og gko::span, except that the members are not const.
- * Necessary since the normal gko::span is not copy/movable.
- */
-struct value_span {
-    constexpr value_span(size_type point) noexcept
-        : value_span{point, point + 1}
-    {}
-
-    constexpr value_span(size_type begin, size_type end) noexcept
-        : begin{begin}, end{end}
-    {}
-
-    constexpr operator span() const { return {begin, end}; }
-
-    constexpr value_span(const span& s) noexcept : value_span(s.begin, s.end) {}
-
-    constexpr bool is_valid() const { return begin <= end; }
-
-    constexpr size_type length() const { return end - begin; }
-
-    size_type begin;
-    size_type end;
-};
-
-
-}  // namespace detail
 
 
 /**
@@ -164,8 +134,8 @@ private:
                     LinOp* x) const override;
 
     dim<2> block_size_;
-    std::vector<detail::value_span> row_spans_;
-    std::vector<detail::value_span> col_spans_;
+    std::vector<local_span> row_spans_;
+    std::vector<local_span> col_spans_;
     std::vector<std::shared_ptr<const LinOp>> blocks_;
     /**
      * @internal Using a fixed precision here may lead to temporary

--- a/include/ginkgo/core/matrix/dense.hpp
+++ b/include/ginkgo/core/matrix/dense.hpp
@@ -1203,8 +1203,8 @@ template <typename VecPtr>
 std::unique_ptr<matrix::Dense<typename detail::pointee<VecPtr>::value_type>>
 make_dense_view(VecPtr&& vector)
 {
-    using value_type = typename detail::pointee<VecPtr>::value_type;
-    return matrix::Dense<value_type>::create_view_of(vector);
+    auto size = vector->get_size();
+    return vector->create_subview({0, size[0]}, {0, size[1]});
 }
 
 
@@ -1220,8 +1220,8 @@ std::unique_ptr<
     const matrix::Dense<typename detail::pointee<VecPtr>::value_type>>
 make_const_dense_view(VecPtr&& vector)
 {
-    using value_type = typename detail::pointee<VecPtr>::value_type;
-    return matrix::Dense<value_type>::create_const_view_of(vector);
+    auto size = vector->get_size();
+    return vector->create_subview({0, size[0]}, {0, size[1]}, size);
 }
 
 

--- a/include/ginkgo/core/matrix/dense.hpp
+++ b/include/ginkgo/core/matrix/dense.hpp
@@ -13,6 +13,7 @@
 #include <ginkgo/core/base/exception_helpers.hpp>
 #include <ginkgo/core/base/executor.hpp>
 #include <ginkgo/core/base/lin_op.hpp>
+#include <ginkgo/core/base/multivector.hpp>
 #include <ginkgo/core/base/range_accessors.hpp>
 #include <ginkgo/core/base/types.hpp>
 #include <ginkgo/core/base/utils.hpp>
@@ -87,8 +88,7 @@ class SparsityCsr;
  */
 template <typename ValueType = default_precision>
 class Dense
-    : public LinOp,
-      public EnableCloneable<Dense<ValueType>>,
+    : public EnableMultiVector<Dense<ValueType>>,
       public ConvertibleTo<Dense<next_precision<ValueType>>>,
 #if GINKGO_ENABLE_HALF || GINKGO_ENABLE_BFLOAT16
       public ConvertibleTo<Dense<next_precision<ValueType, 2>>>,
@@ -142,8 +142,9 @@ class Dense
     GKO_ASSERT_SUPPORTED_VALUE_TYPE;
 
 public:
-    using EnableCloneable<Dense>::convert_to;
-    using EnableCloneable<Dense>::move_to;
+    using EnableMultiVector<Dense>::convert_to;
+    using EnableMultiVector<Dense>::move_to;
+    using EnableMultiVector<Dense>::create_with_type_of;
     using ConvertibleTo<Dense<next_precision<ValueType>>>::convert_to;
     using ConvertibleTo<Dense<next_precision<ValueType>>>::move_to;
     using ConvertibleTo<Coo<ValueType, int32>>::convert_to;
@@ -176,8 +177,11 @@ public:
     using ConvertibleTo<SparsityCsr<ValueType, int64>>::move_to;
     using ReadableFromMatrixData<ValueType, int32>::read;
     using ReadableFromMatrixData<ValueType, int64>::read;
+    // necessary because of overload for diagonal matrices
+    using EnableMultiVector<Dense>::add_scaled;
+    using EnableMultiVector<Dense>::sub_scaled;
 
-    using value_type = ValueType;
+    using value_type = typename EnableMultiVector<Dense>::value_type;
     using index_type = int64;
     using transposed_type = Dense<value_type>;
     using mat_data = matrix_data<value_type, int64>;
@@ -187,105 +191,11 @@ public:
     using absolute_type = remove_complex<Dense>;
     using real_type = absolute_type;
     using complex_type = to_complex<Dense>;
-    using device_view = matrix::view::dense<value_type>;
-    using const_device_view = matrix::view::dense<const value_type>;
+    using device_view = typename EnableMultiVector<Dense>::device_view;
+    using const_device_view =
+        typename EnableMultiVector<Dense>::const_device_view;
 
     using row_major_range = gko::range<gko::accessor::row_major<ValueType, 2>>;
-
-    /**
-     * Creates a Dense matrix with the same size and stride as another Dense
-     * matrix.
-     *
-     * @param other  The other matrix whose configuration needs to copied.
-     */
-    static std::unique_ptr<Dense> create_with_config_of(
-        ptr_param<const Dense> other)
-    {
-        // De-referencing `other` before calling the functions (instead of
-        // using operator `->`) is currently required to be compatible with
-        // CUDA 10.1.
-        // Otherwise, it results in a compile error.
-        return (*other).create_with_same_config();
-    }
-
-    /**
-     * Creates a Dense matrix with the same type as another Dense
-     * matrix but on a different executor and with a different size.
-     *
-     * @param other  The other matrix whose type we target.
-     * @param exec  The executor of the new matrix.
-     * @param size  The size of the new matrix.
-     * @param stride  The stride of the new matrix.
-     *
-     * @returns a Dense matrix with the type of other.
-     */
-    static std::unique_ptr<Dense> create_with_type_of(
-        ptr_param<const Dense> other, std::shared_ptr<const Executor> exec,
-        const dim<2>& size = dim<2>{})
-    {
-        // See create_with_config_of()
-        return (*other).create_with_type_of_impl(exec, size, size[1]);
-    }
-
-    /**
-     * @copydoc create_with_type_of(const Dense*, std::shared_ptr<const
-     * Executor>, const dim<2>)
-     *
-     * @param stride  The stride of the new matrix.
-     *
-     * @note This is an overload which allows full parameter specification.
-     */
-    static std::unique_ptr<Dense> create_with_type_of(
-        ptr_param<const Dense> other, std::shared_ptr<const Executor> exec,
-        const dim<2>& size, size_type stride)
-    {
-        // See create_with_config_of()
-        return (*other).create_with_type_of_impl(exec, size, stride);
-    }
-
-    /**
-     * @copydoc create_with_type_of(const Dense*, std::shared_ptr<const
-     * Executor>, const dim<2>)
-     *
-     * @param local_size  Unused
-     * @param stride  The stride of the new matrix.
-     *
-     * @note This is an overload to stay consistent with
-     *       gko::experimental::distributed::Vector
-     */
-    static std::unique_ptr<Dense> create_with_type_of(
-        ptr_param<const Dense> other, std::shared_ptr<const Executor> exec,
-        const dim<2>& size, const dim<2>& local_size, size_type stride)
-    {
-        // See create_with_config_of()
-        return (*other).create_with_type_of_impl(exec, size, stride);
-    }
-
-    /**
-     * Creates a Dense matrix, where the underlying array is a view of another
-     * Dense matrix' array.
-     *
-     * @param other  The other matrix on which to create the view
-     *
-     * @return  A Dense matrix that is a view of other
-     */
-    static std::unique_ptr<Dense> create_view_of(ptr_param<Dense> other)
-    {
-        return other->create_view_of_impl();
-    }
-
-    /**
-     * Creates a immutable Dense matrix, where the underlying array is a view of
-     * another Dense matrix' array.
-     *
-     * @param other  The other matrix on which to create the view
-     * @return  A immutable Dense matrix that is a view of other
-     */
-    static std::unique_ptr<const Dense> create_const_view_of(
-        ptr_param<const Dense> other)
-    {
-        return other->create_const_view_of_impl();
-    }
 
     friend class Dense<previous_precision<ValueType>>;
 
@@ -404,13 +314,6 @@ public:
      *                `gko::transpose(this->get_size())`
      */
     void conj_transpose(ptr_param<Dense> output) const;
-
-    /**
-     * Fill the dense matrix with a given value.
-     *
-     * @param value  the value to be filled
-     */
-    void fill(const ValueType value);
 
     /**
      * Creates a permuted copy $A'$ of this matrix $A$ with the given
@@ -808,55 +711,6 @@ public:
      */
     void extract_diagonal(ptr_param<Diagonal<ValueType>> output) const;
 
-    std::unique_ptr<absolute_type> compute_absolute() const override;
-
-    /**
-     * Writes the absolute values of this matrix into an existing matrix.
-     *
-     * @param output  The output matrix. Its size must match the size of this
-     *                matrix.
-     * @see Dense::compute_absolute()
-     */
-    void compute_absolute(ptr_param<absolute_type> output) const;
-
-    void compute_absolute_inplace() override;
-
-    /**
-     * Creates a complex copy of the original matrix. If the original matrix
-     * was real, the imaginary part of the result will be zero.
-     */
-    std::unique_ptr<complex_type> make_complex() const;
-
-    /**
-     * Writes a complex copy of the original matrix to a given complex matrix.
-     * If the original matrix was real, the imaginary part of the result will
-     * be zero.
-     */
-    void make_complex(ptr_param<complex_type> result) const;
-
-    /**
-     * Creates a new real matrix and extracts the real part of the original
-     * matrix into that.
-     */
-    std::unique_ptr<real_type> get_real() const;
-
-    /**
-     * Extracts the real part of the original matrix into a given real matrix.
-     */
-    void get_real(ptr_param<real_type> result) const;
-
-    /**
-     * Creates a new real matrix and extracts the imaginary part of the
-     * original matrix into that.
-     */
-    std::unique_ptr<real_type> get_imag() const;
-
-    /**
-     * Extracts the imaginary part of the original matrix into a given real
-     * matrix.
-     */
-    void get_imag(ptr_param<real_type> result) const;
-
     /**
      * Returns a pointer to the array of values of the matrix.
      *
@@ -947,165 +801,11 @@ public:
         return values_.get_const_data()[linearize_index(idx)];
     }
 
-    /**
-     * Scales the matrix with a scalar (aka: BLAS scal).
-     *
-     * @param alpha  If alpha is 1x1 Dense matrix, the entire matrix is scaled
-     *               by alpha. If it is a Dense row vector of values,
-     *               then i-th column of the matrix is scaled with the i-th
-     *               element of alpha (the number of columns of alpha has to
-     *               match the number of columns of the matrix).
-     */
-    void scale(ptr_param<const LinOp> alpha);
+    void add_scaled(ptr_param<const MultiVector> alpha,
+                    ptr_param<const Diagonal<value_type>> diag);
 
-    /**
-     * Scales the matrix with the inverse of a scalar.
-     *
-     * @param alpha  If alpha is 1x1 Dense matrix, the entire matrix is scaled
-     *               by 1 / alpha. If it is a Dense row vector of values,
-     *               then i-th column of the matrix is scaled with the inverse
-     *               of the i-th element of alpha (the number of columns of
-     *               alpha has to match the number of columns of the matrix).
-     */
-    void inv_scale(ptr_param<const LinOp> alpha);
-
-    /**
-     * Adds `b` scaled by `alpha` to the matrix (aka: BLAS axpy).
-     *
-     * @param alpha  If alpha is 1x1 Dense matrix, the entire matrix is scaled
-     *               by alpha. If it is a Dense row vector of values,
-     *               then i-th column of the matrix is scaled with the i-th
-     *               element of alpha (the number of columns of alpha has to
-     *               match the number of columns of the matrix).
-     * @param b  a matrix of the same dimension as this
-     */
-    void add_scaled(ptr_param<const LinOp> alpha, ptr_param<const LinOp> b);
-
-    /**
-     * Subtracts `b` scaled by `alpha` from the matrix (aka: BLAS axpy).
-     *
-     * @param alpha  If alpha is 1x1 Dense matrix, b is scaled
-     *               by alpha. If it is a Dense row vector of values,
-     *               then i-th column of b is scaled with the i-th
-     *               element of alpha (the number of columns of alpha has to
-     *               match the number of columns of the matrix).
-     * @param b  a matrix of the same dimension as this
-     */
-    void sub_scaled(ptr_param<const LinOp> alpha, ptr_param<const LinOp> b);
-
-    /**
-     * Computes the column-wise dot product of this matrix and `b`.
-     *
-     * @param b  a Dense matrix of same dimension as this
-     * @param result  a Dense row vector, used to store the dot product
-     *                (the number of column in the vector must match the number
-     *                of columns of this)
-     */
-    void compute_dot(ptr_param<const LinOp> b, ptr_param<LinOp> result) const;
-
-    /**
-     * Computes the column-wise dot product of this matrix and `b`.
-     *
-     * @param b  a Dense matrix of same dimension as this
-     * @param result  a Dense row vector, used to store the dot product
-     *                (the number of column in the vector must match the number
-     *                of columns of this)
-     * @param tmp  the temporary storage to use for partial sums during the
-     *             reduction computation. It may be resized and/or reset to the
-     *             correct executor.
-     */
-    void compute_dot(ptr_param<const LinOp> b, ptr_param<LinOp> result,
-                     array<char>& tmp) const;
-
-    /**
-     * Computes the column-wise dot product of `conj(this matrix)` and `b`.
-     *
-     * @param b  a Dense matrix of same dimension as this
-     * @param result  a Dense row vector, used to store the dot product
-     *                (the number of column in the vector must match the number
-     *                of columns of this)
-     */
-    void compute_conj_dot(ptr_param<const LinOp> b,
-                          ptr_param<LinOp> result) const;
-
-    /**
-     * Computes the column-wise dot product of `conj(this matrix)` and `b`.
-     *
-     * @param b  a Dense matrix of same dimension as this
-     * @param result  a Dense row vector, used to store the dot product
-     *                (the number of column in the vector must match the number
-     *                of columns of this)
-     * @param tmp  the temporary storage to use for partial sums during the
-     *             reduction computation. It may be resized and/or reset to the
-     *             correct executor.
-     */
-    void compute_conj_dot(ptr_param<const LinOp> b, ptr_param<LinOp> result,
-                          array<char>& tmp) const;
-
-    /**
-     * Computes the column-wise Euclidean (L^2) norm of this matrix.
-     *
-     * @param result  a Dense row vector, used to store the norm
-     *                (the number of columns in the vector must match the number
-     *                of columns of this)
-     */
-    void compute_norm2(ptr_param<LinOp> result) const;
-
-    /**
-     * Computes the column-wise Euclidean (L^2) norm of this matrix.
-     *
-     * @param result  a Dense row vector, used to store the norm
-     *                (the number of columns in the vector must match the
-     *                number of columns of this)
-     * @param tmp  the temporary storage to use for partial sums during the
-     *             reduction computation. It may be resized and/or reset to the
-     *             correct executor.
-     */
-    void compute_norm2(ptr_param<LinOp> result, array<char>& tmp) const;
-
-    /**
-     * Computes the column-wise (L^1) norm of this matrix.
-     *
-     * @param result  a Dense row vector, used to store the norm
-     *                (the number of columns in the vector must match the number
-     *                of columns of this)
-     */
-    void compute_norm1(ptr_param<LinOp> result) const;
-
-    /**
-     * Computes the column-wise (L^1) norm of this matrix.
-     *
-     * @param result  a Dense row vector, used to store the norm
-     *                (the number of columns in the vector must match the
-     *                number of columns of this)
-     * @param tmp  the temporary storage to use for partial sums during the
-     *             reduction computation. It may be resized and/or reset to the
-     *             correct executor.
-     */
-    void compute_norm1(ptr_param<LinOp> result, array<char>& tmp) const;
-
-    /**
-     * Computes the square of the column-wise Euclidean (L^2) norm of this
-     * matrix.
-     *
-     * @param result  a Dense row vector, used to store the norm
-     *                (the number of columns in the vector must match the number
-     *                of columns of this)
-     */
-    void compute_squared_norm2(ptr_param<LinOp> result) const;
-
-    /**
-     * Computes the square of the column-wise Euclidean (L^2) norm of this
-     * matrix.
-     *
-     * @param result  a Dense row vector, used to store the norm
-     *                (the number of columns in the vector must match the
-     *                number of columns of this)
-     * @param tmp  the temporary storage to use for partial sums during the
-     *             reduction computation. It may be resized and/or reset to the
-     *             correct executor.
-     */
-    void compute_squared_norm2(ptr_param<LinOp> result, array<char>& tmp) const;
+    void sub_scaled(ptr_param<const MultiVector> alpha,
+                    ptr_param<const Diagonal<value_type>> diag);
 
     /**
      * Computes the column-wise arithmetic mean of this matrix.
@@ -1128,66 +828,13 @@ public:
      */
     void compute_mean(ptr_param<LinOp> result, array<char>& tmp) const;
 
-    /**
-     * Create a submatrix from the original matrix.
-     * Warning: defining stride for this create_submatrix method might cause
-     * wrong memory access. Better use the create_submatrix(rows, columns)
-     * method instead.
-     *
-     * @param rows     row span
-     * @param columns  column span
-     * @param stride   stride of the new submatrix.
-     */
-    std::unique_ptr<Dense> create_submatrix(const span& rows,
-                                            const span& columns,
-                                            const size_type stride)
-    {
-        return this->create_submatrix_impl(rows, columns, stride);
-    }
+    template <typename OtherValueType>
+    [[nodiscard]] gko::detail::temporary_conversion<Dense<OtherValueType>>
+    as_precision();
 
-    /**
-     * Create a submatrix from the original matrix.
-     *
-     * @param rows     row span
-     * @param columns  column span
-     */
-    std::unique_ptr<Dense> create_submatrix(const span& rows,
-                                            const span& columns)
-    {
-        return create_submatrix(rows, columns, this->get_stride());
-    }
-
-
-    /**
-     * Create a submatrix from the original matrix.
-     *
-     * @param rows  row span
-     * @param columns  column span
-     * @param size  size of the submatrix (only used for consistency with
-     *              distributed::Vector)
-     */
-    std::unique_ptr<Dense> create_submatrix(const local_span& rows,
-                                            const local_span& columns,
-                                            dim<2> size)
-    {
-        dim<2> deduced_size{rows.length(), columns.length()};
-        GKO_ASSERT_EQUAL_DIMENSIONS(deduced_size, size);
-        return create_submatrix(rows, columns, this->get_stride());
-    }
-
-    /**
-     * Create a real view of the (potentially) complex original matrix.
-     * If the original matrix is real, nothing changes. If the original matrix
-     * is complex, the result is created by viewing the complex matrix with as
-     * real with a reinterpret_cast with twice the number of columns and
-     * double the stride.
-     */
-    std::unique_ptr<real_type> create_real_view();
-
-    /**
-     * @copydoc create_real_view()
-     */
-    std::unique_ptr<const real_type> create_real_view() const;
+    template <typename OtherValueType>
+    [[nodiscard]] gko::detail::temporary_conversion<const Dense<OtherValueType>>
+    as_precision() const;
 
     /**
      * Creates an uninitialized Dense matrix of the specified size.
@@ -1296,7 +943,7 @@ protected:
      *
      * @returns a Dense matrix with the same size and stride as the caller.
      */
-    virtual std::unique_ptr<Dense> create_with_same_config() const
+    std::unique_ptr<Dense> create_with_same_config_impl() const override
     {
         return Dense::create(this->get_executor(), this->get_size(),
                              this->get_stride());
@@ -1370,78 +1017,6 @@ protected:
     void convert_impl(SparsityCsr<ValueType, IndexType>* result) const;
 
     /**
-     * @copydoc scale(const LinOp *)
-     *
-     * @deprecated  This function will be removed in the future,
-     *              we will instead always use Ginkgo's implementation.
-     */
-    virtual void scale_impl(const LinOp* alpha);
-
-    /**
-     * @copydoc inv_scale(const LinOp *)
-     *
-     * @deprecated  This function will be removed in the future,
-     *              we will instead always use Ginkgo's implementation.
-     */
-    virtual void inv_scale_impl(const LinOp* alpha);
-
-    /**
-     * @copydoc add_scaled(const LinOp *, const LinOp *)
-     *
-     * @deprecated  This function will be removed in the future,
-     *              we will instead always use Ginkgo's implementation.
-     */
-    virtual void add_scaled_impl(const LinOp* alpha, const LinOp* b);
-
-    /**
-     * @copydoc sub_scaled(const LinOp *, const LinOp *)
-     *
-     * @deprecated  This function will be removed in the future,
-     *              we will instead always use Ginkgo's implementation.
-     */
-    virtual void sub_scaled_impl(const LinOp* alpha, const LinOp* b);
-
-    /**
-     * @copydoc compute_dot(const LinOp*, LinOp*) const
-     *
-     * @deprecated  This function will be removed in the future,
-     *              we will instead always use Ginkgo's implementation.
-     */
-    virtual void compute_dot_impl(const LinOp* b, LinOp* result) const;
-
-    /**
-     * @copydoc compute_conj_dot(const LinOp*, LinOp*) const
-     *
-     * @deprecated  This function will be removed in the future,
-     *              we will instead always use Ginkgo's implementation.
-     */
-    virtual void compute_conj_dot_impl(const LinOp* b, LinOp* result) const;
-
-    /**
-     * @copydoc compute_norm2(LinOp*) const
-     *
-     * @deprecated  This function will be removed in the future,
-     *              we will instead always use Ginkgo's implementation.
-     */
-    virtual void compute_norm2_impl(LinOp* result) const;
-
-    /**
-     * @copydoc compute_norm1(LinOp*) const
-     *
-     * @deprecated  This function will be removed in the future,
-     *              we will instead always use Ginkgo's implementation.
-     */
-    virtual void compute_norm1_impl(LinOp* result) const;
-
-    /**
-     * @copydoc compute_squared_norm2(LinOp*) const
-     *
-     * @deprecated  This function will be removed in the future,
-     *              we will instead always use Ginkgo's implementation.
-     */
-    virtual void compute_squared_norm2_impl(LinOp* result) const;
-
-    /**
      * @copydoc compute_mean(LinOp*) const
      */
     virtual void compute_mean_impl(LinOp* result) const;
@@ -1455,16 +1030,6 @@ protected:
      * @param new_size  the new matrix dimensions
      */
     void resize(gko::dim<2> new_size);
-
-    /**
-     * @copydoc create_submatrix(const span, const span, const size_type)
-     *
-     * @note  Other implementations of dense should override this function
-     *        instead of create_submatrix(const span, const span, const
-     *        size_type).
-     */
-    virtual std::unique_ptr<Dense> create_submatrix_impl(
-        const span& rows, const span& columns, const size_type stride);
 
     void apply_impl(const LinOp* b, LinOp* x) const override;
 
@@ -1511,6 +1076,89 @@ protected:
                          const array<IndexType>* row_idxs,
                          const Dense<ValueType>* beta,
                          Dense<OutputType>* row_collection) const;
+
+    void compute_absolute_inplace_impl() override;
+
+    [[nodiscard]] std::unique_ptr<Dense> create_with_type_of_impl(
+        std::shared_ptr<const Executor> exec, const dim<2>& global_size,
+        const dim<2>& local_size, size_type stride) const override;
+
+    [[nodiscard]] std::unique_ptr<Dense> create_subview_impl(
+        local_span rows, local_span columns) override;
+
+    [[nodiscard]] std::unique_ptr<const Dense> create_subview_impl(
+        local_span rows, local_span columns) const override;
+
+    [[nodiscard]] std::unique_ptr<Dense> create_subview_impl(
+        local_span rows, local_span columns, dim<2> global_size) override;
+
+    [[nodiscard]] std::unique_ptr<const Dense> create_subview_impl(
+        local_span rows, local_span columns, dim<2> global_size) const override;
+
+    [[nodiscard]] std::unique_ptr<const real_type> create_real_view_impl()
+        const override;
+
+    [[nodiscard]] std::unique_ptr<real_type> create_real_view_impl() override;
+
+    [[nodiscard]] std::unique_ptr<absolute_type> compute_absolute_impl()
+        const override;
+
+    [[nodiscard]] std::unique_ptr<complex_type> make_complex_impl()
+        const override;
+
+    [[nodiscard]] std::unique_ptr<real_type> get_real_impl() const override;
+
+    [[nodiscard]] std::unique_ptr<real_type> get_imag_impl() const override;
+
+    void compute_absolute_impl(absolute_type* result) const override;
+
+    void make_complex_impl(complex_type* result) const override;
+
+    void get_real_impl(real_type* result) const override;
+
+    void get_imag_impl(real_type* result) const override;
+
+    void fill_impl(value_type value) override;
+
+    void scale_impl(scaling_param<value_type> alpha) override;
+
+    void inv_scale_impl(scaling_param<value_type> alpha) override;
+
+    void add_scaled_impl(scaling_param<value_type> alpha,
+                         const Dense* b) override;
+
+    void sub_scaled_impl(scaling_param<value_type> alpha,
+                         const Dense* b) override;
+
+    void compute_dot_impl(const Dense* b, Dense* result) const override;
+
+    void compute_dot_impl(const Dense* b, Dense* result,
+                          array<char>& tmp) const override;
+
+    void compute_conj_dot_impl(const Dense* b, Dense* result) const override;
+
+    void compute_conj_dot_impl(const Dense* b, Dense* result,
+                               array<char>& tmp) const override;
+
+    void compute_norm2_impl(absolute_type* result) const override;
+
+    void compute_norm2_impl(absolute_type* result,
+                            array<char>& tmp) const override;
+
+    void compute_norm1_impl(absolute_type* result) const override;
+
+    void compute_norm1_impl(absolute_type* result,
+                            array<char>& tmp) const override;
+
+    void compute_squared_norm2_impl(absolute_type* result) const override;
+
+    void compute_squared_norm2_impl(absolute_type* result,
+                                    array<char>& tmp) const override;
+
+    [[nodiscard]] device_view get_local_device_view_impl() override;
+
+    [[nodiscard]] const_device_view get_const_local_device_view_impl()
+        const override;
 
 private:
     size_type stride_;

--- a/reference/test/matrix/dense_kernels.cpp
+++ b/reference/test/matrix/dense_kernels.cpp
@@ -530,40 +530,6 @@ TYPED_TEST(Dense, AddScaledFailsOnWrongSizes)
 }
 
 
-TYPED_TEST(Dense, AddsScaledDiag)
-{
-    using Mtx = typename TestFixture::Mtx;
-    using T = typename TestFixture::value_type;
-    auto alpha = gko::initialize<Mtx>({2.0}, this->exec);
-    auto diag = gko::matrix::Diagonal<T>::create(
-        this->exec, 2, gko::array<T>{this->exec, {3.0, 2.0}});
-
-    this->mtx2->add_scaled(alpha, diag);
-
-    ASSERT_EQ(this->mtx2->at(0, 0), T{7.0});
-    ASSERT_EQ(this->mtx2->at(0, 1), T{-1.0});
-    ASSERT_EQ(this->mtx2->at(1, 0), T{-2.0});
-    ASSERT_EQ(this->mtx2->at(1, 1), T{6.0});
-}
-
-
-TYPED_TEST(Dense, SubtractsScaledDiag)
-{
-    using Mtx = typename TestFixture::Mtx;
-    using T = typename TestFixture::value_type;
-    auto alpha = gko::initialize<Mtx>({-2.0}, this->exec);
-    auto diag = gko::matrix::Diagonal<T>::create(
-        this->exec, 2, gko::array<T>{this->exec, {3.0, 2.0}});
-
-    this->mtx2->sub_scaled(alpha, diag);
-
-    ASSERT_EQ(this->mtx2->at(0, 0), T{7.0});
-    ASSERT_EQ(this->mtx2->at(0, 1), T{-1.0});
-    ASSERT_EQ(this->mtx2->at(1, 0), T{-2.0});
-    ASSERT_EQ(this->mtx2->at(1, 1), T{6.0});
-}
-
-
 TYPED_TEST(Dense, ComputesDot)
 {
     using Mtx = typename TestFixture::Mtx;
@@ -586,7 +552,7 @@ TYPED_TEST(Dense, ComputesDotMixed)
     this->mtx3->convert_to(mmtx3);
     auto result = MixedMtx::create(this->exec, gko::dim<2>{1, 3});
 
-    this->mtx1->compute_dot(this->mtx3, result);
+    this->mtx1->compute_dot(mmtx3, result);
 
     EXPECT_EQ(result->at(0, 0), MixedT{1.75});
     EXPECT_EQ(result->at(0, 1), MixedT{7.75});
@@ -616,7 +582,7 @@ TYPED_TEST(Dense, ComputesConjDotMixed)
     this->mtx3->convert_to(mmtx3);
     auto result = MixedMtx::create(this->exec, gko::dim<2>{1, 3});
 
-    this->mtx1->compute_conj_dot(this->mtx3, result);
+    this->mtx1->compute_conj_dot(mmtx3, result);
 
     EXPECT_EQ(result->at(0, 0), MixedT{1.75});
     EXPECT_EQ(result->at(0, 1), MixedT{7.75});
@@ -880,7 +846,7 @@ TYPED_TEST(Dense, SquareSubmatrixIsTransposableIntoDense)
     using T = typename TestFixture::value_type;
     auto trans = Mtx::create(this->exec, gko::dim<2>{2, 2}, 4);
 
-    this->mtx5->create_submatrix({0, 2}, {0, 2})->transpose(trans);
+    this->mtx5->create_subview({0, 2}, {0, 2})->transpose(trans);
 
     GKO_ASSERT_MTX_NEAR(trans, l<T>({{1.0, -2.0}, {-1.0, 2.0}}), 0.0);
     ASSERT_EQ(trans->get_stride(), 4);
@@ -925,7 +891,7 @@ TYPED_TEST(Dense, NonSquareSubmatrixIsTransposableIntoDense)
     using T = typename TestFixture::value_type;
     auto trans = Mtx::create(this->exec, gko::dim<2>{2, 1}, 5);
 
-    this->mtx4->create_submatrix({0, 1}, {0, 2})->transpose(trans);
+    this->mtx4->create_subview({0, 1}, {0, 2})->transpose(trans);
 
     GKO_ASSERT_MTX_NEAR(trans, l({1.0, 3.0}), 0.0);
     ASSERT_EQ(trans->get_stride(), 5);
@@ -1039,7 +1005,7 @@ TYPED_TEST(Dense, InplaceAbsolute)
 TYPED_TEST(Dense, InplaceAbsoluteSubMatrix)
 {
     using T = typename TestFixture::value_type;
-    auto mtx = this->mtx5->create_submatrix(gko::span{0, 2}, gko::span{0, 2});
+    auto mtx = this->mtx5->create_subview(gko::span{0, 2}, gko::span{0, 2});
 
     mtx->compute_absolute_inplace();
 
@@ -1079,7 +1045,7 @@ TYPED_TEST(Dense, OutplaceAbsoluteIntoDense)
 TYPED_TEST(Dense, OutplaceAbsoluteSubMatrix)
 {
     using T = typename TestFixture::value_type;
-    auto mtx = this->mtx5->create_submatrix(gko::span{0, 2}, gko::span{0, 2});
+    auto mtx = this->mtx5->create_subview(gko::span{0, 2}, gko::span{0, 2});
 
     auto abs_mtx = mtx->compute_absolute();
 
@@ -1092,7 +1058,7 @@ TYPED_TEST(Dense, OutplaceSubmatrixAbsoluteIntoDense)
 {
     using Mtx = typename TestFixture::Mtx;
     using T = typename TestFixture::value_type;
-    auto mtx = this->mtx5->create_submatrix(gko::span{0, 2}, gko::span{0, 2});
+    auto mtx = this->mtx5->create_subview(gko::span{0, 2}, gko::span{0, 2});
     auto abs_mtx =
         gko::remove_complex<Mtx>::create(this->exec, gko::dim<2>{2, 2}, 4);
 
@@ -2636,7 +2602,7 @@ TYPED_TEST(DenseWithIndexType, SquareSubmatrixCanGatherRowsIntoDense)
     gko::array<index_type> permute_idxs{exec, {1, 0}};
     auto row_collection = Mtx::create(exec, gko::dim<2>{2, 2}, 4);
 
-    this->mtx5->create_submatrix({0, 2}, {1, 3})
+    this->mtx5->create_subview({0, 2}, {1, 3})
         ->row_gather(&permute_idxs, row_collection);
 
     GKO_ASSERT_MTX_NEAR(row_collection,
@@ -2743,7 +2709,7 @@ TYPED_TEST(DenseWithIndexType, SquareSubmatrixIsPermutableIntoDense)
     auto exec = this->mtx5->get_executor();
     gko::array<index_type> permute_idxs{exec, {1, 0}};
     auto permuted = Mtx::create(exec, gko::dim<2>{2, 2}, 4);
-    auto mtx = this->mtx5->create_submatrix({0, 2}, {1, 3});
+    auto mtx = this->mtx5->create_subview({0, 2}, {1, 3});
 
     auto ref_permuted =
         gko::as<Mtx>(gko::as<Mtx>(mtx->row_permute(&permute_idxs))
@@ -2833,7 +2799,7 @@ TYPED_TEST(DenseWithIndexType, SquareSubmatrixIsInversePermutableIntoDense)
     auto exec = this->mtx5->get_executor();
     gko::array<index_type> permute_idxs{exec, {1, 0}};
     auto permuted = Mtx::create(exec, gko::dim<2>{2, 2}, 4);
-    auto mtx = this->mtx5->create_submatrix({0, 2}, {1, 3});
+    auto mtx = this->mtx5->create_subview({0, 2}, {1, 3});
 
     auto ref_permuted =
         gko::as<Mtx>(gko::as<Mtx>(mtx->inverse_row_permute(&permute_idxs))
@@ -2944,7 +2910,7 @@ TYPED_TEST(DenseWithIndexType, SquareSubmatrixIsRowPermutableIntoDense)
     gko::array<index_type> permute_idxs{exec, {1, 0}};
     auto permuted = Mtx::create(exec, gko::dim<2>{2, 2}, 4);
 
-    this->mtx5->create_submatrix({0, 2}, {0, 2})
+    this->mtx5->create_subview({0, 2}, {0, 2})
         ->row_permute(&permute_idxs, permuted);
 
     GKO_ASSERT_MTX_NEAR(permuted, l<value_type>({{-2.0, 2.0}, {1.0, -1.0}}),
@@ -3039,7 +3005,7 @@ TYPED_TEST(DenseWithIndexType, SquareSubmatrixIsColPermutableIntoDense)
     gko::array<index_type> permute_idxs{exec, {1, 0}};
     auto permuted = Mtx::create(exec, gko::dim<2>{2, 2}, 4);
 
-    this->mtx5->create_submatrix({0, 2}, {0, 2})
+    this->mtx5->create_subview({0, 2}, {0, 2})
         ->column_permute(&permute_idxs, permuted);
 
     GKO_ASSERT_MTX_NEAR(permuted, l<value_type>({{-1.0, 1.0}, {2.0, -2.0}}),
@@ -3136,7 +3102,7 @@ TYPED_TEST(DenseWithIndexType, SquareSubmatrixIsInverseRowPermutableIntoDense)
     gko::array<index_type> permute_idxs{exec, {1, 0}};
     auto permuted = Mtx::create(exec, gko::dim<2>{2, 2}, 4);
 
-    this->mtx5->create_submatrix({0, 2}, {0, 2})
+    this->mtx5->create_subview({0, 2}, {0, 2})
         ->inverse_row_permute(&permute_idxs, permuted);
 
     GKO_ASSERT_MTX_NEAR(permuted, l<value_type>({{-2.0, 2.0}, {1.0, -1.0}}),
@@ -3234,7 +3200,7 @@ TYPED_TEST(DenseWithIndexType, SquareSubmatrixIsInverseColPermutableIntoDense)
     gko::array<index_type> permute_idxs{exec, {1, 0}};
     auto permuted = Mtx::create(exec, gko::dim<2>{2, 2}, 4);
 
-    this->mtx5->create_submatrix({0, 2}, {0, 2})
+    this->mtx5->create_subview({0, 2}, {0, 2})
         ->column_permute(&permute_idxs, permuted);
 
     GKO_ASSERT_MTX_NEAR(permuted, l<value_type>({{-1.0, 1.0}, {2.0, -2.0}}),


### PR DESCRIPTION
This is the `Dense` implementation of the `MultiVector` interface. It almost exclusively adds functionality. Only the `create_with*` functions are modified slightly, the rest of the functionality that is duplicated in the `MultiVector` interface is kept.