### PR TITLE
Distributed Vector MultiVector Implementation

### DIFF
--- a/core/distributed/vector.cpp
+++ b/core/distributed/vector.cpp
@@ -9,7 +9,7 @@
 #include "core/distributed/vector_kernels.hpp"
 #include "core/matrix/dense_kernels.hpp"
 #include "core/mpi/mpi_op.hpp"
-
+#include "ginkgo/core/base/temporary_conversion.hpp"
 
 namespace gko {
 namespace experimental {
@@ -63,7 +63,7 @@ template <typename ValueType>
 Vector<ValueType>::Vector(std::shared_ptr<const Executor> exec,
                           mpi::communicator comm, dim<2> global_size,
                           dim<2> local_size, size_type stride)
-    : LinOp{exec, global_size},
+    : EnableMultiVector<Vector>{exec, global_size},
       DistributedBase{comm},
       local_{exec, local_size, stride}
 {
@@ -74,7 +74,9 @@ template <typename ValueType>
 Vector<ValueType>::Vector(std::shared_ptr<const Executor> exec,
                           mpi::communicator comm, dim<2> global_size,
                           std::unique_ptr<local_vector_type> local_vector)
-    : LinOp{exec, global_size}, DistributedBase{comm}, local_{exec}
+    : EnableMultiVector<Vector>{exec, global_size},
+      DistributedBase{comm},
+      local_{exec}
 {
     local_vector->move_to(&local_);
 }
@@ -84,7 +86,7 @@ template <typename ValueType>
 Vector<ValueType>::Vector(std::shared_ptr<const Executor> exec,
                           mpi::communicator comm,
                           std::unique_ptr<local_vector_type> local_vector)
-    : LinOp{exec, {}}, DistributedBase{comm}, local_{exec}
+    : EnableMultiVector<Vector>{exec, {}}, DistributedBase{comm}, local_{exec}
 {
     this->set_size(compute_global_size(exec, comm, local_vector->get_size()));
     local_vector->move_to(&local_);
@@ -157,39 +159,73 @@ std::unique_ptr<const Vector<ValueType>> Vector<ValueType>::create_const(
 
 
 template <typename ValueType>
-std::unique_ptr<Vector<ValueType>> Vector<ValueType>::create_with_config_of(
-    ptr_param<const Vector> other)
+std::unique_ptr<Vector<ValueType>> Vector<ValueType>::create_subview_impl(
+    local_span rows, local_span columns)
 {
-    // De-referencing `other` before calling the functions (instead of
-    // using operator `->`) is currently required to be compatible with
-    // CUDA 10.1.
-    // Otherwise, it results in a compile error.
-    return (*other).create_with_same_config();
+    auto exec = this->get_executor();
+    auto comm = this->get_communicator();
+    auto global_rows = this->get_size()[0];
+    auto global_cols = this->get_size()[1];
+    comm.all_reduce(exec, &global_rows, 1, MPI_SUM);
+    comm.all_reduce(exec, &global_cols, 1, MPI_SUM);
+    return create_subview_impl(rows, columns, {global_rows, global_cols});
 }
 
 
 template <typename ValueType>
-std::unique_ptr<Vector<ValueType>> Vector<ValueType>::create_with_type_of(
-    ptr_param<const Vector> other, std::shared_ptr<const Executor> exec)
+std::unique_ptr<const Vector<ValueType>> Vector<ValueType>::create_subview_impl(
+    local_span rows, local_span columns) const
 {
-    return (*other).create_with_type_of_impl(exec, {}, {}, 0);
+    auto exec = this->get_executor();
+    auto comm = this->get_communicator();
+    auto global_rows = this->get_size()[0];
+    auto global_cols = this->get_size()[1];
+    comm.all_reduce(exec, &global_rows, 1, MPI_SUM);
+    comm.all_reduce(exec, &global_cols, 1, MPI_SUM);
+    return create_subview_impl(rows, columns, {global_rows, global_cols});
 }
 
 
 template <typename ValueType>
-std::unique_ptr<Vector<ValueType>> Vector<ValueType>::create_with_type_of(
-    ptr_param<const Vector> other, std::shared_ptr<const Executor> exec,
-    const dim<2>& global_size, const dim<2>& local_size, size_type stride)
+std::unique_ptr<const Vector<ValueType>> Vector<ValueType>::create_subview_impl(
+    local_span rows, local_span columns, dim<2> global_size) const
 {
-    return (*other).create_with_type_of_impl(exec, global_size, local_size,
-                                             stride);
+    // @todo: use const-cast here until dense also has const create_submatrix
+    return create(
+        this->get_executor(), this->get_communicator(), global_size,
+        const_cast<local_vector_type&>(local_).create_subview(rows, columns));
+}
+
+
+template <typename ValueType>
+std::unique_ptr<Vector<ValueType>> Vector<ValueType>::create_subview_impl(
+    local_span rows, local_span columns, dim<2> global_size)
+{
+    return create(this->get_executor(), this->get_communicator(), global_size,
+                  local_.create_subview(rows, columns));
+}
+
+
+template <typename ValueType>
+typename Vector<ValueType>::device_view
+Vector<ValueType>::get_local_device_view_impl()
+{
+    return local_.get_device_view();
+}
+
+
+template <typename ValueType>
+typename Vector<ValueType>::const_device_view
+Vector<ValueType>::get_const_local_device_view_impl() const
+{
+    return local_.get_const_device_view();
 }
 
 
 template <typename ValueType>
 template <typename LocalIndexType, typename GlobalIndexType>
 void Vector<ValueType>::read_distributed_impl(
-    const device_matrix_data<ValueType, GlobalIndexType>& data,
+    const device_matrix_data<value_type, GlobalIndexType>& data,
     const Partition<LocalIndexType, GlobalIndexType>* partition)
 {
     auto exec = this->get_executor();
@@ -200,7 +236,7 @@ void Vector<ValueType>::read_distributed_impl(
                global_cols));
 
     auto rank = this->get_communicator().rank();
-    local_.fill(zero<ValueType>());
+    local_.fill(zero<value_type>());
     exec->run(vector::make_build_local(
         data, make_temporary_clone(exec, partition).get(), rank,
         local_.get_device_view()));
@@ -209,7 +245,7 @@ void Vector<ValueType>::read_distributed_impl(
 
 template <typename ValueType>
 void Vector<ValueType>::read_distributed(
-    const device_matrix_data<ValueType, int64>& data,
+    const device_matrix_data<value_type, int64>& data,
     ptr_param<const Partition<int64, int64>> partition)
 {
     this->read_distributed_impl(data, partition.get());
@@ -218,7 +254,7 @@ void Vector<ValueType>::read_distributed(
 
 template <typename ValueType>
 void Vector<ValueType>::read_distributed(
-    const device_matrix_data<ValueType, int64>& data,
+    const device_matrix_data<value_type, int64>& data,
     ptr_param<const Partition<int32, int64>> partition)
 {
     this->read_distributed_impl(data, partition.get());
@@ -227,7 +263,7 @@ void Vector<ValueType>::read_distributed(
 
 template <typename ValueType>
 void Vector<ValueType>::read_distributed(
-    const device_matrix_data<ValueType, int32>& data,
+    const device_matrix_data<value_type, int32>& data,
     ptr_param<const Partition<int32, int32>> partition)
 {
     this->read_distributed_impl(data, partition.get());
@@ -236,7 +272,7 @@ void Vector<ValueType>::read_distributed(
 
 template <typename ValueType>
 void Vector<ValueType>::read_distributed(
-    const matrix_data<ValueType, int64>& data,
+    const matrix_data<value_type, int64>& data,
     ptr_param<const Partition<int64, int64>> partition)
 {
     this->read_distributed(
@@ -248,7 +284,7 @@ void Vector<ValueType>::read_distributed(
 
 template <typename ValueType>
 void Vector<ValueType>::read_distributed(
-    const matrix_data<ValueType, int64>& data,
+    const matrix_data<value_type, int64>& data,
     ptr_param<const Partition<int32, int64>> partition)
 {
     this->read_distributed(
@@ -260,7 +296,7 @@ void Vector<ValueType>::read_distributed(
 
 template <typename ValueType>
 void Vector<ValueType>::read_distributed(
-    const matrix_data<ValueType, int32>& data,
+    const matrix_data<value_type, int32>& data,
     ptr_param<const Partition<int32, int32>> partition)
 {
     this->read_distributed(
@@ -271,7 +307,7 @@ void Vector<ValueType>::read_distributed(
 
 
 template <typename ValueType>
-void Vector<ValueType>::fill(const ValueType value)
+void Vector<ValueType>::fill_impl(value_type value)
 {
     local_.fill(value);
 }
@@ -279,7 +315,7 @@ void Vector<ValueType>::fill(const ValueType value)
 
 template <typename ValueType>
 void Vector<ValueType>::convert_to(
-    Vector<next_precision<ValueType>>* result) const
+    Vector<next_precision<value_type>>* result) const
 {
     GKO_ASSERT(this->get_communicator().size() ==
                result->get_communicator().size());
@@ -289,7 +325,7 @@ void Vector<ValueType>::convert_to(
 
 
 template <typename ValueType>
-void Vector<ValueType>::move_to(Vector<next_precision<ValueType>>* result)
+void Vector<ValueType>::move_to(Vector<next_precision<value_type>>* result)
 {
     this->convert_to(result);
 }
@@ -298,7 +334,7 @@ void Vector<ValueType>::move_to(Vector<next_precision<ValueType>>* result)
 #if GINKGO_ENABLE_HALF || GINKGO_ENABLE_BFLOAT16
 template <typename ValueType>
 void Vector<ValueType>::convert_to(
-    Vector<next_precision<ValueType, 2>>* result) const
+    Vector<next_precision<value_type, 2>>* result) const
 {
     GKO_ASSERT(this->get_communicator().size() ==
                result->get_communicator().size());
@@ -308,7 +344,7 @@ void Vector<ValueType>::convert_to(
 
 
 template <typename ValueType>
-void Vector<ValueType>::move_to(Vector<next_precision<ValueType, 2>>* result)
+void Vector<ValueType>::move_to(Vector<next_precision<value_type, 2>>* result)
 {
     this->convert_to(result);
 }
@@ -318,7 +354,7 @@ void Vector<ValueType>::move_to(Vector<next_precision<ValueType, 2>>* result)
 #if GINKGO_ENABLE_HALF && GINKGO_ENABLE_BFLOAT16
 template <typename ValueType>
 void Vector<ValueType>::convert_to(
-    Vector<next_precision<ValueType, 3>>* result) const
+    Vector<next_precision<value_type, 3>>* result) const
 {
     GKO_ASSERT(this->get_communicator().size() ==
                result->get_communicator().size());
@@ -328,7 +364,7 @@ void Vector<ValueType>::convert_to(
 
 
 template <typename ValueType>
-void Vector<ValueType>::move_to(Vector<next_precision<ValueType, 3>>* result)
+void Vector<ValueType>::move_to(Vector<next_precision<value_type, 3>>* result)
 {
     this->convert_to(result);
 }
@@ -336,7 +372,7 @@ void Vector<ValueType>::move_to(Vector<next_precision<ValueType, 3>>* result)
 
 template <typename ValueType>
 std::unique_ptr<typename Vector<ValueType>::absolute_type>
-Vector<ValueType>::compute_absolute() const
+Vector<ValueType>::compute_absolute_impl() const
 {
     auto exec = this->get_executor();
 
@@ -353,7 +389,14 @@ Vector<ValueType>::compute_absolute() const
 
 
 template <typename ValueType>
-void Vector<ValueType>::compute_absolute_inplace()
+void Vector<ValueType>::compute_absolute_impl(absolute_type* result) const
+{
+    local_.compute_absolute(&result->local_);
+}
+
+
+template <typename ValueType>
+void Vector<ValueType>::compute_absolute_inplace_impl()
 {
     local_.compute_absolute_inplace();
 }
@@ -369,7 +412,7 @@ Vector<ValueType>::get_local_vector() const
 
 template <typename ValueType>
 std::unique_ptr<typename Vector<ValueType>::complex_type>
-Vector<ValueType>::make_complex() const
+Vector<ValueType>::make_complex_impl() const
 {
     auto result = complex_type::create(
         this->get_executor(), this->get_communicator(), this->get_size(),
@@ -381,8 +424,7 @@ Vector<ValueType>::make_complex() const
 
 
 template <typename ValueType>
-void Vector<ValueType>::make_complex(
-    ptr_param<Vector::complex_type> result) const
+void Vector<ValueType>::make_complex_impl(complex_type* result) const
 {
     this->get_local_vector()->make_complex(&result->local_);
 }
@@ -390,7 +432,7 @@ void Vector<ValueType>::make_complex(
 
 template <typename ValueType>
 std::unique_ptr<typename Vector<ValueType>::real_type>
-Vector<ValueType>::get_real() const
+Vector<ValueType>::get_real_impl() const
 {
     auto result = real_type::create(this->get_executor(),
                                     this->get_communicator(), this->get_size(),
@@ -402,7 +444,7 @@ Vector<ValueType>::get_real() const
 
 
 template <typename ValueType>
-void Vector<ValueType>::get_real(ptr_param<Vector::real_type> result) const
+void Vector<ValueType>::get_real_impl(real_type* result) const
 {
     this->get_local_vector()->get_real(&result->local_);
 }
@@ -410,7 +452,7 @@ void Vector<ValueType>::get_real(ptr_param<Vector::real_type> result) const
 
 template <typename ValueType>
 std::unique_ptr<typename Vector<ValueType>::real_type>
-Vector<ValueType>::get_imag() const
+Vector<ValueType>::get_imag_impl() const
 {
     auto result = real_type::create(this->get_executor(),
                                     this->get_communicator(), this->get_size(),
@@ -422,47 +464,53 @@ Vector<ValueType>::get_imag() const
 
 
 template <typename ValueType>
-void Vector<ValueType>::get_imag(ptr_param<Vector::real_type> result) const
+void Vector<ValueType>::get_imag_impl(real_type* result) const
 {
     this->get_local_vector()->get_imag(&result->local_);
 }
 
 
 template <typename ValueType>
-void Vector<ValueType>::scale(ptr_param<const LinOp> alpha)
+void Vector<ValueType>::scale_impl(scaling_param<value_type> alpha)
 {
-    local_.scale(alpha);
+    std::visit([this](auto alpha_v) { local_.scale(alpha_v); }, alpha);
 }
 
 
 template <typename ValueType>
-void Vector<ValueType>::inv_scale(ptr_param<const LinOp> alpha)
+void Vector<ValueType>::inv_scale_impl(scaling_param<value_type> alpha)
 {
-    local_.inv_scale(alpha);
+    std::visit([this](auto alpha_v) { local_.inv_scale(alpha_v); }, alpha);
 }
 
 
 template <typename ValueType>
-void Vector<ValueType>::add_scaled(ptr_param<const LinOp> alpha,
-                                   ptr_param<const LinOp> b)
+void Vector<ValueType>::add_scaled_impl(scaling_param<value_type> alpha,
+                                        const Vector* b)
 {
-    auto dense_b = as<Vector>(b);
-    local_.add_scaled(alpha, dense_b->get_local_vector());
+    std::visit(
+        [this, b](auto alpha_v) {
+            local_.add_scaled(alpha_v, b->get_local_vector());
+        },
+        alpha);
 }
 
 
 template <typename ValueType>
-void Vector<ValueType>::sub_scaled(ptr_param<const LinOp> alpha,
-                                   ptr_param<const LinOp> b)
+void Vector<ValueType>::sub_scaled_impl(scaling_param<value_type> alpha,
+                                        const Vector* b)
 {
-    auto dense_b = as<Vector>(b);
-    local_.sub_scaled(alpha, dense_b->get_local_vector());
+    std::visit(
+        [this, b](auto alpha_v) {
+            local_.sub_scaled(alpha_v, b->get_local_vector());
+        },
+        alpha);
 }
 
 
 template <typename ValueType>
-void Vector<ValueType>::compute_dot(ptr_param<const LinOp> b,
-                                    ptr_param<LinOp> result) const
+void Vector<ValueType>::compute_dot_impl(const Vector* b,
+                                         local_vector_type* result) const
 {
     array<char> tmp{this->get_executor()};
     this->compute_dot(b, result, tmp);
@@ -470,22 +518,20 @@ void Vector<ValueType>::compute_dot(ptr_param<const LinOp> b,
 
 
 template <typename ValueType>
-void Vector<ValueType>::compute_dot(ptr_param<const LinOp> b,
-                                    ptr_param<LinOp> result,
-                                    array<char>& tmp) const
+void Vector<ValueType>::compute_dot_impl(const Vector* b,
+                                         local_vector_type* result,
+                                         array<char>& tmp) const
 {
-    GKO_ASSERT_EQUAL_DIMENSIONS(result, dim<2>(1, this->get_size()[1]));
     auto exec = this->get_executor();
     const auto comm = this->get_communicator();
-    auto dense_res =
-        make_temporary_clone(exec, as<matrix::Dense<ValueType>>(result));
+    auto dense_res = as<matrix::Dense<value_type>>(result);
     this->get_local_vector()->compute_dot(as<Vector>(b)->get_local_vector(),
-                                          dense_res.get(), tmp);
+                                          dense_res, tmp);
     exec->synchronize();
-    auto sum_op = gko::experimental::mpi::sum<ValueType>();
+    auto sum_op = gko::experimental::mpi::sum<value_type>();
     if (mpi::requires_host_buffer(exec, comm)) {
         host_reduction_buffer_.init(exec->get_master(), dense_res->get_size());
-        host_reduction_buffer_->copy_from(dense_res.get());
+        host_reduction_buffer_->copy_from(dense_res);
         comm.all_reduce(exec->get_master(),
                         host_reduction_buffer_->get_values(),
                         static_cast<int>(this->get_size()[1]), sum_op.get_op());
@@ -498,8 +544,8 @@ void Vector<ValueType>::compute_dot(ptr_param<const LinOp> b,
 
 
 template <typename ValueType>
-void Vector<ValueType>::compute_conj_dot(ptr_param<const LinOp> b,
-                                         ptr_param<LinOp> result) const
+void Vector<ValueType>::compute_conj_dot_impl(const Vector* b,
+                                              local_vector_type* result) const
 {
     array<char> tmp{this->get_executor()};
     this->compute_conj_dot(b, result, tmp);
@@ -507,22 +553,20 @@ void Vector<ValueType>::compute_conj_dot(ptr_param<const LinOp> b,
 
 
 template <typename ValueType>
-void Vector<ValueType>::compute_conj_dot(ptr_param<const LinOp> b,
-                                         ptr_param<LinOp> result,
-                                         array<char>& tmp) const
+void Vector<ValueType>::compute_conj_dot_impl(const Vector* b,
+                                              local_vector_type* result,
+                                              array<char>& tmp) const
 {
-    GKO_ASSERT_EQUAL_DIMENSIONS(result, dim<2>(1, this->get_size()[1]));
     auto exec = this->get_executor();
     const auto comm = this->get_communicator();
-    auto dense_res =
-        make_temporary_clone(exec, as<matrix::Dense<ValueType>>(result));
+    auto dense_res = as<matrix::Dense<value_type>>(result);
     this->get_local_vector()->compute_conj_dot(
-        as<Vector>(b)->get_local_vector(), dense_res.get(), tmp);
+        as<Vector>(b)->get_local_vector(), dense_res, tmp);
     exec->synchronize();
-    auto sum_op = gko::experimental::mpi::sum<ValueType>();
+    auto sum_op = gko::experimental::mpi::sum<value_type>();
     if (mpi::requires_host_buffer(exec, comm)) {
         host_reduction_buffer_.init(exec->get_master(), dense_res->get_size());
-        host_reduction_buffer_->copy_from(dense_res.get());
+        host_reduction_buffer_->copy_from(dense_res);
         comm.all_reduce(exec->get_master(),
                         host_reduction_buffer_->get_values(),
                         static_cast<int>(this->get_size()[1]), sum_op.get_op());
@@ -535,7 +579,8 @@ void Vector<ValueType>::compute_conj_dot(ptr_param<const LinOp> b,
 
 
 template <typename ValueType>
-void Vector<ValueType>::compute_norm2(ptr_param<LinOp> result) const
+void Vector<ValueType>::compute_norm2_impl(
+    local_absolute_vector_type* result) const
 {
     array<char> tmp{this->get_executor()};
     this->compute_norm2(result, tmp);
@@ -543,20 +588,21 @@ void Vector<ValueType>::compute_norm2(ptr_param<LinOp> result) const
 
 
 template <typename ValueType>
-void Vector<ValueType>::compute_norm2(ptr_param<LinOp> result,
-                                      array<char>& tmp) const
+void Vector<ValueType>::compute_norm2_impl(local_absolute_vector_type* result,
+                                           array<char>& tmp) const
 {
     using NormVector = typename local_vector_type::absolute_type;
     auto exec = this->get_executor();
     const auto comm = this->get_communicator();
-    auto dense_res = make_temporary_clone(exec, as<NormVector>(result));
-    this->compute_squared_norm2(dense_res.get(), tmp);
+    auto dense_res = as<NormVector>(result);
+    this->compute_squared_norm2(dense_res, tmp);
     exec->run(vector::make_compute_sqrt(dense_res->get_device_view()));
 }
 
 
 template <typename ValueType>
-void Vector<ValueType>::compute_norm1(ptr_param<LinOp> result) const
+void Vector<ValueType>::compute_norm1_impl(
+    local_absolute_vector_type* result) const
 {
     array<char> tmp{this->get_executor()};
     this->compute_norm1(result, tmp);
@@ -564,20 +610,20 @@ void Vector<ValueType>::compute_norm1(ptr_param<LinOp> result) const
 
 
 template <typename ValueType>
-void Vector<ValueType>::compute_norm1(ptr_param<LinOp> result,
-                                      array<char>& tmp) const
+void Vector<ValueType>::compute_norm1_impl(local_absolute_vector_type* result,
+                                           array<char>& tmp) const
 {
     using NormVector = typename local_vector_type::absolute_type;
-    GKO_ASSERT_EQUAL_DIMENSIONS(result, dim<2>(1, this->get_size()[1]));
     auto exec = this->get_executor();
     const auto comm = this->get_communicator();
-    auto dense_res = make_temporary_clone(exec, as<NormVector>(result));
-    this->get_local_vector()->compute_norm1(dense_res.get());
+    auto dense_res = as<NormVector>(result);
+    this->get_local_vector()->compute_norm1(dense_res);
     exec->synchronize();
-    auto norm_sum_op = gko::experimental::mpi::sum<remove_complex<ValueType>>();
+    auto norm_sum_op =
+        gko::experimental::mpi::sum<remove_complex<value_type>>();
     if (mpi::requires_host_buffer(exec, comm)) {
         host_norm_buffer_.init(exec->get_master(), dense_res->get_size());
-        host_norm_buffer_->copy_from(dense_res.get());
+        host_norm_buffer_->copy_from(dense_res);
         comm.all_reduce(exec->get_master(), host_norm_buffer_->get_values(),
                         static_cast<int>(this->get_size()[1]),
                         norm_sum_op.get_op());
@@ -591,7 +637,8 @@ void Vector<ValueType>::compute_norm1(ptr_param<LinOp> result,
 
 
 template <typename ValueType>
-void Vector<ValueType>::compute_squared_norm2(ptr_param<LinOp> result) const
+void Vector<ValueType>::compute_squared_norm2_impl(
+    local_absolute_vector_type* result) const
 {
     array<char> tmp{this->get_executor()};
     this->compute_squared_norm2(result, tmp);
@@ -599,22 +646,22 @@ void Vector<ValueType>::compute_squared_norm2(ptr_param<LinOp> result) const
 
 
 template <typename ValueType>
-void Vector<ValueType>::compute_squared_norm2(ptr_param<LinOp> result,
-                                              array<char>& tmp) const
+void Vector<ValueType>::compute_squared_norm2_impl(
+    local_absolute_vector_type* result, array<char>& tmp) const
 {
     using NormVector = typename local_vector_type::absolute_type;
-    GKO_ASSERT_EQUAL_DIMENSIONS(result, dim<2>(1, this->get_size()[1]));
     auto exec = this->get_executor();
     const auto comm = this->get_communicator();
-    auto dense_res = make_temporary_clone(exec, as<NormVector>(result));
+    auto dense_res = as<NormVector>(result);
     exec->run(vector::make_compute_squared_norm2(
         this->get_local_vector()->get_const_device_view(),
         dense_res->get_device_view(), tmp));
     exec->synchronize();
-    auto norm_sum_op = gko::experimental::mpi::sum<remove_complex<ValueType>>();
+    auto norm_sum_op =
+        gko::experimental::mpi::sum<remove_complex<value_type>>();
     if (mpi::requires_host_buffer(exec, comm)) {
         host_norm_buffer_.init(exec->get_master(), dense_res->get_size());
-        host_norm_buffer_->copy_from(dense_res.get());
+        host_norm_buffer_->copy_from(dense_res);
         comm.all_reduce(exec->get_master(), host_norm_buffer_->get_values(),
                         static_cast<int>(this->get_size()[1]),
                         norm_sum_op.get_op());
@@ -650,13 +697,13 @@ void Vector<ValueType>::compute_mean(ptr_param<LinOp> result,
     this->get_local_vector()->compute_mean(dense_res.get());
 
     // scale by its weight ie ratio of local to global size
-    auto weight = initialize<matrix::Dense<remove_complex<ValueType>>>(
-        {static_cast<remove_complex<ValueType>>(local_size) / global_size},
+    auto weight = initialize<matrix::Dense<remove_complex<value_type>>>(
+        {static_cast<remove_complex<value_type>>(local_size) / global_size},
         this->get_executor());
     dense_res->scale(weight.get());
 
     exec->synchronize();
-    auto sum_op = gko::experimental::mpi::sum<ValueType>();
+    auto sum_op = gko::experimental::mpi::sum<value_type>();
     if (mpi::requires_host_buffer(exec, comm)) {
         host_reduction_buffer_.init(exec->get_master(), dense_res->get_size());
         host_reduction_buffer_->copy_from(dense_res.get());
@@ -671,42 +718,43 @@ void Vector<ValueType>::compute_mean(ptr_param<LinOp> result,
 }
 
 template <typename ValueType>
-ValueType& Vector<ValueType>::at_local(size_type row, size_type col) noexcept
+auto Vector<ValueType>::at_local(size_type row, size_type col) noexcept
+    -> value_type&
 {
     return local_.at(row, col);
 }
 
 
 template <typename ValueType>
-ValueType Vector<ValueType>::at_local(size_type row,
-                                      size_type col) const noexcept
+auto Vector<ValueType>::at_local(size_type row, size_type col) const noexcept
+    -> value_type
 {
     return local_.at(row, col);
 }
 
 
 template <typename ValueType>
-ValueType& Vector<ValueType>::at_local(size_type idx) noexcept
+auto Vector<ValueType>::at_local(size_type idx) noexcept -> value_type&
 {
     return local_.at(idx);
 }
 
 template <typename ValueType>
-ValueType Vector<ValueType>::at_local(size_type idx) const noexcept
+auto Vector<ValueType>::at_local(size_type idx) const noexcept -> value_type
 {
     return local_.at(idx);
 }
 
 
 template <typename ValueType>
-ValueType* Vector<ValueType>::get_local_values()
+auto Vector<ValueType>::get_local_values() -> value_type*
 {
     return local_.get_values();
 }
 
 
 template <typename ValueType>
-const ValueType* Vector<ValueType>::get_const_local_values() const
+auto Vector<ValueType>::get_const_local_values() const -> const value_type*
 {
     return local_.get_const_values();
 }
@@ -724,11 +772,11 @@ void Vector<ValueType>::resize(dim<2> global_size, dim<2> local_size)
 
 template <typename ValueType>
 std::unique_ptr<const typename Vector<ValueType>::real_type>
-Vector<ValueType>::create_real_view() const
+Vector<ValueType>::create_real_view_impl() const
 {
     const auto num_global_rows = this->get_size()[0];
-    const auto num_cols =
-        is_complex<ValueType>() ? 2 * this->get_size()[1] : this->get_size()[1];
+    const auto num_cols = is_complex<value_type>() ? 2 * this->get_size()[1]
+                                                   : this->get_size()[1];
 
     return real_type::create_const(
         this->get_executor(), this->get_communicator(),
@@ -738,11 +786,11 @@ Vector<ValueType>::create_real_view() const
 
 template <typename ValueType>
 std::unique_ptr<typename Vector<ValueType>::real_type>
-Vector<ValueType>::create_real_view()
+Vector<ValueType>::create_real_view_impl()
 {
     const auto num_global_rows = this->get_size()[0];
-    const auto num_cols =
-        is_complex<ValueType>() ? 2 * this->get_size()[1] : this->get_size()[1];
+    const auto num_cols = is_complex<value_type>() ? 2 * this->get_size()[1]
+                                                   : this->get_size()[1];
 
     return real_type::create(this->get_executor(), this->get_communicator(),
                              dim<2>{num_global_rows, num_cols},
@@ -751,16 +799,8 @@ Vector<ValueType>::create_real_view()
 
 
 template <typename ValueType>
-std::unique_ptr<Vector<ValueType>> Vector<ValueType>::create_submatrix(
-    local_span rows, local_span columns, dim<2> global_size)
-{
-    return this->create_submatrix_impl(rows, columns, global_size);
-}
-
-
-template <typename ValueType>
-std::unique_ptr<Vector<ValueType>> Vector<ValueType>::create_with_same_config()
-    const
+std::unique_ptr<Vector<ValueType>>
+Vector<ValueType>::create_with_same_config_impl() const
 {
     return Vector::create(
         this->get_executor(), this->get_communicator(), this->get_size(),
@@ -775,15 +815,6 @@ std::unique_ptr<Vector<ValueType>> Vector<ValueType>::create_with_type_of_impl(
 {
     return Vector::create(exec, this->get_communicator(), global_size,
                           local_size, stride);
-}
-
-
-template <typename ValueType>
-std::unique_ptr<Vector<ValueType>> Vector<ValueType>::create_submatrix_impl(
-    local_span rows, local_span columns, dim<2> global_size)
-{
-    return Vector::create(this->get_executor(), this->get_communicator(),
-                          global_size, local_.create_submatrix(rows, columns));
 }
 
 

--- a/core/distributed/vector.cpp
+++ b/core/distributed/vector.cpp
@@ -159,6 +159,63 @@ std::unique_ptr<const Vector<ValueType>> Vector<ValueType>::create_const(
 
 
 template <typename ValueType>
+template <typename OtherValueType>
+gko::detail::temporary_conversion<Vector<OtherValueType>>
+Vector<ValueType>::as_precision()
+{
+    // See the implementation of Dense::as_precision for details
+    if constexpr (is_complex<ValueType>() == is_complex<OtherValueType>()) {
+        return gko::detail::temporary_conversion<
+            Vector<OtherValueType>>::create(this);
+    } else if constexpr (is_complex<ValueType>() &&
+                         std::is_same_v<to_complex<OtherValueType>,
+                                        ValueType>) {
+        return gko::detail::temporary_conversion<
+            Vector<OtherValueType>>::create(this->create_real_view());
+    } else {
+        GKO_NOT_IMPLEMENTED;
+    }
+}
+
+#define GKO_DECLARE_VECTOR_AS_PRECISION(ValueType, OtherValueType) \
+    auto Vector<ValueType>::as_precision()                         \
+        ->gko::detail::temporary_conversion<Vector<OtherValueType>>
+#define GKO_DECLARE_VECTOR_AS_PRECISION_same(ValueType) \
+    GKO_DECLARE_VECTOR_AS_PRECISION(ValueType, ValueType)
+GKO_INSTANTIATE_FOR_EACH_VALUE_CONVERSION(GKO_DECLARE_VECTOR_AS_PRECISION);
+GKO_INSTANTIATE_FOR_EACH_VALUE_TYPE(GKO_DECLARE_VECTOR_AS_PRECISION_same);
+
+
+template <typename ValueType>
+template <typename OtherValueType>
+gko::detail::temporary_conversion<const Vector<OtherValueType>>
+Vector<ValueType>::as_precision() const
+{
+    // See the implementation of Dense::as_precision for details
+    if constexpr (is_complex<ValueType>() == is_complex<OtherValueType>()) {
+        return gko::detail::temporary_conversion<
+            const Vector<OtherValueType>>::create(this);
+    } else if constexpr (is_complex<ValueType>() &&
+                         std::is_same_v<to_complex<OtherValueType>,
+                                        ValueType>) {
+        return gko::detail::temporary_conversion<
+            const Vector<OtherValueType>>::create(this->create_real_view());
+    } else {
+        GKO_NOT_IMPLEMENTED;
+    }
+}
+
+#define GKO_DECLARE_VECTOR_CONST_AS_PRECISION(ValueType, OtherValueType) \
+    auto Vector<ValueType>::as_precision()                               \
+        const->gko::detail::temporary_conversion<const Vector<OtherValueType>>
+#define GKO_DECLARE_VECTOR_CONST_AS_PRECISION_same(ValueType) \
+    GKO_DECLARE_VECTOR_CONST_AS_PRECISION(ValueType, ValueType)
+GKO_INSTANTIATE_FOR_EACH_VALUE_CONVERSION(
+    GKO_DECLARE_VECTOR_CONST_AS_PRECISION);
+GKO_INSTANTIATE_FOR_EACH_VALUE_TYPE(GKO_DECLARE_VECTOR_CONST_AS_PRECISION_same);
+
+
+template <typename ValueType>
 std::unique_ptr<Vector<ValueType>> Vector<ValueType>::create_subview_impl(
     local_span rows, local_span columns)
 {

--- a/core/solver/gcr.cpp
+++ b/core/solver/gcr.cpp
@@ -232,18 +232,18 @@ void Gcr<ValueType>::apply_dense_impl(const VectorType* dense_b,
             restart_iter = 0;
         }
 
-        auto Ap = mapped_krylov_bases_Ap->create_submatrix(
+        auto Ap = mapped_krylov_bases_Ap->create_subview(
             local_span{local_num_rows * restart_iter,
                        local_num_rows * (restart_iter + 1)},
             local_span{0, num_rhs}, dim<2>{num_rows, num_rhs});
-        auto p = krylov_bases_p->create_submatrix(
+        auto p = krylov_bases_p->create_subview(
             local_span{local_num_rows * restart_iter,
                        local_num_rows * (restart_iter + 1)},
             local_span{0, num_rhs}, dim<2>{num_rows, num_rhs});
         // compute r*Ap
         residual->compute_conj_dot(Ap.get(), tmp_rAp, reduction_tmp);
         // normalise
-        auto Ap_norm = Ap_norms->create_submatrix(
+        auto Ap_norm = Ap_norms->create_subview(
             local_span{restart_iter, restart_iter + 1}, local_span{0, num_rhs});
         Ap->compute_squared_norm2(Ap_norm.get(), reduction_tmp);
 
@@ -265,11 +265,11 @@ void Gcr<ValueType>::apply_dense_impl(const VectorType* dense_b,
         this->get_system_matrix()->apply(precon_residual, A_precon_residual);
 
         // modified Gram-Schmidt
-        auto next_Ap = mapped_krylov_bases_Ap->create_submatrix(
+        auto next_Ap = mapped_krylov_bases_Ap->create_subview(
             local_span{local_num_rows * (restart_iter + 1),
                        local_num_rows * (restart_iter + 2)},
             local_span{0, num_rhs}, dim<2>{num_rows, num_rhs});
-        auto next_p = krylov_bases_p->create_submatrix(
+        auto next_p = krylov_bases_p->create_subview(
             local_span{local_num_rows * (restart_iter + 1),
                        local_num_rows * (restart_iter + 2)},
             local_span{0, num_rhs}, dim<2>{num_rows, num_rhs});
@@ -278,14 +278,14 @@ void Gcr<ValueType>::apply_dense_impl(const VectorType* dense_b,
         next_Ap->copy_from(A_precon_residual);
         next_p->copy_from(precon_residual);
         for (size_type i = 0; i <= restart_iter; ++i) {
-            Ap = mapped_krylov_bases_Ap->create_submatrix(
+            Ap = mapped_krylov_bases_Ap->create_subview(
                 local_span{local_num_rows * i, local_num_rows * (i + 1)},
                 local_span{0, num_rhs}, dim<2>{num_rows, num_rhs});
-            p = krylov_bases_p->create_submatrix(
+            p = krylov_bases_p->create_subview(
                 local_span{local_num_rows * i, local_num_rows * (i + 1)},
                 local_span{0, num_rhs}, dim<2>{num_rows, num_rhs});
-            Ap_norm = Ap_norms->create_submatrix(local_span{i, i + 1},
-                                                 local_span{0, num_rhs});
+            Ap_norm = Ap_norms->create_subview(local_span{i, i + 1},
+                                               local_span{0, num_rhs});
             // tmp_minus_beta = -beta = Ar*Ap/Ap*Ap
             A_precon_residual->compute_conj_dot(Ap.get(), tmp_minus_beta,
                                                 reduction_tmp);

--- a/core/solver/gmres.cpp
+++ b/core/solver/gmres.cpp
@@ -165,9 +165,9 @@ void orthogonalize_mgs(matrix::Dense<ValueType>* hessenberg_iter,
         // i)
         // next_krylov -= hessenberg(i, restart_iter) * krylov_bases(:,
         // i)
-        auto hessenberg_entry =
-            hessenberg_iter->create_submatrix(span{i, i + 1}, span{0, num_rhs});
-        auto krylov_basis = krylov_bases->create_submatrix(
+        auto hessenberg_entry = hessenberg_iter->create_subview(
+            local_span{i, i + 1}, local_span{0, num_rhs});
+        auto krylov_basis = krylov_bases->create_subview(
             local_span{local_num_rows * i, local_num_rows * (i + 1)},
             local_span{0, num_rhs}, dim<2>{num_rows, num_rhs});
         krylov_basis->compute_conj_dot(next_krylov, hessenberg_entry,
@@ -199,8 +199,8 @@ void finish_reduce(matrix::Dense<ValueType>* hessenberg_iter,
     // are not setting the last values for each rhs here. Values that would be
     // below the diagonal in the "full" matrix are skipped, because they will
     // be used to hold the norm of next_krylov for each rhs.
-    auto hessenberg_reduce = hessenberg_iter->create_submatrix(
-        span{0, restart_iter + 1}, span{0, num_rhs});
+    auto hessenberg_reduce = hessenberg_iter->create_subview(
+        local_span{0, restart_iter + 1}, local_span{0, num_rhs});
     int message_size = static_cast<int>((restart_iter + 1) * num_rhs);
     auto sum_op = gko::experimental::mpi::sum<ValueType>();
     if (experimental::mpi::requires_host_buffer(exec, comm)) {
@@ -228,7 +228,7 @@ void orthogonalize_cgs(matrix::Dense<ValueType>* hessenberg_iter,
     auto exec = hessenberg_iter->get_executor();
     // hessenberg(0:restart_iter, restart_iter) = krylov_basis' *
     // next_krylov
-    auto krylov_basis_small = krylov_bases->create_submatrix(
+    auto krylov_basis_small = krylov_bases->create_subview(
         local_span{0, local_num_rows * (restart_iter + 1)},
         local_span{0, num_rhs}, dim<2>{num_rows * (restart_iter + 1), num_rhs});
     exec->run(gmres::make_multi_dot(
@@ -240,9 +240,9 @@ void orthogonalize_cgs(matrix::Dense<ValueType>* hessenberg_iter,
     for (size_type i = 0; i <= restart_iter; i++) {
         // next_krylov -= hessenberg(i, restart_iter) * krylov_bases(:,
         // i)
-        auto hessenberg_entry =
-            hessenberg_iter->create_submatrix(span{i, i + 1}, span{0, num_rhs});
-        auto krylov_col = krylov_bases->create_submatrix(
+        auto hessenberg_entry = hessenberg_iter->create_subview(
+            local_span{i, i + 1}, local_span{0, num_rhs});
+        auto krylov_col = krylov_bases->create_subview(
             local_span{local_num_rows * i, local_num_rows * (i + 1)},
             local_span{0, num_rhs}, dim<2>{num_rows, num_rhs});
         next_krylov->sub_scaled(hessenberg_entry, krylov_col);
@@ -261,7 +261,7 @@ void orthogonalize_cgs2(matrix::Dense<ValueType>* hessenberg_iter,
     auto exec = hessenberg_iter->get_executor();
     // hessenberg(0:restart_iter, restart_iter) = krylov_bases' *
     // next_krylov
-    auto krylov_basis_small = krylov_bases->create_submatrix(
+    auto krylov_basis_small = krylov_bases->create_subview(
         local_span{0, local_num_rows * (restart_iter + 1)},
         local_span{0, num_rhs}, dim<2>{num_rows * (restart_iter + 1), num_rhs});
     exec->run(gmres::make_multi_dot(
@@ -273,16 +273,16 @@ void orthogonalize_cgs2(matrix::Dense<ValueType>* hessenberg_iter,
     for (size_type i = 0; i <= restart_iter; i++) {
         // next_krylov -= hessenberg(i, restart_iter) * krylov_bases(:,
         // i)
-        auto hessenberg_entry =
-            hessenberg_iter->create_submatrix(span{i, i + 1}, span{0, num_rhs});
-        auto krylov_col = krylov_bases->create_submatrix(
+        auto hessenberg_entry = hessenberg_iter->create_subview(
+            local_span{i, i + 1}, local_span{0, num_rhs});
+        auto krylov_col = krylov_bases->create_subview(
             local_span{local_num_rows * i, local_num_rows * (i + 1)},
             local_span{0, num_rhs}, dim<2>{num_rows, num_rhs});
         next_krylov->sub_scaled(hessenberg_entry, krylov_col);
     }
     // Re-orthogonalize
-    auto hessenberg_aux_iter = hessenberg_aux->create_submatrix(
-        span{0, restart_iter + 2}, span{0, num_rhs});
+    auto hessenberg_aux_iter = hessenberg_aux->create_subview(
+        local_span{0, restart_iter + 2}, local_span{0, num_rhs});
     exec->run(gmres::make_multi_dot(
         gko::detail::get_local(krylov_basis_small.get())
             ->get_const_device_view(),
@@ -294,9 +294,9 @@ void orthogonalize_cgs2(matrix::Dense<ValueType>* hessenberg_iter,
     for (size_type i = 0; i <= restart_iter; i++) {
         // next_krylov -= hessenberg(i, restart_iter) * krylov_bases(:,
         // i)
-        auto hessenberg_entry =
-            hessenberg_aux->create_submatrix(span{i, i + 1}, span{0, num_rhs});
-        auto krylov_col = krylov_bases->create_submatrix(
+        auto hessenberg_entry = hessenberg_aux->create_subview(
+            local_span{i, i + 1}, local_span{0, num_rhs});
+        auto krylov_col = krylov_bases->create_subview(
             local_span{local_num_rows * i, local_num_rows * (i + 1)},
             local_span{0, num_rhs}, dim<2>{num_rows, num_rhs});
         next_krylov->sub_scaled(hessenberg_entry, krylov_col);
@@ -507,23 +507,22 @@ void Gmres<ValueType>::apply_dense_impl(const VectorType* dense_b,
                 final_iter_nums.get_data()));
             restart_iter = 0;
         }
-        auto this_krylov = krylov_bases->create_submatrix(
+        auto this_krylov = krylov_bases->create_subview(
             local_span{local_num_rows * restart_iter,
                        local_num_rows * (restart_iter + 1)},
             local_span{0, num_rhs}, dim<2>{num_rows, num_rhs});
 
-        auto next_krylov = krylov_bases->create_submatrix(
+        auto next_krylov = krylov_bases->create_subview(
             local_span{local_num_rows * (restart_iter + 1),
                        local_num_rows * (restart_iter + 2)},
             local_span{0, num_rhs}, dim<2>{num_rows, num_rhs});
         std::unique_ptr<VectorType> preconditioned_krylov;
         auto preconditioned_krylov_vector = preconditioned_vector;
         if (is_flexible) {
-            preconditioned_krylov =
-                preconditioned_krylov_bases->create_submatrix(
-                    local_span{local_num_rows * restart_iter,
-                               local_num_rows * (restart_iter + 1)},
-                    local_span{0, num_rhs}, dim<2>{num_rows, num_rhs});
+            preconditioned_krylov = preconditioned_krylov_bases->create_subview(
+                local_span{local_num_rows * restart_iter,
+                           local_num_rows * (restart_iter + 1)},
+                local_span{0, num_rhs}, dim<2>{num_rows, num_rhs});
             preconditioned_krylov_vector = preconditioned_krylov.get();
         }
         // preconditioned_krylov_vector = get_preconditioner() * this_krylov
@@ -563,8 +562,9 @@ void Gmres<ValueType>::apply_dense_impl(const VectorType* dense_b,
         // hessenberg(restart_iter+1, restart_iter) = norm(next_krylov)
         // (stored in hessenberg(restart_iter, (restart_iter + 1) * num_rhs))
         // next_krylov /= hessenberg(restart_iter+1, restart_iter)
-        auto hessenberg_norm_entry = hessenberg_iter->create_submatrix(
-            span{restart_iter + 1, restart_iter + 2}, span{0, num_rhs});
+        auto hessenberg_norm_entry = hessenberg_iter->create_subview(
+            local_span{restart_iter + 1, restart_iter + 2},
+            local_span{0, num_rhs});
         help_compute_norm<ValueType>::compute_next_krylov_norm_into_hessenberg(
             next_krylov.get(), hessenberg_norm_entry.get(),
             next_krylov_norm_tmp, reduction_tmp);
@@ -603,8 +603,8 @@ void Gmres<ValueType>::apply_dense_impl(const VectorType* dense_b,
         restart_iter++;
     }
 
-    auto hessenberg_small = hessenberg->create_submatrix(
-        span{0, restart_iter}, span{0, num_rhs * restart_iter});
+    auto hessenberg_small = hessenberg->create_subview(
+        local_span{0, restart_iter}, local_span{0, num_rhs * restart_iter});
 
     // Solve upper triangular.
     // y = hessenberg \ residual_norm_collection
@@ -614,7 +614,7 @@ void Gmres<ValueType>::apply_dense_impl(const VectorType* dense_b,
         final_iter_nums.get_const_data(), stop_status.get_const_data()));
     if (is_flexible) {
         auto preconditioned_krylov_bases_small =
-            preconditioned_krylov_bases->create_submatrix(
+            preconditioned_krylov_bases->create_subview(
                 local_span{0, local_num_rows * (restart_iter + 1)},
                 local_span{0, num_rhs},
                 dim<2>{num_rows * (restart_iter + 1), num_rhs});
@@ -626,7 +626,7 @@ void Gmres<ValueType>::apply_dense_impl(const VectorType* dense_b,
             gko::detail::get_local(after_preconditioner)->get_device_view(),
             final_iter_nums.get_const_data(), stop_status.get_data()));
     } else {
-        auto krylov_bases_small = krylov_bases->create_submatrix(
+        auto krylov_bases_small = krylov_bases->create_subview(
             local_span{0, local_num_rows * (restart_iter + 1)},
             local_span{0, num_rhs},
             dim<2>{num_rows * (restart_iter + 1), num_rhs});

--- a/core/solver/pipe_cg.cpp
+++ b/core/solver/pipe_cg.cpp
@@ -118,11 +118,11 @@ void PipeCg<ValueType>::apply_dense_impl(const VectorType* dense_b,
         this->template create_workspace_op_with_type_of<VectorType>(
             GKO_SOLVER_TRAITS::rw, dense_b, global_conjoined_size,
             local_conjoined_size);
-    auto r_unique = rw->create_submatrix(local_span{0, local_original_size[0]},
-                                         local_span{0, local_original_size[1]},
-                                         global_original_size);
+    auto r_unique = rw->create_subview(local_span{0, local_original_size[0]},
+                                       local_span{0, local_original_size[1]},
+                                       global_original_size);
     auto* r = r_unique.get();
-    auto w_unique = rw->create_submatrix(
+    auto w_unique = rw->create_subview(
         local_span{0, local_original_size[0]},
         local_span{b_stride, b_stride + local_original_size[1]},
         global_original_size);
@@ -131,11 +131,11 @@ void PipeCg<ValueType>::apply_dense_impl(const VectorType* dense_b,
     // z now consists of two identical repeating parts: z1 and z2, again, for
     // the same reason
     GKO_SOLVER_VECTOR(z, rw);
-    auto z1_unique = z->create_submatrix(local_span{0, local_original_size[0]},
-                                         local_span{0, local_original_size[1]},
-                                         global_original_size);
+    auto z1_unique = z->create_subview(local_span{0, local_original_size[0]},
+                                       local_span{0, local_original_size[1]},
+                                       global_original_size);
     auto* z1 = z1_unique.get();
-    auto z2_unique = z->create_submatrix(
+    auto z2_unique = z->create_subview(
         local_span{0, local_original_size[0]},
         local_span{b_stride, b_stride + local_original_size[1]},
         global_original_size);
@@ -150,11 +150,11 @@ void PipeCg<ValueType>::apply_dense_impl(const VectorType* dense_b,
 
     // rho and delta become combined as well
     GKO_SOLVER_SCALAR(rhodelta, rw);
-    auto rho_unique = rhodelta->create_submatrix(
+    auto rho_unique = rhodelta->create_subview(
         local_span{0, 1}, local_span{0, local_original_size[1]},
         dim<2>{1, global_original_size[1]});
     auto* rho = rho_unique.get();
-    auto delta_unique = rhodelta->create_submatrix(
+    auto delta_unique = rhodelta->create_subview(
         local_span{0, 1},
         local_span{b_stride, b_stride + local_original_size[1]},
         dim<2>{1, global_original_size[1]});

--- a/include/ginkgo/core/distributed/vector.hpp
+++ b/include/ginkgo/core/distributed/vector.hpp
@@ -15,9 +15,9 @@
 #include <ginkgo/core/base/dense_cache.hpp>
 #include <ginkgo/core/base/lin_op.hpp>
 #include <ginkgo/core/base/mpi.hpp>
+#include <ginkgo/core/base/multivector.hpp>
 #include <ginkgo/core/distributed/base.hpp>
 #include <ginkgo/core/matrix/dense.hpp>
-
 
 namespace gko {
 namespace experimental {
@@ -64,19 +64,15 @@ class Partition;
  * @ingroup LinOp
  */
 template <typename ValueType = double>
-class Vector
-    : public LinOp,
-      public EnableCloneable<Vector<ValueType>>,
-      public ConvertibleTo<Vector<next_precision<ValueType>>>,
+class Vector : public EnableMultiVector<Vector<ValueType>>,
+               public ConvertibleTo<Vector<next_precision<ValueType>>>,
 #if GINKGO_ENABLE_HALF || GINKGO_ENABLE_BFLOAT16
-      public ConvertibleTo<Vector<next_precision<ValueType, 2>>>,
+               public ConvertibleTo<Vector<next_precision<ValueType, 2>>>,
 #endif
 #if GINKGO_ENABLE_HALF && GINKGO_ENABLE_BFLOAT16
-      public ConvertibleTo<Vector<next_precision<ValueType, 3>>>,
+               public ConvertibleTo<Vector<next_precision<ValueType, 3>>>,
 #endif
-      public EnableAbsoluteComputation<remove_complex<Vector<ValueType>>>,
-      public DistributedBase {
-    friend class EnableCloneable<Vector>;
+               public DistributedBase {
     friend class Vector<to_complex<ValueType>>;
     friend class Vector<remove_complex<ValueType>>;
     friend class Vector<previous_precision<ValueType>>;
@@ -84,56 +80,20 @@ class Vector
     GKO_ASSERT_SUPPORTED_VALUE_TYPE;
 
 public:
-    using EnableCloneable<Vector>::convert_to;
-    using EnableCloneable<Vector>::move_to;
+    using EnableMultiVector<Vector>::convert_to;
+    using EnableMultiVector<Vector>::move_to;
     using ConvertibleTo<Vector<next_precision<ValueType>>>::convert_to;
     using ConvertibleTo<Vector<next_precision<ValueType>>>::move_to;
 
-    using value_type = ValueType;
+    using typename EnableMultiVector<Vector>::value_type;
+    using typename EnableMultiVector<Vector>::absolute_value_type;
     using absolute_type = remove_complex<Vector>;
     using real_type = absolute_type;
     using complex_type = Vector<to_complex<value_type>>;
     using local_vector_type = gko::matrix::Dense<value_type>;
-
-    /**
-     * Creates a distributed Vector with the same size and stride as another
-     * Vector.
-     *
-     * @param other  The other vector whose configuration needs to copied.
-     */
-    static std::unique_ptr<Vector> create_with_config_of(
-        ptr_param<const Vector> other);
-
-
-    /**
-     * Creates an empty Vector with the same type as another Vector, but on a
-     * different executor.
-     *
-     * @param other  The other multi-vector whose type we target.
-     * @param exec  The executor of the new multi-vector.
-     *
-     * @note  The new multi-vector uses the same communicator as other.
-     *
-     * @returns an empty Vector with the type of other.
-     */
-    static std::unique_ptr<Vector> create_with_type_of(
-        ptr_param<const Vector> other, std::shared_ptr<const Executor> exec);
-
-    /**
-     * Creates an Vector with the same type as another Vector, but on a
-     * different executor and with a different size.
-     *
-     * @param other  The other multi-vector whose type we target.
-     * @param exec  The executor of the new multi-vector.
-     * @param global_size  The global size of the multi-vector.
-     * @param local_size  The local size of the multi-vector.
-     * @param stride  The stride of the new multi-vector.
-     *
-     * @returns a Vector of specified size with the type of other.
-     */
-    static std::unique_ptr<Vector> create_with_type_of(
-        ptr_param<const Vector> other, std::shared_ptr<const Executor> exec,
-        const dim<2>& global_size, const dim<2>& local_size, size_type stride);
+    using local_absolute_vector_type = gko::matrix::Dense<absolute_value_type>;
+    using typename EnableMultiVector<Vector>::device_view;
+    using typename EnableMultiVector<Vector>::const_device_view;
 
     /**
      * Reads a vector from the device_matrix_data structure and a global row
@@ -149,13 +109,13 @@ public:
      * @param data  The device_matrix_data structure
      * @param partition  The global row partition
      */
-    void read_distributed(const device_matrix_data<ValueType, int64>& data,
+    void read_distributed(const device_matrix_data<value_type, int64>& data,
                           ptr_param<const Partition<int64, int64>> partition);
 
-    void read_distributed(const device_matrix_data<ValueType, int64>& data,
+    void read_distributed(const device_matrix_data<value_type, int64>& data,
                           ptr_param<const Partition<int32, int64>> partition);
 
-    void read_distributed(const device_matrix_data<ValueType, int32>& data,
+    void read_distributed(const device_matrix_data<value_type, int32>& data,
                           ptr_param<const Partition<int32, int32>> partition);
 
     /**
@@ -167,251 +127,41 @@ public:
      * @note For efficiency it is advised to use the device_matrix_data
      * overload.
      */
-    void read_distributed(const matrix_data<ValueType, int64>& data,
+    void read_distributed(const matrix_data<value_type, int64>& data,
                           ptr_param<const Partition<int64, int64>> partition);
 
-    void read_distributed(const matrix_data<ValueType, int64>& data,
+    void read_distributed(const matrix_data<value_type, int64>& data,
                           ptr_param<const Partition<int32, int64>> partition);
 
-    void read_distributed(const matrix_data<ValueType, int32>& data,
+    void read_distributed(const matrix_data<value_type, int32>& data,
                           ptr_param<const Partition<int32, int32>> partition);
 
-    void convert_to(Vector<next_precision<ValueType>>* result) const override;
+    void convert_to(Vector<next_precision<value_type>>* result) const override;
 
-    void move_to(Vector<next_precision<ValueType>>* result) override;
+    void move_to(Vector<next_precision<value_type>>* result) override;
 
 #if GINKGO_ENABLE_HALF || GINKGO_ENABLE_BFLOAT16
-    friend class Vector<previous_precision<ValueType, 2>>;
-    using ConvertibleTo<Vector<next_precision<ValueType, 2>>>::convert_to;
-    using ConvertibleTo<Vector<next_precision<ValueType, 2>>>::move_to;
+    friend class Vector<previous_precision<value_type, 2>>;
+    using ConvertibleTo<Vector<next_precision<value_type, 2>>>::convert_to;
+    using ConvertibleTo<Vector<next_precision<value_type, 2>>>::move_to;
 
     void convert_to(
-        Vector<next_precision<ValueType, 2>>* result) const override;
+        Vector<next_precision<value_type, 2>>* result) const override;
 
-    void move_to(Vector<next_precision<ValueType, 2>>* result) override;
+    void move_to(Vector<next_precision<value_type, 2>>* result) override;
 #endif
 
 #if GINKGO_ENABLE_HALF && GINKGO_ENABLE_BFLOAT16
-    friend class Vector<previous_precision<ValueType, 3>>;
-    using ConvertibleTo<Vector<next_precision<ValueType, 3>>>::convert_to;
-    using ConvertibleTo<Vector<next_precision<ValueType, 3>>>::move_to;
+    friend class Vector<previous_precision<value_type, 3>>;
+    using ConvertibleTo<Vector<next_precision<value_type, 3>>>::convert_to;
+    using ConvertibleTo<Vector<next_precision<value_type, 3>>>::move_to;
 
     void convert_to(
-        Vector<next_precision<ValueType, 3>>* result) const override;
+        Vector<next_precision<value_type, 3>>* result) const override;
 
-    void move_to(Vector<next_precision<ValueType, 3>>* result) override;
+    void move_to(Vector<next_precision<value_type, 3>>* result) override;
 #endif
 
-    std::unique_ptr<absolute_type> compute_absolute() const override;
-
-    void compute_absolute_inplace() override;
-
-    /**
-     * Creates a complex copy of the original vectors. If the original vectors
-     * were real, the imaginary part of the result will be zero.
-     */
-    std::unique_ptr<complex_type> make_complex() const;
-
-    /**
-     * Writes a complex copy of the original vectors to given complex vectors.
-     * If the original vectors were real, the imaginary part of the result will
-     * be zero.
-     */
-    void make_complex(ptr_param<complex_type> result) const;
-
-    /**
-     * Creates new real vectors and extracts the real part of the original
-     * vectors into that.
-     */
-    std::unique_ptr<real_type> get_real() const;
-
-    /**
-     * Extracts the real part of the original vectors into given real vectors.
-     */
-    void get_real(ptr_param<real_type> result) const;
-
-    /**
-     * Creates new real vectors and extracts the imaginary part of the
-     * original vectors into that.
-     */
-    std::unique_ptr<real_type> get_imag() const;
-
-    /**
-     * Extracts the imaginary part of the original vectors into given real
-     * vectors.
-     */
-    void get_imag(ptr_param<real_type> result) const;
-
-    /**
-     * Fill the distributed vectors with a given value.
-     *
-     * @param value  the value to be filled
-     */
-    void fill(ValueType value);
-
-    /**
-     * Scales the vectors with a scalar (aka: BLAS scal).
-     *
-     * @param alpha  If alpha is 1x1 Dense matrx, the all vectors are scaled
-     *               by alpha. If it is a Dense row vector of values,
-     *               then i-th column vector is scaled with the i-th
-     *               element of alpha (the number of columns of alpha has to
-     *               match the number of vectors).
-     */
-    void scale(ptr_param<const LinOp> alpha);
-
-    /**
-     * Scales the vectors with the inverse of a scalar.
-     *
-     * @param alpha  If alpha is 1x1 Dense matrix, the all vectors are scaled
-     *               by 1 / alpha. If it is a Dense row vector of values,
-     *               then i-th column vector is scaled with the inverse
-     *               of the i-th element of alpha (the number of columns of
-     *               alpha has to match the number of vectors).
-     */
-    void inv_scale(ptr_param<const LinOp> alpha);
-
-    /**
-     * Adds `b` scaled by `alpha` to the vectors (aka: BLAS axpy).
-     *
-     * @param alpha  If alpha is 1x1 Dense matrix, the all vectors of b are
-     * scaled by alpha. If it is a Dense row vector of values, then i-th column
-     * vector of b is scaled with the i-th element of alpha (the number of
-     * columns of alpha has to match the number of vectors).
-     * @param b  a (multi-)vector of the same dimension as this
-     */
-    void add_scaled(ptr_param<const LinOp> alpha, ptr_param<const LinOp> b);
-
-    /**
-     * Subtracts `b` scaled by `alpha` from the vectors (aka: BLAS axpy).
-     *
-     * @param alpha  If alpha is 1x1 Dense matrix, the all vectors of b are
-     * scaled by alpha. If it is a Dense row vector of values, then i-th column
-     * vector of b is scaled with the i-th element of alpha (the number of c
-     * @param b  a (multi-)vector of the same dimension as this
-     */
-    void sub_scaled(ptr_param<const LinOp> alpha, ptr_param<const LinOp> b);
-
-    /**
-     * Computes the column-wise dot product of this (multi-)vector and `b` using
-     * a global reduction.
-     *
-     * @param b  a (multi-)vector of same dimension as this
-     * @param result  a Dense row matrix, used to store the dot product
-     *                (the number of column in result must match the number
-     *                of columns of this)
-     */
-    void compute_dot(ptr_param<const LinOp> b, ptr_param<LinOp> result) const;
-
-    /**
-     * Computes the column-wise dot product of this (multi-)vector and `b` using
-     * a global reduction.
-     *
-     * @param b  a (multi-)vector of same dimension as this
-     * @param result  a Dense row matrix, used to store the dot product
-     *                (the number of column in result must match the number
-     *                of columns of this)
-     * @param tmp  the temporary storage to use for partial sums during the
-     *             reduction computation. It may be resized and/or reset to the
-     *             correct executor.
-     */
-    void compute_dot(ptr_param<const LinOp> b, ptr_param<LinOp> result,
-                     array<char>& tmp) const;
-
-    /**
-     * Computes the column-wise dot product of this (multi-)vector and `conj(b)`
-     * using a global reduction.
-     *
-     * @param b  a (multi-)vector of same dimension as this
-     * @param result  a Dense row matrix, used to store the dot product
-     *                (the number of column in result must match the number
-     *                of columns of this)
-     */
-    void compute_conj_dot(ptr_param<const LinOp> b,
-                          ptr_param<LinOp> result) const;
-
-    /**
-     * Computes the column-wise dot product of this (multi-)vector and `conj(b)`
-     * using a global reduction.
-     *
-     * @param b  a (multi-)vector of same dimension as this
-     * @param result  a Dense row matrix, used to store the dot product
-     *                (the number of column in result must match the number
-     *                of columns of this)
-     * @param tmp  the temporary storage to use for partial sums during the
-     *             reduction computation. It may be resized and/or reset to the
-     *             correct executor.
-     */
-    void compute_conj_dot(ptr_param<const LinOp> b, ptr_param<LinOp> result,
-                          array<char>& tmp) const;
-
-    /**
-     * Computes the square of the column-wise Euclidean ($L^2$) norm of this
-     * (multi-)vector using a global reduction.
-     *
-     * @param result  a Dense row vector, used to store the norm
-     *                (the number of columns in the vector must match the number
-     *                of columns of this)
-     */
-    void compute_squared_norm2(ptr_param<LinOp> result) const;
-
-    /**
-     * Computes the square of the column-wise Euclidean ($L^2$) norm of this
-     * (multi-)vector using a global reduction.
-     *
-     * @param result  a Dense row vector, used to store the norm
-     *                (the number of columns in the vector must match the
-     *                number of columns of this)
-     * @param tmp  the temporary storage to use for partial sums during the
-     *             reduction computation. It may be resized and/or reset to the
-     *             correct executor.
-     */
-    void compute_squared_norm2(ptr_param<LinOp> result, array<char>& tmp) const;
-
-    /**
-     * Computes the Euclidean (L^2) norm of this (multi-)vector using a global
-     * reduction.
-     *
-     * @param result  a Dense row matrix, used to store the norm
-     *                (the number of columns in result must match the number
-     *                of columns of this)
-     */
-    void compute_norm2(ptr_param<LinOp> result) const;
-
-    /**
-     * Computes the Euclidean (L^2) norm of this (multi-)vector using a global
-     * reduction.
-     *
-     * @param result  a Dense row matrix, used to store the norm
-     *                (the number of columns in result must match the number
-     *                of columns of this)
-     * @param tmp  the temporary storage to use for partial sums during the
-     *             reduction computation. It may be resized and/or reset to the
-     *             correct executor.
-     */
-    void compute_norm2(ptr_param<LinOp> result, array<char>& tmp) const;
-
-    /**
-     * Computes the column-wise (L^1) norm of this (multi-)vector.
-     *
-     * @param result  a Dense row matrix, used to store the norm
-     *                (the number of columns in result must match the number
-     *                of columns of this)
-     */
-    void compute_norm1(ptr_param<LinOp> result) const;
-
-    /**
-     * Computes the column-wise (L^1) norm of this (multi-)vector using a global
-     * reduction.
-     *
-     * @param result  a Dense row matrix, used to store the norm
-     *                (the number of columns in result must match the number
-     *                of columns of this)
-     * @param tmp  the temporary storage to use for partial sums during the
-     *             reduction computation. It may be resized and/or reset to the
-     *             correct executor.
-     */
-    void compute_norm1(ptr_param<LinOp> result, array<char>& tmp) const;
 
     /**
      * Computes the column-wise mean of this (multi-)vector using a global
@@ -467,12 +217,12 @@ public:
      *        stored at (e.g. trying to call this method on a GPU matrix from
      *        the OMP results in a runtime error)
      */
-    ValueType& at_local(size_type idx) noexcept;
+    value_type& at_local(size_type idx) noexcept;
 
     /**
      * @copydoc Vector::at(size_type)
      */
-    ValueType at_local(size_type idx) const noexcept;
+    value_type at_local(size_type idx) const noexcept;
 
     /**
      * Returns a pointer to the array of local values of the multi-vector.
@@ -496,33 +246,6 @@ public:
      * @return a constant pointer to the underlying local_vector_type vectors
      */
     const local_vector_type* get_local_vector() const;
-
-    /**
-     * Create a real view of the (potentially) complex original multi-vector.
-     * If the original vector is real, nothing changes. If the original vector
-     * is complex, the result is created by viewing the complex vector with as
-     * real with a reinterpret_cast with twice the number of columns and
-     * double the stride.
-     */
-    std::unique_ptr<const real_type> create_real_view() const;
-
-    /**
-     * @copydoc create_real_view
-     */
-    std::unique_ptr<real_type> create_real_view();
-
-    /**
-     * Creates a view of a submatrix of this vector.
-     *
-     * @param rows  The local rows of the submatrix
-     * @param columns  The local columns of the submatrix
-     * @param global_size  The global size of the submatrix
-     *
-     * @return A view of a submatrix.
-     */
-    std::unique_ptr<Vector> create_submatrix(local_span rows,
-                                             local_span columns,
-                                             dim<2> global_size);
 
     size_type get_stride() const noexcept { return local_.get_stride(); }
 
@@ -652,7 +375,7 @@ protected:
 
     template <typename LocalIndexType, typename GlobalIndexType>
     void read_distributed_impl(
-        const device_matrix_data<ValueType, GlobalIndexType>& data,
+        const device_matrix_data<value_type, GlobalIndexType>& data,
         const Partition<LocalIndexType, GlobalIndexType>* partition);
 
     void apply_impl(const LinOp*, LinOp*) const override;
@@ -666,7 +389,7 @@ protected:
      *
      * @returns a Vector with the same size and stride as the caller.
      */
-    virtual std::unique_ptr<Vector> create_with_same_config() const;
+    std::unique_ptr<Vector> create_with_same_config_impl() const override;
 
     /**
      * Creates a Vector with the same type as the callers multi-vector.
@@ -680,21 +403,95 @@ protected:
      *
      * @returns a Vector with the same type as the caller.
      */
-    virtual std::unique_ptr<Vector> create_with_type_of_impl(
+    std::unique_ptr<Vector> create_with_type_of_impl(
         std::shared_ptr<const Executor> exec, const dim<2>& global_size,
-        const dim<2>& local_size, size_type stride) const;
+        const dim<2>& local_size, size_type stride) const override;
 
-    /**
-     * @copydoc create_submatrix
-     */
-    virtual std::unique_ptr<Vector> create_submatrix_impl(local_span rows,
-                                                          local_span columns,
-                                                          dim<2> global_size);
+    [[nodiscard]] std::unique_ptr<absolute_type> compute_absolute_impl()
+        const override;
+
+    void compute_absolute_inplace_impl() override;
+
+    [[nodiscard]] std::unique_ptr<complex_type> make_complex_impl()
+        const override;
+
+    [[nodiscard]] std::unique_ptr<real_type> get_real_impl() const override;
+
+    [[nodiscard]] std::unique_ptr<real_type> get_imag_impl() const override;
+
+    [[nodiscard]] std::unique_ptr<const real_type> create_real_view_impl()
+        const override;
+
+    [[nodiscard]] std::unique_ptr<real_type> create_real_view_impl() override;
+
+    [[nodiscard]] std::unique_ptr<Vector> create_subview_impl(
+        local_span rows, local_span columns) override;
+
+    [[nodiscard]] std::unique_ptr<const Vector> create_subview_impl(
+        local_span rows, local_span columns) const override;
+
+    [[nodiscard]] std::unique_ptr<Vector> create_subview_impl(
+        local_span rows, local_span columns, dim<2> global_size) override;
+
+    [[nodiscard]] std::unique_ptr<const Vector> create_subview_impl(
+        local_span rows, local_span columns, dim<2> global_size) const override;
+
+    void compute_absolute_impl(absolute_type* result) const override;
+
+    void make_complex_impl(complex_type* result) const override;
+
+    void get_real_impl(real_type* result) const override;
+
+    void get_imag_impl(real_type* result) const override;
+
+    void compute_dot_impl(const Vector* b,
+                          local_vector_type* result) const override;
+
+    void compute_dot_impl(const Vector* b, local_vector_type* result,
+                          array<char>& tmp) const override;
+
+    void compute_conj_dot_impl(const Vector* b,
+                               local_vector_type* result) const override;
+
+    void compute_conj_dot_impl(const Vector* b, local_vector_type* result,
+                               array<char>& tmp) const override;
+
+    void compute_norm2_impl(local_absolute_vector_type* result) const override;
+
+    void compute_norm2_impl(local_absolute_vector_type* result,
+                            array<char>& tmp) const override;
+
+    void compute_norm1_impl(local_absolute_vector_type* result) const override;
+
+    void compute_norm1_impl(local_absolute_vector_type* result,
+                            array<char>& tmp) const override;
+
+    void compute_squared_norm2_impl(
+        local_absolute_vector_type* result) const override;
+
+    void compute_squared_norm2_impl(local_absolute_vector_type* result,
+                                    array<char>& tmp) const override;
+
+    void fill_impl(value_type value) override;
+
+    void scale_impl(scaling_param<value_type> alpha) override;
+
+    void inv_scale_impl(scaling_param<value_type> alpha) override;
+
+    void add_scaled_impl(scaling_param<value_type> alpha,
+                         const Vector* b) override;
+
+    void sub_scaled_impl(scaling_param<value_type> alpha,
+                         const Vector* b) override;
+
+    device_view get_local_device_view_impl() override;
+
+    const_device_view get_const_local_device_view_impl() const override;
 
 private:
     local_vector_type local_;
-    ::gko::detail::DenseCache<ValueType> host_reduction_buffer_;
-    ::gko::detail::DenseCache<remove_complex<ValueType>> host_norm_buffer_;
+    ::gko::detail::DenseCache<value_type> host_reduction_buffer_;
+    ::gko::detail::DenseCache<remove_complex<value_type>> host_norm_buffer_;
 };
 
 

--- a/include/ginkgo/core/distributed/vector.hpp
+++ b/include/ginkgo/core/distributed/vector.hpp
@@ -357,6 +357,15 @@ public:
         std::shared_ptr<const Executor> exec, mpi::communicator comm,
         std::unique_ptr<const local_vector_type> local_vector);
 
+    template <typename OtherValueType>
+    [[nodiscard]] gko::detail::temporary_conversion<Vector<OtherValueType>>
+    as_precision();
+
+    template <typename OtherValueType>
+    [[nodiscard]] gko::detail::temporary_conversion<
+        const Vector<OtherValueType>>
+    as_precision() const;
+
 protected:
     Vector(std::shared_ptr<const Executor> exec, mpi::communicator comm,
            dim<2> global_size, dim<2> local_size, size_type stride);

--- a/test/mpi/distributed/vector.cpp
+++ b/test/mpi/distributed/vector.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -1054,8 +1054,8 @@ TYPED_TEST(VectorLocalOps, CreateSubmatrixSameAsLocal)
     this->comm.all_reduce(this->exec, &global_cols, 1, MPI_SUM);
     gko::dim<2> global_size{global_rows, global_cols};
 
-    auto rv = this->x->create_submatrix(rows, cols, global_size);
-    auto local_rv = this->local_x->create_submatrix(rows, cols);
+    auto rv = this->x->create_subview(rows, cols, global_size);
+    auto local_rv = this->local_x->create_subview(rows, cols);
 
     GKO_ASSERT_EQUAL_DIMENSIONS(rv, global_size);
     GKO_ASSERT_MTX_NEAR(rv->get_local_vector(), local_rv, 0.0);


### PR DESCRIPTION
This is the `distributed::Vector` implementation of the `MultiVector` interface. It almost exclusively adds functionality. Only the create_with* functions are modified slightly, the rest of the functionality that is duplicated in the `MultiVector` interface is kept.