### PR TITLE
add synchronization log event

### DIFF
--- a/core/device_hooks/cuda_hooks.cpp
+++ b/core/device_hooks/cuda_hooks.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -141,7 +141,7 @@ void CudaExecutor::raw_copy_to(const DpcppExecutor*, size_type num_bytes,
     GKO_NOT_COMPILED(cuda);
 
 
-void CudaExecutor::synchronize() const GKO_NOT_COMPILED(cuda);
+void CudaExecutor::synchronize_impl() const GKO_NOT_COMPILED(cuda);
 
 
 scoped_device_id_guard CudaExecutor::get_scoped_device_id_guard() const

--- a/core/device_hooks/dpcpp_hooks.cpp
+++ b/core/device_hooks/dpcpp_hooks.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -84,7 +84,7 @@ void DpcppExecutor::raw_copy_to(const DpcppExecutor*, size_type num_bytes,
     GKO_NOT_COMPILED(dpcpp);
 
 
-void DpcppExecutor::synchronize() const GKO_NOT_COMPILED(dpcpp);
+void DpcppExecutor::synchronize_impl() const GKO_NOT_COMPILED(dpcpp);
 
 
 scoped_device_id_guard DpcppExecutor::get_scoped_device_id_guard() const

--- a/core/device_hooks/hip_hooks.cpp
+++ b/core/device_hooks/hip_hooks.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -140,7 +140,7 @@ void HipExecutor::raw_copy_to(const DpcppExecutor*, size_type num_bytes,
     GKO_NOT_COMPILED(hip);
 
 
-void HipExecutor::synchronize() const GKO_NOT_COMPILED(hip);
+void HipExecutor::synchronize_impl() const GKO_NOT_COMPILED(hip);
 
 
 scoped_device_id_guard HipExecutor::get_scoped_device_id_guard() const

--- a/core/log/profiler_hook.cpp
+++ b/core/log/profiler_hook.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -280,6 +280,18 @@ void ProfilerHook::on_iteration_complete(
 }
 
 
+void ProfilerHook::on_synchronize_started(const gko::Executor*) const
+{
+    this->begin_hook_("synchronize", profile_event_category::operation);
+}
+
+
+void ProfilerHook::on_synchronize_completed(const gko::Executor*) const
+{
+    this->end_hook_("synchronize", profile_event_category::operation);
+}
+
+
 bool ProfilerHook::needs_propagation() const { return true; }
 
 
@@ -306,10 +318,12 @@ void ProfilerHook::set_synchronization(bool synchronize)
 void ProfilerHook::maybe_synchronize(const Executor* exec) const
 {
     if (synchronize_) {
-        profiling_scope_guard sync_guard{"synchronize",
+        profiling_scope_guard sync_guard{"logger_synchronize",
                                          profile_event_category::internal,
                                          begin_hook_, end_hook_};
-        exec->synchronize();
+        // we call synchronize_impl not synchronize to separate the syncrhonize
+        // caller.
+        exec->synchronize_impl();
     }
 }
 

--- a/cuda/base/executor.cpp
+++ b/cuda/base/executor.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -165,7 +165,7 @@ void CudaExecutor::raw_copy_to(const CudaExecutor* dest, size_type num_bytes,
 }
 
 
-void CudaExecutor::synchronize() const
+void CudaExecutor::synchronize_impl() const
 {
     detail::cuda_scoped_device_id_guard g(this->get_device_id());
     GKO_ASSERT_NO_CUDA_ERRORS(cudaStreamSynchronize(this->get_stream()));

--- a/devices/omp/executor.cpp
+++ b/devices/omp/executor.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -58,7 +58,7 @@ void OmpExecutor::raw_copy_to(const OmpExecutor*, size_type num_bytes,
 }
 
 
-void OmpExecutor::synchronize() const
+void OmpExecutor::synchronize_impl() const
 {
     // This is a no-op for single-threaded OMP
     // TODO: change when adding support for multi-threaded OMP execution

--- a/dpcpp/base/executor.dp.cpp
+++ b/dpcpp/base/executor.dp.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -153,7 +153,7 @@ void DpcppExecutor::raw_copy_to(const DpcppExecutor* dest, size_type num_bytes,
 }
 
 
-void DpcppExecutor::synchronize() const { queue_->wait_and_throw(); }
+void DpcppExecutor::synchronize_impl() const { queue_->wait_and_throw(); }
 
 scoped_device_id_guard DpcppExecutor::get_scoped_device_id_guard() const
 {

--- a/hip/base/executor.hip.cpp
+++ b/hip/base/executor.hip.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -161,7 +161,7 @@ void HipExecutor::raw_copy_to(const HipExecutor* dest, size_type num_bytes,
 }
 
 
-void HipExecutor::synchronize() const
+void HipExecutor::synchronize_impl() const
 {
     detail::hip_scoped_device_id_guard g(this->get_device_id());
     GKO_ASSERT_NO_HIP_ERRORS(hipStreamSynchronize(this->get_stream()));

--- a/include/ginkgo/core/base/executor.hpp
+++ b/include/ginkgo/core/base/executor.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -139,6 +139,15 @@ class ExecutorBase;
 
 
 }  // namespace detail
+
+
+namespace log {
+
+
+class ProfilerHook;
+
+
+}  // namespace log
 
 
 /**
@@ -619,6 +628,8 @@ class Executor : public log::EnableLogging<Executor> {
     GKO_ENABLE_FOR_ALL_EXECUTORS(GKO_DECLARE_EXECUTOR_FRIEND);
     friend class ReferenceExecutor;
 
+    friend class log::ProfilerHook;
+
 public:
     virtual ~Executor() = default;
 
@@ -827,7 +838,12 @@ public:
     /**
      * Synchronize the operations launched on the executor with its master.
      */
-    virtual void synchronize() const = 0;
+    void synchronize() const
+    {
+        this->template log<log::Logger::synchronize_started>(this);
+        this->synchronize_impl();
+        this->template log<log::Logger::synchronize_completed>(this);
+    }
 
     /**
      * @copydoc Loggable::add_logger
@@ -1022,6 +1038,11 @@ protected:
      * @return  the exec_info struct
      */
     const exec_info& get_exec_info() const { return this->exec_info_; }
+
+    /**
+     * Synchronize the operations launched on the executor with its master.
+     */
+    virtual void synchronize_impl() const = 0;
 
     /**
      * Allocates raw memory in this Executor.
@@ -1404,8 +1425,6 @@ public:
 
     std::shared_ptr<const Executor> get_master() const noexcept override;
 
-    void synchronize() const override;
-
     int get_num_cores() const
     {
         return this->get_exec_info().num_computing_units;
@@ -1430,6 +1449,8 @@ protected:
     }
 
     void populate_exec_info(const machine_topology* mach_topo) override;
+
+    void synchronize_impl() const override;
 
     void* raw_alloc(size_type size) const override;
 
@@ -1588,8 +1609,6 @@ public:
 
     std::shared_ptr<const Executor> get_master() const noexcept override;
 
-    void synchronize() const override;
-
     scoped_device_id_guard get_scoped_device_id_guard() const override;
 
     std::string get_description() const override;
@@ -1731,6 +1750,8 @@ protected:
         this->init_handles();
     }
 
+    void synchronize_impl() const override;
+
     void* raw_alloc(size_type size) const override;
 
     void raw_free(void* ptr) const noexcept override;
@@ -1811,8 +1832,6 @@ public:
     std::shared_ptr<Executor> get_master() noexcept override;
 
     std::shared_ptr<const Executor> get_master() const noexcept override;
-
-    void synchronize() const override;
 
     scoped_device_id_guard get_scoped_device_id_guard() const override;
 
@@ -1949,6 +1968,8 @@ protected:
         this->init_handles();
     }
 
+    void synchronize_impl() const override;
+
     void* raw_alloc(size_type size) const override;
 
     void raw_free(void* ptr) const noexcept override;
@@ -2016,8 +2037,6 @@ public:
     std::shared_ptr<Executor> get_master() noexcept override;
 
     std::shared_ptr<const Executor> get_master() const noexcept override;
-
-    void synchronize() const override;
 
     scoped_device_id_guard get_scoped_device_id_guard() const override;
 
@@ -2131,6 +2150,8 @@ protected:
     }
 
     void populate_exec_info(const machine_topology* mach_topo) override;
+
+    void synchronize_impl() const override;
 
     void* raw_alloc(size_type size) const override;
 

--- a/include/ginkgo/core/log/logger.hpp
+++ b/include/ginkgo/core/log/logger.hpp
@@ -618,6 +618,22 @@ protected:
 
 
 public:
+    /**
+     * synchronize started event.
+     *
+     * @param exec  the executor used
+     */
+    GKO_LOGGER_REGISTER_EVENT(27, synchronize_started, const Executor* exec)
+
+    /**
+     * synchronize completed event.
+     *
+     * @param exec  the executor used
+     */
+    GKO_LOGGER_REGISTER_EVENT(28, synchronize_completed, const Executor* exec)
+
+
+public:
 #undef GKO_LOGGER_REGISTER_EVENT
 
     /**
@@ -626,7 +642,8 @@ public:
     static constexpr mask_type executor_events_mask =
         allocation_started_mask | allocation_completed_mask |
         free_started_mask | free_completed_mask | copy_started_mask |
-        copy_completed_mask;
+        copy_completed_mask | synchronize_started_mask |
+        synchronize_completed_mask;
 
     /**
      * Bitset Mask which activates all operation events

--- a/include/ginkgo/core/log/profiler_hook.hpp
+++ b/include/ginkgo/core/log/profiler_hook.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -86,6 +86,10 @@ public:
 
     void on_operation_completed(const Executor* exec,
                                 const Operation* operation) const override;
+
+    void on_synchronize_started(const Executor*) const override;
+
+    void on_synchronize_completed(const Executor*) const override;
 
     /* PolymorphicObject events */
     void on_polymorphic_object_copy_started(


### PR DESCRIPTION
This PR adds the event to synchronize.
I put event in executor_event collection and operations tag in profile_hook.
To distinguish `profiler_hook` additional sync and function sync, I allow profiler hook to call `synchronize_impl` such that they do not have usual syncrhonize event.

BTW, this PR is not enough such that we can distinguish the real copy time from waiting the previous gpu activity because the result in residual_norm copy is pageable memory unless we are on grace hopper or use `cudaMallocHost` for the resulting memory, which will handled in another PR.  According to https://docs.nvidia.com/cuda/cuda-runtime-api/api-sync-behavior.html#api-sync-behavior__memcpy-async, it might sync with respect to host.
In practice, the current behavior synchronizes during the `cudaMemcpyAsync`, so we have two sync - copy and explicit sync actually. Unfortunately, we can not eliminate the sync because cuda only mentions it "might" sync.

