### PR TITLE
SELLp device_view

### DIFF
--- a/common/cuda_hip/matrix/dense_kernels.cpp
+++ b/common/cuda_hip/matrix/dense_kernels.cpp
@@ -603,18 +603,18 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 template <typename ValueType, typename IndexType>
 void convert_to_sellp(std::shared_ptr<const DefaultExecutor> exec,
                       matrix::view::dense<const ValueType> source,
-                      matrix::Sellp<ValueType, IndexType>* result)
+                      matrix::view::sellp<ValueType, IndexType> result)
 {
     const auto stride = source.stride;
-    const auto num_rows = result->get_size()[0];
-    const auto num_cols = result->get_size()[1];
+    const auto num_rows = result.size[0];
+    const auto num_cols = result.size[1];
 
-    auto vals = result->get_values();
-    auto col_idxs = result->get_col_idxs();
-    auto slice_sets = result->get_slice_sets();
+    auto vals = result.values;
+    auto col_idxs = result.col_idxs;
+    auto slice_sets = result.slice_sets;
 
-    const auto slice_size = result->get_slice_size();
-    const auto stride_factor = result->get_stride_factor();
+    const auto slice_size = result.slice_size;
+    const auto stride_factor = result.stride_factor;
 
     auto grid_dim = ceildiv(num_rows, default_block_size / config::warp_size);
     if (grid_dim > 0) {

--- a/common/cuda_hip/matrix/sellp_kernels.cpp
+++ b/common/cuda_hip/matrix/sellp_kernels.cpp
@@ -91,18 +91,17 @@ __global__ __launch_bounds__(default_block_size) void advanced_spmv_kernel(
 
 template <typename ValueType, typename IndexType>
 void spmv(std::shared_ptr<const DefaultExecutor> exec,
-          const matrix::Sellp<ValueType, IndexType>* a,
+          matrix::view::sellp<const ValueType, const IndexType> a,
           matrix::view::dense<const ValueType> b,
           matrix::view::dense<ValueType> c)
 {
     const auto block_size = default_block_size;
-    const dim3 grid(ceildiv(a->get_size()[0], block_size), b.size[1]);
+    const dim3 grid(ceildiv(a.size[0], block_size), b.size[1]);
 
     if (grid.x > 0 && grid.y > 0) {
         spmv_kernel<<<grid, block_size, 0, exec->get_stream()>>>(
-            a->get_size()[0], b.size[1], b.stride, c.stride,
-            a->get_slice_size(), a->get_const_slice_sets(),
-            as_device_type(a->get_const_values()), a->get_const_col_idxs(),
+            a.size[0], b.size[1], b.stride, c.stride, a.slice_size,
+            a.slice_sets, as_device_type(a.values), a.col_idxs,
             as_device_type(b.values), as_device_type(c.values));
     }
 }
@@ -113,20 +112,19 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(GKO_DECLARE_SELLP_SPMV_KERNEL);
 template <typename ValueType, typename IndexType>
 void advanced_spmv(std::shared_ptr<const DefaultExecutor> exec,
                    matrix::view::dense<const ValueType> alpha,
-                   const matrix::Sellp<ValueType, IndexType>* a,
+                   matrix::view::sellp<const ValueType, const IndexType> a,
                    matrix::view::dense<const ValueType> b,
                    matrix::view::dense<const ValueType> beta,
                    matrix::view::dense<ValueType> c)
 {
     const auto block_size = default_block_size;
-    const dim3 grid(ceildiv(a->get_size()[0], block_size), b.size[1]);
+    const dim3 grid(ceildiv(a.size[0], block_size), b.size[1]);
 
     if (grid.x > 0 && grid.y > 0) {
         advanced_spmv_kernel<<<grid, block_size, 0, exec->get_stream()>>>(
-            a->get_size()[0], b.size[1], b.stride, c.stride,
-            a->get_slice_size(), a->get_const_slice_sets(),
-            as_device_type(alpha.values), as_device_type(a->get_const_values()),
-            a->get_const_col_idxs(), as_device_type(b.values),
+            a.size[0], b.size[1], b.stride, c.stride, a.slice_size,
+            a.slice_sets, as_device_type(alpha.values),
+            as_device_type(a.values), a.col_idxs, as_device_type(b.values),
             as_device_type(beta.values), as_device_type(c.values));
     }
 }

--- a/common/unified/matrix/csr_kernels.cpp
+++ b/common/unified/matrix/csr_kernels.cpp
@@ -121,7 +121,7 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(GKO_DECLARE_CSR_INV_SCALE_KERNEL);
 template <typename ValueType, typename IndexType>
 void convert_to_sellp(std::shared_ptr<const DefaultExecutor> exec,
                       const matrix::Csr<ValueType, IndexType>* matrix,
-                      matrix::Sellp<ValueType, IndexType>* output)
+                      matrix::view::sellp<ValueType, IndexType> output)
 {
     run_kernel(
         exec,
@@ -144,10 +144,9 @@ void convert_to_sellp(std::shared_ptr<const DefaultExecutor> exec,
                 out_idx += slice_size;
             }
         },
-        output->get_size()[0], matrix->get_const_col_idxs(),
+        output.size[0], matrix->get_const_col_idxs(),
         matrix->get_const_values(), matrix->get_const_row_ptrs(),
-        output->get_slice_size(), output->get_const_slice_sets(),
-        output->get_col_idxs(), output->get_values());
+        output.slice_size, output.slice_sets, output.col_idxs, output.values);
 }
 
 GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(

--- a/common/unified/matrix/sellp_kernels.cpp
+++ b/common/unified/matrix/sellp_kernels.cpp
@@ -58,7 +58,7 @@ template <typename ValueType, typename IndexType>
 void fill_in_matrix_data(std::shared_ptr<const DefaultExecutor> exec,
                          const device_matrix_data<ValueType, IndexType>& data,
                          const int64* row_ptrs,
-                         matrix::Sellp<ValueType, IndexType>* output)
+                         matrix::view::sellp<ValueType, IndexType> output)
 {
     run_kernel(
         exec,
@@ -81,10 +81,9 @@ void fill_in_matrix_data(std::shared_ptr<const DefaultExecutor> exec,
                 out_idx += slice_size;
             }
         },
-        output->get_size()[0], data.get_const_col_idxs(),
-        data.get_const_values(), row_ptrs, output->get_slice_size(),
-        output->get_const_slice_sets(), output->get_col_idxs(),
-        output->get_values());
+        output.size[0], data.get_const_col_idxs(), data.get_const_values(),
+        row_ptrs, output.slice_size, output.slice_sets, output.col_idxs,
+        output.values);
 }
 
 GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
@@ -93,7 +92,7 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 
 template <typename ValueType, typename IndexType>
 void fill_in_dense(std::shared_ptr<const DefaultExecutor> exec,
-                   const matrix::Sellp<ValueType, IndexType>* source,
+                   matrix::view::sellp<const ValueType, const IndexType> source,
                    matrix::view::dense<ValueType> result)
 {
     run_kernel(
@@ -114,9 +113,8 @@ void fill_in_dense(std::shared_ptr<const DefaultExecutor> exec,
                 in_idx += slice_size;
             }
         },
-        source->get_size()[0], source->get_slice_size(),
-        source->get_const_slice_sets(), source->get_const_col_idxs(),
-        source->get_const_values(), result);
+        source.size[0], source.slice_size, source.slice_sets, source.col_idxs,
+        source.values, result);
 }
 
 GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
@@ -124,9 +122,10 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 
 
 template <typename ValueType, typename IndexType>
-void count_nonzeros_per_row(std::shared_ptr<const DefaultExecutor> exec,
-                            const matrix::Sellp<ValueType, IndexType>* source,
-                            IndexType* result)
+void count_nonzeros_per_row(
+    std::shared_ptr<const DefaultExecutor> exec,
+    matrix::view::sellp<const ValueType, const IndexType> source,
+    IndexType* result)
 {
     run_kernel(
         exec,
@@ -145,8 +144,8 @@ void count_nonzeros_per_row(std::shared_ptr<const DefaultExecutor> exec,
             }
             result[row] = row_nnz;
         },
-        source->get_size()[0], source->get_slice_size(),
-        source->get_const_slice_sets(), source->get_const_col_idxs(), result);
+        source.size[0], source.slice_size, source.slice_sets, source.col_idxs,
+        result);
 }
 
 GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
@@ -154,9 +153,10 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 
 
 template <typename ValueType, typename IndexType>
-void convert_to_csr(std::shared_ptr<const DefaultExecutor> exec,
-                    const matrix::Sellp<ValueType, IndexType>* source,
-                    matrix::Csr<ValueType, IndexType>* result)
+void convert_to_csr(
+    std::shared_ptr<const DefaultExecutor> exec,
+    matrix::view::sellp<const ValueType, const IndexType> source,
+    matrix::Csr<ValueType, IndexType>* result)
 {
     run_kernel(
         exec,
@@ -177,10 +177,9 @@ void convert_to_csr(std::shared_ptr<const DefaultExecutor> exec,
                 in_idx += slice_size;
             }
         },
-        source->get_size()[0], source->get_slice_size(),
-        source->get_const_slice_sets(), source->get_const_col_idxs(),
-        source->get_const_values(), result->get_row_ptrs(),
-        result->get_col_idxs(), result->get_values());
+        source.size[0], source.slice_size, source.slice_sets, source.col_idxs,
+        source.values, result->get_row_ptrs(), result->get_col_idxs(),
+        result->get_values());
 }
 
 GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
@@ -188,9 +187,10 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 
 
 template <typename ValueType, typename IndexType>
-void extract_diagonal(std::shared_ptr<const DefaultExecutor> exec,
-                      const matrix::Sellp<ValueType, IndexType>* orig,
-                      matrix::Diagonal<ValueType>* diag)
+void extract_diagonal(
+    std::shared_ptr<const DefaultExecutor> exec,
+    matrix::view::sellp<const ValueType, const IndexType> orig,
+    matrix::Diagonal<ValueType>* diag)
 {
     run_kernel(
         exec,
@@ -210,9 +210,8 @@ void extract_diagonal(std::shared_ptr<const DefaultExecutor> exec,
                 in_idx += slice_size;
             }
         },
-        orig->get_size()[0], orig->get_slice_size(),
-        orig->get_const_slice_sets(), orig->get_const_col_idxs(),
-        orig->get_const_values(), diag->get_values());
+        orig.size[0], orig.slice_size, orig.slice_sets, orig.col_idxs,
+        orig.values, diag->get_values());
 }
 
 GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(

--- a/core/matrix/csr.cpp
+++ b/core/matrix/csr.cpp
@@ -475,7 +475,7 @@ void Csr<ValueType, IndexType>::convert_to(
     tmp->col_idxs_.resize_and_reset(total_cols * slice_size);
     tmp->values_.resize_and_reset(total_cols * slice_size);
     tmp->set_size(this->get_size());
-    exec->run(csr::make_convert_to_sellp(this, tmp.get()));
+    exec->run(csr::make_convert_to_sellp(this, tmp->get_device_view()));
 }
 
 

--- a/core/matrix/csr_kernels.hpp
+++ b/core/matrix/csr_kernels.hpp
@@ -118,7 +118,7 @@ namespace kernels {
 #define GKO_DECLARE_CSR_CONVERT_TO_SELLP_KERNEL(ValueType, IndexType)      \
     void convert_to_sellp(std::shared_ptr<const DefaultExecutor> exec,     \
                           const matrix::Csr<ValueType, IndexType>* source, \
-                          matrix::Sellp<ValueType, IndexType>* result)
+                          matrix::view::sellp<ValueType, IndexType> result)
 
 #define GKO_DECLARE_CSR_TRANSPOSE_KERNEL(ValueType, IndexType)    \
     void transpose(std::shared_ptr<const DefaultExecutor> exec,   \

--- a/core/matrix/dense.cpp
+++ b/core/matrix/dense.cpp
@@ -966,8 +966,8 @@ void Dense<ValueType>::convert_impl(Sellp<ValueType, IndexType>* result) const
     tmp->col_idxs_.resize_and_reset(total_cols * slice_size);
     tmp->values_.resize_and_reset(total_cols * slice_size);
     tmp->set_size(this->get_size());
-    exec->run(
-        dense::make_convert_to_sellp(this->get_const_device_view(), tmp.get()));
+    exec->run(dense::make_convert_to_sellp(this->get_const_device_view(),
+                                           tmp->get_device_view()));
 }
 
 

--- a/core/matrix/dense_kernels.hpp
+++ b/core/matrix/dense_kernels.hpp
@@ -175,7 +175,7 @@ namespace kernels {
 #define GKO_DECLARE_DENSE_CONVERT_TO_SELLP_KERNEL(ValueType, IndexType) \
     void convert_to_sellp(std::shared_ptr<const DefaultExecutor> exec,  \
                           matrix::view::dense<const ValueType> source,  \
-                          matrix::Sellp<ValueType, IndexType>* other)
+                          matrix::view::sellp<ValueType, IndexType> other)
 
 #define GKO_DECLARE_DENSE_CONVERT_TO_SPARSITY_CSR_KERNEL(ValueType, IndexType) \
     void convert_to_sparsity_csr(                                              \

--- a/core/matrix/sellp.cpp
+++ b/core/matrix/sellp.cpp
@@ -150,6 +150,33 @@ Sellp<ValueType, IndexType>::create(std::shared_ptr<const Executor> exec,
 }
 
 
+/** get the non-owning device view */
+template <typename ValueType, typename IndexType>
+auto Sellp<ValueType, IndexType>::get_device_view() -> device_view
+{
+    return device_view{this->get_size(),          this->get_slice_size(),
+                       this->get_stride_factor(), this->get_total_cols(),
+                       this->get_values(),        this->get_col_idxs(),
+                       this->get_slice_lengths(), this->get_slice_sets()};
+}
+
+
+/** get the const non-owning device view */
+template <typename ValueType, typename IndexType>
+auto Sellp<ValueType, IndexType>::get_const_device_view() const
+    -> const_device_view
+{
+    return const_device_view{this->get_size(),
+                             this->get_slice_size(),
+                             this->get_stride_factor(),
+                             this->get_total_cols(),
+                             this->get_const_values(),
+                             this->get_const_col_idxs(),
+                             this->get_const_slice_lengths(),
+                             this->get_const_slice_sets()};
+}
+
+
 template <typename ValueType, typename IndexType>
 void Sellp<ValueType, IndexType>::apply_impl(const LinOp* b, LinOp* x) const
 {

--- a/core/matrix/sellp.cpp
+++ b/core/matrix/sellp.cpp
@@ -182,9 +182,9 @@ void Sellp<ValueType, IndexType>::apply_impl(const LinOp* b, LinOp* x) const
 {
     precision_dispatch_real_complex<ValueType>(
         [this](auto dense_b, auto dense_x) {
-            this->get_executor()->run(
-                sellp::make_spmv(this, dense_b->get_const_device_view(),
-                                 dense_x->get_device_view()));
+            this->get_executor()->run(sellp::make_spmv(
+                this->get_const_device_view(), dense_b->get_const_device_view(),
+                dense_x->get_device_view()));
         },
         b, x);
 }
@@ -197,8 +197,8 @@ void Sellp<ValueType, IndexType>::apply_impl(const LinOp* alpha, const LinOp* b,
     precision_dispatch_real_complex<ValueType>(
         [this](auto dense_alpha, auto dense_b, auto dense_beta, auto dense_x) {
             this->get_executor()->run(sellp::make_advanced_spmv(
-                dense_alpha->get_const_device_view(), this,
-                dense_b->get_const_device_view(),
+                dense_alpha->get_const_device_view(),
+                this->get_const_device_view(), dense_b->get_const_device_view(),
                 dense_beta->get_const_device_view(),
                 dense_x->get_device_view()));
         },
@@ -283,7 +283,8 @@ void Sellp<ValueType, IndexType>::convert_to(Dense<ValueType>* result) const
     auto tmp_result = make_temporary_output_clone(exec, result);
     tmp_result->resize(this->get_size());
     tmp_result->fill(zero<ValueType>());
-    exec->run(sellp::make_fill_in_dense(this, tmp_result->get_device_view()));
+    exec->run(sellp::make_fill_in_dense(this->get_const_device_view(),
+                                        tmp_result->get_device_view()));
 }
 
 
@@ -304,7 +305,7 @@ void Sellp<ValueType, IndexType>::convert_to(
         auto tmp = make_temporary_clone(exec, result);
         tmp->row_ptrs_.resize_and_reset(num_rows + 1);
         exec->run(sellp::make_count_nonzeros_per_row(
-            this, tmp->row_ptrs_.get_data()));
+            this->get_const_device_view(), tmp->row_ptrs_.get_data()));
         exec->run(sellp::make_prefix_sum_nonnegative(tmp->row_ptrs_.get_data(),
                                                      num_rows + 1));
         const auto nnz =
@@ -312,7 +313,8 @@ void Sellp<ValueType, IndexType>::convert_to(
         tmp->col_idxs_.resize_and_reset(nnz);
         tmp->values_.resize_and_reset(nnz);
         tmp->set_size(this->get_size());
-        exec->run(sellp::make_convert_to_csr(this, tmp.get()));
+        exec->run(sellp::make_convert_to_csr(this->get_const_device_view(),
+                                             tmp.get()));
     }
     result->make_srow();
 }
@@ -345,8 +347,8 @@ void Sellp<ValueType, IndexType>::read(const device_mat_data& data)
         get_element(slice_sets_, slice_sets_.get_size() - 1);
     values_.resize_and_reset(total_cols * slice_size_);
     col_idxs_.resize_and_reset(total_cols * slice_size_);
-    exec->run(sellp::make_fill_in_matrix_data(*local_data,
-                                              row_ptrs.get_const_data(), this));
+    exec->run(sellp::make_fill_in_matrix_data(
+        *local_data, row_ptrs.get_const_data(), this->get_device_view()));
 }
 
 
@@ -405,7 +407,8 @@ Sellp<ValueType, IndexType>::extract_diagonal() const
     auto diag = Diagonal<ValueType>::create(exec, diag_size);
     exec->run(sellp::make_fill_array(diag->get_values(), diag->get_size()[0],
                                      zero<ValueType>()));
-    exec->run(sellp::make_extract_diagonal(this, diag.get()));
+    exec->run(sellp::make_extract_diagonal(this->get_const_device_view(),
+                                           diag.get()));
     return diag;
 }
 

--- a/core/matrix/sellp_kernels.hpp
+++ b/core/matrix/sellp_kernels.hpp
@@ -18,25 +18,27 @@ namespace gko {
 namespace kernels {
 
 
-#define GKO_DECLARE_SELLP_SPMV_KERNEL(ValueType, IndexType) \
-    void spmv(std::shared_ptr<const DefaultExecutor> exec,  \
-              const matrix::Sellp<ValueType, IndexType>* a, \
-              matrix::view::dense<const ValueType> b,       \
+#define GKO_DECLARE_SELLP_SPMV_KERNEL(ValueType, IndexType)            \
+    void spmv(std::shared_ptr<const DefaultExecutor> exec,             \
+              matrix::view::sellp<const ValueType, const IndexType> a, \
+              matrix::view::dense<const ValueType> b,                  \
               matrix::view::dense<ValueType> c)
 
 #define GKO_DECLARE_SELLP_ADVANCED_SPMV_KERNEL(ValueType, IndexType) \
-    void advanced_spmv(std::shared_ptr<const DefaultExecutor> exec,  \
-                       matrix::view::dense<const ValueType> alpha,   \
-                       const matrix::Sellp<ValueType, IndexType>* a, \
-                       matrix::view::dense<const ValueType> b,       \
-                       matrix::view::dense<const ValueType> beta,    \
-                       matrix::view::dense<ValueType> c)
+    void advanced_spmv(                                              \
+        std::shared_ptr<const DefaultExecutor> exec,                 \
+        matrix::view::dense<const ValueType> alpha,                  \
+        matrix::view::sellp<const ValueType, const IndexType> a,     \
+        matrix::view::dense<const ValueType> b,                      \
+        matrix::view::dense<const ValueType> beta,                   \
+        matrix::view::dense<ValueType> c)
 
 #define GKO_DECLARE_SELLP_FILL_IN_MATRIX_DATA_KERNEL(ValueType, IndexType) \
     void fill_in_matrix_data(                                              \
         std::shared_ptr<const DefaultExecutor> exec,                       \
         const device_matrix_data<ValueType, IndexType>& data,              \
-        const int64* row_ptrs, matrix::Sellp<ValueType, IndexType>* output)
+        const int64* row_ptrs,                                             \
+        matrix::view::sellp<ValueType, IndexType> output)
 
 #define GKO_DECLARE_SELLP_COMPUTE_SLICE_SETS_KERNEL(IndexType)             \
     void compute_slice_sets(std::shared_ptr<const DefaultExecutor> exec,   \
@@ -44,25 +46,29 @@ namespace kernels {
                             size_type slice_size, size_type stride_factor, \
                             size_type* slice_sets, size_type* slice_lengths)
 
-#define GKO_DECLARE_SELLP_FILL_IN_DENSE_KERNEL(ValueType, IndexType)      \
-    void fill_in_dense(std::shared_ptr<const DefaultExecutor> exec,       \
-                       const matrix::Sellp<ValueType, IndexType>* source, \
-                       matrix::view::dense<ValueType> result)
+#define GKO_DECLARE_SELLP_FILL_IN_DENSE_KERNEL(ValueType, IndexType)  \
+    void fill_in_dense(                                               \
+        std::shared_ptr<const DefaultExecutor> exec,                  \
+        matrix::view::sellp<const ValueType, const IndexType> source, \
+        matrix::view::dense<ValueType> result)
 
-#define GKO_DECLARE_SELLP_CONVERT_TO_CSR_KERNEL(ValueType, IndexType)      \
-    void convert_to_csr(std::shared_ptr<const DefaultExecutor> exec,       \
-                        const matrix::Sellp<ValueType, IndexType>* source, \
-                        matrix::Csr<ValueType, IndexType>* result)
+#define GKO_DECLARE_SELLP_CONVERT_TO_CSR_KERNEL(ValueType, IndexType) \
+    void convert_to_csr(                                              \
+        std::shared_ptr<const DefaultExecutor> exec,                  \
+        matrix::view::sellp<const ValueType, const IndexType> source, \
+        matrix::Csr<ValueType, IndexType>* result)
 
 #define GKO_DECLARE_SELLP_COUNT_NONZEROS_PER_ROW_KERNEL(ValueType, IndexType) \
     void count_nonzeros_per_row(                                              \
         std::shared_ptr<const DefaultExecutor> exec,                          \
-        const matrix::Sellp<ValueType, IndexType>* source, IndexType* result)
+        matrix::view::sellp<const ValueType, const IndexType> source,         \
+        IndexType* result)
 
-#define GKO_DECLARE_SELLP_EXTRACT_DIAGONAL_KERNEL(ValueType, IndexType)    \
-    void extract_diagonal(std::shared_ptr<const DefaultExecutor> exec,     \
-                          const matrix::Sellp<ValueType, IndexType>* orig, \
-                          matrix::Diagonal<ValueType>* diag)
+#define GKO_DECLARE_SELLP_EXTRACT_DIAGONAL_KERNEL(ValueType, IndexType) \
+    void extract_diagonal(                                              \
+        std::shared_ptr<const DefaultExecutor> exec,                    \
+        matrix::view::sellp<const ValueType, const IndexType> orig,     \
+        matrix::Diagonal<ValueType>* diag)
 
 #define GKO_DECLARE_ALL_AS_TEMPLATES                                       \
     template <typename ValueType, typename IndexType>                      \

--- a/core/test/matrix/device_views.cpp
+++ b/core/test/matrix/device_views.cpp
@@ -242,3 +242,33 @@ TYPED_TEST(SellpView, AccessWorks)
     ASSERT_EQ(const_view.slice_lengths, view.slice_lengths);
     ASSERT_EQ(const_view.slice_sets, view.slice_sets);
 }
+
+
+TYPED_TEST(SellpView, AssertTriggersOnOutOfBoundsDeathTest)
+{
+#ifdef NDEBUG
+    GTEST_SKIP() << "Assertion is only enabled in debug mode";
+#endif
+
+    using value_type = typename TestFixture::value_type;
+    using index_type = typename TestFixture::index_type;
+    std::vector<value_type> values(21);
+    std::vector<index_type> col_idxs(21);
+    std::vector<gko::size_type> slice_lengths{3, 4};
+    std::vector<gko::size_type> slice_sets{0, 3, 7};
+    gko::matrix::view::sellp<value_type, index_type> view{gko::dim<2>{3, 5},
+                                                          2,
+                                                          3,
+                                                          7,
+                                                          values.data(),
+                                                          col_idxs.data(),
+                                                          slice_lengths.data(),
+                                                          slice_sets.data()};
+
+    // access exceed row per slice
+    EXPECT_EXIT((void)(view.val_at(2, 0)), check_assertion_exit_code, "");
+    EXPECT_EXIT((void)(view.col_at(2, 0)), check_assertion_exit_code, "");
+    // access exceed the total col
+    EXPECT_EXIT((void)(view.val_at(0, 7)), check_assertion_exit_code, "");
+    EXPECT_EXIT((void)(view.col_at(0, 7)), check_assertion_exit_code, "");
+}

--- a/core/test/matrix/device_views.cpp
+++ b/core/test/matrix/device_views.cpp
@@ -266,9 +266,13 @@ TYPED_TEST(SellpView, AssertTriggersOnOutOfBoundsDeathTest)
                                                           slice_sets.data()};
 
     // access exceed row per slice
-    EXPECT_EXIT((void)(view.val_at(2, 0)), check_assertion_exit_code, "");
-    EXPECT_EXIT((void)(view.col_at(2, 0)), check_assertion_exit_code, "");
+    EXPECT_EXIT((void)(view.val_at(2, slice_sets.at(0), 0)),
+                check_assertion_exit_code, "");
+    EXPECT_EXIT((void)(view.col_at(2, slice_sets.at(0), 0)),
+                check_assertion_exit_code, "");
     // access exceed the total col
-    EXPECT_EXIT((void)(view.val_at(0, 7)), check_assertion_exit_code, "");
-    EXPECT_EXIT((void)(view.col_at(0, 7)), check_assertion_exit_code, "");
+    EXPECT_EXIT((void)(view.val_at(0, slice_sets.at(0), 7)),
+                check_assertion_exit_code, "");
+    EXPECT_EXIT((void)(view.col_at(0, slice_sets.at(0), 7)),
+                check_assertion_exit_code, "");
 }

--- a/core/test/matrix/device_views.cpp
+++ b/core/test/matrix/device_views.cpp
@@ -180,3 +180,65 @@ TYPED_TEST(EllView, AssertTriggersOnOutOfBoundsDeathTest)
     EXPECT_EXIT((void)(view.val_at(4, 0)), check_assertion_exit_code, "");
     EXPECT_EXIT((void)(view.col_at(4, 0)), check_assertion_exit_code, "");
 }
+
+
+template <typename ValueIndexType>
+class SellpView : public ::testing::Test {
+public:
+    using value_type =
+        typename std::tuple_element<0, decltype(ValueIndexType())>::type;
+    using index_type =
+        typename std::tuple_element<1, decltype(ValueIndexType())>::type;
+};
+
+TYPED_TEST_SUITE(SellpView, gko::test::ValueIndexTypes,
+                 PairTypenameNameGenerator);
+
+
+TYPED_TEST(SellpView, AccessWorks)
+{
+    using value_type = typename TestFixture::value_type;
+    using index_type = typename TestFixture::index_type;
+    std::vector<value_type> values(21);
+    std::vector<index_type> col_idxs(21);
+    std::vector<gko::size_type> slice_lengths{3, 4};
+    std::vector<gko::size_type> slice_sets{0, 3, 7};
+    gko::matrix::view::sellp<value_type, index_type> view{gko::dim<2>{3, 5},
+                                                          2,
+                                                          3,
+                                                          7,
+                                                          values.data(),
+                                                          col_idxs.data(),
+                                                          slice_lengths.data(),
+                                                          slice_sets.data()};
+    auto const_view = view.as_const();
+
+    ASSERT_EQ(view.size, gko::dim<2>(3, 5));
+    ASSERT_EQ(view.slice_size, 2);
+    ASSERT_EQ(view.stride_factor, 3);
+    ASSERT_EQ(view.total_cols, 7);
+    ASSERT_EQ(view.values, values.data());
+    ASSERT_EQ(view.col_idxs, col_idxs.data());
+    ASSERT_EQ(view.slice_lengths, slice_lengths.data());
+    ASSERT_EQ(view.slice_sets, slice_sets.data());
+    ASSERT_EQ(&view.val_at(0, slice_sets.at(0), 0), &values[0]);
+    ASSERT_EQ(&view.val_at(1, slice_sets.at(0), 0), &values[1]);
+    ASSERT_EQ(&view.val_at(1, slice_sets.at(0), 1), &values[3]);
+    ASSERT_EQ(&view.val_at(0, slice_sets.at(1), 0), &values[6]);
+    ASSERT_EQ(&view.val_at(1, slice_sets.at(1), 0), &values[7]);
+    ASSERT_EQ(&view.val_at(1, slice_sets.at(1), 1), &values[9]);
+    ASSERT_EQ(&view.col_at(0, slice_sets.at(0), 0), &col_idxs[0]);
+    ASSERT_EQ(&view.col_at(1, slice_sets.at(0), 0), &col_idxs[1]);
+    ASSERT_EQ(&view.col_at(1, slice_sets.at(0), 1), &col_idxs[3]);
+    ASSERT_EQ(&view.col_at(0, slice_sets.at(1), 0), &col_idxs[6]);
+    ASSERT_EQ(&view.col_at(1, slice_sets.at(1), 0), &col_idxs[7]);
+    ASSERT_EQ(&view.col_at(1, slice_sets.at(1), 1), &col_idxs[9]);
+    ASSERT_EQ(const_view.size, view.size);
+    ASSERT_EQ(const_view.slice_size, view.slice_size);
+    ASSERT_EQ(const_view.stride_factor, view.stride_factor);
+    ASSERT_EQ(const_view.total_cols, view.total_cols);
+    ASSERT_EQ(const_view.values, view.values);
+    ASSERT_EQ(const_view.col_idxs, view.col_idxs);
+    ASSERT_EQ(const_view.slice_lengths, view.slice_lengths);
+    ASSERT_EQ(const_view.slice_sets, view.slice_sets);
+}

--- a/core/test/matrix/sellp.cpp
+++ b/core/test/matrix/sellp.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -189,6 +189,36 @@ TYPED_TEST(Sellp, CanBeCleared)
     this->mtx->clear();
 
     this->assert_empty(this->mtx.get());
+}
+
+
+TYPED_TEST(Sellp, CanCreateDeviceView)
+{
+    auto view = this->mtx->get_device_view();
+
+    EXPECT_EQ(view.size, this->mtx->get_size());
+    EXPECT_EQ(view.slice_size, this->mtx->get_slice_size());
+    EXPECT_EQ(view.stride_factor, this->mtx->get_stride_factor());
+    EXPECT_EQ(view.total_cols, this->mtx->get_total_cols());
+    EXPECT_EQ(view.values, this->mtx->get_values());
+    EXPECT_EQ(view.col_idxs, this->mtx->get_col_idxs());
+    EXPECT_EQ(view.slice_lengths, this->mtx->get_slice_lengths());
+    EXPECT_EQ(view.slice_sets, this->mtx->get_slice_sets());
+}
+
+
+TYPED_TEST(Sellp, CanCreateConstDeviceView)
+{
+    auto view = this->mtx->get_const_device_view();
+
+    EXPECT_EQ(view.size, this->mtx->get_size());
+    EXPECT_EQ(view.slice_size, this->mtx->get_slice_size());
+    EXPECT_EQ(view.stride_factor, this->mtx->get_stride_factor());
+    EXPECT_EQ(view.total_cols, this->mtx->get_total_cols());
+    EXPECT_EQ(view.values, this->mtx->get_const_values());
+    EXPECT_EQ(view.col_idxs, this->mtx->get_const_col_idxs());
+    EXPECT_EQ(view.slice_lengths, this->mtx->get_const_slice_lengths());
+    EXPECT_EQ(view.slice_sets, this->mtx->get_const_slice_sets());
 }
 
 

--- a/dpcpp/matrix/dense_kernels.dp.cpp
+++ b/dpcpp/matrix/dense_kernels.dp.cpp
@@ -463,17 +463,17 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 template <typename ValueType, typename IndexType>
 void convert_to_sellp(std::shared_ptr<const DefaultExecutor> exec,
                       matrix::view::dense<const ValueType> source,
-                      matrix::Sellp<ValueType, IndexType>* result)
+                      matrix::view::sellp<ValueType, IndexType> result)
 {
-    const auto num_rows = result->get_size()[0];
-    const auto num_cols = result->get_size()[1];
+    const auto num_rows = result.size[0];
+    const auto num_cols = result.size[1];
     const auto stride = source.stride;
     const auto in_vals = as_device_type(source.values);
 
-    const auto slice_sets = result->get_const_slice_sets();
-    const auto slice_size = result->get_slice_size();
-    auto vals = as_device_type(result->get_values());
-    auto col_idxs = result->get_col_idxs();
+    const auto slice_sets = result.slice_sets;
+    const auto slice_size = result.slice_size;
+    auto vals = as_device_type(result.values);
+    auto col_idxs = result.col_idxs;
 
     exec->get_queue()->submit([&](sycl::handler& cgh) {
         cgh.parallel_for(num_rows, [=](sycl::item<1> item) {

--- a/dpcpp/matrix/sellp_kernels.dp.cpp
+++ b/dpcpp/matrix/sellp_kernels.dp.cpp
@@ -107,18 +107,16 @@ GKO_ENABLE_DEFAULT_HOST(advanced_spmv_kernel, advanced_spmv_kernel);
 
 template <typename ValueType, typename IndexType>
 void spmv(std::shared_ptr<const DpcppExecutor> exec,
-          const matrix::Sellp<ValueType, IndexType>* a,
+          matrix::view::sellp<const ValueType, const IndexType> a,
           matrix::view::dense<const ValueType> b,
           matrix::view::dense<ValueType> c)
 {
     const dim3 blockSize(default_block_size);
-    const dim3 gridSize(ceildiv(a->get_size()[0], default_block_size),
-                        b.size[1]);
+    const dim3 gridSize(ceildiv(a.size[0], default_block_size), b.size[1]);
 
-    spmv_kernel(gridSize, blockSize, 0, exec->get_queue(), a->get_size()[0],
-                b.size[1], b.stride, c.stride, a->get_slice_size(),
-                a->get_const_slice_sets(), a->get_const_values(),
-                a->get_const_col_idxs(), b.values, c.values);
+    spmv_kernel(gridSize, blockSize, 0, exec->get_queue(), a.size[0], b.size[1],
+                b.stride, c.stride, a.slice_size, a.slice_sets, a.values,
+                a.col_idxs, b.values, c.values);
 }
 
 GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(GKO_DECLARE_SELLP_SPMV_KERNEL);
@@ -127,20 +125,18 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(GKO_DECLARE_SELLP_SPMV_KERNEL);
 template <typename ValueType, typename IndexType>
 void advanced_spmv(std::shared_ptr<const DpcppExecutor> exec,
                    matrix::view::dense<const ValueType> alpha,
-                   const matrix::Sellp<ValueType, IndexType>* a,
+                   matrix::view::sellp<const ValueType, const IndexType> a,
                    matrix::view::dense<const ValueType> b,
                    matrix::view::dense<const ValueType> beta,
                    matrix::view::dense<ValueType> c)
 {
     const dim3 blockSize(default_block_size);
-    const dim3 gridSize(ceildiv(a->get_size()[0], default_block_size),
-                        b.size[1]);
+    const dim3 gridSize(ceildiv(a.size[0], default_block_size), b.size[1]);
 
-    advanced_spmv_kernel(
-        gridSize, blockSize, 0, exec->get_queue(), a->get_size()[0], b.size[1],
-        b.stride, c.stride, a->get_slice_size(), a->get_const_slice_sets(),
-        alpha.values, a->get_const_values(), a->get_const_col_idxs(), b.values,
-        beta.values, c.values);
+    advanced_spmv_kernel(gridSize, blockSize, 0, exec->get_queue(), a.size[0],
+                         b.size[1], b.stride, c.stride, a.slice_size,
+                         a.slice_sets, alpha.values, a.values, a.col_idxs,
+                         b.values, beta.values, c.values);
 }
 
 GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(

--- a/include/ginkgo/core/matrix/device_views.hpp
+++ b/include/ginkgo/core/matrix/device_views.hpp
@@ -144,6 +144,76 @@ private:
 };
 
 
+/**
+ * Non-owning view of a matrix::Sellp to be used inside device kernels.
+ * This type is used to provide a simple and stable ABI for passing data between
+ * libraries.
+ *
+ * @tparam ValueType  the value type used to store matrix values.
+ * @tparam IndexType  the index type used to store matrix columns.
+ */
+template <typename ValueType, typename IndexType>
+struct sellp {
+    dim<2> size;
+    size_type slice_size;
+    size_type stride_factor;
+    size_type total_cols;
+    ValueType* values;
+    IndexType* col_idxs;
+    static_assert(std::is_const_v<ValueType> == std::is_const_v<IndexType>,
+                  "ValueType and IndexType must share the same constness");
+    using adapt_size_type = std::conditional_t<std::is_const_v<ValueType>,
+                                               const size_type, size_type>;
+    adapt_size_type* slice_lengths;
+    adapt_size_type* slice_sets;
+
+    /** Constructs a sellp view */
+    constexpr sellp(dim<2> size, size_type slice_size, size_type stride_factor,
+                    size_type total_cols, ValueType* values,
+                    IndexType* col_idxs, adapt_size_type* slice_lengths,
+                    adapt_size_type* slice_sets)
+        : size{size},
+          slice_size{slice_size},
+          stride_factor{stride_factor},
+          total_cols{total_cols},
+          values{values},
+          col_idxs{col_idxs},
+          slice_lengths{slice_lengths},
+          slice_sets{slice_sets}
+    {}
+
+    /** Returns a const view of the same values */
+    constexpr sellp<const ValueType, const IndexType> as_const() const
+    {
+        return sellp<const ValueType, const IndexType>{
+            size,   slice_size, stride_factor, total_cols,
+            values, col_idxs,   slice_lengths, slice_sets};
+    }
+
+    /** accessing the value of the idx-th element within the given row */
+    constexpr ValueType& val_at(size_type row, size_type slice_set,
+                                size_type idx) const
+    {
+        return values[this->linearize_index(row, slice_set, idx)];
+    }
+
+    /** accessing the column index of the idx-th element within the given row */
+    constexpr IndexType& col_at(size_type row, size_type slice_set,
+                                size_type idx) const
+    {
+        return col_idxs[this->linearize_index(row, slice_set, idx)];
+    }
+
+private:
+    /** Return the index of Sellp storage */
+    constexpr size_type linearize_index(size_type row, size_type slice_set,
+                                        size_type idx) const noexcept
+    {
+        return (slice_set + idx) * slice_size + row;
+    }
+};
+
+
 }  // namespace view
 }  // namespace matrix
 }  // namespace gko

--- a/include/ginkgo/core/matrix/device_views.hpp
+++ b/include/ginkgo/core/matrix/device_views.hpp
@@ -209,6 +209,9 @@ private:
     constexpr size_type linearize_index(size_type row, size_type slice_set,
                                         size_type idx) const noexcept
     {
+        assert(row < slice_size);
+        // note the following does not catch all idx out of bound access.
+        assert(idx < total_cols);
         return (slice_set + idx) * slice_size + row;
     }
 };

--- a/include/ginkgo/core/matrix/sellp.hpp
+++ b/include/ginkgo/core/matrix/sellp.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -8,6 +8,7 @@
 
 #include <ginkgo/core/base/array.hpp>
 #include <ginkgo/core/base/lin_op.hpp>
+#include <ginkgo/core/matrix/device_views.hpp>
 
 
 namespace gko {
@@ -79,6 +80,9 @@ public:
     using mat_data = matrix_data<ValueType, IndexType>;
     using device_mat_data = device_matrix_data<ValueType, IndexType>;
     using absolute_type = remove_complex<Sellp>;
+    using device_view = matrix::view::sellp<value_type, index_type>;
+    using const_device_view =
+        matrix::view::sellp<const value_type, const index_type>;
 
     friend class Sellp<previous_precision<ValueType>, IndexType>;
 
@@ -305,6 +309,12 @@ public:
         return this
             ->get_const_col_idxs()[this->linearize_index(row, slice_set, idx)];
     }
+
+    /** get the non-owning device view */
+    device_view get_device_view();
+
+    /** get the const non-owning device view */
+    const_device_view get_const_device_view() const;
 
     /**
      * Creates an uninitialized Sellp matrix of the specified size.

--- a/include/ginkgo/core/stop/iteration.hpp
+++ b/include/ginkgo/core/stop/iteration.hpp
@@ -127,7 +127,7 @@ min_iters(size_type count, Args&&... criteria)
     std::vector<deferred_factory_parameter<const CriterionFactory>>
         criterion_vec{std::forward<Args>(criteria)...};
     return min_iters(count, Combined::build().with_criteria(criterion_vec));
-};
+}
 
 
 }  // namespace stop

--- a/omp/matrix/dense_kernels.cpp
+++ b/omp/matrix/dense_kernels.cpp
@@ -335,14 +335,14 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 template <typename ValueType, typename IndexType>
 void convert_to_sellp(std::shared_ptr<const DefaultExecutor> exec,
                       matrix::view::dense<const ValueType> source,
-                      matrix::Sellp<ValueType, IndexType>* result)
+                      matrix::view::sellp<ValueType, IndexType> result)
 {
-    const auto num_rows = result->get_size()[0];
-    const auto num_cols = result->get_size()[1];
-    const auto vals = result->get_values();
-    const auto col_idxs = result->get_col_idxs();
-    const auto slice_sets = result->get_slice_sets();
-    const auto slice_size = result->get_slice_size();
+    const auto num_rows = result.size[0];
+    const auto num_cols = result.size[1];
+    const auto vals = result.values;
+    const auto col_idxs = result.col_idxs;
+    const auto slice_sets = result.slice_sets;
+    const auto slice_size = result.slice_size;
     const auto num_slices = ceildiv(num_rows, slice_size);
 #pragma omp parallel for
     for (size_type slice = 0; slice < num_slices; slice++) {

--- a/omp/matrix/sellp_kernels.cpp
+++ b/omp/matrix/sellp_kernels.cpp
@@ -24,25 +24,25 @@ namespace sellp {
 
 template <int num_rhs, typename ValueType, typename IndexType, typename OutFn>
 void spmv_small_rhs(std::shared_ptr<const OmpExecutor> exec,
-                    const matrix::Sellp<ValueType, IndexType>* a,
+                    matrix::view::sellp<const ValueType, const IndexType> a,
                     matrix::view::dense<const ValueType> b,
                     matrix::view::dense<ValueType> c, OutFn out)
 {
     GKO_ASSERT(b.size[1] == num_rhs);
-    auto slice_lengths = a->get_const_slice_lengths();
-    auto slice_sets = a->get_const_slice_sets();
-    auto slice_size = a->get_slice_size();
-    auto slice_num = ceildiv(a->get_size()[0] + slice_size - 1, slice_size);
+    auto slice_lengths = a.slice_lengths;
+    auto slice_sets = a.slice_sets;
+    auto slice_size = a.slice_size;
+    auto slice_num = ceildiv(a.size[0] + slice_size - 1, slice_size);
 #pragma omp parallel for collapse(2)
     for (size_type slice = 0; slice < slice_num; slice++) {
         for (size_type row = 0; row < slice_size; row++) {
             size_type global_row = slice * slice_size + row;
-            if (global_row < a->get_size()[0]) {
+            if (global_row < a.size[0]) {
                 std::array<ValueType, num_rhs> partial_sum;
                 partial_sum.fill(zero<ValueType>());
                 for (size_type i = 0; i < slice_lengths[slice]; i++) {
-                    auto val = a->val_at(row, slice_sets[slice], i);
-                    auto col = a->col_at(row, slice_sets[slice], i);
+                    auto val = a.val_at(row, slice_sets[slice], i);
+                    auto col = a.col_at(row, slice_sets[slice], i);
                     if (col != invalid_index<IndexType>()) {
 #pragma unroll
                         for (size_type j = 0; j < num_rhs; j++) {
@@ -65,28 +65,28 @@ void spmv_small_rhs(std::shared_ptr<const OmpExecutor> exec,
 template <int block_size, typename ValueType, typename IndexType,
           typename OutFn>
 void spmv_blocked(std::shared_ptr<const OmpExecutor> exec,
-                  const matrix::Sellp<ValueType, IndexType>* a,
+                  matrix::view::sellp<const ValueType, const IndexType> a,
                   matrix::view::dense<const ValueType> b,
                   matrix::view::dense<ValueType> c, OutFn out)
 {
-    auto slice_lengths = a->get_const_slice_lengths();
-    auto slice_sets = a->get_const_slice_sets();
-    auto slice_size = a->get_slice_size();
-    auto slice_num = ceildiv(a->get_size()[0] + slice_size - 1, slice_size);
+    auto slice_lengths = a.slice_lengths;
+    auto slice_sets = a.slice_sets;
+    auto slice_size = a.slice_size;
+    auto slice_num = ceildiv(a.size[0] + slice_size - 1, slice_size);
     const auto num_rhs = b.size[1];
     const auto rounded_rhs = num_rhs / block_size * block_size;
 #pragma omp parallel for collapse(2)
     for (size_type slice = 0; slice < slice_num; slice++) {
         for (size_type row = 0; row < slice_size; row++) {
             size_type global_row = slice * slice_size + row;
-            if (global_row < a->get_size()[0]) {
+            if (global_row < a.size[0]) {
                 std::array<ValueType, block_size> partial_sum;
                 for (size_type rhs_base = 0; rhs_base < rounded_rhs;
                      rhs_base += block_size) {
                     partial_sum.fill(zero<ValueType>());
                     for (size_type i = 0; i < slice_lengths[slice]; i++) {
-                        auto val = a->val_at(row, slice_sets[slice], i);
-                        auto col = a->col_at(row, slice_sets[slice], i);
+                        auto val = a.val_at(row, slice_sets[slice], i);
+                        auto col = a.col_at(row, slice_sets[slice], i);
                         if (col != invalid_index<IndexType>()) {
 #pragma unroll
                             for (size_type j = 0; j < block_size; j++) {
@@ -104,8 +104,8 @@ void spmv_blocked(std::shared_ptr<const OmpExecutor> exec,
                 }
                 partial_sum.fill(zero<ValueType>());
                 for (size_type i = 0; i < slice_lengths[slice]; i++) {
-                    auto val = a->val_at(row, slice_sets[slice], i);
-                    auto col = a->col_at(row, slice_sets[slice], i);
+                    auto val = a.val_at(row, slice_sets[slice], i);
+                    auto col = a.col_at(row, slice_sets[slice], i);
                     if (col != invalid_index<IndexType>()) {
                         for (size_type j = rounded_rhs; j < num_rhs; j++) {
                             partial_sum[j - rounded_rhs] += val * b(col, j);
@@ -126,7 +126,7 @@ void spmv_blocked(std::shared_ptr<const OmpExecutor> exec,
 
 template <typename ValueType, typename IndexType>
 void spmv(std::shared_ptr<const OmpExecutor> exec,
-          const matrix::Sellp<ValueType, IndexType>* a,
+          matrix::view::sellp<const ValueType, const IndexType> a,
           matrix::view::dense<const ValueType> b,
           matrix::view::dense<ValueType> c)
 {
@@ -160,7 +160,7 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(GKO_DECLARE_SELLP_SPMV_KERNEL);
 template <typename ValueType, typename IndexType>
 void advanced_spmv(std::shared_ptr<const OmpExecutor> exec,
                    matrix::view::dense<const ValueType> alpha,
-                   const matrix::Sellp<ValueType, IndexType>* a,
+                   matrix::view::sellp<const ValueType, const IndexType> a,
                    matrix::view::dense<const ValueType> b,
                    matrix::view::dense<const ValueType> beta,
                    matrix::view::dense<ValueType> c)

--- a/reference/matrix/csr_kernels.cpp
+++ b/reference/matrix/csr_kernels.cpp
@@ -528,16 +528,16 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 template <typename ValueType, typename IndexType>
 void convert_to_sellp(std::shared_ptr<const ReferenceExecutor> exec,
                       const matrix::Csr<ValueType, IndexType>* source,
-                      matrix::Sellp<ValueType, IndexType>* result)
+                      matrix::view::sellp<ValueType, IndexType> result)
 {
-    auto num_rows = result->get_size()[0];
-    auto num_cols = result->get_size()[1];
-    auto vals = result->get_values();
-    auto col_idxs = result->get_col_idxs();
-    auto slice_lengths = result->get_slice_lengths();
-    auto slice_sets = result->get_slice_sets();
-    auto slice_size = result->get_slice_size();
-    auto stride_factor = result->get_stride_factor();
+    auto num_rows = result.size[0];
+    auto num_cols = result.size[1];
+    auto vals = result.values;
+    auto col_idxs = result.col_idxs;
+    auto slice_lengths = result.slice_lengths;
+    auto slice_sets = result.slice_sets;
+    auto slice_size = result.slice_size;
+    auto stride_factor = result.stride_factor;
 
     const auto source_row_ptrs = source->get_const_row_ptrs();
     const auto source_col_idxs = source->get_const_col_idxs();

--- a/reference/matrix/dense_kernels.cpp
+++ b/reference/matrix/dense_kernels.cpp
@@ -650,15 +650,15 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 template <typename ValueType, typename IndexType>
 void convert_to_sellp(std::shared_ptr<const ReferenceExecutor> exec,
                       matrix::view::dense<const ValueType> source,
-                      matrix::Sellp<ValueType, IndexType>* result)
+                      matrix::view::sellp<ValueType, IndexType> result)
 {
-    auto num_rows = result->get_size()[0];
-    auto num_cols = result->get_size()[1];
-    auto vals = result->get_values();
-    auto col_idxs = result->get_col_idxs();
-    auto slice_lengths = result->get_slice_lengths();
-    auto slice_sets = result->get_slice_sets();
-    auto slice_size = result->get_slice_size();
+    auto num_rows = result.size[0];
+    auto num_cols = result.size[1];
+    auto vals = result.values;
+    auto col_idxs = result.col_idxs;
+    auto slice_lengths = result.slice_lengths;
+    auto slice_sets = result.slice_sets;
+    auto slice_size = result.slice_size;
     for (size_type row = 0; row < num_rows; row++) {
         const auto slice = row / slice_size;
         const auto local_row = row % slice_size;

--- a/reference/matrix/sellp_kernels.cpp
+++ b/reference/matrix/sellp_kernels.cpp
@@ -25,27 +25,27 @@ namespace sellp {
 
 template <typename ValueType, typename IndexType>
 void spmv(std::shared_ptr<const ReferenceExecutor> exec,
-          const matrix::Sellp<ValueType, IndexType>* a,
+          matrix::view::sellp<const ValueType, const IndexType> a,
           matrix::view::dense<const ValueType> b,
           matrix::view::dense<ValueType> c)
 {
-    auto col_idxs = a->get_const_col_idxs();
-    auto slice_lengths = a->get_const_slice_lengths();
-    auto slice_sets = a->get_const_slice_sets();
-    auto slice_size = a->get_slice_size();
-    auto slice_num = ceildiv(a->get_size()[0] + slice_size - 1, slice_size);
+    auto col_idxs = a.col_idxs;
+    auto slice_lengths = a.slice_lengths;
+    auto slice_sets = a.slice_sets;
+    auto slice_size = a.slice_size;
+    auto slice_num = ceildiv(a.size[0] + slice_size - 1, slice_size);
     for (size_type slice = 0; slice < slice_num; slice++) {
         for (size_type row = 0; row < slice_size; row++) {
             size_type global_row = slice * slice_size + row;
-            if (global_row >= a->get_size()[0]) {
+            if (global_row >= a.size[0]) {
                 break;
             }
             for (size_type j = 0; j < c.size[1]; j++) {
                 c(global_row, j) = zero<ValueType>();
             }
             for (size_type i = 0; i < slice_lengths[slice]; i++) {
-                auto val = a->val_at(row, slice_sets[slice], i);
-                auto col = a->col_at(row, slice_sets[slice], i);
+                auto val = a.val_at(row, slice_sets[slice], i);
+                auto col = a.col_at(row, slice_sets[slice], i);
                 if (col != invalid_index<IndexType>()) {
                     for (size_type j = 0; j < c.size[1]; j++) {
                         c(global_row, j) += val * b(col, j);
@@ -62,23 +62,23 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(GKO_DECLARE_SELLP_SPMV_KERNEL);
 template <typename ValueType, typename IndexType>
 void advanced_spmv(std::shared_ptr<const ReferenceExecutor> exec,
                    matrix::view::dense<const ValueType> alpha,
-                   const matrix::Sellp<ValueType, IndexType>* a,
+                   matrix::view::sellp<const ValueType, const IndexType> a,
                    matrix::view::dense<const ValueType> b,
                    matrix::view::dense<const ValueType> beta,
                    matrix::view::dense<ValueType> c)
 {
-    auto vals = a->get_const_values();
-    auto col_idxs = a->get_const_col_idxs();
-    auto slice_lengths = a->get_const_slice_lengths();
-    auto slice_sets = a->get_const_slice_sets();
-    auto slice_size = a->get_slice_size();
-    auto slice_num = ceildiv(a->get_size()[0] + slice_size - 1, slice_size);
+    auto vals = a.values;
+    auto col_idxs = a.col_idxs;
+    auto slice_lengths = a.slice_lengths;
+    auto slice_sets = a.slice_sets;
+    auto slice_size = a.slice_size;
+    auto slice_num = ceildiv(a.size[0] + slice_size - 1, slice_size);
     auto valpha = alpha(0, 0);
     auto vbeta = beta(0, 0);
     for (size_type slice = 0; slice < slice_num; slice++) {
         for (size_type row = 0; row < slice_size; row++) {
             size_type global_row = slice * slice_size + row;
-            if (global_row >= a->get_size()[0]) {
+            if (global_row >= a.size[0]) {
                 break;
             }
             for (size_type j = 0; j < c.size[1]; j++) {
@@ -89,8 +89,8 @@ void advanced_spmv(std::shared_ptr<const ReferenceExecutor> exec,
                 }
             }
             for (size_type i = 0; i < slice_lengths[slice]; i++) {
-                auto val = a->val_at(row, slice_sets[slice], i);
-                auto col = a->col_at(row, slice_sets[slice], i);
+                auto val = a.val_at(row, slice_sets[slice], i);
+                auto col = a.col_at(row, slice_sets[slice], i);
                 if (col != invalid_index<IndexType>()) {
                     for (size_type j = 0; j < c.size[1]; j++) {
                         c(global_row, j) += valpha * val * b(col, j);
@@ -139,13 +139,13 @@ template <typename ValueType, typename IndexType>
 void fill_in_matrix_data(std::shared_ptr<const DefaultExecutor> exec,
                          const device_matrix_data<ValueType, IndexType>& data,
                          const int64* row_ptrs,
-                         matrix::Sellp<ValueType, IndexType>* output)
+                         matrix::view::sellp<ValueType, IndexType> output)
 {
-    const auto slice_size = output->get_slice_size();
-    const auto slice_sets = output->get_const_slice_sets();
-    const auto cols = output->get_col_idxs();
-    const auto vals = output->get_values();
-    for (size_type row = 0; row < output->get_size()[0]; row++) {
+    const auto slice_size = output.slice_size;
+    const auto slice_sets = output.slice_sets;
+    const auto cols = output.col_idxs;
+    const auto vals = output.values;
+    for (size_type row = 0; row < output.size[0]; row++) {
         const auto row_begin = row_ptrs[row];
         const auto row_end = row_ptrs[row + 1];
         const auto row_nnz = row_end - row_begin;
@@ -174,18 +174,17 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 
 template <typename ValueType, typename IndexType>
 void fill_in_dense(std::shared_ptr<const ReferenceExecutor> exec,
-                   const matrix::Sellp<ValueType, IndexType>* source,
+                   matrix::view::sellp<const ValueType, const IndexType> source,
                    matrix::view::dense<ValueType> result)
 {
-    auto num_rows = source->get_size()[0];
-    auto num_cols = source->get_size()[1];
-    auto vals = source->get_const_values();
-    auto col_idxs = source->get_const_col_idxs();
-    auto slice_lengths = source->get_const_slice_lengths();
-    auto slice_sets = source->get_const_slice_sets();
-    auto slice_size = source->get_slice_size();
-    auto slice_num =
-        ceildiv(source->get_size()[0] + slice_size - 1, slice_size);
+    auto num_rows = source.size[0];
+    auto num_cols = source.size[1];
+    auto vals = source.values;
+    auto col_idxs = source.col_idxs;
+    auto slice_lengths = source.slice_lengths;
+    auto slice_sets = source.slice_sets;
+    auto slice_size = source.slice_size;
+    auto slice_num = ceildiv(source.size[0] + slice_size - 1, slice_size);
     for (size_type slice = 0; slice < slice_num; slice++) {
         for (size_type row = 0; row < slice_size; row++) {
             size_type global_row = slice * slice_size + row;
@@ -208,18 +207,19 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 
 
 template <typename ValueType, typename IndexType>
-void count_nonzeros_per_row(std::shared_ptr<const DefaultExecutor> exec,
-                            const matrix::Sellp<ValueType, IndexType>* source,
-                            IndexType* result)
+void count_nonzeros_per_row(
+    std::shared_ptr<const DefaultExecutor> exec,
+    matrix::view::sellp<const ValueType, const IndexType> source,
+    IndexType* result)
 {
-    auto num_rows = source->get_size()[0];
-    auto slice_size = source->get_slice_size();
+    auto num_rows = source.size[0];
+    auto slice_size = source.slice_size;
     auto slice_num = ceildiv(num_rows, slice_size);
 
-    const auto vals = source->get_const_values();
-    const auto slice_lengths = source->get_const_slice_lengths();
-    const auto slice_sets = source->get_const_slice_sets();
-    const auto col_idxs = source->get_const_col_idxs();
+    const auto vals = source.values;
+    const auto slice_lengths = source.slice_lengths;
+    const auto slice_sets = source.slice_sets;
+    const auto col_idxs = source.col_idxs;
 
     for (size_type slice = 0; slice < slice_num; slice++) {
         for (size_type row = 0; row < slice_size; row++) {
@@ -244,18 +244,19 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 
 
 template <typename ValueType, typename IndexType>
-void convert_to_csr(std::shared_ptr<const ReferenceExecutor> exec,
-                    const matrix::Sellp<ValueType, IndexType>* source,
-                    matrix::Csr<ValueType, IndexType>* result)
+void convert_to_csr(
+    std::shared_ptr<const ReferenceExecutor> exec,
+    matrix::view::sellp<const ValueType, const IndexType> source,
+    matrix::Csr<ValueType, IndexType>* result)
 {
-    auto num_rows = source->get_size()[0];
-    auto slice_size = source->get_slice_size();
+    auto num_rows = source.size[0];
+    auto slice_size = source.slice_size;
     auto slice_num = ceildiv(num_rows, slice_size);
 
-    const auto source_vals = source->get_const_values();
-    const auto source_slice_lengths = source->get_const_slice_lengths();
-    const auto source_slice_sets = source->get_const_slice_sets();
-    const auto source_col_idxs = source->get_const_col_idxs();
+    const auto source_vals = source.values;
+    const auto source_slice_lengths = source.slice_lengths;
+    const auto source_slice_sets = source.slice_sets;
+    const auto source_col_idxs = source.col_idxs;
 
     auto result_vals = result->get_values();
     auto result_row_ptrs = result->get_row_ptrs();
@@ -290,18 +291,19 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 
 
 template <typename ValueType, typename IndexType>
-void extract_diagonal(std::shared_ptr<const ReferenceExecutor> exec,
-                      const matrix::Sellp<ValueType, IndexType>* orig,
-                      matrix::Diagonal<ValueType>* diag)
+void extract_diagonal(
+    std::shared_ptr<const ReferenceExecutor> exec,
+    matrix::view::sellp<const ValueType, const IndexType> orig,
+    matrix::Diagonal<ValueType>* diag)
 {
     const auto diag_size = diag->get_size()[0];
-    const auto slice_size = orig->get_slice_size();
-    const auto slice_num = ceildiv(orig->get_size()[0], slice_size);
+    const auto slice_size = orig.slice_size;
+    const auto slice_num = ceildiv(orig.size[0], slice_size);
 
-    const auto orig_values = orig->get_const_values();
-    const auto orig_slice_sets = orig->get_const_slice_sets();
-    const auto orig_slice_lengths = orig->get_const_slice_lengths();
-    const auto orig_col_idxs = orig->get_const_col_idxs();
+    const auto orig_values = orig.values;
+    const auto orig_slice_sets = orig.slice_sets;
+    const auto orig_slice_lengths = orig.slice_lengths;
+    const auto orig_col_idxs = orig.col_idxs;
     auto diag_values = diag->get_values();
 
     for (size_type slice = 0; slice < slice_num; slice++) {
@@ -311,10 +313,9 @@ void extract_diagonal(std::shared_ptr<const ReferenceExecutor> exec,
                 break;
             }
             for (size_type i = 0; i < orig_slice_lengths[slice]; i++) {
-                if (orig->col_at(row, orig_slice_sets[slice], i) ==
-                    global_row) {
+                if (orig.col_at(row, orig_slice_sets[slice], i) == global_row) {
                     diag_values[global_row] =
-                        orig->val_at(row, orig_slice_sets[slice], i);
+                        orig.val_at(row, orig_slice_sets[slice], i);
                     break;
                 }
             }

--- a/test/matrix/device_views.cpp
+++ b/test/matrix/device_views.cpp
@@ -130,17 +130,16 @@ void assert_ell_view(std::shared_ptr<const gko::EXEC_TYPE> exec)
             gko::matrix::view::ell<device_type, IndexType> view{
                 gko::dim<2>{2, 3}, 2, 3, values, col_idxs};
             if (view.size == gko::dim<2>(2, 3) &&
-                    view.num_stored_elements_per_row == 2,
-                view.stride == 3 && view.values == values &&
-                    view.col_idxs == col_idxs &&
-                    &view.val_at(0, 0) == &values[0] &&
-                    &view.val_at(1, 0) == &values[1] &&
-                    &view.val_at(1, 1) == &values[4] &&
-                    view.val_at(1, 1) == gko::one<device_type>() &&
-                    &view.col_at(0, 0) == &col_idxs[0] &&
-                    &view.col_at(1, 0) == &col_idxs[1] &&
-                    &view.col_at(1, 1) == &col_idxs[4] &&
-                    view.col_at(1, 1) == gko::zero<IndexType>()) {
+                view.num_stored_elements_per_row == 2 && view.stride == 3 &&
+                view.values == values && view.col_idxs == col_idxs &&
+                &view.val_at(0, 0) == &values[0] &&
+                &view.val_at(1, 0) == &values[1] &&
+                &view.val_at(1, 1) == &values[4] &&
+                view.val_at(1, 1) == gko::one<device_type>() &&
+                &view.col_at(0, 0) == &col_idxs[0] &&
+                &view.col_at(1, 0) == &col_idxs[1] &&
+                &view.col_at(1, 1) == &col_idxs[4] &&
+                view.col_at(1, 1) == gko::zero<IndexType>()) {
                 *correct = true;
             }
         },
@@ -148,9 +147,76 @@ void assert_ell_view(std::shared_ptr<const gko::EXEC_TYPE> exec)
     ASSERT_TRUE(get_element(correct, 0));
 }
 
+
 TYPED_TEST(EllView, WorksOnDevice)
 {
     using value_type = typename TestFixture::value_type;
     using index_type = typename TestFixture::index_type;
     assert_ell_view<value_type, index_type>(this->exec);
+}
+
+
+template <typename ValueIndexType>
+class SellpView : public CommonTestFixture {
+public:
+    using value_type =
+        typename std::tuple_element<0, decltype(ValueIndexType())>::type;
+    using index_type =
+        typename std::tuple_element<1, decltype(ValueIndexType())>::type;
+};
+
+TYPED_TEST_SUITE(SellpView, gko::test::ValueIndexTypes,
+                 PairTypenameNameGenerator);
+
+
+template <typename ValueType, typename IndexType>
+void assert_sellp_view(std::shared_ptr<const gko::EXEC_TYPE> exec)
+{
+    gko::array<bool> correct{exec, {false}};
+    gko::array<ValueType> values{exec, 21};
+    gko::array<IndexType> col_idxs{exec, 21};
+    gko::array<gko::size_type> slice_lengths{exec, {3, 4}};
+    gko::array<gko::size_type> slice_sets{exec, {0, 3, 7}};
+    values.fill(gko::one<ValueType>());
+    col_idxs.fill(gko::zero<IndexType>());
+    gko::kernels::GKO_DEVICE_NAMESPACE::run_kernel(
+        exec,
+        [] GKO_KERNEL(auto i, auto values, auto col_idxs, auto slice_lengths,
+                      auto slice_sets, auto correct) {
+            using device_type = std::decay_t<decltype(values[0])>;
+            gko::matrix::view::sellp<device_type, IndexType> view{
+                gko::dim<2>{3, 5}, 2,         3, 7, values, col_idxs,
+                slice_lengths,     slice_sets};
+            if (view.size == gko::dim<2>(3, 5) && view.slice_size == 2 &&
+                view.stride_factor == 3 && view.total_cols == 7 &&
+                view.values == values && view.col_idxs == col_idxs &&
+                view.slice_lengths == slice_lengths &&
+                view.slice_sets == slice_sets &&
+                &view.val_at(0, slice_sets[0], 0) == &values[0] &&
+                &view.val_at(1, slice_sets[0], 0) == &values[1] &&
+                &view.val_at(1, slice_sets[0], 1) == &values[3] &&
+                &view.val_at(0, slice_sets[1], 0) == &values[6] &&
+                &view.val_at(1, slice_sets[1], 0) == &values[7] &&
+                &view.val_at(1, slice_sets[1], 1) == &values[9] &&
+                view.val_at(1, slice_sets[1], 1) == gko::one<device_type>() &&
+                &view.col_at(0, slice_sets[0], 0) == &col_idxs[0] &&
+                &view.col_at(1, slice_sets[0], 0) == &col_idxs[1] &&
+                &view.col_at(1, slice_sets[0], 1) == &col_idxs[3] &&
+                &view.col_at(0, slice_sets[1], 0) == &col_idxs[6] &&
+                &view.col_at(1, slice_sets[1], 0) == &col_idxs[7] &&
+                &view.col_at(1, slice_sets[1], 1) == &col_idxs[9] &&
+                view.col_at(1, slice_sets[1], 1) == gko::zero<IndexType>()) {
+                *correct = true;
+            }
+        },
+        1, values, col_idxs, slice_lengths, slice_sets, correct);
+    ASSERT_TRUE(get_element(correct, 0));
+}
+
+
+TYPED_TEST(SellpView, WorksOnDevice)
+{
+    using value_type = typename TestFixture::value_type;
+    using index_type = typename TestFixture::index_type;
+    assert_sellp_view<value_type, index_type>(this->exec);
 }


### PR DESCRIPTION
It adds SELLp device view and adapt it in corresponding kernels.

Any feedback:
- [x] figure out assert check
- [ ] stride_factor is only used when generate new matrix. When slice_sets is given, there is no re-computation from stride_factor.
- [ ] size_type const aware typename?