### PR TITLE
Add view::coo for COO matrix format

### DIFF
--- a/common/cuda_hip/factorization/par_ic_kernels.cpp
+++ b/common/cuda_hip/factorization/par_ic_kernels.cpp
@@ -1,11 +1,10 @@
-// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
 #include "core/factorization/par_ic_kernels.hpp"
 
 #include <ginkgo/core/base/math.hpp>
-#include <ginkgo/core/matrix/coo.hpp>
 #include <ginkgo/core/matrix/csr.hpp>
 
 #include "common/cuda_hip/base/math.hpp"
@@ -117,7 +116,7 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 template <typename ValueType, typename IndexType>
 void compute_factor(std::shared_ptr<const DefaultExecutor> exec,
                     size_type iterations,
-                    const matrix::Coo<ValueType, IndexType>* a_lower,
+                    matrix::view::coo<const ValueType, const IndexType> a_lower,
                     matrix::Csr<ValueType, IndexType>* l)
 {
     auto nnz = l->get_num_stored_elements();
@@ -133,11 +132,9 @@ void compute_factor(std::shared_ptr<const DefaultExecutor> exec,
             for (size_type i = 0; i < iterations; ++i) {
                 kernel::ic_sweep<<<num_blocks, default_block_size, 0,
                                    exec->get_stream()>>>(
-                    a_lower->get_const_row_idxs(),
-                    a_lower->get_const_col_idxs(),
-                    as_device_type(a_lower->get_const_values()),
-                    l->get_const_row_ptrs(), l->get_const_col_idxs(),
-                    as_device_type(l->get_values()),
+                    a_lower.row_idxs, a_lower.col_idxs,
+                    as_device_type(a_lower.values), l->get_const_row_ptrs(),
+                    l->get_const_col_idxs(), as_device_type(l->get_values()),
                     static_cast<IndexType>(l->get_num_stored_elements()));
             }
         }

--- a/common/cuda_hip/factorization/par_ict_kernels.cpp
+++ b/common/cuda_hip/factorization/par_ict_kernels.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -386,7 +386,7 @@ void compute_factor(syn::value_list<int, subwarp_size>,
                     std::shared_ptr<const DefaultExecutor> exec,
                     const matrix::Csr<ValueType, IndexType>* a,
                     matrix::Csr<ValueType, IndexType>* l,
-                    const matrix::Coo<ValueType, IndexType>* l_coo)
+                    matrix::view::coo<const ValueType, const IndexType> l_coo)
 {
     auto total_nnz = static_cast<IndexType>(l->get_num_stored_elements());
     auto block_size = default_block_size / subwarp_size;
@@ -403,7 +403,7 @@ void compute_factor(syn::value_list<int, subwarp_size>,
                 <<<num_blocks, default_block_size, 0, exec->get_stream()>>>(
                     a->get_const_row_ptrs(), a->get_const_col_idxs(),
                     as_device_type(a->get_const_values()),
-                    l->get_const_row_ptrs(), l_coo->get_const_row_idxs(),
+                    l->get_const_row_ptrs(), l_coo.row_idxs,
                     l->get_const_col_idxs(), as_device_type(l->get_values()),
                     static_cast<IndexType>(l->get_num_stored_elements()));
         }
@@ -445,7 +445,7 @@ template <typename ValueType, typename IndexType>
 void compute_factor(std::shared_ptr<const DefaultExecutor> exec,
                     const matrix::Csr<ValueType, IndexType>* a,
                     matrix::Csr<ValueType, IndexType>* l,
-                    const matrix::Coo<ValueType, IndexType>* l_coo)
+                    matrix::view::coo<const ValueType, const IndexType> l_coo)
 {
     auto num_rows = a->get_size()[0];
     auto total_nnz = 2 * l->get_num_stored_elements();

--- a/common/cuda_hip/factorization/par_ilu_kernels.cpp
+++ b/common/cuda_hip/factorization/par_ilu_kernels.cpp
@@ -1,10 +1,8 @@
-// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
 #include "core/factorization/par_ilu_kernels.hpp"
-
-#include <ginkgo/core/matrix/coo.hpp>
 
 #include "common/cuda_hip/base/math.hpp"
 #include "common/cuda_hip/base/runtime.hpp"
@@ -82,14 +80,14 @@ __global__ __launch_bounds__(default_block_size) void compute_l_u_factors(
 
 
 template <typename ValueType, typename IndexType>
-void compute_l_u_factors(std::shared_ptr<const DefaultExecutor> exec,
-                         size_type iterations,
-                         const matrix::Coo<ValueType, IndexType>* system_matrix,
-                         matrix::Csr<ValueType, IndexType>* l_factor,
-                         matrix::Csr<ValueType, IndexType>* u_factor)
+void compute_l_u_factors(
+    std::shared_ptr<const DefaultExecutor> exec, size_type iterations,
+    matrix::view::coo<const ValueType, const IndexType> system_matrix,
+    matrix::Csr<ValueType, IndexType>* l_factor,
+    matrix::Csr<ValueType, IndexType>* u_factor)
 {
     iterations = (iterations == 0) ? 10 : iterations;
-    const auto num_elements = system_matrix->get_num_stored_elements();
+    const auto num_elements = system_matrix.num_stored_elements;
     const auto block_size = default_block_size;
     const auto grid_dim = static_cast<uint32>(
         ceildiv(num_elements, static_cast<size_type>(block_size)));
@@ -104,9 +102,9 @@ void compute_l_u_factors(std::shared_ptr<const DefaultExecutor> exec,
             for (size_type i = 0; i < iterations; ++i) {
                 kernel::compute_l_u_factors<<<grid_dim, block_size, 0,
                                               exec->get_stream()>>>(
-                    num_elements, system_matrix->get_const_row_idxs(),
-                    system_matrix->get_const_col_idxs(),
-                    as_device_type(system_matrix->get_const_values()),
+                    num_elements, system_matrix.row_idxs,
+                    system_matrix.col_idxs,
+                    as_device_type(system_matrix.values),
                     l_factor->get_const_row_ptrs(),
                     l_factor->get_const_col_idxs(),
                     as_device_type(l_factor->get_values()),

--- a/common/cuda_hip/factorization/par_ilut_approx_filter_kernels.cpp
+++ b/common/cuda_hip/factorization/par_ilut_approx_filter_kernels.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -54,7 +54,7 @@ void threshold_filter_approx(syn::value_list<int, subwarp_size>,
                              IndexType rank, array<ValueType>* tmp,
                              remove_complex<ValueType>* threshold,
                              matrix::Csr<ValueType, IndexType>* m_out,
-                             matrix::Coo<ValueType, IndexType>* m_out_coo)
+                             matrix::view::coo<ValueType, IndexType> m_out_coo)
 {
     auto values = m->get_const_values();
     IndexType size = m->get_num_stored_elements();
@@ -123,16 +123,7 @@ void threshold_filter_approx(syn::value_list<int, subwarp_size>,
     builder.get_value_array().resize_and_reset(new_nnz);
     auto new_col_idxs = m_out->get_col_idxs();
     auto new_vals = m_out->get_values();
-    IndexType* new_row_idxs{};
-    if (m_out_coo) {
-        matrix::CooBuilder<ValueType, IndexType> coo_builder{m_out_coo};
-        coo_builder.get_row_idx_array().resize_and_reset(new_nnz);
-        coo_builder.get_col_idx_array() =
-            make_array_view(exec, new_nnz, new_col_idxs);
-        coo_builder.get_value_array() =
-            make_array_view(exec, new_nnz, new_vals);
-        new_row_idxs = m_out_coo->get_row_idxs();
-    }
+    auto new_row_idxs = m_out_coo.row_idxs;
     if (num_blocks > 0) {
         kernel::bucket_filter<subwarp_size>
             <<<num_blocks, default_block_size, 0, exec->get_stream()>>>(
@@ -153,7 +144,7 @@ void threshold_filter_approx(std::shared_ptr<const DefaultExecutor> exec,
                              IndexType rank, array<ValueType>& tmp,
                              remove_complex<ValueType>& threshold,
                              matrix::Csr<ValueType, IndexType>* m_out,
-                             matrix::Coo<ValueType, IndexType>* m_out_coo)
+                             matrix::view::coo<ValueType, IndexType> m_out_coo)
 {
     auto num_rows = m->get_size()[0];
     auto total_nnz = m->get_num_stored_elements();

--- a/common/cuda_hip/factorization/par_ilut_approx_filter_kernels.cpp
+++ b/common/cuda_hip/factorization/par_ilut_approx_filter_kernels.cpp
@@ -54,7 +54,7 @@ void threshold_filter_approx(syn::value_list<int, subwarp_size>,
                              IndexType rank, array<ValueType>* tmp,
                              remove_complex<ValueType>* threshold,
                              matrix::Csr<ValueType, IndexType>* m_out,
-                             matrix::view::coo<ValueType, IndexType> m_out_coo)
+                             matrix::Coo<ValueType, IndexType>* m_out_coo)
 {
     auto values = m->get_const_values();
     IndexType size = m->get_num_stored_elements();
@@ -123,7 +123,16 @@ void threshold_filter_approx(syn::value_list<int, subwarp_size>,
     builder.get_value_array().resize_and_reset(new_nnz);
     auto new_col_idxs = m_out->get_col_idxs();
     auto new_vals = m_out->get_values();
-    auto new_row_idxs = m_out_coo.row_idxs;
+    IndexType* new_row_idxs{};
+    if (m_out_coo) {
+        matrix::CooBuilder<ValueType, IndexType> coo_builder{m_out_coo};
+        coo_builder.get_row_idx_array().resize_and_reset(new_nnz);
+        coo_builder.get_col_idx_array() =
+            make_array_view(exec, new_nnz, new_col_idxs);
+        coo_builder.get_value_array() =
+            make_array_view(exec, new_nnz, new_vals);
+        new_row_idxs = m_out_coo->get_row_idxs();
+    }
     if (num_blocks > 0) {
         kernel::bucket_filter<subwarp_size>
             <<<num_blocks, default_block_size, 0, exec->get_stream()>>>(
@@ -144,7 +153,7 @@ void threshold_filter_approx(std::shared_ptr<const DefaultExecutor> exec,
                              IndexType rank, array<ValueType>& tmp,
                              remove_complex<ValueType>& threshold,
                              matrix::Csr<ValueType, IndexType>* m_out,
-                             matrix::view::coo<ValueType, IndexType> m_out_coo)
+                             matrix::Coo<ValueType, IndexType>* m_out_coo)
 {
     auto num_rows = m->get_size()[0];
     auto total_nnz = m->get_num_stored_elements();

--- a/common/cuda_hip/factorization/par_ilut_filter_kernels.cpp
+++ b/common/cuda_hip/factorization/par_ilut_filter_kernels.cpp
@@ -50,8 +50,7 @@ void threshold_filter(syn::value_list<int, subwarp_size>,
                       const matrix::Csr<ValueType, IndexType>* a,
                       remove_complex<ValueType> threshold,
                       matrix::Csr<ValueType, IndexType>* m_out,
-                      matrix::view::coo<ValueType, IndexType> m_out_coo,
-                      bool lower)
+                      matrix::Coo<ValueType, IndexType>* m_out_coo, bool lower)
 {
     auto old_row_ptrs = a->get_const_row_ptrs();
     auto old_col_idxs = a->get_const_col_idxs();
@@ -79,7 +78,16 @@ void threshold_filter(syn::value_list<int, subwarp_size>,
     builder.get_value_array().resize_and_reset(new_nnz);
     auto new_col_idxs = m_out->get_col_idxs();
     auto new_vals = m_out->get_values();
-    auto new_row_idxs = m_out_coo.row_idxs;
+    IndexType* new_row_idxs{};
+    if (m_out_coo) {
+        matrix::CooBuilder<ValueType, IndexType> coo_builder{m_out_coo};
+        coo_builder.get_row_idx_array().resize_and_reset(new_nnz);
+        coo_builder.get_col_idx_array() =
+            make_array_view(exec, new_nnz, new_col_idxs);
+        coo_builder.get_value_array() =
+            make_array_view(exec, new_nnz, new_vals);
+        new_row_idxs = m_out_coo->get_row_idxs();
+    }
     if (num_blocks > 0) {
         kernel::threshold_filter<subwarp_size>
             <<<num_blocks, default_block_size, 0, exec->get_stream()>>>(
@@ -100,8 +108,7 @@ void threshold_filter(std::shared_ptr<const DefaultExecutor> exec,
                       const matrix::Csr<ValueType, IndexType>* a,
                       remove_complex<ValueType> threshold,
                       matrix::Csr<ValueType, IndexType>* m_out,
-                      matrix::view::coo<ValueType, IndexType> m_out_coo,
-                      bool lower)
+                      matrix::Coo<ValueType, IndexType>* m_out_coo, bool lower)
 {
     auto num_rows = a->get_size()[0];
     auto total_nnz = a->get_num_stored_elements();

--- a/common/cuda_hip/factorization/par_ilut_filter_kernels.cpp
+++ b/common/cuda_hip/factorization/par_ilut_filter_kernels.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -50,7 +50,8 @@ void threshold_filter(syn::value_list<int, subwarp_size>,
                       const matrix::Csr<ValueType, IndexType>* a,
                       remove_complex<ValueType> threshold,
                       matrix::Csr<ValueType, IndexType>* m_out,
-                      matrix::Coo<ValueType, IndexType>* m_out_coo, bool lower)
+                      matrix::view::coo<ValueType, IndexType> m_out_coo,
+                      bool lower)
 {
     auto old_row_ptrs = a->get_const_row_ptrs();
     auto old_col_idxs = a->get_const_col_idxs();
@@ -78,16 +79,7 @@ void threshold_filter(syn::value_list<int, subwarp_size>,
     builder.get_value_array().resize_and_reset(new_nnz);
     auto new_col_idxs = m_out->get_col_idxs();
     auto new_vals = m_out->get_values();
-    IndexType* new_row_idxs{};
-    if (m_out_coo) {
-        matrix::CooBuilder<ValueType, IndexType> coo_builder{m_out_coo};
-        coo_builder.get_row_idx_array().resize_and_reset(new_nnz);
-        coo_builder.get_col_idx_array() =
-            make_array_view(exec, new_nnz, new_col_idxs);
-        coo_builder.get_value_array() =
-            make_array_view(exec, new_nnz, new_vals);
-        new_row_idxs = m_out_coo->get_row_idxs();
-    }
+    auto new_row_idxs = m_out_coo.row_idxs;
     if (num_blocks > 0) {
         kernel::threshold_filter<subwarp_size>
             <<<num_blocks, default_block_size, 0, exec->get_stream()>>>(
@@ -108,7 +100,8 @@ void threshold_filter(std::shared_ptr<const DefaultExecutor> exec,
                       const matrix::Csr<ValueType, IndexType>* a,
                       remove_complex<ValueType> threshold,
                       matrix::Csr<ValueType, IndexType>* m_out,
-                      matrix::Coo<ValueType, IndexType>* m_out_coo, bool lower)
+                      matrix::view::coo<ValueType, IndexType> m_out_coo,
+                      bool lower)
 {
     auto num_rows = a->get_size()[0];
     auto total_nnz = a->get_num_stored_elements();

--- a/common/cuda_hip/factorization/par_ilut_sweep_kernels.cpp
+++ b/common/cuda_hip/factorization/par_ilut_sweep_kernels.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -141,14 +141,15 @@ namespace {
 
 
 template <int subwarp_size, typename ValueType, typename IndexType>
-void compute_l_u_factors(syn::value_list<int, subwarp_size>,
-                         std::shared_ptr<const DefaultExecutor> exec,
-                         const matrix::Csr<ValueType, IndexType>* a,
-                         matrix::Csr<ValueType, IndexType>* l,
-                         const matrix::Coo<ValueType, IndexType>* l_coo,
-                         matrix::Csr<ValueType, IndexType>* u,
-                         const matrix::Coo<ValueType, IndexType>* u_coo,
-                         matrix::Csr<ValueType, IndexType>* u_csc)
+void compute_l_u_factors(
+    syn::value_list<int, subwarp_size>,
+    std::shared_ptr<const DefaultExecutor> exec,
+    const matrix::Csr<ValueType, IndexType>* a,
+    matrix::Csr<ValueType, IndexType>* l,
+    matrix::view::coo<const ValueType, const IndexType> l_coo,
+    matrix::Csr<ValueType, IndexType>* u,
+    matrix::view::coo<const ValueType, const IndexType> u_coo,
+    matrix::Csr<ValueType, IndexType>* u_csc)
 {
     auto total_nnz = static_cast<IndexType>(l->get_num_stored_elements() +
                                             u->get_num_stored_elements());
@@ -166,10 +167,10 @@ void compute_l_u_factors(syn::value_list<int, subwarp_size>,
                 <<<num_blocks, default_block_size, 0, exec->get_stream()>>>(
                     a->get_const_row_ptrs(), a->get_const_col_idxs(),
                     as_device_type(a->get_const_values()),
-                    l->get_const_row_ptrs(), l_coo->get_const_row_idxs(),
+                    l->get_const_row_ptrs(), l_coo.row_idxs,
                     l->get_const_col_idxs(), as_device_type(l->get_values()),
                     static_cast<IndexType>(l->get_num_stored_elements()),
-                    u_coo->get_const_row_idxs(), u_coo->get_const_col_idxs(),
+                    u_coo.row_idxs, u_coo.col_idxs,
                     as_device_type(u->get_values()),
                     u_csc->get_const_row_ptrs(), u_csc->get_const_col_idxs(),
                     as_device_type(u_csc->get_values()),
@@ -186,13 +187,14 @@ GKO_ENABLE_IMPLEMENTATION_SELECTION(select_compute_l_u_factors,
 
 
 template <typename ValueType, typename IndexType>
-void compute_l_u_factors(std::shared_ptr<const DefaultExecutor> exec,
-                         const matrix::Csr<ValueType, IndexType>* a,
-                         matrix::Csr<ValueType, IndexType>* l,
-                         const matrix::Coo<ValueType, IndexType>* l_coo,
-                         matrix::Csr<ValueType, IndexType>* u,
-                         const matrix::Coo<ValueType, IndexType>* u_coo,
-                         matrix::Csr<ValueType, IndexType>* u_csc)
+void compute_l_u_factors(
+    std::shared_ptr<const DefaultExecutor> exec,
+    const matrix::Csr<ValueType, IndexType>* a,
+    matrix::Csr<ValueType, IndexType>* l,
+    matrix::view::coo<const ValueType, const IndexType> l_coo,
+    matrix::Csr<ValueType, IndexType>* u,
+    matrix::view::coo<const ValueType, const IndexType> u_coo,
+    matrix::Csr<ValueType, IndexType>* u_csc)
 {
     auto num_rows = a->get_size()[0];
     auto total_nnz =

--- a/common/cuda_hip/matrix/coo_kernels.cpp
+++ b/common/cuda_hip/matrix/coo_kernels.cpp
@@ -306,8 +306,8 @@ void spmv2(std::shared_ptr<const DefaultExecutor> exec,
 
             abstract_spmm<<<coo_grid, coo_block, 0, exec->get_stream()>>>(
                 nnz, num_elems, as_device_type(a.values), a.col_idxs,
-               a.row_idxs, b_ncols, as_device_type(b.values),
-                b.stride, as_device_type(c.values), c.stride);
+                a.row_idxs, b_ncols, as_device_type(b.values), b.stride,
+                as_device_type(c.values), c.stride);
         }
     }
 }
@@ -354,9 +354,9 @@ void advanced_spmv2(std::shared_ptr<const DefaultExecutor> exec,
 
             abstract_spmv<<<coo_grid, coo_block, 0, exec->get_stream()>>>(
                 nnz, num_lines, as_device_type(alpha.values),
-                as_device_type(a.values), a.col_idxs,
-                a.row_idxs, as_device_type(b.values), b.stride,
-                as_device_type(c.values), c.stride);
+                as_device_type(a.values), a.col_idxs, a.row_idxs,
+                as_device_type(b.values), b.stride, as_device_type(c.values),
+                c.stride);
         } else {
             int num_elems =
                 ceildiv(nnz, nwarps * config::warp_size) * config::warp_size;
@@ -365,9 +365,9 @@ void advanced_spmv2(std::shared_ptr<const DefaultExecutor> exec,
 
             abstract_spmm<<<coo_grid, coo_block, 0, exec->get_stream()>>>(
                 nnz, num_elems, as_device_type(alpha.values),
-                as_device_type(a.values), a.col_idxs,
-                a.row_idxs, b_ncols, as_device_type(b.values),
-                b.stride, as_device_type(c.values), c.stride);
+                as_device_type(a.values), a.col_idxs, a.row_idxs, b_ncols,
+                as_device_type(b.values), b.stride, as_device_type(c.values),
+                c.stride);
         }
     }
 }

--- a/common/cuda_hip/matrix/coo_kernels.cpp
+++ b/common/cuda_hip/matrix/coo_kernels.cpp
@@ -231,7 +231,7 @@ __global__ __launch_bounds__(spmv_block_size) void abstract_spmm(
 
 template <typename ValueType, typename IndexType>
 void spmv(std::shared_ptr<const DefaultExecutor> exec,
-          const matrix::Coo<ValueType, IndexType>* a,
+          matrix::view::coo<const ValueType, const IndexType> a,
           matrix::view::dense<const ValueType> b,
           matrix::view::dense<ValueType> c)
 {
@@ -245,7 +245,7 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(GKO_DECLARE_COO_SPMV_KERNEL);
 template <typename ValueType, typename IndexType>
 void advanced_spmv(std::shared_ptr<const DefaultExecutor> exec,
                    matrix::view::dense<const ValueType> alpha,
-                   const matrix::Coo<ValueType, IndexType>* a,
+                   matrix::view::coo<const ValueType, const IndexType> a,
                    matrix::view::dense<const ValueType> b,
                    matrix::view::dense<const ValueType> beta,
                    matrix::view::dense<ValueType> c)
@@ -260,11 +260,11 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 
 template <typename ValueType, typename IndexType>
 void spmv2(std::shared_ptr<const DefaultExecutor> exec,
-           const matrix::Coo<ValueType, IndexType>* a,
+           matrix::view::coo<const ValueType, const IndexType> a,
            matrix::view::dense<const ValueType> b,
            matrix::view::dense<ValueType> c)
 {
-    const auto nnz = a->get_num_stored_elements();
+    const auto nnz = a.num_stored_elements;
     const auto b_ncols = b.size[1];
     const dim3 coo_block(config::warp_size, warps_in_block, 1);
     const auto nwarps = host_kernel::calculate_nwarps(exec, nnz);
@@ -295,11 +295,9 @@ void spmv2(std::shared_ptr<const DefaultExecutor> exec,
             int num_lines = ceildiv(nnz, nwarps * config::warp_size);
 
             abstract_spmv<<<coo_grid, coo_block, 0, exec->get_stream()>>>(
-                nnz, num_lines, as_device_type(a->get_const_values()),
-                a->get_const_col_idxs(),
-                as_device_type(a->get_const_row_idxs()),
-                as_device_type(b.values), b.stride, as_device_type(c.values),
-                c.stride);
+                nnz, num_lines, as_device_type(a.values), a.col_idxs,
+                as_device_type(a.row_idxs), as_device_type(b.values), b.stride,
+                as_device_type(c.values), c.stride);
         } else {
             int num_elems =
                 ceildiv(nnz, nwarps * config::warp_size) * config::warp_size;
@@ -307,11 +305,9 @@ void spmv2(std::shared_ptr<const DefaultExecutor> exec,
                                 ceildiv(b_ncols, config::warp_size));
 
             abstract_spmm<<<coo_grid, coo_block, 0, exec->get_stream()>>>(
-                nnz, num_elems, as_device_type(a->get_const_values()),
-                a->get_const_col_idxs(),
-                as_device_type(a->get_const_row_idxs()), b_ncols,
-                as_device_type(b.values), b.stride, as_device_type(c.values),
-                c.stride);
+                nnz, num_elems, as_device_type(a.values), a.col_idxs,
+                as_device_type(a.row_idxs), b_ncols, as_device_type(b.values),
+                b.stride, as_device_type(c.values), c.stride);
         }
     }
 }
@@ -322,11 +318,11 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(GKO_DECLARE_COO_SPMV2_KERNEL);
 template <typename ValueType, typename IndexType>
 void advanced_spmv2(std::shared_ptr<const DefaultExecutor> exec,
                     matrix::view::dense<const ValueType> alpha,
-                    const matrix::Coo<ValueType, IndexType>* a,
+                    matrix::view::coo<const ValueType, const IndexType> a,
                     matrix::view::dense<const ValueType> b,
                     matrix::view::dense<ValueType> c)
 {
-    const auto nnz = a->get_num_stored_elements();
+    const auto nnz = a.num_stored_elements;
     const auto nwarps = host_kernel::calculate_nwarps(exec, nnz);
     const dim3 coo_block(config::warp_size, warps_in_block, 1);
     const auto b_ncols = b.size[1];
@@ -358,10 +354,9 @@ void advanced_spmv2(std::shared_ptr<const DefaultExecutor> exec,
 
             abstract_spmv<<<coo_grid, coo_block, 0, exec->get_stream()>>>(
                 nnz, num_lines, as_device_type(alpha.values),
-                as_device_type(a->get_const_values()), a->get_const_col_idxs(),
-                as_device_type(a->get_const_row_idxs()),
-                as_device_type(b.values), b.stride, as_device_type(c.values),
-                c.stride);
+                as_device_type(a.values), a.col_idxs,
+                as_device_type(a.row_idxs), as_device_type(b.values), b.stride,
+                as_device_type(c.values), c.stride);
         } else {
             int num_elems =
                 ceildiv(nnz, nwarps * config::warp_size) * config::warp_size;
@@ -370,10 +365,9 @@ void advanced_spmv2(std::shared_ptr<const DefaultExecutor> exec,
 
             abstract_spmm<<<coo_grid, coo_block, 0, exec->get_stream()>>>(
                 nnz, num_elems, as_device_type(alpha.values),
-                as_device_type(a->get_const_values()), a->get_const_col_idxs(),
-                as_device_type(a->get_const_row_idxs()), b_ncols,
-                as_device_type(b.values), b.stride, as_device_type(c.values),
-                c.stride);
+                as_device_type(a.values), a.col_idxs,
+                as_device_type(a.row_idxs), b_ncols, as_device_type(b.values),
+                b.stride, as_device_type(c.values), c.stride);
         }
     }
 }

--- a/common/cuda_hip/matrix/coo_kernels.cpp
+++ b/common/cuda_hip/matrix/coo_kernels.cpp
@@ -296,7 +296,7 @@ void spmv2(std::shared_ptr<const DefaultExecutor> exec,
 
             abstract_spmv<<<coo_grid, coo_block, 0, exec->get_stream()>>>(
                 nnz, num_lines, as_device_type(a.values), a.col_idxs,
-                as_device_type(a.row_idxs), as_device_type(b.values), b.stride,
+                a.row_idxs, as_device_type(b.values), b.stride,
                 as_device_type(c.values), c.stride);
         } else {
             int num_elems =
@@ -306,7 +306,7 @@ void spmv2(std::shared_ptr<const DefaultExecutor> exec,
 
             abstract_spmm<<<coo_grid, coo_block, 0, exec->get_stream()>>>(
                 nnz, num_elems, as_device_type(a.values), a.col_idxs,
-                as_device_type(a.row_idxs), b_ncols, as_device_type(b.values),
+               a.row_idxs, b_ncols, as_device_type(b.values),
                 b.stride, as_device_type(c.values), c.stride);
         }
     }
@@ -355,7 +355,7 @@ void advanced_spmv2(std::shared_ptr<const DefaultExecutor> exec,
             abstract_spmv<<<coo_grid, coo_block, 0, exec->get_stream()>>>(
                 nnz, num_lines, as_device_type(alpha.values),
                 as_device_type(a.values), a.col_idxs,
-                as_device_type(a.row_idxs), as_device_type(b.values), b.stride,
+                a.row_idxs, as_device_type(b.values), b.stride,
                 as_device_type(c.values), c.stride);
         } else {
             int num_elems =
@@ -366,7 +366,7 @@ void advanced_spmv2(std::shared_ptr<const DefaultExecutor> exec,
             abstract_spmm<<<coo_grid, coo_block, 0, exec->get_stream()>>>(
                 nnz, num_elems, as_device_type(alpha.values),
                 as_device_type(a.values), a.col_idxs,
-                as_device_type(a.row_idxs), b_ncols, as_device_type(b.values),
+                a.row_idxs, b_ncols, as_device_type(b.values),
                 b.stride, as_device_type(c.values), c.stride);
         }
     }

--- a/common/cuda_hip/matrix/dense_kernels.cpp
+++ b/common/cuda_hip/matrix/dense_kernels.cpp
@@ -441,14 +441,14 @@ template <typename ValueType, typename IndexType>
 void convert_to_coo(std::shared_ptr<const DefaultExecutor> exec,
                     matrix::view::dense<const ValueType> source,
                     const int64* row_ptrs,
-                    matrix::Coo<ValueType, IndexType>* result)
+                    matrix::view::coo<ValueType, IndexType> result)
 {
-    auto num_rows = result->get_size()[0];
-    auto num_cols = result->get_size()[1];
+    auto num_rows = result.size[0];
+    auto num_cols = result.size[1];
 
-    auto row_idxs = result->get_row_idxs();
-    auto col_idxs = result->get_col_idxs();
-    auto values = result->get_values();
+    auto row_idxs = result.row_idxs;
+    auto col_idxs = result.col_idxs;
+    auto values = result.values;
 
     auto stride = source.stride;
 

--- a/common/cuda_hip/multigrid/pgm_kernels.cpp
+++ b/common/cuda_hip/multigrid/pgm_kernels.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -85,7 +85,7 @@ template <typename ValueType, typename IndexType>
 void compute_coarse_coo(std::shared_ptr<const DefaultExecutor> exec,
                         size_type fine_nnz, const IndexType* row_idxs,
                         const IndexType* col_idxs, const ValueType* vals,
-                        matrix::Coo<ValueType, IndexType>* coarse_coo)
+                        matrix::view::coo<ValueType, IndexType> coarse_coo)
 {
     auto vals_it = as_device_type(vals);
     // this const_cast is necessary as a workaround for CCCL bug
@@ -94,9 +94,9 @@ void compute_coarse_coo(std::shared_ptr<const DefaultExecutor> exec,
     auto key_it = thrust::make_zip_iterator(thrust::make_tuple(
         const_cast<IndexType*>(row_idxs), const_cast<IndexType*>(col_idxs)));
 
-    auto coarse_vals_it = as_device_type(coarse_coo->get_values());
-    auto coarse_key_it = thrust::make_zip_iterator(thrust::make_tuple(
-        coarse_coo->get_row_idxs(), coarse_coo->get_col_idxs()));
+    auto coarse_vals_it = as_device_type(coarse_coo.values);
+    auto coarse_key_it = thrust::make_zip_iterator(
+        thrust::make_tuple(coarse_coo.row_idxs, coarse_coo.col_idxs));
 
     thrust::reduce_by_key(thrust_policy(exec), key_it, key_it + fine_nnz,
                           vals_it, coarse_key_it, coarse_vals_it);

--- a/common/unified/matrix/coo_kernels.cpp
+++ b/common/unified/matrix/coo_kernels.cpp
@@ -22,7 +22,7 @@ namespace coo {
 
 template <typename ValueType, typename IndexType>
 void extract_diagonal(std::shared_ptr<const DefaultExecutor> exec,
-                      const matrix::Coo<ValueType, IndexType>* orig,
+                      matrix::view::coo<const ValueType, const IndexType> orig,
                       matrix::Diagonal<ValueType>* diag)
 {
     run_kernel(
@@ -33,8 +33,7 @@ void extract_diagonal(std::shared_ptr<const DefaultExecutor> exec,
                 diag[orig_row_idxs[tidx]] = orig_values[tidx];
             }
         },
-        orig->get_num_stored_elements(), orig->get_const_values(),
-        orig->get_const_row_idxs(), orig->get_const_col_idxs(),
+        orig.num_stored_elements, orig.values, orig.row_idxs, orig.col_idxs,
         diag->get_values());
 }
 
@@ -44,7 +43,7 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 
 template <typename ValueType, typename IndexType>
 void fill_in_dense(std::shared_ptr<const DefaultExecutor> exec,
-                   const matrix::Coo<ValueType, IndexType>* orig,
+                   matrix::view::coo<const ValueType, const IndexType> orig,
                    matrix::view::dense<ValueType> result)
 {
     run_kernel(
@@ -54,8 +53,8 @@ void fill_in_dense(std::shared_ptr<const DefaultExecutor> exec,
             result(orig_row_idxs[tidx], orig_col_idxs[tidx]) =
                 orig_values[tidx];
         },
-        orig->get_num_stored_elements(), orig->get_const_values(),
-        orig->get_const_row_idxs(), orig->get_const_col_idxs(), result);
+        orig.num_stored_elements, orig.values, orig.row_idxs, orig.col_idxs,
+        result);
 }
 
 GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(

--- a/core/factorization/par_ic.cpp
+++ b/core/factorization/par_ic.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -131,7 +131,8 @@ std::unique_ptr<Composition<ValueType>> ParIc<ValueType, IndexType>::generate(
 
     // execute sweeps
     exec->run(par_ic_factorization::make_compute_factor(
-        parameters_.iterations, a_lower_coo.get(), l_factor.get()));
+        parameters_.iterations, a_lower_coo->get_const_device_view(),
+        l_factor.get()));
 
     if (both_factors) {
         auto lh_factor = l_factor->conj_transpose();

--- a/core/factorization/par_ic_kernels.hpp
+++ b/core/factorization/par_ic_kernels.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -11,8 +11,8 @@
 #include <ginkgo/core/base/executor.hpp>
 #include <ginkgo/core/base/types.hpp>
 #include <ginkgo/core/factorization/par_ic.hpp>
-#include <ginkgo/core/matrix/coo.hpp>
 #include <ginkgo/core/matrix/csr.hpp>
+#include <ginkgo/core/matrix/device_views.hpp>
 
 #include "core/base/kernel_declaration.hpp"
 
@@ -25,11 +25,12 @@ namespace kernels {
     void init_factor(std::shared_ptr<const DefaultExecutor> exec,   \
                      matrix::Csr<ValueType, IndexType>* l_factor)
 
-#define GKO_DECLARE_PAR_IC_COMPUTE_FACTOR_KERNEL(ValueType, IndexType)     \
-    void compute_factor(                                                   \
-        std::shared_ptr<const DefaultExecutor> exec, size_type iterations, \
-        const matrix::Coo<ValueType, IndexType>* lower_system_matrix,      \
-        matrix::Csr<ValueType, IndexType>* l_factor)
+#define GKO_DECLARE_PAR_IC_COMPUTE_FACTOR_KERNEL(ValueType, IndexType)      \
+    void compute_factor(std::shared_ptr<const DefaultExecutor> exec,        \
+                        size_type iterations,                               \
+                        matrix::view::coo<const ValueType, const IndexType> \
+                            lower_system_matrix,                            \
+                        matrix::Csr<ValueType, IndexType>* l_factor)
 
 #define GKO_DECLARE_ALL_AS_TEMPLATES                             \
     template <typename ValueType, typename IndexType>            \

--- a/core/factorization/par_ict.cpp
+++ b/core/factorization/par_ict.cpp
@@ -272,7 +272,7 @@ void ParIctState<ValueType, IndexType>::iterate()
         // remove approximately smallest candidates
         exec->run(make_threshold_filter_approx(l_new.get(), l_filter_rank,
                                                selection_tmp, tmp, l.get(),
-                                               l_coo->get_device_view()));
+                                               l_coo.get()));
     } else {
         // select threshold to remove smallest candidates
         remove_complex<ValueType> l_threshold{};
@@ -282,7 +282,7 @@ void ParIctState<ValueType, IndexType>::iterate()
 
         // remove smallest candidates
         exec->run(make_threshold_filter(l_new.get(), l_threshold, l.get(),
-                                        l_coo->get_device_view(), true));
+                                        l_coo.get(), true));
     }
 
     // execute asynchronous iteration

--- a/core/factorization/par_ict.cpp
+++ b/core/factorization/par_ict.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -260,7 +260,8 @@ void ParIctState<ValueType, IndexType>::iterate()
                                         l_coo->get_row_idxs()));
 
     // execute asynchronous iteration
-    exec->run(make_compute_factor(system_matrix, l_new.get(), l_coo.get()));
+    exec->run(make_compute_factor(system_matrix, l_new.get(),
+                                  l_coo->get_const_device_view()));
 
     // determine ranks for selection/filtering
     IndexType l_nnz = l_new->get_num_stored_elements();
@@ -271,7 +272,7 @@ void ParIctState<ValueType, IndexType>::iterate()
         // remove approximately smallest candidates
         exec->run(make_threshold_filter_approx(l_new.get(), l_filter_rank,
                                                selection_tmp, tmp, l.get(),
-                                               l_coo.get()));
+                                               l_coo->get_device_view()));
     } else {
         // select threshold to remove smallest candidates
         remove_complex<ValueType> l_threshold{};
@@ -281,11 +282,12 @@ void ParIctState<ValueType, IndexType>::iterate()
 
         // remove smallest candidates
         exec->run(make_threshold_filter(l_new.get(), l_threshold, l.get(),
-                                        l_coo.get(), true));
+                                        l_coo->get_device_view(), true));
     }
 
     // execute asynchronous iteration
-    exec->run(make_compute_factor(system_matrix, l.get(), l_coo.get()));
+    exec->run(make_compute_factor(system_matrix, l.get(),
+                                  l_coo->get_const_device_view()));
 
     // convert L to L^H
     {

--- a/core/factorization/par_ict_kernels.hpp
+++ b/core/factorization/par_ict_kernels.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -13,6 +13,7 @@
 #include <ginkgo/core/factorization/par_ict.hpp>
 #include <ginkgo/core/matrix/coo.hpp>
 #include <ginkgo/core/matrix/csr.hpp>
+#include <ginkgo/core/matrix/device_views.hpp>
 
 #include "core/base/kernel_declaration.hpp"
 
@@ -29,10 +30,11 @@ namespace kernels {
                         matrix::Csr<ValueType, IndexType>* l_new)
 
 #define GKO_DECLARE_PAR_ICT_COMPUTE_FACTOR_KERNEL(ValueType, IndexType) \
-    void compute_factor(std::shared_ptr<const DefaultExecutor> exec,    \
-                        const matrix::Csr<ValueType, IndexType>* a,     \
-                        matrix::Csr<ValueType, IndexType>* l,           \
-                        const matrix::Coo<ValueType, IndexType>* l_coo)
+    void compute_factor(                                                \
+        std::shared_ptr<const DefaultExecutor> exec,                    \
+        const matrix::Csr<ValueType, IndexType>* a,                     \
+        matrix::Csr<ValueType, IndexType>* l,                           \
+        matrix::view::coo<const ValueType, const IndexType> l_coo)
 
 #define GKO_DECLARE_ALL_AS_TEMPLATES                                 \
     template <typename ValueType, typename IndexType>                \

--- a/core/factorization/par_ilu.cpp
+++ b/core/factorization/par_ilu.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -145,8 +145,8 @@ ParIlu<ValueType, IndexType>::generate_l_u(
     }
 
     exec->run(par_ilu_factorization::make_compute_l_u_factors(
-        parameters_.iterations, coo_system_matrix_ptr, l_factor.get(),
-        u_factor_transpose));
+        parameters_.iterations, coo_system_matrix_ptr->get_const_device_view(),
+        l_factor.get(), u_factor_transpose));
 
     // Transpose it again, which is basically a conversion from CSC back to CSR
     // Since the transposed version has the exact same non-zero positions

--- a/core/factorization/par_ilu_kernels.hpp
+++ b/core/factorization/par_ilu_kernels.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -12,6 +12,7 @@
 #include <ginkgo/core/base/types.hpp>
 #include <ginkgo/core/factorization/par_ilu.hpp>
 #include <ginkgo/core/matrix/csr.hpp>
+#include <ginkgo/core/matrix/device_views.hpp>
 
 #include "core/base/kernel_declaration.hpp"
 
@@ -22,7 +23,7 @@ namespace kernels {
 #define GKO_DECLARE_PAR_ILU_COMPUTE_L_U_FACTORS_KERNEL(ValueType, IndexType) \
     void compute_l_u_factors(                                                \
         std::shared_ptr<const DefaultExecutor> exec, size_type iterations,   \
-        const matrix::Coo<ValueType, IndexType>* system_matrix,              \
+        matrix::view::coo<const ValueType, const IndexType> system_matrix,   \
         matrix::Csr<ValueType, IndexType>* l_factor,                         \
         matrix::Csr<ValueType, IndexType>* u_factor)
 

--- a/core/factorization/par_ilut.cpp
+++ b/core/factorization/par_ilut.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -304,9 +304,9 @@ void ParIlutState<ValueType, IndexType>::iterate()
                                         u_coo->get_row_idxs()));
 
     // execute asynchronous iteration
-    exec->run(make_compute_l_u_factors(system_matrix, l_new.get(), l_coo.get(),
-                                       u_new.get(), u_coo.get(),
-                                       u_new_csc.get()));
+    exec->run(make_compute_l_u_factors(
+        system_matrix, l_new.get(), l_coo->get_const_device_view(), u_new.get(),
+        u_coo->get_const_device_view(), u_new_csc.get()));
 
     // determine ranks for selection/filtering
     IndexType l_nnz = l_new->get_num_stored_elements();
@@ -316,12 +316,13 @@ void ParIlutState<ValueType, IndexType>::iterate()
     auto u_filter_rank = std::max<IndexType>(0, u_nnz - u_nnz_limit - 1);
     remove_complex<ValueType> l_threshold{};
     remove_complex<ValueType> u_threshold{};
-    CooMatrix* null_coo = nullptr;
+    using null_coo_type = matrix::view::coo<ValueType, IndexType>;
+    null_coo_type null_coo{{}, 0, nullptr, nullptr, nullptr};
     if (use_approx_select) {
         // remove approximately smallest candidates from L' and U'^T
-        exec->run(make_threshold_filter_approx(l_new.get(), l_filter_rank,
-                                               selection_tmp, l_threshold,
-                                               l.get(), l_coo.get()));
+        exec->run(make_threshold_filter_approx(
+            l_new.get(), l_filter_rank, selection_tmp, l_threshold, l.get(),
+            l_coo->get_device_view()));
         exec->run(make_threshold_filter_approx(u_new_csc.get(), u_filter_rank,
                                                selection_tmp, u_threshold,
                                                u_csc.get(), null_coo));
@@ -336,17 +337,18 @@ void ParIlutState<ValueType, IndexType>::iterate()
 
         // remove smallest candidates from L' and U'^T
         exec->run(make_threshold_filter(l_new.get(), l_threshold, l.get(),
-                                        l_coo.get(), true));
+                                        l_coo->get_device_view(), true));
         exec->run(make_threshold_filter(u_new_csc.get(), u_threshold,
                                         u_csc.get(), null_coo, true));
     }
     // remove smallest candidates from U'
     exec->run(make_threshold_filter(u_new.get(), u_threshold, u.get(),
-                                    u_coo.get(), false));
+                                    u_coo->get_device_view(), false));
 
     // execute asynchronous iteration
-    exec->run(make_compute_l_u_factors(system_matrix, l.get(), l_coo.get(),
-                                       u.get(), u_coo.get(), u_csc.get()));
+    exec->run(make_compute_l_u_factors(
+        system_matrix, l.get(), l_coo->get_const_device_view(), u.get(),
+        u_coo->get_const_device_view(), u_csc.get()));
 }
 
 

--- a/core/factorization/par_ilut.cpp
+++ b/core/factorization/par_ilut.cpp
@@ -316,13 +316,12 @@ void ParIlutState<ValueType, IndexType>::iterate()
     auto u_filter_rank = std::max<IndexType>(0, u_nnz - u_nnz_limit - 1);
     remove_complex<ValueType> l_threshold{};
     remove_complex<ValueType> u_threshold{};
-    using null_coo_type = matrix::view::coo<ValueType, IndexType>;
-    null_coo_type null_coo{{}, 0, nullptr, nullptr, nullptr};
+    CooMatrix* null_coo = nullptr;
     if (use_approx_select) {
         // remove approximately smallest candidates from L' and U'^T
-        exec->run(make_threshold_filter_approx(
-            l_new.get(), l_filter_rank, selection_tmp, l_threshold, l.get(),
-            l_coo->get_device_view()));
+        exec->run(make_threshold_filter_approx(l_new.get(), l_filter_rank,
+                                               selection_tmp, l_threshold,
+                                               l.get(), l_coo.get()));
         exec->run(make_threshold_filter_approx(u_new_csc.get(), u_filter_rank,
                                                selection_tmp, u_threshold,
                                                u_csc.get(), null_coo));
@@ -337,13 +336,13 @@ void ParIlutState<ValueType, IndexType>::iterate()
 
         // remove smallest candidates from L' and U'^T
         exec->run(make_threshold_filter(l_new.get(), l_threshold, l.get(),
-                                        l_coo->get_device_view(), true));
+                                        l_coo.get(), true));
         exec->run(make_threshold_filter(u_new_csc.get(), u_threshold,
                                         u_csc.get(), null_coo, true));
     }
     // remove smallest candidates from U'
     exec->run(make_threshold_filter(u_new.get(), u_threshold, u.get(),
-                                    u_coo->get_device_view(), false));
+                                    u_coo.get(), false));
 
     // execute asynchronous iteration
     exec->run(make_compute_l_u_factors(

--- a/core/factorization/par_ilut_kernels.hpp
+++ b/core/factorization/par_ilut_kernels.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -13,6 +13,7 @@
 #include <ginkgo/core/factorization/par_ilut.hpp>
 #include <ginkgo/core/matrix/coo.hpp>
 #include <ginkgo/core/matrix/csr.hpp>
+#include <ginkgo/core/matrix/device_views.hpp>
 
 #include "core/base/kernel_declaration.hpp"
 
@@ -31,13 +32,14 @@ namespace kernels {
                         matrix::Csr<ValueType, IndexType>* u_new)
 
 #define GKO_DECLARE_PAR_ILUT_COMPUTE_LU_FACTORS_KERNEL(ValueType, IndexType) \
-    void compute_l_u_factors(std::shared_ptr<const DefaultExecutor> exec,    \
-                             const matrix::Csr<ValueType, IndexType>* a,     \
-                             matrix::Csr<ValueType, IndexType>* l,           \
-                             const matrix::Coo<ValueType, IndexType>* l_coo, \
-                             matrix::Csr<ValueType, IndexType>* u,           \
-                             const matrix::Coo<ValueType, IndexType>* u_coo, \
-                             matrix::Csr<ValueType, IndexType>* u_csc)
+    void compute_l_u_factors(                                                \
+        std::shared_ptr<const DefaultExecutor> exec,                         \
+        const matrix::Csr<ValueType, IndexType>* a,                          \
+        matrix::Csr<ValueType, IndexType>* l,                                \
+        matrix::view::coo<const ValueType, const IndexType> l_coo,           \
+        matrix::Csr<ValueType, IndexType>* u,                                \
+        matrix::view::coo<const ValueType, const IndexType> u_coo,           \
+        matrix::Csr<ValueType, IndexType>* u_csc)
 
 #define GKO_DECLARE_PAR_ILUT_THRESHOLD_SELECT_KERNEL(ValueType, IndexType) \
     void threshold_select(std::shared_ptr<const DefaultExecutor> exec,     \
@@ -46,22 +48,22 @@ namespace kernels {
                           array<remove_complex<ValueType>>& tmp2,          \
                           remove_complex<ValueType>& threshold)
 
-#define GKO_DECLARE_PAR_ILUT_THRESHOLD_FILTER_KERNEL(ValueType, IndexType) \
-    void threshold_filter(std::shared_ptr<const DefaultExecutor> exec,     \
-                          const matrix::Csr<ValueType, IndexType>* m,      \
-                          remove_complex<ValueType> threshold,             \
-                          matrix::Csr<ValueType, IndexType>* m_out,        \
-                          matrix::Coo<ValueType, IndexType>* m_out_coo,    \
+#define GKO_DECLARE_PAR_ILUT_THRESHOLD_FILTER_KERNEL(ValueType, IndexType)   \
+    void threshold_filter(std::shared_ptr<const DefaultExecutor> exec,       \
+                          const matrix::Csr<ValueType, IndexType>* m,        \
+                          remove_complex<ValueType> threshold,               \
+                          matrix::Csr<ValueType, IndexType>* m_out,          \
+                          matrix::view::coo<ValueType, IndexType> m_out_coo, \
                           bool lower)
 
-#define GKO_DECLARE_PAR_ILUT_THRESHOLD_FILTER_APPROX_KERNEL(ValueType,        \
-                                                            IndexType)        \
-    void threshold_filter_approx(std::shared_ptr<const DefaultExecutor> exec, \
-                                 const matrix::Csr<ValueType, IndexType>* m,  \
-                                 IndexType rank, array<ValueType>& tmp,       \
-                                 remove_complex<ValueType>& threshold,        \
-                                 matrix::Csr<ValueType, IndexType>* m_out,    \
-                                 matrix::Coo<ValueType, IndexType>* m_out_coo)
+#define GKO_DECLARE_PAR_ILUT_THRESHOLD_FILTER_APPROX_KERNEL(ValueType, \
+                                                            IndexType) \
+    void threshold_filter_approx(                                      \
+        std::shared_ptr<const DefaultExecutor> exec,                   \
+        const matrix::Csr<ValueType, IndexType>* m, IndexType rank,    \
+        array<ValueType>& tmp, remove_complex<ValueType>& threshold,   \
+        matrix::Csr<ValueType, IndexType>* m_out,                      \
+        matrix::view::coo<ValueType, IndexType> m_out_coo)
 
 #define GKO_DECLARE_ALL_AS_TEMPLATES                                      \
     constexpr auto sampleselect_searchtree_height = 8;                    \

--- a/core/factorization/par_ilut_kernels.hpp
+++ b/core/factorization/par_ilut_kernels.hpp
@@ -48,22 +48,22 @@ namespace kernels {
                           array<remove_complex<ValueType>>& tmp2,          \
                           remove_complex<ValueType>& threshold)
 
-#define GKO_DECLARE_PAR_ILUT_THRESHOLD_FILTER_KERNEL(ValueType, IndexType)   \
-    void threshold_filter(std::shared_ptr<const DefaultExecutor> exec,       \
-                          const matrix::Csr<ValueType, IndexType>* m,        \
-                          remove_complex<ValueType> threshold,               \
-                          matrix::Csr<ValueType, IndexType>* m_out,          \
-                          matrix::view::coo<ValueType, IndexType> m_out_coo, \
+#define GKO_DECLARE_PAR_ILUT_THRESHOLD_FILTER_KERNEL(ValueType, IndexType) \
+    void threshold_filter(std::shared_ptr<const DefaultExecutor> exec,     \
+                          const matrix::Csr<ValueType, IndexType>* m,      \
+                          remove_complex<ValueType> threshold,             \
+                          matrix::Csr<ValueType, IndexType>* m_out,        \
+                          matrix::Coo<ValueType, IndexType>* m_out_coo,    \
                           bool lower)
 
-#define GKO_DECLARE_PAR_ILUT_THRESHOLD_FILTER_APPROX_KERNEL(ValueType, \
-                                                            IndexType) \
-    void threshold_filter_approx(                                      \
-        std::shared_ptr<const DefaultExecutor> exec,                   \
-        const matrix::Csr<ValueType, IndexType>* m, IndexType rank,    \
-        array<ValueType>& tmp, remove_complex<ValueType>& threshold,   \
-        matrix::Csr<ValueType, IndexType>* m_out,                      \
-        matrix::view::coo<ValueType, IndexType> m_out_coo)
+#define GKO_DECLARE_PAR_ILUT_THRESHOLD_FILTER_APPROX_KERNEL(ValueType,        \
+                                                            IndexType)        \
+    void threshold_filter_approx(std::shared_ptr<const DefaultExecutor> exec, \
+                                 const matrix::Csr<ValueType, IndexType>* m,  \
+                                 IndexType rank, array<ValueType>& tmp,       \
+                                 remove_complex<ValueType>& threshold,        \
+                                 matrix::Csr<ValueType, IndexType>* m_out,    \
+                                 matrix::Coo<ValueType, IndexType>* m_out_coo)
 
 #define GKO_DECLARE_ALL_AS_TEMPLATES                                      \
     constexpr auto sampleselect_searchtree_height = 8;                    \

--- a/core/matrix/coo.cpp
+++ b/core/matrix/coo.cpp
@@ -171,9 +171,9 @@ void Coo<ValueType, IndexType>::apply_impl(const LinOp* b, LinOp* x) const
 {
     precision_dispatch_real_complex<ValueType>(
         [this](auto dense_b, auto dense_x) {
-            this->get_executor()->run(
-                coo::make_spmv(this, dense_b->get_const_device_view(),
-                               dense_x->get_device_view()));
+            this->get_executor()->run(coo::make_spmv(
+                this->get_const_device_view(), dense_b->get_const_device_view(),
+                dense_x->get_device_view()));
         },
         b, x);
 }
@@ -185,11 +185,11 @@ void Coo<ValueType, IndexType>::apply_impl(const LinOp* alpha, const LinOp* b,
 {
     precision_dispatch_real_complex<ValueType>(
         [this](auto dense_alpha, auto dense_b, auto dense_beta, auto dense_x) {
-            this->get_executor()->run(
-                coo::make_advanced_spmv(dense_alpha->get_const_device_view(),
-                                        this, dense_b->get_const_device_view(),
-                                        dense_beta->get_const_device_view(),
-                                        dense_x->get_device_view()));
+            this->get_executor()->run(coo::make_advanced_spmv(
+                dense_alpha->get_const_device_view(),
+                this->get_const_device_view(), dense_b->get_const_device_view(),
+                dense_beta->get_const_device_view(),
+                dense_x->get_device_view()));
         },
         alpha, b, beta, x);
 }
@@ -200,9 +200,9 @@ void Coo<ValueType, IndexType>::apply2_impl(const LinOp* b, LinOp* x) const
 {
     precision_dispatch_real_complex<ValueType>(
         [this](auto dense_b, auto dense_x) {
-            this->get_executor()->run(
-                coo::make_spmv2(this, dense_b->get_const_device_view(),
-                                dense_x->get_device_view()));
+            this->get_executor()->run(coo::make_spmv2(
+                this->get_const_device_view(), dense_b->get_const_device_view(),
+                dense_x->get_device_view()));
         },
         b, x);
 }
@@ -215,8 +215,9 @@ void Coo<ValueType, IndexType>::apply2_impl(const LinOp* alpha, const LinOp* b,
     precision_dispatch_real_complex<ValueType>(
         [this](auto dense_alpha, auto dense_b, auto dense_x) {
             this->get_executor()->run(coo::make_advanced_spmv2(
-                dense_alpha->get_const_device_view(), this,
-                dense_b->get_const_device_view(), dense_x->get_device_view()));
+                dense_alpha->get_const_device_view(),
+                this->get_const_device_view(), dense_b->get_const_device_view(),
+                dense_x->get_device_view()));
         },
         alpha, b, x);
 }
@@ -323,7 +324,8 @@ void Coo<ValueType, IndexType>::convert_to(Dense<ValueType>* result) const
     auto tmp_result = make_temporary_output_clone(exec, result);
     tmp_result->resize(this->get_size());
     tmp_result->fill(zero<ValueType>());
-    exec->run(coo::make_fill_in_dense(this, tmp_result->get_device_view()));
+    exec->run(coo::make_fill_in_dense(this->get_const_device_view(),
+                                      tmp_result->get_device_view()));
 }
 
 
@@ -441,7 +443,8 @@ Coo<ValueType, IndexType>::extract_diagonal() const
     auto diag = Diagonal<ValueType>::create(exec, diag_size);
     exec->run(coo::make_fill_array(diag->get_values(), diag->get_size()[0],
                                    zero<ValueType>()));
-    exec->run(coo::make_extract_diagonal(this, diag.get()));
+    exec->run(
+        coo::make_extract_diagonal(this->get_const_device_view(), diag.get()));
     return diag;
 }
 
@@ -472,6 +475,26 @@ Coo<ValueType, IndexType>::compute_absolute() const
                                                 abs_coo->get_values()));
 
     return abs_coo;
+}
+
+
+template <typename ValueType, typename IndexType>
+auto Coo<ValueType, IndexType>::get_device_view() -> device_view
+{
+    return device_view{this->get_size(), this->get_num_stored_elements(),
+                       this->get_values(), this->get_row_idxs(),
+                       this->get_col_idxs()};
+}
+
+
+template <typename ValueType, typename IndexType>
+auto Coo<ValueType, IndexType>::get_const_device_view() const
+    -> const_device_view
+{
+    return const_device_view{this->get_size(), this->get_num_stored_elements(),
+                             this->get_const_values(),
+                             this->get_const_row_idxs(),
+                             this->get_const_col_idxs()};
 }
 
 

--- a/core/matrix/coo_kernels.hpp
+++ b/core/matrix/coo_kernels.hpp
@@ -10,6 +10,7 @@
 #include <ginkgo/core/matrix/coo.hpp>
 #include <ginkgo/core/matrix/csr.hpp>
 #include <ginkgo/core/matrix/dense.hpp>
+#include <ginkgo/core/matrix/device_views.hpp>
 #include <ginkgo/core/matrix/diagonal.hpp>
 
 #include "core/base/kernel_declaration.hpp"
@@ -19,42 +20,44 @@ namespace gko {
 namespace kernels {
 
 
-#define GKO_DECLARE_COO_SPMV_KERNEL(ValueType, IndexType)  \
-    void spmv(std::shared_ptr<const DefaultExecutor> exec, \
-              const matrix::Coo<ValueType, IndexType>* a,  \
-              matrix::view::dense<const ValueType> b,      \
+#define GKO_DECLARE_COO_SPMV_KERNEL(ValueType, IndexType)            \
+    void spmv(std::shared_ptr<const DefaultExecutor> exec,           \
+              matrix::view::coo<const ValueType, const IndexType> a, \
+              matrix::view::dense<const ValueType> b,                \
               matrix::view::dense<ValueType> c)
 
-#define GKO_DECLARE_COO_ADVANCED_SPMV_KERNEL(ValueType, IndexType)  \
-    void advanced_spmv(std::shared_ptr<const DefaultExecutor> exec, \
-                       matrix::view::dense<const ValueType> alpha,  \
-                       const matrix::Coo<ValueType, IndexType>* a,  \
-                       matrix::view::dense<const ValueType> b,      \
-                       matrix::view::dense<const ValueType> beta,   \
+#define GKO_DECLARE_COO_ADVANCED_SPMV_KERNEL(ValueType, IndexType)            \
+    void advanced_spmv(std::shared_ptr<const DefaultExecutor> exec,           \
+                       matrix::view::dense<const ValueType> alpha,            \
+                       matrix::view::coo<const ValueType, const IndexType> a, \
+                       matrix::view::dense<const ValueType> b,                \
+                       matrix::view::dense<const ValueType> beta,             \
                        matrix::view::dense<ValueType> c)
 
-#define GKO_DECLARE_COO_SPMV2_KERNEL(ValueType, IndexType)  \
-    void spmv2(std::shared_ptr<const DefaultExecutor> exec, \
-               const matrix::Coo<ValueType, IndexType>* a,  \
-               matrix::view::dense<const ValueType> b,      \
+#define GKO_DECLARE_COO_SPMV2_KERNEL(ValueType, IndexType)            \
+    void spmv2(std::shared_ptr<const DefaultExecutor> exec,           \
+               matrix::view::coo<const ValueType, const IndexType> a, \
+               matrix::view::dense<const ValueType> b,                \
                matrix::view::dense<ValueType> c)
 
-#define GKO_DECLARE_COO_ADVANCED_SPMV2_KERNEL(ValueType, IndexType)  \
-    void advanced_spmv2(std::shared_ptr<const DefaultExecutor> exec, \
-                        matrix::view::dense<const ValueType> alpha,  \
-                        const matrix::Coo<ValueType, IndexType>* a,  \
-                        matrix::view::dense<const ValueType> b,      \
+#define GKO_DECLARE_COO_ADVANCED_SPMV2_KERNEL(ValueType, IndexType)            \
+    void advanced_spmv2(std::shared_ptr<const DefaultExecutor> exec,           \
+                        matrix::view::dense<const ValueType> alpha,            \
+                        matrix::view::coo<const ValueType, const IndexType> a, \
+                        matrix::view::dense<const ValueType> b,                \
                         matrix::view::dense<ValueType> c)
 
-#define GKO_DECLARE_COO_FILL_IN_DENSE_KERNEL(ValueType, IndexType)      \
-    void fill_in_dense(std::shared_ptr<const DefaultExecutor> exec,     \
-                       const matrix::Coo<ValueType, IndexType>* source, \
-                       matrix::view::dense<ValueType> result)
+#define GKO_DECLARE_COO_FILL_IN_DENSE_KERNEL(ValueType, IndexType)  \
+    void fill_in_dense(                                             \
+        std::shared_ptr<const DefaultExecutor> exec,                \
+        matrix::view::coo<const ValueType, const IndexType> source, \
+        matrix::view::dense<ValueType> result)
 
-#define GKO_DECLARE_COO_EXTRACT_DIAGONAL_KERNEL(ValueType, IndexType)    \
-    void extract_diagonal(std::shared_ptr<const DefaultExecutor> exec,   \
-                          const matrix::Coo<ValueType, IndexType>* orig, \
-                          matrix::Diagonal<ValueType>* diag)
+#define GKO_DECLARE_COO_EXTRACT_DIAGONAL_KERNEL(ValueType, IndexType) \
+    void extract_diagonal(                                            \
+        std::shared_ptr<const DefaultExecutor> exec,                  \
+        matrix::view::coo<const ValueType, const IndexType> orig,     \
+        matrix::Diagonal<ValueType>* diag)
 
 #define GKO_DECLARE_COO_CONJ_ARRAY_KERNEL(ValueType)             \
     void conj_array(std::shared_ptr<const DefaultExecutor> exec, \

--- a/core/matrix/dense.cpp
+++ b/core/matrix/dense.cpp
@@ -706,7 +706,7 @@ void Dense<ValueType>::convert_impl(Coo<ValueType, IndexType>* result) const
     result->resize(this->get_size(), nnz);
     exec->run(dense::make_convert_to_coo(
         this->get_const_device_view(), row_ptrs.get_const_data(),
-        make_temporary_clone(exec, result).get()));
+        make_temporary_clone(exec, result)->get_device_view()));
 }
 
 

--- a/core/matrix/dense_kernels.hpp
+++ b/core/matrix/dense_kernels.hpp
@@ -149,7 +149,7 @@ namespace kernels {
     void convert_to_coo(std::shared_ptr<const DefaultExecutor> exec,  \
                         matrix::view::dense<const ValueType> source,  \
                         const int64* row_ptrs,                        \
-                        matrix::Coo<ValueType, IndexType>* other)
+                        matrix::view::coo<ValueType, IndexType> other)
 
 #define GKO_DECLARE_DENSE_CONVERT_TO_CSR_KERNEL(ValueType, IndexType) \
     void convert_to_csr(std::shared_ptr<const DefaultExecutor> exec,  \

--- a/core/matrix/hybrid.cpp
+++ b/core/matrix/hybrid.cpp
@@ -278,8 +278,9 @@ void Hybrid<ValueType, IndexType>::convert_to(Dense<ValueType>* result) const
     exec->run(
         hybrid::make_ell_fill_in_dense(this->get_ell()->get_const_device_view(),
                                        result_local->get_device_view()));
-    exec->run(hybrid::make_coo_fill_in_dense(this->get_coo(),
-                                             result_local->get_device_view()));
+    exec->run(
+        hybrid::make_coo_fill_in_dense(this->get_coo()->get_const_device_view(),
+                                       result_local->get_device_view()));
 }
 
 
@@ -431,7 +432,8 @@ Hybrid<ValueType, IndexType>::extract_diagonal() const
                                       zero<ValueType>()));
     exec->run(hybrid::make_ell_extract_diagonal(
         this->get_ell()->get_const_device_view(), diag.get()));
-    exec->run(hybrid::make_coo_extract_diagonal(this->get_coo(), diag.get()));
+    exec->run(hybrid::make_coo_extract_diagonal(
+        this->get_coo()->get_const_device_view(), diag.get()));
     return diag;
 }
 

--- a/core/multigrid/pgm.cpp
+++ b/core/multigrid/pgm.cpp
@@ -135,7 +135,7 @@ std::shared_ptr<matrix::Csr<ValueType, IndexType>> generate_coarse(
         coarse_nnz);
     exec->run(pgm::make_compute_coarse_coo(
         nnz, row_idxs.get_const_data(), col_idxs.get_const_data(),
-        vals.get_const_data(), coarse_coo.get()));
+        vals.get_const_data(), coarse_coo->get_device_view()));
     // use move_to
     auto coarse_csr = matrix::Csr<ValueType, IndexType>::create(exec);
     coarse_csr->move_from(coarse_coo);

--- a/core/multigrid/pgm_kernels.hpp
+++ b/core/multigrid/pgm_kernels.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -12,6 +12,7 @@
 #include <ginkgo/core/matrix/coo.hpp>
 #include <ginkgo/core/matrix/csr.hpp>
 #include <ginkgo/core/matrix/dense.hpp>
+#include <ginkgo/core/matrix/device_views.hpp>
 #include <ginkgo/core/matrix/diagonal.hpp>
 
 #include "core/base/kernel_declaration.hpp"
@@ -69,11 +70,12 @@ namespace pgm {
         const matrix::Diagonal<ValueType>* diag, array<IndexType>& agg, \
         array<IndexType>& intermediate_agg)
 
-#define GKO_DECLARE_PGM_COMPUTE_COARSE_COO(ValueType, IndexType)              \
-    void compute_coarse_coo(std::shared_ptr<const DefaultExecutor> exec,      \
-                            size_type fine_nnz, const IndexType* row_idxs,    \
-                            const IndexType* col_idxs, const ValueType* vals, \
-                            matrix::Coo<ValueType, IndexType>* coarse_coo)
+#define GKO_DECLARE_PGM_COMPUTE_COARSE_COO(ValueType, IndexType)         \
+    void compute_coarse_coo(                                             \
+        std::shared_ptr<const DefaultExecutor> exec, size_type fine_nnz, \
+        const IndexType* row_idxs, const IndexType* col_idxs,            \
+        const ValueType* vals,                                           \
+        matrix::view::coo<ValueType, IndexType> coarse_coo)
 
 #define GKO_DECLARE_PGM_GATHER_INDEX(IndexType)                    \
     void gather_index(std::shared_ptr<const DefaultExecutor> exec, \

--- a/core/test/matrix/device_views.cpp
+++ b/core/test/matrix/device_views.cpp
@@ -63,6 +63,43 @@ TYPED_TEST(DenseView, AssertTriggersOnOutOfBoundsDeathTest)
 
 
 template <typename ValueIndexType>
+class CooView : public ::testing::Test {
+protected:
+    using value_type =
+        typename std::tuple_element<0, decltype(ValueIndexType())>::type;
+    using index_type =
+        typename std::tuple_element<1, decltype(ValueIndexType())>::type;
+};
+
+TYPED_TEST_SUITE(CooView, gko::test::ValueIndexTypes,
+                 PairTypenameNameGenerator);
+
+
+TYPED_TEST(CooView, AccessWorks)
+{
+    using value_type = typename TestFixture::value_type;
+    using index_type = typename TestFixture::index_type;
+    std::vector<value_type> values{1, 2, 3};
+    std::vector<index_type> row_idxs{0, 1, 2};
+    std::vector<index_type> col_idxs{1, 0, 2};
+    gko::matrix::view::coo<value_type, index_type> view{
+        gko::dim<2>{3, 3}, 3, values.data(), row_idxs.data(), col_idxs.data()};
+    auto const_view = view.as_const();
+
+    ASSERT_EQ(view.size, gko::dim<2>(3, 3));
+    ASSERT_EQ(view.num_stored_elements, 3);
+    ASSERT_EQ(view.values, values.data());
+    ASSERT_EQ(view.row_idxs, row_idxs.data());
+    ASSERT_EQ(view.col_idxs, col_idxs.data());
+    ASSERT_EQ(const_view.size, view.size);
+    ASSERT_EQ(const_view.num_stored_elements, view.num_stored_elements);
+    ASSERT_EQ(const_view.values, view.values);
+    ASSERT_EQ(const_view.row_idxs, view.row_idxs);
+    ASSERT_EQ(const_view.col_idxs, view.col_idxs);
+}
+
+
+template <typename ValueIndexType>
 class EllView : public ::testing::Test {
 public:
     using value_type =

--- a/dpcpp/factorization/par_ic_kernels.dp.cpp
+++ b/dpcpp/factorization/par_ic_kernels.dp.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -7,7 +7,6 @@
 #include <sycl/sycl.hpp>
 
 #include <ginkgo/core/base/math.hpp>
-#include <ginkgo/core/matrix/coo.hpp>
 #include <ginkgo/core/matrix/csr.hpp>
 
 #include "dpcpp/base/dim3.dp.hpp"
@@ -139,16 +138,15 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 template <typename ValueType, typename IndexType>
 void compute_factor(std::shared_ptr<const DefaultExecutor> exec,
                     size_type iterations,
-                    const matrix::Coo<ValueType, IndexType>* a_lower,
+                    matrix::view::coo<const ValueType, const IndexType> a_lower,
                     matrix::Csr<ValueType, IndexType>* l)
 {
     auto nnz = l->get_num_stored_elements();
     auto num_blocks = ceildiv(nnz, default_block_size);
     for (size_type i = 0; i < iterations; ++i) {
         kernel::ic_sweep(num_blocks, default_block_size, 0, exec->get_queue(),
-                         a_lower->get_const_row_idxs(),
-                         a_lower->get_const_col_idxs(),
-                         as_device_type(a_lower->get_const_values()),
+                         a_lower.row_idxs, a_lower.col_idxs,
+                         as_device_type(a_lower.values),
                          l->get_const_row_ptrs(), l->get_const_col_idxs(),
                          as_device_type(l->get_values()),
                          static_cast<IndexType>(l->get_num_stored_elements()));

--- a/dpcpp/factorization/par_ict_kernels.dp.cpp
+++ b/dpcpp/factorization/par_ict_kernels.dp.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -446,7 +446,7 @@ void compute_factor(syn::value_list<int, subgroup_size>,
                     std::shared_ptr<const DefaultExecutor> exec,
                     const matrix::Csr<ValueType, IndexType>* a,
                     matrix::Csr<ValueType, IndexType>* l,
-                    const matrix::Coo<ValueType, IndexType>* l_coo)
+                    matrix::view::coo<const ValueType, const IndexType> l_coo)
 {
     auto total_nnz = static_cast<IndexType>(l->get_num_stored_elements());
     auto block_size = default_block_size / subgroup_size;
@@ -455,7 +455,7 @@ void compute_factor(syn::value_list<int, subgroup_size>,
         num_blocks, default_block_size, 0, exec->get_queue(),
         a->get_const_row_ptrs(), a->get_const_col_idxs(),
         as_device_type(a->get_const_values()), l->get_const_row_ptrs(),
-        l_coo->get_const_row_idxs(), l->get_const_col_idxs(),
+        l_coo.row_idxs, l->get_const_col_idxs(),
         as_device_type(l->get_values()),
         static_cast<IndexType>(l->get_num_stored_elements()));
 }
@@ -495,7 +495,7 @@ template <typename ValueType, typename IndexType>
 void compute_factor(std::shared_ptr<const DefaultExecutor> exec,
                     const matrix::Csr<ValueType, IndexType>* a,
                     matrix::Csr<ValueType, IndexType>* l,
-                    const matrix::Coo<ValueType, IndexType>* l_coo)
+                    matrix::view::coo<const ValueType, const IndexType> l_coo)
 {
     auto num_rows = a->get_size()[0];
     auto total_nnz = 2 * l->get_num_stored_elements();

--- a/dpcpp/factorization/par_ilu_kernels.dp.cpp
+++ b/dpcpp/factorization/par_ilu_kernels.dp.cpp
@@ -1,12 +1,10 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
 #include "core/factorization/par_ilu_kernels.hpp"
 
 #include <sycl/sycl.hpp>
-
-#include <ginkgo/core/matrix/coo.hpp>
 
 #include "dpcpp/base/dim3.dp.hpp"
 #include "dpcpp/base/math.hpp"
@@ -103,14 +101,14 @@ void compute_l_u_factors(dim3 grid, dim3 block, size_type dynamic_shared_memory,
 
 
 template <typename ValueType, typename IndexType>
-void compute_l_u_factors(std::shared_ptr<const DpcppExecutor> exec,
-                         size_type iterations,
-                         const matrix::Coo<ValueType, IndexType>* system_matrix,
-                         matrix::Csr<ValueType, IndexType>* l_factor,
-                         matrix::Csr<ValueType, IndexType>* u_factor)
+void compute_l_u_factors(
+    std::shared_ptr<const DpcppExecutor> exec, size_type iterations,
+    matrix::view::coo<const ValueType, const IndexType> system_matrix,
+    matrix::Csr<ValueType, IndexType>* l_factor,
+    matrix::Csr<ValueType, IndexType>* u_factor)
 {
     iterations = (iterations == 0) ? 10 : iterations;
-    const auto num_elements = system_matrix->get_num_stored_elements();
+    const auto num_elements = system_matrix.num_stored_elements;
     const dim3 block_size{default_block_size, 1, 1};
     const dim3 grid_dim{
         static_cast<uint32>(
@@ -119,9 +117,8 @@ void compute_l_u_factors(std::shared_ptr<const DpcppExecutor> exec,
     for (size_type i = 0; i < iterations; ++i) {
         kernel::compute_l_u_factors(
             grid_dim, block_size, 0, exec->get_queue(), num_elements,
-            system_matrix->get_const_row_idxs(),
-            system_matrix->get_const_col_idxs(),
-            as_device_type(system_matrix->get_const_values()),
+            system_matrix.row_idxs, system_matrix.col_idxs,
+            as_device_type(system_matrix.values),
             l_factor->get_const_row_ptrs(), l_factor->get_const_col_idxs(),
             as_device_type(l_factor->get_values()),
             u_factor->get_const_row_ptrs(), u_factor->get_const_col_idxs(),

--- a/dpcpp/factorization/par_ilut_approx_filter_kernel.dp.cpp
+++ b/dpcpp/factorization/par_ilut_approx_filter_kernel.dp.cpp
@@ -58,7 +58,7 @@ void threshold_filter_approx(syn::value_list<int, subgroup_size>,
                              IndexType rank, array<ValueType>* tmp,
                              remove_complex<ValueType>* threshold,
                              matrix::Csr<ValueType, IndexType>* m_out,
-                             matrix::view::coo<ValueType, IndexType> m_out_coo)
+                             matrix::Coo<ValueType, IndexType>* m_out_coo)
 {
     auto values = m->get_const_values();
     IndexType size = m->get_num_stored_elements();
@@ -125,7 +125,16 @@ void threshold_filter_approx(syn::value_list<int, subgroup_size>,
     builder.get_value_array().resize_and_reset(new_nnz);
     auto new_col_idxs = m_out->get_col_idxs();
     auto new_vals = m_out->get_values();
-    auto new_row_idxs = m_out_coo.row_idxs;
+    IndexType* new_row_idxs{};
+    if (m_out_coo) {
+        matrix::CooBuilder<ValueType, IndexType> coo_builder{m_out_coo};
+        coo_builder.get_row_idx_array().resize_and_reset(new_nnz);
+        coo_builder.get_col_idx_array() =
+            array<IndexType>::view(exec, new_nnz, new_col_idxs);
+        coo_builder.get_value_array() =
+            array<ValueType>::view(exec, new_nnz, new_vals);
+        new_row_idxs = m_out_coo->get_row_idxs();
+    }
     kernel::bucket_filter<subgroup_size>(
         num_blocks, default_block_size, 0, exec->get_queue(), old_row_ptrs,
         old_col_idxs, old_vals, oracles, num_rows, bucket, new_row_ptrs,
@@ -143,7 +152,7 @@ void threshold_filter_approx(std::shared_ptr<const DefaultExecutor> exec,
                              IndexType rank, array<ValueType>& tmp,
                              remove_complex<ValueType>& threshold,
                              matrix::Csr<ValueType, IndexType>* m_out,
-                             matrix::view::coo<ValueType, IndexType> m_out_coo)
+                             matrix::Coo<ValueType, IndexType>* m_out_coo)
 {
     auto num_rows = m->get_size()[0];
     auto total_nnz = m->get_num_stored_elements();

--- a/dpcpp/factorization/par_ilut_approx_filter_kernel.dp.cpp
+++ b/dpcpp/factorization/par_ilut_approx_filter_kernel.dp.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -58,7 +58,7 @@ void threshold_filter_approx(syn::value_list<int, subgroup_size>,
                              IndexType rank, array<ValueType>* tmp,
                              remove_complex<ValueType>* threshold,
                              matrix::Csr<ValueType, IndexType>* m_out,
-                             matrix::Coo<ValueType, IndexType>* m_out_coo)
+                             matrix::view::coo<ValueType, IndexType> m_out_coo)
 {
     auto values = m->get_const_values();
     IndexType size = m->get_num_stored_elements();
@@ -125,16 +125,7 @@ void threshold_filter_approx(syn::value_list<int, subgroup_size>,
     builder.get_value_array().resize_and_reset(new_nnz);
     auto new_col_idxs = m_out->get_col_idxs();
     auto new_vals = m_out->get_values();
-    IndexType* new_row_idxs{};
-    if (m_out_coo) {
-        matrix::CooBuilder<ValueType, IndexType> coo_builder{m_out_coo};
-        coo_builder.get_row_idx_array().resize_and_reset(new_nnz);
-        coo_builder.get_col_idx_array() =
-            array<IndexType>::view(exec, new_nnz, new_col_idxs);
-        coo_builder.get_value_array() =
-            array<ValueType>::view(exec, new_nnz, new_vals);
-        new_row_idxs = m_out_coo->get_row_idxs();
-    }
+    auto new_row_idxs = m_out_coo.row_idxs;
     kernel::bucket_filter<subgroup_size>(
         num_blocks, default_block_size, 0, exec->get_queue(), old_row_ptrs,
         old_col_idxs, old_vals, oracles, num_rows, bucket, new_row_ptrs,
@@ -152,7 +143,7 @@ void threshold_filter_approx(std::shared_ptr<const DefaultExecutor> exec,
                              IndexType rank, array<ValueType>& tmp,
                              remove_complex<ValueType>& threshold,
                              matrix::Csr<ValueType, IndexType>* m_out,
-                             matrix::Coo<ValueType, IndexType>* m_out_coo)
+                             matrix::view::coo<ValueType, IndexType> m_out_coo)
 {
     auto num_rows = m->get_size()[0];
     auto total_nnz = m->get_num_stored_elements();

--- a/dpcpp/factorization/par_ilut_filter_kernel.dp.cpp
+++ b/dpcpp/factorization/par_ilut_filter_kernel.dp.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -55,7 +55,8 @@ void threshold_filter(syn::value_list<int, subgroup_size>,
                       const matrix::Csr<ValueType, IndexType>* a,
                       remove_complex<ValueType> threshold,
                       matrix::Csr<ValueType, IndexType>* m_out,
-                      matrix::Coo<ValueType, IndexType>* m_out_coo, bool lower)
+                      matrix::view::coo<ValueType, IndexType> m_out_coo,
+                      bool lower)
 {
     auto old_row_ptrs = a->get_const_row_ptrs();
     auto old_col_idxs = a->get_const_col_idxs();
@@ -80,16 +81,7 @@ void threshold_filter(syn::value_list<int, subgroup_size>,
     builder.get_value_array().resize_and_reset(new_nnz);
     auto new_col_idxs = m_out->get_col_idxs();
     auto new_vals = m_out->get_values();
-    IndexType* new_row_idxs{};
-    if (m_out_coo) {
-        matrix::CooBuilder<ValueType, IndexType> coo_builder{m_out_coo};
-        coo_builder.get_row_idx_array().resize_and_reset(new_nnz);
-        coo_builder.get_col_idx_array() =
-            array<IndexType>::view(exec, new_nnz, new_col_idxs);
-        coo_builder.get_value_array() =
-            array<ValueType>::view(exec, new_nnz, new_vals);
-        new_row_idxs = m_out_coo->get_row_idxs();
-    }
+    auto new_row_idxs = m_out_coo.row_idxs;
     kernel::threshold_filter<subgroup_size>(
         num_blocks, default_block_size, 0, exec->get_queue(), old_row_ptrs,
         old_col_idxs, old_vals, num_rows, as_device_type(threshold),
@@ -108,7 +100,8 @@ void threshold_filter(std::shared_ptr<const DefaultExecutor> exec,
                       const matrix::Csr<ValueType, IndexType>* a,
                       remove_complex<ValueType> threshold,
                       matrix::Csr<ValueType, IndexType>* m_out,
-                      matrix::Coo<ValueType, IndexType>* m_out_coo, bool lower)
+                      matrix::view::coo<ValueType, IndexType> m_out_coo,
+                      bool lower)
 {
     auto num_rows = a->get_size()[0];
     auto total_nnz = a->get_num_stored_elements();

--- a/dpcpp/factorization/par_ilut_filter_kernel.dp.cpp
+++ b/dpcpp/factorization/par_ilut_filter_kernel.dp.cpp
@@ -55,8 +55,7 @@ void threshold_filter(syn::value_list<int, subgroup_size>,
                       const matrix::Csr<ValueType, IndexType>* a,
                       remove_complex<ValueType> threshold,
                       matrix::Csr<ValueType, IndexType>* m_out,
-                      matrix::view::coo<ValueType, IndexType> m_out_coo,
-                      bool lower)
+                      matrix::Coo<ValueType, IndexType>* m_out_coo, bool lower)
 {
     auto old_row_ptrs = a->get_const_row_ptrs();
     auto old_col_idxs = a->get_const_col_idxs();
@@ -81,7 +80,16 @@ void threshold_filter(syn::value_list<int, subgroup_size>,
     builder.get_value_array().resize_and_reset(new_nnz);
     auto new_col_idxs = m_out->get_col_idxs();
     auto new_vals = m_out->get_values();
-    auto new_row_idxs = m_out_coo.row_idxs;
+    IndexType* new_row_idxs{};
+    if (m_out_coo) {
+        matrix::CooBuilder<ValueType, IndexType> coo_builder{m_out_coo};
+        coo_builder.get_row_idx_array().resize_and_reset(new_nnz);
+        coo_builder.get_col_idx_array() =
+            array<IndexType>::view(exec, new_nnz, new_col_idxs);
+        coo_builder.get_value_array() =
+            array<ValueType>::view(exec, new_nnz, new_vals);
+        new_row_idxs = m_out_coo->get_row_idxs();
+    }
     kernel::threshold_filter<subgroup_size>(
         num_blocks, default_block_size, 0, exec->get_queue(), old_row_ptrs,
         old_col_idxs, old_vals, num_rows, as_device_type(threshold),
@@ -100,8 +108,7 @@ void threshold_filter(std::shared_ptr<const DefaultExecutor> exec,
                       const matrix::Csr<ValueType, IndexType>* a,
                       remove_complex<ValueType> threshold,
                       matrix::Csr<ValueType, IndexType>* m_out,
-                      matrix::view::coo<ValueType, IndexType> m_out_coo,
-                      bool lower)
+                      matrix::Coo<ValueType, IndexType>* m_out_coo, bool lower)
 {
     auto num_rows = a->get_size()[0];
     auto total_nnz = a->get_num_stored_elements();

--- a/dpcpp/factorization/par_ilut_kernels.dp.cpp
+++ b/dpcpp/factorization/par_ilut_kernels.dp.cpp
@@ -54,7 +54,7 @@ template <typename Predicate, typename ValueType, typename IndexType>
 void abstract_filter(std::shared_ptr<const DefaultExecutor> exec,
                      const matrix::Csr<ValueType, IndexType>* m,
                      matrix::Csr<ValueType, IndexType>* m_out,
-                     matrix::view::coo<ValueType, IndexType> m_out_coo,
+                     matrix::Coo<ValueType, IndexType>* m_out_coo,
                      Predicate pred) GKO_NOT_IMPLEMENTED;
 
 
@@ -63,7 +63,7 @@ void threshold_filter(std::shared_ptr<const DefaultExecutor> exec,
                       const matrix::Csr<ValueType, IndexType>* m,
                       remove_complex<ValueType> threshold,
                       matrix::Csr<ValueType, IndexType>* m_out,
-                      matrix::view::coo<ValueType, IndexType> m_out_coo,
+                      matrix::Coo<ValueType, IndexType>* m_out_coo,
                       bool) GKO_NOT_IMPLEMENTED;
 
 GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
@@ -80,7 +80,7 @@ void threshold_filter_approx(
     const matrix::Csr<ValueType, IndexType>* m, IndexType rank,
     array<ValueType>& tmp, remove_complex<ValueType>& threshold,
     matrix::Csr<ValueType, IndexType>* m_out,
-    matrix::view::coo<ValueType, IndexType> m_out_coo) GKO_NOT_IMPLEMENTED;
+    matrix::Coo<ValueType, IndexType>* m_out_coo) GKO_NOT_IMPLEMENTED;
 
 GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
     GKO_DECLARE_PAR_ILUT_THRESHOLD_FILTER_APPROX_KERNEL);

--- a/dpcpp/factorization/par_ilut_kernels.dp.cpp
+++ b/dpcpp/factorization/par_ilut_kernels.dp.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -54,7 +54,7 @@ template <typename Predicate, typename ValueType, typename IndexType>
 void abstract_filter(std::shared_ptr<const DefaultExecutor> exec,
                      const matrix::Csr<ValueType, IndexType>* m,
                      matrix::Csr<ValueType, IndexType>* m_out,
-                     matrix::Coo<ValueType, IndexType>* m_out_coo,
+                     matrix::view::coo<ValueType, IndexType> m_out_coo,
                      Predicate pred) GKO_NOT_IMPLEMENTED;
 
 
@@ -63,7 +63,7 @@ void threshold_filter(std::shared_ptr<const DefaultExecutor> exec,
                       const matrix::Csr<ValueType, IndexType>* m,
                       remove_complex<ValueType> threshold,
                       matrix::Csr<ValueType, IndexType>* m_out,
-                      matrix::Coo<ValueType, IndexType>* m_out_coo,
+                      matrix::view::coo<ValueType, IndexType> m_out_coo,
                       bool) GKO_NOT_IMPLEMENTED;
 
 GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
@@ -80,7 +80,7 @@ void threshold_filter_approx(
     const matrix::Csr<ValueType, IndexType>* m, IndexType rank,
     array<ValueType>& tmp, remove_complex<ValueType>& threshold,
     matrix::Csr<ValueType, IndexType>* m_out,
-    matrix::Coo<ValueType, IndexType>* m_out_coo) GKO_NOT_IMPLEMENTED;
+    matrix::view::coo<ValueType, IndexType> m_out_coo) GKO_NOT_IMPLEMENTED;
 
 GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
     GKO_DECLARE_PAR_ILUT_THRESHOLD_FILTER_APPROX_KERNEL);
@@ -90,9 +90,9 @@ template <typename ValueType, typename IndexType>
 void compute_l_u_factors(std::shared_ptr<const DefaultExecutor> exec,
                          const matrix::Csr<ValueType, IndexType>* a,
                          matrix::Csr<ValueType, IndexType>* l,
-                         const matrix::Coo<ValueType, IndexType>*,
+                         matrix::view::coo<const ValueType, const IndexType>,
                          matrix::Csr<ValueType, IndexType>* u,
-                         const matrix::Coo<ValueType, IndexType>*,
+                         matrix::view::coo<const ValueType, const IndexType>,
                          matrix::Csr<ValueType, IndexType>* u_csc)
     GKO_NOT_IMPLEMENTED;
 

--- a/dpcpp/factorization/par_ilut_sweep_kernel.dp.cpp
+++ b/dpcpp/factorization/par_ilut_sweep_kernel.dp.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -163,14 +163,15 @@ namespace {
 
 
 template <int subgroup_size, typename ValueType, typename IndexType>
-void compute_l_u_factors(syn::value_list<int, subgroup_size>,
-                         std::shared_ptr<const DefaultExecutor> exec,
-                         const matrix::Csr<ValueType, IndexType>* a,
-                         matrix::Csr<ValueType, IndexType>* l,
-                         const matrix::Coo<ValueType, IndexType>* l_coo,
-                         matrix::Csr<ValueType, IndexType>* u,
-                         const matrix::Coo<ValueType, IndexType>* u_coo,
-                         matrix::Csr<ValueType, IndexType>* u_csc)
+void compute_l_u_factors(
+    syn::value_list<int, subgroup_size>,
+    std::shared_ptr<const DefaultExecutor> exec,
+    const matrix::Csr<ValueType, IndexType>* a,
+    matrix::Csr<ValueType, IndexType>* l,
+    matrix::view::coo<const ValueType, const IndexType> l_coo,
+    matrix::Csr<ValueType, IndexType>* u,
+    matrix::view::coo<const ValueType, const IndexType> u_coo,
+    matrix::Csr<ValueType, IndexType>* u_csc)
 {
     auto total_nnz = static_cast<IndexType>(l->get_num_stored_elements() +
                                             u->get_num_stored_elements());
@@ -180,12 +181,12 @@ void compute_l_u_factors(syn::value_list<int, subgroup_size>,
         num_blocks, default_block_size, 0, exec->get_queue(),
         a->get_const_row_ptrs(), a->get_const_col_idxs(),
         as_device_type(a->get_const_values()), l->get_const_row_ptrs(),
-        l_coo->get_const_row_idxs(), l->get_const_col_idxs(),
+        l_coo.row_idxs, l->get_const_col_idxs(),
         as_device_type(l->get_values()),
-        static_cast<IndexType>(l->get_num_stored_elements()),
-        u_coo->get_const_row_idxs(), u_coo->get_const_col_idxs(),
-        as_device_type(u->get_values()), u_csc->get_const_row_ptrs(),
-        u_csc->get_const_col_idxs(), as_device_type(u_csc->get_values()),
+        static_cast<IndexType>(l->get_num_stored_elements()), u_coo.row_idxs,
+        u_coo.col_idxs, as_device_type(u->get_values()),
+        u_csc->get_const_row_ptrs(), u_csc->get_const_col_idxs(),
+        as_device_type(u_csc->get_values()),
         static_cast<IndexType>(u->get_num_stored_elements()));
 }
 
@@ -197,13 +198,14 @@ GKO_ENABLE_IMPLEMENTATION_SELECTION(select_compute_l_u_factors,
 
 
 template <typename ValueType, typename IndexType>
-void compute_l_u_factors(std::shared_ptr<const DefaultExecutor> exec,
-                         const matrix::Csr<ValueType, IndexType>* a,
-                         matrix::Csr<ValueType, IndexType>* l,
-                         const matrix::Coo<ValueType, IndexType>* l_coo,
-                         matrix::Csr<ValueType, IndexType>* u,
-                         const matrix::Coo<ValueType, IndexType>* u_coo,
-                         matrix::Csr<ValueType, IndexType>* u_csc)
+void compute_l_u_factors(
+    std::shared_ptr<const DefaultExecutor> exec,
+    const matrix::Csr<ValueType, IndexType>* a,
+    matrix::Csr<ValueType, IndexType>* l,
+    matrix::view::coo<const ValueType, const IndexType> l_coo,
+    matrix::Csr<ValueType, IndexType>* u,
+    matrix::view::coo<const ValueType, const IndexType> u_coo,
+    matrix::Csr<ValueType, IndexType>* u_csc)
 {
     auto num_rows = a->get_size()[0];
     auto total_nnz =

--- a/dpcpp/matrix/coo_kernels.dp.cpp
+++ b/dpcpp/matrix/coo_kernels.dp.cpp
@@ -254,7 +254,7 @@ GKO_ENABLE_DEFAULT_HOST(abstract_spmm, abstract_spmm);
 
 template <typename ValueType, typename IndexType>
 void spmv(std::shared_ptr<const DpcppExecutor> exec,
-          const matrix::Coo<ValueType, IndexType>* a,
+          matrix::view::coo<const ValueType, const IndexType> a,
           matrix::view::dense<const ValueType> b,
           matrix::view::dense<ValueType> c)
 {
@@ -268,7 +268,7 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(GKO_DECLARE_COO_SPMV_KERNEL);
 template <typename ValueType, typename IndexType>
 void advanced_spmv(std::shared_ptr<const DpcppExecutor> exec,
                    matrix::view::dense<const ValueType> alpha,
-                   const matrix::Coo<ValueType, IndexType>* a,
+                   matrix::view::coo<const ValueType, const IndexType> a,
                    matrix::view::dense<const ValueType> b,
                    matrix::view::dense<const ValueType> beta,
                    matrix::view::dense<ValueType> c)
@@ -283,11 +283,11 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 
 template <typename ValueType, typename IndexType>
 void spmv2(std::shared_ptr<const DpcppExecutor> exec,
-           const matrix::Coo<ValueType, IndexType>* a,
+           matrix::view::coo<const ValueType, const IndexType> a,
            matrix::view::dense<const ValueType> b,
            matrix::view::dense<ValueType> c)
 {
-    const auto nnz = a->get_num_stored_elements();
+    const auto nnz = a.num_stored_elements;
     const auto b_ncols = b.size[1];
     const dim3 coo_block(config::warp_size, warps_in_block, 1);
     const auto nwarps = host_kernel::calculate_nwarps(exec, nnz);
@@ -303,9 +303,8 @@ void spmv2(std::shared_ptr<const DpcppExecutor> exec,
             const dim3 coo_grid(ceildiv(nwarps, warps_in_block), b_ncols);
             int num_lines = ceildiv(nnz, nwarps * config::warp_size);
             abstract_spmv(coo_grid, coo_block, 0, exec->get_queue(), nnz,
-                          num_lines, as_device_type(a->get_const_values()),
-                          a->get_const_col_idxs(), a->get_const_row_idxs(),
-                          as_device_type(b.values), b.stride,
+                          num_lines, as_device_type(a.values), a.col_idxs,
+                          a.row_idxs, as_device_type(b.values), b.stride,
                           as_device_type(c.values), c.stride);
         } else {
             int num_elems =
@@ -313,10 +312,9 @@ void spmv2(std::shared_ptr<const DpcppExecutor> exec,
             const dim3 coo_grid(ceildiv(nwarps, warps_in_block),
                                 ceildiv(b_ncols, config::warp_size));
             abstract_spmm(coo_grid, coo_block, 0, exec->get_queue(), nnz,
-                          num_elems, as_device_type(a->get_const_values()),
-                          a->get_const_col_idxs(), a->get_const_row_idxs(),
-                          b_ncols, as_device_type(b.values), b.stride,
-                          as_device_type(c.values), c.stride);
+                          num_elems, as_device_type(a.values), a.col_idxs,
+                          a.row_idxs, b_ncols, as_device_type(b.values),
+                          b.stride, as_device_type(c.values), c.stride);
         }
     }
 }
@@ -327,11 +325,11 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(GKO_DECLARE_COO_SPMV2_KERNEL);
 template <typename ValueType, typename IndexType>
 void advanced_spmv2(std::shared_ptr<const DpcppExecutor> exec,
                     matrix::view::dense<const ValueType> alpha,
-                    const matrix::Coo<ValueType, IndexType>* a,
+                    matrix::view::coo<const ValueType, const IndexType> a,
                     matrix::view::dense<const ValueType> b,
                     matrix::view::dense<ValueType> c)
 {
-    const auto nnz = a->get_num_stored_elements();
+    const auto nnz = a.num_stored_elements;
     const auto nwarps = host_kernel::calculate_nwarps(exec, nnz);
     const dim3 coo_block(config::warp_size, warps_in_block, 1);
     const auto b_ncols = b.size[1];
@@ -348,8 +346,7 @@ void advanced_spmv2(std::shared_ptr<const DpcppExecutor> exec,
             const dim3 coo_grid(ceildiv(nwarps, warps_in_block), b_ncols);
             abstract_spmv(coo_grid, coo_block, 0, exec->get_queue(), nnz,
                           num_lines, as_device_type(alpha.values),
-                          as_device_type(a->get_const_values()),
-                          a->get_const_col_idxs(), a->get_const_row_idxs(),
+                          as_device_type(a.values), a.col_idxs, a.row_idxs,
                           as_device_type(b.values), b.stride,
                           as_device_type(c.values), c.stride);
         } else {
@@ -359,8 +356,7 @@ void advanced_spmv2(std::shared_ptr<const DpcppExecutor> exec,
                                 ceildiv(b_ncols, config::warp_size));
             abstract_spmm(coo_grid, coo_block, 0, exec->get_queue(), nnz,
                           num_elems, as_device_type(alpha.values),
-                          as_device_type(a->get_const_values()),
-                          a->get_const_col_idxs(), a->get_const_row_idxs(),
+                          as_device_type(a.values), a.col_idxs, a.row_idxs,
                           b_ncols, as_device_type(b.values), b.stride,
                           as_device_type(c.values), c.stride);
         }

--- a/dpcpp/matrix/dense_kernels.dp.cpp
+++ b/dpcpp/matrix/dense_kernels.dp.cpp
@@ -279,16 +279,16 @@ template <typename ValueType, typename IndexType>
 void convert_to_coo(std::shared_ptr<const DefaultExecutor> exec,
                     matrix::view::dense<const ValueType> source,
                     const int64* row_ptrs,
-                    matrix::Coo<ValueType, IndexType>* result)
+                    matrix::view::coo<ValueType, IndexType> result)
 {
-    const auto num_rows = result->get_size()[0];
-    const auto num_cols = result->get_size()[1];
+    const auto num_rows = result.size[0];
+    const auto num_cols = result.size[1];
     const auto in_vals = as_device_type(source.values);
     const auto stride = source.stride;
 
-    auto rows = result->get_row_idxs();
-    auto cols = result->get_col_idxs();
-    auto vals = as_device_type(result->get_values());
+    auto rows = result.row_idxs;
+    auto cols = result.col_idxs;
+    auto vals = as_device_type(result.values);
 
     exec->get_queue()->submit([&](sycl::handler& cgh) {
         cgh.parallel_for(num_rows, [=](sycl::item<1> item) {

--- a/dpcpp/multigrid/pgm_kernels.dp.cpp
+++ b/dpcpp/multigrid/pgm_kernels.dp.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -78,7 +78,7 @@ template <typename ValueType, typename IndexType>
 void compute_coarse_coo(std::shared_ptr<const DefaultExecutor> exec,
                         size_type fine_nnz, const IndexType* row_idxs,
                         const IndexType* col_idxs, const ValueType* vals,
-                        matrix::Coo<ValueType, IndexType>* coarse_coo)
+                        matrix::view::coo<ValueType, IndexType> coarse_coo)
 {
     // WORKAROUND: reduce_by_segment needs unique policy. Otherwise, dpcpp
     // throws same mangled name error. Related:
@@ -87,12 +87,12 @@ void compute_coarse_coo(std::shared_ptr<const DefaultExecutor> exec,
         coarse_coo_policy<ValueType, IndexType>>(*exec->get_queue());
     auto key_it = oneapi::dpl::make_zip_iterator(row_idxs, col_idxs);
 
-    auto coarse_key_it = oneapi::dpl::make_zip_iterator(
-        coarse_coo->get_row_idxs(), coarse_coo->get_col_idxs());
+    auto coarse_key_it = oneapi::dpl::make_zip_iterator(coarse_coo.row_idxs,
+                                                        coarse_coo.col_idxs);
 
     oneapi::dpl::reduce_by_segment(
         policy, key_it, key_it + fine_nnz, vals, coarse_key_it,
-        coarse_coo->get_values(),
+        coarse_coo.values,
         [](auto a, auto b) {
             return std::tie(std::get<0>(a), std::get<1>(a)) ==
                    std::tie(std::get<0>(b), std::get<1>(b));

--- a/include/ginkgo/core/matrix/coo.hpp
+++ b/include/ginkgo/core/matrix/coo.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -8,6 +8,7 @@
 
 #include <ginkgo/core/base/array.hpp>
 #include <ginkgo/core/base/lin_op.hpp>
+#include <ginkgo/core/matrix/device_views.hpp>
 
 
 namespace gko {
@@ -88,6 +89,9 @@ public:
     using mat_data = matrix_data<ValueType, IndexType>;
     using device_mat_data = device_matrix_data<ValueType, IndexType>;
     using absolute_type = remove_complex<Coo>;
+    using device_view = matrix::view::coo<value_type, index_type>;
+    using const_device_view =
+        matrix::view::coo<const value_type, const index_type>;
 
     friend class Coo<previous_precision<ValueType>, IndexType>;
 
@@ -212,6 +216,20 @@ public:
     {
         return values_.get_size();
     }
+
+    /**
+     * Returns a non-owning device view of this matrix.
+     *
+     * @return a device view of this matrix.
+     */
+    device_view get_device_view();
+
+    /**
+     * Returns a non-owning const device view of this matrix.
+     *
+     * @return a const device view of this matrix.
+     */
+    const_device_view get_const_device_view() const;
 
     /**
      * Applies Coo matrix axpy to a vector (or a sequence of vectors).

--- a/include/ginkgo/core/matrix/device_views.hpp
+++ b/include/ginkgo/core/matrix/device_views.hpp
@@ -52,6 +52,41 @@ struct dense {
 
 
 /**
+ * Non-owning view of a matrix::Coo to be used inside device kernels.
+ * This type is used to provide a simple and stable ABI for passing data between
+ * libraries.
+ *
+ * @tparam ValueType  the value type used to store matrix entries.
+ * @tparam IndexType  the index type used to store row and column indices.
+ */
+template <typename ValueType, typename IndexType>
+struct coo {
+    dim<2> size;
+    size_type num_stored_elements;
+    ValueType* values;
+    IndexType* row_idxs;
+    IndexType* col_idxs;
+
+    /** Constructs a coo view from size, nnz, values, row and column indices. */
+    constexpr coo(dim<2> size, size_type num_stored_elements, ValueType* values,
+                  IndexType* row_idxs, IndexType* col_idxs)
+        : size{size},
+          num_stored_elements{num_stored_elements},
+          values{values},
+          row_idxs{row_idxs},
+          col_idxs{col_idxs}
+    {}
+
+    /** Returns a const view of the same data */
+    constexpr coo<const ValueType, const IndexType> as_const() const
+    {
+        return coo<const ValueType, const IndexType>{
+            size, num_stored_elements, values, row_idxs, col_idxs};
+    }
+};
+
+
+/**
  * Non-owning view of a matrix::Ell to be used inside device kernels.
  * This type is used to provide a simple and stable ABI for passing data between
  * libraries.

--- a/omp/factorization/par_ic_kernels.cpp
+++ b/omp/factorization/par_ic_kernels.cpp
@@ -1,11 +1,10 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
 #include "core/factorization/par_ic_kernels.hpp"
 
 #include <ginkgo/core/base/math.hpp>
-#include <ginkgo/core/matrix/coo.hpp>
 #include <ginkgo/core/matrix/csr.hpp>
 
 #include "core/base/utils.hpp"
@@ -50,14 +49,14 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 template <typename ValueType, typename IndexType>
 void compute_factor(std::shared_ptr<const DefaultExecutor> exec,
                     size_type iterations,
-                    const matrix::Coo<ValueType, IndexType>* a_lower,
+                    matrix::view::coo<const ValueType, const IndexType> a_lower,
                     matrix::Csr<ValueType, IndexType>* l)
 {
-    auto num_rows = a_lower->get_size()[0];
+    auto num_rows = a_lower.size[0];
     auto l_row_ptrs = l->get_const_row_ptrs();
     auto l_col_idxs = l->get_const_col_idxs();
     auto l_vals = l->get_values();
-    auto a_vals = a_lower->get_const_values();
+    auto a_vals = a_lower.values;
 
     for (size_type i = 0; i < iterations; ++i) {
 #pragma omp parallel for

--- a/omp/factorization/par_ict_kernels.cpp
+++ b/omp/factorization/par_ict_kernels.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -36,7 +36,7 @@ template <typename ValueType, typename IndexType>
 void compute_factor(std::shared_ptr<const DefaultExecutor> exec,
                     const matrix::Csr<ValueType, IndexType>* a,
                     matrix::Csr<ValueType, IndexType>* l,
-                    const matrix::Coo<ValueType, IndexType>*)
+                    matrix::view::coo<const ValueType, const IndexType>)
 {
     auto num_rows = a->get_size()[0];
     auto l_row_ptrs = l->get_const_row_ptrs();

--- a/omp/factorization/par_ilu_kernels.cpp
+++ b/omp/factorization/par_ilu_kernels.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -7,7 +7,6 @@
 #include <memory>
 
 #include <ginkgo/core/base/math.hpp>
-#include <ginkgo/core/matrix/coo.hpp>
 #include <ginkgo/core/matrix/csr.hpp>
 
 #include "omp/components/atomic.hpp"
@@ -25,18 +24,18 @@ namespace par_ilu_factorization {
 
 
 template <typename ValueType, typename IndexType>
-void compute_l_u_factors(std::shared_ptr<const OmpExecutor> exec,
-                         size_type iterations,
-                         const matrix::Coo<ValueType, IndexType>* system_matrix,
-                         matrix::Csr<ValueType, IndexType>* l_factor,
-                         matrix::Csr<ValueType, IndexType>* u_factor)
+void compute_l_u_factors(
+    std::shared_ptr<const OmpExecutor> exec, size_type iterations,
+    matrix::view::coo<const ValueType, const IndexType> system_matrix,
+    matrix::Csr<ValueType, IndexType>* l_factor,
+    matrix::Csr<ValueType, IndexType>* u_factor)
 {
     // If `iterations` is set to `Auto`, we do 3 fix-point sweeps as
     // experiments indicate this works well for many problems.
     iterations = (iterations == 0) ? 3 : iterations;
-    const auto col_idxs = system_matrix->get_const_col_idxs();
-    const auto row_idxs = system_matrix->get_const_row_idxs();
-    const auto vals = system_matrix->get_const_values();
+    const auto col_idxs = system_matrix.col_idxs;
+    const auto row_idxs = system_matrix.row_idxs;
+    const auto vals = system_matrix.values;
     const auto row_ptrs_l = l_factor->get_const_row_ptrs();
     const auto row_ptrs_u = u_factor->get_const_row_ptrs();
     const auto col_idxs_l = l_factor->get_const_col_idxs();
@@ -46,8 +45,7 @@ void compute_l_u_factors(std::shared_ptr<const OmpExecutor> exec,
     for (size_type iter = 0; iter < iterations; ++iter) {
         // all elements in the incomplete factors are updated in parallel
 #pragma omp parallel for
-        for (size_type el = 0; el < system_matrix->get_num_stored_elements();
-             ++el) {
+        for (size_type el = 0; el < system_matrix.num_stored_elements; ++el) {
             const auto row = row_idxs[el];
             const auto col = col_idxs[el];
             const auto val = vals[el];

--- a/omp/factorization/par_ilut_kernels.cpp
+++ b/omp/factorization/par_ilut_kernels.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -69,7 +69,7 @@ template <typename Predicate, typename ValueType, typename IndexType>
 void abstract_filter(std::shared_ptr<const DefaultExecutor> exec,
                      const matrix::Csr<ValueType, IndexType>* m,
                      matrix::Csr<ValueType, IndexType>* m_out,
-                     matrix::Coo<ValueType, IndexType>* m_out_coo,
+                     matrix::view::coo<ValueType, IndexType> m_out_coo,
                      Predicate pred)
 {
     auto num_rows = m->get_size()[0];
@@ -100,16 +100,7 @@ void abstract_filter(std::shared_ptr<const DefaultExecutor> exec,
     builder.get_value_array().resize_and_reset(new_nnz);
     auto new_col_idxs = m_out->get_col_idxs();
     auto new_vals = m_out->get_values();
-    IndexType* new_row_idxs{};
-    if (m_out_coo) {
-        matrix::CooBuilder<ValueType, IndexType> coo_builder{m_out_coo};
-        coo_builder.get_row_idx_array().resize_and_reset(new_nnz);
-        coo_builder.get_col_idx_array() =
-            make_array_view(exec, new_nnz, new_col_idxs);
-        coo_builder.get_value_array() =
-            make_array_view(exec, new_nnz, new_vals);
-        new_row_idxs = m_out_coo->get_row_idxs();
-    }
+    auto new_row_idxs = m_out_coo.row_idxs;
 
 #pragma omp parallel for
     for (size_type row = 0; row < num_rows; ++row) {
@@ -135,7 +126,7 @@ void threshold_filter(std::shared_ptr<const DefaultExecutor> exec,
                       const matrix::Csr<ValueType, IndexType>* m,
                       remove_complex<ValueType> threshold,
                       matrix::Csr<ValueType, IndexType>* m_out,
-                      matrix::Coo<ValueType, IndexType>* m_out_coo, bool)
+                      matrix::view::coo<ValueType, IndexType> m_out_coo, bool)
 {
     auto col_idxs = m->get_const_col_idxs();
     auto vals = m->get_const_values();
@@ -159,7 +150,7 @@ void threshold_filter_approx(std::shared_ptr<const DefaultExecutor> exec,
                              IndexType rank, array<ValueType>& tmp,
                              remove_complex<ValueType>& threshold,
                              matrix::Csr<ValueType, IndexType>* m_out,
-                             matrix::Coo<ValueType, IndexType>* m_out_coo)
+                             matrix::view::coo<ValueType, IndexType> m_out_coo)
 {
     auto vals = m->get_const_values();
     auto col_idxs = m->get_const_col_idxs();
@@ -242,9 +233,9 @@ template <typename ValueType, typename IndexType>
 void compute_l_u_factors(std::shared_ptr<const DefaultExecutor> exec,
                          const matrix::Csr<ValueType, IndexType>* a,
                          matrix::Csr<ValueType, IndexType>* l,
-                         const matrix::Coo<ValueType, IndexType>*,
+                         matrix::view::coo<const ValueType, const IndexType>,
                          matrix::Csr<ValueType, IndexType>* u,
-                         const matrix::Coo<ValueType, IndexType>*,
+                         matrix::view::coo<const ValueType, const IndexType>,
                          matrix::Csr<ValueType, IndexType>* u_csc)
 {
     auto num_rows = a->get_size()[0];

--- a/omp/factorization/par_ilut_kernels.cpp
+++ b/omp/factorization/par_ilut_kernels.cpp
@@ -69,7 +69,7 @@ template <typename Predicate, typename ValueType, typename IndexType>
 void abstract_filter(std::shared_ptr<const DefaultExecutor> exec,
                      const matrix::Csr<ValueType, IndexType>* m,
                      matrix::Csr<ValueType, IndexType>* m_out,
-                     matrix::view::coo<ValueType, IndexType> m_out_coo,
+                     matrix::Coo<ValueType, IndexType>* m_out_coo,
                      Predicate pred)
 {
     auto num_rows = m->get_size()[0];
@@ -100,7 +100,16 @@ void abstract_filter(std::shared_ptr<const DefaultExecutor> exec,
     builder.get_value_array().resize_and_reset(new_nnz);
     auto new_col_idxs = m_out->get_col_idxs();
     auto new_vals = m_out->get_values();
-    auto new_row_idxs = m_out_coo.row_idxs;
+    IndexType* new_row_idxs{};
+    if (m_out_coo) {
+        matrix::CooBuilder<ValueType, IndexType> coo_builder{m_out_coo};
+        coo_builder.get_row_idx_array().resize_and_reset(new_nnz);
+        coo_builder.get_col_idx_array() =
+            make_array_view(exec, new_nnz, new_col_idxs);
+        coo_builder.get_value_array() =
+            make_array_view(exec, new_nnz, new_vals);
+        new_row_idxs = m_out_coo->get_row_idxs();
+    }
 
 #pragma omp parallel for
     for (size_type row = 0; row < num_rows; ++row) {
@@ -126,7 +135,7 @@ void threshold_filter(std::shared_ptr<const DefaultExecutor> exec,
                       const matrix::Csr<ValueType, IndexType>* m,
                       remove_complex<ValueType> threshold,
                       matrix::Csr<ValueType, IndexType>* m_out,
-                      matrix::view::coo<ValueType, IndexType> m_out_coo, bool)
+                      matrix::Coo<ValueType, IndexType>* m_out_coo, bool)
 {
     auto col_idxs = m->get_const_col_idxs();
     auto vals = m->get_const_values();
@@ -150,7 +159,7 @@ void threshold_filter_approx(std::shared_ptr<const DefaultExecutor> exec,
                              IndexType rank, array<ValueType>& tmp,
                              remove_complex<ValueType>& threshold,
                              matrix::Csr<ValueType, IndexType>* m_out,
-                             matrix::view::coo<ValueType, IndexType> m_out_coo)
+                             matrix::Coo<ValueType, IndexType>* m_out_coo)
 {
     auto vals = m->get_const_values();
     auto col_idxs = m->get_const_col_idxs();

--- a/omp/matrix/coo_kernels.cpp
+++ b/omp/matrix/coo_kernels.cpp
@@ -35,7 +35,7 @@ namespace coo {
 
 template <typename ValueType, typename IndexType>
 void spmv(std::shared_ptr<const OmpExecutor> exec,
-          const matrix::Coo<ValueType, IndexType>* a,
+          matrix::view::coo<const ValueType, const IndexType> a,
           matrix::view::dense<const ValueType> b,
           matrix::view::dense<ValueType> c)
 {
@@ -49,7 +49,7 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(GKO_DECLARE_COO_SPMV_KERNEL);
 template <typename ValueType, typename IndexType>
 void advanced_spmv(std::shared_ptr<const OmpExecutor> exec,
                    matrix::view::dense<const ValueType> alpha,
-                   const matrix::Coo<ValueType, IndexType>* a,
+                   matrix::view::coo<const ValueType, const IndexType> a,
                    matrix::view::dense<const ValueType> b,
                    matrix::view::dense<const ValueType> beta,
                    matrix::view::dense<ValueType> c)
@@ -64,18 +64,18 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 
 template <int block_size, typename ValueType, typename IndexType>
 void spmv2_blocked(std::shared_ptr<const OmpExecutor> exec,
-                   const matrix::Coo<ValueType, IndexType>* a,
+                   matrix::view::coo<const ValueType, const IndexType> a,
                    matrix::view::dense<const ValueType> b,
                    matrix::view::dense<ValueType> c, ValueType scale)
 {
     GKO_ASSERT(b.size[1] > block_size);
-    const auto coo_val = a->get_const_values();
-    const auto coo_col = a->get_const_col_idxs();
-    const auto coo_row = a->get_const_row_idxs();
+    const auto coo_val = a.values;
+    const auto coo_col = a.col_idxs;
+    const auto coo_row = a.row_idxs;
     const auto num_rhs = b.size[1];
     const auto rounded_rhs = num_rhs / block_size * block_size;
-    const auto sentinel_row = a->get_size()[0] + 1;
-    const auto nnz = a->get_num_stored_elements();
+    const auto sentinel_row = a.size[0] + 1;
+    const auto nnz = a.num_stored_elements;
 
 #pragma omp parallel
     {
@@ -194,16 +194,16 @@ void spmv2_blocked(std::shared_ptr<const OmpExecutor> exec,
 
 template <int num_rhs, typename ValueType, typename IndexType>
 void spmv2_small_rhs(std::shared_ptr<const OmpExecutor> exec,
-                     const matrix::Coo<ValueType, IndexType>* a,
+                     matrix::view::coo<const ValueType, const IndexType> a,
                      matrix::view::dense<const ValueType> b,
                      matrix::view::dense<ValueType> c, ValueType scale)
 {
     GKO_ASSERT(b.size[1] == num_rhs);
-    const auto coo_val = a->get_const_values();
-    const auto coo_col = a->get_const_col_idxs();
-    const auto coo_row = a->get_const_row_idxs();
-    const auto sentinel_row = a->get_size()[0] + 1;
-    const auto nnz = a->get_num_stored_elements();
+    const auto coo_val = a.values;
+    const auto coo_col = a.col_idxs;
+    const auto coo_row = a.row_idxs;
+    const auto sentinel_row = a.size[0] + 1;
+    const auto nnz = a.num_stored_elements;
 
 #pragma omp parallel
     {
@@ -267,7 +267,7 @@ void spmv2_small_rhs(std::shared_ptr<const OmpExecutor> exec,
 
 template <typename ValueType, typename IndexType>
 void generic_spmv2(std::shared_ptr<const OmpExecutor> exec,
-                   const matrix::Coo<ValueType, IndexType>* a,
+                   matrix::view::coo<const ValueType, const IndexType> a,
                    matrix::view::dense<const ValueType> b,
                    matrix::view::dense<ValueType> c, ValueType scale)
 {
@@ -297,7 +297,7 @@ void generic_spmv2(std::shared_ptr<const OmpExecutor> exec,
 
 template <typename ValueType, typename IndexType>
 void spmv2(std::shared_ptr<const OmpExecutor> exec,
-           const matrix::Coo<ValueType, IndexType>* a,
+           matrix::view::coo<const ValueType, const IndexType> a,
            matrix::view::dense<const ValueType> b,
            matrix::view::dense<ValueType> c)
 {
@@ -310,7 +310,7 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(GKO_DECLARE_COO_SPMV2_KERNEL);
 template <typename ValueType, typename IndexType>
 void advanced_spmv2(std::shared_ptr<const OmpExecutor> exec,
                     matrix::view::dense<const ValueType> alpha,
-                    const matrix::Coo<ValueType, IndexType>* a,
+                    matrix::view::coo<const ValueType, const IndexType> a,
                     matrix::view::dense<const ValueType> b,
                     matrix::view::dense<ValueType> c)
 {

--- a/omp/matrix/dense_kernels.cpp
+++ b/omp/matrix/dense_kernels.cpp
@@ -145,15 +145,15 @@ template <typename ValueType, typename IndexType>
 void convert_to_coo(std::shared_ptr<const DefaultExecutor> exec,
                     matrix::view::dense<const ValueType> source,
                     const int64* row_ptrs,
-                    matrix::Coo<ValueType, IndexType>* result)
+                    matrix::view::coo<ValueType, IndexType> result)
 {
-    auto num_rows = result->get_size()[0];
-    auto num_cols = result->get_size()[1];
-    auto num_nonzeros = result->get_num_stored_elements();
+    auto num_rows = result.size[0];
+    auto num_cols = result.size[1];
+    auto num_nonzeros = result.num_stored_elements;
 
-    auto row_idxs = result->get_row_idxs();
-    auto col_idxs = result->get_col_idxs();
-    auto values = result->get_values();
+    auto row_idxs = result.row_idxs;
+    auto col_idxs = result.col_idxs;
+    auto values = result.values;
 
 #pragma omp parallel for
     for (size_type row = 0; row < num_rows; ++row) {

--- a/omp/multigrid/pgm_kernels.cpp
+++ b/omp/multigrid/pgm_kernels.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -66,11 +66,11 @@ template <typename ValueType, typename IndexType>
 void compute_coarse_coo(std::shared_ptr<const DefaultExecutor> exec,
                         size_type fine_nnz, const IndexType* row_idxs,
                         const IndexType* col_idxs, const ValueType* vals,
-                        matrix::Coo<ValueType, IndexType>* coarse_coo)
+                        matrix::view::coo<ValueType, IndexType> coarse_coo)
 {
-    auto coarse_row = coarse_coo->get_row_idxs();
-    auto coarse_col = coarse_coo->get_col_idxs();
-    auto coarse_val = coarse_coo->get_values();
+    auto coarse_row = coarse_coo.row_idxs;
+    auto coarse_col = coarse_coo.col_idxs;
+    auto coarse_val = coarse_coo.values;
     size_type idxs = 0;
     size_type coarse_idxs = 0;
     IndexType curr_row = row_idxs[0];
@@ -89,7 +89,7 @@ void compute_coarse_coo(std::shared_ptr<const DefaultExecutor> exec,
         }
         temp_val += vals[idxs];
     }
-    GKO_ASSERT(coarse_idxs + 1 == coarse_coo->get_num_stored_elements());
+    GKO_ASSERT(coarse_idxs + 1 == coarse_coo.num_stored_elements);
     coarse_row[coarse_idxs] = curr_row;
     coarse_col[coarse_idxs] = curr_col;
     coarse_val[coarse_idxs] = temp_val;

--- a/reference/factorization/par_ic_kernels.cpp
+++ b/reference/factorization/par_ic_kernels.cpp
@@ -1,11 +1,10 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
 #include "core/factorization/par_ic_kernels.hpp"
 
 #include <ginkgo/core/base/math.hpp>
-#include <ginkgo/core/matrix/coo.hpp>
 #include <ginkgo/core/matrix/csr.hpp>
 
 #include "core/base/utils.hpp"
@@ -53,14 +52,14 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 template <typename ValueType, typename IndexType>
 void compute_factor(std::shared_ptr<const DefaultExecutor> exec,
                     size_type /* num_iterations */,
-                    const matrix::Coo<ValueType, IndexType>* a_lower,
+                    matrix::view::coo<const ValueType, const IndexType> a_lower,
                     matrix::Csr<ValueType, IndexType>* l)
 {
-    auto num_rows = a_lower->get_size()[0];
+    auto num_rows = a_lower.size[0];
     auto l_row_ptrs = l->get_const_row_ptrs();
     auto l_col_idxs = l->get_const_col_idxs();
     auto l_vals = l->get_values();
-    auto a_vals = a_lower->get_const_values();
+    auto a_vals = a_lower.values;
 
     for (size_type row = 0; row < num_rows; ++row) {
         for (size_type l_nz = l_row_ptrs[row]; l_nz < l_row_ptrs[row + 1];

--- a/reference/factorization/par_ict_kernels.cpp
+++ b/reference/factorization/par_ict_kernels.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -35,7 +35,7 @@ template <typename ValueType, typename IndexType>
 void compute_factor(std::shared_ptr<const DefaultExecutor> exec,
                     const matrix::Csr<ValueType, IndexType>* a,
                     matrix::Csr<ValueType, IndexType>* l,
-                    const matrix::Coo<ValueType, IndexType>*)
+                    matrix::view::coo<const ValueType, const IndexType>)
 {
     auto num_rows = a->get_size()[0];
     auto l_row_ptrs = l->get_const_row_ptrs();

--- a/reference/factorization/par_ilu_kernels.cpp
+++ b/reference/factorization/par_ilu_kernels.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -7,7 +7,6 @@
 #include <memory>
 
 #include <ginkgo/core/base/math.hpp>
-#include <ginkgo/core/matrix/coo.hpp>
 #include <ginkgo/core/matrix/csr.hpp>
 
 
@@ -23,18 +22,18 @@ namespace par_ilu_factorization {
 
 
 template <typename ValueType, typename IndexType>
-void compute_l_u_factors(std::shared_ptr<const ReferenceExecutor> exec,
-                         size_type iterations,
-                         const matrix::Coo<ValueType, IndexType>* system_matrix,
-                         matrix::Csr<ValueType, IndexType>* l_factor,
-                         matrix::Csr<ValueType, IndexType>* u_factor)
+void compute_l_u_factors(
+    std::shared_ptr<const ReferenceExecutor> exec, size_type iterations,
+    matrix::view::coo<const ValueType, const IndexType> system_matrix,
+    matrix::Csr<ValueType, IndexType>* l_factor,
+    matrix::Csr<ValueType, IndexType>* u_factor)
 {
     // If `iterations` is set to `Auto`, a single iteration is sufficient since
     // it is computed sequentially
     iterations = (iterations == 0) ? 1 : iterations;
-    const auto col_idxs = system_matrix->get_const_col_idxs();
-    const auto row_idxs = system_matrix->get_const_row_idxs();
-    const auto vals = system_matrix->get_const_values();
+    const auto col_idxs = system_matrix.col_idxs;
+    const auto row_idxs = system_matrix.row_idxs;
+    const auto vals = system_matrix.values;
     const auto row_ptrs_l = l_factor->get_const_row_ptrs();
     const auto row_ptrs_u = u_factor->get_const_row_ptrs();
     const auto col_idxs_l = l_factor->get_const_col_idxs();
@@ -42,8 +41,7 @@ void compute_l_u_factors(std::shared_ptr<const ReferenceExecutor> exec,
     auto vals_l = l_factor->get_values();
     auto vals_u = u_factor->get_values();
     for (size_type iter = 0; iter < iterations; ++iter) {
-        for (size_type el = 0; el < system_matrix->get_num_stored_elements();
-             ++el) {
+        for (size_type el = 0; el < system_matrix.num_stored_elements; ++el) {
             const auto row = row_idxs[el];
             const auto col = col_idxs[el];
             const auto val = vals[el];

--- a/reference/factorization/par_ilut_kernels.cpp
+++ b/reference/factorization/par_ilut_kernels.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -72,7 +72,7 @@ template <typename Predicate, typename ValueType, typename IndexType>
 void abstract_filter(std::shared_ptr<const DefaultExecutor> exec,
                      const matrix::Csr<ValueType, IndexType>* m,
                      matrix::Csr<ValueType, IndexType>* m_out,
-                     matrix::Coo<ValueType, IndexType>* m_out_coo,
+                     matrix::view::coo<ValueType, IndexType> m_out_coo,
                      Predicate pred)
 {
     auto num_rows = m->get_size()[0];
@@ -101,16 +101,7 @@ void abstract_filter(std::shared_ptr<const DefaultExecutor> exec,
     builder.get_value_array().resize_and_reset(new_nnz);
     auto new_col_idxs = m_out->get_col_idxs();
     auto new_vals = m_out->get_values();
-    IndexType* new_row_idxs{};
-    if (m_out_coo) {
-        matrix::CooBuilder<ValueType, IndexType> coo_builder{m_out_coo};
-        coo_builder.get_row_idx_array().resize_and_reset(new_nnz);
-        coo_builder.get_col_idx_array() =
-            make_array_view(exec, new_nnz, new_col_idxs);
-        coo_builder.get_value_array() =
-            make_array_view(exec, new_nnz, new_vals);
-        new_row_idxs = m_out_coo->get_row_idxs();
-    }
+    auto new_row_idxs = m_out_coo.row_idxs;
 
     for (size_type row = 0; row < num_rows; ++row) {
         auto new_nz = new_row_ptrs[row];
@@ -140,7 +131,7 @@ void threshold_filter(std::shared_ptr<const DefaultExecutor> exec,
                       const matrix::Csr<ValueType, IndexType>* m,
                       remove_complex<ValueType> threshold,
                       matrix::Csr<ValueType, IndexType>* m_out,
-                      matrix::Coo<ValueType, IndexType>* m_out_coo, bool)
+                      matrix::view::coo<ValueType, IndexType> m_out_coo, bool)
 {
     auto col_idxs = m->get_const_col_idxs();
     auto vals = m->get_const_values();
@@ -170,7 +161,7 @@ void threshold_filter_approx(std::shared_ptr<const DefaultExecutor> exec,
                              IndexType rank, array<ValueType>& tmp,
                              remove_complex<ValueType>& threshold,
                              matrix::Csr<ValueType, IndexType>* m_out,
-                             matrix::Coo<ValueType, IndexType>* m_out_coo)
+                             matrix::view::coo<ValueType, IndexType> m_out_coo)
 {
     auto vals = m->get_const_values();
     auto col_idxs = m->get_const_col_idxs();
@@ -239,9 +230,9 @@ template <typename ValueType, typename IndexType>
 void compute_l_u_factors(std::shared_ptr<const DefaultExecutor> exec,
                          const matrix::Csr<ValueType, IndexType>* a,
                          matrix::Csr<ValueType, IndexType>* l,
-                         const matrix::Coo<ValueType, IndexType>*,
+                         matrix::view::coo<const ValueType, const IndexType>,
                          matrix::Csr<ValueType, IndexType>* u,
-                         const matrix::Coo<ValueType, IndexType>*,
+                         matrix::view::coo<const ValueType, const IndexType>,
                          matrix::Csr<ValueType, IndexType>* u_csc)
 {
     auto num_rows = a->get_size()[0];

--- a/reference/factorization/par_ilut_kernels.cpp
+++ b/reference/factorization/par_ilut_kernels.cpp
@@ -72,7 +72,7 @@ template <typename Predicate, typename ValueType, typename IndexType>
 void abstract_filter(std::shared_ptr<const DefaultExecutor> exec,
                      const matrix::Csr<ValueType, IndexType>* m,
                      matrix::Csr<ValueType, IndexType>* m_out,
-                     matrix::view::coo<ValueType, IndexType> m_out_coo,
+                     matrix::Coo<ValueType, IndexType>* m_out_coo,
                      Predicate pred)
 {
     auto num_rows = m->get_size()[0];
@@ -101,7 +101,16 @@ void abstract_filter(std::shared_ptr<const DefaultExecutor> exec,
     builder.get_value_array().resize_and_reset(new_nnz);
     auto new_col_idxs = m_out->get_col_idxs();
     auto new_vals = m_out->get_values();
-    auto new_row_idxs = m_out_coo.row_idxs;
+    IndexType* new_row_idxs{};
+    if (m_out_coo) {
+        matrix::CooBuilder<ValueType, IndexType> coo_builder{m_out_coo};
+        coo_builder.get_row_idx_array().resize_and_reset(new_nnz);
+        coo_builder.get_col_idx_array() =
+            make_array_view(exec, new_nnz, new_col_idxs);
+        coo_builder.get_value_array() =
+            make_array_view(exec, new_nnz, new_vals);
+        new_row_idxs = m_out_coo->get_row_idxs();
+    }
 
     for (size_type row = 0; row < num_rows; ++row) {
         auto new_nz = new_row_ptrs[row];
@@ -131,7 +140,7 @@ void threshold_filter(std::shared_ptr<const DefaultExecutor> exec,
                       const matrix::Csr<ValueType, IndexType>* m,
                       remove_complex<ValueType> threshold,
                       matrix::Csr<ValueType, IndexType>* m_out,
-                      matrix::view::coo<ValueType, IndexType> m_out_coo, bool)
+                      matrix::Coo<ValueType, IndexType>* m_out_coo, bool)
 {
     auto col_idxs = m->get_const_col_idxs();
     auto vals = m->get_const_values();
@@ -161,7 +170,7 @@ void threshold_filter_approx(std::shared_ptr<const DefaultExecutor> exec,
                              IndexType rank, array<ValueType>& tmp,
                              remove_complex<ValueType>& threshold,
                              matrix::Csr<ValueType, IndexType>* m_out,
-                             matrix::view::coo<ValueType, IndexType> m_out_coo)
+                             matrix::Coo<ValueType, IndexType>* m_out_coo)
 {
     auto vals = m->get_const_values();
     auto col_idxs = m->get_const_col_idxs();

--- a/reference/matrix/coo_kernels.cpp
+++ b/reference/matrix/coo_kernels.cpp
@@ -31,7 +31,7 @@ namespace coo {
 
 template <typename ValueType, typename IndexType>
 void spmv(std::shared_ptr<const ReferenceExecutor> exec,
-          const matrix::Coo<ValueType, IndexType>* a,
+          matrix::view::coo<const ValueType, const IndexType> a,
           matrix::view::dense<const ValueType> b,
           matrix::view::dense<ValueType> c)
 {
@@ -45,7 +45,7 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(GKO_DECLARE_COO_SPMV_KERNEL);
 template <typename ValueType, typename IndexType>
 void advanced_spmv(std::shared_ptr<const ReferenceExecutor> exec,
                    matrix::view::dense<const ValueType> alpha,
-                   const matrix::Coo<ValueType, IndexType>* a,
+                   matrix::view::coo<const ValueType, const IndexType> a,
                    matrix::view::dense<const ValueType> b,
                    matrix::view::dense<const ValueType> beta,
                    matrix::view::dense<ValueType> c)
@@ -60,15 +60,15 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 
 template <typename ValueType, typename IndexType>
 void spmv2(std::shared_ptr<const ReferenceExecutor> exec,
-           const matrix::Coo<ValueType, IndexType>* a,
+           matrix::view::coo<const ValueType, const IndexType> a,
            matrix::view::dense<const ValueType> b,
            matrix::view::dense<ValueType> c)
 {
-    auto coo_val = a->get_const_values();
-    auto coo_col = a->get_const_col_idxs();
-    auto coo_row = a->get_const_row_idxs();
+    auto coo_val = a.values;
+    auto coo_col = a.col_idxs;
+    auto coo_row = a.row_idxs;
     auto num_cols = b.size[1];
-    for (size_type i = 0; i < a->get_num_stored_elements(); i++) {
+    for (size_type i = 0; i < a.num_stored_elements; i++) {
         for (size_type j = 0; j < num_cols; j++) {
             c(coo_row[i], j) += coo_val[i] * b(coo_col[i], j);
         }
@@ -81,16 +81,16 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(GKO_DECLARE_COO_SPMV2_KERNEL);
 template <typename ValueType, typename IndexType>
 void advanced_spmv2(std::shared_ptr<const ReferenceExecutor> exec,
                     matrix::view::dense<const ValueType> alpha,
-                    const matrix::Coo<ValueType, IndexType>* a,
+                    matrix::view::coo<const ValueType, const IndexType> a,
                     matrix::view::dense<const ValueType> b,
                     matrix::view::dense<ValueType> c)
 {
-    auto coo_val = a->get_const_values();
-    auto coo_col = a->get_const_col_idxs();
-    auto coo_row = a->get_const_row_idxs();
+    auto coo_val = a.values;
+    auto coo_col = a.col_idxs;
+    auto coo_row = a.row_idxs;
     auto alpha_val = alpha(0, 0);
     auto num_cols = b.size[1];
-    for (size_type i = 0; i < a->get_num_stored_elements(); i++) {
+    for (size_type i = 0; i < a.num_stored_elements; i++) {
         for (size_type j = 0; j < num_cols; j++) {
             c(coo_row[i], j) += alpha_val * coo_val[i] * b(coo_col[i], j);
         }
@@ -103,13 +103,13 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 
 template <typename ValueType, typename IndexType>
 void fill_in_dense(std::shared_ptr<const ReferenceExecutor> exec,
-                   const matrix::Coo<ValueType, IndexType>* source,
+                   matrix::view::coo<const ValueType, const IndexType> source,
                    matrix::view::dense<ValueType> result)
 {
-    auto coo_val = source->get_const_values();
-    auto coo_col = source->get_const_col_idxs();
-    auto coo_row = source->get_const_row_idxs();
-    for (size_type i = 0; i < source->get_num_stored_elements(); i++) {
+    auto coo_val = source.values;
+    auto coo_col = source.col_idxs;
+    auto coo_row = source.row_idxs;
+    for (size_type i = 0; i < source.num_stored_elements; i++) {
         result(coo_row[i], coo_col[i]) += coo_val[i];
     }
 }
@@ -120,14 +120,14 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 
 template <typename ValueType, typename IndexType>
 void extract_diagonal(std::shared_ptr<const ReferenceExecutor> exec,
-                      const matrix::Coo<ValueType, IndexType>* orig,
+                      matrix::view::coo<const ValueType, const IndexType> orig,
                       matrix::Diagonal<ValueType>* diag)
 {
-    const auto row_idxs = orig->get_const_row_idxs();
-    const auto col_idxs = orig->get_const_col_idxs();
-    const auto values = orig->get_const_values();
+    const auto row_idxs = orig.row_idxs;
+    const auto col_idxs = orig.col_idxs;
+    const auto values = orig.values;
     const auto diag_size = diag->get_size()[0];
-    const auto nnz = orig->get_num_stored_elements();
+    const auto nnz = orig.num_stored_elements;
     auto diag_values = diag->get_values();
 
     for (size_type idx = 0; idx < nnz; idx++) {

--- a/reference/matrix/dense_kernels.cpp
+++ b/reference/matrix/dense_kernels.cpp
@@ -458,15 +458,15 @@ GKO_INSTANTIATE_FOR_EACH_NON_COMPLEX_VALUE_TYPE(
 template <typename ValueType, typename IndexType>
 void convert_to_coo(std::shared_ptr<const ReferenceExecutor> exec,
                     matrix::view::dense<const ValueType> source, const int64*,
-                    matrix::Coo<ValueType, IndexType>* result)
+                    matrix::view::coo<ValueType, IndexType> result)
 {
-    auto num_rows = result->get_size()[0];
-    auto num_cols = result->get_size()[1];
-    auto num_nonzeros = result->get_num_stored_elements();
+    auto num_rows = result.size[0];
+    auto num_cols = result.size[1];
+    auto num_nonzeros = result.num_stored_elements;
 
-    auto row_idxs = result->get_row_idxs();
-    auto col_idxs = result->get_col_idxs();
-    auto values = result->get_values();
+    auto row_idxs = result.row_idxs;
+    auto col_idxs = result.col_idxs;
+    auto values = result.values;
 
     size_type idxs = 0;
     for (size_type row = 0; row < num_rows; ++row) {

--- a/reference/multigrid/pgm_kernels.cpp
+++ b/reference/multigrid/pgm_kernels.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -268,11 +268,11 @@ template <typename ValueType, typename IndexType>
 void compute_coarse_coo(std::shared_ptr<const DefaultExecutor> exec,
                         size_type fine_nnz, const IndexType* row_idxs,
                         const IndexType* col_idxs, const ValueType* vals,
-                        matrix::Coo<ValueType, IndexType>* coarse_coo)
+                        matrix::view::coo<ValueType, IndexType> coarse_coo)
 {
-    auto coarse_row = coarse_coo->get_row_idxs();
-    auto coarse_col = coarse_coo->get_col_idxs();
-    auto coarse_val = coarse_coo->get_values();
+    auto coarse_row = coarse_coo.row_idxs;
+    auto coarse_col = coarse_coo.col_idxs;
+    auto coarse_val = coarse_coo.values;
     IndexType row = 0;
     size_type idxs = 0;
     size_type coarse_idxs = 0;
@@ -292,7 +292,7 @@ void compute_coarse_coo(std::shared_ptr<const DefaultExecutor> exec,
         }
         temp_val += vals[idxs];
     }
-    GKO_ASSERT(coarse_idxs + 1 == coarse_coo->get_num_stored_elements());
+    GKO_ASSERT(coarse_idxs + 1 == coarse_coo.num_stored_elements);
     coarse_row[coarse_idxs] = curr_row;
     coarse_col[coarse_idxs] = curr_col;
     coarse_val[coarse_idxs] = temp_val;

--- a/reference/test/factorization/par_ic_kernels.cpp
+++ b/reference/test/factorization/par_ic_kernels.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -110,7 +110,8 @@ TYPED_TEST_SUITE(ParIc, gko::test::ValueIndexTypes, PairTypenameNameGenerator);
 TYPED_TEST(ParIc, KernelCompute)
 {
     gko::kernels::reference::par_ic_factorization::compute_factor(
-        this->ref, 1, this->mtx_l_system_coo.get(), this->mtx_l_system.get());
+        this->ref, 1, this->mtx_l_system_coo->get_const_device_view(),
+        this->mtx_l_system.get());
 
     GKO_ASSERT_MTX_NEAR(this->mtx_l_system, this->mtx_l_it_expect, this->tol);
 }

--- a/reference/test/factorization/par_ict_kernels.cpp
+++ b/reference/test/factorization/par_ict_kernels.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -200,7 +200,7 @@ TYPED_TEST(ParIct, KernelComputeLU)
 
     gko::kernels::reference::par_ict_factorization::compute_factor(
         this->ref, this->mtx_system.get(), this->mtx_l_system.get(),
-        mtx_l_coo.get());
+        mtx_l_coo->get_const_device_view());
 
     GKO_ASSERT_MTX_NEAR(this->mtx_l_system, this->mtx_l_it_expect, this->tol);
 }

--- a/reference/test/factorization/par_ilu_kernels.cpp
+++ b/reference/test/factorization/par_ilu_kernels.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -406,7 +406,8 @@ TYPED_TEST(ParIlu, KernelComputeLU)
         static_cast<Dense*>(u_expected_lin_op.release()));
 
     gko::kernels::reference::par_ilu_factorization::compute_l_u_factors(
-        this->ref, iterations, mtx_coo.get(), l_csr.get(), u_csr.get());
+        this->ref, iterations, mtx_coo->get_const_device_view(), l_csr.get(),
+        u_csr.get());
 
     GKO_ASSERT_MTX_NEAR(l_csr, this->small_l_expected, r<value_type>::value);
     GKO_ASSERT_MTX_NEAR(u_csr, u_expected, r<value_type>::value);

--- a/reference/test/factorization/par_ilut_kernels.cpp
+++ b/reference/test/factorization/par_ilut_kernels.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -15,7 +15,9 @@
 #include <ginkgo/core/matrix/coo.hpp>
 #include <ginkgo/core/matrix/csr.hpp>
 #include <ginkgo/core/matrix/dense.hpp>
+#include <ginkgo/core/matrix/device_views.hpp>
 
+#include "core/matrix/coo_builder.hpp"
 #include "core/test/utils.hpp"
 
 
@@ -202,16 +204,34 @@ protected:
                      gko::remove_complex<value_type> threshold,
                      const std::unique_ptr<Mtx>& expected, bool lower)
     {
+        using vtype = typename Mtx::value_type;
+        using itype = typename Mtx::index_type;
         auto res_mtx = Mtx::create(exec, mtx->get_size());
-        auto res_mtx_coo = Coo::create(exec, mtx->get_size());
+        auto input_nnz = mtx->get_num_stored_elements();
+        gko::array<itype> coo_row_idxs{exec, input_nnz};
+        gko::matrix::view::coo<vtype, itype> coo_view{
+            mtx->get_size(), input_nnz, nullptr, coo_row_idxs.get_data(),
+            nullptr};
 
         auto local_mtx = gko::as<Mtx>(lower ? mtx->clone() : mtx->transpose());
         auto local_expected =
             gko::as<Mtx>(lower ? expected->clone() : expected->transpose());
 
         gko::kernels::reference::par_ilut_factorization::threshold_filter(
-            ref, local_mtx.get(), threshold, res_mtx.get(), res_mtx_coo.get(),
-            lower);
+            ref, local_mtx.get(), threshold, res_mtx.get(), coo_view, lower);
+
+        // Build a Coo from the CSR output and row_idxs for comparison
+        auto res_nnz = res_mtx->get_num_stored_elements();
+        auto res_mtx_coo = Coo::create(exec, res_mtx->get_size(), res_nnz);
+        {
+            gko::matrix::CooBuilder<vtype, itype> coo_builder{res_mtx_coo};
+            coo_builder.get_row_idx_array() =
+                gko::array<itype>::view(exec, res_nnz, coo_row_idxs.get_data());
+            coo_builder.get_col_idx_array() =
+                gko::array<itype>::view(exec, res_nnz, res_mtx->get_col_idxs());
+            coo_builder.get_value_array() =
+                gko::array<vtype>::view(exec, res_nnz, res_mtx->get_values());
+        }
 
         GKO_ASSERT_MTX_EQ_SPARSITY(local_expected, res_mtx);
         GKO_ASSERT_MTX_NEAR(local_expected, res_mtx, 0);
@@ -225,19 +245,51 @@ protected:
     void test_filter_approx(const std::unique_ptr<Mtx>& mtx, index_type rank,
                             const std::unique_ptr<Mtx>& expected)
     {
+        using vtype = typename Mtx::value_type;
+        using itype = typename Mtx::index_type;
+        auto input_nnz = mtx->get_num_stored_elements();
         auto res_mtx = Mtx::create(exec, mtx->get_size());
-        auto res_mtx_coo = Coo::create(exec, mtx->get_size());
+        gko::array<itype> coo_row_idxs{exec, input_nnz};
+        gko::matrix::view::coo<vtype, itype> coo_view{
+            mtx->get_size(), input_nnz, nullptr, coo_row_idxs.get_data(),
+            nullptr};
         auto res_mtx2 = Mtx::create(exec, mtx->get_size());
-        auto res_mtx_coo2 = Coo::create(exec, mtx->get_size());
+        gko::array<itype> coo_row_idxs2{exec, input_nnz};
+        gko::matrix::view::coo<vtype, itype> coo_view2{
+            mtx->get_size(), input_nnz, nullptr, coo_row_idxs2.get_data(),
+            nullptr};
 
         auto tmp = gko::array<typename Mtx::value_type>{exec};
         gko::remove_complex<typename Mtx::value_type> threshold{};
         gko::kernels::reference::par_ilut_factorization::
             threshold_filter_approx(ref, mtx.get(), rank, tmp, threshold,
-                                    res_mtx.get(), res_mtx_coo.get());
+                                    res_mtx.get(), coo_view);
         gko::kernels::reference::par_ilut_factorization::threshold_filter(
-            ref, mtx.get(), threshold, res_mtx2.get(), res_mtx_coo2.get(),
-            true);
+            ref, mtx.get(), threshold, res_mtx2.get(), coo_view2, true);
+
+        // Build Coo from CSR output and row_idxs for comparison
+        auto res_nnz = res_mtx->get_num_stored_elements();
+        auto res_mtx_coo = Coo::create(exec, res_mtx->get_size(), res_nnz);
+        {
+            gko::matrix::CooBuilder<vtype, itype> coo_builder{res_mtx_coo};
+            coo_builder.get_row_idx_array() =
+                gko::array<itype>::view(exec, res_nnz, coo_row_idxs.get_data());
+            coo_builder.get_col_idx_array() =
+                gko::array<itype>::view(exec, res_nnz, res_mtx->get_col_idxs());
+            coo_builder.get_value_array() =
+                gko::array<vtype>::view(exec, res_nnz, res_mtx->get_values());
+        }
+        auto res_nnz2 = res_mtx2->get_num_stored_elements();
+        auto res_mtx_coo2 = Coo::create(exec, res_mtx2->get_size(), res_nnz2);
+        {
+            gko::matrix::CooBuilder<vtype, itype> coo_builder{res_mtx_coo2};
+            coo_builder.get_row_idx_array() = gko::array<itype>::view(
+                exec, res_nnz2, coo_row_idxs2.get_data());
+            coo_builder.get_col_idx_array() = gko::array<itype>::view(
+                exec, res_nnz2, res_mtx2->get_col_idxs());
+            coo_builder.get_value_array() =
+                gko::array<vtype>::view(exec, res_nnz2, res_mtx2->get_values());
+        }
 
         GKO_ASSERT_MTX_EQ_SPARSITY(expected, res_mtx);
         GKO_ASSERT_MTX_EQ_SPARSITY(expected, res_mtx2);
@@ -324,8 +376,11 @@ TYPED_TEST(ParIlut, KernelThresholdFilterNullptrCoo)
 {
     using Csr = typename TestFixture::Csr;
     using Coo = typename TestFixture::Coo;
+    using value_type = typename TestFixture::value_type;
+    using index_type = typename TestFixture::index_type;
     auto res_mtx = Csr::create(this->exec, this->mtx1->get_size());
-    Coo* null_coo = nullptr;
+    gko::matrix::view::coo<value_type, index_type> null_coo{
+        {}, 0, nullptr, nullptr, nullptr};
 
     gko::kernels::reference::par_ilut_factorization::threshold_filter(
         this->ref, this->mtx1.get(), 0.0, res_mtx.get(), null_coo, true);
@@ -406,7 +461,8 @@ TYPED_TEST(ParIlut, KernelThresholdFilterApproxNullptrCoo)
     auto res_mtx = Csr::create(this->exec, this->mtx1->get_size());
     auto tmp = gko::array<value_type>{this->ref};
     gko::remove_complex<value_type> threshold{};
-    Coo* null_coo = nullptr;
+    gko::matrix::view::coo<value_type, index_type> null_coo{
+        {}, 0, nullptr, nullptr, nullptr};
     index_type rank{};
 
     gko::kernels::reference::par_ilut_factorization::threshold_filter_approx(
@@ -481,7 +537,8 @@ TYPED_TEST(ParIlut, KernelComputeLU)
 
     gko::kernels::reference::par_ilut_factorization::compute_l_u_factors(
         this->ref, this->mtx_system.get(), this->mtx_l_system.get(),
-        mtx_l_coo.get(), this->mtx_u_system.get(), mtx_u_coo.get(), mtx_u_csc);
+        mtx_l_coo->get_const_device_view(), this->mtx_u_system.get(),
+        mtx_u_coo->get_const_device_view(), mtx_u_csc);
     auto mtx_utt = gko::as<Csr>(mtx_u_csc->transpose());
 
     GKO_ASSERT_MTX_NEAR(this->mtx_l_system, this->mtx_l_it_expect, this->tol);

--- a/reference/test/factorization/par_ilut_kernels.cpp
+++ b/reference/test/factorization/par_ilut_kernels.cpp
@@ -15,9 +15,7 @@
 #include <ginkgo/core/matrix/coo.hpp>
 #include <ginkgo/core/matrix/csr.hpp>
 #include <ginkgo/core/matrix/dense.hpp>
-#include <ginkgo/core/matrix/device_views.hpp>
 
-#include "core/matrix/coo_builder.hpp"
 #include "core/test/utils.hpp"
 
 
@@ -204,34 +202,16 @@ protected:
                      gko::remove_complex<value_type> threshold,
                      const std::unique_ptr<Mtx>& expected, bool lower)
     {
-        using vtype = typename Mtx::value_type;
-        using itype = typename Mtx::index_type;
         auto res_mtx = Mtx::create(exec, mtx->get_size());
-        auto input_nnz = mtx->get_num_stored_elements();
-        gko::array<itype> coo_row_idxs{exec, input_nnz};
-        gko::matrix::view::coo<vtype, itype> coo_view{
-            mtx->get_size(), input_nnz, nullptr, coo_row_idxs.get_data(),
-            nullptr};
+        auto res_mtx_coo = Coo::create(exec, mtx->get_size());
 
         auto local_mtx = gko::as<Mtx>(lower ? mtx->clone() : mtx->transpose());
         auto local_expected =
             gko::as<Mtx>(lower ? expected->clone() : expected->transpose());
 
         gko::kernels::reference::par_ilut_factorization::threshold_filter(
-            ref, local_mtx.get(), threshold, res_mtx.get(), coo_view, lower);
-
-        // Build a Coo from the CSR output and row_idxs for comparison
-        auto res_nnz = res_mtx->get_num_stored_elements();
-        auto res_mtx_coo = Coo::create(exec, res_mtx->get_size(), res_nnz);
-        {
-            gko::matrix::CooBuilder<vtype, itype> coo_builder{res_mtx_coo};
-            coo_builder.get_row_idx_array() =
-                gko::array<itype>::view(exec, res_nnz, coo_row_idxs.get_data());
-            coo_builder.get_col_idx_array() =
-                gko::array<itype>::view(exec, res_nnz, res_mtx->get_col_idxs());
-            coo_builder.get_value_array() =
-                gko::array<vtype>::view(exec, res_nnz, res_mtx->get_values());
-        }
+            ref, local_mtx.get(), threshold, res_mtx.get(), res_mtx_coo.get(),
+            lower);
 
         GKO_ASSERT_MTX_EQ_SPARSITY(local_expected, res_mtx);
         GKO_ASSERT_MTX_NEAR(local_expected, res_mtx, 0);
@@ -245,51 +225,19 @@ protected:
     void test_filter_approx(const std::unique_ptr<Mtx>& mtx, index_type rank,
                             const std::unique_ptr<Mtx>& expected)
     {
-        using vtype = typename Mtx::value_type;
-        using itype = typename Mtx::index_type;
-        auto input_nnz = mtx->get_num_stored_elements();
         auto res_mtx = Mtx::create(exec, mtx->get_size());
-        gko::array<itype> coo_row_idxs{exec, input_nnz};
-        gko::matrix::view::coo<vtype, itype> coo_view{
-            mtx->get_size(), input_nnz, nullptr, coo_row_idxs.get_data(),
-            nullptr};
+        auto res_mtx_coo = Coo::create(exec, mtx->get_size());
         auto res_mtx2 = Mtx::create(exec, mtx->get_size());
-        gko::array<itype> coo_row_idxs2{exec, input_nnz};
-        gko::matrix::view::coo<vtype, itype> coo_view2{
-            mtx->get_size(), input_nnz, nullptr, coo_row_idxs2.get_data(),
-            nullptr};
+        auto res_mtx_coo2 = Coo::create(exec, mtx->get_size());
 
         auto tmp = gko::array<typename Mtx::value_type>{exec};
         gko::remove_complex<typename Mtx::value_type> threshold{};
         gko::kernels::reference::par_ilut_factorization::
             threshold_filter_approx(ref, mtx.get(), rank, tmp, threshold,
-                                    res_mtx.get(), coo_view);
+                                    res_mtx.get(), res_mtx_coo.get());
         gko::kernels::reference::par_ilut_factorization::threshold_filter(
-            ref, mtx.get(), threshold, res_mtx2.get(), coo_view2, true);
-
-        // Build Coo from CSR output and row_idxs for comparison
-        auto res_nnz = res_mtx->get_num_stored_elements();
-        auto res_mtx_coo = Coo::create(exec, res_mtx->get_size(), res_nnz);
-        {
-            gko::matrix::CooBuilder<vtype, itype> coo_builder{res_mtx_coo};
-            coo_builder.get_row_idx_array() =
-                gko::array<itype>::view(exec, res_nnz, coo_row_idxs.get_data());
-            coo_builder.get_col_idx_array() =
-                gko::array<itype>::view(exec, res_nnz, res_mtx->get_col_idxs());
-            coo_builder.get_value_array() =
-                gko::array<vtype>::view(exec, res_nnz, res_mtx->get_values());
-        }
-        auto res_nnz2 = res_mtx2->get_num_stored_elements();
-        auto res_mtx_coo2 = Coo::create(exec, res_mtx2->get_size(), res_nnz2);
-        {
-            gko::matrix::CooBuilder<vtype, itype> coo_builder{res_mtx_coo2};
-            coo_builder.get_row_idx_array() = gko::array<itype>::view(
-                exec, res_nnz2, coo_row_idxs2.get_data());
-            coo_builder.get_col_idx_array() = gko::array<itype>::view(
-                exec, res_nnz2, res_mtx2->get_col_idxs());
-            coo_builder.get_value_array() =
-                gko::array<vtype>::view(exec, res_nnz2, res_mtx2->get_values());
-        }
+            ref, mtx.get(), threshold, res_mtx2.get(), res_mtx_coo2.get(),
+            true);
 
         GKO_ASSERT_MTX_EQ_SPARSITY(expected, res_mtx);
         GKO_ASSERT_MTX_EQ_SPARSITY(expected, res_mtx2);
@@ -376,11 +324,8 @@ TYPED_TEST(ParIlut, KernelThresholdFilterNullptrCoo)
 {
     using Csr = typename TestFixture::Csr;
     using Coo = typename TestFixture::Coo;
-    using value_type = typename TestFixture::value_type;
-    using index_type = typename TestFixture::index_type;
     auto res_mtx = Csr::create(this->exec, this->mtx1->get_size());
-    gko::matrix::view::coo<value_type, index_type> null_coo{
-        {}, 0, nullptr, nullptr, nullptr};
+    Coo* null_coo = nullptr;
 
     gko::kernels::reference::par_ilut_factorization::threshold_filter(
         this->ref, this->mtx1.get(), 0.0, res_mtx.get(), null_coo, true);
@@ -461,8 +406,7 @@ TYPED_TEST(ParIlut, KernelThresholdFilterApproxNullptrCoo)
     auto res_mtx = Csr::create(this->exec, this->mtx1->get_size());
     auto tmp = gko::array<value_type>{this->ref};
     gko::remove_complex<value_type> threshold{};
-    gko::matrix::view::coo<value_type, index_type> null_coo{
-        {}, 0, nullptr, nullptr, nullptr};
+    Coo* null_coo = nullptr;
     index_type rank{};
 
     gko::kernels::reference::par_ilut_factorization::threshold_filter_approx(

--- a/test/factorization/par_ic_kernels.cpp
+++ b/test/factorization/par_ic_kernels.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -128,9 +128,11 @@ TYPED_TEST(ParIc, KernelComputeFactorIsEquivalentToRef)
         1e-4, static_cast<double>(r<gko::remove_complex<value_type>>::value));
 
     gko::kernels::reference::par_ic_factorization::compute_factor(
-        this->ref, 1, mtx_l_coo.get(), this->mtx_l_ani_init.get());
+        this->ref, 1, mtx_l_coo->get_const_device_view(),
+        this->mtx_l_ani_init.get());
     gko::kernels::GKO_DEVICE_NAMESPACE::par_ic_factorization::compute_factor(
-        this->exec, 100, dmtx_l_coo.get(), this->dmtx_l_ani_init.get());
+        this->exec, 100, dmtx_l_coo->get_const_device_view(),
+        this->dmtx_l_ani_init.get());
 
     GKO_EXPECT_MTX_NEAR(this->mtx_l_ani_init, this->dmtx_l_ani_init, tol);
 }

--- a/test/factorization/par_ict_kernels.cpp
+++ b/test/factorization/par_ict_kernels.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -149,11 +149,13 @@ TYPED_TEST(ParIct, KernelComputeFactorIsEquivalentToRef)
     dmtx_l_coo->copy_from(mtx_l_coo);
 
     gko::kernels::reference::par_ict_factorization::compute_factor(
-        this->ref, this->mtx_ani.get(), this->mtx_l_ani.get(), mtx_l_coo.get());
+        this->ref, this->mtx_ani.get(), this->mtx_l_ani.get(),
+        mtx_l_coo->get_const_device_view());
     for (int i = 0; i < 20; ++i) {
         gko::kernels::GKO_DEVICE_NAMESPACE::par_ict_factorization::
             compute_factor(this->exec, this->dmtx_ani.get(),
-                           this->dmtx_l_ani.get(), dmtx_l_coo.get());
+                           this->dmtx_l_ani.get(),
+                           dmtx_l_coo->get_const_device_view());
     }
 
     GKO_ASSERT_MTX_NEAR(this->mtx_l_ani, this->dmtx_l_ani, 1e-2);

--- a/test/factorization/par_ilu_kernels.cpp
+++ b/test/factorization/par_ilu_kernels.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -133,10 +133,11 @@ protected:
         auto u_transpose_dmtx = gko::as<Csr>(du->transpose());
 
         gko::kernels::reference::par_ilu_factorization::compute_l_u_factors(
-            ref, iterations, coo.get(), l.get(), u_transpose_mtx.get());
+            ref, iterations, coo->get_const_device_view(), l.get(),
+            u_transpose_mtx.get());
         gko::kernels::GKO_DEVICE_NAMESPACE::par_ilu_factorization::
-            compute_l_u_factors(exec, iterations, dcoo.get(), dl.get(),
-                                u_transpose_dmtx.get());
+            compute_l_u_factors(exec, iterations, dcoo->get_const_device_view(),
+                                dl.get(), u_transpose_dmtx.get());
         auto u_lin_op = u_transpose_mtx->transpose();
         u = gko::as<Csr>(std::move(u_lin_op));
         auto du_lin_op = u_transpose_dmtx->transpose();

--- a/test/factorization/par_ilut_kernels.cpp
+++ b/test/factorization/par_ilut_kernels.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -483,14 +483,15 @@ TYPED_TEST(ParIlut, KernelComputeLUIsEquivalentToRef)
     dmtx_u_coo->copy_from(mtx_u_coo);
 
     gko::kernels::reference::par_ilut_factorization::compute_l_u_factors(
-        this->ref, this->mtx_ani.get(), this->mtx_l_ani.get(), mtx_l_coo.get(),
-        this->mtx_u_ani.get(), mtx_u_coo.get(), this->mtx_ut_ani.get());
+        this->ref, this->mtx_ani.get(), this->mtx_l_ani.get(),
+        mtx_l_coo->get_const_device_view(), this->mtx_u_ani.get(),
+        mtx_u_coo->get_const_device_view(), this->mtx_ut_ani.get());
     for (int i = 0; i < 20; ++i) {
         gko::kernels::GKO_DEVICE_NAMESPACE::par_ilut_factorization::
-            compute_l_u_factors(this->exec, this->dmtx_ani.get(),
-                                this->dmtx_l_ani.get(), dmtx_l_coo.get(),
-                                this->dmtx_u_ani.get(), dmtx_u_coo.get(),
-                                this->dmtx_ut_ani.get());
+            compute_l_u_factors(
+                this->exec, this->dmtx_ani.get(), this->dmtx_l_ani.get(),
+                dmtx_l_coo->get_const_device_view(), this->dmtx_u_ani.get(),
+                dmtx_u_coo->get_const_device_view(), this->dmtx_ut_ani.get());
     }
     auto dmtx_utt_ani = gko::as<Csr>(this->dmtx_ut_ani->transpose());
 

--- a/test/matrix/device_views.cpp
+++ b/test/matrix/device_views.cpp
@@ -54,6 +54,55 @@ TYPED_TEST(DenseView, WorksOnDevice)
 
 
 template <typename ValueIndexType>
+class CooView : public CommonTestFixture {
+public:
+    using value_type =
+        typename std::tuple_element<0, decltype(ValueIndexType())>::type;
+    using index_type =
+        typename std::tuple_element<1, decltype(ValueIndexType())>::type;
+};
+
+TYPED_TEST_SUITE(CooView, gko::test::ValueIndexTypes,
+                 PairTypenameNameGenerator);
+
+
+template <typename ValueType, typename IndexType>
+void assert_coo_view(std::shared_ptr<const gko::EXEC_TYPE> exec)
+{
+    gko::array<bool> correct{exec, {false}};
+    gko::array<ValueType> values{exec, 3};
+    gko::array<IndexType> row_idxs{exec, 3};
+    gko::array<IndexType> col_idxs{exec, 3};
+    values.fill(gko::one<ValueType>());
+    row_idxs.fill(IndexType{0});
+    col_idxs.fill(IndexType{1});
+    gko::kernels::GKO_DEVICE_NAMESPACE::run_kernel(
+        exec,
+        [] GKO_KERNEL(auto i, auto values, auto row_idxs, auto col_idxs,
+                      auto correct) {
+            using vt = std::decay_t<decltype(values[0])>;
+            using it = std::decay_t<decltype(row_idxs[0])>;
+            gko::matrix::view::coo<vt, it> view{gko::dim<2>{3, 3}, 3, values,
+                                                row_idxs, col_idxs};
+            if (view.size == gko::dim<2>(3, 3) &&
+                view.num_stored_elements == 3 && view.values == values &&
+                view.row_idxs == row_idxs && view.col_idxs == col_idxs) {
+                *correct = true;
+            }
+        },
+        1, values, row_idxs, col_idxs, correct);
+    ASSERT_TRUE(get_element(correct, 0));
+}
+
+TYPED_TEST(CooView, WorksOnDevice)
+{
+    using value_type = typename TestFixture::value_type;
+    using index_type = typename TestFixture::index_type;
+    assert_coo_view<value_type, index_type>(this->exec);
+}
+
+
+template <typename ValueIndexType>
 class EllView : public CommonTestFixture {
 public:
     using value_type =


### PR DESCRIPTION
Similar to #1991 and the view::dense, this PR adds a view::coo for the kernels. The structure is the same as for Ell and Dense, but the `view_at` is removed, as I think it is not necessary for COO.