### PR TITLE
Use GenericDenseCache to manage workspace

### DIFF
--- a/core/distributed/row_gatherer.cpp
+++ b/core/distributed/row_gatherer.cpp
@@ -30,13 +30,14 @@ template <typename LocalIndexType>
 mpi::request RowGatherer<LocalIndexType>::apply_async(ptr_param<const LinOp> b,
                                                       ptr_param<LinOp> x) const
 {
-    return apply_async(b, x, send_workspace_);
+    return apply_async(b, x, send_cache_);
 }
 
 
 template <typename LocalIndexType>
 mpi::request RowGatherer<LocalIndexType>::apply_async(
-    ptr_param<const LinOp> b, ptr_param<LinOp> x, array<char>& workspace) const
+    ptr_param<const LinOp> b, ptr_param<LinOp> x,
+    gko::detail::GenericDenseCache& workspace) const
 {
     auto ev = this->apply_prepare(b, workspace);
     return this->apply_finalize(b, x, ev, workspace);
@@ -46,13 +47,13 @@ template <typename LocalIndexType>
 std::shared_ptr<const gko::detail::Event>
 RowGatherer<LocalIndexType>::apply_prepare(ptr_param<const LinOp> b) const
 {
-    return apply_prepare(b, send_workspace_);
+    return apply_prepare(b, send_cache_);
 }
 
 template <typename LocalIndexType>
 std::shared_ptr<const gko::detail::Event>
-RowGatherer<LocalIndexType>::apply_prepare(ptr_param<const LinOp> b,
-                                           array<char>& workspace) const
+RowGatherer<LocalIndexType>::apply_prepare(
+    ptr_param<const LinOp> b, gko::detail::GenericDenseCache& workspace) const
 {
     std::shared_ptr<const gko::detail::Event> ev = nullptr;
     auto exec = this->get_executor();
@@ -79,24 +80,8 @@ RowGatherer<LocalIndexType>::apply_prepare(ptr_param<const LinOp> b,
 
                 dim<2> send_size(coll_comm_->get_send_size(),
                                  b_local->get_size()[1]);
-                auto send_size_in_bytes =
-                    sizeof(ValueType) * send_size[0] * send_size[1];
-                // TODO: can not combine them to assignment because array
-                // assignment will copy the data to the place without
-                // changing executor.
-                if (!workspace.get_executor() ||
-                    !mpi_exec->memory_accessible(workspace.get_executor())) {
-                    workspace.set_executor(mpi_exec);
-                }
-                if (send_size_in_bytes > workspace.get_size()) {
-                    workspace.resize_and_reset(send_size_in_bytes);
-                }
-                auto send_buffer = matrix::Dense<ValueType>::create(
-                    mpi_exec, send_size,
-                    make_array_view(
-                        mpi_exec, send_size[0] * send_size[1],
-                        reinterpret_cast<ValueType*>(workspace.get_data())),
-                    send_size[1]);
+                auto send_buffer =
+                    workspace.get<ValueType>(mpi_exec, send_size);
                 b_local->row_gather(&send_idxs_, send_buffer);
                 b_local->get_executor()->run(event::make_record_event(ev));
             });
@@ -110,14 +95,15 @@ mpi::request RowGatherer<LocalIndexType>::apply_finalize(
     ptr_param<const LinOp> b, ptr_param<LinOp> x,
     std::shared_ptr<const gko::detail::Event> ev) const
 {
-    auto req = apply_finalize(b, x, ev, send_workspace_);
+    auto req = apply_finalize(b, x, ev, send_cache_);
     return req;
 }
 
 template <typename LocalIndexType>
 mpi::request RowGatherer<LocalIndexType>::apply_finalize(
     ptr_param<const LinOp> b, ptr_param<LinOp> x,
-    std::shared_ptr<const gko::detail::Event> ev, array<char>& workspace) const
+    std::shared_ptr<const gko::detail::Event> ev,
+    gko::detail::GenericDenseCache& workspace) const
 {
     mpi::request req;
 
@@ -153,12 +139,8 @@ mpi::request RowGatherer<LocalIndexType>::apply_finalize(
 
                     dim<2> send_size(coll_comm_->get_send_size(),
                                      b_local->get_size()[1]);
-                    auto send_buffer = matrix::Dense<ValueType>::create(
-                        mpi_exec, send_size,
-                        make_array_view(
-                            mpi_exec, send_size[0] * send_size[1],
-                            reinterpret_cast<ValueType*>(workspace.get_data())),
-                        send_size[1]);
+                    auto send_buffer =
+                        workspace.get<ValueType>(mpi_exec, send_size);
 
                     auto recv_ptr = x_global->get_local_values();
                     auto send_ptr = send_buffer->get_values();
@@ -189,7 +171,7 @@ std::shared_ptr<const gko::detail::Event> apply_prepare(
 template <typename LocalIndexType>
 std::shared_ptr<const gko::detail::Event> apply_prepare(
     const RowGatherer<LocalIndexType>* rg, ptr_param<const LinOp> b,
-    array<char>& workspace)
+    gko::detail::GenericDenseCache& workspace)
 {
     return rg->apply_prepare(b, workspace);
 }
@@ -208,7 +190,7 @@ template <typename LocalIndexType>
 mpi::request apply_finalize(const RowGatherer<LocalIndexType>* rg,
                             ptr_param<const LinOp> b, ptr_param<LinOp> x,
                             std::shared_ptr<const gko::detail::Event> ev,
-                            array<char>& workspace)
+                            gko::detail::GenericDenseCache& workspace)
 {
     return rg->apply_finalize(b, x, ev, workspace);
 }
@@ -218,9 +200,10 @@ mpi::request apply_finalize(const RowGatherer<LocalIndexType>* rg,
     std::shared_ptr<const gko::detail::Event> apply_prepare( \
         const RowGatherer<IndexType>*, ptr_param<const LinOp>)
 
-#define GKO_DECLARE_TEST_APPLY_PREPARE_WORKSPACE(IndexType)  \
-    std::shared_ptr<const gko::detail::Event> apply_prepare( \
-        const RowGatherer<IndexType>*, ptr_param<const LinOp>, array<char>&)
+#define GKO_DECLARE_TEST_APPLY_PREPARE_WORKSPACE(IndexType)    \
+    std::shared_ptr<const gko::detail::Event> apply_prepare(   \
+        const RowGatherer<IndexType>*, ptr_param<const LinOp>, \
+        gko::detail::GenericDenseCache&)
 
 #define GKO_DECLARE_TEST_APPLY_FINALIZE(IndexType)                            \
     mpi::request apply_finalize(const RowGatherer<IndexType>* rg,             \
@@ -231,7 +214,7 @@ mpi::request apply_finalize(const RowGatherer<LocalIndexType>* rg,
     mpi::request apply_finalize(const RowGatherer<IndexType>* rg,             \
                                 ptr_param<const LinOp> b, ptr_param<LinOp> x, \
                                 std::shared_ptr<const gko::detail::Event> ev, \
-                                array<char>&)
+                                gko::detail::GenericDenseCache&)
 
 GKO_INSTANTIATE_FOR_EACH_INDEX_TYPE(GKO_DECLARE_TEST_APPLY_PREPARE);
 GKO_INSTANTIATE_FOR_EACH_INDEX_TYPE(GKO_DECLARE_TEST_APPLY_PREPARE_WORKSPACE);
@@ -285,7 +268,7 @@ RowGatherer<LocalIndexType>::RowGatherer(
                    imap.get_global_size()}),
       coll_comm_(std::move(coll_comm)),
       send_idxs_(exec),
-      send_workspace_(exec)
+      send_cache_()
 {
     // check that the coll_comm_ and imap have the same recv size
     // the same check for the send size is not possible, since the
@@ -365,8 +348,7 @@ RowGatherer<LocalIndexType>::RowGatherer(
     : EnablePolymorphicObject<RowGatherer>(exec),
       DistributedBase(coll_comm_template->get_base_communicator()),
       coll_comm_(std::move(coll_comm_template)),
-      send_idxs_(exec),
-      send_workspace_(exec)
+      send_idxs_(exec)
 {}
 
 
@@ -374,8 +356,7 @@ template <typename LocalIndexType>
 RowGatherer<LocalIndexType>::RowGatherer(RowGatherer&& o) noexcept
     : EnablePolymorphicObject<RowGatherer>(o.get_executor()),
       DistributedBase(o.get_communicator()),
-      send_idxs_(o.get_executor()),
-      send_workspace_(o.get_executor())
+      send_idxs_(o.get_executor())
 {
     *this = std::move(o);
 }
@@ -404,7 +385,6 @@ RowGatherer<LocalIndexType>& RowGatherer<LocalIndexType>::operator=(
             o.coll_comm_, mpi::detail::create_default_collective_communicator(
                               o.get_communicator()));
         send_idxs_ = std::move(o.send_idxs_);
-        send_workspace_ = std::move(o.send_workspace_);
     }
     return *this;
 }

--- a/include/ginkgo/core/distributed/row_gatherer.hpp
+++ b/include/ginkgo/core/distributed/row_gatherer.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -42,7 +42,7 @@ std::shared_ptr<const gko::detail::Event> apply_prepare(
 template <typename LocalIndexType>
 std::shared_ptr<const gko::detail::Event> apply_prepare(
     const RowGatherer<LocalIndexType>* rg, ptr_param<const LinOp> b,
-    array<char>& workspace);
+    gko::detail::GenericDenseCache& workspace);
 
 // give access to test function on protected function
 template <typename LocalIndexType>
@@ -55,7 +55,7 @@ template <typename LocalIndexType>
 mpi::request apply_finalize(const RowGatherer<LocalIndexType>* rg,
                             ptr_param<const LinOp> b, ptr_param<LinOp> x,
                             std::shared_ptr<const gko::detail::Event>,
-                            array<char>& workspace);
+                            gko::detail::GenericDenseCache& workspace);
 
 
 }  // namespace detail
@@ -99,16 +99,16 @@ class RowGatherer final
     friend std::shared_ptr<const gko::detail::Event>
     detail::apply_prepare<LocalIndexType>(const RowGatherer* rg,
                                           ptr_param<const LinOp> b);
-    friend std::shared_ptr<const gko::detail::Event>
-    detail::apply_prepare<LocalIndexType>(const RowGatherer* rg,
-                                          ptr_param<const LinOp> b,
-                                          array<char>& workspace);
+    friend std::shared_ptr<const gko::detail::Event> detail::apply_prepare<
+        LocalIndexType>(const RowGatherer* rg, ptr_param<const LinOp> b,
+                        gko::detail::GenericDenseCache& workspace);
     friend mpi::request detail::apply_finalize<LocalIndexType>(
         const RowGatherer* rg, ptr_param<const LinOp> b, ptr_param<LinOp> x,
         std::shared_ptr<const gko::detail::Event>);
     friend mpi::request detail::apply_finalize<LocalIndexType>(
         const RowGatherer* rg, ptr_param<const LinOp> b, ptr_param<LinOp> x,
-        std::shared_ptr<const gko::detail::Event>, array<char>& workspace);
+        std::shared_ptr<const gko::detail::Event>,
+        gko::detail::GenericDenseCache& workspace);
 
 public:
     /**
@@ -147,9 +147,9 @@ public:
      * @return  a mpi::request for this task. The task is guaranteed to
      *          be completed only after `.wait()` has been called on it.
      */
-    [[nodiscard]] mpi::request apply_async(ptr_param<const LinOp> b,
-                                           ptr_param<LinOp> x,
-                                           array<char>& workspace) const;
+    [[nodiscard]] mpi::request apply_async(
+        ptr_param<const LinOp> b, ptr_param<LinOp> x,
+        gko::detail::GenericDenseCache& workspace) const;
 
     /**
      * Returns the size of the row gatherer.
@@ -243,15 +243,17 @@ protected:
         ptr_param<const LinOp> b) const;
 
     std::shared_ptr<const gko::detail::Event> apply_prepare(
-        ptr_param<const LinOp> b, array<char>& workspace) const;
+        ptr_param<const LinOp> b,
+        gko::detail::GenericDenseCache& workspace) const;
 
     mpi::request apply_finalize(
         ptr_param<const LinOp> b, ptr_param<LinOp> x,
         std::shared_ptr<const gko::detail::Event>) const;
 
-    mpi::request apply_finalize(ptr_param<const LinOp> b, ptr_param<LinOp> x,
-                                std::shared_ptr<const gko::detail::Event>,
-                                array<char>& workspace) const;
+    mpi::request apply_finalize(
+        ptr_param<const LinOp> b, ptr_param<LinOp> x,
+        std::shared_ptr<const gko::detail::Event>,
+        gko::detail::GenericDenseCache& workspace) const;
 
 private:
     /**
@@ -281,7 +283,7 @@ private:
     dim<2> size_;
     std::shared_ptr<const mpi::CollectiveCommunicator> coll_comm_;
     array<LocalIndexType> send_idxs_;
-    mutable array<char> send_workspace_;
+    mutable gko::detail::GenericDenseCache send_cache_;
 };
 
 

--- a/test/mpi/distributed/row_gatherer.cpp
+++ b/test/mpi/distributed/row_gatherer.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -142,7 +142,7 @@ TYPED_TEST(RowGatherer, CanApplyAsyncWithWorkspace)
     auto x = Vector::create(this->mpi_exec, this->comm,
                             gko::dim<2>{this->rg->get_size()[0], 1},
                             gko::dim<2>{expected.get_size(), 1});
-    gko::array<char> workspace;
+    gko::detail::GenericDenseCache workspace;
 
     auto req = this->rg->apply_async(b, x, workspace);
     req.wait();
@@ -153,7 +153,6 @@ TYPED_TEST(RowGatherer, CanApplyAsyncWithWorkspace)
                       expected, 1));
     GKO_ASSERT_MTX_NEAR(x->get_local_vector(), expected_vec->get_local_vector(),
                         0.0);
-    ASSERT_GT(workspace.get_size(), 0);
 }
 
 
@@ -173,8 +172,8 @@ TYPED_TEST(RowGatherer, CanApplyAsyncMultipleTimesWithWorkspace)
                              gko::dim<2>{this->rg->get_size()[0], 1},
                              gko::dim<2>{expected.get_size(), 1});
     auto x2 = gko::clone(x1);
-    gko::array<char> workspace1;
-    gko::array<char> workspace2;
+    gko::detail::GenericDenseCache workspace1;
+    gko::detail::GenericDenseCache workspace2;
 
     auto req1 = this->rg->apply_async(b1, x1, workspace1);
     auto req2 = this->rg->apply_async(b2, x2, workspace2);
@@ -299,7 +298,7 @@ TYPED_TEST(RowGatherer, CanApplyAsyncWithEventAndWorkspace)
     auto x = Vector::create(this->mpi_exec, this->comm,
                             gko::dim<2>{this->rg->get_size()[0], 1},
                             gko::dim<2>{expected.get_size(), 1});
-    gko::array<char> workspace;
+    gko::detail::GenericDenseCache workspace;
 
     auto ev = apply_prepare(this->rg.get(), b, workspace);
     auto req = apply_finalize(this->rg.get(), b, x, ev, workspace);
@@ -311,7 +310,6 @@ TYPED_TEST(RowGatherer, CanApplyAsyncWithEventAndWorkspace)
                       expected, 1));
     GKO_ASSERT_MTX_NEAR(x->get_local_vector(), expected_vec->get_local_vector(),
                         0.0);
-    ASSERT_GT(workspace.get_size(), 0);
 }
 
 
@@ -331,8 +329,8 @@ TYPED_TEST(RowGatherer, CanApplyAsyncMultipleTimesWithEventAndWorkspace)
                              gko::dim<2>{this->rg->get_size()[0], 1},
                              gko::dim<2>{expected.get_size(), 1});
     auto x2 = gko::clone(x1);
-    gko::array<char> workspace1;
-    gko::array<char> workspace2;
+    gko::detail::GenericDenseCache workspace1;
+    gko::detail::GenericDenseCache workspace2;
 
     auto ev1 = apply_prepare(this->rg.get(), b1, workspace1);
     auto ev2 = apply_prepare(this->rg.get(), b2, workspace2);
@@ -354,9 +352,7 @@ TYPED_TEST(RowGatherer, CanApplyAsyncMultipleTimesWithEventAndWorkspace)
 }
 
 
-TYPED_TEST(
-    RowGatherer,
-    CanApplyAsyncWithEventAndWorkspaceEnsuringPrepareAndFinalizeSeparately)
+TYPED_TEST(RowGatherer, CanOverwriteWorkspaceBetweenPrepareAndFinalize)
 {
     using Dense = gko::matrix::Dense<double>;
     using Vector = gko::experimental::distributed::Vector<double>;
@@ -372,11 +368,15 @@ TYPED_TEST(
     auto x = Vector::create(this->mpi_exec, this->comm,
                             gko::dim<2>{this->rg->get_size()[0], 1},
                             gko::dim<2>{expected.get_size(), 1});
-    gko::array<char> workspace;
+    gko::detail::GenericDenseCache workspace;
 
     auto ev = apply_prepare(this->rg.get(), b, workspace);
-    // we modify the workspace to all 0
-    workspace.fill(static_cast<char>(0));
+    workspace
+        .get<double>(
+            this->rg->get_executor(),
+            gko::dim<2>(
+                this->rg->get_collective_communicator()->get_send_size(), 1))
+        ->fill(0.0);
     this->exec->synchronize();
     auto req = apply_finalize(this->rg.get(), b, x, ev, workspace);
     req.wait();

--- a/test/mpi/distributed/row_gatherer.cpp
+++ b/test/mpi/distributed/row_gatherer.cpp
@@ -352,45 +352,6 @@ TYPED_TEST(RowGatherer, CanApplyAsyncMultipleTimesWithEventAndWorkspace)
 }
 
 
-TYPED_TEST(RowGatherer, CanOverwriteWorkspaceBetweenPrepareAndFinalize)
-{
-    using Dense = gko::matrix::Dense<double>;
-    using Vector = gko::experimental::distributed::Vector<double>;
-    int rank = this->comm.rank();
-    auto offset = static_cast<double>(rank * 3);
-    auto b = Vector::create(
-        this->exec, this->comm, gko::dim<2>{18, 1},
-        gko::initialize<Dense>({offset, offset + 1, offset + 2}, this->exec));
-    auto expected = this->template create_recv_connections<double>()[rank];
-    auto modified_expected =
-        gko::array<double>(expected.get_executor(), expected.get_size());
-    modified_expected.fill(0.0);
-    auto x = Vector::create(this->mpi_exec, this->comm,
-                            gko::dim<2>{this->rg->get_size()[0], 1},
-                            gko::dim<2>{expected.get_size(), 1});
-    gko::detail::GenericDenseCache workspace;
-
-    auto ev = apply_prepare(this->rg.get(), b, workspace);
-    workspace
-        .get<double>(
-            this->rg->get_executor(),
-            gko::dim<2>(
-                this->rg->get_collective_communicator()->get_send_size(), 1))
-        ->fill(0.0);
-    this->exec->synchronize();
-    auto req = apply_finalize(this->rg.get(), b, x, ev, workspace);
-    req.wait();
-
-    auto expected_vec = Vector::create(
-        this->mpi_exec, this->comm, gko::dim<2>{this->rg->get_size()[0], 1},
-        Dense::create(this->mpi_exec,
-                      gko::dim<2>{modified_expected.get_size(), 1},
-                      modified_expected, 1));
-    GKO_ASSERT_MTX_NEAR(x->get_local_vector(), expected_vec->get_local_vector(),
-                        0.0);
-}
-
-
 TYPED_TEST(RowGatherer, ThrowsOnNonMatchingExecutor)
 {
     if (this->mpi_exec == this->exec) {


### PR DESCRIPTION
This PR replaces the `array<char>` workspace in the distributed `RowGatherer` with a `GenericDenseCache`. This simplifies the allocation and resizing of the workspace.
Small issue: the public interface uses a `gko::detail` type. I think this is fine, since one can argue that this interface is more advanced.