### PR TITLE
Reduce the number of copy call in residual norm and allow pinned memory for criterion

### DIFF
--- a/core/solver/bicg.cpp
+++ b/core/solver/bicg.cpp
@@ -134,7 +134,6 @@ void Bicg<ValueType>::apply_dense_impl(const matrix::Dense<ValueType>* dense_b,
 
     GKO_SOLVER_ONE_MINUS_ONE();
 
-    bool one_changed{};
     GKO_SOLVER_STOP_REDUCTION_ARRAYS();
 
     // rho = 0.0
@@ -195,13 +194,13 @@ void Bicg<ValueType>::apply_dense_impl(const matrix::Dense<ValueType>* dense_b,
         z->compute_conj_dot(r2, rho, reduction_tmp);
 
         ++iter;
-        bool all_stopped =
-            stop_criterion->update()
-                .num_iterations(iter)
-                .residual(r)
-                .implicit_sq_residual_norm(rho)
-                .solution(dense_x)
-                .check(RelativeStoppingId, true, &stop_status, &one_changed);
+        bool all_stopped = stop_criterion->update()
+                               .num_iterations(iter)
+                               .residual(r)
+                               .implicit_sq_residual_norm(rho)
+                               .solution(dense_x)
+                               .check(RelativeStoppingId, true, &stop_status,
+                                      stop_indicators.get_data());
         this->template log<log::Logger::iteration_complete>(
             this, dense_b, dense_x, iter, r, nullptr, rho, &stop_status,
             all_stopped);
@@ -251,7 +250,7 @@ void Bicg<ValueType>::apply_impl(const LinOp* alpha, const LinOp* b,
 template <typename ValueType>
 int workspace_traits<Bicg<ValueType>>::num_arrays(const Solver&)
 {
-    return 2;
+    return 3;
 }
 
 

--- a/core/solver/cg.cpp
+++ b/core/solver/cg.cpp
@@ -112,7 +112,6 @@ void Cg<ValueType>::apply_dense_impl(const VectorType* dense_b,
 
     GKO_SOLVER_ONE_MINUS_ONE();
 
-    bool one_changed{};
     GKO_SOLVER_STOP_REDUCTION_ARRAYS();
 
     // r = dense_b
@@ -146,13 +145,13 @@ void Cg<ValueType>::apply_dense_impl(const VectorType* dense_b,
         r->compute_conj_dot(z, rho, reduction_tmp);
 
         ++iter;
-        bool all_stopped =
-            stop_criterion->update()
-                .num_iterations(iter)
-                .residual(r)
-                .implicit_sq_residual_norm(rho)
-                .solution(dense_x)
-                .check(RelativeStoppingId, true, &stop_status, &one_changed);
+        bool all_stopped = stop_criterion->update()
+                               .num_iterations(iter)
+                               .residual(r)
+                               .implicit_sq_residual_norm(rho)
+                               .solution(dense_x)
+                               .check(RelativeStoppingId, true, &stop_status,
+                                      stop_indicators.get_data());
         this->template log<log::Logger::iteration_complete>(
             this, dense_b, dense_x, iter, r, nullptr, rho, &stop_status,
             all_stopped);
@@ -202,7 +201,7 @@ void Cg<ValueType>::apply_impl(const LinOp* alpha, const LinOp* b,
 template <typename ValueType>
 int workspace_traits<Cg<ValueType>>::num_arrays(const Solver&)
 {
-    return 2;
+    return 3;
 }
 
 

--- a/core/solver/cgs.cpp
+++ b/core/solver/cgs.cpp
@@ -118,7 +118,6 @@ void Cgs<ValueType>::apply_dense_impl(const VectorType* dense_b,
 
     GKO_SOLVER_ONE_MINUS_ONE();
 
-    bool one_changed{};
     GKO_SOLVER_STOP_REDUCTION_ARRAYS();
 
     // r = dense_b
@@ -155,13 +154,13 @@ void Cgs<ValueType>::apply_dense_impl(const VectorType* dense_b,
         r->compute_conj_dot(r_tld, rho, reduction_tmp);
 
         ++iter;
-        bool all_stopped =
-            stop_criterion->update()
-                .num_iterations(iter)
-                .residual(r)
-                .implicit_sq_residual_norm(rho)
-                .solution(dense_x)
-                .check(RelativeStoppingId, true, &stop_status, &one_changed);
+        bool all_stopped = stop_criterion->update()
+                               .num_iterations(iter)
+                               .residual(r)
+                               .implicit_sq_residual_norm(rho)
+                               .solution(dense_x)
+                               .check(RelativeStoppingId, true, &stop_status,
+                                      stop_indicators.get_data());
         this->template log<log::Logger::iteration_complete>(
             this, dense_b, dense_x, iter, r, nullptr, rho, &stop_status,
             all_stopped);
@@ -222,7 +221,7 @@ void Cgs<ValueType>::apply_impl(const LinOp* alpha, const LinOp* b,
 template <typename ValueType>
 int workspace_traits<Cgs<ValueType>>::num_arrays(const Solver&)
 {
-    return 2;
+    return 3;
 }
 
 

--- a/core/solver/chebyshev.cpp
+++ b/core/solver/chebyshev.cpp
@@ -225,6 +225,11 @@ void Chebyshev<ValueType>::apply_dense_impl(const VectorType* dense_b,
     auto& stop_status = this->template create_workspace_array<stopping_status>(
         ws::stop, dense_b->get_size()[1]);
     exec->run(ir::make_initialize(&stop_status));
+    exec->run(ir::make_initialize(&stop_status));
+    auto& stop_indicators =
+        this->template create_workspace_array<bool>(ws::indicators, 2);
+    stop_indicators.set_executor(this->get_executor()->get_master());
+    stop_indicators.get_data()[0] = false;
     if (guess != initial_guess_mode::zero) {
         residual->copy_from(dense_b);
         this->get_system_matrix()->apply(neg_one_op, dense_x, one_op, residual);
@@ -251,7 +256,7 @@ void Chebyshev<ValueType>::apply_dense_impl(const VectorType* dense_b,
         };
         bool all_stopped = update_residual(
             this, iter, dense_b, dense_x, residual, residual_ptr,
-            stop_criterion, stop_status, log_func);
+            stop_criterion, stop_status, &stop_indicators, log_func);
         if (all_stopped) {
             break;
         }
@@ -321,7 +326,7 @@ void Chebyshev<ValueType>::apply_with_initial_guess_impl(
 template <typename ValueType>
 int workspace_traits<Chebyshev<ValueType>>::num_arrays(const Solver&)
 {
-    return 1;
+    return 2;
 }
 
 

--- a/core/solver/fcg.cpp
+++ b/core/solver/fcg.cpp
@@ -112,7 +112,6 @@ void Fcg<ValueType>::apply_dense_impl(const VectorType* dense_b,
 
     GKO_SOLVER_ONE_MINUS_ONE();
 
-    bool one_changed{};
     GKO_SOLVER_STOP_REDUCTION_ARRAYS();
 
     // r = dense_b
@@ -148,13 +147,13 @@ void Fcg<ValueType>::apply_dense_impl(const VectorType* dense_b,
         t->compute_conj_dot(z, rho_t, reduction_tmp);
 
         ++iter;
-        bool all_stopped =
-            stop_criterion->update()
-                .num_iterations(iter)
-                .residual(r)
-                .implicit_sq_residual_norm(rho)
-                .solution(dense_x)
-                .check(RelativeStoppingId, true, &stop_status, &one_changed);
+        bool all_stopped = stop_criterion->update()
+                               .num_iterations(iter)
+                               .residual(r)
+                               .implicit_sq_residual_norm(rho)
+                               .solution(dense_x)
+                               .check(RelativeStoppingId, true, &stop_status,
+                                      stop_indicators.get_data());
         this->template log<log::Logger::iteration_complete>(
             this, dense_b, dense_x, iter, r, nullptr, rho, &stop_status,
             all_stopped);
@@ -204,7 +203,7 @@ void Fcg<ValueType>::apply_impl(const LinOp* alpha, const LinOp* b,
 template <typename ValueType>
 int workspace_traits<Fcg<ValueType>>::num_arrays(const Solver&)
 {
-    return 2;
+    return 3;
 }
 
 

--- a/core/solver/gcr.cpp
+++ b/core/solver/gcr.cpp
@@ -136,8 +136,6 @@ void Gcr<ValueType>::apply_dense_impl(const VectorType* dense_b,
     auto& final_iter_nums = this->template create_workspace_array<size_type>(
         ws::final_iter_nums, num_rhs);
 
-    // indicates if the status of a vector has changed
-    bool one_changed{};
     GKO_SOLVER_ONE_MINUS_ONE();
     GKO_SOLVER_STOP_REDUCTION_ARRAYS();
 
@@ -196,13 +194,13 @@ void Gcr<ValueType>::apply_dense_impl(const VectorType* dense_b,
         residual->compute_norm2(residual_norm, reduction_tmp);
 
         // Should the iteration stop?
-        auto all_stopped =
-            stop_criterion->update()
-                .num_iterations(total_iter)
-                .residual(residual)
-                .residual_norm(residual_norm)
-                .solution(dense_x)
-                .check(RelativeStoppingId, true, &stop_status, &one_changed);
+        auto all_stopped = stop_criterion->update()
+                               .num_iterations(total_iter)
+                               .residual(residual)
+                               .residual_norm(residual_norm)
+                               .solution(dense_x)
+                               .check(RelativeStoppingId, true, &stop_status,
+                                      stop_indicators.get_data());
 
         // Log current iteration
         this->template log<log::Logger::iteration_complete>(
@@ -320,7 +318,7 @@ void Gcr<ValueType>::apply_impl(const LinOp* alpha, const LinOp* b,
 template <typename ValueType>
 int workspace_traits<Gcr<ValueType>>::num_arrays(const Solver&)
 {
-    return 3;
+    return 4;
 }
 
 

--- a/core/solver/gmres.cpp
+++ b/core/solver/gmres.cpp
@@ -395,7 +395,6 @@ void Gmres<ValueType>::apply_dense_impl(const VectorType* dense_b,
 
     GKO_SOLVER_ONE_MINUS_ONE();
 
-    bool one_changed{};
     GKO_SOLVER_STOP_REDUCTION_ARRAYS();
     auto& final_iter_nums = this->template create_workspace_array<size_type>(
         ws::final_iter_nums, num_rhs);
@@ -448,13 +447,13 @@ void Gmres<ValueType>::apply_dense_impl(const VectorType* dense_b,
      */
     while (true) {
         ++total_iter;
-        bool all_stopped =
-            stop_criterion->update()
-                .num_iterations(total_iter)
-                .residual(residual)
-                .residual_norm(residual_norm)
-                .solution(dense_x)
-                .check(RelativeStoppingId, false, &stop_status, &one_changed);
+        bool all_stopped = stop_criterion->update()
+                               .num_iterations(total_iter)
+                               .residual(residual)
+                               .residual_norm(residual_norm)
+                               .solution(dense_x)
+                               .check(RelativeStoppingId, false, &stop_status,
+                                      stop_indicators.get_data());
         this->template log<log::Logger::iteration_complete>(
             this, dense_b, dense_x, total_iter, residual, residual_norm,
             nullptr, &stop_status, all_stopped);
@@ -650,7 +649,7 @@ void Gmres<ValueType>::apply_impl(const LinOp* alpha, const LinOp* b,
 template <typename ValueType>
 int workspace_traits<Gmres<ValueType>>::num_arrays(const Solver&)
 {
-    return 3;
+    return 4;
 }
 
 

--- a/core/solver/idr.cpp
+++ b/core/solver/idr.cpp
@@ -157,7 +157,6 @@ void Idr<ValueType>::iterate(const VectorType* dense_b,
             ws::subspace_minus_one, 1);
     subspace_neg_one_op->fill(-one<SubspaceType>());
 
-    bool one_changed{};
     GKO_SOLVER_STOP_REDUCTION_ARRAYS();
 
     // Initialization
@@ -212,13 +211,13 @@ void Idr<ValueType>::iterate(const VectorType* dense_b,
     while (true) {
         ++total_iter;
 
-        bool all_stopped =
-            stop_criterion->update()
-                .num_iterations(total_iter)
-                .residual(residual)
-                .residual_norm(residual_norm)
-                .solution(dense_x)
-                .check(RelativeStoppingId, true, &stop_status, &one_changed);
+        bool all_stopped = stop_criterion->update()
+                               .num_iterations(total_iter)
+                               .residual(residual)
+                               .residual_norm(residual_norm)
+                               .solution(dense_x)
+                               .check(RelativeStoppingId, true, &stop_status,
+                                      stop_indicators.get_data());
         this->template log<log::Logger::iteration_complete>(
             this, dense_b, dense_x, total_iter, residual, nullptr, nullptr,
             &stop_status, all_stopped);
@@ -348,7 +347,7 @@ void Idr<ValueType>::apply_impl(const LinOp* alpha, const LinOp* b,
 template <typename ValueType>
 int workspace_traits<Idr<ValueType>>::num_arrays(const Solver&)
 {
-    return 2;
+    return 3;
 }
 
 

--- a/core/solver/minres.cpp
+++ b/core/solver/minres.cpp
@@ -153,7 +153,6 @@ void Minres<ValueType>::apply_dense_impl(const VectorType* dense_b,
 
     GKO_SOLVER_ONE_MINUS_ONE();
 
-    bool one_changed{};
     GKO_SOLVER_STOP_REDUCTION_ARRAYS();
 
     // r = dense_b
@@ -198,13 +197,13 @@ void Minres<ValueType>::apply_dense_impl(const VectorType* dense_b,
      */
     while (true) {
         ++iter;
-        bool all_stopped =
-            stop_criterion->update()
-                .num_iterations(iter)
-                .residual(nullptr)
-                .implicit_sq_residual_norm(tau)
-                .solution(dense_x)
-                .check(RelativeStoppingId, true, &stop_status, &one_changed);
+        bool all_stopped = stop_criterion->update()
+                               .num_iterations(iter)
+                               .residual(nullptr)
+                               .implicit_sq_residual_norm(tau)
+                               .solution(dense_x)
+                               .check(RelativeStoppingId, true, &stop_status,
+                                      stop_indicators.get_data());
         this->template log<log::Logger::iteration_complete>(
             this, dense_b, dense_x, iter, r, nullptr, tau, &stop_status,
             all_stopped);
@@ -331,7 +330,7 @@ int workspace_traits<Minres<ValueType>>::num_vectors(const Solver&)
 template <typename ValueType>
 int workspace_traits<Minres<ValueType>>::num_arrays(const Solver&)
 {
-    return 2;
+    return 3;
 }
 
 

--- a/core/solver/pipe_cg.cpp
+++ b/core/solver/pipe_cg.cpp
@@ -119,8 +119,6 @@ void PipeCg<ValueType>::apply_dense_impl(const VectorType* dense_b,
 
     GKO_SOLVER_ONE_MINUS_ONE();
 
-    bool one_changed{};
-
     GKO_SOLVER_STOP_REDUCTION_ARRAYS();
 
     // r = b
@@ -149,13 +147,13 @@ void PipeCg<ValueType>::apply_dense_impl(const VectorType* dense_b,
         this->get_system_matrix(),
         std::shared_ptr<const LinOp>(dense_b, [](const LinOp*) {}), dense_x, r);
     int iter = 0;
-    bool all_stopped =
-        stop_criterion->update()
-            .num_iterations(iter)
-            .residual(r)
-            .implicit_sq_residual_norm(rho)
-            .solution(dense_x)
-            .check(RelativeStoppingId, true, &stop_status, &one_changed);
+    bool all_stopped = stop_criterion->update()
+                           .num_iterations(iter)
+                           .residual(r)
+                           .implicit_sq_residual_norm(rho)
+                           .solution(dense_x)
+                           .check(RelativeStoppingId, true, &stop_status,
+                                  stop_indicators.get_data());
     this->template log<log::Logger::iteration_complete>(
         this, dense_b, dense_x, iter, r, nullptr, rho, &stop_status,
         all_stopped);
@@ -202,13 +200,13 @@ void PipeCg<ValueType>::apply_dense_impl(const VectorType* dense_b,
         w->compute_conj_dot(z, delta, reduction_tmp);
         // check
         ++iter;
-        bool all_stopped =
-            stop_criterion->update()
-                .num_iterations(iter)
-                .residual(r)
-                .implicit_sq_residual_norm(rho)
-                .solution(dense_x)
-                .check(RelativeStoppingId, true, &stop_status, &one_changed);
+        bool all_stopped = stop_criterion->update()
+                               .num_iterations(iter)
+                               .residual(r)
+                               .implicit_sq_residual_norm(rho)
+                               .solution(dense_x)
+                               .check(RelativeStoppingId, true, &stop_status,
+                                      stop_indicators.get_data());
         this->template log<log::Logger::iteration_complete>(
             this, dense_b, dense_x, iter, r, nullptr, rho, &stop_status,
             all_stopped);
@@ -252,7 +250,7 @@ void PipeCg<ValueType>::apply_impl(const LinOp* alpha, const LinOp* b,
 template <typename ValueType>
 int workspace_traits<PipeCg<ValueType>>::num_arrays(const Solver&)
 {
-    return 2;
+    return 3;
 }
 
 

--- a/core/solver/solver_boilerplate.hpp
+++ b/core/solver/solver_boilerplate.hpp
@@ -25,9 +25,13 @@
     auto neg_one_op = this->template create_workspace_fixed_scalar<ValueType>( \
         GKO_SOLVER_TRAITS::minus_one, 1, -one<ValueType>())
 
-#define GKO_SOLVER_STOP_REDUCTION_ARRAYS()                      \
-    auto& stop_status =                                         \
-        this->template create_workspace_array<stopping_status>( \
-            GKO_SOLVER_TRAITS::stop, dense_b->get_size()[1]);   \
-    auto& reduction_tmp =                                       \
-        this->template create_workspace_array<char>(GKO_SOLVER_TRAITS::tmp)
+#define GKO_SOLVER_STOP_REDUCTION_ARRAYS()                                   \
+    auto& stop_status =                                                      \
+        this->template create_workspace_array<stopping_status>(              \
+            GKO_SOLVER_TRAITS::stop, dense_b->get_size()[1]);                \
+    auto& reduction_tmp =                                                    \
+        this->template create_workspace_array<char>(GKO_SOLVER_TRAITS::tmp); \
+    auto& stop_indicators = this->template create_workspace_array<bool>(     \
+        GKO_SOLVER_TRAITS::indicators, 2);                                   \
+    stop_indicators.set_executor(this->get_executor()->get_master());        \
+    stop_indicators.get_data()[0] = false

--- a/core/solver/update_residual.hpp
+++ b/core/solver/update_residual.hpp
@@ -21,7 +21,8 @@ bool update_residual(SolverType* solver, int iter, const VectorType* dense_b,
                      VectorType* dense_x, VectorType* residual,
                      const VectorType*& residual_ptr,
                      std::unique_ptr<gko::stop::Criterion>& stop_criterion,
-                     array<stopping_status>& stop_status, LogFunc log)
+                     array<stopping_status>& stop_status,
+                     array<bool>* stop_indicators, LogFunc log)
 {
     using ws = workspace_traits<std::remove_cv_t<SolverType>>;
     constexpr uint8 relative_stopping_id{1};
@@ -30,27 +31,26 @@ bool update_residual(SolverType* solver, int iter, const VectorType* dense_b,
     auto one_op = solver->get_workspace_op(ws::one);
     auto neg_one_op = solver->get_workspace_op(ws::minus_one);
 
-    bool one_changed{};
     if (iter == 0) {
         // In iter 0, the iteration and residual are updated.
-        bool all_stopped =
-            stop_criterion->update()
-                .num_iterations(iter)
-                .residual(residual_ptr)
-                .solution(dense_x)
-                .check(relative_stopping_id, true, &stop_status, &one_changed);
+        bool all_stopped = stop_criterion->update()
+                               .num_iterations(iter)
+                               .residual(residual_ptr)
+                               .solution(dense_x)
+                               .check(relative_stopping_id, true, &stop_status,
+                                      stop_indicators->get_data());
         log(solver, dense_b, dense_x, iter, residual_ptr, stop_status,
             all_stopped);
         return all_stopped;
     } else {
         // In the other iterations, the residual can be updated separately.
-        bool all_stopped =
-            stop_criterion->update()
-                .num_iterations(iter)
-                .solution(dense_x)
-                // we have the residual check later
-                .ignore_residual_check(true)
-                .check(relative_stopping_id, false, &stop_status, &one_changed);
+        bool all_stopped = stop_criterion->update()
+                               .num_iterations(iter)
+                               .solution(dense_x)
+                               // we have the residual check later
+                               .ignore_residual_check(true)
+                               .check(relative_stopping_id, false, &stop_status,
+                                      stop_indicators->get_data());
         if (all_stopped) {
             log(solver, dense_b, dense_x, iter, nullptr, stop_status,
                 all_stopped);
@@ -61,12 +61,12 @@ bool update_residual(SolverType* solver, int iter, const VectorType* dense_b,
         residual->copy_from(dense_b);
         solver->get_system_matrix()->apply(neg_one_op, dense_x, one_op,
                                            residual);
-        all_stopped =
-            stop_criterion->update()
-                .num_iterations(iter)
-                .residual(residual_ptr)
-                .solution(dense_x)
-                .check(relative_stopping_id, true, &stop_status, &one_changed);
+        all_stopped = stop_criterion->update()
+                          .num_iterations(iter)
+                          .residual(residual_ptr)
+                          .solution(dense_x)
+                          .check(relative_stopping_id, true, &stop_status,
+                                 stop_indicators->get_data());
         log(solver, dense_b, dense_x, iter, residual_ptr, stop_status,
             all_stopped);
         return all_stopped;

--- a/core/stop/iteration.cpp
+++ b/core/stop/iteration.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -11,12 +11,12 @@ namespace stop {
 
 bool Iteration::check_impl(uint8 stoppingId, bool setFinalized,
                            array<stopping_status>* stop_status,
-                           bool* one_changed, const Updater& updater)
+                           bool* indicators, const Updater& updater)
 {
     bool result = updater.num_iterations_ >= parameters_.max_iters;
     if (result) {
         this->set_all_statuses(stoppingId, setFinalized, stop_status);
-        *one_changed = true;
+        *indicators = true;
     }
     return result;
 }

--- a/core/stop/residual_norm.cpp
+++ b/core/stop/residual_norm.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -162,7 +162,7 @@ ResidualNormBase<ValueType>::ResidualNormBase(
 template <typename ValueType>
 bool ResidualNormBase<ValueType>::check_impl(
     uint8 stopping_id, bool set_finalized, array<stopping_status>* stop_status,
-    bool* one_changed, const Criterion::Updater& updater)
+    bool* indicators, const Criterion::Updater& updater)
 {
     const NormVector* dense_tau;
     if (updater.residual_norm_ != nullptr) {
@@ -197,7 +197,7 @@ bool ResidualNormBase<ValueType>::check_impl(
     this->get_executor()->run(residual_norm::make_residual_norm(
         dense_tau, starting_tau_.get(), reduction_factor_, stopping_id,
         set_finalized, stop_status, &device_storage_, &all_converged,
-        one_changed));
+        indicators));
 
     return all_converged;
 }
@@ -206,7 +206,7 @@ bool ResidualNormBase<ValueType>::check_impl(
 template <typename ValueType>
 bool ImplicitResidualNorm<ValueType>::check_impl(
     uint8 stopping_id, bool set_finalized, array<stopping_status>* stop_status,
-    bool* one_changed, const Criterion::Updater& updater)
+    bool* indicators, const Criterion::Updater& updater)
 {
     const Vector* dense_tau;
     if (updater.implicit_sq_residual_norm_ != nullptr) {
@@ -220,7 +220,7 @@ bool ImplicitResidualNorm<ValueType>::check_impl(
         implicit_residual_norm::make_implicit_residual_norm(
             dense_tau, this->starting_tau_.get(), this->reduction_factor_,
             stopping_id, set_finalized, stop_status, &this->device_storage_,
-            &all_converged, one_changed));
+            &all_converged, indicators));
 
     return all_converged;
 }

--- a/core/stop/residual_norm_kernels.hpp
+++ b/core/stop/residual_norm_kernels.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -24,7 +24,7 @@ namespace residual_norm {
         const matrix::Dense<_type>* tau, const matrix::Dense<_type>* orig_tau, \
         _type rel_residual_goal, uint8 stoppingId, bool setFinalized,          \
         array<stopping_status>* stop_status, array<bool>* device_storage,      \
-        bool* all_converged, bool* one_changed)
+        bool* all_converged, bool* indicators)
 
 
 #define GKO_DECLARE_ALL_AS_TEMPLATES \
@@ -45,7 +45,7 @@ namespace implicit_residual_norm {
         const matrix::Dense<remove_complex<_type>>* orig_tau,      \
         remove_complex<_type> rel_residual_goal, uint8 stoppingId, \
         bool setFinalized, array<stopping_status>* stop_status,    \
-        array<bool>* device_storage, bool* all_converged, bool* one_changed)
+        array<bool>* device_storage, bool* all_converged, bool* indicators)
 
 
 #define GKO_DECLARE_ALL_AS_TEMPLATES2 \

--- a/core/stop/time.cpp
+++ b/core/stop/time.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -10,13 +10,13 @@ namespace stop {
 
 
 bool Time::check_impl(uint8 stoppingId, bool setFinalized,
-                      array<stopping_status>* stop_status, bool* one_changed,
+                      array<stopping_status>* stop_status, bool* indicators,
                       const Updater& updater)
 {
     bool result = clock::now() - start_ >= time_limit_;
     if (result) {
         this->set_all_statuses(stoppingId, setFinalized, stop_status);
-        *one_changed = true;
+        *indicators = true;
     }
     return result;
 }

--- a/core/test/stop/criterion.cpp
+++ b/core/test/stop/criterion.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -56,7 +56,7 @@ public:
 protected:
     bool check_impl(gko::uint8 stopping_id, bool set_finalized,
                     gko::array<gko::stopping_status>* stop_status,
-                    bool* one_changed, const Updater& updater) override
+                    bool* indicators, const Updater& updater) override
     {
         return true;
     }
@@ -95,10 +95,10 @@ TEST_F(Criterion, DefaultUpdateStatus)
 TEST_F(Criterion, CanLogCheck)
 {
     auto before_logger = *logger;
-    bool one_changed = false;
+    gko::array<bool> stop_indicators(exec->get_master(), 2);
 
-    criterion->check(gko::uint8(0), false, &stopping_status, &one_changed,
-                     criterion->update());
+    criterion->check(gko::uint8(0), false, &stopping_status,
+                     stop_indicators.get_data(), criterion->update());
 
     ASSERT_EQ(logger->criterion_check_started,
               before_logger.criterion_check_started + 1);

--- a/examples/custom-stopping-criterion/custom-stopping-criterion.cpp
+++ b/examples/custom-stopping-criterion/custom-stopping-criterion.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -37,12 +37,12 @@ public:
 protected:
     bool check_impl(gko::uint8 stoppingId, bool setFinalized,
                     gko::array<gko::stopping_status>* stop_status,
-                    bool* one_changed, const Criterion::Updater&) override
+                    bool* indicators, const Criterion::Updater&) override
     {
         bool result = *(parameters_.stop_iteration_process);
         if (result) {
             this->set_all_statuses(stoppingId, setFinalized, stop_status);
-            *one_changed = true;
+            *indicators = true;
         }
         return result;
     }

--- a/include/ginkgo/core/solver/bicg.hpp
+++ b/include/ginkgo/core/solver/bicg.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -170,6 +170,8 @@ struct workspace_traits<Bicg<ValueType>> {
     constexpr static int stop = 0;
     // reduction tmp array
     constexpr static int tmp = 1;
+    // stopping indicator array
+    constexpr static int indicators = 2;
 };
 
 

--- a/include/ginkgo/core/solver/bicgstab.hpp
+++ b/include/ginkgo/core/solver/bicgstab.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -174,6 +174,8 @@ struct workspace_traits<Bicgstab<ValueType>> {
     constexpr static int stop = 0;
     // reduction tmp array
     constexpr static int tmp = 1;
+    // stopping indicator array
+    constexpr static int indicators = 2;
 };
 
 

--- a/include/ginkgo/core/solver/cg.hpp
+++ b/include/ginkgo/core/solver/cg.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -156,6 +156,8 @@ struct workspace_traits<Cg<ValueType>> {
     constexpr static int stop = 0;
     // reduction tmp array
     constexpr static int tmp = 1;
+    // stopping indicator array
+    constexpr static int indicators = 2;
 };
 
 

--- a/include/ginkgo/core/solver/cgs.hpp
+++ b/include/ginkgo/core/solver/cgs.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -165,6 +165,8 @@ struct workspace_traits<Cgs<ValueType>> {
     constexpr static int stop = 0;
     // reduction tmp array
     constexpr static int tmp = 1;
+    // stopping indicator array
+    constexpr static int indicators = 2;
 };
 
 

--- a/include/ginkgo/core/solver/chebyshev.hpp
+++ b/include/ginkgo/core/solver/chebyshev.hpp
@@ -224,6 +224,8 @@ struct workspace_traits<Chebyshev<ValueType>> {
 
     // stopping status array
     constexpr static int stop = 0;
+    // stopping indicator array
+    constexpr static int indicators = 1;
 };
 
 

--- a/include/ginkgo/core/solver/fcg.hpp
+++ b/include/ginkgo/core/solver/fcg.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -165,6 +165,8 @@ struct workspace_traits<Fcg<ValueType>> {
     constexpr static int stop = 0;
     // reduction tmp array
     constexpr static int tmp = 1;
+    // stopping indicator array
+    constexpr static int indicators = 2;
 };
 
 

--- a/include/ginkgo/core/solver/gcr.hpp
+++ b/include/ginkgo/core/solver/gcr.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -183,6 +183,8 @@ struct workspace_traits<Gcr<ValueType>> {
     constexpr static int tmp = 1;
     // final iteration number array
     constexpr static int final_iter_nums = 2;
+    // stopping indicator array
+    constexpr static int indicators = 3;
 };
 
 

--- a/include/ginkgo/core/solver/gmres.hpp
+++ b/include/ginkgo/core/solver/gmres.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -225,6 +225,8 @@ struct workspace_traits<Gmres<ValueType>> {
     constexpr static int tmp = 1;
     // final iteration number array
     constexpr static int final_iter_nums = 2;
+    // stopping indicator array
+    constexpr static int indicators = 3;
 };
 
 

--- a/include/ginkgo/core/solver/idr.hpp
+++ b/include/ginkgo/core/solver/idr.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -292,6 +292,8 @@ struct workspace_traits<Idr<ValueType>> {
     constexpr static int stop = 0;
     // reduction tmp array
     constexpr static int tmp = 1;
+    // stopping indicator array
+    constexpr static int indicators = 2;
 };
 
 

--- a/include/ginkgo/core/solver/ir.hpp
+++ b/include/ginkgo/core/solver/ir.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -285,6 +285,8 @@ struct workspace_traits<Ir<ValueType>> {
 
     // stopping status array
     constexpr static int stop = 0;
+    // stopping indicator array
+    constexpr static int indicators = 1;
 };
 
 

--- a/include/ginkgo/core/solver/minres.hpp
+++ b/include/ginkgo/core/solver/minres.hpp
@@ -180,6 +180,8 @@ struct workspace_traits<Minres<ValueType>> {
     constexpr static int stop = 0;
     // reduction tmp array
     constexpr static int tmp = 1;
+    // stopping indicator array
+    constexpr static int indicators = 2;
 };
 
 

--- a/include/ginkgo/core/solver/multigrid.hpp
+++ b/include/ginkgo/core/solver/multigrid.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -503,6 +503,8 @@ struct workspace_traits<Multigrid> {
 
     // stopping status array
     constexpr static int stop = 0;
+    // stopping indicator array
+    constexpr static int indicators = 1;
 };
 
 

--- a/include/ginkgo/core/solver/pipe_cg.hpp
+++ b/include/ginkgo/core/solver/pipe_cg.hpp
@@ -182,6 +182,8 @@ struct workspace_traits<PipeCg<ValueType>> {
     constexpr static int stop = 0;
     // reduction tmp array
     constexpr static int tmp = 1;
+    // stopping indicator array
+    constexpr static int indicators = 2;
 };
 
 

--- a/include/ginkgo/core/stop/combined.hpp
+++ b/include/ginkgo/core/stop/combined.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -72,7 +72,7 @@ public:
 
 protected:
     bool check_impl(uint8 stoppingId, bool setFinalized,
-                    array<stopping_status>* stop_status, bool* one_changed,
+                    array<stopping_status>* stop_status, bool* indicators,
                     const Updater&) override;
 
     explicit Combined(std::shared_ptr<const gko::Executor> exec);

--- a/include/ginkgo/core/stop/criterion.hpp
+++ b/include/ginkgo/core/stop/criterion.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -71,10 +71,10 @@ public:
          * @copydoc Criterion::check(uint8, bool, array<stopping_status>, bool)
          */
         bool check(uint8 stopping_id, bool set_finalized,
-                   array<stopping_status>* stop_status, bool* one_changed) const
+                   array<stopping_status>* stop_status, bool* indicators) const
         {
             auto converged = parent_->check(stopping_id, set_finalized,
-                                            stop_status, one_changed, *this);
+                                            stop_status, indicators, *this);
             return converged;
         }
 
@@ -129,26 +129,28 @@ public:
      * @param set_finalized  Controls if the current version should count as
      *                      finalized or not
      * @param stop_status  status of the stopping criterion
-     * @param one_changed  indicates if the status of a vector has changed
+     * @param indicators  it should be a bool pointer to the host array
+     *                    containing at least two elements. The first entry will
+     *                    indicate if the status of a vector has changed.
      * @param updater  the Updater object containing all the information
      *
      * @returns whether convergence was completely reached
      */
     bool check(uint8 stopping_id, bool set_finalized,
-               array<stopping_status>* stop_status, bool* one_changed,
+               array<stopping_status>* stop_status, bool* indecators,
                const Updater& updater)
     {
         this->template log<log::Logger::criterion_check_started>(
             this, updater.num_iterations_, updater.residual_,
             updater.residual_norm_, updater.solution_, stopping_id,
             set_finalized);
-        auto all_converged = this->check_impl(
-            stopping_id, set_finalized, stop_status, one_changed, updater);
+        auto all_converged = this->check_impl(stopping_id, set_finalized,
+                                              stop_status, indecators, updater);
         this->template log<log::Logger::criterion_check_completed>(
             this, updater.num_iterations_, updater.residual_,
             updater.residual_norm_, updater.implicit_sq_residual_norm_,
             updater.solution_, stopping_id, set_finalized, stop_status,
-            *one_changed, all_converged);
+            *indecators, all_converged);
         return all_converged;
     }
 
@@ -164,14 +166,16 @@ protected:
      * @param set_finalized  Controls if the current version should count as
      *                      finalized or not
      * @param stop_status  status of the stopping criterion
-     * @param one_changed  indicates if the status of a vector has changed
+     * @param indicators  it should be a bool pointer to the host array
+     *                    containing at least two elements. The first entry will
+     *                    indicate if the status of a vector has changed.
      * @param updater  the Updater object containing all the information
      *
      * @returns whether convergence was completely reached
      */
     virtual bool check_impl(uint8 stopping_id, bool set_finalized,
                             array<stopping_status>* stop_status,
-                            bool* one_changed, const Updater& updater) = 0;
+                            bool* indicators, const Updater& updater) = 0;
 
     /**
      * This is a helper function which properly sets all elements of the

--- a/include/ginkgo/core/stop/iteration.hpp
+++ b/include/ginkgo/core/stop/iteration.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -37,7 +37,7 @@ public:
 
 protected:
     bool check_impl(uint8 stoppingId, bool setFinalized,
-                    array<stopping_status>* stop_status, bool* one_changed,
+                    array<stopping_status>* stop_status, bool* indicators,
                     const Updater& updater) override;
 
     explicit Iteration(std::shared_ptr<const gko::Executor> exec)

--- a/include/ginkgo/core/stop/residual_norm.hpp
+++ b/include/ginkgo/core/stop/residual_norm.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -59,7 +59,7 @@ protected:
     using NormVector = matrix::Dense<absolute_type>;
     using Vector = matrix::Dense<ValueType>;
     bool check_impl(uint8 stoppingId, bool setFinalized,
-                    array<stopping_status>* stop_status, bool* one_changed,
+                    array<stopping_status>* stop_status, bool* indicators,
                     const Criterion::Updater& updater) override;
 
     explicit ResidualNormBase(std::shared_ptr<const gko::Executor> exec)
@@ -196,7 +196,7 @@ protected:
     // check_impl needs to be overwritten again since we focus on the implicit
     // residual here
     bool check_impl(uint8 stoppingId, bool setFinalized,
-                    array<stopping_status>* stop_status, bool* one_changed,
+                    array<stopping_status>* stop_status, bool* indicators,
                     const Criterion::Updater& updater) override;
 
     explicit ImplicitResidualNorm(std::shared_ptr<const gko::Executor> exec)

--- a/include/ginkgo/core/stop/time.hpp
+++ b/include/ginkgo/core/stop/time.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -39,7 +39,7 @@ public:
 
 protected:
     bool check_impl(uint8 stoppingId, bool setFinalized,
-                    array<stopping_status>* stop_status, bool* one_changed,
+                    array<stopping_status>* stop_status, bool* indicators,
                     const Updater&) override;
 
     explicit Time(std::shared_ptr<const gko::Executor> exec)

--- a/omp/stop/residual_norm_kernels.cpp
+++ b/omp/stop/residual_norm_kernels.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -28,7 +28,7 @@ void residual_norm(std::shared_ptr<const OmpExecutor> exec,
                    ValueType rel_residual_goal, uint8 stoppingId,
                    bool setFinalized, array<stopping_status>* stop_status,
                    array<bool>* device_storage, bool* all_converged,
-                   bool* one_changed)
+                   bool* indicators)
 {
     static_assert(is_complex_s<ValueType>::value == false,
                   "ValueType must not be complex in this function!");
@@ -40,7 +40,7 @@ void residual_norm(std::shared_ptr<const OmpExecutor> exec,
             local_one_changed = true;
         }
     }
-    *one_changed = local_one_changed;
+    *indicators = local_one_changed;
     // No early stopping here because one cannot use break with parallel for
     // But it's parallel so does it matter?
     bool local_all_converged = true;
@@ -75,7 +75,7 @@ void implicit_residual_norm(
     const matrix::Dense<remove_complex<ValueType>>* orig_tau,
     remove_complex<ValueType> rel_residual_goal, uint8 stoppingId,
     bool setFinalized, array<stopping_status>* stop_status,
-    array<bool>* device_storage, bool* all_converged, bool* one_changed)
+    array<bool>* device_storage, bool* all_converged, bool* indicators)
 {
     bool local_one_changed = false;
 #pragma omp parallel for reduction(|| : local_one_changed)
@@ -85,7 +85,7 @@ void implicit_residual_norm(
             local_one_changed = true;
         }
     }
-    *one_changed = local_one_changed;
+    *indicators = local_one_changed;
     // No early stopping here because one cannot use break with parallel for
     // But it's parallel so does it matter?
     bool local_all_converged = true;

--- a/reference/stop/residual_norm_kernels.cpp
+++ b/reference/stop/residual_norm_kernels.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -30,16 +30,16 @@ void residual_norm(std::shared_ptr<const ReferenceExecutor> exec,
                    ValueType rel_residual_goal, uint8 stoppingId,
                    bool setFinalized, array<stopping_status>* stop_status,
                    array<bool>* device_storage, bool* all_converged,
-                   bool* one_changed)
+                   bool* indicators)
 {
     static_assert(is_complex_s<ValueType>::value == false,
                   "ValueType must not be complex in this function!");
     *all_converged = true;
-    *one_changed = false;
+    *indicators = false;
     for (size_type i = 0; i < tau->get_size()[1]; ++i) {
         if (tau->at(i) <= rel_residual_goal * orig_tau->at(i)) {
             stop_status->get_data()[i].converge(stoppingId, setFinalized);
-            *one_changed = true;
+            *indicators = true;
         }
     }
     for (size_type i = 0; i < stop_status->get_size(); ++i) {
@@ -72,14 +72,14 @@ void implicit_residual_norm(
     const matrix::Dense<remove_complex<ValueType>>* orig_tau,
     remove_complex<ValueType> rel_residual_goal, uint8 stoppingId,
     bool setFinalized, array<stopping_status>* stop_status,
-    array<bool>* device_storage, bool* all_converged, bool* one_changed)
+    array<bool>* device_storage, bool* all_converged, bool* indicators)
 {
     *all_converged = true;
-    *one_changed = false;
+    *indicators = false;
     for (size_type i = 0; i < tau->get_size()[1]; ++i) {
         if (sqrt(abs(tau->at(i))) <= rel_residual_goal * orig_tau->at(i)) {
             stop_status->get_data()[i].converge(stoppingId, setFinalized);
-            *one_changed = true;
+            *indicators = true;
         }
     }
     for (size_type i = 0; i < stop_status->get_size(); ++i) {

--- a/reference/test/stop/combined.cpp
+++ b/reference/test/stop/combined.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -63,25 +63,26 @@ protected:
  * the huge time picked. */
 TEST_F(Combined, WaitsTillIteration)
 {
-    bool one_changed{};
+    gko::array<bool> stop_indicators(exec_->get_master(), 2);
+    stop_indicators.get_data()[0] = false;
     gko::array<gko::stopping_status> stop_status(exec_, 1);
     stop_status.get_data()[0].reset();
     constexpr gko::uint8 RelativeStoppingId{1};
     auto criterion = factory_->generate(nullptr, nullptr, nullptr);
     gko::array<bool> converged(exec_, 1);
 
-    ASSERT_FALSE(
-        criterion->update()
-            .num_iterations(test_iterations - 1)
-            .check(RelativeStoppingId, true, &stop_status, &one_changed));
-    ASSERT_TRUE(
-        criterion->update()
-            .num_iterations(test_iterations)
-            .check(RelativeStoppingId, true, &stop_status, &one_changed));
-    ASSERT_TRUE(
-        criterion->update()
-            .num_iterations(test_iterations + 1)
-            .check(RelativeStoppingId, true, &stop_status, &one_changed));
+    ASSERT_FALSE(criterion->update()
+                     .num_iterations(test_iterations - 1)
+                     .check(RelativeStoppingId, true, &stop_status,
+                            stop_indicators.get_data()));
+    ASSERT_TRUE(criterion->update()
+                    .num_iterations(test_iterations)
+                    .check(RelativeStoppingId, true, &stop_status,
+                           stop_indicators.get_data()));
+    ASSERT_TRUE(criterion->update()
+                    .num_iterations(test_iterations + 1)
+                    .check(RelativeStoppingId, true, &stop_status,
+                           stop_indicators.get_data()));
     ASSERT_EQ(static_cast<int>(stop_status.get_data()[0].get_id()), 1);
 }
 
@@ -102,7 +103,8 @@ TEST_F(Combined, WaitsTillTime)
                     .on(exec_))
             .on(exec_);
     unsigned int iters = 0;
-    bool one_changed{};
+    gko::array<bool> stop_indicators(exec_->get_master(), 2);
+    stop_indicators.get_data()[0] = false;
     gko::array<gko::stopping_status> stop_status(exec_, 1);
     stop_status.get_data()[0].reset();
     constexpr gko::uint8 RelativeStoppingId{1};
@@ -112,7 +114,8 @@ TEST_F(Combined, WaitsTillTime)
     for (int i = 0; i < testiters; i++) {
         sleep_millisecond(timelimit_ms / testiters);
         if (criterion->update().num_iterations(i).check(
-                RelativeStoppingId, true, &stop_status, &one_changed))
+                RelativeStoppingId, true, &stop_status,
+                stop_indicators.get_data()))
             break;
     }
     auto time = std::chrono::steady_clock::now() - start;

--- a/reference/test/stop/criterion_kernels.cpp
+++ b/reference/test/stop/criterion_kernels.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -33,7 +33,8 @@ protected:
 
 TEST_F(Criterion, SetsOneStopStatus)
 {
-    bool one_changed{};
+    gko::array<bool> stop_indicators(exec_->get_master(), 2);
+    stop_indicators.get_data()[0] = false;
     constexpr gko::uint8 RelativeStoppingId{1};
     auto criterion = factory_->generate(nullptr, nullptr, nullptr);
     gko::array<gko::stopping_status> stop_status(exec_, 1);
@@ -41,7 +42,8 @@ TEST_F(Criterion, SetsOneStopStatus)
 
     criterion->update()
         .num_iterations(test_iterations)
-        .check(RelativeStoppingId, true, &stop_status, &one_changed);
+        .check(RelativeStoppingId, true, &stop_status,
+               stop_indicators.get_data());
 
     ASSERT_EQ(stop_status.get_data()[0].has_stopped(), true);
 }
@@ -49,7 +51,8 @@ TEST_F(Criterion, SetsOneStopStatus)
 
 TEST_F(Criterion, SetsMultipleStopStatuses)
 {
-    bool one_changed{};
+    gko::array<bool> stop_indicators(exec_->get_master(), 2);
+    stop_indicators.get_data()[0] = false;
     constexpr gko::uint8 RelativeStoppingId{1};
     auto criterion = factory_->generate(nullptr, nullptr, nullptr);
     gko::array<gko::stopping_status> stop_status(exec_, 3);
@@ -59,7 +62,8 @@ TEST_F(Criterion, SetsMultipleStopStatuses)
 
     criterion->update()
         .num_iterations(test_iterations)
-        .check(RelativeStoppingId, true, &stop_status, &one_changed);
+        .check(RelativeStoppingId, true, &stop_status,
+               stop_indicators.get_data());
 
     ASSERT_EQ(stop_status.get_data()[0].has_stopped(), true);
     ASSERT_EQ(stop_status.get_data()[1].has_stopped(), true);

--- a/reference/test/stop/iteration.cpp
+++ b/reference/test/stop/iteration.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -29,24 +29,25 @@ protected:
 
 TEST_F(Iteration, WaitsTillIteration)
 {
-    bool one_changed{};
+    gko::array<bool> stop_indicators(exec_->get_master(), 2);
+    stop_indicators.get_data()[0] = false;
     gko::array<gko::stopping_status> stop_status(exec_, 1);
     stop_status.get_data()[0].reset();
     constexpr gko::uint8 RelativeStoppingId{1};
     auto criterion = factory_->generate(nullptr, nullptr, nullptr);
 
-    ASSERT_FALSE(
-        criterion->update()
-            .num_iterations(test_iterations - 1)
-            .check(RelativeStoppingId, true, &stop_status, &one_changed));
-    ASSERT_TRUE(
-        criterion->update()
-            .num_iterations(test_iterations)
-            .check(RelativeStoppingId, true, &stop_status, &one_changed));
-    ASSERT_TRUE(
-        criterion->update()
-            .num_iterations(test_iterations + 1)
-            .check(RelativeStoppingId, true, &stop_status, &one_changed));
+    ASSERT_FALSE(criterion->update()
+                     .num_iterations(test_iterations - 1)
+                     .check(RelativeStoppingId, true, &stop_status,
+                            stop_indicators.get_data()));
+    ASSERT_TRUE(criterion->update()
+                    .num_iterations(test_iterations)
+                    .check(RelativeStoppingId, true, &stop_status,
+                           stop_indicators.get_data()));
+    ASSERT_TRUE(criterion->update()
+                    .num_iterations(test_iterations + 1)
+                    .check(RelativeStoppingId, true, &stop_status,
+                           stop_indicators.get_data()));
 }
 
 

--- a/reference/test/stop/time.cpp
+++ b/reference/test/stop/time.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -64,15 +64,16 @@ TEST_F(Time, CanCreateCriterion)
 TEST_F(Time, WaitsTillTime)
 {
     auto criterion = factory_->generate(nullptr, nullptr, nullptr);
-    bool one_changed{};
+    gko::array<bool> stop_indicators(exec_->get_master(), 2);
+    stop_indicators.get_data()[0] = false;
     gko::array<gko::stopping_status> stop_status(exec_, 1);
     stop_status.get_data()[0].reset();
     constexpr gko::uint8 RelativeStoppingId{1};
 
     sleep_millisecond(test_ms);
 
-    ASSERT_TRUE(criterion->update().check(RelativeStoppingId, true,
-                                          &stop_status, &one_changed));
+    ASSERT_TRUE(criterion->update().check(
+        RelativeStoppingId, true, &stop_status, stop_indicators.get_data()));
 }
 
 

--- a/test/stop/criterion_kernels.cpp
+++ b/test/stop/criterion_kernels.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -30,7 +30,8 @@ protected:
 
 TEST_F(Criterion, SetsOneStopStatus)
 {
-    bool one_changed{};
+    gko::array<bool> stop_indicators(ref, 2);
+    stop_indicators.get_data()[0] = false;
     constexpr gko::uint8 RelativeStoppingId{1};
     auto criterion = factory->generate(nullptr, nullptr, nullptr);
     gko::array<gko::stopping_status> stop_status(ref, 1);
@@ -39,7 +40,8 @@ TEST_F(Criterion, SetsOneStopStatus)
     stop_status.set_executor(exec);
     criterion->update()
         .num_iterations(test_iterations)
-        .check(RelativeStoppingId, true, &stop_status, &one_changed);
+        .check(RelativeStoppingId, true, &stop_status,
+               stop_indicators.get_data());
     stop_status.set_executor(ref);
 
     ASSERT_EQ(stop_status.get_data()[0].has_stopped(), true);
@@ -48,7 +50,8 @@ TEST_F(Criterion, SetsOneStopStatus)
 
 TEST_F(Criterion, SetsMultipleStopStatuses)
 {
-    bool one_changed{};
+    gko::array<bool> stop_indicators(ref, 2);
+    stop_indicators.get_data()[0] = false;
     constexpr gko::uint8 RelativeStoppingId{1};
     auto criterion = factory->generate(nullptr, nullptr, nullptr);
     gko::array<gko::stopping_status> stop_status(ref, 3);
@@ -59,7 +62,8 @@ TEST_F(Criterion, SetsMultipleStopStatuses)
     stop_status.set_executor(exec);
     criterion->update()
         .num_iterations(test_iterations)
-        .check(RelativeStoppingId, true, &stop_status, &one_changed);
+        .check(RelativeStoppingId, true, &stop_status,
+               stop_indicators.get_data());
     stop_status.set_executor(ref);
 
     ASSERT_EQ(stop_status.get_data()[0].has_stopped(), true);

--- a/test/stop/residual_norm_kernels.cpp
+++ b/test/stop/residual_norm_kernels.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -70,16 +70,18 @@ TYPED_TEST(ResidualNorm, CanIgorneResidualNorm)
     auto criterion =
         this->factory->generate(nullptr, rhs, nullptr, initial_res.get());
     constexpr gko::uint8 RelativeStoppingId{1};
-    bool one_changed{};
+    gko::array<bool> stop_indicators(this->exec->get_master(), 2);
+    stop_indicators.get_data()[0] = false;
     gko::array<gko::stopping_status> stop_status(this->ref, 1);
     stop_status.get_data()[0].reset();
     stop_status.set_executor(this->exec);
 
     ASSERT_FALSE(criterion->update().ignore_residual_check(true).check(
-        RelativeStoppingId, true, &stop_status, &one_changed));
-    ASSERT_THROW(criterion->update().check(RelativeStoppingId, true,
-                                           &stop_status, &one_changed),
-                 gko::NotSupported);
+        RelativeStoppingId, true, &stop_status, stop_indicators.get_data()));
+    ASSERT_THROW(
+        criterion->update().check(RelativeStoppingId, true, &stop_status,
+                                  stop_indicators.get_data()),
+        gko::NotSupported);
 }
 
 
@@ -108,16 +110,18 @@ TYPED_TEST(ResidualNorm, CheckIfResZeroConverges)
                              .on(this->exec)
                              ->generate(mtx, rhs, x.get(), nullptr);
         constexpr gko::uint8 RelativeStoppingId{1};
-        bool one_changed{};
+        gko::array<bool> stop_indicators(this->exec->get_master(), 2);
+        stop_indicators.get_data()[0] = false;
         gko::array<gko::stopping_status> stop_status(this->ref, 1);
         stop_status.get_data()[0].reset();
         stop_status.set_executor(this->exec);
 
         EXPECT_TRUE(criterion->update().residual_norm(res_norm).check(
-            RelativeStoppingId, true, &stop_status, &one_changed));
+            RelativeStoppingId, true, &stop_status,
+            stop_indicators.get_data()));
         stop_status.set_executor(this->ref);
         EXPECT_TRUE(stop_status.get_data()[0].has_converged());
-        EXPECT_TRUE(one_changed);
+        EXPECT_TRUE(stop_indicators.get_const_data()[0]);
     }
 }
 
@@ -139,82 +143,94 @@ TYPED_TEST(ResidualNorm, WaitsTillResidualGoal)
         auto rhs_norm = gko::initialize<NormVector>({100.0}, this->exec);
         gko::as<Mtx>(rhs)->compute_norm2(rhs_norm);
         constexpr gko::uint8 RelativeStoppingId{1};
-        bool one_changed{};
+        gko::array<bool> stop_indicators(this->exec->get_master(), 2);
+        stop_indicators.get_data()[0] = false;
         gko::array<gko::stopping_status> stop_status(this->ref, 1);
         stop_status.get_data()[0].reset();
         stop_status.set_executor(this->exec);
 
         ASSERT_FALSE(criterion->update().residual_norm(res_norm).check(
-            RelativeStoppingId, true, &stop_status, &one_changed));
+            RelativeStoppingId, true, &stop_status,
+            stop_indicators.get_data()));
 
         write(res_norm, 0, 0, r<TypeParam>::value * 1.1 * read(res_norm, 0, 0));
         ASSERT_FALSE(criterion->update().residual_norm(res_norm).check(
-            RelativeStoppingId, true, &stop_status, &one_changed));
+            RelativeStoppingId, true, &stop_status,
+            stop_indicators.get_data()));
         stop_status.set_executor(this->ref);
         ASSERT_FALSE(stop_status.get_data()[0].has_converged());
-        ASSERT_FALSE(one_changed);
+        ASSERT_FALSE(stop_indicators.get_const_data()[0]);
         stop_status.set_executor(this->exec);
 
         write(res_norm, 0, 0, r<TypeParam>::value * 0.9 * read(res_norm, 0, 0));
         ASSERT_TRUE(criterion->update().residual_norm(res_norm).check(
-            RelativeStoppingId, true, &stop_status, &one_changed));
+            RelativeStoppingId, true, &stop_status,
+            stop_indicators.get_data()));
         stop_status.set_executor(this->ref);
         ASSERT_TRUE(stop_status.get_data()[0].has_converged());
-        ASSERT_TRUE(one_changed);
+        ASSERT_TRUE(stop_indicators.get_const_data()[0]);
         stop_status.set_executor(this->exec);
     }
     {
         auto res_norm = gko::initialize<NormVector>({100.0}, this->exec);
         constexpr gko::uint8 RelativeStoppingId{1};
-        bool one_changed{};
+        gko::array<bool> stop_indicators(this->exec->get_master(), 2);
+        stop_indicators.get_data()[0] = false;
         gko::array<gko::stopping_status> stop_status(this->ref, 1);
         stop_status.get_data()[0].reset();
         stop_status.set_executor(this->exec);
 
         ASSERT_FALSE(rel_criterion->update().residual_norm(res_norm).check(
-            RelativeStoppingId, true, &stop_status, &one_changed));
+            RelativeStoppingId, true, &stop_status,
+            stop_indicators.get_data()));
 
         write(res_norm, 0, 0, r<TypeParam>::value * 1.1 * read(res_norm, 0, 0));
         ASSERT_FALSE(rel_criterion->update().residual_norm(res_norm).check(
-            RelativeStoppingId, true, &stop_status, &one_changed));
+            RelativeStoppingId, true, &stop_status,
+            stop_indicators.get_data()));
         stop_status.set_executor(this->ref);
         ASSERT_FALSE(stop_status.get_data()[0].has_converged());
-        ASSERT_FALSE(one_changed);
+        ASSERT_FALSE(stop_indicators.get_const_data()[0]);
         stop_status.set_executor(this->exec);
 
         write(res_norm, 0, 0, r<TypeParam>::value * 0.9 * read(res_norm, 0, 0));
         ASSERT_TRUE(rel_criterion->update().residual_norm(res_norm).check(
-            RelativeStoppingId, true, &stop_status, &one_changed));
+            RelativeStoppingId, true, &stop_status,
+            stop_indicators.get_data()));
         stop_status.set_executor(this->ref);
         ASSERT_TRUE(stop_status.get_data()[0].has_converged());
-        ASSERT_TRUE(one_changed);
+        ASSERT_TRUE(stop_indicators.get_const_data()[0]);
         stop_status.set_executor(this->exec);
     }
     {
         auto res_norm = gko::initialize<NormVector>({100.0}, this->exec);
         constexpr gko::uint8 RelativeStoppingId{1};
-        bool one_changed{};
+        gko::array<bool> stop_indicators(this->exec->get_master(), 2);
+        stop_indicators.get_data()[0] = false;
         gko::array<gko::stopping_status> stop_status(this->ref, 1);
         stop_status.get_data()[0].reset();
         stop_status.set_executor(this->exec);
 
         ASSERT_FALSE(abs_criterion->update().residual_norm(res_norm).check(
-            RelativeStoppingId, true, &stop_status, &one_changed));
+            RelativeStoppingId, true, &stop_status,
+            stop_indicators.get_data()));
 
         write(res_norm, 0, 0, r<TypeParam>::value * 1.1);
         ASSERT_FALSE(abs_criterion->update().residual_norm(res_norm).check(
-            RelativeStoppingId, true, &stop_status, &one_changed));
+            RelativeStoppingId, true, &stop_status,
+            stop_indicators.get_data()));
         stop_status.set_executor(this->ref);
         ASSERT_FALSE(stop_status.get_data()[0].has_converged());
-        ASSERT_FALSE(one_changed);
+        ASSERT_FALSE(stop_indicators.get_const_data()[0]);
         stop_status.set_executor(this->exec);
 
         write(res_norm, 0, 0, r<TypeParam>::value * 0.9);
         ASSERT_TRUE(abs_criterion->update().residual_norm(res_norm).check(
-            RelativeStoppingId, true, &stop_status, &one_changed));
+            RelativeStoppingId, true, &stop_status,
+            stop_indicators.get_data()));
         stop_status.set_executor(this->ref);
         ASSERT_TRUE(stop_status.get_data()[0].has_converged());
-        ASSERT_TRUE(one_changed);
+        ASSERT_TRUE(stop_indicators.get_const_data()[0]);
         stop_status.set_executor(this->exec);
     }
 }
@@ -240,7 +256,8 @@ TYPED_TEST(ResidualNorm, WaitsTillResidualGoalMultipleRHS)
         auto rhs_norm =
             gko::initialize<NormVector>({I<T_nc>{100.0, 100.0}}, this->exec);
         gko::as<Mtx>(rhs)->compute_norm2(rhs_norm);
-        bool one_changed{};
+        gko::array<bool> stop_indicators(this->exec->get_master(), 2);
+        stop_indicators.get_data()[0] = false;
         constexpr gko::uint8 RelativeStoppingId{1};
         gko::array<gko::stopping_status> stop_status(this->ref, 2);
         stop_status.get_data()[0].reset();
@@ -248,28 +265,32 @@ TYPED_TEST(ResidualNorm, WaitsTillResidualGoalMultipleRHS)
         stop_status.set_executor(this->exec);
 
         ASSERT_FALSE(criterion->update().residual_norm(res_norm).check(
-            RelativeStoppingId, true, &stop_status, &one_changed));
+            RelativeStoppingId, true, &stop_status,
+            stop_indicators.get_data()));
 
         write(res_norm, 0, 0, r<TypeParam>::value * 0.9 * read(rhs_norm, 0, 0));
         ASSERT_FALSE(criterion->update().residual_norm(res_norm).check(
-            RelativeStoppingId, true, &stop_status, &one_changed));
+            RelativeStoppingId, true, &stop_status,
+            stop_indicators.get_data()));
         stop_status.set_executor(this->ref);
         ASSERT_TRUE(stop_status.get_data()[0].has_converged());
-        ASSERT_TRUE(one_changed);
+        ASSERT_TRUE(stop_indicators.get_const_data()[0]);
         stop_status.set_executor(this->exec);
 
         write(res_norm, 0, 1, r<TypeParam>::value * 0.9 * read(rhs_norm, 0, 1));
         ASSERT_TRUE(criterion->update().residual_norm(res_norm).check(
-            RelativeStoppingId, true, &stop_status, &one_changed));
+            RelativeStoppingId, true, &stop_status,
+            stop_indicators.get_data()));
         stop_status.set_executor(this->ref);
         ASSERT_TRUE(stop_status.get_data()[1].has_converged());
-        ASSERT_TRUE(one_changed);
+        ASSERT_TRUE(stop_indicators.get_const_data()[0]);
         stop_status.set_executor(this->exec);
     }
     {
         auto res_norm =
             gko::initialize<NormVector>({I<T_nc>{100.0, 100.0}}, this->exec);
-        bool one_changed{};
+        gko::array<bool> stop_indicators(this->exec->get_master(), 2);
+        stop_indicators.get_data()[0] = false;
         constexpr gko::uint8 RelativeStoppingId{1};
         gko::array<gko::stopping_status> stop_status(this->ref, 2);
         stop_status.get_data()[0].reset();
@@ -277,28 +298,32 @@ TYPED_TEST(ResidualNorm, WaitsTillResidualGoalMultipleRHS)
         stop_status.set_executor(this->exec);
 
         ASSERT_FALSE(rel_criterion->update().residual_norm(res_norm).check(
-            RelativeStoppingId, true, &stop_status, &one_changed));
+            RelativeStoppingId, true, &stop_status,
+            stop_indicators.get_data()));
 
         write(res_norm, 0, 0, r<TypeParam>::value * 0.9 * read(res_norm, 0, 0));
         ASSERT_FALSE(rel_criterion->update().residual_norm(res_norm).check(
-            RelativeStoppingId, true, &stop_status, &one_changed));
+            RelativeStoppingId, true, &stop_status,
+            stop_indicators.get_data()));
         stop_status.set_executor(this->ref);
         ASSERT_TRUE(stop_status.get_data()[0].has_converged());
-        ASSERT_TRUE(one_changed);
+        ASSERT_TRUE(stop_indicators.get_const_data()[0]);
         stop_status.set_executor(this->exec);
 
         write(res_norm, 0, 1, r<TypeParam>::value * 0.9 * read(res_norm, 0, 1));
         ASSERT_TRUE(rel_criterion->update().residual_norm(res_norm).check(
-            RelativeStoppingId, true, &stop_status, &one_changed));
+            RelativeStoppingId, true, &stop_status,
+            stop_indicators.get_data()));
         stop_status.set_executor(this->ref);
         ASSERT_TRUE(stop_status.get_data()[1].has_converged());
-        ASSERT_TRUE(one_changed);
+        ASSERT_TRUE(stop_indicators.get_const_data()[0]);
         stop_status.set_executor(this->exec);
     }
     {
         auto res_norm =
             gko::initialize<NormVector>({I<T_nc>{100.0, 100.0}}, this->exec);
-        bool one_changed{};
+        gko::array<bool> stop_indicators(this->exec->get_master(), 2);
+        stop_indicators.get_data()[0] = false;
         constexpr gko::uint8 RelativeStoppingId{1};
         gko::array<gko::stopping_status> stop_status(this->ref, 2);
         stop_status.get_data()[0].reset();
@@ -306,22 +331,25 @@ TYPED_TEST(ResidualNorm, WaitsTillResidualGoalMultipleRHS)
         stop_status.set_executor(this->exec);
 
         ASSERT_FALSE(abs_criterion->update().residual_norm(res_norm).check(
-            RelativeStoppingId, true, &stop_status, &one_changed));
+            RelativeStoppingId, true, &stop_status,
+            stop_indicators.get_data()));
 
         write(res_norm, 0, 0, r<TypeParam>::value * 0.9);
         ASSERT_FALSE(abs_criterion->update().residual_norm(res_norm).check(
-            RelativeStoppingId, true, &stop_status, &one_changed));
+            RelativeStoppingId, true, &stop_status,
+            stop_indicators.get_data()));
         stop_status.set_executor(this->ref);
         ASSERT_TRUE(stop_status.get_data()[0].has_converged());
-        ASSERT_TRUE(one_changed);
+        ASSERT_TRUE(stop_indicators.get_const_data()[0]);
         stop_status.set_executor(this->exec);
 
         write(res_norm, 0, 1, r<TypeParam>::value * 0.9);
         ASSERT_TRUE(abs_criterion->update().residual_norm(res_norm).check(
-            RelativeStoppingId, true, &stop_status, &one_changed));
+            RelativeStoppingId, true, &stop_status,
+            stop_indicators.get_data()));
         stop_status.set_executor(this->ref);
         ASSERT_TRUE(stop_status.get_data()[1].has_converged());
-        ASSERT_TRUE(one_changed);
+        ASSERT_TRUE(stop_indicators.get_const_data()[0]);
         stop_status.set_executor(this->exec);
     }
 }
@@ -357,29 +385,30 @@ TYPED_TEST(ResidualNormWithInitialResnorm, WaitsTillResidualGoal)
     auto res_norm = gko::initialize<NormVector>({100.0}, this->exec);
     auto criterion =
         this->factory->generate(nullptr, rhs, nullptr, initial_res.get());
-    bool one_changed{};
+    gko::array<bool> stop_indicators(this->exec->get_master(), 2);
+    stop_indicators.get_data()[0] = false;
     constexpr gko::uint8 RelativeStoppingId{1};
     gko::array<gko::stopping_status> stop_status(this->ref, 1);
     stop_status.get_data()[0].reset();
     stop_status.set_executor(this->exec);
 
     ASSERT_FALSE(criterion->update().residual_norm(res_norm).check(
-        RelativeStoppingId, true, &stop_status, &one_changed));
+        RelativeStoppingId, true, &stop_status, stop_indicators.get_data()));
 
     write(res_norm, 0, 0, r<TypeParam>::value * 1.1 * read(res_norm, 0, 0));
     ASSERT_FALSE(criterion->update().residual_norm(res_norm).check(
-        RelativeStoppingId, true, &stop_status, &one_changed));
+        RelativeStoppingId, true, &stop_status, stop_indicators.get_data()));
     stop_status.set_executor(this->ref);
     ASSERT_FALSE(stop_status.get_data()[0].has_converged());
-    ASSERT_FALSE(one_changed);
+    ASSERT_FALSE(stop_indicators.get_const_data()[0]);
     stop_status.set_executor(this->exec);
 
     write(res_norm, 0, 0, r<TypeParam>::value * 0.9 * read(res_norm, 0, 0));
     ASSERT_TRUE(criterion->update().residual_norm(res_norm).check(
-        RelativeStoppingId, true, &stop_status, &one_changed));
+        RelativeStoppingId, true, &stop_status, stop_indicators.get_data()));
     stop_status.set_executor(this->ref);
     ASSERT_TRUE(stop_status.get_data()[0].has_converged());
-    ASSERT_TRUE(one_changed);
+    ASSERT_TRUE(stop_indicators.get_const_data()[0]);
     stop_status.set_executor(this->exec);
 }
 
@@ -396,7 +425,8 @@ TYPED_TEST(ResidualNormWithInitialResnorm, WaitsTillResidualGoalMultipleRHS)
     std::shared_ptr<gko::LinOp> rhs =
         gko::initialize<Mtx>({I<T>{10.0, 10.0}}, this->exec);
     auto criterion = this->factory->generate(nullptr, rhs, nullptr, res.get());
-    bool one_changed{};
+    gko::array<bool> stop_indicators(this->exec->get_master(), 2);
+    stop_indicators.get_data()[0] = false;
     constexpr gko::uint8 RelativeStoppingId{1};
     gko::array<gko::stopping_status> stop_status(this->ref, 2);
     stop_status.get_data()[0].reset();
@@ -404,22 +434,22 @@ TYPED_TEST(ResidualNormWithInitialResnorm, WaitsTillResidualGoalMultipleRHS)
     stop_status.set_executor(this->exec);
 
     ASSERT_FALSE(criterion->update().residual_norm(res_norm).check(
-        RelativeStoppingId, true, &stop_status, &one_changed));
+        RelativeStoppingId, true, &stop_status, stop_indicators.get_data()));
 
     write(res_norm, 0, 0, r<TypeParam>::value * 0.9 * read(res_norm, 0, 0));
     ASSERT_FALSE(criterion->update().residual_norm(res_norm).check(
-        RelativeStoppingId, true, &stop_status, &one_changed));
+        RelativeStoppingId, true, &stop_status, stop_indicators.get_data()));
     stop_status.set_executor(this->ref);
     ASSERT_TRUE(stop_status.get_data()[0].has_converged());
-    ASSERT_TRUE(one_changed);
+    ASSERT_TRUE(stop_indicators.get_const_data()[0]);
     stop_status.set_executor(this->exec);
 
     write(res_norm, 0, 1, r<TypeParam>::value * 0.9 * read(res_norm, 0, 1));
     ASSERT_TRUE(criterion->update().residual_norm(res_norm).check(
-        RelativeStoppingId, true, &stop_status, &one_changed));
+        RelativeStoppingId, true, &stop_status, stop_indicators.get_data()));
     stop_status.set_executor(this->ref);
     ASSERT_TRUE(stop_status.get_data()[1].has_converged());
-    ASSERT_TRUE(one_changed);
+    ASSERT_TRUE(stop_indicators.get_const_data()[0]);
     stop_status.set_executor(this->exec);
 }
 
@@ -458,29 +488,30 @@ TYPED_TEST(ResidualNormWithRhsNorm, WaitsTillResidualGoal)
     auto res_norm = gko::initialize<NormVector>({100.0}, this->exec);
     auto criterion =
         this->factory->generate(nullptr, rhs, nullptr, initial_res.get());
-    bool one_changed{};
+    gko::array<bool> stop_indicators(this->exec->get_master(), 2);
+    stop_indicators.get_data()[0] = false;
     constexpr gko::uint8 RelativeStoppingId{1};
     gko::array<gko::stopping_status> stop_status(this->ref, 1);
     stop_status.get_data()[0].reset();
     stop_status.set_executor(this->exec);
 
     ASSERT_FALSE(criterion->update().residual_norm(res_norm).check(
-        RelativeStoppingId, true, &stop_status, &one_changed));
+        RelativeStoppingId, true, &stop_status, stop_indicators.get_data()));
 
     write(res_norm, 0, 0, r<TypeParam>::value * 1.1 * read(rhs_norm, 0, 0));
     ASSERT_FALSE(criterion->update().residual_norm(res_norm).check(
-        RelativeStoppingId, true, &stop_status, &one_changed));
+        RelativeStoppingId, true, &stop_status, stop_indicators.get_data()));
     stop_status.set_executor(this->ref);
     ASSERT_FALSE(stop_status.get_data()[0].has_converged());
-    ASSERT_FALSE(one_changed);
+    ASSERT_FALSE(stop_indicators.get_const_data()[0]);
     stop_status.set_executor(this->exec);
 
     write(res_norm, 0, 0, r<TypeParam>::value * 0.9 * read(rhs_norm, 0, 0));
     ASSERT_TRUE(criterion->update().residual_norm(res_norm).check(
-        RelativeStoppingId, true, &stop_status, &one_changed));
+        RelativeStoppingId, true, &stop_status, stop_indicators.get_data()));
     stop_status.set_executor(this->ref);
     ASSERT_TRUE(stop_status.get_data()[0].has_converged());
-    ASSERT_TRUE(one_changed);
+    ASSERT_TRUE(stop_indicators.get_const_data()[0]);
     stop_status.set_executor(this->exec);
 }
 
@@ -500,7 +531,8 @@ TYPED_TEST(ResidualNormWithRhsNorm, WaitsTillResidualGoalMultipleRHS)
         gko::initialize<NormVector>({I<T_nc>{0.0, 0.0}}, this->exec);
     gko::as<Mtx>(rhs)->compute_norm2(rhs_norm);
     auto criterion = this->factory->generate(nullptr, rhs, nullptr, res.get());
-    bool one_changed{};
+    gko::array<bool> stop_indicators(this->exec->get_master(), 2);
+    stop_indicators.get_data()[0] = false;
     constexpr gko::uint8 RelativeStoppingId{1};
     gko::array<gko::stopping_status> stop_status(this->ref, 2);
     stop_status.get_data()[0].reset();
@@ -508,22 +540,22 @@ TYPED_TEST(ResidualNormWithRhsNorm, WaitsTillResidualGoalMultipleRHS)
     stop_status.set_executor(this->exec);
 
     ASSERT_FALSE(criterion->update().residual_norm(res_norm).check(
-        RelativeStoppingId, true, &stop_status, &one_changed));
+        RelativeStoppingId, true, &stop_status, stop_indicators.get_data()));
 
     write(res_norm, 0, 0, r<TypeParam>::value * 0.9 * read(rhs_norm, 0, 0));
     ASSERT_FALSE(criterion->update().residual_norm(res_norm).check(
-        RelativeStoppingId, true, &stop_status, &one_changed));
+        RelativeStoppingId, true, &stop_status, stop_indicators.get_data()));
     stop_status.set_executor(this->ref);
     ASSERT_TRUE(stop_status.get_data()[0].has_converged());
-    ASSERT_TRUE(one_changed);
+    ASSERT_TRUE(stop_indicators.get_const_data()[0]);
     stop_status.set_executor(this->exec);
 
     write(res_norm, 0, 1, r<TypeParam>::value * 0.9 * read(rhs_norm, 0, 1));
     ASSERT_TRUE(criterion->update().residual_norm(res_norm).check(
-        RelativeStoppingId, true, &stop_status, &one_changed));
+        RelativeStoppingId, true, &stop_status, stop_indicators.get_data()));
     stop_status.set_executor(this->ref);
     ASSERT_TRUE(stop_status.get_data()[1].has_converged());
-    ASSERT_TRUE(one_changed);
+    ASSERT_TRUE(stop_indicators.get_const_data()[0]);
     stop_status.set_executor(this->exec);
 }
 
@@ -574,18 +606,19 @@ TYPED_TEST(ImplicitResidualNorm, CheckIfResZeroConverges)
                              .on(this->exec)
                              ->generate(mtx, rhs, x.get(), nullptr);
         constexpr gko::uint8 RelativeStoppingId{1};
-        bool one_changed{};
+        gko::array<bool> stop_indicators(this->exec->get_master(), 2);
+        stop_indicators.get_data()[0] = false;
         gko::array<gko::stopping_status> stop_status(this->ref, 1);
         stop_status.get_data()[0].reset();
         stop_status.set_executor(this->exec);
 
-        EXPECT_TRUE(
-            criterion->update()
-                .implicit_sq_residual_norm(implicit_sq_res_norm)
-                .check(RelativeStoppingId, true, &stop_status, &one_changed));
+        EXPECT_TRUE(criterion->update()
+                        .implicit_sq_residual_norm(implicit_sq_res_norm)
+                        .check(RelativeStoppingId, true, &stop_status,
+                               stop_indicators.get_data()));
         stop_status.set_executor(this->ref);
         EXPECT_TRUE(stop_status.get_data()[0].has_converged());
-        EXPECT_TRUE(one_changed);
+        EXPECT_TRUE(stop_indicators.get_const_data()[0]);
     }
 }
 
@@ -602,31 +635,32 @@ TYPED_TEST(ImplicitResidualNorm, WaitsTillResidualGoal)
     gko::as<Mtx>(rhs)->compute_norm2(rhs_norm);
     auto criterion =
         this->factory->generate(nullptr, rhs, nullptr, initial_res.get());
-    bool one_changed{};
+    gko::array<bool> stop_indicators(this->exec->get_master(), 2);
+    stop_indicators.get_data()[0] = false;
     constexpr gko::uint8 RelativeStoppingId{1};
     gko::array<gko::stopping_status> stop_status(this->ref, 1);
     stop_status.get_data()[0].reset();
     stop_status.set_executor(this->exec);
 
     ASSERT_FALSE(criterion->update().implicit_sq_residual_norm(res_norm).check(
-        RelativeStoppingId, true, &stop_status, &one_changed));
+        RelativeStoppingId, true, &stop_status, stop_indicators.get_data()));
 
     write(res_norm, 0, 0,
           std::pow(r<TypeParam>::value * 1.1 * read(rhs_norm, 0, 0), 2));
     ASSERT_FALSE(criterion->update().implicit_sq_residual_norm(res_norm).check(
-        RelativeStoppingId, true, &stop_status, &one_changed));
+        RelativeStoppingId, true, &stop_status, stop_indicators.get_data()));
     stop_status.set_executor(this->ref);
     ASSERT_FALSE(stop_status.get_data()[0].has_converged());
-    ASSERT_FALSE(one_changed);
+    ASSERT_FALSE(stop_indicators.get_const_data()[0]);
     stop_status.set_executor(this->exec);
 
     write(res_norm, 0, 0,
           std::pow(r<TypeParam>::value * 0.9 * read(rhs_norm, 0, 0), 2));
     ASSERT_TRUE(criterion->update().implicit_sq_residual_norm(res_norm).check(
-        RelativeStoppingId, true, &stop_status, &one_changed));
+        RelativeStoppingId, true, &stop_status, stop_indicators.get_data()));
     stop_status.set_executor(this->ref);
     ASSERT_TRUE(stop_status.get_data()[0].has_converged());
-    ASSERT_TRUE(one_changed);
+    ASSERT_TRUE(stop_indicators.get_const_data()[0]);
     stop_status.set_executor(this->exec);
 }
 
@@ -645,7 +679,8 @@ TYPED_TEST(ImplicitResidualNorm, WaitsTillResidualGoalMultipleRHS)
         gko::initialize<NormVector>({I<T_nc>{0.0, 0.0}}, this->exec);
     gko::as<Mtx>(rhs)->compute_norm2(rhs_norm);
     auto criterion = this->factory->generate(nullptr, rhs, nullptr, res.get());
-    bool one_changed{};
+    gko::array<bool> stop_indicators(this->exec->get_master(), 2);
+    stop_indicators.get_data()[0] = false;
     constexpr gko::uint8 RelativeStoppingId{1};
     gko::array<gko::stopping_status> stop_status(this->ref, 2);
     stop_status.get_data()[0].reset();
@@ -653,24 +688,24 @@ TYPED_TEST(ImplicitResidualNorm, WaitsTillResidualGoalMultipleRHS)
     stop_status.set_executor(this->exec);
 
     ASSERT_FALSE(criterion->update().implicit_sq_residual_norm(res_norm).check(
-        RelativeStoppingId, true, &stop_status, &one_changed));
+        RelativeStoppingId, true, &stop_status, stop_indicators.get_data()));
 
     write(res_norm, 0, 0,
           std::pow(r<TypeParam>::value * 0.9 * read(rhs_norm, 0, 0), 2));
     ASSERT_FALSE(criterion->update().implicit_sq_residual_norm(res_norm).check(
-        RelativeStoppingId, true, &stop_status, &one_changed));
+        RelativeStoppingId, true, &stop_status, stop_indicators.get_data()));
     stop_status.set_executor(this->ref);
     ASSERT_TRUE(stop_status.get_data()[0].has_converged());
-    ASSERT_TRUE(one_changed);
+    ASSERT_TRUE(stop_indicators.get_const_data()[0]);
     stop_status.set_executor(this->exec);
 
     write(res_norm, 0, 1,
           std::pow(r<TypeParam>::value * 0.9 * read(rhs_norm, 0, 1), 2));
     ASSERT_TRUE(criterion->update().implicit_sq_residual_norm(res_norm).check(
-        RelativeStoppingId, true, &stop_status, &one_changed));
+        RelativeStoppingId, true, &stop_status, stop_indicators.get_data()));
     stop_status.set_executor(this->ref);
     ASSERT_TRUE(stop_status.get_data()[1].has_converged());
-    ASSERT_TRUE(one_changed);
+    ASSERT_TRUE(stop_indicators.get_const_data()[0]);
     stop_status.set_executor(this->exec);
 }
 
@@ -705,29 +740,30 @@ TYPED_TEST(ResidualNormWithAbsolute, WaitsTillResidualGoal)
     auto res_norm = gko::initialize<NormVector>({100.0}, this->exec);
     auto criterion =
         this->factory->generate(nullptr, rhs, nullptr, initial_res.get());
-    bool one_changed{};
+    gko::array<bool> stop_indicators(this->exec->get_master(), 2);
+    stop_indicators.get_data()[0] = false;
     constexpr gko::uint8 RelativeStoppingId{1};
     gko::array<gko::stopping_status> stop_status(this->ref, 1);
     stop_status.get_data()[0].reset();
     stop_status.set_executor(this->exec);
 
     ASSERT_FALSE(criterion->update().residual_norm(res_norm).check(
-        RelativeStoppingId, true, &stop_status, &one_changed));
+        RelativeStoppingId, true, &stop_status, stop_indicators.get_data()));
 
     write(res_norm, 0, 0, r<TypeParam>::value * 1.1);
     ASSERT_FALSE(criterion->update().residual_norm(res_norm).check(
-        RelativeStoppingId, true, &stop_status, &one_changed));
+        RelativeStoppingId, true, &stop_status, stop_indicators.get_data()));
     stop_status.set_executor(this->ref);
     ASSERT_FALSE(stop_status.get_data()[0].has_converged());
-    ASSERT_FALSE(one_changed);
+    ASSERT_FALSE(stop_indicators.get_const_data()[0]);
     stop_status.set_executor(this->exec);
 
     write(res_norm, 0, 0, r<TypeParam>::value * 0.9);
     ASSERT_TRUE(criterion->update().residual_norm(res_norm).check(
-        RelativeStoppingId, true, &stop_status, &one_changed));
+        RelativeStoppingId, true, &stop_status, stop_indicators.get_data()));
     stop_status.set_executor(this->ref);
     ASSERT_TRUE(stop_status.get_data()[0].has_converged());
-    ASSERT_TRUE(one_changed);
+    ASSERT_TRUE(stop_indicators.get_const_data()[0]);
     stop_status.set_executor(this->exec);
 }
 
@@ -744,7 +780,8 @@ TYPED_TEST(ResidualNormWithAbsolute, WaitsTillResidualGoalMultipleRHS)
     std::shared_ptr<gko::LinOp> rhs =
         gko::initialize<Mtx>({I<T>{10.0, 10.0}}, this->exec);
     auto criterion = this->factory->generate(nullptr, rhs, nullptr, res.get());
-    bool one_changed{};
+    gko::array<bool> stop_indicators(this->exec->get_master(), 2);
+    stop_indicators.get_data()[0] = false;
     constexpr gko::uint8 RelativeStoppingId{1};
     gko::array<gko::stopping_status> stop_status(this->ref, 2);
     stop_status.get_data()[0].reset();
@@ -752,21 +789,21 @@ TYPED_TEST(ResidualNormWithAbsolute, WaitsTillResidualGoalMultipleRHS)
     stop_status.set_executor(this->exec);
 
     ASSERT_FALSE(criterion->update().residual_norm(res_norm).check(
-        RelativeStoppingId, true, &stop_status, &one_changed));
+        RelativeStoppingId, true, &stop_status, stop_indicators.get_data()));
 
     write(res_norm, 0, 0, r<TypeParam>::value * 0.9);
     ASSERT_FALSE(criterion->update().residual_norm(res_norm).check(
-        RelativeStoppingId, true, &stop_status, &one_changed));
+        RelativeStoppingId, true, &stop_status, stop_indicators.get_data()));
     stop_status.set_executor(this->ref);
     ASSERT_TRUE(stop_status.get_data()[0].has_converged());
-    ASSERT_TRUE(one_changed);
+    ASSERT_TRUE(stop_indicators.get_const_data()[0]);
     stop_status.set_executor(this->exec);
 
     write(res_norm, 0, 1, r<TypeParam>::value * 0.9);
     ASSERT_TRUE(criterion->update().residual_norm(res_norm).check(
-        RelativeStoppingId, true, &stop_status, &one_changed));
+        RelativeStoppingId, true, &stop_status, stop_indicators.get_data()));
     stop_status.set_executor(this->ref);
     ASSERT_TRUE(stop_status.get_data()[1].has_converged());
-    ASSERT_TRUE(one_changed);
+    ASSERT_TRUE(stop_indicators.get_const_data()[0]);
     stop_status.set_executor(this->exec);
 }


### PR DESCRIPTION
This PR uses master executor to allocate the one_changed + one additional workspace (for all_converged).
When the master executor uses device-specific host allocator like `cudaMallocHost` to allocate the pinned memory, we can get better bandwidth than default pageable memory. Also, it reduces the number of copy call in residual norm.