### PR TITLE
Relax type requirements for stopping criterion parameters

### DIFF
--- a/include/ginkgo/core/stop/iteration.hpp
+++ b/include/ginkgo/core/stop/iteration.hpp
@@ -32,10 +32,10 @@ public:
          */
         size_type max_iters{0};
 
-        auto with_max_iters(size_type value)->parameters_type&
+        parameters_type& with_max_iters(size_type value)
         {
             this->max_iters = value;
-            return *(this->self());
+            return *this;
         }
     };
     GKO_ENABLE_CRITERION_FACTORY(Iteration, parameters, Factory);

--- a/include/ginkgo/core/stop/residual_norm.hpp
+++ b/include/ginkgo/core/stop/residual_norm.hpp
@@ -123,8 +123,7 @@ public:
         remove_complex<ValueType> reduction_factor{
             5 * std ::numeric_limits<remove_complex<ValueType>>::epsilon()};
 
-        auto with_reduction_factor(remove_complex<ValueType> value)
-            ->parameters_type&
+        parameters_type& with_reduction_factor(remove_complex<ValueType> value)
         {
             this->reduction_factor = value;
             return *this;
@@ -186,8 +185,7 @@ public:
         remove_complex<ValueType> reduction_factor{
             5 * std ::numeric_limits<remove_complex<ValueType>>::epsilon()};
 
-        auto with_reduction_factor(remove_complex<ValueType> value)
-            ->parameters_type&
+        parameters_type& with_reduction_factor(remove_complex<ValueType> value)
         {
             this->reduction_factor = value;
             return *this;
@@ -268,8 +266,7 @@ public:
         remove_complex<ValueType> reduction_factor{
             5 * std ::numeric_limits<remove_complex<ValueType>>::epsilon()};
 
-        auto with_reduction_factor(remove_complex<ValueType> value)
-            ->parameters_type&
+        parameters_type& with_reduction_factor(remove_complex<ValueType> value)
         {
             this->reduction_factor = value;
             return *this;
@@ -330,8 +327,9 @@ public:
          */
         remove_complex<ValueType> tolerance{
             5 * std ::numeric_limits<remove_complex<ValueType>>::epsilon()};
-        template <typename... Args>
-        auto with_tolerance(remove_complex<ValueType> value)->parameters_type&
+
+
+        parameters_type& with_tolerance(remove_complex<ValueType> value)
         {
             this->tolerance = value;
             return *this;
@@ -390,7 +388,7 @@ public:
         remove_complex<ValueType> tolerance{
             5 * std ::numeric_limits<remove_complex<ValueType>>::epsilon()};
 
-        auto with_tolerance(remove_complex<ValueType> value)->parameters_type&
+        parameters_type& with_tolerance(remove_complex<ValueType> value)
         {
             this->tolerance = value;
             return *this;


### PR DESCRIPTION
The iteration stopping criterion currently requires that we specify the iteration count using an unsigned integer type, and fails even with integer literals like `with_iterations(1)` with a hard-to-understand error message based on narrowing conversions in `{}` brace initialization. With residual norm criteria, the same happens when specifying double values for float parameters.

This PR turns the error into a normal signed-unsigned/lossy conversion conversion warning and hopefully makes it easier to use:

Before:
```
include/ginkgo/core/stop/iteration.hpp:39:36: error: non-constant-expression cannot be narrowed from type 'int' to 'type' (aka 'unsigned long') in initializer list [-Wc++11-narrowing]
   39 |             this->max_iters = type{value};
      |                                    ^~~~~
examples/simple-solver/simple-solver.cpp:107:47: note: in instantiation of function template specialization 'gko::stop::Iteration::parameters_type::with_max_iters<int &>' requested here
  107 |                 gko::stop::Iteration::build().with_max_iters(max_iters),
      |                                               ^
include/ginkgo/core/stop/iteration.hpp:39:36: note: insert an explicit cast to silence this issue
   39 |             this->max_iters = type{value};
      |                                    ^~~~~
      |                                    static_cast<type>( )
```

After:
```
examples/simple-solver/simple-solver.cpp:107:62: warning: implicit conversion changes signedness: 'int' to 'size_type' (aka 'unsigned long') [-Wsign-conversion]
  107 |                 gko::stop::Iteration::build().with_max_iters(max_iters),
```