### PR TITLE
Remove chain apply ability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ git log --first-parent
 ## Unreleased
 
 Please visit our wiki [Changelog](https://github.com/ginkgo-project/ginkgo/wiki/Changelog) for unreleased changes.
+Interface break and suggested change for 2.0 is under [Interface Change 2.0](./INTERFACE_CHANGE.2.md)
 
 ## Version 1.11.0
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.16)
 project(
     Ginkgo
     LANGUAGES CXX
-    VERSION 1.12.0
+    VERSION 2.0.0
     DESCRIPTION
         "A numerical linear algebra library targeting many-core architectures"
 )

--- a/INTERFACE_CHANGE.2.md
+++ b/INTERFACE_CHANGE.2.md
@@ -1,8 +1,12 @@
 This file collects the interface break introduced by Ginkgo 2.0
 If we still support the same function in different way, we will provide how to change the usage.
 
-# Unsupported Interface
-## LinOp chain apply
-`LinOp->apply(b1, x1)->apply(b2, x2);` is not supported. We also drop this chain support for other kinds of apply such as `Coo->apply2(b, x)`, `LinOp->apply(alpha, b, beta, x)`.  
-To be clear, we only drop the chain behavior not LinOp apply itself. i.e. LinOp apply is still supported
+# Removed Interface
+## LinOp chain apply [#2001](https://github.com/ginkgo-project/ginkgo/pull/2001)
+`LinOp->apply(b1, x1)->apply(b2, x2);` is not supported. We also drop this chain support for other kinds of apply such as `Coo->apply2(b, x)`, `LinOp->apply(alpha, b, beta, x)`, and `BatchLinOp->apply(b, x)`.  
+To be clear, we only drop the chain behavior not LinOp apply itself. i.e. LinOp apply is still supported like the following
+```
+LinOp->apply(b1, x1);
+LinOp->apply(b2, x2);
+```
 # Changed Interface

--- a/INTERFACE_CHANGE.2.md
+++ b/INTERFACE_CHANGE.2.md
@@ -1,0 +1,8 @@
+This file collects the interface break introduced by Ginkgo 2.0
+If we still support the same function in different way, we will provide how to change the usage.
+
+# Unsupported Interface
+## LinOp chain apply
+`LinOp->apply(b1, x1)->apply(b2, x2);` is not supported. We also drop this chain support for other kinds of apply such as `Coo->apply2(b, x)`, `LinOp->apply(alpha, b, beta, x)`.  
+To be clear, we only drop the chain behavior not LinOp apply itself. i.e. LinOp apply is still supported
+# Changed Interface

--- a/core/matrix/batch_csr.cpp
+++ b/core/matrix/batch_csr.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -124,33 +124,29 @@ Csr<ValueType, IndexType>::Csr(std::shared_ptr<const Executor> exec,
 
 
 template <typename ValueType, typename IndexType>
-Csr<ValueType, IndexType>* Csr<ValueType, IndexType>::apply(
-    ptr_param<const MultiVector<ValueType>> b,
-    ptr_param<MultiVector<ValueType>> x)
+void Csr<ValueType, IndexType>::apply(ptr_param<const MultiVector<ValueType>> b,
+                                      ptr_param<MultiVector<ValueType>> x)
 {
     this->validate_application_parameters(b.get(), x.get());
     auto exec = this->get_executor();
     this->apply_impl(make_temporary_clone(exec, b).get(),
                      make_temporary_clone(exec, x).get());
-    return this;
 }
 
 
 template <typename ValueType, typename IndexType>
-const Csr<ValueType, IndexType>* Csr<ValueType, IndexType>::apply(
-    ptr_param<const MultiVector<ValueType>> b,
-    ptr_param<MultiVector<ValueType>> x) const
+void Csr<ValueType, IndexType>::apply(ptr_param<const MultiVector<ValueType>> b,
+                                      ptr_param<MultiVector<ValueType>> x) const
 {
     this->validate_application_parameters(b.get(), x.get());
     auto exec = this->get_executor();
     this->apply_impl(make_temporary_clone(exec, b).get(),
                      make_temporary_clone(exec, x).get());
-    return this;
 }
 
 
 template <typename ValueType, typename IndexType>
-Csr<ValueType, IndexType>* Csr<ValueType, IndexType>::apply(
+void Csr<ValueType, IndexType>::apply(
     ptr_param<const MultiVector<ValueType>> alpha,
     ptr_param<const MultiVector<ValueType>> b,
     ptr_param<const MultiVector<ValueType>> beta,
@@ -163,12 +159,11 @@ Csr<ValueType, IndexType>* Csr<ValueType, IndexType>::apply(
                      make_temporary_clone(exec, b).get(),
                      make_temporary_clone(exec, beta).get(),
                      make_temporary_clone(exec, x).get());
-    return this;
 }
 
 
 template <typename ValueType, typename IndexType>
-const Csr<ValueType, IndexType>* Csr<ValueType, IndexType>::apply(
+void Csr<ValueType, IndexType>::apply(
     ptr_param<const MultiVector<ValueType>> alpha,
     ptr_param<const MultiVector<ValueType>> b,
     ptr_param<const MultiVector<ValueType>> beta,
@@ -181,7 +176,6 @@ const Csr<ValueType, IndexType>* Csr<ValueType, IndexType>::apply(
                      make_temporary_clone(exec, b).get(),
                      make_temporary_clone(exec, beta).get(),
                      make_temporary_clone(exec, x).get());
-    return this;
 }
 
 

--- a/core/matrix/batch_dense.cpp
+++ b/core/matrix/batch_dense.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -118,37 +118,32 @@ Dense<ValueType>::Dense(std::shared_ptr<const Executor> exec,
 
 
 template <typename ValueType>
-Dense<ValueType>* Dense<ValueType>::apply(
-    ptr_param<const MultiVector<ValueType>> b,
-    ptr_param<MultiVector<ValueType>> x)
+void Dense<ValueType>::apply(ptr_param<const MultiVector<ValueType>> b,
+                             ptr_param<MultiVector<ValueType>> x)
 {
     this->validate_application_parameters(b.get(), x.get());
     auto exec = this->get_executor();
     this->apply_impl(make_temporary_clone(exec, b).get(),
                      make_temporary_clone(exec, x).get());
-    return this;
 }
 
 
 template <typename ValueType>
-const Dense<ValueType>* Dense<ValueType>::apply(
-    ptr_param<const MultiVector<ValueType>> b,
-    ptr_param<MultiVector<ValueType>> x) const
+void Dense<ValueType>::apply(ptr_param<const MultiVector<ValueType>> b,
+                             ptr_param<MultiVector<ValueType>> x) const
 {
     this->validate_application_parameters(b.get(), x.get());
     auto exec = this->get_executor();
     this->apply_impl(make_temporary_clone(exec, b).get(),
                      make_temporary_clone(exec, x).get());
-    return this;
 }
 
 
 template <typename ValueType>
-Dense<ValueType>* Dense<ValueType>::apply(
-    ptr_param<const MultiVector<ValueType>> alpha,
-    ptr_param<const MultiVector<ValueType>> b,
-    ptr_param<const MultiVector<ValueType>> beta,
-    ptr_param<MultiVector<ValueType>> x)
+void Dense<ValueType>::apply(ptr_param<const MultiVector<ValueType>> alpha,
+                             ptr_param<const MultiVector<ValueType>> b,
+                             ptr_param<const MultiVector<ValueType>> beta,
+                             ptr_param<MultiVector<ValueType>> x)
 {
     this->validate_application_parameters(alpha.get(), b.get(), beta.get(),
                                           x.get());
@@ -157,16 +152,14 @@ Dense<ValueType>* Dense<ValueType>::apply(
                      make_temporary_clone(exec, b).get(),
                      make_temporary_clone(exec, beta).get(),
                      make_temporary_clone(exec, x).get());
-    return this;
 }
 
 
 template <typename ValueType>
-const Dense<ValueType>* Dense<ValueType>::apply(
-    ptr_param<const MultiVector<ValueType>> alpha,
-    ptr_param<const MultiVector<ValueType>> b,
-    ptr_param<const MultiVector<ValueType>> beta,
-    ptr_param<MultiVector<ValueType>> x) const
+void Dense<ValueType>::apply(ptr_param<const MultiVector<ValueType>> alpha,
+                             ptr_param<const MultiVector<ValueType>> b,
+                             ptr_param<const MultiVector<ValueType>> beta,
+                             ptr_param<MultiVector<ValueType>> x) const
 {
     this->validate_application_parameters(alpha.get(), b.get(), beta.get(),
                                           x.get());
@@ -175,7 +168,6 @@ const Dense<ValueType>* Dense<ValueType>::apply(
                      make_temporary_clone(exec, b).get(),
                      make_temporary_clone(exec, beta).get(),
                      make_temporary_clone(exec, x).get());
-    return this;
 }
 
 

--- a/core/matrix/batch_ell.cpp
+++ b/core/matrix/batch_ell.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -143,33 +143,29 @@ Ell<ValueType, IndexType>::Ell(std::shared_ptr<const Executor> exec,
 
 
 template <typename ValueType, typename IndexType>
-Ell<ValueType, IndexType>* Ell<ValueType, IndexType>::apply(
-    ptr_param<const MultiVector<ValueType>> b,
-    ptr_param<MultiVector<ValueType>> x)
+void Ell<ValueType, IndexType>::apply(ptr_param<const MultiVector<ValueType>> b,
+                                      ptr_param<MultiVector<ValueType>> x)
 {
     this->validate_application_parameters(b.get(), x.get());
     auto exec = this->get_executor();
     this->apply_impl(make_temporary_clone(exec, b).get(),
                      make_temporary_clone(exec, x).get());
-    return this;
 }
 
 
 template <typename ValueType, typename IndexType>
-const Ell<ValueType, IndexType>* Ell<ValueType, IndexType>::apply(
-    ptr_param<const MultiVector<ValueType>> b,
-    ptr_param<MultiVector<ValueType>> x) const
+void Ell<ValueType, IndexType>::apply(ptr_param<const MultiVector<ValueType>> b,
+                                      ptr_param<MultiVector<ValueType>> x) const
 {
     this->validate_application_parameters(b.get(), x.get());
     auto exec = this->get_executor();
     this->apply_impl(make_temporary_clone(exec, b).get(),
                      make_temporary_clone(exec, x).get());
-    return this;
 }
 
 
 template <typename ValueType, typename IndexType>
-Ell<ValueType, IndexType>* Ell<ValueType, IndexType>::apply(
+void Ell<ValueType, IndexType>::apply(
     ptr_param<const MultiVector<ValueType>> alpha,
     ptr_param<const MultiVector<ValueType>> b,
     ptr_param<const MultiVector<ValueType>> beta,
@@ -182,12 +178,11 @@ Ell<ValueType, IndexType>* Ell<ValueType, IndexType>::apply(
                      make_temporary_clone(exec, b).get(),
                      make_temporary_clone(exec, beta).get(),
                      make_temporary_clone(exec, x).get());
-    return this;
 }
 
 
 template <typename ValueType, typename IndexType>
-const Ell<ValueType, IndexType>* Ell<ValueType, IndexType>::apply(
+void Ell<ValueType, IndexType>::apply(
     ptr_param<const MultiVector<ValueType>> alpha,
     ptr_param<const MultiVector<ValueType>> b,
     ptr_param<const MultiVector<ValueType>> beta,
@@ -200,7 +195,6 @@ const Ell<ValueType, IndexType>* Ell<ValueType, IndexType>::apply(
                      make_temporary_clone(exec, b).get(),
                      make_temporary_clone(exec, beta).get(),
                      make_temporary_clone(exec, x).get());
-    return this;
 }
 
 

--- a/core/matrix/batch_identity.cpp
+++ b/core/matrix/batch_identity.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -41,46 +41,39 @@ std::unique_ptr<Identity<ValueType>> Identity<ValueType>::create(
 
 
 template <typename ValueType>
-Identity<ValueType>* Identity<ValueType>::apply(
-    ptr_param<const MultiVector<ValueType>> b,
-    ptr_param<MultiVector<ValueType>> x)
+void Identity<ValueType>::apply(ptr_param<const MultiVector<ValueType>> b,
+                                ptr_param<MultiVector<ValueType>> x)
 {
     static_cast<const Identity*>(this)->apply(b, x);
-    return this;
 }
 
 
 template <typename ValueType>
-const Identity<ValueType>* Identity<ValueType>::apply(
-    ptr_param<const MultiVector<ValueType>> b,
-    ptr_param<MultiVector<ValueType>> x) const
+void Identity<ValueType>::apply(ptr_param<const MultiVector<ValueType>> b,
+                                ptr_param<MultiVector<ValueType>> x) const
 {
     this->validate_application_parameters(b.get(), x.get());
     auto exec = this->get_executor();
     this->apply_impl(make_temporary_clone(exec, b).get(),
                      make_temporary_clone(exec, x).get());
-    return this;
 }
 
 
 template <typename ValueType>
-Identity<ValueType>* Identity<ValueType>::apply(
-    ptr_param<const MultiVector<ValueType>> alpha,
-    ptr_param<const MultiVector<ValueType>> b,
-    ptr_param<const MultiVector<ValueType>> beta,
-    ptr_param<MultiVector<ValueType>> x)
+void Identity<ValueType>::apply(ptr_param<const MultiVector<ValueType>> alpha,
+                                ptr_param<const MultiVector<ValueType>> b,
+                                ptr_param<const MultiVector<ValueType>> beta,
+                                ptr_param<MultiVector<ValueType>> x)
 {
     static_cast<const Identity*>(this)->apply(alpha, b, beta, x);
-    return this;
 }
 
 
 template <typename ValueType>
-const Identity<ValueType>* Identity<ValueType>::apply(
-    ptr_param<const MultiVector<ValueType>> alpha,
-    ptr_param<const MultiVector<ValueType>> b,
-    ptr_param<const MultiVector<ValueType>> beta,
-    ptr_param<MultiVector<ValueType>> x) const
+void Identity<ValueType>::apply(ptr_param<const MultiVector<ValueType>> alpha,
+                                ptr_param<const MultiVector<ValueType>> b,
+                                ptr_param<const MultiVector<ValueType>> beta,
+                                ptr_param<MultiVector<ValueType>> x) const
 {
     this->validate_application_parameters(alpha.get(), b.get(), beta.get(),
                                           x.get());
@@ -89,7 +82,6 @@ const Identity<ValueType>* Identity<ValueType>::apply(
                      make_temporary_clone(exec, b).get(),
                      make_temporary_clone(exec, beta).get(),
                      make_temporary_clone(exec, x).get());
-    return this;
 }
 
 

--- a/core/matrix/coo.cpp
+++ b/core/matrix/coo.cpp
@@ -113,33 +113,31 @@ Coo<ValueType, IndexType>::Coo(std::shared_ptr<const Executor> exec,
 
 
 template <typename ValueType, typename IndexType>
-LinOp* Coo<ValueType, IndexType>::apply2(ptr_param<const LinOp> b,
-                                         ptr_param<LinOp> x)
+void Coo<ValueType, IndexType>::apply2(ptr_param<const LinOp> b,
+                                       ptr_param<LinOp> x)
 {
     this->validate_application_parameters(b.get(), x.get());
     auto exec = this->get_executor();
     this->apply2_impl(make_temporary_clone(exec, b).get(),
                       make_temporary_clone(exec, x).get());
-    return this;
 }
 
 
 template <typename ValueType, typename IndexType>
-const LinOp* Coo<ValueType, IndexType>::apply2(ptr_param<const LinOp> b,
-                                               ptr_param<LinOp> x) const
+void Coo<ValueType, IndexType>::apply2(ptr_param<const LinOp> b,
+                                       ptr_param<LinOp> x) const
 {
     this->validate_application_parameters(b.get(), x.get());
     auto exec = this->get_executor();
     this->apply2_impl(make_temporary_clone(exec, b).get(),
                       make_temporary_clone(exec, x).get());
-    return this;
 }
 
 
 template <typename ValueType, typename IndexType>
-LinOp* Coo<ValueType, IndexType>::apply2(ptr_param<const LinOp> alpha,
-                                         ptr_param<const LinOp> b,
-                                         ptr_param<LinOp> x)
+void Coo<ValueType, IndexType>::apply2(ptr_param<const LinOp> alpha,
+                                       ptr_param<const LinOp> b,
+                                       ptr_param<LinOp> x)
 {
     this->validate_application_parameters(b.get(), x.get());
     GKO_ASSERT_EQUAL_DIMENSIONS(alpha, dim<2>(1, 1));
@@ -147,14 +145,13 @@ LinOp* Coo<ValueType, IndexType>::apply2(ptr_param<const LinOp> alpha,
     this->apply2_impl(make_temporary_clone(exec, alpha).get(),
                       make_temporary_clone(exec, b).get(),
                       make_temporary_clone(exec, x).get());
-    return this;
 }
 
 
 template <typename ValueType, typename IndexType>
-const LinOp* Coo<ValueType, IndexType>::apply2(ptr_param<const LinOp> alpha,
-                                               ptr_param<const LinOp> b,
-                                               ptr_param<LinOp> x) const
+void Coo<ValueType, IndexType>::apply2(ptr_param<const LinOp> alpha,
+                                       ptr_param<const LinOp> b,
+                                       ptr_param<LinOp> x) const
 {
     this->validate_application_parameters(b.get(), x.get());
     GKO_ASSERT_EQUAL_DIMENSIONS(alpha, dim<2>(1, 1));
@@ -162,7 +159,6 @@ const LinOp* Coo<ValueType, IndexType>::apply2(ptr_param<const LinOp> alpha,
     this->apply2_impl(make_temporary_clone(exec, alpha).get(),
                       make_temporary_clone(exec, b).get(),
                       make_temporary_clone(exec, x).get());
-    return this;
 }
 
 

--- a/include/ginkgo/core/base/lin_op.hpp
+++ b/include/ginkgo/core/base/lin_op.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -880,35 +880,7 @@ class EnableLinOp
 public:
     using EnablePolymorphicObject<ConcreteLinOp,
                                   PolymorphicBase>::EnablePolymorphicObject;
-
-    const ConcreteLinOp* apply(ptr_param<const LinOp> b,
-                               ptr_param<LinOp> x) const
-    {
-        PolymorphicBase::apply(b, x);
-        return self();
-    }
-
-    ConcreteLinOp* apply(ptr_param<const LinOp> b, ptr_param<LinOp> x)
-    {
-        PolymorphicBase::apply(b, x);
-        return self();
-    }
-
-    const ConcreteLinOp* apply(ptr_param<const LinOp> alpha,
-                               ptr_param<const LinOp> b,
-                               ptr_param<const LinOp> beta,
-                               ptr_param<LinOp> x) const
-    {
-        PolymorphicBase::apply(alpha, b, beta, x);
-        return self();
-    }
-
-    ConcreteLinOp* apply(ptr_param<const LinOp> alpha, ptr_param<const LinOp> b,
-                         ptr_param<const LinOp> beta, ptr_param<LinOp> x)
-    {
-        PolymorphicBase::apply(alpha, b, beta, x);
-        return self();
-    }
+    using PolymorphicBase::apply;
 
 protected:
     GKO_ENABLE_SELF(ConcreteLinOp);

--- a/include/ginkgo/core/base/lin_op.hpp
+++ b/include/ginkgo/core/base/lin_op.hpp
@@ -123,23 +123,6 @@ public:
      *
      * @param b  the input vector(s) on which the operator is applied
      * @param x  the output vector(s) where the result is stored
-     *
-     * @return this
-     */
-    void apply(ptr_param<const LinOp> b, ptr_param<LinOp> x)
-    {
-        this->template log<log::Logger::linop_apply_started>(this, b.get(),
-                                                             x.get());
-        this->validate_application_parameters(b.get(), x.get());
-        auto exec = this->get_executor();
-        this->apply_impl(make_temporary_clone(exec, b).get(),
-                         make_temporary_clone(exec, x).get());
-        this->template log<log::Logger::linop_apply_completed>(this, b.get(),
-                                                               x.get());
-    }
-
-    /**
-     * @copydoc apply(const LinOp *, LinOp *)
      */
     void apply(ptr_param<const LinOp> b, ptr_param<LinOp> x) const
     {
@@ -153,6 +136,7 @@ public:
                                                                x.get());
     }
 
+
     /**
      * Performs the operation x = alpha * op(b) + beta * x.
      *
@@ -160,30 +144,9 @@ public:
      * @param b  vector(s) on which the operator is applied
      * @param beta  scaling of the input x
      * @param x  output vector(s)
-     *
-     * @return this
      */
     void apply(ptr_param<const LinOp> alpha, ptr_param<const LinOp> b,
-               ptr_param<const LinOp> beta, ptr_param<LinOp> x)
-    {
-        this->template log<log::Logger::linop_advanced_apply_started>(
-            this, alpha.get(), b.get(), beta.get(), x.get());
-        this->validate_application_parameters(alpha.get(), b.get(), beta.get(),
-                                              x.get());
-        auto exec = this->get_executor();
-        this->apply_impl(make_temporary_clone(exec, alpha).get(),
-                         make_temporary_clone(exec, b).get(),
-                         make_temporary_clone(exec, beta).get(),
-                         make_temporary_clone(exec, x).get());
-        this->template log<log::Logger::linop_advanced_apply_completed>(
-            this, alpha.get(), b.get(), beta.get(), x.get());
-    }
-
-    /**
-     * @copydoc apply(const LinOp *, const LinOp *, const LinOp *, LinOp *)
-     */
-    const void apply(ptr_param<const LinOp> alpha, ptr_param<const LinOp> b,
-                     ptr_param<const LinOp> beta, ptr_param<LinOp> x) const
+               ptr_param<const LinOp> beta, ptr_param<LinOp> x) const
     {
         this->template log<log::Logger::linop_advanced_apply_started>(
             this, alpha.get(), b.get(), beta.get(), x.get());

--- a/include/ginkgo/core/base/lin_op.hpp
+++ b/include/ginkgo/core/base/lin_op.hpp
@@ -126,7 +126,7 @@ public:
      *
      * @return this
      */
-    LinOp* apply(ptr_param<const LinOp> b, ptr_param<LinOp> x)
+    void apply(ptr_param<const LinOp> b, ptr_param<LinOp> x)
     {
         this->template log<log::Logger::linop_apply_started>(this, b.get(),
                                                              x.get());
@@ -136,13 +136,12 @@ public:
                          make_temporary_clone(exec, x).get());
         this->template log<log::Logger::linop_apply_completed>(this, b.get(),
                                                                x.get());
-        return this;
     }
 
     /**
      * @copydoc apply(const LinOp *, LinOp *)
      */
-    const LinOp* apply(ptr_param<const LinOp> b, ptr_param<LinOp> x) const
+    void apply(ptr_param<const LinOp> b, ptr_param<LinOp> x) const
     {
         this->template log<log::Logger::linop_apply_started>(this, b.get(),
                                                              x.get());
@@ -152,7 +151,6 @@ public:
                          make_temporary_clone(exec, x).get());
         this->template log<log::Logger::linop_apply_completed>(this, b.get(),
                                                                x.get());
-        return this;
     }
 
     /**
@@ -165,8 +163,8 @@ public:
      *
      * @return this
      */
-    LinOp* apply(ptr_param<const LinOp> alpha, ptr_param<const LinOp> b,
-                 ptr_param<const LinOp> beta, ptr_param<LinOp> x)
+    void apply(ptr_param<const LinOp> alpha, ptr_param<const LinOp> b,
+               ptr_param<const LinOp> beta, ptr_param<LinOp> x)
     {
         this->template log<log::Logger::linop_advanced_apply_started>(
             this, alpha.get(), b.get(), beta.get(), x.get());
@@ -179,14 +177,13 @@ public:
                          make_temporary_clone(exec, x).get());
         this->template log<log::Logger::linop_advanced_apply_completed>(
             this, alpha.get(), b.get(), beta.get(), x.get());
-        return this;
     }
 
     /**
      * @copydoc apply(const LinOp *, const LinOp *, const LinOp *, LinOp *)
      */
-    const LinOp* apply(ptr_param<const LinOp> alpha, ptr_param<const LinOp> b,
-                       ptr_param<const LinOp> beta, ptr_param<LinOp> x) const
+    const void apply(ptr_param<const LinOp> alpha, ptr_param<const LinOp> b,
+                     ptr_param<const LinOp> beta, ptr_param<LinOp> x) const
     {
         this->template log<log::Logger::linop_advanced_apply_started>(
             this, alpha.get(), b.get(), beta.get(), x.get());
@@ -199,7 +196,6 @@ public:
                          make_temporary_clone(exec, x).get());
         this->template log<log::Logger::linop_advanced_apply_completed>(
             this, alpha.get(), b.get(), beta.get(), x.get());
-        return this;
     }
 
     /**

--- a/include/ginkgo/core/matrix/batch_csr.hpp
+++ b/include/ginkgo/core/matrix/batch_csr.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -324,7 +324,7 @@ public:
      * @param b  the multi-vector to be applied to
      * @param x  the output multi-vector
      */
-    Csr* apply(ptr_param<const MultiVector<value_type>> b,
+    void apply(ptr_param<const MultiVector<value_type>> b,
                ptr_param<MultiVector<value_type>> x);
 
     /**
@@ -337,7 +337,7 @@ public:
      * @param beta   the scalar to scale the x vector with
      * @param x      the output multi-vector
      */
-    Csr* apply(ptr_param<const MultiVector<value_type>> alpha,
+    void apply(ptr_param<const MultiVector<value_type>> alpha,
                ptr_param<const MultiVector<value_type>> b,
                ptr_param<const MultiVector<value_type>> beta,
                ptr_param<MultiVector<value_type>> x);
@@ -345,18 +345,18 @@ public:
     /**
      * @copydoc apply(const MultiVector<value_type>*, MultiVector<value_type>*)
      */
-    const Csr* apply(ptr_param<const MultiVector<value_type>> b,
-                     ptr_param<MultiVector<value_type>> x) const;
+    void apply(ptr_param<const MultiVector<value_type>> b,
+               ptr_param<MultiVector<value_type>> x) const;
 
     /**
      * @copydoc apply(const MultiVector<value_type>*, const
      * MultiVector<value_type>*, const MultiVector<value_type>*,
      * MultiVector<value_type>*)
      */
-    const Csr* apply(ptr_param<const MultiVector<value_type>> alpha,
-                     ptr_param<const MultiVector<value_type>> b,
-                     ptr_param<const MultiVector<value_type>> beta,
-                     ptr_param<MultiVector<value_type>> x) const;
+    void apply(ptr_param<const MultiVector<value_type>> alpha,
+               ptr_param<const MultiVector<value_type>> b,
+               ptr_param<const MultiVector<value_type>> beta,
+               ptr_param<MultiVector<value_type>> x) const;
 
     /**
      * Performs in-place row and column scaling for this matrix.

--- a/include/ginkgo/core/matrix/batch_dense.hpp
+++ b/include/ginkgo/core/matrix/batch_dense.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -319,8 +319,8 @@ public:
      * @param b  the multi-vector to be applied to
      * @param x  the output multi-vector
      */
-    Dense* apply(ptr_param<const MultiVector<value_type>> b,
-                 ptr_param<MultiVector<value_type>> x);
+    void apply(ptr_param<const MultiVector<value_type>> b,
+               ptr_param<MultiVector<value_type>> x);
 
     /**
      * Apply the matrix to a multi-vector with a linear combination of the given
@@ -332,26 +332,26 @@ public:
      * @param beta   the scalar to scale the x vector with
      * @param x      the output multi-vector
      */
-    Dense* apply(ptr_param<const MultiVector<value_type>> alpha,
-                 ptr_param<const MultiVector<value_type>> b,
-                 ptr_param<const MultiVector<value_type>> beta,
-                 ptr_param<MultiVector<value_type>> x);
+    void apply(ptr_param<const MultiVector<value_type>> alpha,
+               ptr_param<const MultiVector<value_type>> b,
+               ptr_param<const MultiVector<value_type>> beta,
+               ptr_param<MultiVector<value_type>> x);
 
     /**
      * @copydoc apply(const MultiVector<value_type>*, MultiVector<value_type>*)
      */
-    const Dense* apply(ptr_param<const MultiVector<value_type>> b,
-                       ptr_param<MultiVector<value_type>> x) const;
+    void apply(ptr_param<const MultiVector<value_type>> b,
+               ptr_param<MultiVector<value_type>> x) const;
 
     /**
      * @copydoc apply(const MultiVector<value_type>*, const
      * MultiVector<value_type>*, const MultiVector<value_type>*,
      * MultiVector<value_type>*)
      */
-    const Dense* apply(ptr_param<const MultiVector<value_type>> alpha,
-                       ptr_param<const MultiVector<value_type>> b,
-                       ptr_param<const MultiVector<value_type>> beta,
-                       ptr_param<MultiVector<value_type>> x) const;
+    void apply(ptr_param<const MultiVector<value_type>> alpha,
+               ptr_param<const MultiVector<value_type>> b,
+               ptr_param<const MultiVector<value_type>> beta,
+               ptr_param<MultiVector<value_type>> x) const;
 
     /**
      * Performs in-place row and column scaling for this matrix.

--- a/include/ginkgo/core/matrix/batch_ell.hpp
+++ b/include/ginkgo/core/matrix/batch_ell.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -336,7 +336,7 @@ public:
      * @param b  the multi-vector to be applied to
      * @param x  the output multi-vector
      */
-    Ell* apply(ptr_param<const MultiVector<value_type>> b,
+    void apply(ptr_param<const MultiVector<value_type>> b,
                ptr_param<MultiVector<value_type>> x);
 
     /**
@@ -349,7 +349,7 @@ public:
      * @param beta   the scalar to scale the x vector with
      * @param x      the output multi-vector
      */
-    Ell* apply(ptr_param<const MultiVector<value_type>> alpha,
+    void apply(ptr_param<const MultiVector<value_type>> alpha,
                ptr_param<const MultiVector<value_type>> b,
                ptr_param<const MultiVector<value_type>> beta,
                ptr_param<MultiVector<value_type>> x);
@@ -357,18 +357,18 @@ public:
     /**
      * @copydoc apply(const MultiVector<value_type>*, MultiVector<value_type>*)
      */
-    const Ell* apply(ptr_param<const MultiVector<value_type>> b,
-                     ptr_param<MultiVector<value_type>> x) const;
+    void apply(ptr_param<const MultiVector<value_type>> b,
+               ptr_param<MultiVector<value_type>> x) const;
 
     /**
      * @copydoc apply(const MultiVector<value_type>*, const
      * MultiVector<value_type>*, const MultiVector<value_type>*,
      * MultiVector<value_type>*)
      */
-    const Ell* apply(ptr_param<const MultiVector<value_type>> alpha,
-                     ptr_param<const MultiVector<value_type>> b,
-                     ptr_param<const MultiVector<value_type>> beta,
-                     ptr_param<MultiVector<value_type>> x) const;
+    void apply(ptr_param<const MultiVector<value_type>> alpha,
+               ptr_param<const MultiVector<value_type>> b,
+               ptr_param<const MultiVector<value_type>> beta,
+               ptr_param<MultiVector<value_type>> x) const;
 
     /**
      * Performs in-place row and column scaling for this matrix.

--- a/include/ginkgo/core/matrix/batch_identity.hpp
+++ b/include/ginkgo/core/matrix/batch_identity.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -47,8 +47,8 @@ public:
      * @param b  the multi-vector to be applied to
      * @param x  the output multi-vector
      */
-    Identity* apply(ptr_param<const MultiVector<value_type>> b,
-                    ptr_param<MultiVector<value_type>> x);
+    void apply(ptr_param<const MultiVector<value_type>> b,
+               ptr_param<MultiVector<value_type>> x);
 
     /**
      * Apply the matrix to a multi-vector with a linear combination of the given
@@ -60,26 +60,26 @@ public:
      * @param beta   the scalar to scale the x vector with
      * @param x      the output multi-vector
      */
-    Identity* apply(ptr_param<const MultiVector<value_type>> alpha,
-                    ptr_param<const MultiVector<value_type>> b,
-                    ptr_param<const MultiVector<value_type>> beta,
-                    ptr_param<MultiVector<value_type>> x);
+    void apply(ptr_param<const MultiVector<value_type>> alpha,
+               ptr_param<const MultiVector<value_type>> b,
+               ptr_param<const MultiVector<value_type>> beta,
+               ptr_param<MultiVector<value_type>> x);
 
     /**
      * @copydoc apply(const MultiVector<value_type>*, MultiVector<value_type>*)
      */
-    const Identity* apply(ptr_param<const MultiVector<value_type>> b,
-                          ptr_param<MultiVector<value_type>> x) const;
+    void apply(ptr_param<const MultiVector<value_type>> b,
+               ptr_param<MultiVector<value_type>> x) const;
 
     /**
      * @copydoc apply(const MultiVector<value_type>*, const
      * MultiVector<value_type>*, const MultiVector<value_type>*,
      * MultiVector<value_type>*)
      */
-    const Identity* apply(ptr_param<const MultiVector<value_type>> alpha,
-                          ptr_param<const MultiVector<value_type>> b,
-                          ptr_param<const MultiVector<value_type>> beta,
-                          ptr_param<MultiVector<value_type>> x) const;
+    void apply(ptr_param<const MultiVector<value_type>> alpha,
+               ptr_param<const MultiVector<value_type>> b,
+               ptr_param<const MultiVector<value_type>> beta,
+               ptr_param<MultiVector<value_type>> x) const;
     /**
      * Creates an Identity matrix of the specified size.
      *

--- a/include/ginkgo/core/matrix/coo.hpp
+++ b/include/ginkgo/core/matrix/coo.hpp
@@ -241,12 +241,12 @@ public:
      *
      * @return this
      */
-    LinOp* apply2(ptr_param<const LinOp> b, ptr_param<LinOp> x);
+    void apply2(ptr_param<const LinOp> b, ptr_param<LinOp> x);
 
     /**
      * @copydoc apply2(cost LinOp *, LinOp *)
      */
-    const LinOp* apply2(ptr_param<const LinOp> b, ptr_param<LinOp> x) const;
+    void apply2(ptr_param<const LinOp> b, ptr_param<LinOp> x) const;
 
     /**
      * Performs the operation x = alpha * Coo * b + x.
@@ -257,14 +257,14 @@ public:
      *
      * @return this
      */
-    LinOp* apply2(ptr_param<const LinOp> alpha, ptr_param<const LinOp> b,
-                  ptr_param<LinOp> x);
+    void apply2(ptr_param<const LinOp> alpha, ptr_param<const LinOp> b,
+                ptr_param<LinOp> x);
 
     /**
      * @copydoc apply2(const LinOp *, const LinOp *, LinOp *)
      */
-    const LinOp* apply2(ptr_param<const LinOp> alpha, ptr_param<const LinOp> b,
-                        ptr_param<LinOp> x) const;
+    void apply2(ptr_param<const LinOp> alpha, ptr_param<const LinOp> b,
+                ptr_param<LinOp> x) const;
 
     /**
      * Creates an uninitialized COO matrix of the specified size.

--- a/include/ginkgo/core/solver/batch_solver_base.hpp
+++ b/include/ginkgo/core/solver/batch_solver_base.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -207,20 +207,19 @@ class EnableBatchSolver
 public:
     using real_type = remove_complex<ValueType>;
 
-    const ConcreteSolver* apply(ptr_param<const MultiVector<ValueType>> b,
-                                ptr_param<MultiVector<ValueType>> x) const
+    void apply(ptr_param<const MultiVector<ValueType>> b,
+               ptr_param<MultiVector<ValueType>> x) const
     {
         this->validate_application_parameters(b.get(), x.get());
         auto exec = this->get_executor();
         this->apply_impl(make_temporary_clone(exec, b).get(),
                          make_temporary_clone(exec, x).get());
-        return self();
     }
 
-    const ConcreteSolver* apply(ptr_param<const MultiVector<ValueType>> alpha,
-                                ptr_param<const MultiVector<ValueType>> b,
-                                ptr_param<const MultiVector<ValueType>> beta,
-                                ptr_param<MultiVector<ValueType>> x) const
+    void apply(ptr_param<const MultiVector<ValueType>> alpha,
+               ptr_param<const MultiVector<ValueType>> b,
+               ptr_param<const MultiVector<ValueType>> beta,
+               ptr_param<MultiVector<ValueType>> x) const
     {
         this->validate_application_parameters(alpha.get(), b.get(), beta.get(),
                                               x.get());
@@ -229,32 +228,6 @@ public:
                          make_temporary_clone(exec, b).get(),
                          make_temporary_clone(exec, beta).get(),
                          make_temporary_clone(exec, x).get());
-        return self();
-    }
-
-    ConcreteSolver* apply(ptr_param<const MultiVector<ValueType>> b,
-                          ptr_param<MultiVector<ValueType>> x)
-    {
-        this->validate_application_parameters(b.get(), x.get());
-        auto exec = this->get_executor();
-        this->apply_impl(make_temporary_clone(exec, b).get(),
-                         make_temporary_clone(exec, x).get());
-        return self();
-    }
-
-    ConcreteSolver* apply(ptr_param<const MultiVector<ValueType>> alpha,
-                          ptr_param<const MultiVector<ValueType>> b,
-                          ptr_param<const MultiVector<ValueType>> beta,
-                          ptr_param<MultiVector<ValueType>> x)
-    {
-        this->validate_application_parameters(alpha.get(), b.get(), beta.get(),
-                                              x.get());
-        auto exec = this->get_executor();
-        this->apply_impl(make_temporary_clone(exec, alpha).get(),
-                         make_temporary_clone(exec, b).get(),
-                         make_temporary_clone(exec, beta).get(),
-                         make_temporary_clone(exec, x).get());
-        return self();
     }
 
 protected:


### PR DESCRIPTION
In Ginkgo 1.x, we support chain apply like `LinOp->apply(b1, x1)->apply(b2, x2);`
In Ginkgo 2, we plan to remove this ability because it is not really used in practice.
People usually do
```
LinOp->apply(b1, x1);
LinOp->apply(b2, x2);
```
Similar to other apply function like `LinOp->apply(alpha, b, beta, x)` and `Csr->apply2(b, x)`

This PR does not remove `EnableLinOp`, which should happen in other pr.
Without supporting this, we can reduce mixin usage.

TODO:
- [x] Batch also has this behavior. should it be removed?