### PR TITLE
Rename distributed::Matrix non_local_matrix to ghost _matrix

### DIFF
--- a/benchmark/solver/distributed/solver.cpp
+++ b/benchmark/solver/distributed/solver.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -42,7 +42,7 @@ struct Generator : public DistributedDefaultSystemGenerator<SolverGenerator> {
         return Vec::create(
             exec, comm, gko::dim<2>{system_matrix->get_size()[0], FLAGS_nrhs},
             local_generator.generate_rhs(
-                exec, gko::as<Mtx>(system_matrix)->get_local_matrix().get(),
+                exec, gko::as<Mtx>(system_matrix)->get_diag_matrix().get(),
                 config));
     }
 
@@ -53,7 +53,7 @@ struct Generator : public DistributedDefaultSystemGenerator<SolverGenerator> {
         return Vec::create(
             exec, comm, gko::dim<2>{rhs->get_size()[0], FLAGS_nrhs},
             local_generator.generate_initial_guess(
-                exec, gko::as<Mtx>(system_matrix)->get_local_matrix().get(),
+                exec, gko::as<Mtx>(system_matrix)->get_diag_matrix().get(),
                 rhs->get_local_vector()));
     }
 };
@@ -84,8 +84,8 @@ int main(int argc, char* argv[])
   Possible values for "stencil" are:  5pt (2D), 7pt (3D), 9pt (2D), 27pt (3D).
   Optional values for "comm_pattern" are: stencil, optimal.
   Possible values for "optimal[spmv]" follow the pattern
-  "<local_format>-<non_local_format>", where both "local_format" and
-  "non_local_format" can be any of the recognized spmv formats.
+  "<diag_format>-<off_diag_format>", where both "diag_format" and
+  "off_diag_format" can be any of the recognized spmv formats.
 )";
     std::string additional_json = R"(,"optimal":{"spmv":"csr-csr"})";
     initialize_argument_parsing_matrix(&argc, &argv, header, format,

--- a/benchmark/spmv/distributed/spmv.cpp
+++ b/benchmark/spmv/distributed/spmv.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -24,11 +24,11 @@
 #include "benchmark/utils/types.hpp"
 
 
-DEFINE_string(local_formats, "csr",
-              "A comma-separated list of formats for the local matrix to run. "
+DEFINE_string(diag_formats, "csr",
+              "A comma-separated list of formats for the diag matrix to run. "
               "See the 'formats' option for a list of supported versions");
-DEFINE_string(non_local_formats, "csr",
-              "A comma-separated list of formats for the non-local matrix to "
+DEFINE_string(off_diag_formats, "csr",
+              "A comma-separated list of formats for the off-diag matrix to "
               "run. See the 'formats' option for a list of supported versions");
 
 
@@ -53,18 +53,18 @@ int main(int argc, char* argv[])
 
     if (do_print) {
         std::string extra_information =
-            "The formats are [" + FLAGS_local_formats + "]x[" +
-            FLAGS_non_local_formats + "]\n" +
+            "The formats are [" + FLAGS_diag_formats + "]x[" +
+            FLAGS_off_diag_formats + "]\n" +
             "The number of right hand sides is " + std::to_string(FLAGS_nrhs);
         print_general_information(extra_information, exec);
     }
 
-    auto local_formats = split(FLAGS_local_formats, ',');
-    auto non_local_formats = split(FLAGS_non_local_formats, ',');
+    auto diag_formats = split(FLAGS_diag_formats, ',');
+    auto off_diag_formats = split(FLAGS_off_diag_formats, ',');
     std::vector<std::string> formats;
-    for (const auto& local_fmt : local_formats) {
-        for (const auto& non_local_fmt : non_local_formats) {
-            formats.push_back(local_fmt + "-" + non_local_fmt);
+    for (const auto& diag_fmt : diag_formats) {
+        for (const auto& off_diag_fmt : off_diag_formats) {
+            formats.push_back(diag_fmt + "-" + off_diag_fmt);
         }
     }
 

--- a/benchmark/test/reference/distributed_solver.profile.stderr
+++ b/benchmark/test/reference/distributed_solver.profile.stderr
@@ -68,8 +68,8 @@ DEBUG: end   copy
 DEBUG: end   copy(<typename>)
 DEBUG: begin components::aos_to_soa
 DEBUG: end   components::aos_to_soa
-DEBUG: begin distributed_matrix::separate_local_nonlocal
-DEBUG: end   distributed_matrix::separate_local_nonlocal
+DEBUG: begin distributed_matrix::separate_diag_off_diag
+DEBUG: end   distributed_matrix::separate_diag_off_diag
 DEBUG: begin components::fill_array
 DEBUG: end   components::fill_array
 DEBUG: begin components::fill_array

--- a/benchmark/test/reference/spmv_distributed.profile.stderr
+++ b/benchmark/test/reference/spmv_distributed.profile.stderr
@@ -84,8 +84,8 @@ DEBUG: end   copy
 DEBUG: end   copy(<typename>)
 DEBUG: begin components::aos_to_soa
 DEBUG: end   components::aos_to_soa
-DEBUG: begin distributed_matrix::separate_local_nonlocal
-DEBUG: end   distributed_matrix::separate_local_nonlocal
+DEBUG: begin distributed_matrix::separate_diag_off_diag
+DEBUG: end   distributed_matrix::separate_diag_off_diag
 DEBUG: begin components::fill_array
 DEBUG: end   components::fill_array
 DEBUG: begin components::fill_array

--- a/benchmark/utils/generator.hpp
+++ b/benchmark/utils/generator.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -256,8 +256,8 @@ struct DistributedDefaultSystemGenerator {
                                      format_name};
         }
 
-        auto local_mat = formats::matrix_type_factory.at(formats[0])(exec);
-        auto non_local_mat = formats::matrix_type_factory.at(formats[1])(exec);
+        auto diag_mat = formats::matrix_type_factory.at(formats[0])(exec);
+        auto off_diag_mat = formats::matrix_type_factory.at(formats[1])(exec);
 
         auto storage_logger = std::make_shared<StorageLogger>();
         if (spmv_case) {
@@ -265,7 +265,7 @@ struct DistributedDefaultSystemGenerator {
         }
 
         auto dist_mat = dist_mtx<etype, itype, global_itype>::create(
-            exec, comm, local_mat, non_local_mat);
+            exec, comm, diag_mat, off_diag_mat);
         dist_mat->read_distributed(data, part);
 
         if (spmv_case) {

--- a/common/cuda_hip/distributed/matrix_kernels.cpp
+++ b/common/cuda_hip/distributed/matrix_kernels.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -50,7 +50,7 @@ struct input_type {
 
 
 template <typename ValueType, typename LocalIndexType, typename GlobalIndexType>
-void separate_local_nonlocal(
+void separate_diag_off_diag(
     std::shared_ptr<const DefaultExecutor> exec,
     const device_matrix_data<ValueType, GlobalIndexType>& input,
     const experimental::distributed::Partition<LocalIndexType, GlobalIndexType>*
@@ -58,11 +58,10 @@ void separate_local_nonlocal(
     const experimental::distributed::Partition<LocalIndexType, GlobalIndexType>*
         col_partition,
     experimental::distributed::comm_index_type local_part,
-    array<LocalIndexType>& local_row_idxs,
-    array<LocalIndexType>& local_col_idxs, array<ValueType>& local_values,
-    array<LocalIndexType>& non_local_row_idxs,
-    array<GlobalIndexType>& non_local_col_idxs,
-    array<ValueType>& non_local_values)
+    array<LocalIndexType>& diag_row_idxs, array<LocalIndexType>& diag_col_idxs,
+    array<ValueType>& diag_values, array<LocalIndexType>& off_diag_row_idxs,
+    array<GlobalIndexType>& off_diag_col_idxs,
+    array<ValueType>& off_diag_values)
 {
     auto input_vals = input.get_const_values();
     auto row_part_ids = row_partition->get_part_ids();
@@ -93,9 +92,9 @@ void separate_local_nonlocal(
                         input_col_idxs + num_input_elements,
                         col_range_ids.get_data());
 
-    // count number of local<0> and non-local<1> elements. Since the input
-    // may contain non-local rows, we don't have
-    // num_local + num_non_local = num_elements and can't just count one of them
+    // count number of diag<0> and off-diag<1> elements. Since the input
+    // may contain rows not owned by this rank, we don't have
+    // num_diag + num_off_diag = num_elements and can't just count one of them
     auto range_ids_it = thrust::make_zip_iterator(thrust::make_tuple(
         row_range_ids.get_const_data(), col_range_ids.get_const_data()));
     auto num_elements_pair = thrust::transform_reduce(
@@ -104,13 +103,13 @@ void separate_local_nonlocal(
             const thrust::tuple<size_type, size_type>& tuple) {
             auto row_part = row_part_ids[thrust::get<0>(tuple)];
             auto col_part = col_part_ids[thrust::get<1>(tuple)];
-            bool is_inner_entry =
+            bool is_diag_entry =
                 row_part == local_part && col_part == local_part;
-            bool is_ghost_entry =
+            bool is_off_diag_entry =
                 row_part == local_part && col_part != local_part;
             return thrust::make_tuple(
-                is_inner_entry ? size_type{1} : size_type{0},
-                is_ghost_entry ? size_type{1} : size_type{0});
+                is_diag_entry ? size_type{1} : size_type{0},
+                is_off_diag_entry ? size_type{1} : size_type{0});
         },
         thrust::make_tuple(size_type{}, size_type{}),
         [] __host__ __device__(const thrust::tuple<size_type, size_type>& a,
@@ -118,8 +117,8 @@ void separate_local_nonlocal(
             return thrust::make_tuple(thrust::get<0>(a) + thrust::get<0>(b),
                                       thrust::get<1>(a) + thrust::get<1>(b));
         });
-    auto num_local_elements = thrust::get<0>(num_elements_pair);
-    auto num_non_local_elements = thrust::get<1>(num_elements_pair);
+    auto num_diag_elements = thrust::get<0>(num_elements_pair);
+    auto num_off_diag_elements = thrust::get<1>(num_elements_pair);
 
     // define global-to-local maps for row and column indices
     auto map_to_local_row =
@@ -143,11 +142,11 @@ void separate_local_nonlocal(
         as_device_type(input.get_const_values()),
         row_range_ids.get_const_data(), col_range_ids.get_const_data()));
 
-    // copy and transform local entries into arrays
-    local_row_idxs.resize_and_reset(num_local_elements);
-    local_col_idxs.resize_and_reset(num_local_elements);
-    local_values.resize_and_reset(num_local_elements);
-    auto local_it = thrust::make_transform_iterator(
+    // copy and transform diag entries into arrays
+    diag_row_idxs.resize_and_reset(num_diag_elements);
+    diag_col_idxs.resize_and_reset(num_diag_elements);
+    diag_values.resize_and_reset(num_diag_elements);
+    auto diag_it = thrust::make_transform_iterator(
         input_it, [map_to_local_row, map_to_local_col] __host__ __device__(
                       const input_type input) {
             auto local_row = map_to_local_row(input.row, input.row_range);
@@ -155,11 +154,11 @@ void separate_local_nonlocal(
             return thrust::make_tuple(local_row, local_col, input.val);
         });
     thrust::copy_if(
-        policy, local_it, local_it + input.get_num_stored_elements(),
+        policy, diag_it, diag_it + input.get_num_stored_elements(),
         range_ids_it,
         thrust::make_zip_iterator(thrust::make_tuple(
-            local_row_idxs.get_data(), local_col_idxs.get_data(),
-            as_device_type(local_values.get_data()))),
+            diag_row_idxs.get_data(), diag_col_idxs.get_data(),
+            as_device_type(diag_values.get_data()))),
         [local_part, row_part_ids, col_part_ids] __host__ __device__(
             const thrust::tuple<size_type, size_type>& tuple) {
             auto row_part = row_part_ids[thrust::get<0>(tuple)];
@@ -168,24 +167,24 @@ void separate_local_nonlocal(
         });
 
 
-    // copy and transform non-local entries into arrays. this keeps global
-    // column indices, and also stores the column part id for each non-local
+    // copy and transform off-diag entries into arrays. this keeps global
+    // column indices, and also stores the column part id for each off-diag
     // entry in an array
-    non_local_row_idxs.resize_and_reset(num_non_local_elements);
-    non_local_col_idxs.resize_and_reset(num_non_local_elements);
-    non_local_values.resize_and_reset(num_non_local_elements);
-    auto non_local_it = thrust::make_transform_iterator(
+    off_diag_row_idxs.resize_and_reset(num_off_diag_elements);
+    off_diag_col_idxs.resize_and_reset(num_off_diag_elements);
+    off_diag_values.resize_and_reset(num_off_diag_elements);
+    auto off_diag_it = thrust::make_transform_iterator(
         input_it, [map_to_local_row,
                    col_part_ids] __host__ __device__(const input_type input) {
             auto local_row = map_to_local_row(input.row, input.row_range);
             return thrust::make_tuple(local_row, input.col, input.val);
         });
     thrust::copy_if(
-        policy, non_local_it, non_local_it + input.get_num_stored_elements(),
+        policy, off_diag_it, off_diag_it + input.get_num_stored_elements(),
         range_ids_it,
         thrust::make_zip_iterator(thrust::make_tuple(
-            non_local_row_idxs.get_data(), non_local_col_idxs.get_data(),
-            as_device_type(non_local_values.get_data()))),
+            off_diag_row_idxs.get_data(), off_diag_col_idxs.get_data(),
+            as_device_type(off_diag_values.get_data()))),
         [local_part, row_part_ids, col_part_ids] __host__ __device__(
             const thrust::tuple<size_type, size_type>& tuple) {
             auto row_part = row_part_ids[thrust::get<0>(tuple)];
@@ -195,7 +194,7 @@ void separate_local_nonlocal(
 }
 
 GKO_INSTANTIATE_FOR_EACH_VALUE_AND_LOCAL_GLOBAL_INDEX_TYPE(
-    GKO_DECLARE_SEPARATE_LOCAL_NONLOCAL);
+    GKO_DECLARE_SEPARATE_DIAG_OFF_DIAG);
 
 
 }  // namespace distributed_matrix

--- a/core/device_hooks/common_kernels.inc.cpp
+++ b/core/device_hooks/common_kernels.inc.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -389,7 +389,7 @@ namespace distributed_matrix {
 
 
 GKO_STUB_VALUE_AND_LOCAL_GLOBAL_INDEX_TYPE_BASE(
-    GKO_DECLARE_SEPARATE_LOCAL_NONLOCAL);
+    GKO_DECLARE_SEPARATE_DIAG_OFF_DIAG);
 
 
 }  // namespace distributed_matrix

--- a/core/distributed/helpers.hpp
+++ b/core/distributed/helpers.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -193,7 +193,7 @@ inline const LinOp* get_local(const LinOp* mtx)
 #if GINKGO_BUILD_MPI
     if (is_distributed(mtx)) {
         return run_matrix(mtx, [](auto concrete) {
-            return concrete->get_local_matrix().get();
+            return concrete->get_diag_matrix().get();
         });
     }
 #endif

--- a/core/distributed/matrix.cpp
+++ b/core/distributed/matrix.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -26,8 +26,8 @@ namespace matrix {
 namespace {
 
 
-GKO_REGISTER_OPERATION(separate_local_nonlocal,
-                       distributed_matrix::separate_local_nonlocal);
+GKO_REGISTER_OPERATION(separate_diag_off_diag,
+                       distributed_matrix::separate_diag_off_diag);
 
 
 }  // namespace
@@ -47,46 +47,46 @@ template <typename ValueType, typename LocalIndexType, typename GlobalIndexType>
 Matrix<ValueType, LocalIndexType, GlobalIndexType>::Matrix(
     std::shared_ptr<const Executor> exec,
     std::shared_ptr<const RowGatherer<LocalIndexType>> row_gather_template,
-    ptr_param<const LinOp> local_matrix_template,
-    ptr_param<const LinOp> non_local_matrix_template)
+    ptr_param<const LinOp> diag_matrix_template,
+    ptr_param<const LinOp> off_diag_matrix_template)
     : EnableLinOp<Matrix>{exec},
       DistributedBase{row_gather_template->get_communicator()},
       row_gatherer_{row_gather_template->clone(exec)},
       imap_{exec},
       one_scalar_{exec, 1.0},
-      local_mtx_{local_matrix_template->clone(exec)},
-      non_local_mtx_{non_local_matrix_template->clone(exec)}
+      diag_mtx_{diag_matrix_template->clone(exec)},
+      off_diag_mtx_{off_diag_matrix_template->clone(exec)}
 {
     GKO_ASSERT(
         (dynamic_cast<ReadableFromMatrixData<ValueType, LocalIndexType>*>(
-            local_mtx_.get())));
+            diag_mtx_.get())));
     GKO_ASSERT(
         (dynamic_cast<ReadableFromMatrixData<ValueType, LocalIndexType>*>(
-            non_local_mtx_.get())));
+            off_diag_mtx_.get())));
 }
 
 template <typename ValueType, typename LocalIndexType, typename GlobalIndexType>
 Matrix<ValueType, LocalIndexType, GlobalIndexType>::Matrix(
     std::shared_ptr<const Executor> exec, mpi::communicator comm, dim<2> size,
-    std::shared_ptr<LinOp> local_linop)
+    std::shared_ptr<LinOp> diag_linop)
     : EnableLinOp<Matrix>{exec},
       DistributedBase{comm},
       row_gatherer_{RowGatherer<LocalIndexType>::create(
           exec, mpi::detail::create_default_collective_communicator(comm))},
       imap_{exec},
       one_scalar_{exec, 1.0},
-      non_local_mtx_(::gko::matrix::Coo<ValueType, LocalIndexType>::create(
-          exec, dim<2>{local_linop->get_size()[0], 0}))
+      off_diag_mtx_(::gko::matrix::Coo<ValueType, LocalIndexType>::create(
+          exec, dim<2>{diag_linop->get_size()[0], 0}))
 {
     this->set_size(size);
-    local_mtx_ = std::move(local_linop);
+    diag_mtx_ = std::move(diag_linop);
 }
 
 template <typename ValueType, typename LocalIndexType, typename GlobalIndexType>
 Matrix<ValueType, LocalIndexType, GlobalIndexType>::Matrix(
     std::shared_ptr<const Executor> exec, mpi::communicator comm,
     index_map<LocalIndexType, GlobalIndexType> imap,
-    std::shared_ptr<LinOp> local_linop, std::shared_ptr<LinOp> non_local_linop)
+    std::shared_ptr<LinOp> diag_linop, std::shared_ptr<LinOp> off_diag_linop)
     : EnableLinOp<Matrix>{exec},
       DistributedBase{comm},
       row_gatherer_(RowGatherer<LocalIndexType>::create(
@@ -98,8 +98,8 @@ Matrix<ValueType, LocalIndexType, GlobalIndexType>::Matrix(
       one_scalar_{exec, 1.0}
 {
     this->set_size({imap_.get_global_size(), imap_.get_global_size()});
-    local_mtx_ = std::move(local_linop);
-    non_local_mtx_ = std::move(non_local_linop);
+    diag_mtx_ = std::move(diag_linop);
+    off_diag_mtx_ = std::move(off_diag_linop);
 }
 
 
@@ -126,14 +126,14 @@ template <typename ValueType, typename LocalIndexType, typename GlobalIndexType>
 std::unique_ptr<Matrix<ValueType, LocalIndexType, GlobalIndexType>>
 Matrix<ValueType, LocalIndexType, GlobalIndexType>::create(
     std::shared_ptr<const Executor> exec, mpi::communicator comm,
-    ptr_param<const LinOp> local_matrix_template,
-    ptr_param<const LinOp> non_local_matrix_template)
+    ptr_param<const LinOp> diag_matrix_template,
+    ptr_param<const LinOp> off_diag_matrix_template)
 {
     return std::unique_ptr<Matrix>{new Matrix{
         exec,
         RowGatherer<LocalIndexType>::create(
             exec, mpi::detail::create_default_collective_communicator(comm)),
-        local_matrix_template, non_local_matrix_template}};
+        diag_matrix_template, off_diag_matrix_template}};
 }
 
 
@@ -141,9 +141,9 @@ template <typename ValueType, typename LocalIndexType, typename GlobalIndexType>
 std::unique_ptr<Matrix<ValueType, LocalIndexType, GlobalIndexType>>
 Matrix<ValueType, LocalIndexType, GlobalIndexType>::create(
     std::shared_ptr<const Executor> exec, mpi::communicator comm, dim<2> size,
-    std::shared_ptr<LinOp> local_linop)
+    std::shared_ptr<LinOp> diag_linop)
 {
-    return std::unique_ptr<Matrix>{new Matrix{exec, comm, size, local_linop}};
+    return std::unique_ptr<Matrix>{new Matrix{exec, comm, size, diag_linop}};
 }
 
 
@@ -151,7 +151,7 @@ template <typename ValueType, typename LocalIndexType, typename GlobalIndexType>
 std::unique_ptr<Matrix<ValueType, LocalIndexType, GlobalIndexType>>
 Matrix<ValueType, LocalIndexType, GlobalIndexType>::create(
     std::shared_ptr<const Executor> exec, mpi::communicator comm, dim<2> size,
-    std::shared_ptr<LinOp> local_linop, std::shared_ptr<LinOp> non_local_linop,
+    std::shared_ptr<LinOp> diag_linop, std::shared_ptr<LinOp> off_diag_linop,
     std::vector<comm_index_type> recv_sizes,
     std::vector<comm_index_type> recv_offsets,
     array<local_index_type> recv_gather_idxs)
@@ -161,7 +161,7 @@ Matrix<ValueType, LocalIndexType, GlobalIndexType>::create(
               0);
     auto contiguous_partition =
         share(build_partition_from_local_size<LocalIndexType, GlobalIndexType>(
-            exec, comm, local_linop->get_size()[0]));
+            exec, comm, diag_linop->get_size()[0]));
     array<global_index_type> global_recv_gather_idxs(
         exec, recv_gather_idxs.get_size());
     for (int rank = 0; rank < comm.size(); ++rank) {
@@ -182,7 +182,7 @@ Matrix<ValueType, LocalIndexType, GlobalIndexType>::create(
         exec, comm,
         index_map<LocalIndexType, GlobalIndexType>(
             exec, contiguous_partition, comm.rank(), global_recv_gather_idxs),
-        std::move(local_linop), std::move(non_local_linop));
+        std::move(diag_linop), std::move(off_diag_linop));
 }
 
 
@@ -191,11 +191,11 @@ std::unique_ptr<Matrix<ValueType, LocalIndexType, GlobalIndexType>>
 Matrix<ValueType, LocalIndexType, GlobalIndexType>::create(
     std::shared_ptr<const Executor> exec, mpi::communicator comm,
     index_map<LocalIndexType, GlobalIndexType> imap,
-    std::shared_ptr<LinOp> local_linop, std::shared_ptr<LinOp> non_local_linop)
+    std::shared_ptr<LinOp> diag_linop, std::shared_ptr<LinOp> off_diag_linop)
 {
     return std::unique_ptr<Matrix>{
         new Matrix{std::move(exec), comm, std::move(imap),
-                   std::move(local_linop), std::move(non_local_linop)}};
+                   std::move(diag_linop), std::move(off_diag_linop)}};
 }
 
 
@@ -206,8 +206,8 @@ void Matrix<ValueType, LocalIndexType, GlobalIndexType>::convert_to(
 {
     GKO_ASSERT(this->get_communicator().size() ==
                result->get_communicator().size());
-    result->local_mtx_->copy_from(this->local_mtx_);
-    result->non_local_mtx_->copy_from(this->non_local_mtx_);
+    result->diag_mtx_->copy_from(this->diag_mtx_);
+    result->off_diag_mtx_->copy_from(this->off_diag_mtx_);
     result->row_gatherer_->copy_from(this->row_gatherer_);
     result->imap_ = this->imap_;
     result->set_size(this->get_size());
@@ -221,8 +221,8 @@ void Matrix<ValueType, LocalIndexType, GlobalIndexType>::move_to(
 {
     GKO_ASSERT(this->get_communicator().size() ==
                result->get_communicator().size());
-    result->local_mtx_->move_from(this->local_mtx_);
-    result->non_local_mtx_->move_from(this->non_local_mtx_);
+    result->diag_mtx_->move_from(this->diag_mtx_);
+    result->off_diag_mtx_->move_from(this->off_diag_mtx_);
     result->row_gatherer_->move_from(this->row_gatherer_);
     result->imap_ = std::move(this->imap_);
     result->set_size(this->get_size());
@@ -238,8 +238,8 @@ void Matrix<ValueType, LocalIndexType, GlobalIndexType>::convert_to(
 {
     GKO_ASSERT(this->get_communicator().size() ==
                result->get_communicator().size());
-    result->local_mtx_->copy_from(this->local_mtx_.get());
-    result->non_local_mtx_->copy_from(this->non_local_mtx_.get());
+    result->diag_mtx_->copy_from(this->diag_mtx_.get());
+    result->off_diag_mtx_->copy_from(this->off_diag_mtx_.get());
     result->row_gatherer_->copy_from(this->row_gatherer_);
     result->imap_ = this->imap_;
     result->set_size(this->get_size());
@@ -253,8 +253,8 @@ void Matrix<ValueType, LocalIndexType, GlobalIndexType>::move_to(
 {
     GKO_ASSERT(this->get_communicator().size() ==
                result->get_communicator().size());
-    result->local_mtx_->move_from(this->local_mtx_.get());
-    result->non_local_mtx_->move_from(this->non_local_mtx_.get());
+    result->diag_mtx_->move_from(this->diag_mtx_.get());
+    result->off_diag_mtx_->move_from(this->off_diag_mtx_.get());
     result->row_gatherer_->move_from(this->row_gatherer_);
     result->imap_ = std::move(this->imap_);
     result->set_size(this->get_size());
@@ -271,8 +271,8 @@ void Matrix<ValueType, LocalIndexType, GlobalIndexType>::convert_to(
 {
     GKO_ASSERT(this->get_communicator().size() ==
                result->get_communicator().size());
-    result->local_mtx_->copy_from(this->local_mtx_.get());
-    result->non_local_mtx_->copy_from(this->non_local_mtx_.get());
+    result->diag_mtx_->copy_from(this->diag_mtx_.get());
+    result->off_diag_mtx_->copy_from(this->off_diag_mtx_.get());
     result->row_gatherer_->copy_from(this->row_gatherer_);
     result->imap_ = this->imap_;
     result->set_size(this->get_size());
@@ -286,8 +286,8 @@ void Matrix<ValueType, LocalIndexType, GlobalIndexType>::move_to(
 {
     GKO_ASSERT(this->get_communicator().size() ==
                result->get_communicator().size());
-    result->local_mtx_->move_from(this->local_mtx_.get());
-    result->non_local_mtx_->move_from(this->non_local_mtx_.get());
+    result->diag_mtx_->move_from(this->diag_mtx_.get());
+    result->off_diag_mtx_->move_from(this->off_diag_mtx_.get());
     result->row_gatherer_->move_from(this->row_gatherer_);
     result->imap_ = std::move(this->imap_);
     result->set_size(this->get_size());
@@ -333,44 +333,44 @@ void Matrix<ValueType, LocalIndexType, GlobalIndexType>::read_distributed(
     this->set_size(global_dim);
 
     // temporary storage for the output
-    array<local_index_type> local_row_idxs{exec};
-    array<local_index_type> local_col_idxs{exec};
-    array<value_type> local_values{exec};
-    array<local_index_type> non_local_row_idxs{exec};
-    array<global_index_type> global_non_local_col_idxs{exec};
-    array<value_type> non_local_values{exec};
+    array<local_index_type> diag_row_idxs{exec};
+    array<local_index_type> diag_col_idxs{exec};
+    array<value_type> diag_values{exec};
+    array<local_index_type> off_diag_row_idxs{exec};
+    array<global_index_type> global_off_diag_col_idxs{exec};
+    array<value_type> off_diag_values{exec};
 
-    // separate input into local and non-local block
-    // The rows and columns of the local block are mapped into local indexing,
-    // as well as the rows of the non-local block. The columns of the non-local
+    // separate input into diag and off-diag block
+    // The rows and columns of the diag block are mapped into local indexing,
+    // as well as the rows of the off-diag block. The columns of the off-diag
     // block are still in global indices.
-    exec->run(matrix::make_separate_local_nonlocal(
+    exec->run(matrix::make_separate_diag_off_diag(
         *all_data_ptr, tmp_row_partition.get(), tmp_col_partition.get(),
-        local_part, local_row_idxs, local_col_idxs, local_values,
-        non_local_row_idxs, global_non_local_col_idxs, non_local_values));
+        local_part, diag_row_idxs, diag_col_idxs, diag_values,
+        off_diag_row_idxs, global_off_diag_col_idxs, off_diag_values));
 
     imap_ = index_map<local_index_type, global_index_type>(
-        exec, col_partition, comm.rank(), global_non_local_col_idxs);
+        exec, col_partition, comm.rank(), global_off_diag_col_idxs);
 
-    auto non_local_col_idxs =
-        imap_.map_to_local(global_non_local_col_idxs, index_space::non_local);
+    auto off_diag_col_idxs =
+        imap_.map_to_local(global_off_diag_col_idxs, index_space::non_local);
 
-    // read the local matrix data
+    // read the diag matrix data
     const auto num_local_rows =
         static_cast<size_type>(row_partition->get_part_size(local_part));
     const auto num_local_cols =
         static_cast<size_type>(col_partition->get_part_size(local_part));
-    device_matrix_data<value_type, local_index_type> local_data{
-        exec, dim<2>{num_local_rows, num_local_cols}, std::move(local_row_idxs),
-        std::move(local_col_idxs), std::move(local_values)};
-    device_matrix_data<value_type, local_index_type> non_local_data{
+    device_matrix_data<value_type, local_index_type> diag_data{
+        exec, dim<2>{num_local_rows, num_local_cols}, std::move(diag_row_idxs),
+        std::move(diag_col_idxs), std::move(diag_values)};
+    device_matrix_data<value_type, local_index_type> off_diag_data{
         exec, dim<2>{num_local_rows, imap_.get_remote_global_idxs().get_size()},
-        std::move(non_local_row_idxs), std::move(non_local_col_idxs),
-        std::move(non_local_values)};
-    as<ReadableFromMatrixData<ValueType, LocalIndexType>>(this->local_mtx_)
-        ->read(std::move(local_data));
-    as<ReadableFromMatrixData<ValueType, LocalIndexType>>(this->non_local_mtx_)
-        ->read(std::move(non_local_data));
+        std::move(off_diag_row_idxs), std::move(off_diag_col_idxs),
+        std::move(off_diag_values)};
+    as<ReadableFromMatrixData<ValueType, LocalIndexType>>(this->diag_mtx_)
+        ->read(std::move(diag_data));
+    as<ReadableFromMatrixData<ValueType, LocalIndexType>>(this->off_diag_mtx_)
+        ->read(std::move(off_diag_data));
 
     row_gatherer_ = RowGatherer<LocalIndexType>::create(
         row_gatherer_->get_executor(),
@@ -479,13 +479,13 @@ void Matrix<ValueType, LocalIndexType, GlobalIndexType>::apply_impl(
                 // reference and omp executor does not have event, so we still
                 // submit the mpi first.
                 auto req = this->row_gatherer_->apply_async(dense_b, recv_ptr);
-                local_mtx_->apply(dense_b->get_local_vector(), local_x);
+                diag_mtx_->apply(dense_b->get_local_vector(), local_x);
                 req.wait();
             } else {
                 // we use event here such that we can submit spmv job first
                 // without waiting for synchronization from the row gatherer.
                 auto ev = this->row_gatherer_->apply_prepare(dense_b);
-                local_mtx_->apply(dense_b->get_local_vector(), local_x);
+                diag_mtx_->apply(dense_b->get_local_vector(), local_x);
                 auto req =
                     this->row_gatherer_->apply_finalize(dense_b, recv_ptr, ev);
                 req.wait();
@@ -496,10 +496,10 @@ void Matrix<ValueType, LocalIndexType, GlobalIndexType>::apply_impl(
             }
             if (auto coo = std::dynamic_pointer_cast<
                     const ::gko::matrix::Coo<ValueType, LocalIndexType>>(
-                    non_local_mtx_)) {
+                    off_diag_mtx_)) {
                 coo->apply2(recv_vector->get_local_vector(), local_x);
             } else {
-                non_local_mtx_->apply(
+                off_diag_mtx_->apply(
                     one_scalar_.template get<ValueType>().get(),
                     recv_vector->get_local_vector(),
                     one_scalar_.template get<x_value_type>().get(), local_x);
@@ -545,17 +545,15 @@ void Matrix<ValueType, LocalIndexType, GlobalIndexType>::apply_impl(
                 // reference and omp executor does not have event, so we still
                 // submit the mpi first.
                 auto req = this->row_gatherer_->apply_async(dense_b, recv_ptr);
-                local_mtx_->apply(local_alpha.get(),
-                                  dense_b->get_local_vector(), local_beta.get(),
-                                  local_x);
+                diag_mtx_->apply(local_alpha.get(), dense_b->get_local_vector(),
+                                 local_beta.get(), local_x);
                 req.wait();
             } else {
                 // we use event here such that we can submit spmv job first
                 // without waiting for synchronization from the row gatherer.
                 auto ev = this->row_gatherer_->apply_prepare(dense_b);
-                local_mtx_->apply(local_alpha.get(),
-                                  dense_b->get_local_vector(), local_beta.get(),
-                                  local_x);
+                diag_mtx_->apply(local_alpha.get(), dense_b->get_local_vector(),
+                                 local_beta.get(), local_x);
                 auto req =
                     this->row_gatherer_->apply_finalize(dense_b, recv_ptr, ev);
                 req.wait();
@@ -566,11 +564,11 @@ void Matrix<ValueType, LocalIndexType, GlobalIndexType>::apply_impl(
             }
             if (auto coo = std::dynamic_pointer_cast<
                     const ::gko::matrix::Coo<ValueType, LocalIndexType>>(
-                    non_local_mtx_)) {
+                    off_diag_mtx_)) {
                 coo->apply2(local_alpha.get(), recv_vector->get_local_vector(),
                             local_x);
             } else {
-                non_local_mtx_->apply(
+                off_diag_mtx_->apply(
                     local_alpha.get(), recv_vector->get_local_vector(),
                     one_scalar_.template get<x_value_type>().get(), local_x);
             }
@@ -587,8 +585,8 @@ void Matrix<ValueType, LocalIndexType, GlobalIndexType>::col_scale(
     GKO_ASSERT_EQ(scaling_factors->get_size()[1], 1);
     auto exec = this->get_executor();
     auto comm = this->get_communicator();
-    size_type n_local_cols = local_mtx_->get_size()[1];
-    size_type n_non_local_cols = non_local_mtx_->get_size()[1];
+    size_type n_local_cols = diag_mtx_->get_size()[1];
+    size_type n_off_diag_cols = off_diag_mtx_->get_size()[1];
 
     std::unique_ptr<global_vector_type> scaling_factors_single_stride;
     auto scaling_stride = scaling_factors->get_stride();
@@ -617,27 +615,27 @@ void Matrix<ValueType, LocalIndexType, GlobalIndexType>::col_scale(
         // submit the mpi first.
         auto req =
             this->row_gatherer_->apply_async(scaling_factors_ptr, recv_ptr);
-        scale_diag->rapply(local_mtx_, local_mtx_);
+        scale_diag->rapply(diag_mtx_, diag_mtx_);
         req.wait();
     } else {
-        // we use event here such that we can submit local matrix scaling job
+        // we use event here such that we can submit diag matrix scaling job
         // first without waiting for synchronization from the row gatherer.
         auto ev = this->row_gatherer_->apply_prepare(scaling_factors_ptr);
-        scale_diag->rapply(local_mtx_, local_mtx_);
+        scale_diag->rapply(diag_mtx_, diag_mtx_);
         auto req = this->row_gatherer_->apply_finalize(scaling_factors_ptr,
                                                        recv_ptr, ev);
         req.wait();
     }
-    if (n_non_local_cols > 0) {
+    if (n_off_diag_cols > 0) {
         if (recv_ptr != recv_vector.get()) {
             recv_vector->copy_from(host_recv_vector);
         }
-        const auto non_local_scale_diag =
+        const auto off_diag_scale_diag =
             gko::matrix::Diagonal<ValueType>::create_const(
-                exec, n_non_local_cols,
-                make_const_array_view(exec, n_non_local_cols,
+                exec, n_off_diag_cols,
+                make_const_array_view(exec, n_off_diag_cols,
                                       recv_vector->get_const_local_values()));
-        non_local_scale_diag->rapply(non_local_mtx_, non_local_mtx_);
+        off_diag_scale_diag->rapply(off_diag_mtx_, off_diag_mtx_);
     }
 }
 
@@ -650,7 +648,7 @@ void Matrix<ValueType, LocalIndexType, GlobalIndexType>::row_scale(
     GKO_ASSERT_EQ(scaling_factors->get_size()[1], 1);
     auto exec = this->get_executor();
     auto comm = this->get_communicator();
-    size_type n_local_rows = local_mtx_->get_size()[0];
+    size_type n_local_rows = diag_mtx_->get_size()[0];
     std::unique_ptr<global_vector_type> scaling_factors_single_stride;
     auto stride = scaling_factors->get_stride();
     if (stride != 1) {
@@ -664,8 +662,8 @@ void Matrix<ValueType, LocalIndexType, GlobalIndexType>::row_scale(
         exec, n_local_rows,
         make_const_array_view(exec, n_local_rows, scale_values));
 
-    scale_diag->apply(local_mtx_, local_mtx_);
-    scale_diag->apply(non_local_mtx_, non_local_mtx_);
+    scale_diag->apply(diag_mtx_, diag_mtx_);
+    scale_diag->apply(off_diag_mtx_, off_diag_mtx_);
 }
 
 
@@ -707,8 +705,8 @@ Matrix<ValueType, LocalIndexType, GlobalIndexType>::operator=(
         GKO_ASSERT_EQ(other.get_communicator().size(),
                       this->get_communicator().size());
         this->set_size(other.get_size());
-        local_mtx_->copy_from(other.local_mtx_);
-        non_local_mtx_->copy_from(other.non_local_mtx_);
+        diag_mtx_->copy_from(other.diag_mtx_);
+        off_diag_mtx_->copy_from(other.off_diag_mtx_);
         row_gatherer_->copy_from(other.row_gatherer_);
         imap_ = other.imap_;
     }
@@ -725,8 +723,8 @@ Matrix<ValueType, LocalIndexType, GlobalIndexType>::operator=(Matrix&& other)
                       this->get_communicator().size());
         this->set_size(other.get_size());
         other.set_size({});
-        local_mtx_->move_from(other.local_mtx_);
-        non_local_mtx_->move_from(other.non_local_mtx_);
+        diag_mtx_->move_from(other.diag_mtx_);
+        off_diag_mtx_->move_from(other.off_diag_mtx_);
         row_gatherer_->move_from(other.row_gatherer_);
         imap_ = std::move(other.imap_);
     }

--- a/core/distributed/matrix_kernels.hpp
+++ b/core/distributed/matrix_kernels.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -19,28 +19,28 @@ namespace gko {
 namespace kernels {
 
 
-#define GKO_DECLARE_SEPARATE_LOCAL_NONLOCAL(ValueType, LocalIndexType,         \
-                                            GlobalIndexType)                   \
-    void separate_local_nonlocal(                                              \
-        std::shared_ptr<const DefaultExecutor> exec,                           \
-        const device_matrix_data<ValueType, GlobalIndexType>& input,           \
-        const experimental::distributed::Partition<                            \
-            LocalIndexType, GlobalIndexType>* row_partition,                   \
-        const experimental::distributed::Partition<                            \
-            LocalIndexType, GlobalIndexType>* col_partition,                   \
-        comm_index_type local_part, array<LocalIndexType>& local_row_idxs,     \
-        array<LocalIndexType>& local_col_idxs, array<ValueType>& local_values, \
-        array<LocalIndexType>& non_local_row_idxs,                             \
-        array<GlobalIndexType>& non_local_col_idxs,                            \
-        array<ValueType>& non_local_values)
+#define GKO_DECLARE_SEPARATE_DIAG_OFF_DIAG(ValueType, LocalIndexType,        \
+                                           GlobalIndexType)                  \
+    void separate_diag_off_diag(                                             \
+        std::shared_ptr<const DefaultExecutor> exec,                         \
+        const device_matrix_data<ValueType, GlobalIndexType>& input,         \
+        const experimental::distributed::Partition<                          \
+            LocalIndexType, GlobalIndexType>* row_partition,                 \
+        const experimental::distributed::Partition<                          \
+            LocalIndexType, GlobalIndexType>* col_partition,                 \
+        comm_index_type local_part, array<LocalIndexType>& diag_row_idxs,    \
+        array<LocalIndexType>& diag_col_idxs, array<ValueType>& diag_values, \
+        array<LocalIndexType>& off_diag_row_idxs,                            \
+        array<GlobalIndexType>& off_diag_col_idxs,                           \
+        array<ValueType>& off_diag_values)
 
 
 #define GKO_DECLARE_ALL_AS_TEMPLATES                                    \
     using comm_index_type = experimental::distributed::comm_index_type; \
     template <typename ValueType, typename LocalIndexType,              \
               typename GlobalIndexType>                                 \
-    GKO_DECLARE_SEPARATE_LOCAL_NONLOCAL(ValueType, LocalIndexType,      \
-                                        GlobalIndexType)
+    GKO_DECLARE_SEPARATE_DIAG_OFF_DIAG(ValueType, LocalIndexType,       \
+                                       GlobalIndexType)
 
 
 GKO_DECLARE_FOR_ALL_EXECUTOR_NAMESPACES(distributed_matrix,

--- a/core/distributed/preconditioner/schwarz.cpp
+++ b/core/distributed/preconditioner/schwarz.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -124,7 +124,7 @@ void Schwarz<ValueType, LocalIndexType, GlobalIndexType>::apply_dense_impl(
         // Should allocate only in the first apply call if the number of rhs is
         // unchanged.
         auto cs_ncols = dense_x->get_size()[1];
-        auto cs_local_nrows = coarse_op->get_local_matrix()->get_size()[0];
+        auto cs_local_nrows = coarse_op->get_diag_matrix()->get_size()[0];
         auto cs_global_nrows = coarse_op->get_size()[0];
         auto cs_local_size = dim<2>(cs_local_nrows, cs_ncols);
         auto cs_global_size = dim<2>(cs_global_nrows, cs_ncols);
@@ -206,41 +206,41 @@ void Schwarz<ValueType, LocalIndexType, GlobalIndexType>::generate(
 
     auto dist_mat =
         as<Matrix<ValueType, LocalIndexType, GlobalIndexType>>(system_matrix);
-    auto local_matrix = dist_mat->get_local_matrix();
+    auto diag_matrix = dist_mat->get_diag_matrix();
 
     if (parameters_.l1_smoother) {
         auto exec = this->get_executor();
 
         using Csr = matrix::Csr<ValueType, LocalIndexType>;
-        auto local_matrix_copy = share(Csr::create(exec));
-        as<ConvertibleTo<Csr>>(local_matrix)->convert_to(local_matrix_copy);
+        auto diag_matrix_copy = share(Csr::create(exec));
+        as<ConvertibleTo<Csr>>(diag_matrix)->convert_to(diag_matrix_copy);
 
-        auto non_local_matrix = copy_and_convert_to<Csr>(
+        auto off_diag_matrix = copy_and_convert_to<Csr>(
             exec, as<Matrix<ValueType, LocalIndexType, GlobalIndexType>>(
                       system_matrix)
-                      ->get_non_local_matrix());
+                      ->get_off_diag_matrix());
 
-        array<ValueType> l1_diag_arr{exec, local_matrix->get_size()[0]};
+        array<ValueType> l1_diag_arr{exec, diag_matrix->get_size()[0]};
 
         exec->run(
-            make_row_wise_absolute_sum(non_local_matrix.get(), l1_diag_arr));
+            make_row_wise_absolute_sum(off_diag_matrix.get(), l1_diag_arr));
 
-        // compute local_matrix_copy <- diag(l1) + local_matrix_copy
+        // compute diag_matrix_copy <- diag(l1) + diag_matrix_copy
         auto l1_diag = matrix::Diagonal<ValueType>::create(
-            exec, local_matrix->get_size()[0], std::move(l1_diag_arr));
+            exec, diag_matrix->get_size()[0], std::move(l1_diag_arr));
         auto l1_diag_csr = Csr::create(exec);
         l1_diag->move_to(l1_diag_csr);
         auto id = matrix::Identity<ValueType>::create(
-            exec, local_matrix->get_size()[0]);
+            exec, diag_matrix->get_size()[0]);
         auto one = initialize<matrix::Dense<ValueType>>(
             {::gko::one<ValueType>()}, exec);
-        l1_diag_csr->apply(one, id, one, local_matrix_copy);
+        l1_diag_csr->apply(one, id, one, diag_matrix_copy);
 
         this->set_solver(
-            gko::share(parameters_.local_solver->generate(local_matrix_copy)));
+            gko::share(parameters_.local_solver->generate(diag_matrix_copy)));
     } else {
         this->set_solver(
-            gko::share(parameters_.local_solver->generate(local_matrix)));
+            gko::share(parameters_.local_solver->generate(diag_matrix)));
     }
 
     gko::remove_complex<ValueType> cweight =

--- a/core/multigrid/pgm.cpp
+++ b/core/multigrid/pgm.cpp
@@ -93,8 +93,8 @@ template <typename ValueType, typename IndexType>
 std::shared_ptr<matrix::Csr<ValueType, IndexType>> generate_coarse(
     std::shared_ptr<const Executor> exec,
     const matrix::Csr<ValueType, IndexType>* fine_csr, IndexType num_agg,
-    const gko::array<IndexType>& agg, IndexType non_local_num_agg,
-    const gko::array<IndexType>& non_local_agg)
+    const gko::array<IndexType>& agg, IndexType off_diag_num_agg,
+    const gko::array<IndexType>& off_diag_agg)
 {
     const auto num = fine_csr->get_size()[0];
     const auto nnz = fine_csr->get_num_stored_elements();
@@ -105,7 +105,7 @@ std::shared_ptr<matrix::Csr<ValueType, IndexType>> generate_coarse(
 
     if (nnz == 0) {
         return matrix::Csr<ValueType, IndexType>::create(
-            exec, dim<2>(num_agg, non_local_num_agg));
+            exec, dim<2>(num_agg, off_diag_num_agg));
     }
 
     // map row_ptrs to coarse row index
@@ -113,7 +113,7 @@ std::shared_ptr<matrix::Csr<ValueType, IndexType>> generate_coarse(
                                 agg.get_const_data(), row_idxs.get_data()));
     // map col_idxs to coarse col index
     exec->run(pgm::make_map_col(nnz, fine_csr->get_const_col_idxs(),
-                                non_local_agg.get_const_data(),
+                                off_diag_agg.get_const_data(),
                                 col_idxs.get_data()));
     // sort by row, col
     // Because reduce_by_key is not deterministic, so we do not need
@@ -131,7 +131,7 @@ std::shared_ptr<matrix::Csr<ValueType, IndexType>> generate_coarse(
     auto coarse_coo = matrix::Coo<ValueType, IndexType>::create(
         exec,
         gko::dim<2>{static_cast<size_type>(num_agg),
-                    static_cast<size_type>(non_local_num_agg)},
+                    static_cast<size_type>(off_diag_num_agg)},
         coarse_nnz);
     exec->run(pgm::make_compute_coarse_coo(
         nnz, row_idxs.get_const_data(), col_idxs.get_const_data(),
@@ -269,7 +269,7 @@ Pgm<ValueType, IndexType>::generate_local(
 
 template <typename ValueType, typename IndexType>
 template <typename GlobalIndexType>
-array<GlobalIndexType> Pgm<ValueType, IndexType>::communicate_non_local_agg(
+array<GlobalIndexType> Pgm<ValueType, IndexType>::communicate_off_diag_agg(
     std::shared_ptr<const experimental::distributed::Matrix<
         ValueType, IndexType, GlobalIndexType>>
         matrix,
@@ -298,7 +298,7 @@ array<GlobalIndexType> Pgm<ValueType, IndexType>::communicate_non_local_agg(
         device_segmented_array<const GlobalIndexType>{}, comm.rank(), send_agg,
         experimental::distributed::index_space::local, send_global_agg));
 
-    array<GlobalIndexType> non_local_agg(exec, total_recv_size);
+    array<GlobalIndexType> off_diag_agg(exec, total_recv_size);
 
     auto use_host_buffer = experimental::mpi::requires_host_buffer(exec, comm);
     array<GlobalIndexType> host_recv_buffer(exec->get_master());
@@ -313,8 +313,8 @@ array<GlobalIndexType> Pgm<ValueType, IndexType>::communicate_non_local_agg(
 
     const auto send_ptr = use_host_buffer ? host_send_buffer.get_const_data()
                                           : send_global_agg.get_const_data();
-    auto recv_ptr = use_host_buffer ? host_recv_buffer.get_data()
-                                    : non_local_agg.get_data();
+    auto recv_ptr =
+        use_host_buffer ? host_recv_buffer.get_data() : off_diag_agg.get_data();
     exec->synchronize();
     coll_comm
         ->i_all_to_all_v(use_host_buffer ? exec->get_master() : exec, send_ptr,
@@ -322,9 +322,9 @@ array<GlobalIndexType> Pgm<ValueType, IndexType>::communicate_non_local_agg(
         .wait();
     if (use_host_buffer) {
         exec->copy_from(exec->get_master(), total_recv_size, recv_ptr,
-                        non_local_agg.get_data());
+                        off_diag_agg.get_data());
     }
-    return non_local_agg;
+    return off_diag_agg;
 }
 
 
@@ -355,13 +355,13 @@ void Pgm<ValueType, IndexType>::generate()
         };
         auto setup_fine_op = [&](auto matrix) {
             // Only support csr matrix currently.
-            auto local_csr = std::dynamic_pointer_cast<const csr_type>(
-                matrix->get_local_matrix());
-            auto non_local_csr = std::dynamic_pointer_cast<const csr_type>(
-                matrix->get_non_local_matrix());
+            auto diag_csr = std::dynamic_pointer_cast<const csr_type>(
+                matrix->get_diag_matrix());
+            auto off_diag_csr = std::dynamic_pointer_cast<const csr_type>(
+                matrix->get_off_diag_matrix());
             // If system matrix is not csr or need sorting, generate the
             // csr.
-            if (!parameters_.skip_sorting || !local_csr || !non_local_csr) {
+            if (!parameters_.skip_sorting || !diag_csr || !off_diag_csr) {
                 using global_index_type =
                     typename std::decay_t<decltype(*matrix)>::global_index_type;
                 convert_fine_op(
@@ -398,7 +398,7 @@ void Pgm<ValueType, IndexType>::generate()
                 gko::as<experimental::distributed::DistributedBase>(matrix)
                     ->get_communicator();
             auto pgm_local_op =
-                gko::as<const csr_type>(matrix->get_local_matrix());
+                gko::as<const csr_type>(matrix->get_diag_matrix());
             auto result = this->generate_local(pgm_local_op);
 
             // create the coarse partition
@@ -413,43 +413,43 @@ void Pgm<ValueType, IndexType>::generate()
                     IndexType, global_index_type>(exec, comm,
                                                   coarse_local_size));
 
-            // get the non-local aggregates as coarse global indices
-            auto non_local_agg =
-                communicate_non_local_agg(matrix, coarse_partition, agg_);
+            // get the off-diag aggregates as coarse global indices
+            auto off_diag_agg =
+                communicate_off_diag_agg(matrix, coarse_partition, agg_);
 
             // create a coarse index map based on the connection given by
-            // the non-local aggregates
+            // the off-diag aggregates
             auto coarse_imap =
                 experimental::distributed::index_map<IndexType,
                                                      global_index_type>(
-                    exec, coarse_partition, comm.rank(), non_local_agg);
+                    exec, coarse_partition, comm.rank(), off_diag_agg);
 
-            // a mapping from the fine non-local indices to the coarse
-            // non-local indices.
-            // non_local_agg already maps the fine non-local indices to
+            // a mapping from the fine off-diag indices to the coarse
+            // off-diag indices.
+            // off_diag_agg already maps the fine off-diag indices to
             // coarse global indices, so mapping it with the coarse index
-            // map results in the coarse non-local indices.
-            auto non_local_map = coarse_imap.map_to_local(
-                non_local_agg,
+            // map results in the coarse off-diag indices.
+            auto off_diag_map = coarse_imap.map_to_local(
+                off_diag_agg,
                 experimental::distributed::index_space::non_local);
 
             // build csr from row and col map
             // unlike non-distributed version, generate_coarse uses
             // different row and col maps.
-            auto non_local_csr =
-                as<const csr_type>(matrix->get_non_local_matrix());
-            auto result_non_local_csr = generate_coarse(
-                exec, non_local_csr.get(),
+            auto off_diag_csr =
+                as<const csr_type>(matrix->get_off_diag_matrix());
+            auto result_off_diag_csr = generate_coarse(
+                exec, off_diag_csr.get(),
                 static_cast<IndexType>(std::get<1>(result)->get_size()[0]),
                 agg_, static_cast<IndexType>(coarse_imap.get_non_local_size()),
-                non_local_map);
+                off_diag_map);
 
             // setup the generated linop.
             auto coarse = share(
                 experimental::distributed::
                     Matrix<ValueType, IndexType, global_index_type>::create(
                         exec, comm, std::move(coarse_imap), std::get<1>(result),
-                        result_non_local_csr));
+                        result_off_diag_csr));
             auto restrict_op = share(
                 experimental::distributed::
                     Matrix<ValueType, IndexType, global_index_type>::create(

--- a/core/solver/multigrid.cpp
+++ b/core/solver/multigrid.cpp
@@ -348,11 +348,11 @@ void MultigridState::generate(const LinOp* system_matrix_in,
                     auto next_comm = distributed_coarse->get_communicator();
                     auto current_local_nrows =
                         ::gko::detail::run_matrix(fine, [](auto* fine_mat) {
-                            return fine_mat->get_local_matrix()->get_size()[0];
+                            return fine_mat->get_diag_matrix()->get_size()[0];
                         });
                     auto next_local_nrows =
                         ::gko::detail::run_matrix(coarse, [](auto* coarse_mat) {
-                            return coarse_mat->get_non_local_matrix()
+                            return coarse_mat->get_off_diag_matrix()
                                 ->get_size()[0];
                         });
                     this->allocate_memory<VectorType>(

--- a/core/test/mpi/distributed/matrix.cpp
+++ b/core/test/mpi/distributed/matrix.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -154,18 +154,18 @@ protected:
         }
     }
 
-    template <typename LocalMatrixType, typename NonLocalMatrixType>
+    template <typename DiagMatrixType, typename OffDiagMatrixType>
     void expected_interface_no_throw(gko::ptr_param<dist_mtx_type> mat,
-                                     LocalMatrixType&& local_matrix_type,
-                                     NonLocalMatrixType&& non_local_matrix_type)
+                                     DiagMatrixType&& diag_matrix_type,
+                                     OffDiagMatrixType&& off_diag_matrix_type)
     {
         auto num_rows = mat->get_size()[0];
         auto a = dist_vec_type::create(ref, comm);
         auto b = dist_vec_type::create(ref, comm);
-        auto convert_result = dist_mtx_type::create(
-            ref, comm, local_matrix_type, non_local_matrix_type);
-        auto move_result = dist_mtx_type::create(ref, comm, local_matrix_type,
-                                                 non_local_matrix_type);
+        auto convert_result = dist_mtx_type::create(ref, comm, diag_matrix_type,
+                                                    off_diag_matrix_type);
+        auto move_result = dist_mtx_type::create(ref, comm, diag_matrix_type,
+                                                 off_diag_matrix_type);
 
         ASSERT_NO_THROW(mat->apply(a, b));
         ASSERT_NO_THROW(mat->convert_to(convert_result));
@@ -195,43 +195,43 @@ TYPED_TEST(MatrixBuilder, BuildWithLocal)
         auto mat =
             dist_mat_type ::create(this->ref, this->comm, with_matrix_type);
 
-        ASSERT_NO_THROW(gko::as<expected_type>(mat->get_local_matrix()));
-        additional_test(mat->get_local_matrix());
-        additional_test(mat->get_non_local_matrix());
+        ASSERT_NO_THROW(gko::as<expected_type>(mat->get_diag_matrix()));
+        additional_test(mat->get_diag_matrix());
+        additional_test(mat->get_off_diag_matrix());
         this->expected_interface_no_throw(mat, with_matrix_type,
                                           with_matrix_type);
     });
 }
 
 
-TYPED_TEST(MatrixBuilder, BuildWithLocalAndNonLocal)
+TYPED_TEST(MatrixBuilder, BuildWithDiagAndOffDiag)
 {
     using value_type = typename TestFixture::value_type;
     using index_type = typename TestFixture::local_index_type;
     using dist_mat_type = typename TestFixture::dist_mtx_type;
-    this->forall_matrix_types([this](auto with_local_matrix_type,
-                                     auto expected_local_type_ptr,
-                                     auto additional_local_test) {
-        using expected_local_type = typename std::remove_pointer<
-            decltype(expected_local_type_ptr.get())>::type;
-        this->forall_matrix_types([&](auto with_non_local_matrix_type,
-                                      auto expected_non_local_type_ptr,
-                                      auto additional_non_local_test) {
-            using expected_non_local_type = typename std::remove_pointer<
-                decltype(expected_non_local_type_ptr.get())>::type;
+    this->forall_matrix_types([this](auto with_diag_matrix_type,
+                                     auto expected_diag_type_ptr,
+                                     auto additional_diag_test) {
+        using expected_diag_type = typename std::remove_pointer<
+            decltype(expected_diag_type_ptr.get())>::type;
+        this->forall_matrix_types([&](auto with_off_diag_matrix_type,
+                                      auto expected_off_diag_type_ptr,
+                                      auto additional_off_diag_test) {
+            using expected_off_diag_type = typename std::remove_pointer<
+                decltype(expected_off_diag_type_ptr.get())>::type;
 
             auto mat = dist_mat_type ::create(this->ref, this->comm,
-                                              with_local_matrix_type,
-                                              with_non_local_matrix_type);
+                                              with_diag_matrix_type,
+                                              with_off_diag_matrix_type);
 
             ASSERT_NO_THROW(
-                gko::as<expected_local_type>(mat->get_local_matrix()));
+                gko::as<expected_diag_type>(mat->get_diag_matrix()));
             ASSERT_NO_THROW(
-                gko::as<expected_non_local_type>(mat->get_non_local_matrix()));
-            additional_local_test(mat->get_local_matrix());
-            additional_non_local_test(mat->get_non_local_matrix());
-            this->expected_interface_no_throw(mat, with_local_matrix_type,
-                                              with_non_local_matrix_type);
+                gko::as<expected_off_diag_type>(mat->get_off_diag_matrix()));
+            additional_diag_test(mat->get_diag_matrix());
+            additional_off_diag_test(mat->get_off_diag_matrix());
+            this->expected_interface_no_throw(mat, with_diag_matrix_type,
+                                              with_off_diag_matrix_type);
         });
     });
 }
@@ -247,7 +247,7 @@ TYPED_TEST(MatrixBuilder, BuildWithCustomLinOp)
     auto mat = dist_mat_type::create(this->ref, this->comm,
                                      gko::with_matrix_type<CustomLinOp>());
 
-    ASSERT_NO_THROW(gko::as<custom_type>(mat->get_local_matrix()));
+    ASSERT_NO_THROW(gko::as<custom_type>(mat->get_diag_matrix()));
     this->expected_interface_no_throw(mat, gko::with_matrix_type<CustomLinOp>(),
                                       gko::with_matrix_type<CustomLinOp>());
 }
@@ -260,7 +260,7 @@ TYPED_TEST(MatrixBuilder, BuildLocalOnly)
     using dist_mtx_type = typename TestFixture::dist_mtx_type;
     using dist_vec_type = typename TestFixture::dist_vec_type;
     using custom_type = CustomLinOp<value_type, index_type>;
-    using empty_non_local_type = gko::matrix::Coo<value_type, index_type>;
+    using empty_off_diag_type = gko::matrix::Coo<value_type, index_type>;
     auto local_n = this->comm.rank() + 1;
     // global_size = 1 + 2 + ... + num_rank
     auto global_n = ((1 + this->comm.size()) * this->comm.size()) / 2;
@@ -275,10 +275,10 @@ TYPED_TEST(MatrixBuilder, BuildLocalOnly)
         this->ref, this->comm, gko::dim<2>(global_n, global_n),
         custom_type::create(this->ref, gko::dim<2>(local_n, local_n)));
 
-    ASSERT_NO_THROW(gko::as<custom_type>(mat->get_local_matrix()));
-    ASSERT_NE(mat->get_non_local_matrix(), nullptr);
-    ASSERT_NO_THROW(gko::as<empty_non_local_type>(mat->get_non_local_matrix()));
-    GKO_ASSERT_EQUAL_DIMENSIONS(mat->get_local_matrix()->get_size(),
+    ASSERT_NO_THROW(gko::as<custom_type>(mat->get_diag_matrix()));
+    ASSERT_NE(mat->get_off_diag_matrix(), nullptr);
+    ASSERT_NO_THROW(gko::as<empty_off_diag_type>(mat->get_off_diag_matrix()));
+    GKO_ASSERT_EQUAL_DIMENSIONS(mat->get_diag_matrix()->get_size(),
                                 gko::dim<2>(local_n, local_n));
     ASSERT_NO_THROW(mat->apply(a, b));
 }
@@ -298,43 +298,43 @@ TYPED_TEST(MatrixBuilder, BuildFromLinOpLocal)
         auto mat =
             dist_mat_type ::create(this->ref, this->comm, expected_type_ptr);
 
-        ASSERT_NO_THROW(gko::as<expected_type>(mat->get_local_matrix()));
-        additional_test(mat->get_local_matrix());
-        additional_test(mat->get_non_local_matrix());
+        ASSERT_NO_THROW(gko::as<expected_type>(mat->get_diag_matrix()));
+        additional_test(mat->get_diag_matrix());
+        additional_test(mat->get_off_diag_matrix());
         this->expected_interface_no_throw(mat, with_matrix_type,
                                           with_matrix_type);
     });
 }
 
 
-TYPED_TEST(MatrixBuilder, BuildFromLinOpLocalAndNonLocal)
+TYPED_TEST(MatrixBuilder, BuildFromLinOpDiagAndOffDiag)
 {
     using value_type = typename TestFixture::value_type;
     using index_type = typename TestFixture::local_index_type;
     using dist_mat_type = typename TestFixture::dist_mtx_type;
-    this->forall_matrix_types([this](auto with_local_matrix_type,
-                                     auto expected_local_type_ptr,
-                                     auto additional_local_test) {
-        using expected_local_type = typename std::remove_pointer<
-            decltype(expected_local_type_ptr.get())>::type;
-        this->forall_matrix_types([&](auto with_non_local_matrix_type,
-                                      auto expected_non_local_type_ptr,
-                                      auto additional_non_local_test) {
-            using expected_non_local_type = typename std::remove_pointer<
-                decltype(expected_non_local_type_ptr.get())>::type;
+    this->forall_matrix_types([this](auto with_diag_matrix_type,
+                                     auto expected_diag_type_ptr,
+                                     auto additional_diag_test) {
+        using expected_diag_type = typename std::remove_pointer<
+            decltype(expected_diag_type_ptr.get())>::type;
+        this->forall_matrix_types([&](auto with_off_diag_matrix_type,
+                                      auto expected_off_diag_type_ptr,
+                                      auto additional_off_diag_test) {
+            using expected_off_diag_type = typename std::remove_pointer<
+                decltype(expected_off_diag_type_ptr.get())>::type;
 
             auto mat = dist_mat_type ::create(this->ref, this->comm,
-                                              expected_local_type_ptr,
-                                              expected_non_local_type_ptr);
+                                              expected_diag_type_ptr,
+                                              expected_off_diag_type_ptr);
 
             ASSERT_NO_THROW(
-                gko::as<expected_local_type>(mat->get_local_matrix()));
+                gko::as<expected_diag_type>(mat->get_diag_matrix()));
             ASSERT_NO_THROW(
-                gko::as<expected_non_local_type>(mat->get_non_local_matrix()));
-            additional_local_test(mat->get_local_matrix());
-            additional_non_local_test(mat->get_non_local_matrix());
-            this->expected_interface_no_throw(mat, with_local_matrix_type,
-                                              with_non_local_matrix_type);
+                gko::as<expected_off_diag_type>(mat->get_off_diag_matrix()));
+            additional_diag_test(mat->get_diag_matrix());
+            additional_off_diag_test(mat->get_off_diag_matrix());
+            this->expected_interface_no_throw(mat, with_diag_matrix_type,
+                                              with_off_diag_matrix_type);
         });
     });
 }

--- a/core/test/mpi/distributed/solver/multigrid.cpp
+++ b/core/test/mpi/distributed/solver/multigrid.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -70,7 +70,7 @@ protected:
     {
         auto exec = this->get_executor();
         auto distributed_op = dynamic_cast<const dist_mtx_type*>(op_.get());
-        auto original_n = distributed_op->get_local_matrix()->get_size()[0];
+        auto original_n = distributed_op->get_diag_matrix()->get_size()[0];
         gko::size_type n = original_n - 1;
 
         auto comm = distributed_op->get_communicator();
@@ -155,7 +155,7 @@ TEST_F(Multigrid, ConstructCorrect)
               gko::dim<2>(first_n));
     ASSERT_EQ(dynamic_cast<const dist_mtx_type*>(
                   mg_level.at(0)->get_coarse_op().get())
-                  ->get_local_matrix()
+                  ->get_diag_matrix()
                   ->get_size(),
               gko::dim<2>(n - 1));
     // next mg_level

--- a/dpcpp/distributed/matrix_kernels.dp.cpp
+++ b/dpcpp/distributed/matrix_kernels.dp.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -14,21 +14,21 @@ namespace distributed_matrix {
 
 
 template <typename ValueType, typename LocalIndexType, typename GlobalIndexType>
-void separate_local_nonlocal(
+void separate_diag_off_diag(
     std::shared_ptr<const DefaultExecutor> exec,
     const device_matrix_data<ValueType, GlobalIndexType>& input,
     const experimental::distributed::Partition<LocalIndexType, GlobalIndexType>*
         row_partition,
     const experimental::distributed::Partition<LocalIndexType, GlobalIndexType>*
         col_partition,
-    comm_index_type local_part, array<LocalIndexType>& local_row_idxs,
-    array<LocalIndexType>& local_col_idxs, array<ValueType>& local_values,
-    array<LocalIndexType>& non_local_row_idxs,
-    array<GlobalIndexType>& non_local_col_idxs,
-    array<ValueType>& non_local_values) GKO_NOT_IMPLEMENTED;
+    comm_index_type local_part, array<LocalIndexType>& diag_row_idxs,
+    array<LocalIndexType>& diag_col_idxs, array<ValueType>& diag_values,
+    array<LocalIndexType>& off_diag_row_idxs,
+    array<GlobalIndexType>& off_diag_col_idxs,
+    array<ValueType>& off_diag_values) GKO_NOT_IMPLEMENTED;
 
 GKO_INSTANTIATE_FOR_EACH_VALUE_AND_LOCAL_GLOBAL_INDEX_TYPE(
-    GKO_DECLARE_SEPARATE_LOCAL_NONLOCAL);
+    GKO_DECLARE_SEPARATE_DIAG_OFF_DIAG);
 
 
 }  // namespace distributed_matrix

--- a/include/ginkgo/core/distributed/matrix.hpp
+++ b/include/ginkgo/core/distributed/matrix.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -171,14 +171,14 @@ class Vector;
  * 0        | 13 .. .. .. 14 .. |                  | .. .. .. 8  ..  9 |
  * ```
  * The local rows are further split into two matrices on each process.
- * One matrix, called `local`, contains only entries from columns that are
- * also owned by the process, while the other one, called `non_local`,
+ * One matrix, called `diag`, contains only entries from columns that are
+ * also owned by the process, while the other one, called `off_diag`,
  * contains entries from columns that are not owned by the process. The
- * non-local matrix is stored in a compressed format, where empty columns are
- * discarded and the remaining columns are renumbered. This splitting is
+ * off-diagonal matrix is stored in a compressed format, where empty columns
+ * are discarded and the remaining columns are renumbered. This splitting is
  * depicted in the following:
  * ```
- * Part-Id  Global                            Local      Non-Local
+ * Part-Id  Global                            Diag       Off-Diag
  * 0        | .. 1  ! 2  .. ! .. .. |         | .. 1  |  | 2  |
  * 0        | 3  4  ! .. .. ! .. .. |         | 3  4  |  | .. |
  *          |-----------------------|
@@ -194,7 +194,7 @@ class Vector;
  * be used for the columns. Using a column partition also allows to create
  * non-square matrices, like the one below:
  * ```
- * Part-Id  Global                  Local      Non-Local
+ * Part-Id  Global                  Diag       Off-Diag
  * P_R/P_C    2  2  0  1
  * 0        | .. 1  2  .. |         | 2  |     | 1  .. |
  * 0        | 3  4  .. .. |         | .. |     | 3  4  |
@@ -411,20 +411,44 @@ public:
         assembly_mode assembly_type = assembly_mode::local_only);
 
     /**
-     * Get read access to the stored local matrix.
+     * Get read access to the stored diagonal matrix block.
      *
-     * @return  Shared pointer to the stored local matrix
+     * The diagonal block contains entries from columns that are owned by this
+     * process.
+     *
+     * @return  Shared pointer to the stored diagonal matrix block
      */
-    std::shared_ptr<const LinOp> get_local_matrix() const { return local_mtx_; }
+    std::shared_ptr<const LinOp> get_diag_matrix() const { return diag_mtx_; }
 
     /**
-     * Get read access to the stored non-local matrix.
+     * Get read access to the stored off-diagonal matrix block.
      *
-     * @return  Shared pointer to the stored non-local matrix
+     * The off-diagonal block contains entries from columns that are not owned
+     * by this process.
+     *
+     * @return  Shared pointer to the stored off-diagonal matrix block
      */
+    std::shared_ptr<const LinOp> get_off_diag_matrix() const
+    {
+        return off_diag_mtx_;
+    }
+
+    /**
+     * @deprecated Use get_diag_matrix() instead.
+     */
+    GKO_DEPRECATED("use get_diag_matrix() instead")
+    std::shared_ptr<const LinOp> get_local_matrix() const
+    {
+        return get_diag_matrix();
+    }
+
+    /**
+     * @deprecated Use get_off_diag_matrix() instead.
+     */
+    GKO_DEPRECATED("use get_off_diag_matrix() instead")
     std::shared_ptr<const LinOp> get_non_local_matrix() const
     {
-        return non_local_mtx_;
+        return get_off_diag_matrix();
     }
 
     /**
@@ -524,50 +548,50 @@ public:
     }
 
     /**
-     * Creates an empty distributed matrix with specified types for the local
-     * matrix and the non-local matrix.
+     * Creates an empty distributed matrix with specified types for the
+     * diagonal matrix and the off-diagonal matrix.
      *
      * @note This is mainly a convenience wrapper for
      *       Matrix(std::shared_ptr<const Executor>, mpi::communicator,
      *       const LinOp*, const LinOp*)
      *
-     * @tparam LocalMatrixType  A type that has a `create<ValueType,
-     *                          IndexType>(exec)` function to create a smart
-     *                          pointer of a type derived from LinOp and
-     *                          ReadableFromMatrixData. @see with_matrix_type
-     * @tparam NonLocalMatrixType  A (possible different) type with the same
-     *                             constraints as LocalMatrixType.
+     * @tparam DiagMatrixType  A type that has a `create<ValueType,
+     *                         IndexType>(exec)` function to create a smart
+     *                         pointer of a type derived from LinOp and
+     *                         ReadableFromMatrixData. @see with_matrix_type
+     * @tparam OffDiagMatrixType  A (possible different) type with the same
+     *                            constraints as DiagMatrixType.
      *
      * @param exec  Executor associated with this matrix.
      * @param comm  Communicator associated with this matrix.
-     * @param local_matrix_template  the local matrix will be constructed
-     *                               with the same type as `create` returns. It
-     *                               should be the return value of
-     *                               make_matrix_template.
-     * @param non_local_matrix_template  the non-local matrix will be
-     *                                   constructed with the same type as
-     *                                   `create` returns. It should be the
-     *                                   return value of make_matrix_template.
+     * @param diag_matrix_template  the diagonal matrix will be constructed
+     *                              with the same type as `create` returns. It
+     *                              should be the return value of
+     *                              make_matrix_template.
+     * @param off_diag_matrix_template  the off-diagonal matrix will be
+     *                                  constructed with the same type as
+     *                                  `create` returns. It should be the
+     *                                  return value of make_matrix_template.
      *
      * @return A smart pointer to the newly created matrix.
      */
-    template <typename LocalMatrixType, typename NonLocalMatrixType,
+    template <typename DiagMatrixType, typename OffDiagMatrixType,
               typename = std::enable_if_t<
+                  gko::detail::is_matrix_type_builder<DiagMatrixType, ValueType,
+                                                      LocalIndexType>::value &&
                   gko::detail::is_matrix_type_builder<
-                      LocalMatrixType, ValueType, LocalIndexType>::value &&
-                  gko::detail::is_matrix_type_builder<
-                      NonLocalMatrixType, ValueType, LocalIndexType>::value>>
+                      OffDiagMatrixType, ValueType, LocalIndexType>::value>>
     static std::unique_ptr<Matrix> create(
         std::shared_ptr<const Executor> exec, mpi::communicator comm,
-        LocalMatrixType local_matrix_template,
-        NonLocalMatrixType non_local_matrix_template)
+        DiagMatrixType diag_matrix_template,
+        OffDiagMatrixType off_diag_matrix_template)
     {
         return create(
             exec, comm,
-            local_matrix_template.template create<ValueType, LocalIndexType>(
+            diag_matrix_template.template create<ValueType, LocalIndexType>(
                 exec),
-            non_local_matrix_template
-                .template create<ValueType, LocalIndexType>(exec));
+            off_diag_matrix_template.template create<ValueType, LocalIndexType>(
+                exec));
     }
 
     /**
@@ -589,57 +613,57 @@ public:
         ptr_param<const LinOp> matrix_template);
 
     /**
-     * Creates an empty distributed matrix with specified types for the local
-     * matrix and the non-local matrix.
+     * Creates an empty distributed matrix with specified types for the
+     * diagonal matrix and the off-diagonal matrix.
      *
-     * @note It internally clones the passed in local_matrix_template and
-     *       non_local_matrix_template. Therefore, those LinOps should be empty.
+     * @note It internally clones the passed in diag_matrix_template and
+     *       off_diag_matrix_template. Therefore, those LinOps should be empty.
      *
      * @param exec  Executor associated with this matrix.
      * @param comm  Communicator associated with this matrix.
-     * @param local_matrix_template  the local matrix will be constructed
-     *                               with the same runtime type.
-     * @param non_local_matrix_template  the non-local matrix will be
-     *                                   constructed with the same runtime type.
+     * @param diag_matrix_template  the diagonal matrix will be constructed
+     *                              with the same runtime type.
+     * @param off_diag_matrix_template  the off-diagonal matrix will be
+     *                                  constructed with the same runtime type.
      *
      * @return A smart pointer to the newly created matrix.
      */
     static std::unique_ptr<Matrix> create(
         std::shared_ptr<const Executor> exec, mpi::communicator comm,
-        ptr_param<const LinOp> local_matrix_template,
-        ptr_param<const LinOp> non_local_matrix_template);
+        ptr_param<const LinOp> diag_matrix_template,
+        ptr_param<const LinOp> off_diag_matrix_template);
 
     /**
-     * Creates a local-only distributed matrix with existent LinOp
+     * Creates a diag-only distributed matrix with existent LinOp
      *
      * @note It use the input to build up the distributed matrix
      *
      * @param exec  Executor associated with this matrix.
      * @param comm  Communicator associated with this matrix.
      * @param size  the global size
-     * @param local_linop  the local linop
+     * @param diag_linop  the diagonal block linop
      *
      * @return A smart pointer to the newly created matrix.
      */
     static std::unique_ptr<Matrix> create(std::shared_ptr<const Executor> exec,
                                           mpi::communicator comm, dim<2> size,
-                                          std::shared_ptr<LinOp> local_linop);
+                                          std::shared_ptr<LinOp> diag_linop);
 
     /**
-     * Creates distributed matrix with existent local and non-local LinOp and
-     * the corresponding mapping to collect the non-local data from the other
-     * ranks.
+     * Creates distributed matrix with existent diagonal and off-diagonal LinOp
+     * and the corresponding mapping to collect the off-diagonal data from the
+     * other ranks.
      *
      * @note It use the input to build up the distributed matrix
      *
      * @param exec  Executor associated with this matrix.
      * @param comm  Communicator associated with this matrix.
      * @param size  the global size
-     * @param local_linop  the local linop
-     * @param non_local_linop  the non-local linop
-     * @param recv_sizes  the size of non-local receiver
-     * @param recv_offsets  the offset of non-local receiver
-     * @param recv_gather_idxs  the gathering index of non-local receiver
+     * @param diag_linop  the diagonal block linop
+     * @param off_diag_linop  the off-diagonal block linop
+     * @param recv_sizes  the size of off-diagonal receiver
+     * @param recv_offsets  the offset of off-diagonal receiver
+     * @param recv_gather_idxs  the gathering index of off-diagonal receiver
      *
      * @return A smart pointer to the newly created matrix.
      */
@@ -647,30 +671,30 @@ public:
         "Please use the overload with an index_map instead.")]] static std::
         unique_ptr<Matrix>
         create(std::shared_ptr<const Executor> exec, mpi::communicator comm,
-               dim<2> size, std::shared_ptr<LinOp> local_linop,
-               std::shared_ptr<LinOp> non_local_linop,
+               dim<2> size, std::shared_ptr<LinOp> diag_linop,
+               std::shared_ptr<LinOp> off_diag_linop,
                std::vector<comm_index_type> recv_sizes,
                std::vector<comm_index_type> recv_offsets,
                array<local_index_type> recv_gather_idxs);
 
     /**
-     * Creates distributed matrix with existent local and non-local LinOp and
-     * the corresponding mapping to collect the non-local data from the other
-     * ranks.
+     * Creates distributed matrix with existent diagonal and off-diagonal LinOp
+     * and the corresponding mapping to collect the off-diagonal data from the
+     * other ranks.
      *
      * @param exec  Executor associated with this matrix.
      * @param comm  Communicator associated with this matrix.
      * @param imap  The index map to define the communication pattern
-     * @param local_linop  the local linop
-     * @param non_local_linop  the non-local linop
+     * @param diag_linop  the diagonal block linop
+     * @param off_diag_linop  the off-diagonal block linop
      *
      * @return A smart pointer to the newly created matrix.
      */
     static std::unique_ptr<Matrix> create(
         std::shared_ptr<const Executor> exec, mpi::communicator comm,
         index_map<local_index_type, global_index_type> imap,
-        std::shared_ptr<LinOp> local_linop,
-        std::shared_ptr<LinOp> non_local_linop);
+        std::shared_ptr<LinOp> diag_linop,
+        std::shared_ptr<LinOp> off_diag_linop);
 
     /**
      * Scales the columns of the matrix by the respective entries of the vector.
@@ -697,18 +721,18 @@ protected:
     explicit Matrix(std::shared_ptr<const Executor> exec,
                     std::shared_ptr<const RowGatherer<LocalIndexType>>
                         row_gatherer_template,
-                    ptr_param<const LinOp> local_matrix_template,
-                    ptr_param<const LinOp> non_local_matrix_template);
+                    ptr_param<const LinOp> diag_matrix_template,
+                    ptr_param<const LinOp> off_diag_matrix_template);
 
     explicit Matrix(std::shared_ptr<const Executor> exec,
                     mpi::communicator comm, dim<2> size,
-                    std::shared_ptr<LinOp> local_linop);
+                    std::shared_ptr<LinOp> diag_linop);
 
     explicit Matrix(std::shared_ptr<const Executor> exec,
                     mpi::communicator comm,
                     index_map<local_index_type, global_index_type> imap,
-                    std::shared_ptr<LinOp> local_linop,
-                    std::shared_ptr<LinOp> non_local_linop);
+                    std::shared_ptr<LinOp> diag_linop,
+                    std::shared_ptr<LinOp> off_diag_linop);
 
     void apply_impl(const LinOp* b, LinOp* x) const override;
 
@@ -721,8 +745,8 @@ private:
     gko::detail::ScalarCache one_scalar_;
     detail::GenericVectorCache recv_buffer_;
     detail::GenericVectorCache host_recv_buffer_;
-    std::shared_ptr<LinOp> local_mtx_;
-    std::shared_ptr<LinOp> non_local_mtx_;
+    std::shared_ptr<LinOp> diag_mtx_;
+    std::shared_ptr<LinOp> off_diag_mtx_;
 };
 
 

--- a/include/ginkgo/core/distributed/preconditioner/schwarz.hpp
+++ b/include/ginkgo/core/distributed/preconditioner/schwarz.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -39,8 +39,8 @@ namespace preconditioner {
  * generalizes the Block Jacobi preconditioner, incorporating options for
  * different local subdomain solvers and overlaps between the subdomains.
  *
- * A L1 smoother variant is also available, which updates the local matrix with
- * the sums of the non-local matrix row sums.
+ * A L1 smoother variant is also available, which updates the diagonal block
+ * with the sums of the off-diagonal block row sums.
  *
  * See Iterative Methods for Sparse Linear Systems (Y. Saad) for a general
  * treatment and variations of the method.
@@ -108,7 +108,7 @@ public:
          * Enable l1 smoother.
          *
          * This creates a diagonal matrix from the row-wise absolute
-         * sum of the non-local matrix entries. The diagonal matrix
+         * sum of the off-diagonal matrix entries. The diagonal matrix
          * is then added to the system matrix when generating the
          * local solver.
          *

--- a/include/ginkgo/core/multigrid/pgm.hpp
+++ b/include/ginkgo/core/multigrid/pgm.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -196,7 +196,7 @@ protected:
 
 #if GINKGO_BUILD_MPI
     /**
-     * Communicates the non-local aggregates (as global indices)
+     * Communicates the off-diag aggregates (as global indices)
      *
      * @tparam GlobalIndexType  Global index type
      *
@@ -205,11 +205,11 @@ protected:
      *                          indices
      * @param local_agg  the local aggregate indices
      *
-     * @return  the aggregates for non-local columns. The aggregated indices are
+     * @return  the aggregates for off-diag columns. The aggregated indices are
      *          in the new global indexing for the coarse matrix
      */
     template <typename GlobalIndexType>
-    array<GlobalIndexType> communicate_non_local_agg(
+    array<GlobalIndexType> communicate_off_diag_agg(
         std::shared_ptr<const experimental::distributed::Matrix<
             ValueType, IndexType, GlobalIndexType>>
             matrix,

--- a/omp/distributed/matrix_kernels.cpp
+++ b/omp/distributed/matrix_kernels.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -21,18 +21,18 @@ namespace distributed_matrix {
 
 
 template <typename ValueType, typename LocalIndexType, typename GlobalIndexType>
-void separate_local_nonlocal(
+void separate_diag_off_diag(
     std::shared_ptr<const DefaultExecutor> exec,
     const device_matrix_data<ValueType, GlobalIndexType>& input,
     const experimental::distributed::Partition<LocalIndexType, GlobalIndexType>*
         row_partition,
     const experimental::distributed::Partition<LocalIndexType, GlobalIndexType>*
         col_partition,
-    comm_index_type local_part, array<LocalIndexType>& local_row_idxs,
-    array<LocalIndexType>& local_col_idxs, array<ValueType>& local_values,
-    array<LocalIndexType>& non_local_row_idxs,
-    array<GlobalIndexType>& non_local_col_idxs,
-    array<ValueType>& non_local_values)
+    comm_index_type local_part, array<LocalIndexType>& diag_row_idxs,
+    array<LocalIndexType>& diag_col_idxs, array<ValueType>& diag_values,
+    array<LocalIndexType>& off_diag_row_idxs,
+    array<GlobalIndexType>& off_diag_col_idxs,
+    array<ValueType>& off_diag_values)
 {
     using range_index_type = GlobalIndexType;
     using global_nonzero = matrix_data_entry<ValueType, GlobalIndexType>;
@@ -46,24 +46,24 @@ void separate_local_nonlocal(
     size_type row_range_id_hint = 0;
     size_type col_range_id_hint = 0;
 
-    // store non-local entries with global column idxs
-    vector<global_nonzero> non_local_entries(exec);
-    vector<local_nonzero> local_entries(exec);
+    // store off-diag entries with global column idxs
+    vector<global_nonzero> off_diag_entries(exec);
+    vector<local_nonzero> diag_entries(exec);
 
     auto num_threads = static_cast<size_type>(omp_get_max_threads());
     auto num_input = input.get_num_stored_elements();
     auto size_per_thread = (num_input + num_threads - 1) / num_threads;
-    vector<size_type> local_entry_offsets(num_threads, 0, exec);
-    vector<size_type> non_local_entry_offsets(num_threads, 0, exec);
+    vector<size_type> diag_entry_offsets(num_threads, 0, exec);
+    vector<size_type> off_diag_entry_offsets(num_threads, 0, exec);
 
 #pragma omp parallel firstprivate(col_range_id_hint, row_range_id_hint)
     {
-        vector<global_nonzero> thread_non_local_entries(exec);
-        vector<local_nonzero> thread_local_entries(exec);
+        vector<global_nonzero> thread_off_diag_entries(exec);
+        vector<local_nonzero> thread_diag_entries(exec);
         auto thread_id = omp_get_thread_num();
         auto thread_begin = thread_id * size_per_thread;
         auto thread_end = std::min(thread_begin + size_per_thread, num_input);
-        // separate local and non-local entries for our input chunk
+        // separate diag and off-diag entries for our input chunk
         for (auto i = thread_begin; i < thread_end; ++i) {
             const auto global_row = input_row_idxs[i];
             const auto global_col = input_col_idxs[i];
@@ -71,7 +71,7 @@ void separate_local_nonlocal(
             auto row_range_id =
                 find_range(global_row, row_partition, row_range_id_hint);
             row_range_id_hint = row_range_id;
-            // skip non-local rows
+            // skip rows that aren't owned by this rank
             if (row_part_ids[row_range_id] == local_part) {
                 // map to part-local indices
                 auto local_row =
@@ -81,76 +81,76 @@ void separate_local_nonlocal(
                     find_range(global_col, col_partition, col_range_id_hint);
                 col_range_id_hint = col_range_id;
                 if (col_part_ids[col_range_id] == local_part) {
-                    // store local entry
+                    // store diag entry
                     auto local_col =
                         map_to_local(global_col, col_partition, col_range_id);
-                    thread_local_entries.emplace_back(local_row, local_col,
-                                                      value);
+                    thread_diag_entries.emplace_back(local_row, local_col,
+                                                     value);
                 } else {
-                    thread_non_local_entries.emplace_back(local_row, global_col,
-                                                          value);
+                    thread_off_diag_entries.emplace_back(local_row, global_col,
+                                                         value);
                 }
             }
         }
-        local_entry_offsets[thread_id] = thread_local_entries.size();
-        non_local_entry_offsets[thread_id] = thread_non_local_entries.size();
+        diag_entry_offsets[thread_id] = thread_diag_entries.size();
+        off_diag_entry_offsets[thread_id] = thread_off_diag_entries.size();
 
 #pragma omp barrier
 #pragma omp single
         {
             // assign output ranges to the individual threads
-            size_type local{};
-            size_type non_local{};
+            size_type diag{};
+            size_type off_diag{};
             for (size_type thread = 0; thread < num_threads; ++thread) {
-                auto size_local = local_entry_offsets[thread];
-                auto size_non_local = non_local_entry_offsets[thread];
-                local_entry_offsets[thread] = local;
-                non_local_entry_offsets[thread] = non_local;
-                local += size_local;
-                non_local += size_non_local;
+                auto size_diag = diag_entry_offsets[thread];
+                auto size_off_diag = off_diag_entry_offsets[thread];
+                diag_entry_offsets[thread] = diag;
+                off_diag_entry_offsets[thread] = off_diag;
+                diag += size_diag;
+                off_diag += size_off_diag;
             }
-            local_entries.resize(local);
-            non_local_entries.resize(non_local);
+            diag_entries.resize(diag);
+            off_diag_entries.resize(off_diag);
         }
-        // write back the local data to the output ranges
-        auto local = local_entry_offsets[thread_id];
-        auto non_local = non_local_entry_offsets[thread_id];
-        for (const auto& entry : thread_local_entries) {
-            local_entries[local] = entry;
-            local++;
+        // write back the diag data to the output ranges
+        auto diag = diag_entry_offsets[thread_id];
+        auto off_diag = off_diag_entry_offsets[thread_id];
+        for (const auto& entry : thread_diag_entries) {
+            diag_entries[diag] = entry;
+            diag++;
         }
-        for (const auto& entry : thread_non_local_entries) {
-            non_local_entries[non_local] = entry;
-            non_local++;
+        for (const auto& entry : thread_off_diag_entries) {
+            off_diag_entries[off_diag] = entry;
+            off_diag++;
         }
     }
-    // store local data to output
-    local_row_idxs.resize_and_reset(local_entries.size());
-    local_col_idxs.resize_and_reset(local_entries.size());
-    local_values.resize_and_reset(local_entries.size());
+    // store diag data to output
+    diag_row_idxs.resize_and_reset(diag_entries.size());
+    diag_col_idxs.resize_and_reset(diag_entries.size());
+    diag_values.resize_and_reset(diag_entries.size());
 #pragma omp parallel for
-    for (size_type i = 0; i < local_entries.size(); ++i) {
-        const auto& entry = local_entries[i];
-        local_row_idxs.get_data()[i] = entry.row;
-        local_col_idxs.get_data()[i] = entry.column;
-        local_values.get_data()[i] = entry.value;
+    for (size_type i = 0; i < diag_entries.size(); ++i) {
+        const auto& entry = diag_entries[i];
+        diag_row_idxs.get_data()[i] = entry.row;
+        diag_col_idxs.get_data()[i] = entry.column;
+        diag_values.get_data()[i] = entry.value;
     }
-    // map non-local values to local column indices
-    non_local_row_idxs.resize_and_reset(non_local_entries.size());
-    non_local_col_idxs.resize_and_reset(non_local_entries.size());
-    non_local_values.resize_and_reset(non_local_entries.size());
+    // map off-diag values to local column indices
+    off_diag_row_idxs.resize_and_reset(off_diag_entries.size());
+    off_diag_col_idxs.resize_and_reset(off_diag_entries.size());
+    off_diag_values.resize_and_reset(off_diag_entries.size());
 #pragma omp parallel for
-    for (size_type i = 0; i < non_local_entries.size(); i++) {
-        auto global = non_local_entries[i];
-        non_local_row_idxs.get_data()[i] =
+    for (size_type i = 0; i < off_diag_entries.size(); i++) {
+        auto global = off_diag_entries[i];
+        off_diag_row_idxs.get_data()[i] =
             static_cast<LocalIndexType>(global.row);
-        non_local_col_idxs.get_data()[i] = global.column;
-        non_local_values.get_data()[i] = global.value;
+        off_diag_col_idxs.get_data()[i] = global.column;
+        off_diag_values.get_data()[i] = global.value;
     }
 }
 
 GKO_INSTANTIATE_FOR_EACH_VALUE_AND_LOCAL_GLOBAL_INDEX_TYPE(
-    GKO_DECLARE_SEPARATE_LOCAL_NONLOCAL);
+    GKO_DECLARE_SEPARATE_DIAG_OFF_DIAG);
 
 
 }  // namespace distributed_matrix

--- a/reference/distributed/matrix_kernels.cpp
+++ b/reference/distributed/matrix_kernels.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -17,18 +17,18 @@ namespace distributed_matrix {
 
 
 template <typename ValueType, typename LocalIndexType, typename GlobalIndexType>
-void separate_local_nonlocal(
+void separate_diag_off_diag(
     std::shared_ptr<const DefaultExecutor> exec,
     const device_matrix_data<ValueType, GlobalIndexType>& input,
     const experimental::distributed::Partition<LocalIndexType, GlobalIndexType>*
         row_partition,
     const experimental::distributed::Partition<LocalIndexType, GlobalIndexType>*
         col_partition,
-    comm_index_type local_part, array<LocalIndexType>& local_row_idxs,
-    array<LocalIndexType>& local_col_idxs, array<ValueType>& local_values,
-    array<LocalIndexType>& non_local_row_idxs,
-    array<GlobalIndexType>& non_local_col_idxs,
-    array<ValueType>& non_local_values)
+    comm_index_type local_part, array<LocalIndexType>& diag_row_idxs,
+    array<LocalIndexType>& diag_col_idxs, array<ValueType>& diag_values,
+    array<LocalIndexType>& off_diag_row_idxs,
+    array<GlobalIndexType>& off_diag_col_idxs,
+    array<ValueType>& off_diag_values)
 {
     using global_nonzero = matrix_data_entry<ValueType, GlobalIndexType>;
     auto input_row_idxs = input.get_const_row_idxs();
@@ -38,8 +38,8 @@ void separate_local_nonlocal(
     auto col_part_ids = col_partition->get_part_ids();
     auto num_parts = row_partition->get_num_parts();
 
-    vector<global_nonzero> local_entries(exec);
-    vector<global_nonzero> non_local_entries(exec);
+    vector<global_nonzero> diag_entries(exec);
+    vector<global_nonzero> off_diag_entries(exec);
     size_type row_range_id = 0;
     size_type col_range_id = 0;
     for (size_type i = 0; i < input.get_num_stored_elements(); ++i) {
@@ -49,45 +49,45 @@ void separate_local_nonlocal(
             auto global_col = input_col_idxs[i];
             col_range_id = find_range(global_col, col_partition, col_range_id);
             if (col_part_ids[col_range_id] == local_part) {
-                local_entries.push_back(
+                diag_entries.push_back(
                     {map_to_local(global_row, row_partition, row_range_id),
                      map_to_local(global_col, col_partition, col_range_id),
                      input_vals[i]});
             } else {
-                non_local_entries.push_back(
+                off_diag_entries.push_back(
                     {map_to_local(global_row, row_partition, row_range_id),
                      global_col, input_vals[i]});
             }
         }
     }
 
-    // create local matrix
-    local_row_idxs.resize_and_reset(local_entries.size());
-    local_col_idxs.resize_and_reset(local_entries.size());
-    local_values.resize_and_reset(local_entries.size());
-    for (size_type i = 0; i < local_entries.size(); ++i) {
-        const auto& entry = local_entries[i];
-        local_row_idxs.get_data()[i] = entry.row;
-        local_col_idxs.get_data()[i] = entry.column;
-        local_values.get_data()[i] = entry.value;
+    // create diag matrix
+    diag_row_idxs.resize_and_reset(diag_entries.size());
+    diag_col_idxs.resize_and_reset(diag_entries.size());
+    diag_values.resize_and_reset(diag_entries.size());
+    for (size_type i = 0; i < diag_entries.size(); ++i) {
+        const auto& entry = diag_entries[i];
+        diag_row_idxs.get_data()[i] = entry.row;
+        diag_col_idxs.get_data()[i] = entry.column;
+        diag_values.get_data()[i] = entry.value;
     }
 
-    // create non-local matrix
-    // copy non-local data into row and value array
-    // copy non-local global column indices into temporary vector
-    non_local_row_idxs.resize_and_reset(non_local_entries.size());
-    non_local_col_idxs.resize_and_reset(non_local_entries.size());
-    non_local_values.resize_and_reset(non_local_entries.size());
-    for (size_type i = 0; i < non_local_entries.size(); ++i) {
-        const auto& entry = non_local_entries[i];
-        non_local_row_idxs.get_data()[i] = entry.row;
-        non_local_col_idxs.get_data()[i] = entry.column;
-        non_local_values.get_data()[i] = entry.value;
+    // create off-diag matrix
+    // copy off-diag data into row and value array
+    // copy off-diag global column indices into temporary vector
+    off_diag_row_idxs.resize_and_reset(off_diag_entries.size());
+    off_diag_col_idxs.resize_and_reset(off_diag_entries.size());
+    off_diag_values.resize_and_reset(off_diag_entries.size());
+    for (size_type i = 0; i < off_diag_entries.size(); ++i) {
+        const auto& entry = off_diag_entries[i];
+        off_diag_row_idxs.get_data()[i] = entry.row;
+        off_diag_col_idxs.get_data()[i] = entry.column;
+        off_diag_values.get_data()[i] = entry.value;
     }
 }
 
 GKO_INSTANTIATE_FOR_EACH_VALUE_AND_LOCAL_GLOBAL_INDEX_TYPE(
-    GKO_DECLARE_SEPARATE_LOCAL_NONLOCAL);
+    GKO_DECLARE_SEPARATE_DIAG_OFF_DIAG);
 
 
 }  // namespace distributed_matrix

--- a/reference/test/distributed/matrix_kernels.cpp
+++ b/reference/test/distributed/matrix_kernels.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -39,16 +39,16 @@ protected:
     Matrix()
         : ref(gko::ReferenceExecutor::create()),
           mapping{ref},
-          local_row_idxs{ref},
-          local_col_idxs{ref},
-          local_values{ref},
-          non_local_row_idxs{ref},
-          non_local_col_idxs{ref},
-          non_local_values{ref}
+          diag_row_idxs{ref},
+          diag_col_idxs{ref},
+          diag_values{ref},
+          off_diag_row_idxs{ref},
+          off_diag_col_idxs{ref},
+          off_diag_values{ref}
     {}
 
     /**
-     * apply the `separate_local_nonlocal` kernel and validate the result
+     * apply the `separate_diag_off_diag` kernel and validate the result
      * against provided reference values
      *
      * @param size  the expected global matrix size
@@ -57,16 +57,16 @@ protected:
      * @param input_rows  the row indices passed to the kernel
      * @param input_cols  the column indices passed to the kernel
      * @param input_vals  the values passed to the kernel
-     * @param local_entries  the reference local matrix data. It is provided
+     * @param diag_entries  the reference diag matrix data. It is provided
      *                       as a list of tuples for each part of the row
      *                       partition. Each tuple consists of the size of
-     *                       the local matrix, a list of row indices,
+     *                       the diag matrix, a list of row indices,
      *                       a list of column indices, and a list of values.
      *                       The indices are mapped to local indexing.
-     * @param non_local_entries  the reference non-local matrix data. It is
+     * @param off_diag_entries  the reference off-diag matrix data. It is
      *                           provided as a list of tuples for each part
      *                           of the row partition. Each tuple contains
-     *                           the size of the non-local matrix, a list of
+     *                           the size of the off-diag matrix, a list of
      *                           row indices (mapped to local indexing), a
      *                           list of column indices (NOT mapped to local
      *                           indexing), and a list of values.
@@ -86,30 +86,30 @@ protected:
             std::tuple<gko::dim<2>, std::initializer_list<global_index_type>,
                        std::initializer_list<global_index_type>,
                        std::initializer_list<value_type>>>
-            local_entries,
+            diag_entries,
         std::initializer_list<
             std::tuple<gko::dim<2>, std::initializer_list<global_index_type>,
                        std::initializer_list<global_index_type>,
                        std::initializer_list<value_type>>>
-            non_local_entries)
+            off_diag_entries)
     {
         std::vector<gko::device_matrix_data<value_type, local_index_type>>
-            ref_locals;
+            ref_diags;
         std::vector<
             std::tuple<gko::dim<2>, gko::array<local_index_type>,
                        gko::array<global_index_type>, gko::array<value_type>>>
-            ref_non_locals;
+            ref_off_diags;
 
         auto input = gko::device_matrix_data<value_type, global_index_type>{
             ref, size, gko::array<global_index_type>{ref, input_rows},
             gko::array<global_index_type>{ref, input_cols},
             gko::array<value_type>{ref, input_vals}};
-        for (auto entry : local_entries) {
-            ref_locals.emplace_back(ref, std::get<0>(entry), std::get<1>(entry),
-                                    std::get<2>(entry), std::get<3>(entry));
+        for (auto entry : diag_entries) {
+            ref_diags.emplace_back(ref, std::get<0>(entry), std::get<1>(entry),
+                                   std::get<2>(entry), std::get<3>(entry));
         }
-        for (auto entry : non_local_entries) {
-            ref_non_locals.emplace_back(
+        for (auto entry : off_diag_entries) {
+            ref_off_diags.emplace_back(
                 std::get<0>(entry),
                 gko::array<local_index_type>{ref, std::get<1>(entry)},
                 gko::array<global_index_type>{ref, std::get<2>(entry)},
@@ -118,23 +118,22 @@ protected:
 
         for (comm_index_type part = 0; part < row_partition->get_num_parts();
              ++part) {
-            gko::kernels::reference::distributed_matrix::
-                separate_local_nonlocal(
-                    ref, input, row_partition.get(), col_partition.get(), part,
-                    local_row_idxs, local_col_idxs, local_values,
-                    non_local_row_idxs, non_local_col_idxs, non_local_values);
+            gko::kernels::reference::distributed_matrix::separate_diag_off_diag(
+                ref, input, row_partition.get(), col_partition.get(), part,
+                diag_row_idxs, diag_col_idxs, diag_values, off_diag_row_idxs,
+                off_diag_col_idxs, off_diag_values);
 
 
-            auto local_arrays = ref_locals[part].empty_out();
-            GKO_ASSERT_ARRAY_EQ(local_row_idxs, local_arrays.row_idxs);
-            GKO_ASSERT_ARRAY_EQ(local_col_idxs, local_arrays.col_idxs);
-            GKO_ASSERT_ARRAY_EQ(local_values, local_arrays.values);
-            GKO_ASSERT_ARRAY_EQ(non_local_row_idxs,
-                                std::get<1>(ref_non_locals[part]));
-            GKO_ASSERT_ARRAY_EQ(non_local_col_idxs,
-                                std::get<2>(ref_non_locals[part]));
-            GKO_ASSERT_ARRAY_EQ(non_local_values,
-                                std::get<3>(ref_non_locals[part]));
+            auto diag_arrays = ref_diags[part].empty_out();
+            GKO_ASSERT_ARRAY_EQ(diag_row_idxs, diag_arrays.row_idxs);
+            GKO_ASSERT_ARRAY_EQ(diag_col_idxs, diag_arrays.col_idxs);
+            GKO_ASSERT_ARRAY_EQ(diag_values, diag_arrays.values);
+            GKO_ASSERT_ARRAY_EQ(off_diag_row_idxs,
+                                std::get<1>(ref_off_diags[part]));
+            GKO_ASSERT_ARRAY_EQ(off_diag_col_idxs,
+                                std::get<2>(ref_off_diags[part]));
+            GKO_ASSERT_ARRAY_EQ(off_diag_values,
+                                std::get<3>(ref_off_diags[part]));
         }
     }
 
@@ -174,19 +173,19 @@ protected:
 
     std::shared_ptr<const gko::ReferenceExecutor> ref;
     gko::array<comm_index_type> mapping;
-    gko::array<local_index_type> local_row_idxs;
-    gko::array<local_index_type> local_col_idxs;
-    gko::array<value_type> local_values;
-    gko::array<local_index_type> non_local_row_idxs;
-    gko::array<global_index_type> non_local_col_idxs;
-    gko::array<value_type> non_local_values;
+    gko::array<local_index_type> diag_row_idxs;
+    gko::array<local_index_type> diag_col_idxs;
+    gko::array<value_type> diag_values;
+    gko::array<local_index_type> off_diag_row_idxs;
+    gko::array<global_index_type> off_diag_col_idxs;
+    gko::array<value_type> off_diag_values;
 };
 
 TYPED_TEST_SUITE(Matrix, gko::test::ValueLocalGlobalIndexTypes,
                  TupleTypenameNameGenerator);
 
 
-TYPED_TEST(Matrix, SeparateLocalNonLocalEmpty)
+TYPED_TEST(Matrix, SeparateDiagOffDiagEmpty)
 {
     using lit = typename TestFixture::local_index_type;
     using git = typename TestFixture::global_index_type;
@@ -208,7 +207,7 @@ TYPED_TEST(Matrix, SeparateLocalNonLocalEmpty)
 }
 
 
-TYPED_TEST(Matrix, SeparateLocalNonLocalSmall)
+TYPED_TEST(Matrix, SeparateDiagOffDiagSmall)
 {
     using lit = typename TestFixture::local_index_type;
     using git = typename TestFixture::global_index_type;
@@ -229,7 +228,7 @@ TYPED_TEST(Matrix, SeparateLocalNonLocalSmall)
 }
 
 
-TYPED_TEST(Matrix, SeparateLocalNonLocalNoNonLocal)
+TYPED_TEST(Matrix, SeparateDiagOffDiagNoOffDiag)
 {
     using lit = typename TestFixture::local_index_type;
     using git = typename TestFixture::global_index_type;
@@ -255,7 +254,7 @@ TYPED_TEST(Matrix, SeparateLocalNonLocalNoNonLocal)
 }
 
 
-TYPED_TEST(Matrix, SeparateLocalNonLocalNoLocal)
+TYPED_TEST(Matrix, SeparateDiagOffDiagNoDiag)
 {
     using lit = typename TestFixture::local_index_type;
     using git = typename TestFixture::global_index_type;
@@ -280,7 +279,7 @@ TYPED_TEST(Matrix, SeparateLocalNonLocalNoLocal)
 }
 
 
-TYPED_TEST(Matrix, SeparateLocalNonLocalMixed)
+TYPED_TEST(Matrix, SeparateDiagOffDiagMixed)
 {
     using lit = typename TestFixture::local_index_type;
     using git = typename TestFixture::global_index_type;
@@ -312,7 +311,7 @@ TYPED_TEST(Matrix, SeparateLocalNonLocalMixed)
 }
 
 
-TYPED_TEST(Matrix, SeparateLocalNonLocalEmptyWithColPartition)
+TYPED_TEST(Matrix, SeparateDiagOffDiagEmptyWithColPartition)
 {
     using lit = typename TestFixture::local_index_type;
     using git = typename TestFixture::global_index_type;
@@ -339,7 +338,7 @@ TYPED_TEST(Matrix, SeparateLocalNonLocalEmptyWithColPartition)
 }
 
 
-TYPED_TEST(Matrix, SeparateLocalNonLocalSmallWithColPartition)
+TYPED_TEST(Matrix, SeparateDiagOffDiagSmallWithColPartition)
 {
     using lit = typename TestFixture::local_index_type;
     using git = typename TestFixture::global_index_type;
@@ -363,7 +362,7 @@ TYPED_TEST(Matrix, SeparateLocalNonLocalSmallWithColPartition)
          std::make_tuple(gko::dim<2>{1, 1}, I<git>{0}, I<git>{0}, I<vt>{1})});
 }
 
-TYPED_TEST(Matrix, SeparateLocalNonLocalNoNonLocalWithColPartition)
+TYPED_TEST(Matrix, SeparateDiagOffDiagNoOffDiagWithColPartition)
 {
     using lit = typename TestFixture::local_index_type;
     using git = typename TestFixture::global_index_type;
@@ -392,7 +391,7 @@ TYPED_TEST(Matrix, SeparateLocalNonLocalNoNonLocalWithColPartition)
 }
 
 
-TYPED_TEST(Matrix, SeparateLocalNonLocalNoLocalWithColPartition)
+TYPED_TEST(Matrix, SeparateDiagOffDiagNoDiagWithColPartition)
 {
     using lit = typename TestFixture::local_index_type;
     using git = typename TestFixture::global_index_type;
@@ -422,7 +421,7 @@ TYPED_TEST(Matrix, SeparateLocalNonLocalNoLocalWithColPartition)
 }
 
 
-TYPED_TEST(Matrix, SeparateLocalNonLocalMixedWithColPartition)
+TYPED_TEST(Matrix, SeparateDiagOffDiagMixedWithColPartition)
 {
     using lit = typename TestFixture::local_index_type;
     using git = typename TestFixture::global_index_type;
@@ -458,7 +457,7 @@ TYPED_TEST(Matrix, SeparateLocalNonLocalMixedWithColPartition)
 }
 
 
-TYPED_TEST(Matrix, SeparateLocalNonLocalNonSquare)
+TYPED_TEST(Matrix, SeparateDiagOffDiagNonSquare)
 {
     using lit = typename TestFixture::local_index_type;
     using git = typename TestFixture::global_index_type;

--- a/test/distributed/matrix_kernels.cpp
+++ b/test/distributed/matrix_kernels.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -50,37 +50,36 @@ protected:
                                                                        input};
         for (comm_index_type part = 0; part < row_partition->get_num_parts();
              ++part) {
-            gko::array<local_index_type> local_row_idxs{ref};
-            gko::array<local_index_type> local_col_idxs{ref};
-            gko::array<value_type> local_values{ref};
-            gko::array<local_index_type> d_local_row_idxs{exec};
-            gko::array<local_index_type> d_local_col_idxs{exec};
-            gko::array<value_type> d_local_values{exec};
-            gko::array<local_index_type> non_local_row_idxs{ref};
-            gko::array<global_index_type> non_local_col_idxs{ref};
-            gko::array<value_type> non_local_values{ref};
-            gko::array<local_index_type> d_non_local_row_idxs{exec};
-            gko::array<global_index_type> d_non_local_col_idxs{exec};
-            gko::array<value_type> d_non_local_values{exec};
+            gko::array<local_index_type> diag_row_idxs{ref};
+            gko::array<local_index_type> diag_col_idxs{ref};
+            gko::array<value_type> diag_values{ref};
+            gko::array<local_index_type> d_diag_row_idxs{exec};
+            gko::array<local_index_type> d_diag_col_idxs{exec};
+            gko::array<value_type> d_diag_values{exec};
+            gko::array<local_index_type> off_diag_row_idxs{ref};
+            gko::array<global_index_type> off_diag_col_idxs{ref};
+            gko::array<value_type> off_diag_values{ref};
+            gko::array<local_index_type> d_off_diag_row_idxs{exec};
+            gko::array<global_index_type> d_off_diag_col_idxs{exec};
+            gko::array<value_type> d_off_diag_values{exec};
 
-            gko::kernels::reference::distributed_matrix::
-                separate_local_nonlocal(
-                    ref, input, row_partition.get(), col_partition.get(), part,
-                    local_row_idxs, local_col_idxs, local_values,
-                    non_local_row_idxs, non_local_col_idxs, non_local_values);
+            gko::kernels::reference::distributed_matrix::separate_diag_off_diag(
+                ref, input, row_partition.get(), col_partition.get(), part,
+                diag_row_idxs, diag_col_idxs, diag_values, off_diag_row_idxs,
+                off_diag_col_idxs, off_diag_values);
             gko::kernels::GKO_DEVICE_NAMESPACE::distributed_matrix::
-                separate_local_nonlocal(
-                    exec, d_input, d_row_partition.get(), d_col_partition.get(),
-                    part, d_local_row_idxs, d_local_col_idxs, d_local_values,
-                    d_non_local_row_idxs, d_non_local_col_idxs,
-                    d_non_local_values);
+                separate_diag_off_diag(exec, d_input, d_row_partition.get(),
+                                       d_col_partition.get(), part,
+                                       d_diag_row_idxs, d_diag_col_idxs,
+                                       d_diag_values, d_off_diag_row_idxs,
+                                       d_off_diag_col_idxs, d_off_diag_values);
 
-            GKO_ASSERT_ARRAY_EQ(local_row_idxs, d_local_row_idxs);
-            GKO_ASSERT_ARRAY_EQ(local_col_idxs, d_local_col_idxs);
-            GKO_ASSERT_ARRAY_EQ(local_values, d_local_values);
-            GKO_ASSERT_ARRAY_EQ(non_local_row_idxs, d_non_local_row_idxs);
-            GKO_ASSERT_ARRAY_EQ(non_local_col_idxs, d_non_local_col_idxs);
-            GKO_ASSERT_ARRAY_EQ(non_local_values, d_non_local_values);
+            GKO_ASSERT_ARRAY_EQ(diag_row_idxs, d_diag_row_idxs);
+            GKO_ASSERT_ARRAY_EQ(diag_col_idxs, d_diag_col_idxs);
+            GKO_ASSERT_ARRAY_EQ(diag_values, d_diag_values);
+            GKO_ASSERT_ARRAY_EQ(off_diag_row_idxs, d_off_diag_row_idxs);
+            GKO_ASSERT_ARRAY_EQ(off_diag_col_idxs, d_off_diag_col_idxs);
+            GKO_ASSERT_ARRAY_EQ(off_diag_values, d_off_diag_values);
         }
     }
 

--- a/test/mpi/distributed/matrix.cpp
+++ b/test/mpi/distributed/matrix.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -110,17 +110,17 @@ TYPED_TEST(MatrixCreation, ReadsDistributedGlobalData)
 {
     using value_type = typename TestFixture::value_type;
     using csr = typename TestFixture::local_matrix_type;
-    I<I<value_type>> res_local[] = {{{0, 1}, {0, 3}}, {{6, 0}, {0, 8}}, {{10}}};
-    I<I<value_type>> res_non_local[] = {
+    I<I<value_type>> res_diag[] = {{{0, 1}, {0, 3}}, {{6, 0}, {0, 8}}, {{10}}};
+    I<I<value_type>> res_off_diag[] = {
         {{0, 2}, {4, 0}}, {{5, 0}, {0, 7}}, {{9}}};
     auto rank = this->dist_mat->get_communicator().rank();
 
     this->dist_mat->read_distributed(this->mat_input, this->row_part);
 
-    GKO_ASSERT_MTX_NEAR(gko::as<csr>(this->dist_mat->get_local_matrix()),
-                        res_local[rank], 0);
-    GKO_ASSERT_MTX_NEAR(gko::as<csr>(this->dist_mat->get_non_local_matrix()),
-                        res_non_local[rank], 0);
+    GKO_ASSERT_MTX_NEAR(gko::as<csr>(this->dist_mat->get_diag_matrix()),
+                        res_diag[rank], 0);
+    GKO_ASSERT_MTX_NEAR(gko::as<csr>(this->dist_mat->get_off_diag_matrix()),
+                        res_off_diag[rank], 0);
 }
 
 
@@ -128,17 +128,17 @@ TYPED_TEST(MatrixCreation, ReadsDistributedLocalData)
 {
     using value_type = typename TestFixture::value_type;
     using csr = typename TestFixture::local_matrix_type;
-    I<I<value_type>> res_local[] = {{{0, 1}, {0, 3}}, {{6, 0}, {0, 8}}, {{10}}};
-    I<I<value_type>> res_non_local[] = {
+    I<I<value_type>> res_diag[] = {{{0, 1}, {0, 3}}, {{6, 0}, {0, 8}}, {{10}}};
+    I<I<value_type>> res_off_diag[] = {
         {{0, 2}, {4, 0}}, {{5, 0}, {0, 7}}, {{9}}};
     auto rank = this->dist_mat->get_communicator().rank();
 
     this->dist_mat->read_distributed(this->dist_input[rank], this->row_part);
 
-    GKO_ASSERT_MTX_NEAR(gko::as<csr>(this->dist_mat->get_local_matrix()),
-                        res_local[rank], 0);
-    GKO_ASSERT_MTX_NEAR(gko::as<csr>(this->dist_mat->get_non_local_matrix()),
-                        res_non_local[rank], 0);
+    GKO_ASSERT_MTX_NEAR(gko::as<csr>(this->dist_mat->get_diag_matrix()),
+                        res_diag[rank], 0);
+    GKO_ASSERT_MTX_NEAR(gko::as<csr>(this->dist_mat->get_off_diag_matrix()),
+                        res_off_diag[rank], 0);
 }
 
 
@@ -146,8 +146,8 @@ TYPED_TEST(MatrixCreation, ReadsDistributedLocalDataWithCommunicate)
 {
     using value_type = typename TestFixture::value_type;
     using csr = typename TestFixture::local_matrix_type;
-    I<I<value_type>> res_local[] = {{{1, 1}, {0, 3}}, {{7, 1}, {0, 7}}, {{10}}};
-    I<I<value_type>> res_non_local[] = {
+    I<I<value_type>> res_diag[] = {{{1, 1}, {0, 3}}, {{7, 1}, {0, 7}}, {{10}}};
+    I<I<value_type>> res_off_diag[] = {
         {{0, 2}, {4, 0}}, {{1, 5, 0}, {0, 0, 7}}, {{9}}};
     auto rank = this->dist_mat->get_communicator().rank();
 
@@ -155,10 +155,10 @@ TYPED_TEST(MatrixCreation, ReadsDistributedLocalDataWithCommunicate)
         this->dist_input[rank], this->row_part,
         gko::experimental::distributed::assembly_mode::communicate);
 
-    GKO_ASSERT_MTX_NEAR(gko::as<csr>(this->dist_mat->get_local_matrix()),
-                        res_local[rank], 0);
-    GKO_ASSERT_MTX_NEAR(gko::as<csr>(this->dist_mat->get_non_local_matrix()),
-                        res_non_local[rank], 0);
+    GKO_ASSERT_MTX_NEAR(gko::as<csr>(this->dist_mat->get_diag_matrix()),
+                        res_diag[rank], 0);
+    GKO_ASSERT_MTX_NEAR(gko::as<csr>(this->dist_mat->get_off_diag_matrix()),
+                        res_off_diag[rank], 0);
 }
 
 
@@ -166,18 +166,18 @@ TYPED_TEST(MatrixCreation, ReadsDistributedWithColPartition)
 {
     using value_type = typename TestFixture::value_type;
     using csr = typename TestFixture::local_matrix_type;
-    I<I<value_type>> res_local[] = {{{2, 0}, {0, 0}}, {{0, 5}, {0, 0}}, {{0}}};
-    I<I<value_type>> res_non_local[] = {
+    I<I<value_type>> res_diag[] = {{{2, 0}, {0, 0}}, {{0, 5}, {0, 0}}, {{0}}};
+    I<I<value_type>> res_off_diag[] = {
         {{1, 0}, {3, 4}}, {{0, 0, 6}, {8, 7, 0}}, {{10, 9}}};
     auto rank = this->dist_mat->get_communicator().rank();
 
     this->dist_mat->read_distributed(this->mat_input, this->row_part,
                                      this->col_part);
 
-    GKO_ASSERT_MTX_NEAR(gko::as<csr>(this->dist_mat->get_local_matrix()),
-                        res_local[rank], 0);
-    GKO_ASSERT_MTX_NEAR(gko::as<csr>(this->dist_mat->get_non_local_matrix()),
-                        res_non_local[rank], 0);
+    GKO_ASSERT_MTX_NEAR(gko::as<csr>(this->dist_mat->get_diag_matrix()),
+                        res_diag[rank], 0);
+    GKO_ASSERT_MTX_NEAR(gko::as<csr>(this->dist_mat->get_off_diag_matrix()),
+                        res_off_diag[rank], 0);
 }
 
 
@@ -185,8 +185,8 @@ TYPED_TEST(MatrixCreation, ReadsDistributedWithColPartitionAndCommunicate)
 {
     using value_type = typename TestFixture::value_type;
     using csr = typename TestFixture::local_matrix_type;
-    I<I<value_type>> res_local[] = {{{2, 0}, {0, 0}}, {{1, 5}, {0, 0}}, {{0}}};
-    I<I<value_type>> res_non_local[] = {
+    I<I<value_type>> res_diag[] = {{{2, 0}, {0, 0}}, {{1, 5}, {0, 0}}, {{0}}};
+    I<I<value_type>> res_off_diag[] = {
         {{1, 1, 0}, {0, 3, 4}}, {{1, 0, 7}, {7, 7, 0}}, {{10, 9}}};
     auto rank = this->dist_mat->get_communicator().rank();
 
@@ -194,10 +194,10 @@ TYPED_TEST(MatrixCreation, ReadsDistributedWithColPartitionAndCommunicate)
         this->dist_input[rank], this->row_part, this->col_part,
         gko::experimental::distributed::assembly_mode::communicate);
 
-    GKO_ASSERT_MTX_NEAR(gko::as<csr>(this->dist_mat->get_local_matrix()),
-                        res_local[rank], 0);
-    GKO_ASSERT_MTX_NEAR(gko::as<csr>(this->dist_mat->get_non_local_matrix()),
-                        res_non_local[rank], 0);
+    GKO_ASSERT_MTX_NEAR(gko::as<csr>(this->dist_mat->get_diag_matrix()),
+                        res_diag[rank], 0);
+    GKO_ASSERT_MTX_NEAR(gko::as<csr>(this->dist_mat->get_off_diag_matrix()),
+                        res_off_diag[rank], 0);
 }
 
 
@@ -211,7 +211,7 @@ TYPED_TEST(MatrixCreation, BuildOnlyLocal)
     using matrix_data = gko::matrix_data<value_type, local_index_type>;
     using dist_mtx_type = typename TestFixture::dist_mtx_type;
     using dist_vec_type = gko::experimental::distributed::Vector<value_type>;
-    I<I<value_type>> res_local[] = {
+    I<I<value_type>> res_diag[] = {
         {{1, 2}, {0, 3}}, {{0, 1}, {-1, 0}}, {{1, 0}, {0, 1}}};
     auto rank = this->comm.rank();
     gko::dim<2> size(2, 2);
@@ -241,7 +241,7 @@ TYPED_TEST(MatrixCreation, BuildOnlyLocal)
         dist_mtx_type::create(this->exec, this->comm, gko::dim<2>{6, 6}, local);
     mat->apply(x, y);
 
-    GKO_ASSERT_MTX_NEAR(gko::as<csr>(mat->get_local_matrix()), res_local[rank],
+    GKO_ASSERT_MTX_NEAR(gko::as<csr>(mat->get_diag_matrix()), res_diag[rank],
                         0);
     GKO_ASSERT_MTX_NEAR(y->get_local_vector(), result[rank], 0);
 }
@@ -264,29 +264,29 @@ TYPED_TEST(MatrixCreation, BuildFromExistingDataDeprecated)
     using dist_vec_type = gko::experimental::distributed::Vector<value_type>;
     using comm_index_type = gko::experimental::distributed::comm_index_type;
     auto rank = this->comm.rank();
-    I<I<value_type>> res_local[] = {{{2, 0}, {0, 0}}, {{0, 5}, {0, 0}}, {{0}}};
-    std::array<gko::dim<2>, 3> size_local{{{2, 2}, {2, 2}, {1, 1}}};
-    std::array<matrix_data, 3> dist_input_local{
-        {{size_local[0], I<input_triple>{{0, 0, 2}}},
-         {size_local[1], I<input_triple>{{0, 1, 5}}},
-         {size_local[2]}}};
-    I<I<value_type>> res_non_local[] = {
+    I<I<value_type>> res_diag[] = {{{2, 0}, {0, 0}}, {{0, 5}, {0, 0}}, {{0}}};
+    std::array<gko::dim<2>, 3> size_diag{{{2, 2}, {2, 2}, {1, 1}}};
+    std::array<matrix_data, 3> dist_input_diag{
+        {{size_diag[0], I<input_triple>{{0, 0, 2}}},
+         {size_diag[1], I<input_triple>{{0, 1, 5}}},
+         {size_diag[2]}}};
+    I<I<value_type>> res_off_diag[] = {
         {{1, 0}, {3, 4}}, {{0, 0, 6}, {8, 7, 0}}, {{10, 9}}};
-    std::array<gko::dim<2>, 3> size_non_local{{{2, 2}, {2, 3}, {1, 2}}};
-    std::array<matrix_data, 3> dist_input_non_local{
-        {{size_non_local[0], I<input_triple>{{0, 0, 1}, {1, 0, 3}, {1, 1, 4}}},
-         {size_non_local[1], I<input_triple>{{0, 2, 6}, {1, 0, 8}, {1, 1, 7}}},
-         {size_non_local[2], I<input_triple>{{0, 0, 10}, {0, 1, 9}}}}};
+    std::array<gko::dim<2>, 3> size_off_diag{{{2, 2}, {2, 3}, {1, 2}}};
+    std::array<matrix_data, 3> dist_input_off_diag{
+        {{size_off_diag[0], I<input_triple>{{0, 0, 1}, {1, 0, 3}, {1, 1, 4}}},
+         {size_off_diag[1], I<input_triple>{{0, 2, 6}, {1, 0, 8}, {1, 1, 7}}},
+         {size_off_diag[2], I<input_triple>{{0, 0, 10}, {0, 1, 9}}}}};
     std::array<std::vector<comm_index_type>, 3> recv_sizes{
         {{0, 1, 1}, {2, 0, 1}, {1, 1, 0}}};
     std::array<std::vector<comm_index_type>, 3> recv_offsets{
         {{0, 0, 1, 2}, {0, 2, 2, 3}, {0, 1, 2, 2}}};
     std::array<gko::array<local_index_type>, 3> recv_gather_index{
         {{this->exec, {1, 0}}, {this->exec, {0, 1, 0}}, {this->exec, {1, 0}}}};
-    auto local = gko::share(csr::create(this->exec));
-    local->read(dist_input_local[rank]);
-    auto non_local = gko::share(csr::create(this->exec));
-    non_local->read(dist_input_non_local[rank]);
+    auto diag = gko::share(csr::create(this->exec));
+    diag->read(dist_input_diag[rank]);
+    auto off_diag = gko::share(csr::create(this->exec));
+    off_diag->read(dist_input_off_diag[rank]);
     // create vector
     auto vec_md = gko::matrix_data<value_type, global_index_type>{
         I<I<value_type>>{{1}, {2}, {3}, {4}, {5}}};
@@ -305,14 +305,14 @@ TYPED_TEST(MatrixCreation, BuildFromExistingDataDeprecated)
     y->read_distributed(vec_md, row_part);
 
     auto mat = dist_mtx_type::create(
-        this->exec, this->comm, gko::dim<2>{5, 5}, local, non_local,
+        this->exec, this->comm, gko::dim<2>{5, 5}, diag, off_diag,
         recv_sizes[rank], recv_offsets[rank], recv_gather_index[rank]);
     mat->apply(x, y);
 
-    GKO_ASSERT_MTX_NEAR(gko::as<csr>(mat->get_local_matrix()), res_local[rank],
+    GKO_ASSERT_MTX_NEAR(gko::as<csr>(mat->get_diag_matrix()), res_diag[rank],
                         0);
-    GKO_ASSERT_MTX_NEAR(gko::as<csr>(mat->get_non_local_matrix()),
-                        res_non_local[rank], 0);
+    GKO_ASSERT_MTX_NEAR(gko::as<csr>(mat->get_off_diag_matrix()),
+                        res_off_diag[rank], 0);
     GKO_ASSERT_MTX_NEAR(y->get_local_vector(), result[rank], 0);
 }
 
@@ -350,23 +350,23 @@ TYPED_TEST(MatrixCreation, BuildFromExistingData)
         gko::array<global_index_type>{this->exec, {3, 4, 2}},
         gko::array<global_index_type>{this->exec, {4, 0}}};
     index_map_type imap(this->exec, col_part, rank, recv_connections[rank]);
-    std::array<gko::dim<2>, 3> size_local{{{2, 2}, {2, 2}, {1, 1}}};
-    std::array<matrix_data, 3> dist_input_local{
-        {{size_local[0], I<input_triple>{{0, 0, 2}}},
-         {size_local[1], I<input_triple>{{0, 1, 5}}},
-         {size_local[2]}}};
-    std::array<gko::dim<2>, 3> size_non_local{{{2, 2}, {2, 3}, {1, 2}}};
-    std::array<matrix_data, 3> dist_input_non_local{
-        {{size_non_local[0], I<input_triple>{{0, 0, 1}, {1, 0, 3}, {1, 1, 4}}},
-         {size_non_local[1], I<input_triple>{{0, 2, 6}, {1, 0, 8}, {1, 1, 7}}},
-         {size_non_local[2], I<input_triple>{{0, 0, 10}, {0, 1, 9}}}}};
-    I<I<value_type>> res_local[] = {{{2, 0}, {0, 0}}, {{0, 5}, {0, 0}}, {{0}}};
-    I<I<value_type>> res_non_local[] = {
+    std::array<gko::dim<2>, 3> size_diag{{{2, 2}, {2, 2}, {1, 1}}};
+    std::array<matrix_data, 3> dist_input_diag{
+        {{size_diag[0], I<input_triple>{{0, 0, 2}}},
+         {size_diag[1], I<input_triple>{{0, 1, 5}}},
+         {size_diag[2]}}};
+    std::array<gko::dim<2>, 3> size_off_diag{{{2, 2}, {2, 3}, {1, 2}}};
+    std::array<matrix_data, 3> dist_input_off_diag{
+        {{size_off_diag[0], I<input_triple>{{0, 0, 1}, {1, 0, 3}, {1, 1, 4}}},
+         {size_off_diag[1], I<input_triple>{{0, 2, 6}, {1, 0, 8}, {1, 1, 7}}},
+         {size_off_diag[2], I<input_triple>{{0, 0, 10}, {0, 1, 9}}}}};
+    I<I<value_type>> res_diag[] = {{{2, 0}, {0, 0}}, {{0, 5}, {0, 0}}, {{0}}};
+    I<I<value_type>> res_off_diag[] = {
         {{1, 0}, {3, 4}}, {{0, 0, 6}, {8, 7, 0}}, {{10, 9}}};
-    auto local = gko::share(csr::create(this->exec));
-    local->read(dist_input_local[rank]);
-    auto non_local = gko::share(csr::create(this->exec));
-    non_local->read(dist_input_non_local[rank]);
+    auto diag = gko::share(csr::create(this->exec));
+    diag->read(dist_input_diag[rank]);
+    auto off_diag = gko::share(csr::create(this->exec));
+    off_diag->read(dist_input_off_diag[rank]);
     // create vector
     auto vec_md = gko::matrix_data<value_type, global_index_type>{
         I<I<value_type>>{{1}, {2}, {3}, {4}, {5}}};
@@ -377,13 +377,13 @@ TYPED_TEST(MatrixCreation, BuildFromExistingData)
     y->read_distributed(vec_md, row_part);
 
     auto mat =
-        dist_mtx_type::create(this->exec, this->comm, imap, local, non_local);
+        dist_mtx_type::create(this->exec, this->comm, imap, diag, off_diag);
     mat->apply(x, y);
 
-    GKO_ASSERT_MTX_NEAR(gko::as<csr>(mat->get_local_matrix()), res_local[rank],
+    GKO_ASSERT_MTX_NEAR(gko::as<csr>(mat->get_diag_matrix()), res_diag[rank],
                         0);
-    GKO_ASSERT_MTX_NEAR(gko::as<csr>(mat->get_non_local_matrix()),
-                        res_non_local[rank], 0);
+    GKO_ASSERT_MTX_NEAR(gko::as<csr>(mat->get_off_diag_matrix()),
+                        res_off_diag[rank], 0);
     GKO_ASSERT_MTX_NEAR(y->get_local_vector(), result[rank], 0);
 }
 
@@ -603,7 +603,7 @@ TYPED_TEST(Matrix, CanAdvancedApplyToSingleVector)
 }
 
 
-TYPED_TEST(Matrix, CanApplyToSingleVectorByNonLocalApply2)
+TYPED_TEST(Matrix, CanApplyToSingleVectorByOffDiagApply2)
 {
     using value_type = typename TestFixture::value_type;
     using global_index_type = typename TestFixture::global_index_type;
@@ -618,7 +618,7 @@ TYPED_TEST(Matrix, CanApplyToSingleVectorByNonLocalApply2)
     this->x->read_distributed(vec_md, this->col_part);
     this->y->read_distributed(vec_md, this->row_part);
     // default setup with csr should use normal advanced apply, so use coo as
-    // non_local to check apply2
+    // off_diag to check apply2
     auto dist_mat_coo = dist_mtx_type::create(
         this->exec, this->comm, gko::with_matrix_type<gko::matrix::Csr>(),
         gko::with_matrix_type<gko::matrix::Coo>());
@@ -631,7 +631,7 @@ TYPED_TEST(Matrix, CanApplyToSingleVectorByNonLocalApply2)
 }
 
 
-TYPED_TEST(Matrix, CanAdvancedApplyToSingleVectorByNonLocalApply2)
+TYPED_TEST(Matrix, CanAdvancedApplyToSingleVectorByOffDiagApply2)
 {
     using value_type = typename TestFixture::value_type;
     using global_index_type = typename TestFixture::global_index_type;
@@ -649,7 +649,7 @@ TYPED_TEST(Matrix, CanAdvancedApplyToSingleVectorByNonLocalApply2)
     this->x->read_distributed(vec_md, this->col_part);
     this->y->read_distributed(vec_md, this->row_part);
     // default setup with csr should use normal advanced apply, so use coo as
-    // non_local to check apply2
+    // off_diag to check apply2
     auto dist_mat_coo = dist_mtx_type::create(
         this->exec, this->comm, gko::with_matrix_type<gko::matrix::Csr>(),
         gko::with_matrix_type<gko::matrix::Coo>());
@@ -709,9 +709,9 @@ TYPED_TEST(Matrix, CanColScale)
     using dist_vec_type = typename TestFixture::dist_vec_type;
     auto vec_md = gko::matrix_data<value_type, index_type>{
         I<I<value_type>>{{1}, {2}, {3}, {4}, {5}}};
-    I<I<value_type>> res_col_scale_local[] = {
+    I<I<value_type>> res_col_scale_diag[] = {
         {{8, 0}, {0, 0}}, {{0, 10}, {0, 0}}, {{0}}};
-    I<I<value_type>> res_col_scale_non_local[] = {
+    I<I<value_type>> res_col_scale_off_diag[] = {
         {{2, 0}, {6, 12}}, {{0, 0, 18}, {32, 35, 0}}, {{50, 9}}};
     auto rank = this->comm.rank();
     auto col_scaling_factors = dist_vec_type::create(this->exec, this->comm);
@@ -719,10 +719,10 @@ TYPED_TEST(Matrix, CanColScale)
 
     this->dist_mat->col_scale(col_scaling_factors);
 
-    GKO_ASSERT_MTX_NEAR(gko::as<csr>(this->dist_mat->get_local_matrix()),
-                        res_col_scale_local[rank], 0);
-    GKO_ASSERT_MTX_NEAR(gko::as<csr>(this->dist_mat->get_non_local_matrix()),
-                        res_col_scale_non_local[rank], 0);
+    GKO_ASSERT_MTX_NEAR(gko::as<csr>(this->dist_mat->get_diag_matrix()),
+                        res_col_scale_diag[rank], 0);
+    GKO_ASSERT_MTX_NEAR(gko::as<csr>(this->dist_mat->get_off_diag_matrix()),
+                        res_col_scale_off_diag[rank], 0);
 }
 
 
@@ -734,9 +734,9 @@ TYPED_TEST(Matrix, CanRowScale)
     using dist_vec_type = typename TestFixture::dist_vec_type;
     auto vec_md = gko::matrix_data<value_type, index_type>{
         I<I<value_type>>{{1}, {2}, {3}, {4}, {5}}};
-    I<I<value_type>> res_row_scale_local[] = {
+    I<I<value_type>> res_row_scale_diag[] = {
         {{2, 0}, {0, 0}}, {{0, 15}, {0, 0}}, {{0}}};
-    I<I<value_type>> res_row_scale_non_local[] = {
+    I<I<value_type>> res_row_scale_off_diag[] = {
         {{1, 0}, {6, 8}}, {{0, 0, 18}, {32, 28, 0}}, {{50, 45}}};
     auto rank = this->comm.rank();
     auto row_scaling_factors = dist_vec_type::create(this->exec, this->comm);
@@ -744,10 +744,10 @@ TYPED_TEST(Matrix, CanRowScale)
 
     this->dist_mat->row_scale(row_scaling_factors);
 
-    GKO_ASSERT_MTX_NEAR(gko::as<csr>(this->dist_mat->get_local_matrix()),
-                        res_row_scale_local[rank], 0);
-    GKO_ASSERT_MTX_NEAR(gko::as<csr>(this->dist_mat->get_non_local_matrix()),
-                        res_row_scale_non_local[rank], 0);
+    GKO_ASSERT_MTX_NEAR(gko::as<csr>(this->dist_mat->get_diag_matrix()),
+                        res_row_scale_diag[rank], 0);
+    GKO_ASSERT_MTX_NEAR(gko::as<csr>(this->dist_mat->get_off_diag_matrix()),
+                        res_row_scale_off_diag[rank], 0);
 }
 
 
@@ -759,9 +759,9 @@ TYPED_TEST(Matrix, CanColScaleWithStride)
     using dist_vec_type = typename TestFixture::dist_vec_type;
     auto vec_md = gko::matrix_data<value_type, index_type>{
         I<I<value_type>>{{1}, {2}, {3}, {4}, {5}}};
-    I<I<value_type>> res_col_scale_local[] = {
+    I<I<value_type>> res_col_scale_diag[] = {
         {{8, 0}, {0, 0}}, {{0, 10}, {0, 0}}, {{0}}};
-    I<I<value_type>> res_col_scale_non_local[] = {
+    I<I<value_type>> res_col_scale_off_diag[] = {
         {{2, 0}, {6, 12}}, {{0, 0, 18}, {32, 35, 0}}, {{50, 9}}};
     gko::dim<2> local_sizes[] = {{2, 1}, {2, 1}, {1, 1}};
     auto rank = this->comm.rank();
@@ -772,10 +772,10 @@ TYPED_TEST(Matrix, CanColScaleWithStride)
     this->dist_mat->col_scale(col_scaling_factors);
 
     ASSERT_EQ(col_scaling_factors->get_stride(), 2);
-    GKO_ASSERT_MTX_NEAR(gko::as<csr>(this->dist_mat->get_local_matrix()),
-                        res_col_scale_local[rank], 0);
-    GKO_ASSERT_MTX_NEAR(gko::as<csr>(this->dist_mat->get_non_local_matrix()),
-                        res_col_scale_non_local[rank], 0);
+    GKO_ASSERT_MTX_NEAR(gko::as<csr>(this->dist_mat->get_diag_matrix()),
+                        res_col_scale_diag[rank], 0);
+    GKO_ASSERT_MTX_NEAR(gko::as<csr>(this->dist_mat->get_off_diag_matrix()),
+                        res_col_scale_off_diag[rank], 0);
 }
 
 
@@ -787,9 +787,9 @@ TYPED_TEST(Matrix, CanRowScaleWithStride)
     using dist_vec_type = typename TestFixture::dist_vec_type;
     auto vec_md = gko::matrix_data<value_type, index_type>{
         I<I<value_type>>{{1}, {2}, {3}, {4}, {5}}};
-    I<I<value_type>> res_row_scale_local[] = {
+    I<I<value_type>> res_row_scale_diag[] = {
         {{2, 0}, {0, 0}}, {{0, 15}, {0, 0}}, {{0}}};
-    I<I<value_type>> res_row_scale_non_local[] = {
+    I<I<value_type>> res_row_scale_off_diag[] = {
         {{1, 0}, {6, 8}}, {{0, 0, 18}, {32, 28, 0}}, {{50, 45}}};
     gko::dim<2> local_sizes[] = {{2, 1}, {2, 1}, {1, 1}};
     auto rank = this->comm.rank();
@@ -800,10 +800,10 @@ TYPED_TEST(Matrix, CanRowScaleWithStride)
     this->dist_mat->row_scale(row_scaling_factors);
 
     ASSERT_EQ(row_scaling_factors->get_stride(), 2);
-    GKO_ASSERT_MTX_NEAR(gko::as<csr>(this->dist_mat->get_local_matrix()),
-                        res_row_scale_local[rank], 0);
-    GKO_ASSERT_MTX_NEAR(gko::as<csr>(this->dist_mat->get_non_local_matrix()),
-                        res_row_scale_non_local[rank], 0);
+    GKO_ASSERT_MTX_NEAR(gko::as<csr>(this->dist_mat->get_diag_matrix()),
+                        res_row_scale_diag[rank], 0);
+    GKO_ASSERT_MTX_NEAR(gko::as<csr>(this->dist_mat->get_off_diag_matrix()),
+                        res_row_scale_off_diag[rank], 0);
 }
 
 
@@ -883,10 +883,10 @@ TYPED_TEST(Matrix, CanConvertToNextPrecision)
     this->dist_mat->convert_to(tmp);
     tmp->convert_to(res);
 
-    GKO_ASSERT_MTX_NEAR(gko::as<csr>(this->dist_mat->get_local_matrix()),
-                        gko::as<csr>(res->get_local_matrix()), residual);
-    GKO_ASSERT_MTX_NEAR(gko::as<csr>(this->dist_mat->get_non_local_matrix()),
-                        gko::as<csr>(res->get_non_local_matrix()), residual);
+    GKO_ASSERT_MTX_NEAR(gko::as<csr>(this->dist_mat->get_diag_matrix()),
+                        gko::as<csr>(res->get_diag_matrix()), residual);
+    GKO_ASSERT_MTX_NEAR(gko::as<csr>(this->dist_mat->get_off_diag_matrix()),
+                        gko::as<csr>(res->get_off_diag_matrix()), residual);
 }
 
 
@@ -910,10 +910,10 @@ TYPED_TEST(Matrix, CanMoveToNextPrecision)
     this->dist_mat->move_to(tmp);
     tmp->convert_to(res);
 
-    GKO_ASSERT_MTX_NEAR(gko::as<csr>(clone_dist_mat->get_local_matrix()),
-                        gko::as<csr>(res->get_local_matrix()), residual);
-    GKO_ASSERT_MTX_NEAR(gko::as<csr>(clone_dist_mat->get_non_local_matrix()),
-                        gko::as<csr>(res->get_non_local_matrix()), residual);
+    GKO_ASSERT_MTX_NEAR(gko::as<csr>(clone_dist_mat->get_diag_matrix()),
+                        gko::as<csr>(res->get_diag_matrix()), residual);
+    GKO_ASSERT_MTX_NEAR(gko::as<csr>(clone_dist_mat->get_off_diag_matrix()),
+                        gko::as<csr>(res->get_off_diag_matrix()), residual);
 }
 
 

--- a/test/mpi/multigrid/pgm.cpp
+++ b/test/mpi/multigrid/pgm.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -92,24 +92,24 @@ TYPED_TEST(Pgm, CanGenerateFromDistributedMatrix)
     using local_matrix_type = typename TestFixture::local_matrix_type;
     auto pgm_factory = pgm::build().on(this->exec);
     auto rank = this->comm.rank();
-    I<I<value_type>> res_local[] = {{{8}}, {{5, 0}, {0, 5}}, {{6, 0}, {0, 6}}};
-    // the non_local new index should follow the local matrix
+    I<I<value_type>> res_diag[] = {{{8}}, {{5, 0}, {0, 5}}, {{6, 0}, {0, 6}}};
+    // the off_diag new index should follow the diag matrix
     // For example, we only store the nonzeros part like [* -1 -2 *] in
     // matrix[2, 4:8], whose * is not in the storage. The 1st and 3rd elements
     // are aggregated to the first group but the rest are aggregated to the
     // second group. Although the stored elements are not aggregated to the same
-    // group, we still need to reorder to fit the local matrix ordering. i.e.
+    // group, we still need to reorder to fit the diag matrix ordering. i.e.
     // [-1 -2] -> [-2 -1] after aggregation.
-    I<I<value_type>> res_non_local[] = {{{-3, -4, 9, 12}},
-                                        {{-3, -2, -1}, {-4, 0, -5}},
-                                        {{9, -2, 0}, {12, -1, -5}}};
+    I<I<value_type>> res_off_diag[] = {{{-3, -4, 9, 12}},
+                                       {{-3, -2, -1}, {-4, 0, -5}},
+                                       {{9, -2, 0}, {12, -1, -5}}};
 
     auto result = pgm_factory->generate(this->dist_mat);
 
     auto coarse = gko::as<dist_mtx_type>(result->get_coarse_op());
-    GKO_ASSERT_MTX_NEAR(gko::as<local_matrix_type>(coarse->get_local_matrix()),
-                        res_local[rank], r<value_type>::value);
+    GKO_ASSERT_MTX_NEAR(gko::as<local_matrix_type>(coarse->get_diag_matrix()),
+                        res_diag[rank], r<value_type>::value);
     GKO_ASSERT_MTX_NEAR(
-        gko::as<local_matrix_type>(coarse->get_non_local_matrix()),
-        res_non_local[rank], r<value_type>::value);
+        gko::as<local_matrix_type>(coarse->get_off_diag_matrix()),
+        res_off_diag[rank], r<value_type>::value);
 }

--- a/test/mpi/preconditioner/schwarz.cpp
+++ b/test/mpi/preconditioner/schwarz.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -82,7 +82,7 @@ protected:
             exec, gko::array<global_index_type>(
                       exec, I<global_index_type>{0, 2, 4, 8}));
 
-        // the default non-local matrix uses Coo, which does not support half
+        // the default off-diag matrix uses Coo, which does not support half
         // precision on HIP and DPCPP because of atomic
         dist_mat = dist_mtx_type::create(
             exec, comm, csr::create(exec),
@@ -247,7 +247,7 @@ TYPED_TEST(SchwarzPreconditioner, CanApplyPreconditionedSolverWithPregenSolver)
         gko::share(local_prec_type::build()
                        .with_max_block_size(1u)
                        .on(this->exec)
-                       ->generate(this->dist_mat->get_local_matrix()));
+                       ->generate(this->dist_mat->get_diag_matrix()));
     auto precond = prec::build()
                        .with_local_solver(this->local_solver_factory)
                        .on(this->exec)


### PR DESCRIPTION
This PR renames the distributed Matrix `non_local_matrix` to `ghost_matrix` . It deprecates the previous `non_local` names.