### PR TITLE
Fix bitvector test by precompiling the kernel in library

### DIFF
--- a/common/cuda_hip/CMakeLists.txt
+++ b/common/cuda_hip/CMakeLists.txt
@@ -4,6 +4,7 @@ set(CUDA_HIP_SOURCES
     base/device_matrix_data_kernels.cpp
     base/index_set_kernels.cpp
     components/prefix_sum_kernels.cpp
+    components/bitvector.cpp
     distributed/assembly_kernels.cpp
     distributed/index_map_kernels.cpp
     distributed/matrix_kernels.cpp

--- a/common/cuda_hip/components/bitvector.cpp
+++ b/common/cuda_hip/components/bitvector.cpp
@@ -1,0 +1,22 @@
+// SPDX-FileCopyrightText: 2025 The Ginkgo authors
+//
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include "common/cuda_hip/components/bitvector.hpp"
+
+namespace gko {
+namespace kernels {
+namespace GKO_DEVICE_NAMESPACE {
+namespace bitvector {
+
+
+template GKO_DECLARE_BITVECTOR_FROM_SORTED_INDICES(gko::int32*);
+template GKO_DECLARE_BITVECTOR_FROM_SORTED_INDICES(gko::int64*);
+template GKO_DECLARE_BITVECTOR_FROM_SORTED_INDICES(const gko::int32*);
+template GKO_DECLARE_BITVECTOR_FROM_SORTED_INDICES(const gko::int64*);
+
+
+}  // namespace bitvector
+}  // namespace GKO_DEVICE_NAMESPACE
+}  // namespace kernels
+}  // namespace gko

--- a/common/cuda_hip/components/bitvector.hpp
+++ b/common/cuda_hip/components/bitvector.hpp
@@ -141,6 +141,12 @@ from_sorted_indices(
     typename std::iterator_traits<IndexIterator>::difference_type count,
     typename std::iterator_traits<IndexIterator>::value_type size)
 {
+// Using EXEC_TYPE as an indicator in test.
+// We pre-compile the routine for test in library to avoid thrust issue before
+// CUDA 12.4
+#ifdef EXEC_TYPE
+    static_assert(false, "must only compile this kernel in ginkgo library");
+#else
     using index_type = typename std::iterator_traits<IndexIterator>::value_type;
     using storage_type = typename device_bitvector<index_type>::storage_type;
     constexpr auto block_size = device_bitvector<index_type>::block_size;
@@ -170,7 +176,25 @@ from_sorted_indices(
                            ranks.get_data(), index_type{});
 
     return gko::bitvector<index_type>{std::move(bits), std::move(ranks), size};
+#endif
 }
+
+#define GKO_DECLARE_BITVECTOR_FROM_SORTED_INDICES(IndexIterator)             \
+    gko::bitvector<typename std::iterator_traits<IndexIterator>::value_type> \
+    from_sorted_indices(                                                     \
+        std::shared_ptr<const DefaultExecutor> exec, IndexIterator it,       \
+        typename std::iterator_traits<IndexIterator>::difference_type count, \
+        typename std::iterator_traits<IndexIterator>::value_type size)
+
+// Before CUDA 12.4 (or NCCL 2.3), THRUST_CUB_WRAPPED_NAMESPACE is required for
+// seperating the thrust implementation in different shared library. The test
+// also compiles thrust kernel, so it leads the thrust issue between test and
+// ginkgo library. Compiling the kernel used by the test in the library to
+// work around this issue.
+extern template GKO_DECLARE_BITVECTOR_FROM_SORTED_INDICES(gko::int32*);
+extern template GKO_DECLARE_BITVECTOR_FROM_SORTED_INDICES(gko::int64*);
+extern template GKO_DECLARE_BITVECTOR_FROM_SORTED_INDICES(const gko::int32*);
+extern template GKO_DECLARE_BITVECTOR_FROM_SORTED_INDICES(const gko::int64*);
 
 
 }  // namespace bitvector

--- a/common/cuda_hip/components/bitvector.hpp
+++ b/common/cuda_hip/components/bitvector.hpp
@@ -145,7 +145,8 @@ from_sorted_indices(
 // We pre-compile the routine for test in library to avoid thrust issue before
 // CUDA 12.4
 #ifdef EXEC_TYPE
-    static_assert(false, "must only compile this kernel in ginkgo library");
+    static_assert(std::is_same_v<IndexIterator, void>,
+                  "must only compile this kernel in ginkgo library");
 #else
     using index_type = typename std::iterator_traits<IndexIterator>::value_type;
     using storage_type = typename device_bitvector<index_type>::storage_type;
@@ -187,7 +188,7 @@ from_sorted_indices(
         typename std::iterator_traits<IndexIterator>::value_type size)
 
 // Before CUDA 12.4 (or NCCL 2.3), THRUST_CUB_WRAPPED_NAMESPACE is required for
-// seperating the thrust implementation in different shared library. The test
+// separating the thrust implementation in different shared library. The test
 // also compiles thrust kernel, so it leads the thrust issue between test and
 // ginkgo library. Compiling the kernel used by the test in the library to
 // work around this issue.


### PR DESCRIPTION
thrust has the issue when the kernel are compiled in different shared library.
We have used `THRUST_CUB_WRAPPED_NAMESPACE` to avoid the issue between Ginkgo and the other library.
However, this issue still bothers us between test and ginkgo library.
We need bitvector kernel implementation in header because of #1832 

To work around this issue, I decide to pre-compile the kernels for tests and avoid any thrust kernel compilation from test.
Another workaround is to skip this test when building shared library with CUDA < 12.4
CCCL waives this `THRUST_CUB_WRAPPED_NAMESPACE` in 2.3.0 and CUDA 12.4 use CCCL 2.3.1 already.
related issue: https://github.com/NVIDIA/cccl/issues/655
From the issue, this issue happens after cub 2.0.0.

It is raised from #1841 cuda 12.2 test
