### PR TITLE
Workaround for the typename issue from MSVC with cuda

### DIFF
--- a/.github/workflows/windows-msvc-cuda.yml
+++ b/.github/workflows/windows-msvc-cuda.yml
@@ -1,0 +1,62 @@
+name: Windows-MSVC-CUDA (compile-only)
+
+on:
+  push:
+    branches:
+      - 'master'
+      - 'develop'
+      - 'release/**'
+      - 'check_msvc_cuda'
+    tags:
+      - '**'
+  pull_request:
+    types: [opened,synchronize]
+  workflow_dispatch:
+    inputs:
+      debug_enabled:
+        description: 'Run the build with tmate debugging enabled by `debug_enabled` keyword (https://github.com/marketplace/actions/debugging-with-tmate)'
+        required: false
+        default: false
+
+concurrency:
+  group: ${{ github.workflow }}-${{ (github.head_ref && github.ref) || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  windows_cuda:
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+        - {version: "latest", name: "cuda-latest/release/shared", "mixed": "ON"}
+    name: msvc/${{ matrix.config.name }} (only compile)
+    runs-on: [windows-2022]
+
+    steps:
+    - name: Checkout the latest code (shallow clone)
+      uses: actions/checkout@v4
+    - name: setup (versioned)
+      if: matrix.config.version != 'latest'
+      run: |
+        choco install cuda --version=${{ matrix.config.version }} -y
+
+    - name: setup (latest)
+      if: matrix.config.version == 'latest'
+      run: |
+        choco install cuda -y
+
+    - name: Debug over SSH (tmate)
+      uses: mxschmitt/action-tmate@v3.5
+      if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.debug_enabled }}
+      with:
+        limit-access-to-actor: true
+
+    - name: configure
+      run: |
+        $env:ChocolateyInstall = Convert-Path "$((Get-Command choco).Path)\..\.."
+        Import-Module "$env:ChocolateyInstall\helpers\chocolateyProfile.psm1"
+        refreshenv
+        mkdir build
+        cd build
+        cmake -DGINKGO_BUILD_CUDA=ON -DGINKGO_BUILD_OMP=OFF -DGINKGO_MIXED_PRECISION=${{ matrix.config.mixed }} -DCMAKE_CUDA_ARCHITECTURES=75 -DGINKGO_ENABLE_HALF=OFF -DGINKGO_ENABLE_BFLOAT16=OFF ..
+        cmake --build . -j4 --config Release

--- a/.github/workflows/windows-msvc-cuda.yml
+++ b/.github/workflows/windows-msvc-cuda.yml
@@ -3,14 +3,16 @@ name: Windows-MSVC-CUDA (compile-only)
 on:
   push:
     branches:
+      - 'main'
       - 'master'
       - 'develop'
       - 'release/**'
-      - 'check_msvc_cuda'
     tags:
       - '**'
   pull_request:
     types: [opened,synchronize]
+    paths-ignore:
+      - 'doc/**'
   workflow_dispatch:
     inputs:
       debug_enabled:

--- a/.github/workflows/windows-msvc-cuda.yml
+++ b/.github/workflows/windows-msvc-cuda.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - 'main'
-      - 'master'
       - 'develop'
       - 'release/**'
     tags:


### PR DESCRIPTION
This PR unpacks the `typename block_lut_type::view_type` manually to make MSVC with CUDA to work.
The error output from MSVC 2022 with CUDA 12.9.1 https://github.com/ginkgo-project/ginkgo/actions/runs/16652623395/job/47129177888
```
D:/a/ginkgo/ginkgo\core/components/range_minimum_query.hpp(671): warning C4346: 'view_type': dependent name is not a type [D:\a\ginkgo\ginkgo\build\cuda\ginkgo_cuda.vcxproj]
  D:/a/ginkgo/ginkgo\core/components/range_minimum_query.hpp(671): note: prefix the qualified-id with 'typename' to indicate a type
  D:/a/ginkgo/ginkgo\core/components/range_minimum_query.hpp(671): note: the template instantiation context (the oldest one first) is
  D:/a/ginkgo/ginkgo\core/components/range_minimum_query.hpp(663): note: while compiling class template 'gko::range_minimum_query'
D:/a/ginkgo/ginkgo\core/components/range_minimum_query.hpp(671): error C2061: syntax error: identifier 'view_type' 
```
note: we already use typename for `typename block_lut_type::view_type` but it still fails with warning C4346 and error C2061.

This issue related to ginkgo is also mentioned in https://github.com/ginkgo-project/ginkgo/issues/1902 and https://github.com/microsoft/vcpkg/pull/46036

Also, CUTLASS also faces the same issue in https://github.com/NVIDIA/cutlass/issues/1732

Additionally, to avoid accident inconsistency by manually unpack, have a check when it is not msvc 