### PR TITLE
Fix DPC++ deprecation warnings

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -481,7 +481,7 @@ build/icpx202421/gpu-fp32/release/shared:
     ENABLE_HALF: "OFF"
     ENABLE_BFLOAT16: "OFF"
     ONEAPI_DEVICE_SELECTOR: "level_zero:gpu"
-    MODULE_LOAD: "cmake/3.28.6 intel-oneapi-compilers/2024.2.1 intel-oneapi-dpl/2022.6.1 intel-oneapi-tbb/2021.13.1 intel-oneapi-mkl/2024.2.1"
+    MODULE_LOAD: "cmake/3.31.6 intel-oneapi-compilers/2024.2.1 intel-oneapi-dpl/2022.6.1 intel-oneapi-tbb/2021.13.1 intel-oneapi-mkl/2024.2.1"
 
 build/icpx202521/gpu/release/shared:
   extends:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -465,22 +465,41 @@ build/nogpu/mpi/gcc13/noomp/release/shared:
     BUILD_MPI: "ON"
     MODULE_LOAD: "cmake/3.18.6 gcc/13.3.0 openmpi/5.0.7"
 
-build/icpx202421/gpu/release/shared:
+build/icpx202421/gpu-fp32/release/shared:
   extends:
     - .build_and_test_tum_template
     - .default_variables
     - .full_test_condition
-    - .use_tum-intel
+    - .use_tum-intel-fp32
   variables:
     CXX_COMPILER: "icpx"
     CXX_FLAGS: "-Wpedantic -ffp-model=precise -Wno-deprecated-declarations"
     BUILD_SYCL: "ON"
     BUILD_OMP: "ON"
     BUILD_TYPE: "Release"
+    DPCPP_SINGLE_MODE: "ON"
+    ENABLE_HALF: "OFF"
+    ENABLE_BFLOAT16: "OFF"
+    ONEAPI_DEVICE_SELECTOR: "level_zero:gpu"
+    MODULE_LOAD: "cmake/3.28.6 intel-oneapi-compilers/2024.2.1 intel-oneapi-dpl/2022.6.1 intel-oneapi-tbb/2021.13.1 intel-oneapi-mkl/2024.2.1"
+
+build/icpx202521/gpu/release/shared:
+  extends:
+    - .build_and_test_tum_template
+    - .default_variables
+    - .quick_test_condition
+    - .use_tum-intel
+  variables:
+    CXX_COMPILER: "icpx"
+    CXX_FLAGS: "-Wpedantic -ffp-model=precise -Wno-deprecated-declarations"
+    BUILD_SYCL: "ON"
+    BUILD_OMP: "OFF"
+    BUILD_HWLOC: "OFF"
+    BUILD_TYPE: "Release"
     ENABLE_HALF: "ON"
     ENABLE_BFLOAT16: "ON"
     ONEAPI_DEVICE_SELECTOR: "level_zero:gpu"
-    MODULE_LOAD: "cmake/3.28.6 intel-oneapi-compilers/2024.2.1 intel-oneapi-dpl/2022.6.1 intel-oneapi-tbb/2021.13.1 intel-oneapi-mkl/2024.2.1"
+    MODULE_LOAD: "cmake/3.28.6 intel-oneapi-compilers/2025.2.1 intel-oneapi-dpl/2022.9.0 intel-oneapi-tbb/2022.2.0 intel-oneapi-mkl/2025.2.0"
 
 # TODO: Enable when debug shared library size issues are fixed
 # build/dpcpp/level_zero_igpu/debug/shared:

--- a/benchmark/utils/dpcpp_linops.dp.cpp
+++ b/benchmark/utils/dpcpp_linops.dp.cpp
@@ -105,8 +105,11 @@ public:
 
         oneapi::mkl::sparse::set_csr_data(
             *(this->get_device_exec()->get_queue()), this->get_mat_handle(),
-            static_cast<int>(this->get_size()[0]),
-            static_cast<int>(this->get_size()[1]),
+            static_cast<IndexType>(this->get_size()[0]),
+            static_cast<IndexType>(this->get_size()[1]),
+#if INTEL_MKL_VERSION >= 20250300
+            static_cast<std::int64_t>(csr_->get_num_stored_elements()),
+#endif
             oneapi::mkl::index_base::zero, csr_->get_row_ptrs(),
             csr_->get_col_idxs(), csr_->get_values());
         if (optimized) {

--- a/cmake/build_helpers.cmake
+++ b/cmake/build_helpers.cmake
@@ -214,3 +214,16 @@ function(
     file(REMOVE ${CMAKE_CURRENT_BINARY_DIR}/extract_dpcpp_ver.cpp)
     file(REMOVE ${CMAKE_CURRENT_BINARY_DIR}/extract_dpcpp_ver)
 endfunction()
+
+# Add `-fsycl-device-lib=all` before icpx 2026 (before GINKGO_DPCPP_MAJOR_VERSION 9).
+# Intel mark `-fsycl-device-lib` deprecated in 2025.3. 
+# The 2025.3 compiler's detectable version is 8.0.0 which is the same as the 2025.2 compiler.
+# However, `-fsycl-device-lib` is not deprecated in 2025.2, so we can only remove it from 2026 not 2025.3
+function(ginkgo_add_sycl_device_lib target)
+    if(GINKGO_DPCPP_MAJOR_VERSION VERSION_LESS_EQUAL "8")
+        # Note: add MKL as PRIVATE not PUBLIC (MKL example shows) to avoid propagating
+        # find_package(MKL) everywhere when linking ginkgo (see the MKL example
+        # https://software.intel.com/content/www/us/en/develop/documentation/onemkl-windows-developer-guide/top/getting-started/cmake-config-for-onemkl.html)
+        target_link_options(${target} PRIVATE -fsycl-device-lib=all)
+    endif()
+endfunction()

--- a/cmake/create_test.cmake
+++ b/cmake/create_test.cmake
@@ -500,8 +500,9 @@ function(ginkgo_create_common_device_test test_name)
         )
         target_link_options(
             ${test_target_name}_dpcpp
-            PRIVATE -fsycl-device-lib=all -fsycl-device-code-split=per_kernel
+            PRIVATE -fsycl-device-code-split=per_kernel
         )
+        ginkgo_add_sycl_device_lib(${test_target_name}_dpcpp)
     endif()
     if(
         GINKGO_BUILD_OMP

--- a/dpcpp/CMakeLists.txt
+++ b/dpcpp/CMakeLists.txt
@@ -143,10 +143,8 @@ target_compile_options(ginkgo_dpcpp PRIVATE "${GINKGO_DPCPP_FLAGS}")
 # If we would like to use SOURCES, please use the new files copied from GKO_UNIFIED_COMMON_SOURCES.
 # Otherwise, the source's properties will be changed by add_sycl_to_target
 gko_add_sycl_to_target(TARGET ginkgo_dpcpp)
-# Note: add MKL as PRIVATE not PUBLIC (MKL example shows) to avoid propagating
-# find_package(MKL) everywhere when linking ginkgo (see the MKL example
-# https://software.intel.com/content/www/us/en/develop/documentation/onemkl-windows-developer-guide/top/getting-started/cmake-config-for-onemkl.html)
-target_link_options(ginkgo_dpcpp PRIVATE -fsycl-device-lib=all)
+
+ginkgo_add_sycl_device_lib(ginkgo_dpcpp)
 # When building ginkgo as a static library, we need to use dpcpp and per_kernel
 # link option when the program uses a dpcpp related function.
 if(BUILD_SHARED_LIBS)

--- a/dpcpp/base/kernel_launch_reduction.dp.hpp
+++ b/dpcpp/base/kernel_launch_reduction.dp.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -17,7 +17,6 @@
 #include "dpcpp/components/cooperative_groups.dp.hpp"
 #include "dpcpp/components/reduction.dp.hpp"
 #include "dpcpp/components/thread_ids.dp.hpp"
-#include "dpcpp/components/uninitialized_array.hpp"
 #include "dpcpp/synthesizer/implementation_selection.hpp"
 
 
@@ -41,15 +40,13 @@ void generic_kernel_reduction_1d(sycl::handler& cgh, int64 size,
     constexpr auto wg_size = DeviceConfig::block_size;
     constexpr auto sg_size = DeviceConfig::subgroup_size;
     constexpr auto num_partials = wg_size / sg_size;
-    sycl::local_accessor<uninitialized_array<ValueType, num_partials>, 0>
-        subgroup_partial_acc(cgh);
+    sycl::local_accessor<ValueType, 1> subgroup_partial(num_partials, cgh);
     const auto range = sycl_nd_range(dim3(num_workgroups), dim3(wg_size));
     const auto global_size = num_workgroups * wg_size;
 
     cgh.parallel_for(
         range,
         [=](sycl::nd_item<3> idx) [[sycl::reqd_sub_group_size(sg_size)]] {
-            auto subgroup_partial = &(*subgroup_partial_acc.get_pointer())[0];
             const auto tidx = thread::get_thread_id_flat<int64>(idx);
             const auto local_tidx = static_cast<int64>(tidx % wg_size);
             auto subgroup =
@@ -89,15 +86,13 @@ void generic_kernel_reduction_2d(sycl::handler& cgh, int64 rows, int64 cols,
     constexpr auto wg_size = DeviceConfig::block_size;
     constexpr auto sg_size = DeviceConfig::subgroup_size;
     constexpr auto num_partials = wg_size / sg_size;
-    sycl::local_accessor<uninitialized_array<ValueType, num_partials>, 0>
-        subgroup_partial_acc(cgh);
+    sycl::local_accessor<ValueType, 1> subgroup_partial(num_partials, cgh);
     const auto range = sycl_nd_range(dim3(num_workgroups), dim3(wg_size));
     const auto global_size = num_workgroups * wg_size;
 
     cgh.parallel_for(
         range,
         [=](sycl::nd_item<3> idx) [[sycl::reqd_sub_group_size(sg_size)]] {
-            auto subgroup_partial = &(*subgroup_partial_acc.get_pointer())[0];
             const auto tidx = thread::get_thread_id_flat<int64>(idx);
             const auto local_tidx = static_cast<int64>(tidx % wg_size);
             auto subgroup =
@@ -341,12 +336,10 @@ void generic_kernel_col_reduction_2d_small(
     constexpr auto subgroups_per_workgroup = wg_size / sg_size;
     // stores the subwarp_size partial sums from each warp, grouped by warp
     constexpr auto shared_storage = subgroups_per_workgroup * ssg_size;
-    sycl::local_accessor<uninitialized_array<ValueType, shared_storage>, 0>
-        block_partial_acc(cgh);
+    sycl::local_accessor<ValueType, 1> block_partial(shared_storage, cgh);
     const auto range = sycl_nd_range(dim3(row_blocks), dim3(wg_size));
     cgh.parallel_for(
         range, [=](sycl::nd_item<3> id) [[sycl::reqd_sub_group_size(sg_size)]] {
-            auto block_partial = &(*block_partial_acc.get_pointer())[0];
             const auto ssg_id =
                 thread::get_subwarp_id_flat<ssg_size, int64>(id);
             const auto local_sg_id = id.get_local_id(2) / sg_size;
@@ -413,8 +406,7 @@ void generic_kernel_col_reduction_2d_blocked(
     constexpr auto sg_size = cfg::subgroup_size;
     const auto range =
         sycl_nd_range(dim3(row_blocks, col_blocks), dim3(wg_size));
-    sycl::local_accessor<uninitialized_array<ValueType, wg_size>, 0>
-        block_partial_acc(cgh);
+    sycl::local_accessor<ValueType, 1> block_partial(wg_size, cgh);
     cgh.parallel_for(
         range, [=](sycl::nd_item<3> id) [[sycl::reqd_sub_group_size(sg_size)]] {
             const auto sg_id = thread::get_subwarp_id_flat<sg_size, int64>(id);
@@ -425,7 +417,6 @@ void generic_kernel_col_reduction_2d_blocked(
             const auto sg_rank = subgroup.thread_rank();
             const auto col =
                 sg_rank + static_cast<int64>(id.get_group(1)) * sg_size;
-            auto block_partial = &(*block_partial_acc.get_pointer())[0];
             auto partial = identity;
             // accumulate within a thread
             if (col < cols) {

--- a/dpcpp/components/cooperative_groups.dp.hpp
+++ b/dpcpp/components/cooperative_groups.dp.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -161,7 +161,10 @@ public:
 
     __dpct_inline__ unsigned size() const noexcept { return Size; }
 
-    __dpct_inline__ void sync() const noexcept { this->barrier(); }
+    __dpct_inline__ void sync() const noexcept
+    {
+        sycl::group_barrier(static_cast<const sycl::sub_group&>(*this));
+    }
 #define GKO_BIND_SHFL(ShflOpName, ShflOp)                                      \
     template <typename ValueType, typename SelectorType>                       \
     __dpct_inline__ ValueType ShflOpName(ValueType var, SelectorType selector) \

--- a/dpcpp/components/cooperative_groups.dp.hpp
+++ b/dpcpp/components/cooperative_groups.dp.hpp
@@ -165,6 +165,7 @@ public:
     {
         sycl::group_barrier(static_cast<const sycl::sub_group&>(*this));
     }
+
 #define GKO_BIND_SHFL(ShflOpName, ShflOp)                                      \
     template <typename ValueType, typename SelectorType>                       \
     __dpct_inline__ ValueType ShflOpName(ValueType var, SelectorType selector) \

--- a/dpcpp/components/prefix_sum.dp.hpp
+++ b/dpcpp/components/prefix_sum.dp.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -100,10 +100,10 @@ __dpct_inline__ void subwarp_prefix_sum(ValueType element,
  *       `block_size`, `finalize_prefix_sum` has to be used as well.
  */
 template <typename DeviceConfig, typename ValueType>
-void start_prefix_sum(
-    size_type num_elements, ValueType* __restrict__ elements,
-    ValueType* __restrict__ block_sum, sycl::nd_item<3> item_ct1,
-    uninitialized_array<ValueType, DeviceConfig::block_size>& prefix_helper)
+void start_prefix_sum(size_type num_elements, ValueType* __restrict__ elements,
+                      ValueType* __restrict__ block_sum,
+                      sycl::nd_item<3> item_ct1,
+                      sycl::local_accessor<ValueType, 1> prefix_helper)
 {
     const auto tidx = thread::get_thread_id_flat(item_ct1);
     const auto element_id = item_ct1.get_local_id(2);
@@ -159,16 +159,14 @@ void start_prefix_sum(dim3 grid, dim3 block, size_type dynamic_shared_memory,
                       ValueType* elements, ValueType* block_sum)
 {
     queue->submit([&](sycl::handler& cgh) {
-        sycl::local_accessor<
-            uninitialized_array<ValueType, DeviceConfig::block_size>, 0>
-            prefix_helper_acc_ct1(cgh);
+        sycl::local_accessor<ValueType, 1> prefix_helper(
+            DeviceConfig::block_size, cgh);
 
-        cgh.parallel_for(sycl_nd_range(grid, block),
-                         [=](sycl::nd_item<3> item_ct1) {
-                             start_prefix_sum<DeviceConfig>(
-                                 num_elements, elements, block_sum, item_ct1,
-                                 *prefix_helper_acc_ct1.get_pointer());
-                         });
+        cgh.parallel_for(
+            sycl_nd_range(grid, block), [=](sycl::nd_item<3> item_ct1) {
+                start_prefix_sum<DeviceConfig>(
+                    num_elements, elements, block_sum, item_ct1, prefix_helper);
+            });
     });
 }
 

--- a/dpcpp/components/reduction.dp.hpp
+++ b/dpcpp/components/reduction.dp.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -194,18 +194,16 @@ void reduce_add_array(dim3 grid, dim3 block, size_type dynamic_shared_memory,
                       const ValueType* source, ValueType* result)
 {
     queue->submit([&](sycl::handler& cgh) {
-        sycl::local_accessor<uninitialized_array<device_type<ValueType>,
-                                                 DeviceConfig::block_size>,
-                             0>
-            block_sum_acc_ct1(cgh);
+        sycl::local_accessor<device_type<ValueType>, 0> block_sum(
+            DeviceConfig::block_size, cgh);
 
         cgh.parallel_for(
             sycl_nd_range(grid, block),
             [=](sycl::nd_item<3> item_ct1)
                 [[sycl::reqd_sub_group_size(DeviceConfig::subgroup_size)]] {
-                    reduce_add_array<DeviceConfig>(
-                        size, as_device_type(source), as_device_type(result),
-                        item_ct1, *block_sum_acc_ct1.get_pointer());
+                    reduce_add_array<DeviceConfig>(size, as_device_type(source),
+                                                   as_device_type(result),
+                                                   item_ct1, &block_sum[0]);
                 });
     });
 }

--- a/dpcpp/components/reduction.dp.hpp
+++ b/dpcpp/components/reduction.dp.hpp
@@ -179,7 +179,7 @@ void reduce_add_array(size_type size, const ValueType* __restrict__ source,
                       sycl::local_accessor<ValueType, 1> block_sum)
 {
     reduce_array<DeviceConfig::subgroup_size>(
-        size, source, block_sum, item_ct1,
+        size, source, &block_sum[0], item_ct1,
         [](const ValueType& x, const ValueType& y) { return x + y; });
 
     if (item_ct1.get_local_id(2) == 0) {

--- a/dpcpp/components/reduction.dp.hpp
+++ b/dpcpp/components/reduction.dp.hpp
@@ -174,13 +174,12 @@ void reduce_array(size_type size, const ValueType* __restrict__ source,
  * an array larger than `block_size`.
  */
 template <typename DeviceConfig, typename ValueType>
-void reduce_add_array(
-    size_type size, const ValueType* __restrict__ source,
-    ValueType* __restrict__ result, sycl::nd_item<3> item_ct1,
-    uninitialized_array<ValueType, DeviceConfig::block_size>& block_sum)
+void reduce_add_array(size_type size, const ValueType* __restrict__ source,
+                      ValueType* __restrict__ result, sycl::nd_item<3> item_ct1,
+                      sycl::local_accessor<ValueType, 1> block_sum)
 {
     reduce_array<DeviceConfig::subgroup_size>(
-        size, source, static_cast<ValueType*>(block_sum), item_ct1,
+        size, source, block_sum, item_ct1,
         [](const ValueType& x, const ValueType& y) { return x + y; });
 
     if (item_ct1.get_local_id(2) == 0) {
@@ -194,7 +193,7 @@ void reduce_add_array(dim3 grid, dim3 block, size_type dynamic_shared_memory,
                       const ValueType* source, ValueType* result)
 {
     queue->submit([&](sycl::handler& cgh) {
-        sycl::local_accessor<device_type<ValueType>, 0> block_sum(
+        sycl::local_accessor<device_type<ValueType>, 1> block_sum(
             DeviceConfig::block_size, cgh);
 
         cgh.parallel_for(
@@ -203,7 +202,7 @@ void reduce_add_array(dim3 grid, dim3 block, size_type dynamic_shared_memory,
                 [[sycl::reqd_sub_group_size(DeviceConfig::subgroup_size)]] {
                     reduce_add_array<DeviceConfig>(size, as_device_type(source),
                                                    as_device_type(result),
-                                                   item_ct1, &block_sum[0]);
+                                                   item_ct1, block_sum);
                 });
     });
 }

--- a/dpcpp/distributed/partition_kernels.dp.cpp
+++ b/dpcpp/distributed/partition_kernels.dp.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -24,8 +24,8 @@ template <typename LocalIndexType, typename GlobalIndexType>
 void setup_sizes_ids_permutation(
     std::shared_ptr<const DefaultExecutor> exec, size_type num_ranges,
     comm_index_type num_parts, const GlobalIndexType* range_offsets,
-    const comm_index_type* range_parts, Array<LocalIndexType>& range_sizes,
-    Array<comm_index_type>& part_ids, Array<GlobalIndexType>& permutation)
+    const comm_index_type* range_parts, array<LocalIndexType>& range_sizes,
+    array<comm_index_type>& part_ids, array<GlobalIndexType>& permutation)
 {
     run_kernel(
         exec,
@@ -48,9 +48,9 @@ void setup_sizes_ids_permutation(
 template <typename LocalIndexType, typename GlobalIndexType>
 void compute_part_sizes_and_starting_indices(
     std::shared_ptr<const DefaultExecutor> exec, size_type num_ranges,
-    const Array<LocalIndexType>& range_sizes,
-    const Array<comm_index_type>& part_ids,
-    const Array<GlobalIndexType>& permutation, LocalIndexType* starting_indices,
+    const array<LocalIndexType>& range_sizes,
+    const array<comm_index_type>& part_ids,
+    const array<GlobalIndexType>& permutation, LocalIndexType* starting_indices,
     LocalIndexType* part_sizes)
 {
     run_kernel(
@@ -91,10 +91,10 @@ void build_starting_indices(std::shared_ptr<const DefaultExecutor> exec,
     if (num_ranges > 0) {
         auto policy = onedpl_policy(exec);
 
-        Array<LocalIndexType> range_sizes{exec, num_ranges};
+        array<LocalIndexType> range_sizes{exec, num_ranges};
         // num_parts sentinel at the end
-        Array<comm_index_type> tmp_part_ids{exec, num_ranges + 1};
-        Array<GlobalIndexType> permutation{exec, num_ranges};
+        array<comm_index_type> tmp_part_ids{exec, num_ranges + 1};
+        array<GlobalIndexType> permutation{exec, num_ranges};
         // set part_sizes to 0 in case of empty parts
         components::fill_array(exec, part_sizes, num_parts,
                                zero<LocalIndexType>());

--- a/dpcpp/factorization/factorization_kernels.dp.cpp
+++ b/dpcpp/factorization/factorization_kernels.dp.cpp
@@ -480,9 +480,8 @@ void add_diagonal_elements(
                             exec->get_queue(), num_rows + 1, dpcpp_old_row_ptrs,
                             dpcpp_row_ptrs_add);
 
-    matrix::CsrBuilder<ValueType, IndexType> mtx_builder{mtx};
-    mtx_builder.get_value_array() = std::move(new_values);
-    mtx_builder.get_col_idx_array() = std::move(new_col_idxs);
+    mtx_builder->get_value_array() = std::move(new_values);
+    mtx_builder->get_col_idx_array() = std::move(new_col_idxs);
 }
 
 GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(

--- a/dpcpp/factorization/par_ilut_approx_filter_kernel.dp.cpp
+++ b/dpcpp/factorization/par_ilut_approx_filter_kernel.dp.cpp
@@ -52,13 +52,13 @@ using compiled_kernels = syn::value_list<int, 1, 16, 32>;
 
 
 template <int subgroup_size, typename ValueType, typename IndexType>
-void threshold_filter_approx(syn::value_list<int, subgroup_size>,
-                             std::shared_ptr<const DefaultExecutor> exec,
-                             const matrix::Csr<ValueType, IndexType>* m,
-                             IndexType rank, array<ValueType>* tmp,
-                             remove_complex<ValueType>* threshold,
-                             matrix::Csr<ValueType, IndexType>* m_out,
-                             matrix::Coo<ValueType, IndexType>* m_out_coo)
+void threshold_filter_approx(
+    syn::value_list<int, subgroup_size>,
+    std::shared_ptr<const DefaultExecutor> exec,
+    const matrix::Csr<ValueType, IndexType>* m, IndexType rank,
+    array<ValueType>* tmp, remove_complex<ValueType>* threshold,
+    matrix::CsrBuilder<ValueType, IndexType>* m_out_builder,
+    matrix::Coo<ValueType, IndexType>* m_out_coo)
 {
     auto values = m->get_const_values();
     IndexType size = m->get_num_stored_elements();
@@ -109,6 +109,7 @@ void threshold_filter_approx(syn::value_list<int, subgroup_size>,
     auto num_rows = static_cast<IndexType>(m->get_size()[0]);
     auto block_size = default_block_size / subgroup_size;
     auto num_blocks = ceildiv(num_rows, block_size);
+    auto m_out = m_out_builder->get_matrix();
     auto new_row_ptrs = m_out->get_row_ptrs();
     kernel::bucket_filter_nnz<subgroup_size>(
         num_blocks, default_block_size, 0, exec->get_queue(), old_row_ptrs,
@@ -120,9 +121,8 @@ void threshold_filter_approx(syn::value_list<int, subgroup_size>,
     // build matrix
     auto new_nnz = exec->copy_val_to_host(new_row_ptrs + num_rows);
     // resize arrays and update aliases
-    matrix::CsrBuilder<ValueType, IndexType> builder{m_out};
-    builder.get_col_idx_array().resize_and_reset(new_nnz);
-    builder.get_value_array().resize_and_reset(new_nnz);
+    m_out_builder->get_col_idx_array().resize_and_reset(new_nnz);
+    m_out_builder->get_value_array().resize_and_reset(new_nnz);
     auto new_col_idxs = m_out->get_col_idxs();
     auto new_vals = m_out->get_values();
     IndexType* new_row_idxs{};
@@ -147,12 +147,12 @@ GKO_ENABLE_IMPLEMENTATION_SELECTION(select_threshold_filter_approx,
 
 
 template <typename ValueType, typename IndexType>
-void threshold_filter_approx(std::shared_ptr<const DefaultExecutor> exec,
-                             const matrix::Csr<ValueType, IndexType>* m,
-                             IndexType rank, array<ValueType>& tmp,
-                             remove_complex<ValueType>& threshold,
-                             matrix::Csr<ValueType, IndexType>* m_out,
-                             matrix::Coo<ValueType, IndexType>* m_out_coo)
+void threshold_filter_approx(
+    std::shared_ptr<const DefaultExecutor> exec,
+    const matrix::Csr<ValueType, IndexType>* m, IndexType rank,
+    array<ValueType>& tmp, remove_complex<ValueType>& threshold,
+    matrix::CsrBuilder<ValueType, IndexType>* m_out_builder,
+    matrix::Coo<ValueType, IndexType>* m_out_coo)
 {
     auto num_rows = m->get_size()[0];
     auto total_nnz = m->get_num_stored_elements();
@@ -164,7 +164,7 @@ void threshold_filter_approx(std::shared_ptr<const DefaultExecutor> exec,
                    compiled_subgroup_size == config::warp_size;
         },
         syn::value_list<int>(), syn::type_list<>(), exec, m, rank, &tmp,
-        &threshold, m_out, m_out_coo);
+        &threshold, m_out_builder, m_out_coo);
 }
 
 GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(

--- a/dpcpp/factorization/par_ilut_select_kernels.hpp.inc
+++ b/dpcpp/factorization/par_ilut_select_kernels.hpp.inc
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -63,15 +63,14 @@ void build_searchtree(dim3 grid, dim3 block, size_type dynamic_shared_memory,
                       IndexType size, remove_complex<ValueType>* tree_output)
 {
     queue->submit([&](sycl::handler& cgh) {
-        sycl::local_accessor<remove_complex<ValueType>, 1> sh_samples_acc_ct1(
+        sycl::local_accessor<remove_complex<ValueType>, 1> sh_samples(
             sycl::range<1>(1024 /*sample_size*/), cgh);
 
         cgh.parallel_for(sycl_nd_range(grid, block),
                          [=](sycl::nd_item<3> item_ct1)
                              [[sycl::reqd_sub_group_size(config::warp_size)]] {
-                                 build_searchtree(
-                                     input, size, tree_output, item_ct1,
-                                     sh_samples_acc_ct1.get_pointer());
+                                 build_searchtree(input, size, tree_output,
+                                                  item_ct1, &sh_samples[0]);
                              });
     });
 }
@@ -143,19 +142,17 @@ void count_buckets(dim3 grid, dim3 block, size_type dynamic_shared_memory,
                    unsigned char* oracles, int items_per_thread)
 {
     queue->submit([&](sycl::handler& cgh) {
-        sycl::local_accessor<remove_complex<ValueType>, 1> sh_tree_acc_ct1(
+        sycl::local_accessor<remove_complex<ValueType>, 1> sh_tree(
             sycl::range<1>(255 /*searchtree_inner_size*/), cgh);
-        sycl::local_accessor<IndexType, 1> sh_counter_acc_ct1(
+        sycl::local_accessor<IndexType, 1> sh_counter(
             sycl::range<1>(256 /*searchtree_width*/), cgh);
 
-        cgh.parallel_for(
-            sycl_nd_range(grid, block), [=](sycl::nd_item<3> item_ct1) {
-                count_buckets(
-                    input, size, tree, counter, oracles, items_per_thread,
-                    item_ct1,
-                    (remove_complex<ValueType>*)sh_tree_acc_ct1.get_pointer(),
-                    (IndexType*)sh_counter_acc_ct1.get_pointer());
-            });
+        cgh.parallel_for(sycl_nd_range(grid, block),
+                         [=](sycl::nd_item<3> item_ct1) {
+                             count_buckets(input, size, tree, counter, oracles,
+                                           items_per_thread, item_ct1,
+                                           &sh_tree[0], &sh_counter[0]);
+                         });
     });
 }
 
@@ -244,19 +241,17 @@ void block_prefix_sum(dim3 grid, dim3 block, size_type dynamic_shared_memory,
                       IndexType* totals, IndexType num_blocks)
 {
     queue->submit([&](sycl::handler& cgh) {
-        sycl::local_accessor<IndexType, 1> warp_sums_acc_ct1(
+        sycl::local_accessor<IndexType, 1> warp_sums(
             sycl::range<1>(default_block_size /
                            config::warp_size /*num_warps*/),
             cgh);
 
-        cgh.parallel_for(
-            sycl_nd_range(grid, block),
-            [=](sycl::nd_item<3> item_ct1)
-                [[sycl::reqd_sub_group_size(config::warp_size)]] {
-                    block_prefix_sum(
-                        counters, totals, num_blocks, item_ct1,
-                        (IndexType*)warp_sums_acc_ct1.get_pointer());
-                });
+        cgh.parallel_for(sycl_nd_range(grid, block),
+                         [=](sycl::nd_item<3> item_ct1)
+                             [[sycl::reqd_sub_group_size(config::warp_size)]] {
+                                 block_prefix_sum(counters, totals, num_blocks,
+                                                  item_ct1, &warp_sums[0]);
+                             });
     });
 }
 
@@ -295,7 +290,7 @@ void filter_bucket(const ValueType* __restrict__ input, IndexType size,
     for (IndexType i = begin; i < end; i += default_block_size) {
         // only copy the element when it belongs to the target bucket
         auto found = bucket == oracles[i];
-        auto ofs = atomic_add<atomic::local_space>(&*counter, IndexType{found});
+        auto ofs = atomic_add<atomic::local_space>(counter, IndexType{found});
         if (found) {
             output[ofs] = gko::abs(input[i]);
         }
@@ -310,13 +305,12 @@ void filter_bucket(dim3 grid, dim3 block, size_type dynamic_shared_memory,
                    remove_complex<ValueType>* output, int items_per_thread)
 {
     queue->submit([&](sycl::handler& cgh) {
-        sycl::local_accessor<IndexType, 0> counter_acc_ct1(cgh);
+        sycl::local_accessor<IndexType, 1> counter(1, cgh);
 
         cgh.parallel_for(
             sycl_nd_range(grid, block), [=](sycl::nd_item<3> item_ct1) {
                 filter_bucket(input, size, bucket, oracles, block_offsets,
-                              output, items_per_thread, item_ct1,
-                              (IndexType*)counter_acc_ct1.get_pointer());
+                              output, items_per_thread, item_ct1, &counter[0]);
             });
     });
 }
@@ -351,16 +345,15 @@ void basecase_select(dim3 grid, dim3 block, size_type dynamic_shared_memory,
                      IndexType rank, ValueType* out)
 {
     queue->submit([&](sycl::handler& cgh) {
-        sycl::local_accessor<ValueType, 1> sh_local_acc_ct1(
+        sycl::local_accessor<ValueType, 1> sh_local(
             sycl::range<1>(1024 /*basecase_size*/), cgh);
 
-        cgh.parallel_for(
-            sycl_nd_range(grid, block),
-            [=](sycl::nd_item<3> item_ct1)
-                [[sycl::reqd_sub_group_size(config::warp_size)]] {
-                    basecase_select(input, size, rank, out, item_ct1,
-                                    (ValueType*)sh_local_acc_ct1.get_pointer());
-                });
+        cgh.parallel_for(sycl_nd_range(grid, block),
+                         [=](sycl::nd_item<3> item_ct1)
+                             [[sycl::reqd_sub_group_size(config::warp_size)]] {
+                                 basecase_select(input, size, rank, out,
+                                                 item_ct1, &sh_local[0]);
+                             });
     });
 }
 

--- a/dpcpp/factorization/par_ilut_spgeam_kernel.dp.cpp
+++ b/dpcpp/factorization/par_ilut_spgeam_kernel.dp.cpp
@@ -355,8 +355,8 @@ void add_candidates(syn::value_list<int, subgroup_size>,
     auto num_rows = static_cast<IndexType>(lu->get_size()[0]);
     auto subwarps_per_block = default_block_size / subgroup_size;
     auto num_blocks = ceildiv(num_rows, subwarps_per_block);
-    auto l_new = l_new->get_matrix();
-    auto u_new = u_new->get_matrix();
+    auto l_new = l_new_builder->get_matrix();
+    auto u_new = u_new_builder->get_matrix();
     auto lu_row_ptrs = lu->get_const_row_ptrs();
     auto lu_col_idxs = lu->get_const_col_idxs();
     auto lu_vals = as_device_type(lu->get_const_values());

--- a/dpcpp/matrix/csr_kernels.dp.cpp
+++ b/dpcpp/matrix/csr_kernels.dp.cpp
@@ -784,7 +784,7 @@ void check_unsorted(const IndexType* __restrict__ row_ptrs,
     }
 
     // fail early
-    if (bool(sh_flag)) {
+    if (static_cast<bool>(sh_flag)) {
         for (auto nz = row_ptrs[row]; nz < row_ptrs[row + 1] - 1; ++nz) {
             if (col_idxs[nz] > col_idxs[nz + 1]) {
                 *flag = false;

--- a/dpcpp/matrix/csr_kernels.dp.cpp
+++ b/dpcpp/matrix/csr_kernels.dp.cpp
@@ -1443,8 +1443,13 @@ bool try_general_sparselib_spmv(std::shared_ptr<const DpcppExecutor> exec,
         oneapi::mkl::sparse::matrix_handle_t mat_handle;
         oneapi::mkl::sparse::init_matrix_handle(&mat_handle);
         oneapi::mkl::sparse::set_csr_data(
-            *exec->get_queue(), mat_handle, IndexType(a->get_size()[0]),
-            IndexType(a->get_size()[1]), oneapi::mkl::index_base::zero,
+            *exec->get_queue(), mat_handle,
+            static_cast<IndexType>(a->get_size()[0]),
+            static_cast<IndexType>(a->get_size()[1]),
+#if INTEL_MKL_VERSION >= 20250300
+            static_cast<std::int64_t>(a->get_num_stored_elements()),
+#endif
+            oneapi::mkl::index_base::zero,
             const_cast<IndexType*>(a->get_const_row_ptrs()),
             const_cast<IndexType*>(a->get_const_col_idxs()),
             const_cast<ValueType*>(a->get_const_values()));

--- a/dpcpp/matrix/csr_kernels.dp.cpp
+++ b/dpcpp/matrix/csr_kernels.dp.cpp
@@ -40,7 +40,6 @@
 #include "dpcpp/components/reduction.dp.hpp"
 #include "dpcpp/components/segment_scan.dp.hpp"
 #include "dpcpp/components/thread_ids.dp.hpp"
-#include "dpcpp/components/uninitialized_array.hpp"
 
 
 namespace gko {
@@ -306,12 +305,13 @@ __dpct_inline__ void merge_path_search(
 
 template <typename arithmetic_type, typename IndexType,
           typename output_accessor, typename Alpha_op>
-void merge_path_reduce(
-    const IndexType nwarps, const arithmetic_type* __restrict__ last_val,
-    const IndexType* __restrict__ last_row, acc::range<output_accessor> c,
-    Alpha_op alpha_op, sycl::nd_item<3> item_ct1,
-    uninitialized_array<IndexType, spmv_block_size>& tmp_ind,
-    uninitialized_array<arithmetic_type, spmv_block_size>& tmp_val)
+void merge_path_reduce(const IndexType nwarps,
+                       const arithmetic_type* __restrict__ last_val,
+                       const IndexType* __restrict__ last_row,
+                       acc::range<output_accessor> c, Alpha_op alpha_op,
+                       sycl::nd_item<3> item_ct1,
+                       sycl::local_accessor<IndexType, 1> tmp_ind,
+                       sycl::local_accessor<arithmetic_type, 1> tmp_val)
 {
     const IndexType cache_lines = ceildivT<IndexType>(nwarps, spmv_block_size);
     const IndexType tid = item_ct1.get_local_id(2);
@@ -338,8 +338,8 @@ void merge_path_reduce(
     tmp_ind[item_ct1.get_local_id(2)] = row;
     group::this_thread_block(item_ct1).sync();
     bool last = block_segment_scan_reverse(
-        static_cast<IndexType*>(tmp_ind),
-        static_cast<arithmetic_type*>(tmp_val), item_ct1);
+        static_cast<IndexType*>(&tmp_ind[0]),
+        static_cast<arithmetic_type*>(&tmp_val[0]), item_ct1);
     group::this_thread_block(item_ct1).sync();
     if (last) {
         c(row, 0) += alpha_op(tmp_val[item_ct1.get_local_id(2)]);
@@ -358,7 +358,7 @@ void merge_path_spmv(
     IndexType* __restrict__ row_out,
     typename output_accessor::arithmetic_type* __restrict__ val_out,
     Alpha_op alpha_op, Beta_op beta_op, sycl::nd_item<3> item_ct1,
-    IndexType* shared_row_ptrs)
+    sycl::local_accessor<IndexType, 1> shared_row_ptrs)
 {
     using arithmetic_type = typename output_accessor::arithmetic_type;
     const auto* row_end_ptrs = row_ptrs + 1;
@@ -389,7 +389,7 @@ void merge_path_spmv(
     IndexType start_x;
     IndexType start_y;
     merge_path_search(IndexType(items_per_thread * item_ct1.get_local_id(2)),
-                      block_num_rows, block_num_nonzeros, shared_row_ptrs,
+                      block_num_rows, block_num_nonzeros, &shared_row_ptrs[0],
                       block_start_y, &start_x, &start_y);
 
 
@@ -411,9 +411,9 @@ void merge_path_spmv(
         }
     }
     group::this_thread_block(item_ct1).sync();
-    IndexType* tmp_ind = shared_row_ptrs;
+    IndexType* tmp_ind = &shared_row_ptrs[0];
     arithmetic_type* tmp_val =
-        reinterpret_cast<arithmetic_type*>(shared_row_ptrs + spmv_block_size);
+        reinterpret_cast<arithmetic_type*>(&shared_row_ptrs[spmv_block_size]);
     tmp_val[item_ct1.get_local_id(2)] = value;
     tmp_ind[item_ct1.get_local_id(2)] = row_i;
     group::this_thread_block(item_ct1).sync();
@@ -435,7 +435,8 @@ void abstract_merge_path_spmv(
     acc::range<input_accessor> b, acc::range<output_accessor> c,
     IndexType* __restrict__ row_out,
     typename output_accessor::arithmetic_type* __restrict__ val_out,
-    sycl::nd_item<3> item_ct1, IndexType* shared_row_ptrs)
+    sycl::nd_item<3> item_ct1,
+    sycl::local_accessor<IndexType, 1> shared_row_ptrs)
 {
     using type = typename output_accessor::arithmetic_type;
     merge_path_spmv<items_per_thread>(
@@ -454,16 +455,14 @@ void abstract_merge_path_spmv(
     IndexType* row_out, typename output_accessor::arithmetic_type* val_out)
 {
     queue->submit([&](sycl::handler& cgh) {
-        sycl::local_accessor<IndexType, 1> shared_row_ptrs_acc_ct1(
-            sycl::range<1>(spmv_block_size * items_per_thread), cgh);
+        sycl::local_accessor<IndexType, 1> shared_row_ptrs(
+            spmv_block_size * items_per_thread, cgh);
 
         cgh.parallel_for(sycl_nd_range(grid, block),
                          [=](sycl::nd_item<3> item_ct1) {
                              abstract_merge_path_spmv<items_per_thread>(
                                  num_rows, val, col_idxs, row_ptrs, srow, b, c,
-                                 row_out, val_out, item_ct1,
-                                 static_cast<IndexType*>(
-                                     shared_row_ptrs_acc_ct1.get_pointer()));
+                                 row_out, val_out, item_ct1, shared_row_ptrs);
                          });
     });
 }
@@ -480,7 +479,8 @@ void abstract_merge_path_spmv(
     const typename output_accessor::storage_type* __restrict__ beta,
     acc::range<output_accessor> c, IndexType* __restrict__ row_out,
     typename output_accessor::arithmetic_type* __restrict__ val_out,
-    sycl::nd_item<3> item_ct1, IndexType* shared_row_ptrs)
+    sycl::nd_item<3> item_ct1,
+    sycl::local_accessor<IndexType, 1> shared_row_ptrs)
 {
     using type = typename output_accessor::arithmetic_type;
     const type alpha_val = static_cast<type>(alpha[0]);
@@ -514,29 +514,27 @@ void abstract_merge_path_spmv(
     typename output_accessor::arithmetic_type* val_out)
 {
     queue->submit([&](sycl::handler& cgh) {
-        sycl::local_accessor<IndexType, 1> shared_row_ptrs_acc_ct1(
+        sycl::local_accessor<IndexType, 1> shared_row_ptrs(
             sycl::range<1>(spmv_block_size * items_per_thread), cgh);
 
-        cgh.parallel_for(sycl_nd_range(grid, block),
-                         [=](sycl::nd_item<3> item_ct1) {
-                             abstract_merge_path_spmv<items_per_thread>(
-                                 num_rows, alpha, val, col_idxs, row_ptrs, srow,
-                                 b, beta, c, row_out, val_out, item_ct1,
-                                 static_cast<IndexType*>(
-                                     shared_row_ptrs_acc_ct1.get_pointer()));
-                         });
+        cgh.parallel_for(
+            sycl_nd_range(grid, block), [=](sycl::nd_item<3> item_ct1) {
+                abstract_merge_path_spmv<items_per_thread>(
+                    num_rows, alpha, val, col_idxs, row_ptrs, srow, b, beta, c,
+                    row_out, val_out, item_ct1, shared_row_ptrs);
+            });
     });
 }
 
 
 template <typename arithmetic_type, typename IndexType,
           typename output_accessor>
-void abstract_reduce(
-    const IndexType nwarps, const arithmetic_type* __restrict__ last_val,
-    const IndexType* __restrict__ last_row, acc::range<output_accessor> c,
-    sycl::nd_item<3> item_ct1,
-    uninitialized_array<IndexType, spmv_block_size>& tmp_ind,
-    uninitialized_array<arithmetic_type, spmv_block_size>& tmp_val)
+void abstract_reduce(const IndexType nwarps,
+                     const arithmetic_type* __restrict__ last_val,
+                     const IndexType* __restrict__ last_row,
+                     acc::range<output_accessor> c, sycl::nd_item<3> item_ct1,
+                     sycl::local_accessor<IndexType, 1> tmp_ind,
+                     sycl::local_accessor<arithmetic_type, 1> tmp_val)
 {
     merge_path_reduce(
         nwarps, last_val, last_row, c,
@@ -552,31 +550,27 @@ void abstract_reduce(dim3 grid, dim3 block, size_type dynamic_shared_memory,
                      acc::range<output_accessor> c)
 {
     queue->submit([&](sycl::handler& cgh) {
-        sycl::local_accessor<uninitialized_array<IndexType, spmv_block_size>, 0>
-            tmp_ind_acc_ct1(cgh);
-        sycl::local_accessor<
-            uninitialized_array<arithmetic_type, spmv_block_size>, 0>
-            tmp_val_acc_ct1(cgh);
+        sycl::local_accessor<IndexType, 1> tmp_ind(spmv_block_size, cgh);
+        sycl::local_accessor<arithmetic_type, 1> tmp_val(spmv_block_size, cgh);
 
-        cgh.parallel_for(
-            sycl_nd_range(grid, block), [=](sycl::nd_item<3> item_ct1) {
-                abstract_reduce(nwarps, last_val, last_row, c, item_ct1,
-                                *tmp_ind_acc_ct1.get_pointer(),
-                                *tmp_val_acc_ct1.get_pointer());
-            });
+        cgh.parallel_for(sycl_nd_range(grid, block),
+                         [=](sycl::nd_item<3> item_ct1) {
+                             abstract_reduce(nwarps, last_val, last_row, c,
+                                             item_ct1, tmp_ind, tmp_val);
+                         });
     });
 }
 
 
 template <typename arithmetic_type, typename MatrixValueType,
           typename IndexType, typename output_accessor>
-void abstract_reduce(
-    const IndexType nwarps, const arithmetic_type* __restrict__ last_val,
-    const IndexType* __restrict__ last_row,
-    const MatrixValueType* __restrict__ alpha, acc::range<output_accessor> c,
-    sycl::nd_item<3> item_ct1,
-    uninitialized_array<IndexType, spmv_block_size>& tmp_ind,
-    uninitialized_array<arithmetic_type, spmv_block_size>& tmp_val)
+void abstract_reduce(const IndexType nwarps,
+                     const arithmetic_type* __restrict__ last_val,
+                     const IndexType* __restrict__ last_row,
+                     const MatrixValueType* __restrict__ alpha,
+                     acc::range<output_accessor> c, sycl::nd_item<3> item_ct1,
+                     sycl::local_accessor<IndexType, 1> tmp_ind,
+                     sycl::local_accessor<arithmetic_type, 1> tmp_val)
 {
     const auto alpha_val = static_cast<arithmetic_type>(alpha[0]);
     merge_path_reduce(
@@ -594,18 +588,14 @@ void abstract_reduce(dim3 grid, dim3 block, size_type dynamic_shared_memory,
                      acc::range<output_accessor> c)
 {
     queue->submit([&](sycl::handler& cgh) {
-        sycl::local_accessor<uninitialized_array<IndexType, spmv_block_size>, 0>
-            tmp_ind_acc_ct1(cgh);
-        sycl::local_accessor<
-            uninitialized_array<arithmetic_type, spmv_block_size>, 0>
-            tmp_val_acc_ct1(cgh);
+        sycl::local_accessor<IndexType, 1> tmp_ind(spmv_block_size, cgh);
+        sycl::local_accessor<arithmetic_type, 1> tmp_val(spmv_block_size, cgh);
 
-        cgh.parallel_for(
-            sycl_nd_range(grid, block), [=](sycl::nd_item<3> item_ct1) {
-                abstract_reduce(nwarps, last_val, last_row, alpha, c, item_ct1,
-                                *tmp_ind_acc_ct1.get_pointer(),
-                                *tmp_val_acc_ct1.get_pointer());
-            });
+        cgh.parallel_for(sycl_nd_range(grid, block),
+                         [=](sycl::nd_item<3> item_ct1) {
+                             abstract_reduce(nwarps, last_val, last_row, alpha,
+                                             c, item_ct1, tmp_ind, tmp_val);
+                         });
     });
 }
 
@@ -779,11 +769,12 @@ GKO_ENABLE_DEFAULT_HOST(fill_in_dense, fill_in_dense);
 template <typename IndexType>
 void check_unsorted(const IndexType* __restrict__ row_ptrs,
                     const IndexType* __restrict__ col_idxs, IndexType num_rows,
-                    bool* flag, sycl::nd_item<3> item_ct1, bool* sh_flag)
+                    bool* flag, sycl::nd_item<3> item_ct1,
+                    sycl::local_accessor<bool, 0> sh_flag)
 {
     auto block = group::this_thread_block(item_ct1);
     if (block.thread_rank() == 0) {
-        *sh_flag = *flag;
+        sh_flag = *flag;
     }
     block.sync();
 
@@ -793,11 +784,11 @@ void check_unsorted(const IndexType* __restrict__ row_ptrs,
     }
 
     // fail early
-    if ((*sh_flag)) {
+    if (bool(sh_flag)) {
         for (auto nz = row_ptrs[row]; nz < row_ptrs[row + 1] - 1; ++nz) {
             if (col_idxs[nz] > col_idxs[nz + 1]) {
                 *flag = false;
-                *sh_flag = false;
+                sh_flag = false;
                 return;
             }
         }
@@ -810,13 +801,13 @@ void check_unsorted(dim3 grid, dim3 block, size_type dynamic_shared_memory,
                     const IndexType* col_idxs, IndexType num_rows, bool* flag)
 {
     queue->submit([&](sycl::handler& cgh) {
-        sycl::local_accessor<bool, 0> sh_flag_acc_ct1(cgh);
+        sycl::local_accessor<bool, 0> sh_flag(cgh);
 
-        cgh.parallel_for(
-            sycl_nd_range(grid, block), [=](sycl::nd_item<3> item_ct1) {
-                check_unsorted(row_ptrs, col_idxs, num_rows, flag, item_ct1,
-                               sh_flag_acc_ct1.get_pointer());
-            });
+        cgh.parallel_for(sycl_nd_range(grid, block),
+                         [=](sycl::nd_item<3> item_ct1) {
+                             check_unsorted(row_ptrs, col_idxs, num_rows, flag,
+                                            item_ct1, sh_flag);
+                         });
     });
 }
 

--- a/dpcpp/matrix/dense_kernels.dp.cpp
+++ b/dpcpp/matrix/dense_kernels.dp.cpp
@@ -25,7 +25,6 @@
 #include "dpcpp/components/cooperative_groups.dp.hpp"
 #include "dpcpp/components/reduction.dp.hpp"
 #include "dpcpp/components/thread_ids.dp.hpp"
-#include "dpcpp/components/uninitialized_array.hpp"
 #include "dpcpp/synthesizer/implementation_selection.hpp"
 
 
@@ -57,7 +56,7 @@ void transpose(const size_type nrows, const size_type ncols,
                const ValueType* __restrict__ in, const size_type in_stride,
                ValueType* __restrict__ out, const size_type out_stride,
                Closure op, sycl::nd_item<3> item_ct1,
-               uninitialized_array<ValueType, sg_size*(sg_size + 1)>& space)
+               sycl::local_accessor<device_type<ValueType>, 1> space)
 {
     auto local_x = item_ct1.get_local_id(2);
     auto local_y = item_ct1.get_local_id(1);
@@ -76,13 +75,11 @@ void transpose(const size_type nrows, const size_type ncols,
 }
 
 template <typename DeviceConfig, typename ValueType>
-void transpose(
-    const size_type nrows, const size_type ncols,
-    const ValueType* __restrict__ in, const size_type in_stride,
-    ValueType* __restrict__ out, const size_type out_stride,
-    sycl::nd_item<3> item_ct1,
-    uninitialized_array<ValueType, DeviceConfig::subgroup_size*(
-                                       DeviceConfig::subgroup_size + 1)>& space)
+void transpose(const size_type nrows, const size_type ncols,
+               const ValueType* __restrict__ in, const size_type in_stride,
+               ValueType* __restrict__ out, const size_type out_stride,
+               sycl::nd_item<3> item_ct1,
+               sycl::local_accessor<device_type<ValueType>, 1> space)
 {
     transpose<DeviceConfig::subgroup_size>(
         nrows, ncols, in, in_stride, out, out_stride,
@@ -99,10 +96,8 @@ void transpose(sycl::queue* queue, matrix::view::dense<const ValueType> orig,
     dim3 block(sg_size, sg_size);
 
     queue->submit([&](sycl::handler& cgh) {
-        sycl::local_accessor<
-            uninitialized_array<device_type<ValueType>, sg_size*(sg_size + 1)>,
-            0>
-            space_acc_ct1(cgh);
+        sycl::local_accessor<device_type<ValueType>, 1> space_acc(
+            sg_size * (sg_size + 1), cgh);
         // Can not pass the member to device function directly
         auto in = as_device_type(orig.values);
         auto in_stride = orig.stride;
@@ -111,8 +106,7 @@ void transpose(sycl::queue* queue, matrix::view::dense<const ValueType> orig,
         cgh.parallel_for(
             sycl_nd_range(grid, block), [=](sycl::nd_item<3> item_ct1) {
                 transpose<DeviceConfig>(size[0], size[1], in, in_stride, out,
-                                        out_stride, item_ct1,
-                                        *space_acc_ct1.get_pointer());
+                                        out_stride, item_ct1, space_acc);
             });
     });
 }
@@ -122,13 +116,11 @@ GKO_ENABLE_DEFAULT_CONFIG_CALL_TYPE(transpose_call, transpose);
 
 
 template <typename DeviceConfig, typename ValueType>
-void conj_transpose(
-    const size_type nrows, const size_type ncols,
-    const ValueType* __restrict__ in, const size_type in_stride,
-    ValueType* __restrict__ out, const size_type out_stride,
-    sycl::nd_item<3> item_ct1,
-    uninitialized_array<ValueType, DeviceConfig::subgroup_size*(
-                                       DeviceConfig::subgroup_size + 1)>& space)
+void conj_transpose(const size_type nrows, const size_type ncols,
+                    const ValueType* __restrict__ in, const size_type in_stride,
+                    ValueType* __restrict__ out, const size_type out_stride,
+                    sycl::nd_item<3> item_ct1,
+                    sycl::local_accessor<device_type<ValueType>, 1> space)
 {
     transpose<DeviceConfig::subgroup_size>(
         nrows, ncols, in, in_stride, out, out_stride,
@@ -144,16 +136,14 @@ void conj_transpose(dim3 grid, dim3 block, size_type dynamic_shared_memory,
 {
     constexpr auto sg_size = DeviceConfig::subgroup_size;
     queue->submit([&](sycl::handler& cgh) {
-        sycl::local_accessor<
-            uninitialized_array<ValueType, sg_size*(sg_size + 1)>, 0>
-            space_acc_ct1(cgh);
+        sycl::local_accessor<device_type<ValueType>, 1> space_acc(
+            sg_size * (sg_size + 1), cgh);
 
         cgh.parallel_for(
             sycl_nd_range(grid, block),
             [=](sycl::nd_item<3> item_ct1) __WG_BOUND__(sg_size, sg_size) {
                 conj_transpose<DeviceConfig>(nrows, ncols, in, in_stride, out,
-                                             out_stride, item_ct1,
-                                             *space_acc_ct1.get_pointer());
+                                             out_stride, item_ct1, space_acc);
             });
     });
 }

--- a/dpcpp/matrix/ell_kernels.dp.cpp
+++ b/dpcpp/matrix/ell_kernels.dp.cpp
@@ -93,8 +93,7 @@ void spmv_kernel(
     const size_type stride, const size_type num_stored_elements_per_row,
     acc::range<b_accessor> b, OutputValueType* __restrict__ c,
     const size_type c_stride, Closure op, sycl::nd_item<3> item_ct1,
-    uninitialized_array<typename a_accessor::arithmetic_type,
-                        default_block_size / num_thread_per_worker>& storage)
+    sycl::local_accessor<typename a_accessor::arithmetic_type, 1> storage)
 {
     using arithmetic_type = typename a_accessor::arithmetic_type;
     const auto tidx = thread::get_thread_id_flat(item_ct1);
@@ -161,14 +160,12 @@ void spmv_kernel(
 
 template <int num_thread_per_worker, bool atomic = false, typename b_accessor,
           typename a_accessor, typename OutputValueType, typename IndexType>
-void spmv(
-    const size_type num_rows, const int num_worker_per_row,
-    acc::range<a_accessor> val, const IndexType* __restrict__ col,
-    const size_type stride, const size_type num_stored_elements_per_row,
-    acc::range<b_accessor> b, OutputValueType* __restrict__ c,
-    const size_type c_stride, sycl::nd_item<3> item_ct1,
-    uninitialized_array<typename a_accessor::arithmetic_type,
-                        default_block_size / num_thread_per_worker>& storage)
+void spmv(const size_type num_rows, const int num_worker_per_row,
+          acc::range<a_accessor> val, const IndexType* __restrict__ col,
+          const size_type stride, const size_type num_stored_elements_per_row,
+          acc::range<b_accessor> b, OutputValueType* __restrict__ c,
+          const size_type c_stride, sycl::nd_item<3> item_ct1,
+          sycl::local_accessor<typename a_accessor::arithmetic_type> storage)
 {
     spmv_kernel<num_thread_per_worker, atomic>(
         num_rows, num_worker_per_row, val, col, stride,
@@ -189,18 +186,15 @@ void spmv(dim3 grid, dim3 block, size_type dynamic_shared_memory,
           OutputValueType* c, const size_type c_stride)
 {
     queue->submit([&](sycl::handler& cgh) {
-        sycl::local_accessor<
-            uninitialized_array<typename a_accessor::arithmetic_type,
-                                default_block_size / num_thread_per_worker>,
-            0>
-            storage_acc_ct1(cgh);
+        sycl::local_accessor<typename a_accessor::arithmetic_type, 1> storage(
+            default_block_size / num_thread_per_worker, cgh);
 
         cgh.parallel_for(sycl_nd_range(grid, block),
                          [=](sycl::nd_item<3> item_ct1) {
                              spmv<num_thread_per_worker, atomic>(
                                  num_rows, num_worker_per_row, val, col, stride,
                                  num_stored_elements_per_row, b, c, c_stride,
-                                 item_ct1, *storage_acc_ct1.get_pointer());
+                                 item_ct1, storage);
                          });
     });
 }
@@ -208,15 +202,14 @@ void spmv(dim3 grid, dim3 block, size_type dynamic_shared_memory,
 
 template <int num_thread_per_worker, bool atomic = false, typename b_accessor,
           typename a_accessor, typename OutputValueType, typename IndexType>
-void spmv(
-    const size_type num_rows, const int num_worker_per_row,
-    acc::range<a_accessor> alpha, acc::range<a_accessor> val,
-    const IndexType* __restrict__ col, const size_type stride,
-    const size_type num_stored_elements_per_row, acc::range<b_accessor> b,
-    const OutputValueType* __restrict__ beta, OutputValueType* __restrict__ c,
-    const size_type c_stride, sycl::nd_item<3> item_ct1,
-    uninitialized_array<typename a_accessor::arithmetic_type,
-                        default_block_size / num_thread_per_worker>& storage)
+void spmv(const size_type num_rows, const int num_worker_per_row,
+          acc::range<a_accessor> alpha, acc::range<a_accessor> val,
+          const IndexType* __restrict__ col, const size_type stride,
+          const size_type num_stored_elements_per_row, acc::range<b_accessor> b,
+          const OutputValueType* __restrict__ beta,
+          OutputValueType* __restrict__ c, const size_type c_stride,
+          sycl::nd_item<3> item_ct1,
+          sycl::local_accessor<typename a_accessor::arithmetic_type, 1> storage)
 {
     using arithmetic_type = typename a_accessor::arithmetic_type;
     const auto alpha_val = alpha(0);
@@ -269,19 +262,16 @@ void spmv(dim3 grid, dim3 block, size_type dynamic_shared_memory,
           OutputValueType* c, const size_type c_stride)
 {
     queue->submit([&](sycl::handler& cgh) {
-        sycl::local_accessor<
-            uninitialized_array<typename a_accessor::arithmetic_type,
-                                default_block_size / num_thread_per_worker>,
-            0>
-            storage_acc_ct1(cgh);
+        sycl::local_accessor<typename a_accessor::arithmetic_type, 1> storage(
+            default_block_size / num_thread_per_worker, cgh);
 
-        cgh.parallel_for(
-            sycl_nd_range(grid, block), [=](sycl::nd_item<3> item_ct1) {
-                spmv<num_thread_per_worker, atomic>(
-                    num_rows, num_worker_per_row, alpha, val, col, stride,
-                    num_stored_elements_per_row, b, beta, c, c_stride, item_ct1,
-                    *storage_acc_ct1.get_pointer());
-            });
+        cgh.parallel_for(sycl_nd_range(grid, block),
+                         [=](sycl::nd_item<3> item_ct1) {
+                             spmv<num_thread_per_worker, atomic>(
+                                 num_rows, num_worker_per_row, alpha, val, col,
+                                 stride, num_stored_elements_per_row, b, beta,
+                                 c, c_stride, item_ct1, storage);
+                         });
     });
 }
 

--- a/dpcpp/matrix/sparsity_csr_kernels.dp.cpp
+++ b/dpcpp/matrix/sparsity_csr_kernels.dp.cpp
@@ -22,7 +22,6 @@
 #include "dpcpp/components/cooperative_groups.dp.hpp"
 #include "dpcpp/components/reduction.dp.hpp"
 #include "dpcpp/components/thread_ids.dp.hpp"
-#include "dpcpp/components/uninitialized_array.hpp"
 
 
 namespace gko {

--- a/dpcpp/preconditioner/batch_jacobi_kernels.dp.cpp
+++ b/dpcpp/preconditioner/batch_jacobi_kernels.dp.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -95,7 +95,7 @@ void extract_common_blocks_pattern(
         cgh.parallel_for(
             sycl_nd_range(grid, block),
             [=](sycl::nd_item<3> item_ct1)
-                [[intel::reqd_sub_group_size(subgroup_size)]] {
+                [[sycl::reqd_sub_group_size(subgroup_size)]] {
                     batch_single_kernels::extract_common_block_pattern_kernel(
                         static_cast<int>(nrows), row_ptrs, col_idxs, num_blocks,
                         cumulative_block_storage, block_pointers, map_block_row,
@@ -141,7 +141,7 @@ void compute_block_jacobi_helper(
         cgh.parallel_for(
             sycl_nd_range(grid, block),
             [=](sycl::nd_item<3> item_ct1)
-                [[intel::reqd_sub_group_size(subgroup_size)]] {
+                [[sycl::reqd_sub_group_size(subgroup_size)]] {
                     batch_single_kernels::compute_block_jacobi_kernel(
                         nbatch, static_cast<int>(nnz), sys_csr_values,
                         num_blocks, cumulative_block_storage, block_pointers,

--- a/dpcpp/preconditioner/batch_jacobi_kernels.hpp
+++ b/dpcpp/preconditioner/batch_jacobi_kernels.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -96,7 +96,7 @@ __dpct_inline__ int choose_pivot(const int block_size,
     if (sg_tid >= block_size) {
         my_abs_ele = static_cast<real_type>(-1);
     }
-    sg.barrier();
+    sycl::group_barrier(sg);
     int my_piv_idx = sg_tid;
     for (int a = sg_size / 2; a > 0; a /= 2) {
         const real_type abs_ele_other =
@@ -107,7 +107,7 @@ __dpct_inline__ int choose_pivot(const int block_size,
             my_piv_idx = piv_idx_other;
         }
     }
-    sg.barrier();
+    sycl::group_barrier(sg);
     const int ipiv = sycl::select_from_group(sg, my_piv_idx, 0);
     return ipiv;
 }
@@ -218,7 +218,7 @@ __dpct_inline__ void compute_block_jacobi_kernel(
     // not mean anything. Also, values in the block_row for
     // index >= block_size are meaningless
     invert_dense_block(block_size, block_row, perm, item_ct1);
-    sg.barrier();
+    sycl::group_barrier(sg);
 
     // write back the transpose of the transposed inverse matrix to block
     // array

--- a/dpcpp/preconditioner/isai_kernels.dp.cpp
+++ b/dpcpp/preconditioner/isai_kernels.dp.cpp
@@ -21,7 +21,6 @@
 #include "dpcpp/components/merging.dp.hpp"
 #include "dpcpp/components/reduction.dp.hpp"
 #include "dpcpp/components/thread_ids.dp.hpp"
-#include "dpcpp/components/uninitialized_array.hpp"
 #include "dpcpp/components/warp_blas.dp.hpp"
 
 
@@ -62,9 +61,7 @@ __dpct_inline__ void generic_generate(
     const IndexType* __restrict__ i_col_idxs, ValueType* __restrict__ i_values,
     IndexType* __restrict__ excess_rhs_sizes,
     IndexType* __restrict__ excess_nnz, Callable direct_solve,
-    sycl::nd_item<3> item_ct1,
-    uninitialized_array<ValueType, subwarp_size * subwarp_size *
-                                       subwarps_per_block>& storage)
+    sycl::nd_item<3> item_ct1, sycl::local_accessor<ValueType, 1> storage)
 {
     static_assert(subwarp_size >= row_size_limit, "incompatible subwarp_size");
     const auto row =
@@ -193,16 +190,17 @@ __dpct_inline__ void generic_generate(
 
 template <int subwarp_size, int subwarps_per_block, typename ValueType,
           typename IndexType>
-void generate_l_inverse(
-    IndexType num_rows, const IndexType* __restrict__ m_row_ptrs,
-    const IndexType* __restrict__ m_col_idxs,
-    const ValueType* __restrict__ m_values,
-    const IndexType* __restrict__ i_row_ptrs,
-    const IndexType* __restrict__ i_col_idxs, ValueType* __restrict__ i_values,
-    IndexType* __restrict__ excess_rhs_sizes,
-    IndexType* __restrict__ excess_nnz, sycl::nd_item<3> item_ct1,
-    uninitialized_array<ValueType, subwarp_size * subwarp_size *
-                                       subwarps_per_block>& storage)
+void generate_l_inverse(IndexType num_rows,
+                        const IndexType* __restrict__ m_row_ptrs,
+                        const IndexType* __restrict__ m_col_idxs,
+                        const ValueType* __restrict__ m_values,
+                        const IndexType* __restrict__ i_row_ptrs,
+                        const IndexType* __restrict__ i_col_idxs,
+                        ValueType* __restrict__ i_values,
+                        IndexType* __restrict__ excess_rhs_sizes,
+                        IndexType* __restrict__ excess_nnz,
+                        sycl::nd_item<3> item_ct1,
+                        sycl::local_accessor<ValueType, 1> storage)
 {
     auto trs_solve =
         [](IndexType num_elems, const ValueType* __restrict__ local_row,
@@ -242,11 +240,8 @@ void generate_l_inverse(dim3 grid, dim3 block, size_type dynamic_shared_memory,
                         IndexType* excess_rhs_sizes, IndexType* excess_nnz)
 {
     queue->submit([&](sycl::handler& cgh) {
-        sycl::local_accessor<
-            uninitialized_array<ValueType, subwarp_size * subwarp_size *
-                                               subwarps_per_block>,
-            0>
-            storage_acc_ct1(cgh);
+        sycl::local_accessor<ValueType, 1> storage(
+            subwarp_size * subwarp_size * subwarps_per_block, cgh);
 
         cgh.parallel_for(
             sycl_nd_range(grid, block),
@@ -255,7 +250,7 @@ void generate_l_inverse(dim3 grid, dim3 block, size_type dynamic_shared_memory,
                     generate_l_inverse<subwarp_size, subwarps_per_block>(
                         num_rows, m_row_ptrs, m_col_idxs, m_values, i_row_ptrs,
                         i_col_idxs, i_values, excess_rhs_sizes, excess_nnz,
-                        item_ct1, *storage_acc_ct1.get_pointer());
+                        item_ct1, storage);
                 });
     });
 }
@@ -263,16 +258,17 @@ void generate_l_inverse(dim3 grid, dim3 block, size_type dynamic_shared_memory,
 
 template <int subwarp_size, int subwarps_per_block, typename ValueType,
           typename IndexType>
-void generate_u_inverse(
-    IndexType num_rows, const IndexType* __restrict__ m_row_ptrs,
-    const IndexType* __restrict__ m_col_idxs,
-    const ValueType* __restrict__ m_values,
-    const IndexType* __restrict__ i_row_ptrs,
-    const IndexType* __restrict__ i_col_idxs, ValueType* __restrict__ i_values,
-    IndexType* __restrict__ excess_rhs_sizes,
-    IndexType* __restrict__ excess_nnz, sycl::nd_item<3> item_ct1,
-    uninitialized_array<ValueType, subwarp_size * subwarp_size *
-                                       subwarps_per_block>& storage)
+void generate_u_inverse(IndexType num_rows,
+                        const IndexType* __restrict__ m_row_ptrs,
+                        const IndexType* __restrict__ m_col_idxs,
+                        const ValueType* __restrict__ m_values,
+                        const IndexType* __restrict__ i_row_ptrs,
+                        const IndexType* __restrict__ i_col_idxs,
+                        ValueType* __restrict__ i_values,
+                        IndexType* __restrict__ excess_rhs_sizes,
+                        IndexType* __restrict__ excess_nnz,
+                        sycl::nd_item<3> item_ct1,
+                        sycl::local_accessor<ValueType, 1> storage)
 {
     auto trs_solve = [](IndexType num_elems,
                         const ValueType* __restrict__ local_row,
@@ -312,11 +308,8 @@ void generate_u_inverse(dim3 grid, dim3 block, size_type dynamic_shared_memory,
                         IndexType* excess_rhs_sizes, IndexType* excess_nnz)
 {
     queue->submit([&](sycl::handler& cgh) {
-        sycl::local_accessor<
-            uninitialized_array<ValueType, subwarp_size * subwarp_size *
-                                               subwarps_per_block>,
-            0>
-            storage_acc_ct1(cgh);
+        sycl::local_accessor<ValueType, 1> storage(
+            subwarp_size * subwarp_size * subwarps_per_block, cgh);
 
         cgh.parallel_for(
             sycl_nd_range(grid, block),
@@ -325,7 +318,7 @@ void generate_u_inverse(dim3 grid, dim3 block, size_type dynamic_shared_memory,
                     generate_u_inverse<subwarp_size, subwarps_per_block>(
                         num_rows, m_row_ptrs, m_col_idxs, m_values, i_row_ptrs,
                         i_col_idxs, i_values, excess_rhs_sizes, excess_nnz,
-                        item_ct1, *storage_acc_ct1.get_pointer());
+                        item_ct1, storage);
                 });
     });
 }
@@ -333,16 +326,17 @@ void generate_u_inverse(dim3 grid, dim3 block, size_type dynamic_shared_memory,
 
 template <int subwarp_size, int subwarps_per_block, typename ValueType,
           typename IndexType>
-void generate_general_inverse(
-    IndexType num_rows, const IndexType* __restrict__ m_row_ptrs,
-    const IndexType* __restrict__ m_col_idxs,
-    const ValueType* __restrict__ m_values,
-    const IndexType* __restrict__ i_row_ptrs,
-    const IndexType* __restrict__ i_col_idxs, ValueType* __restrict__ i_values,
-    IndexType* __restrict__ excess_rhs_sizes,
-    IndexType* __restrict__ excess_nnz, bool spd, sycl::nd_item<3> item_ct1,
-    uninitialized_array<ValueType, subwarp_size * subwarp_size *
-                                       subwarps_per_block>& storage)
+void generate_general_inverse(IndexType num_rows,
+                              const IndexType* __restrict__ m_row_ptrs,
+                              const IndexType* __restrict__ m_col_idxs,
+                              const ValueType* __restrict__ m_values,
+                              const IndexType* __restrict__ i_row_ptrs,
+                              const IndexType* __restrict__ i_col_idxs,
+                              ValueType* __restrict__ i_values,
+                              IndexType* __restrict__ excess_rhs_sizes,
+                              IndexType* __restrict__ excess_nnz, bool spd,
+                              sycl::nd_item<3> item_ct1,
+                              sycl::local_accessor<ValueType, 1> storage)
 {
     auto general_solve = [spd](IndexType num_elems,
                                ValueType* __restrict__ local_row,
@@ -394,11 +388,8 @@ void generate_general_inverse(
     bool spd)
 {
     queue->submit([&](sycl::handler& cgh) {
-        sycl::local_accessor<
-            uninitialized_array<ValueType, subwarp_size * subwarp_size *
-                                               subwarps_per_block>,
-            0>
-            storage_acc_ct1(cgh);
+        sycl::local_accessor<ValueType, 1> storage(
+            subwarp_size * subwarp_size * subwarps_per_block, cgh);
 
         cgh.parallel_for(
             sycl_nd_range(grid, block),
@@ -407,7 +398,7 @@ void generate_general_inverse(
                     generate_general_inverse<subwarp_size, subwarps_per_block>(
                         num_rows, m_row_ptrs, m_col_idxs, m_values, i_row_ptrs,
                         i_col_idxs, i_values, excess_rhs_sizes, excess_nnz, spd,
-                        item_ct1, *storage_acc_ct1.get_pointer());
+                        item_ct1, storage);
                 });
     });
 }

--- a/dpcpp/preconditioner/jacobi_generate_instantiate.inc.dp.cpp
+++ b/dpcpp/preconditioner/jacobi_generate_instantiate.inc.dp.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -20,7 +20,6 @@
 #include "dpcpp/components/cooperative_groups.dp.hpp"
 #include "dpcpp/components/diagonal_block_manipulation.dp.hpp"
 #include "dpcpp/components/thread_ids.dp.hpp"
-#include "dpcpp/components/uninitialized_array.hpp"
 #include "dpcpp/components/warp_blas.dp.hpp"
 #include "dpcpp/preconditioner/jacobi_common.hpp"
 
@@ -93,8 +92,7 @@ void generate(
     const ValueType* __restrict__ values, ValueType* __restrict__ block_data,
     preconditioner::block_interleaved_storage_scheme<IndexType> storage_scheme,
     const IndexType* __restrict__ block_ptrs, size_type num_blocks,
-    sycl::nd_item<3> item_ct1,
-    uninitialized_array<ValueType, max_block_size * warps_per_block>& workspace)
+    sycl::nd_item<3> item_ct1, sycl::local_accessor<ValueType, 1> workspace)
 {
     const auto block_id =
         thread::get_subwarp_id<subwarp_size, warps_per_block>(item_ct1);
@@ -129,9 +127,8 @@ void generate(
     const IndexType* block_ptrs, size_type num_blocks)
 {
     queue->submit([&](sycl::handler& cgh) {
-        sycl::local_accessor<
-            uninitialized_array<ValueType, max_block_size * warps_per_block>, 0>
-            workspace_acc_ct1(cgh);
+        sycl::local_accessor<ValueType, 1> workspace(
+            max_block_size * warps_per_block, cgh);
 
         cgh.parallel_for(
             sycl_nd_range(grid, block),
@@ -140,7 +137,7 @@ void generate(
                     generate<max_block_size, subwarp_size, warps_per_block>(
                         num_rows, row_ptrs, col_idxs, values, block_data,
                         storage_scheme, block_ptrs, num_blocks, item_ct1,
-                        *workspace_acc_ct1.get_pointer());
+                        workspace);
                 });
     });
 }
@@ -208,8 +205,7 @@ void adaptive_generate(
     remove_complex<ValueType>* __restrict__ conditioning,
     precision_reduction* __restrict__ block_precisions,
     const IndexType* __restrict__ block_ptrs, size_type num_blocks,
-    sycl::nd_item<3> item_ct1,
-    uninitialized_array<ValueType, max_block_size * warps_per_block>& workspace)
+    sycl::nd_item<3> item_ct1, sycl::local_accessor<ValueType, 1> workspace)
 {
     // extract blocks
     const auto block_id =
@@ -313,9 +309,8 @@ void adaptive_generate(
     size_type num_blocks)
 {
     queue->submit([&](sycl::handler& cgh) {
-        sycl::local_accessor<
-            uninitialized_array<ValueType, max_block_size * warps_per_block>, 0>
-            workspace_acc_ct1(cgh);
+        sycl::local_accessor<ValueType, 1> workspace(
+            max_block_size * warps_per_block, cgh);
 
         cgh.parallel_for(sycl_nd_range(grid, block),
                          [=](sycl::nd_item<3> item_ct1)
@@ -325,8 +320,7 @@ void adaptive_generate(
                                      num_rows, row_ptrs, col_idxs, values,
                                      accuracy, block_data, storage_scheme,
                                      conditioning, block_precisions, block_ptrs,
-                                     num_blocks, item_ct1,
-                                     *workspace_acc_ct1.get_pointer());
+                                     num_blocks, item_ct1, workspace);
                              });
     });
 }

--- a/dpcpp/solver/batch_bicgstab_launch.instantiate.dp.cpp
+++ b/dpcpp/solver/batch_bicgstab_launch.instantiate.dp.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -58,7 +58,7 @@ void launch_apply_kernel(
 
         cgh.parallel_for(
             sycl_nd_range(grid, block),
-            [=](sycl::nd_item<3> item_ct1) [[intel::reqd_sub_group_size(
+            [=](sycl::nd_item<3> item_ct1) [[sycl::reqd_sub_group_size(
                 subgroup_size)]] [[intel::kernel_args_restrict]] {
                 auto batch_id = item_ct1.get_group_linear_id();
                 const auto mat_global_entry =
@@ -73,8 +73,7 @@ void launch_apply_kernel(
                     sconf, max_iters, res_tol, logger, prec, mat_global_entry,
                     b_global_entry, x_global_entry, num_rows,
                     mat.get_single_item_num_nnz(),
-                    static_cast<device_type<ValueType>*>(
-                        slm_values.get_pointer()),
+                    static_cast<device_type<ValueType>*>(&slm_values[0]),
                     item_ct1, workspace);
             });
     });

--- a/dpcpp/solver/batch_cg_launch.instantiate.dp.cpp
+++ b/dpcpp/solver/batch_cg_launch.instantiate.dp.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -65,7 +65,7 @@ void launch_apply_kernel(
 
         cgh.parallel_for(
             sycl_nd_range(grid, block),
-            [=](sycl::nd_item<3> item_ct1) [[intel::reqd_sub_group_size(
+            [=](sycl::nd_item<3> item_ct1) [[sycl::reqd_sub_group_size(
                 subgroup_size)]] [[intel::kernel_args_restrict]] {
                 auto batch_id = item_ct1.get_group_linear_id();
                 const auto mat_global_entry =
@@ -80,8 +80,7 @@ void launch_apply_kernel(
                     sconf, max_iters, res_tol, logger, prec, mat_global_entry,
                     b_global_entry, x_global_entry, num_rows,
                     mat.get_single_item_num_nnz(),
-                    static_cast<device_type<ValueType>*>(
-                        slm_values.get_pointer()),
+                    static_cast<device_type<ValueType>*>(&slm_values[0]),
                     item_ct1, workspace);
             });
     });

--- a/dpcpp/solver/cb_gmres_kernels.dp.cpp
+++ b/dpcpp/solver/cb_gmres_kernels.dp.cpp
@@ -27,7 +27,6 @@
 #include "dpcpp/components/cooperative_groups.dp.hpp"
 #include "dpcpp/components/reduction.dp.hpp"
 #include "dpcpp/components/thread_ids.dp.hpp"
-#include "dpcpp/components/uninitialized_array.hpp"
 
 
 namespace gko {
@@ -188,9 +187,7 @@ void multinorm2_kernel(
     const ValueType* __restrict__ next_krylov_basis,
     size_type stride_next_krylov, remove_complex<ValueType>* __restrict__ norms,
     const stopping_status* __restrict__ stop_status, sycl::nd_item<3> item_ct1,
-    uninitialized_array<remove_complex<ValueType>,
-                        default_dot_dim*(default_dot_dim + 1)>*
-        reduction_helper_array)
+    sycl::local_accessor<remove_complex<ValueType>, 1> reduction_helper)
 {
     using rc_vtype = remove_complex<ValueType>;
     const auto tidx = item_ct1.get_local_id(2);
@@ -201,10 +198,6 @@ void multinorm2_kernel(
     const auto end_row = ((item_ct1.get_group(1) + 1) * num > num_rows)
                              ? num_rows
                              : (item_ct1.get_group(1) + 1) * num;
-    // Used that way to get around dynamic initialization warning and
-    // template error when using `reduction_helper_array` directly in `reduce`
-
-    rc_vtype* __restrict__ reduction_helper = (*reduction_helper_array);
     rc_vtype local_res = zero<rc_vtype>();
     if (col_idx < num_cols && !stop_status[col_idx].has_stopped()) {
         for (size_type i = start_row + tidy; i < end_row;
@@ -238,21 +231,18 @@ void multinorm2_kernel(dim3 grid, dim3 block, size_type dynamic_shared_memory,
                        const stopping_status* stop_status)
 {
     queue->submit([&](sycl::handler& cgh) {
-        sycl::local_accessor<
-            uninitialized_array<remove_complex<ValueType>,
-                                default_dot_dim*(default_dot_dim + 1)>,
-            0>
-            reduction_helper_array_acc_ct1(cgh);
+        sycl::local_accessor<remove_complex<ValueType>, 1>
+            reduction_helper_array(default_dot_dim * (default_dot_dim + 1),
+                                   cgh);
 
-        cgh.parallel_for(
-            sycl_nd_range(grid, block),
-            [=](sycl::nd_item<3> item_ct1)
-                [[sycl::reqd_sub_group_size(default_dot_dim)]] {
-                    multinorm2_kernel(
-                        num_rows, num_cols, next_krylov_basis,
-                        stride_next_krylov, norms, stop_status, item_ct1,
-                        reduction_helper_array_acc_ct1.get_pointer());
-                });
+        cgh.parallel_for(sycl_nd_range(grid, block),
+                         [=](sycl::nd_item<3> item_ct1)
+                             [[sycl::reqd_sub_group_size(default_dot_dim)]] {
+                                 multinorm2_kernel(
+                                     num_rows, num_cols, next_krylov_basis,
+                                     stride_next_krylov, norms, stop_status,
+                                     item_ct1, reduction_helper_array);
+                             });
     });
 }
 
@@ -263,9 +253,7 @@ void multinorminf_without_stop_kernel(
     const ValueType* __restrict__ next_krylov_basis,
     size_type stride_next_krylov, remove_complex<ValueType>* __restrict__ norms,
     size_type stride_norms, sycl::nd_item<3> item_ct1,
-    uninitialized_array<remove_complex<ValueType>,
-                        default_dot_dim*(default_dot_dim + 1)>*
-        reduction_helper_array)
+    sycl::local_accessor<remove_complex<ValueType>, 1> reduction_helper)
 {
     using rc_vtype = remove_complex<ValueType>;
     const auto tidx = item_ct1.get_local_id(2);
@@ -276,10 +264,6 @@ void multinorminf_without_stop_kernel(
     const auto end_row = ((item_ct1.get_group(1) + 1) * num > num_rows)
                              ? num_rows
                              : (item_ct1.get_group(1) + 1) * num;
-    // Used that way to get around dynamic initialization warning and
-    // template error when using `reduction_helper_array` directly in `reduce`
-
-    rc_vtype* __restrict__ reduction_helper = (*reduction_helper_array);
     rc_vtype local_max = zero<rc_vtype>();
     if (col_idx < num_cols) {
         for (size_type i = start_row + tidy; i < end_row;
@@ -315,21 +299,18 @@ void multinorminf_without_stop_kernel(
     size_type stride_norms)
 {
     queue->submit([&](sycl::handler& cgh) {
-        sycl::local_accessor<
-            uninitialized_array<remove_complex<ValueType>,
-                                default_dot_dim*(default_dot_dim + 1)>,
-            0>
-            reduction_helper_array_acc_ct1(cgh);
+        sycl::local_accessor<remove_complex<ValueType>, 1>
+            reduction_helper_array(default_dot_dim * (default_dot_dim + 1),
+                                   cgh);
 
-        cgh.parallel_for(
-            sycl_nd_range(grid, block),
-            [=](sycl::nd_item<3> item_ct1)
-                [[sycl::reqd_sub_group_size(default_dot_dim)]] {
-                    multinorminf_without_stop_kernel(
-                        num_rows, num_cols, next_krylov_basis,
-                        stride_next_krylov, norms, stride_norms, item_ct1,
-                        reduction_helper_array_acc_ct1.get_pointer());
-                });
+        cgh.parallel_for(sycl_nd_range(grid, block),
+                         [=](sycl::nd_item<3> item_ct1)
+                             [[sycl::reqd_sub_group_size(default_dot_dim)]] {
+                                 multinorminf_without_stop_kernel(
+                                     num_rows, num_cols, next_krylov_basis,
+                                     stride_next_krylov, norms, stride_norms,
+                                     item_ct1, reduction_helper_array);
+                             });
     });
 }
 
@@ -343,10 +324,8 @@ void multinorm2_inf_kernel(
     remove_complex<ValueType>* __restrict__ norms1,
     remove_complex<ValueType>* __restrict__ norms2,
     const stopping_status* __restrict__ stop_status, sycl::nd_item<3> item_ct1,
-    uninitialized_array<remove_complex<ValueType>,
-                        (1 + compute_inf) *
-                            default_dot_dim*(default_dot_dim + 1)>*
-        reduction_helper_array)
+    sycl::local_accessor<remove_complex<ValueType>, 1> reduction_helper_add,
+    sycl::local_accessor<remove_complex<ValueType>, 1> reduction_helper_max)
 {
     using rc_vtype = remove_complex<ValueType>;
     const auto tidx = item_ct1.get_local_id(2);
@@ -357,13 +336,6 @@ void multinorm2_inf_kernel(
     const auto end_row = ((item_ct1.get_group(1) + 1) * num > num_rows)
                              ? num_rows
                              : (item_ct1.get_group(1) + 1) * num;
-    // Used that way to get around dynamic initialization warning and
-    // template error when using `reduction_helper_array` directly in `reduce`
-
-    rc_vtype* __restrict__ reduction_helper_add = (*reduction_helper_array);
-    rc_vtype* __restrict__ reduction_helper_max =
-        static_cast<rc_vtype*>((*reduction_helper_array)) +
-        default_dot_dim * (default_dot_dim + 1);
     rc_vtype local_res = zero<rc_vtype>();
     rc_vtype local_max = zero<rc_vtype>();
     if (col_idx < num_cols && !stop_status[col_idx].has_stopped()) {
@@ -417,12 +389,10 @@ void multinorm2_inf_kernel(
     remove_complex<ValueType>* norms2, const stopping_status* stop_status)
 {
     queue->submit([&](sycl::handler& cgh) {
-        sycl::local_accessor<
-            uninitialized_array<remove_complex<ValueType>,
-                                (1 + compute_inf) *
-                                    default_dot_dim*(default_dot_dim + 1)>,
-            0>
-            reduction_helper_array_acc_ct1(cgh);
+        sycl::local_accessor<remove_complex<ValueType>, 1> reduction_helper_sum(
+            default_dot_dim * (default_dot_dim + 1), cgh);
+        sycl::local_accessor<remove_complex<ValueType>, 1> reduction_helper_max(
+            compute_inf * default_dot_dim * (default_dot_dim + 1), cgh);
 
         cgh.parallel_for(
             sycl_nd_range(grid, block),
@@ -431,20 +401,22 @@ void multinorm2_inf_kernel(
                     multinorm2_inf_kernel<compute_inf>(
                         num_rows, num_cols, next_krylov_basis,
                         stride_next_krylov, norms1, norms2, stop_status,
-                        item_ct1, reduction_helper_array_acc_ct1.get_pointer());
+                        item_ct1, reduction_helper_sum, reduction_helper_max);
                 });
     });
 }
 
 
 template <int dot_dim, typename ValueType, typename Accessor3d>
-void multidot_kernel(
-    size_type num_rows, size_type num_cols,
-    const ValueType* __restrict__ next_krylov_basis,
-    size_type stride_next_krylov, const Accessor3d krylov_bases,
-    ValueType* __restrict__ hessenberg_iter, size_type stride_hessenberg,
-    const stopping_status* __restrict__ stop_status, sycl::nd_item<3> item_ct1,
-    uninitialized_array<ValueType, dot_dim * dot_dim>& reduction_helper_array)
+void multidot_kernel(size_type num_rows, size_type num_cols,
+                     const ValueType* __restrict__ next_krylov_basis,
+                     size_type stride_next_krylov,
+                     const Accessor3d krylov_bases,
+                     ValueType* __restrict__ hessenberg_iter,
+                     size_type stride_hessenberg,
+                     const stopping_status* __restrict__ stop_status,
+                     sycl::nd_item<3> item_ct1,
+                     sycl::local_accessor<ValueType, 1> reduction_helper)
 {
     /*
      * In general in this kernel:
@@ -469,10 +441,6 @@ void multidot_kernel(
     const auto end_row =
         min((item_ct1.get_group(1) + 1) * num_rows_per_thread, num_rows);
     const size_type k = item_ct1.get_group(0);
-    // Used that way to get around dynamic initialization warning and
-    // template error when using `reduction_helper_array` directly in `reduce`
-    ValueType* __restrict__ reduction_helper = reduction_helper_array;
-
     ValueType local_res = zero<ValueType>();
     if (col_idx < num_cols && !stop_status[col_idx].has_stopped()) {
         for (size_type i = start_row; i < end_row;
@@ -511,20 +479,19 @@ void multidot_kernel(dim3 grid, dim3 block, size_type dynamic_shared_memory,
                      const stopping_status* stop_status)
 {
     queue->submit([&](sycl::handler& cgh) {
-        sycl::local_accessor<uninitialized_array<ValueType, dot_dim * dot_dim>,
-                             0>
-            reduction_helper_array_acc_ct1(cgh);
+        sycl::local_accessor<ValueType, 1> reduction_helper_array(
+            dot_dim * dot_dim, cgh);
 
-        cgh.parallel_for(
-            sycl_nd_range(grid, block),
-            [=](sycl::nd_item<3> item_ct1)
-                [[sycl::reqd_sub_group_size(dot_dim)]] {
-                    multidot_kernel<dot_dim>(
-                        num_rows, num_cols, next_krylov_basis,
-                        stride_next_krylov, krylov_bases, hessenberg_iter,
-                        stride_hessenberg, stop_status, item_ct1,
-                        *reduction_helper_array_acc_ct1.get_pointer());
-                });
+        cgh.parallel_for(sycl_nd_range(grid, block),
+                         [=](sycl::nd_item<3> item_ct1)
+                             [[sycl::reqd_sub_group_size(dot_dim)]] {
+                                 multidot_kernel<dot_dim>(
+                                     num_rows, num_cols, next_krylov_basis,
+                                     stride_next_krylov, krylov_bases,
+                                     hessenberg_iter, stride_hessenberg,
+                                     stop_status, item_ct1,
+                                     reduction_helper_array);
+                             });
     });
 }
 
@@ -535,7 +502,7 @@ void singledot_kernel(
     size_type stride_next_krylov, const Accessor3d krylov_bases,
     ValueType* __restrict__ hessenberg_iter, size_type stride_hessenberg,
     const stopping_status* __restrict__ stop_status, sycl::nd_item<3> item_ct1,
-    uninitialized_array<ValueType, block_size>& reduction_helper_array)
+    sycl::local_accessor<ValueType, 1> reduction_helper)
 {
     /*
      * In general in this kernel:
@@ -555,10 +522,6 @@ void singledot_kernel(
         item_ct1.get_group(2) * num_rows_per_thread + item_ct1.get_local_id(2);
     const auto end_row =
         min((item_ct1.get_group(2) + 1) * num_rows_per_thread, num_rows);
-    // Used that way to get around dynamic initialization warning and
-    // template error when using `reduction_helper_array` directly in `reduce`
-
-    ValueType* __restrict__ reduction_helper = reduction_helper_array;
 
     ValueType local_res = zero<ValueType>();
     if (!stop_status[col_idx].has_stopped()) {
@@ -574,7 +537,7 @@ void singledot_kernel(
     auto thread_block = group::this_thread_block(item_ct1);
     thread_block.sync();
     ::gko::kernels::dpcpp::reduce(
-        thread_block, reduction_helper,
+        thread_block, &reduction_helper[0],
         [](const ValueType& a, const ValueType& b) { return a + b; });
     if (tidx == 0 && !stop_status[col_idx].has_stopped()) {
         const auto hessenberg_idx = k * stride_hessenberg + col_idx;
@@ -592,8 +555,8 @@ void singledot_kernel(dim3 grid, dim3 block, size_type dynamic_shared_memory,
                       const stopping_status* stop_status)
 {
     queue->submit([&](sycl::handler& cgh) {
-        sycl::local_accessor<uninitialized_array<ValueType, block_size>, 0>
-            reduction_helper_array_acc_ct1(cgh);
+        sycl::local_accessor<ValueType, 1> reduction_helper_array(block_size,
+                                                                  cgh);
 
         cgh.parallel_for(
             sycl_nd_range(grid, block),
@@ -602,8 +565,7 @@ void singledot_kernel(dim3 grid, dim3 block, size_type dynamic_shared_memory,
                     singledot_kernel<block_size>(
                         num_rows, next_krylov_basis, stride_next_krylov,
                         krylov_bases, hessenberg_iter, stride_hessenberg,
-                        stop_status, item_ct1,
-                        *reduction_helper_array_acc_ct1.get_pointer());
+                        stop_status, item_ct1, reduction_helper_array);
                 });
     });
 }

--- a/dpcpp/solver/common_trs_kernels.hpp
+++ b/dpcpp/solver/common_trs_kernels.hpp
@@ -51,8 +51,13 @@ struct OneMklSolveStruct : gko::solver::SolveStruct {
         diag = unit_diag ? oneapi::mkl::diag::unit : oneapi::mkl::diag::nonunit;
         oneapi::mkl::sparse::init_matrix_handle(&mat_handle);
         oneapi::mkl::sparse::set_csr_data(
-            *exec->get_queue(), mat_handle, IndexType(matrix->get_size()[0]),
-            IndexType(matrix->get_size()[1]), oneapi::mkl::index_base::zero,
+            *exec->get_queue(), mat_handle,
+            static_cast<IndexType>(matrix->get_size()[0]),
+            static_cast<IndexType>(matrix->get_size()[1]),
+#if INTEL_MKL_VERSION >= 20250300
+            static_cast<std::int64_t>(matrix->get_num_stored_elements()),
+#endif
+            oneapi::mkl::index_base::zero,
             const_cast<IndexType*>(matrix->get_const_row_ptrs()),
             const_cast<IndexType*>(matrix->get_const_col_idxs()),
             const_cast<ValueType*>(matrix->get_const_values()));

--- a/dpcpp/solver/idr_kernels.dp.cpp
+++ b/dpcpp/solver/idr_kernels.dp.cpp
@@ -86,12 +86,12 @@ template <size_type block_size, typename ValueType>
 void orthonormalize_subspace_vectors_kernel(
     size_type num_rows, size_type num_cols, ValueType* __restrict__ values,
     size_type stride, sycl::nd_item<3> item_ct1,
-    uninitialized_array<ValueType, block_size>& reduction_helper_array)
+    sycl::local_accessor<ValueType, 1> reduction_helper_array)
 {
     const auto tidx = thread::get_thread_id_flat(item_ct1);
 
     // they are not be used in the same time.
-    ValueType* reduction_helper = reduction_helper_array;
+    ValueType* reduction_helper = &reduction_helper_array[0];
     auto reduction_helper_real =
         reinterpret_cast<remove_complex<ValueType>*>(reduction_helper);
 
@@ -143,8 +143,7 @@ void orthonormalize_subspace_vectors_kernel(
     size_type num_rows, size_type num_cols, ValueType* values, size_type stride)
 {
     stream->submit([&](sycl::handler& cgh) {
-        sycl::local_accessor<uninitialized_array<ValueType, block_size>, 0>
-            reduction_helper_array_acc_ct1(cgh);
+        sycl::local_accessor<ValueType, 1> reduction_helper(block_size, cgh);
 
         cgh.parallel_for(
             sycl_nd_range(grid, block),
@@ -152,7 +151,7 @@ void orthonormalize_subspace_vectors_kernel(
                 [[sycl::reqd_sub_group_size(config::warp_size)]] {
                     orthonormalize_subspace_vectors_kernel<block_size>(
                         num_rows, num_cols, values, stride, item_ct1,
-                        *reduction_helper_array_acc_ct1.get_pointer());
+                        reduction_helper);
                 });
     });
 }
@@ -308,13 +307,13 @@ void step_2_kernel(dim3 grid, dim3 block, size_t dynamic_shared_memory,
 
 
 template <typename ValueType>
-void multidot_kernel(
-    size_type num_rows, size_type nrhs, const ValueType* __restrict__ p_i,
-    const ValueType* __restrict__ g_k, size_type g_k_stride,
-    ValueType* __restrict__ alpha,
-    const stopping_status* __restrict__ stop_status, sycl::nd_item<3> item_ct1,
-    uninitialized_array<ValueType, default_dot_dim*(default_dot_dim + 1)>&
-        reduction_helper_array)
+void multidot_kernel(size_type num_rows, size_type nrhs,
+                     const ValueType* __restrict__ p_i,
+                     const ValueType* __restrict__ g_k, size_type g_k_stride,
+                     ValueType* __restrict__ alpha,
+                     const stopping_status* __restrict__ stop_status,
+                     sycl::nd_item<3> item_ct1,
+                     sycl::local_accessor<ValueType, 1> reduction_helper)
 {
     const auto tidx = item_ct1.get_local_id(2);
     const auto tidy = item_ct1.get_local_id(1);
@@ -324,9 +323,6 @@ void multidot_kernel(
     const auto end_row = ((item_ct1.get_group(1) + 1) * num > num_rows)
                              ? num_rows
                              : (item_ct1.get_group(1) + 1) * num;
-    // Used that way to get around dynamic initialization warning and
-    // template error when using `reduction_helper_array` directly in `reduce`
-    ValueType* __restrict__ reduction_helper = reduction_helper_array;
 
     ValueType local_res = zero<ValueType>();
     if (rhs < nrhs && !stop_status[rhs].has_stopped()) {
@@ -358,21 +354,16 @@ void multidot_kernel(dim3 grid, dim3 block, size_t dynamic_shared_memory,
                      const stopping_status* stop_status)
 {
     stream->submit([&](sycl::handler& cgh) {
-        sycl::local_accessor<
-            uninitialized_array<ValueType,
-                                default_dot_dim*(default_dot_dim + 1)>,
-            0>
-            reduction_helper_array_acc_ct1(cgh);
+        sycl::local_accessor<ValueType, 1> reduction_helper(
+            default_dot_dim * (default_dot_dim + 1), cgh);
 
-        cgh.parallel_for(
-            sycl_nd_range(grid, block),
-            [=](sycl::nd_item<3> item_ct1)
-                [[sycl::reqd_sub_group_size(default_dot_dim)]] {
-                    multidot_kernel(
-                        num_rows, nrhs, p_i, g_k, g_k_stride, alpha,
-                        stop_status, item_ct1,
-                        *reduction_helper_array_acc_ct1.get_pointer());
-                });
+        cgh.parallel_for(sycl_nd_range(grid, block),
+                         [=](sycl::nd_item<3> item_ct1)
+                             [[sycl::reqd_sub_group_size(default_dot_dim)]] {
+                                 multidot_kernel(num_rows, nrhs, p_i, g_k,
+                                                 g_k_stride, alpha, stop_status,
+                                                 item_ct1, reduction_helper);
+                             });
     });
 }
 


### PR DESCRIPTION
This has been bugging me for a long time - compiling the backend creates gigabytes of error messages. This fixes all the issues by replacing uninitialized_array uses with local_accessor directly (which is more idiomatic SYCL anyways) and translating to pointers directly if necessary.