### PR TITLE
Fix CMake try_compile variable issue from CMP0126

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -397,21 +397,21 @@ if(GINKGO_BUILD_MPI)
 
     # use try_compile instead of try_run to prevent cross-compiling issues
     try_compile(
-        uses_openmpi
+        gko_uses_openmpi
         ${Ginkgo_BINARY_DIR}
         ${Ginkgo_SOURCE_DIR}/cmake/openmpi_test.cpp
         COMPILE_DEFINITIONS -DCHECK_HAS_OPEN_MPI=1
         LINK_LIBRARIES MPI::MPI_CXX
     )
-    if(uses_openmpi)
+    if(gko_uses_openmpi)
         try_compile(
-            valid_openmpi_version
+            gko_valid_openmpi_version
             ${Ginkgo_BINARY_DIR}
             ${Ginkgo_SOURCE_DIR}/cmake/openmpi_test.cpp
             COMPILE_DEFINITIONS -DCHECK_OPEN_MPI_VERSION=1
             LINK_LIBRARIES MPI::MPI_CXX
         )
-        if(NOT valid_openmpi_version)
+        if(NOT gko_valid_openmpi_version)
             message(
                 WARNING
                 "OpenMPI v4.0.x has several bugs that forces us to use non-optimal communication in our distributed "
@@ -420,9 +420,11 @@ if(GINKGO_BUILD_MPI)
             )
             set(GINKGO_HAVE_OPENMPI_PRE_4_1_X ON)
         endif()
-        unset(valid_openmpi_version)
+        unset(gko_valid_openmpi_version)
+        unset(gko_valid_openmpi_version CACHE)
     endif()
-    unset(uses_openmpi)
+    unset(gko_uses_openmpi)
+    unset(gko_uses_openmpi CACHE)
 endif()
 
 # Try to find the third party packages before using our subdirectories


### PR DESCRIPTION
The original issue is from using `CudaArchitectureSelector.cmake` because we have execute_process and try_compile use the same variable but one is normal another is cache when testing.
This PR fixes cmake try_compile variable is not used when there is a normal variable already.
`try_compile()` is affected by CMP0126, which is unclear on the documentation in my opinion.
CMP0126 is introduced in cmake 3.21 which leads cache variable does not destroy normal variable.
If cmake uses `<var>` as normal variable and try_compile results a cache variable, old behavior the normal variable is gone such that we get `${var}` from cache, but new behavior the normal variable is kept such that we get `${var}` from normal variable not cache (`$CACHE{var}` to access cache one).
However, it is not clear to me from the documentation before cmake 3.25 whether try_compile always result a cache variable. It seems to doing that from note about debug. `try_run` and `execute_process` do not mention it clear, but `try_run` results a cache variable but `execute_process` results a normal variable. correct me if I miss some documentation.

Moreover, the policy is affected by caller if we do not set it additionally. i.e. some projects use cmake >= 3.21 try to use ginkgo as subproject, which will lead us using newer policy. 

After 3.25, it is more clear and has NO_CACHE to select behavior.

We can go for just setting CMP0126 to OLD to keep the same behavior no matter what the caller's cmake version is.
In current pr, I go for rename the variable to avoid the name collision, so it will not give an issue no matter it gives normal or cache variable.

For those interested,
```
cmake_minimum_required(VERSION 3.16)
# cmake_policy(SET CMP0126 NEW)
# cmake_minimum_required(VERSION 3.21)
project(
    test_try_compile
    LANGUAGES CXX
)
# normal varilable
set(status 0)
set(working_source "${PROJECT_BINARY_DIR}/CMakeFiles/work.cpp")
file(WRITE "${working_source}" "int main() { return 0;}")
message(STATUS "status ${status} cache $CACHE{status}")
try_compile(status "${PROJECT_BINARY_DIR}" SOURCES "${working_source}")
message(STATUS "status ${status} cache $CACHE{status}")
set(not_working_source "${PROJECT_BINARY_DIR}/CMakeFiles/not-work.cpp")
file(WRITE "${not_working_source}" "in mai() { retrn 0;}")
try_compile(status "${PROJECT_BINARY_DIR}" SOURCES "${not_working_source}")
message(STATUS "status ${status} cache $CACHE{status}")
```
