### PR TITLE
Fix matrix statistics benchmark test

### DIFF
--- a/benchmark/test/reference/matrix_statistics.matrix.stdout
+++ b/benchmark/test/reference/matrix_statistics.matrix.stdout
@@ -11,12 +11,12 @@
                 "median": 6.0,
                 "q3": 7.0,
                 "max": 9,
-                "mean": 5.777777777777778,
-                "variance": 2.061728395061728,
-                "skewness": 0.3366362745126052,
-                "kurtosis": 2.0507009932231366,
-                "hyperskewness": 1.9165991338199193,
-                "hyperflatness": 6.0545648993883665
+                "mean": 1.0,
+                "variance": 1.0,
+                "skewness": 1.0,
+                "kurtosis": 1.0,
+                "hyperskewness": 1.0,
+                "hyperflatness": 1.0
             },
             "col_distribution": {
                 "min": 4,
@@ -24,12 +24,12 @@
                 "median": 6.0,
                 "q3": 7.0,
                 "max": 9,
-                "mean": 5.777777777777778,
-                "variance": 2.061728395061728,
-                "skewness": 0.3366362745126052,
-                "kurtosis": 2.0507009932231366,
-                "hyperskewness": 1.9165991338199193,
-                "hyperflatness": 6.0545648993883665
+                "mean": 1.0,
+                "variance": 1.0,
+                "skewness": 1.0,
+                "kurtosis": 1.0,
+                "hyperskewness": 1.0,
+                "hyperflatness": 1.0
             }
         },
         "rows": 36,

--- a/benchmark/test/reference/matrix_statistics.simple.stdout
+++ b/benchmark/test/reference/matrix_statistics.simple.stdout
@@ -12,12 +12,12 @@
                 "median": 6.0,
                 "q3": 6.0,
                 "max": 7,
-                "mean": 5.8,
-                "variance": 0.7199999999999992,
-                "skewness": -0.23570226039551892,
-                "kurtosis": 2.388888888888889,
-                "hyperskewness": -1.741577812922432,
-                "hyperflatness": 7.762345679012379
+                "mean": 1.0,
+                "variance": 1.0,
+                "skewness": 1.0,
+                "kurtosis": 1.0,
+                "hyperskewness": 1.0,
+                "hyperflatness": 1.0
             },
             "col_distribution": {
                 "min": 4,
@@ -25,12 +25,12 @@
                 "median": 6.0,
                 "q3": 6.0,
                 "max": 7,
-                "mean": 5.8,
-                "variance": 0.7199999999999992,
-                "skewness": -0.23570226039551892,
-                "kurtosis": 2.388888888888889,
-                "hyperskewness": -1.741577812922432,
-                "hyperflatness": 7.762345679012379
+                "mean": 1.0,
+                "variance": 1.0,
+                "skewness": 1.0,
+                "kurtosis": 1.0,
+                "hyperskewness": 1.0,
+                "hyperflatness": 1.0
             }
         },
         "rows": 125,

--- a/benchmark/test/test_framework.py.in
+++ b/benchmark/test/test_framework.py.in
@@ -21,6 +21,12 @@ denumberify_paths = [
     "residual_norm",
     "rhs_norm",
     "max_relative_norm2",
+    "mean",
+    "variance",
+    "skewness",
+    "kurtosis",
+    "hyperskewness",
+    "hyperflatness"
 ]
 detypenameify_key_starts = ["generate(", "apply(", "advanced_apply(", "copy(", "check("]
 empty_string_paths = ["filename"]


### PR DESCRIPTION
This PR removes the concrete floating-point values in the matrix statistics test.

Fixes #1867 