### PR TITLE
Make array::resize_and_reset exception-safe

### DIFF
--- a/include/ginkgo/core/base/array.hpp
+++ b/include/ginkgo/core/base/array.hpp
@@ -634,8 +634,8 @@ public:
         }
 
         if (size > 0 && this->is_owning()) {
-            size_ = size;
             data_.reset(exec_->alloc<value_type>(size));
+            size_ = size;
         } else {
             this->clear();
         }


### PR DESCRIPTION
We should only change the size after the allocation was successful. I found this when debugging a test failure related to allocation where the size was already changed when the allocation hadn't happened yet.