### PR TITLE
Add cuda 13.1.1 and rocm 7.2.0 and Fix MSVC thrust

### DIFF
--- a/.github/workflows/windows-msvc-cuda.yml
+++ b/.github/workflows/windows-msvc-cuda.yml
@@ -59,5 +59,5 @@ jobs:
         refreshenv
         mkdir build
         cd build
-        cmake -DCMAKE_CUDA_FLAGS="-Xcompiler /Zc:preprocessor" -DGINKGO_BUILD_CUDA=ON -DGINKGO_BUILD_OMP=OFF -DGINKGO_MIXED_PRECISION=${{ matrix.config.mixed }} -DCMAKE_CUDA_ARCHITECTURES=75 -DGINKGO_ENABLE_HALF=OFF -DGINKGO_ENABLE_BFLOAT16=OFF ..
+        cmake -DCMAKE_CXX_FLAGS="-DNOMINMAX" -DCMAKE_CUDA_FLAGS="-Xcompiler /Zc:preprocessor" -DGINKGO_BUILD_CUDA=ON -DGINKGO_BUILD_OMP=OFF -DGINKGO_MIXED_PRECISION=${{ matrix.config.mixed }} -DCMAKE_CUDA_ARCHITECTURES=75 -DGINKGO_ENABLE_HALF=OFF -DGINKGO_ENABLE_BFLOAT16=OFF ..
         cmake --build . -j4 --config Release

--- a/.github/workflows/windows-msvc-cuda.yml
+++ b/.github/workflows/windows-msvc-cuda.yml
@@ -59,5 +59,5 @@ jobs:
         refreshenv
         mkdir build
         cd build
-        cmake -DCMAKE_CXX_FLAGS="-DNOMINMAX" -DCMAKE_CUDA_FLAGS="-Xcompiler /Zc:preprocessor" -DGINKGO_BUILD_CUDA=ON -DGINKGO_BUILD_OMP=OFF -DGINKGO_MIXED_PRECISION=${{ matrix.config.mixed }} -DCMAKE_CUDA_ARCHITECTURES=75 -DGINKGO_ENABLE_HALF=OFF -DGINKGO_ENABLE_BFLOAT16=OFF ..
+        cmake -DCMAKE_CUDA_FLAGS="-Xcompiler /Zc:preprocessor" -DGINKGO_BUILD_CUDA=ON -DGINKGO_BUILD_OMP=OFF -DGINKGO_MIXED_PRECISION=${{ matrix.config.mixed }} -DCMAKE_CUDA_ARCHITECTURES=75 -DGINKGO_ENABLE_HALF=OFF -DGINKGO_ENABLE_BFLOAT16=OFF ..
         cmake --build . -j4 --config Release

--- a/.github/workflows/windows-msvc-cuda.yml
+++ b/.github/workflows/windows-msvc-cuda.yml
@@ -59,5 +59,5 @@ jobs:
         refreshenv
         mkdir build
         cd build
-        cmake -DGINKGO_BUILD_CUDA=ON -DGINKGO_BUILD_OMP=OFF -DGINKGO_MIXED_PRECISION=${{ matrix.config.mixed }} -DCMAKE_CUDA_ARCHITECTURES=75 -DGINKGO_ENABLE_HALF=OFF -DGINKGO_ENABLE_BFLOAT16=OFF ..
+        cmake -DCMAKE_CUDA_FLAGS="-Xcompiler /Zc:preprocessor" -DGINKGO_BUILD_CUDA=ON -DGINKGO_BUILD_OMP=OFF -DGINKGO_MIXED_PRECISION=${{ matrix.config.mixed }} -DCMAKE_CUDA_ARCHITECTURES=75 -DGINKGO_ENABLE_HALF=OFF -DGINKGO_ENABLE_BFLOAT16=OFF ..
         cmake --build . -j4 --config Release

--- a/.github/workflows/windows-msvc-mpi.yml
+++ b/.github/workflows/windows-msvc-mpi.yml
@@ -61,5 +61,5 @@ jobs:
         refreshenv
         mkdir build
         cd build
-        cmake -DCMAKE_CUDA_FLAGS="-Xcompiler /Zc:preprocessor" -DGINKGO_BUILD_MPI=ON -DGINKGO_BUILD_OMP=OFF -DGINKGO_BUILD_CUDA=ON -DCMAKE_CUDA_ARCHITECTURES=75 -DGINKGO_MIXED_PRECISION=${{ matrix.config.mixed }} -DGINKGO_ENABLE_HALF=OFF -DGINKGO_ENABLE_BFLOAT16=OFF ..
+        cmake -DCMAKE_CXX_FLAGS="-DNOMINMAX" -DCMAKE_CUDA_FLAGS="-Xcompiler /Zc:preprocessor" -DGINKGO_BUILD_MPI=ON -DGINKGO_BUILD_OMP=OFF -DGINKGO_BUILD_CUDA=ON -DCMAKE_CUDA_ARCHITECTURES=75 -DGINKGO_MIXED_PRECISION=${{ matrix.config.mixed }} -DGINKGO_ENABLE_HALF=OFF -DGINKGO_ENABLE_BFLOAT16=OFF ..
         cmake --build . -j4 --config Release

--- a/.github/workflows/windows-msvc-mpi.yml
+++ b/.github/workflows/windows-msvc-mpi.yml
@@ -61,5 +61,5 @@ jobs:
         refreshenv
         mkdir build
         cd build
-        cmake -DGINKGO_BUILD_MPI=ON -DGINKGO_BUILD_OMP=OFF -DGINKGO_BUILD_CUDA=ON -DCMAKE_CUDA_ARCHITECTURES=75 -DGINKGO_MIXED_PRECISION=${{ matrix.config.mixed }} -DGINKGO_ENABLE_HALF=OFF -DGINKGO_ENABLE_BFLOAT16=OFF ..
+        cmake -DCMAKE_CUDA_FLAGS="-Xcompiler /Zc:preprocessor" -DGINKGO_BUILD_MPI=ON -DGINKGO_BUILD_OMP=OFF -DGINKGO_BUILD_CUDA=ON -DCMAKE_CUDA_ARCHITECTURES=75 -DGINKGO_MIXED_PRECISION=${{ matrix.config.mixed }} -DGINKGO_ENABLE_HALF=OFF -DGINKGO_ENABLE_BFLOAT16=OFF ..
         cmake --build . -j4 --config Release

--- a/.github/workflows/windows-msvc-mpi.yml
+++ b/.github/workflows/windows-msvc-mpi.yml
@@ -61,5 +61,5 @@ jobs:
         refreshenv
         mkdir build
         cd build
-        cmake -DCMAKE_CXX_FLAGS="-DNOMINMAX" -DCMAKE_CUDA_FLAGS="-Xcompiler /Zc:preprocessor" -DGINKGO_BUILD_MPI=ON -DGINKGO_BUILD_OMP=OFF -DGINKGO_BUILD_CUDA=ON -DCMAKE_CUDA_ARCHITECTURES=75 -DGINKGO_MIXED_PRECISION=${{ matrix.config.mixed }} -DGINKGO_ENABLE_HALF=OFF -DGINKGO_ENABLE_BFLOAT16=OFF ..
+        cmake -DCMAKE_CUDA_FLAGS="-Xcompiler /Zc:preprocessor" -DGINKGO_BUILD_MPI=ON -DGINKGO_BUILD_OMP=OFF -DGINKGO_BUILD_CUDA=ON -DCMAKE_CUDA_ARCHITECTURES=75 -DGINKGO_MIXED_PRECISION=${{ matrix.config.mixed }} -DGINKGO_ENABLE_HALF=OFF -DGINKGO_ENABLE_BFLOAT16=OFF ..
         cmake --build . -j4 --config Release

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -212,6 +212,20 @@ build/cuda130/nompi/gcc/cuda/release/shared:
     BUILD_TYPE: "Release"
     MODULE_LOAD: "cmake/3.30.8 cuda/13.0.2 gcc/14.3.0"
 
+build/cuda131/nompi/gcc/cuda/release/shared:
+  extends:
+    - .build_and_test_tum_template
+    - .default_variables
+    - .quick_test_condition
+    - .use_tum-nvidia
+  variables:
+    BUILD_CUDA: "ON"
+    BUILD_HWLOC: "OFF"
+    ENABLE_HALF: "ON"
+    ENABLE_BFLOAT16: "ON"
+    BUILD_TYPE: "Release"
+    MODULE_LOAD: "cmake/3.30.8 cuda/13.1.1 gcc/14.3.0"
+
 # ROCm 4.5 and friends
 build/amd/nompi/gcc/rocm45/release/shared:
   extends:
@@ -306,6 +320,21 @@ build/amd/openmpi/gcc/rocm600/release/static:
     BUILD_TYPE: "Release"
     BUILD_SHARED_LIBS: "OFF"
     MODULE_LOAD: "cmake/3.24.4 rocm/6.0.0 gcc/13.3.0 openmpi/5.0.7"
+
+build/amd/nompi/gcc/rocm720/release/shared:
+  extends:
+    - .build_and_test_tum_template
+    - .default_variables
+    - .quick_test_condition
+    - .use_tum-amd
+  variables:
+    BUILD_HIP: "ON"
+    BUILD_OMP: "OFF"
+    BUILD_HWLOC: "OFF"
+    BUILD_TYPE: "Release"
+    ENABLE_BFLOAT16: "OFF"
+    ENABLE_HALF: "OFF"
+    MODULE_LOAD: "cmake/3.25.3 rocm/7.2.0 gcc/12.4.0"
 
 build/amd/nompi/gcc/rocm573/debug/shared:
   extends:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -216,7 +216,7 @@ build/cuda131/nompi/gcc/cuda/release/shared:
   extends:
     - .build_and_test_tum_template
     - .default_variables
-    - .quick_test_condition
+    - .full_test_condition
     - .use_tum-nvidia
   variables:
     BUILD_CUDA: "ON"
@@ -325,7 +325,7 @@ build/amd/nompi/gcc/rocm720/release/shared:
   extends:
     - .build_and_test_tum_template
     - .default_variables
-    - .quick_test_condition
+    - .full_test_condition
     - .use_tum-amd
   variables:
     BUILD_HIP: "ON"

--- a/.gitlab/scripts.yml
+++ b/.gitlab/scripts.yml
@@ -12,13 +12,7 @@
     - export CCACHE_DIR=${CCACHE_DIR}
     - export CCACHE_MAXSIZE=${CCACHE_MAXSIZE}
     - source /storage/apps/opt/spack/share/spack/setup-env.sh
-    - mkdir -p lmod/cuda
-    - echo 'prepend_path("PATH","/storage/apps/usr/local/cuda-13.0.2/bin")' > lmod/cuda/13.0.2.lua
-    - echo 'prepend_path("CMAKE_PREFIX_PATH","/storage/apps/usr/local/cuda-13.0.2/.")' >> lmod/cuda/13.0.2.lua
-    - echo 'setenv("CUDA_HOME","/storage/apps/usr/local/cuda-13.0.2")' >> lmod/cuda/13.0.2.lua
-    - echo 'setenv("NVHPC_CUDA_HOME","/storage/apps/usr/local/cuda-13.0.2")' >> lmod/cuda/13.0.2.lua
     - export MODULEPATH="$(pwd)/lmod":/storage/apps/opt/rocm-modules:/storage/apps/opt/spack/share/spack/lmod/linux-rocky9-x86_64/Core
-    - module av
 
 .before_script_git_template:
   before_script:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -237,9 +237,8 @@ if(GINKGO_BUILD_HIP)
     elseif(
         GINKGO_HIP_PLATFORM_AMD
         AND GINKGO_HIP_VERSION VERSION_GREATER_EQUAL 7.1
-        AND GINKGO_HIP_VERSION VERSION_LESS 7.2
     )
-        # https://github.com/ROCm/rocm-libraries/pull/1769 should fix this issue in ROCm 7.1.1.
+        # track this issue by https://github.com/ROCm/rocm-libraries/issues/6309 
         # HIP VERSION does not use the exact version number as ROCm. Need to wait for ROCm 7.1.1 to set proper range for ROCm 7.1.0
         message(
             STATUS
@@ -251,6 +250,7 @@ if(GINKGO_BUILD_HIP)
         set(GINKGO_HIP_CUSTOM_THRUST_NAMESPACE ON)
     endif()
 endif()
+
 if(GINKGO_BUILD_SYCL)
     include(cmake/sycl.cmake)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -268,7 +268,10 @@ include(cmake/compiler_features.cmake)
 include(cmake/generate_ginkgo_hpp.cmake)
 
 if(MSVC)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /bigobj /permissive-")
+    # MSVC has macro for min/max, it leads C2589 issue with CUDA 13.2.
+    # We disable it by -DNOMINMAX
+    # similar issue: https://stackoverflow.com/questions/1825904/error-c2589-on-stdnumeric-limitsdoublemin
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DNOMINMAX /bigobj /permissive-")
 endif()
 if(MINGW OR CYGWIN)
     if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")

--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -52,7 +52,7 @@ function(ginkgo_benchmark_hipsparse_linops type def)
         utils/hip_linops.hip.cpp
         PROPERTIES LANGUAGE HIP
     )
-    if(GINKGO_CUDA_CUSTOM_THRUST_NAMESPACE)
+    if(GINKGO_HIP_CUSTOM_THRUST_NAMESPACE)
         target_compile_definitions(
             hipsparse_linops_${type}
             PRIVATE THRUST_CUB_WRAPPED_NAMESPACE=gko

--- a/cmake/cuda.cmake
+++ b/cmake/cuda.cmake
@@ -15,7 +15,7 @@ endif()
 find_package(NVTX REQUIRED)
 
 if(CUDAToolkit_VERSION VERSION_GREATER_EQUAL 13)
-    find_package(Thrust REQUIRED CONFIG)
+    find_package(Thrust REQUIRED CONFIG HINTS ${CUDAToolkit_LIBRARY_ROOT})
     thrust_create_target(Thrust)
 endif()
 

--- a/cmake/cuda.cmake
+++ b/cmake/cuda.cmake
@@ -15,7 +15,7 @@ endif()
 find_package(NVTX REQUIRED)
 
 if(CUDAToolkit_VERSION VERSION_GREATER_EQUAL 13)
-    find_package(Thrust REQUIRED)
+    find_package(Thrust REQUIRED CONFIG)
     thrust_create_target(Thrust)
 endif()
 

--- a/common/cuda_hip/matrix/csr_kernels.template.cpp
+++ b/common/cuda_hip/matrix/csr_kernels.template.cpp
@@ -13,6 +13,7 @@
 #include <thrust/iterator/counting_iterator.h>
 #include <thrust/iterator/transform_output_iterator.h>
 #include <thrust/iterator/zip_iterator.h>
+#include <thrust/pair.h>
 #include <thrust/sort.h>
 
 #include <ginkgo/core/base/array.hpp>

--- a/common/cuda_hip/matrix/fbcsr_kernels.template.cpp
+++ b/common/cuda_hip/matrix/fbcsr_kernels.template.cpp
@@ -12,6 +12,7 @@
 #include <thrust/iterator/counting_iterator.h>
 #include <thrust/iterator/transform_output_iterator.h>
 #include <thrust/iterator/zip_iterator.h>
+#include <thrust/pair.h>
 #include <thrust/sort.h>
 
 #include <ginkgo/core/base/array.hpp>

--- a/common/cuda_hip/reorder/rcm_kernels.cpp
+++ b/common/cuda_hip/reorder/rcm_kernels.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -10,6 +10,7 @@
 #include <thrust/iterator/discard_iterator.h>
 #include <thrust/iterator/permutation_iterator.h>
 #include <thrust/iterator/zip_iterator.h>
+#include <thrust/pair.h>
 #include <thrust/reduce.h>
 #include <thrust/sequence.h>
 #include <thrust/sort.h>


### PR DESCRIPTION
This PR adds cuda 13.1.1 and rocm 7.2.0 into ci test.
Also, use the thrust suggested way (thrust > 1.9) in CMake.
The CI currently have setup cuda 13.0, so remove the manual lmod module file.

MSVC with CUDA 13.2 gives the following error.
```
C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v13.2\include\cccl\cub\util_type.cuh(899,44): error C2589: '(': illegal token on right side of '::'
...
```
following https://stackoverflow.com/questions/1825904/error-c2589-on-stdnumeric-limitsdoublemin, we disable minmax macro by `-DNOMINMAX` on MSVC to avoid this issue.


TODO:
- [x] Check whether Thrust work in MSVC
- [x] check whether reproduce the issue in https://github.com/ginkgo-project/ginkgo/issues/1983 on rocm 7.2.0 It is reproduced. create an issue https://github.com/ROCm/rocm-libraries/issues/6309 for that. Currently, disable it after 7.1