### PR TITLE
Increase tolerance for the `PipeCg::ApplyIsEquivalentToRef` test

### DIFF
--- a/test/solver/pipe_cg_kernels.cpp
+++ b/test/solver/pipe_cg_kernels.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 The Ginkgo authors
+// SPDX-FileCopyrightText: 2025 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -246,5 +246,5 @@ TEST_F(PipeCg, ApplyIsEquivalentToRef)
     solver->apply(b, x);
     d_solver->apply(d_b, d_x);
 
-    GKO_ASSERT_MTX_NEAR(d_x, x, ::r<value_type>::value * 5 * 1e4);
+    GKO_ASSERT_MTX_NEAR(d_x, x, ::r<value_type>::value * 6 * 1e4);
 }


### PR DESCRIPTION
As discussed in #1972, for now we can just increase the tolerance of this test, so that it doesn't fail on the architecture in question, as it had already been noted that PIPECG can have some precision issues. 

according to my calculations, replacing `5` with `6` in the multiplier for the tolerance is enough, since:

`5*(2.008522553101075/1.6852000649168166) = 5.959300011064911`

where the fraction is taken from the test fail report as the actual error divided by the previous tolerance.

Fixes: #1972 