### PR TITLE
Fix std::pow on custom precision and clang dynamic_cast to final class issue

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -266,6 +266,16 @@ if(MINGW OR CYGWIN)
     else()
         set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wa,-mbig-obj")
     endif()
+else()
+    # using 16 because we pass that during apple clang 15 but not 16. The version leading this issue is not clear from the bug report.
+    if(
+        CMAKE_CXX_COMPILER_ID MATCHES "Clang"
+        AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 17
+        AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 16
+    )
+        # Similar to MINGW/CYGWIN clang issue. LLVM includes the fix from 17 for Itanium ABI but not MS ABI.
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-assume-unique-vtables")
+    endif()
 endif()
 
 # For now, PGI/NVHPC nvc++ compiler doesn't seem to support

--- a/core/test/utils/matrix_generator.hpp
+++ b/core/test/utils/matrix_generator.hpp
@@ -663,8 +663,10 @@ gko::matrix_data<ValueType, IndexType> generate_tridiag_inverse_matrix_data(
                 // complex<half>. We use the float variant to help it, also for
                 // half.
                 using pow_type = std::conditional_t<
-                    std::is_same<gko::remove_complex<ValueType>,
-                                 gko::float16>::value,
+                    std::is_same_v<gko::remove_complex<ValueType>,
+                                   gko::float16> ||
+                        std::is_same_v<gko::remove_complex<ValueType>,
+                                       gko::bfloat16>,
                     std::conditional_t<gko::is_complex<ValueType>(),
                                        std::complex<float>, float>,
                     ValueType>;


### PR DESCRIPTION
The issues are raised by the ApplyClang 15->16 from updated github runner.

std::pow used bfloat16 as type before.
clang `dynamic_cast` to the class with `final` will be failed.
The issue is also mentioned in https://reviews.llvm.org/D154658 and the fix to Itanium ABI (not MS API) is included in clang 17.0.0.
We have also mentioned it in #1724 