### PR TITLE
Improve class header documentation

### DIFF
--- a/common/cuda_hip/factorization/elimination_forest_kernels.cpp
+++ b/common/cuda_hip/factorization/elimination_forest_kernels.cpp
@@ -204,7 +204,7 @@ void compute_skeleton_tree(std::shared_ptr<const DefaultExecutor> exec,
     // This is a minimum spanning tree algorithm implementation based on
     // A. Fallin, A. Gonzalez, J. Seo, and M. Burtscher,
     // "A High-Performance MST Implementation for GPUs,”
-    // doi: 10.1145/3581784.3607093
+    // <https://doi.org/10.1145/3581784.3607093>
     // we don't filter heavy edges since the heaviest edges are necessary to
     // reach the last node and we don't need to sort since the COO format
     // already sorts by row index.

--- a/core/components/range_minimum_query.hpp
+++ b/core/components/range_minimum_query.hpp
@@ -102,7 +102,7 @@ struct cartesian_tree {
         // triangle simultaneously
         // This is Algorithm 1 from J. Fischer and V. Heun, "Space-Efficient
         // Preprocessing Schemes for Range Minimum Queries on Static Arrays,"
-        // doi: 10.1137/090779759.
+        // <https://doi.org/10.1137/090779759>.
         int rightmost[num_nodes + 1]{};
         rightmost[0] = std::numeric_limits<int>::lowest();
         int number = 0;
@@ -526,7 +526,7 @@ private:
  * This is a non-owning view.
  *
  * J. Fischer and V. Heun, "Space-Efficient Preprocessing Schemes for Range
- * Minimum Queries on Static Arrays," doi: 10.1137/090779759.
+ * Minimum Queries on Static Arrays," <https://doi.org/10.1137/090779759>.
  */
 template <int block_size, typename IndexType>
 class device_range_minimum_query {

--- a/core/solver/minres.cpp
+++ b/core/solver/minres.cpp
@@ -95,8 +95,9 @@ typename Minres<ValueType>::parameters_type Minres<ValueType>::parse(
 
 
 /**
- * This Minres implementation is based on Anne Grennbaum's 'Iterative Methods
- * for Solving Linear Systems' (DOI: 10.1137/1.9781611970937) Ch. 2 and Ch. 8.
+ * This Minres implementation is based on Anne Greenbaum's *Iterative Methods
+ * for Solving Linear Systems* (<https://doi.org/10.1137/1.9781611970937>),
+ * Ch. 2 and Ch. 8.
  * Most variable names are taken from that reference, with the exception that
  * the vector `w` and `w_tilde` from the reference are called `z` and `z_tilde`.
  * The variable declaration have a comment to specify the name used in the

--- a/include/ginkgo/core/base/batch_multi_vector.hpp
+++ b/include/ginkgo/core/base/batch_multi_vector.hpp
@@ -27,18 +27,26 @@ namespace batch {
 
 /**
  * MultiVector stores multiple vectors in a batched fashion and is useful
- * for batched operations. For example, if you want to store two batch items
- * with multi-vectors of size (3 x 2) given below:
+ * for batched operations. For example, two batch items, each a 3 x 2
+ * multi-vector, would be laid out as:
  *
- * [1 2 ; 3 4
- *  1 2 ; 3 4
- *  1 2 ; 3 4]
+ * ```
+ * batch item 0      batch item 1
+ *   1 2               3 4
+ *   1 2               3 4
+ *   1 2               3 4
+ * ```
  *
- * In memory, they would be stored as a single array:
- * [1 2 1 2 1 2 3 4 3 4 3 4].
+ * In memory, both items are stored consecutively as a single
+ * row-major array:
  *
- * Access functions @at can help access individual
- * item if necessary.
+ * ```
+ * [ 1 2  1 2  1 2 | 3 4  3 4  3 4 ]
+ *   item 0          item 1
+ * ```
+ *
+ * The accessor `at()` can be used to reach an individual entry of a
+ * specific batch item.
  *
  * The values of the different batch items are stored consecutively and in each
  * batch item, the multi-vectors are stored in a row-major fashion.

--- a/include/ginkgo/core/base/batch_multi_vector.hpp
+++ b/include/ginkgo/core/base/batch_multi_vector.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -27,18 +27,26 @@ namespace batch {
 
 /**
  * MultiVector stores multiple vectors in a batched fashion and is useful
- * for batched operations. For example, if you want to store two batch items
- * with multi-vectors of size (3 x 2) given below:
+ * for batched operations. For example, two batch items, each a 3 x 2
+ * multi-vector, would be laid out as:
  *
- * [1 2 ; 3 4
- *  1 2 ; 3 4
- *  1 2 ; 3 4]
+ * ```
+ * batch item 0      batch item 1
+ *   1 2               3 4
+ *   1 2               3 4
+ *   1 2               3 4
+ * ```
  *
- * In memory, they would be stored as a single array:
- * [1 2 1 2 1 2 3 4 3 4 3 4].
+ * In memory, both items are stored consecutively as a single
+ * row-major array:
  *
- * Access functions @at can help access individual
- * item if necessary.
+ * ```
+ * [ 1 2  1 2  1 2 | 3 4  3 4  3 4 ]
+ *   item 0          item 1
+ * ```
+ *
+ * The accessor `at()` can be used to reach an individual entry of a
+ * specific batch item.
  *
  * The values of the different batch items are stored consecutively and in each
  * batch item, the multi-vectors are stored in a row-major fashion.

--- a/include/ginkgo/core/base/lin_op.hpp
+++ b/include/ginkgo/core/base/lin_op.hpp
@@ -107,7 +107,7 @@ class Diagonal;
  * product, and `L->apply(a, b)` computes \f$b = L \cdot a\f$.
  * `x->add_scaled(one, b)` is the `axpy` vector update \f$x:=x+b\f$.
  *
- * The interesting part of this example is the apply() routine at line 4 of the
+ * The interesting part of this example is the apply() routine at line 5 of the
  * function body. Since this routine is part of the LinOp base class, the
  * fixed-point iteration routine can calculate a fixed point not only for
  * matrices, but for any type of linear operator.

--- a/include/ginkgo/core/base/lin_op.hpp
+++ b/include/ginkgo/core/base/lin_op.hpp
@@ -375,8 +375,8 @@ public:
  * changing any of its elements representing the operation, \f$B = A^{T}\f$.
  *
  * The conjugate transpose returns the conjugate of each of the elements and
- * additionally transposes the linear operator representing the operation, $B
- * = A^{H}$.
+ * additionally transposes the linear operator representing the operation, \f$B
+ * = A^{H}\f$.
  *
  * Example: Transposing a Csr matrix:
  * ------------------------------------
@@ -450,8 +450,8 @@ public:
      * In the resulting LinOp, the entry at location `(i,j)` contains the input
      * value `(perm[i],perm[j])`.
      *
-     * From the linear algebra perspective, with $P_{ij} = \delta_{i
-     * \pi(i)}$, this represents the operation \f$P A P^T\f$.
+     * From the linear algebra perspective, with \f$P_{ij} = \delta_{i
+     * \pi(i)}\f$, this represents the operation \f$P A P^T\f$.
      *
      * @param permutation_indices  the array of indices containing the
      *                             permutation order.
@@ -471,8 +471,8 @@ public:
      * In the resulting LinOp, the entry at location `(perm[i],perm[j])`
      * contains the input value `(i,j)`.
      *
-     * From the linear algebra perspective, with $P_{ij} = \delta_{i
-     * \pi(i)}$, this represents the operation \f$P^{-1} A P^{-T}\f$.
+     * From the linear algebra perspective, with \f$P_{ij} = \delta_{i
+     * \pi(i)}\f$, this represents the operation \f$P^{-1} A P^{-T}\f$.
      *
      * @param permutation_indices  the array of indices containing the
      *                             permutation order.
@@ -491,8 +491,8 @@ public:
      * object.
      * In the resulting LinOp, the row `i` contains the input row `perm[i]`.
      *
-     * From the linear algebra perspective, with $P_{ij} = \delta_{i
-     * \pi(i)}$, this represents the operation \f$P A\f$.
+     * From the linear algebra perspective, with \f$P_{ij} = \delta_{i
+     * \pi(i)}\f$, this represents the operation \f$P A\f$.
      *
      * @param permutation_indices  the array of indices containing the
      *                             permutation order.
@@ -508,8 +508,8 @@ public:
      * In the resulting LinOp, the column `i` contains the input column
      * `perm[i]`.
      *
-     * From the linear algebra perspective, with $P_{ij} = \delta_{i
-     * \pi(i)}$, this represents the operation \f$A P^T\f$.
+     * From the linear algebra perspective, with \f$P_{ij} = \delta_{i
+     * \pi(i)}\f$, this represents the operation \f$A P^T\f$.
      *
      * @param permutation_indices  the array of indices containing the
      *                             permutation order `perm`.
@@ -524,8 +524,8 @@ public:
      * object.
      * In the resulting LinOp, the row `perm[i]` contains the input row `i`.
      *
-     * From the linear algebra perspective, with $P_{ij} = \delta_{i
-     * \pi(i)}$, this represents the operation \f$P^{-1} A\f$.
+     * From the linear algebra perspective, with \f$P_{ij} = \delta_{i
+     * \pi(i)}\f$, this represents the operation \f$P^{-1} A\f$.
      *
      * @param permutation_indices  the array of indices containing the
      *                             permutation order `perm`.
@@ -541,8 +541,8 @@ public:
      * In the resulting LinOp, the column `perm[i]` contains the input column
      * `i`.
      *
-     * From the linear algebra perspective, with $P_{ij} = \delta_{i
-     * \pi(i)}$, this represents the operation \f$A P^{-T}\f$.
+     * From the linear algebra perspective, with \f$P_{ij} = \delta_{i
+     * \pi(i)}\f$, this represents the operation \f$A P^{-T}\f$.
      *
      * @param permutation_indices  the array of indices containing the
      *                             permutation order `perm`.

--- a/include/ginkgo/core/base/lin_op.hpp
+++ b/include/ginkgo/core/base/lin_op.hpp
@@ -69,22 +69,22 @@ class Diagonal;
  * and preconditioners is that the most common operation performed on all of
  * them can be expressed as an application of a linear operator to a vector:
  *
- * +   the sparse matrix-vector product with a matrix $A$ is a linear
- *     operator application $y = Ax$;
+ * +   the sparse matrix-vector product with a matrix \f$A\f$ is a linear
+ *     operator application \f$y = Ax\f$;
  * +   the application of a preconditioner is a linear operator application
- *     $y = M^{-1}x$, where $M$ is an approximation of the original
- *     system matrix $A$ (thus a preconditioner represents an "approximate
- *     inverse" operator $M^{-1}$).
- * +   the system solve $Ax = b$ can be viewed as linear operator
+ *     \f$y = M^{-1}x\f$, where \f$M\f$ is an approximation of the original
+ *     system matrix \f$A\f$ (thus a preconditioner represents an "approximate
+ *     inverse" operator \f$M^{-1}\f$).
+ * +   the system solve \f$Ax = b\f$ can be viewed as linear operator
  *     application
- *     $x = A^{-1}b$ (it goes without saying that the implementation of
+ *     \f$x = A^{-1}b\f$ (it goes without saying that the implementation of
  *     linear system solves does not follow this conceptual idea), so a linear
  *     system solver can be viewed as a representation of the operator
- *     $A^{-1}$.
+ *     \f$A^{-1}\f$.
  *
  * Finally, direct manipulation of LinOp objects is rarely required in
  * simple scenarios. As an illustrative example, one could construct a
- * fixed-point iteration routine $x_{k+1} = Lx_k + b$ as follows:
+ * fixed-point iteration routine \f$x_{k+1} = Lx_k + b\f$ as follows:
  *
  * ```cpp
  * std::unique_ptr<matrix::Dense<>> calculate_fixed_point(
@@ -103,9 +103,9 @@ class Diagonal;
  * }
  * ```
  *
- * Here, if $L$ is a matrix, LinOp::apply() refers to the matrix vector
- * product, and `L->apply(a, b)` computes $b = L \cdot a$.
- * `x->add_scaled(one, b)` is the `axpy` vector update $x:=x+b$.
+ * Here, if \f$L\f$ is a matrix, LinOp::apply() refers to the matrix vector
+ * product, and `L->apply(a, b)` computes \f$b = L \cdot a\f$.
+ * `x->add_scaled(one, b)` is the `axpy` vector update \f$x:=x+b\f$.
  *
  * The interesting part of this example is the apply() routine at line 4 of the
  * function body. Since this routine is part of the LinOp base class, the
@@ -291,34 +291,34 @@ private:
  * linear operator into another.
  *
  * In Ginkgo, every linear solver is viewed as a mapping. For example,
- * given an s.p.d linear system $Ax = b$, the solution $x = A^{-1}b$
+ * given an s.p.d linear system \f$Ax = b\f$, the solution \f$x = A^{-1}b\f$
  * can be computed using the CG method. This algorithm can be represented in
  * terms of linear operators and mappings between them as follows:
  *
  * -   A Cg::Factory is a higher order mapping which, given an input operator
- *     $A$, returns a new linear operator $A^{-1}$ stored in "CG
+ *     \f$A\f$, returns a new linear operator \f$A^{-1}\f$ stored in "CG
  *     format"
- * -   Storing the operator $A^{-1}$ in "CG format" means that the data
+ * -   Storing the operator \f$A^{-1}\f$ in "CG format" means that the data
  *     structure used to store the operator is just a simple pointer to the
- *     original matrix $A$. The application $x = A^{-1}b$ of such an
+ *     original matrix \f$A\f$. The application \f$x = A^{-1}b\f$ of such an
  *     operator can then be implemented by solving the linear system
- *     $Ax = b$ using the CG method. This is achieved in code by having a
+ *     \f$Ax = b\f$ using the CG method. This is achieved in code by having a
  *     special class for each of those "formats" (e.g. the "Cg" class defines
  *     such a format for the CG solver).
  *
  * Another example of a LinOpFactory is a preconditioner. A preconditioner for
- * a linear operator $A$ is a linear operator $M^{-1}$, which
- * approximates $A^{-1}$. In addition, it is stored in a way such that
- * both the data of $M^{-1}$ is cheap to compute from $A$, and the
- * operation $x = M^{-1}b$ can be computed quickly. These operators are
+ * a linear operator \f$A\f$ is a linear operator \f$M^{-1}\f$, which
+ * approximates \f$A^{-1}\f$. In addition, it is stored in a way such that
+ * both the data of \f$M^{-1}\f$ is cheap to compute from \f$A\f$, and the
+ * operation \f$x = M^{-1}b\f$ can be computed quickly. These operators are
  * useful to accelerate the convergence of  Krylov solvers.
  * Thus, a preconditioner also fits into the LinOpFactory framework:
  *
- * -   The factory maps a linear operator $A$ into a preconditioner
- *     $M^{-1}$ which is stored in suitable format (e.g. as a product of
+ * -   The factory maps a linear operator \f$A\f$ into a preconditioner
+ *     \f$M^{-1}\f$ which is stored in suitable format (e.g. as a product of
  *     two factors in case of ILU preconditioners).
  * -   The resulting linear operator implements the application operation
- *     $x = M^{-1}b$ depending on the format the preconditioner is stored
+ *     \f$x = M^{-1}b\f$ depending on the format the preconditioner is stored
  *     in (e.g. as two triangular solves in case of ILU)
  *
  * Example: using CG in Ginkgo
@@ -372,7 +372,7 @@ public:
  * conjugate transpose.
  *
  * The normal transpose returns the transpose of the linear operator without
- * changing any of its elements representing the operation, $B = A^{T}$.
+ * changing any of its elements representing the operation, \f$B = A^{T}\f$.
  *
  * The conjugate transpose returns the conjugate of each of the elements and
  * additionally transposes the linear operator representing the operation, $B
@@ -451,7 +451,7 @@ public:
      * value `(perm[i],perm[j])`.
      *
      * From the linear algebra perspective, with $P_{ij} = \delta_{i
-     * \pi(i)}$, this represents the operation $P A P^T$.
+     * \pi(i)}$, this represents the operation \f$P A P^T\f$.
      *
      * @param permutation_indices  the array of indices containing the
      *                             permutation order.
@@ -472,7 +472,7 @@ public:
      * contains the input value `(i,j)`.
      *
      * From the linear algebra perspective, with $P_{ij} = \delta_{i
-     * \pi(i)}$, this represents the operation $P^{-1} A P^{-T}$.
+     * \pi(i)}$, this represents the operation \f$P^{-1} A P^{-T}\f$.
      *
      * @param permutation_indices  the array of indices containing the
      *                             permutation order.
@@ -492,7 +492,7 @@ public:
      * In the resulting LinOp, the row `i` contains the input row `perm[i]`.
      *
      * From the linear algebra perspective, with $P_{ij} = \delta_{i
-     * \pi(i)}$, this represents the operation $P A$.
+     * \pi(i)}$, this represents the operation \f$P A\f$.
      *
      * @param permutation_indices  the array of indices containing the
      *                             permutation order.
@@ -509,7 +509,7 @@ public:
      * `perm[i]`.
      *
      * From the linear algebra perspective, with $P_{ij} = \delta_{i
-     * \pi(i)}$, this represents the operation $A P^T$.
+     * \pi(i)}$, this represents the operation \f$A P^T\f$.
      *
      * @param permutation_indices  the array of indices containing the
      *                             permutation order `perm`.
@@ -525,7 +525,7 @@ public:
      * In the resulting LinOp, the row `perm[i]` contains the input row `i`.
      *
      * From the linear algebra perspective, with $P_{ij} = \delta_{i
-     * \pi(i)}$, this represents the operation $P^{-1} A$.
+     * \pi(i)}$, this represents the operation \f$P^{-1} A\f$.
      *
      * @param permutation_indices  the array of indices containing the
      *                             permutation order `perm`.
@@ -542,7 +542,7 @@ public:
      * `i`.
      *
      * From the linear algebra perspective, with $P_{ij} = \delta_{i
-     * \pi(i)}$, this represents the operation $A P^{-T}$.
+     * \pi(i)}$, this represents the operation \f$A P^{-T}\f$.
      *
      * @param permutation_indices  the array of indices containing the
      *                             permutation order `perm`.

--- a/include/ginkgo/core/distributed/index_map.hpp
+++ b/include/ginkgo/core/distributed/index_map.hpp
@@ -30,13 +30,13 @@ enum class index_space {
 /**
  * \brief This class defines mappings between global and local indices.
  *
- * Given an index space $I = [0, \dots, N)$ that is partitioned into $P$
- * disjoint subsets $I_k, k = 1, \dots, P$, this class defines for each
- * subset an extended global index set $\hat{I}_k \supset I_K$. The extended
- * index set contains the global indices owned by part $k$, as well as
- * remote indices $R_k = \hat{I}_k \setminus I_k$, which are also accessed by
- * part $k$, but owned by parts $l \neq k$.
- * At the core, this class provides mappings from the global index space $I$
+ * Given an index space \f$I = [0, \dots, N)\f$ that is partitioned into \f$P\f$
+ * disjoint subsets \f$I_k, k = 1, \dots, P\f$, this class defines for each
+ * subset an extended global index set \f$\hat{I}_k \supset I_K\f$. The extended
+ * index set contains the global indices owned by part \f$k\f$, as well as
+ * remote indices \f$R_k = \hat{I}_k \setminus I_k\f$, which are also accessed by
+ * part \f$k\f$, but owned by parts \f$l \neq k\f$.
+ * At the core, this class provides mappings from the global index space \f$I\f$
  * into different local index spaces. The combined local index space
  * (index_space::combined) is then defined as
  * $[0, \dots, |\hat{I}_k|)$. Additionally, the combined index space can be
@@ -45,19 +45,19 @@ enum class index_space {
  * $[0, \dots, |I_k|)$, and the non-locally owned as $[0, \dots, |R_k|)$.
  * With these index sets, the following mappings are defined:
  *
- * - $c_k : \hat{I}_k \mapsto [0, \dots, |\hat{I}_k|)$ which maps global indices
+ * - \f$c_k : \hat{I}_k \mapsto [0, \dots, |\hat{I}_k|)\f$ which maps global indices
  *   into the combined/full local index space (denoted as
  *   index_space::combined),
- * - $l_k: I_k \mapsto [0, \dots, |I_k|)$ which maps global indices into the
+ * - \f$l_k: I_k \mapsto [0, \dots, |I_k|)\f$ which maps global indices into the
  *   locally owned index space (denoted as index_space::local),
- * - $r_k: R_k \mapsto [0, \dots, |R_k|)$ which maps global indices into the
+ * - \f$r_k: R_k \mapsto [0, \dots, |R_k|)\f$ which maps global indices into the
  *   non-locally owned index space (denoted as index_space::non_local).
  *
  * The required map can be selected by passing the appropriate type of an
  * index_space.
  *
- * The index map for $I_k$ has no knowledge about any other index maps for
- * $I_l, l \neq k$. In particular, any global index passed to the `map_to_local`
+ * The index map for \f$I_k\f$ has no knowledge about any other index maps for
+ * \f$I_l, l \neq k\f$. In particular, any global index passed to the `map_to_local`
  * map that is not part of the specified index space, will be mapped to an
  * invalid_index.
  *
@@ -135,25 +135,25 @@ public:
     index_map(std::shared_ptr<const Executor> exec);
 
     /**
-     * \brief get the index set $R_k$ for this rank.
+     * \brief get the index set \f$R_k\f$ for this rank.
      *
      * The indices are ordered by their owning rank and global index.
      */
     const segmented_array<GlobalIndexType>& get_remote_global_idxs() const;
 
     /**
-     * \brief get the index set $R_k$, but mapped to their respective local
+     * \brief get the index set \f$R_k\f$, but mapped to their respective local
      *        index space.
      *
      * The indices are grouped by their owning rank and sorted according to
      * their global index within each group.
      *
-     * The set $R_k = \hat{I}_k \setminus I_k$ can also be written as the union
-     * of the intersection of $\hat{I}_k$ with other disjoint sets
-     * $I_l, l \neq k$, i.e.
+     * The set \f$R_k = \hat{I}_k \setminus I_k\f$ can also be written as the union
+     * of the intersection of \f$\hat{I}_k\f$ with other disjoint sets
+     * \f$I_l, l \neq k\f$, i.e.
      * $R_k = \bigcup_{j \neq k} \hat{I}_k \cap I_j = \bigcup_{j \neq k}
-     * R_{k,j}$. The set $R_{k,j}$ can then be mapped by $l_j$ to get the local
-     * indices wrt. part $j$. The indices here are mapped by $l_j$.
+     * R_{k,j}$. The set \f$R_{k,j}\f$ can then be mapped by \f$l_j\f$ to get the local
+     * indices wrt. part \f$j\f$. The indices here are mapped by \f$l_j\f$.
      */
     const segmented_array<LocalIndexType>& get_remote_local_idxs() const;
 

--- a/include/ginkgo/core/distributed/index_map.hpp
+++ b/include/ginkgo/core/distributed/index_map.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -34,19 +34,19 @@ enum class index_space {
  * disjoint subsets \f$I_k, k = 1, \dots, P\f$, this class defines for each
  * subset an extended global index set \f$\hat{I}_k \supset I_K\f$. The extended
  * index set contains the global indices owned by part \f$k\f$, as well as
- * remote indices \f$R_k = \hat{I}_k \setminus I_k\f$, which are also accessed by
- * part \f$k\f$, but owned by parts \f$l \neq k\f$.
- * At the core, this class provides mappings from the global index space \f$I\f$
- * into different local index spaces. The combined local index space
- * (index_space::combined) is then defined as
+ * remote indices \f$R_k = \hat{I}_k \setminus I_k\f$, which are also accessed
+ * by part \f$k\f$, but owned by parts \f$l \neq k\f$. At the core, this class
+ * provides mappings from the global index space \f$I\f$ into different local
+ * index spaces. The combined local index space (index_space::combined) is then
+ * defined as
  * $[0, \dots, |\hat{I}_k|)$. Additionally, the combined index space can be
  * separated into locally owned (index_space::local) and non-locally owned
  * (index_space::non_local). The locally owned indices are defined as
  * $[0, \dots, |I_k|)$, and the non-locally owned as $[0, \dots, |R_k|)$.
  * With these index sets, the following mappings are defined:
  *
- * - \f$c_k : \hat{I}_k \mapsto [0, \dots, |\hat{I}_k|)\f$ which maps global indices
- *   into the combined/full local index space (denoted as
+ * - \f$c_k : \hat{I}_k \mapsto [0, \dots, |\hat{I}_k|)\f$ which maps global
+ * indices into the combined/full local index space (denoted as
  *   index_space::combined),
  * - \f$l_k: I_k \mapsto [0, \dots, |I_k|)\f$ which maps global indices into the
  *   locally owned index space (denoted as index_space::local),
@@ -57,9 +57,9 @@ enum class index_space {
  * index_space.
  *
  * The index map for \f$I_k\f$ has no knowledge about any other index maps for
- * \f$I_l, l \neq k\f$. In particular, any global index passed to the `map_to_local`
- * map that is not part of the specified index space, will be mapped to an
- * invalid_index.
+ * \f$I_l, l \neq k\f$. In particular, any global index passed to the
+ * `map_to_local` map that is not part of the specified index space, will be
+ * mapped to an invalid_index.
  *
  * \tparam LocalIndexType  type for local indices
  * \tparam GlobalIndexType  type for global indices
@@ -148,12 +148,13 @@ public:
      * The indices are grouped by their owning rank and sorted according to
      * their global index within each group.
      *
-     * The set \f$R_k = \hat{I}_k \setminus I_k\f$ can also be written as the union
-     * of the intersection of \f$\hat{I}_k\f$ with other disjoint sets
+     * The set \f$R_k = \hat{I}_k \setminus I_k\f$ can also be written as the
+     * union of the intersection of \f$\hat{I}_k\f$ with other disjoint sets
      * \f$I_l, l \neq k\f$, i.e.
      * $R_k = \bigcup_{j \neq k} \hat{I}_k \cap I_j = \bigcup_{j \neq k}
-     * R_{k,j}$. The set \f$R_{k,j}\f$ can then be mapped by \f$l_j\f$ to get the local
-     * indices wrt. part \f$j\f$. The indices here are mapped by \f$l_j\f$.
+     * R_{k,j}$. The set \f$R_{k,j}\f$ can then be mapped by \f$l_j\f$ to get
+     * the local indices wrt. part \f$j\f$. The indices here are mapped by
+     * \f$l_j\f$.
      */
     const segmented_array<LocalIndexType>& get_remote_local_idxs() const;
 

--- a/include/ginkgo/core/distributed/index_map.hpp
+++ b/include/ginkgo/core/distributed/index_map.hpp
@@ -30,6 +30,8 @@ enum class index_space {
 /**
  * \brief This class defines mappings between global and local indices.
  *
+ * This class splits up the global index space and differentiates between
+ * locally owned and non-locally owned index spaces.
  * Given an index space \f$I = [0, \dots, N)\f$ that is partitioned into \f$P\f$
  * disjoint subsets \f$I_k, k = 1, \dots, P\f$, this class defines for each
  * subset an extended global index set \f$\hat{I}_k \supset I_K\f$. The extended

--- a/include/ginkgo/core/distributed/index_map.hpp
+++ b/include/ginkgo/core/distributed/index_map.hpp
@@ -39,11 +39,11 @@ enum class index_space {
  * provides mappings from the global index space \f$I\f$ into different local
  * index spaces. The combined local index space (index_space::combined) is then
  * defined as
- * $[0, \dots, |\hat{I}_k|)$. Additionally, the combined index space can be
+ * \f$[0, \dots, |\hat{I}_k|)\f$. Additionally, the combined index space can be
  * separated into locally owned (index_space::local) and non-locally owned
  * (index_space::non_local). The locally owned indices are defined as
- * $[0, \dots, |I_k|)$, and the non-locally owned as $[0, \dots, |R_k|)$.
- * With these index sets, the following mappings are defined:
+ * \f$[0, \dots, |I_k|)\f$, and the non-locally owned as \f$[0, \dots,
+ * |R_k|)\f$. With these index sets, the following mappings are defined:
  *
  * - \f$c_k : \hat{I}_k \mapsto [0, \dots, |\hat{I}_k|)\f$ which maps global
  * indices into the combined/full local index space (denoted as
@@ -151,8 +151,8 @@ public:
      * The set \f$R_k = \hat{I}_k \setminus I_k\f$ can also be written as the
      * union of the intersection of \f$\hat{I}_k\f$ with other disjoint sets
      * \f$I_l, l \neq k\f$, i.e.
-     * $R_k = \bigcup_{j \neq k} \hat{I}_k \cap I_j = \bigcup_{j \neq k}
-     * R_{k,j}$. The set \f$R_{k,j}\f$ can then be mapped by \f$l_j\f$ to get
+     * \f$R_k = \bigcup_{j \neq k} \hat{I}_k \cap I_j = \bigcup_{j \neq k}
+     * R_{k,j}\f$. The set \f$R_{k,j}\f$ can then be mapped by \f$l_j\f$ to get
      * the local indices wrt. part \f$j\f$. The indices here are mapped by
      * \f$l_j\f$.
      */

--- a/include/ginkgo/core/distributed/matrix.hpp
+++ b/include/ginkgo/core/distributed/matrix.hpp
@@ -538,9 +538,9 @@ public:
      * Creates an empty distributed matrix with specified type
      * for local matrices.
      *
-     * @note This is mainly a convenience wrapper for
-     *       Matrix(std::shared_ptr<const Executor>, mpi::communicator, const
-     *       LinOp*)
+     * @note This is a convenience wrapper around the `create` overload
+     *       that takes an already-constructed `LinOp` template; the
+     *       `matrix_template` argument here is materialised internally.
      *
      * @tparam MatrixType  A type that has a `create<ValueType,
      *                     IndexType>(exec)` function to create a smart pointer
@@ -570,9 +570,10 @@ public:
      * Creates an empty distributed matrix with specified types for the
      * diagonal matrix and the off-diagonal matrix.
      *
-     * @note This is mainly a convenience wrapper for
-     *       Matrix(std::shared_ptr<const Executor>, mpi::communicator,
-     *       const LinOp*, const LinOp*)
+     * @note This is a convenience wrapper around the `create` overload
+     *       that takes already-constructed `LinOp` templates for the
+     *       diagonal and off-diagonal blocks; the two template
+     *       arguments here are materialised internally.
      *
      * @tparam DiagMatrixType  A type that has a `create<ValueType,
      *                         IndexType>(exec)` function to create a smart

--- a/include/ginkgo/core/distributed/matrix.hpp
+++ b/include/ginkgo/core/distributed/matrix.hpp
@@ -540,7 +540,7 @@ public:
      *
      * @note This is a convenience wrapper around the `create` overload
      *       that takes an already-constructed `LinOp` template; the
-     *       `matrix_template` argument here is materialised internally.
+     *       `matrix_template` argument here is materialized internally.
      *
      * @tparam MatrixType  A type that has a `create<ValueType,
      *                     IndexType>(exec)` function to create a smart pointer
@@ -573,7 +573,7 @@ public:
      * @note This is a convenience wrapper around the `create` overload
      *       that takes already-constructed `LinOp` templates for the
      *       diagonal and off-diagonal blocks; the two template
-     *       arguments here are materialised internally.
+     *       arguments here are materialized internally.
      *
      * @tparam DiagMatrixType  A type that has a `create<ValueType,
      *                         IndexType>(exec)` function to create a smart

--- a/include/ginkgo/core/distributed/matrix.hpp
+++ b/include/ginkgo/core/distributed/matrix.hpp
@@ -519,9 +519,9 @@ public:
      * Creates an empty distributed matrix with specified type
      * for local matrices.
      *
-     * @note This is mainly a convenience wrapper for
-     *       Matrix(std::shared_ptr<const Executor>, mpi::communicator, const
-     *       LinOp*)
+     * @note This is a convenience wrapper around the `create` overload
+     *       that takes an already-constructed `LinOp` template; the
+     *       `matrix_template` argument here is materialised internally.
      *
      * @tparam MatrixType  A type that has a `create<ValueType,
      *                     IndexType>(exec)` function to create a smart pointer
@@ -551,9 +551,10 @@ public:
      * Creates an empty distributed matrix with specified types for the
      * diagonal matrix and the off-diagonal matrix.
      *
-     * @note This is mainly a convenience wrapper for
-     *       Matrix(std::shared_ptr<const Executor>, mpi::communicator,
-     *       const LinOp*, const LinOp*)
+     * @note This is a convenience wrapper around the `create` overload
+     *       that takes already-constructed `LinOp` templates for the
+     *       diagonal and off-diagonal blocks; the two template
+     *       arguments here are materialised internally.
      *
      * @tparam DiagMatrixType  A type that has a `create<ValueType,
      *                         IndexType>(exec)` function to create a smart

--- a/include/ginkgo/core/distributed/vector.hpp
+++ b/include/ginkgo/core/distributed/vector.hpp
@@ -41,8 +41,8 @@ class Partition;
  * vectors in a dense storage format.
  *
  * The (multi-)vector is distributed by row, which is described by a
- * Partition. The local vectors are stored using the Dense format. The
- * vector should be filled using the read_distributed method, e.g.
+ * Partition. The local vectors are stored using the matrix::Dense format.
+ * The vector should be filled using the read_distributed method, e.g.
  * ```
  * auto part = Partition<...>::build_from_mapping(...);
  * auto vector = Vector<...>::create(exec, comm);

--- a/include/ginkgo/core/distributed/vector.hpp
+++ b/include/ginkgo/core/distributed/vector.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 

--- a/include/ginkgo/core/distributed/vector.hpp
+++ b/include/ginkgo/core/distributed/vector.hpp
@@ -346,7 +346,7 @@ public:
                           array<char>& tmp) const;
 
     /**
-     * Computes the square of the column-wise Euclidean ($L^2$) norm of this
+     * Computes the square of the column-wise Euclidean (\f$L^2\f$) norm of this
      * (multi-)vector using a global reduction.
      *
      * @param result  a Dense row vector, used to store the norm
@@ -356,7 +356,7 @@ public:
     void compute_squared_norm2(ptr_param<LinOp> result) const;
 
     /**
-     * Computes the square of the column-wise Euclidean ($L^2$) norm of this
+     * Computes the square of the column-wise Euclidean (\f$L^2\f$) norm of this
      * (multi-)vector using a global reduction.
      *
      * @param result  a Dense row vector, used to store the norm

--- a/include/ginkgo/core/distributed/vector.hpp
+++ b/include/ginkgo/core/distributed/vector.hpp
@@ -40,8 +40,8 @@ class Partition;
  * Vector is a format which explicitly stores (multiple) distributed column
  * vectors in a dense storage format.
  *
- * The (multi-)vector is distributed by row, which is described by a @see
- * Partition. The local vectors are stored using the @see Dense format. The
+ * The (multi-)vector is distributed by row, which is described by a
+ * Partition. The local vectors are stored using the Dense format. The
  * vector should be filled using the read_distributed method, e.g.
  * ```
  * auto part = Partition<...>::build_from_mapping(...);
@@ -162,7 +162,7 @@ public:
      * Reads a vector from the matrix_data structure and a global row
      * partition.
      *
-     * See @read_distributed
+     * See read_distributed().
      *
      * @note For efficiency it is advised to use the device_matrix_data
      * overload.

--- a/include/ginkgo/core/distributed/vector.hpp
+++ b/include/ginkgo/core/distributed/vector.hpp
@@ -345,7 +345,7 @@ public:
                           array<char>& tmp) const;
 
     /**
-     * Computes the square of the column-wise Euclidean ($L^2$) norm of this
+     * Computes the square of the column-wise Euclidean (\f$L^2\f$) norm of this
      * (multi-)vector using a global reduction.
      *
      * @param result  a Dense row vector, used to store the norm
@@ -355,7 +355,7 @@ public:
     void compute_squared_norm2(ptr_param<LinOp> result) const;
 
     /**
-     * Computes the square of the column-wise Euclidean ($L^2$) norm of this
+     * Computes the square of the column-wise Euclidean (\f$L^2\f$) norm of this
      * (multi-)vector using a global reduction.
      *
      * @param result  a Dense row vector, used to store the norm

--- a/include/ginkgo/core/distributed/vector.hpp
+++ b/include/ginkgo/core/distributed/vector.hpp
@@ -40,8 +40,8 @@ class Partition;
  * Vector is a format which explicitly stores (multiple) distributed column
  * vectors in a dense storage format.
  *
- * The (multi-)vector is distributed by row, which is described by a @see
- * Partition. The local vectors are stored using the @see Dense format. The
+ * The (multi-)vector is distributed by row, which is described by a
+ * Partition. The local vectors are stored using the Dense format. The
  * vector should be filled using the read_distributed method, e.g.
  * ```
  * auto part = Partition<...>::build_from_mapping(...);
@@ -161,7 +161,7 @@ public:
      * Reads a vector from the matrix_data structure and a global row
      * partition.
      *
-     * See @read_distributed
+     * See read_distributed().
      *
      * @note For efficiency it is advised to use the device_matrix_data
      * overload.

--- a/include/ginkgo/core/factorization/ic.hpp
+++ b/include/ginkgo/core/factorization/ic.hpp
@@ -29,10 +29,10 @@ namespace factorization {
 /**
  * Represents an incomplete Cholesky factorization (IC(0)) of a sparse matrix.
  *
- * More specifically, it consists of a lower triangular factor $L$ and
- * its conjugate transpose $L^H$ with sparsity pattern
- * $\mathcal S(L + L^H)$ = $\mathcal S(A)$
- * fulfilling $LL^H = A$ at every non-zero location of $A$.
+ * More specifically, it consists of a lower triangular factor \f$L\f$ and
+ * its conjugate transpose \f$L^H\f$ with sparsity pattern
+ * \f$\mathcal S(L + L^H)\f$ = \f$\mathcal S(A)\f$
+ * fulfilling \f$LL^H = A\f$ at every non-zero location of \f$A\f$.
  *
  * @tparam ValueType  Type of the values of all matrices used in this class
  * @tparam IndexType  Type of the indices of all matrices used in this class

--- a/include/ginkgo/core/factorization/ic.hpp
+++ b/include/ginkgo/core/factorization/ic.hpp
@@ -31,7 +31,7 @@ namespace factorization {
  *
  * More specifically, it consists of a lower triangular factor \f$L\f$ and
  * its conjugate transpose \f$L^H\f$ with sparsity pattern
- * \f$\mathcal S(L + L^H)\f$ = \f$\mathcal S(A)\f$
+ * \f$\mathcal S(L + L^H) = \mathcal S(A)\f$
  * fulfilling \f$LL^H = A\f$ at every non-zero location of \f$A\f$.
  *
  * @tparam ValueType  Type of the values of all matrices used in this class

--- a/include/ginkgo/core/factorization/ic.hpp
+++ b/include/ginkgo/core/factorization/ic.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 

--- a/include/ginkgo/core/factorization/ilu.hpp
+++ b/include/ginkgo/core/factorization/ilu.hpp
@@ -29,10 +29,10 @@ namespace factorization {
 /**
  * Represents an incomplete LU factorization -- ILU(0) -- of a sparse matrix.
  *
- * More specifically, it consists of a lower unitriangular factor $L$ and
- * an upper triangular factor $U$ with sparsity pattern
- * $\mathcal S(L + U)$ = $\mathcal S(A)$
- * fulfilling $LU = A$ at every non-zero location of $A$.
+ * More specifically, it consists of a lower unitriangular factor \f$L\f$ and
+ * an upper triangular factor \f$U\f$ with sparsity pattern
+ * \f$\mathcal S(L + U)\f$ = \f$\mathcal S(A)\f$
+ * fulfilling \f$LU = A\f$ at every non-zero location of \f$A\f$.
  *
  * @tparam ValueType  Type of the values of all matrices used in this class
  * @tparam IndexType  Type of the indices of all matrices used in this class

--- a/include/ginkgo/core/factorization/ilu.hpp
+++ b/include/ginkgo/core/factorization/ilu.hpp
@@ -31,7 +31,7 @@ namespace factorization {
  *
  * More specifically, it consists of a lower unitriangular factor \f$L\f$ and
  * an upper triangular factor \f$U\f$ with sparsity pattern
- * \f$\mathcal S(L + U)\f$ = \f$\mathcal S(A)\f$
+ * \f$\mathcal S(L + U) = \mathcal S(A)\f$
  * fulfilling \f$LU = A\f$ at every non-zero location of \f$A\f$.
  *
  * @tparam ValueType  Type of the values of all matrices used in this class

--- a/include/ginkgo/core/factorization/ilu.hpp
+++ b/include/ginkgo/core/factorization/ilu.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 

--- a/include/ginkgo/core/factorization/par_ic.hpp
+++ b/include/ginkgo/core/factorization/par_ic.hpp
@@ -48,7 +48,7 @@ namespace factorization {
  * \f$ (R = A - L L^H)\vert_\mathcal{S} = 0\vert_\mathcal{S} \f$
  * where \f$\mathcal{S}\f$ is the pre-defined sparsity pattern (in case of
  * IC(0), the sparsity pattern of the system matrix \f$A\f$). The number of
- * ParIC sweeps needed for convergence depends on the parallelism level: for
+ * ParIC sweeps needed for convergence depends on the parallelism level: For
  * sequential execution, a single sweep is sufficient; for fine-grained
  * parallelism, the number of sweeps necessary to get a good approximation
  * of the incomplete factors depends heavily on the problem. On the OpenMP

--- a/include/ginkgo/core/factorization/par_ic.hpp
+++ b/include/ginkgo/core/factorization/par_ic.hpp
@@ -32,32 +32,34 @@ namespace factorization {
  * \f$A\f$ with \f$A \approx LL^H\f$. Here, \f$L + L^H\f$ has the same sparsity
  * pattern as \f$A\f$, which is also called IC(0).
  *
- * The ParIC algorithm generates the incomplete factors iteratively, using a
+ * The ParIC algorithm generates the incomplete factor iteratively, using a
  * fixed-point iteration of the form
  *
- * $
- * F(L) =
- * \begin{cases}
- *     \sqrt{a_{ii}-\sum_{k=1}^{i-1}|l_{ik}|^2}, \quad & i == j \\
- *     a_{ij}-\sum_{k=1}^{i-1}l_{ik}u_{kj}, \quad & i < j
- * \end{cases}
- * $
+ * \f[
+ *   F(L)_{ij} = \begin{cases}
+ *     \sqrt{a_{ii} - \sum_{k=1}^{i-1} |l_{ik}|^2}, & i = j, \\
+ *     a_{ij} - \sum_{k=1}^{i-1} l_{ik}\, \overline{l_{jk}}, & i < j.
+ *   \end{cases}
+ * \f]
  *
  * In general, the entries of \f$L\f$ can be iterated in parallel and in
- * asynchronous fashion, the algorithm asymptotically converges to the
- * incomplete factors \f$L\f$ and \f$L^H\f$ fulfilling $\left(R = A - L \cdot
- * L^H\right)\vert_\mathcal{S} = 0\vert_\mathcal{S}$ where \f$\mathcal{S}\f$ is
- * the pre-defined sparsity pattern (in case of IC(0) the sparsity pattern of
- * the system matrix \f$A\f$). The number of ParIC sweeps needed for convergence
- * depends on the parallelism level: For sequential execution, a single sweep
- * is sufficient, for fine-grained parallelism, the number of sweeps necessary
- * to get a good approximation of the incomplete factors depends heavily on the
- * problem. On the OpenMP executor, 3 sweeps usually give a decent approximation
- * in our experiments, while GPU executors can take 10 or more iterations.
+ * asynchronous fashion; the algorithm asymptotically converges to incomplete
+ * factors \f$L\f$ and \f$L^H\f$ fulfilling
+ * \f$ (R = A - L L^H)\vert_\mathcal{S} = 0\vert_\mathcal{S} \f$
+ * where \f$\mathcal{S}\f$ is the pre-defined sparsity pattern (in case of
+ * IC(0), the sparsity pattern of the system matrix \f$A\f$).  The number of
+ * ParIC sweeps needed for convergence depends on the parallelism level: for
+ * sequential execution, a single sweep is sufficient; for fine-grained
+ * parallelism, the number of sweeps necessary to get a good approximation
+ * of the incomplete factors depends heavily on the problem.  On the OpenMP
+ * executor, 3 sweeps usually give a decent approximation in our experiments,
+ * while GPU executors can take 10 or more iterations.
  *
- * The ParIC algorithm in Ginkgo follows the design of E. Chow and A. Patel,
- * Fine-grained Parallel Incomplete LU Factorization, SIAM Journal on Scientific
- * Computing, 37, C169-C193 (2015).
+ * @par References
+ * - Chow, E., Patel, A.
+ *   *Fine-Grained Parallel Incomplete LU Factorization.*
+ *   SIAM Journal on Scientific Computing, 37 (2), C169–C193, 2015.
+ *   <https://doi.org/10.1137/140968896>
  *
  * @tparam ValueType  Type of the values of all matrices used in this class
  * @tparam IndexType  Type of the indices of all matrices used in this class

--- a/include/ginkgo/core/factorization/par_ic.hpp
+++ b/include/ginkgo/core/factorization/par_ic.hpp
@@ -28,8 +28,8 @@ namespace factorization {
 /**
  * ParIC is an incomplete Cholesky factorization which is computed in parallel.
  *
- * $L$ is a lower triangular matrix, which approximates a given matrix $A$ with
- * $A \approx LL^H$. Here, $L + L^H$ has the same sparsity pattern as $A$, which
+ * \f$L\f$ is a lower triangular matrix, which approximates a given matrix \f$A\f$ with
+ * \f$A \approx LL^H\f$. Here, \f$L + L^H\f$ has the same sparsity pattern as \f$A\f$, which
  * is also called IC(0).
  *
  * The ParIC algorithm generates the incomplete factors iteratively, using a
@@ -43,12 +43,12 @@ namespace factorization {
  * \end{cases}
  * $
  *
- * In general, the entries of $L$ can be iterated in parallel and in
+ * In general, the entries of \f$L\f$ can be iterated in parallel and in
  * asynchronous fashion, the algorithm asymptotically converges to the
- * incomplete factors $L$ and $L^H$ fulfilling $\left(R = A - L \cdot
- * L^H\right)\vert_\mathcal{S} = 0\vert_\mathcal{S}$ where $\mathcal{S}$ is the
+ * incomplete factors \f$L\f$ and \f$L^H\f$ fulfilling $\left(R = A - L \cdot
+ * L^H\right)\vert_\mathcal{S} = 0\vert_\mathcal{S}$ where \f$\mathcal{S}\f$ is the
  * pre-defined sparsity pattern (in case of IC(0) the sparsity pattern of the
- * system matrix $A$). The number of ParIC sweeps needed for convergence
+ * system matrix \f$A\f$). The number of ParIC sweeps needed for convergence
  * depends on the parallelism level: For sequential execution, a single sweep
  * is sufficient, for fine-grained parallelism, the number of sweeps necessary
  * to get a good approximation of the incomplete factors depends heavily on the

--- a/include/ginkgo/core/factorization/par_ic.hpp
+++ b/include/ginkgo/core/factorization/par_ic.hpp
@@ -38,7 +38,7 @@ namespace factorization {
  * \f[
  *   F(L)_{ij} = \begin{cases}
  *     \sqrt{a_{ii} - \sum_{k=1}^{i-1} |l_{ik}|^2}, & i = j, \\
- *     a_{ij} - \sum_{k=1}^{i-1} l_{ik}\, \overline{l_{jk}}, & i < j.
+ *     a_{ij} - \sum_{k=1}^{i-1} l_{ik} \overline{l_{jk}}, & i < j.
  *   \end{cases}
  * \f]
  *
@@ -47,11 +47,11 @@ namespace factorization {
  * factors \f$L\f$ and \f$L^H\f$ fulfilling
  * \f$ (R = A - L L^H)\vert_\mathcal{S} = 0\vert_\mathcal{S} \f$
  * where \f$\mathcal{S}\f$ is the pre-defined sparsity pattern (in case of
- * IC(0), the sparsity pattern of the system matrix \f$A\f$).  The number of
+ * IC(0), the sparsity pattern of the system matrix \f$A\f$). The number of
  * ParIC sweeps needed for convergence depends on the parallelism level: for
  * sequential execution, a single sweep is sufficient; for fine-grained
  * parallelism, the number of sweeps necessary to get a good approximation
- * of the incomplete factors depends heavily on the problem.  On the OpenMP
+ * of the incomplete factors depends heavily on the problem. On the OpenMP
  * executor, 3 sweeps usually give a decent approximation in our experiments,
  * while GPU executors can take 10 or more iterations.
  *

--- a/include/ginkgo/core/factorization/par_ic.hpp
+++ b/include/ginkgo/core/factorization/par_ic.hpp
@@ -28,9 +28,9 @@ namespace factorization {
 /**
  * ParIC is an incomplete Cholesky factorization which is computed in parallel.
  *
- * \f$L\f$ is a lower triangular matrix, which approximates a given matrix \f$A\f$ with
- * \f$A \approx LL^H\f$. Here, \f$L + L^H\f$ has the same sparsity pattern as \f$A\f$, which
- * is also called IC(0).
+ * \f$L\f$ is a lower triangular matrix, which approximates a given matrix
+ * \f$A\f$ with \f$A \approx LL^H\f$. Here, \f$L + L^H\f$ has the same sparsity
+ * pattern as \f$A\f$, which is also called IC(0).
  *
  * The ParIC algorithm generates the incomplete factors iteratively, using a
  * fixed-point iteration of the form
@@ -46,9 +46,9 @@ namespace factorization {
  * In general, the entries of \f$L\f$ can be iterated in parallel and in
  * asynchronous fashion, the algorithm asymptotically converges to the
  * incomplete factors \f$L\f$ and \f$L^H\f$ fulfilling $\left(R = A - L \cdot
- * L^H\right)\vert_\mathcal{S} = 0\vert_\mathcal{S}$ where \f$\mathcal{S}\f$ is the
- * pre-defined sparsity pattern (in case of IC(0) the sparsity pattern of the
- * system matrix \f$A\f$). The number of ParIC sweeps needed for convergence
+ * L^H\right)\vert_\mathcal{S} = 0\vert_\mathcal{S}$ where \f$\mathcal{S}\f$ is
+ * the pre-defined sparsity pattern (in case of IC(0) the sparsity pattern of
+ * the system matrix \f$A\f$). The number of ParIC sweeps needed for convergence
  * depends on the parallelism level: For sequential execution, a single sweep
  * is sufficient, for fine-grained parallelism, the number of sweeps necessary
  * to get a good approximation of the incomplete factors depends heavily on the

--- a/include/ginkgo/core/factorization/par_ic.hpp
+++ b/include/ginkgo/core/factorization/par_ic.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -28,9 +28,9 @@ namespace factorization {
 /**
  * ParIC is an incomplete Cholesky factorization which is computed in parallel.
  *
- * \f$L\f$ is a lower triangular matrix, which approximates a given matrix \f$A\f$ with
- * \f$A \approx LL^H\f$. Here, \f$L + L^H\f$ has the same sparsity pattern as \f$A\f$, which
- * is also called IC(0).
+ * \f$L\f$ is a lower triangular matrix, which approximates a given matrix
+ * \f$A\f$ with \f$A \approx LL^H\f$. Here, \f$L + L^H\f$ has the same sparsity
+ * pattern as \f$A\f$, which is also called IC(0).
  *
  * The ParIC algorithm generates the incomplete factors iteratively, using a
  * fixed-point iteration of the form
@@ -46,9 +46,9 @@ namespace factorization {
  * In general, the entries of \f$L\f$ can be iterated in parallel and in
  * asynchronous fashion, the algorithm asymptotically converges to the
  * incomplete factors \f$L\f$ and \f$L^H\f$ fulfilling $\left(R = A - L \cdot
- * L^H\right)\vert_\mathcal{S} = 0\vert_\mathcal{S}$ where \f$\mathcal{S}\f$ is the
- * pre-defined sparsity pattern (in case of IC(0) the sparsity pattern of the
- * system matrix \f$A\f$). The number of ParIC sweeps needed for convergence
+ * L^H\right)\vert_\mathcal{S} = 0\vert_\mathcal{S}$ where \f$\mathcal{S}\f$ is
+ * the pre-defined sparsity pattern (in case of IC(0) the sparsity pattern of
+ * the system matrix \f$A\f$). The number of ParIC sweeps needed for convergence
  * depends on the parallelism level: For sequential execution, a single sweep
  * is sufficient, for fine-grained parallelism, the number of sweeps necessary
  * to get a good approximation of the incomplete factors depends heavily on the

--- a/include/ginkgo/core/factorization/par_ict.hpp
+++ b/include/ginkgo/core/factorization/par_ict.hpp
@@ -29,18 +29,18 @@ namespace factorization {
  * ParICT is an incomplete threshold-based Cholesky factorization which is
  * computed in parallel.
  *
- * $L$ is a lower triangular matrix which approximates a given symmetric
- * positive definite matrix $A$ with $A \approx LL^T$. Here, $L$ has a sparsity
+ * \f$L\f$ is a lower triangular matrix which approximates a given symmetric
+ * positive definite matrix \f$A\f$ with \f$A \approx LL^T\f$. Here, \f$L\f$ has a sparsity
  * pattern that is improved iteratively based on its element-wise magnitude.
- * The initial sparsity pattern is chosen based on the lower triangle of $A$.
+ * The initial sparsity pattern is chosen based on the lower triangle of \f$A\f$.
  *
  * One iteration of the ParICT algorithm consists of the following steps:
  *
- * 1. Calculating the residual $R = A - LL^T$
- * 2. Adding new non-zero locations from $R$ to $L$.
+ * 1. Calculating the residual \f$R = A - LL^T\f$
+ * 2. Adding new non-zero locations from \f$R\f$ to \f$L\f$.
  *    The new non-zero locations are initialized based on the corresponding
  *    residual value.
- * 3. Executing a fixed-point iteration on $L$ according to
+ * 3. Executing a fixed-point iteration on \f$L\f$ according to
  * $
  * F(L) =
  * \begin{cases}
@@ -49,11 +49,11 @@ namespace factorization {
  *     \sqrt{a_{ij}-\sum_{k=1}^{j-1}l_{ik}l_{jk}}, \quad & i = j \\
  * \end{cases}
  * $
- * 4. Removing the smallest entries (by magnitude) from $L$
- * 5. Executing a fixed-point iteration on the (now sparser) $L$
+ * 4. Removing the smallest entries (by magnitude) from \f$L\f$
+ * 5. Executing a fixed-point iteration on the (now sparser) \f$L\f$
  *
  * This ParICT algorithm thus improves the sparsity pattern and the
- * approximation of $L$ simultaneously.
+ * approximation of \f$L\f$ simultaneously.
  *
  * The implementation follows the design of H. Anzt et al.,
  * ParILUT - A Parallel Threshold ILU for GPUs, 2019 IEEE International

--- a/include/ginkgo/core/factorization/par_ict.hpp
+++ b/include/ginkgo/core/factorization/par_ict.hpp
@@ -37,28 +37,33 @@ namespace factorization {
  *
  * One iteration of the ParICT algorithm consists of the following steps:
  *
- * 1. Calculating the residual \f$R = A - LL^T\f$
- * 2. Adding new non-zero locations from \f$R\f$ to \f$L\f$.
- *    The new non-zero locations are initialized based on the corresponding
- *    residual value.
- * 3. Executing a fixed-point iteration on \f$L\f$ according to
- * $
- * F(L) =
- * \begin{cases}
- *     \frac{1}{l_{jj}}
- *         \left(a_{ij}-\sum_{k=1}^{j-1}l_{ik}l_{jk}\right), \quad & i \neq j \\
- *     \sqrt{a_{ij}-\sum_{k=1}^{j-1}l_{ik}l_{jk}}, \quad & i = j \\
- * \end{cases}
- * $
- * 4. Removing the smallest entries (by magnitude) from \f$L\f$
- * 5. Executing a fixed-point iteration on the (now sparser) \f$L\f$
+ * 1. Calculate the residual \f$R = A - LL^T\f$.
+ * 2. Add new non-zero locations from \f$R\f$ to \f$L\f$.  The new non-zero
+ *    locations are initialised from the corresponding residual entries.
+ * 3. Execute a fixed-point iteration on \f$L\f$ according to
+ *
+ *    \f[
+ *      F(L)_{ij} = \begin{cases}
+ *        \frac{1}{l_{jj}}
+ *          \left( a_{ij} - \sum_{k=1}^{j-1} l_{ik}\, l_{jk} \right),
+ *          & i \neq j, \\
+ *        \sqrt{ a_{ij} - \sum_{k=1}^{j-1} l_{ik}\, l_{jk} },
+ *          & i = j.
+ *      \end{cases}
+ *    \f]
+ *
+ * 4. Remove the smallest entries (by magnitude) from \f$L\f$.
+ * 5. Execute a fixed-point iteration on the (now sparser) \f$L\f$.
  *
  * This ParICT algorithm thus improves the sparsity pattern and the
  * approximation of \f$L\f$ simultaneously.
  *
- * The implementation follows the design of H. Anzt et al.,
- * ParILUT - A Parallel Threshold ILU for GPUs, 2019 IEEE International
- * Parallel and Distributed Processing Symposium (IPDPS), pp. 231–241.
+ * @par References
+ * - Anzt, H., Chow, E., Dongarra, J.
+ *   *ParILUT — A Parallel Threshold ILU for GPUs.*
+ *   2019 IEEE International Parallel and Distributed Processing Symposium
+ *   (IPDPS), pp. 231–241.
+ *   <https://doi.org/10.1109/IPDPS.2019.00033>
  *
  * @tparam ValueType  Type of the values of all matrices used in this class
  * @tparam IndexType  Type of the indices of all matrices used in this class

--- a/include/ginkgo/core/factorization/par_ict.hpp
+++ b/include/ginkgo/core/factorization/par_ict.hpp
@@ -30,9 +30,10 @@ namespace factorization {
  * computed in parallel.
  *
  * \f$L\f$ is a lower triangular matrix which approximates a given symmetric
- * positive definite matrix \f$A\f$ with \f$A \approx LL^T\f$. Here, \f$L\f$ has a sparsity
- * pattern that is improved iteratively based on its element-wise magnitude.
- * The initial sparsity pattern is chosen based on the lower triangle of \f$A\f$.
+ * positive definite matrix \f$A\f$ with \f$A \approx LL^T\f$. Here, \f$L\f$ has
+ * a sparsity pattern that is improved iteratively based on its element-wise
+ * magnitude. The initial sparsity pattern is chosen based on the lower triangle
+ * of \f$A\f$.
  *
  * One iteration of the ParICT algorithm consists of the following steps:
  *

--- a/include/ginkgo/core/factorization/par_ict.hpp
+++ b/include/ginkgo/core/factorization/par_ict.hpp
@@ -38,16 +38,16 @@ namespace factorization {
  * One iteration of the ParICT algorithm consists of the following steps:
  *
  * 1. Calculate the residual \f$R = A - LL^T\f$.
- * 2. Add new non-zero locations from \f$R\f$ to \f$L\f$.  The new non-zero
- *    locations are initialised from the corresponding residual entries.
+ * 2. Add new non-zero locations from \f$R\f$ to \f$L\f$. The new non-zero
+ *    locations are initialized from the corresponding residual entries.
  * 3. Execute a fixed-point iteration on \f$L\f$ according to
  *
  *    \f[
  *      F(L)_{ij} = \begin{cases}
  *        \frac{1}{l_{jj}}
- *          \left( a_{ij} - \sum_{k=1}^{j-1} l_{ik}\, l_{jk} \right),
+ *          \left( a_{ij} - \sum_{k=1}^{j-1} l_{ik} l_{jk} \right),
  *          & i \neq j, \\
- *        \sqrt{ a_{ij} - \sum_{k=1}^{j-1} l_{ik}\, l_{jk} },
+ *        \sqrt{ a_{ij} - \sum_{k=1}^{j-1} l_{ik} l_{jk} },
  *          & i = j.
  *      \end{cases}
  *    \f]

--- a/include/ginkgo/core/factorization/par_ict.hpp
+++ b/include/ginkgo/core/factorization/par_ict.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -30,9 +30,10 @@ namespace factorization {
  * computed in parallel.
  *
  * \f$L\f$ is a lower triangular matrix which approximates a given symmetric
- * positive definite matrix \f$A\f$ with \f$A \approx LL^T\f$. Here, \f$L\f$ has a sparsity
- * pattern that is improved iteratively based on its element-wise magnitude.
- * The initial sparsity pattern is chosen based on the lower triangle of \f$A\f$.
+ * positive definite matrix \f$A\f$ with \f$A \approx LL^T\f$. Here, \f$L\f$ has
+ * a sparsity pattern that is improved iteratively based on its element-wise
+ * magnitude. The initial sparsity pattern is chosen based on the lower triangle
+ * of \f$A\f$.
  *
  * One iteration of the ParICT algorithm consists of the following steps:
  *

--- a/include/ginkgo/core/factorization/par_ilu.hpp
+++ b/include/ginkgo/core/factorization/par_ilu.hpp
@@ -39,9 +39,9 @@ namespace factorization {
  * \f[
  *   F(L, U)_{ij} = \begin{cases}
  *     \frac{1}{u_{jj}}
- *       \left( a_{ij} - \sum_{k=1}^{j-1} l_{ik}\, u_{kj} \right),
+ *       \left( a_{ij} - \sum_{k=1}^{j-1} l_{ik} u_{kj} \right),
  *       & i > j, \\
- *     a_{ij} - \sum_{k=1}^{i-1} l_{ik}\, u_{kj},
+ *     a_{ij} - \sum_{k=1}^{i-1} l_{ik} u_{kj},
  *       & i \leq j.
  *   \end{cases}
  * \f]
@@ -51,11 +51,11 @@ namespace factorization {
  * incomplete factors \f$L\f$ and \f$U\f$ fulfilling
  * \f$ (R = A - L U)\vert_\mathcal{S} = 0\vert_\mathcal{S} \f$
  * where \f$\mathcal{S}\f$ is the pre-defined sparsity pattern (in case of
- * ILU(0), the sparsity pattern of the system matrix \f$A\f$).  The number of
+ * ILU(0), the sparsity pattern of the system matrix \f$A\f$). The number of
  * ParILU sweeps needed for convergence depends on the parallelism level: for
  * sequential execution, a single sweep is sufficient; for fine-grained
  * parallelism, the number of sweeps necessary to get a good approximation
- * of the incomplete factors depends heavily on the problem.  On the OpenMP
+ * of the incomplete factors depends heavily on the problem. On the OpenMP
  * executor, 3 sweeps usually give a decent approximation in our experiments,
  * while GPU executors can take 10 or more iterations.
  *

--- a/include/ginkgo/core/factorization/par_ilu.hpp
+++ b/include/ginkgo/core/factorization/par_ilu.hpp
@@ -36,31 +36,34 @@ namespace factorization {
  * The ParILU algorithm generates the incomplete factors iteratively, using a
  * fixed-point iteration of the form
  *
- * $
- * F(L, U) =
- * \begin{cases}
+ * \f[
+ *   F(L, U)_{ij} = \begin{cases}
  *     \frac{1}{u_{jj}}
- *         \left(a_{ij}-\sum_{k=1}^{j-1}l_{ik}u_{kj}\right), \quad & i>j \\
- *     a_{ij}-\sum_{k=1}^{i-1}l_{ik}u_{kj}, \quad & i\leq j
- * \end{cases}
- * $
+ *       \left( a_{ij} - \sum_{k=1}^{j-1} l_{ik}\, u_{kj} \right),
+ *       & i > j, \\
+ *     a_{ij} - \sum_{k=1}^{i-1} l_{ik}\, u_{kj},
+ *       & i \leq j.
+ *   \end{cases}
+ * \f]
  *
  * In general, the entries of \f$L\f$ and \f$U\f$ can be iterated in parallel
- * and in asynchronous fashion, the algorithm asymptotically converges to the
- * incomplete factors \f$L\f$ and \f$U\f$ fulfilling $\left(R = A - L \cdot
- * U\right)\vert_\mathcal{S} = 0\vert_\mathcal{S}$ where \f$\mathcal{S}\f$ is
- * the pre-defined sparsity pattern (in case of ILU(0) the sparsity pattern of
- * the system matrix \f$A\f$). The number of ParILU sweeps needed for
- * convergence depends on the parallelism level: For sequential execution, a
- * single sweep is sufficient, for fine-grained parallelism, the number of
- * sweeps necessary to get a good approximation of the incomplete factors
- * depends heavily on the problem. On the OpenMP executor, 3 sweeps usually give
- * a decent approximation in our experiments, while GPU executors can take 10 or
- * more iterations.
+ * and in asynchronous fashion; the algorithm asymptotically converges to
+ * incomplete factors \f$L\f$ and \f$U\f$ fulfilling
+ * \f$ (R = A - L U)\vert_\mathcal{S} = 0\vert_\mathcal{S} \f$
+ * where \f$\mathcal{S}\f$ is the pre-defined sparsity pattern (in case of
+ * ILU(0), the sparsity pattern of the system matrix \f$A\f$).  The number of
+ * ParILU sweeps needed for convergence depends on the parallelism level: for
+ * sequential execution, a single sweep is sufficient; for fine-grained
+ * parallelism, the number of sweeps necessary to get a good approximation
+ * of the incomplete factors depends heavily on the problem.  On the OpenMP
+ * executor, 3 sweeps usually give a decent approximation in our experiments,
+ * while GPU executors can take 10 or more iterations.
  *
- * The ParILU algorithm in Ginkgo follows the design of E. Chow and A. Patel,
- * Fine-grained Parallel Incomplete LU Factorization, SIAM Journal on Scientific
- * Computing, 37, C169-C193 (2015).
+ * @par References
+ * - Chow, E., Patel, A.
+ *   *Fine-Grained Parallel Incomplete LU Factorization.*
+ *   SIAM Journal on Scientific Computing, 37 (2), C169–C193, 2015.
+ *   <https://doi.org/10.1137/140968896>
  *
  * @tparam ValueType  Type of the values of all matrices used in this class
  * @tparam IndexType  Type of the indices of all matrices used in this class

--- a/include/ginkgo/core/factorization/par_ilu.hpp
+++ b/include/ginkgo/core/factorization/par_ilu.hpp
@@ -28,9 +28,10 @@ namespace factorization {
 /**
  * ParILU is an incomplete LU factorization which is computed in parallel.
  *
- * \f$L\f$ is a lower unitriangular, while \f$U\f$ is an upper triangular matrix, which
- * approximate a given matrix \f$A\f$ with \f$A \approx LU\f$. Here, \f$L\f$ and \f$U\f$ have
- * the same sparsity pattern as \f$A\f$, which is also called ILU(0).
+ * \f$L\f$ is a lower unitriangular, while \f$U\f$ is an upper triangular
+ * matrix, which approximate a given matrix \f$A\f$ with \f$A \approx LU\f$.
+ * Here, \f$L\f$ and \f$U\f$ have the same sparsity pattern as \f$A\f$, which is
+ * also called ILU(0).
  *
  * The ParILU algorithm generates the incomplete factors iteratively, using a
  * fixed-point iteration of the form
@@ -44,17 +45,18 @@ namespace factorization {
  * \end{cases}
  * $
  *
- * In general, the entries of \f$L\f$ and \f$U\f$ can be iterated in parallel and in
- * asynchronous fashion, the algorithm asymptotically converges to the
+ * In general, the entries of \f$L\f$ and \f$U\f$ can be iterated in parallel
+ * and in asynchronous fashion, the algorithm asymptotically converges to the
  * incomplete factors \f$L\f$ and \f$U\f$ fulfilling $\left(R = A - L \cdot
- * U\right)\vert_\mathcal{S} = 0\vert_\mathcal{S}$ where \f$\mathcal{S}\f$ is the
- * pre-defined sparsity pattern (in case of ILU(0) the sparsity pattern of the
- * system matrix \f$A\f$). The number of ParILU sweeps needed for convergence
- * depends on the parallelism level: For sequential execution, a single sweep
- * is sufficient, for fine-grained parallelism, the number of sweeps necessary
- * to get a good approximation of the incomplete factors depends heavily on the
- * problem. On the OpenMP executor, 3 sweeps usually give a decent approximation
- * in our experiments, while GPU executors can take 10 or more iterations.
+ * U\right)\vert_\mathcal{S} = 0\vert_\mathcal{S}$ where \f$\mathcal{S}\f$ is
+ * the pre-defined sparsity pattern (in case of ILU(0) the sparsity pattern of
+ * the system matrix \f$A\f$). The number of ParILU sweeps needed for
+ * convergence depends on the parallelism level: For sequential execution, a
+ * single sweep is sufficient, for fine-grained parallelism, the number of
+ * sweeps necessary to get a good approximation of the incomplete factors
+ * depends heavily on the problem. On the OpenMP executor, 3 sweeps usually give
+ * a decent approximation in our experiments, while GPU executors can take 10 or
+ * more iterations.
  *
  * The ParILU algorithm in Ginkgo follows the design of E. Chow and A. Patel,
  * Fine-grained Parallel Incomplete LU Factorization, SIAM Journal on Scientific

--- a/include/ginkgo/core/factorization/par_ilu.hpp
+++ b/include/ginkgo/core/factorization/par_ilu.hpp
@@ -52,7 +52,7 @@ namespace factorization {
  * \f$ (R = A - L U)\vert_\mathcal{S} = 0\vert_\mathcal{S} \f$
  * where \f$\mathcal{S}\f$ is the pre-defined sparsity pattern (in case of
  * ILU(0), the sparsity pattern of the system matrix \f$A\f$). The number of
- * ParILU sweeps needed for convergence depends on the parallelism level: for
+ * ParILU sweeps needed for convergence depends on the parallelism level: For
  * sequential execution, a single sweep is sufficient; for fine-grained
  * parallelism, the number of sweeps necessary to get a good approximation
  * of the incomplete factors depends heavily on the problem. On the OpenMP

--- a/include/ginkgo/core/factorization/par_ilu.hpp
+++ b/include/ginkgo/core/factorization/par_ilu.hpp
@@ -28,9 +28,9 @@ namespace factorization {
 /**
  * ParILU is an incomplete LU factorization which is computed in parallel.
  *
- * $L$ is a lower unitriangular, while $U$ is an upper triangular matrix, which
- * approximate a given matrix $A$ with $A \approx LU$. Here, $L$ and $U$ have
- * the same sparsity pattern as $A$, which is also called ILU(0).
+ * \f$L\f$ is a lower unitriangular, while \f$U\f$ is an upper triangular matrix, which
+ * approximate a given matrix \f$A\f$ with \f$A \approx LU\f$. Here, \f$L\f$ and \f$U\f$ have
+ * the same sparsity pattern as \f$A\f$, which is also called ILU(0).
  *
  * The ParILU algorithm generates the incomplete factors iteratively, using a
  * fixed-point iteration of the form
@@ -44,12 +44,12 @@ namespace factorization {
  * \end{cases}
  * $
  *
- * In general, the entries of $L$ and $U$ can be iterated in parallel and in
+ * In general, the entries of \f$L\f$ and \f$U\f$ can be iterated in parallel and in
  * asynchronous fashion, the algorithm asymptotically converges to the
- * incomplete factors $L$ and $U$ fulfilling $\left(R = A - L \cdot
- * U\right)\vert_\mathcal{S} = 0\vert_\mathcal{S}$ where $\mathcal{S}$ is the
+ * incomplete factors \f$L\f$ and \f$U\f$ fulfilling $\left(R = A - L \cdot
+ * U\right)\vert_\mathcal{S} = 0\vert_\mathcal{S}$ where \f$\mathcal{S}\f$ is the
  * pre-defined sparsity pattern (in case of ILU(0) the sparsity pattern of the
- * system matrix $A$). The number of ParILU sweeps needed for convergence
+ * system matrix \f$A\f$). The number of ParILU sweeps needed for convergence
  * depends on the parallelism level: For sequential execution, a single sweep
  * is sufficient, for fine-grained parallelism, the number of sweeps necessary
  * to get a good approximation of the incomplete factors depends heavily on the

--- a/include/ginkgo/core/factorization/par_ilu.hpp
+++ b/include/ginkgo/core/factorization/par_ilu.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -28,9 +28,10 @@ namespace factorization {
 /**
  * ParILU is an incomplete LU factorization which is computed in parallel.
  *
- * \f$L\f$ is a lower unitriangular, while \f$U\f$ is an upper triangular matrix, which
- * approximate a given matrix \f$A\f$ with \f$A \approx LU\f$. Here, \f$L\f$ and \f$U\f$ have
- * the same sparsity pattern as \f$A\f$, which is also called ILU(0).
+ * \f$L\f$ is a lower unitriangular, while \f$U\f$ is an upper triangular
+ * matrix, which approximate a given matrix \f$A\f$ with \f$A \approx LU\f$.
+ * Here, \f$L\f$ and \f$U\f$ have the same sparsity pattern as \f$A\f$, which is
+ * also called ILU(0).
  *
  * The ParILU algorithm generates the incomplete factors iteratively, using a
  * fixed-point iteration of the form
@@ -44,17 +45,18 @@ namespace factorization {
  * \end{cases}
  * $
  *
- * In general, the entries of \f$L\f$ and \f$U\f$ can be iterated in parallel and in
- * asynchronous fashion, the algorithm asymptotically converges to the
+ * In general, the entries of \f$L\f$ and \f$U\f$ can be iterated in parallel
+ * and in asynchronous fashion, the algorithm asymptotically converges to the
  * incomplete factors \f$L\f$ and \f$U\f$ fulfilling $\left(R = A - L \cdot
- * U\right)\vert_\mathcal{S} = 0\vert_\mathcal{S}$ where \f$\mathcal{S}\f$ is the
- * pre-defined sparsity pattern (in case of ILU(0) the sparsity pattern of the
- * system matrix \f$A\f$). The number of ParILU sweeps needed for convergence
- * depends on the parallelism level: For sequential execution, a single sweep
- * is sufficient, for fine-grained parallelism, the number of sweeps necessary
- * to get a good approximation of the incomplete factors depends heavily on the
- * problem. On the OpenMP executor, 3 sweeps usually give a decent approximation
- * in our experiments, while GPU executors can take 10 or more iterations.
+ * U\right)\vert_\mathcal{S} = 0\vert_\mathcal{S}$ where \f$\mathcal{S}\f$ is
+ * the pre-defined sparsity pattern (in case of ILU(0) the sparsity pattern of
+ * the system matrix \f$A\f$). The number of ParILU sweeps needed for
+ * convergence depends on the parallelism level: For sequential execution, a
+ * single sweep is sufficient, for fine-grained parallelism, the number of
+ * sweeps necessary to get a good approximation of the incomplete factors
+ * depends heavily on the problem. On the OpenMP executor, 3 sweeps usually give
+ * a decent approximation in our experiments, while GPU executors can take 10 or
+ * more iterations.
  *
  * The ParILU algorithm in Ginkgo follows the design of E. Chow and A. Patel,
  * Fine-grained Parallel Incomplete LU Factorization, SIAM Journal on Scientific

--- a/include/ginkgo/core/factorization/par_ilut.hpp
+++ b/include/ginkgo/core/factorization/par_ilut.hpp
@@ -37,30 +37,37 @@ namespace factorization {
  *
  * One iteration of the ParILUT algorithm consists of the following steps:
  *
- * 1. Calculating the residual \f$R = A - LU\f$
- * 2. Adding new non-zero locations from \f$R\f$ to \f$L\f$ and \f$U\f$.
- *    The new non-zero locations are initialized based on the corresponding
- *    residual value.
- * 3. Executing a fixed-point iteration on \f$L\f$ and \f$U\f$ according to
- * $
- * F(L, U) =
- * \begin{cases}
- *     \frac{1}{u_{jj}}
- *         \left(a_{ij}-\sum_{k=1}^{j-1}l_{ik}u_{kj}\right), \quad & i>j \\
- *     a_{ij}-\sum_{k=1}^{i-1}l_{ik}u_{kj}, \quad & i\leq j
- * \end{cases}
- * $
+ * 1. Calculate the residual \f$R = A - LU\f$.
+ * 2. Add new non-zero locations from \f$R\f$ to \f$L\f$ and \f$U\f$.  The new
+ *    non-zero locations are initialised from the corresponding residual
+ *    entries.
+ * 3. Execute a fixed-point iteration on \f$L\f$ and \f$U\f$ according to
+ *
+ *    \f[
+ *      F(L, U)_{ij} = \begin{cases}
+ *        \frac{1}{u_{jj}}
+ *          \left( a_{ij} - \sum_{k=1}^{j-1} l_{ik}\, u_{kj} \right),
+ *          & i > j, \\
+ *        a_{ij} - \sum_{k=1}^{i-1} l_{ik}\, u_{kj},
+ *          & i \leq j.
+ *      \end{cases}
+ *    \f]
+ *
  *    For a more detailed description of the fixed-point iteration, see
  *    @ref ParIlu.
- * 4. Removing the smallest entries (by magnitude) from \f$L\f$ and \f$U\f$
- * 5. Executing a fixed-point iteration on the (now sparser) \f$L\f$ and \f$U\f$
+ * 4. Remove the smallest entries (by magnitude) from \f$L\f$ and \f$U\f$.
+ * 5. Execute a fixed-point iteration on the (now sparser) \f$L\f$ and
+ *    \f$U\f$.
  *
  * This ParILUT algorithm thus improves the sparsity pattern and the
  * approximation of \f$L\f$ and \f$U\f$ simultaneously.
  *
- * The implementation follows the design of H. Anzt et al.,
- * ParILUT - A Parallel Threshold ILU for GPUs, 2019 IEEE International
- * Parallel and Distributed Processing Symposium (IPDPS), pp. 231–241.
+ * @par References
+ * - Anzt, H., Chow, E., Dongarra, J.
+ *   *ParILUT — A Parallel Threshold ILU for GPUs.*
+ *   2019 IEEE International Parallel and Distributed Processing Symposium
+ *   (IPDPS), pp. 231–241.
+ *   <https://doi.org/10.1109/IPDPS.2019.00033>
  *
  * @tparam ValueType  Type of the values of all matrices used in this class
  * @tparam IndexType  Type of the indices of all matrices used in this class

--- a/include/ginkgo/core/factorization/par_ilut.hpp
+++ b/include/ginkgo/core/factorization/par_ilut.hpp
@@ -29,19 +29,19 @@ namespace factorization {
  * ParILUT is an incomplete threshold-based LU factorization which is computed
  * in parallel.
  *
- * $L$ is a lower unitriangular, while $U$ is an upper triangular matrix, which
- * approximate a given matrix $A$ with $A \approx LU$. Here, $L$ and $U$ have
+ * \f$L\f$ is a lower unitriangular, while \f$U\f$ is an upper triangular matrix, which
+ * approximate a given matrix \f$A\f$ with \f$A \approx LU\f$. Here, \f$L\f$ and \f$U\f$ have
  * a sparsity pattern that is improved iteratively based on their element-wise
- * magnitude. The initial sparsity pattern is chosen based on the $ILU(0)$
- * factorization of $A$.
+ * magnitude. The initial sparsity pattern is chosen based on the \f$ILU(0)\f$
+ * factorization of \f$A\f$.
  *
  * One iteration of the ParILUT algorithm consists of the following steps:
  *
- * 1. Calculating the residual $R = A - LU$
- * 2. Adding new non-zero locations from $R$ to $L$ and $U$.
+ * 1. Calculating the residual \f$R = A - LU\f$
+ * 2. Adding new non-zero locations from \f$R\f$ to \f$L\f$ and \f$U\f$.
  *    The new non-zero locations are initialized based on the corresponding
  *    residual value.
- * 3. Executing a fixed-point iteration on $L$ and $U$ according to
+ * 3. Executing a fixed-point iteration on \f$L\f$ and \f$U\f$ according to
  * $
  * F(L, U) =
  * \begin{cases}
@@ -52,11 +52,11 @@ namespace factorization {
  * $
  *    For a more detailed description of the fixed-point iteration, see
  *    @ref ParIlu.
- * 4. Removing the smallest entries (by magnitude) from $L$ and $U$
- * 5. Executing a fixed-point iteration on the (now sparser) $L$ and $U$
+ * 4. Removing the smallest entries (by magnitude) from \f$L\f$ and \f$U\f$
+ * 5. Executing a fixed-point iteration on the (now sparser) \f$L\f$ and \f$U\f$
  *
  * This ParILUT algorithm thus improves the sparsity pattern and the
- * approximation of $L$ and $U$ simultaneously.
+ * approximation of \f$L\f$ and \f$U\f$ simultaneously.
  *
  * The implementation follows the design of H. Anzt et al.,
  * ParILUT - A Parallel Threshold ILU for GPUs, 2019 IEEE International

--- a/include/ginkgo/core/factorization/par_ilut.hpp
+++ b/include/ginkgo/core/factorization/par_ilut.hpp
@@ -29,11 +29,11 @@ namespace factorization {
  * ParILUT is an incomplete threshold-based LU factorization which is computed
  * in parallel.
  *
- * \f$L\f$ is a lower unitriangular, while \f$U\f$ is an upper triangular matrix, which
- * approximate a given matrix \f$A\f$ with \f$A \approx LU\f$. Here, \f$L\f$ and \f$U\f$ have
- * a sparsity pattern that is improved iteratively based on their element-wise
- * magnitude. The initial sparsity pattern is chosen based on the \f$ILU(0)\f$
- * factorization of \f$A\f$.
+ * \f$L\f$ is a lower unitriangular, while \f$U\f$ is an upper triangular
+ * matrix, which approximate a given matrix \f$A\f$ with \f$A \approx LU\f$.
+ * Here, \f$L\f$ and \f$U\f$ have a sparsity pattern that is improved
+ * iteratively based on their element-wise magnitude. The initial sparsity
+ * pattern is chosen based on the \f$ILU(0)\f$ factorization of \f$A\f$.
  *
  * One iteration of the ParILUT algorithm consists of the following steps:
  *

--- a/include/ginkgo/core/factorization/par_ilut.hpp
+++ b/include/ginkgo/core/factorization/par_ilut.hpp
@@ -38,17 +38,17 @@ namespace factorization {
  * One iteration of the ParILUT algorithm consists of the following steps:
  *
  * 1. Calculate the residual \f$R = A - LU\f$.
- * 2. Add new non-zero locations from \f$R\f$ to \f$L\f$ and \f$U\f$.  The new
- *    non-zero locations are initialised from the corresponding residual
+ * 2. Add new non-zero locations from \f$R\f$ to \f$L\f$ and \f$U\f$. The new
+ *    non-zero locations are initialized from the corresponding residual
  *    entries.
  * 3. Execute a fixed-point iteration on \f$L\f$ and \f$U\f$ according to
  *
  *    \f[
  *      F(L, U)_{ij} = \begin{cases}
  *        \frac{1}{u_{jj}}
- *          \left( a_{ij} - \sum_{k=1}^{j-1} l_{ik}\, u_{kj} \right),
+ *          \left( a_{ij} - \sum_{k=1}^{j-1} l_{ik} u_{kj} \right),
  *          & i > j, \\
- *        a_{ij} - \sum_{k=1}^{i-1} l_{ik}\, u_{kj},
+ *        a_{ij} - \sum_{k=1}^{i-1} l_{ik} u_{kj},
  *          & i \leq j.
  *      \end{cases}
  *    \f]

--- a/include/ginkgo/core/factorization/par_ilut.hpp
+++ b/include/ginkgo/core/factorization/par_ilut.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -29,11 +29,11 @@ namespace factorization {
  * ParILUT is an incomplete threshold-based LU factorization which is computed
  * in parallel.
  *
- * \f$L\f$ is a lower unitriangular, while \f$U\f$ is an upper triangular matrix, which
- * approximate a given matrix \f$A\f$ with \f$A \approx LU\f$. Here, \f$L\f$ and \f$U\f$ have
- * a sparsity pattern that is improved iteratively based on their element-wise
- * magnitude. The initial sparsity pattern is chosen based on the \f$ILU(0)\f$
- * factorization of \f$A\f$.
+ * \f$L\f$ is a lower unitriangular, while \f$U\f$ is an upper triangular
+ * matrix, which approximate a given matrix \f$A\f$ with \f$A \approx LU\f$.
+ * Here, \f$L\f$ and \f$U\f$ have a sparsity pattern that is improved
+ * iteratively based on their element-wise magnitude. The initial sparsity
+ * pattern is chosen based on the \f$ILU(0)\f$ factorization of \f$A\f$.
  *
  * One iteration of the ParILUT algorithm consists of the following steps:
  *

--- a/include/ginkgo/core/matrix/csr.hpp
+++ b/include/ginkgo/core/matrix/csr.hpp
@@ -112,15 +112,15 @@ enum class spmv_strategy {
  *
  * - Against a `Dense` operand `b`, `apply` computes a sparse matrix-vector
  *   (or matrix-multivector) product:
- *   \f[ x = A b, \qquad x = \alpha\, A b + \beta\, x. \f]
+ *   \f[ x = A b, \qquad x = \alpha A b + \beta x. \f]
  *
  * - Against another `Csr` operand `B`, `apply` computes a sparse-sparse
  *   matrix product (SpGEMM):
- *   \f[ C = A B, \qquad C = \alpha\, A B + \beta\, C. \f]
+ *   \f[ C = A B, \qquad C = \alpha A B + \beta C. \f]
  *
  * - Against an `Identity` operand, `apply` reduces to a sparse-sparse
  *   matrix addition (SpGEAM):
- *   \f[ B = \alpha\, A + \beta\, B. \f]
+ *   \f[ B = \alpha A + \beta B. \f]
  *
  * In code:
  *

--- a/include/ginkgo/core/matrix/csr.hpp
+++ b/include/ginkgo/core/matrix/csr.hpp
@@ -67,14 +67,14 @@ enum class spmv_strategy {
      * load_balance is the strategy trying to distribute the work equally in
      * terms of the number of matrix entries. More detail can be checked in
      * Goran and Enrique: Balanced CSR sparse matrix-vector product on graphics
-     * processors (doi: 10.1007/978-3-319-64203-1_50).
+     * processors (<https://doi.org/10.1007/978-3-319-64203-1_50>).
      */
     load_balance,
     /**
      * merge_path is the strategy trying to distribute the work equally in terms
      * of the number of matrix entries and row pointers. More detail can be
      * checked in Merrill and Garland: Merge-Based Parallel Sparse Matrix-Vector
-     * Multiplication (doi: 10.1109/SC.2016.57).
+     * Multiplication (<https://doi.org/10.1109/SC.2016.57>).
      */
     merge_path,
     /**
@@ -668,14 +668,10 @@ public:
      * Creates a permuted copy \f$A'\f$ of this matrix \f$A\f$ with the given
      * permutation \f$P\f$. By default, this computes a symmetric permutation
      * (permute_mode::symmetric). For the effect of the different permutation
-     * modes, see @ref permute_mode
+     * modes, see @ref permute_mode.
      *
      * @param permutation  The input permutation.
-     * @param mode  The permutation mode. If permute_mode::inverse is set, we
-     *              use the inverse permutation \f$P^{-1}\f$ instead of \f$P\f$.
-     *              If permute_mode::rows is set, the rows will be permuted.
-     *              If permute_mode::columns is set, the columns will be
-     *              permuted.
+     * @param mode  The permutation mode, see @ref permute_mode.
      * @return  The permuted matrix.
      */
     std::unique_ptr<Csr> permute(
@@ -713,11 +709,7 @@ public:
      * reuse->update_values(matrix, permuted);
      * ```
      * @param permutation  The input permutation.
-     * @param mode  The permutation mode. If permute_mode::inverse is set, we
-     *              use the inverse permutation \f$P^{-1}\f$ instead of \f$P\f$.
-     *              If permute_mode::rows is set, the rows will be permuted.
-     *              If permute_mode::columns is set, the columns will be
-     *              permuted.
+     * @param mode  The permutation mode, see @ref permute_mode.
      * @return an std::pair consisting of the permuted matrix and the reuse info
      *         that can be used to update values in the permuted matrix.
      */

--- a/include/ginkgo/core/matrix/csr.hpp
+++ b/include/ginkgo/core/matrix/csr.hpp
@@ -683,14 +683,15 @@ public:
         permute_mode mode = permute_mode::symmetric) const;
 
     /**
-     * Creates a non-symmetrically permuted copy \f$A'\f$ of this matrix \f$A\f$ with
-     * the given row and column permutations \f$P\f$ and \f$Q\f$. The operation will
-     * compute \f$A'(i, j) = A(p[i], q[j])\f$, or \f$A' = P A Q^T\f$ if `invert` is
-     * `false`, and \f$A'(p[i], q[j]) = A(i,j)\f$, or \f$A' = P^{-1} A Q^{-T}\f$ if
-     * `invert` is `true`.
+     * Creates a non-symmetrically permuted copy \f$A'\f$ of this matrix \f$A\f$
+     * with the given row and column permutations \f$P\f$ and \f$Q\f$. The
+     * operation will compute \f$A'(i, j) = A(p[i], q[j])\f$, or \f$A' = P A
+     * Q^T\f$ if `invert` is `false`, and \f$A'(p[i], q[j]) = A(i,j)\f$, or
+     * \f$A' = P^{-1} A Q^{-T}\f$ if `invert` is `true`.
      *
      * @param row_permutation  The permutation \f$P\f$ to apply to the rows
-     * @param column_permutation  The permutation \f$Q\f$ to apply to the columns
+     * @param column_permutation  The permutation \f$Q\f$ to apply to the
+     * columns
      * @param invert  If set to `false`, uses the input permutations, otherwise
      *                uses their inverses \f$P^{-1}, Q^{-1}\f$
      * @return  The permuted matrix.
@@ -736,7 +737,8 @@ public:
      * reuse->update_values(matrix, permuted);
      * ```
      * @param row_permutation  The permutation \f$P\f$ to apply to the rows
-     * @param column_permutation  The permutation \f$Q\f$ to apply to the columns
+     * @param column_permutation  The permutation \f$Q\f$ to apply to the
+     * columns
      * @param invert  If set to `false`, uses the input permutations, otherwise
      *                uses their inverses \f$P^{-1}, Q^{-1}\f$
      * @return an std::pair consisting of the permuted matrix and the reuse info

--- a/include/ginkgo/core/matrix/csr.hpp
+++ b/include/ginkgo/core/matrix/csr.hpp
@@ -107,7 +107,22 @@ enum class spmv_strategy {
  * An additional column index array is used to identify the column of each
  * nonzero element.
  *
- * The Csr LinOp supports different operations:
+ * The Csr LinOp supports three families of `apply` operations,
+ * dispatched on the type of the right operand:
+ *
+ * - Against a `Dense` operand `b`, `apply` computes a sparse matrix-vector
+ *   (or matrix-multivector) product:
+ *   \f[ x = A b, \qquad x = \alpha\, A b + \beta\, x. \f]
+ *
+ * - Against another `Csr` operand `B`, `apply` computes a sparse-sparse
+ *   matrix product (SpGEMM):
+ *   \f[ C = A B, \qquad C = \alpha\, A B + \beta\, C. \f]
+ *
+ * - Against an `Identity` operand, `apply` reduces to a sparse-sparse
+ *   matrix addition (SpGEAM):
+ *   \f[ B = \alpha\, A + \beta\, B. \f]
+ *
+ * In code:
  *
  * ```cpp
  * matrix::Csr *A, *B, *C;      // matrices
@@ -650,14 +665,14 @@ public:
         const;
 
     /**
-     * Creates a permuted copy $A'$ of this matrix $A$ with the given
-     * permutation $P$. By default, this computes a symmetric permutation
+     * Creates a permuted copy \f$A'\f$ of this matrix \f$A\f$ with the given
+     * permutation \f$P\f$. By default, this computes a symmetric permutation
      * (permute_mode::symmetric). For the effect of the different permutation
      * modes, see @ref permute_mode
      *
      * @param permutation  The input permutation.
      * @param mode  The permutation mode. If permute_mode::inverse is set, we
-     *              use the inverse permutation $P^{-1}$ instead of $P$.
+     *              use the inverse permutation \f$P^{-1}\f$ instead of \f$P\f$.
      *              If permute_mode::rows is set, the rows will be permuted.
      *              If permute_mode::columns is set, the columns will be
      *              permuted.
@@ -668,16 +683,16 @@ public:
         permute_mode mode = permute_mode::symmetric) const;
 
     /**
-     * Creates a non-symmetrically permuted copy $A'$ of this matrix $A$ with
-     * the given row and column permutations $P$ and $Q$. The operation will
-     * compute $A'(i, j) = A(p[i], q[j])$, or $A' = P A Q^T$ if `invert` is
-     * `false`, and $A'(p[i], q[j]) = A(i,j)$, or $A' = P^{-1} A Q^{-T}$ if
+     * Creates a non-symmetrically permuted copy \f$A'\f$ of this matrix \f$A\f$ with
+     * the given row and column permutations \f$P\f$ and \f$Q\f$. The operation will
+     * compute \f$A'(i, j) = A(p[i], q[j])\f$, or \f$A' = P A Q^T\f$ if `invert` is
+     * `false`, and \f$A'(p[i], q[j]) = A(i,j)\f$, or \f$A' = P^{-1} A Q^{-T}\f$ if
      * `invert` is `true`.
      *
-     * @param row_permutation  The permutation $P$ to apply to the rows
-     * @param column_permutation  The permutation $Q$ to apply to the columns
+     * @param row_permutation  The permutation \f$P\f$ to apply to the rows
+     * @param column_permutation  The permutation \f$Q\f$ to apply to the columns
      * @param invert  If set to `false`, uses the input permutations, otherwise
-     *                uses their inverses $P^{-1}, Q^{-1}$
+     *                uses their inverses \f$P^{-1}, Q^{-1}\f$
      * @return  The permuted matrix.
      */
     std::unique_ptr<Csr> permute(
@@ -698,7 +713,7 @@ public:
      * ```
      * @param permutation  The input permutation.
      * @param mode  The permutation mode. If permute_mode::inverse is set, we
-     *              use the inverse permutation $P^{-1}$ instead of $P$.
+     *              use the inverse permutation \f$P^{-1}\f$ instead of \f$P\f$.
      *              If permute_mode::rows is set, the rows will be permuted.
      *              If permute_mode::columns is set, the columns will be
      *              permuted.
@@ -720,10 +735,10 @@ public:
      * change_values(matrix);
      * reuse->update_values(matrix, permuted);
      * ```
-     * @param row_permutation  The permutation $P$ to apply to the rows
-     * @param column_permutation  The permutation $Q$ to apply to the columns
+     * @param row_permutation  The permutation \f$P\f$ to apply to the rows
+     * @param column_permutation  The permutation \f$Q\f$ to apply to the columns
      * @param invert  If set to `false`, uses the input permutations, otherwise
-     *                uses their inverses $P^{-1}, Q^{-1}$
+     *                uses their inverses \f$P^{-1}, Q^{-1}\f$
      * @return an std::pair consisting of the permuted matrix and the reuse info
      *         that can be used to update values in the permuted matrix.
      */
@@ -754,7 +769,7 @@ public:
      * @param row_permutation  The scaled row permutation.
      * @param column_permutation  The scaled column permutation.
      * @param invert  If set to `false`, uses the input permutations, otherwise
-     *                uses their inverses $P^{-1}, Q^{-1}$
+     *                uses their inverses \f$P^{-1}, Q^{-1}\f$
      * @return The permuted matrix.
      */
     std::unique_ptr<Csr> scale_permute(

--- a/include/ginkgo/core/matrix/csr.hpp
+++ b/include/ginkgo/core/matrix/csr.hpp
@@ -71,7 +71,22 @@ void strategy_rebuild_helper(Csr<ValueType, IndexType>* result);
  * An additional column index array is used to identify the column of each
  * nonzero element.
  *
- * The Csr LinOp supports different operations:
+ * The Csr LinOp supports three families of `apply` operations,
+ * dispatched on the type of the right operand:
+ *
+ * - Against a `Dense` operand `b`, `apply` computes a sparse matrix-vector
+ *   (or matrix-multivector) product:
+ *   \f[ x = A b, \qquad x = \alpha\, A b + \beta\, x. \f]
+ *
+ * - Against another `Csr` operand `B`, `apply` computes a sparse-sparse
+ *   matrix product (SpGEMM):
+ *   \f[ C = A B, \qquad C = \alpha\, A B + \beta\, C. \f]
+ *
+ * - Against an `Identity` operand, `apply` reduces to a sparse-sparse
+ *   matrix addition (SpGEAM):
+ *   \f[ B = \alpha\, A + \beta\, B. \f]
+ *
+ * In code:
  *
  * ```cpp
  * matrix::Csr *A, *B, *C;      // matrices
@@ -1055,14 +1070,14 @@ public:
         const;
 
     /**
-     * Creates a permuted copy $A'$ of this matrix $A$ with the given
-     * permutation $P$. By default, this computes a symmetric permutation
+     * Creates a permuted copy \f$A'\f$ of this matrix \f$A\f$ with the given
+     * permutation \f$P\f$. By default, this computes a symmetric permutation
      * (permute_mode::symmetric). For the effect of the different permutation
      * modes, see @ref permute_mode
      *
      * @param permutation  The input permutation.
      * @param mode  The permutation mode. If permute_mode::inverse is set, we
-     *              use the inverse permutation $P^{-1}$ instead of $P$.
+     *              use the inverse permutation \f$P^{-1}\f$ instead of \f$P\f$.
      *              If permute_mode::rows is set, the rows will be permuted.
      *              If permute_mode::columns is set, the columns will be
      *              permuted.
@@ -1073,16 +1088,16 @@ public:
         permute_mode mode = permute_mode::symmetric) const;
 
     /**
-     * Creates a non-symmetrically permuted copy $A'$ of this matrix $A$ with
-     * the given row and column permutations $P$ and $Q$. The operation will
-     * compute $A'(i, j) = A(p[i], q[j])$, or $A' = P A Q^T$ if `invert` is
-     * `false`, and $A'(p[i], q[j]) = A(i,j)$, or $A' = P^{-1} A Q^{-T}$ if
+     * Creates a non-symmetrically permuted copy \f$A'\f$ of this matrix \f$A\f$ with
+     * the given row and column permutations \f$P\f$ and \f$Q\f$. The operation will
+     * compute \f$A'(i, j) = A(p[i], q[j])\f$, or \f$A' = P A Q^T\f$ if `invert` is
+     * `false`, and \f$A'(p[i], q[j]) = A(i,j)\f$, or \f$A' = P^{-1} A Q^{-T}\f$ if
      * `invert` is `true`.
      *
-     * @param row_permutation  The permutation $P$ to apply to the rows
-     * @param column_permutation  The permutation $Q$ to apply to the columns
+     * @param row_permutation  The permutation \f$P\f$ to apply to the rows
+     * @param column_permutation  The permutation \f$Q\f$ to apply to the columns
      * @param invert  If set to `false`, uses the input permutations, otherwise
-     *                uses their inverses $P^{-1}, Q^{-1}$
+     *                uses their inverses \f$P^{-1}, Q^{-1}\f$
      * @return  The permuted matrix.
      */
     std::unique_ptr<Csr> permute(
@@ -1103,7 +1118,7 @@ public:
      * ```
      * @param permutation  The input permutation.
      * @param mode  The permutation mode. If permute_mode::inverse is set, we
-     *              use the inverse permutation $P^{-1}$ instead of $P$.
+     *              use the inverse permutation \f$P^{-1}\f$ instead of \f$P\f$.
      *              If permute_mode::rows is set, the rows will be permuted.
      *              If permute_mode::columns is set, the columns will be
      *              permuted.
@@ -1125,10 +1140,10 @@ public:
      * change_values(matrix);
      * reuse->update_values(matrix, permuted);
      * ```
-     * @param row_permutation  The permutation $P$ to apply to the rows
-     * @param column_permutation  The permutation $Q$ to apply to the columns
+     * @param row_permutation  The permutation \f$P\f$ to apply to the rows
+     * @param column_permutation  The permutation \f$Q\f$ to apply to the columns
      * @param invert  If set to `false`, uses the input permutations, otherwise
-     *                uses their inverses $P^{-1}, Q^{-1}$
+     *                uses their inverses \f$P^{-1}, Q^{-1}\f$
      * @return an std::pair consisting of the permuted matrix and the reuse info
      *         that can be used to update values in the permuted matrix.
      */
@@ -1159,7 +1174,7 @@ public:
      * @param row_permutation  The scaled row permutation.
      * @param column_permutation  The scaled column permutation.
      * @param invert  If set to `false`, uses the input permutations, otherwise
-     *                uses their inverses $P^{-1}, Q^{-1}$
+     *                uses their inverses \f$P^{-1}, Q^{-1}\f$
      * @return The permuted matrix.
      */
     std::unique_ptr<Csr> scale_permute(

--- a/include/ginkgo/core/matrix/csr.hpp
+++ b/include/ginkgo/core/matrix/csr.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -1088,14 +1088,15 @@ public:
         permute_mode mode = permute_mode::symmetric) const;
 
     /**
-     * Creates a non-symmetrically permuted copy \f$A'\f$ of this matrix \f$A\f$ with
-     * the given row and column permutations \f$P\f$ and \f$Q\f$. The operation will
-     * compute \f$A'(i, j) = A(p[i], q[j])\f$, or \f$A' = P A Q^T\f$ if `invert` is
-     * `false`, and \f$A'(p[i], q[j]) = A(i,j)\f$, or \f$A' = P^{-1} A Q^{-T}\f$ if
-     * `invert` is `true`.
+     * Creates a non-symmetrically permuted copy \f$A'\f$ of this matrix \f$A\f$
+     * with the given row and column permutations \f$P\f$ and \f$Q\f$. The
+     * operation will compute \f$A'(i, j) = A(p[i], q[j])\f$, or \f$A' = P A
+     * Q^T\f$ if `invert` is `false`, and \f$A'(p[i], q[j]) = A(i,j)\f$, or
+     * \f$A' = P^{-1} A Q^{-T}\f$ if `invert` is `true`.
      *
      * @param row_permutation  The permutation \f$P\f$ to apply to the rows
-     * @param column_permutation  The permutation \f$Q\f$ to apply to the columns
+     * @param column_permutation  The permutation \f$Q\f$ to apply to the
+     * columns
      * @param invert  If set to `false`, uses the input permutations, otherwise
      *                uses their inverses \f$P^{-1}, Q^{-1}\f$
      * @return  The permuted matrix.
@@ -1141,7 +1142,8 @@ public:
      * reuse->update_values(matrix, permuted);
      * ```
      * @param row_permutation  The permutation \f$P\f$ to apply to the rows
-     * @param column_permutation  The permutation \f$Q\f$ to apply to the columns
+     * @param column_permutation  The permutation \f$Q\f$ to apply to the
+     * columns
      * @param invert  If set to `false`, uses the input permutations, otherwise
      *                uses their inverses \f$P^{-1}, Q^{-1}\f$
      * @return an std::pair consisting of the permuted matrix and the reuse info

--- a/include/ginkgo/core/matrix/dense.hpp
+++ b/include/ginkgo/core/matrix/dense.hpp
@@ -413,14 +413,14 @@ public:
     void fill(const ValueType value);
 
     /**
-     * Creates a permuted copy $A'$ of this matrix $A$ with the given
-     * permutation $P$. By default, this computes a symmetric permutation
+     * Creates a permuted copy \f$A'\f$ of this matrix \f$A\f$ with the given
+     * permutation \f$P\f$. By default, this computes a symmetric permutation
      * (permute_mode::symmetric). For the effect of the different permutation
      * modes, see @ref permute_mode.
      *
      * @param permutation  The input permutation.
      * @param mode  The permutation mode. If permute_mode::inverse is set, we
-     *              use the inverse permutation $P^{-1}$ instead of $P$.
+     *              use the inverse permutation \f$P^{-1}\f$ instead of \f$P\f$.
      *              If permute_mode::rows is set, the rows will be permuted.
      *              If permute_mode::columns is set, the columns will be
      *              permuted.
@@ -453,16 +453,16 @@ public:
                  ptr_param<Dense> output, permute_mode mode) const;
 
     /**
-     * Creates a non-symmetrically permuted copy $A'$ of this matrix $A$ with
-     * the given row and column permutations $P$ and $Q$. The operation will
-     * compute $A'(i, j) = A(p[i], q[j])$, or $A' = P A Q^T$ if `invert` is
-     * `false`, and $A'(p[i], q[j]) = A(i,j)$, or $A' = P^{-1} A Q^{-T}$ if
+     * Creates a non-symmetrically permuted copy \f$A'\f$ of this matrix \f$A\f$ with
+     * the given row and column permutations \f$P\f$ and \f$Q\f$. The operation will
+     * compute \f$A'(i, j) = A(p[i], q[j])\f$, or \f$A' = P A Q^T\f$ if `invert` is
+     * `false`, and \f$A'(p[i], q[j]) = A(i,j)\f$, or \f$A' = P^{-1} A Q^{-T}\f$ if
      * `invert` is `true`.
      *
-     * @param row_permutation  The permutation $P$ to apply to the rows
-     * @param column_permutation  The permutation $Q$ to apply to the columns
+     * @param row_permutation  The permutation \f$P\f$ to apply to the rows
+     * @param column_permutation  The permutation \f$Q\f$ to apply to the columns
      * @param invert  If set to `false`, uses the input permutations, otherwise
-     *                uses their inverses $P^{-1}, Q^{-1}$
+     *                uses their inverses \f$P^{-1}, Q^{-1}\f$
      * @return  The permuted matrix.
      */
     std::unique_ptr<Dense> permute(
@@ -545,7 +545,7 @@ public:
      * @param row_permutation  The scaled row permutation.
      * @param column_permutation  The scaled column permutation.
      * @param invert  If set to `false`, uses the input permutations, otherwise
-     *                uses their inverses $P^{-1}, Q^{-1}$
+     *                uses their inverses \f$P^{-1}, Q^{-1}\f$
      * @return The permuted matrix.
      */
     std::unique_ptr<Dense> scale_permute(

--- a/include/ginkgo/core/matrix/dense.hpp
+++ b/include/ginkgo/core/matrix/dense.hpp
@@ -453,14 +453,15 @@ public:
                  ptr_param<Dense> output, permute_mode mode) const;
 
     /**
-     * Creates a non-symmetrically permuted copy \f$A'\f$ of this matrix \f$A\f$ with
-     * the given row and column permutations \f$P\f$ and \f$Q\f$. The operation will
-     * compute \f$A'(i, j) = A(p[i], q[j])\f$, or \f$A' = P A Q^T\f$ if `invert` is
-     * `false`, and \f$A'(p[i], q[j]) = A(i,j)\f$, or \f$A' = P^{-1} A Q^{-T}\f$ if
-     * `invert` is `true`.
+     * Creates a non-symmetrically permuted copy \f$A'\f$ of this matrix \f$A\f$
+     * with the given row and column permutations \f$P\f$ and \f$Q\f$. The
+     * operation will compute \f$A'(i, j) = A(p[i], q[j])\f$, or \f$A' = P A
+     * Q^T\f$ if `invert` is `false`, and \f$A'(p[i], q[j]) = A(i,j)\f$, or
+     * \f$A' = P^{-1} A Q^{-T}\f$ if `invert` is `true`.
      *
      * @param row_permutation  The permutation \f$P\f$ to apply to the rows
-     * @param column_permutation  The permutation \f$Q\f$ to apply to the columns
+     * @param column_permutation  The permutation \f$Q\f$ to apply to the
+     * columns
      * @param invert  If set to `false`, uses the input permutations, otherwise
      *                uses their inverses \f$P^{-1}, Q^{-1}\f$
      * @return  The permuted matrix.

--- a/include/ginkgo/core/matrix/dense.hpp
+++ b/include/ginkgo/core/matrix/dense.hpp
@@ -419,11 +419,7 @@ public:
      * modes, see @ref permute_mode.
      *
      * @param permutation  The input permutation.
-     * @param mode  The permutation mode. If permute_mode::inverse is set, we
-     *              use the inverse permutation \f$P^{-1}\f$ instead of \f$P\f$.
-     *              If permute_mode::rows is set, the rows will be permuted.
-     *              If permute_mode::columns is set, the columns will be
-     *              permuted.
+     * @param mode  The permutation mode, see @ref permute_mode.
      * @return  The permuted matrix.
      */
     std::unique_ptr<Dense> permute(

--- a/include/ginkgo/core/matrix/dense.hpp
+++ b/include/ginkgo/core/matrix/dense.hpp
@@ -452,14 +452,15 @@ public:
                  ptr_param<Dense> output, permute_mode mode) const;
 
     /**
-     * Creates a non-symmetrically permuted copy \f$A'\f$ of this matrix \f$A\f$ with
-     * the given row and column permutations \f$P\f$ and \f$Q\f$. The operation will
-     * compute \f$A'(i, j) = A(p[i], q[j])\f$, or \f$A' = P A Q^T\f$ if `invert` is
-     * `false`, and \f$A'(p[i], q[j]) = A(i,j)\f$, or \f$A' = P^{-1} A Q^{-T}\f$ if
-     * `invert` is `true`.
+     * Creates a non-symmetrically permuted copy \f$A'\f$ of this matrix \f$A\f$
+     * with the given row and column permutations \f$P\f$ and \f$Q\f$. The
+     * operation will compute \f$A'(i, j) = A(p[i], q[j])\f$, or \f$A' = P A
+     * Q^T\f$ if `invert` is `false`, and \f$A'(p[i], q[j]) = A(i,j)\f$, or
+     * \f$A' = P^{-1} A Q^{-T}\f$ if `invert` is `true`.
      *
      * @param row_permutation  The permutation \f$P\f$ to apply to the rows
-     * @param column_permutation  The permutation \f$Q\f$ to apply to the columns
+     * @param column_permutation  The permutation \f$Q\f$ to apply to the
+     * columns
      * @param invert  If set to `false`, uses the input permutations, otherwise
      *                uses their inverses \f$P^{-1}, Q^{-1}\f$
      * @return  The permuted matrix.

--- a/include/ginkgo/core/matrix/dense.hpp
+++ b/include/ginkgo/core/matrix/dense.hpp
@@ -412,14 +412,14 @@ public:
     void fill(const ValueType value);
 
     /**
-     * Creates a permuted copy $A'$ of this matrix $A$ with the given
-     * permutation $P$. By default, this computes a symmetric permutation
+     * Creates a permuted copy \f$A'\f$ of this matrix \f$A\f$ with the given
+     * permutation \f$P\f$. By default, this computes a symmetric permutation
      * (permute_mode::symmetric). For the effect of the different permutation
      * modes, see @ref permute_mode.
      *
      * @param permutation  The input permutation.
      * @param mode  The permutation mode. If permute_mode::inverse is set, we
-     *              use the inverse permutation $P^{-1}$ instead of $P$.
+     *              use the inverse permutation \f$P^{-1}\f$ instead of \f$P\f$.
      *              If permute_mode::rows is set, the rows will be permuted.
      *              If permute_mode::columns is set, the columns will be
      *              permuted.
@@ -452,16 +452,16 @@ public:
                  ptr_param<Dense> output, permute_mode mode) const;
 
     /**
-     * Creates a non-symmetrically permuted copy $A'$ of this matrix $A$ with
-     * the given row and column permutations $P$ and $Q$. The operation will
-     * compute $A'(i, j) = A(p[i], q[j])$, or $A' = P A Q^T$ if `invert` is
-     * `false`, and $A'(p[i], q[j]) = A(i,j)$, or $A' = P^{-1} A Q^{-T}$ if
+     * Creates a non-symmetrically permuted copy \f$A'\f$ of this matrix \f$A\f$ with
+     * the given row and column permutations \f$P\f$ and \f$Q\f$. The operation will
+     * compute \f$A'(i, j) = A(p[i], q[j])\f$, or \f$A' = P A Q^T\f$ if `invert` is
+     * `false`, and \f$A'(p[i], q[j]) = A(i,j)\f$, or \f$A' = P^{-1} A Q^{-T}\f$ if
      * `invert` is `true`.
      *
-     * @param row_permutation  The permutation $P$ to apply to the rows
-     * @param column_permutation  The permutation $Q$ to apply to the columns
+     * @param row_permutation  The permutation \f$P\f$ to apply to the rows
+     * @param column_permutation  The permutation \f$Q\f$ to apply to the columns
      * @param invert  If set to `false`, uses the input permutations, otherwise
-     *                uses their inverses $P^{-1}, Q^{-1}$
+     *                uses their inverses \f$P^{-1}, Q^{-1}\f$
      * @return  The permuted matrix.
      */
     std::unique_ptr<Dense> permute(
@@ -544,7 +544,7 @@ public:
      * @param row_permutation  The scaled row permutation.
      * @param column_permutation  The scaled column permutation.
      * @param invert  If set to `false`, uses the input permutations, otherwise
-     *                uses their inverses $P^{-1}, Q^{-1}$
+     *                uses their inverses \f$P^{-1}, Q^{-1}\f$
      * @return The permuted matrix.
      */
     std::unique_ptr<Dense> scale_permute(

--- a/include/ginkgo/core/matrix/fft.hpp
+++ b/include/ginkgo/core/matrix/fft.hpp
@@ -20,8 +20,8 @@ namespace matrix {
  * It implements forward and inverse DFT.
  *
  * For a power-of-two size n with corresponding root of unity
- * \f$\omega = e^{-2\pi i / n}\f$ for forward DFT and \f$\omega = e^{2 \pi i / n}\f$
- * for inverse DFT it computes
+ * \f$\omega = e^{-2\pi i / n}\f$ for forward DFT and \f$\omega = e^{2 \pi i /
+ * n}\f$ for inverse DFT it computes
  *
  * \f[
  *     x_k = \sum_{j=0}^{n-1} \omega^{jk} b_j

--- a/include/ginkgo/core/matrix/fft.hpp
+++ b/include/ginkgo/core/matrix/fft.hpp
@@ -20,7 +20,7 @@ namespace matrix {
  * It implements forward and inverse DFT.
  *
  * For a power-of-two size n with corresponding root of unity
- * $\omega = e^{-2\pi i / n}$ for forward DFT and $\omega = e^{2 \pi i / n}$
+ * \f$\omega = e^{-2\pi i / n}\f$ for forward DFT and \f$\omega = e^{2 \pi i / n}\f$
  * for inverse DFT it computes
  *
  * \f[
@@ -117,9 +117,9 @@ private:
  *
  * It implements complex-to-complex forward and inverse FFT.
  *
- * For a power-of-two sizes $n_1, n_2$ with corresponding root of unity
- * $\omega = e^{-2\pi i / (n_1 n_2)}$ for forward DFT and
- * $\omega = e^{2 \pi i / (n_1 n_2)}$ for inverse DFT it computes
+ * For a power-of-two sizes \f$n_1, n_2\f$ with corresponding root of unity
+ * \f$\omega = e^{-2\pi i / (n_1 n_2)}\f$ for forward DFT and
+ * \f$\omega = e^{2 \pi i / (n_1 n_2)}\f$ for inverse DFT it computes
  *
  * \f[
  *     x_{k_1 n_2 + k_2} = \sum_{i_1=0}^{n_1-1} \sum_{i_2=0}^{n_2-1}
@@ -228,9 +228,9 @@ private:
  *
  * It implements complex-to-complex forward and inverse FFT.
  *
- * For a power-of-two sizes $n_1, n_2, n_3$ with corresponding root of unity
- * $\omega = e^{-2\pi i / (n_1 n_2 n_3)}$ for forward DFT and
- * $\omega = e^{2 \pi i / (n_1 n_2 n_3)}$ for inverse DFT it computes
+ * For a power-of-two sizes \f$n_1, n_2, n_3\f$ with corresponding root of unity
+ * \f$\omega = e^{-2\pi i / (n_1 n_2 n_3)}\f$ for forward DFT and
+ * \f$\omega = e^{2 \pi i / (n_1 n_2 n_3)}\f$ for inverse DFT it computes
  *
  * \f[
  *     x_{k_1 n_2 n_3 + k_2 n_3 + k_3} = \sum_{i_1=0}^{n_1-1}

--- a/include/ginkgo/core/matrix/fft.hpp
+++ b/include/ginkgo/core/matrix/fft.hpp
@@ -33,7 +33,7 @@ namespace matrix {
  * sizes, as they use the Radix-2 algorithm by J. W. Cooley and J. W. Tukey,
  * "An Algorithm for the Machine Calculation of Complex Fourier Series,"
  * Mathematics of Computation, vol. 19, no. 90, pp. 297–301, 1965,
- * doi: 10.2307/2003354.
+ * <https://doi.org/10.2307/2003354>.
  * The CUDA and HIP implementations use cuSPARSE/hipSPARSE with full support for
  * non-power-of-two input sizes and special optimizations for products of
  * small prime powers.
@@ -132,7 +132,7 @@ private:
  * sizes, as they use the Radix-2 algorithm by J. W. Cooley and J. W. Tukey,
  * "An Algorithm for the Machine Calculation of Complex Fourier Series,"
  * Mathematics of Computation, vol. 19, no. 90, pp. 297–301, 1965,
- * doi: 10.2307/2003354.
+ * <https://doi.org/10.2307/2003354>.
  * The CUDA and HIP implementations use cuSPARSE/hipSPARSE with full support for
  * non-power-of-two input sizes and special optimizations for products of
  * small prime powers.
@@ -245,7 +245,7 @@ private:
  * sizes, as they use the Radix-2 algorithm by J. W. Cooley and J. W. Tukey,
  * "An Algorithm for the Machine Calculation of Complex Fourier Series,"
  * Mathematics of Computation, vol. 19, no. 90, pp. 297–301, 1965,
- * doi: 10.2307/2003354.
+ * <https://doi.org/10.2307/2003354>.
  * The CUDA and HIP implementations use cuSPARSE/hipSPARSE with full support for
  * non-power-of-two input sizes and special optimizations for products of
  * small prime powers.

--- a/include/ginkgo/core/matrix/fft.hpp
+++ b/include/ginkgo/core/matrix/fft.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -20,8 +20,8 @@ namespace matrix {
  * It implements forward and inverse DFT.
  *
  * For a power-of-two size n with corresponding root of unity
- * \f$\omega = e^{-2\pi i / n}\f$ for forward DFT and \f$\omega = e^{2 \pi i / n}\f$
- * for inverse DFT it computes
+ * \f$\omega = e^{-2\pi i / n}\f$ for forward DFT and \f$\omega = e^{2 \pi i /
+ * n}\f$ for inverse DFT it computes
  *
  * \f[
  *     x_k = \sum_{j=0}^{n-1} \omega^{jk} b_j

--- a/include/ginkgo/core/matrix/fft.hpp
+++ b/include/ginkgo/core/matrix/fft.hpp
@@ -20,7 +20,7 @@ namespace matrix {
  * It implements forward and inverse DFT.
  *
  * For a power-of-two size n with corresponding root of unity
- * $\omega = e^{-2\pi i / n}$ for forward DFT and $\omega = e^{2 \pi i / n}$
+ * \f$\omega = e^{-2\pi i / n}\f$ for forward DFT and \f$\omega = e^{2 \pi i / n}\f$
  * for inverse DFT it computes
  *
  * \f[
@@ -116,9 +116,9 @@ private:
  *
  * It implements complex-to-complex forward and inverse FFT.
  *
- * For a power-of-two sizes $n_1, n_2$ with corresponding root of unity
- * $\omega = e^{-2\pi i / (n_1 n_2)}$ for forward DFT and
- * $\omega = e^{2 \pi i / (n_1 n_2)}$ for inverse DFT it computes
+ * For a power-of-two sizes \f$n_1, n_2\f$ with corresponding root of unity
+ * \f$\omega = e^{-2\pi i / (n_1 n_2)}\f$ for forward DFT and
+ * \f$\omega = e^{2 \pi i / (n_1 n_2)}\f$ for inverse DFT it computes
  *
  * \f[
  *     x_{k_1 n_2 + k_2} = \sum_{i_1=0}^{n_1-1} \sum_{i_2=0}^{n_2-1}
@@ -226,9 +226,9 @@ private:
  *
  * It implements complex-to-complex forward and inverse FFT.
  *
- * For a power-of-two sizes $n_1, n_2, n_3$ with corresponding root of unity
- * $\omega = e^{-2\pi i / (n_1 n_2 n_3)}$ for forward DFT and
- * $\omega = e^{2 \pi i / (n_1 n_2 n_3)}$ for inverse DFT it computes
+ * For a power-of-two sizes \f$n_1, n_2, n_3\f$ with corresponding root of unity
+ * \f$\omega = e^{-2\pi i / (n_1 n_2 n_3)}\f$ for forward DFT and
+ * \f$\omega = e^{2 \pi i / (n_1 n_2 n_3)}\f$ for inverse DFT it computes
  *
  * \f[
  *     x_{k_1 n_2 n_3 + k_2 n_3 + k_3} = \sum_{i_1=0}^{n_1-1}

--- a/include/ginkgo/core/matrix/permutation.hpp
+++ b/include/ginkgo/core/matrix/permutation.hpp
@@ -29,16 +29,15 @@ namespace matrix {
  * For the effect of the different permutation
  * modes, see the following table.
  *
- * mode              | entry mapping              | matrix representation
- * ------------------|----------------------------|----------------------
- * none              | \f$A'(i, j) = A(i, j)\f$       | \f$A' = A\f$
- * rows              | \f$A'(i, j) = A(p[i], j)\f$    | \f$A' = P A\f$
- * columns           | \f$A'(i, j) = A(i, p[j])\f$    | \f$A' = A P^T\f$
- * inverse_rows      | \f$A'(p[i], j) = A(i, j)\f$    | \f$A' = P^{-1} A\f$
- * inverse_columns   | \f$A'(i, p[j]) = A(i, j)\f$    | \f$A' = A P^{-T}\f$
- * symmetric         | \f$A'(i, j) = A(p[i], p[j])\f$ | \f$A' = P A P^T\f$
- * inverse_symmetric | \f$A'(p[i], p[j]) = A(i, j)\f$ | \f$A' = P^{-1} A
- * P^{-T}\f$
+ * mode              | entry mapping                | matrix representation
+ * ------------------|------------------------------|----------------------
+ * none              | \f$A'(i,j) = A(i,j)\f$       | \f$A' = A\f$
+ * rows              | \f$A'(i,j) = A(p[i],j)\f$    | \f$A' = P A\f$
+ * columns           | \f$A'(i,j) = A(i,p[j])\f$    | \f$A' = A P^T\f$
+ * inverse_rows      | \f$A'(p[i],j) = A(i,j)\f$    | \f$A' = P^{-1} A\f$
+ * inverse_columns   | \f$A'(i,p[j]) = A(i,j)\f$    | \f$A' = A P^{-T}\f$
+ * symmetric         | \f$A'(i,j) = A(p[i],p[j])\f$ | \f$A' = P A P^T\f$
+ * inverse_symmetric | \f$A'(p[i],p[j]) = A(i,j)\f$ | \f$A' = P^{-1} A P^{-T}\f$
  */
 enum class permute_mode : unsigned {
     /** Neither rows nor columns will be permuted. */

--- a/include/ginkgo/core/matrix/permutation.hpp
+++ b/include/ginkgo/core/matrix/permutation.hpp
@@ -37,7 +37,8 @@ namespace matrix {
  * inverse_rows      | \f$A'(p[i], j) = A(i, j)\f$    | \f$A' = P^{-1} A\f$
  * inverse_columns   | \f$A'(i, p[j]) = A(i, j)\f$    | \f$A' = A P^{-T}\f$
  * symmetric         | \f$A'(i, j) = A(p[i], p[j])\f$ | \f$A' = P A P^T\f$
- * inverse_symmetric | \f$A'(p[i], p[j]) = A(i, j)\f$ | \f$A' = P^{-1} A P^{-T}\f$
+ * inverse_symmetric | \f$A'(p[i], p[j]) = A(i, j)\f$ | \f$A' = P^{-1} A
+ * P^{-T}\f$
  */
 enum class permute_mode : unsigned {
     /** Neither rows nor columns will be permuted. */
@@ -166,8 +167,9 @@ public:
      * The resulting permutation fulfills `result[i] = this[other[i]]`
      * or `result = other * this` from the matrix perspective, which is
      * equivalent to first permuting by `this` and then by `other`:
-     * Combining permutations \f$P_1\f$ and \f$P_2\f$ with `P = P_1.combine(P_2)`
-     * performs the operation permute(A, P) = permute(permute(A, P_1), P_2).
+     * Combining permutations \f$P_1\f$ and \f$P_2\f$ with `P =
+     * P_1.combine(P_2)` performs the operation permute(A, P) =
+     * permute(permute(A, P_1), P_2).
      *
      * @param other  the other permutation
      * @return the combined permutation

--- a/include/ginkgo/core/matrix/permutation.hpp
+++ b/include/ginkgo/core/matrix/permutation.hpp
@@ -31,13 +31,13 @@ namespace matrix {
  *
  * mode              | entry mapping              | matrix representation
  * ------------------|----------------------------|----------------------
- * none              | $A'(i, j) = A(i, j)$       | $A' = A$
- * rows              | $A'(i, j) = A(p[i], j)$    | $A' = P A$
- * columns           | $A'(i, j) = A(i, p[j])$    | $A' = A P^T$
- * inverse_rows      | $A'(p[i], j) = A(i, j)$    | $A' = P^{-1} A$
- * inverse_columns   | $A'(i, p[j]) = A(i, j)$    | $A' = A P^{-T}$
- * symmetric         | $A'(i, j) = A(p[i], p[j])$ | $A' = P A P^T$
- * inverse_symmetric | $A'(p[i], p[j]) = A(i, j)$ | $A' = P^{-1} A P^{-T}$
+ * none              | \f$A'(i, j) = A(i, j)\f$       | \f$A' = A\f$
+ * rows              | \f$A'(i, j) = A(p[i], j)\f$    | \f$A' = P A\f$
+ * columns           | \f$A'(i, j) = A(i, p[j])\f$    | \f$A' = A P^T\f$
+ * inverse_rows      | \f$A'(p[i], j) = A(i, j)\f$    | \f$A' = P^{-1} A\f$
+ * inverse_columns   | \f$A'(i, p[j]) = A(i, j)\f$    | \f$A' = A P^{-T}\f$
+ * symmetric         | \f$A'(i, j) = A(p[i], p[j])\f$ | \f$A' = P A P^T\f$
+ * inverse_symmetric | \f$A'(p[i], p[j]) = A(i, j)\f$ | \f$A' = P^{-1} A P^{-T}\f$
  */
 enum class permute_mode : unsigned {
     /** Neither rows nor columns will be permuted. */
@@ -99,7 +99,7 @@ static constexpr mask_type inverse_permute = mask_type{1 << 3};
  * Permutation is a matrix format that represents a permutation matrix,
  * i.e. a matrix where each row and column has exactly one entry.
  * The matrix can only be applied to Dense inputs, where it represents
- * a row permutation: $A' = PA$ means $A'(i, j) = A(p[i], j)$.
+ * a row permutation: \f$A' = PA\f$ means \f$A'(i, j) = A(p[i], j)\f$.
  *
  * @tparam IndexType  precision of permutation array indices.
  *
@@ -166,7 +166,7 @@ public:
      * The resulting permutation fulfills `result[i] = this[other[i]]`
      * or `result = other * this` from the matrix perspective, which is
      * equivalent to first permuting by `this` and then by `other`:
-     * Combining permutations $P_1$ and $P_2$ with `P = P_1.combine(P_2)`
+     * Combining permutations \f$P_1\f$ and \f$P_2\f$ with `P = P_1.combine(P_2)`
      * performs the operation permute(A, P) = permute(permute(A, P_1), P_2).
      *
      * @param other  the other permutation

--- a/include/ginkgo/core/matrix/permutation.hpp
+++ b/include/ginkgo/core/matrix/permutation.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -37,7 +37,8 @@ namespace matrix {
  * inverse_rows      | \f$A'(p[i], j) = A(i, j)\f$    | \f$A' = P^{-1} A\f$
  * inverse_columns   | \f$A'(i, p[j]) = A(i, j)\f$    | \f$A' = A P^{-T}\f$
  * symmetric         | \f$A'(i, j) = A(p[i], p[j])\f$ | \f$A' = P A P^T\f$
- * inverse_symmetric | \f$A'(p[i], p[j]) = A(i, j)\f$ | \f$A' = P^{-1} A P^{-T}\f$
+ * inverse_symmetric | \f$A'(p[i], p[j]) = A(i, j)\f$ | \f$A' = P^{-1} A
+ * P^{-T}\f$
  */
 enum class permute_mode : unsigned {
     /** Neither rows nor columns will be permuted. */
@@ -165,8 +166,9 @@ public:
      * The resulting permutation fulfills `result[i] = this[other[i]]`
      * or `result = other * this` from the matrix perspective, which is
      * equivalent to first permuting by `this` and then by `other`:
-     * Combining permutations \f$P_1\f$ and \f$P_2\f$ with `P = P_1.combine(P_2)`
-     * performs the operation permute(A, P) = permute(permute(A, P_1), P_2).
+     * Combining permutations \f$P_1\f$ and \f$P_2\f$ with `P =
+     * P_1.combine(P_2)` performs the operation permute(A, P) =
+     * permute(permute(A, P_1), P_2).
      *
      * @param other  the other permutation
      * @return the combined permutation

--- a/include/ginkgo/core/matrix/permutation.hpp
+++ b/include/ginkgo/core/matrix/permutation.hpp
@@ -31,13 +31,13 @@ namespace matrix {
  *
  * mode              | entry mapping              | matrix representation
  * ------------------|----------------------------|----------------------
- * none              | $A'(i, j) = A(i, j)$       | $A' = A$
- * rows              | $A'(i, j) = A(p[i], j)$    | $A' = P A$
- * columns           | $A'(i, j) = A(i, p[j])$    | $A' = A P^T$
- * inverse_rows      | $A'(p[i], j) = A(i, j)$    | $A' = P^{-1} A$
- * inverse_columns   | $A'(i, p[j]) = A(i, j)$    | $A' = A P^{-T}$
- * symmetric         | $A'(i, j) = A(p[i], p[j])$ | $A' = P A P^T$
- * inverse_symmetric | $A'(p[i], p[j]) = A(i, j)$ | $A' = P^{-1} A P^{-T}$
+ * none              | \f$A'(i, j) = A(i, j)\f$       | \f$A' = A\f$
+ * rows              | \f$A'(i, j) = A(p[i], j)\f$    | \f$A' = P A\f$
+ * columns           | \f$A'(i, j) = A(i, p[j])\f$    | \f$A' = A P^T\f$
+ * inverse_rows      | \f$A'(p[i], j) = A(i, j)\f$    | \f$A' = P^{-1} A\f$
+ * inverse_columns   | \f$A'(i, p[j]) = A(i, j)\f$    | \f$A' = A P^{-T}\f$
+ * symmetric         | \f$A'(i, j) = A(p[i], p[j])\f$ | \f$A' = P A P^T\f$
+ * inverse_symmetric | \f$A'(p[i], p[j]) = A(i, j)\f$ | \f$A' = P^{-1} A P^{-T}\f$
  */
 enum class permute_mode : unsigned {
     /** Neither rows nor columns will be permuted. */
@@ -99,7 +99,7 @@ static constexpr mask_type inverse_permute = mask_type{1 << 3};
  * Permutation is a matrix format that represents a permutation matrix,
  * i.e. a matrix where each row and column has exactly one entry.
  * The matrix can only be applied to Dense inputs, where it represents
- * a row permutation: $A' = PA$ means $A'(i, j) = A(p[i], j)$.
+ * a row permutation: \f$A' = PA\f$ means \f$A'(i, j) = A(p[i], j)\f$.
  *
  * @tparam IndexType  precision of permutation array indices.
  *
@@ -165,7 +165,7 @@ public:
      * The resulting permutation fulfills `result[i] = this[other[i]]`
      * or `result = other * this` from the matrix perspective, which is
      * equivalent to first permuting by `this` and then by `other`:
-     * Combining permutations $P_1$ and $P_2$ with `P = P_1.combine(P_2)`
+     * Combining permutations \f$P_1\f$ and \f$P_2\f$ with `P = P_1.combine(P_2)`
      * performs the operation permute(A, P) = permute(permute(A, P_1), P_2).
      *
      * @param other  the other permutation

--- a/include/ginkgo/core/matrix/scaled_permutation.hpp
+++ b/include/ginkgo/core/matrix/scaled_permutation.hpp
@@ -23,7 +23,7 @@ namespace matrix {
 /**
  * ScaledPermutation is a matrix combining a permutation with scaling factors.
  * It is a combination of Diagonal and Permutation, and can be read as
- * $SP = P \cdot S$, i.e. the scaling gets applied before the permutation.
+ * \f$SP = P \cdot S\f$, i.e. the scaling gets applied before the permutation.
  *
  * @tparam IndexType  index type of permutation indices
  * @tparam ValueType  value type of the scaling factors

--- a/include/ginkgo/core/matrix/scaled_permutation.hpp
+++ b/include/ginkgo/core/matrix/scaled_permutation.hpp
@@ -84,7 +84,7 @@ public:
 
     /**
      * Returns the inverse of this operator as a scaled permutation.
-     * It is computed via $(P S)^-1 = P^{-1} (P S P^{-1})$.
+     * It is computed via \f$(P S)^-1 = P^{-1} (P S P^{-1})\f$.
      *
      * @return a newly created ScaledPermutation object storing the inverse
      *         of the permutation and scaling factors of this

--- a/include/ginkgo/core/matrix/scaled_permutation.hpp
+++ b/include/ginkgo/core/matrix/scaled_permutation.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 

--- a/include/ginkgo/core/matrix/scaled_permutation.hpp
+++ b/include/ginkgo/core/matrix/scaled_permutation.hpp
@@ -83,7 +83,7 @@ public:
 
     /**
      * Returns the inverse of this operator as a scaled permutation.
-     * It is computed via $(P S)^-1 = P^{-1} (P S P^{-1})$.
+     * It is computed via \f$(P S)^-1 = P^{-1} (P S P^{-1})\f$.
      *
      * @return a newly created ScaledPermutation object storing the inverse
      *         of the permutation and scaling factors of this

--- a/include/ginkgo/core/preconditioner/batch_jacobi.hpp
+++ b/include/ginkgo/core/preconditioner/batch_jacobi.hpp
@@ -109,12 +109,17 @@ public:
     /**
      * Returns the pointer to the memory used for storing the block data.
      *
-     * Element (`i`, `j`) of the block, which belongs to the batch entry with
-     * index = "batch_id" and has local id = "block_id" within its batch entry
-     * is stored at the address = get_const_blocks() +
-     * detail::get_global_block_offset(batch_id, num_blocks, block_id,
-     * cumulative_blocks_storage) + i * detail::get_stride(block_id,
-     * block_pointers) + j
+     * Element \f$(i, j)\f$ of the block that belongs to batch entry
+     * `batch_id` and has local id `block_id` within that entry is stored
+     * at the address
+     *
+     * ```cpp
+     * get_const_blocks()
+     *     + detail::get_global_block_offset(batch_id, num_blocks, block_id,
+     *                                       cumulative_blocks_storage)
+     *     + i * detail::get_stride(block_id, block_pointers)
+     *     + j
+     * ```
      *
      * @note Returns nullptr in case of a scalar jacobi preconditioner
      *       (max_block_size = 1).

--- a/include/ginkgo/core/preconditioner/batch_jacobi.hpp
+++ b/include/ginkgo/core/preconditioner/batch_jacobi.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -112,12 +112,17 @@ public:
     /**
      * Returns the pointer to the memory used for storing the block data.
      *
-     * Element (`i`, `j`) of the block, which belongs to the batch entry with
-     * index = "batch_id" and has local id = "block_id" within its batch entry
-     * is stored at the address = get_const_blocks() +
-     * detail::get_global_block_offset(batch_id, num_blocks, block_id,
-     * cumulative_blocks_storage) + i * detail::get_stride(block_id,
-     * block_pointers) + j
+     * Element \f$(i, j)\f$ of the block that belongs to batch entry
+     * `batch_id` and has local id `block_id` within that entry is stored
+     * at the address
+     *
+     * ```cpp
+     * get_const_blocks()
+     *     + detail::get_global_block_offset(batch_id, num_blocks, block_id,
+     *                                       cumulative_blocks_storage)
+     *     + i * detail::get_stride(block_id, block_pointers)
+     *     + j
+     * ```
      *
      * @note Returns nullptr in case of a scalar jacobi preconditioner
      *       (max_block_size = 1).

--- a/include/ginkgo/core/preconditioner/gauss_seidel.hpp
+++ b/include/ginkgo/core/preconditioner/gauss_seidel.hpp
@@ -22,7 +22,7 @@ namespace preconditioner {
 /**
  * This class generates the Gauss-Seidel preconditioner.
  *
- * This is the special case of the relaxation factor $\omega = 1$ of the (S)SOR
+ * This is the special case of the relaxation factor \f$\omega = 1\f$ of the (S)SOR
  * preconditioner.
  *
  * @see Sor

--- a/include/ginkgo/core/preconditioner/gauss_seidel.hpp
+++ b/include/ginkgo/core/preconditioner/gauss_seidel.hpp
@@ -22,8 +22,8 @@ namespace preconditioner {
 /**
  * This class generates the Gauss-Seidel preconditioner.
  *
- * This is the special case of the relaxation factor \f$\omega = 1\f$ of the (S)SOR
- * preconditioner.
+ * This is the special case of the relaxation factor \f$\omega = 1\f$ of the
+ * (S)SOR preconditioner.
  *
  * @see Sor
  *

--- a/include/ginkgo/core/preconditioner/gauss_seidel.hpp
+++ b/include/ginkgo/core/preconditioner/gauss_seidel.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -22,8 +22,8 @@ namespace preconditioner {
 /**
  * This class generates the Gauss-Seidel preconditioner.
  *
- * This is the special case of the relaxation factor \f$\omega = 1\f$ of the (S)SOR
- * preconditioner.
+ * This is the special case of the relaxation factor \f$\omega = 1\f$ of the
+ * (S)SOR preconditioner.
  *
  * @see Sor
  *

--- a/include/ginkgo/core/preconditioner/ic.hpp
+++ b/include/ginkgo/core/preconditioner/ic.hpp
@@ -32,9 +32,9 @@ namespace preconditioner {
 
 
 /**
- * The Incomplete Cholesky (IC) preconditioner solves the equation \f$LL^H*x = b\f$
- * for a given lower triangular matrix L and the right hand side b (can contain
- * multiple right hand sides).
+ * The Incomplete Cholesky (IC) preconditioner solves the equation \f$LL^H*x =
+ * b\f$ for a given lower triangular matrix L and the right hand side b (can
+ * contain multiple right hand sides).
  *
  * It allows setting the solver for L, defaulting to solver::LowerTrs, which is
  * a direct triangular solvers. The solver for L^H is the
@@ -54,7 +54,8 @@ namespace preconditioner {
  *
  * @note When providing a gko::Composition, the first matrix must be the lower
  *       matrix (\f$L\f$), and the second matrix must be its conjugate-transpose
- * (\f$L^H\f$). If they are swapped, solving might crash or return the wrong result.
+ * (\f$L^H\f$). If they are swapped, solving might crash or return the wrong
+ * result.
  *
  * @note Do not use symmetric solvers (like CG) for the L solver since both
  *       matrices (L and L^H) are, by design, not symmetric.

--- a/include/ginkgo/core/preconditioner/ic.hpp
+++ b/include/ginkgo/core/preconditioner/ic.hpp
@@ -53,9 +53,9 @@ namespace preconditioner {
  * orders the factors in the correct way.
  *
  * @note When providing a gko::Composition, the first matrix must be the lower
- *       matrix (\f$L\f$), and the second matrix must be its conjugate-transpose
- * (\f$L^H\f$). If they are swapped, solving might crash or return the wrong
- * result.
+ *       matrix (\f$L\f$), and the second matrix must be its
+ *       conjugate-transpose (\f$L^H\f$). If they are swapped, solving might
+ *       crash or return the wrong result.
  *
  * @note Do not use symmetric solvers (like CG) for the L solver since both
  *       matrices (L and L^H) are, by design, not symmetric.

--- a/include/ginkgo/core/preconditioner/ic.hpp
+++ b/include/ginkgo/core/preconditioner/ic.hpp
@@ -32,7 +32,7 @@ namespace preconditioner {
 
 
 /**
- * The Incomplete Cholesky (IC) preconditioner solves the equation $LL^H*x = b$
+ * The Incomplete Cholesky (IC) preconditioner solves the equation \f$LL^H*x = b\f$
  * for a given lower triangular matrix L and the right hand side b (can contain
  * multiple right hand sides).
  *
@@ -53,8 +53,8 @@ namespace preconditioner {
  * orders the factors in the correct way.
  *
  * @note When providing a gko::Composition, the first matrix must be the lower
- *       matrix ($L$), and the second matrix must be its conjugate-transpose
- * ($L^H$). If they are swapped, solving might crash or return the wrong result.
+ *       matrix (\f$L\f$), and the second matrix must be its conjugate-transpose
+ * (\f$L^H\f$). If they are swapped, solving might crash or return the wrong result.
  *
  * @note Do not use symmetric solvers (like CG) for the L solver since both
  *       matrices (L and L^H) are, by design, not symmetric.

--- a/include/ginkgo/core/preconditioner/ic.hpp
+++ b/include/ginkgo/core/preconditioner/ic.hpp
@@ -32,33 +32,34 @@ namespace preconditioner {
 
 
 /**
- * The Incomplete Cholesky (IC) preconditioner solves the equation \f$LL^H*x =
- * b\f$ for a given lower triangular matrix L and the right hand side b (can
- * contain multiple right hand sides).
+ * The Incomplete Cholesky (IC) preconditioner solves the equation
+ * \f$L L^H x = b\f$ for a given lower triangular matrix \f$L\f$ and the
+ * right hand side \f$b\f$ (can contain multiple right hand sides).
  *
- * It allows setting the solver for L, defaulting to solver::LowerTrs, which is
- * a direct triangular solvers. The solver for L^H is the
- * conjugate-transposed solver for L, ensuring that the preconditioner is
- * symmetric and positive-definite. For this L solver, a factory can be provided
- * (using `with_l_solver`) to have more control over their behavior. In
- * particular, it is possible to use an iterative method for solving the
- * triangular systems.
+ * It allows setting the solver for \f$L\f$, defaulting to solver::LowerTrs,
+ * which is a direct triangular solver. The solver for \f$L^H\f$ is the
+ * conjugate-transposed solver for \f$L\f$, ensuring that the preconditioner
+ * is symmetric and positive-definite. For this \f$L\f$ solver, a factory can
+ * be provided (using `with_l_solver`) to have more control over their
+ * behavior. In particular, it is possible to use an iterative method for
+ * solving the triangular systems.
  *
  * An object of this class can be created with a matrix or a gko::Composition
  * containing two matrices. If created with a matrix, it is factorized before
  * creating the solver. If a gko::Composition (containing two matrices) is
- * used, the first operand will be taken as the L matrix, the second will be
- * considered the L^H matrix, which helps to avoid the otherwise necessary
- * transposition of L inside the solver. ParIc can be directly used, since it
- * orders the factors in the correct way.
+ * used, the first operand will be taken as the \f$L\f$ matrix, the second
+ * will be considered the \f$L^H\f$ matrix, which helps to avoid the
+ * otherwise necessary transposition of \f$L\f$ inside the solver. ParIc can
+ * be directly used, since it orders the factors in the correct way.
  *
  * @note When providing a gko::Composition, the first matrix must be the lower
  *       matrix (\f$L\f$), and the second matrix must be its
  *       conjugate-transpose (\f$L^H\f$). If they are swapped, solving might
  *       crash or return the wrong result.
  *
- * @note Do not use symmetric solvers (like CG) for the L solver since both
- *       matrices (L and L^H) are, by design, not symmetric.
+ * @note Do not use symmetric solvers (like CG) for the \f$L\f$ solver since
+ *       both matrices (\f$L\f$ and \f$L^H\f$) are, by design, not
+ *       symmetric.
  *
  * @note This class is not thread safe (even a const object is not) because it
  *       uses an internal cache to accelerate multiple (sequential) applies.
@@ -69,9 +70,10 @@ namespace preconditioner {
  *       <LowerTrs, IndexType>. Only the variants with ValueType are supported
  *       in parse.
  *
- * @tparam ValueType  the value type used for the L matrix.
+ * @tparam ValueType  the value type used for the \f$L\f$ matrix.
  * @tparam IndexType  type of the indices when ParIc is used to generate
- *                    the L and L^H factors. Irrelevant otherwise.
+ *                    the \f$L\f$ and \f$L^H\f$ factors. Irrelevant
+ *                    otherwise.
  *
  * @ingroup precond
  * @ingroup LinOp
@@ -88,7 +90,7 @@ public:
     struct parameters_type
         : public enable_parameters_type<parameters_type, Factory> {
         /**
-         * Factory for the L solver
+         * Factory for the \f$L\f$ solver
          */
         std::shared_ptr<const LinOpFactory> l_solver_factory{};
 
@@ -163,16 +165,16 @@ public:
             config::make_type_descriptor<value_type, index_type>());
 
     /**
-     * Returns the solver which is used for the provided L matrix.
+     * Returns the solver which is used for the provided \f$L\f$ matrix.
      *
-     * @returns  the solver which is used for the provided L matrix
+     * @returns  the solver which is used for the provided \f$L\f$ matrix
      */
     std::shared_ptr<const LinOp> get_l_solver() const { return l_solver_; }
 
     /**
-     * Returns the solver which is used for the L^H matrix.
+     * Returns the solver which is used for the \f$L^H\f$ matrix.
      *
-     * @returns  the solver which is used for the L^H matrix
+     * @returns  the solver which is used for the \f$L^H\f$ matrix
      */
     std::shared_ptr<const LinOp> get_lh_solver() const { return lh_solver_; }
 

--- a/include/ginkgo/core/preconditioner/ilu.hpp
+++ b/include/ginkgo/core/preconditioner/ilu.hpp
@@ -52,8 +52,8 @@ namespace preconditioner {
  *
  * @note When providing a gko::Composition, the first matrix must be the lower
  *       matrix (\f$L\f$), and the second matrix must be the upper matrix
- * (\f$U\f$). If they are swapped, solving might crash or return the wrong
- * result.
+ *       (\f$U\f$). If they are swapped, solving might crash or return the
+ *       wrong result.
  *
  * @note Do not use symmetric solvers (like CG) for L or U solvers since both
  *       matrices (L and U) are, by design, not symmetric.
@@ -62,6 +62,7 @@ namespace preconditioner {
  *       uses an internal cache to accelerate multiple (sequential) applies.
  *       Using it in parallel can lead to segmentation faults, wrong results
  *       and other unwanted behavior.
+ *
  * @note The default template during parse is <ValueType, IndexType> not
  *       <LowerTrs, IndexType>. Only the variants with ValueType are supported
  *       in parse.

--- a/include/ginkgo/core/preconditioner/ilu.hpp
+++ b/include/ginkgo/core/preconditioner/ilu.hpp
@@ -32,7 +32,7 @@ namespace preconditioner {
 
 
 /**
- * The Incomplete LU (ILU) preconditioner solves the equation $LUx = b$ for a
+ * The Incomplete LU (ILU) preconditioner solves the equation \f$LUx = b\f$ for a
  * given lower triangular matrix L, an upper triangular matrix U and the right
  * hand side b (can contain multiple right hand sides).
  *
@@ -51,7 +51,7 @@ namespace preconditioner {
  * factors in the correct way.
  *
  * @note When providing a gko::Composition, the first matrix must be the lower
- *       matrix ($L$), and the second matrix must be the upper matrix ($U$).
+ *       matrix (\f$L\f$), and the second matrix must be the upper matrix (\f$U\f$).
  *       If they are swapped, solving might crash or return the wrong result.
  *
  * @note Do not use symmetric solvers (like CG) for L or U solvers since both

--- a/include/ginkgo/core/preconditioner/ilu.hpp
+++ b/include/ginkgo/core/preconditioner/ilu.hpp
@@ -32,8 +32,8 @@ namespace preconditioner {
 
 
 /**
- * The Incomplete LU (ILU) preconditioner solves the equation \f$LUx = b\f$ for a
- * given lower triangular matrix L, an upper triangular matrix U and the right
+ * The Incomplete LU (ILU) preconditioner solves the equation \f$LUx = b\f$ for
+ * a given lower triangular matrix L, an upper triangular matrix U and the right
  * hand side b (can contain multiple right hand sides).
  *
  * It allows to set both the solver for L and the solver for U independently,
@@ -51,8 +51,9 @@ namespace preconditioner {
  * factors in the correct way.
  *
  * @note When providing a gko::Composition, the first matrix must be the lower
- *       matrix (\f$L\f$), and the second matrix must be the upper matrix (\f$U\f$).
- *       If they are swapped, solving might crash or return the wrong result.
+ *       matrix (\f$L\f$), and the second matrix must be the upper matrix
+ * (\f$U\f$). If they are swapped, solving might crash or return the wrong
+ * result.
  *
  * @note Do not use symmetric solvers (like CG) for L or U solvers since both
  *       matrices (L and U) are, by design, not symmetric.

--- a/include/ginkgo/core/preconditioner/ilu.hpp
+++ b/include/ginkgo/core/preconditioner/ilu.hpp
@@ -33,12 +33,13 @@ namespace preconditioner {
 
 /**
  * The Incomplete LU (ILU) preconditioner solves the equation \f$LUx = b\f$ for
- * a given lower triangular matrix L, an upper triangular matrix U and the right
- * hand side b (can contain multiple right hand sides).
+ * a given lower triangular matrix \f$L\f$, an upper triangular matrix
+ * \f$U\f$ and the right hand side \f$b\f$ (can contain multiple right hand
+ * sides).
  *
- * It allows to set both the solver for L and the solver for U independently,
- * while providing the defaults solver::LowerTrs and solver::UpperTrs, which
- * are direct triangular solvers.
+ * It allows to set both the solver for \f$L\f$ and the solver for \f$U\f$
+ * independently, while providing the defaults solver::LowerTrs and
+ * solver::UpperTrs, which are direct triangular solvers.
  * For these solvers, a factory can be provided (with `with_l_solver` and
  * `with_u_solver`) to have more control over their behavior. In particular, it
  * is possible to use an iterative method for solving the triangular systems.
@@ -46,17 +47,18 @@ namespace preconditioner {
  * An object of this class can be created with a matrix or a gko::Composition
  * containing two matrices. If created with a matrix, it is factorized before
  * creating the solver. If a gko::Composition (containing two matrices) is
- * used, the first operand will be taken as the L matrix, the second will be
- * considered the U matrix. ParIlu can be directly used, since it orders the
- * factors in the correct way.
+ * used, the first operand will be taken as the \f$L\f$ matrix, the second
+ * will be considered the \f$U\f$ matrix. ParIlu can be directly used, since
+ * it orders the factors in the correct way.
  *
  * @note When providing a gko::Composition, the first matrix must be the lower
  *       matrix (\f$L\f$), and the second matrix must be the upper matrix
  *       (\f$U\f$). If they are swapped, solving might crash or return the
  *       wrong result.
  *
- * @note Do not use symmetric solvers (like CG) for L or U solvers since both
- *       matrices (L and U) are, by design, not symmetric.
+ * @note Do not use symmetric solvers (like CG) for \f$L\f$ or \f$U\f$
+ *       solvers since both matrices (\f$L\f$ and \f$U\f$) are, by design,
+ *       not symmetric.
  *
  * @note This class is not thread safe (even a const object is not) because it
  *       uses an internal cache to accelerate multiple (sequential) applies.
@@ -67,13 +69,15 @@ namespace preconditioner {
  *       <LowerTrs, IndexType>. Only the variants with ValueType are supported
  *       in parse.
  *
- * @tparam ValueType  the value type used for the L and U matrices.
+ * @tparam ValueType  the value type used for the \f$L\f$ and \f$U\f$
+ *                    matrices.
  * @tparam ReverseApply  default behavior (ReverseApply = false) is first to
- *                       solve with L (Ly = b) and then with U (Ux = y).
- *                       When set to true, it will solve first with U, and then
- *                       with L.
+ *                       solve with \f$L\f$ (\f$Ly = b\f$) and then with
+ *                       \f$U\f$ (\f$Ux = y\f$). When set to true, it will
+ *                       solve first with \f$U\f$, and then with \f$L\f$.
  * @tparam IndexType  Type of the indices when ParIlu is used to generate
- *                    both L and U factors. Irrelevant otherwise.
+ *                    both \f$L\f$ and \f$U\f$ factors. Irrelevant
+ *                    otherwise.
  *
  * @ingroup precond
  * @ingroup LinOp
@@ -92,12 +96,12 @@ public:
     struct parameters_type
         : public enable_parameters_type<parameters_type, Factory> {
         /**
-         * Factory for the L solver
+         * Factory for the \f$L\f$ solver
          */
         std::shared_ptr<const LinOpFactory> l_solver_factory{};
 
         /**
-         * Factory for the U solver
+         * Factory for the \f$U\f$ solver
          */
         std::shared_ptr<const LinOpFactory> u_solver_factory{};
 
@@ -179,16 +183,16 @@ public:
             config::make_type_descriptor<value_type, index_type>());
 
     /**
-     * Returns the solver which is used for the provided L matrix.
+     * Returns the solver which is used for the provided \f$L\f$ matrix.
      *
-     * @returns  the solver which is used for the provided L matrix
+     * @returns  the solver which is used for the provided \f$L\f$ matrix
      */
     std::shared_ptr<const LinOp> get_l_solver() const { return l_solver_; }
 
     /**
-     * Returns the solver which is used for the provided U matrix.
+     * Returns the solver which is used for the provided \f$U\f$ matrix.
      *
-     * @returns  the solver which is used for the provided U matrix
+     * @returns  the solver which is used for the provided \f$U\f$ matrix
      */
     std::shared_ptr<const LinOp> get_u_solver() const { return u_solver_; }
 

--- a/include/ginkgo/core/preconditioner/isai.hpp
+++ b/include/ginkgo/core/preconditioner/isai.hpp
@@ -40,30 +40,37 @@ enum struct isai_type { lower, upper, general, spd };
  * an approximate inverse matrix for a given square matrix A, lower triangular
  * matrix L, upper triangular matrix U or symmetric positive (spd) matrix B.
  *
- * Using the preconditioner computes \f$aiA * x\f$, \f$aiU * x\f$, \f$aiL * x\f$
- * or $aiC^T * aiC * x$ (depending on the type of the Isai) for a given vector x
- * (may have multiple right hand sides). aiA, aiU and aiL are the approximate
- * inverses for A, U and L respectively. aiC is an approximation to C, the exact
- * Cholesky factor of B (This is commonly referred to as a Factorized Sparse
- * Approximate Inverse, short FSPAI).
+ * Let \f$ M_A \approx A^{-1} \f$ denote the approximate inverse of a
+ * general matrix \f$ A \f$, and similarly \f$ M_L \approx L^{-1} \f$,
+ * \f$ M_U \approx U^{-1} \f$ for lower and upper triangular matrices, and
+ * \f$ M_C \approx C^{-1} \f$ for the Cholesky factor of an SPD matrix
+ * \f$ B = C^T C \f$ (the last case is commonly called a Factorized Sparse
+ * Approximate Inverse, FSPAI).  Applying the preconditioner then computes,
+ * depending on the type of the Isai,
+ * \f[
+ *   M_A\, x, \qquad M_U\, x, \qquad M_L\, x, \qquad
+ *   \text{or} \qquad M_C^{T}\, M_C\, x,
+ * \f]
+ * for a given vector \f$ x \f$ (which may carry multiple right-hand sides).
  *
- * The sparsity pattern used for the approximate inverse of A, L and U is the
- * same as the sparsity pattern of the respective matrix. For B, the sparsity
- * pattern used for the approximate inverse is the same as the sparsity pattern
- * of the lower triangular half of B.
+ * The sparsity pattern used for the approximate inverse of \f$ A \f$,
+ * \f$ L \f$ and \f$ U \f$ is the same as the sparsity pattern of the
+ * respective matrix.  For \f$ B \f$, the sparsity pattern of \f$ M_C \f$
+ * matches the sparsity pattern of the lower triangular half of \f$ B \f$.
  *
- * Note that, except for the spd case, for a matrix A generally
- * ISAI(A)^T != ISAI(A^T).
- *
- * For more details on the algorithm, see the paper
- * <a href="https://doi.org/10.1016/j.parco.2017.10.003">
- * Incomplete Sparse Approximate Inverses for Parallel Preconditioning</a>,
- * which is the basis for this work.
+ * Note that, except for the SPD case, in general
+ * \f$ \mathrm{ISAI}(A)^T \ne \mathrm{ISAI}(A^T) \f$.
  *
  * @note GPU implementations can only handle the vector unit width `width`
  *       (warp size for CUDA) as number of elements per row in the sparse
  *       matrix. If there are more than `width` elements per row, the remaining
  *       elements will be ignored.
+ *
+ * @par References
+ * - Anzt, H., Huckle, T. K., Bräckle, J., Dongarra, J.
+ *   *Incomplete Sparse Approximate Inverses for Parallel Preconditioning.*
+ *   Parallel Computing, 71, 1–22, 2018.
+ *   <https://doi.org/10.1016/j.parco.2017.10.003>
  *
  * @tparam IsaiType  determines if the ISAI is generated for a general square
  *         matrix, a lower triangular matrix, an upper triangular matrix or an

--- a/include/ginkgo/core/preconditioner/isai.hpp
+++ b/include/ginkgo/core/preconditioner/isai.hpp
@@ -40,7 +40,7 @@ enum struct isai_type { lower, upper, general, spd };
  * an approximate inverse matrix for a given square matrix A, lower triangular
  * matrix L, upper triangular matrix U or symmetric positive (spd) matrix B.
  *
- * Using the preconditioner computes $aiA * x$, $aiU * x$, $aiL * x$ or $aiC^T *
+ * Using the preconditioner computes \f$aiA * x\f$, \f$aiU * x\f$, \f$aiL * x\f$ or $aiC^T *
  * aiC * x$ (depending on the type of the Isai) for a given vector x (may have
  * multiple right hand sides). aiA, aiU and aiL are the approximate inverses for
  * A, U and L respectively. aiC is an approximation to C, the exact Cholesky

--- a/include/ginkgo/core/preconditioner/isai.hpp
+++ b/include/ginkgo/core/preconditioner/isai.hpp
@@ -45,17 +45,20 @@ enum struct isai_type { lower, upper, general, spd };
  * \f$ M_U \approx U^{-1} \f$ for lower and upper triangular matrices, and
  * \f$ M_C \approx C^{-1} \f$ for the Cholesky factor of an SPD matrix
  * \f$ B = C^T C \f$ (the last case is commonly called a Factorized Sparse
- * Approximate Inverse, FSPAI).  Applying the preconditioner then computes,
- * depending on the type of the Isai,
+ * Approximate Inverse, FSPAI). For a given vector \f$ x \f$ (which may
+ * carry multiple right-hand sides), applying the preconditioner computes
  * \f[
- *   M_A\, x, \qquad M_U\, x, \qquad M_L\, x, \qquad
- *   \text{or} \qquad M_C^{T}\, M_C\, x,
+ *   \begin{aligned}
+ *     \texttt{isai\_type::general} &: \quad M_A x, \\
+ *     \texttt{isai\_type::lower}   &: \quad M_L x, \\
+ *     \texttt{isai\_type::upper}   &: \quad M_U x, \\
+ *     \texttt{isai\_type::spd}     &: \quad M_C^{T} M_C x.
+ *   \end{aligned}
  * \f]
- * for a given vector \f$ x \f$ (which may carry multiple right-hand sides).
  *
  * The sparsity pattern used for the approximate inverse of \f$ A \f$,
  * \f$ L \f$ and \f$ U \f$ is the same as the sparsity pattern of the
- * respective matrix.  For \f$ B \f$, the sparsity pattern of \f$ M_C \f$
+ * respective matrix. For \f$ B \f$, the sparsity pattern of \f$ M_C \f$
  * matches the sparsity pattern of the lower triangular half of \f$ B \f$.
  *
  * Note that, except for the SPD case, in general

--- a/include/ginkgo/core/preconditioner/isai.hpp
+++ b/include/ginkgo/core/preconditioner/isai.hpp
@@ -40,12 +40,12 @@ enum struct isai_type { lower, upper, general, spd };
  * an approximate inverse matrix for a given square matrix A, lower triangular
  * matrix L, upper triangular matrix U or symmetric positive (spd) matrix B.
  *
- * Using the preconditioner computes \f$aiA * x\f$, \f$aiU * x\f$, \f$aiL * x\f$ or $aiC^T *
- * aiC * x$ (depending on the type of the Isai) for a given vector x (may have
- * multiple right hand sides). aiA, aiU and aiL are the approximate inverses for
- * A, U and L respectively. aiC is an approximation to C, the exact Cholesky
- * factor of B (This is commonly referred to as a Factorized Sparse Approximate
- * Inverse, short FSPAI).
+ * Using the preconditioner computes \f$aiA * x\f$, \f$aiU * x\f$, \f$aiL * x\f$
+ * or $aiC^T * aiC * x$ (depending on the type of the Isai) for a given vector x
+ * (may have multiple right hand sides). aiA, aiU and aiL are the approximate
+ * inverses for A, U and L respectively. aiC is an approximation to C, the exact
+ * Cholesky factor of B (This is commonly referred to as a Factorized Sparse
+ * Approximate Inverse, short FSPAI).
  *
  * The sparsity pattern used for the approximate inverse of A, L and U is the
  * same as the sparsity pattern of the respective matrix. For B, the sparsity

--- a/include/ginkgo/core/preconditioner/isai.hpp
+++ b/include/ginkgo/core/preconditioner/isai.hpp
@@ -31,19 +31,20 @@ namespace preconditioner {
  * This enum lists the types of the ISAI preconditioner.
  *
  * ISAI can either be generated for a general square matrix, a lower triangular
- * matrix, an upper triangular matrix or an spd matrix.
+ * matrix, an upper triangular matrix or an s.p.d matrix.
  */
 enum struct isai_type { lower, upper, general, spd };
 
 /**
  * The Incomplete Sparse Approximate Inverse (ISAI) Preconditioner generates
- * an approximate inverse matrix for a given square matrix A, lower triangular
- * matrix L, upper triangular matrix U or symmetric positive (spd) matrix B.
+ * an approximate inverse matrix for a given square matrix \f$A\f$, lower
+ * triangular matrix \f$L\f$, upper triangular matrix \f$U\f$ or symmetric
+ * positive definite (s.p.d) matrix \f$B\f$.
  *
  * Let \f$ M_A \approx A^{-1} \f$ denote the approximate inverse of a
  * general matrix \f$ A \f$, and similarly \f$ M_L \approx L^{-1} \f$,
  * \f$ M_U \approx U^{-1} \f$ for lower and upper triangular matrices, and
- * \f$ M_C \approx C^{-1} \f$ for the Cholesky factor of an SPD matrix
+ * \f$ M_C \approx C^{-1} \f$ for the Cholesky factor of an s.p.d matrix
  * \f$ B = C^T C \f$ (the last case is commonly called a Factorized Sparse
  * Approximate Inverse, FSPAI). For a given vector \f$ x \f$ (which may
  * carry multiple right-hand sides), applying the preconditioner computes
@@ -61,7 +62,7 @@ enum struct isai_type { lower, upper, general, spd };
  * respective matrix. For \f$ B \f$, the sparsity pattern of \f$ M_C \f$
  * matches the sparsity pattern of the lower triangular half of \f$ B \f$.
  *
- * Note that, except for the SPD case, in general
+ * Note that, except for the s.p.d case, in general
  * \f$ \mathrm{ISAI}(A)^T \ne \mathrm{ISAI}(A^T) \f$.
  *
  * @note GPU implementations can only handle the vector unit width `width`
@@ -77,7 +78,7 @@ enum struct isai_type { lower, upper, general, spd };
  *
  * @tparam IsaiType  determines if the ISAI is generated for a general square
  *         matrix, a lower triangular matrix, an upper triangular matrix or an
- *         spd matrix
+ *         s.p.d matrix
  * @tparam ValueType  precision of matrix elements
  * @tparam IndexType  precision of matrix indexes
  *

--- a/include/ginkgo/core/preconditioner/isai.hpp
+++ b/include/ginkgo/core/preconditioner/isai.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -40,12 +40,12 @@ enum struct isai_type { lower, upper, general, spd };
  * an approximate inverse matrix for a given square matrix A, lower triangular
  * matrix L, upper triangular matrix U or symmetric positive (spd) matrix B.
  *
- * Using the preconditioner computes \f$aiA * x\f$, \f$aiU * x\f$, \f$aiL * x\f$ or $aiC^T *
- * aiC * x$ (depending on the type of the Isai) for a given vector x (may have
- * multiple right hand sides). aiA, aiU and aiL are the approximate inverses for
- * A, U and L respectively. aiC is an approximation to C, the exact Cholesky
- * factor of B (This is commonly referred to as a Factorized Sparse Approximate
- * Inverse, short FSPAI).
+ * Using the preconditioner computes \f$aiA * x\f$, \f$aiU * x\f$, \f$aiL * x\f$
+ * or $aiC^T * aiC * x$ (depending on the type of the Isai) for a given vector x
+ * (may have multiple right hand sides). aiA, aiU and aiL are the approximate
+ * inverses for A, U and L respectively. aiC is an approximation to C, the exact
+ * Cholesky factor of B (This is commonly referred to as a Factorized Sparse
+ * Approximate Inverse, short FSPAI).
  *
  * The sparsity pattern used for the approximate inverse of A, L and U is the
  * same as the sparsity pattern of the respective matrix. For B, the sparsity

--- a/include/ginkgo/core/preconditioner/jacobi.hpp
+++ b/include/ginkgo/core/preconditioner/jacobi.hpp
@@ -371,15 +371,25 @@ public:
                                                             nullptr);
 
         /**
-         * Use L1 Jacboi, which is introduced in the paper A. H. Baker et al.
-         * "Multigrid smoothers for ultraparallel computing." This paper
-         * discusses this type of smoother with the following matrix property.
-         * $ A_{ii} \geq \theta \sum_{j \in \text{off diagonal block}} |A_{ij}|,
-         * \theta \geq 0 $
-         * If it is true, it generates the preconditioner on A +
-         * Diag(sum_{k in off-diagonal block of i} |A_ik|) instead of A. We
-         * aggregate the absolute value of the entries with the same row in the
-         * off-diagonal block into the diagonal value.
+         * Use L1 Jacobi, introduced in Baker et al., *Multigrid smoothers
+         * for ultraparallel computing*. The smoother applies whenever the
+         * matrix satisfies the row-dominance condition
+         * \f[
+         *   A_{ii} \geq \theta \sum_{j \in \text{off-diagonal block}}
+         *                       |A_{ij}|,
+         *   \qquad \theta \geq 0.
+         * \f]
+         * If set, the preconditioner is generated on
+         * \f$ A + \mathrm{diag}\!\left( \sum_{k \in \text{off-diagonal block
+         * of } i} |A_{ik}| \right) \f$ instead of \f$A\f$ — i.e. the
+         * absolute values of off-diagonal-block entries on each row are
+         * aggregated into the diagonal entry before block inversion.
+         *
+         * Reference:
+         * Baker, A. H., Falgout, R. D., Kolev, T. V., Yang, U. M.
+         * *Multigrid Smoothers for Ultraparallel Computing.*
+         * SIAM Journal on Scientific Computing, 33 (5), 2864–2887, 2011.
+         * <https://doi.org/10.1137/100798806>
          */
         bool GKO_FACTORY_PARAMETER_SCALAR(aggregate_l1, false);
 

--- a/include/ginkgo/core/preconditioner/jacobi.hpp
+++ b/include/ginkgo/core/preconditioner/jacobi.hpp
@@ -371,9 +371,8 @@ public:
                                                             nullptr);
 
         /**
-         * Use L1 Jacobi, introduced in Baker et al., *Multigrid smoothers
-         * for ultraparallel computing*. The smoother applies whenever the
-         * matrix satisfies the row-dominance condition
+         * Use L1 Jacobi, introduced by Baker et al. The smoother applies
+         * whenever the matrix satisfies the row-dominance condition
          * \f[
          *   A_{ii} \geq \theta \sum_{j \in \text{off-diagonal block}}
          *                       |A_{ij}|,
@@ -385,11 +384,11 @@ public:
          * absolute values of off-diagonal-block entries on each row are
          * aggregated into the diagonal entry before block inversion.
          *
-         * Reference:
-         * Baker, A. H., Falgout, R. D., Kolev, T. V., Yang, U. M.
-         * *Multigrid Smoothers for Ultraparallel Computing.*
-         * SIAM Journal on Scientific Computing, 33 (5), 2864–2887, 2011.
-         * <https://doi.org/10.1137/100798806>
+         * @par References
+         * - Baker, A. H., Falgout, R. D., Kolev, T. V., Yang, U. M.
+         *   *Multigrid Smoothers for Ultraparallel Computing.*
+         *   SIAM Journal on Scientific Computing, 33 (5), 2864–2887, 2011.
+         *   <https://doi.org/10.1137/100798806>
          */
         bool GKO_FACTORY_PARAMETER_SCALAR(aggregate_l1, false);
 

--- a/include/ginkgo/core/preconditioner/jacobi.hpp
+++ b/include/ginkgo/core/preconditioner/jacobi.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -373,15 +373,25 @@ public:
                                                             nullptr);
 
         /**
-         * Use L1 Jacboi, which is introduced in the paper A. H. Baker et al.
-         * "Multigrid smoothers for ultraparallel computing." This paper
-         * discusses this type of smoother with the following matrix property.
-         * $ A_{ii} \geq \theta \sum_{j \in \text{off diagonal block}} |A_{ij}|,
-         * \theta \geq 0 $
-         * If it is true, it generates the preconditioner on A +
-         * Diag(sum_{k in off-diagonal block of i} |A_ik|) instead of A. We
-         * aggregate the absolute value of the entries with the same row in the
-         * off-diagonal block into the diagonal value.
+         * Use L1 Jacobi, introduced in Baker et al., *Multigrid smoothers
+         * for ultraparallel computing*. The smoother applies whenever the
+         * matrix satisfies the row-dominance condition
+         * \f[
+         *   A_{ii} \geq \theta \sum_{j \in \text{off-diagonal block}}
+         *                       |A_{ij}|,
+         *   \qquad \theta \geq 0.
+         * \f]
+         * If set, the preconditioner is generated on
+         * \f$ A + \mathrm{diag}\!\left( \sum_{k \in \text{off-diagonal block
+         * of } i} |A_{ik}| \right) \f$ instead of \f$A\f$ — i.e. the
+         * absolute values of off-diagonal-block entries on each row are
+         * aggregated into the diagonal entry before block inversion.
+         *
+         * Reference:
+         * Baker, A. H., Falgout, R. D., Kolev, T. V., Yang, U. M.
+         * *Multigrid Smoothers for Ultraparallel Computing.*
+         * SIAM Journal on Scientific Computing, 33 (5), 2864–2887, 2011.
+         * <https://doi.org/10.1137/100798806>
          */
         bool GKO_FACTORY_PARAMETER_SCALAR(aggregate_l1, false);
 

--- a/include/ginkgo/core/preconditioner/sor.hpp
+++ b/include/ginkgo/core/preconditioner/sor.hpp
@@ -22,16 +22,16 @@ namespace preconditioner {
 /**
  * This class generates the (S)SOR preconditioner.
  *
- * The SOR preconditioner starts from a splitting of the the matrix $A$ into
- * $A = D + L + U$, where $L$ contains all entries below the diagonal, and $U$
+ * The SOR preconditioner starts from a splitting of the the matrix \f$A\f$ into
+ * \f$A = D + L + U\f$, where \f$L\f$ contains all entries below the diagonal, and \f$U\f$
  * contains all entries above the diagonal. The application of the
- * preconditioner is then defined as solving $M x = y$ with
+ * preconditioner is then defined as solving \f$M x = y\f$ with
  * \f[
  * M = \frac{1}{\omega} (D + \omega L), \quad 0 < \omega < 2.
  * \f]
- * $\omega$ is known as the relaxation factor.
+ * \f$\omega\f$ is known as the relaxation factor.
  * The preconditioner can be made symmetric, leading to the SSOR preconitioner.
- * Here, $M$ is defined as
+ * Here, \f$M\f$ is defined as
  * \f[
  * M = \frac{1}{\omega (2 - \omega)} (D + \omega L) D^{-1} (D + \omega U) ,
  * \quad 0 < \omega < 2.
@@ -40,7 +40,7 @@ namespace preconditioner {
  * Systems (Y. Saad) ch. 4.1.
  *
  * This class is a factory, which will only generate the preconditioner. The
- * resulting LinOp will represent the application of $M^{-1}$.
+ * resulting LinOp will represent the application of \f$M^{-1}\f$.
  *
  * @tparam ValueType  The value type of the internally used CSR matrix
  * @tparam IndexType  The index type of the internally used CSR matrix

--- a/include/ginkgo/core/preconditioner/sor.hpp
+++ b/include/ginkgo/core/preconditioner/sor.hpp
@@ -23,8 +23,8 @@ namespace preconditioner {
  * This class generates the (S)SOR preconditioner.
  *
  * The SOR preconditioner starts from a splitting of the the matrix \f$A\f$ into
- * \f$A = D + L + U\f$, where \f$L\f$ contains all entries below the diagonal, and \f$U\f$
- * contains all entries above the diagonal. The application of the
+ * \f$A = D + L + U\f$, where \f$L\f$ contains all entries below the diagonal,
+ * and \f$U\f$ contains all entries above the diagonal. The application of the
  * preconditioner is then defined as solving \f$M x = y\f$ with
  * \f[
  * M = \frac{1}{\omega} (D + \omega L), \quad 0 < \omega < 2.

--- a/include/ginkgo/core/preconditioner/sor.hpp
+++ b/include/ginkgo/core/preconditioner/sor.hpp
@@ -22,7 +22,7 @@ namespace preconditioner {
 /**
  * This class generates the (S)SOR preconditioner.
  *
- * The SOR preconditioner starts from a splitting of the the matrix \f$A\f$ into
+ * The SOR preconditioner starts from a splitting of the matrix \f$A\f$ into
  * \f$A = D + L + U\f$, where \f$L\f$ contains all entries below the diagonal,
  * and \f$U\f$ contains all entries above the diagonal. The application of the
  * preconditioner is then defined as solving \f$M x = y\f$ with
@@ -30,17 +30,19 @@ namespace preconditioner {
  * M = \frac{1}{\omega} (D + \omega L), \quad 0 < \omega < 2.
  * \f]
  * \f$\omega\f$ is known as the relaxation factor.
- * The preconditioner can be made symmetric, leading to the SSOR preconitioner.
+ * The preconditioner can be made symmetric, leading to the SSOR preconditioner.
  * Here, \f$M\f$ is defined as
  * \f[
  * M = \frac{1}{\omega (2 - \omega)} (D + \omega L) D^{-1} (D + \omega U) ,
  * \quad 0 < \omega < 2.
  * \f]
- * A detailed description can be found in Iterative Methods for Sparse Linear
- * Systems (Y. Saad) ch. 4.1.
  *
  * This class is a factory, which will only generate the preconditioner. The
  * resulting LinOp will represent the application of \f$M^{-1}\f$.
+ *
+ * @par References
+ * - Saad, Y. *Iterative Methods for Sparse Linear Systems.* 2nd ed.
+ *   SIAM, 2003, ch. 4.1. <https://doi.org/10.1137/1.9780898718003>
  *
  * @tparam ValueType  The value type of the internally used CSR matrix
  * @tparam IndexType  The index type of the internally used CSR matrix

--- a/include/ginkgo/core/preconditioner/sor.hpp
+++ b/include/ginkgo/core/preconditioner/sor.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -23,8 +23,8 @@ namespace preconditioner {
  * This class generates the (S)SOR preconditioner.
  *
  * The SOR preconditioner starts from a splitting of the the matrix \f$A\f$ into
- * \f$A = D + L + U\f$, where \f$L\f$ contains all entries below the diagonal, and \f$U\f$
- * contains all entries above the diagonal. The application of the
+ * \f$A = D + L + U\f$, where \f$L\f$ contains all entries below the diagonal,
+ * and \f$U\f$ contains all entries above the diagonal. The application of the
  * preconditioner is then defined as solving \f$M x = y\f$ with
  * \f[
  * M = \frac{1}{\omega} (D + \omega L), \quad 0 < \omega < 2.

--- a/include/ginkgo/core/reorder/amd.hpp
+++ b/include/ginkgo/core/reorder/amd.hpp
@@ -26,8 +26,19 @@ namespace reorder {
 
 
 /**
- * Computes a Approximate Minimum Degree (AMD) reordering of an input
- * matrix.
+ * Computes an Approximate Minimum Degree (AMD) reordering of an input
+ * matrix.  The implementation reuses the AMD routine from the
+ * [SuiteSparse](https://github.com/DrTimothyAldenDavis/SuiteSparse) suite
+ * (Tim Davis et al.) — Ginkgo wraps it in a `LinOpFactory` that produces
+ * a `gko::matrix::Permutation`.  The system matrix must therefore be a
+ * structurally-symmetric CSR matrix.
+ *
+ * @par References
+ * - Amestoy, P. R., Davis, T. A., Duff, I. S.
+ *   *Algorithm 837: AMD, an Approximate Minimum Degree Ordering
+ *   Algorithm.*
+ *   ACM Transactions on Mathematical Software, 30 (3), 381–388, 2004.
+ *   <https://doi.org/10.1145/1024074.1024081>
  *
  * @tparam IndexType  the type used to store sparsity pattern indices of the
  *                    system matrix

--- a/include/ginkgo/core/reorder/amd.hpp
+++ b/include/ginkgo/core/reorder/amd.hpp
@@ -27,10 +27,10 @@ namespace reorder {
 
 /**
  * Computes an Approximate Minimum Degree (AMD) reordering of an input
- * matrix.  The implementation reuses the AMD routine from the
+ * matrix. The implementation reuses the AMD routine from the
  * [SuiteSparse](https://github.com/DrTimothyAldenDavis/SuiteSparse) suite
  * (Tim Davis et al.) — Ginkgo wraps it in a `LinOpFactory` that produces
- * a `gko::matrix::Permutation`.  The system matrix must therefore be a
+ * a `gko::matrix::Permutation`. The system matrix must therefore be a
  * structurally-symmetric CSR matrix.
  *
  * @par References

--- a/include/ginkgo/core/reorder/mc64.hpp
+++ b/include/ginkgo/core/reorder/mc64.hpp
@@ -52,8 +52,8 @@ enum class mc64_strategy { max_diagonal_product, max_diagonal_sum };
  * perfect matching on a weighted edge bipartite graph of the matrix. It is
  * described in detail in "On Algorithms for Permuting Large Entries to the
  * Diagonal of a Sparse Matrix" (Duff, Koster, 2001,
- * DOI: 10.1137/S0895479899358443). There are two strategies for choosing the
- * weights supported:
+ * <https://doi.org/10.1137/S0895479899358443>). There are two strategies for
+ * choosing the weights supported:
  *  - Maximizing the product of the absolute values on the diagonal.
  *    For this strategy, the weights are computed as
  *    \f$c(i, j) = \log_2(a_i) - \log_2(|a(i, j)|)\f$ if \f$a(i, j) \neq 0\f$

--- a/include/ginkgo/core/reorder/mc64.hpp
+++ b/include/ginkgo/core/reorder/mc64.hpp
@@ -56,16 +56,18 @@ enum class mc64_strategy { max_diagonal_product, max_diagonal_sum };
  * weights supported:
  *  - Maximizing the product of the absolute values on the diagonal.
  *    For this strategy, the weights are computed as
- *    \f$c(i, j) = \log_2(a_i) - \log_2(|a(i, j)|)\f$ if \f$a(i, j) \neq 0 \f$
- * and \f$c(i, j) = \infty\f$ otherwise. Here, a_i is the maximum absolute value
- * in row i of the matrix A. In this case, the implementation computes a row
- *    permutation P and row and column scaling coefficients L and R such that
- *    the matrix P*L*A*R has values with unity absolute value on the diagonal
- *    and smaller or equal entries everywhere else.
+ *    \f$c(i, j) = \log_2(a_i) - \log_2(|a(i, j)|)\f$ if \f$a(i, j) \neq 0\f$
+ *    and \f$c(i, j) = \infty\f$ otherwise. Here, \f$a_i\f$ is the maximum
+ *    absolute value in row \f$i\f$ of the matrix \f$A\f$. In this case, the
+ *    implementation computes a row permutation \f$P\f$ and row and column
+ *    scaling coefficients \f$L\f$ and \f$R\f$ such that the matrix
+ *    \f$P L A R\f$ has values with unity absolute value on the diagonal and
+ *    smaller or equal entries everywhere else.
  *  - Maximizing the sum of the absolute values on the diagonal.
  *    For this strategy, the weights are computed as
- *    \f$c(i, j) = a_i - |a(i, j)|\f$ if \f$a(i, j) \neq 0\f$ and \f$c(i, j) =
- *    \infty\f$ otherwise. In this case, no scaling coefficients are computed.
+ *    \f$c(i, j) = a_i - |a(i, j)|\f$ if \f$a(i, j) \neq 0\f$ and
+ *    \f$c(i, j) = \infty\f$ otherwise. In this case, no scaling coefficients
+ *    are computed.
  *
  * This class creates a Combination of two ScaledPermutations representing the
  * row and column permutation and scaling factors computed by this algorithm.

--- a/include/ginkgo/core/reorder/mc64.hpp
+++ b/include/ginkgo/core/reorder/mc64.hpp
@@ -56,9 +56,9 @@ enum class mc64_strategy { max_diagonal_product, max_diagonal_sum };
  * weights supported:
  *  - Maximizing the product of the absolute values on the diagonal.
  *    For this strategy, the weights are computed as
- *    \f$c(i, j) = \log_2(a_i) - \log_2(|a(i, j)|)\f$ if \f$a(i, j) \neq 0 \f$ and
- *    \f$c(i, j) = \infty\f$ otherwise. Here, a_i is the maximum absolute value in
- *    row i of the matrix A. In this case, the implementation computes a row
+ *    \f$c(i, j) = \log_2(a_i) - \log_2(|a(i, j)|)\f$ if \f$a(i, j) \neq 0 \f$
+ * and \f$c(i, j) = \infty\f$ otherwise. Here, a_i is the maximum absolute value
+ * in row i of the matrix A. In this case, the implementation computes a row
  *    permutation P and row and column scaling coefficients L and R such that
  *    the matrix P*L*A*R has values with unity absolute value on the diagonal
  *    and smaller or equal entries everywhere else.

--- a/include/ginkgo/core/reorder/mc64.hpp
+++ b/include/ginkgo/core/reorder/mc64.hpp
@@ -64,8 +64,8 @@ enum class mc64_strategy { max_diagonal_product, max_diagonal_sum };
  *    and smaller or equal entries everywhere else.
  *  - Maximizing the sum of the absolute values on the diagonal.
  *    For this strategy, the weights are computed as
- *    \f$c(i, j) = a_i - |a(i, j)|\f$ if \f$a(i, j) \neq 0\f$ and $c(i, j) =
- *    \infty$ otherwise. In this case, no scaling coefficients are computed.
+ *    \f$c(i, j) = a_i - |a(i, j)|\f$ if \f$a(i, j) \neq 0\f$ and \f$c(i, j) =
+ *    \infty\f$ otherwise. In this case, no scaling coefficients are computed.
  *
  * This class creates a Combination of two ScaledPermutations representing the
  * row and column permutation and scaling factors computed by this algorithm.

--- a/include/ginkgo/core/reorder/mc64.hpp
+++ b/include/ginkgo/core/reorder/mc64.hpp
@@ -56,15 +56,15 @@ enum class mc64_strategy { max_diagonal_product, max_diagonal_sum };
  * weights supported:
  *  - Maximizing the product of the absolute values on the diagonal.
  *    For this strategy, the weights are computed as
- *    $c(i, j) = \log_2(a_i) - \log_2(|a(i, j)|)$ if $a(i, j) \neq 0 $ and
- *    $c(i, j) = \infty$ otherwise. Here, a_i is the maximum absolute value in
+ *    \f$c(i, j) = \log_2(a_i) - \log_2(|a(i, j)|)\f$ if \f$a(i, j) \neq 0 \f$ and
+ *    \f$c(i, j) = \infty\f$ otherwise. Here, a_i is the maximum absolute value in
  *    row i of the matrix A. In this case, the implementation computes a row
  *    permutation P and row and column scaling coefficients L and R such that
  *    the matrix P*L*A*R has values with unity absolute value on the diagonal
  *    and smaller or equal entries everywhere else.
  *  - Maximizing the sum of the absolute values on the diagonal.
  *    For this strategy, the weights are computed as
- *    $c(i, j) = a_i - |a(i, j)|$ if $a(i, j) \neq 0$ and $c(i, j) =
+ *    \f$c(i, j) = a_i - |a(i, j)|\f$ if \f$a(i, j) \neq 0\f$ and $c(i, j) =
  *    \infty$ otherwise. In this case, no scaling coefficients are computed.
  *
  * This class creates a Combination of two ScaledPermutations representing the

--- a/include/ginkgo/core/reorder/mc64.hpp
+++ b/include/ginkgo/core/reorder/mc64.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -56,9 +56,9 @@ enum class mc64_strategy { max_diagonal_product, max_diagonal_sum };
  * weights supported:
  *  - Maximizing the product of the absolute values on the diagonal.
  *    For this strategy, the weights are computed as
- *    \f$c(i, j) = \log_2(a_i) - \log_2(|a(i, j)|)\f$ if \f$a(i, j) \neq 0 \f$ and
- *    \f$c(i, j) = \infty\f$ otherwise. Here, a_i is the maximum absolute value in
- *    row i of the matrix A. In this case, the implementation computes a row
+ *    \f$c(i, j) = \log_2(a_i) - \log_2(|a(i, j)|)\f$ if \f$a(i, j) \neq 0 \f$
+ * and \f$c(i, j) = \infty\f$ otherwise. Here, a_i is the maximum absolute value
+ * in row i of the matrix A. In this case, the implementation computes a row
  *    permutation P and row and column scaling coefficients L and R such that
  *    the matrix P*L*A*R has values with unity absolute value on the diagonal
  *    and smaller or equal entries everywhere else.

--- a/include/ginkgo/core/solver/bicg.hpp
+++ b/include/ginkgo/core/solver/bicg.hpp
@@ -37,9 +37,20 @@ namespace solver {
  * the capability to solve generic systems.
  *
  * BiCG is based on the bi-Lanczos tridiagonalization method and in exact
- * arithmetic should terminate in at most N iterations (2N MV's, with A and
- * A^H). It forms the basis of many of the cheaper methods such as BiCGSTAB and
- * CGS.
+ * arithmetic should terminate in at most \f$ N \f$ iterations (\f$ 2N \f$
+ * matrix-vector products — one with \f$ A \f$ and one with \f$ A^H \f$).
+ * It couples two Krylov sequences and maintains residuals \f$ r_k \f$,
+ * shadow residuals \f$ \tilde r_k \f$, and search directions
+ * \f$ p_k, \tilde p_k \f$ that satisfy the biorthogonality conditions
+ * \f$ \tilde r_i^H r_j = 0 \f$ for \f$ i \ne j \f$.  Each iteration
+ * performs the coupled update
+ * \f[
+ *   \alpha_k = \frac{\tilde r_k^H r_k}{\tilde p_k^H A p_k}, \qquad
+ *   r_{k+1}       = r_k       - \alpha_k\, A\, p_k, \qquad
+ *   \tilde r_{k+1} = \tilde r_k - \alpha_k\, A^H\, \tilde p_k.
+ * \f]
+ * It forms the basis of cheaper variants such as BiCGSTAB and CGS, which
+ * avoid the explicit \f$ A^H \f$ apply.
  *
  * Reference: R.Fletcher, Conjugate gradient methods for indefinite systems,
  * doi: 10.1007/BFb0080116

--- a/include/ginkgo/core/solver/bicg.hpp
+++ b/include/ginkgo/core/solver/bicg.hpp
@@ -38,7 +38,8 @@ namespace solver {
  *
  * BiCG is based on the bi-Lanczos tridiagonalization method and in exact
  * arithmetic should terminate in at most \f$ N \f$ iterations (\f$ 2N \f$
- * matrix-vector products — one with \f$ A \f$ and one with \f$ A^H \f$).
+ * matrix-vector products — one per iteration with \f$ A \f$ and
+ * \f$ A^H \f$ each).
  * It couples two Krylov sequences and maintains residuals \f$ r_k \f$,
  * shadow residuals \f$ \tilde r_k \f$, and search directions
  * \f$ p_k, \tilde p_k \f$ that satisfy the biorthogonality conditions

--- a/include/ginkgo/core/solver/bicg.hpp
+++ b/include/ginkgo/core/solver/bicg.hpp
@@ -42,12 +42,12 @@ namespace solver {
  * It couples two Krylov sequences and maintains residuals \f$ r_k \f$,
  * shadow residuals \f$ \tilde r_k \f$, and search directions
  * \f$ p_k, \tilde p_k \f$ that satisfy the biorthogonality conditions
- * \f$ \tilde r_i^H r_j = 0 \f$ for \f$ i \ne j \f$.  Each iteration
+ * \f$ \tilde r_i^H r_j = 0 \f$ for \f$ i \ne j \f$. Each iteration
  * performs the coupled update
  * \f[
  *   \alpha_k = \frac{\tilde r_k^H r_k}{\tilde p_k^H A p_k}, \qquad
- *   r_{k+1}       = r_k       - \alpha_k\, A\, p_k, \qquad
- *   \tilde r_{k+1} = \tilde r_k - \alpha_k\, A^H\, \tilde p_k.
+ *   r_{k+1}       = r_k       - \alpha_k A p_k, \qquad
+ *   \tilde r_{k+1} = \tilde r_k - \alpha_k A^H \tilde p_k.
  * \f]
  * It forms the basis of cheaper variants such as BiCGSTAB and CGS, which
  * avoid the explicit \f$ A^H \f$ apply.

--- a/include/ginkgo/core/solver/bicg.hpp
+++ b/include/ginkgo/core/solver/bicg.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 

--- a/include/ginkgo/core/solver/bicg.hpp
+++ b/include/ginkgo/core/solver/bicg.hpp
@@ -52,8 +52,10 @@ namespace solver {
  * It forms the basis of cheaper variants such as BiCGSTAB and CGS, which
  * avoid the explicit \f$ A^H \f$ apply.
  *
- * Reference: R.Fletcher, Conjugate gradient methods for indefinite systems,
- * doi: 10.1007/BFb0080116
+ * @par References
+ * - Fletcher, R. *Conjugate gradient methods for indefinite systems.*
+ *   Numerical Analysis (Dundee 1975), Lecture Notes in Mathematics 506,
+ *   Springer, 1976. <https://doi.org/10.1007/BFb0080116>
  *
  * @tparam ValueType  precision of matrix elements
  *

--- a/include/ginkgo/core/solver/bicgstab.hpp
+++ b/include/ginkgo/core/solver/bicgstab.hpp
@@ -39,18 +39,19 @@ namespace solver {
  * non-s.p.d matrices. Though, the memory and the computational requirement of
  * the BiCGSTAB solver are higher than of its s.p.d solver counterpart, it has
  * the capability to solve generic systems. It was developed by stabilizing the
- * BiCG method, removing the explicit \f$ A^H \f$ apply at the cost of one
- * extra preconditioner apply and matrix-vector product per iteration.
+ * BiCG method: both operator applications of an iteration use \f$ A \f$
+ * itself, so no \f$ A^H \f$ apply (nor a transposed preconditioner) is
+ * needed, at the cost of one additional inner product per iteration.
  *
  * Each iteration interleaves a BiCG-style step with a one-dimensional GMRES
- * minimisation: an intermediate residual
- * \f$ s = r_k - \alpha_k\, A p_k \f$ is constructed, then the stabilising
- * coefficient is chosen to minimise \f$ \| r_{k+1} \|_2 \f$ along
+ * minimization: an intermediate residual
+ * \f$ s = r_k - \alpha_k A p_k \f$ is constructed, then the stabilizing
+ * coefficient is chosen to minimize \f$ \| r_{k+1} \|_2 \f$ along
  * \f$ A s \f$:
  * \f[
  *   \omega_k = \frac{(A s)^H s}{(A s)^H (A s)}, \qquad
- *   x_{k+1}  = x_k + \alpha_k\, p_k + \omega_k\, s, \qquad
- *   r_{k+1}  = s - \omega_k\, A s.
+ *   x_{k+1}  = x_k + \alpha_k p_k + \omega_k s, \qquad
+ *   r_{k+1}  = s - \omega_k A s.
  * \f]
  *
  * @tparam ValueType precision of the elements of the system matrix.

--- a/include/ginkgo/core/solver/bicgstab.hpp
+++ b/include/ginkgo/core/solver/bicgstab.hpp
@@ -39,7 +39,19 @@ namespace solver {
  * non-s.p.d matrices. Though, the memory and the computational requirement of
  * the BiCGSTAB solver are higher than of its s.p.d solver counterpart, it has
  * the capability to solve generic systems. It was developed by stabilizing the
- * BiCG method.
+ * BiCG method, removing the explicit \f$ A^H \f$ apply at the cost of one
+ * extra preconditioner apply and matrix-vector product per iteration.
+ *
+ * Each iteration interleaves a BiCG-style step with a one-dimensional GMRES
+ * minimisation: an intermediate residual
+ * \f$ s = r_k - \alpha_k\, A p_k \f$ is constructed, then the stabilising
+ * coefficient is chosen to minimise \f$ \| r_{k+1} \|_2 \f$ along
+ * \f$ A s \f$:
+ * \f[
+ *   \omega_k = \frac{(A s)^H s}{(A s)^H (A s)}, \qquad
+ *   x_{k+1}  = x_k + \alpha_k\, p_k + \omega_k\, s, \qquad
+ *   r_{k+1}  = s - \omega_k\, A s.
+ * \f]
  *
  * @tparam ValueType precision of the elements of the system matrix.
  *

--- a/include/ginkgo/core/solver/bicgstab.hpp
+++ b/include/ginkgo/core/solver/bicgstab.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 

--- a/include/ginkgo/core/solver/cb_gmres.hpp
+++ b/include/ginkgo/core/solver/cb_gmres.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 

--- a/include/ginkgo/core/solver/cb_gmres.hpp
+++ b/include/ginkgo/core/solver/cb_gmres.hpp
@@ -92,17 +92,17 @@ enum class storage_precision {
  * \f$ \bar H_m \f$ with
  * \f$ A V_m = V_{m+1} \bar H_m \f$, and the iterate is chosen as
  * \f[
- *   x_m = x_0 + V_m\, y_m,
+ *   x_m = x_0 + V_m y_m,
  *   \qquad
- *   y_m = \arg\min_{y} \| \beta\, e_1 - \bar H_m\, y \|_2.
+ *   y_m = \arg\min_{y} \| \beta e_1 - \bar H_m y \|_2.
  * \f]
  * The "compressed basis" variant stores the columns of \f$ V_m \f$ in a
  * precision lower than ValueType: each basis vector is cast down to the
- * storage type when written and cast back up when read.  The Hessenberg
+ * storage type when written and cast back up when read. The Hessenberg
  * matrix, the Givens rotations, and the working residual all stay in
  * full ValueType precision, so the final approximation has the same
  * accuracy as standard GMRES while the basis storage and the bandwidth
- * needed to apply it are reduced.  See the `storage_precision` enum for
+ * needed to apply it are reduced. See the `storage_precision` enum for
  * the supported compression options.
  *
  * @tparam ValueType  the arithmetic precision and the precision of matrix

--- a/include/ginkgo/core/solver/cb_gmres.hpp
+++ b/include/ginkgo/core/solver/cb_gmres.hpp
@@ -86,6 +86,25 @@ enum class storage_precision {
  * are performed in the same arithmetic precision ValueType. By default, the
  * Krylov basis are stored in one precision lower than ValueType.
  *
+ * Mathematically CB-GMRES is the same algorithm as standard
+ * \ref gko::solver::Gmres "GMRES" — the Arnoldi process produces an
+ * orthonormal basis \f$ V_m \f$ and an upper Hessenberg
+ * \f$ \bar H_m \f$ with
+ * \f$ A V_m = V_{m+1} \bar H_m \f$, and the iterate is chosen as
+ * \f[
+ *   x_m = x_0 + V_m\, y_m,
+ *   \qquad
+ *   y_m = \arg\min_{y} \| \beta\, e_1 - \bar H_m\, y \|_2.
+ * \f]
+ * The "compressed basis" variant stores the columns of \f$ V_m \f$ in a
+ * precision lower than ValueType: each basis vector is cast down to the
+ * storage type when written and cast back up when read.  The Hessenberg
+ * matrix, the Givens rotations, and the working residual all stay in
+ * full ValueType precision, so the final approximation has the same
+ * accuracy as standard GMRES while the basis storage and the bandwidth
+ * needed to apply it are reduced.  See the `storage_precision` enum for
+ * the supported compression options.
+ *
  * @tparam ValueType  the arithmetic precision and the precision of matrix
  *                    elements
  *

--- a/include/ginkgo/core/solver/cg.hpp
+++ b/include/ginkgo/core/solver/cg.hpp
@@ -54,7 +54,7 @@ namespace solver {
  *   p_k = z_k + \beta_k p_{k-1}.
  * \f]
  * This formula assumes that \f$ M \f$ stays fixed across iterations; for a
- * varying preconditioner use the Polak-Ribière variant in
+ * varying preconditioner, use the Polak-Ribière variant in
  * \ref gko::solver::Fcg "FCG".
  *
  * The implementation in Ginkgo makes use of the merged kernel to make the best

--- a/include/ginkgo/core/solver/cg.hpp
+++ b/include/ginkgo/core/solver/cg.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 

--- a/include/ginkgo/core/solver/cg.hpp
+++ b/include/ginkgo/core/solver/cg.hpp
@@ -37,10 +37,10 @@ namespace solver {
  *
  * CG constructs a sequence of search directions \f$ p_0, p_1, \ldots \f$
  * that are mutually \f$ A \f$-conjugate (\f$ \langle p_i, A p_j \rangle = 0
- * \f$ for \f$ i \ne j \f$).  The iterate chosen along these directions
- * minimises the error in the energy norm over the affine Krylov subspace,
+ * \f$ for \f$ i \ne j \f$). The iterate chosen along these directions
+ * minimizes the error in the energy norm over the affine Krylov subspace,
  * \f[
- *   x_k = \arg\min_{x \,\in\, x_0 + \mathcal{K}_k(A, r_0)}
+ *   x_k = \arg\min_{x \in x_0 + \mathcal{K}_k(A, r_0)}
  *         \| x - x^{*} \|_A,
  *   \qquad \| e \|_A = \sqrt{\langle e, A e \rangle},
  * \f]
@@ -48,10 +48,10 @@ namespace solver {
  * is built from the preconditioned residual \f$ z_k = M r_k \f$ and the
  * previous direction via the Fletcher-Reeves coefficient
  * \f[
- *   \beta_k = \frac{\langle r_k,\, z_k \rangle}
- *                  {\langle r_{k-1},\, z_{k-1} \rangle},
+ *   \beta_k = \frac{\langle r_k, z_k \rangle}
+ *                  {\langle r_{k-1}, z_{k-1} \rangle},
  *   \qquad
- *   p_k = z_k + \beta_k\, p_{k-1}.
+ *   p_k = z_k + \beta_k p_{k-1}.
  * \f]
  * This formula assumes that \f$ M \f$ stays fixed across iterations; for a
  * varying preconditioner use the Polak-Ribière variant in

--- a/include/ginkgo/core/solver/cg.hpp
+++ b/include/ginkgo/core/solver/cg.hpp
@@ -35,6 +35,28 @@ namespace solver {
  * Though this method performs very well for symmetric positive definite
  * matrices, it is in general not suitable for general matrices.
  *
+ * CG constructs a sequence of search directions \f$ p_0, p_1, \ldots \f$
+ * that are mutually \f$ A \f$-conjugate (\f$ \langle p_i, A p_j \rangle = 0
+ * \f$ for \f$ i \ne j \f$).  The iterate chosen along these directions
+ * minimises the error in the energy norm over the affine Krylov subspace,
+ * \f[
+ *   x_k = \arg\min_{x \,\in\, x_0 + \mathcal{K}_k(A, r_0)}
+ *         \| x - x^{*} \|_A,
+ *   \qquad \| e \|_A = \sqrt{\langle e, A e \rangle},
+ * \f]
+ * which yields a short recurrence: at each step the new search direction
+ * is built from the preconditioned residual \f$ z_k = M r_k \f$ and the
+ * previous direction via the Fletcher-Reeves coefficient
+ * \f[
+ *   \beta_k = \frac{\langle r_k,\, z_k \rangle}
+ *                  {\langle r_{k-1},\, z_{k-1} \rangle},
+ *   \qquad
+ *   p_k = z_k + \beta_k\, p_{k-1}.
+ * \f]
+ * This formula assumes that \f$ M \f$ stays fixed across iterations; for a
+ * varying preconditioner use the Polak-Ribière variant in
+ * \ref gko::solver::Fcg "FCG".
+ *
  * The implementation in Ginkgo makes use of the merged kernel to make the best
  * use of data locality. The inner operations in one iteration of CG are merged
  * into 2 separate steps.

--- a/include/ginkgo/core/solver/cgs.hpp
+++ b/include/ginkgo/core/solver/cgs.hpp
@@ -32,17 +32,43 @@ namespace solver {
  * subspace method which is suitable for general systems.
  *
  * CGS rests on the identity that BiCG produces a residual of the form
- * \f$ r_k^{\mathrm{BiCG}} = \psi_k(A)\, r_0 \f$, where \f$ \psi_k \f$ is the
- * residual polynomial.  Squaring this polynomial yields the CGS residual
+ * \f$ r_k^{\mathrm{BiCG}} = \psi_k(A) r_0 \f$, where \f$ \psi_k \f$ is the
+ * residual polynomial. Squaring this polynomial yields the CGS residual
  * \f[
- *   r_k^{\mathrm{CGS}} = \psi_k(A)^2\, r_0,
+ *   r_k^{\mathrm{CGS}} = \psi_k(A)^2 r_0,
  * \f]
  * so the iteration avoids the explicit \f$ A^H \f$ apply that BiCG
- * requires.  The trade-off is that residuals lose monotonicity and can
- * exhibit large oscillations on poorly-conditioned systems — when this
- * matters in practice, \ref gko::solver::Bicgstab "BiCGSTAB" stabilises
- * the same idea at the cost of one extra matrix-vector product per
- * iteration.
+ * requires, and it contracts the residual twice as fast per step when
+ * BiCG converges.
+ *
+ * Starting from \f$ r_0 = b - A x_0 \f$, a shadow residual
+ * \f$ \tilde r_0 \f$ (Ginkgo uses \f$ \tilde r_0 = r_0 \f$),
+ * \f$ q_{-1} = p_{-1} = 0 \f$ and \f$ \rho_{-1} = 1 \f$, one iteration
+ * with the preconditioner \f$ M \approx A^{-1} \f$ reads
+ * \f[
+ *   \begin{aligned}
+ *     \rho_k     &= \langle \tilde r_0, r_k \rangle,
+ *       &\qquad \beta_k   &= \rho_k / \rho_{k-1}, \\
+ *     u_k        &= r_k + \beta_k q_{k-1},
+ *       &\qquad p_k      &= u_k + \beta_k
+ *                             (q_{k-1} + \beta_k p_{k-1}), \\
+ *     \hat v_k   &= A M p_k,
+ *       &\qquad \alpha_k  &= \rho_k /
+ *                             \langle \tilde r_0, \hat v_k \rangle, \\
+ *     q_k        &= u_k - \alpha_k \hat v_k,
+ *       &\qquad \hat u_k  &= M (u_k + q_k), \\
+ *     x_{k+1}    &= x_k + \alpha_k \hat u_k,
+ *       &\qquad r_{k+1}   &= r_k - \alpha_k A \hat u_k.
+ *   \end{aligned}
+ * \f]
+ * The pair \f$ u_k, q_k \f$ takes the place of the single BiCG search
+ * direction, which is why the update of \f$ x \f$ uses their sum. The
+ * trade-off for dropping \f$ A^H \f$ is that the squared polynomial also
+ * squares the error: the residuals lose monotonicity and can oscillate
+ * strongly on poorly conditioned systems. When this matters in practice,
+ * \ref gko::solver::Bicgstab "BiCGSTAB" replaces the second application of
+ * \f$ \psi_k \f$ by a locally minimizing polynomial for the same number of
+ * operator applies and one extra inner product.
  *
  * The implementation in Ginkgo makes use of the merged kernel to make the best
  * use of data locality. The inner operations in one iteration of CGS are merged

--- a/include/ginkgo/core/solver/cgs.hpp
+++ b/include/ginkgo/core/solver/cgs.hpp
@@ -31,6 +31,19 @@ namespace solver {
  * CGS or the conjugate gradient square method is an iterative type Krylov
  * subspace method which is suitable for general systems.
  *
+ * CGS rests on the identity that BiCG produces a residual of the form
+ * \f$ r_k^{\mathrm{BiCG}} = \psi_k(A)\, r_0 \f$, where \f$ \psi_k \f$ is the
+ * residual polynomial.  Squaring this polynomial yields the CGS residual
+ * \f[
+ *   r_k^{\mathrm{CGS}} = \psi_k(A)^2\, r_0,
+ * \f]
+ * so the iteration avoids the explicit \f$ A^H \f$ apply that BiCG
+ * requires.  The trade-off is that residuals lose monotonicity and can
+ * exhibit large oscillations on poorly-conditioned systems — when this
+ * matters in practice, \ref gko::solver::Bicgstab "BiCGSTAB" stabilises
+ * the same idea at the cost of one extra matrix-vector product per
+ * iteration.
+ *
  * The implementation in Ginkgo makes use of the merged kernel to make the best
  * use of data locality. The inner operations in one iteration of CGS are merged
  * into 3 separate steps.

--- a/include/ginkgo/core/solver/cgs.hpp
+++ b/include/ginkgo/core/solver/cgs.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 

--- a/include/ginkgo/core/solver/chebyshev.hpp
+++ b/include/ginkgo/core/solver/chebyshev.hpp
@@ -39,9 +39,6 @@ using coeff_type =
  * matrix. It avoids the computation of inner products, which may be a
  * performance bottleneck for distributed system. Chebyshev iteration is
  * developed based on Chebyshev polynomials of the first kind.
- * This implementation follows the algorithm in "Templates for the
- * Solution of Linear Systems: Building Blocks for Iterative Methods, 2nd
- * Edition".
  *
  * Given a preconditioner \f$ M \approx A^{-1} \f$, the iterate is updated
  * with the three-term recurrence
@@ -61,6 +58,11 @@ using coeff_type =
  * solution_{i-1})
  * ```
  *
+ * @par References
+ * - Barrett, R., Berry, M., Chan, T. F., et al.
+ *   *Templates for the Solution of Linear Systems: Building Blocks for
+ *   Iterative Methods.* 2nd ed. SIAM, 1994.
+ *   <https://doi.org/10.1137/1.9781611971538>
  *
  * @tparam ValueType  precision of matrix elements
  *

--- a/include/ginkgo/core/solver/chebyshev.hpp
+++ b/include/ginkgo/core/solver/chebyshev.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 The Ginkgo authors
+// SPDX-FileCopyrightText: 2025 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 

--- a/include/ginkgo/core/solver/chebyshev.hpp
+++ b/include/ginkgo/core/solver/chebyshev.hpp
@@ -43,6 +43,15 @@ using coeff_type =
  * Solution of Linear Systems: Building Blocks for Iterative Methods, 2nd
  * Edition".
  *
+ * Given a preconditioner \f$ M \approx A^{-1} \f$, the iterate is updated
+ * with the three-term recurrence
+ * \f[
+ *   x_{k+1} = x_k + \alpha_k \, M (b - A x_k)
+ *                 + \beta_k \, (x_k - x_{k-1}),
+ * \f]
+ * where the scalars \f$ \alpha_k, \beta_k \f$ are derived from an estimate
+ * of the spectrum of \f$ M A \f$.  In pseudo-code:
+ *
  * ```
  * solution = initial_guess
  * while not converged:

--- a/include/ginkgo/core/solver/chebyshev.hpp
+++ b/include/ginkgo/core/solver/chebyshev.hpp
@@ -43,11 +43,11 @@ using coeff_type =
  * Given a preconditioner \f$ M \approx A^{-1} \f$, the iterate is updated
  * with the three-term recurrence
  * \f[
- *   x_{k+1} = x_k + \alpha_k \, M (b - A x_k)
- *                 + \beta_k \, (x_k - x_{k-1}),
+ *   x_{k+1} = x_k + \alpha_k M (b - A x_k)
+ *                 + \beta_k (x_k - x_{k-1}),
  * \f]
  * where the scalars \f$ \alpha_k, \beta_k \f$ are derived from an estimate
- * of the spectrum of \f$ M A \f$.  In pseudo-code:
+ * of the spectrum of \f$ M A \f$. In pseudo-code:
  *
  * ```
  * solution = initial_guess

--- a/include/ginkgo/core/solver/fcg.hpp
+++ b/include/ginkgo/core/solver/fcg.hpp
@@ -36,17 +36,25 @@ namespace solver {
  *
  * In contrast to the standard CG, which uses the Fletcher-Reeves formula
  * \f[
- *   \beta_k = \frac{\langle r_k,\, z_k \rangle}
- *                  {\langle r_{k-1},\, z_{k-1} \rangle},
+ *   \beta_k = \frac{\langle r_k, z_k \rangle}
+ *                  {\langle r_{k-1}, z_{k-1} \rangle},
  * \f]
  * the flexible CG uses the Polak-Ribière formula
  * \f[
- *   \beta_k = \frac{\langle r_k - r_{k-1},\, z_k \rangle}
- *                  {\langle r_{k-1},\, z_{k-1} \rangle}
+ *   \beta_k = \frac{\langle r_k - r_{k-1}, z_k \rangle}
+ *                  {\langle r_{k-1}, z_{k-1} \rangle}
  * \f]
- * for the next search direction.  This requires one additional inner
- * product per iteration but allows the preconditioner \f$ M \f$ (and
- * therefore \f$ z = M r \f$) to change between iterations — useful when
+ * for the next search direction. In CG the denominator
+ * \f$ \langle r_{k-1}, z_{k-1} \rangle \f$ is exactly the numerator that
+ * the previous iteration already computed, so a single dot product per
+ * iteration is enough. FCG still needs \f$ \langle r_k, z_k \rangle \f$
+ * as the denominator of the next iteration, and has to compute
+ * \f$ \langle r_k - r_{k-1}, z_k \rangle \f$ on top of it — one extra dot
+ * product, and therefore one extra global reduction, per iteration.
+ *
+ * In exchange, \f$ \beta_k \f$ no longer relies on the search directions
+ * staying \f$ A \f$-conjugate, so the preconditioner \f$ M \f$ (and
+ * therefore \f$ z = M r \f$) may change between iterations — useful when
  * the preconditioner is itself an inner iterative solve, a randomized
  * smoother, or otherwise not a fixed linear operator.
  *

--- a/include/ginkgo/core/solver/fcg.hpp
+++ b/include/ginkgo/core/solver/fcg.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 

--- a/include/ginkgo/core/solver/fcg.hpp
+++ b/include/ginkgo/core/solver/fcg.hpp
@@ -34,10 +34,21 @@ namespace solver {
  * Though this method performs very well for symmetric positive definite
  * matrices, it is in general not suitable for general matrices.
  *
- * In contrast to the standard CG based on the Polack-Ribiere formula, the
- * flexible CG uses the Fletcher-Reeves formula for creating the orthonormal
- * vectors spanning the Krylov subspace. This increases the computational cost
- * of every Krylov solver iteration but allows for non-constant preconditioners.
+ * In contrast to the standard CG, which uses the Fletcher-Reeves formula
+ * \f[
+ *   \beta_k = \frac{\langle r_k,\, z_k \rangle}
+ *                  {\langle r_{k-1},\, z_{k-1} \rangle},
+ * \f]
+ * the flexible CG uses the Polak-Ribière formula
+ * \f[
+ *   \beta_k = \frac{\langle r_k - r_{k-1},\, z_k \rangle}
+ *                  {\langle r_{k-1},\, z_{k-1} \rangle}
+ * \f]
+ * for the next search direction.  This requires one additional inner
+ * product per iteration but allows the preconditioner \f$ M \f$ (and
+ * therefore \f$ z = M r \f$) to change between iterations — useful when
+ * the preconditioner is itself an inner iterative solve, a randomized
+ * smoother, or otherwise not a fixed linear operator.
  *
  * The implementation in Ginkgo makes use of the merged kernel to make the best
  * use of data locality. The inner operations in one iteration of FCG are

--- a/include/ginkgo/core/solver/gcr.hpp
+++ b/include/ginkgo/core/solver/gcr.hpp
@@ -35,6 +35,25 @@ constexpr size_type gcr_default_krylov_dim = 100u;
  * subspace method similar to GMRES which is suitable for nonsymmetric linear
  * systems.
  *
+ * GCR maintains a sequence of search directions \f$ p_0, p_1, \ldots \f$
+ * chosen so that the vectors \f$ A p_k \f$ are mutually orthogonal,
+ * \f$ \langle A p_i, A p_j \rangle = 0 \f$ for \f$ i \ne j \f$.  At each
+ * iteration the residual is updated by orthogonal projection along
+ * \f$ A p_k \f$,
+ * \f[
+ *   \alpha_k = \frac{\langle r_k,\, A p_k \rangle}
+ *                   {\langle A p_k,\, A p_k \rangle},
+ *   \qquad
+ *   r_{k+1} = r_k - \alpha_k\, A p_k,
+ * \f]
+ * so the iterate
+ * \f$ x_k = x_0 + \sum_{j<k} \alpha_j\, p_j \f$ minimises
+ * \f$ \| r \|_2 \f$ over \f$ x_0 + \mathcal{K}_k(A, r_0) \f$ — the same
+ * minimisation property as GMRES, but with a long recurrence over the
+ * search directions instead of an Arnoldi basis and Hessenberg solve.
+ * The memory cost grows linearly with the iteration count, so GCR is
+ * typically run with a restart parameter (`krylov_dim`).
+ *
  * The implementation in Ginkgo makes use of the merged kernel to make the best
  * use of data locality. The inner operations in one iteration of GCR are
  * merged into one step. Modified Gram-Schmidt is used.

--- a/include/ginkgo/core/solver/gcr.hpp
+++ b/include/ginkgo/core/solver/gcr.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 

--- a/include/ginkgo/core/solver/gcr.hpp
+++ b/include/ginkgo/core/solver/gcr.hpp
@@ -37,19 +37,19 @@ constexpr size_type gcr_default_krylov_dim = 100u;
  *
  * GCR maintains a sequence of search directions \f$ p_0, p_1, \ldots \f$
  * chosen so that the vectors \f$ A p_k \f$ are mutually orthogonal,
- * \f$ \langle A p_i, A p_j \rangle = 0 \f$ for \f$ i \ne j \f$.  At each
+ * \f$ \langle A p_i, A p_j \rangle = 0 \f$ for \f$ i \ne j \f$. At each
  * iteration the residual is updated by orthogonal projection along
  * \f$ A p_k \f$,
  * \f[
- *   \alpha_k = \frac{\langle r_k,\, A p_k \rangle}
- *                   {\langle A p_k,\, A p_k \rangle},
+ *   \alpha_k = \frac{\langle r_k, A p_k \rangle}
+ *                   {\langle A p_k, A p_k \rangle},
  *   \qquad
- *   r_{k+1} = r_k - \alpha_k\, A p_k,
+ *   r_{k+1} = r_k - \alpha_k A p_k,
  * \f]
  * so the iterate
- * \f$ x_k = x_0 + \sum_{j<k} \alpha_j\, p_j \f$ minimises
+ * \f$ x_k = x_0 + \sum_{j<k} \alpha_j p_j \f$ minimizes
  * \f$ \| r \|_2 \f$ over \f$ x_0 + \mathcal{K}_k(A, r_0) \f$ — the same
- * minimisation property as GMRES, but with a long recurrence over the
+ * minimization property as GMRES, but with a long recurrence over the
  * search directions instead of an Arnoldi basis and Hessenberg solve.
  * The memory cost grows linearly with the iteration count, so GCR is
  * typically run with a restart parameter (`krylov_dim`).

--- a/include/ginkgo/core/solver/gmres.hpp
+++ b/include/ginkgo/core/solver/gmres.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 

--- a/include/ginkgo/core/solver/gmres.hpp
+++ b/include/ginkgo/core/solver/gmres.hpp
@@ -62,16 +62,16 @@ std::ostream& operator<<(std::ostream& stream, ortho_method ortho);
  * The Arnoldi process builds an orthonormal basis \f$ V_m \f$ of the Krylov
  * subspace
  * \f[
- *   \mathcal{K}_m(A, r_0) = \mathrm{span}\{r_0,\, A r_0,\, A^2 r_0,\, \ldots,\,
+ *   \mathcal{K}_m(A, r_0) = \mathrm{span}\{r_0, A r_0, A^2 r_0, \ldots,
  *                                          A^{m-1} r_0\},
  * \f]
  * and produces an upper Hessenberg matrix \f$ \bar H_m \f$ satisfying the
- * Arnoldi relation \f$ A V_m = V_{m+1} \bar H_m \f$.  GMRES then chooses the
+ * Arnoldi relation \f$ A V_m = V_{m+1} \bar H_m \f$. GMRES then chooses the
  * approximate solution
- * \f$ x_m = x_0 + V_m y_m \f$ with \f$ y_m \f$ minimising the residual norm
+ * \f$ x_m = x_0 + V_m y_m \f$ with \f$ y_m \f$ minimizing the residual norm
  * over the subspace,
  * \f[
- *   y_m = \arg\min_{y \in \mathbb{R}^m} \| \beta\, e_1 - \bar H_m\, y \|_2,
+ *   y_m = \arg\min_{y \in \mathbb{R}^m} \| \beta e_1 - \bar H_m y \|_2,
  *   \qquad \beta = \| r_0 \|_2.
  * \f]
  *

--- a/include/ginkgo/core/solver/gmres.hpp
+++ b/include/ginkgo/core/solver/gmres.hpp
@@ -59,6 +59,22 @@ std::ostream& operator<<(std::ostream& stream, ortho_method ortho);
  * GMRES or the generalized minimal residual method is an iterative type Krylov
  * subspace method which is suitable for nonsymmetric linear systems.
  *
+ * The Arnoldi process builds an orthonormal basis \f$ V_m \f$ of the Krylov
+ * subspace
+ * \f[
+ *   \mathcal{K}_m(A, r_0) = \mathrm{span}\{r_0,\, A r_0,\, A^2 r_0,\, \ldots,\,
+ *                                          A^{m-1} r_0\},
+ * \f]
+ * and produces an upper Hessenberg matrix \f$ \bar H_m \f$ satisfying the
+ * Arnoldi relation \f$ A V_m = V_{m+1} \bar H_m \f$.  GMRES then chooses the
+ * approximate solution
+ * \f$ x_m = x_0 + V_m y_m \f$ with \f$ y_m \f$ minimising the residual norm
+ * over the subspace,
+ * \f[
+ *   y_m = \arg\min_{y \in \mathbb{R}^m} \| \beta\, e_1 - \bar H_m\, y \|_2,
+ *   \qquad \beta = \| r_0 \|_2.
+ * \f]
+ *
  * The implementation in Ginkgo makes use of the merged kernel to make the best
  * use of data locality. The inner operations in one iteration of GMRES are
  * merged into 2 separate steps. Modified Gram-Schmidt is used.

--- a/include/ginkgo/core/solver/idr.hpp
+++ b/include/ginkgo/core/solver/idr.hpp
@@ -36,9 +36,8 @@ namespace solver {
 
 /**
  * IDR(s) is an efficient method for solving large nonsymmetric systems of
- * linear equations. The implemented version is the one presented in the
- * paper "Algorithm 913: An elegant IDR(s) variant that efficiently exploits
- * biorthogonality properties" by M. B. Van Gijzen and P. Sonneveld.
+ * linear equations. The implementation follows the elegant variant that
+ * exploits the biorthogonality of the shadow vectors.
  *
  * The method is based on the induced dimension reduction theorem.  Fixing a
  * full-rank shadow space \f$ R = \mathrm{span}(r_1, \ldots, r_s) \f$ — the
@@ -52,6 +51,13 @@ namespace solver {
  * forced into these shrinking spaces and become identically zero after at
  * most \f$ N + N/s \f$ iterations in exact arithmetic — substantially fewer
  * matrix-vector products than the \f$ 2N \f$ BiCG would require.
+ *
+ * @par References
+ * - Van Gijzen, M. B., Sonneveld, P.
+ *   *Algorithm 913: An Elegant IDR(s) Variant that Efficiently Exploits
+ *   Biorthogonality Properties.*
+ *   ACM Transactions on Mathematical Software, 38 (1), Article 5, 2011.
+ *   <https://doi.org/10.1145/2049662.2049667>
  *
  * @tparam ValueType  precision of the elements of the system matrix.
  *

--- a/include/ginkgo/core/solver/idr.hpp
+++ b/include/ginkgo/core/solver/idr.hpp
@@ -192,8 +192,8 @@ public:
         size_type GKO_FACTORY_PARAMETER_SCALAR(subspace_dim, 2u);
 
         /**
-         * Threshold to determine if Av_n and v_n are too close to being
-         * perpendicular.
+         * Threshold to determine if \f$Av_n\f$ and \f$v_n\f$ are too close
+         * to being perpendicular.
          * This is considered to be the case if
          * \f$|(Av_n)^H * v_n / (norm(Av_n) * norm(v_n))| < kappa\f$
          */

--- a/include/ginkgo/core/solver/idr.hpp
+++ b/include/ginkgo/core/solver/idr.hpp
@@ -180,7 +180,7 @@ public:
          * Threshold to determine if Av_n and v_n are too close to being
          * perpendicular.
          * This is considered to be the case if
-         * $|(Av_n)^H * v_n / (norm(Av_n) * norm(v_n))| < kappa$
+         * \f$|(Av_n)^H * v_n / (norm(Av_n) * norm(v_n))| < kappa\f$
          */
         remove_complex<ValueType> GKO_FACTORY_PARAMETER_SCALAR(kappa, 0.7);
 

--- a/include/ginkgo/core/solver/idr.hpp
+++ b/include/ginkgo/core/solver/idr.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 

--- a/include/ginkgo/core/solver/idr.hpp
+++ b/include/ginkgo/core/solver/idr.hpp
@@ -39,18 +39,26 @@ namespace solver {
  * linear equations. The implementation follows the elegant variant that
  * exploits the biorthogonality of the shadow vectors.
  *
- * The method is based on the induced dimension reduction theorem.  Fixing a
- * full-rank shadow space \f$ R = \mathrm{span}(r_1, \ldots, r_s) \f$ — the
- * \f$ s \f$ random orthonormal vectors stored in a dense matrix — the
- * theorem guarantees the existence of a sequence of nested subspaces
+ * The method is based on the induced dimension reduction (IDR) theorem.
+ * Let \f$ P = [p_1, \ldots, p_s] \f$ be the shadow matrix — the \f$ s \f$
+ * random, orthonormalized vectors that Ginkgo stores in a dense matrix —
+ * and let
  * \f[
- *   \mathcal{G}_{j+1} = (I - \omega_j A)\, (\mathcal{G}_j \cap R^{\perp}),
- *   \qquad \mathcal{G}_0 = \mathbb{R}^N,
+ *   \mathcal{S} = \{ v \in \mathbb{C}^N : P^H v = 0 \}
  * \f]
- * each strictly contained in its predecessor.  Successive residuals are
- * forced into these shrinking spaces and become identically zero after at
- * most \f$ N + N/s \f$ iterations in exact arithmetic — substantially fewer
- * matrix-vector products than the \f$ 2N \f$ BiCG would require.
+ * be its left null space, that is, the orthogonal complement of the space
+ * spanned by the shadow vectors. Starting from the full Krylov space
+ * \f$ \mathcal{G}_0 = \mathcal{K}_N(A, r_0) \f$, the theorem states that
+ * the subspaces
+ * \f[
+ *   \mathcal{G}_j = (I - \omega_j A) (\mathcal{G}_{j-1} \cap \mathcal{S}),
+ *   \qquad \omega_j \ne 0,
+ * \f]
+ * are nested, \f$ \mathcal{G}_j \subset \mathcal{G}_{j-1} \f$, and that
+ * \f$ \mathcal{G}_j = \{0\} \f$ for some \f$ j \le N \f$. IDR(s) forces
+ * the residuals into these shrinking spaces; in exact arithmetic it
+ * therefore reaches the true solution after at most \f$ N + N/s \f$
+ * matrix-vector products.
  *
  * @par References
  * - Van Gijzen, M. B., Sonneveld, P.
@@ -58,6 +66,13 @@ namespace solver {
  *   Biorthogonality Properties.*
  *   ACM Transactions on Mathematical Software, 38 (1), Article 5, 2011.
  *   <https://doi.org/10.1145/2049662.2049667>
+ *   (the implemented variant; the IDR theorem is Theorem 2.1 in Section 2.1)
+ * - Sonneveld, P., Van Gijzen, M. B.
+ *   *IDR(s): A Family of Simple and Fast Algorithms for Solving Large
+ *   Nonsymmetric Systems of Linear Equations.*
+ *   SIAM Journal on Scientific Computing, 31 (2), 1035–1062, 2008.
+ *   <https://doi.org/10.1137/070685804>
+ *   (proof of the IDR theorem and of the \f$ N + N/s \f$ bound)
  *
  * @tparam ValueType  precision of the elements of the system matrix.
  *

--- a/include/ginkgo/core/solver/idr.hpp
+++ b/include/ginkgo/core/solver/idr.hpp
@@ -40,11 +40,18 @@ namespace solver {
  * paper "Algorithm 913: An elegant IDR(s) variant that efficiently exploits
  * biorthogonality properties" by M. B. Van Gijzen and P. Sonneveld.
  *
- * The method is based on the induced dimension reduction theorem which
- * provides a way to construct subsequent residuals that lie in a sequence
- * of shrinking subspaces. These subspaces are spanned by s vectors which are
- * first generated randomly and then orthonormalized. They are stored in
- * a dense matrix.
+ * The method is based on the induced dimension reduction theorem.  Fixing a
+ * full-rank shadow space \f$ R = \mathrm{span}(r_1, \ldots, r_s) \f$ — the
+ * \f$ s \f$ random orthonormal vectors stored in a dense matrix — the
+ * theorem guarantees the existence of a sequence of nested subspaces
+ * \f[
+ *   \mathcal{G}_{j+1} = (I - \omega_j A)\, (\mathcal{G}_j \cap R^{\perp}),
+ *   \qquad \mathcal{G}_0 = \mathbb{R}^N,
+ * \f]
+ * each strictly contained in its predecessor.  Successive residuals are
+ * forced into these shrinking spaces and become identically zero after at
+ * most \f$ N + N/s \f$ iterations in exact arithmetic — substantially fewer
+ * matrix-vector products than the \f$ 2N \f$ BiCG would require.
  *
  * @tparam ValueType  precision of the elements of the system matrix.
  *

--- a/include/ginkgo/core/solver/idr.hpp
+++ b/include/ginkgo/core/solver/idr.hpp
@@ -182,7 +182,7 @@ public:
          * Threshold to determine if Av_n and v_n are too close to being
          * perpendicular.
          * This is considered to be the case if
-         * $|(Av_n)^H * v_n / (norm(Av_n) * norm(v_n))| < kappa$
+         * \f$|(Av_n)^H * v_n / (norm(Av_n) * norm(v_n))| < kappa\f$
          */
         remove_complex<ValueType> GKO_FACTORY_PARAMETER_SCALAR(kappa, 0.7);
 

--- a/include/ginkgo/core/solver/ir.hpp
+++ b/include/ginkgo/core/solver/ir.hpp
@@ -37,11 +37,11 @@ namespace solver {
  * obtained as the solution to the residual equation `Ae = residual`, since `A e
  * = Ax - A solution = b - A solution = residual`. Then, the real solution is
  * computed as `x = relaxation_factor * solution + e`. Instead of accurately
- * solving the residual equation `Ae = residual`, the solution of the system `e`
- * can be approximated to obtain the approximation `error` using a coarse method
- * `solver`, which is used to update `solution`, and the entire process is
- * repeated with the updated `solution`.  This yields the iterative refinement
- * method:
+ * solving the residual equation \f$ A e = r \f$, the solution of the
+ * system \f$ e \f$ can be approximated to obtain the approximation
+ * `error` using a coarse method `solver`, which is used to update
+ * `solution`, and the entire process is repeated with the updated
+ * `solution`.  This yields the iterative refinement method:
  *
  * ```
  * solution = initial_guess
@@ -56,21 +56,23 @@ namespace solver {
  * solver is a Richardson iteration, with possibility for additional
  * preconditioning.
  *
- * Assuming that `solver` has accuracy `c`, i.e., `| e - error | <= c | e |`,
- * iterative refinement will converge with a convergence rate of `c`. Indeed,
- * from `e - error = x - solution - error = x - solution*` (where `solution*`
- * denotes the value stored in `solution` after the update) and `e = inv(A)
- * residual = inv(A)b - inv(A) A solution = x - solution` it follows that | x -
- * solution* | <= c | x - solution |.
+ * Assuming that `solver` has accuracy \f$ c \f$, i.e.
+ * \f$ \| e - \tilde{e} \| \le c \, \| e \| \f$, iterative refinement will
+ * converge with a convergence rate of \f$ c \f$.  Indeed, from
+ * \f$ e - \tilde{e} = x - x_k - \tilde{e} = x - x_{k+1} \f$ (where
+ * \f$ x_{k+1} \f$ denotes the value stored in `solution` after the update)
+ * and \f$ e = A^{-1} r = A^{-1} b - A^{-1} A x_k = x - x_k \f$ it follows
+ * that \f$ \| x - x_{k+1} \| \le c \, \| x - x_k \| \f$.
  *
  * Unless otherwise specified via the `solver` factory parameter, this
  * implementation uses the identity operator (i.e. the solver that approximates
- * the solution of a system Ax = b by setting x := b) as the default inner
- * solver. Such a setting results in a relaxation method known as the Richardson
- * iteration with parameter 1, which is guaranteed to converge for matrices
- * whose spectrum is strictly contained within the unit disc around 1 (i.e., all
- * its eigenvalues `lambda` have to satisfy the equation `|relaxation_factor *
- * lambda - 1| < 1).
+ * the solution of a system \f$ A x = b \f$ by setting \f$ x := b \f$) as the
+ * default inner solver.  Such a setting results in a relaxation method known
+ * as the Richardson iteration with parameter 1, which is guaranteed to
+ * converge for matrices whose spectrum is strictly contained within the unit
+ * disc around 1 — i.e. all eigenvalues \f$ \lambda \f$ must satisfy
+ * \f$ |\, \alpha \, \lambda - 1 \,| < 1 \f$, where \f$ \alpha \f$ is the
+ * relaxation factor.
  *
  * @tparam ValueType  precision of matrix elements
  *

--- a/include/ginkgo/core/solver/ir.hpp
+++ b/include/ginkgo/core/solver/ir.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 

--- a/include/ginkgo/core/solver/ir.hpp
+++ b/include/ginkgo/core/solver/ir.hpp
@@ -41,7 +41,7 @@ namespace solver {
  * system \f$ e \f$ can be approximated to obtain the approximation
  * `error` using a coarse method `solver`, which is used to update
  * `solution`, and the entire process is repeated with the updated
- * `solution`.  This yields the iterative refinement method:
+ * `solution`. This yields the iterative refinement method:
  *
  * ```
  * solution = initial_guess
@@ -57,21 +57,21 @@ namespace solver {
  * preconditioning.
  *
  * Assuming that `solver` has accuracy \f$ c \f$, i.e.
- * \f$ \| e - \tilde{e} \| \le c \, \| e \| \f$, iterative refinement will
- * converge with a convergence rate of \f$ c \f$.  Indeed, from
+ * \f$ \| e - \tilde{e} \| \le c \| e \| \f$, iterative refinement will
+ * converge with a convergence rate of \f$ c \f$. Indeed, from
  * \f$ e - \tilde{e} = x - x_k - \tilde{e} = x - x_{k+1} \f$ (where
  * \f$ x_{k+1} \f$ denotes the value stored in `solution` after the update)
  * and \f$ e = A^{-1} r = A^{-1} b - A^{-1} A x_k = x - x_k \f$ it follows
- * that \f$ \| x - x_{k+1} \| \le c \, \| x - x_k \| \f$.
+ * that \f$ \| x - x_{k+1} \| \le c \| x - x_k \| \f$.
  *
  * Unless otherwise specified via the `solver` factory parameter, this
  * implementation uses the identity operator (i.e. the solver that approximates
  * the solution of a system \f$ A x = b \f$ by setting \f$ x := b \f$) as the
- * default inner solver.  Such a setting results in a relaxation method known
+ * default inner solver. Such a setting results in a relaxation method known
  * as the Richardson iteration with parameter 1, which is guaranteed to
  * converge for matrices whose spectrum is strictly contained within the unit
  * disc around 1 — i.e. all eigenvalues \f$ \lambda \f$ must satisfy
- * \f$ |\, \alpha \, \lambda - 1 \,| < 1 \f$, where \f$ \alpha \f$ is the
+ * \f$ |\alpha \lambda - 1| < 1 \f$, where \f$ \alpha \f$ is the
  * relaxation factor.
  *
  * @tparam ValueType  precision of matrix elements

--- a/include/ginkgo/core/solver/ir.hpp
+++ b/include/ginkgo/core/solver/ir.hpp
@@ -31,17 +31,25 @@ namespace solver {
  * residual. Moreover, it can be also considered as preconditioned Richardson
  * iteration with relaxation factor = 1.
  *
- * For any approximation of the solution `solution` to the system `Ax = b`, the
- * residual is defined as: `residual = b - A solution`. The error in
- * `solution`,  `e = x - solution` (with `x` being the exact solution) can be
- * obtained as the solution to the residual equation `Ae = residual`, since `A e
- * = Ax - A solution = b - A solution = residual`. Then, the real solution is
- * computed as `x = relaxation_factor * solution + e`. Instead of accurately
- * solving the residual equation \f$ A e = r \f$, the solution of the
- * system \f$ e \f$ can be approximated to obtain the approximation
- * `error` using a coarse method `solver`, which is used to update
- * `solution`, and the entire process is repeated with the updated
- * `solution`. This yields the iterative refinement method:
+ * Let \f$ x_k \f$ be the approximation of the solution of \f$ A x = b \f$
+ * after \f$ k \f$ iterations and let \f$ x \f$ denote the exact solution.
+ * The residual and the error of \f$ x_k \f$ are
+ * \f[
+ *   r_k = b - A x_k, \qquad e_k = x - x_k,
+ * \f]
+ * and they are linked by the residual equation
+ * \f$ A e_k = A x - A x_k = b - A x_k = r_k \f$. Knowing \f$ e_k \f$
+ * exactly would give the exact solution in a single update
+ * \f$ x = x_k + e_k \f$. Instead of solving \f$ A e_k = r_k \f$ exactly,
+ * IR approximates \f$ e_k \f$ by \f$ \tilde e_k \f$ using a cheap inner
+ * `solver`, applies that correction with a relaxation factor
+ * \f$ \alpha \f$,
+ * \f[
+ *   x_{k+1} = x_k + \alpha \tilde e_k,
+ * \f]
+ * and repeats the process with the updated iterate. Written with the names
+ * used below, \f$ x_k \f$ is `solution`, \f$ r_k \f$ is `residual` and
+ * \f$ \tilde e_k \f$ is `error`:
  *
  * ```
  * solution = initial_guess
@@ -56,23 +64,24 @@ namespace solver {
  * solver is a Richardson iteration, with possibility for additional
  * preconditioning.
  *
- * Assuming that `solver` has accuracy \f$ c \f$, i.e.
- * \f$ \| e - \tilde{e} \| \le c \| e \| \f$, iterative refinement will
- * converge with a convergence rate of \f$ c \f$. Indeed, from
- * \f$ e - \tilde{e} = x - x_k - \tilde{e} = x - x_{k+1} \f$ (where
- * \f$ x_{k+1} \f$ denotes the value stored in `solution` after the update)
- * and \f$ e = A^{-1} r = A^{-1} b - A^{-1} A x_k = x - x_k \f$ it follows
- * that \f$ \| x - x_{k+1} \| \le c \| x - x_k \| \f$.
+ * Assume \f$ \alpha = 1 \f$ and that `solver` has accuracy \f$ c \f$,
+ * i.e. \f$ \| e_k - \tilde e_k \| \le c \| e_k \| \f$. Then iterative
+ * refinement converges with a convergence rate of \f$ c \f$: from
+ * \f$ e_k - \tilde e_k = (x - x_k) - \tilde e_k = x - x_{k+1} \f$ it
+ * follows that \f$ \| x - x_{k+1} \| \le c \| x - x_k \| \f$.
  *
  * Unless otherwise specified via the `solver` factory parameter, this
  * implementation uses the identity operator (i.e. the solver that approximates
  * the solution of a system \f$ A x = b \f$ by setting \f$ x := b \f$) as the
- * default inner solver. Such a setting results in a relaxation method known
- * as the Richardson iteration with parameter 1, which is guaranteed to
- * converge for matrices whose spectrum is strictly contained within the unit
- * disc around 1 — i.e. all eigenvalues \f$ \lambda \f$ must satisfy
- * \f$ |\alpha \lambda - 1| < 1 \f$, where \f$ \alpha \f$ is the
- * relaxation factor.
+ * default inner solver. It leaves the residual unchanged,
+ * \f$ \tilde e_k = r_k \f$, so the iteration reduces to the Richardson
+ * iteration \f$ x_{k+1} = x_k + \alpha r_k \f$, which converges for every
+ * initial guess if and only if \f$ | 1 - \alpha \lambda | < 1 \f$ holds for
+ * every eigenvalue \f$ \lambda \f$ of \f$ A \f$.
+ *
+ * @par References
+ * - Saad, Y. *Iterative Methods for Sparse Linear Systems.* 2nd ed.
+ *   SIAM, 2003. <https://doi.org/10.1137/1.9780898718003>
  *
  * @tparam ValueType  precision of matrix elements
  *

--- a/include/ginkgo/core/solver/minres.hpp
+++ b/include/ginkgo/core/solver/minres.hpp
@@ -32,7 +32,7 @@ namespace solver {
  * specialization of the Gmres method for symmetric/hermitian operators, and can
  * be computed using short recurrences, similar to the CG method.
  *
- * For symmetric \f$ A \f$ the Arnoldi process collapses to a three-term
+ * For symmetric \f$ A \f$, the Arnoldi process collapses to a three-term
  * Lanczos recurrence and the Hessenberg matrix \f$ \bar H_m \f$ becomes
  * tridiagonal \f$ \bar T_m \f$. Minres exploits this structure to
  * minimize the residual norm
@@ -63,11 +63,11 @@ namespace solver {
  *   <https://web.stanford.edu/group/SOL/dissertations/sou-cheng-choi-thesis.pdf>
  *
  * @note The Minres solver only reports an approximation of the residual norm
- *        directly to the stopping criteria. Neither the actual residual, nor
- *        the actual residual norm are reported. Thus, to get the minimal
- *        overhead, the gko::stop::ImplicitResidualNorm criteria should be used.
- *        The gko::stop::ResidualNorm criteria will require an additional
- *        matrix-vector product and global reduction.
+ *       directly to the stopping criteria. Neither the actual residual, nor
+ *       the actual residual norm are reported. Thus, to get the minimal
+ *       overhead, the gko::stop::ImplicitResidualNorm criteria should be
+ *       used. The gko::stop::ResidualNorm criteria will require an additional
+ *       matrix-vector product and global reduction.
  *
  * @tparam ValueType  precision of matrix elements
  *

--- a/include/ginkgo/core/solver/minres.hpp
+++ b/include/ginkgo/core/solver/minres.hpp
@@ -34,16 +34,20 @@ namespace solver {
  *
  * For symmetric \f$ A \f$ the Arnoldi process collapses to a three-term
  * Lanczos recurrence and the Hessenberg matrix \f$ \bar H_m \f$ becomes
- * tridiagonal \f$ \bar T_m \f$.  Minres exploits this structure to
- * minimise the residual norm
+ * tridiagonal \f$ \bar T_m \f$. Minres exploits this structure to
+ * minimize the residual norm
  * \f[
- *   y_m = \arg\min_{y \in \mathbb{R}^m} \| \beta\, e_1 - \bar T_m\, y \|_2,
+ *   y_m = \arg\min_{y \in \mathbb{R}^m} \| \beta e_1 - \bar T_m y \|_2,
  *   \qquad \beta = \| r_0 \|_2,
  * \f]
- * using an incremental QR factorisation of \f$ \bar T_m \f$.  The Givens
- * rotations and the resulting short recurrence allow each iteration to
- * run with bounded memory and one matrix-vector product, in contrast to
- * GMRES's growing Krylov basis.
+ * The least-squares problem is not re-solved from scratch: a QR
+ * factorization of \f$ \bar T_m \f$ is carried along and extended in every
+ * iteration. Since \f$ \bar T_m \f$ is tridiagonal, a new column is
+ * brought to upper-triangular form by re-applying the two previous Givens
+ * rotations and then one freshly computed rotation, so only those
+ * rotations, three basis vectors and three update directions have to be
+ * kept. Each iteration therefore costs one matrix-vector product and a
+ * constant amount of memory, in contrast to GMRES's growing Krylov basis.
  *
  * The implementation in Ginkgo makes use of the merged kernel to make the best
  * use of data locality. The inner operations in one iteration of Minres are

--- a/include/ginkgo/core/solver/minres.hpp
+++ b/include/ginkgo/core/solver/minres.hpp
@@ -49,12 +49,16 @@ namespace solver {
  * use of data locality. The inner operations in one iteration of Minres are
  * merged into 2 separate steps.
  *
- * For more details see Anne Grennbaum's 'Iterative Methods
- * for Solving Linear Systems' (DOI: 10.1137/1.9781611970937), and Sou-Cheng
- * (Terrya) Choi's 'ITERATIVE METHODS FOR SINGULAR LINEAR EQUATIONS AND
- * LEAST-SQUARES PROBLEMS'.
+ * @par References
+ * - Greenbaum, A. *Iterative Methods for Solving Linear Systems.*
+ *   SIAM Frontiers in Applied Mathematics, 17, 1997.
+ *   <https://doi.org/10.1137/1.9781611970937>
+ * - Choi, S.-C. T. *Iterative Methods for Singular Linear Equations and
+ *   Least-Squares Problems.*
+ *   PhD thesis, Stanford University, 2006.
+ *   <https://web.stanford.edu/group/SOL/dissertations/sou-cheng-choi-thesis.pdf>
  *
- * @note: The Minres solver only reports an approximation of the residual norm
+ * @note The Minres solver only reports an approximation of the residual norm
  *        directly to the stopping criteria. Neither the actual residual, nor
  *        the actual residual norm are reported. Thus, to get the minimal
  *        overhead, the gko::stop::ImplicitResidualNorm criteria should be used.

--- a/include/ginkgo/core/solver/minres.hpp
+++ b/include/ginkgo/core/solver/minres.hpp
@@ -32,6 +32,19 @@ namespace solver {
  * specialization of the Gmres method for symmetric/hermitian operators, and can
  * be computed using short recurrences, similar to the CG method.
  *
+ * For symmetric \f$ A \f$ the Arnoldi process collapses to a three-term
+ * Lanczos recurrence and the Hessenberg matrix \f$ \bar H_m \f$ becomes
+ * tridiagonal \f$ \bar T_m \f$.  Minres exploits this structure to
+ * minimise the residual norm
+ * \f[
+ *   y_m = \arg\min_{y \in \mathbb{R}^m} \| \beta\, e_1 - \bar T_m\, y \|_2,
+ *   \qquad \beta = \| r_0 \|_2,
+ * \f]
+ * using an incremental QR factorisation of \f$ \bar T_m \f$.  The Givens
+ * rotations and the resulting short recurrence allow each iteration to
+ * run with bounded memory and one matrix-vector product, in contrast to
+ * GMRES's growing Krylov basis.
+ *
  * The implementation in Ginkgo makes use of the merged kernel to make the best
  * use of data locality. The inner operations in one iteration of Minres are
  * merged into 2 separate steps.

--- a/include/ginkgo/core/solver/minres.hpp
+++ b/include/ginkgo/core/solver/minres.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 

--- a/include/ginkgo/core/solver/multigrid.hpp
+++ b/include/ginkgo/core/solver/multigrid.hpp
@@ -45,11 +45,13 @@ namespace multigrid {
 /**
  * cycle defines which kind of multigrid cycle can be used.
  * It contains V, W, and F cycle.
- * - V, W cycle uses the algorithm according to Briggs, Henson, and McCormick: A
- *   multigrid tutorial 2nd Edition.
- * - F cycle uses the algorithm according to Trottenberg, Oosterlee, and
- *   Schuller: Multigrid 1st Edition. F cycle first uses the recursive call but
- *   second uses the V-cycle call such that F-cycle is between V and W cycle.
+ * - V, W cycles use the algorithm from Briggs–Henson–McCormick
+ *   (*A Multigrid Tutorial*, 2nd ed., SIAM 2000).
+ * - F cycle uses the algorithm from Trottenberg–Oosterlee–Schüller
+ *   (*Multigrid*, 1st ed., Academic Press 2001); F-cycle first does the
+ *   recursive call then a V-cycle call, sitting between V and W in cost.
+ *
+ * See the @ref Multigrid class for the full reference list with DOIs.
  */
 enum class cycle { v, f, w };
 
@@ -82,11 +84,17 @@ class MultigridState;
 
 
 /**
- * Multigrid methods have a hierarchy of many levels, whose corase level is a
- * subset of the fine level, of the problem. The coarse level solves the system
- * on the residual of fine level and fine level will use the coarse solution to
- * correct its own result. Multigrid solves the problem by relatively cheap step
- * in each level and refining the result when prolongating back.
+ * Multigrid solves a linear system by combining cheap iterative sweeps
+ * (smoothers) on a hierarchy of progressively coarser representations of
+ * the operator with corrections transferred between adjacent levels.  A
+ * smoother on the fine level removes the high-frequency components of the
+ * error quickly; the remaining low-frequency error is well-resolved on a
+ * coarser space, where it is computed by a cheaper solve — or, recursively,
+ * by another multigrid call.  The correction is prolongated back to the
+ * fine level and a second smoothing sweep removes any high-frequency error
+ * introduced by the transfer.  Because each coarser level holds only a
+ * fraction of the unknowns of the next, the total work per cycle stays
+ * close to that of a single fine-level matrix-vector apply.
  *
  * Each level \f$ \ell \f$ holds a system matrix \f$ A_\ell \f$, a smoother
  * \f$ S_\ell \f$, a restriction operator
@@ -120,6 +128,13 @@ class MultigridState;
  * Ginkgo uses the index from 0 for finest level (original problem size) ~ N for
  * the coarsest level (the coarsest solver), and its level counts is N (N
  * multigrid level generation).
+ *
+ * @par References
+ * - Briggs, W. L., Henson, V. E., McCormick, S. F.
+ *   *A %Multigrid Tutorial.* 2nd ed. SIAM, 2000.
+ *   <https://doi.org/10.1137/1.9780898719505>
+ * - Trottenberg, U., Oosterlee, C. W., Schüller, A.
+ *   *%Multigrid.* 1st ed. Academic Press, 2001. ISBN 978-0-12-701070-0.
  *
  * @ingroup Multigrid
  * @ingroup solvers

--- a/include/ginkgo/core/solver/multigrid.hpp
+++ b/include/ginkgo/core/solver/multigrid.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 

--- a/include/ginkgo/core/solver/multigrid.hpp
+++ b/include/ginkgo/core/solver/multigrid.hpp
@@ -88,13 +88,34 @@ class MultigridState;
  * correct its own result. Multigrid solves the problem by relatively cheap step
  * in each level and refining the result when prolongating back.
  *
- * The main step of each level
- * - Presmooth (solve on the fine level)
- * - Calculate residual
- * - Restrict (reduce the problem dimension)
- * - Solve residual in next level
- * - Prolongate (return to the fine level size)
- * - Postsmooth (correct the answer in fine level)
+ * Each level \f$ \ell \f$ holds a system matrix \f$ A_\ell \f$, a smoother
+ * \f$ S_\ell \f$, a restriction operator
+ * \f$ R_\ell : \mathbb{R}^{n_\ell} \to \mathbb{R}^{n_{\ell+1}} \f$ and a
+ * prolongation operator
+ * \f$ P_\ell : \mathbb{R}^{n_{\ell+1}} \to \mathbb{R}^{n_\ell} \f$.  The
+ * Galerkin coarse operator is
+ * \f$ A_{\ell+1} = R_\ell\, A_\ell\, P_\ell \f$.  One V-cycle step at
+ * level \f$ \ell \f$ on a fine-level system \f$ A_\ell x = b \f$ is:
+ *
+ * \f[
+ *   \begin{aligned}
+ *     x &\leftarrow x + S_\ell^{\mathrm{pre}}(b - A_\ell x)
+ *       && \text{(pre-smooth)}, \\
+ *     r_{\ell+1} &= R_\ell\, (b - A_\ell x)
+ *       && \text{(restrict)}, \\
+ *     e_{\ell+1} &\approx A_{\ell+1}^{-1}\, r_{\ell+1}
+ *       && \text{(recursive coarse solve)}, \\
+ *     x &\leftarrow x + P_\ell\, e_{\ell+1}
+ *       && \text{(prolongate and correct)}, \\
+ *     x &\leftarrow x + S_\ell^{\mathrm{post}}(b - A_\ell x)
+ *       && \text{(post-smooth)}.
+ *   \end{aligned}
+ * \f]
+ *
+ * At the coarsest level the recursive call is replaced by a direct or
+ * iterative coarse solver.  W- and F-cycles differ from V only in how
+ * many recursive coarse-solves are performed per level (see the
+ * `cycle` enum above).
  *
  * Ginkgo uses the index from 0 for finest level (original problem size) ~ N for
  * the coarsest level (the coarsest solver), and its level counts is N (N

--- a/include/ginkgo/core/solver/multigrid.hpp
+++ b/include/ginkgo/core/solver/multigrid.hpp
@@ -86,13 +86,13 @@ class MultigridState;
 /**
  * Multigrid solves a linear system by combining cheap iterative sweeps
  * (smoothers) on a hierarchy of progressively coarser representations of
- * the operator with corrections transferred between adjacent levels.  A
+ * the operator with corrections transferred between adjacent levels. A
  * smoother on the fine level removes the high-frequency components of the
  * error quickly; the remaining low-frequency error is well-resolved on a
  * coarser space, where it is computed by a cheaper solve — or, recursively,
- * by another multigrid call.  The correction is prolongated back to the
+ * by another multigrid call. The correction is prolongated back to the
  * fine level and a second smoothing sweep removes any high-frequency error
- * introduced by the transfer.  Because each coarser level holds only a
+ * introduced by the transfer. Because each coarser level holds only a
  * fraction of the unknowns of the next, the total work per cycle stays
  * close to that of a single fine-level matrix-vector apply.
  *
@@ -100,20 +100,20 @@ class MultigridState;
  * \f$ S_\ell \f$, a restriction operator
  * \f$ R_\ell : \mathbb{R}^{n_\ell} \to \mathbb{R}^{n_{\ell+1}} \f$ and a
  * prolongation operator
- * \f$ P_\ell : \mathbb{R}^{n_{\ell+1}} \to \mathbb{R}^{n_\ell} \f$.  The
+ * \f$ P_\ell : \mathbb{R}^{n_{\ell+1}} \to \mathbb{R}^{n_\ell} \f$. The
  * Galerkin coarse operator is
- * \f$ A_{\ell+1} = R_\ell\, A_\ell\, P_\ell \f$.  One V-cycle step at
+ * \f$ A_{\ell+1} = R_\ell A_\ell P_\ell \f$. One V-cycle step at
  * level \f$ \ell \f$ on a fine-level system \f$ A_\ell x = b \f$ is:
  *
  * \f[
  *   \begin{aligned}
  *     x &\leftarrow x + S_\ell^{\mathrm{pre}}(b - A_\ell x)
  *       && \text{(pre-smooth)}, \\
- *     r_{\ell+1} &= R_\ell\, (b - A_\ell x)
+ *     r_{\ell+1} &= R_\ell (b - A_\ell x)
  *       && \text{(restrict)}, \\
- *     e_{\ell+1} &\approx A_{\ell+1}^{-1}\, r_{\ell+1}
+ *     e_{\ell+1} &\approx A_{\ell+1}^{-1} r_{\ell+1}
  *       && \text{(recursive coarse solve)}, \\
- *     x &\leftarrow x + P_\ell\, e_{\ell+1}
+ *     x &\leftarrow x + P_\ell e_{\ell+1}
  *       && \text{(prolongate and correct)}, \\
  *     x &\leftarrow x + S_\ell^{\mathrm{post}}(b - A_\ell x)
  *       && \text{(post-smooth)}.
@@ -121,7 +121,7 @@ class MultigridState;
  * \f]
  *
  * At the coarsest level the recursive call is replaced by a direct or
- * iterative coarse solver.  W- and F-cycles differ from V only in how
+ * iterative coarse solver. W- and F-cycles differ from V only in how
  * many recursive coarse-solves are performed per level (see the
  * `cycle` enum above).
  *

--- a/include/ginkgo/core/solver/pipe_cg.hpp
+++ b/include/ginkgo/core/solver/pipe_cg.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 The Ginkgo authors
+// SPDX-FileCopyrightText: 2025 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 

--- a/include/ginkgo/core/solver/pipe_cg.hpp
+++ b/include/ginkgo/core/solver/pipe_cg.hpp
@@ -62,9 +62,11 @@ namespace solver {
  * 3. As the CG itself, this method performs very well for symmetric positive
  * definite matrices but it is in general not suitable for general matrices.
  *
- * The implementation in Ginkgo is based on the following paper:
- * Pipelined, Flexible Krylov Subspace Methods, P. Sanan et. al, SISC, 2016,
- * doi: 10.1137/15M1049130
+ * @par References
+ * - Sanan, P., Schnepp, S. M., May, D. A.
+ *   *Pipelined, Flexible Krylov Subspace Methods.*
+ *   SIAM Journal on Scientific Computing, 38 (5), 2016.
+ *   <https://doi.org/10.1137/15M1049130>
  *
  * @tparam ValueType  precision of matrix elements
  *

--- a/include/ginkgo/core/solver/pipe_cg.hpp
+++ b/include/ginkgo/core/solver/pipe_cg.hpp
@@ -37,6 +37,20 @@ namespace solver {
  * exascale machine, while its standard counterpart level off about one order of
  * magnitude earlier, as suggested in the referenced paper (see below).
  *
+ * Mathematically the iterates \f$ x_k \f$ are the same as those produced
+ * by \ref gko::solver::Cg "CG": the algorithm minimises the energy-norm
+ * error over the Krylov subspace
+ * \f$ x_0 + \mathcal{K}_k(A, r_0) \f$ and uses the same Fletcher-Reeves
+ * \f$ \beta_k \f$.  The pipelining rearrangement maintains additional
+ * auxiliary vectors \f$ s_k = A p_k \f$, \f$ w_k = A z_k \f$ and updates
+ * them via short recurrences so that the global reductions for
+ * \f$ \langle r_k, z_k \rangle \f$, \f$ \langle s_k, p_k \rangle \f$ and
+ * \f$ \langle w_k, z_k \rangle \f$ can be merged and overlapped with the
+ * next matrix-vector product and preconditioner apply.  In exact
+ * arithmetic the trajectory is identical to CG; in finite arithmetic the
+ * decoupling of dependencies amplifies round-off and the residuals can
+ * deviate from the classical iterates.
+ *
  * Possible issues:
  * 1. Numerical instability: Due to the rearrangement of the operations, the
  * method is known to be less stable than standard PCG.

--- a/include/ginkgo/core/solver/pipe_cg.hpp
+++ b/include/ginkgo/core/solver/pipe_cg.hpp
@@ -38,18 +38,33 @@ namespace solver {
  * magnitude earlier, as suggested in the referenced paper (see below).
  *
  * Mathematically the iterates \f$ x_k \f$ are the same as those produced
- * by \ref gko::solver::Cg "CG": the algorithm minimises the energy-norm
- * error over the Krylov subspace
- * \f$ x_0 + \mathcal{K}_k(A, r_0) \f$ and uses the same Fletcher-Reeves
- * \f$ \beta_k \f$.  The pipelining rearrangement maintains additional
- * auxiliary vectors \f$ s_k = A p_k \f$, \f$ w_k = A z_k \f$ and updates
- * them via short recurrences so that the global reductions for
- * \f$ \langle r_k, z_k \rangle \f$, \f$ \langle s_k, p_k \rangle \f$ and
- * \f$ \langle w_k, z_k \rangle \f$ can be merged and overlapped with the
- * next matrix-vector product and preconditioner apply.  In exact
- * arithmetic the trajectory is identical to CG; in finite arithmetic the
- * decoupling of dependencies amplifies round-off and the residuals can
- * deviate from the classical iterates.
+ * by \ref gko::solver::Cg "CG": the algorithm minimizes the energy-norm
+ * error over the Krylov subspace \f$ x_0 + \mathcal{K}_k(A, r_0) \f$ and
+ * uses the same Fletcher-Reeves \f$ \beta_k \f$. CG, however, needs two
+ * global reductions per iteration that cannot be merged:
+ * \f$ \rho_k = \langle r_k, z_k \rangle \f$ is needed to build
+ * \f$ p_k \f$, and only afterwards can \f$ q_k = A p_k \f$ and the second
+ * reduction \f$ \langle p_k, q_k \rangle \f$ be computed.
+ *
+ * The pipelined variant removes that second synchronization point by
+ * carrying an extra vector \f$ w_k = A z_k \f$ — the operator applied to
+ * the preconditioned residual \f$ z_k = M r_k \f$, which plain CG never
+ * forms. It gives access to \f$ \delta_k = \langle w_k, z_k \rangle =
+ * \langle A z_k, z_k \rangle \f$, from which the denominator of
+ * \f$ \alpha_k \f$ follows by a recurrence instead of a second reduction:
+ * \f[
+ *   \langle p_k, A p_k \rangle = \delta_k
+ *     - \left| \frac{\rho_k}{\rho_{k-1}} \right|^2
+ *       \langle p_{k-1}, A p_{k-1} \rangle .
+ * \f]
+ * Because \f$ \rho_k \f$ and \f$ \delta_k \f$ are available at the same
+ * point of the iteration, they are computed in a single global reduction
+ * that can be overlapped with the operator and preconditioner applies
+ * updating the auxiliary vectors \f$ w_k \f$, \f$ q_k = A p_k \f$,
+ * \f$ m_k = M w_k \f$ and \f$ n_k = A m_k \f$, all of which are advanced
+ * by short recurrences. In exact arithmetic the trajectory is identical to
+ * CG; in finite arithmetic the decoupling of dependencies amplifies
+ * round-off and the residuals can deviate from the classical iterates.
  *
  * Possible issues:
  * 1. Numerical instability: Due to the rearrangement of the operations, the

--- a/include/ginkgo/core/stop/batch_stop_enum.hpp
+++ b/include/ginkgo/core/stop/batch_stop_enum.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -16,13 +16,14 @@ namespace stop {
  * solver.
  *
  * `absolute` tolerance implies that the convergence criteria check is
- * against the computed residual ($||r|| \leq \tau$)
+ * against the computed residual (\f$||r|| \leq \tau\f$)
  *
  * With the `relative` tolerance type, the solver
  * convergence criteria checks against the relative residual norm
- * ($||r|| \leq ||b|| \times \tau$, where $||b||$ is the L2 norm of the rhs).
+ * (\f$||r|| \leq ||b|| \times \tau\f$, where \f$||b||\f$ is the L2 norm of the
+ * rhs).
  *
- * @note the computed residual norm, $||r||$ may be implicit or explicit
+ * @note the computed residual norm, \f$||r||\f$ may be implicit or explicit
  * depending on the solver algorithm.
  */
 enum class tolerance_type { absolute, relative };

--- a/include/ginkgo/core/stop/criterion.hpp
+++ b/include/ginkgo/core/stop/criterion.hpp
@@ -37,20 +37,24 @@ class Criterion : public PolymorphicObject {
 public:
     /**
      * The Updater class serves for convenient argument passing to the
-     * Criterion's check function. The pattern used is a Builder, except Updater
-     * builds a function's arguments before calling the function itself, and
-     * does not build an object. This allows calling a Criterion's check in the
-     * form of: stop_criterion->update()
-     *   .num_iterations(num_iterations)
-     *   .ignore_residual_check(ignore_residual_check)
-     *   .residual_norm(residual_norm)
-     *   .implicit_sq_residual_norm(implicit_sq_residual_norm)
-     *   .residual(residual)
-     *   .solution(solution)
-     *   .check(converged);
+     * Criterion's check function. The pattern used is a Builder, except
+     * Updater builds a function's arguments before calling the function
+     * itself, and does not build an object. This allows calling a
+     * Criterion's check in the form
      *
-     * If there is a need for a new form of data to pass to the Criterion, it
-     * should be added here.
+     * ```cpp
+     * stop_criterion->update()
+     *     .num_iterations(num_iterations)
+     *     .ignore_residual_check(ignore_residual_check)
+     *     .residual_norm(residual_norm)
+     *     .implicit_sq_residual_norm(implicit_sq_residual_norm)
+     *     .residual(residual)
+     *     .solution(solution)
+     *     .check(converged);
+     * ```
+     *
+     * If there is a need for a new form of data to pass to the Criterion,
+     * it should be added here.
      */
     class Updater {
         friend class Criterion;

--- a/include/ginkgo/core/stop/criterion.hpp
+++ b/include/ginkgo/core/stop/criterion.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -37,20 +37,24 @@ class Criterion : public EnableAbstractPolymorphicObject<Criterion> {
 public:
     /**
      * The Updater class serves for convenient argument passing to the
-     * Criterion's check function. The pattern used is a Builder, except Updater
-     * builds a function's arguments before calling the function itself, and
-     * does not build an object. This allows calling a Criterion's check in the
-     * form of: stop_criterion->update()
-     *   .num_iterations(num_iterations)
-     *   .ignore_residual_check(ignore_residual_check)
-     *   .residual_norm(residual_norm)
-     *   .implicit_sq_residual_norm(implicit_sq_residual_norm)
-     *   .residual(residual)
-     *   .solution(solution)
-     *   .check(converged);
+     * Criterion's check function. The pattern used is a Builder, except
+     * Updater builds a function's arguments before calling the function
+     * itself, and does not build an object. This allows calling a
+     * Criterion's check in the form
      *
-     * If there is a need for a new form of data to pass to the Criterion, it
-     * should be added here.
+     * ```cpp
+     * stop_criterion->update()
+     *     .num_iterations(num_iterations)
+     *     .ignore_residual_check(ignore_residual_check)
+     *     .residual_norm(residual_norm)
+     *     .implicit_sq_residual_norm(implicit_sq_residual_norm)
+     *     .residual(residual)
+     *     .solution(solution)
+     *     .check(converged);
+     * ```
+     *
+     * If there is a need for a new form of data to pass to the Criterion,
+     * it should be added here.
      */
     class Updater {
         friend class Criterion;

--- a/include/ginkgo/core/stop/iteration.hpp
+++ b/include/ginkgo/core/stop/iteration.hpp
@@ -64,7 +64,7 @@ protected:
  * iterations of the solver have finished.
  *
  * Full usage example: Stop after 100 iterations or when the relative residual
- * norm is below $10^{-10}$, whichever happens first.
+ * norm is below \f$10^{-10}\f$, whichever happens first.
  * ```cpp
  * auto factory = gko::solver::Cg<double>::build()
  *                    .with_criteria(
@@ -88,7 +88,7 @@ deferred_factory_parameter<const Iteration::Factory> max_iters(size_type count);
  * iterations finished.
  *
  * Full usage example: Stop when the relative residual
- * norm is below $10^{-10}$, but with at least 100 iterations.
+ * norm is below \f$10^{-10}\f$, but with at least 100 iterations.
  * ```cpp
  * auto factory = gko::solver::Cg<double>::build()
  *                    .with_criteria(gko::stop::min_iters(100,

--- a/include/ginkgo/core/stop/iteration.hpp
+++ b/include/ginkgo/core/stop/iteration.hpp
@@ -67,7 +67,7 @@ protected:
  * iterations of the solver have finished.
  *
  * Full usage example: Stop after 100 iterations or when the relative residual
- * norm is below $10^{-10}$, whichever happens first.
+ * norm is below \f$10^{-10}\f$, whichever happens first.
  * ```cpp
  * auto factory = gko::solver::Cg<double>::build()
  *                    .with_criteria(
@@ -91,7 +91,7 @@ deferred_factory_parameter<const Iteration::Factory> max_iters(size_type count);
  * iterations finished.
  *
  * Full usage example: Stop when the relative residual
- * norm is below $10^{-10}$, but with at least 100 iterations.
+ * norm is below \f$10^{-10}\f$, but with at least 100 iterations.
  * ```cpp
  * auto factory = gko::solver::Cg<double>::build()
  *                    .with_criteria(gko::stop::min_iters(100,

--- a/include/ginkgo/core/stop/residual_norm.hpp
+++ b/include/ginkgo/core/stop/residual_norm.hpp
@@ -238,8 +238,8 @@ protected:
  * ```
  *
  * @param tolerance  the value the residual norm needs to be below.
- *     With residual \f$r\f$, initial guess \f$x_0\f$, right-hand side \f$b\f$, matrix \f$A\f$,
- *     `absolute` means the exact value of the norm $||r||$,
+ *     With residual \f$r\f$, initial guess \f$x_0\f$, right-hand side \f$b\f$,
+ * matrix \f$A\f$, `absolute` means the exact value of the norm $||r||$,
  *     `relative` means the norm relative to the right-hand side $||r||/||b||$,
  *     `initial` means the norm relative to the initial residual
  *     $||r||/||b - A x_0||$.

--- a/include/ginkgo/core/stop/residual_norm.hpp
+++ b/include/ginkgo/core/stop/residual_norm.hpp
@@ -89,11 +89,11 @@ private:
  * The ResidualNorm class is a stopping criterion which
  * stops the iteration process when the actual residual norm is below a
  * certain threshold relative to
- * 1. the norm of the right-hand side, norm(residual) $\leq$ < threshold *
+ * 1. the norm of the right-hand side, norm(residual) \f$\leq\f$ < threshold *
  *    norm(right_hand_side).
- * 2. the initial residual, norm(residual) $\leq$ threshold *
+ * 2. the initial residual, norm(residual) \f$\leq\f$ threshold *
  *    norm(initial_residual).
- * 3. one,  norm(residual) $\leq$ threshold.
+ * 3. one,  norm(residual) \f$\leq\f$ threshold.
  *
  * For better performance, the checks are run on the executor
  * where the algorithm is executed.
@@ -154,11 +154,11 @@ protected:
  * The ImplicitResidualNorm class is a stopping criterion which
  * stops the iteration process when the implicit residual norm is below a
  * certain threshold relative to
- * 1. the norm of the right-hand side, implicit_resnorm $\leq$ < threshold *
+ * 1. the norm of the right-hand side, implicit_resnorm \f$\leq\f$ < threshold *
  * norm(right_hand_side)
- * 2. the initial residual, implicit_resnorm $\leq$ threshold *
+ * 2. the initial residual, implicit_resnorm \f$\leq\f$ threshold *
  * norm(initial_residual) .
- * 3. one,  implicit_resnorm $\leq$ threshold.
+ * 3. one,  implicit_resnorm \f$\leq\f$ threshold.
  *
  * @note To use this stopping criterion there are some dependencies. The
  * constructor depends on either `b` or the `initial_residual` in order to
@@ -238,7 +238,7 @@ protected:
  * ```
  *
  * @param tolerance  the value the residual norm needs to be below.
- *     With residual $r$, initial guess $x_0$, right-hand side $b$, matrix $A$,
+ *     With residual \f$r\f$, initial guess \f$x_0\f$, right-hand side \f$b\f$, matrix \f$A\f$,
  *     `absolute` means the exact value of the norm $||r||$,
  *     `relative` means the norm relative to the right-hand side $||r||/||b||$,
  *     `initial` means the norm relative to the initial residual

--- a/include/ginkgo/core/stop/residual_norm.hpp
+++ b/include/ginkgo/core/stop/residual_norm.hpp
@@ -24,13 +24,13 @@ namespace stop {
  * The mode for the residual norm criterion.
  *
  * - absolute:        Check for tolerance against residual norm.
- *                    $ || r || \leq \tau $
+ *                    \f$ || r || \leq \tau \f$
  *
  * - initial_resnorm: Check for tolerance relative to the initial residual norm.
- *                    $ || r || \leq \tau \times || r_0|| $
+ *                    \f$ || r || \leq \tau \times || r_0|| \f$
  *
  * - rhs_norm:        Check for tolerance relative to the rhs norm.
- *                    $ || r || \leq \tau \times || b || $
+ *                    \f$ || r || \leq \tau \times || b || \f$
  *
  * @ingroup stop
  */
@@ -265,7 +265,7 @@ protected:
  * amount.
  *
  * Full usage example: Stop after 100 iterations or when the absolute residual
- * norm is below $10^{-10}$, whichever happens first.
+ * norm is below \f$10^{-10}\f$, whichever happens first.
  * ```cpp
  * auto factory = gko::solver::Cg<double>::build()
  *                    .with_criteria(
@@ -276,13 +276,13 @@ protected:
  *
  * @param tolerance  the value the residual norm needs to be below.
  *     With residual \f$r\f$, initial guess \f$x_0\f$, right-hand side \f$b\f$,
- * matrix \f$A\f$, `absolute` means the exact value of the norm $||r||$,
- *     `relative` means the norm relative to the right-hand side $||r||/||b||$,
- *     `initial` means the norm relative to the initial residual
- *     $||r||/||b - A x_0||$.
+ * matrix \f$A\f$, `absolute` means the exact value of the norm \f$||r||\f$,
+ *     `relative` means the norm relative to the right-hand side
+ * \f$||r||/||b||\f$, `initial` means the norm relative to the initial residual
+ *     \f$||r||/||b - A x_0||\f$.
  *     An implicit stopping criterion is only available with some solvers, and
- *     refers to either the energy norm $||r||_A$ in short-recurrence solvers
- *     like Cg or the euclidian norm $||r||$ in solvers like GMRES.
+ *     refers to either the energy norm \f$||r||_A\f$ in short-recurrence
+ * solvers like Cg or the euclidian norm \f$||r||\f$ in solvers like GMRES.
  *     Implicit residual norms are cheaper to compute, but may be less precise
  *     due to accumulating rounding errors.
  * @return a deferred_factory_parameter that can be passed to the

--- a/include/ginkgo/core/stop/residual_norm.hpp
+++ b/include/ginkgo/core/stop/residual_norm.hpp
@@ -27,7 +27,7 @@ namespace stop {
  *                    \f$ || r || \leq \tau \f$
  *
  * - initial_resnorm: Check for tolerance relative to the initial residual norm.
- *                    \f$ || r || \leq \tau \times || r_0|| \f$
+ *                    \f$ || r || \leq \tau \times || r_0 || \f$
  *
  * - rhs_norm:        Check for tolerance relative to the rhs norm.
  *                    \f$ || r || \leq \tau \times || b || \f$
@@ -87,24 +87,24 @@ private:
 
 /**
  * Stopping criterion based on the explicit residual norm
- * \f$ \| r_k \| = \| b - A x_k \| \f$.  The iteration halts once
+ * \f$ \| r_k \| = \| b - A x_k \| \f$. The iteration halts once
  * \f$ \| r_k \| \le \tau \cdot \beta \f$, where \f$\tau\f$ is the
  * factory parameter `reduction_factor` and the baseline \f$\beta\f$ is
  * selected by the `baseline` factory parameter:
  *
  * - `mode::rhs_norm` (default) — relative to the right-hand side:
  *   \f$ \beta = \| b \| \f$, so the condition is
- *   \f$ \| r_k \| \le \tau \, \| b \| \f$.
+ *   \f$ \| r_k \| \le \tau \| b \| \f$.
  * - `mode::initial_resnorm` — relative to the initial residual:
  *   \f$ \beta = \| r_0 \| \f$, so the condition is
- *   \f$ \| r_k \| \le \tau \, \| r_0 \| \f$.
+ *   \f$ \| r_k \| \le \tau \| r_0 \| \f$.
  * - `mode::absolute` — absolute threshold:
  *   \f$ \beta = 1 \f$, so the condition is \f$ \| r_k \| \le \tau \f$.
  *
  * Per-iteration, the criterion prefers a pre-computed residual norm
  * passed by the solver (via `Updater::residual_norm`); otherwise it
  * falls back to computing the 2-norm of the residual vector itself
- * (via `Updater::residual`), which costs one global reduction.  When
+ * (via `Updater::residual`), which costs one global reduction. When
  * even cheaper checks are needed and the solver maintains an internal
  * squared-norm estimate, use \ref ImplicitResidualNorm instead.
  *
@@ -112,7 +112,7 @@ private:
  *       - `mode::rhs_norm` requires the right-hand side \f$ b \f$.
  *       - `mode::initial_resnorm` requires either the initial residual
  *         \f$ r_0 \f$ explicitly, or the triple
- *         \f$ (A,\, b,\, x_0) \f$ from which it is computed as
+ *         \f$ (A, b, x_0) \f$ from which it is computed as
  *         \f$ r_0 = b - A x_0 \f$.
  *       - `mode::absolute` requires \f$ b \f$ as well — to determine the
  *         number of right-hand sides; its baseline is then filled with
@@ -169,17 +169,17 @@ protected:
 
 /**
  * Stopping criterion based on a solver-maintained squared residual-norm
- * estimate \f$ \rho_k^2 \approx \| r_k \|^2 \f$.  Several Krylov methods
+ * estimate \f$ \rho_k^2 \approx \| r_k \|^2 \f$. Several Krylov methods
  * (CG, BiCGSTAB, …) already compute this quantity per iteration as a
  * by-product of their inner-product recurrences, so the criterion can
  * check convergence without computing a norm of its own — saving the
  * global reduction the explicit \ref ResidualNorm form needs when the
- * solver only passes \f$ r_k \f$.  The iteration halts once
+ * solver only passes \f$ r_k \f$. The iteration halts once
  * \f$ \rho_k \le \tau \cdot \beta \f$, with the same `reduction_factor`
  * and `baseline` factory parameters as \ref ResidualNorm:
  *
- * - `mode::rhs_norm` (default) — \f$ \rho_k \le \tau \, \| b \| \f$.
- * - `mode::initial_resnorm` — \f$ \rho_k \le \tau \, \| r_0 \| \f$.
+ * - `mode::rhs_norm` (default) — \f$ \rho_k \le \tau \| b \| \f$.
+ * - `mode::initial_resnorm` — \f$ \rho_k \le \tau \| r_0 \| \f$.
  * - `mode::absolute` — \f$ \rho_k \le \tau \f$.
  *
  * Because \f$ \rho_k^2 \f$ is updated by short recurrences rather than
@@ -189,14 +189,14 @@ protected:
  *
  * @note The solver must pass the squared estimate through
  *       `Updater::implicit_sq_residual_norm` on every check — there is
- *       no fallback path.  If it is missing, ::gko::NotSupported() is
+ *       no fallback path. If it is missing, ::gko::NotSupported() is
  *       thrown at check time.
  *
  * @note Baseline prerequisites at construction time mirror
  *       \ref ResidualNorm:
  *       - `mode::rhs_norm` requires \f$ b \f$.
  *       - `mode::initial_resnorm` requires either \f$ r_0 \f$ explicitly
- *         or the triple \f$ (A,\, b,\, x_0) \f$ to derive it.
+ *         or the triple \f$ (A, b, x_0) \f$ to derive it.
  *       - `mode::absolute` requires \f$ b \f$ for sizing the per-RHS
  *         baseline.
  *       If the required arguments are missing, ::gko::NotSupported() is
@@ -275,14 +275,15 @@ protected:
  * ```
  *
  * @param tolerance  the value the residual norm needs to be below.
- *     With residual \f$r\f$, initial guess \f$x_0\f$, right-hand side \f$b\f$,
- * matrix \f$A\f$, `absolute` means the exact value of the norm \f$||r||\f$,
- *     `relative` means the norm relative to the right-hand side
- * \f$||r||/||b||\f$, `initial` means the norm relative to the initial residual
- *     \f$||r||/||b - A x_0||\f$.
+ *     With residual \f$r\f$, initial guess \f$x_0\f$, right-hand side
+ *     \f$b\f$ and matrix \f$A\f$, `absolute` means the exact value of the
+ *     norm \f$||r||\f$, `relative` means the norm relative to the right-hand
+ *     side \f$||r||/||b||\f$, `initial` means the norm relative to the
+ *     initial residual \f$||r||/||b - A x_0||\f$.
  *     An implicit stopping criterion is only available with some solvers, and
  *     refers to either the energy norm \f$||r||_A\f$ in short-recurrence
- * solvers like Cg or the euclidian norm \f$||r||\f$ in solvers like GMRES.
+ *     solvers like Cg or the euclidian norm \f$||r||\f$ in solvers like
+ *     GMRES.
  *     Implicit residual norms are cheaper to compute, but may be less precise
  *     due to accumulating rounding errors.
  * @return a deferred_factory_parameter that can be passed to the

--- a/include/ginkgo/core/stop/residual_norm.hpp
+++ b/include/ginkgo/core/stop/residual_norm.hpp
@@ -86,22 +86,39 @@ private:
 
 
 /**
- * The ResidualNorm class is a stopping criterion which
- * stops the iteration process when the actual residual norm is below a
- * certain threshold relative to
- * 1. the norm of the right-hand side, norm(residual) \f$\leq\f$ < threshold *
- *    norm(right_hand_side).
- * 2. the initial residual, norm(residual) \f$\leq\f$ threshold *
- *    norm(initial_residual).
- * 3. one,  norm(residual) \f$\leq\f$ threshold.
+ * Stopping criterion based on the explicit residual norm
+ * \f$ \| r_k \| = \| b - A x_k \| \f$.  The iteration halts once
+ * \f$ \| r_k \| \le \tau \cdot \beta \f$, where \f$\tau\f$ is the
+ * factory parameter `reduction_factor` and the baseline \f$\beta\f$ is
+ * selected by the `baseline` factory parameter:
  *
- * For better performance, the checks are run on the executor
- * where the algorithm is executed.
+ * - `mode::rhs_norm` (default) — relative to the right-hand side:
+ *   \f$ \beta = \| b \| \f$, so the condition is
+ *   \f$ \| r_k \| \le \tau \, \| b \| \f$.
+ * - `mode::initial_resnorm` — relative to the initial residual:
+ *   \f$ \beta = \| r_0 \| \f$, so the condition is
+ *   \f$ \| r_k \| \le \tau \, \| r_0 \| \f$.
+ * - `mode::absolute` — absolute threshold:
+ *   \f$ \beta = 1 \f$, so the condition is \f$ \| r_k \| \le \tau \f$.
  *
- * @note To use this stopping criterion there are some dependencies. The
- * constructor depends on either `b` or the `initial_residual` in order to
- * compute their norms. If this is not correctly provided, an exception
- * ::gko::NotSupported() is thrown.
+ * Per-iteration, the criterion prefers a pre-computed residual norm
+ * passed by the solver (via `Updater::residual_norm`); otherwise it
+ * falls back to computing the 2-norm of the residual vector itself
+ * (via `Updater::residual`), which costs one global reduction.  When
+ * even cheaper checks are needed and the solver maintains an internal
+ * squared-norm estimate, use \ref ImplicitResidualNorm instead.
+ *
+ * @note Baseline prerequisites at construction time:
+ *       - `mode::rhs_norm` requires the right-hand side \f$ b \f$.
+ *       - `mode::initial_resnorm` requires either the initial residual
+ *         \f$ r_0 \f$ explicitly, or the triple
+ *         \f$ (A,\, b,\, x_0) \f$ from which it is computed as
+ *         \f$ r_0 = b - A x_0 \f$.
+ *       - `mode::absolute` requires \f$ b \f$ as well — to determine the
+ *         number of right-hand sides; its baseline is then filled with
+ *         ones.
+ *       If the required arguments are missing, ::gko::NotSupported() is
+ *       thrown.
  *
  * @ingroup stop
  */
@@ -151,19 +168,39 @@ protected:
 
 
 /**
- * The ImplicitResidualNorm class is a stopping criterion which
- * stops the iteration process when the implicit residual norm is below a
- * certain threshold relative to
- * 1. the norm of the right-hand side, implicit_resnorm \f$\leq\f$ < threshold *
- * norm(right_hand_side)
- * 2. the initial residual, implicit_resnorm \f$\leq\f$ threshold *
- * norm(initial_residual) .
- * 3. one,  implicit_resnorm \f$\leq\f$ threshold.
+ * Stopping criterion based on a solver-maintained squared residual-norm
+ * estimate \f$ \rho_k^2 \approx \| r_k \|^2 \f$.  Several Krylov methods
+ * (CG, BiCGSTAB, …) already compute this quantity per iteration as a
+ * by-product of their inner-product recurrences, so the criterion can
+ * check convergence without computing a norm of its own — saving the
+ * global reduction the explicit \ref ResidualNorm form needs when the
+ * solver only passes \f$ r_k \f$.  The iteration halts once
+ * \f$ \rho_k \le \tau \cdot \beta \f$, with the same `reduction_factor`
+ * and `baseline` factory parameters as \ref ResidualNorm:
  *
- * @note To use this stopping criterion there are some dependencies. The
- * constructor depends on either `b` or the `initial_residual` in order to
- * compute their norms. If this is not correctly provided, an exception
- * ::gko::NotSupported() is thrown.
+ * - `mode::rhs_norm` (default) — \f$ \rho_k \le \tau \, \| b \| \f$.
+ * - `mode::initial_resnorm` — \f$ \rho_k \le \tau \, \| r_0 \| \f$.
+ * - `mode::absolute` — \f$ \rho_k \le \tau \f$.
+ *
+ * Because \f$ \rho_k^2 \f$ is updated by short recurrences rather than
+ * recomputed from \f$ b - A x_k \f$ each step, it can drift from the
+ * true residual norm on long runs in finite precision; pair this
+ * criterion with an \ref Iteration cap when that matters.
+ *
+ * @note The solver must pass the squared estimate through
+ *       `Updater::implicit_sq_residual_norm` on every check — there is
+ *       no fallback path.  If it is missing, ::gko::NotSupported() is
+ *       thrown at check time.
+ *
+ * @note Baseline prerequisites at construction time mirror
+ *       \ref ResidualNorm:
+ *       - `mode::rhs_norm` requires \f$ b \f$.
+ *       - `mode::initial_resnorm` requires either \f$ r_0 \f$ explicitly
+ *         or the triple \f$ (A,\, b,\, x_0) \f$ to derive it.
+ *       - `mode::absolute` requires \f$ b \f$ for sizing the per-RHS
+ *         baseline.
+ *       If the required arguments are missing, ::gko::NotSupported() is
+ *       thrown.
  *
  * @ingroup stop
  */

--- a/include/ginkgo/core/stop/residual_norm.hpp
+++ b/include/ginkgo/core/stop/residual_norm.hpp
@@ -90,22 +90,39 @@ private:
 
 
 /**
- * The ResidualNorm class is a stopping criterion which
- * stops the iteration process when the actual residual norm is below a
- * certain threshold relative to
- * 1. the norm of the right-hand side, norm(residual) \f$\leq\f$ < threshold *
- *    norm(right_hand_side).
- * 2. the initial residual, norm(residual) \f$\leq\f$ threshold *
- *    norm(initial_residual).
- * 3. one,  norm(residual) \f$\leq\f$ threshold.
+ * Stopping criterion based on the explicit residual norm
+ * \f$ \| r_k \| = \| b - A x_k \| \f$.  The iteration halts once
+ * \f$ \| r_k \| \le \tau \cdot \beta \f$, where \f$\tau\f$ is the
+ * factory parameter `reduction_factor` and the baseline \f$\beta\f$ is
+ * selected by the `baseline` factory parameter:
  *
- * For better performance, the checks are run on the executor
- * where the algorithm is executed.
+ * - `mode::rhs_norm` (default) — relative to the right-hand side:
+ *   \f$ \beta = \| b \| \f$, so the condition is
+ *   \f$ \| r_k \| \le \tau \, \| b \| \f$.
+ * - `mode::initial_resnorm` — relative to the initial residual:
+ *   \f$ \beta = \| r_0 \| \f$, so the condition is
+ *   \f$ \| r_k \| \le \tau \, \| r_0 \| \f$.
+ * - `mode::absolute` — absolute threshold:
+ *   \f$ \beta = 1 \f$, so the condition is \f$ \| r_k \| \le \tau \f$.
  *
- * @note To use this stopping criterion there are some dependencies. The
- * constructor depends on either `b` or the `initial_residual` in order to
- * compute their norms. If this is not correctly provided, an exception
- * ::gko::NotSupported() is thrown.
+ * Per-iteration, the criterion prefers a pre-computed residual norm
+ * passed by the solver (via `Updater::residual_norm`); otherwise it
+ * falls back to computing the 2-norm of the residual vector itself
+ * (via `Updater::residual`), which costs one global reduction.  When
+ * even cheaper checks are needed and the solver maintains an internal
+ * squared-norm estimate, use \ref ImplicitResidualNorm instead.
+ *
+ * @note Baseline prerequisites at construction time:
+ *       - `mode::rhs_norm` requires the right-hand side \f$ b \f$.
+ *       - `mode::initial_resnorm` requires either the initial residual
+ *         \f$ r_0 \f$ explicitly, or the triple
+ *         \f$ (A,\, b,\, x_0) \f$ from which it is computed as
+ *         \f$ r_0 = b - A x_0 \f$.
+ *       - `mode::absolute` requires \f$ b \f$ as well — to determine the
+ *         number of right-hand sides; its baseline is then filled with
+ *         ones.
+ *       If the required arguments are missing, ::gko::NotSupported() is
+ *       thrown.
  *
  * @ingroup stop
  */
@@ -155,19 +172,39 @@ protected:
 
 
 /**
- * The ImplicitResidualNorm class is a stopping criterion which
- * stops the iteration process when the implicit residual norm is below a
- * certain threshold relative to
- * 1. the norm of the right-hand side, implicit_resnorm \f$\leq\f$ < threshold *
- * norm(right_hand_side)
- * 2. the initial residual, implicit_resnorm \f$\leq\f$ threshold *
- * norm(initial_residual) .
- * 3. one,  implicit_resnorm \f$\leq\f$ threshold.
+ * Stopping criterion based on a solver-maintained squared residual-norm
+ * estimate \f$ \rho_k^2 \approx \| r_k \|^2 \f$.  Several Krylov methods
+ * (CG, BiCGSTAB, …) already compute this quantity per iteration as a
+ * by-product of their inner-product recurrences, so the criterion can
+ * check convergence without computing a norm of its own — saving the
+ * global reduction the explicit \ref ResidualNorm form needs when the
+ * solver only passes \f$ r_k \f$.  The iteration halts once
+ * \f$ \rho_k \le \tau \cdot \beta \f$, with the same `reduction_factor`
+ * and `baseline` factory parameters as \ref ResidualNorm:
  *
- * @note To use this stopping criterion there are some dependencies. The
- * constructor depends on either `b` or the `initial_residual` in order to
- * compute their norms. If this is not correctly provided, an exception
- * ::gko::NotSupported() is thrown.
+ * - `mode::rhs_norm` (default) — \f$ \rho_k \le \tau \, \| b \| \f$.
+ * - `mode::initial_resnorm` — \f$ \rho_k \le \tau \, \| r_0 \| \f$.
+ * - `mode::absolute` — \f$ \rho_k \le \tau \f$.
+ *
+ * Because \f$ \rho_k^2 \f$ is updated by short recurrences rather than
+ * recomputed from \f$ b - A x_k \f$ each step, it can drift from the
+ * true residual norm on long runs in finite precision; pair this
+ * criterion with an \ref Iteration cap when that matters.
+ *
+ * @note The solver must pass the squared estimate through
+ *       `Updater::implicit_sq_residual_norm` on every check — there is
+ *       no fallback path.  If it is missing, ::gko::NotSupported() is
+ *       thrown at check time.
+ *
+ * @note Baseline prerequisites at construction time mirror
+ *       \ref ResidualNorm:
+ *       - `mode::rhs_norm` requires \f$ b \f$.
+ *       - `mode::initial_resnorm` requires either \f$ r_0 \f$ explicitly
+ *         or the triple \f$ (A,\, b,\, x_0) \f$ to derive it.
+ *       - `mode::absolute` requires \f$ b \f$ for sizing the per-RHS
+ *         baseline.
+ *       If the required arguments are missing, ::gko::NotSupported() is
+ *       thrown.
  *
  * @ingroup stop
  */

--- a/include/ginkgo/core/stop/residual_norm.hpp
+++ b/include/ginkgo/core/stop/residual_norm.hpp
@@ -24,13 +24,13 @@ namespace stop {
  * The mode for the residual norm criterion.
  *
  * - absolute:        Check for tolerance against residual norm.
- *                    $ || r || \leq \tau $
+ *                    \f$ || r || \leq \tau \f$
  *
  * - initial_resnorm: Check for tolerance relative to the initial residual norm.
- *                    $ || r || \leq \tau \times || r_0|| $
+ *                    \f$ || r || \leq \tau \times || r_0|| \f$
  *
  * - rhs_norm:        Check for tolerance relative to the rhs norm.
- *                    $ || r || \leq \tau \times || b || $
+ *                    \f$ || r || \leq \tau \times || b || \f$
  *
  * @ingroup stop
  */
@@ -269,7 +269,7 @@ protected:
  * amount.
  *
  * Full usage example: Stop after 100 iterations or when the absolute residual
- * norm is below $10^{-10}$, whichever happens first.
+ * norm is below \f$10^{-10}\f$, whichever happens first.
  * ```cpp
  * auto factory = gko::solver::Cg<double>::build()
  *                    .with_criteria(
@@ -280,13 +280,13 @@ protected:
  *
  * @param tolerance  the value the residual norm needs to be below.
  *     With residual \f$r\f$, initial guess \f$x_0\f$, right-hand side \f$b\f$,
- * matrix \f$A\f$, `absolute` means the exact value of the norm $||r||$,
- *     `relative` means the norm relative to the right-hand side $||r||/||b||$,
- *     `initial` means the norm relative to the initial residual
- *     $||r||/||b - A x_0||$.
+ * matrix \f$A\f$, `absolute` means the exact value of the norm \f$||r||\f$,
+ *     `relative` means the norm relative to the right-hand side
+ * \f$||r||/||b||\f$, `initial` means the norm relative to the initial residual
+ *     \f$||r||/||b - A x_0||\f$.
  *     An implicit stopping criterion is only available with some solvers, and
- *     refers to either the energy norm $||r||_A$ in short-recurrence solvers
- *     like Cg or the euclidian norm $||r||$ in solvers like GMRES.
+ *     refers to either the energy norm \f$||r||_A\f$ in short-recurrence
+ * solvers like Cg or the euclidian norm \f$||r||\f$ in solvers like GMRES.
  *     Implicit residual norms are cheaper to compute, but may be less precise
  *     due to accumulating rounding errors.
  * @return a deferred_factory_parameter that can be passed to the

--- a/include/ginkgo/core/stop/residual_norm.hpp
+++ b/include/ginkgo/core/stop/residual_norm.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -242,8 +242,8 @@ protected:
  * ```
  *
  * @param tolerance  the value the residual norm needs to be below.
- *     With residual \f$r\f$, initial guess \f$x_0\f$, right-hand side \f$b\f$, matrix \f$A\f$,
- *     `absolute` means the exact value of the norm $||r||$,
+ *     With residual \f$r\f$, initial guess \f$x_0\f$, right-hand side \f$b\f$,
+ * matrix \f$A\f$, `absolute` means the exact value of the norm $||r||$,
  *     `relative` means the norm relative to the right-hand side $||r||/||b||$,
  *     `initial` means the norm relative to the initial residual
  *     $||r||/||b - A x_0||$.

--- a/include/ginkgo/core/stop/residual_norm.hpp
+++ b/include/ginkgo/core/stop/residual_norm.hpp
@@ -93,11 +93,11 @@ private:
  * The ResidualNorm class is a stopping criterion which
  * stops the iteration process when the actual residual norm is below a
  * certain threshold relative to
- * 1. the norm of the right-hand side, norm(residual) $\leq$ < threshold *
+ * 1. the norm of the right-hand side, norm(residual) \f$\leq\f$ < threshold *
  *    norm(right_hand_side).
- * 2. the initial residual, norm(residual) $\leq$ threshold *
+ * 2. the initial residual, norm(residual) \f$\leq\f$ threshold *
  *    norm(initial_residual).
- * 3. one,  norm(residual) $\leq$ threshold.
+ * 3. one,  norm(residual) \f$\leq\f$ threshold.
  *
  * For better performance, the checks are run on the executor
  * where the algorithm is executed.
@@ -158,11 +158,11 @@ protected:
  * The ImplicitResidualNorm class is a stopping criterion which
  * stops the iteration process when the implicit residual norm is below a
  * certain threshold relative to
- * 1. the norm of the right-hand side, implicit_resnorm $\leq$ < threshold *
+ * 1. the norm of the right-hand side, implicit_resnorm \f$\leq\f$ < threshold *
  * norm(right_hand_side)
- * 2. the initial residual, implicit_resnorm $\leq$ threshold *
+ * 2. the initial residual, implicit_resnorm \f$\leq\f$ threshold *
  * norm(initial_residual) .
- * 3. one,  implicit_resnorm $\leq$ threshold.
+ * 3. one,  implicit_resnorm \f$\leq\f$ threshold.
  *
  * @note To use this stopping criterion there are some dependencies. The
  * constructor depends on either `b` or the `initial_residual` in order to
@@ -242,7 +242,7 @@ protected:
  * ```
  *
  * @param tolerance  the value the residual norm needs to be below.
- *     With residual $r$, initial guess $x_0$, right-hand side $b$, matrix $A$,
+ *     With residual \f$r\f$, initial guess \f$x_0\f$, right-hand side \f$b\f$, matrix \f$A\f$,
  *     `absolute` means the exact value of the norm $||r||$,
  *     `relative` means the norm relative to the right-hand side $||r||/||b||$,
  *     `initial` means the norm relative to the initial residual

--- a/include/ginkgo/core/stop/time.hpp
+++ b/include/ginkgo/core/stop/time.hpp
@@ -71,7 +71,7 @@ private:
  * specified amount of time since the start of the solver run has elapsed.
  *
  * Full usage example: Stop after 1 second or when the relative residual norm is
- * below $10^{-10}$, whichever happens first.
+ * below \f$10^{-10}\f$, whichever happens first.
  * ```cpp
  * auto factory = gko::solver::Cg<double>::build()
  *                    .with_criteria(

--- a/include/ginkgo/core/stop/time.hpp
+++ b/include/ginkgo/core/stop/time.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -75,7 +75,7 @@ private:
  * specified amount of time since the start of the solver run has elapsed.
  *
  * Full usage example: Stop after 1 second or when the relative residual norm is
- * below $10^{-10}$, whichever happens first.
+ * below \f$10^{-10}\f$, whichever happens first.
  * ```cpp
  * auto factory = gko::solver::Cg<double>::build()
  *                    .with_criteria(


### PR DESCRIPTION
This PR improves the documentation for the headers.

1. Fixes the doxygen math.
2. Fixes some minor issues, typos and language in docs
3. Adds some basic summary on the math for each solver/preconditioner.