### PR TITLE
Fix MSVC test fails

### DIFF
--- a/core/test/log/profiler_hook.cpp
+++ b/core/test/log/profiler_hook.cpp
@@ -48,7 +48,9 @@ std::string normalize_type_name(std::string s)
 
     for (;;) {
         auto pos = s.find(class_tok);
-        if (pos == std::string::npos) break;
+        if (pos == std::string::npos) {
+            break;
+        }
         s.erase(pos, class_tok.size());
     }
     for (;;) {

--- a/core/test/log/profiler_hook.cpp
+++ b/core/test/log/profiler_hook.cpp
@@ -71,7 +71,7 @@ std::string normalize_type_name(std::string s)
 }
 #endif
 
-static void normalize_type_names(std::vector<std::string> & output,
+void normalize_type_names(std::vector<std::string> & output,
                                  std::vector<std::string> & expected) {
     #ifdef _MSC_VER
     std::transform(output.begin(), output.end(), output.begin(),

--- a/core/test/log/profiler_hook.cpp
+++ b/core/test/log/profiler_hook.cpp
@@ -39,6 +39,41 @@ make_hooks(std::vector<std::string>& output)
         });
 }
 
+#ifdef _MSC_VER
+static std::string normalize_type_name(std::string s)
+{
+    // Remove all MSVC-specific "class " and "struct " tokens
+    const std::string class_tok = "class ";
+    const std::string struct_tok = "struct ";
+
+    for (;;) {
+        auto pos = s.find(class_tok);
+        if (pos == std::string::npos) break;
+        s.erase(pos, class_tok.size());
+    }
+    for (;;) {
+        auto pos = s.find(struct_tok);
+        if (pos == std::string::npos) break;
+        s.erase(pos, struct_tok.size());
+    }
+    return s;
+}
+#endif
+
+static void normalize_type_names(std::vector<std::string> & output,
+                                 std::vector<std::string> & expected) {
+    #ifdef _MSC_VER
+    std::transform(output.begin(), output.end(), output.begin(),
+            [](std::string s) { return normalize_type_name(std::move(s)); });
+
+    std::transform(expected.begin(), expected.end(), expected.begin(),
+            [](std::string s) { return normalize_type_name(std::move(s)); });
+    #endif
+
+}
+
+
+
 
 class DummyOperation : public gko::Operation {
 public:
@@ -160,6 +195,9 @@ TEST(ProfilerHook, LogsPolymorphicObjectLinOp)
                                          false);
 
     exec->remove_logger(logger);
+
+    normalize_type_names(output, expected);
+
     ASSERT_EQ(output, expected);
 }
 
@@ -207,6 +245,8 @@ TEST(ProfilerHook, LogsPolymorphicObjectLinOpApplyWithType)
     linop->apply(linop, outvec);
     linop->apply(alpha, invec, scalar, linop);
 
+    normalize_type_names(output, expected);
+
     ASSERT_EQ(output, expected);
 }
 
@@ -245,6 +285,9 @@ TEST(ProfilerHook, LogsIteration)
     solver->apply(alpha, mtx, alpha, mtx);
 
     solver->remove_logger(logger);
+
+    normalize_type_names(output, expected);
+
     ASSERT_EQ(output, expected);
 }
 

--- a/core/test/log/profiler_hook.cpp
+++ b/core/test/log/profiler_hook.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -42,21 +42,9 @@ make_hooks(std::vector<std::string>& output)
 #ifdef _MSC_VER
 std::string normalize_type_name(std::string s)
 {
-    // Remove all MSVC-specific "class " and "struct " tokens
     const std::string class_tok = "class ";
     const std::string struct_tok = "struct ";
 
-    for (;;) {
-        auto pos = s.find(class_tok);
-        if (pos == std::string::npos) {
-            break;
-        }
-        s.erase(pos, class_tok.size());
-    }
-    for (;;) {
-        auto pos = s.find(struct_tok);
-        if (pos == std::string::npos) break;
-        s.erase(pos, struct_tok.size());
     auto pos = s.find(class_tok);
     while (pos != std::string::npos) {
         s.erase(pos, class_tok.size());
@@ -65,25 +53,27 @@ std::string normalize_type_name(std::string s)
     pos = s.find(struct_tok);
     while (pos != std::string::npos) {
         s.erase(pos, struct_tok.size());
-        auto pos = s.find(struct_tok);
+        pos = s.find(
+            struct_tok);  // was: auto pos = ... (bug: shadowed outer pos)
     }
     return s;
 }
+
 #endif
 
-void normalize_type_names(std::vector<std::string> & output,
-                                 std::vector<std::string> & expected) {
-    #ifdef _MSC_VER
-    std::transform(output.begin(), output.end(), output.begin(),
-            [](std::string s) { return normalize_type_name(std::move(s)); });
+void normalize_type_names(std::vector<std::string>& output,
+                          std::vector<std::string>& expected)
+{
+#ifdef _MSC_VER
+    std::transform(
+        output.begin(), output.end(), output.begin(),
+        [](std::string s) { return normalize_type_name(std::move(s)); });
 
-    std::transform(expected.begin(), expected.end(), expected.begin(),
-            [](std::string s) { return normalize_type_name(std::move(s)); });
-    #endif
-
+    std::transform(
+        expected.begin(), expected.end(), expected.begin(),
+        [](std::string s) { return normalize_type_name(std::move(s)); });
+#endif
 }
-
-
 
 
 class DummyOperation : public gko::Operation {

--- a/core/test/log/profiler_hook.cpp
+++ b/core/test/log/profiler_hook.cpp
@@ -40,7 +40,7 @@ make_hooks(std::vector<std::string>& output)
 }
 
 #ifdef _MSC_VER
-static std::string normalize_type_name(std::string s)
+std::string normalize_type_name(std::string s)
 {
     // Remove all MSVC-specific "class " and "struct " tokens
     const std::string class_tok = "class ";

--- a/core/test/log/profiler_hook.cpp
+++ b/core/test/log/profiler_hook.cpp
@@ -57,6 +57,15 @@ std::string normalize_type_name(std::string s)
         auto pos = s.find(struct_tok);
         if (pos == std::string::npos) break;
         s.erase(pos, struct_tok.size());
+    auto pos = s.find(class_tok);
+    while (pos != std::string::npos) {
+        s.erase(pos, class_tok.size());
+        pos = s.find(class_tok);
+    }
+    pos = s.find(struct_tok);
+    while (pos != std::string::npos) {
+        s.erase(pos, struct_tok.size());
+        auto pos = s.find(struct_tok);
     }
     return s;
 }

--- a/cuda/test/solver/upper_trs_kernels.cu
+++ b/cuda/test/solver/upper_trs_kernels.cu
@@ -19,6 +19,13 @@
 
 #include "cuda/test/utils.hpp"
 
+#ifdef _MSC_VER
+constexpr double tol = 1e-13;
+#else
+constexpr double tol = 1e-14;
+#endif
+
+
 
 namespace {
 
@@ -98,7 +105,7 @@ TEST_F(UpperTrs, CudaSingleRhsApplySyncfreelibIsEquivalentToRef)
     solver->apply(b2, x);
     d_solver->apply(d_b2, d_x);
 
-    GKO_ASSERT_MTX_NEAR(d_x, x, 1e-14);
+    GKO_ASSERT_MTX_NEAR(d_x, x, tol);
 }
 
 
@@ -113,7 +120,7 @@ TEST_F(UpperTrs, CudaSingleRhsApplyIsEquivalentToRef)
     solver->apply(b2, x);
     d_solver->apply(d_b2, d_x);
 
-    GKO_ASSERT_MTX_NEAR(d_x, x, 1e-14);
+    GKO_ASSERT_MTX_NEAR(d_x, x, tol);
 }
 
 
@@ -136,7 +143,7 @@ TEST_F(UpperTrs, CudaMultipleRhsApplySyncfreeIsEquivalentToRef)
     solver->apply(b2, x);
     d_solver->apply(db2_strided, dx_strided);
 
-    GKO_ASSERT_MTX_NEAR(dx_strided, x, 1e-14);
+    GKO_ASSERT_MTX_NEAR(dx_strided, x, tol);
 }
 
 
@@ -172,7 +179,7 @@ TEST_F(UpperTrs, CudaMultipleRhsApplyIsEquivalentToRef)
     solver->apply(b2, x);
     d_solver->apply(db2_strided, dx_strided);
 
-    GKO_ASSERT_MTX_NEAR(dx_strided, x, 1e-14);
+    GKO_ASSERT_MTX_NEAR(dx_strided, x, tol);
 }
 
 

--- a/cuda/test/solver/upper_trs_kernels.cu
+++ b/cuda/test/solver/upper_trs_kernels.cu
@@ -20,8 +20,6 @@
 #include "cuda/test/utils.hpp"
 
 
-constexpr double tol = 1e-13;
-
 namespace {
 
 
@@ -100,7 +98,7 @@ TEST_F(UpperTrs, CudaSingleRhsApplySyncfreelibIsEquivalentToRef)
     solver->apply(b2, x);
     d_solver->apply(d_b2, d_x);
 
-    GKO_ASSERT_MTX_NEAR(d_x, x, tol);
+    GKO_ASSERT_MTX_NEAR(d_x, x, 1e-14);
 }
 
 
@@ -115,7 +113,7 @@ TEST_F(UpperTrs, CudaSingleRhsApplyIsEquivalentToRef)
     solver->apply(b2, x);
     d_solver->apply(d_b2, d_x);
 
-    GKO_ASSERT_MTX_NEAR(d_x, x, tol);
+    GKO_ASSERT_MTX_NEAR(d_x, x, 1e-14);
 }
 
 
@@ -138,7 +136,7 @@ TEST_F(UpperTrs, CudaMultipleRhsApplySyncfreeIsEquivalentToRef)
     solver->apply(b2, x);
     d_solver->apply(db2_strided, dx_strided);
 
-    GKO_ASSERT_MTX_NEAR(dx_strided, x, tol);
+    GKO_ASSERT_MTX_NEAR(dx_strided, x, 1e-14);
 }
 
 
@@ -174,7 +172,7 @@ TEST_F(UpperTrs, CudaMultipleRhsApplyIsEquivalentToRef)
     solver->apply(b2, x);
     d_solver->apply(db2_strided, dx_strided);
 
-    GKO_ASSERT_MTX_NEAR(dx_strided, x, tol);
+    GKO_ASSERT_MTX_NEAR(dx_strided, x, 1e-14);
 }
 
 

--- a/cuda/test/solver/upper_trs_kernels.cu
+++ b/cuda/test/solver/upper_trs_kernels.cu
@@ -19,13 +19,8 @@
 
 #include "cuda/test/utils.hpp"
 
-#ifdef _MSC_VER
+
 constexpr double tol = 1e-13;
-#else
-constexpr double tol = 1e-14;
-#endif
-
-
 
 namespace {
 

--- a/reference/test/base/batch_multi_vector_kernels.cpp
+++ b/reference/test/base/batch_multi_vector_kernels.cpp
@@ -30,51 +30,52 @@ protected:
     using DenseMtx = gko::matrix::Dense<value_type>;
     using ComplexMtx = gko::to_complex<Mtx>;
     MultiVector()
-        : exec(gko::ReferenceExecutor::create()),
-          mtx_0(gko::batch::initialize<Mtx>(
+        : exec(gko::ReferenceExecutor::create())
+    {
+        mtx_0 = gko::batch::initialize<Mtx>(
               {{I<T>({1.0, -1.0, 1.5}), I<T>({-2.0, 2.0, 3.0})},
                {{1.0, -2.0, -0.5}, {1.0, -2.5, 4.0}}},
-              exec)),
-          mtx_00(gko::initialize<DenseMtx>(
-              {I<T>({1.0, -1.0, 1.5}), I<T>({-2.0, 2.0, 3.0})}, exec)),
-          mtx_01(gko::initialize<DenseMtx>(
-              {I<T>({1.0, -2.0, -0.5}), I<T>({1.0, -2.5, 4.0})}, exec)),
-          mtx_1(gko::batch::initialize<Mtx>(
+              exec);
+        mtx_00 = gko::initialize<DenseMtx>(
+              {I<T>({1.0, -1.0, 1.5}), I<T>({-2.0, 2.0, 3.0})}, exec);
+        mtx_01 = gko::initialize<DenseMtx>(
+              {I<T>({1.0, -2.0, -0.5}), I<T>({1.0, -2.5, 4.0})}, exec);
+        mtx_1 = gko::batch::initialize<Mtx>(
               {{{1.0, -1.0, 2.2}, {-2.0, 2.0, -0.5}},
                {{1.0, 2.5, 3.0}, {1.0, 2.0, 3.0}}},
-              exec)),
-          mtx_10(gko::initialize<DenseMtx>(
-              {I<T>({1.0, -1.0, 2.2}), I<T>({-2.0, 2.0, -0.5})}, exec)),
-          mtx_11(gko::initialize<DenseMtx>({{1.0, 2.5, 3.0}, {1.0, 2.0, 3.0}},
-                                           exec)),
-          mtx_2(gko::batch::initialize<Mtx>(
+              exec);
+        mtx_10 = gko::initialize<DenseMtx>(
+              {I<T>({1.0, -1.0, 2.2}), I<T>({-2.0, 2.0, -0.5})}, exec);
+        mtx_11 = gko::initialize<DenseMtx>({{1.0, 2.5, 3.0}, {1.0, 2.0, 3.0}},
+                                           exec);
+        mtx_2 = gko::batch::initialize<Mtx>(
               {{{1.0, 1.5}, {6.0, 1.0}, {-0.25, 1.0}},
                {I<T>({2.0, -2.0}), I<T>({1.0, 3.0}), I<T>({4.0, 3.0})}},
-              exec)),
-          mtx_20(gko::initialize<DenseMtx>(
-              {I<T>({1.0, 1.5}), I<T>({6.0, 1.0}), I<T>({-0.25, 1.0})}, exec)),
-          mtx_21(gko::initialize<DenseMtx>(
-              {I<T>({2.0, -2.0}), I<T>({1.0, 3.0}), I<T>({4.0, 3.0})}, exec)),
-          mtx_3(gko::batch::initialize<Mtx>(
+              exec);
+        mtx_20 = gko::initialize<DenseMtx>(
+              {I<T>({1.0, 1.5}), I<T>({6.0, 1.0}), I<T>({-0.25, 1.0})}, exec);
+        mtx_21 = gko::initialize<DenseMtx>(
+              {I<T>({2.0, -2.0}), I<T>({1.0, 3.0}), I<T>({4.0, 3.0})}, exec);
+        mtx_3 = gko::batch::initialize<Mtx>(
               {{I<T>({1.0, 1.5}), I<T>({6.0, 1.0})}, {{2.0, -2.0}, {1.0, 3.0}}},
-              exec)),
-          mtx_30(gko::initialize<DenseMtx>({I<T>({1.0, 1.5}), I<T>({6.0, 1.0})},
-                                           exec)),
-          mtx_31(gko::initialize<DenseMtx>(
-              {I<T>({2.0, -2.0}), I<T>({1.0, 3.0})}, exec)),
-          mtx_4(gko::batch::initialize<Mtx>(
+              exec);
+        mtx_30 = gko::initialize<DenseMtx>({I<T>({1.0, 1.5}), I<T>({6.0, 1.0})},
+                                           exec);
+        mtx_31 = gko::initialize<DenseMtx>(
+              {I<T>({2.0, -2.0}), I<T>({1.0, 3.0})}, exec);
+        mtx_4 = gko::batch::initialize<Mtx>(
               {{{1.0, 1.5, 3.0}, {6.0, 1.0, 5.0}, {6.0, 1.0, 5.5}},
                {{2.0, -2.0, 1.5}, {4.0, 3.0, 2.2}, {-1.25, 3.0, 0.5}}},
-              exec)),
-          mtx_5(gko::batch::initialize<Mtx>(
+              exec);
+        mtx_5 = gko::batch::initialize<Mtx>(
               {{{1.0, 1.5}, {6.0, 1.0}, {7.0, -4.5}},
                {I<T>({2.0, -2.0}), I<T>({1.0, 3.0}), I<T>({4.0, 3.0})}},
-              exec)),
-          mtx_6(gko::batch::initialize<Mtx>(
+              exec);
+        mtx_6 = gko::batch::initialize<Mtx>(
               {{{1.0, 0.0, 3.0}, {0.0, 3.0, 0.0}, {0.0, 1.0, 5.0}},
                {{2.0, 0.0, 5.0}, {0.0, 1.0, 0.0}, {0.0, -1.0, 8.0}}},
-              exec))
-    {}
+              exec);
+    }
 
     std::shared_ptr<const gko::ReferenceExecutor> exec;
     std::unique_ptr<Mtx> mtx_0;

--- a/reference/test/base/combination.cpp
+++ b/reference/test/base/combination.cpp
@@ -21,13 +21,14 @@ protected:
     using Mtx = gko::matrix::Dense<T>;
 
     Combination()
-        : exec{gko::ReferenceExecutor::create()},
-          coefficients{gko::initialize<Mtx>({1}, exec),
-                       gko::initialize<Mtx>({2}, exec)},
-          operators{
+        : exec{gko::ReferenceExecutor::create()}
+    {
+          coefficients = {gko::initialize<Mtx>({1}, exec),
+                          gko::initialize<Mtx>({2}, exec)};
+          operators = {
               gko::initialize<Mtx>({I<T>({2.0, 3.0}), I<T>({1.0, 4.0})}, exec),
-              gko::initialize<Mtx>({I<T>({3.0, 2.0}), I<T>({2.0, 0.0})}, exec)}
-    {}
+              gko::initialize<Mtx>({I<T>({3.0, 2.0}), I<T>({2.0, 0.0})}, exec)};
+    }
 
     std::shared_ptr<const gko::Executor> exec;
     std::vector<std::shared_ptr<gko::LinOp>> coefficients;

--- a/reference/test/base/composition.cpp
+++ b/reference/test/base/composition.cpp
@@ -51,8 +51,9 @@ protected:
     using value_type = T;
 
     Composition()
-        : exec{gko::ReferenceExecutor::create()},
-          operators{
+        : exec{gko::ReferenceExecutor::create()}
+    {
+        operators = {
               gko::initialize<Mtx>(I<T>({2.0, 1.0}), exec),
               gko::initialize<Mtx>({I<T>({3.0, 2.0})}, exec),
               gko::initialize<Mtx>(
@@ -61,12 +62,13 @@ protected:
                   {I<T>({9.0, 4.0}), I<T>({6.0, -2.0}), I<T>({-3.0, 2.0})},
                   exec),
               gko::initialize<Mtx>({I<T>({1.0, 0.0}), I<T>({0.0, 1.0})}, exec),
-              gko::initialize<Mtx>({I<T>({1.0, 0.0}), I<T>({0.0, 1.0})}, exec)},
-          identity{
-              gko::initialize<Mtx>({I<T>({1.0, 0.0}), I<T>({0.0, 1.0})}, exec)},
-          product{gko::initialize<Mtx>({I<T>({-9.0, -2.0}), I<T>({27.0, 26.0})},
-                                       exec)}
-    {}
+              gko::initialize<Mtx>({I<T>({1.0, 0.0}), I<T>({0.0, 1.0})}, exec)};
+
+        identity = {
+              gko::initialize<Mtx>({I<T>({1.0, 0.0}), I<T>({0.0, 1.0})}, exec)};
+        product = {gko::initialize<Mtx>({I<T>({-9.0, -2.0}), I<T>({27.0, 26.0})},
+                                       exec)};
+    }
 
     std::shared_ptr<const gko::Executor> exec;
     std::vector<std::shared_ptr<gko::LinOp>> coefficients;

--- a/reference/test/base/perturbation.cpp
+++ b/reference/test/base/perturbation.cpp
@@ -21,11 +21,12 @@ protected:
     using Mtx = gko::matrix::Dense<T>;
 
     Perturbation()
-        : exec{gko::ReferenceExecutor::create()},
-          basis{gko::initialize<Mtx>({2.0, 1.0}, exec)},
-          projector{gko::initialize<Mtx>({I<T>({3.0, 2.0})}, exec)},
-          scalar{gko::initialize<Mtx>({2.0}, exec)}
-    {}
+        : exec{gko::ReferenceExecutor::create()}
+    {
+        basis = {gko::initialize<Mtx>({2.0, 1.0}, exec)};
+        projector = {gko::initialize<Mtx>({I<T>({3.0, 2.0})}, exec)};
+        scalar = {gko::initialize<Mtx>({2.0}, exec)};
+    }
 
     std::shared_ptr<const gko::Executor> exec;
     std::shared_ptr<gko::LinOp> basis;

--- a/reference/test/matrix/batch_csr_kernels.cpp
+++ b/reference/test/matrix/batch_csr_kernels.cpp
@@ -31,38 +31,39 @@ protected:
     using CsrMtx = gko::matrix::Csr<value_type>;
     using DenseMtx = gko::matrix::Dense<value_type>;
     Csr()
-        : exec(gko::ReferenceExecutor::create()),
-          mtx_0(gko::batch::initialize<BMtx>(
+        : exec(gko::ReferenceExecutor::create())
+    {
+        mtx_0 = gko::batch::initialize<BMtx>(
               {{{1.0, -1.0, 0.0}, {-2.0, 2.0, 3.0}},
                {{1.0, -2.0, 0.0}, {1.0, -2.5, 4.0}}},
-              exec, 5)),
-          mtx_00(gko::initialize<CsrMtx>(
-              {I<T>({1.0, -1.0, 0.0}), I<T>({-2.0, 2.0, 3.0})}, exec)),
-          mtx_01(gko::initialize<CsrMtx>(
-              {I<T>({1.0, -2.0, 0.0}), I<T>({1.0, -2.5, 4.0})}, exec)),
-          b_0(gko::batch::initialize<BMVec>(
-              {{I<T>({1.0, 0.0, 1.0}), I<T>({2.0, 0.0, 1.0}),
-                I<T>({1.0, 0.0, 2.0})},
-               {I<T>({-1.0, 1.0, 1.0}), I<T>({1.0, -1.0, 1.0}),
-                I<T>({1.0, 0.0, 2.0})}},
-              exec)),
-          b_00(gko::initialize<DenseMtx>(
-              {I<T>({1.0, 0.0, 1.0}), I<T>({2.0, 0.0, 1.0}),
-               I<T>({1.0, 0.0, 2.0})},
-              exec)),
-          b_01(gko::initialize<DenseMtx>(
-              {I<T>({-1.0, 1.0, 1.0}), I<T>({1.0, -1.0, 1.0}),
-               I<T>({1.0, 0.0, 2.0})},
-              exec)),
-          x_0(gko::batch::initialize<BMVec>(
-              {{I<T>({2.0, 0.0, 1.0}), I<T>({2.0, 0.0, 2.0})},
-               {I<T>({-2.0, 1.0, 1.0}), I<T>({1.0, -1.0, -1.0})}},
-              exec)),
-          x_00(gko::initialize<DenseMtx>(
-              {I<T>({2.0, 0.0, 1.0}), I<T>({2.0, 0.0, 2.0})}, exec)),
-          x_01(gko::initialize<DenseMtx>(
-              {I<T>({-2.0, 1.0, 1.0}), I<T>({1.0, -1.0, -1.0})}, exec))
-    {}
+              exec, 5);
+        mtx_00 = gko::initialize<CsrMtx>(
+            {I<T>({1.0, -1.0, 0.0}), I<T>({-2.0, 2.0, 3.0})}, exec);
+        mtx_01 = gko::initialize<CsrMtx>(
+            {I<T>({1.0, -2.0, 0.0}), I<T>({1.0, -2.5, 4.0})}, exec);
+        b_0 = gko::batch::initialize<BMVec>(
+            {{I<T>({1.0, 0.0, 1.0}), I<T>({2.0, 0.0, 1.0}),
+            I<T>({1.0, 0.0, 2.0})},
+            {I<T>({-1.0, 1.0, 1.0}), I<T>({1.0, -1.0, 1.0}),
+            I<T>({1.0, 0.0, 2.0})}},
+            exec);
+        b_00 = gko::initialize<DenseMtx>(
+            {I<T>({1.0, 0.0, 1.0}), I<T>({2.0, 0.0, 1.0}),
+            I<T>({1.0, 0.0, 2.0})},
+            exec);
+        b_01 = gko::initialize<DenseMtx>(
+            {I<T>({-1.0, 1.0, 1.0}), I<T>({1.0, -1.0, 1.0}),
+            I<T>({1.0, 0.0, 2.0})},
+            exec);
+        x_0 = gko::batch::initialize<BMVec>(
+            {{I<T>({2.0, 0.0, 1.0}), I<T>({2.0, 0.0, 2.0})},
+            {I<T>({-2.0, 1.0, 1.0}), I<T>({1.0, -1.0, -1.0})}},
+            exec);
+        x_00 = gko::initialize<DenseMtx>(
+            {I<T>({2.0, 0.0, 1.0}), I<T>({2.0, 0.0, 2.0})}, exec);
+        x_01 = gko::initialize<DenseMtx>(
+            {I<T>({-2.0, 1.0, 1.0}), I<T>({1.0, -1.0, -1.0})}, exec);
+    }
 
     std::shared_ptr<const gko::ReferenceExecutor> exec;
     std::unique_ptr<BMtx> mtx_0;

--- a/reference/test/matrix/batch_dense_kernels.cpp
+++ b/reference/test/matrix/batch_dense_kernels.cpp
@@ -29,38 +29,39 @@ protected:
     using BMVec = gko::batch::MultiVector<value_type>;
     using DenseMtx = gko::matrix::Dense<value_type>;
     Dense()
-        : exec(gko::ReferenceExecutor::create()),
-          mtx_0(gko::batch::initialize<BMtx>(
-              {{I<T>({1.0, -1.0, 1.5}), I<T>({-2.0, 2.0, 3.0})},
-               {{1.0, -2.0, -0.5}, {1.0, -2.5, 4.0}}},
-              exec)),
-          mtx_00(gko::initialize<DenseMtx>(
-              {I<T>({1.0, -1.0, 1.5}), I<T>({-2.0, 2.0, 3.0})}, exec)),
-          mtx_01(gko::initialize<DenseMtx>(
-              {I<T>({1.0, -2.0, -0.5}), I<T>({1.0, -2.5, 4.0})}, exec)),
-          b_0(gko::batch::initialize<BMVec>(
-              {{I<T>({1.0, 0.0, 1.0}), I<T>({2.0, 0.0, 1.0}),
-                I<T>({1.0, 0.0, 2.0})},
-               {I<T>({-1.0, 1.0, 1.0}), I<T>({1.0, -1.0, 1.0}),
-                I<T>({1.0, 0.0, 2.0})}},
-              exec)),
-          b_00(gko::initialize<DenseMtx>(
-              {I<T>({1.0, 0.0, 1.0}), I<T>({2.0, 0.0, 1.0}),
-               I<T>({1.0, 0.0, 2.0})},
-              exec)),
-          b_01(gko::initialize<DenseMtx>(
-              {I<T>({-1.0, 1.0, 1.0}), I<T>({1.0, -1.0, 1.0}),
-               I<T>({1.0, 0.0, 2.0})},
-              exec)),
-          x_0(gko::batch::initialize<BMVec>(
-              {{I<T>({2.0, 0.0, 1.0}), I<T>({2.0, 0.0, 2.0})},
-               {I<T>({-2.0, 1.0, 1.0}), I<T>({1.0, -1.0, -1.0})}},
-              exec)),
-          x_00(gko::initialize<DenseMtx>(
-              {I<T>({2.0, 0.0, 1.0}), I<T>({2.0, 0.0, 2.0})}, exec)),
-          x_01(gko::initialize<DenseMtx>(
-              {I<T>({-2.0, 1.0, 1.0}), I<T>({1.0, -1.0, -1.0})}, exec))
-    {}
+        : exec(gko::ReferenceExecutor::create())
+    {
+        mtx_0 = gko::batch::initialize<BMtx>(
+            {{I<T>({1.0, -1.0, 1.5}), I<T>({-2.0, 2.0, 3.0})},
+            {{1.0, -2.0, -0.5}, {1.0, -2.5, 4.0}}},
+            exec);
+        mtx_00 = gko::initialize<DenseMtx>(
+            {I<T>({1.0, -1.0, 1.5}), I<T>({-2.0, 2.0, 3.0})}, exec);
+        mtx_01 = gko::initialize<DenseMtx>(
+            {I<T>({1.0, -2.0, -0.5}), I<T>({1.0, -2.5, 4.0})}, exec);
+        b_0 = gko::batch::initialize<BMVec>(
+            {{I<T>({1.0, 0.0, 1.0}), I<T>({2.0, 0.0, 1.0}),
+            I<T>({1.0, 0.0, 2.0})},
+            {I<T>({-1.0, 1.0, 1.0}), I<T>({1.0, -1.0, 1.0}),
+            I<T>({1.0, 0.0, 2.0})}},
+            exec);
+        b_00 = gko::initialize<DenseMtx>(
+            {I<T>({1.0, 0.0, 1.0}), I<T>({2.0, 0.0, 1.0}),
+            I<T>({1.0, 0.0, 2.0})},
+            exec);
+        b_01 = gko::initialize<DenseMtx>(
+            {I<T>({-1.0, 1.0, 1.0}), I<T>({1.0, -1.0, 1.0}),
+            I<T>({1.0, 0.0, 2.0})},
+            exec);
+        x_0 = gko::batch::initialize<BMVec>(
+            {{I<T>({2.0, 0.0, 1.0}), I<T>({2.0, 0.0, 2.0})},
+            {I<T>({-2.0, 1.0, 1.0}), I<T>({1.0, -1.0, -1.0})}},
+            exec);
+        x_00 = gko::initialize<DenseMtx>(
+            {I<T>({2.0, 0.0, 1.0}), I<T>({2.0, 0.0, 2.0})}, exec);
+        x_01 = gko::initialize<DenseMtx>(
+            {I<T>({-2.0, 1.0, 1.0}), I<T>({1.0, -1.0, -1.0})}, exec);
+    }
 
     std::shared_ptr<const gko::ReferenceExecutor> exec;
     std::unique_ptr<BMtx> mtx_0;

--- a/reference/test/matrix/batch_ell_kernels.cpp
+++ b/reference/test/matrix/batch_ell_kernels.cpp
@@ -31,38 +31,39 @@ protected:
     using EllMtx = gko::matrix::Ell<value_type>;
     using DenseMtx = gko::matrix::Dense<value_type>;
     Ell()
-        : exec(gko::ReferenceExecutor::create()),
-          mtx_0(gko::batch::initialize<BMtx>(
-              {{I<T>({1.0, -1.0, 1.5}), I<T>({-2.0, 2.0, 3.0})},
-               {{1.0, -2.0, -0.5}, {1.0, -2.5, 4.0}}},
-              exec)),
-          mtx_00(gko::initialize<EllMtx>(
-              {I<T>({1.0, -1.0, 1.5}), I<T>({-2.0, 2.0, 3.0})}, exec)),
-          mtx_01(gko::initialize<EllMtx>(
-              {I<T>({1.0, -2.0, -0.5}), I<T>({1.0, -2.5, 4.0})}, exec)),
-          b_0(gko::batch::initialize<BMVec>(
-              {{I<T>({1.0, 0.0, 1.0}), I<T>({2.0, 0.0, 1.0}),
-                I<T>({1.0, 0.0, 2.0})},
-               {I<T>({-1.0, 1.0, 1.0}), I<T>({1.0, -1.0, 1.0}),
-                I<T>({1.0, 0.0, 2.0})}},
-              exec)),
-          b_00(gko::initialize<DenseMtx>(
-              {I<T>({1.0, 0.0, 1.0}), I<T>({2.0, 0.0, 1.0}),
-               I<T>({1.0, 0.0, 2.0})},
-              exec)),
-          b_01(gko::initialize<DenseMtx>(
-              {I<T>({-1.0, 1.0, 1.0}), I<T>({1.0, -1.0, 1.0}),
-               I<T>({1.0, 0.0, 2.0})},
-              exec)),
-          x_0(gko::batch::initialize<BMVec>(
-              {{I<T>({2.0, 0.0, 1.0}), I<T>({2.0, 0.0, 2.0})},
-               {I<T>({-2.0, 1.0, 1.0}), I<T>({1.0, -1.0, -1.0})}},
-              exec)),
-          x_00(gko::initialize<DenseMtx>(
-              {I<T>({2.0, 0.0, 1.0}), I<T>({2.0, 0.0, 2.0})}, exec)),
-          x_01(gko::initialize<DenseMtx>(
-              {I<T>({-2.0, 1.0, 1.0}), I<T>({1.0, -1.0, -1.0})}, exec))
-    {}
+        : exec(gko::ReferenceExecutor::create())
+    {
+        mtx_0 = gko::batch::initialize<BMtx>(
+            {{I<T>({1.0, -1.0, 1.5}), I<T>({-2.0, 2.0, 3.0})},
+            {{1.0, -2.0, -0.5}, {1.0, -2.5, 4.0}}},
+            exec);
+        mtx_00 = gko::initialize<EllMtx>(
+            {I<T>({1.0, -1.0, 1.5}), I<T>({-2.0, 2.0, 3.0})}, exec);
+        mtx_01 = gko::initialize<EllMtx>(
+            {I<T>({1.0, -2.0, -0.5}), I<T>({1.0, -2.5, 4.0})}, exec);
+        b_0 = gko::batch::initialize<BMVec>(
+            {{I<T>({1.0, 0.0, 1.0}), I<T>({2.0, 0.0, 1.0}),
+            I<T>({1.0, 0.0, 2.0})},
+            {I<T>({-1.0, 1.0, 1.0}), I<T>({1.0, -1.0, 1.0}),
+            I<T>({1.0, 0.0, 2.0})}},
+            exec);
+        b_00 = gko::initialize<DenseMtx>(
+            {I<T>({1.0, 0.0, 1.0}), I<T>({2.0, 0.0, 1.0}),
+            I<T>({1.0, 0.0, 2.0})},
+            exec);
+        b_01 = gko::initialize<DenseMtx>(
+            {I<T>({-1.0, 1.0, 1.0}), I<T>({1.0, -1.0, 1.0}),
+            I<T>({1.0, 0.0, 2.0})},
+            exec);
+        x_0 = gko::batch::initialize<BMVec>(
+            {{I<T>({2.0, 0.0, 1.0}), I<T>({2.0, 0.0, 2.0})},
+            {I<T>({-2.0, 1.0, 1.0}), I<T>({1.0, -1.0, -1.0})}},
+            exec);
+        x_00 = gko::initialize<DenseMtx>(
+            {I<T>({2.0, 0.0, 1.0}), I<T>({2.0, 0.0, 2.0})}, exec);
+        x_01 = gko::initialize<DenseMtx>(
+            {I<T>({-2.0, 1.0, 1.0}), I<T>({1.0, -1.0, -1.0})}, exec);
+    }
 
     std::shared_ptr<const gko::ReferenceExecutor> exec;
     std::unique_ptr<BMtx> mtx_0;

--- a/reference/test/matrix/dense_kernels.cpp
+++ b/reference/test/matrix/dense_kernels.cpp
@@ -41,22 +41,23 @@ protected:
     using ComplexMtx = gko::to_complex<Mtx>;
     using RealMtx = gko::remove_complex<Mtx>;
     Dense()
-        : exec(gko::ReferenceExecutor::create()),
-          mtx1(gko::initialize<Mtx>(4, {{1.0, 2.0, 3.0}, {1.5, 2.5, 3.5}},
-                                    exec)),
-          mtx2(gko::initialize<Mtx>({I<T>({1.0, -1.0}), I<T>({-2.0, 2.0})},
-                                    exec)),
-          mtx3(gko::initialize<Mtx>(4, {{1.0, 2.0, 3.0}, {0.5, 1.5, 2.5}},
-                                    exec)),
-          mtx4(gko::initialize<Mtx>(4, {{1.0, 3.0, 2.0}, {0.0, 5.0, 0.0}},
-                                    exec)),
-          mtx5(gko::initialize<Mtx>(
-              {{1.0, -1.0, -0.5}, {-2.0, 2.0, 4.5}, {2.1, 3.4, 1.2}}, exec)),
-          mtx6(gko::initialize<Mtx>({{1.0, 2.0, 0.0}, {0.0, 1.5, 0.0}}, exec)),
-          mtx7(gko::initialize<Mtx>({{1.0, 2.0, 3.0}, {0.0, 1.5, 0.0}}, exec)),
-          mtx8(gko::initialize<Mtx>(
-              {I<T>({1.0, -1.0}), I<T>({-2.0, 2.0}), I<T>({-3.0, 3.0})}, exec))
-    {}
+        : exec(gko::ReferenceExecutor::create())
+    {
+        mtx1 = gko::initialize<Mtx>(4, {{1.0, 2.0, 3.0}, {1.5, 2.5, 3.5}},
+                                    exec);
+        mtx2 = gko::initialize<Mtx>({I<T>({1.0, -1.0}), I<T>({-2.0, 2.0})},
+                                exec);
+        mtx3 = gko::initialize<Mtx>(4, {{1.0, 2.0, 3.0}, {0.5, 1.5, 2.5}},
+                                exec);
+        mtx4 = gko::initialize<Mtx>(4, {{1.0, 3.0, 2.0}, {0.0, 5.0, 0.0}},
+                                exec);
+        mtx5 = gko::initialize<Mtx>(
+            {{1.0, -1.0, -0.5}, {-2.0, 2.0, 4.5}, {2.1, 3.4, 1.2}}, exec);
+        mtx6 = gko::initialize<Mtx>({{1.0, 2.0, 0.0}, {0.0, 1.5, 0.0}}, exec);
+        mtx7 = gko::initialize<Mtx>({{1.0, 2.0, 3.0}, {0.0, 1.5, 0.0}}, exec);
+        mtx8 = gko::initialize<Mtx>(
+            {I<T>({1.0, -1.0}), I<T>({-2.0, 2.0}), I<T>({-3.0, 3.0})}, exec);
+    }
 
     std::shared_ptr<const gko::Executor> exec;
     std::unique_ptr<Mtx> mtx1;

--- a/reference/test/multigrid/pgm_kernels.cpp
+++ b/reference/test/multigrid/pgm_kernels.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -59,32 +59,26 @@ protected:
                              std::make_shared<typename Mtx::classical>())),
           agg(exec, 5)
     {
-
         fine_b = gko::initialize<Vec>(
-              {I<VT>({2.0, -1.0}), I<VT>({-1.0, 2.0}), I<VT>({0.0, -1.0}),
-               I<VT>({3.0, -2.0}), I<VT>({-2.0, 1.0})},
-              exec);
-
+            {I<VT>({2.0, -1.0}), I<VT>({-1.0, 2.0}), I<VT>({0.0, -1.0}),
+             I<VT>({3.0, -2.0}), I<VT>({-2.0, 1.0})},
+            exec);
         coarse_b = gko::initialize<Vec>(
-              {I<VT>({2.0, -1.0}), I<VT>({0.0, -1.0})}, exec);
-
+            {I<VT>({2.0, -1.0}), I<VT>({0.0, -1.0})}, exec);
         restrict_ans = (gko::initialize<Vec>(
-              {I<VT>({0.0, -1.0}), I<VT>({2.0, 0.0})}, exec));
-
+            {I<VT>({0.0, -1.0}), I<VT>({2.0, 0.0})}, exec));
         prolong_ans = gko::initialize<Vec>(
-              {I<VT>({0.0, -2.0}), I<VT>({1.0, -2.0}), I<VT>({1.0, -2.0}),
-               I<VT>({0.0, -1.0}), I<VT>({2.0, 1.0})},
-              exec);
-
+            {I<VT>({0.0, -2.0}), I<VT>({1.0, -2.0}), I<VT>({1.0, -2.0}),
+             I<VT>({0.0, -1.0}), I<VT>({2.0, 1.0})},
+            exec);
         prolong_applyans = gko::initialize<Vec>(
-              {I<VT>({2.0, -1.0}), I<VT>({0.0, -1.0}), I<VT>({2.0, -1.0}),
-               I<VT>({0.0, -1.0}), I<VT>({2.0, -1.0})},
-              exec);
-
+            {I<VT>({2.0, -1.0}), I<VT>({0.0, -1.0}), I<VT>({2.0, -1.0}),
+             I<VT>({0.0, -1.0}), I<VT>({2.0, -1.0})},
+            exec);
         fine_x = gko::initialize<Vec>(
-              {I<VT>({-2.0, -1.0}), I<VT>({1.0, -1.0}), I<VT>({-1.0, -1.0}),
-               I<VT>({0.0, 0.0}), I<VT>({0.0, 2.0})},
-              exec);
+            {I<VT>({-2.0, -1.0}), I<VT>({1.0, -1.0}), I<VT>({-1.0, -1.0}),
+             I<VT>({0.0, 0.0}), I<VT>({0.0, 2.0})},
+            exec);
 
         this->create_mtx(mtx.get(), weight.get(), &agg, coarse.get());
         mg_level = pgm_factory->generate(mtx);

--- a/reference/test/multigrid/pgm_kernels.cpp
+++ b/reference/test/multigrid/pgm_kernels.cpp
@@ -50,26 +50,6 @@ protected:
                           .with_max_unassigned_ratio(0.1)
                           .with_skip_sorting(true)
                           .on(exec)),
-          fine_b(gko::initialize<Vec>(
-              {I<VT>({2.0, -1.0}), I<VT>({-1.0, 2.0}), I<VT>({0.0, -1.0}),
-               I<VT>({3.0, -2.0}), I<VT>({-2.0, 1.0})},
-              exec)),
-          coarse_b(gko::initialize<Vec>(
-              {I<VT>({2.0, -1.0}), I<VT>({0.0, -1.0})}, exec)),
-          restrict_ans((gko::initialize<Vec>(
-              {I<VT>({0.0, -1.0}), I<VT>({2.0, 0.0})}, exec))),
-          prolong_ans(gko::initialize<Vec>(
-              {I<VT>({0.0, -2.0}), I<VT>({1.0, -2.0}), I<VT>({1.0, -2.0}),
-               I<VT>({0.0, -1.0}), I<VT>({2.0, 1.0})},
-              exec)),
-          prolong_applyans(gko::initialize<Vec>(
-              {I<VT>({2.0, -1.0}), I<VT>({0.0, -1.0}), I<VT>({2.0, -1.0}),
-               I<VT>({0.0, -1.0}), I<VT>({2.0, -1.0})},
-              exec)),
-          fine_x(gko::initialize<Vec>(
-              {I<VT>({-2.0, -1.0}), I<VT>({1.0, -1.0}), I<VT>({-1.0, -1.0}),
-               I<VT>({0.0, 0.0}), I<VT>({0.0, 2.0})},
-              exec)),
           mtx(Mtx::create(exec, gko::dim<2>(5, 5), 15,
                           std::make_shared<typename Mtx::classical>())),
           weight(WeightMtx::create(
@@ -79,6 +59,33 @@ protected:
                              std::make_shared<typename Mtx::classical>())),
           agg(exec, 5)
     {
+
+        fine_b = gko::initialize<Vec>(
+              {I<VT>({2.0, -1.0}), I<VT>({-1.0, 2.0}), I<VT>({0.0, -1.0}),
+               I<VT>({3.0, -2.0}), I<VT>({-2.0, 1.0})},
+              exec);
+
+        coarse_b = gko::initialize<Vec>(
+              {I<VT>({2.0, -1.0}), I<VT>({0.0, -1.0})}, exec);
+
+        restrict_ans = (gko::initialize<Vec>(
+              {I<VT>({0.0, -1.0}), I<VT>({2.0, 0.0})}, exec));
+
+        prolong_ans = gko::initialize<Vec>(
+              {I<VT>({0.0, -2.0}), I<VT>({1.0, -2.0}), I<VT>({1.0, -2.0}),
+               I<VT>({0.0, -1.0}), I<VT>({2.0, 1.0})},
+              exec);
+
+        prolong_applyans = gko::initialize<Vec>(
+              {I<VT>({2.0, -1.0}), I<VT>({0.0, -1.0}), I<VT>({2.0, -1.0}),
+               I<VT>({0.0, -1.0}), I<VT>({2.0, -1.0})},
+              exec);
+
+        fine_x = gko::initialize<Vec>(
+              {I<VT>({-2.0, -1.0}), I<VT>({1.0, -1.0}), I<VT>({-1.0, -1.0}),
+               I<VT>({0.0, 0.0}), I<VT>({0.0, 2.0})},
+              exec);
+
         this->create_mtx(mtx.get(), weight.get(), &agg, coarse.get());
         mg_level = pgm_factory->generate(mtx);
         mtx_diag = weight->extract_diagonal();

--- a/reference/test/solver/upper_trs_kernels.cpp
+++ b/reference/test/solver/upper_trs_kernels.cpp
@@ -36,23 +36,6 @@ protected:
     UpperTrs()
         : exec(gko::ReferenceExecutor::create()),
           ref(gko::ReferenceExecutor::create()),
-          mtx(gko::initialize<Mtx>(
-              {{1, 3.0, 1.0}, {0.0, 1, 2.0}, {0.0, 0.0, 1}}, exec)),
-          mtx2(gko::initialize<Mtx>(
-              {{2, 3.0, 1.0}, {0.0, 3, 2.0}, {0.0, 0.0, 4}}, exec)),
-          mtx_big_upper(gko::initialize<Mtx>({{365.0, 97.0, -654.0, 8.0, 91.0},
-                                              {0.0, -642.0, 684.0, 68.0, 387.0},
-                                              {0.0, 0.0, 134, -651.0, 654.0},
-                                              {0.0, 0.0, 0.0, 43.0, -789.0},
-                                              {0.0, 0.0, 0.0, 0.0, 124.0}},
-                                             exec)),
-          mtx_big_general(
-              gko::initialize<Mtx>({{365.0, 97.0, -654.0, 8.0, 91.0},
-                                    {6.0, -642.0, 684.0, 68.0, 387.0},
-                                    {0.0, 0.0, 134, -651.0, 654.0},
-                                    {0.0, 0.0, -1.0, 43.0, -789.0},
-                                    {0.0, 2.0, 0.0, 4.0, 124.0}},
-                                   exec)),
           upper_trs_factory(Solver::build().on(exec)),
           upper_trs_syncfree_factory(
               Solver::build()
@@ -61,7 +44,25 @@ protected:
           upper_trs_factory_mrhs(Solver::build().with_num_rhs(2u).on(exec)),
           upper_trs_factory_unit(
               Solver::build().with_unit_diagonal(true).on(exec))
-    {}
+    {
+        mtx = gko::initialize<Mtx>(
+              {{1, 3.0, 1.0}, {0.0, 1, 2.0}, {0.0, 0.0, 1}}, exec);
+        mtx2 = gko::initialize<Mtx>(
+            {{2, 3.0, 1.0}, {0.0, 3, 2.0}, {0.0, 0.0, 4}}, exec);
+        mtx_big_upper = gko::initialize<Mtx>({{365.0, 97.0, -654.0, 8.0, 91.0},
+                                            {0.0, -642.0, 684.0, 68.0, 387.0},
+                                            {0.0, 0.0, 134, -651.0, 654.0},
+                                            {0.0, 0.0, 0.0, 43.0, -789.0},
+                                            {0.0, 0.0, 0.0, 0.0, 124.0}},
+                                            exec);
+        mtx_big_general =
+            gko::initialize<Mtx>({{365.0, 97.0, -654.0, 8.0, 91.0},
+                                {6.0, -642.0, 684.0, 68.0, 387.0},
+                                {0.0, 0.0, 134, -651.0, 654.0},
+                                {0.0, 0.0, -1.0, 43.0, -789.0},
+                                {0.0, 2.0, 0.0, 4.0, 124.0}},
+                                exec);
+    }
 
     std::shared_ptr<const gko::Executor> exec;
     std::shared_ptr<const gko::ReferenceExecutor> ref;


### PR DESCRIPTION
These changes fix two kinds of issues which cause various test failures seen running the tests on the following platform:

- NVIDIA RTX5070 Ti
- Windows 11
- MSVC 14.50 (Compiler Version 19.50.35729)  <-- this is the most relevant thing here in this PR
- CUDA 13.2

The two underlying issues are:

1) MSVC chokes on the combination of templating and braced initializer lists within member-initializer lists.  Moving the initializations into the constructor bodies allows the MSVC templating engine to function correctly.  Without this certain matrices were being default initialized to zero causing catastrophic failure of any tests which used this pattern.

Here are a couple of links concerning documented historical issues in MSVC with template resolution and initialiser lists:
https://learn.microsoft.com/en-us/cpp/overview/cpp-conformance-improvements-2019?view=msvc-170
https://devblogs.microsoft.com/cppblog/two-phase-name-lookup-support-comes-to-msvc/

2) The RTTI type introspection outputs on MSVC is different to GCC and it adds "class " and "struct " to descriptions which was then causing failures in the logger tests.  For example MSVC has:

```
class DummyLinOp *
class gko::matrix::Dense<float>
class gko::matrix::Dense<class std::complex<double>>
```

Whereas GCC has:

```
DummyLinOp *
gko::matrix::Dense<float>
gko::matrix::Dense<std::complex<double>>
```
This PR adds a couple of normalisation loops over the output and expected variables to strip out any mention of "class " or "struct ".

Here are the test summaries. Before the changes:

```
The following tests FAILED:
         15 - cuda/test/solver/upper_trs_kernels (Failed)
         18 - reference/test/base/batch_multi_vector_kernels (Failed)
         19 - reference/test/base/combination (Failed)
         20 - reference/test/base/composition (Failed)
         22 - reference/test/base/perturbation (Failed)
         48 - reference/test/matrix/batch_csr_kernels (Failed)
         49 - reference/test/matrix/batch_dense_kernels (Failed)
         50 - reference/test/matrix/batch_ell_kernels (Failed)
         53 - reference/test/matrix/dense_kernels (Failed)
         65 - reference/test/multigrid/pgm_kernels (Failed)
         66 - reference/test/multigrid/fixed_coarsening_kernels (Failed)
        174 - core/test/log/profiler_hook (Failed)
        285 - test/matrix/csr_kernels2_cuda (Failed)
        294 - test/matrix/matrix_cuda (Failed)
```

After:

```
The following tests FAILED:
         15 - cuda/test/solver/upper_trs_kernels (Failed)
         66 - reference/test/multigrid/fixed_coarsening_kernels (Failed)
        285 - test/matrix/csr_kernels2_cuda (Failed)
        294 - test/matrix/matrix_cuda (Failed)
```

These final four failures are CUDA hardware related and I am investigating them.  One of these is reported [here](https://github.com/ginkgo-project/ginkgo/issues/1981): 

I've also added my cmake configuration script for reference.

[ginkgo-run-cmake.txt](https://github.com/user-attachments/files/27240393/ginkgo-run-cmake.txt)
