### PR TITLE
Fix redefinition issue related to HIP's ::min

### DIFF
--- a/core/test/mpi/base/bindings.cpp
+++ b/core/test/mpi/base/bindings.cpp
@@ -21,7 +21,7 @@ namespace detail {
 
 
 template <typename ValueType>
-inline void min(void* input, void* output, int* len, MPI_Datatype* datatype)
+inline void do_min(void* input, void* output, int* len, MPI_Datatype* datatype)
 {
     ValueType* input_ptr = static_cast<ValueType*>(input);
     ValueType* output_ptr = static_cast<ValueType*>(output);
@@ -34,7 +34,7 @@ inline void min(void* input, void* output, int* len, MPI_Datatype* datatype)
 
 
 template <typename ValueType>
-inline void max(void* input, void* output, int* len, MPI_Datatype* datatype)
+inline void do_max(void* input, void* output, int* len, MPI_Datatype* datatype)
 {
     ValueType* input_ptr = static_cast<ValueType*>(input);
     ValueType* output_ptr = static_cast<ValueType*>(output);
@@ -44,9 +44,6 @@ inline void max(void* input, void* output, int* len, MPI_Datatype* datatype)
         }
     }
 }
-
-
-}  // namespace detail
 
 
 using gko::experimental::mpi::op_manager;
@@ -71,7 +68,7 @@ public:
         op_ = op_manager(
             []() {
                 MPI_Op* operation = new MPI_Op;
-                MPI_Op_create(&detail::min<ValueType>, 1, operation);
+                MPI_Op_create(&do_min<ValueType>, 1, operation);
                 return operation;
             }(),
             [](MPI_Op* op) {
@@ -107,7 +104,7 @@ public:
         op_ = op_manager(
             []() {
                 MPI_Op* operation = new MPI_Op;
-                MPI_Op_create(&detail::max<ValueType>, 1, operation);
+                MPI_Op_create(&do_max<ValueType>, 1, operation);
                 return operation;
             }(),
             [](MPI_Op* op) {
@@ -123,6 +120,9 @@ private:
 };
 
 
+}  // namespace detail
+
+
 template <typename T>
 class MpiBindings : public ::testing::Test {
 protected:
@@ -130,14 +130,14 @@ protected:
     MpiBindings()
         : ref(gko::ReferenceExecutor::create()),
           sum_op(gko::experimental::mpi::sum<value_type>()),
-          max_op(max<value_type>()),
-          min_op(min<value_type>())
+          max_op(detail::max<value_type>()),
+          min_op(detail::min<value_type>())
     {}
 
     std::shared_ptr<gko::Executor> ref;
     gko::experimental::mpi::sum<value_type> sum_op;
-    max<value_type> max_op;
-    min<value_type> min_op;
+    detail::max<value_type> max_op;
+    detail::min<value_type> min_op;
 };
 
 using TestTypes = gko::test::merge_type_list_t<gko::test::RealValueTypes,


### PR DESCRIPTION
+ Pushed min/max difinitions into the detail namespace
+ renamed min/max to do_min and do_max

-----

On a Cray machine, using:

```
module load cpe/24.07
module load craype-accel-amd-gfx90a craype-x86-trento
module load PrgEnv-amd
module load amd/6.4.3
module load rocm/6.4.3
module load cmake ninja

cmake .. -G Ninja \
    -DCMAKE_CXX_COMPILER=CC -DCMAKE_C_COMPILER=cc -DCMAKE_HIP_COMPILER="CC" \
    -DCMAKE_BUILD_TYPE=Release -DGPU_TARGETS=gfx90a -DCMAKE_HIP_ARCHITECTURES=gfx90a \
    -DGINKGO_BUILD_HIP=ON \
    -DGINKGO_BUILD_OMP=ON \
    -DGINKGO_BUILD_MPI=ON -DGINKGO_FORCE_GPU_AWARE_MPI=ON \
    -DGINKGO_BUILD_EXAMPLES=OFF -DGINKGO_BUILD_TESTS=ON \
    -DGINKGO_BUILD_BENCHMARKS=ON -DGINKGO_BENCHMARK_ENABLE_TUNING=OFF \
    -DGINKGO_MIXED_PRECISION=OFF -DGINKGO_ENABLE_BFLOAT16=OFF -DGINKGO_ENABLE_HALF=OFF \
    -DGINKGO_BUILD_HWLOC=OFF -DGINKGO_BUILD_PAPI_SDE=OFF -DGINKGO_WITH_CCACHE=OFF
```

All builds fine except for `ginkgo/core/test/mpi/base/bindings.cpp` which fails with:

```
ginkgo/core/test/mpi/base/bindings.cpp:56:7: error: redefinition of 'min' as different kind of symbol
ginkgo/core/test/mpi/base/bindings.cpp:59:7: error: explicit specialization of non-template class 'min'
ginkgo/core/test/mpi/base/bindings.cpp:59:7: error: redefinition of 'min' as different kind of symbol
ginkgo/core/test/mpi/base/bindings.cpp:66:7: error: explicit specialization of non-template class 'min'
ginkgo/core/test/mpi/base/bindings.cpp:66:7: error: redefinition of 'min' as different kind of symbol
ginkgo/core/test/mpi/base/bindings.cpp:92:7: error: redefinition of 'max' as different kind of symbol
ginkgo/core/test/mpi/base/bindings.cpp:95:7: error: explicit specialization of non-template class 'max'
ginkgo/core/test/mpi/base/bindings.cpp:95:7: error: redefinition of 'max' as different kind of symbol
ginkgo/core/test/mpi/base/bindings.cpp:102:7: error: explicit specialization of non-template class 'max'
ginkgo/core/test/mpi/base/bindings.cpp:102:7: error: redefinition of 'max' as different kind of symbol
ginkgo/core/test/mpi/base/bindings.cpp:139:5: error: no template named 'max'
ginkgo/core/test/mpi/base/bindings.cpp:140:5: error: no template named 'min'
ginkgo/core/test/mpi/base/bindings.cpp:133:22: error: unexpected type name 'value_type': expected expression
ginkgo/core/test/mpi/base/bindings.cpp:133:34: error: expected expression
ginkgo/core/test/mpi/base/bindings.cpp:134:22: error: unexpected type name 'value_type': expected expression
ginkgo/core/test/mpi/base/bindings.cpp:134:34: error: expected expression
ginkgo/core/test/mpi/base/bindings.cpp:149:1: error: only virtual member functions can be marked 'override'
ginkgo/build/_deps/googletest-src/googletest/include/gtest/internal/gtest-internal.h:448:40: error: cannot initialize return object of type 'Test *' with an rvalue of type 'MpiBindings_CanSetADefaultwindow_Test<double> *'
ginkgo/core/test/mpi/base/bindings.cpp:149:1: error: only virtual member functions can be marked 'override'
```

Min/max are already present at line LEET in ROCm 6.4.3 at least:
```
/opt/rocm/6.4.3/lib/llvm/lib/clang/19/include/__clang_hip_math.h:1337:8: note: previous definition is here
 1337 | double min(double __x, double __y) { return __builtin_fmin(__x, __y); }
```
