### PR TITLE
1912/0 identity config

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -48,6 +48,7 @@ target_sources(
         components/range_minimum_query.cpp
         config/config.cpp
         config/config_helper.cpp
+        config/matrix.cpp
         config/property_tree.cpp
         config/stop_config.cpp
         config/type_descriptor.cpp

--- a/core/config/config_helper.hpp
+++ b/core/config/config_helper.hpp
@@ -71,7 +71,8 @@ enum class LinOpFactoryType : int {
     Sor,
     Multigrid,
     Pgm,
-    Schwarz
+    Schwarz,
+    Identity
 };
 
 

--- a/core/config/matrix.cpp
+++ b/core/config/matrix.cpp
@@ -1,0 +1,22 @@
+// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
+//
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include <ginkgo/core/config/config.hpp>
+#include <ginkgo/core/config/registry.hpp>
+#include <ginkgo/core/matrix/identity.hpp>
+
+#include "core/config/config_helper.hpp"
+#include "core/config/dispatch.hpp"
+#include "core/config/parse_macro.hpp"
+
+
+namespace gko {
+namespace config {
+
+
+GKO_PARSE_VALUE_TYPE(Identity, matrix::IdentityFactory);
+
+
+}  // namespace config
+}  // namespace gko

--- a/core/config/registry.cpp
+++ b/core/config/registry.cpp
@@ -53,10 +53,9 @@ configuration_map generate_config_map()
             {"solver::Multigrid", parse<LinOpFactoryType::Multigrid>},
             {"multigrid::Pgm", parse<LinOpFactoryType::Pgm>},
 #if GINKGO_BUILD_MPI
-        {
-            "preconditioner::Schwarz", parse<LinOpFactoryType::Schwarz>
-        }
+            {"preconditioner::Schwarz", parse<LinOpFactoryType::Schwarz>},
 #endif
+            {"matrix::Identity", parse<LinOpFactoryType::Identity>},
     };
 }
 

--- a/core/matrix/identity.cpp
+++ b/core/matrix/identity.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -31,6 +31,16 @@ void Identity<ValueType>::apply_impl(const LinOp* alpha, const LinOp* b,
             dense_x->add_scaled(dense_alpha, dense_b);
         },
         alpha, b, beta, x);
+}
+
+
+template <typename ValueType>
+typename IdentityFactory<ValueType>::parameters_type
+IdentityFactory<ValueType>::parse(const config::pnode& config,
+                                  const config::registry& context,
+                                  const config::type_descriptor& td_for_child)
+{
+    return {};
 }
 
 

--- a/core/test/config/CMakeLists.txt
+++ b/core/test/config/CMakeLists.txt
@@ -1,5 +1,6 @@
 ginkgo_create_test(config)
 ginkgo_create_test(factorization)
+ginkgo_create_test(matrix)
 ginkgo_create_test(multigrid)
 ginkgo_create_test(preconditioner)
 ginkgo_create_test(property_tree)

--- a/core/test/config/matrix.cpp
+++ b/core/test/config/matrix.cpp
@@ -1,0 +1,48 @@
+// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
+//
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include <typeinfo>
+
+#include <gtest/gtest.h>
+
+#include <ginkgo/core/base/exception.hpp>
+#include <ginkgo/core/base/executor.hpp>
+#include <ginkgo/core/config/config.hpp>
+#include <ginkgo/core/matrix/identity.hpp>
+
+#include "cmake-build-debug/_deps/googletest-src/googletest/include/gtest/gtest-typed-test.h"
+#include "core/config/config_helper.hpp"
+#include "core/config/registry_accessor.hpp"
+#include "core/test/utils.hpp"
+
+
+using namespace gko::config;
+
+
+template <typename ValueType>
+class Identity : public ::testing::Test {
+protected:
+    using value_type = ValueType;
+
+    std::shared_ptr<const gko::Executor> exec =
+        gko::ReferenceExecutor::create();
+    std::shared_ptr<const gko::matrix::Identity<value_type>> ans =
+        gko::matrix::Identity<value_type>::create(exec, 4u);
+};
+
+TYPED_TEST_SUITE(Identity, gko::test::ValueTypes, TypenameNameGenerator);
+
+
+TYPED_TEST(Identity, CanParse)
+{
+    using value_type = typename TestFixture::value_type;
+    auto config = pnode({{"type", pnode("matrix::Identity")}});
+
+    auto res = parse(config, {}, make_type_descriptor<value_type>())
+                   .on(this->exec)
+                   ->generate(this->ans);
+
+    ASSERT_TRUE(dynamic_cast<gko::matrix::Identity<value_type>*>(res.get()));
+    GKO_ASSERT_EQUAL_DIMENSIONS(res, this->ans);
+}

--- a/include/ginkgo/core/config/config.hpp
+++ b/include/ginkgo/core/config/config.hpp
@@ -6,15 +6,8 @@
 #define GKO_PUBLIC_CORE_CONFIG_CONFIG_HPP_
 
 
-#include <map>
-#include <string>
-#include <unordered_map>
-
 #include <ginkgo/core/base/lin_op.hpp>
-#include <ginkgo/core/base/types.hpp>
 #include <ginkgo/core/config/type_descriptor.hpp>
-#include <ginkgo/core/solver/solver_base.hpp>
-
 
 namespace gko {
 namespace config {
@@ -194,7 +187,7 @@ class pnode;
  * @return a deferred_factory_parameter which creates an LinOpFactory after
  *         `.on(exec)` is called on it.
  */
-deferred_factory_parameter<gko::LinOpFactory> parse(
+deferred_factory_parameter<LinOpFactory> parse(
     const pnode& config, const registry& context,
     const type_descriptor& td = make_type_descriptor<>());
 

--- a/include/ginkgo/core/matrix/identity.hpp
+++ b/include/ginkgo/core/matrix/identity.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -7,6 +7,8 @@
 
 
 #include <ginkgo/core/base/lin_op.hpp>
+
+#include "ginkgo/core/config/config.hpp"
 
 
 namespace gko {
@@ -88,10 +90,29 @@ protected:
 template <typename ValueType = default_precision>
 class IdentityFactory
     : public EnablePolymorphicObject<IdentityFactory<ValueType>, LinOpFactory> {
-    friend class EnablePolymorphicObject<IdentityFactory, LinOpFactory>;
-
 public:
     using value_type = ValueType;
+
+    struct parameters_type
+        : enable_parameters_type<parameters_type, IdentityFactory> {};
+
+    /**
+     * Create the parameters from the property_tree.
+     * Because this is directly tied to the specific type, the value/index type
+     * settings within config are ignored and type_descriptor is only used
+     * for children configs.
+     *
+     * @param config  the property tree for setting
+     * @param context  the registry
+     * @param td_for_child  the type descriptor for children configs. The
+     *                      default uses the value type of this class.
+     *
+     * @return parameters
+     */
+    static parameters_type parse(const config::pnode& config,
+                                 const config::registry& context,
+                                 const config::type_descriptor& td_for_child =
+                                     config::make_type_descriptor<ValueType>());
 
     /**
      * Creates a new Identity factory.
@@ -108,10 +129,14 @@ public:
     }
 
 protected:
+    friend class EnablePolymorphicObject<IdentityFactory, LinOpFactory>;
+    friend class enable_parameters_type<parameters_type, IdentityFactory>;
+
     std::unique_ptr<LinOp> generate_impl(
         std::shared_ptr<const LinOp> base) const override;
 
-    IdentityFactory(std::shared_ptr<const Executor> exec)
+    explicit IdentityFactory(std::shared_ptr<const Executor> exec,
+                             const parameters_type& params = {})
         : EnablePolymorphicObject<IdentityFactory, LinOpFactory>(exec)
     {}
 };


### PR DESCRIPTION
This PR allows parsing an object of type `matrix::Identity`. This is helpful for configuring the preconditioner benchmark with no preconditioner.