### PR TITLE
Checked Dense View access

### DIFF
--- a/core/test/base/index_range.cpp
+++ b/core/test/base/index_range.cpp
@@ -1,10 +1,12 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
 #include "core/base/index_range.hpp"
 
 #include <gtest/gtest.h>
+
+#include "core/test/utils.hpp"
 
 
 TEST(IRange, KnowsItsProperties)
@@ -97,18 +99,6 @@ TEST(IRangeIterator, IteratorProperties)
 
 
 #ifndef NDEBUG
-
-
-bool check_assertion_exit_code(int exit_code)
-{
-#ifdef _MSC_VER
-    // MSVC picks up the exit code incorrectly,
-    // so we can only check that it exits
-    return true;
-#else
-    return exit_code != 0;
-#endif
-}
 
 
 TEST(DeathTest, Assertions)

--- a/core/test/base/iterator_factory.cpp
+++ b/core/test/base/iterator_factory.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -218,18 +218,6 @@ TYPED_TEST(ZipIterator, IncreasingIterator)
 
 
 #ifndef NDEBUG
-
-
-bool check_assertion_exit_code(int exit_code)
-{
-#ifdef _MSC_VER
-    // MSVC picks up the exit code incorrectly,
-    // so we can only check that it exits
-    return true;
-#else
-    return exit_code != 0;
-#endif
-}
 
 
 TYPED_TEST(ZipIterator, IncompatibleIteratorDeathTest)

--- a/core/test/base/segmented_range.cpp
+++ b/core/test/base/segmented_range.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -9,6 +9,8 @@
 #include <vector>
 
 #include <gtest/gtest.h>
+
+#include "core/test/utils.hpp"
 
 
 TEST(SegmentedRange, WorksByIndex)
@@ -194,18 +196,6 @@ TEST(SegmentedEnumeratedValueRange, WorksByRangeFor)
 
 
 #ifndef NDEBUG
-
-
-bool check_assertion_exit_code(int exit_code)
-{
-#ifdef _MSC_VER
-    // MSVC picks up the exit code incorrectly,
-    // so we can only check that it exits
-    return true;
-#else
-    return exit_code != 0;
-#endif
-}
 
 
 TEST(DeathTest, Assertions)

--- a/core/test/matrix/device_views.cpp
+++ b/core/test/matrix/device_views.cpp
@@ -18,11 +18,11 @@ TYPED_TEST_SUITE(DenseView, gko::test::ValueTypes, TypenameNameGenerator);
 TYPED_TEST(DenseView, AccessWorks)
 {
     std::vector<TypeParam> values(10);
-    gko::matrix::view::dense<TypeParam> view{gko::dim<2>{1, 2}, 3,
+    gko::matrix::view::dense<TypeParam> view{gko::dim<2>{2, 2}, 3,
                                              values.data()};
     auto const_view = view.as_const();
 
-    ASSERT_EQ(view.size, gko::dim<2>(1, 2));
+    ASSERT_EQ(view.size, gko::dim<2>(2, 2));
     ASSERT_EQ(view.stride, 3);
     ASSERT_EQ(view.values, values.data());
     ASSERT_EQ(&view(0, 0), &values[0]);

--- a/core/test/matrix/device_views.cpp
+++ b/core/test/matrix/device_views.cpp
@@ -32,3 +32,19 @@ TYPED_TEST(DenseView, AccessWorks)
     ASSERT_EQ(const_view.stride, view.stride);
     ASSERT_EQ(const_view.values, view.values);
 }
+
+
+TYPED_TEST(DenseView, AssertTriggersOnOutOfBoundsDeathTest)
+{
+#ifdef NDEBUG
+    GTEST_SKIP() << "Assertion is only enabled in debug mode";
+#endif
+
+    std::vector<TypeParam> values(10);
+    gko::matrix::view::dense<TypeParam> view{gko::dim<2>{2, 2}, 3,
+                                             values.data()};
+
+    EXPECT_EXIT((void)(view(3, 0)), check_assertion_exit_code, "");
+    EXPECT_EXIT((void)(view(0, 3)), check_assertion_exit_code, "");
+    EXPECT_EXIT((void)(view(3, 3)), check_assertion_exit_code, "");
+}

--- a/core/test/solver/workspace.cpp
+++ b/core/test/solver/workspace.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -173,18 +173,6 @@ TEST_F(Workspace, CanResizeArrays)
 
 
 #ifndef NDEBUG
-
-
-bool check_assertion_exit_code(int exit_code)
-{
-#ifdef _MSC_VER
-    // MSVC picks up the exit code incorrectly,
-    // so we can only check that it exits
-    return true;
-#else
-    return exit_code != 0;
-#endif
-}
 
 
 TEST_F(Workspace, AbortsOnDifferentArrayTypes)

--- a/core/test/utils.hpp
+++ b/core/test/utils.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -494,5 +494,20 @@ struct TupleTypenameNameGenerator {
     static_assert(true,                                                      \
                   "This assert is used to counter the false positive extra " \
                   "semi-colon warnings")
+
+
+// Helper function necessary for death tests
+// see https://google.github.io/googletest/advanced.html#death-tests
+inline bool check_assertion_exit_code(int exit_code)
+{
+#ifdef _MSC_VER
+    // MSVC picks up the exit code incorrectly,
+    // so we can only check that it exits
+    return true;
+#else
+    return exit_code != 0;
+#endif
+}
+
 
 #endif  // GKO_CORE_TEST_UTILS_HPP_

--- a/include/ginkgo/core/matrix/device_views.hpp
+++ b/include/ginkgo/core/matrix/device_views.hpp
@@ -19,6 +19,7 @@ namespace view {
  * Non-owning view of a matrix::Dense to be used inside device kernels.
  * This type is used to provide a simple and stable ABI for passing data between
  * libraries.
+ * The data is stored in row-major order.
  *
  * @tparam ValueType  the value type used to store matrix entries.
  */
@@ -31,7 +32,9 @@ struct dense {
     /** Constructs a dense view from size, stride and values. */
     constexpr dense(dim<2> size, size_type stride, ValueType* values)
         : size{size}, stride{stride}, values{values}
-    {}
+    {
+        assert(stride >= size[1]);
+    }
 
     /** Returns a const view of the same values */
     constexpr dense<const ValueType> as_const() const

--- a/include/ginkgo/core/matrix/device_views.hpp
+++ b/include/ginkgo/core/matrix/device_views.hpp
@@ -5,6 +5,8 @@
 #ifndef GKO_PUBLIC_CORE_MATRIX_DEVICE_DENSE_HPP_
 #define GKO_PUBLIC_CORE_MATRIX_DEVICE_DENSE_HPP_
 
+#include <cassert>
+
 #include <ginkgo/core/base/dim.hpp>
 
 
@@ -40,6 +42,7 @@ struct dense {
     /** Subscript operator accessing the given row and column */
     constexpr ValueType& operator()(size_type row, size_type col) const
     {
+        assert(row < size[0] && col < size[1]);
         return values[row * stride + col];
     }
 };

--- a/reference/test/solver/gcr_kernels.cpp
+++ b/reference/test/solver/gcr_kernels.cpp
@@ -199,7 +199,7 @@ TYPED_TEST(Gcr, KernelStep1)
     this->mtx->apply(this->small_krylov_bases_p,
                      this->small_mapped_krylov_bases_Ap);
     this->small_mapped_krylov_bases_Ap->compute_norm2(this->small_Ap_norm);
-    this->small_tmp_rAp = gko::initialize<Mtx>({13.0, 7.0, 1.0}, this->exec);
+    this->small_tmp_rAp = gko::initialize<Mtx>({{13.0, 7.0, 1.0}}, this->exec);
 
     gko::kernels::reference::gcr::step_1(
         this->exec, this->small_x->get_device_view(),

--- a/test/matrix/device_views.cpp
+++ b/test/matrix/device_views.cpp
@@ -28,15 +28,15 @@ template <typename ValueType>
 void assert_dense_view(std::shared_ptr<const gko::EXEC_TYPE> exec)
 {
     gko::array<bool> correct{exec, {false}};
-    gko::array<ValueType> values{exec, 5};
+    gko::array<ValueType> values{exec, 6};
     values.fill(gko::one<ValueType>());
     gko::kernels::GKO_DEVICE_NAMESPACE::run_kernel(
         exec,
         [] GKO_KERNEL(auto i, auto values, auto correct) {
             using device_type = std::decay_t<decltype(values[0])>;
-            gko::matrix::view::dense<device_type> view{gko::dim<2>{1, 2}, 3,
+            gko::matrix::view::dense<device_type> view{gko::dim<2>{2, 2}, 3,
                                                        values};
-            if (view.size == gko::dim<2>(1, 2) && view.stride == 3 &&
+            if (view.size == gko::dim<2>(2, 2) && view.stride == 3 &&
                 view.values == values && &view(0, 0) == &values[0] &&
                 &view(1, 0) == &values[3] && &view(1, 1) == &values[4] &&
                 view(1, 1) == gko::one(view(1, 1))) {

--- a/test/matrix/matrix.cpp
+++ b/test/matrix/matrix.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -1154,7 +1154,7 @@ TYPED_TEST(Matrix, ConvertFromDenseIsEquivalentToRef)
     using Mtx = typename TestFixture::Mtx;
     using Dense = gko::matrix::Dense<typename Mtx::value_type>;
     this->forall_matrix_data_scenarios([&](auto data) {
-        const auto stride = data.size[0] + 2;
+        const auto stride = data.size[1] + 2;
         auto ref_src = Dense::create(this->ref, data.size, stride);
         auto dev_src = Dense::create(this->exec, data.size, stride);
         ref_src->read(data);
@@ -1179,7 +1179,7 @@ TYPED_TEST(Matrix, MoveFromDenseIsEquivalentToRef)
     using Mtx = typename TestFixture::Mtx;
     using Dense = gko::matrix::Dense<typename Mtx::value_type>;
     this->forall_matrix_data_scenarios([&](auto data) {
-        const auto stride = data.size[0] + 2;
+        const auto stride = data.size[1] + 2;
         auto ref_src = Dense::create(this->ref, data.size, stride);
         auto dev_src = Dense::create(this->exec, data.size, stride);
         ref_src->read(data);

--- a/test/solver/gmres_kernels.cpp
+++ b/test/solver/gmres_kernels.cpp
@@ -293,25 +293,24 @@ TEST_F(Gmres, GmresKernelMultiAxpyIsEquivalentToRef)
 TEST_F(Gmres, GmresKernelMultiDotIsEquivalentToRef)
 {
     initialize_data();
-
     auto krylov_basis = krylov_bases->create_submatrix(
-        gko::span{
-            0, x->get_size()[0] * (gko::solver::gmres_default_krylov_dim - 1)},
+        gko::span{0, x->get_size()[0] * gko::solver::gmres_default_krylov_dim},
         gko::span{0, x->get_size()[1]});
     auto d_krylov_basis = d_krylov_bases->create_submatrix(
-        gko::span{0, d_x->get_size()[0] *
-                         (gko::solver::gmres_default_krylov_dim - 1)},
+        gko::span{0,
+                  d_x->get_size()[0] * gko::solver::gmres_default_krylov_dim},
         gko::span{0, d_x->get_size()[1]});
     auto next_krylov = krylov_bases->create_submatrix(
         gko::span{
-            x->get_size()[0] * (gko::solver::gmres_default_krylov_dim - 1),
-            x->get_size()[0] * gko::solver::gmres_default_krylov_dim},
+            x->get_size()[0] * gko::solver::gmres_default_krylov_dim,
+            x->get_size()[0] * (gko::solver::gmres_default_krylov_dim + 1)},
         gko::span{0, x->get_size()[1]});
     auto d_next_krylov = d_krylov_bases->create_submatrix(
         gko::span{
-            d_x->get_size()[0] * (gko::solver::gmres_default_krylov_dim - 1),
-            d_x->get_size()[0] * gko::solver::gmres_default_krylov_dim},
+            d_x->get_size()[0] * gko::solver::gmres_default_krylov_dim,
+            d_x->get_size()[0] * (gko::solver::gmres_default_krylov_dim + 1)},
         gko::span{0, d_x->get_size()[1]});
+
     gko::kernels::reference::gmres::multi_dot(
         ref, krylov_basis->get_const_device_view(),
         next_krylov->get_const_device_view(),


### PR DESCRIPTION
This PR adds an in-dimensions check for accessing a `view::dense`. This was already mentioned #1979.