### PR TITLE
Avoid reallocation for self residual norm calculation

### DIFF
--- a/include/ginkgo/core/stop/residual_norm.hpp
+++ b/include/ginkgo/core/stop/residual_norm.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -86,6 +86,8 @@ private:
     std::shared_ptr<const Vector> neg_one_{};
     // workspace for reduction
     mutable gko::array<char> reduction_tmp_;
+    // temporary rhs for residual computation
+    mutable std::shared_ptr<LinOp> rhs_{};
 };
 
 


### PR DESCRIPTION
In most of our solver, we need to calculate the actual residual norm by `b - Ax` when required because these solvers only have the implicit residual norm, which is updated from the previous iteration such that it might not be correct enough for residual norm like CG.

This PR avoids reallocation the internal rhs in each iteration.
Note. we still have the allocation when generating the criterion, but it also requires storing the criterion in the solver and it is more critical when we setup some residual-norm aware smoother not the usual setup.